### PR TITLE
Add keyboard shortcut to close context panel tab

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -492,10 +492,10 @@ function App({ apis }: AppProps) {
   // VS Code runtime - simplified layout without git/terminal views
   if (isVSCodeRuntime) {
     // Check if this is the Agent Manager panel
-    const panelType = typeof window !== 'undefined' 
-      ? (window as { __OPENCHAMBER_PANEL_TYPE__?: 'chat' | 'agentManager' }).__OPENCHAMBER_PANEL_TYPE__ 
+    const panelType = typeof window !== 'undefined'
+      ? (window as { __OPENCHAMBER_PANEL_TYPE__?: 'chat' | 'agentManager' }).__OPENCHAMBER_PANEL_TYPE__
       : 'chat';
-    
+
     if (panelType === 'agentManager') {
     return (
       <ErrorBoundary>
@@ -510,7 +510,7 @@ function App({ apis }: AppProps) {
       </ErrorBoundary>
     );
     }
-    
+
     return (
       <ErrorBoundary>
         <RuntimeAPIProvider apis={apis}>

--- a/packages/ui/src/components/ui/HelpDialog.tsx
+++ b/packages/ui/src/components/ui/HelpDialog.tsx
@@ -170,6 +170,12 @@ export const HelpDialog: React.FC = () => {
           icon: RiTimeLine,
           keys: '',
         },
+        {
+          id: 'close_tab',
+          description: 'Close Context Panel Tab',
+          icon: RiCloseCircleLine,
+          keys: '',
+        },
       ],
     },
     {

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -342,6 +342,35 @@ export const useKeyboardShortcuts = () => {
         return;
       }
 
+      if (eventMatchesShortcut(e, combo('close_tab'))) {
+        const activeElement = document.activeElement;
+        const isContextPanelFocused = activeElement?.closest('[data-context-panel="true"]');
+
+        if (!isContextPanelFocused) {
+          return;
+        }
+
+        const { contextPanelByDirectory, closeContextPanelTab } = useUIStore.getState();
+
+        for (const [directoryKey, panelState] of Object.entries(contextPanelByDirectory)) {
+          if (!panelState?.isOpen || !panelState.activeTabId) {
+            continue;
+          }
+
+          const tabs = panelState.tabs ?? [];
+          if (tabs.length <= 1) {
+            continue;
+          }
+
+          e.preventDefault();
+          e.stopPropagation();
+          closeContextPanelTab(directoryKey, panelState.activeTabId);
+          return;
+        }
+
+        return;
+      }
+
       if (e.key === 'Escape') {
         const target = e.target as Element | null;
         const isInsideDialog = Boolean(target?.closest('[role="dialog"]'));

--- a/packages/ui/src/lib/shortcuts.ts
+++ b/packages/ui/src/lib/shortcuts.ts
@@ -372,6 +372,13 @@ const SHORTCUT_ACTIONS: ReadonlyArray<ShortcutAction> = [
     label: 'Switch to tab 9',
     description: 'Switch to the ninth tab or project',
   },
+  {
+    id: 'close_tab',
+    defaultCombo: 'mod+w',
+    label: 'Close tab',
+    description: 'Close the current tab or project',
+    customizable: true,
+  },
 ] as const;
 
 export function normalizeCombo(combo: ShortcutCombo): ShortcutCombo {


### PR DESCRIPTION
Hello,
I would like to propose this CMD+W shortcut to close current opened tab.
Not sure if it works in the Tauri version because I could not test it, but I'm pretty sure we will have to prevent window close somehow. I'm open to discussion to provide a better PR if needed.
Cheers, Alex