### PR TITLE
fix(ui): wrap 'Add to chat' selections in markdown fenced blocks

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -589,11 +589,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
             if (pending?.text) {
                 if (pending.mode === 'append') {
                     setMessage((prev) => {
-                        const next = pending.text.trim();
-                        if (!next) return prev;
-                        const base = prev.trimEnd();
-                        if (!base.trim()) return next;
-                        return `${base} ${next}`;
+                        if (!pending.text) return prev;
+                        if (!prev.trim()) return pending.text;
+                        return `${prev}\n\n${pending.text}`;
                     });
                 } else {
                     setMessage(pending.text);

--- a/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
+++ b/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
@@ -249,7 +249,8 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
   const handleAddToChat = React.useCallback(() => {
     if (!selectedText) return;
 
-    setPendingInputText(selectedText, 'append');
+    const fenced = `\`\`\`md\n${selectedText}\n\`\`\``;
+    setPendingInputText(fenced, 'append');
     
     hideMenu();
     

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -192,7 +192,8 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
         return;
       }
       routeToChat();
-      setPendingInputText(todoText, 'append');
+      const fenced = `\`\`\`md\n${todoText}\n\`\`\``;
+      setPendingInputText(fenced, 'append');
       toast.success('Todo sent to current session');
       onActionComplete?.();
     },


### PR DESCRIPTION
## Problem

When using "Add to chat" (text selection menu or project notes/todos), the selected text is appended to the composer as raw, unformatted text. This makes it hard to distinguish quoted context from the user's own prompt, especially when appending multiple selections.

Additionally, the previous append logic (`trimEnd()` + `trim()` + single-space join) collapsed multi-line formatting, losing the structure of the original text.

## Solution

- **Fenced block wrapping**: Selected text and todo items are now wrapped in `` ```md `` fenced code blocks before being appended to the composer. This visually separates quoted context from the user's prompt.
- **Preserved formatting on append**: The `ChatInput` append mode now uses `\n\n` as the separator (matching existing patterns in `inlineComments.ts` and the VS Code runtime), preserving the original text structure instead of collapsing it.

## Files changed

| File | Change |
|------|--------|
| `packages/ui/src/components/chat/ChatInput.tsx` | Append mode uses `\n\n` separator instead of trim+space-join |
| `packages/ui/src/components/chat/message/TextSelectionMenu.tsx` | Wraps selected text in `` ```md `` fenced block before appending |
| `packages/ui/src/components/session/ProjectNotesTodoPanel.tsx` | Wraps todo text in `` ```md `` fenced block before appending |

## Demo

https://github.com/user-attachments/assets/ace02aa7-c0a1-4719-b21f-e38a2b655e74

closes #641 