### PR TITLE
fix(sessions): update changed share URLs

### DIFF
--- a/packages/ui/src/stores/useGlobalSessionsStore.test.ts
+++ b/packages/ui/src/stores/useGlobalSessionsStore.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { Session } from '@opencode-ai/sdk/v2';
+
+import { useGlobalSessionsStore } from './useGlobalSessionsStore';
+
+const buildSession = (shareUrl: string): Session => ({
+  id: 'ses_1',
+  title: 'Shared session',
+  time: { created: 1, updated: 2 },
+  share: { url: shareUrl },
+} as Session);
+
+describe('useGlobalSessionsStore', () => {
+  beforeEach(() => {
+    useGlobalSessionsStore.setState({
+      activeSessions: [],
+      archivedSessions: [],
+      sessionsByDirectory: new Map(),
+      hasLoaded: false,
+      status: 'idle',
+    });
+  });
+
+  test('updates an existing session when the share URL changes', () => {
+    useGlobalSessionsStore.getState().upsertSession(buildSession('https://share.example/a'));
+    useGlobalSessionsStore.getState().upsertSession(buildSession('https://share.example/b'));
+
+    expect(useGlobalSessionsStore.getState().activeSessions[0]?.share?.url).toBe('https://share.example/b');
+  });
+});

--- a/packages/ui/src/stores/useGlobalSessionsStore.ts
+++ b/packages/ui/src/stores/useGlobalSessionsStore.ts
@@ -76,7 +76,7 @@ const getSessionSignature = (session: Session): string => {
     session.time?.created ?? 0,
     session.time?.updated ?? 0,
     session.time?.archived ?? 0,
-    session.share ? 1 : 0,
+    session.share?.url ?? '',
     resolveGlobalSessionDirectory(session) ?? '',
   ].join(':');
 };


### PR DESCRIPTION
## Summary
- Include the share URL in global session signatures so non-null URL changes update existing session rows.
- Add targeted store coverage for share URL changes.

## Validation
- `vet "ensure global sessions update when share URL changes" --agentic --agent-harness claude`
- `bun test packages/ui/src/stores/useGlobalSessionsStore.test.ts`
- `bun run type-check`
- `bun run lint`
- `git diff --check`