### PR TITLE
fix(vscode): clear activity snapshot on stop

### DIFF
--- a/packages/vscode/src/sessionActivityWatcher.ts
+++ b/packages/vscode/src/sessionActivityWatcher.ts
@@ -262,6 +262,7 @@ export const stopGlobalEventWatcher = (): void => {
     clearTimeout(timer);
   }
   sessionActivityCooldowns.clear();
+  sessionActivityPhases.clear();
 };
 
 export const setChatViewProvider = (provider: { postMessage: (message: unknown) => void } | null): void => {


### PR DESCRIPTION
## Summary
- Clear cached VS Code session activity phases when the global watcher is stopped.
- Prevent `/api/session-activity:get` from returning stale busy/cooldown state after watcher shutdown.

## Validation
- `vet "fix VS Code stale activity snapshot after watcher stop" --agentic --agent-harness claude`
- `bun run vscode:type-check`
- `bun run type-check`
- `bun run lint`
- `git diff --check`