### PR TITLE
Add chat setting to toggle hidden files (dotfiles)

### DIFF
--- a/packages/desktop/src/api/files.ts
+++ b/packages/desktop/src/api/files.ts
@@ -74,7 +74,8 @@ export const createDesktopFilesAPI = (): FilesAPI => ({
       const result = await safeInvoke<SearchFilesResponse>('search_files', {
         directory: normalizedDirectory,
         query: payload.query,
-        max_results: payload.maxResults || 100
+        max_results: payload.maxResults || 100,
+        include_hidden: payload.includeHidden ?? false,
       }, {
         timeout: 15000,
         onCancel: () => {

--- a/packages/ui/src/components/chat/FileMentionAutocomplete.tsx
+++ b/packages/ui/src/components/chat/FileMentionAutocomplete.tsx
@@ -7,6 +7,7 @@ import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import type { ProjectFileSearchHit } from '@/lib/opencode/client';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
+import { useDirectoryShowHidden } from '@/lib/directoryShowHidden';
 
 type FileInfo = ProjectFileSearchHit;
 
@@ -29,6 +30,7 @@ export const FileMentionAutocomplete = React.forwardRef<FileMentionHandle, FileM
   const { addServerFile } = useSessionStore();
   const searchFiles = useFileSearchStore((state) => state.searchFiles);
   const debouncedQuery = useDebouncedValue(searchQuery, 180);
+  const showHidden = useDirectoryShowHidden();
   const [files, setFiles] = React.useState<FileInfo[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [selectedIndex, setSelectedIndex] = React.useState(0);
@@ -120,7 +122,7 @@ export const FileMentionAutocomplete = React.forwardRef<FileMentionHandle, FileM
     let cancelled = false;
     setLoading(true);
 
-    searchFiles(currentDirectory, normalizedQueryLower, 80)
+    searchFiles(currentDirectory, normalizedQueryLower, 80, { includeHidden: showHidden })
       .then((hits) => {
         if (cancelled) {
           return;
@@ -158,7 +160,7 @@ export const FileMentionAutocomplete = React.forwardRef<FileMentionHandle, FileM
     return () => {
       cancelled = true;
     };
-  }, [currentDirectory, debouncedQuery, fuzzyScore, searchFiles]);
+  }, [currentDirectory, debouncedQuery, fuzzyScore, searchFiles, showHidden]);
 
   React.useEffect(() => {
     setSelectedIndex(0);

--- a/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
@@ -10,6 +10,10 @@ import { ButtonSmall } from '@/components/ui/button-small';
 import { NumberInput } from '@/components/ui/number-input';
 import { isVSCodeRuntime } from '@/lib/desktop';
 import { useDeviceInfo } from '@/lib/device';
+import {
+    setDirectoryShowHidden,
+    useDirectoryShowHidden,
+} from '@/lib/directoryShowHidden';
 
 interface Option<T extends string> {
     id: T;
@@ -78,6 +82,7 @@ interface OpenChamberVisualSettingsProps {
 
 export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps> = ({ visibleSettings }) => {
     const { isMobile } = useDeviceInfo();
+    const directoryShowHidden = useDirectoryShowHidden();
     const showReasoningTraces = useUIStore(state => state.showReasoningTraces);
     const setShowReasoningTraces = useUIStore(state => state.setShowReasoningTraces);
     const toolCallExpansion = useUIStore(state => state.toolCallExpansion);
@@ -473,6 +478,38 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
                         <p className="typography-meta text-muted-foreground/80 max-w-xl">
                             {DIFF_VIEW_MODE_OPTIONS.find((option) => option.id === diffViewMode)?.description}
                         </p>
+                    </div>
+
+                </div>
+            )}
+
+            {shouldShow('diffLayout') && !isVSCodeRuntime() && (
+                <div className="space-y-3">
+                    <div className="space-y-1">
+                        <h3 className="typography-ui-header font-semibold text-foreground">
+                            Hidden files (Chat)
+                        </h3>
+                        <p className="typography-meta text-muted-foreground/80">
+                            Show or hide dotfiles in file lists and directory pickers.
+                        </p>
+                    </div>
+
+                    <div className="flex flex-col gap-2">
+                        <div className="flex gap-1 w-fit">
+                            {[
+                                { id: 'hide', label: 'Hide', value: false },
+                                { id: 'show', label: 'Show', value: true },
+                            ].map((option) => (
+                                <ButtonSmall
+                                    key={option.id}
+                                    variant={directoryShowHidden === option.value ? 'default' : 'outline'}
+                                    className={cn(directoryShowHidden === option.value ? undefined : 'text-foreground')}
+                                    onClick={() => setDirectoryShowHidden(option.value)}
+                                >
+                                    {option.label}
+                                </ButtonSmall>
+                            ))}
+                        </div>
                     </div>
                 </div>
             )}

--- a/packages/ui/src/components/session/DirectoryExplorerDialog.tsx
+++ b/packages/ui/src/components/session/DirectoryExplorerDialog.tsx
@@ -22,8 +22,10 @@ import {
 import { useDeviceInfo } from '@/lib/device';
 import { MobileOverlayPanel } from '@/components/ui/MobileOverlayPanel';
 import { DirectoryAutocomplete, type DirectoryAutocompleteHandle } from './DirectoryAutocomplete';
-
-const SHOW_HIDDEN_STORAGE_KEY = 'directoryTreeShowHidden';
+import {
+  setDirectoryShowHidden,
+  useDirectoryShowHidden,
+} from '@/lib/directoryShowHidden';
 
 interface DirectoryExplorerDialogProps {
   open: boolean;
@@ -40,21 +42,7 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
   const [pathInputValue, setPathInputValue] = React.useState('');
   const [hasUserSelection, setHasUserSelection] = React.useState(false);
   const [isConfirming, setIsConfirming] = React.useState(false);
-  const [showHidden, setShowHidden] = React.useState<boolean>(() => {
-    if (typeof window === 'undefined') {
-      return false;
-    }
-    try {
-      const stored = window.localStorage.getItem(SHOW_HIDDEN_STORAGE_KEY);
-      if (stored === 'true') {
-        return true;
-      }
-      if (stored === 'false') {
-        return false;
-      }
-    } catch { /* ignored */ }
-    return false;
-  });
+  const showHidden = useDirectoryShowHidden();
   const { isDesktop, requestAccess, startAccessing } = useFileSystemAccess();
   const { isMobile } = useDeviceInfo();
   const [autocompleteVisible, setAutocompleteVisible] = React.useState(false);
@@ -92,15 +80,6 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
     }
   }, [open, hasUserSelection, pendingPath, homeDirectory, isHomeReady]);
 
-  // Persist show hidden setting
-  React.useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    try {
-      window.localStorage.setItem(SHOW_HIDDEN_STORAGE_KEY, showHidden ? 'true' : 'false');
-    } catch { /* ignored */ }
-  }, [showHidden]);
 
   const handleClose = React.useCallback(() => {
     onOpenChange(false);
@@ -220,8 +199,8 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
   }, []);
 
   const toggleShowHidden = React.useCallback(() => {
-    setShowHidden(prev => !prev);
-  }, []);
+    setDirectoryShowHidden(!showHidden);
+  }, [showHidden]);
 
 
 

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -322,6 +322,7 @@ export interface FileSearchQuery {
   directory: string;
   query: string;
   maxResults?: number;
+  includeHidden?: boolean;
 }
 
 export interface FileSearchResult {
@@ -576,4 +577,3 @@ export interface SkillsInstallResponse {
   skipped?: Array<{ skillName: string; reason: string }>;
   error?: SkillsInstallError;
 }
-

--- a/packages/ui/src/lib/directoryShowHidden.ts
+++ b/packages/ui/src/lib/directoryShowHidden.ts
@@ -1,0 +1,60 @@
+import React from 'react';
+import { getSafeStorage } from '@/stores/utils/safeStorage';
+
+const SHOW_HIDDEN_STORAGE_KEY = 'directoryTreeShowHidden';
+const SHOW_HIDDEN_EVENT = 'directory-show-hidden-change';
+
+const readStoredShowHidden = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    const stored = getSafeStorage().getItem(SHOW_HIDDEN_STORAGE_KEY);
+    return stored === 'true';
+  } catch {
+    return false;
+  }
+};
+
+export const notifyDirectoryShowHiddenChanged = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.dispatchEvent(new Event(SHOW_HIDDEN_EVENT));
+};
+
+export const setDirectoryShowHidden = (value: boolean) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    getSafeStorage().setItem(SHOW_HIDDEN_STORAGE_KEY, value ? 'true' : 'false');
+    notifyDirectoryShowHiddenChanged();
+  } catch {
+    // ignore storage errors
+  }
+};
+
+export const useDirectoryShowHidden = (): boolean => {
+  const [showHidden, setShowHidden] = React.useState(readStoredShowHidden);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const handleChange = () => {
+      setShowHidden(readStoredShowHidden());
+    };
+
+    window.addEventListener('storage', handleChange);
+    window.addEventListener(SHOW_HIDDEN_EVENT, handleChange);
+    return () => {
+      window.removeEventListener('storage', handleChange);
+      window.removeEventListener(SHOW_HIDDEN_EVENT, handleChange);
+    };
+  }, []);
+
+  return showHidden;
+};
+
+export const DIRECTORY_SHOW_HIDDEN_STORAGE_KEY = SHOW_HIDDEN_STORAGE_KEY;

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -1753,7 +1753,10 @@ class OpencodeService {
     }
   }
 
