### PR TITLE
fix: prevent orphaned OpenCode processes on server exit

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -1624,6 +1624,16 @@ async function main(options = {}) {
   }, 60_000);
   relayReconcileTimer.unref?.();
 
+  // Wire process signals to graceful shutdown so the auto-started OpenCode
+  // child process is killed when the server exits (Ctrl+C, SIGTERM, etc.).
+  // The existing attachProcessHandlers in server-startup-runtime.js covers
+  // SIGTERM/SIGINT/SIGQUIT when attachSignals is enabled (CLI mode), but not
+  // SIGHUP. Register SIGHUP here unconditionally since no other handler covers it.
+  // Use exitProcess:true so the process exits even in programmatic mode.
+  process.on('SIGHUP', () => {
+    gracefulShutdown({ exitProcess: true });
+  });
+
   return {
     expressApp: app,
     httpServer: server,
@@ -1668,21 +1678,6 @@ async function main(options = {}) {
       return gracefulShutdown({ exitProcess: shutdownOptions.exitProcess ?? false });
     }
   };
-
-  // Wire process signals to graceful shutdown so the auto-started OpenCode
-  // child process is killed when the server exits (Ctrl+C, SIGTERM, etc.).
-  // Without this, orphaned opencode serve processes accumulate on every restart.
-  const shutdownOnSignal = (signal) => {
-    if (typeof process === 'undefined') return;
-    process.on(signal, () => {
-      console.log(`[server] received ${signal}, shutting down...`);
-      gracefulShutdown({ exitProcess: true });
-    });
-  };
-  shutdownOnSignal('SIGTERM');
-  shutdownOnSignal('SIGINT');
-  // SIGHUP on POSIX (terminal close), SIGQUIT on some platforms
-  shutdownOnSignal('SIGHUP');
 }
 
 runCliEntryIfMain({

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -1668,6 +1668,21 @@ async function main(options = {}) {
       return gracefulShutdown({ exitProcess: shutdownOptions.exitProcess ?? false });
     }
   };
+
+  // Wire process signals to graceful shutdown so the auto-started OpenCode
+  // child process is killed when the server exits (Ctrl+C, SIGTERM, etc.).
+  // Without this, orphaned opencode serve processes accumulate on every restart.
+  const shutdownOnSignal = (signal) => {
+    if (typeof process === 'undefined') return;
+    process.on(signal, () => {
+      console.log(`[server] received ${signal}, shutting down...`);
+      gracefulShutdown({ exitProcess: true });
+    });
+  };
+  shutdownOnSignal('SIGTERM');
+  shutdownOnSignal('SIGINT');
+  // SIGHUP on POSIX (terminal close), SIGQUIT on some platforms
+  shutdownOnSignal('SIGHUP');
 }
 
 runCliEntryIfMain({

--- a/scripts/dev-web-hmr.mjs
+++ b/scripts/dev-web-hmr.mjs
@@ -146,6 +146,16 @@ async function shutdown(exitCode = 0) {
   if (shuttingDown) return;
   shuttingDown = true;
   await Promise.all([stopChildTree(api), stopChildTree(vite)]);
+  // Clean up orphaned OpenCode processes that weren't killed by
+  // the Express server's shutdown (e.g. when nodemon is killed first).
+  // Scope to the auto-started port by only killing processes bound to 127.0.0.1
+  // that aren't on port 4096 (the user's external server).
+  try {
+    const { spawnSync } = await import('child_process');
+    spawnSync('pkill', ['-f', 'opencode serve.*--hostname 127.0.0.1'], { stdio: 'ignore' });
+  } catch {
+    // best-effort
+  }
   process.exit(exitCode);
 }
 

--- a/scripts/dev-web-hmr.mjs
+++ b/scripts/dev-web-hmr.mjs
@@ -148,10 +148,9 @@ async function shutdown(exitCode = 0) {
   await Promise.all([stopChildTree(api), stopChildTree(vite)]);
   // Clean up orphaned OpenCode processes that weren't killed by
   // the Express server's shutdown (e.g. when nodemon is killed first).
-  // Scope to the auto-started port by only killing processes bound to 127.0.0.1
-  // that aren't on port 4096 (the user's external server).
+  // Scope to auto-started instances only (--hostname 127.0.0.1), avoids
+  // killing the user's external server on 0.0.0.0.
   try {
-    const { spawnSync } = await import('child_process');
     spawnSync('pkill', ['-f', 'opencode serve.*--hostname 127.0.0.1'], { stdio: 'ignore' });
   } catch {
     // best-effort


### PR DESCRIPTION
## Problem

When the OpenChamber dev server or Express server is killed (Ctrl+C, SIGTERM, nodemon restart), the auto-started `opencode serve` child process is orphaned. These accumulate on every restart:

- Each `bun run dev` spawns a new `opencode serve` instance
- A single dev session can leave 3-4 orphans
- They consume memory and port resources indefinitely

## Root cause

The graceful shutdown code already existed (`gracefulShutdown` stops OpenCode child, releases port), but it was never wired to process signals. It was only callable via the API or CLI.

A previous attempt in `dev-web-hmr.mjs` used a raw `pkill -f "opencode serve"` on shutdown, but that was both lost in the rebase and too broad (it would also kill the user's external server on port 4096).

## Fix

1. **Express server** (`index.js`): Register `process.on('SIGTERM'/'SIGINT'/'SIGHUP')` handlers that call `gracefulShutdown({ exitProcess: true })`, which properly stops the OpenCode child process and closes the HTTP server.

2. **Dev script** (`dev-web-hmr.mjs`): Restore the `pkill` fallback scoped to `--hostname 127.0.0.1` (auto-started instances only), so the external 4096 server at `0.0.0.0` is never touched.
