### PR TITLE
fix(chat): persist default thinking variant selection

### DIFF
--- a/packages/ui/src/hooks/useEventStream.ts
+++ b/packages/ui/src/hooks/useEventStream.ts
@@ -1149,9 +1149,7 @@ export const useEventStream = () => {
                   const variant = typeof (messageExt as { variant?: unknown }).variant === 'string'
                     ? (messageExt as { variant: string }).variant
                     : undefined;
-                  if (variant) {
-                    context.saveAgentModelVariantForSession(sessionId, agentCandidate, providerID, modelID, variant);
-                  }
+                  context.saveAgentModelVariantForSession(sessionId, agentCandidate, providerID, modelID, variant);
 
                   if (currentSessionIdRef.current === sessionId) {
                     try {

--- a/packages/ui/src/stores/contextStore.ts
+++ b/packages/ui/src/stores/contextStore.ts
@@ -304,6 +304,10 @@ export const useContextStore = create<ContextStore>()(
                                 ? infoAny.model.modelID
                                 : (typeof infoAny.modelID === 'string' && infoAny.modelID.trim().length > 0 ? infoAny.modelID : undefined);
 
+                            const userVariant = typeof infoAny.variant === 'string' && infoAny.variant.trim().length > 0
+                                ? infoAny.variant
+                                : undefined;
+
                             if (agentName && userProvider && userModel && agents.find((a) => a.name === agentName)) {
                                 const choice = {
                                     providerId: userProvider,
@@ -314,15 +318,11 @@ export const useContextStore = create<ContextStore>()(
                                 if (!existing || choice.timestamp > existing.timestamp) {
                                     agentLastChoices.set(agentName, choice);
                                 }
-                                if (typeof infoAny.variant === 'string' && infoAny.variant.trim().length > 0) {
-                                    saveAgentModelVariantForSession(sessionId, agentName, userProvider, userModel, infoAny.variant);
-                                }
+                                saveAgentModelVariantForSession(sessionId, agentName, userProvider, userModel, userVariant);
                             }
 
                             // User message: variant is top-level, model is nested in model.providerID/modelID
-                            pendingVariant = typeof infoAny.variant === 'string' && infoAny.variant.trim().length > 0
-                                ? infoAny.variant
-                                : undefined;
+                            pendingVariant = userVariant;
                             pendingUserModel = infoAny.model?.providerID && infoAny.model?.modelID
                                 ? { providerID: infoAny.model.providerID, modelID: infoAny.model.modelID }
                                 : undefined;
@@ -335,7 +335,7 @@ export const useContextStore = create<ContextStore>()(
 
                             if (agentName && agents.find((a) => a.name === agentName)) {
                                 // Apply pending variant from user message if model matches
-                                if (pendingVariant && pendingUserModel &&
+                                if (pendingUserModel &&
                                     pendingUserModel.providerID === infoAny.providerID &&
                                     pendingUserModel.modelID === infoAny.modelID) {
                                     saveAgentModelVariantForSession(sessionId, agentName, infoAny.providerID, infoAny.modelID, pendingVariant);

--- a/packages/ui/src/stores/useSessionStore.ts
+++ b/packages/ui/src/stores/useSessionStore.ts
@@ -397,14 +397,12 @@ export const useSessionStore = create<SessionStore>()(
                                         // ignored
                                     }
 
-                                    if (variant !== undefined) {
-                                        try {
-                                            useContextStore
-                                                .getState()
-                                                .saveAgentModelVariantForSession(created.id, effectiveDraftAgent, draftProviderId, draftModelId, variant);
-                                        } catch {
-                                            // ignored
-                                        }
+                                    try {
+                                        useContextStore
+                                            .getState()
+                                            .saveAgentModelVariantForSession(created.id, effectiveDraftAgent, draftProviderId, draftModelId, variant);
+                                    } catch {
+                                        // ignored
                                     }
                                 }
                         }
@@ -461,14 +459,12 @@ export const useSessionStore = create<SessionStore>()(
                             // ignored
                         }
 
-                        if (variant !== undefined) {
-                            try {
-                                useContextStore
-                                    .getState()
-                                    .saveAgentModelVariantForSession(currentSessionId, effectiveAgent, providerID, modelID, variant);
-                            } catch {
-                                // ignored
-                            }
+                        try {
+                            useContextStore
+                                .getState()
+                                .saveAgentModelVariantForSession(currentSessionId, effectiveAgent, providerID, modelID, variant);
+                        } catch {
+                            // ignored
                         }
                     }
  


### PR DESCRIPTION
## Summary
- treat selecting `Default` thinking as an explicit variant clear when sending a message, so previous non-default selections are not retained
- persist the same clear behavior when user-message metadata is applied from event stream updates
- update historical session analysis to store/propagate variant clears (undefined) so session rehydration no longer restores stale non-default variants

## Validation
- bun run type-check
- bun run lint
- bun run build