### PR TITLE
fix(ui): prevent header dropdown from cutting off content and adjust last-updated text

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1373,7 +1373,7 @@ export const Header: React.FC = () => {
               <DropdownMenuContent
                 align="end"
                 sideOffset={0}
-                className="h-[100vh] w-[100vw] max-h-none rounded-none border-0 p-0"
+                className="h-dvh w-[100vw] max-h-none rounded-none border-0 p-0 overflow-hidden"
               >
                 <div className="flex h-full flex-col bg-[var(--surface-elevated)]">
                   <div className="sticky top-0 z-20 border-b border-[var(--interactive-border)] bg-[var(--surface-elevated)]">
@@ -1431,11 +1431,11 @@ export const Header: React.FC = () => {
                         </button>
                       </div>
                     </div>
-                    <div className="px-3 pb-3 typography-micro text-muted-foreground text-[10px]">
+                    <div className="px-3 pb-3 text-right typography-micro text-muted-foreground text-[8px]">
                       Last updated {formatTime(quotaLastUpdated)}
                     </div>
                   </div>
-                  <div className="flex-1 overflow-y-auto overflow-x-hidden">
+                  <div className="flex-1 overflow-y-auto overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))]">
                     {!hasRateLimits && (
                       <div className="px-3 py-4 typography-ui-label text-muted-foreground">
                         No rate limits available.


### PR DESCRIPTION
## Summary
- Use viewport height unit dvh for header dropdown to avoid covering entire screen on mobile
- Set width to 100vw, remove max-height constraints, and apply overflow-hidden to prevent content spill
- Right-align and reduce the font size of the last-updated timestamp for compact header UI
- Add bottom padding to the header content to account for safe-area insets on devices

## Why
- Prevents the header dropdown from occupying the full viewport and causing scroll/content cut-off on some devices
- Improves visual compactness of the last-updated line in the dropdown
- Ensures the header layout remains usable with safe-area insets across devices

## Testing
- [ ] Not run locally
- [ ] Manually verify in the app that the header dropdown does not overflow and can scroll when needed
- [ ] Confirm the last-updated timestamp is visible, right-aligned, and uses a smaller font on all viewports
- [ ] Ensure safe-area bottom padding does not cause layout issues on mobile devices