### PR TITLE
Improve Todo tool rendering and reconnect state recovery

### DIFF
--- a/packages/ui/src/components/chat/StatusRow.tsx
+++ b/packages/ui/src/components/chat/StatusRow.tsx
@@ -202,11 +202,11 @@ export const StatusRow: React.FC<StatusRowProps> = ({
 
   const statusSummary = React.useMemo(() => {
     const active = visibleTodos.filter((t) => t.status === "in_progress").length;
-    const left = visibleTodos.filter((t) => t.status === "in_progress" || t.status === "pending").length;
+    const left = visibleTodos.filter((t) => t.status === "pending").length;
     return { active, left };
   }, [visibleTodos]);
 
-  const hasTodoContent = showTodos && statusSummary.left > 0;
+  const hasTodoContent = showTodos && (statusSummary.active > 0 || statusSummary.left > 0);
   const hasAssistantContent = showAssistantStatus && (
     isWorking ||
     Boolean(wasAborted) ||

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -725,9 +725,7 @@ const summarizeTodoToolItems = (todos: TodoToolItem[]): { completed: number; tot
         total += 1;
         if (todo.status === 'completed') {
             completed += 1;
-            continue;
         }
-
     }
 
     return { completed, total };
@@ -2635,8 +2633,8 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
             ? inputTodos
             : parseTodoToolItems(stateWithData.output);
         const summary = summarizeTodoToolItems(todos);
-        if (summary.total === 0) {
-            return t('chat.todo.summary.empty');
+        if (todos.length === 0 || summary.total === 0) {
+            return todos.length === 0 ? t('chat.todo.summary.empty') : t('chat.todo.cancelled');
         }
         return t('chat.todo.summary.progress', {
             completed: summary.completed,

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -152,13 +152,14 @@ const normalizeToolName = (toolName: string | undefined | null): string => {
         return '';
     }
 
-    if (trimmed.includes('.')) {
-        const dotParts = trimmed.split('.').filter(Boolean);
+    const withoutIndex = trimmed.replace(/:\d+$/, '');
+    if (withoutIndex.includes('.')) {
+        const dotParts = withoutIndex.split('.').filter(Boolean);
         const last = dotParts[dotParts.length - 1];
         if (last) return last;
     }
 
-    return trimmed;
+    return withoutIndex;
 };
 
 const MAX_DURATION_MS = 5 * 60 * 1000; // 5 minutes cap
@@ -626,6 +627,123 @@ const parseQuestionOutput = (output: string): Array<{ question: string; answer: 
     }
 
     return pairs.length > 0 ? pairs : null;
+};
+
+type TodoToolItem = {
+    id?: string;
+    content: string;
+    status?: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+    priority?: 'low' | 'medium' | 'high';
+};
+
+const parseTodoToolStatus = (value: unknown): TodoToolItem['status'] => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'pending') return 'pending';
+    if (normalized === 'in_progress' || normalized === 'in progress' || normalized === 'inprogress') return 'in_progress';
+    if (normalized === 'completed' || normalized === 'done') return 'completed';
+    if (normalized === 'cancelled' || normalized === 'canceled') return 'cancelled';
+    return undefined;
+};
+
+const parseTodoToolPriority = (value: unknown): TodoToolItem['priority'] => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'low') return 'low';
+    if (normalized === 'medium') return 'medium';
+    if (normalized === 'high') return 'high';
+    return undefined;
+};
+
+const parseTodoToolContent = (record: Record<string, unknown>): string => {
+    if (typeof record.content === 'string') {
+        return record.content;
+    }
+    if (typeof record.text === 'string') {
+        return record.text;
+    }
+    if (typeof record.title === 'string') {
+        return record.title;
+    }
+    return '';
+};
+
+const parseTodoToolItemsFromArray = (value: unknown[]): TodoToolItem[] => {
+    const items: TodoToolItem[] = [];
+    for (const item of value) {
+        if (!item || typeof item !== 'object') {
+            continue;
+        }
+        const record = item as Record<string, unknown>;
+        const content = parseTodoToolContent(record);
+        if (!content.trim()) {
+            continue;
+        }
+        items.push({
+            id: typeof record.id === 'string' ? record.id : undefined,
+            content,
+            status: parseTodoToolStatus(record.status),
+            priority: parseTodoToolPriority(record.priority),
+        });
+    }
+    return items;
+};
+
+const parseTodoToolItems = (value: unknown): TodoToolItem[] => {
+    if (Array.isArray(value)) {
+        return parseTodoToolItemsFromArray(value);
+    }
+    if (value && typeof value === 'object') {
+        const todos = (value as { todos?: unknown }).todos;
+        if (Array.isArray(todos)) {
+            return parseTodoToolItemsFromArray(todos);
+        }
+    }
+    if (typeof value === 'string' && value.trim()) {
+        try {
+            return parseTodoToolItems(JSON.parse(value) as unknown);
+        } catch {
+            return [];
+        }
+    }
+    return [];
+};
+
+const summarizeTodoToolItems = (todos: TodoToolItem[]): { completed: number; total: number } => {
+    let completed = 0;
+    let total = 0;
+
+    for (const todo of todos) {
+        if (todo.status === 'cancelled') {
+            continue;
+        }
+
+        total += 1;
+        if (todo.status === 'completed') {
+            completed += 1;
+            continue;
+        }
+
+    }
+
+    return { completed, total };
+};
+
+const getTodoStatusStyle = (status: TodoToolItem['status']): React.CSSProperties => {
+    if (status === 'completed') {
+        return { color: 'var(--status-success)', backgroundColor: 'var(--status-success-background)', borderColor: 'var(--status-success-border)' };
+    }
+    if (status === 'in_progress') {
+        return { color: 'var(--status-info)', backgroundColor: 'var(--status-info-background)', borderColor: 'var(--status-info-border)' };
+    }
+    if (status === 'cancelled') {
+        return { color: 'var(--status-error)', backgroundColor: 'var(--status-error-background)', borderColor: 'var(--status-error-border)' };
+    }
+    return { color: 'var(--tools-description)', backgroundColor: 'var(--surface-elevated)', borderColor: 'var(--tools-border)' };
 };
 
 const getToolDescriptionPath = (part: ToolPartType, state: ToolStateUnion, currentDirectory: string): string | null => {
@@ -1468,6 +1586,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
     const metadata = stateWithData.metadata;
     const input = stateWithData.input;
     const rawOutput = stateWithData.output;
+    const normalizedToolName = normalizeToolName(part.tool);
     const hasStringOutput = typeof rawOutput === 'string' && rawOutput.length > 0;
     const outputString = typeof rawOutput === 'string' ? rawOutput : '';
 
@@ -1584,8 +1703,62 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
             );
         };
 
