### PR TITLE
fix: close dropdown menus when clicking outside in settings window

### DIFF
--- a/packages/ui/src/components/views/SettingsWindow.tsx
+++ b/packages/ui/src/components/views/SettingsWindow.tsx
@@ -30,13 +30,17 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ open, onOpenChan
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay
           className="fixed inset-0 z-50 bg-black/50 backdrop-blur-md"
+          onPointerDown={() => {
+            if (hasOpenFloatingMenu()) {
+              return;
+            }
+            onOpenChange(false);
+          }}
         />
         <DialogPrimitive.Content
           aria-describedby={descriptionId}
-          onInteractOutside={(event) => {
-            if (hasOpenFloatingMenu()) {
-              event.preventDefault();
-            }
+          onPointerDownOutside={(event) => {
+            event.preventDefault();
           }}
           className={cn(
             'fixed z-50 top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]',


### PR DESCRIPTION
## Summary

- Fix dropdown menus in the settings window not closing when clicking outside

## Root Cause

Radix UI's `DropdownMenu` listens for `pointerdown` at the document level to detect outside clicks. The Dialog overlay's `onPointerDown` handler was calling `event.stopPropagation()`, which prevented the event from reaching Radix's listener. Since `hasOpenFloatingMenu()` already guards against closing the dialog when a dropdown is open, `stopPropagation()` was redundant and only broke the dropdown's own close mechanism.

## Test plan

- [ ] Open the settings menu/window
- [ ] Open any dropdown (e.g., project selector, provider selector)
- [ ] Click outside the dropdown — it should close
- [ ] Click the overlay again (with no open dropdown) — dialog should close