### PR TITLE
feat: invert quota usage markers when remaining mode enabled

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -998,7 +998,9 @@ export const Header: React.FC = () => {
                                 : window.usedPercent;
                               const paceInfo = calculatePace(window.usedPercent, window.resetAt, window.windowSeconds, label);
                               const expectedMarker = paceInfo?.dailyAllocationPercent != null
-                                ? calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                                ? (quotaDisplayMode === 'remaining' 
+                                    ? 100 - calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                                    : calculateExpectedUsagePercent(paceInfo.elapsedRatio))
                                 : null;
                               return (
                               <DropdownMenuItem
@@ -1066,7 +1068,9 @@ export const Header: React.FC = () => {
                                             // For model-level quotas, use '5h' as typical window label for Google models
                                             const paceInfo = calculatePace(window.usedPercent, window.resetAt, window.windowSeconds, '5h');
                                             const expectedMarker = paceInfo?.dailyAllocationPercent != null
-                                              ? calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                                              ? (quotaDisplayMode === 'remaining'
+                                                  ? 100 - calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                                                  : calculateExpectedUsagePercent(paceInfo.elapsedRatio))
                                               : null;
                                             return (
                                             <div
@@ -1451,7 +1455,9 @@ export const Header: React.FC = () => {
                             : window.usedPercent;
                           const paceInfo = calculatePace(window.usedPercent, window.resetAt, window.windowSeconds, label);
                           const expectedMarker = paceInfo?.dailyAllocationPercent != null
-                            ? calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                            ? (quotaDisplayMode === 'remaining'
+                                ? 100 - calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                                : calculateExpectedUsagePercent(paceInfo.elapsedRatio))
                             : null;
                           return (
                             <div key={`${group.providerId}-${label}`} className="px-3 py-2">
@@ -1512,7 +1518,9 @@ export const Header: React.FC = () => {
                                         // For model-level quotas, use '5h' as typical window label for Google models
                                         const paceInfo = calculatePace(window.usedPercent, window.resetAt, window.windowSeconds, '5h');
                                         const expectedMarker = paceInfo?.dailyAllocationPercent != null
-                                          ? calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                                          ? (quotaDisplayMode === 'remaining'
+                                              ? 100 - calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                                              : calculateExpectedUsagePercent(paceInfo.elapsedRatio))
                                           : null;
                                         return (
                                           <div key={`${group.providerId}-${modelName}`} className="py-1.5">

--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -615,7 +615,9 @@ const VSCodeHeader: React.FC<VSCodeHeaderProps> = ({ title, showBack, onBack, on
                       : window.usedPercent;
                     const paceInfo = calculatePace(window.usedPercent, window.resetAt, window.windowSeconds, label);
                     const expectedMarker = paceInfo?.dailyAllocationPercent != null
-                      ? calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                      ? (quotaDisplayMode === 'remaining'
+                          ? 100 - calculateExpectedUsagePercent(paceInfo.elapsedRatio)
+                          : calculateExpectedUsagePercent(paceInfo.elapsedRatio))
                       : null;
                     return (
                     <DropdownMenuItem

--- a/packages/ui/src/components/sections/usage/UsageCard.tsx
+++ b/packages/ui/src/components/sections/usage/UsageCard.tsx
@@ -42,8 +42,10 @@ export const UsageCard: React.FC<UsageCardProps> = ({
       return null;
     }
     // Show marker based on elapsed time ratio
-    return calculateExpectedUsagePercent(paceInfo.elapsedRatio);
-  }, [paceInfo]);
+    const expectedUsed = calculateExpectedUsagePercent(paceInfo.elapsedRatio);
+    // If displaying remaining, invert the marker position
+    return displayMode === 'remaining' ? 100 - expectedUsed : expectedUsed;
+  }, [paceInfo, displayMode]);
 
   return (
     <div className="rounded-xl border border-[var(--interactive-border)] bg-[var(--surface-elevated)]/60 p-4 shadow-sm">


### PR DESCRIPTION
## Summary
- In header and layout usage components, the expected usage marker now inverts when quotaDisplayMode is set to remaining
- All markers correctly reflect remaining quota instead of used quota across Header, VSCodeLayout, and UsageCard
- Keeps existing behavior when quotaDisplayMode is not remaining

## Why
- Improves clarity for users who view remaining quota rather than consumed percentage
- Aligns visual indicators with the selected quota display mode to avoid confusion
- Centralizes the inversion logic to prevent duplicate or inconsistent marker calculations across components

## Testing
- [ ] Not run locally
- [ ] Manual: toggle quotaDisplayMode between default and remaining in the UI and verify markers invert as expected in all affected components (Header, VSCodeLayout, UsageCard)
- [ ] Automated: ensure unit tests covering calculateExpectedUsagePercent usage and displayMode handling pass (if tests exist for paceInfo and marker calculation)