### PR TITLE
fix: remove shell-specific && operators for non-POSIX shell compat

### DIFF
--- a/packages/ui/src/lib/git/integrateWorktreeCommits.ts
+++ b/packages/ui/src/lib/git/integrateWorktreeCommits.ts
@@ -110,10 +110,10 @@ async function ensureLocalBranch(repoRoot: string, candidate: string): Promise<s
   }
 
   const hasLocal = await execCommand(
-    `git show-ref --verify --quiet ${shellQuote(`refs/heads/${raw}`)} && echo ok || echo missing`,
+    `git show-ref --verify --quiet ${shellQuote(`refs/heads/${raw}`)}`,
     repoRoot
   );
-  if (stdoutText(hasLocal) === 'ok') {
+  if (isOk(hasLocal)) {
     return raw;
   }
 
@@ -131,10 +131,10 @@ async function ensureLocalBranch(repoRoot: string, candidate: string): Promise<s
 
   // Try origin/<raw>
   const remoteCheck = await execCommand(
-    `git show-ref --verify --quiet ${shellQuote(`refs/remotes/origin/${raw}`)} && echo ok || echo missing`,
+    `git show-ref --verify --quiet ${shellQuote(`refs/remotes/origin/${raw}`)}`,
     repoRoot
   );
-  if (stdoutText(remoteCheck) === 'ok') {
+  if (isOk(remoteCheck)) {
     await execCommand(`git branch --track ${shellQuote(raw)} ${shellQuote(`origin/${raw}`)}`, repoRoot);
     return raw;
   }
@@ -177,8 +177,14 @@ export async function computeIntegratePlan(args: {
 }
 
 async function createTempWorktree(repoRoot: string, targetBranch: string): Promise<string> {
+  // Use two separate execCommand calls instead of shell-specific && operator
+  // to support non-POSIX shells like Nushell (see #870)
+  const mkdirResult = await execCommand('mkdir -p "$HOME/.config/openchamber/tmp"', repoRoot);
+  if (!isOk(mkdirResult)) {
+    throw new Error(stderrText(mkdirResult) || 'Failed to create temp directory parent');
+  }
   const tmp = await execCommand(
-    'mkdir -p "$HOME/.config/openchamber/tmp" && mktemp -d "$HOME/.config/openchamber/tmp/oc-integrate-XXXXXX"',
+    'mktemp -d "$HOME/.config/openchamber/tmp/oc-integrate-XXXXXX"',
     repoRoot
   );
   const tmpDir = stdoutText(tmp);
@@ -234,8 +240,8 @@ export async function getIntegrateConflictDetails(tmpDir: string): Promise<Integ
 }
 
 export async function isCherryPickInProgress(tmpDir: string): Promise<boolean> {
-  const head = await execCommand('git rev-parse --verify --quiet CHERRY_PICK_HEAD && echo yes || echo no', tmpDir);
-  return stdoutText(head) === 'yes';
+  const head = await execCommand('git rev-parse --verify --quiet CHERRY_PICK_HEAD', tmpDir);
+  return isOk(head);
 }
 
 export async function integrateWorktreeCommits(plan: IntegratePlan): Promise<IntegrateResult> {


### PR DESCRIPTION
## Summary

Closes #870

The "Re-integrate commits" feature fails when the user's default shell is **Nushell** （Non-POSIX shell）, which does not support the `&&` operator. This PR removes all shell-specific `&&` and `||` operators from `execCommand` calls in `integrateWorktreeCommits.ts`, replacing them with TypeScript control flow.

## Changes

| Location | Before | After |
|---|---|---|
| `createTempWorktree` | `mkdir -p ... && mktemp -d ...` | Two separate `execCommand` calls + `isOk()` check |
| `ensureLocalBranch` (local) | `git show-ref ... && echo ok \|\| echo missing` + `stdoutText() === 'ok'` | `git show-ref ...` + `isOk()` |
| `ensureLocalBranch` (remote) | `git show-ref ... && echo ok \|\| echo missing` + `stdoutText() === 'ok'` | `git show-ref ...` + `isOk()` |
| `isCherryPickInProgress` | `git rev-parse ... && echo yes \|\| echo no` + `stdoutText() === 'yes'` | `git rev-parse ...` + `isOk()` |

## Why this works

All replaced patterns relied on POSIX shell `&&`/`||` to coerce git exit codes into text (`echo ok`/`echo missing`). The replacement uses the already-available `isOk()` helper which checks `result.success` (i.e. exit code 0), which is semantically identical:

- `git show-ref --verify --quiet <ref>` exits 0 if ref exists, 1 otherwise ✓
- `git rev-parse --verify --quiet <ref>` exits 0 if ref exists, non-zero otherwise ✓

## Test plan

- [x] Verified `git show-ref --verify --quiet` exit codes match expected behavior
- [x] Verified `git rev-parse --verify --quiet` exit codes match expected behavior
- [x] TypeScript type-check passes
- [ ] Manual test: set shell to Nushell, open OpenChamber, click "Move" on a worktree with commits to re-integrate
- [ ] Manual test: verify re-integrate still works with bash/zsh (regression)