### PR TITLE
fix(PierreDiffViewer): align diff viewer dark mode detection to use currentTheme

### DIFF
--- a/packages/ui/src/components/views/PierreDiffViewer.tsx
+++ b/packages/ui/src/components/views/PierreDiffViewer.tsx
@@ -149,7 +149,7 @@ export const PierreDiffViewer: React.FC<PierreDiffViewerProps> = ({
 }) => {
   const themeContext = useOptionalThemeSystem();
   
-  const isDark = themeContext?.themeMode === 'dark';
+  const isDark = themeContext?.currentTheme.metadata.variant === 'dark';
   const lightTheme = themeContext?.availableThemes.find(t => t.metadata.id === themeContext.lightThemeId) ?? getDefaultTheme(false);
   const darkTheme = themeContext?.availableThemes.find(t => t.metadata.id === themeContext.darkThemeId) ?? getDefaultTheme(true);
 


### PR DESCRIPTION
## Summary
- Aligns dark mode detection in PierreDiffViewer to use currentTheme.metadata.variant instead of themeMode
- Ensures the diff viewer renders correctly across theme changes and variants
- Maintains existing light/dark theme resolution using availableThemes and IDs

## Why
- Fixes incorrect dark mode detection that could cause misrendering when using non-standard or nested themes