### PR TITLE
Fix(queue): auto-send queued messages FIFO

### DIFF
--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { buildQueuedAutoSendPayload } from './useQueuedMessageAutoSend';
+import type { QueuedMessage } from '../stores/messageQueueStore';
+
+describe('buildQueuedAutoSendPayload', () => {
+  test('returns only the first queued message for auto-send', () => {
+    const queue: QueuedMessage[] = [
+      {
+        id: 'queued-1',
+        content: 'first queued message',
+        createdAt: 1,
+      },
+      {
+        id: 'queued-2',
+        content: 'second queued message',
+        createdAt: 2,
+      },
+    ];
+
+    const payload = buildQueuedAutoSendPayload(queue);
+
+    expect(payload).not.toBeNull();
+    expect(payload?.queuedMessageId).toBe('queued-1');
+    expect(payload?.primaryText).toBe('first queued message');
+    expect(payload?.primaryAttachments).toEqual([]);
+  });
+
+  test('preserves attachment-only queued messages as sendable payloads', () => {
+    const queue: QueuedMessage[] = [
+      {
+        id: 'queued-attachments',
+        content: '',
+        createdAt: 1,
+        attachments: [
+          {
+            id: 'file-1',
+            filename: 'notes.txt',
+            mimeType: 'text/plain',
+            size: 5,
+            source: 'local',
+            file: new File(['hello'], 'notes.txt', { type: 'text/plain' }),
+            dataUrl: 'data:text/plain;base64,aGVsbG8=',
+          },
+        ],
+      },
+      {
+        id: 'queued-2',
+        content: 'later queued message',
+        createdAt: 2,
+      },
+    ];
+
+    const payload = buildQueuedAutoSendPayload(queue);
+
+    expect(payload).not.toBeNull();
+    expect(payload?.queuedMessageId).toBe('queued-attachments');
+    expect(payload?.primaryText).toBe('');
+    expect(payload?.primaryAttachments).toHaveLength(1);
+    expect(payload?.primaryAttachments[0]?.filename).toBe('notes.txt');
+  });
+});

