### PR TITLE
Sort skills within groups

### DIFF
--- a/packages/ui/src/components/sections/skills/SkillsSidebar.tsx
+++ b/packages/ui/src/components/sections/skills/SkillsSidebar.tsx
@@ -192,7 +192,11 @@ export const SkillsSidebar: React.FC<SkillsSidebarProps> = ({ onItemSelect }) =>
     }
     const sortedGroups = Object.keys(groups)
       .sort((a, b) => a.localeCompare(b))
-      .map((name) => ({ name, skills: groups[name] }));
+      .map((name) => ({
+        name,
+        skills: [...groups[name]].sort((a, b) => a.name.localeCompare(b.name)),
+      }));
+    ungrouped.sort((a, b) => a.name.localeCompare(b.name));
     return { sortedGroups, ungrouped };
   }
 


### PR DESCRIPTION
# What

- Sort individual skills alphabetically by name within each group in the Skills sidebar.
- Sort ungrouped skills alphabetically by name in the Skills sidebar.

# Why

The Commands sidebar already sorts its items alphabetically for consistent discoverability.
The Skills sidebar sorted group names but left individual skills in arbitrary filesystem order, creating an inconsistent experience between the two tabs.

# How to test

1. Open the Settings view and navigate to the Skills tab.
2. Verify that skills within each group are listed in alphabetical order by name.
3. Verify that ungrouped skills are also listed alphabetically.
4. Navigate to the Commands tab and confirm both tabs now present items in the same sorted order.