### PR TITLE
fix(ui): prevent queued message truncation from stale React closure

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1253,11 +1253,19 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
     // Add message to queue instead of sending
     const handleQueueMessage = React.useCallback(() => {
-        if (!hasContent || !currentSessionId) return;
+        // Read the textarea value directly from the DOM ref to avoid capturing a
+        // stale `message` state from a pending React render.  When the user types
+        // quickly and clicks the Queue button before React commits the latest
+        // render, the `message` closure may still hold a previous (often the first
+        // character) value.  Falling back to the React state handles the case where
+        // the textarea ref is unavailable (e.g., during SSR or after unmount).
+        const currentMessage = textareaRef.current?.value ?? message;
+        const currentHasContent = currentMessage.trim().length > 0 || sendableAttachedFiles.length > 0 || hasDrafts;
+        if (!currentHasContent || !currentSessionId) return;
 
         const drafts = consumeDrafts(currentSessionId);
 
-        let messageToQueue = message.replace(/^\n+|\n+$/g, '');
+        let messageToQueue = currentMessage.replace(/^\n+|\n+$/g, '');
         if (drafts.length > 0) {
             messageToQueue = appendInlineComments(messageToQueue, drafts);
         }
@@ -1286,7 +1294,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         if (!isMobile) {
             textareaRef.current?.focus();
         }
-    }, [hasContent, currentSessionId, message, sendableAttachedFiles, sanitizeAttachmentsForSend, addToQueue, clearAttachedFiles, isMobile, consumeDrafts, currentProviderId, currentModelId, currentAgentName, currentVariant]);
+    }, [hasContent, hasDrafts, currentSessionId, message, sendableAttachedFiles, sanitizeAttachmentsForSend, addToQueue, clearAttachedFiles, isMobile, consumeDrafts, currentProviderId, currentModelId, currentAgentName, currentVariant]);
 
     const handleQueuedMessageEdit = React.useCallback((content: string) => {
         setMessage(content);

--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1245,6 +1245,14 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
     const canAbort = sessionPhase !== 'idle';
 
+    const getCurrentInputSnapshot = React.useCallback(() => {
+        const currentMessage = textareaRef.current?.value ?? message;
+        return {
+            message: currentMessage,
+            hasContent: currentMessage.trim().length > 0 || sendableAttachedFiles.length > 0 || hasDrafts,
+        };
+    }, [hasDrafts, message, sendableAttachedFiles.length]);
+
     // Keep a ref to handleSubmit so callbacks don't depend on it.
     type SubmitOptions = {
         queuedOnly?: boolean;
@@ -1253,19 +1261,12 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
     // Add message to queue instead of sending
     const handleQueueMessage = React.useCallback(() => {
-        // Read the textarea value directly from the DOM ref to avoid capturing a
-        // stale `message` state from a pending React render.  When the user types
-        // quickly and clicks the Queue button before React commits the latest
-        // render, the `message` closure may still hold a previous (often the first
-        // character) value.  Falling back to the React state handles the case where
-        // the textarea ref is unavailable (e.g., during SSR or after unmount).
-        const currentMessage = textareaRef.current?.value ?? message;
-        const currentHasContent = currentMessage.trim().length > 0 || sendableAttachedFiles.length > 0 || hasDrafts;
-        if (!currentHasContent || !currentSessionId) return;
+        const inputSnapshot = getCurrentInputSnapshot();
+        if (!inputSnapshot.hasContent || !currentSessionId) return;
 
         const drafts = consumeDrafts(currentSessionId);
 
-        let messageToQueue = currentMessage.replace(/^\n+|\n+$/g, '');
+        let messageToQueue = inputSnapshot.message.replace(/^\n+|\n+$/g, '');
         if (drafts.length > 0) {
             messageToQueue = appendInlineComments(messageToQueue, drafts);
         }
@@ -1294,7 +1295,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         if (!isMobile) {
             textareaRef.current?.focus();
         }
-    }, [hasContent, hasDrafts, currentSessionId, message, sendableAttachedFiles, sanitizeAttachmentsForSend, addToQueue, clearAttachedFiles, isMobile, consumeDrafts, currentProviderId, currentModelId, currentAgentName, currentVariant]);
+    }, [getCurrentInputSnapshot, currentSessionId, sendableAttachedFiles, sanitizeAttachmentsForSend, addToQueue, clearAttachedFiles, isMobile, consumeDrafts, currentProviderId, currentModelId, currentAgentName, currentVariant]);
 
     const handleQueuedMessageEdit = React.useCallback((content: string) => {
         setMessage(content);
@@ -1321,10 +1322,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
     const handleSubmit = async (options?: SubmitOptions) => {
         const queuedOnly = options?.queuedOnly ?? false;
+        const inputSnapshot = getCurrentInputSnapshot();
 
         if (queuedOnly) {
             if (!hasQueuedMessages || !currentSessionId) return;
-        } else if (!canSend || (!currentSessionId && !newSessionDraftOpen)) {
+        } else if ((!inputSnapshot.hasContent && !hasQueuedMessages) || (!currentSessionId && !newSessionDraftOpen)) {
             return;
         }
 
@@ -1371,8 +1373,8 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         }
 
         // Add current input (skip for queued-only auto-send)
-        if (!queuedOnly && hasContent) {
-            const messageToSend = message.replace(/^\n+|\n+$/g, '');
+        if (!queuedOnly && inputSnapshot.hasContent) {
+            const messageToSend = inputSnapshot.message.replace(/^\n+|\n+$/g, '');
             const { sanitizedText, mention } = parseAgentMentions(messageToSend, agents);
             const { sanitizedText: messageText, attachments: mentionAttachments } = extractInlineFileMentions(sanitizedText);
             const attachmentsToSend = sanitizeAttachmentsForSend(sendableAttachedFiles);
@@ -1643,13 +1645,14 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
     // Primary action for send button - respects queue mode setting
     const handlePrimaryAction = React.useCallback(() => {
-        const canQueue = inputMode === 'normal' && hasContent && currentSessionId && sessionPhase !== 'idle';
+        const inputSnapshot = getCurrentInputSnapshot();
+        const canQueue = inputMode === 'normal' && inputSnapshot.hasContent && currentSessionId && sessionPhase !== 'idle';
         if (queueModeEnabled && canQueue) {
             handleQueueMessage();
         } else {
             void handleSubmitRef.current();
         }
-    }, [inputMode, hasContent, currentSessionId, sessionPhase, queueModeEnabled, handleQueueMessage]);
+    }, [inputMode, getCurrentInputSnapshot, currentSessionId, sessionPhase, queueModeEnabled, handleQueueMessage]);
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         // Early return during IME composition to prevent interference with autocomplete.


### PR DESCRIPTION
## Summary

- Fix a race condition where clicking the Queue button captures only the first character(s) of the message instead of the full text
- Read the textarea DOM value directly via `textareaRef.current.value` instead of relying on the React state closure in `handleQueueMessage`, which can be stale when React hasn't yet committed the latest render after rapid typing
- Recompute `hasContent` from the DOM value to keep the guard check consistent

## Problem

When the user types quickly and clicks the Queue button before React commits the latest state update, the `handleQueueMessage` callback (wrapped in `useCallback` with `message` as a dependency) still holds the `message` value from the previous completed render. This causes the queued message to contain only the first character(s) typed rather than the full message.

## Root Cause

React 18's automatic batching can delay state commits. The `handleTextChange` handler calls `setMessage(value)` on each keystroke, but the `useCallback` closure for `handleQueueMessage` only updates when React completes a render cycle. If the click event fires between a `setMessage` call and the corresponding re-render, the callback captures stale state.

## Fix

Read `textareaRef.current.value` directly from the DOM, which always reflects the current input regardless of React's render cycle. Fall back to the React state when the ref is unavailable (SSR, unmount).

## Test plan

- [ ] Type a multi-word message while the model is busy, click Queue — verify full message is queued
- [ ] Type rapidly and immediately click Queue — verify no truncation
- [ ] Queue multiple messages, let model finish — verify all messages auto-send with full content
- [ ] Edit a queued message chip, re-queue — verify content preserved


🤖 Generated with [Claude Code](https://claude.com/claude-code)