### PR TITLE
Fix chat list sorting by user activity

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
+import type { Message } from '@opencode-ai/sdk/v2/client';
 import { RiLayoutLeftLine } from '@remixicon/react';
 import { toast } from '@/components/ui';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -79,6 +80,9 @@ import { refreshGlobalSessions, resolveGlobalSessionDirectory, useGlobalSessions
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
 import { useGitHubAuthStore } from '@/stores/useGitHubAuthStore';
 import { subscribeOpenchamberEvents } from '@/lib/openchamberEvents';
+import { getSyncMessages } from '@/sync/sync-refs';
+import { useSessionUserActivityStore } from '@/sync/session-user-activity-store';
+import { opencodeClient } from '@/lib/opencode/client';
 
 const PROJECT_COLLAPSE_STORAGE_KEY = 'oc.sessions.projectCollapse';
 const GROUP_ORDER_STORAGE_KEY = 'oc.sessions.groupOrder';
@@ -86,6 +90,7 @@ const GROUP_COLLAPSE_STORAGE_KEY = 'oc.sessions.groupCollapse';
 const PROJECT_ACTIVE_SESSION_STORAGE_KEY = 'oc.sessions.activeSessionByProject';
 const SESSION_EXPANDED_STORAGE_KEY = 'oc.sessions.expandedParents';
 const SESSION_PINNED_STORAGE_KEY = 'oc.sessions.pinned';
+const SESSION_USER_ACTIVITY_MESSAGE_LIMIT = 200;
 
 type PrVisualState = 'draft' | 'open' | 'blocked' | 'merged' | 'closed';
 
@@ -305,8 +310,11 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const gitBranches = useGitAllBranches();
 
   const sync = useSync();
+  const syncSession = sync.syncSession;
   const liveSessions = useAllLiveSessions();
   const liveSessionStatuses = useAllSessionStatuses();
+  const lastUserMessageAtBySessionId = useSessionUserActivityStore((state) => state.bySessionId);
+  const resolvedSessionUserActivityIds = useSessionUserActivityStore((state) => state.resolvedSessionIds);
   const hasLoadedGlobalSessions = useGlobalSessionsStore((state) => state.hasLoaded);
   const globalActiveSessions = useGlobalSessionsStore((state) => state.activeSessions);
   const archivedSessions = useGlobalSessionsStore((state) => state.archivedSessions);
@@ -523,6 +531,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     pinnedSessionIds,
     gitBranches,
     isVSCode,
+    lastUserMessageAtBySessionId,
   });
 
   const { scheduleCollapsedProjectsPersist } = useSidebarPersistence({
@@ -560,8 +569,8 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   }, []);
 
   const sortedSessions = React.useMemo(() => {
-    return [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds));
-  }, [sessions, pinnedSessionIds]);
+    return [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, lastUserMessageAtBySessionId));
+  }, [sessions, pinnedSessionIds, lastUserMessageAtBySessionId]);
 
   const sessionOrderIndex = React.useMemo(
     () => new Map(sortedSessions.map((session, index) => [session.id, index])),
@@ -579,9 +588,78 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       collection.push(session);
       map.set(parentID, collection);
     });
-    map.forEach((list) => list.sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds)));
+    map.forEach((list) => list.sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, lastUserMessageAtBySessionId)));
     return map;
-  }, [sortedSessions, pinnedSessionIds]);
+  }, [sortedSessions, pinnedSessionIds, lastUserMessageAtBySessionId]);
+
+  const userActivityHydrationQueueRef = React.useRef<Array<{ sessionId: string; directory: string | null }>>([]);
+  const userActivityHydrationQueuedIdsRef = React.useRef<Set<string>>(new Set());
+  const userActivityHydrationInFlightRef = React.useRef(false);
+
+  const pumpUserActivityHydrationQueue = React.useCallback(() => {
+    if (userActivityHydrationInFlightRef.current) {
+      return;
+    }
+
+    userActivityHydrationInFlightRef.current = true;
+    void (async () => {
+      try {
+        while (userActivityHydrationQueueRef.current.length > 0) {
+          const next = userActivityHydrationQueueRef.current.shift();
+          if (!next) {
+            continue;
+          }
+
+          try {
+            const activityStore = useSessionUserActivityStore.getState();
+            if (activityStore.resolvedSessionIds.has(next.sessionId)) {
+              continue;
+            }
+
+            const cachedMessages = getSyncMessages(next.sessionId, next.directory ?? undefined);
+            if (cachedMessages.length > 0) {
+              activityStore.reconcileSessionFromMessages(next.sessionId, cachedMessages);
+              continue;
+            }
+
+            const scopedClient = opencodeClient.getScopedSdkClient(next.directory ?? '');
+            const response = await scopedClient.session.messages({
+              sessionID: next.sessionId,
+              limit: SESSION_USER_ACTIVITY_MESSAGE_LIMIT,
+            });
+            const messages = (response.data ?? [])
+              .map((record: { info?: Message }) => record.info ?? null)
+              .filter((message): message is Message => Boolean(message?.id));
+            activityStore.reconcileSessionFromMessages(next.sessionId, messages);
+          } finally {
+            userActivityHydrationQueuedIdsRef.current.delete(next.sessionId);
+          }
+        }
+      } finally {
+        userActivityHydrationInFlightRef.current = false;
+      }
+    })();
+  }, []);
+
+  React.useEffect(() => {
+    if (sortedSessions.length === 0) {
+      return;
+    }
+
+    sortedSessions.forEach((session) => {
+      if (resolvedSessionUserActivityIds.has(session.id) || userActivityHydrationQueuedIdsRef.current.has(session.id)) {
+        return;
+      }
+
+      userActivityHydrationQueuedIdsRef.current.add(session.id);
+      userActivityHydrationQueueRef.current.push({
+        sessionId: session.id,
+        directory: normalizePath(resolveGlobalSessionDirectory(session)),
+      });
+    });
+
+    pumpUserActivityHydrationQueue();
+  }, [pumpUserActivityHydrationQueue, resolvedSessionUserActivityIds, sortedSessions]);
 
   const emptyState = (
     <div className="py-6 text-center text-muted-foreground">
@@ -1008,17 +1086,17 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       return [];
     }
 
