### PR TITLE
fix(terminal): stability improvements with auto-reconnect

### DIFF
--- a/src/lib/terminalApi.ts
+++ b/src/lib/terminalApi.ts
@@ -10,16 +10,25 @@ export interface TerminalSession {
 }
 
 export interface TerminalStreamEvent {
-  type: 'connected' | 'data' | 'exit';
+  type: 'connected' | 'data' | 'exit' | 'reconnecting';
   data?: string;
   exitCode?: number;
   signal?: number | null;
+  attempt?: number;
+  maxAttempts?: number;
 }
 
 export interface CreateTerminalOptions {
   cwd: string;
   cols?: number;
   rows?: number;
+}
+
+export interface ConnectStreamOptions {
+  maxRetries?: number;
+  initialRetryDelay?: number;
+  maxRetryDelay?: number;
+  connectionTimeout?: number;
 }
 
 /**
@@ -47,45 +56,154 @@ export async function createTerminalSession(
 }
 
 /**
- * Connect to terminal output stream via Server-Sent Events
+ * Connect to terminal output stream via Server-Sent Events with automatic reconnection
  */
 export function connectTerminalStream(
   sessionId: string,
   onEvent: (event: TerminalStreamEvent) => void,
-  onError?: (error: Error) => void
+  onError?: (error: Error, fatal?: boolean) => void,
+  options: ConnectStreamOptions = {}
 ): () => void {
-  const eventSource = new EventSource(`/api/terminal/${sessionId}/stream`);
-  let hasDispatchedOpen = false;
+  const {
+    maxRetries = 3,
+    initialRetryDelay = 1000,
+    maxRetryDelay = 8000,
+    connectionTimeout = 10000,
+  } = options;
 
-  eventSource.onopen = () => {
-    if (hasDispatchedOpen) {
+  let eventSource: EventSource | null = null;
+  let retryCount = 0;
+  let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+  let connectionTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let isClosed = false;
+  let hasDispatchedOpen = false;
+  let terminalExited = false;
+
+  const clearTimeouts = () => {
+    if (retryTimeout) {
+      clearTimeout(retryTimeout);
+      retryTimeout = null;
+    }
+    if (connectionTimeoutId) {
+      clearTimeout(connectionTimeoutId);
+      connectionTimeoutId = null;
+    }
+  };
+
+  const cleanup = () => {
+    isClosed = true;
+    clearTimeouts();
+    if (eventSource) {
+      eventSource.close();
+      eventSource = null;
+    }
+  };
+
+  const connect = () => {
+    if (isClosed || terminalExited) {
       return;
     }
-    hasDispatchedOpen = true;
-    // Emit synthetic connected event to unblock UI immediately
-    onEvent({ type: 'connected' });
+
+    // Check if EventSource already exists and is connecting/open
+    if (eventSource && eventSource.readyState !== EventSource.CLOSED) {
+      console.warn('Attempted to create duplicate EventSource, skipping');
+      return;
+    }
+
+    hasDispatchedOpen = false;
+    eventSource = new EventSource(`/api/terminal/${sessionId}/stream`);
+
+    // Connection timeout detection
+    connectionTimeoutId = setTimeout(() => {
+      if (!hasDispatchedOpen && eventSource?.readyState !== EventSource.OPEN) {
+        console.error('Terminal connection timeout');
+        eventSource?.close();
+        handleError(new Error('Connection timeout'), false);
+      }
+    }, connectionTimeout);
+
+    eventSource.onopen = () => {
+      if (hasDispatchedOpen) {
+        return;
+      }
+      hasDispatchedOpen = true;
+      retryCount = 0; // Reset retry count on successful connection
+      clearTimeouts();
+
+      // Emit synthetic connected event to unblock UI immediately
+      onEvent({ type: 'connected' });
+    };
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as TerminalStreamEvent;
+
+        // Handle terminal exit - don't reconnect
+        if (data.type === 'exit') {
+          terminalExited = true;
+          cleanup();
+        }
+
+        onEvent(data);
+      } catch (error) {
+        console.error('Failed to parse terminal event:', error);
+        onError?.(error as Error, false);
+      }
+    };
+
+    eventSource.onerror = (error) => {
+      console.error('Terminal stream error:', error, 'readyState:', eventSource?.readyState);
+      clearTimeouts();
+
+      // Differentiate between network errors and terminal death
+      const isFatalError = terminalExited || eventSource?.readyState === EventSource.CLOSED;
+
+      eventSource?.close();
+      eventSource = null;
+
+      if (!terminalExited) {
+        handleError(new Error('Terminal stream connection error'), isFatalError);
+      }
+    };
   };
 
-  eventSource.onmessage = (event) => {
-    try {
-      const data = JSON.parse(event.data) as TerminalStreamEvent;
-      onEvent(data);
-    } catch (error) {
-      console.error('Failed to parse terminal event:', error);
-      onError?.(error as Error);
+  const handleError = (error: Error, isFatal: boolean) => {
+    if (isClosed || terminalExited) {
+      return;
+    }
+
+    // Exponential backoff reconnection
+    if (retryCount < maxRetries && !isFatal) {
+      retryCount++;
+      const delay = Math.min(initialRetryDelay * Math.pow(2, retryCount - 1), maxRetryDelay);
+
+      console.log(`Reconnecting to terminal stream (attempt ${retryCount}/${maxRetries}) in ${delay}ms`);
+
+      // Notify UI about reconnection attempt
+      onEvent({
+        type: 'reconnecting',
+        attempt: retryCount,
+        maxAttempts: maxRetries,
+      });
+
+      retryTimeout = setTimeout(() => {
+        if (!isClosed && !terminalExited) {
+          connect();
+        }
+      }, delay);
+    } else {
+      // Max retries reached or fatal error
+      console.error(`Terminal connection failed after ${retryCount} attempts`);
+      onError?.(error, true);
+      cleanup();
     }
   };
 
-  eventSource.onerror = (error) => {
-    console.error('Terminal stream error:', error);
-    onError?.(new Error('Terminal stream connection error'));
-    eventSource.close();
-  };
+  // Initial connection
+  connect();
 
   // Return cleanup function
-  return () => {
-    eventSource.close();
-  };
+  return cleanup;
 }
 
 /**


### PR DESCRIPTION
Server-side fixes:
- Add SSE heartbeat (15s) to prevent idle timeouts
- Fix memory leak by disposing PTY event listeners on disconnect
- Improve error handling with cleanup on data errors

Client-side fixes:
- Implement exponential backoff reconnection (max 3 retries: 1s→2s→4s)
- Add EventSource state management to prevent duplicate connections
- Add connection timeout detection (10s)
- Differentiate network errors (retryable) from terminal exit (fatal)
- Add 'reconnecting' event type with progress indicator

UI improvements:
- Show reconnection progress in status badge
- Fix React hooks ordering to prevent error boundary on directory changes
- Remove unstable dependency from effect