### PR TITLE
Fix notification button text color in dark mode

### DIFF
--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -93,7 +93,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           title: "typography-ui-label !font-medium !text-foreground",
           description: "typography-meta !text-muted-foreground !mt-0.5",
           actionButton:
-            "!rounded-[var(--radius-md)] !bg-[var(--primary-base)] !text-white hover:!opacity-85 !px-2 !py-1 typography-meta !font-medium transition-opacity",
+            "!rounded-[var(--radius-md)] !bg-[var(--primary-base)] !text-[var(--primary-foreground)] hover:!opacity-85 !px-2 !py-1 typography-meta !font-medium transition-opacity",
           cancelButton:
             "!rounded-[var(--radius-md)] !bg-[var(--interactive-hover)] !text-foreground hover:!bg-[var(--interactive-active)] !px-2 !py-1 typography-meta !font-medium transition-colors",
           closeButton:


### PR DESCRIPTION
# What

- Fix notification toast action button text color to use theme token instead of hardcoded white.

## Before
<img width="653" height="131" alt="chrome_HFChxx09jP" src="https://github.com/user-attachments/assets/4780d365-6436-4572-8a21-54bca18a5790" />

## After
<img width="686" height="163" alt="chrome_wj2d9m7lQv" src="https://github.com/user-attachments/assets/51efd842-c76c-4469-ba89-1928b5f7980f" />

# Why

The action button on toast notifications used `!text-white`, which is
invisible against light primary backgrounds in dark theme mode.
The button should use `--primary-foreground` theme token so it adapts
correctly to the active theme.

# How to test

1. Switch to dark theme.
2. Trigger a toast notification with an action button.
3. Verify the action button text is readable (uses `--primary-foreground`).
4. Switch to light theme and confirm the button text remains readable.



