### PR TITLE
feat: Add directory creation UI in DirectoryTree picker

### DIFF
--- a/src/lib/opencode/client.ts
+++ b/src/lib/opencode/client.ts
@@ -962,17 +962,41 @@ class OpencodeService {
       if (!response.ok) {
         return false;
       }
-      
+
       const healthData = await response.json();
-      
+
       // Check if OpenCode is actually ready (not just WebUI server)
       if (healthData.isOpenCodeReady === false) {
         return false;
       }
-      
+
       return true;
     } catch (error) {
       return false;
+    }
+  }
+
+  // File System Operations
+  async createDirectory(dirPath: string): Promise<{ success: boolean; path: string }> {
+    try {
+      const response = await fetch(`${this.baseUrl}/fs/mkdir`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ path: dirPath }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Failed to create directory' }));
+        throw new Error(error.error || 'Failed to create directory');
+      }
+
+      const result = await response.json();
+      return result;
+    } catch (error) {
+      console.error('Failed to create directory:', error);
+      throw error;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Added inline directory creation feature to DirectoryTree component
- New backend endpoint for directory creation with security checks
- Auto-increment naming logic for new directories

## Changes

### Backend
- **POST /api/fs/mkdir** endpoint with path traversal protection
- Added `/api/fs` to JSON parsing middleware
- Secure directory creation using `fs.mkdirSync` with recursive option

### Frontend
- **DirectoryTree UI**: Added `+` button on each directory (visible on hover)
- **Inline creation**: Input field appears when creating new directory
- **Auto-increment naming**: `new_directory` → `new_directory2` → `new_directory3`
- **Keyboard shortcuts**: Enter to create, ESC to cancel
- **Auto-expand**: Parent directory expands automatically when adding child
- **Client method**: `opencodeClient.createDirectory(path)` for API calls

### UX Improvements
- Muted selection colors (`selection:bg-muted selection:text-muted-foreground`)
- Plus icon with `weight="regular"` for consistency
- Single confirm button (✓) - ESC for cancel
- Works in both `inline` and `dropdown` DirectoryTree variants

## Test plan
- [x] Create directory via + button
- [x] Test auto-increment naming when duplicates exist
- [x] Test Enter, ESC, and blur interactions
- [x] Verify security (path traversal protection)
- [x] Test on both inline and dropdown variants