### PR TITLE
fix(tasks): avoid weekday checkbox double toggle

### DIFF
--- a/packages/ui/src/components/session/ScheduledTaskEditorDialog.tsx
+++ b/packages/ui/src/components/session/ScheduledTaskEditorDialog.tsx
@@ -1213,7 +1213,7 @@ export function ScheduledTaskEditorDialog(props: {
                         <div
                           key={weekday.value}
                           className={[
-                            'inline-flex items-center gap-1.5 px-0.5 py-0.5 typography-meta',
+                            'group inline-flex items-center gap-1.5 px-0.5 py-0.5 typography-meta',
                             checked ? 'text-foreground' : 'text-muted-foreground',
                           ].join(' ')}
                         >
@@ -1221,7 +1221,7 @@ export function ScheduledTaskEditorDialog(props: {
                           <button
                             type="button"
                             onClick={() => toggleWeekday(weekday.value, !checked)}
-                            className="hover:text-foreground"
+                            className="hover:text-foreground group-hover:text-foreground"
                           >
                             {weekday.label}
                           </button>

--- a/packages/ui/src/components/session/ScheduledTaskEditorDialog.tsx
+++ b/packages/ui/src/components/session/ScheduledTaskEditorDialog.tsx
@@ -1221,7 +1221,7 @@ export function ScheduledTaskEditorDialog(props: {
                           <button
                             type="button"
                             onClick={() => toggleWeekday(weekday.value, !checked)}
-                            className="hover:text-foreground group-hover:text-foreground"
+                            className="group-hover:text-foreground"
                           >
                             {weekday.label}
                           </button>

--- a/packages/ui/src/components/session/ScheduledTaskEditorDialog.tsx
+++ b/packages/ui/src/components/session/ScheduledTaskEditorDialog.tsx
@@ -1210,19 +1210,22 @@ export function ScheduledTaskEditorDialog(props: {
                     {orderedWeekdays.map((weekday) => {
                       const checked = draft.schedule.weekdays.includes(weekday.value);
                       return (
-                        <button
+                        <div
                           key={weekday.value}
-                          type="button"
-                          onClick={() => toggleWeekday(weekday.value, !checked)}
                           className={[
                             'inline-flex items-center gap-1.5 px-0.5 py-0.5 typography-meta',
                             checked ? 'text-foreground' : 'text-muted-foreground',
-                            'hover:text-foreground',
                           ].join(' ')}
                         >
                           <Checkbox checked={checked} onChange={(next) => toggleWeekday(weekday.value, next)} ariaLabel={weekday.label} />
-                          <span>{weekday.label}</span>
-                        </button>
+                          <button
+                            type="button"
+                            onClick={() => toggleWeekday(weekday.value, !checked)}
+                            className="hover:text-foreground"
+                          >
+                            {weekday.label}
+                          </button>
+                        </div>
                       );
                     })}
                   </div>


### PR DESCRIPTION
## Summary
- Remove the nested checkbox-inside-button structure from weekly scheduled-task weekday options.
- Keep checkbox and weekday-text toggles independent so direct checkbox clicks toggle once.

## Validation
- `vet "Fix weekly scheduled task weekday checkbox double-toggle" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`