### PR TITLE
fix(skills): ignore stale catalog scans

### DIFF
--- a/packages/ui/src/components/sections/skills/catalog/AddCatalogDialog.tsx
+++ b/packages/ui/src/components/sections/skills/catalog/AddCatalogDialog.tsx
@@ -96,10 +96,18 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
 
   const [identityOptions, setIdentityOptions] = React.useState<IdentityOption[]>([]);
   const [gitIdentityId, setGitIdentityId] = React.useState<string | null>(null);
+  const scanRequestIdRef = React.useRef(0);
+
+  const invalidateScan = React.useCallback(() => {
+    scanRequestIdRef.current += 1;
+    setScanOk(false);
+    setScanCount(null);
+  }, []);
 
   React.useEffect(() => {
     if (!open) return;
 
+    scanRequestIdRef.current += 1;
     setLabel('');
     setSource('');
     setSubpath('');
@@ -140,12 +148,18 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
 
     setScanOk(false);
     setScanCount(null);
+    const requestId = scanRequestIdRef.current + 1;
+    scanRequestIdRef.current = requestId;
 
     const result = await scanRepo({
       source: trimmedSource,
       subpath: subpath.trim() || undefined,
       gitIdentityId: gitIdentityId || undefined,
     });
+
+    if (scanRequestIdRef.current !== requestId) {
+      return;
+    }
 
     if (!result.ok) {
       if (result.error?.kind === 'authRequired') {
@@ -257,8 +271,7 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
               value={source}
               onChange={(e) => {
                 setSource(e.target.value);
-                setScanOk(false);
-                setScanCount(null);
+                invalidateScan();
               }}
               placeholder={t('settings.skills.catalog.shared.field.repositoryPlaceholder')}
             />
@@ -273,8 +286,7 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
               value={subpath}
               onChange={(e) => {
                 setSubpath(e.target.value);
-                setScanOk(false);
-                setScanCount(null);
+                invalidateScan();
               }}
               placeholder={t('settings.skills.catalog.shared.field.subpathPlaceholder')}
             />
@@ -286,7 +298,13 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
                 <span className="typography-ui-label text-[var(--status-warning)]">{t('settings.skills.catalog.shared.auth.title')}</span>
                 <span className="typography-meta text-muted-foreground ml-2">{t('settings.skills.catalog.shared.auth.description')}</span>
               </div>
-              <Select value={gitIdentityId || ''} onValueChange={(v) => setGitIdentityId(v)}>
+              <Select
+                value={gitIdentityId || ''}
+                onValueChange={(v) => {
+                  setGitIdentityId(v);
+                  invalidateScan();
+                }}
+              >
                 <SelectTrigger className="w-fit">
                   <span>{identityOptions.find((i) => i.id === gitIdentityId)?.name || t('settings.skills.catalog.shared.auth.chooseIdentity')}</span>
                 </SelectTrigger>

--- a/packages/ui/src/components/sections/skills/catalog/AddCatalogDialog.tsx
+++ b/packages/ui/src/components/sections/skills/catalog/AddCatalogDialog.tsx
@@ -98,10 +98,14 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
   const [gitIdentityId, setGitIdentityId] = React.useState<string | null>(null);
   const scanRequestIdRef = React.useRef(0);
 
-  const invalidateScan = React.useCallback(() => {
+  const invalidateScan = React.useCallback((options?: { clearIdentity?: boolean }) => {
     scanRequestIdRef.current += 1;
     setScanOk(false);
     setScanCount(null);
+    if (options?.clearIdentity) {
+      setIdentityOptions([]);
+      setGitIdentityId(null);
+    }
   }, []);
 
   React.useEffect(() => {
@@ -271,7 +275,7 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
               value={source}
               onChange={(e) => {
                 setSource(e.target.value);
-                invalidateScan();
+                invalidateScan({ clearIdentity: true });
               }}
               placeholder={t('settings.skills.catalog.shared.field.repositoryPlaceholder')}
             />
@@ -286,7 +290,7 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
               value={subpath}
               onChange={(e) => {
                 setSubpath(e.target.value);
-                invalidateScan();
+                invalidateScan({ clearIdentity: true });
               }}
               placeholder={t('settings.skills.catalog.shared.field.subpathPlaceholder')}
             />


### PR DESCRIPTION
## Summary
- Add a scan request token to the Add Catalog dialog.
- Invalidate scan results when repository, subpath, identity, or dialog session changes so stale scans cannot enable Add Catalog.

## Validation
- `vet "Ignore stale Add Catalog scan results" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`