### PR TITLE
:bug: fix: Use light blue to display light theme conversation text selections

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -62,6 +62,12 @@ textarea[data-chat-input="true"]:focus-visible {
   cursor: not-allowed;
 }
 
+:root.light .message-content-text::selection,
+:root.light .message-content-text ::selection {
+  background: color-mix(in srgb, var(--interactive-border-focus) 18%, transparent);
+  color: var(--surface-foreground);
+}
+
 .oc-cm-selected-line {
   background: color-mix(in srgb, var(--primary-base) 22%, transparent);
 }


### PR DESCRIPTION
### What was solved

When using a light theme, after selecting text, the background of the selected text is dark blue, resulting in poor text visibility. Change it to light blue to improve text visibility.