### PR TITLE
fix: match root project sessions in switcher

### DIFF
--- a/packages/ui/src/components/session/sidebar/hooks/useSwitcherItems.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSwitcherItems.ts
@@ -7,7 +7,7 @@ import { useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
 import { useGitAllBranches, useGitStore } from '@/stores/useGitStore';
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
 import type { SessionNode } from '../types';
-import { compareSessionsByPinnedAndTime } from '../utils';
+import { compareSessionsByPinnedAndTime, isPathWithinProject } from '../utils';
 
 export type SwitcherItem = {
   node: SessionNode;
@@ -60,7 +60,7 @@ export const useSwitcherItems = (enabled: boolean, options: SwitcherItemsOptions
     (directory: string | null) => {
       if (!directory) return null;
       const matches = normalizedProjects
-        .filter((project) => directory === project.normalizedPath || directory.startsWith(`${project.normalizedPath}/`))
+        .filter((project) => isPathWithinProject(directory, project.normalizedPath))
         .sort((a, b) => (b.normalizedPath?.length ?? 0) - (a.normalizedPath?.length ?? 0));
       return matches[0] ?? null;
     },

--- a/packages/ui/src/components/session/sidebar/utils.test.ts
+++ b/packages/ui/src/components/session/sidebar/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isPathWithinProject } from './utils';
+
+describe('isPathWithinProject', () => {
+  test('matches child directories for root projects', () => {
+    expect(isPathWithinProject('/workspace/app', '/')).toBe(true);
+  });
+
+  test('matches exact project directories', () => {
+    expect(isPathWithinProject('/workspace/app', '/workspace/app')).toBe(true);
+  });
+
+  test('does not match sibling directory prefixes', () => {
+    expect(isPathWithinProject('/workspace/app2', '/workspace/app')).toBe(false);
+  });
+});

--- a/packages/ui/src/components/session/sidebar/utils.test.ts
+++ b/packages/ui/src/components/session/sidebar/utils.test.ts
@@ -14,4 +14,16 @@ describe('isPathWithinProject', () => {
   test('does not match sibling directory prefixes', () => {
     expect(isPathWithinProject('/workspace/app2', '/workspace/app')).toBe(false);
   });
+
+  test('returns false when directory is null', () => {
+    expect(isPathWithinProject(null, '/workspace/app')).toBe(false);
+  });
+
+  test('returns false when projectPath is null', () => {
+    expect(isPathWithinProject('/workspace/app', null)).toBe(false);
+  });
+
+  test('matches deep child directories', () => {
+    expect(isPathWithinProject('/workspace/app/sub/dir', '/workspace/app')).toBe(true);
+  });
 });

--- a/packages/ui/src/components/session/sidebar/utils.tsx
+++ b/packages/ui/src/components/session/sidebar/utils.tsx
@@ -81,6 +81,15 @@ export const normalizePath = (value?: string | null) => {
   return normalized.length === 0 ? '/' : normalized;
 };
 
+export const isPathWithinProject = (directory?: string | null, projectPath?: string | null): boolean => {
+  const normalizedDirectory = normalizePath(directory);
+  const normalizedProjectPath = normalizePath(projectPath);
+  if (!normalizedDirectory || !normalizedProjectPath) return false;
+  if (normalizedDirectory === normalizedProjectPath) return true;
+  if (normalizedProjectPath === '/') return normalizedDirectory.startsWith('/');
+  return normalizedDirectory.startsWith(`${normalizedProjectPath}/`);
+};
+
 export const normalizeForBranchComparison = (value: string): string => {
   return value
     .toLowerCase()


### PR DESCRIPTION
## Summary
- Fix session switcher project matching so a project rooted at `/` includes child session directories.
- Add a targeted regression test for root, exact, and sibling-prefix path matching.

## Validation
- `vet "Fix root-scoped projects matching child session directories in the session switcher" --agentic --agent-harness claude`
- `bun test packages/ui/src/components/session/sidebar/utils.test.ts`
- `bun run type-check`
- `bun run lint`
- `git diff --check`