### PR TITLE
Improve permission auto-accept recovery and todo history rendering

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -628,6 +628,103 @@ const parseQuestionOutput = (output: string): Array<{ question: string; answer: 
     return pairs.length > 0 ? pairs : null;
 };
 
+type TodoToolItem = {
+    id?: string;
+    content: string;
+    status?: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+    priority?: 'low' | 'medium' | 'high';
+};
+
+const parseTodoToolStatus = (value: unknown): TodoToolItem['status'] => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'pending') return 'pending';
+    if (normalized === 'in_progress' || normalized === 'in progress' || normalized === 'inprogress') return 'in_progress';
+    if (normalized === 'completed' || normalized === 'done') return 'completed';
+    if (normalized === 'cancelled' || normalized === 'canceled') return 'cancelled';
+    return undefined;
+};
+
+const parseTodoToolPriority = (value: unknown): TodoToolItem['priority'] => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'low') return 'low';
+    if (normalized === 'medium') return 'medium';
+    if (normalized === 'high') return 'high';
+    return undefined;
+};
+
+const parseTodoToolContent = (record: Record<string, unknown>): string => {
+    if (typeof record.content === 'string') {
+        return record.content;
+    }
+    if (typeof record.text === 'string') {
+        return record.text;
+    }
+    if (typeof record.title === 'string') {
+        return record.title;
+    }
+    return '';
+};
+
+const parseTodoToolItemsFromArray = (value: unknown[]): TodoToolItem[] => {
+    const items: TodoToolItem[] = [];
+    for (const item of value) {
+        if (!item || typeof item !== 'object') {
+            continue;
+        }
+        const record = item as Record<string, unknown>;
+        const content = parseTodoToolContent(record);
+        if (!content.trim()) {
+            continue;
+        }
+        items.push({
+            id: typeof record.id === 'string' ? record.id : undefined,
+            content,
+            status: parseTodoToolStatus(record.status),
+            priority: parseTodoToolPriority(record.priority),
+        });
+    }
+    return items;
+};
+
+const parseTodoToolItems = (value: unknown): TodoToolItem[] => {
+    if (Array.isArray(value)) {
+        return parseTodoToolItemsFromArray(value);
+    }
+    if (value && typeof value === 'object') {
+        const todos = (value as { todos?: unknown }).todos;
+        if (Array.isArray(todos)) {
+            return parseTodoToolItemsFromArray(todos);
+        }
+    }
+    if (typeof value === 'string' && value.trim()) {
+        try {
+            return parseTodoToolItems(JSON.parse(value) as unknown);
+        } catch {
+            return [];
+        }
+    }
+    return [];
+};
+
+const getTodoStatusStyle = (status: TodoToolItem['status']): React.CSSProperties => {
+    if (status === 'completed') {
+        return { color: 'var(--status-success)', backgroundColor: 'var(--status-success-background)', borderColor: 'var(--status-success-border)' };
+    }
+    if (status === 'in_progress') {
+        return { color: 'var(--status-info)', backgroundColor: 'var(--status-info-background)', borderColor: 'var(--status-info-border)' };
+    }
+    if (status === 'cancelled') {
+        return { color: 'var(--status-error)', backgroundColor: 'var(--status-error-background)', borderColor: 'var(--status-error-border)' };
+    }
+    return { color: 'var(--tools-description)', backgroundColor: 'var(--surface-elevated)', borderColor: 'var(--tools-border)' };
+};
+
 const getToolDescriptionPath = (part: ToolPartType, state: ToolStateUnion, currentDirectory: string): string | null => {
     const stateWithData = state as ToolStateWithMetadata;
     const metadata = stateWithData.metadata;
@@ -1468,6 +1565,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
     const metadata = stateWithData.metadata;
     const input = stateWithData.input;
     const rawOutput = stateWithData.output;
+    const normalizedToolName = normalizeToolName(part.tool);
     const hasStringOutput = typeof rawOutput === 'string' && rawOutput.length > 0;
     const outputString = typeof rawOutput === 'string' ? rawOutput : '';
 
@@ -1583,6 +1681,60 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                 </div>
             );
         };
