### PR TITLE
fix(chat): stop stale auto-follow flicker without live status

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -16,6 +16,7 @@ import { useChatScrollManager, type AnimationHandlers, type ContentChangeReason 
 import { useChatTimelineController } from './hooks/useChatTimelineController';
 import { TimelineDialog } from './TimelineDialog';
 import { useChatTurnNavigation } from './hooks/useChatTurnNavigation';
+import { computeSessionIsWorking } from './lib/computeSessionIsWorking';
 import { useDeviceInfo } from '@/lib/device';
 import { Button } from '@/components/ui/button';
 import { OverlayScrollbar } from '@/components/ui/OverlayScrollbar';
@@ -422,22 +423,25 @@ export const ChatContainer: React.FC = () => {
         return flattenBlockingRequests(questionsMap, scopedSessionIds);
     }, [questionsMap, scopedSessionIds]);
     const sessionIsWorking = React.useMemo(() => {
-        if (!currentSessionId || sessionPermissions.length > 0 || sessionQuestions.length > 0) {
-            return false;
-        }
-
-        const statusType = sessionStatusForCurrent.type ?? 'idle';
-        if (statusType === 'busy' || statusType === 'retry') {
-            return true;
-        }
-
         const lastMessage = sessionMessages[sessionMessages.length - 1]?.info as Message | undefined;
-        return Boolean(
-            lastMessage
-            && lastMessage.role === 'assistant'
-            && typeof (lastMessage as { time?: { completed?: number } }).time?.completed !== 'number',
-        );
-    }, [currentSessionId, sessionMessages, sessionPermissions.length, sessionQuestions.length, sessionStatusForCurrent.type]);
+        return computeSessionIsWorking({
+            sessionId: currentSessionId,
+            hasBlockingRequests: sessionPermissions.length > 0 || sessionQuestions.length > 0,
+            streamingMessageId,
+            activeStreamingPhase,
+            statusType: sessionStatusForCurrent.type,
+            hasLiveStatus: Boolean(sessionStatusForCurrent.type),
+            lastMessage,
+        });
+    }, [
+        activeStreamingPhase,
+        currentSessionId,
+        sessionMessages,
+        sessionPermissions.length,
+        sessionQuestions.length,
+        sessionStatusForCurrent.type,
+        streamingMessageId,
+    ]);
     const activeRetryStatus = React.useMemo(() => {
         if (!currentSessionId || sessionStatusForCurrent.type !== 'retry') {
             return null;

--- a/packages/ui/src/components/chat/lib/computeSessionIsWorking.test.ts
+++ b/packages/ui/src/components/chat/lib/computeSessionIsWorking.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import type { Message } from '@opencode-ai/sdk/v2/client';
+
+import { computeSessionIsWorking } from './computeSessionIsWorking';
+
+function assistantMessage(id: string, completed?: number): Message {
+  return {
+    id,
+    role: 'assistant',
+    sessionID: 'ses_1',
+    time: completed ? { created: 1, updated: 1, completed } : { created: 1, updated: 1 },
+  } as unknown as Message;
+}
+
+describe('computeSessionIsWorking', () => {
+  test('returns false without live status even if last assistant looks incomplete', () => {
+    expect(
+      computeSessionIsWorking({
+        sessionId: 'ses_1',
+        hasBlockingRequests: false,
+        statusType: 'idle',
+        hasLiveStatus: false,
+        lastMessage: assistantMessage('msg_1'),
+      }),
+    ).toBe(false);
+  });
+
+  test('returns true during active streaming phase without live status', () => {
+    expect(
+      computeSessionIsWorking({
+        sessionId: 'ses_1',
+        hasBlockingRequests: false,
+        activeStreamingPhase: 'response',
+        statusType: 'idle',
+        hasLiveStatus: false,
+        lastMessage: assistantMessage('msg_1'),
+      }),
+    ).toBe(true);
+  });
+
+  test('returns true for busy/retry live status', () => {
+    expect(
+      computeSessionIsWorking({
+        sessionId: 'ses_1',
+        hasBlockingRequests: false,
+        statusType: 'busy',
+        hasLiveStatus: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      computeSessionIsWorking({
+        sessionId: 'ses_1',
+        hasBlockingRequests: false,
+        statusType: 'retry',
+        hasLiveStatus: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/ui/src/components/chat/lib/computeSessionIsWorking.ts
+++ b/packages/ui/src/components/chat/lib/computeSessionIsWorking.ts
@@ -1,0 +1,40 @@
+import type { Message } from '@opencode-ai/sdk/v2/client';
+
+type SessionStatusType = 'idle' | 'busy' | 'retry' | undefined;
+
+type ComputeSessionIsWorkingInput = {
+  sessionId: string | null;
+  hasBlockingRequests: boolean;
+  streamingMessageId?: string | null;
+  activeStreamingPhase?: string | null;
+  statusType: SessionStatusType;
+  hasLiveStatus: boolean;
+  lastMessage?: Message;
+};
+
+export function computeSessionIsWorking(input: ComputeSessionIsWorkingInput): boolean {
+  if (!input.sessionId || input.hasBlockingRequests) {
+    return false;
+  }
+
+  if (input.streamingMessageId || input.activeStreamingPhase) {
+    return true;
+  }
+
+  if (input.statusType === 'busy' || input.statusType === 'retry') {
+    return true;
+  }
+
+  // Do not infer active work from historical incomplete assistant messages
+  // when there is no live status signal for this session.
+  if (!input.hasLiveStatus) {
+    return false;
+  }
+
+  const lastMessage = input.lastMessage;
+  return Boolean(
+    lastMessage
+      && lastMessage.role === 'assistant'
+      && typeof (lastMessage as { time?: { completed?: number } }).time?.completed !== 'number',
+  );
+}


### PR DESCRIPTION
## Summary
- fix session working-state detection to prioritize live streaming/live status signals and avoid inferring active work from historical incomplete assistant messages when no live status exists
- extract `computeSessionIsWorking` to keep the logic explicit and testable
- add regression tests covering no-live-status fallback and active streaming behavior

## Testing
- bun test packages/ui/src/components/chat/lib/computeSessionIsWorking.test.ts
- bun run type-check
- bun run lint

Fixes #1135