### PR TITLE
fix: preserve manual agent selection during active runs

### DIFF
--- a/packages/ui/src/hooks/useEventStream.ts
+++ b/packages/ui/src/hooks/useEventStream.ts
@@ -1462,6 +1462,17 @@ export const useEventStream = (options?: { enabled?: boolean }) => {
               return true;
             }
 
+            if (currentSessionIdRef.current === sessionId) {
+              const explicitSelection = useContextStore.getState().getSessionAgentSelection(sessionId);
+              if (explicitSelection && explicitSelection !== agentCandidate) {
+                const status = useSessionStore.getState().sessionStatus?.get(sessionId);
+                const isBusy = status?.type === 'busy' || status?.type === 'retry';
+                if (isBusy) {
+                  return false;
+                }
+              }
+            }
+
             const last = lastUserAgentSelectionRef.current.get(sessionId);
             if (!last) return true;
 


### PR DESCRIPTION
## Summary
- prevent stale `message.updated` user-agent metadata from overwriting a newer manual agent selection for the active session while it is still busy
- keep synthetic plan/build mode-switch behavior unchanged so server-injected mode transitions still apply
- fixes #678

## Validation
- bun run type-check
- bun run lint
- bun run build