### PR TITLE
fix(web): implement Anthropic OAuth endpoints for provider auth flow

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -10,6 +10,7 @@ import os from 'os';
 import crypto from 'crypto';
 import { createUiAuth } from './lib/opencode/ui-auth.js';
 import { createTunnelAuth } from './lib/opencode/tunnel-auth.js';
+import { startAnthropicOAuth, completeAnthropicOAuth, isAnthropicProvider } from './lib/opencode/anthropic-oauth.js';
 import {
   printTunnelWarning,
 } from './lib/cloudflare-tunnel.js';
@@ -7215,6 +7216,7 @@ async function main(options = {}) {
       req.path.startsWith('/api/push') ||
       req.path.startsWith('/api/voice') ||
       req.path.startsWith('/api/tts') ||
+      req.path.startsWith('/api/provider') ||
       req.path.startsWith('/api/openchamber/tunnel')
     ) {
 
@@ -11713,6 +11715,71 @@ async function main(options = {}) {
     } catch (error) {
       console.error('Failed to get provider sources:', error);
       res.status(500).json({ error: error.message || 'Failed to get provider sources' });
+    }
+  });
+
+  app.post('/api/provider/:providerId/oauth/authorize', async (req, res) => {
+    try {
+      const { providerId } = req.params;
+      if (!providerId) {
+        return res.status(400).json({ error: 'Provider ID is required' });
+      }
+
+      const { method } = req.body || {};
+      if (method !== 0 && method !== '0') {
+        return res.status(400).json({ error: 'Unsupported OAuth method' });
+      }
+
+      if (!isAnthropicProvider(providerId)) {
+        return res.status(400).json({ error: 'Provider does not support OAuth' });
+      }
+
+      const oauthData = await startAnthropicOAuth();
+      
+      res.json({
+        data: {
+          url: oauthData.url,
+          user_code: null,
+          instructions: 'You will be redirected to Anthropic to authorize. After authorizing, copy the code from the URL and paste it in the callback.',
+          verification_uri: 'https://console.anthropic.com/oauth/code/callback',
+          verifier: oauthData.verifier
+        }
+      });
+    } catch (error) {
+      console.error('Failed to start OAuth flow:', error);
+      res.status(500).json({ error: error.message || 'Failed to start OAuth flow' });
+    }
+  });
+
+  app.post('/api/provider/:providerId/oauth/callback', async (req, res) => {
+    try {
+      const { providerId } = req.params;
+      if (!providerId) {
+        return res.status(400).json({ error: 'Provider ID is required' });
+      }
+
+      const { method, code, verifier } = req.body || {};
+      if (method !== 0 && method !== '0') {
+        return res.status(400).json({ error: 'Unsupported OAuth method' });
+      }
+
+      if (!isAnthropicProvider(providerId)) {
+        return res.status(400).json({ error: 'Provider does not support OAuth' });
+      }
+
+      if (!code) {
+        return res.status(400).json({ error: 'Authorization code is required' });
+      }
+
+      const result = await completeAnthropicOAuth(code, verifier || '');
+      
+      res.json({
+        success: true,
+        providerId: result.providerId
+      });
+    } catch (error) {
+      console.error('Failed to complete OAuth flow:', error);
+      res.status(500).json({ error: error.message || 'Failed to complete OAuth flow' });
     }
   });
 

--- a/packages/web/server/lib/opencode/anthropic-oauth.js
+++ b/packages/web/server/lib/opencode/anthropic-oauth.js
@@ -1,0 +1,93 @@
+/**
+ * Anthropic OAuth Handler
+ * 
+ * Implements OAuth 2.0 with PKCE for Anthropic/Anthropic Claude.
+ */
+
+import { readAuthFile, writeAuthFile } from './auth.js';
+
+const ANTHROPIC_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const AUTH_URL_CONSOLE = 'https://console.anthropic.com/oauth/authorize';
+const TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+
+function generateCodeVerifier() {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+async function generateCodeChallenge(verifier) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+export async function startAnthropicOAuth() {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const state = generateCodeVerifier();
+
+  const url = new URL(AUTH_URL_CONSOLE);
+  url.searchParams.set('code', 'true');
+  url.searchParams.set('client_id', ANTHROPIC_CLIENT_ID);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('redirect_uri', 'https://console.anthropic.com/oauth/code/callback');
+  url.searchParams.set('scope', 'org:create_api_key user:profile user:inference');
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+
+  return {
+    url: url.toString(),
+    verifier: codeVerifier,
+    state: state
+  };
+}
+
+export async function completeAnthropicOAuth(code, verifier) {
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      code: code,
+      grant_type: 'authorization_code',
+      client_id: ANTHROPIC_CLIENT_ID,
+      redirect_uri: 'https://console.anthropic.com/oauth/code/callback',
+      code_verifier: verifier,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Token exchange failed: ${response.status} - ${errorText}`);
+  }
+
+  const json = await response.json();
+  
+  const auth = readAuthFile();
+  auth['anthropic'] = {
+    type: 'oauth',
+    access: json.access_token,
+    refresh: json.refresh_token,
+    expires: Date.now() + json.expires_in * 1000,
+  };
+  writeAuthFile(auth);
+
+  return {
+    success: true,
+    providerId: 'anthropic'
+  };
+}
+
+export function isAnthropicProvider(providerId) {
+  return ['anthropic', 'claude'].includes(providerId.toLowerCase());
+}


### PR DESCRIPTION
## Summary

- Implement missing `POST /api/provider/:providerId/oauth/authorize` and `POST /api/provider/:providerId/oauth/callback` endpoints
- Add `anthropic-oauth.js` module with PKCE-based OAuth 2.0 flow (uses same Anthropic public client ID as Claude Code CLI)
- Add `/api/provider` to JSON body parser whitelist

## Problem

The Providers Settings UI (`ProvidersPage.tsx`) calls these two OAuth endpoints when users click "Connect" for Anthropic. However, the server had no route handlers for them — requests fell through to the SPA HTML fallback, causing the UI to fail JSON parsing and show **"Failed to complete OAuth flow"**.

## How it works

1. **Authorize** — generates PKCE code verifier/challenge, builds Anthropic consent URL, returns it to the UI which opens it in a browser tab
2. **Callback** — receives the authorization code + verifier from the UI, exchanges them for access/refresh tokens via Anthropic's token endpoint, persists to `~/.local/share/opencode/auth.json`

## Testing

```bash
# Start authorize flow
curl -X POST http://localhost:3001/api/provider/anthropic/oauth/authorize \
  -H "Content-Type: application/json" \
  -d '{"method":0}'

# Returns: { data: { url: "https://console.anthropic.com/oauth/authorize?...", verifier: "..." } }
```

Verified end-to-end: Settings > Providers > Connect Anthropic now opens the OAuth consent page and completes the flow successfully.