### PR TITLE
fix: preserve model selection when toggling agents via TAB

### DIFF
--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -2031,20 +2031,6 @@ export const useConfigStore = create<ConfigStore>()(
                             });
                         };
 
-                        // Prefer the selected agent's configured model when switching agents.
-                        const agent = agents.find((candidate) => candidate.name === agentName);
-                        const agentModelSelection = agent?.model;
-                        if (agentModelSelection?.providerID && agentModelSelection?.modelID) {
-                            const { providerID, modelID } = agentModelSelection;
-                            const agentProvider = providers.find((provider) => provider.id === providerID);
-                            const agentModel = agentProvider?.models.find((model) => model.id === modelID);
-
-                            if (agentModel) {
-                                applyResolvedModelSelection(providerID, modelID, undefined);
-                                return;
-                            }
-                        }
-
                         if (currentSessionId) {
                             const existingAgentModel = useSelectionStore.getState().getAgentModelForSession(currentSessionId, agentName);
                             if (existingAgentModel && hasProviderModel(providers, existingAgentModel.providerId, existingAgentModel.modelId)) {
@@ -2061,6 +2047,20 @@ export const useConfigStore = create<ConfigStore>()(
                                 ) {
                                     applyResolvedModelSelection(existingAgentModel.providerId, existingAgentModel.modelId, savedVariant);
                                 }
+                                return;
+                            }
+                        }
+
+                        // Fall back to the selected agent's configured model when no session-saved selection exists.
+                        const agent = agents.find((candidate) => candidate.name === agentName);
+                        const agentModelSelection = agent?.model;
+                        if (agentModelSelection?.providerID && agentModelSelection?.modelID) {
+                            const { providerID, modelID } = agentModelSelection;
+                            const agentProvider = providers.find((provider) => provider.id === providerID);
+                            const agentModel = agentProvider?.models.find((model) => model.id === modelID);
+
+                            if (agentModel) {
+                                applyResolvedModelSelection(providerID, modelID, undefined);
                                 return;
                             }
                         }


### PR DESCRIPTION
# What

Reorders the model resolution priority in `setAgent()` so session-saved model selections are checked before the agent's configured default model.

# Why

When switching agents (build/plan) with TAB, the agent's configured default model had highest priority and returned early. This meant the user's previously selected model for that agent in the current session was discarded every time they toggled modes.

Closes #1414

# How to test

1. Start a session with the default agent (build) and its default model
2. Open the model picker and select a different model (e.g., switch from sonnet-4 to gemini-2.5-pro)
3. Press TAB to switch to plan mode
4. Press TAB again to switch back to build mode
5. Verify the model selection is preserved (not reset to the agent default)
6. Repeat with plan mode: switch to plan, change model, toggle to build and back
7. Verify the plan mode model selection is also preserved

# Acceptance criteria coverage

- [x] TAB toggling between build/plan preserves user's model selection for each agent
- [x] First-time agent switch (no session-saved model) still falls back to agent's configured default
- [x] Settings default model still applies when agent has no configured model and no session-saved selection