### PR TITLE
feat(theme): port additional opencode presets

### DIFF
--- a/packages/ui/src/lib/theme/themes/amoled-dark.json
+++ b/packages/ui/src/lib/theme/themes/amoled-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "amoled-dark",
+    "name": "AMOLED",
+    "description": "Port of OpenCode AMOLED theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "amoled"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#954af5",
+      "hover": "#9f66f4",
+      "active": "#9f66f4",
+      "foreground": "#ffffff",
+      "muted": "#954af580",
+      "emphasis": "#9f66f4"
+    },
+    "surface": {
+      "background": "#000000",
+      "foreground": "#ffffff",
+      "muted": "#111111",
+      "mutedForeground": "#dbdbdb",
+      "elevated": "#0a0a0a",
+      "elevatedForeground": "#ffffff",
+      "overlay": "#00000080",
+      "subtle": "#191919"
+    },
+    "interactive": {
+      "border": "#434343",
+      "borderHover": "#4e4e4e",
+      "borderFocus": "#531195",
+      "selection": "#3c0770",
+      "selectionForeground": "#ffffff",
+      "focus": "#531195",
+      "focusRing": "#53119559",
+      "cursor": "#ffffff",
+      "hover": "#191919",
+      "active": "#191919"
+    },
+    "status": {
+      "error": "#c71133",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#5d0212",
+      "errorBorder": "#7d081d",
+      "warning": "#c49925",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#353003",
+      "warningBorder": "#494308",
+      "success": "#2bbd69",
+      "successForeground": "#ffffff",
+      "successBackground": "#08391c",
+      "successBorder": "#025027",
+      "info": "#24b6b6",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#063636",
+      "infoBorder": "#0f4b4b"
+    },
+    "pr": {
+      "open": "#2bbd69",
+      "draft": "#dbdbdb",
+      "blocked": "#c49925",
+      "merged": "#ff00ff",
+      "closed": "#c71133"
+    },
+    "syntax": {
+      "base": {
+        "background": "#111111",
+        "foreground": "#ffffff",
+        "comment": "#555555",
+        "keyword": "#ff00ff",
+        "string": "#00ff88",
+        "number": "#18ffff",
+        "function": "#ffea00",
+        "variable": "#ffffff",
+        "type": "#fef5a2",
+        "operator": "#dbdbdb"
+      },
+      "tokens": {
+        "commentDoc": "#555555",
+        "stringEscape": "#b388ff",
+        "keywordImport": "#ff00ff",
+        "storageModifier": "#ff00ff",
+        "functionCall": "#ffea00",
+        "method": "#ffea00",
+        "variableProperty": "#ffea00",
+        "variableOther": "#ffffff",
+        "variableGlobal": "#b388ff",
+        "variableLocal": "#dbdbdb",
+        "parameter": "#ffffff",
+        "constant": "#b388ff",
+        "class": "#fef5a2",
+        "className": "#fef5a2",
+        "interface": "#fef5a2",
+        "struct": "#fef5a2",
+        "enum": "#fef5a2",
+        "typeParameter": "#fef5a2",
+        "namespace": "#ff00ff",
+        "module": "#ff00ff",
+        "tag": "#ff00ff",
+        "jsxTag": "#ff00ff",
+        "tagAttribute": "#ffea00",
+        "tagAttributeValue": "#00ff88",
+        "boolean": "#18ffff",
+        "decorator": "#ff00ff",
+        "label": "#ff00ff",
+        "punctuation": "#dbdbdb",
+        "macro": "#ff00ff",
+        "preprocessor": "#ff00ff",
+        "regex": "#ffffff",
+        "url": "#e3d7fe",
+        "key": "#ffea00",
+        "exception": "#c71133"
+      },
+      "highlights": {
+        "diffAdded": "#92fdb3",
+        "diffAddedBackground": "#011406",
+        "diffRemoved": "#f20e3f",
+        "diffRemovedBackground": "#230204",
+        "diffModified": "#fef5a2",
+        "diffModifiedBackground": "#1f1b27",
+        "lineNumber": "#bebebe",
+        "lineNumberActive": "#ffffff"
+      }
+    },
+    "markdown": {
+      "heading1": "#e3d7fe",
+      "heading2": "#e3d7fe",
+      "heading3": "#ffffff",
+      "heading4": "#ffffff",
+      "link": "#e3d7fe",
+      "linkHover": "#a9fdfc",
+      "inlineCode": "#8cfeb0",
+      "inlineCodeBackground": "#111111",
+      "blockquote": "#fef5a2",
+      "blockquoteBorder": "#434343",
+      "listMarker": "#e3d7fe99"
+    },
+    "chat": {
+      "userMessage": "#ffffff",
+      "userMessageBackground": "#3c0770",
+      "assistantMessage": "#ffffff",
+      "assistantMessageBackground": "#000000",
+      "timestamp": "#dbdbdb",
+      "divider": "#434343"
+    },
+    "tools": {
+      "background": "#11111180",
+      "border": "#434343b3",
+      "headerHover": "#19191980",
+      "icon": "#dbdbdb",
+      "title": "#ffffff",
+      "description": "#dbdbdb",
+      "edit": {
+        "added": "#92fdb3",
+        "addedBackground": "#011406",
+        "removed": "#f20e3f",
+        "removedBackground": "#230204",
+        "lineNumber": "#bebebe"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/amoled-light.json
+++ b/packages/ui/src/lib/theme/themes/amoled-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "amoled-light",
+    "name": "AMOLED",
+    "description": "Port of OpenCode AMOLED theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "amoled"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#6209fd",
+      "hover": "#5806e6",
+      "active": "#5806e6",
+      "foreground": "#ffffff",
+      "muted": "#6209fd80",
+      "emphasis": "#5806e6"
+    },
+    "surface": {
+      "background": "#f1f1f1",
+      "foreground": "#0a0a0a",
+      "muted": "#e3e3e3",
+      "mutedForeground": "#232323",
+      "elevated": "#eaeaea",
+      "elevatedForeground": "#0a0a0a",
+      "overlay": "#0000004d",
+      "subtle": "#dbdbdb"
+    },
+    "interactive": {
+      "border": "#b9b9b9",
+      "borderHover": "#ababab",
+      "borderFocus": "#babafa",
+      "selection": "#e7e8fe",
+      "selectionForeground": "#000000",
+      "focus": "#babafa",
+      "focusRing": "#babafa47",
+      "cursor": "#0a0a0a",
+      "hover": "#dbdbdb",
+      "active": "#dbdbdb"
+    },
+    "status": {
+      "error": "#ea1f40",
+      "errorForeground": "#000000",
+      "errorBackground": "#fee2e1",
+      "errorBorder": "#fea6a4",
+      "warning": "#fbac7c",
+      "warningForeground": "#000000",
+      "warningBackground": "#ffe6c6",
+      "warningBorder": "#fab141",
+      "success": "#20e679",
+      "successForeground": "#000000",
+      "successBackground": "#b4ffc7",
+      "successBorder": "#20e679",
+      "info": "#7fcbfd",
+      "infoForeground": "#000000",
+      "infoBackground": "#d8edfd",
+      "infoBorder": "#7fcbfd"
+    },
+    "pr": {
+      "open": "#20e679",
+      "draft": "#232323",
+      "blocked": "#fbac7c",
+      "merged": "#d500f9",
+      "closed": "#ea1f40"
+    },
+    "syntax": {
+      "base": {
+        "background": "#e3e3e3",
+        "foreground": "#0a0a0a",
+        "comment": "#757575",
+        "keyword": "#d500f9",
+        "string": "#00e676",
+        "number": "#00b0ff",
+        "function": "#ff9100",
+        "variable": "#010101",
+        "type": "#785110",
+        "operator": "#0a0a0a"
+      },
+      "tokens": {
+        "commentDoc": "#757575",
+        "stringEscape": "#6200ff",
+        "keywordImport": "#d500f9",
+        "storageModifier": "#d500f9",
+        "functionCall": "#ff9100",
+        "method": "#ff9100",
+        "variableProperty": "#ff9100",
+        "variableOther": "#010101",
+        "variableGlobal": "#6200ff",
+        "variableLocal": "#232323",
+        "parameter": "#010101",
+        "constant": "#6200ff",
+        "class": "#785110",
+        "className": "#785110",
+        "interface": "#785110",
+        "struct": "#785110",
+        "enum": "#785110",
+        "typeParameter": "#785110",
+        "namespace": "#d500f9",
+        "module": "#d500f9",
+        "tag": "#d500f9",
+        "jsxTag": "#d500f9",
+        "tagAttribute": "#ff9100",
+        "tagAttributeValue": "#00e676",
+        "boolean": "#00b0ff",
+        "decorator": "#d500f9",
+        "label": "#d500f9",
+        "punctuation": "#0a0a0a",
+        "macro": "#d500f9",
+        "preprocessor": "#d500f9",
+        "regex": "#0a0a0a",
+        "url": "#580ce6",
+        "key": "#ff9100",
+        "exception": "#ea1f40"
+      },
+      "highlights": {
+        "diffAdded": "#15733c",
+        "diffAddedBackground": "#f8fff9",
+        "diffRemoved": "#ea1f40",
+        "diffRemovedBackground": "#fffcfc",
+        "diffModified": "#785110",
+        "diffModifiedBackground": "#dddcea",
+        "lineNumber": "#3c3c3c",
+        "lineNumberActive": "#0a0a0a"
+      }
+    },
+    "markdown": {
+      "heading1": "#580ce6",
+      "heading2": "#580ce6",
+      "heading3": "#0a0a0a",
+      "heading4": "#0a0a0a",
+      "link": "#580ce6",
+      "linkHover": "#13608a",
+      "inlineCode": "#126b37",
+      "inlineCodeBackground": "#e3e3e3",
+      "blockquote": "#785110",
+      "blockquoteBorder": "#b9b9b9",
+      "listMarker": "#580ce699"
+    },
+    "chat": {
+      "userMessage": "#0a0a0a",
+      "userMessageBackground": "#e7e8fe",
+      "assistantMessage": "#0a0a0a",
+      "assistantMessageBackground": "#f1f1f1",
+      "timestamp": "#232323",
+      "divider": "#b9b9b9"
+    },
+    "tools": {
+      "background": "#e3e3e380",
+      "border": "#b9b9b9b3",
+      "headerHover": "#dbdbdb80",
+      "icon": "#232323",
+      "title": "#0a0a0a",
+      "description": "#232323",
+      "edit": {
+        "added": "#15733c",
+        "addedBackground": "#f8fff9",
+        "removed": "#ea1f40",
+        "removedBackground": "#fffcfc",
+        "lineNumber": "#3c3c3c"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/cursor-dark.json
+++ b/packages/ui/src/lib/theme/themes/cursor-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "cursor-dark",
+    "name": "Cursor",
+    "description": "Port of OpenCode Cursor theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "cursor"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#369ab3",
+      "hover": "#41aac5",
+      "active": "#41aac5",
+      "foreground": "#000000",
+      "muted": "#369ab380",
+      "emphasis": "#41aac5"
+    },
+    "surface": {
+      "background": "#0e0e0e",
+      "foreground": "#e4e4e4",
+      "muted": "#1c1c1c",
+      "mutedForeground": "#e4e4e45e",
+      "elevated": "#161616",
+      "elevatedForeground": "#e4e4e4",
+      "overlay": "#00000080",
+      "subtle": "#232323"
+    },
+    "interactive": {
+      "border": "#464646",
+      "borderHover": "#4f4f4f",
+      "borderFocus": "#044c4a",
+      "selection": "#003735",
+      "selectionForeground": "#ffffff",
+      "focus": "#044c4a",
+      "focusRing": "#044c4a59",
+      "cursor": "#e4e4e4",
+      "hover": "#232323",
+      "active": "#232323"
+    },
+    "status": {
+      "error": "#c21a55",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#5a0523",
+      "errorBorder": "#7a0e33",
+      "warning": "#ca6803",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#422902",
+      "warningBorder": "#5b3a07",
+      "success": "#078146",
+      "successForeground": "#ffffff",
+      "successBackground": "#00391c",
+      "successBorder": "#045029",
+      "info": "#4b7dad",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#093152",
+      "infoBorder": "#1a446a"
+    },
+    "pr": {
+      "open": "#078146",
+      "draft": "#e4e4e45e",
+      "blocked": "#ca6803",
+      "merged": "#82D2CE",
+      "closed": "#c21a55"
+    },
+    "syntax": {
+      "base": {
+        "background": "#1c1c1c",
+        "foreground": "#e4e4e4",
+        "comment": "#e4e4e45e",
+        "keyword": "#82D2CE",
+        "string": "#E394DC",
+        "number": "#EFB080",
+        "function": "#81a1c1",
+        "variable": "#e4e4e4",
+        "type": "#EFB080",
+        "operator": "#e4e4e4"
+      },
+      "tokens": {
+        "commentDoc": "#e4e4e45e",
+        "stringEscape": "#F8C762",
+        "keywordImport": "#82D2CE",
+        "storageModifier": "#82D2CE",
+        "functionCall": "#81a1c1",
+        "method": "#81a1c1",
+        "variableProperty": "#81a1c1",
+        "variableOther": "#e4e4e4",
+        "variableGlobal": "#F8C762",
+        "variableLocal": "#e4e4e45e",
+        "parameter": "#e4e4e4",
+        "constant": "#F8C762",
+        "class": "#EFB080",
+        "className": "#EFB080",
+        "interface": "#EFB080",
+        "struct": "#EFB080",
+        "enum": "#EFB080",
+        "typeParameter": "#EFB080",
+        "namespace": "#82D2CE",
+        "module": "#82D2CE",
+        "tag": "#82D2CE",
+        "jsxTag": "#82D2CE",
+        "tagAttribute": "#81a1c1",
+        "tagAttributeValue": "#E394DC",
+        "boolean": "#EFB080",
+        "decorator": "#82D2CE",
+        "label": "#82D2CE",
+        "punctuation": "#e4e4e4",
+        "macro": "#82D2CE",
+        "preprocessor": "#82D2CE",
+        "regex": "#e4e4e4",
+        "url": "#82D2CE",
+        "key": "#81a1c1",
+        "exception": "#c21a55"
+      },
+      "highlights": {
+        "diffAdded": "#75f1a8",
+        "diffAddedBackground": "#011307",
+        "diffRemoved": "#f72661",
+        "diffRemovedBackground": "#240007",
+        "diffModified": "#fdd8ac",
+        "diffModifiedBackground": "#29302f",
+        "lineNumber": "#bdbdbd",
+        "lineNumberActive": "#e4e4e4"
+      }
+    },
+    "markdown": {
+      "heading1": "#AAA0FA",
+      "heading2": "#AAA0FA",
+      "heading3": "#e4e4e4",
+      "heading4": "#e4e4e4",
+      "link": "#82D2CE",
+      "linkHover": "#81a1c1",
+      "inlineCode": "#E394DC",
+      "inlineCodeBackground": "#1c1c1c",
+      "blockquote": "#e4e4e45e",
+      "blockquoteBorder": "#464646",
+      "listMarker": "#e4e4e499"
+    },
+    "chat": {
+      "userMessage": "#e4e4e4",
+      "userMessageBackground": "#003735",
+      "assistantMessage": "#e4e4e4",
+      "assistantMessageBackground": "#0e0e0e",
+      "timestamp": "#e4e4e45e",
+      "divider": "#464646"
+    },
+    "tools": {
+      "background": "#1c1c1c80",
+      "border": "#464646b3",
+      "headerHover": "#23232380",
+      "icon": "#e4e4e45e",
+      "title": "#e4e4e4",
+      "description": "#e4e4e45e",
+      "edit": {
+        "added": "#75f1a8",
+        "addedBackground": "#011307",
+        "removed": "#f72661",
+        "removedBackground": "#240007",
+        "lineNumber": "#bdbdbd"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/cursor-light.json
+++ b/packages/ui/src/lib/theme/themes/cursor-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "cursor-light",
+    "name": "Cursor",
+    "description": "Port of OpenCode Cursor theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "cursor"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#659daa",
+      "hover": "#5992a0",
+      "active": "#5992a0",
+      "foreground": "#000000",
+      "muted": "#659daa80",
+      "emphasis": "#5992a0"
+    },
+    "surface": {
+      "background": "#fcfcfc",
+      "foreground": "#131313",
+      "muted": "#eeeeee",
+      "mutedForeground": "#141414ad",
+      "elevated": "#f5f5f5",
+      "elevatedForeground": "#131313",
+      "overlay": "#0000004d",
+      "subtle": "#e5e5e5"
+    },
+    "interactive": {
+      "border": "#c3c3c3",
+      "borderHover": "#b5b5b5",
+      "borderFocus": "#88c9fd",
+      "selection": "#daedfd",
+      "selectionForeground": "#000000",
+      "focus": "#88c9fd",
+      "focusRing": "#88c9fd47",
+      "cursor": "#131313",
+      "hover": "#e5e5e5",
+      "active": "#e5e5e5"
+    },
+    "status": {
+      "error": "#c4174b",
+      "errorForeground": "#000000",
+      "errorBackground": "#fee2e4",
+      "errorBorder": "#fba6af",
+      "warning": "#ffa5a8",
+      "warningForeground": "#000000",
+      "warningBackground": "#fde4db",
+      "warningBorder": "#faab90",
+      "success": "#6fdaad",
+      "successForeground": "#000000",
+      "successBackground": "#bbfadd",
+      "successBorder": "#6fdaad",
+      "info": "#8ac9fa",
+      "infoForeground": "#000000",
+      "infoBackground": "#d8edfe",
+      "infoBorder": "#8ac9fa"
+    },
+    "pr": {
+      "open": "#6fdaad",
+      "draft": "#141414ad",
+      "blocked": "#ffa5a8",
+      "merged": "#b3003f",
+      "closed": "#c4174b"
+    },
+    "syntax": {
+      "base": {
+        "background": "#eeeeee",
+        "foreground": "#131313",
+        "comment": "#141414ad",
+        "keyword": "#b3003f",
+        "string": "#9e94d5",
+        "number": "#db704b",
+        "function": "#141414ad",
+        "variable": "#141414",
+        "type": "#206595",
+        "operator": "#141414"
+      },
+      "tokens": {
+        "commentDoc": "#141414ad",
+        "stringEscape": "#b8448b",
+        "keywordImport": "#b3003f",
+        "storageModifier": "#b3003f",
+        "functionCall": "#141414ad",
+        "method": "#141414ad",
+        "variableProperty": "#141414ad",
+        "variableOther": "#141414",
+        "variableGlobal": "#b8448b",
+        "variableLocal": "#141414ad",
+        "parameter": "#141414",
+        "constant": "#b8448b",
+        "class": "#206595",
+        "className": "#206595",
+        "interface": "#206595",
+        "struct": "#206595",
+        "enum": "#206595",
+        "typeParameter": "#206595",
+        "namespace": "#b3003f",
+        "module": "#b3003f",
+        "tag": "#b3003f",
+        "jsxTag": "#b3003f",
+        "tagAttribute": "#141414ad",
+        "tagAttributeValue": "#9e94d5",
+        "boolean": "#db704b",
+        "decorator": "#b3003f",
+        "label": "#b3003f",
+        "punctuation": "#141414",
+        "macro": "#b3003f",
+        "preprocessor": "#b3003f",
+        "regex": "#131313",
+        "url": "#206595",
+        "key": "#141414ad",
+        "exception": "#c4174b"
+      },
+      "highlights": {
+        "diffAdded": "#0c7251",
+        "diffAddedBackground": "#f7fffb",
+        "diffRemoved": "#ec3766",
+        "diffRemovedBackground": "#fffcfc",
+        "diffModified": "#FF8C00",
+        "diffModifiedBackground": "#e3e7eb",
+        "lineNumber": "#313131",
+        "lineNumberActive": "#131313"
+      }
+    },
+    "markdown": {
+      "heading1": "#206595",
+      "heading2": "#206595",
+      "heading3": "#131313",
+      "heading4": "#131313",
+      "link": "#206595",
+      "linkHover": "#141414ad",
+      "inlineCode": "#1f8a65",
+      "inlineCodeBackground": "#eeeeee",
+      "blockquote": "#141414ad",
+      "blockquoteBorder": "#c3c3c3",
+      "listMarker": "#14141499"
+    },
+    "chat": {
+      "userMessage": "#131313",
+      "userMessageBackground": "#daedfd",
+      "assistantMessage": "#131313",
+      "assistantMessageBackground": "#fcfcfc",
+      "timestamp": "#141414ad",
+      "divider": "#c3c3c3"
+    },
+    "tools": {
+      "background": "#eeeeee80",
+      "border": "#c3c3c3b3",
+      "headerHover": "#e5e5e580",
+      "icon": "#141414ad",
+      "title": "#131313",
+      "description": "#141414ad",
+      "edit": {
+        "added": "#0c7251",
+        "addedBackground": "#f7fffb",
+        "removed": "#ec3766",
+        "removedBackground": "#fffcfc",
+        "lineNumber": "#313131"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/github-dark.json
+++ b/packages/ui/src/lib/theme/themes/github-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "github-dark",
+    "name": "GitHub",
+    "description": "Port of OpenCode GitHub theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "github"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#197de0",
+      "hover": "#238cf5",
+      "active": "#238cf5",
+      "foreground": "#000000",
+      "muted": "#197de080",
+      "emphasis": "#238cf5"
+    },
+    "surface": {
+      "background": "#05080e",
+      "foreground": "#ccd4dc",
+      "muted": "#12151b",
+      "mutedForeground": "#8b949e",
+      "elevated": "#0c0f16",
+      "elevatedForeground": "#ccd4dc",
+      "overlay": "#00000080",
+      "subtle": "#181c22"
+    },
+    "interactive": {
+      "border": "#393d44",
+      "borderHover": "#41454c",
+      "borderFocus": "#09427a",
+      "selection": "#032f5a",
+      "selectionForeground": "#ffffff",
+      "focus": "#09427a",
+      "focusRing": "#09427a59",
+      "cursor": "#ccd4dc",
+      "hover": "#181c22",
+      "active": "#181c22"
+    },
+    "status": {
+      "error": "#d01d21",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#5e0206",
+      "errorBorder": "#7e080d",
+      "warning": "#b37002",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#3c2c02",
+      "warningBorder": "#533e07",
+      "success": "#1a9132",
+      "successForeground": "#ffffff",
+      "successBackground": "#063a10",
+      "successBorder": "#0f501a",
+      "info": "#a27516",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#3f2b02",
+      "infoBorder": "#563d07"
+    },
+    "pr": {
+      "open": "#1a9132",
+      "draft": "#8b949e",
+      "blocked": "#b37002",
+      "merged": "#ff7b72",
+      "closed": "#d01d21"
+    },
+    "syntax": {
+      "base": {
+        "background": "#12151b",
+        "foreground": "#ccd4dc",
+        "comment": "#8b949e",
+        "keyword": "#ff7b72",
+        "string": "#39c5cf",
+        "number": "#bc8cff",
+        "function": "#39c5cf",
+        "variable": "#d29922",
+        "type": "#d29922",
+        "operator": "#ff7b72"
+      },
+      "tokens": {
+        "commentDoc": "#8b949e",
+        "stringEscape": "#58a6ff",
+        "keywordImport": "#ff7b72",
+        "storageModifier": "#ff7b72",
+        "functionCall": "#39c5cf",
+        "method": "#39c5cf",
+        "variableProperty": "#39c5cf",
+        "variableOther": "#d29922",
+        "variableGlobal": "#58a6ff",
+        "variableLocal": "#8b949e",
+        "parameter": "#d29922",
+        "constant": "#58a6ff",
+        "class": "#d29922",
+        "className": "#d29922",
+        "interface": "#d29922",
+        "struct": "#d29922",
+        "enum": "#d29922",
+        "typeParameter": "#d29922",
+        "namespace": "#ff7b72",
+        "module": "#ff7b72",
+        "tag": "#ff7b72",
+        "jsxTag": "#ff7b72",
+        "tagAttribute": "#39c5cf",
+        "tagAttributeValue": "#39c5cf",
+        "boolean": "#bc8cff",
+        "decorator": "#ff7b72",
+        "label": "#ff7b72",
+        "punctuation": "#c9d1d9",
+        "macro": "#ff7b72",
+        "preprocessor": "#ff7b72",
+        "regex": "#ccd4dc",
+        "url": "#58a6ff",
+        "key": "#39c5cf",
+        "exception": "#d01d21"
+      },
+      "highlights": {
+        "diffAdded": "#6af679",
+        "diffAddedBackground": "#011403",
+        "diffRemoved": "#f5031c",
+        "diffRemovedBackground": "#240202",
+        "diffModified": "#fdda8e",
+        "diffModifiedBackground": "#1b2432",
+        "lineNumber": "#6a7077",
+        "lineNumberActive": "#ccd4dc"
+      }
+    },
+    "markdown": {
+      "heading1": "#58a6ff",
+      "heading2": "#58a6ff",
+      "heading3": "#ccd4dc",
+      "heading4": "#ccd4dc",
+      "link": "#58a6ff",
+      "linkHover": "#39c5cf",
+      "inlineCode": "#ff7b72",
+      "inlineCodeBackground": "#12151b",
+      "blockquote": "#8b949e",
+      "blockquoteBorder": "#393d44",
+      "listMarker": "#58a6ff99"
+    },
+    "chat": {
+      "userMessage": "#ccd4dc",
+      "userMessageBackground": "#032f5a",
+      "assistantMessage": "#ccd4dc",
+      "assistantMessageBackground": "#05080e",
+      "timestamp": "#8b949e",
+      "divider": "#393d44"
+    },
+    "tools": {
+      "background": "#12151b80",
+      "border": "#393d44b3",
+      "headerHover": "#181c2280",
+      "icon": "#8b949e",
+      "title": "#ccd4dc",
+      "description": "#8b949e",
+      "edit": {
+        "added": "#6af679",
+        "addedBackground": "#011403",
+        "removed": "#f5031c",
+        "removedBackground": "#240202",
+        "lineNumber": "#6a7077"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/github-light.json
+++ b/packages/ui/src/lib/theme/themes/github-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "github-light",
+    "name": "GitHub",
+    "description": "Port of OpenCode GitHub theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "github"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#0d69d9",
+      "hover": "#0c5fc5",
+      "active": "#0c5fc5",
+      "foreground": "#ffffff",
+      "muted": "#0d69d980",
+      "emphasis": "#0c5fc5"
+    },
+    "surface": {
+      "background": "#ffffff",
+      "foreground": "#1e2329",
+      "muted": "#f2f3f3",
+      "mutedForeground": "#57606a",
+      "elevated": "#f9f9f9",
+      "elevatedForeground": "#1e2329",
+      "overlay": "#0000004d",
+      "subtle": "#eaeaeb"
+    },
+    "interactive": {
+      "border": "#cacbcc",
+      "borderHover": "#bcbec0",
+      "borderFocus": "#9dc3fb",
+      "selection": "#deebfe",
+      "selectionForeground": "#000000",
+      "focus": "#9dc3fb",
+      "focusRing": "#9dc3fb47",
+      "cursor": "#1e2329",
+      "hover": "#eaeaeb",
+      "active": "#eaeaeb"
+    },
+    "status": {
+      "error": "#bc212b",
+      "errorForeground": "#000000",
+      "errorBackground": "#ffe2df",
+      "errorBorder": "#ffa69f",
+      "warning": "#feab76",
+      "warningForeground": "#000000",
+      "warningBackground": "#ffe6c4",
+      "warningBorder": "#f1b55c",
+      "success": "#76dc88",
+      "successForeground": "#000000",
+      "successBackground": "#bffcc6",
+      "successBorder": "#76dc88",
+      "info": "#ffa983",
+      "infoForeground": "#000000",
+      "infoBackground": "#ffe3d8",
+      "infoBorder": "#ffa983"
+    },
+    "pr": {
+      "open": "#76dc88",
+      "draft": "#57606a",
+      "blocked": "#feab76",
+      "merged": "#cf222e",
+      "closed": "#bc212b"
+    },
+    "syntax": {
+      "base": {
+        "background": "#f2f3f3",
+        "foreground": "#1e2329",
+        "comment": "#57606a",
+        "keyword": "#cf222e",
+        "string": "#0969da",
+        "number": "#8250df",
+        "function": "#1b7c83",
+        "variable": "#bc4c00",
+        "type": "#bc4c00",
+        "operator": "#cf222e"
+      },
+      "tokens": {
+        "commentDoc": "#57606a",
+        "stringEscape": "#1b7c83",
+        "keywordImport": "#cf222e",
+        "storageModifier": "#cf222e",
+        "functionCall": "#1b7c83",
+        "method": "#1b7c83",
+        "variableProperty": "#1b7c83",
+        "variableOther": "#bc4c00",
+        "variableGlobal": "#1b7c83",
+        "variableLocal": "#57606a",
+        "parameter": "#bc4c00",
+        "constant": "#1b7c83",
+        "class": "#bc4c00",
+        "className": "#bc4c00",
+        "interface": "#bc4c00",
+        "struct": "#bc4c00",
+        "enum": "#bc4c00",
+        "typeParameter": "#bc4c00",
+        "namespace": "#cf222e",
+        "module": "#cf222e",
+        "tag": "#cf222e",
+        "jsxTag": "#cf222e",
+        "tagAttribute": "#1b7c83",
+        "tagAttributeValue": "#0969da",
+        "boolean": "#8250df",
+        "decorator": "#cf222e",
+        "label": "#cf222e",
+        "punctuation": "#24292f",
+        "macro": "#cf222e",
+        "preprocessor": "#cf222e",
+        "regex": "#1e2329",
+        "url": "#0969da",
+        "key": "#1b7c83",
+        "exception": "#bc212b"
+      },
+      "highlights": {
+        "diffAdded": "#396e42",
+        "diffAddedBackground": "#f9fff9",
+        "diffRemoved": "#d54645",
+        "diffRemovedBackground": "#fffcfc",
+        "diffModified": "#785105",
+        "diffModifiedBackground": "#e6ecf4",
+        "lineNumber": "#7b828a",
+        "lineNumberActive": "#1e2329"
+      }
+    },
+    "markdown": {
+      "heading1": "#0969da",
+      "heading2": "#0969da",
+      "heading3": "#1e2329",
+      "heading4": "#1e2329",
+      "link": "#0969da",
+      "linkHover": "#1b7c83",
+      "inlineCode": "#bf3989",
+      "inlineCodeBackground": "#f2f3f3",
+      "blockquote": "#57606a",
+      "blockquoteBorder": "#cacbcc",
+      "listMarker": "#0969da99"
+    },
+    "chat": {
+      "userMessage": "#1e2329",
+      "userMessageBackground": "#deebfe",
+      "assistantMessage": "#1e2329",
+      "assistantMessageBackground": "#ffffff",
+      "timestamp": "#57606a",
+      "divider": "#cacbcc"
+    },
+    "tools": {
+      "background": "#f2f3f380",
+      "border": "#cacbccb3",
+      "headerHover": "#eaeaeb80",
+      "icon": "#57606a",
+      "title": "#1e2329",
+      "description": "#57606a",
+      "edit": {
+        "added": "#396e42",
+        "addedBackground": "#f9fff9",
+        "removed": "#d54645",
+        "removedBackground": "#fffcfc",
+        "lineNumber": "#7b828a"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/lucent-orng-dark.json
+++ b/packages/ui/src/lib/theme/themes/lucent-orng-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "lucent-orng-dark",
+    "name": "Lucent Orng",
+    "description": "Port of OpenCode Lucent Orng theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "lucent-orng"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#be3c07",
+      "hover": "#da4f1f",
+      "active": "#da4f1f",
+      "foreground": "#ffffff",
+      "muted": "#be3c0780",
+      "emphasis": "#da4f1f"
+    },
+    "surface": {
+      "background": "#1a0c08",
+      "foreground": "#eeeeee",
+      "muted": "#281b17",
+      "mutedForeground": "#808080",
+      "elevated": "#221411",
+      "elevatedForeground": "#eeeeee",
+      "overlay": "#00000080",
+      "subtle": "#2f221f"
+    },
+    "interactive": {
+      "border": "#524845",
+      "borderHover": "#5a514e",
+      "borderFocus": "#752101",
+      "selection": "#531906",
+      "selectionForeground": "#ffffff",
+      "focus": "#752101",
+      "focusRing": "#75210159",
+      "cursor": "#eeeeee",
+      "hover": "#2f221f",
+      "active": "#2f221f"
+    },
+    "status": {
+      "error": "#ce2245",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#5c0318",
+      "errorBorder": "#7c0a25",
+      "warning": "#c51d33",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#531906",
+      "warningBorder": "#752101",
+      "success": "#1277e2",
+      "successForeground": "#ffffff",
+      "successBackground": "#042e5d",
+      "successBorder": "#09417d",
+      "info": "#228f9b",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#05363b",
+      "infoBorder": "#0d4b51"
+    },
+    "pr": {
+      "open": "#1277e2",
+      "draft": "#808080",
+      "blocked": "#c51d33",
+      "merged": "#EC5B2B",
+      "closed": "#ce2245"
+    },
+    "syntax": {
+      "base": {
+        "background": "#281b17",
+        "foreground": "#eeeeee",
+        "comment": "#808080",
+        "keyword": "#EC5B2B",
+        "string": "#6ba1e6",
+        "number": "#EE7948",
+        "function": "#56b6c2",
+        "variable": "#e06c75",
+        "type": "#e5c07b",
+        "operator": "#56b6c2"
+      },
+      "tokens": {
+        "commentDoc": "#808080",
+        "stringEscape": "#FFF7F1",
+        "keywordImport": "#EC5B2B",
+        "storageModifier": "#EC5B2B",
+        "functionCall": "#56b6c2",
+        "method": "#56b6c2",
+        "variableProperty": "#56b6c2",
+        "variableOther": "#e06c75",
+        "variableGlobal": "#FFF7F1",
+        "variableLocal": "#808080",
+        "parameter": "#e06c75",
+        "constant": "#FFF7F1",
+        "class": "#e5c07b",
+        "className": "#e5c07b",
+        "interface": "#e5c07b",
+        "struct": "#e5c07b",
+        "enum": "#e5c07b",
+        "typeParameter": "#e5c07b",
+        "namespace": "#EC5B2B",
+        "module": "#EC5B2B",
+        "tag": "#EC5B2B",
+        "jsxTag": "#EC5B2B",
+        "tagAttribute": "#56b6c2",
+        "tagAttributeValue": "#6ba1e6",
+        "boolean": "#EE7948",
+        "decorator": "#EC5B2B",
+        "label": "#EC5B2B",
+        "punctuation": "#eeeeee",
+        "macro": "#EC5B2B",
+        "preprocessor": "#EC5B2B",
+        "regex": "#eeeeee",
+        "url": "#EC5B2B",
+        "key": "#56b6c2",
+        "exception": "#ce2245"
+      },
+      "highlights": {
+        "diffAdded": "#b8d6fe",
+        "diffAddedBackground": "#010e24",
+        "diffRemoved": "#e92b53",
+        "diffRemovedBackground": "#230106",
+        "diffModified": "#ffba92",
+        "diffModifiedBackground": "#392018",
+        "lineNumber": "#5d5d5d",
+        "lineNumberActive": "#eeeeee"
+      }
+    },
+    "markdown": {
+      "heading1": "#EC5B2B",
+      "heading2": "#EC5B2B",
+      "heading3": "#eeeeee",
+      "heading4": "#eeeeee",
+      "link": "#EC5B2B",
+      "linkHover": "#56b6c2",
+      "inlineCode": "#6ba1e6",
+      "inlineCodeBackground": "#281b17",
+      "blockquote": "#FFF7F1",
+      "blockquoteBorder": "#524845",
+      "listMarker": "#EC5B2B99"
+    },
+    "chat": {
+      "userMessage": "#eeeeee",
+      "userMessageBackground": "#531906",
+      "assistantMessage": "#eeeeee",
+      "assistantMessageBackground": "#1a0c08",
+      "timestamp": "#808080",
+      "divider": "#524845"
+    },
+    "tools": {
+      "background": "#281b1780",
+      "border": "#524845b3",
+      "headerHover": "#2f221f80",
+      "icon": "#808080",
+      "title": "#eeeeee",
+      "description": "#808080",
+      "edit": {
+        "added": "#b8d6fe",
+        "addedBackground": "#010e24",
+        "removed": "#e92b53",
+        "removedBackground": "#230106",
+        "lineNumber": "#5d5d5d"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/lucent-orng-light.json
+++ b/packages/ui/src/lib/theme/themes/lucent-orng-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "lucent-orng-light",
+    "name": "Lucent Orng",
+    "description": "Port of OpenCode Lucent Orng theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "lucent-orng"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#f45214",
+      "hover": "#e14d17",
+      "active": "#e14d17",
+      "foreground": "#000000",
+      "muted": "#f4521480",
+      "emphasis": "#e14d17"
+    },
+    "surface": {
+      "background": "#fef7f3",
+      "foreground": "#181818",
+      "muted": "#f1eae6",
+      "mutedForeground": "#8a8a8a",
+      "elevated": "#f7f1ed",
+      "elevatedForeground": "#181818",
+      "overlay": "#0000004d",
+      "subtle": "#e8e2de"
+    },
+    "interactive": {
+      "border": "#c6c1be",
+      "borderHover": "#b9b4b1",
+      "borderFocus": "#fea88e",
+      "selection": "#ffe3da",
+      "selectionForeground": "#000000",
+      "focus": "#fea88e",
+      "focusRing": "#fea88e47",
+      "cursor": "#181818",
+      "hover": "#e8e2de",
+      "active": "#e8e2de"
+    },
+    "status": {
+      "error": "#ce0727",
+      "errorForeground": "#000000",
+      "errorBackground": "#fde3e0",
+      "errorBorder": "#faa8a3",
+      "warning": "#fca6ab",
+      "warningForeground": "#000000",
+      "warningBackground": "#ffe3da",
+      "warningBorder": "#fea88e",
+      "success": "#9ec3fa",
+      "successForeground": "#000000",
+      "successBackground": "#deebfe",
+      "successBorder": "#9ec3fa",
+      "info": "#77d1e1",
+      "infoForeground": "#000000",
+      "infoBackground": "#bff5ff",
+      "infoBorder": "#77d1e1"
+    },
+    "pr": {
+      "open": "#9ec3fa",
+      "draft": "#8a8a8a",
+      "blocked": "#fca6ab",
+      "merged": "#EC5B2B",
+      "closed": "#ce0727"
+    },
+    "syntax": {
+      "base": {
+        "background": "#f1eae6",
+        "foreground": "#181818",
+        "comment": "#8a8a8a",
+        "keyword": "#EC5B2B",
+        "string": "#0062d1",
+        "number": "#c94d24",
+        "function": "#318795",
+        "variable": "#d1383d",
+        "type": "#b0851f",
+        "operator": "#318795"
+      },
+      "tokens": {
+        "commentDoc": "#8a8a8a",
+        "stringEscape": "#EC5B2B",
+        "keywordImport": "#EC5B2B",
+        "storageModifier": "#EC5B2B",
+        "functionCall": "#318795",
+        "method": "#318795",
+        "variableProperty": "#318795",
+        "variableOther": "#d1383d",
+        "variableGlobal": "#EC5B2B",
+        "variableLocal": "#8a8a8a",
+        "parameter": "#d1383d",
+        "constant": "#EC5B2B",
+        "class": "#b0851f",
+        "className": "#b0851f",
+        "interface": "#b0851f",
+        "struct": "#b0851f",
+        "enum": "#b0851f",
+        "typeParameter": "#b0851f",
+        "namespace": "#EC5B2B",
+        "module": "#EC5B2B",
+        "tag": "#EC5B2B",
+        "jsxTag": "#EC5B2B",
+        "tagAttribute": "#318795",
+        "tagAttributeValue": "#0062d1",
+        "boolean": "#c94d24",
+        "decorator": "#EC5B2B",
+        "label": "#EC5B2B",
+        "punctuation": "#1a1a1a",
+        "macro": "#EC5B2B",
+        "preprocessor": "#EC5B2B",
+        "regex": "#181818",
+        "url": "#EC5B2B",
+        "key": "#318795",
+        "exception": "#ce0727"
+      },
+      "highlights": {
+        "diffAdded": "#2f60a4",
+        "diffAddedBackground": "#fbfdff",
+        "diffRemoved": "#e9055a",
+        "diffRemovedBackground": "#fffcfc",
+        "diffModified": "#FF8C00",
+        "diffModifiedBackground": "#f8e8e1",
+        "lineNumber": "#afafaf",
+        "lineNumberActive": "#181818"
+      }
+    },
+    "markdown": {
+      "heading1": "#EC5B2B",
+      "heading2": "#EC5B2B",
+      "heading3": "#181818",
+      "heading4": "#181818",
+      "link": "#EC5B2B",
+      "linkHover": "#318795",
+      "inlineCode": "#0062d1",
+      "inlineCodeBackground": "#f1eae6",
+      "blockquote": "#b0851f",
+      "blockquoteBorder": "#c6c1be",
+      "listMarker": "#EC5B2B99"
+    },
+    "chat": {
+      "userMessage": "#181818",
+      "userMessageBackground": "#ffe3da",
+      "assistantMessage": "#181818",
+      "assistantMessageBackground": "#fef7f3",
+      "timestamp": "#8a8a8a",
+      "divider": "#c6c1be"
+    },
+    "tools": {
+      "background": "#f1eae680",
+      "border": "#c6c1beb3",
+      "headerHover": "#e8e2de80",
+      "icon": "#8a8a8a",
+      "title": "#181818",
+      "description": "#8a8a8a",
+      "edit": {
+        "added": "#2f60a4",
+        "addedBackground": "#fbfdff",
+        "removed": "#e9055a",
+        "removedBackground": "#fffcfc",
+        "lineNumber": "#afafaf"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/oc-2-dark.json
+++ b/packages/ui/src/lib/theme/themes/oc-2-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "oc-2-dark",
+    "name": "OC-2",
+    "description": "Port of OpenCode OC-2 theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "oc-2"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#e27618",
+      "hover": "#f88524",
+      "active": "#f88524",
+      "foreground": "#000000",
+      "muted": "#e2761880",
+      "emphasis": "#f88524"
+    },
+    "surface": {
+      "background": "#0c0c0c",
+      "foreground": "#f1ece8",
+      "muted": "#1b1b1a",
+      "mutedForeground": "#cdc8c5",
+      "elevated": "#151414",
+      "elevatedForeground": "#f1ece8",
+      "overlay": "#00000080",
+      "subtle": "#232222"
+    },
+    "interactive": {
+      "border": "#484746",
+      "borderHover": "#52504f",
+      "borderFocus": "#022fa6",
+      "selection": "#00207d",
+      "selectionForeground": "#ffffff",
+      "focus": "#022fa6",
+      "focusRing": "#022fa659",
+      "cursor": "#f1ece8",
+      "hover": "#232222",
+      "active": "#232222"
+    },
+    "status": {
+      "error": "#cb321c",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#5a0c03",
+      "errorBorder": "#7a1608",
+      "warning": "#c78b05",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#382e05",
+      "warningBorder": "#4e410b",
+      "success": "#089b00",
+      "successForeground": "#ffffff",
+      "successBackground": "#083a05",
+      "successBorder": "#10500d",
+      "info": "#cd73d5",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#4d0853",
+      "infoBorder": "#651b6c"
+    },
+    "pr": {
+      "open": "#089b00",
+      "draft": "#cdc8c5",
+      "blocked": "#c78b05",
+      "merged": "#edb2f1",
+      "closed": "#cb321c"
+    },
+    "syntax": {
+      "base": {
+        "background": "#1b1b1a",
+        "foreground": "#f1ece8",
+        "comment": "#8f8f8f",
+        "keyword": "#edb2f1",
+        "string": "#00ceb9",
+        "number": "#8cb0ff",
+        "function": "#fab283",
+        "variable": "#fefdfd",
+        "type": "#fcd53a",
+        "operator": "#cdc8c5"
+      },
+      "tokens": {
+        "commentDoc": "#8f8f8f",
+        "stringEscape": "#93e9f6",
+        "keywordImport": "#edb2f1",
+        "storageModifier": "#edb2f1",
+        "functionCall": "#fab283",
+        "method": "#fab283",
+        "variableProperty": "#fab283",
+        "variableOther": "#fefdfd",
+        "variableGlobal": "#93e9f6",
+        "variableLocal": "#cdc8c5",
+        "parameter": "#fefdfd",
+        "constant": "#93e9f6",
+        "class": "#fcd53a",
+        "className": "#fcd53a",
+        "interface": "#fcd53a",
+        "struct": "#fcd53a",
+        "enum": "#fcd53a",
+        "typeParameter": "#fcd53a",
+        "namespace": "#edb2f1",
+        "module": "#edb2f1",
+        "tag": "#edb2f1",
+        "jsxTag": "#edb2f1",
+        "tagAttribute": "#fab283",
+        "tagAttributeValue": "#00ceb9",
+        "boolean": "#8cb0ff",
+        "decorator": "#edb2f1",
+        "label": "#edb2f1",
+        "punctuation": "#cdc8c5",
+        "macro": "#edb2f1",
+        "preprocessor": "#edb2f1",
+        "regex": "#f1ece8",
+        "url": "#cfdffd",
+        "key": "#fab283",
+        "exception": "#cb321c"
+      },
+      "highlights": {
+        "diffAdded": "#c4ffc0",
+        "diffAddedBackground": "#001401",
+        "diffRemoved": "#ec2f14",
+        "diffRemovedBackground": "#240200",
+        "diffModified": "#fde280",
+        "diffModifiedBackground": "#141c2c",
+        "lineNumber": "#afaca9",
+        "lineNumberActive": "#f1ece8"
+      }
+    },
+    "markdown": {
+      "heading1": "#fed6bd",
+      "heading2": "#fed6bd",
+      "heading3": "#f1ece8",
+      "heading4": "#f1ece8",
+      "link": "#cfdffd",
+      "linkHover": "#facffe",
+      "inlineCode": "#94fd8b",
+      "inlineCodeBackground": "#1b1b1a",
+      "blockquote": "#fde280",
+      "blockquoteBorder": "#484746",
+      "listMarker": "#cfdffd99"
+    },
+    "chat": {
+      "userMessage": "#f1ece8",
+      "userMessageBackground": "#00207d",
+      "assistantMessage": "#f1ece8",
+      "assistantMessageBackground": "#0c0c0c",
+      "timestamp": "#cdc8c5",
+      "divider": "#484746"
+    },
+    "tools": {
+      "background": "#1b1b1a80",
+      "border": "#484746b3",
+      "headerHover": "#23222280",
+      "icon": "#cdc8c5",
+      "title": "#f1ece8",
+      "description": "#cdc8c5",
+      "edit": {
+        "added": "#c4ffc0",
+        "addedBackground": "#001401",
+        "removed": "#ec2f14",
+        "removedBackground": "#240200",
+        "lineNumber": "#afaca9"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/oc-2-light.json
+++ b/packages/ui/src/lib/theme/themes/oc-2-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "oc-2-light",
+    "name": "OC-2",
+    "description": "Port of OpenCode OC-2 theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "oc-2"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#dddf79",
+      "hover": "#d2d369",
+      "active": "#d2d369",
+      "foreground": "#000000",
+      "muted": "#dddf7980",
+      "emphasis": "#d2d369"
+    },
+    "surface": {
+      "background": "#f8f8f8",
+      "foreground": "#161210",
+      "muted": "#ebebeb",
+      "mutedForeground": "#302c2a",
+      "elevated": "#f1f1f1",
+      "elevatedForeground": "#161210",
+      "overlay": "#0000004d",
+      "subtle": "#e2e2e2"
+    },
+    "interactive": {
+      "border": "#c1c0c0",
+      "borderHover": "#b4b2b2",
+      "borderFocus": "#a3c1fd",
+      "selection": "#e0eafd",
+      "selectionForeground": "#000000",
+      "focus": "#a3c1fd",
+      "focusRing": "#a3c1fd47",
+      "cursor": "#161210",
+      "hover": "#e2e2e2",
+      "active": "#e2e2e2"
+    },
+    "status": {
+      "error": "#fa3012",
+      "errorForeground": "#000000",
+      "errorBackground": "#fde3de",
+      "errorBorder": "#faaa9b",
+      "warning": "#f9b13f",
+      "warningForeground": "#000000",
+      "warningBackground": "#feeb92",
+      "warningBorder": "#dec025",
+      "success": "#2ce822",
+      "successForeground": "#000000",
+      "successBackground": "#bbffb4",
+      "successBorder": "#2ce822",
+      "info": "#f39cf9",
+      "infoForeground": "#000000",
+      "infoBackground": "#fcdffe",
+      "infoBorder": "#f39cf9"
+    },
+    "pr": {
+      "open": "#2ce822",
+      "draft": "#302c2a",
+      "blocked": "#f9b13f",
+      "merged": "#a753ae",
+      "closed": "#fa3012"
+    },
+    "syntax": {
+      "base": {
+        "background": "#ebebeb",
+        "foreground": "#161210",
+        "comment": "#7a7a7a",
+        "keyword": "#a753ae",
+        "string": "#00ceb9",
+        "number": "#034cff",
+        "function": "#a753ae",
+        "variable": "#070504",
+        "type": "#8a6f00",
+        "operator": "#161210"
+      },
+      "tokens": {
+        "commentDoc": "#7a7a7a",
+        "stringEscape": "#007b80",
+        "keywordImport": "#a753ae",
+        "storageModifier": "#a753ae",
+        "functionCall": "#a753ae",
+        "method": "#a753ae",
+        "variableProperty": "#a753ae",
+        "variableOther": "#070504",
+        "variableGlobal": "#007b80",
+        "variableLocal": "#302c2a",
+        "parameter": "#070504",
+        "constant": "#007b80",
+        "class": "#8a6f00",
+        "className": "#8a6f00",
+        "interface": "#8a6f00",
+        "struct": "#8a6f00",
+        "enum": "#8a6f00",
+        "typeParameter": "#8a6f00",
+        "namespace": "#a753ae",
+        "module": "#a753ae",
+        "tag": "#a753ae",
+        "jsxTag": "#a753ae",
+        "tagAttribute": "#a753ae",
+        "tagAttributeValue": "#00ceb9",
+        "boolean": "#034cff",
+        "decorator": "#a753ae",
+        "label": "#a753ae",
+        "punctuation": "#161210",
+        "macro": "#a753ae",
+        "preprocessor": "#a753ae",
+        "regex": "#161210",
+        "url": "#0040df",
+        "key": "#a753ae",
+        "exception": "#fa3012"
+      },
+      "highlights": {
+        "diffAdded": "#167517",
+        "diffAddedBackground": "#f9fff8",
+        "diffRemoved": "#fa3012",
+        "diffRemovedBackground": "#fffcfb",
+        "diffModified": "#675912",
+        "diffModifiedBackground": "#dfe4f0",
+        "lineNumber": "#494644",
+        "lineNumberActive": "#161210"
+      }
+    },
+    "markdown": {
+      "heading1": "#5e5e11",
+      "heading2": "#5e5e11",
+      "heading3": "#161210",
+      "heading4": "#161210",
+      "link": "#0040df",
+      "linkHover": "#8c1896",
+      "inlineCode": "#166c11",
+      "inlineCodeBackground": "#ebebeb",
+      "blockquote": "#675912",
+      "blockquoteBorder": "#c1c0c0",
+      "listMarker": "#0040df99"
+    },
+    "chat": {
+      "userMessage": "#161210",
+      "userMessageBackground": "#e0eafd",
+      "assistantMessage": "#161210",
+      "assistantMessageBackground": "#f8f8f8",
+      "timestamp": "#302c2a",
+      "divider": "#c1c0c0"
+    },
+    "tools": {
+      "background": "#ebebeb80",
+      "border": "#c1c0c0b3",
+      "headerHover": "#e2e2e280",
+      "icon": "#302c2a",
+      "title": "#161210",
+      "description": "#302c2a",
+      "edit": {
+        "added": "#167517",
+        "addedBackground": "#f9fff8",
+        "removed": "#fa3012",
+        "removedBackground": "#fffcfb",
+        "lineNumber": "#494644"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/orng-dark.json
+++ b/packages/ui/src/lib/theme/themes/orng-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "orng-dark",
+    "name": "Orng",
+    "description": "Port of OpenCode Orng theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "orng"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#be3c07",
+      "hover": "#da4f1f",
+      "active": "#da4f1f",
+      "foreground": "#ffffff",
+      "muted": "#be3c0780",
+      "emphasis": "#da4f1f"
+    },
+    "surface": {
+      "background": "#050505",
+      "foreground": "#eeeeee",
+      "muted": "#141414",
+      "mutedForeground": "#808080",
+      "elevated": "#0e0e0e",
+      "elevatedForeground": "#eeeeee",
+      "overlay": "#00000080",
+      "subtle": "#1c1c1c"
+    },
+    "interactive": {
+      "border": "#434343",
+      "borderHover": "#4c4c4c",
+      "borderFocus": "#752101",
+      "selection": "#531906",
+      "selectionForeground": "#ffffff",
+      "focus": "#752101",
+      "focusRing": "#75210159",
+      "cursor": "#eeeeee",
+      "hover": "#1c1c1c",
+      "active": "#1c1c1c"
+    },
+    "status": {
+      "error": "#ce2245",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#5c0318",
+      "errorBorder": "#7c0a25",
+      "warning": "#c51d33",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#531906",
+      "warningBorder": "#752101",
+      "success": "#1277e2",
+      "successForeground": "#ffffff",
+      "successBackground": "#042e5d",
+      "successBorder": "#09417d",
+      "info": "#228f9b",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#05363b",
+      "infoBorder": "#0d4b51"
+    },
+    "pr": {
+      "open": "#1277e2",
+      "draft": "#808080",
+      "blocked": "#c51d33",
+      "merged": "#EC5B2B",
+      "closed": "#ce2245"
+    },
+    "syntax": {
+      "base": {
+        "background": "#141414",
+        "foreground": "#eeeeee",
+        "comment": "#808080",
+        "keyword": "#EC5B2B",
+        "string": "#6ba1e6",
+        "number": "#EE7948",
+        "function": "#56b6c2",
+        "variable": "#e06c75",
+        "type": "#e5c07b",
+        "operator": "#56b6c2"
+      },
+      "tokens": {
+        "commentDoc": "#808080",
+        "stringEscape": "#FFF7F1",
+        "keywordImport": "#EC5B2B",
+        "storageModifier": "#EC5B2B",
+        "functionCall": "#56b6c2",
+        "method": "#56b6c2",
+        "variableProperty": "#56b6c2",
+        "variableOther": "#e06c75",
+        "variableGlobal": "#FFF7F1",
+        "variableLocal": "#808080",
+        "parameter": "#e06c75",
+        "constant": "#FFF7F1",
+        "class": "#e5c07b",
+        "className": "#e5c07b",
+        "interface": "#e5c07b",
+        "struct": "#e5c07b",
+        "enum": "#e5c07b",
+        "typeParameter": "#e5c07b",
+        "namespace": "#EC5B2B",
+        "module": "#EC5B2B",
+        "tag": "#EC5B2B",
+        "jsxTag": "#EC5B2B",
+        "tagAttribute": "#56b6c2",
+        "tagAttributeValue": "#6ba1e6",
+        "boolean": "#EE7948",
+        "decorator": "#EC5B2B",
+        "label": "#EC5B2B",
+        "punctuation": "#eeeeee",
+        "macro": "#EC5B2B",
+        "preprocessor": "#EC5B2B",
+        "regex": "#eeeeee",
+        "url": "#EC5B2B",
+        "key": "#56b6c2",
+        "exception": "#ce2245"
+      },
+      "highlights": {
+        "diffAdded": "#b8d6fe",
+        "diffAddedBackground": "#010e24",
+        "diffRemoved": "#e92b53",
+        "diffRemovedBackground": "#230106",
+        "diffModified": "#ffba92",
+        "diffModifiedBackground": "#281a16",
+        "lineNumber": "#5d5d5d",
+        "lineNumberActive": "#eeeeee"
+      }
+    },
+    "markdown": {
+      "heading1": "#EC5B2B",
+      "heading2": "#EC5B2B",
+      "heading3": "#eeeeee",
+      "heading4": "#eeeeee",
+      "link": "#EC5B2B",
+      "linkHover": "#56b6c2",
+      "inlineCode": "#6ba1e6",
+      "inlineCodeBackground": "#141414",
+      "blockquote": "#FFF7F1",
+      "blockquoteBorder": "#434343",
+      "listMarker": "#EC5B2B99"
+    },
+    "chat": {
+      "userMessage": "#eeeeee",
+      "userMessageBackground": "#531906",
+      "assistantMessage": "#eeeeee",
+      "assistantMessageBackground": "#050505",
+      "timestamp": "#808080",
+      "divider": "#434343"
+    },
+    "tools": {
+      "background": "#14141480",
+      "border": "#434343b3",
+      "headerHover": "#1c1c1c80",
+      "icon": "#808080",
+      "title": "#eeeeee",
+      "description": "#808080",
+      "edit": {
+        "added": "#b8d6fe",
+        "addedBackground": "#010e24",
+        "removed": "#e92b53",
+        "removedBackground": "#230106",
+        "lineNumber": "#5d5d5d"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/orng-light.json
+++ b/packages/ui/src/lib/theme/themes/orng-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "orng-light",
+    "name": "Orng",
+    "description": "Port of OpenCode Orng theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "orng"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#f45214",
+      "hover": "#e14d17",
+      "active": "#e14d17",
+      "foreground": "#000000",
+      "muted": "#f4521480",
+      "emphasis": "#e14d17"
+    },
+    "surface": {
+      "background": "#ffffff",
+      "foreground": "#181818",
+      "muted": "#f2f2f2",
+      "mutedForeground": "#8a8a8a",
+      "elevated": "#f8f8f8",
+      "elevatedForeground": "#181818",
+      "overlay": "#0000004d",
+      "subtle": "#e9e9e9"
+    },
+    "interactive": {
+      "border": "#c7c7c7",
+      "borderHover": "#b9b9b9",
+      "borderFocus": "#fea88e",
+      "selection": "#ffe3da",
+      "selectionForeground": "#000000",
+      "focus": "#fea88e",
+      "focusRing": "#fea88e47",
+      "cursor": "#181818",
+      "hover": "#e9e9e9",
+      "active": "#e9e9e9"
+    },
+    "status": {
+      "error": "#ce0727",
+      "errorForeground": "#000000",
+      "errorBackground": "#fde3e0",
+      "errorBorder": "#faa8a3",
+      "warning": "#fca6ab",
+      "warningForeground": "#000000",
+      "warningBackground": "#ffe3da",
+      "warningBorder": "#fea88e",
+      "success": "#9ec3fa",
+      "successForeground": "#000000",
+      "successBackground": "#deebfe",
+      "successBorder": "#9ec3fa",
+      "info": "#77d1e1",
+      "infoForeground": "#000000",
+      "infoBackground": "#bff5ff",
+      "infoBorder": "#77d1e1"
+    },
+    "pr": {
+      "open": "#9ec3fa",
+      "draft": "#8a8a8a",
+      "blocked": "#fca6ab",
+      "merged": "#EC5B2B",
+      "closed": "#ce0727"
+    },
+    "syntax": {
+      "base": {
+        "background": "#f2f2f2",
+        "foreground": "#181818",
+        "comment": "#8a8a8a",
+        "keyword": "#EC5B2B",
+        "string": "#0062d1",
+        "number": "#c94d24",
+        "function": "#318795",
+        "variable": "#d1383d",
+        "type": "#b0851f",
+        "operator": "#318795"
+      },
+      "tokens": {
+        "commentDoc": "#8a8a8a",
+        "stringEscape": "#EC5B2B",
+        "keywordImport": "#EC5B2B",
+        "storageModifier": "#EC5B2B",
+        "functionCall": "#318795",
+        "method": "#318795",
+        "variableProperty": "#318795",
+        "variableOther": "#d1383d",
+        "variableGlobal": "#EC5B2B",
+        "variableLocal": "#8a8a8a",
+        "parameter": "#d1383d",
+        "constant": "#EC5B2B",
+        "class": "#b0851f",
+        "className": "#b0851f",
+        "interface": "#b0851f",
+        "struct": "#b0851f",
+        "enum": "#b0851f",
+        "typeParameter": "#b0851f",
+        "namespace": "#EC5B2B",
+        "module": "#EC5B2B",
+        "tag": "#EC5B2B",
+        "jsxTag": "#EC5B2B",
+        "tagAttribute": "#318795",
+        "tagAttributeValue": "#0062d1",
+        "boolean": "#c94d24",
+        "decorator": "#EC5B2B",
+        "label": "#EC5B2B",
+        "punctuation": "#1a1a1a",
+        "macro": "#EC5B2B",
+        "preprocessor": "#EC5B2B",
+        "regex": "#181818",
+        "url": "#EC5B2B",
+        "key": "#318795",
+        "exception": "#ce0727"
+      },
+      "highlights": {
+        "diffAdded": "#2f60a4",
+        "diffAddedBackground": "#fbfdff",
+        "diffRemoved": "#e9055a",
+        "diffRemovedBackground": "#fffcfc",
+        "diffModified": "#FF8C00",
+        "diffModifiedBackground": "#f9eeeb",
+        "lineNumber": "#afafaf",
+        "lineNumberActive": "#181818"
+      }
+    },
+    "markdown": {
+      "heading1": "#EC5B2B",
+      "heading2": "#EC5B2B",
+      "heading3": "#181818",
+      "heading4": "#181818",
+      "link": "#EC5B2B",
+      "linkHover": "#318795",
+      "inlineCode": "#0062d1",
+      "inlineCodeBackground": "#f2f2f2",
+      "blockquote": "#b0851f",
+      "blockquoteBorder": "#c7c7c7",
+      "listMarker": "#EC5B2B99"
+    },
+    "chat": {
+      "userMessage": "#181818",
+      "userMessageBackground": "#ffe3da",
+      "assistantMessage": "#181818",
+      "assistantMessageBackground": "#ffffff",
+      "timestamp": "#8a8a8a",
+      "divider": "#c7c7c7"
+    },
+    "tools": {
+      "background": "#f2f2f280",
+      "border": "#c7c7c7b3",
+      "headerHover": "#e9e9e980",
+      "icon": "#8a8a8a",
+      "title": "#181818",
+      "description": "#8a8a8a",
+      "edit": {
+        "added": "#2f60a4",
+        "addedBackground": "#fbfdff",
+        "removed": "#e9055a",
+        "removedBackground": "#fffcfc",
+        "lineNumber": "#afafaf"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/presets.ts
+++ b/packages/ui/src/lib/theme/themes/presets.ts
@@ -1,6 +1,8 @@
 import type { Theme } from '@/types/theme';
 import { withPrColors } from './prColors';
 
+import amoled_dark_Raw from './amoled-dark.json';
+import amoled_light_Raw from './amoled-light.json';
 import aura_dark_Raw from './aura-dark.json';
 import aura_light_Raw from './aura-light.json';
 import ayu_dark_Raw from './ayu-dark.json';
@@ -9,26 +11,44 @@ import carbonfox_dark_Raw from './carbonfox-dark.json';
 import carbonfox_light_Raw from './carbonfox-light.json';
 import catppuccin_dark_Raw from './catppuccin-dark.json';
 import catppuccin_light_Raw from './catppuccin-light.json';
+import cursor_dark_Raw from './cursor-dark.json';
+import cursor_light_Raw from './cursor-light.json';
 import dracula_dark_Raw from './dracula-dark.json';
 import dracula_light_Raw from './dracula-light.json';
+import github_dark_Raw from './github-dark.json';
+import github_light_Raw from './github-light.json';
 import gruvbox_dark_Raw from './gruvbox-dark.json';
 import gruvbox_light_Raw from './gruvbox-light.json';
 import kanagawa_dark_Raw from './kanagawa-dark.json';
 import kanagawa_light_Raw from './kanagawa-light.json';
+import lucent_orng_dark_Raw from './lucent-orng-dark.json';
+import lucent_orng_light_Raw from './lucent-orng-light.json';
 import monokai_dark_Raw from './monokai-dark.json';
 import monokai_light_Raw from './monokai-light.json';
 import nightowl_dark_Raw from './nightowl-dark.json';
 import nightowl_light_Raw from './nightowl-light.json';
 import nord_dark_Raw from './nord-dark.json';
 import nord_light_Raw from './nord-light.json';
+import oc_2_dark_Raw from './oc-2-dark.json';
+import oc_2_light_Raw from './oc-2-light.json';
 import onedarkpro_dark_Raw from './onedarkpro-dark.json';
 import onedarkpro_light_Raw from './onedarkpro-light.json';
+import orng_dark_Raw from './orng-dark.json';
+import orng_light_Raw from './orng-light.json';
+import rosepine_dark_Raw from './rosepine-dark.json';
+import rosepine_light_Raw from './rosepine-light.json';
+import shadesofpurple_dark_Raw from './shadesofpurple-dark.json';
+import shadesofpurple_light_Raw from './shadesofpurple-light.json';
 import solarized_dark_Raw from './solarized-dark.json';
 import solarized_light_Raw from './solarized-light.json';
 import tokyonight_dark_Raw from './tokyonight-dark.json';
 import tokyonight_light_Raw from './tokyonight-light.json';
+import vercel_dark_Raw from './vercel-dark.json';
+import vercel_light_Raw from './vercel-light.json';
 import vesper_dark_Raw from './vesper-dark.json';
 import vesper_light_Raw from './vesper-light.json';
+import zenburn_dark_Raw from './zenburn-dark.json';
+import zenburn_light_Raw from './zenburn-light.json';
 import mono_plus_dark_Raw from './mono-plus-dark.json';
 import mono_plus_light_Raw from './mono-plus-light.json';
 import mono_dark_Raw from './mono-dark.json';
@@ -37,6 +57,8 @@ import vitesse_dark_dark_Raw from './vitesse-dark-dark.json';
 import vitesse_light_light_Raw from './vitesse-light-light.json';
 
 export const presetThemes: Theme[] = [
+  amoled_dark_Raw as Theme,
+  amoled_light_Raw as Theme,
   aura_dark_Raw as Theme,
   aura_light_Raw as Theme,
   ayu_dark_Raw as Theme,
@@ -45,26 +67,44 @@ export const presetThemes: Theme[] = [
   carbonfox_light_Raw as Theme,
   catppuccin_dark_Raw as Theme,
   catppuccin_light_Raw as Theme,
+  cursor_dark_Raw as Theme,
+  cursor_light_Raw as Theme,
   dracula_dark_Raw as Theme,
   dracula_light_Raw as Theme,
+  github_dark_Raw as Theme,
+  github_light_Raw as Theme,
   gruvbox_dark_Raw as Theme,
   gruvbox_light_Raw as Theme,
   kanagawa_dark_Raw as Theme,
   kanagawa_light_Raw as Theme,
+  lucent_orng_dark_Raw as Theme,
+  lucent_orng_light_Raw as Theme,
   monokai_dark_Raw as Theme,
   monokai_light_Raw as Theme,
   nightowl_dark_Raw as Theme,
   nightowl_light_Raw as Theme,
   nord_dark_Raw as Theme,
   nord_light_Raw as Theme,
+  oc_2_dark_Raw as Theme,
+  oc_2_light_Raw as Theme,
   onedarkpro_dark_Raw as Theme,
   onedarkpro_light_Raw as Theme,
+  orng_dark_Raw as Theme,
+  orng_light_Raw as Theme,
+  rosepine_dark_Raw as Theme,
+  rosepine_light_Raw as Theme,
+  shadesofpurple_dark_Raw as Theme,
+  shadesofpurple_light_Raw as Theme,
   solarized_dark_Raw as Theme,
   solarized_light_Raw as Theme,
   tokyonight_dark_Raw as Theme,
   tokyonight_light_Raw as Theme,
+  vercel_dark_Raw as Theme,
+  vercel_light_Raw as Theme,
   vesper_dark_Raw as Theme,
   vesper_light_Raw as Theme,
+  zenburn_dark_Raw as Theme,
+  zenburn_light_Raw as Theme,
   mono_plus_dark_Raw as Theme,
   mono_plus_light_Raw as Theme,
   mono_dark_Raw as Theme,

--- a/packages/ui/src/lib/theme/themes/rosepine-dark.json
+++ b/packages/ui/src/lib/theme/themes/rosepine-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "rosepine-dark",
+    "name": "Rose Pine",
+    "description": "Port of OpenCode Rose Pine theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "rosepine"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#51a6b4",
+      "hover": "#5db8c7",
+      "active": "#5db8c7",
+      "foreground": "#000000",
+      "muted": "#51a6b480",
+      "emphasis": "#5db8c7"
+    },
+    "surface": {
+      "background": "#0c0a16",
+      "foreground": "#e0def5",
+      "muted": "#1a1824",
+      "mutedForeground": "#6e6a86",
+      "elevated": "#14121e",
+      "elevatedForeground": "#e0def5",
+      "overlay": "#00000080",
+      "subtle": "#211f2c"
+    },
+    "interactive": {
+      "border": "#444251",
+      "borderHover": "#4c4a59",
+      "borderFocus": "#0d4a53",
+      "selection": "#06353c",
+      "selectionForeground": "#ffffff",
+      "focus": "#0d4a53",
+      "focusRing": "#0d4a5359",
+      "cursor": "#e0def5",
+      "hover": "#211f2c",
+      "active": "#211f2c"
+    },
+    "status": {
+      "error": "#d81b69",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#590628",
+      "errorBorder": "#780f39",
+      "warning": "#cc7520",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#402a06",
+      "warningBorder": "#5a3a01",
+      "success": "#0c7699",
+      "successForeground": "#ffffff",
+      "successBackground": "#023446",
+      "successBorder": "#06495f",
+      "info": "#51a6b4",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#06353c",
+      "infoBorder": "#0d4a53"
+    },
+    "pr": {
+      "open": "#0c7699",
+      "draft": "#6e6a86",
+      "blocked": "#cc7520",
+      "merged": "#31748f",
+      "closed": "#d81b69"
+    },
+    "syntax": {
+      "base": {
+        "background": "#1a1824",
+        "foreground": "#e0def5",
+        "comment": "#6e6a86",
+        "keyword": "#31748f",
+        "string": "#f6c177",
+        "number": "#ebbcba",
+        "function": "#ebbcba",
+        "variable": "#e0def4",
+        "type": "#9ccfd8",
+        "operator": "#908caa"
+      },
+      "tokens": {
+        "commentDoc": "#6e6a86",
+        "stringEscape": "#c4a7e7",
+        "keywordImport": "#31748f",
+        "storageModifier": "#31748f",
+        "functionCall": "#ebbcba",
+        "method": "#ebbcba",
+        "variableProperty": "#ebbcba",
+        "variableOther": "#e0def4",
+        "variableGlobal": "#c4a7e7",
+        "variableLocal": "#6e6a86",
+        "parameter": "#e0def4",
+        "constant": "#c4a7e7",
+        "class": "#9ccfd8",
+        "className": "#9ccfd8",
+        "interface": "#9ccfd8",
+        "struct": "#9ccfd8",
+        "enum": "#9ccfd8",
+        "typeParameter": "#9ccfd8",
+        "namespace": "#31748f",
+        "module": "#31748f",
+        "tag": "#31748f",
+        "jsxTag": "#31748f",
+        "tagAttribute": "#ebbcba",
+        "tagAttributeValue": "#f6c177",
+        "boolean": "#ebbcba",
+        "decorator": "#31748f",
+        "label": "#31748f",
+        "punctuation": "#908caa",
+        "macro": "#31748f",
+        "preprocessor": "#31748f",
+        "regex": "#e0def5",
+        "url": "#9ccfd8",
+        "key": "#ebbcba",
+        "exception": "#d81b69"
+      },
+      "highlights": {
+        "diffAdded": "#9bdffd",
+        "diffAddedBackground": "#011119",
+        "diffRemoved": "#e13474",
+        "diffRemovedBackground": "#23000b",
+        "diffModified": "#fdcd8b",
+        "diffModifiedBackground": "#292d37",
+        "lineNumber": "#4c4a5d",
+        "lineNumberActive": "#e0def5"
+      }
+    },
+    "markdown": {
+      "heading1": "#c4a7e7",
+      "heading2": "#c4a7e7",
+      "heading3": "#e0def5",
+      "heading4": "#e0def5",
+      "link": "#9ccfd8",
+      "linkHover": "#ebbcba",
+      "inlineCode": "#31748f",
+      "inlineCodeBackground": "#1a1824",
+      "blockquote": "#6e6a86",
+      "blockquoteBorder": "#444251",
+      "listMarker": "#9ccfd899"
+    },
+    "chat": {
+      "userMessage": "#e0def5",
+      "userMessageBackground": "#06353c",
+      "assistantMessage": "#e0def5",
+      "assistantMessageBackground": "#0c0a16",
+      "timestamp": "#6e6a86",
+      "divider": "#444251"
+    },
+    "tools": {
+      "background": "#1a182480",
+      "border": "#444251b3",
+      "headerHover": "#211f2c80",
+      "icon": "#6e6a86",
+      "title": "#e0def5",
+      "description": "#6e6a86",
+      "edit": {
+        "added": "#9bdffd",
+        "addedBackground": "#011119",
+        "removed": "#e13474",
+        "removedBackground": "#23000b",
+        "lineNumber": "#4c4a5d"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/rosepine-light.json
+++ b/packages/ui/src/lib/theme/themes/rosepine-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "rosepine-light",
+    "name": "Rose Pine",
+    "description": "Port of OpenCode Rose Pine theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "rosepine"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#157597",
+      "hover": "#136a89",
+      "active": "#136a89",
+      "foreground": "#ffffff",
+      "muted": "#15759780",
+      "emphasis": "#136a89"
+    },
+    "surface": {
+      "background": "#fbf5ef",
+      "foreground": "#454066",
+      "muted": "#f2ebe8",
+      "mutedForeground": "#9893a5",
+      "elevated": "#f6f0ec",
+      "elevatedForeground": "#454066",
+      "overlay": "#0000004d",
+      "subtle": "#ebe5e3"
+    },
+    "interactive": {
+      "border": "#d3cdd2",
+      "borderHover": "#c9c3cb",
+      "borderFocus": "#84cded",
+      "selection": "#d0f0ff",
+      "selectionForeground": "#000000",
+      "focus": "#84cded",
+      "focusRing": "#84cded47",
+      "cursor": "#454066",
+      "hover": "#ebe5e3",
+      "active": "#ebe5e3"
+    },
+    "status": {
+      "error": "#b34e6e",
+      "errorForeground": "#000000",
+      "errorBackground": "#fde2e8",
+      "errorBorder": "#faa5bb",
+      "warning": "#fbac84",
+      "warningForeground": "#000000",
+      "warningBackground": "#fde6cc",
+      "warningBorder": "#fbaf4f",
+      "success": "#86ccec",
+      "successForeground": "#000000",
+      "successBackground": "#d1f0fe",
+      "successBorder": "#86ccec",
+      "info": "#89cedb",
+      "infoForeground": "#000000",
+      "infoBackground": "#c8f3fb",
+      "infoBorder": "#89cedb"
+    },
+    "pr": {
+      "open": "#86ccec",
+      "draft": "#9893a5",
+      "blocked": "#fbac84",
+      "merged": "#286983",
+      "closed": "#b34e6e"
+    },
+    "syntax": {
+      "base": {
+        "background": "#f2ebe8",
+        "foreground": "#454066",
+        "comment": "#9893a5",
+        "keyword": "#286983",
+        "string": "#ea9d34",
+        "number": "#d7827e",
+        "function": "#d7827e",
+        "variable": "#575279",
+        "type": "#56949f",
+        "operator": "#797593"
+      },
+      "tokens": {
+        "commentDoc": "#9893a5",
+        "stringEscape": "#907aa9",
+        "keywordImport": "#286983",
+        "storageModifier": "#286983",
+        "functionCall": "#d7827e",
+        "method": "#d7827e",
+        "variableProperty": "#d7827e",
+        "variableOther": "#575279",
+        "variableGlobal": "#907aa9",
+        "variableLocal": "#9893a5",
+        "parameter": "#575279",
+        "constant": "#907aa9",
+        "class": "#56949f",
+        "className": "#56949f",
+        "interface": "#56949f",
+        "struct": "#56949f",
+        "enum": "#56949f",
+        "typeParameter": "#56949f",
+        "namespace": "#286983",
+        "module": "#286983",
+        "tag": "#286983",
+        "jsxTag": "#286983",
+        "tagAttribute": "#d7827e",
+        "tagAttributeValue": "#ea9d34",
+        "boolean": "#d7827e",
+        "decorator": "#286983",
+        "label": "#286983",
+        "punctuation": "#797593",
+        "macro": "#286983",
+        "preprocessor": "#286983",
+        "regex": "#454066",
+        "url": "#31748f",
+        "key": "#d7827e",
+        "exception": "#b34e6e"
+      },
+      "highlights": {
+        "diffAdded": "#416677",
+        "diffAddedBackground": "#fafdff",
+        "diffRemoved": "#bd7488",
+        "diffRemovedBackground": "#fffcfc",
+        "diffModified": "#7c4e09",
+        "diffModifiedBackground": "#e4e3e0",
+        "lineNumber": "#bdb9c7",
+        "lineNumberActive": "#454066"
+      }
+    },
+    "markdown": {
+      "heading1": "#907aa9",
+      "heading2": "#907aa9",
+      "heading3": "#454066",
+      "heading4": "#454066",
+      "link": "#31748f",
+      "linkHover": "#d7827e",
+      "inlineCode": "#286983",
+      "inlineCodeBackground": "#f2ebe8",
+      "blockquote": "#9893a5",
+      "blockquoteBorder": "#d3cdd2",
+      "listMarker": "#31748f99"
+    },
+    "chat": {
+      "userMessage": "#454066",
+      "userMessageBackground": "#d0f0ff",
+      "assistantMessage": "#454066",
+      "assistantMessageBackground": "#fbf5ef",
+      "timestamp": "#9893a5",
+      "divider": "#d3cdd2"
+    },
+    "tools": {
+      "background": "#f2ebe880",
+      "border": "#d3cdd2b3",
+      "headerHover": "#ebe5e380",
+      "icon": "#9893a5",
+      "title": "#454066",
+      "description": "#9893a5",
+      "edit": {
+        "added": "#416677",
+        "addedBackground": "#fafdff",
+        "removed": "#bd7488",
+        "removedBackground": "#fffcfc",
+        "lineNumber": "#bdb9c7"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/shadesofpurple-dark.json
+++ b/packages/ui/src/lib/theme/themes/shadesofpurple-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "shadesofpurple-dark",
+    "name": "Shades of Purple",
+    "description": "Port of OpenCode Shades of Purple theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "shadesofpurple"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#ab4afb",
+      "hover": "#b569fb",
+      "active": "#b569fb",
+      "foreground": "#000000",
+      "muted": "#ab4afb80",
+      "emphasis": "#b569fb"
+    },
+    "surface": {
+      "background": "#0e051d",
+      "foreground": "#f5f0fe",
+      "muted": "#1d142c",
+      "mutedForeground": "#d1ccd8",
+      "elevated": "#170e25",
+      "elevatedForeground": "#f5f0fe",
+      "overlay": "#00000080",
+      "subtle": "#251c33"
+    },
+    "interactive": {
+      "border": "#4b4359",
+      "borderHover": "#544c62",
+      "borderFocus": "#5c0092",
+      "selection": "#410a67",
+      "selectionForeground": "#ffffff",
+      "focus": "#5c0092",
+      "focusRing": "#5c009259",
+      "cursor": "#f5f0fe",
+      "hover": "#251c33",
+      "active": "#251c33"
+    },
+    "status": {
+      "error": "#e816a4",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#55073a",
+      "errorBorder": "#731051",
+      "warning": "#d58611",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#3d2c02",
+      "warningBorder": "#543e06",
+      "success": "#0eb67d",
+      "successForeground": "#ffffff",
+      "successBackground": "#053825",
+      "successBorder": "#0d4e35",
+      "info": "#22a7dc",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#003448",
+      "infoBorder": "#034862"
+    },
+    "pr": {
+      "open": "#0eb67d",
+      "draft": "#d1ccd8",
+      "blocked": "#d58611",
+      "merged": "#ff9d00",
+      "closed": "#e816a4"
+    },
+    "syntax": {
+      "base": {
+        "background": "#1d142c",
+        "foreground": "#f5f0fe",
+        "comment": "#b362ff",
+        "keyword": "#ff9d00",
+        "string": "#a5ff90",
+        "number": "#fb94ff",
+        "function": "#9effff",
+        "variable": "#fefeff",
+        "type": "#fad000",
+        "operator": "#d1ccd8"
+      },
+      "tokens": {
+        "commentDoc": "#b362ff",
+        "stringEscape": "#ff628c",
+        "keywordImport": "#ff9d00",
+        "storageModifier": "#ff9d00",
+        "functionCall": "#9effff",
+        "method": "#9effff",
+        "variableProperty": "#9effff",
+        "variableOther": "#fefeff",
+        "variableGlobal": "#ff628c",
+        "variableLocal": "#d1ccd8",
+        "parameter": "#fefeff",
+        "constant": "#ff628c",
+        "class": "#fad000",
+        "className": "#fad000",
+        "interface": "#fad000",
+        "struct": "#fad000",
+        "enum": "#fad000",
+        "typeParameter": "#fad000",
+        "namespace": "#ff9d00",
+        "module": "#ff9d00",
+        "tag": "#ff9d00",
+        "jsxTag": "#ff9d00",
+        "tagAttribute": "#9effff",
+        "tagAttributeValue": "#a5ff90",
+        "boolean": "#fb94ff",
+        "decorator": "#ff9d00",
+        "label": "#ff9d00",
+        "punctuation": "#d1ccd8",
+        "macro": "#ff9d00",
+        "preprocessor": "#ff9d00",
+        "regex": "#f5f0fe",
+        "url": "#e7d6fd",
+        "key": "#9effff",
+        "exception": "#e816a4"
+      },
+      "highlights": {
+        "diffAdded": "#24f6c0",
+        "diffAddedBackground": "#01130c",
+        "diffRemoved": "#de299a",
+        "diffRemovedBackground": "#210113",
+        "diffModified": "#fee2ad",
+        "diffModifiedBackground": "#2d213f",
+        "lineNumber": "#b4b0ba",
+        "lineNumberActive": "#f5f0fe"
+      }
+    },
+    "markdown": {
+      "heading1": "#e7d6fd",
+      "heading2": "#e7d6fd",
+      "heading3": "#f5f0fe",
+      "heading4": "#f5f0fe",
+      "link": "#e7d6fd",
+      "linkHover": "#bae6fd",
+      "inlineCode": "#77fdc0",
+      "inlineCodeBackground": "#1d142c",
+      "blockquote": "#fee2ad",
+      "blockquoteBorder": "#4b4359",
+      "listMarker": "#e7d6fd99"
+    },
+    "chat": {
+      "userMessage": "#f5f0fe",
+      "userMessageBackground": "#410a67",
+      "assistantMessage": "#f5f0fe",
+      "assistantMessageBackground": "#0e051d",
+      "timestamp": "#d1ccd8",
+      "divider": "#4b4359"
+    },
+    "tools": {
+      "background": "#1d142c80",
+      "border": "#4b4359b3",
+      "headerHover": "#251c3380",
+      "icon": "#d1ccd8",
+      "title": "#f5f0fe",
+      "description": "#d1ccd8",
+      "edit": {
+        "added": "#24f6c0",
+        "addedBackground": "#01130c",
+        "removed": "#de299a",
+        "removedBackground": "#210113",
+        "lineNumber": "#b4b0ba"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/shadesofpurple-light.json
+++ b/packages/ui/src/lib/theme/themes/shadesofpurple-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "shadesofpurple-light",
+    "name": "Shades of Purple",
+    "description": "Port of OpenCode Shades of Purple theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "shadesofpurple"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#7a5bf7",
+      "hover": "#7242fb",
+      "active": "#7242fb",
+      "foreground": "#000000",
+      "muted": "#7a5bf780",
+      "emphasis": "#7242fb"
+    },
+    "surface": {
+      "background": "#f8effe",
+      "foreground": "#32224f",
+      "muted": "#ede4f4",
+      "mutedForeground": "#4e406b",
+      "elevated": "#f3e9f9",
+      "elevatedForeground": "#32224f",
+      "overlay": "#0000004d",
+      "subtle": "#e6dcee"
+    },
+    "interactive": {
+      "border": "#cabfd6",
+      "borderHover": "#bfb4cc",
+      "borderFocus": "#bcb9fb",
+      "selection": "#e8e7ff",
+      "selectionForeground": "#000000",
+      "focus": "#bcb9fb",
+      "focusRing": "#bcb9fb47",
+      "cursor": "#32224f",
+      "hover": "#e6dcee",
+      "active": "#e6dcee"
+    },
+    "status": {
+      "error": "#fb50ce",
+      "errorForeground": "#000000",
+      "errorBackground": "#fee0f2",
+      "errorBorder": "#fb9ddd",
+      "warning": "#fdae57",
+      "warningForeground": "#000000",
+      "warningBackground": "#fee8b1",
+      "warningBorder": "#ecba16",
+      "success": "#35e29f",
+      "successForeground": "#000000",
+      "successBackground": "#b0fed6",
+      "successBorder": "#35e29f",
+      "info": "#63d1fa",
+      "infoForeground": "#000000",
+      "infoBackground": "#d0f0fe",
+      "infoBorder": "#63d1fa"
+    },
+    "pr": {
+      "open": "#35e29f",
+      "draft": "#4e406b",
+      "blocked": "#fdae57",
+      "merged": "#c45f00",
+      "closed": "#fb50ce"
+    },
+    "syntax": {
+      "base": {
+        "background": "#ede4f4",
+        "foreground": "#32224f",
+        "comment": "#8e4be3",
+        "keyword": "#c45f00",
+        "string": "#2f8b32",
+        "number": "#a13bd6",
+        "function": "#008fb8",
+        "variable": "#210f3d",
+        "type": "#9d7a00",
+        "operator": "#32224f"
+      },
+      "tokens": {
+        "commentDoc": "#8e4be3",
+        "stringEscape": "#e04d7a",
+        "keywordImport": "#c45f00",
+        "storageModifier": "#c45f00",
+        "functionCall": "#008fb8",
+        "method": "#008fb8",
+        "variableProperty": "#008fb8",
+        "variableOther": "#210f3d",
+        "variableGlobal": "#e04d7a",
+        "variableLocal": "#4e406b",
+        "parameter": "#210f3d",
+        "constant": "#e04d7a",
+        "class": "#9d7a00",
+        "className": "#9d7a00",
+        "interface": "#9d7a00",
+        "struct": "#9d7a00",
+        "enum": "#9d7a00",
+        "typeParameter": "#9d7a00",
+        "namespace": "#c45f00",
+        "module": "#c45f00",
+        "tag": "#c45f00",
+        "jsxTag": "#c45f00",
+        "tagAttribute": "#008fb8",
+        "tagAttributeValue": "#2f8b32",
+        "boolean": "#a13bd6",
+        "decorator": "#c45f00",
+        "label": "#c45f00",
+        "punctuation": "#32224f",
+        "macro": "#c45f00",
+        "preprocessor": "#c45f00",
+        "regex": "#32224f",
+        "url": "#5c1adc",
+        "key": "#008fb8",
+        "exception": "#fb50ce"
+      },
+      "highlights": {
+        "diffAdded": "#386d50",
+        "diffAddedBackground": "#f9fefb",
+        "diffRemoved": "#fcb1e9",
+        "diffRemovedBackground": "#fffcfe",
+        "diffModified": "#6e560d",
+        "diffModifiedBackground": "#e7dff7",
+        "lineNumber": "#695e82",
+        "lineNumberActive": "#32224f"
+      }
+    },
+    "markdown": {
+      "heading1": "#5c1adc",
+      "heading2": "#5c1adc",
+      "heading3": "#32224f",
+      "heading4": "#32224f",
+      "link": "#5c1adc",
+      "linkHover": "#03637f",
+      "inlineCode": "#006b47",
+      "inlineCodeBackground": "#ede4f4",
+      "blockquote": "#6e560d",
+      "blockquoteBorder": "#cabfd6",
+      "listMarker": "#5c1adc99"
+    },
+    "chat": {
+      "userMessage": "#32224f",
+      "userMessageBackground": "#e8e7ff",
+      "assistantMessage": "#32224f",
+      "assistantMessageBackground": "#f8effe",
+      "timestamp": "#4e406b",
+      "divider": "#cabfd6"
+    },
+    "tools": {
+      "background": "#ede4f480",
+      "border": "#cabfd6b3",
+      "headerHover": "#e6dcee80",
+      "icon": "#4e406b",
+      "title": "#32224f",
+      "description": "#4e406b",
+      "edit": {
+        "added": "#386d50",
+        "addedBackground": "#f9fefb",
+        "removed": "#fcb1e9",
+        "removedBackground": "#fffcfe",
+        "lineNumber": "#695e82"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/vercel-dark.json
+++ b/packages/ui/src/lib/theme/themes/vercel-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "vercel-dark",
+    "name": "Vercel",
+    "description": "Port of OpenCode Vercel theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "vercel"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#0164db",
+      "hover": "#207dfc",
+      "active": "#207dfc",
+      "foreground": "#ffffff",
+      "muted": "#0164db80",
+      "emphasis": "#207dfc"
+    },
+    "surface": {
+      "background": "#000000",
+      "foreground": "#ededed",
+      "muted": "#0f0f0f",
+      "mutedForeground": "#878787",
+      "elevated": "#090909",
+      "elevatedForeground": "#ededed",
+      "overlay": "#00000080",
+      "subtle": "#171717"
+    },
+    "interactive": {
+      "border": "#3f3f3f",
+      "borderHover": "#484848",
+      "borderFocus": "#0e4374",
+      "selection": "#063056",
+      "selectionForeground": "#ffffff",
+      "focus": "#0e4374",
+      "focusRing": "#0e437459",
+      "cursor": "#ededed",
+      "hover": "#171717",
+      "active": "#171717"
+    },
+    "status": {
+      "error": "#c41e2f",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#5b0710",
+      "errorBorder": "#7b101b",
+      "warning": "#c37018",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#412900",
+      "warningBorder": "#593b03",
+      "success": "#148434",
+      "successForeground": "#ffffff",
+      "successBackground": "#023a12",
+      "successBorder": "#08501d",
+      "info": "#2280d6",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#063056",
+      "infoBorder": "#0e4374"
+    },
+    "pr": {
+      "open": "#148434",
+      "draft": "#878787",
+      "blocked": "#c37018",
+      "merged": "#F75590",
+      "closed": "#c41e2f"
+    },
+    "syntax": {
+      "base": {
+        "background": "#0f0f0f",
+        "foreground": "#ededed",
+        "comment": "#878787",
+        "keyword": "#F75590",
+        "string": "#63C46D",
+        "number": "#BF7AF0",
+        "function": "#0AC7AC",
+        "variable": "#52A8FF",
+        "type": "#0AC7AC",
+        "operator": "#F75590"
+      },
+      "tokens": {
+        "commentDoc": "#878787",
+        "stringEscape": "#F2A700",
+        "keywordImport": "#F75590",
+        "storageModifier": "#F75590",
+        "functionCall": "#0AC7AC",
+        "method": "#0AC7AC",
+        "variableProperty": "#0AC7AC",
+        "variableOther": "#52A8FF",
+        "variableGlobal": "#F2A700",
+        "variableLocal": "#878787",
+        "parameter": "#52A8FF",
+        "constant": "#F2A700",
+        "class": "#0AC7AC",
+        "className": "#0AC7AC",
+        "interface": "#0AC7AC",
+        "struct": "#0AC7AC",
+        "enum": "#0AC7AC",
+        "typeParameter": "#0AC7AC",
+        "namespace": "#F75590",
+        "module": "#F75590",
+        "tag": "#F75590",
+        "jsxTag": "#F75590",
+        "tagAttribute": "#0AC7AC",
+        "tagAttributeValue": "#63C46D",
+        "boolean": "#BF7AF0",
+        "decorator": "#F75590",
+        "label": "#F75590",
+        "punctuation": "#EDEDED",
+        "macro": "#F75590",
+        "preprocessor": "#F75590",
+        "regex": "#ededed",
+        "url": "#52A8FF",
+        "key": "#0AC7AC",
+        "exception": "#c41e2f"
+      },
+      "highlights": {
+        "diffAdded": "#38fc61",
+        "diffAddedBackground": "#001402",
+        "diffRemoved": "#f22942",
+        "diffRemovedBackground": "#240103",
+        "diffModified": "#fdd8a4",
+        "diffModifiedBackground": "#161e27",
+        "lineNumber": "#646464",
+        "lineNumberActive": "#ededed"
+      }
+    },
+    "markdown": {
+      "heading1": "#BF7AF0",
+      "heading2": "#BF7AF0",
+      "heading3": "#ededed",
+      "heading4": "#ededed",
+      "link": "#52A8FF",
+      "linkHover": "#0AC7AC",
+      "inlineCode": "#63C46D",
+      "inlineCodeBackground": "#0f0f0f",
+      "blockquote": "#878787",
+      "blockquoteBorder": "#3f3f3f",
+      "listMarker": "#EDEDED99"
+    },
+    "chat": {
+      "userMessage": "#ededed",
+      "userMessageBackground": "#063056",
+      "assistantMessage": "#ededed",
+      "assistantMessageBackground": "#000000",
+      "timestamp": "#878787",
+      "divider": "#3f3f3f"
+    },
+    "tools": {
+      "background": "#0f0f0f80",
+      "border": "#3f3f3fb3",
+      "headerHover": "#17171780",
+      "icon": "#878787",
+      "title": "#ededed",
+      "description": "#878787",
+      "edit": {
+        "added": "#38fc61",
+        "addedBackground": "#001402",
+        "removed": "#f22942",
+        "removedBackground": "#240103",
+        "lineNumber": "#646464"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/vercel-light.json
+++ b/packages/ui/src/lib/theme/themes/vercel-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "vercel-light",
+    "name": "Vercel",
+    "description": "Port of OpenCode Vercel theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "vercel"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#0570f2",
+      "hover": "#0767dd",
+      "active": "#0767dd",
+      "foreground": "#000000",
+      "muted": "#0570f280",
+      "emphasis": "#0767dd"
+    },
+    "surface": {
+      "background": "#ffffff",
+      "foreground": "#161616",
+      "muted": "#f1f1f1",
+      "mutedForeground": "#666666",
+      "elevated": "#f8f8f8",
+      "elevatedForeground": "#161616",
+      "overlay": "#0000004d",
+      "subtle": "#e8e8e8"
+    },
+    "interactive": {
+      "border": "#c6c6c6",
+      "borderHover": "#b8b8b8",
+      "borderFocus": "#9ec3fb",
+      "selection": "#deebfe",
+      "selectionForeground": "#000000",
+      "focus": "#9ec3fb",
+      "focusRing": "#9ec3fb47",
+      "cursor": "#161616",
+      "hover": "#e8e8e8",
+      "active": "#e8e8e8"
+    },
+    "status": {
+      "error": "#d12139",
+      "errorForeground": "#000000",
+      "errorBackground": "#ffe2e1",
+      "errorBorder": "#fea6a4",
+      "warning": "#fcaa8d",
+      "warningForeground": "#000000",
+      "warningBackground": "#ffe4ce",
+      "warningBorder": "#faaf68",
+      "success": "#7ddb7e",
+      "successForeground": "#000000",
+      "successBackground": "#c2fcc1",
+      "successBorder": "#7ddb7e",
+      "info": "#9ec3fb",
+      "infoForeground": "#000000",
+      "infoBackground": "#deebfe",
+      "infoBorder": "#9ec3fb"
+    },
+    "pr": {
+      "open": "#7ddb7e",
+      "draft": "#666666",
+      "blocked": "#fcaa8d",
+      "merged": "#E93D82",
+      "closed": "#d12139"
+    },
+    "syntax": {
+      "base": {
+        "background": "#f1f1f1",
+        "foreground": "#161616",
+        "comment": "#888888",
+        "keyword": "#E93D82",
+        "string": "#46A758",
+        "number": "#8E4EC6",
+        "function": "#12A594",
+        "variable": "#0070F3",
+        "type": "#12A594",
+        "operator": "#E93D82"
+      },
+      "tokens": {
+        "commentDoc": "#888888",
+        "stringEscape": "#FFB224",
+        "keywordImport": "#E93D82",
+        "storageModifier": "#E93D82",
+        "functionCall": "#12A594",
+        "method": "#12A594",
+        "variableProperty": "#12A594",
+        "variableOther": "#0070F3",
+        "variableGlobal": "#FFB224",
+        "variableLocal": "#666666",
+        "parameter": "#0070F3",
+        "constant": "#FFB224",
+        "class": "#12A594",
+        "className": "#12A594",
+        "interface": "#12A594",
+        "struct": "#12A594",
+        "enum": "#12A594",
+        "typeParameter": "#12A594",
+        "namespace": "#E93D82",
+        "module": "#E93D82",
+        "tag": "#E93D82",
+        "jsxTag": "#E93D82",
+        "tagAttribute": "#12A594",
+        "tagAttributeValue": "#46A758",
+        "boolean": "#8E4EC6",
+        "decorator": "#E93D82",
+        "label": "#E93D82",
+        "punctuation": "#171717",
+        "macro": "#E93D82",
+        "preprocessor": "#E93D82",
+        "regex": "#161616",
+        "url": "#0070F3",
+        "key": "#12A594",
+        "exception": "#d12139"
+      },
+      "highlights": {
+        "diffAdded": "#0a752b",
+        "diffAddedBackground": "#f8fff9",
+        "diffRemoved": "#e22539",
+        "diffRemovedBackground": "#fffcfc",
+        "diffModified": "#FF8C00",
+        "diffModifiedBackground": "#e7edf7",
+        "lineNumber": "#898989",
+        "lineNumberActive": "#161616"
+      }
+    },
+    "markdown": {
+      "heading1": "#8E4EC6",
+      "heading2": "#8E4EC6",
+      "heading3": "#161616",
+      "heading4": "#161616",
+      "link": "#0070F3",
+      "linkHover": "#12A594",
+      "inlineCode": "#46A758",
+      "inlineCodeBackground": "#f1f1f1",
+      "blockquote": "#666666",
+      "blockquoteBorder": "#c6c6c6",
+      "listMarker": "#17171799"
+    },
+    "chat": {
+      "userMessage": "#161616",
+      "userMessageBackground": "#deebfe",
+      "assistantMessage": "#161616",
+      "assistantMessageBackground": "#ffffff",
+      "timestamp": "#666666",
+      "divider": "#c6c6c6"
+    },
+    "tools": {
+      "background": "#f1f1f180",
+      "border": "#c6c6c6b3",
+      "headerHover": "#e8e8e880",
+      "icon": "#666666",
+      "title": "#161616",
+      "description": "#666666",
+      "edit": {
+        "added": "#0a752b",
+        "addedBackground": "#f8fff9",
+        "removed": "#e22539",
+        "removedBackground": "#fffcfc",
+        "lineNumber": "#898989"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/zenburn-dark.json
+++ b/packages/ui/src/lib/theme/themes/zenburn-dark.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "zenburn-dark",
+    "name": "Zenburn",
+    "description": "Port of OpenCode Zenburn theme (dark variant)",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "zenburn"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#24a9af",
+      "hover": "#31bbc1",
+      "active": "#31bbc1",
+      "foreground": "#000000",
+      "muted": "#24a9af80",
+      "emphasis": "#31bbc1"
+    },
+    "surface": {
+      "background": "#262626",
+      "foreground": "#dcdccb",
+      "muted": "#323231",
+      "mutedForeground": "#9f9f9f",
+      "elevated": "#2d2d2c",
+      "elevatedForeground": "#dcdccb",
+      "overlay": "#00000080",
+      "subtle": "#383836"
+    },
+    "interactive": {
+      "border": "#565652",
+      "borderHover": "#5d5d58",
+      "borderFocus": "#084b4e",
+      "selection": "#033638",
+      "selectionForeground": "#ffffff",
+      "focus": "#084b4e",
+      "focusRing": "#084b4e59",
+      "cursor": "#dcdccb",
+      "hover": "#383836",
+      "active": "#383836"
+    },
+    "status": {
+      "error": "#b56264",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#52181d",
+      "errorBorder": "#6b292d",
+      "warning": "#c89343",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#3a2d04",
+      "warningBorder": "#504009",
+      "success": "#4e8050",
+      "successForeground": "#ffffff",
+      "successBackground": "#133816",
+      "successBorder": "#234d26",
+      "info": "#c37c49",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#492303",
+      "infoBorder": "#643309"
+    },
+    "pr": {
+      "open": "#4e8050",
+      "draft": "#9f9f9f",
+      "blocked": "#c89343",
+      "merged": "#f0dfaf",
+      "closed": "#b56264"
+    },
+    "syntax": {
+      "base": {
+        "background": "#323231",
+        "foreground": "#dcdccb",
+        "comment": "#7f9f7f",
+        "keyword": "#f0dfaf",
+        "string": "#cc9393",
+        "number": "#8cd0d3",
+        "function": "#93e0e3",
+        "variable": "#dcdccc",
+        "type": "#93e0e3",
+        "operator": "#f0dfaf"
+      },
+      "tokens": {
+        "commentDoc": "#7f9f7f",
+        "stringEscape": "#8fb28f",
+        "keywordImport": "#f0dfaf",
+        "storageModifier": "#f0dfaf",
+        "functionCall": "#93e0e3",
+        "method": "#93e0e3",
+        "variableProperty": "#93e0e3",
+        "variableOther": "#dcdccc",
+        "variableGlobal": "#8fb28f",
+        "variableLocal": "#9f9f9f",
+        "parameter": "#dcdccc",
+        "constant": "#8fb28f",
+        "class": "#93e0e3",
+        "className": "#93e0e3",
+        "interface": "#93e0e3",
+        "struct": "#93e0e3",
+        "enum": "#93e0e3",
+        "typeParameter": "#93e0e3",
+        "namespace": "#f0dfaf",
+        "module": "#f0dfaf",
+        "tag": "#f0dfaf",
+        "jsxTag": "#f0dfaf",
+        "tagAttribute": "#93e0e3",
+        "tagAttributeValue": "#cc9393",
+        "boolean": "#8cd0d3",
+        "decorator": "#f0dfaf",
+        "label": "#f0dfaf",
+        "punctuation": "#dcdccc",
+        "macro": "#f0dfaf",
+        "preprocessor": "#f0dfaf",
+        "regex": "#dcdccb",
+        "url": "#8cd0d3",
+        "key": "#93e0e3",
+        "exception": "#b56264"
+      },
+      "highlights": {
+        "diffAdded": "#aae6aa",
+        "diffAddedBackground": "#011402",
+        "diffRemoved": "#d67c7e",
+        "diffRemovedBackground": "#220205",
+        "diffModified": "#fdeab3",
+        "diffModifiedBackground": "#3d4444",
+        "lineNumber": "#7b7b7b",
+        "lineNumberActive": "#dcdccb"
+      }
+    },
+    "markdown": {
+      "heading1": "#f0dfaf",
+      "heading2": "#f0dfaf",
+      "heading3": "#dcdccb",
+      "heading4": "#dcdccb",
+      "link": "#8cd0d3",
+      "linkHover": "#93e0e3",
+      "inlineCode": "#7f9f7f",
+      "inlineCodeBackground": "#323231",
+      "blockquote": "#9f9f9f",
+      "blockquoteBorder": "#565652",
+      "listMarker": "#8cd0d399"
+    },
+    "chat": {
+      "userMessage": "#dcdccb",
+      "userMessageBackground": "#033638",
+      "assistantMessage": "#dcdccb",
+      "assistantMessageBackground": "#262626",
+      "timestamp": "#9f9f9f",
+      "divider": "#565652"
+    },
+    "tools": {
+      "background": "#32323180",
+      "border": "#565652b3",
+      "headerHover": "#38383680",
+      "icon": "#9f9f9f",
+      "title": "#dcdccb",
+      "description": "#9f9f9f",
+      "edit": {
+        "added": "#aae6aa",
+        "addedBackground": "#011402",
+        "removed": "#d67c7e",
+        "removedBackground": "#220205",
+        "lineNumber": "#7b7b7b"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/zenburn-light.json
+++ b/packages/ui/src/lib/theme/themes/zenburn-light.json
@@ -1,0 +1,187 @@
+{
+  "metadata": {
+    "id": "zenburn-light",
+    "name": "Zenburn",
+    "description": "Port of OpenCode Zenburn theme (light variant)",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "zenburn"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#588094",
+      "hover": "#4d7689",
+      "active": "#4d7689",
+      "foreground": "#000000",
+      "muted": "#58809480",
+      "emphasis": "#4d7689"
+    },
+    "surface": {
+      "background": "#fffff4",
+      "foreground": "#333333",
+      "muted": "#f4f4e9",
+      "mutedForeground": "#6f6f6f",
+      "elevated": "#f9f9ef",
+      "elevatedForeground": "#333333",
+      "overlay": "#0000004d",
+      "subtle": "#ecece2"
+    },
+    "interactive": {
+      "border": "#d0d0c8",
+      "borderHover": "#c5c5bd",
+      "borderFocus": "#a3c8da",
+      "selection": "#d7eefa",
+      "selectionForeground": "#000000",
+      "focus": "#a3c8da",
+      "focusRing": "#a3c8da47",
+      "cursor": "#333333",
+      "hover": "#ecece2",
+      "active": "#ecece2"
+    },
+    "status": {
+      "error": "#8b5051",
+      "errorForeground": "#000000",
+      "errorBackground": "#fee2e1",
+      "errorBorder": "#eab0b0",
+      "warning": "#d5bf8f",
+      "warningForeground": "#000000",
+      "warningBackground": "#ecedca",
+      "warningBorder": "#c5c58f",
+      "success": "#9bd29a",
+      "successForeground": "#000000",
+      "successBackground": "#d2f5d1",
+      "successBorder": "#9bd29a",
+      "info": "#d2bf9a",
+      "infoForeground": "#000000",
+      "infoBackground": "#f5e9d1",
+      "infoBorder": "#d2bf9a"
+    },
+    "pr": {
+      "open": "#9bd29a",
+      "draft": "#6f6f6f",
+      "blocked": "#d5bf8f",
+      "merged": "#8f8f5f",
+      "closed": "#8b5051"
+    },
+    "syntax": {
+      "base": {
+        "background": "#f4f4e9",
+        "foreground": "#333333",
+        "comment": "#5f7f5f",
+        "keyword": "#8f8f5f",
+        "string": "#8f5f5f",
+        "number": "#5f7f8f",
+        "function": "#5f8f8f",
+        "variable": "#3f3f3f",
+        "type": "#5f8f8f",
+        "operator": "#8f8f5f"
+      },
+      "tokens": {
+        "commentDoc": "#5f7f5f",
+        "stringEscape": "#5f8f5f",
+        "keywordImport": "#8f8f5f",
+        "storageModifier": "#8f8f5f",
+        "functionCall": "#5f8f8f",
+        "method": "#5f8f8f",
+        "variableProperty": "#5f8f8f",
+        "variableOther": "#3f3f3f",
+        "variableGlobal": "#5f8f5f",
+        "variableLocal": "#6f6f6f",
+        "parameter": "#3f3f3f",
+        "constant": "#5f8f5f",
+        "class": "#5f8f8f",
+        "className": "#5f8f8f",
+        "interface": "#5f8f8f",
+        "struct": "#5f8f8f",
+        "enum": "#5f8f8f",
+        "typeParameter": "#5f8f8f",
+        "namespace": "#8f8f5f",
+        "module": "#8f8f5f",
+        "tag": "#8f8f5f",
+        "jsxTag": "#8f8f5f",
+        "tagAttribute": "#5f8f8f",
+        "tagAttributeValue": "#8f5f5f",
+        "boolean": "#5f7f8f",
+        "decorator": "#8f8f5f",
+        "label": "#8f8f5f",
+        "punctuation": "#3f3f3f",
+        "macro": "#8f8f5f",
+        "preprocessor": "#8f8f5f",
+        "regex": "#333333",
+        "url": "#5f7f8f",
+        "key": "#5f8f8f",
+        "exception": "#8b5051"
+      },
+      "highlights": {
+        "diffAdded": "#4c694c",
+        "diffAddedBackground": "#fafefa",
+        "diffRemoved": "#996e6e",
+        "diffRemovedBackground": "#fffcfc",
+        "diffModified": "#5f5d10",
+        "diffModifiedBackground": "#eceee6",
+        "lineNumber": "#939393",
+        "lineNumberActive": "#333333"
+      }
+    },
+    "markdown": {
+      "heading1": "#8f8f5f",
+      "heading2": "#8f8f5f",
+      "heading3": "#333333",
+      "heading4": "#333333",
+      "link": "#5f7f8f",
+      "linkHover": "#5f8f8f",
+      "inlineCode": "#5f8f5f",
+      "inlineCodeBackground": "#f4f4e9",
+      "blockquote": "#6f6f6f",
+      "blockquoteBorder": "#d0d0c8",
+      "listMarker": "#5f7f8f99"
+    },
+    "chat": {
+      "userMessage": "#333333",
+      "userMessageBackground": "#d7eefa",
+      "assistantMessage": "#333333",
+      "assistantMessageBackground": "#fffff4",
+      "timestamp": "#6f6f6f",
+      "divider": "#d0d0c8"
+    },
+    "tools": {
+      "background": "#f4f4e980",
+      "border": "#d0d0c8b3",
+      "headerHover": "#ecece280",
+      "icon": "#6f6f6f",
+      "title": "#333333",
+      "description": "#6f6f6f",
+      "edit": {
+        "added": "#4c694c",
+        "addedBackground": "#fafefa",
+        "removed": "#996e6e",
+        "removedBackground": "#fffcfc",
+        "lineNumber": "#939393"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "\"IBM Plex Mono\", monospace",
+      "mono": "\"IBM Plex Mono\", monospace",
+      "heading": "\"IBM Plex Mono\", monospace"
+    },
+    "radius": {
+      "none": "0",
+      "sm": "0.125rem",
+      "md": "0.375rem",
+      "lg": "0.5rem",
+      "xl": "0.75rem",
+      "full": "9999px"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- port 10 additional OpenCode themes into OpenChamber as built-in presets: OC-2, AMOLED, Cursor, GitHub, Lucent Orng, Orng, Rose Pine, Shades of Purple, Vercel, and Zenburn
- add light/dark theme JSON variants for each preset and register all 20 variants in `packages/ui/src/lib/theme/themes/presets.ts`
- map the presets from OpenCode's resolved theme tokens so brand, syntax, markdown, and surface colors stay aligned with the source themes

## Validation
- `bun run lint`
- compared the new theme ports against resolved OpenCode theme tokens with a local Bun verification script
- `bun run type-check` *(fails on the current branch due to an existing CodeMirror dependency mismatch in `packages/ui/src/lib/codemirror/languageByExtension.ts`)*
- `bun run build` *(fails on the current branch due to the same existing CodeMirror dependency mismatch)*

## Review Guide
- `packages/ui/src/lib/theme/themes/presets.ts`
- `packages/ui/src/lib/theme/themes/*{oc-2,amoled,cursor,github,lucent-orng,orng,rosepine,shadesofpurple,vercel,zenburn}-*.json`
- spot-check OC-2 and AMOLED in the app theme picker, especially primary/brand color parity against OpenCode