### PR TITLE
fix: add hidden models state to ModelMultiSelect component

### DIFF
--- a/packages/ui/src/components/multirun/ModelMultiSelect.tsx
+++ b/packages/ui/src/components/multirun/ModelMultiSelect.tsx
@@ -114,6 +114,7 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
   const toggleFavoriteModel = useUIStore((state) => state.toggleFavoriteModel);
   const isFavoriteModel = useUIStore((state) => state.isFavoriteModel);
   const { favoriteModelsList, recentModelsList } = useModelLists();
+  const hiddenModels = useUIStore((state) => state.hiddenModels);
   const [isOpen, setIsOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState('');
   const [availableHeight, setAvailableHeight] = React.useState<number | null>(null);
@@ -270,6 +271,7 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
                 favoriteModels={favoriteModelsList}
                 recentModels={recentModelsList}
                 modelsMetadata={modelsMetadata}
+                hiddenModels={hiddenModels}
                 searchQuery={searchQuery}
                 onSearchQueryChange={setSearchQuery}
                 onSelect={handleSelectModel}


### PR DESCRIPTION
Currently, in multi-run, the model selector shows all models, even the models that are hidden by the user in the providers section, this commit fixes that