### PR TITLE
fix: settings and model selection not persisting across browser reloads

### DIFF
--- a/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
@@ -75,15 +75,21 @@ export const DefaultsSettings: React.FC = () => {
           }
         }
 
-        if (data) {
-          const model = typeof data.defaultModel === 'string' && data.defaultModel.trim().length > 0 ? data.defaultModel.trim() : undefined;
-          const variant = typeof data.defaultVariant === 'string' && data.defaultVariant.trim().length > 0 ? data.defaultVariant.trim() : undefined;
-          const agent = typeof data.defaultAgent === 'string' && data.defaultAgent.trim().length > 0 ? data.defaultAgent.trim() : undefined;
+         if (data) {
+           const model = typeof data.defaultModel === 'string' && data.defaultModel.trim().length > 0 ? data.defaultModel.trim() : undefined;
+           const variant = typeof data.defaultVariant === 'string' && data.defaultVariant.trim().length > 0 ? data.defaultVariant.trim() : undefined;
+           const agent = typeof data.defaultAgent === 'string' && data.defaultAgent.trim().length > 0 ? data.defaultAgent.trim() : undefined;
 
-          setDefaultModel(model);
-          setDefaultVariant(variant);
-          setDefaultAgent(agent);
-        }
+           if (model !== undefined) {
+             setDefaultModel(model);
+           }
+           if (variant !== undefined) {
+             setDefaultVariant(variant);
+           }
+           if (agent !== undefined) {
+             setDefaultAgent(agent);
+           }
+         }
       } catch (error) {
         console.warn('Failed to load defaults settings:', error);
       } finally {
@@ -114,14 +120,25 @@ export const DefaultsSettings: React.FC = () => {
       }
     }
 
-    try {
-      await updateDesktopSettings({
-        defaultModel: newValue ?? '',
-        defaultVariant: '',
-      });
-    } catch (error) {
-      console.warn('Failed to save default model:', error);
-    }
+     try {
+       await updateDesktopSettings({
+         defaultModel: newValue ?? '',
+         defaultVariant: '',
+       });
+
+       if (!isDesktopRuntime()) {
+         const response = await fetch('/api/config/settings', {
+           method: 'PUT',
+           headers: { 'Content-Type': 'application/json' },
+           body: JSON.stringify({ defaultModel: newValue }),
+         });
+         if (!response.ok) {
+           console.warn('Failed to save default model to server:', response.status, response.statusText);
+         }
+       }
+     } catch (error) {
+       console.warn('Failed to save default model:', error);
+     }
   }, [providers, setCurrentVariant, setProvider, setModel, setSettingsDefaultModel, setSettingsDefaultVariant]);
 
   const DEFAULT_VARIANT_VALUE = '__default__';

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -530,6 +530,29 @@ export const useConfigStore = create<ConfigStore>()(
                                 if (state.activeDirectoryKey === directoryKey) {
                                     nextState.providers = processedProviders;
                                     nextState.defaultProviders = defaults;
+
+                                    if (!state.currentProviderId && !state.currentModelId && state.settingsDefaultModel) {
+                                        const parsed = parseModelString(state.settingsDefaultModel);
+                                        if (parsed) {
+                                            const settingsProvider = processedProviders.find((p) => p.id === parsed.providerId);
+                                            if (settingsProvider?.models.some((m) => m.id === parsed.modelId)) {
+                                                const model = settingsProvider.models.find((m) => m.id === parsed.modelId);
+                                                const currentVariant = state.settingsDefaultVariant && (model as { variants?: Record<string, unknown> } | undefined)?.variants?.[state.settingsDefaultVariant]
+                                                    ? state.settingsDefaultVariant
+                                                    : undefined;
+
+                                                nextState.currentProviderId = parsed.providerId;
+                                                nextState.currentModelId = parsed.modelId;
+                                                nextState.currentVariant = currentVariant;
+                                                nextState.selectedProviderId = parsed.providerId;
+
+                                                nextSnapshot.currentProviderId = parsed.providerId;
+                                                nextSnapshot.currentModelId = parsed.modelId;
+                                                nextSnapshot.currentVariant = currentVariant;
+                                                nextSnapshot.selectedProviderId = parsed.providerId;
+                                            }
+                                        }
+                                    }
                                 }
 
                                 return nextState;
@@ -573,6 +596,29 @@ export const useConfigStore = create<ConfigStore>()(
                         if (state.activeDirectoryKey === directoryKey) {
                             nextState.providers = previousProviders;
                             nextState.defaultProviders = previousDefaults;
+
+                            if (!state.currentProviderId && !state.currentModelId && state.settingsDefaultModel) {
+                                const parsed = parseModelString(state.settingsDefaultModel);
+                                if (parsed) {
+                                    const settingsProvider = previousProviders.find((p) => p.id === parsed.providerId);
+                                    if (settingsProvider?.models.some((m) => m.id === parsed.modelId)) {
+                                        const model = settingsProvider.models.find((m) => m.id === parsed.modelId);
+                                        const currentVariant = state.settingsDefaultVariant && (model as { variants?: Record<string, unknown> } | undefined)?.variants?.[state.settingsDefaultVariant]
+                                            ? state.settingsDefaultVariant
+                                            : undefined;
+
+                                        nextState.currentProviderId = parsed.providerId;
+                                        nextState.currentModelId = parsed.modelId;
+                                        nextState.currentVariant = currentVariant;
+                                        nextState.selectedProviderId = parsed.providerId;
+
+                                        nextSnapshot.currentProviderId = parsed.providerId;
+                                        nextSnapshot.currentModelId = parsed.modelId;
+                                        nextSnapshot.currentVariant = currentVariant;
+                                        nextSnapshot.selectedProviderId = parsed.providerId;
+                                    }
+                                }
+                            }
                         }
 
                         return nextState;
@@ -1337,14 +1383,23 @@ export const useConfigStore = create<ConfigStore>()(
             {
                 name: "config-store",
                 storage: createJSONStorage(() => getSafeStorage()),
-                partialize: () => ({
-
-                }),
-            },
-        ),
-        {
-            name: "config-store",
-        },
+                partialize: (state) => ({
+                    activeDirectoryKey: state.activeDirectoryKey,
+                    directoryScoped: state.directoryScoped,
+                    currentProviderId: state.currentProviderId,
+                    currentModelId: state.currentModelId,
+                    currentVariant: state.currentVariant,
+                    currentAgentName: state.currentAgentName,
+                    selectedProviderId: state.selectedProviderId,
+                    agentModelSelections: state.agentModelSelections,
+                    defaultProviders: state.defaultProviders,
+                    settingsDefaultModel: state.settingsDefaultModel,
+                    settingsDefaultVariant: state.settingsDefaultVariant,
+                    settingsDefaultAgent: state.settingsDefaultAgent,
+                    settingsAutoCreateWorktree: state.settingsAutoCreateWorktree,
+                 }),
+             },
+         ),
     ),
 );
 


### PR DESCRIPTION
Fixed localStorage persistence bug where user settings (model selections, agent selections, project states) were lost on browser reload.

Changes:
- Add proper partialize function to config-store persist middleware
- Apply settingsDefaultModel when loading providers for new projects
- Persist default model changes to both localStorage and disk via API
- Fix state update logic to prevent overwriting with undefined values from disk
