### PR TITLE
fix: invalidate worktree list cache after create and remove

### DIFF
--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -246,7 +246,6 @@ export async function listProjectWorktrees(project: ProjectRef): Promise<Worktre
           projectDirectory: metadataProjectDirectory,
           branch: branch,
           label: branch || name || deriveSdkWorktreeNameFromDirectory(worktreePath),
-          // Phase 1 canonical fields
           worktreeRoot: canonical.worktreeRoot,
           worktreeStatus: canonical.worktreeStatus,
           headState: canonical.headState,
@@ -307,7 +306,6 @@ export async function createWorktree(project: ProjectRef, args: CreateWorktreeAr
     projectDirectory: metadataProjectDirectory,
     branch: returnedBranch,
     label: returnedBranch || returnedName,
-    // Phase 1 canonical fields
     worktreeRoot: normalizePath(returnedPath),
     worktreeStatus: 'ready',
     headState: returnedBranch ? 'branch' : 'unborn',
@@ -315,6 +313,8 @@ export async function createWorktree(project: ProjectRef, args: CreateWorktreeAr
   };
 
   markWorktreeBootstrapPending(metadata.path);
+
+  _worktreeListCache.delete(projectDirectory);
 
   return metadata;
 }
@@ -344,6 +344,8 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
   }
 
   clearWorktreeBootstrapState(worktree.path);
+
+  _worktreeListCache.delete(project.path);
 
   const branchName = (worktree.branch || '').replace(/^refs\/heads\//, '').trim();
   if (deleteRemote && branchName) {

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -345,7 +345,7 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
 
   clearWorktreeBootstrapState(worktree.path);
 
-  _worktreeListCache.delete(project.path);
+  _worktreeListCache.delete(normalizePath(project.path));
 
   const branchName = (worktree.branch || '').replace(/^refs\/heads\//, '').trim();
   if (deleteRemote && branchName) {


### PR DESCRIPTION
## Summary

- Closes #957
- After `createWorktree()` or `removeProjectWorktree()` succeeds, the internal `_worktreeListCache` is now cleared so subsequent `listProjectWorktrees()` calls fetch fresh data instead of returning stale cached results for up to 30 seconds.
- Also removes two obsolete `// Phase 1 canonical fields` comments.

## Root Cause

`createWorktree()` and `removeProjectWorktree()` mutated git state but never invalidated `_worktreeListCache`. The `WorktreeSectionContent` refresh depends on `sessionsKey` changing, but the draft-first creation flow doesn't create a session immediately, so the effect never fires and the cache serves stale data.

## Test Plan

- [ ] Create a worktree via keyboard shortcut (Mod+Shift+N) → verify worktree list in Settings updates immediately
- [ ] Delete a worktree from Settings → verify list updates immediately
- [ ] Create worktree, then navigate to Settings within 30s → verify new worktree is visible without manual refresh