-    return deriveActiveNowSessions(activeNowEntries, new Map(sessions.map((session) => [session.id, session])))
-      .sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds));
-  }, [activeNowEntries, pinnedSessionIds, sessions, showRecentSection]);
+    return deriveActiveNowSessions(activeNowEntries, new Map(sessions.map((session) => [session.id, session])), lastUserMessageAtBySessionId)
+      .sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, lastUserMessageAtBySessionId));
+  }, [activeNowEntries, pinnedSessionIds, sessions, showRecentSection, lastUserMessageAtBySessionId]);
 
   const liveActiveSessions = React.useMemo(() => {
     if (!showRecentSection) {
       return [];
     }
 
-    return deriveLiveActiveNowSessions(sessions, liveSessionStatuses);
-  }, [liveSessionStatuses, sessions, showRecentSection]);
+    return deriveLiveActiveNowSessions(sessions, liveSessionStatuses, lastUserMessageAtBySessionId);
+  }, [liveSessionStatuses, sessions, showRecentSection, lastUserMessageAtBySessionId]);
 
   React.useEffect(() => {
     if (!showRecentSection || liveActiveSessions.length === 0) {
@@ -1045,14 +1123,14 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       allKnownSessionsById.set(session.id, session);
     });
 
-    const pruned = pruneActiveNowEntries(activeNowEntries, allKnownSessionsById);
+    const pruned = pruneActiveNowEntries(activeNowEntries, allKnownSessionsById, lastUserMessageAtBySessionId);
     if (pruned.length === activeNowEntries.length && pruned.every((entry, index) => entry.sessionId === activeNowEntries[index]?.sessionId)) {
       return;
     }
 
     setActiveNowEntries(pruned);
     persistActiveNowEntries(safeStorage, pruned);
-  }, [activeNowEntries, archivedSessions, safeStorage, sessions, showRecentSection]);
+  }, [activeNowEntries, archivedSessions, lastUserMessageAtBySessionId, safeStorage, sessions, showRecentSection]);
 
   // Prefetch is wired below, after recentSessionIds is computed.
 
@@ -1087,7 +1165,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     currentSessionId,
     sortedSessions,
     recentSessionIds: recentSessionIdsList,
-    loadMessages: sync.syncSession,
+    loadMessages: syncSession,
   });
 
   const sectionsForSidebarRender = React.useMemo(() => {
@@ -1397,6 +1475,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         setRenameFolderDraft={setRenameFolderDraft}
         setRenamingFolderId={setRenamingFolderId}
         pinnedSessionIds={pinnedSessionIds}
+        lastUserMessageAtBySessionId={lastUserMessageAtBySessionId}
         sessionOrderIndex={sessionOrderIndex}
         prVisualStateByDirectoryBranch={prVisualStateByDirectoryBranch}
         onToggleCollapsedGroup={toggleCollapsedGroup}
@@ -1431,6 +1510,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       renamingFolderId,
       renameFolderDraft,
       pinnedSessionIds,
+      lastUserMessageAtBySessionId,
       sessionOrderIndex,
       prVisualStateByDirectoryBranch,
       toggleCollapsedGroup,

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -81,7 +81,7 @@ import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
 import { useGitHubAuthStore } from '@/stores/useGitHubAuthStore';
 import { subscribeOpenchamberEvents } from '@/lib/openchamberEvents';
 import { getSyncMessages } from '@/sync/sync-refs';
-import { useSessionUserActivityStore } from '@/sync/session-user-activity-store';
+import { getApexUserActivityMap, useSessionUserActivityStore } from '@/sync/session-user-activity-store';
 import { opencodeClient } from '@/lib/opencode/client';
 
 const PROJECT_COLLAPSE_STORAGE_KEY = 'oc.sessions.projectCollapse';
@@ -521,6 +521,11 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     await startDesktopWindowDrag();
   }, [isDesktopShellRuntime]);
 
+  const visualUserActivityBySessionId = React.useMemo(
+    () => getApexUserActivityMap(sessions, lastUserMessageAtBySessionId),
+    [sessions, lastUserMessageAtBySessionId],
+  );
+
   const {
     buildGroupSearchText,
     filterSessionNodesForSearch,
@@ -531,7 +536,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     pinnedSessionIds,
     gitBranches,
     isVSCode,
-    lastUserMessageAtBySessionId,
+    lastUserMessageAtBySessionId: visualUserActivityBySessionId,
   });
 
   const { scheduleCollapsedProjectsPersist } = useSidebarPersistence({
@@ -569,8 +574,8 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   }, []);
 
   const sortedSessions = React.useMemo(() => {
-    return [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, lastUserMessageAtBySessionId));
-  }, [sessions, pinnedSessionIds, lastUserMessageAtBySessionId]);
+    return [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, visualUserActivityBySessionId));
+  }, [sessions, pinnedSessionIds, visualUserActivityBySessionId]);
 
   const sessionOrderIndex = React.useMemo(
     () => new Map(sortedSessions.map((session, index) => [session.id, index])),
@@ -588,9 +593,9 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       collection.push(session);
       map.set(parentID, collection);
     });
-    map.forEach((list) => list.sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, lastUserMessageAtBySessionId)));
+    map.forEach((list) => list.sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, visualUserActivityBySessionId)));
     return map;
-  }, [sortedSessions, pinnedSessionIds, lastUserMessageAtBySessionId]);
+  }, [sortedSessions, pinnedSessionIds, visualUserActivityBySessionId]);
 
   const userActivityHydrationQueueRef = React.useRef<Array<{ sessionId: string; directory: string | null }>>([]);
   const userActivityHydrationQueuedIdsRef = React.useRef<Set<string>>(new Set());
@@ -631,6 +636,9 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
               .map((record: { info?: Message }) => record.info ?? null)
               .filter((message): message is Message => Boolean(message?.id));
             activityStore.reconcileSessionFromMessages(next.sessionId, messages);
+          } catch {
+            // Leave this session unresolved so a later render can retry it, but
+            // keep draining the rest of the hydration queue.
           } finally {
             userActivityHydrationQueuedIdsRef.current.delete(next.sessionId);
           }
@@ -1086,17 +1094,17 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       return [];
     }
 
