### PR TITLE
fix(chat): stabilize session switch to prevent scroll jumps and empty viewports

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -34,6 +34,7 @@ import {
 
 // New sync system imports
 import { useSessionUIStore } from '@/sync/session-ui-store';
+import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useStreamingStore } from '@/sync/streaming';
 import {
     useSessionMessageCount,
@@ -787,7 +788,27 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
     React.useEffect(() => {
         if (!currentSessionId) return;
         if (hasRenderableSessionSnapshot) return;
-        if (effectiveSessionDirectory !== syncDirectory) return;
+        if (effectiveSessionDirectory !== syncDirectory) {
+            // Directory hasn't reconciled yet after the atomic store update.
+            // Retry on a short interval (capped) to avoid silently skipping
+            // the message fetch — otherwise the session can stay in an
+            // unrenderable state forever.
+            const start = Date.now();
+            const interval = window.setInterval(() => {
+                const dirMatches = effectiveSessionDirectory === useDirectoryStore.getState().currentDirectory;
+                const nowRenderable = hasRenderableSessionSnapshot;
+                if (nowRenderable || dirMatches) {
+                    window.clearInterval(interval);
+                    if (!nowRenderable) {
+                        void ensureSessionRenderable(currentSessionId);
+                    }
+                } else if (Date.now() - start > 2000) {
+                    // Give up after 2s — the session is unlikely to recover.
+                    window.clearInterval(interval);
+                }
+            }, 80);
+            return () => window.clearInterval(interval);
+        }
         void ensureSessionRenderable(currentSessionId);
     }, [currentSessionId, effectiveSessionDirectory, ensureSessionRenderable, hasRenderableSessionSnapshot, syncDirectory]);
 
@@ -938,7 +959,6 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
 		<div className="relative flex flex-col h-full bg-background">
 			{returnToParentButton}
 			<ChatViewport
-				key={currentSessionId}
 				currentSessionId={currentSessionId}
                 isDesktopExpandedInput={isDesktopExpandedInput}
                 isMobile={isMobile}

--- a/packages/ui/src/components/chat/hooks/useChatTurnNavigation.ts
+++ b/packages/ui/src/components/chat/hooks/useChatTurnNavigation.ts
@@ -168,6 +168,16 @@ export const useChatTurnNavigation = ({
             return;
         }
 
+        // Clear any stale hash inherited from a previous session — a hash
+        // pointing to a turn/message that doesn't exist in the new session
+        // used to release auto-follow, fail to scroll, and leave the view
+        // stuck at an intermediate point.
+        const currentHash = window.location.hash;
+        const parsed = parseChatHashTarget(currentHash);
+        if (parsed) {
+            setHash(null);
+        }
+
         const applyHash = () => {
             const target = parseChatHashTarget(window.location.hash);
             if (!target) {

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -358,7 +358,17 @@ export const useChatAutoFollow = ({
         }
         pendingInitialRestoreRef.current = null;
 
+        // Guard: Virtualizer may not have flushed its measurements yet, so
+        // scrollHeight/clientHeight can be 0 or smaller than the saved snapshot.
+        // If so, defer the restore one more frame and let the replay effect
+        // pick it up once layout is stable.
+        const hasLayout = container.scrollHeight > 0;
         const saved = getViewportSessionMemory(sessionId)?.scrollPosition;
+        const savedHeight = saved ? saved.scrollHeight : 0;
+        if (hasLayout && saved && savedHeight > 0 && container.scrollHeight < Math.min(savedHeight, savedHeight * 0.5)) {
+            pendingInitialRestoreRef.current = sessionId;
+            return false;
+        }
 
         if (!saved || isAtBottomSnapshot(saved, isMobile)) {
             setStateValue('following');
@@ -555,6 +565,15 @@ export const useChatAutoFollow = ({
             if (stateRef.current === 'following') {
                 startFollowLoop();
             }
+            // Replay a deferred restoreSnapshot once the scroll container has
+            // enough layout to map the saved ratio (Virtualizer flushed).
+            if (
+                pendingInitialRestoreRef.current
+                && pendingInitialRestoreRef.current === currentSessionId
+                && container.scrollHeight > 0
+            ) {
+                void restoreSnapshot();
+            }
         });
         observer.observe(container);
         const inner = container.firstElementChild;
@@ -562,7 +581,7 @@ export const useChatAutoFollow = ({
             observer.observe(inner);
         }
         return () => observer.disconnect();
-    }, [containerEl, startFollowLoop, updateOverflowAndButton]);
+    }, [containerEl, currentSessionId, restoreSnapshot, startFollowLoop, updateOverflowAndButton]);
 
     React.useEffect(() => {
         updateOverflowAndButton();

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -513,7 +513,16 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     // skeleton to render and reads messages which can be expensive.
     if (previousSessionId && previousSessionId !== id) {
       const prevId = previousSessionId
-      setTimeout(() => {
+      const newId = id
+      // queueMicrotask runs after the current synchronous call stack (and
+      // before the next macrotask / setTimeout(0) / paint), so the previous
+      // session's anchor is saved before the new session's restoreSnapshot
+      // effect fires. This eliminates the race where save and restore
+      // interleave against the same viewport store entry.
+      queueMicrotask(() => {
+        // Bail if the user already switched again — save is now stale.
+        const current = get().currentSessionId
+        if (current !== newId) return
         const memState = getViewportSessionMemory(prevId)
         if (!memState?.isStreaming) {
           const prevMessages = getSyncMessages(prevId)
@@ -521,7 +530,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
             useViewportStore.getState().updateViewportAnchor(prevId, prevMessages.length - 1)
           }
         }
-      }, 0)
+      })
     }
 
     // Mark session viewed in notification store + update active session ref


### PR DESCRIPTION
## Summary

Fix multiple race conditions in the chat session-switching flow that caused:
- Blank/black viewport flashes on session switch
- Scroll jumping to an intermediate point or staying at the top
- Sessions stuck in an unrenderable state (no messages ever loaded)
- Stale turn/message hash from the previous session stranding the view

## Root causes

1. **ChatViewport `key={currentSessionId}`** forced a full DOM remount on every session switch. The remount gap raced with message delivery, producing transient empty/blank states.
2. **Scroll restore by ratio** ran while the Virtualizer had not yet flushed its measurements. With `scrollHeight === 0`, the ratio math produced `targetTop = 0`, jumping the view to the top.
3. **`effectiveSessionDirectory !== syncDirectory` guard** silently skipped `ensureSessionRenderable`, leaving the session in an unrenderable state when the directory had not yet reconciled after the atomic store update.
4. **`setTimeout(0)` for previous-session anchor save** interleaved with the new session's `restoreSnapshot` effect, racing against the same viewport-store entry.
5. **Stale `window.location.hash`** from a previous session released auto-follow and then failed to scroll to a non-existent turn, stranding the view at an intermediate point.

## Changes

- `packages/ui/src/components/chat/ChatContainer.tsx`
  - Remove `key={currentSessionId}` from `ChatViewport`. The Virtualizer still remounts on `sessionKey` change internally, but the scroll-container DOM is now preserved across session switches.
  - Replace the silent `return` in the `ensureSessionRenderable` effect with a short-interval retry (80ms, capped 2s) that polls `useDirectoryStore.getState().currentDirectory` so the message fetch is no longer skipped.
- `packages/ui/src/hooks/useChatAutoFollow.ts`
  - Add a `scrollHeight` guard to `restoreSnapshot`: when the container's current height is too small to map the saved ratio, defer the restore and let the `ResizeObserver` replay it once the Virtualizer has flushed.
- `packages/ui/src/sync/session-ui-store.ts`
  - Replace `setTimeout(0)` with `queueMicrotask` for the previous-session anchor save. The microtask runs after the current sync call stack but before the next paint / `restoreSnapshot` effect, eliminating the race. Bail if the user has already switched again.
- `packages/ui/src/components/chat/hooks/useChatTurnNavigation.ts`
  - Clear any stale `window.location.hash` on session change so a hash pointing to a turn that does not exist in the new session no longer releases auto-follow and strands the view.

## Verification

- `bun run type-check` clean across all packages
- `bun run lint` clean (one pre-existing warning in `SettingsView.tsx` unrelated to this change)
- Manual reproduction of the original failure (rapid session switching, sessions with many turns, sessions with virtualization enabled) now stays fluid without flashes or scroll jumps.