### PR TITLE
test(input): restore FileReader mock

### DIFF
--- a/packages/ui/src/sync/input-store.test.ts
+++ b/packages/ui/src/sync/input-store.test.ts
@@ -11,6 +11,22 @@ class MockFileReader {
 }
 
 const pendingReaders: MockFileReader[] = []
+const originalFileReader = globalThis.FileReader
+
+const restoreFileReader = () => {
+  pendingReaders.length = 0
+  globalThis.FileReader = originalFileReader
+}
+
+const testWithMockFileReader = (name: string, fn: () => Promise<void>) => {
+  test(name, async () => {
+    try {
+      await fn()
+    } finally {
+      restoreFileReader()
+    }
+  })
+}
 
 const resolveReader = (reader: MockFileReader, result: string) => {
   reader.result = result
@@ -30,7 +46,7 @@ describe("input-store attachments", () => {
     useInputStore.getState().setAttachedFiles([])
   })
 
-  test("does not attach a local file that finishes reading after attachments are cleared", async () => {
+  testWithMockFileReader("does not attach a local file that finishes reading after attachments are cleared", async () => {
     const addPromise = useInputStore.getState().addAttachedFile(new File(["hello"], "hello.txt", { type: "text/plain" }))
     expect(pendingReaders).toHaveLength(1)
 
@@ -41,7 +57,7 @@ describe("input-store attachments", () => {
     expect(useInputStore.getState().attachedFiles).toEqual([])
   })
 
-  test("does not attach a local file after attached files are replaced", async () => {
+  testWithMockFileReader("does not attach a local file after attached files are replaced", async () => {
     const addPromise = useInputStore.getState().addAttachedFile(new File(["hello"], "hello.txt", { type: "text/plain" }))
     expect(pendingReaders).toHaveLength(1)
 
@@ -52,7 +68,7 @@ describe("input-store attachments", () => {
     expect(useInputStore.getState().attachedFiles).toEqual([])
   })
 
-  test("does not attach a local file after attached files are restored", async () => {
+  testWithMockFileReader("does not attach a local file after attached files are restored", async () => {
     const addPromise = useInputStore.getState().addAttachedFile(new File(["hello"], "hello.txt", { type: "text/plain" }))
     expect(pendingReaders).toHaveLength(1)
 
@@ -72,7 +88,7 @@ describe("input-store attachments", () => {
     expect(useInputStore.getState().attachedFiles.map((file) => file.filename)).toEqual(["restored.txt"])
   })
 
-  test("does not attach a VS Code selection that finishes reading after attachments are cleared", async () => {
+  testWithMockFileReader("does not attach a VS Code selection that finishes reading after attachments are cleared", async () => {
     const addPromise = useInputStore.getState().addVSCodeSelectionAttachment(
       "/workspace/hello.txt",
       new File(["hello"], "hello.txt", { type: "text/plain" })


### PR DESCRIPTION
## Summary
- Restore the original global `FileReader` after each input attachment test.
- Prevent the mock reader from leaking into later tests in the same process.

## Validation
- `vet "fix input-store FileReader test mock cleanup" --agentic --agent-harness claude`
- `bun test packages/ui/src/sync/input-store.test.ts`
- `bun run type-check`
- `bun run lint`
- `git diff --check`