### PR TITLE
fix(desktop): lower macOS minimum version to 13.0 (Ventura)

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
     ],
     "macOS": {
       "exceptionDomain": "localhost",
-      "minimumSystemVersion": "14.0",
+      "minimumSystemVersion": "13.0",
       "signingIdentity": null,
       "entitlements": "./entitlements.plist",
       "infoPlist": "Info.plist",


### PR DESCRIPTION
The desktop app builds and runs correctly on macOS Ventura (13.x). Lowering minimumSystemVersion from 14.0 to 13.0 allows users on Ventura to build and use the desktop app.