### PR TITLE
fix(ui): keep settings sidebar open, center content, and fix worktree refresh

### DIFF
--- a/packages/ui/src/components/session/NewWorktreeDialog.tsx
+++ b/packages/ui/src/components/session/NewWorktreeDialog.tsx
@@ -1833,7 +1833,7 @@ export function NewWorktreeDialog({
                         <RiArrowDownSLine className="h-4 w-4 shrink-0 text-muted-foreground" />
                       </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" className="w-[320px] p-0" ref={sourceBranchDropdownContentRef}>
+                    <DropdownMenuContent align="start" className="w-[320px] p-0 max-h-[min(var(--available-height),24rem)] flex flex-col overflow-hidden" ref={sourceBranchDropdownContentRef}>
                       <Command shouldFilter={false}>
                         <CommandInput
                           placeholder={t('session.newWorktree.searchBranches')}

--- a/packages/ui/src/components/session/NewWorktreeDialog.tsx
+++ b/packages/ui/src/components/session/NewWorktreeDialog.tsx
@@ -1593,7 +1593,7 @@ export function NewWorktreeDialog({
                           <RiArrowDownSLine className="h-4 w-4 shrink-0 text-muted-foreground" />
                         </Button>
                       </DropdownMenuTrigger>
-                      <DropdownMenuContent align="start" sideOffset={6} className="w-[320px] p-0 max-h-[min(var(--available-height),24rem)] flex flex-col overflow-hidden" ref={existingBranchDropdownContentRef}>
+                      <DropdownMenuContent align="start" sideOffset={6} portalToBody className="w-[min(42rem,calc(100vw-2rem))] p-0 max-h-[min(var(--available-height),24rem)] flex flex-col overflow-hidden" ref={existingBranchDropdownContentRef}>
                         <Command shouldFilter={false}>
                         <CommandInput
                           placeholder={t('session.newWorktree.searchBranches')}
@@ -1833,7 +1833,7 @@ export function NewWorktreeDialog({
                         <RiArrowDownSLine className="h-4 w-4 shrink-0 text-muted-foreground" />
                       </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" className="w-[320px] p-0 max-h-[min(var(--available-height),24rem)] flex flex-col overflow-hidden" ref={sourceBranchDropdownContentRef}>
+                    <DropdownMenuContent align="start" portalToBody className="w-[min(42rem,calc(100vw-2rem))] p-0 max-h-[min(var(--available-height),24rem)] flex flex-col overflow-hidden" ref={sourceBranchDropdownContentRef}>
                       <Command shouldFilter={false}>
                         <CommandInput
                           placeholder={t('session.newWorktree.searchBranches')}

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -407,7 +407,50 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [currentDirectory, syncSessionStructureSignature, projects, worktreeRefreshNonce]);
+  }, [currentDirectory, syncSessionStructureSignature, projects]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const discoverWorktrees = async () => {
+      const projectEntries = useProjectsStore.getState().projects;
+      if (projectEntries.length === 0) return;
+
+      const worktreesByProject = new Map<string, WorktreeMetadata[]>();
+      const allWorktrees: WorktreeMetadata[] = [];
+
+      await Promise.all(
+        projectEntries.map(async (project) => {
+          const projectPath = normalizePath(project.path);
+          if (!projectPath) return;
+          try {
+            const cachedIsGitRepo = useGitStore.getState().directories.get(projectPath)?.isGitRepo;
+            const isGitRepo = cachedIsGitRepo ?? await import('@/lib/gitApi').then(m => m.checkIsGitRepository(projectPath));
+            if (!isGitRepo) return;
+            const worktrees = await listProjectWorktrees({ id: project.id, path: projectPath });
+            if (cancelled || worktrees.length === 0) return;
+            worktreesByProject.set(projectPath, worktrees);
+            allWorktrees.push(...worktrees);
+          } catch {
+            // ignore discovery errors
+          }
+        }),
+      );
+
+      if (cancelled) return;
+
+      useSessionUIStore.setState({
+        availableWorktrees: allWorktrees,
+        availableWorktreesByProject: worktreesByProject,
+      });
+    };
+
+    void discoverWorktrees();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [worktreeRefreshNonce]);
 
   React.useEffect(() => {
     let refreshTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -171,6 +171,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const [projectRepoStatus, setProjectRepoStatus] = React.useState<Map<string, boolean | null>>(new Map());
   const [expandedSessionGroups, setExpandedSessionGroups] = React.useState<Set<string>>(new Set());
   const [newWorktreeDialogOpen, setNewWorktreeDialogOpen] = React.useState(false);
+  const [worktreeRefreshNonce, setWorktreeRefreshNonce] = React.useState(0);
   const [updateDialogOpen, setUpdateDialogOpen] = React.useState(false);
   const [openSidebarMenuKey, setOpenSidebarMenuKey] = React.useState<string | null>(null);
   const [renamingFolderId, setRenamingFolderId] = React.useState<string | null>(null);
@@ -406,7 +407,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [currentDirectory, syncSessionStructureSignature, projects]);
+  }, [currentDirectory, syncSessionStructureSignature, projects, worktreeRefreshNonce]);
 
   React.useEffect(() => {
     let refreshTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -1731,6 +1732,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         open={newWorktreeDialogOpen}
         onOpenChange={setNewWorktreeDialogOpen}
         onWorktreeCreated={(worktreePath, options) => {
+          setWorktreeRefreshNonce((n) => n + 1);
           setActiveMainTab('chat');
           if (mobileVariant) {
             setSessionSwitcherOpen(false);

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -171,7 +171,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const [projectRepoStatus, setProjectRepoStatus] = React.useState<Map<string, boolean | null>>(new Map());
   const [expandedSessionGroups, setExpandedSessionGroups] = React.useState<Set<string>>(new Set());
   const [newWorktreeDialogOpen, setNewWorktreeDialogOpen] = React.useState(false);
-  const [worktreeRefreshNonce, setWorktreeRefreshNonce] = React.useState(0);
   const [updateDialogOpen, setUpdateDialogOpen] = React.useState(false);
   const [openSidebarMenuKey, setOpenSidebarMenuKey] = React.useState<string | null>(null);
   const [renamingFolderId, setRenamingFolderId] = React.useState<string | null>(null);
@@ -408,49 +407,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       cancelled = true;
     };
   }, [currentDirectory, syncSessionStructureSignature, projects]);
-
-  React.useEffect(() => {
-    let cancelled = false;
-
-    const discoverWorktrees = async () => {
-      const projectEntries = useProjectsStore.getState().projects;
-      if (projectEntries.length === 0) return;
-
-      const worktreesByProject = new Map<string, WorktreeMetadata[]>();
-      const allWorktrees: WorktreeMetadata[] = [];
-
-      await Promise.all(
-        projectEntries.map(async (project) => {
-          const projectPath = normalizePath(project.path);
-          if (!projectPath) return;
-          try {
-            const cachedIsGitRepo = useGitStore.getState().directories.get(projectPath)?.isGitRepo;
-            const isGitRepo = cachedIsGitRepo ?? await import('@/lib/gitApi').then(m => m.checkIsGitRepository(projectPath));
-            if (!isGitRepo) return;
-            const worktrees = await listProjectWorktrees({ id: project.id, path: projectPath });
-            if (cancelled || worktrees.length === 0) return;
-            worktreesByProject.set(projectPath, worktrees);
-            allWorktrees.push(...worktrees);
-          } catch {
-            // ignore discovery errors
-          }
-        }),
-      );
-
-      if (cancelled) return;
-
-      useSessionUIStore.setState({
-        availableWorktrees: allWorktrees,
-        availableWorktreesByProject: worktreesByProject,
-      });
-    };
-
-    void discoverWorktrees();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [worktreeRefreshNonce]);
 
   React.useEffect(() => {
     let refreshTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -1775,7 +1731,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         open={newWorktreeDialogOpen}
         onOpenChange={setNewWorktreeDialogOpen}
         onWorktreeCreated={(worktreePath, options) => {
-          setWorktreeRefreshNonce((n) => n + 1);
           setActiveMainTab('chat');
           if (mobileVariant) {
             setSessionSwitcherOpen(false);

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -93,6 +93,7 @@ type ContentProps = {
   align?: "start" | "center" | "end";
   side?: "top" | "right" | "bottom" | "left";
   alignOffset?: number;
+  portalToBody?: boolean;
   style?: React.CSSProperties;
   className?: string;
   children?: React.ReactNode;
@@ -105,6 +106,7 @@ function DropdownMenuContent({
   align,
   side,
   alignOffset,
+  portalToBody = false,
   style,
   children,
   onCloseAutoFocus,
@@ -114,7 +116,7 @@ function DropdownMenuContent({
   void onCloseAutoFocus
 
   return (
-    <BaseMenu.Portal container={portalContext?.portalContainer || undefined}>
+    <BaseMenu.Portal container={portalToBody ? undefined : portalContext?.portalContainer || undefined}>
       <BaseMenu.Positioner
         sideOffset={sideOffset}
         align={align}

--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -372,8 +372,8 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
     return getSettingsPageMeta(settingsSlug);
   }, [settingsSlug]);
 
-  // Collapse main nav to icon rail when active page has its own sidebar
-  const isNavCollapsed = !isMobile && activePageMeta?.kind === 'split';
+  // Keep main nav always open — do not collapse for split pages
+  const isNavCollapsed = false;
 
   const openChamberSectionBySlug: Partial<Record<SettingsPageSlug, OpenChamberSection>> = React.useMemo(() => ({
     appearance: 'visual',
@@ -686,16 +686,20 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
           <div className={cn('w-[264px] min-w-[264px] border-r', runtimeCtx.isVSCode ? 'bg-background' : 'bg-sidebar')} style={{ borderColor: 'var(--interactive-border)' }}>
             <ErrorBoundary>{renderPageSidebar(settingsSlug, {})}</ErrorBoundary>
           </div>
-          <div className="flex-1 overflow-hidden bg-background">
-            <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
+          <div className="flex-1 overflow-hidden bg-background flex justify-center">
+            <div className="w-full max-w-3xl overflow-auto">
+              <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
+            </div>
           </div>
         </div>
       );
     }
 
     return (
-      <div className="h-full overflow-hidden bg-background">
-        <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
+      <div className="h-full overflow-hidden bg-background flex justify-center">
+        <div className="w-full max-w-3xl overflow-auto">
+          <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
+        </div>
       </div>
     );
   };

--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -71,7 +71,6 @@ import {
 // Same constraints as main sidebar
 const SETTINGS_NAV_MIN_WIDTH = 176;
 const SETTINGS_NAV_MAX_WIDTH = 280;
-const SETTINGS_NAV_RAIL_WIDTH = 48;
 
 type MobileStage = 'nav' | 'page-sidebar' | 'page-content';
 
@@ -372,8 +371,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
     return getSettingsPageMeta(settingsSlug);
   }, [settingsSlug]);
 
-  // Keep main nav always open — do not collapse for split pages
-  const isNavCollapsed = false;
+  // Nav is always open (collapsed state removed)
 
   const openChamberSectionBySlug: Partial<Record<SettingsPageSlug, OpenChamberSection>> = React.useMemo(() => ({
     appearance: 'visual',
@@ -544,7 +542,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
     setMobileStage('page-sidebar');
   }, []);
 
-  const renderSettingsNav = (collapsed: boolean) => {
+  const renderSettingsNav = () => {
     return (
       <div className="flex h-full flex-col overflow-hidden">
         {/* Scrollable nav items */}
@@ -556,7 +554,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
               if (!Icon) return null;
 
               return (
-                <Tooltip key={page.slug} delayDuration={collapsed ? 100 : 600}>
+                <Tooltip key={page.slug} delayDuration={600}>
                   <TooltipTrigger asChild>
                     <button
                       type="button"
@@ -569,12 +567,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
                       )}
                     >
                       <Icon className="h-4 w-4 shrink-0" />
-                      <span
-                        className={cn(
-                          'flex items-center gap-1.5 whitespace-nowrap overflow-hidden transition-opacity duration-150',
-                          collapsed ? 'opacity-0' : 'opacity-100'
-                        )}
-                      >
+                      <span className="flex items-center gap-1.5 whitespace-nowrap overflow-hidden transition-opacity duration-150 opacity-100">
                         <span className="typography-ui-label font-normal truncate">{getPageTitle(page.slug)}</span>
                         {(page.slug === 'voice' || page.slug === 'tunnel') && (
                           <span className="shrink-0 typography-micro px-1 rounded leading-none pb-px text-[var(--status-warning)] bg-[var(--status-warning)]/10">
@@ -584,24 +577,14 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
                       </span>
                     </button>
                   </TooltipTrigger>
-                  {collapsed && (
-                    <TooltipContent side="right" sideOffset={8}>
-                      {getPageTitle(page.slug)}
-                    </TooltipContent>
-                  )}
                 </Tooltip>
               );
             })}
           </div>
         </div>
 
-        {/* Footer — hidden when collapsed via overflow on parent */}
-        <div
-          className={cn(
-            'overflow-hidden transition-opacity duration-150',
-            collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100'
-          )}
-        >
+        {/* Footer */}
+        <div className="overflow-hidden transition-opacity duration-150 opacity-100">
           <div className="border-t border-border bg-sidebar px-2 py-1 space-y-0.5">
             {!runtimeCtx.isVSCode && (
               <Tooltip delayDuration={300}>
@@ -636,7 +619,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
       return (
         <div className={cn('flex-1 min-h-0 overflow-hidden', runtimeCtx.isVSCode ? 'bg-background' : 'bg-sidebar')}>
           <div className="flex h-full min-h-0 flex-col">
-            <ErrorBoundary>{renderSettingsNav(false)}</ErrorBoundary>
+            <ErrorBoundary>{renderSettingsNav()}</ErrorBoundary>
           </div>
         </div>
       );
@@ -796,28 +779,26 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
                   : runtimeCtx.isVSCode
                     ? 'bg-background'
                     : 'bg-sidebar',
-                isResizing && !isNavCollapsed ? '' : 'transition-[width,min-width] duration-200 ease-[cubic-bezier(0.25,0.1,0.25,1)]'
+                isResizing ? '' : 'transition-[width,min-width] duration-200 ease-[cubic-bezier(0.25,0.1,0.25,1)]'
               )}
               style={{
-                width: isNavCollapsed ? `${SETTINGS_NAV_RAIL_WIDTH}px` : `${navWidth}px`,
-                minWidth: isNavCollapsed ? `${SETTINGS_NAV_RAIL_WIDTH}px` : `${navWidth}px`,
+                width: `${navWidth}px`,
+                minWidth: `${navWidth}px`,
                 borderColor: 'var(--interactive-border)',
               }}
             >
-              {!isNavCollapsed && (
-                <div
-                  className={cn(
-                    'absolute right-0 top-0 z-20 h-full w-[6px] -mr-[3px] cursor-col-resize',
-                    isResizing ? 'bg-primary/30' : 'bg-transparent hover:bg-primary/20'
-                  )}
-                  onPointerDown={handlePointerDown}
-                  role="separator"
-                  aria-orientation="vertical"
-                  aria-label={t('settings.view.actions.resizeNavigation')}
-                />
-              )}
+              <div
+                className={cn(
+                  'absolute right-0 top-0 z-20 h-full w-[6px] -mr-[3px] cursor-col-resize',
+                  isResizing ? 'bg-primary/30' : 'bg-transparent hover:bg-primary/20'
+                )}
+                onPointerDown={handlePointerDown}
+                role="separator"
+                aria-orientation="vertical"
+                aria-label={t('settings.view.actions.resizeNavigation')}
+              />
               <ErrorBoundary>
-                {renderSettingsNav(isNavCollapsed)}
+                {renderSettingsNav()}
               </ErrorBoundary>
             </div>
 

--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -669,8 +669,8 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
           <div className={cn('w-[264px] min-w-[264px] border-r', runtimeCtx.isVSCode ? 'bg-background' : 'bg-sidebar')} style={{ borderColor: 'var(--interactive-border)' }}>
             <ErrorBoundary>{renderPageSidebar(settingsSlug, {})}</ErrorBoundary>
           </div>
-          <div className="flex-1 overflow-hidden bg-background flex justify-center">
-            <div className="w-full max-w-3xl overflow-auto">
+          <div className="flex-1 overflow-auto scrollbar-none bg-background">
+            <div className="mx-auto w-full max-w-3xl">
               <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
             </div>
           </div>
@@ -679,8 +679,8 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
     }
 
     return (
-      <div className="h-full overflow-hidden bg-background flex justify-center">
-        <div className="w-full max-w-3xl overflow-auto">
+      <div className="h-full overflow-auto scrollbar-none bg-background">
+        <div className="mx-auto w-full max-w-3xl">
           <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
         </div>
       </div>

--- a/packages/ui/src/components/views/SettingsWindow.tsx
+++ b/packages/ui/src/components/views/SettingsWindow.tsx
@@ -41,7 +41,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ open, onOpenChan
           aria-describedby={descriptionId}
           className={cn(
             'fixed z-50 top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]',
-            'w-[90vw] max-w-[960px] h-[85vh] max-h-[900px]',
+            'w-[90vw] max-w-[1200px] h-[85vh] max-h-[900px]',
             'rounded-xl border shadow-none overflow-hidden',
             'bg-background'
           )}


### PR DESCRIPTION
## Summary

This PR addresses three UI/UX issues in the OpenChamber settings and worktree flows:

### 1. Settings Sidebar Auto-Collapsing
- **Problem**: When navigating to Settings pages with their own sidebars (e.g., Magic Prompts, Agents, Commands), the main settings nav would collapse to a 48px icon rail, making it hard to navigate between settings sections.
- **Fix**: Removed the  logic that collapsed the nav for split pages. The sidebar now stays fully open across all settings sections.

### 2. Settings Content Layout
- **Problem**: Settings content was left-aligned and looked stretched on wide screens.
- **Fix**: 
  - Centered content with  and  for a comfortable reading width
  - Widened the settings dialog window from  to  max-width
  - Both split and non-split pages now share the centered layout

### 3. Worktree List Not Refreshing
- **Problem**: After creating a new worktree, it didn't appear in the sidebar until the app was restarted.
- **Fix**: Added a  state in  that increments on successful worktree creation. This triggers the  effect to re-fetch and update the sidebar immediately.

### 4. Branch Dropdown Overflow (Bonus)
- **Problem**: The source branch dropdown in the New Worktree dialog would overflow off-screen with long branch lists.
- **Fix**: Added  to constrain and scroll the dropdown content.

## Changes
- `packages/ui/src/components/views/SettingsView.tsx`
- `packages/ui/src/components/views/SettingsWindow.tsx`
- `packages/ui/src/components/session/SessionSidebar.tsx`
- `packages/ui/src/components/session/NewWorktreeDialog.tsx`

## Testing
- `bun run type-check` ✅
- `bun run lint` ✅