### PR TITLE
fix(mobile): collapse session status bar by default and on dismiss

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -191,7 +191,11 @@ const ChatViewport = React.memo(({
         }
 
         scrollRef.current?.focus({ preventScroll: true });
-    }, [scrollRef]);
+
+        if (isMobile && !useUIStore.getState().isMobileSessionStatusBarCollapsed) {
+            useUIStore.getState().setIsMobileSessionStatusBarCollapsed(true);
+        }
+    }, [scrollRef, isMobile]);
 
     return (
         <div

--- a/packages/ui/src/components/chat/MobileSessionStatusBar.tsx
+++ b/packages/ui/src/components/chat/MobileSessionStatusBar.tsx
@@ -1478,6 +1478,12 @@ export const MobileSessionStatusBar: React.FC<MobileSessionStatusBarProps> = ({
 
   const [isExpanded, setIsExpanded] = React.useState(false);
 
+  React.useEffect(() => {
+    if (isMobileSessionStatusBarCollapsed) {
+      setIsExpanded(false);
+    }
+  }, [isMobileSessionStatusBarCollapsed]);
+
   if (!isMobile || !showMobileSessionStatusBar || totalCount === 0) {
     return null;
   }
@@ -1486,6 +1492,7 @@ export const MobileSessionStatusBar: React.FC<MobileSessionStatusBarProps> = ({
     setCurrentSession(sessionId);
     onSessionSwitch?.(sessionId);
     setIsExpanded(false);
+    setIsMobileSessionStatusBarCollapsed(true);
   };
 
   const handleSessionDoubleClick = () => {

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -837,7 +837,7 @@ export const useUIStore = create<UIStore>()(
         stickyUserHeader: true,
         showSplitAssistantMessageActions: false,
         showMobileSessionStatusBar: true,
-        isMobileSessionStatusBarCollapsed: false,
+        isMobileSessionStatusBarCollapsed: true,
         isExpandedInput: false,
         reportUsage: true,
         shortcutOverrides: {},


### PR DESCRIPTION
## Summary

On mobile, the session status bar stays expanded in situations where it should collapse:

1. **Starts expanded by default** — even when a session is already active, the full session list is visible on load
2. **Stays open after selecting a session** — tapping a session switches to it but leaves the list open, wasting vertical space
3. **No tap-outside-to-dismiss** — tapping the chat area does not collapse the bar

The collapsed view still shows the current session title, running/unread indicators, context usage, and a "New" button — so discoverability is preserved.

## Changes

- `useUIStore.ts`: Default `isMobileSessionStatusBarCollapsed` to `true`
- `MobileSessionStatusBar.tsx`: Call `setIsMobileSessionStatusBarCollapsed(true)` in `handleSessionClick`
- `ChatContainer.tsx`: Collapse the bar when tapping the chat viewport on mobile

## Validation

- Tested in Chrome DevTools mobile emulation (iPhone 14 Pro, 390×844, touch enabled)
- Verified bar starts collapsed on load
- Verified bar collapses after session selection
- Verified tapping chat area dismisses the expanded bar
- `bun run type-check` — passes
- `bun run lint` — passes