### PR TITLE
fix: use platform-aware UTF-8 locale fallback for PTY

### DIFF
--- a/packages/web/server/lib/terminal/runtime.js
+++ b/packages/web/server/lib/terminal/runtime.js
@@ -121,6 +121,9 @@ export function createTerminalRuntime({
     return resolved;
   };
 
+  const utf8LocaleFallback = process.platform === 'darwin' ? 'en_US.UTF-8' : 'C.UTF-8';
+  const lcCtypeFallback = process.platform === 'darwin' ? 'UTF-8' : 'C.UTF-8';
+
   const spawnTerminalPtyWithFallback = (pty, { cols, rows, cwd, env }) => {
     const shellCandidates = getTerminalShellCandidates();
     if (shellCandidates.length === 0) {
@@ -139,7 +142,8 @@ export function createTerminalRuntime({
             ...env,
             TERM: 'xterm-256color',
             COLORTERM: 'truecolor',
-            LANG: env.LANG || process.env.LANG || 'C.UTF-8',
+            LANG: env.LANG || process.env.LANG || utf8LocaleFallback,
+            LC_CTYPE: env.LC_CTYPE || process.env.LC_CTYPE || lcCtypeFallback,
           },
         };
 


### PR DESCRIPTION
## Summary
- Fix terminal UTF-8 locale fallback to use platform-appropriate values
- `C.UTF-8` (used in #1129) does not exist on macOS, causing the terminal to fall back to ASCII encoding when `LANG` is unset
- Add `LC_CTYPE` env var for additional locale safety

## Problem
PR #1129 set `LANG` fallback to `C.UTF-8`, which doesn't exist on macOS:

```
$ LANG=C.UTF-8 locale charmap
US-ASCII   # ← not UTF-8!
```

macOS only has the `C` locale (pure ASCII) — no `C.UTF-8` variant. When `process.env.LANG` is empty and the fallback `C.UTF-8` is used, the PTY shell cannot display UTF-8 characters (Chinese, Japanese, etc.).

## Changes
- Use `en_US.UTF-8` as LANG fallback on macOS, `C.UTF-8` on Linux
- Set `LC_CTYPE` with platform-appropriate value (`UTF-8` on macOS, `C.UTF-8` on Linux)
- Both values are determined once at module init via `process.platform` check

## Verification
On macOS with no `LANG` set:
```
$ LANG=en_US.UTF-8 locale charmap
UTF-8   # ✓ works

$ LC_CTYPE=UTF-8 locale charmap  
UTF-8   # ✓ works
```

Fixes the regression introduced in #1129.