### PR TITLE
feat: support custom localhost allowlist via environment variable

### DIFF
--- a/packages/web/server/lib/opencode/tunnel-auth.js
+++ b/packages/web/server/lib/opencode/tunnel-auth.js
@@ -77,7 +77,18 @@ const normalizeHost = (candidate) => {
   if (!trimmed) {
     return null;
   }
-  return trimmed.replace(/:\d+$/, '');
+
+  const bracketedIpv6Match = trimmed.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (bracketedIpv6Match) {
+    return bracketedIpv6Match[1];
+  }
+
+  const colonCount = trimmed.split(':').length - 1;
+  if (colonCount === 1 && /:\d+$/.test(trimmed)) {
+    return trimmed.replace(/:\d+$/, '');
+  }
+
+  return trimmed;
 };
 
 let cachedCustomLocalHostRaw = null;


### PR DESCRIPTION
Allow tunnel auth localhost checks to include hosts from CUSTOM_LOCALHOST Parse CUSTOM_LOCALHOST with space/comma/semicolon separators and host normalization Cache parsed CUSTOM_LOCALHOST values to avoid repeated parsing at runtime

Fix: #549 