### PR TITLE
feat(vscode): support multi-root workspaces

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -2824,6 +2824,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
     const footerGapClass = 'gap-x-1.5 gap-y-0';
     const isVSCode = isVSCodeRuntime();
+    const showWorkspaceSelector = isVSCode && projects.length > 1;
     const showDraftTargetSelectors = newSessionDraftOpen && !isVSCode;
 
     const selectedDraftProject = React.useMemo(() => {
@@ -2843,6 +2844,18 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
         return projects[0] ?? null;
     }, [activeProjectId, newSessionDraft?.selectedProjectId, projects]);
+
+    const activeProject = React.useMemo(
+        () => activeProjectId
+            ? projects.find((project) => project.id === activeProjectId) ?? null
+            : (projects[0] ?? null),
+        [activeProjectId, projects],
+    );
+
+    const selectedWorkspaceProject = React.useMemo(
+        () => (newSessionDraftOpen ? selectedDraftProject : activeProject) ?? selectedDraftProject ?? activeProject,
+        [activeProject, newSessionDraftOpen, selectedDraftProject],
+    );
 
     const selectedDraftProjectPath = React.useMemo(
         () => normalizePath(selectedDraftProject?.path ?? null),
@@ -3041,6 +3054,24 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             directoryOverride: directory,
         }, { force: true });
     }, [selectedDraftProject, setNewSessionDraftTarget]);
