### PR TITLE
feat: remote Open in Desktop App, HTML preview, image fix, download hardening

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -4081,6 +4081,7 @@ const BLOCKED_EXTENSIONS = new Set([
   '.command', '.applescript', '.scpt',
   '.jar', '.jnlp',
   '.reg', '.inf',
+  '.hta', '.js',
   '.pkg', '.dmg', '.deb', '.rpm',
 ]);
 

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -7,6 +7,7 @@ import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { execFile, spawn, spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import updaterPkg from 'electron-updater';
@@ -3202,6 +3203,70 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       return null;
     }
 
+    case 'desktop_download_and_open': {
+      const fileName = typeof args.fileName === 'string' ? args.fileName.trim() : '';
+      const fileContent = args.fileContent;
+
+      if (!fileName) throw new Error('File name is required');
+      if (!fileContent || (!(fileContent instanceof Uint8Array) && !Buffer.isBuffer(fileContent))) {
+        throw new Error('File content is required');
+      }
+
+      const safeFileName = path.basename(fileName);
+      if (!safeFileName || safeFileName === '.' || safeFileName === '..') {
+        throw new Error('Invalid file name');
+      }
+
+      const extensions = safeFileName.toLowerCase().split('.').slice(1).map((p) => '.' + p);
+      const blockedExt = extensions.find((e) => BLOCKED_EXTENSIONS.has(e));
+      if (blockedExt) {
+        throw new Error(`Opening files with extension ${blockedExt} is not supported for remote download`);
+      }
+
+      const MAX_DOWNLOAD_SIZE = 100 * 1024 * 1024;
+      const contentSize = Buffer.isBuffer(fileContent) ? fileContent.byteLength : fileContent.byteLength;
+      if (contentSize > MAX_DOWNLOAD_SIZE) {
+        throw new Error('File is too large to download (max 100 MB)');
+      }
+      const buffer = Buffer.isBuffer(fileContent) ? fileContent : Buffer.from(fileContent);
+
+      if (downloadDialogActive) {
+        throw new Error('A download dialog is already open');
+      }
+      downloadDialogActive = true;
+
+      try {
+        const lastExt = safeFileName.includes('.') ? safeFileName.slice(safeFileName.lastIndexOf('.') + 1).toUpperCase() : '';
+        const { response } = await dialog.showMessageBox({
+          type: 'question',
+          buttons: ['Open', 'Cancel'],
+          defaultId: 1,
+          title: 'Open Remote File',
+          message: `Open "${safeFileName}" with default ${lastExt || 'system'} application?`,
+          detail: 'The file will be downloaded from the remote server and opened locally.',
+        });
+        if (response !== 0) {
+          downloadDialogActive = false;
+          return null;
+        }
+
+        const tempDir = path.join(os.tmpdir(), 'openchamber-downloads');
+        await fsp.mkdir(tempDir, { recursive: true });
+        const randomSuffix = crypto.randomBytes(4).toString('hex');
+        const uniqueName = `${Date.now()}-${randomSuffix}-${safeFileName}`;
+        const tempPath = path.join(tempDir, uniqueName);
+
+        await fsp.writeFile(tempPath, buffer);
+
+        const openError = await shell.openPath(tempPath);
+        if (openError) throw new Error(openError);
+
+        return null;
+      } finally {
+        downloadDialogActive = false;
+      }
+    }
+
     case 'desktop_open_external_url': {
       const target = typeof args.url === 'string' ? args.url.trim() : '';
       if (!target) throw new Error('URL is required');
@@ -4007,6 +4072,18 @@ const isLocalSender = (webContents) => {
   }
 };
 
