### PR TITLE
Implement worktree session management UI and remote cleanup

### DIFF
--- a/docs/plans/worktree-session-plan.md
+++ b/docs/plans/worktree-session-plan.md
@@ -1,0 +1,105 @@
+# Worktree-Aware Session Workflow – Implementation Plan
+
+## 1. Goals & Scope
+- Allow users to create or reuse Git worktrees (`project_dir/.openchamber/<name>`) when starting a new session.
+- Surface worktree context across the UI (session list badge, metadata).
+- Provide voluntary cleanup: archive worktree on demand or during session deletion.
+- Respect recent bulk deletion changes (`SessionStore.deleteSessions`, date-group UI).
+
+## 2. High-Level Architecture
+1. **Metadata plumbing**
+   - Extend session store state with a `worktreeMetadata` map keyed by `sessionId` (branch, path, status flags).
+   - Persist metadata in session storage (`persist(...)` partial) and hydrate from backend response once API supports it; until then store only client-side.
+   - Update composed store (`useSessionStore`) selectors to expose `getWorktreeMetadata(sessionId)` and `setWorktreeMetadata`.
+
+2. **Worktree management service**
+   - Create `src/lib/git/worktreeService.ts` to wrap `gitApi` helpers (`createCommit`, etc.) with new endpoints:
+     - `createWorktree({ branch, path, baseRef })`
+     - `removeWorktree({ branch, path, force })`
+     - `listWorktrees()` and `getStatus(path)` (optional caching).
+   - Reuse `opencodeClient` additions for filesystem operations (mkdir, list).
+
+3. **Session creation flow**
+   - Update create-session dialog to include a “Worktree mode” section:
+     - Radio buttons: `No worktree` (default), `Create new`, `Reuse existing`.
+     - Fields:
+       - New worktree: branch name (validated), base ref dropdown (default `HEAD`), path preview.
+       - Reuse: dropdown of `.openchamber/*` directories with resolved branch names.
+     - Hook `onSubmit` to orchestrate:
+       1. Create/reuse semantics (`worktreeService.createWorktree` or `setDirectory` to existing).
+       2. Store metadata locally (`setWorktreeMetadata`).
+       3. Call `createSession`.
+   - Disable controls during `isLoading`.
+
+4. **Session list UI enhancements**
+   - Augment session rows with badge showing branch name when metadata exists; tooltip reveals full path.
+   - Ensure date-group bulk delete button accounts for metadata (see §5).
+
+5. **Deletion & archiving**
+   - Introduce shared confirmation modal (`SessionDeleteDialog`) used for both single session and date-group deletes.
+     - Shows list/count of targeted sessions.
+     - Includes `Archive attached worktrees` checkbox when any selected session has metadata.
+     - Inline warning (yellow) if any worktree is dirty (computed via pre-fetch of git status).
+   - Modify `deleteSession` and `deleteSessions` actions:
+     - Accept options `{ archiveWorktree?: boolean }`.
+     - When true, perform `removeWorktree` before calling `opencodeClient.deleteSession`.
+     - Handle failures gracefully (collect `failedIds`, toast error).
+   - Ensure `setDirectory` is reset to project root when an archived session was active.
+
+6. **Reassignment / detaching**
+   - Add “Detach worktree” option to session dropdown:
+     - Removes metadata and resets directory to root.
+     - Optionally leaves worktree on disk (no git action).
+   - Consider future support for reattaching via edit flow (not required now).
+
+## 3. Detailed Task Breakdown
+- **State & Types**
+  1. Add `WorktreeMetadata` interface in `src/types/worktree.ts`.
+  2. Update `SessionStore` types (including `SessionStore` interface and persisted slice) with metadata maps and new methods.
+  3. Extend `sessionStore` implementation (load/save, trimming metadata on delete).
+
+- **Services & API**
+  4. Implement `worktreeService` with functions calling `/api/git/*` endpoints (`git worktree add/remove`, `git status`).
+  5. Extend `server/lib/gitApi.ts` & Express routes to expose required operations (if not already present).
+  6. Wire new service into `opencodeClient` as needed for path resolution.
+
+- **Create Session UI**
+  7. Refactor `SessionList` dialog content into subcomponent `CreateSessionDialog` to keep file manageable.
+  8. Add form state (radio selection, branch input, reuse dropdown).
+  9. Validate branch names (no whitespace, unique, not existing as branch unless reuse).
+  10. Handle async workflow inside `handleCreateSession`: orchestrate worktree creation & session creation; on failure, rollback (`removeWorktree`).
+
+- **Session List Enhancements**
+  11. Render badge + tooltip on rows; ensure compatibility with new `shouldAlwaysShowSessionActions`.
+  12. Add `Detach worktree` to dropdown; implement handler to update metadata.
+
+- **Deletion Flow**
+  13. Introduce `useSessionDeletion` hook managing confirmation dialog state and orchestrating archive calls.
+  14. Update single-session delete & bulk delete buttons to use shared dialog.
+  15. Expand store delete methods with options & metadata cleanup.
+  16. Surface toast messaging summarizing deleted/archived counts.
+
+- **Git Status Warnings**
+  17. Extend `worktreeService.getStatus` to inspect uncommitted changes.
+  18. Pass warning flags into dialog for inline messaging (no extra prompt).
+
+- **Testing & Validation**
+  19. Manual flows: create + new worktree, reuse existing, skip worktree, detach, archive on delete, bulk delete with mix of sessions.
+  20. Run `npm run lint` and `npx tsc --noEmit`.
+
+## 4. Open Questions / Follow-ups
+- Backend support for storing worktree metadata per session? Currently client-held; future API changes may simplify.
+- Need for automatic cleanup of orphaned `.openchamber` directories when metadata missing (out-of-scope now).
+- Should we expose base branch selection beyond `HEAD`? For now keep simple; could add advanced dropdown later.
+
+## 5. Rollout Considerations
+- Feature flags: wrap UI in optional flag (e.g., `enableWorktreeSessions`) for safe rollout.
+- Migration handling: ensure existing sessions start with empty metadata; no breaking changes expected.
+- Documentation: Update `docs/` usage guide once implementation stabilized.
+
+## 6. Implementation Summary (2025-11-05)
+- Delivered full client-side worktree metadata plumbing with persistent mapping, directory overrides, and smart session selection tied to per-session directories.
+- Added worktree creation/reuse UX inside session creation, including sanitized branch/slug handling, automatic upstream setup attempts, and `.openchamber` ignore management.
+- Enhanced right-sidebar Git/Diff/Terminal tabs plus message/permission stores so all requests honor the active session directory (worktree or project root) without forcing global OpenCode restarts.
+- Implemented robust deletion flow with archive + optional remote-branch removal, remote branch API support, and resilient toast/status feedback for single and bulk operations.
+- Refined UI polish: worktree badge/tooltip, mobile overlays for create/delete dialogs, accessible button styling, path wrapping, and removed detach workflow in favor of explicit archive/delete.

