### PR TITLE
fix: make todo list update dynamically when task status changes

### DIFF
--- a/packages/ui/src/components/chat/message/renderCompare.ts
+++ b/packages/ui/src/components/chat/message/renderCompare.ts
@@ -80,6 +80,13 @@ export const areRenderRelevantPartsEqual = (left: Part[], right: Part[]): boolea
       if (leftTool !== rightTool) {
         return false;
       }
+      // Compare tool output so streaming updates (e.g., todo list progress)
+      // trigger re-renders when the output payload changes.
+      const leftOutput = (leftPart as { output?: unknown }).output;
+      const rightOutput = (rightPart as { output?: unknown }).output;
+      if (leftOutput !== rightOutput) {
+        return false;
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary
Fix todo list UI getting stuck when AI marks tasks as completed / in-progress / pending.

### Root cause
`areRenderRelevantPartsEqual` did not compare the tool part `output` field. When the AI updated a todo list (e.g., marking items completed), the `ToolPart` memo comparator returned `true` and skipped re-render. The UI showed stale task status.

### Fix
Add `output` reference comparison for tool parts in `areRenderRelevantPartsEqual` so streaming tool output updates trigger re-renders correctly.

### Files changed
- `packages/ui/src/components/chat/message/renderCompare.ts` (+7 lines)

## Dependency
Builds on top of **#994** — should be merged after the global AGENTS.md PR.

## Test Plan
- [ ] `bun run type-check`
- [ ] `bun run lint`
- [ ] Start a session with todo list generation
- [ ] Verify task status updates dynamically as AI marks items done
