### PR TITLE
fix: session rename exits immediately due to focus race

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -284,7 +284,6 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
         : (showQuickArchiveAction ? 'group-hover:pr-12 group-focus-within:pr-12' : 'group-hover:pr-5 group-focus-within:pr-5'));
   const alwaysActionPaddingClass = showQuickArchiveAction ? 'pr-13' : 'pr-7';
   const suppressNextSelectRef = React.useRef(false);
-  const editCancelledRef = React.useRef(false);
   const [isTouchPressed, setIsTouchPressed] = React.useState(false);
   const editingIdRef = React.useRef(editingId);
   editingIdRef.current = editingId;
@@ -489,7 +488,6 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
               onKeyDown={(event) => {
                 if (event.key === 'Escape') {
                   event.stopPropagation();
-                  editCancelledRef.current = true;
                   handleCancelEdit();
                   return;
                 }

--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -286,6 +286,12 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
   const suppressNextSelectRef = React.useRef(false);
   const editCancelledRef = React.useRef(false);
   const [isTouchPressed, setIsTouchPressed] = React.useState(false);
+  const editingIdRef = React.useRef(editingId);
+  editingIdRef.current = editingId;
+  const pendingRenameRef = React.useRef<{ id: string; title: string } | null>(null);
+  const handleSaveEditRef = React.useRef(handleSaveEdit);
+  handleSaveEditRef.current = handleSaveEdit;
+  const formRef = React.useRef<HTMLFormElement>(null);
 
   const session = node.session;
   const liveSession = useSession(session.id);
@@ -447,6 +453,18 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
     });
   }, [session.id, sessionDirectory]);
 
+  // Capture outside-clicks to save edits — immune to focus-race with onBlur.
+  React.useEffect(() => {
+    if (editingId !== session.id) return;
+    const handleDocMouseDown = (e: MouseEvent) => {
+      if (formRef.current && !formRef.current.contains(e.target as Node)) {
+        handleSaveEditRef.current();
+      }
+    };
+    document.addEventListener('mousedown', handleDocMouseDown);
+    return () => document.removeEventListener('mousedown', handleDocMouseDown);
+  }, [editingId, session.id]);
+
   if (editingId === session.id) {
     return (
       <div
@@ -455,8 +473,8 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
       >
         <div className="flex min-w-0 flex-1 flex-col gap-0">
           <form
+            ref={formRef}
             className="flex w-full items-center gap-2"
-
             onSubmit={(event) => {
               event.preventDefault();
               handleSaveEdit();
@@ -478,13 +496,6 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
                 if (event.key === ' ' || event.key === 'Enter') {
                   event.stopPropagation();
                 }
-              }}
-              onBlur={() => {
-                if (editCancelledRef.current) {
-                  editCancelledRef.current = false;
-                  return;
-                }
-                handleSaveEdit();
               }}
             />
             <button
@@ -592,6 +603,15 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
     setOpenSidebarMenuKey(open ? menuInstanceKey : null);
   };
 
+  const handleMenuOpenChangeComplete = (open: boolean) => {
+    if (!open && pendingRenameRef.current) {
+      const { id, title } = pendingRenameRef.current;
+      pendingRenameRef.current = null;
+      setEditingId(id);
+      setEditTitle(title);
+    }
+  };
+
   const handleMenuTriggerClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -685,11 +705,13 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
   };
 
   const sessionMenuContent = (
-    <DropdownMenuContent align="end" className="min-w-[180px]" onCloseAutoFocus={(event) => { if (renamingFolderId) event.preventDefault(); }}>
+    <DropdownMenuContent align="end" className="min-w-[180px]" finalFocus={() => (renamingFolderId || editingIdRef.current) ? false : true}>
       <DropdownMenuItem
         onClick={() => {
-          setEditingId(session.id);
-          setEditTitle(sessionTitle);
+          // Defer rename until dropdown close transition completes.
+          // onOpenChangeComplete fires after animation + focus cleanup are done,
+          // avoiding focus stealing from Base UI's unmount cleanup.
+          pendingRenameRef.current = { id: session.id, title: sessionTitle };
         }}
         className="[&>svg]:mr-1"
       >
@@ -991,7 +1013,7 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
                 </TooltipContent>
               </Tooltip>
             ) : null}
-            <DropdownMenu open={isMenuOpen} onOpenChange={handleMenuOpenChange}>
+            <DropdownMenu open={isMenuOpen} onOpenChange={handleMenuOpenChange} onOpenChangeComplete={handleMenuOpenChangeComplete}>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary

Fixes a bug where clicking "Rename" in the session dropdown menu enters rename mode briefly then immediately exits, making sessions unrenamable in the web UI. The issue affected auto-named sessions (new sessions with AI-generated titles) but was intermittent — some sessions worked while others didn't.

The root cause was a focus race between the rename input's `onBlur` handler and Base UI's dropdown popup cleanup (FocusScope focus restoration, CSS transition teardown). When the dropdown closes after clicking "Rename", Base UI's internal effects could steal focus from the newly-mounted rename input, triggering `onBlur` → `handleSaveEdit()` → immediate exit.

## Changes

`packages/ui/src/components/session/sidebar/SessionNodeItem.tsx` (+34/-12)

1. **Replaced `onBlur` with document `mousedown` listener** — saves only on click-outside, immune to focus management timing
2. **Deferred dropdown-initiated rename to `onOpenChangeComplete`** — fires after CSS transition + all cleanup effects complete
3. **Replaced dead `onCloseAutoFocus` with `finalFocus`** — `onCloseAutoFocus` was discarded in the wrapper (`void`), never forwarded to Base UI; `finalFocus` is properly passed via `{...props}`

## Why

The `DropdownMenuContent` wrapper extracts `onCloseAutoFocus` but then runs `void onCloseAutoFocus` — a no-op that suppresses lint warnings but never forwards the prop to `BaseMenu.Popup`. The `finalFocus` prop IS forwarded, and the `editingIdRef` (synced every render) avoids stale closure timing issues.

The `onOpenChangeComplete` approach guarantees the dropdown's close transition (150ms CSS + FocusScope cleanup) is fully done before the rename form mounts, eliminating the focus race entirely.

The document `mousedown` listener replaces the fragile `onBlur` handler — it's a simpler, more reliable mechanism that's immune to any focus management side effects.

## Testing

- Open any session dropdown → click "Rename" → rename form appears and stays open
- Type a new title → press Enter → title saves and edit mode exits
- Click ✓ button → title saves and edit mode exits
- Click ✗ button or press Escape → edit mode exits without saving
- Click outside the rename form → title saves and edit mode exits
- Double-click on a session title → rename form appears
- Auto-named sessions (new sessions with AI-generated titles) can now be renamed
- Previously renamed sessions still rename correctly
- Multiple sessions in sidebar — rename one, verify others unaffected

```
  Type check: 5/5 packages pass
  Lint:       5/5 packages pass
```