+
+    const handleWorkspaceProjectChange = React.useCallback((projectId: string) => {
+        const project = projects.find((entry) => entry.id === projectId);
+        if (!project) {
+            return;
+        }
+
+        if (activeProjectId !== projectId) {
+            setActiveProjectIdOnly(projectId);
+        }
+
+        if (newSessionDraftOpen) {
+            setNewSessionDraftTarget({
+                projectId,
+                directoryOverride: project.path,
+            }, { force: true });
+        }
+    }, [activeProjectId, newSessionDraftOpen, projects, setActiveProjectIdOnly, setNewSessionDraftTarget]);
 
     const renderProjectLabelWithIcon = React.useCallback((project: {
         id: string;
@@ -3290,30 +3321,53 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                     showAssistantStatus={false}
                     showTodos
                 />
-                {showDraftTargetSelectors && selectedDraftProject ? (
+                {(showWorkspaceSelector && selectedWorkspaceProject) || (showDraftTargetSelectors && selectedDraftProject) ? (
                     <div className="mb-1.5 flex min-w-0 items-center gap-1.5 px-0.5">
-                        <Select
-                            value={selectedDraftProject.id}
-                            onValueChange={handleDraftProjectChange}
-                        >
-                            <SelectTrigger
-                                size="sm"
-                                className="h-7 min-w-0 w-fit max-w-[42vw] sm:max-w-[18rem] border-transparent bg-transparent px-1.5 hover:bg-transparent data-[state=open]:bg-transparent"
+                        {showWorkspaceSelector && selectedWorkspaceProject ? (
+                            <Select
+                                value={selectedWorkspaceProject.id}
+                                onValueChange={handleWorkspaceProjectChange}
                             >
-                                <SelectValue>
-                                    {renderProjectLabelWithIcon(selectedDraftProject)}
-                                </SelectValue>
-                            </SelectTrigger>
-                            <SelectContent fitContent>
-                                {projects.map((project) => (
-                                    <SelectItem key={project.id} value={project.id} className="max-w-[24rem] truncate">
-                                        {renderProjectLabelWithIcon(project)}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
+                                <SelectTrigger
+                                    size="sm"
+                                    className="h-7 min-w-0 w-fit max-w-[42vw] sm:max-w-[18rem] border-transparent bg-transparent px-1.5 hover:bg-transparent data-[state=open]:bg-transparent"
+                                >
+                                    <SelectValue>
+                                        {renderProjectLabelWithIcon(selectedWorkspaceProject)}
+                                    </SelectValue>
+                                </SelectTrigger>
+                                <SelectContent fitContent>
+                                    {projects.map((project) => (
+                                        <SelectItem key={project.id} value={project.id} className="max-w-[24rem] truncate">
+                                            {renderProjectLabelWithIcon(project)}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        ) : showDraftTargetSelectors && selectedDraftProject ? (
+                            <Select
+                                value={selectedDraftProject.id}
+                                onValueChange={handleDraftProjectChange}
+                            >
+                                <SelectTrigger
+                                    size="sm"
+                                    className="h-7 min-w-0 w-fit max-w-[42vw] sm:max-w-[18rem] border-transparent bg-transparent px-1.5 hover:bg-transparent data-[state=open]:bg-transparent"
+                                >
+                                    <SelectValue>
+                                        {renderProjectLabelWithIcon(selectedDraftProject)}
+                                    </SelectValue>
+                                </SelectTrigger>
+                                <SelectContent fitContent>
+                                    {projects.map((project) => (
+                                        <SelectItem key={project.id} value={project.id} className="max-w-[24rem] truncate">
+                                            {renderProjectLabelWithIcon(project)}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        ) : null}
 
-                        {shouldShowDraftBranchSelector ? (
+                        {showDraftTargetSelectors && shouldShowDraftBranchSelector ? (
                             <Select
                                 value={selectedDraftDirectory ?? draftBranchItems[0]?.value ?? normalizePath(selectedDraftProject.path) ?? ''}
                                 onValueChange={handleDraftDirectoryChange}

--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -6,6 +6,7 @@ import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useViewportStore } from '@/sync/viewport-store';
 import { useSessions, useDirectorySync } from '@/sync/sync-context';
 import { useConfigStore } from '@/stores/useConfigStore';
+import { useProjectsStore } from '@/stores/useProjectsStore';
 import { ContextUsageDisplay } from '@/components/ui/ContextUsageDisplay';
 import { McpDropdown } from '@/components/mcp/McpDropdown';
 import { cn } from '@/lib/utils';
@@ -92,6 +93,8 @@ export const VSCodeLayout: React.FC = () => {
   const expandedSidebarResizePointerIdRef = React.useRef<number | null>(null);
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
   const sessions = useSessions();
+  const projects = useProjectsStore((state) => state.projects);
+  const showOnlyMainWorkspace = projects.length <= 1;
 
   const activeSessionTitle = React.useMemo(() => {
     if (!currentSessionId) {
@@ -404,7 +407,7 @@ export const VSCodeLayout: React.FC = () => {
               mobileVariant
               allowReselect
               hideDirectoryControls
-              showOnlyMainWorkspace
+              showOnlyMainWorkspace={showOnlyMainWorkspace}
             />
             <div
               className={cn(
@@ -450,7 +453,7 @@ export const VSCodeLayout: React.FC = () => {
                 allowReselect
                 onSessionSelected={() => setCurrentView('chat')}
                 hideDirectoryControls
-                showOnlyMainWorkspace
+                showOnlyMainWorkspace={showOnlyMainWorkspace}
               />
             </div>
           </div>

--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -326,6 +326,23 @@ export const VSCodeLayout: React.FC = () => {
   const usesMobileLayout = containerWidth > 0 && containerWidth < MOBILE_WIDTH_THRESHOLD;
   const usesExpandedLayout = containerWidth >= EXPANDED_LAYOUT_THRESHOLD;
 
+  React.useEffect(() => {
+    if (viewMode !== 'sidebar') {
+      return;
+    }
+    if (usesExpandedLayout) {
+      return;
+    }
+    if (currentView !== 'sessions') {
+      return;
+    }
+    if (!newSessionDraftOpen) {
+      return;
+    }
+
+    setCurrentView('chat');
+  }, [currentView, newSessionDraftOpen, usesExpandedLayout, viewMode]);
+
   const clampExpandedSidebarWidth = React.useCallback((value: number) => {
     return Math.min(SESSIONS_SIDEBAR_MAX_WIDTH, Math.max(SESSIONS_SIDEBAR_MIN_WIDTH, value));
   }, []);

--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -103,6 +103,7 @@ export const VSCodeLayout: React.FC = () => {
     return sessions.find((session) => session.id === currentSessionId)?.title || 'Session';
   }, [currentSessionId, sessions]);
   const newSessionDraftOpen = useSessionUIStore((state) => Boolean(state.newSessionDraft?.open));
+  const newSessionDraftRequestKey = useSessionUIStore((state) => state.newSessionDraft?.requestKey ?? 0);
   const isSyncingMessages = useViewportStore((state) => state.isSyncing);
   const hasActiveSessionWork = useDirectorySync((state) => {
     const statuses = state.session_status;
@@ -128,7 +129,7 @@ export const VSCodeLayout: React.FC = () => {
   const [hasInitializedOnce, setHasInitializedOnce] = React.useState<boolean>(() => configInitialized);
   const [isInitializing, setIsInitializing] = React.useState<boolean>(false);
   const lastBootstrapAttemptAt = React.useRef<number>(0);
-  const previousNewSessionDraftOpenRef = React.useRef(newSessionDraftOpen);
+  const previousDraftRequestKeyRef = React.useRef(newSessionDraftRequestKey);
 
   // Navigate to chat when a session is selected
   React.useEffect(() => {
@@ -328,8 +329,8 @@ export const VSCodeLayout: React.FC = () => {
   const usesExpandedLayout = containerWidth >= EXPANDED_LAYOUT_THRESHOLD;
 
   React.useEffect(() => {
-    const draftJustOpened = !previousNewSessionDraftOpenRef.current && newSessionDraftOpen;
-    previousNewSessionDraftOpenRef.current = newSessionDraftOpen;
+    const draftRequestChanged = previousDraftRequestKeyRef.current !== newSessionDraftRequestKey;
+    previousDraftRequestKeyRef.current = newSessionDraftRequestKey;
 
     if (viewMode !== 'sidebar') {
       return;
@@ -340,12 +341,12 @@ export const VSCodeLayout: React.FC = () => {
     if (currentView !== 'sessions') {
       return;
     }
-    if (!draftJustOpened) {
+    if (!newSessionDraftOpen || !draftRequestChanged) {
       return;
     }
 
     setCurrentView('chat');
-  }, [currentView, newSessionDraftOpen, usesExpandedLayout, viewMode]);
+  }, [currentView, newSessionDraftOpen, newSessionDraftRequestKey, usesExpandedLayout, viewMode]);
 
   const clampExpandedSidebarWidth = React.useCallback((value: number) => {
     return Math.min(SESSIONS_SIDEBAR_MAX_WIDTH, Math.max(SESSIONS_SIDEBAR_MIN_WIDTH, value));

--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -128,6 +128,7 @@ export const VSCodeLayout: React.FC = () => {
   const [hasInitializedOnce, setHasInitializedOnce] = React.useState<boolean>(() => configInitialized);
   const [isInitializing, setIsInitializing] = React.useState<boolean>(false);
   const lastBootstrapAttemptAt = React.useRef<number>(0);
+  const previousNewSessionDraftOpenRef = React.useRef(newSessionDraftOpen);
 
   // Navigate to chat when a session is selected
   React.useEffect(() => {
@@ -327,6 +328,9 @@ export const VSCodeLayout: React.FC = () => {
   const usesExpandedLayout = containerWidth >= EXPANDED_LAYOUT_THRESHOLD;
 
   React.useEffect(() => {
+    const draftJustOpened = !previousNewSessionDraftOpenRef.current && newSessionDraftOpen;
+    previousNewSessionDraftOpenRef.current = newSessionDraftOpen;
+
     if (viewMode !== 'sidebar') {
       return;
     }
@@ -336,7 +340,7 @@ export const VSCodeLayout: React.FC = () => {
     if (currentView !== 'sessions') {
       return;
     }
-    if (!newSessionDraftOpen) {
+    if (!draftJustOpened) {
       return;
     }
 

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -253,6 +253,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const setDirectory = useDirectoryStore((state) => state.setDirectory);
 
   const projects = useProjectsStore((state) => state.projects);
+  const includeProjectWorktreesInVSCode = projects.length > 1;
   const activeProjectId = useProjectsStore((state) => state.activeProjectId);
   const addProject = useProjectsStore((state) => state.addProject);
   const removeProject = useProjectsStore((state) => state.removeProject);
@@ -877,12 +878,14 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     archivedSessions,
     normalizedProjects,
     isVSCode,
+    includeWorktreesInVSCode: includeProjectWorktreesInVSCode,
     availableWorktreesByProject,
     cleanupSessions,
   });
 
   const { getSessionsForProject, getArchivedSessionsForProject } = useProjectSessionLists({
     isVSCode,
+    includeWorktreesInVSCode: includeProjectWorktreesInVSCode,
     sessions,
     archivedSessions,
     availableWorktreesByProject,
@@ -894,6 +897,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     archivedSessions,
     availableWorktreesByProject,
     isVSCode,
+    includeWorktreesInVSCode: includeProjectWorktreesInVSCode,
     isSessionsLoading,
     foldersMap,
     createFolder,

--- a/packages/ui/src/components/session/sidebar/hooks/useArchivedAutoFolders.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useArchivedAutoFolders.ts
@@ -19,6 +19,7 @@ type Args = {
   archivedSessions: Session[];
   availableWorktreesByProject: Map<string, WorktreeMetadata[]>;
   isVSCode: boolean;
+  includeWorktreesInVSCode?: boolean;
   isSessionsLoading: boolean;
   foldersMap: Record<string, FolderEntry[]>;
   createFolder: (scopeKey: string, name: string, parentId?: string | null) => FolderEntry;
@@ -28,9 +29,11 @@ type Args = {
 
 const getArchivedSessionsForProject = (
   project: ProjectForArchivedFolders,
-  params: Pick<Args, 'sessions' | 'archivedSessions' | 'availableWorktreesByProject' | 'isVSCode'>,
+  params: Pick<Args, 'sessions' | 'archivedSessions' | 'availableWorktreesByProject' | 'isVSCode' | 'includeWorktreesInVSCode'>,
 ): Session[] => {
-  const worktreesForProject = params.isVSCode ? [] : (params.availableWorktreesByProject.get(project.normalizedPath) ?? []);
+  const worktreesForProject = params.isVSCode && !params.includeWorktreesInVSCode
+    ? []
+    : (params.availableWorktreesByProject.get(project.normalizedPath) ?? []);
   const validDirectories = new Set<string>([
     project.normalizedPath,
     ...worktreesForProject
@@ -64,6 +67,7 @@ export const useArchivedAutoFolders = (args: Args): void => {
     archivedSessions,
     availableWorktreesByProject,
     isVSCode,
+    includeWorktreesInVSCode,
     isSessionsLoading,
     foldersMap,
     createFolder,
@@ -83,6 +87,7 @@ export const useArchivedAutoFolders = (args: Args): void => {
         archivedSessions,
         availableWorktreesByProject,
         isVSCode,
+        includeWorktreesInVSCode,
       });
       const sessionIds = new Set(projectArchivedSessions.map((session) => session.id));
 
@@ -110,6 +115,7 @@ export const useArchivedAutoFolders = (args: Args): void => {
     sessions,
     archivedSessions,
     availableWorktreesByProject,
+    includeWorktreesInVSCode,
     isVSCode,
     isSessionsLoading,
     foldersMap,

--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionLists.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionLists.ts
@@ -6,6 +6,7 @@ type WorktreeMeta = { path: string };
 
 type Args = {
   isVSCode: boolean;
+  includeWorktreesInVSCode?: boolean;
   sessions: Session[];
   archivedSessions: Session[];
   availableWorktreesByProject: Map<string, WorktreeMeta[]>;
@@ -14,6 +15,7 @@ type Args = {
 export const useProjectSessionLists = (args: Args) => {
   const {
     isVSCode,
+    includeWorktreesInVSCode,
     sessions,
     archivedSessions,
     availableWorktreesByProject,
@@ -37,7 +39,9 @@ export const useProjectSessionLists = (args: Args) => {
 
   const getSessionsForProject = React.useCallback(
     (project: { normalizedPath: string }) => {
-      const worktreesForProject = isVSCode ? [] : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
+      const worktreesForProject = isVSCode && !includeWorktreesInVSCode
+        ? []
+        : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
       const directories = [
         project.normalizedPath,
         ...worktreesForProject
@@ -61,12 +65,12 @@ export const useProjectSessionLists = (args: Args) => {
 
       return collected;
     },
-    [availableWorktreesByProject, isVSCode, sessionsByDirectory],
+    [availableWorktreesByProject, includeWorktreesInVSCode, isVSCode, sessionsByDirectory],
   );
 
   const getArchivedSessionsForProject = React.useCallback(
     (project: { normalizedPath: string }) => {
-      if (isVSCode) {
+      if (isVSCode && !includeWorktreesInVSCode) {
         const archived = archivedSessions.filter((session) => {
           const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
           const projectWorktree = normalizePath((session as Session & { project?: { worktree?: string | null } | null }).project?.worktree ?? null);
@@ -93,7 +97,9 @@ export const useProjectSessionLists = (args: Args) => {
         return dedupeSessionsById([...archived, ...unassignedLive]);
       }
 
-      const worktreesForProject = isVSCode ? [] : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
+      const worktreesForProject = isVSCode && !includeWorktreesInVSCode
+        ? []
+        : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
       const validDirectories = new Set<string>([
         project.normalizedPath,
         ...worktreesForProject
@@ -123,7 +129,7 @@ export const useProjectSessionLists = (args: Args) => {
 
       return dedupeSessionsById([...archived, ...unassignedLive]);
     },
-    [archivedSessions, availableWorktreesByProject, isVSCode, sessions],
+    [archivedSessions, availableWorktreesByProject, includeWorktreesInVSCode, isVSCode, sessions],
   );
 
   return {

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionFolderCleanup.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionFolderCleanup.ts
@@ -16,6 +16,7 @@ type Args = {
   archivedSessions: Session[];
   normalizedProjects: NormalizedProject[];
   isVSCode: boolean;
+  includeWorktreesInVSCode?: boolean;
   availableWorktreesByProject: Map<string, WorktreeMeta[]>;
   cleanupSessions: (scopeKey: string, validSessionIds: Set<string>) => void;
 };
@@ -27,6 +28,7 @@ export const useSessionFolderCleanup = (args: Args): void => {
     archivedSessions,
     normalizedProjects,
     isVSCode,
+    includeWorktreesInVSCode,
     availableWorktreesByProject,
     cleanupSessions,
   } = args;
@@ -52,7 +54,9 @@ export const useSessionFolderCleanup = (args: Args): void => {
 
     normalizedProjects.forEach((project) => {
       const scopeKey = getArchivedScopeKey(project.normalizedPath);
-      const worktreesForProject = isVSCode ? [] : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
+      const worktreesForProject = isVSCode && !includeWorktreesInVSCode
+        ? []
+        : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
       const validDirectories = new Set<string>([
         project.normalizedPath,
         ...worktreesForProject
@@ -86,6 +90,7 @@ export const useSessionFolderCleanup = (args: Args): void => {
     archivedSessions,
     availableWorktreesByProject,
     cleanupSessions,
+    includeWorktreesInVSCode,
     isSessionsLoading,
     isVSCode,
     normalizedProjects,

--- a/packages/ui/src/components/session/sidebar/sortableItems.tsx
+++ b/packages/ui/src/components/session/sidebar/sortableItems.tsx
@@ -18,6 +18,7 @@ import {
   RiNodeTree,
   RiPencilAiLine,
 } from '@remixicon/react';
+import { isVSCodeRuntime } from '@/lib/desktop';
 import { cn } from '@/lib/utils';
 import { PROJECT_COLOR_MAP, PROJECT_ICON_MAP, getProjectIconImageUrl } from '@/lib/projectMeta';
 import { useThemeSystem } from '@/contexts/useThemeSystem';
@@ -83,6 +84,7 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
   setOpenSidebarMenuKey,
 }) => {
   const { currentTheme } = useThemeSystem();
+  const isVSCode = React.useMemo(() => isVSCodeRuntime(), []);
   const {
     attributes,
     listeners,
@@ -96,6 +98,17 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
   const suppressNextToggleRef = React.useRef(false);
   const menuInstanceKey = `project:${id}`;
   const isMenuOpen = openSidebarMenuKey === menuInstanceKey;
+  const showNewSessionMenuItem = showCreateButtons && !isRepo && !hideDirectoryControls;
+  const showRenameAction = !isVSCode;
+  const showCloseAction = !isVSCode;
+  const showProjectMenu = showNewSessionMenuItem || showRenameAction || showCloseAction;
+  const togglePaddingClass = isRepo && !hideDirectoryControls
+    ? (showProjectMenu
+      ? (mobileVariant ? 'pr-20' : 'pr-7 group-hover/project:pr-20 group-focus-within/project:pr-20')
+      : (mobileVariant ? 'pr-14' : 'pr-7 group-hover/project:pr-14 group-focus-within/project:pr-14'))
+    : (showProjectMenu
+      ? (mobileVariant ? 'pr-14' : 'pr-7 group-hover/project:pr-14 group-focus-within/project:pr-14')
+      : 'pr-7');
 
   React.useEffect(() => {
     setImageFailed(false);
@@ -165,9 +178,7 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
                       {...listeners}
                       className={cn(
                         'flex-1 min-w-0 flex items-center gap-1.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 rounded-md cursor-grab active:cursor-grabbing transition-[padding]',
-                        isRepo && !hideDirectoryControls
-                          ? (mobileVariant ? 'pr-20' : 'pr-7 group-hover/project:pr-20 group-focus-within/project:pr-20')
-                          : (mobileVariant ? 'pr-14' : 'pr-7 group-hover/project:pr-14 group-focus-within/project:pr-14'),
+                        togglePaddingClass,
                       )}
                     >
                     <span className="inline-flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center">
@@ -234,47 +245,53 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
                   </Tooltip>
                 ) : null}
 
-                <DropdownMenu
-                  open={isMenuOpen}
-                  onOpenChange={handleMenuOpenChange}
-                >
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        className={cn(
-                          'inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 hover:text-foreground',
-                          isMenuOpen
-                            ? 'opacity-100 pointer-events-auto'
-                            : mobileVariant
-                              ? 'opacity-100'
-                              : 'opacity-0 pointer-events-none group-hover/project:opacity-100 group-hover/project:pointer-events-auto group-focus-within/project:opacity-100 group-focus-within/project:pointer-events-auto',
+                {showProjectMenu ? (
+                  <DropdownMenu
+                    open={isMenuOpen}
+                    onOpenChange={handleMenuOpenChange}
+                  >
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className={cn(
+                            'inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 hover:text-foreground',
+                            isMenuOpen
+                              ? 'opacity-100 pointer-events-auto'
+                              : mobileVariant
+                                ? 'opacity-100'
+                                : 'opacity-0 pointer-events-none group-hover/project:opacity-100 group-hover/project:pointer-events-auto group-focus-within/project:opacity-100 group-focus-within/project:pointer-events-auto',
+                          )}
+                          aria-label="Project menu"
+                          onClick={handleMenuTriggerClick}
+                        >
+                          <RiMore2Line className="h-3.5 w-3.5" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="min-w-[180px]">
+                        {showNewSessionMenuItem && (
+                          <DropdownMenuItem onClick={onNewSession}>
+                            <RiAddLine className="mr-1.5 h-4 w-4" />
+                            New Session
+                          </DropdownMenuItem>
                         )}
-                        aria-label="Project menu"
-                        onClick={handleMenuTriggerClick}
-                      >
-                        <RiMore2Line className="h-3.5 w-3.5" />
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="min-w-[180px]">
-                      {showCreateButtons && !isRepo && !hideDirectoryControls && onNewSession && (
-                      <DropdownMenuItem onClick={onNewSession}>
-                        <RiAddLine className="mr-1.5 h-4 w-4" />
-                        New Session
-                      </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem onClick={onRenameStart}>
-                      <RiPencilAiLine className="mr-1.5 h-4 w-4" />
-                      Rename
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={onClose}
-                      className="text-destructive focus:text-destructive"
-                    >
-                      <RiCloseLine className="mr-1.5 h-4 w-4" />
-                      Close Project
-                    </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                        {showRenameAction ? (
+                          <DropdownMenuItem onClick={onRenameStart}>
+                            <RiPencilAiLine className="mr-1.5 h-4 w-4" />
+                            Rename
+                          </DropdownMenuItem>
+                        ) : null}
+                        {showCloseAction ? (
+                          <DropdownMenuItem
+                            onClick={onClose}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <RiCloseLine className="mr-1.5 h-4 w-4" />
+                            Close Project
+                          </DropdownMenuItem>
+                        ) : null}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                ) : null}
               </div>
 
               {showCreateButtons && onNewSession ? (

--- a/packages/ui/src/stores/types/sessionTypes.ts
+++ b/packages/ui/src/stores/types/sessionTypes.ts
@@ -116,6 +116,7 @@ export interface SyntheticContextPart {
 
 export type NewSessionDraftState = {
     open: boolean;
+    requestKey: number;
     selectedProjectId?: string | null;
     directoryOverride: string | null;
     pendingWorktreeRequestId?: string | null;

--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -289,46 +289,156 @@ const persistProjects = (projects: ProjectEntry[], activeProjectId: string | nul
 };
 
 const initialProjects = readPersistedProjects();
-const getVSCodeWorkspaceProject = (): { projects: ProjectEntry[]; activeProjectId: string | null } | null => {
+
+type VSCodeWorkspaceContext = {
+  projects: ProjectEntry[];
+  activeProjectId: string | null;
+  activeProjectPath: string | null;
+};
+
+const isVSCodeWorkspaceRuntime = (): boolean => {
   if (typeof window === 'undefined') {
-    return null;
+    return false;
   }
 
   const runtimeApis = (window as unknown as { __OPENCHAMBER_RUNTIME_APIS__?: { runtime?: { isVSCode?: boolean } } })
     .__OPENCHAMBER_RUNTIME_APIS__;
-  if (!runtimeApis?.runtime?.isVSCode) {
-    return null;
-  }
-
-  const workspaceFolder = (window as unknown as { __VSCODE_CONFIG__?: { workspaceFolder?: unknown } }).__VSCODE_CONFIG__?.workspaceFolder;
-  if (typeof workspaceFolder !== 'string' || workspaceFolder.trim().length === 0) {
-    return null;
-  }
-
-  const normalizedPath = normalizeProjectPath(workspaceFolder);
-  if (!normalizedPath) {
-    return null;
-  }
-
-  const id = `vscode:${normalizedPath}`;
-  const entry: ProjectEntry = {
-    id,
-    path: normalizedPath,
-    label: deriveProjectLabel(normalizedPath),
-    addedAt: Date.now(),
-    lastOpenedAt: Date.now(),
-  };
-
-  if (streamDebugEnabled()) {
-    console.log('[OpenChamber][VSCode][projects] Using workspace fallback project', entry);
-  }
-
-  return { projects: [entry], activeProjectId: id };
+  return Boolean(runtimeApis?.runtime?.isVSCode);
 };
 
-// VS Code runtime should behave as a single-project environment scoped to the workspace folder.
-// Always prefer the workspace project over any persisted multi-project registry.
-const vscodeWorkspace = getVSCodeWorkspaceProject();
+const readVSCodeWorkspaceContext = (): VSCodeWorkspaceContext | null => {
+  if (!isVSCodeWorkspaceRuntime()) {
+    return null;
+  }
+
+  const persistedByPath = new Map(
+    readPersistedProjects().map((project) => [normalizeProjectPath(project.path), project] as const),
+  );
+
+  const config = (window as unknown as {
+    __VSCODE_CONFIG__?: {
+      workspaceFolder?: unknown;
+      activeWorkspaceFolder?: unknown;
+      workspaceFolders?: unknown;
+    };
+  }).__VSCODE_CONFIG__;
+
+  const workspaceFolders = Array.isArray(config?.workspaceFolders)
+    ? config?.workspaceFolders
+    : [];
+
+  const projects: ProjectEntry[] = workspaceFolders.reduce<ProjectEntry[]>((acc, entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return acc;
+      }
+      const candidate = entry as { name?: unknown; path?: unknown };
+      const normalizedPath = typeof candidate.path === 'string'
+        ? normalizeProjectPath(candidate.path)
+        : '';
+      if (!normalizedPath) {
+        return acc;
+      }
+
+      const label = typeof candidate.name === 'string' && candidate.name.trim().length > 0
+        ? candidate.name.trim()
+        : deriveProjectLabel(normalizedPath);
+      const persisted = persistedByPath.get(normalizedPath);
+
+      const id = `vscode:${normalizedPath}`;
+      acc.push({
+        id,
+        path: normalizedPath,
+        label,
+        addedAt: persisted?.addedAt ?? 0,
+        lastOpenedAt: persisted?.lastOpenedAt ?? 0,
+      });
+      return acc;
+    }, []);
+
+  const fallbackWorkspaceFolder = typeof config?.workspaceFolder === 'string'
+    ? normalizeProjectPath(config.workspaceFolder)
+    : '';
+  const activeWorkspaceFolder = typeof config?.activeWorkspaceFolder === 'string'
+    ? normalizeProjectPath(config.activeWorkspaceFolder)
+    : fallbackWorkspaceFolder;
+
+  const normalizedProjects: ProjectEntry[] = projects.length > 0 ? projects : (() => {
+    if (!fallbackWorkspaceFolder) {
+      return [];
+    }
+    return [{
+      id: `vscode:${fallbackWorkspaceFolder}`,
+      path: fallbackWorkspaceFolder,
+      label: deriveProjectLabel(fallbackWorkspaceFolder),
+      addedAt: persistedByPath.get(fallbackWorkspaceFolder)?.addedAt ?? 0,
+      lastOpenedAt: persistedByPath.get(fallbackWorkspaceFolder)?.lastOpenedAt ?? 0,
+    } satisfies ProjectEntry];
+  })();
+
+  if (normalizedProjects.length === 0) {
+    return null;
+  }
+
+  const persistedActiveId = readPersistedActiveProjectId();
+  const activeProject = normalizedProjects.find((project) => project.path === activeWorkspaceFolder)
+    ?? (persistedActiveId ? normalizedProjects.find((project) => project.id === persistedActiveId) : null)
+    ?? normalizedProjects[0]
+    ?? null;
+
+  if (streamDebugEnabled()) {
+    console.log('[OpenChamber][VSCode][projects] Using workspace roots', normalizedProjects);
+  }
+
+  return {
+    projects: normalizedProjects,
+    activeProjectId: activeProject?.id ?? null,
+    activeProjectPath: activeProject?.path ?? null,
+  };
+};
+
+const syncVSCodeRuntimeSelection = (project: ProjectEntry | null) => {
+  if (!project || typeof window === 'undefined') {
+    return;
+  }
+
+  const windowWithConfig = window as typeof window & {
+    __VSCODE_CONFIG__?: {
+      workspaceFolder: string;
+      activeWorkspaceFolder?: string;
+      workspaceFolders?: Array<{ name: string; path: string; index?: number }>;
+      theme: string;
+      connectionStatus: string;
+      cliAvailable?: boolean;
+      panelType?: string;
+      viewMode?: 'sidebar' | 'editor';
+      initialSessionId?: string | null;
+    };
+    __OPENCHAMBER_HOME__?: string;
+  };
+
+  if (windowWithConfig.__VSCODE_CONFIG__) {
+    windowWithConfig.__VSCODE_CONFIG__ = {
+      ...windowWithConfig.__VSCODE_CONFIG__,
+      workspaceFolder: project.path,
+      activeWorkspaceFolder: project.path,
+    };
+  }
+
+  windowWithConfig.__OPENCHAMBER_HOME__ = project.path;
+  window.dispatchEvent(new CustomEvent('openchamber:vscode-workspace-context', {
+    detail: {
+      workspaceFolder: project.path,
+      activeWorkspaceFolder: project.path,
+      workspaceFolders: windowWithConfig.__VSCODE_CONFIG__?.workspaceFolders ?? [],
+    },
+  }));
+  useDirectoryStore.getState().synchronizeHomeDirectory(project.path);
+  opencodeClient.setDirectory(project.path);
+  useDirectoryStore.getState().setDirectory(project.path, { showOverlay: false });
+};
+
+const vscodeWorkspace = readVSCodeWorkspaceContext();
+const isVSCodeWorkspace = Boolean(vscodeWorkspace);
 const effectiveInitialProjects = vscodeWorkspace?.projects ?? initialProjects;
 const initialActiveProjectId = vscodeWorkspace?.activeProjectId
   ?? readPersistedActiveProjectId()
@@ -337,6 +447,8 @@ const initialActiveProjectId = vscodeWorkspace?.activeProjectId
 
 if (vscodeWorkspace) {
   cacheProjects(effectiveInitialProjects, initialActiveProjectId);
+  const initialActiveProject = effectiveInitialProjects.find((project) => project.id === initialActiveProjectId) ?? null;
+  syncVSCodeRuntimeSelection(initialActiveProject);
 }
 
 export const useProjectsStore = create<ProjectsStore>()(
@@ -358,7 +470,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     addProject: (path: string, options?: { label?: string; id?: string }) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return null;
       }
       const { validateProjectPath } = get();
@@ -402,7 +514,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     removeProject: (id: string) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return;
       }
       const current = get();
@@ -428,9 +540,6 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     setActiveProject: (id: string) => {
-      if (vscodeWorkspace) {
-        return;
-      }
       const { projects, activeProjectId } = get();
       if (activeProjectId === id) {
         return;
@@ -446,16 +555,17 @@ export const useProjectsStore = create<ProjectsStore>()(
       );
 
       set({ projects: nextProjects, activeProjectId: id });
-      persistProjects(nextProjects, id);
-
-      opencodeClient.setDirectory(target.path);
-      useDirectoryStore.getState().setDirectory(target.path, { showOverlay: false });
+      if (isVSCodeWorkspace) {
+        cacheProjects(nextProjects, id);
+        syncVSCodeRuntimeSelection(target);
+      } else {
+        persistProjects(nextProjects, id);
+        opencodeClient.setDirectory(target.path);
+        useDirectoryStore.getState().setDirectory(target.path, { showOverlay: false });
+      }
     },
 
     setActiveProjectIdOnly: (id: string) => {
-      if (vscodeWorkspace) {
-        return;
-      }
       const { projects, activeProjectId } = get();
       if (activeProjectId === id) {
         return;
@@ -471,11 +581,16 @@ export const useProjectsStore = create<ProjectsStore>()(
       );
 
       set({ projects: nextProjects, activeProjectId: id });
-      persistProjects(nextProjects, id);
+      if (isVSCodeWorkspace) {
+        cacheProjects(nextProjects, id);
+        syncVSCodeRuntimeSelection(target);
+      } else {
+        persistProjects(nextProjects, id);
+      }
     },
 
     renameProject: (id: string, label: string) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return;
       }
       const trimmed = label.trim();
@@ -492,7 +607,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     updateProjectMeta: (id: string, meta: { label?: string; icon?: string | null; color?: string | null; iconBackground?: string | null }) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return;
       }
       const { projects, activeProjectId } = get();
@@ -515,7 +630,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     uploadProjectIcon: async (id: string, file: File) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return { ok: false, error: 'Custom icons are not supported in this runtime' };
       }
 
@@ -560,7 +675,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     removeProjectIcon: async (id: string) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return { ok: false, error: 'Custom icons are not supported in this runtime' };
       }
 
@@ -589,7 +704,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     discoverProjectIcon: async (id: string, options?: { force?: boolean }) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return { ok: false, error: 'Custom icons are not supported in this runtime' };
       }
 
@@ -630,7 +745,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     reorderProjects: (fromIndex: number, toIndex: number) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return;
       }
       const { projects, activeProjectId } = get();
@@ -653,7 +768,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     synchronizeFromSettings: (settings: DesktopSettings) => {
-      if (vscodeWorkspace) {
+      if (isVSCodeWorkspace) {
         return;
       }
       const incomingProjects = sanitizeProjects(settings.projects ?? []);
@@ -698,5 +813,30 @@ if (typeof window !== 'undefined') {
     if (detail && typeof detail === 'object') {
       useProjectsStore.getState().synchronizeFromSettings(detail);
     }
+  });
+
+  window.addEventListener('openchamber:vscode-workspace-context', () => {
+    const context = readVSCodeWorkspaceContext();
+    if (!context) {
+      return;
+    }
+
+    const current = useProjectsStore.getState();
+    const activeProjectId = context.activeProjectId ?? context.projects[0]?.id ?? null;
+    const projectsChanged = JSON.stringify(current.projects) !== JSON.stringify(context.projects);
+    const activeChanged = current.activeProjectId !== activeProjectId;
+
+    if (!projectsChanged && !activeChanged) {
+      return;
+    }
+
+    useProjectsStore.setState({
+      projects: context.projects,
+      activeProjectId,
+    });
+    cacheProjects(context.projects, activeProjectId);
+
+    const activeProject = context.projects.find((project) => project.id === activeProjectId) ?? null;
+    syncVSCodeRuntimeSelection(activeProject);
   });
 }

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -137,6 +137,7 @@ export type { VoiceStatus, VoiceMode } from "./voice-store"
 
 export type NewSessionDraftState = {
   open: boolean
+  requestKey: number
   selectedProjectId?: string | null
   directoryOverride: string | null
   pendingWorktreeRequestId?: string | null
@@ -360,6 +361,7 @@ const activateConfigForDirectory = async (directory: string | null | undefined):
 
 const DEFAULT_DRAFT: NewSessionDraftState = {
   open: false,
+  requestKey: 0,
   directoryOverride: null,
   parentID: null,
 }
@@ -481,9 +483,10 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
 
     persistDraftTarget({ projectId: selectedProject?.id ?? null, directory })
 
-    set({
+    set((s) => ({
       newSessionDraft: {
         open: true,
+        requestKey: s.newSessionDraft.requestKey + 1,
         selectedProjectId: selectedProject?.id ?? null,
         directoryOverride: directory,
         pendingWorktreeRequestId: options?.pendingWorktreeRequestId ?? null,
@@ -497,7 +500,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       },
       currentSessionId: null,
       error: null,
-    })
+    }))
 
     if (options?.initialPrompt) {
       useInputStore.getState().setPendingInputText(options.initialPrompt)
@@ -510,8 +513,9 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
   // closeNewSessionDraft
   // ---------------------------------------------------------------------------
   closeNewSessionDraft: () => {
-    set({
+    set((s) => ({
       newSessionDraft: {
+        ...s.newSessionDraft,
         open: false,
         selectedProjectId: null,
         directoryOverride: null,
@@ -524,7 +528,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
         syntheticParts: undefined,
         targetFolderId: undefined,
       },
-    })
+    }))
   },
 
   setNewSessionDraftTarget: (target) => {

--- a/packages/vscode/src/AgentManagerPanelProvider.ts
+++ b/packages/vscode/src/AgentManagerPanelProvider.ts
@@ -6,6 +6,7 @@ import { getWebviewShikiThemes } from './shikiThemes';
 import { getWebviewHtml } from './webviewHtml';
 import { openSseProxy } from './sseProxy';
 import { resolveWebviewDevServerUrl } from './webviewDevServer';
+import { getWorkspaceContextPayload } from './workspaceRoots';
 
 export class AgentManagerPanelProvider {
   public static readonly viewType = 'openchamber.agentManager';
@@ -119,6 +120,18 @@ export class AgentManagerPanelProvider {
     // Send to webview if it exists
     this._sendCachedState();
   }
+
+  public updateWorkspaceContext(): void {
+    if (!this._panel) {
+      return;
+    }
+
+    this._panel.webview.postMessage({
+      type: 'command',
+      command: 'vscodeWorkspaceContext',
+      payload: getWorkspaceContextPayload(),
+    });
+  }
   
   private _sendCachedState() {
     if (!this._panel) {
@@ -221,13 +234,15 @@ export class AgentManagerPanelProvider {
   }
 
   private _getHtmlForWebview(webview: vscode.Webview): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
+    const workspaceContext = getWorkspaceContextPayload();
     const cliAvailable = this._openCodeManager?.isCliAvailable() ?? false;
 
     return getWebviewHtml({
       webview,
       extensionUri: this._extensionUri,
-      workspaceFolder,
+      workspaceFolder: workspaceContext.workspaceFolder,
+      activeWorkspaceFolder: workspaceContext.activeWorkspaceFolder,
+      workspaceFolders: workspaceContext.workspaceFolders,
       initialStatus: this._cachedStatus,
       cliAvailable,
       panelType: 'agentManager',

--- a/packages/vscode/src/ChatViewProvider.ts
+++ b/packages/vscode/src/ChatViewProvider.ts
@@ -6,6 +6,7 @@ import { getWebviewShikiThemes } from './shikiThemes';
 import { getWebviewHtml } from './webviewHtml';
 import { openSseProxy } from './sseProxy';
 import { resolveWebviewDevServerUrl } from './webviewDevServer';
+import { getWorkspaceContextPayload } from './workspaceRoots';
 
 export class ChatViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'openchamber.chatView';
@@ -291,6 +292,18 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  public updateWorkspaceContext(): void {
+    if (!this._view) {
+      return;
+    }
+
+    this._view.webview.postMessage({
+      type: 'command',
+      command: 'vscodeWorkspaceContext',
+      payload: getWorkspaceContextPayload(),
+    });
+  }
+
   private _sendCachedState() {
     if (!this._view) {
       return;
@@ -392,7 +405,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   }
 
   private _getHtmlForWebview(webview: vscode.Webview) {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
+    const workspaceContext = getWorkspaceContextPayload();
     // Use cached values which are updated by onStatusChange callback
     const initialStatus = this._cachedStatus;
     const cliAvailable = this._openCodeManager?.isCliAvailable() ?? false;
@@ -400,7 +413,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     return getWebviewHtml({
       webview,
       extensionUri: this._extensionUri,
-      workspaceFolder,
+      workspaceFolder: workspaceContext.workspaceFolder,
+      activeWorkspaceFolder: workspaceContext.activeWorkspaceFolder,
+      workspaceFolders: workspaceContext.workspaceFolders,
       initialStatus,
       cliAvailable,
       devServerUrl: this._webviewDevServerUrl,

--- a/packages/vscode/src/SessionEditorPanelProvider.ts
+++ b/packages/vscode/src/SessionEditorPanelProvider.ts
@@ -6,6 +6,7 @@ import { getWebviewShikiThemes } from './shikiThemes';
 import { getWebviewHtml } from './webviewHtml';
 import { openSseProxy } from './sseProxy';
 import { resolveWebviewDevServerUrl } from './webviewDevServer';
+import { getWorkspaceContextPayload } from './workspaceRoots';
 
 type SessionPanelState = {
   panel: vscode.WebviewPanel;
@@ -148,6 +149,17 @@ export class SessionEditorPanelProvider {
     }
   }
 
+  public updateWorkspaceContext(): void {
+    const payload = getWorkspaceContextPayload();
+    for (const entry of this._panels.values()) {
+      entry.panel.webview.postMessage({
+        type: 'command',
+        command: 'vscodeWorkspaceContext',
+        payload,
+      });
+    }
+  }
+
   private _sendCachedStateToPanel(entry: SessionPanelState) {
     entry.panel.webview.postMessage({
       type: 'connectionStatus',
@@ -257,14 +269,16 @@ export class SessionEditorPanelProvider {
   }
 
   private _getHtmlForWebview(webview: vscode.Webview, sessionId: string | null) {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
+    const workspaceContext = getWorkspaceContextPayload();
     const initialStatus = this._cachedStatus;
     const cliAvailable = this._openCodeManager?.isCliAvailable() ?? false;
 
     return getWebviewHtml({
       webview,
       extensionUri: this._extensionUri,
-      workspaceFolder,
+      workspaceFolder: workspaceContext.workspaceFolder,
+      activeWorkspaceFolder: workspaceContext.activeWorkspaceFolder,
+      workspaceFolders: workspaceContext.workspaceFolders,
       initialStatus,
       cliAvailable,
       panelType: 'chat',

--- a/packages/vscode/src/bridge-config-runtime.ts
+++ b/packages/vscode/src/bridge-config-runtime.ts
@@ -37,6 +37,7 @@ import {
   type SkillsCatalogSourceConfig,
 } from './skillsCatalog';
 import type { BridgeContext, BridgeResponse } from './bridge';
+import { getActiveWorkspaceFolderPath } from './workspaceRoots';
 
 type BridgeMessageInput = {
   id: string;
@@ -58,7 +59,7 @@ type ConfigRuntimeDeps = {
 const resolveWorkingDirectory = (ctx: BridgeContext | undefined, directory?: string): string | undefined => (
   (typeof directory === 'string' && directory.trim())
     ? directory.trim()
-    : (ctx?.manager?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath)
+    : (ctx?.manager?.getWorkingDirectory() || getActiveWorkspaceFolderPath())
 );
 
 const parseSkillsCatalogSources = (settings: Record<string, unknown>): SkillsCatalogSourceConfig[] => {
@@ -425,7 +426,7 @@ export async function handleConfigBridgeMessage(
 
     case 'api:config/skills': {
       const { method, name, body } = (payload || {}) as { method?: string; name?: string; body?: Record<string, unknown> };
-      const workingDirectory = ctx?.manager?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const workingDirectory = ctx?.manager?.getWorkingDirectory() || getActiveWorkspaceFolderPath();
       const normalizedMethod = typeof method === 'string' && method.trim() ? method.trim().toUpperCase() : 'GET';
 
       if (!name && normalizedMethod === 'GET') {
@@ -507,7 +508,7 @@ export async function handleConfigBridgeMessage(
 
     case 'api:config/skills:catalog': {
       const refresh = Boolean((payload as { refresh?: boolean } | undefined)?.refresh);
-      const workingDirectory = ctx?.manager?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const workingDirectory = ctx?.manager?.getWorkingDirectory() || getActiveWorkspaceFolderPath();
       const settings = deps.readSettings(ctx);
       const additionalSources = parseSkillsCatalogSources(settings);
       const installedSkills = (await deps.fetchOpenCodeSkillsFromApi(ctx, workingDirectory)) || undefined;
@@ -535,7 +536,7 @@ export async function handleConfigBridgeMessage(
         conflictDecisions?: Record<string, 'skip' | 'overwrite'>;
       };
 
-      const workingDirectory = ctx?.manager?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const workingDirectory = ctx?.manager?.getWorkingDirectory() || getActiveWorkspaceFolderPath();
 
       const data = await installSkillsFromGit({
         source: String(body.source || ''),
@@ -582,7 +583,7 @@ export async function handleConfigBridgeMessage(
         filePath?: string;
         content?: string;
       };
-      const workingDirectory = ctx?.manager?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const workingDirectory = ctx?.manager?.getWorkingDirectory() || getActiveWorkspaceFolderPath();
 
       const skillName = typeof name === 'string' ? name.trim() : '';
       if (!skillName) {

--- a/packages/vscode/src/bridge-fs-helpers-runtime.ts
+++ b/packages/vscode/src/bridge-fs-helpers-runtime.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { execGit } from './bridge-git-process-runtime';
+import { findWorkspaceFolderForPath, getActiveWorkspaceFolderPath, getWorkspaceFolders } from './workspaceRoots';
 
 const MAX_FILE_ATTACH_SIZE_BYTES = 10 * 1024 * 1024;
 
@@ -114,6 +115,10 @@ const isPathInside = (candidatePath: string, parentPath: string): boolean => {
 
 export const normalizeFsPath = (value: string) => value.replace(/\\/g, '/');
 
+export type WorkspacePathResolution =
+  | { ok: true; resolvedPath: string; workspaceRoot: string | null }
+  | { ok: false; status: number; error: string };
+
 const gitCheckIgnoreNames = async (cwd: string, names: string[]): Promise<Set<string>> => {
   if (names.length === 0) {
     return new Set();
@@ -176,6 +181,62 @@ export const resolveUserPath = (value: string, baseDirectory: string) => {
     return expanded;
   }
   return path.resolve(baseDirectory, expanded);
+};
+
+const getWorkspaceAccessRoots = (fallbackBase?: string | null): string[] => {
+  const roots = getWorkspaceFolders().map((folder) => path.resolve(folder.path));
+  if (roots.length > 0) {
+    return roots;
+  }
+
+  if (fallbackBase && fallbackBase.trim()) {
+    return [path.resolve(fallbackBase)];
+  }
+
+  return [path.resolve(os.homedir())];
+};
+
+const getPreferredWorkspaceRoot = (hintPath?: string | null): string => {
+  const matched = findWorkspaceFolderForPath(hintPath)?.path;
+  if (matched) {
+    return matched;
+  }
+
+  return getActiveWorkspaceFolderPath() || getWorkspaceFolders()[0]?.path || os.homedir();
+};
+
+export const resolveWorkspacePath = (targetPath: string, baseDirectory?: string | null): WorkspacePathResolution => {
+  const trimmed = targetPath.trim();
+  if (!trimmed) {
+    return { ok: false, status: 400, error: 'Path is required' };
+  }
+
+  const expanded = expandTildePath(trimmed);
+  if (!expanded) {
+    return { ok: false, status: 400, error: 'Path is required' };
+  }
+
+  const preferredRoot = getPreferredWorkspaceRoot(baseDirectory);
+  const resolvedPath = path.isAbsolute(expanded)
+    ? path.resolve(expanded)
+    : path.resolve(preferredRoot, expanded);
+
+  const workspaceRoot = findWorkspaceFolderForPath(resolvedPath)?.path ?? null;
+  const accessRoots = getWorkspaceAccessRoots(baseDirectory);
+
+  if (getWorkspaceFolders().length > 0) {
+    if (!workspaceRoot) {
+      return { ok: false, status: 403, error: 'Path is outside of active workspace' };
+    }
+    return { ok: true, resolvedPath, workspaceRoot };
+  }
+
+  const fallbackRoot = accessRoots[0] ?? path.resolve(os.homedir());
+  if (!isPathInside(resolvedPath, fallbackRoot)) {
+    return { ok: false, status: 403, error: 'Path is outside of active workspace' };
+  }
+
+  return { ok: true, resolvedPath, workspaceRoot: fallbackRoot };
 };
 
 export const listDirectoryEntries = async (dirPath: string) => {
@@ -400,10 +461,13 @@ export const searchDirectory = async (
   includeHidden = false,
   respectGitignore = true,
 ) => {
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
+  const workspaceRoot = getPreferredWorkspaceRoot(directory);
   const rootPath = directory
-    ? resolveUserPath(directory, workspaceRoot)
-    : vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
+    ? (() => {
+        const resolution = resolveWorkspacePath(directory, workspaceRoot);
+        return resolution.ok ? resolution.resolvedPath : '';
+      })()
+    : getActiveWorkspaceFolderPath() || getWorkspaceFolders()[0]?.path || '';
   if (!rootPath) return [];
 
   const sanitizedQuery = query?.trim() || '';
@@ -504,7 +568,7 @@ export const fetchModelsMetadata = async () => {
   }
 };
 
-const getFsAccessRoot = (): string => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
+const getFsAccessRoot = (): string => getActiveWorkspaceFolderPath() || getWorkspaceFolders()[0]?.path || os.homedir();
 
 export const getFsMimeType = (filePath: string): string => {
   const ext = path.extname(filePath).toLowerCase();
@@ -537,15 +601,18 @@ export const resolveFileReadPath = async (targetPath: string): Promise<FsReadPat
   }
 
   const baseRoot = getFsAccessRoot();
-  const resolved = resolveUserPath(trimmed, baseRoot);
-  if (!resolved) {
-    return { ok: false, status: 400, error: 'Path is required' };
+  const resolution = resolveWorkspacePath(trimmed, baseRoot);
+  if (!resolution.ok) {
+    return { ok: false, status: resolution.status, error: resolution.error };
   }
+
+  const resolved = resolution.resolvedPath;
+  const allowedRoot = resolution.workspaceRoot || baseRoot;
 
   try {
     const [canonicalPath, canonicalBase] = await Promise.all([
       fs.promises.realpath(resolved),
-      fs.promises.realpath(baseRoot).catch(() => path.resolve(baseRoot)),
+      fs.promises.realpath(allowedRoot).catch(() => path.resolve(allowedRoot)),
     ]);
 
     if (!isPathInside(canonicalPath, canonicalBase)) {

--- a/packages/vscode/src/bridge-fs-runtime.ts
+++ b/packages/vscode/src/bridge-fs-runtime.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import type { BridgeResponse } from './bridge';
+import { getActiveWorkspaceFolderPath, getWorkspaceContextPayload } from './workspaceRoots';
 
 type BridgeMessageInput = {
   id: string;
@@ -38,6 +39,9 @@ type DirectoryEntry = {
 
 type FsDeps = {
   resolveUserPath: (value: string, baseDirectory: string) => string;
+  resolveWorkspacePath: (value: string, baseDirectory?: string | null) =>
+    | { ok: true; resolvedPath: string; workspaceRoot: string | null }
+    | { ok: false; status: number; error: string };
   listDirectoryEntries: (directoryPath: string) => Promise<DirectoryEntry[]>;
   normalizeFsPath: (value: string) => string;
   execGit: (args: string[], cwd: string) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
@@ -61,12 +65,18 @@ export async function handleFsBridgeMessage(
   deps: FsDeps,
 ): Promise<BridgeResponse | null> {
   const { id, type, payload } = message;
+  const getDefaultWorkspaceRoot = () => getActiveWorkspaceFolderPath() || os.homedir();
 
   switch (type) {
     case 'files:list': {
       const { path: dirPath } = payload as { path: string };
-      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-      const resolvedPath = deps.resolveUserPath(dirPath, workspaceRoot);
+      const workspaceRoot = getDefaultWorkspaceRoot();
+      const target = typeof dirPath === 'string' && dirPath.trim() ? dirPath : workspaceRoot;
+      const resolution = deps.resolveWorkspacePath(target, workspaceRoot);
+      if (!resolution.ok) {
+        return { id, type, success: false, error: resolution.error };
+      }
+      const resolvedPath = resolution.resolvedPath;
       const uri = vscode.Uri.file(resolvedPath);
       const entries = await vscode.workspace.fs.readDirectory(uri);
       const result = entries.map(([name, fileType]) => ({
@@ -79,8 +89,16 @@ export async function handleFsBridgeMessage(
 
     case 'files:search': {
       const { query, maxResults = 50 } = payload as { query: string; maxResults?: number };
+      const workspaceRoot = getActiveWorkspaceFolderPath();
+      if (!workspaceRoot) {
+        return { id, type, success: true, data: [] };
+      }
       const pattern = `**/*${query}*`;
-      const files = await vscode.workspace.findFiles(pattern, '**/node_modules/**', maxResults);
+      const files = await vscode.workspace.findFiles(
+        new vscode.RelativePattern(vscode.Uri.file(workspaceRoot), pattern),
+        '**/node_modules/**',
+        maxResults,
+      );
       const results = files.map((file) => ({
         path: file.fsPath,
       }));
@@ -88,8 +106,17 @@ export async function handleFsBridgeMessage(
     }
 
     case 'workspace:folder': {
-      const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
-      return { id, type, success: true, data: { folder } };
+      const context = getWorkspaceContextPayload();
+      return {
+        id,
+        type,
+        success: true,
+        data: {
+          folder: context.workspaceFolder,
+          activeFolder: context.activeWorkspaceFolder,
+          folders: context.workspaceFolders,
+        },
+      };
     }
 
     case 'config:get': {
@@ -100,10 +127,14 @@ export async function handleFsBridgeMessage(
     }
 
     case 'api:fs:list': {
-      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
+      const workspaceRoot = getDefaultWorkspaceRoot();
       const { path: targetPath, respectGitignore } = (payload || {}) as { path?: string; respectGitignore?: boolean };
       const target = targetPath || workspaceRoot;
-      const resolvedPath = deps.resolveUserPath(target, workspaceRoot) || workspaceRoot;
+      const resolution = deps.resolveWorkspacePath(target, workspaceRoot);
+      if (!resolution.ok) {
+        return { id, type, success: false, error: resolution.error };
+      }
+      const resolvedPath = resolution.resolvedPath;
 
       const entries = await deps.listDirectoryEntries(resolvedPath);
       const normalized = deps.normalizeFsPath(resolvedPath);
@@ -150,8 +181,12 @@ export async function handleFsBridgeMessage(
       if (!target) {
         return { id, type, success: false, error: 'Path is required' };
       }
-      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-      const resolvedPath = deps.resolveUserPath(target, workspaceRoot);
+      const workspaceRoot = getDefaultWorkspaceRoot();
+      const resolution = deps.resolveWorkspacePath(target, workspaceRoot);
+      if (!resolution.ok) {
+        return { id, type, success: false, error: resolution.error };
+      }
+      const resolvedPath = resolution.resolvedPath;
       await vscode.workspace.fs.createDirectory(vscode.Uri.file(resolvedPath));
       return { id, type, success: true, data: { success: true, path: deps.normalizeFsPath(resolvedPath) } };
     }
@@ -222,8 +257,12 @@ export async function handleFsBridgeMessage(
         return { id, type, success: false, error: 'Content is required' };
       }
       try {
-        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-        const resolvedPath = deps.resolveUserPath(targetPath, workspaceRoot);
+        const workspaceRoot = getDefaultWorkspaceRoot();
+        const resolution = deps.resolveWorkspacePath(targetPath, workspaceRoot);
+        if (!resolution.ok) {
+          return { id, type, success: false, error: resolution.error };
+        }
+        const resolvedPath = resolution.resolvedPath;
         const uri = vscode.Uri.file(resolvedPath);
         const parentUri = vscode.Uri.file(path.dirname(resolvedPath));
         try {
@@ -245,8 +284,12 @@ export async function handleFsBridgeMessage(
         return { id, type, success: false, error: 'Path is required' };
       }
       try {
-        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-        const resolvedPath = deps.resolveUserPath(targetPath, workspaceRoot);
+        const workspaceRoot = getDefaultWorkspaceRoot();
+        const resolution = deps.resolveWorkspacePath(targetPath, workspaceRoot);
+        if (!resolution.ok) {
+          return { id, type, success: false, error: resolution.error };
+        }
+        const resolvedPath = resolution.resolvedPath;
         const uri = vscode.Uri.file(resolvedPath);
         await vscode.workspace.fs.delete(uri, { recursive: true, useTrash: false });
         return { id, type, success: true, data: { success: true } };
@@ -265,9 +308,17 @@ export async function handleFsBridgeMessage(
         return { id, type, success: false, error: 'newPath is required' };
       }
       try {
-        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-        const resolvedOld = deps.resolveUserPath(oldPath, workspaceRoot);
-        const resolvedNew = deps.resolveUserPath(newPath, workspaceRoot);
+        const workspaceRoot = getDefaultWorkspaceRoot();
+        const oldResolution = deps.resolveWorkspacePath(oldPath, workspaceRoot);
+        if (!oldResolution.ok) {
+          return { id, type, success: false, error: oldResolution.error };
+        }
+        const newResolution = deps.resolveWorkspacePath(newPath, workspaceRoot);
+        if (!newResolution.ok) {
+          return { id, type, success: false, error: newResolution.error };
+        }
+        const resolvedOld = oldResolution.resolvedPath;
+        const resolvedNew = newResolution.resolvedPath;
         const oldUri = vscode.Uri.file(resolvedOld);
         const newUri = vscode.Uri.file(resolvedNew);
         await vscode.workspace.fs.rename(oldUri, newUri, { overwrite: false });
@@ -287,8 +338,12 @@ export async function handleFsBridgeMessage(
         return { id, type, success: false, error: 'Working directory (cwd) is required' };
       }
       try {
-        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-        const resolvedCwd = deps.resolveUserPath(cwd, workspaceRoot);
+        const workspaceRoot = getDefaultWorkspaceRoot();
+        const resolution = deps.resolveWorkspacePath(cwd, workspaceRoot);
+        if (!resolution.ok) {
+          return { id, type, success: false, error: resolution.error };
+        }
+        const resolvedCwd = resolution.resolvedPath;
         const { exec } = await import('child_process');
         const { promisify } = await import('util');
         const execAsync = promisify(exec);
@@ -350,7 +405,8 @@ export async function handleFsBridgeMessage(
 
     case 'api:files/pick': {
       const allowMany = (payload as { allowMany?: boolean })?.allowMany !== false;
-      const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+      const defaultFolder = getActiveWorkspaceFolderPath();
+      const defaultUri = defaultFolder ? vscode.Uri.file(defaultFolder) : undefined;
 
       const picks = await vscode.window.showOpenDialog({
         canSelectFiles: true,
@@ -421,11 +477,12 @@ export async function handleFsBridgeMessage(
       const defaultFileName = typeof rawFileName === 'string' && rawFileName.trim().length > 0
         ? rawFileName.trim()
         : `message-${Date.now()}.png`;
+      const defaultFolder = getActiveWorkspaceFolderPath();
 
       const saveUri = await vscode.window.showSaveDialog({
         saveLabel: 'Save image',
-        defaultUri: vscode.workspace.workspaceFolders?.[0]
-          ? vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, defaultFileName)
+        defaultUri: defaultFolder
+          ? vscode.Uri.joinPath(vscode.Uri.file(defaultFolder), defaultFileName)
           : undefined,
         filters: { Images: ['png'] },
       });

--- a/packages/vscode/src/bridge-settings-runtime.ts
+++ b/packages/vscode/src/bridge-settings-runtime.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { type DiscoveredSkill, type SkillScope, type SkillSource } from './opencodeConfig';
 import type { BridgeContext } from './bridge';
+import { getActiveWorkspaceFolderPath } from './workspaceRoots';
 
 const SETTINGS_KEY = 'openchamber.settings';
 const OPENCHAMBER_SHARED_SETTINGS_PATH = path.join(os.homedir(), '.config', 'openchamber', 'settings.json');
@@ -213,7 +214,7 @@ export const readSettings = (ctx?: BridgeContext): Record<string, unknown> => {
   delete (restStored as Record<string, unknown>).lastDirectory;
   const shared = readSharedSettingsFromDisk();
   const sharedOpencodeBinary = typeof shared.opencodeBinary === 'string' ? shared.opencodeBinary.trim() : '';
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
+  const workspaceFolder = getActiveWorkspaceFolderPath() || '';
   const themeVariant =
     vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Light ||
     vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrastLight

--- a/packages/vscode/src/bridge-system-runtime.ts
+++ b/packages/vscode/src/bridge-system-runtime.ts
@@ -8,6 +8,7 @@ import { getProviderAuth, removeProviderAuth } from './opencodeAuth';
 import { fetchQuotaForProvider, listConfiguredQuotaProviders } from './quotaProviders';
 import { getSessionActivitySnapshot } from './sessionActivityWatcher';
 import type { BridgeContext, BridgeResponse } from './bridge';
+import { getActiveWorkspaceFolderPath } from './workspaceRoots';
 
 type BridgeMessageInput = {
   id: string;
@@ -253,7 +254,7 @@ export async function handleSystemBridgeMessage(
         return { id, type, success: false, error: 'Path is required' };
       }
       const baseDirectory =
-        ctx?.manager?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
+        ctx?.manager?.getWorkingDirectory() || getActiveWorkspaceFolderPath() || os.homedir();
       const resolvedPath = deps.resolveUserPath(target, baseDirectory);
       const result = await ctx?.manager?.setWorkingDirectory(resolvedPath);
       if (!result) {

--- a/packages/vscode/src/bridge.ts
+++ b/packages/vscode/src/bridge.ts
@@ -20,6 +20,7 @@ import {
   parseDroppedFileReference,
   readUriAsAttachment,
   resolveUserPath,
+  resolveWorkspacePath,
   listDirectoryEntries,
   normalizeFsPath,
   searchDirectory,
@@ -79,6 +80,7 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
       { id, type, payload },
       {
         resolveUserPath,
+        resolveWorkspacePath,
         listDirectoryEntries,
         normalizeFsPath,
         execGit,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -4,6 +4,7 @@ import { AgentManagerPanelProvider } from './AgentManagerPanelProvider';
 import { SessionEditorPanelProvider } from './SessionEditorPanelProvider';
 import { createOpenCodeManager, type OpenCodeManager } from './opencode';
 import { startGlobalEventWatcher, stopGlobalEventWatcher, setChatViewProvider } from './sessionActivityWatcher';
+import { getWorkspaceContextPayload } from './workspaceRoots';
 
 let chatViewProvider: ChatViewProvider | undefined;
 let agentManagerProvider: AgentManagerPanelProvider | undefined;
@@ -165,6 +166,24 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('openchamber.internal.settingsSynced', (settings: unknown) => {
       chatViewProvider?.notifySettingsSynced(settings);
       sessionEditorProvider?.notifySettingsSynced(settings);
+    })
+  );
+
+  const broadcastWorkspaceContext = () => {
+    chatViewProvider?.updateWorkspaceContext();
+    agentManagerProvider?.updateWorkspaceContext();
+    sessionEditorProvider?.updateWorkspaceContext();
+  };
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      broadcastWorkspaceContext();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      broadcastWorkspaceContext();
     })
   );
 
@@ -410,7 +429,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
       const extensionVersion = String(context.extension?.packageJSON?.version || '');
       const workspaceFolders = (vscode.workspace.workspaceFolders || []).map((folder) => folder.uri.fsPath);
-      const primaryWorkspace = workspaceFolders[0] || '';
+      const primaryWorkspace = getWorkspaceContextPayload().activeWorkspaceFolder || workspaceFolders[0] || '';
 
       const debug = openCodeManager?.getDebugInfo();
       const resolvedApiUrl = openCodeManager?.getApiUrl();

--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -7,6 +7,7 @@ import { execSync } from 'child_process';
 import { spawnSync } from 'child_process';
 import { spawn } from 'child_process';
 import { randomBytes } from 'crypto';
+import { getWorkspaceFallbackPath } from './workspaceRoots';
 
 const READY_CHECK_TIMEOUT_MS = 30000;
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
@@ -629,7 +630,7 @@ export function createOpenCodeManager(_context: vscode.ExtensionContext): OpenCo
   const normalizeWindowsDriveLetter = (p: string): string =>
     p.replace(/^([a-z]):/, (_, letter: string) => letter.toUpperCase() + ':');
   const workspaceDirectory = (): string =>
-    normalizeWindowsDriveLetter(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir());
+    normalizeWindowsDriveLetter(getWorkspaceFallbackPath() || os.homedir());
   let workingDirectory: string = workspaceDirectory();
   let startCount = 0;
   let restartCount = 0;
@@ -937,9 +938,7 @@ export function createOpenCodeManager(_context: vscode.ExtensionContext): OpenCo
   }
 
   async function setWorkingDirectory(newPath: string): Promise<{ success: boolean; restarted: boolean; path: string }> {
-    void newPath;
-    const workspacePath = workspaceDirectory();
-    const nextDirectory = workspacePath;
+    const nextDirectory = normalizeWindowsDriveLetter((newPath || '').trim()) || workspaceDirectory();
 
     if (workingDirectory === nextDirectory) {
       return { success: true, restarted: false, path: nextDirectory };

--- a/packages/vscode/src/webviewHtml.ts
+++ b/packages/vscode/src/webviewHtml.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { getThemeKindName } from './theme';
 import type { ConnectionStatus } from './opencode';
+import type { WorkspaceFolderInfo } from './workspaceRoots';
 
 export type PanelType = 'chat' | 'agentManager';
 
@@ -8,6 +9,8 @@ export interface WebviewHtmlOptions {
   webview: vscode.Webview;
   extensionUri: vscode.Uri;
   workspaceFolder: string;
+  workspaceFolders?: WorkspaceFolderInfo[];
+  activeWorkspaceFolder?: string;
   initialStatus: ConnectionStatus;
   cliAvailable: boolean;
   panelType?: PanelType;
@@ -44,6 +47,8 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
     webview,
     extensionUri,
     workspaceFolder,
+    workspaceFolders = [],
+    activeWorkspaceFolder = workspaceFolder,
     initialStatus,
     cliAvailable,
     panelType = 'chat',
@@ -63,6 +68,11 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
   const fontSrc = uniqueTokens([webview.cspSource, 'data:', devServerOrigin]);
 
   const themeKind = getThemeKindName(vscode.window.activeColorTheme.kind);
+  const serializedWorkspaceFolders = JSON.stringify(workspaceFolders)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
+  const escapedWorkspaceFolder = workspaceFolder.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const escapedActiveWorkspaceFolder = activeWorkspaceFolder.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
   // Use VS Code CSS variables for proper theme integration
   // These variables are automatically provided by VS Code to webviews
@@ -162,7 +172,9 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
     window.process = window.process || { env: { NODE_ENV: 'production' }, platform: '', version: '', browser: true };
 
     window.__VSCODE_CONFIG__ = {
-      workspaceFolder: "${workspaceFolder.replace(/\\/g, '\\\\')}",
+      workspaceFolder: "${escapedWorkspaceFolder}",
+      activeWorkspaceFolder: "${escapedActiveWorkspaceFolder}",
+      workspaceFolders: ${serializedWorkspaceFolders},
       theme: "${themeKind}",
       connectionStatus: "${initialStatus}",
       cliAvailable: ${cliAvailable},
@@ -170,7 +182,7 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
       viewMode: "${viewMode}",
       initialSessionId: ${initialSessionId ? `"${initialSessionId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"` : 'null'},
     };
-    window.__OPENCHAMBER_HOME__ = "${workspaceFolder.replace(/\\/g, '\\\\')}";
+    window.__OPENCHAMBER_HOME__ = "${escapedActiveWorkspaceFolder}";
     
     // Handle connection status updates to update loading screen
     window.addEventListener('message', function(event) {

--- a/packages/vscode/src/workspaceRoots.ts
+++ b/packages/vscode/src/workspaceRoots.ts
@@ -1,0 +1,97 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export type WorkspaceFolderInfo = {
+  name: string;
+  path: string;
+  index: number;
+};
+
+export type WorkspaceContextPayload = {
+  workspaceFolder: string;
+  activeWorkspaceFolder: string;
+  workspaceFolders: WorkspaceFolderInfo[];
+};
+
+const normalizeWorkspacePath = (value: string): string => {
+  const normalized = value.replace(/\\/g, '/');
+  if (normalized === '/') {
+    return '/';
+  }
+  return normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized;
+};
+
+const toWorkspaceFolderInfo = (folder: vscode.WorkspaceFolder): WorkspaceFolderInfo => {
+  return {
+    name: folder.name,
+    path: normalizeWorkspacePath(folder.uri.fsPath),
+    index: vscode.workspace.workspaceFolders?.findIndex((entry) => entry.uri.toString() === folder.uri.toString()) ?? 0,
+  };
+};
+
+export const getWorkspaceFolders = (): WorkspaceFolderInfo[] => {
+  return (vscode.workspace.workspaceFolders || []).map(toWorkspaceFolderInfo);
+};
+
+export const getWorkspaceFolderForUri = (uri: vscode.Uri | undefined): WorkspaceFolderInfo | null => {
+  if (!uri) {
+    return null;
+  }
+
+  const folder = vscode.workspace.getWorkspaceFolder(uri);
+  return folder ? toWorkspaceFolderInfo(folder) : null;
+};
+
+export const findWorkspaceFolderForPath = (targetPath?: string | null): WorkspaceFolderInfo | null => {
+  if (!targetPath || !targetPath.trim()) {
+    return null;
+  }
+
+  const normalizedTarget = normalizeWorkspacePath(path.resolve(targetPath));
+  const folders = getWorkspaceFolders();
+  let matched: WorkspaceFolderInfo | null = null;
+
+  for (const folder of folders) {
+    const folderPath = normalizeWorkspacePath(path.resolve(folder.path));
+    if (
+      normalizedTarget === folderPath
+      || normalizedTarget.startsWith(`${folderPath}/`)
+    ) {
+      if (!matched || folderPath.length > matched.path.length) {
+        matched = folder;
+      }
+    }
+  }
+
+  return matched;
+};
+
+export const getActiveWorkspaceFolder = (): WorkspaceFolderInfo | null => {
+  const activeEditorFolder = getWorkspaceFolderForUri(vscode.window.activeTextEditor?.document.uri);
+  if (activeEditorFolder) {
+    return activeEditorFolder;
+  }
+
+  const folders = getWorkspaceFolders();
+  return folders[0] ?? null;
+};
+
+export const getActiveWorkspaceFolderPath = (): string => {
+  return getActiveWorkspaceFolder()?.path || '';
+};
+
+export const getWorkspaceContextPayload = (): WorkspaceContextPayload => {
+  const workspaceFolders = getWorkspaceFolders();
+  const activeWorkspaceFolder = getActiveWorkspaceFolder()?.path || workspaceFolders[0]?.path || '';
+
+  return {
+    workspaceFolder: activeWorkspaceFolder,
+    activeWorkspaceFolder,
+    workspaceFolders,
+  };
+};
+
+export const getWorkspaceFallbackPath = (): string => {
+  return getActiveWorkspaceFolderPath() || getWorkspaceFolders()[0]?.path || normalizeWorkspacePath(os.homedir());
+};

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -20,6 +20,8 @@ declare global {
     __VSCODE_CONFIG__?: {
       apiUrl?: string;
       workspaceFolder: string;
+      activeWorkspaceFolder?: string;
+      workspaceFolders?: Array<{ name: string; path: string; index?: number }>;
       theme: string;
       connectionStatus: string;
       cliAvailable?: boolean;
@@ -47,6 +49,89 @@ try {
 }
 
 window.__OPENCHAMBER_RUNTIME_APIS__ = createVSCodeAPIs();
+
+const normalizeWorkspacePath = (value: string) => {
+  const normalized = value
+    .replace(/\\/g, '/')
+    .replace(/^([a-z]):\//, (_, letter: string) => `${letter.toUpperCase()}:/`)
+    .replace(/^\/([a-z]):\//, (_, letter: string) => `/${letter.toUpperCase()}:/`);
+  if (normalized === '/') {
+    return '/';
+  }
+  return normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized;
+};
+
+const normalizeWorkspaceFolders = (
+  folders: unknown,
+): Array<{ name: string; path: string; index: number }> => {
+  if (!Array.isArray(folders)) {
+    return [];
+  }
+
+  return folders
+    .map((entry, index) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const candidate = entry as { name?: unknown; path?: unknown; index?: unknown };
+      const pathValue = typeof candidate.path === 'string' ? normalizeWorkspacePath(candidate.path) : '';
+      if (!pathValue) {
+        return null;
+      }
+      const nameValue = typeof candidate.name === 'string' && candidate.name.trim().length > 0
+        ? candidate.name.trim()
+        : pathValue.split('/').filter(Boolean).pop() || pathValue;
+      const indexValue = typeof candidate.index === 'number' && Number.isFinite(candidate.index)
+        ? candidate.index
+        : index;
+      return {
+        name: nameValue,
+        path: pathValue,
+        index: indexValue,
+      };
+    })
+    .filter((entry): entry is { name: string; path: string; index: number } => entry !== null);
+};
+
+const applyWorkspaceContext = (payload?: {
+  workspaceFolder?: string;
+  activeWorkspaceFolder?: string;
+  workspaceFolders?: Array<{ name: string; path: string; index?: number }>;
+}) => {
+  const current = window.__VSCODE_CONFIG__ || {
+    workspaceFolder: '',
+    theme: 'dark',
+    connectionStatus: 'connecting',
+  };
+  const workspaceFolders = normalizeWorkspaceFolders(payload?.workspaceFolders ?? current.workspaceFolders ?? []);
+  const activeWorkspaceFolder = normalizeWorkspacePath(
+    payload?.activeWorkspaceFolder
+      || payload?.workspaceFolder
+      || current.activeWorkspaceFolder
+      || current.workspaceFolder
+      || workspaceFolders[0]?.path
+      || '',
+  );
+
+  window.__VSCODE_CONFIG__ = {
+    ...current,
+    workspaceFolder: activeWorkspaceFolder,
+    activeWorkspaceFolder,
+    workspaceFolders,
+  };
+
+  if (activeWorkspaceFolder) {
+    window.__OPENCHAMBER_HOME__ = activeWorkspaceFolder;
+  }
+
+  window.dispatchEvent(new CustomEvent('openchamber:vscode-workspace-context', {
+    detail: {
+      workspaceFolder: activeWorkspaceFolder,
+      activeWorkspaceFolder,
+      workspaceFolders,
+    },
+  }));
+};
 
 const bootstrapConnectionStatus = () => {
   const initialStatus = (window.__VSCODE_CONFIG__?.connectionStatus as ConnectionStatus | undefined) || 'connecting';
@@ -261,19 +346,10 @@ onThemeChange((payload) => {
   scheduleThemeRecompute(kind);
 });
 
+applyWorkspaceContext(window.__VSCODE_CONFIG__);
+
 const workspaceFolder = window.__VSCODE_CONFIG__?.workspaceFolder;
 if (workspaceFolder) {
-  const normalizeWorkspacePath = (value: string) => {
-    const normalized = value
-      .replace(/\\/g, '/')
-      .replace(/^([a-z]):\//, (_, letter: string) => `${letter.toUpperCase()}:/`)
-      .replace(/^\/([a-z]):\//, (_, letter: string) => `/${letter.toUpperCase()}:/`);
-    if (normalized === '/') {
-      return '/';
-    }
-    return normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized;
-  };
-
   const normalizedWorkspaceFolder = normalizeWorkspacePath(workspaceFolder);
   window.__OPENCHAMBER_HOME__ = normalizedWorkspaceFolder;
   try {
@@ -1204,6 +1280,14 @@ onCommand('showSettings', () => {
 onCommand('settingsSynced', () => {
   import('@openchamber/ui/lib/persistence').then(({ syncDesktopSettings }) => {
     void syncDesktopSettings();
+  });
+});
+
+onCommand('vscodeWorkspaceContext', (payload) => {
+  applyWorkspaceContext(payload as {
+    workspaceFolder?: string;
+    activeWorkspaceFolder?: string;
+    workspaceFolders?: Array<{ name: string; path: string; index?: number }>;
   });
 });
 


### PR DESCRIPTION
## Summary

- add multi-root workspace support to the VS Code extension runtime
- align the VS Code session sidebar with web-style project/worktree grouping
- allow selecting the target workspace for new chats in VS Code
- keep single-root VS Code behavior unchanged
- polish VS Code compact-layout draft navigation and hide unsupported project actions

## What changed

- treat VS Code `workspaceFolders` as projects instead of assuming a single `workspaceFolder`
- pass `workspaceFolders` and `activeWorkspaceFolder` into the webview config
- resolve files, config, git, and session defaults against the active workspace root instead of hardcoding the first root
- render multiple workspace sections in the session sidebar, with sessions grouped under the correct workspace root
- show the workspace selector in the VS Code chat composer when multiple roots are open
- keep single-root mode visually and behaviorally aligned with current `main`
- hide unsupported `Rename` and `Close Project` actions in VS Code project menus
- fix compact VS Code layout so opening a new draft from the sidebar navigates to chat
- preserve back navigation from chat to sessions while still allowing `New session` to reopen the draft view

## Why

VS Code multi-root workspaces were previously treated like a single-root environment. That caused sessions, directory scoping, and chat targeting to drift toward the first workspace folder and made the VS Code UX fall behind the web runtime.

This change brings VS Code much closer to the existing web mental model while preserving the current single-root experience.

## Validation

Ran VS Code-only checks and packaging during development:

- `bun run vscode:type-check`
- `bun run vscode:build`
- `bun run vscode:package`

## Notes

- this keeps the current single OpenCode manager model; it does not introduce one backend instance per workspace root
- single-root workspaces intentionally degrade to the existing behavior
