### PR TITLE
fix(ui): preserve slash command message ids

### DIFF
--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -70,9 +70,8 @@ function routeMessage(params: {
   files?: Array<{ type: "file"; mime: string; url: string; filename: string }>
   additionalParts?: Array<{ text: string; synthetic?: boolean; files?: Array<{ type: "file"; mime: string; url: string; filename: string }> }>
 }): Promise<void> {
-  const sdk = opencodeClient.getSdkClient()
-
   if (params.inputMode === "shell") {
+    const sdk = opencodeClient.getSdkClient()
     const dir = opencodeClient.getDirectory() || undefined
     return sdk.session.shell({
       sessionID: params.sessionId,
@@ -96,17 +95,25 @@ function routeMessage(params: {
       || storeCommands.find((c) => c.name === cmdName)
 
     if (isCommand) {
-      const dir = opencodeClient.getDirectory() || undefined
-      return sdk.session.command({
-        sessionID: params.sessionId,
-        directory: dir,
-        command: cmdName,
-        arguments: tail.join(" "),
+      return optimisticSend({
+        sessionId: params.sessionId,
+        content: params.content,
+        providerID: params.providerID,
+        modelID: params.modelID,
         agent: params.agent,
-        model: `${params.providerID}/${params.modelID}`,
-        variant: params.variant,
-        parts: params.files,
-      }).then(() => {})
+        files: params.files,
+        send: (messageID) => opencodeClient.sendCommand({
+          id: params.sessionId,
+          providerID: params.providerID,
+          modelID: params.modelID,
+          command: cmdName,
+          arguments: tail.join(" "),
+          agent: params.agent,
+          variant: params.variant,
+          files: params.files,
+          messageId: messageID,
+        }).then(() => {}),
+      })
     }
   }
 
@@ -130,6 +137,11 @@ function routeMessage(params: {
       messageId: messageID,
     }).then(() => {}),
   })
+}
+
+function notifyMessageSent(sessionId: string): void {
+  fetch(`/api/sessions/${sessionId}/message-sent`, { method: "POST" })
+    .catch(() => { /* ignore */ })
 }
 
 // ---------------------------------------------------------------------------
@@ -755,6 +767,8 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
         await waitForWorktreeBootstrap(createdDirectory)
       }
 
+      notifyMessageSent(created.id)
+
       markPendingUserSendAnimation(created.id)
 
       const files = attachments?.map((a) => ({
@@ -824,8 +838,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     }
 
     if (currentSessionId) {
-      fetch(`/api/sessions/${currentSessionId}/message-sent`, { method: "POST" })
-        .catch(() => { /* ignore */ })
+      notifyMessageSent(currentSessionId)
     }
 
     if (currentSessionId) {


### PR DESCRIPTION
## Summary
- route recognized slash commands in `packages/ui/src/sync/session-ui-store.ts` through `optimisticSend(...)`
- preserve `messageID` when calling `opencodeClient.sendCommand(...)` for `/command` sends
- keep the fix scoped to the session send path and leave the unrelated `ChatInput.tsx` draft-command change out of this PR

## Why
Fresh worktree sessions can lose the first command-style send because the slash-command path bypassed the optimistic message persistence flow used by normal prompt sends. This keeps `/command` endpoint behavior intact while making persistence consistent with other first-message flows.

Fixes #1030

## Testing
- `bun run type-check`
- `bun run lint`
- `bun run build`