### PR TITLE
feat(sidebar): add browser tab

### DIFF
--- a/packages/ui/src/components/layout/RightSidebarTabs.tsx
+++ b/packages/ui/src/components/layout/RightSidebarTabs.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RiBookletLine, RiFolder3Line, RiGitBranchLine } from '@remixicon/react';
+import { RiBookletLine, RiFolder3Line, RiGitBranchLine, RiGlobalLine } from '@remixicon/react';
 
 import { SortableTabsStrip } from '@/components/ui/sortable-tabs-strip';
 import { ProjectNotesTodoPanel } from '@/components/session/ProjectNotesTodoPanel';
@@ -11,9 +11,10 @@ import { useUIStore } from '@/stores/useUIStore';
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
 import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
 import { formatDirectoryName } from '@/lib/utils';
+import { SidebarBrowserPanel } from './SidebarBrowserPanel';
 import { SidebarFilesTree } from './SidebarFilesTree';
 
-type RightTab = 'git' | 'files' | 'context';
+type RightTab = 'git' | 'files' | 'context' | 'browser';
 
 /**
  * Keeps git status fresh while the right sidebar is open.
@@ -113,6 +114,11 @@ export const RightSidebarTabs: React.FC = () => {
       label: 'Context',
       icon: <RiBookletLine className="h-3.5 w-3.5" />,
     },
+    {
+      id: 'browser',
+      label: 'Browser',
+      icon: <RiGlobalLine className="h-3.5 w-3.5" />,
+    },
   ], []);
 
   return (
@@ -132,6 +138,7 @@ export const RightSidebarTabs: React.FC = () => {
         {rightSidebarTab === 'git' && <GitView />}
         {rightSidebarTab === 'files' && <SidebarFilesTree />}
         {rightSidebarTab === 'context' && <ContextSidebarPanel />}
+        {rightSidebarTab === 'browser' && <SidebarBrowserPanel />}
       </div>
     </div>
   );

--- a/packages/ui/src/components/layout/SidebarBrowserPanel.tsx
+++ b/packages/ui/src/components/layout/SidebarBrowserPanel.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { RiArrowRightLine, RiRefreshLine } from '@remixicon/react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/components/ui';
+import { useUIStore } from '@/stores/useUIStore';
+
+export const SidebarBrowserPanel: React.FC = () => {
+  const currentUrl = useUIStore((state) => state.rightSidebarBrowserUrl);
+  const setCurrentUrl = useUIStore((state) => state.setRightSidebarBrowserUrl);
+  const [inputValue, setInputValue] = React.useState(currentUrl);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [iframeReloadKey, setIframeReloadKey] = React.useState(0);
+
+  React.useEffect(() => {
+    setInputValue(currentUrl);
+  }, [currentUrl]);
+
+  const openUrl = React.useCallback((url: string) => {
+    setIsLoading(true);
+
+    if (url === currentUrl) {
+      setIframeReloadKey((value) => value + 1);
+      return;
+    }
+
+    setCurrentUrl(url);
+    setIframeReloadKey(0);
+  }, [currentUrl, setCurrentUrl]);
+
+  const handleSubmit = React.useCallback((event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmed = inputValue.trim();
+    if (!trimmed) {
+      setIsLoading(false);
+      toast.error('Enter a URL.');
+      return;
+    }
+
+    openUrl(/^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`);
+  }, [inputValue, openUrl]);
+
+  const handleRefresh = React.useCallback(() => {
+    if (!currentUrl) {
+      return;
+    }
+
+    setIsLoading(true);
+    setIframeReloadKey((value) => value + 1);
+  }, [currentUrl]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-sidebar">
+      <form onSubmit={handleSubmit} className="flex items-center gap-1.5 border-b border-border/40 px-2 py-1.5">
+        <Input
+          value={inputValue}
+          onChange={(event) => {
+            setInputValue(event.target.value);
+          }}
+          placeholder="Enter a URL"
+          aria-label="Browser address"
+          className="h-8 bg-[var(--surface-base)]"
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={handleRefresh}
+          disabled={!currentUrl}
+          aria-label="Refresh page"
+          title="Refresh"
+        >
+          <RiRefreshLine className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+        </Button>
+        <Button
+          type="submit"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Open address"
+          title="Open"
+        >
+          <RiArrowRightLine className="h-4 w-4" />
+        </Button>
+      </form>
+
+      <div className="relative min-h-0 flex-1 overflow-hidden bg-[var(--surface-base)]">
+        {currentUrl ? (
+          <>
+            <iframe
+              key={`${currentUrl}:${iframeReloadKey}`}
+              src={currentUrl}
+              title={currentUrl}
+              className="h-full w-full border-0 bg-background"
+              referrerPolicy="no-referrer"
+              onLoad={() => {
+                setIsLoading(false);
+              }}
+            />
+            {isLoading ? (
+              <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-center p-3">
+                <div className="rounded-full border border-border/50 bg-[color-mix(in_srgb,var(--surface-elevated)_92%,transparent)] px-3 py-1 typography-micro text-muted-foreground shadow-sm backdrop-blur-sm">
+                  Loading
+                </div>
+              </div>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -183,7 +183,8 @@ export const useKeyboardShortcuts = () => {
         }
 
         const tabs = ['git', 'files', 'context'] as const;
-        const currentIndex = tabs.indexOf(rightSidebarTab);
+        const currentTab = rightSidebarTab === 'browser' ? 'context' : rightSidebarTab;
+        const currentIndex = tabs.indexOf(currentTab);
         const nextTab = tabs[(currentIndex + 1) % tabs.length];
 
         e.preventDefault();

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -6,7 +6,7 @@ import { SEMANTIC_TYPOGRAPHY, getTypographyVariable, type SemanticTypographyKey 
 import type { ShortcutCombo } from '@/lib/shortcuts';
 
 export type MainTab = 'chat' | 'plan' | 'git' | 'diff' | 'terminal' | 'files';
-export type RightSidebarTab = 'git' | 'files' | 'context';
+export type RightSidebarTab = 'git' | 'files' | 'context' | 'browser';
 export type ContextPanelMode = 'diff' | 'file' | 'context' | 'plan' | 'chat';
 export type MermaidRenderingMode = 'svg' | 'ascii';
 export type UserMessageRenderingMode = 'markdown' | 'plain';
@@ -469,6 +469,7 @@ interface UIStore {
   rightSidebarWidth: number;
   hasManuallyResizedRightSidebar: boolean;
   rightSidebarTab: RightSidebarTab;
+  rightSidebarBrowserUrl: string;
   contextPanelByDirectory: Record<string, ContextPanelDirectoryState>;
   isBottomTerminalOpen: boolean;
   isBottomTerminalExpanded: boolean;
@@ -579,6 +580,7 @@ interface UIStore {
   setRightSidebarOpen: (open: boolean) => void;
   setRightSidebarWidth: (width: number) => void;
   setRightSidebarTab: (tab: RightSidebarTab) => void;
+  setRightSidebarBrowserUrl: (url: string) => void;
   openContextPanelTab: (directory: string, tab: ContextPanelTabDescriptor) => void;
   openContextDiff: (directory: string, filePath: string) => void;
   openContextFile: (directory: string, filePath: string) => void;
@@ -711,6 +713,7 @@ export const useUIStore = create<UIStore>()(
         rightSidebarWidth: RIGHT_SIDEBAR_MIN_WIDTH,
         hasManuallyResizedRightSidebar: false,
         rightSidebarTab: 'git',
+        rightSidebarBrowserUrl: '',
         contextPanelByDirectory: {},
         isBottomTerminalOpen: false,
         isBottomTerminalExpanded: false,
@@ -898,6 +901,10 @@ export const useUIStore = create<UIStore>()(
 
         setRightSidebarTab: (tab) => {
           set({ rightSidebarTab: tab });
+        },
+
+        setRightSidebarBrowserUrl: (url) => {
+          set({ rightSidebarBrowserUrl: url.trim() });
         },
 
         openContextPanelTab: (directory, tab) => {
@@ -1830,7 +1837,7 @@ export const useUIStore = create<UIStore>()(
 
           if (
             typeof state.rightSidebarTab !== 'string'
-            || (state.rightSidebarTab !== 'git' && state.rightSidebarTab !== 'files' && state.rightSidebarTab !== 'context')
+            || (state.rightSidebarTab !== 'git' && state.rightSidebarTab !== 'files' && state.rightSidebarTab !== 'context' && state.rightSidebarTab !== 'browser')
           ) {
             state.rightSidebarTab = 'git';
           }


### PR DESCRIPTION
## Summary
- Adds a `Browser` tab to the right sidebar.
- This implementation uses an iframe, so sites that block embedding will not render inside the panel.

## Screenshots

<img width="1830" height="1172" alt="image" src="https://github.com/user-attachments/assets/31bea3f7-584b-412e-8b63-f546e0577c79" />

