### PR TITLE
fix(scheduled-tasks): skip scheduling after stop

### DIFF
--- a/packages/web/server/lib/scheduled-tasks/runtime.js
+++ b/packages/web/server/lib/scheduled-tasks/runtime.js
@@ -272,6 +272,10 @@ export const createScheduledTasksRuntime = (deps) => {
     const taskKey = buildTaskKey(projectID, taskID);
     clearTimerForKey(taskKey);
 
+    if (!started) {
+      return;
+    }
+
     if (!Number.isFinite(nextRunAt) || nextRunAt <= 0) {
       return;
     }


### PR DESCRIPTION
## Summary
- Guard scheduled-task timer creation when the runtime is stopped.
- Prevent late internal callers, including finishing in-flight runs, from recreating timers after shutdown.

## Validation
- `vet "Ensure scheduled-task runtime does not create timers after stop" --agentic --agent-harness claude`
- `bun run --cwd packages/web test -- server/lib/scheduled-tasks/runtime.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`