### PR TITLE
fix(chat): restore scroll on revisit and keep auto-follow glued on updates

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -775,6 +775,68 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
         // triggering a spurious re-restore that overwrites user scroll.
         let rafId: number | null = null;
         let cancelled = false;
+        let settleObserver: ResizeObserver | null = null;
+        let settleTimer: number | null = null;
+
+        const teardownSettle = () => {
+            if (settleObserver) {
+                settleObserver.disconnect();
+                settleObserver = null;
+            }
+            if (settleTimer !== null && typeof window !== 'undefined') {
+                window.clearTimeout(settleTimer);
+                settleTimer = null;
+            }
+        };
+
+        const setupSettleObserver = (container: HTMLElement) => {
+            // The relaxed restore gate (`sessionMessages.length > 0`) lets
+            // the initial restore fire before tool parts (mermaid SVG, lazy
+            // markdown chunks, syntax highlighter, image dimensions) have
+            // finished materializing. The first `restoreSnapshot()` is
+            // therefore calibrated against an intermediate layout, so the
+            // user lands at a scrollTop whose visible region will drift
+            // away from the saved position as parts settle. Watch
+            // scrollHeight for a brief window and re-apply the saved
+            // snapshot whenever it changes — but only while the user has
+            // not scrolled away from where we placed them.
+            if (cancelled) return;
+            if (typeof ResizeObserver === 'undefined' || typeof window === 'undefined') return;
+
+            const SETTLE_TOLERANCE_PX = 4;
+            const SETTLE_MAX_MS = 1500;
+            let lastAppliedTop = container.scrollTop;
+
+            settleObserver = new ResizeObserver(() => {
+                if (cancelled || !settleObserver) return;
+                const currentTop = container.scrollTop;
+                if (Math.abs(currentTop - lastAppliedTop) > SETTLE_TOLERANCE_PX) {
+                    // User scrolled away from our placement — they have
+                    // intent, stop tracking. Also catches the at-bottom
+                    // path's follow-loop / settle-burst writes, which
+                    // disconnect this observer on the first growth event
+                    // and let the existing chase mechanism handle the
+                    // tail.
+                    teardownSettle();
+                    return;
+                }
+                // Layout shifted while user is still where we put them.
+                // Re-apply the saved snapshot against the new scrollHeight
+                // so the visible region matches the original save.
+                void restoreSnapshot().then((ready) => {
+                    if (cancelled || !ready) return;
+                    lastAppliedTop = container.scrollTop;
+                });
+            });
+            settleObserver.observe(container);
+            const inner = container.firstElementChild;
+            if (inner instanceof Element) {
+                settleObserver.observe(inner);
+            }
+            settleTimer = window.setTimeout(() => {
+                teardownSettle();
+            }, SETTLE_MAX_MS);
+        };
 
         const run = () => {
             rafId = null;
@@ -784,9 +846,9 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
             // effect retries when the container re-mounts.
             void restoreSnapshot().then((containerWasReady) => {
                 if (cancelled) return;
-                if (containerWasReady) {
-                    lastScrolledSessionRef.current = sessionAtScheduleTime;
-                }
+                if (!containerWasReady) return;
+                lastScrolledSessionRef.current = sessionAtScheduleTime;
+                setupSettleObserver(scrollContainerEl);
             });
         };
         if (typeof window === 'undefined') {
@@ -800,6 +862,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
             if (rafId !== null && typeof window !== 'undefined') {
                 window.cancelAnimationFrame(rafId);
             }
+            teardownSettle();
         };
     }, [currentSessionId, releaseAutoFollow, restoreSnapshot, sessionMessages.length, scrollContainerEl]);
 

--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -575,6 +575,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
         goToBottom,
         releaseAutoFollow,
         restoreSnapshot,
+        scrollContainerEl,
         isPinned,
         isFollowingProgrammatically,
         showScrollButton,
@@ -748,26 +749,40 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
         // Gate on rendered messages: hasRenderableSessionSnapshot can stay
         // false for the rest of the visit if any assistant message has
         // unmaterialized parts. By the time sessionMessages renders, the
-        // scroll container has mounted.
+        // scroll container has mounted (in the normal case).
         if (sessionMessages.length === 0) return;
+        // Defensive: messages can be rendered while the scroll container is
+        // briefly detached (Suspense fallback re-mount, etc.). Skip until
+        // the container is attached; the `scrollContainerEl` dep below
+        // re-runs this effect when it re-mounts.
+        if (!scrollContainerEl) return;
 
