### PR TITLE
feat: close sortable tabs with middle-click

### DIFF
--- a/packages/ui/src/components/ui/sortable-tabs-strip.tsx
+++ b/packages/ui/src/components/ui/sortable-tabs-strip.tsx
@@ -377,10 +377,31 @@ export const SortableTabsStrip: React.FC<SortableTabsStripProps> = ({
                 ? 'flex-none basis-auto'
                 : (isMobile ? 'flex-1 basis-0 min-w-0' : 'flex-1 basis-0 min-w-fit'))
               : 'min-w-0 flex-1 basis-0';
+          const handleAuxClick = closable
+            ? (event: React.MouseEvent<HTMLDivElement>) => {
+                // Middle-click (button === 1) closes the tab. Matches browser tab behavior.
+                if (event.button !== 1) {
+                  return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                onClose?.(item.id);
+              }
+            : undefined;
+          const handleMouseDown = closable
+            ? (event: React.MouseEvent<HTMLDivElement>) => {
+                // Prevent the browser's middle-click autoscroll affordance.
+                if (event.button === 1) {
+                  event.preventDefault();
+                }
+              }
+            : undefined;
           return (
             <Wrapper key={item.id} id={item.id} className={wrapperClassName}>
               <div
                 ref={(element) => setTabRef(item.id, element)}
+                onAuxClick={handleAuxClick}
+                onMouseDown={handleMouseDown}
                 className={cn(
                   'group flex h-full min-w-0 flex-nowrap items-center',
                   (isScrollable || useIntrinsicPillSizing)


### PR DESCRIPTION
## Summary

- Adds middle-click-to-close support to `SortableTabsStrip` tab items.
- Handles `onAuxClick` (button 1) on the tab wrapper and delegates to the existing `onClose` callback, matching exactly what the X button does.
- Suppresses the browser's native middle-click autoscroll affordance via `onMouseDown` with `preventDefault` when `button === 1`.
- Both handlers are only wired when the tab is closable, so non-closable tabs are unaffected.

## Why

Editor tabs expose a close button that only becomes visible on hover, requiring users to move the pointer, wait for the icon to fade in, and then click — three steps for an action performed constantly during file-switching sessions. Middle-click-to-close is a universal convention in VS Code, Chrome, Firefox, Sublime Text, and JetBrains IDEs; users with that muscle memory reach for it immediately and find it does nothing.

## Implementation notes

- All changes are in `packages/ui/src/components/ui/sortable-tabs-strip.tsx` (+21 lines, no other files touched).
- `handleAuxClick` guards on `event.button !== 1` before calling `onClose?.(item.id)`, so right-click context menus are not intercepted.
- `handleMouseDown` calls `event.preventDefault()` only when `button === 1` to cancel the autoscroll cursor that browsers show on middle-button press; it does not stop propagation so drag-and-drop sorting is unaffected.
- Both handlers are defined conditionally (`closable ? handler : undefined`) to avoid attaching no-op listeners on every non-closable tab.
- No new dependencies, no new props on the public API of `SortableTabsStrip`.

## Risk / Compatibility

- **Web / Electron / VS Code**: `onAuxClick` and `onMouseDown` are standard React synthetic events present in all three runtimes; no branching needed.
- **Bundle impact**: +21 lines in a single existing component; negligible.
- **Opt-in vs opt-out**: strictly additive — middle-click now closes tabs, hover-and-click continues to work exactly as before.
- **i18n**: no user-visible strings added.

## Testing

- `bun run type-check` (5/5 packages) — passes
- `bun run lint` (5/5 packages) — passes
- `bun run build` — passes
- Manual: open multiple editor tabs; middle-click each tab and verify it closes without triggering the autoscroll cursor; verify left-click and right-click behavior is unchanged; verify tabs marked non-closable do not respond to middle-click.