### PR TITLE
fix: use openCodeBaseUrl in proxy router for external OpenCode server support

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -581,8 +581,9 @@ const serverUtilsRuntime = createServerUtilsRuntime({
   process,
   openCodeReadyGraceMs: OPEN_CODE_READY_GRACE_MS,
   longRequestTimeoutMs: LONG_REQUEST_TIMEOUT_MS,
-  getRuntime: () => ({
+   getRuntime: () => ({
     openCodePort,
+    openCodeBaseUrl,
     openCodeNotReadySince,
     isOpenCodeReady,
     isRestartingOpenCode,

--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -233,13 +233,13 @@ export const registerOpenCodeProxy = (app, deps) => {
 
   // Generic proxy for non-SSE OpenCode API routes.
   const apiProxy = createProxyMiddleware({
-    target: `http://127.0.0.1:${runtime.openCodePort || 3902}`,
+    target: runtime.openCodeBaseUrl ?? `http://127.0.0.1:${runtime.openCodePort || 3902}`,
     changeOrigin: true,
     pathRewrite: { '^/api': '' },
-    // Dynamic target — port can change after restart
+    // Dynamic target — base URL or port can change after restart
     router: () => {
       const rt = getRuntime();
-      return `http://127.0.0.1:${rt.openCodePort || 3902}`;
+      return rt.openCodeBaseUrl ?? `http://127.0.0.1:${rt.openCodePort || 3902}`;
     },
     on: {
       proxyReq: (proxyReq) => {


### PR DESCRIPTION
## Summary

- Passes `openCodeBaseUrl` through the server runtime object so the proxy router can use it
- Updates `registerOpenCodeProxy` to prefer `rt.openCodeBaseUrl` over the default `127.0.0.1:<port>` fallback
- Enables correct proxying when connecting to an external OpenCode instance via `OPENCODE_HOST`