### PR TITLE
fix: set LANG env for PTY to support UTF-8/Unicode in terminal

### DIFF
--- a/packages/web/server/lib/terminal/runtime.js
+++ b/packages/web/server/lib/terminal/runtime.js
@@ -139,6 +139,7 @@ export function createTerminalRuntime({
             ...env,
             TERM: 'xterm-256color',
             COLORTERM: 'truecolor',
+            LANG: env.LANG || process.env.LANG || 'C.UTF-8',
           },
         };
 


### PR DESCRIPTION
## Summary
- Set `LANG` environment variable for PTY to support UTF-8/Unicode in terminal
- Without this fix, Chinese/Japanese characters and other non-ASCII UTF-8 characters may not display correctly in the integrated terminal

## Changes
- Add `LANG` env var to PTY spawn options in `packages/web/server/lib/terminal/runtime.js`
- Falls back to `C.UTF-8` if no LANG is set (updated from `en_US.UTF-8` for better cross-platform compatibility - `C.UTF-8` is available on Alpine and slim Docker images without requiring locale generation)

## Testing
- Terminal now correctly displays Chinese characters (中文测试)
- Japanese characters (日本語)
- Korean characters (한글)
- Other UTF-8 Unicode characters

## Review Feedback
- Addressed concern about `en_US.UTF-8` fallback not being available on minimal systems
- Changed fallback to `C.UTF-8` which is more universally available

Fixes issue where terminal would show garbled text for non-ASCII UTF-8 content.