### PR TITLE
fix(tasks): preserve timestamps when listing

### DIFF
--- a/packages/web/server/lib/projects/project-config.js
+++ b/packages/web/server/lib/projects/project-config.js
@@ -270,6 +270,7 @@ const normalizeTaskForStorage = (value, options) => {
     createId,
     existingTask,
     allowCreate,
+    refreshUpdatedAt = true,
   } = options;
 
   if (!value || typeof value !== 'object') {
@@ -307,7 +308,7 @@ const normalizeTaskForStorage = (value, options) => {
   const state = {
     ...baseState,
     createdAt: existingTask?.state?.createdAt ?? baseState.createdAt ?? nowMs,
-    updatedAt: nowMs,
+    updatedAt: refreshUpdatedAt ? nowMs : baseState.updatedAt ?? nowMs,
   };
 
   return {
@@ -386,6 +387,7 @@ export const createProjectConfigRuntime = (deps) => {
           createId: taskIDFactory,
           existingTask: null,
           allowCreate: true,
+          refreshUpdatedAt: false,
         });
         scheduledTasks.push(normalized);
       } catch {

--- a/packages/web/server/lib/projects/project-config.test.js
+++ b/packages/web/server/lib/projects/project-config.test.js
@@ -114,6 +114,37 @@ describe('project-config runtime', () => {
     }
   });
 
+  it('preserves scheduled task state timestamps when listing tasks', async () => {
+    const { runtime, cleanup } = await createRuntime();
+    try {
+      const projectID = 'timestamp_preserve';
+      const filePath = path.join(runtime.resolveProjectConfigPath(projectID));
+      await writeFile(
+        filePath,
+        JSON.stringify({
+          scheduledTasks: [{
+            id: 'task-existing',
+            name: 'nightly',
+            enabled: true,
+            schedule: { kind: 'daily', times: ['09:00'], timezone: 'UTC' },
+            execution: { prompt: 'run', providerID: 'openai', modelID: 'gpt-4.1' },
+            state: { createdAt: 10, updatedAt: 20, lastStatus: 'idle' },
+          }],
+        }, null, 2),
+        'utf8',
+      );
+
+      const first = await runtime.listScheduledTasks(projectID);
+      const second = await runtime.listScheduledTasks(projectID);
+
+      expect(first[0].state.createdAt).toBe(10);
+      expect(first[0].state.updatedAt).toBe(20);
+      expect(second[0].state.updatedAt).toBe(20);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('accepts one-time schedule with date and time', async () => {
     const { runtime, cleanup } = await createRuntime();
     try {


### PR DESCRIPTION
## Summary
- Preserve stored scheduled-task `state.updatedAt` during read/list normalization.
- Keep write/upsert normalization refreshing `updatedAt` as before.
- Add project-config coverage for stable timestamps across repeated lists.

## Validation
- `vet "ensure listing scheduled tasks preserves stored state timestamps" --agentic --agent-harness claude`
- `bun run --cwd packages/web test server/lib/projects/project-config.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`