### PR TITLE
fix: return empty list for plans directory instead of 404

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -6619,6 +6619,10 @@ async function main(options = {}) {
         console.error('Failed to list directory:', error);
       }
       if (code === 'ENOENT') {
+        // For plans directory, return empty list instead of 404 to avoid console noise
+        if (isPlansPath) {
+          return res.json({ path: resolvedPath, entries: [] });
+        }
         return res.status(404).json({ error: 'Directory not found' });
       }
       if (code === 'EACCES') {


### PR DESCRIPTION
## Summary

When the plans directory (`.opencode/plans`) does not exist, return an empty list instead of a 404 error to avoid console noise.

## Motivation

The server was logging errors to console when the plans directory doesn't exist, creating unnecessary noise. Since the frontend already handles directory listing errors silently, this change aligns the server behavior with frontend expectations.

## Changes

- Modified `packages/web/server/index.js` to return `{}` with empty `entries` array when `ENOENT` error occurs on plans directory path, instead of returning 404 status.

## Verification

- Frontend already handles directory listing errors silently by catching exceptions and displaying empty list
- No breaking changes to existing functionality