### PR TITLE
fix: auto-detect existing OpenCode server on startup

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -2667,6 +2667,7 @@ let openCodeApiDetectionTimer = null;
 let lastOpenCodeError = null;
 let isOpenCodeReady = false;
 let openCodeNotReadySince = 0;
+let isExternalOpenCode = false;
 let exitOnShutdown = true;
 let uiAuthController = null;
 let cloudflareTunnelController = null;
@@ -2715,6 +2716,36 @@ async function isOpenCodeProcessHealthy() {
       signal: AbortSignal.timeout(2000),
     });
     return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Probe if an external OpenCode instance is already running on the given port.
+ * Unlike isOpenCodeProcessHealthy(), this doesn't require openCodeProcess to be set.
+ * Used to auto-detect and connect to an existing OpenCode instance on startup.
+ */
+async function probeExternalOpenCode(port) {
+  if (!port || port <= 0) {
+    return false;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const response = await fetch(`http://127.0.0.1:${port}/global/health`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...getOpenCodeAuthHeaders(),
+      },
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (!response.ok) return false;
+    const body = await response.json().catch(() => null);
+    return body?.healthy === true;
   } catch {
     return false;
   }
@@ -4332,6 +4363,31 @@ async function restartOpenCode() {
     openCodeNotReadySince = Date.now();
     console.log('Restarting OpenCode process...');
 
+    // For external OpenCode servers, re-probe instead of kill + respawn
+    if (isExternalOpenCode) {
+      console.log('Re-probing external OpenCode server...');
+      const probePort = openCodePort || ENV_CONFIGURED_OPENCODE_PORT || 4096;
+      const healthy = await probeExternalOpenCode(probePort);
+      if (healthy) {
+        console.log(`External OpenCode server on port ${probePort} is healthy`);
+        setOpenCodePort(probePort);
+        isOpenCodeReady = true;
+        lastOpenCodeError = null;
+        openCodeNotReadySince = 0;
+        syncToHmrState();
+      } else {
+        lastOpenCodeError = `External OpenCode server on port ${probePort} is not responding`;
+        console.error(lastOpenCodeError);
+        throw new Error(lastOpenCodeError);
+      }
+
+      if (expressApp) {
+        setupProxy(expressApp);
+        ensureOpenCodeApiPrefix();
+      }
+      return;
+    }
+
     const portToKill = openCodePort;
 
     if (openCodeProcess) {
@@ -5012,7 +5068,7 @@ async function gracefulShutdown(options = {}) {
   }
 
   // Only stop OpenCode if we started it ourselves (not when using external server)
-  if (!ENV_SKIP_OPENCODE_START) {
+  if (!ENV_SKIP_OPENCODE_START && !isExternalOpenCode) {
     const portToKill = openCodePort;
 
     if (openCodeProcess) {
@@ -10586,6 +10642,23 @@ Context:
       console.log(`Using external OpenCode server on port ${ENV_CONFIGURED_OPENCODE_PORT} (skip-start mode)`);
       setOpenCodePort(ENV_CONFIGURED_OPENCODE_PORT);
       isOpenCodeReady = true;
+      isExternalOpenCode = true;
+      lastOpenCodeError = null;
+      openCodeNotReadySince = 0;
+      syncToHmrState();
+    } else if (ENV_CONFIGURED_OPENCODE_PORT && await probeExternalOpenCode(ENV_CONFIGURED_OPENCODE_PORT)) {
+      console.log(`Auto-detected existing OpenCode server on port ${ENV_CONFIGURED_OPENCODE_PORT}`);
+      setOpenCodePort(ENV_CONFIGURED_OPENCODE_PORT);
+      isOpenCodeReady = true;
+      isExternalOpenCode = true;
+      lastOpenCodeError = null;
+      openCodeNotReadySince = 0;
+      syncToHmrState();
+    } else if (!ENV_CONFIGURED_OPENCODE_PORT && await probeExternalOpenCode(4096)) {
+      console.log('Auto-detected existing OpenCode server on default port 4096');
+      setOpenCodePort(4096);
+      isOpenCodeReady = true;
+      isExternalOpenCode = true;
       lastOpenCodeError = null;
       openCodeNotReadySince = 0;
       syncToHmrState();


### PR DESCRIPTION
## Summary

OpenChamber now automatically detects and connects to an already-running OpenCode instance instead of failing with a port conflict. This eliminates the need to manually set `OPENCODE_SKIP_START=true` when OpenCode is started independently.

## Problem & Solution

**Problem:** When a user starts OpenCode separately (e.g. via TUI) and then launches OpenChamber, the startup fails with `"Failed to start server on port 4096"`. The only workaround is setting both `OPENCODE_PORT=4096` and `OPENCODE_SKIP_START=true` — undiscoverable for most users and not mentioned in error output.

**Solution:** Before attempting to spawn a new OpenCode process, probe the target port (configured or default 4096) with a lightweight HTTP health check. If an OpenCode instance is already responding, connect to it directly — same behavior as the existing `OPENCODE_SKIP_START` mode, but automatic.

## Key Changes

- **Auto-detection on configured port**: When `OPENCODE_PORT` is set, probe that port before trying to start a new instance
- **Auto-detection on default port**: When no port is configured, probe the well-known default port 4096 as a fallback
- **Zero breaking changes**: Existing `OPENCODE_SKIP_START` behavior is preserved; auto-detection is a new branch in the startup cascade

## System Design

The startup decision cascade now has two additional checks between the existing HMR reuse and skip-start paths:

```
Startup
  ├─ HMR process alive?          → reuse (existing)
  ├─ SKIP_START + PORT set?      → connect (existing)
  ├─ PORT set + port responding?  → connect (NEW)
  ├─ port 4096 responding?        → connect (NEW)
  └─ otherwise                    → spawn new instance (existing)
```

## Testing Strategy

Tested by starting OpenCode on port 4096 via TUI, then launching OpenChamber **without** any environment variables. Verified:
- Startup log shows `Auto-detected existing OpenCode server on default port 4096`
- Health endpoint reports `openCodeRunning: true`, `isOpenCodeReady: true`
- Session listing with directory filtering works end-to-end through the proxy
- UI displays sessions correctly after login

## Reviewer Notes

- The probe function (`probeExternalOpenCode`) mirrors the existing `isOpenCodeProcessHealthy` but skips the `openCodeProcess` guard — that guard makes sense for HMR but blocks detection of externally-started instances
- The 3-second timeout on the probe is intentional: fast enough for startup, long enough for a loaded server to respond
- Default port 4096 is hardcoded as the well-known OpenCode default; if this changes upstream, it should be extracted to a constant