### PR TITLE
fix: stabilize question custom textarea resizing

### DIFF
--- a/packages/ui/src/components/chat/QuestionCard.tsx
+++ b/packages/ui/src/components/chat/QuestionCard.tsx
@@ -14,7 +14,7 @@ import { useSessions } from '@/sync/sync-context';
 import * as sessionActions from '@/sync/session-actions';
 import { useI18n } from '@/lib/i18n';
 import { serializeQuestionAsJson, serializeQuestionAsMarkdown } from './questionSerializers';
-import { getQuestionCustomTextareaHeight } from './questionTextareaSizing';
+import { QUESTION_CUSTOM_TEXTAREA_MIN_HEIGHT, getQuestionCustomTextareaHeight } from './questionTextareaSizing';
 
 interface QuestionCardProps {
   question: QuestionRequest;
@@ -40,7 +40,7 @@ const CustomAnswerTextarea = React.memo(function CustomAnswerTextarea({
 }: CustomAnswerTextareaProps) {
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
   const [localValue, setLocalValue] = React.useState(value);
-  const [height, setHeight] = React.useState(40);
+  const [height, setHeight] = React.useState(QUESTION_CUSTOM_TEXTAREA_MIN_HEIGHT);
   const [isScrollable, setIsScrollable] = React.useState(false);
 
   React.useEffect(() => {
@@ -231,6 +231,8 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
   const handleSelectCustom = React.useCallback(() => {
     setCustomMode((prev) => ({ ...prev, [activeIndex]: true }));
     setSelectedOptions((prev) => ({ ...prev, [activeIndex]: [] }));
+    const hasValue = (customTextRef.current[activeIndex] ?? '').trim().length > 0;
+    setCustomTextFilled((prev) => (prev[activeIndex] === hasValue ? prev : { ...prev, [activeIndex]: hasValue }));
   }, [activeIndex]);
 
   const handleCustomValueChange = React.useCallback((value: string) => {

--- a/packages/ui/src/components/chat/QuestionCard.tsx
+++ b/packages/ui/src/components/chat/QuestionCard.tsx
@@ -14,6 +14,7 @@ import { useSessions } from '@/sync/sync-context';
 import * as sessionActions from '@/sync/session-actions';
 import { useI18n } from '@/lib/i18n';
 import { serializeQuestionAsJson, serializeQuestionAsMarkdown } from './questionSerializers';
+import { getQuestionCustomTextareaHeight } from './questionTextareaSizing';
 
 interface QuestionCardProps {
   question: QuestionRequest;
@@ -21,6 +22,70 @@ interface QuestionCardProps {
 
 type TabKey = string;
 const SUMMARY_TAB = 'summary';
+
+interface CustomAnswerTextareaProps {
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  onValueChange: (value: string) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+}
+
+const CustomAnswerTextarea = React.memo(function CustomAnswerTextarea({
+  value,
+  placeholder,
+  disabled,
+  onValueChange,
+  onKeyDown,
+}: CustomAnswerTextareaProps) {
+  const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const [localValue, setLocalValue] = React.useState(value);
+  const [height, setHeight] = React.useState(40);
+  const [isScrollable, setIsScrollable] = React.useState(false);
+
+  React.useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  React.useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const nextHeight = getQuestionCustomTextareaHeight({
+      scrollHeight: textarea.scrollHeight,
+      currentHeight: height,
+    });
+    const nextScrollable = textarea.scrollHeight > (nextHeight ?? height);
+    if (isScrollable !== nextScrollable) {
+      setIsScrollable(nextScrollable);
+    }
+    if (nextHeight !== null) {
+      setHeight(nextHeight);
+    }
+  }, [height, isScrollable, localValue]);
+
+  return (
+    <textarea
+      ref={textareaRef}
+      value={localValue}
+      onChange={(event) => {
+        const nextValue = event.target.value;
+        setLocalValue(nextValue);
+        onValueChange(nextValue);
+      }}
+      placeholder={placeholder}
+      disabled={disabled}
+      rows={2}
+      onKeyDown={onKeyDown}
+      style={{ height }}
+      className={cn(
+        'w-full bg-transparent border border-border/30 focus:border-primary rounded px-2 py-1 outline-none typography-meta text-foreground placeholder:text-muted-foreground/50 transition-colors resize-none',
+        isScrollable ? 'overflow-y-auto' : 'overflow-hidden'
+      )}
+      autoFocus
+    />
+  );
+});
 
 export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
   const { t } = useI18n();
@@ -40,7 +105,8 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
 
   const [selectedOptions, setSelectedOptions] = React.useState<Record<number, string[]>>({});
   const [customMode, setCustomMode] = React.useState<Record<number, boolean>>({});
-  const [customText, setCustomText] = React.useState<Record<number, string>>({});
+  const customTextRef = React.useRef<Record<number, string>>({});
+  const [customTextFilled, setCustomTextFilled] = React.useState<Record<number, boolean>>({});
 
   const questions = React.useMemo(() => question.questions ?? [], [question.questions]);
   const isSummaryTab = activeTab === SUMMARY_TAB;
@@ -56,7 +122,8 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
     setActiveTab('0');
     setSelectedOptions({});
     setCustomMode({});
-    setCustomText({});
+    customTextRef.current = {};
+    setCustomTextFilled({});
     setHasResponded(false);
   }, [question.id]);
 
@@ -76,12 +143,12 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
   const getAnswerDisplay = React.useCallback((index: number): string => {
     const isCustom = Boolean(customMode[index]);
     if (isCustom) {
-      const value = (customText[index] ?? '').trim();
+      const value = (customTextRef.current[index] ?? '').trim();
       return value || t('chat.questionCard.noAnswer');
     }
     const answers = selectedOptions[index] ?? [];
     return answers.length > 0 ? answers.join(', ') : t('chat.questionCard.noAnswer');
-  }, [customMode, customText, selectedOptions, t]);
+  }, [customMode, selectedOptions, t]);
 
   const isMultiple = Boolean(activeQuestion?.multiple);
   const selectedForActive = selectedOptions[activeIndex] ?? [];
@@ -92,8 +159,7 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
     for (let index = 0; index < questions.length; index += 1) {
       const isCustom = Boolean(customMode[index]);
       if (isCustom) {
-        const value = (customText[index] ?? '').trim();
-        if (!value) pending.push(index);
+        if (!customTextFilled[index]) pending.push(index);
         continue;
       }
 
@@ -103,7 +169,7 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
       }
     }
     return pending;
-  }, [customMode, customText, questions.length, selectedOptions]);
+  }, [customMode, customTextFilled, questions.length, selectedOptions]);
 
   const requiredSatisfied = React.useMemo(() => {
     if (questions.length === 0) return false;
@@ -131,7 +197,7 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
     for (let index = 0; index < questions.length; index += 1) {
       const isCustom = Boolean(customMode[index]);
       if (isCustom) {
-        const value = (customText[index] ?? '').trim();
+        const value = (customTextRef.current[index] ?? '').trim();
         answers.push(value ? [value] : []);
         continue;
       }
@@ -140,13 +206,14 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
     }
 
     return answers;
-  }, [customMode, customText, questions.length, selectedOptions]);
+  }, [customMode, questions.length, selectedOptions]);
 
   const handleToggleOption = React.useCallback(
     (label: string) => {
       if (!activeQuestion) return;
 
       setCustomMode((prev) => ({ ...prev, [activeIndex]: false }));
+      setCustomTextFilled((prev) => (prev[activeIndex] ? { ...prev, [activeIndex]: false } : prev));
 
       setSelectedOptions((prev) => {
         const current = prev[activeIndex] ?? [];
@@ -164,6 +231,12 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
   const handleSelectCustom = React.useCallback(() => {
     setCustomMode((prev) => ({ ...prev, [activeIndex]: true }));
     setSelectedOptions((prev) => ({ ...prev, [activeIndex]: [] }));
+  }, [activeIndex]);
+
+  const handleCustomValueChange = React.useCallback((value: string) => {
+    customTextRef.current[activeIndex] = value;
+    const hasValue = value.trim().length > 0;
+    setCustomTextFilled((prev) => (prev[activeIndex] === hasValue ? prev : { ...prev, [activeIndex]: hasValue }));
   }, [activeIndex]);
 
   const handleConfirm = React.useCallback(async () => {
@@ -438,32 +511,12 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
 
                   {isCustomActive ? (
                     <div className="pl-6 pr-1 pt-0.5">
-                      <textarea
-                        ref={(el) => {
-                          if (el) {
-                            el.style.height = 'auto';
-                            const lineHeight = 20; // approx typography-meta line height
-                            const minHeight = lineHeight * 2;
-                            const maxHeight = lineHeight * 4;
-                            el.style.height = `${Math.min(Math.max(el.scrollHeight, minHeight), maxHeight)}px`;
-                          }
-                        }}
-                        value={customText[activeIndex] ?? ''}
-                        onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-                          const el = event.target;
-                          el.style.height = 'auto';
-                          const lineHeight = 20;
-                          const minHeight = lineHeight * 2;
-                          const maxHeight = lineHeight * 4;
-                          el.style.height = `${Math.min(Math.max(el.scrollHeight, minHeight), maxHeight)}px`;
-                          setCustomText((prev) => ({ ...prev, [activeIndex]: el.value }));
-                        }}
+                      <CustomAnswerTextarea
+                        value={customTextRef.current[activeIndex] ?? ''}
+                        onValueChange={handleCustomValueChange}
                         placeholder={t('chat.questionCard.yourAnswer')}
                         disabled={isResponding}
-                        rows={2}
                         onKeyDown={handleKeyDown}
-                        className="w-full bg-transparent border border-border/30 focus:border-primary rounded px-2 py-1 outline-none typography-meta text-foreground placeholder:text-muted-foreground/50 transition-colors resize-none overflow-hidden"
-                        autoFocus
                       />
                     </div>
                   ) : null}

--- a/packages/ui/src/components/chat/__tests__/questionTextareaSizing.test.ts
+++ b/packages/ui/src/components/chat/__tests__/questionTextareaSizing.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { getQuestionCustomTextareaHeight } from '../questionTextareaSizing';
+
+describe('getQuestionCustomTextareaHeight', () => {
+  test('returns null when the textarea is already at the target height', () => {
+    expect(getQuestionCustomTextareaHeight({ scrollHeight: 60, currentHeight: 60 })).toBeNull();
+  });
+
+  test('clamps textarea height between two and ten lines', () => {
+    expect(getQuestionCustomTextareaHeight({ scrollHeight: 10, currentHeight: 0 })).toBe(40);
+    expect(getQuestionCustomTextareaHeight({ scrollHeight: 120, currentHeight: 0 })).toBe(120);
+    expect(getQuestionCustomTextareaHeight({ scrollHeight: 260, currentHeight: 0 })).toBe(200);
+  });
+});

--- a/packages/ui/src/components/chat/__tests__/questionTextareaSizing.test.ts
+++ b/packages/ui/src/components/chat/__tests__/questionTextareaSizing.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { getQuestionCustomTextareaHeight } from '../questionTextareaSizing';
+import { QUESTION_CUSTOM_TEXTAREA_MIN_HEIGHT, getQuestionCustomTextareaHeight } from '../questionTextareaSizing';
 
 describe('getQuestionCustomTextareaHeight', () => {
+  test('exports the initial textarea height', () => {
+    expect(QUESTION_CUSTOM_TEXTAREA_MIN_HEIGHT).toBe(40);
+  });
+
   test('returns null when the textarea is already at the target height', () => {
     expect(getQuestionCustomTextareaHeight({ scrollHeight: 60, currentHeight: 60 })).toBeNull();
   });

--- a/packages/ui/src/components/chat/questionTextareaSizing.ts
+++ b/packages/ui/src/components/chat/questionTextareaSizing.ts
@@ -2,6 +2,8 @@ const QUESTION_TEXTAREA_LINE_HEIGHT = 20;
 const QUESTION_TEXTAREA_MIN_LINES = 2;
 const QUESTION_TEXTAREA_MAX_LINES = 10;
 
+export const QUESTION_CUSTOM_TEXTAREA_MIN_HEIGHT = QUESTION_TEXTAREA_LINE_HEIGHT * QUESTION_TEXTAREA_MIN_LINES;
+
 export function getQuestionCustomTextareaHeight({
   scrollHeight,
   currentHeight,
@@ -9,9 +11,8 @@ export function getQuestionCustomTextareaHeight({
   scrollHeight: number;
   currentHeight: number | null | undefined;
 }): number | null {
-  const minHeight = QUESTION_TEXTAREA_LINE_HEIGHT * QUESTION_TEXTAREA_MIN_LINES;
   const maxHeight = QUESTION_TEXTAREA_LINE_HEIGHT * QUESTION_TEXTAREA_MAX_LINES;
-  const nextHeight = Math.min(Math.max(scrollHeight, minHeight), maxHeight);
+  const nextHeight = Math.min(Math.max(scrollHeight, QUESTION_CUSTOM_TEXTAREA_MIN_HEIGHT), maxHeight);
 
   return currentHeight === nextHeight ? null : nextHeight;
 }

--- a/packages/ui/src/components/chat/questionTextareaSizing.ts
+++ b/packages/ui/src/components/chat/questionTextareaSizing.ts
@@ -1,0 +1,17 @@
+const QUESTION_TEXTAREA_LINE_HEIGHT = 20;
+const QUESTION_TEXTAREA_MIN_LINES = 2;
+const QUESTION_TEXTAREA_MAX_LINES = 10;
+
+export function getQuestionCustomTextareaHeight({
+  scrollHeight,
+  currentHeight,
+}: {
+  scrollHeight: number;
+  currentHeight: number | null | undefined;
+}): number | null {
+  const minHeight = QUESTION_TEXTAREA_LINE_HEIGHT * QUESTION_TEXTAREA_MIN_LINES;
+  const maxHeight = QUESTION_TEXTAREA_LINE_HEIGHT * QUESTION_TEXTAREA_MAX_LINES;
+  const nextHeight = Math.min(Math.max(scrollHeight, minHeight), maxHeight);
+
+  return currentHeight === nextHeight ? null : nextHeight;
+}


### PR DESCRIPTION
## Summary

Fixes #1613 

This MR fixes the custom-answer textarea in `QuestionCard` so it no longer flickers on every keystroke in long chat sessions, and so long custom answers remain readable while typing.

## Background

When an agent uses the `question` tool, users can choose predefined options or provide a custom answer. In long chat sessions, typing a custom answer became visually unstable once the answer grew beyond a couple of lines.

This was especially noticeable when the chat history was large, because each keystroke could trigger expensive layout work inside the main chat scroll container.

## Problem

The previous custom-answer textarea implementation resized itself directly inside the render ref and `onChange` handler:

- Set textarea height to `auto`
- Read `scrollHeight`
- Write the new height back
- Update parent `QuestionCard` state on every keystroke

This caused two issues:

- The textarea could flicker/reflow on every keystroke in long sessions.
- The textarea was capped at a small height and used hidden overflow, so longer answers could hide earlier text and feel difficult to edit.

## Changes

This MR updates the custom-answer textarea behavior by:

- Extracting the custom answer input into a memoized `CustomAnswerTextarea` component.
- Keeping per-keystroke input state local to the textarea component.
- Storing custom answer text in a ref at the parent level, while only updating parent state when the answer changes between empty and non-empty.
- Moving textarea height measurement into a layout effect.
- Adding `getQuestionCustomTextareaHeight` to clamp textarea height consistently.
- Increasing the max auto-resize height from 4 lines to 10 lines.
- Allowing vertical scrolling once the content exceeds the max textarea height.
- Adding regression tests for the textarea sizing behavior.

## Behavior After Fix

After this change:

- Typing in the custom-answer textarea no longer flickers in long chat sessions.
- The textarea grows automatically from 2 lines up to 10 lines.
- Very long answers remain accessible through internal textarea scrolling.
- The parent question card avoids unnecessary full re-renders on every keystroke.
- Submit validation still works: empty custom answers remain incomplete, non-empty custom answers can be submitted normally.

## Before Recording


https://github.com/user-attachments/assets/07a4aaa7-39c7-4930-bc19-4bcc0f145d02


## After Recording

https://github.com/user-attachments/assets/2e38ac91-01cb-4d18-a51e-353460bebbfc


## Testing

```bash
bun test packages/ui/src/components/chat/__tests__/questionTextareaSizing.test.ts
bun run lint
bun run type-check