### PR TITLE
Fix iOS PWA keyboard viewport alignment

### DIFF
--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -20,7 +20,7 @@ import { useUIStore } from '@/stores/useUIStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useUpdateStore } from '@/stores/useUpdateStore';
 import { useDeviceInfo } from '@/lib/device';
-import { useVisualViewport } from '@/hooks/useVisualViewport';
+import { useVisualViewport, deriveMobileRootStyle } from '@/hooks/useVisualViewport';
 import { cn } from '@/lib/utils';
 import { lazyWithChunkRecovery } from '@/lib/chunkLoadRecovery';
 
@@ -434,7 +434,11 @@ export const MainLayout: React.FC = () => {
                     isMobile ? 'flex flex-col' : 'flex h-[100dvh]',
                     'bg-background'
                 )}
-                style={isMobile && visualViewport.height > 0 ? { height: visualViewport.height } : undefined}
+                style={deriveMobileRootStyle({
+                    isMobile: !!isMobile,
+                    viewport: visualViewport,
+                    scrollY: typeof window !== 'undefined' ? window.scrollY : 0,
+                })}
             >
                 <CommandPalette />
                 <HelpDialog />

--- a/packages/ui/src/hooks/useVisualViewport.test.ts
+++ b/packages/ui/src/hooks/useVisualViewport.test.ts
@@ -1,13 +1,28 @@
 import { describe, expect, test } from 'bun:test';
 
-import { getVisualViewportState } from './useVisualViewport';
+import { getVisualViewportState, visualViewportStateEqual, deriveMobileRootStyle, type VisualViewportState } from './useVisualViewport';
 
