### PR TITLE
fix(terminal): preserve UTF-8 replay chunks

### DIFF
--- a/packages/web/server/lib/terminal/output-replay-buffer.js
+++ b/packages/web/server/lib/terminal/output-replay-buffer.js
@@ -10,8 +10,20 @@ const trimTerminalOutputChunkToMaxBytes = (data, maxBytes) => {
     return data;
   }
 
-  const trimmedBuffer = Buffer.from(data, 'utf8').subarray(-maxBytes);
-  return trimmedBuffer.toString('utf8');
+  let trimmed = '';
+  let trimmedBytes = 0;
+  const characters = Array.from(data);
+  for (let index = characters.length - 1; index >= 0; index -= 1) {
+    const character = characters[index];
+    const characterBytes = Buffer.byteLength(character, 'utf8');
+    if (trimmedBytes + characterBytes > maxBytes) {
+      break;
+    }
+    trimmed = `${character}${trimmed}`;
+    trimmedBytes += characterBytes;
+  }
+
+  return trimmed;
 };
 
 export const createTerminalOutputReplayBuffer = () => ({

--- a/packages/web/server/lib/terminal/output-replay-buffer.js
+++ b/packages/web/server/lib/terminal/output-replay-buffer.js
@@ -10,7 +10,7 @@ const trimTerminalOutputChunkToMaxBytes = (data, maxBytes) => {
     return data;
   }
 
-  let trimmed = '';
+  const kept = [];
   let trimmedBytes = 0;
   const characters = Array.from(data);
   for (let index = characters.length - 1; index >= 0; index -= 1) {
@@ -19,11 +19,11 @@ const trimTerminalOutputChunkToMaxBytes = (data, maxBytes) => {
     if (trimmedBytes + characterBytes > maxBytes) {
       break;
     }
-    trimmed = `${character}${trimmed}`;
+    kept.push(character);
     trimmedBytes += characterBytes;
   }
 
-  return trimmed;
+  return kept.reverse().join('');
 };
 
 export const createTerminalOutputReplayBuffer = () => ({

--- a/packages/web/server/lib/terminal/output-replay-buffer.test.js
+++ b/packages/web/server/lib/terminal/output-replay-buffer.test.js
@@ -56,6 +56,15 @@ describe('terminal output replay buffer', () => {
     expect(bufferState.totalBytes).toBe(4);
   });
 
+  it('does not split multibyte characters when trimming oversized chunks', () => {
+    const bufferState = createTerminalOutputReplayBuffer();
+    const chunk = appendTerminalOutputReplayChunk(bufferState, '🙂x', 2);
+
+    expect(chunk?.data).toBe('x');
+    expect(chunk?.bytes).toBe(1);
+    expect(bufferState.totalBytes).toBe(1);
+  });
+
   it('uses the default max bytes when not provided', () => {
     const bufferState = createTerminalOutputReplayBuffer();
     const chunk = appendTerminalOutputReplayChunk(bufferState, 'ok');


### PR DESCRIPTION
## Summary
- Trim oversized terminal replay chunks by whole Unicode characters instead of raw byte slices.
- Add coverage for multibyte output that previously produced replacement characters.

## Validation
- `vet "fix terminal replay UTF-8 trimming" --agentic --agent-harness claude`
- `bun run --cwd packages/web test -- server/lib/terminal/output-replay-buffer.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`