### PR TITLE
Create and push branches in reproduce-issue and update reproduction labels

### DIFF
--- a/.github/workflows/reproduce-issue.yml
+++ b/.github/workflows/reproduce-issue.yml
@@ -12,7 +12,7 @@ jobs:
       group: reproduce-issue-${{ github.event.issue.number }}
       cancel-in-progress: true
     permissions:
-      contents: read
+      contents: write
       issues: write
     steps:
       - name: Checkout repository

--- a/.opencode/agent/reproduce-issue.md
+++ b/.opencode/agent/reproduce-issue.md
@@ -31,7 +31,7 @@ Your goal is to create a minimal, working reproduction of the reported bug and l
 4. If you can reproduce the bug:
    - Describe the exact reproduction steps that reliably trigger it.
    - Identify the root cause or the most likely code location.
-   - Create a branch named `reproduce/issue-<number>` from the current branch, commit any reproduction scripts, tests, or code you produced, and push the branch.
+   - Create a branch named `reproduce/issue-<number>` from the current branch, commit any reproduction scripts, tests, or code you produced, and push the branch. If the branch already exists, force-push with `git push --force`.
    - Leave a concise comment on the issue with your findings and a link to the branch.
    - Add the `reproducible:true` label to the issue.
 5. If you cannot reproduce the bug:

--- a/.opencode/agent/reproduce-issue.md
+++ b/.opencode/agent/reproduce-issue.md
@@ -31,17 +31,17 @@ Your goal is to create a minimal, working reproduction of the reported bug and l
 4. If you can reproduce the bug:
    - Describe the exact reproduction steps that reliably trigger it.
    - Identify the root cause or the most likely code location.
-   - Leave a concise comment on the issue with your findings.
-   - Add the `confirmed` label if it exists.
+   - Create a branch named `reproduce/issue-<number>` from the current branch, commit any reproduction scripts, tests, or code you produced, and push the branch.
+   - Leave a concise comment on the issue with your findings and a link to the branch.
+   - Add the `reproducible:true` label to the issue.
 5. If you cannot reproduce the bug:
    - Describe what you tried and why it did not reproduce.
    - Ask the reporter for specific missing details (browser version, OS, config, steps).
-   - Add the `needs-info` label if it exists.
+   - Add the `reproducible:false` and `needs-info` label to the issue.
 
 ## Constraints
 
 - Do not fix the bug. Only reproduce it.
-- Do not push commits or create branches.
 - Keep comments concise and factual.
 - If the issue lacks enough detail to even attempt reproduction, say so and ask for the minimum needed.
 - Use the GitHub CLI (`gh`) to inspect the issue, list labels, add labels, and leave comments.

--- a/.opencode/agent/triage.md
+++ b/.opencode/agent/triage.md
@@ -88,8 +88,8 @@ Only use labels that already exist in this repository. Do not create labels.
 | `priority:low` | Minor UX polish, niche feature request |
 | `data-loss` | Risk of losing user data or overwriting files |
 | `regression` | Bug that worked in a previous release |
-| `has-repro` | Confirmed reproducible with clear steps |
-| `needs-repro` | No clear reproduction steps provided |
+| `reproduction-steps:true` | Clear reproduction steps provided |
+| `reproduction-steps:false` | No clear reproduction steps provided |
 | `needs-info` | Needs more info from reporter to reproduce |
 
 ### General guidelines


### PR DESCRIPTION
# What

Update the reproduce-issue and triage agent definitions to create a dedicated reproduction branch and use updated label naming conventions.
- The reproduce-issue agent now creates a `reproduce/issue-<number>` branch, pushes reproduction artifacts, and comments with a link to the branch.
- Label `confirmed` replaced with `reproducible:true`, and `needs-info` now paired with `reproducible:false` when reproduction fails.
- The triage agent label mapping replaces `has-repro`/`needs-repro` with `reproduction-steps:true`/`reproduction-steps:false`.

# Why

The previous workflow instructed agents to only leave comments without persisting reproduction artifacts, making it hard to revisit or share reproduction work. The updated labels align with the project's label naming conventions for consistency across automation workflows.