### PR TITLE
fix(pwa): allow any screen orientation in PWA manifest

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -32,7 +32,7 @@
         "display": "standalone",
         "background_color": "#151313",
         "theme_color": "#edb449",
-        "orientation": "portrait-primary",
+        "orientation": "any",
           "icons": [
             { "src": baseUrl + "/pwa-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
             { "src": baseUrl + "/pwa-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },


### PR DESCRIPTION
## Summary
PWA manifest was locked to `portrait-primary`, preventing landscape mode on tablets.
Changed orientation to `any` in `web/index.html` to respect system rotation settings.

## Note
Users must reinstall the PWA for manifest changes to take effect (PWAs cache manifest on install).
