### PR TITLE
feat: improve long user message collapse, scrolling, and navigation

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -33,6 +33,7 @@ import { FadeInOnReveal } from './message/FadeInOnReveal';
 import { streamPerfCount } from '@/stores/utils/streamDebug';
 import { areOptionalRenderRelevantMessagesEqual, areRenderRelevantMessagesEqual, areRelevantTurnGroupingContextsEqual } from './message/renderCompare';
 import type { ReviewTransferDirection } from '@/lib/reviewFlow';
+import type { UserMessageNavInfo } from './MessageList';
 
 const ToolOutputDialog = lazyWithChunkRecovery(() => import('./message/ToolOutputDialog'));
 
@@ -136,6 +137,7 @@ interface ChatMessageProps {
     animateUserOnMount?: boolean;
     onUserAnimationConsumed?: (messageId: string) => void;
     reviewTransferDirection?: ReviewTransferDirection | null;
+    userMessageNavInfo?: UserMessageNavInfo;
 }
 
 const ChatMessage: React.FC<ChatMessageProps> = ({
@@ -151,6 +153,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
     animateUserOnMount = false,
     onUserAnimationConsumed,
     reviewTransferDirection = null,
+    userMessageNavInfo,
 }) => {
     const { isMobile, isTablet, hasTouchInput } = useDeviceInfo();
     const alwaysShowMessageActions = isMobile || isTablet;
@@ -771,6 +774,16 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
         forkFromMessage(sessionId, message.info.id);
     }, [sessionId, message.info.id, forkFromMessage]);
 
