### PR TITLE
feat: add unified dev script for concurrent development

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Bohdan Triapitsyn",
   "license": "MIT",
   "scripts": {
+    "dev": "concurrently -n \"server,web,ui\" -c \"cyan,magenta,yellow\" \"bun run --cwd packages/web dev:server:watch\" \"bun run --cwd packages/web build:watch\" \"bun run --cwd packages/ui dev\"",
     "build": "bun run --filter '*' build",
     "build:web": "bun run --cwd packages/web build",
     "build:ui": "bun run --cwd packages/ui build",


### PR DESCRIPTION
## Summary
- Adds a `dev` script to run server, web build, and UI dev mode concurrently
- Uses colored output labels (`cyan`, `magenta`, `yellow`) for easy log identification
- Simplifies development workflow with a single command

## Usage
```bash
bun run dev
```

This runs:
- `packages/web dev:server:watch` (cyan)
- `packages/web build:watch` (magenta)  
- `packages/ui dev` (yellow)

## Test plan
- [ ] Run `bun run dev` and verify all three processes start correctly
- [ ] Verify colored output labels appear in terminal
- [ ] Confirm hot-reload works for both web and UI packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)