### PR TITLE
Fix quick notes textarea text truncation after resize

### DIFF
--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -523,7 +523,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
           onChange={(event) => setNotes(event.target.value.slice(0, OPENCHAMBER_PROJECT_NOTES_MAX_LENGTH))}
           onBlur={handleNotesBlur}
           placeholder={t('rightSidebar.contextNotesTodo.notes.placeholder')}
-          className="min-h-28 max-h-80 resize-none"
+          className="min-h-28 resize-none"
           useScrollShadow
           scrollShadowSize={56}
           disabled={isLoading}


### PR DESCRIPTION
## Summary
Removes the `max-h-80` height cap from the quick notes `<Textarea>` so that when users drag the resize handle to make the panel taller, the editable area actually grows with it instead of clipping text at the old 320 px limit.

## Why
The custom resize handle in the `Textarea` component increases the wrapper's height, but the inner `<textarea>` element was capped at `max-h-80` (320 px). This meant users could drag the handle to enlarge the panel, yet text would still be truncated/overflow at 320 px with empty dead space below — making the resize control feel broken.

## Testing
- Verified the component renders correctly after the change.
- `bun run type-check` — passed across all workspaces.
- `bun run lint` — passed across all workspaces.