### PR TITLE
fix(settings): mark active nav page

### DIFF
--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -568,6 +568,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
                     <button
                       type="button"
                       onClick={() => openPage(page.slug)}
+                      aria-current={selected ? 'page' : undefined}
                       className={cn(
                         'flex h-8 items-center gap-2 rounded-md px-2 overflow-hidden',
                         selected


### PR DESCRIPTION
## Summary
- Add `aria-current=\"page\"` to the selected Settings navigation button so assistive technologies can identify the active page.

## Validation
- `vet "Expose the active Settings navigation page with aria-current" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`