### PR TITLE
Setup stale issue/pr cleanup workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+name: stale
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            any activity in the last 60 days. It will be closed in 7 days if no
+            further activity occurs.
+          close-issue-message: >
+            This issue has been automatically closed because it has been stale for
+            7 days with no activity. If this is still relevant, please comment or
+            reopen the issue.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has
+            not had any activity in the last 60 days. It will be closed in 7 days
+            if no further activity occurs.
+          close-pr-message: >
+            This pull request has been automatically closed because it has been
+            stale for 7 days with no activity. If this is still relevant, please
+            comment or reopen the pull request.
+          exempt-issue-labels: pinned,security,help wanted
+          exempt-pr-labels: pinned,security,help wanted
+          remove-stale-when-updated: true
+          labels-to-add-when-unstale: ""
+          operations-per-run: 100


### PR DESCRIPTION
# What

- Adds a GitHub Actions workflow (`.github/workflows/stale.yml`) that automatically marks inactive issues and pull requests as stale after 60 days and closes them after an additional 7 days of inactivity.
- Uses the `actions/stale@v10` action with configurable schedules, messages, exemptions, and rate limits.
- Supports both scheduled execution (`cron: "30 1 * * *"`) and manual triggering via `workflow_dispatch`.

# Why

Stale issues and pull requests accumulate over time, making it harder to maintain a clear view of active work. Automated stale management helps keep the issue tracker focused on relevant, actionable items while giving contributors a clear window to re-engage before closure.

---
Generated with [create-pr-description](https://github.com/tomzx/dot-claude/blob/6699cc103c8c1759ee0a7d9636cc71443ada592d/skills/create-pr-description/SKILL.md) (`6699cc1`)