+        const sessionAtScheduleTime = currentSessionId;
         const hasHashTarget = typeof window !== 'undefined' && window.location.hash.length > 0;
-        lastScrolledSessionRef.current = currentSessionId;
         if (hasHashTarget) {
             // Hash navigation handler will scroll to target; we just release auto-follow.
+            lastScrolledSessionRef.current = sessionAtScheduleTime;
             releaseAutoFollow();
             return;
         }
 
         const run = () => {
-            void restoreSnapshot();
+            // Only mark this session as restored once the restore actually
+            // applied scroll (container was attached). On failure
+            // (container un-mount race), leave the guard untouched so the
+            // effect retries when the container re-mounts.
+            void restoreSnapshot().then((containerWasReady) => {
+                if (containerWasReady) {
+                    lastScrolledSessionRef.current = sessionAtScheduleTime;
+                }
+            });
         };
         if (typeof window === 'undefined') {
             run();
         } else {
             window.requestAnimationFrame(run);
         }
-    }, [currentSessionId, releaseAutoFollow, restoreSnapshot, sessionMessages.length]);
+    }, [currentSessionId, releaseAutoFollow, restoreSnapshot, sessionMessages.length, scrollContainerEl]);
 
     React.useEffect(() => {
         if (!currentSessionId) return;

--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -725,14 +725,31 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
     }, [currentSessionId, isDesktopExpandedInput, scrollRef]);
 
     const lastScrolledSessionRef = React.useRef<string | null>(null);
