### PR TITLE
fix(desktop): Radix UI dropdowns not dismissing on click-outside in Tauri macOS

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -21,6 +21,7 @@ import { usePwaInstallPrompt } from '@/hooks/usePwaInstallPrompt';
 import { useWindowTitle } from '@/hooks/useWindowTitle';
 import { useGitHubPrBackgroundTracking } from '@/hooks/useGitHubPrBackgroundTracking';
 import { GitPollingProvider } from '@/hooks/useGitPolling';
+import { useRadixDismissWorkaround } from '@/hooks/useRadixDismissWorkaround';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { hasModifier } from '@/lib/utils';
 import { isDesktopLocalOriginActive, isDesktopShell } from '@/lib/desktop';
@@ -380,6 +381,7 @@ function App({ apis }: AppProps) {
   useRouter();
 
   useKeyboardShortcuts();
+  useRadixDismissWorkaround();
 
   const handleToggleMemoryDebug = React.useCallback(() => {
     setShowMemoryDebug(prev => !prev);

--- a/packages/ui/src/hooks/useRadixDismissWorkaround.ts
+++ b/packages/ui/src/hooks/useRadixDismissWorkaround.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { isTauriShell } from '@/lib/desktop';
+
+/**
+ * Workaround for Radix UI dropdown/select dismiss failing in Tauri on macOS.
+ *
+ * Root cause: Radix's DismissableLayer sets `body.style.pointerEvents = "none"`
+ * for modal menus/selects. In Tauri with `transparent: true` on macOS, this
+ * causes WKWebView to stop delivering `pointerdown` events to the document,
+ * so the DismissableLayer's dismiss handler never fires.
+ *
+ * Fix: Listen for `mousedown` on the window (which still fires reliably) and
+ * when a click lands outside any open Radix floating content, synthesize an
+ * Escape keydown event to trigger Radix's built-in escape-key dismiss path.
+ */
+export function useRadixDismissWorkaround() {
+  useEffect(() => {
+    if (!isTauriShell()) return;
+
+    const FLOATING_SELECTOR = [
+      '[data-radix-menu-content][data-state="open"]',
+      '[data-radix-select-content]',
+      '[data-slot="dropdown-menu-content"][data-state="open"]',
+      '[data-slot="select-content"][data-state="open"]',
+    ].join(', ');
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const openContent = document.querySelectorAll(FLOATING_SELECTOR);
+      if (openContent.length === 0) return;
+
+      const target = event.target as Node | null;
+      if (!target) return;
+
+      // Check if the click is inside any open floating content
+      for (const el of openContent) {
+        if (el.contains(target)) return;
+      }
+
+      // Click was outside all open floating content — dismiss via Escape
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          code: 'Escape',
+          keyCode: 27,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    };
+
+    // Use capture phase to fire before anything else can stopPropagation
+    window.addEventListener('mousedown', handleMouseDown, { capture: true });
+    return () => {
+      window.removeEventListener('mousedown', handleMouseDown, { capture: true });
+    };
+  }, []);
+}

--- a/packages/ui/src/styles/design-system.css
+++ b/packages/ui/src/styles/design-system.css
@@ -135,6 +135,16 @@
     overscroll-behavior-y: none;
   }
 
+  /* Desktop shell: prevent Radix UI DismissableLayer from setting
+     body { pointer-events: none } on modal menus/selects/dialogs.
+     In Tauri with transparent: true on macOS, pointer-events: none on body
+     causes WKWebView to treat the entire page as click-through, so
+     pointerdown events never fire and dropdowns/selects can't be dismissed
+     by clicking outside. */
+  :root.desktop-runtime body {
+    pointer-events: auto !important;
+  }
+
   :root.desktop-runtime body,
   :root.desktop-runtime #root {
     background: transparent !important;


### PR DESCRIPTION
## Summary

- Fix all dropdown menus and selects being unable to dismiss on click-outside in the Tauri desktop shell on macOS
- Root cause: Radix UI's DismissableLayer sets `body.style.pointerEvents = "none"` for modal menus, which prevents WKWebView from delivering `pointerdown` events in Tauri's transparent window
- Add a `mousedown` listener workaround that dispatches synthetic Escape to trigger Radix's built-in dismiss path
- Add CSS `pointer-events: auto !important` override as a defense-in-depth measure

## Test plan

- [ ] Open app in Tauri desktop on macOS
- [ ] Open any dropdown menu (e.g., in Settings) — verify it closes when clicking outside
- [ ] Open any select component — verify it closes when clicking outside
- [ ] Verify dropdowns still work normally in web/PWA runtime (workaround is gated behind `isTauriShell()`)
- [ ] Verify keyboard Escape still dismisses dropdowns