### PR TITLE
feat: show session cost in desktop header

### DIFF
--- a/packages/ui/src/components/layout/ContextSidebarTab.tsx
+++ b/packages/ui/src/components/layout/ContextSidebarTab.tsx
@@ -8,6 +8,8 @@ import { useConfigStore } from '@/stores/useConfigStore';
 import { useUIStore } from '@/stores/useUIStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { computeCacheHitRate } from '@/stores/utils/tokenUtils';
+import { sumAssistantMessageCosts } from '@/stores/utils/costUtils';
+import { formatUsdCost } from '@/lib/costFormat';
 import { useSessions, useSessionMessageRecords } from '@/sync/sync-context';
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { getCurrentIntlLocale, useI18n } from '@/lib/i18n';
@@ -232,16 +234,6 @@ const computeContextBreakdown = (
 
 const formatNumber = (value: number): string => value.toLocaleString(getCurrentIntlLocale());
 
-const formatMoney = (value: number): string => {
-  if (!Number.isFinite(value) || value <= 0) return new Intl.NumberFormat(getCurrentIntlLocale(), { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(0);
-  return new Intl.NumberFormat(getCurrentIntlLocale(), {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: value < 0.01 ? 4 : 2,
-    maximumFractionDigits: value < 0.01 ? 4 : 2,
-  }).format(value);
-};
-
 const formatDateTime = (timestamp: number | null, timeFormatPreference: TimeFormatPreference): string => {
   if (!timestamp || !Number.isFinite(timestamp)) return '-';
   return formatDateTimeForPreference(timestamp, timeFormatPreference, {
@@ -338,10 +330,7 @@ export const ContextPanelContent: React.FC = () => {
       cache: { read: tokenBreakdown.cacheRead, write: tokenBreakdown.cacheWrite },
     });
 
-    const totalAssistantCost = assistantMessages.reduce((sum, message) => {
-      const cost = toNonNegativeNumber((message.info as { cost?: unknown }).cost);
-      return sum + cost;
-    }, 0);
+    const totalAssistantCost = sumAssistantMessageCosts(assistantMessages);
 
     const latestAssistantInfo = (contextMessage?.info ?? null) as (Message & { providerID?: string; modelID?: string }) | null;
     const providerModel = resolveProviderAndModel(
@@ -459,7 +448,7 @@ export const ContextPanelContent: React.FC = () => {
             { label: t('contextSidebar.stats.messages'), value: formatNumber(viewModel.messagesCount) },
             { label: t('contextSidebar.stats.user'), value: formatNumber(viewModel.userMessagesCount) },
             { label: t('contextSidebar.stats.assistant'), value: formatNumber(viewModel.assistantMessagesCount) },
-            { label: t('contextSidebar.stats.cost'), value: formatMoney(viewModel.totalAssistantCost) },
+            { label: t('contextSidebar.stats.cost'), value: formatUsdCost(viewModel.totalAssistantCost) },
           ] as const).map((item) => (
             <div key={item.label} className="rounded-lg bg-[var(--surface-elevated)]/70 px-3 py-2.5">
               <div className="typography-micro text-muted-foreground/70">{item.label}</div>

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -620,6 +620,7 @@ const isSameContextUsage = (
 
   return a.totalTokens === b.totalTokens
     && a.percentage === b.percentage
+    && (a.cost ?? 0) === (b.cost ?? 0)
     && a.contextLimit === b.contextLimit
     && (a.outputLimit ?? 0) === (b.outputLimit ?? 0)
     && (a.normalizedOutput ?? 0) === (b.normalizedOutput ?? 0)
@@ -2193,6 +2194,7 @@ export const Header: React.FC<HeaderProps> = ({
             <ContextUsageDisplay
               totalTokens={stableDesktopContextUsage.totalTokens}
               percentage={desktopHeaderDisplayPercentage}
+              cost={stableDesktopContextUsage.cost}
               colorPercentage={stableDesktopContextUsage.percentage}
               contextLimit={stableDesktopContextUsage.contextLimit}
               outputLimit={stableDesktopContextUsage.outputLimit ?? 0}

--- a/packages/ui/src/components/ui/ContextUsageDisplay.tsx
+++ b/packages/ui/src/components/ui/ContextUsageDisplay.tsx
@@ -5,10 +5,12 @@ import { MobileOverlayPanel } from '@/components/ui/MobileOverlayPanel';
 import { Icon } from "@/components/icon/Icon";
 import { useI18n } from '@/lib/i18n';
 import { clampPercent, resolveUsageTone } from '@/lib/quota';
+import { formatUsdCost } from '@/lib/costFormat';
 
 interface ContextUsageDisplayProps {
   totalTokens: number;
   percentage: number;
+  cost?: number;
   colorPercentage?: number;
   contextLimit: number;
   outputLimit?: number;
@@ -26,6 +28,7 @@ interface ContextUsageDisplayProps {
 export const ContextUsageDisplay: React.FC<ContextUsageDisplayProps> = ({
   totalTokens,
   percentage,
+  cost,
   colorPercentage,
   contextLimit,
   outputLimit,
@@ -73,6 +76,8 @@ export const ContextUsageDisplay: React.FC<ContextUsageDisplayProps> = ({
   const circularProgressOffset = circularProgressCircumference * (1 - progressPct / 100);
 
   const safeOutputLimit = typeof outputLimit === 'number' ? Math.max(outputLimit, 0) : 0;
+  const safeCost = typeof cost === 'number' && Number.isFinite(cost) && cost > 0 ? cost : 0;
+  const formattedCost = safeCost > 0 ? formatUsdCost(safeCost) : null;
   const tooltipLines = [
     t('contextUsage.tooltip.usedTokens', { tokens: formatTokens(totalTokens) }),
     t('contextUsage.tooltip.contextLimit', { tokens: formatTokens(contextLimit) }),
@@ -117,10 +122,14 @@ export const ContextUsageDisplay: React.FC<ContextUsageDisplayProps> = ({
               />
             </svg>
             <span className="text-foreground">{Math.min(percentage, 999).toFixed(1)}%</span>
+            {formattedCost ? <span className="text-muted-foreground">&middot;</span> : null}
+            {formattedCost ? <span className="text-foreground">{formattedCost}</span> : null}
           </>
         ) : (
           <>
             <span className={getPercentageColor(colorPct)}>{Math.min(percentage, 999).toFixed(1)}</span>%
+            {formattedCost ? <span className="text-muted-foreground">&middot;</span> : null}
+            {formattedCost ? <span className="text-foreground">{formattedCost}</span> : null}
           </>
         )}
       </span>
@@ -189,6 +198,12 @@ export const ContextUsageDisplay: React.FC<ContextUsageDisplayProps> = ({
                   {Math.min(percentage, 999).toFixed(1)}%
                 </span>
               </div>
+              {formattedCost ? (
+                <div className="flex justify-between items-center pt-1 border-t border-border/40">
+                  <span className="typography-meta text-muted-foreground">{t('contextSidebar.stats.cost')}</span>
+                  <span className="typography-meta text-foreground font-medium">{formattedCost}</span>
+                </div>
+              ) : null}
             </div>
           </div>
         </MobileOverlayPanel>

--- a/packages/ui/src/lib/costFormat.ts
+++ b/packages/ui/src/lib/costFormat.ts
@@ -1,0 +1,11 @@
+import { getCurrentIntlLocale } from '@/lib/i18n';
+
+export const formatUsdCost = (value: number): string => {
+  const safeValue = typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+  return new Intl.NumberFormat(getCurrentIntlLocale(), {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: safeValue > 0 && safeValue < 0.01 ? 4 : 2,
+    maximumFractionDigits: safeValue > 0 && safeValue < 0.01 ? 4 : 2,
+  }).format(safeValue);
+};

--- a/packages/ui/src/stores/types/sessionTypes.ts
+++ b/packages/ui/src/stores/types/sessionTypes.ts
@@ -36,6 +36,7 @@ export interface SessionHistoryMeta {
 export interface SessionContextUsage {
     totalTokens: number;
     percentage: number;
+    cost?: number;
     contextLimit: number;
     outputLimit?: number;
     normalizedOutput?: number;

--- a/packages/ui/src/stores/utils/costUtils.test.ts
+++ b/packages/ui/src/stores/utils/costUtils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { sumAssistantMessageCosts } from "./costUtils";
+
+describe("sumAssistantMessageCosts", () => {
+  test("sums positive assistant cost values from direct SDK messages", () => {
+    const cost = sumAssistantMessageCosts([
+      { role: "assistant", cost: 0.12 },
+      { role: "user", cost: 10 },
+      { role: "assistant", cost: 0.3 },
+    ]);
+
+    expect(cost).toBe(0.42);
+  });
+
+  test("sums positive assistant cost values from wrapped UI messages", () => {
+    const cost = sumAssistantMessageCosts([
+      { info: { role: "assistant", cost: 0.0042 } },
+      { info: { role: "assistant", cost: 0 } },
+      { info: { role: "assistant", cost: -1 } },
+      { info: { role: "assistant", cost: Number.NaN } },
+    ]);
+
+    expect(cost).toBe(0.0042);
+  });
+});

--- a/packages/ui/src/stores/utils/costUtils.ts
+++ b/packages/ui/src/stores/utils/costUtils.ts
@@ -1,0 +1,30 @@
+const toPositiveFiniteNumber = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return value;
+};
+
+const getMessageInfo = (message: unknown): Record<string, unknown> | null => {
+  if (!message || typeof message !== 'object') {
+    return null;
+  }
+
+  const record = message as Record<string, unknown>;
+  const info = record.info;
+  if (info && typeof info === 'object') {
+    return info as Record<string, unknown>;
+  }
+
+  return record;
+};
+
+export const sumAssistantMessageCosts = (messages: readonly unknown[]): number => {
+  return messages.reduce<number>((sum, message) => {
+    const info = getMessageInfo(message);
+    if (info?.role !== 'assistant') {
+      return sum;
+    }
+    return sum + toPositiveFiniteNumber(info.cost);
+  }, 0);
+};

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -64,6 +64,7 @@ import { getAttachedSessionDirectory } from "./session-worktree-contract"
 import { setSessionOpener } from "./session-navigation"
 import { getRuntimeKey } from "@/lib/runtime-switch"
 import { rememberRuntimeLiveStatus } from "./runtime-live-memory"
+import { sumAssistantMessageCosts } from "@/stores/utils/costUtils"
 
 export type { AttachedFile }
 
@@ -882,6 +883,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     if (!lastTokens) return null
 
     const totalTokens = lastTokens.input + lastTokens.output + lastTokens.reasoning + (lastTokens.cache?.read ?? 0) + (lastTokens.cache?.write ?? 0)
+    const cost = sumAssistantMessageCosts(messages)
     const thresholdLimit = contextLimit > 0 ? contextLimit : 200000
     const percentage = contextLimit > 0 ? Math.round((totalTokens / contextLimit) * 100) : 0
     const normalizedOutput = outputLimit > 0 ? Math.round((lastTokens.output / outputLimit) * 100) : undefined
@@ -889,6 +891,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     return {
       totalTokens,
       percentage,
+      ...(cost > 0 ? { cost } : {}),
       contextLimit: contextLimit || 0,
       outputLimit: outputLimit || undefined,
       normalizedOutput,


### PR DESCRIPTION
## Summary

Show actual session cost beside desktop header context usage:

<img width="345" height="39" alt="Screenshot 2026-06-12 at 9 59 23 PM" src="https://github.com/user-attachments/assets/d6631a23-909d-4054-8660-538ef1ce0704" />

This gives users the same cost visibility they already get in the context panel, without making them open the panel just to check spend.

The header reuses the existing actual assistant-message cost metadata used by the context panel. It only shows cost when real positive cost data is present, so free or subscription-based sessions remain uncluttered and we avoid showing estimates.

Related to: https://github.com/openchamber/openchamber/issues/1387.

## Testing

- `bun test "packages/ui/src/stores/utils/costUtils.test.ts"`
- `bun run type-check`
- `bun run lint`