### PR TITLE
fix: update parent session tool parts when subagent completes

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -161,6 +161,7 @@ const TASK_TOOL_ACTIVE_FETCH_LIMIT = 160;
 const TASK_TOOL_IDLE_FETCH_LIMIT = 80;
 const TASK_TOOL_NO_CHANGE_BACKOFF_AFTER_POLLS = 3;
 const TASK_TOOL_SETTLE_GRACE_MS = 2500;
+const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"]);
 const GIT_REFRESH_MUTATING_TOOLS = new Set([
     'bash',
     'edit',
@@ -2210,6 +2211,74 @@ const ToolPart: React.FC<ToolPartProps> = ({
         taskSessionId,
     ]);
 
+
+    // When child session polling stops (child completed + settle grace elapsed),
+    // resync the parent session's messages/parts to ensure the task tool part
+    // reflects the final state. This covers the case where SSE
+    // message.part.updated for the parent's task tool part was coalesced,
+    // delayed, or lost after the subagent completed.
+    //
+    // Only updates the specific message that contains this task tool part,
+    // avoiding overwriting in-flight SSE state for other messages.
+    React.useEffect(() => {
+        if (!taskChildPollingStopped || !isTaskTool || !currentSessionId || !currentDirectory || !part.messageID) {
+            return;
+        }
+
+        let cancelled = false;
+        const targetMessageID = part.messageID;
+        const childStores = getSyncChildStores();
+
+        void (async () => {
+            try {
+                const scopedClient = opencodeClient.getScopedSdkClient(currentDirectory);
+                const response = await scopedClient.session.messages({
+                    sessionID: currentSessionId,
+                    limit: TASK_TOOL_ACTIVE_FETCH_LIMIT,
+                });
+                const records = response.data ?? [];
+                if (cancelled || !Array.isArray(records) || records.length === 0) {
+                    return;
+                }
+
+                // Find only the target message record that contains our task tool part
+                const targetRecord = records.find((record) => record?.info?.id === targetMessageID);
+                if (!targetRecord || !targetRecord.parts) return;
+
+                const fetchedParts = targetRecord.parts
+                    .filter((p: { id?: unknown; type?: unknown }) => !!p?.id && typeof p.type === 'string' && !SKIP_PARTS.has(p.type))
+                    .sort((a: { id?: unknown }, b: { id?: unknown }) => {
+                        const aId = String(a.id ?? '');
+                        const bId = String(b.id ?? '');
+                        return aId < bId ? -1 : aId > bId ? 1 : 0;
+                    });
+
+                // Preserve reference identity: only write if parts actually changed
+                const existingParts = childStores.getState(currentDirectory)?.part[targetMessageID];
+                if (existingParts && existingParts.length === fetchedParts.length) {
+                    let identical = true;
+                    for (let i = 0; i < existingParts.length; i++) {
+                        if (existingParts[i] !== fetchedParts[i]) {
+                            identical = false;
+                            break;
+                        }
+                    }
+                    if (identical) return;
+                }
+
+                childStores.update(currentDirectory, (prev) => ({
+                    ...prev,
+                    part: { ...prev.part, [targetMessageID]: fetchedParts },
+                }));
+            } catch {
+                // Ignore transient parent session fetch errors.
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [taskChildPollingStopped, isTaskTool, currentSessionId, currentDirectory, part.messageID]);
 
     const taskSummaryLenRef = React.useRef<number>(taskSummaryEntries.length);
     React.useEffect(() => {

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -585,6 +585,8 @@ async function resyncDirectoryAfterReconnect(
   }
 
   const scopedClient = opencodeClient.getScopedSdkClient(directory)
+  const resyncedChildSessions = new Set<string>()
+
   await Promise.all(candidateSessionIds.map(async (sessionId) => {
     const [sessionResponse, messageResponse] = await Promise.all([
       scopedClient.session.get({ sessionID: sessionId }).catch(() => null),
@@ -600,6 +602,11 @@ async function resyncDirectoryAfterReconnect(
       .map((record) => stripMessageDiffSnapshots(record.info))
       .sort((a, b) => cmp(a.id, b.id))
     const nextMessageIds = new Set(nextMessages.map((message) => message.id))
+
+    // Track child sessions for parent resync
+    if (nextSession.parentID) {
+      resyncedChildSessions.add(nextSession.id)
+    }
 
     store.setState((state: DirectoryStore) => {
       const sessions = [...state.session]
@@ -646,6 +653,53 @@ async function resyncDirectoryAfterReconnect(
   }))
 
   ingestDirectoryStateIntoRoutingIndex(routingIndex, directory, store.getState())
+
+  // Resync parent sessions to update tool parts that reference child sessions
+  // This fixes the issue where child sessions complete during SSE disconnect,
+  // but parent session tool parts don't get the updated tool state/output
+  if (resyncedChildSessions.size > 0) {
+    const parentSessionIds = new Set<string>()
+    for (const childSessionId of resyncedChildSessions) {
+      const childSession = store.getState().session.find((s) => s.id === childSessionId)
+      if (childSession?.parentID) {
+        parentSessionIds.add(childSession.parentID)
+      }
+    }
+
+    await Promise.all(Array.from(parentSessionIds).map(async (parentSessionId) => {
+      const messageResponse = await scopedClient.session.messages({ sessionID: parentSessionId, limit: RECONNECT_MESSAGE_LIMIT }).catch(() => null)
+      const records = messageResponse?.data
+      if (!records) return
+
+      const nextMessages = records
+        .filter((record) => !!record?.info?.id)
+        .map((record) => stripMessageDiffSnapshots(record.info))
+        .sort((a, b) => cmp(a.id, b.id))
+      const nextMessageIds = new Set(nextMessages.map((message) => message.id))
+
+      store.setState((state: DirectoryStore) => {
+        const nextPartState = { ...state.part }
+        const previousMessages = state.message[parentSessionId] ?? []
+        for (const message of previousMessages) {
+          if (!nextMessageIds.has(message.id)) {
+            delete nextPartState[message.id]
+          }
+        }
+        for (const record of records) {
+          const messageId = record?.info?.id
+          if (!messageId) continue
+          nextPartState[messageId] = (record.parts ?? [])
+            .filter((part) => !!part?.id && !RECONNECT_SKIP_PARTS.has(part.type))
+            .sort((a, b) => cmp(a.id, b.id))
+        }
+
+        return {
+          message: { ...state.message, [parentSessionId]: nextMessages },
+          part: nextPartState,
+        }
+      })
+    }))
+  }
 }
 
 function handleEvent(


### PR DESCRIPTION
Fixes #810 (follow-up to #817)

## Problem

Parent session tool parts don't update when child sessions complete:

1. **SSE reconnect**: Child session data is resynced, but parent session tool parts aren't
2. **Normal SSE + coalesced events**: When `message.part.updated` events are coalesced or delayed, tool parts remain stuck showing "waiting for subagent activity"

## Solution

| Scenario | Fix |
|----------|-----|
| SSE reconnect | Sync parent sessions in `resyncDirectoryAfterReconnect` after child sessions are resynced |
| Normal SSE + delayed events | Add `useEffect` in ToolPart that fetches parent session's latest parts when child polling stops, scoped to only the target message containing the task tool part |

### Fix 1: SSE reconnect scenario
Enhanced `resyncDirectoryAfterReconnect` in `sync-context.tsx`:
- Track all child sessions that were resynced
- Find their parent sessions and resync their messages/parts from the server

### Fix 2: Normal SSE flow scenario
Added `useEffect` in `ToolPart.tsx`:
- Triggers when child session polling stops (child completed + 2.5s settle grace elapsed)
- Fetches only the target message (`part.messageID`) containing the task tool part
- Preserves reference identity to avoid unnecessary re-renders
- Won't overwrite in-flight SSE state for other messages in the parent session

## Testing
- ✅ Type check: pass
- ✅ Lint: pass  
- ✅ CI: pass