### PR TITLE
Bun install in reproduce-issue

### DIFF
--- a/.github/workflows/reproduce-issue.yml
+++ b/.github/workflows/reproduce-issue.yml
@@ -25,7 +25,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Install opencode
         run: curl -fsSL https://opencode.ai/install | bash

--- a/.github/workflows/reproduce-issue.yml
+++ b/.github/workflows/reproduce-issue.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
       - name: Install opencode
         run: curl -fsSL https://opencode.ai/install | bash
 


### PR DESCRIPTION
# What

Adds Bun setup and dependency installation to the `reproduce-issue` GitHub Actions workflow, running before the OpenCode CLI install step.

# Why

The `reproduce-issue` workflow was missing a package manager setup step, so any reproduction that requires project dependencies would fail.

# How to test

- Push a change to a branch and trigger the `reproduce-issue` workflow.
- Confirm the "Setup Bun" and "Install dependencies" steps complete successfully before "Install opencode".