### PR TITLE
fix: strip code before TTS markdown cleanup

### DIFF
--- a/packages/web/server/lib/text/summarization.js
+++ b/packages/web/server/lib/text/summarization.js
@@ -11,9 +11,9 @@ export function sanitizeForTTS(text) {
   if (!text || typeof text !== 'string') return '';
 
   return text
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
     .replace(/[*_~`#]/g, '')
-    .replace(/```[\s\S]*?```/g, '')
-    .replace(/`[^`]*`/g, '')
     .replace(/^\s*[$#>]\s*/gm, '')
     .replace(/[|&;<>]/g, ' ')
     .replace(/\\/g, '')

--- a/packages/web/server/lib/text/summarization.test.js
+++ b/packages/web/server/lib/text/summarization.test.js
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { summarizeText } from './summarization.js';
+import { sanitizeForTTS, summarizeText } from './summarization.js';
 
 describe('text summarization stubs', () => {
+  it('removes code from TTS text before stripping markdown punctuation', () => {
+    expect(sanitizeForTTS('Read `const value = 1` aloud')).toBe('Read aloud');
+    expect(sanitizeForTTS('Before\n```js\nconst value = 1\n```\nAfter')).toBe('Before After');
+  });
+
   it('does not call the retired zen provider', async () => {
     const result = await summarizeText({
       text: 'The implementation now correctly loads notification templates before dispatching the notification. It also fetches the latest assistant message when the event payload does not include message parts. This should make completion notifications match user settings.',


### PR DESCRIPTION
Summary:
- Remove fenced and inline code from TTS text before generic markdown punctuation cleanup.
- Add regression coverage for inline and fenced code sanitization.

Validation:
- vet "Ensure TTS sanitizer removes inline and fenced code before stripping markdown punctuation" --agentic --agent-harness claude
- bun test packages/web/server/lib/text/summarization.test.js
- bun run type-check
- bun run lint
- git diff --check