### PR TITLE
fix(quota): show actual overusage percentage for GitHub Copilot

### DIFF
--- a/packages/ui/src/lib/quota/utils.ts
+++ b/packages/ui/src/lib/quota/utils.ts
@@ -6,11 +6,10 @@ export const clampPercent = (value: number | null): number | null => {
 };
 
 export const formatPercent = (value: number | null): string => {
-  const clamped = clampPercent(value);
-  if (clamped === null) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
     return '-';
   }
-  return `${clamped}%`;
+  return `${Math.round(value)}%`;
 };
 
 export const resolveUsageTone = (percent: number | null): 'safe' | 'warn' | 'critical' => {

--- a/packages/web/server/lib/quota/providers/copilot.js
+++ b/packages/web/server/lib/quota/providers/copilot.js
@@ -18,7 +18,7 @@ const buildCopilotWindows = (payload) => {
     const entitlement = toNumber(snapshot.entitlement);
     const remaining = toNumber(snapshot.remaining);
     const usedPercent = entitlement && remaining !== null
-      ? Math.max(0, Math.min(100, 100 - (remaining / entitlement) * 100))
+      ? Math.max(0, 100 - (remaining / entitlement) * 100)
       : null;
     const valueLabel = entitlement !== null && remaining !== null
       ? `${remaining.toFixed(0)} / ${entitlement.toFixed(0)} left`


### PR DESCRIPTION
## Summary

- Show the real overusage percentage (e.g. **353%**) for GitHub Copilot in the header usage popover and settings, instead of capping at 100%.
- This matches the behavior of the [GitHub Copilot settings page](https://github.com/settings/copilot), which reports the actual percentage when a subscription exceeds its quota (e.g. "350.0%").

## Problem

When a GitHub Copilot subscription goes over its premium request entitlement, the API returns a **negative `remaining`** value (e.g. `-759` out of `300`). Previously, `usedPercent` was clamped to `[0, 100]` in the Copilot provider, and `formatPercent` also clamped its output to `[0, 100]`. This meant both the header popover and settings page showed **100%** — hiding the actual overusage.

## Changes

**`packages/web/server/lib/quota/providers/copilot.js`**
- Remove `Math.min(100, ...)` from `usedPercent` calculation so values above 100% flow through (e.g. 353% when remaining is -759 out of 300 entitlement).

**`packages/ui/src/lib/quota/utils.ts`**
- `formatPercent` no longer routes through `clampPercent`, so it displays the actual rounded value (e.g. `353%`).
- `clampPercent` is unchanged — `UsageProgressBar` still uses it independently to cap the bar width at 100%.

## Safety

- **Progress bar**: Unaffected — uses `clampPercent` directly, bar stays at 100% max width.
- **Color tone**: `resolveUsageTone` returns `critical` (red) for anything >= 80% — values above 100% still show red. No change.
- **Pace calculation**: Already handles `usedPercent >= 100` as "exhausted". No change.
- **Other providers**: All other quota providers (Claude, Google, etc.) apply their own clamps in their respective provider files. This change only affects GitHub Copilot.
- **Settings view**: `UsageCard` prefers `valueLabel` (e.g. "-759 / 300 left") when available, so the detailed settings view is unaffected.
- **Remaining mode**: `remainingPercent` is `Math.max(0, 100 - usedPercent)` (computed server-side in `toUsageWindow`), so it correctly shows `0%` when over-limit.

## Testing

Verified with an active GitHub Copilot subscription at 350%+ usage:
- Header popover now shows `353%` for Premium Interactions instead of `100%`
- Settings Usage page continues to show `-759 / 300 left` (unchanged, uses `valueLabel`)
- Progress bar fills to 100% with red/critical color (unchanged)
- Type-check, lint, and build all pass