### PR TITLE
Detect external worktrees instantly

### DIFF
--- a/packages/ui/src/components/sections/openchamber/WorktreeSectionContent.tsx
+++ b/packages/ui/src/components/sections/openchamber/WorktreeSectionContent.tsx
@@ -37,6 +37,8 @@ export const WorktreeSectionContent: React.FC<WorktreeSectionContentProps> = ({ 
   const [isGitRepoLocal, setIsGitRepoLocal] = React.useState<boolean | null>(null);
   const [availableWorktrees, setAvailableWorktrees] = React.useState<WorktreeMetadata[]>([]);
   const [isLoadingWorktrees, setIsLoadingWorktrees] = React.useState(false);
+  const sharedAvailableWorktrees = useSessionUIStore((s) => projectPath ? s.availableWorktreesByProject.get(projectPath) : undefined);
+  const displayedWorktrees = sharedAvailableWorktrees ?? availableWorktrees;
 
   const projectRef = React.useMemo(() => {
     if (projectRefProp?.id && projectRefProp?.path) {
@@ -344,13 +346,13 @@ export const WorktreeSectionContent: React.FC<WorktreeSectionContentProps> = ({ 
 
         {isLoadingWorktrees ? (
           <p className="typography-meta text-muted-foreground px-1">{t('settings.openchamber.worktrees.list.loading')}</p>
-        ) : availableWorktrees.length === 0 ? (
+        ) : displayedWorktrees.length === 0 ? (
           <p className="typography-meta text-muted-foreground/70 px-1">
             {t('settings.openchamber.worktrees.list.empty')}
           </p>
         ) : (
           <div className="space-y-1 px-1 max-w-[32.5rem]">
-            {availableWorktrees.map((worktree) => (
+            {displayedWorktrees.map((worktree) => (
               <div
                 key={worktree.path}
                 className="group flex w-full items-center gap-2 py-1.5"

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -44,6 +44,7 @@ import { SessionNodeItem } from './sidebar/SessionNodeItem';
 import { useUpdateStore } from '@/stores/useUpdateStore';
 import { useShallow } from 'zustand/react/shallow';
 import { listProjectWorktrees } from '@/lib/worktrees/worktreeManager';
+import { useWorktreeDiscoveryEvents } from '@/lib/worktrees/useWorktreeDiscoveryEvents';
 import type { WorktreeMetadata } from '@/types/worktree';
 import type { SortableDragHandleProps } from './sidebar/sortableItems';
 import {
@@ -295,6 +296,9 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   });
 
   const gitBranches = useGitAllBranches();
+  const isVSCode = React.useMemo(() => isVSCodeRuntime(), []);
+
+  useWorktreeDiscoveryEvents(projects, { enabled: !isVSCode });
 
   const sync = useSync();
   const liveSessions = useAllLiveSessions();
@@ -443,7 +447,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
   const isDesktopShellRuntime = React.useMemo(() => isDesktopShell(), []);
 
-  const isVSCode = React.useMemo(() => isVSCodeRuntime(), []);
   const { isTablet } = useDeviceInfo();
   const alwaysShowSidebarActions = mobileVariant || isTablet;
 

--- a/packages/ui/src/lib/worktrees/useWorktreeDiscoveryEvents.ts
+++ b/packages/ui/src/lib/worktrees/useWorktreeDiscoveryEvents.ts
@@ -1,0 +1,78 @@
+import React from 'react';
+import { refreshProjectWorktrees, type ProjectRef } from '@/lib/worktrees/worktreeManager';
+
+type UseWorktreeDiscoveryEventsOptions = {
+  enabled?: boolean;
+};
+
+export type WorktreeChangedEventDetail = {
+  directory: string;
+  reason?: string;
+  at?: number;
+};
+
+export const WORKTREE_CHANGED_EVENT = 'openchamber:worktree-changed';
+
+const normalizePath = (value: string): string => {
+  const replaced = value.trim().replace(/\\/g, '/');
+  if (replaced === '/') return '/';
+  return replaced.length > 1 ? replaced.replace(/\/+$/, '') : replaced;
+};
+
+export function useWorktreeDiscoveryEvents(
+  projects: ProjectRef[],
+  options: UseWorktreeDiscoveryEventsOptions = {},
+): void {
+  const enabled = options.enabled ?? true;
+  const projectByPath = React.useMemo(() => {
+    const next = new Map<string, ProjectRef>();
+    for (const project of projects) {
+      const path = normalizePath(project.path);
+      if (!path) continue;
+      next.set(path, { id: project.id, path });
+    }
+    return next;
+  }, [projects]);
+
+  React.useEffect(() => {
+    if (!enabled || typeof window === 'undefined') {
+      return;
+    }
+
+    const refreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+    const scheduleRefresh = (project: ProjectRef) => {
+      const path = normalizePath(project.path);
+      const existing = refreshTimers.get(path);
+      if (existing) {
+        clearTimeout(existing);
+      }
+      const timer = setTimeout(() => {
+        refreshTimers.delete(path);
+        void refreshProjectWorktrees(project).catch((error) => {
+          console.warn('Failed to refresh worktrees after metadata change:', error);
+        });
+      }, 250);
+      refreshTimers.set(path, timer);
+    };
+
+    const handleWorktreeChanged = (event: Event) => {
+      const detail = (event as CustomEvent<WorktreeChangedEventDetail>).detail;
+      const directory = typeof detail?.directory === 'string' ? normalizePath(detail.directory) : '';
+      if (!directory) return;
+
+      const project = projectByPath.get(directory);
+      if (!project) return;
+      scheduleRefresh(project);
+    };
+
+    window.addEventListener(WORKTREE_CHANGED_EVENT, handleWorktreeChanged);
+    return () => {
+      window.removeEventListener(WORKTREE_CHANGED_EVENT, handleWorktreeChanged);
+      for (const timer of refreshTimers.values()) {
+        clearTimeout(timer);
+      }
+      refreshTimers.clear();
+    };
+  }, [enabled, projectByPath]);
+}

--- a/packages/ui/src/lib/worktrees/useWorktreeDiscoveryEvents.ts
+++ b/packages/ui/src/lib/worktrees/useWorktreeDiscoveryEvents.ts
@@ -24,15 +24,21 @@ export function useWorktreeDiscoveryEvents(
   options: UseWorktreeDiscoveryEventsOptions = {},
 ): void {
   const enabled = options.enabled ?? true;
-  const projectByPath = React.useMemo(() => {
-    const next = new Map<string, ProjectRef>();
+  const projectLookup = React.useMemo(() => {
+    const byPath = new Map<string, ProjectRef>();
+    const keyParts: string[] = [];
     for (const project of projects) {
       const path = normalizePath(project.path);
       if (!path) continue;
-      next.set(path, { id: project.id, path });
+      byPath.set(path, { id: project.id, path });
+      keyParts.push(`${project.id}:${path}`);
     }
-    return next;
+    return { byPath, key: keyParts.sort().join('|') };
   }, [projects]);
+  const projectLookupRef = React.useRef(projectLookup);
+  if (projectLookupRef.current.key !== projectLookup.key) {
+    projectLookupRef.current = projectLookup;
+  }
 
   React.useEffect(() => {
     if (!enabled || typeof window === 'undefined') {
@@ -61,7 +67,7 @@ export function useWorktreeDiscoveryEvents(
       const directory = typeof detail?.directory === 'string' ? normalizePath(detail.directory) : '';
       if (!directory) return;
 
-      const project = projectByPath.get(directory);
+      const project = projectLookupRef.current.byPath.get(directory);
       if (!project) return;
       scheduleRefresh(project);
     };
@@ -74,5 +80,5 @@ export function useWorktreeDiscoveryEvents(
       }
       refreshTimers.clear();
     };
-  }, [enabled, projectByPath]);
+  }, [enabled, projectLookup.key]);
 }

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -183,7 +183,11 @@ export async function listProjectWorktrees(project: ProjectRef, options: { force
     const metadataProjectDirectory = await resolveProjectRoot(projectDirectory).catch(() => projectDirectory);
     const normalizedProjectDirectory = normalizePath(projectDirectory);
 
-    const worktrees = await git.worktree.list(projectDirectory).catch(() => []);
+    // Let a genuine git failure reject (every caller wraps this in try/catch).
+    // Swallowing to `[]` here would both poison the 30s cache with an empty
+    // result and let callers conflate a transient fetch failure with an
+    // empty-but-successful list. See refreshProjectWorktrees.
+    const worktrees = await git.worktree.list(projectDirectory);
     const results: WorktreeMetadata[] = worktrees
       .filter((entry) => typeof entry.path === 'string' && entry.path.trim().length > 0)
       .map((entry) => {
@@ -248,7 +252,17 @@ const mergeAvailableWorktrees = (
 
 export async function refreshProjectWorktrees(project: ProjectRef): Promise<WorktreeMetadata[]> {
   const projectDirectory = normalizePath(project.path);
-  const worktrees = await listProjectWorktrees(project, { forceRefresh: true });
+
+  let worktrees: WorktreeMetadata[];
+  try {
+    worktrees = await listProjectWorktrees(project, { forceRefresh: true });
+  } catch (error) {
+    // Distinguish fetch failure from empty success: a transient git error
+    // (lock file, slow remote, etc.) must not wipe the project's worktrees
+    // from the shared store. Leave the existing entries untouched.
+    console.warn('Skipping worktree store update after refresh failure:', error);
+    return useSessionUIStore.getState().availableWorktreesByProject.get(projectDirectory) ?? [];
+  }
 
   const currentByProject = useSessionUIStore.getState().availableWorktreesByProject;
   const updatedByProject = new Map(currentByProject);

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -11,6 +11,7 @@ import {
 import { invalidateResolvedProjectRootCache, resolveProjectRoot } from '@/lib/worktrees/worktreeStatus';
 import type {
   CreateGitWorktreePayload,
+  GitWorktreeInfo,
   GitWorktreeValidationResult,
 } from '@/lib/api/types';
 import { useSessionUIStore } from '@/sync/session-ui-store';
@@ -152,6 +153,11 @@ const _worktreeListCache = new Map<string, { value: WorktreeMetadata[]; at: numb
 const _worktreeListInflight = new Map<string, Promise<WorktreeMetadata[]>>();
 const WORKTREE_LIST_CACHE_TTL = 30_000; // 30 seconds
 
+type ListProjectWorktreesOptions = {
+  forceRefresh?: boolean;
+  throwOnError?: boolean;
+};
+
 export const invalidateProjectWorktreeCache = (project?: ProjectRef | string | null): void => {
   if (!project) {
     _worktreeListCache.clear();
@@ -162,8 +168,9 @@ export const invalidateProjectWorktreeCache = (project?: ProjectRef | string | n
   _worktreeListCache.delete(projectDirectory);
 };
 
-export async function listProjectWorktrees(project: ProjectRef, options: { forceRefresh?: boolean } = {}): Promise<WorktreeMetadata[]> {
+export async function listProjectWorktrees(project: ProjectRef, options: ListProjectWorktreesOptions = {}): Promise<WorktreeMetadata[]> {
   const projectDirectory = normalizePath(project.path);
+  const inflightKey = `${projectDirectory}:${options.throwOnError ? 'throw' : 'safe'}`;
 
   if (options.forceRefresh) {
     _worktreeListCache.delete(projectDirectory);
@@ -176,18 +183,23 @@ export async function listProjectWorktrees(project: ProjectRef, options: { force
   }
 
   // Dedup in-flight requests
-  const inflight = _worktreeListInflight.get(projectDirectory);
+  const inflight = _worktreeListInflight.get(inflightKey);
   if (inflight) return inflight;
 
   const promise = (async (): Promise<WorktreeMetadata[]> => {
     const metadataProjectDirectory = await resolveProjectRoot(projectDirectory).catch(() => projectDirectory);
     const normalizedProjectDirectory = normalizePath(projectDirectory);
 
-    // Let a genuine git failure reject (every caller wraps this in try/catch).
-    // Swallowing to `[]` here would both poison the 30s cache with an empty
-    // result and let callers conflate a transient fetch failure with an
-    // empty-but-successful list. See refreshProjectWorktrees.
-    const worktrees = await git.worktree.list(projectDirectory);
+    let worktrees: GitWorktreeInfo[];
+    try {
+      worktrees = await git.worktree.list(projectDirectory);
+    } catch (error) {
+      if (options.throwOnError) {
+        throw error;
+      }
+      console.warn('Failed to list project worktrees:', error);
+      return [];
+    }
     const results: WorktreeMetadata[] = worktrees
       .filter((entry) => typeof entry.path === 'string' && entry.path.trim().length > 0)
       .map((entry) => {
@@ -222,10 +234,10 @@ export async function listProjectWorktrees(project: ProjectRef, options: { force
     _worktreeListCache.set(projectDirectory, { value: sorted, at: Date.now() });
     return sorted;
   })().finally(() => {
-    _worktreeListInflight.delete(projectDirectory);
+    _worktreeListInflight.delete(inflightKey);
   });
 
-  _worktreeListInflight.set(projectDirectory, promise);
+  _worktreeListInflight.set(inflightKey, promise);
   return promise;
 }
 
@@ -255,7 +267,7 @@ export async function refreshProjectWorktrees(project: ProjectRef): Promise<Work
 
   let worktrees: WorktreeMetadata[];
   try {
-    worktrees = await listProjectWorktrees(project, { forceRefresh: true });
+    worktrees = await listProjectWorktrees(project, { forceRefresh: true, throwOnError: true });
   } catch (error) {
     // Distinguish fetch failure from empty success: a transient git error
     // (lock file, slow remote, etc.) must not wipe the project's worktrees

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -152,8 +152,22 @@ const _worktreeListCache = new Map<string, { value: WorktreeMetadata[]; at: numb
 const _worktreeListInflight = new Map<string, Promise<WorktreeMetadata[]>>();
 const WORKTREE_LIST_CACHE_TTL = 30_000; // 30 seconds
 
-export async function listProjectWorktrees(project: ProjectRef): Promise<WorktreeMetadata[]> {
+export const invalidateProjectWorktreeCache = (project?: ProjectRef | string | null): void => {
+  if (!project) {
+    _worktreeListCache.clear();
+    return;
+  }
+
+  const projectDirectory = normalizePath(typeof project === 'string' ? project : project.path);
+  _worktreeListCache.delete(projectDirectory);
+};
+
+export async function listProjectWorktrees(project: ProjectRef, options: { forceRefresh?: boolean } = {}): Promise<WorktreeMetadata[]> {
   const projectDirectory = normalizePath(project.path);
+
+  if (options.forceRefresh) {
+    _worktreeListCache.delete(projectDirectory);
+  }
 
   // Return cached if fresh
   const cached = _worktreeListCache.get(projectDirectory);
@@ -209,6 +223,47 @@ export async function listProjectWorktrees(project: ProjectRef): Promise<Worktre
 
   _worktreeListInflight.set(projectDirectory, promise);
   return promise;
+}
+
+const mergeAvailableWorktrees = (
+  current: WorktreeMetadata[],
+  projectDirectory: string,
+  nextForProject: WorktreeMetadata[],
+): WorktreeMetadata[] => {
+  const normalizedProjectDirectory = normalizePath(projectDirectory);
+  const byPath = new Map<string, WorktreeMetadata>();
+
+  for (const entry of current) {
+    if (normalizePath(entry.projectDirectory) !== normalizedProjectDirectory) {
+      byPath.set(normalizePath(entry.path), entry);
+    }
+  }
+
+  for (const entry of nextForProject) {
+    byPath.set(normalizePath(entry.path), entry);
+  }
+
+  return Array.from(byPath.values());
+};
+
+export async function refreshProjectWorktrees(project: ProjectRef): Promise<WorktreeMetadata[]> {
+  const projectDirectory = normalizePath(project.path);
+  const worktrees = await listProjectWorktrees(project, { forceRefresh: true });
+
+  const currentByProject = useSessionUIStore.getState().availableWorktreesByProject;
+  const updatedByProject = new Map(currentByProject);
+  updatedByProject.set(projectDirectory, worktrees);
+
+  useSessionUIStore.setState({
+    availableWorktreesByProject: updatedByProject,
+    availableWorktrees: mergeAvailableWorktrees(
+      useSessionUIStore.getState().availableWorktrees,
+      projectDirectory,
+      worktrees,
+    ),
+  });
+
+  return worktrees;
 }
 
 export type CreateWorktreeArgs = {

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -40,6 +40,7 @@ import type { QuestionRequest } from "@/types/question"
 import * as sessionActions from "./session-actions"
 import { getSessionMaterializationStatus, materializeSessionSnapshots } from "./materialization"
 import { setSessionPrefetch } from "./session-prefetch-cache"
+import { WORKTREE_CHANGED_EVENT, type WorktreeChangedEventDetail } from "@/lib/worktrees/useWorktreeDiscoveryEvents"
 
 // ---------------------------------------------------------------------------
 // Context
@@ -1386,6 +1387,23 @@ const dispatchOpenCodeUpdateAvailable = (payload: { version: string }) => {
   window.dispatchEvent(new CustomEvent("openchamber:opencode-update-available", { detail: payload }))
 }
 
+const dispatchWorktreeChanged = (payload: unknown) => {
+  const record = payload as { type?: unknown; properties?: unknown }
+  if (typeof window === "undefined" || record.type !== "worktree.changed") return
+  const properties = record.properties as { directory?: unknown; reason?: unknown; at?: unknown } | undefined
+  const directory = typeof properties?.directory === "string" && properties.directory.trim().length > 0
+    ? properties.directory.trim()
+    : ""
+  if (!directory) return
+
+  const detail: WorktreeChangedEventDetail = {
+    directory,
+    reason: typeof properties?.reason === "string" ? properties.reason : undefined,
+    at: typeof properties?.at === "number" ? properties.at : undefined,
+  }
+  window.dispatchEvent(new CustomEvent(WORKTREE_CHANGED_EVENT, { detail }))
+}
+
 export function SyncProvider(props: {
   sdk: OpencodeClient
   directory: string
@@ -1553,6 +1571,7 @@ export function SyncProvider(props: {
           lastActiveEventAtByDirectoryRef.current.set(directory, Date.now())
         }
         dispatchVSCodeRuntimeNotificationEvent(directory, payload)
+        dispatchWorktreeChanged(payload)
         if (payload.type === "installation.update-available") {
           const version = typeof (payload.properties as { version?: unknown })?.version === "string"
             ? (payload.properties as { version: string }).version

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -1197,6 +1197,7 @@ async function main(options = {}) {
     scheduledTasksRuntime,
     getOpenChamberEventClients: () => uiOpenChamberEventClients,
     writeSseEvent,
+    broadcastEvent: broadcastGlobalUiEvent,
   });
 
   const previewProxyRuntime = createPreviewProxyRuntime({

--- a/packages/web/server/lib/git/routes.js
+++ b/packages/web/server/lib/git/routes.js
@@ -1,5 +1,6 @@
 export function registerGitRoutes(app, options = {}) {
   const broadcastEvent = typeof options.broadcastEvent === 'function' ? options.broadcastEvent : null;
+  const MAX_WORKTREE_WATCHERS = 50;
   const worktreeWatchers = new Map();
   let gitLibraries = null;
   const getGitLibraries = async () => {
@@ -9,19 +10,59 @@ export function registerGitRoutes(app, options = {}) {
     return gitLibraries;
   };
 
+  const normalizeWatcherKey = (directory) => {
+    const normalized = directory.trim().replace(/\\/g, '/');
+    if (normalized === '/') return '/';
+    return normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized;
+  };
+
+  const disposeWorktreeWatcher = (key) => {
+    const entry = worktreeWatchers.get(key);
+    if (!entry) {
+      return;
+    }
+    worktreeWatchers.delete(key);
+    if (typeof entry.unsubscribe === 'function') {
+      entry.unsubscribe();
+    }
+  };
+
+  const touchWorktreeWatcher = (key, entry) => {
+    if (worktreeWatchers.get(key) !== entry) {
+      return;
+    }
+    worktreeWatchers.delete(key);
+    worktreeWatchers.set(key, entry);
+  };
+
+  const trimWorktreeWatchers = () => {
+    while (worktreeWatchers.size > MAX_WORKTREE_WATCHERS) {
+      const oldestKey = worktreeWatchers.keys().next().value;
+      if (oldestKey === undefined) break;
+      disposeWorktreeWatcher(oldestKey);
+    }
+  };
+
   const ensureWorktreeWatcher = async (directory) => {
     if (!broadcastEvent || typeof directory !== 'string' || directory.trim().length === 0) {
       return;
     }
 
-    const key = directory.trim();
-    if (worktreeWatchers.has(key)) {
+    const key = normalizeWatcherKey(directory);
+    const existing = worktreeWatchers.get(key);
+    if (existing) {
+      touchWorktreeWatcher(key, existing);
       return;
     }
+
+    const entry = { unsubscribe: null };
+    worktreeWatchers.set(key, entry);
+    trimWorktreeWatchers();
 
     try {
       const { watchWorktreeChanges } = await getGitLibraries();
       if (typeof watchWorktreeChanges !== 'function') {
+        disposeWorktreeWatcher(key);
         return;
       }
 
@@ -31,12 +72,18 @@ export function registerGitRoutes(app, options = {}) {
           properties: {
             directory: key,
             reason: event?.reason || 'changed',
-            at: Date.now(),
+            at: typeof event?.at === 'number' ? event.at : Date.now(),
           },
         }, { directory: key });
       });
-      worktreeWatchers.set(key, unsubscribe);
+      if (worktreeWatchers.get(key) !== entry) {
+        unsubscribe();
+        return;
+      }
+      entry.unsubscribe = unsubscribe;
+      touchWorktreeWatcher(key, entry);
     } catch (error) {
+      disposeWorktreeWatcher(key);
       console.warn('Failed to watch worktree metadata:', error?.message || error);
     }
   };

--- a/packages/web/server/lib/git/routes.js
+++ b/packages/web/server/lib/git/routes.js
@@ -1,10 +1,44 @@
-export function registerGitRoutes(app) {
+export function registerGitRoutes(app, options = {}) {
+  const broadcastEvent = typeof options.broadcastEvent === 'function' ? options.broadcastEvent : null;
+  const worktreeWatchers = new Map();
   let gitLibraries = null;
   const getGitLibraries = async () => {
     if (!gitLibraries) {
       gitLibraries = await import('./index.js');
     }
     return gitLibraries;
+  };
+
+  const ensureWorktreeWatcher = async (directory) => {
+    if (!broadcastEvent || typeof directory !== 'string' || directory.trim().length === 0) {
+      return;
+    }
+
+    const key = directory.trim();
+    if (worktreeWatchers.has(key)) {
+      return;
+    }
+
+    try {
+      const { watchWorktreeChanges } = await getGitLibraries();
+      if (typeof watchWorktreeChanges !== 'function') {
+        return;
+      }
+
+      const unsubscribe = await watchWorktreeChanges(key, (event) => {
+        broadcastEvent({
+          type: 'worktree.changed',
+          properties: {
+            directory: key,
+            reason: event?.reason || 'changed',
+            at: Date.now(),
+          },
+        }, { directory: key });
+      });
+      worktreeWatchers.set(key, unsubscribe);
+    } catch (error) {
+      console.warn('Failed to watch worktree metadata:', error?.message || error);
+    }
   };
 
   app.get('/api/git/identities', async (req, res) => {
@@ -854,6 +888,7 @@ export function registerGitRoutes(app) {
       }
 
       const worktrees = await getWorktrees(directory);
+      void ensureWorktreeWatcher(directory);
       res.json(worktrees);
     } catch (error) {
       // Worktrees are an optional feature. Avoid repeated 500s (and repeated client retries)

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2844,7 +2844,7 @@ export async function watchWorktreeChanges(directory, onChange) {
   const addWatcher = async (targetPath, handleEvent) => {
     const stat = await fsp.stat(targetPath).catch(() => null);
     if (!stat?.isDirectory()) {
-      return;
+      return false;
     }
 
     const watcher = fs.watch(targetPath, { persistent: false }, (eventType, filename) => {
@@ -2854,14 +2854,21 @@ export async function watchWorktreeChanges(directory, onChange) {
       console.warn('Git worktree watcher error:', error?.message || error);
     });
     watchers.push(watcher);
+    return true;
   };
 
   const ensureWorktreesWatcher = async () => {
     if (closed || watchingWorktreesDir) {
       return;
     }
-    await addWatcher(worktreesDir, () => notify('worktrees-directory-changed'));
-    watchingWorktreesDir = watchers.length > 1;
+    // Claim the slot synchronously, before the first await, so a concurrent
+    // invocation (the common-dir watcher fires this fire-and-forget on every
+    // relevant event) can't pass the guard and add a duplicate fs.watch.
+    watchingWorktreesDir = true;
+    const added = await addWatcher(worktreesDir, () => notify('worktrees-directory-changed'));
+    // If the worktrees directory didn't exist yet, release the slot so a later
+    // event can retry once it's created.
+    watchingWorktreesDir = added;
   };
 
   await addWatcher(commonGitDir, (_eventType, filename) => {

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2819,7 +2819,12 @@ export async function watchWorktreeChanges(directory, onChange) {
   const watchers = [];
   let closed = false;
   let debounceTimer = null;
-  let watchingWorktreesDir = false;
+  let worktreesWatcher = null;
+  // Inode the worktrees watcher is bound to. git removes `.git/worktrees` when
+  // the last worktree is deleted and recreates it (with a fresh inode) on the
+  // next add, silently invalidating the fs.watch handle; tracking the inode
+  // lets us notice the swap and re-attach even if the two events coalesce.
+  let worktreesWatchIno = null;
 
   const notify = (reason) => {
     if (closed) return;
@@ -2841,10 +2846,23 @@ export async function watchWorktreeChanges(directory, onChange) {
     }
   };
 
-  const addWatcher = async (targetPath, handleEvent) => {
-    const stat = await fsp.stat(targetPath).catch(() => null);
-    if (!stat?.isDirectory()) {
-      return false;
+  const removeWatcher = (watcher) => {
+    const index = watchers.indexOf(watcher);
+    if (index !== -1) {
+      watchers.splice(index, 1);
+    }
+    closeWatcher(watcher);
+  };
+
+  const attachWatcher = (targetPath, handleEvent) => {
+    let stat;
+    try {
+      stat = fs.statSync(targetPath);
+    } catch {
+      return null;
+    }
+    if (!stat.isDirectory()) {
+      return null;
     }
 
     const watcher = fs.watch(targetPath, { persistent: false }, (eventType, filename) => {
@@ -2854,31 +2872,57 @@ export async function watchWorktreeChanges(directory, onChange) {
       console.warn('Git worktree watcher error:', error?.message || error);
     });
     watchers.push(watcher);
-    return true;
+    return watcher;
   };
 
-  const ensureWorktreesWatcher = async () => {
-    if (closed || watchingWorktreesDir) {
+  // Keep the `.git/worktrees` watcher in sync with the directory's current
+  // existence and identity. Runs synchronously from watcher callbacks, so
+  // events are processed one at a time — there is no await window for a
+  // concurrent invocation to attach a duplicate watcher, and a deleted dir is
+  // re-watched as soon as git recreates it (otherwise granular add/remove
+  // events stop arriving after the last worktree is removed and a new one
+  // added).
+  const syncWorktreesWatcher = () => {
+    if (closed) {
       return;
     }
-    // Claim the slot synchronously, before the first await, so a concurrent
-    // invocation (the common-dir watcher fires this fire-and-forget on every
-    // relevant event) can't pass the guard and add a duplicate fs.watch.
-    watchingWorktreesDir = true;
-    const added = await addWatcher(worktreesDir, () => notify('worktrees-directory-changed'));
-    // If the worktrees directory didn't exist yet, release the slot so a later
-    // event can retry once it's created.
-    watchingWorktreesDir = added;
+    let stat;
+    try {
+      stat = fs.statSync(worktreesDir);
+    } catch {
+      stat = null;
+    }
+    if (!stat?.isDirectory()) {
+      if (worktreesWatcher) {
+        removeWatcher(worktreesWatcher);
+        worktreesWatcher = null;
+        worktreesWatchIno = null;
+      }
+      return;
+    }
+    if (worktreesWatcher && worktreesWatchIno === stat.ino) {
+      return;
+    }
+    if (worktreesWatcher) {
+      removeWatcher(worktreesWatcher);
+      worktreesWatcher = null;
+      worktreesWatchIno = null;
+    }
+    const watcher = attachWatcher(worktreesDir, () => notify('worktrees-directory-changed'));
+    if (watcher) {
+      worktreesWatcher = watcher;
+      worktreesWatchIno = stat.ino;
+    }
   };
 
-  await addWatcher(commonGitDir, (_eventType, filename) => {
+  attachWatcher(commonGitDir, (_eventType, filename) => {
     if (!filename || filename === 'worktrees') {
-      void ensureWorktreesWatcher();
+      syncWorktreesWatcher();
       notify('common-git-directory-changed');
     }
   });
 
-  await ensureWorktreesWatcher();
+  syncWorktreesWatcher();
 
   if (watchers.length === 0) {
     throw new Error('Failed to watch git worktree metadata');

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2884,7 +2884,7 @@ export async function watchWorktreeChanges(directory, onChange) {
   // added).
   const syncWorktreesWatcher = () => {
     if (closed) {
-      return;
+      return false;
     }
     let stat;
     try {
@@ -2897,27 +2897,36 @@ export async function watchWorktreeChanges(directory, onChange) {
         removeWatcher(worktreesWatcher);
         worktreesWatcher = null;
         worktreesWatchIno = null;
+        return true;
       }
-      return;
+      return false;
     }
     if (worktreesWatcher && worktreesWatchIno === stat.ino) {
-      return;
+      return false;
     }
+    let changed = false;
     if (worktreesWatcher) {
       removeWatcher(worktreesWatcher);
       worktreesWatcher = null;
       worktreesWatchIno = null;
+      changed = true;
     }
     const watcher = attachWatcher(worktreesDir, () => notify('worktrees-directory-changed'));
     if (watcher) {
       worktreesWatcher = watcher;
       worktreesWatchIno = stat.ino;
+      changed = true;
     }
+    return changed;
   };
 
   attachWatcher(commonGitDir, (_eventType, filename) => {
-    if (!filename || filename === 'worktrees') {
+    if (filename === 'worktrees') {
       syncWorktreesWatcher();
+      notify('common-git-directory-changed');
+      return;
+    }
+    if (!filename && syncWorktreesWatcher()) {
       notify('common-git-directory-changed');
     }
   });

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2789,6 +2789,104 @@ export async function resetToCommit(directory, hash, mode, force = false) {
   }
 }
 
+const resolveGitCommonDirectory = async (directory) => {
+  const directoryPath = normalizeDirectoryPath(directory);
+  if (!directoryPath || !fs.existsSync(directoryPath)) {
+    throw new Error('Directory does not exist');
+  }
+
+  const directoryGit = await createGit(directoryPath);
+  const repoRoot = await resolveGitRepositoryRoot(directoryPath, directoryGit);
+  const repoGit = path.resolve(directoryPath) === repoRoot ? directoryGit : await createGit(repoRoot);
+  const commonDirRaw = await repoGit.raw(['rev-parse', '--git-common-dir']);
+  const commonDir = commonDirRaw.trim();
+  if (!commonDir) {
+    throw new Error('Failed to resolve git common directory');
+  }
+
+  return path.isAbsolute(commonDir)
+    ? path.resolve(commonDir)
+    : path.resolve(repoRoot, commonDir);
+};
+
+export async function watchWorktreeChanges(directory, onChange) {
+  if (typeof onChange !== 'function') {
+    throw new Error('Worktree change callback is required');
+  }
+
+  const commonGitDir = await resolveGitCommonDirectory(directory);
+  const worktreesDir = path.join(commonGitDir, 'worktrees');
+  const watchers = [];
+  let closed = false;
+  let debounceTimer = null;
+  let watchingWorktreesDir = false;
+
+  const notify = (reason) => {
+    if (closed) return;
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      if (closed) return;
+      onChange({ reason, commonGitDir, worktreesDir, at: Date.now() });
+    }, 200);
+  };
+
+  const closeWatcher = (watcher) => {
+    try {
+      watcher.close();
+    } catch {
+      // ignored
+    }
+  };
+
+  const addWatcher = async (targetPath, handleEvent) => {
+    const stat = await fsp.stat(targetPath).catch(() => null);
+    if (!stat?.isDirectory()) {
+      return;
+    }
+
+    const watcher = fs.watch(targetPath, { persistent: false }, (eventType, filename) => {
+      handleEvent(eventType, typeof filename === 'string' ? filename : null);
+    });
+    watcher.on('error', (error) => {
+      console.warn('Git worktree watcher error:', error?.message || error);
+    });
+    watchers.push(watcher);
+  };
+
+  const ensureWorktreesWatcher = async () => {
+    if (closed || watchingWorktreesDir) {
+      return;
+    }
+    await addWatcher(worktreesDir, () => notify('worktrees-directory-changed'));
+    watchingWorktreesDir = watchers.length > 1;
+  };
+
+  await addWatcher(commonGitDir, (_eventType, filename) => {
+    if (!filename || filename === 'worktrees') {
+      void ensureWorktreesWatcher();
+      notify('common-git-directory-changed');
+    }
+  });
+
+  await ensureWorktreesWatcher();
+
+  if (watchers.length === 0) {
+    throw new Error('Failed to watch git worktree metadata');
+  }
+
+  return () => {
+    closed = true;
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    watchers.splice(0).forEach(closeWatcher);
+  };
+}
+
 export async function getWorktrees(directory) {
   const directoryPath = normalizeDirectoryPath(directory);
   if (!directoryPath || !fs.existsSync(directoryPath)) {

--- a/packages/web/server/lib/opencode/feature-routes-runtime.js
+++ b/packages/web/server/lib/opencode/feature-routes-runtime.js
@@ -61,6 +61,7 @@ export const createFeatureRoutesRuntime = (dependencies) => {
       scheduledTasksRuntime,
       getOpenChamberEventClients,
       writeSseEvent,
+      broadcastEvent,
     } = routeDependencies;
 
     const { getProviderSources, removeProviderConfig } = await import('./index.js');
@@ -262,7 +263,7 @@ export const createFeatureRoutesRuntime = (dependencies) => {
 
     registerQuotaRoutes(app, { getQuotaProviders });
     registerGitHubRoutes(app);
-    registerGitRoutes(app);
+    registerGitRoutes(app, { broadcastEvent });
     registerMagicPromptRoutes(app, {
       fsPromises,
       path,


### PR DESCRIPTION
> **AI Megamind** - By: Pi coding agent / GPT-5.1 Codex Max

## Summary

- Added a best-effort server-side Git worktree metadata watcher using `fs.watch` on the repository common git directory and `worktrees` metadata directory.
- Routed `worktree.changed` through the existing global UI event stream (`broadcastGlobalUiEvent`) instead of adding a separate per-project SSE transport.
- Added client handling for global `worktree.changed` events that bypasses the 30s worktree cache and refreshes shared worktree UI state immediately.
- Updated the settings worktree list to reflect shared store refreshes.

## Test plan

- `bun run type-check` — passed
- `bun run lint` — passed
- Manual temp-repo watcher smoke test — passed (`watchWorktreeChanges()` observed an externally-created `git worktree add`)

# Megamind Educational Brief

## Journey

- The request was to make externally-created Git worktrees appear instantly in OpenChamber instead of waiting for the existing discovery path.
- Planning identified two constraints: Git worktree metadata lives in the repository common Git dir (not always a literal `.git/` directory), and the UI had a 30s worktree list cache that would otherwise mask fresh server data.
- Initial implementation used a dedicated worktree SSE endpoint; reviewer feedback correctly pointed out that OpenChamber already has a multiplexed global event stream with WS/SSE fallback.
- The final implementation keeps the watcher, but routes `worktree.changed` through `broadcastGlobalUiEvent` and the existing sync pipeline.
- Local verification passed: `bun run type-check`, `bun run lint`, and a temp-repo smoke test where `watchWorktreeChanges()` observed an external `git worktree add`.

## Design Decisions

| Decision | Why | Alternative rejected | Evidence |
|---|---|---|---|
| Use Node `fs.watch` instead of adding an inotify dependency | Cross-platform, no new dependency, maps to native file notifications where available | Linux-only direct inotify package | `packages/web/server/lib/git/service.js`, `package.json` no dependency changes |
| Resolve `rev-parse --git-common-dir` before watching | Handles primary worktrees and linked worktrees where `.git` may be a file | Watch `<repo>/.git/worktrees` directly | `watchWorktreeChanges()` / `resolveGitCommonDirectory()` |
| Deliver `worktree.changed` via existing global event stream | Reuses the app's multiplexed WS/SSE transport, auth/origin handling, heartbeat, and reconnect behavior | Separate `/api/git/worktrees/events` SSE endpoint | `packages/web/server/lib/git/routes.js`, `packages/web/server/lib/event-stream/runtime.js` |
| Bypass the 30s client cache on watcher events | Existing cache would delay visible refresh despite instant notification | Reuse cached `listProjectWorktrees()` result | `refreshProjectWorktrees()` in `worktreeManager.ts` |
| Update shared session UI store per project | Sidebar/chat/settings derive worktree choices from shared state | Component-local refresh only | `useWorktreeDiscoveryEvents.ts`, `WorktreeSectionContent.tsx` |

## Architecture

```mermaid
flowchart LR
  GitMeta["Git common dir / worktrees metadata"] --> Watcher["watchWorktreeChanges(); fs.watch + debounce"]
  Watcher --> Broadcast["broadcastGlobalUiEvent(); worktree.changed"]
  Broadcast --> Pipeline["Existing global event stream; WS/SSE"]
  Pipeline --> Sync["SyncProvider dispatches local worktree-changed event"]
  Sync --> Refresh["refreshProjectWorktrees(); cache bypass"]
  Refresh --> Store["useSessionUIStore.availableWorktreesByProject"]
  Store --> UI["Sidebar / chat options / settings list"]
```

Runtime behavior:

1. Existing worktree listing (`/api/git/worktrees`) starts a best-effort server watcher for that project when a global broadcaster is available.
2. The server resolves the common Git directory, watches it and its `worktrees` child when present, and emits debounced `worktree.changed` events through `broadcastGlobalUiEvent`.
3. The existing event pipeline receives the event over its current transport and `SyncProvider` dispatches a browser-local `openchamber:worktree-changed` event.
4. `useWorktreeDiscoveryEvents()` maps the changed directory to a configured project, refreshes only that project with `forceRefresh`, updates `availableWorktreesByProject`, and deduplicates the flat `availableWorktrees` list by path.
5. Existing manual/list discovery remains available if the watcher cannot be established.

## Lessons

- File watchers need authoritative path resolution. For Git features, prefer `git rev-parse` outputs over constructing `.git` paths manually.
- Instant notification still needs cache invalidation. A fast event path is not enough if the client reads stale cached data.
- Prefer existing app event transports before adding feature-specific SSE/WS endpoints.
- Coarse invalidation is safer than interpreting partially-written Git metadata.
- Best-effort watcher features should preserve existing fetch/list behavior as fallback instead of becoming a hard dependency.
