### PR TITLE
feat: add user-configurable zen model for lightweight AI tasks

### DIFF
--- a/packages/ui/src/components/sections/openchamber/OpenChamberSidebar.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberSidebar.tsx
@@ -38,7 +38,7 @@ const OPENCHAMBER_SECTION_GROUPS: SectionGroup[] = [
   {
     id: 'sessions',
     label: 'Sessions',
-    items: ['Defaults', 'Retention'],
+    items: ['Defaults', 'Zen Model', 'Retention'],
   },
   {
     id: 'git',

--- a/packages/ui/src/components/views/GitView.tsx
+++ b/packages/ui/src/components/views/GitView.tsx
@@ -839,9 +839,11 @@ export const GitView: React.FC<GitViewProps> = ({ mode = 'full' }) => {
 
     setIsGeneratingMessage(true);
     try {
+      const zenModel = useConfigStore.getState().settingsZenModel;
       const { message } = await git.generateCommitMessage(
         currentDirectory,
-        Array.from(selectedPaths)
+        Array.from(selectedPaths),
+        zenModel ? { zenModel } : undefined
       );
       const subject = message.subject?.trim() ?? '';
       const highlights = Array.isArray(message.highlights) ? message.highlights : [];

--- a/packages/ui/src/components/views/git/PullRequestSection.tsx
+++ b/packages/ui/src/components/views/git/PullRequestSection.tsx
@@ -951,10 +951,12 @@ export const PullRequestSection: React.FC<{
     if (!directory) return;
     setIsGenerating(true);
     try {
+      const zenModel = useConfigStore.getState().settingsZenModel;
       const generated = await generatePullRequestDescription(directory, {
         base: baseBranch,
         head: branch,
         context: additionalContext,
+        ...(zenModel ? { zenModel } : {}),
       });
 
       if (generated.title?.trim()) {

--- a/packages/ui/src/hooks/useServerTTS.ts
+++ b/packages/ui/src/hooks/useServerTTS.ts
@@ -78,7 +78,7 @@ export function useServerTTS(): UseServerTTSReturn {
   const abortControllerRef = useRef<AbortController | null>(null);
   
   // Get current model, threshold, and max length from config store for summarization
-  const { currentProviderId, currentModelId, summarizeCharacterThreshold, summarizeMaxLength, openaiApiKey } = useConfigStore();
+  const { currentProviderId, currentModelId, summarizeCharacterThreshold, summarizeMaxLength, openaiApiKey, settingsZenModel } = useConfigStore();
 
   // Check if server TTS is available
   const checkAvailability = useCallback(async (): Promise<boolean> => {
@@ -209,6 +209,7 @@ export function useServerTTS(): UseServerTTSReturn {
           maxLength: summarizeMaxLength ?? 500,
           // Send API key from settings if available
           apiKey: openaiApiKey || undefined,
+          ...(settingsZenModel ? { zenModel: settingsZenModel } : {}),
         }),
         signal: abortControllerRef.current.signal,
       });
@@ -258,7 +259,7 @@ export function useServerTTS(): UseServerTTSReturn {
       options?.onError?.(errorMsg);
       setIsPlaying(false);
     }
-  }, [stop, currentProviderId, currentModelId, summarizeCharacterThreshold, summarizeMaxLength, openaiApiKey]);
+  }, [stop, currentProviderId, currentModelId, summarizeCharacterThreshold, summarizeMaxLength, openaiApiKey, settingsZenModel]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -332,10 +332,10 @@ export interface GitAPI {
   getGitBranches(directory: string): Promise<GitBranch>;
   deleteGitBranch(directory: string, payload: GitDeleteBranchPayload): Promise<{ success: boolean }>;
   deleteRemoteBranch(directory: string, payload: GitDeleteRemoteBranchPayload): Promise<{ success: boolean }>;
-  generateCommitMessage(directory: string, files: string[]): Promise<{ message: GeneratedCommitMessage }>;
+  generateCommitMessage(directory: string, files: string[], options?: { zenModel?: string }): Promise<{ message: GeneratedCommitMessage }>;
   generatePullRequestDescription(
     directory: string,
-    payload: { base: string; head: string; context?: string }
+    payload: { base: string; head: string; context?: string; zenModel?: string }
   ): Promise<GeneratedPullRequestDescription>;
   listGitWorktrees(directory: string): Promise<GitWorktreeInfo[]>;
   createGitCommit(directory: string, message: string, options?: CreateGitCommitOptions): Promise<GitCommitResult>;

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -91,6 +91,7 @@ export type DesktopSettings = {
   autoCreateWorktree?: boolean;
   queueModeEnabled?: boolean;
   gitmojiEnabled?: boolean;
+  zenModel?: string;
   toolCallExpansion?: 'collapsed' | 'activity' | 'detailed';
   fontSize?: number;
   terminalFontSize?: number;

--- a/packages/ui/src/lib/gitApi.ts
+++ b/packages/ui/src/lib/gitApi.ts
@@ -99,16 +99,17 @@ export async function deleteRemoteBranch(directory: string, payload: import('./a
 
 export async function generateCommitMessage(
   directory: string,
-  files: string[]
+  files: string[],
+  options?: { zenModel?: string }
 ): Promise<{ message: import('./api/types').GeneratedCommitMessage }> {
   const runtime = getRuntimeGit();
   if (runtime) return runtime.generateCommitMessage(directory, files);
-  return gitHttp.generateCommitMessage(directory, files);
+  return gitHttp.generateCommitMessage(directory, files, options);
 }
 
 export async function generatePullRequestDescription(
   directory: string,
-  payload: { base: string; head: string; context?: string }
+  payload: { base: string; head: string; context?: string; zenModel?: string }
 ): Promise<import('./api/types').GeneratedPullRequestDescription> {
   const runtime = getRuntimeGit();
   if (runtime?.generatePullRequestDescription) {

--- a/packages/ui/src/lib/gitApiHttp.ts
+++ b/packages/ui/src/lib/gitApiHttp.ts
@@ -205,16 +205,22 @@ export async function deleteRemoteBranch(directory: string, payload: GitDeleteRe
 
 export async function generateCommitMessage(
   directory: string,
-  files: string[]
+  files: string[],
+  options?: { zenModel?: string }
 ): Promise<{ message: GeneratedCommitMessage }> {
   if (!Array.isArray(files) || files.length === 0) {
     throw new Error('No files provided to generate commit message');
   }
 
+  const body: Record<string, unknown> = { files };
+  if (options?.zenModel) {
+    body.zenModel = options.zenModel;
+  }
+
   const response = await fetch(buildUrl(`${API_BASE}/commit-message`, directory), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ files }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {
@@ -249,16 +255,19 @@ export async function generateCommitMessage(
 
 export async function generatePullRequestDescription(
   directory: string,
-  payload: { base: string; head: string; context?: string }
+  payload: { base: string; head: string; context?: string; zenModel?: string }
 ): Promise<{ title: string; body: string }> {
-  const { base, head, context } = payload;
+  const { base, head, context, zenModel } = payload;
   if (!base || !head) {
     throw new Error('base and head are required');
   }
 
-  const requestBody: { base: string; head: string; context?: string } = { base, head };
+  const requestBody: { base: string; head: string; context?: string; zenModel?: string } = { base, head };
   if (context?.trim()) {
     requestBody.context = context.trim();
+  }
+  if (zenModel) {
+    requestBody.zenModel = zenModel;
   }
 
   const response = await fetch(buildUrl(`${API_BASE}/pr-description`, directory), {

--- a/packages/ui/src/lib/voice/summarize.ts
+++ b/packages/ui/src/lib/voice/summarize.ts
@@ -33,12 +33,13 @@ export async function summarizeText(
     }
     
     try {
+        const zenModel = store.settingsZenModel;
         const response = await fetch('/api/tts/summarize', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ text, threshold, maxLength }),
+            body: JSON.stringify({ text, threshold, maxLength, ...(zenModel ? { zenModel } : {}) }),
         });
         
         if (!response.ok) {

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -25,6 +25,7 @@ interface OpenChamberDefaults {
     defaultAgent?: string;
     autoCreateWorktree?: boolean;
     gitmojiEnabled?: boolean;
+    zenModel?: string;
 }
 
 const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
@@ -40,6 +41,7 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
                     const defaultVariant = typeof data?.defaultVariant === 'string' ? data.defaultVariant.trim() : '';
                     const defaultAgent = typeof data?.defaultAgent === 'string' ? data.defaultAgent.trim() : '';
                     const gitmojiEnabled = typeof data?.gitmojiEnabled === 'boolean' ? data.gitmojiEnabled : undefined;
+                    const zenModel = typeof data?.zenModel === 'string' ? data.zenModel.trim() : '';
 
                     return {
                         defaultModel: defaultModel.length > 0 ? defaultModel : undefined,
@@ -47,6 +49,7 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
                         defaultAgent: defaultAgent.length > 0 ? defaultAgent : undefined,
                         autoCreateWorktree: typeof data?.autoCreateWorktree === 'boolean' ? data.autoCreateWorktree : undefined,
                         gitmojiEnabled,
+                        zenModel: zenModel.length > 0 ? zenModel : undefined,
                     };
                 }
             } catch {
@@ -67,6 +70,7 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
         const defaultVariant = typeof data?.defaultVariant === 'string' ? data.defaultVariant.trim() : '';
         const defaultAgent = typeof data?.defaultAgent === 'string' ? data.defaultAgent.trim() : '';
         const gitmojiEnabled = typeof data?.gitmojiEnabled === 'boolean' ? data.gitmojiEnabled : undefined;
+        const zenModel = typeof data?.zenModel === 'string' ? data.zenModel.trim() : '';
 
         return {
             defaultModel: defaultModel.length > 0 ? defaultModel : undefined,
@@ -74,6 +78,7 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
             defaultAgent: defaultAgent.length > 0 ? defaultAgent : undefined,
             autoCreateWorktree: typeof data?.autoCreateWorktree === 'boolean' ? data.autoCreateWorktree : undefined,
             gitmojiEnabled,
+            zenModel: zenModel.length > 0 ? zenModel : undefined,
         };
     } catch {
         return {};
@@ -366,6 +371,7 @@ interface ConfigStore {
     settingsDefaultAgent: string | undefined;
     settingsAutoCreateWorktree: boolean;
     settingsGitmojiEnabled: boolean;
+    settingsZenModel: string | undefined;
     // Voice provider preference ('browser', 'openai', or 'say' for macOS)
     voiceProvider: 'browser' | 'openai' | 'say';
     setVoiceProvider: (provider: 'browser' | 'openai' | 'say') => void;
@@ -414,6 +420,7 @@ interface ConfigStore {
     setSettingsDefaultAgent: (agent: string | undefined) => void;
     setSettingsAutoCreateWorktree: (enabled: boolean) => void;
     setSettingsGitmojiEnabled: (enabled: boolean) => void;
+    setSettingsZenModel: (model: string | undefined) => void;
     saveAgentModelSelection: (agentName: string, providerId: string, modelId: string) => void;
     getAgentModelSelection: (agentName: string) => { providerId: string; modelId: string } | null;
     checkConnection: () => Promise<boolean>;
@@ -458,6 +465,7 @@ export const useConfigStore = create<ConfigStore>()(
                 settingsDefaultAgent: undefined,
                 settingsAutoCreateWorktree: false,
                 settingsGitmojiEnabled: false,
+                settingsZenModel: undefined,
                 // Voice provider preference - load from localStorage or default to 'browser'
                 voiceProvider: (() => {
                     if (typeof window !== 'undefined') {
@@ -1023,6 +1031,7 @@ export const useConfigStore = create<ConfigStore>()(
                                     settingsDefaultAgent: openChamberDefaults.defaultAgent,
                                     settingsAutoCreateWorktree: openChamberDefaults.autoCreateWorktree ?? false,
                                     settingsGitmojiEnabled: openChamberDefaults.gitmojiEnabled ?? false,
+                                    settingsZenModel: openChamberDefaults.zenModel,
                                     directoryScoped: {
                                         ...state.directoryScoped,
                                         [directoryKey]: nextSnapshot,
@@ -1447,6 +1456,10 @@ export const useConfigStore = create<ConfigStore>()(
                     set({ settingsGitmojiEnabled: enabled });
                 },
 
+                setSettingsZenModel: (model: string | undefined) => {
+                    set({ settingsZenModel: model });
+                },
+
                 setVoiceProvider: (provider: 'browser' | 'openai' | 'say') => {
                     set({ voiceProvider: provider });
                     if (typeof window !== 'undefined') {
@@ -1656,6 +1669,7 @@ export const useConfigStore = create<ConfigStore>()(
                     settingsDefaultAgent: state.settingsDefaultAgent,
                     settingsAutoCreateWorktree: state.settingsAutoCreateWorktree,
                     settingsGitmojiEnabled: state.settingsGitmojiEnabled,
+                    settingsZenModel: state.settingsZenModel,
                     speechRate: state.speechRate,
                     speechPitch: state.speechPitch,
                     speechVolume: state.speechVolume,

--- a/packages/vscode/src/bridge.ts
+++ b/packages/vscode/src/bridge.ts
@@ -2540,11 +2540,14 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
         const prompt = `You are drafting a GitHub Pull Request title + description. Respond in JSON of the shape {"title": string, "body": string} (ONLY JSON in response, no markdown fences) with these rules:\n- title: concise, sentence case, <= 80 chars, no trailing punctuation, no commit-style prefixes (no "feat:", "fix:")\n- body: GitHub-flavored markdown with these sections in this order: Summary, Testing, Notes\n- Summary: 3-6 bullet points describing user-visible changes; avoid internal helper function names\n- Testing: bullet list ("- Not tested" allowed)\n- Notes: bullet list; include breaking/rollout notes only when relevant\n\nContext:\n- base branch: ${base}\n- head branch: ${head}\n\nDiff summary:\n${diffSummaries}`;
 
         try {
+          const zenSettings = readSettings(ctx) as Record<string, unknown>;
+          const zenModelRaw = typeof zenSettings?.zenModel === 'string' ? (zenSettings.zenModel as string).trim() : '';
+          const zenModel = zenModelRaw.length > 0 ? zenModelRaw : 'gpt-5-nano';
           const response = await fetch('https://opencode.ai/zen/v1/responses', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              model: 'gpt-5-nano',
+              model: zenModel,
               input: [{ role: 'user', content: prompt }],
               max_output_tokens: 1200,
               stream: false,

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -588,7 +588,76 @@ const shouldApplyResolvedTemplateMessage = (template, resolved, variables) => {
   return true;
 };
 
-const summarizeText = async (text, targetLength) => {
+const ZEN_DEFAULT_MODEL = 'gpt-5-nano';
+
+/**
+ * Validated fallback zen model determined at startup by checking available free
+ * models from the zen API. When `null`, startup validation hasn't run yet (or
+ * failed), so `resolveZenModel` falls back to `ZEN_DEFAULT_MODEL`.
+ */
+let validatedZenFallback = null;
+
+/** Cached free zen models response and timestamp (shared by startup + endpoint). */
+let cachedZenModels = null;
+let cachedZenModelsTimestamp = 0;
+const ZEN_MODELS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Fetch free models from the zen API with caching. Returns an array of
+ * `{ id, owned_by }` objects (may be empty on failure). Results are cached
+ * for `ZEN_MODELS_CACHE_TTL` ms.
+ */
+const fetchFreeZenModels = async () => {
+  const now = Date.now();
+  if (cachedZenModels && now - cachedZenModelsTimestamp < ZEN_MODELS_CACHE_TTL) {
+    return cachedZenModels.models;
+  }
+
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+  const timeout = controller ? setTimeout(() => controller.abort(), 8000) : null;
+  try {
+    const response = await fetch('https://opencode.ai/zen/v1/models', {
+      signal: controller?.signal,
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(`zen/v1/models responded with status ${response.status}`);
+    }
+    const data = await response.json();
+    const allModels = Array.isArray(data?.data) ? data.data : [];
+    const freeModels = allModels
+      .filter((m) => typeof m?.id === 'string' && m.id.endsWith('-free'))
+      .map((m) => ({ id: m.id, owned_by: m.owned_by }));
+
+    cachedZenModels = { models: freeModels };
+    cachedZenModelsTimestamp = Date.now();
+    return freeModels;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+};
+
+/**
+ * Resolve the zen model to use. Checks the provided override first,
+ * then falls back to the stored zenModel setting, then to the validated
+ * startup fallback, then to the hardcoded default.
+ */
+const resolveZenModel = async (override) => {
+  if (typeof override === 'string' && override.trim().length > 0) {
+    return override.trim();
+  }
+  try {
+    const settings = await readSettingsFromDisk();
+    if (typeof settings?.zenModel === 'string' && settings.zenModel.trim().length > 0) {
+      return settings.zenModel.trim();
+    }
+  } catch {
+    // ignore
+  }
+  return validatedZenFallback || ZEN_DEFAULT_MODEL;
+};
+
+const summarizeText = async (text, targetLength, zenModel) => {
   if (!text || typeof text !== 'string' || text.trim().length === 0) return text;
 
   try {
@@ -601,7 +670,7 @@ const summarizeText = async (text, targetLength) => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          model: 'gpt-5-nano',
+          model: zenModel || ZEN_DEFAULT_MODEL,
           input: [{ role: 'user', content: prompt }],
           max_output_tokens: 1000,
           stream: false,
@@ -1450,6 +1519,10 @@ const sanitizeSettingsUpdate = (payload) => {
   }
   if (typeof candidate.gitmojiEnabled === 'boolean') {
     result.gitmojiEnabled = candidate.gitmojiEnabled;
+  }
+  if (typeof candidate.zenModel === 'string') {
+    const trimmed = candidate.zenModel.trim();
+    result.zenModel = trimmed.length > 0 ? trimmed : undefined;
   }
   if (typeof candidate.toolCallExpansion === 'string') {
     const mode = candidate.toolCallExpansion.trim();
@@ -3876,10 +3949,11 @@ const maybeSendPushForTrigger = async (payload) => {
           lastMessage = await fetchLastAssistantMessageText(sessionId, messageId);
         }
 
+        const notifZenModel = await resolveZenModel(settings?.zenModel);
         variables.last_message = await prepareNotificationLastMessage({
           message: lastMessage,
           settings,
-          summarize: summarizeText,
+          summarize: (text, len) => summarizeText(text, len, notifZenModel),
         });
 
         const resolvedTitle = resolveNotificationTemplate(completionTemplate.title, variables);
@@ -3936,10 +4010,11 @@ const maybeSendPushForTrigger = async (payload) => {
           lastMessage = await fetchLastAssistantMessageText(sessionId, errorMessageId);
         }
 
+        const errZenModel = await resolveZenModel(settings?.zenModel);
         variables.last_message = await prepareNotificationLastMessage({
           message: lastMessage,
           settings,
-          summarize: summarizeText,
+          summarize: (text, len) => summarizeText(text, len, errZenModel),
         });
 
         const errorTemplate = (settings.notificationTemplates || {}).error || { title: 'Tool error', message: '{last_message}' };
@@ -5109,6 +5184,36 @@ async function main(options = {}) {
     sayTTSCapability = { available: false, voices: [], reason: 'Not macOS' };
   }
 
+  // Validate stored zen model at startup – best-effort, never blocks startup
+  try {
+    const freeModels = await fetchFreeZenModels();
+    const freeModelIds = freeModels.map((m) => m.id);
+
+    if (freeModelIds.length > 0) {
+      // Set the validated fallback to the first available free model
+      validatedZenFallback = freeModelIds[0];
+
+      const settings = await readSettingsFromDisk();
+      const storedModel = typeof settings?.zenModel === 'string' ? settings.zenModel.trim() : '';
+
+      if (!storedModel || !freeModelIds.includes(storedModel)) {
+        const fallback = freeModelIds[0];
+        console.log(
+          storedModel
+            ? `[zen] Stored model "${storedModel}" not found in free models, falling back to "${fallback}"`
+            : `[zen] No model configured, setting default to "${fallback}"`
+        );
+        await persistSettings({ zenModel: fallback });
+      } else {
+        console.log(`[zen] Stored model "${storedModel}" verified as available`);
+      }
+    } else {
+      console.warn('[zen] No free models returned from API, skipping validation');
+    }
+  } catch (error) {
+    console.warn('[zen] Startup model validation failed (non-blocking):', error?.message || error);
+  }
+
   const app = express();
   app.set('trust proxy', true);
   expressApp = app;
@@ -5367,7 +5472,8 @@ async function main(options = {}) {
       if (summarize && textToSpeak.length > threshold) {
         try {
           const { summarizeText } = await import('./lib/summarization-service.js');
-          const result = await summarizeText({ text: textToSpeak, threshold, maxLength });
+          const speakZenModel = await resolveZenModel(typeof req.body?.zenModel === 'string' ? req.body.zenModel : undefined);
+          const result = await summarizeText({ text: textToSpeak, threshold, maxLength, zenModel: speakZenModel });
           
           if (result.summarized && result.summary) {
             textToSpeak = result.summary;
@@ -5435,7 +5541,8 @@ async function main(options = {}) {
         return res.status(400).json({ error: 'Text is required' });
       }
 
-      const result = await summarizeText({ text, threshold, maxLength });
+      const sumZenModel = await resolveZenModel(typeof req.body?.zenModel === 'string' ? req.body.zenModel : undefined);
+      const result = await summarizeText({ text, threshold, maxLength, zenModel: sumZenModel });
 
       return res.json(result);
     } catch (error) {
@@ -5800,6 +5907,25 @@ async function main(options = {}) {
     } finally {
       if (timeout) {
         clearTimeout(timeout);
+      }
+    }
+  });
+
+  // Zen models endpoint - returns available free models from the zen API
+  app.get('/api/zen/models', async (_req, res) => {
+    try {
+      const models = await fetchFreeZenModels();
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      res.json({ models });
+    } catch (error) {
+      console.warn('Failed to fetch zen models:', error);
+      // Serve stale cache if available
+      if (cachedZenModels) {
+        res.setHeader('Cache-Control', 'public, max-age=60');
+        res.json(cachedZenModels);
+      } else {
+        const statusCode = error?.name === 'AbortError' ? 504 : 502;
+        res.status(statusCode).json({ error: 'Failed to retrieve zen models' });
       }
     }
   });
@@ -8761,7 +8887,7 @@ highlights:
 Diff summary (may be truncated):
 ${diffSummaries}`;
 
-      const model = 'gpt-5-nano';
+      const model = await resolveZenModel(typeof req.body?.zenModel === 'string' ? req.body.zenModel : undefined);
 
       const completionTimeout = createTimeoutSignal(LONG_REQUEST_TIMEOUT_MS);
       let response;
@@ -8874,7 +9000,7 @@ Context:
 
       prompt += `\n\nDiff summary:\n${diffSummaries}`;
 
-      const model = 'gpt-5-nano';
+      const model = await resolveZenModel(typeof req.body?.zenModel === 'string' ? req.body.zenModel : undefined);
 
       const completionTimeout = createTimeoutSignal(LONG_REQUEST_TIMEOUT_MS);
       let response;

--- a/packages/web/server/lib/summarization-service.js
+++ b/packages/web/server/lib/summarization-service.js
@@ -78,18 +78,20 @@ function extractZenOutputText(data) {
 }
 
 /**
- * Summarize text using the opencode.ai zen API with gpt-5-nano
+ * Summarize text using the opencode.ai zen API
  * 
  * @param {Object} options
  * @param {string} options.text - The text to summarize
  * @param {number} options.threshold - Character threshold (don't summarize if under this length)
  * @param {number} options.maxLength - Maximum character length for the summary output (50-2000)
+ * @param {string} [options.zenModel] - Override zen model (defaults to gpt-5-nano)
  * @returns {Promise<{summary: string, summarized: boolean, reason?: string}>}
  */
 export async function summarizeText({
   text,
   threshold = 200,
   maxLength = 500,
+  zenModel,
 }) {
   // Don't summarize if text is under threshold
   if (!text || text.length <= threshold) {
@@ -110,7 +112,7 @@ export async function summarizeText({
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: 'gpt-5-nano',
+        model: zenModel || 'gpt-5-nano',
         input: [
           { role: 'user', content: `${prompt}\n\nText to summarize:\n${text}` },
         ],


### PR DESCRIPTION
## Summary
- Adds "Zen Model" dropdown in Settings to select free model for commit messages, PR descriptions, and text summarization
- Persists selection across sessions and validates availability at startup
- Passes selected model to zen API for commit message, PR description, and TTS summarization endpoints
- Gracefully falls back to default model if configured model becomes unavailable

## Why
- Gives users control over which free model handles lightweight internal tasks
- Improves reliability by validating the stored model at startup with auto-fallback
- Centralizes model configuration instead of hardcoding `gpt-5-nano` across multiple endpoints

## Testing
- [ ] Verify zen model dropdown appears in Settings and loads available models
- [ ] Select a model and confirm it persists after app restart
- [ ] Generate a commit message and verify the configured model is used in the API call
- [ ] Generate a PR description and verify the selected model is passed
- [ ] Trigger TTS text summarization and validate the chosen model is invoked
- [ ] Test fallback behavior when configured model is not in the available free models list
- [ ] Not run locally