### PR TITLE
fix(notification): cache parentID from session events to fix subtask notification detection

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -847,6 +847,11 @@ const maybeCacheSessionInfoFromEvent = (payload) => {
   const sessionId = info.id;
   const title = info.title;
   cacheSessionTitle(sessionId, title);
+  // Also cache parentID from session events to ensure subtask detection works correctly
+  const parentID = info.parentID;
+  if (sessionId && parentID !== undefined) {
+    setCachedSessionParentId(sessionId, parentID);
+  }
 };
 
 /**
@@ -4170,7 +4175,7 @@ const fetchSessionParentId = async (sessionId) => {
     }
 
     const match = data.find((s) => s && typeof s === 'object' && s.id === sessionId);
-    const parentID = match && typeof match.parentID === 'string' && match.parentID.length > 0 ? match.parentID : null;
+    const parentID = match?.parentID ? match.parentID : null;
     setCachedSessionParentId(sessionId, parentID);
     return parentID;
   } catch {


### PR DESCRIPTION
## Problem
When users create sub-sessions using the Agent Task tool, completion notifications are still sent even when the "Subagent Completion" notification toggle is turned off.

## Root Cause
The backend notification logic determines whether a session is a subtask by checking its `parentID`. However, the `maybeCacheSessionInfoFromEvent` function only cached the session title when processing `session.created` and `session.updated` events, **not the parentID**.

This caused:
1. When Agent Task creates a sub-session, OpenCode sends a `session.created` event with the correct `parentID`, but it wasn't cached
2. When the sub-session completes and triggers a `message.updated` event, the notification logic calls `fetchSessionParentId` to get the parentID
3. If not in cache, it needs to fetch from the API; in some cases this returns null/undefined
4. Result: subtasks were incorrectly identified as regular tasks, sending notifications

## Fix

**1. Cache parentID in event handler**
```javascript
const maybeCacheSessionInfoFromEvent = (payload) => {
  // ... existing logic ...
  
  // Also cache parentID from session events to ensure subtask detection works correctly
  const parentID = info.parentID;
  if (sessionId && parentID !== undefined) {
    setCachedSessionParentId(sessionId, parentID);
  }
};
```

**2. Align frontend/backend detection logic**
Changed `fetchSessionParentId` to use loose checking (matching frontend):
```javascript
// Before: strict check
const parentID = match && typeof match.parentID === 'string' && match.parentID.length > 0 ? match.parentID : null;

// After: loose check (consistent with frontend)
const parentID = match?.parentID ? match.parentID : null;
```

## Verification
- Frontend UI correctly identifies subtasks (indentation, attention dots)
- This fix ensures backend notification logic uses the same parentID source and detection logic as the frontend
- Sub-session completions will be correctly identified and won't send notifications (when toggle is off)

## Changes
- `packages/web/server/index.js`: +6 lines, -1 line