### PR TITLE
feat: Add Nerd Fonts support for terminal icons

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1523,3 +1523,20 @@ html:not(.dark) .chat-scroll {
 .terminal-viewport-container textarea {
   caret-color: transparent !important;
 }
+
+/* Mobile Terminal Optimizations */
+@media (max-width: 1024px) {
+  .terminal-viewport-container {
+    font-variant-ligatures: none;
+    font-feature-settings: "liga" 0, "calt" 0;
+  }
+}
+
+/* Font loading states */
+.fonts-loading .terminal-viewport-container {
+  font-family: monospace;
+}
+
+.fonts-loaded .terminal-viewport-container {
+  font-family: "JetBrainsMono Nerd Font", "FiraCode Nerd Font", "Fira Code", "JetBrains Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+}

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -15,6 +15,12 @@
     <link rel="apple-touch-icon" sizes="167x167" href="/apple-touch-icon-167x167.png" />
     <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
 
+    <!-- Preload Nerd Fonts for terminal icon display -->
+    <link rel="preload" href="https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts/JetBrainsMonoNerdFont-Regular.woff2"
+          as="font" type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" href="https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts/FiraCodeNerdFont-Regular.woff2"
+          as="font" type="font/woff2" crossorigin="anonymous">
+
     <!-- Web app manifest (data URL to avoid nginx auth issues) -->
     <script>
       const baseUrl = location.origin;
@@ -119,8 +125,33 @@
     <meta name="application-name" content="OpenChamber" />
     <meta name="apple-mobile-web-app-title" content="OpenChamber" />
 
-    <!-- Inline CSS for loading screen (before Tailwind loads) -->
+    <!-- Inline CSS for loading screen and Nerd Fonts (before Tailwind loads) -->
     <style>
+      /* Nerd Font @font-face declarations for terminal icon support */
+      @font-face {
+        font-family: 'JetBrainsMono Nerd Font';
+        src:
+          local('JetBrainsMono Nerd Font'),
+          url('https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts/JetBrainsMonoNerdFont-Regular.woff2') format('woff2'),
+          url('https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts/JetBrainsMonoNerdFont-Regular.woff') format('woff');
+        font-weight: normal;
+        font-style: normal;
+        font-display: swap;
+        unicode-range: U+E000-F8FF, U+F0000-FFFFF;
+      }
+
+      @font-face {
+        font-family: 'FiraCode Nerd Font';
+        src:
+          local('FiraCode Nerd Font'),
+          url('https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts/FiraCodeNerdFont-Regular.woff2') format('woff2'),
+          url('https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts/FiraCodeNerdFont-Regular.woff') format('woff');
+        font-weight: normal;
+        font-style: normal;
+        font-display: swap;
+        unicode-range: U+E000-F8FF, U+F0000-FFFFF;
+      }
+
       :root {
         --splash-background: #151313;
         --splash-stroke: white;
@@ -237,6 +268,34 @@
           }, 300);
         }
       }, 10000);
+    </script>
+
+    <!-- CSS Font Loading API for reliable Nerd Font loading -->
+    <script>
+      (function() {
+        const fonts = [
+          {
+            name: 'JetBrainsMono Nerd Font',
+            url: 'https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts/JetBrainsMonoNerdFont-Regular.woff2'
+          },
+          {
+            name: 'FiraCode Nerd Font',
+            url: 'https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/fonts/FiraCodeNerdFont-Regular.woff2'
+          }
+        ];
+
+        const fontPromises = fonts.map(font => {
+          const fontFace = new FontFace(font.name, `url(${font.url}) format('woff2')`);
+          document.fonts.add(fontFace);
+          return fontFace.load().catch(err => {
+            console.warn(`Failed to load font: ${font.name}`, err);
+          });
+        });
+
+        Promise.allSettled(fontPromises).then(() => {
+          document.documentElement.classList.add('fonts-loaded');
+        });
+      })();
     </script>
 
     <!-- Polyfill for process before loading React -->


### PR DESCRIPTION
## Summary
- Load Nerd Fonts (JetBrainsMono, FiraCode) for terminal icon display
- Implement progressive font loading with fallback to system monospace
- Add CSS Font Loading API for reliable font detection

## Changes
### Font Loading
- Added `<link rel="preload">` for priority font fetching
- Defined `@font-face` with optimized unicode-range (icons only)
- Implemented JavaScript Font Loading API for reliable load detection
- Added `.fonts-loading` / `.fonts-loaded` CSS classes for state management

### Mobile Optimization
- Disabled ligatures on small screens (≤1024px) for better readability

### Test
![image](https://github.com/user-attachments/assets/917e38eb-eac2-42c2-90f3-922976fb0e5b)