### PR TITLE
feat: Show Cancel Button on both desktop and mobile

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1319,8 +1319,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
         };
     }, []);
 
-    // For mobile only, show abort in StatusRow; desktop and vscode show in footer (Esc-triggered)
-    const showAbortInStatusRow = isMobile && canAbort;
+    // Show abort button in StatusRow for all screen sizes when operation can be aborted
+    const showAbortInStatusRow = canAbort;
 
     return (
 


### PR DESCRIPTION
I've noticed this handy cancel button on mobile that doesn't show up on desktop for some reason. This just adds it there
