### PR TITLE
fix(ui): clamp text loop index

### DIFF
--- a/packages/ui/src/components/ui/TextLoop.tsx
+++ b/packages/ui/src/components/ui/TextLoop.tsx
@@ -35,7 +35,19 @@ export function TextLoop({
   const items = Children.toArray(children);
 
   useEffect(() => {
-    if (!trigger) return;
+    setCurrentIndex((current) => {
+      if (items.length === 0) {
+        return current === 0 ? current : 0;
+      }
+      if (!Number.isInteger(current) || current < 0) {
+        return 0;
+      }
+      return current >= items.length ? items.length - 1 : current;
+    });
+  }, [items.length]);
+
+  useEffect(() => {
+    if (!trigger || items.length <= 1) return;
 
     const intervalMs = interval * 1000;
     const timer = setInterval(() => {

--- a/packages/ui/src/components/ui/TextLoop.tsx
+++ b/packages/ui/src/components/ui/TextLoop.tsx
@@ -35,16 +35,20 @@ export function TextLoop({
   const items = Children.toArray(children);
 
   useEffect(() => {
-    setCurrentIndex((current) => {
-      if (items.length === 0) {
-        return current === 0 ? current : 0;
-      }
-      if (!Number.isInteger(current) || current < 0) {
-        return 0;
-      }
-      return current >= items.length ? items.length - 1 : current;
-    });
-  }, [items.length]);
+    let next = currentIndex;
+    if (items.length === 0) {
+      next = 0;
+    } else if (!Number.isInteger(currentIndex) || currentIndex < 0) {
+      next = 0;
+    } else if (currentIndex >= items.length) {
+      next = items.length - 1;
+    }
+
+    if (next !== currentIndex) {
+      setCurrentIndex(next);
+      onIndexChange?.(next);
+    }
+  }, [currentIndex, items.length, onIndexChange]);
 
   useEffect(() => {
     if (!trigger || items.length <= 1) return;


### PR DESCRIPTION
## Summary
- Clamp `TextLoop`'s current index when the children list shrinks or becomes empty.
- Skip the rotation interval when there are zero or one items to avoid modulo-by-zero/blank output.

## Validation
- `vet "Fix TextLoop to clamp stale indexes when children change" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`