### PR TITLE
Fix mobile terminal touch scrolling

### DIFF
--- a/packages/ui/src/components/terminal/TerminalViewport.tsx
+++ b/packages/ui/src/components/terminal/TerminalViewport.tsx
@@ -69,6 +69,10 @@ type RendererWithScrollbar = {
   renderScrollbar?: (...args: unknown[]) => void;
 };
 
+type TerminalWithRenderer = {
+  renderer?: RendererWithScrollbar;
+};
+
 interface TerminalViewportProps {
   sessionKey: string;
   chunks: TerminalChunk[];
@@ -1076,13 +1080,15 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
           terminal.loadAddon(fitAddon);
           terminal.open(container);
           if (enableTouchScroll) {
-            const renderer = (terminal as unknown as { renderer?: RendererWithScrollbar }).renderer;
+            const renderer = (terminal as unknown as TerminalWithRenderer).renderer;
             if (renderer && typeof renderer.renderScrollbar === 'function') {
               const originalRenderScrollbar = renderer.renderScrollbar.bind(renderer);
               renderer.renderScrollbar = () => {};
               restorePatchedScrollbar = () => {
                 renderer.renderScrollbar = originalRenderScrollbar;
               };
+            } else if (process.env.NODE_ENV === 'development') {
+              console.warn('[TerminalViewport] Ghostty renderer scrollbar hook is unavailable; touch scrollbar suppression may need an update.');
             }
           }
           bumpTerminalReady();

--- a/packages/ui/src/components/terminal/TerminalViewport.tsx
+++ b/packages/ui/src/components/terminal/TerminalViewport.tsx
@@ -65,6 +65,10 @@ type FitAddonWithObserveResize = FitAddon & {
   observeResize?: () => void;
 };
 
+type RendererWithScrollbar = {
+  renderScrollbar?: (...args: unknown[]) => void;
+};
+
 interface TerminalViewportProps {
   sessionKey: string;
   chunks: TerminalChunk[];
@@ -787,7 +791,9 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
         container.addEventListener('pointercancel', handlePointerUp, listenerOptions);
 
         const previousTouchAction = container.style.touchAction;
-        container.style.touchAction = 'manipulation';
+        const previousOverscrollBehaviorY = container.style.overscrollBehaviorY;
+        container.style.touchAction = 'none';
+        container.style.overscrollBehaviorY = 'contain';
 
         touchScrollCleanupRef.current = () => {
           stopKinetic();
@@ -801,6 +807,7 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
           container.removeEventListener('pointerup', handlePointerUp, listenerOptions);
           container.removeEventListener('pointercancel', handlePointerUp, listenerOptions);
           container.style.touchAction = previousTouchAction;
+          container.style.overscrollBehaviorY = previousOverscrollBehaviorY;
         };
 
         return;
@@ -942,7 +949,9 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
       container.addEventListener('touchcancel', handleTouchEnd as unknown as EventListener, listenerOptions);
 
       const previousTouchAction = container.style.touchAction;
-      container.style.touchAction = 'manipulation';
+      const previousOverscrollBehaviorY = container.style.overscrollBehaviorY;
+      container.style.touchAction = 'none';
+      container.style.overscrollBehaviorY = 'contain';
 
       touchScrollCleanupRef.current = () => {
         stopKinetic();
@@ -956,6 +965,7 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
         container.removeEventListener('touchend', handleTouchEnd as unknown as EventListener, listenerOptions);
         container.removeEventListener('touchcancel', handleTouchEnd as unknown as EventListener, listenerOptions);
         container.style.touchAction = previousTouchAction;
+        container.style.overscrollBehaviorY = previousOverscrollBehaviorY;
       };
     }, [enableTouchScroll, useHiddenInputOverlay, focusHiddenInput, fontSize]);
 
@@ -966,6 +976,7 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
       let localTextareaObserver: MutationObserver | null = null;
       let localDisposables: Array<{ dispose: () => void }> = [];
       let restorePatchedScrollToBottom: (() => void) | null = null;
+      let restorePatchedScrollbar: (() => void) | null = null;
       let restoreContainerFocus: (() => void) | null = null;
 
       const container = containerRef.current;
@@ -1064,6 +1075,16 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
 
           terminal.loadAddon(fitAddon);
           terminal.open(container);
+          if (enableTouchScroll) {
+            const renderer = (terminal as unknown as { renderer?: RendererWithScrollbar }).renderer;
+            if (renderer && typeof renderer.renderScrollbar === 'function') {
+              const originalRenderScrollbar = renderer.renderScrollbar.bind(renderer);
+              renderer.renderScrollbar = () => {};
+              restorePatchedScrollbar = () => {
+                renderer.renderScrollbar = originalRenderScrollbar;
+              };
+            }
+          }
           bumpTerminalReady();
           cursorBlinkStateRef.current = false;
 
@@ -1158,6 +1179,8 @@ const TerminalViewport = React.forwardRef<TerminalController, TerminalViewportPr
         localDisposables.forEach((disposable) => disposable.dispose());
         restorePatchedScrollToBottom?.();
         restorePatchedScrollToBottom = null;
+        restorePatchedScrollbar?.();
+        restorePatchedScrollbar = null;
         if (localTerminalTextarea) {
           localTerminalTextarea.removeEventListener('focus', handleTerminalTextareaFocus);
           localTerminalTextarea.removeEventListener('blur', handleTerminalTextareaBlur);


### PR DESCRIPTION
## Summary

- improve touch scrolling in the mobile terminal by preventing the browser from taking over vertical pan gestures
- contain terminal overscroll so touch gestures stay scoped to the terminal viewport
- hide Ghostty's internal canvas scrollbar in touch terminal mode because it paints over the last text column and clips terminal output
- restore patched styles and renderer behavior during terminal cleanup to avoid leaking touch-specific behavior across remounts