### PR TITLE
fix: improve Linux clipboard image paste support

### DIFF
--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -2378,6 +2378,123 @@ struct FileContent {
     size: usize,
 }
 
+/// Read image data from the system clipboard.
+/// On Linux, uses wl-paste (Wayland) or xclip (X11) to query available
+/// image MIME types and read the first available one.
+/// On macOS, uses osascript to read PNG from clipboard.
+/// Returns { mime, base64 } or null if no image is available.
+#[tauri::command]
+fn desktop_read_clipboard_image() -> Result<Option<ClipboardImage>, String> {
+    let os = std::env::consts::OS;
+
+    if os == "linux" {
+        let mime_priority = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/bmp"];
+
+        // Try Wayland first
+        if std::env::var("WAYLAND_DISPLAY").is_ok() {
+            let types_output = Command::new("wl-paste")
+                .arg("--list-types")
+                .output()
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok());
+
+            if let Some(types_str) = types_output {
+                let available: HashSet<String> = types_str
+                    .lines()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+
+                for mime in &mime_priority {
+                    if available.contains(*mime) {
+                        let data = Command::new("wl-paste")
+                            .args(["-t", mime])
+                            .output()
+                            .ok();
+                        if let Some(output) = data {
+                            if output.status.success() && !output.stdout.is_empty() {
+                                return Ok(Some(ClipboardImage {
+                                    mime: mime.to_string(),
+                                    base64: general_purpose::STANDARD.encode(&output.stdout),
+                                }));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Try X11 via xclip
+        let targets_output = Command::new("xclip")
+            .args(["-selection", "clipboard", "-t", "TARGETS", "-o"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok());
+
+        if let Some(targets_str) = targets_output {
+            let available: HashSet<String> = targets_str
+                .lines()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            for mime in &mime_priority {
+                if available.contains(*mime) {
+                    let data = Command::new("xclip")
+                        .args(["-selection", "clipboard", "-t", mime, "-o"])
+                        .output()
+                        .ok();
+                    if let Some(output) = data {
+                        if output.status.success() && !output.stdout.is_empty() {
+                            return Ok(Some(ClipboardImage {
+                                mime: mime.to_string(),
+                                base64: general_purpose::STANDARD.encode(&output.stdout),
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if os == "macos" {
+        let tmpfile = format!("/tmp/openchamber-clipboard-{}.png", std::process::id());
+        let result = Command::new("osascript")
+            .args([
+                "-e",
+                &format!(
+                    r#"set imageData to the clipboard as "PNGf"
+set fileRef to open for access POSIX file "{}" with write permission
+set eof fileRef to 0
+write imageData to fileRef
+close access fileRef"#,
+                    tmpfile
+                ),
+            ])
+            .output()
+            .ok();
+
+        if result.is_some() {
+            if let Ok(bytes) = std::fs::read(&tmpfile) {
+                let _ = std::fs::remove_file(&tmpfile);
+                return Ok(Some(ClipboardImage {
+                    mime: "image/png".to_string(),
+                    base64: general_purpose::STANDARD.encode(&bytes),
+                }));
+            }
+            let _ = std::fs::remove_file(&tmpfile);
+        }
+    }
+
+    Ok(None)
+}
+
+#[derive(Serialize)]
+struct ClipboardImage {
+    mime: String,
+    base64: String,
+}
+
 #[cfg(target_os = "macos")]
 fn macos_major_version() -> Option<u32> {
     fn cmd_stdout(cmd: &str, args: &[&str]) -> Option<String> {
@@ -3293,6 +3410,7 @@ fn main() {
             remote_ssh::desktop_ssh_logs,
             remote_ssh::desktop_ssh_logs_clear,
             desktop_read_file,
+            desktop_read_clipboard_image,
         ])
         .setup(|app| {
             let handle = app.handle().clone();

--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -2233,8 +2233,30 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
             }
         });
 
+        // Fallback: on Linux/Tauri, WebKitGTK may not expose clipboard images
+        // via clipboardData. Try reading via native clipboard tools.
         const imageFiles = Array.from(fileMap.values());
-        if (imageFiles.length === 0) {
+        if (imageFiles.length === 0 && typeof window !== 'undefined' && (window as any).__TAURI__) {
+            try {
+                const { invoke } = await import('@tauri-apps/api/core');
+                const result = await invoke<{ mime: string; base64: string } | null>('desktop_read_clipboard_image');
+                if (result && result.base64) {
+                    const byteCharacters = atob(result.base64);
+                    const byteNumbers = new Array(byteCharacters.length);
+                    for (let i = 0; i < byteCharacters.length; i++) {
+                        byteNumbers[i] = byteCharacters.charCodeAt(i);
+                    }
+                    const byteArray = new Uint8Array(byteNumbers);
+                    const file = new File([byteArray], `clipboard-image.${result.mime.split('/')[1]}`, { type: result.mime });
+                    fileMap.set(`${file.name}-${file.size}`, file);
+                }
+            } catch {
+                // Native clipboard read failed — fall through to normal paste
+            }
+        }
+
+        const finalImageFiles = Array.from(fileMap.values());
+        if (finalImageFiles.length === 0) {
             return;
         }
 
@@ -2249,7 +2271,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ onOpenSettings, scrollToBo
             insertTextAtSelection(pastedText);
         }
 
-        for (const file of imageFiles) {
+        for (const file of finalImageFiles) {
             try {
                 await addAttachedFile(file);
             } catch (error) {


### PR DESCRIPTION
## Summary

- Add `desktop_read_clipboard_image` Tauri command that reads image data from the system clipboard using `wl-paste` (Wayland) or `xclip` (X11)
- Update `ChatInput` paste handler to fall back to native clipboard read when WebKitGTK doesn't expose clipboard images via `clipboardData` API
- Also supports macOS via `osascript` PNG clipboard read (parity with existing macOS behavior)

## Why

On Linux/WebKitGTK, pasting images from the clipboard doesn't populate `e.clipboardData.files` or `e.clipboardData.items` the same way as on macOS. The image data is available in the system clipboard but not exposed through the WebView's clipboard API.

This fix mirrors the approach from [anomalyco/opencode#14552](https://github.com/anomalyco/opencode/pull/14552), which added the same native clipboard reading for the OpenCode TUI.

## How it works

1. When the user pastes in the chat input, the existing `clipboardData` check runs first (works on macOS and some Linux setups)
2. If no image files are found AND running in the Tauri shell, the frontend calls `desktop_read_clipboard_image`
3. The Rust command queries the system clipboard via `wl-paste --list-types` (Wayland) or `xclip -t TARGETS` (X11) and reads the first available image MIME type
4. The image is returned as base64 and converted to a `File` object for attachment

## Dependencies

Requires `wl-clipboard` (Wayland) or `xclip` (X11) to be installed on the system. These are common clipboard utilities already present on most Linux desktop setups.