### PR TITLE
feat: add 'Open files in preview mode' setting

### DIFF
--- a/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
@@ -31,6 +31,7 @@ export const DefaultsSettings: React.FC = () => {
   const setSettingsDefaultVariant = useConfigStore((state) => state.setSettingsDefaultVariant);
   const setSettingsDefaultAgent = useConfigStore((state) => state.setSettingsDefaultAgent);
   const setSettingsDefaultFileViewerPreview = useConfigStore((state) => state.setSettingsDefaultFileViewerPreview);
+  const settingsDefaultFileViewerPreview = useConfigStore((state) => state.settingsDefaultFileViewerPreview);
   const showDeletionDialog = useUIStore((state) => state.showDeletionDialog);
   const setShowDeletionDialog = useUIStore((state) => state.setShowDeletionDialog);
   const providers = useConfigStore((state) => state.providers);
@@ -38,7 +39,6 @@ export const DefaultsSettings: React.FC = () => {
   const [defaultModel, setDefaultModel] = React.useState<string | undefined>();
   const [defaultVariant, setDefaultVariant] = React.useState<string | undefined>();
   const [defaultAgent, setDefaultAgent] = React.useState<string | undefined>();
-  const [defaultFileViewerPreview, setDefaultFileViewerPreview] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(true);
 
   const parsedModel = React.useMemo(() => getDisplayModel(defaultModel), [defaultModel]);
@@ -50,7 +50,6 @@ export const DefaultsSettings: React.FC = () => {
           defaultModel?: string;
           defaultVariant?: string;
           defaultAgent?: string;
-          defaultFileViewerPreview?: boolean;
         } | null = null;
 
         if (!data) {
@@ -67,9 +66,6 @@ export const DefaultsSettings: React.FC = () => {
                       ? ((settings as Record<string, unknown>).defaultVariant as string)
                       : undefined,
                   defaultAgent: typeof settings.defaultAgent === 'string' ? settings.defaultAgent : undefined,
-                  defaultFileViewerPreview: typeof (settings as Record<string, unknown>).defaultFileViewerPreview === 'boolean'
-                    ? ((settings as Record<string, unknown>).defaultFileViewerPreview as boolean)
-                    : undefined,
                 };
               }
             } catch {
@@ -105,7 +101,6 @@ export const DefaultsSettings: React.FC = () => {
           if (model !== undefined) setDefaultModel(model);
           if (variant !== undefined) setDefaultVariant(variant);
           if (agent !== undefined) setDefaultAgent(agent);
-          if (typeof data.defaultFileViewerPreview === 'boolean') setDefaultFileViewerPreview(data.defaultFileViewerPreview);
         }
       } catch (error) {
         console.warn('Failed to load defaults settings:', error);
@@ -193,6 +188,12 @@ export const DefaultsSettings: React.FC = () => {
     },
     [setAgent, setSettingsDefaultAgent]
   );
+
+  const handleToggleFileViewerPreview = React.useCallback(() => {
+    const next = !settingsDefaultFileViewerPreview;
+    setSettingsDefaultFileViewerPreview(next);
+    updateDesktopSettings({ defaultFileViewerPreview: next }).catch(console.warn);
+  }, [settingsDefaultFileViewerPreview, setSettingsDefaultFileViewerPreview]);
 
   const availableVariants = React.useMemo(() => {
     if (!parsedModel.providerId || !parsedModel.modelId) return [];
@@ -311,24 +312,16 @@ export const DefaultsSettings: React.FC = () => {
           className="group flex cursor-pointer items-center gap-2 py-1"
           role="button"
           tabIndex={0}
-          aria-pressed={defaultFileViewerPreview}
-          onClick={() => {
-            const next = !defaultFileViewerPreview;
-            setDefaultFileViewerPreview(next);
-            setSettingsDefaultFileViewerPreview(next);
-            updateDesktopSettings({ defaultFileViewerPreview: next }).catch(console.warn);
-          }}
+          aria-pressed={settingsDefaultFileViewerPreview}
+          onClick={handleToggleFileViewerPreview}
           onKeyDown={(event) => {
             if (event.key === ' ' || event.key === 'Enter') {
               event.preventDefault();
-              const next = !defaultFileViewerPreview;
-              setDefaultFileViewerPreview(next);
-              setSettingsDefaultFileViewerPreview(next);
-              updateDesktopSettings({ defaultFileViewerPreview: next }).catch(console.warn);
+              handleToggleFileViewerPreview();
             }
           }}
         >
-          <Checkbox checked={defaultFileViewerPreview} onChange={setDefaultFileViewerPreview} ariaLabel="Open files in preview mode" />
+          <Checkbox checked={settingsDefaultFileViewerPreview} onChange={setSettingsDefaultFileViewerPreview} ariaLabel="Open files in preview mode" />
           <span className="typography-ui-label text-foreground">Open files in preview mode</span>
         </div>
 

--- a/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
@@ -30,6 +30,7 @@ export const DefaultsSettings: React.FC = () => {
   const setSettingsDefaultModel = useConfigStore((state) => state.setSettingsDefaultModel);
   const setSettingsDefaultVariant = useConfigStore((state) => state.setSettingsDefaultVariant);
   const setSettingsDefaultAgent = useConfigStore((state) => state.setSettingsDefaultAgent);
+  const setSettingsDefaultFileViewerPreview = useConfigStore((state) => state.setSettingsDefaultFileViewerPreview);
   const showDeletionDialog = useUIStore((state) => state.showDeletionDialog);
   const setShowDeletionDialog = useUIStore((state) => state.setShowDeletionDialog);
   const providers = useConfigStore((state) => state.providers);
@@ -37,6 +38,7 @@ export const DefaultsSettings: React.FC = () => {
   const [defaultModel, setDefaultModel] = React.useState<string | undefined>();
   const [defaultVariant, setDefaultVariant] = React.useState<string | undefined>();
   const [defaultAgent, setDefaultAgent] = React.useState<string | undefined>();
+  const [defaultFileViewerPreview, setDefaultFileViewerPreview] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(true);
 
   const parsedModel = React.useMemo(() => getDisplayModel(defaultModel), [defaultModel]);
@@ -48,6 +50,7 @@ export const DefaultsSettings: React.FC = () => {
           defaultModel?: string;
           defaultVariant?: string;
           defaultAgent?: string;
+          defaultFileViewerPreview?: boolean;
         } | null = null;
 
         if (!data) {
@@ -64,6 +67,9 @@ export const DefaultsSettings: React.FC = () => {
                       ? ((settings as Record<string, unknown>).defaultVariant as string)
                       : undefined,
                   defaultAgent: typeof settings.defaultAgent === 'string' ? settings.defaultAgent : undefined,
+                  defaultFileViewerPreview: typeof (settings as Record<string, unknown>).defaultFileViewerPreview === 'boolean'
+                    ? ((settings as Record<string, unknown>).defaultFileViewerPreview as boolean)
+                    : undefined,
                 };
               }
             } catch {
@@ -99,6 +105,7 @@ export const DefaultsSettings: React.FC = () => {
           if (model !== undefined) setDefaultModel(model);
           if (variant !== undefined) setDefaultVariant(variant);
           if (agent !== undefined) setDefaultAgent(agent);
+          if (typeof data.defaultFileViewerPreview === 'boolean') setDefaultFileViewerPreview(data.defaultFileViewerPreview);
         }
       } catch (error) {
         console.warn('Failed to load defaults settings:', error);
@@ -298,6 +305,31 @@ export const DefaultsSettings: React.FC = () => {
         >
           <Checkbox checked={showDeletionDialog} onChange={setShowDeletionDialog} ariaLabel="Show deletion dialog" />
           <span className="typography-ui-label text-foreground">Show Deletion Dialog</span>
+        </div>
+
+        <div
+          className="group flex cursor-pointer items-center gap-2 py-1"
+          role="button"
+          tabIndex={0}
+          aria-pressed={defaultFileViewerPreview}
+          onClick={() => {
+            const next = !defaultFileViewerPreview;
+            setDefaultFileViewerPreview(next);
+            setSettingsDefaultFileViewerPreview(next);
+            updateDesktopSettings({ defaultFileViewerPreview: next }).catch(console.warn);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === ' ' || event.key === 'Enter') {
+              event.preventDefault();
+              const next = !defaultFileViewerPreview;
+              setDefaultFileViewerPreview(next);
+              setSettingsDefaultFileViewerPreview(next);
+              updateDesktopSettings({ defaultFileViewerPreview: next }).catch(console.warn);
+            }
+          }}
+        >
+          <Checkbox checked={defaultFileViewerPreview} onChange={setDefaultFileViewerPreview} ariaLabel="Open files in preview mode" />
+          <span className="typography-ui-label text-foreground">Open files in preview mode</span>
         </div>
 
       </section>

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -1866,13 +1866,26 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
   }, [canEdit, textViewMode]);
 
+  const MD_VIEWER_MODE_KEY = 'openchamber:files:md-viewer-mode';
+  const HTML_VIEWER_MODE_KEY = 'openchamber:files:html-viewer-mode';
+
   React.useEffect(() => {
     const defaultMode = settingsDefaultFileViewerPreview ? 'view' : 'edit';
     setTextViewMode(defaultMode);
-    setHtmlViewMode(settingsDefaultFileViewerPreview ? 'preview' : 'edit');
-  }, [selectedFile?.path, settingsDefaultFileViewerPreview]);
 
-  const MD_VIEWER_MODE_KEY = 'openchamber:files:md-viewer-mode';
+    // Respect per-type localStorage preference when available,
+    // falling back to the setting-derived default when nothing is stored.
+    let htmlDefault: 'preview' | 'edit' = settingsDefaultFileViewerPreview ? 'preview' : 'edit';
+    try {
+      const stored = localStorage.getItem(HTML_VIEWER_MODE_KEY);
+      if (stored === 'preview' || stored === 'edit') {
+        htmlDefault = stored;
+      }
+    } catch {
+      // Ignore localStorage errors
+    }
+    setHtmlViewMode(htmlDefault);
+  }, [selectedFile?.path, settingsDefaultFileViewerPreview]);
 
   React.useEffect(() => {
     try {
@@ -1909,21 +1922,6 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
         setJsonViewMode('tree');
       } else if (stored === 'text') {
         setJsonViewMode('text');
-      }
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, []);
-
-  const HTML_VIEWER_MODE_KEY = 'openchamber:files:html-viewer-mode';
-
-  React.useEffect(() => {
-    try {
-      const stored = localStorage.getItem(HTML_VIEWER_MODE_KEY);
-      if (stored === 'preview') {
-        setHtmlViewMode('preview');
-      } else if (stored === 'edit') {
-        setHtmlViewMode('edit');
       }
     } catch {
       // Ignore localStorage errors

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -1875,6 +1875,17 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
     // Respect per-type localStorage preference when available,
     // falling back to the setting-derived default when nothing is stored.
+    let mdDefault: 'preview' | 'edit' = settingsDefaultFileViewerPreview ? 'preview' : 'edit';
+    try {
+      const stored = localStorage.getItem(MD_VIEWER_MODE_KEY);
+      if (stored === 'preview' || stored === 'edit') {
+        mdDefault = stored;
+      }
+    } catch {
+      // Ignore localStorage errors
+    }
+    setMdViewMode(mdDefault);
+
     let htmlDefault: 'preview' | 'edit' = settingsDefaultFileViewerPreview ? 'preview' : 'edit';
     try {
       const stored = localStorage.getItem(HTML_VIEWER_MODE_KEY);
@@ -1886,19 +1897,6 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
     setHtmlViewMode(htmlDefault);
   }, [selectedFile?.path, settingsDefaultFileViewerPreview]);
-
-  React.useEffect(() => {
-    try {
-      const stored = localStorage.getItem(MD_VIEWER_MODE_KEY);
-      if (stored === 'preview') {
-        setMdViewMode('preview');
-      } else if (stored === 'edit') {
-        setMdViewMode('edit');
-      }
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, []);
 
   const saveMdViewMode = React.useCallback((mode: 'preview' | 'edit') => {
     setMdViewMode(mode);

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -71,6 +71,7 @@ import { useThemeSystem } from '@/contexts/useThemeSystem';
 import { useUIStore } from '@/stores/useUIStore';
 import { useFilesViewTabsStore } from '@/stores/useFilesViewTabsStore';
 import { useGitStatus } from '@/stores/useGitStore';
+import { useConfigStore } from '@/stores/useConfigStore';
 import { buildCodeMirrorCommentWidgets, normalizeLineRange, useInlineCommentController } from '@/components/comments';
 import { opencodeClient } from '@/lib/opencode/client';
 import { useDirectoryShowHidden } from '@/lib/directoryShowHidden';
@@ -729,6 +730,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const pendingFileFocusPath = useUIStore((state) => state.pendingFileFocusPath);
   const setPendingFileFocusPath = useUIStore((state) => state.setPendingFileFocusPath);
   const shortcutOverrides = useUIStore((state) => state.shortcutOverrides);
+  const settingsDefaultFileViewerPreview = useConfigStore((state) => state.settingsDefaultFileViewerPreview);
 
   // Global mouseup to end drag selection
   React.useEffect(() => {
@@ -1865,9 +1867,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   }, [canEdit, textViewMode]);
 
   React.useEffect(() => {
-    setTextViewMode('edit');
-    setHtmlViewMode('edit');
-  }, [selectedFile?.path]);
+    const defaultMode = settingsDefaultFileViewerPreview ? 'view' : 'edit';
+    setTextViewMode(defaultMode);
+    setHtmlViewMode(settingsDefaultFileViewerPreview ? 'preview' : 'edit');
+  }, [selectedFile?.path, settingsDefaultFileViewerPreview]);
 
   const MD_VIEWER_MODE_KEY = 'openchamber:files:md-viewer-mode';
 

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -115,6 +115,7 @@ export type DesktopSettings = {
   autoCreateWorktree?: boolean;
   queueModeEnabled?: boolean;
   gitmojiEnabled?: boolean;
+  defaultFileViewerPreview?: boolean;
   zenModel?: string;
   gitProviderId?: string;
   gitModelId?: string;

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -28,6 +28,7 @@ interface OpenChamberDefaults {
     defaultAgent?: string;
     autoCreateWorktree?: boolean;
     gitmojiEnabled?: boolean;
+    defaultFileViewerPreview?: boolean;
     zenModel?: string;
     messageStreamTransport?: 'auto' | 'ws' | 'sse';
 }
@@ -45,6 +46,7 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
                     const defaultVariant = typeof data?.defaultVariant === 'string' ? data.defaultVariant.trim() : '';
                     const defaultAgent = typeof data?.defaultAgent === 'string' ? data.defaultAgent.trim() : '';
                     const gitmojiEnabled = typeof data?.gitmojiEnabled === 'boolean' ? data.gitmojiEnabled : undefined;
+                    const defaultFileViewerPreview = typeof data?.defaultFileViewerPreview === 'boolean' ? data.defaultFileViewerPreview : undefined;
                     const zenModel = typeof data?.zenModel === 'string' ? data.zenModel.trim() : '';
                     const messageStreamTransport =
                         data?.messageStreamTransport === 'ws' || data?.messageStreamTransport === 'sse' || data?.messageStreamTransport === 'auto'
@@ -57,6 +59,7 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
                         defaultAgent: defaultAgent.length > 0 ? defaultAgent : undefined,
                         autoCreateWorktree: typeof data?.autoCreateWorktree === 'boolean' ? data.autoCreateWorktree : undefined,
                         gitmojiEnabled,
+                        defaultFileViewerPreview,
                         zenModel: zenModel.length > 0 ? zenModel : undefined,
                         messageStreamTransport,
                     };
@@ -79,6 +82,7 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
         const defaultVariant = typeof data?.defaultVariant === 'string' ? data.defaultVariant.trim() : '';
         const defaultAgent = typeof data?.defaultAgent === 'string' ? data.defaultAgent.trim() : '';
         const gitmojiEnabled = typeof data?.gitmojiEnabled === 'boolean' ? data.gitmojiEnabled : undefined;
+        const defaultFileViewerPreview = typeof data?.defaultFileViewerPreview === 'boolean' ? data.defaultFileViewerPreview : undefined;
         const zenModel = typeof data?.zenModel === 'string' ? data.zenModel.trim() : '';
         const messageStreamTransport =
             data?.messageStreamTransport === 'ws' || data?.messageStreamTransport === 'sse' || data?.messageStreamTransport === 'auto'
@@ -91,6 +95,7 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
             defaultAgent: defaultAgent.length > 0 ? defaultAgent : undefined,
             autoCreateWorktree: typeof data?.autoCreateWorktree === 'boolean' ? data.autoCreateWorktree : undefined,
             gitmojiEnabled,
+            defaultFileViewerPreview,
             zenModel: zenModel.length > 0 ? zenModel : undefined,
             messageStreamTransport,
         };
@@ -477,6 +482,7 @@ interface ConfigStore {
     settingsDefaultAgent: string | undefined;
     settingsAutoCreateWorktree: boolean;
     settingsGitmojiEnabled: boolean;
+    settingsDefaultFileViewerPreview: boolean;
     settingsZenModel: string | undefined;
     settingsMessageStreamTransport: 'auto' | 'ws' | 'sse';
     // Voice provider preference ('browser', 'openai', 'openai-compatible', or 'say' for macOS)
@@ -546,6 +552,7 @@ interface ConfigStore {
     setSettingsDefaultAgent: (agent: string | undefined) => void;
     setSettingsAutoCreateWorktree: (enabled: boolean) => void;
     setSettingsGitmojiEnabled: (enabled: boolean) => void;
+    setSettingsDefaultFileViewerPreview: (enabled: boolean) => void;
     setSettingsZenModel: (model: string | undefined) => void;
     setSettingsMessageStreamTransport: (transport: 'auto' | 'ws' | 'sse') => void;
     getResolvedGitGenerationModel: () => { providerId: string; modelId: string } | null;
@@ -597,6 +604,7 @@ export const useConfigStore = create<ConfigStore>()(
                 settingsDefaultAgent: undefined,
                 settingsAutoCreateWorktree: false,
                 settingsGitmojiEnabled: false,
+                settingsDefaultFileViewerPreview: false,
                 settingsZenModel: undefined,
                 settingsMessageStreamTransport: 'auto',
                 // Voice provider preference - load from localStorage or default to 'browser'
@@ -1271,6 +1279,7 @@ export const useConfigStore = create<ConfigStore>()(
                                     settingsDefaultAgent: openChamberDefaults.defaultAgent,
                                     settingsAutoCreateWorktree: openChamberDefaults.autoCreateWorktree ?? false,
                                     settingsGitmojiEnabled: openChamberDefaults.gitmojiEnabled ?? false,
+                                    settingsDefaultFileViewerPreview: openChamberDefaults.defaultFileViewerPreview ?? false,
                                     settingsZenModel: resolvedZenModel,
                                     settingsMessageStreamTransport: openChamberDefaults.messageStreamTransport ?? state.settingsMessageStreamTransport ?? 'auto',
                                     directoryScoped: {
@@ -1700,6 +1709,10 @@ export const useConfigStore = create<ConfigStore>()(
                     set({ settingsGitmojiEnabled: enabled });
                 },
 
+                setSettingsDefaultFileViewerPreview: (enabled: boolean) => {
+                    set({ settingsDefaultFileViewerPreview: enabled });
+                },
+
                 setSettingsZenModel: (model: string | undefined) => {
                     set({ settingsZenModel: model });
                 },
@@ -2003,6 +2016,7 @@ export const useConfigStore = create<ConfigStore>()(
                     settingsDefaultAgent: state.settingsDefaultAgent,
                     settingsAutoCreateWorktree: state.settingsAutoCreateWorktree,
                     settingsGitmojiEnabled: state.settingsGitmojiEnabled,
+                    settingsDefaultFileViewerPreview: state.settingsDefaultFileViewerPreview,
                     settingsZenModel: state.settingsZenModel,
                     settingsMessageStreamTransport: state.settingsMessageStreamTransport,
                     speechRate: state.speechRate,

--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -289,6 +289,9 @@ export const createSettingsHelpers = (dependencies) => {
     if (typeof candidate.gitmojiEnabled === 'boolean') {
       result.gitmojiEnabled = candidate.gitmojiEnabled;
     }
+    if (typeof candidate.defaultFileViewerPreview === 'boolean') {
+      result.defaultFileViewerPreview = candidate.defaultFileViewerPreview;
+    }
     if (typeof candidate.zenModel === 'string') {
       const trimmed = candidate.zenModel.trim();
       result.zenModel = trimmed.length > 0 ? trimmed : undefined;


### PR DESCRIPTION
## Summary

Adds a new user preference that allows files to open in preview mode by default, rather than edit mode.

## Why

Most work with modern agentic harnesses involves reviewing plans, markdown files, and generated output rather than manually editing source code. This setting gives users the option to default to preview mode, reducing friction for review-heavy workflows where the edit view is rarely needed.

## Changes

- **Backend** (settings-helpers.js): Adds `defaultFileViewerPreview` to the settings sanitizer
- **Config Store** (useConfigStore.ts): Adds state field and setter for the new preference
- **Desktop Settings Type** (desktop.ts): Adds the new field to `DesktopSettings`
- **Settings UI** (DefaultsSettings.tsx): Adds checkbox in Session Defaults section labeled **"Open files in preview mode"**
- **Files View** (FilesView.tsx): Reads the setting and initializes file viewer mode accordingly

## Behavior

- When enabled, files open in preview/view mode by default
- When disabled (default), files open in edit mode (existing behavior)
- Markdown/HTML/JSON files still respect their per-file-type localStorage persistence when available
- Setting persists across sessions via `/api/config/settings`

## Testing

- TypeScript type-check passes
- ESLint passes
- Dev server tested locally with existing OpenCode backend
