### PR TITLE
fix(server): force identity encoding for OpenCode proxy requests

### DIFF
--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -155,6 +155,10 @@ export const registerOpenCodeProxy = (app, deps) => {
         if (authHeaders.Authorization) {
           proxyReq.setHeader('Authorization', authHeaders.Authorization);
         }
+
+        // Defensive: request identity encoding from upstream OpenCode.
+        // This avoids compressed-body/header mismatches in multi-proxy setups.
+        proxyReq.setHeader('accept-encoding', 'identity');
       },
       error: (err, _req, res) => {
         console.error('[proxy] OpenCode proxy error:', err.message);


### PR DESCRIPTION
## Summary
- set `accept-encoding: identity` on OpenCode proxy requests in the server gateway
- prevent compressed-body/header mismatch issues that can surface as browser `ERR_CONTENT_DECODING_FAILED` behind reverse proxies or tunnels
- keep behavior scoped to proxy request headers only, with no API payload contract changes