### PR TITLE
fix: resolve sidebar stale state after worktree, folder, project, and session mutations

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -407,7 +407,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [currentDirectory, syncSessionStructureSignature]);
+  }, [currentDirectory, syncSessionStructureSignature, projects]);
 
   React.useEffect(() => {
     let refreshTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -922,7 +922,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     normalizedSessionSearchQuery,
     filterSessionNodesForSearch,
     buildGroupSearchText,
-    getFoldersForScope,
+    foldersMap,
   });
 
   const searchEmptyState = (
@@ -1355,7 +1355,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         expandedSessionGroups={expandedSessionGroups}
         collapsedGroups={collapsedGroups}
         hideDirectoryControls={hideDirectoryControls}
-        getFoldersForScope={getFoldersForScope}
         collapsedFolderIds={collapsedFolderIds}
         toggleFolderCollapse={toggleFolderCollapse}
         renameFolder={renameFolder}
@@ -1393,7 +1392,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       expandedSessionGroups,
       collapsedGroups,
       hideDirectoryControls,
-      getFoldersForScope,
       collapsedFolderIds,
       toggleFolderCollapse,
       renameFolder,

--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -19,6 +19,7 @@ import type { SortableDragHandleProps } from './sortableItems';
 import type { GroupSearchData, SessionGroup, SessionNode } from './types';
 import { compareSessionsByPinnedAndTime, isBranchDifferentFromLabel, normalizePath, renderHighlightedText } from './utils';
 import type { SessionFolder } from '@/stores/useSessionFoldersStore';
+import { useSessionFoldersStore } from '@/stores/useSessionFoldersStore';
 import { useSessionDisplayStore } from '@/stores/useSessionDisplayStore';
 import { openExternalUrl } from '@/lib/url';
 import { useI18n } from '@/lib/i18n';
@@ -42,7 +43,6 @@ type Props = {
   expandedSessionGroups: Set<string>;
   collapsedGroups: Set<string>;
   hideDirectoryControls: boolean;
-  getFoldersForScope: (scopeKey: string) => SessionFolder[];
   collapsedFolderIds: Set<string>;
   toggleFolderCollapse: (folderId: string) => void;
   renameFolder: (scopeKey: string, folderId: string, name: string) => void;
@@ -109,7 +109,6 @@ export function SessionGroupSection(props: Props): React.ReactNode {
     expandedSessionGroups,
     collapsedGroups,
     hideDirectoryControls,
-    getFoldersForScope,
     collapsedFolderIds,
     toggleFolderCollapse,
     renameFolder,
@@ -153,6 +152,7 @@ export function SessionGroupSection(props: Props): React.ReactNode {
 
   const searchData = hasSessionSearchQuery ? groupSearchDataByGroup.get(group) : null;
   const displayMode = useSessionDisplayStore((state) => state.displayMode);
+  const foldersMap = useSessionFoldersStore((state) => state.foldersMap);
   const isMinimalMode = displayMode === 'minimal';
   const isExpanded = expandedSessionGroups.has(groupKey);
   const isCollapsed = hasSessionSearchQuery ? false : collapsedGroups.has(groupKey);
@@ -166,8 +166,8 @@ export function SessionGroupSection(props: Props): React.ReactNode {
   );
   const folderScopeKey = group.folderScopeKey ?? normalizePath(group.directory ?? null);
   const scopeFolders = React.useMemo(
-    () => folderScopeKey ? getFoldersForScope(folderScopeKey) : [],
-    [folderScopeKey, getFoldersForScope]
+    () => folderScopeKey ? (foldersMap[folderScopeKey] ?? []) : [],
+    [folderScopeKey, foldersMap]
   );
 
   const nodeBySessionId = React.useMemo(() => {

--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -208,6 +208,7 @@ const areEqual = (prev: Props, next: Props): boolean => {
   if ((prev.secondaryMeta?.branchLabel ?? null) !== (next.secondaryMeta?.branchLabel ?? null)) return false;
   if (prev.mobileVariant !== next.mobileVariant) return false;
   if ((prev.renderContext ?? 'project') !== (next.renderContext ?? 'project')) return false;
+  if (prev.renamingFolderId !== next.renamingFolderId) return false;
 
   return true;
 };

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionSidebarSections.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionSidebarSections.ts
@@ -3,6 +3,7 @@ import type { Session } from '@opencode-ai/sdk/v2';
 import type { SessionGroup, SessionNode, GroupSearchData } from '../types';
 import { dedupeSessionsById, normalizePath } from '../utils';
 import type { WorktreeMetadata } from '@/types/worktree';
+import type { SessionFoldersMap } from '@/stores/useSessionFoldersStore';
 
 type ProjectItem = {
   id: string;
@@ -39,7 +40,7 @@ type Args = {
   normalizedSessionSearchQuery: string;
   filterSessionNodesForSearch: (nodes: SessionNode[], query: string) => SessionNode[];
   buildGroupSearchText: (group: SessionGroup) => string;
-  getFoldersForScope: (scopeKey: string) => Array<{ name: string }>;
+  foldersMap: SessionFoldersMap;
 };
 
 export const useSessionSidebarSections = (args: Args) => {
@@ -56,7 +57,7 @@ export const useSessionSidebarSections = (args: Args) => {
     normalizedSessionSearchQuery,
     filterSessionNodesForSearch,
     buildGroupSearchText,
-    getFoldersForScope,
+    foldersMap,
   } = args;
 
   const projectSections = React.useMemo<ProjectSection[]>(() => {
@@ -107,9 +108,8 @@ export const useSessionSidebarSections = (args: Args) => {
         const matchedSessionCount = countNodes(filteredNodes);
         const groupMatches = buildGroupSearchText(group).includes(normalizedSessionSearchQuery);
         const scopeKey = normalizePath(group.directory ?? null);
-        const folderNameMatchCount = scopeKey
-          ? getFoldersForScope(scopeKey).filter((folder) => folder.name.toLowerCase().includes(normalizedSessionSearchQuery)).length
-          : 0;
+        const scopeFolders = scopeKey ? (foldersMap[scopeKey] ?? []) : [];
+        const folderNameMatchCount = scopeFolders.filter((folder) => folder.name.toLowerCase().includes(normalizedSessionSearchQuery)).length;
 
         result.set(group, {
           filteredNodes,
@@ -128,7 +128,7 @@ export const useSessionSidebarSections = (args: Args) => {
     filterSessionNodesForSearch,
     normalizedSessionSearchQuery,
     buildGroupSearchText,
-    getFoldersForScope,
+    foldersMap,
   ]);
 
   const searchableProjectSections = React.useMemo(() => {

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -358,6 +358,22 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
 
   _worktreeListCache.delete(normalizePath(project.path));
 
+  // Update sidebar store so removed worktree disappears immediately
+  const normalizedWorktreePath = normalizePath(worktree.path);
+  const currentByProject = useSessionUIStore.getState().availableWorktreesByProject;
+  const updatedByProject = new Map(currentByProject);
+  const projectWorktrees = updatedByProject.get(normalizePath(project.path)) ?? [];
+  updatedByProject.set(
+    normalizePath(project.path),
+    projectWorktrees.filter((w) => normalizePath(w.path) !== normalizedWorktreePath),
+  );
+  useSessionUIStore.setState({
+    availableWorktreesByProject: updatedByProject,
+    availableWorktrees: useSessionUIStore.getState().availableWorktrees.filter(
+      (w) => normalizePath(w.path) !== normalizedWorktreePath,
+    ),
+  });
+
   const branchName = (worktree.branch || '').replace(/^refs\/heads\//, '').trim();
   if (deleteRemote && branchName) {
     await deleteRemoteBranch(projectDirectory, { branch: branchName, remote: remoteName }).catch(() => undefined);

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -318,10 +318,11 @@ export async function createWorktree(project: ProjectRef, args: CreateWorktreeAr
   _worktreeListCache.delete(projectDirectory);
 
   // Update sidebar store so new worktree appears immediately
+  const sidebarProjectKey = projectDirectory;
   const currentByProject = useSessionUIStore.getState().availableWorktreesByProject;
   const updatedByProject = new Map(currentByProject);
-  const existing = updatedByProject.get(metadataProjectDirectory) ?? [];
-  updatedByProject.set(metadataProjectDirectory, [...existing, metadata]);
+  const existing = updatedByProject.get(sidebarProjectKey) ?? [];
+  updatedByProject.set(sidebarProjectKey, [...existing, metadata]);
   useSessionUIStore.setState({
     availableWorktreesByProject: updatedByProject,
     availableWorktrees: [...useSessionUIStore.getState().availableWorktrees, metadata],
@@ -342,7 +343,6 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
   remoteName?: string;
 }): Promise<void> {
   const projectDirectory = normalizePath(project.path);
-  const metadataProjectDirectory = await resolvePrimaryWorktreeDirectory(projectDirectory).catch(() => projectDirectory);
 
   const deleteRemote = Boolean(options?.deleteRemoteBranch);
   const deleteLocalBranch = options?.deleteLocalBranch === true;
@@ -361,11 +361,12 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
 
   // Update sidebar store so removed worktree disappears immediately
   const normalizedWorktreePath = normalizePath(worktree.path);
+  const sidebarProjectKey = projectDirectory;
   const currentByProject = useSessionUIStore.getState().availableWorktreesByProject;
   const updatedByProject = new Map(currentByProject);
-  const projectWorktrees = updatedByProject.get(metadataProjectDirectory) ?? [];
+  const projectWorktrees = updatedByProject.get(sidebarProjectKey) ?? [];
   updatedByProject.set(
-    metadataProjectDirectory,
+    sidebarProjectKey,
     projectWorktrees.filter((w) => normalizePath(w.path) !== normalizedWorktreePath),
   );
 

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -13,6 +13,7 @@ import type {
   CreateGitWorktreePayload,
   GitWorktreeValidationResult,
 } from '@/lib/api/types';
+import { useSessionUIStore } from '@/sync/session-ui-store';
 
 type WorktreeListEntry = {
   path?: string;
@@ -315,6 +316,16 @@ export async function createWorktree(project: ProjectRef, args: CreateWorktreeAr
   markWorktreeBootstrapPending(metadata.path);
 
   _worktreeListCache.delete(projectDirectory);
+
+  // Update sidebar store so new worktree appears immediately
+  const currentByProject = useSessionUIStore.getState().availableWorktreesByProject;
+  const updatedByProject = new Map(currentByProject);
+  const existing = updatedByProject.get(metadataProjectDirectory) ?? [];
+  updatedByProject.set(metadataProjectDirectory, [...existing, metadata]);
+  useSessionUIStore.setState({
+    availableWorktreesByProject: updatedByProject,
+    availableWorktrees: [...useSessionUIStore.getState().availableWorktrees, metadata],
+  });
 
   return metadata;
 }

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -368,11 +368,22 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
     metadataProjectDirectory,
     projectWorktrees.filter((w) => normalizePath(w.path) !== normalizedWorktreePath),
   );
+
+  // Clean up worktreeMetadata for sessions in the removed worktree
+  const currentMetadata = useSessionUIStore.getState().worktreeMetadata;
+  const updatedMetadata = new Map(currentMetadata);
+  for (const [sid, meta] of currentMetadata.entries()) {
+    if (meta && normalizePath(meta.path) === normalizedWorktreePath) {
+      updatedMetadata.delete(sid);
+    }
+  }
+
   useSessionUIStore.setState({
     availableWorktreesByProject: updatedByProject,
     availableWorktrees: useSessionUIStore.getState().availableWorktrees.filter(
       (w) => normalizePath(w.path) !== normalizedWorktreePath,
     ),
+    worktreeMetadata: updatedMetadata,
   });
 
   const branchName = (worktree.branch || '').replace(/^refs\/heads\//, '').trim();

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -341,7 +341,8 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
   deleteLocalBranch?: boolean;
   remoteName?: string;
 }): Promise<void> {
-  const projectDirectory = project.path;
+  const projectDirectory = normalizePath(project.path);
+  const metadataProjectDirectory = await resolvePrimaryWorktreeDirectory(projectDirectory).catch(() => projectDirectory);
 
   const deleteRemote = Boolean(options?.deleteRemoteBranch);
   const deleteLocalBranch = options?.deleteLocalBranch === true;
@@ -362,9 +363,9 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
   const normalizedWorktreePath = normalizePath(worktree.path);
   const currentByProject = useSessionUIStore.getState().availableWorktreesByProject;
   const updatedByProject = new Map(currentByProject);
-  const projectWorktrees = updatedByProject.get(normalizePath(project.path)) ?? [];
+  const projectWorktrees = updatedByProject.get(metadataProjectDirectory) ?? [];
   updatedByProject.set(
-    normalizePath(project.path),
+    metadataProjectDirectory,
     projectWorktrees.filter((w) => normalizePath(w.path) !== normalizedWorktreePath),
   );
   useSessionUIStore.setState({

--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -9,6 +9,7 @@ import { getSafeStorage } from './utils/safeStorage';
 import { useDirectoryStore } from './useDirectoryStore';
 import { streamDebugEnabled } from '@/stores/utils/streamDebug';
 import { PROJECT_COLORS } from '@/lib/projectMeta';
+import { useSessionUIStore } from '@/sync/session-ui-store';
 
 /** Pick a color key that's least used among existing projects */
 const pickAutoColor = (projects: ProjectEntry[]): string => {
@@ -399,6 +400,7 @@ export const useProjectsStore = create<ProjectsStore>()(
         return;
       }
       const current = get();
+      const project = current.projects.find((p) => p.id === id);
       const nextProjects = current.projects.filter((project) => project.id !== id);
       let nextActiveId = current.activeProjectId;
 
@@ -408,6 +410,16 @@ export const useProjectsStore = create<ProjectsStore>()(
 
       set({ projects: nextProjects, activeProjectId: nextActiveId });
       persistProjects(nextProjects, nextActiveId);
+
+      // Clean up worktree entries for the removed project
+      if (project) {
+        const normalizedPath = project.path.replace(/\\/g, '/').replace(/\/+$/, '') || '/';
+        useSessionUIStore.setState((s) => {
+          const next = new Map(s.availableWorktreesByProject);
+          next.delete(normalizedPath);
+          return { availableWorktreesByProject: next };
+        });
+      }
 
       if (nextActiveId) {
         const nextActive = nextProjects.find((project) => project.id === nextActiveId);

--- a/packages/ui/src/stores/useSessionFoldersStore.ts
+++ b/packages/ui/src/stores/useSessionFoldersStore.ts
@@ -14,7 +14,7 @@ export interface SessionFolder {
   parentId?: string | null;
 }
 
-type SessionFoldersMap = Record<string, SessionFolder[]>;
+export type SessionFoldersMap = Record<string, SessionFolder[]>;
 
 interface SessionFoldersState {
   foldersMap: SessionFoldersMap;

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -214,7 +214,7 @@ export async function deleteSession(sessionId: string, _options?: Record<string,
   const sessionDirectory = getSessionDirectory(sessionId)
   // Remove from UI immediately, rollback on error
   let snapshot = optimisticRemoveSession(sessionId, sessionDirectory)
-  let removedFromDir: string | null = snapshot ? sessionDirectory : null
+  let removedFromDir: string | null = snapshot ? (sessionDirectory ?? null) : null
 
   // If the session wasn't in the resolved directory (e.g. archived session
   // whose original child store was disposed), search all child stores.

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -213,7 +213,26 @@ function optimisticRemoveSession(sessionId: string, directory?: string): Session
 export async function deleteSession(sessionId: string, _options?: Record<string, unknown>): Promise<boolean> {
   const sessionDirectory = getSessionDirectory(sessionId)
   // Remove from UI immediately, rollback on error
-  const snapshot = optimisticRemoveSession(sessionId, sessionDirectory)
+  let snapshot = optimisticRemoveSession(sessionId, sessionDirectory)
+  let removedFromDir: string | null = snapshot ? sessionDirectory : null
+
+  // If the session wasn't in the resolved directory (e.g. archived session
+  // whose original child store was disposed), search all child stores.
+  if (!snapshot && _childStores) {
+    for (const [dir, store] of _childStores.children.entries()) {
+      const current = store.getState()
+      const sessions = [...current.session]
+      const result = Binary.search(sessions, sessionId, (s) => s.id)
+      if (result.found) {
+        snapshot = current.session
+        sessions.splice(result.index, 1)
+        store.setState({ session: sessions })
+        removedFromDir = dir
+        break
+      }
+    }
+  }
+
   const ui = useSessionUIStore.getState()
   if (ui.currentSessionId === sessionId) {
     ui.setCurrentSession(null)
@@ -224,7 +243,13 @@ export async function deleteSession(sessionId: string, _options?: Record<string,
     return true
   } catch (error) {
     console.error("[session-actions] deleteSession failed", error)
-    if (snapshot) getDirectoryStore(sessionDirectory).setState({ session: snapshot })
+    if (snapshot && removedFromDir) {
+      try {
+        getDirectoryStore(removedFromDir).setState({ session: snapshot })
+      } catch {
+        // child store may have been disposed since — ignore rollback
+      }
+    }
     return false
   }
 }


### PR DESCRIPTION
## Summary

Fix multiple categories of sidebar staleness where mutations (create/delete/move) didn't reflect in the UI until page refresh.

### Worktree mutations
- Update sidebar store immediately after worktree creation (previously: delayed until next discovery cycle)
- Update sidebar store immediately after worktree removal
- Fix key mismatch in sidebar store updates for worktree removal
- Clean up `worktreeMetadata` map entries when a worktree is removed (previously: phantom group headers lingered)

### Project mutations
- `removeProject` now cleans up `availableWorktreesByProject` in the UI store (previously: stale entries persisted for removed projects)
- Worktree discovery effect now depends on `projects` array — adding a project triggers immediate worktree discovery

### Folder mutations (session organizational folders)
- `scopeFolders` memo in `SessionGroupSection` now depends on `foldersMap` data (not stable store function ref), so creating, deleting, or moving sessions between folders is immediately reflected in the sidebar
- `SessionNodeItem` `areEqual` comparator now checks `renamingFolderId` for correct dropdown behavior
- `useSessionSidebarSections` folder search memo now depends on `foldersMap` (not stable function ref), so folder name matches update during active search

### Bulk delete sessions
- `deleteSession` now falls back to searching all child stores if the session isn't in the directory resolved by routing (fixes stale archived session items remaining after bulk delete)

### Cleanup
- Removed unused `getFoldersForScope` prop from `SessionGroupSection`
- Exported `SessionFoldersMap` type from `useSessionFoldersStore`

Close #984