### PR TITLE
fix(macos): add audio-input entitlement for microphone access

### DIFF
--- a/packages/desktop/src-tauri/entitlements.plist
+++ b/packages/desktop/src-tauri/entitlements.plist
@@ -17,5 +17,7 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Adds the missing `com.apple.security.device.audio-input` entitlement to the macOS app entitlements file.

The app already declares `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` in Info.plist, but without the corresponding entitlement, macOS blocks the permission request entirely — no dialog appears and voice input cannot work.

Fixes #669