### PR TITLE
Match Opencode Config Resolution Behavior

### DIFF
--- a/packages/vscode/src/opencodeConfig.ts
+++ b/packages/vscode/src/opencodeConfig.ts
@@ -7,7 +7,7 @@ import { parse as parseJsonc } from 'jsonc-parser';
 const OPENCODE_CONFIG_DIR = path.join(os.homedir(), '.config', 'opencode');
 const AGENT_DIR = path.join(OPENCODE_CONFIG_DIR, 'agents');
 const COMMAND_DIR = path.join(OPENCODE_CONFIG_DIR, 'commands');
-const CONFIG_FILE = path.join(OPENCODE_CONFIG_DIR, 'opencode.json');
+const CONFIG_FILE = path.join(OPENCODE_CONFIG_DIR, 'config.json');
 const CUSTOM_CONFIG_FILE = process.env.OPENCODE_CONFIG
   ? path.resolve(process.env.OPENCODE_CONFIG)
   : null;
@@ -321,7 +321,11 @@ const getProjectConfigPath = (workingDirectory?: string): string | null => {
 };
 
 const getConfigPaths = (workingDirectory?: string) => ({
-  userPath: CONFIG_FILE,
+  userPaths: [
+    path.join(OPENCODE_CONFIG_DIR, 'config.json'),
+    path.join(OPENCODE_CONFIG_DIR, 'opencode.json'),
+    path.join(OPENCODE_CONFIG_DIR, 'opencode.jsonc'),
+  ],
   projectPath: getProjectConfigPath(workingDirectory),
   customPath: CUSTOM_CONFIG_FILE
 });
@@ -355,8 +359,11 @@ const mergeConfigs = (base: Record<string, unknown>, override: Record<string, un
 };
 
 const readConfigLayers = (workingDirectory?: string) => {
-  const { userPath, projectPath, customPath } = getConfigPaths(workingDirectory);
-  const userConfig = readConfigFile(userPath);
+  const { userPaths, projectPath, customPath } = getConfigPaths(workingDirectory);
+  const userConfig = userPaths.reduce(
+    (config, userPath) => mergeConfigs(config, readConfigFile(userPath)),
+    {} as Record<string, unknown>
+  );
   const projectConfig = readConfigFile(projectPath);
   const customConfig = readConfigFile(customPath);
   const mergedConfig = mergeConfigs(mergeConfigs(userConfig, projectConfig), customConfig);
@@ -366,7 +373,7 @@ const readConfigLayers = (workingDirectory?: string) => {
     projectConfig,
     customConfig,
     mergedConfig,
-    paths: { userPath, projectPath, customPath }
+    paths: { userPath: CONFIG_FILE, projectPath, customPath }
   };
 };
 

--- a/packages/vscode/src/opencodeConfig.ts
+++ b/packages/vscode/src/opencodeConfig.ts
@@ -330,6 +330,16 @@ const getConfigPaths = (workingDirectory?: string) => ({
   customPath: CUSTOM_CONFIG_FILE
 });
 
