### PR TITLE
fix: merge skills from both OpenCode and local .agents/skills sources

### DIFF
--- a/packages/web/server/lib/opencode/skill-routes.js
+++ b/packages/web/server/lib/opencode/skill-routes.js
@@ -164,6 +164,24 @@ export const registerSkillRoutes = (app, dependencies) => {
     }
   };
 
+  const mergeDiscoveredSkills = async (directory) => {
+    const [openCodeSkills, localSkills] = await Promise.all([
+      fetchOpenCodeDiscoveredSkills(directory),
+      discoverSkills(directory),
+    ]);
+    // Merge both sources — local skills take precedence, dedup by name
+    const skillMap = new Map();
+    for (const skill of localSkills) {
+      skillMap.set(skill.name, skill);
+    }
+    for (const skill of (openCodeSkills || [])) {
+      if (!skillMap.has(skill.name)) {
+        skillMap.set(skill.name, skill);
+      }
+    }
+    return Array.from(skillMap.values());
+  };
+
   const listGitIdentitiesForResponse = () => {
     try {
       const profiles = getProfiles();
@@ -195,7 +213,7 @@ export const registerSkillRoutes = (app, dependencies) => {
       if (!directory) {
         return res.status(400).json({ error });
       }
-      const skills = (await fetchOpenCodeDiscoveredSkills(directory)) || discoverSkills(directory);
+      const skills = await mergeDiscoveredSkills(directory);
 
       const enrichedSkills = skills.map((skill) => {
         const sources = getSkillSources(skill.name, directory, skill);
@@ -278,7 +296,7 @@ export const registerSkillRoutes = (app, dependencies) => {
       }
 
       const discovered = directory
-        ? ((await fetchOpenCodeDiscoveredSkills(directory)) || discoverSkills(directory))
+        ? await mergeDiscoveredSkills(directory)
         : [];
       const installedByName = new Map(discovered.map((s) => [s.name, s]));
 

--- a/packages/web/server/lib/opencode/skill-routes.js
+++ b/packages/web/server/lib/opencode/skill-routes.js
@@ -171,7 +171,7 @@ export const registerSkillRoutes = (app, dependencies) => {
     ]);
     // Merge both sources — local skills take precedence, dedup by name
     const skillMap = new Map();
-    for (const skill of (localSkills || [])) {
+    for (const skill of localSkills) {
       skillMap.set(skill.name, skill);
     }
     for (const skill of (openCodeSkills || [])) {

--- a/packages/web/server/lib/opencode/skill-routes.js
+++ b/packages/web/server/lib/opencode/skill-routes.js
@@ -522,7 +522,10 @@ export const registerSkillRoutes = (app, dependencies) => {
       if (error) {
         return res.status(400).json({ error });
       }
-      const discoveredSkill = (await fetchOpenCodeDiscoveredSkills(directory))
+      const discoveredSkill = mergeDiscoveredSkills(
+          await fetchOpenCodeDiscoveredSkills(directory),
+          discoverSkills(directory),
+        )
         .find((skill) => skill.name === skillName) || null;
       const sources = getSkillSources(skillName, directory, discoveredSkill);
 
@@ -551,7 +554,10 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = (await fetchOpenCodeDiscoveredSkills(directory))
+      const discoveredSkill = mergeDiscoveredSkills(
+          await fetchOpenCodeDiscoveredSkills(directory),
+          discoverSkills(directory),
+        )
         .find((skill) => skill.name === skillName) || null;
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {
@@ -642,7 +648,10 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = (await fetchOpenCodeDiscoveredSkills(directory))
+      const discoveredSkill = mergeDiscoveredSkills(
+          await fetchOpenCodeDiscoveredSkills(directory),
+          discoverSkills(directory),
+        )
         .find((skill) => skill.name === skillName) || null;
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {
@@ -676,7 +685,10 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = (await fetchOpenCodeDiscoveredSkills(directory))
+      const discoveredSkill = mergeDiscoveredSkills(
+          await fetchOpenCodeDiscoveredSkills(directory),
+          discoverSkills(directory),
+        )
         .find((skill) => skill.name === skillName) || null;
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {

--- a/packages/web/server/lib/opencode/skill-routes.js
+++ b/packages/web/server/lib/opencode/skill-routes.js
@@ -171,7 +171,7 @@ export const registerSkillRoutes = (app, dependencies) => {
     ]);
     // Merge both sources — local skills take precedence, dedup by name
     const skillMap = new Map();
-    for (const skill of localSkills) {
+    for (const skill of (localSkills || [])) {
       skillMap.set(skill.name, skill);
     }
     for (const skill of (openCodeSkills || [])) {
@@ -526,7 +526,7 @@ export const registerSkillRoutes = (app, dependencies) => {
       if (!directory) {
         return res.status(400).json({ error });
       }
-      const discoveredSkill = ((await fetchOpenCodeDiscoveredSkills(directory)) || [])
+      const discoveredSkill = (await mergeDiscoveredSkills(directory))
         .find((skill) => skill.name === skillName) || null;
       const sources = getSkillSources(skillName, directory, discoveredSkill);
 
@@ -555,7 +555,7 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = ((await fetchOpenCodeDiscoveredSkills(directory)) || [])
+      const discoveredSkill = (await mergeDiscoveredSkills(directory))
         .find((skill) => skill.name === skillName) || null;
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {
@@ -644,7 +644,7 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = ((await fetchOpenCodeDiscoveredSkills(directory)) || [])
+      const discoveredSkill = (await mergeDiscoveredSkills(directory))
         .find((skill) => skill.name === skillName) || null;
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {
@@ -678,7 +678,7 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = ((await fetchOpenCodeDiscoveredSkills(directory)) || [])
+      const discoveredSkill = (await mergeDiscoveredSkills(directory))
         .find((skill) => skill.name === skillName) || null;
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {

--- a/packages/web/server/lib/opencode/skill-routes.js
+++ b/packages/web/server/lib/opencode/skill-routes.js
@@ -171,7 +171,7 @@ export const registerSkillRoutes = (app, dependencies) => {
     ]);
     // Merge both sources — local skills take precedence, dedup by name
     const skillMap = new Map();
-    for (const skill of localSkills) {
+    for (const skill of (localSkills || [])) {
       skillMap.set(skill.name, skill);
     }
     for (const skill of (openCodeSkills || [])) {


### PR DESCRIPTION
## Problem

When OpenCode is running, `fetchOpenCodeDiscoveredSkills()` can return an empty array `[]` (no skills set up in `.opencode/skills`). The route handler used `||` between the two sources:

```js
const skills = (await fetchOpenCodeDiscoveredSkills(directory)) || discoverSkills(directory);
```

Since `[]` is truthy, `discoverSkills()` was never evaluated — making `.agents/skills` skills invisible while OpenCode was running.

## Fix

Replaced both occurrences (main skills listing + browse sources endpoint) with a `mergeDiscoveredSkills` helper that:

1. Fetches **both** sources in parallel via `Promise.all`
2. Merges results by `name` with dedup
3. Local skills take precedence

## Test plan

- Existing tests pass (41 pass, 4 pre-existing failures unrelated to skills)
- Verified `discoverSkills()` returns `.agents/skills` skills correctly
- Merge is a no-op when OpenCode is not running (returns `null` → `openCodeSkills` is `null` → `|| []` kicks in → only local skills returned)