### PR TITLE
fix: redirect focus to hidden input after blurring Ghostty elements

### DIFF
--- a/packages/ui/src/components/terminal/TerminalViewport.tsx
+++ b/packages/ui/src/components/terminal/TerminalViewport.tsx
@@ -1000,6 +1000,7 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
           if (useHiddenInputOverlay && target instanceof HTMLElement) {
             window.setTimeout(() => {
               target.blur();
+              focusHiddenInput();
             }, 0);
             setTerminalCursorBlink(false);
             return;


### PR DESCRIPTION
On Android tablets in Desktop site mode, the handleDocumentFocusIn handler intercepted Ghostty's internal element focus and blurred them, but never redirected focus to the hidden input overlay. This left the terminal with no focused element - the IME keyboard would appear but keystrokes went nowhere. Now focusHiddenInput() is called after the blur to ensure the terminal always has a focused input surface.