### PR TITLE
fix(chat): replace hover bridge with padding to unblock desktop interactions

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -990,7 +990,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                 respectReducedMotion
                             >
                                 <div className={cn('relative flex justify-end', !isMobile ? 'group/user-shell' : undefined)}>
-                                    <div className={cn('max-w-[85%]', showStickyInlineHoverRow ? 'pb-12' : undefined)}>
+                                    <div className={cn('max-w-[85%]', showStickyInlineHoverRow ? 'pb-5' : undefined)}>
                                         <div
                                             style={{
                                                 backgroundColor: 'var(--chat-user-message-bg)',

--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -990,7 +990,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                 respectReducedMotion
                             >
                                 <div className={cn('relative flex justify-end', !isMobile ? 'group/user-shell' : undefined)}>
-                                    <div className="max-w-[85%]">
+                                    <div className={cn('max-w-[85%]', showStickyInlineHoverRow ? 'pb-12' : undefined)}>
                                         <div
                                             style={{
                                                 backgroundColor: 'var(--chat-user-message-bg)',
@@ -1063,8 +1063,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                             />
                                         ) : null}
                                     </div>
-                                    {showStickyInlineHoverRow ? <div aria-hidden="true" className="absolute left-0 right-0 top-full h-11" /> : null}
-                                </div>
+                                 </div>
                             </FadeInOnReveal>
                         )
                     ) : (


### PR DESCRIPTION
## Summary

Fixes a regression from #826 that blocked all pointer interactions with messages below a user message on the Tauri desktop runtime.

## Problem

PR #826 removed `pointer-events-none` from the hover bridge `<div>` to fix hover continuity for short user messages. This worked on web but broke Tauri desktop — the 44px full-width transparent overlay (`absolute left-0 right-0 top-full h-11`) consumed all mouse events in the entire area below the user message, making every message underneath completely unclickable and unselectable.

On web the overlay still intercepted events, but the rendering pipeline happened to route them through differently; on Tauri's webview the overlay consumed everything.


## Fix

Remove the bridge div entirely. Instead, conditionally add `pb-12` to the `max-w-[85%]` message bubble wrapper when `showStickyInlineHoverRow` is active. This extends the bubble container's own padding downward by 48px, creating a continuous hover hit area from the bubble through to the action buttons — without any overlay that could block sibling content.

```
Before (broken on desktop):
 group/user-shell
 ├── max-w-[85%]
 │   └── bubble
 └── bridge div (absolute, full-width, blocks everything below) ← removed

After:
 group/user-shell
 └── max-w-[85%] + pb-12 when sticky hover active
     └── bubble
         └── padding extends hover area downward ✓ no overlay ✓
```

## Why this works

| Property | Bridge div | Padding (`pb-12`) |
|----------|-----------|-------------------|
| Maintains hover path | ✅ (with `pointer-events`) | ✅ (padding is part of the element) |
| Blocks sibling content | ❌ yes — overlay covers next message | ✅ no — padding stays within own box |
| Works on Tauri desktop | ❌ | ✅ |
| Works on web | ✅ (partially) | ✅ |

The padding area is part of `max-w-[85%]` which sits inside `group/user-shell`. Hovering over padding counts as hovering `group/user-shell`, keeping action buttons visible during the bubble-to-button transition.

## Test plan

- [x] Send a short user message (e.g. "OK") → hover bubble → verify revert/fork/copy buttons appear
- [x] Move cursor from bubble to revert button → verify buttons stay visible and clickable
- [x] Click revert button → verify it works
- [x] Verify text selection on messages below works
- [x] Verify clicking links/buttons on messages below works
- [x] Test on both web and Tauri desktop
- [x] Verify mobile layout is unaffected (bridge was never rendered on mobile)

Fixes #826 (follow-up regression)