### PR TITLE
fix: prevent worktree modal from disappearing after opening

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -183,7 +183,8 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
   const [projectRepoStatus, setProjectRepoStatus] = React.useState<Map<string, boolean | null>>(new Map());
   const [visibleSessionCountByGroup, setVisibleSessionCountByGroup] = React.useState<Map<string, number>>(new Map());
-  const [newWorktreeDialogOpen, setNewWorktreeDialogOpen] = React.useState(false);
+  const newWorktreeDialogOpen = useUIStore((state) => state.isNewWorktreeDialogOpen);
+  const setNewWorktreeDialogOpen = useUIStore((state) => state.setNewWorktreeDialogOpen);
   const [updateDialogOpen, setUpdateDialogOpen] = React.useState(false);
   const [openSidebarMenuKey, setOpenSidebarMenuKey] = React.useState<string | null>(null);
   const [renamingFolderId, setRenamingFolderId] = React.useState<string | null>(null);
@@ -537,7 +538,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
   const openNewWorktreeDialog = React.useCallback(() => {
     setNewWorktreeDialogOpen(true);
-  }, []);
+  }, [setNewWorktreeDialogOpen]);
 
   const handleOpenUpdateDialog = React.useCallback(() => {
     const current = useUpdateStore.getState();

--- a/packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx
+++ b/packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx
@@ -181,7 +181,6 @@ export function SidebarProjectsList(props: Props): React.ReactNode {
                     onNewWorktreeSession={() => {
                       if (projectKey !== props.activeProjectId) props.setActiveProjectIdOnly(projectKey);
                       props.setActiveMainTab('chat');
-                      if (props.mobileVariant) props.setSessionSwitcherOpen(false);
                       props.openNewWorktreeDialog();
                     }}
                     onRenameStart={() => props.openProjectEditDialog(projectKey)}

--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
@@ -3,6 +3,7 @@ import type { Session } from '@opencode-ai/sdk/v2';
 import type { SessionGroup, SessionNode } from '../types';
 import { normalizePath } from '../utils';
 import type { MainTab } from '@/stores/useUIStore';
+import { useUIStore } from '@/stores/useUIStore';
 
 type ProjectSection = {
   project: { id: string; normalizedPath: string };
@@ -90,6 +91,10 @@ export const useProjectSessionSelection = (args: Args): { currentSessionDirector
     }
 
     if (newSessionDraftOpen) {
+      return;
+    }
+
+    if (useUIStore.getState().isNewWorktreeDialogOpen) {
       return;
     }
 

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -536,6 +536,7 @@ interface UIStore {
   isSessionCreateDialogOpen: boolean;
   isScheduledTasksDialogOpen: boolean;
   isSettingsDialogOpen: boolean;
+  isNewWorktreeDialogOpen: boolean;
   isModelSelectorOpen: boolean;
   sidebarSection: SidebarSection;
 
@@ -683,6 +684,7 @@ interface UIStore {
   setSessionCreateDialogOpen: (open: boolean) => void;
   setScheduledTasksDialogOpen: (open: boolean) => void;
   setSettingsDialogOpen: (open: boolean) => void;
+  setNewWorktreeDialogOpen: (open: boolean) => void;
   setModelSelectorOpen: (open: boolean) => void;
   applyTheme: () => void;
   setSidebarSection: (section: SidebarSection) => void;
@@ -822,6 +824,7 @@ export const useUIStore = create<UIStore>()(
         isSessionCreateDialogOpen: false,
         isScheduledTasksDialogOpen: false,
         isSettingsDialogOpen: false,
+        isNewWorktreeDialogOpen: false,
         isModelSelectorOpen: false,
         sidebarSection: 'sessions',
         settingsPage: 'home',
@@ -1490,6 +1493,10 @@ export const useUIStore = create<UIStore>()(
             }
             return { isSettingsDialogOpen: true, settingsHasOpenedOnce: true };
           });
+        },
+
+        setNewWorktreeDialogOpen: (open) => {
+          set({ isNewWorktreeDialogOpen: open });
         },
 
         setModelSelectorOpen: (open) => {


### PR DESCRIPTION
# What

Prevents the new worktree modal from briefly appearing then immediately disappearing.

# Why

The worktree dialog state (`newWorktreeDialogOpen`) was local React state in `SessionSidebar`. When the component unmounted (mobile drawer closing, VSCode view switching), the state was destroyed and the modal disappeared.

Closes #1414

# How to test

1. Open the session sidebar
2. Click the worktree button to open the new worktree modal
3. Verify the modal stays open and does not disappear
4. On mobile: repeat and verify the sidebar drawer does not auto-close
5. Switch to a different project that has no sessions, then open the worktree modal
6. Verify the modal still stays open (layout effect should not auto-select a session)

# Acceptance criteria coverage

- [x] Worktree modal remains visible and functional after opening
- [x] Worktree modal does not close or disappear without explicit user action
- [ ] Regression test added to prevent this from recurring

# Changes

- **`useUIStore.ts`**: Add `isNewWorktreeDialogOpen` / `setNewWorktreeDialogOpen` to global store
- **`SessionSidebar.tsx`**: Read worktree dialog state from `useUIStore` instead of local `useState`
- **`SidebarProjectsList.tsx`**: Remove `setSessionSwitcherOpen(false)` from worktree button handler on mobile (was causing sidebar unmount)
- **`useProjectSessionSelection.ts`**: Guard layout effect to skip when worktree dialog is open (prevents auto-session-selection from interfering)