### PR TITLE
fix(vscode): normalize Windows directory paths for SSE event store lookup

### DIFF
--- a/packages/ui/src/stores/useDirectoryStore.ts
+++ b/packages/ui/src/stores/useDirectoryStore.ts
@@ -45,7 +45,9 @@ const normalizeDirectoryPath = (value: string): string => {
   if (!trimmed) {
     return trimmed;
   }
-  const normalized = trimmed.replace(/\\/g, '/');
+  const normalized = trimmed
+    .replace(/\\/g, '/')
+    .replace(/^([a-z]):/, (_, letter: string) => letter.toUpperCase() + ':');
   if (normalized.length > 1) {
     return normalized.replace(/\/+$/, '');
   }

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -108,10 +108,16 @@ function isRecentBoot() {
 }
 
 function handleEvent(
-  directory: string,
+  rawDirectory: string,
   payload: Event,
   childStores: ChildStoreManager,
 ) {
+  // Normalize directory path: SSE events from OpenCode use native OS separators
+  // (backslashes on Windows) and may differ in drive-letter case.
+  // Child stores are keyed with forward slashes and uppercase drive letters.
+  const directory = rawDirectory && rawDirectory !== "global"
+    ? rawDirectory.replace(/\\/g, "/").replace(/^([a-z]):/, (_, l: string) => l.toUpperCase() + ":")
+    : rawDirectory
   // Global events
   if (directory === "global" || !directory) {
     const recent = isRecentBoot()


### PR DESCRIPTION
## Summary

Fixes #816

On Windows, the VS Code extension's SSE streaming silently fails to render chat responses. Messages are sent to the server and responses stream back through the SSE pipeline correctly, but the UI never updates.

## Root Cause

SSE events from the OpenCode server arrive with **native Windows path separators and system-cased drive letters** (e.g. D:\Dev\workspace\...), while the child store Map keys use **forward slashes with the original VS Code workspace folder casing** (e.g. d:/Dev/workspace/...).

This causes childStores.getChild(directory) in handleEvent to return undefined on every directory event, silently dropping all session, message, and streaming events before they reach the React UI.

Two mismatches:
| Aspect | SSE Event (OpenCode server) | Child Store Key (VS Code) |
|--------|---------------------------|--------------------------|
| Separators | \ (backslashes) | / (forward slashes) |
| Drive letter | D: (uppercase) | d: (lowercase) |

## Changes

### packages/ui/src/sync/sync-context.tsx
Normalize the incoming SSE event directory in handleEvent before the child store lookup — convert backslashes to forward slashes and uppercase the Windows drive letter.

### packages/ui/src/stores/useDirectoryStore.ts
Add drive letter uppercasing to normalizeDirectoryPath, aligning it with the canonical normalization already used in normalizeCandidatePath (client.ts) and normalizeWorkspacePath (main.tsx).

## Cross-Platform Safety

Both normalizations are **no-ops on macOS/Linux**:
- replace(/\\/g, "/") — no backslashes in POSIX paths
- replace(/^([a-z]):/, ...) — no x: drive prefix in POSIX paths

## Testing

- ✅ bun run type-check — passed
- ✅ bun run lint — passed
- ✅ bun run build — ui + vscode packages pass (@openchamber/web has a pre-existing workbox failure unrelated to this change)
- ✅ Manual verification: VS Code Extension Development Host on Windows 11 — chat messages send and AI responses stream correctly after fix