### PR TITLE
fix: provide UI feedback when /compact command is issued

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1462,13 +1462,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                 return;
             }
             else if (commandName === 'compact' && currentSessionId) {
-                const { opencodeClient } = await import('@/lib/opencode/client');
-                const sdk = opencodeClient.getSdkClient();
                 const configState = useConfigStore.getState();
-                await sdk.session.summarize({
-                    sessionID: currentSessionId,
-                    modelID: configState.currentModelId || '',
+                await sessionActions.compactSession({
+                    sessionId: currentSessionId,
                     providerID: configState.currentProviderId || '',
+                    modelID: configState.currentModelId || '',
                 });
                 return;
             }

--- a/packages/ui/src/sync/index.ts
+++ b/packages/ui/src/sync/index.ts
@@ -146,6 +146,7 @@ export {
   shareSession,
   unshareSession,
   optimisticSend,
+  compactSession,
   abortCurrentOperation,
   respondToPermission,
   dismissPermission,

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -336,6 +336,111 @@ export async function optimisticSend(input: {
 }
 
 // ---------------------------------------------------------------------------
+// Compact (summarize session)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compacts a session by calling the server's summarize endpoint.
+ *
+ * Unlike optimisticSend (which passes the client messageID to the server so
+ * both share the same ID), the summarize API has no messageID parameter.
+ * The server generates its own IDs for compaction messages.
+ *
+ * Strategy:
+ * 1. Insert an optimistic user message ("/compact") for instant feedback
+ * 2. Set session to "busy" so the UI shows activity
+ * 3. Call sdk.session.summarize() — the server runs the compaction agent
+ * 4. After the API resolves, remove the optimistic message since the server
+ *    will have already emitted SSE events with the real compaction messages
+ * 5. SSE events (message.updated, message.part.updated, session.idle) will
+ *    deliver the actual compaction result and clear the busy status
+ */
+export async function compactSession(input: {
+  sessionId: string
+  providerID: string
+  modelID: string
+}): Promise<void> {
+  if (!_optimisticAdd || !_optimisticRemove) {
+    throw new Error("Optimistic refs not set — is useSync() mounted?")
+  }
+
+  const store = dirStore()
+  const directory = dir()
+  const messageID = ascendingId("msg")
+  const textPartId = ascendingId("prt")
+
+  const optimisticParts: Part[] = [
+    { id: textPartId, type: "text", text: "/compact" } as Part,
+  ]
+
+  const optimisticMessage = {
+    id: messageID,
+    role: "user" as const,
+    sessionID: input.sessionId,
+    parentID: "",
+    modelID: input.modelID,
+    providerID: input.providerID,
+    system: "",
+    agent: "",
+    model: `${input.providerID}/${input.modelID}`,
+    metadata: {} as Record<string, unknown>,
+    time: { created: Date.now(), completed: 0 },
+  } as unknown as Message
+
+  // Insert optimistic message so user sees "/compact" instantly
+  _optimisticAdd({
+    sessionID: input.sessionId,
+    message: optimisticMessage,
+    parts: optimisticParts,
+  })
+
+  // Set busy status so the UI shows the session is working
+  const current = store.getState()
+  store.setState({
+    session_status: {
+      ...current.session_status,
+      [input.sessionId]: { type: "busy" as const },
+    },
+  })
+
+  try {
+    await sdk().session.summarize({
+      sessionID: input.sessionId,
+      directory,
+      providerID: input.providerID,
+      modelID: input.modelID,
+    })
+
+    // The summarize API returned, meaning the server has processed the
+    // compaction request and SSE events with real messages should be in
+    // flight or already delivered. Remove the optimistic placeholder to
+    // avoid a duplicate user message (optimistic + real server message).
+    _optimisticRemove({
+      sessionID: input.sessionId,
+      messageID,
+    })
+
+    // Note: we do NOT reset session_status to idle here. The compaction
+    // agent may still be running in the background. The session.idle SSE
+    // event will clear the busy status when the agent truly finishes.
+  } catch (error) {
+    // Rollback optimistic message on failure
+    _optimisticRemove({
+      sessionID: input.sessionId,
+      messageID,
+    })
+    const s = store.getState()
+    store.setState({
+      session_status: {
+        ...s.session_status,
+        [input.sessionId]: { type: "idle" as const },
+      },
+    })
+    throw error
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Abort
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Close #840 

## Summary

- Fixes #840 — the `/compact` command appeared to freeze the session with no visual feedback
- Adds `compactSession()` to `session-actions.ts` using the same optimistic message pattern as `optimisticSend()`, but adapted for the summarize API which has no `messageID` parameter

## Problem

When a user ran `/compact`, `ChatInput.tsx` called `sdk.session.summarize()` directly and returned. There was **no optimistic message**, **no busy indicator**, and **no immediate UI feedback**. The session looked stuck until SSE events eventually arrived — sometimes after a long wait, sometimes only visible after restarting.

## Approach

The fix mirrors `optimisticSend()` but accounts for a key difference: the summarize API doesn't accept a `messageID`, so the server generates its own message IDs for compaction messages.

**Strategy:**
1. Insert an optimistic user message (`/compact`) for instant visual feedback
2. Set session status to `busy` so the UI shows activity
3. Call `sdk.session.summarize()` — server runs the compaction agent
4. After the API resolves, **remove the optimistic placeholder** to avoid a duplicate (optimistic + real server message)
5. SSE events (`message.updated`, `message.part.updated`, `session.idle`) deliver the actual compaction result and clear the busy status

**Why not reuse `optimisticSend()` directly?** `optimisticSend` passes the client-generated `messageID` to the server via `promptAsync({ messageID })` so both share the same ID. The summarize API has no such parameter — the server always generates its own IDs. Keeping the optimistic message after the API resolves would cause a visible duplicate user message.

## Files changed

| File | Change |
|------|--------|
| `packages/ui/src/sync/session-actions.ts` | Add `compactSession()` with optimistic message, busy status, and post-resolve cleanup |
| `packages/ui/src/sync/index.ts` | Export `compactSession` |
| `packages/ui/src/components/chat/ChatInput.tsx` | Replace direct `sdk.session.summarize()` call with `sessionActions.compactSession()` |

## Test plan

- [ ] Run `/compact` in a session with enough context — user message appears immediately, busy indicator shows, compaction result appears after completion
- [ ] Run `/compact` when server is unreachable — optimistic message is removed, error is surfaced, session returns to idle
- [ ] Verify no duplicate user messages appear after compaction completes
- [ ] Verify session status returns to idle after compaction agent finishes (via `session.idle` SSE event)