### PR TITLE
Temporarily disable empty response detection

### DIFF
--- a/src/hooks/useEventStream.ts
+++ b/src/hooks/useEventStream.ts
@@ -18,6 +18,8 @@ declare global {
   }
 }
 
+const ENABLE_EMPTY_RESPONSE_DETECTION = false; // TODO: Re-enable once false positive investigation completes
+
 export const useEventStream = () => {
   const {
     addStreamingPart,
@@ -310,7 +312,7 @@ export const useEventStream = () => {
                   // Detect empty response patterns only when we have no meaningful content
                   const isEmptyResponse = !hasMeaningfulContent && !hasStepMarkers;
 
-                  if (isEmptyResponse) {
+                  if (ENABLE_EMPTY_RESPONSE_DETECTION && isEmptyResponse) {
                     // Show toast only once per message
                     if (!emptyResponseToastShownRef.current.has(message.id as string)) {
                       emptyResponseToastShownRef.current.add(message.id as string);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Guards empty-response toast behind a feature flag set to false, effectively disabling it pending false-positive investigation.
> 
> - **Hooks**:
>   - In `src/hooks/useEventStream.ts`, introduce `ENABLE_EMPTY_RESPONSE_DETECTION = false` and gate empty-response detection/toast behind it, disabling the toast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5233577abcb8516314d0442c81ac50ad817643e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->