### PR TITLE
feat(providers): add support for disconnecting config-based providers

### DIFF
--- a/packages/web/server/lib/opencode-auth.js
+++ b/packages/web/server/lib/opencode-auth.js
@@ -70,12 +70,18 @@ function listProviderAuths() {
   return Object.keys(auth);
 }
 
+function hasProviderAuth(providerId) {
+  const auth = readAuthFile();
+  return !!auth[providerId];
+}
+
 export {
   readAuthFile,
   writeAuthFile,
   removeProviderAuth,
   getProviderAuth,
   listProviderAuths,
+  hasProviderAuth,
   AUTH_FILE,
   OPENCODE_DATA_DIR
 };

--- a/packages/web/server/lib/provider-config.js
+++ b/packages/web/server/lib/provider-config.js
@@ -1,0 +1,191 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { parse as parseJsonc } from 'jsonc-parser';
+
+const OPENCODE_CONFIG_DIR = path.join(os.homedir(), '.config', 'opencode');
+const CONFIG_FILE = path.join(OPENCODE_CONFIG_DIR, 'opencode.json');
+
+/**
+ * Read a config file (supports JSON and JSONC)
+ */
+function readConfigFile(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return {};
+  }
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const normalized = content.trim();
+    if (!normalized) {
+      return {};
+    }
+    return parseJsonc(normalized, [], { allowTrailingComma: true });
+  } catch (error) {
+    console.error(`Failed to read config file: ${filePath}`, error);
+    return {};
+  }
+}
+
+/**
+ * Write config file with backup
+ */
+function writeConfigFile(config, filePath) {
+  try {
+    if (fs.existsSync(filePath)) {
+      const backupFile = `${filePath}.openchamber.backup`;
+      fs.copyFileSync(filePath, backupFile);
+      console.log(`Created config backup: ${backupFile}`);
+    }
+
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(config, null, 2), 'utf8');
+    console.log(`Successfully wrote config file: ${filePath}`);
+  } catch (error) {
+    console.error(`Failed to write config file: ${filePath}`, error);
+    throw new Error('Failed to write OpenCode configuration');
+  }
+}
+
+/**
+ * Get all possible project config paths in priority order
+ */
+function getProjectConfigCandidates(workingDirectory) {
+  if (!workingDirectory) return [];
+  return [
+    path.join(workingDirectory, 'opencode.json'),
+    path.join(workingDirectory, 'opencode.jsonc'),
+    path.join(workingDirectory, '.opencode', 'opencode.json'),
+    path.join(workingDirectory, '.opencode', 'opencode.jsonc'),
+  ];
+}
+
+/**
+ * Find existing project config file
+ */
+function getProjectConfigPath(workingDirectory) {
+  if (!workingDirectory) return null;
+
+  const candidates = getProjectConfigCandidates(workingDirectory);
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get provider sources - where a provider is defined
+ * Returns info about auth.json, user config, and project config
+ */
+function getProviderSources(providerId, workingDirectory) {
+  const sources = {
+    auth: false,
+    userConfig: false,
+    projectConfig: false,
+    userConfigPath: CONFIG_FILE,
+    projectConfigPath: null,
+  };
+
+  // Check auth.json
+  const AUTH_FILE = path.join(os.homedir(), '.local', 'share', 'opencode', 'auth.json');
+  if (fs.existsSync(AUTH_FILE)) {
+    try {
+      const authContent = fs.readFileSync(AUTH_FILE, 'utf8').trim();
+      if (authContent) {
+        const auth = JSON.parse(authContent);
+        sources.auth = !!auth[providerId];
+      }
+    } catch (error) {
+      console.error('Failed to read auth file:', error);
+    }
+  }
+
+  // Check user config
+  const userConfig = readConfigFile(CONFIG_FILE);
+  if (userConfig.provider && userConfig.provider[providerId]) {
+    sources.userConfig = true;
+  }
+
+  // Check project config
+  if (workingDirectory) {
+    const projectConfigPath = getProjectConfigPath(workingDirectory);
+    if (projectConfigPath) {
+      sources.projectConfigPath = projectConfigPath;
+      const projectConfig = readConfigFile(projectConfigPath);
+      if (projectConfig.provider && projectConfig.provider[providerId]) {
+        sources.projectConfig = true;
+      }
+    }
+  }
+
+  return sources;
+}
+
+/**
+ * Remove provider from config file
+ * @param {string} providerId - Provider ID to remove
+ * @param {string} scope - 'user' or 'project'
+ * @param {string|null} workingDirectory - Working directory for project scope
+ * @returns {boolean} - Whether provider was removed
+ */
+function removeProviderFromConfig(providerId, scope, workingDirectory) {
+  let configPath;
+  
+  if (scope === 'project' && workingDirectory) {
+    configPath = getProjectConfigPath(workingDirectory);
+    if (!configPath) {
+      console.log(`No project config found in ${workingDirectory}`);
+      return false;
+    }
+  } else {
+    configPath = CONFIG_FILE;
+  }
+
+  const config = readConfigFile(configPath);
+  
+  if (!config.provider || !config.provider[providerId]) {
+    console.log(`Provider ${providerId} not found in ${configPath}`);
+    return false;
+  }
+
+  delete config.provider[providerId];
+  
+  // Clean up empty provider section
+  if (Object.keys(config.provider).length === 0) {
+    delete config.provider;
+  }
+
+  writeConfigFile(config, configPath);
+  console.log(`Removed provider ${providerId} from ${scope} config: ${configPath}`);
+  return true;
+}
+
+/**
+ * Check if provider can be disconnected and from where
+ */
+function canDisconnectProvider(providerId, workingDirectory) {
+  const sources = getProviderSources(providerId, workingDirectory);
+  
+  return {
+    canDisconnect: sources.auth || sources.userConfig || sources.projectConfig,
+    sources: {
+      auth: sources.auth,
+      userConfig: sources.userConfig,
+      projectConfig: sources.projectConfig,
+    },
+    paths: {
+      userConfig: sources.userConfigPath,
+      projectConfig: sources.projectConfigPath,
+    }
+  };
+}
+
+export {
+  getProviderSources,
+  removeProviderFromConfig,
+  canDisconnectProvider,
+  readConfigFile,
+  writeConfigFile,
+  CONFIG_FILE,
+};


### PR DESCRIPTION
## Summary
Adds support for disconnecting providers configured directly in OpenCode's `opencode.json` config files, making it possible to remove providers from both user and project configurations via the UI.

## Changes
- Add new [provider-config.js](cci:7://file:///home/daoan/Projects/vms/openchamber/packages/web/server/lib/provider-config.js:0:0-0:0) module with source detection and config modification functions
- Enhance `DELETE /api/provider/:id/auth` endpoint to accept `scope` parameter (`auth`, `user`, [project](cci:1://file:///home/daoan/Projects/vms/openchamber/packages/desktop/src-tauri/src/main.rs:1322:0-1337:1))
- Add `GET /api/provider/:id/source` endpoint to detect where provider is configured
- Update [ProvidersPage.tsx](cci:7://file:///home/daoan/Projects/vms/openchamber/packages/ui/src/components/sections/providers/ProvidersPage.tsx:0:0-0:0) to display source info and separate disconnect buttons for each source

## Before/After
**Before:**
[Provider Name] API key: [input] [Save key] ─────────────────────────────── [Disconnect provider] ← Single button, only removes from auth.json

**After:**
[Provider Name] API key: [input] [Save key] ─────────────────────────────── Configured in: auth credentials, user config [Disconnect auth credentials] [Disconnect from user config]


### Screenshot
<img width="1264" height="702" alt="providers_privatemode_auth_1768712309872" src="https://github.com/user-attachments/assets/e5caebde-0139-4015-85ad-1db70e482140" />


## Why
Previously, only providers stored in `auth.json` (connected via OAuth/API key in UI) could be disconnected. Providers defined directly in `~/.config/opencode/opencode.json` (user level) or project-level `opencode.json` were not removable from the UI, causing confusion when users tried to disconnect them and nothing happened.

This change:
- Shows users exactly where their provider is configured ("Configured in: ...")
- Provides separate disconnect buttons for each configuration source
- Allows full control over provider management without manually editing config files
