### PR TITLE
fix: prevent mobile keyboard from occluding terminal viewport

### DIFF
--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -20,6 +20,7 @@ import { useUIStore } from '@/stores/useUIStore';
 import { useUpdateStore } from '@/stores/useUpdateStore';
 import { useDeviceInfo } from '@/lib/device';
 import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
+import { useVisualViewport } from '@/hooks/useVisualViewport';
 import { useI18n } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { isDesktopShell } from '@/lib/desktop';
@@ -84,6 +85,7 @@ export const MainLayout: React.FC = () => {
     const multiRunLauncherPrefillPrompt = useUIStore((state) => state.multiRunLauncherPrefillPrompt);
 
     const { isMobile, isTablet } = useDeviceInfo();
+    const visualViewport = useVisualViewport();
     const isDesktopShellRuntime = React.useMemo(() => isDesktopShell(), []);
     const sidebarWidth = useUIStore((state) => state.sidebarWidth);
     const rightSidebarWidth = useUIStore((state) => state.rightSidebarWidth);
@@ -390,10 +392,11 @@ export const MainLayout: React.FC = () => {
             <div
                 data-page-scroll-lock="true"
                 className={cn(
-                    'main-content-safe-area h-[100dvh]',
-                    isMobile ? 'flex flex-col' : 'flex',
+                    'main-content-safe-area',
+                    isMobile ? 'flex flex-col' : 'flex h-[100dvh]',
                     'bg-background'
                 )}
+                style={isMobile && visualViewport.height > 0 ? { height: visualViewport.height } : undefined}
             >
                 <CommandPalette />
                 <HelpDialog />

--- a/packages/ui/src/hooks/useVisualViewport.ts
+++ b/packages/ui/src/hooks/useVisualViewport.ts
@@ -1,0 +1,50 @@
+import React from 'react';
+
+export interface VisualViewportState {
+  height: number;
+  keyboardHeight: number;
+}
+
+const getInitialHeight = (): number => {
+  if (typeof window === 'undefined') return 0;
+  return window.visualViewport?.height ?? window.innerHeight;
+};
+
+export const useVisualViewport = (): VisualViewportState => {
+  const [state, setState] = React.useState<VisualViewportState>(() => ({
+    height: getInitialHeight(),
+    keyboardHeight: 0,
+  }));
+
+  const rafIdRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.visualViewport) return;
+
+    const handleChange = () => {
+      if (rafIdRef.current !== null) return;
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = null;
+        const vv = window.visualViewport!;
+        setState({
+          height: vv.height,
+          keyboardHeight: Math.max(0, window.innerHeight - vv.height),
+        });
+      });
+    };
+
+    window.visualViewport.addEventListener('resize', handleChange);
+    window.visualViewport.addEventListener('scroll', handleChange, { passive: true });
+    handleChange();
+
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+      }
+      window.visualViewport?.removeEventListener('resize', handleChange);
+      window.visualViewport?.removeEventListener('scroll', handleChange);
+    };
+  }, []);
+
+  return state;
+};

--- a/packages/ui/src/hooks/useVisualViewport.ts
+++ b/packages/ui/src/hooks/useVisualViewport.ts
@@ -26,9 +26,11 @@ export const useVisualViewport = (): VisualViewportState => {
       rafIdRef.current = requestAnimationFrame(() => {
         rafIdRef.current = null;
         const vv = window.visualViewport!;
-        setState({
-          height: vv.height,
-          keyboardHeight: Math.max(0, window.innerHeight - vv.height),
+        const height = vv.height;
+        const keyboardHeight = Math.max(0, window.innerHeight - height);
+        setState((prev) => {
+          if (prev.height === height && prev.keyboardHeight === keyboardHeight) return prev;
+          return { height, keyboardHeight };
         });
       });
     };


### PR DESCRIPTION
On mobile web `100dvh` does not shrink when the soft keyboard opens because `dvh` only accounts for browser chrome (URL bar / home indicator) — the keyboard overlays content without changing the layout viewport. The root container stayed full-height, so every `absolute inset-0` view (terminal, chat, files, etc.) extended behind the keyboard, with the bottom portion occluded.

Switch the root container height on mobile from a static `h-[100dvh]` class to `style={{ height: visualViewport.height }}` driven by `window.visualViewport` resize/scroll events coalesced through `requestAnimationFrame`. `visualViewport.height` is the actual visible area above any overlaid UI (keyboard, zoomed toolbar), so content stays in the readable band.

Added `packages/ui/src/hooks/useVisualViewport.ts`:

- Listens to `window.visualViewport.resize` and `scroll` (passive) events.
- Coalesces via `requestAnimationFrame` — only one state write per frame regardless of how many intermediate events fire (keyboard transitions can emit multiple resize + scroll events in quick succession).
- Exposes `{ height, keyboardHeight }` for any future consumer that needs the occluded band value.
- Guarded: no-op when `visualViewport` is unavailable (SSR, pre-Chromium 61 / pre-Safari 13, desktop without devtools open) — `height` is `0` and the `style` guard `visualViewport.height > 0` falls back to no explicit override, letting the browser's default layout take over.

Updated `MainLayout.tsx`:

- `h-[100dvh]` moved from the shared class list to the desktop-only branch (`isMobile ? "flex flex-col" : "flex h-[100dvh]"`).
- Mobile gets `style={isMobile && visualViewport.height > 0 ? { height: visualViewport.height } : undefined}` instead.
- Desktop behaviour is unchanged — `useVisualViewport` is called but its value is ignored because the desktop branch keeps the `h-[100dvh]` class.

No interaction with `mobileKeyboardMode.ts` (`interactive-widget=resizes-content`): that path is a viewport meta hint on Android; this fix works via the same `visualViewport` API regardless of the meta setting and covers iOS too (where `interactive-widget` is unsupported).

The pattern is already established in `FilesView.tsx` (`packages/ui/src/components/views/FilesView.tsx:2329`) which uses `visualViewport` to nudge the CodeMirror cursor above the keyboard. This generalises it to the whole app shell.