### PR TITLE
Feat: spell check toggle for desktop

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -155,7 +155,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
     const { currentProviderId, currentModelId, currentVariant, currentAgentName, setAgent, getVisibleAgents } = useConfigStore();
     const agents = getVisibleAgents();
     const primaryAgents = React.useMemo(() => agents.filter((agent) => agent.mode === 'primary'), [agents]);
-    const { isMobile, inputBarOffset, isKeyboardOpen, setTimelineDialogOpen, cornerRadius, persistChatDraft, chatInputSpellcheckEnabled, isExpandedInput, setExpandedInput } = useUIStore();
+    const { isMobile, inputBarOffset, isKeyboardOpen, setTimelineDialogOpen, cornerRadius, persistChatDraft, inputSpellcheckEnabled, isExpandedInput, setExpandedInput } = useUIStore();
     const { working } = useAssistantStatus();
     const { currentTheme } = useThemeSystem();
     const chatSearchDirectory = useChatSearchDirectory();
@@ -2682,7 +2682,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
                             disabled={!currentSessionId && !newSessionDraftOpen}
                             autoCorrect={isMobile ? "on" : "off"}
                             autoCapitalize={isMobile ? "sentences" : "off"}
-                            spellCheck={isMobile || chatInputSpellcheckEnabled}
+                            spellCheck={isMobile || inputSpellcheckEnabled}
                             fillContainer={isDesktopExpanded}
                             outerClassName={cn('focus-within:ring-0', isDesktopExpanded && 'flex-1 min-h-0')}
                             className={cn(

--- a/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
@@ -117,7 +117,7 @@ const VisualSectionContent: React.FC = () => {
 
 // Chat section: Default Tool Output, User message rendering, Diff layout, Mobile status bar, Show reasoning traces, Justification activity, Activity header timestamps, Queue mode, Persist draft
 const ChatSectionContent: React.FC = () => {
-    return <OpenChamberVisualSettings visibleSettings={['toolOutput', 'mermaidRendering', 'userMessageRendering', 'stickyUserHeader', 'diffLayout', 'mobileStatusBar', 'dotfiles', 'reasoning', 'textJustificationActivity', 'activityHeaderTimestamps', 'queueMode', 'persistDraft', 'chatInputSpellcheck']} />;
+    return <OpenChamberVisualSettings visibleSettings={['toolOutput', 'mermaidRendering', 'userMessageRendering', 'stickyUserHeader', 'diffLayout', 'mobileStatusBar', 'dotfiles', 'reasoning', 'textJustificationActivity', 'activityHeaderTimestamps', 'queueMode', 'persistDraft', 'inputSpellcheck']} />;
 };
 
 // Sessions section: Default model & agent, Session retention, Memory limits

--- a/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
@@ -124,7 +124,7 @@ const normalizeUserMessageRenderingMode = (mode: unknown): 'markdown' | 'plain' 
     return mode === 'markdown' ? 'markdown' : 'plain';
 };
 
-export type VisibleSetting = 'theme' | 'pwaInstallName' | 'fontSize' | 'terminalFontSize' | 'spacing' | 'cornerRadius' | 'inputBarOffset' | 'navRail' | 'toolOutput' | 'mermaidRendering' | 'userMessageRendering' | 'stickyUserHeader' | 'diffLayout' | 'mobileStatusBar' | 'dotfiles' | 'reasoning' | 'queueMode' | 'textJustificationActivity' | 'activityHeaderTimestamps' | 'terminalQuickKeys' | 'persistDraft' | 'chatInputSpellcheck';
+export type VisibleSetting = 'theme' | 'pwaInstallName' | 'fontSize' | 'terminalFontSize' | 'spacing' | 'cornerRadius' | 'inputBarOffset' | 'navRail' | 'toolOutput' | 'mermaidRendering' | 'userMessageRendering' | 'stickyUserHeader' | 'diffLayout' | 'mobileStatusBar' | 'dotfiles' | 'reasoning' | 'queueMode' | 'textJustificationActivity' | 'activityHeaderTimestamps' | 'terminalQuickKeys' | 'persistDraft' | 'inputSpellcheck';
 
 interface OpenChamberVisualSettingsProps {
     /** Which settings to show. If undefined, shows all. */
@@ -169,8 +169,8 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
     const setQueueMode = useMessageQueueStore(state => state.setQueueMode);
     const persistChatDraft = useUIStore(state => state.persistChatDraft);
     const setPersistChatDraft = useUIStore(state => state.setPersistChatDraft);
-    const chatInputSpellcheckEnabled = useUIStore(state => state.chatInputSpellcheckEnabled);
-    const setChatInputSpellcheckEnabled = useUIStore(state => state.setChatInputSpellcheckEnabled);
+    const inputSpellcheckEnabled = useUIStore(state => state.inputSpellcheckEnabled);
+    const setInputSpellcheckEnabled = useUIStore(state => state.setInputSpellcheckEnabled);
     const isNavRailExpanded = useUIStore(state => state.isNavRailExpanded);
     const setNavRailExpanded = useUIStore(state => state.setNavRailExpanded);
     const showMobileSessionStatusBar = useUIStore(state => state.showMobileSessionStatusBar);
@@ -198,10 +198,10 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
         void updateDesktopSettings({ stickyUserHeader: enabled });
     }, [setStickyUserHeader]);
 
-    const handleChatInputSpellcheckChange = React.useCallback((enabled: boolean) => {
-        setChatInputSpellcheckEnabled(enabled);
-        void updateDesktopSettings({ chatInputSpellcheckEnabled: enabled });
-    }, [setChatInputSpellcheckEnabled]);
+    const handleInputSpellcheckChange = React.useCallback((enabled: boolean) => {
+        setInputSpellcheckEnabled(enabled);
+        void updateDesktopSettings({ inputSpellcheckEnabled: enabled });
+    }, [setInputSpellcheckEnabled]);
 
     const lightThemes = React.useMemo(
         () => availableThemes
@@ -253,7 +253,7 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
         || shouldShow('textJustificationActivity')
         || shouldShow('activityHeaderTimestamps')
         || shouldShow('persistDraft')
-        || (!isMobile && shouldShow('chatInputSpellcheck'));
+        || (!isMobile && shouldShow('inputSpellcheck'));
     const selectedToolExpansionOption = TOOL_EXPANSION_OPTIONS.find((option) => option.value === toolCallExpansion);
 
     const showPwaInstallNameSetting = shouldShow('pwaInstallName') && isWebRuntime() && browserTab;
@@ -895,7 +895,7 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
                                 </div>
                             )}
 
