### PR TITLE
fix(vscode): avoid POSIX login-shell opencode detection in code-server

### DIFF
--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -127,6 +127,34 @@ function appendToPath(dir: string) {
   process.env.PATH = [trimmed, ...parts].join(path.delimiter);
 }
 
+function findExecutableInPath(binaryName: string): string | null {
+  const trimmed = (binaryName || '').trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const current = process.env.PATH || '';
+  if (!current) {
+    return null;
+  }
+
+  for (const segment of current.split(path.delimiter)) {
+    const dir = segment.trim();
+    if (!dir) {
+      continue;
+    }
+
+    const candidate = path.join(dir, trimmed);
+    if (isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+let cachedDetectedOpencodeCliPath: string | undefined;
+
 function resolveOpencodeCliPath(): string | null {
   const configured = (() => {
     try {
@@ -185,11 +213,20 @@ function resolveOpencodeCliPath(): string | null {
     }
   }
 
+  if (cachedDetectedOpencodeCliPath) {
+    if (isExecutable(cachedDetectedOpencodeCliPath)) {
+      return cachedDetectedOpencodeCliPath;
+    }
+    cachedDetectedOpencodeCliPath = undefined;
+  }
+
   const home = os.homedir();
   const unixFallbacks = [
     path.join(home, '.opencode', 'bin', 'opencode'),
     path.join(home, '.bun', 'bin', 'opencode'),
     path.join(home, '.local', 'bin', 'opencode'),
+    '/usr/local/bin/opencode',
+    '/opt/homebrew/bin/opencode',
     path.join(home, 'bin', 'opencode'),
   ];
 
@@ -214,9 +251,18 @@ function resolveOpencodeCliPath(): string | null {
     ].filter(Boolean);
   })();
 
+  if (process.platform !== 'win32') {
+    const fromPath = findExecutableInPath('opencode');
+    if (fromPath) {
+      cachedDetectedOpencodeCliPath = fromPath;
+      return fromPath;
+    }
+  }
+
   const fallbacks = process.platform === 'win32' ? winFallbacks : unixFallbacks;
   for (const candidate of fallbacks) {
     if (isExecutable(candidate)) {
+      cachedDetectedOpencodeCliPath = candidate;
       return candidate;
     }
   }
@@ -233,26 +279,8 @@ function resolveOpencodeCliPath(): string | null {
           .map((line) => line.trim())
           .filter(Boolean);
         const found = lines.find((line) => isExecutable(line));
-        if (found) return found;
-      }
-    } catch {
-      // ignore
-    }
-    return null;
-  }
-
-  // Non-Windows: try a login shell PATH lookup.
-  const shells = [process.env.SHELL, '/bin/zsh', '/bin/bash', '/bin/sh'].filter(Boolean) as string[];
-  for (const shell of shells) {
-    if (!isExecutable(shell)) continue;
-    try {
-      const result = spawnSync(shell, ['-lic', 'command -v opencode'], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      if (result.status === 0) {
-        const found = (result.stdout || '').trim().split(/\s+/).pop() || '';
-        if (found && isExecutable(found)) {
+        if (found) {
+          cachedDetectedOpencodeCliPath = found;
           return found;
         }
       }
@@ -377,40 +405,15 @@ function getLoginShellEnvSnapshot(): Record<string, string> | null {
     return cachedLoginShellEnvSnapshot;
   }
 
-  if (process.platform === 'win32') {
-    const windowsSnapshot = getWindowsShellEnvSnapshot();
-    cachedLoginShellEnvSnapshot = windowsSnapshot;
-    return windowsSnapshot;
+  // Avoid interactive POSIX login shells in the extension host.
+  if (process.platform !== 'win32') {
+    cachedLoginShellEnvSnapshot = null;
+    return null;
   }
 
-  const shellCandidates = [process.env.SHELL, '/bin/zsh', '/bin/bash', '/bin/sh'].filter(Boolean) as string[];
-  for (const shellPath of shellCandidates) {
-    if (!isExecutable(shellPath)) {
-      continue;
-    }
-
-    try {
-      const result = spawnSync(shellPath, ['-lic', 'env -0'], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe'],
-        maxBuffer: 10 * 1024 * 1024,
-        windowsHide: true,
-      });
-      if (result.status !== 0) {
-        continue;
-      }
-      const parsed = parseNullSeparatedEnvSnapshot(result.stdout || '');
-      if (parsed) {
-        cachedLoginShellEnvSnapshot = parsed;
-        return parsed;
-      }
-    } catch {
-      continue;
-    }
-  }
-
-  cachedLoginShellEnvSnapshot = null;
-  return null;
+  const windowsSnapshot = getWindowsShellEnvSnapshot();
+  cachedLoginShellEnvSnapshot = windowsSnapshot;
+  return windowsSnapshot;
 }
 
 function mergePathValues(preferred: string, fallback: string): string {


### PR DESCRIPTION
## Summary

This PR removes POSIX interactive login-shell detection from the VS Code extension's OpenCode startup path.

In `code-server`, the previous detection logic could synchronously spawn interactive login shells such as:

- `bash -lic 'command -v opencode'`
- `bash -lic 'env -0'`

In practice, this could leave stopped shell processes behind and cause `code-server` to crash without any useful error logs.

## Root Cause

The issue was not `command -v` itself, but the broader pattern of running synchronous interactive login shells from the extension host on POSIX platforms.

Two code paths shared that risk:

- login-shell environment snapshotting via `env -0`
- login-shell CLI lookup via `command -v opencode`

## What Changed

- Removed the POSIX login-shell fallback from `resolveOpencodeCliPath()`
- Stopped applying login-shell environment snapshots on POSIX
- Added in-process PATH scanning for `opencode`
- Added caching for detected CLI paths
- Expanded POSIX fallback locations to include:
  - `/usr/local/bin/opencode`
  - `/opt/homebrew/bin/opencode`
- Kept the Windows-specific detection flow unchanged

## Why This Is Better

- avoids interactive shell startup during extension activation
- avoids TTY and job-control related hangs in `code-server`
- keeps binary detection deterministic and process-local
- still supports explicit configuration, environment variables, PATH lookup, and common install locations

## Validation

This change was validated against the reported `code-server` behavior:

- the POSIX `bash -lic 'command -v opencode'` path is removed
- the POSIX `bash -lic 'env -0'` path is removed
- binary resolution now relies on explicit config, environment variables, in-process PATH scanning, and common fallback locations

## Scope

This PR intentionally keeps the diff narrow and only changes VS Code-side OpenCode binary/environment detection behavior on POSIX platforms.

Windows behavior is unchanged.
