### PR TITLE
fix: restore variant restoration for OpenCode 1.4.0

### DIFF
--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -655,7 +655,10 @@ const TurnBlock: React.FC<TurnBlockProps> = ({
 
     const turnGroupingContextBase = React.useMemo(() => {
         const userCreatedAt = (turn.userMessage.info.time as { created?: number } | undefined)?.created;
-        const rawVariant = (turn.userMessage.info as { variant?: unknown } | undefined)?.variant;
+        // OpenCode 1.4.0 moved variant from top-level to model.variant on UserMessage.
+        // Prefer the new location, fall back to the legacy one for older servers.
+        const info = turn.userMessage.info as { variant?: unknown; model?: { variant?: unknown } } | undefined;
+        const rawVariant = info?.model?.variant ?? info?.variant;
         const userMessageVariant = typeof rawVariant === 'string' && rawVariant.trim().length > 0
             ? rawVariant
             : undefined;

--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -581,7 +581,7 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     const latestLoadedUserChoice = React.useMemo(() => {
         for (let i = currentSessionMessagesFromSync.length - 1; i >= 0; i -= 1) {
             const message = currentSessionMessagesFromSync[i] as typeof currentSessionMessagesFromSync[number] & {
-                model?: { providerID?: string; modelID?: string };
+                model?: { providerID?: string; modelID?: string; variant?: string };
                 variant?: string;
                 mode?: string;
             };
@@ -598,8 +598,11 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
             const agent = typeof message.agent === 'string' && message.agent.trim().length > 0
                 ? message.agent
                 : (typeof message.mode === 'string' && message.mode.trim().length > 0 ? message.mode : undefined);
-            const variant = typeof message.variant === 'string' && message.variant.trim().length > 0
-                ? message.variant
+            // OpenCode 1.4.0 moved variant from top-level to model.variant.
+            // Prefer the new location, fall back to the legacy one for older servers.
+            const variantCandidate = message.model?.variant ?? message.variant;
+            const variant = typeof variantCandidate === 'string' && variantCandidate.trim().length > 0
+                ? variantCandidate
                 : undefined;
 
             return { id: message.id, agent, providerID, modelID, variant };


### PR DESCRIPTION
## Summary

OpenCode 1.4.0 moved `UserMessage.variant` from the top-level to `UserMessage.model.variant`. OpenChamber still reads the legacy top-level location in three places, so model variant is silently lost on sessions served by OpenCode 1.4.0+:

- The variant selector in the chat input bar resets to default when a session is reopened.
- The variant badge on the assistant message header shows "default" instead of the variant actually used by the user turn.

No crash — the defensive `typeof` checks just fall through and the fallback kicks in. The user just sees their variant selection lost.

## Changes

- `ModelControls.tsx` — `latestLoadedUserChoice` reads `message.model?.variant` first, falls back to `message.variant`
- `MessageList.tsx` — same fallback inside `turnGroupingContextBase` so the assistant message variant badge is rendered correctly
- Extend the local type assertions to include `model.variant`

Both pre-1.4 and 1.4+ OpenCode servers keep working after this change.

## Fixes

#868