### PR TITLE
test(sync): shorten websocket fallback test

### DIFF
--- a/packages/ui/src/sync/__tests__/event-pipeline.test.js
+++ b/packages/ui/src/sync/__tests__/event-pipeline.test.js
@@ -654,8 +654,6 @@ describe('createEventPipeline', () => {
         wsReadyTimeoutMs: 20,
         onEvent: (directory, payload) => {
           received.push({ directory, payload });
-          cleanup();
-          releaseStream();
           resolve();
         },
       });

--- a/packages/ui/src/sync/__tests__/event-pipeline.test.js
+++ b/packages/ui/src/sync/__tests__/event-pipeline.test.js
@@ -74,6 +74,14 @@ function createSdkWithSingleEvent(event, hold) {
   };
 }
 
+function withTimeout(promise, ms, message) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timeoutId));
+}
+
 // Helper to create an SDK that yields multiple events in sequence, then holds.
 function createSdkWithEvents(events, hold) {
   return {
@@ -638,10 +646,12 @@ describe('createEventPipeline', () => {
       },
     }, hold);
 
+    let cleanup;
     const delivered = new Promise((resolve) => {
-      const { cleanup } = createEventPipeline({
+      const pipeline = createEventPipeline({
         sdk,
         transport: 'auto',
+        wsReadyTimeoutMs: 20,
         onEvent: (directory, payload) => {
           received.push({ directory, payload });
           cleanup();
@@ -649,14 +659,19 @@ describe('createEventPipeline', () => {
           resolve();
         },
       });
+      cleanup = pipeline.cleanup;
     });
 
     await Promise.resolve();
     const socket = FakeWebSocket.instances[0];
     socket.emitOpen();
 
-    await new Promise((resolve) => setTimeout(resolve, 2300));
-    await delivered;
+    try {
+      await withTimeout(delivered, 500, 'timed out waiting for websocket-ready SSE fallback');
+    } finally {
+      cleanup?.();
+      releaseStream();
+    }
 
     expect(received).toEqual([
       {


### PR DESCRIPTION
## Summary
- Configure the websocket-ready fallback test with a short `wsReadyTimeoutMs` instead of waiting for the default timeout.
- Add a bounded wait so regressions fail quickly and still clean up the pipeline.

## Validation
- `vet "make websocket-ready fallback test use a short timeout" --agentic --agent-harness claude`
- `bun test packages/ui/src/sync/__tests__/event-pipeline.test.js -t "falls back to SSE when websocket does not become ready in auto mode"`
- `bun run type-check`
- `bun run lint`
- `git diff --check`