### PR TITLE
test(git): assert relative URLs in gitApiHttp stage/unstage tests

### DIFF
--- a/packages/ui/src/lib/gitApiHttp.test.ts
+++ b/packages/ui/src/lib/gitApiHttp.test.ts
@@ -56,7 +56,7 @@ describe('gitApiHttp index mutations', () => {
       await stageGitFiles('/repo', ['a.ts', 'b.ts']);
 
       expect(calls).toHaveLength(1);
-      expect(String(calls[0].input)).toBe('http://localhost:3000/api/git/stage?directory=%2Frepo');
+      expect(String(calls[0].input)).toBe('/api/git/stage?directory=%2Frepo');
       expect(calls[0].init?.method).toBe('POST');
       expect(JSON.parse(String(calls[0].init?.body))).toEqual({ paths: ['a.ts', 'b.ts'] });
     } finally {
@@ -71,7 +71,7 @@ describe('gitApiHttp index mutations', () => {
       await unstageGitFiles('/repo', ['a.ts', 'b.ts']);
 
       expect(calls).toHaveLength(1);
-      expect(String(calls[0].input)).toBe('http://localhost:3000/api/git/unstage?directory=%2Frepo');
+      expect(String(calls[0].input)).toBe('/api/git/unstage?directory=%2Frepo');
       expect(calls[0].init?.method).toBe('POST');
       expect(JSON.parse(String(calls[0].init?.body))).toEqual({ paths: ['a.ts', 'b.ts'] });
     } finally {


### PR DESCRIPTION
## What

Fix the two `gitApiHttp index mutations` tests (`sends bulk stage payloads as paths` and `sends bulk unstage payloads as paths`) in `packages/ui/src/lib/gitApiHttp.test.ts`. They asserted absolute `http://localhost:3000/api/git/...` URLs, but the helpers return relative URLs. The expectations are updated to `/api/git/stage?directory=%2Frepo` and `/api/git/unstage?directory=%2Frepo`.

## Why

#1228 ("Decouple bundled UI from runtime API and add remote instance tooling") changed `gitApiHttp.buildUrl` from `new URL(path, resolveBaseOrigin())` (absolute, based on `window.location.origin`) to `getRuntimeUrlResolver().api()`. The default runtime URL resolver is created with an empty `apiBaseUrl`, so `api()` returns a relative URL; it only produces an absolute URL when a base URL is configured, and it never reads `window`.

That refactor updated the sibling tests `runtime-url.test.ts` and `runtime-fetch.test.ts`, but `gitApiHttp.test.ts` was missed, so these two assertions have failed ever since. There is no CI step that runs the unit-test suite, so the breakage went unnoticed.

The `window.location.origin` mock in those tests no longer affects `api()`; relative URLs are the correct, intended behavior (the browser resolves them against the current origin) and are consistent with the resolver's own tests. The change is test-only and does not alter any production code.

## Testing

```
bun test packages/ui/src/lib/gitApiHttp.test.ts   # 4 pass (was 2 fail / 2 pass)
bun run type-check                                 # all packages exit 0
bun run lint                                        # all packages exit 0
```

## Note

The open PR #1457 also touches this file but on different lines (it appends new `revert-hunk`/`file-diff` tests using the same absolute-URL pattern); it does not modify these stage/unstage assertions, so there is no conflict. If #1457 lands, its new assertions will likely need the same relative-URL treatment.
