### PR TITLE
feat: add opencode-go rate limit display support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -246,6 +246,7 @@
         "@octokit/rest": "^22.0.1",
         "@opencode-ai/sdk": "^1.17.7",
         "@simplewebauthn/server": "13.3.0",
+        "@steipete/sweet-cookie": "^0.4.0",
         "adm-zip": "^0.5.16",
         "better-sqlite3": "^12.10.0",
         "bun-pty": "^0.4.5",
@@ -1206,6 +1207,8 @@
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@steipete/sweet-cookie": ["@steipete/sweet-cookie@0.4.0", "", { "bin": { "sweet-cookie": "dist/cli.js" } }, "sha512-SREuwUPPVZOj0X4lp+3uN7/sP/I6J2HYY50usKfb5+uLSKUrrlU0TkKPaOx0XAKNR7VC4DpjbsVm0Z7hIo6U8w=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 
@@ -3378,8 +3381,6 @@
     "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@npmcli/agent/socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
-
-    "@openchamber/ui/ghostty-web": ["ghostty-web@0.4.0", "", {}, "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg=="],
 
     "@openchamber/web/cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
 

--- a/packages/ui/src/lib/quota/providers/index.ts
+++ b/packages/ui/src/lib/quota/providers/index.ts
@@ -20,6 +20,7 @@ export const QUOTA_PROVIDERS: QuotaProviderMeta[] = [
   { id: 'minimax-coding-plan', name: 'MiniMax Coding Plan (minimax.io)' },
   { id: 'ollama-cloud', name: 'Ollama Cloud' },
   { id: 'wafer', name: 'Wafer.ai' },
+  { id: 'opencode-go', name: 'OpenCode' },
 ];
 
 export const QUOTA_PROVIDER_MAP = QUOTA_PROVIDERS.reduce<

--- a/packages/ui/src/types/quota.ts
+++ b/packages/ui/src/types/quota.ts
@@ -14,7 +14,8 @@ export type QuotaProviderId =
   | 'minimax-coding-plan'
   | 'minimax-cn-coding-plan'
   | 'ollama-cloud'
