### PR TITLE
fix(git): label stash icon buttons

### DIFF
--- a/packages/ui/src/components/views/git/StashesDialog.tsx
+++ b/packages/ui/src/components/views/git/StashesDialog.tsx
@@ -187,7 +187,7 @@ export const StashesDialog: React.FC<StashesDialogProps> = ({
 const StashIconButton: React.FC<{ label: string; loading: boolean; disabled: boolean; destructive?: boolean; onClick: () => void; children: React.ReactNode }> = ({ label, loading, disabled, destructive, onClick, children }) => (
   <Tooltip>
     <TooltipTrigger asChild>
-      <button type="button" className={cn('flex h-6 w-6 items-center justify-center transition-colors disabled:opacity-50', destructive ? 'text-[var(--status-error)] hover:text-[var(--status-error)]' : 'text-muted-foreground hover:text-foreground')} onClick={onClick} disabled={disabled}>
+      <button type="button" aria-label={label} aria-busy={loading || undefined} className={cn('flex h-6 w-6 items-center justify-center transition-colors disabled:opacity-50', destructive ? 'text-[var(--status-error)] hover:text-[var(--status-error)]' : 'text-muted-foreground hover:text-foreground')} onClick={onClick} disabled={disabled}>
         {loading ? <RiLoader4Line className="size-4 animate-spin" /> : children}
       </button>
     </TooltipTrigger>


### PR DESCRIPTION
## Summary
- Add accessible names to stash action icon buttons using their existing tooltip labels.
- Mark loading stash buttons as busy for assistive technologies.

## Validation
- `vet "ensure stash icon buttons have accessible labels" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`