### PR TITLE
fix(terminal): make SSE cleanup idempotent

### DIFF
--- a/packages/web/server/lib/terminal/runtime.js
+++ b/packages/web/server/lib/terminal/runtime.js
@@ -570,6 +570,34 @@ export function createTerminalRuntime({
       }
     }, 15000);
 
+    let cleanedUp = false;
+    let dataDisposable = null;
+    let exitDisposable = null;
+    const cleanup = () => {
+      if (cleanedUp) {
+        return;
+      }
+
+      cleanedUp = true;
+      clearInterval(heartbeatInterval);
+      session.clients.delete(clientId);
+
+      if (dataDisposable && typeof dataDisposable.dispose === 'function') {
+        dataDisposable.dispose();
+      }
+      if (exitDisposable && typeof exitDisposable.dispose === 'function') {
+        exitDisposable.dispose();
+      }
+
+      try {
+        res.end();
+      } catch (error) {
+
+      }
+
+      console.log(`Client ${clientId} disconnected from terminal session ${sessionId}`);
+    };
+
     const dataHandler = (data) => {
       try {
         session.lastActivity = Date.now();
@@ -598,28 +626,15 @@ export function createTerminalRuntime({
       cleanup();
     };
 
-    const dataDisposable = session.ptyProcess.onData(dataHandler);
-    const exitDisposable = session.ptyProcess.onExit(exitHandler);
+    dataDisposable = session.ptyProcess.onData(dataHandler);
+    if (cleanedUp && dataDisposable && typeof dataDisposable.dispose === 'function') {
+      dataDisposable.dispose();
+    }
 
-    const cleanup = () => {
-      clearInterval(heartbeatInterval);
-      session.clients.delete(clientId);
-
-      if (dataDisposable && typeof dataDisposable.dispose === 'function') {
-        dataDisposable.dispose();
-      }
-      if (exitDisposable && typeof exitDisposable.dispose === 'function') {
-        exitDisposable.dispose();
-      }
-
-      try {
-        res.end();
-      } catch (error) {
-
-      }
-
-      console.log(`Client ${clientId} disconnected from terminal session ${sessionId}`);
-    };
+    exitDisposable = session.ptyProcess.onExit(exitHandler);
+    if (cleanedUp && exitDisposable && typeof exitDisposable.dispose === 'function') {
+      exitDisposable.dispose();
+    }
 
     req.on('close', cleanup);
     req.on('error', cleanup);


### PR DESCRIPTION
## Summary
- Define terminal SSE cleanup before PTY listener registration.
- Make cleanup idempotent and immediately dispose listeners if a synchronous callback already closed the stream.

## Validation
- vet "make terminal SSE cleanup idempotent during PTY callback registration" --agentic --agent-harness claude
- bun run --cwd packages/web test -- server/lib/terminal/terminal-ws-protocol.test.js server/lib/terminal/output-replay-buffer.test.js
- bun run type-check
- bun run lint
- git diff --check