### PR TITLE
feat: implement full-height sidebar layout with improved mobile UX

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,7 +5,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
-import { Menu, RefreshCcw, ChevronDown, ChevronUp, Palette } from 'lucide-react';
+import { PanelLeftOpen, PanelLeftClose, RefreshCcw, ChevronDown, ChevronUp, Palette } from 'lucide-react';
 import { OpenCodeIcon } from '@/components/ui/OpenCodeIcon';
 import { ThemeSwitcher } from '@/components/ui/ThemeSwitcher';
 import { useUIStore } from '@/stores/useUIStore';
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils';
 
 export const Header: React.FC = () => {
   const toggleSidebar = useUIStore((state) => state.toggleSidebar);
+  const isSidebarOpen = useUIStore((state) => state.isSidebarOpen);
 
   const {
     isConnected,
@@ -101,7 +102,7 @@ export const Header: React.FC = () => {
           className="h-9 w-9 rounded-md p-2 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           aria-label="Toggle sidebar"
         >
-          <Menu className="h-5 w-5" />
+          {isSidebarOpen ? <PanelLeftOpen className="h-5 w-5" /> : <PanelLeftClose className="h-5 w-5" />}
         </button>
         <div className="flex items-center gap-2 min-w-0">
           <Tooltip>
@@ -168,7 +169,7 @@ export const Header: React.FC = () => {
             className="h-9 w-9 rounded-md p-2 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             aria-label="Toggle sidebar"
           >
-            <Menu className="h-5 w-5" />
+            {isSidebarOpen ? <PanelLeftOpen className="h-5 w-5" /> : <PanelLeftClose className="h-5 w-5" />}
           </button>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -11,6 +11,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useUIStore } from '@/stores/useUIStore';
 import { useDeviceInfo } from '@/lib/device';
 import { cn } from '@/lib/utils';
+import { X } from 'lucide-react';
 import { useSessionStore } from '@/stores/useSessionStore';
 import {
     SIDEBAR_SECTIONS,
@@ -76,65 +77,81 @@ export const MainLayout: React.FC = () => {
     }, [sidebarSection]);
 
     return (
-        <div className="main-content-safe-area flex h-screen flex-col bg-background">
-            <Header />
-            <CommandPalette />
-            <HelpDialog />
+        <div className="main-content-safe-area flex h-[100dvh] bg-background">
+            <aside
+                className={cn(
+                    'fixed left-0 top-0 z-40 flex h-full transform border-r bg-sidebar transition-all duration-300 ease-in-out lg:relative lg:z-0',
+                    isSidebarOpen ? 'translate-x-0 opacity-100' : '-translate-x-full opacity-0'
+                )}
+                style={{
+                    width: isSidebarOpen ? (isMobile ? '100%' : `${SIDEBAR_DESKTOP_WIDTH}px`) : '0px',
+                    transition: 'width 300ms ease-in-out, opacity 300ms ease-in-out, transform 300ms ease-in-out',
+                }}
+                aria-hidden={!isSidebarOpen}
+            >
+                <div className="flex h-full w-full overflow-hidden">
+                    <nav className={cn('flex w-14 flex-col items-center gap-2 border-r border-border/40 bg-sidebar/80 py-4 backdrop-blur', isMobile && !sidebarSection ? 'pt-6' : 'pt-6 md:pt-4')}>
+                        {/* Close button for mobile */}
+                        {isMobile && (
+                            <Tooltip delayDuration={300}>
+                                <TooltipTrigger asChild>
+                                    <button
+                                        type="button"
+                                        onClick={() => setSidebarOpen(false)}
+                                        className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                                        aria-label="Close sidebar"
+                                    >
+                                        <X className="h-4 w-4" />
+                                    </button>
+                                </TooltipTrigger>
+                                <TooltipContent side="right">Close sidebar</TooltipContent>
+                            </Tooltip>
+                        )}
 
-            <div className="flex flex-1 overflow-hidden bg-background">
-                <aside
-                    className={cn(
-                        'mobile-sidebar-top fixed left-0 z-40 flex-shrink-0 transform border-r bg-sidebar transition-all duration-300 ease-in-out lg:relative lg:z-0',
-                        isSidebarOpen ? 'translate-x-0 opacity-100' : '-translate-x-full opacity-0'
-                    )}
-                    style={{
-                        width: isSidebarOpen ? (isMobile ? '100%' : `${SIDEBAR_DESKTOP_WIDTH}px`) : '0px',
-                        transition: 'width 300ms ease-in-out, opacity 300ms ease-in-out, transform 300ms ease-in-out',
-                    }}
-                    aria-hidden={!isSidebarOpen}
-                >
-                    <div className="flex h-full w-full overflow-hidden">
-                        <nav className={cn('flex w-14 flex-col items-center gap-2 border-r border-border/40 bg-sidebar/80 py-4 backdrop-blur', isMobile && !sidebarSection ? 'pt-6' : 'pt-6 md:pt-4')}>
-                            {SIDEBAR_SECTIONS.map((section) => {
-                                const isActive = sidebarSection === section.id;
+                        {SIDEBAR_SECTIONS.map((section) => {
+                            const isActive = sidebarSection === section.id;
 
-                                return (
-                                    <Tooltip key={section.id} delayDuration={300}>
-                                        <TooltipTrigger asChild>
-                                            <button
-                                                type="button"
-                                                onClick={() => setSidebarSection(section.id)}
-                                                className={cn(
-                                                    'flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
-                                                    isActive
-                                                        ? 'bg-primary/15 text-primary shadow-sm'
-                                                        : 'hover:bg-accent hover:text-foreground'
-                                                )}
-                                                aria-pressed={isActive}
-                                                aria-label={section.label}
-                                            >
-                                                <section.icon className="h-4 w-4" />
-                                            </button>
-                                        </TooltipTrigger>
-                                        <TooltipContent side="right">{section.label}</TooltipContent>
-                                    </Tooltip>
-                                );
-                            })}
-                        </nav>
-                        <div className="flex-1 overflow-hidden">
-                            <ErrorBoundary>{sidebarContent}</ErrorBoundary>
-                        </div>
+                            return (
+                                <Tooltip key={section.id} delayDuration={300}>
+                                    <TooltipTrigger asChild>
+                                        <button
+                                            type="button"
+                                            onClick={() => setSidebarSection(section.id)}
+                                            className={cn(
+                                                'flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                                                isActive
+                                                    ? 'bg-primary/15 text-primary shadow-sm'
+                                                    : 'hover:bg-accent hover:text-foreground'
+                                            )}
+                                            aria-pressed={isActive}
+                                            aria-label={section.label}
+                                        >
+                                            <section.icon className="h-4 w-4" />
+                                        </button>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="right">{section.label}</TooltipContent>
+                                </Tooltip>
+                            );
+                        })}
+                    </nav>
+                    <div className="flex-1 overflow-hidden">
+                        <ErrorBoundary>{sidebarContent}</ErrorBoundary>
                     </div>
-                </aside>
+                </div>
+            </aside>
 
-                <div
-                    className={cn(
-                        'fixed inset-0 z-30 bg-background/80 backdrop-blur-sm transition-opacity duration-300 lg:hidden',
-                        isSidebarOpen ? 'opacity-100 pointer-events-auto' : 'pointer-events-none opacity-0'
-                    )}
-                    onClick={() => setSidebarOpen(false)}
-                />
+            <div
+                className={cn(
+                    'fixed inset-0 z-30 bg-background/80 backdrop-blur-sm transition-opacity duration-300 lg:hidden',
+                    isSidebarOpen ? 'opacity-100 pointer-events-auto' : 'pointer-events-none opacity-0'
+                )}
+                onClick={() => setSidebarOpen(false)}
+            />
 
+            <div className="flex flex-1 flex-col overflow-hidden bg-background">
+                <Header />
+                <CommandPalette />
+                <HelpDialog />
                 <main className="flex-1 overflow-hidden bg-background">
                     <ChatErrorBoundary sessionId={currentSessionId || undefined}>
                         <ChatContainer />


### PR DESCRIPTION
## Summary
- Implement full-height sidebar layout where sidebar extends from top to bottom
- Header starts after sidebar on desktop instead of overlapping
- Replace hamburger menu icon with state-aware sidebar toggle icons (PanelLeftOpen/PanelLeftClose)
- Add mobile close button (X) inside sidebar for better mobile navigation since header is hidden
- Fix mobile viewport height issues using 100dvh instead of h-screen

## Test plan
- [ ] Verify sidebar takes full height on desktop
- [ ] Verify header starts after sidebar and doesn't overlap
- [ ] Test sidebar toggle icons change state correctly (open/closed)
- [ ] Test mobile sidebar can be closed with X button inside sidebar
- [ ] Verify mobile viewport height is correct and chat input positioned properly
- [ ] Test transitions and accessibility features work as expected
- [ ] Verify responsive behavior between mobile and desktop