### PR TITLE
fix: add orientation lock to dynamic PWA manifest

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -168,6 +168,7 @@
           start_url: `${baseUrl}/`,
           scope: `${baseUrl}/`,
           display: 'standalone',
+          orientation: 'portrait-primary',
           background_color: '#151313',
           theme_color: '#edb449',
           icons: [


### PR DESCRIPTION
**Problem**
The PWA was not respecting orientation lock on Android devices. The static site.webmanifest file contained `"orientation": "portrait-primary"`, but the dynamically generated manifest (built at runtime in index.html) was missing this property.

**Solution**
Added orientation: `'portrait-primary'` to the `buildManifest()` function in [packages/web/index.html](vscode-webview://1d0jd43f7uq5c0sk70p9areo26ghjttga22c0e86452ct5ssa6i4/packages/web/index.html:171).

**Changes**
Added single line: `orientation: 'portrait-primary'` to the manifest object returned by `buildManifest()`
Behavior
If orientation lock is ON → PWA stays in portrait (respects system lock)
If orientation lock is OFF → PWA can rotate (follows system auto-rotate)
The manifest orientation property is a preference/hint, not a hard lock, so it respects the user's system-level rotation settings.