### PR TITLE
fix(sync): compare retry status metadata

### DIFF
--- a/packages/ui/src/sync/__tests__/live-aggregate.test.js
+++ b/packages/ui/src/sync/__tests__/live-aggregate.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   aggregateLiveSessions,
   aggregateLiveSessionStatuses,
+  areStatusMapsEquivalent,
   findLiveSession,
   findLiveSessionStatus,
 } from '../live-aggregate.ts'
@@ -77,6 +78,13 @@ describe('live aggregate', () => {
     const statuses = aggregateLiveSessionStatuses(states)
     expect(statuses['ses-1']?.type).toBe('idle')
     expect(findLiveSessionStatus(states, 'ses-1')?.type).toBe('idle')
+  })
+
+  it('detects retry metadata changes in status maps', () => {
+    expect(areStatusMapsEquivalent(
+      { 'ses-1': { type: 'retry', message: 'retrying', attempt: 1, next: 100 } },
+      { 'ses-1': { type: 'retry', message: 'retrying', attempt: 2, next: 200 } },
+    )).toBe(false)
   })
 
   it('derives active-now sessions from live statuses instead of persisted history', () => {

--- a/packages/ui/src/sync/__tests__/live-aggregate.test.js
+++ b/packages/ui/src/sync/__tests__/live-aggregate.test.js
@@ -81,9 +81,16 @@ describe('live aggregate', () => {
   })
 
   it('detects retry metadata changes in status maps', () => {
+    const retryStatus = { type: 'retry', message: 'retrying|server|message', attempt: 1, next: 100 }
+
     expect(areStatusMapsEquivalent(
-      { 'ses-1': { type: 'retry', message: 'retrying', attempt: 1, next: 100 } },
-      { 'ses-1': { type: 'retry', message: 'retrying', attempt: 2, next: 200 } },
+      { 'ses-1': retryStatus },
+      { 'ses-1': { ...retryStatus } },
+    )).toBe(true)
+
+    expect(areStatusMapsEquivalent(
+      { 'ses-1': retryStatus },
+      { 'ses-1': { ...retryStatus, attempt: 2, next: 200 } },
     )).toBe(false)
   })
 

--- a/packages/ui/src/sync/live-aggregate.ts
+++ b/packages/ui/src/sync/live-aggregate.ts
@@ -42,9 +42,16 @@ const getStatusPriority = (status: SessionStatus | undefined): number => {
   }
 }
 
-const getStatusMessage = (status: SessionStatus | undefined): string | null => {
+const getStatusSignature = (status: SessionStatus | undefined): string => {
   const message = (status as { message?: unknown } | undefined)?.message
-  return typeof message === 'string' ? message : null
+  const attempt = (status as { attempt?: unknown } | undefined)?.attempt
+  const next = (status as { next?: unknown } | undefined)?.next
+  return [
+    status?.type ?? '',
+    typeof message === 'string' ? message : '',
+    typeof attempt === 'number' ? attempt : '',
+    typeof next === 'number' ? next : '',
+  ].join('|')
 }
 
 type StatusCandidate = {
@@ -114,10 +121,7 @@ export const areStatusMapsEquivalent = (
     }
     const leftStatus = left[key]
     const rightStatus = right[key]
-    if (leftStatus?.type !== rightStatus?.type) {
-      return false
-    }
-    if (getStatusMessage(leftStatus) !== getStatusMessage(rightStatus)) {
+    if (getStatusSignature(leftStatus) !== getStatusSignature(rightStatus)) {
       return false
     }
   }

--- a/packages/ui/src/sync/live-aggregate.ts
+++ b/packages/ui/src/sync/live-aggregate.ts
@@ -42,16 +42,21 @@ const getStatusPriority = (status: SessionStatus | undefined): number => {
   }
 }
 
-const getStatusSignature = (status: SessionStatus | undefined): string => {
+const getStatusMessage = (status: SessionStatus | undefined): string | null => {
   const message = (status as { message?: unknown } | undefined)?.message
-  const attempt = (status as { attempt?: unknown } | undefined)?.attempt
-  const next = (status as { next?: unknown } | undefined)?.next
-  return [
-    status?.type ?? '',
-    typeof message === 'string' ? message : '',
-    typeof attempt === 'number' ? attempt : '',
-    typeof next === 'number' ? next : '',
-  ].join('|')
+  return typeof message === 'string' ? message : null
+}
+
+const getStatusNumberField = (status: SessionStatus | undefined, field: 'attempt' | 'next'): number | null => {
+  const value = (status as Record<string, unknown> | undefined)?.[field]
+  return typeof value === 'number' ? value : null
+}
+
+const areStatusesEquivalent = (left: SessionStatus | undefined, right: SessionStatus | undefined): boolean => {
+  return left?.type === right?.type
+    && getStatusMessage(left) === getStatusMessage(right)
+    && getStatusNumberField(left, 'attempt') === getStatusNumberField(right, 'attempt')
+    && getStatusNumberField(left, 'next') === getStatusNumberField(right, 'next')
 }
 
 type StatusCandidate = {
@@ -121,7 +126,7 @@ export const areStatusMapsEquivalent = (
     }
     const leftStatus = left[key]
     const rightStatus = right[key]
-    if (getStatusSignature(leftStatus) !== getStatusSignature(rightStatus)) {
+    if (!areStatusesEquivalent(leftStatus, rightStatus)) {
       return false
     }
   }


### PR DESCRIPTION
## Summary
- Include retry `attempt` and `next` metadata when comparing live session status maps.
- Prevent retry countdown/attempt changes from being treated as equivalent no-op updates.
- Add regression coverage for retry metadata changes.

## Testing
- `vet "Detect retry attempt and next timestamp changes in live session status maps" --agentic --agent-harness claude`
- `bun test packages/ui/src/sync/__tests__/live-aggregate.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`