### PR TITLE
fix(docker): stabilize workspace dependency install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM oven/bun:1.3.6 AS base
+FROM oven/bun:1.3.5 AS base
 WORKDIR /app
 
 FROM base AS deps
@@ -7,7 +7,6 @@ WORKDIR /app
 COPY package.json bun.lock ./
 COPY packages/ui/package.json ./packages/ui/
 COPY packages/web/package.json ./packages/web/
-COPY packages/desktop/package.json ./packages/desktop/
 COPY packages/electron/package.json ./packages/electron/
 COPY packages/vscode/package.json ./packages/vscode/
 RUN bun install --frozen-lockfile --ignore-scripts
@@ -17,7 +16,7 @@ WORKDIR /app
 COPY . .
 RUN bun run build:web
 
-FROM oven/bun:1.3.6 AS runtime
+FROM oven/bun:1.3.5 AS runtime
 WORKDIR /home/openchamber
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM oven/bun:1 AS base
+FROM oven/bun:1.3.6 AS base
 WORKDIR /app
 
 FROM base AS deps
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY . .
 RUN bun run build:web
 
-FROM oven/bun:1 AS runtime
+FROM oven/bun:1.3.6 AS runtime
 WORKDIR /home/openchamber
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json bun.lock ./
 COPY packages/ui/package.json ./packages/ui/
 COPY packages/web/package.json ./packages/web/
 COPY packages/desktop/package.json ./packages/desktop/
+COPY packages/electron/package.json ./packages/electron/
 COPY packages/vscode/package.json ./packages/vscode/
 RUN bun install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
## Summary

- Pin the Bun image tag used by the Docker build so dependency installation is reproducible.
- Copy the Electron workspace package manifest before install so workspace dependency resolution has the manifest it expects.

## Validation

- bun install --frozen-lockfile
- git diff --check upstream/main..HEAD