### PR TITLE
fix: change agent cycle shortcut from Tab to Ctrl+Tab

### DIFF
--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -37,7 +37,7 @@ import { useIsTextTruncated } from '@/hooks/useIsTextTruncated';
 import { formatEffortLabel, getCycledPrimaryAgentName, isPrimaryMode, type MobileControlsPanel } from './mobileControlsUtils';
 import { getCurrentIntlLocale, useI18n } from '@/lib/i18n';
 import { useOpenCodeReadiness } from '@/hooks/useOpenCodeReadiness';
-import { eventMatchesShortcut, getEffectiveShortcutCombo, normalizeCombo } from '@/lib/shortcuts';
+import { eventMatchesShortcut, formatShortcutForDisplay, getEffectiveShortcutCombo, normalizeCombo } from '@/lib/shortcuts';
 import { markStartupTrace } from '@/lib/startupTrace';
 
 type IconComponent = IconName;
@@ -2385,7 +2385,7 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                                     return (
                                         <div className="flex items-center gap-x-2 whitespace-nowrap overflow-hidden">
                                             <span>{t('chat.modelControls.keyboardHintNavigate')}</span>
-                                            <span>{t('chat.modelControls.keyboardHintSwitchAgent', { shortcut: 'Tab' })}</span>
+                                            <span>{t('chat.modelControls.keyboardHintSwitchAgent', { shortcut: formatShortcutForDisplay(cycleAgentShortcut) })}</span>
                                             {activeHasThinkingVariants ? <span>{t('chat.modelControls.keyboardHintThinking')}</span> : null}
                                         </div>
                                     );

--- a/packages/ui/src/lib/shortcuts.ts
+++ b/packages/ui/src/lib/shortcuts.ts
@@ -308,7 +308,7 @@ const SHORTCUT_ACTIONS: ReadonlyArray<ShortcutAction> = [
   },
   {
     id: 'cycle_agent',
-    defaultCombo: 'tab',
+    defaultCombo: 'ctrl+tab',
     label: 'Cycle agent',
     description: 'Cycle agent while the model selector is open',
     customizable: true,


### PR DESCRIPTION
## Problem

The agent cycle shortcut is bound to `Tab`, which conflicts with several other Tab behaviors:
- Command autocomplete (navigating suggestions)
- Skill autocomplete
- Snippet autocomplete
- File mention autocomplete
- Natural tab-to-indent in the chat input

## Fix

Changed the default combo for `cycle_agent` from `tab` to `ctrl+tab` in `packages/ui/src/lib/shortcuts.ts`. Also updated the shortcut hint displayed in the model picker to use the computed shortcut (`formatShortcutForDisplay`) instead of a hardcoded `'Tab'` string, so it respects user customization.

The shortcut is still customizable — users can restore the old behavior in their `opencode.json`:

```json
{
  "shortcuts": {
    "cycle_agent": "tab"
  }
}
```

## Changes
- `packages/ui/src/lib/shortcuts.ts` — defaultCombo: `'tab'` → `'ctrl+tab'`
- `packages/ui/src/components/chat/ModelControls.tsx` — hardcoded `'Tab'` → `formatShortcutForDisplay(cycleAgentShortcut)`