### PR TITLE
fix: stop tab-complete from also swapping the selected agent

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -2256,6 +2256,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         if (showCommandAutocomplete && commandRef.current) {
             if (e.key === 'Enter' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'Escape' || e.key === 'Tab') {
                 e.preventDefault();
+                e.stopPropagation();
                 commandRef.current.handleKeyDown(e.key);
                 return;
             }
@@ -2264,6 +2265,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         if (showSkillAutocomplete && skillRef.current) {
             if (e.key === 'Enter' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'Escape' || e.key === 'Tab') {
                 e.preventDefault();
+                e.stopPropagation();
                 skillRef.current.handleKeyDown(e.key);
                 return;
             }
@@ -2272,6 +2274,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         if (showSnippetAutocomplete && snippetRef.current) {
             if (e.key === 'Enter' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'Escape' || e.key === 'Tab') {
                 e.preventDefault();
+                e.stopPropagation();
                 snippetRef.current.handleKeyDown(e.key);
                 return;
             }
@@ -2280,6 +2283,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         if (showFileMention && mentionRef.current) {
             if (e.key === 'Enter' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'Escape' || e.key === 'Tab') {
                 e.preventDefault();
+                e.stopPropagation();
                 mentionRef.current.handleKeyDown(e.key);
                 return;
             }


### PR DESCRIPTION
## Problem

Tab-completing a skill, snippet, command, or file mention in the chat input also swapped the selected agent. The completion should not propagate to the agent-cycle shortcut.

## Root cause

Two `keydown` listeners both bind `cycle_agent` (default combo `tab`):

- `ChatInput.tsx` textarea `onKeyDown` — the autocomplete branches (command/skill/snippet/file-mention) called `e.preventDefault()` + `return` but **not** `e.stopPropagation()`.
- `useKeyboardShortcuts.ts` — a global `window` (bubble-phase) `keydown` listener whose `cycle_agent` guard checks overlays / active tab / `isChatInputTarget`, but **not** whether an autocomplete is open.

`preventDefault()` blocks the default browser action but does not stop propagation. The Tab event bubbled to the window listener, `isChatInputTarget` was true (focus in chat input), and it ran `setAgent()` → agent swapped.

## Fix

Add `e.stopPropagation()` to all four autocomplete branches in `ChatInput.tsx`. The React SyntheticEvent `stopPropagation` calls native `stopPropagation`, so the event no longer reaches the window-level handler once an autocomplete consumes the key.

## Verification

- LSP diagnostics on `ChatInput.tsx`: clean
- `bun run type-check`: only pre-existing errors in unrelated test files (`appearancePersistence.verbose.test.ts`, `toolRenderUtils.test.ts`); not introduced by this change
- `bun run lint`: pass (all packages exit 0)

## Notes

No regression test added: the bug lives in keyboard-event bubbling across the React tree and a native window listener, which has no clean unit seam — it would need a jsdom/Playwright e2e harness dispatching real events.