### PR TITLE
fix: improve git diff --no-index error handling

### DIFF
--- a/packages/web/server/lib/git-service.js
+++ b/packages/web/server/lib/git-service.js
@@ -428,7 +428,8 @@ export async function getDiff(directory, { path, staged = false, contextLines = 
         const noIndexDiff = await git.raw(noIndexArgs);
         return noIndexDiff;
       } catch (noIndexError) {
-        if (noIndexError.message && noIndexError.message.includes('diff --git')) {
+        // git diff --no-index returns exit code 1 when differences exist (not a real error)
+        if (noIndexError.exitCode === 1 && noIndexError.message) {
           return noIndexError.message;
         }
         throw noIndexError;


### PR DESCRIPTION
## Problem

When viewing diff for untracked files, the code uses `git diff --no-index` to compare `/dev/null` with the new file. However, `git diff --no-index` returns **exit code 1** when differences exist (which is expected behavior for new files), causing `simple-git` to throw an error.

The previous fix checked if `error.message` contains `'diff --git'` to identify this case, but this approach is fragile:
- It relies on parsing output content rather than the documented exit code behavior
- It may fail with localized git messages or different git versions
- The diff output might not always start with `'diff --git'`

## Solution

Check `exitCode === 1` instead of message content. According to git documentation, exit code 1 specifically indicates "differences found" for diff commands, making this a more reliable and semantically correct check.

## Changes

- Updated error handling in `getDiff()` function in `packages/web/server/lib/git-service.js`