### PR TITLE
fix(desktop): finish empty app scans

### DIFF
--- a/packages/ui/src/stores/useOpenInAppsStore.ts
+++ b/packages/ui/src/stores/useOpenInAppsStore.ts
@@ -121,7 +121,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
         const shouldRetryEmptyScan = success && !hasCache && installed.length === 0 && retryAttempt < 3;
 
         set({ isCacheStale: hasCache ? isCacheStale : false });
-        applyInstalledApps(installed, !shouldRetryEmptyScan);
+        applyInstalledApps(installed, success ? !shouldRetryEmptyScan : false);
 
         if (success) {
           if (shouldRetryEmptyScan) {

--- a/packages/ui/src/stores/useOpenInAppsStore.ts
+++ b/packages/ui/src/stores/useOpenInAppsStore.ts
@@ -64,9 +64,9 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
     }
     initialized = true;
 
-    const applyInstalledApps = (installed: InstalledDesktopAppInfo[]) => {
+    const applyInstalledApps = (installed: InstalledDesktopAppInfo[], hasLoadedApps = true) => {
       if (!Array.isArray(installed) || installed.length === 0) {
-        set({ availableApps: getAlwaysAvailableApps(), hasLoadedApps: false });
+        set({ availableApps: getAlwaysAvailableApps(), hasLoadedApps });
         return;
       }
 
@@ -118,11 +118,13 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
           isCacheStale,
         } = await fetchDesktopInstalledApps(appNames, force);
 
+        const shouldRetryEmptyScan = success && !hasCache && installed.length === 0 && retryAttempt < 3;
+
         set({ isCacheStale: hasCache ? isCacheStale : false });
-        applyInstalledApps(installed);
+        applyInstalledApps(installed, !shouldRetryEmptyScan);
 
         if (success) {
-          if (!hasCache && installed.length === 0 && retryAttempt < 3) {
+          if (shouldRetryEmptyScan) {
             const delays = [800, 1600, 3200];
             const delay = delays[retryAttempt] ?? 3200;
             retryAttempt += 1;


### PR DESCRIPTION
## Summary
- Preserve the startup retry behavior for empty desktop app scans.
- Mark the Open-In-Apps store as loaded once an empty successful scan has exhausted the retry window.

## Validation
- `vet "Fix Open-In-Apps empty scan loaded state after retries" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`