### PR TITLE
feat: align skills with Opencode discovery + add Agents locations + improve skills editor UX

### DIFF
--- a/packages/ui/src/components/sections/skills/SkillsSidebar.tsx
+++ b/packages/ui/src/components/sections/skills/SkillsSidebar.tsx
@@ -68,7 +68,7 @@ export const SkillsSidebar: React.FC<SkillsSidebarProps> = ({ onItemSelect }) =>
     }
 
     // Set draft and open the page for editing
-    setSkillDraft({ name: newName, scope: 'user', description: '' });
+    setSkillDraft({ name: newName, scope: 'user', source: 'opencode', description: '' });
     setSelectedSkill(newName);
     onItemSelect?.();
 
@@ -115,12 +115,13 @@ export const SkillsSidebar: React.FC<SkillsSidebarProps> = ({ onItemSelect }) =>
     }
 
     // Set draft with prefilled values from source skill
-    setSkillDraft({
-      name: newName,
-      scope: skill.scope || 'user',
-      description: detail.sources.md.fields.includes('description') ? '' : '', // Will be populated from page
-      instructions: '',
-    });
+      setSkillDraft({
+        name: newName,
+        scope: skill.scope || 'user',
+        source: skill.source || 'opencode',
+        description: detail.sources.md.fields.includes('description') ? '' : '', // Will be populated from page
+        instructions: '',
+      });
     setSelectedSkill(newName);
 
     if (isMobile) {
@@ -166,6 +167,7 @@ export const SkillsSidebar: React.FC<SkillsSidebarProps> = ({ onItemSelect }) =>
       name: sanitizedName,
       description: 'Renamed skill', // Will need proper description
       scope: renameDialogSkill.scope,
+      source: renameDialogSkill.source,
     });
 
     if (success) {
@@ -376,6 +378,11 @@ const SkillListItem: React.FC<SkillListItemProps> = ({
             {skill.source === 'claude' && (
               <span className="typography-micro text-muted-foreground bg-muted px-1 rounded flex-shrink-0 leading-none pb-px border border-border/50">
                 claude
+              </span>
+            )}
+            {skill.source === 'agents' && (
+              <span className="typography-micro text-muted-foreground bg-muted px-1 rounded flex-shrink-0 leading-none pb-px border border-border/50">
+                agents
               </span>
             )}
           </div>

--- a/packages/ui/src/components/sections/skills/catalog/InstallConflictsDialog.tsx
+++ b/packages/ui/src/components/sections/skills/catalog/InstallConflictsDialog.tsx
@@ -20,6 +20,7 @@ import {
 export type SkillConflict = {
   skillName: string;
   scope: 'user' | 'project';
+  source?: 'opencode' | 'agents';
 };
 
 export type ConflictDecision = 'skip' | 'overwrite';
@@ -85,7 +86,9 @@ export const InstallConflictsDialog: React.FC<InstallConflictsDialogProps> = ({
               >
                 <div className="min-w-0">
                   <div className="typography-ui-label truncate">{conflict.skillName}</div>
-                  <div className="typography-micro text-muted-foreground">Installed in {conflict.scope} scope</div>
+                  <div className="typography-micro text-muted-foreground">
+                    Installed in {conflict.scope} / {conflict.source || 'opencode'}
+                  </div>
                 </div>
 
                 <Select

--- a/packages/ui/src/components/sections/skills/catalog/InstallFromRepoDialog.tsx
+++ b/packages/ui/src/components/sections/skills/catalog/InstallFromRepoDialog.tsx
@@ -20,7 +20,7 @@ import {
   SelectItem,
   SelectTrigger,
 } from '@/components/ui/select';
-import { RiFolderLine, RiGitRepositoryLine, RiUser3Line } from '@remixicon/react';
+import { RiFolderLine, RiGitRepositoryLine, RiRobot2Line, RiUser3Line } from '@remixicon/react';
 
 import { isVSCodeRuntime } from '@/lib/desktop';
 import type { SkillsCatalogItem } from '@/lib/api/types';
@@ -28,6 +28,13 @@ import { useSkillsCatalogStore } from '@/stores/useSkillsCatalogStore';
 import { useSkillsStore } from '@/stores/useSkillsStore';
 import { useGitIdentitiesStore } from '@/stores/useGitIdentitiesStore';
 import { InstallConflictsDialog, type ConflictDecision, type SkillConflict } from './InstallConflictsDialog';
+import {
+  SKILL_LOCATION_OPTIONS,
+  locationLabel,
+  locationPartsFrom,
+  locationValueFrom,
+  type SkillLocationValue,
+} from '../skillLocations';
 
 interface InstallFromRepoDialogProps {
   open: boolean;
@@ -45,6 +52,7 @@ export const InstallFromRepoDialog: React.FC<InstallFromRepoDialogProps> = ({ op
   const [source, setSource] = React.useState('');
   const [subpath, setSubpath] = React.useState('');
   const [scope, setScope] = React.useState<'user' | 'project'>('user');
+  const [targetSource, setTargetSource] = React.useState<'opencode' | 'agents'>('opencode');
 
   const [items, setItems] = React.useState<SkillsCatalogItem[]>([]);
   const [selected, setSelected] = React.useState<Record<string, boolean>>({});
@@ -59,6 +67,7 @@ export const InstallFromRepoDialog: React.FC<InstallFromRepoDialogProps> = ({ op
     source: string;
     subpath?: string;
     scope: 'user' | 'project';
+    targetSource: 'opencode' | 'agents';
     selections: Array<{ skillDir: string }>;
     gitIdentityId?: string;
   } | null>(null);
@@ -68,6 +77,7 @@ export const InstallFromRepoDialog: React.FC<InstallFromRepoDialogProps> = ({ op
     setSource('');
     setSubpath('');
     setScope('user');
+    setTargetSource('opencode');
     setItems([]);
     setSelected({});
     setSearch('');
@@ -82,9 +92,9 @@ export const InstallFromRepoDialog: React.FC<InstallFromRepoDialogProps> = ({ op
   }, [open, loadDefaultGitIdentityId]);
 
   const installedByName = React.useMemo(() => {
-    const map = new Map<string, { scope: 'user' | 'project' }>();
+    const map = new Map<string, { scope: 'user' | 'project'; source: 'opencode' | 'claude' | 'agents' }>();
     for (const s of installedSkills) {
-      map.set(s.name, { scope: s.scope });
+      map.set(s.name, { scope: s.scope, source: s.source });
     }
     return map;
   }, [installedSkills]);
@@ -176,6 +186,7 @@ export const InstallFromRepoDialog: React.FC<InstallFromRepoDialogProps> = ({ op
       source: source.trim(),
       subpath: subpath.trim() || undefined,
       scope,
+      targetSource,
       selections: selectedDirs.map((dir) => ({ skillDir: dir })),
       gitIdentityId: gitIdentityId || undefined,
     };
@@ -272,31 +283,33 @@ export const InstallFromRepoDialog: React.FC<InstallFromRepoDialogProps> = ({ op
               </div>
 
               <div className="space-y-2">
-                <label className="typography-ui-label font-medium text-foreground">Target scope</label>
-                <Select value={scope} onValueChange={(v) => setScope(v as 'user' | 'project')}>
+                <label className="typography-ui-label font-medium text-foreground">Target location</label>
+                <Select
+                  value={locationValueFrom(scope, targetSource)}
+                  onValueChange={(v) => {
+                    const next = locationPartsFrom(v as SkillLocationValue);
+                    setScope(next.scope);
+                    setTargetSource(next.source === 'agents' ? 'agents' : 'opencode');
+                  }}
+                >
                   <SelectTrigger className="!h-9 w-full gap-1.5">
                     {scope === 'user' ? <RiUser3Line className="h-4 w-4" /> : <RiFolderLine className="h-4 w-4" />}
-                    <span className="capitalize">{scope}</span>
+                    {targetSource === 'agents' ? <RiRobot2Line className="h-4 w-4" /> : null}
+                    <span>{locationLabel(scope, targetSource)}</span>
                   </SelectTrigger>
                   <SelectContent align="start">
-                    <SelectItem value="user" className="pr-2 [&>span:first-child]:hidden">
-                      <div className="flex flex-col gap-0.5">
-                        <div className="flex items-center gap-2">
-                          <RiUser3Line className="h-4 w-4" />
-                          <span>User</span>
+                    {SKILL_LOCATION_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value} className="pr-2 [&>span:first-child]:hidden">
+                        <div className="flex flex-col gap-0.5">
+                          <div className="flex items-center gap-2">
+                            {option.scope === 'user' ? <RiUser3Line className="h-4 w-4" /> : <RiFolderLine className="h-4 w-4" />}
+                            {option.source === 'agents' ? <RiRobot2Line className="h-4 w-4" /> : null}
+                            <span>{option.label}</span>
+                          </div>
+                          <span className="typography-micro text-muted-foreground ml-6">{option.description}</span>
                         </div>
-                        <span className="typography-micro text-muted-foreground ml-6">Available in all projects</span>
-                      </div>
-                    </SelectItem>
-                    <SelectItem value="project" className="pr-2 [&>span:first-child]:hidden">
-                      <div className="flex flex-col gap-0.5">
-                        <div className="flex items-center gap-2">
-                          <RiFolderLine className="h-4 w-4" />
-                          <span>Project</span>
-                        </div>
-                        <span className="typography-micro text-muted-foreground ml-6">Only in current project</span>
-                      </div>
-                    </SelectItem>
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -378,7 +391,7 @@ export const InstallFromRepoDialog: React.FC<InstallFromRepoDialogProps> = ({ op
                             <div className="typography-ui-label truncate">{item.skillName}</div>
                             {installed ? (
                               <span className="typography-micro text-muted-foreground bg-muted px-1 rounded flex-shrink-0 leading-none pb-px border border-border/50">
-                                installed ({installed.scope})
+                                installed ({installed.scope}/{installed.source})
                               </span>
                             ) : null}
                           </div>

--- a/packages/ui/src/components/sections/skills/skillLocations.ts
+++ b/packages/ui/src/components/sections/skills/skillLocations.ts
@@ -1,0 +1,60 @@
+import type { SkillScope, SkillSource } from '@/stores/useSkillsStore';
+
+export type SkillLocationValue = 'user-opencode' | 'project-opencode' | 'user-agents' | 'project-agents';
+
+export const SKILL_LOCATION_OPTIONS: Array<{
+  value: SkillLocationValue;
+  scope: SkillScope;
+  source: SkillSource;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'user-opencode',
+    scope: 'user',
+    source: 'opencode',
+    label: 'User / OpenCode',
+    description: 'Global OpenCode config location',
+  },
+  {
+    value: 'project-opencode',
+    scope: 'project',
+    source: 'opencode',
+    label: 'Project / OpenCode',
+    description: 'Current project .opencode location',
+  },
+  {
+    value: 'user-agents',
+    scope: 'user',
+    source: 'agents',
+    label: 'User / Agents',
+    description: 'Global .agents compatibility location',
+  },
+  {
+    value: 'project-agents',
+    scope: 'project',
+    source: 'agents',
+    label: 'Project / Agents',
+    description: 'Current project .agents compatibility location',
+  },
+];
+
+export function locationValueFrom(scope: SkillScope, source: SkillSource): SkillLocationValue {
+  if (scope === 'project' && source === 'agents') return 'project-agents';
+  if (scope === 'project') return 'project-opencode';
+  if (source === 'agents') return 'user-agents';
+  return 'user-opencode';
+}
+
+export function locationPartsFrom(value: SkillLocationValue): { scope: SkillScope; source: SkillSource } {
+  const match = SKILL_LOCATION_OPTIONS.find((option) => option.value === value);
+  if (!match) {
+    return { scope: 'user', source: 'opencode' };
+  }
+  return { scope: match.scope, source: match.source };
+}
+
+export function locationLabel(scope: SkillScope, source: SkillSource): string {
+  const match = SKILL_LOCATION_OPTIONS.find((option) => option.scope === scope && option.source === source);
+  return match?.label || `${scope} / ${source}`;
+}

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -940,6 +940,7 @@ export interface SkillsCatalogSource {
 export interface SkillsCatalogItemInstalledBadge {
   isInstalled: boolean;
   scope?: 'user' | 'project';
+  source?: 'opencode' | 'agents' | 'claude';
 }
 
 export interface ClawdHubSkillMetadata {
@@ -1018,6 +1019,7 @@ export interface SkillsInstallRequest {
   subpath?: string;
   gitIdentityId?: string;
   scope: 'user' | 'project';
+  targetSource?: 'opencode' | 'agents';
   selections: SkillsInstallSelection[];
   conflictPolicy?: 'prompt' | 'skipAll' | 'overwriteAll';
   conflictDecisions?: Record<string, 'skip' | 'overwrite'>;
@@ -1026,12 +1028,12 @@ export interface SkillsInstallRequest {
 export type SkillsInstallError = SkillsRepoScanError | {
   kind: 'conflicts';
   message: string;
-  conflicts: Array<{ skillName: string; scope: 'user' | 'project' }>;
+  conflicts: Array<{ skillName: string; scope: 'user' | 'project'; source?: 'opencode' | 'agents' }>;
 };
 
 export interface SkillsInstallResponse {
   ok: boolean;
-  installed?: Array<{ skillName: string; scope: 'user' | 'project' }>;
+  installed?: Array<{ skillName: string; scope: 'user' | 'project'; source?: 'opencode' | 'agents' }>;
   skipped?: Array<{ skillName: string; reason: string }>;
   error?: SkillsInstallError;
 }

--- a/packages/ui/src/stores/useSkillsStore.ts
+++ b/packages/ui/src/stores/useSkillsStore.ts
@@ -30,7 +30,7 @@ const getCurrentDirectory = (): string | null => {
 };
 
 export type SkillScope = 'user' | 'project';
-export type SkillSource = 'opencode' | 'claude';
+export type SkillSource = 'opencode' | 'claude' | 'agents';
 
 export interface SupportingFile {
   name: string;
@@ -83,6 +83,7 @@ export interface SkillConfig {
   description: string;
   instructions?: string;
   scope?: SkillScope;
+  source?: SkillSource;
   supportingFiles?: Array<{ path: string; content: string }>;
 }
 
@@ -94,6 +95,7 @@ export interface PendingFile {
 export interface SkillDraft {
   name: string;
   scope: SkillScope;
+  source?: SkillSource;
   description: string;
   instructions?: string;
   pendingFiles?: PendingFile[];
@@ -217,6 +219,7 @@ export const useSkillsStore = create<SkillsStore>()(
 
             if (config.instructions) skillConfig.instructions = config.instructions;
             if (config.scope) skillConfig.scope = config.scope;
+            if (config.source) skillConfig.source = config.source;
             if (config.supportingFiles) skillConfig.supportingFiles = config.supportingFiles;
 
             const currentDirectory = getCurrentDirectory();

--- a/packages/vscode/src/bridge.ts
+++ b/packages/vscode/src/bridge.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import { spawn, execFile } from 'child_process';
 import { promisify } from 'util';
 import { type OpenCodeManager } from './opencode';
-import { createAgent, createCommand, deleteAgent, deleteCommand, getAgentSources, getCommandSources, updateAgent, updateCommand, type AgentScope, type CommandScope, AGENT_SCOPE, COMMAND_SCOPE, discoverSkills, getSkillSources, createSkill, updateSkill, deleteSkill, readSkillSupportingFile, writeSkillSupportingFile, deleteSkillSupportingFile, type SkillScope, SKILL_SCOPE, getProviderSources, removeProviderConfig } from './opencodeConfig';
+import { createAgent, createCommand, deleteAgent, deleteCommand, getAgentSources, getCommandSources, updateAgent, updateCommand, type AgentScope, type CommandScope, AGENT_SCOPE, COMMAND_SCOPE, discoverSkills, getSkillSources, createSkill, updateSkill, deleteSkill, readSkillSupportingFile, writeSkillSupportingFile, deleteSkillSupportingFile, type SkillScope, type SkillSource, type DiscoveredSkill, SKILL_SCOPE, getProviderSources, removeProviderConfig } from './opencodeConfig';
 import { getProviderAuth, removeProviderAuth } from './opencodeAuth';
 import { fetchQuotaForProvider, listConfiguredQuotaProviders } from './quotaProviders';
 import * as gitService from './gitService';
@@ -101,6 +101,132 @@ const execFileAsync = promisify(execFile);
 const gpgconfCandidates = ['gpgconf', '/opt/homebrew/bin/gpgconf', '/usr/local/bin/gpgconf'];
 
 const OPENCHAMBER_SHARED_SETTINGS_PATH = path.join(os.homedir(), '.config', 'openchamber', 'settings.json');
+
+const isPathInside = (candidatePath: string, parentPath: string): boolean => {
+  const normalizedCandidate = path.resolve(candidatePath);
+  const normalizedParent = path.resolve(parentPath);
+  return normalizedCandidate === normalizedParent || normalizedCandidate.startsWith(`${normalizedParent}${path.sep}`);
+};
+
+const findWorktreeRootForSkills = (workingDirectory?: string): string | null => {
+  if (!workingDirectory) return null;
+  let current = path.resolve(workingDirectory);
+  while (true) {
+    if (fs.existsSync(path.join(current, '.git'))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+};
+
+const getProjectAncestors = (workingDirectory?: string): string[] => {
+  if (!workingDirectory) return [];
+  const result: string[] = [];
+  let current = path.resolve(workingDirectory);
+  const stop = findWorktreeRootForSkills(workingDirectory) || current;
+  while (true) {
+    result.push(current);
+    if (current === stop) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return result;
+};
+
+const inferSkillScopeAndSourceFromLocation = (location: string, workingDirectory?: string): { scope: SkillScope; source: SkillSource } => {
+  const resolvedPath = path.resolve(location);
+  const source: SkillSource = resolvedPath.includes(`${path.sep}.agents${path.sep}skills${path.sep}`)
+    ? 'agents'
+    : resolvedPath.includes(`${path.sep}.claude${path.sep}skills${path.sep}`)
+      ? 'claude'
+      : 'opencode';
+
+  const projectAncestors = getProjectAncestors(workingDirectory);
+  const isProjectScoped = projectAncestors.some((ancestor) => {
+    const candidates = [
+      path.join(ancestor, '.opencode'),
+      path.join(ancestor, '.claude', 'skills'),
+      path.join(ancestor, '.agents', 'skills'),
+    ];
+    return candidates.some((candidate) => isPathInside(resolvedPath, candidate));
+  });
+
+  if (isProjectScoped) {
+    return { scope: 'project', source };
+  }
+
+  const home = os.homedir();
+  const userRoots = [
+    path.join(home, '.config', 'opencode'),
+    path.join(home, '.opencode'),
+    path.join(home, '.claude', 'skills'),
+    path.join(home, '.agents', 'skills'),
+    process.env.OPENCODE_CONFIG_DIR ? path.resolve(process.env.OPENCODE_CONFIG_DIR) : null,
+  ].filter((value): value is string => Boolean(value));
+
+  if (userRoots.some((root) => isPathInside(resolvedPath, root))) {
+    return { scope: 'user', source };
+  }
+
+  return { scope: 'user', source };
+};
+
+const fetchOpenCodeSkillsFromApi = async (ctx: BridgeContext | undefined, workingDirectory?: string): Promise<DiscoveredSkill[] | null> => {
+  const apiUrl = ctx?.manager?.getApiUrl();
+  if (!apiUrl) {
+    return null;
+  }
+
+  try {
+    const base = apiUrl.endsWith('/') ? apiUrl : `${apiUrl}/`;
+    const url = new URL('skill', base);
+    if (workingDirectory) {
+      url.searchParams.set('directory', workingDirectory);
+    }
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...(ctx?.manager?.getOpenCodeAuthHeaders() || {}),
+      },
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = await response.json();
+    if (!Array.isArray(payload)) {
+      return null;
+    }
+
+    return payload
+      .map((item) => {
+        const name = typeof item?.name === 'string' ? item.name.trim() : '';
+        const location = typeof item?.location === 'string' ? item.location : '';
+        const description = typeof item?.description === 'string' ? item.description : '';
+        if (!name || !location) {
+          return null;
+        }
+        const inferred = inferSkillScopeAndSourceFromLocation(location, workingDirectory);
+        return {
+          name,
+          path: location,
+          scope: inferred.scope,
+          source: inferred.source,
+          description,
+        } as DiscoveredSkill;
+      })
+      .filter((item): item is DiscoveredSkill => item !== null);
+  } catch {
+    return null;
+  }
+};
 
 const readSharedSettingsFromDisk = (): Record<string, unknown> => {
   try {
@@ -1851,7 +1977,7 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
 
         // LIST all skills (no name provided)
         if (!name && normalizedMethod === 'GET') {
-          const skills = discoverSkills(workingDirectory);
+          const skills = (await fetchOpenCodeSkillsFromApi(ctx, workingDirectory)) || discoverSkills(workingDirectory);
           return { id, type, success: true, data: { skills } };
         }
 
@@ -1861,7 +1987,9 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
         }
 
         if (normalizedMethod === 'GET') {
-          const sources = getSkillSources(skillName, workingDirectory);
+          const discoveredSkill = ((await fetchOpenCodeSkillsFromApi(ctx, workingDirectory)) || [])
+            .find((skill) => skill.name === skillName);
+          const sources = getSkillSources(skillName, workingDirectory, discoveredSkill || null);
           return {
             id,
             type,
@@ -1872,8 +2000,10 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
 
         if (normalizedMethod === 'POST') {
           const scopeValue = body?.scope as string | undefined;
+          const sourceValue = body?.source as string | undefined;
           const scope: SkillScope | undefined = scopeValue === 'project' ? SKILL_SCOPE.PROJECT : scopeValue === 'user' ? SKILL_SCOPE.USER : undefined;
-          createSkill(skillName, (body || {}) as Record<string, unknown>, workingDirectory, scope);
+          const normalizedSource = sourceValue === 'agents' ? 'agents' : 'opencode';
+          createSkill(skillName, { ...(body || {}), source: normalizedSource } as Record<string, unknown>, workingDirectory, scope);
           // Skills are just files - OpenCode loads them on-demand, no restart needed
           return {
             id,
@@ -1949,7 +2079,8 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
               .filter((v) => v !== null) as SkillsCatalogSourceConfig[])
           : [];
 
-        const data = await getSkillsCatalog(workingDirectory, refresh, additionalSources);
+        const installedSkills = (await fetchOpenCodeSkillsFromApi(ctx, workingDirectory)) || undefined;
+        const data = await getSkillsCatalog(workingDirectory, refresh, additionalSources, installedSkills);
         return { id, type, success: true, data };
       }
 
@@ -1967,6 +2098,7 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
           source?: string;
           subpath?: string;
           scope?: 'user' | 'project';
+          targetSource?: 'opencode' | 'agents';
           selections?: Array<{ skillDir: string }>;
           conflictPolicy?: 'prompt' | 'skipAll' | 'overwriteAll';
           conflictDecisions?: Record<string, 'skip' | 'overwrite'>;
@@ -1978,6 +2110,7 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
           source: String(body.source || ''),
           subpath: body.subpath,
           scope: body.scope === 'project' ? 'project' : 'user',
+          targetSource: body.targetSource === 'agents' ? 'agents' : 'opencode',
           workingDirectory: body.scope === 'project' ? workingDirectory : undefined,
           selections: Array.isArray(body.selections) ? body.selections : [],
           conflictPolicy: body.conflictPolicy,
@@ -2006,7 +2139,9 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
           return { id, type, success: false, error: 'File path is required' };
         }
 
-        const sources = getSkillSources(skillName, workingDirectory);
+        const discoveredSkill = ((await fetchOpenCodeSkillsFromApi(ctx, workingDirectory)) || [])
+          .find((skill) => skill.name === skillName);
+        const sources = getSkillSources(skillName, workingDirectory, discoveredSkill || null);
         if (!sources.md.dir) {
           return { id, type, success: false, error: `Skill "${skillName}" not found` };
         }


### PR DESCRIPTION
- Switch skills discovery to Opencode API (`/skill`) as source of truth, with safe fallback to local scan.
- Align scope/source behavior with Opencode paths, including `.agents` support and correct user vs project labeling.
- Add 4 install/create target locations in UI and backend handling: User/OpenCode, Project/OpenCode, User/Agents, Project/Agents.
- Improve skills editing UX: CodeMirror for `SKILL.md` and supporting files, extension-based syntax autodetection, working scroll for related files, resizable `SKILL.md` editor with visible corner resize affordance.
- Keep existing create/update/delete flows intact while making discovery authoritative and catalog installed-state more accurate.