### PR TITLE
fix: expand chat tool details

### DIFF
--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -1641,7 +1641,7 @@ const AssistantMessageBody = React.memo(({
                     continue;
                 }
 
-                // Expandable tools: bash, edit, write, task, question — individual rows
+                // Expandable named tools: individual rows
                 if (isExpandableTool(toolName)) {
                     rendered.push(
                         <FadeInOnReveal key={`tool-${toolPart.id}`}>
@@ -1664,7 +1664,7 @@ const AssistantMessageBody = React.memo(({
                     continue;
                 }
 
-                // Static tools: one row per tool call (no grouping)
+                // Empty or malformed tool names: one compact fallback row
                 rendered.push(
                     <FadeInOnReveal key={`static-tools-${toolPart.id}`}>
                         <ToolRevealOnMount animate={animatedToolIdsLookup.has(toolPart.id)} wipe>

--- a/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
@@ -8,17 +8,17 @@ Use this doc when you ask an agent to change tool/header/description behavior.
 
 - Message parts are rendered from `MessageBody.tsx`.
 - There are two tool rendering paths:
-  - **Static grouped tools** -> `StaticToolRow` in `ProgressiveGroup.tsx`
-  - **Expandable tools** -> `ToolPart.tsx`
+  - **Expandable named tools** -> `ToolPart.tsx`
+  - **Compact fallback rows** -> `StaticToolRow` in `ProgressiveGroup.tsx` for legacy or malformed tool records
 - Shared tool icon mapping is centralized in `toolPresentation.tsx` (`getToolIcon`).
 
 ## Which file controls what
 
 - `ProgressiveGroup.tsx`
-  - Renders grouped Activity rows and grouped static tools.
+  - Renders grouped Activity rows and compact fallback tool rows.
   - Contains `StaticToolRow`.
   - Contains static tool short description logic (`getToolShortDescription`).
-  - If you want to change how `read/grep/perplexity/webfetch/...` look in compact/grouped mode, edit here.
+  - If you want to change compact fallback copy, edit here.
 
 - `ToolPart.tsx`
   - Renders expandable tool rows (bash/edit/write/question/task + fallback).
@@ -32,10 +32,8 @@ Use this doc when you ask an agent to change tool/header/description behavior.
 - `toolRenderUtils.ts`
   - Core classification helpers:
     - `isExpandableTool`
-    - `isStaticTool`
     - `isStandaloneTool`
-    - `getStaticGroupToolName`
-  - If a tool should switch between static vs expandable, change it here.
+  - If a tool should switch between standalone vs expandable, change it here.
 
 - `ReasoningPart.tsx`
   - Thinking block UI (`ReasoningTimelineBlock`), summary + optional duration.
@@ -45,26 +43,24 @@ Use this doc when you ask an agent to change tool/header/description behavior.
 
 ## Current important behavior
 
-- `read` and most search/fetch tools are treated as **static tools** and usually render via `StaticToolRow`.
-- `bash/edit/write/question/task` are **expandable tools** and render via `ToolPart`.
-- `perplexity` is currently treated as static and grouped into search/web-search style rows (through static grouping + short description extraction).
+- All non-empty, non-task tool names are **expandable tools** and render via `ToolPart`.
+- `task` is standalone and handled by its dedicated rendering flow.
 - Thinking/Justification duration is hidden in `sorted` mode (handled in `ReasoningPart.tsx` + `JustificationBlock.tsx`).
 
 ## "I want to change description for Perplexity" (example recipe)
 
 If task is: "change text shown near Perplexity tool header/description":
 
-1. Edit `ProgressiveGroup.tsx` -> `getToolShortDescription(activity)`.
-2. Update the branch that handles web-search tools (`websearch`, `web-search`, `search_web`, `codesearch`, `perplexity`, etc.).
-3. If needed, update group rendering in `StaticToolRow` (search/fetch specific rendering branches).
-4. Keep icon changes (if any) in `toolPresentation.tsx`.
+1. Edit `ToolPart.tsx` for the expanded header or body.
+2. If the compact fallback row also needs the copy, edit `ProgressiveGroup.tsx` -> `getToolShortDescription(activity)`.
+3. Keep icon changes (if any) in `toolPresentation.tsx`.
 
-Why: in current pipeline Perplexity is static/grouped, so `StaticToolRow` is the primary path.
+Why: named tools, including Perplexity-style tools, render through `ToolPart`.
 
 ## "I want tool to become expandable" (example)
 
 1. Update `toolRenderUtils.ts`:
-   - add/remove tool name in `EXPANDABLE_TOOL_NAMES`
+   - add/remove standalone exclusions as needed
 2. Ensure `ToolPart.tsx` supports desired header + expanded output format for that tool.
 3. Validate both modes (`sorted` and `live`).
 

--- a/packages/ui/src/components/chat/message/parts/ProgressiveGroup.tsx
+++ b/packages/ui/src/components/chat/message/parts/ProgressiveGroup.tsx
@@ -14,7 +14,7 @@ import { Icon } from "@/components/icon/Icon";
 import { FadeInOnReveal } from '../FadeInOnReveal';
 import { getToolIcon } from './toolPresentation';
 import { getToolMetadata } from '@/lib/toolHelpers';
-import { isExpandableTool, isStandaloneTool, isStaticTool } from './toolRenderUtils';
+import { isExpandableTool, isStandaloneTool } from './toolRenderUtils';
 import { RuntimeAPIContext } from '@/contexts/runtimeAPIContext';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -410,7 +410,6 @@ const getToolShortDescription = (activity: TurnActivityPart): string | null => {
 
 type AggregatedRow =
     | { type: 'tool-expandable'; activity: TurnActivityPart }
-    | { type: 'tool-static-group'; toolName: string; activities: TurnActivityPart[] }
     | { type: 'reasoning'; activity: TurnActivityPart }
     | { type: 'justification'; activity: TurnActivityPart }
     | { type: 'tool-fallback'; activity: TurnActivityPart };
@@ -483,53 +482,11 @@ const MemoExpandableToolRow = React.memo(ExpandableToolRow, (prev, next) => {
         && areRenderRelevantPartsEqual([prev.activity.part], [next.activity.part]);
 });
 
-interface StaticGroupedToolRowProps {
-    toolName: string;
-    activities: TurnActivityPart[];
-    animateTailText: boolean;
-    animateRows: boolean;
-}
-
-const StaticGroupedToolRow: React.FC<StaticGroupedToolRowProps> = ({
-    toolName,
-    activities,
-    animateTailText,
-    animateRows,
-}) => {
-    const content = (
-        <StaticToolRow
-            toolName={toolName}
-            activities={activities}
-            animateTailText={animateTailText}
-        />
-    );
-
-    const maybeWrapped = animateTailText ? (
-        <ToolRevealOnMount animate={true} wipe>
-            {content}
-        </ToolRevealOnMount>
-    ) : content;
-
-    if (!animateRows) {
-        return maybeWrapped;
-    }
-
-    return <FadeInOnReveal>{maybeWrapped}</FadeInOnReveal>;
-};
-
-const MemoStaticGroupedToolRow = React.memo(StaticGroupedToolRow, (prev, next) => {
-    return prev.toolName === next.toolName
-        && prev.animateTailText === next.animateTailText
-        && prev.animateRows === next.animateRows
-        && areActivityListsEqual(prev.activities, next.activities);
-});
-
 /**
  * Aggregate sorted activity parts into display rows.
- * Static tools are rendered as one row per call.
  * Reasoning/justification become inline text.
- * Expandable tools (edit, bash, write, question) stay as individual rows.
- * Unknown tools stay as individual expandable rows (fallback).
+ * Expandable tools stay as individual rows.
+ * Unknown named tools stay as individual expandable rows.
  */
 const aggregateRows = (parts: TurnActivityPart[]): AggregatedRow[] => {
     const rows: AggregatedRow[] = [];
@@ -566,13 +523,7 @@ const aggregateRows = (parts: TurnActivityPart[]): AggregatedRow[] => {
             continue;
         }
 
-        if (isStaticTool(toolName)) {
-            rows.push({ type: 'tool-static-group', toolName, activities: [activity] });
-            i++;
-            continue;
-        }
-
-        // Unknown/fallback tool — keep as expandable
+        // Empty or malformed tool names fall back to the generic expandable row.
         rows.push({ type: 'tool-fallback', activity });
         i++;
     }
@@ -898,7 +849,7 @@ const ProgressiveGroup: React.FC<ProgressiveGroupProps> = ({
     };
 
     const renderedRows = shouldRenderRows
-        ? visibleRows.map((row, index) => {
+        ? visibleRows.map((row) => {
         switch (row.type) {
             case 'reasoning':
                 return wrapRow(
@@ -936,17 +887,6 @@ const ProgressiveGroup: React.FC<ProgressiveGroupProps> = ({
                         onShowPopup={onShowPopup}
                         onContentChange={onContentChange}
                         animateTailText={Boolean(animatedToolIds?.has(row.activity.id))}
-                        animateRows={animateRows}
-                    />
-                );
-
-            case 'tool-static-group':
-                return (
-                    <MemoStaticGroupedToolRow
-                        key={`static-${row.toolName}-${row.activities[0]?.id ?? index}`}
-                        toolName={row.toolName}
-                        activities={row.activities}
-                        animateTailText={row.activities.some((activity) => animatedToolIds?.has(activity.id))}
                         animateRows={animateRows}
                     />
                 );

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -45,7 +45,13 @@ import { resolveFallbackTaskSessionId } from './resolveFallbackTaskSessionId';
 import { areRenderRelevantPartsEqual } from '../renderCompare';
 import { useI18n } from '@/lib/i18n';
 
-type ToolStateWithMetadata = ToolStateUnion & { metadata?: Record<string, unknown>; input?: Record<string, unknown>; output?: string; error?: string; time?: { start: number; end?: number } };
+type ToolStateWithMetadata = ToolStateUnion & {
+    metadata?: Record<string, unknown>;
+    input?: Record<string, unknown>;
+    output?: unknown;
+    error?: string;
+    time?: { start: number; end?: number };
+};
 
 interface ToolPartProps {
     part: ToolPartType;
@@ -748,17 +754,77 @@ const ToolScrollableSection: React.FC<ToolScrollableSectionProps> = ({
     </div>
 );
 
+const isStructuredValue = (value: unknown): value is Record<string, unknown> | unknown[] => {
+    if (Array.isArray(value)) {
+        return true;
+    }
+
+    return isRecord(value);
+};
+
+const hasNonEmptyStructuredValue = (value: unknown): value is Record<string, unknown> | unknown[] => {
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+
+    return isRecord(value) && Object.keys(value).length > 0;
+};
+
+const renderJsonTreeBlock = (data: unknown) => {
+    return (
+        <div className="tool-output-surface p-2 rounded-xl w-full min-w-0">
+            <JsonTreeViewer
+                data={data}
+                initiallyExpandedDepth={1}
+                maxHeight="400px"
+            />
+        </div>
+    );
+};
+
+const shouldRenderToolOutputAsMarkdown = (toolName: string): boolean => {
+    const normalizedToolName = normalizeToolName(toolName);
+    // Task output is handled by its dedicated renderer below because it also
+    // carries child-session summary behavior that should stay centralized there.
+    if (!normalizedToolName || normalizedToolName === 'task') {
+        return false;
+    }
+
+    return getToolMetadata(normalizedToolName).outputLanguage === 'markdown';
+};
+
+const isEditLikeTool = (toolName: string): boolean => {
+    return toolName === 'edit' || toolName === 'multiedit' || toolName === 'apply_patch';
+};
+
+const shouldSkipGenericInputRendering = (
+    toolName: string,
+    hideToolInputPreview: boolean,
+    isWriteLikeTool: boolean,
+): boolean => {
+    return hideToolInputPreview
+        || isWriteLikeTool
+        || toolName === 'bash'
+        || toolName === 'question'
+        || toolName === 'task';
+};
+
 const getToolOutputLanguage = (
     output: string,
     part: ToolPartType,
     metadata: Record<string, unknown> | undefined,
     input: Record<string, unknown> | undefined,
 ): string => {
-    if (part.tool === 'bash') {
+    const normalizedToolName = normalizeToolName(part.tool);
+    if (normalizedToolName === 'bash') {
         return 'bash';
     }
 
-    return detectLanguageFromOutput(formatEditOutput(output, part.tool, metadata), part.tool, input);
+    return detectLanguageFromOutput(
+        formatEditOutput(output, normalizedToolName || part.tool, metadata),
+        normalizedToolName || part.tool,
+        input,
+    );
 };
 
 const getToolOutputText = (
@@ -766,11 +832,12 @@ const getToolOutputText = (
     part: ToolPartType,
     metadata: Record<string, unknown> | undefined,
 ): string => {
-    if (part.tool === 'bash') {
+    const normalizedToolName = normalizeToolName(part.tool);
+    if (normalizedToolName === 'bash') {
         return output;
     }
 
-    return formatEditOutput(output, part.tool, metadata);
+    return formatEditOutput(output, normalizedToolName || part.tool, metadata);
 };
 
 const ToolScrollableTextOutput: React.FC<{
@@ -785,15 +852,7 @@ const ToolScrollableTextOutput: React.FC<{
     const jsonResult = React.useMemo(() => tryParseJsonOutput(renderedOutput), [renderedOutput]);
 
     if (jsonResult.isJson) {
-        return (
-            <div className="tool-output-surface p-2 rounded-xl w-full min-w-0">
-                <JsonTreeViewer
-                    data={jsonResult.data}
-                    initiallyExpandedDepth={1}
-                    maxHeight="400px"
-                />
-            </div>
-        );
+        return renderJsonTreeBlock(jsonResult.data);
     }
 
     return (
@@ -1548,12 +1607,15 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
     const { t } = useI18n();
     const { pierreTheme, pierreThemeType } = usePierreThemeConfig();
     const [diffViewMode, setDiffViewMode] = React.useState<DiffViewMode>('unified');
+    const normalizedToolName = normalizeToolName(part.tool);
     const stateWithData = state as ToolStateWithMetadata;
     const metadata = stateWithData.metadata;
     const input = stateWithData.input;
     const rawOutput = stateWithData.output;
     const hasStringOutput = typeof rawOutput === 'string' && rawOutput.length > 0;
     const outputString = typeof rawOutput === 'string' ? rawOutput : '';
+    const hasStructuredOutput = !hasStringOutput && isStructuredValue(rawOutput);
+    const hasMarkdownOutput = hasStringOutput && shouldRenderToolOutputAsMarkdown(normalizedToolName || part.tool);
 
     const diffContent = getPatchText((metadata as { patch?: unknown } | undefined)?.patch)
         ?? getPatchText(metadata?.diff)
@@ -1562,9 +1624,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
         () => (diffContent ? getDiffPatchEntries(metadata, diffContent, currentDirectory) : []),
         [currentDirectory, diffContent, metadata]
     );
-    const hideToolInputPreview = part.tool === 'apply_patch'
-        || part.tool === 'edit'
-        || part.tool === 'multiedit';
+    const hideToolInputPreview = isEditLikeTool(normalizedToolName);
     const diagnosticSection = React.useMemo(
         () => getToolDiagnosticSection(part.tool, input, metadata, currentDirectory),
         [currentDirectory, input, metadata, part.tool],
@@ -1575,7 +1635,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
             return '';
         }
 
-        if ('command' in input && typeof input.command === 'string' && part.tool === 'bash') {
+        if ('command' in input && typeof input.command === 'string' && normalizedToolName === 'bash') {
             return formatInputForDisplay(input, part.tool);
         }
 
@@ -1584,9 +1644,16 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
         }
 
         return formatInputForDisplay(input, part.tool);
-    }, [input, part.tool]);
-    const hasInputText = !hideToolInputPreview && inputTextContent.trim().length > 0;
-    const isWriteLikeTool = part.tool === 'write' || part.tool === 'create' || part.tool === 'file_write';
+    }, [input, normalizedToolName, part.tool]);
+    const isWriteLikeTool = normalizedToolName === 'write' || normalizedToolName === 'create' || normalizedToolName === 'file_write';
+    const genericStructuredInput = React.useMemo(() => {
+        if (shouldSkipGenericInputRendering(normalizedToolName, hideToolInputPreview, isWriteLikeTool)) {
+            return null;
+        }
+
+        return hasNonEmptyStructuredValue(input) ? input : null;
+    }, [hideToolInputPreview, input, isWriteLikeTool, normalizedToolName]);
+    const hasInputText = !genericStructuredInput && !hideToolInputPreview && inputTextContent.trim().length > 0;
     const writeLikeInputPatch = React.useMemo(() => {
         if (!isWriteLikeTool || !hasInputText) {
             return undefined;
@@ -1665,7 +1732,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
         };
 
         // Question tool: show parsed Q&A summary or question content from input
-        if (part.tool === 'question') {
+        if (normalizedToolName === 'question') {
             if (state.status === 'completed' && hasStringOutput) {
                 const parsedQA = parseQuestionOutput(outputString);
                 if (parsedQA && parsedQA.length > 0) {
@@ -1730,7 +1797,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
             return <div className="typography-meta text-muted-foreground">{t('chat.toolPart.awaitingResponse')}</div>;
         }
 
-        if (part.tool === 'task' && hasStringOutput) {
+        if (normalizedToolName === 'task' && hasStringOutput) {
             return renderScrollableBlock(
                 <div className="w-full min-w-0">
                     <SimpleMarkdownRenderer content={outputString} variant="tool" onShowPopup={onShowPopup} />
@@ -1738,7 +1805,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
             );
         }
 
-        if ((part.tool === 'edit' || part.tool === 'multiedit' || part.tool === 'apply_patch' || part.tool === 'write') && (diffEntries.length > 0 || !!diagnosticSection)) {
+        if ((isEditLikeTool(normalizedToolName) || normalizedToolName === 'write') && (diffEntries.length > 0 || !!diagnosticSection)) {
             return renderScrollableBlock(
                 <div className="space-y-3">
                     {diffEntries.map((entry) => (
@@ -1762,7 +1829,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
             );
         }
 
-        if (part.tool === 'write' && diagnosticSection) {
+        if (normalizedToolName === 'write' && diagnosticSection) {
             return renderScrollableBlock(
                 <div className="space-y-3">
                     {renderDiagnosticsSection()}
@@ -1773,6 +1840,21 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
 
         if (isWriteLikeTool) {
             return null;
+        }
+
+        if (hasStructuredOutput) {
+            return renderScrollableBlock(
+                renderJsonTreeBlock(rawOutput),
+                { className: 'p-1', maxHeightClass: 'max-h-[50vh]' },
+            );
+        }
+
+        if (hasMarkdownOutput && outputString.trim()) {
+            return renderScrollableBlock(
+                <div className="w-full min-w-0">
+                    <SimpleMarkdownRenderer content={outputString} variant="tool" onShowPopup={onShowPopup} />
+                </div>
+            );
         }
 
         if (hasStringOutput && outputString.trim()) {
@@ -1803,14 +1885,26 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                 'relative pr-2 pb-2 pt-2 space-y-2 pl-4'
             )}
         >
-            {part.tool === 'question' ? (
+            {normalizedToolName === 'question' ? (
                 renderResultContent()
             ) : (
                 <>
+                    {genericStructuredInput ? (
+                        <div className="my-1">
+                            {renderScrollableBlock(
+                                renderJsonTreeBlock(genericStructuredInput),
+                                {
+                                    maxHeightClass: 'max-h-60',
+                                    className: 'tool-input-surface p-1',
+                                }
+                            )}
+                        </div>
+                    ) : null}
+
                     {hasInputText ? (
                         <div className="my-1">
                             {renderScrollableBlock(
-                                part.tool === 'bash' ? (
+                                normalizedToolName === 'bash' ? (
                                     <pre className="tool-input-text whitespace-pre-wrap break-words typography-code text-muted-foreground/90 m-0 p-0">
                                         {inputTextContent}
                                     </pre>
@@ -1828,7 +1922,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                                 ),
                                 {
                                     maxHeightClass: 'max-h-60',
-                                    className: part.tool === 'bash' ? 'tool-input-surface p-0 rounded-none' : 'tool-input-surface',
+                                    className: normalizedToolName === 'bash' ? 'tool-input-surface p-0 rounded-none' : 'tool-input-surface',
                                 }
                             )}
                         </div>
@@ -1836,7 +1930,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
 
                     {state.status === 'completed' && 'output' in state && (
                         <div>
-                            {(part.tool === 'edit' || part.tool === 'multiedit' || part.tool === 'apply_patch' || part.tool === 'write') && diffContent ? (
+                            {(isEditLikeTool(normalizedToolName) || normalizedToolName === 'write') && diffContent ? (
                                 <div className="mb-1 flex items-center justify-end gap-2">
                                     <DiffViewToggle
                                         mode={diffViewMode}

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -450,6 +450,30 @@ const getRelativePath = (absolutePath: string, currentDirectory: string): string
     return normalizedAbsolutePath;
 };
 
+const resolveAbsolutePath = (currentDirectory: string, filePath: string): string | null => {
+    const trimmed = filePath.trim();
+    if (!trimmed) return null;
+    if (trimmed.startsWith('/')) return normalizeDisplayPath(trimmed);
+    return normalizeDisplayPath(currentDirectory.endsWith('/') ? `${currentDirectory}${trimmed}` : `${currentDirectory}/${trimmed}`);
+};
+
+const getContextDirectoryForPath = (currentDirectory: string, absolutePath: string): string => {
+    const normalizedCurrent = normalizeDisplayPath(currentDirectory);
+    const normalizedAbsolute = normalizeDisplayPath(absolutePath);
+    return normalizedCurrent && normalizedAbsolute.startsWith(`${normalizedCurrent}/`)
+        ? normalizedCurrent
+        : normalizedAbsolute.replace(/\/[^/]*$/, '') || normalizedCurrent;
+};
+
+const readPositiveLine = (...values: unknown[]): number | undefined => {
+    for (const value of values) {
+        if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+            return Math.floor(value);
+        }
+    }
+    return undefined;
+};
+
 type ToolDiagnostic = {
     message: string;
     line: number;
@@ -685,6 +709,51 @@ const getToolDescriptionPath = (part: ToolPartType, state: ToolStateUnion, curre
     return null;
 };
 
+const readTrimmedString = (value: unknown): string | null => {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+};
+
+const truncateDescription = (value: string, maxLength: number): string => (
+    value.length > maxLength ? `${value.slice(0, maxLength)}...` : value
+);
+
+const formatTodoSummary = (todos: unknown[]): string | null => {
+    if (todos.length === 0) return '0 tasks';
+
+    let activeCount = 0;
+    for (const todo of todos) {
+        if (!todo || typeof todo !== 'object') continue;
+        const status = readTrimmedString((todo as { status?: unknown }).status)?.toLowerCase();
+        if (status === 'pending' || status === 'in_progress' || status === 'in progress' || status === 'inprogress') {
+            activeCount += 1;
+        }
+    }
+
+    return `${activeCount} ${activeCount === 1 ? 'task' : 'tasks'}`;
+};
+
+const getTodoDescription = (input: Record<string, unknown> | undefined, output: unknown): string | null => {
+    if (Array.isArray(input?.todos)) return formatTodoSummary(input.todos);
+    if (Array.isArray(output)) return formatTodoSummary(output);
+    if (output && typeof output === 'object' && Array.isArray((output as { todos?: unknown }).todos)) {
+        return formatTodoSummary((output as { todos: unknown[] }).todos);
+    }
+    if (typeof output === 'string' && output.trim().length > 0) {
+        try {
+            const parsed = JSON.parse(output) as unknown;
+            if (Array.isArray(parsed)) return formatTodoSummary(parsed);
+            if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { todos?: unknown }).todos)) {
+                return formatTodoSummary((parsed as { todos: unknown[] }).todos);
+            }
+        } catch {
+            return null;
+        }
+    }
+    return null;
+};
+
 const getToolDescription = (part: ToolPartType, state: ToolStateUnion, currentDirectory: string): string => {
     const stateWithData = state as ToolStateWithMetadata;
     const metadata = stateWithData.metadata;
@@ -716,6 +785,29 @@ const getToolDescription = (part: ToolPartType, state: ToolStateUnion, currentDi
 
     if (part.tool === 'task' && input?.description && typeof input.description === 'string') {
         return input.description.substring(0, 80);
+    }
+
+    if (part.tool === 'grep' || part.tool === 'search' || part.tool === 'find' || part.tool === 'ripgrep' || part.tool === 'glob') {
+        const pattern = readTrimmedString(input?.pattern);
+        if (pattern) return truncateDescription(pattern, 40);
+    }
+
+    if (part.tool === 'webfetch' || part.tool === 'fetch' || part.tool === 'curl' || part.tool === 'wget') {
+        const url = readTrimmedString(input?.url)
+            ?? readTrimmedString(input?.URL)
+            ?? readTrimmedString(metadata?.url)
+            ?? readTrimmedString(metadata?.URL);
+        if (url) return url;
+    }
+
+    if (part.tool === 'skill') {
+        const name = readTrimmedString(input?.name);
+        if (name) return name;
+    }
+
+    if (part.tool === 'todowrite' || part.tool === 'todoread') {
+        const todoSummary = getTodoDescription(input, stateWithData.output);
+        if (todoSummary) return todoSummary;
     }
 
     const desc = input?.description || metadata?.description || ('title' in state && state.title) || '';
@@ -1977,10 +2069,10 @@ const ToolPart: React.FC<ToolPartProps> = ({
     const state = part.state;
     const showToolFileIcons = useUIStore((s) => s.showToolFileIcons);
     const currentDirectory = useDirectoryStore((s) => s.currentDirectory);
-    const currentSessionId = useSessionUIStore((s) => s.currentSessionId);
 
     const normalizedPartTool = normalizeToolName(part.tool);
     const isTaskTool = normalizedPartTool === 'task';
+    const currentSessionId = useSessionUIStore((s) => isTaskTool ? s.currentSessionId : undefined);
 
     const status = state?.status as string | undefined;
     const isFinalized = status === 'completed' || status === 'error' || status === 'aborted' || status === 'failed' || status === 'timeout' || status === 'cancelled';
@@ -2027,6 +2119,7 @@ const ToolPart: React.FC<ToolPartProps> = ({
     const onContentChangeRef = React.useRef(onContentChange);
     onContentChangeRef.current = onContentChange;
     const expandedContentRef = React.useRef<HTMLDivElement>(null);
+    const expandedContentId = React.useId();
     const expandedContentAnimationRef = React.useRef<AnimationPlaybackControls | null>(null);
     const expandedContentMountedRef = React.useRef(false);
 
@@ -2691,7 +2784,7 @@ const ToolPart: React.FC<ToolPartProps> = ({
     const runtime = React.useContext(RuntimeAPIContext);
 
     const handleMainClick = (e: { stopPropagation: () => void }) => {
-        if (isTaskTool || !runtime?.editor) {
+        if (isTaskTool) {
             onToggle(part.id);
             return;
         }
@@ -2699,36 +2792,47 @@ const ToolPart: React.FC<ToolPartProps> = ({
         let filePath: unknown;
         let targetLine: number | undefined;
         let toolDiff: string | undefined;
-        if (part.tool === 'edit' || part.tool === 'multiedit') {
+        if (normalizedPartTool === 'edit' || normalizedPartTool === 'multiedit') {
             filePath = input?.filePath || input?.file_path || input?.path || metadata?.filePath || metadata?.file_path || metadata?.path;
-            targetLine = getFirstChangedLineFromMetadata(part.tool, metadata);
+            targetLine = getFirstChangedLineFromMetadata(normalizedPartTool, metadata);
             if (typeof filePath === 'string') {
-                toolDiff = getPrimaryDiffFromMetadata(part.tool, metadata, filePath);
+                toolDiff = getPrimaryDiffFromMetadata(normalizedPartTool, metadata, filePath);
             }
-        } else if (part.tool === 'apply_patch') {
+        } else if (normalizedPartTool === 'apply_patch') {
             const files = Array.isArray(metadata?.files) ? metadata?.files : [];
             const firstFile = files[0] as { relativePath?: string; filePath?: string } | undefined;
             filePath = firstFile?.relativePath || firstFile?.filePath;
-            targetLine = getFirstChangedLineFromMetadata(part.tool, metadata);
+            targetLine = getFirstChangedLineFromMetadata(normalizedPartTool, metadata);
             if (typeof filePath === 'string') {
-                toolDiff = getPrimaryDiffFromMetadata(part.tool, metadata, filePath);
+                toolDiff = getPrimaryDiffFromMetadata(normalizedPartTool, metadata, filePath);
             }
-        } else if (['write', 'create', 'file_write'].includes(part.tool)) {
+        } else if (['write', 'create', 'file_write', 'read'].includes(normalizedPartTool)) {
             filePath = input?.filePath || input?.file_path || input?.path || metadata?.filePath || metadata?.file_path || metadata?.path;
+            if (normalizedPartTool === 'read') {
+                targetLine = readPositiveLine(input?.offset, input?.line, metadata?.offset, metadata?.line);
+            }
         }
 
         if (typeof filePath === 'string') {
             e.stopPropagation();
-            let absolutePath = filePath;
-            if (!filePath.startsWith('/')) {
-                absolutePath = currentDirectory.endsWith('/') ? currentDirectory + filePath : currentDirectory + '/' + filePath;
-            }
-            if (runtime.runtime.isVSCode && toolDiff && (part.tool === 'edit' || part.tool === 'multiedit' || part.tool === 'apply_patch')) {
+            const absolutePath = resolveAbsolutePath(currentDirectory, filePath);
+            if (!absolutePath) return;
+            if (runtime?.runtime.isVSCode && runtime.editor && toolDiff && (normalizedPartTool === 'edit' || normalizedPartTool === 'multiedit' || normalizedPartTool === 'apply_patch')) {
                 const label = `${getRelativePath(absolutePath, currentDirectory)} (changes)`;
                 void runtime.editor.openDiff('', absolutePath, label, { line: targetLine, patch: toolDiff });
                 return;
             }
-            runtime.editor.openFile(absolutePath, targetLine);
+            if (runtime?.editor) {
+                runtime.editor.openFile(absolutePath, targetLine);
+                return;
+            }
+            const uiStore = useUIStore.getState();
+            const contextDirectory = getContextDirectoryForPath(currentDirectory, absolutePath);
+            if (targetLine) {
+                uiStore.openContextFileAtLine(contextDirectory, absolutePath, targetLine, 1);
+                return;
+            }
+            uiStore.openContextFile(contextDirectory, absolutePath);
         } else {
             onToggle(part.id);
         }
@@ -2755,19 +2859,26 @@ const ToolPart: React.FC<ToolPartProps> = ({
             {}
             <div
                 className={cn(
-                'group/tool flex gap-1.5 pr-2 pl-px py-2 rounded-xl cursor-pointer',
+                'group/tool flex gap-1.5 pr-2 pl-px py-2 rounded-xl cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--interactive-focusRing)]',
                 isMultiFileApplyPatch ? 'flex-wrap items-start' : 'items-center'
             )}
                 onClick={handleMainClick}
                 onKeyDown={handleMainKeyDown}
                 role="button"
                 tabIndex={0}
+                aria-expanded={!isTaskTool ? isExpanded : undefined}
+                aria-controls={!isTaskTool ? expandedContentId : undefined}
+                aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${displayName} details`}
             >
                 <div className={cn('flex gap-1.5', isMultiFileApplyPatch ? 'w-full min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5' : 'items-center flex-shrink-0')}>
                     {}
-                    <div
-                        className="relative h-3.5 w-3.5 flex-shrink-0 cursor-pointer"
+                    <button
+                        type="button"
+                        className="relative h-3.5 w-3.5 flex-shrink-0 cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--interactive-focusRing)]"
                         onClick={(event) => { event.stopPropagation(); onToggle(part.id); }}
+                        aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${displayName} details`}
+                        aria-expanded={isExpanded}
+                        aria-controls={expandedContentId}
                     >
                         {}
                         <div
@@ -2790,7 +2901,7 @@ const ToolPart: React.FC<ToolPartProps> = ({
                         >
                             {isExpanded ? <Icon name="arrow-down-s" className="h-3.5 w-3.5" /> : <Icon name="arrow-right-s" className="h-3.5 w-3.5" />}
                         </div>
-                    </div>
+                    </button>
                     {isMultiFileApplyPatch ? (
                         <>
                             <MinDurationShineText
@@ -2890,6 +3001,7 @@ const ToolPart: React.FC<ToolPartProps> = ({
 
             {!isTaskTool ? (
                 <div
+                    id={expandedContentId}
                     ref={expandedContentRef}
                     aria-hidden={!isExpanded}
                     style={{

--- a/packages/ui/src/components/chat/message/parts/toolRenderUtils.test.ts
+++ b/packages/ui/src/components/chat/message/parts/toolRenderUtils.test.ts
@@ -17,8 +17,11 @@ describe('toolRenderUtils', () => {
 
     test('makes built-in summary tools expandable for input and output inspection', () => {
         expect(isExpandableTool('read')).toBe(true);
+        expect(isExpandableTool('functions.read:1')).toBe(true);
         expect(isExpandableTool('grep')).toBe(true);
+        expect(isExpandableTool('functions.grep:1')).toBe(true);
         expect(isExpandableTool('glob')).toBe(true);
+        expect(isExpandableTool('functions.glob:1')).toBe(true);
         expect(isExpandableTool('websearch')).toBe(true);
         expect(isExpandableTool('todowrite')).toBe(true);
     });

--- a/packages/ui/src/components/chat/message/parts/toolRenderUtils.test.ts
+++ b/packages/ui/src/components/chat/message/parts/toolRenderUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isExpandableTool, isStandaloneTool } from './toolRenderUtils';
+
+describe('toolRenderUtils', () => {
+    test('keeps built-in expandable tools expandable', () => {
+        expect(isExpandableTool('bash')).toBe(true);
+        expect(isExpandableTool('write')).toBe(true);
+        expect(isExpandableTool('question')).toBe(true);
+    });
+
+    test('keeps task standalone', () => {
+        expect(isStandaloneTool('task')).toBe(true);
+        expect(isStandaloneTool('functions.task:1')).toBe(true);
+        expect(isExpandableTool('task')).toBe(false);
+    });
+
+    test('makes built-in summary tools expandable for input and output inspection', () => {
+        expect(isExpandableTool('read')).toBe(true);
+        expect(isExpandableTool('grep')).toBe(true);
+        expect(isExpandableTool('glob')).toBe(true);
+        expect(isExpandableTool('websearch')).toBe(true);
+        expect(isExpandableTool('todowrite')).toBe(true);
+    });
+
+    test('treats unknown custom tool names as expandable', () => {
+        expect(isExpandableTool('custom-tool')).toBe(true);
+        expect(isExpandableTool('functions.custom_tool')).toBe(true);
+        expect(isExpandableTool('multi_tool_use.parallel:2')).toBe(true);
+        expect(isStandaloneTool('custom-tool')).toBe(false);
+    });
+
+    test('treats empty or missing tool names as non-expandable', () => {
+        expect(isExpandableTool('')).toBe(false);
+        expect(isExpandableTool('   ')).toBe(false);
+        expect(isExpandableTool(null)).toBe(false);
+        expect(isExpandableTool(undefined)).toBe(false);
+        expect(isStandaloneTool(undefined)).toBe(false);
+    });
+});

--- a/packages/ui/src/components/chat/message/parts/toolRenderUtils.ts
+++ b/packages/ui/src/components/chat/message/parts/toolRenderUtils.ts
@@ -1,13 +1,4 @@
-const EXPANDABLE_TOOL_NAMES = new Set<string>([
-    'edit', 'multiedit', 'apply_patch', 'str_replace', 'str_replace_based_edit_tool',
-    'bash', 'shell', 'cmd', 'terminal',
-    'write', 'create', 'file_write',
-    'question', 'task',
-]);
-
 const STANDALONE_TOOL_NAMES = new Set<string>(['task']);
-
-const SEARCH_TOOL_NAMES = new Set<string>(['grep', 'search', 'find', 'ripgrep', 'glob']);
 
 const normalizeToolName = (toolName: unknown): string => {
     if (typeof toolName !== 'string') return '';
@@ -23,22 +14,14 @@ const normalizeToolName = (toolName: unknown): string => {
 };
 
 export const isExpandableTool = (toolName: unknown): boolean => {
-    return EXPANDABLE_TOOL_NAMES.has(normalizeToolName(toolName));
+    const normalizedToolName = normalizeToolName(toolName);
+    if (!normalizedToolName) {
+        return false;
+    }
+
+    return !STANDALONE_TOOL_NAMES.has(normalizedToolName);
 };
 
 export const isStandaloneTool = (toolName: unknown): boolean => {
     return STANDALONE_TOOL_NAMES.has(normalizeToolName(toolName));
-};
-
-export const isStaticTool = (toolName: unknown): boolean => {
-    if (typeof toolName !== 'string') return false;
-    return !isExpandableTool(toolName) && !isStandaloneTool(toolName);
-};
-
-export const getStaticGroupToolName = (toolName: string): string => {
-    const normalized = normalizeToolName(toolName);
-    if (SEARCH_TOOL_NAMES.has(normalized)) {
-        return 'grep';
-    }
-    return normalized;
 };


### PR DESCRIPTION
## Summary
- make non-task chat tools expandable so users can inspect inputs and outputs for built-in and custom tool calls
- render structured generic input/output with the JSON tree viewer and markdown-capable outputs with the markdown renderer
- add coverage for built-in summary tools, custom tools, task handling, and empty tool names

## Validation
- bun test packages/ui/src/components/chat/message/parts/toolRenderUtils.test.ts
- bun run type-check
- bun run lint