-    return deriveActiveNowSessions(activeNowEntries, new Map(sessions.map((session) => [session.id, session])), lastUserMessageAtBySessionId)
-      .sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, lastUserMessageAtBySessionId));
-  }, [activeNowEntries, pinnedSessionIds, sessions, showRecentSection, lastUserMessageAtBySessionId]);
+    return deriveActiveNowSessions(activeNowEntries, new Map(sessions.map((session) => [session.id, session])), visualUserActivityBySessionId)
+      .sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds, visualUserActivityBySessionId));
+  }, [activeNowEntries, pinnedSessionIds, sessions, showRecentSection, visualUserActivityBySessionId]);
 
   const liveActiveSessions = React.useMemo(() => {
     if (!showRecentSection) {
       return [];
     }
 
-    return deriveLiveActiveNowSessions(sessions, liveSessionStatuses, lastUserMessageAtBySessionId);
-  }, [liveSessionStatuses, sessions, showRecentSection, lastUserMessageAtBySessionId]);
+    return deriveLiveActiveNowSessions(sessions, liveSessionStatuses, visualUserActivityBySessionId);
+  }, [liveSessionStatuses, sessions, showRecentSection, visualUserActivityBySessionId]);
 
   React.useEffect(() => {
     if (!showRecentSection || liveActiveSessions.length === 0) {
@@ -1123,14 +1131,14 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       allKnownSessionsById.set(session.id, session);
     });
 
-    const pruned = pruneActiveNowEntries(activeNowEntries, allKnownSessionsById, lastUserMessageAtBySessionId);
+    const pruned = pruneActiveNowEntries(activeNowEntries, allKnownSessionsById, visualUserActivityBySessionId, resolvedSessionUserActivityIds);
     if (pruned.length === activeNowEntries.length && pruned.every((entry, index) => entry.sessionId === activeNowEntries[index]?.sessionId)) {
       return;
     }
 
     setActiveNowEntries(pruned);
     persistActiveNowEntries(safeStorage, pruned);
-  }, [activeNowEntries, archivedSessions, lastUserMessageAtBySessionId, safeStorage, sessions, showRecentSection]);
+  }, [activeNowEntries, archivedSessions, visualUserActivityBySessionId, resolvedSessionUserActivityIds, safeStorage, sessions, showRecentSection]);
 
   // Prefetch is wired below, after recentSessionIds is computed.
 
@@ -1475,7 +1483,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         setRenameFolderDraft={setRenameFolderDraft}
         setRenamingFolderId={setRenamingFolderId}
         pinnedSessionIds={pinnedSessionIds}
-        lastUserMessageAtBySessionId={lastUserMessageAtBySessionId}
+        lastUserMessageAtBySessionId={visualUserActivityBySessionId}
         sessionOrderIndex={sessionOrderIndex}
         prVisualStateByDirectoryBranch={prVisualStateByDirectoryBranch}
         onToggleCollapsedGroup={toggleCollapsedGroup}
@@ -1510,7 +1518,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       renamingFolderId,
       renameFolderDraft,
       pinnedSessionIds,
-      lastUserMessageAtBySessionId,
+      visualUserActivityBySessionId,
       sessionOrderIndex,
       prVisualStateByDirectoryBranch,
       toggleCollapsedGroup,

--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -68,6 +68,7 @@ type Props = {
   setRenameFolderDraft: React.Dispatch<React.SetStateAction<string>>;
   setRenamingFolderId: React.Dispatch<React.SetStateAction<string | null>>;
   pinnedSessionIds: Set<string>;
+  lastUserMessageAtBySessionId: Map<string, number>;
   sessionOrderIndex: Map<string, number>;
   prVisualStateByDirectoryBranch: Map<string, {
     visualState: 'draft' | 'open' | 'blocked' | 'merged' | 'closed';
@@ -134,6 +135,7 @@ export function SessionGroupSection(props: Props): React.ReactNode {
     setRenameFolderDraft,
     setRenamingFolderId,
     pinnedSessionIds,
+    lastUserMessageAtBySessionId,
     sessionOrderIndex,
     prVisualStateByDirectoryBranch,
     onToggleCollapsedGroup,
@@ -149,8 +151,8 @@ export function SessionGroupSection(props: Props): React.ReactNode {
       if (bIndex === undefined) return -1;
       if (aIndex !== bIndex) return aIndex - bIndex;
     }
-    return compareSessionsByPinnedAndTime(a.session, b.session, pinnedSessionIds);
-  }, [pinnedSessionIds, sessionOrderIndex]);
+    return compareSessionsByPinnedAndTime(a.session, b.session, pinnedSessionIds, lastUserMessageAtBySessionId);
+  }, [pinnedSessionIds, sessionOrderIndex, lastUserMessageAtBySessionId]);
 
   const searchData = hasSessionSearchQuery ? groupSearchDataByGroup.get(group) : null;
   const displayMode = useSessionDisplayStore((state) => state.displayMode);

--- a/packages/ui/src/components/session/sidebar/activitySections.test.ts
+++ b/packages/ui/src/components/session/sidebar/activitySections.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2"
+import { ACTIVE_NOW_MAX_AGE_MS, getSessionCreatedAtMs, pruneActiveNowEntries } from "./activitySections"
+
+const session = (id: string, created: number, archived = 0, parentID: string | null = null): Session => ({
+  id,
+  title: id,
+  parentID,
+  share: null,
+  version: "",
+  time: { created, updated: created, archived },
+}) as unknown as Session
+
+describe("activitySections", () => {
+  test("keeps unresolved active-now entries until activity hydration resolves", () => {
+    const oldSession = session("old", 100)
+    const pruned = pruneActiveNowEntries(
+      [{ sessionId: "old" }],
+      new Map([["old", oldSession]]),
+      new Map(),
+      new Set(),
+      ACTIVE_NOW_MAX_AGE_MS + 1_000,
+    )
+
+    expect(pruned).toEqual([{ sessionId: "old" }])
+  })
+
+  test("prunes resolved active-now entries by last user activity", () => {
+    const oldSession = session("old", 100)
+    const pruned = pruneActiveNowEntries(
+      [{ sessionId: "old" }],
+      new Map([["old", oldSession]]),
+      new Map([["old", 100]]),
+      new Set(["old"]),
+      ACTIVE_NOW_MAX_AGE_MS + 1_000,
+    )
+
+    expect(pruned).toEqual([])
+  })
+
+  test("keeps root active-now entries while descendant activity is unresolved", () => {
+    const root = session("root", 100)
+    const child = session("child", 200, 0, "root")
+    const pruned = pruneActiveNowEntries(
+      [{ sessionId: "root" }],
+      new Map([["root", root], ["child", child]]),
+      new Map(),
+      new Set(["root"]),
+      ACTIVE_NOW_MAX_AGE_MS + 1_000,
+    )
+
+    expect(pruned).toEqual([{ sessionId: "root" }])
+  })
+
+  test("exports created-at timestamp with accurate naming", () => {
+    expect(getSessionCreatedAtMs(session("created", 123))).toBe(123)
+  })
+})

--- a/packages/ui/src/components/session/sidebar/activitySections.ts
+++ b/packages/ui/src/components/session/sidebar/activitySections.ts
@@ -1,5 +1,6 @@
 import type { Session } from '@opencode-ai/sdk/v2';
 import type { SessionStatus } from '@opencode-ai/sdk/v2/client';
+import { getSessionVisualSortTimestamp } from './utils';
 
 export const ACTIVE_NOW_STORAGE_KEY = 'oc.sessions.activeNow';
 export const ACTIVE_NOW_MAX_AGE_MS = 36 * 60 * 60 * 1000;
