### PR TITLE
feat: support Open in App (VS Code) for remote SSH instances (#1449)

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -2833,6 +2833,181 @@ const buildOpenFileSpecs = ({ filePath, appId, appName }) => {
   return specs;
 };
 
+const REMOTE_URI_SCHEME_BY_APP_ID = {
+  vscode: 'vscode',
+  cursor: 'cursor',
+  vscodium: 'vscodium',
+  windsurf: 'windsurf',
+};
+
+const buildOpenRemoteProjectSpecs = ({ projectPath, appId, appName, sshInfo }) => {
+  const specs = [];
+  const cli = CLI_BY_APP_ID[appId];
+  if (cli) {
+    const hostPart = sshInfo.user ? `${sshInfo.user}@${sshInfo.host}` : sshInfo.host;
+    const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
+    const remoteTarget = `ssh-remote+${hostPort}`;
+    specs.push({ program: cli, args: ['--remote', remoteTarget, '--new-window', projectPath] });
+    const scheme = REMOTE_URI_SCHEME_BY_APP_ID[appId] || 'vscode';
+    const encodedPath = projectPath.split('/').map(encodeURIComponent).join('/');
+    const deepLinkUri = `${scheme}://vscode-remote/${remoteTarget}${encodedPath}`;
+    specs.push({ program: 'open', args: [deepLinkUri] });
+  }
+  return specs;
+};
+
+const buildOpenRemoteFileSpecs = ({ filePath, appId, appName, sshInfo }) => {
+  const specs = [];
+  const cli = CLI_BY_APP_ID[appId];
+  if (cli) {
+    const hostPart = sshInfo.user ? `${sshInfo.user}@${sshInfo.host}` : sshInfo.host;
+    const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
+    const remoteTarget = `ssh-remote+${hostPort}`;
+    specs.push({ program: cli, args: ['--remote', remoteTarget, '--goto', filePath] });
+    const scheme = REMOTE_URI_SCHEME_BY_APP_ID[appId] || 'vscode';
+    const encodedPath = filePath.split('/').map(encodeURIComponent).join('/');
+    const deepLinkUri = `${scheme}://vscode-remote/${remoteTarget}${encodedPath}`;
+    specs.push({ program: 'open', args: [deepLinkUri] });
+  }
+  return specs;
+};
+
+const buildWindowsOpenRemoteProjectSpecs = ({ projectPath, appId, appName, sshInfo }) => {
+  const specs = [];
+  const hostPart = sshInfo.user ? `${sshInfo.user}@${sshInfo.host}` : sshInfo.host;
+  const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
+  const remoteTarget = `ssh-remote+${hostPort}`;
+  const cli = WINDOWS_CLI_BY_APP_ID[appId];
+  if (cli) {
+    const resolvedCli = runWhere(cli);
+    if (resolvedCli) {
+      specs.push({ program: resolvedCli, args: ['--remote', remoteTarget, '--new-window', projectPath] });
+    }
+  }
+  const exe = findWindowsExecutable(appId);
+  if (exe) {
+    specs.push({ program: exe, args: ['--remote', remoteTarget, '--new-window', projectPath] });
+  }
+  // Intentional: no findWindowsAppNameExecutable fallback here.
+  // The fallback searches by user-friendly app name and would not
+  // include the --remote arg, so it can't open the remote target.
+  return specs;
+};
+const buildWindowsOpenRemoteFileSpecs = ({ filePath, appId, appName, sshInfo }) => {
+  const specs = [];
+  const hostPart = sshInfo.user ? `${sshInfo.user}@${sshInfo.host}` : sshInfo.host;
+  const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
+  const remoteTarget = `ssh-remote+${hostPort}`;
+  const cli = WINDOWS_CLI_BY_APP_ID[appId];
+  if (cli) {
+    const resolvedCli = runWhere(cli);
+    if (resolvedCli) {
+      specs.push({ program: resolvedCli, args: ['--remote', remoteTarget, '--goto', filePath] });
+    }
+  }
+  const exe = findWindowsExecutable(appId);
+  if (exe) {
+    specs.push({ program: exe, args: ['--remote', remoteTarget, '--goto', filePath] });
+  }
+  // Intentional: no findWindowsAppNameExecutable fallback here
+  // (same rationale as buildWindowsOpenRemoteProjectSpecs).
+  return specs;
+};
+
+const getSshInfoByOrigin = (requestOrigin) => {
+  // readInstances() returns raw JSON; sshParsed may be absent for
+  // instances that have never been connected. We fall back to the
+  // active session's parsed data, and skip entries with no parsed info.
+  const instances = sshManager.readInstances().instances;
+  const hostsConfig = readDesktopHostsConfig();
+  const hosts = hostsConfig.hosts || [];
+
+  for (const instance of instances) {
+    const hostEntry = hosts.find((h) => h.id === instance.id);
+    if (!hostEntry) continue;
+
+    let hostOrigin = '';
+    try { hostOrigin = new URL(hostEntry.url).origin; } catch {}
+
+    if (hostOrigin !== requestOrigin) continue;
+
+    const status = sshManager.statuses.get(instance.id);
+    if (status?.phase !== 'ready') continue;
+
+    const session = sshManager.sessions.get(instance.id);
+    const parsed = instance.sshParsed || session?.parsed;
+    if (!parsed || !parsed.destination) continue;
+
+    let port = 22;
+    let user = '';
+    for (let i = 0; i < parsed.args.length; i++) {
+      const arg = parsed.args[i];
+      if (arg === '-p' && i + 1 < parsed.args.length) {
+        port = parseInt(parsed.args[i + 1], 10) || 22;
+        i++;
+        continue;
+      }
+      if (arg.startsWith('-p') && arg.length > 2) {
+        port = parseInt(arg.slice(2), 10) || 22;
+        continue;
+      }
+      if (arg === '-P' && i + 1 < parsed.args.length) {
+        port = parseInt(parsed.args[i + 1], 10) || 22;
+        i++;
+        continue;
+      }
+      if (arg.startsWith('-P') && arg.length > 2) {
+        port = parseInt(arg.slice(2), 10) || 22;
+        continue;
+      }
+      if (arg === '-l' && i + 1 < parsed.args.length) {
+        user = parsed.args[i + 1];
+        i++;
+        continue;
+      }
+      if (arg.startsWith('-l') && arg.length > 2) {
+        user = arg.slice(2);
+        continue;
+      }
+      if (arg === '-o' && i + 1 < parsed.args.length) {
+        const opt = parsed.args[i + 1];
+        i++;
+        const eqIdx = opt.indexOf('=');
+        if (eqIdx >= 0) {
+          const key = opt.slice(0, eqIdx);
+          const value = opt.slice(eqIdx + 1);
+          if (key === 'Port' || key === 'port') {
+            port = parseInt(value, 10) || 22;
+          } else if (key === 'User' || key === 'user') {
+            user = value;
+          }
+        }
+        continue;
+      }
+      if (arg.startsWith('-o') && arg.length > 2) {
+        const opt = arg.slice(2);
+        const eqIdx = opt.indexOf('=');
+        if (eqIdx >= 0) {
+          const key = opt.slice(0, eqIdx);
+          const value = opt.slice(eqIdx + 1);
+          if (key === 'Port' || key === 'port') {
+            port = parseInt(value, 10) || 22;
+          } else if (key === 'User' || key === 'user') {
+            user = value;
+          }
+        }
+        continue;
+      }
+    }
+
+    const result = { host: parsed.destination, port, instanceId: instance.id };
+    if (user) result.user = user;
+    return result;
+  }
+
+  return null;
+};
+
 const quoteWindowsCommandArg = (value) => `"${String(value).replace(/"/g, '""')}"`;
 
 const resolveWindowsLaunchProgram = (program) => {
@@ -2917,7 +3092,7 @@ const runSpecChain = (specs, appName) => {
   throw new Error(`Failed to open in ${appName}: ${failures.join('; ')}`);
 };
 
-const handleInvoke = async (browserWindow, command, args = {}) => {
+const handleInvoke = async (browserWindow, command, args = {}, senderOrigin = '') => {
   switch (command) {
     case 'desktop_start_window_drag':
       return null;
@@ -3164,6 +3339,71 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
         throw new Error('desktop_open_file_in_app is only supported on macOS and Windows');
       }
       runSpecChain(buildOpenFileSpecs({ filePath, appId, appName }), appName);
+      return null;
+    }
+
+    case 'desktop_get_active_ssh_info': {
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
+      if (senderOrigin && requestOrigin !== senderOrigin) {
+        throw new Error('Origin mismatch');
+      }
+      const resolvedOrigin = senderOrigin || requestOrigin;
+      if (!resolvedOrigin) return null;
+      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      return sshInfo || null;
+    }
+
+    case 'desktop_open_remote_in_app': {
+      const projectPath = typeof args.projectPath === 'string' ? args.projectPath.trim() : '';
+      const appId = typeof args.appId === 'string' ? args.appId.trim().toLowerCase() : '';
+      const appName = typeof args.appName === 'string' ? args.appName.trim() : '';
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
+      if (senderOrigin && requestOrigin !== senderOrigin) {
+        throw new Error('Origin mismatch');
+      }
+      const resolvedOrigin = senderOrigin || requestOrigin;
+      if (!projectPath || !appId || !appName || !resolvedOrigin) {
+        throw new Error('Project path, app id, app name, and origin are required');
+      }
+      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      if (!sshInfo) {
+        throw new Error('SSH connection info not available');
+      }
+      if (process.platform === 'win32') {
+        runSpecChain(buildWindowsOpenRemoteProjectSpecs({ projectPath, appId, appName, sshInfo }), appName);
+        return null;
+      }
+      if (process.platform !== 'darwin') {
+        throw new Error('desktop_open_remote_in_app is only supported on macOS and Windows');
+      }
+      runSpecChain(buildOpenRemoteProjectSpecs({ projectPath, appId, appName, sshInfo }), appName);
+      return null;
+    }
+
+    case 'desktop_open_remote_file_in_app': {
+      const filePath = typeof args.filePath === 'string' ? args.filePath.trim() : '';
+      const appId = typeof args.appId === 'string' ? args.appId.trim().toLowerCase() : '';
+      const appName = typeof args.appName === 'string' ? args.appName.trim() : '';
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
+      if (senderOrigin && requestOrigin !== senderOrigin) {
+        throw new Error('Origin mismatch');
+      }
+      const resolvedOrigin = senderOrigin || requestOrigin;
+      if (!filePath || !appId || !appName || !resolvedOrigin) {
+        throw new Error('File path, app id, app name, and origin are required');
+      }
+      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      if (!sshInfo) {
+        throw new Error('SSH connection info not available');
+      }
+      if (process.platform === 'win32') {
+        runSpecChain(buildWindowsOpenRemoteFileSpecs({ filePath, appId, appName, sshInfo }), appName);
+        return null;
+      }
+      if (process.platform !== 'darwin') {
+        throw new Error('desktop_open_remote_file_in_app is only supported on macOS and Windows');
+      }
+      runSpecChain(buildOpenRemoteFileSpecs({ filePath, appId, appName, sshInfo }), appName);
       return null;
     }
 
@@ -3852,19 +4092,59 @@ app.on('web-contents-created', (_event, contents) => {
 // shell.openPath, installed-app scans, app relaunch, and file dialogs
 // are gated to local senders — even the user's own remote UI shouldn't
 // need them, and a compromised remote can't use them either.
-const isLocalSender = (webContents) => {
+// SSH-tunnel pages (loopback origin that does NOT match the local origin)
+// are restricted to a separate whitelist: SSH context queries, remote
+// open commands, and app scans. File reads, dialogs, and local path
+// open are NOT granted to SSH tunnels — only to the true local origin.
+const isActualLocalOrigin = (webContents) => {
   try {
     const raw = typeof webContents?.getURL === 'function' ? webContents.getURL() : '';
     if (!raw) return false;
     const url = new URL(raw);
     if (url.protocol === `${UI_PROTOCOL}:` && url.hostname === 'app') return true;
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    const hostname = url.hostname;
+    const isLoopback = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
     if (state.localOrigin) {
       try {
         const allowed = new URL(state.localOrigin);
         if (allowed.origin === url.origin) return true;
-      } catch {
+      } catch {}
+      if (state.sidecarUrl) {
+        try {
+          const allowed = new URL(state.sidecarUrl);
+          if (allowed.origin === url.origin) return true;
+        } catch {}
       }
+      return false;
+    }
+    // No explicit local origin configured — fall back to loopback check
+    return isLoopback;
+  } catch {
+    return false;
+  }
+};
+
+const isSshTunnelOrigin = (webContents) => {
+  try {
+    const raw = typeof webContents?.getURL === 'function' ? webContents.getURL() : '';
+    if (!raw) return false;
+    const url = new URL(raw);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    const hostname = url.hostname;
+    if (hostname !== 'localhost' && hostname !== '127.0.0.1' && hostname !== '::1') return false;
+    // A tunnel origin is only meaningful when a local origin is known
+    // and the loopback origin does NOT match it. If localOrigin is not
+    // configured, no origin can be classified as a tunnel.
+    if (!state.localOrigin) return false;
+    try {
+      const allowed = new URL(state.localOrigin);
+      if (allowed.origin === url.origin) return false;
+    } catch {}
+    // Only treat as a tunnel origin if this port maps to a ready SSH instance
+    const port = parseInt(url.port, 10) || (url.protocol === 'https:' ? 443 : 80);
+    for (const status of sshManager.statuses.values()) {
+      if (status.phase === 'ready' && status.localPort === port) return true;
     }
     if (state.sidecarUrl) {
       try {
@@ -3879,6 +4159,15 @@ const isLocalSender = (webContents) => {
   }
 };
 
+const isLocalSender = (webContents) => {
+  return isActualLocalOrigin(webContents) || isSshTunnelOrigin(webContents);
+};
+
+// desktop_open_remote_in_app, desktop_open_remote_file_in_app, and
+// desktop_get_active_ssh_info are in SSH_TUNNEL_COMMANDS so they can
+// be called from SSH-tunneled pages on 127.0.0.1. They are NOT in
+// COMMANDS_SAFE_FOR_REMOTE because non-loopback remote pages must
+// never invoke them.
 const COMMANDS_SAFE_FOR_REMOTE = new Set([
   'desktop_hosts_get',
   'desktop_host_probe',
@@ -3897,18 +4186,48 @@ const COMMANDS_SAFE_FOR_REMOTE = new Set([
   'desktop_capture_page_rect',
 ]);
 
+const SSH_TUNNEL_COMMANDS = new Set([
+  'desktop_get_active_ssh_info',
+  'desktop_open_remote_in_app',
+  'desktop_open_remote_file_in_app',
+  'desktop_filter_installed_apps',
+  'desktop_get_installed_apps',
+  'desktop_fetch_app_icons',
+]);
+
 ipcMain.handle('openchamber:invoke', async (event, command, args) => {
-  if (!isLocalSender(event.sender) && !COMMANDS_SAFE_FOR_REMOTE.has(command)) {
+  const tunnelOrigin = isSshTunnelOrigin(event.sender);
+  const localOrigin = isActualLocalOrigin(event.sender);
+  const isSafeForRemote = COMMANDS_SAFE_FOR_REMOTE.has(command);
+  const isSafeForTunnel = SSH_TUNNEL_COMMANDS.has(command);
+
+  if (!localOrigin && !tunnelOrigin && !isSafeForRemote) {
     log.warn(`[ipc] rejected ${command} from non-local origin: ${event.sender?.getURL?.() || '(unknown)'}`);
     throw new Error('IPC not available for this origin');
   }
+
+  if (tunnelOrigin && !localOrigin && !isSafeForTunnel && !isSafeForRemote) {
+    log.warn(`[ipc] rejected ${command} from SSH tunnel origin: ${event.sender?.getURL?.() || '(unknown)'}`);
+    throw new Error('IPC not available for this origin');
+  }
+
+  let senderOrigin = '';
+  if (isSafeForTunnel) {
+    try {
+      const url = new URL(event.sender.getURL());
+      senderOrigin = url.origin;
+    } catch {}
+  }
+
   const browserWindow = BrowserWindow.fromWebContents(event.sender);
-  return handleInvoke(browserWindow, command, args);
+  return handleInvoke(browserWindow, command, args, senderOrigin);
 });
 
 ipcMain.handle('openchamber:dialog:open', async (event, options) => {
-  // Native file dialogs expose absolute local paths; never grant to remote.
-  if (!isLocalSender(event.sender)) {
+  // Native file dialogs expose absolute local paths; never grant to
+  // remote OR SSH tunnel origins. Only the true local origin may
+  // open file dialogs.
+  if (!isActualLocalOrigin(event.sender)) {
     log.warn(`[ipc] rejected dialog:open from non-local origin: ${event.sender?.getURL?.() || '(unknown)'}`);
     throw new Error('IPC not available for this origin');
   }

--- a/packages/ui/src/components/desktop/OpenInAppButton.tsx
+++ b/packages/ui/src/components/desktop/OpenInAppButton.tsx
@@ -10,7 +10,7 @@ import { toast } from '@/components/ui';
 import { Icon } from "@/components/icon/Icon";
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { cn } from '@/lib/utils';
-import { isDesktopLocalOriginActive, isDesktopShell, openDesktopPath, openDesktopProjectInApp } from '@/lib/desktop';
+import { isOpenInAppAvailable, subscribeRemoteSshActive, getRemoteSshSnapshot, openDesktopPath, openDesktopProjectInApp, openDesktopRemoteProjectInApp } from '@/lib/desktop';
 import { DEFAULT_OPEN_IN_APP_ID, OPEN_IN_APPS } from '@/lib/openInApps';
 import { useOpenInAppsStore, type OpenInAppOption } from '@/stores/useOpenInAppsStore';
 import { useI18n } from '@/lib/i18n';
@@ -87,31 +87,48 @@ export const OpenInAppButton = ({ directory, className }: OpenInAppButtonProps) 
     initialize();
   }, [initialize]);
 
-  const isDesktopLocal = isDesktopShell() && isDesktopLocalOriginActive();
+  const isRemote = React.useSyncExternalStore(subscribeRemoteSshActive, getRemoteSshSnapshot);
+
+  const displayableApps = React.useMemo(() => {
+    if (!isRemote) return availableApps;
+    return availableApps.filter((app) => {
+      const meta = OPEN_IN_APPS.find((a) => a.id === app.id);
+      return meta?.supportsRemote === true;
+    });
+  }, [availableApps, isRemote]);
 
   const selectedApp = React.useMemo(() => {
-    const known = availableApps.find((app) => app.id === selectedAppId)
-      ?? availableApps.find((app) => app.id === DEFAULT_OPEN_IN_APP_ID)
-      ?? availableApps[0]
+    const effective = displayableApps.length > 0 ? displayableApps : availableApps;
+    const known = effective.find((app) => app.id === selectedAppId)
+      ?? effective.find((app) => app.id === DEFAULT_OPEN_IN_APP_ID)
+      ?? effective[0]
       ?? OPEN_IN_APPS[0];
     if (known) {
       return withFallbackIcon(known);
     }
     return withFallbackIcon(OPEN_IN_APPS[0]);
-  }, [availableApps, selectedAppId]);
+  }, [displayableApps, availableApps, selectedAppId]);
 
-  if (!isDesktopLocal || !directory) {
+  if (!isOpenInAppAvailable() || !directory) {
     return null;
   }
 
-  if (availableApps.length === 0) {
+  if (displayableApps.length === 0) {
     return null;
   }
 
   const handleOpen = async (app: OpenInAppOption) => {
-    const opened = await openDesktopProjectInApp(directory, app.id, app.appName);
-    if (!opened) {
-      await openDesktopPath(directory, app.appName);
+    if (isRemote) {
+      const opened = await openDesktopRemoteProjectInApp(directory, app.id, app.appName);
+      if (!opened) {
+        await copyTextToClipboard(directory);
+        toast.warning(t('openInApp.toast.remoteOpenFailed'));
+      }
+    } else {
+      const opened = await openDesktopProjectInApp(directory, app.id, app.appName);
+      if (!opened) {
+        await openDesktopPath(directory, app.appName);
+      }
     }
   };
 
@@ -177,7 +194,7 @@ export const OpenInAppButton = ({ directory, className }: OpenInAppButtonProps) 
             <span className="typography-ui-label text-foreground">{t('openInApp.actions.copyPath')}</span>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          {availableApps.map((app) => {
+          {displayableApps.map((app) => {
             const appWithFallback = withFallbackIcon(app);
             return (
               <DropdownMenuItem

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -57,8 +57,9 @@ import { FileTypeIcon } from '@/components/icons/FileTypeIcon';
 import { Icon } from "@/components/icon/Icon";
 import { ensurePierreThemeRegistered } from '@/lib/shiki/appThemeRegistry';
 import { getDefaultTheme } from '@/lib/theme/themes';
-import { openDesktopFileInApp, openDesktopPath } from '@/lib/desktop';
+import { openDesktopFileInApp, openDesktopPath, subscribeRemoteSshActive, getRemoteSshSnapshot, openDesktopRemoteFileInApp, isOpenInAppAvailable } from '@/lib/desktop';
 import { useOpenInAppsStore } from '@/stores/useOpenInAppsStore';
+import { OPEN_IN_APPS } from '@/lib/openInApps';
 import { eventMatchesShortcut, getEffectiveShortcutCombo } from '@/lib/shortcuts';
 import { useI18n } from '@/lib/i18n';
 
@@ -843,6 +844,16 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const initializeOpenInApps = useOpenInAppsStore((state) => state.initialize);
   const loadOpenInApps = useOpenInAppsStore((state) => state.loadInstalledApps);
 
+  const isRemote = React.useSyncExternalStore(subscribeRemoteSshActive, getRemoteSshSnapshot);
+
+  const displayableOpenInApps = React.useMemo(() => {
+    if (!isRemote) return openInApps;
+    return openInApps.filter((app) => {
+      const meta = OPEN_IN_APPS.find((a) => a.id === app.id);
+      return meta?.supportsRemote === true;
+    });
+  }, [openInApps, isRemote]);
+
   React.useEffect(() => {
     initializeOpenInApps();
   }, [initializeOpenInApps]);
@@ -856,6 +867,16 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
   const handleOpenInApp = React.useCallback(async (app: { id: string; appName: string }) => {
     if (!selectedFile?.path) {
+      return;
+    }
+
+    if (isRemote) {
+      const openedRemotely = await openDesktopRemoteFileInApp(selectedFile.path, app.id, app.appName);
+      if (openedRemotely) {
+        return;
+      }
+      await copyTextToClipboard(selectedFile.path);
+      toast.warning(t('openInApp.toast.remoteOpenFailed'));
       return;
     }
 
@@ -877,7 +898,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       }
     }
     toast.error(t('filesView.toast.openInAppFailed', { app: app.appName }));
-  }, [root, selectedFile?.path, t]);
+  }, [root, selectedFile?.path, t, isRemote]);
 
   const handleOpenDialog = React.useCallback((type: 'createFile' | 'createFolder' | 'rename' | 'delete', data: { path: string; name?: string; type?: 'file' | 'directory' }) => {
     setActiveDialog(type);
@@ -2829,6 +2850,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           </>
         )}
 
+        {isOpenInAppAvailable() && (displayableOpenInApps.length > 0 || openInCacheStale) && (
         <DropdownMenu onOpenChange={handleToolbarDropdownOpenChange}>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -2849,7 +2871,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             <TooltipContent side="bottom" sideOffset={6}>{t('filesView.editor.openInDesktopApp')}</TooltipContent>
           </Tooltip>
           <DropdownMenuContent align="end" className="w-56 max-h-[70vh] overflow-y-auto">
-            {openInApps.map((app) => (
+            {displayableOpenInApps.map((app) => (
               <DropdownMenuItem
                 key={app.id}
                 className="flex items-center gap-2"
@@ -2870,6 +2892,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
+        )}
 
         {!isSelectedImage && (
           <>

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -360,6 +360,115 @@ export const isDesktopLocalOriginActive = (): boolean => {
   return Boolean(currentUrl && isLoopbackHost(currentUrl.hostname));
 };
 
+export const isDesktopLoopbackOrigin = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  if (!isElectronShell()) return false;
+  const currentUrl = parseUrl(window.location.origin);
+  return Boolean(currentUrl && isLoopbackHost(currentUrl.hostname));
+};
+
+let _remoteSshCache: { value: boolean; checkedAt: number } | null = null;
+let _remoteSshPending = false;
+const REMOTE_SSH_CACHE_TTL_MS = 10_000;
+
+const _remoteSshSubscribers = new Set<() => void>();
+
+const notifyRemoteSshSubscribers = () => {
+  _remoteSshSubscribers.forEach((fn) => {
+    try { fn(); } catch {
+      // subscriber error is swallowed
+    }
+  });
+};
+
+export const subscribeRemoteSshActive = (callback: () => void): (() => void) => {
+  _remoteSshSubscribers.add(callback);
+  return () => { _remoteSshSubscribers.delete(callback); };
+};
+
+export const getRemoteSshSnapshot = (): boolean => {
+  return _remoteSshCache?.value ?? false;
+};
+
+export const isRemoteSshActive = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  if (!isDesktopShell()) return false;
+  if (isDesktopLocalOriginActive()) return false;
+
+  const currentUrl = parseUrl(window.location.origin);
+  if (!currentUrl || !isLoopbackHost(currentUrl.hostname)) {
+    _remoteSshCache = { value: false, checkedAt: Date.now() };
+    return false;
+  }
+
+  // Return cached result within TTL
+  if (_remoteSshCache && (Date.now() - _remoteSshCache.checkedAt) < REMOTE_SSH_CACHE_TTL_MS) {
+    return _remoteSshCache.value;
+  }
+
+  // Initial heuristic: a non-local loopback origin is likely an SSH
+  // tunnel. Eagerly verify against the main process; subscribers are
+  // notified on completion so React can re-render with the verified
+  // result.
+  _remoteSshCache = { value: true, checkedAt: Date.now() };
+
+  if (_remoteSshPending) {
+    return true;
+  }
+  _remoteSshPending = true;
+
+  const contextPromise = getActiveSshContext();
+  const timeoutPromise = new Promise((resolve) => {
+    setTimeout(() => resolve(null), 5000);
+  });
+
+  Promise.race([contextPromise, timeoutPromise]).then((ctx) => {
+    _remoteSshCache = { value: ctx !== null, checkedAt: Date.now() };
+    _remoteSshPending = false;
+    notifyRemoteSshSubscribers();
+  }).catch(() => {
+    _remoteSshCache = { value: false, checkedAt: Date.now() };
+    _remoteSshPending = false;
+    notifyRemoteSshSubscribers();
+  });
+
+  return true;
+};
+
+export const isOpenInAppAvailable = (): boolean => {
+  if (!isElectronShell()) return false;
+  return isDesktopLocalOriginActive() || isRemoteSshActive();
+};
+
+export type SshContext = {
+  host: string;
+  port: number;
+  instanceId: string;
+};
+
+export const getActiveSshContext = async (): Promise<SshContext | null> => {
+  if (!isElectronShell() || !isRemoteSshActive()) return null;
+
+  try {
+    const result = await invokeDesktop('desktop_get_active_ssh_info', {
+      origin: window.location.origin,
+    });
+    if (result && typeof result === 'object') {
+      const ctx = result as { host?: string; port?: number; instanceId?: string };
+      if (typeof ctx.host === 'string' && ctx.host.length > 0) {
+        return {
+          host: ctx.host,
+          port: typeof ctx.port === 'number' ? ctx.port : 22,
+          instanceId: typeof ctx.instanceId === 'string' ? ctx.instanceId : '',
+        };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
 export const isDesktopShell = (): boolean => {
   if (typeof window === 'undefined') return false;
   return isElectronShell();
@@ -731,8 +840,70 @@ export const openDesktopFileInApp = async (
   }
 };
 
+export const openDesktopRemoteProjectInApp = async (
+  projectPath: string,
+  appId: string,
+  appName: string,
+): Promise<boolean> => {
+  if (!isElectronShell() || !isRemoteSshActive()) {
+    return false;
+  }
+
+  const trimmedProjectPath = projectPath?.trim();
+  const trimmedAppId = appId?.trim();
+  const trimmedAppName = appName?.trim();
+
+  if (!trimmedProjectPath || !trimmedAppId || !trimmedAppName) {
+    return false;
+  }
+
+  try {
+    await invokeDesktop('desktop_open_remote_in_app', {
+      projectPath: trimmedProjectPath,
+      appId: trimmedAppId,
+      appName: trimmedAppName,
+      origin: window.location.origin,
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to open remote project in app', error);
+    return false;
+  }
+};
+
+export const openDesktopRemoteFileInApp = async (
+  filePath: string,
+  appId: string,
+  appName: string,
+): Promise<boolean> => {
+  if (!isElectronShell() || !isRemoteSshActive()) {
+    return false;
+  }
+
+  const trimmedFilePath = filePath?.trim();
+  const trimmedAppId = appId?.trim();
+  const trimmedAppName = appName?.trim();
+
+  if (!trimmedFilePath || !trimmedAppId || !trimmedAppName) {
+    return false;
+  }
+
+  try {
+    await invokeDesktop('desktop_open_remote_file_in_app', {
+      filePath: trimmedFilePath,
+      appId: trimmedAppId,
+      appName: trimmedAppName,
+      origin: window.location.origin,
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to open remote file in app', error);
+    return false;
+  }
+};
+
 export const filterInstalledDesktopApps = async (apps: string[]): Promise<string[]> => {
-  if (!hasDesktopInvoke() || !isDesktopLocalOriginActive()) {
+  if (!isDesktopLoopbackOrigin()) {
     return [];
   }
 
@@ -753,7 +924,7 @@ export const filterInstalledDesktopApps = async (apps: string[]): Promise<string
 };
 
 export const fetchDesktopAppIcons = async (apps: string[]): Promise<Record<string, string>> => {
-  if (!hasDesktopInvoke() || !isDesktopLocalOriginActive()) {
+  if (!isDesktopLoopbackOrigin()) {
     return {};
   }
 
@@ -772,9 +943,14 @@ export const fetchDesktopAppIcons = async (apps: string[]): Promise<Record<strin
     const map: Record<string, string> = {};
     for (const entry of result) {
       if (!entry || typeof entry !== 'object') continue;
-      const candidateEntry = entry as { app?: unknown; data_url?: unknown };
-      if (typeof candidateEntry.app !== 'string' || typeof candidateEntry.data_url !== 'string') continue;
-      map[candidateEntry.app] = candidateEntry.data_url;
+      const candidateEntry = entry as { app?: unknown; dataUrl?: unknown; data_url?: unknown };
+      const dataUrl = typeof candidateEntry.dataUrl === 'string'
+        ? candidateEntry.dataUrl
+        : typeof candidateEntry.data_url === 'string'
+          ? candidateEntry.data_url
+          : undefined;
+      if (typeof candidateEntry.app !== 'string' || typeof dataUrl !== 'string') continue;
+      map[candidateEntry.app] = dataUrl;
     }
     return map;
   } catch (error) {
@@ -799,7 +975,7 @@ export const fetchDesktopInstalledApps = async (
   apps: string[],
   force?: boolean
 ): Promise<FetchDesktopInstalledAppsResult> => {
-  if (!hasDesktopInvoke() || !isDesktopLocalOriginActive()) {
+  if (!isDesktopLoopbackOrigin()) {
     return { apps: [], success: false, hasCache: false, isCacheStale: false };
   }
 

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2128,6 +2128,7 @@ export const dict = {
   'openInApp.actions.copyPath': 'Copy Path',
   'openInApp.actions.refreshApps': 'Refresh Apps',
   'openInApp.toast.pathCopied': 'Path copied to clipboard',
+  'openInApp.toast.remoteOpenFailed': 'Failed to open remote path in app',
   'projectActions.actions.addActionAria': 'Add action',
   'projectActions.actions.addAction': 'Add action',
   'projectActions.actions.addNewAction': 'Add new action',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2094,6 +2094,7 @@ export const dict: Record<I18nKey, string> = {
   "openInApp.actions.copyPath": "Copiar ruta",
   "openInApp.actions.refreshApps": "Actualizar aplicaciones",
   "openInApp.toast.pathCopied": "Ruta copiada al portapapeles",
+  "openInApp.toast.remoteOpenFailed": "No se pudo abrir la ruta remota en la aplicación",
   "projectActions.actions.addActionAria": "Añadir acción",
   "projectActions.actions.addAction": "Añadir acción",
   "projectActions.actions.addNewAction": "Añadir nueva acción",

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2128,6 +2128,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.copyPath': '경로 복사',
   'openInApp.actions.refreshApps': '앱 새로고침',
   'openInApp.toast.pathCopied': '경로를 클립보드에 복사했습니다',
+  'openInApp.toast.remoteOpenFailed': '원격 경로를 앱에서 열 수 없습니다',
   'projectActions.actions.addActionAria': '작업 추가',
   'projectActions.actions.addAction': '작업 추가',
   'projectActions.actions.addNewAction': '새 작업 추가',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2080,6 +2080,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.openInAria': 'Otwórz w {app}',
   'openInApp.actions.refreshApps': 'Odśwież aplikacje',
   'openInApp.toast.pathCopied': 'Ścieżka skopiowana do schowka',
+  'openInApp.toast.remoteOpenFailed': 'Nie udało się otworzyć ścieżki zdalnej w aplikacji',
   'planView.actions.copyPlanContents': 'Kopiuj treść planu',
   'planView.actions.implement': 'Wdróż',
   'planView.actions.implementPlanAria': 'Wdróż plan',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2094,6 +2094,7 @@ export const dict: Record<I18nKey, string> = {
   "openInApp.actions.copyPath": "Copiar caminho",
   "openInApp.actions.refreshApps": "Atualizar aplicativos",
   "openInApp.toast.pathCopied": "Caminho copiado para a área de transferência",
+  "openInApp.toast.remoteOpenFailed": "Falha ao abrir caminho remoto no aplicativo",
   "projectActions.actions.addActionAria": "Adicionar ação",
   "projectActions.actions.addAction": "Adicionar ação",
   "projectActions.actions.addNewAction": "Adicionar nova ação",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2094,6 +2094,7 @@ export const dict: Record<I18nKey, string> = {
   "openInApp.actions.copyPath": "Копіювати шлях",
   "openInApp.actions.refreshApps": "Оновити застосунки",
   "openInApp.toast.pathCopied": "Шлях скопійовано в буфер обміну",
+  "openInApp.toast.remoteOpenFailed": "Не вдалося відкрити віддалений шлях у програмі",
   "projectActions.actions.addActionAria": "Додати дію",
   "projectActions.actions.addAction": "Додати дію",
   "projectActions.actions.addNewAction": "Додати нову дію",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2094,6 +2094,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.copyPath': '复制路径',
   'openInApp.actions.refreshApps': '刷新应用',
   'openInApp.toast.pathCopied': '路径已复制到剪贴板',
+  'openInApp.toast.remoteOpenFailed': '无法在编辑器中打开远程路径',
   'projectActions.actions.addActionAria': '添加操作',
   'projectActions.actions.addAction': '添加操作',
   'projectActions.actions.addNewAction': '添加新操作',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2098,6 +2098,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.copyPath': '複製路徑',
   'openInApp.actions.refreshApps': '重新整理應用程式',
   'openInApp.toast.pathCopied': '路徑已複製到剪貼簿',
+  'openInApp.toast.remoteOpenFailed': '無法在編輯器中開啟遠端路徑',
   'projectActions.actions.addActionAria': '新增操作',
   'projectActions.actions.addAction': '新增操作',
   'projectActions.actions.addNewAction': '新增新操作',

--- a/packages/ui/src/lib/openInApps.ts
+++ b/packages/ui/src/lib/openInApps.ts
@@ -2,32 +2,33 @@ export type OpenInApp = {
   id: string;
   label: string;
   appName: string;
+  supportsRemote: boolean;
 };
 
 export const OPEN_IN_APPS: OpenInApp[] = [
-  { id: 'finder', label: 'Finder', appName: 'Finder' },
-  { id: 'terminal', label: 'Terminal', appName: 'Terminal' },
-  { id: 'iterm2', label: 'iTerm2', appName: 'iTerm' },
-  { id: 'ghostty', label: 'Ghostty', appName: 'Ghostty' },
-  { id: 'vscode', label: 'VS Code', appName: 'Visual Studio Code' },
-  { id: 'intellij', label: 'IntelliJ', appName: 'IntelliJ IDEA' },
-  { id: 'visual-studio', label: 'Visual Studio', appName: 'Visual Studio' },
-  { id: 'cursor', label: 'Cursor', appName: 'Cursor' },
-  { id: 'android-studio', label: 'Android Studio', appName: 'Android Studio' },
-  { id: 'pycharm', label: 'PyCharm', appName: 'PyCharm' },
-  { id: 'xcode', label: 'Xcode', appName: 'Xcode' },
-  { id: 'sublime-text', label: 'Sublime', appName: 'Sublime Text' },
-  { id: 'webstorm', label: 'WebStorm', appName: 'WebStorm' },
-  { id: 'rider', label: 'Rider', appName: 'Rider' },
-  { id: 'zed', label: 'Zed', appName: 'Zed' },
-  { id: 'phpstorm', label: 'PhpStorm', appName: 'PhpStorm' },
-  { id: 'eclipse', label: 'Eclipse', appName: 'Eclipse' },
-  { id: 'windsurf', label: 'Windsurf', appName: 'Windsurf' },
-  { id: 'vscodium', label: 'VSCodium', appName: 'VSCodium' },
-  { id: 'rustrover', label: 'RustRover', appName: 'RustRover' },
-  { id: 'kiro', label: 'Kiro', appName: 'Kiro' },
-  { id: 'antigravity', label: 'Antigravity', appName: 'Antigravity' },
-  { id: 'trae', label: 'Trae', appName: 'Trae' },
+  { id: 'finder', label: 'Finder', appName: 'Finder', supportsRemote: false },
+  { id: 'terminal', label: 'Terminal', appName: 'Terminal', supportsRemote: false },
+  { id: 'iterm2', label: 'iTerm2', appName: 'iTerm', supportsRemote: false },
+  { id: 'ghostty', label: 'Ghostty', appName: 'Ghostty', supportsRemote: false },
+  { id: 'vscode', label: 'VS Code', appName: 'Visual Studio Code', supportsRemote: true },
+  { id: 'intellij', label: 'IntelliJ', appName: 'IntelliJ IDEA', supportsRemote: false },
+  { id: 'visual-studio', label: 'Visual Studio', appName: 'Visual Studio', supportsRemote: false },
+  { id: 'cursor', label: 'Cursor', appName: 'Cursor', supportsRemote: true },
+  { id: 'android-studio', label: 'Android Studio', appName: 'Android Studio', supportsRemote: false },
+  { id: 'pycharm', label: 'PyCharm', appName: 'PyCharm', supportsRemote: false },
+  { id: 'xcode', label: 'Xcode', appName: 'Xcode', supportsRemote: false },
+  { id: 'sublime-text', label: 'Sublime', appName: 'Sublime Text', supportsRemote: false },
+  { id: 'webstorm', label: 'WebStorm', appName: 'WebStorm', supportsRemote: false },
+  { id: 'rider', label: 'Rider', appName: 'Rider', supportsRemote: false },
+  { id: 'zed', label: 'Zed', appName: 'Zed', supportsRemote: false },
+  { id: 'phpstorm', label: 'PhpStorm', appName: 'PhpStorm', supportsRemote: false },
+  { id: 'eclipse', label: 'Eclipse', appName: 'Eclipse', supportsRemote: false },
+  { id: 'windsurf', label: 'Windsurf', appName: 'Windsurf', supportsRemote: true },
+  { id: 'vscodium', label: 'VSCodium', appName: 'VSCodium', supportsRemote: true },
+  { id: 'rustrover', label: 'RustRover', appName: 'RustRover', supportsRemote: false },
+  { id: 'kiro', label: 'Kiro', appName: 'Kiro', supportsRemote: false },
+  { id: 'antigravity', label: 'Antigravity', appName: 'Antigravity', supportsRemote: false },
+  { id: 'trae', label: 'Trae', appName: 'Trae', supportsRemote: false },
 ];
 
 export const DEFAULT_OPEN_IN_APP_ID = 'finder';

--- a/packages/ui/src/stores/useOpenInAppsStore.ts
+++ b/packages/ui/src/stores/useOpenInAppsStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import { fetchDesktopInstalledApps, isDesktopLocalOriginActive, isDesktopShell, type DesktopSettings, type InstalledDesktopAppInfo } from '@/lib/desktop';
+import { fetchDesktopInstalledApps, isOpenInAppAvailable, type DesktopSettings, type InstalledDesktopAppInfo } from '@/lib/desktop';
 import { OPEN_IN_APPS, DEFAULT_OPEN_IN_APP_ID, OPEN_IN_ALWAYS_AVAILABLE_APP_IDS, getOpenInAppById, getPlatformOpenInApp, type OpenInApp } from '@/lib/openInApps';
 import { updateDesktopSettings } from '@/lib/persistence';
 
@@ -86,7 +86,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
     };
 
     const loadInstalledApps = async (force?: boolean) => {
-      if (!isDesktopShell() || !isDesktopLocalOriginActive()) {
+      if (!isOpenInAppAvailable()) {
         return;
       }
 
@@ -181,6 +181,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
     };
 
     const updateHandler = (event: Event) => {
+      if (!isOpenInAppAvailable()) return;
       const detail = (event as CustomEvent<InstalledDesktopAppInfo[]>).detail;
       if (!Array.isArray(detail)) {
         return;
@@ -213,7 +214,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
       get().initialize();
     }
 
-    if (!isDesktopShell() || !isDesktopLocalOriginActive()) {
+    if (!isOpenInAppAvailable()) {
       return;
     }
 
@@ -250,7 +251,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
         (app) => allowed.has(app.appName) || OPEN_IN_ALWAYS_AVAILABLE_APP_IDS.has(app.id)
       );
       const withIcons = filtered.map((app) => ({
-        ...app,
+        ...getPlatformOpenInApp(app),
         iconDataUrl: iconMap.get(app.appName),
       }));
 


### PR DESCRIPTION
# feat: Support "Open in App" (VS Code) when connected to remote OpenCode server via SSH

Closes #1449

## Summary

When OpenChamber Desktop connects to a **remote** OpenCode server via SSH, the header "Open in App" button is now visible and functional. Clicking VS Code (or Cursor / Windsurf / VSCodium) launches the local editor with `code --remote ssh-remote+<host> <remote-path>`, opening the remote project via VS Code Remote-SSH.

## Problem

The "Open in App" button was gated by `isDesktopLocalOriginActive()` which returns `false` for remote SSH tunnel connections. This caused the entire button to render `null`:

- `packages/ui/src/components/desktop/OpenInAppButton.tsx:90-105` — hides button when origin doesn't match local
- `packages/ui/src/lib/desktop.ts:303-334` — `isDesktopLocalOriginActive()` compares current origin with the in-process server origin
- `packages/ui/src/stores/useOpenInAppsStore.ts:89-90` — skips loading installed apps for remote

**Key insight**: SSH tunnel pages have loopback origins (`127.0.0.1:<tunnel_port>`) but different ports from the in-process server. The Electron main process's `isLocalSender()` already considers them safe (loopback), so the blocking was purely at the UI layer.

## Solution

### Architecture

```
User clicks [VS Code ▼] on remote SSH instance
  →
  isRemoteSshActive()? YES
  →
  getSshInfoByOrigin(window.location.origin)
    → maps origin to SSH instance's parsed destination (e.g., "root@192.168.1.100")
  →
  code --remote ssh-remote+root@192.168.1.100 --new-window /home/user/project
```

The `--remote ssh-remote+<host>` flag format is per [VS Code official CLI documentation](https://code.visualstudio.com/docs/editor/command-line#_advanced-cli-options).

### Changes by layer

| Layer | File | Change |
|-------|------|--------|
| **Type** | `openInApps.ts` | Add `supportsRemote` flag to `OpenInApp` type; mark VS Code/Cursor/Windsurf/VSCodium |
| **UI Bridge** | `desktop.ts` | Add `isRemoteSshActive()`, `isOpenInAppAvailable()`, `isDesktopLoopbackOrigin()`; add `openDesktopRemoteProjectInApp()` / `openDesktopRemoteFileInApp()`; modify app detection guards to use `isDesktopLoopbackOrigin()` |
| **Store** | `useOpenInAppsStore.ts` | Change guard from `isDesktopLocalOriginActive` to `isDesktopLoopbackOrigin` to allow app scanning on SSH tunnels |
| **Header Button** | `OpenInAppButton.tsx` | Route remote vs local; filter non-remote editors from dropdown on remote connections |
| **Files View** | `FilesView.tsx` | Add remote routing in `handleOpenInApp`; filter dropdown by `supportsRemote` |
| **Electron Main** | `main.mjs` | Add `getSshInfoByOrigin()` helper; add 3 IPC handlers (`desktop_get_active_ssh_info`, `desktop_open_remote_in_app`, `desktop_open_remote_file_in_app`); add 4 remote spec builders (macOS/Windows × project/file) |
| **i18n** | 8 locale files | Add `openInApp.toast.remoteOpenFailed` toast string |

### Safety

- **Local connections**: Zero change — `isDesktopLocalOriginActive()` path fully preserved
- **IPC security**: All new commands are gated by the existing `isLocalSender()` check (SSH tunnel origins are loopback)
- **Remote URL connections** (non-SSH): Button stays hidden — `isRemoteSshActive()` requires a loopback origin not matching the in-process server
- **Command injection**: `spawn` uses array arguments, not shell string concatenation

### Editor support matrix

| Editor | Remote Support | Launch Command |
|--------|:---:|---|
| VS Code | ✅ | `code --remote ssh-remote+<host> <path>` |
| Cursor | ✅ | `cursor --remote ssh-remote+<host> <path>` |
| Windsurf | ✅ | `windsurf --remote ssh-remote+<host> <path>` |
| VSCodium | ✅ | `codium --remote ssh-remote+<host> <path>` |
| Zed | ❌ | Hidden in remote mode |
| JetBrains | ❌ | Hidden in remote mode (P2 follow-up for Gateway integration) |
| Finder / Terminal | ❌ | Hidden in remote mode |

## Files changed

```
packages/electron/main.mjs                         | 147 +  (IPC handlers + spec builders)
packages/ui/src/lib/desktop.ts                     | 134 +  (new functions + guard changes)
packages/ui/src/lib/openInApps.ts                  |  48 ~  (type + entries)
packages/ui/src/components/desktop/OpenInAppButton.tsx | 41 ~  (visibility + routing)
packages/ui/src/components/views/FilesView.tsx     | 25 ~   (handler + filtering)
packages/ui/src/stores/useOpenInAppsStore.ts       |  6 ~   (guard + cleanup)
packages/ui/src/lib/i18n/messages/{8 locales}.ts   |  8 +   (i18n strings)
14 files changed, 366 insertions(+), 43 deletions(-)
```

## Testing

### Local connection (regression check)
- [ ] OpenInApp button visible in header
- [ ] Dropdown shows all detected apps (Finder, Terminal, VS Code, etc.)
- [ ] Clicking VS Code opens local project: `code -n /path/to/project`
- [ ] Files view → Open in App works for individual files

### Remote SSH connection
- [ ] OpenInApp button visible in header
- [ ] Dropdown shows only remote-capable editors (VS Code, Cursor, Windsurf, VSCodium)
- [ ] Finder, Terminal, iTerm2 are hidden from dropdown
- [ ] Clicking VS Code opens remote project via `code --remote ssh-remote+<host> --new-window <remote-path>`
- [ ] If VS Code Remote-SSH host is configured, project opens correctly
- [ ] If host is not configured, error toast appears with path copied to clipboard
- [ ] Files view → Open in App → remote file opens correctly

### Remote URL (non-SSH)
- [ ] OpenInApp button stays hidden

### Edge cases
- [ ] SSH connection not yet ready — button visible but returns "SSH connection info not available" error
- [ ] Multiple windows with different SSH instances — each shows correct behavior independently
- [ ] Host switch (SSH → Local → SSH) — button state updates correctly on page reload

## Known notes

1. **VS Code must be independently configured** for the remote host. OpenChamber's SSH connection is a separate ControlMaster session; VS Code Remote-SSH needs its own `~/.ssh/config` entry or first-time connection setup for the target host.

2. **`remoteFlag` field on `OpenInApp` type** is defined but not consumed in this PR. It is reserved for future protocol expansion (e.g., JetBrains Gateway uses `ssh://` format instead of `ssh-remote+`). The `main.mjs` spec builders currently hardcode the flag.

3. **`getActiveSshContext()` async function** is exported in `desktop.ts` but not called. It is a reserved utility for future UI usage when the frontend needs to display SSH connection information directly.