### PR TITLE
fix(git): fetch from upstream now targets correct remote

### DIFF
--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2250,6 +2250,20 @@ export async function fetch(directory, options = {}) {
     args.push(remote);
     if (options.branch) args.push(options.branch);
 
+    // Forward extra git flags (mirrors simple-git's appendTaskOptions logic).
+    // Array form: ['--tags', '--prune'] is spread directly.
+    // Object form: string/number values become key=value flags; null/boolean
+    // values are skipped — consistent with how simple-git handled them.
+    if (Array.isArray(options.options)) {
+      args.push(...options.options);
+    } else if (options.options && typeof options.options === 'object') {
+      for (const [flag, value] of Object.entries(options.options)) {
+        if (value !== null && value !== undefined && typeof value !== 'boolean') {
+          args.push(`${flag}=${value}`);
+        }
+      }
+    }
+
     await git.raw(args);
 
     return { success: true };

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2240,11 +2240,17 @@ export async function fetch(directory, options = {}) {
   const { git } = await createRepositoryGitContext(directory);
 
   try {
-    await git.fetch(
-      options.remote || 'origin',
-      options.branch,
-      options.options || {}
-    );
+    // simple-git's git.fetch(remote, branch, options) only appends the remote
+    // to the command when *both* remote and branch are truthy. When only a
+    // remote is supplied (branch is undefined), the command silently degrades
+    // to bare `git fetch` (default remote) instead of `git fetch <remote>`.
+    // Use git.raw() to build the command directly and avoid that limitation.
+    const args = ['fetch'];
+    const remote = options.remote || 'origin';
+    args.push(remote);
+    if (options.branch) args.push(options.branch);
+
+    await git.raw(args);
 
     return { success: true };
   } catch (error) {


### PR DESCRIPTION
## Summary

Replace `git.fetch(remote, branch, options)` with `git.raw(['fetch', remote, ...])` in `packages/web/server/lib/git/service.js` so that specifying only a remote (no branch) actually runs `git fetch <remote>` instead of bare `git fetch`.

## Why

simple-git v3's internal `fetchTask` only appends the remote name to the command when **both** `remote` and `branch` are truthy:

```js
if (remote && branch) {
  commands.push(remote, branch);
}
```

When the UI dispatches "Fetch from upstream" it sends `{ remote: 'upstream' }` with no branch. The server called `git.fetch('upstream', undefined, {})`, the condition evaluated to `false`, and the resulting command was bare `git fetch` — silently fetching from the default/tracking remote (`origin`) instead of `upstream`. Users had to run `git fetch upstream` manually in the terminal to get the expected result.

Using `git.raw()` builds the command directly and bypasses this limitation entirely.

## Testing

- Add a remote named `upstream` pointing to any GitHub fork parent.
- Open the Git panel → dropdown → "Fetch from upstream".
- Confirm the operation now fetches refs from `upstream` (verify with `git log --remotes=upstream` or `git remote show upstream`).
- Confirm "Fetch from origin" still works correctly.
- Confirm that fetching with both remote and branch (used internally by sync flows) continues to work.