### PR TITLE
Improve tool card UI with hover chevron and inline metadata

### DIFF
--- a/src/components/chat/message/parts/ReasoningPart.tsx
+++ b/src/components/chat/message/parts/ReasoningPart.tsx
@@ -50,8 +50,8 @@ const ReasoningPart: React.FC<ReasoningPartProps> = ({ part, onContentChange, is
         return rawText.split('\n').map((line: string) => line.replace(/^>\s?/, '')).join('\n');
     }, [rawText]);
 
-    // Generate preview for collapsed view
-    const preview = text.length > 0 ? text.substring(0, 100) + (text.length > 100 ? '...' : '') : '';
+    // Generate preview for collapsed view (60 chars limit for both mobile and desktop)
+    const preview = text.length > 0 ? text.substring(0, 60) + (text.length > 60 ? '...' : '') : '';
 
     const handlePopup = React.useCallback((e: React.MouseEvent) => {
         e.stopPropagation();
@@ -70,14 +70,35 @@ const ReasoningPart: React.FC<ReasoningPartProps> = ({ part, onContentChange, is
             {/* Single-line collapsed view */}
             <div
                 className={cn(
-                    'flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors',
-                    isExpanded && 'bg-muted/20'
+                    'group/reasoning flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors'
                 )}
                 onClick={() => setIsExpanded(!isExpanded)}
             >
                 <div className="flex items-center gap-2 flex-shrink-0">
-                    <div className={cn(isRunning && 'animate-pulse')}>
-                        <Brain className="h-3.5 w-3.5 flex-shrink-0" />
+                    {/* Icon with hover chevron replacement */}
+                    <div className="relative h-3.5 w-3.5 flex-shrink-0">
+                        {/* Brain icon - hidden on hover when not mobile, always hidden when expanded */}
+                        <div
+                            className={cn(
+                                'absolute inset-0 transition-opacity',
+                                isExpanded && 'opacity-0',
+                                !isExpanded && !isMobile && 'group-hover/reasoning:opacity-0',
+                                isRunning && 'animate-pulse'
+                            )}
+                        >
+                            <Brain className="h-3.5 w-3.5" />
+                        </div>
+                        {/* Chevron - shown on hover when not mobile, or always when expanded */}
+                        <div
+                            className={cn(
+                                'absolute inset-0 transition-opacity flex items-center justify-center',
+                                isExpanded && 'opacity-100',
+                                !isExpanded && isMobile && 'opacity-0',
+                                !isExpanded && !isMobile && 'opacity-0 group-hover/reasoning:opacity-100'
+                            )}
+                        >
+                            {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                        </div>
                     </div>
                     <span className={cn(
                         'typography-meta font-medium',
@@ -90,16 +111,18 @@ const ReasoningPart: React.FC<ReasoningPartProps> = ({ part, onContentChange, is
                 {preview && (
                     <span className="typography-micro text-muted-foreground/70 truncate flex-1 min-w-0">
                         {preview}
+                        {isFinalized && time && (
+                            <>
+                                {' '}
+                                <span className="text-muted-foreground/60">
+                                    {formatDuration(time.start, time.end)}
+                                </span>
+                            </>
+                        )}
                     </span>
                 )}
 
                 <div className="flex items-center gap-1.5 flex-shrink-0 ml-auto">
-                    {isFinalized && time && (
-                        <span className="typography-meta text-muted-foreground/60">
-                            {formatDuration(time.start, time.end)}
-                        </span>
-                    )}
-
                     {isFinalized && text && (
                         <Button
                             size="sm"
@@ -110,18 +133,6 @@ const ReasoningPart: React.FC<ReasoningPartProps> = ({ part, onContentChange, is
                             <Maximize2 weight="regular" className="h-3 w-3" />
                         </Button>
                     )}
-
-                    <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-5 w-5 p-0 opacity-60 hover:opacity-100"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            setIsExpanded(!isExpanded);
-                        }}
-                    >
-                        {isExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-                    </Button>
                 </div>
             </div>
 

--- a/src/components/chat/message/parts/ToolPart.tsx
+++ b/src/components/chat/message/parts/ToolPart.tsx
@@ -224,14 +224,36 @@ const ToolPart: React.FC<ToolPartProps> = ({ part, isExpanded, onToggle, syntaxT
             {/* Single-line collapsed view */}
             <div
                 className={cn(
-                    'flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors',
-                    isExpanded && 'bg-muted/20'
+                    'group/tool flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors'
                 )}
                 onClick={() => onToggle(part.id)}
             >
                 <div className="flex items-center gap-2 flex-shrink-0">
-                    <div className={cn(isRunning && 'animate-pulse')} style={isError ? { color: 'var(--status-error)' } : {}}>
-                        {getToolIcon(part.tool)}
+                    {/* Icon with hover chevron replacement */}
+                    <div className="relative h-3.5 w-3.5 flex-shrink-0">
+                        {/* Tool icon - hidden on hover when not mobile, always hidden when expanded */}
+                        <div
+                            className={cn(
+                                'absolute inset-0 transition-opacity',
+                                isExpanded && 'opacity-0',
+                                !isExpanded && !isMobile && 'group-hover/tool:opacity-0',
+                                isRunning && 'animate-pulse'
+                            )}
+                            style={isError ? { color: 'var(--status-error)' } : {}}
+                        >
+                            {getToolIcon(part.tool)}
+                        </div>
+                        {/* Chevron - shown on hover when not mobile, or always when expanded */}
+                        <div
+                            className={cn(
+                                'absolute inset-0 transition-opacity flex items-center justify-center',
+                                isExpanded && 'opacity-100',
+                                !isExpanded && isMobile && 'opacity-0',
+                                !isExpanded && !isMobile && 'opacity-0 group-hover/tool:opacity-100'
+                            )}
+                        >
+                            {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                        </div>
                     </div>
                     <span
                         className={cn('typography-meta font-medium', isRunning && 'animate-pulse')}
@@ -244,26 +266,30 @@ const ToolPart: React.FC<ToolPartProps> = ({ part, isExpanded, onToggle, syntaxT
                 {description && (
                     <span className="typography-meta text-muted-foreground/70 truncate flex-1 min-w-0">
                         {description}
-                    </span>
-                )}
-
-                {diffStats && (
-                    <span className="typography-meta text-muted-foreground/60 flex-shrink-0">
-                        <span style={{ color: 'var(--status-success)' }}>+{diffStats.added}</span>
-                        {' '}
-                        <span style={{ color: 'var(--status-error)' }}>-{diffStats.removed}</span>
+                        {diffStats && (
+                            <>
+                                {' '}
+                                <span className="text-muted-foreground/60">
+                                    <span style={{ color: 'var(--status-success)' }}>+{diffStats.added}</span>
+                                    {' '}
+                                    <span style={{ color: 'var(--status-error)' }}>-{diffStats.removed}</span>
+                                </span>
+                            </>
+                        )}
+                        {isFinalized && 'time' in state && (
+                            <>
+                                {' '}
+                                <span className="text-muted-foreground/60">
+                                    {formatDuration(state.time.start, 'end' in state.time ? state.time.end : undefined)}
+                                </span>
+                            </>
+                        )}
                     </span>
                 )}
 
                 <div className="flex items-center gap-1.5 flex-shrink-0 ml-auto">
                     {isFinalized && isError && (
                         <span className="typography-micro font-medium" style={{ color: 'var(--status-error)' }}>Error</span>
-                    )}
-
-                    {isFinalized && 'time' in state && (
-                        <span className="typography-meta text-muted-foreground/60">
-                            {formatDuration(state.time.start, 'end' in state.time ? state.time.end : undefined)}
-                        </span>
                     )}
 
                     {isExpanded && diffStats && (
@@ -283,18 +309,6 @@ const ToolPart: React.FC<ToolPartProps> = ({ part, isExpanded, onToggle, syntaxT
                             <Maximize2 weight="regular" className="h-3 w-3" />
                         </Button>
                     )}
-
-                    <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-5 w-5 p-0 opacity-60 hover:opacity-100"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            onToggle(part.id);
-                        }}
-                    >
-                        {isExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-                    </Button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
Enhances the tool and reasoning card UI with cleaner, more intuitive interactions and better space utilization.

## Changes
- **Hover-activated chevron**: Tool/reasoning icons swap to expand/collapse chevron on hover (desktop), making the action more discoverable while keeping the UI clean
- **Inline metadata**: Diff stats (+73 -13) and duration (1.2s) now display inline with the filename/description instead of as separate elements
- **Removed backgrounds**: Eliminated background highlighting from expanded tool cards for a cleaner appearance
- **Reasoning preview limit**: Capped reasoning preview to 60 characters on all platforms for consistency

## Visual improvements
**Before**: Separate chevron button, scattered metadata
**After**: Hover-reveal chevron, compact inline metadata display

## Files changed
- `src/components/chat/message/parts/ToolPart.tsx`
- `src/components/chat/message/parts/ReasoningPart.tsx`

## Testing
Test on desktop (hover interactions) and mobile (icons always visible) to ensure proper behavior across platforms.