### PR TITLE
fix(vscode): include mtime in fs stat proxy

### DIFF
--- a/packages/vscode/src/bridge-localfs-proxy-runtime.ts
+++ b/packages/vscode/src/bridge-localfs-proxy-runtime.ts
@@ -79,6 +79,7 @@ export const tryHandleLocalFsProxy = async (method: string, requestPath: string)
           path: normalizeFsPath(resolution.resolvedPath),
           isFile: true,
           size: stats.size,
+          mtimeMs: stats.mtimeMs,
         })),
       };
     }


### PR DESCRIPTION
## Summary
- Include `mtimeMs` in the VS Code local `/api/fs/stat` proxy response.
- Restores parity with the web route and direct VS Code bridge so shared file caching can detect same-size edits.

## Validation
- `vet "fix VS Code local fs stat mtime parity" --agentic --agent-harness claude`
- `bun run vscode:type-check`
- `bun run type-check`
- `bun run lint`
- `git diff --check`