### PR TITLE
fix(web): hide Windows console popups from daemon/git subprocesses

### DIFF
--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -2731,6 +2731,7 @@ const commands = {
 
     const child = spawn(runtimeBin, serverArgs, {
       detached: true,
+      windowsHide: true,
       stdio: ['ignore', logFd, logFd, 'ipc'],
       env: {
         ...process.env,

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -564,6 +564,7 @@ const searchFilesystemFiles = async (rootPath, options) => {
           const result = await new Promise((resolve) => {
             const child = spawn('git', ['check-ignore', '--', ...pathsToCheck], {
               cwd: dir,
+              windowsHide: true,
               stdio: ['ignore', 'pipe', 'pipe'],
             });
 
@@ -1135,7 +1136,7 @@ const buildTemplateVariables = async (payload, sessionId) => {
   if (worktreeDir) {
     try {
       const { simpleGit } = await import('simple-git');
-      const git = simpleGit(worktreeDir);
+      const git = simpleGit({ baseDir: worktreeDir, spawnOptions: { windowsHide: true } });
       branch = await Promise.race([
         git.revparse(['--abbrev-ref', 'HEAD']),
         new Promise((_, reject) => setTimeout(() => reject(new Error('git timeout')), 3000)),
@@ -12950,6 +12951,7 @@ async function main(options = {}) {
               const result = await new Promise((resolve) => {
                 const child = spawn('git', ['check-ignore', '--', ...pathsToCheck], {
                   cwd: resolvedPath,
+                  windowsHide: true,
                   stdio: ['ignore', 'pipe', 'pipe'],
                 });
 

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -125,10 +125,11 @@ const buildGitEnv = async () => {
 
 const createGit = async (directory) => {
   const env = await buildGitEnv();
+  const spawnOptions = { windowsHide: true };
   if (!directory) {
-    return simpleGit({ env });
+    return simpleGit({ env, spawnOptions });
   }
-  return simpleGit({ baseDir: normalizeDirectoryPath(directory), env });
+  return simpleGit({ baseDir: normalizeDirectoryPath(directory), env, spawnOptions });
 };
 
 const normalizeDirectoryPath = (value) => {
@@ -415,6 +416,7 @@ const runGitCommand = async (cwd, args) => {
     const { stdout, stderr } = await execFileAsync('git', args, {
       cwd,
       env: await buildGitEnv(),
+      windowsHide: true,
       maxBuffer: 20 * 1024 * 1024,
     });
     return {


### PR DESCRIPTION
﻿## Summary
- Hide the detached daemon server process window on Windows by setting `windowsHide: true` for the CLI spawn path.
- Hide Git subprocess windows on Windows by setting `spawnOptions.windowsHide: true` for server-side `simple-git` usage.
- Apply `windowsHide: true` to direct Git subprocess calls (`git check-ignore` and `execFile('git', ...)`) used by the web server.

## Testing
- `git diff --check` ✅
- Full project validation (`bun run type-check`, `bun run lint`, `bun run build`) was not runnable in this environment because `bun` is not available in PATH.

## Related
Fixes #647