### PR TITLE
feat: add quota provider plugins

### DIFF
--- a/examples/plugins/quota/opencode-go.js
+++ b/examples/plugins/quota/opencode-go.js
@@ -1,0 +1,403 @@
+// Example OpenChamber quota plugin for OpenCode Go.
+//
+// OpenCode Go is a low-cost subscription plan that gives reliable access to
+// popular open coding models through OpenCode's gateway:
+//   https://opencode.ai/docs/go
+//
+// What this plugin actually shows
+// -------------------------------
+//   1.  Whether your OpenCode Go API key is valid (checks against
+//       https://opencode.ai/zen/go/v1/models and counts the models).
+//   2.  The dashboard usage numbers (rolling 5h / weekly / monthly) for
+//       your subscription, if and only if you provide your OpenCode
+//       dashboard auth cookie + workspace id.
+//
+// Why two pieces
+// --------------
+//   OpenCode Go does NOT publish a public REST endpoint for usage. The
+//   live numbers only exist inside the workspace dashboard at
+//   https://opencode.ai/workspace/<workspaceId>/go, which is a SolidStart
+//   app behind a session cookie. There is no API key path to usage.
+//
+//   We don't try to probe individual Go models to "infer" usage —
+//   probing tells you whether a model is reachable, not whether your
+//   subscription is exhausted. Both are useful pieces of information
+//   but they are not the same thing, and conflating them just produces
+//   a noisy UI that doesn't answer the real question: "how much of my
+//   monthly $60 cap is left?"
+//
+// Set up live usage (one-time, ~30 seconds)
+// ----------------------------------------
+//
+//   1. Sign in to https://opencode.ai in any browser and open the Go
+//      usage page once:
+//        https://opencode.ai/workspace/<workspaceId>/go
+//   2. Copy the workspace id from the URL (the part after /workspace/,
+//      it starts with `wrk_`).
+//   3. Open DevTools -> Application -> Cookies -> https://opencode.ai
+//      and copy the value of the `auth` cookie.
+//   4. Save them to ONE of:
+//
+//        ~/.config/opencode/opencode-quota/opencode-go.json
+//        ~/.config/opencode-bar/opencode-go.json
+//        ~/.config/openchamber/opencode-go.json
+//        $XDG_CONFIG_HOME/opencode/opencode-quota/opencode-go.json
+//
+//      File shape:
+//
+//        {
+//          "workspaceId": "wrk_XXXXXXXXXXXXXXXXXXXXXXXX",
+//          "authCookie":  "<paste-cookie-value-here>"
+//        }
+//
+//   Or use environment variables (preferred for shared machines):
+//
+//        export OPENCODE_GO_WORKSPACE_ID="wrk_XXXX..."
+//        export OPENCODE_GO_AUTH_COOKIE="<cookie-value>"
+//
+//   The cookie expires with your browser session. When you see usage stop
+//   updating, repeat step 3 and update the file/environment variable.
+//
+// To install:
+//   cp examples/plugins/quota/opencode-go.js \
+//      ~/.config/openchamber/plugins/quota/opencode-go.js
+
+const MODELS_URL = 'https://opencode.ai/zen/go/v1/models';
+const DASHBOARD_URL_PREFIX = 'https://opencode.ai/workspace';
+const CHECK_TIMEOUT_MS = 15_000;
+
+const WINDOW_LABELS = {
+  rollingUsage: '5h',
+  weeklyUsage: 'weekly',
+  monthlyUsage: 'monthly',
+};
+
+const HTML_DECODE = {
+  '&quot;': '"',
+  '&#34;': '"',
+  '&#x27;': "'",
+  '&#39;': "'",
+  '&amp;': '&',
+  '\\"': '"',
+  '\\u0022': '"',
+};
+
+const PROVIDER_ID = 'opencode-go';
+const PROVIDER_NAME = 'OpenCode Go';
+const ALIASES = ['opencode-go', 'opencode_zen_go', 'opengogo'];
+
+const DASHBOARD_SETUP_INSTRUCTION = [
+  'OpenCode Go usage needs your dashboard auth cookie. To see real numbers:',
+  '  1. Sign in at https://opencode.ai and open the Go usage page.',
+  '  2. Copy the workspaceId from the URL (starts with wrk_).',
+  '  3. Copy the `auth` cookie value from DevTools -> Application -> Cookies.',
+  '  4. Save them to ~/.config/opencode/opencode-quota/opencode-go.json',
+  '     (or set OPENCODE_GO_WORKSPACE_ID + OPENCODE_GO_AUTH_COOKIE env vars).',
+].join('\n');
+
+const isLikelySafePath = (value) => {
+  if (typeof value !== 'string') return false;
+  return value.length > 0 && !value.includes('\0') && !value.includes('\n');
+};
+
+const configPathCandidates = () => {
+  const home = (typeof process !== 'undefined' && process.env && process.env.HOME) || '';
+  const xdg = (typeof process !== 'undefined' && process.env && process.env.XDG_CONFIG_HOME) || '';
+  const explicit = (typeof process !== 'undefined' && process.env && process.env.OPENCODE_GO_CONFIG_FILE) || '';
+  const list = [];
+  if (explicit) list.push(explicit);
+  if (xdg) {
+    list.push(`${xdg}/opencode/opencode-quota/opencode-go.json`);
+    list.push(`${xdg}/opencode-bar/opencode-go.json`);
+    list.push(`${xdg}/openchamber/opencode-go.json`);
+  }
+  if (home) {
+    list.push(`${home}/.config/opencode/opencode-quota/opencode-go.json`);
+    list.push(`${home}/.config/opencode-bar/opencode-go.json`);
+    list.push(`${home}/.config/openchamber/opencode-go.json`);
+  }
+  return list.filter(isLikelySafePath);
+};
+
+const loadDashboardConfig = async () => {
+  const env = (typeof process !== 'undefined' && process.env) || {};
+  const envWorkspace = env.OPENCODE_GO_WORKSPACE_ID && env.OPENCODE_GO_WORKSPACE_ID.trim();
+  const envCookie = env.OPENCODE_GO_AUTH_COOKIE && env.OPENCODE_GO_AUTH_COOKIE.trim();
+  if (envWorkspace || envCookie) {
+    if (envWorkspace && envCookie) {
+      return { workspaceId: envWorkspace, authCookie: envCookie, source: 'env' };
+    }
+    return { error: 'OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE must both be set.' };
+  }
+
+  for (const path of configPathCandidates()) {
+    try {
+      let raw;
+      if (typeof Bun !== 'undefined' && Bun.file) {
+        const file = Bun.file(path);
+        if (!(await file.exists())) continue;
+        raw = await file.text();
+      } else {
+        const fs = await import('node:fs/promises');
+        try {
+          await fs.access(path);
+        } catch {
+          continue;
+        }
+        raw = await fs.readFile(path, 'utf-8');
+      }
+      const parsed = JSON.parse(raw);
+      const workspaceId = typeof parsed.workspaceId === 'string' ? parsed.workspaceId.trim() : '';
+      const authCookie = typeof parsed.authCookie === 'string' ? parsed.authCookie.trim() : '';
+      if (workspaceId && authCookie) {
+        return { workspaceId, authCookie, source: path };
+      }
+      if (workspaceId || authCookie) {
+        return { error: `${path} needs both workspaceId and authCookie.` };
+      }
+    } catch {}
+  }
+
+  return null;
+};
+
+const normalizeHtml = (html) => {
+  let text = html;
+  for (const [encoded, decoded] of Object.entries(HTML_DECODE)) {
+    text = text.split(encoded).join(decoded);
+  }
+  return text;
+};
+
+const captureObjectBody = (fieldName, text) => {
+  // Matches both shapes seen in the wild:
+  //   1. JSON-in-__next_f:    "rollingUsage":{...}
+  //   2. SolidStart inline:   rollingUsage:$R[1]={...}
+  const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(
+    `["']?${escaped}["']?\\s*:\\s*(?:\\$R\\[\\d+\\]\\s*=\\s*)?\\{([^{}]*)\\}`,
+    's',
+  );
+  const match = pattern.exec(text);
+  return match ? match[1] : null;
+};
+
+const captureNumber = (fieldName, text) => {
+  const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`["']?${escaped}["']?\\s*:\\s*"?(-?\\d+(?:\\.\\d+)?)"?`);
+  const match = pattern.exec(text);
+  if (!match) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : null;
+};
+
+const parseWindow = (fieldName, text, now) => {
+  const body = captureObjectBody(fieldName, text);
+  if (!body) return null;
+  const usagePercent = captureNumber('usagePercent', body);
+  const resetInSec = captureNumber('resetInSec', body);
+  if (usagePercent === null || resetInSec === null) return null;
+  const used = Math.max(0, Math.min(100, usagePercent));
+  const resetAtMs = now + Math.max(0, Math.round(resetInSec)) * 1000;
+  return {
+    usedPercent: used,
+    remainingPercent: Math.max(0, 100 - used),
+    resetAt: new Date(resetAtMs).toISOString(),
+    resetAfterSeconds: Math.max(0, Math.round(resetInSec)),
+  };
+};
+
+const parseDashboardUsage = (html) => {
+  const text = normalizeHtml(html);
+  const now = Date.now();
+  const windows = {};
+  for (const [field, label] of Object.entries(WINDOW_LABELS)) {
+    const parsed = parseWindow(field, text, now);
+    if (parsed) windows[label] = parsed;
+  }
+  return Object.keys(windows).length > 0 ? windows : null;
+};
+
+const fetchDashboardUsage = async ({ workspaceId, authCookie }) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CHECK_TIMEOUT_MS);
+  try {
+    const response = await fetch(
+      `${DASHBOARD_URL_PREFIX}/${encodeURIComponent(workspaceId)}/go`,
+      {
+        headers: {
+          Accept: 'text/html,application/xhtml+xml',
+          Cookie: authCookie.includes('auth=') ? authCookie : `auth=${authCookie}`,
+          'User-Agent': 'openchamber-quota-plugin (https://opencode.ai)',
+        },
+        signal: controller.signal,
+      },
+    );
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new Error('Auth cookie expired or invalid — re-copy it from DevTools.');
+      }
+      throw new Error(`OpenCode Go dashboard returned HTTP ${response.status}`);
+    }
+    const html = await response.text();
+    return parseDashboardUsage(html);
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const checkApiKey = async (apiKey) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CHECK_TIMEOUT_MS);
+  try {
+    const response = await fetch(MODELS_URL, {
+      headers: {
+        Authorization: `Bearer ${apiKey.trim()}`,
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      if (response.status === 401) throw new Error('Invalid OpenCode Go API key.');
+      throw new Error(`OpenCode Go key check failed: HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    if (data && typeof data === 'object') {
+      if (Array.isArray(data.data)) return data.data.length;
+      if (Array.isArray(data.models)) return data.models.length;
+      if (Array.isArray(data)) return data.length;
+      return Object.keys(data).length;
+    }
+    return 0;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const buildWindows = (parsed) => {
+  const windows = {};
+  for (const [label, info] of Object.entries(parsed || {})) {
+    windows[label] = {
+      usedPercent: info.usedPercent,
+      remainingPercent: info.remainingPercent,
+      windowSeconds: null,
+      resetAt: info.resetAt,
+      resetAtFormatted: null,
+      resetAfterSeconds: info.resetAfterSeconds,
+      resetAfterFormatted: info.resetAfterSeconds > 0
+        ? `${Math.round(info.resetAfterSeconds / 60)} min`
+        : null,
+      valueLabel: `${info.usedPercent.toFixed(0)}% used`,
+    };
+  }
+  return windows;
+};
+
+const buildSetupWindow = (modelCount) => ({
+  usedPercent: null,
+  remainingPercent: null,
+  windowSeconds: null,
+  resetAt: null,
+  resetAtFormatted: null,
+  resetAfterFormatted: null,
+  valueLabel: `Active (${modelCount} models) — see error below for setup`,
+});
+
+export default ({
+  buildResult,
+  readAuthFile,
+  getAuthEntry,
+  normalizeAuthEntry,
+}) => {
+  const getApiKey = () => {
+    const auth = readAuthFile();
+    const entry = normalizeAuthEntry(getAuthEntry(auth, ALIASES));
+    return entry?.key || entry?.token || null;
+  };
+
+  return {
+    providerId: PROVIDER_ID,
+    providerName: PROVIDER_NAME,
+    aliases: ALIASES,
+
+    isConfigured: () => Boolean(getApiKey()),
+
+    fetchQuota: async () => {
+      const apiKey = getApiKey();
+      if (!apiKey) {
+        return buildResult({
+          providerId: PROVIDER_ID,
+          providerName: PROVIDER_NAME,
+          ok: false,
+          configured: false,
+          error: 'Not configured. Run /connect in OpenCode and pick OpenCode Go to store the API key.',
+        });
+      }
+
+      let modelCount = 0;
+      try {
+        modelCount = await checkApiKey(apiKey);
+      } catch (error) {
+        return buildResult({
+          providerId: PROVIDER_ID,
+          providerName: PROVIDER_NAME,
+          ok: false,
+          configured: true,
+          error: error instanceof Error ? error.message : 'OpenCode Go key check failed',
+        });
+      }
+
+      const dashboardConfig = await loadDashboardConfig();
+      if (dashboardConfig && dashboardConfig.error) {
+        return buildResult({
+          providerId: PROVIDER_ID,
+          providerName: PROVIDER_NAME,
+          ok: true,
+          configured: true,
+          usage: { windows: { Subscription: buildSetupWindow(modelCount) } },
+          error: dashboardConfig.error,
+        });
+      }
+      if (!dashboardConfig) {
+        return buildResult({
+          providerId: PROVIDER_ID,
+          providerName: PROVIDER_NAME,
+          ok: true,
+          configured: true,
+          usage: { windows: { Subscription: buildSetupWindow(modelCount) } },
+          error: DASHBOARD_SETUP_INSTRUCTION,
+        });
+      }
+
+      try {
+        const parsed = await fetchDashboardUsage(dashboardConfig);
+        if (!parsed) {
+          return buildResult({
+            providerId: PROVIDER_ID,
+            providerName: PROVIDER_NAME,
+            ok: true,
+            configured: true,
+            usage: { windows: { Subscription: buildSetupWindow(modelCount) } },
+            error: `Dashboard loaded from ${dashboardConfig.source} but no usage windows were found. The page layout may have changed; please report.`,
+          });
+        }
+        return buildResult({
+          providerId: PROVIDER_ID,
+          providerName: PROVIDER_NAME,
+          ok: true,
+          configured: true,
+          usage: { windows: buildWindows(parsed) },
+        });
+      } catch (error) {
+        return buildResult({
+          providerId: PROVIDER_ID,
+          providerName: PROVIDER_NAME,
+          ok: true,
+          configured: true,
+          usage: { windows: { Subscription: buildSetupWindow(modelCount) } },
+          error: error instanceof Error ? error.message : 'Dashboard fetch failed',
+        });
+      }
+    },
+  };
+};

--- a/packages/ui/src/apps/MobileApp.tsx
+++ b/packages/ui/src/apps/MobileApp.tsx
@@ -26,7 +26,7 @@ import { opencodeClient } from '@/lib/opencode/client';
 import type { ProjectEntry, RuntimeAPIs } from '@/lib/api/types';
 import { useI18n } from '@/lib/i18n';
 import { resolveProjectForDirectory, resolveProjectForSessionDirectory } from '@/lib/projectResolution';
-import { clampPercent, formatQuotaResetLabel, formatQuotaValueLabel, formatWindowLabel, QUOTA_PROVIDERS, resolveUsageTone } from '@/lib/quota';
+import { clampPercent, formatQuotaResetLabel, formatQuotaValueLabel, formatWindowLabel, mergeQuotaProviders, resolveUsageTone } from '@/lib/quota';
 import { getDisplayModelName } from '@/lib/quota/model-families';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { sessionEvents } from '@/lib/sessionEvents';
@@ -610,7 +610,7 @@ const MobileSessionMetadataButton = React.memo(function MobileSessionMetadataBut
 
   const usageGroups = React.useMemo<MobileUsageProviderGroup[]>(() => {
     const resultsByProvider = new Map(quotaResults.map((result) => [result.providerId, result]));
-    return QUOTA_PROVIDERS
+    return mergeQuotaProviders(quotaResults)
       .filter((providerMeta) => dropdownProviderIds.includes(providerMeta.id))
       .filter((providerMeta) => resultsByProvider.get(providerMeta.id)?.configured === true)
       .map((providerMeta) => {

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -39,7 +39,7 @@ import { cn, hasModifier } from '@/lib/utils';
 import { McpDropdownContent } from '@/components/mcp/McpDropdown';
 import { McpIcon } from '@/components/icons/McpIcon';
 import { ProviderLogo } from '@/components/ui/ProviderLogo';
-import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, QUOTA_PROVIDERS, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
+import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, mergeQuotaProviders, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
 import { UsageProgressBar } from '@/components/sections/usage/UsageProgressBar';
 import { PaceIndicator } from '@/components/sections/usage/PaceIndicator';
 import { updateDesktopSettings } from '@/lib/persistence';
@@ -1020,7 +1020,7 @@ export const Header: React.FC<HeaderProps> = ({
   const rateLimitGroups = React.useMemo(() => {
     const groups: RateLimitGroup[] = [];
 
-    for (const provider of QUOTA_PROVIDERS) {
+    for (const provider of mergeQuotaProviders(quotaResults)) {
       if (!dropdownProviderIds.includes(provider.id)) {
         continue;
       }

--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -32,7 +32,7 @@ import { ProviderLogo } from '@/components/ui/ProviderLogo';
 import { UsageProgressBar } from '@/components/sections/usage/UsageProgressBar';
 import { PaceIndicator } from '@/components/sections/usage/PaceIndicator';
 import { Icon } from "@/components/icon/Icon";
-import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, QUOTA_PROVIDERS, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
+import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, mergeQuotaProviders, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
 import { useQuotaAutoRefresh, useQuotaStore } from '@/stores/useQuotaStore';
 import { updateDesktopSettings } from '@/lib/persistence';
 import { formatTimeForPreference } from '@/lib/timeFormat';
@@ -767,7 +767,7 @@ const VSCodeHeader: React.FC<VSCodeHeaderProps> = ({ title, showBack, onBack, on
       error?: string;
     }> = [];
 
-    for (const provider of QUOTA_PROVIDERS) {
+    for (const provider of mergeQuotaProviders(quotaResults)) {
       if (!dropdownProviderIds.includes(provider.id)) {
         continue;
       }

--- a/packages/ui/src/components/sections/usage/UsagePage.tsx
+++ b/packages/ui/src/components/sections/usage/UsagePage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
 import { Checkbox } from '@/components/ui/checkbox';
 import { UsageCard } from './UsageCard';
-import { QUOTA_PROVIDERS } from '@/lib/quota';
+import { QUOTA_PROVIDERS, getQuotaProviderMeta } from '@/lib/quota';
 import { useQuotaAutoRefresh, useQuotaStore } from '@/stores/useQuotaStore';
 import { updateDesktopSettings } from '@/lib/persistence';
 import { ProviderLogo } from '@/components/ui/ProviderLogo';
@@ -70,7 +70,9 @@ export const UsagePage: React.FC = () => {
 
   const selectedResult = results.find((entry) => entry.providerId === selectedProviderId) ?? null;
 
-  const providerMeta = QUOTA_PROVIDERS.find((provider) => provider.id === selectedProviderId);
+  const providerMeta = selectedProviderId
+    ? getQuotaProviderMeta(selectedProviderId, selectedResult?.providerName)
+    : null;
   const providerName = providerMeta?.name ?? selectedProviderId ?? t('settings.usage.sidebar.title');
   const usage = selectedResult?.usage;
   const showInDropdown = selectedProviderId ? dropdownProviderIds.includes(selectedProviderId) : false;

--- a/packages/ui/src/components/sections/usage/UsageSidebar.tsx
+++ b/packages/ui/src/components/sections/usage/UsageSidebar.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Icon } from "@/components/icon/Icon";
 import { cn } from '@/lib/utils';
-import { QUOTA_PROVIDERS, resolveUsageTone } from '@/lib/quota';
+import { mergeQuotaProviders, resolveUsageTone } from '@/lib/quota';
 import { useQuotaStore } from '@/stores/useQuotaStore';
 import { updateDesktopSettings } from '@/lib/persistence';
 import { useI18n } from '@/lib/i18n';
@@ -43,6 +43,7 @@ export const UsageSidebar: React.FC<UsageSidebarProps> = ({ onItemSelect }) => {
   const showPredValues = useQuotaStore((state) => state.showPredValues);
   const setShowPredValues = useQuotaStore((state) => state.setShowPredValues);
   const loadUsageSettings = useQuotaStore((state) => state.loadSettings);
+  const providers = React.useMemo(() => mergeQuotaProviders(results), [results]);
 
   React.useEffect(() => {
     void loadUsageSettings();
@@ -90,7 +91,7 @@ export const UsageSidebar: React.FC<UsageSidebarProps> = ({ onItemSelect }) => {
       <div className="border-b px-3 pt-4 pb-3">
         <h2 className="text-base font-semibold text-foreground mb-3">{t('settings.usage.sidebar.title')}</h2>
         <div className="flex items-center justify-between gap-2">
-          <span className="typography-meta text-muted-foreground">{t('settings.usage.sidebar.total', { count: QUOTA_PROVIDERS.length })}</span>
+          <span className="typography-meta text-muted-foreground">{t('settings.usage.sidebar.total', { count: providers.length })}</span>
           <div className="flex items-center gap-2">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -157,7 +158,7 @@ export const UsageSidebar: React.FC<UsageSidebarProps> = ({ onItemSelect }) => {
       </div>
 
       <ScrollableOverlay outerClassName="flex-1 min-h-0" className="space-y-1 px-3 py-2 overflow-x-hidden">
-        {QUOTA_PROVIDERS.map((provider) => {
+        {providers.map((provider) => {
           const result = results.find((entry) => entry.providerId === provider.id);
           const percent = getUsagePercent(result?.usage);
           const tone = resolveUsageTone(percent);

--- a/packages/ui/src/hooks/useTraySync.ts
+++ b/packages/ui/src/hooks/useTraySync.ts
@@ -15,7 +15,7 @@ import {
   resolveGlobalSessionDirectory,
 } from '@/stores/useGlobalSessionsStore';
 import { useQuotaStore } from '@/stores/useQuotaStore';
-import { QUOTA_PROVIDERS, formatWindowLabel, formatQuotaValueLabel } from '@/lib/quota';
+import { formatWindowLabel, formatQuotaValueLabel, mergeQuotaProviders } from '@/lib/quota';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useGitStore } from '@/stores/useGitStore';
@@ -166,7 +166,7 @@ const buildUsage = (): TrayUsage => {
 
   const byProvider = new Map(results.map((result) => [result.providerId, result]));
   const groups: TrayUsageGroup[] = [];
-  for (const meta of QUOTA_PROVIDERS) {
+  for (const meta of mergeQuotaProviders(results)) {
     if (!dropdownProviderIds.includes(meta.id)) continue;
     const result = byProvider.get(meta.id);
     if (!result || result.configured !== true) continue;

--- a/packages/ui/src/lib/quota/index.ts
+++ b/packages/ui/src/lib/quota/index.ts
@@ -1,4 +1,4 @@
-export { QUOTA_PROVIDERS, QUOTA_PROVIDER_MAP } from './providers';
+export { QUOTA_PROVIDERS, QUOTA_PROVIDER_MAP, getQuotaProviderMeta, mergeQuotaProviders } from './providers';
 export type { QuotaProviderMeta } from './providers';
 export {
   clampPercent,

--- a/packages/ui/src/lib/quota/providers/index.ts
+++ b/packages/ui/src/lib/quota/providers/index.ts
@@ -28,3 +28,30 @@ export const QUOTA_PROVIDER_MAP = QUOTA_PROVIDERS.reduce<
   acc[provider.id] = provider;
   return acc;
 }, {});
+
+export const getQuotaProviderMeta = (
+  providerId: QuotaProviderId | string,
+  providerName?: string | null
+): QuotaProviderMeta => {
+  return QUOTA_PROVIDER_MAP[providerId] ?? {
+    id: providerId as QuotaProviderId,
+    name: providerName || providerId,
+  };
+};
+
+export const mergeQuotaProviders = (
+  results: Array<{ providerId: QuotaProviderId | string; providerName?: string | null }> = []
+): QuotaProviderMeta[] => {
+  const providers = [...QUOTA_PROVIDERS];
+  const seen = new Set(providers.map((provider) => provider.id));
+
+  for (const result of results) {
+    if (seen.has(result.providerId)) {
+      continue;
+    }
+    providers.push(getQuotaProviderMeta(result.providerId, result.providerName));
+    seen.add(result.providerId);
+  }
+
+  return providers;
+};

--- a/packages/ui/src/stores/useQuotaStore.ts
+++ b/packages/ui/src/stores/useQuotaStore.ts
@@ -64,7 +64,7 @@ const parseSettings = (data: Record<string, unknown> | null): QuotaSettingsState
     : null;
   const dropdownProviderIds = rawDropdownProviders
     ? rawDropdownProviders.filter((entry): entry is QuotaProviderId =>
-        typeof entry === 'string' && allProviderIds.includes(entry as QuotaProviderId)
+        typeof entry === 'string'
       )
     : allProviderIds;
 
@@ -164,6 +164,19 @@ export const useQuotaStore = create<QuotaStore>()(
       fetchAllQuotas: async () => {
         set({ isLoading: true, error: null });
         const providerIds = QUOTA_PROVIDERS.map((provider) => provider.id);
+        try {
+          const resp = await runtimeFetch('/api/quota/providers');
+          if (resp.ok) {
+            const data = await resp.json().catch(() => null);
+            if (data?.providers) {
+              for (const id of data.providers) {
+                if (!providerIds.includes(id)) providerIds.push(id);
+              }
+            }
+          }
+        } catch (error) {
+          console.warn('Failed to fetch dynamic quota providers:', error);
+        }
         try {
           await Promise.all(
             providerIds.map((providerId) => get().fetchProviderQuota(providerId))

--- a/packages/ui/src/types/quota.ts
+++ b/packages/ui/src/types/quota.ts
@@ -14,7 +14,8 @@ export type QuotaProviderId =
   | 'minimax-coding-plan'
   | 'minimax-cn-coding-plan'
   | 'ollama-cloud'
-  | 'wafer';
+  | 'wafer'
+  | (string & {});
 
 export interface UsageWindow {
   usedPercent: number | null;

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { pathToFileURL } from 'node:url';
 
 type AuthEntry = Record<string, unknown> | string;
 type AuthFile = Record<string, AuthEntry>;
@@ -124,6 +125,7 @@ const OPENCODE_CONFIG_DIR = path.join(os.homedir(), '.config', 'opencode');
 const OPENCODE_DATA_DIR = path.join(os.homedir(), '.local', 'share', 'opencode');
 const AUTH_FILE = path.join(OPENCODE_DATA_DIR, 'auth.json');
 const OLLAMA_CLOUD_COOKIE_PATH = path.join(os.homedir(), '.config', 'ollama-quota', 'cookie');
+const OPENCHAMBER_PLUGINS_DIR = path.join(os.homedir(), '.config', 'openchamber', 'plugins', 'quota');
 
 
 const ANTIGRAVITY_ACCOUNTS_PATHS = [
@@ -453,7 +455,76 @@ export const listConfiguredQuotaProviders = () => {
     configured.add('wafer');
   }
 
+  // Plugin providers from ~/.config/openchamber/plugins/quota/. Each plugin
+  // exports a default function; we don't execute plugin code (different
+  // runtime, no server context) but we read its static `providerId` and
+  // `aliases` via regex on the file text. A plugin is considered
+  // "configured" if any of its alias keys has an auth.json entry. The
+  // plugin file's own `isConfigured` and `fetchQuota` still run inside the
+  // webview bridge, which has access to the same `~/.config/opencode/auth.json`
+  // and the same plugin loader the standalone web/desktop servers use.
+  if (fs.existsSync(OPENCHAMBER_PLUGINS_DIR)) {
+    let pluginFiles: string[] = [];
+    try {
+      pluginFiles = fs.readdirSync(OPENCHAMBER_PLUGINS_DIR).filter((name) => name.endsWith('.js') || name.endsWith('.mjs'));
+    } catch (err) {
+      // Plugin directory unreadable — fall through to no plugins.
+      void err;
+    }
+    for (const file of pluginFiles) {
+      const fullPath = path.join(OPENCHAMBER_PLUGINS_DIR, file);
+      const text = readTextFile(fullPath);
+      if (!text) continue;
+      const providerId = extractPluginId(text);
+      if (!providerId) continue;
+      const aliases = extractPluginAliases(text);
+      const candidateKeys = aliases.length > 0 ? [providerId, ...aliases] : [providerId];
+      const pluginAuth = normalizeAuthEntry(getAuthEntry(auth, candidateKeys));
+      if (pluginAuth && ((pluginAuth as Record<string, unknown>).key || (pluginAuth as Record<string, unknown>).token)) {
+        configured.add(providerId);
+      }
+    }
+  }
+
   return Array.from(configured);
+};
+
+// Extracts the first `providerId: ...` value from a plugin source file.
+// Accepts a string literal (`'foo'`, `"foo"`) or a `const` reference
+// (`PROVIDER_ID`) that is also defined in the same file. Cheap, regex-
+// only; the plugin file is not executed.
+const extractPluginId = (source: string): string | null => {
+  const literal = source.match(/providerId\s*[:=]\s*['"]([^'"]+)['"]/);
+  if (literal) return literal[1];
+  const constRef = source.match(/providerId\s*[:=]\s*([A-Z][A-Z0-9_]*)/);
+  if (!constRef) return null;
+  const name = constRef[1];
+  const def = source.match(new RegExp(`(?:const|let|var)\\s+${name}\\s*=\\s*['"]([^'"]+)['"]`));
+  return def ? def[1] : null;
+};
+
+const extractStringArrayItems = (arraySource: string): string[] => {
+  const items: string[] = [];
+  const re = /['"]([^'"]+)['"]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(arraySource)) !== null) {
+    items.push(m[1]);
+  }
+  return items;
+};
+
+// Extracts `aliases: ['a', 'b']`, multiline arrays, or const references like
+// `aliases: ALIASES` where `const ALIASES = [...]` is declared in the same file.
+const extractPluginAliases = (source: string): string[] => {
+  const inline = source.match(/aliases\s*[:=]\s*\[([\s\S]*?)\]/);
+  if (inline) return extractStringArrayItems(inline[1]);
+
+  const constRef = source.match(/aliases\s*[:=]\s*([A-Z][A-Z0-9_]*)/);
+  if (!constRef) return [];
+
+  const name = constRef[1];
+  const def = source.match(new RegExp(String.raw`(?:const|let|var)\s+${name}\s*=\s*\[([\s\S]*?)\]`));
+  return def ? extractStringArrayItems(def[1]) : [];
 };
 
 export const fetchCodexQuota = async (): Promise<ProviderResult> => {
@@ -1893,12 +1964,89 @@ export const fetchQuotaForProvider = async (providerId: string): Promise<Provide
     case 'wafer':
       return fetchWaferQuota();
     default:
-      return buildResult({
-        providerId,
-        providerName: providerId,
-        ok: false,
-        configured: false,
-        error: 'Unsupported provider',
+      // Plugin provider: load ~/.config/openchamber/plugins/quota/<id>.js,
+      // execute it with the same context the web/desktop loader passes, and
+      // delegate to its fetchQuota. The plugin's own isConfigured() decides
+      // whether the API key / cookie is present; we surface that result.
+      return fetchPluginProviderQuota(providerId);
+  }
+};
+
+// Load and execute a single quota plugin by providerId. Mirrors the
+// web/desktop server loader but inlines it here so VS Code users do not
+// need a running web server.
+const loadPluginProvider = async (providerId: string) => {
+  if (!fs.existsSync(OPENCHAMBER_PLUGINS_DIR)) return null;
+  let files: string[] = [];
+  try {
+    files = fs.readdirSync(OPENCHAMBER_PLUGINS_DIR).filter((n) => n.endsWith('.js') || n.endsWith('.mjs'));
+  } catch {
+    return null;
+  }
+  for (const file of files) {
+    const text = readTextFile(path.join(OPENCHAMBER_PLUGINS_DIR, file));
+    if (!text) continue;
+    if (extractPluginId(text) !== providerId) continue;
+    try {
+      // Use dynamic import() so the file is evaluated as an ES module.
+      // Plugins are expected to `export default (ctx) => ({...})`.
+      const fileUrl = pathToFileURL(path.join(OPENCHAMBER_PLUGINS_DIR, file)).href;
+      // Bust Node's import cache between calls so plugin authors can edit
+      // a plugin file and reload without restarting the extension host.
+      const mod = await import(`${fileUrl}?t=${Date.now()}`);
+      const factory = (mod && (mod.default || mod)) as (ctx: unknown) => Record<string, unknown>;
+      if (typeof factory !== 'function') return null;
+      const provider = factory({
+        buildResult,
+        toUsageWindow,
+        toNumber,
+        toTimestamp,
+        formatMoney,
+        readAuthFile,
+        getAuthEntry,
+        normalizeAuthEntry,
       });
+      return provider;
+    } catch (err) {
+      console.error(`[openchamber:plugins] Failed to load ${file}:`, err);
+      return null;
+    }
+  }
+  return null;
+};
+
+const fetchPluginProviderQuota = async (providerId: string): Promise<ProviderResult> => {
+  const plugin = await loadPluginProvider(providerId);
+  if (!plugin || typeof (plugin as { fetchQuota?: unknown }).fetchQuota !== 'function') {
+    return buildResult({
+      providerId,
+      providerName: providerId,
+      ok: false,
+      configured: false,
+      error: 'Unsupported provider (no built-in or plugin handler for this id)',
+    });
+  }
+  const isConfigured = typeof (plugin as { isConfigured?: () => boolean }).isConfigured === 'function'
+    ? Boolean((plugin as { isConfigured: () => boolean }).isConfigured())
+    : true;
+  if (!isConfigured) {
+    return buildResult({
+      providerId,
+      providerName: (plugin as { providerName?: string }).providerName || providerId,
+      ok: false,
+      configured: false,
+      error: 'Plugin not configured (missing auth)',
+    });
+  }
+  try {
+    return await (plugin as { fetchQuota: () => Promise<ProviderResult> }).fetchQuota();
+  } catch (err) {
+    return buildResult({
+      providerId,
+      providerName: (plugin as { providerName?: string }).providerName || providerId,
+      ok: false,
+      configured: true,
+      error: err instanceof Error ? err.message : 'Plugin fetch failed',
+    });
   }
 };

--- a/packages/web/server/lib/plugins/DOCUMENTATION.md
+++ b/packages/web/server/lib/plugins/DOCUMENTATION.md
@@ -1,0 +1,72 @@
+# Plugins Module Documentation
+
+## Purpose
+This module loads user-owned OpenChamber extension files from the local config directory.
+
+OpenChamber plugins are separate from OpenCode plugins. OpenCode plugins extend OpenCode request/provider behavior, while OpenChamber plugins extend OpenChamber UI/server features. The first supported OpenChamber plugin interface is for quota providers.
+
+## Quota provider plugins
+Quota plugins live outside the package directory so they survive package updates:
+
+```text
+~/.config/openchamber/plugins/quota/<provider>.js
+~/.config/openchamber/plugins/quota/<provider>.mjs
+```
+
+Each plugin file should export a default function. The loader calls the function with a context object and expects a provider implementation object in return.
+
+```js
+export default ({
+  buildResult,
+  toUsageWindow,
+  toNumber,
+  toTimestamp,
+  formatMoney,
+  readAuthFile,
+  getAuthEntry,
+  normalizeAuthEntry,
+}) => ({
+  providerId: 'my-provider',
+  providerName: 'My Provider',
+  isConfigured: () => {
+    const auth = readAuthFile();
+    const entry = normalizeAuthEntry(getAuthEntry(auth, ['my-provider']));
+    return Boolean(entry?.key || entry?.token);
+  },
+  fetchQuota: async () => {
+    return buildResult({
+      providerId: 'my-provider',
+      providerName: 'My Provider',
+      configured: true,
+      usage: {
+        windows: {
+          daily: toUsageWindow({ usedPercent: 25, remainingPercent: 75 }),
+        },
+      },
+    });
+  },
+});
+```
+
+## Loader context
+The quota plugin context currently includes:
+
+- `buildResult`
+- `toUsageWindow`
+- `toNumber`
+- `toTimestamp`
+- `formatMoney`
+- `readAuthFile`
+- `getAuthEntry`
+- `normalizeAuthEntry`
+
+These helpers mirror the built-in quota provider helpers so plugin providers can produce the same API shape without importing internal files directly.
+
+## Provider ID collisions
+If a quota plugin returns a `providerId` that matches a built-in quota provider, the plugin overrides the built-in provider in the local registry. This allows local customization, but it is intentionally silent at runtime, so plugin authors should choose stable, unique provider IDs unless they explicitly want to replace a built-in provider.
+
+## Trust boundary
+Plugin files are regular JavaScript modules loaded by the local OpenChamber server. Users should only install plugin files they trust. This is intended for local user customization, not for loading untrusted remote code.
+
+## Runtime scope
+The plugin loader runs in the web, desktop (Electron), and VS Code extension runtimes. The web and desktop runtimes use the full server-side loader at `packages/web/server/lib/plugins/loader.js`, which executes plugin modules and returns their provider implementations directly. The VS Code extension host cannot run the full loader (different runtime, no express context) but its quota list in `packages/vscode/src/quotaProviders.ts` now scans the same plugin directory via regex on each file's `providerId` / `aliases` literals; a plugin is reported as "configured" if any of its alias keys has an entry in `~/.local/share/opencode/auth.json`. Plugin `fetchQuota` calls still run through the webview bridge, which sees the same auth.json and the same plugin directory.

--- a/packages/web/server/lib/plugins/loader.js
+++ b/packages/web/server/lib/plugins/loader.js
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+export async function loadQuotaPlugins() {
+  const dir = path.join(os.homedir(), '.config', 'openchamber', 'plugins', 'quota');
+  const registry = {};
+  if (!fs.existsSync(dir)) return registry;
+
+  let files = [];
+  try {
+    files = fs.readdirSync(dir).filter(f => f.endsWith('.js') || f.endsWith('.mjs'));
+  } catch (err) {
+    console.warn(`[openchamber:plugins] Failed to read ${dir}:`, err);
+    return registry;
+  }
+  if (!files.length) return registry;
+
+  const utils = await import('../quota/utils/index.js');
+  const auth = await import('../opencode/auth.js');
+
+  const ctx = {
+    buildResult: utils.buildResult,
+    toUsageWindow: utils.toUsageWindow,
+    toNumber: utils.toNumber,
+    toTimestamp: utils.toTimestamp,
+    formatMoney: utils.formatMoney,
+    readAuthFile: auth.readAuthFile,
+    getAuthEntry: utils.getAuthEntry,
+    normalizeAuthEntry: utils.normalizeAuthEntry,
+  };
+
+  for (const file of files) {
+    try {
+      const mod = await import(path.resolve(dir, file));
+      const plugin = (mod.default || mod)(ctx);
+      if (plugin?.providerId && plugin?.fetchQuota) {
+        registry[plugin.providerId] = {
+          providerId: plugin.providerId,
+          providerName: plugin.providerName,
+          isConfigured: plugin.isConfigured || (() => false),
+          fetchQuota: plugin.fetchQuota,
+        };
+      } else {
+        console.warn(`[openchamber:plugins] ${file} is missing required fields (providerId, fetchQuota), skipping`);
+      }
+    } catch (err) {
+      console.error(`[openchamber:plugins] Failed to load ${file}:`, err);
+    }
+  }
+
+  return registry;
+}

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -43,6 +43,10 @@ All providers should return results via shared helpers to preserve API shape:
 - Unsupported provider requests should return `ok: false`, `configured: false`, `error: Unsupported provider`
 
 ## Add a new provider (quick steps)
+For local/private providers, prefer an OpenChamber quota plugin in `~/.config/openchamber/plugins/quota/`. Plugins survive package updates and avoid maintaining a core fork. See `packages/web/server/lib/plugins/DOCUMENTATION.md` for the quota plugin interface.
+
+For providers that should ship as built-in OpenChamber integrations:
+
 1. Choose module shape based on complexity:
    - Simple providers: create `packages/web/server/lib/quota/providers/<provider>.js`.
    - Complex providers (multi-source auth, multiple API calls, non-trivial transforms): create `packages/web/server/lib/quota/providers/<provider>/` with split modules like Google (`index.js`, `auth.js`, `api.js`, `transforms.js`).

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -22,6 +22,7 @@ import * as minimaxCodingPlan from './minimax-coding-plan.js';
 import * as minimaxCnCodingPlan from './minimax-cn-coding-plan.js';
 import * as ollamaCloud from './ollama-cloud.js';
 import * as wafer from './wafer.js';
+import { loadQuotaPlugins } from '../../plugins/loader.js';
 
 const registry = {
   claude: {
@@ -115,6 +116,21 @@ const registry = {
     fetchQuota: wafer.fetchQuota
   }
 };
+
+// Load user quota plugins from ~/.config/openchamber/plugins/quota/.
+// Wrapped in try/catch so a failure in plugin loading (filesystem errors,
+// malformed plugin modules, internal module resolution problems) can never
+// take down the entire built-in quota registry. Built-in providers keep
+// working; plugins are silently skipped.
+let pluginProviders = {};
+try {
+  pluginProviders = await loadQuotaPlugins();
+} catch (err) {
+  console.warn('[openchamber:quota] Failed to load quota plugins:', err);
+}
+if (Object.keys(pluginProviders).length > 0) {
+  Object.assign(registry, pluginProviders);
+}
 
 export const listConfiguredQuotaProviders = () => {
   const configured = [];


### PR DESCRIPTION
## Why

OpenChamber currently has built-in quota providers, but adding a local/private provider requires editing core files. This PR adds a small plugin surface for quota providers so users can add custom providers without maintaining a fork.

OpenCode plugins and OpenChamber plugins remain separate systems in this PR:

- OpenCode plugins: model/provider/request behavior in OpenCode.
- OpenChamber plugins: OpenChamber UI/server features, starting here with Usage/quota providers.

## Changes

Server-side plugin loader:

- `packages/web/server/lib/plugins/loader.js` scans `~/.config/openchamber/plugins/quota/`, dynamically imports `.js`/`.mjs` plugin files, and returns a quota provider registry.
- `packages/web/server/lib/quota/providers/index.js` loads plugin providers at module init and merges them into the built-in quota registry.
- `packages/web/server/lib/plugins/DOCUMENTATION.md` documents the plugin contract, context shape, trust boundary, and runtime scope.

Frontend dynamic discovery:

- `packages/ui/src/stores/useQuotaStore.ts` discovers runtime providers from `/api/quota/providers` before fetching quotas.
- `packages/ui/src/lib/quota/providers/index.ts` adds `mergeQuotaProviders()` and `getQuotaProviderMeta()` helpers.
- Header, layout, Usage page/sidebar, mobile overlay, and tray sync now render runtime plugin providers alongside built-ins.

VS Code extension parity:

- `packages/vscode/src/quotaProviders.ts` scans `~/.config/openchamber/plugins/quota/`, detects configured plugin providers through `auth.json` aliases, dynamically imports matching plugins, and delegates quota fetching to the plugin.

Documentation and example:

- `packages/web/server/lib/quota/DOCUMENTATION.md` now leads with the plugin path for local/private providers, with built-in provider steps still documented for providers that should ship with OpenChamber.
- `examples/plugins/quota/opencode-go.js` demonstrates an OpenCode Go quota provider plugin.

## Plugin shape

```js
export default ({
  buildResult,
  toUsageWindow,
  toNumber,
  toTimestamp,
  formatMoney,
  readAuthFile,
  getAuthEntry,
  normalizeAuthEntry,
}) => ({
  providerId: 'my-provider',
  providerName: 'My Provider',
  isConfigured: () => Boolean(getApiKey()),
  fetchQuota: async () => {
    return buildResult({
      providerId: 'my-provider',
      providerName: 'My Provider',
      configured: true,
      usage: {
        windows: {
          daily: toUsageWindow({ usedPercent: 25, remainingPercent: 75 }),
        },
      },
    });
  },
});
```

## Verification

- `bun run type-check` — clean
- `bun run lint` — clean
- `bun run build` — clean
- `bun run vscode:build` — clean

Build emitted existing-style warnings about unresolved KaTeX font assets, `onnxruntime-web` eval usage, dynamic/static import chunking, and large chunks.

## Files

- `packages/web/server/lib/plugins/loader.js` (new)
- `packages/web/server/lib/plugins/DOCUMENTATION.md` (new)
- `packages/web/server/lib/quota/providers/index.js`
- `packages/web/server/lib/quota/DOCUMENTATION.md`
- `packages/vscode/src/quotaProviders.ts`
- `packages/ui/src/stores/useQuotaStore.ts`
- `packages/ui/src/lib/quota/providers/index.ts`
- `packages/ui/src/lib/quota/index.ts`
- `packages/ui/src/components/layout/Header.tsx`
- `packages/ui/src/components/layout/VSCodeLayout.tsx`
- `packages/ui/src/components/sections/usage/UsagePage.tsx`
- `packages/ui/src/components/sections/usage/UsageSidebar.tsx`
- `packages/ui/src/apps/MobileApp.tsx`
- `packages/ui/src/hooks/useTraySync.ts`
- `examples/plugins/quota/opencode-go.js` (new)
