### PR TITLE
fix(ui): load agents from OpenCode /agent endpoint

### DIFF
--- a/packages/ui/src/lib/opencode/client.test.ts
+++ b/packages/ui/src/lib/opencode/client.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { opencodeClient } from './client'
+
+type MutableClientState = {
+  client: {
+    app: {
+      agents: (options?: { directory?: string }) => Promise<{ data?: Array<{ name: string }> }>
+    }
+  }
+  currentDirectory?: string
+}
+
+const clientState = opencodeClient as unknown as MutableClientState
+const originalClient = clientState.client
+const originalDirectory = clientState.currentDirectory
+const originalFetch = globalThis.fetch
+
+beforeEach(() => {
+  clientState.client = originalClient
+  clientState.currentDirectory = originalDirectory
+  globalThis.fetch = originalFetch
+})
+
+describe('opencodeClient.listAgents', () => {
+  test('prefers the /agent endpoint so plugin agents remain visible', async () => {
+    clientState.client = {
+      app: {
+        agents: async () => ({
+          data: [{ name: 'build' }],
+        }),
+      },
+    }
+
+    clientState.currentDirectory = '/workspace/project'
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      expect(url).toBe('http://localhost/api/agent?directory=%2Fworkspace%2Fproject')
+
+      return new Response(JSON.stringify([
+        { name: 'build' },
+        { name: 'sisyphus' },
+      ]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const agents = await opencodeClient.listAgents()
+
+    expect(agents).toEqual([
+      { name: 'build' },
+      { name: 'sisyphus' },
+    ])
+  })
+})

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -1259,6 +1259,29 @@ class OpencodeService {
   // Agent Management
   async listAgents(): Promise<Agent[]> {
     try {
+      const base = this.baseUrl.replace(/\/+$/, '');
+      const url = new URL(`${base}/agent`, typeof window !== 'undefined' ? window.location.href : 'http://localhost');
+      if (this.currentDirectory) {
+        url.searchParams.set('directory', this.currentDirectory);
+      }
+
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        const data = await response.json().catch(() => null);
+        if (Array.isArray(data)) {
+          return data as Agent[];
+        }
+      }
+    } catch {
+    }
+
+    try {
       const response = await this.client.app.agents(
         this.currentDirectory ? { directory: this.currentDirectory } : undefined
       );

--- a/packages/ui/src/sync/bootstrap.ts
+++ b/packages/ui/src/sync/bootstrap.ts
@@ -1,4 +1,5 @@
 import type { OpencodeClient, PermissionRequest, Project, QuestionRequest } from "@opencode-ai/sdk/v2/client"
+import { opencodeClient } from "@/lib/opencode/client"
 import { retry } from "./retry"
 import type { GlobalState, State } from "./types"
 
@@ -187,7 +188,7 @@ export async function bootstrapDirectory(input: {
   // These enrich the UI but aren't required for basic functionality.
   // ---------------------------------------------------------------------------
   void Promise.allSettled([
-    retry(() => sdk.app.agents().then((x) => set({ agent: unwrap(x, "app.agents") }))),
+    retry(() => opencodeClient.withDirectory(directory, () => opencodeClient.listAgents()).then((agents) => set({ agent: agents }))),
     retry(() => sdk.command.list().then((x) => set({ command: unwrap(x, "command.list") }))),
     retry(() => sdk.mcp.status().then((x) => set({ mcp: unwrap(x, "mcp.status") }))),
     retry(() => sdk.lsp.status().then((x) => set({ lsp: unwrap(x, "lsp.status") }))),


### PR DESCRIPTION
## Summary
- use the OpenCode `/agent` endpoint as the primary UI agent source so plugin-provided agents like oh-my-openagent remain visible in OpenChamber
- keep the existing SDK `app.agents()` call as a fallback when the proxied endpoint is unavailable
- route bootstrap agent loading through the shared client and add a regression test covering the `/agent` path

## Testing
- `bun run --cwd packages/ui type-check`
- `bun test packages/ui/src/lib/opencode/client.test.ts`

## Context
- addresses the agent discovery gap reported around OMO/OpenAgent integration in OpenChamber UI
- related to #1002