### PR TITLE
fix(ui): allow escape to close mobile settings

### DIFF
--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -388,11 +388,6 @@ export const useKeyboardShortcuts = () => {
           target?.getAttribute('data-terminal-hidden-input') === 'true'
         );
 
-        if (isInsideDialog || isSettingsMounted || isInsideTerminal) {
-          resetAbortPriming();
-          return;
-        }
-
         const {
           isSettingsDialogOpen,
           isCommandPaletteOpen,
@@ -404,10 +399,20 @@ export const useKeyboardShortcuts = () => {
           activeMainTab,
         } = useUIStore.getState();
 
+        if (isInsideDialog || isInsideTerminal) {
+          resetAbortPriming();
+          return;
+        }
+
         // If settings is open, close it
         if (isSettingsDialogOpen) {
           e.preventDefault();
           setSettingsDialogOpen(false);
+          resetAbortPriming();
+          return;
+        }
+
+        if (isSettingsMounted) {
           resetAbortPriming();
           return;
         }


### PR DESCRIPTION
## Summary
- Let the global Escape handler close fullscreen mobile Settings before the mounted settings-view guard suppresses shortcut handling.
- Continue letting nested dialogs and terminal inputs consume Escape first.

## Testing
- `vet "Allow Escape to close mobile fullscreen settings before suppressing settings view shortcuts" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`