### PR TITLE
perf(chat): optimize output generation pipeline

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -30,6 +30,7 @@ import type { TurnGroupingContext } from './lib/turns/types';
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { FadeInOnReveal } from './message/FadeInOnReveal';
 import { streamPerfCount } from '@/stores/utils/streamDebug';
+import { areOptionalRenderRelevantMessagesEqual, areRenderRelevantMessagesEqual, areRelevantTurnGroupingContextsEqual } from './message/renderCompare';
 
 const ToolOutputDialog = React.lazy(() => import('./message/ToolOutputDialog'));
 
@@ -1126,4 +1127,28 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
     );
 };
 
-export default ChatMessage;
+export default React.memo(ChatMessage, (prev, next) => {
+    return areRenderRelevantMessagesEqual(
+        { info: prev.message.info, parts: prev.message.parts },
+        { info: next.message.info, parts: next.message.parts }
+    )
+        && areOptionalRenderRelevantMessagesEqual(
+            prev.previousMessage ? { info: prev.previousMessage.info, parts: prev.previousMessage.parts } : undefined,
+            next.previousMessage ? { info: next.previousMessage.info, parts: next.previousMessage.parts } : undefined
+        )
+        && areOptionalRenderRelevantMessagesEqual(
+            prev.nextMessage ? { info: prev.nextMessage.info, parts: prev.nextMessage.parts } : undefined,
+            next.nextMessage ? { info: next.nextMessage.info, parts: next.nextMessage.parts } : undefined
+        )
+        && prev.isInActiveTurn === next.isInActiveTurn
+        && prev.activeStreamingPhase === next.activeStreamingPhase
+        && prev.assistantHeaderMessageId === next.assistantHeaderMessageId
+        && prev.animateUserOnMount === next.animateUserOnMount
+        && prev.onUserAnimationConsumed === next.onUserAnimationConsumed
+        && areRelevantTurnGroupingContextsEqual(
+            prev.turnGroupingContext,
+            next.turnGroupingContext,
+            prev.message.info.id,
+            deriveMessageRole(prev.message.info).isUser
+        );
+});

--- a/packages/ui/src/components/chat/MarkdownRenderer.tsx
+++ b/packages/ui/src/components/chat/MarkdownRenderer.tsx
@@ -1406,7 +1406,7 @@ const useMermaidInlineInteractions = ({
   }, [allowWheelZoom, containerRef, mermaidBlocks, onShowPopup]);
 };
 
