### PR TITLE
feat(terminal): add mobile quick keys and modifier handling

### DIFF
--- a/src/components/right-sidebar/TerminalTab.tsx
+++ b/src/components/right-sidebar/TerminalTab.tsx
@@ -765,6 +765,7 @@ export const TerminalTab: React.FC = () => {
                             theme={xtermTheme}
                             fontFamily={resolvedFontStack}
                             fontSize={TERMINAL_FONT_SIZE}
+                            enableTouchScroll={isMobile}
                         />
                     ) : null}
                 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a mobile quick-keys bar with Ctrl/Cmd modifiers, modifier-aware input handling, and touch scrolling support in the terminal viewport.
> 
> - **Terminal (UI/Behavior)**:
>   - **Mobile quick keys**: Adds quick-keys bar in `right-sidebar/TerminalTab.tsx` with `Esc`, `Tab`, arrow keys, and `Enter`.
>   - **Modifiers**: Introduces togglable `Ctrl`/`Cmd` modifiers; generates correct control codes and modified arrow sequences; resets modifier when appropriate.
>   - **Input handling**: Updates `onInput` to apply modifiers; adds mobile `keydown` processing; integrates `useDeviceInfo`.
>   - **Toolbar tweaks**: Minor layout and explicit `type="button"` on actions.
> - **TerminalViewport**:
>   - **Touch scrolling**: New `enableTouchScroll` prop and touch handlers to scroll via swipe; estimates line height using xterm core when available; proper setup/cleanup.
>   - Preserves fit/write behavior; wires resize and focus as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 142495eab7fbf48c21a5b33ec6e3dc93a0ed2e09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->