### PR TITLE
fix(web): normalize Windows drive letter case for session path matching

### DIFF
--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -199,7 +199,11 @@ class OpencodeService {
       return null;
     }
 
-    const normalized = trimmed.replace(/\\/g, '/');
+    // Normalize backslashes and uppercase the Windows drive letter so that
+    // d:\MyProject and D:\MyProject resolve to the same canonical form.
+    const normalized = trimmed
+      .replace(/\\/g, '/')
+      .replace(/^([a-z]):/, (_, letter: string) => letter.toUpperCase() + ':');
     const withoutTrailingSlash = normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized;
 
     return withoutTrailingSlash || null;

--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -467,8 +467,13 @@ export function createOpenCodeManager(_context: vscode.ExtensionContext): OpenCo
   let status: ConnectionStatus = 'disconnected';
   let lastError: string | undefined;
   const listeners = new Set<(status: ConnectionStatus, error?: string) => void>();
+  /** On Windows, VS Code's uri.fsPath returns a lowercase drive letter (e.g. d:\...)
+   *  while process.cwd() (used by OpenCode server) returns uppercase (D:\...).
+   *  Normalize to uppercase so session directory queries match. */
+  const normalizeWindowsDriveLetter = (p: string): string =>
+    p.replace(/^([a-z]):/, (_, letter: string) => letter.toUpperCase() + ':');
   const workspaceDirectory = (): string =>
-    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
+    normalizeWindowsDriveLetter(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir());
   let workingDirectory: string = workspaceDirectory();
   let startCount = 0;
   let restartCount = 0;
@@ -577,7 +582,7 @@ export function createOpenCodeManager(_context: vscode.ExtensionContext): OpenCo
     lastStartAttempts = startCount;
 
     if (typeof workdir === 'string' && workdir.trim().length > 0) {
-      workingDirectory = workdir.trim();
+      workingDirectory = normalizeWindowsDriveLetter(workdir.trim());
     } else {
       workingDirectory = workspaceDirectory();
     }


### PR DESCRIPTION
## Summary

- Fixes Windows drive letter case mismatch (`d:\` vs `D:\`) that caused sessions to not appear in the extension when VS Code's `uri.fsPath` returns a lowercase drive letter while the OpenCode server stores paths with uppercase via `process.cwd()`
- Normalizes drive letters to uppercase in both the VS Code extension (`opencode.ts`) and the shared UI client path normalization (`client.ts`)

## Details

On Windows, `vscode.Uri.fsPath` always returns a lowercase drive letter (e.g. `d:\MyProject`), while `process.cwd()` used by the OpenCode server returns uppercase (`D:\MyProject`). The session API performs case-sensitive string comparison on directory paths, so the extension's query returns no matching sessions.

**Changes:**
- `packages/vscode/src/opencode.ts`: Added `normalizeWindowsDriveLetter()` helper applied to all `workingDirectory` assignments (initial, start, and restart paths)
- `packages/ui/src/lib/opencode/client.ts`: Extended `normalizeCandidatePath()` to uppercase the drive letter after backslash normalization, ensuring all client-side directory comparisons and event stream filtering use a canonical form

Fixes #670

## Test plan

- [ ] On Windows, open a project on a non-C drive (e.g. `D:\MyProject`)
- [ ] Create sessions via OpenCode CLI
- [ ] Open VS Code with OpenChamber in the same directory
- [ ] Verify sessions appear in the sidebar (previously showed empty)
- [ ] Verify no regression on macOS/Linux (regex only matches `^[a-z]:` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)