-export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
+const MarkdownRendererImpl: React.FC<MarkdownRendererProps> = ({
   content,
   part,
   messageId,
@@ -1463,7 +1463,20 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   return markdownContent;
 };
 
-export const SimpleMarkdownRenderer: React.FC<{
+export const MarkdownRenderer = React.memo(MarkdownRendererImpl, (prev, next) => {
+  return prev.content === next.content
+    && prev.isStreaming === next.isStreaming
+    && prev.disableStreamAnimation === next.disableStreamAnimation
+    && prev.variant === next.variant
+    && prev.isAnimated === next.isAnimated
+    && prev.skipFadeIn === next.skipFadeIn
+    && prev.className === next.className
+    && prev.messageId === next.messageId
+    && prev.onShowPopup === next.onShowPopup
+    && prev.part?.id === next.part?.id;
+});
+
+const SimpleMarkdownRendererImpl: React.FC<{
   content: string;
   className?: string;
   variant?: MarkdownVariant;
@@ -1523,3 +1536,13 @@ export const SimpleMarkdownRenderer: React.FC<{
     </div>
   );
 };
+
+export const SimpleMarkdownRenderer = React.memo(SimpleMarkdownRendererImpl, (prev, next) => {
+  return prev.content === next.content
+    && prev.variant === next.variant
+    && prev.className === next.className
+    && prev.disableLinkSafety === next.disableLinkSafety
+    && prev.stripFrontmatter === next.stripFrontmatter
+    && prev.onShowPopup === next.onShowPopup
+    && prev.allowMermaidWheelZoom === next.allowMermaidWheelZoom;
+});

--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -16,7 +16,7 @@ import { hasPendingUserSendAnimation, consumePendingUserSendAnimation } from '@/
 import { streamPerfCount, streamPerfMeasure } from '@/stores/utils/streamDebug';
 import type { StreamPhase } from './message/types';
 
-const MESSAGE_LIST_VIRTUALIZE_THRESHOLD = 40;
+const MESSAGE_LIST_VIRTUALIZE_THRESHOLD = 15;
 const MESSAGE_LIST_OVERSCAN = 6;
 
 const estimateHistoryEntryHeight = (entry: RenderEntry | undefined): number => {

--- a/packages/ui/src/sync/streaming.ts
+++ b/packages/ui/src/sync/streaming.ts
@@ -35,80 +35,80 @@ export const useStreamingStore = create<StreamingStore>()(() => ({
  * Called from the SyncBridge/flush handler when child store state changes.
  * Derives streaming state from session_status + messages.
  */
+/** Only update lastUpdateAt every this many ms to avoid 60Hz store churn */
+const STREAMING_HEARTBEAT_MS = 1000
+
 export function updateStreamingState(state: State) {
   const now = Date.now()
+  const currentStore = useStreamingStore.getState()
+  const currentStreamingIds = currentStore.streamingMessageIds
+  const currentStreamStates = currentStore.messageStreamStates
+
   const nextStreamingIds = new Map<string, string | null>()
-  const nextStreamStates = new Map(useStreamingStore.getState().messageStreamStates)
+  const nextStreamStates = new Map(currentStreamStates)
   let changed = false
 
+  // Fast path: only scan sessions that are actually busy.
+  // Idle sessions are handled by checking against currentStreamingIds below.
+  const busySessionIds = new Set<string>()
   for (const [sessionID, status] of Object.entries(state.session_status ?? {})) {
-    const isBusy = (status as SessionStatus).type === "busy"
-    const messages = state.message[sessionID]
-
-    if (isBusy && messages && messages.length > 0) {
-      // Find the last assistant message — that's the one streaming
-      let streamingMsg: Message | null = null
-      for (let i = messages.length - 1; i >= 0; i--) {
-        if (messages[i].role === "assistant") {
-          streamingMsg = messages[i]
-          break
-        }
-      }
-
-      if (streamingMsg) {
-        const prevId = nextStreamingIds.get(sessionID)
-        if (prevId !== streamingMsg.id) changed = true
-        nextStreamingIds.set(sessionID, streamingMsg.id)
-
-        const existing = nextStreamStates.get(streamingMsg.id)
-        if (!existing || existing.phase !== "streaming") {
-          nextStreamStates.set(streamingMsg.id, {
-            phase: "streaming",
-            startedAt: existing?.startedAt ?? now,
-            lastUpdateAt: now,
-          })
-          changed = true
-        } else if (existing.lastUpdateAt !== now) {
-          nextStreamStates.set(streamingMsg.id, {
-            ...existing,
-            lastUpdateAt: now,
-          })
-          changed = true
-        }
-      }
-    } else {
-      // Session is idle — check if we had a streaming message
-      const prev = useStreamingStore.getState().streamingMessageIds.get(sessionID)
-      if (prev) {
-        nextStreamingIds.set(sessionID, null)
-        const existing = nextStreamStates.get(prev)
-        if (existing && existing.phase === "streaming") {
-          // Transition to cooldown then completed
-          nextStreamStates.set(prev, {
-            ...existing,
-            phase: "completed",
-            completedAt: now,
-          })
-          changed = true
-        }
-      }
+    if ((status as SessionStatus).type === "busy") {
+      busySessionIds.add(sessionID)
     }
   }
 
-  // Also mark completed any streaming messages for sessions no longer in status
-  const currentIds = useStreamingStore.getState().streamingMessageIds
-  for (const [sessionID, msgId] of currentIds) {
-    if (msgId && !state.session_status?.[sessionID]) {
-      const existing = nextStreamStates.get(msgId)
-      if (existing && existing.phase === "streaming") {
-        nextStreamStates.set(msgId, {
-          ...existing,
-          phase: "completed",
-          completedAt: now,
-        })
-        changed = true
+  for (const sessionID of busySessionIds) {
+    const messages = state.message[sessionID]
+    if (!messages || messages.length === 0) continue
+
+    // Find the last assistant message — that's the one streaming
+    let streamingMsg: Message | null = null
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant") {
+        streamingMsg = messages[i]
+        break
       }
-      nextStreamingIds.set(sessionID, null)
+    }
+
+    if (!streamingMsg) continue
+
+    const prevId = currentStreamingIds.get(sessionID)
+    if (prevId !== streamingMsg.id) changed = true
+    nextStreamingIds.set(sessionID, streamingMsg.id)
+
+    const existing = nextStreamStates.get(streamingMsg.id)
+    if (!existing || existing.phase !== "streaming") {
+      nextStreamStates.set(streamingMsg.id, {
+        phase: "streaming",
+        startedAt: existing?.startedAt ?? now,
+        lastUpdateAt: now,
+      })
+      changed = true
+    } else if (now - existing.lastUpdateAt >= STREAMING_HEARTBEAT_MS) {
+      // Throttle lastUpdateAt writes to ~1Hz instead of 60Hz
+      nextStreamStates.set(streamingMsg.id, {
+        ...existing,
+        lastUpdateAt: now,
+      })
+      changed = true
+    }
+  }
+
+  // Mark completed any previously streaming sessions that are now idle or gone
+  for (const [sessionID, msgId] of currentStreamingIds) {
+    if (!msgId) continue
+    const isStillBusy = busySessionIds.has(sessionID)
+    if (isStillBusy) continue
+
+    nextStreamingIds.set(sessionID, null)
+    const existing = nextStreamStates.get(msgId)
+    if (existing && existing.phase === "streaming") {
+      nextStreamStates.set(msgId, {
+        ...existing,
+        phase: "completed",
+        completedAt: now,
+      })
+      changed = true
     }
   }
 


### PR DESCRIPTION
## Summary

Reduces React re-render churn and DOM pressure during AI streaming by throttling store writes, lowering the virtualization threshold, and adding selective memoization to hot-path components.

## Changes

| File | Change |
|------|--------|
| `packages/ui/src/sync/streaming.ts` | Throttle `lastUpdateAt` writes from ~60Hz → ~1Hz. Restrict scan to busy sessions only (`Set`, O(1)). |
| `packages/ui/src/components/chat/MessageList.tsx` | Lower `MESSAGE_LIST_VIRTUALIZE_THRESHOLD` from `40` → `15`. |
| `packages/ui/src/components/chat/ChatMessage.tsx` | Wrap export in `React.memo` with custom comparator using existing `areRenderRelevantMessagesEqual` helpers. |
| `packages/ui/src/components/chat/MarkdownRenderer.tsx` | Wrap `MarkdownRenderer` and `SimpleMarkdownRenderer` in `React.memo` with explicit prop comparators. |

## Performance Impact

| Area | Before | After |
|------|--------|-------|
| Streaming store writes | ~60/sec | ~1/sec |
| Session scan scope | All sessions | Busy sessions only |
| Virtualization start | 40 messages | 15 messages |
| ChatMessage re-renders | Every parent update | Only when message changes |
| MarkdownRenderer re-parses | Every parent update | Only when props change |

## Review Feedback Addressed

All Greptile review feedback from the previous iteration has been incorporated:

- `MarkdownRenderer` comparator now includes `part.id` to prevent suppressed animation resets
- `streaming.ts` cleanup loop uses `Set.has()` (O(1)) instead of `Array.includes()` (O(n))
- `ChatMessage` comparator now includes `animateUserOnMount` and `onUserAnimationConsumed`
- `ChatMessage` comparator uses `areRelevantTurnGroupingContextsEqual` instead of reference equality for `turnGroupingContext`

## Testing

- [x] `bun run type-check` passes
- [x] `bun run lint` passes
- [x] Streaming behavior verified (active sessions show typing indicator, completed sessions clear correctly)
- [x] Virtualization verified (conversations >15 messages use virtualizer)
- [x] Message memoization verified (static messages skip re-render)

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally