### PR TITLE
feat(electron): enable Windows NSIS installer build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,6 @@ jobs:
           retention-days: 1
 
   build-desktop-electron-windows:
-    if: ${{ false }} # Windows artifact is disabled until the build is release-ready.
     needs: create-release
     runs-on: windows-latest
     strategy:
@@ -512,7 +511,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   combine-electron-manifests:
-    needs: [create-release, build-desktop-electron-macos]
+    needs: [create-release, build-desktop-electron-macos, build-desktop-electron-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -528,6 +527,12 @@ jobs:
           pattern: latest-yml-*-apple-darwin
           path: artifacts
 
+      - name: Download per-arch latest.yml (Windows)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: latest-yml-*-pc-windows-msvc
+          path: artifacts
+
       - name: Finalize combined latest-mac.yml
         env:
           LATEST_YML_DIR: ${{ github.workspace }}/artifacts
@@ -541,11 +546,12 @@ jobs:
           tag_name: v${{ needs.create-release.outputs.version }}
           files: |
             ${{ runner.temp }}/latest-mac.yml
+            ${{ runner.temp }}/latest.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   finalize-release:
-    needs: [create-release, build-desktop-electron-macos, repackage-electron-as-tauri-update, publish-npm, combine-manifests, combine-electron-manifests]
+    needs: [create-release, build-desktop-electron-macos, build-desktop-electron-windows, repackage-electron-as-tauri-update, publish-npm, combine-manifests, combine-electron-manifests]
     runs-on: ubuntu-latest
     env:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,7 +533,7 @@ jobs:
           pattern: latest-yml-*-pc-windows-msvc
           path: artifacts
 
-      - name: Finalize combined latest-mac.yml
+      - name: Finalize combined electron manifests
         env:
           LATEST_YML_DIR: ${{ github.workspace }}/artifacts
           GH_REPO: ${{ github.repository }}

--- a/packages/electron/scripts/rebuild-native.mjs
+++ b/packages/electron/scripts/rebuild-native.mjs
@@ -129,6 +129,75 @@ const ensureWindowsNodeAddonApiForNodePty = async (rebuildRootPath) => {
   };
 };
 
+const patchNodeGypForVS2026 = () => {
+  if (process.platform === 'win32') {
+    try {
+      const fs = require('fs');
+      const bunDir = path.join(repoRoot, 'node_modules', '.bun');
+      if (!existsSync(bunDir)) return;
+
+      const entries = fs.readdirSync(bunDir, { withFileTypes: true });
+      const nodeGypDirs = entries
+        .filter((e) => e.isDirectory() && (e.name.startsWith('@electron+node-gyp@') || e.name.startsWith('node-gyp@')))
+        .map((e) => path.join(bunDir, e.name));
+
+      for (const pkgDir of nodeGypDirs) {
+        const findGlob = (base, pattern) => {
+          const results = [];
+          const walk = (dir) => {
+            if (!existsSync(dir)) return;
+            for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+              const full = path.join(dir, item.name);
+              if (item.isDirectory()) walk(full);
+              else if (item.name === pattern) results.push(full);
+            }
+          };
+          walk(base);
+          return results;
+        };
+
+        const vsJsFiles = findGlob(path.join(pkgDir, 'node_modules'), 'find-visualstudio.js');
+        for (const fullPath of vsJsFiles) {
+          let content = fs.readFileSync(fullPath, 'utf8');
+          if (!content.includes('ret.versionMajor === 18')) {
+            content = content.replace(
+              /(if \(ret\.versionMajor === 17\) \{\s+ret\.versionYear = 2022\s+return ret\s+\})/,
+              '$1\n    if (ret.versionMajor === 18) {\n      ret.versionYear = 2026\n      return ret\n    }',
+            );
+            console.log(`[electron] patched ${path.relative(repoRoot, fullPath)} for VS 2026`);
+          }
+          if (!content.includes('versionYear === 2026')) {
+            content = content.replace(
+              /(} else if \(versionYear === 2022\) \{\s+return 'v143'\s+\})/,
+              "$1 else if (versionYear === 2026) {\n      return 'v145'\n    }",
+            );
+            content = content.replace(/\[2019, 2022\]/g, '[2019, 2022, 2026]');
+            fs.writeFileSync(fullPath, content);
+            console.log(`[electron] patched ${path.relative(repoRoot, fullPath)} for v145 toolset`);
+          }
+        }
+
+        const buildJsFiles = findGlob(path.join(pkgDir, 'node_modules'), 'build.js');
+        for (const fullPath of buildJsFiles) {
+          let content = fs.readFileSync(fullPath, 'utf8');
+          if (!content.includes('SpectreMitigation=false')) {
+            content = content.replace(
+              "/p:Configuration=' + buildType + ';Platform=' + p)",
+              "/p:Configuration=' + buildType + ';Platform=' + p + ';SpectreMitigation=false')",
+            );
+            fs.writeFileSync(fullPath, content);
+            console.log(`[electron] patched ${path.relative(repoRoot, fullPath)} for SpectreMitigation`);
+          }
+        }
+      }
+    } catch (err) {
+      console.warn('[electron] could not patch node-gyp for VS 2026:', err.message);
+    }
+  }
+};
+
+patchNodeGypForVS2026();
+
 console.log(`[electron] rebuilding native modules against Electron ${electronVersion}...`);
 
 // Rebuild against the hoisted root node_modules (bun workspace layout).

