### PR TITLE
feat(tts/stt): add API key support for OpenAI-compatible custom providers

### DIFF
--- a/packages/ui/src/components/sections/openchamber/VoiceSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/VoiceSettings.tsx
@@ -164,6 +164,8 @@ export const VoiceSettings: React.FC = () => {
     const setSttProvider = useConfigStore((state) => state.setSttProvider);
     const sttServerUrl = useConfigStore((state) => state.sttServerUrl);
     const setSttServerUrl = useConfigStore((state) => state.setSttServerUrl);
+    const sttApiKey = useConfigStore((state) => state.sttApiKey);
+    const setSttApiKey = useConfigStore((state) => state.setSttApiKey);
     const sttModel = useConfigStore((state) => state.sttModel);
     const setSttModel = useConfigStore((state) => state.setSttModel);
     const wasmSttModel = useConfigStore((state) => state.wasmSttModel);
@@ -915,6 +917,30 @@ export const VoiceSettings: React.FC = () => {
                                             <button
                                                 type="button"
                                                 onClick={() => setSttServerUrl('')}
+                                                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                                            >
+                                                <Icon name="close" className="w-3.5 h-3.5" />
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                                <div>
+                                    <span className="typography-ui-label text-foreground">API Key</span>
+                                    <span className="typography-meta ml-2 text-muted-foreground">
+                                        Optional
+                                    </span>
+                                    <div className="relative mt-1.5 max-w-xs">
+                                        <input
+                                            type="password"
+                                            value={sttApiKey}
+                                            onChange={(e) => setSttApiKey(e.target.value)}
+                                            placeholder="sk-..."
+                                            className="w-full h-7 rounded-lg border border-input bg-transparent px-2 typography-ui-label text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary/50 focus:border-primary/70"
+                                        />
+                                        {sttApiKey && (
+                                            <button
+                                                type="button"
+                                                onClick={() => setSttApiKey('')}
                                                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                                             >
                                                 <Icon name="close" className="w-3.5 h-3.5" />

--- a/packages/ui/src/components/sections/openchamber/VoiceSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/VoiceSettings.tsx
@@ -152,6 +152,8 @@ export const VoiceSettings: React.FC = () => {
     const setOpenaiApiKey = useConfigStore((state) => state.setOpenaiApiKey);
     const openaiCompatibleUrl = useConfigStore((state) => state.openaiCompatibleUrl);
     const setOpenaiCompatibleUrl = useConfigStore((state) => state.setOpenaiCompatibleUrl);
+    const openaiCompatibleApiKey = useConfigStore((state) => state.openaiCompatibleApiKey);
+    const setOpenaiCompatibleApiKey = useConfigStore((state) => state.setOpenaiCompatibleApiKey);
     const openaiCompatibleVoice = useConfigStore((state) => state.openaiCompatibleVoice);
     const setOpenaiCompatibleVoice = useConfigStore((state) => state.setOpenaiCompatibleVoice);
     const openaiCompatibleTtsModel = useConfigStore((state) => state.openaiCompatibleTtsModel);
@@ -445,6 +447,7 @@ export const VoiceSettings: React.FC = () => {
                     model: openaiCompatibleTtsModel || undefined,
                     speed: speechRate,
                     baseURL: openaiCompatibleUrl,
+                    apiKey: openaiCompatibleApiKey || undefined,
                 }),
             });
 
@@ -474,7 +477,7 @@ export const VoiceSettings: React.FC = () => {
         } catch {
             setIsCompatiblePreviewPlaying(false);
         }
-    }, [openaiCompatibleUrl, openaiCompatibleVoice, openaiCompatibleTtsModel, speechRate, compatiblePreviewAudio, t]);
+    }, [openaiCompatibleUrl, openaiCompatibleVoice, openaiCompatibleTtsModel, openaiCompatibleApiKey, speechRate, compatiblePreviewAudio, t]);
 
     useEffect(() => {
         return () => {
@@ -631,6 +634,30 @@ export const VoiceSettings: React.FC = () => {
                                                 <button
                                                     type="button"
                                                     onClick={() => setOpenaiCompatibleUrl('')}
+                                                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                                                >
+                                                    <Icon name="close" className="w-3.5 h-3.5" />
+                                                </button>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <span className="typography-ui-label text-foreground">API Key</span>
+                                        <span className="typography-meta ml-2 text-muted-foreground">
+                                            Optional
+                                        </span>
+                                        <div className="relative mt-1.5 max-w-xs">
+                                            <input
+                                                type="password"
+                                                value={openaiCompatibleApiKey}
+                                                onChange={(e) => setOpenaiCompatibleApiKey(e.target.value)}
+                                                placeholder="sk-..."
+                                                className="w-full h-7 rounded-lg border border-input bg-transparent px-2 typography-ui-label text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary/50 focus:border-primary/70"
+                                            />
+                                            {openaiCompatibleApiKey && (
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setOpenaiCompatibleApiKey('')}
                                                     className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                                                 >
                                                     <Icon name="close" className="w-3.5 h-3.5" />

--- a/packages/ui/src/hooks/useBrowserVoice.ts
+++ b/packages/ui/src/hooks/useBrowserVoice.ts
@@ -151,6 +151,7 @@ export function useBrowserVoice(): UseBrowserVoiceReturn {
   const openaiCompatibleVoice = useConfigStore((state) => state.openaiCompatibleVoice);
   const openaiCompatibleUrl = useConfigStore((state) => state.openaiCompatibleUrl);
   const openaiCompatibleTtsModel = useConfigStore((state) => state.openaiCompatibleTtsModel);
+  const openaiCompatibleApiKey = useConfigStore((state) => state.openaiCompatibleApiKey);
 
   const shouldCheckOpenAIAvailability = voiceModeEnabled && (voiceProvider === 'openai' || voiceProvider === 'openai-compatible');
   const shouldCheckSayAvailability = voiceModeEnabled && voiceProvider === 'say';
@@ -773,6 +774,7 @@ export function useBrowserVoice(): UseBrowserVoiceReturn {
         language: sttLanguage || undefined,
         silenceThresholdDb: sttSilenceThresholdDb,
         silenceHoldMs: sttSilenceHoldMs,
+        apiKey: openaiCompatibleApiKey || undefined,
       });
       try {
         await audioStreamService.startListening(language, handleSpeechResult, handleSpeechError);

--- a/packages/ui/src/hooks/useBrowserVoice.ts
+++ b/packages/ui/src/hooks/useBrowserVoice.ts
@@ -151,7 +151,7 @@ export function useBrowserVoice(): UseBrowserVoiceReturn {
   const openaiCompatibleVoice = useConfigStore((state) => state.openaiCompatibleVoice);
   const openaiCompatibleUrl = useConfigStore((state) => state.openaiCompatibleUrl);
   const openaiCompatibleTtsModel = useConfigStore((state) => state.openaiCompatibleTtsModel);
-  const openaiCompatibleApiKey = useConfigStore((state) => state.openaiCompatibleApiKey);
+  const sttApiKey = useConfigStore((state) => state.sttApiKey);
 
   const shouldCheckOpenAIAvailability = voiceModeEnabled && (voiceProvider === 'openai' || voiceProvider === 'openai-compatible');
   const shouldCheckSayAvailability = voiceModeEnabled && voiceProvider === 'say';
@@ -774,7 +774,7 @@ export function useBrowserVoice(): UseBrowserVoiceReturn {
         language: sttLanguage || undefined,
         silenceThresholdDb: sttSilenceThresholdDb,
         silenceHoldMs: sttSilenceHoldMs,
-        apiKey: openaiCompatibleApiKey || undefined,
+        apiKey: sttApiKey || undefined,
       });
       try {
         await audioStreamService.startListening(language, handleSpeechResult, handleSpeechError);

--- a/packages/ui/src/hooks/useBrowserVoice.ts
+++ b/packages/ui/src/hooks/useBrowserVoice.ts
@@ -860,7 +860,7 @@ export function useBrowserVoice(): UseBrowserVoiceReturn {
         isActiveRef.current = false;
       }
     }
-  }, [isSupported, currentSessionId, language, handleSpeechResult, handleSpeechError, isMobile, unlockServerTTSAudio, unlockSayTTSAudio, sttProvider, sttServerUrl, sttModel, wasmSttModel, sttLanguage, sttSilenceThresholdDb, sttSilenceHoldMs]);
+  }, [isSupported, currentSessionId, language, handleSpeechResult, handleSpeechError, isMobile, unlockServerTTSAudio, unlockSayTTSAudio, sttProvider, sttServerUrl, sttModel, sttApiKey, wasmSttModel, sttLanguage, sttSilenceThresholdDb, sttSilenceHoldMs]);
 
   // Stop voice mode
   const stopVoice = useCallback(() => {

--- a/packages/ui/src/hooks/useServerTTS.ts
+++ b/packages/ui/src/hooks/useServerTTS.ts
@@ -139,6 +139,7 @@ export function useServerTTS(options: UseServerTTSOptions = {}): UseServerTTSRet
   const currentModelId = useConfigStore((state) => state.currentModelId);
   const openaiApiKey = useConfigStore((state) => state.openaiApiKey);
   const openaiCompatibleUrl = useConfigStore((state) => state.openaiCompatibleUrl);
+  const openaiCompatibleApiKey = useConfigStore((state) => state.openaiCompatibleApiKey);
 
   // Check if server TTS is available
   const checkAvailability = useCallback(async (): Promise<boolean> => {
@@ -277,7 +278,7 @@ export function useServerTTS(options: UseServerTTSOptions = {}): UseServerTTSRet
           providerId: options?.providerId || currentProviderId || undefined,
           modelId: options?.modelId || currentModelId || undefined,
           // Send API key from settings if available
-          apiKey: openaiApiKey || undefined,
+          apiKey: options?.baseURL ? (openaiCompatibleApiKey || undefined) : (openaiApiKey || undefined),
           // Send custom base URL for OpenAI-compatible servers
           baseURL: options?.baseURL || undefined,
         }),
@@ -342,7 +343,7 @@ export function useServerTTS(options: UseServerTTSOptions = {}): UseServerTTSRet
       options?.onError?.(errorMsg);
       setIsPlaying(false);
     }
-  }, [stop, currentProviderId, currentModelId, openaiApiKey]);
+  }, [stop, currentProviderId, currentModelId, openaiApiKey, openaiCompatibleApiKey]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/packages/ui/src/lib/voice/audioStreamService.ts
+++ b/packages/ui/src/lib/voice/audioStreamService.ts
@@ -39,6 +39,8 @@ export interface AudioStreamConfig {
    * Default: 1500
    */
   silenceHoldMs?: number;
+  /** Optional API key for the OpenAI-compatible STT server. */
+  apiKey?: string;
 }
 
 // How often (ms) the VAD samples the analyser