+const getPrimaryUserConfigPath = (userPaths: string[]): string => {
+  for (const userPath of userPaths) {
+    if (fs.existsSync(userPath)) {
+      return userPath;
+    }
+  }
+
+  return CONFIG_FILE;
+};
+
 const readConfigFile = (filePath?: string | null): Record<string, unknown> => {
   if (!filePath || !fs.existsSync(filePath)) return {};
   const content = fs.readFileSync(filePath, 'utf8');
@@ -360,10 +370,8 @@ const mergeConfigs = (base: Record<string, unknown>, override: Record<string, un
 
 const readConfigLayers = (workingDirectory?: string) => {
   const { userPaths, projectPath, customPath } = getConfigPaths(workingDirectory);
-  const userConfig = userPaths.reduce(
-    (config, userPath) => mergeConfigs(config, readConfigFile(userPath)),
-    {} as Record<string, unknown>
-  );
+  const userPath = getPrimaryUserConfigPath(userPaths);
+  const userConfig = readConfigFile(userPath);
   const projectConfig = readConfigFile(projectPath);
   const customConfig = readConfigFile(customPath);
   const mergedConfig = mergeConfigs(mergeConfigs(userConfig, projectConfig), customConfig);
@@ -373,7 +381,7 @@ const readConfigLayers = (workingDirectory?: string) => {
     projectConfig,
     customConfig,
     mergedConfig,
-    paths: { userPath: CONFIG_FILE, projectPath, customPath }
+    paths: { userPath, projectPath, customPath }
   };
 };
 

--- a/packages/web/server/lib/opencode/shared.js
+++ b/packages/web/server/lib/opencode/shared.js
@@ -10,7 +10,7 @@ const OPENCODE_CONFIG_DIR = path.join(os.homedir(), '.config', 'opencode');
 const AGENT_DIR = path.join(OPENCODE_CONFIG_DIR, 'agents');
 const COMMAND_DIR = path.join(OPENCODE_CONFIG_DIR, 'commands');
 const SKILL_DIR = path.join(OPENCODE_CONFIG_DIR, 'skills');
-const CONFIG_FILE = path.join(OPENCODE_CONFIG_DIR, 'opencode.json');
+const CONFIG_FILE = path.join(OPENCODE_CONFIG_DIR, 'config.json');
 const CUSTOM_CONFIG_FILE = process.env.OPENCODE_CONFIG
   ? path.resolve(process.env.OPENCODE_CONFIG)
   : null;
@@ -115,7 +115,11 @@ function getProjectConfigPath(workingDirectory) {
 
 function getConfigPaths(workingDirectory) {
   return {
-    userPath: CONFIG_FILE,
+    userPaths: [
+      path.join(OPENCODE_CONFIG_DIR, 'config.json'),
+      path.join(OPENCODE_CONFIG_DIR, 'opencode.json'),
+      path.join(OPENCODE_CONFIG_DIR, 'opencode.jsonc'),
+    ],
     projectPath: getProjectConfigPath(workingDirectory),
     customPath: CUSTOM_CONFIG_FILE
   };
@@ -163,8 +167,11 @@ function mergeConfigs(base, override) {
 }
 
 function readConfigLayers(workingDirectory) {
-  const { userPath, projectPath, customPath } = getConfigPaths(workingDirectory);
-  const userConfig = readConfigFile(userPath);
+  const { userPaths, projectPath, customPath } = getConfigPaths(workingDirectory);
+  const userConfig = userPaths.reduce(
+    (config, userPath) => mergeConfigs(config, readConfigFile(userPath)),
+    {}
+  );
   const projectConfig = readConfigFile(projectPath);
   const customConfig = readConfigFile(customPath);
   const mergedConfig = mergeConfigs(mergeConfigs(userConfig, projectConfig), customConfig);
@@ -174,7 +181,7 @@ function readConfigLayers(workingDirectory) {
     projectConfig,
     customConfig,
     mergedConfig,
-    paths: { userPath, projectPath, customPath }
+    paths: { userPath: CONFIG_FILE, projectPath, customPath }
   };
 }
 

--- a/packages/web/server/lib/opencode/shared.js
+++ b/packages/web/server/lib/opencode/shared.js
@@ -125,6 +125,16 @@ function getConfigPaths(workingDirectory) {
   };
 }
 
+function getPrimaryUserConfigPath(userPaths) {
+  for (const userPath of userPaths) {
+    if (fs.existsSync(userPath)) {
+      return userPath;
+    }
+  }
+
+  return CONFIG_FILE;
+}
+
 function readConfigFile(filePath) {
   if (!filePath || !fs.existsSync(filePath)) {
     return {};
@@ -168,10 +178,8 @@ function mergeConfigs(base, override) {
 
 function readConfigLayers(workingDirectory) {
   const { userPaths, projectPath, customPath } = getConfigPaths(workingDirectory);
-  const userConfig = userPaths.reduce(
-    (config, userPath) => mergeConfigs(config, readConfigFile(userPath)),
-    {}
-  );
+  const userPath = getPrimaryUserConfigPath(userPaths);
+  const userConfig = readConfigFile(userPath);
   const projectConfig = readConfigFile(projectPath);
   const customConfig = readConfigFile(customPath);
   const mergedConfig = mergeConfigs(mergeConfigs(userConfig, projectConfig), customConfig);
@@ -181,7 +189,7 @@ function readConfigLayers(workingDirectory) {
     projectConfig,
     customConfig,
     mergedConfig,
-    paths: { userPath: CONFIG_FILE, projectPath, customPath }
+    paths: { userPath, projectPath, customPath }
   };
 }
 


### PR DESCRIPTION
context:
- it's currently assumed that opencode configs always live at ~/.config/opencode/opencode.json
- however, opencode actually supports all of `config.json`, `opencode.json`, and `opencode.jsonc`

- the latest version on opencode `dev@origin` also uses `config.json` by default instead of `opencode.json`, so `CONFIG_FILE` should be changed to that
- current config resolution broke things that relied on user defined opencode config, such as session title generation (which relies on an agent.title config being defined

changes:
- made config.json the default config file
- copy the exact same config merging as opencode

now:
- auto title generation is no longer broken for users that has `config.json` 