+        if (normalizedToolName === 'todowrite') {
+            const inputTodos = parseTodoToolItems(input?.todos);
+            const todos = inputTodos.length > 0
+                ? inputTodos
+                : parseTodoToolItems(rawOutput);
+
+            if (todos.length === 0) {
+                return renderScrollableBlock(
+                    <div className="typography-meta" style={{ color: 'var(--tools-description)' }}>{t('chat.toolPart.noOutputProduced')}</div>,
+                    { maxHeightClass: 'max-h-60' }
+                );
+            }
+
+            const getStatusLabel = (status: TodoToolItem['status']) => {
+                if (status === 'completed') return t('chat.todo.completed');
+                if (status === 'in_progress') return t('chat.todo.inProgress');
+                if (status === 'cancelled') return t('chat.todo.cancelled');
+                return t('chat.todo.pending');
+            };
+
+            const getPriorityLabel = (priority: TodoToolItem['priority']) => {
+                if (priority === 'high') return t('chat.statusRow.todo.priority.high');
+                if (priority === 'low') return t('chat.statusRow.todo.priority.low');
+                return t('chat.statusRow.todo.priority.medium');
+            };
+
+            return renderScrollableBlock(
+                <div className="space-y-1.5">
+                    {todos.map((todo, index) => {
+                        const status = todo.status ?? 'pending';
+                        const priority = todo.priority ?? 'medium';
+                        return (
+                            <div key={todo.id ?? `${index}:${todo.content}`} className="rounded-lg border px-2 py-1.5" style={{ backgroundColor: 'var(--surface-elevated)', borderColor: 'var(--tools-border)' }}>
+                                <div className="flex items-start gap-2 min-w-0">
+                                    <span className="mt-0.5 inline-flex shrink-0 rounded-full border px-1.5 py-0.5 typography-micro font-medium" style={getTodoStatusStyle(status)}>
+                                        {getStatusLabel(status)}
+                                    </span>
+                                    <div className="min-w-0 flex-1 space-y-0.5">
+                                        <div className="typography-meta whitespace-pre-wrap break-words" style={{ color: 'var(--surface-foreground)' }}>
+                                            {todo.content}
+                                        </div>
+                                        <div className="typography-micro" style={{ color: 'var(--surface-muted-foreground)' }}>
+                                            {getPriorityLabel(priority)}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>,
+                { maxHeightClass: 'max-h-[40vh]', className: 'p-1' }
+            );
+        }
+
         // Question tool: show parsed Q&A summary or question content from input
-        if (part.tool === 'question') {
+        if (normalizedToolName === 'question') {
             if (state.status === 'completed' && hasStringOutput) {
                 const parsedQA = parseQuestionOutput(outputString);
                 if (parsedQA && parsedQA.length > 0) {
@@ -1727,7 +1900,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                 'relative pr-2 pb-2 pt-2 space-y-2 pl-4'
             )}
         >
-            {part.tool === 'question' ? (
+            {normalizedToolName === 'question' || normalizedToolName === 'todowrite' ? (
                 renderResultContent()
             ) : (
                 <>
@@ -1804,6 +1977,7 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
     onShowPopup,
     animateTailText = true,
 }) => {
+    const { t } = useI18n();
     const state = part.state;
     const showToolFileIcons = useUIStore((s) => s.showToolFileIcons);
     const currentDirectory = useDirectoryStore((s) => s.currentDirectory);
@@ -2451,6 +2625,24 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
     const normalizedPart = normalizedPartTool !== part.tool ? ({ ...part, tool: normalizedPartTool } as ToolPartType) : part;
     const descriptionPath = getToolDescriptionPath(normalizedPart, state, currentDirectory);
     const description = getToolDescription(normalizedPart, state, currentDirectory);
+    const todoDescription = React.useMemo(() => {
+        if (normalizedPartTool !== 'todowrite') {
+            return null;
+        }
+
+        const inputTodos = parseTodoToolItems(input?.todos);
+        const todos = inputTodos.length > 0
+            ? inputTodos
+            : parseTodoToolItems(stateWithData.output);
+        const summary = summarizeTodoToolItems(todos);
+        if (summary.total === 0) {
+            return t('chat.todo.summary.empty');
+        }
+        return t('chat.todo.summary.progress', {
+            completed: summary.completed,
+            total: summary.total,
+        });
+    }, [input?.todos, normalizedPartTool, stateWithData.output, t]);
     const displayName = getToolMetadata(normalizedPartTool || part.tool).displayName;
     
     // Tool title/description — shown inline as context
@@ -2459,6 +2651,9 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
             return null;
         }
         if (normalizedPartTool === 'apply_patch') {
+            return null;
+        }
+        if (normalizedPartTool === 'todowrite') {
             return null;
         }
         if (
@@ -2632,17 +2827,17 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
                                     {justificationText}
                                 </span>
                             )}
-                            {!justificationText && description && (
-                                descriptionPath && description === descriptionPath ? (
+                            {!justificationText && (todoDescription || description) && (
+                                !todoDescription && descriptionPath && description === descriptionPath ? (
                                     renderAnimatedPathWithIcon(descriptionPath, animateTailText, false, showToolFileIcons)
                                 ) : (
                                     <Text
                                         variant={animateTailText ? 'generate-effect' : 'static'}
                                         className={cn('min-w-0 truncate', TOOL_ROW_DESCRIPTION_CLASS)}
                                         style={{ color: 'var(--tools-description)' }}
-                                        title={description}
+                                        title={todoDescription ?? description}
                                     >
-                                        {description}
+                                        {todoDescription ?? description}
                                     </Text>
                                 )
                             )}

--- a/packages/ui/src/components/chat/message/parts/toolRenderUtils.ts
+++ b/packages/ui/src/components/chat/message/parts/toolRenderUtils.ts
@@ -2,7 +2,7 @@ const EXPANDABLE_TOOL_NAMES = new Set<string>([
     'edit', 'multiedit', 'apply_patch', 'str_replace', 'str_replace_based_edit_tool',
     'bash', 'shell', 'cmd', 'terminal',
     'write', 'create', 'file_write',
-    'question', 'task',
+    'question', 'task', 'todowrite',
 ]);
 
 const STANDALONE_TOOL_NAMES = new Set<string>(['task']);

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1688,6 +1688,8 @@ export const dict = {
   'chat.todo.pending': 'Pending',
   'chat.todo.completed': 'Completed',
   'chat.todo.cancelled': 'Cancelled',
+  'chat.todo.summary.empty': '0/0 done',
+  'chat.todo.summary.progress': '{completed}/{total} done',
   'chat.permissionCard.workingDirectory': 'Working Directory:',
   'chat.permissionCard.timeout': 'Timeout:',
   'chat.permissionCard.request': 'Request:',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1654,6 +1654,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.todo.pending": "Pendiente",
   "chat.todo.completed": "Completado",
   "chat.todo.cancelled": "Cancelado",
+  "chat.todo.summary.empty": "0/0 completados",
+  "chat.todo.summary.progress": "{completed}/{total} completados",
   "chat.permissionCard.workingDirectory": "Directorio de trabajo:",
   "chat.permissionCard.timeout": "Tiempo de espera:",
   "chat.permissionCard.request": "Solicitud:",

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1688,6 +1688,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.todo.pending': '대기 중',
   'chat.todo.completed': '완료됨',
   'chat.todo.cancelled': '취소됨',
+  'chat.todo.summary.empty': '0/0 완료',
+  'chat.todo.summary.progress': '{completed}/{total} 완료',
   'chat.permissionCard.workingDirectory': '작업 디렉터리:',
   'chat.permissionCard.timeout': '시간 제한:',
   'chat.permissionCard.request': '요청:',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1041,6 +1041,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.todo.completed': 'Ukończone',
   'chat.todo.inProgress': 'W trakcie',
   'chat.todo.pending': 'Oczekujące',
+  'chat.todo.summary.empty': '0/0 ukończone',
+  'chat.todo.summary.progress': '{completed}/{total} ukończone',
   'chat.todo.total': 'Łącznie',
   'chat.toolOutputDialog.commandCompleted': 'Polecenie zakończone pomyślnie',
   'chat.toolOutputDialog.image.closeAria': 'Zamknij podgląd obrazu',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1654,6 +1654,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.todo.pending": "Pendente",
   "chat.todo.completed": "Concluído",
   "chat.todo.cancelled": "Cancelado",
+  "chat.todo.summary.empty": "0/0 concluídos",
+  "chat.todo.summary.progress": "{completed}/{total} concluídos",
   "chat.permissionCard.workingDirectory": "Diretório de trabalho:",
   "chat.permissionCard.timeout": "Tempo limite:",
   "chat.permissionCard.request": "Solicitação:",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1654,6 +1654,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.todo.pending": "В очікуванні",
   "chat.todo.completed": "Виконано",
   "chat.todo.cancelled": "Скасовано",
+  "chat.todo.summary.empty": "0/0 виконано",
+  "chat.todo.summary.progress": "{completed}/{total} виконано",
   "chat.permissionCard.workingDirectory": "Робочий каталог:",
   "chat.permissionCard.timeout": "Час очікування:",
   "chat.permissionCard.request": "запит:",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1654,6 +1654,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.todo.pending': '待处理',
   'chat.todo.completed': '已完成',
   'chat.todo.cancelled': '已取消',
+  'chat.todo.summary.empty': '0/0 已完成',
+  'chat.todo.summary.progress': '{completed}/{total} 已完成',
   'chat.permissionCard.workingDirectory': '工作目录：',
   'chat.permissionCard.timeout': '超时：',
   'chat.permissionCard.request': '请求：',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1651,6 +1651,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.todo.pending': '待處理',
   'chat.todo.completed': '已完成',
   'chat.todo.cancelled': '已取消',
+  'chat.todo.summary.empty': '0/0 已完成',
+  'chat.todo.summary.progress': '{completed}/{total} 已完成',
   'chat.permissionCard.workingDirectory': '工作目錄：',
   'chat.permissionCard.timeout': '逾時：',
   'chat.permissionCard.request': 'Request：',

--- a/packages/ui/src/sync/__tests__/session-switch-resync.test.ts
+++ b/packages/ui/src/sync/__tests__/session-switch-resync.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test, beforeEach, mock } from "bun:test"
 import { create, type StoreApi } from "zustand"
-import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client"
+import type { PermissionRequest, QuestionRequest, Todo } from "@opencode-ai/sdk/v2/client"
 
 const listPendingQuestionsCalls: Array<{ directories?: Array<string | null | undefined> }> = []
 const listPendingPermissionsCalls: Array<{ directories?: Array<string | null | undefined> }> = []
+const sessionTodoCalls: string[] = []
+const persistedTodoUpdates: Array<{ sessionId: string; todos: Todo[] | undefined }> = []
 let pendingQuestionsResponse: QuestionRequest[] = []
 let pendingPermissionsResponse: PermissionRequest[] = []
+let persistedTodoResponses: Record<string, Todo[] | undefined> = {}
+let sessionTodoResponses: Record<string, Todo[]> = {}
+let sessionTodoShouldFail = false
 let pendingQuestionsShouldThrow = false
 let pendingPermissionsShouldThrow = false
 
@@ -22,7 +27,15 @@ mock.module("@/lib/opencode/client", () => ({
       return pendingPermissionsResponse
     }),
     getDirectory: () => "/repo",
-    getScopedSdkClient: () => ({}),
+    getScopedSdkClient: () => ({
+      session: {
+        todo: mock(async ({ sessionID }: { sessionID: string }) => {
+          sessionTodoCalls.push(sessionID)
+          if (sessionTodoShouldFail) return { error: { message: "simulated" } }
+          return { data: sessionTodoResponses[sessionID] ?? [] }
+        }),
+      },
+    }),
     setDirectory: () => undefined,
   },
 }))
@@ -41,7 +54,14 @@ mock.module("@/stores/useConfigStore", () => ({
 }))
 
 mock.module("@/stores/useTodosPersistStore", () => ({
-  useTodosPersistStore: { getState: () => ({}) },
+  useTodosPersistStore: {
+    getState: () => ({
+      setSessionTodos: (sessionId: string, todos: Todo[] | undefined) => {
+        persistedTodoUpdates.push({ sessionId, todos })
+      },
+      getSessionTodos: (sessionId: string) => persistedTodoResponses[sessionId],
+    }),
+  },
 }))
 
 mock.module("@/components/ui", () => ({
@@ -50,7 +70,7 @@ mock.module("@/components/ui", () => ({
 
 import { INITIAL_STATE, type State } from "../types"
 import type { DirectoryStore } from "../child-store"
-import { resyncBlockingRequestsForDirectory } from "../sync-context"
+import { resyncBlockingRequestsForDirectory, resyncSessionTodosForDirectory } from "../sync-context"
 
 function buildQuestion(overrides: Partial<QuestionRequest> = {}): QuestionRequest {
   return {
@@ -87,8 +107,13 @@ describe("resyncBlockingRequestsForDirectory", () => {
   beforeEach(() => {
     listPendingQuestionsCalls.length = 0
     listPendingPermissionsCalls.length = 0
+    sessionTodoCalls.length = 0
+    persistedTodoUpdates.length = 0
     pendingQuestionsResponse = []
     pendingPermissionsResponse = []
+    persistedTodoResponses = {}
+    sessionTodoResponses = {}
+    sessionTodoShouldFail = false
     pendingQuestionsShouldThrow = false
     pendingPermissionsShouldThrow = false
   })
@@ -204,5 +229,65 @@ describe("resyncBlockingRequestsForDirectory", () => {
     expect(store.getState().question["ses_a"]).toHaveLength(1)
     expect(store.getState().question["ses_a"]?.[0]?.id).toBe("que_1")
     expect(listPendingPermissionsCalls).toHaveLength(1)
+  })
+})
+
+describe("resyncSessionTodosForDirectory", () => {
+  beforeEach(() => {
+    sessionTodoCalls.length = 0
+    persistedTodoUpdates.length = 0
+    persistedTodoResponses = {}
+    sessionTodoResponses = {}
+    sessionTodoShouldFail = false
+  })
+
+  test("refreshes session todos from the authoritative session.todo endpoint", async () => {
+    const store = createDirectoryStore({})
+    sessionTodoResponses = {
+      ses_a: [{ id: "todo_1", content: "Done", status: "completed", priority: "medium" } as Todo],
+    }
+
+    await resyncSessionTodosForDirectory("/repo", store, ["ses_a"])
+
+    expect(sessionTodoCalls).toEqual(["ses_a"])
+    expect(store.getState().todo["ses_a"]?.[0]?.status).toBe("completed")
+    expect(persistedTodoUpdates).toHaveLength(1)
+    expect((persistedTodoUpdates[0]?.todos?.[0] as Todo & { id?: string } | undefined)?.id).toBe("todo_1")
+  })
+
+  test("clears stale todos when the server returns an empty list", async () => {
+    const store = createDirectoryStore({
+      todo: { ses_a: [{ id: "todo_stale", content: "Old", status: "pending", priority: "medium" } as Todo] },
+    })
+    sessionTodoResponses = { ses_a: [] }
+
+    await resyncSessionTodosForDirectory("/repo", store, ["ses_a"])
+
+    expect(store.getState().todo["ses_a"]).toEqual(undefined)
+    expect(persistedTodoUpdates).toEqual([{ sessionId: "ses_a", todos: undefined }])
+  })
+
+  test("clears persisted stale todos when live state is already empty", async () => {
+    const store = createDirectoryStore({})
+    persistedTodoResponses = {
+      ses_a: [{ id: "todo_stale", content: "Old", status: "pending", priority: "medium" } as Todo],
+    }
+    sessionTodoResponses = { ses_a: [] }
+
+    await resyncSessionTodosForDirectory("/repo", store, ["ses_a"])
+
+    expect(store.getState().todo["ses_a"]).toEqual(undefined)
+    expect(persistedTodoUpdates).toEqual([{ sessionId: "ses_a", todos: undefined }])
+  })
+
+  test("preserves existing todos when the todo fetch fails", async () => {
+    const existing = [{ id: "todo_existing", content: "Keep", status: "pending", priority: "medium" } as Todo]
+    const store = createDirectoryStore({ todo: { ses_a: existing } })
+    sessionTodoShouldFail = true
+
+    await resyncSessionTodosForDirectory("/repo", store, ["ses_a"])
+
+    expect(store.getState().todo["ses_a"]).toBe(existing)
+    expect(persistedTodoUpdates).toHaveLength(0)
   })
 })

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, useEffect, useRef, useCallback, useMemo } from "react"
-import type { Event, Message, Part } from "@opencode-ai/sdk/v2/client"
+import type { Event, Message, Part, Todo } from "@opencode-ai/sdk/v2/client"
 import type { Session } from "@opencode-ai/sdk/v2"
 import type { StoreApi } from "zustand"
 import { useStore } from "zustand"
@@ -409,6 +409,60 @@ async function resyncDirectorySessionStatuses(
   if (relevantStatuses === null) return null
   applySessionStatusSnapshot(store, relevantStatuses)
   return relevantStatuses
+}
+
+export async function resyncSessionTodosForDirectory(
+  directory: string,
+  store: StoreApi<DirectoryStore>,
+  candidateSessionIds: string[],
+) {
+  if (candidateSessionIds.length === 0) return
+
+  const before = store.getState()
+  const beforeSignatures = new Map(
+    candidateSessionIds.map((sessionId) => [sessionId, syncSnapshotSignature(before.todo[sessionId] ?? [])]),
+  )
+  const scopedClient = opencodeClient.getScopedSdkClient(directory)
+  const results = await Promise.all(candidateSessionIds.map(async (sessionId) => {
+    const response = await scopedClient.session.todo({ sessionID: sessionId }).catch(() => null)
+    if (!response || response.error) {
+      return null
+    }
+    return [sessionId, (response.data ?? []) as Todo[]] as const
+  }))
+
+  store.setState((state: DirectoryStore) => {
+    let nextTodo = state.todo
+    let changed = false
+
+    for (const result of results) {
+      if (!result) continue
+      const [sessionId, todos] = result
+      const beforeSignature = beforeSignatures.get(sessionId) ?? "[]"
+      const currentSignature = syncSnapshotSignature(state.todo[sessionId] ?? [])
+      if (currentSignature !== beforeSignature) continue
+
+      if (todos.length === 0) {
+        const todosPersistStore = useTodosPersistStore.getState()
+        const hasPersistedTodos = (todosPersistStore.getSessionTodos(sessionId)?.length ?? 0) > 0
+        if (!state.todo[sessionId] && !hasPersistedTodos) continue
+        todosPersistStore.setSessionTodos(sessionId, undefined)
+        if (!state.todo[sessionId]) continue
+        if (!changed) nextTodo = { ...state.todo }
+        delete nextTodo[sessionId]
+        changed = true
+        continue
+      }
+
+      if (currentSignature === syncSnapshotSignature(todos)) continue
+      if (!changed) nextTodo = { ...state.todo }
+      nextTodo[sessionId] = todos
+      useTodosPersistStore.getState().setSessionTodos(sessionId, todos)
+      changed = true
+    }
+
+    return changed ? { todo: nextTodo } : state
+  })
 }
 
 function needsSnapshotAfterStatusPoll(
@@ -1016,6 +1070,8 @@ async function resyncDirectoryAfterReconnect(
   routingIndex: EventRoutingIndex,
 ) {
   const current = store.getState()
+  await resyncBlockingRequestsForDirectory(directory, store)
+
   const candidateSessionIds = getActiveSessionCandidateIds(directory, current)
   if (candidateSessionIds.length === 0) return
 
@@ -1091,7 +1147,7 @@ async function resyncDirectoryAfterReconnect(
     setIndexedSessionMessages(routingIndex, sessionId, directory, nextMessages)
   }))
 
-  await resyncBlockingRequestsForDirectory(directory, store, candidateSessionIds)
+  await resyncSessionTodosForDirectory(directory, store, candidateSessionIds)
 
   ingestDirectoryStateIntoRoutingIndex(routingIndex, directory, store.getState())
 }


### PR DESCRIPTION
## Summary

- Render `todowrite` tool calls as expandable Todo list updates in chat history.
- Show Todo progress summaries inline for Todo tool rows.
- Add localized Todo summary strings across supported locales.
- Keep active Todo status visible in the status row even when no pending items remain.
- Refresh authoritative session Todo state during reconnect recovery.
- Preserve existing Todo state when reconnect Todo fetching fails, and clear stale persisted Todos only after a confirmed empty server response.
- Add reconnect recovery coverage for session Todo refresh, stale cleanup, and fetch-failure preservation.

## Notes

This keeps OpenChamber responsible for faithfully displaying Todo tool state and recovering authoritative Todo state after reconnects, without trying to reinterpret or merge separate `todowrite` calls made by the agent.

Todo history is intentionally rendered from the exact `todowrite` calls emitted by the agent, so the visual history can differ significantly depending on prompt specificity. A prompt that explicitly requires each phase transition to complete the current todo and start the next todo in the same update call produces the minimal number of Todo tool entries. A looser prompt may still produce that minimal sequence, but it may also split each transition into separate calls: create all todos as pending, mark one in progress, mark it completed, then separately mark the next one in progress, and so on.

Because this behavior changes based on prompting, it is not an OpenChamber rendering problem. OpenChamber should display the tool history it receives. If the desired behavior is fewer or more atomic Todo updates, that should be handled at the OpenCode/model/agent/system-instruction layer that controls when and how `todowrite` is called.

### Minimal Todo update prompt

```text
Test task synchronization and permission auto-approve while the client is asleep.

Create exactly 4 todos:
1. wait phase
2. process tmp file
3. write summary
4. final verification

Important todo update rules:
- In the initial todo creation call, create all 4 todos and set todo 1 to in_progress immediately.
- Do not create all todos as pending first.
- Use exactly one todo update call for each phase transition.
- A phase transition means: mark the current todo as completed AND mark the next todo as in_progress in the same todo update call.
- Do not first mark the current todo completed and then separately mark the next todo in_progress.
- Keep exactly one todo in_progress at a time, except after the final update when all todos are completed.
- Do not add, remove, rename, or reorder todos.

Required sequence:
1. Create the 4 todos in one call: todo 1 = in_progress, todos 2-4 = pending.
2. Wait 15 seconds.
3. Update todos once: todo 1 = completed, todo 2 = in_progress, todos 3-4 = pending.
4. Update todos once: todo 1-2 = completed, todo 3 = in_progress, todo 4 = pending.
5. Write a short summary in the assistant response.
6. Update todos once: todo 1-3 = completed, todo 4 = in_progress.
7. Verify that todos 1-3 are completed and todo 4 is in_progress.
8. Update todos once: all 4 todos = completed.
```

### Looser Todo update prompt

```text
Test task synchronization and permission auto-approve while the client is asleep.

Create exactly 4 todos:
1. wait phase
2. process tmp file
3. write summary
4. final verification

Then:
- Mark todo 1 in_progress, wait 15 seconds, then completed.
- Mark todo 2 in_progress, then completed.
- Mark todo 3 in_progress, write a short summary in the assistant response, then completed.
- Mark todo 4 in_progress, verify all todos are completed, then completed.
```
<img width="1115" height="2375" alt="Screenshot_20260531_110115" src="https://github.com/user-attachments/assets/591401c0-31e7-4d1f-93db-728e4ca88d49" />
