### PR TITLE
fix: resolve heartbeat race condition causing session stalls

### DIFF
--- a/packages/ui/src/hooks/useEventStream.ts
+++ b/packages/ui/src/hooks/useEventStream.ts
@@ -1675,7 +1675,7 @@ export const useEventStream = () => {
       if (hasBusySessions) {
         void refreshSessionActivityStatus();
       }
-      if (now - lastEventTimestampRef.current > 25000) {
+      if (now - lastEventTimestampRef.current > 45000) {
         Promise.resolve().then(async () => {
           try {
             const healthy = await opencodeClient.checkHealth();

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -15,7 +15,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const DEFAULT_PORT = 3000;
-const HEALTH_CHECK_INTERVAL = 30000;
+const HEALTH_CHECK_INTERVAL = 15000;
 const SHUTDOWN_TIMEOUT = 10000;
 const MODELS_DEV_API_URL = 'https://models.dev/api.json';
 const MODELS_METADATA_CACHE_TTL = 5 * 60 * 1000;
@@ -2244,7 +2244,7 @@ async function main(options = {}) {
 
     const heartbeatInterval = setInterval(() => {
       writeSseEvent(res, { type: 'openchamber:heartbeat', timestamp: Date.now() });
-    }, 30000);
+    }, 15000);
 
     const decoder = new TextDecoder();
     const reader = upstream.body.getReader();
@@ -2370,7 +2370,7 @@ async function main(options = {}) {
 
     const heartbeatInterval = setInterval(() => {
       writeSseEvent(res, { type: 'openchamber:heartbeat', timestamp: Date.now() });
-    }, 30000);
+    }, 15000);
 
     const decoder = new TextDecoder();
     const reader = upstream.body.getReader();


### PR DESCRIPTION
This fixes a race condition where the client watchdog timeout (25s) was shorter than the server heartbeat interval (30s).

    Changes:
    - Server: Decreased heartbeat interval from 30s to 15s to send keepalives more frequently.
    - Client: Increased stale connection threshold from 25s to 45s to allow for 3 missed heartbeats before reconnecting.

    This ensures stable connections during long subagent tasks where no text generation occurs.