### PR TITLE
Update CHANGELOG with contributor name corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Desktop: Electron is now the desktop release target, with updated macOS menu actions for the right sidebar and terminal dock.
 - Chat: added reusable snippets with `#` autocomplete in the composer and a Snippets settings page for global and project snippets with [opencode-snippets](https://github.com/JosXa/opencode-snippets) plugin compatibility.
-- Multi-Run: runs can now be split into separate prompt/model groups, and Multi-Run prompts support command, file, agent, and snippet autocomplete (thanks to @roctom).
+- Multi-Run: runs can now be split into separate prompt/model groups, and Multi-Run prompts support command, file, agent, and snippet autocomplete (thanks to @tomzx).
 - UI: refreshed the desktop workspace shell with a full-width header, framed chat area, and smooth left/right sidebar open and close states.
 - Chat: completed reasoning blocks stay collapsed without replaying the collapse animation when you reopen a session.
 - Files: file search and mention results avoid mixing entries from similar query/cache keys (thanks to @isanchez404).
@@ -188,7 +188,7 @@ All notable changes to this project will be documented in this file.
 - Chat/Requests: restored blocking request visibility in sub-sessions, scoped auto-approve to the active session tree, and reduced noisy auto-approved notifications during multi-session work.
 - Desktop: added quick open and a LAN access toggle, plus safer quit behavior around scheduled tasks (thanks to @An-jinu).
 - Chat/Markdown: added LaTeX rendering support for clearer math and technical notation in messages (thanks to @ricautomation).
-- Settings/Skills: skills are now sorted within groups (thanks to @roctom).
+- Settings/Skills: skills are now sorted within groups (thanks to @tomzx).
 
 ## [1.9.5] - 2026-04-14
 


### PR DESCRIPTION
Small correction to use my GitHub handle instead of my email username in the changelog.