### PR TITLE
feat: Add Kanagawa theme

### DIFF
--- a/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { RiRestartLine } from '@remixicon/react';
+import type { ThemeMode } from '@/types/theme';
 
 import { useThemeSystem } from '@/contexts/useThemeSystem';
-import type { ThemeMode } from '@/types/theme';
 import { useUIStore } from '@/stores/useUIStore';
 import { useMessageQueueStore } from '@/stores/messageQueueStore';
 import { cn, getModifierLabel } from '@/lib/utils';
@@ -10,6 +10,7 @@ import { ButtonSmall } from '@/components/ui/button-small';
 import { NumberInput } from '@/components/ui/number-input';
 import { isVSCodeRuntime } from '@/lib/desktop';
 import { useDeviceInfo } from '@/lib/device';
+import { themes } from '@/lib/theme/themes';
 
 interface Option<T extends string> {
     id: T;
@@ -97,6 +98,10 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
     const {
         themeMode,
         setThemeMode,
+        lightThemeId,
+        darkThemeId,
+        setLightThemePreference,
+        setDarkThemePreference,
     } = useThemeSystem();
 
     const shouldShow = (setting: VisibleSetting): boolean => {
@@ -107,25 +112,71 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
     return (
         <div className="w-full space-y-8">
             {shouldShow('theme') && !isVSCodeRuntime() && (
-                <div className="space-y-4">
-                    <div className="space-y-1">
-                        <h3 className="typography-ui-header font-semibold text-foreground">
-                            Theme Mode
-                        </h3>
+                <div className="space-y-6">
+                    <div className="space-y-4">
+                        <div className="space-y-1">
+                            <h3 className="typography-ui-header font-semibold text-foreground">
+                                Theme Mode
+                            </h3>
+                        </div>
+
+                        <div className="flex gap-1 w-fit">
+                            {THEME_MODE_OPTIONS.map((option) => (
+                                <ButtonSmall
+                                    key={option.value}
+                                    variant={themeMode === option.value ? 'default' : 'outline'}
+                                    className={cn(themeMode === option.value ? undefined : 'text-foreground')}
+                                    onClick={() => setThemeMode(option.value)}
+                                >
+                                    {option.label}
+                                </ButtonSmall>
+                            ))}
+                        </div>
                     </div>
 
-                    <div className="flex gap-1 w-fit">
-                        {THEME_MODE_OPTIONS.map((option) => (
-                            <ButtonSmall
-                                key={option.value}
-                                variant={themeMode === option.value ? 'default' : 'outline'}
-                                className={cn(themeMode === option.value ? undefined : 'text-foreground')}
-                                onClick={() => setThemeMode(option.value)}
-                            >
-                                {option.label}
-                            </ButtonSmall>
-                        ))}
-                    </div>
+                    {(themeMode === 'light' || themeMode === 'system') && (
+                        <div className="space-y-4">
+                            <div className="space-y-1">
+                                <h3 className="typography-ui-header font-semibold text-foreground">
+                                    Light Theme
+                                </h3>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                                {themes.filter(t => t.metadata.variant === 'light').map((theme) => (
+                                    <ButtonSmall
+                                        key={theme.metadata.id}
+                                        variant={lightThemeId === theme.metadata.id ? 'default' : 'outline'}
+                                        className={cn(lightThemeId === theme.metadata.id ? undefined : 'text-foreground')}
+                                        onClick={() => setLightThemePreference(theme.metadata.id)}
+                                    >
+                                        {theme.metadata.name}
+                                    </ButtonSmall>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {(themeMode === 'dark' || themeMode === 'system') && (
+                        <div className="space-y-4">
+                            <div className="space-y-1">
+                                <h3 className="typography-ui-header font-semibold text-foreground">
+                                    Dark Theme
+                                </h3>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                                {themes.filter(t => t.metadata.variant === 'dark').map((theme) => (
+                                    <ButtonSmall
+                                        key={theme.metadata.id}
+                                        variant={darkThemeId === theme.metadata.id ? 'default' : 'outline'}
+                                        className={cn(darkThemeId === theme.metadata.id ? undefined : 'text-foreground')}
+                                        onClick={() => setDarkThemePreference(theme.metadata.id)}
+                                    >
+                                        {theme.metadata.name}
+                                    </ButtonSmall>
+                                ))}
+                            </div>
+                        </div>
+                    )}
                 </div>
             )}
 

--- a/packages/ui/src/lib/theme/themes/index.ts
+++ b/packages/ui/src/lib/theme/themes/index.ts
@@ -1,15 +1,21 @@
 import type { Theme } from '@/types/theme';
 import { flexokiLightTheme } from './flexoki-light';
 import { flexokiDarkTheme } from './flexoki-dark';
+import { kanagawaLightTheme } from './kanagawa-light';
+import { kanagawaDarkTheme } from './kanagawa-dark';
 
 export const themes: Theme[] = [
   flexokiLightTheme,
   flexokiDarkTheme,
+  kanagawaLightTheme,
+  kanagawaDarkTheme,
 ];
 
 export {
   flexokiLightTheme,
   flexokiDarkTheme,
+  kanagawaLightTheme,
+  kanagawaDarkTheme,
 };
 
 export function getThemeById(id: string): Theme | undefined {

--- a/packages/ui/src/lib/theme/themes/kanagawa-dark.ts
+++ b/packages/ui/src/lib/theme/themes/kanagawa-dark.ts
@@ -1,0 +1,197 @@
+import type { Theme } from '@/types/theme';
+
+export const kanagawaDarkTheme: Theme = {
+  metadata: {
+    id: 'kanagawa-dark',
+    name: 'Kanagawa Dark',
+    description: 'A color scheme inspired by Japanese art and ink painting - dark variant',
+    author: 'rebelot',
+    version: '1.0.0',
+    variant: 'dark',
+    tags: ['dark', 'japanese', 'ink', 'elegant']
+  },
+
+  colors: {
+
+    primary: {
+      base: '#7FB4CA',
+      hover: '#9DC5E0',
+      active: '#658594',
+      foreground: '#1F1F28',
+      muted: '#7FB4CA80',
+      emphasis: '#7E9CD8'
+    },
+
+    surface: {
+      background: '#1F1F28',
+      foreground: '#DCD7BA',
+      muted: '#16161D',
+      mutedForeground: '#727169',
+      elevated: '#2A2A37',
+      elevatedForeground: '#DCD7BA',
+      overlay: '#16161DCC',
+      subtle: '#363646'
+    },
+
+    interactive: {
+      border: '#363646',
+      borderHover: '#54546D',
+      borderFocus: '#7FB4CA',
+      selection: '#7FB4CA33',
+      selectionForeground: '#DCD7BA',
+      focus: '#7FB4CA',
+      focusRing: '#7FB4CA50',
+      cursor: '#DCD7BA',
+      hover: '#363646',
+      active: '#54546D'
+    },
+
+    status: {
+      error: '#E82424',
+      errorForeground: '#DCD7BA',
+      errorBackground: '#E8242420',
+      errorBorder: '#E8242450',
+
+      warning: '#FF9E3B',
+      warningForeground: '#1F1F28',
+      warningBackground: '#FF9E3B20',
+      warningBorder: '#FF9E3B50',
+
+      success: '#98BB6C',
+      successForeground: '#1F1F28',
+      successBackground: '#98BB6C20',
+      successBorder: '#98BB6C50',
+
+      info: '#7E9CD8',
+      infoForeground: '#1F1F28',
+      infoBackground: '#7E9CD820',
+      infoBorder: '#7E9CD850'
+    },
+
+    syntax: {
+      base: {
+        background: '#16161D',
+        foreground: '#DCD7BA',
+        comment: '#54546D',
+        keyword: '#7E9CD8',
+        string: '#98BB6C',
+        number: '#FF9E3B',
+        function: '#E6C384',
+        variable: '#DCD7BA',
+        type: '#C8C093',
+        operator: '#C34043'
+      },
+
+      tokens: {
+        commentDoc: '#727169',
+        stringEscape: '#DCD7BA',
+        keywordImport: '#957FB8',
+        storageModifier: '#7E9CD8',
+        functionCall: '#E6C384',
+        method: '#76946A',
+        variableProperty: '#7E9CD8',
+        variableOther: '#76946A',
+        variableGlobal: '#D27E99',
+        variableLocal: '#2A2A37',
+        parameter: '#DCD7BA',
+        constant: '#DCD7BA',
+        class: '#E6C384',
+        className: '#E6C384',
+        interface: '#C8C093',
+        struct: '#E6C384',
+        enum: '#E6C384',
+        typeParameter: '#E6C384',
+        namespace: '#C8C093',
+        module: '#C34043',
+        tag: '#7E9CD8',
+        jsxTag: '#D27E99',
+        tagAttribute: '#C8C093',
+        tagAttributeValue: '#98BB6C',
+        boolean: '#C8C093',
+        decorator: '#C8C093',
+        label: '#D27E99',
+        punctuation: '#54546D',
+        macro: '#7E9CD8',
+        preprocessor: '#D27E99',
+        regex: '#98BB6C',
+        url: '#7E9CD8',
+        key: '#E6C384',
+        exception: '#D27E99'
+      },
+
+      highlights: {
+        diffAdded: '#98BB6C',
+        diffAddedBackground: '#76946A20',
+        diffRemoved: '#C34043',
+        diffRemovedBackground: '#E8242420',
+        diffModified: '#7E9CD8',
+        diffModifiedBackground: '#7E9CD820',
+        lineNumber: '#363646',
+        lineNumberActive: '#DCD7BA'
+      }
+    },
+
+    markdown: {
+      heading1: '#FF9E3B',
+      heading2: '#C34043',
+      heading3: '#7E9CD8',
+      heading4: '#DCD7BA',
+      link: '#7FB4CA',
+      linkHover: '#7E9CD8',
+      inlineCode: '#98BB6C',
+      inlineCodeBackground: '#16161D',
+      blockquote: '#54546D',
+      blockquoteBorder: '#363646',
+      listMarker: '#FF9E3B99'
+    },
+
+    chat: {
+      userMessage: '#DCD7BA',
+      userMessageBackground: '#2A2A37',
+      assistantMessage: '#DCD7BA',
+      assistantMessageBackground: '#1F1F28',
+      timestamp: '#54546D',
+      divider: '#363646'
+    },
+
+    tools: {
+      background: '#16161D50',
+      border: '#36364680',
+      headerHover: '#36364650',
+      icon: '#54546D',
+       title: '#DCD7BA',
+      description: '#54546D',
+
+      edit: {
+        added: '#98BB6C',
+        addedBackground: '#98BB6C25',
+        removed: '#C34043',
+        removedBackground: '#C3404325',
+        lineNumber: '#363646'
+      }
+    }
+  },
+
+  config: {
+    fonts: {
+      sans: '"IBM Plex Mono", monospace',
+      mono: '"IBM Plex Mono", monospace',
+      heading: '"IBM Plex Mono", monospace'
+    },
+
+    radius: {
+      none: '0',
+      sm: '0.125rem',
+      md: '0.375rem',
+      lg: '0.5rem',
+      xl: '0.75rem',
+      full: '9999px'
+    },
+
+    transitions: {
+      fast: '150ms ease',
+      normal: '250ms ease',
+      slow: '350ms ease'
+    }
+  }
+};

--- a/packages/ui/src/lib/theme/themes/kanagawa-light.ts
+++ b/packages/ui/src/lib/theme/themes/kanagawa-light.ts
@@ -1,0 +1,197 @@
+import type { Theme } from '@/types/theme';
+
+export const kanagawaLightTheme: Theme = {
+  metadata: {
+    id: 'kanagawa-light',
+    name: 'Kanagawa Light',
+    description: 'A color scheme inspired by Japanese art and ink painting - light variant (Lotus)',
+    author: 'rebelot',
+    version: '1.0.0',
+    variant: 'light',
+    tags: ['light', 'japanese', 'lotus', 'elegant']
+  },
+
+  colors: {
+
+    primary: {
+      base: '#4d699b',
+      hover: '#6693bf',
+      active: '#5d57a3',
+      foreground: '#F2ECBC',
+      muted: '#4d699b80',
+      emphasis: '#6693bf'
+    },
+
+    surface: {
+      background: '#F2ECBC',
+      foreground: '#545464',
+      muted: '#DCD5AC',
+      mutedForeground: '#8a8980',
+      elevated: '#D5CEA3',
+      elevatedForeground: '#545464',
+      overlay: '#54546433',
+      subtle: '#B7D0AE'
+    },
+
+    interactive: {
+      border: '#716e61',
+      borderHover: '#8a8980',
+      borderFocus: '#4d699b',
+      selection: '#4d699b33',
+      selectionForeground: '#545464',
+      focus: '#4d699b',
+      focusRing: '#4d699b40',
+      cursor: '#545464',
+      hover: '#716e61',
+      active: '#8a8980'
+    },
+
+    status: {
+       error: '#E82424',
+       errorForeground: '#F2ECBC',
+       errorBackground: '#E8242420',
+       errorBorder: '#E8242450',
+
+       warning: '#de9800',
+      warningForeground: '#545464',
+      warningBackground: '#de980020',
+      warningBorder: '#de980050',
+
+      success: '#6f894e',
+      successForeground: '#F2ECBC',
+      successBackground: '#98BB6C20',
+      successBorder: '#6f894e50',
+
+      info: '#4d699b',
+      infoForeground: '#F2ECBC',
+      infoBackground: '#6693bf20',
+      infoBorder: '#4d699b50'
+    },
+
+    syntax: {
+      base: {
+        background: '#DCD5AC',
+        foreground: '#545464',
+        comment: '#716e61',
+        keyword: '#4d699b',
+        string: '#6f894e',
+        number: '#836f4a',
+        function: '#cc6d00',
+        variable: '#545464',
+        type: '#77713f',
+        operator: '#c84053'
+      },
+
+      tokens: {
+        commentDoc: '#8a8980',
+        stringEscape: '#545464',
+        keywordImport: '#624c83',
+        storageModifier: '#4d699b',
+        functionCall: '#cc6d00',
+        method: '#6e915f',
+        variableProperty: '#4d699b',
+        variableOther: '#6e915f',
+        variableGlobal: '#b35b79',
+        variableLocal: '#D5CEA3',
+        parameter: '#545464',
+        constant: '#545464',
+        class: '#cc6d00',
+        className: '#cc6d00',
+        interface: '#77713f',
+        struct: '#cc6d00',
+        enum: '#cc6d00',
+        typeParameter: '#cc6d00',
+        namespace: '#77713f',
+        module: '#c84053',
+        tag: '#4d699b',
+        jsxTag: '#b35b79',
+        tagAttribute: '#77713f',
+        tagAttributeValue: '#6f894e',
+        boolean: '#77713f',
+        decorator: '#77713f',
+        label: '#b35b79',
+        punctuation: '#716e61',
+        macro: '#4d699b',
+        preprocessor: '#b35b79',
+        regex: '#6f894e',
+        url: '#4d699b',
+        key: '#cc6d00',
+        exception: '#b35b79'
+      },
+
+      highlights: {
+        diffAdded: '#6f894e',
+        diffAddedBackground: '#6f894e20',
+        diffRemoved: '#c84053',
+        diffRemovedBackground: '#c8405320',
+        diffModified: '#4d699b',
+        diffModifiedBackground: '#4d699b20',
+        lineNumber: '#8a8980',
+        lineNumberActive: '#545464'
+      }
+    },
+
+    markdown: {
+      heading1: '#836f4a',
+      heading2: '#cc6d00',
+      heading3: '#4d699b',
+      heading4: '#545464',
+      link: '#5d57a3',
+      linkHover: '#4d699b',
+      inlineCode: '#6f894e',
+      inlineCodeBackground: '#DCD5AC',
+      blockquote: '#716e61',
+      blockquoteBorder: '#716e61',
+      listMarker: '#836f4a99'
+    },
+
+    chat: {
+      userMessage: '#545464',
+      userMessageBackground: '#DCD5AC',
+      assistantMessage: '#545464',
+      assistantMessageBackground: '#F2ECBC',
+      timestamp: '#716e61',
+      divider: '#716e61'
+    },
+
+    tools: {
+      background: '#DCD5AC50',
+      border: '#716e6180',
+      headerHover: '#716e61',
+      icon: '#8a8980',
+       title: '#545464',
+      description: '#8a8980',
+
+      edit: {
+        added: '#6f894e',
+        addedBackground: '#6f894e25',
+        removed: '#c84053',
+        removedBackground: '#c8405325',
+        lineNumber: '#8a8980'
+      }
+    }
+  },
+
+  config: {
+    fonts: {
+      sans: '"IBM Plex Mono", monospace',
+      mono: '"IBM Plex Mono", monospace',
+      heading: '"IBM Plex Mono", monospace'
+    },
+
+    radius: {
+      none: '0',
+      sm: '0.125rem',
+      md: '0.375rem',
+      lg: '0.5rem',
+      xl: '0.75rem',
+      full: '9999px'
+    },
+
+    transitions: {
+      fast: '150ms ease',
+      normal: '250ms ease',
+      slow: '350ms ease'
+    }
+  }
+};


### PR DESCRIPTION
- Add Kanagawa Light and Dark theme options to visual settings
- Enable per-mode theme selection with light/dark theme preferences
- Import and register new Kanagawa theme variants in theme system

<img width="1751" height="1209" alt="image" src="https://github.com/user-attachments/assets/5b668f6e-c27a-425d-93c0-89707e0037f9" />
