### PR TITLE
fix(chat): guard skill autocomplete tab

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1772,7 +1772,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             return;
         }
 
-        if (e.key === 'Tab' && !showCommandAutocomplete && !showFileMention) {
+        if (e.key === 'Tab' && !showCommandAutocomplete && !showSkillAutocomplete && !showFileMention) {
             e.preventDefault();
             handleCycleAgent();
             return;


### PR DESCRIPTION
## Summary
- Prevent the fallback Tab handler from cycling agents while skill autocomplete is visible.
- Avoid a ref-timing edge where skill autocomplete appears but has not attached its key handler yet.

## Validation
- `vet "Prevent skill autocomplete Tab from cycling agents" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`