### PR TITLE
Add Cascadia Code font and update defaults to Inter/Cascadia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@fontsource/cascadia-code": "^5.2.3",
         "@fontsource/fira-code": "^5.1.1",
         "@fontsource/ibm-plex-sans": "^5.1.1",
         "@fontsource/inter": "^5.1.1",
@@ -1274,6 +1275,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/cascadia-code": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@fontsource/cascadia-code/-/cascadia-code-5.2.3.tgz",
+      "integrity": "sha512-jnKfdZ+0UL25XUqYV7iq9gDlaUMWXxZNA7KnYzO4v8De6jBJmTkLHxDXs+1iZwl/8w7eKlDrTJWcyalOHdE2eg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@fontsource/fira-code": {
       "version": "5.2.7",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "convert-theme": "tsx scripts/convert-theme.ts"
   },
   "dependencies": {
+    "@fontsource/cascadia-code": "^5.2.3",
     "@fontsource/fira-code": "^5.1.1",
     "@fontsource/ibm-plex-sans": "^5.1.1",
     "@fontsource/inter": "^5.1.1",

--- a/src/lib/fontOptions.ts
+++ b/src/lib/fontOptions.ts
@@ -6,6 +6,7 @@ export type UiFontOption =
     | 'jetbrains-mono'
     | 'fira-code'
     | 'source-code-pro'
+    | 'cascadia-code'
     | 'paper-mono';
 
 export type MonoFontOption =
@@ -13,6 +14,7 @@ export type MonoFontOption =
     | 'jetbrains-mono'
     | 'fira-code'
     | 'source-code-pro'
+    | 'cascadia-code'
     | 'paper-mono'
     | 'ibm-plex-sans'
     | 'inter'
@@ -71,6 +73,12 @@ export const UI_FONT_OPTIONS: FontOptionDefinition<UiFontOption>[] = [
         stack: '"Source Code Pro", "Fira Code", "JetBrains Mono", "IBM Plex Mono", "SFMono-Regular", monospace'
     },
     {
+        id: 'cascadia-code',
+        label: 'Cascadia Code',
+        description: 'Microsoft monospace font with programming ligatures and rounded aesthetics.',
+        stack: '"Cascadia Code", "JetBrains Mono", "Fira Code", "IBM Plex Mono", "SFMono-Regular", monospace'
+    },
+    {
         id: 'paper-mono',
         label: 'Paper Mono',
         description: 'Beautiful modern monospace with distinctive character from Paper Design.',
@@ -106,6 +114,12 @@ export const CODE_FONT_OPTIONS: FontOptionDefinition<MonoFontOption>[] = [
         stack: '"Source Code Pro", "Fira Code", "JetBrains Mono", "IBM Plex Mono", "SFMono-Regular", monospace'
     },
     {
+        id: 'cascadia-code',
+        label: 'Cascadia Code',
+        description: 'Microsoft monospace with programming ligatures and rounded aesthetics.',
+        stack: '"Cascadia Code", "JetBrains Mono", "Fira Code", "IBM Plex Mono", "SFMono-Regular", monospace'
+    },
+    {
         id: 'paper-mono',
         label: 'Paper Mono',
         description: 'Beautiful modern monospace with distinctive character and excellent readability.',
@@ -138,5 +152,5 @@ const buildFontMap = <T extends string>(options: FontOptionDefinition<T>[]) =>
 export const UI_FONT_OPTION_MAP = buildFontMap(UI_FONT_OPTIONS);
 export const CODE_FONT_OPTION_MAP = buildFontMap(CODE_FONT_OPTIONS);
 
-export const DEFAULT_UI_FONT: UiFontOption = 'ibm-plex-mono';
-export const DEFAULT_MONO_FONT: MonoFontOption = 'ibm-plex-mono';
+export const DEFAULT_UI_FONT: UiFontOption = 'inter';
+export const DEFAULT_MONO_FONT: MonoFontOption = 'cascadia-code';

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -24,5 +24,10 @@ import '@fontsource/source-code-pro/latin-400.css';
 import '@fontsource/source-code-pro/latin-500.css';
 import '@fontsource/source-code-pro/latin-600.css';
 
+import '@fontsource/cascadia-code/latin-400.css';
+import '@fontsource/cascadia-code/latin-500.css';
+import '@fontsource/cascadia-code/latin-600.css';
+import '@fontsource/cascadia-code/latin-700.css';
+
 // Paper Mono - beautiful monospace font from Paper Design
 import '../assets/fonts/paper-mono.css';


### PR DESCRIPTION
## Summary
- Added Cascadia Code as font option for both UI and Code selectors
- Changed default UI font from IBM Plex Mono to Inter
- Changed default Code font from IBM Plex Mono to Cascadia Code

## Changes
- Installed `@fontsource/cascadia-code` package
- Added Cascadia Code imports to `src/styles/fonts.ts`
- Added Cascadia Code definitions to `src/lib/fontOptions.ts`
- Updated default font constants

## Test plan
- [ ] Verify Cascadia Code appears in UI font selector
- [ ] Verify Cascadia Code appears in Code font selector
- [ ] Verify new installations default to Inter for UI
- [ ] Verify new installations default to Cascadia Code for code
- [ ] Verify existing users' font preferences are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)