### PR TITLE
fix: handle terminal keyboard input on Android tablet

### DIFF
--- a/packages/ui/src/components/terminal/TerminalViewport.tsx
+++ b/packages/ui/src/components/terminal/TerminalViewport.tsx
@@ -128,7 +128,10 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
     inputHandlerRef.current = onInput;
     resizeHandlerRef.current = onResize;
 
-    const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent);
+    const isAndroid = typeof navigator !== 'undefined' && (
+      /Android/i.test(navigator.userAgent) ||
+      (navigator as { userAgentData?: { platform: string } }).userAgentData?.platform === 'Android'
+    );
     // Touch devices need a dedicated editable surface so special keys like
     // Backspace and arrows are captured reliably without relying on Ghostty's
     // internal mobile text handling.
@@ -1406,6 +1409,25 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
         if ((isMacCopyShortcut || isWindowsLinuxCopyShortcut) && hasCopyableSelectionInViewport()) {
           event.preventDefault();
           void copySelectionToClipboard();
+          return;
+        }
+
+        if (event.ctrlKey && !event.metaKey && !event.altKey && event.key.length === 1) {
+          const upper = event.key.toUpperCase();
+          if (upper >= 'A' && upper <= 'Z') {
+            event.preventDefault();
+            (event.nativeEvent as KeyboardEvent | undefined)?.stopImmediatePropagation();
+            inputHandlerRef.current(String.fromCharCode(upper.charCodeAt(0) - 64));
+            clearEditableValue(event.currentTarget as HTMLElement);
+            return;
+          }
+        }
+
+        if (event.altKey && !event.ctrlKey && !event.metaKey && event.key.length === 1) {
+          event.preventDefault();
+          (event.nativeEvent as KeyboardEvent | undefined)?.stopImmediatePropagation();
+          inputHandlerRef.current('\x1b' + event.key);
+          clearEditableValue(event.currentTarget as HTMLElement);
           return;
         }
 

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -64,7 +64,6 @@ export const useKeyboardShortcuts = () => {
         target.getAttribute('data-terminal-hidden-input') === 'true'
       );
     };
-
     const handleTerminalShortcutCapture = (e: KeyboardEvent) => {
       if (!isTerminalEventTarget(e.target)) {
         return;
@@ -94,6 +93,10 @@ export const useKeyboardShortcuts = () => {
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTerminalEventTarget(e.target)) {
+        return;
+      }
+
       if (eventMatchesShortcut(e, combo('open_command_palette'))) {
         e.preventDefault();
         toggleCommandPalette();
@@ -185,14 +188,6 @@ export const useKeyboardShortcuts = () => {
       if (eventMatchesShortcut(e, combo('toggle_right_sidebar'))) {
         const { isMobile } = useUIStore.getState();
         if (isMobile) {
-          return;
-        }
-        const target = e.target as Element | null;
-        const isInsideTerminal = Boolean(
-          target?.closest('.terminal-viewport-container') ||
-          target?.getAttribute('data-terminal-hidden-input') === 'true'
-        );
-        if (isInsideTerminal) {
           return;
         }
         e.preventDefault();

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -187,6 +187,14 @@ export const useKeyboardShortcuts = () => {
         if (isMobile) {
           return;
         }
+        const target = e.target as Element | null;
+        const isInsideTerminal = Boolean(
+          target?.closest('.terminal-viewport-container') ||
+          target?.getAttribute('data-terminal-hidden-input') === 'true'
+        );
+        if (isInsideTerminal) {
+          return;
+        }
         e.preventDefault();
         toggleRightSidebar();
         return;


### PR DESCRIPTION
- Detect Android via navigator.userAgentData.platform when UA is spoofed by Chrome's "Desktop site" mode, so the <input> overlay (useTextInput) is used instead of <textarea>.
- Handle Ctrl+letter and Alt+letter combos in the hidden input overlay's keydown handler, so terminal control sequences (^C, ^D, ^S, M-x, etc.) work through the touch input path.
- Skip global keyboard shortcuts (sidebar toggle, etc.) when focus is inside the terminal viewport, preventing shortcut steal.