### PR TITLE
fix: respect session prefetch page size

### DIFF
--- a/packages/ui/src/sync/__tests__/session-prefetch-cache.test.ts
+++ b/packages/ui/src/sync/__tests__/session-prefetch-cache.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+
+import { shouldSkipSessionPrefetch } from "../session-prefetch-cache"
+
+describe("shouldSkipSessionPrefetch", () => {
+  test("does not skip a larger fetch when only a smaller partial prefetch is cached", () => {
+    expect(shouldSkipSessionPrefetch({
+      hasMessages: true,
+      info: { limit: 50, complete: false, at: 1_000 },
+      pageSize: 200,
+      now: 1_001,
+    })).toBe(false)
+  })
+
+  test("still skips a recent partial prefetch when cached coverage matches the request", () => {
+    expect(shouldSkipSessionPrefetch({
+      hasMessages: true,
+      info: { limit: 200, complete: false, at: 1_000 },
+      pageSize: 200,
+      now: 1_001,
+    })).toBe(true)
+  })
+})

--- a/packages/ui/src/sync/session-prefetch-cache.ts
+++ b/packages/ui/src/sync/session-prefetch-cache.ts
@@ -35,6 +35,7 @@ export function shouldSkipSessionPrefetch(input: {
     if (!input.info) return true
     if (input.info.complete) return true
     if (input.info.limit > input.pageSize) return true
+    if (input.info.limit < input.pageSize) return false
   } else {
     if (!input.info) return false
   }


### PR DESCRIPTION
Summary:
- Prevent a smaller partial session prefetch cache entry from suppressing a larger requested fetch.
- Add focused regression coverage for smaller partial cache entries and matching-size recent cache entries.

Validation:
- vet "Fix session prefetch cache so smaller partial prefetches do not skip larger requested fetches" --agentic --agent-harness claude
- bun test packages/ui/src/sync/__tests__/session-prefetch-cache.test.ts
- bun run type-check
- bun run lint
- git diff --check