-                            {(shouldShow('stickyUserHeader') || (shouldShow('mobileStatusBar') && isMobile) || shouldShow('dotfiles') || shouldShow('queueMode') || shouldShow('persistDraft') || (!isMobile && shouldShow('chatInputSpellcheck')) || shouldShow('reasoning') || shouldShow('textJustificationActivity')) && (
+                            {(shouldShow('stickyUserHeader') || (shouldShow('mobileStatusBar') && isMobile) || shouldShow('dotfiles') || shouldShow('queueMode') || shouldShow('persistDraft') || (!isMobile && shouldShow('inputSpellcheck')) || shouldShow('reasoning') || shouldShow('textJustificationActivity')) && (
                                 <section className="p-2 space-y-0.5">
                                     {shouldShow('stickyUserHeader') && (
                                         <div
@@ -1022,23 +1022,23 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
                                         </div>
                                     )}
 
-                                    {!isMobile && shouldShow('chatInputSpellcheck') && (
+                                    {!isMobile && shouldShow('inputSpellcheck') && (
                                         <div
                                             className="group flex cursor-pointer items-center gap-2 py-1.5"
                                             role="button"
                                             tabIndex={0}
-                                            aria-pressed={chatInputSpellcheckEnabled}
-                                            onClick={() => handleChatInputSpellcheckChange(!chatInputSpellcheckEnabled)}
+                                            aria-pressed={inputSpellcheckEnabled}
+                                            onClick={() => handleInputSpellcheckChange(!inputSpellcheckEnabled)}
                                             onKeyDown={(event) => {
                                                 if (event.key === ' ' || event.key === 'Enter') {
                                                     event.preventDefault();
-                                                    handleChatInputSpellcheckChange(!chatInputSpellcheckEnabled);
+                                                    handleInputSpellcheckChange(!inputSpellcheckEnabled);
                                                 }
                                             }}
                                         >
                                             <Checkbox
-                                                checked={chatInputSpellcheckEnabled}
-                                                onChange={handleChatInputSpellcheckChange}
+                                                checked={inputSpellcheckEnabled}
+                                                onChange={handleInputSpellcheckChange}
                                                 ariaLabel="Enable spellcheck in text inputs"
                                             />
                                             <span className="typography-ui-label text-foreground">Enable Spellcheck in Text Inputs</span>

--- a/packages/ui/src/components/views/git/CommitInput.tsx
+++ b/packages/ui/src/components/views/git/CommitInput.tsx
@@ -9,6 +9,7 @@ interface CommitInputProps {
   placeholder?: string;
   disabled?: boolean;
   hasTouchInput?: boolean;
+  isMobile?: boolean;
 }
 
 const MIN_HEIGHT = 38; // Single line height
@@ -20,9 +21,10 @@ export const CommitInput: React.FC<CommitInputProps> = ({
   placeholder = 'Commit message',
   disabled = false,
   hasTouchInput = false,
+  isMobile = false,
 }) => {
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
-  const chatInputSpellcheckEnabled = useUIStore((state) => state.chatInputSpellcheckEnabled);
+  const inputSpellcheckEnabled = useUIStore((state) => state.inputSpellcheckEnabled);
 
   // Auto-resize based on content (layout phase to avoid mount flicker)
   React.useLayoutEffect(() => {
@@ -47,7 +49,7 @@ export const CommitInput: React.FC<CommitInputProps> = ({
       disabled={disabled}
       autoCorrect={hasTouchInput ? 'on' : 'off'}
       autoCapitalize={hasTouchInput ? 'sentences' : 'off'}
-      spellCheck={hasTouchInput || chatInputSpellcheckEnabled}
+      spellCheck={isMobile || inputSpellcheckEnabled}
       scrollbarClassName="hidden"
       className={cn(
         'rounded-lg bg-transparent resize-none overflow-y-hidden',

--- a/packages/ui/src/components/views/git/CommitSection.tsx
+++ b/packages/ui/src/components/views/git/CommitSection.tsx
@@ -105,6 +105,7 @@ export const CommitSection: React.FC<CommitSectionProps> = ({
             placeholder="Commit message"
             disabled={commitAction !== null}
             hasTouchInput={hasTouchInput}
+            isMobile={isMobile}
           />
 
           {gitmojiEnabled && (

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -525,7 +525,7 @@ export interface SettingsPayload {
   queueModeEnabled?: boolean;
   gitmojiEnabled?: boolean;
   toolCallExpansion?: 'collapsed' | 'activity' | 'detailed' | 'changes';
-  chatInputSpellcheckEnabled?: boolean;
+  inputSpellcheckEnabled?: boolean;
   fontSize?: number;
   terminalFontSize?: number;
   padding?: number;

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -116,7 +116,7 @@ export type DesktopSettings = {
   gitModelId?: string;
   pwaAppName?: string;
   toolCallExpansion?: 'collapsed' | 'activity' | 'detailed' | 'changes';
-  chatInputSpellcheckEnabled?: boolean;
+  inputSpellcheckEnabled?: boolean;
   userMessageRenderingMode?: 'markdown' | 'plain';
   stickyUserHeader?: boolean;
   fontSize?: number;

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -374,8 +374,8 @@ const applyDesktopUiPreferences = (settings: DesktopSettings) => {
       store.setToolCallExpansion(settings.toolCallExpansion);
     }
   }
-  if (typeof settings.chatInputSpellcheckEnabled === 'boolean' && settings.chatInputSpellcheckEnabled !== store.chatInputSpellcheckEnabled) {
-    store.setChatInputSpellcheckEnabled(settings.chatInputSpellcheckEnabled);
+  if (typeof settings.inputSpellcheckEnabled === 'boolean' && settings.inputSpellcheckEnabled !== store.inputSpellcheckEnabled) {
+    store.setInputSpellcheckEnabled(settings.inputSpellcheckEnabled);
   }
   if (typeof settings.userMessageRenderingMode === 'string'
     && (settings.userMessageRenderingMode === 'markdown' || settings.userMessageRenderingMode === 'plain')) {
@@ -744,8 +744,8 @@ const sanitizeWebSettings = (payload: unknown): DesktopSettings | null => {
   ) {
     result.toolCallExpansion = candidate.toolCallExpansion;
   }
-  if (typeof candidate.chatInputSpellcheckEnabled === 'boolean') {
-    result.chatInputSpellcheckEnabled = candidate.chatInputSpellcheckEnabled;
+  if (typeof candidate.inputSpellcheckEnabled === 'boolean') {
+    result.inputSpellcheckEnabled = candidate.inputSpellcheckEnabled;
   }
   if (typeof candidate.userMessageRenderingMode === 'string'
     && (candidate.userMessageRenderingMode === 'markdown' || candidate.userMessageRenderingMode === 'plain')) {

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -550,7 +550,7 @@ interface UIStore {
 
   showTerminalQuickKeysOnDesktop: boolean;
   persistChatDraft: boolean;
-  chatInputSpellcheckEnabled: boolean;
+  inputSpellcheckEnabled: boolean;
   mermaidRenderingMode: MermaidRenderingMode;
   userMessageRenderingMode: UserMessageRenderingMode;
   stickyUserHeader: boolean;
@@ -661,7 +661,7 @@ interface UIStore {
   setSummaryLength: (value: number) => void;
   setMaxLastMessageLength: (value: number) => void;
   setPersistChatDraft: (value: boolean) => void;
-  setChatInputSpellcheckEnabled: (value: boolean) => void;
+  setInputSpellcheckEnabled: (value: boolean) => void;
   setMermaidRenderingMode: (value: MermaidRenderingMode) => void;
   setUserMessageRenderingMode: (value: UserMessageRenderingMode) => void;
   setStickyUserHeader: (value: boolean) => void;
@@ -772,7 +772,7 @@ export const useUIStore = create<UIStore>()(
 
         showTerminalQuickKeysOnDesktop: false,
         persistChatDraft: true,
-        chatInputSpellcheckEnabled: false,
+        inputSpellcheckEnabled: false,
         mermaidRenderingMode: 'svg',
         userMessageRenderingMode: 'markdown',
         stickyUserHeader: true,
@@ -1671,8 +1671,8 @@ export const useUIStore = create<UIStore>()(
         setPersistChatDraft: (value) => {
           set({ persistChatDraft: value });
         },
-        setChatInputSpellcheckEnabled: (value) => {
-          set({ chatInputSpellcheckEnabled: value });
+        setInputSpellcheckEnabled: (value) => {
+          set({ inputSpellcheckEnabled: value });
         },
         setMermaidRenderingMode: (value) => {
           set({ mermaidRenderingMode: value });
@@ -1860,7 +1860,7 @@ export const useUIStore = create<UIStore>()(
           summaryLength: state.summaryLength,
           maxLastMessageLength: state.maxLastMessageLength,
           persistChatDraft: state.persistChatDraft,
-          chatInputSpellcheckEnabled: state.chatInputSpellcheckEnabled,
+          inputSpellcheckEnabled: state.inputSpellcheckEnabled,
           mermaidRenderingMode: state.mermaidRenderingMode,
           userMessageRenderingMode: state.userMessageRenderingMode,
           stickyUserHeader: state.stickyUserHeader,

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -2094,8 +2094,8 @@ const sanitizeSettingsUpdate = (payload) => {
       result.toolCallExpansion = mode;
     }
   }
-  if (typeof candidate.chatInputSpellcheckEnabled === 'boolean') {
-    result.chatInputSpellcheckEnabled = candidate.chatInputSpellcheckEnabled;
+  if (typeof candidate.inputSpellcheckEnabled === 'boolean') {
+    result.inputSpellcheckEnabled = candidate.inputSpellcheckEnabled;
   }
   if (typeof candidate.userMessageRenderingMode === 'string') {
     const mode = candidate.userMessageRenderingMode.trim();


### PR DESCRIPTION
Added a desktop spellcheck setting for chat input while preserving the current mobile behavior.

- `packages/ui/src/components/chat/ChatInput.tsx:158` now reads chatInputSpellcheckEnabled, and `packages/ui/src/components/chat/ChatInput.tsx:2685` uses spellCheck={isMobile || chatInputSpellcheckEnabled} so mobile stays on by default and desktop follows the new toggle.
- `packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx:127` adds a new visible setting, `packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx:201` persists it through shared settings, and `packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx:1025` adds the checkbox row in Chat settings.
- `packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx` The checkbox does not render on mobile (mobile still keeps spellcheck on by default, without showing the toggle).
- `packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx:120` includes the new toggle in the Chat settings page.
- `packages/ui/src/stores/useUIStore.ts` add the new Zustand state, default, setter, and persisted local store field.
- `packages/ui/src/lib/desktop.ts:119`, `packages/ui/src/lib/api/types.ts:528`, `packages/ui/src/lib/persistence.ts:377`, `packages/ui/src/lib/persistence.ts:747`, and `packages/web/server/index.js:2097` wire the setting through the shared settings sync path so it survives reloads.
- `packages/ui/src/components/views/git/CommitInput.tsx:4` and `packages/ui/src/components/views/git/CommitInput.tsx:25` now reads chatInputSpellcheckEnabled from useUIStore, and spellCheck now follows `hasTouchInput || chatInputSpellcheckEnabled`, so touch/mobile keeps current behavior and desktop uses the same toggle as chat.

> ```
> bun run type-check
> bun run lint
> bun run build
> ```
All passed.

I tested the app on desktop (web) and mobile web. The setting correctly only shows on desktop, and the spellcheck toggle works for both the main chat input and the git commit input.

Closes #346