### PR TITLE
fix: eliminate parent-child session desync across reconnect and navigation

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -1928,7 +1928,7 @@ const ToolPart: React.FC<ToolPartProps> = ({
     const taskSessionId = explicitTaskSessionId ?? fallbackTaskSessionId;
 
     const childSessionMessages = useSessionMessageRecords(taskSessionId ?? '', currentDirectory);
-    useEnsureSessionMessages(taskSessionId ?? '', currentDirectory)
+    useEnsureSessionMessages(taskSessionId ?? '', currentDirectory);
 
     const metadataTaskSummaryEntries = React.useMemo<TaskToolSummaryEntry[]>(() => {
         if (!isTaskTool) {

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -12,7 +12,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { useOptionalThemeSystem } from '@/contexts/useThemeSystem';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
-import { useDirectorySync, useSessionMessageRecords } from '@/sync/sync-context';
+import { useDirectorySync, useSessionMessageRecords, useEnsureSessionMessages } from '@/sync/sync-context';
 import { getSyncChildStores } from '@/sync/sync-refs';
 import { useUIStore } from '@/stores/useUIStore';
 import { useSessionActivity } from '@/hooks/useSessionActivity';
@@ -1928,6 +1928,7 @@ const ToolPart: React.FC<ToolPartProps> = ({
     const taskSessionId = explicitTaskSessionId ?? fallbackTaskSessionId;
 
     const childSessionMessages = useSessionMessageRecords(taskSessionId ?? '', currentDirectory);
+    useEnsureSessionMessages(taskSessionId ?? '', currentDirectory)
 
     const metadataTaskSummaryEntries = React.useMemo<TaskToolSummaryEntry[]>(() => {
         if (!isTaskTool) {

--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -35,6 +35,8 @@ export type EventPipelineInput = {
   onReconnect?: () => void
   /** Called when the stream disconnects (heartbeat timeout, network error, or transport failure). */
   onDisconnect?: (reason: string) => void
+  /** Called when transport switches (e.g. WS timeout → SSE fallback) without actual disconnection. */
+  onTransportSwitch?: () => void
   transport?: "auto" | "ws" | "sse"
 }
 
@@ -144,7 +146,7 @@ type DirectoryQueue = {
 }
 
 export function createEventPipeline(input: EventPipelineInput) {
-  const { sdk, onEvent, onReconnect, onDisconnect, routeDirectory, transport = "auto" } = input
+  const { sdk, onEvent, onReconnect, onDisconnect, onTransportSwitch, routeDirectory, transport = "auto" } = input
   const abort = new AbortController()
   let disconnected = false
   let lastEventId: string | undefined
@@ -514,6 +516,12 @@ export function createEventPipeline(input: EventPipelineInput) {
         const code = typeof error === "object" && error !== null ? (error as { code?: unknown }).code : undefined
         if (currentTransport === "ws" && code === "WS_FALLBACK") {
           retryDelayMs = 0
+          // Transport switch (WS → SSE fallback), not a real disconnection.
+          // No events were lost — the next attempt will use SSE and carry
+          // lastEventId for gapless replay. Notify consumer so it can set
+          // isConnected, but do NOT treat this as a disconnection requiring
+          // a full directory resync.
+          onTransportSwitch?.()
         } else if (!isAbortError(error)) {
           if (!streamErrorLogged) {
             streamErrorLogged = true

--- a/packages/ui/src/sync/index.ts
+++ b/packages/ui/src/sync/index.ts
@@ -70,6 +70,7 @@ export {
   useSyncDirectory,
   useChildStoreManager,
   useSessionMessageRecords,
+  useEnsureSessionMessages,
   useSessionTextMessages,
   useUserMessageHistory,
   buildSessionMessageRecordsSnapshot,

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1116,7 +1116,30 @@ function handleEvent(
     }
   }
 
-  // Read live state, create targeted draft cloning ONLY fields the event
+  // Sync-layer parent resync: when a child session goes idle, schedule
+  // a targeted parts repair for the parent session. This ensures the
+  // parent's task tool part reflects the child's completion even when
+  // no ToolPart component is mounted.
+  if (payload.type === "session.idle" && sessionID) {
+    const sessionState = store.getState()
+    const idleSession = sessionState.session.find((s) => s.id === sessionID)
+    const parentID = idleSession
+      ? (idleSession as Session & { parentID?: string | null }).parentID
+      : null
+    if (parentID && resolvedDirectory && resolvedDirectory !== "global") {
+      void Promise.resolve().then(async () => {
+        const dirStore = childStores.getChild(resolvedDirectory)
+        if (!dirStore) return
+        try {
+          await repairSessionParts(resolvedDirectory, parentID, dirStore)
+        } catch {
+          // Transient failure — next event or reconnect will catch up
+        }
+      })
+    }
+  }
+
+  // Read live state, create targeted draft cloning ONLY fields that event
   // type will mutate. This preserves reference identity for untouched slices
   // so Zustand selectors skip re-renders for unrelated subscribers.
   const current = store.getState()

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1365,6 +1365,12 @@ export function SyncProvider(props: {
       onDisconnect: (reason) => {
         useConfigStore.setState({ isConnected: false, lastDisconnectReason: reason })
       },
+      onTransportSwitch: () => {
+        // Transport switched (e.g. WS timeout → SSE fallback) without
+        // actual disconnection. No events lost — just update connection
+        // state without triggering a full directory resync.
+        useConfigStore.setState({ isConnected: true })
+      },
     })
     return cleanup
   }, [props.sdk, childStores, routingIndex, messageStreamTransport])

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -750,7 +750,6 @@ async function resyncDirectoryAfterReconnect(
       .filter((record) => !!record?.info?.id)
       .map((record) => stripMessageDiffSnapshots(record.info))
       .sort((a, b) => cmp(a.id, b.id))
-    const nextMessageIds = new Set(nextMessages.map((message) => message.id))
 
     store.setState((state: DirectoryStore) => {
       const sessions = [...state.session]
@@ -1120,22 +1119,25 @@ function handleEvent(
   // a targeted parts repair for the parent session. This ensures the
   // parent's task tool part reflects the child's completion even when
   // no ToolPart component is mounted.
-  if (payload.type === "session.idle" && sessionID) {
-    const sessionState = store.getState()
-    const idleSession = sessionState.session.find((s) => s.id === sessionID)
-    const parentID = idleSession
-      ? (idleSession as Session & { parentID?: string | null }).parentID
-      : null
-    if (parentID && resolvedDirectory && resolvedDirectory !== "global") {
-      void Promise.resolve().then(async () => {
-        const dirStore = childStores.getChild(resolvedDirectory)
-        if (!dirStore) return
-        try {
-          await repairSessionParts(resolvedDirectory, parentID, dirStore)
-        } catch {
-          // Transient failure — next event or reconnect will catch up
-        }
-      })
+  if (payload.type === "session.idle") {
+    const idleSessionId = getSessionIdFromPayload(payload)
+    if (idleSessionId && resolvedDirectory && resolvedDirectory !== "global") {
+      const sessionState = store.getState()
+      const idleSession = sessionState.session.find((s) => s.id === idleSessionId)
+      const parentID = idleSession
+        ? (idleSession as Session & { parentID?: string | null }).parentID
+        : null
+      if (parentID) {
+        void Promise.resolve().then(async () => {
+          const dirStore = childStores.getChild(resolvedDirectory)
+          if (!dirStore) return
+          try {
+            await repairSessionParts(resolvedDirectory, parentID, dirStore)
+          } catch {
+            // Transient failure — next event or reconnect will catch up
+          }
+        })
+      }
     }
   }
 
@@ -1918,9 +1920,9 @@ export function useEnsureSessionMessages(sessionID: string, directory?: string) 
 
     void (async () => {
       try {
-        const scopedClient = opencodeClient.getScopedSdkClient(dir)
+        const scopedClient = opencodeClient.getScopedSdkClient(dir ?? "")
         const response = await scopedClient.session.messages({
-          sessionID,
+          sessionID: sessionID,
           limit: RECONNECT_MESSAGE_LIMIT,
         })
         const records = (response.data ?? []).filter(

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -291,6 +291,21 @@ function getReconnectCandidateSessionIds(state: State) {
     }
   }
 
+  // Ensure parent sessions of any child sessions are also resynced.
+  // A child may have completed during the disconnect gap without the
+  // store knowing (SSE events lost). The parent's task tool part needs
+  // to reflect the child's final state.
+  const parentIds = new Set<string>()
+  for (const session of state.session) {
+    const parentId = (session as Session & { parentID?: string | null }).parentID
+    if (parentId) {
+      parentIds.add(parentId)
+    }
+  }
+  for (const pid of parentIds) {
+    ids.add(pid)
+  }
+
   return Array.from(ids)
 }
 
@@ -755,13 +770,10 @@ async function resyncDirectoryAfterReconnect(
         sessionChanged = true
       }
 
+      // Merge parts: overwrite only messages present in the fetch snapshot.
+      // Do NOT delete parts for messages that may have been added by SSE
+      // events arriving between the fetch and the setState — those are more recent.
       const nextPartState = { ...state.part }
-      const previousMessages = state.message[sessionId] ?? []
-      for (const message of previousMessages) {
-        if (!nextMessageIds.has(message.id)) {
-          delete nextPartState[message.id]
-        }
-      }
       for (const record of records) {
         const messageId = record?.info?.id
         if (!messageId) continue

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1128,15 +1128,7 @@ function handleEvent(
         ? (idleSession as Session & { parentID?: string | null }).parentID
         : null
       if (parentID) {
-        void Promise.resolve().then(async () => {
-          const dirStore = childStores.getChild(resolvedDirectory)
-          if (!dirStore) return
-          try {
-            await repairSessionParts(resolvedDirectory, parentID, dirStore)
-          } catch {
-            // Transient failure — next event or reconnect will catch up
-          }
-        })
+        enqueuePartsRepair(resolvedDirectory, parentID, childStores)
       }
     }
   }
@@ -1900,9 +1892,14 @@ export function useSessionMessageRecords(
  * whose child session messages were never loaded — bootstrap only loads
  * session metadata, not messages.
  */
+
+// Module-level in-flight tracking for useEnsureSessionMessages.
+// Prevents redundant parallel fetches when multiple component instances
+// (e.g. multiple ToolParts) request the same session's messages.
+const _ensureMessagesLoading = new Set<string>()
+
 export function useEnsureSessionMessages(sessionID: string, directory?: string) {
   const store = useDirectoryStore(directory)
-  const loadingRef = React.useRef<Set<string>>(new Set())
 
   React.useEffect(() => {
     if (!sessionID) return
@@ -1912,11 +1909,13 @@ export function useEnsureSessionMessages(sessionID: string, directory?: string) 
     if (Object.prototype.hasOwnProperty.call(state.message, sessionID)) return
     // Session doesn't exist — nothing to load
     if (!state.session.some((s) => s.id === sessionID)) return
-    // Already loading this session
-    if (loadingRef.current.has(sessionID)) return
 
-    loadingRef.current.add(sessionID)
     const dir = directory ?? opencodeClient.getDirectory()
+    const loadingKey = `${dir ?? ""}:${sessionID}`
+    // Already loading this session for this directory
+    if (_ensureMessagesLoading.has(loadingKey)) return
+
+    _ensureMessagesLoading.add(loadingKey)
 
     void (async () => {
       try {
@@ -1951,7 +1950,7 @@ export function useEnsureSessionMessages(sessionID: string, directory?: string) 
       } catch {
         // Transient failure — next navigation or reconnect will retry
       } finally {
-        loadingRef.current.delete(sessionID)
+        _ensureMessagesLoading.delete(loadingKey)
       }
     })()
   }, [sessionID, store, directory])

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1867,6 +1867,72 @@ export function useSessionMessageRecords(
 }
 
 /**
+ * Ensures a session's messages are loaded into the sync store.
+ * If the session exists in state.session but messages haven't been fetched
+ * (state.message[sessionID] is absent), triggers a background API fetch.
+ *
+ * This covers the case where a user navigates to an old parent session
+ * whose child session messages were never loaded — bootstrap only loads
+ * session metadata, not messages.
+ */
+export function useEnsureSessionMessages(sessionID: string, directory?: string) {
+  const store = useDirectoryStore(directory)
+  const loadingRef = React.useRef<Set<string>>(new Set())
+
+  React.useEffect(() => {
+    if (!sessionID) return
+
+    const state = store.getState()
+    // Already loaded — nothing to do
+    if (Object.prototype.hasOwnProperty.call(state.message, sessionID)) return
+    // Session doesn't exist — nothing to load
+    if (!state.session.some((s) => s.id === sessionID)) return
+    // Already loading this session
+    if (loadingRef.current.has(sessionID)) return
+
+    loadingRef.current.add(sessionID)
+    const dir = directory ?? opencodeClient.getDirectory()
+
+    void (async () => {
+      try {
+        const scopedClient = opencodeClient.getScopedSdkClient(dir)
+        const response = await scopedClient.session.messages({
+          sessionID,
+          limit: RECONNECT_MESSAGE_LIMIT,
+        })
+        const records = (response.data ?? []).filter(
+          (record: { info?: { id?: string } }) => !!record?.info?.id,
+        )
+        if (records.length === 0) return
+
+        const nextMessages = records
+          .map((record: { info: Message }) => stripMessageDiffSnapshots(record.info))
+          .filter((m: Message | null): m is Message => m !== null)
+          .sort((a: Message, b: Message) => cmp(a.id, b.id))
+
+        const nextPartState: Record<string, Part[]> = {}
+        for (const record of records) {
+          const messageId = record?.info?.id
+          if (!messageId) continue
+          nextPartState[messageId] = (record.parts ?? [])
+            .filter((part: Part) => !!part?.id && !RECONNECT_SKIP_PARTS.has(part.type))
+            .sort((a: Part, b: Part) => cmp(a.id, b.id))
+        }
+
+        store.setState((state: DirectoryStore) => ({
+          message: { ...state.message, [sessionID]: nextMessages },
+          part: { ...state.part, ...nextPartState },
+        }))
+      } catch {
+        // Transient failure — next navigation or reconnect will retry
+      } finally {
+        loadingRef.current.delete(sessionID)
+      }
+    })()
+  }, [sessionID, store, directory])
+}
+
+/**
  * Determines if a session is actively working.
  * Checks session_status and only falls back to incomplete assistant messages
  * when authoritative status is missing.


### PR DESCRIPTION
## Summary

Fixes parent-child session message desynchronization across reconnect, transport switch, and navigation.

### Root causes fixed

1. **Transport switch ≠ disconnection**: WS timeout → SSE fallback fired `onDisconnect` → `onReconnect` → full directory resync, causing unnecessary state churn.
2. **Reconnect missed idle parents**: `getReconnectCandidateSessionIds` only selected "busy" sessions. If a child completed during disconnect, neither child nor parent was resynced.
3. **Parent resync replaced entire `part` state**: Parts from SSE events arriving between API fetch and `setState` could be silently deleted.
4. **Child messages never bootstrapped**: `session.list(roots: true)` loads only session metadata. Navigating to an old parent session showed empty child messages.
5. **ToolPart resync only works when mounted**: User navigates away → child completes → returns to parent → state permanently stale — no recovery path.

---

## Commits

| Commit | Change |
|--------|--------|
| `fb698f11` | **fix(pipeline): distinguish transport switch from real disconnect** — WS_FALLBACK errors fire `onTransportSwitch` (update connected state only, no resync). True disconnections (heartbeat timeout, network error) still trigger full resync cycle. |
| `da47c362` | **fix(sync): relationship-aware reconnect with merge-not-replace** — Candidate selection now includes parent sessions of any child sessions. Parent resync merges parts instead of replacing: only overwrites fetched messages, preserves SSE-delivered parts. |
| `7ec951b4` | **fix(sync): demand-load child session messages on access** — New `useEnsureSessionMessages` hook detects when a session exists in metadata but messages haven't been loaded, and triggers a background API fetch. Called from ToolPart for the child session. |
| `c599833b` | **fix(sync): unmount-safe parent resync when child session goes idle** — When a `session.idle` event arrives for a child session, the sync layer schedules a targeted `repairSessionParts` for the parent. Covers all cases where ToolPart is not mounted. |
| `a4ca8f8f` | **fix: type-check fixes for sync-layer parent resync** — Remove unused variables after refactor. |

---

## What reviewers should test

- **Transport switch**: Enable "auto" transport mode, force a slow OpenCode response. The WS→SSE switch should not flash "Disconnected" in the UI.
- **Reconnect with subagent**: Start a subagent, disconnect network, let subagent complete, reconnect. Parent task tool part should show completion — not "Running".
- **Navigate to old session**: Load a session with completed subagents from a previous day. Child messages and summaries should appear without manual refresh.
- **Mid-navigation child completion**: Start subagent, navigate to a different session, wait for completion, navigate back to parent. Task tool part should show final state.

---

## What is NOT fixed (follow-up PR)

- **`staleDeltas` gating**: The delta drop mechanism still fires during coalesce phase, not gated by reducer confirmation. Addressed in separate PR to avoid scope creep here.