### PR TITLE
Show details for custom tool calls

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { RuntimeAPIContext } from '@/contexts/runtimeAPIContext';
 import { PatchDiff } from '@pierre/diffs/react';
@@ -38,6 +37,7 @@ import { JsonSummaryView } from './JsonSummaryView';
 import { Icon } from "@/components/icon/Icon";
 import { DiffViewToggle, type DiffViewMode } from '../DiffViewToggle';
 import { MinDurationShineText } from './MinDurationShineText';
+import { formatToolParamSummaryValue, shouldShowToolParamSummary } from './toolRenderUtils';
 import { ToolRevealOnMount } from './ToolRevealOnMount';
 import { getToolIcon } from './toolPresentation';
 import { useDurationTickerNow } from './useDurationTicker';
@@ -1947,6 +1947,7 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
 
     const normalizedPartTool = normalizeToolName(part.tool);
     const isTaskTool = normalizedPartTool === 'task';
+    const shouldShowParamSummary = shouldShowToolParamSummary(part.tool);
 
     const status = state?.status as string | undefined;
     const isFinalized = status === 'completed' || status === 'error' || status === 'aborted' || status === 'failed' || status === 'timeout' || status === 'cancelled';
@@ -2017,6 +2018,19 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
     const partMetadata = (part as unknown as { metadata?: unknown }).metadata;
     const input = stateWithData.input;
     const time = stateWithData.time;
