### PR TITLE
Migrate typography to IBM Plex Mono

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@ibm/plex": "^6.4.1",
         "@opencode-ai/sdk": "^0.7.1",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -1125,6 +1126,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@ibm/plex": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@ibm/plex/-/plex-6.4.1.tgz",
+      "integrity": "sha512-fnsipQywHt3zWvsnlyYKMikcVI7E2fEwpiPnIHFqlbByXVfQfANAAeJk1IV4mNnxhppUIDlhU0TzwYwL++Rn2g==",
+      "hasInstallScript": true,
+      "license": "OFL-1.1",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.5.1"
+      }
+    },
+    "node_modules/@ibm/telemetry-js": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.10.2.tgz",
+      "integrity": "sha512-F8+/NNUwtm8BuFz18O9KPvIFTFDo8GUSoyhPxPjEpk7nEyEzWGfhIiEPhL00B2NdHRLDSljh3AiCfSnL/tutiQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ibmtelemetry": "dist/collect.js"
       }
     },
     "node_modules/@isaacs/fs-minipass": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "convert-theme": "tsx scripts/convert-theme.ts"
   },
   "dependencies": {
+    "@ibm/plex": "^6.4.1",
     "@opencode-ai/sdk": "^0.7.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "@ibm/plex/css/ibm-plex.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/lib/theme/themes/default-dark.ts
+++ b/src/lib/theme/themes/default-dark.ts
@@ -158,9 +158,9 @@ export const defaultDarkTheme: Theme = {
   
   config: {
     fonts: {
-      sans: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-      mono: '"SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, monospace',
-      heading: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+      sans: '"IBM Plex Mono", monospace',
+      mono: '"IBM Plex Mono", monospace',
+      heading: '"IBM Plex Mono", monospace'
     },
     
     radius: {

--- a/src/lib/theme/themes/default-light.ts
+++ b/src/lib/theme/themes/default-light.ts
@@ -155,9 +155,9 @@ export const defaultLightTheme: Theme = {
   
   config: {
     fonts: {
-      sans: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-      mono: '"SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, monospace',
-      heading: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+      sans: '"IBM Plex Mono", monospace',
+      mono: '"IBM Plex Mono", monospace',
+      heading: '"IBM Plex Mono", monospace'
     },
     
     radius: {


### PR DESCRIPTION
## Summary
- Install `@ibm/plex` package for IBM Plex Mono font family
- Import IBM Plex CSS in main stylesheet  
- Update both light and dark themes to use IBM Plex Mono for all font types (sans, mono, heading)
- Provides consistent monospace typography across entire UI for a more technical, geometric aesthetic

## Changes
- **package.json**: Added `@ibm/plex@^6.4.1` dependency
- **src/index.css**: Added `@import "@ibm/plex/css/ibm-plex.css"`
- **src/lib/theme/themes/default-dark.ts**: Updated all font families to IBM Plex Mono
- **src/lib/theme/themes/default-light.ts**: Updated all font families to IBM Plex Mono

## Visual Impact
All text throughout the application now uses IBM Plex Mono, creating a cohesive monospace aesthetic that enhances the technical/coding tool feel of the interface.