### PR TITLE
fix: allow Enter/Ctrl+Enter to submit custom answer in QuestionCard

### DIFF
--- a/packages/ui/src/components/chat/QuestionCard.tsx
+++ b/packages/ui/src/components/chat/QuestionCard.tsx
@@ -175,6 +175,20 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
     }
   }, [buildAnswersPayload, question.id, question.sessionID, requiredSatisfied, respondToQuestion]);
 
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        if (requiredSatisfied) {
+          handleConfirm();
+        } else {
+          handleNextUnanswered();
+        }
+      }
+    },
+    [requiredSatisfied, handleConfirm, handleNextUnanswered]
+  );
+
   const handleDismiss = React.useCallback(async () => {
     setIsResponding(true);
     try {
@@ -385,6 +399,7 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
                         placeholder={t('chat.questionCard.yourAnswer')}
                         disabled={isResponding}
                         rows={2}
+                        onKeyDown={handleKeyDown}
                         className="w-full bg-transparent border border-border/30 focus:border-primary rounded px-2 py-1 outline-none typography-meta text-foreground placeholder:text-muted-foreground/50 transition-colors resize-none overflow-hidden"
                         autoFocus
                       />

--- a/packages/ui/src/components/chat/QuestionCard.tsx
+++ b/packages/ui/src/components/chat/QuestionCard.tsx
@@ -4,7 +4,9 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Radio } from '@/components/ui/radio';
 
 import { cn } from '@/lib/utils';
+import { isIMECompositionEvent } from '@/lib/ime';
 import type { QuestionRequest } from '@/types/question';
+import { useUIStore } from '@/stores/useUIStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSessions } from '@/sync/sync-context';
 import * as sessionActions from '@/sync/session-actions';
@@ -21,6 +23,7 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
   const { t } = useI18n();
   const respondToQuestion = sessionActions.respondToQuestion;
     const rejectQuestion = sessionActions.rejectQuestion;;
+  const isMobile = useUIStore((state) => state.isMobile);
   const sessions = useSessions();
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
   const isFromSubagent = React.useMemo(() => {
@@ -177,7 +180,9 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
 
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (isIMECompositionEvent(e)) return;
+
+      if (e.key === 'Enter' && !e.shiftKey && (!isMobile || e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         if (requiredSatisfied) {
           handleConfirm();
@@ -186,7 +191,7 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
         }
       }
     },
-    [requiredSatisfied, handleConfirm, handleNextUnanswered]
+    [handleConfirm, handleNextUnanswered, isMobile, requiredSatisfied]
   );
 
   const handleDismiss = React.useCallback(async () => {


### PR DESCRIPTION
## Summary

The "Other..." custom answer textarea in the QuestionCard component had no keyboard handler — pressing Enter would just insert a newline instead of submitting, unlike the normal chat input where Enter/Ctrl+Enter sends the message.

## Changes

- Added `handleKeyDown` callback on `QuestionCard.tsx` that intercepts Enter (no Shift) and Ctrl+Enter on the custom answer textarea
- Matches the submit button's behavior: submits when all questions are answered (`requiredSatisfied`), otherwise navigates to the next unanswered question
- Shift+Enter continues to insert a newline (default textarea behavior)

## Testing

Verified manually via the Vite dev server — selecting "Other...", typing a custom answer, and pressing Enter now submits the answer.
