### PR TITLE
fix: add defensive checks for missing model cost and capabilities fields

### DIFF
--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -234,7 +234,8 @@ const buildModelMetadataKey = (providerId: string, modelId: string) => {
     return `${normalizedProvider}/${modelId}`;
 };
 
-const mapModalities = (cap: { text: boolean; audio: boolean; image: boolean; video: boolean; pdf: boolean }): string[] => {
+const mapModalities = (cap: { text: boolean; audio: boolean; image: boolean; video: boolean; pdf: boolean } | undefined): string[] => {
+    if (!cap) return [];
     const result: string[] = [];
     if (cap.text) result.push('text');
     if (cap.audio) result.push('audio');
@@ -248,20 +249,20 @@ const deriveModelMetadata = (providerId: string, model: ProviderModel): ModelMet
     id: model.id,
     providerId,
     name: model.name,
-    tool_call: model.capabilities.toolcall,
-    reasoning: model.capabilities.reasoning,
-    temperature: model.capabilities.temperature,
-    attachment: model.capabilities.attachment,
-    modalities: {
+    tool_call: model.capabilities?.toolcall,
+    reasoning: model.capabilities?.reasoning,
+    temperature: model.capabilities?.temperature,
+    attachment: model.capabilities?.attachment,
+    modalities: model.capabilities ? {
         input: mapModalities(model.capabilities.input),
         output: mapModalities(model.capabilities.output),
-    },
-    cost: {
+    } : undefined,
+    cost: model.cost ? {
         input: model.cost.input,
         output: model.cost.output,
-        cache_read: model.cost.cache.read,
-        cache_write: model.cost.cache.write,
-    },
+        cache_read: model.cost.cache?.read,
+        cache_write: model.cost.cache?.write,
+    } : undefined,
     limit: model.limit,
     release_date: model.release_date,
 });


### PR DESCRIPTION
## Summary
`deriveModelMetadata` (introduced in #747) accesses `model.cost.cache.read`,`model.cost.cache.write`, and `model.capabilities.*` without optional chaining. Providers that omit `cost.cache` or `capabilities` from their model config crash the chat UI with:
```text
TypeError: Cannot read properties of undefined (reading 'read')
```
## Root Cause
PR \#747 added a fallback path that derives model metadata directly from OpenCode provider responses when models.dev data is unavailable. Unlike the models.dev path (which returns pre-normalized data), raw provider responses may omit `cost`, `cost.cache`, or `capabilities` entirely — depending on the provider (e.g. Gemini models have no cache pricing).
## Changes
- Guard `model.capabilities` and `model.cost` at the object level — pass `undefined` when the parent field is missing, instead of fabricating `false` / `0` defaults that misrepresent unknown data as known values
- Add `?.` on `model.cost.cache` to handle providers without cache pricing
- Add `undefined` guard to `mapModalities` parameter

This aligns `deriveModelMetadata` with the existing `transformModelsDevResponse` path, which already uses `undefined` for absent fields.
## Fixes
#825
#854