--- a/server/index.js
+++ b/server/index.js
@@ -2628,6 +2628,50 @@ const loadRepositoryDiff = async (directory) => {
     }
   });
 
+  // DELETE /api/git/branches - Remove branch
+  app.delete('/api/git/branches', async (req, res) => {
+    const { deleteBranch } = await getGitLibraries();
+    try {
+      const directory = req.query.directory;
+      if (!directory) {
+        return res.status(400).json({ error: 'directory parameter is required' });
+      }
+
+      const { branch, force } = req.body;
+      if (!branch) {
+        return res.status(400).json({ error: 'branch is required' });
+      }
+
+      const result = await deleteBranch(directory, branch, { force });
+      res.json(result);
+    } catch (error) {
+      console.error('Failed to delete branch:', error);
+      res.status(500).json({ error: error.message || 'Failed to delete branch' });
+    }
+  });
+
+  // DELETE /api/git/remote-branches - Remove remote branch
+  app.delete('/api/git/remote-branches', async (req, res) => {
+    const { deleteRemoteBranch } = await getGitLibraries();
+    try {
+      const directory = req.query.directory;
+      if (!directory) {
+        return res.status(400).json({ error: 'directory parameter is required' });
+      }
+
+      const { branch, remote } = req.body;
+      if (!branch) {
+        return res.status(400).json({ error: 'branch is required' });
+      }
+
+      const result = await deleteRemoteBranch(directory, { branch, remote });
+      res.json(result);
+    } catch (error) {
+      console.error('Failed to delete remote branch:', error);
+      res.status(500).json({ error: error.message || 'Failed to delete remote branch' });
+    }
+  });
+
   // POST /api/git/checkout - Checkout branch
   app.post('/api/git/checkout', async (req, res) => {
     const { checkoutBranch } = await getGitLibraries();
@@ -2708,6 +2752,23 @@ const loadRepositoryDiff = async (directory) => {
     } catch (error) {
       console.error('Failed to remove worktree:', error);
       res.status(500).json({ error: error.message || 'Failed to remove worktree' });
+    }
+  });
+
+  // POST /api/git/ignore-openchamber - Ensure .openchamber/ is ignored
+  app.post('/api/git/ignore-openchamber', async (req, res) => {
+    const { ensureOpenChamberIgnored } = await getGitLibraries();
+    try {
+      const directory = req.query.directory;
+      if (!directory) {
+        return res.status(400).json({ error: 'directory parameter is required' });
+      }
+
+      await ensureOpenChamberIgnored(directory);
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Failed to ignore .openchamber directory:', error);
+      res.status(500).json({ error: error.message || 'Failed to update git ignore' });
     }
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,8 @@ import { ConfigUpdateOverlay } from '@/components/ui/ConfigUpdateOverlay';
 function App() {
   const { initializeApp, loadProviders, isInitialized } = useConfigStore();
   const { error, clearError, loadSessions } = useSessionStore();
-  const { currentDirectory } = useDirectoryStore();
+  const currentDirectory = useDirectoryStore((state) => state.currentDirectory);
+  const isSwitchingDirectory = useDirectoryStore((state) => state.isSwitchingDirectory);
   const [showMemoryDebug, setShowMemoryDebug] = React.useState(false);
   const [markdownMode] = useMarkdownDisplayMode();
   const { uiFont, monoFont } = useFontPreferences();
@@ -105,6 +106,10 @@ function App() {
 
   // Update OpenCode client whenever directory changes and load sessions
   React.useEffect(() => {
+    if (isSwitchingDirectory) {
+      return;
+    }
+
     const syncDirectoryAndSessions = async () => {
       opencodeClient.setDirectory(currentDirectory);
       // Load sessions for the current directory
@@ -112,7 +117,7 @@ function App() {
     };
 
     syncDirectoryAndSessions();
-  }, [currentDirectory, loadSessions]);
+  }, [currentDirectory, isSwitchingDirectory, loadSessions]);
 
   // Set up event streaming
   useEventStream();

--- a/src/components/right-sidebar/TerminalTab.tsx
+++ b/src/components/right-sidebar/TerminalTab.tsx
@@ -87,13 +87,20 @@ export const TerminalTab: React.FC = () => {
     const { monoFont } = useFontPreferences();
     const { isMobile } = useDeviceInfo();
 
-    const { currentSessionId, sessions } = useSessionStore();
+    const { currentSessionId, sessions, worktreeMetadata: worktreeMap } = useSessionStore();
+    const worktreeMetadata = currentSessionId ? worktreeMap.get(currentSessionId) ?? undefined : undefined;
+
     const sessionDirectory = React.useMemo(() => {
+        if (worktreeMetadata?.path) {
+            return worktreeMetadata.path;
+        }
         if (!currentSessionId) return null;
         const entry = sessions.find((session) => session.id === currentSessionId);
-        const directory = typeof entry?.directory === 'string' ? entry.directory : null;
+        const directory = typeof (entry as { directory?: string } | undefined)?.directory === 'string'
+            ? (entry as { directory?: string }).directory
+            : null;
         return directory && directory.length > 0 ? directory : null;
-    }, [currentSessionId, sessions]);
+    }, [currentSessionId, sessions, worktreeMetadata]);
 
     const { currentDirectory: fallbackDirectory, homeDirectory } = useDirectoryStore();
     const effectiveDirectory = sessionDirectory || fallbackDirectory || null;

--- a/src/lib/git/worktreeService.ts
+++ b/src/lib/git/worktreeService.ts
@@ -1,0 +1,167 @@
+import { addGitWorktree, deleteGitBranch, deleteRemoteBranch, getGitStatus, listGitWorktrees, removeGitWorktree, type GitAddWorktreePayload, type GitWorktreeInfo } from '@/lib/gitApi';
+import { opencodeClient } from '@/lib/opencode/client';
+import type { WorktreeMetadata } from '@/types/worktree';
+
+const WORKTREE_ROOT = '.openchamber';
+
+const normalize = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+  const replaced = value.replace(/\\/g, '/');
+  if (replaced === '/') {
+    return '/';
+  }
+  return replaced.replace(/\/+$/, '');
+};
+
+const joinPath = (base: string, segment: string): string => {
+  const normalizedBase = normalize(base);
+  const sanitizedSegment = segment.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+  if (!normalizedBase || normalizedBase === '/') {
+    return `/${sanitizedSegment}`;
+  }
+  return `${normalizedBase}/${sanitizedSegment}`;
+};
+
+const shortBranchLabel = (branch?: string): string => {
+  if (!branch) {
+    return '';
+  }
+  if (branch.startsWith('refs/heads/')) {
+    return branch.substring('refs/heads/'.length);
+  }
+  if (branch.startsWith('heads/')) {
+    return branch.substring('heads/'.length);
+  }
+  if (branch.startsWith('refs/')) {
+    return branch.substring('refs/'.length);
+  }
+  return branch;
+};
+
+const ensureDirectory = async (path: string) => {
+  try {
+    await opencodeClient.createDirectory(path);
+  } catch (error) {
+    // createDirectory throws if directory already exists; ignore that case
+    if (error instanceof Error) {
+      if (/exist/i.test(error.message)) {
+        return;
+      }
+    }
+    throw error;
+  }
+};
+
+export interface CreateWorktreeOptions {
+  projectDirectory: string;
+  worktreeSlug: string;
+  branch: string;
+  createBranch?: boolean;
+}
+
+export interface RemoveWorktreeOptions {
+  projectDirectory: string;
+  path: string;
+  force?: boolean;
+}
+
+export interface ArchiveWorktreeOptions {
+  projectDirectory: string;
+  path: string;
+  branch: string;
+  force?: boolean;
+  deleteRemote?: boolean;
+  remote?: string;
+}
+
+export async function resolveWorktreePath(projectDirectory: string, worktreeSlug: string): Promise<string> {
+  const normalizedProject = normalize(projectDirectory);
+  const root = joinPath(normalizedProject, WORKTREE_ROOT);
+  await ensureDirectory(root);
+  return joinPath(root, worktreeSlug);
+}
+
+export async function createWorktree(options: CreateWorktreeOptions): Promise<WorktreeMetadata> {
+  const { projectDirectory, worktreeSlug, branch, createBranch } = options;
+  const normalizedProject = normalize(projectDirectory);
+  const worktreePath = await resolveWorktreePath(normalizedProject, worktreeSlug);
+
+  const payload: GitAddWorktreePayload = {
+    path: worktreePath,
+    branch,
+    createBranch: Boolean(createBranch),
+  };
+
+  await addGitWorktree(normalizedProject, payload);
+
+  return {
+    path: worktreePath,
+    branch,
+    label: shortBranchLabel(branch),
+    projectDirectory: normalizedProject,
+    relativePath: worktreePath.startsWith(`${normalizedProject}/`)
+      ? worktreePath.slice(normalizedProject.length + 1)
+      : worktreePath,
+  };
+}
+
+export async function removeWorktree(options: RemoveWorktreeOptions): Promise<void> {
+  const { projectDirectory, path, force } = options;
+  const normalizedProject = normalize(projectDirectory);
+  await removeGitWorktree(normalizedProject, { path, force });
+}
+
+export async function archiveWorktree(options: ArchiveWorktreeOptions): Promise<void> {
+  const { projectDirectory, path, branch, force, deleteRemote, remote } = options;
+  const normalizedProject = normalize(projectDirectory);
+  const normalizedBranch = branch.startsWith('refs/heads/')
+    ? branch.substring('refs/heads/'.length)
+    : branch;
+
+  await removeGitWorktree(normalizedProject, { path, force });
+  if (normalizedBranch) {
+    await deleteGitBranch(normalizedProject, { branch: normalizedBranch, force: true });
+    if (deleteRemote) {
+      try {
+        await deleteRemoteBranch(normalizedProject, {
+          branch: normalizedBranch,
+          remote,
+        });
+      } catch (error) {
+        console.warn('Failed to delete remote branch during worktree archive:', error);
+      }
+    }
+  }
+}
+
+export async function listWorktrees(projectDirectory: string): Promise<GitWorktreeInfo[]> {
+  const normalizedProject = normalize(projectDirectory);
+  return listGitWorktrees(normalizedProject);
+}
+
+export async function getWorktreeStatus(worktreePath: string): Promise<WorktreeMetadata['status']> {
+  const normalizedPath = normalize(worktreePath);
+  const status = await getGitStatus(normalizedPath);
+  return {
+    isDirty: !status.isClean,
+    ahead: status.ahead,
+    behind: status.behind,
+    upstream: status.tracking,
+  };
+}
+
+export function mapWorktreeToMetadata(projectDirectory: string, info: GitWorktreeInfo): WorktreeMetadata {
+  const normalizedProject = normalize(projectDirectory);
+  const normalizedPath = normalize(info.worktree);
+  return {
+    path: normalizedPath,
+    branch: info.branch ?? '',
+    label: shortBranchLabel(info.branch ?? ''),
+    projectDirectory: normalizedProject,
+    relativePath: normalizedPath.startsWith(`${normalizedProject}/`)
+      ? normalizedPath.slice(normalizedProject.length + 1)
+      : normalizedPath,
+  };
+}

--- a/src/lib/opencode/client.ts
+++ b/src/lib/opencode/client.ts
@@ -140,6 +140,20 @@ class OpencodeService {
     return this.currentDirectory;
   }
 
+  async withDirectory<T>(directory: string | undefined | null, fn: () => Promise<T>): Promise<T> {
+    if (directory === undefined || directory === null) {
+      return fn();
+    }
+
+    const previousDirectory = this.currentDirectory;
+    this.currentDirectory = directory;
+    try {
+      return await fn();
+    } finally {
+      this.currentDirectory = previousDirectory;
+    }
+  }
+
   // Get the raw API client for direct access
   getApiClient(): OpencodeClient {
     return this.client;

--- a/src/stores/types/sessionTypes.ts
+++ b/src/stores/types/sessionTypes.ts
@@ -78,6 +78,7 @@ export interface SessionStore {
     sessionAgentModelSelections: Map<string, Map<string, { providerId: string; modelId: string }>>; // sessionId -> agentName -> model
     // Track OpenChamber-created sessions for proper initialization
     webUICreatedSessions: Set<string>; // sessionIds created by OpenChamber
+    worktreeMetadata: Map<string, import('@/types/worktree').WorktreeMetadata>;
     // Track current agent context for each session (for TUI message analysis)
     currentAgentContext: Map<string, string>; // sessionId -> current agent name
     // Store context usage per session (updated only when messages are complete)
@@ -90,10 +91,10 @@ export interface SessionStore {
     toggleSessionAgentEditMode: (sessionId: string, agentName: string | undefined, defaultMode?: EditPermissionMode) => void;
     setSessionAgentEditMode: (sessionId: string, agentName: string | undefined, mode: EditPermissionMode, defaultMode?: EditPermissionMode) => void;
     loadSessions: () => Promise<void>;
-    createSession: (title?: string) => Promise<Session | null>;
+    createSession: (title?: string, directoryOverride?: string | null) => Promise<Session | null>;
 
-    deleteSession: (id: string) => Promise<boolean>;
-    deleteSessions: (ids: string[]) => Promise<{ deletedIds: string[]; failedIds: string[] }>;
+    deleteSession: (id: string, options?: { archiveWorktree?: boolean; deleteRemoteBranch?: boolean; remoteName?: string }) => Promise<boolean>;
+    deleteSessions: (ids: string[], options?: { archiveWorktree?: boolean; deleteRemoteBranch?: boolean; remoteName?: string }) => Promise<{ deletedIds: string[]; failedIds: string[] }>;
     updateSessionTitle: (id: string, title: string) => Promise<void>;
     shareSession: (id: string) => Promise<Session | null>;
     unshareSession: (id: string) => Promise<Session | null>;
@@ -114,6 +115,7 @@ export interface SessionStore {
     getCurrentAgent: (sessionId: string) => string | undefined;
     syncMessages: (sessionId: string, messages: { info: Message; parts: Part[] }[]) => void;
     applySessionMetadata: (sessionId: string, metadata: Partial<Session>) => void;
+    setSessionDirectory: (sessionId: string, directory: string | null) => void;
 
     // File attachment actions
     addAttachedFile: (file: File) => Promise<void>;
@@ -143,6 +145,9 @@ export interface SessionStore {
     markSessionAsOpenChamberCreated: (sessionId: string) => void;
     // New OpenChamber session initialization
     initializeNewOpenChamberSession: (sessionId: string, agents: Array<{ name: string; [key: string]: unknown }>) => void;
+    // Manage worktree metadata associated with sessions
+    setWorktreeMetadata: (sessionId: string, metadata: import('@/types/worktree').WorktreeMetadata | null) => void;
+    getWorktreeMetadata: (sessionId: string) => import('@/types/worktree').WorktreeMetadata | undefined;
     // Get context usage for current session
     getContextUsage: (contextLimit: number) => SessionContextUsage | null;
     // Update stored context usage for a session

--- a/src/types/worktree.ts
+++ b/src/types/worktree.ts
@@ -1,0 +1,33 @@
+export interface WorktreeMetadata {
+  /**
+   * Absolute filesystem path to the worktree directory.
+   */
+  path: string;
+  /**
+   * Root project directory where the worktree is registered.
+   */
+  projectDirectory: string;
+  /**
+   * Git branch that backs the worktree (e.g. refs/heads/feature-x).
+   */
+  branch: string;
+  /**
+   * Display label (usually short branch name) for UI badges/tooltips.
+   */
+  label: string;
+  /**
+   * Relative path from the primary project root (optional convenience).
+   */
+  relativePath?: string;
+  /**
+   * Git status snapshot used for warnings during archive/delete operations.
+   */
+  status?: {
+    isDirty: boolean;
+    ahead?: number;
+    behind?: number;
+    upstream?: string | null;
+  };
+}
+
+export type WorktreeMap = Map<string, WorktreeMetadata>;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds worktree-aware sessions (create/reuse, badges, archive on delete) with new git APIs and end-to-end directory scoping across UI and stores.
> 
> - **Sessions & UI**:
>   - Add worktree-aware session creation (`none/create/reuse`) with branch/slug validation and path preview in `SessionList`.
>   - New delete confirmation with options to `Archive attached worktrees` and optionally remove remote branches; mobile overlays for create/delete.
>   - Show worktree badge/tooltip per session row.
> - **Right Sidebar**:
>   - `GitTab`, `DiffTab`, `TerminalTab` now resolve effective directory from session worktree; branch creation flow sets upstream.
> - **State/Stores**:
>   - Extend `SessionStore` with `worktreeMetadata`, directory overrides per session, and delete APIs `{ archiveWorktree, deleteRemoteBranch }` with cleanup.
>   - Route messages/permissions to the session/worktree directory; add `opencodeClient.withDirectory` helper.
>   - `useDirectoryStore`: add `isSwitchingDirectory` gating to avoid redundant loads.
> - **Git Service & API**:
>   - Server: add endpoints `DELETE /api/git/branches`, `DELETE /api/git/remote-branches`, `POST /api/git/ignore-openchamber`; expose worktree add/remove/list.
>   - Implement `ensureOpenChamberIgnored`, remote branch delete, branch delete in `git-service`.
>   - Client: extend `gitApi` and add `worktreeService` (`create/remove/archive/list/status`, metadata mapping).
> - **Docs**:
>   - Add implementation plan `docs/plans/worktree-session-plan.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39a6ad700a672ae3931fd001b633d050ffc3a4f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->