### PR TITLE
fix(terminal): remove upgrade listener on shutdown

### DIFF
--- a/packages/web/server/lib/terminal/runtime.js
+++ b/packages/web/server/lib/terminal/runtime.js
@@ -385,7 +385,7 @@ export function createTerminalRuntime({
     });
   });
 
-  server.on('upgrade', (req, socket, head) => {
+  const upgradeHandler = (req, socket, head) => {
     const pathname = parseRequestPathname(req.url);
     if (pathname !== TERMINAL_INPUT_WS_PATH) {
       return;
@@ -422,7 +422,9 @@ export function createTerminalRuntime({
     };
 
     void handleUpgrade();
-  });
+  };
+
+  server.on('upgrade', upgradeHandler);
 
   const wireTerminalSession = (sessionId, session) => {
     session.ptyProcess.onData((data) => {
@@ -791,6 +793,8 @@ export function createTerminalRuntime({
   });
 
   const shutdown = async () => {
+    server.off('upgrade', upgradeHandler);
+
     if (idleSweepInterval) {
       clearInterval(idleSweepInterval);
     }

--- a/packages/web/server/lib/terminal/runtime.test.js
+++ b/packages/web/server/lib/terminal/runtime.test.js
@@ -1,0 +1,44 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { createTerminalRuntime } from './runtime.js';
+
+function createRuntime(server) {
+  const app = {
+    post() {},
+    get() {},
+    delete() {},
+  };
+
+  return createTerminalRuntime({
+    app,
+    server,
+    express: { text: () => (_req, _res, next) => next?.() },
+    fs,
+    path,
+    uiAuthController: null,
+    buildAugmentedPath: () => process.env.PATH || '',
+    searchPathFor: () => null,
+    isExecutable: () => false,
+    isRequestOriginAllowed: async () => true,
+    rejectWebSocketUpgrade() {},
+    TERMINAL_INPUT_WS_HEARTBEAT_INTERVAL_MS: 30_000,
+    TERMINAL_INPUT_WS_REBIND_WINDOW_MS: 1_000,
+    TERMINAL_INPUT_WS_MAX_REBINDS_PER_WINDOW: 3,
+  });
+}
+
+describe('terminal runtime', () => {
+  it('removes its websocket upgrade listener on shutdown', async () => {
+    const server = new EventEmitter();
+    const runtime = createRuntime(server);
+
+    expect(server.listenerCount('upgrade')).toBe(1);
+
+    await runtime.shutdown();
+
+    expect(server.listenerCount('upgrade')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Keep the terminal WebSocket upgrade handler in a named function.
- Remove that handler during runtime shutdown to avoid stale upgrade listeners after recreation.
- Add a focused runtime test for listener cleanup.

## Validation
- vet "remove terminal websocket upgrade listener during shutdown" --agentic --agent-harness claude
- bun run --cwd packages/web test -- server/lib/terminal/runtime.test.js
- bun run type-check
- bun run lint
- git diff --check