+
+        if (normalizedToolName === 'todowrite') {
+            const inputTodos = parseTodoToolItems(input?.todos);
+            const todos = inputTodos.length > 0
+                ? inputTodos
+                : parseTodoToolItems(rawOutput);
+
+            if (todos.length === 0) {
+                return renderScrollableBlock(
+                    <div className="typography-meta" style={{ color: 'var(--tools-description)' }}>{t('chat.toolPart.noOutputProduced')}</div>,
+                    { maxHeightClass: 'max-h-60' }
+                );
+            }
+
+            const getStatusLabel = (status: TodoToolItem['status']) => {
+                if (status === 'completed') return t('chat.todo.completed');
+                if (status === 'in_progress') return t('chat.todo.inProgress');
+                if (status === 'cancelled') return t('chat.todo.cancelled');
+                return t('chat.todo.pending');
+            };
+
+            const getPriorityLabel = (priority: TodoToolItem['priority']) => {
+                if (priority === 'high') return t('chat.statusRow.todo.priority.high');
+                if (priority === 'low') return t('chat.statusRow.todo.priority.low');
+                return t('chat.statusRow.todo.priority.medium');
+            };
+
+            return renderScrollableBlock(
+                <div className="space-y-1.5">
+                    {todos.map((todo, index) => {
+                        const status = todo.status ?? 'pending';
+                        const priority = todo.priority ?? 'medium';
+                        return (
+                            <div key={todo.id ?? `${index}:${todo.content}`} className="rounded-lg border px-2 py-1.5" style={{ backgroundColor: 'var(--surface-elevated)', borderColor: 'var(--tools-border)' }}>
+                                <div className="flex items-start gap-2 min-w-0">
+                                    <span className="mt-0.5 inline-flex shrink-0 rounded-full border px-1.5 py-0.5 typography-micro font-medium" style={getTodoStatusStyle(status)}>
+                                        {getStatusLabel(status)}
+                                    </span>
+                                    <div className="min-w-0 flex-1 space-y-0.5">
+                                        <div className="typography-meta whitespace-pre-wrap break-words" style={{ color: 'var(--surface-foreground)' }}>
+                                            {todo.content}
+                                        </div>
+                                        <div className="typography-micro" style={{ color: 'var(--surface-muted-foreground)' }}>
+                                            {getPriorityLabel(priority)}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>,
+                { maxHeightClass: 'max-h-[40vh]', className: 'p-1' }
+            );
+        }
 
         // Question tool: show parsed Q&A summary or question content from input
         if (part.tool === 'question') {
@@ -1727,7 +1879,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                 'relative pr-2 pb-2 pt-2 space-y-2 pl-4'
             )}
         >
-            {part.tool === 'question' ? (
+            {normalizedToolName === 'question' || normalizedToolName === 'todowrite' ? (
                 renderResultContent()
             ) : (
                 <>

--- a/packages/ui/src/components/chat/message/parts/toolRenderUtils.ts
+++ b/packages/ui/src/components/chat/message/parts/toolRenderUtils.ts
@@ -2,7 +2,7 @@ const EXPANDABLE_TOOL_NAMES = new Set<string>([
     'edit', 'multiedit', 'apply_patch', 'str_replace', 'str_replace_based_edit_tool',
     'bash', 'shell', 'cmd', 'terminal',
     'write', 'create', 'file_write',
-    'question', 'task',
+    'question', 'task', 'todowrite',
 ]);
 
 const STANDALONE_TOOL_NAMES = new Set<string>(['task']);

--- a/packages/ui/src/stores/permissionStore.ts
+++ b/packages/ui/src/stores/permissionStore.ts
@@ -107,6 +107,14 @@ const normalizeDirectoryCandidate = (value: unknown): string | null => {
     return trimmed.length > 0 ? trimmed : null;
 };
 
+const mirrorSessionPermissionAutoAccept = (sessionId: string, enabled: boolean, directory: string | null): void => {
+    void fetch(`/api/sessions/${encodeURIComponent(sessionId)}/permission-auto-accept`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled, directory: directory || '' }),
+    }).catch(() => { /* best-effort */ });
+};
+
 const collectPendingFromSyncStores = (): Array<{ id: string; sessionID: string }> => {
     try {
         const stores = getSyncChildStores();
@@ -236,25 +244,23 @@ export const usePermissionStore = create<PermissionStore>()(
                     // permission notifications before the client auto-response
                     // round-trip. Send known descendants too; server-side
                     // ancestry lookup can lag OpenCode session indexing.
+                    const sessionDirectory = useSessionUIStore.getState().getDirectoryForSession(sessionId);
+                    const currentDirectory = normalizeDirectoryCandidate(opencodeClient.getDirectory());
+                    const mappedSessionDirectory = normalizeDirectoryCandidate(sessionDirectory);
+
                     for (const scopedSessionId of sessionScope) {
-                        void fetch('/api/notifications/auto-accept', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ sessionId: scopedSessionId, enabled }),
-                        }).catch(() => { /* best-effort */ });
+                        const scopedDirectory = normalizeDirectoryCandidate(useSessionUIStore.getState().getDirectoryForSession(scopedSessionId)) || mappedSessionDirectory || currentDirectory;
+                        mirrorSessionPermissionAutoAccept(scopedSessionId, enabled, scopedDirectory);
                     }
 
                     if (!enabled) {
                         return;
                     }
 
-                    const sessionDirectory = useSessionUIStore.getState().getDirectoryForSession(sessionId);
                     const directories = new Set<string>();
-                    const currentDirectory = normalizeDirectoryCandidate(opencodeClient.getDirectory());
                     if (currentDirectory) {
                         directories.add(currentDirectory);
                     }
-                    const mappedSessionDirectory = normalizeDirectoryCandidate(sessionDirectory);
                     if (mappedSessionDirectory) {
                         directories.add(mappedSessionDirectory);
                     }
@@ -354,13 +360,11 @@ export const usePermissionStore = create<PermissionStore>()(
                     // Re-broadcast auto-accept state to the server after
                     // rehydration so server-side notification suppression
                     // survives page reloads / server restarts.
+                    const currentDirectory = normalizeDirectoryCandidate(opencodeClient.getDirectory());
                     for (const [sid, enabled] of Object.entries(state.autoAccept || {})) {
                         if (enabled === true) {
-                            void fetch('/api/notifications/auto-accept', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ sessionId: sid, enabled: true }),
-                            }).catch(() => { /* best-effort */ });
+                            const mappedDirectory = normalizeDirectoryCandidate(useSessionUIStore.getState().getDirectoryForSession(sid)) || currentDirectory;
+                            mirrorSessionPermissionAutoAccept(sid, true, mappedDirectory);
                         }
                     }
                 },

--- a/packages/ui/src/sync/__tests__/session-switch-resync.test.ts
+++ b/packages/ui/src/sync/__tests__/session-switch-resync.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test, beforeEach, mock } from "bun:test"
 import { create, type StoreApi } from "zustand"
