### PR TITLE
fix(opencode): clear server close timeout

### DIFF
--- a/packages/web/server/lib/opencode/shutdown-runtime.js
+++ b/packages/web/server/lib/opencode/shutdown-runtime.js
@@ -90,20 +90,27 @@ export const createGracefulShutdownRuntime = (dependencies) => {
 
     const server = getServer();
     if (server) {
-      await Promise.race([
-        new Promise((resolve) => {
-          server.close(() => {
-            console.log('HTTP server closed');
-            resolve();
-          });
-        }),
-        new Promise((resolve) => {
-          setTimeout(() => {
-            console.warn('Server close timeout reached, forcing shutdown');
-            resolve();
-          }, shutdownTimeoutMs);
-        }),
-      ]);
+      let closeTimeout = null;
+      try {
+        await Promise.race([
+          new Promise((resolve) => {
+            server.close(() => {
+              console.log('HTTP server closed');
+              resolve();
+            });
+          }),
+          new Promise((resolve) => {
+            closeTimeout = setTimeout(() => {
+              console.warn('Server close timeout reached, forcing shutdown');
+              resolve();
+            }, shutdownTimeoutMs);
+          }),
+        ]);
+      } finally {
+        if (closeTimeout) {
+          clearTimeout(closeTimeout);
+        }
+      }
     }
 
     const uiAuthController = getUiAuthController();

--- a/packages/web/server/lib/opencode/shutdown-runtime.test.js
+++ b/packages/web/server/lib/opencode/shutdown-runtime.test.js
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createGracefulShutdownRuntime } from './shutdown-runtime.js';
+
+const createRuntime = (server) => createGracefulShutdownRuntime({
+  process: { exit: vi.fn() },
+  shutdownTimeoutMs: 1000,
+  getExitOnShutdown: () => false,
+  getIsShuttingDown: () => false,
+  setIsShuttingDown: vi.fn(),
+  syncToHmrState: vi.fn(),
+  openCodeWatcherRuntime: { stop: vi.fn() },
+  sessionRuntime: { dispose: vi.fn() },
+  scheduledTasksRuntime: { stop: vi.fn() },
+  getHealthCheckInterval: () => null,
+  clearHealthCheckInterval: vi.fn(),
+  getTerminalRuntime: () => null,
+  setTerminalRuntime: vi.fn(),
+  getMessageStreamRuntime: () => null,
+  setMessageStreamRuntime: vi.fn(),
+  shouldSkipOpenCodeStop: () => true,
+  getOpenCodePort: () => null,
+  getOpenCodeProcess: () => null,
+  setOpenCodeProcess: vi.fn(),
+  killProcessOnPort: vi.fn(),
+  waitForPortRelease: vi.fn(async () => true),
+  getServer: () => server,
+  getUiAuthController: () => null,
+  setUiAuthController: vi.fn(),
+  getActiveTunnelController: () => null,
+  setActiveTunnelController: vi.fn(),
+  tunnelAuthController: { clearActiveTunnel: vi.fn() },
+});
+
+describe('graceful shutdown runtime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('clears the server close timeout when the server closes first', async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const server = {
+      close: vi.fn((callback) => {
+        callback();
+      }),
+    };
+
+    const runtime = createRuntime(server);
+    await runtime.gracefulShutdown({ exitProcess: false });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(warnSpy).not.toHaveBeenCalledWith('Server close timeout reached, forcing shutdown');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Clear the graceful-shutdown server-close timeout when `server.close()` wins the race.
- Add regression coverage to ensure the stale timeout warning is not emitted after a clean close.

## Validation
- `vet "Clear graceful shutdown server-close timeout when close wins" --agentic --agent-harness claude`
- `vet "Add regression coverage for graceful shutdown server-close timeout cleanup" --agentic --agent-harness claude`
- `bun run --cwd packages/web test server/lib/opencode/shutdown-runtime.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`