### PR TITLE
fix(ui): split multi-file patches and add per-diff error boundary

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -886,6 +886,25 @@ const renderPathLikeGitChanges = (path: string, grow = true) => {
     );
 };
 
+const splitMultiFilePatch = (patch: string): DiffPatchEntry[] | null => {
+    const segments = patch.split(/(?=^diff --git )/m).filter((s) => s.trim());
+    if (segments.length <= 1) {
+        return null;
+    }
+
+    return segments.map((segment, index) => {
+        const headerLine = segment.match(/^diff --git (.+)$/m)?.[1] ?? '';
+        // lastIndexOf handles filenames that contain spaces
+        const bIdx = headerLine.lastIndexOf(' b/');
+        const title = bIdx !== -1 ? headerLine.slice(bIdx + 3) : `File ${index + 1}`;
+        return {
+            id: `${title}-${index}`,
+            title,
+            patch: segment,
+        } satisfies DiffPatchEntry;
+    });
+};
+
 const getDiffPatchEntries = (
     metadata: Record<string, unknown> | undefined,
     fallbackDiff: string,
@@ -927,6 +946,14 @@ const getDiffPatchEntries = (
         return entries;
     }
 
+    const splitEntries = splitMultiFilePatch(fallbackDiff);
+    if (splitEntries) {
+        return splitEntries.map((entry) => ({
+            ...entry,
+            title: getRelativePath(entry.title, currentDirectory),
+        }));
+    }
+
     return [
         {
             id: 'diff-0',
@@ -935,6 +962,31 @@ const getDiffPatchEntries = (
         },
     ];
 };
+
+class DiffPreviewErrorBoundary extends React.Component<
+    { children: React.ReactNode },
+    { hasError: boolean }
+> {
+    constructor(props: { children: React.ReactNode }) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): { hasError: boolean } {
+        return { hasError: true };
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <div className="typography-meta text-muted-foreground/70 p-2">
+                    Unable to render diff preview.
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}
 
 const DiffPreview: React.FC<DiffPreviewProps> = React.memo(({ diff, pierreTheme, pierreThemeType, diffViewMode }) => {
     return (
@@ -1380,12 +1432,14 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                                     {renderPathLikeGitChanges(entry.title)}
                                 </div>
                             ) : null}
-                            <DiffPreview
-                                diff={entry.patch}
-                                pierreTheme={pierreTheme}
-                                pierreThemeType={pierreThemeType}
-                                diffViewMode={diffViewMode}
-                            />
+                            <DiffPreviewErrorBoundary key={entry.id}>
+                                <DiffPreview
+                                    diff={entry.patch}
+                                    pierreTheme={pierreTheme}
+                                    pierreThemeType={pierreThemeType}
+                                    diffViewMode={diffViewMode}
+                                />
+                            </DiffPreviewErrorBoundary>
                         </div>
                     ))}
                 </div>,


### PR DESCRIPTION
## Problem

When an AI agent edits multiple files simultaneously (via `apply_patch` or `multiedit`), OpenCode stores the combined diff in `metadata.diff` as a standard multi-file unified diff. If `metadata.files[].diff` is not populated, `getDiffPatchEntries` falls back to passing the entire multi-file string to a single `<PatchDiff>` component.

`PatchDiff` from `@pierre/diffs` only accepts patches with **exactly 1 file diff**, so it throws:

```
Error: FileDiff: Provided patch must contain exactly 1 file diff
```

This error propagates to `ChatErrorBoundary`, which wraps the entire chat view. Clicking "Reset Chat" clears the error state, but the same messages immediately re-render and throw again — making the session **permanently unviewable in the VSCode chat UI** (while the TUI is unaffected, as it does not use Pierre).

Fixes: https://github.com/openchamber/openchamber/issues (reported by user)

## Solution

**1. `splitMultiFilePatch` — split before rendering**

Splits a git unified diff on `diff --git` boundaries into individual per-file entries. When the fallback `metadata.diff` contains multiple files, each gets its own `DiffPatchEntry` and its own `<PatchDiff>` call (one file each).

**2. `DiffPreviewErrorBoundary` — isolate rendering failures**

Wraps each `<DiffPreview>` in a React error boundary. Any edge-case rendering failure (malformed patch, unexpected Pierre behavior) shows a localized "Unable to render diff preview." message instead of crashing the entire session.

## Testing

Reproduce by triggering a tool call that edits 2+ files when `metadata.files` is absent — the diff viewer should now render each file separately instead of throwing.