### PR TITLE
fix(quota): ignore invalid reset timestamps

### DIFF
--- a/packages/web/server/lib/quota/utils/formatters.js
+++ b/packages/web/server/lib/quota/utils/formatters.js
@@ -29,7 +29,9 @@ export const formatResetTime = (timestamp) => {
 
 export const calculateResetAfterSeconds = (resetAt) => {
   if (!resetAt) return null;
-  const delta = Math.floor((resetAt - Date.now()) / 1000);
+  const resetAtTime = new Date(resetAt).getTime();
+  if (!Number.isFinite(resetAtTime)) return null;
+  const delta = Math.floor((resetAtTime - Date.now()) / 1000);
   return delta < 0 ? 0 : delta;
 };
 

--- a/packages/web/server/lib/quota/utils/formatters.js
+++ b/packages/web/server/lib/quota/utils/formatters.js
@@ -1,6 +1,10 @@
 export const formatResetTime = (timestamp) => {
   try {
     const resetDate = new Date(timestamp);
+    if (!Number.isFinite(resetDate.getTime())) {
+      return null;
+    }
+
     const now = new Date();
     const isToday = resetDate.toDateString() === now.toDateString();
     

--- a/packages/web/server/lib/quota/utils/formatters.test.js
+++ b/packages/web/server/lib/quota/utils/formatters.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatResetTime } from './formatters.js';
+
+describe('formatResetTime', () => {
+  it('returns null for invalid timestamps', () => {
+    expect(formatResetTime('not-a-date')).toBeNull();
+  });
+});

--- a/packages/web/server/lib/quota/utils/formatters.test.js
+++ b/packages/web/server/lib/quota/utils/formatters.test.js
@@ -1,9 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatResetTime } from './formatters.js';
+import { calculateResetAfterSeconds, formatResetTime } from './formatters.js';
 
 describe('formatResetTime', () => {
   it('returns null for invalid timestamps', () => {
     expect(formatResetTime('not-a-date')).toBeNull();
+    expect(formatResetTime(NaN)).toBeNull();
+    expect(formatResetTime(Infinity)).toBeNull();
+    expect(formatResetTime(-Infinity)).toBeNull();
+  });
+});
+
+describe('calculateResetAfterSeconds', () => {
+  it('returns null for invalid timestamps', () => {
+    expect(calculateResetAfterSeconds('not-a-date')).toBeNull();
+    expect(calculateResetAfterSeconds(NaN)).toBeNull();
+    expect(calculateResetAfterSeconds(Infinity)).toBeNull();
+    expect(calculateResetAfterSeconds(-Infinity)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Return `null` for invalid quota reset timestamps instead of formatting `Invalid Date`.
- Add targeted coverage for invalid reset timestamp input.

## Validation
- `vet "ensure quota reset formatter rejects invalid dates" --agentic --agent-harness claude`
- `bun run --cwd packages/web test server/lib/quota/utils/formatters.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`