### PR TITLE
fix(multirun): disable adding models at limit

### DIFF
--- a/packages/ui/src/components/multirun/ModelMultiSelect.tsx
+++ b/packages/ui/src/components/multirun/ModelMultiSelect.tsx
@@ -128,6 +128,7 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
   const dropdownRef = React.useRef<HTMLDivElement>(null);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const itemRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+  const canAddModel = maxModels === undefined || selectedModels.length < maxModels;
 
   // Count occurrences of each model for display purposes
   const modelCounts = React.useMemo(() => {
@@ -239,6 +240,14 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
     }
   }, [isOpen]);
 
+  React.useEffect(() => {
+    if (!canAddModel && isOpen) {
+      setIsOpen(false);
+      setSearchQuery('');
+      setSelectedIndex(0);
+    }
+  }, [canAddModel, isOpen]);
+
   // Close dropdown when clicking outside
   React.useEffect(() => {
     if (!isOpen) return;
@@ -281,7 +290,9 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
         key={`${keyPrefix}-${key}`}
         ref={(el) => { itemRefs.current[flatIndex] = el; }}
         type="button"
+        disabled={!canAddModel}
         onClick={() => {
+          if (!canAddModel) return;
           onAdd({
             providerID,
             modelID,
@@ -293,7 +304,8 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
         onMouseEnter={() => setSelectedIndex(flatIndex)}
         className={cn(
           'w-full text-left px-2 py-1.5 rounded-md typography-meta transition-colors flex items-center gap-2',
-          isHighlighted ? 'bg-interactive-selection' : 'hover:bg-interactive-hover/50'
+          canAddModel && (isHighlighted ? 'bg-interactive-selection' : 'hover:bg-interactive-hover/50'),
+          !canAddModel && 'cursor-not-allowed opacity-60'
         )}
       >
         <div className="flex items-center gap-1.5 flex-1 min-w-0">
@@ -333,7 +345,11 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
               '!border-border/80 !bg-[var(--surface-subtle)] hover:!bg-[var(--interactive-hover)]/70',
               addButtonClassName,
             )}
-            onClick={() => setIsOpen(!isOpen)}
+            disabled={!canAddModel}
+            onClick={() => {
+              if (!canAddModel) return;
+              setIsOpen(!isOpen);
+            }}
           >
             <RiAddLine className="h-3.5 w-3.5 mr-1" />
             {addButtonLabel ?? t('multirun.modelMultiSelect.actions.addModel')}
@@ -383,7 +399,7 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
                 e.preventDefault();
                 e.stopPropagation();
                 const selectedItem = flatModelList[selectedIndex];
-                if (selectedItem) {
+                if (selectedItem && canAddModel) {
                   onAdd({
                     providerID: selectedItem.providerID,
                     modelID: selectedItem.modelID,

--- a/packages/ui/src/components/multirun/ModelMultiSelect.tsx
+++ b/packages/ui/src/components/multirun/ModelMultiSelect.tsx
@@ -292,7 +292,6 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
         type="button"
         disabled={!canAddModel}
         onClick={() => {
-          if (!canAddModel) return;
           onAdd({
             providerID,
             modelID,
@@ -347,7 +346,6 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
             )}
             disabled={!canAddModel}
             onClick={() => {
-              if (!canAddModel) return;
               setIsOpen(!isOpen);
             }}
           >


### PR DESCRIPTION
## Summary
- Enforce `maxModels` inside `ModelMultiSelect` instead of relying on the parent to ignore extra additions.
- Disable the add trigger and row/Enter add paths once the model limit is reached.
- Close and reset the dropdown if the selection reaches the limit while it is open.

## Testing
- `vet "Prevent ModelMultiSelect add interactions after max model limit is reached" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`