### PR TITLE
feat: add PDF file preview support

### DIFF
--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -35,7 +35,7 @@ import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useDeviceInfo } from '@/lib/device';
 import { cn, getModifierLabel, getRevealLabelKey, hasModifier } from '@/lib/utils';
-import { getLanguageFromExtension, getImageMimeType, isImageFile } from '@/lib/toolHelpers';
+import { getLanguageFromExtension, getImageMimeType, isImageFile, isPdfFile } from '@/lib/toolHelpers';
 import { getRuntimeUrlResolver } from '@/lib/runtime-url';
 import { refreshRuntimeUrlAuthToken } from '@/lib/runtime-auth';
 import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
@@ -1623,6 +1623,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
     const selectedIsImage = isImageFile(node.path);
     const isSvg = node.path.toLowerCase().endsWith('.svg');
+    const selectedIsPdf = isPdfFile(node.path);
 
     if (isMobile) {
       setShowMobilePageContent(true);
@@ -1642,6 +1643,30 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       setDraftContent('');
       setLoadedFilePath(node.path);
       setFileLoading(false);
+      return;
+    }
+
+    // PDFs: open in a new tab on web, load binary on desktop.
+    if (selectedIsPdf) {
+      setFileContent('');
+      setDraftContent('');
+      setLoadedFilePath(node.path);
+
+      if (runtime.isDesktop) {
+        setFileLoading(true);
+        return;
+      }
+
+      setFileLoading(true);
+      void refreshRuntimeUrlAuthToken(getRuntimeApiBaseUrl()).then(() => {
+        const url = getRuntimeUrlResolver().authenticatedAsset('/api/fs/raw', {
+          path: node.path,
+          allowOutsideWorkspace: mode === 'editor-only' && Boolean(root) && !isPathWithinRoot(node.path, root) ? 'true' : undefined,
+        });
+        window.open(url, '_blank');
+      }).finally(() => {
+        setFileLoading(false);
+      });
       return;
     }
 
@@ -2100,6 +2125,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
   const isSelectedImage = Boolean(selectedFile?.path && isImageFile(selectedFile.path));
   const isSelectedSvg = Boolean(selectedFile?.path && selectedFile.path.toLowerCase().endsWith('.svg'));
+  const isSelectedPdf = Boolean(selectedFile?.path && isPdfFile(selectedFile.path));
   const pendingNavigationTargetPath = React.useMemo(
     () => normalizePath(pendingFileNavigation?.path ?? ''),
     [pendingFileNavigation?.path],
@@ -2111,20 +2137,21 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       && selectedFilePath === pendingNavigationTargetPath
       && !fileLoading
       && !fileError
-      && !isSelectedImage,
+      && !isSelectedImage
+      && !isSelectedPdf,
   );
 
   const displaySelectedPath = React.useMemo(() => {
     return getDisplayPath(root, selectedFilePath);
   }, [selectedFilePath, root]);
 
-  const canCopy = Boolean(selectedFile && (!isSelectedImage || isSelectedSvg) && fileContent.length > 0);
+  const canCopy = Boolean(selectedFile && (!isSelectedImage || isSelectedSvg) && !isSelectedPdf && fileContent.length > 0);
   const canCopyPath = Boolean(selectedFile && displaySelectedPath.length > 0);
-  const canEdit = Boolean(selectedFile && !selectedFileIsOutsideWorkspace && !isSelectedImage && files.writeFile && fileContent.length <= MAX_VIEW_CHARS);
+  const canEdit = Boolean(selectedFile && !selectedFileIsOutsideWorkspace && !isSelectedImage && !isSelectedPdf && files.writeFile && fileContent.length <= MAX_VIEW_CHARS);
   const isMarkdown = Boolean(selectedFile?.path && isMarkdownFile(selectedFile.path));
   const isJson = Boolean(selectedFile?.path && isJsonFile(selectedFile.path));
   const isHtml = Boolean(selectedFile?.path && isHtmlFile(selectedFile.path));
-  const isTextFile = Boolean(selectedFile && !isSelectedImage);
+  const isTextFile = Boolean(selectedFile && !isSelectedImage && !isSelectedPdf);
   const canUseShikiFileView = isTextFile && !isMarkdown && !(isHtml && htmlViewMode === 'preview');
   const staticLanguageExtension = React.useMemo(
     () => (selectedFilePath ? languageByExtension(selectedFilePath) : null),

--- a/packages/ui/src/lib/toolHelpers.ts
+++ b/packages/ui/src/lib/toolHelpers.ts
@@ -686,6 +686,11 @@ export function isImageFile(filePath: string): boolean {
   return IMAGE_EXTENSIONS.includes(ext || '');
 }
 
+export function isPdfFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return ext === 'pdf';
+}
+
 export function getImageMimeType(filePath: string): string {
   const ext = filePath.split('.').pop()?.toLowerCase();
   const mimeMap: Record<string, string> = {

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -724,6 +724,7 @@ export const registerFsRoutes = (app, dependencies) => {
         '.ico': 'image/x-icon',
         '.bmp': 'image/bmp',
         '.avif': 'image/avif',
+        '.pdf': 'application/pdf',
       };
       const mimeType = mimeMap[ext] || 'application/octet-stream';
 


### PR DESCRIPTION
Clicking a PDF file in the file tree now opens it in a new browser tab with the correct `application/pdf` content type.

## Changes

- **`packages/web/server/lib/fs/routes.js`**: Added `.pdf` → `application/pdf` to the MIME type map in `/api/fs/raw` endpoint. Previously PDFs were served as `application/octet-stream`, causing browsers to download them instead of displaying.

- **`packages/ui/src/lib/toolHelpers.ts`**: Added `isPdfFile()` helper function to detect PDF files by their `.pdf` extension.

- **`packages/ui/src/components/views/FilesView.tsx`**: 
  - PDFs are detected and excluded from text/copy/edit operations
  - On click, refreshes the URL auth token and opens the PDF in a new tab via `window.open()` using the authenticated `/api/fs/raw` URL
  - Desktop (Electron) path preserved for future native handling