### PR TITLE
fix(chat): sort sessions by user activity

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -71,11 +71,13 @@ import {
   readActiveNowEntries,
 } from './sidebar/activitySections';
 import {
+  compareRootSessionsByPinnedAndUserActivity,
   compareSessionsByPinnedAndTime,
   formatProjectLabel,
   normalizePath,
 } from './sidebar/utils';
 import { refreshGlobalSessions, resolveGlobalSessionDirectory, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
+import { useSessionUserActivityStore } from '@/sync/session-user-activity-store';
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
 import { useGitHubAuthStore } from '@/stores/useGitHubAuthStore';
 import { subscribeOpenchamberEvents } from '@/lib/openchamberEvents';
@@ -137,6 +139,11 @@ const isKnownActiveSessionDirectory = (session: Session, knownDirectories: Set<s
   if (!directory) return true;
   if (knownDirectories.size === 0) return true;
   return knownDirectories.has(directory);
+};
+
+const hasParentSession = (session: Session): boolean => {
+  const parentID = (session as Session & { parentID?: string | null }).parentID;
+  return Boolean(parentID);
 };
 
 const SIDEBAR_PR_NO_PR_RETRY_MS = 5 * 60_000;
@@ -306,6 +313,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
   const sync = useSync();
   const liveSessions = useAllLiveSessions();
+  const lastUserMessageAtBySession = useSessionUserActivityStore((state) => state.lastUserMessageAtBySession);
   const liveSessionStatuses = useAllSessionStatuses();
   const hasLoadedGlobalSessions = useGlobalSessionsStore((state) => state.hasLoaded);
   const globalActiveSessions = useGlobalSessionsStore((state) => state.activeSessions);
@@ -560,8 +568,17 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   }, []);
 
   const sortedSessions = React.useMemo(() => {
-    return [...sessions].sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds));
-  }, [sessions, pinnedSessionIds]);
+    return [...sessions].sort((a, b) => {
+      const aIsRoot = !hasParentSession(a);
+      const bIsRoot = !hasParentSession(b);
+
+      if (aIsRoot && bIsRoot) {
+        return compareRootSessionsByPinnedAndUserActivity(a, b, pinnedSessionIds, lastUserMessageAtBySession);
+      }
+
+      return compareSessionsByPinnedAndTime(a, b, pinnedSessionIds);
+    });
+  }, [lastUserMessageAtBySession, sessions, pinnedSessionIds]);
 
   const sessionOrderIndex = React.useMemo(
     () => new Map(sortedSessions.map((session, index) => [session.id, index])),

--- a/packages/ui/src/components/session/sidebar/utils.tsx
+++ b/packages/ui/src/components/session/sidebar/utils.tsx
@@ -133,6 +133,27 @@ export const compareSessionsByPinnedAndTime = (
   return getSessionUpdatedAt(b) - getSessionUpdatedAt(a);
 };
 
+export const compareRootSessionsByPinnedAndUserActivity = (
+  a: Session,
+  b: Session,
+  pinnedSessionIds: Set<string>,
+  lastUserMessageAtBySession: Map<string, number>,
+): number => {
+  const aPinned = pinnedSessionIds.has(a.id);
+  const bPinned = pinnedSessionIds.has(b.id);
+  if (aPinned !== bPinned) {
+    return aPinned ? -1 : 1;
+  }
+
+  if (aPinned && bPinned) {
+    return getSessionCreatedAt(b) - getSessionCreatedAt(a);
+  }
+
+  const aRank = lastUserMessageAtBySession.get(a.id) ?? getSessionUpdatedAt(a);
+  const bRank = lastUserMessageAtBySession.get(b.id) ?? getSessionUpdatedAt(b);
+  return bRank - aRank;
+};
+
 export const compareSessionsByPinnedAndCreated = (
   a: Session,
   b: Session,

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -50,6 +50,7 @@ import {
 } from "./session-actions"
 import { useInputStore, type SyntheticContextPart } from "./input-store"
 import { useSelectionStore } from "./selection-store"
+import { recordRootSessionUserMessageAt, removeRootSessionUserActivity } from "./session-user-activity-store"
 import { useViewportStore } from "./viewport-store"
 import { useSessionWorktreeStore } from "./session-worktree-store"
 import { getAttachedSessionDirectory } from "./session-worktree-contract"
@@ -769,6 +770,10 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
 
       notifyMessageSent(created.id)
 
+      if (!draft.parentID) {
+        recordRootSessionUserMessageAt(created.id, Date.now())
+      }
+
       markPendingUserSendAnimation(created.id)
 
       const files = attachments?.map((a) => ({
@@ -815,6 +820,12 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     }
 
     if (currentSessionId) {
+      const currentSession = getAllSyncSessions().find((session) => session.id === currentSessionId)
+      const parentID = (currentSession as Session & { parentID?: string | null } | undefined)?.parentID
+      if (!parentID) {
+        recordRootSessionUserMessageAt(currentSessionId, Date.now())
+      }
+
       const viewportState = useViewportStore.getState()
       const memState = viewportState.sessionMemoryState.get(currentSessionId)
       if (!memState || !memState.lastUserMessageAt) {
@@ -905,28 +916,44 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
   // ---------------------------------------------------------------------------
   // deleteSession — calls SDK, SSE event updates child store
   // ---------------------------------------------------------------------------
-  deleteSession: (id) => deleteSessionAction(id),
+  deleteSession: async (id) => {
+    const ok = await deleteSessionAction(id)
+    if (ok) removeRootSessionUserActivity(id)
+    return ok
+  },
 
   deleteSessions: async (ids) => {
     const deletedIds: string[] = []
     const failedIds: string[] = []
     for (const id of ids) {
       const ok = await deleteSessionAction(id)
-      if (ok) deletedIds.push(id)
-      else failedIds.push(id)
+      if (ok) {
+        removeRootSessionUserActivity(id)
+        deletedIds.push(id)
+      } else {
+        failedIds.push(id)
+      }
     }
     return { deletedIds, failedIds }
   },
 
-  archiveSession: (id) => archiveSessionAction(id),
+  archiveSession: async (id) => {
+    const ok = await archiveSessionAction(id)
+    if (ok) removeRootSessionUserActivity(id)
+    return ok
+  },
 
   archiveSessions: async (ids) => {
     const archivedIds: string[] = []
     const failedIds: string[] = []
     for (const id of ids) {
       const ok = await archiveSessionAction(id)
-      if (ok) archivedIds.push(id)
-      else failedIds.push(id)
+      if (ok) {
+        removeRootSessionUserActivity(id)
+        archivedIds.push(id)
+      } else {
+        failedIds.push(id)
+      }
     }
     return { archivedIds, failedIds }
   },

--- a/packages/ui/src/sync/session-user-activity-store.ts
+++ b/packages/ui/src/sync/session-user-activity-store.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand"
+
+type SessionUserActivityState = {
+  lastUserMessageAtBySession: Map<string, number>
+  recordRootUserMessage: (sessionId: string, timestamp: number) => void
+  removeSession: (sessionId: string) => void
+}
+
+export const useSessionUserActivityStore = create<SessionUserActivityState>((set, get) => ({
+  lastUserMessageAtBySession: new Map(),
+
+  recordRootUserMessage: (sessionId, timestamp) => {
+    const current = get().lastUserMessageAtBySession.get(sessionId)
+    if (typeof current === "number" && current >= timestamp) {
+      return
+    }
+
+    const next = new Map(get().lastUserMessageAtBySession)
+    next.set(sessionId, timestamp)
+    set({ lastUserMessageAtBySession: next })
+  },
+
+  removeSession: (sessionId) => {
+    if (!get().lastUserMessageAtBySession.has(sessionId)) {
+      return
+    }
+
+    const next = new Map(get().lastUserMessageAtBySession)
+    next.delete(sessionId)
+    set({ lastUserMessageAtBySession: next })
+  },
+}))
+
+export function recordRootSessionUserMessageAt(sessionId: string, timestamp: number) {
+  useSessionUserActivityStore.getState().recordRootUserMessage(sessionId, timestamp)
+}
+
+export function removeRootSessionUserActivity(sessionId: string) {
+  useSessionUserActivityStore.getState().removeSession(sessionId)
+}


### PR DESCRIPTION
## Summary
- Track root-session user sends in a narrow activity store for sidebar ordering.
- Sort root chats by pinned state, then last real user message timestamp, while preserving existing fallback and child-session sorting.
- Exclude child/subagent sessions from parent/root ordering so agent-to-subagent traffic does not count as user activity.

Fixes #1174

## Verification
- bun run type-check
- bun run lint