### PR TITLE
fix(git): restore changes panel visibility and sidebar sync

### DIFF
--- a/packages/ui/src/components/layout/RightSidebarTabs.tsx
+++ b/packages/ui/src/components/layout/RightSidebarTabs.tsx
@@ -4,13 +4,44 @@ import { RiFolder3Line, RiGitBranchLine } from '@remixicon/react';
 import { SortableTabsStrip } from '@/components/ui/sortable-tabs-strip';
 import { GitView } from '@/components/views';
 import { useUIStore } from '@/stores/useUIStore';
+import { useGitStore } from '@/stores/useGitStore';
+import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
+import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
 import { SidebarFilesTree } from './SidebarFilesTree';
 
 type RightTab = 'git' | 'files';
 
+/**
+ * Keeps git status fresh while the right sidebar is open.
+ * Replaces the GitPollingProvider removed in commit b2d5ccb4.
+ * The previous polling ran globally; now we only refresh when the sidebar is open.
+ */
+function useRightSidebarGitSync(directory: string | undefined, isSidebarOpen: boolean) {
+  const { git } = useRuntimeAPIs();
+  const ensureStatus = useGitStore((state) => state.ensureStatus);
+
+  React.useEffect(() => {
+    if (!directory || !git || !isSidebarOpen) return;
+
+    void ensureStatus(directory, git);
+
+    const POLL_INTERVAL = 10_000;
+    const id = setInterval(() => {
+      if (typeof document !== 'undefined' && document.hidden) return;
+      void ensureStatus(directory, git);
+    }, POLL_INTERVAL);
+
+    return () => clearInterval(id);
+  }, [directory, git, isSidebarOpen, ensureStatus]);
+}
+
 export const RightSidebarTabs: React.FC = () => {
   const rightSidebarTab = useUIStore((state) => state.rightSidebarTab);
   const setRightSidebarTab = useUIStore((state) => state.setRightSidebarTab);
+  const isRightSidebarOpen = useUIStore((state) => state.isRightSidebarOpen);
+  const directory = useEffectiveDirectory();
+
+  useRightSidebarGitSync(directory, isRightSidebarOpen);
 
   const tabItems = React.useMemo(() => [
     {

--- a/packages/ui/src/components/views/git/ChangesSection.tsx
+++ b/packages/ui/src/components/views/git/ChangesSection.tsx
@@ -67,10 +67,30 @@ export const ChangesSection: React.FC<ChangesSectionProps> = ({
     enabled: shouldVirtualize,
   });
 
-  const virtualRows = React.useMemo(
-    () => (shouldVirtualize ? rowVirtualizer.getVirtualItems() : []),
-    [rowVirtualizer, shouldVirtualize],
-  );
+  // Force virtualizer to remeasure when the scroll container transitions
+  // from display:none (hidden tab via keep-alive) back to visible layout.
+  // Without this, the virtualizer uses stale zero-height measurements and
+  // renders no rows until the user scrolls.
+  React.useEffect(() => {
+    if (!shouldVirtualize) return;
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      rowVirtualizer.measure();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [shouldVirtualize, rowVirtualizer]);
+
+  // getVirtualItems() must be called on every render, not cached with useMemo.
+  // The virtualizer updates its internal range on measure/scroll, which triggers
+  // a re-render. If we memoize with useMemo([rowVirtualizer, shouldVirtualize]),
+  // the stable rowVirtualizer reference means the cache is never invalidated
+  // after the first empty render, leaving virtualRows permanently empty.
+  const virtualRows = shouldVirtualize
+    ? rowVirtualizer.getVirtualItems()
+    : [];
 
   React.useEffect(() => {
     if (!onVisiblePathsChange) {

--- a/packages/ui/src/components/views/git/ChangesSection.tsx
+++ b/packages/ui/src/components/views/git/ChangesSection.tsx
@@ -83,14 +83,21 @@ export const ChangesSection: React.FC<ChangesSectionProps> = ({
     return () => observer.disconnect();
   }, [shouldVirtualize, rowVirtualizer]);
 
-  // getVirtualItems() must be called on every render, not cached with useMemo.
-  // The virtualizer updates its internal range on measure/scroll, which triggers
-  // a re-render. If we memoize with useMemo([rowVirtualizer, shouldVirtualize]),
-  // the stable rowVirtualizer reference means the cache is never invalidated
-  // after the first empty render, leaving virtualRows permanently empty.
-  const virtualRows = shouldVirtualize
-    ? rowVirtualizer.getVirtualItems()
-    : [];
+  // Compute virtual rows with useMemo. We include totalSize as a dependency so
+  // that when the ResizeObserver calls measure() — which clears the itemSizeCache
+  // and recalculates — the size change invalidates the memo and getVirtualItems()
+  // returns fresh rows. Using useMemo avoids calling getVirtualItems() directly in
+  // the render body, which can trigger maybeNotify() → onChange() → useReducer
+  // dispatch during render (React minified error #185).
+  const totalSize = rowVirtualizer.getTotalSize();
+  const virtualRows = React.useMemo(
+    // totalSize invalidates the memo when the virtualizer recalculates after
+    // measure/scroll, ensuring getVirtualItems() returns up-to-date rows.
+    // Without it, the stable rowVirtualizer ref would never invalidate the memo
+    // and rows would stay empty after measure().
+    () => (shouldVirtualize && totalSize >= 0 ? rowVirtualizer.getVirtualItems() : []),
+    [shouldVirtualize, rowVirtualizer, totalSize],
+  );
 
   React.useEffect(() => {
     if (!onVisiblePathsChange) {


### PR DESCRIPTION
Closes #887

## Summary

- **Fix blank git changes panel**: `ChangesSection.tsx` used `useMemo` to cache `rowVirtualizer.getVirtualItems()`, but `rowVirtualizer` is a stable reference — so the cache was never invalidated after the initial empty render, leaving `virtualRows` permanently `[]`. The original fix removed `useMemo` entirely, but this caused [React error #185](https://react.dev/errors/185) (see below). The updated fix restores `useMemo` with `totalSize` as an invalidation dependency.

- **Restore git status sync in right sidebar**: Commit `b2d5ccb4` removed `GitPollingProvider` without replacement, causing git changes to stop updating when the Files tab was active or on initial load. Added `useRightSidebarGitSync` hook in `RightSidebarTabs` that polls `ensureStatus` every 10s while the sidebar is open (with `document.hidden` skip).

- **Defensive: ResizeObserver on virtualizer**: Added a `ResizeObserver` on the scroll container in `ChangesSection` to force `rowVirtualizer.measure()` on size changes, ensuring recovery from any future display transitions.

## Root Cause

### Original bug: permanently empty `virtualRows`
The `useMemo` caching `rowVirtualizer.getVirtualItems()` with `[rowVirtualizer, shouldVirtualize]` dependencies was the primary bug. Since `useVirtualizer` returns a stable object reference via `useState`, React's `useMemo` never recomputed after the first render where the virtualizer hadn't measured the container yet. This left `virtualRows` as an empty array permanently.

### Follow-up bug: [Minified React error #185](https://react.dev/errors/185)
Removing `useMemo` and calling `getVirtualItems()` directly in the render body caused a new issue. `getVirtualItems()` internally calls `getMeasurements()` → `maybeNotify()`, which uses TanStack's `memo()` utility. When the virtualizer's internal state changes, `maybeNotify` triggers `onChange()` → `rerender()` (a `useReducer` dispatch). Calling this during the render phase produces [React error #185](https://react.dev/errors/185): cannot update a component while rendering a different component.

### Final fix: `useMemo` with `totalSize` dependency
`rowVirtualizer.getTotalSize()` returns a number that changes whenever the virtualizer recalculates (after `measure()`, scroll, etc.). Including it as a `useMemo` dependency ensures the memo is invalidated when the virtualizer has new data, while keeping `getVirtualItems()` inside `useMemo` prevents render-phase state updates.

## Related

- `b2d5ccb4` removed `GitPollingProvider` without replacement, also causing stale git status — fixed in the same PR.

## Test Plan

- [x] Open git panel — changes list renders with 500+ files
- [x] Switch to Files tab and back — changes still visible (polling keeps status fresh)
- [x] Scroll through changes list — virtualizer works correctly
- [x] No React error 185 in console
- [x] `bun run type-check` passes
- [x] `bun run lint` passes