### PR TITLE
fix(ui): keep mobile changes empty states dismissible

### DIFF
--- a/packages/ui/src/apps/MobileChangesSurface.tsx
+++ b/packages/ui/src/apps/MobileChangesSurface.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RiArrowLeftLine, RiCloseLine, RiGitBranchLine, RiLoader4Line } from '@remixicon/react';
+import { Icon } from '@/components/icon/Icon';
 
 import { toast } from '@/components/ui';
 import { Button } from '@/components/ui/button';
@@ -443,16 +443,41 @@ export const MobileChangesSurface: React.FC<MobileChangesSurfaceProps> = ({ onCl
     return groups;
   }, [handleRevertFile, handleViewChangeDiff, moveChangePaths, stagedChangeEntries, t, unstagedChangeEntries]);
 
+  const renderListState = (state: React.ReactNode) => (
+    <div className="flex h-full flex-col overflow-hidden bg-background text-foreground">
+      <header className="flex h-[var(--oc-header-height,56px)] shrink-0 items-center gap-2 px-3 text-foreground">
+        {onClose ? (
+          <button
+            type="button"
+            className="-ml-1 flex size-10 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label={t('mobile.surface.closeAria')}
+            onClick={onClose}
+            style={{ touchAction: 'manipulation' }}
+          >
+            <Icon name="close" className="size-5" />
+          </button>
+        ) : null}
+        <div className="min-w-0 flex-1 px-1">
+          <h2 className="typography-ui-label text-foreground">{t('mobile.nav.changes')}</h2>
+          <p className="truncate typography-micro text-muted-foreground">
+            {status?.current || currentDirectory || ''}
+          </p>
+        </div>
+      </header>
+      <div className="min-h-0 flex-1">{state}</div>
+    </div>
+  );
+
   if (!currentDirectory) {
-    return <MobileChangesState message={t('gitView.empty.selectSessionOrDirectory')} />;
+    return renderListState(<MobileChangesState message={t('gitView.empty.selectSessionOrDirectory')} />);
   }
 
   if (isLoadingStatus && isGitRepo === null) {
-    return <MobileChangesState loading message={t('gitView.loading.checkingRepository')} />;
+    return renderListState(<MobileChangesState loading message={t('gitView.loading.checkingRepository')} />);
   }
 
   if (isGitRepo === false) {
-    return <MobileChangesState icon message={t('gitView.empty.notGitRepository')} description={t('gitView.empty.notGitRepositoryDescription')} />;
+    return renderListState(<MobileChangesState icon message={t('gitView.empty.notGitRepository')} description={t('gitView.empty.notGitRepositoryDescription')} />);
   }
 
   if (route.type === 'diff') {
@@ -479,7 +504,7 @@ export const MobileChangesSurface: React.FC<MobileChangesSurfaceProps> = ({ onCl
             onClick={onClose}
             style={{ touchAction: 'manipulation' }}
           >
-            <RiCloseLine className="size-5" />
+            <Icon name="close" className="size-5" />
           </button>
         ) : null}
         <div className="min-w-0 flex-1 px-1">
@@ -548,8 +573,8 @@ const MobileChangesState: React.FC<{
 }> = ({ message, description, loading = false, icon = false }) => (
   <div className="flex h-full items-center justify-center px-6 text-center">
     <div className="flex max-w-sm flex-col items-center gap-2">
-      {loading ? <RiLoader4Line className="size-5 animate-spin text-muted-foreground" /> : null}
-      {icon ? <RiGitBranchLine className="size-6 text-muted-foreground" /> : null}
+      {loading ? <Icon name="loader-4" className="size-5 animate-spin text-muted-foreground" /> : null}
+      {icon ? <Icon name="git-branch" className="size-6 text-muted-foreground" /> : null}
       <p className="typography-ui-label font-semibold text-foreground">{message}</p>
       {description ? <p className="typography-meta text-muted-foreground">{description}</p> : null}
     </div>
@@ -576,7 +601,7 @@ const MobileDiffDetail: React.FC<{
           aria-label={t('header.actions.backAria')}
           onClick={onBack}
         >
-          <RiArrowLeftLine className="size-5" />
+          <Icon name="arrow-left" className="size-5" />
         </button>
         <div className="min-w-0 flex-1 px-2">
           <h2 className="truncate typography-ui-header text-foreground">{path}</h2>


### PR DESCRIPTION
## Summary

This fixes a regression in the newer mobile Changes surface / sheet UI on Android PWA.

When the Changes surface is opened in a directory that is **not** a Git repository (or while repository status is still loading, or before any directory is selected), `MobileChangesSurface` returned early with a bare `MobileChangesState` and skipped rendering the normal header row entirely.

That meant the new mobile sheet had:

- no visible close / back affordance,
- no obvious way to dismiss it from inside the surface,
- and on Android PWA the browser/system back gesture did not reliably dismiss the modal sheet.

In practice the only escape path was tapping sparse overlay whitespace outside the sheet, which is easy to miss and effectively traps users in the empty state.

## Root cause

`MobileChangesSurface` has three early-return branches:

- no current directory selected,
- repository status still loading,
- current directory is not a Git repository.

Those branches returned `MobileChangesState` directly instead of going through the standard list layout that includes the top header and close button.

The normal Changes list already had a proper header with a visible close control, so only the new empty/error/loading states were broken.

## Fix

- Add a small `renderListState(...)` helper that wraps empty/loading/non-git states in the same top-level layout as the normal Changes list.
- Keep the close button visible for those states, so the sheet can always be dismissed from inside the UI.
- Preserve the current directory / status subtitle in the header for consistency.
- While touching this file, switch the remaining direct `@remixicon/react` usages in `MobileChangesSurface.tsx` to the shared `Icon` component to match current UI conventions.

## Why this is specifically a "new UI" fix

This only affects the newer mobile Changes sheet implementation in:

- `packages/ui/src/apps/MobileChangesSurface.tsx`
- rendered via `MobileSurfaceShell` from `packages/ui/src/apps/MobileApp.tsx`

The desktop Changes UI is unaffected.

## Validation

- `packages/ui`: `bun run type-check`
- `packages/web`: `bun run build`
- Manually verified that the Android PWA Changes sheet now keeps a visible close button in:
  - "select a session or directory"
  - "checking repository"
  - "current directory is not a Git repository"

## Files changed

- `packages/ui/src/apps/MobileChangesSurface.tsx`
