### PR TITLE
Fix: Escape HTML tags in user messages to prevent parsing as actual elements

### DIFF
--- a/packages/ui/src/components/chat/message/parts/UserTextPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/UserTextPart.tsx
@@ -19,6 +19,15 @@ const buildMentionUrl = (name: string): string => {
     return `https://opencode.ai/docs/agents/#${encoded}`;
 };
 
+const escapeHtml = (text: string): string => {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#x27;');
+};
+
 const normalizeUserMessageRenderingMode = (mode: unknown): 'markdown' | 'plain' => {
     return mode === 'markdown' ? 'markdown' : 'plain';
 };
@@ -99,12 +108,18 @@ const UserTextPart: React.FC<UserTextPartProps> = ({ part, messageId, agentMenti
     }, [collapseZoneHeight, hasActiveSelectionInElement, isExpanded, isTruncated]);
 
     const processedMarkdownContent = React.useMemo(() => {
-        if (!agentMention?.token || !textContent.includes(agentMention.token)) {
-            return textContent;
+        let content = textContent;
+
+        // Step 1: First escape HTML to protect against XSS and ensure HTML tags display as text
+        content = escapeHtml(content);
+
+        // Step 2: Then insert agent mention links (after escaping, so <a> tags won't be escaped)
+        if (agentMention?.token && content.includes(agentMention.token)) {
+            const mentionHtml = `<a href="${buildMentionUrl(agentMention.name)}" class="text-primary hover:underline" target="_blank" rel="noopener noreferrer">${agentMention.token}</a>`;
+            content = content.replace(agentMention.token, mentionHtml);
         }
-        
-        const mentionHtml = `<a href="${buildMentionUrl(agentMention.name)}" class="text-primary hover:underline" target="_blank" rel="noopener noreferrer">${agentMention.token}</a>`;
-        return textContent.replace(agentMention.token, mentionHtml);
+
+        return content;
     }, [agentMention, textContent]);
 
     const plainTextContent = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- Add HTML escaping for user messages in Markdown mode
- Fix agent mention link rendering order issue
- Plain mode remains unchanged (uses React elements)

## Problem
When users send messages containing HTML tags (e.g., `<div>test</div>`), the tags were being parsed as actual HTML elements by the Markdown renderer, causing:
- Empty `<div>` tags to appear invisible
- Potential XSS vulnerabilities
- Agent mention links (`@agent`) being escaped and not clickable

## Solution
Modified `UserTextPart.tsx` to:
1. Add `escapeHtml()` function to escape HTML special characters
2. Reorder processing: escape HTML first, then insert agent mention links
3. Ensure agent mentions render as clickable links in Markdown mode

## Test Cases
✅ `@explore <div>test</div>` → @explore shows as clickable link, HTML escaped
✅ `<div class="flex-shrink-0" aria-hidden="true" style="height: 10vh;">` → Fully escaped and visible
✅ Agent mentions (`@agent`) render correctly as links
✅ Plain mode unchanged (uses React elements)

## Screenshots
<img width="946" height="234" alt="image" src="https://github.com/user-attachments/assets/14c2a6ac-6f6c-4797-adb9-3dba79a5ab79" />
