### PR TITLE
fix(vscode): Change Health Check to Health API Endpoint and increase timeout

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -415,6 +415,7 @@ export async function activate(context: vscode.ExtensionContext) {
       };
 
       const probeTargets: Array<{ label: string; path: string; includeDirectory?: boolean; timeoutMs?: number }> = [
+        { label: 'health', path: '/global/health', includeDirectory: false },
         { label: 'config', path: '/config', includeDirectory: true },
         { label: 'providers', path: '/config/providers', includeDirectory: true },
         // Can be slower on large configs; keep the probe from producing false negatives.
@@ -446,6 +447,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const lines = [
         `Time: ${new Date().toISOString()}`,
         `OpenChamber version: ${extensionVersion || '(unknown)'}`,
+        `OpenCode Version: ${debug?.version ?? '(unknown)'}`,
         `VS Code version: ${vscode.version}`,
         `Platform: ${process.platform} ${process.arch}`,
         `Workspace folders: ${workspaceFolders.length}${workspaceFolders.length ? ` (${workspaceFolders.join(', ')})` : ''}`,


### PR DESCRIPTION
It looks like that this increased stability on windows. But lets see how it effects it. I do not see a regression for linux, and health shoudl in theory be used for health checking instead of config especially if the result is not used.

Added a debug output for the Manager to add additional logging if the healthcheck failed we could get additional logs from there. 

Can be deleted in the future if this fix works