### PR TITLE
Fixed OpenCode GitHub url

### DIFF
--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -275,7 +275,7 @@ export function createOpenCodeManager(_context: vscode.ExtensionContext): OpenCo
           'More Info'
         ).then(selection => {
           if (selection === 'More Info') {
-            vscode.env.openExternal(vscode.Uri.parse('https://github.com/opencode-ai/opencode'));
+            vscode.env.openExternal(vscode.Uri.parse('https://github.com/anomalyco/opencode'));
           }
         });
       } else {


### PR DESCRIPTION
When installing in VS Code, and the opencode binary was missing, it redirected to the wrong opencode GitHub page.