### PR TITLE
fix: hide empty archived section and folders

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -188,6 +188,17 @@ export function SessionGroupSection(props: Props): React.ReactNode {
   const shouldKeepFolder = (folderId: string): boolean => {
     const entry = folderMapById.get(folderId);
     if (!entry) return false;
+
+    // For archived buckets, hide folders with no sessions
+    // This prevents showing empty "project root" folders
+    if (group.isArchivedBucket && entry.nodes.length === 0) {
+      // Check if any sub-folders have content
+      const hasContentInChildren = allFoldersForGroupBase
+        .filter(({ folder }) => folder.parentId === folderId)
+        .some((childEntry) => shouldKeepFolder(childEntry.folder.id));
+      return hasContentInChildren;
+    }
+
     if (!hasSessionSearchQuery) return true;
     const folderMatches = entry.folder.name.toLowerCase().includes(normalizedSessionSearchQuery);
     if (folderMatches || entry.nodes.length > 0) return true;
@@ -196,9 +207,7 @@ export function SessionGroupSection(props: Props): React.ReactNode {
       .some(({ folder }) => shouldKeepFolder(folder.id));
   };
 
-  const allFoldersForGroup = hasSessionSearchQuery
-    ? allFoldersForGroupBase.filter(({ folder }) => shouldKeepFolder(folder.id))
-    : allFoldersForGroupBase;
+  const allFoldersForGroup = allFoldersForGroupBase.filter(({ folder }) => shouldKeepFolder(folder.id));
 
   const sessionIdsInFolders = new Set(allFoldersForGroup.flatMap((f) => f.folder.sessionIds));
   const ungroupedSessions = sourceGroupNodes.filter((node) => !sessionIdsInFolders.has(node.session.id));
@@ -325,6 +334,8 @@ export function SessionGroupSection(props: Props): React.ReactNode {
             }}
             onDelete={() => {
               if (group.isArchivedBucket) {
+                // Delete sessions in the folder
+                // Empty folders are auto-hidden by useArchivedAutoFolders
                 sessionEvents.requestDelete({
                   sessions: folderSessionsForDelete,
                   mode: 'session',

--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -184,30 +184,57 @@ export function SessionGroupSection(props: Props): React.ReactNode {
     return { folder, nodes };
   });
 
-  const folderMapById = new Map(allFoldersForGroupBase.map((entry) => [entry.folder.id, entry]));
-  const shouldKeepFolder = (folderId: string): boolean => {
-    const entry = folderMapById.get(folderId);
-    if (!entry) return false;
-
-    // For archived buckets, hide folders with no sessions
-    // This prevents showing empty "project root" folders
-    if (group.isArchivedBucket && entry.nodes.length === 0) {
-      // Check if any sub-folders have content
-      const hasContentInChildren = allFoldersForGroupBase
-        .filter(({ folder }) => folder.parentId === folderId)
-        .some((childEntry) => shouldKeepFolder(childEntry.folder.id));
-      return hasContentInChildren;
+  const allFoldersForGroup = React.useMemo(() => {
+    const folderMapById = new Map(allFoldersForGroupBase.map((entry) => [entry.folder.id, entry]));
+    const childFolderIdsByParentId = new Map<string, string[]>();
+    for (const { folder } of allFoldersForGroupBase) {
+      if (!folder.parentId) continue;
+      const existing = childFolderIdsByParentId.get(folder.parentId);
+      if (existing) {
+        existing.push(folder.id);
+      } else {
+        childFolderIdsByParentId.set(folder.parentId, [folder.id]);
+      }
     }
 
-    if (!hasSessionSearchQuery) return true;
-    const folderMatches = entry.folder.name.toLowerCase().includes(normalizedSessionSearchQuery);
-    if (folderMatches || entry.nodes.length > 0) return true;
-    return allFoldersForGroupBase
-      .filter(({ folder }) => folder.parentId === folderId)
-      .some(({ folder }) => shouldKeepFolder(folder.id));
-  };
+    const keepByFolderId = new Map<string, boolean>();
+    const shouldKeepFolder = (folderId: string): boolean => {
+      const cached = keepByFolderId.get(folderId);
+      if (cached !== undefined) return cached;
 
-  const allFoldersForGroup = allFoldersForGroupBase.filter(({ folder }) => shouldKeepFolder(folder.id));
+      const entry = folderMapById.get(folderId);
+      if (!entry) {
+        keepByFolderId.set(folderId, false);
+        return false;
+      }
+
+      const childFolderIds = childFolderIdsByParentId.get(folderId) ?? [];
+
+      // For archived buckets, hide folders with no sessions unless descendants have content.
+      if (group.isArchivedBucket && entry.nodes.length === 0) {
+        const hasContentInChildren = childFolderIds.some((childId) => shouldKeepFolder(childId));
+        keepByFolderId.set(folderId, hasContentInChildren);
+        return hasContentInChildren;
+      }
+
+      if (!hasSessionSearchQuery) {
+        keepByFolderId.set(folderId, true);
+        return true;
+      }
+
+      const folderMatches = entry.folder.name.toLowerCase().includes(normalizedSessionSearchQuery);
+      if (folderMatches || entry.nodes.length > 0) {
+        keepByFolderId.set(folderId, true);
+        return true;
+      }
+
+      const hasMatchingChildren = childFolderIds.some((childId) => shouldKeepFolder(childId));
+      keepByFolderId.set(folderId, hasMatchingChildren);
+      return hasMatchingChildren;
+    };
+
+    return allFoldersForGroupBase.filter(({ folder }) => shouldKeepFolder(folder.id));
+  }, [allFoldersForGroupBase, group.isArchivedBucket, hasSessionSearchQuery, normalizedSessionSearchQuery]);
 
   const sessionIdsInFolders = new Set(allFoldersForGroup.flatMap((f) => f.folder.sessionIds));
   const ungroupedSessions = sourceGroupNodes.filter((node) => !sessionIdsInFolders.has(node.session.id));

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
@@ -219,18 +219,21 @@ export const useSessionGrouping = (args: Args) => {
         });
       });
 
-      groups.push({
-        id: 'archived',
-        label: 'archived',
-        branch: null,
-        description: 'Archived and unassigned sessions',
-        isMain: false,
-        isArchivedBucket: true,
-        worktree: null,
-        directory: null,
-        folderScopeKey: !args.isVSCode && normalizedProjectRoot ? getArchivedScopeKey(normalizedProjectRoot) : null,
-        sessions: groupedNodes.get(archivedKey) ?? [],
-      });
+      const archivedSessions = groupedNodes.get(archivedKey) ?? [];
+      if (archivedSessions.length > 0) {
+        groups.push({
+          id: 'archived',
+          label: 'archived',
+          branch: null,
+          description: 'Archived and unassigned sessions',
+          isMain: false,
+          isArchivedBucket: true,
+          worktree: null,
+          directory: null,
+          folderScopeKey: !args.isVSCode && normalizedProjectRoot ? getArchivedScopeKey(normalizedProjectRoot) : null,
+          sessions: archivedSessions,
+        });
+      }
 
       return groups;
     },


### PR DESCRIPTION
Closes #865

## Summary

- **Hide archived section when no archived sessions exist** — `useSessionGrouping` now only pushes the archived group into the groups array when there are actual archived sessions to display, preventing an empty archived section from rendering in the sidebar
- **Hide empty folders in archived bucket** — `shouldKeepFolder` in `SessionGroupSection` now filters out folders with zero sessions in the archived bucket (unless they have content in child folders), and this filter always applies instead of only during search

## Problem

Reported in #865: clicking the delete button on empty auto-generated folders in the archived section had no visible effect. The root cause is two-fold:

1. The archived section was **always rendered** even with zero sessions, showing an empty bucket with ghost folders
2. Empty auto-generated folders (e.g. the mysterious "project root" folder) were **never hidden** in the archived bucket, even after all sessions in them were deleted

## UX improvement

These changes make the sidebar feel cleaner and more intuitive:

- **No ghost sections**: When there are no archived sessions, the entire archived section simply doesn't exist — no empty header, no empty folders
- **No zombie folders**: When all sessions are deleted from an auto-generated folder, the folder disappears too — no lingering empty containers that users can't get rid of
- **Consistent behavior**: Folder visibility filtering now always applies (not just during search), so the UI behaves the same whether searching or browsing

## Before → After

| Scenario | Before | After |
|----------|--------|-------|
| No archived sessions | Empty "archived" section visible | Section hidden entirely |
| All sessions deleted from a folder | Empty folder remains, delete button does nothing visible | Folder disappears |
| Folder has sub-folders with content | Sub-folders hidden if parent was empty | Sub-folders kept visible |

## Files changed

| File | Change |
|------|--------|
| `useSessionGrouping.ts` | Conditional push of archived group — only when `archivedSessions.length > 0` |
| `SessionGroupSection.tsx` | `shouldKeepFolder` checks `isArchivedBucket && entry.nodes.length === 0` to hide empty folders; folder filter now always applies |

## Test plan

- [ ] Verify no archived section appears when there are zero archived sessions
- [ ] Verify archived section appears correctly when sessions are archived
- [ ] Verify empty folders are hidden in archived bucket after deleting all sessions in them
- [ ] Verify folders with remaining sessions still display normally
- [ ] Verify search filtering still works correctly for archived folders
- [ ] Verify the scenario from #865: deleting sessions from an auto-generated "project root" folder causes it to disappear