### PR TITLE
Add session date group bulk deletion controls

### DIFF
--- a/src/stores/types/sessionTypes.ts
+++ b/src/stores/types/sessionTypes.ts
@@ -93,6 +93,7 @@ export interface SessionStore {
     createSession: (title?: string) => Promise<Session | null>;
 
     deleteSession: (id: string) => Promise<boolean>;
+    deleteSessions: (ids: string[]) => Promise<{ deletedIds: string[]; failedIds: string[] }>;
     updateSessionTitle: (id: string, title: string) => Promise<void>;
     shareSession: (id: string) => Promise<Session | null>;
     unshareSession: (id: string) => Promise<Session | null>;

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -74,6 +74,7 @@ export const useSessionStore = create<SessionStore>()(
                     return result;
                 },
                 deleteSession: (id: string) => useSessionManagementStore.getState().deleteSession(id),
+                deleteSessions: (ids: string[]) => useSessionManagementStore.getState().deleteSessions(ids),
                 updateSessionTitle: (id: string, title: string) => useSessionManagementStore.getState().updateSessionTitle(id, title),
                 shareSession: (id: string) => useSessionManagementStore.getState().shareSession(id),
                 unshareSession: (id: string) => useSessionManagementStore.getState().unshareSession(id),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds bulk deletion of sessions by date group via new store action `deleteSessions` and a group-level delete control in `SessionList`.
> 
> - **UI (`src/components/session/SessionList.tsx`)**
>   - Add date group header actions with a trash button to delete all sessions in a date group (`handleDeleteSessionGroup`).
>   - Show contextual toasts for partial/complete failures; disable button while `isLoading`.
>   - Responsive visibility: always show group delete and session actions on mobile/tablet/touch; hover-reveal on desktop.
>   - Minor structural/class tweaks: wrap groups in `section`/`header`, use `group/session` identifiers, adjust actions menu visibility.
> - **Store**
>   - `src/stores/sessionStore.ts`: implement `deleteSessions(ids)` to batch delete, update `sessions` and `currentSessionId`, persist selection, and set concise error messages.
>   - `src/stores/types/sessionTypes.ts`: add `deleteSessions` to `SessionStore` interface.
>   - `src/stores/useSessionStore.ts`: expose `deleteSessions` by delegating to session management store.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09bcf908b5363a21f3e57e4178fa7f36f71d05c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->