### PR TITLE
fix(ui): prevent session title from overflowing into drawer controls on mobile

### DIFF
--- a/packages/ui/src/components/chat/MobileSessionStatusBar.tsx
+++ b/packages/ui/src/components/chat/MobileSessionStatusBar.tsx
@@ -446,8 +446,8 @@ function SessionStatusHeader({
           <div className="w-full h-px bg-[var(--interactive-border)] my-1" />
         </div>
       )}
-      <div className="flex items-center gap-1.5">
-        <span className="text-[13px] text-[var(--surface-foreground)] truncate leading-none">
+      <div className="flex items-center gap-1.5 min-w-0">
+        <span className="flex-1 min-w-0 text-[13px] text-[var(--surface-foreground)] truncate leading-none">
           {currentSessionTitle}
         </span>
         {childIndicators.length > 0 && (


### PR DESCRIPTION
## Summary

Fixes #556 — session name bleeds into right-side elements (running indicator, unread count, token %, New button) in the mobile drawer on iPhone 13 mini.

## Root cause

`SessionStatusHeader` rendered the title row as `flex items-center gap-1.5` with no `min-w-0`. A flex container defaults to `min-width: auto`, so it expands to full text content width rather than shrinking. The title `<span>` had `truncate` applied but no width ceiling to truncate against — making it a no-op.

## Fix

Two-line change inside `SessionStatusHeader`:

- Added `min-w-0` to the title row flex container (establishes shrink budget)
- Added `flex-1 min-w-0` to the title `<span>` (gives `truncate` a ceiling to work against)

Child session indicators already sit outside the span so they remain unaffected.

<img width="372" height="638" alt="Screenshot 2026-02-28 at 9 43 10 PM" src="https://github.com/user-attachments/assets/c100bd04-94a4-45e4-88ec-225289545963" />
<img width="344" height="146" alt="Screenshot 2026-02-28 at 9 43 17 PM" src="https://github.com/user-attachments/assets/f56b075e-8e7e-46c0-8bea-4cc692718449" />



## Blast radius

- Single file: `MobileSessionStatusBar.tsx`
- `SessionStatusHeader` is file-private (unexported) — zero external API impact
- No tests to update