### PR TITLE
feat: Add complete slash commands management system

### DIFF
--- a/src/components/sections/commands/AgentSelector.tsx
+++ b/src/components/sections/commands/AgentSelector.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useAgentsStore } from '@/stores/useAgentsStore';
+import { useUIStore } from '@/stores/useUIStore';
+import { useDeviceInfo } from '@/lib/device';
+import { Robot, CaretDown as ChevronDown } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
+import { MobileOverlayPanel } from '@/components/ui/MobileOverlayPanel';
+
+interface AgentSelectorProps {
+    agentName: string;
+    onChange: (agentName: string) => void;
+    className?: string;
+}
+
+export const AgentSelector: React.FC<AgentSelectorProps> = ({
+    agentName,
+    onChange,
+    className
+}) => {
+    const { agents, loadAgents } = useAgentsStore();
+    const isMobile = useUIStore(state => state.isMobile);
+    const { isMobile: deviceIsMobile } = useDeviceInfo();
+    const isActuallyMobile = isMobile || deviceIsMobile;
+
+    // Mobile panel state
+    const [isMobilePanelOpen, setIsMobilePanelOpen] = React.useState(false);
+
+    // Load agents on mount
+    React.useEffect(() => {
+        loadAgents();
+    }, [loadAgents]);
+
+    const closeMobilePanel = () => setIsMobilePanelOpen(false);
+
+    const handleAgentChange = (newAgentName: string) => {
+        onChange(newAgentName);
+    };
+
+    // Mobile panel
+    const renderMobileAgentPanel = () => {
+        if (!isActuallyMobile) return null;
+
+        return (
+            <MobileOverlayPanel
+                open={isMobilePanelOpen}
+                onClose={closeMobilePanel}
+                title="Select Agent"
+            >
+                <div className="space-y-1">
+                    {agents.map((agent) => {
+                        const isSelected = agent.name === agentName;
+
+                        return (
+                            <button
+                                key={agent.name}
+                                type="button"
+                                className={cn(
+                                    'flex w-full items-center justify-between rounded-md border border-border/40 bg-background/95 px-2 py-1.5 text-left',
+                                    isSelected ? 'bg-primary/10 text-primary' : 'text-foreground'
+                                )}
+                                onClick={() => {
+                                    handleAgentChange(agent.name);
+                                    closeMobilePanel();
+                                }}
+                            >
+                                <div className="flex flex-col">
+                                    <span className="typography-meta font-medium">{agent.name}</span>
+                                    {agent.description && (
+                                        <span className="typography-micro text-muted-foreground">
+                                            {agent.description}
+                                        </span>
+                                    )}
+                                </div>
+                                {isSelected && (
+                                    <div className="h-2 w-2 rounded-full bg-primary" />
+                                )}
+                            </button>
+                        );
+                    })}
+
+                    <button
+                        type="button"
+                        className="flex w-full items-center justify-between rounded-md border border-border/40 bg-background/95 px-2 py-1.5 text-left"
+                        onClick={() => {
+                            handleAgentChange('');
+                            closeMobilePanel();
+                        }}
+                    >
+                        <span className="typography-meta text-muted-foreground">No agent (optional)</span>
+                    </button>
+                </div>
+            </MobileOverlayPanel>
+        );
+    };
+
+    return (
+        <>
+            {isActuallyMobile ? (
+                <button
+                    type="button"
+                    onClick={() => setIsMobilePanelOpen(true)}
+                    className={cn(
+                        'flex w-full items-center justify-between gap-2 rounded-md border border-border/40 bg-background/95 px-2 py-1.5 text-left',
+                        className
+                    )}
+                >
+                    <div className="flex items-center gap-2">
+                        <Robot className="h-3.5 w-3.5 text-muted-foreground" />
+                        <span className="typography-meta font-medium text-foreground">
+                            {agentName || 'Select agent...'}
+                        </span>
+                    </div>
+                    <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                </button>
+            ) : (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <div className={cn(
+                            'flex items-center gap-2 px-2 rounded-md bg-accent/20 border border-border/20 min-w-0 cursor-pointer hover:bg-accent/30 transition-colors h-8 w-fit max-w-[200px]',
+                            className
+                        )}>
+                            <Robot className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
+                            <span className="typography-micro font-medium truncate">
+                                {agentName || 'Not selected'}
+                            </span>
+                            <ChevronDown className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
+                        </div>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="max-w-[300px]">
+                        {agents.map((agent) => (
+                            <DropdownMenuItem
+                                key={agent.name}
+                                className="typography-meta"
+                                onSelect={() => handleAgentChange(agent.name)}
+                            >
+                                <span className="font-medium">{agent.name}</span>
+                            </DropdownMenuItem>
+                        ))}
+                        <DropdownMenuItem
+                            className="typography-meta"
+                            onSelect={() => handleAgentChange('')}
+                        >
+                            <span className="text-muted-foreground">No agent (optional)</span>
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            )}
+            {renderMobileAgentPanel()}
+        </>
+    );
+};