+    const handleScrollToMessage = React.useCallback((target: 'prev' | 'next' | 'self-top') => {
+        if (target === 'self-top') {
+            messageContainerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            return;
+        }
+        const targetId = target === 'prev' ? userMessageNavInfo?.previousUserMessageId : userMessageNavInfo?.nextUserMessageId;
+        if (!targetId) return;
+        userMessageNavInfo?.scrollToUserMessage(targetId);
+    }, [userMessageNavInfo]);
+
     const handleToggleTool = React.useCallback((toolId: string) => {
         const isDefaultOpen = defaultOpenToolIds.has(toolId);
         const isCurrentlyExpanded = effectiveExpandedTools.has(toolId);
@@ -1051,6 +1064,8 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                                 errorVariant={assistantErrorVariant}
                                                 userActionsMode={useExternalUserActionsRow ? 'external-content' : 'inline'}
                                                 stickyUserHeaderEnabled={stickyUserHeader}
+                                                onScrollToMessage={isUser ? handleScrollToMessage : undefined}
+                                                userMessageNavInfo={isUser ? userMessageNavInfo : undefined}
                                             />
                                         </div>
                                         {useExternalUserActionsRow ? (
@@ -1085,6 +1100,8 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                                 errorVariant={assistantErrorVariant}
                                                 userActionsMode="external-actions"
                                                 stickyUserHeaderEnabled={stickyUserHeader}
+                                                onScrollToMessage={isUser ? handleScrollToMessage : undefined}
+                                                userMessageNavInfo={isUser ? userMessageNavInfo : undefined}
                                             />
                                         ) : null}
                                     </div>

--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -420,6 +420,12 @@ export interface MessageListHandle {
     scrollToBottom: () => void;
 }
 
+export interface UserMessageNavInfo {
+    previousUserMessageId?: string;
+    nextUserMessageId?: string;
+    scrollToUserMessage: (messageId: string) => void;
+}
+
 type RenderEntry =
     | {
         kind: 'ungrouped';
@@ -448,6 +454,8 @@ interface MessageRowProps {
     animationHandlers: AnimationHandlers;
     scrollToBottom?: () => void;
     reviewTransferDirection?: ReviewTransferDirection | null;
+    userNavigationById?: Map<string, { previousUserMessageId?: string; nextUserMessageId?: string }>;
+    scrollToUserMessage?: (messageId: string) => void;
 }
 
 const MessageRow = React.memo<MessageRowProps>(({ 
@@ -464,7 +472,20 @@ const MessageRow = React.memo<MessageRowProps>(({
     animationHandlers,
     scrollToBottom,
     reviewTransferDirection,
+    userNavigationById,
+    scrollToUserMessage,
 }) => {
+    const userMessageNavInfo = React.useMemo(() => {
+        if (resolveMessageRole(message) !== 'user' || !userNavigationById || !scrollToUserMessage) return undefined;
+        const nav = userNavigationById.get(message.info.id);
+        if (!nav) return undefined;
+        return {
+            previousUserMessageId: nav.previousUserMessageId,
+            nextUserMessageId: nav.nextUserMessageId,
+            scrollToUserMessage,
+        };
+    }, [message, userNavigationById, scrollToUserMessage]);
+
     return (
         <ChatMessage
             message={message}
@@ -480,6 +501,7 @@ const MessageRow = React.memo<MessageRowProps>(({
             isInActiveTurn={isInActiveTurn}
             activeStreamingPhase={activeStreamingPhase}
             reviewTransferDirection={reviewTransferDirection}
+            userMessageNavInfo={userMessageNavInfo}
         />
     );
 }, (prev, next) => {
@@ -526,6 +548,8 @@ interface TurnBlockProps {
     activeStreamingMessageId?: string | null;
     activeStreamingPhase?: StreamPhase | null;
     reviewTransferDirection?: ReviewTransferDirection | null;
+    userNavigationById?: Map<string, { previousUserMessageId?: string; nextUserMessageId?: string }>;
+    scrollToUserMessage?: (messageId: string) => void;
 }
 
 const TurnBlock = React.memo(({
@@ -545,6 +569,8 @@ const TurnBlock = React.memo(({
     activeStreamingMessageId,
     activeStreamingPhase,
     reviewTransferDirection,
+    userNavigationById,
+    scrollToUserMessage,
 }: TurnBlockProps) => {
     const turnUiState = turnUiStates.get(turn.turnId) ?? { isExpanded: defaultActivityExpanded };
     const handleToggleTurnGroup = React.useCallback(() => {
@@ -771,6 +797,8 @@ const TurnBlock = React.memo(({
                     onContentChange={onMessageContentChange}
                     animationHandlers={getAnimationHandlers(message.info.id)}
                     scrollToBottom={scrollToBottom}
+                    userNavigationById={userNavigationById}
+                    scrollToUserMessage={scrollToUserMessage}
                 />
             );
         },
@@ -800,6 +828,8 @@ const TurnBlock = React.memo(({
             shouldAnimateUserMessage,
             onUserAnimationConsumed,
             handleToggleTurnGroup,
+            userNavigationById,
+            scrollToUserMessage,
         ]
     );
 
@@ -832,6 +862,8 @@ interface UngroupedMessageRowProps {
     activeStreamingMessageId?: string | null;
     activeStreamingPhase?: StreamPhase | null;
     reviewTransferDirection?: ReviewTransferDirection | null;
+    userNavigationById?: Map<string, { previousUserMessageId?: string; nextUserMessageId?: string }>;
+    scrollToUserMessage?: (messageId: string) => void;
 }
 
 const UngroupedMessageRow = React.memo(({
@@ -846,6 +878,8 @@ const UngroupedMessageRow = React.memo(({
     activeStreamingMessageId,
     activeStreamingPhase,
     reviewTransferDirection,
+    userNavigationById,
+    scrollToUserMessage,
 }: UngroupedMessageRowProps) => {
     return (
         <MessageRow
@@ -860,6 +894,8 @@ const UngroupedMessageRow = React.memo(({
             isInActiveTurn={Boolean(activeStreamingMessageId) && message.info.id === activeStreamingMessageId}
             activeStreamingPhase={message.info.id === activeStreamingMessageId ? activeStreamingPhase : null}
             reviewTransferDirection={reviewTransferDirection}
+            userNavigationById={userNavigationById}
+            scrollToUserMessage={scrollToUserMessage}
         />
     );
 });
@@ -882,6 +918,8 @@ interface MessageListEntryProps {
     activeStreamingMessageId?: string | null;
     activeStreamingPhase?: StreamPhase | null;
     reviewTransferDirection?: ReviewTransferDirection | null;
+    userNavigationById?: Map<string, { previousUserMessageId?: string; nextUserMessageId?: string }>;
+    scrollToUserMessage?: (messageId: string) => void;
 }
 
 const turnContainsMessageId = (turn: TurnRecord, messageId: string | null | undefined): boolean => {
@@ -912,6 +950,8 @@ const MessageListEntry = React.memo(({
     activeStreamingMessageId,
     activeStreamingPhase,
     reviewTransferDirection,
+    userNavigationById,
+    scrollToUserMessage,
 }: MessageListEntryProps) => {
     if (entry.kind === 'ungrouped') {
         return (
@@ -927,6 +967,8 @@ const MessageListEntry = React.memo(({
                 activeStreamingMessageId={activeStreamingMessageId}
                 activeStreamingPhase={activeStreamingPhase}
                 reviewTransferDirection={reviewTransferDirection}
+                userNavigationById={userNavigationById}
+                scrollToUserMessage={scrollToUserMessage}
             />
         );
     }
@@ -949,6 +991,8 @@ const MessageListEntry = React.memo(({
             getAnimationHandlers={getAnimationHandlers}
             scrollToBottom={scrollToBottom}
             stickyUserHeader={stickyUserHeader}
+            userNavigationById={userNavigationById}
+            scrollToUserMessage={scrollToUserMessage}
         />
     );
 });
@@ -975,9 +1019,11 @@ type StaticHistoryListProps = {
     onUserAnimationConsumed: (messageId: string) => void;
     activeStreamingPhase?: StreamPhase | null;
     reviewTransferDirection?: ReviewTransferDirection | null;
+    userNavigationById?: Map<string, { previousUserMessageId?: string; nextUserMessageId?: string }>;
+    scrollToUserMessage?: (messageId: string) => void;
 };
 
-const StaticHistoryList = React.memo(({ entries, shouldVirtualize, virtualRows, totalSize, measureElement, contentRef, onMessageContentChange, getAnimationHandlers, scrollToBottom, stickyUserHeader, defaultActivityExpanded, turnUiStates, onToggleTurnGroup, chatRenderMode, shouldAnimateUserMessage, onUserAnimationConsumed, activeStreamingPhase, reviewTransferDirection }: StaticHistoryListProps) => {
+const StaticHistoryList = React.memo(({ entries, shouldVirtualize, virtualRows, totalSize, measureElement, contentRef, onMessageContentChange, getAnimationHandlers, scrollToBottom, stickyUserHeader, defaultActivityExpanded, turnUiStates, onToggleTurnGroup, chatRenderMode, shouldAnimateUserMessage, onUserAnimationConsumed, activeStreamingPhase, reviewTransferDirection, userNavigationById, scrollToUserMessage }: StaticHistoryListProps) => {
     const renderEntry = React.useCallback((entry: RenderEntry) => {
         return (
             <MessageListEntry
@@ -997,9 +1043,11 @@ const StaticHistoryList = React.memo(({ entries, shouldVirtualize, virtualRows, 
                 activeStreamingMessageId={null}
                 activeStreamingPhase={activeStreamingPhase}
                 reviewTransferDirection={reviewTransferDirection}
+                userNavigationById={userNavigationById}
+                scrollToUserMessage={scrollToUserMessage}
             />
         );
-    }, [activeStreamingPhase, chatRenderMode, defaultActivityExpanded, getAnimationHandlers, onMessageContentChange, onToggleTurnGroup, onUserAnimationConsumed, reviewTransferDirection, scrollToBottom, shouldAnimateUserMessage, stickyUserHeader, turnUiStates]);
+    }, [activeStreamingPhase, chatRenderMode, defaultActivityExpanded, getAnimationHandlers, onMessageContentChange, onToggleTurnGroup, onUserAnimationConsumed, reviewTransferDirection, scrollToBottom, shouldAnimateUserMessage, stickyUserHeader, turnUiStates, userNavigationById, scrollToUserMessage]);
 
     const paddingTop = shouldVirtualize && virtualRows.length > 0
         ? virtualRows[0]?.start ?? 0
@@ -1081,6 +1129,8 @@ const StreamingTailContent: React.FC<{
     activeStreamingMessageId?: string | null;
     activeStreamingPhase?: StreamPhase | null;
     reviewTransferDirection?: ReviewTransferDirection | null;
+    userNavigationById?: Map<string, { previousUserMessageId?: string; nextUserMessageId?: string }>;
+    scrollToUserMessage?: (messageId: string) => void;
 }> = ({
     entry,
     onMessageContentChange,
@@ -1097,6 +1147,8 @@ const StreamingTailContent: React.FC<{
     activeStreamingMessageId,
     activeStreamingPhase,
     reviewTransferDirection,
+    userNavigationById,
+    scrollToUserMessage,
 }) => {
     return (
         <MessageListEntry
@@ -1115,6 +1167,8 @@ const StreamingTailContent: React.FC<{
             activeStreamingMessageId={activeStreamingMessageId}
             activeStreamingPhase={activeStreamingPhase}
             reviewTransferDirection={reviewTransferDirection}
+            userNavigationById={userNavigationById}
+            scrollToUserMessage={scrollToUserMessage}
         />
     );
 };
@@ -1459,6 +1513,20 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
             .map((message) => message.info.id);
     }, [messages]);
 
+    const userNavigationById = React.useMemo(() => {
+        const navMap = new Map<string, { previousUserMessageId?: string; nextUserMessageId?: string }>();
+        const userOrder = currentUserOrder;
+        for (let i = 0; i < userOrder.length; i++) {
+            const id = userOrder[i];
+            if (!id) continue;
+            navMap.set(id, {
+                previousUserMessageId: i > 0 ? userOrder[i - 1] : undefined,
+                nextUserMessageId: i < userOrder.length - 1 ? userOrder[i + 1] : undefined,
+            });
+        }
+        return navMap;
+    }, [currentUserOrder]);
+
     // Detect new user messages SYNCHRONOUSLY during render.
     // Must happen during render (not in useEffect) so that ToolRevealOnMount
     // receives animate=true on the FIRST render of the new message,
@@ -1563,7 +1631,14 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
         return true;
     }, [findMessageElement, resolveScrollContainer]);
 
-    React.useEffect(() => {
+    const scrollToUserMessage = React.useCallback((messageId: string) => {
+        const index = messageIndexMap.get(messageId);
+        if (typeof index === 'number') {
+            scrollHistoryIndexIntoView(index, 'smooth');
+        }
+    }, [messageIndexMap, scrollHistoryIndexIntoView]);
+
+    React.useLayoutEffect(() => {
         if (!ref) {
             return;
         }
@@ -1730,6 +1805,8 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
                             onUserAnimationConsumed={onUserAnimationConsumed}
                             activeStreamingPhase={activeStreamingPhase}
                             reviewTransferDirection={reviewTransferDirection}
+                            userNavigationById={userNavigationById}
+                            scrollToUserMessage={scrollToUserMessage}
                         />
                         {trailingStreamingEntry ? (
                             <StreamingTailContent
@@ -1748,6 +1825,8 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
                                 activeStreamingMessageId={activeStreamingMessageId}
                                 activeStreamingPhase={activeStreamingPhase}
                                 reviewTransferDirection={reviewTransferDirection}
+                                userNavigationById={userNavigationById}
+                                scrollToUserMessage={scrollToUserMessage}
                             />
                         ) : null}
                     </div>

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -366,6 +366,8 @@ interface MessageBodyProps {
     userActionsMode?: 'inline' | 'external-content' | 'external-actions';
     stickyUserHeaderEnabled?: boolean;
     reviewTransferDirection?: ReviewTransferDirection | null;
+    onScrollToMessage?: (target: 'prev' | 'next' | 'self-top') => void;
+    userMessageNavInfo?: import('../MessageList').UserMessageNavInfo;
 }
 
 const TOOL_REVEAL_CACHE_MAX = 200;
@@ -386,7 +388,7 @@ const writeRevealedToolIds = (messageId: string, value: Set<string>): void => {
     revealedToolIdsByMessage.set(messageId, new Set(value));
 };
 
-const UserMessageBody = React.memo(({ messageId, parts, isMobile, alwaysShowActions = isMobile, hasTouchInput, hasTextContent, onCopyMessage, copiedMessage, onShowPopup, agentMention, onRevert, onFork, userActionsMode = 'inline', stickyUserHeaderEnabled = true }: {
+const UserMessageBody = React.memo(({ messageId, parts, isMobile, alwaysShowActions = isMobile, hasTouchInput, hasTextContent, onCopyMessage, copiedMessage, onShowPopup, agentMention, onRevert, onFork, onScrollToMessage, userMessageNavInfo, userActionsMode = 'inline', stickyUserHeaderEnabled = true }: {
     messageId: string;
     parts: Part[];
     isMobile: boolean;
@@ -399,6 +401,8 @@ const UserMessageBody = React.memo(({ messageId, parts, isMobile, alwaysShowActi
     agentMention?: AgentMentionInfo;
     onRevert?: () => void;
     onFork?: () => void;
+    onScrollToMessage?: (target: 'prev' | 'next' | 'self-top') => void;
+    userMessageNavInfo?: import('../MessageList').UserMessageNavInfo;
     userActionsMode?: 'inline' | 'external-content' | 'external-actions';
     stickyUserHeaderEnabled?: boolean;
 }) => {
@@ -432,6 +436,9 @@ const UserMessageBody = React.memo(({ messageId, parts, isMobile, alwaysShowActi
     const showUserContent = userActionsMode !== 'external-actions';
     const showUserActions = userActionsMode !== 'external-content';
     const useStickyScrollableUserContent = stickyUserHeaderEnabled && userActionsMode === 'inline';
+    const hasPrevSibling = Boolean(userMessageNavInfo?.previousUserMessageId);
+    const hasNextSibling = Boolean(userMessageNavInfo?.nextUserMessageId);
+    const hasNavActions = Boolean(onScrollToMessage);
 
     const clearCopyHintTimeout = React.useCallback(() => {
         if (copyHintTimeoutRef.current !== null && typeof window !== 'undefined') {
@@ -478,7 +485,8 @@ const UserMessageBody = React.memo(({ messageId, parts, isMobile, alwaysShowActi
     );
 
     const effectiveOnFork = chatSurfaceMode === 'mini-chat' ? undefined : onFork;
-    const actionsBlock = ((canCopyMessage && hasCopyableText) || onRevert || effectiveOnFork) && showUserActions ? (
+    const hasAnyActions = (canCopyMessage && hasCopyableText) || Boolean(onRevert) || Boolean(effectiveOnFork) || hasNavActions;
+    const actionsBlock = hasAnyActions && showUserActions ? (
         <div className={cn(
             'group/user-actions',
             isMobile
@@ -488,95 +496,137 @@ const UserMessageBody = React.memo(({ messageId, parts, isMobile, alwaysShowActi
                         ? 'flex h-9 items-start justify-end pt-0'
                         : 'flex h-11 items-start justify-end pt-0'
                 : userActionsMode === 'inline'
-                    ? 'absolute top-full left-0 right-0 z-10 pt-5'
+                    ? 'absolute top-full right-0 z-10 pt-5 w-max'
                     : 'flex h-8 items-start justify-end pt-2'
         )}>
             <div
                 className={cn(
-                    'flex items-center justify-end gap-1',
-                    isMobile
-                        ? userActionsMode === 'inline'
-                            ? 'translate-x-5'
-                            : 'translate-x-0'
-                        : userActionsMode === 'inline'
-                            ? 'translate-x-5'
-                            : 'translate-x-0',
+                    'flex items-center gap-1 w-full',
+                    !isMobile && userActionsMode === 'inline' && 'justify-between',
                     alwaysShowActions
                         ? 'pointer-events-auto opacity-100'
                         : 'pointer-events-none opacity-0 transition-opacity duration-150 group-hover/message:pointer-events-auto group-hover/message:opacity-100 group-hover/user-actions:pointer-events-auto group-hover/user-actions:opacity-100 group-hover/user-shell:pointer-events-auto group-hover/user-shell:opacity-100'
                 )}
             >
-                {onRevert && (
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="h-6 w-6 text-muted-foreground bg-transparent hover:text-foreground hover:!bg-transparent active:!bg-transparent focus-visible:!bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
-                                aria-label={t('chat.messageBody.actions.revertAria')}
-                                onPointerDown={(event) => event.stopPropagation()}
-                                onClick={(event) => {
-                                    event.stopPropagation();
-                                    onRevert();
-                                }}
-                            >
-                                <Icon name="arrow-go-back" className="h-3 w-3" />
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent sideOffset={6}>{t('chat.messageBody.actions.revert')}</TooltipContent>
-                    </Tooltip>
+                {hasNavActions && (
+                    <div className="flex items-center gap-1">
+                        {hasPrevSibling && (
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-6 w-6 text-muted-foreground bg-transparent hover:text-foreground hover:!bg-transparent active:!bg-transparent focus-visible:!bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
+                                        aria-label={t('chat.userText.previous')}
+                                        onPointerDown={(event) => event.stopPropagation()}
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            onScrollToMessage?.('prev');
+                                        }}
+                                    >
+                                        <Icon name="arrow-up-s" className="h-4 w-4" />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent sideOffset={6}>{t('chat.userText.previous')}</TooltipContent>
+                            </Tooltip>
+                        )}
+                        {hasNextSibling && (
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-6 w-6 text-muted-foreground bg-transparent hover:text-foreground hover:!bg-transparent active:!bg-transparent focus-visible:!bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
+                                        aria-label={t('chat.userText.next')}
+                                        onPointerDown={(event) => event.stopPropagation()}
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            onScrollToMessage?.('next');
+                                        }}
+                                    >
+                                        <Icon name="arrow-down-s" className="h-4 w-4" />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent sideOffset={6}>{t('chat.userText.next')}</TooltipContent>
+                            </Tooltip>
+                        )}
+                    </div>
                 )}
-                {effectiveOnFork && (
+                <div className="flex items-center gap-1">
+                    {onRevert && (
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="h-6 w-6 text-muted-foreground bg-transparent hover:text-foreground hover:!bg-transparent active:!bg-transparent focus-visible:!bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
-                                aria-label={t('chat.messageBody.actions.forkAria')}
-                                onPointerDown={(event) => event.stopPropagation()}
-                                onClick={(event) => {
-                                    event.stopPropagation();
-                                    effectiveOnFork();
-                                }}
-                            >
-                                <Icon name="git-branch" className="h-3 w-3" />
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent sideOffset={6}>{t('chat.messageBody.actions.fork')}</TooltipContent>
-                    </Tooltip>
-                )}
-                {canCopyMessage && hasCopyableText && (
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                data-visible={copyHintVisible || isMessageCopied ? 'true' : undefined}
-                                className="h-6 w-6 text-muted-foreground bg-transparent hover:text-foreground hover:!bg-transparent active:!bg-transparent focus-visible:!bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
-                                aria-label={t('chat.messageBody.actions.copyMessageAria')}
-                                onPointerDown={(event) => event.stopPropagation()}
-                                onClick={handleCopyButtonClick}
-                                onFocus={() => setCopyHintVisible(true)}
-                                onBlur={() => {
-                                    if (!isMessageCopied) {
-                                        setCopyHintVisible(false);
-                                    }
-                                }}
-                            >
-                                {isMessageCopied ? (
-                                    <Icon name="check" className="h-3 w-3 text-[color:var(--status-success)]" />
-                                ) : (
-                                    <Icon name="file-copy" className="h-3 w-3" />
-                                )}
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent sideOffset={6}>{t('chat.messageBody.actions.copyMessage')}</TooltipContent>
-                    </Tooltip>
-                )}
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-6 w-6 text-muted-foreground bg-transparent hover:text-foreground hover:!bg-transparent active:!bg-transparent focus-visible:!bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
+                                    aria-label={t('chat.messageBody.actions.revertAria')}
+                                    onPointerDown={(event) => event.stopPropagation()}
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        onRevert();
+                                    }}
+                                >
+                                    <Icon name="arrow-go-back" className="h-3 w-3" />
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent sideOffset={6}>{t('chat.messageBody.actions.revert')}</TooltipContent>
+                        </Tooltip>
+                    )}
+                    {effectiveOnFork && (
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-6 w-6 text-muted-foreground bg-transparent hover:text-foreground hover:!bg-transparent active:!bg-transparent focus-visible:!bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
+                                    aria-label={t('chat.messageBody.actions.forkAria')}
+                                    onPointerDown={(event) => event.stopPropagation()}
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        effectiveOnFork();
+                                    }}
+                                >
+                                    <Icon name="git-branch" className="h-3 w-3" />
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent sideOffset={6}>{t('chat.messageBody.actions.fork')}</TooltipContent>
+                        </Tooltip>
+                    )}
+                    {canCopyMessage && hasCopyableText && (
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    data-visible={copyHintVisible || isMessageCopied ? 'true' : undefined}
+                                    className="h-6 w-6 text-muted-foreground bg-transparent hover:text-foreground hover:!bg-transparent active:!bg-transparent focus-visible:!bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
+                                    aria-label={t('chat.messageBody.actions.copyMessageAria')}
+                                    onPointerDown={(event) => event.stopPropagation()}
+                                    onClick={handleCopyButtonClick}
+                                    onFocus={() => setCopyHintVisible(true)}
+                                    onBlur={() => {
+                                        if (!isMessageCopied) {
+                                            setCopyHintVisible(false);
+                                        }
+                                    }}
+                                >
+                                    {isMessageCopied ? (
+                                        <Icon name="check" className="h-3 w-3 text-[color:var(--status-success)]" />
+                                    ) : (
+                                        <Icon name="file-copy" className="h-3 w-3" />
+                                    )}
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent sideOffset={6}>{t('chat.messageBody.actions.copyMessage')}</TooltipContent>
+                        </Tooltip>
+                    )}
+                </div>
             </div>
         </div>
     ) : null;
@@ -2107,6 +2157,8 @@ const MessageBody = React.memo(({ isUser, ...props }: MessageBodyProps) => {
                 agentMention={props.agentMention}
                 onRevert={props.onRevert}
                 onFork={props.onFork}
+                onScrollToMessage={props.onScrollToMessage}
+                userMessageNavInfo={props.userMessageNavInfo}
                 userActionsMode={props.userActionsMode}
                 stickyUserHeaderEnabled={props.stickyUserHeaderEnabled}
             />

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1964,6 +1964,8 @@ export const dict = {
   'chat.messageBody.shellCommand.showOutput': 'Show output',
   'chat.messageBody.shellCommand.copied': 'Copied',
   'chat.messageBody.shellCommand.copyOutput': 'Copy output',
+  'chat.userText.previous': 'Previous message',
+  'chat.userText.next': 'Next message',
   'commandPalette.title': 'Command Palette',
   'commandPalette.description': 'Search files, sessions, and commands.',
   'commandPalette.input.placeholder': 'Search files, sessions, commands...',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1930,6 +1930,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.messageBody.shellCommand.showOutput": "Mostrar salida",
   "chat.messageBody.shellCommand.copied": "Copiado",
   "chat.messageBody.shellCommand.copyOutput": "Copiar salida",
+  "chat.userText.previous": "Mensaje anterior",
+  "chat.userText.next": "Siguiente mensaje",
   "commandPalette.title": "Paleta de comandos",
   "commandPalette.description": "Buscar archivos, sesiones y comandos.",
   "commandPalette.input.placeholder": "Buscar archivos, sesiones, comandos...",

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1964,6 +1964,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.messageBody.shellCommand.showOutput': '표시 출력',
   'chat.messageBody.shellCommand.copied': '복사됨',
   'chat.messageBody.shellCommand.copyOutput': '출력 복사',
+  'chat.userText.previous': '이전 메시지',
+  'chat.userText.next': '다음 메시지',
   'commandPalette.title': '명령 팔레트',
   'commandPalette.description': '파일, 세션, 명령을 검색합니다.',
   'commandPalette.input.placeholder': '파일, 세션, 명령 검색…',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1214,6 +1214,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.toolPart.copyOutput': 'Kopiuj wyjście',
   'chat.toolPart.copiedOutput': 'Skopiowano wyjście',
   'chat.toolPart.copyOutputFailed': 'Nie udało się skopiować wyjścia',
+  'chat.userText.previous': 'Poprzednia wiadomość',
+  'chat.userText.next': 'Następna wiadomość',
   'commandPalette.description': 'Szukaj plików, sesji i poleceń.',
   'commandPalette.empty.noResults': 'Nie znaleziono wyników.',
   'commandPalette.empty.searchingFiles': 'Wyszukiwanie plików...',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1930,6 +1930,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.messageBody.shellCommand.showOutput": "Mostrar saída",
   "chat.messageBody.shellCommand.copied": "Copiado",
   "chat.messageBody.shellCommand.copyOutput": "Copiar saída",
+  "chat.userText.previous": "Mensagem anterior",
+  "chat.userText.next": "Próxima mensagem",
   "commandPalette.title": "Paleta de comandos",
   "commandPalette.description": "Buscar arquivos, sessões e comandos.",
   "commandPalette.input.placeholder": "Buscar arquivos, sessões, comandos...",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1930,6 +1930,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.messageBody.shellCommand.showOutput": "Показати результат",
   "chat.messageBody.shellCommand.copied": "Скопійовано",
   "chat.messageBody.shellCommand.copyOutput": "Копіювати вивід",
+  "chat.userText.previous": "Попереднє повідомлення",
+  "chat.userText.next": "Наступне повідомлення",
   "commandPalette.title": "Палітра команд",
   "commandPalette.description": "Пошук файлів, сесій і команд.",
   "commandPalette.input.placeholder": "Пошук файлів, сесій, команд...",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1930,6 +1930,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.messageBody.shellCommand.showOutput': '显示输出',
   'chat.messageBody.shellCommand.copied': '已复制',
   'chat.messageBody.shellCommand.copyOutput': '复制输出',
+  'chat.userText.previous': '上一条消息',
+  'chat.userText.next': '下一条消息',
   'commandPalette.title': '命令面板',
   'commandPalette.description': '搜索文件、会话和命令。',
   'commandPalette.input.placeholder': '搜索文件、会话、命令...',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1934,6 +1934,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.messageBody.shellCommand.showOutput': '顯示輸出',
   'chat.messageBody.shellCommand.copied': '已複製',
   'chat.messageBody.shellCommand.copyOutput': '複製輸出',
+  'chat.userText.previous': '上一條訊息',
+  'chat.userText.next': '下一條訊息',
   'commandPalette.title': '命令面板',
   'commandPalette.description': '搜尋檔案、會話和命令。',
   'commandPalette.input.placeholder': '搜尋檔案、會話、命令...',


### PR DESCRIPTION
## Summary

Improves long user-message handling in the chat:

- deterministic collapsed previews for long user messages;
- scrollable expanded user-message content;
- inline Previous/Next controls for jumping between user prompts.

## Why

Long agent sessions often contain large user prompts separated by many assistant
responses. Reviewing these sessions is difficult when user prompts take over the
viewport or when users have to scroll manually between their own messages.

This PR makes user messages easier to scan, expand, scroll, and navigate without
leaving the current message context.

## Changes

### Long user-message collapse

- Adds deterministic plain-text previews for collapsible user text parts.
- Shows a `+N lines` hint for collapsed long user messages.
- Adds a collapse affordance when a user text part is expanded.
- Avoids relying on CSS line clamping for markdown/block-level content.

### Scrollable expanded user messages

- Keeps expanded long user-message content scrollable instead of letting it take
  over the viewport.
- Preserves existing message actions while keeping long prompts manageable.

### Inline user-message navigation

- Adds inline Previous/Next controls on user messages.
- Computes Previous/Next targets from the message data model, not from rendered
  DOM siblings.
- Uses the existing virtualizer-backed scroll path, so navigation works even
  when the target user message is not currently mounted.
- Ignores assistant messages when navigating between user prompts.
- Keeps navigation controls visually separated from existing message actions:
  Previous/Next are grouped on the left, while Revert/Fork/Copy/Collapse remain
  on the right.

## Relation to #1583

#1583 adds a global/floating affordance for jumping to the last user message.

This PR focuses on inline per-message review controls: from a given user prompt,
jump to the previous/next user prompt while keeping the current message context.

The two approaches are related but not identical, and can be complementary.

<img width="1034" height="235" alt="pr1584-prev-next" src="https://github.com/user-attachments/assets/ecb0c25b-567e-466d-a585-40e0aa9b1ca0" />
