### PR TITLE
fix(files): match Windows prefixes case-insensitively

### DIFF
--- a/packages/ui/src/stores/useFilesViewTabsStore.ts
+++ b/packages/ui/src/stores/useFilesViewTabsStore.ts
@@ -238,13 +238,18 @@ export const useFilesViewTabsStore = create<FilesViewTabsStore>()(
               return state;
             }
 
-            const prefixWithSlash = normalizedPrefix.endsWith('/') ? normalizedPrefix : `${normalizedPrefix}/`;
-            const openPaths = current.openPaths.filter((p) => p !== normalizedPrefix && !p.startsWith(prefixWithSlash));
+            const comparablePrefix = toComparablePath(normalizedPrefix);
+            const comparablePrefixWithSlash = comparablePrefix.endsWith('/') ? comparablePrefix : `${comparablePrefix}/`;
+            const isWithinPrefix = (candidate: string) => {
+              const comparablePath = toComparablePath(candidate);
+              return comparablePath === comparablePrefix || comparablePath.startsWith(comparablePrefixWithSlash);
+            };
+            const openPaths = current.openPaths.filter((p) => !isWithinPrefix(p));
             if (openPaths.length === current.openPaths.length) {
               return state;
             }
 
-            const selectedPath = current.selectedPath && (current.selectedPath === normalizedPrefix || current.selectedPath.startsWith(prefixWithSlash))
+            const selectedPath = current.selectedPath && isWithinPrefix(current.selectedPath)
               ? (openPaths[0] ?? null)
               : current.selectedPath;
 

--- a/packages/ui/src/stores/useFilesViewTabsStore.ts
+++ b/packages/ui/src/stores/useFilesViewTabsStore.ts
@@ -205,12 +205,15 @@ export const useFilesViewTabsStore = create<FilesViewTabsStore>()(
               return state;
             }
 
-            if (!current.openPaths.includes(normalizedPath) && current.selectedPath !== normalizedPath) {
+            const comparablePath = toComparablePath(normalizedPath);
+            const isMatchingPath = (candidate: string) => toComparablePath(candidate) === comparablePath;
+            const selectedPathMatches = current.selectedPath ? isMatchingPath(current.selectedPath) : false;
+            if (!current.openPaths.some(isMatchingPath) && !selectedPathMatches) {
               return state;
             }
 
-            const openPaths = current.openPaths.filter((p) => p !== normalizedPath);
-            const selectedPath = current.selectedPath === normalizedPath ? (openPaths[0] ?? null) : current.selectedPath;
+            const openPaths = current.openPaths.filter((p) => !isMatchingPath(p));
+            const selectedPath = selectedPathMatches ? (openPaths[0] ?? null) : current.selectedPath;
 
             const byRoot = {
               ...state.byRoot,

--- a/packages/ui/src/stores/useFilesViewTabsStore.windows.test.ts
+++ b/packages/ui/src/stores/useFilesViewTabsStore.windows.test.ts
@@ -19,4 +19,18 @@ describe('useFilesViewTabsStore Windows paths', () => {
     expect(rootState?.openPaths).toEqual(['C:/Repo/other.ts']);
     expect(rootState?.selectedPath).toBe('C:/Repo/other.ts');
   });
+
+  test('removes a single open path case-insensitively for Windows drive paths', () => {
+    const root = 'C:/Repo';
+    const store = useFilesViewTabsStore.getState();
+
+    store.addOpenPath(root, 'C:/Repo/src/a.ts');
+    store.addOpenPath(root, 'C:/Repo/other.ts');
+    store.setSelectedPath(root, 'C:/Repo/src/a.ts');
+    store.removeOpenPath(root, 'c:/repo/src/a.ts');
+
+    const rootState = useFilesViewTabsStore.getState().byRoot[root];
+    expect(rootState?.openPaths).toEqual(['C:/Repo/other.ts']);
+    expect(rootState?.selectedPath).toBe('C:/Repo/other.ts');
+  });
 });

--- a/packages/ui/src/stores/useFilesViewTabsStore.windows.test.ts
+++ b/packages/ui/src/stores/useFilesViewTabsStore.windows.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { useFilesViewTabsStore } from './useFilesViewTabsStore';
+
+describe('useFilesViewTabsStore Windows paths', () => {
+  beforeEach(() => {
+    useFilesViewTabsStore.setState({ byRoot: {} });
+  });
+
+  test('removes open paths by prefix case-insensitively for Windows drive paths', () => {
+    const root = 'C:/Repo';
+    const store = useFilesViewTabsStore.getState();
+
+    store.addOpenPath(root, 'C:/Repo/src/a.ts');
+    store.addOpenPath(root, 'C:/Repo/other.ts');
+    store.setSelectedPath(root, 'C:/Repo/src/a.ts');
+    store.removeOpenPathsByPrefix(root, 'c:/repo/src');
+
+    const rootState = useFilesViewTabsStore.getState().byRoot[root];
+    expect(rootState?.openPaths).toEqual(['C:/Repo/other.ts']);
+    expect(rootState?.selectedPath).toBe('C:/Repo/other.ts');
+  });
+});


### PR DESCRIPTION
## Summary
- Compare Windows drive paths case-insensitively when removing open files by prefix.
- Add coverage for closing an uppercase stored path with a lowercase prefix.

## Validation
- `vet "make files-view tab prefix removal case-insensitive for Windows drive paths" --agentic --agent-harness claude`
- `bun test packages/ui/src/stores/useFilesViewTabsStore.windows.test.ts`
- `bun run type-check`
- `bun run lint`
- `git diff --check`