### PR TITLE
fix: uncap tool-call duration display past 5 minutes (#1580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Chat: tool-call duration now shows real elapsed time past 5 minutes instead of freezing at 300s.
+
 ## [1.13.1] - 2026-06-17
 
 - Chat: inline math delimiters no longer incorrectly treat currency amounts like `$50` as LaTeX math expressions — only `$$...$$` display math and `\(...\)` inline math are recognized.

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -163,7 +163,6 @@ const normalizeToolName = (toolName: string | undefined | null): string => {
     return trimmed;
 };
 
-const MAX_DURATION_MS = 5 * 60 * 1000; // 5 minutes cap
 const TASK_TOOL_POLL_FAST_MS = 1200;
 const TASK_TOOL_POLL_IDLE_MS = 3200;
 const TASK_TOOL_POLL_HIDDEN_MS = 6000;
@@ -186,7 +185,7 @@ const GIT_REFRESH_MUTATING_TOOLS = new Set([
 ]);
 
 const formatDuration = (start: number, end?: number, now: number = Date.now()) => {
-    const duration = Math.min(Math.max(0, (end ?? now) - start), MAX_DURATION_MS);
+    const duration = Math.max(0, (end ?? now) - start);
     const seconds = duration / 1000;
 
     const displaySeconds = seconds < 0.05 && end !== undefined ? 0.1 : seconds;


### PR DESCRIPTION
## What / Why

In `ToolPart.tsx`, tool-row elapsed time was clamped to `MAX_DURATION_MS`
(5 minutes), so any tool running longer displayed a frozen `300.0s`
(for example a 10-minute `bash` command). Fixes #1580.

This removes the upper clamp in `formatDuration` so a tool's real elapsed
time is shown, and adds a changelog entry.

## Testing

- Verified a >5-minute span now renders its real value (e.g. `360.0s`) instead of `300.0s`.
- `bun run lint` passes; the changed file is type-clean under `bun run type-check:ui`.

## References

Fixes #1580
