### PR TITLE
fix: allow loopback origins for push VAPID fallback

### DIFF
--- a/packages/web/server/lib/notifications/push-runtime.js
+++ b/packages/web/server/lib/notifications/push-runtime.js
@@ -1,5 +1,15 @@
 const PUSH_SUBSCRIPTIONS_VERSION = 1;
 
+const isLoopbackHttpOrigin = (value) => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  return value.startsWith('http://localhost')
+    || value.startsWith('http://127.0.0.1')
+    || value.startsWith('http://[::1]');
+};
+
 export const createPushRuntime = (deps) => {
   const {
     fsPromises,
@@ -241,7 +251,7 @@ export const createPushRuntime = (deps) => {
     const originEnv = process.env.OPENCHAMBER_PUBLIC_ORIGIN;
     if (typeof originEnv === 'string' && originEnv.trim().length > 0) {
       const trimmed = originEnv.trim();
-      if (trimmed.startsWith('http://localhost')) {
+      if (isLoopbackHttpOrigin(trimmed)) {
         return 'mailto:openchamber@localhost';
       }
       return trimmed;
@@ -252,7 +262,7 @@ export const createPushRuntime = (deps) => {
       const stored = settings?.publicOrigin;
       if (typeof stored === 'string' && stored.trim().length > 0) {
         const trimmed = stored.trim();
-        if (trimmed.startsWith('http://localhost')) {
+        if (isLoopbackHttpOrigin(trimmed)) {
           return 'mailto:openchamber@localhost';
         }
         return trimmed;


### PR DESCRIPTION
## Summary
- treat `http://127.0.0.1:*` and `http://[::1]:*` the same way as `http://localhost:*` when resolving the VAPID subject
- keep loopback browser/PWA origins valid for background push setup

## Why
Background push setup failed on loopback origins like `127.0.0.1` because the runtime reused the local HTTP origin as the VAPID subject. `web-push` rejects plain `http://...` subjects unless they are converted to a valid `mailto:` or `https:` value.

This made browser/PWA background notifications fail with errors like `Failed to load push key` even though the app was running locally and notifications worked on `localhost`.

## What changed
- added a shared loopback-origin helper
- reused the localhost fallback for `127.0.0.1` and `[::1]`

## Validation
- `bun run type-check`
- `bun run lint`
- `bun run build`

## Repro
1. Run OpenChamber locally on `http://127.0.0.1:<port>`.
2. Open the web UI and enable background push notifications.
3. Before this fix, push setup fails because the VAPID subject resolves to an invalid loopback HTTP origin.
4. After this fix, push setup succeeds on loopback origins.