-import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client"
+import type { PermissionRequest, QuestionRequest, Todo } from "@opencode-ai/sdk/v2/client"
 
 const listPendingQuestionsCalls: Array<{ directories?: Array<string | null | undefined> }> = []
 const listPendingPermissionsCalls: Array<{ directories?: Array<string | null | undefined> }> = []
+const sessionTodoCalls: string[] = []
+const persistedTodoUpdates: Array<{ sessionId: string; todos: Todo[] | undefined }> = []
 let pendingQuestionsResponse: QuestionRequest[] = []
 let pendingPermissionsResponse: PermissionRequest[] = []
+let sessionTodoResponses: Record<string, Todo[]> = {}
+let sessionTodoShouldFail = false
 let pendingQuestionsShouldThrow = false
 let pendingPermissionsShouldThrow = false
 
@@ -22,7 +26,15 @@ mock.module("@/lib/opencode/client", () => ({
       return pendingPermissionsResponse
     }),
     getDirectory: () => "/repo",
-    getScopedSdkClient: () => ({}),
+    getScopedSdkClient: () => ({
+      session: {
+        todo: mock(async ({ sessionID }: { sessionID: string }) => {
+          sessionTodoCalls.push(sessionID)
+          if (sessionTodoShouldFail) return { error: { message: "simulated" } }
+          return { data: sessionTodoResponses[sessionID] ?? [] }
+        }),
+      },
+    }),
     setDirectory: () => undefined,
   },
 }))
