### PR TITLE
fix(mobile): expand clickable area for session status bar collapse

### DIFF
--- a/packages/ui/src/components/chat/MobileSessionStatusBar.tsx
+++ b/packages/ui/src/components/chat/MobileSessionStatusBar.tsx
@@ -902,7 +902,18 @@ function ExpandedView({
             isExpanded={true}
           />
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div
+          className="flex items-center gap-2 flex-shrink-0 cursor-pointer !min-h-0"
+          onClick={onToggleCollapse}
+          tabIndex={0}
+          role="button"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onToggleCollapse();
+            }
+          }}
+        >
           <RunningIndicator count={runningCount} />
           <UnreadIndicator count={unreadCount} />
           <TokenUsageIndicator contextUsage={contextUsage} />


### PR DESCRIPTION
## Summary

Make the running status indicator, unread indicator, and token usage percentage clickable to collapse the mobile session status bar.

## Changes

- Add `onClick` handler to trigger collapse
- Add `cursor-pointer` and `!min-h-0` classes
- Add keyboard accessibility (Enter/Space)