--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
@@ -47,7 +47,9 @@ describe('buildQueuedAutoSendPayload', () => {
     visibleAgents = [
       {
         name: 'Builder',
-        mode: 'secondary',
+        mode: 'subagent',
+        permission: [],
+        options: {},
       } as Agent,
     ];
 

--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
@@ -1,8 +1,26 @@
-import { describe, expect, test } from 'bun:test';
-import { buildQueuedAutoSendPayload } from './useQueuedMessageAutoSend';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { Agent } from '@opencode-ai/sdk/v2';
 import type { QueuedMessage } from '../stores/messageQueueStore';
 
+let visibleAgents: Agent[] = [];
+
+const getVisibleAgentsMock = mock(() => visibleAgents);
+
+mock.module('@/stores/useConfigStore', () => ({
+  useConfigStore: {
+    getState: () => ({
+      getVisibleAgents: getVisibleAgentsMock,
+    }),
+  },
+}));
+
+import { buildQueuedAutoSendPayload } from './useQueuedMessageAutoSend';
+
 describe('buildQueuedAutoSendPayload', () => {
+  beforeEach(() => {
+    visibleAgents = [];
+  });
+
   test('returns only the first queued message for auto-send', () => {
     const queue: QueuedMessage[] = [
       {
@@ -23,6 +41,29 @@ describe('buildQueuedAutoSendPayload', () => {
     expect(payload?.queuedMessageId).toBe('queued-1');
     expect(payload?.primaryText).toBe('first queued message');
     expect(payload?.primaryAttachments).toEqual([]);
+  });
+
+  test('uses the configured visible agents when parsing queued mentions', () => {
+    visibleAgents = [
+      {
+        name: 'Builder',
+        mode: 'secondary',
+      } as Agent,
+    ];
+
+    const queue: QueuedMessage[] = [
+      {
+        id: 'queued-mention',
+        content: '@Builder please take this',
+        createdAt: 1,
+      },
+    ];
+
+    const payload = buildQueuedAutoSendPayload(queue);
+
+    expect(payload).not.toBeNull();
+    expect(payload?.agentMentionName).toBe('Builder');
+    expect(payload?.primaryText).toBe('@Builder please take this');
   });
 
   test('preserves attachment-only queued messages as sendable payloads', () => {

--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { AttachedFile } from '@/stores/types/sessionTypes';
 import { useMessageQueueStore, type QueuedMessage } from '@/stores/messageQueueStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSelectionStore } from '@/sync/selection-store';
@@ -21,37 +20,21 @@ const hasRecentAbort = (sessionId: string): boolean => {
   return Date.now() - abortRecord.timestamp < RECENT_ABORT_WINDOW_MS;
 };
 
-const buildQueuedPayload = (queue: QueuedMessage[]) => {
-  const agents = useConfigStore.getState().getVisibleAgents();
-  let primaryText = '';
-  let primaryAttachments: AttachedFile[] = [];
-  let agentMentionName: string | undefined;
-  const additionalParts: Array<{ text: string; attachments?: AttachedFile[] }> = [];
-
-  for (let i = 0; i < queue.length; i += 1) {
-    const queued = queue[i];
-    const { sanitizedText, mention } = parseAgentMentions(queued.content, agents);
-
-    if (!agentMentionName && mention?.name) {
-      agentMentionName = mention.name;
-    }
-
-    if (i === 0) {
-      primaryText = sanitizedText;
-      primaryAttachments = queued.attachments ?? [];
-    } else {
-      additionalParts.push({
-        text: sanitizedText,
-        attachments: queued.attachments,
-      });
-    }
+export const buildQueuedAutoSendPayload = (queue: QueuedMessage[]) => {
+  const queued = queue[0];
+  if (!queued) {
+    return null;
   }
 
+  const agents = useConfigStore.getState().getVisibleAgents();
+  const { sanitizedText, mention } = parseAgentMentions(queued.content, agents);
+
   return {
-    primaryText,
-    primaryAttachments,
-    agentMentionName,
-    additionalParts: additionalParts.length > 0 ? additionalParts : undefined,
+    queuedMessageId: queued.id,
+    primaryText: sanitizedText,
+    primaryAttachments: queued.attachments ?? [],
+    agentMentionName: mention?.name,
+    sendConfig: queued.sendConfig,
   };
 };
 
@@ -125,13 +108,16 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
         return;
       }
 
-      const payload = buildQueuedPayload(queueSnapshot);
-      if (!payload.primaryText && payload.primaryAttachments.length === 0 && !payload.additionalParts?.length) {
+      const payload = buildQueuedAutoSendPayload(queueSnapshot);
+      if (!payload) {
+        return;
+      }
+      if (!payload.primaryText && payload.primaryAttachments.length === 0) {
         return;
       }
 
       // Use send config captured at queue time; fall back to current config
-      const captured = queueSnapshot[0]?.sendConfig;
+      const captured = payload.sendConfig;
       const resolved = captured?.providerID && captured?.modelID
         ? captured
         : resolveSessionSendConfig(sessionId);
@@ -149,15 +135,13 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
           resolved.agent,
           payload.primaryAttachments,
           payload.agentMentionName,
-          payload.additionalParts,
+          undefined,
           resolved.variant,
           'normal'
         );
 
         const removeFromQueue = useMessageQueueStore.getState().removeFromQueue;
-        queueSnapshot.forEach((item) => {
-          removeFromQueue(sessionId, item.id);
-        });
+        removeFromQueue(sessionId, payload.queuedMessageId);
       } catch (error) {
         console.warn('[queue] queued auto-send failed:', error);
       } finally {


### PR DESCRIPTION
## Summary
- auto-send only the first queued message when a session becomes idle
- remove only the dispatched queue item instead of flushing the entire queue
- add coverage for FIFO queued auto-send payload selection and attachment-only queued payloads

## Context
- fixes #1253
- current `useQueuedMessageAutoSend` behavior aggregates the entire queue into one send by turning later queued items into `additionalParts`
- this change makes queued auto-send behave like a real FIFO queue instead

## Validation
- local code change prepared and smoke-checked against the deployed OpenChamber instance behavior
- full upstream `bun test` / `bun run type-check` were not completed in this environment because `bun` was unavailable on PATH and dependency installation could not be finished within the session time window