### PR TITLE
feat(ui): context panel enhancements — resizable panels, drag-and-drop todo ordering, and persistent sizes

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -2575,6 +2575,9 @@ ipcMain.handle('openchamber:dialog:open', async (event, options) => {
   const browserWindow = BrowserWindow.fromWebContents(event.sender);
   const result = await dialog.showOpenDialog(browserWindow || undefined, {
     title: typeof options?.title === 'string' ? options.title : undefined,
+    defaultPath: typeof options?.defaultPath === 'string' && options.defaultPath.trim().length > 0
+      ? options.defaultPath.trim()
+      : undefined,
     filters: Array.isArray(options?.filters)
       ? options.filters
           .filter((filter) => filter && typeof filter === 'object')

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -156,10 +156,16 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
   const [contextReloadTick, setContextReloadTick] = React.useState(0);
   const notesHydratedRef = React.useRef(false);
   const lastSavedNotesRef = React.useRef('');
-  const [todoPanelHeight, setTodoPanelHeight] = React.useState(() => getPanelHeightForItems(7, 100));
+  const todoPanelHeight = useUIStore((state) => state.todoPanelHeight);
+  const setTodoPanelHeight = useUIStore((state) => state.setTodoPanelHeight);
+  const notesPanelHeight = useUIStore((state) => state.notesPanelHeight);
+  const setNotesPanelHeight = useUIStore((state) => state.setNotesPanelHeight);
   const [isTodoPanelResizing, setIsTodoPanelResizing] = React.useState(false);
+  const [isNotesPanelResizing, setIsNotesPanelResizing] = React.useState(false);
   const todoPanelStartYRef = React.useRef(0);
   const todoPanelStartHeightRef = React.useRef(todoPanelHeight);
+  const notesPanelStartYRef = React.useRef(0);
+  const notesPanelStartHeightRef = React.useRef(notesPanelHeight);
 
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
   const createSession = useSessionUIStore((state) => state.createSession);
@@ -266,14 +272,11 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
       return;
     }
     const targetHeight = getPanelHeightForItems(todos.length, padding);
-    setTodoPanelHeight((prev) => {
-      const minHeight = getEffectiveItemHeight(padding) * TODO_PANEL_MIN_ITEMS;
-      if (prev < minHeight || prev > targetHeight) {
-        return targetHeight;
-      }
-      return prev;
-    });
-  }, [todos.length, padding]);
+    const minHeight = getEffectiveItemHeight(padding) * TODO_PANEL_MIN_ITEMS;
+    if (todoPanelHeight < minHeight || todoPanelHeight > targetHeight) {
+      setTodoPanelHeight(targetHeight);
+    }
+  }, [todos.length, padding, todoPanelHeight, setTodoPanelHeight]);
 
   React.useEffect(() => {
     if (!isTodoPanelResizing) {
@@ -300,7 +303,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerUp);
     };
-  }, [isTodoPanelResizing, padding]);
+  }, [isTodoPanelResizing, padding, setTodoPanelHeight]);
 
   const handleTodoPanelResizeStart = React.useCallback((event: React.PointerEvent) => {
     setIsTodoPanelResizing(true);
@@ -308,6 +311,40 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
     todoPanelStartHeightRef.current = todoPanelHeight;
     event.preventDefault();
   }, [todoPanelHeight]);
