### PR TITLE
fix(event-stream): isolate subscriber failures

### DIFF
--- a/packages/web/server/lib/event-stream/global-hub.js
+++ b/packages/web/server/lib/event-stream/global-hub.js
@@ -24,7 +24,12 @@ export function createGlobalMessageStreamHub({
 
   const notifySubscriber = (kind, subscriber, payload) => {
     try {
-      subscriber(payload);
+      const result = subscriber(payload);
+      if (result && typeof result.catch === 'function') {
+        result.catch((error) => {
+          console.warn(`Global message stream ${kind} subscriber failed:`, error);
+        });
+      }
     } catch (error) {
       console.warn(`Global message stream ${kind} subscriber failed:`, error);
     }

--- a/packages/web/server/lib/event-stream/global-hub.js
+++ b/packages/web/server/lib/event-stream/global-hub.js
@@ -22,9 +22,17 @@ export function createGlobalMessageStreamHub({
   let everConnected = false;
   let buildUrlFailed = false;
 
+  const notifySubscriber = (kind, subscriber, payload) => {
+    try {
+      subscriber(payload);
+    } catch (error) {
+      console.warn(`Global message stream ${kind} subscriber failed:`, error);
+    }
+  };
+
   const notifyStatus = (status) => {
     for (const subscriber of Array.from(statusSubscribers)) {
-      subscriber(status);
+      notifySubscriber('status', subscriber, status);
     }
   };
 
@@ -81,7 +89,7 @@ export function createGlobalMessageStreamHub({
         }
 
         for (const subscriber of Array.from(eventSubscribers)) {
-          subscriber(normalized);
+          notifySubscriber('event', subscriber, normalized);
         }
       },
       onError(error) {

--- a/packages/web/server/lib/event-stream/global-hub.test.js
+++ b/packages/web/server/lib/event-stream/global-hub.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createGlobalMessageStreamHub } from './global-hub.js';
 
-function createSseResponse({ blocks = [] }) {
+function createSseResponse({ blocks = [] } = {}) {
   const encoder = new TextEncoder();
   let index = 0;
 
@@ -21,6 +21,23 @@ function createSseResponse({ blocks = [] }) {
       },
     },
   };
+}
+
+async function waitForAssertion(assertion) {
+  const deadline = Date.now() + 1000;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  throw lastError;
 }
 
 describe('createGlobalMessageStreamHub', () => {
@@ -47,10 +64,74 @@ describe('createGlobalMessageStreamHub', () => {
 
     try {
       hub.start();
-      await vi.waitFor(() => {
+      await waitForAssertion(() => {
         expect(received).toEqual(['evt-1']);
       });
       expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      hub.stop();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('continues status fanout when a status subscriber throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const received = [];
+    const hub = createGlobalMessageStreamHub({
+      buildOpenCodeUrl: (pathname) => `http://127.0.0.1:4096${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      upstreamReconnectDelayMs: 100,
+      fetchImpl: async () => createSseResponse(),
+    });
+
+    hub.subscribeStatus(() => {
+      throw new Error('status subscriber failed');
+    });
+    hub.subscribeStatus((status) => {
+      received.push(status.type);
+    });
+
+    try {
+      hub.start();
+      await waitForAssertion(() => {
+        expect(received).toContain('connect');
+      });
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      hub.stop();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('continues fanout when an async event subscriber rejects', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const received = [];
+    const hub = createGlobalMessageStreamHub({
+      buildOpenCodeUrl: (pathname) => `http://127.0.0.1:4096${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      upstreamReconnectDelayMs: 100,
+      fetchImpl: async () => createSseResponse({
+        blocks: [
+          'id: evt-1\ndata: {"type":"session.updated","properties":{}}\n\n',
+        ],
+      }),
+    });
+
+    hub.subscribeEvent(async () => {
+      throw new Error('async subscriber failed');
+    });
+    hub.subscribeEvent((event) => {
+      received.push(event.eventId);
+    });
+
+    try {
+      hub.start();
+      await waitForAssertion(() => {
+        expect(received).toEqual(['evt-1']);
+      });
+      await waitForAssertion(() => {
+        expect(warnSpy).toHaveBeenCalled();
+      });
     } finally {
       hub.stop();
       warnSpy.mockRestore();

--- a/packages/web/server/lib/event-stream/global-hub.test.js
+++ b/packages/web/server/lib/event-stream/global-hub.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGlobalMessageStreamHub } from './global-hub.js';
+
+function createSseResponse({ blocks = [] }) {
+  const encoder = new TextEncoder();
+  let index = 0;
+
+  return {
+    ok: true,
+    body: {
+      getReader() {
+        return {
+          async read() {
+            if (index < blocks.length) {
+              return { value: encoder.encode(blocks[index++]), done: false };
+            }
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe('createGlobalMessageStreamHub', () => {
+  it('continues fanout when an event subscriber throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const received = [];
+    const hub = createGlobalMessageStreamHub({
+      buildOpenCodeUrl: (pathname) => `http://127.0.0.1:4096${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      upstreamReconnectDelayMs: 100,
+      fetchImpl: async () => createSseResponse({
+        blocks: [
+          'id: evt-1\ndata: {"type":"session.updated","properties":{}}\n\n',
+        ],
+      }),
+    });
+
+    hub.subscribeEvent(() => {
+      throw new Error('subscriber failed');
+    });
+    hub.subscribeEvent((event) => {
+      received.push(event.eventId);
+    });
+
+    try {
+      hub.start();
+      await vi.waitFor(() => {
+        expect(received).toEqual(['evt-1']);
+      });
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      hub.stop();
+      warnSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap global message stream event/status subscriber callbacks so one throw does not block fanout.
- Log failed subscribers and add regression coverage for event fanout continuing after a throw.

## Validation
- vet "isolate global event stream subscribers during fanout" --agentic --agent-harness claude
- bun run --cwd packages/web test -- server/lib/event-stream/global-hub.test.js
- bun run type-check
- bun run lint
- git diff --check