### PR TITLE
test(opencode): restore PATH after lifecycle tests

### DIFF
--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -11,14 +11,21 @@ vi.mock('node:child_process', () => ({
 const { createOpenCodeLifecycleRuntime } = await import('./lifecycle.js');
 
 const originalOpencodeBinary = process.env.OPENCODE_BINARY;
+const originalPath = process.env.PATH;
 
 afterEach(() => {
   spawnMock.mockReset();
   if (typeof originalOpencodeBinary === 'string') {
     process.env.OPENCODE_BINARY = originalOpencodeBinary;
-    return;
+  } else {
+    delete process.env.OPENCODE_BINARY;
   }
-  delete process.env.OPENCODE_BINARY;
+
+  if (typeof originalPath === 'string') {
+    process.env.PATH = originalPath;
+  } else {
+    delete process.env.PATH;
+  }
 });
 
 const createMockChild = () => {
@@ -147,7 +154,6 @@ describe('OpenCode lifecycle', () => {
 
   it('falls back to process.env.PATH when neither build function is provided', async () => {
     delete process.env.OPENCODE_BINARY;
-    const originalPath = process.env.PATH;
     process.env.PATH = '/usr/bin:/bin';
     const child = createMockChild();
     spawnMock.mockImplementationOnce(() => {
@@ -165,7 +171,6 @@ describe('OpenCode lifecycle', () => {
     const [, , options] = spawnMock.mock.calls[0];
 
     expect(options.env.PATH).toBe('/usr/bin:/bin');
-    process.env.PATH = originalPath;
 
     await server.close();
   });


### PR DESCRIPTION
## Summary
- Restore `process.env.PATH` in lifecycle test `afterEach` so failures do not leak a modified PATH into later tests.
- Keep OPENCODE_BINARY restoration in the same failure-safe cleanup path.

## Validation
- `vet "restore PATH after OpenCode lifecycle tests even on failure" --agentic --agent-harness claude`
- `bun test packages/web/server/lib/opencode/lifecycle.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`