### PR TITLE
fix(mobile): subagent chevron overlaps session title on mobile

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -582,6 +582,7 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
           toggleParent(expansionKey);
         }
       }}
+      style={{ minWidth: 14, minHeight: 14 }}
       className={cn(
         'absolute left-[-10px] inline-flex h-3.5 w-3.5 items-center justify-center rounded-md text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 transition-opacity',
         isMinimalMode ? 'top-1/2 -translate-y-1/2' : 'top-[14.5px] -translate-y-1/2',


### PR DESCRIPTION
## What
Subagent chevron arrow overlaps session title on mobile devices.

<img width="694" height="198" alt="image" src="https://github.com/user-attachments/assets/9ebd9935-681d-489d-b946-71844c93e33a" />


## Why
`mobile.css` applies `min-width: 36px; min-height: 36px` to all `[role="button"]` elements on mobile to meet touch target guidelines. The subagent expand/collapse chevron uses `role="button"` and is sized at `w-3.5 h-3.5` (14×14px). The mobile CSS selector has higher specificity than the Tailwind utility classes, so the chevron is silently enlarged to 36×36px. Since the chevron is absolutely positioned at `left-[-10px]`, the expanded 36px box extends 20px past the content edge, visually overlapping the session title text.

## How to test
1. Open the app on a mobile device or in Chrome DevTools with a mobile viewport (≤1024px + touch emulation)
2. Create a session that spawns at least one subagent
3. Verify the expand/collapse chevron arrow does not overlap or visually collide with the session title

<img width="688" height="198" alt="image" src="https://github.com/user-attachments/assets/00c7993a-d556-42d3-8581-40012f7d6d95" />

