### PR TITLE
feat: Added hunk reverting to comment box.

### DIFF
--- a/packages/ui/src/components/comments/InlineCommentInput.tsx
+++ b/packages/ui/src/components/comments/InlineCommentInput.tsx
@@ -15,6 +15,8 @@ export interface InlineCommentInputProps {
   isEditing?: boolean;
   className?: string;
   maxWidth?: number;
+  canRevertHunk?: boolean;
+  onRevertHunk?: () => Promise<void> | void;
 }
 
 export function InlineCommentInput({
@@ -26,12 +28,15 @@ export function InlineCommentInput({
   isEditing = false,
   className,
   maxWidth,
+  canRevertHunk = false,
+  onRevertHunk,
 }: InlineCommentInputProps) {
   const { t } = useI18n();
   const themeContext = useOptionalThemeSystem();
   const currentTheme = themeContext?.currentTheme;
   const { isMobile } = useDeviceInfo();
   const [text, setText] = React.useState(initialText);
+  const [isRevertingHunk, setIsRevertingHunk] = React.useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   
   // Stable range snapshot to prevent race with selection clearing
@@ -113,6 +118,18 @@ export function InlineCommentInput({
     }
   };
 
+  const handleRevertHunkClick = async (e: React.MouseEvent | React.TouchEvent | React.PointerEvent) => {
+    e.stopPropagation();
+    if (!onRevertHunk || isRevertingHunk) return;
+
+    setIsRevertingHunk(true);
+    try {
+      await onRevertHunk();
+    } finally {
+      setIsRevertingHunk(false);
+    }
+  };
+
   return (
     <div
       className={cn(
@@ -152,31 +169,48 @@ export function InlineCommentInput({
           className="min-h-[80px] px-3 py-2.5 text-sm resize-y"
         />
         
-        <div className="flex items-center justify-end gap-2 mt-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onCancel}
-            onPointerDown={(e) => e.stopPropagation()}
-            onTouchStart={(e) => e.stopPropagation()}
-            className="h-8 text-muted-foreground hover:text-foreground"
-          >
-            {t('inlineComment.actions.cancel')}
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleSaveClick}
-            onPointerDown={(e) => e.stopPropagation()}
-            onTouchStart={(e) => e.stopPropagation()}
-            disabled={!text.trim()}
-            className="h-8 min-w-[80px]"
-            style={{
-              backgroundColor: currentTheme?.colors?.status?.success,
-              color: currentTheme?.colors?.status?.successForeground,
-            }}
-          >
-            {isEditing ? t('inlineComment.actions.save') : t('inlineComment.actions.comment')}
-          </Button>
+        <div className="flex items-center justify-between gap-2 mt-3">
+          <div>
+            {canRevertHunk && onRevertHunk ? (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleRevertHunkClick}
+                onPointerDown={(e) => e.stopPropagation()}
+                onTouchStart={(e) => e.stopPropagation()}
+                disabled={isRevertingHunk}
+                className="h-8"
+              >
+                {isRevertingHunk ? t('inlineComment.actions.revertingHunk') : t('inlineComment.actions.revertHunk')}
+              </Button>
+            ) : null}
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onCancel}
+              onPointerDown={(e) => e.stopPropagation()}
+              onTouchStart={(e) => e.stopPropagation()}
+              className="h-8 text-muted-foreground hover:text-foreground"
+            >
+              {t('inlineComment.actions.cancel')}
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSaveClick}
+              onPointerDown={(e) => e.stopPropagation()}
+              onTouchStart={(e) => e.stopPropagation()}
+              disabled={!text.trim()}
+              className="h-8 min-w-[80px]"
+              style={{
+                backgroundColor: currentTheme?.colors?.status?.success,
+                color: currentTheme?.colors?.status?.successForeground,
+              }}
+            >
+              {isEditing ? t('inlineComment.actions.save') : t('inlineComment.actions.comment')}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/comments/PierreDiffCommentOverlays.tsx
+++ b/packages/ui/src/components/comments/PierreDiffCommentOverlays.tsx
@@ -5,6 +5,7 @@ import type { InlineCommentDraft } from '@/stores/useInlineCommentDraftStore';
 import { InlineCommentCard } from './InlineCommentCard';
 import { InlineCommentInput } from './InlineCommentInput';
 import { toPierreAnnotationId } from './PierreDiffCommentUtils';
+import { findRevertHunkActionForSelection, type RevertHunkAction } from '@/lib/gitDiffHunks';
 
 interface PierreDiffCommentOverlaysProps {
   diffRootRef: React.RefObject<HTMLDivElement | null>;
@@ -17,6 +18,8 @@ interface PierreDiffCommentOverlaysProps {
   onCancel: () => void;
   onEdit: (draft: InlineCommentDraft) => void;
   onDelete: (draft: InlineCommentDraft) => void;
+  hunkActions?: RevertHunkAction[];
+  onRevertHunk?: (action: RevertHunkAction) => Promise<void> | void;
 }
 
 function parseCssWidth(value: string): number | null {
@@ -53,6 +56,8 @@ export function PierreDiffCommentOverlays(props: PierreDiffCommentOverlaysProps)
     onCancel,
     onEdit,
     onDelete,
+    hunkActions = [],
+    onRevertHunk,
   } = props;
 
   const [retryTick, setRetryTick] = React.useState(0);
@@ -166,6 +171,11 @@ export function PierreDiffCommentOverlays(props: PierreDiffCommentOverlaysProps)
 
   void retryTick;
 
+  const selectedHunkAction = React.useMemo(
+    () => findRevertHunkActionForSelection(hunkActions, selection),
+    [hunkActions, selection]
+  );
+
   return (
     <>
       {drafts.map((draft) => {
@@ -220,6 +230,8 @@ export function PierreDiffCommentOverlays(props: PierreDiffCommentOverlaysProps)
             onSave={onSave}
             onCancel={onCancel}
             maxWidth={targetMaxWidth}
+            canRevertHunk={Boolean(selectedHunkAction && onRevertHunk)}
+            onRevertHunk={selectedHunkAction && onRevertHunk ? () => onRevertHunk(selectedHunkAction) : undefined}
           />,
           target,
           selectionAnnotationId

--- a/packages/ui/src/components/views/DiffView.tsx
+++ b/packages/ui/src/components/views/DiffView.tsx
@@ -31,6 +31,7 @@ import { toAbsoluteFilePath } from '@/lib/path-utils';
 import { sessionEvents } from '@/lib/sessionEvents';
 import { useI18n } from '@/lib/i18n';
 import type { I18nKey } from '@/lib/i18n/store';
+import { buildRevertHunkActions, type RevertHunkAction } from '@/lib/gitDiffHunks';
 
 // Minimum width for side-by-side diff view (px)
 const SIDE_BY_SIDE_MIN_WIDTH = 1100;
@@ -52,7 +53,7 @@ type FileEntry = GitStatus['files'][number] & {
     isNew: boolean;
 };
 
-type DiffData = { original: string; modified: string; isBinary?: boolean };
+type DiffData = { original: string; modified: string; isBinary?: boolean; hunkPatch?: string };
 type DiffScope = 'all' | 'staged' | 'working';
 
 const BinaryDiffPlaceholder = React.memo(() => {
@@ -502,6 +503,8 @@ interface InlineDiffViewerProps {
     diff: DiffData;
     renderSideBySide: boolean;
     wrapLines: boolean;
+    hunkActions?: RevertHunkAction[];
+    onRevertHunk?: (action: RevertHunkAction) => Promise<void> | void;
 }
 
 const InlineDiffViewer = React.memo<InlineDiffViewerProps>(({ 
@@ -509,6 +512,8 @@ const InlineDiffViewer = React.memo<InlineDiffViewerProps>(({
     diff,
     renderSideBySide,
     wrapLines,
+    hunkActions,
+    onRevertHunk,
 }) => {
     const language = React.useMemo(
         () => getLanguageFromExtension(filePath) || 'text',
@@ -539,6 +544,8 @@ const InlineDiffViewer = React.memo<InlineDiffViewerProps>(({
                 renderSideBySide={renderSideBySide}
                 wrapLines={wrapLines}
                 layout="inline"
+                hunkActions={hunkActions}
+                onRevertHunk={onRevertHunk}
             />
         </div>
     );
@@ -551,6 +558,8 @@ interface SingleDiffViewerProps {
     isVisible: boolean;
     renderSideBySide: boolean;
     wrapLines: boolean;
+    hunkActions?: RevertHunkAction[];
+    onRevertHunk?: (action: RevertHunkAction) => Promise<void> | void;
 }
 
 const SingleDiffViewer = React.memo<SingleDiffViewerProps>(({ 
@@ -559,6 +568,8 @@ const SingleDiffViewer = React.memo<SingleDiffViewerProps>(({
     isVisible,
     renderSideBySide,
     wrapLines,
+    hunkActions,
+    onRevertHunk,
 }) => {
     const language = React.useMemo(
         () => getLanguageFromExtension(filePath) || 'text',
@@ -603,6 +614,8 @@ const SingleDiffViewer = React.memo<SingleDiffViewerProps>(({
                 renderSideBySide={renderSideBySide}
                 wrapLines={wrapLines}
                 layout="inline"
+                hunkActions={hunkActions}
+                onRevertHunk={onRevertHunk}
             />
         </ScrollableOverlay>
     );
@@ -654,6 +667,9 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
         }, [directory, file.path])
     );
     const setDiff = useGitStore((state) => state.setDiff);
+    const clearDiffCache = useGitStore((state) => state.clearDiffCache);
+    const fetchStatus = useGitStore((state) => state.fetchStatus);
+    const bumpIndexRevision = useGitStore((state) => state.bumpIndexRevision);
     const setDiffFileLayout = useUIStore((state) => state.setDiffFileLayout);
 
     const [isExpanded, setIsExpanded] = React.useState(!defaultCollapsed);
@@ -663,6 +679,7 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
     const [isLoading, setIsLoading] = React.useState(false);
     const [forceRenderLarge, setForceRenderLarge] = React.useState(false);
     const [stagedDiffData, setStagedDiffData] = React.useState<DiffData | null>(null);
+    const [hunkActions, setHunkActions] = React.useState<RevertHunkAction[]>([]);
     const lastDiffRequestRef = React.useRef<string | null>(null);
     const sectionRef = React.useRef<HTMLDivElement | null>(null);
 
@@ -672,8 +689,22 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
     const diffData = React.useMemo<DiffData | null>(() => {
         if (staged) return stagedDiffData;
         if (!cachedDiff) return null;
-        return { original: cachedDiff.original, modified: cachedDiff.modified, isBinary: cachedDiff.isBinary };
+        return {
+            original: cachedDiff.original,
+            modified: cachedDiff.modified,
+            isBinary: cachedDiff.isBinary,
+            hunkPatch: cachedDiff.hunkPatch,
+        };
     }, [cachedDiff, staged, stagedDiffData]);
+
+    React.useEffect(() => {
+        if (!diffData || diffData.isBinary || !diffData.hunkPatch) {
+            setHunkActions([]);
+            return;
+        }
+
+        setHunkActions(buildRevertHunkActions(file.path, diffData.hunkPatch));
+    }, [diffData, file.path]);
 
     const setSectionRef = React.useCallback((node: HTMLDivElement | null) => {
         sectionRef.current = node;
@@ -730,13 +761,33 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
         }
 
         setStagedDiffData(null);
+        setHunkActions([]);
         setDiffLoadError(null);
         lastDiffRequestRef.current = null;
     }, [staged, stagedRevision]);
 
+    const handleRevertHunk = React.useCallback(async (action: RevertHunkAction) => {
+        try {
+            await git.revertGitHunk(directory, {
+                path: file.path,
+                staged,
+                patch: action.patch,
+            });
+            clearDiffCache(directory);
+            setHunkActions([]);
+            if (staged) {
+                setStagedDiffData(null);
+                bumpIndexRevision(directory);
+            }
+            await fetchStatus(directory, git);
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : t('gitView.toast.revertFailed'));
+        }
+    }, [bumpIndexRevision, clearDiffCache, directory, fetchStatus, file.path, git, staged, t]);
+
     React.useEffect(() => {
         if (!isExpanded || !hasBeenVisible) return;
-        if (!directory || diffData) {
+        if (!directory || (diffData && (diffData.isBinary || diffData.hunkPatch))) {
             lastDiffRequestRef.current = null;
             setIsLoading(false);
             return;
@@ -751,7 +802,7 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
         setIsLoading(true);
 
         let cancelled = false;
-        const fetchPromise = git.getGitFileDiff(directory, { path: file.path, staged });
+        const fetchPromise = git.getGitFileDiff(directory, { path: file.path, staged, includeHunkPatch: true });
         const timeoutMs = DIFF_REQUEST_TIMEOUT_MS;
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
@@ -765,6 +816,7 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
                     original: response.original ?? '',
                     modified: response.modified ?? '',
                     isBinary: response.isBinary,
+                    hunkPatch: response.hunkPatch,
                 };
                 if (staged) {
                     setStagedDiffData(nextDiff);
@@ -945,6 +997,8 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
                             diff={diffData}
                             renderSideBySide={renderSideBySide}
                             wrapLines={wrapLines}
+                            hunkActions={hunkActions}
+                            onRevertHunk={handleRevertHunk}
                         />
                     ) : null}
                 </div>
@@ -984,6 +1038,8 @@ export const DiffView: React.FC<DiffViewProps> = ({
     const ensureStatus = useGitStore((state) => state.ensureStatus);
     const fetchStatus = useGitStore((state) => state.fetchStatus);
     const setDiff = useGitStore((state) => state.setDiff);
+    const clearDiffCache = useGitStore((state) => state.clearDiffCache);
+    const bumpIndexRevision = useGitStore((state) => state.bumpIndexRevision);
     const indexRevision = useGitStore(React.useCallback((state) => {
         if (!effectiveDirectory) return 0;
         return state.directories.get(effectiveDirectory)?.indexRevision ?? 0;
@@ -997,6 +1053,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
     const [pinnedStackedTarget, setPinnedStackedTarget] = React.useState<string | null>(null);
     const [diffRetryNonce, setDiffRetryNonce] = React.useState(0);
     const [diffLoadError, setDiffLoadError] = React.useState<string | null>(null);
+    const [selectedHunkActions, setSelectedHunkActions] = React.useState<RevertHunkAction[]>([]);
     const lastDiffRequestRef = React.useRef<string | null>(null);
 
     const pendingDiffFile = useUIStore((state) => state.pendingDiffFile);
@@ -1496,8 +1553,43 @@ export const DiffView: React.FC<DiffViewProps> = ({
     const selectedDiffData = React.useMemo<DiffData | null>(() => {
         if (activeDiffStaged) return selectedStagedDiffData;
         if (!selectedCachedDiff) return null;
-        return { original: selectedCachedDiff.original, modified: selectedCachedDiff.modified, isBinary: selectedCachedDiff.isBinary };
+        return {
+            original: selectedCachedDiff.original,
+            modified: selectedCachedDiff.modified,
+            isBinary: selectedCachedDiff.isBinary,
+            hunkPatch: selectedCachedDiff.hunkPatch,
+        };
     }, [activeDiffStaged, selectedCachedDiff, selectedStagedDiffData]);
+
+    React.useEffect(() => {
+        if (isStackedView || !selectedFile || !selectedDiffData || selectedDiffData.isBinary || !selectedDiffData.hunkPatch) {
+            setSelectedHunkActions([]);
+            return;
+        }
+
+        setSelectedHunkActions(buildRevertHunkActions(selectedFile, selectedDiffData.hunkPatch));
+    }, [isStackedView, selectedDiffData, selectedFile]);
+
+    const handleSelectedRevertHunk = React.useCallback(async (action: RevertHunkAction) => {
+        if (!effectiveDirectory || !selectedFile) return;
+
+        try {
+            await git.revertGitHunk(effectiveDirectory, {
+                path: selectedFile,
+                staged: activeDiffStaged,
+                patch: action.patch,
+            });
+            clearDiffCache(effectiveDirectory);
+            setSelectedHunkActions([]);
+            if (activeDiffStaged) {
+                setSelectedStagedDiffData(null);
+                bumpIndexRevision(effectiveDirectory);
+            }
+            await fetchStatus(effectiveDirectory, git);
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : t('gitView.toast.revertFailed'));
+        }
+    }, [activeDiffStaged, bumpIndexRevision, clearDiffCache, effectiveDirectory, fetchStatus, git, selectedFile, t]);
 
     const [openingEditorFilePath, setOpeningEditorFilePath] = React.useState<string | null>(null);
 
@@ -1587,7 +1679,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
             return;
         }
 
-        if (activeDiffStaged ? selectedStagedDiffData : selectedCachedDiff) {
+        if (selectedDiffData && (selectedDiffData.isBinary || selectedDiffData.hunkPatch)) {
             lastDiffRequestRef.current = null;
             return;
         }
@@ -1599,7 +1691,11 @@ export const DiffView: React.FC<DiffViewProps> = ({
         lastDiffRequestRef.current = requestKey;
 
         let cancelled = false;
-        const fetchPromise = git.getGitFileDiff(effectiveDirectory, { path: selectedFile, staged: activeDiffStaged });
+        const fetchPromise = git.getGitFileDiff(effectiveDirectory, {
+            path: selectedFile,
+            staged: activeDiffStaged,
+            includeHunkPatch: true,
+        });
         const timeoutMs = DIFF_REQUEST_TIMEOUT_MS;
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
@@ -1613,6 +1709,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
                     original: response.original ?? '',
                     modified: response.modified ?? '',
                     isBinary: response.isBinary,
+                    hunkPatch: response.hunkPatch,
                 };
                 if (activeDiffStaged) {
                     setSelectedStagedDiffData(nextDiff);
@@ -1633,7 +1730,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
                 lastDiffRequestRef.current = null;
             }
         };
-    }, [activeDiffStaged, effectiveDirectory, indexRevision, isStackedView, selectedFile, selectedCachedDiff, selectedStagedDiffData, git, setDiff, diffRetryNonce]);
+    }, [activeDiffStaged, effectiveDirectory, indexRevision, isStackedView, selectedDiffData, selectedFile, git, setDiff, diffRetryNonce]);
 
     // Render only the selected diff viewer to prevent memory bloat with many files
     const renderSelectedDiffViewer = () => {
@@ -1647,6 +1744,8 @@ export const DiffView: React.FC<DiffViewProps> = ({
                 isVisible={true}
                 renderSideBySide={renderSideBySide}
                 wrapLines={diffWrapLines}
+                hunkActions={selectedHunkActions}
+                onRevertHunk={handleSelectedRevertHunk}
             />
         );
     };

--- a/packages/ui/src/components/views/DiffView.tsx
+++ b/packages/ui/src/components/views/DiffView.tsx
@@ -667,7 +667,7 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
         }, [directory, file.path])
     );
     const setDiff = useGitStore((state) => state.setDiff);
-    const clearDiffCache = useGitStore((state) => state.clearDiffCache);
+    const clearDiffCacheEntry = useGitStore((state) => state.clearDiffCacheEntry);
     const fetchStatus = useGitStore((state) => state.fetchStatus);
     const bumpIndexRevision = useGitStore((state) => state.bumpIndexRevision);
     const setDiffFileLayout = useUIStore((state) => state.setDiffFileLayout);
@@ -773,7 +773,7 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
                 staged,
                 patch: action.patch,
             });
-            clearDiffCache(directory);
+            clearDiffCacheEntry(directory, file.path);
             setHunkActions([]);
             if (staged) {
                 setStagedDiffData(null);
@@ -783,7 +783,7 @@ const MultiFileDiffEntry = React.memo<MultiFileDiffEntryProps>(({
         } catch (error) {
             toast.error(error instanceof Error ? error.message : t('gitView.toast.revertFailed'));
         }
-    }, [bumpIndexRevision, clearDiffCache, directory, fetchStatus, file.path, git, staged, t]);
+    }, [bumpIndexRevision, clearDiffCacheEntry, directory, fetchStatus, file.path, git, staged, t]);
 
     React.useEffect(() => {
         if (!isExpanded || !hasBeenVisible) return;
@@ -1038,7 +1038,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
     const ensureStatus = useGitStore((state) => state.ensureStatus);
     const fetchStatus = useGitStore((state) => state.fetchStatus);
     const setDiff = useGitStore((state) => state.setDiff);
-    const clearDiffCache = useGitStore((state) => state.clearDiffCache);
+    const clearDiffCacheEntry = useGitStore((state) => state.clearDiffCacheEntry);
     const bumpIndexRevision = useGitStore((state) => state.bumpIndexRevision);
     const indexRevision = useGitStore(React.useCallback((state) => {
         if (!effectiveDirectory) return 0;
@@ -1579,7 +1579,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
                 staged: activeDiffStaged,
                 patch: action.patch,
             });
-            clearDiffCache(effectiveDirectory);
+            clearDiffCacheEntry(effectiveDirectory, selectedFile);
             setSelectedHunkActions([]);
             if (activeDiffStaged) {
                 setSelectedStagedDiffData(null);
@@ -1589,7 +1589,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
         } catch (error) {
             toast.error(error instanceof Error ? error.message : t('gitView.toast.revertFailed'));
         }
-    }, [activeDiffStaged, bumpIndexRevision, clearDiffCache, effectiveDirectory, fetchStatus, git, selectedFile, t]);
+    }, [activeDiffStaged, bumpIndexRevision, clearDiffCacheEntry, effectiveDirectory, fetchStatus, git, selectedFile, t]);
 
     const [openingEditorFilePath, setOpeningEditorFilePath] = React.useState<string | null>(null);
 

--- a/packages/ui/src/components/views/PierreDiffViewer.tsx
+++ b/packages/ui/src/components/views/PierreDiffViewer.tsx
@@ -26,6 +26,7 @@ import { getDefaultTheme } from '@/lib/theme/themes';
 
 import { useDeviceInfo } from '@/lib/device';
 import { cn } from '@/lib/utils';
+import type { RevertHunkAction } from '@/lib/gitDiffHunks';
 
 
 // Threshold (bytes) above which syntax highlighting is degraded for performance
@@ -39,6 +40,8 @@ interface PierreDiffViewerProps {
   renderSideBySide: boolean;
   wrapLines?: boolean;
   layout?: 'fill' | 'inline';
+  hunkActions?: RevertHunkAction[];
+  onRevertHunk?: (action: RevertHunkAction) => Promise<void> | void;
 }
 
 /**
@@ -212,6 +215,8 @@ export const PierreDiffViewer: React.FC<PierreDiffViewerProps> = ({
   renderSideBySide,
   wrapLines,
   layout = 'fill',
+  hunkActions,
+  onRevertHunk,
 }) => {
   const themeContext = useOptionalThemeSystem();
 
@@ -727,6 +732,8 @@ export const PierreDiffViewer: React.FC<PierreDiffViewerProps> = ({
         startEdit(draft);
       }}
       onDelete={deleteDraft}
+      hunkActions={hunkActions}
+      onRevertHunk={onRevertHunk}
     />
   );
 

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -153,16 +153,24 @@ export interface GetGitDiffOptions {
   contextLines?: number;
 }
 
+export interface RevertGitHunkPayload {
+  path: string;
+  staged?: boolean;
+  patch: string;
+}
+
 export interface GitFileDiffResponse {
   original: string;
   modified: string;
   path: string;
   isBinary?: boolean;
+  hunkPatch?: string;
 }
 
 export interface GetGitFileDiffOptions {
   path: string;
   staged?: boolean;
+  includeHunkPatch?: boolean;
 }
 
 export interface GitBranchDetails {
@@ -469,6 +477,7 @@ export interface GitAPI {
   getGitDiff(directory: string, options: GetGitDiffOptions): Promise<GitDiffResponse>;
   getGitFileDiff(directory: string, options: GetGitFileDiffOptions): Promise<GitFileDiffResponse>;
   revertGitFile(directory: string, filePath: string, options?: { scope?: 'all' | 'working' }): Promise<void>;
+  revertGitHunk(directory: string, payload: RevertGitHunkPayload): Promise<void>;
   stageGitFile(directory: string, filePath: string): Promise<void>;
   stageGitFiles?(directory: string, filePaths: string[]): Promise<void>;
   unstageGitFile(directory: string, filePath: string): Promise<void>;

--- a/packages/ui/src/lib/gitApi.test.ts
+++ b/packages/ui/src/lib/gitApi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { GitAPI, GitStatus } from "./api/types"
-import { getGitStatus, stageGitFile, stageGitFiles, unstageGitFile, unstageGitFiles } from "./gitApi"
+import { getGitStatus, revertGitHunk, stageGitFile, stageGitFiles, unstageGitFile, unstageGitFiles } from "./gitApi"
 
 const status: GitStatus = {
   current: "main",
@@ -108,5 +108,20 @@ describe("git index mutations", () => {
     })
 
     expect(received).toEqual({ directory: "/repo", path: "a.ts" })
+  })
+
+  test("forwards hunk revert requests to runtime git APIs", async () => {
+    let received: { directory: string; path: string; staged?: boolean; patch: string } | null = null
+    const runtimeGit = {
+      revertGitHunk: async (directory: string, payload: { path: string; staged?: boolean; patch: string }) => {
+        received = { directory, ...payload }
+      },
+    } as Partial<GitAPI> as GitAPI
+
+    await withRuntimeGit(runtimeGit, async () => {
+      await revertGitHunk("/repo", { path: "a.ts", staged: true, patch: "patch" })
+    })
+
+    expect(received).toEqual({ directory: "/repo", path: "a.ts", staged: true, patch: "patch" })
   })
 })

--- a/packages/ui/src/lib/gitApi.ts
+++ b/packages/ui/src/lib/gitApi.ts
@@ -1,4 +1,4 @@
-
+import type { RevertGitHunkPayload } from './api/types';
 import * as gitHttp from './gitApiHttp';
 import { opencodeClient } from './opencode/client';
 import { renderMagicPrompt } from './magicPrompts';
@@ -36,6 +36,7 @@ export type {
   GitRebaseResult,
   MergeConflictDetails,
   CommitFileDiffResponse,
+  RevertGitHunkPayload,
 } from './api/types';
 
 const getRuntimeGit = () => {
@@ -124,6 +125,12 @@ export async function revertGitFile(
   const runtime = getRuntimeGit();
   if (runtime) return runtime.revertGitFile(directory, filePath, options);
   return gitHttp.revertGitFile(directory, filePath, options);
+}
+
+export async function revertGitHunk(directory: string, payload: RevertGitHunkPayload): Promise<void> {
+  const runtime = getRuntimeGit();
+  if (runtime) return runtime.revertGitHunk(directory, payload);
+  return gitHttp.revertGitHunk(directory, payload);
 }
 
 export async function stageGitFile(directory: string, filePath: string): Promise<void> {

--- a/packages/ui/src/lib/gitApiHttp.test.ts
+++ b/packages/ui/src/lib/gitApiHttp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { stageGitFile, stageGitFiles, unstageGitFile, unstageGitFiles } from './gitApiHttp';
+import { getGitFileDiff, revertGitHunk, stageGitFile, stageGitFiles, unstageGitFile, unstageGitFiles } from './gitApiHttp';
 
 type FetchCall = {
   input: RequestInfo | URL;
@@ -105,6 +105,44 @@ describe('gitApiHttp index mutations', () => {
       expect(unstageError).toBeInstanceOf(Error);
       expect((unstageError as Error).message).toBe('path is required to unstage git changes');
       expect(calls).toHaveLength(0);
+    } finally {
+      restoreMocks();
+    }
+  });
+
+  test('sends hunk revert payloads', async () => {
+    installWindowMock();
+    const calls = installFetchMock();
+    try {
+      await revertGitHunk('/repo', {
+        path: 'src/file.ts',
+        staged: true,
+        patch: 'diff --git a/src/file.ts b/src/file.ts\n',
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(String(calls[0].input)).toBe('http://localhost:3000/api/git/revert-hunk?directory=%2Frepo');
+      expect(calls[0].init?.method).toBe('POST');
+      expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+        path: 'src/file.ts',
+        staged: true,
+        patch: 'diff --git a/src/file.ts b/src/file.ts\n',
+      });
+    } finally {
+      restoreMocks();
+    }
+  });
+
+  test('requests file diff hunk patches when needed', async () => {
+    installWindowMock();
+    const calls = installFetchMock();
+    try {
+      await getGitFileDiff('/repo', { path: 'src/file.ts', staged: true, includeHunkPatch: true });
+
+      expect(calls).toHaveLength(1);
+      expect(String(calls[0].input)).toBe(
+        'http://localhost:3000/api/git/file-diff?directory=%2Frepo&path=src%2Ffile.ts&staged=true&hunkPatch=true'
+      );
     } finally {
       restoreMocks();
     }

--- a/packages/ui/src/lib/gitApiHttp.ts
+++ b/packages/ui/src/lib/gitApiHttp.ts
@@ -34,6 +34,7 @@ import type {
   CherryPickResponse,
   RevertCommitResponse,
   ResetToCommitResponse,
+  RevertGitHunkPayload,
 } from './api/types';
 import { runtimeFetch } from './runtime-fetch';
 import { getRuntimeUrlResolver } from './runtime-url';
@@ -155,7 +156,7 @@ export async function getGitDiff(directory: string, options: GetGitDiffOptions):
 }
 
 export async function getGitFileDiff(directory: string, options: GetGitFileDiffOptions): Promise<GitFileDiffResponse> {
-  const { path, staged } = options;
+  const { path, staged, includeHunkPatch } = options;
   if (!path) {
     throw new Error('path is required to fetch git file diff');
   }
@@ -164,6 +165,7 @@ export async function getGitFileDiff(directory: string, options: GetGitFileDiffO
     buildUrl(`${API_BASE}/file-diff`, directory, {
       path,
       staged: staged ? 'true' : undefined,
+      hunkPatch: includeHunkPatch ? 'true' : undefined,
     })
   );
 
@@ -194,6 +196,29 @@ export async function revertGitFile(
       .json()
       .catch(() => ({ error: response.statusText }));
     throw new Error(message.error || 'Failed to revert git changes');
+  }
+}
+
+export async function revertGitHunk(directory: string, payload: RevertGitHunkPayload): Promise<void> {
+  const path = payload.path.trim();
+  if (!path) {
+    throw new Error('path is required to revert git hunk');
+  }
+  if (!payload.patch.trim()) {
+    throw new Error('patch is required to revert git hunk');
+  }
+
+  const response = await fetch(buildUrl(`${API_BASE}/revert-hunk`, directory), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path, staged: Boolean(payload.staged), patch: payload.patch }),
+  });
+
+  if (!response.ok) {
+    const message = await response
+      .json()
+      .catch(() => ({ error: response.statusText }));
+    throw new Error(message.error || 'Failed to revert git hunk');
   }
 }
 

--- a/packages/ui/src/lib/gitDiffHunks.test.ts
+++ b/packages/ui/src/lib/gitDiffHunks.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { buildRevertHunkActions, findRevertHunkActionForSelection } from './gitDiffHunks';
+
+const patch = `diff --git a/src/file.ts b/src/file.ts
+index 1111111..2222222 100644
+--- a/src/file.ts
++++ b/src/file.ts
+@@ -2,2 +2,2 @@
+-oldA
+-oldB
++newA
++newB
+@@ -8,1 +8,2 @@
+-oldC
++newC
++newD
+`;
+
+describe('git diff hunk actions', () => {
+  test('builds one reverse-apply patch per hunk', () => {
+    const actions = buildRevertHunkActions('src/file.ts', patch);
+
+    expect(actions).toHaveLength(2);
+    expect(actions[0].oldRange).toEqual({ start: 2, end: 3 });
+    expect(actions[0].newRange).toEqual({ start: 2, end: 3 });
+    expect(actions[0].patch).toContain('--- a/src/file.ts');
+    expect(actions[0].patch).toContain('@@ -2,2 +2,2 @@');
+    expect(actions[0].patch).not.toContain('@@ -8,1 +8,2 @@');
+    expect(actions[1].oldRange).toEqual({ start: 8, end: 8 });
+    expect(actions[1].newRange).toEqual({ start: 8, end: 9 });
+  });
+
+  test('matches additions selections against new hunk ranges', () => {
+    const actions = buildRevertHunkActions('src/file.ts', patch);
+
+    const action = findRevertHunkActionForSelection(actions, {
+      start: 9,
+      end: 9,
+      side: 'additions',
+    });
+
+    expect(action).toBe(actions[1]);
+  });
+
+  test('matches deletions selections against old hunk ranges', () => {
+    const actions = buildRevertHunkActions('src/file.ts', patch);
+
+    const action = findRevertHunkActionForSelection(actions, {
+      start: 3,
+      end: 3,
+      side: 'deletions',
+    });
+
+    expect(action).toBe(actions[0]);
+  });
+
+  test('does not match selections outside changed hunk ranges', () => {
+    const actions = buildRevertHunkActions('src/file.ts', patch);
+
+    expect(findRevertHunkActionForSelection(actions, {
+      start: 20,
+      end: 20,
+      side: 'additions',
+    })).toBeNull();
+  });
+});

--- a/packages/ui/src/lib/gitDiffHunks.ts
+++ b/packages/ui/src/lib/gitDiffHunks.ts
@@ -1,0 +1,115 @@
+export type DiffSelectionSide = 'additions' | 'deletions';
+
+export interface DiffLineRange {
+  start: number;
+  end: number;
+}
+
+export interface RevertHunkAction {
+  path: string;
+  oldRange: DiffLineRange | null;
+  newRange: DiffLineRange | null;
+  patch: string;
+}
+
+interface HunkHeader {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+}
+
+const HUNK_HEADER_PATTERN = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/;
+
+const parseCount = (value: string | undefined): number => {
+  if (value === undefined) return 1;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1;
+};
+
+const parseHunkHeader = (line: string): HunkHeader | null => {
+  const match = line.match(HUNK_HEADER_PATTERN);
+  if (!match) return null;
+
+  const oldStart = Number.parseInt(match[1], 10);
+  const newStart = Number.parseInt(match[3], 10);
+  if (!Number.isFinite(oldStart) || !Number.isFinite(newStart)) return null;
+
+  return {
+    oldStart,
+    oldCount: parseCount(match[2]),
+    newStart,
+    newCount: parseCount(match[4]),
+  };
+};
+
+const toRange = (start: number, count: number): DiffLineRange | null => {
+  if (count <= 0) return null;
+  return { start, end: start + count - 1 };
+};
+
+const rangesIntersect = (left: DiffLineRange, right: DiffLineRange): boolean =>
+  left.start <= right.end && right.start <= left.end;
+
+const normalizeSelectionRange = (selection: { start: number; end: number }): DiffLineRange => ({
+  start: Math.min(selection.start, selection.end),
+  end: Math.max(selection.start, selection.end),
+});
+
+export const buildRevertHunkActions = (path: string, patch: string): RevertHunkAction[] => {
+  const trimmedPath = path.trim();
+  if (!trimmedPath || !patch.trim()) return [];
+
+  const lines = patch.replace(/\r\n/g, '\n').split('\n');
+  const firstHunkIndex = lines.findIndex(line => line.startsWith('@@ '));
+  if (firstHunkIndex < 0) return [];
+
+  const fileHeader = lines.slice(0, firstHunkIndex);
+  const actions: RevertHunkAction[] = [];
+  let index = firstHunkIndex;
+
+  while (index < lines.length) {
+    const header = parseHunkHeader(lines[index]);
+    if (!header) {
+      index += 1;
+      continue;
+    }
+
+    const hunkLines = [lines[index]];
+    index += 1;
+
+    while (index < lines.length && !lines[index].startsWith('@@ ')) {
+      hunkLines.push(lines[index]);
+      index += 1;
+    }
+
+    const hunkPatch = [...fileHeader, ...hunkLines].join('\n');
+    actions.push({
+      path: trimmedPath,
+      oldRange: toRange(header.oldStart, header.oldCount),
+      newRange: toRange(header.newStart, header.newCount),
+      patch: hunkPatch.endsWith('\n') ? hunkPatch : `${hunkPatch}\n`,
+    });
+  }
+
+  return actions;
+};
+
+export const findRevertHunkActionForSelection = (
+  actions: RevertHunkAction[],
+  selection: { start: number; end: number; side?: DiffSelectionSide } | null,
+): RevertHunkAction | null => {
+  if (!selection) return null;
+
+  const selectedRange = normalizeSelectionRange(selection);
+  const side = selection.side ?? 'additions';
+
+  for (const action of actions) {
+    const actionRange = side === 'deletions' ? action.oldRange : action.newRange;
+    if (actionRange && rangesIntersect(selectedRange, actionRange)) {
+      return action;
+    }
+  }
+
+  return null;
+};

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1256,6 +1256,8 @@ export const dict = {
   'inlineComment.actions.cancel': 'Cancel',
   'inlineComment.actions.save': 'Save',
   'inlineComment.actions.comment': 'Comment',
+  'inlineComment.actions.revertHunk': 'Revert Hunk',
+  'inlineComment.actions.revertingHunk': 'Reverting...',
   'inlineComment.actions.showLess': 'Show less',
   'inlineComment.actions.showMore': 'Show more',
   'inlineComment.actions.editComment': 'Edit comment',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1222,6 +1222,8 @@ export const dict: Record<I18nKey, string> = {
   "inlineComment.actions.cancel": "Cancelar",
   "inlineComment.actions.save": "Guardar",
   "inlineComment.actions.comment": "Comentar",
+  "inlineComment.actions.revertHunk": "Revertir fragmento",
+  "inlineComment.actions.revertingHunk": "Revirtiendo...",
   "inlineComment.actions.showLess": "Mostrar menos",
   "inlineComment.actions.showMore": "Mostrar más",
   "inlineComment.actions.editComment": "Editar comentario",

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1259,6 +1259,8 @@ export const dict: Record<I18nKey, string> = {
   'inlineComment.actions.cancel': '취소',
   'inlineComment.actions.save': '저장',
   'inlineComment.actions.comment': '댓글',
+  'inlineComment.actions.revertHunk': '헝크 되돌리기',
+  'inlineComment.actions.revertingHunk': '되돌리는 중...',
   'inlineComment.actions.showLess': '간단히 보기',
   'inlineComment.actions.showMore': '더 보기',
   'inlineComment.actions.editComment': '편집 댓글',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2020,6 +2020,8 @@ export const dict: Record<I18nKey, string> = {
   'inlineComment.actions.comment': 'Comment',
   'inlineComment.actions.deleteComment': 'Delete comment',
   'inlineComment.actions.editComment': 'Edit comment',
+  'inlineComment.actions.revertHunk': 'Revert Hunk',
+  'inlineComment.actions.revertingHunk': 'Reverting...',
   'inlineComment.actions.save': 'Zapisz',
   'inlineComment.actions.showLess': 'Show less',
   'inlineComment.actions.showMore': 'Show more',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1222,6 +1222,8 @@ export const dict: Record<I18nKey, string> = {
   "inlineComment.actions.cancel": "Cancelar",
   "inlineComment.actions.save": "Salvar",
   "inlineComment.actions.comment": "Comentar",
+  "inlineComment.actions.revertHunk": "Reverter trecho",
+  "inlineComment.actions.revertingHunk": "Revertendo...",
   "inlineComment.actions.showLess": "Mostrar menos",
   "inlineComment.actions.showMore": "Mostrar mais",
   "inlineComment.actions.editComment": "Editar comentário",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1222,6 +1222,8 @@ export const dict: Record<I18nKey, string> = {
   "inlineComment.actions.cancel": "Скасувати",
   "inlineComment.actions.save": "Зберегти",
   "inlineComment.actions.comment": "Коментар",
+  "inlineComment.actions.revertHunk": "Скасувати фрагмент",
+  "inlineComment.actions.revertingHunk": "Скасування...",
   "inlineComment.actions.showLess": "Показувати менше",
   "inlineComment.actions.showMore": "Показати більше",
   "inlineComment.actions.editComment": "Редагувати коментар",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1222,6 +1222,8 @@ export const dict: Record<I18nKey, string> = {
   'inlineComment.actions.cancel': '取消',
   'inlineComment.actions.save': '保存',
   'inlineComment.actions.comment': '评论',
+  'inlineComment.actions.revertHunk': '还原区块',
+  'inlineComment.actions.revertingHunk': '正在还原...',
   'inlineComment.actions.showLess': '收起',
   'inlineComment.actions.showMore': '展开',
   'inlineComment.actions.editComment': '编辑评论',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1232,6 +1232,8 @@ export const dict: Record<I18nKey, string> = {
   'inlineComment.actions.cancel': '取消',
   'inlineComment.actions.save': '儲存',
   'inlineComment.actions.comment': '留言',
+  'inlineComment.actions.revertHunk': '還原區塊',
+  'inlineComment.actions.revertingHunk': '正在還原...',
   'inlineComment.actions.showLess': '收起',
   'inlineComment.actions.showMore': '展開',
   'inlineComment.actions.editComment': '編輯留言',

--- a/packages/ui/src/stores/useGitStore.ts
+++ b/packages/ui/src/stores/useGitStore.ts
@@ -23,6 +23,7 @@ const DIFF_PREFETCH_LARGE_FILE_THRESHOLD = 500; // skip prefetch for files with 
 const DIFF_CACHE_MAX_ENTRIES = 30;
 const DIFF_CACHE_MAX_TOTAL_SIZE_BYTES = 20 * 1024 * 1024; // 20MB
 type GitStatusFetchMode = 'full' | 'light';
+type DiffCacheEntry = { original: string; modified: string; fetchedAt: number; isBinary?: boolean; hunkPatch?: string };
 
 interface DirectoryGitState {
   isGitRepo: boolean | null;
@@ -30,7 +31,7 @@ interface DirectoryGitState {
   branches: GitBranch | null;
   log: GitLogResponse | null;
   identity: GitIdentitySummary | null;
-  diffCache: Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean; hunkPatch?: string }>;
+  diffCache: Map<string, DiffCacheEntry>;
   indexRevision: number;
   lastRepoCheckAt: number;
   lastStatusFetch: number;
@@ -69,6 +70,7 @@ interface GitStore {
   getDiff: (directory: string, filePath: string) => { original: string; modified: string; fetchedAt: number; isBinary?: boolean; hunkPatch?: string } | null;
   setDiff: (directory: string, filePath: string, diff: { original: string; modified: string; isBinary?: boolean; hunkPatch?: string }) => void;
   clearDiffCache: (directory: string) => void;
+  clearDiffCacheEntry: (directory: string, filePath: string) => void;
   fetchAllDiffs: (directory: string, git: GitAPI) => Promise<void>;
   prefetchDiffs: (directory: string, git: GitAPI, filePaths: string[], options?: { maxFiles?: number }) => Promise<void>;
 
@@ -143,10 +145,10 @@ const createEmptyDirectoryState = (): DirectoryGitState => ({
 
 // LRU eviction helper for diff cache
 const evictDiffCacheIfNeeded = (
-  diffCache: Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean; hunkPatch?: string }>,
+  diffCache: Map<string, DiffCacheEntry>,
   maxEntries: number = DIFF_CACHE_MAX_ENTRIES,
   maxTotalSize: number = DIFF_CACHE_MAX_TOTAL_SIZE_BYTES
-): Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean }> => {
+): Map<string, DiffCacheEntry> => {
   // Calculate total size
   let totalSize = 0;
   for (const entry of diffCache.values()) {
@@ -162,7 +164,7 @@ const evictDiffCacheIfNeeded = (
   const entries = Array.from(diffCache.entries())
     .sort((a, b) => a[1].fetchedAt - b[1].fetchedAt);
 
-  const newCache = new Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean }>();
+  const newCache = new Map<string, DiffCacheEntry>();
   let newTotalSize = 0;
 
   // Keep entries from newest to oldest until limits are reached
@@ -774,6 +776,20 @@ export const useGitStore = create<GitStore>()(
           newDirectories.set(directory, { ...dirState, diffCache: new Map() });
           set({ directories: newDirectories });
         }
+      },
+
+      clearDiffCacheEntry: (directory, filePath) => {
+        bumpDiffFetchGeneration(directory);
+        const newDirectories = new Map(get().directories);
+        const dirState = newDirectories.get(directory);
+        if (!dirState || !dirState.diffCache.has(filePath)) {
+          return;
+        }
+
+        const newDiffCache = new Map(dirState.diffCache);
+        newDiffCache.delete(filePath);
+        newDirectories.set(directory, { ...dirState, diffCache: newDiffCache });
+        set({ directories: newDirectories });
       },
 
       fetchAllDiffs: async (directory, git) => {

--- a/packages/ui/src/stores/useGitStore.ts
+++ b/packages/ui/src/stores/useGitStore.ts
@@ -30,7 +30,7 @@ interface DirectoryGitState {
   branches: GitBranch | null;
   log: GitLogResponse | null;
   identity: GitIdentitySummary | null;
-  diffCache: Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean }>;
+  diffCache: Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean; hunkPatch?: string }>;
   indexRevision: number;
   lastRepoCheckAt: number;
   lastStatusFetch: number;
@@ -66,8 +66,8 @@ interface GitStore {
   restoreStatus: (directory: string, status: GitStatus | null) => void;
   bumpIndexRevision: (directory: string) => void;
 
-  getDiff: (directory: string, filePath: string) => { original: string; modified: string; fetchedAt: number; isBinary?: boolean } | null;
-  setDiff: (directory: string, filePath: string, diff: { original: string; modified: string; isBinary?: boolean }) => void;
+  getDiff: (directory: string, filePath: string) => { original: string; modified: string; fetchedAt: number; isBinary?: boolean; hunkPatch?: string } | null;
+  setDiff: (directory: string, filePath: string, diff: { original: string; modified: string; isBinary?: boolean; hunkPatch?: string }) => void;
   clearDiffCache: (directory: string) => void;
   fetchAllDiffs: (directory: string, git: GitAPI) => Promise<void>;
   prefetchDiffs: (directory: string, git: GitAPI, filePaths: string[], options?: { maxFiles?: number }) => Promise<void>;
@@ -82,6 +82,7 @@ interface GitFileDiffResponse {
   modified: string;
   path: string;
   isBinary?: boolean;
+  hunkPatch?: string;
 }
 
 interface GitAPI {
@@ -142,7 +143,7 @@ const createEmptyDirectoryState = (): DirectoryGitState => ({
 
 // LRU eviction helper for diff cache
 const evictDiffCacheIfNeeded = (
-  diffCache: Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean }>,
+  diffCache: Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean; hunkPatch?: string }>,
   maxEntries: number = DIFF_CACHE_MAX_ENTRIES,
   maxTotalSize: number = DIFF_CACHE_MAX_TOTAL_SIZE_BYTES
 ): Map<string, { original: string; modified: string; fetchedAt: number; isBinary?: boolean }> => {
@@ -830,7 +831,7 @@ export const useGitStore = create<GitStore>()(
         limitedFilePaths.forEach((path) => inFlight.add(path));
 
         let nextIndex = 0;
-        const results: Array<{ path: string; diff: { original: string; modified: string; isBinary?: boolean } }> = [];
+        const results: Array<{ path: string; diff: { original: string; modified: string; isBinary?: boolean; hunkPatch?: string } }> = [];
 
         const takeNext = () => {
           const current = nextIndex;
@@ -846,7 +847,12 @@ export const useGitStore = create<GitStore>()(
           const response = await Promise.race([fetchPromise, timeoutPromise]);
           return {
             path: filePath,
-            diff: { original: response.original ?? '', modified: response.modified ?? '', isBinary: response.isBinary },
+            diff: {
+              original: response.original ?? '',
+              modified: response.modified ?? '',
+              isBinary: response.isBinary,
+              hunkPatch: response.hunkPatch,
+            },
           };
         };
 

--- a/packages/vscode/src/bridge-git-runtime.ts
+++ b/packages/vscode/src/bridge-git-runtime.ts
@@ -208,15 +208,16 @@ export async function handleStandardGitBridgeMessage(message: BridgeMessageInput
     }
 
     case 'api:git/file-diff': {
-      const { directory, path: filePath, staged } = (payload || {}) as {
+      const { directory, path: filePath, staged, includeHunkPatch } = (payload || {}) as {
         directory?: string;
         path?: string;
         staged?: boolean;
+        includeHunkPatch?: boolean;
       };
       if (!directory || !filePath) {
         return { id, type, success: false, error: 'Directory and path are required' };
       }
-      const result = await gitService.getGitFileDiff(directory, filePath, staged);
+      const result = await gitService.getGitFileDiff(directory, filePath, staged, includeHunkPatch);
       return { id, type, success: true, data: result };
     }
 
@@ -226,6 +227,20 @@ export async function handleStandardGitBridgeMessage(message: BridgeMessageInput
         return { id, type, success: false, error: 'Directory and path are required' };
       }
       await gitService.revertGitFile(directory, filePath, { scope });
+      return { id, type, success: true, data: { success: true } };
+    }
+
+    case 'api:git/revert-hunk': {
+      const { directory, path: filePath, staged, patch } = (payload || {}) as {
+        directory?: string;
+        path?: string;
+        staged?: boolean;
+        patch?: string;
+      };
+      if (!directory || !filePath || !patch) {
+        return { id, type, success: false, error: 'Directory, path, and patch are required' };
+      }
+      await gitService.revertGitHunk(directory, { path: filePath, staged, patch });
       return { id, type, success: true, data: { success: true } };
     }
 

--- a/packages/vscode/src/gitService.ts
+++ b/packages/vscode/src/gitService.ts
@@ -279,6 +279,45 @@ async function execGit(args: string[], cwd: string): Promise<{ stdout: string; s
   });
 }
 
+async function execGitWithInput(args: string[], cwd: string, input: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const normalizedCwd = normalizePath(cwd);
+    const gitPath = gitApi?.git.path || 'git';
+
+    buildGitEnv().then((env) => {
+      const proc = spawn(gitPath, args, {
+        cwd: normalizedCwd,
+        env,
+        windowsHide: true,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      proc.stdout?.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr?.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      proc.on('close', (exitCode) => {
+        resolve({ stdout, stderr, exitCode: exitCode ?? 0 });
+      });
+
+      proc.on('error', (error) => {
+        resolve({ stdout: '', stderr: error.message, exitCode: 1 });
+      });
+
+      proc.stdin.end(input);
+    }).catch((error) => {
+      resolve({ stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 1 });
+    });
+  });
+}
+
 function isValidCommitHash(hash: string): boolean {
   return /^[0-9a-fA-F]{7,40}$/.test(hash);
 }
@@ -2180,8 +2219,9 @@ export async function getGitRangeFiles(
 export async function getGitFileDiff(
   directory: string, 
   filePath: string, 
-  staged = false
-): Promise<{ original: string; modified: string; path: string }> {
+  staged = false,
+  includeHunkPatch = false
+): Promise<{ original: string; modified: string; path: string; hunkPatch?: string }> {
   const repo = await getRepository(directory);
   
   if (repo) {
@@ -2211,14 +2251,18 @@ export async function getGitFileDiff(
         modified = Buffer.from(modifiedBytes).toString('utf8');
       }
       
-      return { original, modified, path: filePath };
+      const hunkPatch = includeHunkPatch
+        ? (await getGitDiff(directory, filePath, staged, 0)).diff
+        : undefined;
+
+      return { original, modified, path: filePath, hunkPatch };
     } catch (error) {
       console.error('[GitService] Failed to get file diff:', error);
     }
   }
 
   // Fallback: return empty content
-  return { original: '', modified: '', path: filePath };
+  return { original: '', modified: '', path: filePath, hunkPatch: includeHunkPatch ? '' : undefined };
 }
 
 /**
@@ -2259,6 +2303,98 @@ export async function revertGitFile(
   const fallback = await execGit(['checkout', '--', filePath], directory);
   if (fallback.exitCode !== 0) {
     throw new Error(fallback.stderr || restore.stderr || 'Failed to revert git file');
+  }
+}
+
+const normalizePatchFilePath = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '/dev/null') return trimmed;
+  if (trimmed.startsWith('a/') || trimmed.startsWith('b/')) return trimmed.slice(2);
+  return trimmed;
+};
+
+const toGitPath = (value: string): string => value.replace(/\\/g, '/');
+
+const resolveGitRepositoryRoot = async (directory: string): Promise<string> => {
+  const result = await execGit(['rev-parse', '--show-toplevel'], directory);
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || 'Failed to resolve git repository root');
+  }
+
+  const root = result.stdout.trim();
+  return path.isAbsolute(root) ? path.resolve(root) : path.resolve(directory, root);
+};
+
+const resolveGitFileContext = async (directory: string, filePath: string): Promise<{ repoRoot: string; repoPath: string }> => {
+  const directoryPath = path.resolve(normalizeDirectoryPath(directory));
+  const repoRoot = await resolveGitRepositoryRoot(directoryPath);
+  const candidates = Array.from(new Set([
+    path.resolve(repoRoot, filePath),
+    path.resolve(directoryPath, filePath),
+  ]));
+
+  for (const absolutePath of candidates) {
+    if (!isInsideOrSameDirectory(repoRoot, absolutePath)) {
+      continue;
+    }
+
+    const repoPath = toGitPath(path.relative(repoRoot, absolutePath));
+    const existsInWorktree = await fs.promises.stat(absolutePath).then((stat) => stat.isFile()).catch(() => false);
+    const existsInIndex = await execGit(['cat-file', '-e', `:${repoPath}`], repoRoot).then((result) => result.exitCode === 0);
+    const existsInHead = await execGit(['cat-file', '-e', `HEAD:${repoPath}`], repoRoot).then((result) => result.exitCode === 0);
+
+    if (existsInWorktree || existsInIndex || existsInHead) {
+      return { repoRoot, repoPath };
+    }
+  }
+
+  throw new Error('Invalid file path');
+};
+
+const validateSingleFilePatchPath = (patch: string, filePath: string): void => {
+  const paths = new Set<string>();
+  for (const line of patch.replace(/\r\n/g, '\n').split('\n')) {
+    if (line.startsWith('--- ') || line.startsWith('+++ ')) {
+      const normalized = normalizePatchFilePath(line.slice(4).split('\t')[0] || '');
+      if (normalized && normalized !== '/dev/null') {
+        paths.add(normalized);
+      }
+    }
+  }
+
+  if (paths.size === 0) {
+    throw new Error('Patch must include file headers');
+  }
+  if (paths.size !== 1 || !paths.has(filePath)) {
+    throw new Error('Patch does not match selected file');
+  }
+};
+
+export async function revertGitHunk(
+  directory: string,
+  payload: { path: string; staged?: boolean; patch: string },
+): Promise<void> {
+  const filePath = payload.path.trim();
+  const patch = payload.patch;
+  if (!filePath) {
+    throw new Error('path is required');
+  }
+  if (!patch.trim()) {
+    throw new Error('patch is required');
+  }
+
+  const { repoRoot, repoPath } = await resolveGitFileContext(directory, filePath);
+  validateSingleFilePatchPath(patch, repoPath);
+
+  const args = ['apply'];
+  if (payload.staged === true) {
+    args.push('--cached');
+  }
+  args.push('--reverse', '--whitespace=nowarn', '--unidiff-zero', '--recount');
+
+  const result = await execGitWithInput(args, repoRoot, patch);
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.stdout || 'Failed to revert git hunk');
   }
 }
 

--- a/packages/vscode/webview/api/git.ts
+++ b/packages/vscode/webview/api/git.ts
@@ -39,6 +39,7 @@ import type {
   CherryPickResponse,
   RevertCommitResponse,
   ResetToCommitResponse,
+  RevertGitHunkPayload,
 } from '@openchamber/ui/lib/api/types';
 
 export const createVSCodeGitAPI = (): GitAPI => ({
@@ -64,11 +65,16 @@ export const createVSCodeGitAPI = (): GitAPI => ({
       directory,
       path: options.path,
       staged: options.staged,
+      includeHunkPatch: options.includeHunkPatch,
     });
   },
 
   revertGitFile: async (directory: string, filePath: string, options?: { scope?: 'all' | 'working' }): Promise<void> => {
     await sendBridgeMessage('api:git/revert', { directory, path: filePath, scope: options?.scope });
+  },
+
+  revertGitHunk: async (directory: string, payload: RevertGitHunkPayload): Promise<void> => {
+    await sendBridgeMessage('api:git/revert-hunk', { directory, ...payload });
   },
 
   stageGitFile: async (directory: string, filePath: string): Promise<void> => {

--- a/packages/web/server/lib/git/DOCUMENTATION.md
+++ b/packages/web/server/lib/git/DOCUMENTATION.md
@@ -31,6 +31,7 @@ The following functions are exported and used by the web server:
 - `getFileDiff(directory, { path, staged })`: Get original and modified file contents for a single file (handles images as data URLs).
 - `collectDiffs(directory, files)`: Collect diff output for multiple files.
 - `revertFile(directory, filePath, options)`: Revert a file. Default scope `all` discards staged and working-tree changes; scope `working` discards only unstaged/working-tree changes.
+- `revertHunk(directory, { path, staged, patch })`: Revert one selected single-file hunk by reverse-applying its unified patch. Uses `git apply --reverse --whitespace=nowarn --unidiff-zero --recount`; staged hunks add `--cached` so only the index is changed.
 - `stageFile(directory, filePath)`: Add one file path to the index.
 - `unstageFile(directory, filePath)`: Remove one file path from the index while preserving working-tree content.
 
@@ -113,6 +114,8 @@ The following functions are internal helpers used by exported functions:
 - A file with both staged and unstaged changes can appear in both UI sections. Staged rows request diffs with `staged: true`; unstaged rows request normal working-tree diffs.
 - The shared Git panel exposes explicit staging actions. Unstaged rows use `stageFile`, staged rows use `unstageFile`, and commits operate on the current staged index.
 - `stageFiles` remains supported for callers that need to stage a selected unstaged subset as part of commit. In that mode the server temporarily unstages unrelated index entries, stages `stageFiles`, commits from the index, then restores temporarily unstaged entries.
+- Hunk revert receives a caller-selected single-file patch from `/api/git/revert-hunk`. The service validates that the patch file headers match the requested repository path before applying it. UI callers should generate these patches from zero-context diffs so the selected hunk can be reverted independently from adjacent hunks.
+
 ### Worktree Create/Remove Response
 - `head`: HEAD commit SHA.
 - `name`: Worktree name.

--- a/packages/web/server/lib/git/routes.js
+++ b/packages/web/server/lib/git/routes.js
@@ -265,10 +265,12 @@ export function registerGitRoutes(app) {
       }
 
       const staged = req.query.staged === 'true';
+      const includeHunkPatch = req.query.hunkPatch === 'true';
 
       const result = await getFileDiff(directory, {
         path: pathParam,
         staged,
+        includeHunkPatch,
       });
 
       res.json({
@@ -276,6 +278,7 @@ export function registerGitRoutes(app) {
         modified: result.modified,
         path: result.path,
         isBinary: Boolean(result.isBinary),
+        hunkPatch: result.hunkPatch,
       });
     } catch (error) {
       console.error('Failed to get git file diff:', error);
@@ -301,6 +304,30 @@ export function registerGitRoutes(app) {
     } catch (error) {
       console.error('Failed to revert git file:', error);
       res.status(500).json({ error: error.message || 'Failed to revert git file' });
+    }
+  });
+
+  app.post('/api/git/revert-hunk', async (req, res) => {
+    const { revertHunk } = await getGitLibraries();
+    try {
+      const directory = req.query.directory;
+      if (!directory) {
+        return res.status(400).json({ error: 'directory parameter is required' });
+      }
+
+      const { path, staged, patch } = req.body || {};
+      if (!path || typeof path !== 'string') {
+        return res.status(400).json({ error: 'path parameter is required' });
+      }
+      if (!patch || typeof patch !== 'string') {
+        return res.status(400).json({ error: 'patch parameter is required' });
+      }
+
+      await revertHunk(directory, { path, staged: staged === true, patch });
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Failed to revert git hunk:', error);
+      res.status(500).json({ error: error.message || 'Failed to revert git hunk' });
     }
   });
 

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2,7 +2,7 @@ import simpleGit from 'simple-git';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import { createRequire } from 'module';
 
@@ -862,6 +862,40 @@ const runGitCommandOrThrow = async (cwd, args, fallbackMessage) => {
     throw new Error(result.message || fallbackMessage || 'Git command failed');
   }
   return result;
+};
+
+const runGitCommandWithInputOrThrow = async (cwd, args, input, fallbackMessage) => {
+  const env = await buildGitEnv();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(getGitBinary(), args, {
+      cwd,
+      env,
+      windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', code => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new Error(stderr.trim() || stdout.trim() || fallbackMessage || 'Git command failed'));
+    });
+
+    child.stdin.end(input);
+  });
 };
 
 const ensureOpenCodeProjectId = async (primaryWorktree) => {
@@ -2001,7 +2035,7 @@ const isBinaryDiff = async (directoryPath, filePath, staged) => {
   return false;
 };
 
-export async function getFileDiff(directory, { path: filePath, staged = false } = {}) {
+export async function getFileDiff(directory, { path: filePath, staged = false, includeHunkPatch = false } = {}) {
   if (!directory || !filePath) {
     throw new Error('directory and path are required for getFileDiff');
   }
@@ -2020,6 +2054,7 @@ export async function getFileDiff(directory, { path: filePath, staged = false } 
         modified: '',
         path: filePath,
         isBinary: true,
+        hunkPatch: undefined,
       };
     }
   }
@@ -2085,11 +2120,16 @@ export async function getFileDiff(directory, { path: filePath, staged = false } 
     }
   }
 
+  const hunkPatch = includeHunkPatch
+    ? await getDiff(directory, { path: filePath, staged, contextLines: 0 })
+    : undefined;
+
   return {
     original: typeof original === 'string' ? original.replace(/\r\n/g, '\n') : original,
     modified: typeof modified === 'string' ? modified.replace(/\r\n/g, '\n') : modified,
     path: filePath,
     isBinary: false,
+    hunkPatch,
   };
 }
 
@@ -2143,6 +2183,62 @@ export async function revertFile(directory, filePath, options = {}) {
         throw fallbackError;
       }
     }
+  });
+}
+
+const normalizePatchFilePath = (value) => {
+  const trimmed = String(value || '').trim();
+  if (!trimmed || trimmed === '/dev/null') return trimmed;
+  if (trimmed.startsWith('a/') || trimmed.startsWith('b/')) return trimmed.slice(2);
+  return trimmed;
+};
+
+const validateSingleFilePatchPath = (patch, repoPath) => {
+  const paths = new Set();
+  for (const line of patch.replace(/\r\n/g, '\n').split('\n')) {
+    if (line.startsWith('--- ') || line.startsWith('+++ ')) {
+      const value = line.slice(4).split('\t')[0];
+      const normalized = normalizePatchFilePath(value);
+      if (normalized && normalized !== '/dev/null') {
+        paths.add(normalized);
+      }
+    }
+  }
+
+  if (paths.size === 0) {
+    throw new Error('Patch must include file headers');
+  }
+  if (paths.size !== 1 || !paths.has(repoPath)) {
+    throw new Error('Patch does not match selected file');
+  }
+};
+
+export async function revertHunk(directory, options = {}) {
+  return withGitIndexMutationQueue(directory, async () => {
+    const filePath = typeof options.path === 'string' ? options.path : '';
+    const patch = typeof options.patch === 'string' ? options.patch : '';
+    if (!filePath.trim()) {
+      throw new Error('path parameter is required');
+    }
+    if (!patch.trim()) {
+      throw new Error('patch parameter is required');
+    }
+
+    const staged = options.staged === true;
+    const directoryPath = normalizeDirectoryPath(directory);
+    const directoryGit = await createGit(directoryPath);
+    const repoRoot = await resolveGitRepositoryRoot(directoryPath, directoryGit);
+    const { repoPath } = await resolveGitFileContext(directoryPath, directoryGit, filePath, repoRoot);
+
+    validateSingleFilePatchPath(patch, repoPath);
+
+    const args = ['apply'];
+    if (staged) {
+      args.push('--cached');
+    }
+    args.push('--reverse', '--whitespace=nowarn', '--unidiff-zero', '--recount');
+
+    await runGitCommandWithInputOrThrow(repoRoot, args, patch, 'Failed to revert git hunk');
   });
 }
 

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -12,6 +12,7 @@ import {
   resetToCommit,
   resolveBaseRefForLog,
   revertCommit,
+  revertHunk,
   stageFiles,
   unstageFiles,
 } from './service.js';
@@ -116,6 +117,51 @@ describe('git index path validation', () => {
     await expect(unstageFiles('/repo', ['../secret.txt'])).rejects.toThrow(
       'Path is outside repository: ../secret.txt'
     );
+  });
+});
+
+describe('revertHunk', () => {
+  it('reverse-applies a single working-tree hunk', async () => {
+    if (!canRunGit()) return;
+
+    const repo = createTempDir();
+    runGit(repo, ['init']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'one\ntwo\nthree\n', 'utf8');
+    runGit(repo, ['add', 'file.txt']);
+    runGit(repo, ['commit', '-m', 'initial']);
+
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'one\nTWO\nthree\n', 'utf8');
+    await revertHunk(repo, {
+      path: 'file.txt',
+      patch: 'diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -2 +2 @@\n-two\n+TWO\n',
+    });
+
+    expect(fs.readFileSync(path.join(repo, 'file.txt'), 'utf8')).toBe('one\ntwo\nthree\n');
+  });
+
+  it('reverse-applies a single staged hunk to the index', async () => {
+    if (!canRunGit()) return;
+
+    const repo = createTempDir();
+    runGit(repo, ['init']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'one\ntwo\nthree\n', 'utf8');
+    runGit(repo, ['add', 'file.txt']);
+    runGit(repo, ['commit', '-m', 'initial']);
+
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'one\nTWO\nthree\n', 'utf8');
+    runGit(repo, ['add', 'file.txt']);
+    await revertHunk(repo, {
+      path: 'file.txt',
+      staged: true,
+      patch: 'diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -2 +2 @@\n-two\n+TWO\n',
+    });
+
+    expect(runGit(repo, ['show', ':file.txt'])).toBe('one\ntwo\nthree\n');
+    expect(fs.readFileSync(path.join(repo, 'file.txt'), 'utf8')).toBe('one\nTWO\nthree\n');
   });
 });
 

--- a/packages/web/src/api/git.test.ts
+++ b/packages/web/src/api/git.test.ts
@@ -6,6 +6,7 @@ vi.mock('@openchamber/ui/lib/gitApiHttp', () => ({
   getGitDiff: vi.fn(),
   getGitFileDiff: vi.fn(),
   revertGitFile: vi.fn(),
+  revertGitHunk: vi.fn(),
   stageGitFile: vi.fn(),
   stageGitFiles: vi.fn(),
   unstageGitFile: vi.fn(),
@@ -58,11 +59,12 @@ vi.mock('@openchamber/ui/lib/gitApiHttp', () => ({
 }));
 
 describe('createWebGitAPI', () => {
-  it('exposes bulk stage and unstage methods', async () => {
+  it('exposes bulk stage, unstage, and hunk revert methods', async () => {
     const { createWebGitAPI } = await import('./git');
     const api = createWebGitAPI();
 
     expect(typeof api.stageGitFiles).toBe('function');
     expect(typeof api.unstageGitFiles).toBe('function');
+    expect(typeof api.revertGitHunk).toBe('function');
   });
 });

--- a/packages/web/src/api/git.ts
+++ b/packages/web/src/api/git.ts
@@ -11,6 +11,7 @@ export const createWebGitAPI = (): GitAPI => ({
   getGitDiff: gitApiHttp.getGitDiff,
   getGitFileDiff: gitApiHttp.getGitFileDiff,
   revertGitFile: gitApiHttp.revertGitFile,
+  revertGitHunk: gitApiHttp.revertGitHunk,
   stageGitFile: gitApiHttp.stageGitFile,
   stageGitFiles: gitApiHttp.stageGitFiles,
   unstageGitFile: gitApiHttp.unstageGitFile,


### PR DESCRIPTION
## Summary

- Adds contextual `Revert Hunk` support inside the existing Pierre diff comment box for selections that intersect a revertable changed hunk.
- Introduces shared hunk parsing and a `revertGitHunk(directory, { path, staged, patch })` API, backed by `/api/git/revert-hunk`.
- Reverse-applies selected single-file hunks with `git apply --reverse --whitespace=nowarn --unidiff-zero --recount`, with staged/index support via runtime parity for web and VS Code.
- Refreshes git status, clears diff cache, and bumps staged revision after successful staged hunk reverts.
- Documents the new git hunk revert contract and adds coverage for parsing, API payloads, runtime exposure, and working/staged backend hunk reverts.

## Validation

- `bun test packages/ui/src/lib/gitDiffHunks.test.ts packages/ui/src/lib/gitApiHttp.test.ts packages/ui/src/lib/gitApi.test.ts`
- `bun test packages/web/server/lib/git/service.test.js`
- `bun test packages/web/src/api/git.test.ts`
- `bun run type-check`
- `bun run lint`