### PR TITLE
fix(chat): prevent accidental abort after mobile send

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -127,7 +127,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
     const [showAbortStatus, setShowAbortStatus] = React.useState(false);
     const abortTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const prevWasAbortedRef = React.useRef(false);
-    const sendTriggeredByPointerDownRef = React.useRef(false);
 
     // Message queue
     const queueModeEnabled = useMessageQueueStore((state) => state.queueModeEnabled);
@@ -1660,27 +1659,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
         <button
             type={isMobile ? 'button' : 'submit'}
             disabled={!canSend || (!currentSessionId && !newSessionDraftOpen)}
-            onPointerDownCapture={(event) => {
-                if (!isMobile || event.pointerType !== 'touch') {
-                    return;
-                }
-
-                if (!canSend || (!currentSessionId && !newSessionDraftOpen)) {
-                    return;
-                }
-
-                sendTriggeredByPointerDownRef.current = true;
-                event.preventDefault();
-                event.stopPropagation();
-                handlePrimaryAction();
-            }}
             onClick={(event) => {
                 if (!isMobile) {
-                    return;
-                }
-
-                if (sendTriggeredByPointerDownRef.current) {
-                    sendTriggeredByPointerDownRef.current = false;
                     return;
                 }
 
@@ -1704,26 +1684,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
         <button
             type="button"
             disabled={!hasContent || !currentSessionId}
-            onPointerDownCapture={(event) => {
-                if (!isMobile || event.pointerType !== 'touch') {
-                    return;
-                }
-
-                if (!hasContent || !currentSessionId) {
-                    return;
-                }
-
-                sendTriggeredByPointerDownRef.current = true;
-                event.preventDefault();
-                event.stopPropagation();
-                handleQueueMessage();
-            }}
             onClick={(event) => {
                 if (isMobile) {
-                    if (sendTriggeredByPointerDownRef.current) {
-                        sendTriggeredByPointerDownRef.current = false;
-                        return;
-                    }
                     event.preventDefault();
                 }
                 handleQueueMessage();


### PR DESCRIPTION
## Summary
- Fixes Android/mobile chat behavior where tapping Send could immediately trigger Abort on the same gesture.
- Removes pointerdown-triggered send/queue handling in `ChatInput` and relies on mobile click handling for those actions.
- Prevents gesture retargeting from `Send message` to `Stop generating` when UI transitions to busy state.

## Root Cause
- On mobile touch, send was executed in `onPointerDownCapture`.
- The run switched to busy quickly (`canAbort=true`) and UI replaced Send with Stop before touch completed.
- The synthetic `click` from the same touch then targeted `Stop generating`, invoking abort.

## Evidence (debug trace from Android repro)
```text
[chat-debug] footer event pointerdown -> buttonAriaLabel: 'Send message', canAbort: false
[chat-debug] send pointerdown accepted
[chat-debug] handlePrimaryAction
[chat-debug] canAbort changed: false -> true
[chat-debug] footer event pointerup -> buttonAriaLabel: 'Stop generating'
[chat-debug] footer event click -> buttonAriaLabel: 'Stop generating'
[chat-debug] handleAbort
```
This confirms a single touch gesture was retargeted to Stop after state transition.

## Change Details
- File: `packages/ui/src/components/chat/ChatInput.tsx`
- Removed `sendTriggeredByPointerDownRef`.
- Removed mobile `onPointerDownCapture` send path on Send button.
- Removed mobile `onPointerDownCapture` queue path on Queue button.
- Kept mobile `onClick` handling for send/queue to preserve behavior without mid-gesture retarget abort.

## Validation
- `bun run type-check`
- `bun run lint`
- `bun run build`