### PR TITLE
fix(sidebar): auto-expand parent node when navigating to subagent session

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -732,6 +732,23 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       });
   }, [addProject, tauriIpcAvailable]);
 
+  // Auto-expand parent session when navigating to a subagent (child) session
+  React.useEffect(() => {
+    if (!currentSessionId) return;
+    const current = sessions.find((s) => s.id === currentSessionId);
+    const parentID = (current as Session & { parentID?: string | null })?.parentID;
+    if (!parentID) return;
+    setExpandedParents((prev) => {
+      if (prev.has(parentID)) return prev;
+      const next = new Set(prev);
+      next.add(parentID);
+      try {
+        safeStorage.setItem(SESSION_EXPANDED_STORAGE_KEY, JSON.stringify(Array.from(next)));
+      } catch { /* ignored */ }
+      return next;
+    });
+  }, [currentSessionId, sessions, safeStorage]);
+
   const toggleParent = React.useCallback((sessionId: string) => {
     setExpandedParents((prev) => {
       const next = new Set(prev);


### PR DESCRIPTION
## Summary

- When navigating to a subagent (child) session, the parent session node in the left sidebar was not automatically expanded, making the child session invisible in the tree hierarchy.
- Added a `useEffect` in `SessionSidebar` that detects when `currentSessionId` points to a session with a `parentID` and automatically adds that `parentID` to `expandedParents`, ensuring the subagent session is visible in the sidebar.
- The expanded state is also persisted to localStorage, surviving page refreshes.

## Problem

When an agent task creates a subagent session and the UI navigates to it, the left sidebar shows no visual change — the parent node stays collapsed, hiding the child session. Combined with the "Active Now" section filtering out subtask sessions, the user has no way to see or navigate to the subagent session from the sidebar.

## Fix

- Auto-expand the parent session node when `currentSessionId` switches to a child session (one with `parentID`)
- Uses the same `expandedParents` mechanism and `SESSION_EXPANDED_STORAGE_KEY` persistence as manual expand/collapse
- No-op if the parent is already expanded (returns `prev` to avoid unnecessary re-renders)

## Test plan

- [ ] Create a session, trigger an agent task that creates a subagent session
- [ ] Verify the parent node in the sidebar automatically expands to reveal the child session
- [ ] Verify the `← Parent` button in ChatContainer still works to navigate back
- [ ] Refresh the page — parent should remain expanded (localStorage persistence)
- [ ] Manually collapse the parent, navigate away, then navigate back to the child session — parent should re-expand