### PR TITLE
fix(i18n): retry failed locale loads

### DIFF
--- a/packages/ui/src/lib/i18n/store.test.ts
+++ b/packages/ui/src/lib/i18n/store.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_LOCALE } from './runtime';
+import { useI18nStore } from './store';
+
+describe('i18n store', () => {
+  test('retries loading the active locale when it is not cached', () => {
+    const defaultDictionary = useI18nStore.getState().dictionary;
+    useI18nStore.setState({
+      locale: 'es',
+      dictionary: defaultDictionary,
+      loadingLocale: null,
+    });
+
+    try {
+      useI18nStore.getState().setLocale('es');
+
+      expect(useI18nStore.getState().loadingLocale).toBe('es');
+    } finally {
+      useI18nStore.setState({
+        locale: DEFAULT_LOCALE,
+        dictionary: defaultDictionary,
+        loadingLocale: null,
+      });
+    }
+  });
+});

--- a/packages/ui/src/lib/i18n/store.test.ts
+++ b/packages/ui/src/lib/i18n/store.test.ts
@@ -1,10 +1,32 @@
-import { describe, expect, test } from 'bun:test';
-import { DEFAULT_LOCALE } from './runtime';
-import { useI18nStore } from './store';
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { DEFAULT_LOCALE, type Locale } from './runtime';
+import { resetI18nDictionaryCacheForTests, useI18nStore } from './store';
+
+const defaultDictionary = useI18nStore.getState().dictionary;
+
+const resetStore = () => {
+  resetI18nDictionaryCacheForTests();
+  useI18nStore.setState({
+    locale: DEFAULT_LOCALE,
+    dictionary: defaultDictionary,
+    loadingLocale: null,
+  });
+};
+
+const waitForLocaleLoadToSettle = async (locale: Locale) => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (useI18nStore.getState().loadingLocale !== locale) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`Timed out waiting for ${locale} dictionary load`);
+};
 
 describe('i18n store', () => {
-  test('retries loading the active locale when it is not cached', () => {
-    const defaultDictionary = useI18nStore.getState().dictionary;
+  beforeEach(resetStore);
+
+  test('retries loading the active locale when it is not cached', async () => {
     useI18nStore.setState({
       locale: 'es',
       dictionary: defaultDictionary,
@@ -15,12 +37,9 @@ describe('i18n store', () => {
       useI18nStore.getState().setLocale('es');
 
       expect(useI18nStore.getState().loadingLocale).toBe('es');
+      await waitForLocaleLoadToSettle('es');
     } finally {
-      useI18nStore.setState({
-        locale: DEFAULT_LOCALE,
-        dictionary: defaultDictionary,
-        loadingLocale: null,
-      });
+      resetStore();
     }
   });
 });

--- a/packages/ui/src/lib/i18n/store.ts
+++ b/packages/ui/src/lib/i18n/store.ts
@@ -44,13 +44,13 @@ export const useI18nStore = create<I18nState>()((set, get) => ({
   loadingLocale: null,
   setLocale: (locale) => {
     const current = get();
-    if (current.locale === locale && current.loadingLocale !== locale) {
+    const cached = dictionaries.get(locale);
+    if (current.locale === locale && current.loadingLocale !== locale && cached) {
       return;
     }
 
     writeStoredLocale(locale);
 
-    const cached = dictionaries.get(locale);
     set({
       locale,
       dictionary: cached ?? current.dictionary,

--- a/packages/ui/src/lib/i18n/store.ts
+++ b/packages/ui/src/lib/i18n/store.ts
@@ -15,6 +15,11 @@ type I18nState = {
 
 const dictionaries = new Map<Locale, I18nDictionary>([[DEFAULT_LOCALE, enDict]]);
 
+export function resetI18nDictionaryCacheForTests(): void {
+  dictionaries.clear();
+  dictionaries.set(DEFAULT_LOCALE, enDict);
+}
+
 async function loadDictionary(locale: Locale): Promise<I18nDictionary> {
   const cached = dictionaries.get(locale);
   if (cached) {


### PR DESCRIPTION
## Summary
- Allow `setLocale()` to retry the active locale when its dictionary is not cached after a previous load failure.
- Add store coverage for the failed-load state where locale is active but no dictionary is cached.

## Validation
- `vet "allow retrying an active locale after its dictionary failed to load" --agentic --agent-harness claude`
- `bun test packages/ui/src/lib/i18n/store.test.ts`
- `bun run type-check`
- `bun run lint`
- `git diff --check`