### PR TITLE
fix: restore SSH auto-connect when clicking remote device in host switcher

### DIFF
--- a/packages/ui/src/components/desktop/DesktopHostSwitcher.tsx
+++ b/packages/ui/src/components/desktop/DesktopHostSwitcher.tsx
@@ -488,28 +488,6 @@ export function DesktopHostSwitcherDialog({
     const apiOrigin = host.id === LOCAL_HOST_ID ? localOrigin : (normalizeHostUrl(getDesktopHostApiUrl(host)) || '');
     if (!origin) return;
 
-    if (isElectronShell()) {
-      if (!apiOrigin) return;
-      setSwitchingHostId(host.id);
-      const clientToken = host.id === LOCAL_HOST_ID ? await getLocalClientToken() : (host.clientToken || '');
-      const probe = await desktopHostProbe(apiOrigin, { clientToken: clientToken || null }).catch((): HostProbeResult => ({ status: 'unreachable', latencyMs: 0 }));
-      setStatusById((prev) => ({
-        ...prev,
-        [host.id]: { status: probe.status, latencyMs: probe.latencyMs },
-      }));
-
-      if (isBlockedHostStatus(probe.status)) {
-        toast.error(t('desktopHostSwitcher.toast.instanceUnreachable', { host: redactSensitiveUrl(host.label) }));
-        setSwitchingHostId(null);
-        return;
-      }
-
-      switchRuntimeEndpoint({ apiBaseUrl: apiOrigin, clientToken: clientToken || null, runtimeKey: runtimeKeyForHost(host) });
-      onHostSwitched?.();
-      setSwitchingHostId(null);
-      return;
-    }
-
     const isSshHost = Boolean(sshHostIds[host.id]);
 
     if (host.id !== LOCAL_HOST_ID && isSshHost && isDesktopShell()) {
@@ -526,10 +504,15 @@ export function DesktopHostSwitcherDialog({
       }
 
       const existingUrl = normalizeHostUrl(existingStatus?.localUrl || host.url || '');
+      const electronic = isElectronShell();
       if (existingStatus?.phase === 'ready' && existingUrl) {
         const target = toNavigationUrl(existingUrl);
         onHostSwitched?.();
-        window.location.assign(target);
+        if (electronic) {
+          switchRuntimeEndpoint({ apiBaseUrl: existingUrl, clientToken: host.clientToken || null, runtimeKey: runtimeKeyForHost(host) });
+        } else {
+          window.location.assign(target);
+        }
         return;
       }
 
@@ -569,7 +552,11 @@ export function DesktopHostSwitcherDialog({
         const targetOrigin = normalizeHostUrl(readyStatus.localUrl || '') || origin;
         const target = toNavigationUrl(targetOrigin);
         onHostSwitched?.();
-        window.location.assign(target);
+        if (isElectronShell()) {
+          switchRuntimeEndpoint({ apiBaseUrl: targetOrigin, clientToken: host.clientToken || null, runtimeKey: runtimeKeyForHost(host) });
+        } else {
+          window.location.assign(target);
+        }
         return;
       } catch (err) {
         if (switchToken !== sshSwitchTokenRef.current) {
@@ -594,6 +581,28 @@ export function DesktopHostSwitcherDialog({
           setSwitchingHostId(null);
         }
       }
+    }
+
+    if (isElectronShell()) {
+      if (!apiOrigin) return;
+      setSwitchingHostId(host.id);
+      const clientToken = host.id === LOCAL_HOST_ID ? await getLocalClientToken() : (host.clientToken || '');
+      const probe = await desktopHostProbe(apiOrigin, { clientToken: clientToken || null }).catch((): HostProbeResult => ({ status: 'unreachable', latencyMs: 0 }));
+      setStatusById((prev) => ({
+        ...prev,
+        [host.id]: { status: probe.status, latencyMs: probe.latencyMs },
+      }));
+
+      if (isBlockedHostStatus(probe.status)) {
+        toast.error(t('desktopHostSwitcher.toast.instanceUnreachable', { host: redactSensitiveUrl(host.label) }));
+        setSwitchingHostId(null);
+        return;
+      }
+
+      switchRuntimeEndpoint({ apiBaseUrl: apiOrigin, clientToken: clientToken || null, runtimeKey: runtimeKeyForHost(host) });
+      onHostSwitched?.();
+      setSwitchingHostId(null);
+      return;
     }
 
     if (host.id !== LOCAL_HOST_ID && isDesktopShell()) {


### PR DESCRIPTION
## Problem

After the Tauri→Electron refactor and multi-server merge, clicking an SSH remote device in the host switcher no longer auto-connects. Instead, it shows "instance unreachable" because the SSH tunnel is never established. Users must first manually click "Connect" in the remote instances settings, then click the device to navigate.

## Root cause

In `DesktopHostSwitcher.tsx` `handleSwitch()`, the `isElectronShell()` early return (added during the refactor) was placed **before** the SSH host auto-connect flow:

```
handleSwitch:
  if (isElectronShell()) {      // ← returns early
    probe remote URL            // tunnel not up → "unreachable"
    switchRuntimeEndpoint()
    return                      // never reaches SSH connect
  }
  if (isSshHost) {              // ← dead code for SSH hosts in Electron
    desktopSshConnect()
    ...
  }
```

Since `isElectronShell()` returns `true` in the Electron desktop app, every click on an SSH remote device entered the Electron shell branch, probed the unestablished tunnel URL, and bailed out.

## Fix

Reordered `handleSwitch` so SSH hosts are detected and connected **before** the `isElectronShell()` branch:

```
handleSwitch:
  if (isSshHost) {              // ← SSH always goes first
    desktopSshConnect()         // auto-connects the tunnel
    if (isElectronShell())      // uses switchRuntimeEndpoint
      switchRuntimeEndpoint()   // instead of page reload
    else
      window.location.assign()
    return
  }
  if (isElectronShell()) {      // ← non-SSH hosts only
    ...
  }
```

Also added `isElectronShell()` awareness to both SSH success paths (already-ready and newly-connected), using `switchRuntimeEndpoint()` instead of `window.location.assign()` in Electron shell — consistent with the existing `connectDefaultSshInstance()` pattern.

## Testing

- [x] Clicking SSH remote device in Electron desktop now auto-connects and switches endpoint
- [x] Non-SSH remote devices still work correctly in Electron shell (switchRuntimeEndpoint)
- [x] Non-Electron shell behavior unchanged (window.location.assign)
- [x] Already-connected SSH hosts navigate without reconnecting