### PR TITLE
fix(sync): deduplicate overlapping delta after coalesced part.updated

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -184,57 +184,30 @@ export function SessionGroupSection(props: Props): React.ReactNode {
     return { folder, nodes };
   });
 
-  const allFoldersForGroup = React.useMemo(() => {
-    const folderMapById = new Map(allFoldersForGroupBase.map((entry) => [entry.folder.id, entry]));
-    const childFolderIdsByParentId = new Map<string, string[]>();
-    for (const { folder } of allFoldersForGroupBase) {
-      if (!folder.parentId) continue;
-      const existing = childFolderIdsByParentId.get(folder.parentId);
-      if (existing) {
-        existing.push(folder.id);
-      } else {
-        childFolderIdsByParentId.set(folder.parentId, [folder.id]);
-      }
+  const folderMapById = new Map(allFoldersForGroupBase.map((entry) => [entry.folder.id, entry]));
+  const shouldKeepFolder = (folderId: string): boolean => {
+    const entry = folderMapById.get(folderId);
+    if (!entry) return false;
+
+    // For archived buckets, hide folders with no sessions
+    // This prevents showing empty "project root" folders
+    if (group.isArchivedBucket && entry.nodes.length === 0) {
+      // Check if any sub-folders have content
+      const hasContentInChildren = allFoldersForGroupBase
+        .filter(({ folder }) => folder.parentId === folderId)
+        .some((childEntry) => shouldKeepFolder(childEntry.folder.id));
+      return hasContentInChildren;
     }
 
-    const keepByFolderId = new Map<string, boolean>();
-    const shouldKeepFolder = (folderId: string): boolean => {
-      const cached = keepByFolderId.get(folderId);
-      if (cached !== undefined) return cached;
+    if (!hasSessionSearchQuery) return true;
+    const folderMatches = entry.folder.name.toLowerCase().includes(normalizedSessionSearchQuery);
+    if (folderMatches || entry.nodes.length > 0) return true;
+    return allFoldersForGroupBase
+      .filter(({ folder }) => folder.parentId === folderId)
+      .some(({ folder }) => shouldKeepFolder(folder.id));
+  };
 
-      const entry = folderMapById.get(folderId);
-      if (!entry) {
-        keepByFolderId.set(folderId, false);
-        return false;
-      }
-
-      const childFolderIds = childFolderIdsByParentId.get(folderId) ?? [];
-
-      // For archived buckets, hide folders with no sessions unless descendants have content.
-      if (group.isArchivedBucket && entry.nodes.length === 0) {
-        const hasContentInChildren = childFolderIds.some((childId) => shouldKeepFolder(childId));
-        keepByFolderId.set(folderId, hasContentInChildren);
-        return hasContentInChildren;
-      }
-
-      if (!hasSessionSearchQuery) {
-        keepByFolderId.set(folderId, true);
-        return true;
-      }
-
-      const folderMatches = entry.folder.name.toLowerCase().includes(normalizedSessionSearchQuery);
-      if (folderMatches || entry.nodes.length > 0) {
-        keepByFolderId.set(folderId, true);
-        return true;
-      }
-
-      const hasMatchingChildren = childFolderIds.some((childId) => shouldKeepFolder(childId));
-      keepByFolderId.set(folderId, hasMatchingChildren);
-      return hasMatchingChildren;
-    };
-
-    return allFoldersForGroupBase.filter(({ folder }) => shouldKeepFolder(folder.id));
-  }, [allFoldersForGroupBase, group.isArchivedBucket, hasSessionSearchQuery, normalizedSessionSearchQuery]);
+  const allFoldersForGroup = allFoldersForGroupBase.filter(({ folder }) => shouldKeepFolder(folder.id));
 
   const sessionIdsInFolders = new Set(allFoldersForGroup.flatMap((f) => f.folder.sessionIds));
   const ungroupedSessions = sourceGroupNodes.filter((node) => !sessionIdsInFolders.has(node.session.id));

--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -184,30 +184,57 @@ export function SessionGroupSection(props: Props): React.ReactNode {
     return { folder, nodes };
   });
 
