### PR TITLE
test(opencode): avoid duplicate WSL env assertion

### DIFF
--- a/packages/web/server/lib/opencode/env-runtime.test.js
+++ b/packages/web/server/lib/opencode/env-runtime.test.js
@@ -7,6 +7,7 @@ import { createOpenCodeEnvRuntime } from './env-runtime.js';
 const originalOpencodeBinary = process.env.OPENCODE_BINARY;
 const originalPlatform = process.platform;
 const tempDirs = [];
+const itIf = (condition) => condition ? it : it.skip;
 
 const createTempDir = (prefix) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -93,7 +94,7 @@ describe('OpenCode env runtime', () => {
     expect(state.resolvedOpencodeBinarySource).toBe('settings');
   });
 
-  it.runIf(process.platform === 'darwin')('rejects known macOS OpenCode app bundle executable paths', async () => {
+  itIf(process.platform === 'darwin')('rejects known macOS OpenCode app bundle executable paths', async () => {
     const { runtime } = createRuntime({ opencodeBinary: '/Applications/OpenCode.app/Contents/MacOS/OpenCode' });
 
     await expect(runtime.applyOpencodeBinaryFromSettings({ strict: true })).rejects.toMatchObject({
@@ -106,9 +107,9 @@ describe('OpenCode env runtime', () => {
     setPlatform('win32');
     const { runtime } = createRuntime({ opencodeBinary: 'wsl:/usr/local/bin/opencode' });
 
-    await expect(runtime.applyOpencodeBinaryFromSettings({ strict: true })).rejects.toThrow('uses WSL');
-    await runtime.applyOpencodeBinaryFromSettings({ strict: true }).catch((error) => {
-      expect(error.code).toBeUndefined();
-    });
+    const error = await runtime.applyOpencodeBinaryFromSettings({ strict: true }).catch((caught) => caught);
+
+    expect(error.message).toContain('uses WSL');
+    expect(error.code).toBeUndefined();
   });
 });

--- a/packages/web/server/lib/opencode/env-runtime.test.js
+++ b/packages/web/server/lib/opencode/env-runtime.test.js
@@ -107,9 +107,10 @@ describe('OpenCode env runtime', () => {
     setPlatform('win32');
     const { runtime } = createRuntime({ opencodeBinary: 'wsl:/usr/local/bin/opencode' });
 
-    const error = await runtime.applyOpencodeBinaryFromSettings({ strict: true }).catch((caught) => caught);
+    const rejection = runtime.applyOpencodeBinaryFromSettings({ strict: true });
 
-    expect(error.message).toContain('uses WSL');
+    await expect(rejection).rejects.toThrow('uses WSL');
+    const error = await rejection.catch((caught) => caught);
     expect(error.code).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Assert the strict WSL failure path from a single `applyOpencodeBinaryFromSettings()` invocation.
- Replace `it.runIf` with a Bun-compatible conditional test helper so this test file runs under the repository test command.

## Validation
- `vet "make env runtime strict WSL test deterministic under the Bun test runner" --agentic --agent-harness claude`
- `bun test packages/web/server/lib/opencode/env-runtime.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`