### PR TITLE
fix(queue): auto-send attachment-only messages

### DIFF
--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
@@ -126,7 +126,7 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
       }
 
       const payload = buildQueuedPayload(queueSnapshot);
-      if (!payload.primaryText && !payload.additionalParts?.length) {
+      if (!payload.primaryText && payload.primaryAttachments.length === 0 && !payload.additionalParts?.length) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- Treat primary attachments as sendable queued content during auto-send.
- Prevent attachment-only queued messages from getting stuck when the session returns to idle.

## Validation
- `vet "Allow queued attachment-only messages to auto-send" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`