### PR TITLE
fix(ui): ignore non-finite quota percentages

### DIFF
--- a/packages/ui/src/lib/quota/utils.test.ts
+++ b/packages/ui/src/lib/quota/utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+
+import { clampPercent, formatPercent } from './utils';
+
+describe('quota utils', () => {
+  test('treats non-finite percentages as missing', () => {
+    expect(clampPercent(Infinity)).toBeNull();
+    expect(clampPercent(-Infinity)).toBeNull();
+
+    expect(formatPercent(Infinity)).toBe('-');
+    expect(formatPercent(-Infinity)).toBe('-');
+  });
+});

--- a/packages/ui/src/lib/quota/utils.ts
+++ b/packages/ui/src/lib/quota/utils.ts
@@ -1,12 +1,12 @@
 export const clampPercent = (value: number | null): number | null => {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
     return null;
   }
   return Math.max(0, Math.min(100, Math.round(value)));
 };
 
 export const formatPercent = (value: number | null): string => {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
     return '-';
   }
   return `${Math.round(value)}%`;


### PR DESCRIPTION
Summary:
- Treat non-finite quota percentages as missing instead of rendering or clamping Infinity values.
- Add targeted coverage for Infinity and -Infinity in quota percentage utilities.

Validation:
- vet "Ensure quota percentage utilities reject non-finite numbers and tests cover the regression" --agentic --agent-harness claude
- bun test packages/ui/src/lib/quota/utils.test.ts
- bun run type-check
- bun run lint
- git diff --check