### PR TITLE
fix(ui): keep generated copy feedback stable

### DIFF
--- a/packages/ui/src/components/chat/message/parts/GeneratedJsonResultCard.tsx
+++ b/packages/ui/src/components/chat/message/parts/GeneratedJsonResultCard.tsx
@@ -8,6 +8,15 @@ import type { GeneratedResult } from './generatedJsonResult';
 export const GeneratedJsonResultCard: React.FC<{ result: GeneratedResult }> = ({ result }) => {
   const { t } = useI18n();
   const [copied, setCopied] = React.useState(false);
+  const copiedResetTimerRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (copiedResetTimerRef.current !== null) {
+        window.clearTimeout(copiedResetTimerRef.current);
+      }
+    };
+  }, []);
 
   const copyText = React.useMemo(() => {
     if (result.kind === 'commit') {
@@ -19,8 +28,16 @@ export const GeneratedJsonResultCard: React.FC<{ result: GeneratedResult }> = ({
   const handleCopy = React.useCallback(async () => {
     const copyResult = await copyTextToClipboard(copyText || result.raw);
     if (!copyResult.ok) return;
+
+    if (copiedResetTimerRef.current !== null) {
+      window.clearTimeout(copiedResetTimerRef.current);
+    }
+
     setCopied(true);
-    window.setTimeout(() => setCopied(false), 2000);
+    copiedResetTimerRef.current = window.setTimeout(() => {
+      copiedResetTimerRef.current = null;
+      setCopied(false);
+    }, 2000);
   }, [copyText, result.raw]);
 
   return (


### PR DESCRIPTION
Summary:
- Track the generated JSON copy feedback reset timer in a ref.
- Clear any previous reset before scheduling a new one, and clear it on unmount.
- Prevent stale timers from hiding the copied indicator shortly after a repeated copy.

Validation:
- vet "ensure generated JSON copy feedback timer is cleared and typed safely" --agentic --agent-harness claude
- bun run type-check
- bun run lint
- git diff --check