-  const folderMapById = new Map(allFoldersForGroupBase.map((entry) => [entry.folder.id, entry]));
-  const shouldKeepFolder = (folderId: string): boolean => {
-    const entry = folderMapById.get(folderId);
-    if (!entry) return false;
-
-    // For archived buckets, hide folders with no sessions
-    // This prevents showing empty "project root" folders
-    if (group.isArchivedBucket && entry.nodes.length === 0) {
-      // Check if any sub-folders have content
-      const hasContentInChildren = allFoldersForGroupBase
-        .filter(({ folder }) => folder.parentId === folderId)
-        .some((childEntry) => shouldKeepFolder(childEntry.folder.id));
-      return hasContentInChildren;
+  const allFoldersForGroup = React.useMemo(() => {
+    const folderMapById = new Map(allFoldersForGroupBase.map((entry) => [entry.folder.id, entry]));
+    const childFolderIdsByParentId = new Map<string, string[]>();
+    for (const { folder } of allFoldersForGroupBase) {
+      if (!folder.parentId) continue;
+      const existing = childFolderIdsByParentId.get(folder.parentId);
+      if (existing) {
+        existing.push(folder.id);
+      } else {
+        childFolderIdsByParentId.set(folder.parentId, [folder.id]);
+      }
     }
 
-    if (!hasSessionSearchQuery) return true;
-    const folderMatches = entry.folder.name.toLowerCase().includes(normalizedSessionSearchQuery);
-    if (folderMatches || entry.nodes.length > 0) return true;
-    return allFoldersForGroupBase
-      .filter(({ folder }) => folder.parentId === folderId)
-      .some(({ folder }) => shouldKeepFolder(folder.id));
-  };
+    const keepByFolderId = new Map<string, boolean>();
+    const shouldKeepFolder = (folderId: string): boolean => {
+      const cached = keepByFolderId.get(folderId);
+      if (cached !== undefined) return cached;
 
-  const allFoldersForGroup = allFoldersForGroupBase.filter(({ folder }) => shouldKeepFolder(folder.id));
+      const entry = folderMapById.get(folderId);
+      if (!entry) {
+        keepByFolderId.set(folderId, false);
+        return false;
+      }
+
+      const childFolderIds = childFolderIdsByParentId.get(folderId) ?? [];
+
+      // For archived buckets, hide folders with no sessions unless descendants have content.
+      if (group.isArchivedBucket && entry.nodes.length === 0) {
+        const hasContentInChildren = childFolderIds.some((childId) => shouldKeepFolder(childId));
+        keepByFolderId.set(folderId, hasContentInChildren);
+        return hasContentInChildren;
+      }
+
+      if (!hasSessionSearchQuery) {
+        keepByFolderId.set(folderId, true);
+        return true;
+      }
+
+      const folderMatches = entry.folder.name.toLowerCase().includes(normalizedSessionSearchQuery);
+      if (folderMatches || entry.nodes.length > 0) {
+        keepByFolderId.set(folderId, true);
+        return true;
+      }
+
+      const hasMatchingChildren = childFolderIds.some((childId) => shouldKeepFolder(childId));
+      keepByFolderId.set(folderId, hasMatchingChildren);
+      return hasMatchingChildren;
+    };
+
+    return allFoldersForGroupBase.filter(({ folder }) => shouldKeepFolder(folder.id));
+  }, [allFoldersForGroupBase, group.isArchivedBucket, hasSessionSearchQuery, normalizedSessionSearchQuery]);
 
   const sessionIdsInFolders = new Set(allFoldersForGroup.flatMap((f) => f.folder.sessionIds));
   const ungroupedSessions = sourceGroupNodes.filter((node) => !sessionIdsInFolders.has(node.session.id));

--- a/packages/ui/src/sync/__tests__/event-reducer.test.js
+++ b/packages/ui/src/sync/__tests__/event-reducer.test.js
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'bun:test'
+import { applyDirectoryEvent } from '../event-reducer'
+import { INITIAL_STATE } from '../types'
+
+describe('applyDirectoryEvent', () => {
+  it('does not duplicate overlapping delta text after a newer part.updated replaces an older one', () => {
+    const state = structuredClone(INITIAL_STATE)
+    const messageID = 'msg-1'
+    const partID = 'part-1'
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: partID,
+          type: 'text',
+          messageID,
+          text: 'Fix typo in ToolOutputDialog — ',
+        },
+      },
+    })
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: partID,
+          type: 'text',
+          messageID,
+          text: 'Fix typo in ToolOutputDialog — toolFailedToReadDiagram vs toolFailedReadDiagram • Let me fix it.',
+        },
+      },
+    })
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.delta',
+      properties: {
+        messageID,
+        partID,
+        field: 'text',
+        delta: 'toolFailedToReadDiagram vs toolFailedReadDiagram • Let me fix it.',
+      },
+    })
+
+    expect(state.part[messageID]).toHaveLength(1)
+    expect(state.part[messageID]?.[0]?.text).toBe(
+      'Fix typo in ToolOutputDialog — toolFailedToReadDiagram vs toolFailedReadDiagram • Let me fix it.',
+    )
+  })
+
+  it('appends only the non-overlapping suffix of a streaming delta', () => {
+    const state = structuredClone(INITIAL_STATE)
+    const messageID = 'msg-2'
+    const partID = 'part-2'
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: partID,
+          type: 'text',
+          messageID,
+          text: 'toolFailedToReadDiagram vs toolFailedRead',
+        },
+      },
+    })
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: partID,
+          type: 'text',
+          messageID,
+          text: 'toolFailedToReadDiagram vs toolFailedReadDiagra',
+        },
+      },
+    })
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.delta',
+      properties: {
+        messageID,
+        partID,
+        field: 'text',
+        delta: 'Diagram • Let me fix it.',
+      },
+    })
+
+    expect(state.part[messageID]?.[0]?.text).toBe(
+      'toolFailedToReadDiagram vs toolFailedReadDiagram • Let me fix it.',
+    )
+  })
+
+  it('appends a non-overlapping delta unchanged', () => {
+    const state = structuredClone(INITIAL_STATE)
+    const messageID = 'msg-3'
+    const partID = 'part-3'
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: partID,
+          type: 'text',
+          messageID,
+          text: 'PR comment done — ',
+        },
+      },
+    })
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.delta',
+      properties: {
+        messageID,
+        partID,
+        field: 'text',
+        delta: 'Let me fix it.',
+      },
+    })
+
+    expect(state.part[messageID]?.[0]?.text).toBe('PR comment done — Let me fix it.')
+  })
+
+  it('preserves legitimate repeated output when no updated-to-delta dedupe window is active', () => {
+    const state = structuredClone(INITIAL_STATE)
+    const messageID = 'msg-4'
+    const partID = 'part-4'
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: partID,
+          type: 'text',
+          messageID,
+          text: 'ha',
+        },
+      },
+    })
+
+    applyDirectoryEvent(state, {
+      type: 'message.part.delta',
+      properties: {
+        messageID,
+        partID,
+        field: 'text',
+        delta: 'ha',
+      },
+    })
+
+    expect(state.part[messageID]?.[0]?.text).toBe('haha')
+  })
+})

