### PR TITLE
fix: prevent cascade rollback from restoring deleted session descendants

### DIFF
--- a/packages/ui/src/components/session/sidebar/hooks/useSessionActions.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionActions.ts
@@ -214,16 +214,18 @@ export const useSessionActions = (args: Args) => {
 
       const ids = [session.id, ...descendantIds];
       if (shouldHardDelete) {
-        const { deletedIds, failedIds } = await args.deleteSessions(ids);
-        if (deletedIds.length > 0) {
-          toast.success(deletedIds.length === 1
-            ? t('sessions.sidebar.bulkActions.deletedSingle', { count: deletedIds.length })
-            : t('sessions.sidebar.bulkActions.deletedPlural', { count: deletedIds.length }));
-        }
-        if (failedIds.length > 0) {
-          toast.error(failedIds.length === 1
-            ? t('sessions.sidebar.bulkActions.failedDeleteSingle', { count: failedIds.length })
-            : t('sessions.sidebar.bulkActions.failedDeletePlural', { count: failedIds.length }));
+        // The server cascade-deletes all descendant sessions when the parent
+        // is removed. Only send the root session delete request; sending
+        // individual requests for each descendant would hit 404 (already
+        // deleted by cascade) and trigger rollback that restores them.
+        const success = await args.deleteSession(session.id);
+        if (success) {
+          const totalDeleted = descendantIds.length + 1;
+          toast.success(totalDeleted === 1
+            ? t('sessions.sidebar.bulkActions.deletedSingle', { count: totalDeleted })
+            : t('sessions.sidebar.bulkActions.deletedPlural', { count: totalDeleted }));
+        } else {
+          toast.error(t('sessions.sidebar.session.delete.error'));
         }
         return;
       }

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -416,6 +416,12 @@ export async function deleteSession(sessionId: string, _options?: Record<string,
     return true
   } catch (error) {
     console.error("[session-actions] deleteSession failed", error)
+    // The server cascade-deletes child sessions when the parent is removed.
+    // Subsequent delete attempts for those children return 404; treat as
+    // success since the session was already deleted by the cascade.
+    if ((error as { status?: number })?.status === 404) {
+      return true
+    }
     restoreSessionListSnapshots(snapshots)
     restoreGlobalSessionSnapshot(globalSnapshot)
     return false
@@ -439,6 +445,9 @@ export async function deleteSessionInDirectory(sessionId: string, directory: str
     return true
   } catch (error) {
     console.error("[session-actions] deleteSessionInDirectory failed", error)
+    if ((error as { status?: number })?.status === 404) {
+      return true
+    }
     restoreSessionListSnapshots(snapshots)
     restoreGlobalSessionSnapshot(globalSnapshot)
     return false


### PR DESCRIPTION
The OpenCode server cascade-deletes all child sessions when a parent is removed (`session.remove` recurses into children). The client was sending individual `DELETE` requests for every descendant alongside the parent, creating a race where descendants returned 404 (already deleted by the server cascade). The 404 triggered the rollback path in `deleteSessionAction`, which restored the deleted sessions back into the global store — making them appear as "failed to delete" in the UI while actually gone on the server.

### Changes

- **`useSessionActions.ts`** — When hard-deleting a session that has descendants, only send the delete request for the root session. The server cascade handles the rest. Previously, every descendant was sent as a separate request, each hitting 404 after the parent's cascade removed them.

- **`session-actions.ts`** — In both `deleteSession` and `deleteSessionInDirectory`, treat HTTP 404 as success in the catch block. This acts as a safety net for any remaining code paths that may still send individual descendant deletes (e.g., the sidebar bulk action bar when a parent and child are both checkbox-selected).

### Verification

- `bun run type-check` — passes
- `bun run lint` — passes