### PR TITLE
fix(ui): expose sidebar group collapse state

### DIFF
--- a/packages/ui/src/components/sections/shared/SidebarGroup.tsx
+++ b/packages/ui/src/components/sections/shared/SidebarGroup.tsx
@@ -74,11 +74,13 @@ export const SidebarGroup: React.FC<SidebarGroupProps> = ({
         <span className="ml-1 tabular-nums opacity-60">{count}</span>
       </button>
 
-      {expanded && (
-        <div id={contentId} className="mt-0.5 space-y-0.5 ml-2 pl-3 border-l-2 border-[var(--interactive-border)]">
-          {children}
-        </div>
-      )}
+      <div
+        id={contentId}
+        hidden={!expanded}
+        className="mt-0.5 space-y-0.5 ml-2 pl-3 border-l-2 border-[var(--interactive-border)]"
+      >
+        {children}
+      </div>
     </div>
   );
 };

--- a/packages/ui/src/components/sections/shared/SidebarGroup.tsx
+++ b/packages/ui/src/components/sections/shared/SidebarGroup.tsx
@@ -30,6 +30,7 @@ export const SidebarGroup: React.FC<SidebarGroupProps> = ({
   children,
 }) => {
   const key = getStorageKey(storageKey, label);
+  const contentId = React.useId();
 
   const [expanded, setExpanded] = useState<boolean>(() => {
     try {
@@ -54,6 +55,8 @@ export const SidebarGroup: React.FC<SidebarGroupProps> = ({
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls={contentId}
         className={cn(
           'flex w-full items-center gap-1 rounded-md px-2 py-1 text-left',
           'text-xs font-semibold uppercase tracking-wide text-muted-foreground',
@@ -72,7 +75,7 @@ export const SidebarGroup: React.FC<SidebarGroupProps> = ({
       </button>
 
       {expanded && (
-        <div className="mt-0.5 space-y-0.5 ml-2 pl-3 border-l-2 border-[var(--interactive-border)]">
+        <div id={contentId} className="mt-0.5 space-y-0.5 ml-2 pl-3 border-l-2 border-[var(--interactive-border)]">
           {children}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add `aria-expanded` to shared sidebar group toggle buttons.
- Link each toggle to its collapsible content with `aria-controls` and a stable React-generated panel id.

## Validation
- `vet "Expose SidebarGroup collapse state and controlled panel relationship to assistive technologies" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`