### PR TITLE
fix(mobile): sync project switch with draft target state

### DIFF
--- a/packages/ui/src/components/chat/MobileSessionStatusBar.tsx
+++ b/packages/ui/src/components/chat/MobileSessionStatusBar.tsx
@@ -1436,6 +1436,7 @@ export const MobileSessionStatusBar: React.FC<MobileSessionStatusBarProps> = ({
   const projects = useProjectsStore((state) => state.projects);
   const activeProjectId = useProjectsStore((state) => state.activeProjectId);
   const setActiveProject = useProjectsStore((state) => state.setActiveProject);
+  const setActiveProjectIdOnly = useProjectsStore((state) => state.setActiveProjectIdOnly);
   const removeProject = useProjectsStore((state) => state.removeProject);
   const getActiveProject = useProjectsStore((state) => state.getActiveProject);
 
@@ -1498,9 +1499,29 @@ export const MobileSessionStatusBar: React.FC<MobileSessionStatusBarProps> = ({
   };
 
   const handleProjectSwitch = (projectId: string) => {
-    if (projectId !== activeProjectId) {
-      setActiveProject(projectId);
+    if (projectId === activeProjectId) {
+      return;
     }
+    const draft = useSessionUIStore.getState().newSessionDraft;
+    if (draft?.open) {
+      if (
+        draft.pendingWorktreeRequestId ||
+        draft.bootstrapPendingDirectory ||
+        draft.preserveDirectoryOverride
+      ) {
+        return;
+      }
+      const project = projects.find((p) => p.id === projectId);
+      if (project) {
+        setActiveProjectIdOnly(projectId);
+        useSessionUIStore.getState().setNewSessionDraftTarget({
+          projectId,
+          directoryOverride: project.path,
+        });
+      }
+      return;
+    }
+    setActiveProject(projectId);
   };
 
   const handleAddProject = () => {


### PR DESCRIPTION
## Problem

On mobile, two project switchers are visible simultaneously when a new session draft is open: the desktop dropdown selectors (above the input) and the mobile ProjectBar (below). They drive different state:

- Desktop dropdowns: `handleDraftProjectChange` → `setActiveProjectIdOnly` + `setNewSessionDraftTarget` (updates draft target)
- Mobile ProjectBar: `handleProjectSwitch` → `setActiveProject` (changes global active project, no draft awareness)

When switching projects via the mobile ProjectBar while a draft is open, the draft target is not updated. This desyncs the two switchers.

## Changes

**`packages/ui/src/components/chat/MobileSessionStatusBar.tsx`**

- `handleProjectSwitch` now mirrors the desktop `handleDraftProjectChange` when a new session draft is open:
  - Honours `preserveDirectoryOverride` / `pendingWorktreeRequestId` / `bootstrapPendingDirectory` guards — does not overwrite a locked draft directory.
  - When a draft is open, project not found in the list is a no-op (no fallback to `setActiveProject`, which would silently desync).
  - On a valid project switch during draft: `setActiveProjectIdOnly(projectId)` + `setNewSessionDraftTarget({ projectId, directoryOverride: project.path })`.
- When no draft is open, the original `setActiveProject(projectId)` behavior is preserved.
- Added `setActiveProjectIdOnly` to the `useProjectsStore` selectors.

## Validation

- `bun run type-check` — no new errors
- `bun run lint` — exits 0 across all packages