### PR TITLE
fix(electron): preserve desktop hosts when saving SSH instances

### DIFF
--- a/packages/electron/ssh-manager.mjs
+++ b/packages/electron/ssh-manager.mjs
@@ -579,16 +579,20 @@ export class ElectronSshManager {
 
   async setInstances(config) {
     const root = readJsonRoot(this.settingsFilePath);
+    const previousSshIds = new Set(
+      (Array.isArray(root.desktopSshInstances) ? root.desktopSshInstances : [])
+        .map((entry) => String(entry?.id || '').trim())
+        .filter((id) => id && id !== LOCAL_HOST_ID)
+    );
     const instances = Array.isArray(config?.instances) ? config.instances.map((instance) => this.sanitizeInstance(instance)) : [];
     root.desktopSshInstances = instances;
 
-    const previousIds = new Set((Array.isArray(root.desktopHosts) ? root.desktopHosts : []).map((entry) => String(entry?.id || '').trim()).filter(Boolean));
     const hosts = Array.isArray(root.desktopHosts) ? root.desktopHosts.filter(Boolean) : [];
     const nextIds = new Set(instances.map((instance) => instance.id));
 
     const filteredHosts = hosts.filter((entry) => {
       const id = String(entry?.id || '').trim();
-      return id && !(previousIds.has(id) && !nextIds.has(id));
+      return id && id !== LOCAL_HOST_ID && !(previousSshIds.has(id) && !nextIds.has(id));
     });
 
     for (const instance of instances) {
@@ -605,7 +609,7 @@ export class ElectronSshManager {
     }
 
     root.desktopHosts = filteredHosts;
-    if (typeof root.desktopDefaultHostId === 'string' && previousIds.has(root.desktopDefaultHostId) && !nextIds.has(root.desktopDefaultHostId)) {
+    if (typeof root.desktopDefaultHostId === 'string' && previousSshIds.has(root.desktopDefaultHostId) && !nextIds.has(root.desktopDefaultHostId)) {
       root.desktopDefaultHostId = LOCAL_HOST_ID;
     }
 


### PR DESCRIPTION
## Summary
- Preserve manually configured desktop hosts when SSH instances are saved.
- Only remove desktop host entries that correspond to deleted SSH instances.

## Testing
- `node --check packages/electron/ssh-manager.mjs`
- `node --check packages/electron/main.mjs`
- `node --check packages/electron/preload.mjs`
- Manual Node scenario for SSH host filtering
- `bun run type-check` — all packages pass
- `bun run lint` — all packages pass