-  | 'wafer';
+  | 'wafer'
+  | 'opencode-go';
 
 export interface UsageWindow {
   usedPercent: number | null;

--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -1004,6 +1004,7 @@ function parseArgs(argv = process.argv.slice(2)) {
   const subcommand = command === 'tunnel' ? (positional[1] || 'help') : null;
   const tunnelAction = command === 'tunnel' ? (positional[2] || null) : null;
   const startupAction = command === 'startup' ? (positional[1] || 'status') : null;
+  const quotaAction = command === 'quota' ? (positional[1] || 'status') : null;
 
   if (options.lan && typeof options.host !== 'string') {
     options.host = '0.0.0.0';
@@ -1018,6 +1019,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     subcommand,
     tunnelAction,
     startupAction,
+    quotaAction,
     options,
     removedFlagErrors,
     helpRequested,
@@ -1042,6 +1044,7 @@ COMMANDS:
   logs           Tail OpenChamber logs
   connect-url    Generate URL/QR for connecting another client
   update         Check for and install updates
+  quota          Quota provider commands (status, login)
 
 OPTIONS:
   -p, --port              Web server port (default: ${DEFAULT_PORT})
@@ -1138,6 +1141,30 @@ EXAMPLES:
   openchamber connect-url --port 3000 --qr
   openchamber connect-url --port 3000 --api-only --lan --server http://workstation.local:3000 --qr
   openchamber connect-url --server https://openchamber.example.com --name Workstation
+`);
+}
+
+function showQuotaHelp() {
+  console.log(`
+ Quota Provider Commands
+
+USAGE:
+  openchamber quota <SUBCOMMAND> [OPTIONS]
+
+SUBCOMMANDS:
+  status      Show quota provider status
+  login       Log in to a quota provider via browser cookie detection
+
+OPTIONS:
+  --provider <id>  Quota provider ID (default: opencode-go)
+  --json           Output machine-readable JSON
+  -q, --quiet      Suppress non-essential output
+  -h, --help       Show this help
+
+EXAMPLES:
+  openchamber quota login
+  openchamber quota login --provider ollama-cloud
+  openchamber quota login --json
 `);
 }
 
@@ -5569,11 +5596,79 @@ const commands = {
       process.stdout.write(`updated ${updateInfo.version || 'latest'}\n`);
     }
   },
+
+  async quota(options, action) {
+    if (action === 'login') {
+      const providerId = options.provider || 'opencode-go';
+      let mod;
+      try {
+        mod = await import(`../server/lib/quota/providers/${providerId}.js`);
+      } catch {
+        if (isJsonMode(options)) {
+          printJson({ status: 'error', provider: providerId, message: `Unknown provider '${providerId}'` });
+        } else {
+          console.error(`Error: Unknown quota provider '${providerId}'.`);
+        }
+        process.exit(EXIT_CODE.USAGE_ERROR);
+      }
+      if (typeof mod.login !== 'function') {
+        if (isJsonMode(options)) {
+          printJson({ status: 'error', provider: providerId, message: `Provider '${providerId}' does not support login` });
+        } else {
+          console.error(`Error: Provider '${providerId}' does not support login.`);
+        }
+        process.exit(EXIT_CODE.USAGE_ERROR);
+      }
+      try {
+        await mod.login(options);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (isJsonMode(options)) {
+          printJson({ status: 'error', provider: providerId, message: msg });
+        } else {
+          console.error(`Error: ${msg}`);
+        }
+        process.exit(EXIT_CODE.GENERAL_ERROR);
+      }
+      return;
+    }
+
+    if (action === 'status') {
+      const { listConfiguredQuotaProviders } = await import('../server/lib/quota/providers/index.js');
+
+      if (isJsonMode(options)) {
+        const configured = listConfiguredQuotaProviders();
+        printJson({ status: 'ok', provider: options.provider || 'all', configuredProviders: configured });
+        return;
+      }
+      if (isQuietMode(options)) {
+        process.stdout.write('quota status\n');
+        return;
+      }
+      clackIntro(boldText('Quota Status'));
+      const configured = listConfiguredQuotaProviders();
+      if (configured.length > 0) {
+        logStatus('success', `Configured providers: ${configured.join(', ')}`);
+      } else {
+        clackLog.info('No quota providers configured.');
+        clackLog.info('Use `openchamber quota login` to set up a quota provider.');
+      }
+      clackOutro('');
+      return;
+    }
+
+    if (isJsonMode(options)) {
+      printJson({ status: 'error', error: `Unknown quota action '${action}'` });
+    } else {
+      console.error(`Error: Unknown quota action '${action}'. Use: status, login`);
+    }
+    process.exit(EXIT_CODE.USAGE_ERROR);
+  },
 };
 
 async function main() {
   const parsed = parseArgs();
-  const { command, subcommand, tunnelAction, startupAction, options, removedFlagErrors, helpRequested, versionRequested } = parsed;
+  const { command, subcommand, tunnelAction, startupAction, quotaAction, options, removedFlagErrors, helpRequested, versionRequested } = parsed;
   activeCommandOptions = options;
 
   if (versionRequested) {
@@ -5609,6 +5704,8 @@ async function main() {
       showStartupHelp();
     } else if (command === 'connect-url') {
       showConnectUrlHelp();
+    } else if (command === 'quota') {
+      showQuotaHelp();
     } else {
       showHelp();
     }
@@ -5625,8 +5722,13 @@ async function main() {
     return;
   }
 
+  if (command === 'quota') {
+    await commands.quota(options, quotaAction);
+    return;
+  }
+
   if (!commands[command]) {
-    const knownCommands = ['serve', 'stop', 'restart', 'status', 'tunnel', 'startup', 'logs', 'update'];
+    const knownCommands = ['serve', 'stop', 'restart', 'status', 'tunnel', 'startup', 'logs', 'update', 'quota'];
     const suggestion = findClosestMatch(command, knownCommands);
     const hint = suggestion ? ` Did you mean '${suggestion}'?` : '';
     if (isJsonMode(options)) {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,6 +27,7 @@
     "@octokit/rest": "^22.0.1",
     "@opencode-ai/sdk": "^1.17.7",
     "@simplewebauthn/server": "13.3.0",
+    "@steipete/sweet-cookie": "^0.4.0",
     "adm-zip": "^0.5.16",
     "better-sqlite3": "^12.10.0",
     "bun-pty": "^0.4.5",

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -32,6 +32,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 | `minimax-cn-coding-plan` | MiniMax Coding Plan (minimaxi.com) | `providers/minimax-cn-coding-plan.js` | `minimax-cn-coding-plan` |
 | `ollama-cloud` | Ollama Cloud | `providers/ollama-cloud.js` | Cookie file at `~/.config/ollama-quota/cookie` (raw session cookie string) |
 | `wafer` | Wafer.ai | `providers/wafer.js` | `wafer`, `wafer-ai`, `wafer_ai`, `wafer.ai` |
+| `opencode-go` | OpenCode | `providers/opencode-go.js` | `opencode-go`, `opencode_go`, `opencodego` |
 
 ## Internal-only provider module
 - `providers/openai.js` exists for logic parity/reuse but is intentionally not registered for dispatcher ID routing.

--- a/packages/web/server/lib/quota/index.js
+++ b/packages/web/server/lib/quota/index.js
@@ -23,5 +23,6 @@ export {
   fetchMinimaxCnCodingPlanQuota,
   fetchOllamaCloudQuota,
   fetchZhipuaiQuota,
-  fetchWaferQuota
+  fetchWaferQuota,
+  fetchOpencodeGoQuota
 } from './providers/index.js';

--- a/packages/web/server/lib/quota/providers/claude.js
+++ b/packages/web/server/lib/quota/providers/claude.js
@@ -5,8 +5,11 @@ import {
   buildResult,
   toUsageWindow,
   toNumber,
-  toTimestamp
+  toTimestamp,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'claude';
 export const providerName = 'Claude';
@@ -17,6 +20,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.access || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/codex.js
+++ b/packages/web/server/lib/quota/providers/codex.js
@@ -6,8 +6,11 @@ import {
   toUsageWindow,
   toNumber,
   toTimestamp,
-  formatMoney
+  formatMoney,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'codex';
 export const providerName = 'Codex';
@@ -18,6 +21,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.access || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/copilot.js
+++ b/packages/web/server/lib/quota/providers/copilot.js
@@ -5,8 +5,11 @@ import {
   buildResult,
   toUsageWindow,
   toNumber,
-  toTimestamp
+  toTimestamp,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 const buildCopilotWindows = (payload) => {
   const quota = payload?.quota_snapshots ?? {};
@@ -47,6 +50,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.access || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/cursor.js
+++ b/packages/web/server/lib/quota/providers/cursor.js
@@ -9,6 +9,7 @@ import {
   toTimestamp,
   toUsageWindow
 } from '../utils/index.js';
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 const BASE_URL = 'https://api2.cursor.sh';
 const USAGE_URL = `${BASE_URL}/aiserver.v1.DashboardService/GetCurrentPeriodUsage`;
@@ -270,6 +271,12 @@ const appendCreditsWindow = (windows, credits) => {
 export const isConfigured = () => {
   const auth = loadAuthState();
   return Boolean(auth.accessToken || auth.refreshToken);
+};
+
+export const login = async (options = {}) => {
+  if (isJsonMode(options)) printJson({ provider: providerId, type: 'unsupported' });
+  else if (isQuietMode(options)) process.stdout.write('Login not supported\n');
+  else log.info(`Login not available for ${providerName}.`);
 };
 
 export const fetchQuota = async () => {

--- a/packages/web/server/lib/quota/providers/google/index.js
+++ b/packages/web/server/lib/quota/providers/google/index.js
@@ -26,6 +26,7 @@ export {
 } from './api.js';
 
 import { buildResult } from '../../utils/index.js';
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../../bin/cli-output.js';
 import {
   resolveGoogleAuthSources,
   resolveGoogleOAuthClient,
@@ -37,6 +38,12 @@ import {
   fetchGoogleQuotaBuckets,
   fetchGoogleModels
 } from './api.js';
+
+export const login = async (options = {}) => {
+  if (isJsonMode(options)) printJson({ provider: 'google', command: 'opencode auth login' });
+  else if (isQuietMode(options)) process.stdout.write('Run: opencode auth login\n');
+  else log.info("Run 'opencode auth login' to add auth for Google.");
+};
 
 export const fetchGoogleQuota = async () => {
   const authSources = resolveGoogleAuthSources();

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -22,6 +22,7 @@ import * as minimaxCodingPlan from './minimax-coding-plan.js';
 import * as minimaxCnCodingPlan from './minimax-cn-coding-plan.js';
 import * as ollamaCloud from './ollama-cloud.js';
 import * as wafer from './wafer.js';
+import * as opencodeGo from './opencode-go.js';
 
 const registry = {
   claude: {
@@ -113,6 +114,12 @@ const registry = {
     providerName: wafer.providerName,
     isConfigured: wafer.isConfigured,
     fetchQuota: wafer.fetchQuota
+  },
+  'opencode-go': {
+    providerId: opencodeGo.providerId,
+    providerName: opencodeGo.providerName,
+    isConfigured: opencodeGo.isConfigured,
+    fetchQuota: opencodeGo.fetchQuota
   }
 };
 
@@ -174,4 +181,5 @@ export const fetchMinimaxCodingPlanQuota = minimaxCodingPlan.fetchQuota;
 export const fetchMinimaxCnCodingPlanQuota = minimaxCnCodingPlan.fetchQuota;
 export const fetchOllamaCloudQuota = ollamaCloud.fetchQuota;
 export const fetchWaferQuota = wafer.fetchQuota;
+export const fetchOpencodeGoQuota = opencodeGo.fetchQuota;
 export const fetchZhipuaiQuota = zhipuaiCodingPlan.fetchQuota;

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -29,97 +29,113 @@ const registry = {
     providerId: claude.providerId,
     providerName: claude.providerName,
     isConfigured: claude.isConfigured,
-    fetchQuota: claude.fetchQuota
+    fetchQuota: claude.fetchQuota,
+    login: claude.login
   },
   codex: {
     providerId: codex.providerId,
     providerName: codex.providerName,
     isConfigured: codex.isConfigured,
-    fetchQuota: codex.fetchQuota
+    fetchQuota: codex.fetchQuota,
+    login: codex.login
   },
   cursor: {
     providerId: cursor.providerId,
     providerName: cursor.providerName,
     isConfigured: cursor.isConfigured,
-    fetchQuota: cursor.fetchQuota
+    fetchQuota: cursor.fetchQuota,
+    login: cursor.login
   },
   google: {
     providerId: 'google',
     providerName: 'Google',
     isConfigured: () => google.resolveGoogleAuthSources().length > 0,
-    fetchQuota: google.fetchGoogleQuota
+    fetchQuota: google.fetchGoogleQuota,
+    login: google.login
   },
   'zai-coding-plan': {
     providerId: zai.providerId,
     providerName: zai.providerName,
     isConfigured: zai.isConfigured,
-    fetchQuota: zai.fetchQuota
+    fetchQuota: zai.fetchQuota,
+    login: zai.login
   },
   'zhipuai-coding-plan': {
     providerId: zhipuaiCodingPlan.providerId,
     providerName: zhipuaiCodingPlan.providerName,
     isConfigured: zhipuaiCodingPlan.isConfigured,
-    fetchQuota: zhipuaiCodingPlan.fetchQuota
+    fetchQuota: zhipuaiCodingPlan.fetchQuota,
+    login: zhipuaiCodingPlan.login
   },
   'kimi-for-coding': {
     providerId: kimi.providerId,
     providerName: kimi.providerName,
     isConfigured: kimi.isConfigured,
-    fetchQuota: kimi.fetchQuota
+    fetchQuota: kimi.fetchQuota,
+    login: kimi.login
   },
   openrouter: {
     providerId: openrouter.providerId,
     providerName: openrouter.providerName,
     isConfigured: openrouter.isConfigured,
-    fetchQuota: openrouter.fetchQuota
+    fetchQuota: openrouter.fetchQuota,
+    login: openrouter.login
   },
   'nano-gpt': {
     providerId: nanogpt.providerId,
     providerName: nanogpt.providerName,
     isConfigured: nanogpt.isConfigured,
-    fetchQuota: nanogpt.fetchQuota
+    fetchQuota: nanogpt.fetchQuota,
+    login: nanogpt.login
   },
   'github-copilot': {
     providerId: copilot.providerId,
     providerName: copilot.providerName,
     isConfigured: copilot.isConfigured,
-    fetchQuota: copilot.fetchQuota
+    fetchQuota: copilot.fetchQuota,
+    login: copilot.login
   },
   'github-copilot-addon': {
     providerId: copilot.providerIdAddon,
     providerName: copilot.providerNameAddon,
     isConfigured: copilot.isConfigured,
-    fetchQuota: copilot.fetchQuotaAddon
+    fetchQuota: copilot.fetchQuotaAddon,
+    login: copilot.login
   },
   'minimax-coding-plan': {
     providerId: minimaxCodingPlan.providerId,
     providerName: minimaxCodingPlan.providerName,
     isConfigured: minimaxCodingPlan.isConfigured,
-    fetchQuota: minimaxCodingPlan.fetchQuota
+    fetchQuota: minimaxCodingPlan.fetchQuota,
+    login: minimaxCodingPlan.login
   },
   'minimax-cn-coding-plan': {
     providerId: minimaxCnCodingPlan.providerId,
     providerName: minimaxCnCodingPlan.providerName,
     isConfigured: minimaxCnCodingPlan.isConfigured,
-    fetchQuota: minimaxCnCodingPlan.fetchQuota
+    fetchQuota: minimaxCnCodingPlan.fetchQuota,
+    login: minimaxCnCodingPlan.login
   },
   'ollama-cloud': {
     providerId: ollamaCloud.providerId,
     providerName: ollamaCloud.providerName,
     isConfigured: ollamaCloud.isConfigured,
-    fetchQuota: ollamaCloud.fetchQuota
+    fetchQuota: ollamaCloud.fetchQuota,
+    login: ollamaCloud.login
   },
   wafer: {
     providerId: wafer.providerId,
     providerName: wafer.providerName,
     isConfigured: wafer.isConfigured,
-    fetchQuota: wafer.fetchQuota
+    fetchQuota: wafer.fetchQuota,
+    login: wafer.login
   },
   'opencode-go': {
     providerId: opencodeGo.providerId,
     providerName: opencodeGo.providerName,
     isConfigured: opencodeGo.isConfigured,
-    fetchQuota: opencodeGo.fetchQuota
+    fetchQuota: opencodeGo.fetchQuota,
+    login: opencodeGo.login,
   }
 };
 

--- a/packages/web/server/lib/quota/providers/kimi.js
+++ b/packages/web/server/lib/quota/providers/kimi.js
@@ -7,8 +7,11 @@ import {
   toNumber,
   toTimestamp,
   durationToLabel,
-  durationToSeconds
+  durationToSeconds,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'kimi-for-coding';
 export const providerName = 'Kimi for Coding';
@@ -19,6 +22,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.key || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/minimax-cn-coding-plan.js
+++ b/packages/web/server/lib/quota/providers/minimax-cn-coding-plan.js
@@ -7,7 +7,10 @@ import {
   toUsageWindow,
   toNumber,
   toTimestamp,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'minimax-cn-coding-plan';
 export const providerName = 'MiniMax Coding Plan (minimaxi.com)';
@@ -18,6 +21,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.key || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/minimax-coding-plan.js
+++ b/packages/web/server/lib/quota/providers/minimax-coding-plan.js
@@ -6,7 +6,10 @@ import {
   toUsageWindow,
   toNumber,
   toTimestamp,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'minimax-coding-plan';
 export const providerName = 'MiniMax Coding Plan (minimax.io)';
@@ -17,6 +20,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.key || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/nanogpt.js
+++ b/packages/web/server/lib/quota/providers/nanogpt.js
@@ -5,8 +5,11 @@ import {
   buildResult,
   toUsageWindow,
   toNumber,
-  toTimestamp
+  toTimestamp,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 const NANO_GPT_DAILY_WINDOW_SECONDS = 86400;
 
@@ -19,6 +22,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.key || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/ollama-cloud.js
+++ b/packages/web/server/lib/quota/providers/ollama-cloud.js
@@ -1,33 +1,129 @@
-import { homedir } from 'os';
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
-import { readAuthFile } from '../../opencode/auth.js';
-import { buildResult, toUsageWindow, toNumber, discoverBrowserCookie } from '../utils/index.js';
+import { readAuthFile, writeAuthFile } from '../../opencode/auth.js';
+import {
+  getAuthEntry,
+  normalizeAuthEntry,
+  buildResult,
+  toUsageWindow,
+  toNumber,
+  discoverBrowserCookie
+} from '../utils/index.js';
 import { isJsonMode, isQuietMode, canPrompt, printJson, log, text, isCancel } from '../../../../bin/cli-output.js';
-
-const COOKIE_PATH = join(homedir(), '.config', 'ollama-quota', 'cookie');
-const hostPattern = /\.ollama\.com$/;
 
 export const providerId = 'ollama-cloud';
 export const providerName = 'Ollama Cloud';
 export const aliases = ['ollama-cloud', 'ollamacloud'];
 
-const readCookieFile = () => {
-  try {
-    if (!existsSync(COOKIE_PATH)) return null;
-    const content = readFileSync(COOKIE_PATH, 'utf-8');
-    const trimmed = content.trim();
-    return trimmed || null;
-  } catch {
-    return null;
-  }
+const hostPattern = /\.ollama\.com$/;
+
+const readEntry = () => {
+  const envCookie = process.env.OLLAMA_CLOUD_COOKIE || null;
+  if (envCookie) return { cookie: envCookie };
+
+  const auth = readAuthFile();
+  return normalizeAuthEntry(getAuthEntry(auth, aliases));
 };
 
-const saveCookieFile = (cookie) => {
+export const isConfigured = () => {
+  const entry = readEntry();
+  return Boolean(entry?.cookie);
+};
+
+export const login = async (options = {}) => {
+  const auth = readAuthFile();
+  if (Object.keys(auth).length === 0) {
+    if (isJsonMode(options)) printJson({ provider: providerId, command: 'opencode auth login' });
+    else if (isQuietMode(options)) process.stdout.write('Run: opencode auth login\n');
+    else log.info(`Run 'opencode auth login' to add auth for ${providerName}.`);
+    return;
+  }
+
+  if (isJsonMode(options)) {
+    printJson({ provider: providerId, type: 'browser-login', loginUrl: 'https://ollama.com/settings' });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write('Login at https://ollama.com/settings\n');
+    return;
+  }
+
+  log.step('Open https://ollama.com/settings in your browser and log in.');
+  if (canPrompt(options)) {
+    const result = await text({ message: 'Press Enter after logging in', placeholder: 'Enter to continue' });
+    if (isCancel(result)) process.exit(0);
+  }
+
+  const cookie = await discoverBrowserCookie(hostPattern, '__Secure-session');
+  if (!cookie) {
+    log.error('No cookie found. Run `openchamber quota login` again after logging in.');
+    return;
+  }
+
+  const stored = readAuthFile();
+  const current = stored?.[providerId] || {};
+  writeAuthFile({ ...stored, [providerId]: { ...current, cookie } });
+
+  log.success('Login complete.');
+};
+
+export const fetchQuota = async () => {
+  const entry = readEntry();
+  const authCookie = entry?.cookie;
+
+  if (!authCookie) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: false,
+      error: 'Not configured'
+    });
+  }
+
+  const timeoutSignal = AbortSignal.timeout(15_000);
+
   try {
-    mkdirSync(dirname(COOKIE_PATH), { recursive: true });
-    writeFileSync(COOKIE_PATH, cookie, 'utf8');
-  } catch {
+    const response = await fetch('https://ollama.com/settings', {
+      method: 'GET',
+      headers: {
+        Cookie: `__Secure-session=${authCookie}`,
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+      signal: timeoutSignal,
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: response.status === 401 || response.status === 403
+          ? 'Authentication failed' : `HTTP ${response.status}`
+      });
+    }
+
+    const html = await response.text();
+    const windows = parseOllamaSettingsHtml(html);
+
+    return buildResult({
+      providerId,
+      providerName,
+      ok: true,
+      configured: true,
+      usage: { windows }
+    });
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && error.name === 'AbortError' && timeoutSignal.aborted;
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: isTimeout
+        ? 'Request timed out'
+        : (error instanceof Error ? error.message : 'Request failed')
+    });
   }
 };
 
@@ -62,101 +158,4 @@ const parseOllamaSettingsHtml = (html) => {
     });
   }
   return windows;
-};
-
-const readCookie = () => {
-  const envCookie = process.env.OLLAMA_CLOUD_COOKIE || null;
-  if (envCookie) return envCookie;
-  return readCookieFile();
-};
-
-export const isConfigured = () => {
-  const cookie = readCookie();
-  return Boolean(cookie);
-};
-
-export const login = async (options = {}) => {
-  const auth = readAuthFile();
-  if (Object.keys(auth).length === 0) {
-    if (isJsonMode(options)) printJson({ provider: providerId, command: 'opencode auth login' });
-    else if (isQuietMode(options)) process.stdout.write('Run: opencode auth login\n');
-    else log.info(`Run 'opencode auth login' to add auth for ${providerName}.`);
-    return;
-  }
-
-  if (isJsonMode(options)) {
-    printJson({ provider: providerId, type: 'browser-login', loginUrl: 'https://ollama.com/settings' });
-    return;
-  }
-  if (isQuietMode(options)) {
-    process.stdout.write('Login at https://ollama.com/settings\n');
-    return;
-  }
-
-  log.step('Open https://ollama.com/settings in your browser and log in.');
-  if (canPrompt(options)) {
-    const result = await text({ message: 'Press Enter after logging in', placeholder: 'Enter to continue' });
-    if (isCancel(result)) process.exit(0);
-  }
-
-  const cookie = await discoverBrowserCookie(hostPattern, 'ollama_session');
-  if (cookie) {
-    saveCookieFile(cookie);
-    log.success('Cookie found and saved.');
-  } else {
-    log.error('No cookie found. Run `openchamber quota login` again after logging in.');
-  }
-};
-
-export const fetchQuota = async () => {
-  const authCookie = readCookie();
-
-  if (!authCookie) {
-    return buildResult({
-      providerId,
-      providerName,
-      ok: false,
-      configured: false,
-      error: 'Not configured'
-    });
-  }
-
-  try {
-    const response = await fetch('https://ollama.com/settings', {
-      method: 'GET',
-      headers: {
-        Cookie: authCookie,
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
-      }
-    });
-
-    if (!response.ok) {
-      return buildResult({
-        providerId,
-        providerName,
-        ok: false,
-        configured: true,
-        error: `API error: ${response.status}`
-      });
-    }
-
-    const html = await response.text();
-    const windows = parseOllamaSettingsHtml(html);
-
-    return buildResult({
-      providerId,
-      providerName,
-      ok: true,
-      configured: true,
-      usage: { windows }
-    });
-  } catch (error) {
-    return buildResult({
-      providerId,
-      providerName,
-      ok: false,
-      configured: true,
-      error: error instanceof Error ? error.message : 'Request failed'
-    });
-  }
 };

--- a/packages/web/server/lib/quota/providers/ollama-cloud.js
+++ b/packages/web/server/lib/quota/providers/ollama-cloud.js
@@ -1,9 +1,12 @@
 import { homedir } from 'os';
-import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
-import { buildResult, toUsageWindow, toNumber } from '../utils/index.js';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { readAuthFile } from '../../opencode/auth.js';
+import { buildResult, toUsageWindow, toNumber, discoverBrowserCookie } from '../utils/index.js';
+import { isJsonMode, isQuietMode, canPrompt, printJson, log, text, isCancel } from '../../../../bin/cli-output.js';
 
 const COOKIE_PATH = join(homedir(), '.config', 'ollama-quota', 'cookie');
+const hostPattern = /\.ollama\.com$/;
 
 export const providerId = 'ollama-cloud';
 export const providerName = 'Ollama Cloud';
@@ -17,6 +20,14 @@ const readCookieFile = () => {
     return trimmed || null;
   } catch {
     return null;
+  }
+};
+
+const saveCookieFile = (cookie) => {
+  try {
+    mkdirSync(dirname(COOKIE_PATH), { recursive: true });
+    writeFileSync(COOKIE_PATH, cookie, 'utf8');
+  } catch {
   }
 };
 
@@ -53,15 +64,54 @@ const parseOllamaSettingsHtml = (html) => {
   return windows;
 };
 
+const readCookie = () => {
+  const envCookie = process.env.OLLAMA_CLOUD_COOKIE || null;
+  if (envCookie) return envCookie;
+  return readCookieFile();
+};
+
 export const isConfigured = () => {
-  const cookie = readCookieFile();
+  const cookie = readCookie();
   return Boolean(cookie);
 };
 
-export const fetchQuota = async () => {
-  const cookie = readCookieFile();
+export const login = async (options = {}) => {
+  const auth = readAuthFile();
+  if (Object.keys(auth).length === 0) {
+    if (isJsonMode(options)) printJson({ provider: providerId, command: 'opencode auth login' });
+    else if (isQuietMode(options)) process.stdout.write('Run: opencode auth login\n');
+    else log.info(`Run 'opencode auth login' to add auth for ${providerName}.`);
+    return;
+  }
 
-  if (!cookie) {
+  if (isJsonMode(options)) {
+    printJson({ provider: providerId, type: 'browser-login', loginUrl: 'https://ollama.com/settings' });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write('Login at https://ollama.com/settings\n');
+    return;
+  }
+
+  log.step('Open https://ollama.com/settings in your browser and log in.');
+  if (canPrompt(options)) {
+    const result = await text({ message: 'Press Enter after logging in', placeholder: 'Enter to continue' });
+    if (isCancel(result)) process.exit(0);
+  }
+
+  const cookie = await discoverBrowserCookie(hostPattern, 'ollama_session');
+  if (cookie) {
+    saveCookieFile(cookie);
+    log.success('Cookie found and saved.');
+  } else {
+    log.error('No cookie found. Run `openchamber quota login` again after logging in.');
+  }
+};
+
+export const fetchQuota = async () => {
+  const authCookie = readCookie();
+
+  if (!authCookie) {
     return buildResult({
       providerId,
       providerName,
@@ -75,7 +125,7 @@ export const fetchQuota = async () => {
     const response = await fetch('https://ollama.com/settings', {
       method: 'GET',
       headers: {
-        Cookie: cookie,
+        Cookie: authCookie,
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
       }
     });

--- a/packages/web/server/lib/quota/providers/ollama-cloud.js
+++ b/packages/web/server/lib/quota/providers/ollama-cloud.js
@@ -106,6 +106,16 @@ export const fetchQuota = async () => {
     const html = await response.text();
     const windows = parseOllamaSettingsHtml(html);
 
+    if (Object.keys(windows).length === 0) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'Failed to parse usage data'
+      });
+    }
+
     return buildResult({
       providerId,
       providerName,

--- a/packages/web/server/lib/quota/providers/ollama-cloud.js
+++ b/packages/web/server/lib/quota/providers/ollama-cloud.js
@@ -1,17 +1,25 @@
-import { readAuthFile, writeAuthFile } from '../../opencode/auth.js';
+import { readAuthFile, writeAuthFile } from "../../opencode/auth.js";
 import {
   getAuthEntry,
   normalizeAuthEntry,
   buildResult,
   toUsageWindow,
   toNumber,
-  discoverBrowserCookie
-} from '../utils/index.js';
-import { isJsonMode, isQuietMode, canPrompt, printJson, log, text, isCancel } from '../../../../bin/cli-output.js';
+  discoverBrowserCookie,
+} from "../utils/index.js";
+import {
+  isJsonMode,
+  isQuietMode,
+  canPrompt,
+  printJson,
+  log,
+  text,
+  isCancel,
+} from "../../../../bin/cli-output.js";
 
-export const providerId = 'ollama-cloud';
-export const providerName = 'Ollama Cloud';
-export const aliases = ['ollama-cloud', 'ollamacloud'];
+export const providerId = "ollama-cloud";
+export const providerName = "Ollama Cloud";
+export const aliases = ["ollama-cloud", "ollamacloud"];
 
 const hostPattern = /\.ollama\.com$/;
 
@@ -31,30 +39,41 @@ export const isConfigured = () => {
 export const login = async (options = {}) => {
   const auth = readAuthFile();
   if (Object.keys(auth).length === 0) {
-    if (isJsonMode(options)) printJson({ provider: providerId, command: 'opencode auth login' });
-    else if (isQuietMode(options)) process.stdout.write('Run: opencode auth login\n');
+    if (isJsonMode(options))
+      printJson({ provider: providerId, command: "opencode auth login" });
+    else if (isQuietMode(options))
+      process.stdout.write("Run: opencode auth login\n");
     else log.info(`Run 'opencode auth login' to add auth for ${providerName}.`);
     return;
   }
 
   if (isJsonMode(options)) {
-    printJson({ provider: providerId, type: 'browser-login', loginUrl: 'https://ollama.com/settings' });
+    printJson({
+      provider: providerId,
+      type: "browser-login",
+      loginUrl: "https://ollama.com/settings",
+    });
     return;
   }
   if (isQuietMode(options)) {
-    process.stdout.write('Login at https://ollama.com/settings\n');
+    process.stdout.write("Login at https://ollama.com/settings\n");
     return;
   }
 
-  log.step('Open https://ollama.com/settings in your browser and log in.');
+  log.step("Open https://ollama.com/settings in your browser and log in.");
   if (canPrompt(options)) {
-    const result = await text({ message: 'Press Enter after logging in', placeholder: 'Enter to continue' });
+    const result = await text({
+      message: "Press Enter after logging in",
+      placeholder: "Enter to continue",
+    });
     if (isCancel(result)) process.exit(0);
   }
 
-  const cookie = await discoverBrowserCookie(hostPattern, '__Secure-session');
+  const cookie = await discoverBrowserCookie(hostPattern, "__Secure-session");
   if (!cookie) {
-    log.error('No cookie found. Run `openchamber quota login` again after logging in.');
+    log.error(
+      "No cookie found. Run `openchamber quota login` again after logging in.",
+    );
     return;
   }
 
@@ -62,7 +81,7 @@ export const login = async (options = {}) => {
   const current = stored?.[providerId] || {};
   writeAuthFile({ ...stored, [providerId]: { ...current, cookie } });
 
-  log.success('Login complete.');
+  log.success("Login complete.");
 };
 
 export const fetchQuota = async () => {
@@ -75,19 +94,21 @@ export const fetchQuota = async () => {
       providerName,
       ok: false,
       configured: false,
-      error: 'Not configured'
+      error: "Not configured",
     });
   }
 
   const timeoutSignal = AbortSignal.timeout(15_000);
 
   try {
-    const response = await fetch('https://ollama.com/settings', {
-      method: 'GET',
+    const response = await fetch("https://ollama.com/settings", {
+      method: "GET",
       headers: {
         Cookie: `__Secure-session=${authCookie}`,
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       },
       signal: timeoutSignal,
     });
@@ -98,8 +119,10 @@ export const fetchQuota = async () => {
         providerName,
         ok: false,
         configured: true,
-        error: response.status === 401 || response.status === 403
-          ? 'Authentication failed' : `HTTP ${response.status}`
+        error:
+          response.status === 401 || response.status === 403
+            ? "Authentication failed"
+            : `HTTP ${response.status}`,
       });
     }
 
@@ -112,7 +135,7 @@ export const fetchQuota = async () => {
         providerName,
         ok: false,
         configured: true,
-        error: 'Failed to parse usage data'
+        error: "Failed to parse usage data",
       });
     }
 
@@ -121,18 +144,23 @@ export const fetchQuota = async () => {
       providerName,
       ok: true,
       configured: true,
-      usage: { windows }
+      usage: { windows },
     });
   } catch (error) {
-    const isTimeout = error instanceof DOMException && error.name === 'AbortError' && timeoutSignal.aborted;
+    const isTimeout =
+      error instanceof DOMException &&
+      error.name === "AbortError" &&
+      timeoutSignal.aborted;
     return buildResult({
       providerId,
       providerName,
       ok: false,
       configured: true,
       error: isTimeout
-        ? 'Request timed out'
-        : (error instanceof Error ? error.message : 'Request failed')
+        ? "Request timed out"
+        : error instanceof Error
+          ? error.message
+          : "Request failed",
     });
   }
 };
@@ -144,7 +172,7 @@ const parseOllamaSettingsHtml = (html) => {
     windows.session = toUsageWindow({
       usedPercent: toNumber(sessionMatch[1]),
       windowSeconds: null,
-      resetAt: null
+      resetAt: null,
     });
   }
   const weeklyMatch = html.match(/Weekly\s+usage[^0-9]*([0-9.]+)%/i);
@@ -152,19 +180,20 @@ const parseOllamaSettingsHtml = (html) => {
     windows.weekly = toUsageWindow({
       usedPercent: toNumber(weeklyMatch[1]),
       windowSeconds: null,
-      resetAt: null
+      resetAt: null,
     });
   }
   const premiumMatch = html.match(/Premium[^0-9]*([0-9]+)\s*\/\s*([0-9]+)/i);
   if (premiumMatch) {
     const used = toNumber(premiumMatch[1]);
     const total = toNumber(premiumMatch[2]);
-    const usedPercent = total && used !== null ? Math.min(100, (used / total) * 100) : null;
+    const usedPercent =
+      total && used !== null ? Math.min(100, (used / total) * 100) : null;
     windows.premium = toUsageWindow({
       usedPercent,
       windowSeconds: null,
       resetAt: null,
-      valueLabel: `${used ?? 0} / ${total ?? 0}`
+      valueLabel: `${used ?? 0} / ${total ?? 0}`,
     });
   }
   return windows;

--- a/packages/web/server/lib/quota/providers/opencode-go.js
+++ b/packages/web/server/lib/quota/providers/opencode-go.js
@@ -1,30 +1,123 @@
+import { readAuthFile, writeAuthFile } from '../../opencode/auth.js';
 import {
+  getAuthEntry,
+  normalizeAuthEntry,
   buildResult,
   toUsageWindow,
   toNumber,
+  discoverBrowserCookie
 } from '../utils/index.js';
+import { isJsonMode, isQuietMode, canPrompt, printJson, log, text, isCancel } from '../../../../bin/cli-output.js';
 
 export const providerId = 'opencode-go';
 export const providerName = 'OpenCode';
 export const aliases = ['opencode-go', 'opencode_go', 'opencodego'];
 
+const hostPattern = /\.opencode\.ai$/;
+
+const readEntry = () => {
+  const envWorkspaceId = process.env.OPENCODE_GO_WORKSPACE_ID || null;
+  const envCookie = process.env.OPENCODE_GO_AUTH_COOKIE || null;
+  if (envWorkspaceId && envCookie) return { workspaceId: envWorkspaceId, cookie: envCookie };
+
+  const auth = readAuthFile();
+  return normalizeAuthEntry(getAuthEntry(auth, aliases));
+};
+
 export const isConfigured = () => {
-  return Boolean(
-    process.env.OPENCODE_GO_WORKSPACE_ID && process.env.OPENCODE_GO_AUTH_COOKIE
-  );
+  const entry = readEntry();
+  return Boolean(entry?.workspaceId && entry?.cookie);
+};
+
+const resolveWorkspaceId = async (cookie) => {
+  const response = await fetch('https://opencode.ai/auth', {
+    method: 'GET',
+    redirect: 'manual',
+    headers: {
+      Cookie: `auth=${cookie}`,
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (response.status >= 300 && response.status < 400) {
+    const location = response.headers.get('location');
+    if (!location) return null;
+    const match = location.match(/\/workspace\/([^/]+)/);
+    return match ? match[1] : null;
+  }
+
+  if (response.status === 200) {
+    return null;
+  }
+
+  throw new Error(`Unexpected auth response: HTTP ${response.status}`);
+};
+
+export const login = async (options = {}) => {
+  const auth = readAuthFile();
+  if (Object.keys(auth).length === 0) {
+    if (isJsonMode(options)) printJson({ provider: providerId, command: 'opencode auth login' });
+    else if (isQuietMode(options)) process.stdout.write('Run: opencode auth login\n');
+    else log.info(`Run 'opencode auth login' to add auth for ${providerName}.`);
+    return;
+  }
+
+  if (isJsonMode(options)) {
+    printJson({ provider: providerId, type: 'browser-login', loginUrl: 'https://opencode.ai/auth' });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write('Login at https://opencode.ai/auth\n');
+    return;
+  }
+
+  log.step('Open https://opencode.ai/auth in your browser and log in.');
+  if (canPrompt(options)) {
+    const result = await text({ message: 'Press Enter after logging in', placeholder: 'Enter to continue' });
+    if (isCancel(result)) process.exit(0);
+  }
+
+  const cookie = await discoverBrowserCookie(hostPattern, 'auth');
+  if (!cookie) {
+    log.error('No cookie found. Run `openchamber quota login` again after logging in.');
+    return;
+  }
+
+  let workspaceId;
+  try {
+    workspaceId = await resolveWorkspaceId(cookie);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to resolve workspace';
+    log.error(msg);
+    return;
+  }
+
+  if (!workspaceId) {
+    log.error('No workspace found for this account.');
+    return;
+  }
+
+  const stored = readAuthFile();
+  const current = stored?.['opencode-go'] || {};
+  writeAuthFile({ ...stored, 'opencode-go': { ...current, workspaceId, cookie } });
+
+  log.success('Login complete.');
 };
 
 export const fetchQuota = async () => {
-  const workspaceId = process.env.OPENCODE_GO_WORKSPACE_ID;
-  const explicitCookie = process.env.OPENCODE_GO_AUTH_COOKIE;
+  const entry = readEntry();
+  const workspaceId = entry?.workspaceId;
+  const authCookie = entry?.cookie;
 
-  if (!workspaceId || !explicitCookie) {
+  if (!workspaceId || !authCookie) {
     return buildResult({
       providerId,
       providerName,
       ok: false,
-      configured: !!workspaceId,
-      error: !workspaceId ? 'Not configured' : 'No auth cookie found'
+      configured: !!workspaceId && !!authCookie,
+      error: !(workspaceId && authCookie) ? 'Not configured' : 'No auth cookie found'
     });
   }
 
@@ -35,7 +128,7 @@ export const fetchQuota = async () => {
     const response = await fetch(url, {
       method: 'GET',
       headers: {
-        Cookie: `auth=${explicitCookie}`,
+        Cookie: `auth=${authCookie}`,
         'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
         Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
       },

--- a/packages/web/server/lib/quota/providers/opencode-go.js
+++ b/packages/web/server/lib/quota/providers/opencode-go.js
@@ -1,24 +1,33 @@
-import { readAuthFile, writeAuthFile } from '../../opencode/auth.js';
+import { readAuthFile, writeAuthFile } from "../../opencode/auth.js";
 import {
   getAuthEntry,
   normalizeAuthEntry,
   buildResult,
   toUsageWindow,
   toNumber,
-  discoverBrowserCookie
-} from '../utils/index.js';
-import { isJsonMode, isQuietMode, canPrompt, printJson, log, text, isCancel } from '../../../../bin/cli-output.js';
+  discoverBrowserCookie,
+} from "../utils/index.js";
+import {
+  isJsonMode,
+  isQuietMode,
+  canPrompt,
+  printJson,
+  log,
+  text,
+  isCancel,
+} from "../../../../bin/cli-output.js";
 
-export const providerId = 'opencode-go';
-export const providerName = 'OpenCode';
-export const aliases = ['opencode-go', 'opencode_go', 'opencodego'];
+export const providerId = "opencode-go";
+export const providerName = "OpenCode";
+export const aliases = ["opencode-go", "opencode_go", "opencodego"];
 
 const hostPattern = /\.opencode\.ai$/;
 
 const readEntry = () => {
   const envWorkspaceId = process.env.OPENCODE_GO_WORKSPACE_ID || null;
   const envCookie = process.env.OPENCODE_GO_AUTH_COOKIE || null;
-  if (envWorkspaceId && envCookie) return { workspaceId: envWorkspaceId, cookie: envCookie };
+  if (envWorkspaceId && envCookie)
+    return { workspaceId: envWorkspaceId, cookie: envCookie };
 
   const auth = readAuthFile();
   return normalizeAuthEntry(getAuthEntry(auth, aliases));
@@ -30,19 +39,20 @@ export const isConfigured = () => {
 };
 
 const resolveWorkspaceId = async (cookie) => {
-  const response = await fetch('https://opencode.ai/auth', {
-    method: 'GET',
-    redirect: 'manual',
+  const response = await fetch("https://opencode.ai/auth", {
+    method: "GET",
+    redirect: "manual",
     headers: {
       Cookie: `auth=${cookie}`,
-      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
-      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      "User-Agent":
+        "Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0",
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     },
     signal: AbortSignal.timeout(15_000),
   });
 
   if (response.status >= 300 && response.status < 400) {
-    const location = response.headers.get('location');
+    const location = response.headers.get("location");
     if (!location) return null;
     const match = location.match(/\/workspace\/([^/]+)/);
     return match ? match[1] : null;
@@ -58,30 +68,41 @@ const resolveWorkspaceId = async (cookie) => {
 export const login = async (options = {}) => {
   const auth = readAuthFile();
   if (Object.keys(auth).length === 0) {
-    if (isJsonMode(options)) printJson({ provider: providerId, command: 'opencode auth login' });
-    else if (isQuietMode(options)) process.stdout.write('Run: opencode auth login\n');
+    if (isJsonMode(options))
+      printJson({ provider: providerId, command: "opencode auth login" });
+    else if (isQuietMode(options))
+      process.stdout.write("Run: opencode auth login\n");
     else log.info(`Run 'opencode auth login' to add auth for ${providerName}.`);
     return;
   }
 
   if (isJsonMode(options)) {
-    printJson({ provider: providerId, type: 'browser-login', loginUrl: 'https://opencode.ai/auth' });
+    printJson({
+      provider: providerId,
+      type: "browser-login",
+      loginUrl: "https://opencode.ai/auth",
+    });
     return;
   }
   if (isQuietMode(options)) {
-    process.stdout.write('Login at https://opencode.ai/auth\n');
+    process.stdout.write("Login at https://opencode.ai/auth\n");
     return;
   }
 
-  log.step('Open https://opencode.ai/auth in your browser and log in.');
+  log.step("Open https://opencode.ai/auth in your browser and log in.");
   if (canPrompt(options)) {
-    const result = await text({ message: 'Press Enter after logging in', placeholder: 'Enter to continue' });
+    const result = await text({
+      message: "Press Enter after logging in",
+      placeholder: "Enter to continue",
+    });
     if (isCancel(result)) process.exit(0);
   }
 
-  const cookie = await discoverBrowserCookie(hostPattern, 'auth');
+  const cookie = await discoverBrowserCookie(hostPattern, "auth");
   if (!cookie) {
-    log.error('No cookie found. Run `openchamber quota login` again after logging in.');
+    log.error(
+      "No cookie found. Run `openchamber quota login` again after logging in.",
+    );
     return;
   }
 
@@ -89,21 +110,25 @@ export const login = async (options = {}) => {
   try {
     workspaceId = await resolveWorkspaceId(cookie);
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Failed to resolve workspace';
+    const msg =
+      error instanceof Error ? error.message : "Failed to resolve workspace";
     log.error(msg);
     return;
   }
 
   if (!workspaceId) {
-    log.error('No workspace found for this account.');
+    log.error("No workspace found for this account.");
     return;
   }
 
   const stored = readAuthFile();
-  const current = stored?.['opencode-go'] || {};
-  writeAuthFile({ ...stored, 'opencode-go': { ...current, workspaceId, cookie } });
+  const current = stored?.["opencode-go"] || {};
+  writeAuthFile({
+    ...stored,
+    "opencode-go": { ...current, workspaceId, cookie },
+  });
 
-  log.success('Login complete.');
+  log.success("Login complete.");
 };
 
 export const fetchQuota = async () => {
@@ -117,7 +142,9 @@ export const fetchQuota = async () => {
       providerName,
       ok: false,
       configured: !!workspaceId && !!authCookie,
-      error: !(workspaceId && authCookie) ? 'Not configured' : 'No auth cookie found'
+      error: !(workspaceId && authCookie)
+        ? "Not configured"
+        : "No auth cookie found",
     });
   }
 
@@ -126,11 +153,13 @@ export const fetchQuota = async () => {
   try {
     const url = `https://opencode.ai/workspace/${encodeURIComponent(workspaceId)}/go`;
     const response = await fetch(url, {
-      method: 'GET',
+      method: "GET",
       headers: {
         Cookie: `auth=${authCookie}`,
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        "User-Agent":
+          "Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       },
       signal: timeoutSignal,
     });
@@ -141,8 +170,10 @@ export const fetchQuota = async () => {
         providerName,
         ok: false,
         configured: true,
-        error: response.status === 401 || response.status === 403
-          ? 'Authentication failed' : `HTTP ${response.status}`
+        error:
+          response.status === 401 || response.status === 403
+            ? "Authentication failed"
+            : `HTTP ${response.status}`,
       });
     }
 
@@ -156,7 +187,7 @@ export const fetchQuota = async () => {
         providerName,
         ok: false,
         configured: true,
-        error: 'Failed to parse usage data'
+        error: "Failed to parse usage data",
       });
     }
 
