### PR TITLE
fix(pwa): keep scoped shortcuts isolated

### DIFF
--- a/packages/web/server/lib/opencode/pwa-manifest-routes.js
+++ b/packages/web/server/lib/opencode/pwa-manifest-routes.js
@@ -130,7 +130,7 @@ export const registerPwaManifestRoute = (app, dependencies) => {
         } else {
           const globalPayload = await listSessions(null);
           const filteredGlobalPayload = filterSessionsByDirectory(globalPayload, preferredDirectory);
-          payload = filteredGlobalPayload.length > 0 ? filteredGlobalPayload : globalPayload;
+          payload = filteredGlobalPayload;
         }
       } else {
         payload = await listSessions(null);

--- a/packages/web/server/lib/opencode/pwa-manifest-routes.test.js
+++ b/packages/web/server/lib/opencode/pwa-manifest-routes.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { registerPwaManifestRoute } from './pwa-manifest-routes.js';
+
+const createResponse = () => ({
+  headers: new Map(),
+  contentType: '',
+  body: '',
+  setHeader(name, value) {
+    this.headers.set(name, value);
+    return this;
+  },
+  type(value) {
+    this.contentType = value;
+    return this;
+  },
+  send(value) {
+    this.body = value;
+    return this;
+  },
+});
+
+describe('PWA manifest route', () => {
+  it('does not fall back to unrelated global session shortcuts for scoped manifests', async () => {
+    const routes = new Map();
+    const app = {
+      get(route, handler) {
+        routes.set(route, handler);
+      },
+    };
+    const originalFetch = globalThis.fetch;
+    const fetchCalls = [];
+    globalThis.fetch = async (url) => {
+      fetchCalls.push(String(url));
+      const sessions = String(url).includes('?directory=')
+        ? []
+        : [
+            {
+              id: 'other-session',
+              title: 'Other project',
+              directory: '/workspace/other',
+              time: { updated: 2 },
+            },
+          ];
+      return {
+        ok: true,
+        json: async () => sessions,
+      };
+    };
+
+    try {
+      registerPwaManifestRoute(app, {
+        process: { platform: 'darwin' },
+        resolveProjectDirectory: async () => ({ directory: '/workspace/app' }),
+        buildOpenCodeUrl: (route) => route,
+        getOpenCodeAuthHeaders: () => ({}),
+        readSettingsFromDiskMigrated: async () => ({}),
+        normalizePwaAppName: (value, fallback) => typeof value === 'string' && value.trim() ? value.trim() : fallback,
+        normalizePwaOrientation: (value, fallback) => typeof value === 'string' && value.trim() ? value.trim() : fallback,
+      });
+
+      const handler = routes.get('/manifest.webmanifest');
+      const res = createResponse();
+      await handler({ query: {} }, res);
+
+      const manifest = JSON.parse(res.body);
+      expect(fetchCalls).toHaveLength(2);
+      expect(manifest.shortcuts).toEqual([
+        {
+          name: 'Appearance Settings',
+          short_name: 'Settings',
+          description: 'Open appearance settings',
+          url: '/?settings=appearance',
+          icons: [{ src: '/pwa-192.png', sizes: '192x192', type: 'image/png' }],
+        },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Keep project-scoped PWA manifests from falling back to unrelated global session shortcuts.
- Add route coverage for an empty scoped result with unrelated global sessions.

## Validation
- `vet "keep project-scoped PWA manifest shortcuts scoped to the project directory" --agentic --agent-harness claude`
- `bun test packages/web/server/lib/opencode/pwa-manifest-routes.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`