### PR TITLE
fix: preserve --host flag across update and restart

### DIFF
--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -1752,6 +1752,7 @@ function writeInstanceOptions(instanceFilePath, options, onNotice) {
   try {
     const toStore = {
       port: options.port,
+      host: typeof options.host === 'string' && options.host.length > 0 ? options.host : undefined,
       launchMode: options.launchMode === 'foreground' ? 'foreground' : 'daemon',
       uiPassword: typeof options.uiPassword === 'string' ? options.uiPassword : undefined,
       hasUiPassword: typeof options.uiPassword === 'string',
@@ -2931,6 +2932,7 @@ const commands = {
       writePidFile(fgPidFilePath, process.pid, emitNotice);
       writeInstanceOptions(fgInstanceFilePath, {
         port: resolvedPort,
+        host: effectiveHost,
         launchMode: 'foreground',
         uiPassword: effectiveUiPassword,
       }, emitNotice);
@@ -3058,6 +3060,7 @@ const commands = {
     writePidFile(pidFilePath, child.pid, emitNotice);
     writeInstanceOptions(instanceFilePath, {
       port: resolvedPort,
+      host: effectiveHost,
       launchMode: 'daemon',
       uiPassword: effectiveUiPassword,
     }, emitNotice);
@@ -3356,6 +3359,7 @@ const commands = {
 
         const restartedPort = await this.serve({
           port: restartPort,
+          host: storedOptions.host,
           explicitPort: true,
           uiPassword: options.explicitUiPassword ? options.uiPassword : storedOptions.uiPassword,
           suppressStartupSummary: true,
@@ -4791,6 +4795,7 @@ const commands = {
         const storedOptions = readInstanceOptions(instance.instanceFilePath) || { port: instance.port };
         await this.serve({
           port: storedOptions.port || instance.port,
+          host: storedOptions.host,
           explicitPort: true,
           uiPassword: storedOptions.uiPassword,
           suppressStartupSummary: true,

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -130,6 +130,17 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
       ];
       let restartCmdPrimary = restartParts.join(' ');
       let restartCmdFallback = `openchamber serve --port ${storedOptions.port}`;
+      if (storedOptions.host) {
+        if (isWindows) {
+          const escapedHost = storedOptions.host.replace(/"/g, '""');
+          restartCmdPrimary += ` --host "${escapedHost}"`;
+          restartCmdFallback += ` --host "${escapedHost}"`;
+        } else {
+          const escapedHost = storedOptions.host.replace(/'/g, "'\\''");
+          restartCmdPrimary += ` --host '${escapedHost}'`;
+          restartCmdFallback += ` --host '${escapedHost}'`;
+        }
+      }
       if (storedOptions.uiPassword) {
         if (isWindows) {
           const escapedPw = storedOptions.uiPassword.replace(/"/g, '""');


### PR DESCRIPTION
## Summary

- Store `host` in the instance state file alongside `port` and `uiPassword`
- Restore `host` when restarting after `update`, `restart`, and server-side update-install

## Changes

**`packages/web/bin/cli.js`**
- `writeInstanceOptions()`: add `host` to persisted state
- Foreground and daemon `serve()` callers: pass `host` to write
- `restart` and `update` commands: restore `host` from stored options

**`packages/web/server/lib/opencode/openchamber-routes.js`**
- Append `--host` to the restart shell command when present (with proper escaping for Windows/POSIX)

Fixes #971