### PR TITLE
fix(sync): drop orphan session parts

### DIFF
--- a/packages/ui/src/sync/__tests__/eviction.test.ts
+++ b/packages/ui/src/sync/__tests__/eviction.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import type { Message, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client"
+import type { Message, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client"
 import {
   canDisposeDirectory,
   hasPendingBlockingRequests,
   pickDirectoriesToEvict,
 } from "../eviction"
-import { getProtectedSessionCacheIds, pickSessionCacheEvictions } from "../session-cache"
+import { dropSessionCaches, getProtectedSessionCacheIds, pickSessionCacheEvictions } from "../session-cache"
 import { INITIAL_STATE, type DirState, type State } from "../types"
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -171,5 +171,21 @@ describe("session cache eviction", () => {
     expect(seen.has("ses_permission")).toBe(true)
     expect(seen.has("ses_question")).toBe(true)
     expect(seen.has("ses_streaming")).toBe(true)
+  })
+
+  test("drops parts for evicted messages without part session ids", () => {
+    const store = buildState({
+      message: {
+        ses_old: [{ id: "msg_1", role: "user", time: { created: 1 } } as Message],
+      },
+      part: {
+        msg_1: [{ id: "prt_1", messageID: "msg_1" } as Part],
+      },
+    })
+
+    dropSessionCaches(store, ["ses_old"])
+
+    expect(store.message.ses_old).toBe(undefined)
+    expect(store.part.msg_1).toBe(undefined)
   })
 })

--- a/packages/ui/src/sync/session-cache.ts
+++ b/packages/ui/src/sync/session-cache.ts
@@ -56,6 +56,17 @@ export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<stri
   const stale = new Set(Array.from(sessionIDs).filter(Boolean))
   if (stale.size === 0) return
 
+  const staleMessageIDs = new Set<string>()
+  for (const sessionID of stale) {
+    for (const message of store.message?.[sessionID] ?? []) {
+      if (message?.id) staleMessageIDs.add(message.id)
+    }
+  }
+
+  for (const messageID of staleMessageIDs) {
+    delete store.part[messageID]
+  }
+
   for (const key of Object.keys(store.part ?? {})) {
     const parts = store.part[key]
     if (!parts?.some((part) => stale.has((part as { sessionID?: string })?.sessionID ?? "")))

--- a/packages/ui/src/sync/session-cache.ts
+++ b/packages/ui/src/sync/session-cache.ts
@@ -64,7 +64,7 @@ export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<stri
   }
 
   for (const messageID of staleMessageIDs) {
-    delete store.part[messageID]
+    if (store.part) delete store.part[messageID]
   }
 
   for (const key of Object.keys(store.part ?? {})) {


### PR DESCRIPTION
## Summary
- Delete cached message parts by evicted message ID before falling back to part `sessionID` matching.
- Add eviction coverage for parts that do not include `sessionID`.

## Validation
- `vet "ensure session cache eviction removes orphan message parts" --agentic --agent-harness claude`
- `bun test packages/ui/src/sync/__tests__/eviction.test.ts`
- `bun run type-check`
- `bun run lint`
- `git diff --check`