### PR TITLE
refactor(auth): migrate session storage to JWT with persistent secret

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -261,6 +261,7 @@
         "express": "^5.1.0",
         "ghostty-web": "0.3.0",
         "http-proxy-middleware": "^3.0.5",
+        "jose": "^6.1.3",
         "jsonc-parser": "^3.3.1",
         "next-themes": "^0.4.6",
         "node-pty": "^1.1.0",
@@ -2176,6 +2177,8 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -3223,6 +3226,8 @@
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@openchamber/ui/ghostty-web": ["ghostty-web@0.4.0", "", {}, "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg=="],
+
+    "@openchamber/web/@opencode-ai/sdk": ["@opencode-ai/sdk@1.2.10", "", {}, "sha512-SyXcVqry2hitPVvQtvXOhqsWyFhSycG/+LTLYXrcq8AFmd9FR7dyBSDB3f5Ol6IPkYOegk8P2Eg2kKPNSNiKGw=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/packages/ui/src/hooks/useServerSessionStatus.ts
+++ b/packages/ui/src/hooks/useServerSessionStatus.ts
@@ -78,6 +78,10 @@ export function useServerSessionStatus() {
           headers: { Accept: 'application/json' },
         }).then(async (r) => {
           if (!r.ok) {
+            console.warn('[useServerSessionStatus] API returned', r.status);
+            if (r.status === 401) {
+              console.warn('[useServerSessionStatus] Authentication required - session may have expired');
+            }
             throw new Error(String(r.status));
           }
           return (await r.json()) as ServerSnapshotResponse;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,6 +48,7 @@
     "express": "^5.1.0",
     "ghostty-web": "0.3.0",
     "http-proxy-middleware": "^3.0.5",
+    "jose": "^6.1.3",
     "jsonc-parser": "^3.3.1",
     "next-themes": "^0.4.6",
     "node-pty": "^1.1.0",

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -5973,10 +5973,22 @@ async function main(options = {}) {
     console.log('UI password protection enabled for browser sessions');
   }
 
-  app.get('/auth/session', (req, res) => uiAuthController.handleSessionStatus(req, res));
+  app.get('/auth/session', async (req, res) => {
+    try {
+      await uiAuthController.handleSessionStatus(req, res);
+    } catch (err) {
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
   app.post('/auth/session', (req, res) => uiAuthController.handleSessionCreate(req, res));
 
-  app.use('/api', (req, res, next) => uiAuthController.requireAuth(req, res, next));
+  app.use('/api', async (req, res, next) => {
+    try {
+      await uiAuthController.requireAuth(req, res, next);
+    } catch (err) {
+      next(err);
+    }
+  });
 
   const parsePushSubscribeBody = (body) => {
     if (!body || typeof body !== 'object') return null;
@@ -6017,7 +6029,7 @@ async function main(options = {}) {
     await ensurePushInitialized();
 
     const uiToken = uiAuthController?.ensureSessionToken
-      ? uiAuthController.ensureSessionToken(req, res)
+      ? await uiAuthController.ensureSessionToken(req, res)
       : getUiSessionTokenFromRequest(req);
     if (!uiToken) {
       return res.status(401).json({ error: 'UI session missing' });
@@ -6065,7 +6077,7 @@ async function main(options = {}) {
     await ensurePushInitialized();
 
     const uiToken = uiAuthController?.ensureSessionToken
-      ? uiAuthController.ensureSessionToken(req, res)
+      ? await uiAuthController.ensureSessionToken(req, res)
       : getUiSessionTokenFromRequest(req);
     if (!uiToken) {
       return res.status(401).json({ error: 'UI session missing' });
@@ -6080,9 +6092,9 @@ async function main(options = {}) {
     res.json({ ok: true });
   });
 
-  app.post('/api/push/visibility', (req, res) => {
+  app.post('/api/push/visibility', async (req, res) => {
     const uiToken = uiAuthController?.ensureSessionToken
-      ? uiAuthController.ensureSessionToken(req, res)
+      ? await uiAuthController.ensureSessionToken(req, res)
       : getUiSessionTokenFromRequest(req);
     if (!uiToken) {
       return res.status(401).json({ error: 'UI session missing' });


### PR DESCRIPTION
## Summary
Migrates UI authentication from in-memory session storage to stateless JWT tokens with persistent secret management.

## Changes
- Replace in-memory session Map with stateless JWT tokens using `jose` library
- Implement persistent JWT secret storage in `~/.config/openchamber/jwt-secret`
- Support `OPENCODE_JWT_SECRET` environment variable for secret override
- Update `SessionAuthGate` component with improved session handling
- Update `useServerSessionStatus` hook for JWT-based sessions
- Remove session cleanup timer (JWTs are stateless, no server-side storage needed)
- Add `jose` dependency to `packages/web/package.json`

## Benefits
- Stateless authentication (no server-side session storage)
- Better scalability (sessions survive server restarts)
- Improved security with persistent secret
- Simpler session management

## Testing
- [ ] Test login/logout flow
- [ ] Test session persistence after server restart
- [ ] Test JWT secret generation and persistence