### PR TITLE
fix(ui): honor opencode default_agent for new sessions

### DIFF
--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -298,6 +298,7 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     const currentAgentName = useConfigStore((state) => state.currentAgentName);
     const settingsDefaultVariant = useConfigStore((state) => state.settingsDefaultVariant);
     const settingsDefaultAgent = useConfigStore((state) => state.settingsDefaultAgent);
+    const opencodeDefaultAgent = useConfigStore((state) => state.opencodeDefaultAgent);
     const setProvider = useConfigStore((state) => state.setProvider);
     const setSelectedProvider = useConfigStore((state) => state.setSelectedProvider);
     const setModel = useConfigStore((state) => state.setModel);
@@ -496,10 +497,14 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
             const found = selectableDesktopAgents.find(a => a.name === settingsDefaultAgent);
             if (found) return found.name;
         }
+        if (opencodeDefaultAgent) {
+            const found = selectableDesktopAgents.find(a => a.name === opencodeDefaultAgent);
+            if (found) return found.name;
+        }
         const buildAgent = selectableDesktopAgents.find(a => a.name === 'build');
         if (buildAgent) return buildAgent.name;
         return selectableDesktopAgents[0]?.name;
-    }, [settingsDefaultAgent, selectableDesktopAgents]);
+    }, [settingsDefaultAgent, opencodeDefaultAgent, selectableDesktopAgents]);
 
     const currentAgent = React.useMemo(() => {
         if (uiAgentName) {
@@ -943,7 +948,10 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                 return;
             }
 
-            const fallbackAgent = agents.find(agent => agent.name === 'build') || primaryAgents[0] || agents[0];
+            const fallbackAgent =
+                (settingsDefaultAgent ? agents.find(agent => agent.name === settingsDefaultAgent) : undefined) ||
+                (opencodeDefaultAgent ? agents.find(agent => agent.name === opencodeDefaultAgent) : undefined) ||
+                agents.find(agent => agent.name === 'build') || primaryAgents[0] || agents[0];
             if (!fallbackAgent) {
                 return;
             }
@@ -984,6 +992,8 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
         latestLoadedUserChoice,
         agents,
         primaryAgents,
+        settingsDefaultAgent,
+        opencodeDefaultAgent,
         currentAgentName,
         getSessionModelSelection,
         getAgentModelForSession,

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -1217,7 +1217,9 @@ class OpencodeService {
 
   // Configuration
   async getConfig(): Promise<Config> {
-    const response = await this.client.config.get();
+    const response = await this.client.config.get(
+      this.currentDirectory ? { directory: this.currentDirectory } : undefined
+    );
     if (!response.data) throw new Error('Failed to get config');
     return response.data;
   }

--- a/packages/ui/src/lib/worktreeSessionCreator.ts
+++ b/packages/ui/src/lib/worktreeSessionCreator.ts
@@ -70,6 +70,13 @@ const applyDefaultAgentAndModelSelection = (sessionId: string, configState = use
       }
     }
 
+    if (!agentName && configState.opencodeDefaultAgent) {
+      const configAgent = visibleAgents.find((a) => a.name === configState.opencodeDefaultAgent);
+      if (configAgent) {
+        agentName = configAgent.name;
+      }
+    }
+
     if (!agentName) {
       agentName =
         visibleAgents.find((agent) => agent.name === 'build')?.name ||

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -504,6 +504,9 @@ interface DirectoryScopedConfig {
     currentModelId: string;
     currentVariant?: string | undefined;
     currentAgentName: string | undefined;
+    // Per-directory opencode config `default_agent` (cached so it can be
+    // restored instantly when switching back to a known directory).
+    opencodeDefaultAgent?: string | undefined;
     selectedProviderId: string;
     agentModelSelections: { [agentName: string]: { providerId: string; modelId: string } };
     defaultProviders: { [key: string]: string };
@@ -533,6 +536,8 @@ interface ConfigStore {
     settingsDefaultModel: string | undefined; // format: "provider/model"
     settingsDefaultVariant: string | undefined;
     settingsDefaultAgent: string | undefined;
+    // Default agent from the active directory's opencode config (`default_agent`)
+    opencodeDefaultAgent: string | undefined;
     settingsAutoCreateWorktree: boolean;
     settingsGitmojiEnabled: boolean;
     settingsDefaultFileViewerPreview: boolean;
@@ -668,6 +673,7 @@ export const useConfigStore = create<ConfigStore>()(
                 settingsDefaultModel: undefined,
                 settingsDefaultVariant: undefined,
                 settingsDefaultAgent: undefined,
+                opencodeDefaultAgent: undefined,
                 settingsAutoCreateWorktree: false,
                 settingsGitmojiEnabled: false,
                 settingsDefaultFileViewerPreview: false,
@@ -915,6 +921,7 @@ export const useConfigStore = create<ConfigStore>()(
                                 currentModelId: snapshot.currentModelId,
                                 currentVariant: snapshot.currentVariant,
                                 currentAgentName: snapshot.currentAgentName,
+                                opencodeDefaultAgent: snapshot.opencodeDefaultAgent,
                                 selectedProviderId: snapshot.selectedProviderId,
                                 agentModelSelections: snapshot.agentModelSelections,
                                 defaultProviders: snapshot.defaultProviders,
@@ -928,6 +935,7 @@ export const useConfigStore = create<ConfigStore>()(
                             currentProviderId: "",
                             currentModelId: "",
                             currentAgentName: undefined,
+                            opencodeDefaultAgent: undefined,
                             selectedProviderId: "",
                             agentModelSelections: {},
                             defaultProviders: {},
@@ -1324,13 +1332,22 @@ export const useConfigStore = create<ConfigStore>()(
 
                     for (let attempt = 0; attempt < 3; attempt++) {
                         try {
-                            // Fetch agents and OpenChamber settings in parallel
-                            const [agents, openChamberDefaults] = await Promise.all([
+                            // Fetch agents, OpenChamber settings, and the opencode
+                            // config (for its `default_agent`) in parallel.
+                            const [agents, openChamberDefaults, opencodeConfig] = await Promise.all([
                                 opencodeClient.withDirectory(fromDirectoryKey(directoryKey), () => opencodeClient.listAgents()),
                                 fetchOpenChamberDefaults(),
+                                opencodeClient
+                                    .withDirectory(fromDirectoryKey(directoryKey), () => opencodeClient.getConfig())
+                                    .catch(() => null),
                             ]);
 
                             const safeAgents = Array.isArray(agents) ? agents : [];
+
+                            const opencodeDefaultAgent =
+                                typeof opencodeConfig?.default_agent === 'string' && opencodeConfig.default_agent.trim().length > 0
+                                    ? opencodeConfig.default_agent.trim()
+                                    : undefined;
 
                             const providers = get().activeDirectoryKey === directoryKey
                                 ? get().providers
@@ -1370,12 +1387,14 @@ export const useConfigStore = create<ConfigStore>()(
                                     ...baseSnapshot,
                                     providers,
                                     agents: safeAgents,
+                                    opencodeDefaultAgent,
                                 };
 
                                 const nextState: Partial<ConfigStore> = {
                                     settingsDefaultModel: openChamberDefaults.defaultModel,
                                     settingsDefaultVariant: openChamberDefaults.defaultVariant,
                                     settingsDefaultAgent: openChamberDefaults.defaultAgent,
+                                    opencodeDefaultAgent,
                                     settingsAutoCreateWorktree: openChamberDefaults.autoCreateWorktree ?? false,
                                     settingsGitmojiEnabled: openChamberDefaults.gitmojiEnabled ?? false,
                                     settingsDefaultFileViewerPreview: openChamberDefaults.defaultFileViewerPreview ?? false,
@@ -1460,7 +1479,7 @@ export const useConfigStore = create<ConfigStore>()(
                             };
 
                             // --- Agent Selection ---
-                            // Priority: settings.defaultAgent → build → first primary → first agent
+                            // Priority: settings.defaultAgent → opencode default_agent → build → first primary → first agent
                             const primaryAgents = safeAgents.filter((agent) => isPrimaryMode(agent.mode));
                             const buildAgent = primaryAgents.find((agent) => agent.name === "build");
                             const fallbackAgent = buildAgent || primaryAgents[0] || safeAgents[0];
@@ -1471,13 +1490,23 @@ export const useConfigStore = create<ConfigStore>()(
                              const invalidSettings: { defaultModel?: string; defaultVariant?: string; defaultAgent?: string } = {};
 
                             // 1. Check OpenChamber settings for default agent
+                            let resolvedFromDefaults = false;
                             if (openChamberDefaults.defaultAgent) {
                                 const settingsAgent = safeAgents.find((agent) => agent.name === openChamberDefaults.defaultAgent);
                                 if (settingsAgent) {
                                     resolvedAgent = settingsAgent;
+                                    resolvedFromDefaults = true;
                                 } else {
                                     // Agent no longer exists - mark for clearing
                                     invalidSettings.defaultAgent = '';
+                                }
+                            }
+
+                            // 2. Fall back to the opencode config's `default_agent`
+                            if (!resolvedFromDefaults && opencodeDefaultAgent) {
+                                const configAgent = safeAgents.find((agent) => agent.name === opencodeDefaultAgent);
+                                if (configAgent) {
+                                    resolvedAgent = configAgent;
                                 }
                             }
 

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -352,6 +352,26 @@ const activateConfigForDirectory = async (directory: string | null | undefined):
   await useConfigStore.getState().activateDirectory(normalizePath(directory))
 }
 
+// Resolve the agent a brand-new session should start on. Mirrors the priority
+// used by the config store's agent resolution:
+// settings.defaultAgent → opencode config default_agent → "build" → first visible agent.
+const resolveDefaultDraftAgentName = (): string | undefined => {
+  const configState = useConfigStore.getState()
+  const visibleAgents = configState.getVisibleAgents()
+
+  if (configState.settingsDefaultAgent) {
+    const settingsAgent = visibleAgents.find((agent) => agent.name === configState.settingsDefaultAgent)
+    if (settingsAgent) return settingsAgent.name
+  }
+
+  if (configState.opencodeDefaultAgent) {
+    const configAgent = visibleAgents.find((agent) => agent.name === configState.opencodeDefaultAgent)
+    if (configAgent) return configAgent.name
+  }
+
+  return visibleAgents.find((agent) => agent.name === "build")?.name ?? visibleAgents[0]?.name
+}
+
 const DEFAULT_DRAFT: NewSessionDraftState = {
   open: false,
   directoryOverride: null,
@@ -508,7 +528,24 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       useInputStore.getState().setPendingInputText(options.initialPrompt)
     }
 
+    // Activate the draft's directory first. activateDirectory restores state
+    // synchronously: for a previously-loaded directory it restores the cached
+    // snapshot (including its opencode default agent); for a first-visit
+    // directory it clears the agent to undefined. Either way the
+    // previously-active session's agent is dropped immediately. The async
+    // provider/agent refresh then continues in the background.
     void activateConfigForDirectory(directory)
+
+    // For a known directory the cached default is available now, so set it
+    // synchronously to avoid a stale capture if the user sends immediately.
+    // For a first-visit directory there is nothing to resolve yet (no agents
+    // loaded); the agent stays undefined until the background refresh — and
+    // the send path re-resolves the default after awaiting it — so the
+    // previous session's agent still never leaks into the new session.
+    const defaultDraftAgent = resolveDefaultDraftAgentName()
+    if (defaultDraftAgent) {
+      useConfigStore.getState().setAgent(defaultDraftAgent)
+    }
   },
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
New sessions always fell back to the "build" agent because agent resolution only read OpenChamber's own `defaultAgent` setting and ignored the `default_agent` key in opencode config.

- Make `getConfig()` directory-aware so it returns the project-scoped merged opencode config (where `default_agent` lives).
- Read `default_agent` in `loadAgents`, store it as `opencodeDefaultAgent`, and add it to resolution priority: settings.defaultAgent -> opencode default_agent -> build -> first primary.
- Reset a new draft's agent to the resolved default on open, so it no longer inherits the previously-active session's agent.
- Honor the same default in the agent picker's default chip, the existing-session fallback, and worktree session creation.