### PR TITLE
fix: display selected source label in skills catalog dropdown

### DIFF
--- a/packages/ui/src/components/sections/skills/catalog/SkillsCatalogPage.tsx
+++ b/packages/ui/src/components/sections/skills/catalog/SkillsCatalogPage.tsx
@@ -199,7 +199,9 @@ export const SkillsCatalogPage: React.FC<SkillsCatalogPageProps> = ({ mode, onMo
                 onValueChange={(v) => setSelectedSource(v)}
               >
                 <SelectTrigger className="w-fit">
-                  <SelectValue placeholder={t('settings.skills.catalog.page.field.selectSourcePlaceholder')} />
+                  <SelectValue placeholder={t('settings.skills.catalog.page.field.selectSourcePlaceholder')}>
+                    {selectedSource?.label}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent align="start">
                   {sources.map((src) => (


### PR DESCRIPTION
Fixes a minor bug in the Skills catalog dropdown, which currently shows the internal ID instead of the label.

Before:
<img width="736" height="205" alt="Screenshot 2026-05-15 at 1 05 44 PM" src="https://github.com/user-attachments/assets/a6f42d84-fd90-494f-9e69-3038aec0af86" />
After:
<img width="736" height="205" alt="Screenshot 2026-05-15 at 1 05 51 PM" src="https://github.com/user-attachments/assets/2e2bdc09-50c4-4caf-9bc7-7a33a60a4b41" />
