### PR TITLE
fix(ui): recover from corrupt chunk reload markers

### DIFF
--- a/packages/ui/src/lib/chunkLoadRecovery.test.ts
+++ b/packages/ui/src/lib/chunkLoadRecovery.test.ts
@@ -37,8 +37,8 @@ describe('importWithChunkRecovery', () => {
         caught = error;
       }
 
-      expect(caught instanceof Error).toBe(true);
-      expect(storedMarker === null).toBe(false);
+      expect(caught).toBeInstanceOf(Error);
+      expect(storedMarker).not.toBeNull();
       expect(reloadCount).toBe(1);
     } finally {
       if (previousWindow === undefined) {

--- a/packages/ui/src/lib/chunkLoadRecovery.test.ts
+++ b/packages/ui/src/lib/chunkLoadRecovery.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+
+import { importWithChunkRecovery } from './chunkLoadRecovery';
+
+describe('importWithChunkRecovery', () => {
+  test('schedules recovery reload when stored reload marker is corrupt', async () => {
+    const globalWithWindow = globalThis as unknown as { window?: unknown };
+    const previousWindow = globalWithWindow.window;
+    let storedMarker: string | null = null;
+    let reloadCount = 0;
+
+    globalWithWindow.window = {
+      sessionStorage: {
+        getItem: () => '{not json',
+        setItem: (_key: string, value: string) => {
+          storedMarker = value;
+        },
+      },
+      setTimeout: (callback: () => void) => {
+        callback();
+        return 0;
+      },
+      location: {
+        reload: () => {
+          reloadCount += 1;
+        },
+      },
+    };
+
+    try {
+      let caught: unknown;
+      try {
+        await importWithChunkRecovery(async () => {
+          throw new Error('Failed to fetch dynamically imported module');
+        }, { retries: 0 });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught instanceof Error).toBe(true);
+      expect(storedMarker === null).toBe(false);
+      expect(reloadCount).toBe(1);
+    } finally {
+      if (previousWindow === undefined) {
+        delete globalWithWindow.window;
+      } else {
+        globalWithWindow.window = previousWindow;
+      }
+    }
+  });
+});

--- a/packages/ui/src/lib/chunkLoadRecovery.ts
+++ b/packages/ui/src/lib/chunkLoadRecovery.ts
@@ -46,13 +46,26 @@ function scheduleReloadOnce(error: unknown): void {
   const now = Date.now();
   const signature = reloadMarkerSignature(error);
 
+  let marker: { signature?: unknown; timestamp?: unknown } | null = null;
   try {
     const rawMarker = window.sessionStorage.getItem(RELOAD_STORAGE_KEY);
-    const marker = rawMarker ? JSON.parse(rawMarker) as { signature?: unknown; timestamp?: unknown } : null;
-    const markerTimestamp = typeof marker?.timestamp === 'number' ? marker.timestamp : 0;
-    if (marker?.signature === signature && now - markerTimestamp < RELOAD_GUARD_MS) {
-      return;
+    if (rawMarker) {
+      try {
+        marker = JSON.parse(rawMarker) as { signature?: unknown; timestamp?: unknown };
+      } catch {
+        marker = null;
+      }
     }
+  } catch {
+    return;
+  }
+
+  const markerTimestamp = typeof marker?.timestamp === 'number' ? marker.timestamp : 0;
+  if (marker?.signature === signature && now - markerTimestamp < RELOAD_GUARD_MS) {
+    return;
+  }
+
+  try {
     window.sessionStorage.setItem(RELOAD_STORAGE_KEY, JSON.stringify({ signature, timestamp: now }));
   } catch {
     return;

--- a/packages/ui/src/types/bun-test.d.ts
+++ b/packages/ui/src/types/bun-test.d.ts
@@ -15,10 +15,12 @@ declare module "bun:test" {
     toBeGreaterThan(expected: number): void;
     toBeLessThan(expected: number): void;
     toHaveLength(expected: number): void;
+    toBeInstanceOf(expected: unknown): void;
     not: {
       toEqual(expected: unknown): void;
       toBe(expected: unknown): void;
       toContain(expected: unknown): void;
+      toBeNull(): void;
     };
   };
   export function beforeEach(fn: () => void | Promise<void>): void;


### PR DESCRIPTION
## Summary
- Ignore corrupt chunk-reload session storage markers instead of aborting recovery.
- Add a focused regression test for scheduling reload after a malformed marker.

## Validation
- vet "recover chunk reload after corrupt session storage marker" --agentic --agent-harness claude
- bun test packages/ui/src/lib/chunkLoadRecovery.test.ts
- bun run type-check
- bun run lint
- git diff --check