### PR TITLE
feat(sidebar): add worktree session button to project header

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -133,6 +133,7 @@ interface SortableProjectItemProps {
   onToggle: () => void;
   onHoverChange: (hovered: boolean) => void;
   onNewSession: () => void;
+  onNewWorktreeSession?: () => void;
   onOpenMultiRunLauncher: () => void;
   onClose: () => void;
   sentinelRef: (el: HTMLDivElement | null) => void;
@@ -154,6 +155,7 @@ const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
   onToggle,
   onHoverChange,
   onNewSession,
+  onNewWorktreeSession,
   onOpenMultiRunLauncher,
   onClose,
   sentinelRef,
@@ -252,18 +254,47 @@ const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* New session button */}
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onNewSession();
-            }}
-            className="inline-flex h-6 w-6 items-center justify-center text-muted-foreground hover:text-foreground flex-shrink-0 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
-            aria-label="New session"
-          >
-            <RiAddLine className="h-4 w-4" />
-          </button>
+          {isRepo && onNewWorktreeSession && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onNewWorktreeSession();
+                  }}
+                  className={cn(
+                    'inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 hover:text-foreground',
+                    mobileVariant ? 'opacity-70' : 'opacity-0 group-hover/project:opacity-100',
+                  )}
+                  aria-label="New session in worktree"
+                >
+                  <RiGitBranchLine className="h-4 w-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={4}>
+                <p>New session in worktree</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onNewSession();
+                }}
+                className="inline-flex h-6 w-6 items-center justify-center text-muted-foreground hover:text-foreground flex-shrink-0 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                aria-label="New session"
+              >
+                <RiAddLine className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={4}>
+              <p>New session</p>
+            </TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -1540,6 +1571,16 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
                       } else {
                         openNewSessionDraft({ directoryOverride: project.normalizedPath });
                       }
+                    }}
+                    onNewWorktreeSession={() => {
+                      if (projectKey !== activeProjectId) {
+                        setActiveProject(projectKey);
+                      }
+                      setActiveMainTab('chat');
+                      if (mobileVariant) {
+                        setSessionSwitcherOpen(false);
+                      }
+                      createWorktreeSession();
                     }}
                     onOpenMultiRunLauncher={() => {
                       if (projectKey !== activeProjectId) {


### PR DESCRIPTION
## Summary

Adds a dedicated button to create new worktree sessions directly from the project header, making the worktree feature more discoverable.

## Changes

- Add new git branch icon button (🌿) between the project menu and the new session (+) button
- Button only appears for git repositories
- Uses the same hover-to-reveal behavior as the existing 3-dot menu
- Clicking the button creates a new session in a worktree (same as `Shift+Cmd+N`)

## Before/After

**Before (hover):**
```
[📂 Project Name]        [⋮]     [+]
```

**After (hover on git repo):**
```
[📂 Project Name]        [⋮] [🌿] [+]
```

## Why

The worktree feature (`Shift+Cmd+N`) is powerful but not discoverable. This change surfaces it in the UI alongside the regular new session button, helping users discover and use worktrees more easily.