### PR TITLE
Sync speech recognition settings across devices

### DIFF
--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -172,6 +172,7 @@ export type DesktopSettings = {
   sttLanguage?: string;
   sttSilenceThresholdDb?: number;
   sttSilenceHoldMs?: number;
+  sttTranscribeOnStop?: boolean;
 };
 
 type TauriGlobal = {

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -166,6 +166,12 @@ export type DesktopSettings = {
   responseStyleEnabled?: boolean;
   responseStylePreset?: 'concise' | 'detailed' | 'mentor' | 'pushback' | 'noFiller' | 'matchEnergy' | 'warmPeer' | 'custom';
   responseStyleCustomInstructions?: string;
+  sttProvider?: 'browser' | 'server';
+  sttServerUrl?: string;
+  sttModel?: string;
+  sttLanguage?: string;
+  sttSilenceThresholdDb?: number;
+  sttSilenceHoldMs?: number;
 };
 
 type TauriGlobal = {

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -96,6 +96,24 @@ const persistToLocalStorage = (settings: DesktopSettings) => {
   if (typeof settings.mobileKeyboardMode === 'string') {
     setStoredMobileKeyboardMode(settings.mobileKeyboardMode);
   }
+  if (settings.sttProvider === 'browser' || settings.sttProvider === 'server') {
+    localStorage.setItem('sttProvider', settings.sttProvider);
+  }
+  if (typeof settings.sttServerUrl === 'string') {
+    localStorage.setItem('sttServerUrl', settings.sttServerUrl);
+  }
+  if (typeof settings.sttModel === 'string') {
+    localStorage.setItem('sttModel', settings.sttModel);
+  }
+  if (typeof settings.sttLanguage === 'string') {
+    localStorage.setItem('sttLanguage', settings.sttLanguage);
+  }
+  if (typeof settings.sttSilenceThresholdDb === 'number' && Number.isFinite(settings.sttSilenceThresholdDb)) {
+    localStorage.setItem('sttSilenceThresholdDb', String(settings.sttSilenceThresholdDb));
+  }
+  if (typeof settings.sttSilenceHoldMs === 'number' && Number.isFinite(settings.sttSilenceHoldMs)) {
+    localStorage.setItem('sttSilenceHoldMs', String(settings.sttSilenceHoldMs));
+  }
 };
 
 type PersistApi = {
@@ -316,6 +334,9 @@ const applyDesktopUiPreferences = (settings: DesktopSettings) => {
   const configStore = typeof window !== 'undefined'
     ? window.__zustand_config_store__?.getState?.() ?? null
     : null;
+  const configStoreApi = typeof window !== 'undefined'
+    ? window.__zustand_config_store__ ?? null
+    : null;
   const queueStore = useMessageQueueStore.getState();
 
   if (typeof settings.showReasoningTraces === 'boolean' && settings.showReasoningTraces !== store.showReasoningTraces) {
@@ -472,6 +493,30 @@ const applyDesktopUiPreferences = (settings: DesktopSettings) => {
     const mode = normalizeMobileKeyboardMode(settings.mobileKeyboardMode, store.mobileKeyboardMode);
     if (mode !== store.mobileKeyboardMode) {
       store.setMobileKeyboardMode(mode);
+    }
+  }
+  if (configStoreApi && configStore) {
+    const nextConfigState: Partial<typeof configStore> = {};
+    if ((settings.sttProvider === 'browser' || settings.sttProvider === 'server') && settings.sttProvider !== configStore.sttProvider) {
+      nextConfigState.sttProvider = settings.sttProvider;
+    }
+    if (typeof settings.sttServerUrl === 'string' && settings.sttServerUrl !== configStore.sttServerUrl) {
+      nextConfigState.sttServerUrl = settings.sttServerUrl;
+    }
+    if (typeof settings.sttModel === 'string' && settings.sttModel !== configStore.sttModel) {
+      nextConfigState.sttModel = settings.sttModel;
+    }
+    if (typeof settings.sttLanguage === 'string' && settings.sttLanguage !== configStore.sttLanguage) {
+      nextConfigState.sttLanguage = settings.sttLanguage;
+    }
+    if (typeof settings.sttSilenceThresholdDb === 'number' && Number.isFinite(settings.sttSilenceThresholdDb) && settings.sttSilenceThresholdDb !== configStore.sttSilenceThresholdDb) {
+      nextConfigState.sttSilenceThresholdDb = settings.sttSilenceThresholdDb;
+    }
+    if (typeof settings.sttSilenceHoldMs === 'number' && Number.isFinite(settings.sttSilenceHoldMs) && settings.sttSilenceHoldMs !== configStore.sttSilenceHoldMs) {
+      nextConfigState.sttSilenceHoldMs = settings.sttSilenceHoldMs;
+    }
+    if (Object.keys(nextConfigState).length > 0) {
+      configStoreApi.setState(nextConfigState);
     }
   }
 
@@ -979,6 +1024,24 @@ const sanitizeWebSettings = (payload: unknown): DesktopSettings | null => {
   }
   if (typeof candidate.responseStyleCustomInstructions === 'string') {
     result.responseStyleCustomInstructions = candidate.responseStyleCustomInstructions;
+  }
+  if (candidate.sttProvider === 'browser' || candidate.sttProvider === 'server') {
+    result.sttProvider = candidate.sttProvider;
+  }
+  if (typeof candidate.sttServerUrl === 'string') {
+    result.sttServerUrl = candidate.sttServerUrl.trim();
+  }
+  if (typeof candidate.sttModel === 'string') {
+    result.sttModel = candidate.sttModel.trim();
+  }
+  if (typeof candidate.sttLanguage === 'string') {
+    result.sttLanguage = candidate.sttLanguage.trim();
+  }
+  if (typeof candidate.sttSilenceThresholdDb === 'number' && Number.isFinite(candidate.sttSilenceThresholdDb)) {
+    result.sttSilenceThresholdDb = candidate.sttSilenceThresholdDb;
+  }
+  if (typeof candidate.sttSilenceHoldMs === 'number' && Number.isFinite(candidate.sttSilenceHoldMs)) {
+    result.sttSilenceHoldMs = candidate.sttSilenceHoldMs;
   }
 
   return result;

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -114,6 +114,9 @@ const persistToLocalStorage = (settings: DesktopSettings) => {
   if (typeof settings.sttSilenceHoldMs === 'number' && Number.isFinite(settings.sttSilenceHoldMs)) {
     localStorage.setItem('sttSilenceHoldMs', String(settings.sttSilenceHoldMs));
   }
+  if (typeof settings.sttTranscribeOnStop === 'boolean') {
+    localStorage.setItem('sttTranscribeOnStop', String(settings.sttTranscribeOnStop));
+  }
 };
 
 type PersistApi = {
@@ -514,6 +517,9 @@ const applyDesktopUiPreferences = (settings: DesktopSettings) => {
     }
     if (typeof settings.sttSilenceHoldMs === 'number' && Number.isFinite(settings.sttSilenceHoldMs) && settings.sttSilenceHoldMs !== configStore.sttSilenceHoldMs) {
       nextConfigState.sttSilenceHoldMs = settings.sttSilenceHoldMs;
+    }
+    if (typeof settings.sttTranscribeOnStop === 'boolean' && settings.sttTranscribeOnStop !== configStore.sttTranscribeOnStop) {
+      nextConfigState.sttTranscribeOnStop = settings.sttTranscribeOnStop;
     }
     if (Object.keys(nextConfigState).length > 0) {
       configStoreApi.setState(nextConfigState);
@@ -1042,6 +1048,9 @@ const sanitizeWebSettings = (payload: unknown): DesktopSettings | null => {
   }
   if (typeof candidate.sttSilenceHoldMs === 'number' && Number.isFinite(candidate.sttSilenceHoldMs)) {
     result.sttSilenceHoldMs = candidate.sttSilenceHoldMs;
+  }
+  if (typeof candidate.sttTranscribeOnStop === 'boolean') {
+    result.sttTranscribeOnStop = candidate.sttTranscribeOnStop;
   }
 
   return result;

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -17,11 +17,29 @@ import { parseModelIdentifier } from "@/lib/modelIdentifier";
 
 const MODELS_DEV_API_URL = "https://models.dev/api.json";
 const MODELS_DEV_PROXY_URL = "/api/openchamber/models-metadata";
+const STT_SILENCE_THRESHOLD_DB_MIN = -100;
+const STT_SILENCE_THRESHOLD_DB_MAX = 0;
+const STT_SILENCE_HOLD_MS_MIN = 250;
+const STT_SILENCE_HOLD_MS_MAX = 10000;
 
 const FALLBACK_PROVIDER_ID = "opencode";
 const FALLBACK_MODEL_ID = "big-pickle";
 const GIT_UTILITY_PROVIDER_ID = "zen";
 const GIT_UTILITY_PREFERRED_MODEL_ID = "big-pickle";
+
+const normalizeSttSilenceThresholdDb = (value: unknown): number | undefined => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return undefined;
+    }
+    return Math.max(STT_SILENCE_THRESHOLD_DB_MIN, Math.min(STT_SILENCE_THRESHOLD_DB_MAX, value));
+};
+
+const normalizeSttSilenceHoldMs = (value: unknown): number | undefined => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return undefined;
+    }
+    return Math.max(STT_SILENCE_HOLD_MS_MIN, Math.min(STT_SILENCE_HOLD_MS_MAX, Math.round(value)));
+};
 
 interface OpenChamberDefaults {
     defaultModel?: string;
@@ -63,8 +81,8 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
                     const sttServerUrl = typeof data?.sttServerUrl === 'string' ? data.sttServerUrl.trim() : undefined;
                     const sttModel = typeof data?.sttModel === 'string' ? data.sttModel.trim() : undefined;
                     const sttLanguage = typeof data?.sttLanguage === 'string' ? data.sttLanguage.trim() : undefined;
-                    const sttSilenceThresholdDb = typeof data?.sttSilenceThresholdDb === 'number' && Number.isFinite(data.sttSilenceThresholdDb) ? data.sttSilenceThresholdDb : undefined;
-                    const sttSilenceHoldMs = typeof data?.sttSilenceHoldMs === 'number' && Number.isFinite(data.sttSilenceHoldMs) ? data.sttSilenceHoldMs : undefined;
+                    const sttSilenceThresholdDb = normalizeSttSilenceThresholdDb(data?.sttSilenceThresholdDb);
+                    const sttSilenceHoldMs = normalizeSttSilenceHoldMs(data?.sttSilenceHoldMs);
 
                     return {
                         defaultModel: defaultModel.length > 0 ? defaultModel : undefined,
@@ -111,8 +129,8 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
         const sttServerUrl = typeof data?.sttServerUrl === 'string' ? data.sttServerUrl.trim() : undefined;
         const sttModel = typeof data?.sttModel === 'string' ? data.sttModel.trim() : undefined;
         const sttLanguage = typeof data?.sttLanguage === 'string' ? data.sttLanguage.trim() : undefined;
-        const sttSilenceThresholdDb = typeof data?.sttSilenceThresholdDb === 'number' && Number.isFinite(data.sttSilenceThresholdDb) ? data.sttSilenceThresholdDb : undefined;
-        const sttSilenceHoldMs = typeof data?.sttSilenceHoldMs === 'number' && Number.isFinite(data.sttSilenceHoldMs) ? data.sttSilenceHoldMs : undefined;
+        const sttSilenceThresholdDb = normalizeSttSilenceThresholdDb(data?.sttSilenceThresholdDb);
+        const sttSilenceHoldMs = normalizeSttSilenceHoldMs(data?.sttSilenceHoldMs);
 
         return {
             defaultModel: defaultModel.length > 0 ? defaultModel : undefined,

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -1939,6 +1939,7 @@ export const useConfigStore = create<ConfigStore>()(
                     if (typeof window !== 'undefined') {
                         localStorage.setItem('sttTranscribeOnStop', String(enabled));
                     }
+                    updateDesktopSettings({ sttTranscribeOnStop: enabled }).catch(() => {});
                 },
 
                 setShowMessageTTSButtons: (show: boolean) => {

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -32,6 +32,12 @@ interface OpenChamberDefaults {
     defaultFileViewerPreview?: boolean;
     zenModel?: string;
     messageStreamTransport?: 'auto' | 'ws' | 'sse';
+    sttProvider?: 'browser' | 'server';
+    sttServerUrl?: string;
+    sttModel?: string;
+    sttLanguage?: string;
+    sttSilenceThresholdDb?: number;
+    sttSilenceHoldMs?: number;
 }
 
 const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
@@ -53,6 +59,12 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
                         data?.messageStreamTransport === 'ws' || data?.messageStreamTransport === 'sse' || data?.messageStreamTransport === 'auto'
                             ? data.messageStreamTransport
                             : undefined;
+                    const sttProvider = data?.sttProvider === 'browser' || data?.sttProvider === 'server' ? data.sttProvider : undefined;
+                    const sttServerUrl = typeof data?.sttServerUrl === 'string' ? data.sttServerUrl.trim() : undefined;
+                    const sttModel = typeof data?.sttModel === 'string' ? data.sttModel.trim() : undefined;
+                    const sttLanguage = typeof data?.sttLanguage === 'string' ? data.sttLanguage.trim() : undefined;
+                    const sttSilenceThresholdDb = typeof data?.sttSilenceThresholdDb === 'number' && Number.isFinite(data.sttSilenceThresholdDb) ? data.sttSilenceThresholdDb : undefined;
+                    const sttSilenceHoldMs = typeof data?.sttSilenceHoldMs === 'number' && Number.isFinite(data.sttSilenceHoldMs) ? data.sttSilenceHoldMs : undefined;
 
                     return {
                         defaultModel: defaultModel.length > 0 ? defaultModel : undefined,
@@ -63,6 +75,12 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
                         defaultFileViewerPreview,
                         zenModel: zenModel.length > 0 ? zenModel : undefined,
                         messageStreamTransport,
+                        sttProvider,
+                        sttServerUrl,
+                        sttModel,
+                        sttLanguage,
+                        sttSilenceThresholdDb,
+                        sttSilenceHoldMs,
                     };
                 }
             } catch {
@@ -89,6 +107,12 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
             data?.messageStreamTransport === 'ws' || data?.messageStreamTransport === 'sse' || data?.messageStreamTransport === 'auto'
                 ? data.messageStreamTransport
                 : undefined;
+        const sttProvider = data?.sttProvider === 'browser' || data?.sttProvider === 'server' ? data.sttProvider : undefined;
+        const sttServerUrl = typeof data?.sttServerUrl === 'string' ? data.sttServerUrl.trim() : undefined;
+        const sttModel = typeof data?.sttModel === 'string' ? data.sttModel.trim() : undefined;
+        const sttLanguage = typeof data?.sttLanguage === 'string' ? data.sttLanguage.trim() : undefined;
+        const sttSilenceThresholdDb = typeof data?.sttSilenceThresholdDb === 'number' && Number.isFinite(data.sttSilenceThresholdDb) ? data.sttSilenceThresholdDb : undefined;
+        const sttSilenceHoldMs = typeof data?.sttSilenceHoldMs === 'number' && Number.isFinite(data.sttSilenceHoldMs) ? data.sttSilenceHoldMs : undefined;
 
         return {
             defaultModel: defaultModel.length > 0 ? defaultModel : undefined,
@@ -99,6 +123,12 @@ const fetchOpenChamberDefaults = async (): Promise<OpenChamberDefaults> => {
             defaultFileViewerPreview,
             zenModel: zenModel.length > 0 ? zenModel : undefined,
             messageStreamTransport,
+            sttProvider,
+            sttServerUrl,
+            sttModel,
+            sttLanguage,
+            sttSilenceThresholdDb,
+            sttSilenceHoldMs,
         };
     } catch {
         return {};
@@ -1300,6 +1330,12 @@ export const useConfigStore = create<ConfigStore>()(
                                     settingsDefaultFileViewerPreview: openChamberDefaults.defaultFileViewerPreview ?? false,
                                     settingsZenModel: resolvedZenModel,
                                     settingsMessageStreamTransport: openChamberDefaults.messageStreamTransport ?? state.settingsMessageStreamTransport ?? 'auto',
+                                    sttProvider: openChamberDefaults.sttProvider ?? state.sttProvider,
+                                    sttServerUrl: openChamberDefaults.sttServerUrl ?? state.sttServerUrl,
+                                    sttModel: openChamberDefaults.sttModel ?? state.sttModel,
+                                    sttLanguage: openChamberDefaults.sttLanguage ?? state.sttLanguage,
+                                    sttSilenceThresholdDb: openChamberDefaults.sttSilenceThresholdDb ?? state.sttSilenceThresholdDb,
+                                    sttSilenceHoldMs: openChamberDefaults.sttSilenceHoldMs ?? state.sttSilenceHoldMs,
                                     directoryScoped: {
                                         ...state.directoryScoped,
                                         [directoryKey]: nextSnapshot,
@@ -1837,6 +1873,7 @@ export const useConfigStore = create<ConfigStore>()(
                     if (typeof window !== 'undefined') {
                         localStorage.setItem('sttProvider', provider);
                     }
+                    updateDesktopSettings({ sttProvider: provider }).catch(() => {});
                 },
 
                 setSttServerUrl: (url: string) => {
@@ -1844,6 +1881,7 @@ export const useConfigStore = create<ConfigStore>()(
                     if (typeof window !== 'undefined') {
                         localStorage.setItem('sttServerUrl', url);
                     }
+                    updateDesktopSettings({ sttServerUrl: url }).catch(() => {});
                 },
 
                 setSttModel: (model: string) => {
@@ -1851,6 +1889,7 @@ export const useConfigStore = create<ConfigStore>()(
                     if (typeof window !== 'undefined') {
                         localStorage.setItem('sttModel', model);
                     }
+                    updateDesktopSettings({ sttModel: model }).catch(() => {});
                 },
 
                 setSttLanguage: (lang: string) => {
@@ -1858,6 +1897,7 @@ export const useConfigStore = create<ConfigStore>()(
                     if (typeof window !== 'undefined') {
                         localStorage.setItem('sttLanguage', lang);
                     }
+                    updateDesktopSettings({ sttLanguage: lang }).catch(() => {});
                 },
 
                 setSttSilenceThresholdDb: (db: number) => {
@@ -1865,6 +1905,7 @@ export const useConfigStore = create<ConfigStore>()(
                     if (typeof window !== 'undefined') {
                         localStorage.setItem('sttSilenceThresholdDb', String(db));
                     }
+                    updateDesktopSettings({ sttSilenceThresholdDb: db }).catch(() => {});
                 },
 
                 setSttSilenceHoldMs: (ms: number) => {
@@ -1872,6 +1913,7 @@ export const useConfigStore = create<ConfigStore>()(
                     if (typeof window !== 'undefined') {
                         localStorage.setItem('sttSilenceHoldMs', String(ms));
                     }
+                    updateDesktopSettings({ sttSilenceHoldMs: ms }).catch(() => {});
                 },
 
                 setSttTranscribeOnStop: (enabled: boolean) => {

--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -599,6 +599,30 @@ export const createSettingsHelpers = (dependencies) => {
       }
     }
 
+    if (typeof candidate.sttProvider === 'string') {
+      const provider = candidate.sttProvider.trim();
+      if (provider === 'browser' || provider === 'server') {
+        result.sttProvider = provider;
+      }
+    }
+    if (typeof candidate.sttServerUrl === 'string') {
+      const trimmed = candidate.sttServerUrl.trim();
+      result.sttServerUrl = trimmed;
+    }
+    if (typeof candidate.sttModel === 'string') {
+      const trimmed = candidate.sttModel.trim();
+      result.sttModel = trimmed;
+    }
+    if (typeof candidate.sttLanguage === 'string') {
+      result.sttLanguage = candidate.sttLanguage.trim();
+    }
+    if (typeof candidate.sttSilenceThresholdDb === 'number' && Number.isFinite(candidate.sttSilenceThresholdDb)) {
+      result.sttSilenceThresholdDb = Math.max(-100, Math.min(0, candidate.sttSilenceThresholdDb));
+    }
+    if (typeof candidate.sttSilenceHoldMs === 'number' && Number.isFinite(candidate.sttSilenceHoldMs)) {
+      result.sttSilenceHoldMs = Math.max(250, Math.min(10000, Math.round(candidate.sttSilenceHoldMs)));
+    }
+
     return result;
   };
 

--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -632,6 +632,9 @@ export const createSettingsHelpers = (dependencies) => {
     if (typeof candidate.sttSilenceHoldMs === 'number' && Number.isFinite(candidate.sttSilenceHoldMs)) {
       result.sttSilenceHoldMs = Math.max(250, Math.min(10000, Math.round(candidate.sttSilenceHoldMs)));
     }
+    if (typeof candidate.sttTranscribeOnStop === 'boolean') {
+      result.sttTranscribeOnStop = candidate.sttTranscribeOnStop;
+    }
 
     return result;
   };

--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -18,6 +18,9 @@ export const createSettingsHelpers = (dependencies) => {
   } = dependencies;
 
   const PWA_APP_NAME_MAX_LENGTH = 64;
+  const STT_SERVER_URL_MAX_LENGTH = 2048;
+  const STT_MODEL_MAX_LENGTH = 256;
+  const STT_LANGUAGE_MAX_LENGTH = 64;
   const PWA_ORIENTATION_VALUES = new Set(['system', 'portrait', 'landscape']);
   const MOBILE_KEYBOARD_MODE_VALUES = new Set(['native', 'resize-content']);
 
@@ -607,14 +610,21 @@ export const createSettingsHelpers = (dependencies) => {
     }
     if (typeof candidate.sttServerUrl === 'string') {
       const trimmed = candidate.sttServerUrl.trim();
-      result.sttServerUrl = trimmed;
+      if (trimmed.length <= STT_SERVER_URL_MAX_LENGTH) {
+        result.sttServerUrl = trimmed;
+      }
     }
     if (typeof candidate.sttModel === 'string') {
       const trimmed = candidate.sttModel.trim();
-      result.sttModel = trimmed;
+      if (trimmed.length <= STT_MODEL_MAX_LENGTH) {
+        result.sttModel = trimmed;
+      }
     }
     if (typeof candidate.sttLanguage === 'string') {
-      result.sttLanguage = candidate.sttLanguage.trim();
+      const trimmed = candidate.sttLanguage.trim();
+      if (trimmed.length <= STT_LANGUAGE_MAX_LENGTH) {
+        result.sttLanguage = trimmed;
+      }
     }
     if (typeof candidate.sttSilenceThresholdDb === 'number' && Number.isFinite(candidate.sttSilenceThresholdDb)) {
       result.sttSilenceThresholdDb = Math.max(-100, Math.min(0, candidate.sttSilenceThresholdDb));


### PR DESCRIPTION
This PR persists speech recognition settings through the shared OpenChamber settings flow instead of keeping them only in local browser storage.

Currently STT preferences can diverge between desktop and mobile clients. For example, changing the STT provider, server URL, model, language, or silence detection settings on one device does not reliably apply to another device using the same OpenChamber setup.

Changes included:

* Add STT fields to shared `DesktopSettings`.
* Persist STT settings to local storage when shared settings are loaded.
* Apply incoming shared STT settings to the config store without triggering another settings update loop.
* Send STT setting changes through `updateDesktopSettings(...)` from the config store setters.
* Accept and sanitize STT fields on the server settings helper.
* Support STT defaults from OpenChamber runtime/default settings.

This keeps speech recognition preferences consistent across devices while preserving the existing localStorage behavior as a local fallback.
