### PR TITLE
feat: add configurable web native notifications for assistant completion

### DIFF
--- a/packages/ui/src/components/sections/openchamber/NotificationSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/NotificationSettings.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { useUIStore } from '@/stores/useUIStore';
+import { isWebRuntime } from '@/lib/desktop';
+import { getRegisteredRuntimeAPIs } from '@/contexts/runtimeAPIRegistry';
+import { toast } from 'sonner';
+
+export const NotificationSettings: React.FC = () => {
+  const nativeNotificationsEnabled = useUIStore(state => state.nativeNotificationsEnabled);
+  const setNativeNotificationsEnabled = useUIStore(state => state.setNativeNotificationsEnabled);
+
+  const [notificationPermission, setNotificationPermission] = React.useState<NotificationPermission>('default');
+
+  React.useEffect(() => {
+    if (typeof Notification !== 'undefined') {
+      setNotificationPermission(Notification.permission);
+    }
+  }, []);
+
+  const handleToggleChange = async (checked: boolean) => {
+    if (checked && typeof Notification !== 'undefined' && Notification.permission === 'default') {
+      try {
+        const permission = await Notification.requestPermission();
+        setNotificationPermission(permission);
+        if (permission === 'granted') {
+          setNativeNotificationsEnabled(true);
+        } else {
+          toast.error('Notification permission denied', {
+            description: 'Please enable notifications in your browser settings.',
+          });
+        }
+      } catch (error) {
+        console.error('Failed to request notification permission:', error);
+        toast.error('Failed to request notification permission');
+      }
+    } else if (checked && notificationPermission === 'granted') {
+      setNativeNotificationsEnabled(true);
+    } else {
+      setNativeNotificationsEnabled(false);
+    }
+  };
+
+  const canShowNotifications = typeof Notification !== 'undefined' && Notification.permission === 'granted';
+
+  if (!isWebRuntime()) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h3 className="typography-ui-header font-semibold text-foreground">
+          Native Notifications
+        </h3>
+        <p className="typography-ui text-muted-foreground">
+          Show browser notifications when an assistant completes a task.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="typography-ui text-foreground">
+          Enable native notifications
+        </span>
+        <label className="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            checked={nativeNotificationsEnabled && canShowNotifications}
+            onChange={(e) => handleToggleChange(e.target.checked)}
+            className="sr-only peer"
+          />
+          <div className="w-11 h-6 bg-neutral-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/50 dark:peer-focus:ring-primary/50 rounded-full peer dark:bg-neutral-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-neutral-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-neutral-600 peer-checked:bg-primary" />
+        </label>
+      </div>
+
+      {notificationPermission === 'denied' && (
+        <p className="typography-micro text-destructive">
+          Notification permission denied. Enable notifications in your browser settings.
+        </p>
+      )}
+
+      {notificationPermission === 'granted' && !nativeNotificationsEnabled && (
+        <p className="typography-micro text-muted-foreground">
+          Notifications are enabled in your browser. Toggle the switch above to activate them.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
@@ -4,6 +4,7 @@ import { AboutSettings } from './AboutSettings';
 import { SessionRetentionSettings } from './SessionRetentionSettings';
 import { DefaultsSettings } from './DefaultsSettings';
 import { WorktreeSectionContent } from './WorktreeSectionContent';
+import { NotificationSettings } from './NotificationSettings';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
 import { useDeviceInfo } from '@/lib/device';
 import { isWebRuntime } from '@/lib/desktop';
@@ -53,6 +54,8 @@ export const OpenChamberPage: React.FC<OpenChamberPageProps> = ({ section }) => 
                 return <SessionsSectionContent />;
             case 'worktree':
                 return <WorktreeSectionContent />;
+            case 'notifications':
+                return <NotificationSectionContent />;
             default:
                 return null;
         }
@@ -89,4 +92,9 @@ const SessionsSectionContent: React.FC = () => {
             </div>
         </div>
     );
+};
+
+// Notifications section: Native browser notifications
+const NotificationSectionContent: React.FC = () => {
+    return <NotificationSettings />;
 };

--- a/packages/ui/src/components/sections/openchamber/OpenChamberSidebar.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberSidebar.tsx
@@ -5,7 +5,7 @@ import { isVSCodeRuntime, isWebRuntime } from '@/lib/desktop';
 import { AboutSettings } from './AboutSettings';
 import { cn } from '@/lib/utils';
 
-export type OpenChamberSection = 'visual' | 'chat' | 'sessions' | 'worktree';
+export type OpenChamberSection = 'visual' | 'chat' | 'sessions' | 'worktree' | 'notifications';
 
 interface OpenChamberSidebarProps {
   selectedSection: OpenChamberSection;
@@ -38,6 +38,11 @@ const OPENCHAMBER_SECTION_GROUPS: SectionGroup[] = [
     id: 'worktree',
     label: 'Worktree',
     items: ['Branch', 'Setup'],
+  },
+  {
+    id: 'notifications',
+    label: 'Notifications',
+    items: ['Native'],
   },
 ];
 

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -53,6 +53,7 @@ interface UIStore {
   diffFileLayout: Record<string, 'inline' | 'side-by-side'>;
   diffWrapLines: boolean;
   isTimelineDialogOpen: boolean;
+  nativeNotificationsEnabled: boolean;
 
   setTheme: (theme: 'light' | 'dark' | 'system') => void;
   toggleSidebar: () => void;
@@ -95,6 +96,7 @@ interface UIStore {
   setDiffWrapLines: (wrap: boolean) => void;
   setMultiRunLauncherOpen: (open: boolean) => void;
   setTimelineDialogOpen: (open: boolean) => void;
+  setNativeNotificationsEnabled: (value: boolean) => void;
   openMultiRunLauncher: () => void;
   openMultiRunLauncherWithPrompt: (prompt: string) => void;
 }
@@ -138,6 +140,7 @@ export const useUIStore = create<UIStore>()(
         diffFileLayout: {},
         diffWrapLines: false,
         isTimelineDialogOpen: false,
+        nativeNotificationsEnabled: false,
 
         setTheme: (theme) => {
           set({ theme });
@@ -465,6 +468,10 @@ export const useUIStore = create<UIStore>()(
         setTimelineDialogOpen: (open) => {
           set({ isTimelineDialogOpen: open });
         },
+
+        setNativeNotificationsEnabled: (value) => {
+          set({ nativeNotificationsEnabled: value });
+        },
       }),
       {
         name: 'ui-store',
@@ -489,6 +496,7 @@ export const useUIStore = create<UIStore>()(
           recentModels: state.recentModels,
           diffLayoutPreference: state.diffLayoutPreference,
           diffWrapLines: state.diffWrapLines,
+          nativeNotificationsEnabled: state.nativeNotificationsEnabled,
         })
       }
     ),


### PR DESCRIPTION
## Summary

Adds browser native notifications for web runtime when an assistant completes a task. Previously, `notifyAgentCompletion()` API existed but was never called. Desktop notifications were already working (via Tauri), but web runtime had no notification support.

## Changes

### New Files
- `packages/ui/src/components/sections/openchamber/NotificationSettings.tsx` - Settings component for native notifications toggle

### Modified Files
- `packages/ui/src/stores/useUIStore.ts`
  - Added `nativeNotificationsEnabled` state (persisted)
  - Added `setNativeNotificationsEnabled()` setter

- `packages/ui/src/components/sections/openchamber/OpenChamberSidebar.tsx`
  - Added `'notifications'` to `OpenChamberSection` type
  - Added Notifications section group

- `packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx`
  - Added notifications section handler
  - Imported `NotificationSettings` component

- `packages/ui/src/hooks/useEventStream.ts`
  - Added notification trigger on `message.updated` with `finish: 'stop'`
  - Added `formatModelID()` helper for readable model names
  - Added `notifiedMessagesRef` to prevent duplicate notifications
  - Added cleanup for notification tracking

## Features

- **Toggle setting**: Users can enable/disable native notifications in Settings → OpenChamber → Notifications
- **Permission handling**: Automatically requests browser permission on first enable
- **Smart notifications**: Shows formatted title and body with agent mode and model name
- **Deduplication**: Tracks notified message IDs to prevent duplicate notifications
- **Runtime-aware**: Only shows in web runtime (desktop already has notifications)
- **User feedback**: Toast errors when permission denied, hints when permission granted but toggle off

## Technical Details

Notifications trigger when:
1. Running in web runtime (`isWebRuntime()`)
2. Native notifications are enabled in settings
3. Assistant message completes with `finish: 'stop'`
4. Message hasn't been notified before (tracked by messageId)

Notification format:
- **Title**: `"{Mode} agent is ready"` (e.g., "Agent agent is ready")
- **Body**: `"{Model} completed to task"` (e.g., "Gpt 4.1 completed task")

## Testing

Casual testing performed:
- ✅ Toggle persists across page refresh
- ✅ Browser permission request on first enable
- ✅ Error toast when permission denied
- ✅ Notifications appear when task completes
- ✅ No duplicate notifications for same message

**Note**: Additional testing with different browsers and edge cases recommended.

## Code Style Adherence

- ✅ Functional React components only
- ✅ TypeScript strict mode - no `any` used
- ✅ Uses existing theme colors/typography
- ✅ Components support light and dark themes
- ✅ `bun run build` passes