### PR TITLE
fix(mobile): optimize usage rate limits tabs UI for mobile

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1573,20 +1573,41 @@ export const Header: React.FC<HeaderProps> = ({
                     <div className="flex-1 overflow-y-auto overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))]">
                       <div className="bg-[var(--surface-elevated)] border-b border-[var(--interactive-border)]">
                         <div className="flex items-center justify-between gap-3 px-3 py-2.5">
-                          <div className="flex min-w-0 items-center gap-2">
+                          <div className="flex flex-col min-w-0">
                             <span className="typography-ui-header font-semibold text-foreground">Rate limits</span>
                             <span className="truncate typography-ui-label text-muted-foreground">
                               Last updated {formatTime(quotaLastUpdated)}
                             </span>
                           </div>
-                          <div className="flex items-center gap-1.5">
-                            <AnimatedTabs<'usage' | 'remaining'>
-                              value={quotaDisplayMode}
-                              onValueChange={handleDisplayModeChange}
-                              tabs={quotaDisplayTabs}
-                              size="sm"
-                              className="w-[10.5rem]"
-                            />
+                          <div className="flex items-center gap-2 shrink-0">
+                            {/* Light-weight text toggle for Used/Remaining */}
+                            <div className="flex items-center h-6">
+                              <button
+                                type="button"
+                                onClick={() => handleDisplayModeChange('usage')}
+                                className={cn(
+                                  'typography-ui-label px-1 pb-0.5 transition-colors',
+                                  quotaDisplayMode === 'usage'
+                                    ? 'text-foreground border-b-2 border-[var(--primary-base)]'
+                                    : 'text-muted-foreground hover:text-foreground'
+                                )}
+                              >
+                                Used
+                              </button>
+                              <span className="text-muted-foreground typography-ui-label px-0.5">·</span>
+                              <button
+                                type="button"
+                                onClick={() => handleDisplayModeChange('remaining')}
+                                className={cn(
+                                  'typography-ui-label px-1 pb-0.5 transition-colors',
+                                  quotaDisplayMode === 'remaining'
+                                    ? 'text-foreground border-b-2 border-[var(--primary-base)]'
+                                    : 'text-muted-foreground hover:text-foreground'
+                                )}
+                              >
+                                Remaining
+                              </button>
+                            </div>
                             <button
                               type="button"
                               className={cn(


### PR DESCRIPTION
Optimize the Rate limits section UI in the mobile Usage page.

## Problem
In the mobile Service menu's Usage tab, the Rate limits row display was not ideal:
1. The Used/Remaining toggle used the same visual style (AnimatedTabs) as the top Usage/MCP tabs
2. This caused both tabs to have equal visual weight, making it unclear which was primary navigation vs filter

## Solution
Replaced the Used/Remaining toggle with a lightweight text-based toggle:

**Before:**
- Rate limits title and Used/Remaining tabs on same row
- Both tabs used card-style appearance with equal visual weight

**After:**
- Rate limits title and timestamp stacked vertically (saves horizontal space)
- Used/Remaining now uses plain text buttons with underline indicator
- Options separated by · (more compact)
- Clearer visual hierarchy: navigation with background vs text-only filters

## Scope
- File: \`packages/ui/src/components/layout/Header.tsx\`
- Only affects the Usage tab in mobile Service menu
- Desktop display remains unchanged

![image](https://github.com/user-attachments/assets/9719dceb-653d-486f-ac87-99ad3d0f1294)