### PR TITLE
test(opencode): restore missing PATH cleanly

### DIFF
--- a/packages/web/server/lib/opencode/server-utils-runtime.test.js
+++ b/packages/web/server/lib/opencode/server-utils-runtime.test.js
@@ -7,6 +7,11 @@ import { createServerUtilsRuntime } from './server-utils-runtime.js';
 const originalPath = process.env.PATH;
 
 afterEach(() => {
+  if (originalPath === undefined) {
+    delete process.env.PATH;
+    return;
+  }
+
   process.env.PATH = originalPath;
 });
 


### PR DESCRIPTION
## Summary
- Restore `process.env.PATH` in server-utils tests without assigning `undefined`.
- Prevent test cleanup from leaking a stringified `undefined` PATH when the variable was originally absent.

## Validation
- `vet "Ensure server-utils tests restore PATH without creating an undefined string value" --agentic --agent-harness claude`
- `bun run --cwd packages/web test -- server/lib/opencode/server-utils-runtime.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`