### PR TITLE
fix(updates): use host platform/arch for server update checks

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -7573,28 +7573,13 @@ async function main(options = {}) {
         if (value.includes('mobi') || value.includes('android') || value.includes('iphone')) return 'mobile';
         return 'desktop';
       };
-      const inferArch = (ua) => {
-        const value = (ua || '').toLowerCase();
-        if (!value) return 'unknown';
-        if (value.includes('aarch64') || value.includes('arm64') || value.includes(' arm;') || value.includes('armv')) return 'arm64';
-        if (value.includes('x86_64') || value.includes('x64') || value.includes('amd64') || value.includes('win64') || value.includes('x86-64')) return 'x64';
-        return 'unknown';
-      };
-      const inferPlatform = (ua) => {
-        const value = (ua || '').toLowerCase();
-        if (!value) return undefined;
-        if (value.includes('mac os') || value.includes('macintosh') || value.includes('darwin')) return 'macos';
-        if (value.includes('windows') || value.includes('win32') || value.includes('win64')) return 'windows';
-        if (value.includes('linux') || value.includes('x11')) return 'linux';
-        return 'web';
-      };
       const userAgent = typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : '';
 
       const updateInfo = await checkForUpdates({
         appType: parseString(req.query.appType),
         deviceClass: parseString(req.query.deviceClass) || inferDeviceClass(userAgent),
-        platform: parseString(req.query.platform) || inferPlatform(userAgent),
-        arch: parseString(req.query.arch) || inferArch(userAgent),
+        platform: parseString(req.query.platform),
+        arch: parseString(req.query.arch),
         instanceMode: parseString(req.query.instanceMode),
         currentVersion: parseString(req.query.currentVersion),
         reportUsage: parseReportUsage(parseString(req.query.reportUsage)),

--- a/packages/web/server/lib/package-manager.js
+++ b/packages/web/server/lib/package-manager.js
@@ -81,11 +81,15 @@ function normalizeArch(value) {
 async function checkForUpdatesFromApi(currentVersion, options = {}) {
   try {
     const appType = normalizeAppType(options.appType);
+    const hostPlatform = mapPlatform(process.platform);
+    const hostArch = mapArch(process.arch);
+    const platform = appType === 'vscode' ? normalizePlatform(options.platform) : hostPlatform;
+    const arch = appType === 'vscode' ? normalizeArch(options.arch) : hostArch;
     const payload = {
       appType,
       deviceClass: normalizeDeviceClass(options.deviceClass),
-      platform: normalizePlatform(options.platform),
-      arch: normalizeArch(options.arch),
+      platform,
+      arch,
       channel: 'stable',
       currentVersion,
       installId: getOrCreateInstallId(appType),


### PR DESCRIPTION
## Summary
This PR makes update checks deterministic by using the server host runtime (`process.platform` / `process.arch`) instead of relying on inferred client values from User-Agent.

## What changed
- In `packages/web/server/index.js`:
  - Removed User-Agent-based `platform` and `arch` inference.
  - Stopped passing inferred `platform`/`arch` to `checkForUpdates` unless explicitly provided in query params.
- In `packages/web/server/lib/package-manager.js`:
  - `checkForUpdatesFromApi` now resolves host `platform` and `arch` from Node runtime.
  - For `vscode` app type, it still respects normalized client-provided `platform`/`arch`.
  - For non-`vscode` app types, it always sends host `platform`/`arch`.

## Why
UA-based platform/arch detection is noisy and can be inaccurate. Using host runtime values improves correctness and consistency of update targeting, while preserving VS Code-specific behavior where client runtime details are relevant.