### PR TITLE
ci: skip stale workflow on forks

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   stale:
+    if: ${{ github.repository == 'openchamber/openchamber' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot app token


### PR DESCRIPTION
## Summary
- Add a repository guard to the scheduled stale workflow so it only runs in `openchamber/openchamber`.
- Prevent forks from running the secret-dependent GitHub App token step.

## Why
Forks do not receive the upstream repository secrets used by `actions/create-github-app-token` (`OC_REVIEW_APP_ID` and `OC_REVIEW_APP_PRIVATE_KEY`). The scheduled `stale` workflow can therefore run and fail on forks even though stale issue/PR management is only intended for the upstream repository.

A job-level `if` keeps the workflow visible but skips the job before any secret-dependent action runs.

## Validation
- Not run: local YAML validation tooling is unavailable in this environment (no `ruby`, no local `yaml` package, no `actionlint`).
- Reviewed the workflow diff manually; the change is a single GitHub Actions job-level `if` expression.