### PR TITLE
feat(chat): show dynamic subagent type in task tool button

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -554,7 +554,8 @@ const TaskToolSummary: React.FC<{
     output?: string;
     sessionId?: string;
     onShowPopup?: (content: ToolPopupContent) => void;
-}> = ({ entries, isExpanded, hasPrevTool, hasNextTool, output, sessionId, onShowPopup }) => {
+    input?: Record<string, unknown>;
+}> = ({ entries, isExpanded, hasPrevTool, hasNextTool, output, sessionId, onShowPopup, input }) => {
     const setCurrentSession = useSessionStore((state) => state.setCurrentSession);
     const displayEntries = React.useMemo(() => {
         const nonPending = entries.filter((entry) => entry.state?.status !== 'pending');
@@ -573,6 +574,10 @@ const TaskToolSummary: React.FC<{
             setCurrentSession(sessionId);
         }
     };
+
+    const agentType = typeof input?.subagent_type === 'string'
+        ? input.subagent_type
+        : 'subagent';
 
     if (displayEntries.length === 0 && !hasOutput && !sessionId) {
         return null;
@@ -627,7 +632,7 @@ const TaskToolSummary: React.FC<{
                     onClick={handleOpenSession}
                 >
                     <RiExternalLinkLine className="h-3.5 w-3.5 flex-shrink-0" />
-                    <span className="typography-meta text-primary font-medium">Open subAgent session</span>
+                    <span className="typography-meta text-primary font-medium">Open {agentType.charAt(0).toUpperCase() + agentType.slice(1)} subtask</span>
                 </button>
             )}
 
@@ -1569,6 +1574,7 @@ const ToolPart: React.FC<ToolPartProps> = ({
                     output={taskOutputString}
                     sessionId={taskSessionId}
                     onShowPopup={onShowPopup}
+                    input={input}
                 />
             ) : null}
 


### PR DESCRIPTION
## Summary

Dynamic agent type label in task tool button - replaces hardcoded "Open subAgent session" with "Open {Type} subtask" (e.g., "Open General subtask", "Open Build subtask").

<img width="528" height="151" alt="Screenshot 2026-02-27 at 3 50 48 PM" src="https://github.com/user-attachments/assets/800f722e-dbf8-4983-8eb2-a62280b0c525" />

<img width="903" height="339" alt="Screenshot 2026-02-27 at 3 51 19 PM" src="https://github.com/user-attachments/assets/81af79be-3b32-479d-8b2b-324eb5196a26" />

<img width="560" height="201" alt="Screenshot 2026-02-27 at 3 51 07 PM" src="https://github.com/user-attachments/assets/bd6d35a8-4a5c-4bcd-be89-032ef408e7a9" />

## Changes
- Extract `subagent_type` from task tool input
- Capitalize first letter using existing codebase pattern (consistent with ModelControls.tsx and WorkingPlaceholder.tsx)
- Update button text from "session" to "subtask"
- Maintain backward compatibility (defaults to "Subagent")

## Files Changed
- `packages/ui/src/components/chat/message/parts/ToolPart.tsx`
  - Added `input` prop to TaskToolSummary component
  - Extract and capitalize agent type from input
  - Dynamic button text: "Open {AgentType} subtask"

## Testing
- Button displays actual agent type when task tool is used
- Falls back to "Subagent" when no type specified
- No breaking changes to navigation functionality