### PR TITLE
Fix concurrency in reproduce-issue

### DIFF
--- a/.github/workflows/reproduce-issue.yml
+++ b/.github/workflows/reproduce-issue.yml
@@ -4,14 +4,13 @@ on:
   issues:
     types: [labeled]
 
-concurrency:
-  group: reproduce-issue-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   reproduce:
     if: github.event.label.name == 'bug'
     runs-on: ubuntu-latest
+    concurrency:
+      group: reproduce-issue-${{ github.event.issue.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
# What

- Moves the `concurrency` block in `.github/workflows/reproduce-issue.yml` from the workflow level down to the `reproduce` job level, keeping the same group key (`reproduce-issue-${{ github.event.issue.number }}`) and `cancel-in-progress: true` behavior.

# Why

When the concurrency group is declared at the workflow level, GitHub cancels the entire workflow run if a new event arrives with the same group key. This causes in-flight reproduce-issue runs to be killed for any label being added which then causes the workflow to sometimes not execute because the added label is not `bug`.

---
Generated with [create-pr-description](https://github.com/tomzx/dot-claude/blob/4a36c332cc596c9ce3ffcc7d0be55465f38128fc/skills/create-pr-description/SKILL.md) (`4a36c33`)