### PR TITLE
feat: widen chat input column with Wide Chat Layout setting

### DIFF
--- a/packages/ui/src/styles/typography.css
+++ b/packages/ui/src/styles/typography.css
@@ -40,6 +40,10 @@
     padding-inline: calc(clamp(0.75rem, 2.5vw, 1rem) * var(--padding-scale, 1));
   }
 
+  .wide-chat-layout .chat-input-column {
+    width: min(100%, 64rem);
+  }
+
   .chat-message-column {
     width: min(100%, 48rem);
     margin-inline: auto;


### PR DESCRIPTION
The 'Wide Chat Layout' setting toggles a 'wide-chat-layout' class on the document root that widens '.chat-column' and '.chat-message-column' from 48rem to 64rem, but '.chat-input-column' (which wraps the textarea) was missing the matching rule, so the prompt input stayed narrow while the messages above it widened.

Add the missing .wide-chat-layout .chat-input-column { width: min(100%, 64rem) } selector so the input column tracks the message column under the same setting. The value min(100%, 64rem) matches the existing rule on .chat-message-column, so input and messages reach the same maximum width.