### PR TITLE
fix: project label text hidden by selection overlay in dark mode

### DIFF
--- a/packages/ui/src/components/layout/NavRail.tsx
+++ b/packages/ui/src/components/layout/NavRail.tsx
@@ -355,7 +355,7 @@ const ProjectTile: React.FC<{
       <span
         aria-hidden={!projectTextVisible}
         className={cn(
-          'min-w-0 truncate text-left text-[13px] leading-tight transition-opacity duration-[180ms] ease-in-out',
+          'relative z-10 min-w-0 truncate text-left text-[13px] leading-tight transition-opacity duration-[180ms] ease-in-out',
           expanded ? 'flex-1' : 'w-0 flex-none',
           projectTextVisible ? 'opacity-100' : 'opacity-0',
           isActive && expanded ? 'font-medium text-[var(--interactive-selection-foreground)]' : 'text-[var(--surface-foreground)]',


### PR DESCRIPTION
## Summary

- In the expanded NavRail, the active `ProjectTile` renders an absolutely-positioned background overlay (`--interactive-selection`) that visually covers the text label in dark themes
- The label `<span>` was missing `relative z-10`, so the absolute overlay (layer 1) rendered on top of the text (layer 3)
- Fix: add `relative z-10` to the label span, consistent with how `NavRailActionButton` already handles it

## Root Cause

```tsx
// NavRail.tsx — ProjectTile expanded button structure
<button className="group relative flex ...">
  <span aria-hidden="true" className="pointer-events-none absolute inset-y-0 ..." />  {/* overlay, z unset */}
  <span className="flex size-[34px] ...">  {/* icon */}
  <span className="min-w-0 truncate ...">  {/* text — NO relative/z-10 ❌ */}
</button>
```

## Fix

```diff
- 'min-w-0 truncate text-left text-[13px] leading-tight ...',
+ 'relative z-10 min-w-0 truncate text-left text-[13px] leading-tight ...',
```

## Affected themes

Dark themes with near-opaque `--interactive-selection` are most affected: `nord-dark`, `dracula-dark`, `monokai-dark`, `gruvbox-dark`.

## Testing

Switch to any dark theme → expand the NavRail sidebar → the active project label should now be visible.