### PR TITLE
fix: merge local + upstream skills so Claude Code skills appear in Skills tab, not Commands

### DIFF
--- a/packages/web/server/lib/opencode/skill-routes.js
+++ b/packages/web/server/lib/opencode/skill-routes.js
@@ -112,6 +112,35 @@ export const registerSkillRoutes = (app, dependencies) => {
     return { scope: SKILL_SCOPE.USER, source };
   };
 
+  /**
+   * Merge upstream (OpenCode server) skills with local (filesystem-scanned) skills.
+   * Deduplicates by name — local skills take priority because they have more
+   * complete scope/source/path metadata.
+   */
+  const mergeSkillLists = (upstreamSkills, localSkills) => {
+    const merged = new Map();
+    for (const skill of localSkills) {
+      merged.set(skill.name, skill);
+    }
+    for (const skill of upstreamSkills) {
+      if (!merged.has(skill.name)) {
+        merged.set(skill.name, skill);
+      }
+    }
+    return Array.from(merged.values());
+  };
+
+  /**
+   * Search for a specific skill across both upstream and local discovery.
+   * Used by individual skill file endpoints.
+   */
+  const findDiscoveredSkill = async (directory, skillName) => {
+    const upstreamSkills = await fetchOpenCodeDiscoveredSkills(directory) ?? [];
+    const localSkills = discoverSkills(directory);
+    const merged = mergeSkillLists(upstreamSkills, localSkills);
+    return merged.find((skill) => skill.name === skillName) || null;
+  };
+
   const fetchOpenCodeDiscoveredSkills = async (workingDirectory) => {
     if (!getOpenCodePort()) {
       return null;
@@ -195,7 +224,9 @@ export const registerSkillRoutes = (app, dependencies) => {
       if (!directory) {
         return res.status(400).json({ error });
       }
-      const skills = (await fetchOpenCodeDiscoveredSkills(directory)) || discoverSkills(directory);
+      const upstreamSkills = await fetchOpenCodeDiscoveredSkills(directory) ?? [];
+      const localSkills = discoverSkills(directory);
+      const skills = mergeSkillLists(upstreamSkills, localSkills);
 
       const enrichedSkills = skills.map((skill) => {
         const sources = getSkillSources(skill.name, directory, skill);
@@ -277,9 +308,12 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(404).json({ ok: false, error: { kind: 'invalidSource', message: 'Unknown source' } });
       }
 
-      const discovered = directory
-        ? ((await fetchOpenCodeDiscoveredSkills(directory)) || discoverSkills(directory))
-        : [];
+      let discovered = [];
+      if (directory) {
+        const upstreamSkills = await fetchOpenCodeDiscoveredSkills(directory) ?? [];
+        const localSkills = discoverSkills(directory);
+        discovered = mergeSkillLists(upstreamSkills, localSkills);
+      }
       const installedByName = new Map(discovered.map((s) => [s.name, s]));
 
       if (src.sourceType === 'clawdhub' || isClawdHubSource(src.source)) {
@@ -508,8 +542,7 @@ export const registerSkillRoutes = (app, dependencies) => {
       if (!directory) {
         return res.status(400).json({ error });
       }
-      const discoveredSkill = ((await fetchOpenCodeDiscoveredSkills(directory)) || [])
-        .find((skill) => skill.name === skillName) || null;
+      const discoveredSkill = await findDiscoveredSkill(directory, skillName);
       const sources = getSkillSources(skillName, directory, discoveredSkill);
 
       res.json({
@@ -537,8 +570,7 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = ((await fetchOpenCodeDiscoveredSkills(directory)) || [])
-        .find((skill) => skill.name === skillName) || null;
+      const discoveredSkill = await findDiscoveredSkill(directory, skillName);
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {
         return res.status(404).json({ error: 'Skill not found' });
@@ -626,8 +658,7 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = ((await fetchOpenCodeDiscoveredSkills(directory)) || [])
-        .find((skill) => skill.name === skillName) || null;
+      const discoveredSkill = await findDiscoveredSkill(directory, skillName);
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {
         return res.status(404).json({ error: 'Skill not found' });
@@ -660,8 +691,7 @@ export const registerSkillRoutes = (app, dependencies) => {
         return res.status(400).json({ error });
       }
 
-      const discoveredSkill = ((await fetchOpenCodeDiscoveredSkills(directory)) || [])
-        .find((skill) => skill.name === skillName) || null;
+      const discoveredSkill = await findDiscoveredSkill(directory, skillName);
       const sources = getSkillSources(skillName, directory, discoveredSkill);
       if (!sources.md.exists || !sources.md.dir) {
         return res.status(404).json({ error: 'Skill not found' });

--- a/packages/web/server/lib/opencode/skills.js
+++ b/packages/web/server/lib/opencode/skills.js
@@ -255,7 +255,7 @@ function getSkillSources(skillName, workingDirectory, discoveredSkill = null) {
     mdScope = SKILL_SCOPE.USER;
     mdSource = 'opencode';
     mdDir = userDir;
-  } else if (matchedDiscovered?.path) {
+  } else if (matchedDiscovered?.path && fs.existsSync(matchedDiscovered.path)) {
     mdPath = matchedDiscovered.path;
     mdScope = matchedDiscovered.scope || null;
     mdSource = matchedDiscovered.source || null;


### PR DESCRIPTION
## Problem

Claude Code skills (`~/.claude/skills/*/SKILL.md`) were showing up in the **Commands** tab instead of the **Skills** tab in Settings.

## Root cause

Two interacting bugs:

### Bug 1: `||` prevents local filesystem scanning

In `skill-routes.js:198`:
```js
const skills = (await fetchOpenCodeDiscoveredSkills(directory)) || discoverSkills(directory);
```

The `||` operator treats empty arrays `[]` as **truthy** in JavaScript. Since the upstream OpenCode `/skill` API returns `[]` (no skills), the `discoverSkills()` function — which scans `~/.claude/skills/`, `~/.agents/skills/`, `.opencode/skills/` etc. — **never ran**.

This same pattern was replicated across all 6 skill endpoints.

### Bug 2: Upstream contamination

The OpenCode SDK `command.list()` API returns `.claude/skills/` entries as commands. The `CommandsSidebar` already had a dedup filter to strip these out (matching command names against skill names), but since the Skills store was empty due to Bug 1, the dedup had no names to filter against.

## Changes

| File | Change |
|------|--------|
| `packages/web/server/lib/opencode/skill-routes.js` | Added `mergeSkillLists()` and `findDiscoveredSkill()` helpers. Replaced all 6 `||` fallback patterns with proper source merging. |
| `packages/web/server/lib/opencode/skills.js` | Added `fs.existsSync` guard before using `matchedDiscovered.path` in `getSkillSources()` to handle upstream built-in skills with synthetic paths like `"<built-in>"`. |

## Verification

Tested with the server running locally:

- `GET /api/config/skills` now returns **47 skills**: 41 from `~/.claude/skills/` (`source=claude`) + 6 from `~/.config/opencode/skills/` (`source=opencode`)
- Individual skill lookups work correctly
- Non-existent skills return `exists: false` gracefully
- The existing CommandsSidebar dedup filter now functions correctly since the Skills store is properly populated

---

_Discovered and fixed while investigating the "skills appearing in commands tab" bug report._