### PR TITLE
fix(sync): advance sidebar recency after streams

### DIFF
--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1669,7 +1669,7 @@ export function useSidebarSessions(directory?: string): Session[] {
       const wasStreaming = cached?.streamingById.get(session.id) ?? false
       const stableUpdatedAt = isStreaming
         ? (wasStreaming ? cachedUpdatedAt : Math.max(rawUpdatedAt, cachedUpdatedAt, Date.now()))
-        : cachedUpdatedAt
+        : Math.max(rawUpdatedAt, cachedUpdatedAt)
       const signature = getSidebarSessionSignature(session, stableUpdatedAt)
       signatures.set(session.id, signature)
       stableUpdatedAtById.set(session.id, stableUpdatedAt)


### PR DESCRIPTION
## Summary
- Let sidebar session recency advance from authoritative session timestamps after streaming stops.
- Preserve the existing no-backwards behavior while avoiding permanently stale cached recency.

## Validation
- vet "allow sidebar recency cache to advance after streaming stops" --agentic --agent-harness claude
- bun run type-check
- bun run lint
- git diff --check