### PR TITLE
fix: correct typos in CHANGELOG files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -898,7 +898,7 @@ All notable changes to this project will be documented in this file.
 ## [1.1.4] - 2025-12-15
 
 - Flexoki themes for Shiki syntax highlighting for consistency with the app color schema.
-- Enchanced VSCode extension theming with editor themes.
+- Enhanced VSCode extension theming with editor themes.
 - Fixed mobile view model/agent selection.
 
 ## [1.1.3] - 2025-12-14

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -375,7 +375,7 @@
 ## [1.5.9] - 2026-01-28
 
 - Agent Manager: migrated to the OpenCode SDK worktree implementation; sessions in worktrees are now completely isolated.
-- Agent Manager: worktree setup commands are now persistant per project and automatically saved/restored.
+- Agent Manager: worktree setup commands are now persistent per project and automatically saved/restored.
 
 
 ## [1.5.8] - 2026-01-26


### PR DESCRIPTION
Fixes #1337

Corrects two spelling mistakes found in changelog files:

- "Enchanced" → "Enhanced" in `CHANGELOG.md`
- "persistant" → "persistent" in `packages/vscode/CHANGELOG.md`