### PR TITLE
fix(server): prevent streaming hang during long agent sessions

### DIFF
--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -20,6 +20,8 @@ export type QueuedEvent = {
 export type FlushHandler = (events: QueuedEvent[]) => void
 
 const FLUSH_FRAME_MS = 33
+const BACKPRESSURE_FLUSH_FRAME_MS = 200
+const BACKPRESSURE_MODE_MS = 10_000
 const STREAM_YIELD_MS = 8
 const DEFAULT_RECONNECT_DELAY_MS = 250
 const DEFAULT_HEARTBEAT_TIMEOUT_MS = 30_000
@@ -44,7 +46,7 @@ export type EventPipelineInput = {
 }
 
 type MessageStreamWsFrame = {
-  type: "ready" | "event" | "error"
+  type: "ready" | "event" | "error" | "backpressure"
   payload?: unknown
   eventId?: string
   directory?: string
@@ -254,7 +256,8 @@ export function createEventPipeline(input: EventPipelineInput) {
     const d = getOrCreateDir(directory)
     if (d.timer) return
     const elapsed = Date.now() - d.last
-    d.timer = setTimeout(() => flushDir(directory), Math.max(0, FLUSH_FRAME_MS - elapsed))
+    const flushFrameMs = Date.now() < backpressureUntil ? BACKPRESSURE_FLUSH_FRAME_MS : FLUSH_FRAME_MS
+    d.timer = setTimeout(() => flushDir(directory), Math.max(0, flushFrameMs - elapsed))
   }
 
   const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
@@ -269,6 +272,7 @@ export function createEventPipeline(input: EventPipelineInput) {
   let activeTransport: "ws" | "sse" = transport === "ws" ? "ws" : "sse"
   let attemptAbortReason: AttemptAbortReason = null
   let consecutiveFailures = 0
+  let backpressureUntil = 0
 
   const notifyDisconnected = (reason: string) => {
     if (disconnected) {
@@ -486,6 +490,11 @@ export function createEventPipeline(input: EventPipelineInput) {
           } catch {
             // ignore
           }
+          return
+        }
+
+        if (frame.type === "backpressure") {
+          backpressureUntil = Date.now() + BACKPRESSURE_MODE_MS
           return
         }
 

--- a/packages/web/server/lib/event-stream/global-hub.js
+++ b/packages/web/server/lib/event-stream/global-hub.js
@@ -1,6 +1,8 @@
 import { createUpstreamSseReader } from './upstream-reader.js';
 
-export const MESSAGE_STREAM_GLOBAL_REPLAY_LIMIT = 512;
+// Raised from 512 → 2048 to improve recovery after brief disconnects during
+// long-running agent sessions where many events accumulate quickly.
+export const MESSAGE_STREAM_GLOBAL_REPLAY_LIMIT = 2048;
 
 export function createGlobalMessageStreamHub({
   buildOpenCodeUrl,

--- a/packages/web/server/lib/event-stream/protocol.js
+++ b/packages/web/server/lib/event-stream/protocol.js
@@ -3,7 +3,13 @@ export const MESSAGE_STREAM_DIRECTORY_WS_PATH = '/api/event/ws';
 export const MESSAGE_STREAM_WS_HEARTBEAT_INTERVAL_MS = 15 * 1000;
 // Per-client pending outbound WS buffer, not a payload or stream-size limit.
 // Healthy clients stay near 0; this only trips when a client is far behind.
-export const MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES = 4 * 1024 * 1024;
+// Raised from 4 MB → 16 MB to tolerate bursts during long agent sessions
+// (e.g. ultrawork / multi-tool loops) where the browser briefly falls behind.
+export const MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES = 16 * 1024 * 1024;
+
+// Threshold at which we emit a backpressure warning frame so the client can
+// proactively start shedding low-priority updates before the hard disconnect.
+export const MESSAGE_STREAM_WS_BACKPRESSURE_WARN_BYTES = 12 * 1024 * 1024;
 
 export function parseSseEventEnvelope(block) {
   if (!block || typeof block !== 'string') {
@@ -67,7 +73,9 @@ export function sendMessageStreamWsFrame(socket, payload) {
     return false;
   }
 
-  if (typeof socket.bufferedAmount === 'number' && socket.bufferedAmount > MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES) {
+  const buffered = typeof socket.bufferedAmount === 'number' ? socket.bufferedAmount : 0;
+
+  if (buffered > MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES) {
     try {
       socket.close(1013, 'Message stream client is too slow');
     } catch {
@@ -77,13 +85,36 @@ export function sendMessageStreamWsFrame(socket, payload) {
 
   try {
     socket.send(JSON.stringify(payload));
-    if (typeof socket.bufferedAmount === 'number' && socket.bufferedAmount > MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES) {
+    const bufferedAfter = typeof socket.bufferedAmount === 'number' ? socket.bufferedAmount : 0;
+    if (bufferedAfter > MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES) {
       try {
         socket.close(1013, 'Message stream client is too slow');
       } catch {
       }
       return false;
     }
+
+    // Emit a one-shot backpressure warning when the buffer is building up.
+    // The flag prevents sending repeated warnings that would themselves
+    // increase the buffer.  It resets once the buffer drains below the
+    // threshold.
+    if (bufferedAfter > MESSAGE_STREAM_WS_BACKPRESSURE_WARN_BYTES) {
+      if (!socket._ocBackpressureWarned) {
+        socket._ocBackpressureWarned = true;
+        try {
+          socket.send(JSON.stringify({
+            type: 'backpressure',
+            bufferedBytes: bufferedAfter,
+            maxBytes: MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES,
+          }));
+        } catch {
+          // Best-effort warning — ignore send failures.
+        }
+      }
+    } else if (socket._ocBackpressureWarned) {
+      socket._ocBackpressureWarned = false;
+    }
+
     return true;
   } catch {
     return false;

--- a/packages/web/server/lib/event-stream/protocol.test.js
+++ b/packages/web/server/lib/event-stream/protocol.test.js
@@ -4,6 +4,7 @@ import {
   MESSAGE_STREAM_DIRECTORY_WS_PATH,
   MESSAGE_STREAM_GLOBAL_WS_PATH,
   MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES,
+  MESSAGE_STREAM_WS_BACKPRESSURE_WARN_BYTES,
   parseSseEventEnvelope,
   sendMessageStreamWsEvent,
   sendMessageStreamWsFrame,
@@ -86,6 +87,73 @@ describe('event stream protocol helpers', () => {
       code: 1013,
       reason: 'Message stream client is too slow',
     });
+  });
+
+  it('emits a backpressure warning when buffer exceeds the warn threshold', () => {
+    const sentPayloads = [];
+    const socket = {
+      readyState: 1,
+      bufferedAmount: MESSAGE_STREAM_WS_BACKPRESSURE_WARN_BYTES + 1,
+      send(payload) {
+        sentPayloads.push(payload);
+      },
+    };
+
+    const sent = sendMessageStreamWsFrame(socket, { type: 'test' });
+
+    expect(sent).toBe(true);
+    expect(sentPayloads).toHaveLength(2);
+
+    const warning = JSON.parse(sentPayloads[1]);
+    expect(warning.type).toBe('backpressure');
+    expect(warning.bufferedBytes).toBeGreaterThan(0);
+    expect(warning.maxBytes).toBe(MESSAGE_STREAM_WS_MAX_BUFFERED_BYTES);
+  });
+
+  it('does not repeat backpressure warnings while still above threshold', () => {
+    const sentPayloads = [];
+    const socket = {
+      readyState: 1,
+      bufferedAmount: MESSAGE_STREAM_WS_BACKPRESSURE_WARN_BYTES + 1,
+      send(payload) {
+        sentPayloads.push(payload);
+      },
+    };
+
+    sendMessageStreamWsFrame(socket, { type: 'test1' });
+    sendMessageStreamWsFrame(socket, { type: 'test2' });
+
+    // First call: data + warning = 2 sends.  Second call: data only = 1 send.
+    expect(sentPayloads).toHaveLength(3);
+    expect(JSON.parse(sentPayloads[1]).type).toBe('backpressure');
+    expect(JSON.parse(sentPayloads[2])).toEqual({ type: 'test2' });
+  });
+
+  it('resets backpressure warning flag when buffer drains', () => {
+    const sentPayloads = [];
+    const socket = {
+      readyState: 1,
+      bufferedAmount: MESSAGE_STREAM_WS_BACKPRESSURE_WARN_BYTES + 1,
+      send(payload) {
+        sentPayloads.push(payload);
+      },
+    };
+
+    sendMessageStreamWsFrame(socket, { type: 'first' });
+    expect(socket._ocBackpressureWarned).toBe(true);
+
+    // Buffer drains
+    socket.bufferedAmount = 100;
+    sendMessageStreamWsFrame(socket, { type: 'recovered' });
+    expect(socket._ocBackpressureWarned).toBe(false);
+
+    // Buffer spikes again — warning should fire again
+    socket.bufferedAmount = MESSAGE_STREAM_WS_BACKPRESSURE_WARN_BYTES + 1;
+    sendMessageStreamWsFrame(socket, { type: 'again' });
+    const backpressureFrames = sentPayloads
+      .map((p) => JSON.parse(p))
+      .filter((p) => p.type === 'backpressure');
+    expect(backpressureFrames).toHaveLength(2);
   });
 
   it('serializes event frames with routing metadata', () => {


### PR DESCRIPTION
## Summary

- Raise the WebSocket outbound buffer limit from 4 MB to 16 MB to tolerate bursts during long agent sessions
- Add a backpressure warning frame at 12 MB so the client can proactively respond before the hard disconnect
- Raise the event replay buffer from 512 to 2048 events to improve recovery after brief disconnects
- Add tests for the backpressure warning behavior (emit, dedup, reset)

## Problem

During long-running agent sessions (e.g. ultrawork loops with many tool calls), the OpenChamber server generates high volumes of streaming events. If the browser WebSocket client briefly falls behind (heavy DOM rendering, tab in background, etc.), the server's outbound buffer exceeds 4 MB and force-disconnects the client with close code 1013 ("Message stream client is too slow").

After disconnect, the replay buffer only holds 512 events. If more events were missed during the reconnection gap, they are permanently lost — leaving the UI permanently stalled while the underlying CLI agent continues making progress.

## Root Cause

The combination of:
1. A relatively small 4 MB buffer limit that's insufficient for burst-heavy agent workloads
2. A hard disconnect with no warning signal to the client
3. A small replay buffer (512 events) that can't cover the gap

## Fix

1. **Increase buffer limit to 16 MB** — gives the browser more room to catch up during bursts without triggering a disconnect
2. **Backpressure warning at 12 MB** — sends a one-shot `{ type: "backpressure" }` frame when the buffer starts filling up. The warning is deduplicated (only fires once per spike) and resets when the buffer drains below the threshold. This gives the client a signal to shed low-priority updates.
3. **Increase replay limit to 2048** — ensures more events survive brief reconnection gaps, making recovery more reliable

## Test plan

- [ ] Run a long ultrawork session (30+ minutes) with heavy tool usage — verify UI stays in sync
- [ ] Simulate slow client (browser DevTools network throttling) — verify backpressure warning is sent before disconnect
- [ ] Disconnect and reconnect — verify replay buffer recovers recent events
- [ ] All existing event-stream tests pass (22/22)
- [ ] New backpressure tests pass (3 new tests: emit, dedup, reset)


🤖 Generated with [Claude Code](https://claude.com/claude-code)