### PR TITLE
fix: remove over-aggressive check blocking git branch operations

### DIFF
--- a/packages/ui/src/components/views/GitView.tsx
+++ b/packages/ui/src/components/views/GitView.tsx
@@ -1057,10 +1057,6 @@ export const GitView: React.FC = () => {
   }, [currentDirectory, selectedPaths, settingsGitmojiEnabled, gitmojiEmojis, scrollActionPanelToBottom]);
 
   const formatBlockingReason = (reason: ReturnType<typeof getMutationBlockingReasons>[number]): string => {
-    if (reason.reason === 'dirty') {
-      const count = typeof reason.dirtyFiles === 'number' ? reason.dirtyFiles : null;
-      return count != null ? `${count} uncommitted file${count === 1 ? '' : 's'}` : 'uncommitted changes';
-    }
     if (reason.reason === 'attention') {
       return `${reason.attentionReason} in progress`;
     }
@@ -1073,7 +1069,7 @@ export const GitView: React.FC = () => {
   const handleCreateBranch = async (branchName: string, remote?: GitRemote) => {
     if (!currentDirectory || !status) return;
 
-    const blockingReasons = getMutationBlockingReasons(worktreeAttachment ?? null, status);
+    const blockingReasons = getMutationBlockingReasons(worktreeAttachment);
     if (blockingReasons.length > 0) {
       toast.error(`Cannot create branch: ${formatBlockingReason(blockingReasons[0])}`);
       return;
@@ -1127,7 +1123,7 @@ export const GitView: React.FC = () => {
   const handleRenameBranch = async (oldName: string, newName: string) => {
     if (!currentDirectory) return;
 
-    const blockingReasons = getMutationBlockingReasons(worktreeAttachment ?? null, status);
+    const blockingReasons = getMutationBlockingReasons(worktreeAttachment);
     if (blockingReasons.length > 0) {
       toast.error(`Cannot rename branch: ${formatBlockingReason(blockingReasons[0])}`);
       return;
@@ -1149,7 +1145,7 @@ export const GitView: React.FC = () => {
     if (!currentDirectory) return;
 
     // Block mutation if worktree is in an attention-required state
-    const blockingReasons = getMutationBlockingReasons(worktreeAttachment ?? null, status);
+    const blockingReasons = getMutationBlockingReasons(worktreeAttachment);
     if (blockingReasons.length > 0) {
       toast.error(`Cannot checkout: ${formatBlockingReason(blockingReasons[0])}`);
       return;

--- a/packages/ui/src/sync/session-worktree-contract.ts
+++ b/packages/ui/src/sync/session-worktree-contract.ts
@@ -167,24 +167,14 @@ export function getSessionWorktreeRepairActions(
 }
 
 export type MutationBlockingReason =
-  | { reason: 'dirty'; dirtyFiles?: number }
   | { reason: 'attention'; attentionReason: NonNullable<SessionWorktreeAttachment['attentionReason']> }
   | { reason: 'missing' }
   | { reason: 'invalid' };
 
-export type GitStatusForBlocking = {
-  isClean: boolean;
-  files?: unknown[];
-};
-
 export function getMutationBlockingReasons(
-  attachment: SessionWorktreeAttachment | null | undefined,
-  gitStatus?: GitStatusForBlocking | null
+  attachment: SessionWorktreeAttachment | null | undefined
 ): MutationBlockingReason[] {
   const reasons: MutationBlockingReason[] = [];
-  if (gitStatus && !gitStatus.isClean) {
-    reasons.push({ reason: 'dirty', dirtyFiles: Array.isArray(gitStatus.files) ? gitStatus.files.length : undefined });
-  }
   if (!attachment) return reasons;
   if (attachment.worktreeStatus === 'missing') {
     reasons.push({ reason: 'missing' });


### PR DESCRIPTION
## Summary

- Remove dirty/uncommitted-files pre-check from `getMutationBlockingReasons` that blocked all git branch operations (checkout, create, rename) whenever any uncommitted files existed — including untracked files
- Git operations themselves (`git checkout`, `git branch`, `git branch -m`) already handle dirty working trees correctly and only fail when local changes would actually be overwritten
- The pre-check was stricter than `git checkout`: it blocked on untracked files (`??`) that git would silently carry across the switch

## Changes

- **`session-worktree-contract.ts`**: Removed `dirty` variant from `MutationBlockingReason`, removed `GitStatusForBlocking` type, removed `gitStatus` parameter from `getMutationBlockingReasons`
- **`GitView.tsx`**: Updated 3 call sites (checkout, create branch, rename branch) and removed `dirty` branch from `formatBlockingReason`

## Behavior comparison

| Scenario | Before | After (≈ `git checkout`) |
|----------|--------|--------------------------|
| Untracked files | ❌ Blocked | ✅ Switch succeeds, files carried over |
| Tracked changes, no conflict | ❌ Blocked | ✅ Switch succeeds, changes carried over |
| Tracked changes, would be overwritten | ❌ Blocked | ❌ Git native error shown via toast |
| Merge/rebase in progress | ❌ Blocked | ❌ Blocked (attention check retained) |

## Test plan

- [ ] Verify branch switch works with untracked files present
- [ ] Verify branch switch works with unstaged tracked changes that don't conflict
- [ ] Verify branch switch shows git error when changes would be overwritten
- [ ] Verify branch switch still blocked during merge/rebase
- [ ] Verify create branch and rename branch behave the same way