@@ -41,7 +53,13 @@ mock.module("@/stores/useConfigStore", () => ({
 }))
 
 mock.module("@/stores/useTodosPersistStore", () => ({
-  useTodosPersistStore: { getState: () => ({}) },
+  useTodosPersistStore: {
+    getState: () => ({
+      setSessionTodos: (sessionId: string, todos: Todo[] | undefined) => {
+        persistedTodoUpdates.push({ sessionId, todos })
+      },
+    }),
+  },
 }))
 
 mock.module("@/components/ui", () => ({
@@ -50,7 +68,7 @@ mock.module("@/components/ui", () => ({
 
 import { INITIAL_STATE, type State } from "../types"
 import type { DirectoryStore } from "../child-store"
-import { resyncBlockingRequestsForDirectory } from "../sync-context"
+import { resyncBlockingRequestsForDirectory, resyncSessionTodosForDirectory } from "../sync-context"
 
 function buildQuestion(overrides: Partial<QuestionRequest> = {}): QuestionRequest {
   return {
@@ -87,8 +105,12 @@ describe("resyncBlockingRequestsForDirectory", () => {
   beforeEach(() => {
     listPendingQuestionsCalls.length = 0
     listPendingPermissionsCalls.length = 0
+    sessionTodoCalls.length = 0
+    persistedTodoUpdates.length = 0
     pendingQuestionsResponse = []
     pendingPermissionsResponse = []
+    sessionTodoResponses = {}
+    sessionTodoShouldFail = false
     pendingQuestionsShouldThrow = false
     pendingPermissionsShouldThrow = false
   })
@@ -204,5 +226,51 @@ describe("resyncBlockingRequestsForDirectory", () => {
     expect(store.getState().question["ses_a"]).toHaveLength(1)
     expect(store.getState().question["ses_a"]?.[0]?.id).toBe("que_1")
     expect(listPendingPermissionsCalls).toHaveLength(1)
+  })
+})
+
+describe("resyncSessionTodosForDirectory", () => {
+  beforeEach(() => {
+    sessionTodoCalls.length = 0
+    persistedTodoUpdates.length = 0
+    sessionTodoResponses = {}
+    sessionTodoShouldFail = false
+  })
+
+  test("refreshes session todos from the authoritative session.todo endpoint", async () => {
+    const store = createDirectoryStore({})
+    sessionTodoResponses = {
+      ses_a: [{ id: "todo_1", content: "Done", status: "completed", priority: "medium" } as Todo],
+    }
+
+    await resyncSessionTodosForDirectory("/repo", store, ["ses_a"])
+
+    expect(sessionTodoCalls).toEqual(["ses_a"])
+    expect(store.getState().todo["ses_a"]?.[0]?.status).toBe("completed")
+    expect(persistedTodoUpdates).toHaveLength(1)
+    expect((persistedTodoUpdates[0]?.todos?.[0] as Todo & { id?: string } | undefined)?.id).toBe("todo_1")
+  })
+
+  test("clears stale todos when the server returns an empty list", async () => {
+    const store = createDirectoryStore({
+      todo: { ses_a: [{ id: "todo_stale", content: "Old", status: "pending", priority: "medium" } as Todo] },
+    })
+    sessionTodoResponses = { ses_a: [] }
+
+    await resyncSessionTodosForDirectory("/repo", store, ["ses_a"])
+
+    expect(store.getState().todo["ses_a"]).toEqual(undefined)
+    expect(persistedTodoUpdates).toEqual([{ sessionId: "ses_a", todos: undefined }])
+  })
+
+  test("preserves existing todos when the todo fetch fails", async () => {
+    const existing = [{ id: "todo_existing", content: "Keep", status: "pending", priority: "medium" } as Todo]
+    const store = createDirectoryStore({ todo: { ses_a: existing } })
+    sessionTodoShouldFail = true
+
+    await resyncSessionTodosForDirectory("/repo", store, ["ses_a"])
+
+    expect(store.getState().todo["ses_a"]).toBe(existing)
+    expect(persistedTodoUpdates).toHaveLength(0)
   })
 })

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, useEffect, useRef, useCallback, useMemo } from "react"
-import type { Event, Message, Part } from "@opencode-ai/sdk/v2/client"
+import type { Event, Message, Part, Todo } from "@opencode-ai/sdk/v2/client"
 import type { Session } from "@opencode-ai/sdk/v2"
 import type { StoreApi } from "zustand"
 import { useStore } from "zustand"
@@ -409,6 +409,57 @@ async function resyncDirectorySessionStatuses(
   if (relevantStatuses === null) return null
   applySessionStatusSnapshot(store, relevantStatuses)
   return relevantStatuses
+}
+
+export async function resyncSessionTodosForDirectory(
+  directory: string,
+  store: StoreApi<DirectoryStore>,
+  candidateSessionIds: string[],
+) {
+  if (candidateSessionIds.length === 0) return
+
+  const before = store.getState()
+  const beforeSignatures = new Map(
+    candidateSessionIds.map((sessionId) => [sessionId, syncSnapshotSignature(before.todo[sessionId] ?? [])]),
+  )
+  const scopedClient = opencodeClient.getScopedSdkClient(directory)
+  const results = await Promise.all(candidateSessionIds.map(async (sessionId) => {
+    const response = await scopedClient.session.todo({ sessionID: sessionId }).catch(() => null)
+    if (!response || response.error) {
+      return null
+    }
+    return [sessionId, (response.data ?? []) as Todo[]] as const
+  }))
+
+  store.setState((state: DirectoryStore) => {
+    let nextTodo = state.todo
+    let changed = false
+
+    for (const result of results) {
+      if (!result) continue
+      const [sessionId, todos] = result
+      const beforeSignature = beforeSignatures.get(sessionId) ?? "[]"
+      const currentSignature = syncSnapshotSignature(state.todo[sessionId] ?? [])
+      if (currentSignature !== beforeSignature) continue
+
+      if (todos.length === 0) {
+        if (!state.todo[sessionId]) continue
+        if (!changed) nextTodo = { ...state.todo }
+        delete nextTodo[sessionId]
+        useTodosPersistStore.getState().setSessionTodos(sessionId, undefined)
+        changed = true
+        continue
+      }
+
+      if (currentSignature === syncSnapshotSignature(todos)) continue
+      if (!changed) nextTodo = { ...state.todo }
+      nextTodo[sessionId] = todos
+      useTodosPersistStore.getState().setSessionTodos(sessionId, todos)
+      changed = true
+    }
+
+    return changed ? { todo: nextTodo } : state
+  })
 }
 
 function needsSnapshotAfterStatusPoll(
@@ -1016,6 +1067,8 @@ async function resyncDirectoryAfterReconnect(
   routingIndex: EventRoutingIndex,
 ) {
   const current = store.getState()
+  await resyncBlockingRequestsForDirectory(directory, store)
+
   const candidateSessionIds = getActiveSessionCandidateIds(directory, current)
   if (candidateSessionIds.length === 0) return
 
@@ -1091,7 +1144,7 @@ async function resyncDirectoryAfterReconnect(
     setIndexedSessionMessages(routingIndex, sessionId, directory, nextMessages)
   }))
 
-  await resyncBlockingRequestsForDirectory(directory, store, candidateSessionIds)
+  await resyncSessionTodosForDirectory(directory, store, candidateSessionIds)
 
   ingestDirectoryStateIntoRoutingIndex(routingIndex, directory, store.getState())
 }
@@ -1177,24 +1230,23 @@ function handleEvent(
     if (permissionStore.isSessionAutoAccepting(permission.sessionID)) {
       updateRoutingIndexFromEvent(routingIndex, resolvedDirectory, payload)
       void sessionActions.respondToPermission(permission.sessionID, permission.id, "once").catch(() => undefined)
-      return
-    }
-
-    const toastKey = getPermissionToastKey(permission.sessionID, permission.id)
-    const isViewed = isViewedInCurrentSession(resolvedDirectory, permission.sessionID)
-    if (!isViewed && toastKey && !pendingPermissionToastIds.has(toastKey)) {
-      pendingPermissionToastIds.add(toastKey)
-      const description = typeof permission.permission === "string" && permission.permission.trim().length > 0
-        ? permission.permission
-        : "Agent needs your approval"
-      toast.info("Permission needed", {
-        id: `permission-${toastKey}`,
-        description,
-        action: {
-          label: "Open session",
-          onClick: () => openSessionFromToast(permission.sessionID, resolvedDirectory),
-        },
-      })
+    } else {
+      const toastKey = getPermissionToastKey(permission.sessionID, permission.id)
+      const isViewed = isViewedInCurrentSession(resolvedDirectory, permission.sessionID)
+      if (!isViewed && toastKey && !pendingPermissionToastIds.has(toastKey)) {
+        pendingPermissionToastIds.add(toastKey)
+        const description = typeof permission.permission === "string" && permission.permission.trim().length > 0
+          ? permission.permission
+          : "Agent needs your approval"
+        toast.info("Permission needed", {
+          id: `permission-${toastKey}`,
+          description,
+          action: {
+            label: "Open session",
+            onClick: () => openSessionFromToast(permission.sessionID, resolvedDirectory),
+          },
+        })
+      }
     }
   }
 

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1228,7 +1228,6 @@ function handleEvent(
     const permission = payload.properties as PermissionRequest
     const permissionStore = usePermissionStore.getState()
     if (permissionStore.isSessionAutoAccepting(permission.sessionID)) {
-      updateRoutingIndexFromEvent(routingIndex, resolvedDirectory, payload)
       void sessionActions.respondToPermission(permission.sessionID, permission.id, "once").catch(() => undefined)
     } else {
       const toastKey = getPermissionToastKey(permission.sessionID, permission.id)

--- a/packages/vscode/src/bridge-system-runtime.ts
+++ b/packages/vscode/src/bridge-system-runtime.ts
@@ -498,7 +498,7 @@ export async function handleSystemBridgeMessage(
       }
     }
 
-    case 'api:notifications/auto-accept': {
+    case 'api:sessions/permission-auto-accept': {
       const request = (payload || {}) as { sessionId?: unknown; enabled?: unknown };
       const sessionId = typeof request.sessionId === 'string' ? request.sessionId.trim() : '';
       if (!sessionId) {

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -440,12 +440,14 @@ const handleLocalApiRequest = async (url: URL, init?: RequestInit) => {
     });
   }
 
-  if (normalizedPathname === '/api/notifications/auto-accept' && method === 'POST') {
+  const sessionAutoAcceptMatch = normalizedPathname.match(/^\/api\/sessions\/([^/]+)\/permission-auto-accept$/);
+  if (sessionAutoAcceptMatch && method === 'POST') {
     const bodyText = await extractBodyText(url, init, method);
     const body = bodyText
       ? JSON.parse(bodyText) as { sessionId?: unknown; enabled?: unknown }
       : {};
-    const result = await sendBridgeMessage<{ success?: boolean }>('api:notifications/auto-accept', body)
+    const sessionId = decodeURIComponent(sessionAutoAcceptMatch[1] || '');
+    const result = await sendBridgeMessage<{ success?: boolean }>('api:sessions/permission-auto-accept', { ...body, sessionId })
       .catch(() => ({ success: false }));
     return new Response(JSON.stringify(result), {
       status: result?.success === false ? 400 : 200,

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -444,7 +444,7 @@ const handleLocalApiRequest = async (url: URL, init?: RequestInit) => {
   if (sessionAutoAcceptMatch && method === 'POST') {
     const bodyText = await extractBodyText(url, init, method);
     const body = bodyText
-      ? JSON.parse(bodyText) as { sessionId?: unknown; enabled?: unknown }
+      ? JSON.parse(bodyText) as { sessionId?: unknown; enabled?: unknown; directory?: unknown }
       : {};
     const sessionId = decodeURIComponent(sessionAutoAcceptMatch[1] || '');
     const result = await sendBridgeMessage<{ success?: boolean }>('api:sessions/permission-auto-accept', { ...body, sessionId })

--- a/packages/web/server/lib/notifications/DOCUMENTATION.md
+++ b/packages/web/server/lib/notifications/DOCUMENTATION.md
@@ -35,13 +35,18 @@ This module provides notification message preparation utilities for the web serv
   - `POST /api/sessions/:id/view`
   - `POST /api/sessions/:id/unview`
   - `POST /api/sessions/:id/message-sent`
+  - `POST /api/sessions/:id/permission-auto-accept`
 
 ### Trigger runtime API (runtime.js)
 - `createNotificationTriggerRuntime(dependencies)`: creates runtime-owned debounced trigger handling for OpenCode events.
 - Returned API:
   - `maybeSendPushForTrigger(payload)`
+  - `setAutoAcceptSession(sessionId, enabled, options?)`
+  - `drainAutoAcceptPermissions()`
+  - `setGetIsWindowFocused(callback)`
 - Owns:
   - completion/error/question/permission trigger routing
+  - server-side Permission Auto-Accept for mirrored sessions while the client is backgrounded
   - session parent cache for subtask suppression
   - template resolution and fallback behavior
   - native notification fanout and web push payload fanout

--- a/packages/web/server/lib/notifications/routes.js
+++ b/packages/web/server/lib/notifications/routes.js
@@ -299,19 +299,22 @@ export const registerNotificationRoutes = (app, dependencies) => {
     });
   });
 
-  // Mirror client-side Permission Auto-Accept state to the server so it can
-  // suppress permission notifications at the source (the 500ms debounce race
-  // otherwise leaks notifications for auto-accepted permissions).
-  app.post('/api/notifications/auto-accept', (req, res) => {
+  const updateSessionPermissionAutoAccept = async (req, res, rawSessionId) => {
     const body = req.body && typeof req.body === 'object' ? req.body : {};
-    const sessionId = typeof body.sessionId === 'string' ? body.sessionId.trim() : '';
+    const sessionId = typeof rawSessionId === 'string' ? rawSessionId.trim() : '';
     const enabled = body.enabled === true;
+    const directory = typeof body.directory === 'string' ? body.directory.trim() : '';
     if (!sessionId) {
       return res.status(400).json({ error: 'sessionId required' });
     }
+    await ensureSessionWatcher();
     if (typeof setAutoAcceptSession === 'function') {
-      setAutoAcceptSession(sessionId, enabled);
+      setAutoAcceptSession(sessionId, enabled, { directory });
     }
     return res.json({ success: true, sessionId, enabled });
+  };
+
+  app.post('/api/sessions/:id/permission-auto-accept', async (req, res) => {
+    return updateSessionPermissionAutoAccept(req, res, req.params.id);
   });
 };

--- a/packages/web/server/lib/notifications/runtime.js
+++ b/packages/web/server/lib/notifications/runtime.js
@@ -34,17 +34,49 @@ export const createNotificationTriggerRuntime = (deps) => {
   const SESSION_PARENT_CACHE_TTL_MS = 60 * 1000;
 
   // Sessions where the client has enabled Permission Auto-Accept. Mirrored
-  // from the client-side permissionStore via POST /api/notifications/auto-accept
+  // from the client-side permissionStore via the session auto-accept endpoint
   // so the server can suppress permission notifications BEFORE dispatch (the
   // 500ms debounce race otherwise leaks notifications for auto-accepted
   // permissions when the replied round-trip is slower than the debounce).
   const autoAcceptingSessions = new Set();
-  const setAutoAcceptSession = (sessionId, enabled) => {
+  const autoAcceptingPermissionRequests = new Set();
+  const autoAcceptSessionDirectories = new Map();
+  let autoAcceptPollTimer = null;
+  let autoAcceptDrainInFlight = false;
+
+  const rememberAutoAcceptDirectory = (sessionId, directory) => {
     if (typeof sessionId !== 'string' || sessionId.length === 0) return;
+    if (typeof directory !== 'string' || directory.trim().length === 0) return;
+    const existing = autoAcceptSessionDirectories.get(sessionId) ?? new Set();
+    existing.add(directory.trim());
+    autoAcceptSessionDirectories.set(sessionId, existing);
+  };
+
+  const stopAutoAcceptPollerIfIdle = () => {
+    if (autoAcceptingSessions.size > 0 || !autoAcceptPollTimer) return;
+    clearInterval(autoAcceptPollTimer);
+    autoAcceptPollTimer = null;
+  };
+
+  const ensureAutoAcceptPoller = () => {
+    if (autoAcceptPollTimer || autoAcceptingSessions.size === 0) return;
+    autoAcceptPollTimer = setInterval(() => {
+      void drainAutoAcceptPermissions().catch(() => undefined);
+    }, 1500);
+    autoAcceptPollTimer.unref?.();
+  };
+
+  const setAutoAcceptSession = (sessionId, enabled, options = {}) => {
+    if (typeof sessionId !== 'string' || sessionId.length === 0) return;
+    rememberAutoAcceptDirectory(sessionId, options.directory);
     if (enabled) {
       autoAcceptingSessions.add(sessionId);
+      ensureAutoAcceptPoller();
+      void drainAutoAcceptPermissions().catch(() => undefined);
     } else {
       autoAcceptingSessions.delete(sessionId);
+      autoAcceptSessionDirectories.delete(sessionId);
+      stopAutoAcceptPollerIfIdle();
     }
   };
 
@@ -139,6 +171,91 @@ export const createNotificationTriggerRuntime = (deps) => {
       current = parent;
     }
     return false;
+  };
+
+  const getDirectoryFromPayload = (payload) => {
+    const directory = payload?.properties?.directory ?? payload?.directory;
+    return typeof directory === 'string' && directory.trim().length > 0 ? directory.trim() : '';
+  };
+
+  const autoAcceptPermission = async (sessionId, requestId, directory = '') => {
+    if (!sessionId || !requestId) return false;
+    const key = `${sessionId}:${requestId}`;
+    if (autoAcceptingPermissionRequests.has(key)) return false;
+    autoAcceptingPermissionRequests.add(key);
+    try {
+      const url = new URL(buildOpenCodeUrl(`/permission/${encodeURIComponent(requestId)}/reply`, ''));
+      if (directory) {
+        url.searchParams.set('directory', directory);
+      }
+      const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          ...getOpenCodeAuthHeaders(),
+        },
+        body: JSON.stringify({ reply: 'once' }),
+        signal: AbortSignal.timeout(5000),
+      });
+      return response.ok;
+    } catch (error) {
+      console.warn('[Notification] Background permission auto-accept failed:', error?.message || error);
+      return false;
+    } finally {
+      autoAcceptingPermissionRequests.delete(key);
+    }
+  };
+
+  const drainAutoAcceptPermissions = async () => {
+    if (autoAcceptingSessions.size === 0) return;
+    if (autoAcceptDrainInFlight) return;
+    autoAcceptDrainInFlight = true;
+    try {
+      const directories = new Set(['']);
+      for (const directorySet of autoAcceptSessionDirectories.values()) {
+        for (const directory of directorySet) {
+          directories.add(directory);
+        }
+      }
+
+      for (const directory of directories) {
+        try {
+          const url = new URL(buildOpenCodeUrl('/permission', ''));
+          if (directory) {
+            url.searchParams.set('directory', directory);
+          }
+          const response = await fetch(url.toString(), {
+            method: 'GET',
+            headers: {
+              Accept: 'application/json',
+              ...getOpenCodeAuthHeaders(),
+            },
+            signal: AbortSignal.timeout(5000),
+          });
+          if (!response.ok) continue;
+          const data = await response.json().catch(() => null);
+          const permissions = Array.isArray(data)
+            ? data
+            : Array.isArray(data?.items)
+              ? data.items
+              : Array.isArray(data?.data)
+                ? data.data
+                : [];
+          for (const permission of permissions) {
+            const sessionId = permission?.sessionID ?? permission?.sessionId;
+            const requestId = permission?.id ?? permission?.requestID ?? permission?.requestId;
+            if (typeof sessionId !== 'string' || typeof requestId !== 'string') continue;
+            rememberAutoAcceptDirectory(sessionId, permission?.directory ?? directory);
+            if (!await isSessionAutoAccepting(sessionId)) continue;
+            void autoAcceptPermission(sessionId, requestId, permission?.directory ?? directory);
+          }
+        } catch {
+        }
+      }
+    } finally {
+      autoAcceptDrainInFlight = false;
+    }
   };
 
   const extractSessionIdFromPayload = (payload) => {
@@ -464,6 +581,7 @@ export const createNotificationTriggerRuntime = (deps) => {
       // ancestor). Skip the whole notification path — the client responds
       // directly and the user has opted out of approval prompts.
       if (await isSessionAutoAccepting(sessionId)) {
+        void autoAcceptPermission(sessionId, requestId, getDirectoryFromPayload(payload));
         if (requestKey) notifiedPermissionRequests.add(requestKey);
         return;
       }
@@ -477,6 +595,7 @@ export const createNotificationTriggerRuntime = (deps) => {
         pushPermissionDebounceTimers.delete(sessionId);
 
         if (await isSessionAutoAccepting(sessionId)) {
+          void autoAcceptPermission(sessionId, requestId, getDirectoryFromPayload(payload));
           if (requestKey) notifiedPermissionRequests.add(requestKey);
           return;
         }
@@ -561,6 +680,7 @@ export const createNotificationTriggerRuntime = (deps) => {
   return {
     maybeSendPushForTrigger,
     setAutoAcceptSession,
+    drainAutoAcceptPermissions,
     setGetIsWindowFocused,
   };
 };


### PR DESCRIPTION
## Summary

- Move permission auto-accept mirroring to a session-scoped API endpoint.
- Let the server auto-accept pending permission requests while the UI is backgrounded or disconnected.
- Resync pending permissions and session todos after reconnect without clearing local state on fetch failures.
- Keep auto-accepted permission events in sync state so permission history remains visible while connected.
- Add expanded rendering for `todowrite` tool calls in chat history.
- Keep VS Code local API handling aligned with the new session-scoped auto-accept route.

## Details

### Permission auto-accept

Permission auto-accept is now mirrored through `POST /api/sessions/:id/permission-auto-accept`.

The server tracks enabled sessions, remembers known directory hints, drains current pending permissions when auto-accept is enabled, and runs a lightweight background poller while auto-accept sessions exist.

This allows permission requests to be approved even when the browser UI is asleep, disconnected, or delayed.

### Reconnect and resync

Reconnect recovery now refreshes blocking requests before returning early for directories without active candidate sessions. It also refreshes authoritative session todos for reconnect candidates.

Todo resync preserves existing local todos when the fetch fails, and only clears stale todos after a successful empty server response.

### Chat history

`todowrite` is now expandable in chat history and renders structured todo rows with status and priority labels using existing localized strings and theme tokens.

<img width="1115" height="2404" alt="Screenshot_20260529_103111" src="https://github.com/user-attachments/assets/b382a080-acd3-4a84-9cd0-bf57cc8a23cd" />
