### PR TITLE
fix(chat): prevent auto-send during session change

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -666,9 +666,18 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
             // Prevent double-triggering
             autoSendTriggeredRef.current = true;
 
+            const targetSessionId = currentSessionId;
+
             // Use setTimeout to avoid calling during render
             setTimeout(() => {
-                if (currentSessionId && currentProviderId && currentModelId) {
+                const activeSessionId = useSessionStore.getState().currentSessionId;
+                const currentStatus = targetSessionId
+                    ? useSessionStore.getState().sessionStatus?.get(targetSessionId)
+                    : null;
+                const stillIdle = currentStatus?.type === 'idle';
+                const sessionUnchanged = Boolean(targetSessionId) && activeSessionId === targetSessionId;
+
+                if (sessionUnchanged && stillIdle && targetSessionId && currentProviderId && currentModelId) {
                     void handleSubmitRef.current({ queuedOnly: true });
                 }
                 autoSendTriggeredRef.current = false;

--- a/packages/ui/src/hooks/useEventStream.ts
+++ b/packages/ui/src/hooks/useEventStream.ts
@@ -1382,7 +1382,6 @@ export const useEventStream = () => {
           }
 
 	          completeStreamingMessage(sessionId, messageId);
-	          updateSessionStatus(sessionId, { type: 'idle' }, 'sse:message.updated.completed');
 	          // Removed: void refreshSessionStatus();
 
 	          const rawMessageSessionId = (message as { sessionID?: string }).sessionID;


### PR DESCRIPTION
## Summary
- Auto-send only triggers if the session is idle.
- Session status update on message completion removed to avoid false idle states.
- Fixes race condition where auto-send could trigger prematurely.
## Why
- Prevent accidental message sends when switching between session statuses until the turn is done.
- Avoid stale session status causing incorrect auto-send behavior.