### PR TITLE
Improve button transition animations and add WebKit-specific CSS fixes for SVG icons within buttons

### DIFF
--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg typography-ui-label font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg typography-ui-label font-medium transition-[background-color,border-color,color,box-shadow,opacity] duration-150 ease-in-out disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -21,6 +21,74 @@
   }
 }
 
+/* Safari/WebKit fixes for buttons and SVG icons */
+/* Remixicon puts fill="currentColor" on root SVG which WebKit renders as background */
+button svg.remixicon,
+[role="button"] svg.remixicon,
+button svg,
+[role="button"] svg {
+  background: none !important;
+  background-color: transparent !important;
+  /* Override inline fill attribute on SVG root */
+  fill: none !important;
+  /* Ensure SVG uses CSS rendering, not native */
+  shape-rendering: geometricPrecision;
+}
+
+/* GPU acceleration for non-spinning SVGs */
+button svg:not(.animate-spin),
+[role="button"] svg:not(.animate-spin) {
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
+}
+
+/* Fix SVG elements inside buttons - remove any rect/circle backgrounds */
+button svg rect,
+button svg circle,
+[role="button"] svg rect,
+[role="button"] svg circle {
+  fill: none !important;
+}
+
+/* Ensure SVG paths/shapes inherit color properly */
+button svg.remixicon path,
+button svg.remixicon circle[fill],
+[role="button"] svg.remixicon path,
+[role="button"] svg.remixicon circle[fill],
+button svg path,
+[role="button"] svg path {
+  fill: currentColor !important;
+}
+
+/* Safari/WebKit animation fixes - outside @layer for higher specificity */
+.animate-spin {
+  animation: webkit-spin 1s linear infinite !important;
+  will-change: transform !important;
+  background: transparent !important;
+  background-color: transparent !important;
+}
+
+/* Specific SVG spinner fixes for WebKit */
+svg.animate-spin {
+  /* Use CSS box as transform reference for proper centering with scaled SVGs */
+  transform-box: fill-box !important;
+  transform-origin: 50% 50% !important;
+  background: none !important;
+  background-color: transparent !important;
+  overflow: visible !important;
+  /* Ensure SVG content is centered */
+  display: block !important;
+}
+
+@keyframes webkit-spin {
+  0% {
+    transform: translateZ(0) rotate(0deg);
+  }
+  100% {
+    transform: translateZ(0) rotate(360deg);
+  }
+}
+
 .app-region-drag {
   -webkit-app-region: drag;
 }


### PR DESCRIPTION
Improves button transitions with specific property targeting (background-color, border-color, color, box-shadow, opacity) at 150ms duration. Adds comprehensive WebKit/Safari fixes for SVG icons in buttons: removes unwanted backgrounds from Remixicon icons, ensures proper color inheritance, fixes spinner animations with GPU acceleration, and normalizes rendering across browsers.

- Enhanced button transition specificity and duration
- WebKit SVG background and fill fixes  
- GPU acceleration for non-spinning SVGs
- Spinner animation improvements for Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)