-const withWindow = (value: { innerHeight: number; visualViewport?: { height: number } | null }, run: () => void) => {
+interface MockVisualViewport {
+  height: number;
+  offsetTop?: number;
+  pageTop?: number;
+}
+
+const withWindow = (
+  value:
+    | { innerHeight: number; visualViewport?: MockVisualViewport | null }
+    | undefined,
+  run: () => void,
+) => {
   const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
-  Object.defineProperty(globalThis, 'window', {
-    configurable: true,
-    value,
-  });
+  if (value === undefined) {
+    Reflect.deleteProperty(globalThis, 'window');
+  } else {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value,
+    });
+  }
 
   try {
     run();
@@ -21,15 +36,259 @@ const withWindow = (value: { innerHeight: number; visualViewport?: { height: num
 };
 
 describe('getVisualViewportState', () => {
+  test('returns zeroed geometry when window is undefined', () => {
+    withWindow(undefined, () => {
+      expect(getVisualViewportState()).toEqual({
+        height: 0,
+        keyboardHeight: 0,
+        offsetTop: 0,
+        pageTop: 0,
+      });
+    });
+  });
+
   test('falls back to innerHeight when visualViewport is unavailable', () => {
     withWindow({ innerHeight: 812 }, () => {
-      expect(getVisualViewportState()).toEqual({ height: 812, keyboardHeight: 0 });
+      expect(getVisualViewportState()).toEqual({
+        height: 812,
+        keyboardHeight: 0,
+        offsetTop: 0,
+        pageTop: 0,
+      });
     });
   });
 
   test('derives keyboard height from visualViewport height', () => {
     withWindow({ innerHeight: 812, visualViewport: { height: 512 } }, () => {
-      expect(getVisualViewportState()).toEqual({ height: 512, keyboardHeight: 300 });
+      expect(getVisualViewportState()).toEqual({
+        height: 512,
+        keyboardHeight: 300,
+        offsetTop: 0,
+        pageTop: 0,
+      });
     });
+  });
+
+  test('clamps keyboard height to zero when visualViewport is taller than innerHeight', () => {
+    withWindow({ innerHeight: 812, visualViewport: { height: 900 } }, () => {
+      expect(getVisualViewportState()).toEqual({
+        height: 900,
+        keyboardHeight: 0,
+        offsetTop: 0,
+        pageTop: 0,
+      });
+    });
+  });
+
+  test('exposes offsetTop and pageTop from visualViewport (iOS keyboard pan)', () => {
+    withWindow(
+      {
+        innerHeight: 812,
+        visualViewport: { height: 420, offsetTop: 60, pageTop: 392 },
+      },
+      () => {
+        const state = getVisualViewportState();
+        expect(state.height).toBe(420);
+        expect(state.keyboardHeight).toBe(392);
+        expect(state.offsetTop).toBe(60);
+        expect(state.pageTop).toBe(392);
+      },
+    );
+  });
+
+  test('iOS pan without resize: height equals innerHeight with non-zero offset', () => {
+    withWindow(
+      {
+        innerHeight: 812,
+        visualViewport: { height: 812, offsetTop: 200, pageTop: 200 },
+      },
+      () => {
+        expect(getVisualViewportState()).toEqual({
+          height: 812,
+          keyboardHeight: 0,
+          offsetTop: 200,
+          pageTop: 200,
+        });
+      },
+    );
+  });
+
+  test('uses zero fallback for missing offsetTop and pageTop', () => {
+    withWindow(
+      { innerHeight: 812, visualViewport: { height: 600 } },
+      () => {
+        const state = getVisualViewportState();
+        expect(state.offsetTop).toBe(0);
+        expect(state.pageTop).toBe(0);
+      },
+    );
+  });
+});
+
+describe('visualViewportStateEqual', () => {
+  const base: VisualViewportState = {
+    height: 812,
+    keyboardHeight: 300,
+    offsetTop: 60,
+    pageTop: 392,
+  };
+
+  test('returns true for identical values (same reference)', () => {
+    expect(visualViewportStateEqual(base, base)).toBe(true);
+  });
+
+  test('returns true for equal values (different reference)', () => {
+    const copy: VisualViewportState = { ...base };
+    expect(visualViewportStateEqual(base, copy)).toBe(true);
+    expect(base).not.toBe(copy);
+  });
+
+  test('returns false when height differs', () => {
+    const other: VisualViewportState = { ...base, height: 600 };
+    expect(visualViewportStateEqual(base, other)).toBe(false);
+  });
+
+  test('returns false when keyboardHeight differs', () => {
+    const other: VisualViewportState = { ...base, keyboardHeight: 0 };
+    expect(visualViewportStateEqual(base, other)).toBe(false);
+  });
+
+  test('returns false when offsetTop differs', () => {
+    const other: VisualViewportState = { ...base, offsetTop: 0 };
+    expect(visualViewportStateEqual(base, other)).toBe(false);
+  });
+
+  test('returns false when pageTop differs', () => {
+    const other: VisualViewportState = { ...base, pageTop: 0 };
+    expect(visualViewportStateEqual(base, other)).toBe(false);
+  });
+
+  test('covers all fields: zero state equal to itself', () => {
+    const zero: VisualViewportState = { height: 0, keyboardHeight: 0, offsetTop: 0, pageTop: 0 };
+    expect(visualViewportStateEqual(zero, { height: 0, keyboardHeight: 0, offsetTop: 0, pageTop: 0 })).toBe(true);
+  });
+});
+
+describe('deriveMobileRootStyle', () => {
+  // Helper to extract effective top from a CSSProperties object.
+  const getEffectiveTop = (style: { top?: number | string } | undefined): number => {
+    if (!style || style.top === undefined) return 0;
+    return typeof style.top === 'number' ? style.top : parseFloat(String(style.top)) || 0;
+  };
+
+  test('returns undefined when isMobile is false (desktop)', () => {
+    expect(
+      deriveMobileRootStyle({
+        isMobile: false,
+        viewport: { height: 500, keyboardHeight: 0, offsetTop: 0, pageTop: 0 },
+        scrollY: 0,
+      }),
+    ).toBe(undefined);
+  });
+
+  test('returns undefined when viewport height is zero', () => {
+    expect(
+      deriveMobileRootStyle({
+        isMobile: true,
+        viewport: { height: 0, keyboardHeight: 0, offsetTop: 0, pageTop: 0 },
+        scrollY: 0,
+      }),
+    ).toBe(undefined);
+  });
+
+  test('returns undefined when viewport height is negative', () => {
+    expect(
+      deriveMobileRootStyle({
+        isMobile: true,
+        viewport: { height: -10, keyboardHeight: 0, offsetTop: 0, pageTop: 0 },
+        scrollY: 0,
+      }),
+    ).toBe(undefined);
+  });
+
+  test('resize-only geometry: effective root top 0, height equals visualViewport.height', () => {
+    const result = deriveMobileRootStyle({
+      isMobile: true,
+      viewport: { height: 500, keyboardHeight: 312, offsetTop: 0, pageTop: 0 },
+      scrollY: 0,
+    });
+    expect(result).not.toBe(undefined);
+    expect(result!.height).toBe(500);
+    expect(getEffectiveTop(result)).toBe(0);
+  });
+
+  test('pan-only geometry: effective root top equals visual viewport origin', () => {
+    const result = deriveMobileRootStyle({
+      isMobile: true,
+      viewport: { height: 812, keyboardHeight: 0, offsetTop: 200, pageTop: 200 },
+      scrollY: 0,
+    });
+    expect(result).not.toBe(undefined);
+    expect(result!.height).toBe(812);
+    expect(getEffectiveTop(result)).toBe(200);
+  });
+
+  test('mixed resize+pan geometry: effective root top equals visual viewport origin', () => {
+    const result = deriveMobileRootStyle({
+      isMobile: true,
+      viewport: { height: 420, keyboardHeight: 392, offsetTop: 60, pageTop: 392 },
+      scrollY: 0,
+    });
+    expect(result).not.toBe(undefined);
+    expect(result!.height).toBe(420);
+    expect(getEffectiveTop(result)).toBe(60);
+  });
+
+  test('origin normalization: offsetTop takes priority over pageTop', () => {
+    const result = deriveMobileRootStyle({
+      isMobile: true,
+      viewport: { height: 420, keyboardHeight: 392, offsetTop: 60, pageTop: 500 },
+      scrollY: 100,
+    });
+    // offsetTop=60 should win; pageTop-scrollY=400 should not be used
+    expect(getEffectiveTop(result)).toBe(60);
+  });
+
+  test('origin normalization: pageTop - scrollY fallback when offsetTop is zero', () => {
+    const result = deriveMobileRootStyle({
+      isMobile: true,
+      viewport: { height: 420, keyboardHeight: 392, offsetTop: 0, pageTop: 392 },
+      scrollY: 100,
+    });
+    expect(result).not.toBe(undefined);
+    expect(result!.height).toBe(420);
+    expect(getEffectiveTop(result)).toBe(292); // pageTop - scrollY = 392 - 100
+  });
+
+  test('origin is 0 when both offsetTop and pageTop are zero', () => {
+    const result = deriveMobileRootStyle({
+      isMobile: true,
+      viewport: { height: 500, keyboardHeight: 312, offsetTop: 0, pageTop: 0 },
+      scrollY: 0,
+    });
+    expect(result).not.toBe(undefined);
+    expect(getEffectiveTop(result)).toBe(0);
+  });
+
+  test('style does not include position:fixed when origin is 0 (preserves flow layout)', () => {
+    const result = deriveMobileRootStyle({
+      isMobile: true,
+      viewport: { height: 500, keyboardHeight: 312, offsetTop: 0, pageTop: 0 },
+      scrollY: 0,
+    });
+    expect(result).not.toBe(undefined);
+    expect(result!.position).toBe(undefined);
+  });
+
+  test('style includes position:fixed when origin is non-zero', () => {
+    const result = deriveMobileRootStyle({
+      isMobile: true,
+      viewport: { height: 420, keyboardHeight: 392, offsetTop: 60, pageTop: 392 },
+      scrollY: 0,
+    });
+    expect(result).not.toBe(undefined);
+    expect(result!.position).toBe('fixed');
+    expect(result!.left).toBe(0);
+    expect(result!.right).toBe(0);
   });
 });

--- a/packages/ui/src/hooks/useVisualViewport.ts
+++ b/packages/ui/src/hooks/useVisualViewport.ts
@@ -3,19 +3,74 @@ import React from 'react';
 export interface VisualViewportState {
   height: number;
   keyboardHeight: number;
+  offsetTop: number;
+  pageTop: number;
 }
 
 export const getVisualViewportState = (): VisualViewportState => {
   if (typeof window === 'undefined') {
-    return { height: 0, keyboardHeight: 0 };
+    return { height: 0, keyboardHeight: 0, offsetTop: 0, pageTop: 0 };
   }
 
   const height = window.visualViewport?.height ?? window.innerHeight;
   const keyboardHeight = window.visualViewport
     ? Math.max(0, window.innerHeight - height)
     : 0;
+  const offsetTop = window.visualViewport?.offsetTop ?? 0;
+  const pageTop = window.visualViewport?.pageTop ?? 0;
 
-  return { height, keyboardHeight };
+  return { height, keyboardHeight, offsetTop, pageTop };
+};
+
+export const visualViewportStateEqual = (
+  prev: VisualViewportState,
+  next: VisualViewportState,
+): boolean =>
+  prev.height === next.height &&
+  prev.keyboardHeight === next.keyboardHeight &&
+  prev.offsetTop === next.offsetTop &&
+  prev.pageTop === next.pageTop;
+
+/** Derive the mobile root inline style from visual viewport geometry.
+ *  Returns undefined for non-mobile or non-positive height.
+ *
+ *  Origin normalization:
+ *  - Primary: offsetTop (viewport-relative position of the visual viewport top).
+ *  - Fallback: pageTop - scrollY when offsetTop is zero but pageTop is available.
+ *
+ *  When the visual viewport origin is non-zero (iOS keyboard pan), the style
+ *  includes position:fixed to anchor the root to the visual viewport rectangle.
+ *  When origin is zero (no pan, resize-only), only height is set to preserve
+ *  normal flow layout. */
+export const deriveMobileRootStyle = (input: {
+  isMobile: boolean;
+  viewport: VisualViewportState;
+  scrollY: number;
+}): React.CSSProperties | undefined => {
+  if (!input.isMobile || input.viewport.height <= 0) {
+    return undefined;
+  }
+
+  const origin =
+    input.viewport.offsetTop > 0
+      ? input.viewport.offsetTop
+      : input.viewport.pageTop > 0
+        ? input.viewport.pageTop - input.scrollY
+        : 0;
+
+  if (origin > 0) {
+    return {
+      position: 'fixed',
+      top: origin,
+      height: input.viewport.height,
+      left: 0,
+      right: 0,
+    };
+  }
+
+  return {
+    height: input.viewport.height,
+  };
 };
 
 export const useVisualViewport = (): VisualViewportState => {
@@ -33,10 +88,9 @@ export const useVisualViewport = (): VisualViewportState => {
       rafIdRef.current = requestAnimationFrame(() => {
         rafIdRef.current = null;
         const nextState = getVisualViewportState();
-        setState((prev) => {
-          if (prev.height === nextState.height && prev.keyboardHeight === nextState.keyboardHeight) return prev;
-          return nextState;
-        });
+        setState((prev) =>
+          visualViewportStateEqual(prev, nextState) ? prev : nextState,
+        );
       });
     };
 


### PR DESCRIPTION
## Summary
- Expose visual viewport origin fields (`offsetTop`, `pageTop`) and include them in viewport state equality checks.
- Derive the mobile root style from the current visual viewport rectangle so iOS keyboard panning keeps the chat composer aligned with the visible area.
- Preserve desktop/non-mobile behavior by returning no mobile inline style outside the mobile path.

## Testing
- `bun test packages/ui/src/hooks/useVisualViewport.test.ts`
- `bun run type-check`
- `bun run lint`
- `bun run build`

## Manual verification
- Tested on an iOS standalone PWA installed from the home screen.
- With the keyboard open, the composer remains attached to the keyboard-visible area.
- No large blank region remains above the keyboard.

Screenshot evidence will be attached in the PR discussion.