### PR TITLE
feat: add quick-add button to directory explorer rows

### DIFF
--- a/packages/ui/src/components/session/DirectoryExplorerDialog.tsx
+++ b/packages/ui/src/components/session/DirectoryExplorerDialog.tsx
@@ -389,6 +389,18 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
     onOpenChange(false);
   }, [onOpenChange]);
 
+  const handleQuickAdd = React.useCallback((event: React.MouseEvent, path: string) => {
+    event.stopPropagation();
+    const normalized = normalizeDirectoryPath(path);
+    if (normalized && addedProjectPaths.has(normalized)) return;
+    const added = addProject(path);
+    if (!added) {
+      toast.error(t('directoryExplorerDialog.toast.failedToAddProject'), {
+        description: t('directoryExplorerDialog.toast.selectValidDirectoryPath'),
+      });
+    }
+  }, [addProject, addedProjectPaths, t]);
+
   const finalizeSelection = React.useCallback(async (target: string) => {
     if (!target || isConfirming) return;
     const normalized = normalizeDirectoryPath(target);
@@ -628,6 +640,16 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
                     <span className="rounded-full border border-border/60 px-2 py-0.5 typography-meta text-muted-foreground">
                       {t('directoryExplorerDialog.browse.addedBadge')}
                     </span>
+                  ) : row.type === 'directory' ? (
+                    <button
+                      type="button"
+                      onMouseDown={(event) => event.stopPropagation()}
+                      onClick={(event) => handleQuickAdd(event, row.path)}
+                      className="flex-shrink-0 rounded-full p-1 text-muted-foreground transition-colors hover:bg-interactive-hover/60 hover:text-foreground"
+                      title={t('directoryExplorerDialog.browse.quickAdd')}
+                    >
+                      <Icon name="add" className="h-3.5 w-3.5" />
+                    </button>
                   ) : null}
                 </button>
               );

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1156,6 +1156,7 @@ export const dict = {
   'directoryExplorerDialog.browse.empty': 'No matching directories.',
   'directoryExplorerDialog.browse.parentDirectory': 'Parent directory',
   'directoryExplorerDialog.browse.addedBadge': 'Added',
+  'directoryExplorerDialog.browse.quickAdd': 'Add',
   'directoryExplorerDialog.footer.navigate': 'Navigate',
   'directoryExplorerDialog.footer.select': 'Select',
   'directoryExplorerDialog.footer.add': 'Add',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1122,6 +1122,7 @@ export const dict: Record<I18nKey, string> = {
   "directoryExplorerDialog.browse.empty": "No hay directorios coincidentes.",
   "directoryExplorerDialog.browse.parentDirectory": "Directorio padre",
   "directoryExplorerDialog.browse.addedBadge": "Añadido",
+  "directoryExplorerDialog.browse.quickAdd": "Añadir",
   "directoryExplorerDialog.footer.navigate": "Navegar",
   "directoryExplorerDialog.footer.select": "Seleccionar",
   "directoryExplorerDialog.footer.add": "Añadir",

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1158,6 +1158,7 @@ export const dict: Record<I18nKey, string> = {
   'directoryExplorerDialog.browse.empty': '일치하는 디렉터리가 없습니다.',
   'directoryExplorerDialog.browse.parentDirectory': '상위 디렉터리',
   'directoryExplorerDialog.browse.addedBadge': '추가됨',
+  'directoryExplorerDialog.browse.quickAdd': '추가',
   'directoryExplorerDialog.footer.navigate': '탐색',
   'directoryExplorerDialog.footer.select': '선택',
   'directoryExplorerDialog.footer.add': '추가',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1255,6 +1255,7 @@ export const dict: Record<I18nKey, string> = {
   'directoryExplorerDialog.actions.openInFinder': 'Otwórz w Finderze',
   'directoryExplorerDialog.actions.openingFinder': 'Otwieranie...',
   'directoryExplorerDialog.browse.addedBadge': 'Dodano',
+  'directoryExplorerDialog.browse.quickAdd': 'Dodaj',
   'directoryExplorerDialog.browse.directories': 'Katalogi',
   'directoryExplorerDialog.browse.empty': 'Brak pasujących katalogów.',
   'directoryExplorerDialog.browse.loading': 'Ładowanie katalogów...',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1122,6 +1122,7 @@ export const dict: Record<I18nKey, string> = {
   "directoryExplorerDialog.browse.empty": "Nenhum diretório correspondente.",
   "directoryExplorerDialog.browse.parentDirectory": "Diretório pai",
   "directoryExplorerDialog.browse.addedBadge": "Adicionado",
+  "directoryExplorerDialog.browse.quickAdd": "Adicionar",
   "directoryExplorerDialog.footer.navigate": "Navegar",
   "directoryExplorerDialog.footer.select": "Selecionar",
   "directoryExplorerDialog.footer.add": "Adicionar",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1122,6 +1122,7 @@ export const dict: Record<I18nKey, string> = {
   "directoryExplorerDialog.browse.empty": "Немає відповідних каталогів.",
   "directoryExplorerDialog.browse.parentDirectory": "Батьківський каталог",
   "directoryExplorerDialog.browse.addedBadge": "Додано",
+  "directoryExplorerDialog.browse.quickAdd": "Додати",
   "directoryExplorerDialog.footer.navigate": "Навігація",
   "directoryExplorerDialog.footer.select": "Вибрати",
   "directoryExplorerDialog.footer.add": "Додати",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1122,6 +1122,7 @@ export const dict: Record<I18nKey, string> = {
   'directoryExplorerDialog.browse.empty': '没有匹配的目录。',
   'directoryExplorerDialog.browse.parentDirectory': '上级目录',
   'directoryExplorerDialog.browse.addedBadge': '已添加',
+  'directoryExplorerDialog.browse.quickAdd': '添加',
   'directoryExplorerDialog.footer.navigate': '导航',
   'directoryExplorerDialog.footer.select': '选择',
   'directoryExplorerDialog.footer.add': '添加',


### PR DESCRIPTION
## Summary

Addresses #351 by adding an inline "+" button on each directory row in the directory explorer dialog, allowing users to add multiple projects without closing and reopening the dialog.

### Before
<img width="997" height="1085" alt="chrome_SgWvBYHyv2" src="https://github.com/user-attachments/assets/59b64be1-56f3-4a1a-ac4c-371dd44b1116" />

### After
<img width="983" height="1087" alt="chrome_AuZ2XTwidr" src="https://github.com/user-attachments/assets/de05d031-d526-4fe3-baa4-855702bf2f71" />

## Changes

- Added a quick-add "+" icon button on each non-disabled directory row in `DirectoryExplorerDialog.tsx`
- Clicking "+" calls `addProject(path)` directly, keeping the dialog open for further selections
- The row automatically transitions to the "Added" badge state after being added (existing reactivity)
- The last project added becomes the active project (existing `addProject` behavior)
- Added `directoryExplorerDialog.browse.quickAdd` i18n key to all 7 locale dictionaries (en, zh-CN, uk, pt-BR, pl, ko, es)

## Testing

- `npx tsc --noEmit -p packages/ui/tsconfig.json` passes
- Manual verification: open dialog, click "+" on multiple directories, confirm all appear as "added" without dialog closing

Closes #351