### PR TITLE
fix(files): guard pending navigation

### DIFF
--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -2111,9 +2111,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
 
     if (selectedFile?.path !== targetPath) {
-      if (selectedPath !== targetPath) {
-        setSelectedPath(root, targetPath);
-      }
+      void handleSelectFile(toFileNode(targetPath));
       return;
     }
 
@@ -2192,13 +2190,13 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     fileLoading,
     isSelectedImage,
     loadedFilePath,
+    handleSelectFile,
     pendingFileNavigation,
     root,
     selectedFile?.path,
-    selectedPath,
     setPendingFileNavigation,
-    setSelectedPath,
     textViewMode,
+    toFileNode,
   ]);
 
   React.useEffect(() => {
@@ -2213,9 +2211,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
 
     if (selectedFile?.path !== targetPath) {
-      if (selectedPath !== targetPath) {
-        setSelectedPath(root, targetPath);
-      }
+      void handleSelectFile(toFileNode(targetPath));
       return;
     }
 
@@ -2236,15 +2232,15 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     canEdit,
     fileError,
     fileLoading,
+    handleSelectFile,
     isSelectedImage,
     loadedFilePath,
     pendingFileFocusPath,
     root,
     selectedFile?.path,
-    selectedPath,
     setPendingFileFocusPath,
-    setSelectedPath,
     textViewMode,
+    toFileNode,
   ]);
 
   const nudgeEditorSelectionAboveKeyboard = React.useCallback((view: EditorView | null) => {

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -2111,6 +2111,9 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
 
     if (selectedFile?.path !== targetPath) {
+      if (confirmDiscardOpen) {
+        return;
+      }
       void handleSelectFile(toFileNode(targetPath));
       return;
     }
@@ -2184,6 +2187,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     pendingNavigationCycleRef.current = { key: '', attempts: 0 };
   }, [
     canEdit,
+    confirmDiscardOpen,
     draftContent,
     editorViewReadyNonce,
     fileError,
@@ -2211,6 +2215,9 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
 
     if (selectedFile?.path !== targetPath) {
+      if (confirmDiscardOpen) {
+        return;
+      }
       void handleSelectFile(toFileNode(targetPath));
       return;
     }
@@ -2230,6 +2237,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     setPendingFileFocusPath(null);
   }, [
     canEdit,
+    confirmDiscardOpen,
     fileError,
     fileLoading,
     handleSelectFile,


### PR DESCRIPTION
## Summary
- Route pending file navigation and focus selection through `handleSelectFile` instead of setting selected path directly.
- Reuse the existing unsaved-draft guard so pending navigation/focus requests do not bypass dirty file confirmation.

## Validation
- `vet "Route pending FilesView navigation and focus file selection through the unsaved-draft guard" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`