### PR TITLE
fix(sync): fetch sessions in active directory

### DIFF
--- a/packages/ui/src/sync/use-sync.ts
+++ b/packages/ui/src/sync/use-sync.ts
@@ -189,7 +189,7 @@ export function useSync() {
   const fetchMessages = useCallback(
     async (sessionID: string, limit: number, before?: string) => {
       const result = await retry(() =>
-        sdk.session.messages({ sessionID, limit, before }),
+        sdk.session.messages({ sessionID, directory, limit, before }),
       )
       const items = (result.data ?? []).filter((x: { info?: { id?: string } }) => !!x?.info?.id)
       const session = items
@@ -202,7 +202,7 @@ export function useSync() {
       const cursor = result.response?.headers?.get?.("x-next-cursor") ?? undefined
       return { session, part, cursor, complete: !cursor }
     },
-    [sdk],
+    [sdk, directory],
   )
 
   // Load messages for a session
@@ -286,7 +286,7 @@ export function useSync() {
         // Fetch session info if needed
         if (!hasSession || force) {
           try {
-            const result = await retry(() => sdk.session.get({ sessionID }))
+            const result = await retry(() => sdk.session.get({ sessionID, directory }))
             if (result.data) {
               const s = store.getState()
               const sessions = [...s.session]


### PR DESCRIPTION
## Summary
- Pass the active sync directory to session metadata and message fetches.
- Keep fetch dependencies aligned with the directory-scoped cache keys.

## Validation
- vet "scope sync session fetches to the active directory" --agentic --agent-harness claude
- bun run type-check
- bun run lint
- git diff --check
- bun test packages/ui/src/sync (currently fails unrelated event-pipeline coalescing expectations in packages/ui/src/sync/__tests__/event-pipeline.test.js)