### PR TITLE
add OpenCode Go usage support

### DIFF
--- a/packages/ui/src/components/sections/usage/UsagePage.tsx
+++ b/packages/ui/src/components/sections/usage/UsagePage.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { UsageCard } from './UsageCard';
 import { QUOTA_PROVIDERS } from '@/lib/quota';
 import { useQuotaAutoRefresh, useQuotaStore } from '@/stores/useQuotaStore';
@@ -16,6 +18,7 @@ import type { UsageWindows, QuotaProviderId } from '@/types';
 import { getAllModelFamilies, getDisplayModelName, sortModelFamilies, groupModelsByFamilyWithGetter } from '@/lib/quota/model-families';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useI18n } from '@/lib/i18n';
+import { getRegisteredRuntimeAPIs } from '@/contexts/runtimeAPIRegistry';
 
 const formatTime = (timestamp: number | null) => {
   if (!timestamp) return '-';
@@ -49,6 +52,7 @@ export const UsagePage: React.FC = () => {
   const selectedModels = useQuotaStore((state) => state.selectedModels);
   const toggleModelSelected = useQuotaStore((state) => state.toggleModelSelected);
   const applyDefaultSelections = useQuotaStore((state) => state.applyDefaultSelections);
+  const fetchProviderQuota = useQuotaStore((state) => state.fetchProviderQuota);
 
   useQuotaAutoRefresh();
 
@@ -140,6 +144,83 @@ export const UsagePage: React.FC = () => {
   }, [selectedProviderId, selectedModels, toggleModelSelected]);
 
   const providerSelectedModels = selectedProviderId ? (selectedModels[selectedProviderId] ?? []) : [];
+  const [opencodeGoWorkspaceId, setOpencodeGoWorkspaceId] = React.useState('');
+  const [opencodeGoSessionCookie, setOpencodeGoSessionCookie] = React.useState('');
+  const [isSavingOpencodeGoAccess, setIsSavingOpencodeGoAccess] = React.useState(false);
+  const [opencodeGoAccessMessage, setOpencodeGoAccessMessage] = React.useState<string | null>(null);
+  const [opencodeGoAccessError, setOpencodeGoAccessError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const loadOpencodeGoAccess = async () => {
+      try {
+        const runtimeSettings = getRegisteredRuntimeAPIs()?.settings;
+        if (runtimeSettings) {
+          const result = await runtimeSettings.load();
+          if (cancelled) return;
+          const settings = result?.settings as Record<string, unknown> | undefined;
+          setOpencodeGoWorkspaceId(typeof settings?.opencodeGoWorkspaceId === 'string' ? settings.opencodeGoWorkspaceId : '');
+          setOpencodeGoSessionCookie(typeof settings?.opencodeGoSessionCookie === 'string' ? settings.opencodeGoSessionCookie : '');
+          return;
+        }
+
+        const response = await fetch('/api/config/settings', {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+        });
+        const settings = await response.json().catch(() => null) as Record<string, unknown> | null;
+        if (cancelled) return;
+        setOpencodeGoWorkspaceId(typeof settings?.opencodeGoWorkspaceId === 'string' ? settings.opencodeGoWorkspaceId : '');
+        setOpencodeGoSessionCookie(typeof settings?.opencodeGoSessionCookie === 'string' ? settings.opencodeGoSessionCookie : '');
+      } catch (error) {
+        console.warn('Failed to load OpenCode Go access settings:', error);
+      }
+    };
+
+    void loadOpencodeGoAccess();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const saveOpencodeGoAccess = React.useCallback(async () => {
+    setIsSavingOpencodeGoAccess(true);
+    setOpencodeGoAccessMessage(null);
+    setOpencodeGoAccessError(null);
+
+    const payload = {
+      opencodeGoWorkspaceId: opencodeGoWorkspaceId.trim(),
+      opencodeGoSessionCookie: opencodeGoSessionCookie.trim(),
+    };
+
+    try {
+      const runtimeSettings = getRegisteredRuntimeAPIs()?.settings;
+      if (runtimeSettings) {
+        await runtimeSettings.save(payload);
+      } else {
+        const response = await fetch('/api/config/settings', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const data = await response.json().catch(() => null);
+          throw new Error(typeof data?.error === 'string' ? data.error : 'Failed to save OpenCode Go access settings');
+        }
+      }
+
+      await fetchProviderQuota('opencode-go');
+      setOpencodeGoAccessMessage('Saved. OpenCode Go usage has been refreshed.');
+    } catch (error) {
+      setOpencodeGoAccessError(error instanceof Error ? error.message : 'Failed to save OpenCode Go access settings');
+    } finally {
+      setIsSavingOpencodeGoAccess(false);
+    }
+  }, [fetchProviderQuota, opencodeGoSessionCookie, opencodeGoWorkspaceId]);
 
   if (!selectedProviderId) {
     return (
@@ -224,6 +305,65 @@ export const UsagePage: React.FC = () => {
             <p className="typography-meta text-[var(--status-warning)]/80 mt-1">
               {t('settings.usage.page.state.providerNotConfiguredDescription')}
             </p>
+          </div>
+        )}
+
+        {selectedProviderId === 'opencode-go' && (
+          <div className="mb-8">
+            <div className="mb-1 px-1">
+              <h3 className="typography-ui-header font-medium text-foreground">Dashboard Access</h3>
+              <p className="typography-meta mt-1 text-muted-foreground">
+                OpenCode Go subscription usage comes from the opencode.ai dashboard. The API key is not enough on its own, so add your workspace ID and a logged-in dashboard session here.
+              </p>
+            </div>
+            <section className="space-y-3 p-2">
+              <div className="space-y-1.5">
+                <span className="typography-ui-label text-foreground">Workspace ID</span>
+                <Input
+                  className="h-7"
+                  value={opencodeGoWorkspaceId}
+                  onChange={(event) => setOpencodeGoWorkspaceId(event.target.value)}
+                  placeholder="wrk_..."
+                />
+              </div>
+              <div className="space-y-1.5">
+                <span className="typography-ui-label text-foreground">Dashboard Session Cookie</span>
+                <Input
+                  type="password"
+                  className="h-7"
+                  value={opencodeGoSessionCookie}
+                  onChange={(event) => setOpencodeGoSessionCookie(event.target.value)}
+                  placeholder="Paste the auth cookie value"
+                />
+                <p className="typography-meta text-muted-foreground">
+                  Paste the `auth` cookie value from a logged-in `opencode.ai` dashboard session. This is stored locally in your OpenChamber settings.
+                </p>
+              </div>
+              <div className="flex items-center gap-2 pt-1">
+                <Button size="sm" onClick={() => void saveOpencodeGoAccess()} disabled={isSavingOpencodeGoAccess}>
+                  {isSavingOpencodeGoAccess ? 'Saving…' : 'Save and Refresh'}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setOpencodeGoWorkspaceId('');
+                    setOpencodeGoSessionCookie('');
+                    setOpencodeGoAccessMessage(null);
+                    setOpencodeGoAccessError(null);
+                  }}
+                  disabled={isSavingOpencodeGoAccess}
+                >
+                  Clear Draft
+                </Button>
+              </div>
+              {opencodeGoAccessMessage && (
+                <p className="typography-meta text-[var(--status-success)]">{opencodeGoAccessMessage}</p>
+              )}
+              {opencodeGoAccessError && (
+                <p className="typography-meta text-[var(--status-error)]">{opencodeGoAccessError}</p>
+              )}
+            </section>
           </div>
         )}
 

--- a/packages/ui/src/hooks/useProviderLogo.ts
+++ b/packages/ui/src/hooks/useProviderLogo.ts
@@ -23,6 +23,7 @@ const LOGO_ALIAS = new Map<string, string>([
     ['evroc-ai', 'evroc'],
     ['evrocai', 'evroc'],
     ['ollama-cloud', 'ollama'],
+    ['opencode-go', 'gocode'],
 ]);
 
 const normalizeProviderId = (providerId: string | null | undefined) => {

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -85,6 +85,8 @@ export type DesktopSettings = {
   usageRefreshIntervalMs?: number;
   usageDisplayMode?: 'usage' | 'remaining';
   usageDropdownProviders?: string[];
+  opencodeGoWorkspaceId?: string;
+  opencodeGoSessionCookie?: string;
   usageSelectedModels?: Record<string, string[]>;  // Map of providerId -> selected model names
   usageCollapsedFamilies?: Record<string, string[]>;  // Map of providerId -> collapsed family IDs (UsagePage)
   usageExpandedFamilies?: Record<string, string[]>;  // Map of providerId -> EXPANDED family IDs (header dropdown - inverted)

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -721,6 +721,14 @@ const sanitizeWebSettings = (payload: unknown): DesktopSettings | null => {
       (entry): entry is string => typeof entry === 'string' && entry.length > 0
     );
   }
+  if (typeof candidate.opencodeGoWorkspaceId === 'string') {
+    const trimmed = candidate.opencodeGoWorkspaceId.trim();
+    result.opencodeGoWorkspaceId = trimmed;
+  }
+  if (typeof candidate.opencodeGoSessionCookie === 'string') {
+    const trimmed = candidate.opencodeGoSessionCookie.trim();
+    result.opencodeGoSessionCookie = trimmed;
+  }
 
   // Parse usageSelectedModels (Record<string, string[]>)
   if (candidate.usageSelectedModels && typeof candidate.usageSelectedModels === 'object') {

--- a/packages/ui/src/lib/quota/providers/index.ts
+++ b/packages/ui/src/lib/quota/providers/index.ts
@@ -12,6 +12,7 @@ export const QUOTA_PROVIDERS: QuotaProviderMeta[] = [
   { id: 'google', name: 'Google' },
   { id: 'kimi-for-coding', name: 'Kimi for Coding' },
   { id: 'nano-gpt', name: 'NanoGPT' },
+  { id: 'opencode-go', name: 'OpenCode Go' },
   { id: 'openrouter', name: 'OpenRouter' },
   { id: 'zai-coding-plan', name: 'z.ai' },
   { id: 'zhipuai-coding-plan', name: 'Zhipu AI Coding Plan' },

--- a/packages/ui/src/lib/quota/utils.ts
+++ b/packages/ui/src/lib/quota/utils.ts
@@ -26,6 +26,7 @@ export const resolveUsageTone = (percent: number | null): 'safe' | 'warn' | 'cri
 };
 
 export const formatWindowLabel = (label: string): string => {
+  if (label === 'rolling') return 'Rolling Usage';
   if (label === '5h') return '5-Hour';
   if (label === '7d') return '7-Day Limit';
   if (label === '7d-sonnet') return '7-Day Sonnet Limit';
@@ -83,6 +84,7 @@ export const inferWindowSeconds = (label: string): number | null => {
   const normalized = label.toLowerCase().trim();
   
   // Exact matches
+  if (normalized === 'rolling') return 5 * 3600;
   if (normalized === '5h') return 5 * 3600;
   if (normalized === '7d' || normalized === 'weekly' || normalized === '7d-sonnet' || normalized === '7d-opus') return 7 * 86400;
   if (normalized === 'monthly') return 30 * 86400;

--- a/packages/ui/src/types/quota.ts
+++ b/packages/ui/src/types/quota.ts
@@ -8,6 +8,7 @@ export type QuotaProviderId =
   | 'kimi-for-coding'
   | 'nano-gpt'
   | 'openrouter'
+  | 'opencode-go'
   | 'zai-coding-plan'
   | 'zhipuai-coding-plan'
   | 'minimax-coding-plan'

--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -207,6 +207,12 @@ export const createSettingsHelpers = (dependencies) => {
     if (Array.isArray(candidate.usageDropdownProviders)) {
       result.usageDropdownProviders = normalizeStringArray(candidate.usageDropdownProviders);
     }
+    if (typeof candidate.opencodeGoWorkspaceId === 'string') {
+      result.opencodeGoWorkspaceId = candidate.opencodeGoWorkspaceId.trim();
+    }
+    if (typeof candidate.opencodeGoSessionCookie === 'string') {
+      result.opencodeGoSessionCookie = candidate.opencodeGoSessionCookie.trim();
+    }
     if (typeof candidate.autoDeleteEnabled === 'boolean') {
       result.autoDeleteEnabled = candidate.autoDeleteEnabled;
     }

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -30,6 +30,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 | `minimax-coding-plan` | MiniMax Coding Plan (minimax.io) | `providers/minimax-coding-plan.js` | `minimax-coding-plan` |
 | `minimax-cn-coding-plan` | MiniMax Coding Plan (minimaxi.com) | `providers/minimax-cn-coding-plan.js` | `minimax-cn-coding-plan` |
 | `ollama-cloud` | Ollama Cloud | `providers/ollama-cloud.js` | Cookie file at `~/.config/ollama-quota/cookie` (raw session cookie string) |
+| `opencode-go` | OpenCode Go | `providers/opencode-go.js` | API key in `~/.local/share/opencode/auth.json` under `opencode-go`; subscription usage can also use dashboard access saved in OpenChamber settings (or `OPENCODE_GO_WORKSPACE_ID` + `OPENCODE_GO_SESSION_COOKIE`) |
 | `zhipuai-coding-plan` | ZhipuAI | `providers/zhipuai.js` | `zhipuai-coding-plan`, `zhipuai`, `zhipu` |
 
 ## Internal-only provider module

--- a/packages/web/server/lib/quota/index.js
+++ b/packages/web/server/lib/quota/index.js
@@ -21,5 +21,6 @@ export {
   fetchMinimaxCodingPlanQuota,
   fetchMinimaxCnCodingPlanQuota,
   fetchOllamaCloudQuota,
+  fetchOpenCodeGoQuota,
   fetchZhipuaiQuota
 } from './providers/index.js';

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -20,6 +20,7 @@ import * as zhipuaiCodingPlan from './zhipuai-coding-plan.js';
 import * as minimaxCodingPlan from './minimax-coding-plan.js';
 import * as minimaxCnCodingPlan from './minimax-cn-coding-plan.js';
 import * as ollamaCloud from './ollama-cloud.js';
+import * as opencodeGo from './opencode-go.js';
 import * as zhipuai from './zhipuai.js';
 
 const registry = {
@@ -101,6 +102,12 @@ const registry = {
     isConfigured: ollamaCloud.isConfigured,
     fetchQuota: ollamaCloud.fetchQuota
   },
+  'opencode-go': {
+    providerId: opencodeGo.providerId,
+    providerName: opencodeGo.providerName,
+    isConfigured: opencodeGo.isConfigured,
+    fetchQuota: opencodeGo.fetchQuota
+  },
   'zhipuai-coding-plan': {
     providerId: zhipuai.providerId,
     providerName: zhipuai.providerName,
@@ -165,4 +172,5 @@ export const fetchNanoGptQuota = nanogpt.fetchQuota;
 export const fetchMinimaxCodingPlanQuota = minimaxCodingPlan.fetchQuota;
 export const fetchMinimaxCnCodingPlanQuota = minimaxCnCodingPlan.fetchQuota;
 export const fetchOllamaCloudQuota = ollamaCloud.fetchQuota;
+export const fetchOpenCodeGoQuota = opencodeGo.fetchQuota;
 export const fetchZhipuaiQuota = zhipuai.fetchQuota;

--- a/packages/web/server/lib/quota/providers/opencode-go.js
+++ b/packages/web/server/lib/quota/providers/opencode-go.js
@@ -1,0 +1,290 @@
+import { readAuthFile } from '../../opencode/auth.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  getAuthEntry,
+  normalizeAuthEntry,
+  buildResult,
+  toUsageWindow,
+} from '../utils/index.js';
+
+export const providerId = 'opencode-go';
+export const providerName = 'OpenCode Go';
+export const aliases = ['opencode-go'];
+const OPENCHAMBER_SETTINGS_FILE = path.join(os.homedir(), '.config', 'openchamber', 'settings.json');
+
+const getApiKey = () => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  return entry?.key ?? entry?.token ?? entry?.access ?? null;
+};
+
+const normalizeSessionCookie = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // Users will often paste the raw auth cookie token from the browser.
+  // The dashboard expects it as `auth=<token>`.
+  if (!trimmed.includes('=')) {
+    return `auth=${trimmed}`;
+  }
+
+  return trimmed;
+};
+
+const readOpenChamberSettings = () => {
+  try {
+    if (!fs.existsSync(OPENCHAMBER_SETTINGS_FILE)) {
+      return null;
+    }
+    const content = fs.readFileSync(OPENCHAMBER_SETTINGS_FILE, 'utf8').trim();
+    if (!content) {
+      return null;
+    }
+    const parsed = JSON.parse(content);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const getDashboardAccess = (settings) => {
+  const workspaceFromSettings = typeof settings?.opencodeGoWorkspaceId === 'string'
+    ? settings.opencodeGoWorkspaceId.trim()
+    : '';
+  const cookieFromSettings = typeof settings?.opencodeGoSessionCookie === 'string'
+    ? settings.opencodeGoSessionCookie.trim()
+    : '';
+  const workspaceFromEnv = typeof process?.env?.OPENCODE_GO_WORKSPACE_ID === 'string'
+    ? process.env.OPENCODE_GO_WORKSPACE_ID.trim()
+    : '';
+  const cookieFromEnv = typeof process?.env?.OPENCODE_GO_SESSION_COOKIE === 'string'
+    ? process.env.OPENCODE_GO_SESSION_COOKIE.trim()
+    : '';
+
+  return {
+    workspaceId: workspaceFromSettings || workspaceFromEnv || null,
+    sessionCookie: cookieFromSettings || cookieFromEnv || null,
+  };
+};
+
+const toResetAt = (seconds) => {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) {
+    return null;
+  }
+  return Date.now() + seconds * 1000;
+};
+
+const parseResetDurationSeconds = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const text = value.trim().toLowerCase();
+  if (!text) {
+    return null;
+  }
+
+  if (text.includes('few seconds')) {
+    return 15;
+  }
+
+  const matches = Array.from(text.matchAll(/(\d+)\s+(day|days|hour|hours|minute|minutes)/g));
+  if (matches.length === 0) {
+    return null;
+  }
+
+  let total = 0;
+  for (const match of matches) {
+    const amount = Number.parseInt(match[1], 10);
+    const unit = match[2];
+    if (!Number.isFinite(amount)) {
+      continue;
+    }
+    if (unit.startsWith('day')) {
+      total += amount * 24 * 60 * 60;
+    } else if (unit.startsWith('hour')) {
+      total += amount * 60 * 60;
+    } else if (unit.startsWith('minute')) {
+      total += amount * 60;
+    }
+  }
+
+  return total > 0 ? total : null;
+};
+
+const parseSubscriptionFromDashboardHtml = (html) => {
+  if (typeof html !== 'string' || !html.includes('You are subscribed to OpenCode Go.')) {
+    return null;
+  }
+
+  const sectionMatch = html.match(/<div data-slot="usage">([\s\S]*?)<\/div><form action=/);
+  const section = sectionMatch?.[1] ?? null;
+  if (!section) {
+    return null;
+  }
+
+  const itemMatches = Array.from(section.matchAll(/<div data-slot="usage-item">([\s\S]*?)<span data-slot="reset-time"><!--\$-->Resets in<!--\/--> <!--\$-->([^<]+)<!--\/--><\/span><\/div>/g));
+  if (itemMatches.length < 3) {
+    return null;
+  }
+
+  const parseItem = (match) => {
+    const chunk = typeof match?.[1] === 'string' ? match[1] : '';
+    const percentMatch = chunk.match(/data-slot="usage-value"><!--\$-->(\d+)<!--\/-->%/);
+    const resetText = typeof match?.[2] === 'string' ? match[2] : null;
+    const usedPercent = percentMatch ? Number.parseInt(percentMatch[1], 10) : null;
+    const resetSeconds = resetText ? parseResetDurationSeconds(resetText) : null;
+    return {
+      usedPercent: Number.isFinite(usedPercent) ? usedPercent : null,
+      resetAt: toResetAt(resetSeconds),
+    };
+  };
+
+  return {
+    rollingUsage: parseItem(itemMatches[0]),
+    weeklyUsage: parseItem(itemMatches[1]),
+    monthlyUsage: parseItem(itemMatches[2]),
+  };
+};
+
+const buildUsageFromSubscription = (subscription) => {
+  const rollingUsage = subscription?.rollingUsage;
+  const weeklyUsage = subscription?.weeklyUsage;
+  const monthlyUsage = subscription?.monthlyUsage;
+
+  if (!rollingUsage || !weeklyUsage || !monthlyUsage) {
+    return null;
+  }
+
+  return {
+    windows: {
+      rolling: toUsageWindow({
+        usedPercent: typeof rollingUsage.usedPercent === 'number' ? rollingUsage.usedPercent : null,
+        resetAt: rollingUsage.resetAt ?? null,
+        windowSeconds: null,
+      }),
+      weekly: toUsageWindow({
+        usedPercent: typeof weeklyUsage.usedPercent === 'number' ? weeklyUsage.usedPercent : null,
+        resetAt: weeklyUsage.resetAt ?? null,
+        windowSeconds: 7 * 24 * 60 * 60,
+      }),
+      monthly: toUsageWindow({
+        usedPercent: typeof monthlyUsage.usedPercent === 'number' ? monthlyUsage.usedPercent : null,
+        resetAt: monthlyUsage.resetAt ?? null,
+        windowSeconds: 30 * 24 * 60 * 60,
+      }),
+    }
+  };
+};
+
+const fetchSubscriptionViaDashboardSession = async (workspaceId, sessionCookie) => {
+  const normalizedCookie = normalizeSessionCookie(sessionCookie);
+  if (!normalizedCookie) {
+    throw new Error('Missing dashboard session cookie');
+  }
+
+  const response = await fetch(`https://opencode.ai/workspace/${encodeURIComponent(workspaceId)}/go`, {
+    method: 'GET',
+    headers: {
+      Accept: 'text/html,application/xhtml+xml',
+      Cookie: normalizedCookie,
+    },
+  });
+
+  const payload = await response.text().catch(() => null);
+
+  if (!response.ok) {
+    const message = typeof payload === 'string' && payload.includes('/auth/authorize')
+      ? 'Dashboard session is not authorized for this workspace'
+      : `Dashboard API error: ${response.status}`;
+    throw new Error(message);
+  }
+
+  const subscription = parseSubscriptionFromDashboardHtml(payload);
+  if (!subscription) {
+    throw new Error('Failed to parse OpenCode Go subscription usage from dashboard page');
+  }
+
+  return subscription;
+};
+
+export const isConfigured = () => {
+  return Boolean(getApiKey());
+};
+
+export const fetchQuota = async () => {
+  const apiKey = getApiKey();
+
+  if (!apiKey) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: false,
+      error: 'Not configured'
+    });
+  }
+
+  try {
+    // We can validate the OpenCode Go key against the published models API,
+    // but the subscription usage endpoint is not exposed in a stable public API.
+    const response = await fetch('https://opencode.ai/zen/go/v1/models', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: `API error: ${response.status}`
+      });
+    }
+
+    const settings = readOpenChamberSettings();
+    const { workspaceId, sessionCookie } = getDashboardAccess(settings);
+
+    if (workspaceId && sessionCookie) {
+      const subscription = await fetchSubscriptionViaDashboardSession(workspaceId, sessionCookie);
+      const usage = buildUsageFromSubscription(subscription);
+
+      if (usage) {
+        return buildResult({
+          providerId,
+          providerName,
+          ok: true,
+          configured: true,
+          usage,
+        });
+      }
+    }
+
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: 'OpenCode Go is configured, but its subscription usage needs dashboard access details saved in OpenCode Go usage settings.'
+    });
+  } catch (error) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: error instanceof Error ? error.message : 'Request failed'
+    });
+  }
+};

