### PR TITLE
fix(ui): label session rename buttons

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -473,8 +473,23 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
                 }
               }}
             />
-            <button type="submit" className="shrink-0 text-muted-foreground hover:text-foreground"><RiCheckLine className="size-4" /></button>
-            <button type="button" onClick={handleCancelEdit} className="shrink-0 text-muted-foreground hover:text-foreground"><RiCloseLine className="size-4" /></button>
+            <button
+              type="submit"
+              aria-label={t('sessions.sidebar.session.rename.save')}
+              title={t('sessions.sidebar.session.rename.save')}
+              className="shrink-0 text-muted-foreground hover:text-foreground"
+            >
+              <RiCheckLine className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={handleCancelEdit}
+              aria-label={t('sessions.sidebar.session.rename.cancel')}
+              title={t('sessions.sidebar.session.rename.cancel')}
+              className="shrink-0 text-muted-foreground hover:text-foreground"
+            >
+              <RiCloseLine className="size-4" />
+            </button>
           </form>
           {!isMinimalMode ? (
             <div className="flex items-center justify-between gap-3 text-muted-foreground/60 min-w-0 overflow-hidden leading-tight" style={{ fontSize: 'calc(var(--text-ui-label) * 0.85)' }}>

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -231,6 +231,8 @@ export const dict = {
   'sessions.sidebar.project.actions.closeProject': 'Close project',
   'sessions.sidebar.project.actions.newDraftSession': 'New draft session',
   'sessions.sidebar.session.menu.rename': 'Rename',
+  'sessions.sidebar.session.rename.save': 'Save session name',
+  'sessions.sidebar.session.rename.cancel': 'Cancel renaming session',
   'sessions.sidebar.session.menu.unpin': 'Unpin session',
   'sessions.sidebar.session.menu.pin': 'Pin session',
   'sessions.sidebar.session.menu.share': 'Share',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -232,6 +232,8 @@ export const dict: Record<I18nKey, string> = {
   "sessions.sidebar.project.actions.closeProject": "Cerrar proyecto",
   "sessions.sidebar.project.actions.newDraftSession": "Nueva sesión de borrador",
   "sessions.sidebar.session.menu.rename": "Cambiar nombre",
+  "sessions.sidebar.session.rename.save": "Guardar nombre de sesión",
+  "sessions.sidebar.session.rename.cancel": "Cancelar cambio de nombre de sesión",
   "sessions.sidebar.session.menu.unpin": "Desanclar sesión",
   "sessions.sidebar.session.menu.pin": "Anclar sesión",
   "sessions.sidebar.session.menu.share": "Compartir",

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -232,6 +232,8 @@ export const dict: Record<I18nKey, string> = {
   'sessions.sidebar.project.actions.closeProject': '프로젝트 닫기',
   'sessions.sidebar.project.actions.newDraftSession': '새 드래프트 세션',
   'sessions.sidebar.session.menu.rename': '이름 변경',
+  'sessions.sidebar.session.rename.save': '세션 이름 저장',
+  'sessions.sidebar.session.rename.cancel': '세션 이름 변경 취소',
   'sessions.sidebar.session.menu.unpin': '세션 고정 해제',
   'sessions.sidebar.session.menu.pin': '세션 고정',
   'sessions.sidebar.session.menu.share': '공유',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -75,6 +75,8 @@ export const dict: Record<I18nKey, string> = {
   'sessions.sidebar.project.actions.closeProject': 'Zamknij projekt',
   'sessions.sidebar.project.actions.newDraftSession': 'Nowa sesja robocza',
   'sessions.sidebar.session.menu.rename': 'Zmień nazwę',
+  'sessions.sidebar.session.rename.save': 'Zapisz nazwę sesji',
+  'sessions.sidebar.session.rename.cancel': 'Anuluj zmianę nazwy sesji',
   'sessions.sidebar.session.menu.unpin': 'Odepnij sesję',
   'sessions.sidebar.session.menu.pin': 'Przypnij sesję',
   'sessions.sidebar.session.menu.share': 'Udostępnij',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -232,6 +232,8 @@ export const dict: Record<I18nKey, string> = {
   "sessions.sidebar.project.actions.closeProject": "Fechar projeto",
   "sessions.sidebar.project.actions.newDraftSession": "Nova sessão de rascunho",
   "sessions.sidebar.session.menu.rename": "Renomear",
+  "sessions.sidebar.session.rename.save": "Salvar nome da sessão",
+  "sessions.sidebar.session.rename.cancel": "Cancelar renomeação da sessão",
   "sessions.sidebar.session.menu.unpin": "Desfixar sessão",
   "sessions.sidebar.session.menu.pin": "Fixar sessão",
   "sessions.sidebar.session.menu.share": "Compartilhar",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -232,6 +232,8 @@ export const dict: Record<I18nKey, string> = {
   "sessions.sidebar.project.actions.closeProject": "Закрити проєкт",
   "sessions.sidebar.project.actions.newDraftSession": "Нова чернетка сесії",
   "sessions.sidebar.session.menu.rename": "Перейменувати",
+  "sessions.sidebar.session.rename.save": "Зберегти назву сесії",
+  "sessions.sidebar.session.rename.cancel": "Скасувати перейменування сесії",
   "sessions.sidebar.session.menu.unpin": "Відкріпити сесія",
   "sessions.sidebar.session.menu.pin": "Закріпити сесія",
   "sessions.sidebar.session.menu.share": "Поділитися",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -232,6 +232,8 @@ export const dict: Record<I18nKey, string> = {
   'sessions.sidebar.project.actions.closeProject': '关闭项目',
   'sessions.sidebar.project.actions.newDraftSession': '新建草稿会话',
   'sessions.sidebar.session.menu.rename': '重命名',
+  'sessions.sidebar.session.rename.save': '保存会话名称',
+  'sessions.sidebar.session.rename.cancel': '取消重命名会话',
   'sessions.sidebar.session.menu.unpin': '取消置顶会话',
   'sessions.sidebar.session.menu.pin': '置顶会话',
   'sessions.sidebar.session.menu.share': '分享',


### PR DESCRIPTION
## Summary
- Add localized accessible names and titles to the icon-only session rename save/cancel buttons.
- Add matching strings across supported locale dictionaries.

## Validation
- vet "label session rename icon buttons for assistive technology" --agentic --agent-harness claude
- bun run type-check
- bun run lint
- git diff --check