### PR TITLE
Add Kiro as an 'Open in' app option

### DIFF
--- a/packages/ui/src/lib/openInApps.ts
+++ b/packages/ui/src/lib/openInApps.ts
@@ -25,6 +25,7 @@ export const OPEN_IN_APPS: OpenInApp[] = [
   { id: 'windsurf', label: 'Windsurf', appName: 'Windsurf' },
   { id: 'vscodium', label: 'VSCodium', appName: 'VSCodium' },
   { id: 'rustrover', label: 'RustRover', appName: 'RustRover' },
+  { id: 'kiro', label: 'Kiro', appName: 'Kiro' },
   { id: 'antigravity', label: 'Antigravity', appName: 'Antigravity' },
   { id: 'trae', label: 'Trae', appName: 'Trae' },
 ];


### PR DESCRIPTION
## Summary

- Add Kiro to the Open in app dropdown

<img width="425" height="393" alt="Image" src="https://github.com/user-attachments/assets/04d75cbc-6e9e-465e-8106-7ec5980c5a5d" />

## Changes

- packages/ui/src/lib/openInApps.ts — Added { id: 'kiro', label: 'Kiro', appName: 'Kiro' }

## Motivation

Users who use Kiro as their primary IDE should be able to open files directly in Kiro from OpenChamber.

## References

- Issue: openchamber/openchamber#881