### PR TITLE
fix: align session status parsing and vscode reconnect reconcile

### DIFF
--- a/packages/vscode/src/sessionActivityWatcher.ts
+++ b/packages/vscode/src/sessionActivityWatcher.ts
@@ -16,6 +16,38 @@ const SESSION_COOLDOWN_DURATION_MS = 2000;
 let globalEventWatcherAbortController: AbortController | null = null;
 let chatViewProvider: { postMessage: (message: unknown) => void } | null = null;
 
+const reconcileSessionActivityFromStatus = async (manager: OpenCodeManager): Promise<void> => {
+  const baseUrl = manager.getApiUrl();
+  if (!baseUrl) {
+    return;
+  }
+
+  const url = new URL('/session/status', baseUrl);
+  const response = await fetch(url.toString(), {
+    headers: manager.getOpenCodeAuthHeaders(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`session status fetch failed (${response.status})`);
+  }
+
+  const statuses = await response.json() as Record<string, { type?: string }>;
+  const knownSessionIds = new Set(Object.keys(statuses || {}));
+
+  for (const [sessionId, data] of Object.entries(statuses || {})) {
+    const type = typeof data?.type === 'string' ? data.type : 'idle';
+    const phase: ActivityPhase = type === 'busy' || type === 'retry' ? 'busy' : 'idle';
+    setSessionActivityPhase(sessionId, phase);
+  }
+
+  // Drop stale in-memory activity entries not present in authoritative status.
+  for (const [sessionId] of sessionActivityPhases) {
+    if (!knownSessionIds.has(sessionId)) {
+      setSessionActivityPhase(sessionId, 'idle');
+    }
+  }
+};
+
 const setSessionActivityPhase = (sessionId: string, phase: ActivityPhase): void => {
   if (!sessionId) return;
 
@@ -166,6 +198,14 @@ export const startGlobalEventWatcher = async (
           baseUrl,
           headers: manager.getOpenCodeAuthHeaders(),
         });
+        try {
+          await reconcileSessionActivityFromStatus(manager);
+        } catch (error) {
+          console.warn(
+            '[VSCode:Activity] session status reconcile failed',
+            error instanceof Error ? error.message : error,
+          );
+        }
         const result = await client.global.event({
           signal,
           sseMaxRetryAttempts: 0,

--- a/packages/vscode/src/sessionActivityWatcher.ts
+++ b/packages/vscode/src/sessionActivityWatcher.ts
@@ -41,7 +41,7 @@ const reconcileSessionActivityFromStatus = async (manager: OpenCodeManager): Pro
   }
 
   // Drop stale in-memory activity entries not present in authoritative status.
-  for (const [sessionId] of sessionActivityPhases) {
+  for (const sessionId of Array.from(sessionActivityPhases.keys())) {
     if (!knownSessionIds.has(sessionId)) {
       setSessionActivityPhase(sessionId, 'idle');
     }
@@ -114,8 +114,9 @@ const deriveSessionActivity = (payload: Record<string, unknown>): SessionActivit
 
   if (type === 'session.status') {
     const status = properties?.status as Record<string, unknown> | undefined;
+    const info = properties?.info as Record<string, unknown> | undefined;
     const sessionId = (properties?.sessionID ?? properties?.sessionId) as string;
-    const statusType = status?.type as string;
+    const statusType = (status?.type ?? info?.type) as string;
 
     if (typeof sessionId === 'string' && sessionId.length > 0 && typeof statusType === 'string') {
       const phase = statusType === 'busy' || statusType === 'retry' ? 'busy' : 'idle';

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -696,9 +696,12 @@ const processForwardedEventPayload = (payload, emitSyntheticEvent) => {
   }
 
   const properties = payload.properties && typeof payload.properties === 'object' ? payload.properties : {};
+  const statusInfo = properties.status && typeof properties.status === 'object' ? properties.status : {};
   const info = properties.info && typeof properties.info === 'object' ? properties.info : {};
   const sessionId = typeof properties.sessionID === 'string' ? properties.sessionID.trim() : '';
-  const status = typeof info.type === 'string' ? info.type.trim() : '';
+  const status = typeof statusInfo.type === 'string'
+    ? statusInfo.type.trim()
+    : (typeof info.type === 'string' ? info.type.trim() : '');
 
   if (!sessionId || !status) {
     return;
@@ -711,9 +714,15 @@ const processForwardedEventPayload = (payload, emitSyntheticEvent) => {
       status,
       timestamp: Date.now(),
       metadata: {
-        attempt: typeof info.attempt === 'number' ? info.attempt : undefined,
-        message: typeof info.message === 'string' ? info.message : undefined,
-        next: typeof info.next === 'number' ? info.next : undefined,
+        attempt: typeof statusInfo.attempt === 'number'
+          ? statusInfo.attempt
+          : (typeof info.attempt === 'number' ? info.attempt : undefined),
+        message: typeof statusInfo.message === 'string'
+          ? statusInfo.message
+          : (typeof info.message === 'string' ? info.message : undefined),
+        next: typeof statusInfo.next === 'number'
+          ? statusInfo.next
+          : (typeof info.next === 'number' ? info.next : undefined),
       },
       needsAttention: false,
     },

--- a/packages/web/server/lib/opencode/session-runtime.js
+++ b/packages/web/server/lib/opencode/session-runtime.js
@@ -9,9 +9,13 @@ const extractSessionStatusUpdate = (payload) => {
   }
 
   const properties = payload.properties && typeof payload.properties === 'object' ? payload.properties : {};
+  const status = properties.status && typeof properties.status === 'object' ? properties.status : {};
   const info = properties.info && typeof properties.info === 'object' ? properties.info : {};
   const sessionId = typeof properties.sessionID === 'string' ? properties.sessionID.trim() : '';
-  const type = typeof info.type === 'string' ? info.type.trim() : '';
+  // Canonical OpenCode schema uses properties.status.type. Keep legacy info.type fallback for compatibility.
+  const type = typeof status.type === 'string'
+    ? status.type.trim()
+    : (typeof info.type === 'string' ? info.type.trim() : '');
 
   if (!sessionId || !type) {
     return null;
@@ -21,9 +25,15 @@ const extractSessionStatusUpdate = (payload) => {
     sessionId,
     type,
     eventId: typeof payload.id === 'string' ? payload.id : '',
-    attempt: typeof info.attempt === 'number' ? info.attempt : undefined,
-    message: typeof info.message === 'string' ? info.message : undefined,
-    next: typeof info.next === 'number' ? info.next : undefined,
+    attempt: typeof status.attempt === 'number'
+      ? status.attempt
+      : (typeof info.attempt === 'number' ? info.attempt : undefined),
+    message: typeof status.message === 'string'
+      ? status.message
+      : (typeof info.message === 'string' ? info.message : undefined),
+    next: typeof status.next === 'number'
+      ? status.next
+      : (typeof info.next === 'number' ? info.next : undefined),
   };
 };
 

--- a/packages/web/server/lib/opencode/session-runtime.test.js
+++ b/packages/web/server/lib/opencode/session-runtime.test.js
@@ -29,7 +29,7 @@ describe('session runtime', () => {
       type: 'session.status',
       properties: {
         sessionID: 'session-1',
-        info: {
+        status: {
           type: 'busy',
         },
       },
@@ -39,7 +39,7 @@ describe('session runtime', () => {
       type: 'session.status',
       properties: {
         sessionID: 'session-1',
-        info: {
+        status: {
           type: 'idle',
         },
       },
@@ -63,6 +63,38 @@ describe('session runtime', () => {
         metadata: {},
         needsAttention: false,
       },
+    });
+  });
+
+  it('accepts legacy session.status info.type payloads', () => {
+    const events = [];
+    const runtime = createSessionRuntime({
+      writeSseEvent() {
+        throw new Error('SSE fallback should not be used when broadcastEvent is provided');
+      },
+      getNotificationClients: () => new Set(),
+      broadcastEvent: (payload) => {
+        events.push(payload);
+      },
+    });
+    runtimes.push(runtime);
+
+    runtime.processOpenCodeSsePayload({
+      type: 'session.status',
+      properties: {
+        sessionID: 'legacy-session-1',
+        info: {
+          type: 'busy',
+        },
+      },
+    });
+
+    expect(events).toContainEqual({
+      type: 'openchamber:session-status',
+      properties: expect.objectContaining({
+        sessionId: 'legacy-session-1',
+        status: 'busy',
+      }),
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes stale "active/running" session indicators by aligning OpenChamber session-status handling with OpenCode’s canonical event schema and hardening VS Code reconnect behavior.

## Problem
Some completed OpenCode sessions remained shown as active in OpenChamber.

Root causes:
- OpenChamber parsed `session.status` using legacy `properties.info.type` while OpenCode emits canonical `properties.status.type`.
- VS Code activity watcher relied on streaming events only; after reconnects, missed idle transitions could leave stale busy state.

## Changes
### 1) Session status schema parity (web runtime)
- Updated session-status parsing to prefer canonical `properties.status.type`.
- Kept backward-compatible fallback to legacy `properties.info.type`.
- Applied in web runtime session processing paths.

### 2) Retry metadata parity
- Retry metadata (`attempt`, `message`, `next`) now reads from canonical `properties.status.*` with fallback to legacy `properties.info.*`.

### 3) VS Code reconnect reconciliation
- Added authoritative reconciliation from `/session/status` in VS Code session activity watcher.
- Reconcile is best-effort and does **not** block SSE connection if the status fetch fails transiently.
- Stale in-memory activity entries not present in authoritative status are reset to idle.

### 4) Tests
- Updated session runtime tests to use canonical `properties.status` shape.
- Added compatibility test proving legacy `properties.info.type` payloads are still accepted.

## Validation
- `bun run type-check` ✅
- `bun run lint` ✅
- `bun run --filter @openchamber/web build` ✅

## Risk / Compatibility
- Low risk.
- Backward compatibility maintained for legacy payloads.
- Behavior is more deterministic after reconnects in VS Code.

## Notes
- Scope intentionally kept tight to status parsing and reconnect correctness.
