### PR TITLE
Enable cross-origin manifest to make PWA work behind Cloudflare Access

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -198,6 +198,9 @@
 
       const manifestLink = document.createElement('link');
       manifestLink.rel = 'manifest';
+      // Required so the browser sends auth cookies when fetching the manifest,
+      // enabling PWA installation behind authentication proxies (e.g. Cloudflare Access).
+      manifestLink.crossOrigin = 'use-credentials';
       document.head.appendChild(manifestLink);
 
       let activeManifestBlobUrl = null;


### PR DESCRIPTION
> I used AI just to write this simple line for me so i could open this PR through my phone without cloning the repo :)

Inspired by https://github.com/danny-avila/LibreChat/discussions/5154

Currently, protecting the tunnel behind access throws:

```
Failed to load resource: net::ERR_BLOCKED_BY_CLIENT
(index):1 Access to manifest at 'https://slug.cloudflareaccess.com/cdn-cgi/access/login/chamber.domain.com?...&redirect_url=%2Fmanifest.webmanifest' (redirected from 'https://chamber.domain.com/manifest.webmanifest') from origin 'https://chamber.domain.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

Putting this allows cookies Cloudflare sets to be sent, thus allowing the proxy connection to be made instead of CF redirecting to auth portal.