### PR TITLE
Allow Ctrl+Enter send in narrow desktop layouts

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1054,7 +1054,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
         }
 
         // Handle Enter/Ctrl+Enter based on queue mode
-        if (e.key === 'Enter' && !e.shiftKey && !isMobile) {
+        if (e.key === 'Enter' && !e.shiftKey && (!isMobile || e.ctrlKey || e.metaKey)) {
             e.preventDefault();
 
             const isCtrlEnter = e.ctrlKey || e.metaKey;


### PR DESCRIPTION
## Summary
- keep `Ctrl+Enter` / `Cmd+Enter` working in the chat input when OpenChamber switches to the narrow/mobile-style layout
- only gate plain `Enter` on mobile, instead of blocking all Enter-based shortcuts
- fix the Firefox on Windows case where a narrow desktop window prevented modified Enter from sending

## Problem
On desktop Firefox on Windows, narrowing the window can make OpenChamber treat the chat input like a mobile layout. In that state, `Ctrl+Enter` stops sending even though users may rely on it instead of plain `Enter`.

## Fix
Allow modified Enter (`Ctrl+Enter` / `Cmd+Enter`) to pass through the chat input key handler even when `isMobile` is true, while keeping the existing plain `Enter` behavior unchanged.

## Testing
- verified manually in a narrow Firefox window on Windows
- `bun` validation was not run in this environment because `bun` is not installed

Closes #630