--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -16,6 +16,39 @@ import { stripSessionDiffSnapshots } from "./sanitize"
 import { syncDebug } from "./debug"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
+const DELTA_OVERLAP_FIELDS = ["text", "output"] as const
+
+type DedupeMetadata = {
+  __dedupeNextDeltaFields?: string[]
+}
+
+function appendNonOverlappingDelta(existingValue: string | undefined, delta: string) {
+  if (!existingValue || delta.length === 0) return (existingValue ?? "") + delta
+  if (existingValue.endsWith(delta)) return existingValue
+
+  const maxOverlap = Math.min(existingValue.length, delta.length)
+  for (let overlap = maxOverlap; overlap > 0; overlap--) {
+    if (existingValue.endsWith(delta.slice(0, overlap))) {
+      return existingValue + delta.slice(overlap)
+    }
+  }
+
+  return existingValue + delta
+}
+
+function getUpdatedDeltaFields(previous: Part, next: Part) {
+  const dedupeFields: string[] = []
+  for (const field of DELTA_OVERLAP_FIELDS) {
+    const previousValue = (previous as Record<string, unknown>)[field]
+    const nextValue = (next as Record<string, unknown>)[field]
+    if (typeof previousValue !== "string" || typeof nextValue !== "string") continue
+    if (previousValue.length === 0 || nextValue.length === 0) continue
+    if (nextValue === previousValue || nextValue.startsWith(previousValue) || previousValue.startsWith(nextValue)) {
+      dedupeFields.push(field)
+    }
+  }
+  return dedupeFields
+}
 
 // ---------------------------------------------------------------------------
 // Global events
