### PR TITLE
fix: enable detached children for Linux in dev scripts

### DIFF
--- a/scripts/dev-vscode.mjs
+++ b/scripts/dev-vscode.mjs
@@ -9,7 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const extensionPath = path.join(repoRoot, 'packages', 'vscode');
-const useDetachedChildren = process.platform === 'darwin';
+const useDetachedChildren = process.platform === 'darwin' || process.platform === 'linux';
 
 const codeBin = process.env.OPENCHAMBER_VSCODE_BIN || 'code';
 const workspaceArg = process.argv[2] || process.env.OPENCHAMBER_VSCODE_DEV_WORKSPACE || repoRoot;

--- a/scripts/dev-web-full.mjs
+++ b/scripts/dev-web-full.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
-const useDetachedChildren = process.platform === 'darwin';
+const useDetachedChildren = process.platform === 'darwin' || process.platform === 'linux';
 
 function run(label, command, args, options = {}) {
   const child = spawn(command, args, {

--- a/scripts/dev-web-hmr.mjs
+++ b/scripts/dev-web-hmr.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
-const useDetachedChildren = process.platform === 'darwin';
+const useDetachedChildren = process.platform === 'darwin' || process.platform === 'linux';
 const webRoot = path.join(repoRoot, 'packages/web');
 
 const quoteWindowsCommandArg = (value) => `"${String(value).replace(/"/g, '""')}"`;


### PR DESCRIPTION
# What

- Enables detached child processes for Linux in the dev scripts,  matching the existing macOS behavior.

# Why

On Linux, spawned child processes (Vite dev server, OpenCode server) were not detached from the parent terminal. When the parent process exited, children could linger as orphans or fail to terminate cleanly. macOS already used detached mode; Linux needs the same treatment for consistent dev-experience behavior across platforms.

# How to test

1. On a Linux machine, run `bun run dev:web:hmr`, `bun run dev:web:full`, `bun run vscode:dev`.
2. Verify that Vite and OpenCode server processes start correctly.
3. Ctrl+C the parent script and confirm all child processes are terminated (no orphans).

---
Generated with [create-pr-description](https://github.com/tomzx/dot-claude/blob/db569037f4445c5a3001781256afad19f186d462/skills/create-pr-description/SKILL.md) (`db569037`)