### PR TITLE
fix(mobile): improve branch selection dropdown interaction in merge dialog

### DIFF
--- a/packages/ui/src/components/views/git/BranchIntegrationSection.tsx
+++ b/packages/ui/src/components/views/git/BranchIntegrationSection.tsx
@@ -153,12 +153,6 @@ export const BranchIntegrationSection: React.FC<BranchIntegrationSectionProps> =
   React.useEffect(() => {
     if (!branchDropdownOpen) {
       setBranchSearch('');
-    } else {
-      // Focus the search input when dropdown opens
-      const timer = setTimeout(() => {
-        searchInputRef.current?.focus();
-      }, 0);
-      return () => clearTimeout(timer);
     }
   }, [branchDropdownOpen]);
 
@@ -288,7 +282,7 @@ export const BranchIntegrationSection: React.FC<BranchIntegrationSectionProps> =
         <p className="typography-meta text-muted-foreground">
           {operation === 'merge' ? `Branch to merge into ${targetBranchLabel}` : 'Branch to rebase onto'}
         </p>
-        <DropdownMenu open={branchDropdownOpen} onOpenChange={setBranchDropdownOpen}>
+        <DropdownMenu open={branchDropdownOpen} onOpenChange={setBranchDropdownOpen} modal={false}>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" className="w-full justify-between h-10">
               <span className={cn('truncate', !selectedBranch && 'text-muted-foreground')}>


### PR DESCRIPTION
## Summary
Fixed two UX issues in the branch selection dropdown within the Merge/Rebase dialog on mobile:

1. **Closing branch selector accidentally closes the drawer**
   - When users opened the branch dropdown but didn't select a branch, clicking outside to close it would also close the entire right drawer
   - Fixed by adding `modal={false}` to the DropdownMenu component

2. **Unwanted keyboard popup when opening branch selector**
   - The search input was automatically focused when opening the dropdown, causing the soft keyboard to appear unexpectedly during touch interactions
   - Fixed by removing the auto-focus logic in useEffect

## Changes
- `packages/ui/src/components/views/git/BranchIntegrationSection.tsx`:
  - Added `modal={false}` prop to DropdownMenu
  - Removed auto-focus logic for search input

## Testing
- [ ] Open Merge/Rebase dialog on mobile
- [ ] Click "Select a branch..." dropdown
- [ ] Verify keyboard doesn't auto-appear
- [ ] Click outside dropdown without selecting
- [ ] Verify only dropdown closes, not the drawer
- [ ] Click search input manually - should show keyboard