### PR TITLE
fix(files): keep opened files visible on desktop

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -73,6 +73,7 @@ import { useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { getRuntimeBearerTokenSync } from '@/lib/runtime-auth';
 import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
+import { shouldResetDesktopMainTabToChat } from '@/components/layout/mainTabGuards';
 import type { Session } from '@opencode-ai/sdk/v2/client';
 import type { IconName } from "@/components/icon/icons";
 
@@ -1812,7 +1813,7 @@ export const Header: React.FC<HeaderProps> = ({
   }, [shortcutOverrides]);
 
   useEffect(() => {
-    if (!isMobile && (activeMainTab === 'git' || activeMainTab === 'terminal' || activeMainTab === 'diff' || activeMainTab === 'files' || activeMainTab === 'context')) {
+    if (shouldResetDesktopMainTabToChat(activeMainTab, isMobile)) {
       setActiveMainTab('chat');
     }
   }, [activeMainTab, isMobile, setActiveMainTab]);

--- a/packages/ui/src/components/layout/mainTabGuards.test.ts
+++ b/packages/ui/src/components/layout/mainTabGuards.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { shouldResetDesktopMainTabToChat } from './mainTabGuards';
+
+describe('desktop main tab guard', () => {
+  test('keeps Files open on desktop so sidebar file open actions can reveal the editor', () => {
+    expect(shouldResetDesktopMainTabToChat('files', false)).toBe(false);
+  });
+
+  test('keeps mobile tabs under the mobile tab system', () => {
+    expect(shouldResetDesktopMainTabToChat('git', true)).toBe(false);
+  });
+
+  test('still resets desktop tabs that are not exposed in the desktop header', () => {
+    expect(shouldResetDesktopMainTabToChat('git', false)).toBe(true);
+    expect(shouldResetDesktopMainTabToChat('terminal', false)).toBe(true);
+    expect(shouldResetDesktopMainTabToChat('diff', false)).toBe(true);
+    expect(shouldResetDesktopMainTabToChat('context', false)).toBe(true);
+  });
+});

--- a/packages/ui/src/components/layout/mainTabGuards.ts
+++ b/packages/ui/src/components/layout/mainTabGuards.ts
@@ -1,0 +1,12 @@
+import type { MainTab } from '@/stores/useUIStore';
+
+const DESKTOP_HEADER_HIDDEN_MAIN_TABS = new Set<MainTab>([
+  'git',
+  'terminal',
+  'diff',
+  'context',
+]);
+
+export const shouldResetDesktopMainTabToChat = (tab: MainTab, isMobile: boolean): boolean => (
+  !isMobile && DESKTOP_HEADER_HIDDEN_MAIN_TABS.has(tab)
+);


### PR DESCRIPTION
## Summary

- Preserve the Files tab as a valid desktop main-tab target when opening files from sidebars or other actions.
- Continue resetting hidden desktop-only tabs such as Git, Terminal, Diff, and Context back to Chat.
- Add regression coverage for the desktop tab guard behavior.

## Validation

- bun test packages/ui/src/components/layout/mainTabGuards.test.ts
- bun run --cwd packages/ui type-check
- bun run --cwd packages/ui lint
- git diff --check upstream/main..HEAD