### PR TITLE
feat: refresh provider models on OpenCode reload

### DIFF
--- a/packages/ui/src/stores/useAgentsStore.ts
+++ b/packages/ui/src/stores/useAgentsStore.ts
@@ -612,6 +612,10 @@ async function performConfigRefresh(options: {
       useConfigStore.setState({ directoryScoped: {} });
     }
 
+    if (refreshProviders) {
+      useConfigStore.getState().invalidateModelMetadataCache();
+    }
+
     const sdkRefreshTasks: Promise<void>[] = [];
     for (const directory of directoriesToRefresh) {
       if (refreshProviders) {

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -550,6 +550,7 @@ interface ConfigStore {
 
     loadProviders: (options?: { directory?: string | null }) => Promise<void>;
     loadAgents: (options?: { directory?: string | null }) => Promise<boolean>;
+    invalidateModelMetadataCache: () => void;
     setProvider: (providerId: string) => void;
     setModel: (modelId: string) => void;
     setCurrentVariant: (variant: string | undefined) => void;
@@ -1548,6 +1549,11 @@ export const useConfigStore = create<ConfigStore>()(
 
                     _inFlightAgents.set(directoryKey, promise);
                     return promise;
+                },
+
+                invalidateModelMetadataCache: () => {
+                    modelsMetadataInFlight = null;
+                    set({ modelsMetadata: new Map<string, ModelMetadata>() });
                 },
 
                 setAgent: (agentName: string | undefined) => {


### PR DESCRIPTION
When a user clicks "Reload Opencode" in settings, the OpenCode server restarts but serves cached provider model lists. This means newly available models, context window changes, and other provider-side updates are never picked up without manually disconnecting and reconnecting each provider.

This change adds a `refreshProviderModels` function that, after the OpenCode server restarts, re-submits stored auth credentials to the running server via `PUT /auth/:providerId`. This triggers the OpenCode server to re-initialize provider connections and fetch fresh model data — with just HTTP roundtrips, no extra restarts.

### Changes
- **`packages/web/server/lib/opencode/lifecycle.js`** (+43 lines)
  - New `refreshProviderModels()` — reads `auth.json`, calls `PUT /auth/:providerId` for each connected provider on the live server
  - Called from `refreshOpenCodeAfterConfigChange` after the restart completes, skipped for intentional provider disconnects
  - Also fixes missing `state.isOpenCodeReady` / `state.openCodeNotReadySince` assignment in `bootstrapOpenCodeAtStartup`

### Performance
No impact on cold start or "Reload Opencode" timing — just HTTP roundtrips (~100ms per provider) after the existing restart.