--- a/packages/electron/scripts/rebuild-native.mjs
+++ b/packages/electron/scripts/rebuild-native.mjs
@@ -159,12 +159,13 @@ const patchNodeGypForVS2026 = () => {
         const vsJsFiles = findGlob(path.join(pkgDir, 'node_modules'), 'find-visualstudio.js');
         for (const fullPath of vsJsFiles) {
           let content = fs.readFileSync(fullPath, 'utf8');
+          let changed = false;
           if (!content.includes('ret.versionMajor === 18')) {
             content = content.replace(
               /(if \(ret\.versionMajor === 17\) \{\s+ret\.versionYear = 2022\s+return ret\s+\})/,
               '$1\n    if (ret.versionMajor === 18) {\n      ret.versionYear = 2026\n      return ret\n    }',
             );
-            console.log(`[electron] patched ${path.relative(repoRoot, fullPath)} for VS 2026`);
+            changed = true;
           }
           if (!content.includes('versionYear === 2026')) {
             content = content.replace(
@@ -172,8 +173,11 @@ const patchNodeGypForVS2026 = () => {
               "$1 else if (versionYear === 2026) {\n      return 'v145'\n    }",
             );
             content = content.replace(/\[2019, 2022\]/g, '[2019, 2022, 2026]');
+            changed = true;
+          }
+          if (changed) {
             fs.writeFileSync(fullPath, content);
-            console.log(`[electron] patched ${path.relative(repoRoot, fullPath)} for v145 toolset`);
+            console.log(`[electron] patched ${path.relative(repoRoot, fullPath)} for VS 2026 + v145 toolset`);
           }
         }
 


### PR DESCRIPTION
## Summary

Enables the Windows Electron build in the release pipeline that was previously disabled. Tested locally on Windows 10 with VS 2026.

## Changes

- **`.github/workflows/release.yml`**: Remove `if: ${{ false }}` guard from `build-desktop-electron-windows` job. Add Windows job to `combine-electron-manifests` and `finalize-release` dependencies. Upload combined `latest.yml` alongside `latest-mac.yml`.
- **`packages/electron/scripts/rebuild-native.mjs`**: Add `patchNodeGypForVS2026()` that patches node-gyp at build time to:
  - Detect VS 2026 (version 18) as a valid installation
  - Map v145 toolset for VS 2026
  - Disable SpectreMitigation requirement (MSB8040) now enforced by default in VS 2026

## Local testing

- **OS**: Windows 10 Pro
- **VS**: Visual Studio 2026 Community (v18.5.1)
- **Output**: `OpenChamber-1.11.7-win-x64.exe` (122.6 MB, NSIS one-click installer)
- **Build steps**: web assets → bundle main → rebuild native (node-pty, better-sqlite3) → package NSIS installer

## Notes

- The installer is unsigned (no code signing certificate). The existing smoke workflow (`release-desktop-smoke.yml`) already has Windows support enabled.
- The node-gyp patches are applied at build time automatically; no changes to lockfile or dependencies required.