@@ -69,6 +71,7 @@ class AudioStreamService {
     language: '',
     silenceThresholdDb: -45,
     silenceHoldMs: 1500,
+    apiKey: '',
   };
 
   /** Update service configuration. Can be called before or after startListening. */
@@ -336,6 +339,9 @@ class AudioStreamService {
         'X-Base-URL': this.cfg.baseURL,
         'X-Model': this.cfg.model,
       };
+      if (this.cfg.apiKey) {
+        headers['X-API-Key'] = this.cfg.apiKey;
+      }
       if (this.cfg.language) {
         headers['X-Language'] = this.cfg.language;
       } else if (this.lang && this.lang !== 'auto') {

--- a/packages/ui/src/lib/voice/audioStreamService.ts
+++ b/packages/ui/src/lib/voice/audioStreamService.ts
@@ -39,7 +39,7 @@ export interface AudioStreamConfig {
    * Default: 1500
    */
   silenceHoldMs?: number;
-  /** Optional API key for the OpenAI-compatible STT server. */
+  /** Optional API key for the STT server. */
   apiKey?: string;
 }
 
@@ -80,8 +80,10 @@ class AudioStreamService {
       silenceThresholdDb: -45,
       silenceHoldMs: 1500,
       language: '',
+      apiKey: '',
       ...config,
     };
+    this.cfg.apiKey = config.apiKey ?? '';
   }
 
   /** Whether the browser supports the required APIs. */
