### PR TITLE
feat(model-cost-info): show compact price and capability icons in ModelControls

### DIFF
--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -1994,6 +1994,8 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
         // Rotate metadata in interactive desktop-style pickers (web/desktop), keep VS Code static.
         const supportsRotatingMetadata = !isVSCodeRuntime;
         const shouldAnimate = supportsRotatingMetadata && slides.length > 1 && (isHighlighted || isSelected);
+        const staticSlideIndex = !supportsRotatingMetadata && hasCapabilities && hasPrice ? 1 : 0;
+        const staticMetadataSlide = slides[staticSlideIndex];
 
         return (
             <div
@@ -2032,8 +2034,8 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                                 </TextLoop>
                             ) : (
                                 <>
-                                    {/* On non-desktop or when not highlighted/selected, show first slide (price if available, else capabilities) */}
-                                    {slides[0]}
+                                    {/* In static runtimes (VS Code), prefer capabilities over price when both exist. */}
+                                    {staticMetadataSlide}
                                 </>
                             )}
                         </div>


### PR DESCRIPTION
## Summary
- Adds a compact price string for models (input/output costs) in the ModelControls component on desktop
- Displays capability icons alongside the price when available
- Introduces an animated text loop to rotate price and capabilities on interactive desktop views
- Keeps static display for VS Code runtime and non-desktop environments
- Falls back gracefully when cost data is incomplete or missing

Solves https://github.com/btriapitsyn/openchamber/issues/231

## Screenshots
<img width="396" height="75" alt="image" src="https://github.com/user-attachments/assets/78abe2bd-e955-4d45-bc6b-1fd0d1395534" />
<img width="441" height="106" alt="image" src="https://github.com/user-attachments/assets/3b3459c3-3a16-4727-bc75-4db26c86e8ac" />


https://github.com/user-attachments/assets/8896dcec-b3fd-4b92-b868-5c7a2b9f19c5

