### PR TITLE
fix(web): strip unused summary diff snapshots from message payloads

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -8,6 +8,10 @@ import { WebSocketServer } from 'ws';
 import { fileURLToPath } from 'url';
 import os from 'os';
 import crypto from 'crypto';
+import {
+  rewriteJsonSseBlock,
+  sanitizeMessagePayload,
+} from './lib/opencode/message-payload.js';
 import { createUiAuth } from './lib/opencode/ui-auth.js';
 import { createTunnelAuth } from './lib/opencode/tunnel-auth.js';
 import {
@@ -5103,6 +5107,10 @@ function parseSseDataPayload(block) {
   }
 }
 
+function maybeSanitizeMessagePayload(value) {
+  return sanitizeMessagePayload(value);
+}
+
 function extractSessionStatusUpdate(payload) {
   if (!payload || typeof payload !== 'object' || payload.type !== 'session.status') {
     return null;
@@ -6717,6 +6725,8 @@ function setupProxy(app) {
       }, 30 * 1000);
 
       const reader = upstreamResponse.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
       try {
         while (true) {
           const { done, value } = await reader.read();
@@ -6728,9 +6738,25 @@ function setupProxy(app) {
             break;
           }
           if (value && value.length > 0) {
-            res.write(Buffer.from(value));
-            resetIdleTimeout();
+            buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n');
+
+            let separatorIndex = buffer.indexOf('\n\n');
+            while (separatorIndex !== -1) {
+              const block = buffer.slice(0, separatorIndex);
+              buffer = buffer.slice(separatorIndex + 2);
+              const rewritten = rewriteJsonSseBlock(block, maybeSanitizeMessagePayload);
+              res.write(`${rewritten.block}\n\n`);
+              resetIdleTimeout();
+              separatorIndex = buffer.indexOf('\n\n');
+            }
           }
+        }
+
+        const trailing = buffer.trim();
+        if (trailing.length > 0) {
+          const rewritten = rewriteJsonSseBlock(trailing, maybeSanitizeMessagePayload);
+          res.write(`${rewritten.block}\n\n`);
+          resetIdleTimeout();
         }
       } finally {
         try {
@@ -6871,6 +6897,24 @@ function setupProxy(app) {
           continue;
         }
         res.setHeader(key, value);
+      }
+
+      const isSessionMessageHistoryRequest = req.method === 'GET' && /\/session\/[^/]+\/message$/.test(req.path || '');
+      const upstreamContentType = (upstreamResponse.headers.get('content-type') || '').toLowerCase();
+
+      if (isSessionMessageHistoryRequest && upstreamContentType.includes('application/json')) {
+        const upstreamText = await upstreamResponse.text();
+        let payload;
+        try {
+          payload = JSON.parse(upstreamText);
+        } catch {
+          res.status(upstreamResponse.status).send(upstreamText);
+          return;
+        }
+
+        const nextPayload = maybeSanitizeMessagePayload(payload);
+        res.status(upstreamResponse.status).json(nextPayload);
+        return;
       }
 
       const upstreamBody = Buffer.from(await upstreamResponse.arrayBuffer());
@@ -8732,9 +8776,10 @@ async function main(options = {}) {
 
     const forwardBlock = (block) => {
       if (!block) return;
-      const payload = parseSseDataPayload(block);
+      const rewritten = rewriteJsonSseBlock(block, maybeSanitizeMessagePayload);
+      const payload = rewritten.parsedPayload ?? parseSseDataPayload(rewritten.block);
 
-      res.write(`${block}
+      res.write(`${rewritten.block}
 
 `);
       // Cache session titles from session.updated/session.created events (global stream)
@@ -8875,9 +8920,10 @@ async function main(options = {}) {
 
     const forwardBlock = (block) => {
       if (!block) return;
-      const payload = parseSseDataPayload(block);
+      const rewritten = rewriteJsonSseBlock(block, maybeSanitizeMessagePayload);
+      const payload = rewritten.parsedPayload ?? parseSseDataPayload(rewritten.block);
 
-      res.write(`${block}
+      res.write(`${rewritten.block}
 
 `);
       // Cache session titles from session.updated/session.created events (per-session stream)

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -6,6 +6,8 @@ This module provides OpenCode server integration utilities for the web server ru
 ## Entrypoints and structure
 - `packages/web/server/lib/opencode/index.js`: public entrypoint (currently baseline placeholder).
 - `packages/web/server/lib/opencode/auth.js`: provider authentication file operations.
+- `packages/web/server/lib/opencode/message-payload.js`: helper utilities for removing oversized diff snapshot fields before forwarding message/session payloads to the UI.
+- `packages/web/server/lib/opencode/message-payload.test.js`: unit tests for message payload sanitization helpers.
 - `packages/web/server/lib/opencode/shared.js`: shared utilities for config, markdown, skills, and git helpers.
 - `packages/web/server/lib/opencode/ui-auth.js`: UI session authentication with rate limiting.
 
@@ -53,6 +55,7 @@ This module provides OpenCode server integration utilities for the web server ru
 ## Notes for contributors
 - This module serves as foundation for OpenCode-related server utilities.
 - Index.js is currently a baseline placeholder; direct imports use submodule paths.
+- Message payload sanitization is server-side compatibility logic for UI performance; remove diff snapshot `before`/`after` contents without changing the remaining payload shape.
 - All file writes include automatic backup before modification.
 - Config merging follows priority: custom > project > user.
 - UI auth uses scrypt for password hashing with constant-time comparison.

--- a/packages/web/server/lib/opencode/message-payload.js
+++ b/packages/web/server/lib/opencode/message-payload.js
@@ -1,0 +1,119 @@
+const isRecord = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const stripDiffSnapshotEntry = (entry) => {
+  if (!isRecord(entry)) {
+    return entry;
+  }
+
+  const looksLikeDiffEntry = (
+    typeof entry.file === 'string'
+    || typeof entry.status === 'string'
+    || Object.prototype.hasOwnProperty.call(entry, 'additions')
+    || Object.prototype.hasOwnProperty.call(entry, 'deletions')
+  );
+
+  const hasBefore = Object.prototype.hasOwnProperty.call(entry, 'before');
+  const hasAfter = Object.prototype.hasOwnProperty.call(entry, 'after');
+
+  if (!looksLikeDiffEntry || (!hasBefore && !hasAfter)) {
+    return entry;
+  }
+
+  const nextEntry = { ...entry };
+  delete nextEntry.before;
+  delete nextEntry.after;
+  return nextEntry;
+};
+
+export const sanitizeMessagePayload = (value) => {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const nextItems = value.map((item) => {
+      const nextItem = sanitizeMessagePayload(item);
+      if (nextItem !== item) {
+        changed = true;
+      }
+      return nextItem;
+    });
+
+    return changed ? nextItems : value;
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const maybeSnapshotEntry = stripDiffSnapshotEntry(value);
+  if (maybeSnapshotEntry !== value) {
+    return maybeSnapshotEntry;
+  }
+
+  let changed = false;
+  let nextValue = value;
+
+  for (const [key, child] of Object.entries(value)) {
+    const nextChild = sanitizeMessagePayload(child);
+    if (nextChild === child) {
+      continue;
+    }
+
+    if (!changed) {
+      nextValue = { ...value };
+      changed = true;
+    }
+
+    nextValue[key] = nextChild;
+  }
+
+  return changed ? nextValue : value;
+};
+
+export const rewriteJsonSseBlock = (block, transform) => {
+  if (typeof block !== 'string' || block.length === 0 || typeof transform !== 'function') {
+    return { block, parsedPayload: null, changed: false };
+  }
+
+  const lines = block.split('\n');
+  const preservedLines = [];
+  const dataLines = [];
+
+  for (const line of lines) {
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).replace(/^\s/, ''));
+      continue;
+    }
+
+    preservedLines.push(line);
+  }
+
+  if (dataLines.length === 0) {
+    return { block, parsedPayload: null, changed: false };
+  }
+
+  const payloadText = dataLines.join('\n').trim();
+  if (!payloadText) {
+    return { block, parsedPayload: null, changed: false };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(payloadText);
+  } catch {
+    return { block, parsedPayload: null, changed: false };
+  }
+
+  const transformed = transform(parsed);
+  const parsedPayload = isRecord(transformed) && isRecord(transformed.payload)
+    ? transformed.payload
+    : transformed;
+
+  if (transformed === parsed) {
+    return { block, parsedPayload, changed: false };
+  }
+
+  return {
+    block: [...preservedLines, `data: ${JSON.stringify(transformed)}`].join('\n'),
+    parsedPayload,
+    changed: true,
+  };
+};

--- a/packages/web/server/lib/opencode/message-payload.test.js
+++ b/packages/web/server/lib/opencode/message-payload.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  rewriteJsonSseBlock,
+  sanitizeMessagePayload,
+} from './message-payload.js';
+
+const buildDiff = (lineCount) => Array.from({ length: lineCount }, (_, index) => `line-${index + 1}`).join('\n');
+
+describe('message-payload helpers', () => {
+  it('removes summary diff before/after snapshots inside message info', () => {
+    const payload = [{
+      info: {
+        id: 'message-2',
+        role: 'assistant',
+        summary: {
+          diffs: [{
+            file: 'CLAUDE.md',
+            before: buildDiff(230),
+            after: buildDiff(240),
+            additions: 10,
+            deletions: 5,
+            status: 'modified',
+          }],
+        },
+      },
+      parts: [],
+    }];
+
+    const nextPayload = sanitizeMessagePayload(payload);
+    const diffEntry = nextPayload[0].info.summary.diffs[0];
+
+    expect(nextPayload).not.toBe(payload);
+    expect(diffEntry.before).toBeUndefined();
+    expect(diffEntry.after).toBeUndefined();
+    expect(diffEntry.additions).toBe(10);
+    expect(diffEntry.deletions).toBe(5);
+    expect(diffEntry.status).toBe('modified');
+    expect(diffEntry.file).toBe('CLAUDE.md');
+  });
+
+  it('removes session-level diff snapshot arrays before/after fields', () => {
+    const payload = [{
+      file: 'README.md',
+      before: buildDiff(205),
+      after: buildDiff(206),
+      additions: 3,
+      deletions: 1,
+      status: 'modified',
+    }];
+
+    const nextPayload = sanitizeMessagePayload(payload);
+    const diffEntry = nextPayload[0];
+
+    expect(nextPayload).not.toBe(payload);
+    expect(diffEntry.before).toBeUndefined();
+    expect(diffEntry.after).toBeUndefined();
+    expect(diffEntry.additions).toBe(3);
+    expect(diffEntry.deletions).toBe(1);
+    expect(diffEntry.status).toBe('modified');
+    expect(diffEntry.file).toBe('README.md');
+  });
+
+  it('does not modify unrelated payload objects', () => {
+    const payload = {
+      parts: [
+        { id: 'part-1', type: 'text', text: 'hello' },
+        { id: 'part-2', type: 'tool', state: { metadata: { diff: buildDiff(5) } } },
+      ],
+    };
+
+    expect(sanitizeMessagePayload(payload)).toBe(payload);
+  });
+
+  it('rewrites JSON SSE blocks while preserving non-data lines', () => {
+    const originalBlock = [
+      'id: 10',
+      'event: message',
+      `data: ${JSON.stringify({ payload: { type: 'message.updated', properties: { info: { summary: { diffs: [{ file: 'CLAUDE.md', before: buildDiff(3), after: buildDiff(4), status: 'modified' }] } } } } })}`,
+    ].join('\n');
+
+    const result = rewriteJsonSseBlock(originalBlock, sanitizeMessagePayload);
+
+    expect(result.changed).toBe(true);
+    expect(result.block.startsWith('id: 10\nevent: message\ndata: ')).toBe(true);
+    expect(result.parsedPayload?.properties?.info?.summary?.diffs?.[0]?.before).toBeUndefined();
+    expect(result.parsedPayload?.properties?.info?.summary?.diffs?.[0]?.after).toBeUndefined();
+    expect(result.parsedPayload?.properties?.info?.summary?.diffs?.[0]?.status).toBe('modified');
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a focused `message-payload` sanitization layer in the web server proxy to trim oversized OpenCode message payloads before they reach the frontend.

The immediate issue is that a session can include `summary.diff.before` and `summary.diff.after` snapshots. When those snapshots contain large files, loading the session in the frontend becomes very slow and can even crash the browser tab.

The frontend does not currently use these two fields, so this change removes them server-side before forwarding the payload.

## Problem

Some OpenCode session/message payloads include full diff snapshots in:

- `summary.diffs[].before`
- `summary.diffs[].after`

For large files, these fields can make the payload significantly larger than what the UI actually needs. In practice, this causes:

- very slow session loading
- excessive frontend memory usage
- browser tab instability or crashes for large sessions

## What changed

This PR adds a dedicated message payload middleware/helper on the server side that:

- walks OpenCode JSON payloads recursively
- detects diff snapshot entries
- removes `before` / `after` from those entries
- preserves the rest of the payload shape

## Why this approach

The frontend does not rely on `summary.diff.before` or `summary.diff.after`, so removing them is a safe way to reduce payload size immediately.

By adding a dedicated server-side payload transformation layer, we can:

- minimize unnecessary data sent to the UI
- reduce frontend load time and memory pressure
- keep future payload-related optimizations isolated in one place

## Scope

This PR intentionally keeps the change narrow:

- removes unused diff snapshot contents from message/session payloads

## Validation

- added unit tests for payload sanitization
- verified SSE JSON block rewriting still preserves non-`data:` lines
- verified diff entries keep metadata such as `file`, `status`, `additions`, and `deletions`
