### PR TITLE
fix: switch model when selecting an agent

### DIFF
--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -618,6 +618,7 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     ];
 
     const prevAgentNameRef = React.useRef<string | undefined>(undefined);
+    const explicitAgentSwitchRef = React.useRef<string | null>(null);
     const latestLoadedUserChoiceRestoreRef = React.useRef<string | null>(null);
 
     const currentSessionDirectory = currentSessionId ? getDirectoryForSession(currentSessionId) : undefined;
@@ -1007,6 +1008,9 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                     prevAgentNameRef.current = currentAgentName;
 
                     if (currentAgentName && currentSessionId) {
+                        const shouldPreferAgentModel = explicitAgentSwitchRef.current === currentAgentName;
+                        explicitAgentSwitchRef.current = null;
+
                         await new Promise<void>((resolve) => {
                             const timer = setTimeout(resolve, 50);
                             abortController.signal.addEventListener('abort', () => {
@@ -1019,7 +1023,9 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                             return;
                         }
 
-                        const selectedAgent = agents.find((agent) => agent.name === currentAgentName);
+                        const selectedAgent = shouldPreferAgentModel
+                            ? agents.find((agent) => agent.name === currentAgentName)
+                            : undefined;
                         if (selectedAgent?.model?.providerID && selectedAgent.model.modelID) {
                             const result = tryApplyModelSelection(
                                 selectedAgent.model.providerID,
@@ -1027,6 +1033,19 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                                 currentAgentName,
                             );
                             if (result === 'applied' || result === 'provider-missing') {
+                                if (result === 'applied') {
+                                    saveSessionModelSelection(
+                                        currentSessionId,
+                                        selectedAgent.model.providerID,
+                                        selectedAgent.model.modelID,
+                                    );
+                                    saveAgentModelForSession(
+                                        currentSessionId,
+                                        currentAgentName,
+                                        selectedAgent.model.providerID,
+                                        selectedAgent.model.modelID,
+                                    );
+                                }
                                 return;
                             }
                         }
@@ -1055,7 +1074,16 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
         return () => {
             abortController.abort();
         };
-    }, [agents, currentAgentName, currentSessionId, getAgentModelForSession, tryApplyModelSelection, contextHydrated]);
+    }, [
+        agents,
+        currentAgentName,
+        currentSessionId,
+        getAgentModelForSession,
+        saveAgentModelForSession,
+        saveSessionModelSelection,
+        tryApplyModelSelection,
+        contextHydrated,
+    ]);
 
     React.useEffect(() => {
         if (!contextHydrated || !currentAgentName) {
@@ -1131,6 +1159,7 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
 
     const handleAgentChange = React.useCallback((agentName: string, options?: { closeModelSelector?: boolean }) => {
         try {
+            explicitAgentSwitchRef.current = agentName;
             setAgent(agentName);
             addRecentAgent(agentName);
             if (options?.closeModelSelector ?? true) {

--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -1019,6 +1019,18 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                             return;
                         }
 
+                        const selectedAgent = agents.find((agent) => agent.name === currentAgentName);
+                        if (selectedAgent?.model?.providerID && selectedAgent.model.modelID) {
+                            const result = tryApplyModelSelection(
+                                selectedAgent.model.providerID,
+                                selectedAgent.model.modelID,
+                                currentAgentName,
+                            );
+                            if (result === 'applied' || result === 'provider-missing') {
+                                return;
+                            }
+                        }
+
                         const persistedChoice = getAgentModelForSession(currentSessionId, currentAgentName);
 
                         if (persistedChoice) {
@@ -1043,7 +1055,7 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
         return () => {
             abortController.abort();
         };
-    }, [currentAgentName, currentSessionId, getAgentModelForSession, tryApplyModelSelection, contextHydrated]);
+    }, [agents, currentAgentName, currentSessionId, getAgentModelForSession, tryApplyModelSelection, contextHydrated]);
 
     React.useEffect(() => {
         if (!contextHydrated || !currentAgentName) {

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -1739,6 +1739,20 @@ export const useConfigStore = create<ConfigStore>()(
                             });
                         };
 
+                        // Prefer the selected agent's configured model when switching agents.
+                        const agent = agents.find((candidate) => candidate.name === agentName);
+                        const agentModelSelection = agent?.model;
+                        if (agentModelSelection?.providerID && agentModelSelection?.modelID) {
+                            const { providerID, modelID } = agentModelSelection;
+                            const agentProvider = providers.find((provider) => provider.id === providerID);
+                            const agentModel = agentProvider?.models.find((model) => model.id === modelID);
+
+                            if (agentModel) {
+                                applyResolvedModelSelection(providerID, modelID, undefined);
+                                return;
+                            }
+                        }
+
                         if (currentSessionId) {
                             const existingAgentModel = useSelectionStore.getState().getAgentModelForSession(currentSessionId, agentName);
                             if (existingAgentModel && hasProviderModel(providers, existingAgentModel.providerId, existingAgentModel.modelId)) {
@@ -1759,7 +1773,7 @@ export const useConfigStore = create<ConfigStore>()(
                             }
                         }
 
-                        // If settings has a default model, use it instead of agent's preferred
+                        // If the agent has no preferred model, use settings default.
                         if (settingsDefaultModel) {
                             const parsed = parseModelString(settingsDefaultModel);
                             if (parsed) {
@@ -1780,18 +1794,7 @@ export const useConfigStore = create<ConfigStore>()(
                             }
                         }
 
-                        // Fall back to agent's preferred model
-                        const agent = agents.find((candidate) => candidate.name === agentName);
-                        const agentModelSelection = agent?.model;
-                        if (agentModelSelection?.providerID && agentModelSelection?.modelID) {
-                            const { providerID, modelID } = agentModelSelection;
-                            const agentProvider = providers.find((provider) => provider.id === providerID);
-                            const agentModel = agentProvider?.models.find((model) => model.id === modelID);
-
-                            if (agentModel) {
-                                applyResolvedModelSelection(providerID, modelID, undefined);
-                            }
-                        }
+                        // Otherwise keep the current valid model selection unchanged.
                     }
                 },
 

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -1759,10 +1759,6 @@ export const useConfigStore = create<ConfigStore>()(
                             }
                         }
 
-                        if (hasProviderModel(providers, currentProviderId, currentModelId)) {
-                            return;
-                        }
-
                         // If settings has a default model, use it instead of agent's preferred
                         if (settingsDefaultModel) {
                             const parsed = parseModelString(settingsDefaultModel);


### PR DESCRIPTION
## Bug

When selecting an agent from the chat dropdown, the model selector does not reliably update to the model configured on that agent. It can keep the previously selected model, or a stale per-session agent/model choice can be re-applied shortly after the switch.

## Root Cause

There were two paths preventing the selected agent's configured model from winning:

1. In `useConfigStore.setAgent()`, an early return kept the current model whenever it was valid. Since the current model is usually valid, the agent model fallback was effectively unreachable.
2. In `ModelControls`, the agent-switch effect restored a persisted per-session agent/model selection before considering the agent file's configured model. That could override the model from the selected agent.

## Fix

Explicit agent selection now prefers the model configured on the selected agent:

- `useConfigStore.ts`: applies the selected agent's configured model before saved/default fallback logic.
- `ModelControls.tsx`: applies the selected agent's configured model before restoring persisted per-session agent/model choices.

If the selected agent has no valid configured model, existing fallback behavior remains: saved selection, settings default, then current valid model.

## Testing

- `bun run type-check` — passes
- `bun run lint` — passes
- `bun run build` — passes
- Deployed locally and verified the updated build starts successfully