### PR TITLE
fix(vscode): sync agent manager settings saves

### DIFF
--- a/packages/vscode/src/AgentManagerPanelProvider.ts
+++ b/packages/vscode/src/AgentManagerPanelProvider.ts
@@ -125,6 +125,18 @@ export class AgentManagerPanelProvider {
     this._sendCachedState();
   }
 
+  public notifySettingsSynced(settings: unknown): void {
+    if (!this._panel) {
+      return;
+    }
+
+    this._panel.webview.postMessage({
+      type: 'command',
+      command: 'settingsSynced',
+      payload: settings,
+    });
+  }
+
   private _sendCachedState() {
     if (!this._panel) {
       return;

--- a/packages/vscode/src/AgentManagerPanelProvider.ts
+++ b/packages/vscode/src/AgentManagerPanelProvider.ts
@@ -97,6 +97,10 @@ export class AgentManagerPanelProvider {
         context: this._context,
       });
       this._panel?.webview.postMessage(response);
+
+      if (message.type === 'api:config/settings:save' && response.success) {
+        void vscode.commands.executeCommand('openchamber.internal.settingsSynced', response.data);
+      }
     }, null, this._context.subscriptions);
   }
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -193,6 +193,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('openchamber.internal.settingsSynced', (settings: unknown) => {
       chatViewProvider?.notifySettingsSynced(settings);
       sessionEditorProvider?.notifySettingsSynced(settings);
+      agentManagerProvider?.notifySettingsSynced(settings);
     })
   );
 


### PR DESCRIPTION
## Summary
- Broadcast the internal settings-sync command after successful Agent Manager settings saves.
- Align Agent Manager behavior with Chat and Session Editor webviews.

## Validation
- `vet "Ensure VS Code Agent Manager broadcasts settings sync after successful settings saves" --agentic --agent-harness claude`
- `bun run --cwd packages/vscode type-check`
- `bun run type-check`
- `bun run lint`
- `git diff --check`