### PR TITLE
feat(ui): persist project icon and color with visual update

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -44,6 +44,7 @@ import {
   RiGitBranchLine,
   RiGitPullRequestLine,
   RiGitRepositoryLine,
+  RiNodeTree,
   RiStickyNoteLine,
   RiLinkUnlinkM,
 
@@ -1758,7 +1759,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   }, [activeProjectForHeader, projectRenameDraft, renameProject]);
 
   const headerActionButtonClass =
-    'inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50';
+    'inline-flex h-6 w-6 items-center justify-center rounded-md leading-none text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50';
 
   // Track when project sticky headers become "stuck"
   React.useEffect(() => {
@@ -2535,9 +2536,9 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
           </div>
           )}
           {reserveHeaderActionsSpace ? (
-            <div className="mt-1 -ml-1 flex h-8 items-center">
+            <div className="-ml-1 flex h-8 items-center">
               {activeProjectForHeader ? (
-              <div className="flex h-full items-center gap-1.5 rounded-md pl-0 pr-1">
+              <div className="flex h-8 -translate-y-px items-center gap-1.5 rounded-md pl-0 pr-1">
               {stableActiveProjectIsRepo ? (
                 <>
               <Tooltip>
@@ -2564,7 +2565,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
                     className={headerActionButtonClass}
                     aria-label="New worktree"
                   >
-                    <RiGitBranchLine className="h-4.5 w-4.5" />
+                    <RiNodeTree className="h-4.5 w-4.5" />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom" sideOffset={4}><p>New worktree</p></TooltipContent>

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -147,6 +147,12 @@ const sanitizeProjects = (value: unknown): DesktopSettings['projects'] | undefin
     if (typeof candidate.label === 'string' && candidate.label.trim().length > 0) {
       project.label = candidate.label.trim();
     }
+    if (typeof candidate.icon === 'string' && candidate.icon.trim().length > 0) {
+      project.icon = candidate.icon.trim();
+    }
+    if (typeof candidate.color === 'string' && candidate.color.trim().length > 0) {
+      project.color = candidate.color.trim();
+    }
     if (typeof candidate.addedAt === 'number' && Number.isFinite(candidate.addedAt) && candidate.addedAt >= 0) {
       project.addedAt = candidate.addedAt;
     }

--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -116,6 +116,12 @@ const sanitizeProjects = (value: unknown): ProjectEntry[] => {
     if (typeof candidate.label === 'string' && candidate.label.trim().length > 0) {
       project.label = candidate.label.trim();
     }
+    if (typeof candidate.icon === 'string' && candidate.icon.trim().length > 0) {
+      project.icon = candidate.icon.trim();
+    }
+    if (typeof candidate.color === 'string' && candidate.color.trim().length > 0) {
+      project.color = candidate.color.trim();
+    }
     if (typeof candidate.addedAt === 'number' && Number.isFinite(candidate.addedAt) && candidate.addedAt >= 0) {
       project.addedAt = candidate.addedAt;
     }

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -1325,6 +1325,8 @@ const sanitizeProjects = (input) => {
     const rawPath = typeof candidate.path === 'string' ? candidate.path.trim() : '';
     const normalizedPath = rawPath ? path.resolve(normalizeDirectoryPath(rawPath)) : '';
     const label = typeof candidate.label === 'string' ? candidate.label.trim() : '';
+    const icon = typeof candidate.icon === 'string' ? candidate.icon.trim() : '';
+    const color = typeof candidate.color === 'string' ? candidate.color.trim() : '';
     const addedAt = Number.isFinite(candidate.addedAt) ? Number(candidate.addedAt) : null;
     const lastOpenedAt = Number.isFinite(candidate.lastOpenedAt)
       ? Number(candidate.lastOpenedAt)
@@ -1341,6 +1343,8 @@ const sanitizeProjects = (input) => {
       id,
       path: normalizedPath,
       ...(label ? { label } : {}),
+      ...(icon ? { icon } : {}),
+      ...(color ? { color } : {}),
       ...(Number.isFinite(addedAt) && addedAt >= 0 ? { addedAt } : {}),
       ...(Number.isFinite(lastOpenedAt) && lastOpenedAt >= 0 ? { lastOpenedAt } : {}),
     };


### PR DESCRIPTION
## Summary

- Persists project `icon` and `color` fields across desktop settings and project stores with proper sanitization
- Replaces "New worktree" branch icon with a more descriptive tree icon (`RiNodeTree`) in the sidebar header
- Adjusts header action button spacing and alignment for consistent visual presentation
- Ensures icon/color data flows correctly between UI, stores, and web server layers

## Why

- Users need their custom project icons and colors to persist across sessions for better project identification
- The branch icon was semantically incorrect for worktree operations; the tree icon better represents nested worktree structure
- Sanitization prevents invalid or malicious data from corrupting project metadata