### PR TITLE
Fix mobile scrolling for CommandAutocomplete dropdown

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -325,8 +325,6 @@ html:not(.dark) .chat-scroll {
 .overlay-scrollbar-target {
   scrollbar-width: none !important;
   -ms-overflow-style: none !important;
-  touch-action: pan-y;
-  -webkit-overflow-scrolling: touch;
 }
 
 .overlay-scrollbar-target::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

Fixes scrolling in the **CommandAutocomplete** suggestions dropdown on mobile by ensuring vertical touch gestures are handled by the dropdown itself (instead of getting blocked / scrolling the page), and enabling smoother scrolling on WebKit.

## What changed

* **`packages/ui/src/components/chat/CommandAutocomplete.tsx`**

  * Added `style={{ touchAction: "pan-y" }}` to the dropdown container.
  * Removed `fillContainer={false}` from `ScrollableOverlay` so the overlay can behave correctly with its scroll area.

* **`packages/ui/src/index.css`**

  * Added `touch-action: pan-y;` and `-webkit-overflow-scrolling: touch;` to `.chat-scroll .overlay-scrollbar-target` to improve mobile scrolling behavior (including iOS momentum scrolling).

## Why

On mobile, the autocomplete dropdown could become impossible to scroll when the suggestions overflowed the visible area. These changes make the dropdown reliably capture vertical swipes and scroll smoothly.

## Demo (video)

Upload the video(s) to GitHub (drag & drop into the PR/issue description box) and paste the generated links here:

### Before

https://github.com/user-attachments/assets/00960464-0794-45f4-9872-78dbf5edbf90



### After

https://github.com/user-attachments/assets/bf2b3a23-99d2-4be8-be52-f8cfb9bb7b6e

