### PR TITLE
feat(pwa): add keyboard tools toggle and optimize iOS safe area adaptation

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -155,7 +155,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
     const { currentProviderId, currentModelId, currentVariant, currentAgentName, setAgent, getVisibleAgents } = useConfigStore();
     const agents = getVisibleAgents();
     const primaryAgents = React.useMemo(() => agents.filter((agent) => agent.mode === 'primary'), [agents]);
-    const { isMobile, inputBarOffset, isKeyboardOpen, setTimelineDialogOpen, cornerRadius, persistChatDraft, isExpandedInput, setExpandedInput } = useUIStore();
+    const { isMobile, inputBarOffset, isKeyboardOpen, setTimelineDialogOpen, cornerRadius, persistChatDraft, isExpandedInput, setExpandedInput, showMobileKeyboardTools } = useUIStore();
     const { working } = useAssistantStatus();
     const { currentTheme } = useThemeSystem();
     const chatSearchDirectory = useChatSearchDirectory();
@@ -2720,18 +2720,22 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
                         {isMobile ? (
                             <>
                                 <div className="flex w-full items-center justify-between gap-x-1.5">
-                                    <div className="flex items-center gap-x-1">
-                                        {attachmentsControls}
-                                    </div>
-                                    <div className="flex items-center min-w-0 gap-x-1 justify-end">
-                                        <div className="flex items-center gap-x-1 min-w-0 max-w-[60vw] flex-shrink">
-                                            <MobileModelButton onOpenModel={handleOpenMobileControls} className="min-w-0 flex-shrink" />
-                                            <MobileAgentButton
-                                                onOpenAgentPanel={() => setMobileControlsPanel('agent')}
-                                                onCycleAgent={handleCycleAgent}
-                                                className="min-w-0 flex-shrink"
-                                            />
+                                    {showMobileKeyboardTools && (
+                                        <div className="flex items-center gap-x-1">
+                                            {attachmentsControls}
                                         </div>
+                                    )}
+                                    <div className={cn("flex items-center min-w-0 gap-x-1 justify-end", !showMobileKeyboardTools && "w-full")}>
+                                        {showMobileKeyboardTools && (
+                                            <div className="flex items-center gap-x-1 min-w-0 max-w-[60vw] flex-shrink">
+                                                <MobileModelButton onOpenModel={handleOpenMobileControls} className="min-w-0 flex-shrink" />
+                                                <MobileAgentButton
+                                                    onOpenAgentPanel={() => setMobileControlsPanel('agent')}
+                                                    onCycleAgent={handleCycleAgent}
+                                                    className="min-w-0 flex-shrink"
+                                                />
+                                            </div>
+                                        )}
                                         <div className="flex items-center gap-x-1 flex-shrink-0">
                                             <BrowserVoiceButton />
                                             {actionButtons}

--- a/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
@@ -117,7 +117,7 @@ const VisualSectionContent: React.FC = () => {
 
 // Chat section: Default Tool Output, User message rendering, Diff layout, Mobile status bar, Show reasoning traces, Justification activity, Activity header timestamps, Queue mode, Persist draft
 const ChatSectionContent: React.FC = () => {
-    return <OpenChamberVisualSettings visibleSettings={['toolOutput', 'mermaidRendering', 'userMessageRendering', 'stickyUserHeader', 'diffLayout', 'mobileStatusBar', 'dotfiles', 'reasoning', 'textJustificationActivity', 'activityHeaderTimestamps', 'queueMode', 'persistDraft']} />;
+    return <OpenChamberVisualSettings visibleSettings={['toolOutput', 'mermaidRendering', 'userMessageRendering', 'stickyUserHeader', 'diffLayout', 'mobileStatusBar', 'mobileKeyboardTools', 'dotfiles', 'reasoning', 'textJustificationActivity', 'activityHeaderTimestamps', 'queueMode', 'persistDraft']} />;
 };
 
 // Sessions section: Default model & agent, Session retention, Memory limits

--- a/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
@@ -124,7 +124,7 @@ const normalizeUserMessageRenderingMode = (mode: unknown): 'markdown' | 'plain' 
     return mode === 'markdown' ? 'markdown' : 'plain';
 };
 
-export type VisibleSetting = 'theme' | 'pwaInstallName' | 'fontSize' | 'terminalFontSize' | 'spacing' | 'cornerRadius' | 'inputBarOffset' | 'navRail' | 'toolOutput' | 'mermaidRendering' | 'userMessageRendering' | 'stickyUserHeader' | 'diffLayout' | 'mobileStatusBar' | 'dotfiles' | 'reasoning' | 'queueMode' | 'textJustificationActivity' | 'activityHeaderTimestamps' | 'terminalQuickKeys' | 'persistDraft';
+export type VisibleSetting = 'theme' | 'pwaInstallName' | 'fontSize' | 'terminalFontSize' | 'spacing' | 'cornerRadius' | 'inputBarOffset' | 'navRail' | 'toolOutput' | 'mermaidRendering' | 'userMessageRendering' | 'stickyUserHeader' | 'diffLayout' | 'mobileStatusBar' | 'mobileKeyboardTools' | 'dotfiles' | 'reasoning' | 'queueMode' | 'textJustificationActivity' | 'activityHeaderTimestamps' | 'terminalQuickKeys' | 'persistDraft';
 
 interface OpenChamberVisualSettingsProps {
     /** Which settings to show. If undefined, shows all. */
@@ -173,6 +173,8 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
     const setNavRailExpanded = useUIStore(state => state.setNavRailExpanded);
     const showMobileSessionStatusBar = useUIStore(state => state.showMobileSessionStatusBar);
     const setShowMobileSessionStatusBar = useUIStore(state => state.setShowMobileSessionStatusBar);
+    const showMobileKeyboardTools = useUIStore(state => state.showMobileKeyboardTools);
+    const setShowMobileKeyboardTools = useUIStore(state => state.setShowMobileKeyboardTools);
     const {
         themeMode,
         setThemeMode,
@@ -240,6 +242,7 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
         || shouldShow('stickyUserHeader')
         || shouldShow('diffLayout')
         || (shouldShow('mobileStatusBar') && isMobile)
+        || (shouldShow('mobileKeyboardTools') && isMobile)
         || shouldShow('dotfiles')
         || shouldShow('reasoning')
         || shouldShow('queueMode')
@@ -887,7 +890,7 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
                                 </div>
                             )}
 
-                            {(shouldShow('stickyUserHeader') || (shouldShow('mobileStatusBar') && isMobile) || shouldShow('dotfiles') || shouldShow('queueMode') || shouldShow('persistDraft') || shouldShow('reasoning') || shouldShow('textJustificationActivity')) && (
+                            {(shouldShow('stickyUserHeader') || (shouldShow('mobileStatusBar') && isMobile) || (shouldShow('mobileKeyboardTools') && isMobile) || shouldShow('dotfiles') || shouldShow('queueMode') || shouldShow('persistDraft') || shouldShow('reasoning') || shouldShow('textJustificationActivity')) && (
                                 <section className="p-2 space-y-0.5">
                                     {shouldShow('stickyUserHeader') && (
                                         <div
@@ -932,6 +935,29 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
                                                 ariaLabel="Show mobile status bar"
                                             />
                                             <span className="typography-ui-label text-foreground">Show Mobile Status Bar</span>
+                                        </div>
+                                    )}
+
+                                    {shouldShow('mobileKeyboardTools') && isMobile && (
+                                        <div
+                                            className="group flex cursor-pointer items-center gap-2 py-1.5"
+                                            role="button"
+                                            tabIndex={0}
+                                            aria-pressed={showMobileKeyboardTools}
+                                            onClick={() => setShowMobileKeyboardTools(!showMobileKeyboardTools)}
+                                            onKeyDown={(event) => {
+                                                if (event.key === ' ' || event.key === 'Enter') {
+                                                    event.preventDefault();
+                                                    setShowMobileKeyboardTools(!showMobileKeyboardTools);
+                                                }
+                                            }}
+                                        >
+                                            <Checkbox
+                                                checked={showMobileKeyboardTools}
+                                                onChange={setShowMobileKeyboardTools}
+                                                ariaLabel="Show mobile keyboard tools"
+                                            />
+                                            <span className="typography-ui-label text-foreground">Show Mobile Keyboard Tools</span>
                                         </div>
                                     )}
 

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -554,6 +554,7 @@ interface UIStore {
   userMessageRenderingMode: UserMessageRenderingMode;
   stickyUserHeader: boolean;
   showMobileSessionStatusBar: boolean;
+  showMobileKeyboardTools: boolean;
   isMobileSessionStatusBarCollapsed: boolean;
   viewPagerPage: 'left' | 'center' | 'right';
 
@@ -664,6 +665,7 @@ interface UIStore {
   setUserMessageRenderingMode: (value: UserMessageRenderingMode) => void;
   setStickyUserHeader: (value: boolean) => void;
   setShowMobileSessionStatusBar: (value: boolean) => void;
+  setShowMobileKeyboardTools: (value: boolean) => void;
   setIsMobileSessionStatusBarCollapsed: (value: boolean) => void;
   setViewPagerPage: (page: 'left' | 'center' | 'right') => void;
   toggleExpandedInput: () => void;
@@ -774,6 +776,7 @@ export const useUIStore = create<UIStore>()(
         userMessageRenderingMode: 'markdown',
         stickyUserHeader: true,
         showMobileSessionStatusBar: true,
+        showMobileKeyboardTools: true,
         isMobileSessionStatusBarCollapsed: false,
         isExpandedInput: false,
         shortcutOverrides: {},
@@ -1680,6 +1683,9 @@ export const useUIStore = create<UIStore>()(
         setShowMobileSessionStatusBar: (value) => {
           set({ showMobileSessionStatusBar: value });
         },
+        setShowMobileKeyboardTools: (value) => {
+          set({ showMobileKeyboardTools: value });
+        },
         setIsMobileSessionStatusBarCollapsed: (value) => {
           set({ isMobileSessionStatusBarCollapsed: value });
         },
@@ -1858,6 +1864,7 @@ export const useUIStore = create<UIStore>()(
           userMessageRenderingMode: state.userMessageRenderingMode,
           stickyUserHeader: state.stickyUserHeader,
           showMobileSessionStatusBar: state.showMobileSessionStatusBar,
+          showMobileKeyboardTools: state.showMobileKeyboardTools,
           isMobileSessionStatusBarCollapsed: state.isMobileSessionStatusBarCollapsed,
           shortcutOverrides: state.shortcutOverrides,
         })

--- a/packages/ui/src/styles/mobile.css
+++ b/packages/ui/src/styles/mobile.css
@@ -243,7 +243,7 @@
     --oc-safe-area-top: env(safe-area-inset-top, 0);
     --oc-safe-area-right: env(safe-area-inset-right, 0);
     --oc-safe-area-bottom: env(safe-area-inset-bottom, 0);
-    --oc-safe-area-bottom-visual: clamp(0px, calc(var(--oc-safe-area-bottom) * 0.05), 4px);
+    --oc-safe-area-bottom-visual: clamp(0px, calc(var(--oc-safe-area-bottom) * 0.6), 22px);
     --oc-safe-area-left: env(safe-area-inset-left, 0);
   }
 
@@ -261,7 +261,7 @@
       --oc-safe-area-top: env(safe-area-inset-top, 0);
       --oc-safe-area-right: env(safe-area-inset-right, 0);
       --oc-safe-area-bottom: env(safe-area-inset-bottom, 0);
-      --oc-safe-area-bottom-visual: clamp(0px, calc(var(--oc-safe-area-bottom) * 0.05), 4px);
+      --oc-safe-area-bottom-visual: clamp(0px, calc(var(--oc-safe-area-bottom) * 0.6), 22px);
       --oc-safe-area-left: env(safe-area-inset-left, 0);
     }
 
@@ -289,7 +289,7 @@
 
     /* iOS keyboard home indicator safe area - used when keyboard is open */
     .ios-keyboard-safe-area {
-      padding-bottom: calc(var(--oc-keyboard-home-indicator, 34px) + var(--oc-safe-area-bottom-visual, 0px)) !important;
+      padding-bottom: var(--oc-keyboard-home-indicator, 34px) !important;
     }
 
     /* Prevent keyboard-induced page scroll on iOS PWA */
@@ -362,7 +362,7 @@
       --oc-safe-area-top: env(safe-area-inset-top, 0);
       --oc-safe-area-right: env(safe-area-inset-right, 0);
       --oc-safe-area-bottom: env(safe-area-inset-bottom, 0);
-      --oc-safe-area-bottom-visual: clamp(0px, calc(var(--oc-safe-area-bottom) * 0.05), 4px);
+      --oc-safe-area-bottom-visual: clamp(0px, calc(var(--oc-safe-area-bottom) * 0.6), 22px);
       --oc-safe-area-left: env(safe-area-inset-left, 0);
     }
 
@@ -445,7 +445,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: var(--oc-safe-area-bottom-visual, var(--oc-safe-area-bottom, env(safe-area-inset-bottom, 0)));
+    height: var(--oc-safe-area-bottom, env(safe-area-inset-bottom, 0));
     background: linear-gradient(
       to top,
       var(--background) 0%,


### PR DESCRIPTION
## Summary

- **Keyboard Tools Toggle**: Adds a new setting (Settings → Visual → Mobile Keyboard Tools) to show/hide the mobile keyboard toolbar items (attachments, model selector, agent selector). When hidden, only voice and send/stop buttons remain, providing a cleaner input experience.
- **iOS PWA Safe Area Optimization**: Fixes inadequate bottom safe area padding on iOS PWA. The `--oc-safe-area-bottom-visual` variable now provides meaningful clearance (~20px on iPhone) for the home indicator instead of the previous negligible ~1.7px. The home indicator blur gradient properly covers the full safe area zone, and keyboard-open padding removes redundant double-padding.

## Changes

| File | Change |
|------|--------|
| `useUIStore.ts` | Add `showMobileKeyboardTools` boolean + setter (default: true, persisted) |
| `OpenChamberVisualSettings.tsx` | Add toggle checkbox in Visual settings (mobile only) |
| `OpenChamberPage.tsx` | Include `mobileKeyboardTools` in Chat section visible settings |
| `ChatInput.tsx` | Conditionally render toolbar items based on toggle |
| `mobile.css` | Optimize safe area visual calc (0.05→0.6, 4px→22px cap), fix blur gradient height, simplify keyboard safe area |

## Verification
- `bun run type-check` ✅
- `bun run lint` ✅
- `bun run build` ✅