@@ -340,7 +342,7 @@ class AudioStreamService {
         'X-Model': this.cfg.model,
       };
       if (this.cfg.apiKey) {
-        headers['X-API-Key'] = this.cfg.apiKey;
+        headers['Authorization'] = `Bearer ${this.cfg.apiKey}`;
       }
       if (this.cfg.language) {
         headers['X-Language'] = this.cfg.language;

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -556,6 +556,7 @@ interface ConfigStore {
     // STT (speech-to-text) settings
     sttProvider: 'browser' | 'server' | 'wasm';
     sttServerUrl: string;
+    sttApiKey: string;
     sttModel: string;
     wasmSttModel: string;
     sttLanguage: string;
@@ -577,10 +578,12 @@ interface ConfigStore {
     setOpenaiVoice: (voice: string) => void;
     setOpenaiApiKey: (apiKey: string) => void;
     setOpenaiCompatibleUrl: (url: string) => void;
+    setOpenaiCompatibleApiKey: (apiKey: string) => void;
     setOpenaiCompatibleVoice: (voice: string) => void;
     setOpenaiCompatibleTtsModel: (model: string) => void;
     setSttProvider: (provider: 'browser' | 'server' | 'wasm') => void;
     setSttServerUrl: (url: string) => void;
+    setSttApiKey: (apiKey: string) => void;
     setSttModel: (model: string) => void;
     setWasmSttModel: (model: string) => void;
     setSttLanguage: (lang: string) => void;
@@ -791,6 +794,13 @@ export const useConfigStore = create<ConfigStore>()(
                         if (saved) return saved;
                     }
                     return 'http://localhost:8001/v1';
+                })(),
+                sttApiKey: (() => {
+                    if (typeof window !== 'undefined') {
+                        const saved = localStorage.getItem('sttApiKey');
+                        if (saved) return saved;
+                    }
+                    return '';
                 })(),
                 sttModel: (() => {
                     if (typeof window !== 'undefined') {
@@ -1930,6 +1940,13 @@ export const useConfigStore = create<ConfigStore>()(
                         localStorage.setItem('sttServerUrl', url);
                     }
                     updateDesktopSettings({ sttServerUrl: url }).catch(() => {});
+                },
+
+                setSttApiKey: (apiKey: string) => {
+                    set({ sttApiKey: apiKey });
+                    if (typeof window !== 'undefined') {
+                        localStorage.setItem('sttApiKey', apiKey);
+                    }
                 },
 
                 setSttModel: (model: string) => {

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -550,6 +550,7 @@ interface ConfigStore {
     openaiVoice: string;
     openaiApiKey: string;
     openaiCompatibleUrl: string;
+    openaiCompatibleApiKey: string;
     openaiCompatibleVoice: string;
     openaiCompatibleTtsModel: string;
     // STT (speech-to-text) settings
@@ -744,6 +745,14 @@ export const useConfigStore = create<ConfigStore>()(
                 openaiCompatibleUrl: (() => {
                     if (typeof window !== 'undefined') {
                         const saved = localStorage.getItem('openaiCompatibleUrl');
+                        if (saved) return saved;
+                    }
+                    return '';
+                })(),
+                // OpenAI-compatible custom server API key
+                openaiCompatibleApiKey: (() => {
+                    if (typeof window !== 'undefined') {
+                        const saved = localStorage.getItem('openaiCompatibleApiKey');
                         if (saved) return saved;
                     }
                     return '';
@@ -1883,6 +1892,13 @@ export const useConfigStore = create<ConfigStore>()(
                     set({ openaiCompatibleUrl: url });
                     if (typeof window !== 'undefined') {
                         localStorage.setItem('openaiCompatibleUrl', url);
+                    }
+                },
+
+                setOpenaiCompatibleApiKey: (apiKey: string) => {
+                    set({ openaiCompatibleApiKey: apiKey });
+                    if (typeof window !== 'undefined') {
+                        localStorage.setItem('openaiCompatibleApiKey', apiKey);
                     }
                 },
 

--- a/packages/web/server/lib/tts/routes.js
+++ b/packages/web/server/lib/tts/routes.js
@@ -221,9 +221,8 @@ export function registerTtsRoutes(app, { sayTTSCapability }) {
         const language = typeof req.headers['x-language'] === 'string' && req.headers['x-language'].trim().length > 0
           ? req.headers['x-language'].trim()
           : undefined;
-        const apiKey = typeof req.headers['x-api-key'] === 'string' && req.headers['x-api-key'].trim().length > 0
-          ? req.headers['x-api-key'].trim()
-          : undefined;
+        const authHeader = typeof req.headers['authorization'] === 'string' ? req.headers['authorization'].trim() : '';
+        const apiKey = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : undefined;
 
         if (!req.body || !Buffer.isBuffer(req.body) || req.body.length === 0) {
           return res.status(400).json({ error: 'Audio data is required' });

--- a/packages/web/server/lib/tts/routes.js
+++ b/packages/web/server/lib/tts/routes.js
@@ -221,6 +221,9 @@ export function registerTtsRoutes(app, { sayTTSCapability }) {
         const language = typeof req.headers['x-language'] === 'string' && req.headers['x-language'].trim().length > 0
           ? req.headers['x-language'].trim()
           : undefined;
+        const apiKey = typeof req.headers['x-api-key'] === 'string' && req.headers['x-api-key'].trim().length > 0
+          ? req.headers['x-api-key'].trim()
+          : undefined;
 
         if (!req.body || !Buffer.isBuffer(req.body) || req.body.length === 0) {
           return res.status(400).json({ error: 'Audio data is required' });
@@ -236,6 +239,7 @@ export function registerTtsRoutes(app, { sayTTSCapability }) {
           model,
           baseURL,
           language,
+          hasApiKey: !!apiKey,
         });
 
         const transcript = await transcribeAudio({
@@ -243,6 +247,7 @@ export function registerTtsRoutes(app, { sayTTSCapability }) {
           mimeType,
           model,
           baseURL,
+          apiKey,
           language,
         });
 

--- a/packages/web/server/lib/tts/stt.js
+++ b/packages/web/server/lib/tts/stt.js
@@ -16,10 +16,11 @@ import { normalizeCustomOpenAIBaseURL } from './base-url.js';
  * @param {string} opts.mimeType     - MIME type of the audio (e.g. 'audio/webm')
  * @param {string} opts.model        - Model name accepted by the remote server
  * @param {string} [opts.baseURL]    - Base URL of the compatible server (including /v1)
+ * @param {string} [opts.apiKey]     - Optional API key for the compatible server
  * @param {string} [opts.language]   - Optional BCP-47 language hint (e.g. 'en')
  * @returns {Promise<string>} Transcribed text
  */
-export async function transcribeAudio({ audioBuffer, mimeType, model, baseURL, language }) {
+export async function transcribeAudio({ audioBuffer, mimeType, model, baseURL, apiKey, language }) {
   const normalizedBaseURLResult = normalizeCustomOpenAIBaseURL(baseURL);
   if (normalizedBaseURLResult.error) {
     throw new Error(normalizedBaseURLResult.error);
@@ -31,7 +32,7 @@ export async function transcribeAudio({ audioBuffer, mimeType, model, baseURL, l
   }
 
   const clientOpts = {
-    apiKey: process.env.OPENAI_API_KEY || 'not-required',
+    apiKey: apiKey || process.env.OPENAI_API_KEY || 'not-required',
   };
   clientOpts.baseURL = normalizedBaseURL;
 


### PR DESCRIPTION
## Summary

Adds an optional **API Key** input field for the Custom (OpenAI-compatible) TTS/STT provider in Voice Settings, allowing authentication with self-hosted or third-party compatible servers.

## Problem

When using the **Custom** TTS provider, there are only three input fields: Server URL, Model, and Voice. There is **no API key / token field**. The frontend does not pass any `apiKey` to `/api/tts/speak`, and the server-side fallback hardcodes `not-required`.

The same applies to STT (server transcription via `/api/stt/transcribe`) — no authentication header is forwarded.

Many self-hosted or third-party OpenAI-compatible TTS/STT servers (e.g. behind an API gateway) require authentication. Setting `OPENAI_API_KEY` via environment variable is not an option for Desktop (Electron) users, and the OpenAI provider's API key is scoped to that provider only.

## Changes

### Frontend (TTS)
- Add `openaiCompatibleApiKey` to Zustand config store, persisted to `localStorage`
- Add API Key input field (password type) in `VoiceSettings.tsx` under the custom provider section
- Wire `openaiCompatibleApiKey` through `useServerTTS.speak()` — uses the compatible key when `baseURL` is set, falls back to `openaiApiKey` otherwise
- Pass `apiKey` in `previewCompatibleVoice` for the settings preview button

### Frontend (STT)
- Add `apiKey` field to `AudioStreamConfig` interface
- Forward as `X-API-Key` header in `audioStreamService._upload()`
- Wire `openaiCompatibleApiKey` through `useBrowserVoice` to `audioStreamService.configure()`

### Backend (STT)
- `routes.js`: Parse `X-API-Key` header and forward to `transcribeAudio()`
- `stt.js`: Accept `apiKey` parameter, prefer it over `OPENAI_API_KEY` env var

### Backend (TTS)
- No changes needed — `routes.js` and `service.js` already support `apiKey` in the request body

## Files changed (7)

| File | Change |
|------|--------|
| `packages/ui/src/stores/useConfigStore.ts` | +state, +setter, +localStorage |
| `packages/ui/src/components/sections/openchamber/VoiceSettings.tsx` | +API Key input field |
| `packages/ui/src/hooks/useServerTTS.ts` | Route apiKey based on baseURL |
| `packages/ui/src/hooks/useBrowserVoice.ts` | Pass apiKey to audioStreamService |
| `packages/ui/src/lib/voice/audioStreamService.ts` | +apiKey config, +X-API-Key header |
| `packages/web/server/lib/tts/routes.js` | Parse X-API-Key for STT |
| `packages/web/server/lib/tts/stt.js` | Accept apiKey parameter |

## Testing

- Verified the code compiles (no TypeScript errors in changed files)
- API Key field appears between Server URL and Model in the custom provider section
- Preview button passes the API key to the backend
- STT transcription forwards the API key via X-API-Key header

## Screenshots

The API Key field appears in Settings → Voice → Custom provider section, between Server URL and Model, with an Optional label and password masking.