### PR TITLE
fix(opencode): unref provider tracker interval

### DIFF
--- a/packages/ui/src/lib/opencode/provider-tracker.ts
+++ b/packages/ui/src/lib/opencode/provider-tracker.ts
@@ -41,7 +41,8 @@ function evictStaleProviders(): void {
 }
 
 if (typeof setInterval !== 'undefined') {
-  setInterval(evictStaleProviders, PROVIDER_EVICTION_INTERVAL_MS)
+  const interval = setInterval(evictStaleProviders, PROVIDER_EVICTION_INTERVAL_MS)
+  ;(interval as unknown as { unref?: () => void }).unref?.()
 }
 
 function getOrCreateProvider(providerID: string): ProviderState {


### PR DESCRIPTION
## Summary
- Call `unref()` on the provider tracker eviction interval when supported.
- Prevent the import-time interval from keeping Node/Vitest processes alive.

## Validation
- `vet "ensure provider tracker interval does not keep Node alive" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`