### PR TITLE
fix: improve Linux support in Tauri desktop config

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.28"
 reqwest = { version = "0.12.4", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.143"
-tauri = { version = "2.10.3", features = ["macos-private-api"] }
+tauri = { version = "2.10.3" }
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-log = "2.8.0"
 tauri-plugin-shell = "2.3.5"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -15,27 +15,20 @@
         "label": "main",
         "create": false,
         "title": "OpenChamber",
-        "transparent": true,
         "width": 1280,
         "height": 800,
         "resizable": true,
         "fullscreen": false,
-        "decorations": true,
-        "hiddenTitle": true,
-        "titleBarStyle": "Overlay",
-        "trafficLightPosition": {
-          "x": 17,
-          "y": 26
-        },
-        "dragDropEnabled": false,
+        "decorations": false,
+        "transparent": true,
+        "dragDropEnabled": true,
         "visible": false
       }
     ],
     "security": {
       "csp": null
     },
-    "withGlobalTauri": true,
-    "macOSPrivateApi": true
+    "withGlobalTauri": true
   },
   "bundle": {
     "active": true,


### PR DESCRIPTION
## Summary

- Remove macOS-only window properties (`hiddenTitle`, `titleBarStyle: Overlay`, `trafficLightPosition`) from `tauri.conf.json` — these cause a broken hybrid titlebar on Linux/Wayland
- Set `decorations: false` for clean Hyprland/Wayland window management (WM handles chrome via keybinds)
- Enable `dragDropEnabled: true` for file drag-and-drop support
- Remove `macOSPrivateApi: true` (not needed on Linux)
- Remove `macos-private-api` feature from `Cargo.toml`

## Why

On Linux (especially Hyprland/Wayland), the macOS-specific window config causes:
- An ugly extra topbar (WebKitGTK doesn't support `titleBarStyle: Overlay`)
- Finder appearing in the menu bar (macOS menu code leaking through)
- Window decoration conflicts with the compositor

With `decorations: false`, the WM handles all window chrome, giving a clean fullscreen content area — matching how the web UI looks in a browser.

## Testing

Built and tested on Arch Linux with Hyprland + Wayland.