### PR TITLE
docs(changelog): fix Enchanced and persistant typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -910,7 +910,7 @@ All notable changes to this project will be documented in this file.
 ## [1.1.4] - 2025-12-15
 
 - Flexoki themes for Shiki syntax highlighting for consistency with the app color schema.
-- Enchanced VSCode extension theming with editor themes.
+- Enhanced VSCode extension theming with editor themes.
 - Fixed mobile view model/agent selection.
 
 ## [1.1.3] - 2025-12-14

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -384,7 +384,7 @@
 ## [1.5.9] - 2026-01-28
 
 - Agent Manager: migrated to the OpenCode SDK worktree implementation; sessions in worktrees are now completely isolated.
-- Agent Manager: worktree setup commands are now persistant per project and automatically saved/restored.
+- Agent Manager: worktree setup commands are now persistent per project and automatically saved/restored.
 
 
 ## [1.5.8] - 2026-01-26


### PR DESCRIPTION
## Summary

Closes #1337. Two changelog spelling fixes:

- `CHANGELOG.md:913` - "Enchanced VSCode extension theming with editor themes." -> "Enhanced".
- `packages/vscode/CHANGELOG.md:387` - "worktree setup commands are now persistant per project" -> "persistent".

## Why this matters

Both entries live inside already-shipped release sections (`[1.1.4]` and `[1.5.9]` respectively). The changes are purely cosmetic for anyone reading the changelog or following along with release notes. No runtime behavior, API surface, or migration step is touched.

## How to test

```
$ grep -rn "Enchanced\|persistant" CHANGELOG.md packages/vscode/CHANGELOG.md
(empty)
$ grep -n "^- Enhanced VSCode" CHANGELOG.md
913:- Enhanced VSCode extension theming with editor themes.
$ grep -n "now persistent per project" packages/vscode/CHANGELOG.md
387:- Agent Manager: worktree setup commands are now persistent per project and automatically saved/restored.
```

Fixes #1337

AI-assisted.
