### PR TITLE
fix(docker): update workspace path to packages/electron after Tauri removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package.json bun.lock ./
 COPY packages/ui/package.json ./packages/ui/
 COPY packages/web/package.json ./packages/web/
-COPY packages/desktop/package.json ./packages/desktop/
+COPY packages/electron/package.json ./packages/electron/
 COPY packages/vscode/package.json ./packages/vscode/
 RUN bun install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
## Summary

Commit 024834fc replaced `packages/desktop/` with `packages/electron/`,
but the Dockerfile still references the old workspace path.

Since `bun.lock` already references `packages/electron/`,
`bun install --frozen-lockfile` fails during Docker builds because the
workspace structure inside the image does not match the lockfile.

This updates the Dockerfile to copy the new Electron workspace path.

Closes #1496