@@ -205,7 +238,11 @@ export function applyDirectoryEvent(
       const next = [...parts]
       const result = Binary.search(next, part.id, (p) => p.id)
       if (result.found) {
-        next[result.index] = part
+        const previous = next[result.index]
+        const dedupeFields = getUpdatedDeltaFields(previous, part)
+        next[result.index] = dedupeFields.length > 0
+          ? { ...part, __dedupeNextDeltaFields: dedupeFields } as unknown as Part
+          : part
       } else {
         // Replace optimistic part (no sessionID) with server part of same type.
         // Gate: only scan if the first part lacks sessionID (optimistic parts are
@@ -262,9 +299,15 @@ export function applyDirectoryEvent(
       }
       const existing = parts[result.index] as Record<string, unknown>
       const existingValue = existing[props.field] as string | undefined
+      const dedupeFields = (existing as DedupeMetadata).__dedupeNextDeltaFields ?? []
+      const shouldDedupe = dedupeFields.includes(props.field)
       // Create new Part object + new array so React detects the change
       const next = [...parts]
-      next[result.index] = { ...existing, [props.field]: (existingValue ?? "") + props.delta } as Part
+      next[result.index] = {
+        ...existing,
+        [props.field]: shouldDedupe ? appendNonOverlappingDelta(existingValue, props.delta) : (existingValue ?? "") + props.delta,
+        __dedupeNextDeltaFields: dedupeFields.filter((field) => field !== props.field),
+      } as unknown as Part
       draft.part[props.messageID] = next
       return true
     }


### PR DESCRIPTION
## Summary

When `message.part.updated` coalesces in the event pipeline and a `message.part.delta` for the same part arrives in the same 16ms flush window, the reducer appends the delta verbatim to the already-complete field value, producing duplicated text in tool output and assistant messages.

This is an intermittent regression from #889, which removed the stale-delta skip to fix dropped/incomplete streaming content. That fix was correct, but left a gap: when a coalesced `part.updated` already contains the complete text, an overlapping delta from the same flush window gets appended on top, duplicating the trailing portion.

## Root Cause

Event sequence that triggers the bug:

```
T0: message.part.updated(part-A, text="Hello ")     ← enters queue
T1: message.part.delta(part-A, delta="world")        ← enters queue
T2: message.part.updated(part-A, text="Hello world") ← coalesces with T0
```

After flush, the reducer receives:
1. `part.updated` → sets `text` to `"Hello world"`
2. `part.delta` → appends `"world"` → `text` becomes `"Hello worldworld"` ← **duplicate**

The existing test `event-pipeline.test.js:212-291` already proves deltas are delivered after coalesced updates (intended behavior from #889). The gap is in the reducer's delta handler, which always appends without checking for overlap.

## Fix

Add **targeted overlap reconciliation** scoped to the suspicious `updated → delta` window:

- When `message.part.updated` replaces an existing part with overlapping string content (`text` or `output`), mark the next delta for those fields as dedupe-eligible
- On the next delta, use suffix-overlap detection instead of blind append
- The dedupe marker clears automatically after one delta — normal streaming is untouched

This preserves the #889 guarantee (deltas are never dropped by the pipeline) while preventing the append-side duplication.

## Test Coverage

| Test | Protects |
|------|----------|
| Full overlap: delta already present in updated value → no duplicate | Bug fix |
| Partial overlap: only non-overlapping suffix appended | Variant |
| No overlap: unchanged append behavior | No regression |
| Legitimate repeated output (`ha` + `ha` → `haha`) | No false dedupe |

## Impact Assessment

- **Frequency**: Intermittent. Requires `updated → delta → updated` timing within the same 16ms flush window. More likely during long tool output, subagent tasks, or high-frequency streaming (~60 deltas/sec).
- **User symptom**: Trailing text duplication in tool output or assistant messages. Can make JSON output unparseable.
- **Without fix**: No good live workaround for users; refresh/reconnect eventually self-heals but user may have already copied wrong content.
- **With fix**: Minimal scope — only activates in the suspicious `updated → delta` window. Normal streaming behavior unchanged.

## Files Changed

- `packages/ui/src/sync/event-reducer.ts` — overlap-aware delta merge logic
- `packages/ui/src/sync/__tests__/event-reducer.test.js` — 4 regression tests (new file)

## Test Plan

- [x] `bun test packages/ui/src/sync/__tests__/` — 10 pass, 0 fail
- [x] `bun run type-check:ui` — clean
- [x] Manual testing: bash tool output, file read, subagent task, general streaming — no duplicates, no missing content