### PR TITLE
fix: stabilize chat rendering after message optimization

### DIFF
--- a/packages/ui/src/components/chat/contexts/TurnGroupingContext.tsx
+++ b/packages/ui/src/components/chat/contexts/TurnGroupingContext.tsx
@@ -519,6 +519,9 @@ const hasSameTurnStructure = (prev: ChatMessageEntry[], next: ChatMessageEntry[]
     }
 
     for (let index = 0; index < prev.length; index += 1) {
+        if (prev[index] !== next[index]) {
+            return false;
+        }
         if (prev[index]?.info?.id !== next[index]?.info?.id) {
             return false;
         }
@@ -543,6 +546,9 @@ const isAppendOnlyChange = (prev: ChatMessageEntry[], next: ChatMessageEntry[]):
     }
 
     for (let index = 0; index < prev.length; index += 1) {
+        if (prev[index] !== next[index]) {
+            return false;
+        }
         if (prev[index]?.info?.id !== next[index]?.info?.id) {
             return false;
         }
@@ -658,6 +664,7 @@ export const TurnGroupingProvider: React.FC<TurnGroupingProviderProps> = ({ mess
         const cached = staticCacheRef.current;
         if (
             cached &&
+            hasSameTurnStructure(cached.messages, messages) &&
             cached.structureKey === structureKey &&
             cached.defaultActivityExpanded === defaultActivityExpanded &&
             cached.showTextJustificationActivity === showTextJustificationActivity


### PR DESCRIPTION
## Summary
- Fix chat rendering regressions that could duplicate messages or cause messages to disappear.
- Update `MessageList` and turn-grouping cache logic to keep message ordering and grouping stable during streaming updates.
- Ensure incremental rendering paths stay consistent with deduped message IDs.

## Why
- The recent chat optimization introduced stale/incorrect cache reuse in message grouping.
- That cache mismatch caused intermittent UI issues where text messages appeared twice or vanished.
- This change prioritizes correctness of message rendering while preserving the performance improvements.