### PR TITLE
feat: Add full OpenCode restart to header config reload button

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1194,6 +1194,28 @@ async function main() {
     }
   });
 
+  // POST /api/config/reload - Manual configuration reload (restart OpenCode)
+  app.post('/api/config/reload', async (req, res) => {
+    try {
+      console.log('[Server] Manual configuration reload requested');
+
+      await refreshOpenCodeAfterConfigChange('manual configuration reload');
+
+      res.json({
+        success: true,
+        requiresReload: true,
+        message: 'Configuration reloaded successfully. Refreshing interface…',
+        reloadDelayMs: CLIENT_RELOAD_DELAY_MS,
+      });
+    } catch (error) {
+      console.error('[Server] Failed to reload configuration:', error);
+      res.status(500).json({
+        error: error.message || 'Failed to reload configuration',
+        success: false
+      });
+    }
+  });
+
 
   // Start OpenCode and setup proxy BEFORE static file serving
   try {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,6 +15,7 @@ import { ContextUsageDisplay } from '@/components/ui/ContextUsageDisplay';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useDeviceInfo } from '@/lib/device';
 import { cn } from '@/lib/utils';
+import { reloadOpenCodeConfiguration } from '@/stores/useAgentsStore';
 
 export const Header: React.FC = () => {
   const toggleSidebar = useUIStore((state) => state.toggleSidebar);
@@ -24,8 +25,6 @@ export const Header: React.FC = () => {
   const {
     isConnected,
     getCurrentModel,
-    loadProviders,
-    loadAgents,
   } = useConfigStore();
 
   const getContextUsage = useSessionStore((state) => state.getContextUsage);
@@ -39,23 +38,11 @@ export const Header: React.FC = () => {
   const currentModel = getCurrentModel();
   const contextLimit = currentModel?.limit?.context || 0;
   const contextUsage = getContextUsage(contextLimit);
-  const [isReloadingConfig, setIsReloadingConfig] = React.useState(false);
   const [isMobileDetailsOpen, setIsMobileDetailsOpen] = React.useState(false);
 
-  const handleReloadConfiguration = React.useCallback(async () => {
-    if (isReloadingConfig) {
-      return;
-    }
-
-    setIsReloadingConfig(true);
-    try {
-      await Promise.all([loadProviders(), loadAgents().then(() => undefined)]);
-    } catch (error) {
-      console.error('Failed to reload configuration:', error);
-    } finally {
-      setIsReloadingConfig(false);
-    }
-  }, [isReloadingConfig, loadAgents, loadProviders]);
+  const handleReloadConfiguration = React.useCallback(() => {
+    void reloadOpenCodeConfiguration();
+  }, []);
 
   useEffect(() => {
     if (contextLimit > 0 && currentSessionId) {
@@ -149,11 +136,10 @@ export const Header: React.FC = () => {
               variant="ghost"
               size="sm"
               onClick={handleReloadConfiguration}
-              disabled={isReloadingConfig}
               aria-label="Refresh OpenCode configuration"
               className="h-8 px-2"
             >
-              <RefreshCcw className={`h-3.5 w-3.5 ${isReloadingConfig ? 'animate-spin-once' : ''}`} />
+              <RefreshCcw className="h-3.5 w-3.5" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -222,10 +208,9 @@ export const Header: React.FC = () => {
                 type="button"
                 variant="outline"
                 onClick={handleReloadConfiguration}
-                disabled={isReloadingConfig}
                 className="flex w-full items-center justify-center gap-2 rounded-md border-border/60 bg-background/80 py-2 text-foreground hover:bg-accent/40"
               >
-                <RefreshCcw className={`h-4 w-4 ${isReloadingConfig ? 'animate-spin-once' : ''}`} />
+                <RefreshCcw className="h-4 w-4" />
                 Refresh config
               </Button>
               <ThemeSwitcher


### PR DESCRIPTION
## Summary

Integrates the header "Refresh config" button with the complete OpenCode restart process to reload configuration from disk. Previously, the button only called `loadProviders()` and `loadAgents()`, which reloaded cached data without restarting the OpenCode backend.

## Changes

### Backend (`server/index.js`)
- Added `POST /api/config/reload` endpoint that triggers full OpenCode restart via `refreshOpenCodeAfterConfigChange()`
- Returns standardized response format: `{requiresReload: true, reloadDelayMs: 800, ...}`

### Frontend (`src/stores/useAgentsStore.ts`)
- Exported `reloadOpenCodeConfiguration()` function for shared config reload logic
- Calls backend `/api/config/reload` endpoint to trigger restart
- Uses `performFullConfigRefresh()` for client-side refresh with:
  - localStorage cleanup (agents-store, config-store)
  - Health check polling with retry logic (6 attempts, exponential backoff)
  - Parallel provider/agent data reload

### UI (`src/components/layout/Header.tsx`)
- Simplified `handleReloadConfiguration` to call shared reload function
- Removed local `isReloadingConfig` state (no longer needed)
- Removed icon animation (fullscreen overlay provides feedback)
- Updated both desktop and mobile reload buttons

## Benefits

✅ **Reads fresh config from disk** - Picks up manual changes to `agents.yaml` and other config files  
✅ **Consistent UX** - Same fullscreen overlay + progress messages as agent save operations  
✅ **Full restart** - Ensures OpenCode backend reloads all configuration from disk  
✅ **Reuses infrastructure** - Aligns with existing `refreshOpenCodeAfterConfigChange` pattern  
✅ **Retry logic** - 6 health check attempts with exponential backoff for reliable reconnection  

## Test Plan

Manual testing required:
1. Click "Refresh config" button in header (desktop + mobile)
2. Verify fullscreen overlay appears with progress messages
3. Confirm OpenCode process restarts (check server logs)
4. Verify fresh providers/agents load after restart
5. Test with manual config file changes to ensure they're picked up

## Documentation

Aligns with `docs/guides/CONFIGURATION_REUSE_GUIDE.md` patterns:
- Uses standardized response format (`requiresReload`, `reloadDelayMs`)
- Leverages `refreshOpenCodeAfterConfigChange()` for restart
- Follows overlay system conventions (`startConfigUpdate`, `finishConfigUpdate`)