### PR TITLE
feat: Add usage prediction and pace to usage dropdown and settings

### DIFF
--- a/packages/ui/src/components/sections/usage/PaceIndicator.tsx
+++ b/packages/ui/src/components/sections/usage/PaceIndicator.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import type { PaceInfo } from '@/lib/quota';
+import { getPaceStatusColor, formatRemainingTime } from '@/lib/quota';
+
+interface PaceIndicatorProps {
+  paceInfo: PaceInfo;
+  className?: string;
+  /** Compact mode shows just the status dot and prediction */
+  compact?: boolean;
+}
+
+/**
+ * Visual indicator showing whether usage is on track, slightly fast, or too fast.
+ * Inspired by opencode-bar's pace visualization.
+ */
+export const PaceIndicator: React.FC<PaceIndicatorProps> = ({
+  paceInfo,
+  className,
+  compact = false,
+}) => {
+  const statusColor = getPaceStatusColor(paceInfo.status);
+
+  const statusLabel = React.useMemo(() => {
+    switch (paceInfo.status) {
+      case 'on-track':
+        return 'On track';
+      case 'slightly-fast':
+        return 'Slightly fast';
+      case 'too-fast':
+        return 'Too fast';
+      case 'exhausted':
+        return 'Used up';
+    }
+  }, [paceInfo.status]);
+
+  const predictionTooltip = `Predicted usage at window end based on current pace: ${paceInfo.predictText}`;
+
+  if (compact) {
+    return (
+      <div className={cn('flex items-center gap-1.5', className)}>
+        <div
+          className="h-2 w-2 rounded-full flex-shrink-0"
+          style={{ backgroundColor: statusColor }}
+          title={statusLabel}
+        />
+        <span
+          className="typography-micro tabular-nums"
+          style={{ color: statusColor }}
+          title={paceInfo.isExhausted ? undefined : predictionTooltip}
+        >
+          {paceInfo.isExhausted ? (
+            <>Wait {formatRemainingTime(paceInfo.remainingSeconds)}</>
+          ) : (
+            <>Pred: {paceInfo.predictText}</>
+          )}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('flex items-center justify-between gap-2', className)}>
+      <div className="flex items-center gap-1.5">
+        {!paceInfo.isExhausted && (
+          <span className="typography-micro text-muted-foreground">
+            Pace: {paceInfo.paceRateText}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span
+          className="typography-micro tabular-nums"
+          style={{ color: statusColor }}
+        >
+          {paceInfo.isExhausted ? (
+            <>
+              <span className="font-medium">{statusLabel}</span>
+              <span className="text-muted-foreground"> · Wait </span>
+              <span className="font-medium">{formatRemainingTime(paceInfo.remainingSeconds)}</span>
+            </>
+          ) : (
+            <span title={predictionTooltip}>
+              <span className="text-muted-foreground">Pred: </span>
+              <span className="font-medium">{paceInfo.predictText}</span>
+            </span>
+          )}
+        </span>
+        <div
+          className="h-2 w-2 rounded-full flex-shrink-0"
+          style={{ backgroundColor: statusColor }}
+          title={statusLabel}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/components/sections/usage/UsageCard.tsx
+++ b/packages/ui/src/components/sections/usage/UsageCard.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import type { UsageWindow } from '@/types';
-import { formatPercent, formatWindowLabel } from '@/lib/quota';
+import { formatPercent, formatWindowLabel, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
 import { UsageProgressBar } from './UsageProgressBar';
+import { PaceIndicator } from './PaceIndicator';
 import { useQuotaStore } from '@/stores/useQuotaStore';
 import { Switch } from '@/components/ui/switch';
 
@@ -29,6 +30,21 @@ export const UsageCard: React.FC<UsageCardProps> = ({
   const resetLabel = window.resetAfterFormatted ?? window.resetAtFormatted ?? '';
   const windowLabel = formatWindowLabel(title);
 
+  // Calculate pace info for the usage window
+  // Pass the title (window label) to infer windowSeconds when not provided by the API
+  const paceInfo = React.useMemo(() => {
+    return calculatePace(window.usedPercent, window.resetAt, window.windowSeconds, title);
+  }, [window.usedPercent, window.resetAt, window.windowSeconds, title]);
+
+  // Calculate expected marker position for weekly/monthly quotas
+  const expectedMarkerPercent = React.useMemo(() => {
+    if (!paceInfo || paceInfo.dailyAllocationPercent === null) {
+      return null;
+    }
+    // Show marker based on elapsed time ratio
+    return calculateExpectedUsagePercent(paceInfo.elapsedRatio);
+  }, [paceInfo]);
+
   return (
     <div className="rounded-xl border border-[var(--interactive-border)] bg-[var(--surface-elevated)]/60 p-4 shadow-sm">
       <div className="flex items-center justify-between gap-3">
@@ -52,11 +68,22 @@ export const UsageCard: React.FC<UsageCardProps> = ({
       </div>
 
       <div className="mt-3">
-        <UsageProgressBar percent={displayPercent} tonePercent={window.usedPercent} />
+        <UsageProgressBar
+          percent={displayPercent}
+          tonePercent={window.usedPercent}
+          expectedMarkerPercent={expectedMarkerPercent}
+        />
         <div className="mt-1 text-right typography-micro text-muted-foreground text-[10px]">
           {barLabel}
         </div>
       </div>
+
+      {/* Pace indicator - only shown when we have pace info */}
+      {paceInfo && (
+        <div className="mt-2">
+          <PaceIndicator paceInfo={paceInfo} />
+        </div>
+      )}
 
       <div className="mt-3 flex items-center justify-between text-muted-foreground">
         <span className="typography-micro">Resets</span>

--- a/packages/ui/src/components/sections/usage/UsagePage.tsx
+++ b/packages/ui/src/components/sections/usage/UsagePage.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/collapsible';
 import { RiArrowDownSLine, RiArrowRightSLine } from '@remixicon/react';
 import type { UsageWindows, QuotaProviderId } from '@/types';
-import { getAllModelFamilies, sortModelFamilies, groupModelsByFamilyWithGetter } from '@/lib/quota/model-families';
+import { getAllModelFamilies, getDisplayModelName, sortModelFamilies, groupModelsByFamilyWithGetter } from '@/lib/quota/model-families';
 
 const formatTime = (timestamp: number | null) => {
   if (!timestamp) return '-';
@@ -257,7 +257,7 @@ export const UsagePage: React.FC = () => {
                         <UsageCard
                           key={model.name}
                           title={label}
-                          subtitle={model.name}
+                          subtitle={getDisplayModelName(model.name)}
                           window={window}
                           showToggle
                           toggleEnabled={isSelected}
@@ -306,7 +306,7 @@ export const UsagePage: React.FC = () => {
                         <UsageCard
                           key={model.name}
                           title={label}
-                          subtitle={model.name}
+                          subtitle={getDisplayModelName(model.name)}
                           window={window}
                           showToggle
                           toggleEnabled={isSelected}

--- a/packages/ui/src/components/sections/usage/UsageProgressBar.tsx
+++ b/packages/ui/src/components/sections/usage/UsageProgressBar.tsx
@@ -6,11 +6,24 @@ interface UsageProgressBarProps {
   percent: number | null;
   tonePercent?: number | null;
   className?: string;
+  /** 
+   * Position (0-100) to show a marker indicating expected usage based on time elapsed.
+   * Used for weekly/monthly quotas to show where usage "should" be if evenly distributed.
+   */
+  expectedMarkerPercent?: number | null;
 }
 
-export const UsageProgressBar: React.FC<UsageProgressBarProps> = ({ percent, tonePercent, className }) => {
+export const UsageProgressBar: React.FC<UsageProgressBarProps> = ({
+  percent,
+  tonePercent,
+  className,
+  expectedMarkerPercent,
+}) => {
   const clamped = clampPercent(percent) ?? 0;
   const tone = resolveUsageTone(tonePercent ?? percent);
+  const markerClamped = expectedMarkerPercent != null
+    ? Math.max(0, Math.min(100, expectedMarkerPercent))
+    : null;
 
   const fillStyle = tone === 'critical'
     ? { backgroundColor: 'var(--status-error)' }
@@ -19,7 +32,7 @@ export const UsageProgressBar: React.FC<UsageProgressBarProps> = ({ percent, ton
       : { backgroundColor: 'var(--status-success)' };
 
   return (
-    <div className={cn('h-2.5 rounded-full bg-[var(--interactive-border)] overflow-hidden', className)}>
+    <div className={cn('relative h-2.5 rounded-full bg-[var(--interactive-border)] overflow-hidden', className)}>
       <div
         className="h-full transition-all duration-300"
         style={{ ...fillStyle, width: `${clamped}%` }}
@@ -28,6 +41,14 @@ export const UsageProgressBar: React.FC<UsageProgressBarProps> = ({ percent, ton
         aria-valuemin={0}
         aria-valuemax={100}
       />
+      {markerClamped != null && markerClamped > 0 && markerClamped < 100 && (
+        <div
+          className="absolute top-0 h-full w-0.5 bg-foreground"
+          style={{ left: `${markerClamped}%` }}
+          title={`Expected usage if spread evenly: ${Math.round(markerClamped)}% of quota`}
+          aria-hidden="true"
+        />
+      )}
     </div>
   );
 };

--- a/packages/ui/src/lib/quota/index.ts
+++ b/packages/ui/src/lib/quota/index.ts
@@ -1,3 +1,14 @@
 export { QUOTA_PROVIDERS, QUOTA_PROVIDER_MAP } from './providers';
 export type { QuotaProviderMeta } from './providers';
-export { clampPercent, formatPercent, resolveUsageTone, formatWindowLabel } from './utils';
+export {
+  clampPercent,
+  formatPercent,
+  resolveUsageTone,
+  formatWindowLabel,
+  calculatePace,
+  inferWindowSeconds,
+  getPaceStatusColor,
+  formatRemainingTime,
+  calculateExpectedUsagePercent,
+} from './utils';
+export type { PaceStatus, PaceInfo } from './utils';

--- a/packages/ui/src/lib/quota/utils.ts
+++ b/packages/ui/src/lib/quota/utils.ts
@@ -40,3 +40,203 @@ export const formatWindowLabel = (label: string): string => {
   if (label === 'premium_interactions') return 'Premium interactions';
   return label;
 };
+
+/**
+ * Pace status indicating whether usage is on track, slightly fast, or too fast
+ */
+export type PaceStatus = 'on-track' | 'slightly-fast' | 'too-fast' | 'exhausted';
+
+/**
+ * Information about the current pace of usage
+ */
+export interface PaceInfo {
+  /** Ratio of time elapsed in the window (0-1) */
+  elapsedRatio: number;
+  /** Ratio of quota used (0-1) */
+  usageRatio: number;
+  /** Predicted final usage percentage at end of window */
+  predictedFinalPercent: number;
+  /** Seconds remaining until reset */
+  remainingSeconds: number;
+  /** Whether usage is exhausted (100% used with time remaining) */
+  isExhausted: boolean;
+  /** Elapsed seconds in the window */
+  elapsedSeconds: number;
+  /** Total window duration in seconds */
+  totalSeconds: number;
+  /** Current pace status */
+  status: PaceStatus;
+  /** Per-unit pace rate (e.g., "2.5%/h" or "15%/d") */
+  paceRateText: string;
+  /** Prediction text (e.g., "85%" or "+120%") */
+  predictText: string;
+  /** For weekly quotas: the per-day allocation percentage */
+  dailyAllocationPercent: number | null;
+}
+
+/**
+ * Infer window duration in seconds from a window label.
+ * Used when the API doesn't provide windowSeconds directly.
+ */
+export const inferWindowSeconds = (label: string): number | null => {
+  const normalized = label.toLowerCase().trim();
+  
+  // Exact matches
+  if (normalized === '5h') return 5 * 3600;
+  if (normalized === '7d' || normalized === 'weekly' || normalized === '7d-sonnet' || normalized === '7d-opus') return 7 * 86400;
+  if (normalized === 'monthly') return 30 * 86400;
+  if (normalized === '24h' || normalized === 'daily') return 86400;
+  if (normalized === '1h') return 3600;
+  
+  // Pattern matches
+  const hourMatch = normalized.match(/^(\d+)h$/);
+  if (hourMatch) return parseInt(hourMatch[1], 10) * 3600;
+  
+  const dayMatch = normalized.match(/^(\d+)d$/);
+  if (dayMatch) return parseInt(dayMatch[1], 10) * 86400;
+  
+  return null;
+};
+
+/**
+ * Calculate pace information for a usage window.
+ * 
+ * @param usedPercent - Current usage percentage (0-100)
+ * @param resetAt - Timestamp (ms) when the window resets
+ * @param windowSeconds - Total window duration in seconds (can be null, will be inferred from label if possible)
+ * @param windowLabel - Optional label to infer window duration from
+ * @returns PaceInfo object with pace calculations
+ */
+export const calculatePace = (
+  usedPercent: number | null,
+  resetAt: number | null,
+  windowSeconds: number | null,
+  windowLabel?: string
+): PaceInfo | null => {
+  // Try to infer windowSeconds from label if not provided
+  let effectiveWindowSeconds = windowSeconds;
+  if (effectiveWindowSeconds === null && windowLabel) {
+    effectiveWindowSeconds = inferWindowSeconds(windowLabel);
+  }
+  
+  if (usedPercent === null || resetAt === null || effectiveWindowSeconds === null || effectiveWindowSeconds <= 0) {
+    return null;
+  }
+
+  const now = Date.now();
+  const remainingSeconds = Math.max(0, (resetAt - now) / 1000);
+  const elapsedSeconds = Math.max(0, Math.min(effectiveWindowSeconds, effectiveWindowSeconds - remainingSeconds));
+  const elapsedRatio = Math.max(0, Math.min(1, elapsedSeconds / effectiveWindowSeconds));
+  const usageRatio = usedPercent / 100;
+  const isExhausted = usedPercent >= 100 && remainingSeconds > 0;
+
+  // Calculate predicted final usage
+  let predictedFinalPercent: number;
+  if (elapsedRatio > 0.01) {
+    predictedFinalPercent = Math.min(999, (usageRatio / elapsedRatio) * 100);
+  } else {
+    predictedFinalPercent = usedPercent;
+  }
+
+  // Determine pace status
+  let status: PaceStatus;
+  if (isExhausted) {
+    status = 'exhausted';
+  } else if (usageRatio <= elapsedRatio) {
+    status = 'on-track';
+  } else if (predictedFinalPercent <= 130) {
+    status = 'slightly-fast';
+  } else {
+    status = 'too-fast';
+  }
+
+  // Calculate pace rate text (per hour for < 5 days, per day otherwise)
+  const usePerDay = effectiveWindowSeconds >= 5 * 24 * 3600;
+  const unitSeconds = usePerDay ? 86400 : 3600;
+  const unitSuffix = usePerDay ? 'd' : 'h';
+  const totalUnits = effectiveWindowSeconds / unitSeconds;
+  const elapsedUnits = Math.max(elapsedSeconds / unitSeconds, totalUnits * 0.01);
+  const pacePercentPerUnit = (usedPercent / elapsedUnits);
+  const paceRateText = Number.isFinite(pacePercentPerUnit)
+    ? `${Math.min(999.9, Math.max(0, pacePercentPerUnit)).toFixed(1)}%/${unitSuffix}`
+    : '-';
+
+  // Calculate predict text
+  const predictText = predictedFinalPercent > 100
+    ? `+${Math.round(predictedFinalPercent)}%`
+    : `${Math.round(predictedFinalPercent)}%`;
+
+  // Calculate daily allocation for weekly quotas (7 days = 604800 seconds)
+  // Also include monthly quotas (roughly 30 days)
+  let dailyAllocationPercent: number | null = null;
+  const windowDays = effectiveWindowSeconds / 86400;
+  if (windowDays >= 7) {
+    // For a 7-day window, each day should use ~14.3% (100/7)
+    // For monthly, each day should use ~3.3% (100/30)
+    dailyAllocationPercent = 100 / windowDays;
+  }
+
+  return {
+    elapsedRatio,
+    usageRatio,
+    predictedFinalPercent,
+    remainingSeconds,
+    isExhausted,
+    elapsedSeconds,
+    totalSeconds: effectiveWindowSeconds,
+    status,
+    paceRateText,
+    predictText,
+    dailyAllocationPercent,
+  };
+};
+
+/**
+ * Get the color for a pace status (returns CSS variable names)
+ */
+export const getPaceStatusColor = (status: PaceStatus): string => {
+  switch (status) {
+    case 'exhausted':
+    case 'too-fast':
+      return 'var(--status-error)';
+    case 'slightly-fast':
+      return 'var(--status-warning)';
+    case 'on-track':
+      return 'var(--status-success)';
+  }
+};
+
+/**
+ * Format remaining time as a human-readable string
+ */
+export const formatRemainingTime = (seconds: number): string => {
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const totalHours = Math.floor(totalMinutes / 60);
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  }
+  if (totalHours > 0) {
+    return `${totalHours}h`;
+  }
+  if (totalMinutes === 0) {
+    return '<1m';
+  }
+  return `${minutes}m`;
+};
+
+/**
+ * Calculate the marker position for daily allocation on weekly quotas.
+ * Returns a percentage (0-100) representing where the "expected" usage should be
+ * based on how much time has elapsed.
+ * 
+ * @param elapsedRatio - Ratio of time elapsed (0-1)
+ * @returns Expected usage percentage based on time elapsed
+ */
+export const calculateExpectedUsagePercent = (elapsedRatio: number): number => {
+  return Math.min(100, Math.max(0, elapsedRatio * 100));
+};


### PR DESCRIPTION
Add pace and prediction to usage dropdown and settings
<img width="481" height="725" alt="Screenshot 2026-02-09 at 7 19 27 AM" src="https://github.com/user-attachments/assets/be45d539-1f0e-4bc5-b39b-e05a7dc2aa66" />
