### PR TITLE
fix(chat): allow revert button hover on short user messages

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -1072,7 +1072,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                             />
                                         ) : null}
                                     </div>
-                                    {showStickyInlineHoverRow ? <div aria-hidden="true" className="pointer-events-none absolute left-0 right-0 top-full h-11" /> : null}
+                                    {showStickyInlineHoverRow ? <div aria-hidden="true" className="absolute left-0 right-0 top-full h-11" /> : null}
                                 </div>
                             </FadeInOnReveal>
                         )


### PR DESCRIPTION
## Summary

- Short user messages (e.g. "OK") had an unreachable revert button because the hover state broke when moving the cursor from the small message bubble to the button area below
- The 44px hover bridge element below user messages had `pointer-events-none`, preventing `group-hover/user-shell` from staying active
- Remove `pointer-events-none` so the hover chain works for messages of any height

## Root Cause

The revert/copy/fork action buttons on desktop user messages use `absolute top-full` positioning, floating below the message bubble. Their visibility depends on `group-hover/user-shell` being active. A 44px extension area (`ChatMessage.tsx:1075`) was meant to bridge the hover gap between the bubble and the absolute-positioned buttons, but `pointer-events-none` made it transparent to mouse events — defeating its purpose.

For short messages, the bubble is too small to sustain the hover state long enough for the cursor to reach the buttons, so the buttons disappear instantly.

## Test Plan

- [ ] Send a short user message ("OK", "yes", single word)
- [ ] Hover over the message bubble and move cursor downward
- [ ] Verify revert/copy/fork buttons appear and remain clickable
- [ ] Verify behavior is unchanged for long user messages
- [ ] Verify no interference with messages below (clicking, selecting text)
- [ ] Verify mobile behavior is unaffected (buttons always visible)