### PR TITLE
feat: Add ability to navigate through message history with arrows and persist message draft setting

### DIFF
--- a/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
@@ -93,9 +93,9 @@ const VisualSectionContent: React.FC = () => {
     return <OpenChamberVisualSettings visibleSettings={['theme', 'fontSize', 'terminalFontSize', 'spacing', 'cornerRadius', 'inputBarOffset', 'terminalQuickKeys']} />;
 };
 
-// Chat section: Default Tool Output, Diff layout, Show reasoning traces, Queue mode
+// Chat section: Default Tool Output, Diff layout, Show reasoning traces, Queue mode, Persist draft
 const ChatSectionContent: React.FC = () => {
-    return <OpenChamberVisualSettings visibleSettings={['toolOutput', 'diffLayout', 'dotfiles', 'reasoning', 'textJustificationActivity', 'queueMode']} />;
+    return <OpenChamberVisualSettings visibleSettings={['toolOutput', 'diffLayout', 'dotfiles', 'reasoning', 'textJustificationActivity', 'queueMode', 'persistDraft']} />;
 };
 
 // Sessions section: Default model & agent, Session retention, Memory limits

--- a/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
@@ -82,7 +82,7 @@ const DIFF_VIEW_MODE_OPTIONS: Option<'single' | 'stacked'>[] = [
     },
 ];
 
-export type VisibleSetting = 'theme' | 'fontSize' | 'terminalFontSize' | 'spacing' | 'cornerRadius' | 'inputBarOffset' | 'toolOutput' | 'diffLayout' | 'dotfiles' | 'reasoning' | 'queueMode' | 'textJustificationActivity' | 'terminalQuickKeys';
+export type VisibleSetting = 'theme' | 'fontSize' | 'terminalFontSize' | 'spacing' | 'cornerRadius' | 'inputBarOffset' | 'toolOutput' | 'diffLayout' | 'dotfiles' | 'reasoning' | 'queueMode' | 'textJustificationActivity' | 'terminalQuickKeys' | 'persistDraft';
 
 interface OpenChamberVisualSettingsProps {
     /** Which settings to show. If undefined, shows all. */
@@ -116,6 +116,8 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
     const setShowTerminalQuickKeysOnDesktop = useUIStore(state => state.setShowTerminalQuickKeysOnDesktop);
     const queueModeEnabled = useMessageQueueStore(state => state.queueModeEnabled);
     const setQueueMode = useMessageQueueStore(state => state.setQueueMode);
+    const persistChatDraft = useUIStore(state => state.persistChatDraft);
+    const setPersistChatDraft = useUIStore(state => state.setPersistChatDraft);
     const {
         themeMode,
         setThemeMode,
@@ -753,6 +755,23 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
                         {queueModeEnabled 
                             ? `Enter queues messages, ${getModifierLabel()}+Enter sends immediately.` 
                             : `Enter sends immediately, ${getModifierLabel()}+Enter queues messages.`}
+                    </p>
+                </div>
+            )}
+
+            {shouldShow('persistDraft') && (
+                <div className="space-y-2">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                        <Checkbox
+                            checked={persistChatDraft}
+                            onChange={setPersistChatDraft}
+                        />
+                        <span className="typography-ui-header font-semibold text-foreground">
+                            Persist chat input draft
+                        </span>
+                    </label>
+                    <p className="typography-meta text-muted-foreground pl-5">
+                        Save your typed message across page reloads and session switches.
                     </p>
                 </div>
             )}

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -74,6 +74,7 @@ interface UIStore {
   notifyOnSubtasks: boolean;
 
   showTerminalQuickKeysOnDesktop: boolean;
+  persistChatDraft: boolean;
 
   setTheme: (theme: 'light' | 'dark' | 'system') => void;
   toggleSidebar: () => void;
@@ -133,6 +134,7 @@ interface UIStore {
   setNotificationMode: (mode: 'always' | 'hidden-only') => void;
   setShowTerminalQuickKeysOnDesktop: (value: boolean) => void;
   setNotifyOnSubtasks: (value: boolean) => void;
+  setPersistChatDraft: (value: boolean) => void;
   openMultiRunLauncher: () => void;
   openMultiRunLauncherWithPrompt: (prompt: string) => void;
 }
@@ -196,6 +198,7 @@ export const useUIStore = create<UIStore>()(
         notifyOnSubtasks: true,
 
         showTerminalQuickKeysOnDesktop: false,
+        persistChatDraft: true,
 
         setTheme: (theme) => {
           set({ theme });
@@ -681,6 +684,10 @@ export const useUIStore = create<UIStore>()(
         setNotifyOnSubtasks: (value) => {
           set({ notifyOnSubtasks: value });
         },
+
+        setPersistChatDraft: (value) => {
+          set({ persistChatDraft: value });
+        },
       }),
       {
         name: 'ui-store',
@@ -718,6 +725,7 @@ export const useUIStore = create<UIStore>()(
           notificationMode: state.notificationMode,
           showTerminalQuickKeysOnDesktop: state.showTerminalQuickKeysOnDesktop,
           notifyOnSubtasks: state.notifyOnSubtasks,
+          persistChatDraft: state.persistChatDraft,
         })
       }
     ),


### PR DESCRIPTION
Fixes #322 and #320 

-Up arrow navigates back through chat message history if at start of text box
-Down arrow navigates forward if at end of text box
-New setting added to persist chat drafts - will restore the text if the page is refreshed. When switching sessions, any previously entered text is retained, but selected so a user can start typing immediately