@@ -16,16 +17,22 @@ const isArchivedSession = (session: Session): boolean => {
   return Boolean(session.time?.archived);
 };
 
-const getSessionUpdatedAt = (session: Session): number => {
-  const updated = session.time?.updated;
+const getSessionCreatedAt = (session: Session): number => {
   const created = session.time?.created;
-  if (typeof updated === 'number' && Number.isFinite(updated)) {
-    return updated;
+  return typeof created === 'number' && Number.isFinite(created) ? created : 0;
+};
+
+const compareByVisualActivity = (a: Session, b: Session, lastUserMessageAtBySessionId: Map<string, number>): number => {
+  const byActivity = getSessionVisualSortTimestamp(b, lastUserMessageAtBySessionId)
+    - getSessionVisualSortTimestamp(a, lastUserMessageAtBySessionId);
+  if (byActivity !== 0) {
+    return byActivity;
   }
-  if (typeof created === 'number' && Number.isFinite(created)) {
-    return created;
+  const byCreated = getSessionCreatedAt(b) - getSessionCreatedAt(a);
+  if (byCreated !== 0) {
+    return byCreated;
   }
-  return 0;
+  return a.id.localeCompare(b.id);
 };
 
 export const readActiveNowEntries = (storage: Storage): ActiveNowEntry[] => {
@@ -67,6 +74,7 @@ export const persistActiveNowEntries = (storage: Storage, entries: ActiveNowEntr
 export const pruneActiveNowEntries = (
   entries: ActiveNowEntry[],
   sessionsById: Map<string, Session>,
+  lastUserMessageAtBySessionId: Map<string, number>,
   now = Date.now(),
 ): ActiveNowEntry[] => {
   const minUpdatedAt = now - ACTIVE_NOW_MAX_AGE_MS;
@@ -78,7 +86,7 @@ export const pruneActiveNowEntries = (
     if (isArchivedSession(session)) {
       return false;
     }
-    return getSessionUpdatedAt(session) >= minUpdatedAt;
+    return getSessionVisualSortTimestamp(session, lastUserMessageAtBySessionId) >= minUpdatedAt;
   });
 };
 
@@ -89,25 +97,27 @@ export const addActiveNowSession = (entries: ActiveNowEntry[], sessionId: string
   return [{ sessionId }, ...entries];
 };
 
-export const sortSessionsByUpdated = (sessions: Session[]): Session[] => {
-  return [...sessions].sort((a, b) => getSessionUpdatedAt(b) - getSessionUpdatedAt(a));
+export const sortSessionsByVisualActivity = (sessions: Session[], lastUserMessageAtBySessionId: Map<string, number>): Session[] => {
+  return [...sessions].sort((a, b) => compareByVisualActivity(a, b, lastUserMessageAtBySessionId));
 };
 
 export const deriveActiveNowSessions = (
   entries: ActiveNowEntry[],
   sessionsById: Map<string, Session>,
+  lastUserMessageAtBySessionId: Map<string, number>,
 ): Session[] => {
   const sessions = entries
     .map((entry) => sessionsById.get(entry.sessionId) ?? null)
     .filter((session): session is Session => Boolean(session))
     .filter((session) => !isArchivedSession(session))
     .filter((session) => !isSubtaskSession(session));
-  return sortSessionsByUpdated(sessions);
+  return sortSessionsByVisualActivity(sessions, lastUserMessageAtBySessionId);
 };
 
 export const deriveLiveActiveNowSessions = (
   sessions: Session[],
   statuses: Record<string, SessionStatus>,
+  lastUserMessageAtBySessionId: Map<string, number>,
 ): Session[] => {
   const activeSessions = sessions.filter((session) => {
     if (isArchivedSession(session) || isSubtaskSession(session)) {
@@ -118,7 +128,7 @@ export const deriveLiveActiveNowSessions = (
     return status?.type === 'busy' || status?.type === 'retry';
   });
 
-  return sortSessionsByUpdated(activeSessions);
+  return sortSessionsByVisualActivity(activeSessions, lastUserMessageAtBySessionId);
 };
 
-export const getSessionUpdatedAtMs = getSessionUpdatedAt;
+export const getSessionUpdatedAtMs = getSessionCreatedAt;

--- a/packages/ui/src/components/session/sidebar/activitySections.ts
+++ b/packages/ui/src/components/session/sidebar/activitySections.ts
@@ -22,6 +22,35 @@ const getSessionCreatedAt = (session: Session): number => {
   return typeof created === 'number' && Number.isFinite(created) ? created : 0;
 };
 
+const isDescendantOf = (session: Session, ancestorId: string, sessionsById: Map<string, Session>): boolean => {
+  let parentId: string | null | undefined = (session as Session & { parentID?: string | null }).parentID;
+  const seen = new Set<string>();
+
+  while (parentId && !seen.has(parentId)) {
+    if (parentId === ancestorId) {
+      return true;
+    }
+    seen.add(parentId);
+    const parent = sessionsById.get(parentId) as (Session & { parentID?: string | null }) | undefined;
+    parentId = parent?.parentID ?? null;
+  }
+
+  return false;
+};
+
+const hasUnresolvedDescendantActivitySource = (
+  sessionId: string,
+  sessionsById: Map<string, Session>,
+  resolvedSessionUserActivityIds: Set<string>,
+): boolean => {
+  for (const session of sessionsById.values()) {
+    if (session.id !== sessionId && !resolvedSessionUserActivityIds.has(session.id) && isDescendantOf(session, sessionId, sessionsById)) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const compareByVisualActivity = (a: Session, b: Session, lastUserMessageAtBySessionId: Map<string, number>): number => {
   const byActivity = getSessionVisualSortTimestamp(b, lastUserMessageAtBySessionId)
     - getSessionVisualSortTimestamp(a, lastUserMessageAtBySessionId);
@@ -75,8 +104,15 @@ export const pruneActiveNowEntries = (
   entries: ActiveNowEntry[],
   sessionsById: Map<string, Session>,
   lastUserMessageAtBySessionId: Map<string, number>,
-  now = Date.now(),
+  resolvedSessionUserActivityIdsOrNow: Set<string> | number = new Set(),
+  nowArg?: number,
 ): ActiveNowEntry[] => {
+  const resolvedSessionUserActivityIds = typeof resolvedSessionUserActivityIdsOrNow === 'number'
+    ? new Set<string>()
+    : resolvedSessionUserActivityIdsOrNow;
+  const now = typeof resolvedSessionUserActivityIdsOrNow === 'number'
+    ? resolvedSessionUserActivityIdsOrNow
+    : (nowArg ?? Date.now());
   const minUpdatedAt = now - ACTIVE_NOW_MAX_AGE_MS;
   return entries.filter((entry) => {
     const session = sessionsById.get(entry.sessionId);
@@ -85,6 +121,12 @@ export const pruneActiveNowEntries = (
     }
     if (isArchivedSession(session)) {
       return false;
+    }
+    if (!lastUserMessageAtBySessionId.has(session.id) && (
+      !resolvedSessionUserActivityIds.has(session.id)
+      || hasUnresolvedDescendantActivitySource(session.id, sessionsById, resolvedSessionUserActivityIds)
+    )) {
+      return true;
     }
     return getSessionVisualSortTimestamp(session, lastUserMessageAtBySessionId) >= minUpdatedAt;
   });
@@ -131,4 +173,4 @@ export const deriveLiveActiveNowSessions = (
   return sortSessionsByVisualActivity(activeSessions, lastUserMessageAtBySessionId);
 };
 
-export const getSessionUpdatedAtMs = getSessionCreatedAt;
+export const getSessionCreatedAtMs = getSessionCreatedAt;

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
@@ -5,6 +5,7 @@ import type { SessionGroup, SessionNode } from '../types';
 import {
   compareSessionsByPinnedAndTime,
   dedupeSessionsById,
+  getSessionVisualSortTimestamp,
   getArchivedScopeKey,
   normalizeForBranchComparison,
   normalizePath,
@@ -18,6 +19,7 @@ type Args = {
   pinnedSessionIds: Set<string>;
   gitBranches: Map<string, string | null>;
   isVSCode: boolean;
+  lastUserMessageAtBySessionId: Map<string, number>;
 };
 
 const isArchivedSession = (session: Session): boolean => Boolean(session.time?.archived);
@@ -67,7 +69,7 @@ export const useSessionGrouping = (args: Args) => {
     ) => {
       const normalizedProjectRoot = normalizePath(projectRoot ?? null);
       const sortedProjectSessions = dedupeSessionsById(projectSessions)
-        .sort((a, b) => compareSessionsByPinnedAndTime(a, b, args.pinnedSessionIds));
+        .sort((a, b) => compareSessionsByPinnedAndTime(a, b, args.pinnedSessionIds, args.lastUserMessageAtBySessionId));
 
       const sessionMap = new Map(sortedProjectSessions.map((session) => [session.id, session]));
       const childrenMap = new Map<string, Session[]>();
@@ -82,7 +84,7 @@ export const useSessionGrouping = (args: Args) => {
         collection.push(session);
         childrenMap.set(parentID, collection);
       });
-      childrenMap.forEach((list) => list.sort((a, b) => compareSessionsByPinnedAndTime(a, b, args.pinnedSessionIds)));
+      childrenMap.forEach((list) => list.sort((a, b) => compareSessionsByPinnedAndTime(a, b, args.pinnedSessionIds, args.lastUserMessageAtBySessionId)));
 
       const worktreeByPath = new Map<string, WorktreeMetadata>();
       availableWorktrees.forEach((meta) => {
@@ -158,38 +160,33 @@ export const useSessionGrouping = (args: Args) => {
       }];
 
       // Calculate activity info for each worktree to determine sorting priority
-      const worktreeActivityInfo = new Map<string, { hasActiveSession: boolean; lastUpdatedAt: number }>();
+      const worktreeActivityInfo = new Map<string, { hasActiveSession: boolean; lastUserActivityAt: number }>();
       availableWorktrees.forEach((meta) => {
         const directory = normalizePath(meta.path) ?? meta.path;
         const sessionsInWorktree = groupedNodes.get(directory) ?? [];
         const hasActiveSession = sessionsInWorktree.length > 0;
-        // Calculate the latest update time among all sessions in this worktree
-        const lastUpdatedAt = sessionsInWorktree.reduce((max, node) => {
-          const updatedAt = Number(node.session.time?.updated ?? node.session.time?.created ?? 0);
-          if (!Number.isFinite(updatedAt)) {
-            return max;
-          }
-          return Math.max(max, updatedAt);
+        const lastUserActivityAt = sessionsInWorktree.reduce((max, node) => {
+          return Math.max(max, getSessionVisualSortTimestamp(node.session, args.lastUserMessageAtBySessionId));
         }, 0);
 
-        worktreeActivityInfo.set(directory, { hasActiveSession, lastUpdatedAt });
+        worktreeActivityInfo.set(directory, { hasActiveSession, lastUserActivityAt });
       });
 
-      // Sort worktrees: active first (by last updated desc), then inactive (by label asc)
+      // Sort worktrees: active first (by latest user activity desc), then inactive (by label asc)
       const sortedWorktrees = [...availableWorktrees].sort((a, b) => {
         const aDir = normalizePath(a.path) ?? a.path;
         const bDir = normalizePath(b.path) ?? b.path;
-        const aInfo = worktreeActivityInfo.get(aDir) ?? { hasActiveSession: false, lastUpdatedAt: 0 };
-        const bInfo = worktreeActivityInfo.get(bDir) ?? { hasActiveSession: false, lastUpdatedAt: 0 };
+        const aInfo = worktreeActivityInfo.get(aDir) ?? { hasActiveSession: false, lastUserActivityAt: 0 };
+        const bInfo = worktreeActivityInfo.get(bDir) ?? { hasActiveSession: false, lastUserActivityAt: 0 };
 
         // First priority: active status (active first)
         if (aInfo.hasActiveSession !== bInfo.hasActiveSession) {
           return aInfo.hasActiveSession ? -1 : 1;
         }
 
-        // Second priority: for active worktrees, sort by last updated (desc)
+        // Second priority: for active worktrees, sort by latest user activity (desc)
         if (aInfo.hasActiveSession && bInfo.hasActiveSession) {
-          return bInfo.lastUpdatedAt - aInfo.lastUpdatedAt;
+          return bInfo.lastUserActivityAt - aInfo.lastUserActivityAt;
         }
 
         // Third priority: for inactive worktrees, sort by label (asc)
@@ -241,7 +238,7 @@ export const useSessionGrouping = (args: Args) => {
 
       return groups;
     },
-    [args.homeDirectory, args.worktreeMetadata, args.pinnedSessionIds, args.gitBranches, args.isVSCode, t],
+    [args.homeDirectory, args.worktreeMetadata, args.pinnedSessionIds, args.gitBranches, args.isVSCode, args.lastUserMessageAtBySessionId, t],
   );
 
   return {

--- a/packages/ui/src/components/session/sidebar/utils.test.ts
+++ b/packages/ui/src/components/session/sidebar/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2"
+import { compareSessionsByPinnedAndTime } from "./utils"
+
+const makeSession = (id: string, created: number, updated: number): Session => ({
+  id,
+  title: id,
+  parentID: null,
+  share: null,
+  version: "",
+  time: { created, updated, archived: 0 },
+}) as unknown as Session
+
+describe("compareSessionsByPinnedAndTime", () => {
+  test("keeps pinned sessions first", () => {
+    const pinned = new Set(["b"])
+    const byUser = new Map<string, number>([["a", 500], ["b", 100]])
+    const sessions = [makeSession("a", 100, 900), makeSession("b", 50, 1000)]
+
+    const sorted = [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinned, byUser))
+    expect(sorted.map((session) => session.id)).toEqual(["b", "a"])
+  })
+
+  test("sorts unpinned by last user activity, not session updated", () => {
+    const pinned = new Set<string>()
+    const byUser = new Map<string, number>([["a", 300], ["b", 200]])
+    const sessions = [makeSession("a", 100, 1), makeSession("b", 100, 99999)]
+
+    const sorted = [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinned, byUser))
+    expect(sorted.map((session) => session.id)).toEqual(["a", "b"])
+  })
+})

--- a/packages/ui/src/components/session/sidebar/utils.test.ts
+++ b/packages/ui/src/components/session/sidebar/utils.test.ts
@@ -29,4 +29,12 @@ describe("compareSessionsByPinnedAndTime", () => {
     const sorted = [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinned, byUser))
     expect(sorted.map((session) => session.id)).toEqual(["a", "b"])
   })
+
+  test("falls back to creation time when user activity is unknown", () => {
+    const pinned = new Set<string>()
+    const sessions = [makeSession("a", 100, 99999), makeSession("b", 200, 1)]
+
+    const sorted = [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinned, new Map()))
+    expect(sorted.map((session) => session.id)).toEqual(["b", "a"])
+  })
 })

--- a/packages/ui/src/components/session/sidebar/utils.tsx
+++ b/packages/ui/src/components/session/sidebar/utils.tsx
@@ -111,14 +111,27 @@ const getSessionCreatedAt = (session: Session): number => {
   return toFiniteNumber(session.time?.created) ?? 0;
 };
 
-const getSessionUpdatedAt = (session: Session): number => {
-  return toFiniteNumber(session.time?.updated) ?? toFiniteNumber(session.time?.created) ?? 0;
+const getLastUserMessageAt = (session: Session, lastUserMessageAtBySessionId?: Map<string, number>): number | null => {
+  const fromActivity = lastUserMessageAtBySessionId?.get(session.id);
+  return typeof fromActivity === 'number' && Number.isFinite(fromActivity) ? fromActivity : null;
+};
+
+export const getSessionVisualSortTimestamp = (
+  session: Session,
+  lastUserMessageAtBySessionId?: Map<string, number>,
+): number => {
+  return getLastUserMessageAt(session, lastUserMessageAtBySessionId) ?? getSessionCreatedAt(session);
+};
+
+const compareSessionIds = (a: Session, b: Session): number => {
+  return a.id.localeCompare(b.id);
 };
 
 export const compareSessionsByPinnedAndTime = (
   a: Session,
   b: Session,
   pinnedSessionIds: Set<string>,
+  lastUserMessageAtBySessionId?: Map<string, number>,
 ): number => {
   const aPinned = pinnedSessionIds.has(a.id);
   const bPinned = pinnedSessionIds.has(b.id);
@@ -126,11 +139,18 @@ export const compareSessionsByPinnedAndTime = (
     return aPinned ? -1 : 1;
   }
 
-  if (aPinned && bPinned) {
-    return getSessionCreatedAt(b) - getSessionCreatedAt(a);
+  const byActivityTime = getSessionVisualSortTimestamp(b, lastUserMessageAtBySessionId)
+    - getSessionVisualSortTimestamp(a, lastUserMessageAtBySessionId);
+  if (byActivityTime !== 0) {
+    return byActivityTime;
   }
 
-  return getSessionUpdatedAt(b) - getSessionUpdatedAt(a);
+  const byCreated = getSessionCreatedAt(b) - getSessionCreatedAt(a);
+  if (byCreated !== 0) {
+    return byCreated;
+  }
+
+  return compareSessionIds(a, b);
 };
 
 export const compareSessionsByPinnedAndCreated = (

--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -134,6 +134,9 @@ export function applyDirectoryEvent(
     onRefresh?: (directory: string) => void
     onLoadLsp?: () => void
     onSetSessionTodo?: (sessionID: string, todos: Todo[] | undefined) => void
+    onRecordUserMessageAt?: (sessionID: string, createdAt: number) => void
+    onReconcileSessionUserActivity?: (sessionID: string, messages: Message[]) => void
+    onInvalidateSessionUserActivity?: (sessionID: string) => void
   },
 ): boolean {
   switch (event.type) {
@@ -220,6 +223,12 @@ export function applyDirectoryEvent(
 
     case "message.updated": {
       const info = (event.properties as { info: Message }).info
+      if (info.role === "user") {
+        const createdAt = info.time?.created
+        if (typeof createdAt === "number" && Number.isFinite(createdAt)) {
+          callbacks?.onRecordUserMessageAt?.(info.sessionID, createdAt)
+        }
+      }
       const messages = draft.message[info.sessionID]
       if (!messages) {
         draft.message[info.sessionID] = [info]
@@ -256,7 +265,12 @@ export function applyDirectoryEvent(
         if (result.found) {
           next.splice(result.index, 1)
           draft.message[props.sessionID] = next
+          callbacks?.onReconcileSessionUserActivity?.(props.sessionID, next)
+        } else {
+          callbacks?.onInvalidateSessionUserActivity?.(props.sessionID)
         }
+      } else {
+        callbacks?.onInvalidateSessionUserActivity?.(props.sessionID)
       }
       delete draft.part[props.messageID]
       return true

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -10,6 +10,7 @@ import { useInputStore } from "./input-store"
 import type { ChildStoreManager } from "./child-store"
 import { opencodeClient } from "@/lib/opencode/client"
 import { useGlobalSessionsStore } from "@/stores/useGlobalSessionsStore"
+import { useSessionUserActivityStore } from "./session-user-activity-store"
 import { useConfigStore } from "@/stores/useConfigStore"
 import { registerSessionDirectory } from "./sync-refs"
 import { isSyntheticPart } from "@/lib/messages/synthetic"
@@ -398,6 +399,7 @@ export async function optimisticSend(input: {
     }
   }
 
+  const createdAt = Date.now()
   const optimisticMessage = {
     id: messageID,
     role: "user" as const,
@@ -409,8 +411,10 @@ export async function optimisticSend(input: {
     agent: input.agent ?? "",
     model: `${input.providerID}/${input.modelID}`,
     metadata: {} as Record<string, unknown>,
-    time: { created: Date.now(), completed: 0 },
+    time: { created: createdAt, completed: 0 },
   } as unknown as Message
+
+  useSessionUserActivityStore.getState().recordUserMessageAt(input.sessionId, createdAt)
 
   // Insert into store + register in shadow Map (for mergeOptimisticPage cleanup)
   _optimisticAdd({

--- a/packages/ui/src/sync/session-user-activity-store.test.ts
+++ b/packages/ui/src/sync/session-user-activity-store.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, test } from "bun:test"
-import type { Message } from "@opencode-ai/sdk/v2/client"
-import { useSessionUserActivityStore } from "./session-user-activity-store"
+import type { Message, Session } from "@opencode-ai/sdk/v2/client"
+import { getApexSessionId, getApexUserActivityMap, useSessionUserActivityStore } from "./session-user-activity-store"
+
+const session = (id: string, parentID?: string | null): Session => ({
+  id,
+  title: id,
+  parentID: parentID ?? null,
+  time: { created: 0, updated: 0, archived: 0 },
+}) as unknown as Session
 
 describe("session-user-activity-store", () => {
   beforeEach(() => {
@@ -50,5 +57,25 @@ describe("session-user-activity-store", () => {
     const state = useSessionUserActivityStore.getState()
     expect(state.bySessionId.has("s-1")).toBe(false)
     expect(state.resolvedSessionIds.has("s-1")).toBe(false)
+  })
+
+  test("resolves child sessions to the apex session", () => {
+    const sessions = new Map([
+      ["root", session("root")],
+      ["child", session("child", "root")],
+      ["grandchild", session("grandchild", "child")],
+    ])
+
+    expect(getApexSessionId("grandchild", sessions)).toBe("root")
+  })
+
+  test("aggregates child user activity onto the apex session", () => {
+    const activity = getApexUserActivityMap(
+      [session("root"), session("child", "root"), session("other")],
+      new Map([["root", 100], ["child", 300], ["other", 200]]),
+    )
+
+    expect(activity.get("root")).toBe(300)
+    expect(activity.get("other")).toBe(200)
   })
 })

--- a/packages/ui/src/sync/session-user-activity-store.test.ts
+++ b/packages/ui/src/sync/session-user-activity-store.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import type { Message } from "@opencode-ai/sdk/v2/client"
+import { useSessionUserActivityStore } from "./session-user-activity-store"
+
+describe("session-user-activity-store", () => {
+  beforeEach(() => {
+    useSessionUserActivityStore.setState({ bySessionId: new Map(), resolvedSessionIds: new Set() })
+  })
+
+  test("records newer user timestamps only", () => {
+    const store = useSessionUserActivityStore.getState()
+    store.recordUserMessageAt("s-1", 100)
+    const afterFirst = useSessionUserActivityStore.getState().bySessionId
+    store.recordUserMessageAt("s-1", 90)
+    const afterOlder = useSessionUserActivityStore.getState().bySessionId
+
+    expect(afterFirst.get("s-1")).toBe(100)
+    expect(afterOlder).toBe(afterFirst)
+    expect(useSessionUserActivityStore.getState().resolvedSessionIds.has("s-1")).toBe(true)
+  })
+
+  test("reconciles from messages and removes entry when user messages are gone", () => {
+    const store = useSessionUserActivityStore.getState()
+    store.recordUserMessageAt("s-1", 120)
+
+    const withUsers = [
+      { id: "m-1", role: "assistant", time: { created: 130 } },
+      { id: "m-2", role: "user", time: { created: 110 } },
+      { id: "m-3", role: "user", time: { created: 140 } },
+    ] as Message[]
+    store.reconcileSessionFromMessages("s-1", withUsers)
+
+    expect(useSessionUserActivityStore.getState().bySessionId.get("s-1")).toBe(140)
+
+    const withoutUsers = [
+      { id: "m-4", role: "assistant", time: { created: 150 } },
+    ] as Message[]
+    store.reconcileSessionFromMessages("s-1", withoutUsers)
+
+    expect(useSessionUserActivityStore.getState().bySessionId.has("s-1")).toBe(false)
+    expect(useSessionUserActivityStore.getState().resolvedSessionIds.has("s-1")).toBe(true)
+  })
+
+  test("invalidates stale activity when messages need reloading", () => {
+    const store = useSessionUserActivityStore.getState()
+    store.recordUserMessageAt("s-1", 120)
+
+    store.invalidateSession("s-1")
+
+    const state = useSessionUserActivityStore.getState()
+    expect(state.bySessionId.has("s-1")).toBe(false)
+    expect(state.resolvedSessionIds.has("s-1")).toBe(false)
+  })
+})

--- a/packages/ui/src/sync/session-user-activity-store.ts
+++ b/packages/ui/src/sync/session-user-activity-store.ts
@@ -1,0 +1,123 @@
+import { create } from "zustand"
+import type { Message } from "@opencode-ai/sdk/v2/client"
+
+export type SessionUserActivityState = {
+  bySessionId: Map<string, number>
+  resolvedSessionIds: Set<string>
+  recordUserMessageAt: (sessionId: string, createdAt: number) => void
+  reconcileSessionFromMessages: (sessionId: string, messages: Message[]) => void
+  invalidateSession: (sessionId: string) => void
+}
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+  return null
+}
+
+export const getLatestUserMessageTimestamp = (messages: Message[]): number | null => {
+  let latest: number | null = null
+  for (const message of messages) {
+    if (message.role !== "user") {
+      continue
+    }
+    const createdAt = toFiniteNumber(message.time?.created)
+    if (createdAt === null) {
+      continue
+    }
+    if (latest === null || createdAt > latest) {
+      latest = createdAt
+    }
+  }
+  return latest
+}
+
+export const useSessionUserActivityStore = create<SessionUserActivityState>()((set) => ({
+  bySessionId: new Map<string, number>(),
+  resolvedSessionIds: new Set<string>(),
+
+  recordUserMessageAt: (sessionId, createdAt) => {
+    if (!sessionId || !Number.isFinite(createdAt)) {
+      return
+    }
+    set((state) => {
+      const existing = state.bySessionId.get(sessionId)
+      const resolved = state.resolvedSessionIds.has(sessionId)
+      if (existing !== undefined && createdAt <= existing && resolved) {
+        return state
+      }
+      const nextActivity = existing !== undefined && createdAt <= existing
+        ? state.bySessionId
+        : new Map(state.bySessionId).set(sessionId, createdAt)
+      const nextResolved = resolved
+        ? state.resolvedSessionIds
+        : new Set(state.resolvedSessionIds).add(sessionId)
+      return { bySessionId: nextActivity, resolvedSessionIds: nextResolved }
+    })
+  },
+
+  reconcileSessionFromMessages: (sessionId, messages) => {
+    if (!sessionId) {
+      return
+    }
+    const latest = getLatestUserMessageTimestamp(messages)
+    set((state) => {
+      const existing = state.bySessionId.get(sessionId)
+      const resolved = state.resolvedSessionIds.has(sessionId)
+      if (latest === null) {
+        if (existing === undefined && resolved) {
+          return state
+        }
+        const nextActivity = existing === undefined ? state.bySessionId : new Map(state.bySessionId)
+        if (existing !== undefined) {
+          nextActivity.delete(sessionId)
+        }
+        const nextResolved = resolved
+          ? state.resolvedSessionIds
+          : new Set(state.resolvedSessionIds).add(sessionId)
+        return { bySessionId: nextActivity, resolvedSessionIds: nextResolved }
+      }
+
+      if (existing === latest && resolved) {
+        return state
+      }
+      const nextActivity = existing === latest
+        ? state.bySessionId
+        : new Map(state.bySessionId).set(sessionId, latest)
+      const nextResolved = resolved
+        ? state.resolvedSessionIds
+        : new Set(state.resolvedSessionIds).add(sessionId)
+      return { bySessionId: nextActivity, resolvedSessionIds: nextResolved }
+    })
+  },
+
+  invalidateSession: (sessionId) => {
+    if (!sessionId) {
+      return
+    }
+    set((state) => {
+      const hasActivity = state.bySessionId.has(sessionId)
+      const resolved = state.resolvedSessionIds.has(sessionId)
+      if (!hasActivity && !resolved) {
+        return state
+      }
+
+      const nextActivity = hasActivity ? new Map(state.bySessionId) : state.bySessionId
+      if (hasActivity) {
+        nextActivity.delete(sessionId)
+      }
+      const nextResolved = resolved ? new Set(state.resolvedSessionIds) : state.resolvedSessionIds
+      if (resolved) {
+        nextResolved.delete(sessionId)
+      }
+      return { bySessionId: nextActivity, resolvedSessionIds: nextResolved }
+    })
+  },
+}))

--- a/packages/ui/src/sync/session-user-activity-store.ts
+++ b/packages/ui/src/sync/session-user-activity-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand"
-import type { Message } from "@opencode-ai/sdk/v2/client"
+import type { Message, Session } from "@opencode-ai/sdk/v2/client"
 
 export type SessionUserActivityState = {
   bySessionId: Map<string, number>
@@ -37,6 +37,43 @@ export const getLatestUserMessageTimestamp = (messages: Message[]): number | nul
     }
   }
   return latest
+}
+
+export const getApexSessionId = (sessionId: string, sessionsById: Map<string, Session>): string => {
+  let currentId = sessionId
+  const seen = new Set<string>()
+
+  while (currentId && !seen.has(currentId)) {
+    seen.add(currentId)
+    const session = sessionsById.get(currentId) as (Session & { parentID?: string | null }) | undefined
+    const parentId = session?.parentID
+    if (!parentId) {
+      return currentId
+    }
+    currentId = parentId
+  }
+
+  return sessionId
+}
+
+export const getApexUserActivityMap = (
+  sessions: Session[],
+  lastUserMessageAtBySessionId: Map<string, number>,
+): Map<string, number> => {
+  if (lastUserMessageAtBySessionId.size === 0) {
+    return lastUserMessageAtBySessionId
+  }
+
+  const sessionsById = new Map(sessions.map((session) => [session.id, session]))
+  const activityByApexSessionId = new Map<string, number>()
+  lastUserMessageAtBySessionId.forEach((timestamp, sessionId) => {
+    const apexSessionId = getApexSessionId(sessionId, sessionsById)
+    const existing = activityByApexSessionId.get(apexSessionId)
+    if (existing === undefined || timestamp > existing) {
+      activityByApexSessionId.set(apexSessionId, timestamp)
+    }
+  })
+  return activityByApexSessionId
 }
 
 export const useSessionUserActivityStore = create<SessionUserActivityState>()((set) => ({

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -37,6 +37,7 @@ import type { PermissionRequest } from "@/types/permission"
 import type { QuestionRequest } from "@/types/question"
 import * as sessionActions from "./session-actions"
 import { mergeMessages } from "./optimistic"
+import { useSessionUserActivityStore } from "./session-user-activity-store"
 
 // ---------------------------------------------------------------------------
 // Context
@@ -1214,6 +1215,15 @@ function handleEvent(
   if (applyDirectoryEvent(draft, payload, {
     onSetSessionTodo: (sessionID, todos) => {
       useTodosPersistStore.getState().setSessionTodos(sessionID, todos)
+    },
+    onRecordUserMessageAt: (sessionID, createdAt) => {
+      useSessionUserActivityStore.getState().recordUserMessageAt(sessionID, createdAt)
+    },
+    onReconcileSessionUserActivity: (sessionID, messages) => {
+      useSessionUserActivityStore.getState().reconcileSessionFromMessages(sessionID, messages)
+    },
+    onInvalidateSessionUserActivity: (sessionID) => {
+      useSessionUserActivityStore.getState().invalidateSession(sessionID)
     },
   })) {
     store.setState(draft)

--- a/packages/ui/src/sync/use-sync.ts
+++ b/packages/ui/src/sync/use-sync.ts
@@ -18,6 +18,7 @@ import {
   setSessionPrefetch,
   clearSessionPrefetch,
 } from "./session-prefetch-cache"
+import { useSessionUserActivityStore } from "./session-user-activity-store"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 const MESSAGE_PAGE_SIZE = 200
@@ -247,6 +248,7 @@ export function useSync() {
           patch.part = partUpdate
         }
         store.setState(patch)
+        useSessionUserActivityStore.getState().reconcileSessionFromMessages(sessionID, messages)
         setMetaFor(sessionID, {
           limit: messages.length,
           cursor: merged.cursor,
@@ -388,6 +390,7 @@ export function useSync() {
         if (result.found) {
           next.splice(result.index, 1)
           message[input.sessionID] = next
+          useSessionUserActivityStore.getState().reconcileSessionFromMessages(input.sessionID, next)
         }
       }
       delete part[input.messageID]


### PR DESCRIPTION
## Summary
- Sort chat/session sidebar entries by the latest user message instead of assistant/session update activity.
- Track user-message activity from optimistic sends, message events, loaded history, and cold-start hydration.
- Keep pinned sessions first and add focused tests for ordering and activity reconciliation.

Fixes #1174

## Verification
- bun test packages/ui/src/sync/session-user-activity-store.test.ts packages/ui/src/components/session/sidebar/utils.test.ts
- bun run type-check
- bun run lint