### PR TITLE
fix: use effectiveDirectory in ToolPart to fix empty ContextPanel iframe for sub-tasks

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -10,7 +10,7 @@ import type { ToolPart as ToolPartType, ToolState as ToolStateUnion } from '@ope
 import { toolDisplayStyles } from '@/lib/typography';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { useOptionalThemeSystem } from '@/contexts/useThemeSystem';
-import { useDirectoryStore } from '@/stores/useDirectoryStore';
+import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useDirectorySync, useSessionMessageRecords, useEnsureSessionMessages } from '@/sync/sync-context';
 import { getSyncChildStores } from '@/sync/sync-refs';
@@ -1197,7 +1197,7 @@ const TaskToolSummary: React.FC<{
     isActive?: boolean;
 }> = ({ entries, isExpanded, isMobile, output, sessionId, onShowPopup, input, animateTailText = true, isActive = false }) => {
     const { t } = useI18n();
-    const currentDirectory = useDirectoryStore((state) => state.currentDirectory);
+    const currentDirectory = useEffectiveDirectory();
     const setCurrentSession = useSessionUIStore((state) => state.setCurrentSession);
     const openContextPanelTab = useUIStore((state) => state.openContextPanelTab);
     const showToolFileIcons = useUIStore((state) => state.showToolFileIcons);
@@ -1918,7 +1918,7 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
 }) => {
     const state = part.state;
     const showToolFileIcons = useUIStore((s) => s.showToolFileIcons);
-    const currentDirectory = useDirectoryStore((s) => s.currentDirectory);
+    const currentDirectory = useEffectiveDirectory() ?? '';
     const currentSessionId = useSessionUIStore((s) => s.currentSessionId);
 
     const normalizedPartTool = normalizeToolName(part.tool);


### PR DESCRIPTION
## Fix: Empty ContextPanel iframe when opening sub-task from chat message

### Problem

When using `/review` or similar commands that spawn subagents, clicking the "Open sub-task" button in a `task` tool part opens an empty ContextPanel iframe — no chat messages are displayed. Navigating to the same sub-session from the left sidebar works correctly.

### Root Cause

A **directory key mismatch** between tab storage and tab lookup in the ContextPanel:

- **Tab storage** (`ToolPart` → `openContextPanelTab(directory, ...)`): used `useDirectoryStore.currentDirectory`, which returns the **global project root directory** (e.g. `/home/user/project`).
- **Tab lookup** (`ContextPanel`): uses `useEffectiveDirectory()`, which resolves to the **worktree/session directory** (e.g. `/tmp/worktree-xxx`) when the parent session has a worktree attachment.

When the parent session is associated with a worktree, these two values differ. The key used to store the tab doesn't match the key used to look it up → `panelState` is `undefined` → no tabs rendered → empty iframe.

The sidebar navigation path (SessionNodeItem → handleSessionSelect) works because it passes the sub-session's own `session.directory`, correctly scoped to the worktree.

The `UserSubtaskPart` component in `MessageBody.tsx` uses `useEffectiveDirectory()` as its directory source, which is the correct pattern. This PR aligns `ToolPart` with that same pattern.

### Fix

Replace `useDirectoryStore((s) => s.currentDirectory)` with `useEffectiveDirectory()` in both places within `ToolPart.tsx`:

1. **`TaskToolSummary`** (line 1200) — Used when clicking "Open sub-task" button to open the sub-session in the ContextPanel.
2. **`ToolPartContent`** (line 1921) — Used for loading sub-session messages inline, git refresh triggers, file path display, and scoped SDK client lookups.

Both now use the same directory resolution as `ContextPanel` and `UserSubtaskPart`, eliminating the key mismatch.

### Verification

- Sub-task opened from chat message → ContextPanel shows sub-session messages correctly.
- Sidebar sub-session navigation continues to work (unchanged path).
- Worktree and non-worktree sessions both resolve to the correct directory.
- `UserSubtaskPart` "Open session" button behavior unchanged (already used `useEffectiveDirectory()`).
