### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/packages/vscode/src/skillsCatalog.ts
+++ b/packages/vscode/src/skillsCatalog.ts
@@ -85,6 +85,13 @@ export const CURATED_SOURCES: CuratedSource[] = [
     defaultSubpath: 'skills',
   },
   {
+    id: 'minimax',
+    label: 'MiniMax',
+    description: 'MiniMax AI tools for text, image, video, speech, and music generation',
+    source: 'MiniMax-AI/cli',
+    defaultSubpath: 'skill',
+  },
+  {
     id: 'clawdhub',
     label: 'ClawdHub',
     description: 'Community skill registry with vector search',


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `CURATED_SOURCES` in `packages/vscode/src/skillsCatalog.ts` so the mmx-cli skill is discoverable out of the box
- Users can install via the Skills Catalog panel — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**7 lines changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- Open the Skills Catalog panel in OpenChamber VS Code extension
- MiniMax source now appears in the catalog
- Browse and install the mmx-cli skill
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal