### PR TITLE
feat: implement multi-file tabs (desktop) and dropdown (mobile) in FilesView

### DIFF
--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -1513,11 +1513,11 @@ export const FilesView: React.FC = () => {
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="inline-flex min-w-0 items-center gap-1 text-left typography-ui-label font-medium"
+                    className="inline-flex min-w-0 max-w-full items-center gap-1 text-left typography-ui-label font-medium"
                     aria-label="Open files"
                   >
-                    <span className="truncate">{selectedFile.name}</span>
-                    <RiArrowDownSLine className="h-4 w-4 text-muted-foreground" />
+                    <span className="min-w-0 flex-1 truncate">{selectedFile.name}</span>
+                    <RiArrowDownSLine className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="min-w-[16rem]">


### PR DESCRIPTION
### Summary

Introduces a session-local multi-file state to the `FilesView` component, allowing users to keep multiple files open and switch between them via a tabbed interface (desktop) or a dropdown menu (mobile).

<img width="2026" height="1199" alt="image" src="https://github.com/user-attachments/assets/ab000f05-05cc-40c0-a32d-1adcf4dc285f" />
<img width="391" height="840" alt="image" src="https://github.com/user-attachments/assets/3433c5ef-28b4-464b-b908-b53607dc9d7a" />
<img width="388" height="840" alt="image" src="https://github.com/user-attachments/assets/3459189c-a10c-4dbf-aef9-6eb2623bd5d1" />
