### PR TITLE
fix: improve todo send dialog model picker

### DIFF
--- a/packages/ui/src/components/sections/agents/ModelSelector.tsx
+++ b/packages/ui/src/components/sections/agents/ModelSelector.tsx
@@ -156,7 +156,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         <DropdownMenu open={isReady && isDropdownOpen} onOpenChange={isReady ? setIsDropdownOpen : undefined}>
             <DropdownMenuTrigger asChild>
                 <div className={cn(
-                    'border-input data-[placeholder]:text-muted-foreground flex items-center justify-between gap-2 rounded-lg border bg-transparent px-2 py-2 typography-ui-label whitespace-nowrap shadow-none outline-none hover:bg-interactive-hover data-[popup-open]:bg-interactive-active h-6 w-fit',
+                    'border-input data-[placeholder]:text-muted-foreground flex min-w-0 items-center justify-between gap-2 rounded-lg border bg-transparent px-2 py-2 typography-ui-label whitespace-nowrap shadow-none outline-none hover:bg-interactive-hover data-[popup-open]:bg-interactive-active h-6 w-fit',
                     !isReady && 'opacity-60 cursor-not-allowed',
                     className,
                 )}>
@@ -169,8 +169,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                         </>
                     ) : (
                         <>
-                            {providerId ? <ProviderLogo providerId={providerId} className="h-3.5 w-3.5 flex-shrink-0" /> : <Icon name="pencil-ai" className="h-3.5 w-3.5 text-muted-foreground" />}
-                            <span className="typography-ui-label font-normal whitespace-nowrap text-foreground">{triggerLabel}</span>
+                            {providerId ? <ProviderLogo providerId={providerId} className="h-3.5 w-3.5 flex-shrink-0" /> : <Icon name="pencil-ai" className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />}
+                            <span className="typography-ui-label min-w-0 truncate font-normal text-foreground">{triggerLabel}</span>
                         </>
                     )}
                     <Icon name="arrow-down-s" className="h-4 w-4 flex-shrink-0 text-muted-foreground/50" />

--- a/packages/ui/src/components/sections/agents/ModelSelector.tsx
+++ b/packages/ui/src/components/sections/agents/ModelSelector.tsx
@@ -23,6 +23,8 @@ interface ModelSelectorProps {
     className?: string;
     allowedProviderIds?: string[];
     placeholder?: string;
+    tooltipsEnabled?: boolean;
+    dropdownPortalToBody?: boolean;
 }
 
 export const ModelSelector: React.FC<ModelSelectorProps> = ({
@@ -32,6 +34,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     className,
     allowedProviderIds,
     placeholder,
+    tooltipsEnabled = true,
+    dropdownPortalToBody = false,
 }) => {
     const { t } = useI18n();
     const { isReady, isUnavailable } = useOpenCodeReadiness();
@@ -103,7 +107,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             includeNotSelected
             onSelectNone={handleSelectNone}
             onEscape={closePicker}
-            tooltipsEnabled={isActuallyMobile ? isMobilePanelOpen : isDropdownOpen}
+            tooltipsEnabled={tooltipsEnabled && (isActuallyMobile ? isMobilePanelOpen : isDropdownOpen)}
             isFavorite={(entry) => isFavoriteModel(entry.providerID, entry.modelID)}
             onToggleFavorite={(entry) => toggleFavoriteModel(entry.providerID, entry.modelID)}
         />
@@ -172,7 +176,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                     <Icon name="arrow-down-s" className="h-4 w-4 flex-shrink-0 text-muted-foreground/50" />
                 </div>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="w-[min(380px,calc(100vw-2rem))] p-0 flex flex-col" align="start">
+            <DropdownMenuContent className="w-[min(380px,calc(100vw-2rem))] p-0 flex flex-col" align="start" portalToBody={dropdownPortalToBody}>
                 {picker}
             </DropdownMenuContent>
         </DropdownMenu>

--- a/packages/ui/src/components/session/TodoSendDialog.tsx
+++ b/packages/ui/src/components/session/TodoSendDialog.tsx
@@ -196,30 +196,41 @@ export function TodoSendDialog(props: TodoSendDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => { if (!submitting) onOpenChange(nextOpen); }}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-2xl overflow-visible">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-          <ModelSelector
-            providerId={execution.providerID}
-            modelId={execution.modelID}
-            onChange={(providerID, modelID) => {
-              setExecution((prev) => ({ ...prev, providerID, modelID, variant: '' }));
-            }}
-          />
-          <ThinkingPill
-            value={execution.variant}
-            options={variantOptions}
-            disabled={!hasVariantOptions}
-            onChange={(variant) => setExecution((prev) => ({ ...prev, variant }))}
-          />
-          <AgentSelector
-            agentName={execution.agent}
-            filter={agentFilter}
-            onChange={(agent) => setExecution((prev) => ({ ...prev, agent }))}
-          />
+        <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <span className="typography-meta font-medium text-muted-foreground">{t('chat.modelControls.model')}</span>
+            <ModelSelector
+              providerId={execution.providerID}
+              modelId={execution.modelID}
+              className="w-full justify-between"
+              dropdownPortalToBody
+              onChange={(providerID, modelID) => {
+                setExecution((prev) => ({ ...prev, providerID, modelID, variant: '' }));
+              }}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <span className="typography-meta font-medium text-muted-foreground">{t('sessions.scheduledTasks.editor.thinkingLevel.label')}</span>
+            <ThinkingPill
+              value={execution.variant}
+              options={variantOptions}
+              disabled={!hasVariantOptions}
+              onChange={(variant) => setExecution((prev) => ({ ...prev, variant }))}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <span className="typography-meta font-medium text-muted-foreground">{t('sessions.scheduledTasks.editor.agent.label')}</span>
+            <AgentSelector
+              agentName={execution.agent}
+              filter={agentFilter}
+              onChange={(agent) => setExecution((prev) => ({ ...prev, agent }))}
+            />
+          </div>
         </div>
 
         <div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
## Why
The Todo `Send to new session` / `Send to worktree session` dialog used the same compact inline controls as simpler dialogs, but the model picker is a large searchable dropdown with metadata tooltips. Because dropdowns inside dialogs are normally portaled back into the dialog container, the picker was constrained by the dialog bounds. That made the autocomplete list and model metadata tooltips overlap or clip important controls, including the Send action, which made the Todo send flow difficult to use.

## Summary
- Widen and restructure the Todo send dialog controls so the model, thinking, and agent controls each have clear space.
- Allow `ModelSelector` dropdowns to portal to `body` when used in constrained dialog layouts.
- Enable that body portal only for the Todo send dialog so the searchable model picker can render at its natural size.
- Keep model metadata tooltips enabled now that the picker is no longer trapped inside the dialog content area.

## Screenshots

| Before | After |
| --- | --- |
|<img width="532" height="189" alt="image" src="https://github.com/user-attachments/assets/db97497c-e64f-42b3-b4b6-9cfe23c9a70a" />|<img width="824" height="701" alt="image" src="https://github.com/user-attachments/assets/b79910a2-7108-436b-8daf-3dd6f14a2bdf" />|
| Model metadata tooltip is constrained inside the compact dialog and overlaps the model search field / send action. <!-- image-1.png --> | The dialog has room for labeled controls, the model picker can render outside the dialog bounds, and the metadata tooltip no longer blocks the send flow. <!-- image-2.png --> |

## Test plan
- `bun run type-check`
- `bun run lint`