### PR TITLE
Fix mobile keyboard resize closing right drawer

### DIFF
--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -276,23 +276,23 @@ export const MainLayout: React.FC = () => {
             const width = window.innerWidth;
             const height = window.innerHeight;
 
-            const shouldCloseRightSidebar = width < RIGHT_SIDEBAR_AUTO_CLOSE_WIDTH;
-            const canAutoOpenRightSidebar = width >= RIGHT_SIDEBAR_AUTO_OPEN_WIDTH;
-
-            if (shouldCloseRightSidebar) {
-                if (state.isRightSidebarOpen) {
-                    setRightSidebarOpen(false);
-                    rightSidebarAutoClosedRef.current = true;
-                }
-            } else if (canAutoOpenRightSidebar && rightSidebarAutoClosedRef.current) {
-                setRightSidebarOpen(true);
-                rightSidebarAutoClosedRef.current = false;
-            }
-
             // Touch devices frequently resize when the on-screen keyboard opens.
-            // Treat bottom-terminal auto-collapse/restore as desktop-only so
-            // keyboard viewport changes do not churn terminal layout state.
+            // Treat panel auto-collapse/restore as desktop-only so keyboard
+            // viewport changes do not churn drawer or terminal layout state.
             if (!isMobile && !isTablet) {
+                const shouldCloseRightSidebar = width < RIGHT_SIDEBAR_AUTO_CLOSE_WIDTH;
+                const canAutoOpenRightSidebar = width >= RIGHT_SIDEBAR_AUTO_OPEN_WIDTH;
+
+                if (shouldCloseRightSidebar) {
+                    if (state.isRightSidebarOpen) {
+                        setRightSidebarOpen(false);
+                        rightSidebarAutoClosedRef.current = true;
+                    }
+                } else if (canAutoOpenRightSidebar && rightSidebarAutoClosedRef.current) {
+                    setRightSidebarOpen(true);
+                    rightSidebarAutoClosedRef.current = false;
+                }
+
                 const shouldCloseBottomTerminal =
                     height < BOTTOM_TERMINAL_AUTO_CLOSE_HEIGHT;
                 const canAutoOpenBottomTerminal =


### PR DESCRIPTION
## Summary

Fixes an issue on touch devices where opening the on-screen keyboard could automatically close the right sidebar / right drawer.

Previously, the responsive auto-collapse logic for the right sidebar was applied on all devices. On mobile browsers, focusing an input and opening the virtual keyboard can trigger a viewport resize event, which caused the right drawer state to be changed unexpectedly.

This change makes the right sidebar auto-collapse / auto-restore behavior desktop-only, matching the existing protection already used for the bottom terminal. As a result, mobile and tablet keyboard viewport changes no longer close the right drawer.

## Changes

- Guard right sidebar auto-collapse / auto-restore with `!isMobile && !isTablet`
- Keep bottom terminal behavior unchanged
- Avoid changing mobile drawer state during virtual keyboard resize events

## Manual testing

- Open OpenChamber on a mobile device
- Open the right drawer/sidebar
- Focus the chat input so the on-screen keyboard appears
- Verify that the right drawer remains open
- Verify that desktop responsive auto-collapse behavior still works when resizing the browser window