### PR TITLE
Allow /tmp as external-directory in reproduce-issue

### DIFF
--- a/.opencode/agent/reproduce-issue.md
+++ b/.opencode/agent/reproduce-issue.md
@@ -5,6 +5,8 @@ model: opencode-go/deepseek-v4-flash
 color: "#c0392b"
 permission:
   edit: allow
+  external_directory:
+    "/tmp/**": allow
   bash:
     "gh *": allow
     "git *": allow


### PR DESCRIPTION
# What

- Adds `/tmp/**` as an allowed `external_directory` pattern in the reproduce-issue agent configuration, permitting the agent to write to `/tmp` during bug reproduction workflows.

# Why

The reproduce-issue agent creates worktrees and temporary files when investigating bugs. Without an explicit `external_directory` allow rule for `/tmp`, the agent is blocked from writing to that path, preventing it from using standard temporary file patterns during reproduction.

---
Generated with [create-pr-description](https://github.com/tomzx/dot-claude/blob/4a36c332cc596c9ce3ffcc7d0be55465f38128fc/skills/create-pr-description/SKILL.md) (`4a36c33`)