### PR TITLE
fix: preserve resolved session titles

### DIFF
--- a/packages/ui/src/stores/useGlobalSessionsStore.test.ts
+++ b/packages/ui/src/stores/useGlobalSessionsStore.test.ts
@@ -10,6 +10,12 @@ const buildSession = (shareUrl: string): Session => ({
   share: { url: shareUrl },
 } as Session);
 
+const buildTitledSession = (title: string, updated: number, archived?: number): Session => ({
+  id: 'ses_1',
+  title,
+  time: { created: 1, updated, archived },
+} as Session);
+
 describe('useGlobalSessionsStore', () => {
   beforeEach(() => {
     useGlobalSessionsStore.setState({
@@ -27,4 +33,40 @@ describe('useGlobalSessionsStore', () => {
 
     expect(useGlobalSessionsStore.getState().activeSessions[0]?.share?.url).toBe('https://share.example/b');
   });
+
+  test('preserves a resolved title when passive upsert carries a default title', () => {
+    useGlobalSessionsStore.getState().upsertSession(buildTitledSession('Investigate startup failure', 2));
+    useGlobalSessionsStore.getState().upsertSession(buildTitledSession('New session - 2026-06-02', 3));
+
+    const session = useGlobalSessionsStore.getState().activeSessions[0];
+    expect(session?.title).toBe('Investigate startup failure');
+    expect(session?.time.updated).toBe(3);
+  });
+
+  test('preserves a resolved title when an archived upsert carries a default title', () => {
+    useGlobalSessionsStore.getState().upsertSession(buildTitledSession('Investigate startup failure', 2));
+    useGlobalSessionsStore.getState().upsertSession(buildTitledSession('New session - 2026-06-02', 3, 4));
+
+    expect(useGlobalSessionsStore.getState().activeSessions).toHaveLength(0);
+    const session = useGlobalSessionsStore.getState().archivedSessions[0];
+    expect(session?.title).toBe('Investigate startup failure');
+    expect(session?.time.updated).toBe(3);
+    expect(session?.time.archived).toBe(4);
+  });
+
+  test('preserves a resolved title when snapshot moves a session to archived with a default title', () => {
+    useGlobalSessionsStore.getState().upsertSession(buildTitledSession('Investigate startup failure', 2));
+
+    useGlobalSessionsStore.getState().applySnapshot(
+      [],
+      [buildTitledSession('New session - 2026-06-02', 3, 4)],
+    );
+
+    expect(useGlobalSessionsStore.getState().activeSessions).toHaveLength(0);
+    const session = useGlobalSessionsStore.getState().archivedSessions[0];
+    expect(session?.title).toBe('Investigate startup failure');
+    expect(session?.time.updated).toBe(3);
+    expect(session?.time.archived).toBe(4);
+  });
+
 });

--- a/packages/ui/src/stores/useGlobalSessionsStore.ts
+++ b/packages/ui/src/stores/useGlobalSessionsStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { Session } from '@opencode-ai/sdk/v2';
 import { opencodeClient } from '@/lib/opencode/client';
 import { listGlobalSessionPages } from '@/stores/globalSessions';
+import { mergeSessionPreservingResolvedTitle } from '@/sync/session-title-merge';
 
 type GlobalSessionsStatus = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -101,12 +102,39 @@ const upsertSessionIntoList = (sessions: Session[], session: Session): Session[]
   if (index === -1) {
     return [session, ...sessions];
   }
-  if (getSessionSignature(sessions[index]) === getSessionSignature(session)) {
+  const nextSession = mergeSessionPreservingResolvedTitle(sessions[index], session);
+  if (getSessionSignature(sessions[index]) === getSessionSignature(nextSession)) {
     return sessions;
   }
   const next = [...sessions];
-  next[index] = session;
+  next[index] = nextSession;
   return next;
+};
+
+const preserveResolvedTitlesInIncoming = (existing: Session[], incoming: Session[]): Session[] => {
+  if (existing.length === 0 || incoming.length === 0) {
+    return incoming;
+  }
+
+  const existingById = new Map(existing.map((session) => [session.id, session]));
+  let changed = false;
+  const next = incoming.map((session) => {
+    const merged = mergeSessionPreservingResolvedTitle(existingById.get(session.id), session);
+    if (merged !== session) {
+      changed = true;
+    }
+    return merged;
+  });
+
+  return changed ? next : incoming;
+};
+
+const findSessionById = (sessions: Session[], id: string): Session | undefined => {
+  return sessions.find((session) => session.id === id);
+};
+
+const getKnownSessions = (state: Pick<GlobalSessionsState, 'activeSessions' | 'archivedSessions'>): Session[] => {
+  return [...state.activeSessions, ...state.archivedSessions];
 };
 
 const mergeSessionLists = (existing: Session[], incoming?: Session[]): Session[] => {
@@ -120,7 +148,7 @@ const mergeSessionLists = (existing: Session[], incoming?: Session[]): Session[]
 
   const byId = new Map(existing.map((session) => [session.id, session]));
   incoming.forEach((session) => {
-    byId.set(session.id, session);
+    byId.set(session.id, mergeSessionPreservingResolvedTitle(byId.get(session.id), session));
   });
 
   const ordered: Session[] = [];
@@ -155,12 +183,15 @@ const applySnapshot = (
   archivedSessions: Session[],
   status: GlobalSessionsStatus,
 ): Partial<GlobalSessionsState> | GlobalSessionsState => {
-  const nextActiveSessions = sameSessionList(state.activeSessions, activeSessions)
+  const knownSessions = getKnownSessions(state);
+  const mergedActiveSessions = preserveResolvedTitlesInIncoming(knownSessions, activeSessions);
+  const mergedArchivedSessions = preserveResolvedTitlesInIncoming(knownSessions, archivedSessions);
+  const nextActiveSessions = sameSessionList(state.activeSessions, mergedActiveSessions)
     ? state.activeSessions
-    : activeSessions;
-  const nextArchivedSessions = sameSessionList(state.archivedSessions, archivedSessions)
+    : mergedActiveSessions;
+  const nextArchivedSessions = sameSessionList(state.archivedSessions, mergedArchivedSessions)
     ? state.archivedSessions
-    : archivedSessions;
+    : mergedArchivedSessions;
   const nextSessionsByDirectory = nextActiveSessions === state.activeSessions
     ? state.sessionsByDirectory
     : buildSessionsByDirectory(nextActiveSessions);
@@ -214,7 +245,7 @@ export const useGlobalSessionsStore = create<GlobalSessionsState>((set, get) => 
 
         const fallbackSnapshot = mergeSessionLists(current.activeSessions, fallbackActive);
         const nextActiveSessions = activeResult.status === 'fulfilled'
-          ? activeResult.value
+          ? mergeSessionLists(fallbackSnapshot, activeResult.value)
           : fallbackSnapshot;
         const nextArchivedSessions = archivedResult.status === 'fulfilled'
           ? archivedResult.value
@@ -246,11 +277,14 @@ export const useGlobalSessionsStore = create<GlobalSessionsState>((set, get) => 
   upsertSession: (session) => {
     set((state) => {
       const isArchived = Boolean(session.time?.archived);
+      const existingSession = findSessionById(state.activeSessions, session.id)
+        ?? findSessionById(state.archivedSessions, session.id);
+      const nextSession = mergeSessionPreservingResolvedTitle(existingSession, session);
       const nextActiveSessions = isArchived
         ? state.activeSessions.filter((candidate) => candidate.id !== session.id)
-        : upsertSessionIntoList(state.activeSessions, session);
+        : upsertSessionIntoList(state.activeSessions, nextSession);
       const nextArchivedSessions = isArchived
-        ? upsertSessionIntoList(state.archivedSessions, session)
+        ? upsertSessionIntoList(state.archivedSessions, nextSession)
         : state.archivedSessions.filter((candidate) => candidate.id !== session.id);
 
       if (

--- a/packages/ui/src/sync/__tests__/event-reducer.test.ts
+++ b/packages/ui/src/sync/__tests__/event-reducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import type { Event, Part, PermissionRequest, QuestionRequest, SessionStatus } from "@opencode-ai/sdk/v2/client"
+import type { Event, Part, PermissionRequest, QuestionRequest, Session, SessionStatus } from "@opencode-ai/sdk/v2/client"
 import { applyDirectoryEvent } from "../event-reducer"
 import { INITIAL_STATE, type State } from "../types"
 
@@ -40,7 +40,31 @@ function partUpdatedEvent(): Event {
   } as Event
 }
 
+function session(id: string, title: string, updated: number): Session {
+  return {
+    id,
+    title,
+    time: { created: 1, updated },
+  } as Session
+}
+
 describe("applyDirectoryEvent", () => {
+  test("preserves a resolved title when a passive session update carries a default title", () => {
+    const draft = state({
+      session: [session("ses_1", "Investigate startup failure", 2)],
+    })
+
+    applyDirectoryEvent(draft, {
+      type: "session.updated",
+      properties: {
+        info: session("ses_1", "New session - 2026-06-02", 3),
+      },
+    } as Event)
+
+    expect(draft.session[0]?.title).toBe("Investigate startup failure")
+    expect(draft.session[0]?.time.updated).toBe(3)
+  })
+
   test("returns typed materialization when delta arrives before parts", () => {
     const result = applyDirectoryEvent(state(), deltaEvent())
 

--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -14,6 +14,7 @@ import type { FileDiff, GlobalState, State } from "./types"
 import { dropSessionCaches } from "./session-cache"
 import { stripSessionDiffSnapshots } from "./sanitize"
 import { syncDebug } from "./debug"
+import { mergeSessionPreservingResolvedTitle } from "./session-title-merge"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 const DELTA_OVERLAP_FIELDS = ["text", "output"] as const
@@ -176,7 +177,7 @@ export function applyDirectoryEvent(
       const sessions = draft.session
       const result = Binary.search(sessions, info.id, (s) => s.id)
       if (result.found) {
-        sessions[result.index] = info
+        sessions[result.index] = mergeSessionPreservingResolvedTitle(sessions[result.index], info)
       } else {
         sessions.splice(result.index, 0, info)
         trimSessions(draft)
@@ -198,7 +199,7 @@ export function applyDirectoryEvent(
       }
 
       if (result.found) {
-        sessions[result.index] = info
+        sessions[result.index] = mergeSessionPreservingResolvedTitle(sessions[result.index], info)
       } else {
         sessions.splice(result.index, 0, info)
         trimSessions(draft)

--- a/packages/ui/src/sync/session-title-merge.ts
+++ b/packages/ui/src/sync/session-title-merge.ts
@@ -1,0 +1,31 @@
+type SessionWithTitle = {
+  id: string
+  title?: string | null
+}
+
+const DEFAULT_TITLE_PATTERN = /^New session(?: - \d{4}-\d{2}-\d{2}(?:[ T].*)?)?$/
+
+function normalizedTitle(title: string | null | undefined): string {
+  return typeof title === "string" ? title.trim() : ""
+}
+
+function isDefaultSessionTitle(title: string | null | undefined): boolean {
+  const value = normalizedTitle(title)
+  return value.length === 0 || DEFAULT_TITLE_PATTERN.test(value)
+}
+
+export function mergeSessionPreservingResolvedTitle<T extends SessionWithTitle>(
+  existing: T | undefined,
+  incoming: T,
+): T {
+  if (!existing || existing.id !== incoming.id) {
+    return incoming
+  }
+
+  const existingTitle = normalizedTitle(existing.title)
+  if (existingTitle.length === 0 || isDefaultSessionTitle(existingTitle) || !isDefaultSessionTitle(incoming.title)) {
+    return incoming
+  }
+
+  return { ...incoming, title: existing.title }
+}

--- a/packages/ui/src/sync/session-title-merge.ts
+++ b/packages/ui/src/sync/session-title-merge.ts
@@ -23,7 +23,7 @@ export function mergeSessionPreservingResolvedTitle<T extends SessionWithTitle>(
   }
 
   const existingTitle = normalizedTitle(existing.title)
-  if (existingTitle.length === 0 || isDefaultSessionTitle(existingTitle) || !isDefaultSessionTitle(incoming.title)) {
+  if (isDefaultSessionTitle(existingTitle) || !isDefaultSessionTitle(incoming.title)) {
     return incoming
   }
 

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -44,6 +44,7 @@ import { getRuntimeLiveStatusSeed, LIVE_STATUS_TTL_MS } from "./runtime-live-mem
 import { getRuntimeKey } from "@/lib/runtime-switch"
 import { getRegisteredRuntimeAPIs } from "@/contexts/runtimeAPIRegistry"
 import { setSessionPrefetch } from "./session-prefetch-cache"
+import { mergeSessionPreservingResolvedTitle } from "./session-title-merge"
 
 // ---------------------------------------------------------------------------
 // Context
@@ -1149,9 +1150,10 @@ async function resyncDirectoryAfterReconnect(
       let sessionTotal = state.sessionTotal
 
       if (sessionIndex >= 0) {
-        if (!haveEquivalentSyncSnapshots(sessions[sessionIndex], nextSession)) {
+        const mergedSession = mergeSessionPreservingResolvedTitle(sessions[sessionIndex], nextSession)
+        if (!haveEquivalentSyncSnapshots(sessions[sessionIndex], mergedSession)) {
           sessions = [...state.session]
-          sessions[sessionIndex] = nextSession
+          sessions[sessionIndex] = mergedSession
           sessionChanged = true
         }
       } else {
@@ -1595,7 +1597,11 @@ export function SyncProvider(props: {
                 )
                 return
               }
-              store.setState({ session: sessions, sessionTotal: sessions.length, limit: Math.max(sessions.length, 50) })
+              const currentSessionsById = new Map(currentSessions.map((session) => [session.id, session]))
+              const mergedSessions = sessions.map((session) => (
+                mergeSessionPreservingResolvedTitle(currentSessionsById.get(session.id), session)
+              ))
+              store.setState({ session: mergedSessions, sessionTotal: mergedSessions.length, limit: Math.max(mergedSessions.length, 50) })
               ingestDirectoryStateIntoRoutingIndex(routingIndex, directory, store.getState())
             }),
           })


### PR DESCRIPTION
## Summary
- preserve resolved/custom session titles when incoming passive snapshots carry empty/default titles
- apply title-preserving merges across directory SSE updates, reconnect/bootstrap snapshots, and global session cache updates
- cover active-to-archived global snapshot moves so existing sessions do not roll back to `New session - ...`

## Tests
- `bun test packages/ui/src/sync/__tests__/event-reducer.test.ts packages/ui/src/stores/useGlobalSessionsStore.test.ts`
- `bun run lint`
- `bun run type-check`