### PR TITLE
chore: bump better-sqlite3 from ^11.7.0 to ^12.10.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -249,7 +249,7 @@
         "@opencode-ai/sdk": "^1.16.0",
         "@simplewebauthn/server": "13.3.0",
         "adm-zip": "^0.5.16",
-        "better-sqlite3": "^11.7.0",
+        "better-sqlite3": "^12.10.0",
         "bun-pty": "^0.4.5",
         "compression": "^1.8.1",
         "cron-parser": "^4.9.0",
@@ -1519,7 +1519,7 @@
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
-    "better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
+    "better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
     "@opencode-ai/sdk": "^1.16.0",
     "@simplewebauthn/server": "13.3.0",
     "adm-zip": "^0.5.16",
-    "better-sqlite3": "^11.7.0",
+    "better-sqlite3": "^12.10.0",
     "bun-pty": "^0.4.5",
     "compression": "^1.8.1",
     "cron-parser": "^4.9.0",


### PR DESCRIPTION
# What

Bumps `better-sqlite3` from `^11.7.0` to `^12.10.0` in `packages/web`.

# Why

Keep the dependency up to date. v12 brings performance improvements and Node.js compatibility updates.
v11 also doesn't have Node >23 prebuilt binaries which means every time someone would `bun install` with a recent node version it would build the sqlite3 binary.

# How to test

1. `bun install` succeeds
2. `bun run type-check` passes
3. `bun run lint` passes