### PR TITLE
Fix/1363 skills catalog immediate save

### DIFF
--- a/packages/ui/src/components/multirun/ModelMultiSelect.tsx
+++ b/packages/ui/src/components/multirun/ModelMultiSelect.tsx
@@ -114,6 +114,7 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
   const toggleFavoriteModel = useUIStore((state) => state.toggleFavoriteModel);
   const isFavoriteModel = useUIStore((state) => state.isFavoriteModel);
   const { favoriteModelsList, recentModelsList } = useModelLists();
+  const hiddenModels = useUIStore((state) => state.hiddenModels);
   const [isOpen, setIsOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState('');
   const [availableHeight, setAvailableHeight] = React.useState<number | null>(null);
@@ -270,6 +271,7 @@ export const ModelMultiSelect: React.FC<ModelMultiSelectProps> = ({
                 favoriteModels={favoriteModelsList}
                 recentModels={recentModelsList}
                 modelsMetadata={modelsMetadata}
+                hiddenModels={hiddenModels}
                 searchQuery={searchQuery}
                 onSearchQueryChange={setSearchQuery}
                 onSelect={handleSelectModel}

--- a/packages/ui/src/components/sections/skills/catalog/AddCatalogDialog.tsx
+++ b/packages/ui/src/components/sections/skills/catalog/AddCatalogDialog.tsx
@@ -244,7 +244,7 @@ export const AddCatalogDialog: React.FC<AddCatalogDialogProps> = ({ open, onOpen
     const updated = [...existingCatalogs, next];
 
     try {
-      await updateDesktopSettings({ skillCatalogs: updated });
+      await updateDesktopSettings({ skillCatalogs: updated }, { immediate: true });
       setExistingCatalogs(updated);
       toast.success(t('settings.skills.catalog.add.toast.catalogAdded'));
       await loadCatalog({ refresh: true });

--- a/packages/ui/src/components/sections/skills/catalog/SkillsCatalogPage.tsx
+++ b/packages/ui/src/components/sections/skills/catalog/SkillsCatalogPage.tsx
@@ -152,7 +152,7 @@ export const SkillsCatalogPage: React.FC<SkillsCatalogPageProps> = ({ mode, onMo
       const settings = await loadSettings();
       const catalogs = (Array.isArray(settings?.skillCatalogs) ? settings?.skillCatalogs : []) as SkillCatalogConfig[];
       const updated = catalogs.filter((c) => c.id !== selectedSourceId);
-      await updateDesktopSettings({ skillCatalogs: updated });
+      await updateDesktopSettings({ skillCatalogs: updated }, { immediate: true });
       await loadCatalog({ refresh: true });
       setIsRemoveCatalogDialogOpen(false);
     } finally {

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -1253,7 +1253,10 @@ const _flushSettingsUpdate = async (): Promise<void> => {
   }
 };
 
-export const updateDesktopSettings = async (changes: Partial<DesktopSettings>): Promise<void> => {
+export const updateDesktopSettings = async (
+  changes: Partial<DesktopSettings>,
+  opts?: { immediate?: boolean },
+): Promise<void> => {
   if (typeof window === 'undefined') {
     return;
   }
@@ -1263,6 +1266,11 @@ export const updateDesktopSettings = async (changes: Partial<DesktopSettings>): 
   if (_settingsFlushTimer) {
     clearTimeout(_settingsFlushTimer);
   }
+
+  if (opts?.immediate) {
+    return _flushSettingsUpdate();
+  }
+
   _settingsFlushTimer = setTimeout(() => void _flushSettingsUpdate(), SETTINGS_DEBOUNCE_MS);
 };
 


### PR DESCRIPTION
**What**: When adding or removing a skills catalog in Settings, the catalog dropdown only reflected the change after closing and reopening the settings window.

**Why**: When a skill catalog is added or removed, updateDesktopSettings() is called but it debounces the saves for 200ms so that rapid callers don't spam the server, but due to this after the function is called, GUI gets refreshed immediately without waiting 200ms for the save to actually happen

**Fix**: Added an immediate option to updateDesktopSettings(), if set to true it immediately flushes the saves, also future proofing for any other features that might need immediate saves. All other places that call updateDesktopSettings() remain unchanged.

Closes: #1363 