### PR TITLE
fix: filter subagents from agent picker

### DIFF
--- a/packages/ui/src/stores/useAgentsStore.test.ts
+++ b/packages/ui/src/stores/useAgentsStore.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import type { Agent } from '@opencode-ai/sdk/v2';
+
+import { filterVisibleAgents } from './useAgentsStore';
+
+describe('filterVisibleAgents', () => {
+  test('keeps only non-hidden direct-selection agents', () => {
+    const agents = [
+      { name: 'build', mode: 'primary', permission: [] },
+      { name: 'plan', mode: 'all', permission: [] },
+      { name: 'code-reviewer', mode: 'subagent', permission: [] },
+      { name: 'title', mode: 'primary', permission: [], hidden: true },
+      { name: 'summary', mode: 'all', permission: [], options: { hidden: true } },
+    ] as Agent[];
+
+    expect(filterVisibleAgents(agents).map((agent) => agent.name)).toEqual(['build', 'plan']);
+  });
+});

--- a/packages/ui/src/stores/useAgentsStore.ts
+++ b/packages/ui/src/stores/useAgentsStore.ts
@@ -140,9 +140,9 @@ export const isAgentHidden = (agent: Agent): boolean => {
   return extended.hidden === true || extended.options?.hidden === true;
 };
 
-// Helper to filter only visible (non-hidden) agents
+// Helper to filter agents that can be selected directly as the primary agent.
 export const filterVisibleAgents = (agents: Agent[]): Agent[] =>
-  agents.filter((agent) => !isAgentHidden(agent));
+  agents.filter((agent) => !isAgentHidden(agent) && agent.mode !== 'subagent');
 
 const CONFIG_EVENT_SOURCE = "useAgentsStore";
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Fixes #1528

## Summary
- Exclude `mode: subagent` agents from the shared direct-selection agent visibility helper.
- Keep hidden agents excluded, including `hidden: true` and `options.hidden`.
- Add a focused regression test for direct-selection agent filtering.

## Test Plan
- [x] `bun test packages/ui/src/stores/useAgentsStore.test.ts`
- [x] `bun run type-check:ui`
- [x] `bun run lint:ui`
- [x] `git diff --check`
- [x] Verified `/home/biy311/repos/platform.copilot/agents` has no `canadalife-csdg`, `cost-savings`, `github-security-fixer`, or `security-governance` agent files.
