### PR TITLE
fix: preserve lastEventId in SSE path and add proxy heartbeat

### DIFF
--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -340,6 +340,12 @@ export function createEventPipeline(input: EventPipelineInput) {
     const events = await sdk.global.event({
       signal,
       ...(lastEventId && lastEventId.length > 0 ? { headers: { "Last-Event-ID": lastEventId } } : {}),
+      onSseEvent: (event: { id?: unknown }) => {
+        resetHeartbeat()
+        if (typeof event.id === "string" && event.id.length > 0) {
+          lastEventId = event.id
+        }
+      },
       onSseError: (error: unknown) => {
         if (isAbortError(error)) return
         if (streamErrorLogged) return
@@ -356,11 +362,6 @@ export function createEventPipeline(input: EventPipelineInput) {
     for await (const event of events.stream) {
       resetHeartbeat()
       streamErrorLogged = false
-
-      const eventId = (event as { id?: string }).id
-      if (typeof eventId === "string" && eventId.length > 0) {
-        lastEventId = eventId
-      }
 
       const payload = resolveEventPayload((event as { payload?: Event }).payload ?? event)
       if (!payload) {

--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -356,6 +356,12 @@ export function createEventPipeline(input: EventPipelineInput) {
     for await (const event of events.stream) {
       resetHeartbeat()
       streamErrorLogged = false
+
+      const eventId = (event as { id?: string }).id
+      if (typeof eventId === "string" && eventId.length > 0) {
+        lastEventId = eventId
+      }
+
       const payload = resolveEventPayload((event as { payload?: Event }).payload ?? event)
       if (!payload) {
         continue

--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -113,6 +113,7 @@ export const registerOpenCodeProxy = (app, deps) => {
     const closeUpstream = () => abortController.abort();
     let upstream = null;
     let reader = null;
+    let heartbeatTimer = null;
 
     req.on('close', closeUpstream);
 
@@ -162,7 +163,6 @@ export const registerOpenCodeProxy = (app, deps) => {
       }
 
       const SSE_HEARTBEAT_INTERVAL_MS = 20_000;
-      let heartbeatTimer = null;
 
       const scheduleHeartbeat = () => {
         heartbeatTimer = setTimeout(async () => {
@@ -192,11 +192,6 @@ export const registerOpenCodeProxy = (app, deps) => {
         }
       }
 
-      if (heartbeatTimer) {
-        clearTimeout(heartbeatTimer);
-        heartbeatTimer = null;
-      }
-
       res.end();
     } catch (error) {
       if (isAbortError(error)) {
@@ -209,6 +204,10 @@ export const registerOpenCodeProxy = (app, deps) => {
         res.end();
       }
     } finally {
+      if (heartbeatTimer) {
+        clearTimeout(heartbeatTimer);
+        heartbeatTimer = null;
+      }
       req.off('close', closeUpstream);
       try {
         if (reader) {

--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -161,6 +161,23 @@ export const registerOpenCodeProxy = (app, deps) => {
         res.socket.setNoDelay(true);
       }
 
+      const SSE_HEARTBEAT_INTERVAL_MS = 20_000;
+      let heartbeatTimer = null;
+
+      const scheduleHeartbeat = () => {
+        heartbeatTimer = setTimeout(async () => {
+          if (abortController.signal.aborted || res.writableEnded || res.destroyed) {
+            return;
+          }
+          const canContinue = await writeSseChunkWithBackpressure(res, ':heartbeat\n\n', abortController.signal);
+          if (canContinue) {
+            scheduleHeartbeat();
+          }
+        }, SSE_HEARTBEAT_INTERVAL_MS);
+      };
+
+      scheduleHeartbeat();
+
       reader = upstream.body.getReader();
       while (!abortController.signal.aborted) {
         const { done, value } = await reader.read();
@@ -173,6 +190,11 @@ export const registerOpenCodeProxy = (app, deps) => {
             break;
           }
         }
+      }
+
+      if (heartbeatTimer) {
+        clearTimeout(heartbeatTimer);
+        heartbeatTimer = null;
       }
 
       res.end();

--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -43,6 +43,31 @@ export const writeSseChunkWithBackpressure = async (res, value, signal) => {
   return !signal?.aborted && !res.writableEnded && !res.destroyed;
 };
 
+export const createSseBoundaryTracker = () => {
+  const decoder = new TextDecoder();
+  let tail = '';
+
+  const normalize = (value) => value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  return {
+    observe(value) {
+      const text = typeof value === 'string'
+        ? value
+        : decoder.decode(value, { stream: true });
+      if (text.length > 0) {
+        tail = `${tail}${normalize(text)}`;
+        if (tail.length > 4096) {
+          tail = tail.slice(-4096);
+        }
+      }
+      return this.isAtBoundary();
+    },
+    isAtBoundary() {
+      return tail.length === 0 || tail.endsWith('\n\n');
+    },
+  };
+};
+
 export const registerOpenCodeProxy = (app, deps) => {
   const {
     fs,
@@ -114,6 +139,8 @@ export const registerOpenCodeProxy = (app, deps) => {
     let upstream = null;
     let reader = null;
     let heartbeatTimer = null;
+    let writeQueue = Promise.resolve(true);
+    const sseBoundary = createSseBoundaryTracker();
 
     req.on('close', closeUpstream);
 
@@ -169,11 +196,27 @@ export const registerOpenCodeProxy = (app, deps) => {
           if (abortController.signal.aborted || res.writableEnded || res.destroyed) {
             return;
           }
-          const canContinue = await writeSseChunkWithBackpressure(res, ':heartbeat\n\n', abortController.signal);
+          if (!sseBoundary.isAtBoundary()) {
+            scheduleHeartbeat();
+            return;
+          }
+          const canContinue = await enqueueSseWrite(':heartbeat\n\n');
           if (canContinue) {
             scheduleHeartbeat();
           }
         }, SSE_HEARTBEAT_INTERVAL_MS);
+      };
+
+      const enqueueSseWrite = (value) => {
+        writeQueue = writeQueue
+          .catch(() => false)
+          .then((canContinue) => {
+            if (!canContinue) {
+              return false;
+            }
+            return writeSseChunkWithBackpressure(res, value, abortController.signal);
+          });
+        return writeQueue;
       };
 
       scheduleHeartbeat();
@@ -185,7 +228,8 @@ export const registerOpenCodeProxy = (app, deps) => {
           break;
         }
         if (value && value.length > 0) {
-          const canContinue = await writeSseChunkWithBackpressure(res, value, abortController.signal);
+          sseBoundary.observe(value);
+          const canContinue = await enqueueSseWrite(value);
           if (!canContinue) {
             break;
           }

--- a/packages/web/server/opencode-proxy.test.js
+++ b/packages/web/server/opencode-proxy.test.js
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events';
 import express from 'express';
 import path from 'path';
 
-import { registerOpenCodeProxy, writeSseChunkWithBackpressure } from './lib/opencode/proxy.js';
+import { createSseBoundaryTracker, registerOpenCodeProxy, writeSseChunkWithBackpressure } from './lib/opencode/proxy.js';
 
 const listen = (app, host = '127.0.0.1') => new Promise((resolve, reject) => {
   const server = app.listen(0, host, () => resolve(server));
@@ -101,6 +101,17 @@ describe('OpenCode proxy SSE forwarding', () => {
     res.emit('drain');
 
     await expect(write).resolves.toBe(true);
+  });
+
+  it('tracks whether a raw SSE stream is between event blocks', () => {
+    const tracker = createSseBoundaryTracker();
+
+    expect(tracker.isAtBoundary()).toBe(true);
+    expect(tracker.observe(Buffer.from('id: evt-1\n'))).toBe(false);
+    expect(tracker.observe(Buffer.from('data: {"ok"'))).toBe(false);
+    expect(tracker.observe(Buffer.from(':true}\n'))).toBe(false);
+    expect(tracker.observe(Buffer.from('\n'))).toBe(true);
+    expect(tracker.observe(Buffer.from('data: next\r\n\r\n'))).toBe(true);
   });
 
   it('routes generic API requests through external OpenCode base URL', async () => {


### PR DESCRIPTION
## Summary
Fixes two gaps in the SSE fallback path that can cause dropped events and missing messages after reconnect.

## Problem
- When WebSocket fails and the UI falls back to SSE (`sdk.global.event()`), `lastEventId` was never updated from the SSE event stream. On reconnect, the `Last-Event-ID` header remained stale, so the server could not replay missed events. This led to messages that only appeared after a full restart (when bootstrap re-fetched everything).
- The direct SSE proxy (`/api/global/event`) forwarded upstream chunks without any heartbeat. During upstream idle periods, the UI's 30s heartbeat timeout would fire and abort the connection unnecessarily, increasing reconnect frequency.

## Changes
1. **UI `event-pipeline.ts`** — Extract `event.id` from each SSE stream event and assign it to `lastEventId`, matching the existing WS path behavior (`frame.eventId`).
2. **Server `proxy.js`** — Send a `:heartbeat\n\n` SSE comment every 20s on the direct proxy path, keeping the UI heartbeat watchdog satisfied during idle upstream.

## Testing
- `bun run lint` ✅
- `bun run type-check` ✅