### PR TITLE
fix: handle git identity row keyboard activation

### DIFF
--- a/packages/ui/src/components/sections/git-identities/GitPage.tsx
+++ b/packages/ui/src/components/sections/git-identities/GitPage.tsx
@@ -250,6 +250,14 @@ const IdentityRow: React.FC<IdentityRowProps> = ({
   const iconColor = COLOR_MAP[profile.color || ''];
   const authType = profile.authType || 'ssh';
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.currentTarget !== e.target) return;
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+
+    e.preventDefault();
+    onEdit();
+  };
+
   return (
     <div
       className={cn(
@@ -259,7 +267,7 @@ const IdentityRow: React.FC<IdentityRowProps> = ({
       onClick={onEdit}
       role="button"
       tabIndex={0}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onEdit(); }}
+      onKeyDown={handleKeyDown}
     >
       <div className="flex items-center gap-3 min-w-0">
         <Icon name={iconName} className="w-4 h-4 shrink-0" style={{ color: iconColor }} />


### PR DESCRIPTION
Summary:
- Prevent Git identity row Space/Enter handling from responding to nested controls.
- Prevent Space from scrolling the page when activating the focused row.

Validation:
- `vet "Fix Git identity row keyboard activation so Space behaves like a button without triggering page scroll or nested controls" --agentic --agent-harness claude`
- `bun run type-check`
- `bun run lint`
- `git diff --check`