### PR TITLE
fix(terminal): prevent native caret blink in terminal focus inputs

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -700,8 +700,74 @@ html:not(.dark) .chat-scroll {
 }
 
 /* Hide system caret in terminal - targets both Ghostty internal input and our custom touch input */
-.terminal-viewport-container textarea {
+.terminal-viewport-container textarea,
+.terminal-viewport-container input {
   caret-color: transparent !important;
+}
+
+.terminal-viewport-container [contenteditable="true"][aria-label="Terminal input"] {
+  caret-color: transparent !important;
+  outline: none !important;
+}
+
+[contenteditable="true"][aria-label="Terminal input"] {
+  caret-color: transparent !important;
+  outline: none !important;
+}
+
+/* Keep Ghostty's internal focus textarea fully non-painting on desktop. */
+.terminal-viewport-container textarea:not([data-terminal-hidden-input="true"]) {
+  opacity: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  font-size: 0 !important;
+  line-height: 0 !important;
+  clip-path: inset(100%) !important;
+  color: transparent !important;
+  -webkit-text-fill-color: transparent !important;
+  background: transparent !important;
+  border: 0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+  text-shadow: none !important;
+}
+
+textarea[aria-label="Terminal input"],
+input[aria-label="Terminal input"] {
+  caret-color: transparent !important;
+  color: transparent !important;
+  -webkit-text-fill-color: transparent !important;
+  opacity: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  clip-path: inset(100%) !important;
+  outline: none !important;
+}
+
+/* Terminal touch input is portaled to document.body; keep it fully non-painting across engines. */
+input[data-terminal-hidden-input="true"],
+textarea[data-terminal-hidden-input="true"] {
+  caret-color: transparent !important;
+  color: transparent !important;
+  -webkit-text-fill-color: transparent !important;
+  background: transparent !important;
+  border: 0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+  text-shadow: none !important;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+input[data-terminal-hidden-input="true"]::selection,
+textarea[data-terminal-hidden-input="true"]::selection {
+  background: transparent;
+  color: transparent;
+}
+
+input[data-terminal-hidden-input="true"]::placeholder,
+textarea[data-terminal-hidden-input="true"]::placeholder {
+  color: transparent !important;
 }
 
 /* Mobile Terminal Optimizations */


### PR DESCRIPTION
## Summary
- tighten terminal hidden-input activation so desktop/fine-pointer environments avoid the mobile overlay path
- harden Ghostty focus-node masking (`textarea` + `contenteditable`) to prevent native caret rendering flashes
- add global terminal input caret suppression rules to cover internal and portaled focus elements

## Verification
- bun run type-check
- bun run lint
- bun run build