### PR TITLE
fix(cli): surface tunnel bootstrap connect URL for --try-cf-tunnel

### DIFF
--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -632,10 +632,12 @@ const commands = {
       exitOnShutdown: true,
       uiPassword: typeof effectiveUiPassword === 'string' ? effectiveUiPassword : null,
       tryCfTunnel: options.tryCfTunnel,
-      onTunnelReady: async (url) => {
-        const displayUrl = buildTunnelUrl(url, effectiveUiPassword, options.tunnelPasswordUrl);
+      onTunnelReady: async (url, connectUrl) => {
+        const displayUrl = connectUrl || buildTunnelUrl(url, effectiveUiPassword, options.tunnelPasswordUrl);
         console.log(`\n🌐 Tunnel URL: \x1b[36m${displayUrl}\x1b[0m\n`);
-        if (options.tunnelPasswordUrl && effectiveUiPassword) {
+        if (connectUrl) {
+          console.log('🔑 One-time connect link (expires after first use)\n');
+        } else if (options.tunnelPasswordUrl && effectiveUiPassword) {
           console.log('🔑 Password is embedded in URL for auto-login\n');
         }
         if (options.tunnelQr) {

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -13096,12 +13096,16 @@ async function main(options = {}) {
               const bootstrapTtlMs = settings?.tunnelBootstrapTtlMs === null
                 ? null
                 : normalizeTunnelBootstrapTtlMs(settings?.tunnelBootstrapTtlMs);
-              tunnelAuthController.issueBootstrapToken({ ttlMs: bootstrapTtlMs });
-            }
-            if (onTunnelReady) {
-              if (tunnelUrl) {
-                onTunnelReady(tunnelUrl);
+              const bootstrapToken = tunnelAuthController.issueBootstrapToken({ ttlMs: bootstrapTtlMs });
+              const connectUrl = `${tunnelUrl.replace(/\/$/, '')}/connect?t=${encodeURIComponent(bootstrapToken.token)}`;
+              if (onTunnelReady) {
+                onTunnelReady(tunnelUrl, connectUrl);
+              } else {
+                console.log(`\n🌐 Tunnel URL: ${connectUrl}`);
+                console.log('🔑 One-time connect link (expires after first use)\n');
               }
+            } else if (onTunnelReady) {
+              onTunnelReady(tunnelUrl, null);
             }
           } catch (error) {
             console.error(`Failed to start Cloudflare tunnel: ${error.message}`);


### PR DESCRIPTION
## Problem

- `openchamber --try-cf-tunnel` starts a Cloudflare tunnel and generates a bootstrap token, but the token is discarded (return value of `issueBootstrapToken()` is never captured)
- The CLI builds a URL with `?token=<uiPassword>` via `buildTunnelUrl()`, but the tunnel auth system requires `/connect?t=<bootstrapToken>` — the UI password parameter is ignored for tunnel-scoped requests
- Remote users always see "Tunnel access required" with no way to authenticate, making `--try-cf-tunnel` unusable from the CLI

## Fix

- **server/index.js**: capture the bootstrap token, build the `/connect?t=...` URL, and pass it as a second argument to `onTunnelReady`; add fallback console print when no callback is provided (bun child process path)
- **cli.js**: use the connect URL when available instead of building a password URL; update QR code and console output accordingly

## Tested

- Verified `openchamber --try-cf-tunnel --tunnel-qr --tunnel-password-url` now prints the correct `/connect?t=...` URL and QR code
- Verified scanning the QR code successfully authenticates through the tunnel (no more "Tunnel access required" screen)