### PR TITLE
fix(quota): accept epoch reset timestamps

### DIFF
--- a/packages/web/server/lib/quota/utils/formatters.js
+++ b/packages/web/server/lib/quota/utils/formatters.js
@@ -27,8 +27,10 @@ export const formatResetTime = (timestamp) => {
   }
 };
 
+const hasResetTimestamp = (resetAt) => resetAt !== null && resetAt !== undefined && resetAt !== '';
+
 export const calculateResetAfterSeconds = (resetAt) => {
-  if (resetAt === null || resetAt === undefined || resetAt === '') return null;
+  if (!hasResetTimestamp(resetAt)) return null;
   const resetAtTime = new Date(resetAt).getTime();
   if (!Number.isFinite(resetAtTime)) return null;
   const delta = Math.floor((resetAtTime - Date.now()) / 1000);
@@ -37,7 +39,7 @@ export const calculateResetAfterSeconds = (resetAt) => {
 
 export const toUsageWindow = ({ usedPercent, windowSeconds, resetAt, valueLabel }) => {
   const resetAfterSeconds = calculateResetAfterSeconds(resetAt);
-  const resetFormatted = resetAt ? formatResetTime(resetAt) : null;
+  const resetFormatted = hasResetTimestamp(resetAt) ? formatResetTime(resetAt) : null;
   return {
     usedPercent,
     remainingPercent: usedPercent !== null ? Math.max(0, 100 - usedPercent) : null,

--- a/packages/web/server/lib/quota/utils/formatters.js
+++ b/packages/web/server/lib/quota/utils/formatters.js
@@ -28,7 +28,7 @@ export const formatResetTime = (timestamp) => {
 };
 
 export const calculateResetAfterSeconds = (resetAt) => {
-  if (!resetAt) return null;
+  if (resetAt === null || resetAt === undefined || resetAt === '') return null;
   const resetAtTime = new Date(resetAt).getTime();
   if (!Number.isFinite(resetAtTime)) return null;
   const delta = Math.floor((resetAtTime - Date.now()) / 1000);

--- a/packages/web/server/lib/quota/utils/formatters.test.js
+++ b/packages/web/server/lib/quota/utils/formatters.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { calculateResetAfterSeconds, formatResetTime } from './formatters.js';
+import { calculateResetAfterSeconds, formatResetTime, toUsageWindow } from './formatters.js';
 
 describe('formatResetTime', () => {
   it('returns null for invalid timestamps', () => {
@@ -21,5 +21,15 @@ describe('calculateResetAfterSeconds', () => {
     expect(calculateResetAfterSeconds(NaN)).toBeNull();
     expect(calculateResetAfterSeconds(Infinity)).toBeNull();
     expect(calculateResetAfterSeconds(-Infinity)).toBeNull();
+  });
+});
+
+describe('toUsageWindow', () => {
+  it('formats epoch reset timestamps', () => {
+    const usageWindow = toUsageWindow({ resetAt: 0 });
+
+    expect(usageWindow.resetAfterSeconds).toBe(0);
+    expect(usageWindow.resetAtFormatted).toBe(formatResetTime(0));
+    expect(usageWindow.resetAfterFormatted).toBe(formatResetTime(0));
   });
 });

--- a/packages/web/server/lib/quota/utils/formatters.test.js
+++ b/packages/web/server/lib/quota/utils/formatters.test.js
@@ -12,6 +12,10 @@ describe('formatResetTime', () => {
 });
 
 describe('calculateResetAfterSeconds', () => {
+  it('accepts an epoch reset timestamp', () => {
+    expect(calculateResetAfterSeconds(0)).toBe(0);
+  });
+
   it('returns null for invalid timestamps', () => {
     expect(calculateResetAfterSeconds('not-a-date')).toBeNull();
     expect(calculateResetAfterSeconds(NaN)).toBeNull();


### PR DESCRIPTION
## Summary
- Treat `0` as a valid quota reset timestamp instead of a missing value.
- Add focused formatter coverage for epoch reset handling.

## Validation
- `vet "Ensure quota reset epoch timestamps are handled without changing invalid timestamp behavior" --agentic --agent-harness claude`
- `bun run --cwd packages/web test -- server/lib/quota/utils/formatters.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`