### PR TITLE
Fix font-size/padding not applying in VFix font-size/padding not applying in VS Code (#1261)S Code (#1261)

### DIFF
--- a/packages/ui/src/lib/device.ts
+++ b/packages/ui/src/lib/device.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isDesktopShell } from '@/lib/desktop';
+import { isDesktopShell, isVSCodeRuntime } from '@/lib/desktop';
 
 export type DeviceType = 'desktop' | 'mobile' | 'tablet';
 
@@ -108,7 +108,8 @@ export function getDeviceInfo(): DeviceInfo {
   const prefersCoarsePointer = pointerQuery?.matches ?? false;
   const noHover = hoverQuery?.matches ?? false;
   const maxTouchPoints = typeof navigator !== 'undefined' ? navigator.maxTouchPoints ?? 0 : 0;
-  const isDesktopShellRuntime = isDesktopShell();
+  // VS Code is a desktop surface — don't misdetect a narrow panel as mobile (#1261)
+  const isDesktopShellRuntime = isDesktopShell() || isVSCodeRuntime();
   const { isExplicitTablet } = getNavigatorDeviceHints(maxTouchPoints);
 
   const hasTouchInput = prefersCoarsePointer || noHover || maxTouchPoints > 0;


### PR DESCRIPTION
## Problem
Closes #1261. In the VS Code extension, font-size and padding settings had
no effect when the panel was narrow.

## Root cause
`getDeviceInfo()` only exempted the Electron shell from mobile detection,
not the VS Code runtime. On a touch-capable machine a narrow panel (≤768px)
was classified as mobile, which adds the `mobile-pointer` class to `<html>`.
That triggers `mobile.css` rules like
`:root.mobile-pointer:not(.desktop-runtime) * { --text-markdown: 1rem !important }`,
and those `!important` overrides beat the inline `:root` styles written by
`applyTypography`/`applyPadding` — so user settings were ignored.

## Fix
Treat the VS Code runtime like the desktop shell in `getDeviceInfo()`,
matching how Electron is already handled. VS Code's own responsive layout
(`VSCodeLayout`, a `ResizeObserver`-based compact mode) is independent of
device detection and is unaffected.

## Testing
Reproduced in a browser with the real `mobile.css`: with `mobile-pointer`
set and viewport at 360px, the rendered font-size stays locked at 16px
regardless of the font-size setting; after the fix it scales correctly
(22.5px at 150%, 30px at 200%).