### PR TITLE
fix(chat): show thinking/justification before question card in sorted mode

### DIFF
--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -707,6 +707,14 @@ const AssistantMessageBody: React.FC<Omit<MessageBodyProps, 'isUser'>> = ({
     const isLastAssistantInTurn = turnGroupingContext?.isLastAssistantInTurn ?? false;
     const hasStopFinish = messageFinish === 'stop';
 
+    // When the model calls a blocking tool (e.g. question), it's paused waiting for user input.
+    // In sorted mode, we should show deferred text/reasoning content rather than hiding it.
+    const hasBlockingToolCall = React.useMemo(() => {
+        return visibleParts.some(
+            p => p.type === 'tool' && (p as ToolPartType).tool?.toLowerCase() === 'question'
+        );
+    }, [visibleParts]);
+
     // TTS for message playback
     const { isPlaying: isTTSPlaying, play: playTTS, stop: stopTTS } = useMessageTTS();
     const showMessageTTSButtons = useConfigStore((state) => state.showMessageTTSButtons);
@@ -1153,11 +1161,11 @@ const AssistantMessageBody: React.FC<Omit<MessageBodyProps, 'isUser'>> = ({
 
             if (part.type === 'text') {
                 const activity = activityByPart.get(part);
-                if (isSortedRenderMode && !hasStopFinish) {
+                if (isSortedRenderMode && !hasStopFinish && !hasBlockingToolCall) {
                     i += 1;
                     continue;
                 }
-                if (activity?.kind === 'justification') {
+                if (activity?.kind === 'justification' && (shouldRenderActivityGroup || !hasBlockingToolCall)) {
                     i += 1;
                     continue;
                 }
@@ -1178,7 +1186,7 @@ const AssistantMessageBody: React.FC<Omit<MessageBodyProps, 'isUser'>> = ({
 
             if (part.type === 'reasoning') {
                 const activity = activityByPart.get(part);
-                if (isSortedRenderMode && !hasStopFinish) {
+                if (isSortedRenderMode && !hasStopFinish && !hasBlockingToolCall) {
                     i += 1;
                     continue;
                 }
@@ -1292,6 +1300,7 @@ const AssistantMessageBody: React.FC<Omit<MessageBodyProps, 'isUser'>> = ({
         animatedToolIdsLookup,
         animateActivityRows,
         chatRenderMode,
+        hasBlockingToolCall,
         collapsedPreviewCount,
         expandedTools,
         hasStopFinish,


### PR DESCRIPTION
## Summary

- In sorted render mode during streaming, text/reasoning/justification parts were hidden until the message completed (`finish === 'stop'`). When the model called the `question` tool, the `QuestionCard` rendered immediately via SSE, but the preceding thinking/justification content was invisible.
- Adds `hasBlockingToolCall` detection for question tool parts, and bypasses the sorted-mode text/reasoning deferral when the model is paused waiting for user input.
- Also fixes justification rendering: only skips in flat loop when the activity group will render it, preventing hidden justification when no activity group is active.