### PR TITLE
fix(git): stop PR section refresh loop causing React #185

### DIFF
--- a/packages/ui/src/components/views/git/PullRequestSection.tsx
+++ b/packages/ui/src/components/views/git/PullRequestSection.tsx
@@ -416,6 +416,7 @@ export const PullRequestSection: React.FC<{
   const lastRefreshAtRef = React.useRef(0);
   const lastDiscoveryPollAtRef = React.useRef(0);
   const statusRef = React.useRef<GitHubPullRequestStatus | null>(null);
+  const selectedRemoteNameRef = React.useRef<string | null>(selectedRemote?.name ?? null);
   const attemptedBodyHydrationRef = React.useRef<Set<string>>(new Set());
   const lastSyncedPrNumberRef = React.useRef<number | null>(null);
 
@@ -926,6 +927,10 @@ export const PullRequestSection: React.FC<{
     statusRef.current = status;
   }, [status]);
 
+  React.useEffect(() => {
+    selectedRemoteNameRef.current = selectedRemote?.name ?? null;
+  }, [selectedRemote?.name]);
+
   const refresh = React.useCallback(async (options?: { force?: boolean; onlyExistingPr?: boolean; silent?: boolean; markInitialResolved?: boolean }) => {
     if (!canShow) return;
     if (options?.onlyExistingPr && !statusRef.current?.pr) {
@@ -967,7 +972,7 @@ export const PullRequestSection: React.FC<{
     }
     setError(null);
     try {
-      const next = await github.prStatus(directory, branch, selectedRemote?.name);
+      const next = await github.prStatus(directory, branch, selectedRemoteNameRef.current ?? undefined);
       setStatus((prev) => {
         const nextPr = next.pr;
         const prevPr = prev?.pr;
@@ -1014,11 +1019,11 @@ export const PullRequestSection: React.FC<{
       }
       isRefreshInFlightRef.current = false;
     }
-  }, [branch, canShow, directory, github, githubAuthChecked, githubAuthStatus, selectedRemote?.name]);
+  }, [branch, canShow, directory, github, githubAuthChecked, githubAuthStatus]);
 
   // Refetch PR status when selected remote changes
   const handleRemoteChange = React.useCallback((remote: GitRemote) => {
-    setSelectedRemote(remote);
+    setSelectedRemote((prev) => (prev?.name === remote.name ? prev : remote));
     // Clear current status and refetch
     setStatus(null);
     setError(null);
@@ -1032,24 +1037,26 @@ export const PullRequestSection: React.FC<{
     setBody(snapshot?.body ?? '');
     setDraft(snapshot?.draft ?? false);
     setTargetBaseBranch(snapshot?.targetBaseBranch ? normalizeBranchRef(snapshot.targetBaseBranch) : normalizeBranchRef(baseBranch));
-    setSelectedRemote(
-      pickInitialPrRemote(remotes, {
-        selectedRemoteName: snapshot?.selectedRemoteName,
-        trackingBranch,
-      })
-    );
+    const nextRemote = pickInitialPrRemote(remotes, {
+      selectedRemoteName: snapshot?.selectedRemoteName,
+      trackingBranch,
+    });
+    setSelectedRemote((prev) => (prev?.name === nextRemote?.name ? prev : nextRemote));
     setStatus(statusSnapshot);
     setError(null);
     setIsInitialStatusResolved(Boolean(statusSnapshot));
+  }, [baseBranch, branch, remotes, snapshotKey, trackingBranch]);
+
+  React.useEffect(() => {
     void refresh({ force: true, markInitialResolved: true });
-  }, [baseBranch, branch, refresh, remotes, snapshotKey, trackingBranch]);
+  }, [snapshotKey, refresh]);
 
   // Refetch when selected remote changes
   React.useEffect(() => {
-    if (selectedRemote) {
+    if (selectedRemote?.name) {
       void refresh({ force: true, markInitialResolved: true });
     }
-  }, [selectedRemote, refresh]);
+  }, [selectedRemote?.name, refresh]);
 
   React.useEffect(() => {
     const onFocus = () => {


### PR DESCRIPTION
## Summary
- Fixes a React `#185` (maximum update depth exceeded) crash in the Git PR section.
- Breaks the refresh/state feedback loop by decoupling refresh callback identity from `selectedRemote` object changes.
- Avoids no-op remote state writes and narrows refresh triggers to stable dependencies (`snapshotKey` and `selectedRemote?.name`).

## Why this happened
The PR panel had effects that both updated remote-related state and depended on a `refresh` callback that itself depended on remote selection. Under repeated remote/status updates, this created a render-effect-setState cycle and React aborted with error `#185`.

## Validation
- `bun run type-check`
- `bun run lint`
- `bun run build`

## How it looked before fix
<img width="500" height="1080" alt="Screenshot 2026-03-03 at 13 53 22" src="https://github.com/user-attachments/assets/f4f101f2-7edf-4420-8278-1e5dc19df30b" />
<img width="500" height="1080" alt="Screenshot 2026-03-03 at 13 53 28" src="https://github.com/user-attachments/assets/2d190ef9-aa5e-43c9-9bd4-f896ec6c3236" />
