### PR TITLE
perf: batch mobile keyboard viewport handlers with rAF and debounce

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -281,17 +281,28 @@ export const ChatContainer: React.FC = () => {
 
         updateChatScrollHeight();
 
+        let rafId = 0;
+        const scheduleUpdate = () => {
+            if (rafId) return;
+            rafId = requestAnimationFrame(() => {
+                rafId = 0;
+                updateChatScrollHeight();
+            });
+        };
+
         if (typeof ResizeObserver === 'undefined') {
-            window.addEventListener('resize', updateChatScrollHeight);
+            window.addEventListener('resize', scheduleUpdate);
             return () => {
-                window.removeEventListener('resize', updateChatScrollHeight);
+                if (rafId) cancelAnimationFrame(rafId);
+                window.removeEventListener('resize', scheduleUpdate);
             };
         }
 
-        const resizeObserver = new ResizeObserver(updateChatScrollHeight);
+        const resizeObserver = new ResizeObserver(scheduleUpdate);
         resizeObserver.observe(container);
 
         return () => {
+            if (rafId) cancelAnimationFrame(rafId);
             resizeObserver.disconnect();
         };
     }, [currentSessionId, isDesktopExpandedInput, scrollRef]);

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -779,18 +779,26 @@ export const Header: React.FC<HeaderProps> = ({
       return () => { };
     }
 
-    const observer = new ResizeObserver(() => {
-      updateHeaderHeight();
-    });
+    let rafId = 0;
+    const scheduleUpdate = () => {
+      if (rafId) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        updateHeaderHeight();
+      });
+    };
+
+    const observer = new ResizeObserver(scheduleUpdate);
 
     observer.observe(node);
-    window.addEventListener('resize', updateHeaderHeight);
-    window.addEventListener('orientationchange', updateHeaderHeight);
+    window.addEventListener('resize', scheduleUpdate);
+    window.addEventListener('orientationchange', scheduleUpdate);
 
     return () => {
+      if (rafId) cancelAnimationFrame(rafId);
       observer.disconnect();
-      window.removeEventListener('resize', updateHeaderHeight);
-      window.removeEventListener('orientationchange', updateHeaderHeight);
+      window.removeEventListener('resize', scheduleUpdate);
+      window.removeEventListener('orientationchange', scheduleUpdate);
     };
   }, [updateHeaderHeight]);
 

--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -362,6 +362,10 @@ export const MainLayout: React.FC = () => {
             setKeyboardOpen(false);
         };
 
+        // Batch visualViewport updates to once per animation frame to avoid
+        // layout thrashing during keyboard open/close animations.
+        let rafId = 0;
+
         const updateVisualViewport = () => {
             const viewport = window.visualViewport;
 
@@ -464,13 +468,21 @@ export const MainLayout: React.FC = () => {
             }
         };
 
+        const scheduleVisualViewportUpdate = () => {
+            if (rafId) return;
+            rafId = requestAnimationFrame(() => {
+                rafId = 0;
+                updateVisualViewport();
+            });
+        };
+
         updateVisualViewport();
 
         const viewport = window.visualViewport;
-        viewport?.addEventListener('resize', updateVisualViewport);
-        viewport?.addEventListener('scroll', updateVisualViewport);
-        window.addEventListener('resize', updateVisualViewport);
-        window.addEventListener('orientationchange', updateVisualViewport);
+        viewport?.addEventListener('resize', scheduleVisualViewportUpdate);
+        viewport?.addEventListener('scroll', scheduleVisualViewportUpdate);
+        window.addEventListener('resize', scheduleVisualViewportUpdate);
+        window.addEventListener('orientationchange', scheduleVisualViewportUpdate);
         const isTextInputTarget = (element: HTMLElement | null) => {
             if (!element) {
                 return false;
@@ -488,7 +500,7 @@ export const MainLayout: React.FC = () => {
             if (isTextInputTarget(target)) {
                 ignoreOpenUntilZero = false;
             }
-            updateVisualViewport();
+            scheduleVisualViewportUpdate();
         };
         document.addEventListener('focusin', handleFocusIn, true);
 
@@ -533,10 +545,11 @@ export const MainLayout: React.FC = () => {
         document.addEventListener('focusout', handleFocusOut, true);
 
         return () => {
-            viewport?.removeEventListener('resize', updateVisualViewport);
-            viewport?.removeEventListener('scroll', updateVisualViewport);
-            window.removeEventListener('resize', updateVisualViewport);
-            window.removeEventListener('orientationchange', updateVisualViewport);
+            if (rafId) cancelAnimationFrame(rafId);
+            viewport?.removeEventListener('resize', scheduleVisualViewportUpdate);
+            viewport?.removeEventListener('scroll', scheduleVisualViewportUpdate);
+            window.removeEventListener('resize', scheduleVisualViewportUpdate);
+            window.removeEventListener('orientationchange', scheduleVisualViewportUpdate);
             document.removeEventListener('focusin', handleFocusIn, true);
             document.removeEventListener('focusout', handleFocusOut, true);
             clearKeyboardAvoidTarget();

--- a/packages/ui/src/lib/device.ts
+++ b/packages/ui/src/lib/device.ts
@@ -161,12 +161,19 @@ export function useDeviceInfo(): DeviceInfo {
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
 
+    let debounceTimer: ReturnType<typeof setTimeout>;
     const handleResize = () => {
-      setDeviceInfo(getDeviceInfo());
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        setDeviceInfo(getDeviceInfo());
+      }, 150);
     };
 
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    return () => {
+      clearTimeout(debounceTimer);
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- Batch `updateVisualViewport()` in MainLayout with `requestAnimationFrame` — coalesces 4 event sources (visualViewport resize, visualViewport scroll, window resize, orientationchange) into at most 1 execution per frame
- Batch Header ResizeObserver + resize/orientationchange callbacks with rAF
- Batch ChatContainer ResizeObserver + resize fallback callback with rAF
- Add 150ms debounce to `useDeviceInfo()` resize listener — device type does not change during keyboard transitions
## Why
Opening or closing the virtual keyboard on mobile triggers severe UI lag. Multiple unthrottled event listeners fire synchronously 10-20+ times per animation frame during the keyboard transition (~300ms), each performing synchronous DOM reads (`getBoundingClientRect`, `clientHeight`) followed by CSS variable writes — classic layout thrashing.
Desktop is unaffected: visualViewport events rarely fire without a virtual keyboard, and rAF batching is a no-op when events are infrequent. The `useDeviceInfo` debounce adds an imperceptible 150ms delay on manual window resize.
No visual or behavioral changes — all modifications are internal event scheduling only.
## Testing
- `bun run type-check` ✅
- `bun run lint` ✅
- `bun run build` ✅
- Manual: tested on Android (Galaxy S25+) mobile browser and PWA — keyboard open/close is smooth with no perceptible frame drops
## Related
Fixes #659