### PR TITLE
Improve triage agent definition

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+concurrency:
+  group: triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.opencode/agent/triage.md
+++ b/.opencode/agent/triage.md
@@ -20,21 +20,89 @@ Only use labels that already exist in this repository. Do not create labels.
 
 ## Triage Rules
 
-Classify the issue by the strongest matching area:
+### Step 1: Type label (pick the strongest match)
 
-- UI: shared React UI, chat, settings, terminal UI, theme, typography, layout, and user-facing behavior.
-- Web: web server, HTTP/SSE APIs, OpenCode server integration, filesystem routes, Git/GitHub/quota/notification/terminal/TTS/skills modules.
-- Electron: desktop shell, native menus, dialogs, notifications, updater, deep links, quit behavior, and Electron packaging.
-- VS Code: extension host, webview, bridge/runtime behavior, and VS Code packaging.
-- Release: GitHub Actions, release builds, auto-update, installers, signing, publishing, and packaging pipelines.
-- Docs: documentation, README, changelog, guides, and unclear instructions.
-- Question or support: user needs help, setup guidance, or clarification rather than a code change.
+| Label | When to apply |
+|---|---|
+| `bug` | Something is broken or not working as expected |
+| `enhancement` | New feature request or improvement suggestion |
+| `documentation` | README, guides, changelog, or unclear docs |
+| `question` | User needs help, setup guidance, or clarification (not a code change) |
+
+### Step 2: Area label (pick the strongest match, use `area:*` labels)
+
+| Label | Covers |
+|---|---|
+| `area:chat-ui` | Chat messages, rendering, markdown, bubbles |
+| `area:chat-input` | Chat input box, IME, message composing |
+| `area:sessions` | Session lifecycle, list, status, history |
+| `area:settings` | Settings UI, config, preferences |
+| `area:agents` | Agents, subagents, multi-run, agent manager |
+| `area:providers` | Model providers, API keys, model selection |
+| `area:git` | Git operations, worktrees, branches, diffs, commits |
+| `area:sidebar` | Sidebar, session list, folders, project list |
+| `area:remote` | Remote instances, SSH, VPS, tunnels |
+| `area:terminal` | Integrated terminal, PTY, xterm |
+| `area:vscode` | VS Code extension, webview, extension host |
+| `area:notifications` | Push/mobile/web notifications |
+| `area:streaming` | SSE streaming, spinner, real-time updates |
+| `area:sync` | State sync, cross-runtime consistency |
+| `area:auth` | Authentication, passwords, OAuth, tunnels |
+| `area:installation` | Install, Docker, Nix, deployment |
+| `area:desktop` | Desktop shell (Electron/Tauri), window management |
+| `area:keyboard` | Keyboard shortcuts, keybinds, input handling |
+| `area:permissions` | Permission prompts, allow/deny flows |
+| `area:compact` | Context compaction, /compact command |
+| `area:i18n` | Internationalization, translations, locale |
+| `area:queue` | Message queuing, queued messages |
+| `area:files` | File viewer, file picker, file tree |
+| `area:scheduled-tasks` | Scheduled/recurring tasks |
+
+### Step 3: Platform label (if clearly platform-specific)
+
+| Label | Covers |
+|---|---|
+| `platform:web` | Desktop web browser (incl. CLI serve) |
+| `platform:macos` | macOS desktop (Electron/Tauri) |
+| `platform:linux` | Linux desktop |
+| `platform:windows` | Windows desktop / WSL |
+| `platform:mobile` | Mobile web/PWA (iOS/Android) |
+| `platform:vscode` | VS Code extension |
+
+### Step 4: Provider label (if clearly provider-specific)
+
+| Label | Covers |
+|---|---|
+| `api:anthropic` | Anthropic/Claude provider |
+| `api:openai` | OpenAI provider |
+| `api:openrouter` | OpenRouter provider |
+| `api:copilot` | GitHub Copilot provider |
+| `api:google` | Google/Gemini provider |
+
+### Step 5: Priority and quality labels (apply when evidence supports it)
+
+| Label | When to apply |
+|---|---|
+| `priority:high` | Blocks core workflows, data loss, or many users |
+| `priority:medium` | Significant UX issue or common feature gap |
+| `priority:low` | Minor UX polish, niche feature request |
+| `data-loss` | Risk of losing user data or overwriting files |
+| `regression` | Bug that worked in a previous release |
+| `has-repro` | Confirmed reproducible with clear steps |
+| `needs-repro` | No clear reproduction steps provided |
+| `needs-info` | Needs more info from reporter to reproduce |
+
+### General guidelines
+
+- Apply at most 1 type label, 1-2 area labels, 1 platform label, and 1 provider label.
+- Only add priority/quality labels when the issue clearly warrants them.
+- Do not add labels speculatively; skip any category where the match is ambiguous.
 
 ## Output
 
 For each issue:
 
-- Add a small set of accurate existing labels when appropriate.
-- Leave one helpful comment with a short summary, likely affected area, and any missing information needed from the reporter.
+- Add a small set of accurate existing labels following the steps above.
+- In a single comment summarize the issue and ask the reporter for any additional information needed to complete the request.
 - Keep the comment friendly and concise.
-- If there is not enough information, ask for the smallest useful reproduction details.
+


### PR DESCRIPTION
# What

- Rewrites the triage agent prompt in `.opencode/agent/triage.md` to use a structured multi-step labeling workflow.
- Replaces the previous freeform classification rules with explicit step-by-step tables for type, area, platform, provider, and priority/quality labels.
- Adds 23 fine-grained `area:*` labels covering chat-ui, chat-input, sessions, settings, agents, providers, git, sidebar, remote, terminal, vscode, notifications, streaming, sync, auth, installation, desktop, keyboard, permissions, compact, i18n, queue, files, and scheduled-tasks.
- Adds 6 platform labels, 5 provider labels, and 8 priority/quality labels with clear when-to-apply guidance.
- Includes general guidelines constraining label count per category to avoid over-labeling.

# Why

The previous triage agent used broad, overlapping categories (UI, Web, Electron, VS Code, Release, Docs) that did not map to actual repository labels.
This made triage inconsistent and produced labels that did not exist in the repository.
The new structured approach maps directly to real label namespaces (`area:*`, `platform:*`, `api:*`, `priority:*`, `data-loss`, `regression`, etc.) and gives the agent clear decision boundaries at each step, reducing ambiguity and improving label accuracy.

# How to test

1. Open a new or existing GitHub issue in the openchamber/openchamber repository.
2. Trigger the triage agent on the issue.
3. Verify the agent applies at most 1 type label, 1-2 area labels, 1 platform label, and 1 provider label.
4. Verify labels match actual repository labels (check with `gh label list`).
5. Verify the agent leaves a single concise comment summarizing the issue and requesting any missing info.
6. Test with issues spanning different categories (bug in chat-ui, enhancement for terminal, question about installation) to confirm correct label selection at each step.

---
Generated with [create-pr-description](https://github.com/openchamber/openchamber/blob/55433fde/.opencode/agent/triage.md) (`55433fde`)