### PR TITLE
Add reproduce-issue agent

### DIFF
--- a/.github/workflows/reproduce-issue.yml
+++ b/.github/workflows/reproduce-issue.yml
@@ -1,0 +1,43 @@
+name: reproduce-issue
+
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: reproduce-issue-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  reproduce:
+    if: github.event.label.name == 'bug'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install opencode
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Reproduce issue
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          opencode run --agent reproduce-issue "An issue in the OpenChamber repository has been labeled as a bug and needs reproduction. Reproduce it.
+
+          Issue: $ISSUE_URL
+
+          Title: $ISSUE_TITLE
+
+          $ISSUE_BODY"

--- a/.opencode/agent/reproduce-issue.md
+++ b/.opencode/agent/reproduce-issue.md
@@ -1,0 +1,45 @@
+---
+mode: primary
+hidden: true
+model: opencode-go/deepseek-v4-flash
+color: "#c0392b"
+permission:
+  edit: allow
+  bash:
+    "gh *": allow
+    "git *": allow
+    "bun *": allow
+    "rg *": allow
+    "ls *": allow
+    "cat *": allow
+    "node *": allow
+    "npx *": allow
+    "npm *": allow
+---
+
+You are a reproduce-issue agent responsible for reproducing bugs reported in GitHub issues in the OpenChamber repository.
+
+Your goal is to create a minimal, working reproduction of the reported bug and leave your findings as a comment on the issue.
+
+## Steps
+
+1. Read the issue carefully. Identify the reported behavior, expected behavior, and any reproduction steps the reporter provided.
+2. Inspect the relevant code areas using search and file reads. Identify the most likely module(s) involved based on the issue description.
+3. Attempt to reproduce the bug locally by running commands, inspecting code paths, or writing a small test or script that demonstrates the issue.
+4. If you can reproduce the bug:
+   - Describe the exact reproduction steps that reliably trigger it.
+   - Identify the root cause or the most likely code location.
+   - Leave a concise comment on the issue with your findings.
+   - Add the `confirmed` label if it exists.
+5. If you cannot reproduce the bug:
+   - Describe what you tried and why it did not reproduce.
+   - Ask the reporter for specific missing details (browser version, OS, config, steps).
+   - Add the `needs-info` label if it exists.
+
+## Constraints
+
+- Do not fix the bug. Only reproduce it.
+- Do not push commits or create branches.
+- Keep comments concise and factual.
+- If the issue lacks enough detail to even attempt reproduction, say so and ask for the minimum needed.
+- Use the GitHub CLI (`gh`) to inspect the issue, list labels, add labels, and leave comments.


### PR DESCRIPTION
# What

- Adds an automated `reproduce-issue` GitHub Actions workflow that triggers when an issue receives the `bug` label
- Adds an opencode agent (`reproduce-issue`) that reads the bug report, inspects relevant code, attempts to reproduce the issue, and posts findings as a comment on the issue

# Why

Bug reports often lack clear reproduction steps or enough detail to act on quickly.
Automating reproduction on label gives maintainers a head start: confirmed bugs get a root-cause pointer and reproduction steps, while unclear reports get a targeted request for more info.

# How to test

1. Apply the `bug` label to any issue in the repository
2. Verify the `reproduce-issue` workflow run triggers in the Actions tab
3. Check the issue for an automated comment with reproduction findings or a request for more details
4. Confirm the correct label (`confirmed` or `needs-info`) is applied

---
Generated with [create-pr-description](https://github.com/tomzx/dot-claude/blob/d95675e44c6641fb587c8a200f2a5151255c0816/skills/create-pr-description/SKILL.md) (`d95675e`)