### PR TITLE
fix(chat): refresh memoized action handlers

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -599,6 +599,9 @@ const ComposerActionButtons = React.memo(function ComposerActionButtons(props: C
     && prev.hasContent === next.hasContent
     && prev.currentSessionId === next.currentSessionId
     && prev.newSessionDraftOpen === next.newSessionDraftOpen
+    && prev.onPrimaryAction === next.onPrimaryAction
+    && prev.onQueueMessage === next.onQueueMessage
+    && prev.onAbort === next.onAbort
 ));
 
 const appendWithLineBreaks = (base: string, next: string): string => {


### PR DESCRIPTION
## Summary
- Include `ComposerActionButtons` action callbacks in its custom memo comparator.
- Prevent memoized send, queue, or abort buttons from retaining stale handler closures when callback dependencies change.

## Testing
- `vet "Include ChatInput action callbacks in ComposerActionButtons memo comparator" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`