@@ -164,21 +195,27 @@ export const fetchQuota = async () => {
       windows.rolling = toUsageWindow({
         usedPercent: toNumber(parsed.rolling.usagePercent),
         windowSeconds: parsed.rolling.resetInSec,
-        resetAt: parsed.rolling.resetInSec ? Date.now() + parsed.rolling.resetInSec * 1000 : null,
+        resetAt: parsed.rolling.resetInSec
+          ? Date.now() + parsed.rolling.resetInSec * 1000
+          : null,
       });
     }
     if (parsed.weekly) {
       windows.weekly = toUsageWindow({
         usedPercent: toNumber(parsed.weekly.usagePercent),
         windowSeconds: parsed.weekly.resetInSec,
-        resetAt: parsed.weekly.resetInSec ? Date.now() + parsed.weekly.resetInSec * 1000 : null,
+        resetAt: parsed.weekly.resetInSec
+          ? Date.now() + parsed.weekly.resetInSec * 1000
+          : null,
       });
     }
     if (parsed.monthly) {
       windows.monthly = toUsageWindow({
         usedPercent: toNumber(parsed.monthly.usagePercent),
         windowSeconds: parsed.monthly.resetInSec,
-        resetAt: parsed.monthly.resetInSec ? Date.now() + parsed.monthly.resetInSec * 1000 : null,
+        resetAt: parsed.monthly.resetInSec
+          ? Date.now() + parsed.monthly.resetInSec * 1000
+          : null,
       });
     }
 
