### PR TITLE
fix(ui): prevent revert dock from occluding pending changes popover

### DIFF
--- a/packages/ui/src/components/chat/PendingChangesBar.tsx
+++ b/packages/ui/src/components/chat/PendingChangesBar.tsx
@@ -14,6 +14,7 @@ import {
     isGitFile,
 } from './changedFiles';
 import { ChangedFilesList } from './ChangedFilesList';
+import { changedFilesPopoverClassName, changedFilesPopoverStyle } from './changedFilesPopover';
 import { useI18n } from '@/lib/i18n';
 
 export const PendingChangesBar: React.FC = React.memo(() => {
@@ -135,15 +136,12 @@ export const PendingChangesBar: React.FC = React.memo(() => {
             {isExpanded && (
                 <div
                     style={{
+                        ...changedFilesPopoverStyle,
                         maxWidth: 'min(28rem, calc(100cqw - 4ch))',
-                        backgroundColor: 'var(--surface-elevated)',
-                        color: 'var(--surface-elevated-foreground)',
                     }}
                     className={cn(
+                        changedFilesPopoverClassName,
                         "absolute left-0 bottom-full mb-1 z-50",
-                        "w-max min-w-[280px] max-w-full rounded-xl p-1",
-                        "shadow-[inset_0_1px_0_0_rgba(255,255,255,0.8),inset_0_0_0_1px_rgba(0,0,0,0.04),0_0_0_1px_rgba(0,0,0,0.10),0_1px_2px_-0.5px_rgba(0,0,0,0.08),0_4px_8px_-2px_rgba(0,0,0,0.08),0_12px_20px_-4px_rgba(0,0,0,0.08)]",
-                        "dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12),inset_0_0_0_1px_rgba(255,255,255,0.08),0_0_0_1px_rgba(0,0,0,0.36),0_1px_1px_-0.5px_rgba(0,0,0,0.22),0_3px_3px_-1.5px_rgba(0,0,0,0.20),0_6px_6px_-3px_rgba(0,0,0,0.16)]",
                         "animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2",
                         "duration-150"
                     )}

--- a/packages/ui/src/components/chat/PendingChangesBar.tsx
+++ b/packages/ui/src/components/chat/PendingChangesBar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Popover } from '@base-ui/react/popover';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useGitStore, useIsGitRepo } from '@/stores/useGitStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -7,6 +6,7 @@ import { RuntimeAPIContext } from '@/contexts/runtimeAPIContext';
 import { sessionEvents } from '@/lib/sessionEvents';
 import { normalizePath } from '@/components/session/sidebar/utils';
 import { Icon } from "@/components/icon/Icon";
+import { cn } from '@/lib/utils';
 import {
     type ChangedFileEntry,
     type GitChangedFile,
@@ -14,12 +14,12 @@ import {
     isGitFile,
 } from './changedFiles';
 import { ChangedFilesList } from './ChangedFilesList';
-import { changedFilesPopoverClassName, changedFilesPopoverStyle } from './changedFilesPopover';
 import { useI18n } from '@/lib/i18n';
 
 export const PendingChangesBar: React.FC = React.memo(() => {
     const { t } = useI18n();
     const [isExpanded, setIsExpanded] = React.useState(false);
+    const popoverRef = React.useRef<HTMLDivElement>(null);
     const currentDirectory = useDirectoryStore((s) => s.currentDirectory);
     const runtime = React.useContext(RuntimeAPIContext);
     const isGitRepo = useIsGitRepo(currentDirectory);
@@ -28,6 +28,20 @@ export const PendingChangesBar: React.FC = React.memo(() => {
     );
     const ensureStatus = useGitStore((s) => s.ensureStatus);
     const fetchStatus = useGitStore((s) => s.fetchStatus);
+
+    // Close popover when clicking outside
+    React.useEffect(() => {
+        if (!isExpanded) return;
+
+        const handleClickOutside = (event: MouseEvent) => {
+            if (popoverRef.current && !popoverRef.current.contains(event.target as Node)) {
+                setIsExpanded(false);
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, [isExpanded]);
 
     // Seed git store for currentDirectory so the bar can render independently of
     // DiffView/GitView/right-sidebar mounting. ensureStatus has a 5s staleness
@@ -96,45 +110,52 @@ export const PendingChangesBar: React.FC = React.memo(() => {
         : t('chat.pendingChanges.fileCountPlural', { count: fileCount });
 
     return (
-        <Popover.Root open={isExpanded} onOpenChange={setIsExpanded}>
-            <Popover.Trigger
-                render={
-                    <button
-                        type="button"
-                        className="flex min-w-0 max-w-full items-center gap-1 text-left text-muted-foreground"
-                    >
-                        <Icon name="file-edit" className="h-3.5 w-3.5 flex-shrink-0 text-[var(--status-warning)]" />
-                        <span className="min-w-0 typography-ui-label text-foreground flex-shrink-0">{labelHead}</span>
-                        <span className="status-row__changed-label min-w-0 typography-ui-label text-foreground truncate">
-                            {t('chat.pendingChanges.changedInWorkspace')}
-                        </span>
-                        <span className="text-[0.75rem] tabular-nums inline-flex items-baseline gap-1 flex-shrink-0">
-                            {totalAdded > 0 ? <span style={{ color: 'var(--status-success)' }}>+{totalAdded}</span> : null}
-                            {totalRemoved > 0 ? <span style={{ color: 'var(--status-error)' }}>-{totalRemoved}</span> : null}
-                        </span>
-                        {isExpanded ? (
-                            <Icon name="arrow-up-s" className="h-3.5 w-3.5 flex-shrink-0" />
-                        ) : (
-                            <Icon name="arrow-down-s" className="h-3.5 w-3.5 flex-shrink-0" />
-                        )}
-                    </button>
-                }
-            />
-            <Popover.Portal>
-                <Popover.Positioner side="top" align="start" sideOffset={4} collisionPadding={8}>
-                    <Popover.Popup
-                        style={changedFilesPopoverStyle}
-                        className={`${changedFilesPopoverClassName} transition-all duration-150 ease-out data-[starting-style]:opacity-0 data-[starting-style]:scale-95 data-[ending-style]:opacity-0 data-[ending-style]:scale-95`}
-                    >
-                        <ChangedFilesList
-                            files={gitChangedFiles}
-                            currentDirectory={currentDirectory}
-                            onOpenFile={handleOpenFile}
-                        />
-                    </Popover.Popup>
-                </Popover.Positioner>
-            </Popover.Portal>
-        </Popover.Root>
+        <div className="relative" ref={popoverRef}>
+            <button
+                type="button"
+                className="flex min-w-0 max-w-full items-center gap-1 text-left text-muted-foreground"
+                onClick={() => setIsExpanded((value) => !value)}
+                aria-expanded={isExpanded}
+            >
+                <Icon name="file-edit" className="h-3.5 w-3.5 flex-shrink-0 text-[var(--status-warning)]" />
+                <span className="min-w-0 typography-ui-label text-foreground flex-shrink-0">{labelHead}</span>
+                <span className="status-row__changed-label min-w-0 typography-ui-label text-foreground truncate">
+                    {t('chat.pendingChanges.changedInWorkspace')}
+                </span>
+                <span className="text-[0.75rem] tabular-nums inline-flex items-baseline gap-1 flex-shrink-0">
+                    {totalAdded > 0 ? <span style={{ color: 'var(--status-success)' }}>+{totalAdded}</span> : null}
+                    {totalRemoved > 0 ? <span style={{ color: 'var(--status-error)' }}>-{totalRemoved}</span> : null}
+                </span>
+                {isExpanded ? (
+                    <Icon name="arrow-up-s" className="h-3.5 w-3.5 flex-shrink-0" />
+                ) : (
+                    <Icon name="arrow-down-s" className="h-3.5 w-3.5 flex-shrink-0" />
+                )}
+            </button>
+            {isExpanded && (
+                <div
+                    style={{
+                        maxWidth: 'min(28rem, calc(100cqw - 4ch))',
+                        backgroundColor: 'var(--surface-elevated)',
+                        color: 'var(--surface-elevated-foreground)',
+                    }}
+                    className={cn(
+                        "absolute left-0 bottom-full mb-1 z-50",
+                        "w-max min-w-[280px] max-w-full rounded-xl p-1",
+                        "shadow-[inset_0_1px_0_0_rgba(255,255,255,0.8),inset_0_0_0_1px_rgba(0,0,0,0.04),0_0_0_1px_rgba(0,0,0,0.10),0_1px_2px_-0.5px_rgba(0,0,0,0.08),0_4px_8px_-2px_rgba(0,0,0,0.08),0_12px_20px_-4px_rgba(0,0,0,0.08)]",
+                        "dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12),inset_0_0_0_1px_rgba(255,255,255,0.08),0_0_0_1px_rgba(0,0,0,0.36),0_1px_1px_-0.5px_rgba(0,0,0,0.22),0_3px_3px_-1.5px_rgba(0,0,0,0.20),0_6px_6px_-3px_rgba(0,0,0,0.16)]",
+                        "animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2",
+                        "duration-150"
+                    )}
+                >
+                    <ChangedFilesList
+                        files={gitChangedFiles}
+                        currentDirectory={currentDirectory}
+                        onOpenFile={handleOpenFile}
+                    />
+                </div>
+            )}
+        </div>
     );
 });
 


### PR DESCRIPTION
## Problem

The pending changes indicator (showing workspace file changes) is occluded by the reverted messages dock when the dock is expanded. Since the pending changes popover uses Base UI `Popover.Portal` (rendered to `<body>`), it falls into the same stacking context as the revert dock, and the dock visually covers it.

## Solution

Replace the Base UI `Popover` with `absolute bottom-full z-50` positioning, matching the approach already used by the todo popover in `StatusRow`. This keeps the popup inside the StatusRow's DOM hierarchy, so `z-50` naturally layers it above the revert dock, preventing the dock from occluding the pending changes popover.

### Changes
- Remove `@base-ui/react/popover` dependency from `PendingChangesBar`
- Use `absolute left-0 bottom-full mb-1 z-50` positioning (same as todo popover)
- Add click-outside dismissal via `popoverRef` + `mousedown` listener (same pattern as `StatusRow`)
- Add `cn` import for conditional class merging

### Screenshots

| Before | After |
|--------|-------|
| <img width="924" height="297" alt="Before" src="https://github.com/user-attachments/assets/fb016d89-a03c-46fe-b8a8-7f6cb540188a" /> | <img width="706" height="342" alt="After" src="https://github.com/user-attachments/assets/c3cfb34c-f5b5-4258-951d-4818a26aff65" /> |