### PR TITLE
fix(ui): prevent duplicate long press timers

### DIFF
--- a/packages/ui/src/hooks/useLongPress.ts
+++ b/packages/ui/src/hooks/useLongPress.ts
@@ -26,6 +26,7 @@ export function useLongPress({
   }, []);
 
   const onPointerDown = useCallback((e: React.PointerEvent | React.TouchEvent) => {
+    clear();
     isLongPressRef.current = false;
     
     // Store start position to detect movement
@@ -44,7 +45,7 @@ export function useLongPress({
       }
       onLongPress();
     }, delay);
-  }, [delay, onLongPress, enableHaptic]);
+  }, [clear, delay, onLongPress, enableHaptic]);
 
   const onPointerMove = useCallback((e: React.PointerEvent | React.TouchEvent) => {
     if (!startPosRef.current || !timerRef.current) return;

--- a/packages/ui/src/hooks/useLongPress.ts
+++ b/packages/ui/src/hooks/useLongPress.ts
@@ -96,6 +96,7 @@ export function useLongPress({
     onTouchStart: onPointerDown, // Add touch handlers for better mobile support
     onTouchMove: onPointerMove,
     onTouchEnd: onPointerUp,
+    onTouchCancel: clear,
     onContextMenu,
   };
 }


### PR DESCRIPTION
## Summary
- Clear any existing long-press timer before scheduling a new one.
- Prevent duplicate `onLongPress` callbacks when a browser emits overlapping touch and pointer start events.

## Validation
- `vet "fix duplicate long-press timers" --agentic --agent-harness claude`
- `bun run type-check:ui`
- `bun run type-check`
- `bun run lint`
- `git diff --check`