### PR TITLE
fix(mobile): add iOS keyboard home indicator safe area

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1342,7 +1342,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
 
         <form
             onSubmit={handleSubmit}
-            className="pt-0 pb-2 md:pb-4 bottom-safe-area"
+            className={cn(
+                "pt-0 pb-2 md:pb-4",
+                isMobile && isKeyboardOpen ? "ios-keyboard-safe-area" : "bottom-safe-area"
+            )}
             data-keyboard-avoid="true"
             style={isMobile && inputBarOffset > 0 && !isKeyboardOpen ? { marginBottom: `${inputBarOffset}px` } : undefined}
         >

--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -201,6 +201,10 @@ export const MainLayout: React.FC = () => {
             root.style.setProperty('--oc-keyboard-inset', `${stickyKeyboardInset}px`);
             previousHeight = height;
 
+            const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+            const keyboardHomeIndicator = isIOS && stickyKeyboardInset > 0 ? 34 : 0;
+            root.style.setProperty('--oc-keyboard-home-indicator', `${keyboardHomeIndicator}px`);
+
             const avoidTarget = isTextTarget ? resolveKeyboardAvoidTarget(active) : null;
 
             if (!isMobile || !avoidTarget || !active) {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -13,6 +13,7 @@
   --oc-visual-viewport-offset-top: 0px;
   --oc-keyboard-inset: 0px;
   --oc-keyboard-avoid-offset: 0px;
+  --oc-keyboard-home-indicator: 0px;
   --ui-regular-font-weight: 400;
   --oc-scrollbar-thumb: oklch(0.32 0.03 50 / 0.4);
   --oc-scrollbar-thumb-hover: oklch(0.32 0.03 50 / 0.6);
@@ -1171,6 +1172,11 @@ html:not(.dark) .chat-scroll {
     /* Safe area for bottom fixed/bottom-0 elements */
     .bottom-safe-area {
       padding-bottom: var(--oc-safe-area-bottom-visual) !important;
+    }
+
+    /* iOS keyboard home indicator safe area - used when keyboard is open */
+    .ios-keyboard-safe-area {
+      padding-bottom: calc(var(--oc-keyboard-home-indicator, 34px) + var(--oc-safe-area-bottom-visual, 0px)) !important;
     }
 
     /* Prevent keyboard-induced page scroll on iOS PWA */


### PR DESCRIPTION
## Summary

On iOS devices, when the keyboard is open, there's a home indicator bar (approximately 34px tall) at the bottom of the keyboard that needs additional safe area padding.

## Changes

- Add `--oc-keyboard-home-indicator` CSS variable
- Add `ios-keyboard-safe-area` class for keyboard open state
- Detect iOS userAgent and set keyboard home indicator height (34px)
- Apply `ios-keyboard-safe-area` class to ChatInput when keyboard is open

## Files Changed

- `packages/ui/src/index.css` - Added CSS variable and new safe area class
- `packages/ui/src/components/layout/MainLayout.tsx` - iOS detection and keyboard home indicator logic
- `packages/ui/src/components/chat/ChatInput.tsx` - Dynamic class switching based on keyboard state