### PR TITLE
fix(ui): keep out-of-order assistant replies on the correct turn

### DIFF
--- a/packages/ui/src/components/chat/lib/turns/projectTurnRecords.test.ts
+++ b/packages/ui/src/components/chat/lib/turns/projectTurnRecords.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+import type { Message, Part } from '@opencode-ai/sdk/v2'
+import { projectTurnRecords } from './projectTurnRecords'
+import type { ChatMessageEntry } from './types'
+
+function createMessageEntry({
+  id,
+  role,
+  parentID,
+  createdAt,
+}: {
+  id: string
+  role: 'user' | 'assistant'
+  parentID?: string
+  createdAt: number
+}): ChatMessageEntry {
+  return {
+    info: {
+      id,
+      role,
+      ...(parentID ? { parentID } : {}),
+      time: { created: createdAt },
+    } as Message,
+    parts: [] as Part[],
+  }
+}
+
+describe('projectTurnRecords', () => {
+  test('keeps out-of-order assistant replies attached to their own user turn', () => {
+    const user1 = createMessageEntry({ id: 'u1', role: 'user', createdAt: 1 })
+    const assistant1 = createMessageEntry({ id: 'a1', role: 'assistant', parentID: 'u1', createdAt: 2 })
+    const assistant2 = createMessageEntry({ id: 'a2', role: 'assistant', parentID: 'u2', createdAt: 4 })
+    const user2 = createMessageEntry({ id: 'u2', role: 'user', createdAt: 3 })
+
+    const projection = projectTurnRecords([user1, assistant1, assistant2, user2])
+
+    expect(projection.turns).toHaveLength(2)
+    expect(projection.turns[0]?.turnId).toBe('u1')
+    expect(projection.turns[0]?.assistantMessageIds).toEqual(['a1'])
+    expect(projection.turns[1]?.turnId).toBe('u2')
+    expect(projection.turns[1]?.assistantMessageIds).toEqual(['a2'])
+    expect(projection.ungroupedMessageIds.size).toBe(0)
+  })
+
+  test('resolves deferred assistant chains once the parent assistant arrives', () => {
+    const user = createMessageEntry({ id: 'u1', role: 'user', createdAt: 1 })
+    const assistantChild = createMessageEntry({ id: 'a2', role: 'assistant', parentID: 'a1', createdAt: 3 })
+    const assistantParent = createMessageEntry({ id: 'a1', role: 'assistant', parentID: 'u1', createdAt: 2 })
+
+    const projection = projectTurnRecords([user, assistantChild, assistantParent])
+
+    expect(projection.turns).toHaveLength(1)
+    expect(projection.turns[0]?.assistantMessageIds).toEqual(['a1', 'a2'])
+    expect(projection.ungroupedMessageIds.size).toBe(0)
+  })
+})

--- a/packages/ui/src/components/chat/lib/turns/projectTurnRecords.ts
+++ b/packages/ui/src/components/chat/lib/turns/projectTurnRecords.ts
@@ -100,9 +100,33 @@ export const projectTurnRecords = (
     };
 
     const turns: TurnRecord[] = [];
-    const turnByUserId = new Map<string, TurnRecord>();
+    const turnByMessageId = new Map<string, TurnRecord>();
+    const pendingAssistantsByParentId = new Map<string, Array<{ message: ChatMessageEntry; index: number }>>();
     const groupedMessageIds = new Set<string>();
     let currentTurn: TurnRecord | undefined;
+
+    const attachAssistantToTurn = (targetTurn: TurnRecord, message: ChatMessageEntry, index: number) => {
+        targetTurn.assistantMessages.push(message);
+        targetTurn.assistantMessageIds.push(message.info.id);
+        targetTurn.messages.push(createTurnMessageRecord(message, index));
+        if (!targetTurn.headerMessageId) {
+            targetTurn.headerMessageId = message.info.id;
+        }
+        groupedMessageIds.add(message.info.id);
+        turnByMessageId.set(message.info.id, targetTurn);
+    };
+
+    const flushPendingAssistants = (parentMessageId: string, targetTurn: TurnRecord) => {
+        const pending = pendingAssistantsByParentId.get(parentMessageId);
+        if (!pending || pending.length === 0) {
+            return;
+        }
+        pendingAssistantsByParentId.delete(parentMessageId);
+        pending.forEach(({ message, index }) => {
+            attachAssistantToTurn(targetTurn, message, index);
+            flushPendingAssistants(message.info.id, targetTurn);
+        });
+    };
 
     messages.forEach((message, index) => {
         const role = resolveMessageRole(message);
@@ -129,9 +153,10 @@ export const projectTurnRecords = (
                 },
             };
             turns.push(turn);
-            turnByUserId.set(turn.userMessageId, turn);
+            turnByMessageId.set(turn.userMessageId, turn);
             groupedMessageIds.add(message.info.id);
             currentTurn = turn;
+            flushPendingAssistants(message.info.id, turn);
             return;
         }
 
@@ -140,19 +165,24 @@ export const projectTurnRecords = (
         }
 
         const parentId = getMessageParentId(message);
-        const parentTurn = parentId ? turnByUserId.get(parentId) : undefined;
+        const parentTurn = parentId ? turnByMessageId.get(parentId) : undefined;
+        if (parentId && !parentTurn) {
+            const pending = pendingAssistantsByParentId.get(parentId);
+            if (pending) {
+                pending.push({ message, index });
+            } else {
+                pendingAssistantsByParentId.set(parentId, [{ message, index }]);
+            }
+            return;
+        }
+
         const targetTurn = parentTurn ?? currentTurn;
         if (!targetTurn) {
             return;
         }
 
-        targetTurn.assistantMessages.push(message);
-        targetTurn.assistantMessageIds.push(message.info.id);
-        targetTurn.messages.push(createTurnMessageRecord(message, index));
-        if (!targetTurn.headerMessageId) {
-            targetTurn.headerMessageId = message.info.id;
-        }
-        groupedMessageIds.add(message.info.id);
+        attachAssistantToTurn(targetTurn, message, index);
+        flushPendingAssistants(message.info.id, targetTurn);
 
         if (!parentTurn) {
             currentTurn = targetTurn;


### PR DESCRIPTION
## Summary
- keep assistant messages with unresolved parent IDs deferred instead of attaching them to the current turn
- resolve deferred assistant chains once their parent user/assistant message arrives
- add regression coverage for out-of-order user/assistant delivery and deferred assistant chains

## Why
When network jitter delivers assistant events before their matching user message is projected, the previous fallback path attaches that reply to the current turn. That makes the response render above/below the wrong prompt, which matches #1113.

## Testing
- `npx -y tsx /tmp/openchamber-turns-check.ts`
- `git diff --check -- packages/ui/src/components/chat/lib/turns/projectTurnRecords.ts packages/ui/src/components/chat/lib/turns/projectTurnRecords.test.ts`

Fixes #1113