--- a/packages/web/server/lib/quota/providers/opencode-go.js
+++ b/packages/web/server/lib/quota/providers/opencode-go.js
@@ -119,39 +119,51 @@ const parseResetDurationSeconds = (value) => {
   return total > 0 ? total : null;
 };
 
+const stripHtmlComments = (value) => value.replace(/<!--[^]*?-->/g, '');
+
+const normalizeText = (value) => value.replace(/\s+/g, ' ').trim();
+
 const parseSubscriptionFromDashboardHtml = (html) => {
   if (typeof html !== 'string' || !html.includes('You are subscribed to OpenCode Go.')) {
     return null;
   }
 
-  const sectionMatch = html.match(/<div data-slot="usage">([\s\S]*?)<\/div><form action=/);
+  const sanitizedHtml = stripHtmlComments(html);
+  const sectionMatch = sanitizedHtml.match(/<div data-slot="usage">([\s\S]*?)<\/div><form action=/);
   const section = sectionMatch?.[1] ?? null;
   if (!section) {
     return null;
   }
 
-  const itemMatches = Array.from(section.matchAll(/<div data-slot="usage-item">([\s\S]*?)<span data-slot="reset-time"><!--\$-->Resets in<!--\/--> <!--\$-->([^<]+)<!--\/--><\/span><\/div>/g));
-  if (itemMatches.length < 3) {
-    return null;
-  }
+  const usageByKey = {};
+  const usageMatches = Array.from(section.matchAll(
+    /<div data-slot="usage-item">[\s\S]*?<span data-slot="usage-label">([^<]+)<\/span><span data-slot="usage-value">(\d+)%<\/span>[\s\S]*?<span data-slot="reset-time">\s*Resets in\s*([^<]+)<\/span>[\s\S]*?<\/div>/g
+  ));
 
-  const parseItem = (match) => {
-    const chunk = typeof match?.[1] === 'string' ? match[1] : '';
-    const percentMatch = chunk.match(/data-slot="usage-value"><!--\$-->(\d+)<!--\/-->%/);
-    const resetText = typeof match?.[2] === 'string' ? match[2] : null;
-    const usedPercent = percentMatch ? Number.parseInt(percentMatch[1], 10) : null;
-    const resetSeconds = resetText ? parseResetDurationSeconds(resetText) : null;
-    return {
+  for (const match of usageMatches) {
+    const label = normalizeText(match?.[1] ?? '').toLowerCase();
+
+    let key = null;
+    if (label === 'rolling usage') key = 'rollingUsage';
+    if (label === 'weekly usage') key = 'weeklyUsage';
+    if (label === 'monthly usage') key = 'monthlyUsage';
+    if (!key) {
+      continue;
+    }
+
+    const usedPercent = Number.parseInt(match[2], 10);
+    const resetSeconds = parseResetDurationSeconds(normalizeText(match[3] ?? ''));
+    usageByKey[key] = {
       usedPercent: Number.isFinite(usedPercent) ? usedPercent : null,
       resetAt: toResetAt(resetSeconds),
     };
-  };
+  }
 
-  return {
-    rollingUsage: parseItem(itemMatches[0]),
-    weeklyUsage: parseItem(itemMatches[1]),
-    monthlyUsage: parseItem(itemMatches[2]),
-  };
+  if (!usageByKey.rollingUsage || !usageByKey.weeklyUsage || !usageByKey.monthlyUsage) {
+    return null;
+  }
+
+  return usageByKey;
 };
 
 const buildUsageFromSubscription = (subscription) => {


### PR DESCRIPTION
## Summary
- add OpenCode Go as a quota provider in the Usage page and header usage system
- add dashboard access fields for the Go workspace ID and auth cookie so subscription usage can be fetched locally
- parse rolling, weekly, and monthly usage from the authenticated OpenCode Go dashboard page, including rolling pace prediction