### PR TITLE
Persist appearance preferences across Electron sessions

### DIFF
--- a/conductor-deploy.sh
+++ b/conductor-deploy.sh
@@ -225,12 +225,18 @@ build_electron_package() {
     log_step "Building Electron package..."
     if npm run package:electron; then
         log_success "Electron package created"
-        latest_pkg=$(ls -t release/*.dmg release/*.zip 2>/dev/null | head -n 1 || true)
-        if [ -n "$latest_pkg" ]; then
-            echo -e "${YELLOW}Latest package:${NC} $latest_pkg"
-            open "$latest_pkg" 2>/dev/null || xdg-open "$latest_pkg" 2>/dev/null || echo "Please open it manually."
+        latest_dmg=$(ls -t release/*.dmg 2>/dev/null | head -n 1 || true)
+        if [ -n "$latest_dmg" ]; then
+            echo -e "${YELLOW}Latest DMG:${NC} $latest_dmg"
+            open "$latest_dmg" 2>/dev/null || xdg-open "$latest_dmg" 2>/dev/null || echo "Please open it manually."
         else
-            echo -e "${YELLOW}Packages are available in:${NC} release/"
+            latest_pkg=$(ls -t release/*.zip 2>/dev/null | head -n 1 || true)
+            if [ -n "$latest_pkg" ]; then
+                echo -e "${YELLOW}Latest package:${NC} $latest_pkg"
+                open "$latest_pkg" 2>/dev/null || xdg-open "$latest_pkg" 2>/dev/null || echo "Please open it manually."
+            else
+                echo -e "${YELLOW}Packages are available in:${NC} release/"
+            fi
         fi
     else
         log_error "Electron packaging failed"

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -30,3 +30,8 @@ contextBridge.exposeInMainWorld("opencodeDesktopSettings", {
   updateSettings: (payload) => ipcRenderer.invoke("settings:update", payload)
 });
 contextBridge.exposeInMainWorld("__OPENCHAMBER_HOME__", homeDirectory);
+
+contextBridge.exposeInMainWorld("opencodeAppearance", {
+  load: () => ipcRenderer.invoke("appearance:load"),
+  save: (payload) => ipcRenderer.invoke("appearance:save", payload)
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -120,7 +120,7 @@ export const Header: React.FC = () => {
         desktopPaddingClass
       )}
     >
-      <div className={cn('flex min-w-0 items-center gap-3 app-region-no-drag')}>
+      <div className={cn('flex min-w-0 items-center gap-3')}>
         <button
           onClick={toggleSidebar}
           className="app-region-no-drag h-9 w-9 rounded-md p-2 transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
@@ -132,8 +132,15 @@ export const Header: React.FC = () => {
           <Tooltip>
             <TooltipTrigger asChild>
               <div
-                className="app-region-no-drag flex h-8 w-8 cursor-help items-center justify-center rounded-lg transition-colors"
-                style={{ backgroundColor: 'rgb(from var(--primary) r g b / 0.1)', color: 'var(--primary)' }}
+                className="app-region-no-drag flex cursor-help items-center justify-center rounded-lg transition-colors"
+                style={{
+                  backgroundColor: 'rgb(from var(--primary) r g b / 0.1)',
+                  color: 'var(--primary)',
+                  width: '32px',
+                  height: '32px',
+                  minWidth: '32px',
+                  minHeight: '32px',
+                }}
               >
                 <OpenCodeIcon width={16} height={16} className="opacity-70" />
               </div>
@@ -155,7 +162,7 @@ export const Header: React.FC = () => {
         </div>
       </div>
 
-      <div className="flex items-center gap-2 app-region-no-drag">
+      <div className="flex items-center gap-2">
         {isSessionsSection && contextUsage && contextUsage.totalTokens > 0 && (
           <ContextUsageDisplay
             totalTokens={contextUsage.totalTokens}
@@ -198,7 +205,7 @@ export const Header: React.FC = () => {
   const renderMobile = () => (
     <div className="app-region-drag relative flex flex-col gap-1 px-3 py-2 select-none">
       <div className="flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2 app-region-no-drag">
+        <div className="flex min-w-0 items-center gap-2">
           <button
             onClick={toggleSidebar}
             className="app-region-no-drag h-9 w-9 rounded-md p-2 transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
@@ -209,8 +216,15 @@ export const Header: React.FC = () => {
           <Tooltip>
             <TooltipTrigger asChild>
               <div
-                className="app-region-no-drag flex h-8 w-8 cursor-help items-center justify-center rounded-lg transition-colors"
-                style={{ backgroundColor: 'rgb(from var(--primary) r g b / 0.1)', color: 'var(--primary)' }}
+                className="app-region-no-drag flex cursor-help items-center justify-center rounded-lg transition-colors"
+                style={{
+                  backgroundColor: 'rgb(from var(--primary) r g b / 0.1)',
+                  color: 'var(--primary)',
+                  width: '32px',
+                  height: '32px',
+                  minWidth: '32px',
+                  minHeight: '32px',
+                }}
               >
                 <OpenCodeIcon width={16} height={16} className="opacity-70" />
               </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,14 +7,17 @@ export const SIDEBAR_CONTENT_WIDTH = 264;
 interface SidebarProps {
     isOpen: boolean;
     isMobile: boolean;
+    width?: number;
     children: React.ReactNode;
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ isOpen, isMobile, children }) => {
+export const Sidebar: React.FC<SidebarProps> = ({ isOpen, isMobile, width = SIDEBAR_CONTENT_WIDTH, children }) => {
     if (isMobile) {
         // Mobile sidebar is handled in MainLayout as part of the overlay
         return null;
     }
+
+    const appliedWidth = isOpen ? Math.max(0, width) : 0;
 
     return (
         <aside
@@ -23,13 +26,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, isMobile, children }) 
                 !isOpen && 'border-r-0'
             )}
             style={{
-                width: isOpen ? `${SIDEBAR_CONTENT_WIDTH}px` : '0px',
-                minWidth: isOpen ? `${SIDEBAR_CONTENT_WIDTH}px` : '0px',
-                maxWidth: isOpen ? `${SIDEBAR_CONTENT_WIDTH}px` : '0px',
+                width: `${appliedWidth}px`,
+                minWidth: `${appliedWidth}px`,
+                maxWidth: `${appliedWidth}px`,
             }}
-            aria-hidden={!isOpen}
+            aria-hidden={!isOpen || appliedWidth === 0}
         >
-            <div className="h-full" style={{ width: `${SIDEBAR_CONTENT_WIDTH}px` }}>
+            <div className="h-full" style={{ width: `${appliedWidth}px` }}>
                 <ErrorBoundary>{children}</ErrorBoundary>
             </div>
         </aside>

--- a/src/components/sections/settings/AppearanceSettings.tsx
+++ b/src/components/sections/settings/AppearanceSettings.tsx
@@ -11,13 +11,10 @@ import {
     CODE_FONT_OPTION_MAP,
     UI_FONT_OPTIONS,
     UI_FONT_OPTION_MAP,
-    type MonoFontOption,
-    type UiFontOption,
 } from '@/lib/fontOptions';
 import {
     TYPOGRAPHY_SCALE_OPTIONS,
     detectTypographyScale,
-    type TypographyScale,
 } from '@/lib/typographyPresets';
 import { SEMANTIC_TYPOGRAPHY, type SemanticTypographyKey } from '@/lib/typography';
 import {
@@ -30,6 +27,9 @@ import {
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { MobileOverlayPanel } from '@/components/ui/MobileOverlayPanel';
+import { saveAppearancePreferences } from '@/lib/appearancePersistence';
+import { isDesktopRuntime } from '@/lib/desktop';
+import { toast } from 'sonner';
 
 interface Option<T extends string> {
     id: T;
@@ -66,6 +66,8 @@ export const AppearanceSettings: React.FC = () => {
     const { typographySizes, setTypographySizes, resetTypographySizes } = useTypographySizes();
     const isMobile = useUIStore(state => state.isMobile);
     const markdownConfig = React.useMemo(() => createUserMarkdown({ isMobile }), [isMobile]);
+    const [isSaving, setIsSaving] = React.useState(false);
+    const desktopRuntime = isDesktopRuntime();
 
     // Mobile panel states
     const [isUiFontPanelOpen, setIsUiFontPanelOpen] = React.useState(false);
@@ -77,6 +79,36 @@ export const AppearanceSettings: React.FC = () => {
         [typographySizes]
     );
     const [expandedTypography, setExpandedTypography] = React.useState(false);
+
+    const handleSavePreferences = React.useCallback(async () => {
+        if (!desktopRuntime) {
+            toast.info('Saving appearance settings is available in the desktop app.');
+            return;
+        }
+
+        setIsSaving(true);
+        const success = await saveAppearancePreferences({
+            uiFont,
+            monoFont,
+            markdownDisplayMode: mode,
+            typographySizes: {
+                markdown: typographySizes.markdown,
+                code: typographySizes.code,
+                uiHeader: typographySizes.uiHeader,
+                uiLabel: typographySizes.uiLabel,
+                meta: typographySizes.meta,
+                micro: typographySizes.micro,
+            },
+        });
+
+        if (success) {
+            toast.success('Appearance settings saved');
+        } else {
+            toast.error('Failed to save appearance settings');
+        }
+
+        setIsSaving(false);
+    }, [desktopRuntime, mode, monoFont, typographySizes, uiFont]);
 
     return (
         <div className="w-full space-y-8">
@@ -396,6 +428,33 @@ export const AppearanceSettings: React.FC = () => {
                 </div>
                 </div>
             )}
+
+            {/* Persist Settings */}
+            <div className="flex flex-col gap-2 rounded-lg border border-border/60 bg-background/70 p-4">
+                <div className="flex flex-col gap-1">
+                    <h3 className="typography-ui-header font-semibold text-foreground">
+                        Persist Appearance Settings
+                    </h3>
+                    <p className="typography-meta text-muted-foreground/80">
+                        Save the current font and typography preferences so they reload automatically in the desktop app.
+                    </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                        type="button"
+                        onClick={handleSavePreferences}
+                        disabled={isSaving || !desktopRuntime}
+                        className="min-w-[140px]"
+                    >
+                        {isSaving ? 'Saving…' : 'Save settings'}
+                    </Button>
+                    {!desktopRuntime && (
+                        <span className="typography-meta text-muted-foreground/70">
+                            Available only in the desktop application.
+                        </span>
+                    )}
+                </div>
+            </div>
 
             {/* Mobile Overlay Panels */}
             {isMobile && (

--- a/src/components/ui/ContextUsageDisplay.tsx
+++ b/src/components/ui/ContextUsageDisplay.tsx
@@ -37,7 +37,7 @@ export const ContextUsageDisplay: React.FC<ContextUsageDisplayProps> = ({
         size === 'compact' ? 'typography-micro' : 'typography-meta'
       )}
     >
-      <PieChart className={cn(size === 'compact' ? 'h-3.5 w-3.5' : 'h-4 w-4')} />
+      <PieChart className="h-4 w-4 flex-shrink-0" />
       <span className={getPercentageColor(percentage)}>
         {formatTokens(totalTokens)}/{formatTokens(contextLimit)} ({percentage.toFixed(1)}%)
       </span>

--- a/src/index.css
+++ b/src/index.css
@@ -698,7 +698,7 @@ body {
 }
 
 @media (max-width: 1024px) {
-  :root {
+  :root:not(.desktop-runtime) {
     --is-mobile: 1;
     --device-type: 'mobile';
     --font-scale: 0.9;
@@ -715,11 +715,15 @@ body {
 }
 
 @media (max-width: 1024px) {
-  .desktop-only {
+  :root:not(.desktop-runtime) .desktop-only {
     display: none !important;
   }
 
-  .mobile-only {
+  :root.desktop-runtime .mobile-only {
+    display: none !important;
+  }
+
+  :root:not(.desktop-runtime) .mobile-only {
     display: block !important;
   }
 }
@@ -727,7 +731,7 @@ body {
 /* General mobile improvements for all mobile devices */
 @media (max-width: 1024px) {
   /* Override CSS custom properties for mobile */
-  :root {
+  :root:not(.desktop-runtime) {
     --text-markdown: 1rem;
     --text-code: 0.875rem;
     --text-ui-header: 0.9375rem;
@@ -737,7 +741,7 @@ body {
   }
 
   /* Force override with higher specificity */
-  * {
+  :root:not(.desktop-runtime) * {
     --text-markdown: 1rem !important;
     --text-code: 0.875rem !important;
     --text-ui-header: 0.9375rem !important;
@@ -747,48 +751,58 @@ body {
   }
 
   /* Additional override for elements using typography classes */
-  .typography-markdown,
-  .typography-code,
-  .typography-ui-header,
-  .typography-ui-label,
-  .typography-meta,
-  .typography-micro {
+  :root:not(.desktop-runtime) .typography-markdown,
+  :root:not(.desktop-runtime) .typography-code,
+  :root:not(.desktop-runtime) .typography-ui-header,
+  :root:not(.desktop-runtime) .typography-ui-label,
+  :root:not(.desktop-runtime) .typography-meta,
+  :root:not(.desktop-runtime) .typography-micro {
     font-size: unset !important;
   }
 
   /* Fix font size for tool displays */
-  [class*="tool"], [class*="code"] {
+  :root:not(.desktop-runtime) [class*="tool"],
+  :root:not(.desktop-runtime) [class*="code"] {
     --text-code: 0.875rem !important;
     font-size: var(--text-code) !important;
   }
 
   /* Improve touch targets for mobile */
-  button, .btn, [role="button"] {
+  :root:not(.desktop-runtime) button,
+  :root:not(.desktop-runtime) .btn,
+  :root:not(.desktop-runtime) [role="button"] {
     min-height: 36px;
     min-width: 36px;
   }
 
   /* Improve input field touch targets */
-  input, textarea, select {
+  :root:not(.desktop-runtime) input,
+  :root:not(.desktop-runtime) textarea,
+  :root:not(.desktop-runtime) select {
     min-height: 36px;
   }
 
   /* Fix mobile text inputs */
-  input[type="text"], input[type="search"], input[type="email"], input[type="password"], textarea {
+  :root:not(.desktop-runtime) input[type="text"],
+  :root:not(.desktop-runtime) input[type="search"],
+  :root:not(.desktop-runtime) input[type="email"],
+  :root:not(.desktop-runtime) input[type="password"],
+  :root:not(.desktop-runtime) textarea {
     font-size: 16px !important; /* Prevents iOS zoom */
   }
 
   /* Prevent keyboard on non-input elements */
-  button:not([type="submit"]):not([type="button"]):not([type="reset"]),
-  .btn,
-  [role="button"] {
+  :root:not(.desktop-runtime)
+    button:not([type="submit"]):not([type="button"]):not([type="reset"]),
+  :root:not(.desktop-runtime) .btn,
+  :root:not(.desktop-runtime) [role="button"] {
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     user-select: none;
   }
 
   /* Specific fix for session buttons */
-  button[inputmode="none"] {
+  :root:not(.desktop-runtime) button[inputmode="none"] {
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     user-select: none;
@@ -796,82 +810,83 @@ body {
   }
 
   /* Improve mobile spacing */
-  .px-4 {
+  :root:not(.desktop-runtime) .px-4 {
     padding-left: 1rem !important;
     padding-right: 1rem !important;
   }
 
-  .py-2 {
+  :root:not(.desktop-runtime) .py-2 {
     padding-top: 0.75rem !important;
     padding-bottom: 0.75rem !important;
   }
 
   /* Fix mobile scroll containers */
-  .overflow-hidden {
+  :root:not(.desktop-runtime) .overflow-hidden {
     overflow-x: hidden !important;
     overflow-y: auto !important;
     -webkit-overflow-scrolling: touch;
   }
 
   /* Fix mobile viewport height */
-  html, body {
+  :root:not(.desktop-runtime),
+  :root:not(.desktop-runtime) body {
     height: 100%;
     height: -webkit-fill-available;
     overflow: hidden;
   }
 
   /* Fix main layout container */
-  .flex.flex-col.h-screen {
+  :root:not(.desktop-runtime) .flex.flex-col.h-screen {
     height: 100vh;
     height: -webkit-fill-available;
     min-height: 0;
   }
 
   /* Fix header positioning */
-  .header-safe-area {
+  :root:not(.desktop-runtime) .header-safe-area {
     position: sticky;
     top: 0;
     z-index: 50;
   }
 
   /* Fix main content area */
-  .flex-1.overflow-hidden {
+  :root:not(.desktop-runtime) .flex-1.overflow-hidden {
     min-height: 0;
     flex: 1;
   }
 
   /* Fix chat container */
-  .flex.flex-col.h-full {
+  :root:not(.desktop-runtime) .flex.flex-col.h-full {
     height: 100%;
     min-height: 0;
   }
 
   /* Ensure proper flex behavior */
-  .flex.flex-col {
+  :root:not(.desktop-runtime) .flex.flex-col {
     min-height: 0;
   }
 
   /* Mobile sidebar positioning */
-  .mobile-sidebar-top {
+  :root:not(.desktop-runtime) .mobile-sidebar-top {
     top: var(--header-height, 3rem);
     height: calc(100vh - var(--header-height, 3rem));
   }
 
   /* Set header height variable */
-  .header-safe-area {
+  :root:not(.desktop-runtime) .header-safe-area {
     --header-height: 3rem;
   }
 
   /* For mobile devices with larger header */
   @media (max-width: 768px) {
-    .header-safe-area {
+    :root:not(.desktop-runtime) .header-safe-area {
       --header-height: 3.5rem;
     }
   }
 
   /* For tablet devices */
   @media (min-width: 769px) and (max-width: 1024px) {
-    .header-safe-area {
+    :root:not(.desktop-runtime) .header-safe-area {
       --header-height: 3.25rem;
     }
   }

--- a/src/lib/appearancePersistence.ts
+++ b/src/lib/appearancePersistence.ts
@@ -1,0 +1,134 @@
+import { isDesktopRuntime } from '@/lib/desktop';
+import { useUIStore, type TypographySizes } from '@/stores/useUIStore';
+import type { MarkdownDisplayMode } from '@/lib/markdownDisplayModes';
+
+export interface AppearancePreferences {
+  uiFont?: string;
+  monoFont?: string;
+  markdownDisplayMode?: MarkdownDisplayMode;
+  typographySizes?: TypographySizes;
+}
+
+type RawAppearancePayload = {
+  uiFont?: unknown;
+  monoFont?: unknown;
+  markdownDisplayMode?: unknown;
+  typographySizes?: Record<string, unknown> | null;
+};
+
+const sanitizeTypographySizes = (input?: Record<string, unknown> | null): TypographySizes | undefined => {
+  if (!input || typeof input !== 'object') {
+    return undefined;
+  }
+
+  const defaults = useUIStore.getState().typographySizes;
+  const sizes: TypographySizes = {
+    markdown: typeof input.markdown === 'string' ? input.markdown : defaults.markdown,
+    code: typeof input.code === 'string' ? input.code : defaults.code,
+    uiHeader: typeof input.uiHeader === 'string' ? input.uiHeader : defaults.uiHeader,
+    uiLabel: typeof input.uiLabel === 'string' ? input.uiLabel : defaults.uiLabel,
+    meta: typeof input.meta === 'string' ? input.meta : defaults.meta,
+    micro: typeof input.micro === 'string' ? input.micro : defaults.micro,
+  };
+
+  return sizes;
+};
+
+const sanitizePreferences = (payload?: RawAppearancePayload | null): AppearancePreferences | null => {
+  if (!payload) {
+    return null;
+  }
+
+  const result: AppearancePreferences = {};
+
+  if (typeof payload.uiFont === 'string' && payload.uiFont.length > 0) {
+    result.uiFont = payload.uiFont;
+  }
+
+  if (typeof payload.monoFont === 'string' && payload.monoFont.length > 0) {
+    result.monoFont = payload.monoFont;
+  }
+
+  if (typeof payload.markdownDisplayMode === 'string') {
+    result.markdownDisplayMode = payload.markdownDisplayMode as MarkdownDisplayMode;
+  }
+
+  const typography = sanitizeTypographySizes(payload.typographySizes ?? undefined);
+  if (typography) {
+    result.typographySizes = typography;
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+};
+
+export const applyAppearancePreferences = (preferences: AppearancePreferences): void => {
+  const store = useUIStore.getState();
+
+  if (preferences.uiFont) {
+    store.setUiFont(preferences.uiFont as any);
+  }
+
+  if (preferences.monoFont) {
+    store.setMonoFont(preferences.monoFont as any);
+  }
+
+  if (preferences.markdownDisplayMode) {
+    store.setMarkdownDisplayMode(preferences.markdownDisplayMode);
+  }
+
+  if (preferences.typographySizes) {
+    store.setTypographySizes({
+      ...store.typographySizes,
+      ...preferences.typographySizes,
+    });
+  }
+};
+
+export const loadAppearancePreferences = async (): Promise<AppearancePreferences | null> => {
+  if (typeof window === 'undefined' || !isDesktopRuntime()) {
+    return null;
+  }
+
+  const api = window.opencodeAppearance;
+  if (!api || typeof api.load !== 'function') {
+    return null;
+  }
+
+  try {
+    const raw = await api.load();
+    return sanitizePreferences(raw as RawAppearancePayload | null);
+  } catch (error) {
+    console.warn('Failed to load appearance preferences from desktop storage:', error);
+    return null;
+  }
+};
+
+export const saveAppearancePreferences = async (preferences: AppearancePreferences): Promise<boolean> => {
+  if (typeof window === 'undefined' || !isDesktopRuntime()) {
+    return false;
+  }
+
+  const api = window.opencodeAppearance;
+  if (!api || typeof api.save !== 'function') {
+    return false;
+  }
+
+  const payload: AppearancePreferences = {
+    uiFont: preferences.uiFont,
+    monoFont: preferences.monoFont,
+    markdownDisplayMode: preferences.markdownDisplayMode,
+    typographySizes: preferences.typographySizes ? { ...preferences.typographySizes } : undefined,
+  };
+
+  try {
+    const result = await api.save(payload);
+    if (result?.success) {
+      applyAppearancePreferences(preferences);
+      return true;
+    }
+  } catch (error) {
+    console.warn('Failed to save appearance preferences to desktop storage:', error);
+  }
+
+  return false;
+};

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -1,3 +1,7 @@
+import type { MarkdownDisplayMode } from "@/lib/markdownDisplayModes";
+import type { MonoFontOption, UiFontOption } from "@/lib/fontOptions";
+import type { TypographySizes } from "@/stores/useUIStore";
+
 export type DesktopServerInfo = {
   webPort: number | null;
   openCodePort: number | null;
@@ -12,6 +16,10 @@ export type DesktopSettings = {
   lastDirectory?: string;
   homeDirectory?: string;
   approvedDirectories?: string[];
+  uiFont?: UiFontOption;
+  monoFont?: MonoFontOption;
+  markdownDisplayMode?: MarkdownDisplayMode;
+  typographySizes?: TypographySizes;
 };
 
 export type DesktopSettingsApi = {

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -1,6 +1,8 @@
-
-import { getDesktopSettings, updateDesktopSettings as updateDesktopSettingsApi } from '@/lib/desktop';
+import { getDesktopSettings, updateDesktopSettings as updateDesktopSettingsApi, isDesktopRuntime } from '@/lib/desktop';
 import type { DesktopSettings } from '@/lib/desktop';
+import { useUIStore } from '@/stores/useUIStore';
+import type { TypographySizes } from '@/stores/useUIStore';
+import { loadAppearancePreferences, applyAppearancePreferences } from '@/lib/appearancePersistence';
 
 const persistToLocalStorage = (settings: DesktopSettings) => {
   if (typeof window === 'undefined') {
@@ -25,23 +27,104 @@ const persistToLocalStorage = (settings: DesktopSettings) => {
   }
 };
 
+type PersistApi = {
+  hasHydrated?: () => boolean;
+  onFinishHydration?: (callback: () => void) => (() => void) | void;
+};
+
+const getPersistApi = (): PersistApi | undefined => {
+  const candidate = (useUIStore as unknown as { persist?: PersistApi }).persist;
+  if (candidate && typeof candidate === 'object') {
+    return candidate;
+  }
+  return undefined;
+};
+
+const typographyKeys: Array<keyof TypographySizes> = ['markdown', 'code', 'uiHeader', 'uiLabel', 'meta', 'micro'];
+
+const typographySizesEqual = (a: TypographySizes, b: TypographySizes): boolean =>
+  typographyKeys.every((key) => a[key] === b[key]);
+
+const applyDesktopUiPreferences = (settings: DesktopSettings) => {
+  const store = useUIStore.getState();
+  let updated = false;
+
+  if (settings.uiFont && settings.uiFont !== store.uiFont) {
+    store.setUiFont(settings.uiFont);
+    updated = true;
+  }
+
+  if (settings.monoFont && settings.monoFont !== store.monoFont) {
+    store.setMonoFont(settings.monoFont);
+    updated = true;
+  }
+
+  if (settings.markdownDisplayMode && settings.markdownDisplayMode !== store.markdownDisplayMode) {
+    store.setMarkdownDisplayMode(settings.markdownDisplayMode);
+    updated = true;
+  }
+
+  if (settings.typographySizes && !typographySizesEqual(settings.typographySizes, store.typographySizes)) {
+    store.setTypographySizes(settings.typographySizes);
+    updated = true;
+  }
+};
+
 export const syncDesktopSettings = async (): Promise<void> => {
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || !isDesktopRuntime()) {
     return;
   }
+
+  const persistApi = getPersistApi();
 
   try {
     const settings = await getDesktopSettings();
     if (settings) {
       persistToLocalStorage(settings);
+      const apply = () => applyDesktopUiPreferences(settings);
+
+      if (persistApi?.hasHydrated?.()) {
+        apply();
+      } else {
+        apply();
+        if (persistApi?.onFinishHydration) {
+          const unsubscribe = persistApi.onFinishHydration(() => {
+            unsubscribe?.();
+            apply();
+          });
+        }
+      }
     }
   } catch (error) {
     console.warn('Failed to synchronise desktop settings:', error);
   }
+
+  if (isDesktopRuntime()) {
+    try {
+      const appearance = await loadAppearancePreferences();
+      if (appearance) {
+        const applyAppearance = () => applyAppearancePreferences(appearance);
+
+        if (persistApi?.hasHydrated?.()) {
+          applyAppearance();
+        } else {
+          applyAppearance();
+          if (persistApi?.onFinishHydration) {
+            const unsubscribe = persistApi.onFinishHydration(() => {
+              unsubscribe?.();
+              applyAppearance();
+            });
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to load appearance preferences:', error);
+    }
+  }
 };
 
 export const updateDesktopSettings = async (changes: Partial<DesktopSettings>): Promise<void> => {
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || !isDesktopRuntime()) {
     return;
   }
 
@@ -49,6 +132,7 @@ export const updateDesktopSettings = async (changes: Partial<DesktopSettings>): 
     const updated = await updateDesktopSettingsApi(changes);
     if (updated) {
       persistToLocalStorage(updated);
+      applyDesktopUiPreferences(updated);
     }
   } catch (error) {
     console.warn('Failed to update desktop settings:', error);

--- a/src/types/desktop.d.ts
+++ b/src/types/desktop.d.ts
@@ -1,9 +1,29 @@
 import type { DesktopApi, DesktopSettingsApi } from "@/lib/desktop";
 
+type AppearanceBridgePayload = {
+  uiFont?: string;
+  monoFont?: string;
+  markdownDisplayMode?: string;
+  typographySizes?: {
+    markdown?: string;
+    code?: string;
+    uiHeader?: string;
+    uiLabel?: string;
+    meta?: string;
+    micro?: string;
+  } | null;
+};
+
+type AppearanceBridgeApi = {
+  load: () => Promise<AppearanceBridgePayload | null>;
+  save: (payload: AppearanceBridgePayload) => Promise<{ success: boolean; data?: AppearanceBridgePayload | null; error?: string }>;
+};
+
 declare global {
   interface Window {
     opencodeDesktop?: DesktopApi;
     opencodeDesktopSettings?: DesktopSettingsApi;
+    opencodeAppearance?: AppearanceBridgeApi;
     __OPENCHAMBER_HOME__?: string;
   }
 }


### PR DESCRIPTION
## Summary
- add dedicated appearance persistence bridge for desktop runtime
- load previously saved fonts/typography when app starts
- expose "Save settings" button in Settings → Appearance to write preferences to disk

## Testing
- npm run build:electron:main
- npm run build:package