--- a/src/components/sections/commands/CommandsPage.tsx
+++ b/src/components/sections/commands/CommandsPage.tsx
@@ -1,6 +1,274 @@
 import React from 'react';
-import { SectionPlaceholder } from '../SectionPlaceholder';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from 'sonner';
+import { useCommandsStore, type CommandConfig } from '@/stores/useCommandsStore';
+import { useConfigStore } from '@/stores/useConfigStore';
+import { TerminalWindow, FloppyDisk, Check } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
+import { ModelSelector } from '../agents/ModelSelector';
+import { AgentSelector } from './AgentSelector';
 
 export const CommandsPage: React.FC = () => {
-    return <SectionPlaceholder sectionId="commands" variant="page" />;
+  const { selectedCommandName, getCommandByName, createCommand, updateCommand, commands } = useCommandsStore();
+  const { providers } = useConfigStore();
+
+  const selectedCommand = React.useMemo(() =>
+    selectedCommandName ? getCommandByName(selectedCommandName) : null,
+    [selectedCommandName, commands, getCommandByName]
+  );
+  const isNewCommand = selectedCommandName && !selectedCommand;
+
+  // Form state
+  const [name, setName] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [agent, setAgent] = React.useState('');
+  const [model, setModel] = React.useState('');
+  const [template, setTemplate] = React.useState('');
+  const [subtask, setSubtask] = React.useState(false);
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  // Initialize form when command changes
+  React.useEffect(() => {
+    if (isNewCommand) {
+      // Reset form for new command
+      setName(selectedCommandName || '');
+      setDescription('');
+      setAgent('');
+      setModel('');
+      setTemplate('');
+      setSubtask(false);
+    } else if (selectedCommand) {
+      // Load existing command data
+      setName(selectedCommand.name);
+      setDescription(selectedCommand.description || '');
+      setAgent(selectedCommand.agent || '');
+      setModel(selectedCommand.model || '');
+      setTemplate(selectedCommand.template || '');
+      setSubtask(selectedCommand.subtask || false);
+    }
+  }, [selectedCommand, isNewCommand, selectedCommandName, commands]);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast.error('Command name is required');
+      return;
+    }
+
+    if (!template.trim()) {
+      toast.error('Command template is required');
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const config: CommandConfig = {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        agent: agent.trim() || undefined,
+        model: model.trim() || undefined,
+        template: template.trim(),
+        subtask,
+      };
+
+      let success: boolean;
+      if (isNewCommand) {
+        success = await createCommand(config);
+      } else {
+        success = await updateCommand(name, config);
+      }
+
+      if (success) {
+        toast.success(isNewCommand ? 'Command created successfully' : 'Command updated successfully');
+      } else {
+        toast.error(isNewCommand ? 'Failed to create command' : 'Failed to update command');
+      }
+    } catch (error) {
+      console.error('Error saving command:', error);
+      toast.error('An error occurred while saving');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!selectedCommandName) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <TerminalWindow className="mx-auto mb-3 h-12 w-12 opacity-50" />
+          <p className="typography-body">Select a command from the sidebar</p>
+          <p className="typography-meta mt-1 opacity-75">or create a new one</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-3xl space-y-6 p-6">
+        {/* Header */}
+        <div className="space-y-1">
+          <h1 className="typography-h1 font-semibold">
+            {isNewCommand ? 'New Command' : name}
+          </h1>
+          <p className="typography-body text-muted-foreground mt-1">
+            {isNewCommand
+              ? 'Configure a new slash command with custom template'
+              : 'Configure command template and behavior'}
+          </p>
+        </div>
+
+        {/* Basic Information */}
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="typography-h2 font-semibold text-foreground">Basic Information</h2>
+            <p className="typography-meta text-muted-foreground/80">
+              Configure command identity and metadata
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="typography-ui-label font-medium text-foreground">
+              Command Name
+            </label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-command"
+              disabled={!isNewCommand}
+            />
+            <p className="typography-meta text-muted-foreground">
+              Used with slash (/) prefix in chat
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="typography-ui-label font-medium text-foreground">
+              Description
+            </label>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this command do?"
+              rows={3}
+              className="min-h-[80px]"
+            />
+          </div>
+        </div>
+
+        {/* Model Configuration */}
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="typography-h2 font-semibold text-foreground">Model & Agent Configuration</h2>
+            <p className="typography-meta text-muted-foreground/80">
+              Configure model and agent for command execution
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="typography-ui-label font-medium text-foreground">
+              Agent
+            </label>
+            <AgentSelector
+              agentName={agent}
+              onChange={(agentName: string) => setAgent(agentName)}
+            />
+            <p className="typography-meta text-muted-foreground">
+              Agent to execute this command (optional)
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="typography-ui-label font-medium text-foreground">
+              Model
+            </label>
+            <ModelSelector
+              providerId={model ? model.split('/')[0] : ''}
+              modelId={model ? model.split('/')[1] : ''}
+              onChange={(providerId: string, modelId: string) => {
+                if (providerId && modelId) {
+                  setModel(`${providerId}/${modelId}`);
+                } else {
+                  setModel('');
+                }
+              }}
+            />
+            <p className="typography-meta text-muted-foreground">
+              Default model for this command (optional)
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="typography-ui-label font-medium text-foreground flex items-center gap-2 cursor-pointer">
+              <div className="relative">
+                <input
+                  type="checkbox"
+                  checked={subtask}
+                  onChange={(e) => setSubtask(e.target.checked)}
+                  className="sr-only"
+                />
+                <div className={cn(
+                  "w-5 h-5 rounded border-2 flex items-center justify-center transition-colors",
+                  subtask
+                    ? "bg-primary border-primary"
+                    : "bg-background border-border hover:border-primary/50"
+                )}>
+                  {subtask && <Check className="w-3 h-3 text-primary-foreground" weight="bold" />}
+                </div>
+              </div>
+              Force Subagent Invocation
+            </label>
+            <p className="typography-meta text-muted-foreground">
+              Force command to run in a subagent context
+            </p>
+          </div>
+        </div>
+
+        {/* Command Template */}
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="typography-h2 font-semibold text-foreground">Command Template</h2>
+            <p className="typography-meta text-muted-foreground/80">
+              Define the prompt template for this command. Use $ARGUMENTS for user input.
+            </p>
+          </div>
+          <Textarea
+            value={template}
+            onChange={(e) => setTemplate(e.target.value)}
+            placeholder={`Your command template here...
+
+Use $ARGUMENTS to reference user input.
+Use !\`shell command\` to inject shell output.
+Use @filename to include file contents.`}
+            rows={12}
+            className="font-mono typography-meta min-h-[240px]"
+          />
+          <div className="typography-meta text-muted-foreground/80 space-y-1">
+            <p className="font-medium">Template Features:</p>
+            <ul className="list-disc list-inside space-y-0.5 ml-2">
+              <li><code className="bg-muted px-1 rounded">$ARGUMENTS</code> - User input after command</li>
+              <li><code className="bg-muted px-1 rounded">!`command`</code> - Inject shell command output</li>
+              <li><code className="bg-muted px-1 rounded">@filename</code> - Include file contents</li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Save Button */}
+        <div className="flex justify-end border-t border-border/40 pt-4">
+          <Button
+            size="sm"
+            variant="default"
+            onClick={handleSave}
+            disabled={isSaving}
+            className="gap-2 h-6 px-3 text-xs w-fit"
+          >
+            <FloppyDisk className="h-3 w-3" weight="bold" />
+            {isSaving ? 'Saving...' : 'Save Changes'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/src/components/sections/commands/CommandsSidebar.tsx
+++ b/src/components/sections/commands/CommandsSidebar.tsx
@@ -1,6 +1,280 @@
 import React from 'react';
-import { SectionPlaceholder } from '../SectionPlaceholder';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Plus,
+  TerminalWindow,
+  DotsThreeVertical as MoreVertical,
+  Trash as Trash2,
+  Copy,
+} from '@phosphor-icons/react';
+import { useCommandsStore, type Command } from '@/stores/useCommandsStore';
+import { useUIStore } from '@/stores/useUIStore';
+import { useDeviceInfo } from '@/lib/device';
+import { cn } from '@/lib/utils';
 
 export const CommandsSidebar: React.FC = () => {
-    return <SectionPlaceholder sectionId="commands" variant="sidebar" />;
+  const [newCommandName, setNewCommandName] = React.useState('');
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = React.useState(false);
+
+  const {
+    selectedCommandName,
+    commands,
+    setSelectedCommand,
+    deleteCommand,
+    loadCommands,
+  } = useCommandsStore();
+
+  const { setSidebarOpen } = useUIStore();
+  const { isMobile } = useDeviceInfo();
+
+  // Load commands on mount
+  React.useEffect(() => {
+    loadCommands();
+  }, [loadCommands]);
+
+  const handleCreateCommand = () => {
+    if (!newCommandName.trim()) {
+      toast.error('Command name is required');
+      return;
+    }
+
+    // Sanitize command name: replace spaces with dashes
+    const sanitizedName = newCommandName.trim().replace(/\s+/g, '-');
+
+    // Check for duplicate names
+    if (commands.some((cmd) => cmd.name === sanitizedName)) {
+      toast.error('A command with this name already exists');
+      return;
+    }
+
+    // Select the new command and open the page for configuration
+    setSelectedCommand(sanitizedName);
+    setNewCommandName('');
+    setIsCreateDialogOpen(false);
+
+    // Auto-hide sidebar on mobile
+    if (isMobile) {
+      setSidebarOpen(false);
+    }
+  };
+
+  const handleDeleteCommand = async (command: Command) => {
+    if (window.confirm(`Are you sure you want to delete command "${command.name}"?`)) {
+      const success = await deleteCommand(command.name);
+      if (success) {
+        toast.success(`Command "${command.name}" deleted successfully`);
+      } else {
+        toast.error('Failed to delete command');
+      }
+    }
+  };
+
+  const handleDuplicateCommand = (command: Command) => {
+    const baseName = command.name;
+    let copyNumber = 1;
+    let newName = `${baseName}-copy`;
+
+    // Find a unique name
+    while (commands.some((c) => c.name === newName)) {
+      copyNumber++;
+      newName = `${baseName}-copy-${copyNumber}`;
+    }
+
+    setSelectedCommand(newName);
+    setIsCreateDialogOpen(false);
+
+    // Auto-hide sidebar on mobile
+    if (isMobile) {
+      setSidebarOpen(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-sidebar">
+      <div className={cn('border-b border-border/40 px-3 dark:border-white/10', isMobile ? 'mt-2 py-3' : 'py-3')}>
+        <div className="flex items-center justify-between">
+          <h2 className="typography-ui-label font-semibold text-foreground">Commands</h2>
+          <span className="typography-meta text-muted-foreground">
+            {commands.length} total
+          </span>
+        </div>
+      </div>
+
+      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+        <div className="flex-1 overflow-y-auto overflow-x-hidden">
+          <div className="space-y-1 px-3 py-2">
+            <DialogTrigger asChild>
+              <Button
+                variant="ghost"
+                className="w-full justify-start gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
+              >
+                <Plus className="h-4 w-4 flex-shrink-0" weight="bold" />
+                <span className="typography-ui-label font-medium">New Command</span>
+              </Button>
+            </DialogTrigger>
+
+            {commands.length === 0 ? (
+              <div className="py-12 px-4 text-center text-muted-foreground">
+                <TerminalWindow className="mx-auto mb-3 h-10 w-10 opacity-50" />
+                <p className="typography-ui-label font-medium">No commands configured</p>
+                <p className="typography-meta mt-1 opacity-75">Create one to get started</p>
+              </div>
+            ) : (
+              <>
+                {[...commands].sort((a, b) => a.name.localeCompare(b.name)).map((command) => (
+                  <CommandListItem
+                    key={command.name}
+                    command={command}
+                    isSelected={selectedCommandName === command.name}
+                    onSelect={() => {
+                      setSelectedCommand(command.name);
+                      if (isMobile) {
+                        setSidebarOpen(false);
+                      }
+                    }}
+                    onDelete={() => handleDeleteCommand(command)}
+                    onDuplicate={() => handleDuplicateCommand(command)}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        </div>
+
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New Command</DialogTitle>
+            <DialogDescription>
+              Enter a unique name for your new slash command
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={newCommandName}
+            onChange={(e) => setNewCommandName(e.target.value)}
+            placeholder="Command name..."
+            className="text-foreground placeholder:text-muted-foreground"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleCreateCommand();
+              }
+            }}
+          />
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setIsCreateDialogOpen(false)}
+              className="text-foreground hover:bg-muted hover:text-foreground"
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleCreateCommand}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+interface CommandListItemProps {
+  command: Command;
+  isSelected: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  onDuplicate: () => void;
+}
+
+const CommandListItem: React.FC<CommandListItemProps> = ({
+  command,
+  isSelected,
+  onSelect,
+  onDelete,
+  onDuplicate,
+}) => {
+  return (
+    <div
+      className={cn(
+        "group rounded-lg transition-all duration-200",
+        isSelected
+          ? "bg-sidebar-accent shadow-sm"
+          : "hover:bg-sidebar-accent/50"
+      )}
+    >
+      <div className="relative">
+        <div className="w-full flex items-center justify-between py-1.5 px-2 pr-1 rounded-lg transition-colors hover:bg-background/5">
+          <button
+            onClick={onSelect}
+            className="flex-1 text-left overflow-hidden"
+            inputMode="none"
+            tabIndex={0}
+          >
+            <div className="flex items-center gap-2">
+              <div className="typography-ui-header font-medium truncate flex-1">
+                /{command.name}
+              </div>
+            </div>
+
+            {/* Description preview */}
+            {command.description && (
+              <div className="typography-meta text-muted-foreground truncate mt-0.5">
+                {command.description}
+              </div>
+            )}
+          </button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-6 w-6 flex-shrink-0 -mr-1 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              >
+                <MoreVertical weight="regular" className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-fit min-w-20">
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDuplicate();
+                }}
+              >
+                <Copy className="h-4 w-4 mr-px" />
+                Duplicate
+              </DropdownMenuItem>
+
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="h-4 w-4 mr-px" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/src/lib/opencode/client.ts
+++ b/src/lib/opencode/client.ts
@@ -910,6 +910,25 @@ class OpencodeService {
     }
   }
 
+  async listCommandsWithDetails(): Promise<Array<{ name: string; description?: string; agent?: string; model?: string; template?: string; subtask?: boolean }>> {
+    try {
+      const response = await (this.client as any).command.list({
+        query: this.currentDirectory ? { directory: this.currentDirectory } : undefined
+      });
+      // Return full command details including template
+      return (response.data || []).map((cmd: any) => ({
+        name: cmd.name,
+        description: cmd.description,
+        agent: cmd.agent,
+        model: cmd.model,
+        template: cmd.template,
+        subtask: cmd.subtask
+      }));
+    } catch (error) {
+      return [];
+    }
+  }
+
   async getCommandDetails(name: string): Promise<{ name: string; template: string; description?: string; agent?: string; model?: string } | null> {
     try {
       const response = await (this.client as any).command.list({

--- a/src/stores/useCommandsStore.ts
+++ b/src/stores/useCommandsStore.ts
@@ -1,0 +1,374 @@
+import { create } from "zustand";
+import { devtools, persist, createJSONStorage } from "zustand/middleware";
+import { opencodeClient } from "@/lib/opencode/client";
+import {
+  startConfigUpdate,
+  finishConfigUpdate,
+  updateConfigUpdateMessage,
+} from "@/lib/configUpdate";
+import { emitConfigChange, scopeMatches, subscribeToConfigChanges } from "@/lib/configSync";
+import { getSafeStorage } from "./utils/safeStorage";
+import { useConfigStore } from "@/stores/useConfigStore";
+
+export interface CommandConfig {
+  name: string;
+  description?: string;
+  agent?: string;
+  model?: string;
+  template?: string;
+  subtask?: boolean;
+}
+
+// Extended interface with all possible fields from API
+export interface Command extends CommandConfig {
+  isBuiltIn?: boolean;
+}
+
+const CONFIG_EVENT_SOURCE = "useCommandsStore";
+const DEFAULT_RELOAD_DELAY_MS = 1200;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface CommandsStore {
+  // State
+  selectedCommandName: string | null;
+  commands: Command[];
+  isLoading: boolean;
+
+  // Actions
+  setSelectedCommand: (name: string | null) => void;
+  loadCommands: () => Promise<boolean>;
+  createCommand: (config: CommandConfig) => Promise<boolean>;
+  updateCommand: (name: string, config: Partial<CommandConfig>) => Promise<boolean>;
+  deleteCommand: (name: string) => Promise<boolean>;
+  getCommandByName: (name: string) => Command | undefined;
+}
+
+export const useCommandsStore = create<CommandsStore>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        // Initial State
+        selectedCommandName: null,
+        commands: [],
+        isLoading: false,
+
+        // Set selected command
+        setSelectedCommand: (name: string | null) => {
+          set({ selectedCommandName: name });
+        },
+
+        // Load commands from API
+        loadCommands: async () => {
+          set({ isLoading: true });
+          const previousCommands = get().commands;
+          let lastError: unknown = null;
+
+          for (let attempt = 0; attempt < 3; attempt++) {
+            try {
+              const commands = await opencodeClient.listCommandsWithDetails();
+              set({ commands, isLoading: false });
+              return true;
+            } catch (error) {
+              lastError = error;
+              const waitMs = 200 * (attempt + 1);
+              await new Promise((resolve) => setTimeout(resolve, waitMs));
+            }
+          }
+
+          console.error("Failed to load commands:", lastError);
+          set({ commands: previousCommands, isLoading: false });
+          return false;
+        },
+
+        // Create new command
+        createCommand: async (config: CommandConfig) => {
+          startConfigUpdate("Creating command configuration…");
+          let requiresReload = false;
+          try {
+            console.log('[CommandsStore] Creating command:', config.name);
+
+            const commandConfig: any = {
+              template: config.template || '', // template is required
+            };
+
+            if (config.description) commandConfig.description = config.description;
+            if (config.agent) commandConfig.agent = config.agent;
+            if (config.model) commandConfig.model = config.model;
+            if (config.subtask !== undefined) commandConfig.subtask = config.subtask;
+
+            console.log('[CommandsStore] Command config to save:', commandConfig);
+
+            const response = await fetch(`/api/config/commands/${encodeURIComponent(config.name)}`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(commandConfig)
+            });
+
+            const payload = await response.json().catch(() => null);
+            if (!response.ok) {
+              const message = payload?.error || 'Failed to create command';
+              throw new Error(message);
+            }
+
+            console.log('[CommandsStore] Command created successfully');
+
+            if (payload?.requiresReload) {
+              requiresReload = true;
+              void performFullConfigRefresh({
+                message: payload.message,
+                delayMs: payload.reloadDelayMs,
+              });
+              return true;
+            }
+
+            const loaded = await get().loadCommands();
+            if (loaded) {
+              emitConfigChange("commands", { source: CONFIG_EVENT_SOURCE });
+            }
+            return loaded;
+          } catch (error) {
+            console.error("[CommandsStore] Failed to create command:", error);
+            return false;
+          } finally {
+            if (!requiresReload) {
+              finishConfigUpdate();
+            }
+          }
+        },
+
+        // Update existing command
+        updateCommand: async (name: string, config: Partial<CommandConfig>) => {
+          startConfigUpdate("Updating command configuration…");
+          let requiresReload = false;
+          try {
+            console.log('[CommandsStore] Updating command:', name);
+            console.log('[CommandsStore] Config received:', config);
+
+            const commandConfig: any = {};
+
+            if (config.description !== undefined) commandConfig.description = config.description;
+            if (config.agent !== undefined) commandConfig.agent = config.agent;
+            if (config.model !== undefined) commandConfig.model = config.model;
+            if (config.template !== undefined) commandConfig.template = config.template;
+            if (config.subtask !== undefined) commandConfig.subtask = config.subtask;
+
+            console.log('[CommandsStore] Command config to update:', commandConfig);
+
+            const response = await fetch(`/api/config/commands/${encodeURIComponent(name)}`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(commandConfig)
+            });
+
+            const payload = await response.json().catch(() => null);
+            if (!response.ok) {
+              const message = payload?.error || 'Failed to update command';
+              throw new Error(message);
+            }
+
+            console.log('[CommandsStore] Command updated successfully');
+
+            if (payload?.requiresReload) {
+              requiresReload = true;
+              void performFullConfigRefresh({
+                message: payload.message,
+                delayMs: payload.reloadDelayMs,
+              });
+              return true;
+            }
+
+            const loaded = await get().loadCommands();
+            if (loaded) {
+              emitConfigChange("commands", { source: CONFIG_EVENT_SOURCE });
+            }
+            return loaded;
+          } catch (error) {
+            console.error("[CommandsStore] Failed to update command:", error);
+            return false;
+          } finally {
+            if (!requiresReload) {
+              finishConfigUpdate();
+            }
+          }
+        },
+
+        // Delete command
+        deleteCommand: async (name: string) => {
+          startConfigUpdate("Deleting command configuration…");
+          let requiresReload = false;
+          try {
+            const response = await fetch(`/api/config/commands/${encodeURIComponent(name)}`, {
+              method: 'DELETE'
+            });
+
+            const payload = await response.json().catch(() => null);
+            if (!response.ok) {
+              const message = payload?.error || 'Failed to delete command';
+              throw new Error(message);
+            }
+
+            console.log('[CommandsStore] Command deleted successfully');
+
+            if (payload?.requiresReload) {
+              requiresReload = true;
+              void performFullConfigRefresh({
+                message: payload.message,
+                delayMs: payload.reloadDelayMs,
+              });
+              return true;
+            }
+
+            const loaded = await get().loadCommands();
+            if (loaded) {
+              emitConfigChange("commands", { source: CONFIG_EVENT_SOURCE });
+            }
+
+            if (get().selectedCommandName === name) {
+              set({ selectedCommandName: null });
+            }
+
+            return loaded;
+          } catch (error) {
+            console.error("Failed to delete command:", error);
+            return false;
+          } finally {
+            if (!requiresReload) {
+              finishConfigUpdate();
+            }
+          }
+        },
+
+        // Get command by name
+        getCommandByName: (name: string) => {
+          const { commands } = get();
+          return commands.find((c) => c.name === name);
+        },
+      }),
+      {
+        name: "commands-store",
+        storage: createJSONStorage(() => getSafeStorage()),
+        partialize: (state) => ({
+          selectedCommandName: state.selectedCommandName,
+        }),
+      },
+    ),
+    {
+      name: "commands-store",
+    },
+  ),
+);
+
+if (typeof window !== "undefined") {
+  (window as any).__zustand_commands_store__ = useCommandsStore;
+}
+
+async function waitForOpenCodeConnection(delayMs?: number) {
+  const initialDelay = typeof delayMs === "number" && !Number.isNaN(delayMs)
+    ? delayMs
+    : DEFAULT_RELOAD_DELAY_MS;
+
+  await sleep(initialDelay);
+
+  const maxAttempts = 6;
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      updateConfigUpdateMessage(`Waiting for OpenCode… (${attempt + 1}/${maxAttempts})`);
+      const isHealthy = await opencodeClient.checkHealth();
+      if (isHealthy) {
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    const backoff = 1000 + (attempt * 500);
+    await sleep(backoff);
+  }
+
+  throw lastError || new Error("OpenCode did not become ready in time");
+}
+
+async function performFullConfigRefresh(options: { message?: string; delayMs?: number } = {}) {
+  const { message, delayMs } = options;
+
+  try {
+    updateConfigUpdateMessage(message || "Reloading OpenCode configuration…");
+    if (typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.removeItem("commands-store");
+      window.localStorage.removeItem("config-store");
+    }
+  } catch (error) {
+    console.warn("[CommandsStore] Failed to prepare config refresh:", error);
+  }
+
+  try {
+    await waitForOpenCodeConnection(delayMs);
+    updateConfigUpdateMessage("Refreshing providers and commands…");
+
+    const configStore = useConfigStore.getState();
+    const commandsStore = useCommandsStore.getState();
+
+    await Promise.all([
+      configStore.loadProviders().then(() => undefined),
+      commandsStore.loadCommands().then(() => undefined),
+    ]);
+
+    emitConfigChange("commands", { source: CONFIG_EVENT_SOURCE });
+  } catch (error) {
+    console.error("[CommandsStore] Failed to refresh configuration after OpenCode restart:", error);
+    updateConfigUpdateMessage("OpenCode reload failed. Please retry refreshing configuration manually.");
+    await sleep(1500);
+  } finally {
+    finishConfigUpdate();
+  }
+}
+
+export async function reloadOpenCodeConfiguration(options?: { message?: string; delayMs?: number }) {
+  startConfigUpdate(options?.message || "Reloading OpenCode configuration…");
+
+  try {
+    const response = await fetch('/api/config/reload', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      const message = payload?.error || 'Failed to reload configuration';
+      throw new Error(message);
+    }
+
+    if (payload?.requiresReload) {
+      await performFullConfigRefresh({
+        message: payload.message,
+        delayMs: payload.reloadDelayMs,
+      });
+    } else {
+      await performFullConfigRefresh(options);
+    }
+  } catch (error) {
+    console.error('[reloadOpenCodeConfiguration] Failed:', error);
+    updateConfigUpdateMessage('Failed to reload configuration. Please try again.');
+    await sleep(2000);
+    finishConfigUpdate();
+    throw error;
+  }
+}
+
+let unsubscribeCommandsConfigChanges: (() => void) | null = null;
+
+if (!unsubscribeCommandsConfigChanges) {
+  unsubscribeCommandsConfigChanges = subscribeToConfigChanges((event) => {
+    if (event.source === CONFIG_EVENT_SOURCE) {
+      return;
+    }
+
+    if (scopeMatches(event, "commands")) {
+      const { loadCommands } = useCommandsStore.getState();
+      void loadCommands();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Implements a complete management system for custom slash commands, mirroring the Agents configuration architecture with full CRUD operations and OpenCode integration.

## Changes

### Backend
- **Command config functions** (`server/lib/opencode-config.js`)
  - `getCommandSources()` - retrieve command configuration sources
  - `createCommand()` - create `.md` files in `~/.config/opencode/command/`
  - `updateCommand()` - per-parameter priority logic (MD → JSON)
  - `deleteCommand()` - remove command configurations
  
- **REST API endpoints** (`server/index.js`)
  - `GET /api/config/commands/:name` - command metadata
  - `POST /api/config/commands/:name` - create command
  - `PATCH /api/config/commands/:name` - update command
  - `DELETE /api/config/commands/:name` - delete command
  - Fixed JSON body parser for command routes

### Frontend
- **CommandsStore** (`src/stores/useCommandsStore.ts`)
  - Full CRUD operations with automatic OpenCode restart
  - Config sync via events
  - Retry logic for loading

- **CommandsPage** (`src/components/sections/commands/CommandsPage.tsx`)
  - Command name (disabled after creation)
  - Description textarea
  - Agent selector dropdown
  - Model selector (reused from Agents)
  - Subtask checkbox with custom styling
  - Template textarea with feature hints

- **CommandsSidebar** (`src/components/sections/commands/CommandsSidebar.tsx`)
  - Alphabetically sorted command list
  - New Command dialog
  - Duplicate/Delete actions
  - Mobile support with auto-hide

- **AgentSelector** (`src/components/sections/commands/AgentSelector.tsx`)
  - Desktop: dropdown with agent names only
  - Mobile: overlay panel with names + descriptions
  - "Not selected" default state

### UX Improvements
- ✅ Consistent checkbox design (matches Agents page)
- ✅ Template literal placeholders with real line breaks
- ✅ Command name sanitization (spaces → dashes)
- ✅ Alphabetical sorting in sidebar
- ✅ Mobile-responsive layouts

## Technical Notes
- Follows exact same architecture as Agents management
- Per-parameter priority: `.md` frontmatter → `opencode.json`
- `template` field goes in `.md` body (analogous to `prompt`)
- Full desktop and mobile support