### PR TITLE
fix(cli): use pathToFileURL for dynamic imports on Windows

### DIFF
--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -926,7 +926,7 @@ const commands = {
       executeUpdate,
       detectPackageManager,
       getCurrentVersion,
-    } = await import(packageManagerPath);
+    } = await import(pathToFileURL(packageManagerPath).href);
 
     // Check for running instances before update
     let runningInstances = [];


### PR DESCRIPTION
## Problem

- On Windows, `openchamber serve` and `openchamber update` crash with: `Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. Received protocol 'c:'`
- Node's ESM loader rejects bare Windows paths (e.g. `C:\Users\...\package-manager.js`) passed to dynamic `import()`, interpreting the drive letter `C:` as a URL protocol scheme
- The `serve` command's server import (line 628) was already fixed with `pathToFileURL()`, but the `update` command's `package-manager.js` import (line 929) was not

## Fix

- Wrap `packageManagerPath` in `pathToFileURL().href` before passing it to `import()`, converting `C:\...\package-manager.js` into `file:///C:/.../package-manager.js`
- `pathToFileURL` was already imported but unused for this code path

## Tested

- Verified `openchamber serve` starts successfully on Windows after the fix
- Verified `openchamber --try-cf-tunnel --tunnel-qr --tunnel-password-url` no longer crashes