### PR TITLE
fix(web): restore terminal PTY spawn on macOS arm64

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "ghostty-web": "0.3.0",
         "http-proxy-middleware": "^3.0.5",
         "next-themes": "^0.4.6",
-        "node-pty": "^1.1.0",
+        "node-pty": "1.2.0-beta.12",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-markdown": "^10.1.0",
@@ -269,7 +269,7 @@
         "jose": "^6.1.3",
         "jsonc-parser": "^3.3.1",
         "next-themes": "^0.4.6",
-        "node-pty": "^1.1.0",
+        "node-pty": "1.2.0-beta.12",
         "openai": "^4.79.0",
         "qrcode-terminal": "^0.12.0",
         "react": "^19.1.1",
@@ -2309,7 +2309,7 @@
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+    "node-pty": ["node-pty@1.2.0-beta.12", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "ghostty-web": "0.3.0",
     "http-proxy-middleware": "^3.0.5",
     "next-themes": "^0.4.6",
-    "node-pty": "^1.1.0",
+    "node-pty": "1.2.0-beta.12",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -52,7 +52,7 @@
     "jose": "^6.1.3",
     "jsonc-parser": "^3.3.1",
     "next-themes": "^0.4.6",
-    "node-pty": "^1.1.0",
+    "node-pty": "1.2.0-beta.12",
     "openai": "^4.79.0",
     "qrcode-terminal": "^0.12.0",
     "react": "^19.1.1",


### PR DESCRIPTION
Fixes #656

## Summary
Fix macOS arm64 terminal PTY spawn failure by upgrading `node-pty`.

This updates `node-pty` from `^1.1.0` to `1.2.0-beta.12` in:
- root `package.json`
- `packages/web/package.json`
- `bun.lock`

## Why
On macOS arm64, terminal creation failed with:

```text
Failed to spawn terminal PTY with available shells (/bin/zsh, /bin/bash, /bin/sh): posix_spawnp failed.
```

The UI was fine, but the Terminal panel could not create sessions.

## Validation
I reproduced the issue locally and verified the fix in two ways:

1. **Direct PTY validation**
   - Before: `node-pty@1.1.0` failed to spawn `/bin/zsh`
   - After: `node-pty@1.2.0-beta.12` successfully spawned PTY sessions

2. **OpenChamber API validation**
   - `POST /auth/session` succeeded
   - `POST /api/terminal/create` returned a valid `sessionId`
   - Server logs showed a created terminal session using `/bin/zsh`

## Notes
- This uses a beta `node-pty` release because it is the version that fixed the issue in my local reproduction.
- If maintainers prefer, I’m happy to test an alternative stable upstream fix when available.
