### PR TITLE
feat(vscode): startup parity + workspace-grouped session list

### DIFF
--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -14,6 +14,7 @@ import { ArchiveAllDropdown } from '@/components/session/ArchiveAllDropdown';
 import { SessionSwitcherDropdown } from '@/components/session/SessionSwitcherDropdown';
 import { SessionsTabTitle } from '@/components/session/SessionsTabTitle';
 import { useProjectsStore } from '@/stores/useProjectsStore';
+import { useSessionDisplayStore } from '@/stores/useSessionDisplayStore';
 import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
@@ -546,7 +547,6 @@ export const VSCodeLayout: React.FC = () => {
               mobileVariant
               allowReselect
               hideDirectoryControls
-              showOnlyMainWorkspace
             />
             <div
               className={cn(
@@ -594,7 +594,6 @@ export const VSCodeLayout: React.FC = () => {
                   allowReselect
                   onSessionSelected={() => setCurrentView('chat')}
                   hideDirectoryControls
-                  showOnlyMainWorkspace
                 />
               </div>
             </div>
@@ -640,6 +639,8 @@ interface VSCodeHeaderProps {
 
 const VSCodeHeader: React.FC<VSCodeHeaderProps> = ({ title, showBack, onBack, onArchiveAll, onNewSession, onSettings, onAgentManager, showMcp, showContextUsage, showRateLimits, enableSessionSwitcher }) => {
   const { t } = useI18n();
+  const showArchivedSessions = useSessionDisplayStore((state) => state.showArchivedSessions);
+  const toggleArchivedSessions = useSessionDisplayStore((state) => state.toggleArchivedSessions);
   const getCurrentModel = useConfigStore((state) => state.getCurrentModel);
   const providers = useConfigStore((state) => state.providers);
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
@@ -817,6 +818,21 @@ const VSCodeHeader: React.FC<VSCodeHeaderProps> = ({ title, showBack, onBack, on
         <SessionsTabTitle title={title} />
       )}
       <div className="min-w-0 flex-1" />
+      {onArchiveAll && (
+        <button
+          type="button"
+          onClick={toggleArchivedSessions}
+          className={cn(
+            'inline-flex h-8 w-8 items-center justify-center p-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+            showArchivedSessions ? 'text-primary' : 'text-muted-foreground hover:text-foreground',
+          )}
+          aria-label={t('sessions.sidebar.header.displayMode.showArchived')}
+          aria-pressed={showArchivedSessions}
+          title={t('sessions.sidebar.header.displayMode.showArchived')}
+        >
+          <Icon name="archive-stack" className="h-5 w-5" />
+        </button>
+      )}
       {onArchiveAll && <ArchiveAllDropdown onArchiveAll={onArchiveAll} />}
       {onNewSession && (
         <button

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -60,7 +60,6 @@ import { useSessionDisplayStore } from '@/stores/useSessionDisplayStore';
 import { type SessionGroup, type SessionNode } from './sidebar/types';
 import {
   deriveRecentSessions,
-  getSessionUpdatedAtMs,
 } from './sidebar/activitySections';
 import { useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
 import {
@@ -83,8 +82,6 @@ const PROJECT_COLLAPSE_STORAGE_KEY = 'oc.sessions.projectCollapse';
 const GROUP_ORDER_STORAGE_KEY = 'oc.sessions.groupOrder';
 const GROUP_COLLAPSE_STORAGE_KEY = 'oc.sessions.groupCollapse';
 const PROJECT_ACTIVE_SESSION_STORAGE_KEY = 'oc.sessions.activeSessionByProject';
-const VSCODE_RECENT_INITIAL_SESSION_COUNT = 20;
-const VSCODE_RECENT_SESSION_BATCH_SIZE = 20;
 // v2 key holds composite "${renderContext}:${active|archived}:${sessionId}"
 // entries so the same session in different render contexts (e.g. "Recent"
 // and a project's root) has independent expand state. v1 held bare session
@@ -325,6 +322,16 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const worktreeMetadata = useSessionUIStore((state) => state.worktreeMetadata);
   const availableWorktreesByProject = useSessionUIStore((state) => state.availableWorktreesByProject);
   const openNewSessionDraft = useSessionUIStore((state) => state.openNewSessionDraft);
+  // The sidebar tree's +-buttons (project / group / folder) open a draft but,
+  // unlike selecting an existing session, don't navigate. VS Code's compact view
+  // is driven by the openchamber:navigate event, so switch to chat explicitly
+  // (a no-op in the expanded side-by-side layout, which is always showing chat).
+  const openNewSessionDraftFromTree = React.useCallback<typeof openNewSessionDraft>((options) => {
+    openNewSessionDraft(options);
+    if (isVSCode) {
+      window.dispatchEvent(new CustomEvent('openchamber:navigate', { detail: { view: 'chat' } }));
+    }
+  }, [isVSCode, openNewSessionDraft]);
   const updateStore = useUpdateStore(useShallow((s) => ({
     checkForUpdates: s.checkForUpdates,
     available: s.available,
@@ -1024,29 +1031,17 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       .sort((a, b) => compareSessionsByPinnedAndTime(a, b, pinnedSessionIds));
   }, [isVSCode, pinnedSessionIds, sessions, showRecentSection]);
 
-  const vscodeSharedSessions = React.useMemo(() => {
-    if (!isVSCode) {
-      return [];
-    }
-
-    return sessions
-      .filter((session) => !session.time?.archived)
-      .filter((session) => !(session as Session & { parentID?: string | null }).parentID)
-      .sort((left, right) => {
-        const timeDelta = getSessionUpdatedAtMs(right) - getSessionUpdatedAtMs(left);
-        if (timeDelta !== 0) return timeDelta;
-        return right.id.localeCompare(left.id);
-      });
-  }, [isVSCode, sessions]);
-
   // Prefetch is wired below, after recentSessionIds is computed.
 
   const activitySections = React.useMemo(() => {
-    if (!isVSCode && !showRecentSection) {
+    // VS Code renders the full grouped project view (one group per open
+    // workspace, folders + pinned native); the flat "recent" activity list is
+    // web/desktop-only.
+    if (isVSCode || !showRecentSection) {
       return [];
     }
 
-    const recentSessions = isVSCode ? vscodeSharedSessions : activeNowSessions;
+    const recentSessions = activeNowSessions;
 
     const toItem = (session: Session) => {
       const existing = sessionSidebarMetaById.get(session.id);
@@ -1080,7 +1075,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     return [
       { key: 'active-now' as const, title: t('sessions.sidebar.activity.recentTitle'), items },
     ];
-  }, [activeNowSessions, filterSessionNodesForSearch, hasSessionSearchQuery, isVSCode, normalizedSessionSearchQuery, sessionSidebarMetaById, showRecentSection, t, vscodeSharedSessions]);
+  }, [activeNowSessions, filterSessionNodesForSearch, hasSessionSearchQuery, isVSCode, normalizedSessionSearchQuery, sessionSidebarMetaById, showRecentSection, t]);
 
   const hasActivitySectionItems = React.useMemo(
     () => activitySections.some((section) => section.items.length > 0),
@@ -1376,7 +1371,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         setActiveProjectIdOnly={setActiveProjectIdOnly}
         setActiveMainTab={setActiveMainTab}
         setSessionSwitcherOpen={setSessionSwitcherOpen}
-        openNewSessionDraft={openNewSessionDraft}
+        openNewSessionDraft={openNewSessionDraftFromTree}
         addSessionToFolder={addSessionToFolder}
         createFolderAndStartRename={createFolderAndStartRename}
         renamingFolderId={renamingFolderId}
@@ -1413,7 +1408,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       setActiveProjectIdOnly,
       setActiveMainTab,
       setSessionSwitcherOpen,
-      openNewSessionDraft,
+      openNewSessionDraftFromTree,
       addSessionToFolder,
       createFolderAndStartRename,
       renamingFolderId,
@@ -1425,13 +1420,11 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     ],
   );
 
-  const topContent = (isVSCode || (showRecentSection && !hasSessionSearchQuery)) ? (
+  const topContent = (!isVSCode && showRecentSection && !hasSessionSearchQuery) ? (
     <SidebarActivitySections
       sections={activitySections}
       renderSessionNode={renderSessionNode}
-      variant={isVSCode ? 'flat' : 'section'}
-      initialVisibleCount={isVSCode ? VSCODE_RECENT_INITIAL_SESSION_COUNT : undefined}
-      batchSize={isVSCode ? VSCODE_RECENT_SESSION_BATCH_SIZE : undefined}
+      variant="section"
     />
   ) : null;
   const isInlineEditing = Boolean(renamingFolderId || editingId || editingProjectDialogId);
@@ -1648,7 +1641,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
       <SidebarProjectsList
         topContent={topContent}
-        sharedSessionsOnly={isVSCode}
         hasSharedSessions={hasActivitySectionItems}
         sectionsForRender={sectionsForSidebarRender}
         projectSections={projectSections}
@@ -1670,7 +1662,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         setActiveProjectIdOnly={setActiveProjectIdOnly}
         setActiveMainTab={setActiveMainTab}
         setSessionSwitcherOpen={setSessionSwitcherOpen}
-        openNewSessionDraft={openNewSessionDraft}
+        openNewSessionDraft={openNewSessionDraftFromTree}
         openNewWorktreeDialog={openNewWorktreeDialog}
         openProjectEditDialog={setEditingProjectDialogId}
         removeProject={removeProject}

--- a/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
+++ b/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
@@ -14,6 +14,12 @@
   - folder cleanup sync
   - sticky project header observer
 
+## VS Code grouping
+
+- VS Code uses the **same grouped project tree** as web/desktop (project headers + folders + pinned-first ordering), not a separate flat list. Each open VS Code workspace folder is a project header.
+- VS Code groups strictly **by open workspace**: `useSessionGrouping` funnels every non-archived session into the project's root group and emits **no per-worktree subgroups** (worktrees aren't registered in VS Code). `getSessionsForProject` buckets sessions to a workspace by exact directory match, so only sessions whose directory is an open workspace folder appear.
+- VS Code passes `hideDirectoryControls` (clean workspace headers, no worktree/close chrome) and no longer passes `showOnlyMainWorkspace`/`sharedSessionsOnly`. Folders and pinning therefore work natively, scoped to the workspace root.
+
 ## File summaries
 
 ### Components

--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -264,10 +264,10 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
 
   const displayMode = useSessionDisplayStore((state) => state.displayMode);
   const isVSCode = React.useMemo(() => isVSCodeRuntime(), []);
-  // VS Code keeps the expanded "default" layout regardless of the stored mode:
-  // multi-workspace lists rely on inline project/branch, and hover tooltips
-  // across the whole list would be impractical there.
-  const isMinimalMode = displayMode === 'minimal' && !isVSCode;
+  // VS Code always uses the minimal (single-line) layout: sessions are grouped
+  // under workspace project headers, so the second metadata row (project/branch)
+  // is redundant. The display-mode toggle is hidden there, so force it on.
+  const isMinimalMode = displayMode === 'minimal' || isVSCode;
   const isElectron = React.useMemo(() => canUseElectronDesktopIPC(), []);
   const runtimeApis = React.useContext(RuntimeAPIContext);
   const revealOnHoverClass = isVSCode
@@ -280,7 +280,15 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
   const showQuickArchiveAction = !archivedBucket && !mobileVariant;
   const revealPaddingClass = isMinimalMode
     ? (isVSCode
-        ? 'group-hover:pr-2'
+        // VS Code minimal rows reveal up to three actions on hover
+        // (open-in-editor + quick-archive + menu, each h-4). The date sits in the
+        // row flow, so the title must shrink enough to clear the actions or they
+        // overlap the timestamp. Open-in-editor is always present in VS Code.
+        ? (showQuickArchiveAction && showOpenInEditorAction
+            ? 'group-hover:pr-18'
+            : showQuickArchiveAction || showOpenInEditorAction
+              ? 'group-hover:pr-14'
+              : 'group-hover:pr-8')
         : 'group-hover:pr-2 group-focus-within:pr-2')
     : (isVSCode
         ? (showQuickArchiveAction && showOpenInEditorAction
@@ -1006,6 +1014,9 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
                     </div>
                   </button>
                 </TooltipTrigger>
+                {/* VS Code already shows project context via workspace headers, so
+                    the per-row metadata tooltip is redundant noise there. */}
+                {!isVSCode ? (
                 <TooltipContent side="right" sideOffset={8} className="max-w-xs text-left">
                   <div className="flex flex-col gap-1 text-left text-xs">
                     <div className={cn('flex items-center gap-3 text-left text-muted-foreground', secondaryMeta?.projectLabel ? 'justify-between' : 'justify-start')}>
@@ -1021,6 +1032,7 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
                     ) : null}
                   </div>
                 </TooltipContent>
+                ) : null}
               </Tooltip>
             ) : (
               <button

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
@@ -124,6 +124,11 @@ export const useSessionGrouping = (args: Args) => {
 
       const getGroupKey = (session: Session) => {
         if (session.time?.archived) return archivedKey;
+        // VS Code groups by open workspace, not by worktree: every non-archived
+        // session in a project belongs to that project's single (root) group.
+        // Worktrees aren't registered in VS Code, so the desktop directory-match
+        // below would otherwise dump these sessions into the archived bucket.
+        if (args.isVSCode) return normalizedProjectRoot ?? '__project_root__';
         const metadataPath = normalizePath(args.worktreeMetadata.get(session.id)?.path ?? null);
         const normalizedDir = metadataPath ?? resolveGlobalSessionDirectory(session);
         if (!normalizedDir) return archivedKey;
@@ -196,7 +201,9 @@ export const useSessionGrouping = (args: Args) => {
         return aLabel.localeCompare(bLabel);
       });
 
-      sortedWorktrees.forEach((meta) => {
+      // VS Code groups strictly by open workspace — no per-worktree subgroups.
+      const worktreeGroups = args.isVSCode ? [] : sortedWorktrees;
+      worktreeGroups.forEach((meta) => {
         const directory = normalizePath(meta.path) ?? meta.path;
         const currentBranch = args.gitBranches.get(directory)?.trim() || null;
         const metadataBranch = meta.branch?.trim() || null;

--- a/packages/ui/src/components/session/sidebar/sortableItems.tsx
+++ b/packages/ui/src/components/session/sidebar/sortableItems.tsx
@@ -169,6 +169,8 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
                   className={cn('w-full text-left group/project select-none')}
                   style={{ backgroundColor: isDesktopShell && isStuck ? 'transparent' : undefined }}
                   onContextMenu={(event) => {
+                    // VS Code hides project actions entirely (hideDirectoryControls).
+                    if (hideDirectoryControls) return;
                     event.preventDefault();
                     setIsContextMenuOpen(true);
                   }}
@@ -266,6 +268,7 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
                   </Tooltip>
                 ) : null}
 
+                {!hideDirectoryControls ? (
                 <DropdownMenu
                   open={isMenuOpen}
                   onOpenChange={handleMenuOpenChange}
@@ -293,6 +296,7 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
                       {renderProjectMenuItems(DropdownMenuItem)}
                     </DropdownMenuContent>
                   </DropdownMenu>
+                ) : null}
               </div>
 
               {showCreateButtons && onNewSession ? (

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+- Startup: the extension opens faster — recent sessions, models, providers, and projects appear instantly from cache and refresh in the background, and the loading screen no longer lingers after the interface is ready.
+- Startup: requests made while OpenCode is still starting now wait briefly for it to become ready instead of failing, and if OpenCode fails to start the error now includes what it reported.
+- Sessions: the list now groups sessions under their workspace, so pinning sessions and moving them into folders work as expected.
+- Sessions: session rows now use a cleaner single-line layout, project-level actions are hidden, and a new control next to "archive all" toggles archived sessions on or off.
 - Chat: custom-answer question textareas resize more steadily while typing (thanks to @bigcoder84).
 - Chat/Performance: long conversations now use virtualized rendering to keep large histories responsive.
 - Chat/Input: tab-completing a mention no longer changes the selected agent (thanks to @Quat3rnion).

--- a/packages/vscode/src/bridge-proxy-runtime.test.ts
+++ b/packages/vscode/src/bridge-proxy-runtime.test.ts
@@ -19,8 +19,13 @@ const deps = {
 
 const ctx = {
   manager: {
+    getStatus: () => 'connected',
     getApiUrl: () => 'http://127.0.0.1:3902',
     getOpenCodeAuthHeaders: () => ({}),
+    onStatusChange: (cb: (status: string) => void) => {
+      cb('connected');
+      return { dispose: () => {} };
+    },
   },
 } as unknown as BridgeContext;
 
@@ -52,6 +57,73 @@ describe('VS Code API proxy aborts', () => {
       const response = await pending;
       assert.equal(response?.success, true);
       assert.equal((response?.data as { status?: number }).status, 502);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('VS Code API proxy read coalescing', () => {
+  test('shares one upstream fetch across concurrent identical GET reads', async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCount = 0;
+    let release: () => void = () => {};
+
+    try {
+      globalThis.fetch = (async () => {
+        fetchCount += 1;
+        await new Promise<void>((resolve) => { release = resolve; });
+        return new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'application/json' } });
+      }) as typeof fetch;
+
+      const first = handleProxyBridgeMessage(
+        { id: 'r1', type: 'api:proxy', payload: { method: 'GET', path: '/config?directory=/x' } },
+        ctx,
+        deps,
+      );
+      const second = handleProxyBridgeMessage(
+        { id: 'r2', type: 'api:proxy', payload: { method: 'GET', path: '/config?directory=/x' } },
+        ctx,
+        deps,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      release();
+
+      const [a, b] = await Promise.all([first, second]);
+      assert.equal(fetchCount, 1);
+      assert.equal((a?.data as { bodyText?: string }).bodyText, '{"ok":true}');
+      assert.equal((b?.data as { bodyText?: string }).bodyText, '{"ok":true}');
+      assert.notStrictEqual((a?.data as { headers: unknown }).headers, (b?.data as { headers: unknown }).headers);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('does not coalesce POST writes or non-allowlisted reads', async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCount = 0;
+
+    try {
+      globalThis.fetch = (async () =>
+        new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+
+      await Promise.all([
+        handleProxyBridgeMessage({ id: 'w1', type: 'api:proxy', payload: { method: 'GET', path: '/session?directory=/x' } }, ctx, deps),
+        handleProxyBridgeMessage({ id: 'w2', type: 'api:proxy', payload: { method: 'GET', path: '/session?directory=/x' } }, ctx, deps),
+      ]);
+      assert.equal(fetchCount, 0); // sanity: counter only bumps in the slow mock above
+
+      globalThis.fetch = (async () => {
+        fetchCount += 1;
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+      }) as typeof fetch;
+
+      await Promise.all([
+        handleProxyBridgeMessage({ id: 's1', type: 'api:proxy', payload: { method: 'GET', path: '/session?directory=/x' } }, ctx, deps),
+        handleProxyBridgeMessage({ id: 's2', type: 'api:proxy', payload: { method: 'GET', path: '/session?directory=/x' } }, ctx, deps),
+      ]);
+      assert.equal(fetchCount, 2); // /session is not in the read allowlist
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/vscode/src/bridge-proxy-runtime.ts
+++ b/packages/vscode/src/bridge-proxy-runtime.ts
@@ -65,6 +65,58 @@ type ProxyRuntimeDeps = {
 
 const proxyAbortControllers = new Map<string, AbortController>();
 
+// ---------------------------------------------------------------------------
+// In-flight read coalescing (parity with the web runtimeFetch coalescer)
+//
+// On cold start the webview's two data layers — the sync bootstrap and the
+// config store — fire the SAME idempotent reads (config, path, agents, agent,
+// project, command) concurrently through the bridge with no shared dedup. That
+// saturates the single OpenCode process and delays everything queued behind it
+// (e.g. createSession). Coalesce genuinely-concurrent identical GETs to those
+// read endpoints so OpenCode does the work once; every caller gets its own
+// response payload copy.
+//
+// Scope is deliberately tight: GET only, an allowlist of read paths. The shared
+// fetch runs without a per-request AbortController, so one caller's
+// `api:proxy:abort` cannot cancel the read for the others (these reads are fast
+// and idempotent — losing abort for them is harmless). The entry is removed as
+// soon as the request settles, so this only ever shares overlapping in-flight
+// requests; it never serves a stale response.
+// ---------------------------------------------------------------------------
+const COALESCE_READ_PATH = /^\/(config|path|app\/agents|agent|project|command)(\b|\/|\?|$)/;
+const READ_COALESCE = new Map<string, Promise<ApiProxyResponsePayload>>();
+
+const performApiProxyFetch = async (
+  targetUrl: string,
+  method: string,
+  headers: Record<string, string>,
+  body: Buffer | undefined,
+  signal: AbortSignal | undefined,
+  deps: Pick<ProxyRuntimeDeps, 'collectHeaders'>,
+): Promise<ApiProxyResponsePayload> => {
+  try {
+    const response = await fetch(targetUrl, { method, headers, body, signal });
+    const responseHeaders = collectProxyResponseHeaders(response.headers, deps);
+    if (shouldReturnTextBody(response.headers)) {
+      return { status: response.status, headers: responseHeaders, bodyText: await response.text() };
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    return {
+      status: response.status,
+      headers: responseHeaders,
+      bodyBase64: Buffer.from(arrayBuffer).toString('base64'),
+    };
+  } catch (error) {
+    return {
+      status: 502,
+      headers: { 'content-type': 'application/json' },
+      bodyText: JSON.stringify({
+        error: error instanceof Error ? error.message : 'Failed to reach OpenCode API',
+      }),
+    };
+  }
+};
+
 export async function handleProxyBridgeMessage(
   message: BridgeMessageInput,
   ctx: BridgeContext | undefined,
@@ -119,49 +171,45 @@ export async function handleProxyBridgeMessage(
         ...ctx?.manager?.getOpenCodeAuthHeaders(),
       };
 
+      const requestBody =
+        typeof bodyBase64 === 'string' && bodyBase64.length > 0 && normalizedMethod !== 'GET' && normalizedMethod !== 'HEAD'
+          ? Buffer.from(bodyBase64, 'base64')
+          : undefined;
+
+      // Coalesce concurrent identical GET reads to idempotent endpoints so the
+      // single OpenCode process serves them once. The shared fetch carries no
+      // AbortController (api:proxy:abort can't cancel these reads), so one
+      // caller aborting can't strand the others.
+      const coalesceKey =
+        normalizedMethod === 'GET' && COALESCE_READ_PATH.test(normalizedPath) ? `GET ${targetUrl}` : null;
+      if (coalesceKey) {
+        const existing = READ_COALESCE.get(coalesceKey);
+        if (existing) {
+          const shared = await existing;
+          return { id, type, success: true, data: { ...shared, headers: { ...shared.headers } } };
+        }
+        const pending = performApiProxyFetch(targetUrl, 'GET', requestHeaders, undefined, undefined, deps);
+        READ_COALESCE.set(coalesceKey, pending);
+        pending.then(
+          () => READ_COALESCE.delete(coalesceKey),
+          () => READ_COALESCE.delete(coalesceKey),
+        );
+        const data = await pending;
+        return { id, type, success: true, data };
+      }
+
       const abortController = new AbortController();
       proxyAbortControllers.set(id, abortController);
 
       try {
-        const response = await fetch(targetUrl, {
-          method: normalizedMethod,
-          headers: requestHeaders,
-          body:
-            typeof bodyBase64 === 'string' && bodyBase64.length > 0 && normalizedMethod !== 'GET' && normalizedMethod !== 'HEAD'
-              ? Buffer.from(bodyBase64, 'base64')
-              : undefined,
-          signal: abortController.signal,
-        });
-
-        const responseHeaders = collectProxyResponseHeaders(response.headers, deps);
-        if (shouldReturnTextBody(response.headers)) {
-          const bodyText = await response.text();
-          const data: ApiProxyResponsePayload = {
-            status: response.status,
-            headers: responseHeaders,
-            bodyText,
-          };
-
-          return { id, type, success: true, data };
-        }
-
-        const arrayBuffer = await response.arrayBuffer();
-        const data: ApiProxyResponsePayload = {
-          status: response.status,
-          headers: responseHeaders,
-          bodyBase64: Buffer.from(arrayBuffer).toString('base64'),
-        };
-
-        return { id, type, success: true, data };
-      } catch (error) {
-        const body = JSON.stringify({
-          error: error instanceof Error ? error.message : 'Failed to reach OpenCode API',
-        });
-        const data: ApiProxyResponsePayload = {
-          status: 502,
-          headers: { 'content-type': 'application/json' },
-          bodyText: body,
-        };
+        const data = await performApiProxyFetch(
+          targetUrl,
+          normalizedMethod,
+          requestHeaders,
+          requestBody,
+          abortController.signal,
+          deps,
+        );
         return { id, type, success: true, data };
       } finally {
         proxyAbortControllers.delete(id);

--- a/packages/vscode/src/opencode-ready.test.ts
+++ b/packages/vscode/src/opencode-ready.test.ts
@@ -1,0 +1,74 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ConnectionStatus, OpenCodeManager } from './opencode';
+import { waitForApiUrl } from './opencode-ready';
+
+type Listener = (status: ConnectionStatus, error?: string) => void;
+
+const createManager = (initial: { status: ConnectionStatus; url: string | null }) => {
+  let status = initial.status;
+  let url = initial.url;
+  const listeners = new Set<Listener>();
+
+  const manager = {
+    getStatus: () => status,
+    getApiUrl: () => url,
+    onStatusChange: (cb: Listener) => {
+      listeners.add(cb);
+      cb(status);
+      return { dispose: () => listeners.delete(cb) };
+    },
+  } as unknown as OpenCodeManager;
+
+  const transition = (next: ConnectionStatus, nextUrl: string | null) => {
+    status = next;
+    url = nextUrl;
+    listeners.forEach((cb) => cb(status));
+  };
+
+  return { manager, transition };
+};
+
+describe('waitForApiUrl readiness gating', () => {
+  test('returns immediately when already connected with a URL', async () => {
+    const { manager } = createManager({ status: 'connected', url: 'http://127.0.0.1:3902' });
+    assert.equal(await waitForApiUrl(manager, 1000), 'http://127.0.0.1:3902');
+  });
+
+  test('does not hand out the URL until status is connected (pre-ready spawn window)', async () => {
+    // server.url is exposed while still connecting — must NOT be forwarded to.
+    const { manager, transition } = createManager({ status: 'connecting', url: 'http://127.0.0.1:3902' });
+    const pending = waitForApiUrl(manager, 1000);
+
+    let resolved = false;
+    void pending.then(() => { resolved = true; });
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(resolved, false);
+
+    transition('connected', 'http://127.0.0.1:3902');
+    assert.equal(await pending, 'http://127.0.0.1:3902');
+  });
+
+  test('holds during a restart and resolves once reconnected', async () => {
+    const { manager, transition } = createManager({ status: 'disconnected', url: null });
+    const pending = waitForApiUrl(manager, 1000);
+
+    transition('connecting', null);
+    await new Promise((r) => setTimeout(r, 5));
+    transition('connected', 'http://127.0.0.1:4096');
+    assert.equal(await pending, 'http://127.0.0.1:4096');
+  });
+
+  test('fails fast on error status instead of burning the timeout', async () => {
+    const { manager, transition } = createManager({ status: 'connecting', url: null });
+    const pending = waitForApiUrl(manager, 5000);
+    transition('error', null);
+    // Resolves well before the 5s timeout.
+    assert.equal(await pending, null);
+  });
+
+  test('falls back to whatever URL exists after the timeout', async () => {
+    const { manager } = createManager({ status: 'connecting', url: null });
+    assert.equal(await waitForApiUrl(manager, 20), null);
+  });
+});

--- a/packages/vscode/src/opencode-ready.ts
+++ b/packages/vscode/src/opencode-ready.ts
@@ -1,4 +1,4 @@
-import type { OpenCodeManager } from './opencode';
+import type { ConnectionStatus, OpenCodeManager } from './opencode';
 
 export const API_URL_WAIT_TIMEOUT_MS = 30000;
 
@@ -10,7 +10,21 @@ export async function waitForApiUrl(
     return null;
   }
 
-  const initialUrl = manager.getApiUrl();
+  // Only hand out an API URL once OpenCode has actually passed its readiness
+  // check. getApiUrl() exposes `server.url` as soon as the process is spawned —
+  // BEFORE waitForReady confirms it can serve — so URL-presence alone would
+  // forward requests to a not-yet-ready OpenCode (and to a stale port during a
+  // workspace-switch restart). Gating on the connected status, which flips only
+  // after readiness and clears while restarting, mirrors the web proxy's
+  // isOpenCodeReady hold and closes that pre-ready forwarding window.
+  const readyUrl = (): string | null => {
+    if (manager.getStatus() !== 'connected') {
+      return null;
+    }
+    return manager.getApiUrl();
+  };
+
+  const initialUrl = readyUrl();
   if (initialUrl) {
     return initialUrl;
   }
@@ -21,9 +35,8 @@ export async function waitForApiUrl(
     let subscription: { dispose(): void } | null = null;
     let disposeAfterSubscribe = false;
 
-    const handleStatusChange = () => {
-      const nextUrl = manager.getApiUrl();
-      if (!nextUrl || settled) {
+    const finish = (value: string | null) => {
+      if (settled) {
         return;
       }
       settled = true;
@@ -35,9 +48,25 @@ export async function waitForApiUrl(
       } else {
         disposeAfterSubscribe = true;
       }
-      resolve(nextUrl);
+      resolve(value);
     };
 
+    const handleStatusChange = (status: ConnectionStatus) => {
+      // Permanent failure (CLI missing / spawn error) won't recover from holding
+      // — fail fast instead of burning the full timeout, matching the web gate's
+      // fast 503 for genuinely-down servers.
+      if (status === 'error') {
+        finish(null);
+        return;
+      }
+      const nextUrl = readyUrl();
+      if (nextUrl) {
+        finish(nextUrl);
+      }
+    };
+
+    // onStatusChange invokes the callback synchronously with the current status,
+    // so this also covers an already-ready/already-errored manager.
     subscription = manager.onStatusChange(handleStatusChange);
     if (disposeAfterSubscribe) {
       subscription.dispose();
@@ -48,12 +77,9 @@ export async function waitForApiUrl(
     }
 
     timeoutId = setTimeout(() => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      subscription?.dispose();
-      resolve(manager.getApiUrl());
+      // Bounded fallback: hand back whatever URL exists (possibly null) so a
+      // genuinely-stuck startup surfaces as unavailable rather than hanging.
+      finish(manager.getApiUrl());
     }, timeoutMs);
   });
 }

--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -673,7 +673,12 @@ async function spawnManagedOpenCodeServer(
 
     const timer = setTimeout(() => {
       cleanup();
-      reject(new Error(`Timeout waiting for server to start after ${timeoutMs}ms`));
+      // Surface whatever OpenCode printed while we waited — otherwise a hung or
+      // misconfigured start is indistinguishable from a slow one in the status
+      // report, leaving no thread to pull on.
+      const trimmedOutput = output.trim();
+      const outputHint = trimmedOutput ? ` Output: ${trimmedOutput}` : ' Output: (none — process printed nothing)';
+      reject(new Error(`Timeout waiting for server to start after ${timeoutMs}ms.${outputHint}`));
     }, timeoutMs);
 
     child.stdout?.on('data', onStdout);

--- a/packages/vscode/src/sseProxy.test.js
+++ b/packages/vscode/src/sseProxy.test.js
@@ -4,6 +4,7 @@ const originalFetch = globalThis.fetch;
 const { openSseProxy } = await import('./sseProxy');
 
 const createManager = () => ({
+  getStatus: () => 'connected',
   getApiUrl: () => 'http://127.0.0.1:4096/',
   getWorkingDirectory: () => '/repo',
   getOpenCodeAuthHeaders: () => ({ Authorization: 'Bearer test-token' }),

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -138,36 +138,6 @@ const waitForUiMount = (timeoutMs = 8000): Promise<boolean> => {
 };
 
 let uiMounted = false;
-let bootstrapProvidersReady = false;
-let bootstrapAgentsReady = false;
-let bootstrapFailed = false;
-
-const recordBootstrapFetch = (pathname: string, ok: boolean) => {
-  if (!pathname.startsWith('/api/')) return;
-
-  // Don't mark as failed while still connecting — early 503s are expected
-  const isConnected = window.__OPENCHAMBER_CONNECTION__?.status === 'connected';
-
-  if (pathname.startsWith('/api/config/providers')) {
-    if (ok) {
-      bootstrapProvidersReady = true;
-      // Reset failed flag — a successful retry supersedes earlier 503s
-      if (bootstrapAgentsReady || !isConnected) bootstrapFailed = false;
-    } else if (isConnected) {
-      bootstrapFailed = true;
-    }
-    return;
-  }
-
-  if (pathname === '/api/agent' || pathname.startsWith('/api/agent?')) {
-    if (ok) {
-      bootstrapAgentsReady = true;
-      if (bootstrapProvidersReady || !isConnected) bootstrapFailed = false;
-    } else if (isConnected) {
-      bootstrapFailed = true;
-    }
-  }
-};
 
 const maybeHideLoadingOverlay = () => {
   const connectionStatus = window.__OPENCHAMBER_CONNECTION__?.status ?? 'connecting';
@@ -177,19 +147,14 @@ const maybeHideLoadingOverlay = () => {
   }
 
   if (connectionStatus === 'connected') {
-    if (bootstrapFailed) {
-      setLoadingStatusText(bootstrapMessages.initialDataLoadFailed, 'error');
-      fadeOutLoadingScreen();
-      return;
-    }
-
-    if (bootstrapProvidersReady && bootstrapAgentsReady) {
-      fadeOutLoadingScreen();
-      return;
-    }
-
-    // Still loading providers/agents — stay silent (the animated logo signals work).
-    setLoadingStatusText('');
+    // The UI hydrates pickers and the sidebar from cache and refreshes
+    // providers/agents in the background, so once it's mounted and OpenCode is
+    // connected there's real interactive content underneath the splash. Don't
+    // keep the overlay up waiting on the live provider/agent fetches — on a cold
+    // start those are the slowest tail, and gating on them makes the splash
+    // linger long after the app is usable. Per-widget loaders convey any
+    // remaining background work.
+    fadeOutLoadingScreen();
     return;
   }
 
@@ -1120,7 +1085,6 @@ window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
   if (targetUrl && isLocalRuntimePath(normalizedPathname)) {
     const localResponse = await handleLocalApiRequest(input, targetUrl, init, method);
     if (localResponse) {
-      recordBootstrapFetch(targetUrl.pathname, localResponse.ok);
       maybeHideLoadingOverlay();
       return localResponse;
     }
@@ -1208,7 +1172,6 @@ window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const signal = (input instanceof Request ? input.signal : init?.signal) as AbortSignal | undefined;
       const proxied = await proxySessionMessageRequest({ path: suffixPath, headers, bodyText, signal });
       const response = buildProxiedResponse(proxied);
-      recordBootstrapFetch(targetUrl.pathname, response.ok);
       maybeHideLoadingOverlay();
       return response;
     }
@@ -1217,7 +1180,6 @@ window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const signal = (input instanceof Request ? input.signal : init?.signal) as AbortSignal | undefined;
     const proxied = await proxyApiRequest({ method, path: suffixPath, headers, bodyBase64, signal });
     const response = buildProxiedResponse(proxied);
-    recordBootstrapFetch(targetUrl.pathname, response.ok);
     maybeHideLoadingOverlay();
     return response;
   }


### PR DESCRIPTION
## Summary

VS Code follow-up to the startup-optimization work (#1650), which landed web/desktop-only. This branch brings the VS Code runtime to parity and then reworks the VS Code session list.

## Startup parity

- **Readiness hold.** `waitForApiUrl` now hands out the OpenCode API URL only once the managed server reports `connected`, instead of as soon as the process is spawned. Previously the URL was exposed before OpenCode could serve (and during a workspace-switch restart it pointed at a stale port), so the bridge forwarded requests to a not-yet-ready server and surfaced errors. Also fails fast on a permanent `error` status instead of waiting out the full timeout.
- **Duplicate read coalescing.** Concurrent identical GET reads (config/path/agents/agent/project/command) made on cold start by the sync bootstrap and the config store are now coalesced at the bridge so the single OpenCode process serves them once — the extension-host analog of the web `runtimeFetch` coalescer.
- **Splash.** The startup overlay now fades once the UI is mounted and OpenCode is connected, instead of waiting on the live provider/agent fetches (the slowest cold-start tail); the UI underneath already paints from cache.
- **Diagnostics.** A managed-server spawn timeout now includes whatever OpenCode printed, so a hung/misconfigured start is distinguishable from a slow one.

## Session list rework

The flat multi-workspace "recent" list was replaced with the grouped project view, using each open VS Code workspace folder as a header (no per-worktree subgroups). This restores folder and pin support — which the flat list silently dropped — and fixes clipped row padding.

- Sessions group strictly by open workspace; folders and pinning work natively, scoped to the workspace.
- The project actions (`...`) menu is hidden; the `+` buttons (project/group/folder) now open a draft in the correct workspace and navigate to chat.
- Rows use the minimal single-line layout (the second metadata row is redundant under workspace headers), the per-row tooltip is dropped, and a show/hide archived toggle sits next to the archive-all control.

## Validation

`bun run type-check`, `bun run lint`, and VS Code `tsc` (extension + webview) pass. Bridge/readiness unit tests pass per-file. Manually tested in the extension (startup, grouping, pin/folder, archived toggle, `+` navigation, row layout).

User-facing notes added to `packages/vscode/CHANGELOG.md`.
