### PR TITLE
feat(chat): add export session as markdown workflow

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { RiArrowLeftLine } from '@remixicon/react';
+import { RiArrowLeftLine, RiDownloadLine } from '@remixicon/react';
 import type { Message, Part, Session } from '@opencode-ai/sdk/v2';
 
 import { ChatInput } from './ChatInput';
 import { useUIStore } from '@/stores/useUIStore';
+import { toast } from '@/components/ui';
+import { formatSessionAsMarkdown, downloadAsMarkdown, buildExportFilename } from '@/lib/exportSession';
 import { Skeleton } from '@/components/ui/skeleton';
 import ChatEmptyState from './ChatEmptyState';
 import MessageList, { type MessageListHandle } from './MessageList';
@@ -405,6 +407,23 @@ export const ChatContainer: React.FC = () => {
     const isDesktopExpandedInput = isExpandedInput && !isMobile;
     const messageListRef = React.useRef<MessageListHandle | null>(null);
 
+    const currentSession = React.useMemo(
+        () => currentSessionId ? sessions.find((s) => s.id === currentSessionId) ?? null : null,
+        [currentSessionId, sessions],
+    );
+
+    const handleExportMarkdown = React.useCallback(() => {
+        if (!currentSessionId || sessionMessages.length === 0) {
+            toast.error('Nothing to export');
+            return;
+        }
+        const title = currentSession?.title ?? null;
+        const markdown = formatSessionAsMarkdown(sessionMessages, title);
+        const filename = buildExportFilename(title);
+        downloadAsMarkdown(markdown, filename);
+        toast.success('Session exported');
+    }, [currentSessionId, currentSession, sessionMessages]);
+
     const parentSession = React.useMemo(() => {
         if (!currentSessionId) return null;
         const current = sessions.find((session) => session.id === currentSessionId);
@@ -433,6 +452,20 @@ export const ChatContainer: React.FC = () => {
         >
             <RiArrowLeftLine className="h-4 w-4" />
             Parent
+        </Button>
+    ) : null;
+
+    const exportButton = !isMobile && sessionMessages.length > 0 ? (
+        <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={handleExportMarkdown}
+            className="absolute right-3 top-3 z-20 !font-normal text-muted-foreground hover:text-foreground"
+            aria-label="Export session as Markdown"
+            title="Export session as Markdown"
+        >
+            <RiDownloadLine className="h-4 w-4" />
         </Button>
     ) : null;
 
@@ -778,6 +811,7 @@ export const ChatContainer: React.FC = () => {
             style={isMobile ? { paddingBottom: 'var(--oc-keyboard-inset, 0px)' } : undefined}
         >
             {returnToParentButton}
+            {exportButton}
             <ChatViewport
                 currentSessionId={currentSessionId}
                 isDesktopExpandedInput={isDesktopExpandedInput}

--- a/packages/ui/src/lib/exportSession.ts
+++ b/packages/ui/src/lib/exportSession.ts
@@ -1,0 +1,58 @@
+import type { Message, Part } from '@opencode-ai/sdk/v2';
+
+type SessionMessageRecord = { info: Message; parts: Part[] };
+
+function extractTextFromParts(parts: Part[]): string {
+  return parts
+    .filter((p): p is Part & { type: 'text'; text: string } => p.type === 'text' && typeof p.text === 'string')
+    .map((p) => p.text)
+    .join('');
+}
+
+function formatMessageAsMarkdown(record: SessionMessageRecord): string {
+  const role = record.info.role === 'user' ? '### User' : '### Assistant';
+  const text = extractTextFromParts(record.parts).trim();
+
+  if (!text) return '';
+  return `${role}\n\n${text}`;
+}
+
+export function formatSessionAsMarkdown(
+  messages: SessionMessageRecord[],
+  sessionTitle?: string | null,
+): string {
+  const title = sessionTitle?.trim() || 'Session';
+  const date = new Date().toISOString().split('T')[0];
+
+  const header = `# ${title}\n\n*Exported on ${date}*\n\n---\n\n`;
+
+  const body = messages
+    .map(formatMessageAsMarkdown)
+    .filter(Boolean)
+    .join('\n\n---\n\n');
+
+  return header + body;
+}
+
+export function downloadAsMarkdown(content: string, filename: string): void {
+  const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export function buildExportFilename(sessionTitle?: string | null): string {
+  const base = sessionTitle?.trim() || 'session';
+  const safe = base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  const date = new Date().toISOString().split('T')[0];
+  return `${safe}-${date}.md`;
+}


### PR DESCRIPTION
## Summary
- Add a download button in the chat view to export the current session as a formatted Markdown file.

## Why
- Session content is useful outside the app for sharing, archiving, and reuse, but copying it manually is noisy and error-prone.

## Behavior
- Adds an export button in the chat view when the current session has messages and the UI is not mobile.
- Exports the current session as formatted Markdown with a title header and export date.
- Separates user and assistant messages with horizontal rules for readability.
- Generates filenames from the session title and current date, using slugged names such as `fix-login-bug-2026-04-17.md`.
- Downloads the file directly in the browser and shows success or empty-state toast feedback.
- Includes text message content in the export output.