+    const previousSessionIdRef = React.useRef<string | null>(null);
 
     const isSessionHydrating =
         Boolean(currentSessionId)
         && !hasRenderableSessionSnapshot;
 
     React.useEffect(() => {
+        // Invalidate the "already restored this session" guard whenever the
+        // active session changes. Without this, restoring session X, navigating
+        // away, then returning to X is treated as alreadyRestored and skipped —
+        // even though a fresh restore is exactly what's wanted.
+        if (previousSessionIdRef.current !== currentSessionId) {
+            lastScrolledSessionRef.current = null;
+            previousSessionIdRef.current = currentSessionId;
+        }
+    }, [currentSessionId]);
+
+    React.useEffect(() => {
         if (!currentSessionId) return;
         if (lastScrolledSessionRef.current === currentSessionId) return;
+        // Gate on rendered messages: hasRenderableSessionSnapshot can stay
+        // false for the rest of the visit if any assistant message has
+        // unmaterialized parts. By the time sessionMessages renders, the
+        // scroll container has mounted.
+        if (sessionMessages.length === 0) return;
 
         const hasHashTarget = typeof window !== 'undefined' && window.location.hash.length > 0;
         lastScrolledSessionRef.current = currentSessionId;
@@ -750,7 +767,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
         } else {
             window.requestAnimationFrame(run);
         }
-    }, [currentSessionId, releaseAutoFollow, restoreSnapshot]);
+    }, [currentSessionId, releaseAutoFollow, restoreSnapshot, sessionMessages.length]);
 
     React.useEffect(() => {
         if (!currentSessionId) return;

--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -766,12 +766,24 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
             return;
         }
 
+        // Track the rAF + a cancellation flag so an effect re-run (session
+        // switch, new message arrival, container re-mount) tears down the
+        // pending restore from the previous run. Without this, a stale rAF
+        // — or its microtask `.then()` — could fire after a fresh effect
+        // run and write `sessionAtScheduleTime` (an old session id) into
+        // the guard ref, leaving it pointing at the wrong session and
+        // triggering a spurious re-restore that overwrites user scroll.
+        let rafId: number | null = null;
+        let cancelled = false;
+
         const run = () => {
+            rafId = null;
             // Only mark this session as restored once the restore actually
             // applied scroll (container was attached). On failure
             // (container un-mount race), leave the guard untouched so the
             // effect retries when the container re-mounts.
             void restoreSnapshot().then((containerWasReady) => {
+                if (cancelled) return;
                 if (containerWasReady) {
                     lastScrolledSessionRef.current = sessionAtScheduleTime;
                 }
@@ -780,8 +792,15 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
         if (typeof window === 'undefined') {
             run();
         } else {
-            window.requestAnimationFrame(run);
+            rafId = window.requestAnimationFrame(run);
         }
+
+        return () => {
+            cancelled = true;
+            if (rafId !== null && typeof window !== 'undefined') {
+                window.cancelAnimationFrame(rafId);
+            }
+        };
     }, [currentSessionId, releaseAutoFollow, restoreSnapshot, sessionMessages.length, scrollContainerEl]);
 
     React.useEffect(() => {

--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -810,19 +810,24 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
             settleObserver = new ResizeObserver(() => {
                 if (cancelled || !settleObserver) return;
                 const currentTop = container.scrollTop;
+                // Tolerance catches a real user scroll-up (their scrollTop
+                // diverges from where we placed them by more than a few px)
+                // and tears the observer down so user intent wins. Sub-px
+                // drift from browser clamps stays under the tolerance, so
+                // routine reflows trigger a re-apply.
                 if (Math.abs(currentTop - lastAppliedTop) > SETTLE_TOLERANCE_PX) {
-                    // User scrolled away from our placement — they have
-                    // intent, stop tracking. Also catches the at-bottom
-                    // path's follow-loop / settle-burst writes, which
-                    // disconnect this observer on the first growth event
-                    // and let the existing chase mechanism handle the
-                    // tail.
                     teardownSettle();
                     return;
                 }
                 // Layout shifted while user is still where we put them.
                 // Re-apply the saved snapshot against the new scrollHeight
-                // so the visible region matches the original save.
+                // so the visible region matches the original save. In the
+                // at-bottom restore case the re-apply snaps to the new
+                // bottom, which is consistent with the existing settle-
+                // burst behavior (just extended past its 280ms window);
+                // the follow loop and settle burst continue running but
+                // their writes target the same scrollTop, so the chase
+                // stays coherent.
                 void restoreSnapshot().then((ready) => {
                     if (cancelled || !ready) return;
                     lastAppliedTop = container.scrollTop;

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -619,7 +619,7 @@ export const useChatAutoFollow = ({
         if (cached) return cached;
 
         const kick = () => {
-            if (stateRef.current === 'following' && sessionWorkingRef.current) {
+            if (stateRef.current === 'following') {
                 startFollowLoop();
             }
         };

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -584,10 +584,19 @@ export const useChatAutoFollow = ({
 
         const observer = new ResizeObserver(() => {
             updateOverflowAndButton();
-            // Keep the height baseline fresh so the layout-shrink heuristic
-            // in handleScrollEvent has a previous value to compare against
-            // when a scroll event fires right after a content reflow.
-            lastScrollHeightRef.current = container.scrollHeight;
+            // Baseline the height for handleScrollEvent's layout-shrink
+            // heuristic, but ONLY on growth. Browsers fire ResizeObserver
+            // synchronously after layout, before the scroll event from a
+            // clamp reaches the event loop — so writing the post-shrink
+            // height here would overwrite the pre-shrink baseline and
+            // turn the heuristic back into the bug it was meant to fix
+            // (handleScrollEvent would see previousHeight === currentHeight,
+            // miss the shrink, and false-release on the clamp). On a
+            // shrink, leave the baseline alone; the scroll event will
+            // update it once it has consumed the layoutShrunk signal.
+            if (container.scrollHeight > lastScrollHeightRef.current) {
+                lastScrollHeightRef.current = container.scrollHeight;
+            }
             if (stateRef.current === 'following') {
                 startFollowLoop();
             }

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -138,10 +138,6 @@ export const useChatAutoFollow = ({
     const pendingSaveRef = React.useRef<{ sessionId: string; anchor: number } | null>(null);
     const settleBurstRafRef = React.useRef<number | null>(null);
     const lastUserReleaseAtRef = React.useRef(0);
-    // When restoreSnapshot is invoked while ChatViewport is still hydrating
-    // (skeleton rendered, no scroll container yet), we record the session here
-    // so a follow-up effect can replay the restore once the container mounts.
-    const pendingInitialRestoreRef = React.useRef<string | null>(null);
 
     const updateViewportAnchor = useViewportStore((s) => s.updateViewportAnchor);
 
@@ -356,13 +352,11 @@ export const useChatAutoFollow = ({
 
         const container = scrollRef.current;
         if (!container) {
-            // ChatViewport not mounted yet (e.g., session still hydrating).
-            // Record the request so the container-attach effect can replay it.
-            pendingInitialRestoreRef.current = sessionId;
-            setStateValue('following');
+            // Caller is expected to gate restore on rendered messages, so the
+            // container should be attached by then. If we somehow get here
+            // (e.g. container unmount race), no-op rather than queueing.
             return false;
         }
-        pendingInitialRestoreRef.current = null;
 
         const saved = useViewportStore.getState().sessionMemoryState.get(sessionId)?.scrollPosition;
 
@@ -406,10 +400,6 @@ export const useChatAutoFollow = ({
         stopFollowLoop();
         stopSettleBurst();
         markProgrammaticWrite();
-        // Drop any pending restore request inherited from a different session.
-        if (pendingInitialRestoreRef.current && pendingInitialRestoreRef.current !== currentSessionId) {
-            pendingInitialRestoreRef.current = null;
-        }
     }, [currentSessionId, flushSave, markProgrammaticWrite, stopFollowLoop, stopSettleBurst]);
 
     React.useEffect(() => {
@@ -419,14 +409,6 @@ export const useChatAutoFollow = ({
             startFollowLoop();
         }
     }, [sessionIsWorking, startFollowLoop, stopFollowLoop]);
-
-    // Replay a deferred restoreSnapshot once ChatViewport mounts.
-    React.useEffect(() => {
-        if (!containerEl) return;
-        if (pendingInitialRestoreRef.current && pendingInitialRestoreRef.current === currentSessionId) {
-            void restoreSnapshot();
-        }
-    }, [containerEl, currentSessionId, restoreSnapshot]);
 
     const updateOverflowAndButton = React.useCallback(() => {
         const container = scrollRef.current;

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -39,6 +39,7 @@ export interface UseChatAutoFollowResult {
     releaseAutoFollow: () => void;
     saveSnapshotNow: () => void;
     restoreSnapshot: () => Promise<boolean>;
+    scrollContainerEl: HTMLDivElement | null;
 }
 
 const BOTTOM_SPACER_DESKTOP_VH = 0.10;
@@ -352,9 +353,9 @@ export const useChatAutoFollow = ({
 
         const container = scrollRef.current;
         if (!container) {
-            // Caller is expected to gate restore on rendered messages, so the
-            // container should be attached by then. If we somehow get here
-            // (e.g. container unmount race), no-op rather than queueing.
+            // Container un-mounted during the rAF window (Suspense re-mount,
+            // navigation race, etc.). Return false so the caller can leave
+            // its "already restored" guard untouched and retry on re-mount.
             return false;
         }
 
@@ -369,7 +370,11 @@ export const useChatAutoFollow = ({
                 startFollowLoop();
             }
             startSettleBurst();
-            return false;
+            // Container was ready, scroll-to-bottom path taken. The session
+            // has been positioned; report success so the caller can mark it
+            // restored. Return semantics: `true` = container was attached and
+            // some scroll was applied; `false` = container missing, retry.
+            return true;
         }
 
         const savedMaxScroll = Math.max(0, saved.scrollHeight - saved.clientHeight);
@@ -692,5 +697,10 @@ export const useChatAutoFollow = ({
         releaseAutoFollow,
         saveSnapshotNow,
         restoreSnapshot,
+        // Exposed so ChatContainer can re-trigger the restore effect when
+        // the scroll container un-mounts and re-mounts (Suspense, etc.) —
+        // restoreSnapshot bails out on missing container and never updates
+        // its guard, so the effect needs a dep that actually changes.
+        scrollContainerEl: containerEl,
     };
 };

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -135,6 +135,7 @@ export const useChatAutoFollow = ({
     const followRafRef = React.useRef<number | null>(null);
     const settledFramesRef = React.useRef(0);
     const lastScrollTopRef = React.useRef(0);
+    const lastScrollHeightRef = React.useRef(0);
     const saveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const pendingSaveRef = React.useRef<{ sessionId: string; anchor: number } | null>(null);
     const settleBurstRafRef = React.useRef<number | null>(null);
@@ -186,7 +187,15 @@ export const useChatAutoFollow = ({
             stopFollowLoop();
             return;
         }
-        if (stateRef.current !== 'following' || !sessionWorkingRef.current) {
+        // Gate on pinned state only. `sessionWorking` used to gate here too,
+        // but that hard-stopped chasing the bottom the instant a message
+        // completed — and late reflows (async markdown chunk load, code
+        // highlighter hydration, image height adjustment, reasoning
+        // auto-collapse on stream end) keep changing scrollHeight for
+        // hundreds of ms after `time.completed` arrives. The loop now self-
+        // terminates only when content has actually settled (SETTLE_EPSILON
+        // for SETTLE_FRAMES), regardless of stream phase.
+        if (stateRef.current !== 'following') {
             stopFollowLoop();
             return;
         }
@@ -221,7 +230,7 @@ export const useChatAutoFollow = ({
     const startFollowLoop = React.useCallback(() => {
         if (typeof window === 'undefined') return;
         if (followRafRef.current !== null) return;
-        if (stateRef.current !== 'following' || !sessionWorkingRef.current) return;
+        if (stateRef.current !== 'following') return;
         settledFramesRef.current = 0;
         setIsFollowingProgrammatically(true);
         followRafRef.current = window.requestAnimationFrame(tickFollow);
@@ -408,12 +417,24 @@ export const useChatAutoFollow = ({
     }, [currentSessionId, flushSave, markProgrammaticWrite, stopFollowLoop, stopSettleBurst]);
 
     React.useEffect(() => {
-        if (!sessionIsWorking) {
-            stopFollowLoop();
-        } else if (stateRef.current === 'following') {
-            startFollowLoop();
+        if (sessionIsWorking) {
+            if (stateRef.current === 'following') {
+                startFollowLoop();
+            }
+            return;
         }
-    }, [sessionIsWorking, startFollowLoop, stopFollowLoop]);
+        // sessionIsWorking just flipped to false. Don't hard-stop the
+        // follow loop — late reflows after `time.completed` (async markdown
+        // chunk load, code highlighter hydration, image height adjustment,
+        // reasoning auto-collapse) keep changing scrollHeight, and a pinned
+        // user expects to stay glued through that tail. tickFollow self-
+        // terminates once content settles; the settle burst snaps to the
+        // new bottom each frame for SETTLE_BURST_DURATION_MS to nail the
+        // immediate post-completion reflow window.
+        if (stateRef.current === 'following') {
+            startSettleBurst();
+        }
+    }, [sessionIsWorking, startFollowLoop, startSettleBurst]);
 
     const updateOverflowAndButton = React.useCallback(() => {
         const container = scrollRef.current;
@@ -438,8 +459,11 @@ export const useChatAutoFollow = ({
 
         const programmatic = isInProgrammaticWindow();
         const currentTop = container.scrollTop;
+        const currentHeight = container.scrollHeight;
         const previousTop = lastScrollTopRef.current;
+        const previousHeight = lastScrollHeightRef.current;
         lastScrollTopRef.current = currentTop;
+        lastScrollHeightRef.current = currentHeight;
 
         updateOverflowAndButton();
 
@@ -447,7 +471,18 @@ export const useChatAutoFollow = ({
             return;
         }
 
-        if (currentTop < previousTop && stateRef.current === 'following') {
+        // Distinguish a real user scroll-up from a browser auto-clamp
+        // triggered by shrinking scrollHeight (reasoning block auto-collapse
+        // on stream end, tool placeholder replaced by a shorter output,
+        // image height adjustment after load). On a clamp, the browser
+        // moves scrollTop *down* to fit the new max scroll — which the
+        // raw `currentTop < previousTop` test below would mis-read as a
+        // user release. A real scroll-up arrives with scrollHeight
+        // unchanged; suppress the release path when scrollHeight has
+        // strictly decreased since the last observation.
+        const layoutShrunk = previousHeight > 0 && currentHeight < previousHeight;
+
+        if (!layoutShrunk && currentTop < previousTop && stateRef.current === 'following') {
             stopFollowLoop();
             stopSettleBurst();
             lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -458,9 +493,7 @@ export const useChatAutoFollow = ({
         const inGrace = (now - lastUserReleaseAtRef.current) < REPIN_GRACE_AFTER_RELEASE_MS;
         if (stateRef.current === 'released' && isNearBottom(container, isMobile) && !inGrace) {
             setStateValue('following');
-            if (sessionWorkingRef.current) {
-                startFollowLoop();
-            }
+            startFollowLoop();
         }
 
         queueSave();
@@ -551,7 +584,11 @@ export const useChatAutoFollow = ({
 
         const observer = new ResizeObserver(() => {
             updateOverflowAndButton();
-            if (stateRef.current === 'following' && sessionWorkingRef.current) {
+            // Keep the height baseline fresh so the layout-shrink heuristic
+            // in handleScrollEvent has a previous value to compare against
+            // when a scroll event fires right after a content reflow.
+            lastScrollHeightRef.current = container.scrollHeight;
+            if (stateRef.current === 'following') {
                 startFollowLoop();
             }
         });
@@ -570,7 +607,7 @@ export const useChatAutoFollow = ({
     const notifyContentChange = React.useCallback((_reason?: ContentChangeReason) => {
         void _reason;
         updateOverflowAndButton();
-        if (stateRef.current === 'following' && sessionWorkingRef.current) {
+        if (stateRef.current === 'following') {
             startFollowLoop();
         }
     }, [startFollowLoop, updateOverflowAndButton]);


### PR DESCRIPTION
## Summary

Correctness fixes for two unrelated-symptom-but-shared-area chat scroll bugs: scroll-restore on session revisit, and auto-follow staying glued to the bottom while a message updates. No new UI, no new state in stores, no behavior change for first-visit sessions or for a freshly released auto-follow.

### 1. Guard ref invalidates on session change

`ChatContainer` keeps `lastScrolledSessionRef` so the restore effect skips already-restored sessions. The ref was never invalidated, so once a session had been restored in a tab session, returning to it was treated as `alreadyRestored = true` and the restore was skipped. The user lost their scroll position on revisits.

Reset the ref when `currentSessionId` changes, so every visit triggers a fresh restore.

### 2. Gate on rendered messages, not on snapshot flag

The restore effect was gated on `hasRenderableSessionSnapshot`. That flag can stay `false` for the rest of the visit if any assistant message has unmaterialized parts — so the restore would never fire on those sessions.

Switch the gate to `sessionMessages.length > 0`. By the time messages have rendered, the chat scroll container is attached in the normal flow, so the previously-needed `pendingInitialRestoreRef` queue (which deferred restore until the container mounted) is unreachable and is removed.

### 3. Retry on container un-mount race

With the queue gone, the no-container path needs to be safe under Suspense re-mount / concurrent-transition races: messages can render while the container is briefly detached, and the rAF callback might see `scrollRef.current === null`.

`restoreSnapshot`'s return value now distinguishes "container missing, retry" (`false`) from "container ready, scroll applied" (`true`, covering both the scroll-to-bottom path and the snapshot-restore path). The hook also exposes `scrollContainerEl`, which the effect depends on; the guard ref is only set after a successful restore. If the container re-mounts later, the effect re-runs and the restore applies cleanly.

### 4. Decouple the follow loop from `sessionIsWorking`

Every kick path in `useChatAutoFollow` (`tickFollow`, `startFollowLoop`, the `ResizeObserver` reaction, `notifyContentChange`, and the re-pin branch in `handleScrollEvent`) used to gate on `sessionWorkingRef.current === true` *in addition to* `state === 'following'`. The moment `time.completed` landed on the trailing assistant message, every kick path turned into a no-op — even though late reflows kept arriving for hundreds of ms (async markdown chunk load, code highlighter hydration, image height adjustment, reasoning block auto-collapse on stream end). A pinned user watched the chat freeze a few dozen px above the bottom.

Gate only on `state === 'following'` now. `tickFollow` self-terminates when content actually settles (`SETTLE_EPSILON` for `SETTLE_FRAMES`), so removing the streaming gate doesn't busy-loop.

### 5. Settle burst on stream completion instead of a hard stop

The `sessionIsWorking`-tracking effect used to call `stopFollowLoop()` the moment streaming ended — tearing down the loop right before the post-completion reflow burst hit. Switch to `startSettleBurst()`, which snaps scrollTop to the bottom each frame for `SETTLE_BURST_DURATION_MS` (the exact window where the reflows happen). `tickFollow` continues in parallel and cleans up when content stabilizes.

### 6. Suppress layout-clamp false-releases

`handleScrollEvent` released auto-follow on any `currentTop < previousTop` while pinned. But when `scrollHeight` shrinks (reasoning block collapses on stream end, tool placeholder is replaced by a shorter output, image height drops after load), the browser auto-clamps `scrollTop` down — a scroll event fires with `currentTop < previousTop`, but the user did not scroll. The most user-visible flake: *"I'm pinned, the chat shrinks, suddenly I'm released and stuck above the bottom for 1.2 s"* (the `REPIN_GRACE_AFTER_RELEASE_MS` grace window).

Track `scrollHeight` per scroll event (and from the `ResizeObserver`, so there's a baseline before the first scroll). When `scrollHeight` has strictly decreased since the last observation, treat the scroll-up as a clamp and skip the release branch.

## Files

- `packages/ui/src/components/chat/ChatContainer.tsx` — `+34 / −4` (invalidate guard on session change, gate on `sessionMessages.length`, defensive `scrollContainerEl` check, only mark restored on success)
- `packages/ui/src/hooks/useChatAutoFollow.ts` — `+61 / −37` (remove `pendingInitialRestoreRef` queue, refine `restoreSnapshot` return semantics, expose `scrollContainerEl`, decouple kicks from `sessionWorking`, settle-burst on completion, layout-shrink release suppression)
