### PR TITLE
fix: remove orientation any to respect OS rotation lock

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -170,7 +170,6 @@
           display: 'standalone',
           background_color: '#151313',
           theme_color: '#edb449',
-          orientation: 'any',
           icons: [
             { src: `${baseUrl}/pwa-192.png`, sizes: '192x192', type: 'image/png', purpose: 'any' },
             { src: `${baseUrl}/pwa-512.png`, sizes: '512x512', type: 'image/png', purpose: 'any' },


### PR DESCRIPTION
Fixes #598

Removes the orientation key from the PWA manifest to allow the OS to manage orientation natively for PWAs.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*