+
+    const mcpParamSummary = React.useMemo(() => {
+        if (!shouldShowParamSummary || !input || typeof input !== 'object') return '';
+        const keys = Object.keys(input);
+        if (keys.length === 0) return '';
+        const displayKeys = keys.slice(0, 2);
+        const parts = displayKeys.map(key => {
+            const value = (input as Record<string, unknown>)[key];
+            const displayValue = formatToolParamSummaryValue(value);
+            return `${key}: ${displayValue}`;
+        });
+        return parts.join(', ');
+    }, [shouldShowParamSummary, input]);
 
     const [pinnedTime, setPinnedTime] = React.useState<{ start?: number; end?: number }>(() => ({
         start: typeof time?.start === 'number' ? time.start : undefined,
@@ -2295,7 +2309,7 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
     const shouldRenderTaskSummary = useDeferredExpandedContent(isTaskTool && (taskSummaryEntries.length > 0 || isActive || shouldTreatAsFinalized || !!taskSessionId));
     const shouldRenderExpandedContent = useDeferredExpandedContent(!isTaskTool && isExpanded);
 
-    if (!shouldTreatAsFinalized && !isActive && !isTaskTool) {
+    if (!shouldTreatAsFinalized && !isActive && !isTaskTool && !shouldShowParamSummary) {
         return null;
     }
 
@@ -2365,6 +2379,11 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
                                 >
                                     {displayName}
                                 </MinDurationShineText>
+                                {mcpParamSummary && (
+                                    <span className="typography-meta text-muted-foreground/70 truncate" title={mcpParamSummary}>
+                                        ({mcpParamSummary})
+                                    </span>
+                                )}
                             </div>
                             {normalizedPartTool === 'bash' && typeof effectiveTimeStart === 'number' ? (
                                 <span className={cn('flex-shrink-0 tabular-nums text-muted-foreground/80', TOOL_ROW_DESCRIPTION_CLASS)}>

--- a/packages/ui/src/components/chat/message/parts/toolRenderUtils.test.ts
+++ b/packages/ui/src/components/chat/message/parts/toolRenderUtils.test.ts
@@ -1,30 +1,105 @@
 import { describe, expect, test } from 'bun:test';
 
-import { isExpandableTool, isStaticTool } from './toolRenderUtils';
+import { getCanonicalToolName, getToolMetadata } from '@/lib/toolHelpers';
+import {
+    formatToolParamSummaryValue,
+    isExpandableTool,
+    isStandaloneTool,
+    isStaticTool,
+    shouldShowToolParamSummary,
+} from './toolRenderUtils';
 
-describe('tool rendering classification', () => {
-    test('keeps navigation tools compact', () => {
+describe('toolRenderUtils', () => {
+    test('keeps custom namespaced tools expandable with parameter summaries', () => {
+        expect(isExpandableTool('myplugin_bash')).toBe(true);
+        expect(shouldShowToolParamSummary('myplugin_bash')).toBe(true);
+    });
+
+    test('does not collapse dotted custom tools into built-in tool metadata', () => {
+        expect(isExpandableTool('plugin.bash')).toBe(true);
+        expect(shouldShowToolParamSummary('plugin.bash')).toBe(true);
+        expect(getToolMetadata('plugin.bash').displayName).toBe('Plugin bash');
+    });
+
+    test('keeps only read and skill static (in-app navigation tools)', () => {
         expect(isStaticTool('read')).toBe(true);
         expect(isStaticTool('skill')).toBe(true);
         expect(isExpandableTool('read')).toBe(false);
         expect(isExpandableTool('skill')).toBe(false);
     });
 
-    test('expands built-in tools without direct navigation', () => {
-        expect(isExpandableTool('grep')).toBe(true);
-        expect(isExpandableTool('webfetch')).toBe(true);
-        expect(isExpandableTool('todowrite')).toBe(true);
-        expect(isExpandableTool('plan_exit')).toBe(true);
+    test('makes built-in content tools expandable via the common renderer', () => {
+        for (const toolName of ['bash', 'edit', 'write', 'grep', 'glob', 'list', 'webfetch', 'websearch', 'todowrite', 'lsp', 'question']) {
+            expect([toolName, isExpandableTool(toolName)]).toEqual([toolName, true]);
+            expect([toolName, isStaticTool(toolName)]).toEqual([toolName, false]);
+        }
     });
 
-    test('expands custom and MCP tools', () => {
-        expect(isExpandableTool('linear_list_issues')).toBe(true);
-        expect(isExpandableTool('my-plugin_publish')).toBe(true);
-        expect(isStaticTool('linear_list_issues')).toBe(false);
+    test('keeps task as a standalone activity boundary', () => {
+        expect(isStandaloneTool('task')).toBe(true);
+        expect(isExpandableTool('task')).toBe(true);
+        expect(isStaticTool('task')).toBe(false);
     });
 
-    test('normalizes dotted and indexed tool names', () => {
-        expect(isStaticTool('runtime.read:2')).toBe(true);
-        expect(isExpandableTool('runtime.custom_tool:2')).toBe(true);
+    test('does not show param summaries on known built-in tools', () => {
+        for (const toolName of ['read', 'bash', 'edit', 'task', 'grep', 'webfetch', 'lsp', 'skill']) {
+            expect([toolName, shouldShowToolParamSummary(toolName)]).toEqual([toolName, false]);
+        }
+    });
+
+    test('shows param summaries on unknown custom/plugin/MCP tools', () => {
+        expect(shouldShowToolParamSummary('unknown_custom_tool')).toBe(true);
+        expect(shouldShowToolParamSummary('web-reader_webReader')).toBe(true);
+        expect(shouldShowToolParamSummary('plugin.bash')).toBe(true);
+    });
+
+    describe('formatToolParamSummaryValue', () => {
+        test('truncates long strings to 30 chars with ellipsis', () => {
+            const long = 'a'.repeat(50);
+            expect(formatToolParamSummaryValue(long)).toBe('a'.repeat(30) + '...');
+        });
+
+        test('keeps short strings as-is', () => {
+            expect(formatToolParamSummaryValue('short')).toBe('short');
+        });
+
+        test('stringifies numbers and booleans', () => {
+            expect(formatToolParamSummaryValue(42)).toBe('42');
+            expect(formatToolParamSummaryValue(true)).toBe('true');
+            expect(formatToolParamSummaryValue(false)).toBe('false');
+        });
+
+        test('renders null as "null"', () => {
+            expect(formatToolParamSummaryValue(null)).toBe('null');
+        });
+
+        test('serializes small objects as json', () => {
+            expect(formatToolParamSummaryValue({ a: 1 })).toBe('{"a":1}');
+        });
+
+        test('truncates large objects with ellipsis', () => {
+            const big = { edits: Array(20).fill({ oldString: 'a'.repeat(10) }) };
+            const result = formatToolParamSummaryValue(big);
+            expect(result.endsWith('...')).toBe(true);
+            expect(result.length).toBe(33);
+        });
+    });
+
+    describe('getCanonicalToolName', () => {
+        test('lowercases and strips :N suffix', () => {
+            expect(getCanonicalToolName('BASH:0')).toBe('bash');
+            expect(getCanonicalToolName('Edit:3')).toBe('edit');
+        });
+
+        test('preserves dots in custom namespaced tools', () => {
+            expect(getCanonicalToolName('plugin.bash')).toBe('plugin.bash');
+            expect(getCanonicalToolName('mcp.server.tool:1')).toBe('mcp.server.tool');
+        });
+
+        test('returns empty string for non-string or empty input', () => {
+            expect(getCanonicalToolName(undefined)).toBe('');
+            expect(getCanonicalToolName(123 as unknown)).toBe('');
+            expect(getCanonicalToolName('')).toBe('');
+        });
     });
 });

--- a/packages/ui/src/components/chat/message/parts/toolRenderUtils.ts
+++ b/packages/ui/src/components/chat/message/parts/toolRenderUtils.ts
@@ -1,3 +1,5 @@
+import { shouldShowToolParamSummary as shouldShowToolParamSummaryFromMetadata } from '@/lib/toolHelpers';
+
 // Keep only tools with a direct in-app navigation destination compact. Every
 // other tool uses ToolPart so custom, plugin, and MCP calls expose their input
 // and output through the common expandable renderer.
@@ -28,4 +30,25 @@ export const isStandaloneTool = (toolName: unknown): boolean => {
 
 export const isStaticTool = (toolName: unknown): boolean => {
     return STATIC_TOOL_NAMES.has(normalizeToolName(toolName));
+};
+
+export const shouldShowToolParamSummary = (toolName: unknown): boolean => {
+    return shouldShowToolParamSummaryFromMetadata(toolName);
+};
+
+export const formatToolParamSummaryValue = (value: unknown): string => {
+    if (typeof value === 'string') {
+        return value.length > 30 ? `${value.substring(0, 30)}...` : value;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    if (value === null) {
+        return 'null';
+    }
+    if (typeof value === 'object') {
+        const serialized = JSON.stringify(value);
+        return serialized.length > 30 ? `${serialized.substring(0, 30)}...` : serialized;
+    }
+    return String(value);
 };

--- a/packages/ui/src/lib/toolHelpers.ts
+++ b/packages/ui/src/lib/toolHelpers.ts
@@ -219,9 +219,22 @@ const TOOL_METADATA: Record<string, ToolMetadata> = {
 function formatUnknownToolDisplayName(toolName: string): string {
   return toolName
     .trim()
-    .replace(/[_-]+/g, ' ')
+    .replace(/[_.-]+/g, ' ')
     .replace(/\s+/g, ' ')
     .replace(/^./, (char) => char.toUpperCase());
+}
+
+export function getCanonicalToolName(toolName: unknown): string {
+  if (typeof toolName !== 'string') return '';
+  const trimmed = toolName.trim().toLowerCase();
+  if (!trimmed) return '';
+  return trimmed.replace(/:\d+$/, '');
+}
+
+export function shouldShowToolParamSummary(toolName: unknown): boolean {
+  const canonicalName = getCanonicalToolName(toolName);
+  if (!canonicalName) return false;
+  return !(canonicalName in TOOL_METADATA);
 }
 
 export function getToolMetadata(toolName: string): ToolMetadata {


### PR DESCRIPTION
## Summary
- show inline parameter summaries for tool calls without dedicated OpenChamber rendering
- centralize built-in tool rendering policy in tool metadata instead of hardcoding plugin/MCP IDs in chat utilities
- keep custom/namespaced tools expandable without collapsing them into built-in tool metadata

Fixes #1131

## Verification
- bun test packages/ui/src/components/chat/message/parts/toolRenderUtils.test.ts
- bun run type-check
- bun run lint