### PR TITLE
fix(git): forward status mode to runtimes

### DIFF
--- a/packages/ui/src/lib/gitApi.test.ts
+++ b/packages/ui/src/lib/gitApi.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import type { GitAPI, GitStatus } from "./api/types"
+import { getGitStatus } from "./gitApi"
+
+const status: GitStatus = {
+  current: "main",
+  tracking: null,
+  ahead: 0,
+  behind: 0,
+  files: [],
+  isClean: true,
+}
+
+const withRuntimeGit = async (git: GitAPI, callback: () => Promise<void>) => {
+  const previousWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window")
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      __OPENCHAMBER_RUNTIME_APIS__: { git },
+    },
+  })
+
+  try {
+    await callback()
+  } finally {
+    if (previousWindowDescriptor) {
+      Object.defineProperty(globalThis, "window", previousWindowDescriptor)
+    } else {
+      delete (globalThis as { window?: Window }).window
+    }
+  }
+}
+
+describe("getGitStatus", () => {
+  test("forwards light-mode options to runtime git APIs", async () => {
+    let received: { directory: string; options?: { mode?: "light" } } | null = null
+    const runtimeGit = {
+      getGitStatus: async (directory: string, options?: { mode?: "light" }) => {
+        received = { directory, options }
+        return status
+      },
+    } as Partial<GitAPI> as GitAPI
+
+    await withRuntimeGit(runtimeGit, async () => {
+      await getGitStatus("/repo", { mode: "light" })
+    })
+
+    expect(received).toEqual({ directory: "/repo", options: { mode: "light" } })
+  })
+})

--- a/packages/ui/src/lib/gitApi.ts
+++ b/packages/ui/src/lib/gitApi.ts
@@ -66,7 +66,7 @@ export async function checkIsGitRepository(directory: string): Promise<boolean> 
 
 export async function getGitStatus(directory: string, options?: { mode?: 'light' }): Promise<import('./api/types').GitStatus> {
   const runtime = getRuntimeGit();
-  if (runtime) return runtime.getGitStatus(directory);
+  if (runtime) return runtime.getGitStatus(directory, options);
   return gitHttp.getGitStatus(directory, options);
 }
 

--- a/packages/vscode/src/bridge-git-runtime.ts
+++ b/packages/vscode/src/bridge-git-runtime.ts
@@ -35,10 +35,10 @@ export async function handleStandardGitBridgeMessage(message: BridgeMessageInput
     }
 
     case 'api:git/status': {
-      const { directory } = (payload || {}) as { directory?: string };
+      const { directory, mode } = (payload || {}) as { directory?: string; mode?: 'light' };
       const dirError = requireDirectory(id, type, directory);
       if (dirError) return dirError;
-      const status = await gitService.getGitStatus(directory!);
+      const status = await gitService.getGitStatus(directory!, mode === 'light' ? { mode } : undefined);
       return { id, type, success: true, data: status };
     }
 

--- a/packages/vscode/src/gitService.ts
+++ b/packages/vscode/src/gitService.ts
@@ -342,6 +342,10 @@ export interface GitStatusResult {
   rebaseInProgress?: GitRebaseInProgress | null;
 }
 
+type GitStatusOptions = {
+  mode?: 'light';
+};
+
 /**
  * Map VS Code git status to our status codes
  */
@@ -374,7 +378,10 @@ function mapStatus(status: Status): string {
 /**
  * Get git status for a directory
  */
-export async function getGitStatus(directory: string): Promise<GitStatusResult> {
+export async function getGitStatus(directory: string, options?: GitStatusOptions): Promise<GitStatusResult> {
+  // The VS Code Git API path does not compute heavyweight diff stats today,
+  // but accepts the shared options contract so callers can rely on parity.
+  void options;
   const repo = await getRepository(directory);
   
   if (!repo) {

--- a/packages/vscode/webview/api/git.ts
+++ b/packages/vscode/webview/api/git.ts
@@ -41,8 +41,8 @@ export const createVSCodeGitAPI = (): GitAPI => ({
     return sendBridgeMessage<boolean>('api:git/check', { directory });
   },
 
-  getGitStatus: async (directory: string): Promise<GitStatus> => {
-    return sendBridgeMessage<GitStatus>('api:git/status', { directory });
+  getGitStatus: async (directory: string, options?: { mode?: 'light' }): Promise<GitStatus> => {
+    return sendBridgeMessage<GitStatus>('api:git/status', { directory, mode: options?.mode });
   },
 
   getGitDiff: async (directory: string, options: GetGitDiffOptions): Promise<GitDiffResponse> => {


### PR DESCRIPTION
## Summary
- Forward git status options through runtime Git APIs instead of dropping `mode: 'light'`.
- Preserve VS Code bridge contract parity by carrying the option through webview and extension-host layers.

## Validation
- `vet "Forward git status options to runtime APIs" --agentic --agent-harness claude`
- `bun test packages/ui/src/lib/gitApi.test.ts`
- `bun run type-check`
- `bun run lint`
- `git diff --check`