### PR TITLE
Fix recursive nested subagent expansion in the session sidebar

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -66,6 +66,7 @@ import {
 import { useActiveNowStore } from '@/stores/useActiveNowStore';
 import { useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
 import {
+  collectSessionAncestorIds,
   compareSessionsByPinnedAndTime,
   formatProjectLabel,
   normalizePath,
@@ -645,21 +646,19 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     sessionEvents.requestDirectoryDialog();
   }, []);
 
-  // Auto-expand parent session when navigating to a subagent (child) session.
-  // We don't know which render context the user will look at the parent in
-  // (Recent, project root, archived bucket, ...), so fan out across all
-  // four combinations to ensure it's expanded wherever it appears.
+  // Auto-expand the full ancestor chain when navigating to a nested subagent.
+  // We do not know which render context the user will look at the ancestors
+  // in (Recent, project root, archived bucket, ...), so fan out across all
+  // four combinations to ensure the whole path is visible wherever it appears.
   React.useEffect(() => {
-    if (!currentSessionId) return;
-    const current = sessions.find((s) => s.id === currentSessionId);
-    const parentID = (current as Session & { parentID?: string | null })?.parentID;
-    if (!parentID) return;
-    const keysToAdd = [
-      `project:active:${parentID}`,
-      `project:archived:${parentID}`,
-      `recent:active:${parentID}`,
-      `recent:archived:${parentID}`,
-    ];
+    const ancestorIds = collectSessionAncestorIds(currentSessionId, sessions);
+    if (ancestorIds.length === 0) return;
+    const keysToAdd = ancestorIds.flatMap((ancestorId) => ([
+      `project:active:${ancestorId}`,
+      `project:archived:${ancestorId}`,
+      `recent:active:${ancestorId}`,
+      `recent:archived:${ancestorId}`,
+    ]));
     setExpandedParents((prev) => {
       if (keysToAdd.every((k) => prev.has(k))) return prev;
       const next = new Set(prev);

--- a/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
+++ b/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
@@ -9,6 +9,7 @@
 - Active/hover row styling is text-first; selected sessions use primary text instead of background fills.
 - Archived groups are collapsed by default and support bulk deletion at group/folder level.
 - Session rows support compact inline dates in minimal mode and simplified metadata in default mode.
+- Nested subagent rows use depth-aware indentation at any depth, and selecting a nested subagent auto-expands its full ancestor chain in both project and recent contexts.
 - New extractions in latest pass reduced local effect/callback bulk further:
   - project session list builders
   - folder cleanup sync
@@ -49,4 +50,4 @@
 
 - `types.ts`: Shared sidebar types (`SessionNode`, `SessionGroup`, summary/search metadata).
 - `activitySections.ts`: Persisted top-section storage/helpers for the current `recent` session list.
-- `utils.tsx`: Shared sidebar utilities (path normalization, sorting, dedupe, archived scope keys, project relation checks, text highlight, labels, compact/default date formatting).
+- `utils.tsx`: Shared sidebar utilities (path normalization, tree-indent/ancestor helpers, sorting, dedupe, archived scope keys, project relation checks, text highlight, labels, compact/default date formatting).

--- a/packages/ui/src/components/session/sidebar/NESTED_SUBAGENT_IMPLEMENTATION.md
+++ b/packages/ui/src/components/session/sidebar/NESTED_SUBAGENT_IMPLEMENTATION.md
@@ -1,0 +1,199 @@
+# Nested subagent sidebar implementation
+
+## Purpose
+
+This document explains the nested subagent sidebar fix so it can be reapplied after upstream updates.
+
+The intended behavior is:
+
+- subagents stay expandable from their parent session row at any nesting depth
+- nested subagents remain visible and explorable throughout the sidebar tree
+- the implementation stays recursive because the existing tree model already is
+
+## User-facing problem
+
+The sidebar already stored sessions as a recursive tree, but nested subagents were not reliably explorable in practice.
+
+The visible symptoms were:
+
+1. Clicking a parent subagent chevron could appear to do nothing when the real target was a deeper nested descendant.
+2. Deeper nested rows rendered with the same left indent as first-level subagents, so the tree looked visually flat past the first nesting level.
+3. When the active session was itself nested, only the direct parent was auto-expanded, so the full path to the active node could remain hidden.
+
+## Root cause
+
+The problem was not the data model. `SessionNode.children` already supports recursive nesting.
+
+The real issues were in presentation and memoization:
+
+1. `SessionNodeItem.tsx` used a single `depth > 0` padding rule, so every nested row beyond depth 0 shared the same left indent.
+2. `SessionSidebar.tsx` only auto-expanded the direct parent of the active session instead of the full ancestor chain.
+3. `SessionNodeItem.tsx` is memoized, and its comparator only checked the current row's own expansion key. Ancestor rows therefore could skip rerendering when a deeper descendant expansion key changed.
+
+## Files changed
+
+### Core behavior
+
+- `packages/ui/src/components/session/sidebar/utils.tsx`
+- `packages/ui/src/components/session/sidebar/SessionNodeItem.tsx`
+- `packages/ui/src/components/session/SessionSidebar.tsx`
+
+### Tests
+
+- `packages/ui/src/components/session/sidebar/utils.test.ts`
+
+### Documentation
+
+- `packages/ui/src/components/session/sidebar/DOCUMENTATION.md`
+- `packages/ui/src/components/session/sidebar/NESTED_SUBAGENT_IMPLEMENTATION.md`
+
+## Implementation details
+
+### 1. Add reusable tree helpers in `utils.tsx`
+
+Added:
+
+- `getSessionTreeIndentPx(depth)`
+- `getSessionParentId(session)`
+- `collectSessionAncestorIds(sessionId, sessions)`
+- `treeHasExpansionStateChange(node, previousExpandedParents, nextExpandedParents, renderContext, archivedBucket)`
+
+These helpers cover:
+
+- depth-aware row indentation
+- walking parent -> grandparent -> ... safely
+- cycle protection for malformed parent graphs
+- subtree-aware rerender detection when nested expansion keys change
+
+### 2. Make indentation truly depth-aware in `SessionNodeItem.tsx`
+
+The old behavior effectively treated every nested row as:
+
+```tsx
+depth > 0 && 'pl-[20px]'
+```
+
+That means:
+
+- depth 1 -> 20px
+- depth 2 -> still 20px
+
+The fix computes `rowPaddingLeft = getSessionTreeIndentPx(depth)` and applies it to both:
+
+- the inline rename row
+- the normal rendered session row
+
+This keeps root rows aligned with their existing base padding while letting each additional level step deeper.
+
+### 3. Auto-expand the full ancestor chain in `SessionSidebar.tsx`
+
+The old effect expanded only:
+
+```ts
+current.parentID
+```
+
+The fixed effect expands:
+
+```ts
+collectSessionAncestorIds(currentSessionId, sessions)
+```
+
+and then fans every ancestor ID out across all expansion contexts:
+
+```ts
+project:active
+project:archived
+recent:active
+recent:archived
+```
+
+This matters for trees like:
+
+```text
+root session
+  level-1 subagent
+    level-2 nested subagent
+      level-3 nested subagent
+```
+
+Revealing a deep nested subagent requires every ancestor to be expanded. Expanding only the direct parent is not enough.
+
+### 4. Keep memoized rows responsive to nested expansion changes
+
+`SessionNodeItem.tsx` uses `React.memo(...)` with a custom comparator.
+
+If the comparator only checks the current row's own expansion key, then toggling a deeper descendant can update state without forcing the ancestor row to rerender. The UI symptom is that clicking a nested chevron appears broken until some unrelated state change refreshes the tree.
+
+The fix is to call `treeHasExpansionStateChange(...)` inside the comparator so any expansion-key change anywhere in the rendered subtree invalidates that memoized row.
+
+## What was intentionally not changed
+
+1. **The recursive session tree model was not rewritten.**
+   `SessionNode.children` already supported nested subagents.
+
+2. **No backend or runtime API changes were added.**
+   This is a sidebar rendering/state fix only.
+
+3. **The UI is not hard-coded to any fixed nesting depth.**
+   The safest implementation is depth-aware and recursive, so future deeper delegation chains remain explorable without special cases.
+
+4. **Expansion keys remain render-context-specific.**
+   The same session can appear in project and recent views, and those expansion states must stay independent.
+
+## Reapply checklist
+
+If nested subagents stop being explorable again after an upstream update:
+
+1. Open `packages/ui/src/components/session/sidebar/SessionNodeItem.tsx`
+   - restore depth-based row padding if a single nested padding class was reintroduced
+   - restore subtree-aware expansion invalidation in the memo comparator
+
+2. Open `packages/ui/src/components/session/SessionSidebar.tsx`
+   - restore ancestor-chain auto-expansion if the effect goes back to direct-parent-only logic
+
+3. Open `packages/ui/src/components/session/sidebar/utils.tsx`
+   - restore the tree indent, parent lookup, ancestor collection, and subtree expansion helpers
+
+4. Open `packages/ui/src/components/session/sidebar/utils.test.ts`
+   - restore tests for indent depth, ancestor collection, cycle safety, and nested expansion invalidation
+
+5. Update `packages/ui/src/components/session/sidebar/DOCUMENTATION.md`
+   - keep the short note about depth-aware nested subagents and ancestor auto-expansion
+
+## Validation commands
+
+Run from the repository root:
+
+```bash
+bun test packages\ui\src\components\session\sidebar\utils.test.ts
+bun run type-check
+bun run lint
+bun run build
+```
+
+## Expected result
+
+- the targeted sidebar utils test passes
+- workspace type-check passes
+- workspace lint passes
+- workspace build passes
+
+## Quick acceptance test
+
+Use a tree shaped like:
+
+```text
+root session
+  level-1 subagent
+    level-2 nested subagent
+      level-3 nested subagent
+```
+
+Expected behavior:
+
+1. The root session can expand.
+2. The level-1 session can expand.
+3. The level-2 session renders with a deeper visible indent than level 1.
+4. The level-3 session renders with a deeper visible indent than level 2.
+5. If the active session is deeply nested, the sidebar auto-reveals the full path to it.

--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -26,7 +26,15 @@ import { useSync } from '@/sync/use-sync';
 import { useViewportStore, viewportSessionKey } from '@/sync/viewport-store';
 import { DraggableSessionRow } from './sessionFolderDnd';
 import type { SessionNode, SessionSummaryMeta } from './types';
-import { formatSessionCompactDateLabel, formatSessionDateLabel, normalizePath, renderHighlightedText, resolveSessionDiffStats } from './utils';
+import {
+  formatSessionCompactDateLabel,
+  formatSessionDateLabel,
+  getSessionTreeIndentPx,
+  normalizePath,
+  renderHighlightedText,
+  resolveSessionDiffStats,
+  treeHasExpansionStateChange,
+} from './utils';
 import { useSessionDisplayStore } from '@/stores/useSessionDisplayStore';
 import { useSessionUnseenCount } from '@/sync/notification-store';
 import { useSessionMultiSelectStore } from '@/stores/useSessionMultiSelectStore';
@@ -154,6 +162,9 @@ const areEqual = (prev: Props, next: Props): boolean => {
   if (prev.groupDirectory !== next.groupDirectory) return false;
   if (prev.projectId !== next.projectId) return false;
   if (prev.archivedBucket !== next.archivedBucket) return false;
+  const prevRenderContext = prev.renderContext ?? 'project';
+  const nextRenderContext = next.renderContext ?? 'project';
+  if (prevRenderContext !== nextRenderContext) return false;
   if (prev.currentSessionId !== next.currentSessionId) {
     const prevActiveInTree = treeContainsSessionId(prev.node, prev.currentSessionId);
     const nextActiveInTree = treeContainsSessionId(next.node, next.currentSessionId);
@@ -162,18 +173,16 @@ const areEqual = (prev: Props, next: Props): boolean => {
     }
   }
   if (prev.pinnedSessionIds.has(prevSessionId) !== next.pinnedSessionIds.has(nextSessionId)) return false;
-  // Expansion is keyed per render context, so compare the composite key
-  // matching the one isExpanded reads from in render. If a session appears
-  // in two contexts (project + recent), they have independent state.
-  {
-    const prevRenderContext = prev.renderContext ?? 'project';
-    const nextRenderContext = next.renderContext ?? 'project';
-    const prevArchived = prev.archivedBucket ?? false;
-    const nextArchived = next.archivedBucket ?? false;
-    const prevExpansionKey = `${prevRenderContext}:${prevArchived ? 'archived' : 'active'}:${prevSessionId}`;
-    const nextExpansionKey = `${nextRenderContext}:${nextArchived ? 'archived' : 'active'}:${nextSessionId}`;
-    if (prev.expandedParents.has(prevExpansionKey) !== next.expandedParents.has(nextExpansionKey)) return false;
-  }
+  if (
+    prev.expandedParents !== next.expandedParents
+    && treeHasExpansionStateChange(
+      prev.node,
+      prev.expandedParents,
+      next.expandedParents,
+      prevRenderContext,
+      prev.archivedBucket ?? false,
+    )
+  ) return false;
   if (prev.hasSessionSearchQuery !== next.hasSessionSearchQuery) return false;
   if (prev.normalizedSessionSearchQuery !== next.normalizedSessionSearchQuery) return false;
   if (prev.notifyOnSubtasks !== next.notifyOnSubtasks) return false;
@@ -208,7 +217,6 @@ const areEqual = (prev: Props, next: Props): boolean => {
   if ((prev.secondaryMeta?.branchLabel ?? null) !== (next.secondaryMeta?.branchLabel ?? null)) return false;
   if (prev.mobileVariant !== next.mobileVariant) return false;
   if (prev.alwaysShowActions !== next.alwaysShowActions) return false;
-  if ((prev.renderContext ?? 'project') !== (next.renderContext ?? 'project')) return false;
   if (prev.renamingFolderId !== next.renamingFolderId) return false;
 
   return true;
@@ -345,6 +353,7 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
   // expand the other. Matches the format of menuInstanceKey.
   const expansionKey = menuInstanceKey;
   const isExpanded = hasSessionSearchQuery ? true : expandedParents.has(expansionKey);
+  const rowPaddingLeft = getSessionTreeIndentPx(depth);
   const isSubtaskSession = Boolean((resolvedSession as Session & { parentID?: string | null }).parentID);
   const unseenCount = useSessionUnseenCount(session.id);
   const needsAttention = unseenCount > 0 && (!isSubtaskSession || notifyOnSubtasks);
@@ -476,7 +485,8 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
     return (
       <div
         key={session.id}
-        className={cn('group relative flex items-center rounded-sm px-1.5 py-1', depth > 0 && 'pl-[20px]')}
+        className="group relative flex items-center rounded-sm px-1.5 py-1"
+        style={{ paddingLeft: rowPaddingLeft }}
       >
         <div className="flex min-w-0 flex-1 flex-col gap-0">
           <form
@@ -924,9 +934,9 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
                 className={cn(
                   'group relative my-0.5 flex items-center rounded-sm px-1.5 py-1',
                   isMissingDirectory ? 'opacity-75' : '',
-                  depth > 0 && 'pl-[20px]',
                   isRowSelected && 'bg-primary/15',
                 )}
+                style={{ paddingLeft: rowPaddingLeft }}
               />
             }
           >

--- a/packages/ui/src/components/session/sidebar/utils.test.ts
+++ b/packages/ui/src/components/session/sidebar/utils.test.ts
@@ -1,6 +1,58 @@
 import { describe, expect, test } from 'bun:test';
+import type { Session } from '@opencode-ai/sdk/v2';
 
-import { isPathWithinProject } from './utils';
+import type { SessionNode } from './types';
+import {
+  collectSessionAncestorIds,
+  getSessionTreeIndentPx,
+  isPathWithinProject,
+  treeHasExpansionStateChange,
+} from './utils';
+
+const createSession = (id: string, parentID: string | null = null): Session => {
+  return {
+    id,
+    title: id,
+    ...(parentID ? { parentID } : {}),
+  } as Session & { parentID?: string | null };
+};
+
+const createNode = (session: Session, children: SessionNode[] = []): SessionNode => {
+  return { session, children, worktree: null };
+};
+
+describe('getSessionTreeIndentPx', () => {
+  test('applies a fixed indent step for each nested depth', () => {
+    expect(getSessionTreeIndentPx(0)).toBe(6);
+    expect(getSessionTreeIndentPx(1)).toBe(20);
+    expect(getSessionTreeIndentPx(2)).toBe(34);
+    expect(getSessionTreeIndentPx(3)).toBe(48);
+    expect(getSessionTreeIndentPx(-1)).toBe(6);
+  });
+});
+
+describe('collectSessionAncestorIds', () => {
+  test('collects the full parent chain for arbitrarily nested subagents', () => {
+    const sessions = [
+      createSession('root'),
+      createSession('level-1', 'root'),
+      createSession('level-2', 'level-1'),
+      createSession('level-3', 'level-2'),
+    ];
+
+    expect(collectSessionAncestorIds('level-3', sessions)).toEqual(['level-2', 'level-1', 'root']);
+  });
+
+  test('stops when a malformed cycle is encountered', () => {
+    const sessions = [
+      createSession('root', 'level-2'),
+      createSession('level-1', 'root'),
+      createSession('level-2', 'level-1'),
+    ];
+
+    expect(collectSessionAncestorIds('root', sessions)).toEqual(['level-2', 'level-1']);
+  });
+});
 
 describe('isPathWithinProject', () => {
   test('matches child directories for root projects', () => {
@@ -25,5 +77,33 @@ describe('isPathWithinProject', () => {
 
   test('matches deep child directories', () => {
     expect(isPathWithinProject('/workspace/app/sub/dir', '/workspace/app')).toBe(true);
+  });
+});
+
+describe('treeHasExpansionStateChange', () => {
+  const tree = createNode(createSession('root'), [
+    createNode(createSession('level-1', 'root'), [
+      createNode(createSession('level-2', 'level-1'), [
+        createNode(createSession('level-3', 'level-2')),
+      ]),
+    ]),
+  ]);
+
+  test('detects expansion changes on deeper nested descendants', () => {
+    const previousExpandedParents = new Set<string>();
+    const nextExpandedParents = new Set<string>(['project:active:level-3']);
+
+    expect(
+      treeHasExpansionStateChange(tree, previousExpandedParents, nextExpandedParents, 'project', false),
+    ).toBe(true);
+  });
+
+  test('ignores expansion changes from other render contexts', () => {
+    const previousExpandedParents = new Set<string>();
+    const nextExpandedParents = new Set<string>(['recent:active:level-3']);
+
+    expect(
+      treeHasExpansionStateChange(tree, previousExpandedParents, nextExpandedParents, 'project', false),
+    ).toBe(false);
   });
 });

--- a/packages/ui/src/components/session/sidebar/utils.tsx
+++ b/packages/ui/src/components/session/sidebar/utils.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
 import { getCurrentIntlLocale } from '@/lib/i18n';
 import { formatMessage, useI18nStore } from '@/lib/i18n/store';
-import type { SessionSummaryMeta } from './types';
+import type { SessionNode, SessionSummaryMeta } from './types';
 
 const t = (key: Parameters<typeof formatMessage>[1], params?: Parameters<typeof formatMessage>[2]) =>
   formatMessage(useI18nStore.getState().dictionary, key, params);
@@ -84,6 +84,66 @@ export const normalizePath = (value?: string | null) => {
   }
   const normalized = value.replace(/\\/g, '/').replace(/\/+$/, '');
   return normalized.length === 0 ? '/' : normalized;
+};
+
+const SESSION_TREE_BASE_LEFT_PADDING_PX = 6;
+const SESSION_TREE_CHILD_INDENT_STEP_PX = 14;
+
+const getSessionExpansionKey = (
+  sessionId: string,
+  renderContext: 'project' | 'recent',
+  archivedBucket: boolean,
+): string => `${renderContext}:${archivedBucket ? 'archived' : 'active'}:${sessionId}`;
+
+export const getSessionTreeIndentPx = (depth: number): number => {
+  return SESSION_TREE_BASE_LEFT_PADDING_PX + Math.max(0, depth) * SESSION_TREE_CHILD_INDENT_STEP_PX;
+};
+
+export const getSessionParentId = (session?: Session | null): string | null => {
+  return (session as Session & { parentID?: string | null } | null | undefined)?.parentID ?? null;
+};
+
+export const collectSessionAncestorIds = (
+  sessionId: string | null | undefined,
+  sessions: Session[],
+): string[] => {
+  if (!sessionId) {
+    return [];
+  }
+
+  const sessionsById = new Map(sessions.map((session) => [session.id, session]));
+  const ancestorIds: string[] = [];
+  const visited = new Set<string>([sessionId]);
+
+  let currentSessionId: string | null = sessionId;
+  while (currentSessionId) {
+    const parentId = getSessionParentId(sessionsById.get(currentSessionId));
+    if (!parentId || visited.has(parentId)) {
+      break;
+    }
+
+    ancestorIds.push(parentId);
+    visited.add(parentId);
+    currentSessionId = parentId;
+  }
+
+  return ancestorIds;
+};
+
+export const treeHasExpansionStateChange = (
+  node: SessionNode,
+  previousExpandedParents: Set<string>,
+  nextExpandedParents: Set<string>,
+  renderContext: 'project' | 'recent',
+  archivedBucket: boolean,
+): boolean => {
+  const expansionKey = getSessionExpansionKey(node.session.id, renderContext, archivedBucket);
+  if (previousExpandedParents.has(expansionKey) !== nextExpandedParents.has(expansionKey)) {
+    return true;
+  }
+
+  return node.children.some((child) =>
+    treeHasExpansionStateChange(child, previousExpandedParents, nextExpandedParents, renderContext, archivedBucket));
 };
 
 export const isPathWithinProject = (directory?: string | null, projectPath?: string | null): boolean => {


### PR DESCRIPTION
## Summary

This PR fixes the session sidebar so delegated subagents remain explorable as a true recursive tree instead of behaving like a one-level or two-level UI.

It makes nested subagent rendering and expansion work reliably at arbitrary depth, and removes the remaining depth-2 assumption from the test coverage and implementation notes.

## Problem

The sidebar data model already stored sessions recursively via `SessionNode.children`, but the UI still had three practical issues:

1. Rows beyond the first nested level rendered with the same effective indentation, which made the tree look visually flat.
2. Navigating to a nested session only auto-expanded its direct parent, which could still leave deeper active sessions hidden.
3. `SessionNodeItem` is memoized, and ancestor rows could skip rerendering when a deeper descendant's expansion state changed, making nested chevrons appear unresponsive.

## Changes

### Sidebar tree helpers

Added reusable helpers in `packages/ui/src/components/session/sidebar/utils.tsx` to support recursive sidebar behavior:

- `getSessionTreeIndentPx(depth)` for depth-aware row padding
- `getSessionParentId(session)` for parent lookup
- `collectSessionAncestorIds(sessionId, sessions)` for full ancestor-chain expansion
- `treeHasExpansionStateChange(...)` for subtree-aware memo invalidation

### Recursive row rendering behavior

Updated `packages/ui/src/components/session/sidebar/SessionNodeItem.tsx` to:

- apply left padding from actual row depth rather than a single `depth > 0` class
- keep inline rename rows aligned with the same recursive indentation model
- invalidate memoized subtree rows when expansion state changes anywhere in the rendered descendant tree

### Active-session reveal behavior

Updated `packages/ui/src/components/session/SessionSidebar.tsx` to auto-expand the full ancestor chain of the current session across all render contexts:

- `project:active`
- `project:archived`
- `recent:active`
- `recent:archived`

That keeps deeply nested active sessions visible regardless of whether the user is looking in the project tree or the recent section.

### Tests and documentation

Updated `packages/ui/src/components/session/sidebar/utils.test.ts` to cover:

- recursive depth-based indentation
- full ancestor traversal across deeper nesting
- malformed parent-cycle safety
- nested subtree expansion invalidation

Updated sidebar documentation and added a dedicated implementation/reapply guide:

- `packages/ui/src/components/session/sidebar/DOCUMENTATION.md`
- `packages/ui/src/components/session/sidebar/NESTED_SUBAGENT_IMPLEMENTATION.md`

## Validation

Ran the existing repo validation commands from the repository root:

- `bun test packages\\ui\\src\\components\\session\\sidebar\\utils.test.ts`
- `bun run type-check`
- `bun run lint`
- `bun run build`

## Notes

- No backend or runtime API changes were needed; the fix is entirely in the shared UI sidebar behavior.
- The implementation intentionally remains recursive and does not introduce a fixed nesting cap, so deeper delegation chains continue to render correctly without further special cases.
