### PR TITLE
feat: Show search match count in editor panel

### DIFF
--- a/packages/ui/src/components/ui/CodeMirrorEditor.tsx
+++ b/packages/ui/src/components/ui/CodeMirrorEditor.tsx
@@ -5,7 +5,7 @@ import { Compartment, EditorState, RangeSetBuilder, StateField } from '@codemirr
 import { Decoration, type DecorationSet, EditorView, type KeyBinding, ViewPlugin, WidgetType, gutters, keymap, lineNumbers } from '@codemirror/view';
 import { defaultKeymap, indentWithTab, history, historyKeymap } from '@codemirror/commands';
 import { forceParsing, indentUnit } from '@codemirror/language';
-import { search, searchKeymap, openSearchPanel, closeSearchPanel, searchPanelOpen } from '@codemirror/search';
+import { search, searchKeymap, openSearchPanel, closeSearchPanel, searchPanelOpen, getSearchQuery } from '@codemirror/search';
 import { createPortal } from 'react-dom';
 
 import { cn } from '@/lib/utils';
@@ -39,7 +39,62 @@ function patchSearchTooltips(root: HTMLElement) {
   }
 }
 
+function getSearchMatchStatus(view: EditorView): { current: number; total: number } {
+  const query = getSearchQuery(view.state);
+  if (!query.valid) {
+    return { current: 0, total: 0 };
+  }
 
+  const selection = view.state.selection.main;
+  const cursor = query.getCursor(view.state);
+  let total = 0;
+  let firstMatch = 0;
+  let exactMatch = 0;
+  let overlappingMatch = 0;
+  let nextMatch = 0;
+
+  for (let result = cursor.next(); !result.done; result = cursor.next()) {
+    const match = result.value;
+    total += 1;
+    if (firstMatch === 0) {
+      firstMatch = total;
+    }
+    if (exactMatch === 0 && selection.from === match.from && selection.to === match.to) {
+      exactMatch = total;
+    }
+    if (overlappingMatch === 0 && selection.from < match.to && selection.to > match.from) {
+      overlappingMatch = total;
+    }
+    if (nextMatch === 0 && match.from >= selection.head) {
+      nextMatch = total;
+    }
+  }
+
+  // Prefer the selected match, then fall back to the next match after the cursor.
+  return {
+    current: exactMatch || overlappingMatch || nextMatch || firstMatch,
+    total,
+  };
+}
+
+function syncSearchPanelStatus(root: HTMLElement, view: EditorView) {
+  const panel = root.querySelector('.cm-search');
+  if (!panel) return;
+
+  let status = panel.querySelector<HTMLElement>('.cm-search-message');
+  if (!status) {
+    status = document.createElement('span');
+    status.className = 'cm-search-message';
+    status.setAttribute('aria-live', 'polite');
+
+    const nextButton = panel.querySelector('button[name="next"]');
+    const referenceNode = nextButton?.parentNode === panel ? nextButton : panel.firstChild;
+    panel.insertBefore(status, referenceNode);
+  }
+
+  const { current, total } = getSearchMatchStatus(view);
+  status.textContent = `${current}/${total}`;
+}
 
 export type BlockWidgetDef = {
   afterLine: number;
@@ -299,6 +354,10 @@ export function CodeMirrorEditor({
           if (wasOpen !== isOpen) {
             onSearchOpenChangeRef.current?.(isOpen);
           }
+          const queryChanged = !getSearchQuery(update.startState).eq(getSearchQuery(update.state));
+          if (isOpen && (wasOpen !== isOpen || queryChanged || update.docChanged || update.selectionSet)) {
+            syncSearchPanelStatus(update.view.dom, update.view);
+          }
           if (!update.docChanged) {
             return;
           }
@@ -375,6 +434,7 @@ export function CodeMirrorEditor({
       // Patch tooltips after panel DOM is mounted
       requestAnimationFrame(() => {
         patchSearchTooltips(view.dom);
+        syncSearchPanelStatus(view.dom, view);
       });
     } else {
       closeSearchPanelCompat(view);

--- a/packages/ui/src/components/ui/CodeMirrorEditor.tsx
+++ b/packages/ui/src/components/ui/CodeMirrorEditor.tsx
@@ -39,45 +39,69 @@ function patchSearchTooltips(root: HTMLElement) {
   }
 }
 
-function getSearchMatchStatus(view: EditorView): { current: number; total: number } {
+type SearchQuery = ReturnType<typeof getSearchQuery>;
+type SearchMatchCountCache = {
+  query: SearchQuery;
+  doc: EditorState['doc'];
+  total: number;
+};
+
+const searchMatchCountCache = new WeakMap<EditorView, SearchMatchCountCache>();
+
+function getSearchMatchTotal(view: EditorView, refresh: boolean): number {
   const query = getSearchQuery(view.state);
   if (!query.valid) {
-    return { current: 0, total: 0 };
+    searchMatchCountCache.delete(view);
+    return 0;
+  }
+
+  const cached = searchMatchCountCache.get(view);
+  if (!refresh && cached?.doc === view.state.doc && cached.query.eq(query)) {
+    return cached.total;
+  }
+
+  const cursor = query.getCursor(view.state);
+  let total = 0;
+  for (let result = cursor.next(); !result.done; result = cursor.next()) {
+    total += 1;
+  }
+
+  searchMatchCountCache.set(view, { query, doc: view.state.doc, total });
+  return total;
+}
+
+function getSearchMatchCurrent(view: EditorView): number {
+  const query = getSearchQuery(view.state);
+  if (!query.valid) {
+    return 0;
   }
 
   const selection = view.state.selection.main;
   const cursor = query.getCursor(view.state);
-  let total = 0;
+  let index = 0;
   let firstMatch = 0;
-  let exactMatch = 0;
-  let overlappingMatch = 0;
-  let nextMatch = 0;
 
   for (let result = cursor.next(); !result.done; result = cursor.next()) {
     const match = result.value;
-    total += 1;
+    index += 1;
     if (firstMatch === 0) {
-      firstMatch = total;
+      firstMatch = index;
     }
-    if (exactMatch === 0 && selection.from === match.from && selection.to === match.to) {
-      exactMatch = total;
+    if (selection.from === match.from && selection.to === match.to) {
+      return index;
     }
-    if (overlappingMatch === 0 && selection.from < match.to && selection.to > match.from) {
-      overlappingMatch = total;
+    if (selection.from < match.to && selection.to > match.from) {
+      return index;
     }
-    if (nextMatch === 0 && match.from >= selection.head) {
-      nextMatch = total;
+    if (match.from >= selection.head) {
+      return index;
     }
   }
 
-  // Prefer the selected match, then fall back to the next match after the cursor.
-  return {
-    current: exactMatch || overlappingMatch || nextMatch || firstMatch,
-    total,
-  };
+  return firstMatch;
 }
 
-function syncSearchPanelStatus(root: HTMLElement, view: EditorView) {
+function syncSearchPanelStatus(root: HTMLElement, view: EditorView, refreshTotal = false) {
   const panel = root.querySelector('.cm-search');
   if (!panel) return;
 
@@ -92,8 +116,9 @@ function syncSearchPanelStatus(root: HTMLElement, view: EditorView) {
     panel.insertBefore(status, referenceNode);
   }
 
-  const { current, total } = getSearchMatchStatus(view);
-  status.textContent = `${current}/${total}`;
+  const total = getSearchMatchTotal(view, refreshTotal);
+  const current = total === 0 ? 0 : getSearchMatchCurrent(view);
+  status.textContent = total === 0 ? '' : `${current}/${total}`;
 }
 
 export type BlockWidgetDef = {
@@ -356,7 +381,7 @@ export function CodeMirrorEditor({
           }
           const queryChanged = !getSearchQuery(update.startState).eq(getSearchQuery(update.state));
           if (isOpen && (wasOpen !== isOpen || queryChanged || update.docChanged || update.selectionSet)) {
-            syncSearchPanelStatus(update.view.dom, update.view);
+            syncSearchPanelStatus(update.view.dom, update.view, wasOpen !== isOpen || queryChanged || update.docChanged);
           }
           if (!update.docChanged) {
             return;
@@ -434,7 +459,7 @@ export function CodeMirrorEditor({
       // Patch tooltips after panel DOM is mounted
       requestAnimationFrame(() => {
         patchSearchTooltips(view.dom);
-        syncSearchPanelStatus(view.dom, view);
+        syncSearchPanelStatus(view.dom, view, true);
       });
     } else {
       closeSearchPanelCompat(view);


### PR DESCRIPTION
## Summary
- Show the current search result position and total match count in the CodeMirror search panel.
- Keep the count synced when the query, selection, or document changes.
- Reuse the existing `.cm-search-message` styling already defined for the search panel.

## Testing
- `bun run type-check`
- `bun run lint`

<img width="1176" height="1464" alt="20260522145351_rec_" src="https://github.com/user-attachments/assets/8c582aa0-83ea-445d-9130-217780dd3da7" />
