### PR TITLE
feat(files): auto-refresh file tree on external changes

### DIFF
--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -907,6 +907,37 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
   }, [loadDirectory, root, showGitignored, showHidden]);
 
+  // Auto-refresh expanded directories when user returns to the tab
+  React.useEffect(() => {
+    if (!files.listDirectory) return;
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden && expandedPaths.length > 0) {
+        for (const dir of expandedPaths) {
+          void refreshDirectory(dir);
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [expandedPaths, files.listDirectory, refreshDirectory]);
+
+  // Poll expanded directories for external changes
+  React.useEffect(() => {
+    if (!files.listDirectory) return;
+    if (expandedPaths.length === 0) return;
+
+    const interval = setInterval(() => {
+      if (document.hidden) return;
+      for (const dir of expandedPaths) {
+        void refreshDirectory(dir);
+      }
+    }, 8000);
+
+    return () => clearInterval(interval);
+  }, [expandedPaths, files.listDirectory, refreshDirectory]);
+
   const handleDialogSubmit = React.useCallback(async (e?: React.FormEvent) => {
     e?.preventDefault();
     if (!dialogData || !activeDialog) return;


### PR DESCRIPTION
## Summary

The file tree (left sidebar explorer) does not refresh when files or directories change externally (e.g., via external editor, CLI tools, or background processes). Users must manually click the refresh button to see changes.

This PR adds two automatic refresh triggers for expanded directories:

- **Focus-based refresh**: When the user returns to OpenChamber from another application (`visibilitychange`), all expanded directories are refreshed.
- **Polling refresh**: Every 8 seconds, expanded directories are polled for changes (skipped when tab is hidden).

## What changed

- `packages/ui/src/components/views/FilesView.tsx` — Added two `useEffect` hooks that call the existing `refreshDirectory()` for all expanded paths.

## Why this approach

- Uses the existing `refreshDirectory()` — no new API endpoints or server changes needed
- Only touches expanded directories — unexpanded ones are not polled
- Conservative 8s interval — tree doesn't need sub-second freshness
- Consistent with PR #827's polling pattern for open file content

## User impact

After this change:
- External file creates/deletes appear in the tree within ~8 seconds
- Switching back to OpenChamber from another app immediately refreshes the tree
- No manual refresh button click needed

## Test plan

- [ ] Open FilesView, expand a directory
- [ ] In terminal: `touch newfile.txt` or `rm existingfile.txt`
- [ ] Verify tree updates within 8 seconds
- [ ] Switch away from tab, make external changes, switch back — verify immediate refresh
- [ ] Verify no console errors
- [ ] `bun run type-check` and `bun run lint` pass