-  async searchFiles(query: string, options?: { directory?: string | null; limit?: number }): Promise<ProjectFileSearchHit[]> {
+  async searchFiles(
+    query: string,
+    options?: { directory?: string | null; limit?: number; includeHidden?: boolean }
+  ): Promise<ProjectFileSearchHit[]> {
     const desktopFiles = getDesktopFilesApi();
     const directory = typeof options?.directory === 'string' && options.directory.trim().length > 0
       ? options.directory.trim()
@@ -1766,6 +1769,7 @@ class OpencodeService {
           directory: directory || '',
           query,
           maxResults: options?.limit,
+          includeHidden: options?.includeHidden,
         });
 
         if (!Array.isArray(results)) {
@@ -1808,6 +1812,9 @@ class OpencodeService {
     }
     if (typeof options?.limit === 'number' && Number.isFinite(options.limit)) {
       params.set('limit', String(options.limit));
+    }
+    if (options?.includeHidden) {
+      params.set('includeHidden', 'true');
     }
 
     const searchUrl = `${this.baseUrl}/fs/search${params.toString() ? `?${params.toString()}` : ''}`;

--- a/packages/vscode/webview/api/files.ts
+++ b/packages/vscode/webview/api/files.ts
@@ -36,6 +36,7 @@ export const createVSCodeFilesAPI = (): FilesAPI => ({
       directory: normalizePath(payload.directory),
       query: payload.query,
       limit: payload.maxResults,
+      includeHidden: payload.includeHidden,
     });
 
     const files = Array.isArray(data?.files) ? data.files : [];

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -367,7 +367,13 @@ const handleLocalApiRequest = async (url: URL, init?: RequestInit) => {
     const limitParam = url.searchParams.get('limit');
     const limit = limitParam ? Number(limitParam) : undefined;
     const resolvedLimit = Number.isFinite(limit) ? limit : undefined;
-    const data = await sendBridgeMessage('api:fs:search', { directory, query, limit: resolvedLimit });
+    const includeHidden = url.searchParams.get('includeHidden') === 'true';
+    const data = await sendBridgeMessage('api:fs:search', {
+      directory,
+      query,
+      limit: resolvedLimit,
+      includeHidden,
+    });
     return new Response(JSON.stringify(data), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
 

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -68,11 +68,13 @@ const normalizeRelativeSearchPath = (rootPath, targetPath) => {
   return relative.split(path.sep).join('/') || targetPath;
 };
 
-const shouldSkipSearchDirectory = (name) => {
+const shouldSkipSearchDirectory = (name, includeHidden) => {
   if (!name) {
     return false;
   }
-  // allow dot dirs/files; still skip excluded dirs below
+  if (!includeHidden && name.startsWith('.')) {
+    return true;
+  }
   return FILE_SEARCH_EXCLUDED_DIRS.has(name.toLowerCase());
 };
 
@@ -157,7 +159,8 @@ const fuzzyMatchScoreNormalized = (normalizedQuery, candidate) => {
 };
 
 const searchFilesystemFiles = async (rootPath, options) => {
-  const { limit, query } = options;
+  const { limit, query, includeHidden } = options;
+  const includeHiddenEntries = Boolean(includeHidden);
   const normalizedQuery = query.trim().toLowerCase();
   const matchAll = normalizedQuery.length === 0;
   const queue = [rootPath];
@@ -176,14 +179,14 @@ const searchFilesystemFiles = async (rootPath, options) => {
 
       for (const dirent of dirents) {
         const entryName = dirent.name;
-        if (!entryName) {
+        if (!entryName || (!includeHiddenEntries && entryName.startsWith('.'))) {
           continue;
         }
 
         const entryPath = path.join(currentDir, entryName);
 
         if (dirent.isDirectory()) {
-          if (shouldSkipSearchDirectory(entryName)) {
+          if (shouldSkipSearchDirectory(entryName, includeHiddenEntries)) {
             continue;
           }
           if (!visited.has(entryPath)) {
@@ -4320,6 +4323,7 @@ async function main(options = {}) {
         ? req.query.directory.trim()
         : os.homedir();
     const rawQuery = typeof req.query.q === 'string' ? req.query.q : '';
+    const includeHidden = req.query.includeHidden === 'true';
     const limitParam = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : undefined;
     const parsedLimit = Number.isFinite(limitParam) ? Number(limitParam) : DEFAULT_FILE_SEARCH_LIMIT;
     const limit = Math.max(1, Math.min(parsedLimit, MAX_FILE_SEARCH_LIMIT));
@@ -4331,7 +4335,11 @@ async function main(options = {}) {
         return res.status(400).json({ error: 'Specified root is not a directory' });
       }
 
-      const files = await searchFilesystemFiles(resolvedRoot, { limit, query: rawQuery || '' });
+      const files = await searchFilesystemFiles(resolvedRoot, {
+        limit,
+        query: rawQuery || '',
+        includeHidden,
+      });
       res.json({
         root: resolvedRoot,
         count: files.length,

--- a/packages/web/src/api/files.ts
+++ b/packages/web/src/api/files.ts
@@ -83,6 +83,9 @@ export const createWebFilesAPI = (): FilesAPI => ({
     if (typeof payload.maxResults === 'number' && Number.isFinite(payload.maxResults)) {
       params.set('limit', String(payload.maxResults));
     }
+    if (payload.includeHidden) {
+      params.set('includeHidden', 'true');
+    }
 
     const response = await fetch(`/api/fs/search?${params.toString()}`);
 


### PR DESCRIPTION
## Summary
- add a global "Hidden files" toggle in Chat settings tied to "directoryTreeShowHidden"
- render the toggle on mobile and desktop (excluding VS Code runtime)

## UI impact
- file tree in the Files view
- directory picker dialog ("Add project directory")
- directory autocomplete suggestions