+
+  React.useEffect(() => {
+    if (!isNotesPanelResizing) {
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const delta = event.clientY - notesPanelStartYRef.current;
+      const nextHeight = Math.min(
+        480,
+        Math.max(80, notesPanelStartHeightRef.current + delta)
+      );
+      setNotesPanelHeight(nextHeight);
+    };
+
+    const handlePointerUp = () => {
+      setIsNotesPanelResizing(false);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [isNotesPanelResizing, setNotesPanelHeight]);
+
+  const handleNotesPanelResizeStart = React.useCallback((event: React.PointerEvent) => {
+    setIsNotesPanelResizing(true);
+    notesPanelStartYRef.current = event.clientY;
+    notesPanelStartHeightRef.current = notesPanelHeight;
+    event.preventDefault();
+  }, [notesPanelHeight]);
 
   const handleNotesBlur = React.useCallback(() => {
     lastSavedNotesRef.current = notes;
@@ -705,10 +742,21 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
           onChange={(event) => setNotes(event.target.value.slice(0, OPENCHAMBER_PROJECT_NOTES_MAX_LENGTH))}
           onBlur={handleNotesBlur}
           placeholder={t('rightSidebar.contextNotesTodo.notes.placeholder')}
-          className="min-h-28 resize-none"
+          className={cn('resize-none', isNotesPanelResizing && 'transition-none')}
+          style={{ minHeight: `${notesPanelHeight}px` }}
           useScrollShadow
           scrollShadowSize={56}
           disabled={isLoading}
+        />
+        <div
+          className={cn(
+            'h-[3px] w-full cursor-row-resize hover:bg-[var(--interactive-border)]/80 transition-colors',
+            isNotesPanelResizing && 'bg-[var(--interactive-border)]'
+          )}
+          onPointerDown={handleNotesPanelResizeStart}
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label={t('rightSidebar.contextNotesTodo.notes.resizeAria')}
         />
       </div>
 

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -32,6 +32,7 @@ import {
   type OpenChamberProjectTodoItem,
   type ProjectRef,
 } from '@/lib/openchamberConfig';
+import { requestFileAccess } from '@/lib/desktop';
 import { generateBranchName } from '@/lib/git/branchNameGenerator';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -580,12 +581,54 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
     [deletingPlanId, projectRef, t]
   );
 
-  const handleTriggerUploadPlan = React.useCallback(() => {
+  const handleTriggerUploadPlan = React.useCallback(async () => {
     if (!projectRef || isImportingPlan) {
       return;
     }
-    planFileInputRef.current?.click();
-  }, [isImportingPlan, projectRef]);
+    const result = await requestFileAccess({
+      defaultPath: projectRef.path,
+      filters: [
+        { name: 'Plan files', extensions: ['md', 'markdown', 'txt'] },
+        { name: 'All files', extensions: ['*'] },
+      ],
+    });
+    if (result.success && result.path) {
+      setIsImportingPlan(true);
+      try {
+        const response = await fetch(
+          `${window.location.origin}/fs/read?path=${encodeURIComponent(result.path)}`,
+          { cache: 'no-store' }
+        );
+        if (!response.ok) {
+          toast.error(t('rightSidebar.contextNotesTodo.toast.readPlanFileFailed'));
+          return;
+        }
+        const text = await response.text();
+        if (!text.trim()) {
+          toast.error(t('rightSidebar.contextNotesTodo.toast.planFileEmpty'));
+          return;
+        }
+        const fallbackTitle = result.path.split('/').pop()?.replace(/\.(md|markdown|txt)$/i, '').trim() || '';
+        const created = await importProjectPlanFileFromContent(projectRef, text, fallbackTitle);
+        if (!created) {
+          toast.error(t('rightSidebar.contextNotesTodo.toast.importPlanFailed'));
+          return;
+        }
+        window.dispatchEvent(new CustomEvent('openchamber:project-plan-saved', {
+          detail: { projectId: projectRef.id },
+        }));
+        toast.success(t('rightSidebar.contextNotesTodo.toast.planImported'));
+      } catch (error) {
+        const description = error instanceof Error ? error.message : undefined;
+        toast.error(t('rightSidebar.contextNotesTodo.toast.readPlanFileFailed'), description ? { description } : undefined);
+      } finally {
+        setIsImportingPlan(false);
+      }
+    } else if (result.error === 'Native file picker not available') {
+      // Fall back to HTML file input for web/non-desktop runtimes
+      planFileInputRef.current?.click();
+    }
+  }, [isImportingPlan, projectRef, t]);
 
   const handleUploadPlanFile = React.useCallback(
     async (file: File | null) => {

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -52,9 +52,9 @@ const TODO_PANEL_MAX_ITEMS = 15;
 const getEffectiveItemHeight = (padding: number) => {
   const scale = Math.sqrt(padding / 100);
   const paddingPx = 12 * scale;
-  const contentPx = 24;
+  const contentPx = 24 * scale; // h-6 uses --spacing-6 which also scales with --padding-scale
   const borderPx = 1;
-  return Math.round(paddingPx + contentPx + borderPx);
+  return Math.ceil(paddingPx + contentPx + borderPx);
 };
 
 const getPanelHeightForItems = (itemCount: number, padding: number) => {

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -45,6 +45,25 @@ import { renderMagicPrompt } from '@/lib/magicPrompts';
 import { useI18n } from '@/lib/i18n';
 import { TodoSendDialog, type TodoSendExecution } from './TodoSendDialog';
 
+const TODO_PANEL_MIN_ITEMS = 5;
+const TODO_PANEL_MAX_ITEMS = 15;
+
+const getEffectiveItemHeight = (padding: number) => {
+  const scale = Math.sqrt(padding / 100);
+  const paddingPx = 12 * scale;
+  const contentPx = 24;
+  const borderPx = 1;
+  return Math.round(paddingPx + contentPx + borderPx);
+};
+
+const getPanelHeightForItems = (itemCount: number, padding: number) => {
+  const itemHeight = getEffectiveItemHeight(padding);
+  return Math.max(
+    itemHeight * TODO_PANEL_MIN_ITEMS,
+    Math.min(itemHeight * TODO_PANEL_MAX_ITEMS, itemHeight * itemCount)
+  );
+};
+
 interface ProjectNotesTodoPanelProps {
   projectRef: ProjectRef | null;
   projectLabel?: string | null;
@@ -136,6 +155,10 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
   const [contextReloadTick, setContextReloadTick] = React.useState(0);
   const notesHydratedRef = React.useRef(false);
   const lastSavedNotesRef = React.useRef('');
+  const [todoPanelHeight, setTodoPanelHeight] = React.useState(() => getPanelHeightForItems(7, 100));
+  const [isTodoPanelResizing, setIsTodoPanelResizing] = React.useState(false);
+  const todoPanelStartYRef = React.useRef(0);
+  const todoPanelStartHeightRef = React.useRef(todoPanelHeight);
 
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
   const createSession = useSessionUIStore((state) => state.createSession);
@@ -147,6 +170,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
   const openContextPanelTab = useUIStore((state) => state.openContextPanelTab);
   const setActiveMainTab = useUIStore((state) => state.setActiveMainTab);
   const setSessionSwitcherOpen = useUIStore((state) => state.setSessionSwitcherOpen);
+  const padding = useUIStore((state) => state.padding);
 
   const persistProjectData = React.useCallback(
     async (nextNotes: string, nextTodos: OpenChamberProjectTodoItem[]) => {
@@ -235,6 +259,54 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
       window.removeEventListener('openchamber:project-notes-updated', handleProjectContextRefresh);
     };
   }, [projectRef]);
+
+  React.useEffect(() => {
+    if (todos.length < 7) {
+      return;
+    }
+    const targetHeight = getPanelHeightForItems(todos.length, padding);
+    setTodoPanelHeight((prev) => {
+      const minHeight = getEffectiveItemHeight(padding) * TODO_PANEL_MIN_ITEMS;
+      if (prev < minHeight || prev > targetHeight) {
+        return targetHeight;
+      }
+      return prev;
+    });
+  }, [todos.length, padding]);
+
+  React.useEffect(() => {
+    if (!isTodoPanelResizing) {
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const delta = event.clientY - todoPanelStartYRef.current;
+      const nextHeight = Math.min(
+        getEffectiveItemHeight(padding) * TODO_PANEL_MAX_ITEMS,
+        Math.max(getEffectiveItemHeight(padding) * TODO_PANEL_MIN_ITEMS, todoPanelStartHeightRef.current + delta)
+      );
+      setTodoPanelHeight(nextHeight);
+    };
+
+    const handlePointerUp = () => {
+      setIsTodoPanelResizing(false);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [isTodoPanelResizing, padding]);
+
+  const handleTodoPanelResizeStart = React.useCallback((event: React.PointerEvent) => {
+    setIsTodoPanelResizing(true);
+    todoPanelStartYRef.current = event.clientY;
+    todoPanelStartHeightRef.current = todoPanelHeight;
+    event.preventDefault();
+  }, [todoPanelHeight]);
 
   const handleNotesBlur = React.useCallback(() => {
     lastSavedNotesRef.current = notes;
@@ -646,7 +718,20 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
           </button>
         </div>
 
-        <div className="max-h-56 overflow-y-auto rounded-lg border border-border/60 bg-background/40">
+        <div
+          className={cn(
+            'overflow-y-auto rounded-lg border border-border/60 bg-background/40',
+            isTodoPanelResizing && 'transition-none'
+          )}
+          style={
+            todos.length < 7
+              ? undefined
+              : {
+                  height: `${todoPanelHeight}px`,
+                  maxHeight: `${todoPanelHeight}px`,
+                }
+          }
+        >
           {todos.length === 0 ? (
             <p className="px-3 py-3 typography-meta text-muted-foreground">
               {t('rightSidebar.contextNotesTodo.todo.empty')}
@@ -756,6 +841,18 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
             </DndContext>
           )}
         </div>
+        {todos.length >= 7 && (
+          <div
+            className={cn(
+              'h-[3px] w-full cursor-row-resize hover:bg-[var(--interactive-border)]/80 transition-colors',
+              isTodoPanelResizing && 'bg-[var(--interactive-border)]'
+            )}
+            onPointerDown={handleTodoPanelResizeStart}
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label={t('rightSidebar.contextNotesTodo.todo.resizeAria')}
+          />
+        )}
       </div>
 
       <div className="space-y-2">

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -1,4 +1,14 @@
 import React from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import { CSS as DndCSS } from '@dnd-kit/utilities';
 import { toast } from '@/components/ui';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -69,6 +79,41 @@ const createTodoId = (): string => {
     return crypto.randomUUID();
   }
   return `todo_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+};
+
+type SortableTodoHandleProps = {
+  attributes: ReturnType<typeof useSortable>['attributes'];
+  listeners: ReturnType<typeof useSortable>['listeners'];
+  setActivatorNodeRef: ReturnType<typeof useSortable>['setActivatorNodeRef'];
+  isDragging: boolean;
+};
+
+const SortableTodoItem: React.FC<{
+  id: string;
+  children: (dragHandleProps: SortableTodoHandleProps) => React.ReactNode;
+}> = ({ id, children }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{
+        transform: DndCSS.Transform.toString(transform),
+        transition,
+      }}
+      className={cn(isDragging && 'opacity-60')}
+    >
+      {children({ attributes, listeners, setActivatorNodeRef, isDragging })}
+    </li>
+  );
 };
 
 export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
@@ -273,6 +318,28 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
     setTodos(nextTodos);
     void persistProjectData(notes, nextTodos);
   }, [notes, persistProjectData, todos]);
+
+  const handleTodoReorder = React.useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) {
+        return;
+      }
+      const oldIndex = todos.findIndex((todo) => todo.id === active.id);
+      const newIndex = todos.findIndex((todo) => todo.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) {
+        return;
+      }
+      const nextTodos = arrayMove(todos, oldIndex, newIndex);
+      setTodos(nextTodos);
+      void persistProjectData(notes, nextTodos);
+    },
+    [notes, persistProjectData, todos]
+  );
+
+  const todoSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
 
   const todoInputValue = newTodoText.slice(0, OPENCHAMBER_PROJECT_TODO_TEXT_MAX_LENGTH);
   const completedTodoCount = todos.reduce((count, todo) => count + (todo.completed ? 1 : 0), 0);
@@ -585,78 +652,108 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
               {t('rightSidebar.contextNotesTodo.todo.empty')}
             </p>
           ) : (
-            <ul className="divide-y divide-border/50">
-              {todos.map((todo) => {
-                const isExpandedTodo = expandedTodoIds.has(todo.id);
-                return (
-                  <li key={todo.id} className="flex items-start gap-1.5 px-2.5 py-1.5">
-                    <div className="flex h-6 items-center">
-                      <Checkbox
-                        checked={todo.completed}
-                        onChange={(checked) => handleToggleTodo(todo.id, checked)}
-                        ariaLabel={t('rightSidebar.contextNotesTodo.todo.actions.markComplete', { text: todo.text })}
-                      />
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => handleToggleTodoExpanded(todo.id)}
-                      className={cn(
-                        'block min-h-6 min-w-0 flex-1 bg-transparent p-0 text-left typography-ui-label leading-6 text-foreground',
-                        isExpandedTodo ? 'whitespace-normal break-words' : 'overflow-hidden text-ellipsis whitespace-nowrap',
-                        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
-                        todo.completed && 'text-muted-foreground line-through'
-                      )}
-                      title={isExpandedTodo ? undefined : todo.text}
-                      aria-label={
-                        isExpandedTodo
-                          ? t('rightSidebar.contextNotesTodo.todo.actions.collapse', { text: todo.text })
-                          : t('rightSidebar.contextNotesTodo.todo.actions.expand', { text: todo.text })
-                      }
-                    >
-                      {todo.text}
-                    </button>
-                    <div className="flex h-6 items-center gap-0.5">
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteTodo(todo.id)}
-                        className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
-                        aria-label={t('rightSidebar.contextNotesTodo.todo.actions.delete', { text: todo.text })}
-                        title={t('rightSidebar.contextNotesTodo.todo.actions.delete', { text: todo.text })}
-                      >
-                        <Icon name="delete-bin" className="h-3.5 w-3.5" />
-                      </button>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            disabled={sendingTodoId === todo.id}
-                            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50"
-                            aria-label={t('rightSidebar.contextNotesTodo.todo.actions.send', { text: todo.text })}
-                            title={t('rightSidebar.contextNotesTodo.todo.actions.send', { text: todo.text })}
-                          >
-                            <Icon name="send-plane" className="h-3.5 w-3.5" />
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-56">
-                          <DropdownMenuItem onClick={() => handleSendToCurrentSession(todo.text)}>
-                            {t('rightSidebar.contextNotesTodo.todo.sendMenu.currentSession')}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => handleSendToNewSession(todo.id, todo.text)}>
-                            {t('rightSidebar.contextNotesTodo.todo.sendMenu.newSession')}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() => void handleSendToNewWorktreeSession(todo.id, todo.text)}
-                            disabled={!canCreateWorktree}
-                          >
-                            {t('rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession')}
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
+            <DndContext
+              sensors={todoSensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleTodoReorder}
+            >
+              <SortableContext
+                items={todos.map((todo) => todo.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <ul className="divide-y divide-border/50">
+                  {todos.map((todo) => {
+                    const isExpandedTodo = expandedTodoIds.has(todo.id);
+                    return (
+                      <SortableTodoItem key={todo.id} id={todo.id}>
+                        {(dragHandleProps) => (
+                          <div className="flex items-start gap-1.5 px-2.5 py-1.5">
+                            <button
+                              type="button"
+                              ref={dragHandleProps.setActivatorNodeRef}
+                              {...dragHandleProps.attributes}
+                              {...dragHandleProps.listeners}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                              }}
+                              className="flex h-6 w-4 flex-shrink-0 items-center justify-center text-muted-foreground hover:text-foreground"
+                              aria-label={t('rightSidebar.contextNotesTodo.todo.actions.reorder', { text: todo.text })}
+                              title={t('rightSidebar.contextNotesTodo.todo.actions.reorder', { text: todo.text })}
+                            >
+                              <Icon name="draggable" className="h-3.5 w-3.5" />
+                            </button>
+                            <div className="flex h-6 items-center">
+                              <Checkbox
+                                checked={todo.completed}
+                                onChange={(checked) => handleToggleTodo(todo.id, checked)}
+                                ariaLabel={t('rightSidebar.contextNotesTodo.todo.actions.markComplete', { text: todo.text })}
+                              />
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => handleToggleTodoExpanded(todo.id)}
+                              className={cn(
+                                'block min-h-6 min-w-0 flex-1 bg-transparent p-0 text-left typography-ui-label leading-6 text-foreground',
+                                isExpandedTodo ? 'whitespace-normal break-words' : 'overflow-hidden text-ellipsis whitespace-nowrap',
+                                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+                                todo.completed && 'text-muted-foreground line-through'
+                              )}
+                              title={isExpandedTodo ? undefined : todo.text}
+                              aria-label={
+                                isExpandedTodo
+                                  ? t('rightSidebar.contextNotesTodo.todo.actions.collapse', { text: todo.text })
+                                  : t('rightSidebar.contextNotesTodo.todo.actions.expand', { text: todo.text })
+                              }
+                            >
+                              {todo.text}
+                            </button>
+                            <div className="flex h-6 items-center gap-0.5">
+                              <button
+                                type="button"
+                                onClick={() => handleDeleteTodo(todo.id)}
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                                aria-label={t('rightSidebar.contextNotesTodo.todo.actions.delete', { text: todo.text })}
+                                title={t('rightSidebar.contextNotesTodo.todo.actions.delete', { text: todo.text })}
+                              >
+                                <Icon name="delete-bin" className="h-3.5 w-3.5" />
+                              </button>
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <button
+                                    type="button"
+                                    disabled={sendingTodoId === todo.id}
+                                    className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:opacity-50"
+                                    aria-label={t('rightSidebar.contextNotesTodo.todo.actions.send', { text: todo.text })}
+                                    title={t('rightSidebar.contextNotesTodo.todo.actions.send', { text: todo.text })}
+                                  >
+                                    <Icon name="send-plane" className="h-3.5 w-3.5" />
+                                  </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end" className="w-56">
+                                  <DropdownMenuItem onClick={() => handleSendToCurrentSession(todo.text)}>
+                                    {t('rightSidebar.contextNotesTodo.todo.sendMenu.currentSession')}
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem onClick={() => handleSendToNewSession(todo.id, todo.text)}>
+                                    {t('rightSidebar.contextNotesTodo.todo.sendMenu.newSession')}
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    onClick={() => void handleSendToNewWorktreeSession(todo.id, todo.text)}
+                                    disabled={!canCreateWorktree}
+                                  >
+                                    {t('rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession')}
+                                  </DropdownMenuItem>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            </div>
+                          </div>
+                        )}
+                      </SortableTodoItem>
+                    );
+                  })}
+                </ul>
+              </SortableContext>
+            </DndContext>
           )}
         </div>
       </div>

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -523,7 +523,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
           onChange={(event) => setNotes(event.target.value.slice(0, OPENCHAMBER_PROJECT_NOTES_MAX_LENGTH))}
           onBlur={handleNotesBlur}
           placeholder={t('rightSidebar.contextNotesTodo.notes.placeholder')}
-          className="min-h-28 max-h-80 resize-none"
+          className="min-h-28 resize-none"
           useScrollShadow
           scrollShadowSize={56}
           disabled={isLoading}

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -633,7 +633,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
       setIsImportingPlan(true);
       try {
         const response = await fetch(
-          `${window.location.origin}/fs/read?path=${encodeURIComponent(result.path)}`,
+          `/api/fs/read?path=${encodeURIComponent(result.path)}`,
           { cache: 'no-store' }
         );
         if (!response.ok) {

--- a/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/ProjectNotesTodoPanel.tsx
@@ -161,11 +161,8 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
   const notesPanelHeight = useUIStore((state) => state.notesPanelHeight);
   const setNotesPanelHeight = useUIStore((state) => state.setNotesPanelHeight);
   const [isTodoPanelResizing, setIsTodoPanelResizing] = React.useState(false);
-  const [isNotesPanelResizing, setIsNotesPanelResizing] = React.useState(false);
   const todoPanelStartYRef = React.useRef(0);
   const todoPanelStartHeightRef = React.useRef(todoPanelHeight);
-  const notesPanelStartYRef = React.useRef(0);
-  const notesPanelStartHeightRef = React.useRef(notesPanelHeight);
 
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
   const createSession = useSessionUIStore((state) => state.createSession);
@@ -292,16 +289,18 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
       setTodoPanelHeight(nextHeight);
     };
 
-    const handlePointerUp = () => {
+    const handlePointerEnd = () => {
       setIsTodoPanelResizing(false);
     };
 
     window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', handlePointerUp, { once: true });
+    window.addEventListener('pointerup', handlePointerEnd, { once: true });
+    window.addEventListener('pointercancel', handlePointerEnd, { once: true });
 
     return () => {
       window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
     };
   }, [isTodoPanelResizing, padding, setTodoPanelHeight]);
 
@@ -311,40 +310,6 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
     todoPanelStartHeightRef.current = todoPanelHeight;
     event.preventDefault();
   }, [todoPanelHeight]);
-
-  React.useEffect(() => {
-    if (!isNotesPanelResizing) {
-      return;
-    }
-
-    const handlePointerMove = (event: PointerEvent) => {
-      const delta = event.clientY - notesPanelStartYRef.current;
-      const nextHeight = Math.min(
-        480,
-        Math.max(80, notesPanelStartHeightRef.current + delta)
-      );
-      setNotesPanelHeight(nextHeight);
-    };
-
-    const handlePointerUp = () => {
-      setIsNotesPanelResizing(false);
-    };
-
-    window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', handlePointerUp, { once: true });
-
-    return () => {
-      window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', handlePointerUp);
-    };
-  }, [isNotesPanelResizing, setNotesPanelHeight]);
-
-  const handleNotesPanelResizeStart = React.useCallback((event: React.PointerEvent) => {
-    setIsNotesPanelResizing(true);
-    notesPanelStartYRef.current = event.clientY;
-    notesPanelStartHeightRef.current = notesPanelHeight;
-    event.preventDefault();
-  }, [notesPanelHeight]);
 
   const handleNotesBlur = React.useCallback(() => {
     lastSavedNotesRef.current = notes;
@@ -632,10 +597,11 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
     if (result.success && result.path) {
       setIsImportingPlan(true);
       try {
-        const response = await fetch(
-          `/api/fs/read?path=${encodeURIComponent(result.path)}`,
-          { cache: 'no-store' }
-        );
+        const params = new URLSearchParams({
+          path: result.path,
+          allowOutsideWorkspace: 'true',
+        });
+        const response = await fetch(`/api/fs/read?${params.toString()}`, { cache: 'no-store' });
         if (!response.ok) {
           toast.error(t('rightSidebar.contextNotesTodo.toast.readPlanFileFailed'));
           return;
@@ -742,21 +708,11 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
           onChange={(event) => setNotes(event.target.value.slice(0, OPENCHAMBER_PROJECT_NOTES_MAX_LENGTH))}
           onBlur={handleNotesBlur}
           placeholder={t('rightSidebar.contextNotesTodo.notes.placeholder')}
-          className={cn('resize-none', isNotesPanelResizing && 'transition-none')}
-          style={{ minHeight: `${notesPanelHeight}px` }}
+          resizedHeight={notesPanelHeight}
+          onResizeHeightChange={setNotesPanelHeight}
           useScrollShadow
           scrollShadowSize={56}
           disabled={isLoading}
-        />
-        <div
-          className={cn(
-            'h-[3px] w-full cursor-row-resize hover:bg-[var(--interactive-border)]/80 transition-colors',
-            isNotesPanelResizing && 'bg-[var(--interactive-border)]'
-          )}
-          onPointerDown={handleNotesPanelResizeStart}
-          role="separator"
-          aria-orientation="horizontal"
-          aria-label={t('rightSidebar.contextNotesTodo.notes.resizeAria')}
         />
       </div>
 
@@ -853,7 +809,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
                                 event.preventDefault();
                                 event.stopPropagation();
                               }}
-                              className="flex h-6 w-4 flex-shrink-0 items-center justify-center text-muted-foreground hover:text-foreground"
+                              className="flex h-6 w-4 flex-shrink-0 touch-none items-center justify-center text-muted-foreground hover:text-foreground"
                               aria-label={t('rightSidebar.contextNotesTodo.todo.actions.reorder', { text: todo.text })}
                               title={t('rightSidebar.contextNotesTodo.todo.actions.reorder', { text: todo.text })}
                             >

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -11,6 +11,8 @@ type TextareaProps = React.ComponentProps<"textarea"> & {
   useScrollShadow?: boolean;
   scrollShadowSize?: number;
   hasError?: boolean;
+  resizedHeight?: number | null;
+  onResizeHeightChange?: (height: number) => void;
   /**
    * AlignUI "simple" mode: render a bare textarea (no compound wrapper).
    * Used for chat composer or anywhere the textarea is embedded inside an
@@ -68,6 +70,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       useScrollShadow = false,
       scrollShadowSize,
       hasError,
+      resizedHeight: controlledResizedHeight,
+      onResizeHeightChange,
       disabled,
       simple,
       endSlot,
@@ -79,6 +83,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const wrapperRef = React.useRef<HTMLDivElement>(null);
     const dragStateRef = React.useRef<{ startY: number; startHeight: number } | null>(null);
     const [resizedHeight, setResizedHeight] = React.useState<number | null>(null);
+    const effectiveResizedHeight = controlledResizedHeight ?? resizedHeight;
 
     const handleResizeStart = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
       const wrapper = wrapperRef.current;
@@ -94,7 +99,12 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         const state = dragStateRef.current;
         if (!state) return;
         const next = state.startHeight + (moveEvent.clientY - state.startY);
-        setResizedHeight(Math.max(82, next));
+        const nextHeight = Math.max(82, next);
+        if (onResizeHeightChange) {
+          onResizeHeightChange(nextHeight);
+        } else {
+          setResizedHeight(nextHeight);
+        }
       };
       const onUp = () => {
         dragStateRef.current = null;
@@ -106,7 +116,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       target.addEventListener('pointerup', onUp);
       target.addEventListener('pointercancel', onUp);
       event.preventDefault();
-    }, []);
+    }, [onResizeHeightChange]);
 
     const focusInnerTextarea = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
       // Clicking the wrapper chrome (below/around the textarea) should focus it.
@@ -152,7 +162,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <div
         ref={wrapperRef}
         onPointerDown={focusInnerTextarea}
-        style={resizedHeight !== null ? { height: `${resizedHeight}px` } : undefined}
+        style={effectiveResizedHeight !== null ? { height: `${effectiveResizedHeight}px` } : undefined}
         className={cn(
           "group/textarea relative flex w-full flex-col rounded-[var(--radius-xl)] bg-[var(--surface-elevated)] pb-2.5",
           "ring-1 ring-inset ring-border/60 transition duration-200 ease-out",

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -368,7 +368,7 @@ export const requestDirectoryAccess = async (
 };
 
 export const requestFileAccess = async (
-  options?: { filters?: Array<{ name: string; extensions: string[] }> }
+  options?: { filters?: Array<{ name: string; extensions: string[] }>; defaultPath?: string }
 ): Promise<{ success: boolean; path?: string; error?: string }> => {
   if (isTauriShell() && isDesktopLocalOriginActive()) {
     try {
@@ -378,6 +378,7 @@ export const requestFileAccess = async (
         multiple: false,
         title: 'Select File',
         ...(options?.filters ? { filters: options.filters } : {}),
+        ...(options?.defaultPath ? { defaultPath: options.defaultPath } : {}),
       });
       if (!selected || typeof selected !== 'string') {
         return { success: false, error: 'File selection cancelled' };

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1012,6 +1012,7 @@ export const dict = {
   'rightSidebar.contextNotesTodo.todo.actions.delete': 'Delete "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.send': 'Send "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.reorder': 'Reorder "{text}"',
+  'rightSidebar.contextNotesTodo.todo.resizeAria': 'Resize todo list',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': 'Send to current session',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': 'Send to new session',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': 'Send to new worktree session',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -999,6 +999,7 @@ export const dict = {
   'rightSidebar.contextNotesTodo.empty.selectProject': 'Select a project to add notes and todos.',
   'rightSidebar.contextNotesTodo.notes.title': 'Quick notes - {project}',
   'rightSidebar.contextNotesTodo.notes.placeholder': 'Capture context, reminders, or links',
+  'rightSidebar.contextNotesTodo.notes.resizeAria': 'Resize notes panel',
   'rightSidebar.contextNotesTodo.todo.title': 'Todo',
   'rightSidebar.contextNotesTodo.todo.itemsSingle': '{count} item',
   'rightSidebar.contextNotesTodo.todo.itemsPlural': '{count} items',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1011,6 +1011,7 @@ export const dict = {
   'rightSidebar.contextNotesTodo.todo.actions.expand': 'Expand todo "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.delete': 'Delete "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.send': 'Send "{text}"',
+  'rightSidebar.contextNotesTodo.todo.actions.reorder': 'Reorder "{text}"',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': 'Send to current session',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': 'Send to new session',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': 'Send to new worktree session',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -999,7 +999,6 @@ export const dict = {
   'rightSidebar.contextNotesTodo.empty.selectProject': 'Select a project to add notes and todos.',
   'rightSidebar.contextNotesTodo.notes.title': 'Quick notes - {project}',
   'rightSidebar.contextNotesTodo.notes.placeholder': 'Capture context, reminders, or links',
-  'rightSidebar.contextNotesTodo.notes.resizeAria': 'Resize notes panel',
   'rightSidebar.contextNotesTodo.todo.title': 'Todo',
   'rightSidebar.contextNotesTodo.todo.itemsSingle': '{count} item',
   'rightSidebar.contextNotesTodo.todo.itemsPlural': '{count} items',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -977,6 +977,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.expand": "Expandir tarea pendiente \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Eliminar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Enviar \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.actions.reorder": "Reordenar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Enviar a la sesión actual",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Enviar a una nueva sesión",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Enviar a una nueva sesión de worktree",

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -965,7 +965,6 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.empty.selectProject": "Selecciona un proyecto para añadir notas y tareas pendientes.",
   "rightSidebar.contextNotesTodo.notes.title": "Notas rápidas — {project}",
   "rightSidebar.contextNotesTodo.notes.placeholder": "Captura contexto, recordatorios o enlaces",
-  "rightSidebar.contextNotesTodo.notes.resizeAria": "Redimensionar panel de notas",
   "rightSidebar.contextNotesTodo.todo.title": "Tareas pendientes",
   "rightSidebar.contextNotesTodo.todo.itemsSingle": "{count} elemento",
   "rightSidebar.contextNotesTodo.todo.itemsPlural": "{count} elementos",

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -978,6 +978,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Eliminar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Enviar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.reorder": "Reordenar \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.resizeAria": "Redimensionar lista de tareas",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Enviar a la sesión actual",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Enviar a una nueva sesión",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Enviar a una nueva sesión de worktree",

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -965,6 +965,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.empty.selectProject": "Selecciona un proyecto para añadir notas y tareas pendientes.",
   "rightSidebar.contextNotesTodo.notes.title": "Notas rápidas — {project}",
   "rightSidebar.contextNotesTodo.notes.placeholder": "Captura contexto, recordatorios o enlaces",
+  "rightSidebar.contextNotesTodo.notes.resizeAria": "Redimensionar panel de notas",
   "rightSidebar.contextNotesTodo.todo.title": "Tareas pendientes",
   "rightSidebar.contextNotesTodo.todo.itemsSingle": "{count} elemento",
   "rightSidebar.contextNotesTodo.todo.itemsPlural": "{count} elementos",

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1002,6 +1002,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.empty.selectProject': '메모와 Todo를 추가할 프로젝트를 선택하세요.',
   'rightSidebar.contextNotesTodo.notes.title': '빠른 메모 - {project}',
   'rightSidebar.contextNotesTodo.notes.placeholder': '컨텍스트, 리마인더, 링크를 기록하세요',
+  'rightSidebar.contextNotesTodo.notes.resizeAria': '메모 패널 크기 조정',
   'rightSidebar.contextNotesTodo.todo.title': 'Todo',
   'rightSidebar.contextNotesTodo.todo.itemsSingle': '{count}개 항목',
   'rightSidebar.contextNotesTodo.todo.itemsPlural': '{count}개 항목',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1015,6 +1015,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.delete': '"{text}" 삭제',
   'rightSidebar.contextNotesTodo.todo.actions.send': '보내기 "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.reorder': '재정렬 "{text}"',
+  'rightSidebar.contextNotesTodo.todo.resizeAria': '할 일 목록 크기 조정',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': '현재 세션으로 보내기',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': '새 세션으로 보내기',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': '새 워크트리 세션으로 보내기',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1014,6 +1014,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.expand': '펼치기 todo "{text}"',
   'rightSidebar.contextNotesTodo.todo.actions.delete': '"{text}" 삭제',
   'rightSidebar.contextNotesTodo.todo.actions.send': '보내기 "{text}"',
+  'rightSidebar.contextNotesTodo.todo.actions.reorder': '재정렬 "{text}"',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': '현재 세션으로 보내기',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': '새 세션으로 보내기',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': '새 워크트리 세션으로 보내기',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1002,7 +1002,6 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.empty.selectProject': '메모와 Todo를 추가할 프로젝트를 선택하세요.',
   'rightSidebar.contextNotesTodo.notes.title': '빠른 메모 - {project}',
   'rightSidebar.contextNotesTodo.notes.placeholder': '컨텍스트, 리마인더, 링크를 기록하세요',
-  'rightSidebar.contextNotesTodo.notes.resizeAria': '메모 패널 크기 조정',
   'rightSidebar.contextNotesTodo.todo.title': 'Todo',
   'rightSidebar.contextNotesTodo.todo.itemsSingle': '{count}개 항목',
   'rightSidebar.contextNotesTodo.todo.itemsPlural': '{count}개 항목',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1888,6 +1888,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.expand': 'Rozwiń zadanie „{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.markComplete': 'Oznacz „{text}” jako ukończone',
   'rightSidebar.contextNotesTodo.todo.actions.send': 'Wyślij „{text}”',
+  'rightSidebar.contextNotesTodo.todo.actions.reorder': 'Zmień kolejność "{text}"',
   'rightSidebar.contextNotesTodo.todo.addAria': 'Dodaj zadanie',
   'rightSidebar.contextNotesTodo.todo.clearCompleted': 'Wyczyść ukończone',
   'rightSidebar.contextNotesTodo.todo.empty': 'Brak zadań. Dodaj krótką checklistę dla tego projektu.',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1889,6 +1889,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.markComplete': 'Oznacz „{text}” jako ukończone',
   'rightSidebar.contextNotesTodo.todo.actions.send': 'Wyślij „{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.reorder': 'Zmień kolejność "{text}"',
+  'rightSidebar.contextNotesTodo.todo.resizeAria': 'Zmień rozmiar listy zadań',
   'rightSidebar.contextNotesTodo.todo.addAria': 'Dodaj zadanie',
   'rightSidebar.contextNotesTodo.todo.clearCompleted': 'Wyczyść ukończone',
   'rightSidebar.contextNotesTodo.todo.empty': 'Brak zadań. Dodaj krótką checklistę dla tego projektu.',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1854,6 +1854,7 @@ export const dict: Record<I18nKey, string> = {
   'projectEditDialog.toast.iconUpdated': 'Zaktualizowano ikonę projektu',
   'rightSidebar.contextNotesTodo.empty.selectProject': 'Wybierz projekt, aby dodać notatki i zadania.',
   'rightSidebar.contextNotesTodo.notes.placeholder': 'Zapisz kontekst, przypomnienia lub linki',
+  'rightSidebar.contextNotesTodo.notes.resizeAria': 'Zmień rozmiar panelu notatek',
   'rightSidebar.contextNotesTodo.notes.title': 'Szybkie notatki — {project}',
   'rightSidebar.contextNotesTodo.plan.defaultTitle': 'Plan',
   'rightSidebar.contextNotesTodo.plans.deletePlan': 'Usuń plan',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1854,7 +1854,6 @@ export const dict: Record<I18nKey, string> = {
   'projectEditDialog.toast.iconUpdated': 'Zaktualizowano ikonę projektu',
   'rightSidebar.contextNotesTodo.empty.selectProject': 'Wybierz projekt, aby dodać notatki i zadania.',
   'rightSidebar.contextNotesTodo.notes.placeholder': 'Zapisz kontekst, przypomnienia lub linki',
-  'rightSidebar.contextNotesTodo.notes.resizeAria': 'Zmień rozmiar panelu notatek',
   'rightSidebar.contextNotesTodo.notes.title': 'Szybkie notatki — {project}',
   'rightSidebar.contextNotesTodo.plan.defaultTitle': 'Plan',
   'rightSidebar.contextNotesTodo.plans.deletePlan': 'Usuń plan',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -965,6 +965,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.empty.selectProject": "Selecione um projeto para adicionar notas e tarefas pendentes.",
   "rightSidebar.contextNotesTodo.notes.title": "Notas rápidas — {project}",
   "rightSidebar.contextNotesTodo.notes.placeholder": "Capture contexto, lembretes ou links",
+  "rightSidebar.contextNotesTodo.notes.resizeAria": "Redimensionar painel de notas",
   "rightSidebar.contextNotesTodo.todo.title": "Tarefas pendentes",
   "rightSidebar.contextNotesTodo.todo.itemsSingle": "{count} elemento",
   "rightSidebar.contextNotesTodo.todo.itemsPlural": "{count} elementos",

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -977,6 +977,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.expand": "Expandir tarefa pendente \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Excluir \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Enviar \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.actions.reorder": "Reordenar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Enviar à sessão atual",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Enviar a uma nova sessão",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Enviar a uma nova sessão de worktree",

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -978,6 +978,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Excluir \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Enviar \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.reorder": "Reordenar \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.resizeAria": "Redimensionar lista de tarefas",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Enviar à sessão atual",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Enviar a uma nova sessão",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Enviar a uma nova sessão de worktree",

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -965,7 +965,6 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.empty.selectProject": "Selecione um projeto para adicionar notas e tarefas pendentes.",
   "rightSidebar.contextNotesTodo.notes.title": "Notas rápidas — {project}",
   "rightSidebar.contextNotesTodo.notes.placeholder": "Capture contexto, lembretes ou links",
-  "rightSidebar.contextNotesTodo.notes.resizeAria": "Redimensionar painel de notas",
   "rightSidebar.contextNotesTodo.todo.title": "Tarefas pendentes",
   "rightSidebar.contextNotesTodo.todo.itemsSingle": "{count} elemento",
   "rightSidebar.contextNotesTodo.todo.itemsPlural": "{count} elementos",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -965,7 +965,6 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.empty.selectProject": "Виберіть проєкт, щоб додати нотатки та завдання.",
   "rightSidebar.contextNotesTodo.notes.title": "Швидкі нотатки - {project}",
   "rightSidebar.contextNotesTodo.notes.placeholder": "Зберігайте контекст, нагадування або посилання",
-  "rightSidebar.contextNotesTodo.notes.resizeAria": "Змінити розмір панелі нотаток",
   "rightSidebar.contextNotesTodo.todo.title": "Todo",
   "rightSidebar.contextNotesTodo.todo.itemsSingle": "{count} пункт",
   "rightSidebar.contextNotesTodo.todo.itemsPlural": "пунктів: {count}",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -965,6 +965,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.empty.selectProject": "Виберіть проєкт, щоб додати нотатки та завдання.",
   "rightSidebar.contextNotesTodo.notes.title": "Швидкі нотатки - {project}",
   "rightSidebar.contextNotesTodo.notes.placeholder": "Зберігайте контекст, нагадування або посилання",
+  "rightSidebar.contextNotesTodo.notes.resizeAria": "Змінити розмір панелі нотаток",
   "rightSidebar.contextNotesTodo.todo.title": "Todo",
   "rightSidebar.contextNotesTodo.todo.itemsSingle": "{count} пункт",
   "rightSidebar.contextNotesTodo.todo.itemsPlural": "пунктів: {count}",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -977,6 +977,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.expand": "Розгорнути завдання \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Видалити \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Надіслати \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.actions.reorder": "Змінити порядок \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Надіслати до поточної сесії",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Надіслати до нової сесії",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Надіслати до нової сесії в worktree",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -978,6 +978,7 @@ export const dict: Record<I18nKey, string> = {
   "rightSidebar.contextNotesTodo.todo.actions.delete": "Видалити \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.send": "Надіслати \"{text}\"",
   "rightSidebar.contextNotesTodo.todo.actions.reorder": "Змінити порядок \"{text}\"",
+  "rightSidebar.contextNotesTodo.todo.resizeAria": "Змінити розмір списку завдань",
   "rightSidebar.contextNotesTodo.todo.sendMenu.currentSession": "Надіслати до поточної сесії",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newSession": "Надіслати до нової сесії",
   "rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession": "Надіслати до нової сесії в worktree",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -965,6 +965,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.empty.selectProject': '请选择一个项目以添加笔记和待办事项。',
   'rightSidebar.contextNotesTodo.notes.title': '快速笔记 - {project}',
   'rightSidebar.contextNotesTodo.notes.placeholder': '记录上下文、提醒或链接',
+  'rightSidebar.contextNotesTodo.notes.resizeAria': '调整笔记面板大小',
   'rightSidebar.contextNotesTodo.todo.title': '待办',
   'rightSidebar.contextNotesTodo.todo.itemsSingle': '{count} 项',
   'rightSidebar.contextNotesTodo.todo.itemsPlural': '{count} 项',

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -978,6 +978,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.delete': '删除“{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.send': '发送“{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.reorder': '重新排序"{text}"',
+  'rightSidebar.contextNotesTodo.todo.resizeAria': '调整待办列表大小',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': '发送到当前会话',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': '发送到新会话',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': '发送到新 worktree 会话',

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -965,7 +965,6 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.empty.selectProject': '请选择一个项目以添加笔记和待办事项。',
   'rightSidebar.contextNotesTodo.notes.title': '快速笔记 - {project}',
   'rightSidebar.contextNotesTodo.notes.placeholder': '记录上下文、提醒或链接',
-  'rightSidebar.contextNotesTodo.notes.resizeAria': '调整笔记面板大小',
   'rightSidebar.contextNotesTodo.todo.title': '待办',
   'rightSidebar.contextNotesTodo.todo.itemsSingle': '{count} 项',
   'rightSidebar.contextNotesTodo.todo.itemsPlural': '{count} 项',

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -977,6 +977,7 @@ export const dict: Record<I18nKey, string> = {
   'rightSidebar.contextNotesTodo.todo.actions.expand': '展开待办“{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.delete': '删除“{text}”',
   'rightSidebar.contextNotesTodo.todo.actions.send': '发送“{text}”',
+  'rightSidebar.contextNotesTodo.todo.actions.reorder': '重新排序"{text}"',
   'rightSidebar.contextNotesTodo.todo.sendMenu.currentSession': '发送到当前会话',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newSession': '发送到新会话',
   'rightSidebar.contextNotesTodo.todo.sendMenu.newWorktreeSession': '发送到新 worktree 会话',

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -492,9 +492,7 @@ interface UIStore {
   bottomTerminalHeight: number;
   hasManuallyResizedBottomTerminal: boolean;
   notesPanelHeight: number;
-  hasManuallyResizedNotesPanel: boolean;
   todoPanelHeight: number;
-  hasManuallyResizedTodoPanel: boolean;
   isSessionSwitcherOpen: boolean;
   activeMainTab: MainTab;
   mainTabGuard: MainTabGuard | null;
@@ -755,9 +753,7 @@ export const useUIStore = create<UIStore>()(
         bottomTerminalHeight: 300,
         hasManuallyResizedBottomTerminal: false,
         notesPanelHeight: 112,
-        hasManuallyResizedNotesPanel: false,
         todoPanelHeight: 259,
-        hasManuallyResizedTodoPanel: false,
         isSessionSwitcherOpen: false,
         activeMainTab: 'chat',
         mainTabGuard: null,
@@ -1286,11 +1282,11 @@ export const useUIStore = create<UIStore>()(
         },
 
         setNotesPanelHeight: (height) => {
-          set({ notesPanelHeight: height, hasManuallyResizedNotesPanel: true });
+          set({ notesPanelHeight: height });
         },
 
         setTodoPanelHeight: (height) => {
-          set({ todoPanelHeight: height, hasManuallyResizedTodoPanel: true });
+          set({ todoPanelHeight: height });
         },
 
         setSessionSwitcherOpen: (open) => {
@@ -1958,14 +1954,8 @@ export const useUIStore = create<UIStore>()(
             if (typeof state.notesPanelHeight !== 'number' || !Number.isFinite(state.notesPanelHeight)) {
               state.notesPanelHeight = 112;
             }
-            if (typeof state.hasManuallyResizedNotesPanel !== 'boolean') {
-              state.hasManuallyResizedNotesPanel = false;
-            }
             if (typeof state.todoPanelHeight !== 'number' || !Number.isFinite(state.todoPanelHeight)) {
               state.todoPanelHeight = 259;
-            }
-            if (typeof state.hasManuallyResizedTodoPanel !== 'boolean') {
-              state.hasManuallyResizedTodoPanel = false;
             }
           }
 

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -491,6 +491,10 @@ interface UIStore {
   isBottomTerminalExpanded: boolean;
   bottomTerminalHeight: number;
   hasManuallyResizedBottomTerminal: boolean;
+  notesPanelHeight: number;
+  hasManuallyResizedNotesPanel: boolean;
+  todoPanelHeight: number;
+  hasManuallyResizedTodoPanel: boolean;
   isSessionSwitcherOpen: boolean;
   activeMainTab: MainTab;
   mainTabGuard: MainTabGuard | null;
@@ -618,6 +622,8 @@ interface UIStore {
   setBottomTerminalOpen: (open: boolean) => void;
   setBottomTerminalExpanded: (expanded: boolean) => void;
   setBottomTerminalHeight: (height: number) => void;
+  setNotesPanelHeight: (height: number) => void;
+  setTodoPanelHeight: (height: number) => void;
   setSessionSwitcherOpen: (open: boolean) => void;
   setActiveMainTab: (tab: MainTab) => void;
   setMainTabGuard: (guard: MainTabGuard | null) => void;
@@ -748,6 +754,10 @@ export const useUIStore = create<UIStore>()(
         isBottomTerminalExpanded: false,
         bottomTerminalHeight: 300,
         hasManuallyResizedBottomTerminal: false,
+        notesPanelHeight: 112,
+        hasManuallyResizedNotesPanel: false,
+        todoPanelHeight: 259,
+        hasManuallyResizedTodoPanel: false,
         isSessionSwitcherOpen: false,
         activeMainTab: 'chat',
         mainTabGuard: null,
@@ -1273,6 +1283,14 @@ export const useUIStore = create<UIStore>()(
 
         setBottomTerminalHeight: (height) => {
           set({ bottomTerminalHeight: height, hasManuallyResizedBottomTerminal: true });
+        },
+
+        setNotesPanelHeight: (height) => {
+          set({ notesPanelHeight: height, hasManuallyResizedNotesPanel: true });
+        },
+
+        setTodoPanelHeight: (height) => {
+          set({ todoPanelHeight: height, hasManuallyResizedTodoPanel: true });
         },
 
         setSessionSwitcherOpen: (open) => {
@@ -1928,12 +1946,28 @@ export const useUIStore = create<UIStore>()(
       {
         name: 'ui-store',
         storage: createJSONStorage(() => getSafeStorage()),
-        version: 8,
+        version: 9,
         migrate: (persistedState, version) => {
           if (!persistedState || typeof persistedState !== 'object') {
             return persistedState;
           }
           const state = persistedState as Record<string, unknown>;
+
+          // v8 -> v9: initialize notes/todo panel height fields
+          if (version < 9) {
+            if (typeof state.notesPanelHeight !== 'number' || !Number.isFinite(state.notesPanelHeight)) {
+              state.notesPanelHeight = 112;
+            }
+            if (typeof state.hasManuallyResizedNotesPanel !== 'boolean') {
+              state.hasManuallyResizedNotesPanel = false;
+            }
+            if (typeof state.todoPanelHeight !== 'number' || !Number.isFinite(state.todoPanelHeight)) {
+              state.todoPanelHeight = 259;
+            }
+            if (typeof state.hasManuallyResizedTodoPanel !== 'boolean') {
+              state.hasManuallyResizedTodoPanel = false;
+            }
+          }
 
           // v0 -> v1: reset legacy notification templates
           if (version < 1) {
@@ -2019,6 +2053,8 @@ export const useUIStore = create<UIStore>()(
           isBottomTerminalOpen: state.isBottomTerminalOpen,
           isBottomTerminalExpanded: state.isBottomTerminalExpanded,
           bottomTerminalHeight: state.bottomTerminalHeight,
+          notesPanelHeight: state.notesPanelHeight,
+          todoPanelHeight: state.todoPanelHeight,
           isSessionSwitcherOpen: state.isSessionSwitcherOpen,
           activeMainTab: state.activeMainTab,
           sidebarSection: state.sidebarSection,


### PR DESCRIPTION
## Summary

Improves the Project Notes & Todo context panel with three quality-of-life enhancements:

- **Resizable panels** — Both the todo list and quick notes panels can now be resized by dragging a handle. Heights are density-aware (adapt to the active padding scale) and clamped between a 5-item minimum and 15-item maximum.
- **Drag & drop todo reordering** — Todo items can be reordered via drag & drop using `@dnd-kit`, with visual opacity feedback during drag.
- **Persistent panel sizes** — Resized heights are stored in `useUIStore` and survive page reloads/session switches.

Additional fixes included:
- Removed the hardcoded `max-h-80` cap on the quick notes textarea so user-resized heights are respected.
- Plan import file picker now opens at the project root directory instead of the OS default.
- i18n message keys added across all supported locales.

## Changed files

| File | Change |
|---|---|
| `ProjectNotesTodoPanel.tsx` | Core feature implementation |
| `useUIStore.ts` | Added `todoPanelHeight`, `notesPanelHeight` state + setters |
| `desktop.ts` | `requestFileAccess` export for file picker path hint |
| `en/es/ko/pl/pt-BR/uk/zh-CN.ts` | New i18n keys |
| `electron/main.mjs` | Minor supporting change |