@@ -187,18 +224,23 @@ export const fetchQuota = async () => {
       providerName,
       ok: true,
       configured: true,
-      usage: { windows }
+      usage: { windows },
     });
   } catch (error) {
-    const isTimeout = error instanceof DOMException && error.name === 'AbortError' && timeoutSignal.aborted;
+    const isTimeout =
+      error instanceof DOMException &&
+      error.name === "AbortError" &&
+      timeoutSignal.aborted;
     return buildResult({
       providerId,
       providerName,
       ok: false,
       configured: true,
       error: isTimeout
-        ? 'Request timed out'
-        : (error instanceof Error ? error.message : 'Request failed')
+        ? "Request timed out"
+        : error instanceof Error
+          ? error.message
+          : "Request failed",
     });
   }
 };
@@ -215,7 +257,10 @@ const parseUsageHtml = (html) => {
     const match = html.match(pattern);
     if (match) {
       try {
-        const jsonStr = match[1].replace(/([{,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)/g, '$1"$2"$3');
+        const jsonStr = match[1].replace(
+          /([{,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)/g,
+          '$1"$2"$3',
+        );
         usage[key] = JSON.parse(jsonStr);
       } catch {
         continue;

--- a/packages/web/server/lib/quota/providers/opencode-go.js
+++ b/packages/web/server/lib/quota/providers/opencode-go.js
@@ -150,6 +150,16 @@ export const fetchQuota = async () => {
     const parsed = parseUsageHtml(html);
     const windows = {};
 
+    if (!parsed.rolling && !parsed.weekly && !parsed.monthly) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'Failed to parse usage data'
+      });
+    }
+
     if (parsed.rolling) {
       windows.rolling = toUsageWindow({
         usedPercent: toNumber(parsed.rolling.usagePercent),

--- a/packages/web/server/lib/quota/providers/opencode-go.js
+++ b/packages/web/server/lib/quota/providers/opencode-go.js
@@ -1,0 +1,124 @@
+import {
+  buildResult,
+  toUsageWindow,
+  toNumber,
+} from '../utils/index.js';
+
+export const providerId = 'opencode-go';
+export const providerName = 'OpenCode';
+export const aliases = ['opencode-go', 'opencode_go', 'opencodego'];
+
+export const isConfigured = () => {
+  return Boolean(
+    process.env.OPENCODE_GO_WORKSPACE_ID && process.env.OPENCODE_GO_AUTH_COOKIE
+  );
+};
+
+export const fetchQuota = async () => {
+  const workspaceId = process.env.OPENCODE_GO_WORKSPACE_ID;
+  const explicitCookie = process.env.OPENCODE_GO_AUTH_COOKIE;
+
+  if (!workspaceId || !explicitCookie) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: !!workspaceId,
+      error: !workspaceId ? 'Not configured' : 'No auth cookie found'
+    });
+  }
+
+  const timeoutSignal = AbortSignal.timeout(15_000);
+
+  try {
+    const url = `https://opencode.ai/workspace/${encodeURIComponent(workspaceId)}/go`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Cookie: `auth=${explicitCookie}`,
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+      signal: timeoutSignal,
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: response.status === 401 || response.status === 403
+          ? 'Authentication failed' : `HTTP ${response.status}`
+      });
+    }
+
+    const html = await response.text();
+    const parsed = parseUsageHtml(html);
+    const windows = {};
+
+    if (parsed.rolling) {
+      windows.rolling = toUsageWindow({
+        usedPercent: toNumber(parsed.rolling.usagePercent),
+        windowSeconds: parsed.rolling.resetInSec,
+        resetAt: parsed.rolling.resetInSec ? Date.now() + parsed.rolling.resetInSec * 1000 : null,
+      });
+    }
+    if (parsed.weekly) {
+      windows.weekly = toUsageWindow({
+        usedPercent: toNumber(parsed.weekly.usagePercent),
+        windowSeconds: parsed.weekly.resetInSec,
+        resetAt: parsed.weekly.resetInSec ? Date.now() + parsed.weekly.resetInSec * 1000 : null,
+      });
+    }
+    if (parsed.monthly) {
+      windows.monthly = toUsageWindow({
+        usedPercent: toNumber(parsed.monthly.usagePercent),
+        windowSeconds: parsed.monthly.resetInSec,
+        resetAt: parsed.monthly.resetInSec ? Date.now() + parsed.monthly.resetInSec * 1000 : null,
+      });
+    }
+
+    return buildResult({
+      providerId,
+      providerName,
+      ok: true,
+      configured: true,
+      usage: { windows }
+    });
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && error.name === 'AbortError' && timeoutSignal.aborted;
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: isTimeout
+        ? 'Request timed out'
+        : (error instanceof Error ? error.message : 'Request failed')
+    });
+  }
+};
+
+const parseUsageHtml = (html) => {
+  const usage = { rolling: null, weekly: null, monthly: null };
+  const patterns = {
+    rolling: /rollingUsage:\$R\[\d+\]=(\{[^}]+\})/,
+    weekly: /weeklyUsage:\$R\[\d+\]=(\{[^}]+\})/,
+    monthly: /monthlyUsage:\$R\[\d+\]=(\{[^}]+\})/,
+  };
+
+  for (const [key, pattern] of Object.entries(patterns)) {
+    const match = html.match(pattern);
+    if (match) {
+      try {
+        const jsonStr = match[1].replace(/([{,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)/g, '$1"$2"$3');
+        usage[key] = JSON.parse(jsonStr);
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return usage;
+};

--- a/packages/web/server/lib/quota/providers/openrouter.js
+++ b/packages/web/server/lib/quota/providers/openrouter.js
@@ -5,8 +5,11 @@ import {
   buildResult,
   toUsageWindow,
   toNumber,
-  formatMoney
+  formatMoney,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'openrouter';
 export const providerName = 'OpenRouter';
@@ -17,6 +20,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.key || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/wafer.js
+++ b/packages/web/server/lib/quota/providers/wafer.js
@@ -7,8 +7,11 @@ import {
   toNumber,
   toTimestamp,
   resolveWindowLabel,
-  asNonEmptyString
+  asNonEmptyString,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'wafer';
 export const providerName = 'Wafer.ai';
@@ -22,6 +25,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.key || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/zai.js
+++ b/packages/web/server/lib/quota/providers/zai.js
@@ -8,8 +8,11 @@ import {
   toTimestamp,
   resolveWindowSeconds,
   resolveWindowLabel,
-  normalizeTimestamp
+  normalizeTimestamp,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'zai-coding-plan';
 export const providerName = 'z.ai';
@@ -20,6 +23,9 @@ export const isConfigured = () => {
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.key || entry?.token);
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const auth = readAuthFile();

--- a/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
+++ b/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
@@ -33,8 +33,11 @@ import {
   buildResult,
   toUsageWindow,
   resolveWindowSeconds,
-  normalizeTimestamp
+  normalizeTimestamp,
+  loginWithAuthCheck,
 } from '../utils/index.js';
+
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
 
 export const providerId = 'zhipuai-coding-plan';
 export const providerName = 'Zhipu AI Coding Plan';
@@ -68,6 +71,9 @@ function getApiKey() {
 export const isConfigured = () => {
   return Boolean(getApiKey());
 };
+
+export const login = async (options = {}) =>
+  loginWithAuthCheck({ options, id: providerId, name: providerName, aliases });
 
 export const fetchQuota = async () => {
   const apiKey = getApiKey();

--- a/packages/web/server/lib/quota/utils/browser.js
+++ b/packages/web/server/lib/quota/utils/browser.js
@@ -1,0 +1,147 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { execFileSync } from 'child_process';
+import { getCookies } from '@steipete/sweet-cookie';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+const LINUX_BROWSER_CONFIGS = {
+  chromium: {
+    dir: '.config/chromium',
+    keyringEntry: 'Chromium Safe Storage',
+    keyringFolder: 'Chromium Keys',
+    passwordEnv: 'SWEET_COOKIE_CHROME_SAFE_STORAGE_PASSWORD',
+  },
+  'google-chrome': {
+    dir: '.config/google-chrome',
+    keyringEntry: 'Chrome Safe Storage',
+    keyringFolder: 'Chrome Keys',
+    passwordEnv: 'SWEET_COOKIE_CHROME_SAFE_STORAGE_PASSWORD',
+  },
+  'BraveSoftware/Brave-Browser': {
+    dir: '.config/BraveSoftware/Brave-Browser',
+    keyringEntry: 'Brave Safe Storage',
+    keyringFolder: 'Brave Keys',
+    passwordEnv: 'SWEET_COOKIE_BRAVE_SAFE_STORAGE_PASSWORD',
+  },
+  'microsoft-edge': {
+    dir: '.config/microsoft-edge',
+    keyringEntry: 'Microsoft Edge Safe Storage',
+    keyringFolder: 'Microsoft Edge Keys',
+    passwordEnv: 'SWEET_COOKIE_EDGE_SAFE_STORAGE_PASSWORD',
+  },
+};
+
+const readKWalletPassword = (entry, folder) => {
+  try {
+    const result = execFileSync('kwallet-query', ['--read-password', entry, '--folder', folder, 'kdewallet'], { encoding: 'utf8', timeout: 3000 });
+    const pw = result.trim();
+    return pw && !pw.toLowerCase().startsWith('failed') ? pw : null;
+  } catch {
+    return null;
+  }
+};
+
+const readSecretToolPassword = (service, account) => {
+  try {
+    const result = execFileSync('secret-tool', ['lookup', 'service', service, 'account', account], { encoding: 'utf8', timeout: 3000 });
+    return result.trim() || null;
+  } catch {
+    return null;
+  }
+};
+
+const resolveProfileDir = (configDir) => {
+  const localState = path.join(configDir, 'Local State');
+  if (!fs.existsSync(localState)) return null;
+  try {
+    const ls = JSON.parse(fs.readFileSync(localState, 'utf8'));
+    const infoCache = ls?.profile?.info_cache;
+    if (infoCache) {
+      for (const dir of Object.keys(infoCache)) {
+        const profilePath = path.join(configDir, dir);
+        if (fs.existsSync(path.join(profilePath, 'Cookies')) || fs.existsSync(path.join(profilePath, 'Network', 'Cookies'))) {
+          return profilePath;
+        }
+      }
+    }
+  } catch {
+  }
+  return null;
+};
+
+// TODO: upstream to steipete/sweet-cookie
+const prepareCookieEnv = () => {
+  if (process.platform !== 'linux') return;
+
+  const xdg = process.env.XDG_CURRENT_DESKTOP ?? '';
+  const session = process.env.DESKTOP_SESSION ?? '';
+  const isKde = xdg.toLowerCase().includes('kde') || session.toLowerCase().includes('kde') || session.toLowerCase().includes('plasma');
+
+  process.env.SWEET_COOKIE_LINUX_KEYRING = isKde ? 'kwallet' : 'gnome';
+
+  if (process.env.SWEET_COOKIE_CHROME_PROFILE) return;
+
+  for (const browser of Object.values(LINUX_BROWSER_CONFIGS)) {
+    const configDir = path.join(os.homedir(), browser.dir);
+    const localState = path.join(configDir, 'Local State');
+    if (!fs.existsSync(localState)) continue;
+
+    const profileDir = resolveProfileDir(configDir);
+    if (profileDir) {
+      process.env.SWEET_COOKIE_CHROME_PROFILE = profileDir;
+    }
+
+    if (!process.env[browser.passwordEnv]) {
+      const pw = isKde
+        ? readKWalletPassword(browser.keyringEntry, browser.keyringFolder)
+        : readSecretToolPassword(browser.keyringEntry, browser.keyringFolder.replace(' Keys', ''));
+      if (pw) {
+        process.env[browser.passwordEnv] = pw;
+      }
+    }
+
+    break;
+  }
+};
+
+export const discoverBrowserCookie = async (hostPattern, cookieName = 'auth') => {
+  const url = hostToUrl(hostPattern);
+  if (!url) return null;
+  return discoverCookie(url, cookieName);
+};
+
+const discoverCookie = async (url, cookieName) => {
+  prepareCookieEnv();
+
+  try {
+    const { cookies } = await getCookies({
+      url,
+      names: [cookieName],
+      browsers: ['chrome', 'firefox', 'edge'],
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+    });
+    return cookies.length > 0 ? cookies[0].value : null;
+  } catch {
+    return null;
+  }
+};
+
+const urlForHost = (host) => {
+  const h = typeof host === 'string' ? host.trim() : '';
+  if (!h) return null;
+  const withProtocol = h.startsWith('http://') || h.startsWith('https://') ? h : `https://${h}`;
+  try {
+    const u = new URL(withProtocol);
+    return u.origin;
+  } catch {
+    return null;
+  }
+};
+
+const hostToUrl = (hostPattern) => {
+  const src = hostPattern instanceof RegExp ? hostPattern.source : String(hostPattern);
+  const cleaned = src.replace(/^\^/, '').replace(/\$$/, '').replace(/\\./g, '.').replace(/^\./, '');
+  return urlForHost(cleaned);
+};

--- a/packages/web/server/lib/quota/utils/browser.js
+++ b/packages/web/server/lib/quota/utils/browser.js
@@ -106,7 +106,7 @@ const prepareCookieEnv = () => {
   }
 };
 
-export const discoverBrowserCookie = async (hostPattern, cookieName = 'auth') => {
+export const discoverBrowserCookie = async (hostPattern, cookieName) => {
   const url = hostToUrl(hostPattern);
   if (!url) return null;
   return discoverCookie(url, cookieName);

--- a/packages/web/server/lib/quota/utils/index.js
+++ b/packages/web/server/lib/quota/utils/index.js
@@ -6,5 +6,7 @@
  */
 
 export * from './auth.js';
+export * from './browser.js';
+export * from './login.js';
 export * from './transformers.js';
 export * from './formatters.js';

--- a/packages/web/server/lib/quota/utils/login.js
+++ b/packages/web/server/lib/quota/utils/login.js
@@ -1,0 +1,12 @@
+import { readAuthFile } from '../../opencode/auth.js';
+import { getAuthEntry, normalizeAuthEntry } from './auth.js';
+import { isJsonMode, isQuietMode, printJson, log } from '../../../../bin/cli-output.js';
+
+export const loginWithAuthCheck = async ({ options, id, name, aliases }) => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  if (entry?.key || entry?.token || entry?.access) return;
+  if (isJsonMode(options)) printJson({ provider: id, command: 'opencode auth login' });
+  else if (isQuietMode(options)) process.stdout.write('Run: opencode auth login\n');
+  else log.info(`Run 'opencode auth login' to add auth for ${name}.`);
+};


### PR DESCRIPTION
## Summary

Adds opencode-go subscription rate limit display in the Settings.

The provider fetches rolling, weekly, and monthly usage percentages and reset times from `https://opencode.ai/workspace/{workspaceId}/go` using the opencode.ai auth cookie, then maps them into the existing `UsageWindow` model.

## Configuration

From environment variables:
- `OPENCODE_GO_WORKSPACE_ID` — workspace ID from the opencode.ai workspace URL
- `OPENCODE_GO_AUTH_COOKIE` — the `auth` cookie value for `opencode.ai`

> [!TIP]
> After discussion with @btriapitsyn, I introduce quota subcommand for better UX, and include cookie extraction from installed browsers.

```
bun packages/web/bin/cli.js quota --help

 Quota Provider Commands

USAGE:
  openchamber quota <SUBCOMMAND> [OPTIONS]

SUBCOMMANDS:
  status      Show quota provider status
  login       Log in to a quota provider via browser cookie detection

OPTIONS:
  --provider <id>  Quota provider ID (default: opencode-go)
  --json           Output machine-readable JSON
  -q, --quiet      Suppress non-essential output
  -h, --help       Show this help

EXAMPLES:
  openchamber quota login
  openchamber quota login --provider ollama-cloud
  openchamber quota login --json
```
