### PR TITLE
fix(web): support service worker notifications in PWAs

### DIFF
--- a/packages/web/src/api/notifications.ts
+++ b/packages/web/src/api/notifications.ts
@@ -18,6 +18,10 @@ const getNotificationRegistration = async (): Promise<ServiceWorkerRegistration 
     return existing;
   }
 
+  if (!existing) {
+    return null;
+  }
+
   try {
     const ready = await Promise.race<ServiceWorkerRegistration | null>([
       navigator.serviceWorker.ready,

--- a/packages/web/src/api/notifications.ts
+++ b/packages/web/src/api/notifications.ts
@@ -1,5 +1,55 @@
 import type { NotificationPayload, NotificationsAPI } from '@openchamber/ui/lib/api/types';
 
+const SW_READY_TIMEOUT_MS = 1500;
+
+const getNotificationRegistration = async (): Promise<ServiceWorkerRegistration | null> => {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    return null;
+  }
+
+  let existing: ServiceWorkerRegistration | null = null;
+  try {
+    existing = (await navigator.serviceWorker.getRegistration()) ?? null;
+  } catch {
+    existing = null;
+  }
+
+  if (existing?.active) {
+    return existing;
+  }
+
+  try {
+    const ready = await Promise.race<ServiceWorkerRegistration | null>([
+      navigator.serviceWorker.ready,
+      new Promise<null>((resolve) => {
+        setTimeout(() => resolve(null), SW_READY_TIMEOUT_MS);
+      }),
+    ]);
+
+    return ready ?? existing;
+  } catch {
+    return existing;
+  }
+};
+
+const notifyWithServiceWorker = async (payload?: NotificationPayload): Promise<boolean> => {
+  const registration = await getNotificationRegistration();
+  if (!registration || typeof registration.showNotification !== 'function') {
+    return false;
+  }
+
+  try {
+    await registration.showNotification(payload?.title ?? 'OpenChamber', {
+      body: payload?.body,
+      tag: payload?.tag,
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to send notification via service worker', error);
+    return false;
+  }
+};
+
 const notifyWithWebAPI = async (payload?: NotificationPayload): Promise<boolean> => {
   if (typeof Notification === 'undefined') {
     console.info('Notifications not supported in this environment', payload);
@@ -20,6 +70,12 @@ const notifyWithWebAPI = async (payload?: NotificationPayload): Promise<boolean>
   }
 
   try {
+    // Some installed PWAs expose Notification.permission but only allow
+    // notifications through an active service worker registration.
+    if (await notifyWithServiceWorker(payload)) {
+      return true;
+    }
+
     new Notification(payload?.title ?? 'OpenChamber', {
       body: payload?.body,
       tag: payload?.tag,
@@ -58,7 +114,7 @@ const notifyWithTauri = async (payload?: NotificationPayload): Promise<boolean> 
 
 export const createWebNotificationsAPI = (): NotificationsAPI => ({
   async notifyAgentCompletion(payload?: NotificationPayload): Promise<boolean> {
-    return (await notifyWithTauri(payload)) || notifyWithWebAPI(payload);
+    return (await notifyWithTauri(payload)) || (await notifyWithWebAPI(payload));
   },
   canNotify: () => {
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary

This fixes web notifications for installed PWAs.

The current notification flow relies on `new Notification(...)`, but some installed PWAs report `Notification.permission === 'granted'` while only allowing notifications through an active service worker. In that case, agent completion notifications can silently fail.

This change:

- checks for an existing or ready service worker registration
- sends notifications through `registration.showNotification(...)` when available
- falls back to the standard Web Notification API if no usable service worker registration exists
- awaits the web notification path so `notifyAgentCompletion()` returns the correct boolean result

## Why

On desktop-installed PWAs, permission being granted is not always enough for `new Notification(...)` to work reliably. Using the service worker registration first matches how those environments expect notifications to be delivered.

## Testing

- `bun run lint` ✅
- `bun run type-check` ⚠️ fails on existing upstream TypeScript issues unrelated to this change
- `bun run build` ⚠️ fails on existing upstream Base UI / module resolution issues unrelated to this change
