### PR TITLE
fix(opencode): clear readiness probe timers

### DIFF
--- a/packages/web/server/lib/opencode/network-runtime.js
+++ b/packages/web/server/lib/opencode/network-runtime.js
@@ -29,9 +29,10 @@ export const createOpenCodeNetworkRuntime = (deps) => {
   const waitForReady = async (url, timeoutMs = 10000) => {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
+      let timeout = null;
       try {
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 3000);
+        timeout = setTimeout(() => controller.abort(), 3000);
         const response = await fetch(`${url.replace(/\/+$/, '')}/global/health`, {
           method: 'GET',
           headers: {
@@ -41,6 +42,7 @@ export const createOpenCodeNetworkRuntime = (deps) => {
           signal: controller.signal,
         });
         clearTimeout(timeout);
+        timeout = null;
 
         if (response.ok) {
           const body = await response.json().catch(() => null);
@@ -49,6 +51,10 @@ export const createOpenCodeNetworkRuntime = (deps) => {
           }
         }
       } catch {
+      } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
       }
       await new Promise((resolve) => setTimeout(resolve, 100));
     }

--- a/packages/web/server/lib/opencode/network-runtime.test.js
+++ b/packages/web/server/lib/opencode/network-runtime.test.js
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createOpenCodeNetworkRuntime } from './network-runtime.js';
+
+const createRuntime = () => createOpenCodeNetworkRuntime({
+  state: {
+    openCodePort: 4096,
+    openCodeBaseUrl: null,
+    openCodeApiPrefix: '',
+    openCodeApiPrefixDetected: false,
+    openCodeApiDetectionTimer: null,
+  },
+  getOpenCodeAuthHeaders: () => ({}),
+});
+
+describe('OpenCode network runtime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('clears the probe abort timer when readiness fetch rejects', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('offline');
+    }));
+
+    const runtime = createRuntime();
+    const readyPromise = runtime.waitForReady('http://127.0.0.1:4096', 1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(readyPromise).resolves.toBe(false);
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Clear each OpenCode readiness probe abort timer when `fetch` rejects.
- Add a regression test that verifies rejected probes leave no pending timers.

## Validation
- `vet "Clear OpenCode readiness probe abort timers on fetch rejection" --agentic --agent-harness claude`
- `vet "Add regression coverage for OpenCode readiness timer cleanup" --agentic --agent-harness claude`
- `bun run --cwd packages/web test server/lib/opencode/network-runtime.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`