### PR TITLE
fix(git): load sandbox db dependency in esm

### DIFF
--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -4,8 +4,10 @@ import path from 'path';
 import os from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { createRequire } from 'module';
 
 const fsp = fs.promises;
+const require = createRequire(import.meta.url);
 const execFileAsync = promisify(execFile);
 const gpgconfCandidates = ['gpgconf', '/opt/homebrew/bin/gpgconf', '/usr/local/bin/gpgconf'];
 let resolvedGitBinary = null;


### PR DESCRIPTION
## Summary
- Define CommonJS `require` in the git service ES module using Node's `createRequire`.
- Allows sandbox metadata sync to lazily load `better-sqlite3` instead of failing because `require` is undefined.

## Testing
- `vet "Allow git sandbox metadata sync to load better-sqlite3 from an ES module" --agentic --agent-harness claude`
- `node --check packages/web/server/lib/git/service.js`
- `node --input-type=module -e "await import('./packages/web/server/lib/git/service.js')"`
- `bun run type-check`
- `bun run lint`
- `git diff --check`