### PR TITLE
fix: prevent blank chat viewport when switching sessions

### DIFF
--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -1335,6 +1335,8 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
         scrollEl.scrollTop += prependedHeight;
     });
 
+    const [virtualVersion, bumpVirtualVersion] = React.useReducer((v: number) => v + 1, 0);
+
     const historyVirtualizer = useVirtualizer({
         count: historyEntries.length,
         getScrollElement: resolveScrollContainer,
@@ -1344,6 +1346,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
         useAnimationFrameWithResizeObserver: true,
         overscan: MESSAGE_LIST_OVERSCAN,
         enabled: shouldVirtualizeHistory,
+        onChange: bumpVirtualVersion,
     });
 
     React.useLayoutEffect(() => {
@@ -1400,7 +1403,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
 
     const historyVirtualRows = React.useMemo(
         () => (shouldVirtualizeHistory ? historyVirtualizer.getVirtualItems() : EMPTY_VIRTUAL_ROWS),
-        [historyVirtualizer, shouldVirtualizeHistory],
+        [historyVirtualizer, shouldVirtualizeHistory, virtualVersion],
     );
 
     const allEntries = React.useMemo(() => {

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -411,7 +411,9 @@ export const useChatAutoFollow = ({
     }, [sessionIsWorking, startFollowLoop]);
 
     // Replay a deferred restoreSnapshot once ChatViewport mounts.
-    React.useEffect(() => {
+    // useLayoutEffect ensures scroll position is set before the browser paints,
+    // preventing a visible flash of content at the wrong scroll position.
+    React.useLayoutEffect(() => {
         if (!containerEl) return;
         if (pendingInitialRestoreRef.current && pendingInitialRestoreRef.current === currentSessionId) {
             void restoreSnapshot();


### PR DESCRIPTION
## Problem

When switching sessions — especially in the Electron desktop app
after changing servers — the chat viewport renders blank on entry.
Content only appears after the user scrolls with the mouse wheel.
The issue is most visible with sessions that have long context
(many turns).

## Root cause

Two interacting issues:

### 1. `historyVirtualRows` memo never recomputes (`MessageList.tsx:1403`)

`historyVirtualRows` is memoized with `[historyVirtualizer,
shouldVirtualizeHistory]` as dependencies.  `historyVirtualizer`
is the return value of `@tanstack/react-virtual`'s `useVirtualizer()`,
which stores the instance via `useState` — the reference is stable
across all renders.  When the virtualizer recalculates its visible
range (triggered by scroll events or `ResizeObserver`), it calls
`onChange → rerender()` to re-render the component.  But the memo
sees the same `historyVirtualizer` reference and skips recomputation
— `historyVirtualRows` is frozen at its initial value forever.

**Consequence:** after `restoreSnapshot` scrolls to the bottom on
session switch, the virtualizer still renders items from the initial
range (aligned to `scrollTop: 0`).  The rendered items sit at the top
of the scroll area while the `paddingBottom` spacer fills the visible
viewport → user sees blank.

### 2. Scroll restoration runs after paint (`useChatAutoFollow.ts:414`)

When a session is still hydrating (skeleton shown, scroll container
not mounted), `restoreSnapshot` cannot find the container and stores
the session ID in `pendingInitialRestoreRef` for later replay.  The
replay hook depended on `containerEl` and ran inside `useEffect`,
which fires **after** the browser has already painted the first frame.
That frame shows content at `scrollTop: 0` with the stale virtualizer
range described above — the blank frame becomes user-visible.

This is amplified in Electron because server switches force the
hydrating path (data must be fetched from the new server), and
`backgroundThrottling: false` combined with GPU compositing layers
can stagger `ResizeObserver` / `requestAnimationFrame` callbacks
across different frames.

## Fix

### Fix 1 — force memo recomputation on virtualizer state changes

Add a `virtualVersion` counter (`useReducer`) that increments on
every virtualizer internal state update, and pass it as an `onChange`
callback to `useVirtualizer`:

```ts
const [virtualVersion, bumpVirtualVersion] = React.useReducer((v: number) => v + 1, 0);

const historyVirtualizer = useVirtualizer({
    // ... existing options
    onChange: bumpVirtualVersion,
});
```

Then add `virtualVersion` to the memo:

```ts
const historyVirtualRows = React.useMemo(
    () => shouldVirtualizeHistory ? historyVirtualizer.getVirtualItems() : [],
    [historyVirtualizer, shouldVirtualizeHistory, virtualVersion],  // ← added
);
```

The library wraps our `onChange` into its internal notification
pipeline, so `bumpVirtualVersion` fires after every range, size,
or scroll offset change.  The memo now recomputes exactly when
the virtualizer state actually changes, not when the (stable)
instance reference "changes".

### Fix 2 — restore scroll position before paint

Change the `pendingInitialRestoreRef` replay from `useEffect` to
`useLayoutEffect`:

```ts
// Before: React.useEffect(() => { ...
// After:
React.useLayoutEffect(() => {
    if (!containerEl) return;
    if (pendingInitialRestoreRef.current === currentSessionId) {
        void restoreSnapshot();
    }
}, [containerEl, currentSessionId, restoreSnapshot]);
```

`useLayoutEffect` runs synchronously after DOM commit, before the
browser paints.  When the scroll container mounts after hydration,
`restoreSnapshot` sets `scrollTop` to the bottom before the first
paint — no intermediate frame at the wrong position.

### How tested

- Type-check clean on `@openchamber/ui` and `@openchamber/web`.
- Manually verified on Electron desktop: switching servers with
  sessions that have 10+ turns of long context no longer shows blank
  on entry.