### PR TITLE
refactor(git): update revert button icon

### DIFF
--- a/packages/ui/src/components/views/git/ChangeRow.tsx
+++ b/packages/ui/src/components/views/git/ChangeRow.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import {
   RiCheckboxLine,
   RiCheckboxBlankLine,
-  RiRefreshLine,
+  RiArrowGoBackLine,
   RiLoader4Line,
 } from '@remixicon/react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -149,7 +149,7 @@ export const ChangeRow = React.memo<ChangeRowProps>(function ChangeRow({
               {isReverting ? (
                 <RiLoader4Line className="size-3.5 animate-spin" />
               ) : (
-                <RiRefreshLine className="size-3.5" />
+                <RiArrowGoBackLine className="size-3.5" />
               )}
             </button>
           </TooltipTrigger>


### PR DESCRIPTION
- Replace revert action icon from refresh to back arrow

<img width="310" height="210" alt="CleanShot 2026-01-16 at 23 32 36@2x" src="https://github.com/user-attachments/assets/41fef0aa-51e5-4705-9825-2a635b118402" />

