### PR TITLE
fix(ui): preserve runtime worktree source

### DIFF
--- a/packages/ui/src/sync/session-worktree-contract.test.js
+++ b/packages/ui/src/sync/session-worktree-contract.test.js
@@ -238,6 +238,7 @@ describe('resolveSessionWorktreeState', () => {
 
     expect(result.legacy).toBe(false);
     expect(result.worktreeRoot).toBe('/repo/worktrees/feat-a');
+    expect(result.worktreeSource).toBe('existing');
     expect(result.degraded).toBe(false);
   });
 
@@ -657,4 +658,3 @@ describe('getMutationBlockingReasons', () => {
     expect(reasons[0]).toEqual({ reason: 'dirty' });
   });
 });
-

--- a/packages/ui/src/sync/session-worktree-contract.ts
+++ b/packages/ui/src/sync/session-worktree-contract.ts
@@ -104,7 +104,7 @@ export function resolveSessionWorktreeState(
       branch: runtimeResolution.branch ?? metadata?.branch ?? null,
       headState: runtimeResolution.headState ?? 'branch',
       worktreeStatus: runtimeResolution.worktreeStatus ?? 'ready',
-      worktreeSource: runtimeResolution.worktreeSource ?? metadata?.source === 'sdk' ? 'created-for-session' : 'existing',
+      worktreeSource: runtimeResolution.worktreeSource ?? (metadata?.source === 'sdk' ? 'created-for-session' : 'existing'),
       legacy: false,
       degraded: runtimeResolution.degraded,
       attentionReason: runtimeResolution.attentionReason ?? null,


### PR DESCRIPTION
## Summary
- Preserve an explicit `runtimeResolution.worktreeSource` when resolving session worktree state.
- Add targeted coverage for runtime canonicalization returning an existing worktree source.

## Validation
- `vet "preserve explicit runtime worktree source when resolving session worktree state" --agentic --agent-harness claude`
- `bun test packages/ui/src/sync/session-worktree-contract.test.js`
- `bun run type-check`
- `bun run lint`
- `git diff --check`