### PR TITLE
fix: preserve pinned sessions until global sessions finish loading

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -272,6 +272,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const sync = useSync();
   const liveSessions = useAllLiveSessions();
   const liveSessionStatuses = useAllSessionStatuses();
+  const hasLoadedGlobalSessions = useGlobalSessionsStore((state) => state.hasLoaded);
   const globalActiveSessions = useGlobalSessionsStore((state) => state.activeSessions);
   const archivedSessions = useGlobalSessionsStore((state) => state.archivedSessions);
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
@@ -476,6 +477,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
   const { scheduleCollapsedProjectsPersist } = useSidebarPersistence({
     isVSCode,
+    hasLoadedGlobalSessions,
     safeStorage,
     keys: {
       sessionExpanded: SESSION_EXPANDED_STORAGE_KEY,

--- a/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.ts
@@ -19,6 +19,7 @@ type Keys = {
 
 type Args = {
   isVSCode: boolean;
+  hasLoadedGlobalSessions: boolean;
   safeStorage: SafeStorageLike;
   keys: Keys;
   sessions: Session[];
@@ -34,6 +35,7 @@ type Args = {
 export const useSidebarPersistence = (args: Args) => {
   const {
     isVSCode,
+    hasLoadedGlobalSessions,
     safeStorage,
     keys,
     sessions,
@@ -114,6 +116,10 @@ export const useSidebarPersistence = (args: Args) => {
   }, [keys.projectCollapse, keys.sessionExpanded, safeStorage, setCollapsedProjects, setExpandedParents]);
 
   React.useEffect(() => {
+    if (!hasLoadedGlobalSessions) {
+      return;
+    }
+
     const existingSessionIds = new Set(sessions.map((session) => session.id));
     setPinnedSessionIds((prev) => {
       let changed = false;
@@ -127,7 +133,7 @@ export const useSidebarPersistence = (args: Args) => {
       });
       return changed ? next : prev;
     });
-  }, [sessions, setPinnedSessionIds]);
+  }, [hasLoadedGlobalSessions, sessions, setPinnedSessionIds]);
 
   React.useEffect(() => {
     try {


### PR DESCRIPTION
## Summary
- preserve pinned sessions during sidebar bootstrap until the global session list has finished loading
- avoid pruning valid pinned session IDs when the initial session snapshot is still empty

## Why
Pinned sessions were being restored from local storage and then immediately pruned against an incomplete session list during startup. In browser/PWA usage this made pinned sessions appear to reset after refresh or after reopening the app.

## What changed
- added `hasLoadedGlobalSessions` to the sidebar persistence hook
- gated pinned-session pruning on that loaded flag

## Validation
- `bun run type-check`
- `bun run lint`
- `bun run build`

## Repro
1. Pin one or more sessions in the left sidebar.
2. Refresh the page or reopen the PWA.
3. Before this fix, the pinned sessions disappear.
4. After this fix, the pinned sessions remain pinned.