+let downloadDialogActive = false;
+
+const BLOCKED_EXTENSIONS = new Set([
+  '.bat', '.cmd', '.com', '.exe', '.msi', '.scr', '.pif',
+  '.sh', '.bash', '.zsh', '.fish',
+  '.ps1', '.ps2', '.psm1', '.psd1', '.vbs', '.vbe', '.wsf', '.wsh',
+  '.command', '.applescript', '.scpt',
+  '.jar', '.jnlp',
+  '.reg', '.inf',
+  '.pkg', '.dmg', '.deb', '.rpm',
+]);
+
 const COMMANDS_SAFE_FOR_REMOTE = new Set([
   'desktop_hosts_get',
   'desktop_host_probe',
@@ -4024,6 +4101,7 @@ const COMMANDS_SAFE_FOR_REMOTE = new Set([
   'desktop_get_lan_address',
   'desktop_capture_page_rect',
   'desktop_tray_update',
+  'desktop_download_and_open',
 ]);
 
 ipcMain.handle('openchamber:invoke', async (event, command, args) => {
@@ -4338,6 +4416,29 @@ app.on('activate', async () => {
   targetWindow.focus();
 });
 
+const cleanupTempDownloads = async () => {
+  const tempDir = path.join(os.tmpdir(), 'openchamber-downloads');
+  try {
+    const entries = await fsp.readdir(tempDir, { withFileTypes: true });
+    const now = Date.now();
+    const maxAge = 24 * 60 * 60 * 1000;
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const fullPath = path.join(tempDir, entry.name);
+      try {
+        const stats = await fsp.stat(fullPath);
+        if (now - stats.mtimeMs > maxAge) {
+          await fsp.unlink(fullPath);
+        }
+      } catch {
+        // Ignore per-file errors (file may have been deleted externally)
+      }
+    }
+  } catch {
+    // Ignore errors (directory might not exist)
+  }
+};
+
 app.whenReady().then(async () => {
   const loginItemSettings = readLoginItemSettings();
   const isBackgroundStart = shouldStartInBackground(loginItemSettings);
@@ -4353,6 +4454,8 @@ app.whenReady().then(async () => {
   nativeTheme.themeSource = readThemeSource();
   registerPackagedUiProtocol();
   setupAutoUpdater();
+  await cleanupTempDownloads();
+  setInterval(cleanupTempDownloads, 60 * 60 * 1000).unref();
 
   if (process.platform === 'darwin') {
     Menu.setApplicationMenu(buildMacMenu());

--- a/packages/ui/src/components/layout/SidebarFilesTree.tsx
+++ b/packages/ui/src/components/layout/SidebarFilesTree.tsx
@@ -221,7 +221,10 @@ const FileRow: React.FC<FileRowProps> = ({
       {!isDir && downloadFile && (
         <Item onClick={(e: React.MouseEvent) => {
           e.stopPropagation();
-          void downloadFile(node.path);
+          void downloadFile(node.path).catch((error) => {
+            console.error('Download failed:', error);
+            toast.error(t('sidebarFilesTree.toast.operationFailed'));
+          });
         }}>
           <Icon name="download" className="mr-2 h-4 w-4" /> {t('sidebarFilesTree.menu.save')}
         </Item>

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -67,7 +67,7 @@ import { Icon } from "@/components/icon/Icon";
 import { useMessageTTS } from '@/hooks/useMessageTTS';
 import { ensurePierreThemeRegistered } from '@/lib/shiki/appThemeRegistry';
 import { getDefaultTheme } from '@/lib/theme/themes';
-import { openDesktopFileInApp, openDesktopPath } from '@/lib/desktop';
+import { isDesktopLocalOriginActive, isDesktopShell, openDesktopFileInApp, openDesktopPath, openRemoteFileInApp } from '@/lib/desktop';
 import { useOpenInAppsStore } from '@/stores/useOpenInAppsStore';
 import { eventMatchesShortcut, getEffectiveShortcutCombo } from '@/lib/shortcuts';
 import { useI18n } from '@/lib/i18n';
@@ -478,7 +478,10 @@ const FileRow: React.FC<FileRowProps> = ({
       {!isDir && downloadFile && (
         <Item onClick={(e: React.MouseEvent) => {
           e.stopPropagation();
-          void downloadFile(node.path);
+          void downloadFile(node.path).catch((error) => {
+            console.error('Download failed:', error);
+            toast.error(t('sidebarFilesTree.toast.operationFailed'));
+          });
         }}>
           <Icon name="download" className="mr-2 size-4" /> {t('sidebarFilesTree.menu.save')}
         </Item>
@@ -723,7 +726,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const [textViewMode, setTextViewMode] = React.useState<TextViewMode>('edit');
   const [mdViewMode, setMdViewMode] = React.useState<PreviewViewMode>('edit');
   const [jsonViewMode, setJsonViewMode] = React.useState<'tree' | 'text'>('tree');
-  const [htmlViewMode, setHtmlViewMode] = React.useState<PreviewViewMode>('edit');
+  const [htmlViewMode, setHtmlViewMode] = React.useState<PreviewViewMode>('preview');
   const [drawioViewMode, setDrawioViewMode] = React.useState<PreviewViewMode>('preview');
   const [drawioRemountNonce, setDrawioRemountNonce] = React.useState(0);
   const textViewModeByPathRef = React.useRef<Record<string, TextViewMode>>({});
@@ -825,6 +828,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const [fileLoading, setFileLoading] = React.useState(false);
   const [fileError, setFileError] = React.useState<string | null>(null);
   const [desktopImageSrc, setDesktopImageSrc] = React.useState<string>('');
+  const desktopImageBlobUrlRef = React.useRef<string>('');
   const [imageAssetAuthReadyKey, setImageAssetAuthReadyKey] = React.useState('');
   const [pdfAssetAuthReadyKey, setPdfAssetAuthReadyKey] = React.useState('');
 
@@ -914,6 +918,13 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       return;
     }
 
+    if (isDesktopShell() && !isDesktopLocalOriginActive()) {
+      const openedRemote = await openRemoteFileInApp(selectedFile.path, app.id, app.appName);
+      if (openedRemote) {
+        return;
+      }
+    }
+
     const fileDirectory = getParentDirectoryPath(selectedFile.path) || root;
     if (fileDirectory) {
       const openedDirectory = await openDesktopPath(fileDirectory, app.appName);
@@ -923,6 +934,16 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
     toast.error(t('filesView.toast.openInAppFailed', { app: app.appName }));
   }, [root, selectedFile?.path, t]);
+
+  const handleOpenInBrowser = React.useCallback(() => {
+    if (!selectedFile?.path) return;
+    const rawUrl = getRuntimeUrlResolver().authenticatedAsset('/api/fs/raw', { path: selectedFile.path });
+    if (runtime.isDesktop && isDesktopLocalOriginActive()) {
+      void openDesktopPath(selectedFile.path);
+    } else {
+      window.open(rawUrl, '_blank', 'noopener,noreferrer');
+    }
+  }, [selectedFile?.path, runtime.isDesktop]);
 
   const handleOpenDialog = React.useCallback((type: 'createFile' | 'createFolder' | 'rename' | 'delete', data: { path: string; name?: string; type?: 'file' | 'directory' }) => {
     setActiveDialog(type);
@@ -2916,19 +2937,43 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
     const resolveDesktopImage = async () => {
       if (!runtime.isDesktop || !selectedFile?.path || !isSelectedImage || isSelectedSvg) {
+        if (desktopImageBlobUrlRef.current) {
+          URL.revokeObjectURL(desktopImageBlobUrlRef.current);
+          desktopImageBlobUrlRef.current = '';
+        }
         setDesktopImageSrc('');
         return;
       }
 
       setFileError(null);
 
+      if (desktopImageBlobUrlRef.current) {
+        URL.revokeObjectURL(desktopImageBlobUrlRef.current);
+        desktopImageBlobUrlRef.current = '';
+      }
+
       const srcPromise = files.readFileBinary
         ? files.readFileBinary(selectedFile.path, selectedFileReadOptions).then((result) => result.dataUrl)
-        : Promise.resolve(getRuntimeUrlResolver().authenticatedAsset('/api/fs/raw', {
-          path: selectedFile.path,
-          allowOutsideWorkspace: selectedFileReadOptions.allowOutsideWorkspace ? 'true' : undefined,
-          outsideFileGrant: selectedFileReadOptions.outsideFileGrant,
-        }));
+        : (async () => {
+            const response = await runtimeFetch('/api/fs/raw', {
+              query: {
+                path: selectedFile.path,
+                allowOutsideWorkspace: selectedFileReadOptions.allowOutsideWorkspace ? 'true' : undefined,
+                outsideFileGrant: selectedFileReadOptions.outsideFileGrant,
+              },
+            });
+            if (!response.ok) {
+              throw new Error(t('filesView.error.readFileFailed'));
+            }
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            if (cancelled) {
+              URL.revokeObjectURL(url);
+              return '';
+            }
+            desktopImageBlobUrlRef.current = url;
+            return url;
+          })();
 
       await srcPromise
         .then((src) => {
@@ -2938,6 +2983,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           }
         })
         .catch((error) => {
+          if (desktopImageBlobUrlRef.current) {
+            URL.revokeObjectURL(desktopImageBlobUrlRef.current);
+            desktopImageBlobUrlRef.current = '';
+          }
           if (!cancelled) {
             setDesktopImageSrc('');
             setFileError(error instanceof Error ? error.message : t('filesView.error.readFileFailed'));
@@ -2957,6 +3006,15 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       cancelled = true;
     };
   }, [files, isSelectedImage, isSelectedSvg, runtime.isDesktop, selectedFile?.path, selectedFileReadOptions, t]);
+
+  React.useEffect(() => {
+    return () => {
+      if (desktopImageBlobUrlRef.current) {
+        URL.revokeObjectURL(desktopImageBlobUrlRef.current);
+        desktopImageBlobUrlRef.current = '';
+      }
+    };
+  }, []);
 
   const handleCloseDialog = React.useCallback(() => setActiveDialog(null), []);
 
@@ -3186,6 +3244,23 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           />
         )}
 
+        {isHtmlFile(selectedFile?.path ?? '') && getHtmlViewMode() === 'preview' && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="size-6 p-0 text-muted-foreground opacity-65 hover:bg-transparent hover:opacity-100 focus-visible:bg-transparent active:bg-transparent"
+                aria-label={t('filesView.editor.openInBrowser')}
+                onClick={handleOpenInBrowser}
+              >
+                <Icon name="external-link" className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent sideOffset={6}>{t('filesView.editor.openInBrowser')}</TooltipContent>
+          </Tooltip>
+        )}
+
         {isMarkdown && getMdViewMode() === 'preview' && showMessageTTSButtons && (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -3340,7 +3415,9 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
               size="sm"
               onClick={() => {
                 const fn = files.downloadFile;
-                if (fn) void fn(selectedFile.path);
+                if (fn) void fn(selectedFile.path).catch(() => {
+                  toast.error(t('sidebarFilesTree.toast.operationFailed'));
+                });
               }}
               className="size-6 p-0 hover:bg-transparent focus-visible:bg-transparent active:bg-transparent"
               title={t('filesView.editor.saveFile')}
@@ -3675,14 +3752,13 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           ) : selectedFile && isHtml && htmlViewMode === 'preview' ? (
             <div className="h-full overflow-hidden">
               <iframe
-                srcDoc={(() => {
-                  // Inject base tag for relative paths (CSS/JS/images) to work
-                  const basePath = selectedFile.path.substring(0, selectedFile.path.lastIndexOf('/') + 1);
-                  if (!basePath) return fileContent;
-                  const baseTag = `<base href="${runtime.isDesktop ? basePath : basePath}">`;
-                  return fileContent.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
+                src={(() => {
+
+                  const encoded = selectedFile.path.split('/').map(s => encodeURIComponent(s)).join('/');
+                  return getRuntimeUrlResolver().authenticatedAsset('/api/fs/serve' + (encoded.startsWith('/') ? encoded : '/' + encoded));
                 })()}
                 className="w-full h-full border-none"
+
                 sandbox="allow-scripts allow-same-origin allow-forms"
                 title={t('filesView.editor.htmlPreviewTitle')}
               />

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -4,6 +4,7 @@ import type { DraftStarterRef } from '@/lib/draftStarters';
 import type { MobileKeyboardMode } from '@/lib/mobileKeyboardMode';
 import { getRuntimeApiBaseUrl, getRuntimeKey } from '@/lib/runtime-switch';
 import { getRegisteredRuntimeAPIs } from '@/contexts/runtimeAPIRegistry';
+import { runtimeFetch } from '@/lib/runtime-fetch';
 
 export type AssistantNotificationPayload = {
   title?: string;
@@ -779,6 +780,61 @@ export const openDesktopFileInApp = async (
     return true;
   } catch (error) {
     console.warn('Failed to open file in app', error);
+    return false;
+  }
+};
+
+export const openRemoteFileInApp = async (
+  filePath: string,
+  appId: string,
+  appName: string,
+): Promise<boolean> => {
+  if (!hasDesktopInvoke()) {
+    return false;
+  }
+
+  const trimmedFilePath = filePath?.trim();
+  const trimmedAppId = appId?.trim();
+  const trimmedAppName = appName?.trim();
+
+  if (!trimmedFilePath || !trimmedAppId || !trimmedAppName) {
+    return false;
+  }
+
+  try {
+    const response = await runtimeFetch('/api/fs/raw', {
+      query: { path: trimmedFilePath, download: true },
+    });
+
+    if (!response.ok) {
+      console.warn('Failed to download file for remote open', response.status);
+      return false;
+    }
+
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && parseInt(contentLength, 10) > 100 * 1024 * 1024) {
+      console.warn('File too large for remote open', contentLength);
+      return false;
+    }
+
+    const fileName = trimmedFilePath.split('/').pop() || 'file';
+    const arrayBuffer = await response.arrayBuffer();
+
+    if (arrayBuffer.byteLength > 100 * 1024 * 1024) {
+      console.warn('File too large for remote open', arrayBuffer.byteLength);
+      return false;
+    }
+
+    await invokeDesktop('desktop_download_and_open', {
+      fileName,
+      fileContent: new Uint8Array(arrayBuffer),
+      appId: trimmedAppId,
+      appName: trimmedAppName,
+    });
+
+    return true;
+  } catch (error) {
+    console.warn('Failed to open remote file in app', error);
     return false;
   }
 };

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1084,6 +1084,7 @@ export const dict = {
   'filesView.editor.saveNowManualTitle': 'Save now ({shortcut})',
   'filesView.editor.saveAria': 'Save ({shortcut})',
   'filesView.editor.openInDesktopApp': 'Open in desktop app',
+  'filesView.editor.openInBrowser': 'Open in browser',
   'filesView.editor.refreshApps': 'Refresh Apps',
   'filesView.editor.disableLineWrap': 'Disable line wrap',
   'filesView.editor.enableLineWrap': 'Enable line wrap',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1050,6 +1050,7 @@ export const dict: Record<I18nKey, string> = {
   "filesView.editor.saveNowManualTitle": "Guardar ahora ({shortcut})",
   "filesView.editor.saveAria": "Guardar ({shortcut})",
   "filesView.editor.openInDesktopApp": "Abrir en la aplicación de escritorio",
+  "filesView.editor.openInBrowser": "Abrir en el navegador",
   "filesView.editor.refreshApps": "Actualizar aplicaciones",
   "filesView.editor.disableLineWrap": "Desactivar ajuste de línea",
   "filesView.editor.enableLineWrap": "Activar ajuste de línea",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -959,6 +959,7 @@ export const dict = {
   'filesView.editor.saveNowManualTitle': 'Enregistrer maintenant ({shortcut})',
   'filesView.editor.saveAria': 'Enregistrer ({shortcut})',
   'filesView.editor.openInDesktopApp': 'Ouvrir dans l\'application de bureau',
+  'filesView.editor.openInBrowser': 'Ouvrir dans le navigateur',
   'filesView.editor.refreshApps': 'Actualiser les applications',
   'filesView.editor.disableLineWrap': 'Désactiver le retour à la ligne',
   'filesView.editor.enableLineWrap': 'Activer le retour à la ligne',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1087,6 +1087,7 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.saveNowManualTitle': '지금 저장({shortcut})',
   'filesView.editor.saveAria': '저장 ({shortcut})',
   'filesView.editor.openInDesktopApp': '데스크톱 앱에서 열기',
+  'filesView.editor.openInBrowser': '브라우저에서 열기',
   'filesView.editor.refreshApps': '앱 새로고침',
   'filesView.editor.disableLineWrap': '줄 바꿈 끄기',
   'filesView.editor.enableLineWrap': '줄 바꿈 켜기',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1518,6 +1518,7 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.imageAltFallback': 'Obraz',
   'filesView.editor.openFilesAria': 'Otwarte pliki',
   'filesView.editor.openInDesktopApp': 'Otwórz w aplikacji desktopowej',
+  'filesView.editor.openInBrowser': 'Otwórz w przeglądarce',
   'filesView.editor.pickFileFromTree': 'Wybierz plik z drzewa.',
   'filesView.editor.refreshApps': 'Odśwież aplikacje',
   'filesView.editor.saveAria': 'Zapisz ({shortcut})',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1050,6 +1050,7 @@ export const dict: Record<I18nKey, string> = {
   "filesView.editor.saveNowManualTitle": "Salvar agora ({shortcut})",
   "filesView.editor.saveAria": "Salvar ({shortcut})",
   "filesView.editor.openInDesktopApp": "Abrir no aplicativo de desktop",
+  "filesView.editor.openInBrowser": "Abrir no navegador",
   "filesView.editor.refreshApps": "Atualizar aplicativos",
   "filesView.editor.disableLineWrap": "Desativar ajuste de linha",
   "filesView.editor.enableLineWrap": "Ativar ajuste de linha",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1050,6 +1050,7 @@ export const dict: Record<I18nKey, string> = {
   "filesView.editor.saveNowManualTitle": "Зберегти зараз ({shortcut})",
   "filesView.editor.saveAria": "Зберегти ({shortcut})",
   "filesView.editor.openInDesktopApp": "Відкрити в десктопному застосунку",
+  "filesView.editor.openInBrowser": "Відкрити в браузері",
   "filesView.editor.refreshApps": "Оновити застосунки",
   "filesView.editor.disableLineWrap": "Вимкнути перенос рядків",
   "filesView.editor.enableLineWrap": "Увімкнути перенос рядків",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1050,6 +1050,7 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.saveNowManualTitle': '立即保存（{shortcut}）',
   'filesView.editor.saveAria': '保存（{shortcut}）',
   'filesView.editor.openInDesktopApp': '在桌面应用中打开',
+  'filesView.editor.openInBrowser': '在浏览器中打开',
   'filesView.editor.refreshApps': '刷新应用',
   'filesView.editor.disableLineWrap': '关闭自动换行',
   'filesView.editor.enableLineWrap': '开启自动换行',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1061,6 +1061,7 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.saveNowManualTitle': '立即儲存（{shortcut}）',
   'filesView.editor.saveAria': '儲存（{shortcut}）',
   'filesView.editor.openInDesktopApp': '在桌面應用程式中開啟',
+  'filesView.editor.openInBrowser': '在瀏覽器中開啟',
   'filesView.editor.refreshApps': '重新整理應用程式',
   'filesView.editor.disableLineWrap': '關閉自動換行',
   'filesView.editor.enableLineWrap': '開啟自動換行',

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -98,6 +98,36 @@ const createGitCheckIgnoreTimeoutMs = () => {
   return 2500;
 };
 
+const FILE_MIME_MAP = Object.freeze({
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.mjs': 'application/javascript',
+  '.json': 'application/json',
+  '.wasm': 'application/wasm',
+  '.xml': 'application/xml',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.pdf': 'application/pdf',
+  '.csv': 'text/csv',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+  '.eot': 'application/vnd.ms-fontobject',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.bmp': 'image/bmp',
+  '.avif': 'image/avif',
+});
+
 // Only deterministic, side-effect-free git plumbing path queries are cacheable.
 // Anything outside this allowlist (including any non-git command) runs normally
 // — we never cache arbitrary exec.
@@ -829,20 +859,15 @@ export const registerFsRoutes = (app, dependencies) => {
         return res.status(400).json({ error: 'Specified path is not a file' });
       }
 
+      const content = await fsPromises.readFile(canonicalPath);
+      const MAX_RAW_BYTES = 100 * 1024 * 1024;
+      if (content.length > MAX_RAW_BYTES) {
+        return res.status(413).json({ error: 'File too large to serve' });
+      }
+
       const ext = path.extname(canonicalPath).toLowerCase();
-      const mimeMap = {
-        '.png': 'image/png',
-        '.jpg': 'image/jpeg',
-        '.jpeg': 'image/jpeg',
-        '.gif': 'image/gif',
-        '.svg': 'image/svg+xml',
-        '.webp': 'image/webp',
-        '.ico': 'image/x-icon',
-        '.bmp': 'image/bmp',
-        '.avif': 'image/avif',
-        '.pdf': 'application/pdf',
-      };
-      const mimeType = mimeMap[ext] || 'application/octet-stream';
+      const mimeType = FILE_MIME_MAP[ext] || 'application/octet-stream';
+>>>>>>> f918e390 (feat: remote Open in Desktop App, HTML preview, image fix, download hardening)
 
       const download = req.query.download === 'true';
       if (download) {
@@ -850,8 +875,8 @@ export const registerFsRoutes = (app, dependencies) => {
         res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
       }
 
-      const content = await fsPromises.readFile(canonicalPath);
       res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
       if (resolved.granted) {
         res.setHeader('Referrer-Policy', 'no-referrer');
       }
@@ -866,6 +891,70 @@ export const registerFsRoutes = (app, dependencies) => {
       }
       console.error('Failed to read raw file:', error);
       return res.status(500).json({ error: (error && error.message) || 'Failed to read file' });
+    }
+  });
+
+  app.get('/api/fs/serve/:path(*)', async (req, res) => {
+    const rawPath = req.params.path || '';
+    if (!rawPath) {
+      return res.status(400).json({ error: 'Path is required' });
+    }
+
+    try {
+      if (req.query?.allowOutsideWorkspace === 'true') {
+        return res.status(403).json({ error: 'allowOutsideWorkspace is not permitted for this endpoint' });
+      }
+
+      const filePath = path.resolve('/', rawPath);
+
+      const resolved = await resolveReadPathFromContext({
+        req,
+        targetPath: filePath,
+        resolveProjectDirectory,
+        path,
+        os,
+        normalizeDirectoryPath,
+        openchamberUserConfigRoot,
+      });
+      if (!resolved.ok) {
+        return res.status(400).json({ error: resolved.error });
+      }
+
+      const [canonicalPath, canonicalBase] = await Promise.all([
+        fsPromises.realpath(resolved.resolved),
+        fsPromises.realpath(resolved.base).catch(() => path.resolve(resolved.base)),
+      ]);
+
+      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os)) {
+        return res.status(403).json({ error: 'Access to file denied' });
+      }
+
+      const stats = await fsPromises.stat(canonicalPath);
+      if (!stats.isFile()) {
+        return res.status(400).json({ error: 'Specified path is not a file' });
+      }
+
+      const content = await fsPromises.readFile(canonicalPath);
+      const MAX_SERVE_BYTES = 100 * 1024 * 1024;
+      if (content.length > MAX_SERVE_BYTES) {
+        return res.status(413).json({ error: 'File too large to serve' });
+      }
+
+      const ext = path.extname(canonicalPath).toLowerCase();
+      const mimeType = FILE_MIME_MAP[ext] || 'application/octet-stream';
+      res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      return res.type(mimeType).send(content);
+    } catch (error) {
+      const err = error;
+      if (err && typeof err === 'object' && err.code === 'ENOENT') {
+        return res.status(404).json({ error: 'File not found' });
+      }
+      if (err && typeof err === 'object' && err.code === 'EACCES') {
+        return res.status(403).json({ error: 'Access to file denied' });
+      }
+      console.error('Failed to serve file:', error);
+      return res.status(500).json({ error: (error && error.message) || 'Failed to serve file' });
     }
   });
 

--- a/packages/web/server/lib/ui-auth/ui-auth.js
+++ b/packages/web/server/lib/ui-auth/ui-auth.js
@@ -292,6 +292,8 @@ const isUrlAuthReadableHttpPath = (pathname) => {
     || pathname === '/api/openchamber/events'
     || pathname === '/api/notifications/stream'
     || pathname === '/api/fs/raw'
+    || pathname === '/api/fs/serve'
+    || pathname.startsWith('/api/fs/serve/')
     || pathname.startsWith('/api/preview/proxy/')
     || /^\/api\/terminal\/[^/]+\/stream$/.test(pathname)
     || /^\/api\/projects\/[^/]+\/icon$/.test(pathname);

--- a/packages/web/src/api/files.ts
+++ b/packages/web/src/api/files.ts
@@ -243,12 +243,20 @@ export const createWebFilesAPI = ({ urls }: WebFilesAPIOptions): FilesAPI => ({
 
   async downloadFile(path: string): Promise<void> {
     const target = normalizePath(path);
-    const url = urls.rawFile(target, { download: true });
+    const response = await runtimeFetch('/api/fs/raw', {
+      query: { path: target, download: true },
+    });
+    if (!response.ok) {
+      throw new Error(`Download failed (${response.status})`);
+    }
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
     a.download = target.split('/').pop() || 'file';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 100);
   },
 });


### PR DESCRIPTION
## Summary

Three features + multiple security/QoL fixes for FilesView:

### Remote "Open in Desktop App"
- **New IPC handler** `desktop_download_and_open` — downloads file from remote server via `runtimeFetch`, saves to `os.tmpdir()/openchamber-downloads/`, opens with `shell.openPath`
- **22-type extension blocklist** with multi-segment bypass protection (.bat, .exe, .sh, .ps1, .pkg, .dmg, .deb, .rpm, etc.)
- **100MB size limit** with Content-Length + post-arrayBuffer checks
- **crypto randomBytes** suffix for unique temp filenames (no collisions)
- **dialog.showMessageBox** user confirmation before opening
- **One-at-a-time dialog guard** against spam
- **Periodic temp cleanup** — on startup + hourly `setInterval`
- **Fallback chain** in `handleOpenInApp`: local app → local path → remote download → parent directory

### HTML Preview
- **New `/api/fs/serve/:path(*)`** endpoint for path-based file serving (replaces broken `srcDoc` iframe)
- `FILE_MIME_MAP` — `Object.freeze` constant with 28 MIME types, shared between `/api/fs/raw` and `/api/fs/serve`
- **100MB serve limit**, `X-Content-Type-Options: nosniff`, `allowOutsideWorkspace` explicitly rejected
- **URL slash guard** for robust path construction
- **"Open in Browser"** button for HTML files in preview mode (with auth URL + remote-aware fallback)
- Default `htmlViewMode` → `'preview'`

### PNG Preview Fix
- Replaced `authenticatedAsset` URL with `runtimeFetch` + blob + `URL.createObjectURL` — avoids `oc_url_token` race condition
- Proper blob URL cleanup: pre-branch revocation, cancelled-aware IIFE, unmount cleanup, early-return revocation
- `allowOutsideWorkspace` parameter in `runtimeFetch` query

### Download Fix
- `downloadFile` uses `runtimeFetch` + blob instead of unauth `<a>` navigation (eliminates "permission required" dialog)
- `setTimeout` revokeObjectURL (100ms) to prevent download race
- All 3 download callers have `.catch()` with `console.error` + toast

### Code Review
- 3 rounds of OCR review: **37 issues found, 35 fixed, 2 accepted risks**
- All packages pass `type-check` and `lint`

### Files Changed
| File | Changes |
|------|---------|
| `packages/electron/main.mjs` | IPC handler, COMMANDS_SAFE_FOR_REMOTE, cleanup |
| `packages/ui/src/lib/desktop.ts` | `openRemoteFileInApp()` |
| `packages/ui/src/components/views/FilesView.tsx` | HTML preview, image fix, remote open, download |
| `packages/ui/src/components/layout/SidebarFilesTree.tsx` | download .catch() |
| `packages/web/server/lib/fs/routes.js` | /api/fs/serve, FILE_MIME_MAP, size limits, nosniff |
| `packages/web/server/lib/ui-auth/ui-auth.js` | URL auth whitelist |
| `packages/web/src/api/files.ts` | downloadFile runtimeFetch+blob |
| `packages/ui/src/lib/i18n/messages/*.ts` (9 files) | i18n keys |