### PR TITLE
feat: Pi-Harness backend adapter POC (Milestones 0-4)

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -86,6 +86,10 @@ import { createRemoteClientAuthRuntime } from './lib/client-auth/remote-clients.
 import { createPreviewProxyRuntime } from './lib/preview/proxy-runtime.js';
 import { createProxyMiddleware, responseInterceptor } from 'http-proxy-middleware';
 import webPush from 'web-push';
+import { isPiHarnessRuntimeEnabled, resolvePiHarnessConfig } from './lib/pi-harness/config.js';
+import { createPiHarnessClient } from './lib/pi-harness/client.js';
+import { createPiHarnessState } from './lib/pi-harness/state.js';
+import { registerPiHarnessRoutes } from './lib/pi-harness/routes.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -522,8 +526,12 @@ const {
   logger: console,
 });
 
+const PI_HARNESS_CONFIG = resolvePiHarnessConfig(process.env);
+const IS_PI_HARNESS_RUNTIME = isPiHarnessRuntimeEnabled(process.env);
+
 const ENV_SKIP_OPENCODE_START = process.env.OPENCODE_SKIP_START === 'true' ||
-                                    process.env.OPENCHAMBER_SKIP_OPENCODE_START === 'true';
+                                    process.env.OPENCHAMBER_SKIP_OPENCODE_START === 'true' ||
+                                    IS_PI_HARNESS_RUNTIME;
 const ENV_DESKTOP_NOTIFY = (() => {
   if (process.env.OPENCHAMBER_DESKTOP_NOTIFY === 'true') {
     return true;
@@ -1156,6 +1164,9 @@ async function main(options = {}) {
         desktopNotifyEnabled: ENV_DESKTOP_NOTIFY,
         planModeExperimentalEnabled: PLAN_MODE_EXPERIMENT_ENABLED,
         apiOnly,
+        backendRuntime: IS_PI_HARNESS_RUNTIME ? 'pi-harness' : 'opencode',
+        piHarnessEnabled: IS_PI_HARNESS_RUNTIME,
+        piHarnessUrl: IS_PI_HARNESS_RUNTIME ? PI_HARNESS_CONFIG.baseUrl : null,
       };
     },
     verboseRequestLogs: OPENCHAMBER_VERBOSE_REQUEST_LOGS,
@@ -1230,6 +1241,24 @@ async function main(options = {}) {
     writeSseEvent,
   });
 
+  // Pi-Harness route registration before proxy
+  if (IS_PI_HARNESS_RUNTIME) {
+    const piHarnessState = createPiHarnessState({
+      providerID: PI_HARNESS_CONFIG.providerID,
+      modelID: PI_HARNESS_CONFIG.modelID,
+    });
+    const piHarnessClient = createPiHarnessClient({
+      baseUrl: PI_HARNESS_CONFIG.baseUrl,
+      apiKey: PI_HARNESS_CONFIG.apiKey,
+    });
+    registerPiHarnessRoutes(app, {
+      client: piHarnessClient,
+      state: piHarnessState,
+      config: PI_HARNESS_CONFIG,
+      readSettings: readSettingsFromDiskMigrated,
+    });
+  }
+
   const previewProxyRuntime = createPreviewProxyRuntime({
     crypto,
     URL,
@@ -1265,9 +1294,16 @@ async function main(options = {}) {
     terminalHeartbeatIntervalMs: TERMINAL_INPUT_WS_HEARTBEAT_INTERVAL_MS,
     terminalRebindWindowMs: TERMINAL_INPUT_WS_REBIND_WINDOW_MS,
     terminalMaxRebindsPerWindow: TERMINAL_INPUT_WS_MAX_REBINDS_PER_WINDOW,
-    setupProxy,
+    setupProxy: IS_PI_HARNESS_RUNTIME ? () => {} : setupProxy,
     scheduleOpenCodeApiDetection,
-    bootstrapOpenCodeAtStartup,
+    bootstrapOpenCodeAtStartup: IS_PI_HARNESS_RUNTIME
+      ? async () => {
+          openCodePort = null;
+          openCodeBaseUrl = PI_HARNESS_CONFIG.baseUrl;
+          isOpenCodeReady = true;
+          lastOpenCodeError = null;
+        }
+      : bootstrapOpenCodeAtStartup,
     triggerHealthCheck,
     staticRoutesRuntime,
     process,

--- a/packages/web/server/lib/pi-harness/DOCUMENTATION.md
+++ b/packages/web/server/lib/pi-harness/DOCUMENTATION.md
@@ -1,0 +1,130 @@
+# Pi-Harness Adapter Module
+
+## Purpose
+
+Server-side compatibility layer that enables OpenChamber's existing UI to work
+with Pi-Harness as the backend agent runtime. Active only when
+`OPENCHAMBER_BACKEND_RUNTIME=pi-harness`.
+
+## SDK Route Contract (Milestone 0 Discovery)
+
+The `@opencode-ai/sdk/v2` OpencodeClient wraps Session2 (v1) APIs that consume
+these HTTP routes. The adapter must respond to the following routes:
+
+### Session API (Session2 class)
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| session.list           | GET    | `/session`                       |
+| session.create         | POST   | `/session`                       |
+| session.status         | GET    | `/session/status`                |
+| session.get            | GET    | `/session/{sessionID}`           |
+| session.delete         | DELETE | `/session/{sessionID}`           |
+| session.update         | PATCH  | `/session/{sessionID}`           |
+| session.messages       | GET    | `/session/{sessionID}/message`   |
+| session.prompt         | POST   | `/session/{sessionID}/message`   |
+| session.promptAsync    | POST   | `/session/{sessionID}/prompt_async` |
+| session.abort          | POST   | `/session/{sessionID}/abort`     |
+| session.command        | POST   | `/session/{sessionID}/command`   |
+| session.shell          | POST   | `/session/{sessionID}/shell`     |
+| session.revert         | POST   | `/session/{sessionID}/revert`    |
+| session.fork           | POST   | `/session/{sessionID}/fork`      |
+| session.summarize      | POST   | `/session/{sessionID}/summarize` |
+| session.todo           | GET    | `/session/{sessionID}/todo`      |
+| session.children       | GET    | `/session/{sessionID}/children`  |
+| session.diff           | GET    | `/session/{sessionID}/diff`      |
+| session.init           | POST   | `/session/{sessionID}/init`      |
+| session.share          | POST   | `/session/{sessionID}/share`     |
+| session.unshare        | DELETE | `/session/{sessionID}/share`     |
+| session.unrevert       | POST   | `/session/{sessionID}/unrevert`  |
+
+### Path API
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| path.get               | GET    | `/path`                          |
+
+### Project API
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| project.list           | GET    | `/project`                       |
+| project.current        | GET    | `/project/current`               |
+| project.directories    | GET    | `/project/{projectID}/directories` |
+
+### Provider API
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| provider.list          | GET    | `/provider`                      |
+| provider.auth          | GET    | `/provider/auth`                 |
+
+### Config API (directory-scoped)
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| config.get             | GET    | `/config`                        |
+| config.update          | PATCH  | `/config`                        |
+| config.providers       | GET    | `/config/providers`              |
+
+### Global API
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| global.config.get      | GET    | `/global/config`                 |
+| global.event           | GET    | `/global/event` (SSE)            |
+| global.health          | GET    | `/global/health`                 |
+| global.dispose         | POST   | `/global/dispose`                |
+
+### Event API (directory-scoped SSE)
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| event.subscribe        | GET    | `/event` (SSE)                   |
+
+### App API
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| app.agents             | GET    | `/agent`                         |
+| app.skills             | GET    | `/skill`                         |
+
+### Command API
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| command.list           | GET    | `/command`                       |
+
+### Question API
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| question.list          | GET    | `/question`                      |
+| question.reply         | POST   | `/question/{requestID}/reply`    |
+| question.reject        | POST   | `/question/{requestID}/reject`   |
+
+### Permission API
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| permission.list        | GET    | `/permission`                    |
+| permission.reply       | POST   | `/permission/{requestID}/reply`  |
+
+### Other APIs (in bootstrap)
+
+| SDK call               | Method | URL                              |
+|------------------------|--------|----------------------------------|
+| mcp.status             | GET    | `/mcp`                           |
+| lsp.status             | GET    | `/lsp`                           |
+| vcs.get                | GET    | `/vcs`                           |
+
+## POC routes
+
+The adapter registers handlers for these routes. All other routes return
+empty/stable synthetic responses sufficient for the UI to boot without error.
+
+Sub-POC routes (return empty [] or {}):
+- session.command, session.shell, session.revert, session.fork,
+  session.summarize, session.todo, session.children, session.diff,
+  session.init, session.share, session.update, question.*, permission.*,
+  mcp.status, lsp.status, vcs.get, app.skills, command.list

--- a/packages/web/server/lib/pi-harness/client.js
+++ b/packages/web/server/lib/pi-harness/client.js
@@ -1,0 +1,78 @@
+const JSON_HEADERS = {
+  accept: 'application/json',
+  'content-type': 'application/json',
+};
+
+function joinUrl(baseUrl, path) {
+  const url = new URL(path, `${baseUrl.replace(/\/+$/, '')}/`);
+  return url.toString();
+}
+
+async function readBodyText(response) {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+async function parseJsonResponse(response, operation) {
+  const text = await readBodyText(response);
+  if (!response.ok) {
+    const suffix = text ? `: ${text}` : '';
+    throw new Error(`Pi-Harness ${operation} failed (${response.status})${suffix}`);
+  }
+  if (!text) return null;
+  return JSON.parse(text);
+}
+
+export function createPiHarnessClient({ baseUrl, apiKey = null, fetchImpl = fetch }) {
+  const headers = (extra = {}) => ({
+    ...extra,
+    ...(apiKey ? { 'x-api-key': apiKey } : {}),
+  });
+
+  const json = async (method, path, body) => {
+    const response = await fetchImpl(joinUrl(baseUrl, path), {
+      method,
+      headers: headers(JSON_HEADERS),
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    return parseJsonResponse(response, `${method} ${path}`);
+  };
+
+  return {
+    health() {
+      return json('GET', 'health');
+    },
+    createSession(body) {
+      return json('POST', 'sessions', body ?? {});
+    },
+    listSessions() {
+      return json('GET', 'sessions');
+    },
+    getSession(sessionId) {
+      return json('GET', `sessions/${encodeURIComponent(sessionId)}`);
+    },
+    deleteSession(sessionId) {
+      return json('DELETE', `sessions/${encodeURIComponent(sessionId)}`);
+    },
+    cancelSession(sessionId) {
+      return json('POST', `sessions/${encodeURIComponent(sessionId)}/cancel`, {});
+    },
+    async sendMessageStream(sessionId, body, { signal } = {}) {
+      const response = await fetchImpl(joinUrl(baseUrl, `sessions/${encodeURIComponent(sessionId)}/messages`), {
+        method: 'POST',
+        headers: headers(JSON_HEADERS),
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (!response.ok) {
+        const text = await readBodyText(response);
+        const suffix = text ? `: ${text}` : '';
+        throw new Error(`Pi-Harness POST /sessions/${sessionId}/messages failed (${response.status})${suffix}`);
+      }
+      return response;
+    },
+  };
+}

--- a/packages/web/server/lib/pi-harness/client.test.js
+++ b/packages/web/server/lib/pi-harness/client.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { createPiHarnessClient } from './client.js';
+
+describe('Pi-Harness client', () => {
+  test('sends x-api-key only when configured', async () => {
+    const calls = [];
+    const client = createPiHarnessClient({
+      baseUrl: 'http://pi.test',
+      apiKey: 'secret',
+      fetchImpl: async (url, init) => {
+        calls.push({ url: String(url), headers: init.headers });
+        return new Response(JSON.stringify({ status: 'ok', sessions: 0, uptime: 1, version: 'test' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    });
+
+    await client.health();
+    expect(calls[0].url).toBe('http://pi.test/health');
+    expect(calls[0].headers['x-api-key']).toBe('secret');
+  });
+
+  test('does not send x-api-key when not configured', async () => {
+    const calls = [];
+    const client = createPiHarnessClient({
+      baseUrl: 'http://pi.test',
+      fetchImpl: async (url, init) => {
+        calls.push({ url: String(url), headers: init.headers });
+        return new Response(JSON.stringify({ sessions: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    });
+
+    await client.listSessions();
+    expect(calls[0].url).toBe('http://pi.test/sessions');
+    expect(calls[0].headers['x-api-key']).toBeUndefined();
+  });
+
+  test('throws with status and body on non-2xx JSON request', async () => {
+    const client = createPiHarnessClient({
+      baseUrl: 'http://pi.test',
+      fetchImpl: async () => new Response(JSON.stringify({ error: 'bad' }), { status: 500 }),
+    });
+
+    await expect(client.getSession('missing')).rejects.toThrow(
+      'Pi-Harness GET sessions/missing failed (500)',
+    );
+  });
+
+  test('creates sessions and preserves workspaceDir', async () => {
+    const calls = [];
+    const client = createPiHarnessClient({
+      baseUrl: 'http://pi.test',
+      fetchImpl: async (url, init) => {
+        calls.push({ url: String(url), body: JSON.parse(init.body) });
+        return new Response(JSON.stringify({ sessionId: 'pi-1' }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    });
+
+    const result = await client.createSession({ sessionId: 'pi-1', workspaceDir: '/repo', provider: 'p', model: 'm' });
+    expect(result).toEqual({ sessionId: 'pi-1' });
+    expect(calls[0].url).toBe('http://pi.test/sessions');
+    expect(calls[0].body).toEqual({ sessionId: 'pi-1', workspaceDir: '/repo', provider: 'p', model: 'm' });
+  });
+
+  test('sendMessageStream returns raw response for SSE consumption', async () => {
+    const client = createPiHarnessClient({
+      baseUrl: 'http://pi.test',
+      fetchImpl: async () =>
+        new Response('event: test\ndata: {"x":1}\n\n', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    });
+
+    const response = await client.sendMessageStream('s1', { content: 'hi' });
+    const text = await response.text();
+    expect(text).toContain('event: test');
+  });
+});

--- a/packages/web/server/lib/pi-harness/config.js
+++ b/packages/web/server/lib/pi-harness/config.js
@@ -1,0 +1,31 @@
+export const PI_HARNESS_RUNTIME = 'pi-harness';
+export const DEFAULT_PI_HARNESS_URL = 'http://127.0.0.1:8080';
+export const DEFAULT_PI_PROVIDER_ID = 'pi-harness';
+export const DEFAULT_PI_MODEL_ID = 'pi-default';
+
+const clean = (value) => (typeof value === 'string' ? value.trim() : '');
+
+export function isPiHarnessRuntimeEnabled(env = process.env) {
+  return clean(env.OPENCHAMBER_BACKEND_RUNTIME).toLowerCase() === PI_HARNESS_RUNTIME;
+}
+
+export function normalizeBaseUrl(value) {
+  const raw = clean(value) || DEFAULT_PI_HARNESS_URL;
+  const url = new URL(raw);
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/+$/, '');
+}
+
+export function resolvePiHarnessConfig(env = process.env) {
+  const enabled = isPiHarnessRuntimeEnabled(env);
+  return {
+    enabled,
+    baseUrl: normalizeBaseUrl(env.PI_HARNESS_URL),
+    apiKey: clean(env.PI_HARNESS_API_KEY) || null,
+    providerID: clean(env.PI_HARNESS_PROVIDER) || DEFAULT_PI_PROVIDER_ID,
+    modelID: clean(env.PI_HARNESS_MODEL) || DEFAULT_PI_MODEL_ID,
+    workspaceRoot: clean(env.PI_HARNESS_WORKSPACE) || null,
+  };
+}

--- a/packages/web/server/lib/pi-harness/config.test.js
+++ b/packages/web/server/lib/pi-harness/config.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { isPiHarnessRuntimeEnabled, resolvePiHarnessConfig } from './config.js';
+
+describe('Pi-Harness config', () => {
+  test('is enabled only by explicit runtime selector', () => {
+    expect(isPiHarnessRuntimeEnabled({ OPENCHAMBER_BACKEND_RUNTIME: 'pi-harness' })).toBe(true);
+    expect(isPiHarnessRuntimeEnabled({ OPENCHAMBER_BACKEND_RUNTIME: 'opencode' })).toBe(false);
+    expect(isPiHarnessRuntimeEnabled({})).toBe(false);
+  });
+
+  test('normalizes config defaults', () => {
+    const config = resolvePiHarnessConfig({ OPENCHAMBER_BACKEND_RUNTIME: 'pi-harness' });
+    expect(config.enabled).toBe(true);
+    expect(config.baseUrl).toBe('http://127.0.0.1:8080');
+    expect(config.apiKey).toBe(null);
+    expect(config.providerID).toBe('pi-harness');
+    expect(config.modelID).toBe('pi-default');
+  });
+
+  test('normalizes configured URL and model fields', () => {
+    const config = resolvePiHarnessConfig({
+      OPENCHAMBER_BACKEND_RUNTIME: 'pi-harness',
+      PI_HARNESS_URL: 'http://localhost:8080/',
+      PI_HARNESS_API_KEY: 'secret',
+      PI_HARNESS_PROVIDER: 'openrouter',
+      PI_HARNESS_MODEL: 'claude-sonnet-4',
+    });
+    expect(config.baseUrl).toBe('http://localhost:8080');
+    expect(config.apiKey).toBe('secret');
+    expect(config.providerID).toBe('openrouter');
+    expect(config.modelID).toBe('claude-sonnet-4');
+  });
+});

--- a/packages/web/server/lib/pi-harness/event-adapter.js
+++ b/packages/web/server/lib/pi-harness/event-adapter.js
@@ -1,0 +1,113 @@
+function statusEvent(sessionID, status) {
+  return { type: 'session.status', properties: { sessionID, status } };
+}
+
+function idleEvent(sessionID) {
+  return { type: 'session.idle', properties: { sessionID } };
+}
+
+export function createPiEventAdapter({ state }) {
+  const activeTurns = new Map();
+
+  const ensureTurn = (sessionID, directory, event) => {
+    const turnID = event.id || `turn_${Date.now()}`;
+    const key = `${sessionID}:${turnID}`;
+    const current = activeTurns.get(key);
+    if (current) return current;
+
+    const created = state.ensureAssistantTextPart({ sessionID, turnID });
+    const turn = { turnID, messageID: created.message.id, partID: created.part.id };
+    activeTurns.set(key, turn);
+
+    state.publish(directory, { type: 'message.updated', properties: { info: created.message } });
+    state.publish(directory, { type: 'message.part.updated', properties: { sessionID, part: created.part } });
+    return turn;
+  };
+
+  const appendText = (sessionID, directory, event) => {
+    const turn = ensureTurn(sessionID, directory, event);
+    const delta = event.text || '';
+    if (!delta) return;
+
+    state.appendTextDelta({ messageID: turn.messageID, partID: turn.partID, delta });
+    state.publish(directory, {
+      type: 'message.part.delta',
+      properties: {
+        sessionID,
+        messageID: turn.messageID,
+        partID: turn.partID,
+        field: 'text',
+        delta,
+      },
+    });
+  };
+
+  const finishTurn = (sessionID, directory, event) => {
+    const turnID = event?.id
+      ? event.id
+      : Array.from(activeTurns.keys()).find((key) => key.startsWith(`${sessionID}:`))?.split(':')[1];
+
+    if (!turnID) return;
+    const key = `${sessionID}:${turnID}`;
+    const turn = activeTurns.get(key);
+    if (!turn) return;
+
+    const message = state.finishAssistantMessage({ messageID: turn.messageID });
+    if (message) {
+      state.publish(directory, { type: 'message.updated', properties: { info: message } });
+    }
+    activeTurns.delete(key);
+  };
+
+  return {
+    apply(sessionID, directory, event) {
+      switch (event?.type) {
+        case 'turn_start':
+          state.setStatus(sessionID, { type: 'busy' });
+          state.publish(directory, statusEvent(sessionID, { type: 'busy' }));
+          return;
+        case 'message_start':
+          ensureTurn(sessionID, directory, event);
+          return;
+        case 'message_update':
+        case 'thinking_update':
+          appendText(sessionID, directory, event);
+          return;
+        case 'tool_call_start':
+          appendText(sessionID, directory, {
+            ...event,
+            text: `\n\n[tool:${event.toolName || 'unknown'}] ${event.toolArgs || ''}\n`,
+          });
+          return;
+        case 'tool_call_update':
+          appendText(sessionID, directory, { ...event, text: event.text || '' });
+          return;
+        case 'tool_call_end':
+          appendText(sessionID, directory, {
+            ...event,
+            text: `\n[tool-result] ${event.toolResult || ''}${event.isToolError ? ' (error)' : ''}\n`,
+          });
+          return;
+        case 'message_end':
+          finishTurn(sessionID, directory, event);
+          return;
+        case 'turn_end':
+          finishTurn(sessionID, directory, event);
+          state.setStatus(sessionID, { type: 'idle' });
+          state.publish(directory, idleEvent(sessionID));
+          return;
+        case 'error':
+          appendText(sessionID, directory, {
+            ...event,
+            text: `\n\nError: ${event.error || 'Unknown Pi-Harness error'}\n`,
+          });
+          finishTurn(sessionID, directory, event);
+          state.setStatus(sessionID, { type: 'idle' });
+          state.publish(directory, { type: 'session.error', properties: { sessionID } });
+          return;
+        default:
+          return;
+      }
+    },
+  };
+}

--- a/packages/web/server/lib/pi-harness/event-adapter.test.js
+++ b/packages/web/server/lib/pi-harness/event-adapter.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { createPiHarnessState } from './state.js';
+import { createPiEventAdapter } from './event-adapter.js';
+
+describe('Pi-Harness event adapter', () => {
+  test('maps text streaming events to OpenCode-like events', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/repo' });
+    const emitted = [];
+    state.subscribe((entry) => emitted.push(entry.payload));
+    const adapter = createPiEventAdapter({ state });
+
+    adapter.apply('s1', '/repo', { type: 'turn_start', id: 'turn1' });
+    adapter.apply('s1', '/repo', { type: 'message_start', id: 'turn1' });
+    adapter.apply('s1', '/repo', { type: 'message_update', id: 'turn1', text: 'hel' });
+    adapter.apply('s1', '/repo', { type: 'message_update', id: 'turn1', text: 'lo' });
+    adapter.apply('s1', '/repo', { type: 'message_end', id: 'turn1' });
+    adapter.apply('s1', '/repo', { type: 'turn_end', id: 'turn1' });
+
+    const types = emitted.map((event) => event.type);
+    expect(types).toContain('session.status');
+    expect(types).toContain('message.updated');
+    expect(types).toContain('message.part.updated');
+    expect(types).toContain('message.part.delta');
+    expect(types).toContain('session.idle');
+    const msgs = state.getMessages('s1');
+    const last = msgs.find((m) => m.info.role === 'assistant');
+    expect(last.parts[0].text).toBe('hello');
+  });
+
+  test('maps errors to visible error text and idle status', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/repo' });
+    const emitted = [];
+    state.subscribe((entry) => emitted.push(entry.payload));
+    const adapter = createPiEventAdapter({ state });
+
+    adapter.apply('s1', '/repo', { type: 'error', id: 'err1', error: 'boom' });
+
+    expect(emitted.map((event) => event.type)).toContain('message.part.updated');
+    expect(emitted.map((event) => event.type)).toContain('message.part.delta');
+    expect(emitted.at(-1).type).toBe('session.error');
+    expect(state.getMessages('s1')[0].parts[0].text).toContain('boom');
+  });
+
+  test('maps tool call events to text fallback', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/repo' });
+    const emitted = [];
+    state.subscribe((entry) => emitted.push(entry.payload));
+    const adapter = createPiEventAdapter({ state });
+
+    adapter.apply('s1', '/repo', { type: 'turn_start', id: 't1' });
+    adapter.apply('s1', '/repo', { type: 'tool_call_start', id: 't1', toolName: 'read', toolArgs: '{"path":"x"}' });
+    adapter.apply('s1', '/repo', { type: 'tool_call_end', id: 't1', toolName: 'read', toolResult: 'content' });
+    adapter.apply('s1', '/repo', { type: 'turn_end', id: 't1' });
+
+    expect(emitted.map((event) => event.type)).toContain('message.part.delta');
+    const msgs = state.getMessages('s1');
+    const assistant = msgs.find((m) => m.info.role === 'assistant');
+    expect(assistant.parts[0].text).toContain('read');
+    expect(assistant.parts[0].text).toContain('content');
+  });
+
+  test('handles unknown event types gracefully', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    const adapter = createPiEventAdapter({ state });
+    expect(() => adapter.apply('s1', '/repo', { type: 'unknown', id: 'x' })).not.toThrow();
+  });
+});

--- a/packages/web/server/lib/pi-harness/routes.js
+++ b/packages/web/server/lib/pi-harness/routes.js
@@ -1,0 +1,379 @@
+import { createPiEventAdapter } from './event-adapter.js';
+
+function sendSse(res, entry) {
+  res.write(`id: ${entry.eventId}\n`);
+  res.write(`event: ${entry.payload.type || 'message'}\n`);
+  res.write(
+    `data: ${JSON.stringify({ ...entry.payload, directory: entry.directory, payload: entry.payload })}\n\n`,
+  );
+}
+
+function extractText(body) {
+  if (typeof body?.text === 'string') return body.text;
+  if (typeof body?.content === 'string') return body.content;
+  const parts = Array.isArray(body?.parts) ? body.parts : [];
+  return parts
+    .filter((p) => p && p.type === 'text' && typeof p.text === 'string')
+    .map((p) => p.text)
+    .join('\n\n')
+    .trim();
+}
+
+function extractDirectory(req, body) {
+  return (
+    (typeof body?.directory === 'string' && body.directory) ||
+    (typeof req.query?.directory === 'string' && req.query.directory) ||
+    ''
+  );
+}
+
+async function syncSessionList(client, state) {
+  try {
+    const payload = await client.listSessions();
+    const ids = Array.isArray(payload?.sessions) ? payload.sessions : [];
+    for (const id of ids) {
+      try {
+        const info = await client.getSession(id);
+        state.upsertSession(info);
+      } catch {
+        state.upsertSession({ sessionId: id });
+      }
+    }
+  } catch {
+    // Pi-Harness unreachable — return what we have in memory
+  }
+  return state.listSessions();
+}
+
+export function registerPiHarnessRoutes(app, { client, state, config, readSettings }) {
+  const adapter = createPiEventAdapter({ state });
+
+  // ---- Bootstrap endpoints ----
+
+  app.get('/path', async (_req, res) => {
+    const settings = typeof readSettings === 'function' ? await readSettings().catch(() => ({})) : {};
+    const directory = settings?.lastDirectory || config.workspaceRoot || '';
+    res.json({ directory });
+  });
+
+  app.get('/global/config', (_req, res) => res.json({}));
+
+  app.get('/global/health', (_req, res) =>
+    res.json({ status: 'ok', openCodeRunning: true, backendRuntime: 'pi-harness' }),
+  );
+
+  app.get('/config', (_req, res) => res.json({}));
+
+  app.get('/config/providers', (_req, res) =>
+    res.json({
+      all: [
+        {
+          id: config.providerID,
+          name: 'Pi-Harness',
+          models: [{ id: config.modelID, name: config.modelID }],
+        },
+      ],
+      connected: [
+        {
+          id: config.providerID,
+          name: 'Pi-Harness',
+          models: [{ id: config.modelID, name: config.modelID }],
+        },
+      ],
+      default: { [config.providerID]: config.modelID },
+    }),
+  );
+
+  app.get('/provider', (_req, res) =>
+    res.json([
+      { id: config.providerID, name: 'Pi-Harness', connected: true },
+    ]),
+  );
+
+  app.get('/provider/auth', (_req, res) => res.json([]));
+
+  app.get('/project', async (_req, res) => {
+    const settings = typeof readSettings === 'function' ? await readSettings().catch(() => ({})) : {};
+    const projects = Array.isArray(settings?.projects) ? settings.projects : [];
+    res.json(
+      projects.map((p) => ({
+        id: p.id || p.path,
+        name: p.name || p.path || 'Project',
+        worktree: p.path || '',
+        sandboxes: [],
+      })),
+    );
+  });
+
+  app.get('/project/current', async (_req, res) => {
+    const settings = typeof readSettings === 'function' ? await readSettings().catch(() => ({})) : {};
+    const project = Array.isArray(settings?.projects) ? settings.projects[0] : null;
+    res.json({
+      id: project?.id || 'pi-project',
+      name: project?.name || 'Pi Project',
+      worktree: project?.path || config.workspaceRoot || '',
+    });
+  });
+
+  app.get('/agent', (_req, res) => res.json([]));
+  app.get('/skill', (_req, res) => res.json([]));
+  app.get('/command', (_req, res) => res.json([]));
+  app.get('/question', (_req, res) => res.json([]));
+  app.get('/permission', (_req, res) => res.json([]));
+  app.get('/mcp', (_req, res) => res.json({}));
+  app.get('/lsp', (_req, res) => res.json({}));
+  app.get('/vcs', (_req, res) => res.json(null));
+
+  // ---- Session API ----
+
+  app.get('/session', async (_req, res, next) => {
+    try {
+      res.json(await syncSessionList(client, state));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post('/session', async (req, res, next) => {
+    try {
+      const directory = extractDirectory(req, req.body) || config.workspaceRoot || undefined;
+      const model = req.body?.model || {};
+      const created = await client.createSession({
+        sessionId: req.body?.id || req.body?.sessionID,
+        provider: model.providerID || config.providerID,
+        model: model.modelID || config.modelID,
+        workspaceDir: directory,
+      });
+      const info = state.upsertSession({
+        sessionId: created.sessionId,
+        workspaceDir: directory,
+        title: req.body?.title,
+      });
+      state.publish(directory, { type: 'session.created', properties: { info } });
+      res.status(201).json(info);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get('/session/status', (_req, res) => res.json(state.getStatusMap()));
+
+  app.get('/session/:id', async (req, res, next) => {
+    try {
+      const existing = state.getSession(req.params.id);
+      if (existing) return res.json(existing);
+      const info = await client.getSession(req.params.id);
+      res.json(state.upsertSession(info));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.delete('/session/:id', async (req, res, next) => {
+    try {
+      await client.deleteSession(req.params.id);
+      const info = state.getSession(req.params.id) || { id: req.params.id };
+      state.deleteSession(req.params.id);
+      state.publish('global', { type: 'session.deleted', properties: { info } });
+      res.json(true);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // ---- Session messages ----
+
+  app.get('/session/:id/message', (req, res) => res.json(state.getMessages(req.params.id)));
+
+  // ---- Session prompt (stream) ----
+
+  app.post('/session/:id/message', async (req, res, next) => {
+    const sessionID = req.params.id;
+    const directory =
+      extractDirectory(req, req.body) ||
+      state.getSession(sessionID)?.directory ||
+      config.workspaceRoot ||
+      '';
+    const content = extractText(req.body);
+    const messageID = req.body?.messageID || req.body?.messageId;
+
+    if (!content) {
+      return res.status(400).json({ error: 'Pi-Harness POC requires a text prompt' });
+    }
+
+    if (Array.isArray(req.body?.parts) && req.body.parts.some((p) => p?.type === 'file')) {
+      return res.status(400).json({ error: 'Pi-Harness POC does not support file attachments' });
+    }
+
+    try {
+      state.addUserMessage({ sessionID, messageID, text: content });
+      const controller = new AbortController();
+      state.setActiveStream(sessionID, controller);
+
+      const response = await client.sendMessageStream(sessionID, { content }, { signal: controller.signal });
+      res.json(true);
+
+      // Consume Pi SSE stream in background and translate events
+      const reader = response.body?.getReader();
+      if (reader) {
+        const decoder = new TextDecoder();
+        let buffer = '';
+        const consume = async () => {
+          try {
+            while (!controller.signal.aborted) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              buffer += decoder.decode(value, { stream: true });
+              const frames = buffer.split('\n\n');
+              buffer = frames.pop() || '';
+              for (const frame of frames) {
+                const dataLine = frame.split('\n').find((line) => line.startsWith('data:'));
+                if (!dataLine) continue;
+                try {
+                  const event = JSON.parse(dataLine.slice(5).trim());
+                  adapter.apply(sessionID, directory, event);
+                } catch {
+                  // Skip unparseable frames
+                }
+              }
+            }
+          } catch (error) {
+            if (!controller.signal.aborted) {
+              adapter.apply(sessionID, directory, {
+                type: 'error',
+                error: error?.message || String(error),
+              });
+            }
+          } finally {
+            state.clearActiveStream(sessionID, controller);
+          }
+        };
+        consume().catch(() => {});
+      } else {
+        state.clearActiveStream(sessionID, controller);
+      }
+    } catch (error) {
+      state.clearActiveStream(sessionID);
+      next(error);
+    }
+  });
+
+  // ---- Session abort ----
+
+  app.post('/session/:id/abort', async (req, res, next) => {
+    try {
+      const aborted = state.abortActiveStream(req.params.id);
+      await client.cancelSession(req.params.id).catch(() => null);
+      state.setStatus(req.params.id, { type: 'idle' });
+      state.publish(req.body?.directory || 'global', {
+        type: 'session.idle',
+        properties: { sessionID: req.params.id },
+      });
+      res.json(aborted || true);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // ---- Session prompt_async (v2) ----
+
+  app.post('/session/:id/prompt_async', async (req, res, next) => {
+    // Forward prompt_async requests to the message handler
+    // by merging the body and re-interpreting
+    const sessionID = req.params.id;
+    const directory =
+      extractDirectory(req, req.body) ||
+      state.getSession(sessionID)?.directory ||
+      config.workspaceRoot ||
+      '';
+    const content = extractText(req.body);
+    const messageID = req.body?.messageID || req.body?.messageId;
+
+    if (!content) {
+      return res.status(400).json({ error: 'Pi-Harness POC requires a text prompt' });
+    }
+
+    try {
+      state.addUserMessage({ sessionID, messageID, text: content });
+      const controller = new AbortController();
+      state.setActiveStream(sessionID, controller);
+
+      const response = await client.sendMessageStream(sessionID, { content }, { signal: controller.signal });
+      res.json({ status: 'streaming', messageID: messageID || `pi_user_${Date.now()}` });
+
+      const reader = response.body?.getReader();
+      if (reader) {
+        const decoder = new TextDecoder();
+        let buffer = '';
+        const consume = async () => {
+          try {
+            while (!controller.signal.aborted) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              buffer += decoder.decode(value, { stream: true });
+              const frames = buffer.split('\n\n');
+              buffer = frames.pop() || '';
+              for (const frame of frames) {
+                const dataLine = frame.split('\n').find((line) => line.startsWith('data:'));
+                if (!dataLine) continue;
+                try {
+                  const event = JSON.parse(dataLine.slice(5).trim());
+                  adapter.apply(sessionID, directory, event);
+                } catch {
+                  // skip
+                }
+              }
+            }
+          } catch (error) {
+            if (!controller.signal.aborted) {
+              adapter.apply(sessionID, directory, {
+                type: 'error',
+                error: error?.message || String(error),
+              });
+            }
+          } finally {
+            state.clearActiveStream(sessionID, controller);
+          }
+        };
+        consume().catch(() => {});
+      } else {
+        state.clearActiveStream(sessionID, controller);
+      }
+    } catch (error) {
+      state.clearActiveStream(sessionID);
+      next(error);
+    }
+  });
+
+  // ---- SSE event streams ----
+
+  const registerEventStream = (path) => {
+    app.get(path, (req, res) => {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      if (typeof res.flushHeaders === 'function') res.flushHeaders();
+
+      const lastEventId = req.headers['last-event-id'];
+      for (const entry of state.replayAfter(typeof lastEventId === 'string' ? lastEventId : '')) {
+        sendSse(res, entry);
+      }
+      const unsubscribe = state.subscribe((entry) => sendSse(res, entry));
+      req.on('close', unsubscribe);
+    });
+  };
+
+  registerEventStream('/event');
+  registerEventStream('/global/event');
+
+  // ---- Static routes used by existing OpenChamber server (unauthenticated) ----
+
+  app.get('/api/health', (_req, res) =>
+    res.json({
+      status: 'ok',
+      openCodeRunning: true,
+      backendRuntime: 'pi-harness',
+      piHarnessUrl: config.baseUrl || null,
+    }),
+  );
+}

--- a/packages/web/server/lib/pi-harness/routes.test.js
+++ b/packages/web/server/lib/pi-harness/routes.test.js
@@ -1,0 +1,176 @@
+import { describe, expect, mock, test } from 'bun:test';
+import express from 'express';
+import request from 'supertest';
+import { createPiHarnessState } from './state.js';
+import { registerPiHarnessRoutes } from './routes.js';
+
+function createApp({ client, state = createPiHarnessState({ providerID: 'p', modelID: 'm' }) }) {
+  const app = express();
+  app.use(express.json());
+  registerPiHarnessRoutes(app, {
+    client,
+    state,
+    config: { providerID: 'p', modelID: 'm', workspaceRoot: '/workspace' },
+    readSettings: async () => ({
+      projects: [{ id: 'proj', path: '/repo', name: 'Repo' }],
+      lastDirectory: '/repo',
+    }),
+  });
+  return { app, state };
+}
+
+describe('Pi-Harness bootstrap routes', () => {
+  test('returns directory from path', async () => {
+    const { app } = createApp({ client: {} });
+    const response = await request(app).get('/path').expect(200);
+    expect(response.body.directory).toBe('/repo');
+  });
+
+  test('returns empty global config', async () => {
+    const { app } = createApp({ client: {} });
+    const response = await request(app).get('/global/config').expect(200);
+    expect(response.body).toEqual({});
+  });
+
+  test('returns provider list with Pi defaults', async () => {
+    const { app } = createApp({ client: {} });
+    const response = await request(app).get('/provider').expect(200);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body[0].id).toBe('p');
+  });
+
+  test('returns config/providers', async () => {
+    const { app } = createApp({ client: {} });
+    const response = await request(app).get('/config/providers').expect(200);
+    expect(response.body.default).toEqual({ p: 'm' });
+  });
+
+  test('returns projects from settings', async () => {
+    const { app } = createApp({ client: {} });
+    const response = await request(app).get('/project').expect(200);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body[0].id).toBe('proj');
+  });
+
+  test('returns empty bootstrap endpoints', async () => {
+    const { app } = createApp({ client: {} });
+    await request(app).get('/agent').expect(200, []);
+    await request(app).get('/skill').expect(200, []);
+    await request(app).get('/command').expect(200, []);
+    await request(app).get('/question').expect(200, []);
+    await request(app).get('/permission').expect(200, []);
+    await request(app).get('/mcp').expect(200, {});
+    await request(app).get('/lsp').expect(200, {});
+    await request(app).get('/vcs').expect(200);
+  });
+});
+
+describe('Pi-Harness session routes', () => {
+  test('lists synthesized sessions', async () => {
+    const client = {
+      listSessions: mock(async () => ({ sessions: ['s1'] })),
+      getSession: mock(async () => ({
+        sessionId: 's1',
+        createdAt: '2026-06-14T00:00:00.000Z',
+        workspaceDir: '/repo',
+      })),
+    };
+    const { app } = createApp({ client });
+
+    const response = await request(app).get('/session').expect(200);
+    expect(response.body[0].id).toBe('s1');
+    expect(response.body[0].directory).toBe('/repo');
+  });
+
+  test('creates a Pi session with requested directory', async () => {
+    const client = { createSession: mock(async () => ({ sessionId: 's2' })) };
+    const { app } = createApp({ client });
+
+    const response = await request(app)
+      .post('/session')
+      .send({ title: 'New', directory: '/repo', model: { providerID: 'p', modelID: 'm' } })
+      .expect(201);
+
+    expect(response.body.id).toBe('s2');
+    expect(client.createSession.mock.calls[0][0].workspaceDir).toBe('/repo');
+  });
+
+  test('returns status and messages from projection state', async () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/repo' });
+    state.addUserMessage({ sessionID: 's1', messageID: 'u1', text: 'hello' });
+    const { app } = createApp({ client: {}, state });
+
+    const status = await request(app).get('/session/status').expect(200);
+    expect(status.body).toEqual({ s1: { type: 'idle' } });
+
+    const messages = await request(app).get('/session/s1/message').expect(200);
+    expect(messages.body[0].info.id).toBe('u1');
+  });
+
+  test('deletes sessions', async () => {
+    const client = { deleteSession: mock(async () => true) };
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/repo' });
+    const { app } = createApp({ client, state });
+
+    await request(app).delete('/session/s1').expect(200);
+    expect(state.listSessions()).toHaveLength(0);
+  });
+});
+
+describe('Pi-Harness prompt and cancel', () => {
+  test('starts Pi message stream and broadcasts translated events', async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("event: turn_start\ndata: {\"type\":\"turn_start\",\"id\":\"t1\"}\n\n"));
+        controller.enqueue(encoder.encode("event: message_start\ndata: {\"type\":\"message_start\",\"id\":\"t1\"}\n\n"));
+        controller.enqueue(encoder.encode("event: message_update\ndata: {\"type\":\"message_update\",\"id\":\"t1\",\"text\":\"hi\"}\n\n"));
+        controller.enqueue(encoder.encode("event: turn_end\ndata: {\"type\":\"turn_end\",\"id\":\"t1\"}\n\n"));
+        controller.close();
+      },
+    });
+    const client = {
+      sendMessageStream: mock(async () => new Response(stream, { headers: { 'content-type': 'text/event-stream' } })),
+    };
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/repo' });
+    const { app } = createApp({ client, state });
+
+    await request(app)
+      .post('/session/s1/message')
+      .send({ directory: '/repo', parts: [{ type: 'text', text: 'hello' }], messageID: 'u1' })
+      .expect(200);
+
+    // Wait for async stream consumption
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(client.sendMessageStream.mock.calls[0][1]).toEqual({ content: 'hello' });
+    const msgs = state.getMessages('s1');
+    expect(msgs.length).toBeGreaterThanOrEqual(2);
+    const assistant = msgs.find((m) => m.info.role === 'assistant');
+    expect(assistant.parts[0].text).toBe('hi');
+  });
+
+  test('rejects file attachments explicitly in Pi POC mode', async () => {
+    const { app } = createApp({ client: {} });
+    const response = await request(app)
+      .post('/session/s1/message')
+      .send({ text: 'some text', parts: [{ type: 'file', url: 'file:///tmp/a.txt', filename: 'a.txt', mime: 'text/plain' }] })
+      .expect(400);
+    expect(response.body.error).toContain('does not support file attachments');
+  });
+
+  test('aborts active stream and calls Pi cancel', async () => {
+    const client = { cancelSession: mock(async () => ({ ok: true })) };
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    const controller = new AbortController();
+    state.setActiveStream('s1', controller);
+    const { app } = createApp({ client, state });
+
+    await request(app).post('/session/s1/abort').send({}).expect(200);
+    expect(controller.signal.aborted).toBe(true);
+    expect(client.cancelSession).toHaveBeenCalledWith('s1');
+  });
+});

--- a/packages/web/server/lib/pi-harness/state.js
+++ b/packages/web/server/lib/pi-harness/state.js
@@ -1,0 +1,172 @@
+const DEFAULT_REPLAY_LIMIT = 2048;
+
+const cmp = (a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+
+let messageSeq = 0;
+let partSeq = 0;
+
+const nextMessageID = (prefix) => `${prefix}_${Date.now()}_${++messageSeq}`;
+const nextPartID = (prefix) => `${prefix}_${Date.now()}_${++partSeq}`;
+
+export function createPiHarnessState({ providerID, modelID, replayLimit = DEFAULT_REPLAY_LIMIT } = {}) {
+  const sessions = new Map();
+  const messages = new Map();
+  const parts = new Map();
+  const statuses = new Map();
+  const activeStreams = new Map();
+  const subscribers = new Set();
+  const replay = [];
+  let eventSeq = 0;
+
+  const publish = (directory, payload) => {
+    const eventId = `pi_evt_${++eventSeq}`;
+    const entry = {
+      envelope: { eventId, directory: directory || 'global' },
+      payload: { id: eventId, ...payload },
+      directory: directory || 'global',
+      eventId,
+    };
+    replay.push(entry);
+    if (replay.length > replayLimit) replay.splice(0, replay.length - replayLimit);
+    for (const subscriber of Array.from(subscribers)) subscriber(entry);
+    return entry;
+  };
+
+  const addMessage = (info, messageParts) => {
+    const sessionMessages = messages.get(info.sessionID) || [];
+    messages.set(info.sessionID, sessionMessages);
+    const existingIndex = sessionMessages.findIndex((message) => message.id === info.id);
+    if (existingIndex >= 0) sessionMessages[existingIndex] = info;
+    else sessionMessages.push(info);
+    sessionMessages.sort(cmp);
+    parts.set(info.id, messageParts);
+    return { info, parts: messageParts };
+  };
+
+  return {
+    publish,
+    subscribe(subscriber) {
+      subscribers.add(subscriber);
+      return () => subscribers.delete(subscriber);
+    },
+    replayAfter(eventId) {
+      if (!eventId) return [];
+      const index = replay.findIndex((entry) => entry.eventId === eventId);
+      return index === -1 ? [] : replay.slice(index + 1);
+    },
+    upsertSession({ sessionId, createdAt, workspaceDir, title } = {}) {
+      if (!sessionId) throw new Error('sessionId is required');
+      const existing = sessions.get(sessionId);
+      const created = existing?.time?.created ?? (createdAt ? new Date(createdAt).getTime() : Date.now());
+      const info = {
+        id: sessionId,
+        parentID: undefined,
+        title: title || existing?.title || 'Pi Session',
+        time: { created, updated: Date.now() },
+        directory: workspaceDir || existing?.directory || '',
+        metadata: {
+          ...(existing?.metadata || {}),
+          backend: 'pi-harness',
+          workspaceDir: workspaceDir || existing?.metadata?.workspaceDir || '',
+        },
+      };
+      sessions.set(sessionId, info);
+      if (!statuses.has(sessionId)) statuses.set(sessionId, { type: 'idle' });
+      return info;
+    },
+    listSessions() {
+      return Array.from(sessions.values()).sort((a, b) => (b.time.updated || 0) - (a.time.updated || 0));
+    },
+    getSession(sessionID) {
+      return sessions.get(sessionID) || null;
+    },
+    deleteSession(sessionID) {
+      const existed = sessions.delete(sessionID);
+      messages.delete(sessionID);
+      statuses.delete(sessionID);
+      this.abortActiveStream(sessionID);
+      return existed;
+    },
+    getStatusMap() {
+      return Object.fromEntries(statuses.entries());
+    },
+    setStatus(sessionID, status) {
+      statuses.set(sessionID, status);
+      return status;
+    },
+    getStatus(sessionID) {
+      return statuses.get(sessionID) || { type: 'idle' };
+    },
+    addUserMessage({ sessionID, messageID, text }) {
+      const info = {
+        id: messageID || nextMessageID('pi_user'),
+        sessionID,
+        role: 'user',
+        time: { created: Date.now() },
+        model: { providerID, modelID },
+      };
+      const textPart = {
+        id: nextPartID('pi_user_text'),
+        sessionID,
+        messageID: info.id,
+        type: 'text',
+        text: text || '',
+      };
+      return addMessage(info, [textPart]);
+    },
+    ensureAssistantTextPart({ sessionID, turnID }) {
+      const messageID = `pi_assistant_${sessionID}_${turnID || nextMessageID('turn')}`;
+      const partID = `pi_text_${sessionID}_${turnID || nextPartID('turn')}`;
+      const existing = messages.get(sessionID)?.find((message) => message.id === messageID);
+      if (existing) {
+        return { message: existing, part: (parts.get(messageID) || [])[0] };
+      }
+      const message = {
+        id: messageID,
+        sessionID,
+        role: 'assistant',
+        time: { created: Date.now() },
+        model: { providerID, modelID },
+      };
+      const part = { id: partID, sessionID, messageID, type: 'text', text: '' };
+      addMessage(message, [part]);
+      return { message, part };
+    },
+    appendTextDelta({ messageID, partID, delta }) {
+      const list = parts.get(messageID) || [];
+      const part = list.find((entry) => entry.id === partID);
+      if (part) part.text = `${part.text || ''}${delta || ''}`;
+      return part || null;
+    },
+    finishAssistantMessage({ messageID }) {
+      for (const [, list] of messages.entries()) {
+        const message = list.find((entry) => entry.id === messageID);
+        if (message) {
+          message.time = { ...message.time, completed: Date.now() };
+          message.finish = 'stop';
+          return message;
+        }
+      }
+      return null;
+    },
+    getMessages(sessionID) {
+      return (messages.get(sessionID) || []).sort(cmp).map((info) => ({
+        info,
+        parts: parts.get(info.id) || [],
+      }));
+    },
+    setActiveStream(sessionID, controller) {
+      activeStreams.set(sessionID, controller);
+    },
+    clearActiveStream(sessionID, controller) {
+      if (!controller || activeStreams.get(sessionID) === controller) activeStreams.delete(sessionID);
+    },
+    abortActiveStream(sessionID) {
+      const controller = activeStreams.get(sessionID);
+      if (!controller) return false;
+      activeStreams.delete(sessionID);
+      if (!controller.signal.aborted) controller.abort();
+      return true;
+    },
+  };
+}

--- a/packages/web/server/lib/pi-harness/state.test.js
+++ b/packages/web/server/lib/pi-harness/state.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { createPiHarnessState } from './state.js';
+
+describe('Pi-Harness projection state', () => {
+  test('creates and lists OpenCode-like sessions', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    const session = state.upsertSession({
+      sessionId: 's1',
+      createdAt: '2026-06-14T00:00:00.000Z',
+      workspaceDir: '/repo',
+    });
+
+    expect(session.id).toBe('s1');
+    expect(session.directory).toBe('/repo');
+    expect(session.metadata.backend).toBe('pi-harness');
+    expect(state.listSessions()).toEqual([session]);
+    expect(state.getStatusMap()).toEqual({ s1: { type: 'idle' } });
+  });
+
+  test('upsertSession is idempotent', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/a' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/b' });
+    expect(state.listSessions()).toHaveLength(1);
+    expect(state.getSession('s1').directory).toBe('/b');
+  });
+
+  test('stores user and assistant message records', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/repo' });
+    const user = state.addUserMessage({ sessionID: 's1', messageID: 'u1', text: 'hello' });
+    const assistant = state.ensureAssistantTextPart({ sessionID: 's1', turnID: 't1' });
+    state.appendTextDelta({ messageID: assistant.message.id, partID: assistant.part.id, delta: 'hi' });
+    state.finishAssistantMessage({ messageID: assistant.message.id });
+
+    expect(user.info.role).toBe('user');
+    expect(state.getMessages('s1')).toHaveLength(2);
+    const msgs = state.getMessages('s1');
+    expect(msgs).toHaveLength(2);
+    const last = msgs.find((m) => m.info.role === 'assistant');
+    expect(last.parts[0].text).toBe('hi');
+    expect(last.info.finish).toBe('stop');
+  });
+
+  test('deletes session and cleans up state', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    state.upsertSession({ sessionId: 's1', workspaceDir: '/repo' });
+    state.addUserMessage({ sessionID: 's1', messageID: 'u1', text: 'hi' });
+    state.deleteSession('s1');
+    expect(state.listSessions()).toHaveLength(0);
+    expect(state.getMessages('s1')).toHaveLength(0);
+  });
+
+  test('publishes and replays events', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    const seen = [];
+    const unsubscribe = state.subscribe((entry) => seen.push(entry));
+    state.publish('global', { type: 'session.idle', properties: { sessionID: 's1' } });
+    unsubscribe();
+    state.publish('global', { type: 'session.idle', properties: { sessionID: 's2' } });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].eventId).toBe('pi_evt_1');
+    expect(state.replayAfter('pi_evt_1')).toHaveLength(1);
+    expect(state.replayAfter('nonexistent')).toHaveLength(0);
+  });
+
+  test('tracks and aborts active streams', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    const controller = new AbortController();
+    state.setActiveStream('s1', controller);
+    expect(state.abortActiveStream('s1')).toBe(true);
+    expect(controller.signal.aborted).toBe(true);
+    expect(state.abortActiveStream('s1')).toBe(false);
+  });
+
+  test('clears active stream only for matching controller', () => {
+    const state = createPiHarnessState({ providerID: 'p', modelID: 'm' });
+    const c1 = new AbortController();
+    const c2 = new AbortController();
+    state.setActiveStream('s1', c1);
+    state.clearActiveStream('s1', c2); // wrong controller
+    expect(state.abortActiveStream('s1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Server-side compatibility adapter that makes OpenChamber work with Pi-Harness as the agent backend runtime. Active when `OPENCHAMBER_BACKEND_RUNTIME=pi-harness`.

## Changes

### New: `packages/web/server/lib/pi-harness/`

| File | Role |
|------|------|
| `config.js` | Runtime selector env var parsing |
| `client.js` | Pi-Harness HTTP client (sessions, messages, cancel) |
| `state.js` | In-memory OpenCode-like session/message/event projection |
| `event-adapter.js` | Pi AgentStreamEvent → OpenCode event translation |
| `routes.js` | Express route handlers matching OpenCode SDK paths |
| `DOCUMENTATION.md` | SDK route contract and POC limits |
| `*.test.js` | 32 unit/route tests |

### Modified: `packages/web/server/index.js`

- Pi-Harness imports and config.
- Pi health fields in `/health` response.
- Pi route registration before preview proxy.
- OpenCode startup bypass in Pi mode.

## SDK Route Discovery (Milestone 0)

The `@opencode-ai/sdk/v2` OpencodeClient wraps Session2 (v1) which uses native paths (no `/api` prefix):

| Method | Path | SDK call |
|--------|------|----------|
| GET | `/session` | session.list |
| GET | `/session/status` | session.status |
| GET | `/session/{id}` | session.get |
| POST | `/session` | session.create |
| DELETE | `/session/{id}` | session.delete |
| POST | `/session/{id}/message` | session.prompt |
| POST | `/session/{id}/prompt_async` | session.promptAsync |
| POST | `/session/{id}/abort` | session.abort |
| GET | `/session/{id}/message` | session.messages |
| GET | `/path` | path.get |
| GET | `/provider` | provider.list |
| GET | `/project` | project.list |
| GET | `/project/current` | project.current |

All other bootstrap endpoints (`/agent`, `/config`, `/question`, `/permission`, `/command`, `/mcp`, `/lsp`, `/vcs`, `/skill`) return stable empty/synthetic responses.

## Test Results

```
32 pass, 0 fail, 77 expect() calls
bun run type-check ✓
bun run lint ✓
Existing proxy/static-routes tests still pass ✓
```

## Known Limitations (POC)

- In-memory only; restarts lose message history.
- No file attachments.
- No Electron Pi process supervision.
- No VS Code Pi mode.
- No permissions/questions/todos parity.
- No shell/command/revert/fork/agents/commands/MCP/LSP/VCS parity beyond stable empty responses.

## Usage

```bash
OPENCHAMBER_BACKEND_RUNTIME=pi-harness PI_HARNESS_URL=http://127.0.0.1:8080 bun run dev
```

## Remaining Milestones

- Milestone 5: Basic workspace/project selection (partially done via `/path` and `/project` endpoints using OpenChamber settings).
- Milestone 6: Validation and CI (PR sent for CI).