### PR TITLE
fix: project actions on windows using \r input for enter

### DIFF
--- a/packages/ui/src/components/layout/ProjectActionsButton.tsx
+++ b/packages/ui/src/components/layout/ProjectActionsButton.tsx
@@ -499,7 +499,7 @@ export const ProjectActionsButton = ({
       };
 
       const normalizedCommand = stripControlChars(action.command.trim().replace(/\r\n|\r/g, '\n'));
-      await terminal.sendInput(activeSessionId, `${normalizedCommand}\n\u0004`);
+      await terminal.sendInput(activeSessionId, `${normalizedCommand}\r`);
     } catch (error) {
       setRunningByKey((prev) => {
         const next = { ...prev };


### PR DESCRIPTION
## Problem
On windows, I created an action to open the current folder in windows explorer using this command:
`start .`
It opens that command in a terminal, but it fails to run, because openchamber does not send the correct enter key that windows will recognize. It just displays this in the terminal:
`>start .^D`

## My fix:
- Change project actions to submit commands like a real Enter key
- Remove the trailing Ctrl-D / EOT byte that Windows echoes as ^D

```
const normalizedCommand = stripControlChars(action.command.trim().replace(/\r\n|\r/g, '\n'));
await terminal.sendInput(activeSessionId, `${normalizedCommand}\r`);
```

I think that '\r' is the safer cross-platform choice here?

- In terminal/PTTY input, Enter is generally represented as carriage return, and the shell/terminal layer handles it correctly on Linux, macOS, and Windows.
- openchamber’s normal terminal path already uses '\r' for Enter in packages/ui/src/components/terminal/TerminalViewport.tsx, so matching that behavior is the best signal.
- '\n' often also works in some cases on Unix-like systems, but it is less accurate for emulating an actual Enter key press.
- '\u0004' on Unix means EOF/Ctrl-D, and on Windows it gets echoed as ^D, so it should not be appended for command submission.

One nuance:

- If an action were intentionally trying to send EOF to a running program after stdin input, \u0004 could be meaningful on Unix.
- But I assume that you just want "run this shell command", and '\r' is the correct behavior on all three platforms.

Consider that:
- normal terminal Enter in packages/ui/src/components/terminal/TerminalViewport.tsx sends '\r'
- project actions currently send '\n\u0004'
- on Windows shells, \u0004 becomes visible as ^D
## Testing
I built and ran openchamber again and verified that it now works correctly on windows.