### PR TITLE
feat: add drag & drop reordering to project todo items

### DIFF
--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -1,4 +1,14 @@
 import React from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import { CSS as DndCSS } from '@dnd-kit/utilities';
 import { toast } from '@/components/ui';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -69,6 +79,41 @@ const createTodoId = (): string => {
     return crypto.randomUUID();
   }
   return `todo_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+};
+
+type SortableTodoHandleProps = {
+  attributes: ReturnType<typeof useSortable>['attributes'];
+  listeners: ReturnType<typeof useSortable>['listeners'];
+  setActivatorNodeRef: ReturnType<typeof useSortable>['setActivatorNodeRef'];
+  isDragging: boolean;
+};
+
+const SortableTodoItem: React.FC<{
+  id: string;
+  children: (dragHandleProps: SortableTodoHandleProps) => React.ReactNode;
+}> = ({ id, children }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{
+        transform: DndCSS.Transform.toString(transform),
+        transition,
+      }}
+      className={cn(isDragging && 'opacity-60')}
+    >
+      {children({ attributes, listeners, setActivatorNodeRef, isDragging })}
+    </li>
+  );
 };
 
 export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
@@ -273,6 +318,28 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
     setTodos(nextTodos);
     void persistProjectData(notes, nextTodos);
   }, [notes, persistProjectData, todos]);
+
+  const handleTodoReorder = React.useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) {
+        return;
+      }
+      const oldIndex = todos.findIndex((todo) => todo.id === active.id);
+      const newIndex = todos.findIndex((todo) => todo.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) {
+        return;
+      }
+      const nextTodos = arrayMove(todos, oldIndex, newIndex);
+      setTodos(nextTodos);
+      void persistProjectData(notes, nextTodos);
+    },
+    [notes, persistProjectData, todos]
+  );
+
+  const todoSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
 
   const todoInputValue = newTodoText.slice(0, OPENCHAMBER_PROJECT_TODO_TEXT_MAX_LENGTH);
   const completedTodoCount = todos.reduce((count, todo) => count + (todo.completed ? 1 : 0), 0);
@@ -585,78 +652,108 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
               {t('rightSidebar.contextNotesTodo.todo.empty')}
             </p>
           ) : (
-            <ul className="divide-y divide-border/50">
-              {todos.map((todo) => {
-                const isExpandedTodo = expandedTodoIds.has(todo.id);
-                return (
-                  <li key={todo.id} className="flex items-start gap-1.5 px-2.5 py-1.5">
-                    <div className="flex h-6 items-center">
-                      <Checkbox
-                        checked={todo.completed}
-                        onChange={(checked) => handleToggleTodo(todo.id, checked)}
-                        ariaLabel={t('rightSidebar.contextNotesTodo.todo.actions.markComplete', { text: todo.text })}
-                      />
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => handleToggleTodoExpanded(todo.id)}
-                      className={cn(
-                        'block min-h-6 min-w-0 flex-1 bg-transparent p-0 text-left typography-ui-label leading-6 text-foreground',
-                        isExpandedTodo ? 'whitespace-normal break-words' : 'overflow-hidden text-ellipsis whitespace-nowrap',
-                        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
-                        todo.completed && 'text-muted-foreground line-through'
-                      )}
-                      title={isExpandedTodo ? undefined : todo.text}
-                      aria-label={
-                        isExpandedTodo
-                          ? t('rightSidebar.contextNotesTodo.todo.actions.collapse', { text: todo.text })
-                          : t('rightSidebar.contextNotesTodo.todo.actions.expand', { text: todo.text })
-                      }
-                    >
-                      {todo.text}
-                    </button>
-                    <div className="flex h-6 items-center gap-0.5">
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteTodo(todo.id)}
-                        className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
-                        aria-label={t('rightSidebar.contextNotesTodo.todo.actions.delete', { text: todo.text })}
-                        title={t('rightSidebar.contextNotesTodo.todo.actions.delete', { text: todo.text })}
-                      >
-                        <Icon name="delete-bin" className="h-3.5 w-3.5" />
-                      </button>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            disabled={sendingTodoId === todo.id}
-                            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50"
-                            aria-label={t('rightSidebar.contextNotesTodo.todo.actions.send', { text: todo.text })}
-                            title={t('rightSidebar.contextNotesTodo.todo.actions.send', { text: todo.text })}
-                          >
-                            <Icon name="send-plane" className="h-3.5 w-3.5" />
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-56">
-                          <DropdownMenuItem onClick={() => handleSendToCurrentSession(todo.text)}>
-                            {t('rightSidebar.contextNotesTodo.todo.sendMenu.currentSession')}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => handleSendToNewSession(todo.id, todo.text)}>
-                            {t('rightSidebar.contextNotesTodo.todo.sendMenu.newSession')}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() => void handleSendToNewWorktreeSession(todo.id, todo.text)}
-                            disabled={!canCreateWorktree}
-                          >
-                            {t('rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession')}
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
+            <DndContext
+              sensors={todoSensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleTodoReorder}
+            >
+              <SortableContext
+                items={todos.map((todo) => todo.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <ul className="divide-y divide-border/50">
+                  {todos.map((todo) => {
+                    const isExpandedTodo = expandedTodoIds.has(todo.id);
+                    return (
+                      <SortableTodoItem key={todo.id} id={todo.id}>
+                        {(dragHandleProps) => (
+                          <div className="flex items-start gap-1.5 px-2.5 py-1.5">
+                            <button
+                              type="button"
+                              ref={dragHandleProps.setActivatorNodeRef}
+                              {...dragHandleProps.attributes}
+                              {...dragHandleProps.listeners}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                              }}
+                              className="flex h-6 w-4 flex-shrink-0 items-center justify-center text-muted-foreground hover:text-foreground"
+                              aria-label={t('rightSidebar.contextNotesTodo.todo.actions.reorder', { text: todo.text })}
+                              title={t('rightSidebar.contextNotesTodo.todo.actions.reorder', { text: todo.text })}
+                            >
+                              <Icon name="draggable" className="h-3.5 w-3.5" />
+                            </button>
+                            <div className="flex h-6 items-center">
+                              <Checkbox
+                                checked={todo.completed}
+                                onChange={(checked) => handleToggleTodo(todo.id, checked)}
+                                ariaLabel={t('rightSidebar.contextNotesTodo.todo.actions.markComplete', { text: todo.text })}
+                              />
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => handleToggleTodoExpanded(todo.id)}
+                              className={cn(
+                                'block min-h-6 min-w-0 flex-1 bg-transparent p-0 text-left typography-ui-label leading-6 text-foreground',
+                                isExpandedTodo ? 'whitespace-normal break-words' : 'overflow-hidden text-ellipsis whitespace-nowrap',
+                                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+                                todo.completed && 'text-muted-foreground line-through'
+                              )}
+                              title={isExpandedTodo ? undefined : todo.text}
+                              aria-label={
+                                isExpandedTodo
+                                  ? t('rightSidebar.contextNotesTodo.todo.actions.collapse', { text: todo.text })
+                                  : t('rightSidebar.contextNotesTodo.todo.actions.expand', { text: todo.text })
+                              }
+                            >
+                              {todo.text}
+                            </button>
+                            <div className="flex h-6 items-center gap-0.5">
+                              <button
+                                type="button"
+                                onClick={() => handleDeleteTodo(todo.id)}
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                                aria-label={t('rightSidebar.contextNotesTodo.todo.actions.delete', { text: todo.text })}
+                                title={t('rightSidebar.contextNotesTodo.todo.actions.delete', { text: todo.text })}
+                              >
+                                <Icon name="delete-bin" className="h-3.5 w-3.5" />
+                              </button>
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <button
+                                    type="button"
+                                    disabled={sendingTodoId === todo.id}
+                                    className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50"
+                                    aria-label={t('rightSidebar.contextNotesTodo.todo.actions.send', { text: todo.text })}
+                                    title={t('rightSidebar.contextNotesTodo.todo.actions.send', { text: todo.text })}
+                                  >
+                                    <Icon name="send-plane" className="h-3.5 w-3.5" />
+                                  </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end" className="w-56">
+                                  <DropdownMenuItem onClick={() => handleSendToCurrentSession(todo.text)}>
+                                    {t('rightSidebar.contextNotesTodo.todo.sendMenu.currentSession')}
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem onClick={() => handleSendToNewSession(todo.id, todo.text)}>
+                                    {t('rightSidebar.contextNotesTodo.todo.sendMenu.newSession')}
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    onClick={() => void handleSendToNewWorktreeSession(todo.id, todo.text)}
+                                    disabled={!canCreateWorktree}
+                                  >
+                                    {t('rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession')}
+                                  </DropdownMenuItem>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            </div>
+                          </div>
+                        )}
+                      </SortableTodoItem>
+                    );
+                  })}
+                </ul>
+              </SortableContext>
+            </DndContext>
           )}
         </div>
       </div>

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -523,7 +523,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
           onChange={(event) => setNotes(event.target.value.slice(0, OPENCHAMBER_PROJECT_NOTES_MAX_LENGTH))}
           onBlur={handleNotesBlur}
           placeholder={t('rightSidebar.contextNotesTodo.notes.placeholder')}
-          className="min-h-28 max-h-80 resize-none"
+          className="min-h-28 resize-none"
           useScrollShadow
           scrollShadowSize={56}
           disabled={isLoading}

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1011,6 +1011,7 @@ export const dict = {
   'rightSidebar.contextNotesTodo.todo.actions.expand': 'Expand todo "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.delete': 'Delete "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.send': 'Send "{text}"',
+  'rightSidebar.contextNotesTodo.todo.actions.reorder': 'Reorder "{text}"',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': 'Send to current session',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': 'Send to new session',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': 'Send to new worktree session',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -977,6 +977,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.expand": "Expandir tarea pendiente \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Eliminar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Enviar \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.actions.reorder": "Reordenar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Enviar a la sesión actual",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Enviar a una nueva sesión",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Enviar a una nueva sesión de worktree",

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1014,6 +1014,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.expand': '펼치기 todo "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.delete': '"{text}" 삭제',
   'rightSidebar.contextNotesTodo.todo.actions.send': '보내기 "{text}"',
+  'rightSidebar.contextNotesTodo.todo.actions.reorder': '재정렬 "{text}"',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': '현재 세션으로 보내기',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': '새 세션으로 보내기',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': '새 워크트리 세션으로 보내기',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1888,6 +1888,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.expand': 'Rozwiń zadanie „{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.markComplete': 'Oznacz „{text}” jako ukończone',
   'rightSidebar.contextNotesTodo.todo.actions.send': 'Wyślij „{text}”',
+  'rightSidebar.contextNotesTodo.todo.actions.reorder': 'Zmień kolejność "{text}"',
   'rightSidebar.contextNotesTodo.todo.addAria': 'Dodaj zadanie',
   'rightSidebar.contextNotesTodo.todo.clearCompleted': 'Wyczyść ukończone',
   'rightSidebar.contextNotesTodo.todo.empty': 'Brak zadań. Dodaj krótką checklistę dla tego projektu.',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -977,6 +977,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.expand": "Expandir tarefa pendente \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Excluir \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Enviar \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.actions.reorder": "Reordenar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Enviar à sessão atual",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Enviar a uma nova sessão",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Enviar a uma nova sessão de worktree",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -977,6 +977,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.expand": "Розгорнути завдання \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Видалити \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Надіслати \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.actions.reorder": "Змінити порядок \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Надіслати до поточної сесії",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Надіслати до нової сесії",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Надіслати до нової сесії в worktree",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -977,6 +977,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.expand': '展开待办“{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.delete': '删除“{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.send': '发送“{text}”',
+  'rightSidebar.contextNotesTodo.todo.actions.reorder': '重新排序"{text}"',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': '发送到当前会话',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': '发送到新会话',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': '发送到新 worktree 会话',


### PR DESCRIPTION
## Summary

This PR introduces drag & drop reordering for project todo items

- **Drag & drop reordering**: Each todo item now has a drag handle (grip icon). Grab it and drag to reorder. The new order is saved automatically alongside project notes.

## Why

- Users often want to prioritize todos by reordering them rather than deleting and recreating.

## Testing

- Verified drag & drop with mouse and touch interactions.
- Confirmed reordered state persists across reloads.
- `bun run type-check` and `bun run lint` pass cleanly across all workspaces.