### PR TITLE
feat: support Open in App (VS Code) for remote SSH instances (#1449)

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -3047,6 +3047,198 @@ const buildOpenFileSpecs = ({ filePath, appId, appName }) => {
   return specs;
 };
 
+const REMOTE_URI_SCHEME_BY_APP_ID = {
+  vscode: 'vscode',
+  cursor: 'cursor',
+  vscodium: 'vscodium',
+  windsurf: 'windsurf',
+};
+
+const normalizeSshHost = (host) => {
+  if (!host || typeof host !== 'string') return '';
+  if (host.includes(':') && !host.startsWith('[')) return `[${host}]`;
+  return host;
+};
+
+const buildOpenRemoteProjectSpecs = ({ projectPath, appId, appName, sshInfo }) => {
+  if (process.platform !== 'darwin') return [];
+  const specs = [];
+  const cli = CLI_BY_APP_ID[appId];
+  if (cli) {
+    const hostPart = sshInfo.user ? `${sshInfo.user}@${normalizeSshHost(sshInfo.host)}` : normalizeSshHost(sshInfo.host);
+    const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
+    const remoteTarget = `ssh-remote+${hostPort}`;
+    specs.push({ program: cli, args: ['--remote', remoteTarget, '--new-window', projectPath] });
+    const scheme = REMOTE_URI_SCHEME_BY_APP_ID[appId] || 'vscode';
+    const encodedPath = projectPath.split('/').map(encodeURIComponent).join('/');
+    const deepLinkUri = `${scheme}://vscode-remote/${remoteTarget}${encodedPath}`;
+    specs.push({ program: 'open', args: [deepLinkUri] });
+  }
+  return specs;
+};
+
+const buildOpenRemoteFileSpecs = ({ filePath, appId, appName, sshInfo }) => {
+  if (process.platform !== 'darwin') return [];
+  const specs = [];
+  const cli = CLI_BY_APP_ID[appId];
+  if (cli) {
+    const hostPart = sshInfo.user ? `${sshInfo.user}@${normalizeSshHost(sshInfo.host)}` : normalizeSshHost(sshInfo.host);
+    const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
+    const remoteTarget = `ssh-remote+${hostPort}`;
+    specs.push({ program: cli, args: ['--remote', remoteTarget, '--goto', filePath] });
+    const scheme = REMOTE_URI_SCHEME_BY_APP_ID[appId] || 'vscode';
+    const encodedPath = filePath.split('/').map(encodeURIComponent).join('/');
+    const deepLinkUri = `${scheme}://vscode-remote/${remoteTarget}${encodedPath}`;
+    specs.push({ program: 'open', args: [deepLinkUri] });
+  }
+  return specs;
+};
+
+const buildWindowsOpenRemoteProjectSpecs = ({ projectPath, appId, appName, sshInfo }) => {
+  const specs = [];
+  const hostPart = sshInfo.user ? `${sshInfo.user}@${normalizeSshHost(sshInfo.host)}` : normalizeSshHost(sshInfo.host);
+  const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
+  const remoteTarget = `ssh-remote+${hostPort}`;
+  const cli = WINDOWS_CLI_BY_APP_ID[appId];
+  if (cli) {
+    const resolvedCli = runWhere(cli);
+    if (resolvedCli) {
+      specs.push({ program: resolvedCli, args: ['--remote', remoteTarget, '--new-window', projectPath] });
+    }
+  }
+  const exe = findWindowsExecutable(appId);
+  if (exe) {
+    specs.push({ program: exe, args: ['--remote', remoteTarget, '--new-window', projectPath] });
+  }
+  // Intentional: no findWindowsAppNameExecutable fallback here.
+  // The fallback searches by user-friendly app name and would not
+  // include the --remote arg, so it can't open the remote target.
+  return specs;
+};
+const buildWindowsOpenRemoteFileSpecs = ({ filePath, appId, appName, sshInfo }) => {
+  const specs = [];
+  const hostPart = sshInfo.user ? `${sshInfo.user}@${normalizeSshHost(sshInfo.host)}` : normalizeSshHost(sshInfo.host);
+  const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
+  const remoteTarget = `ssh-remote+${hostPort}`;
+  const cli = WINDOWS_CLI_BY_APP_ID[appId];
+  if (cli) {
+    const resolvedCli = runWhere(cli);
+    if (resolvedCli) {
+      specs.push({ program: resolvedCli, args: ['--remote', remoteTarget, '--goto', filePath] });
+    }
+  }
+  const exe = findWindowsExecutable(appId);
+  if (exe) {
+    specs.push({ program: exe, args: ['--remote', remoteTarget, '--goto', filePath] });
+  }
+  // Intentional: no findWindowsAppNameExecutable fallback here
+  // (same rationale as buildWindowsOpenRemoteProjectSpecs).
+  return specs;
+};
+
+const getSshInfoByOrigin = (requestOrigin) => {
+  // readInstances() returns raw JSON; sshParsed may be absent for
+  // instances that have never been connected. We fall back to the
+  // active session's parsed data, and skip entries with no parsed info.
+  const instances = sshManager.readInstances().instances;
+  const hostsConfig = readDesktopHostsConfig();
+  const hosts = hostsConfig.hosts || [];
+
+  for (const instance of instances) {
+    const hostEntry = hosts.find((h) => h.id === instance.id);
+    if (!hostEntry) continue;
+
+    let hostOrigin = '';
+    try { hostOrigin = new URL(hostEntry.url).origin; } catch {}
+
+    if (hostOrigin !== requestOrigin) continue;
+
+    const status = sshManager.statuses.get(instance.id);
+    if (status?.phase !== 'ready') continue;
+
+    const session = sshManager.sessions.get(instance.id);
+    const parsed = instance.sshParsed || session?.parsed;
+    if (!parsed || !parsed.destination) continue;
+
+    let port = 22;
+    let user = '';
+    for (let i = 0; i < parsed.args.length; i++) {
+      const arg = parsed.args[i];
+      if (arg === '-p' && i + 1 < parsed.args.length) {
+        port = parseInt(parsed.args[i + 1], 10) || 22;
+        i++;
+        continue;
+      }
+      if (arg.startsWith('-p') && arg.length > 2) {
+        port = parseInt(arg.slice(2), 10) || 22;
+        continue;
+      }
+      if (arg === '-P' && i + 1 < parsed.args.length) {
+        port = parseInt(parsed.args[i + 1], 10) || 22;
+        i++;
+        continue;
+      }
+      if (arg.startsWith('-P') && arg.length > 2) {
+        port = parseInt(arg.slice(2), 10) || 22;
+        continue;
+      }
+      if (arg === '-l' && i + 1 < parsed.args.length) {
+        user = parsed.args[i + 1];
+        i++;
+        continue;
+      }
+      if (arg.startsWith('-l') && arg.length > 2) {
+        user = arg.slice(2);
+        continue;
+      }
+      if (arg === '-o' && i + 1 < parsed.args.length) {
+        const opt = parsed.args[i + 1];
+        const eqIdx = opt.indexOf('=');
+        if (eqIdx >= 0) {
+          const key = opt.slice(0, eqIdx);
+          const value = opt.slice(eqIdx + 1);
+          if (key === 'Port' || key === 'port') {
+            port = parseInt(value, 10) || 22;
+          } else if (key === 'User' || key === 'user') {
+            user = value;
+          }
+          i++;
+        } else if (i + 2 < parsed.args.length) {
+          const key = opt;
+          const value = parsed.args[i + 2];
+          if (key === 'Port' || key === 'port') {
+            port = parseInt(value, 10) || 22;
+          } else if (key === 'User' || key === 'user') {
+            user = value;
+          }
+          i += 2;
+        }
+        continue;
+      }
+      if (arg.startsWith('-o') && arg.length > 2) {
+        const opt = arg.slice(2);
+        const eqIdx = opt.indexOf('=');
+        if (eqIdx >= 0) {
+          const key = opt.slice(0, eqIdx);
+          const value = opt.slice(eqIdx + 1);
+          if (key === 'Port' || key === 'port') {
+            port = parseInt(value, 10) || 22;
+          } else if (key === 'User' || key === 'user') {
+            user = value;
+          }
+        }
+        continue;
+      }
+    }
+
+    const result = { host: parsed.destination, port, instanceId: instance.id };
+    if (user) result.user = user;
+    return result;
+  }
+
+  return null;
+};
+
 const quoteWindowsCommandArg = (value) => `"${String(value).replace(/"/g, '""')}"`;
 
 const resolveWindowsLaunchProgram = (program) => {
@@ -3131,7 +3323,7 @@ const runSpecChain = (specs, appName) => {
   throw new Error(`Failed to open in ${appName}: ${failures.join('; ')}`);
 };
 
-const handleInvoke = async (browserWindow, command, args = {}) => {
+const handleInvoke = async (browserWindow, command, args = {}, senderOrigin = '') => {
   switch (command) {
     case 'desktop_start_window_drag':
       return null;
@@ -3399,6 +3591,71 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
         throw new Error('desktop_open_file_in_app is only supported on macOS and Windows');
       }
       runSpecChain(buildOpenFileSpecs({ filePath, appId, appName }), appName);
+      return null;
+    }
+
+    case 'desktop_get_active_ssh_info': {
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
+      if (senderOrigin && requestOrigin !== senderOrigin) {
+        throw new Error('Origin mismatch');
+      }
+      const resolvedOrigin = senderOrigin || requestOrigin;
+      if (!resolvedOrigin) return null;
+      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      return sshInfo || null;
+    }
+
+    case 'desktop_open_remote_in_app': {
+      const projectPath = typeof args.projectPath === 'string' ? args.projectPath.trim() : '';
+      const appId = typeof args.appId === 'string' ? args.appId.trim().toLowerCase() : '';
+      const appName = typeof args.appName === 'string' ? args.appName.trim() : '';
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
+      if (senderOrigin && requestOrigin !== senderOrigin) {
+        throw new Error('Origin mismatch');
+      }
+      const resolvedOrigin = senderOrigin || requestOrigin;
+      if (!projectPath || !appId || !appName || !resolvedOrigin) {
+        throw new Error('Project path, app id, app name, and origin are required');
+      }
+      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      if (!sshInfo) {
+        throw new Error('SSH connection info not available');
+      }
+      if (process.platform === 'win32') {
+        runSpecChain(buildWindowsOpenRemoteProjectSpecs({ projectPath, appId, appName, sshInfo }), appName);
+        return null;
+      }
+      if (process.platform !== 'darwin') {
+        throw new Error('desktop_open_remote_in_app is only supported on macOS and Windows');
+      }
+      runSpecChain(buildOpenRemoteProjectSpecs({ projectPath, appId, appName, sshInfo }), appName);
+      return null;
+    }
+
+    case 'desktop_open_remote_file_in_app': {
+      const filePath = typeof args.filePath === 'string' ? args.filePath.trim() : '';
+      const appId = typeof args.appId === 'string' ? args.appId.trim().toLowerCase() : '';
+      const appName = typeof args.appName === 'string' ? args.appName.trim() : '';
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
+      if (senderOrigin && requestOrigin !== senderOrigin) {
+        throw new Error('Origin mismatch');
+      }
+      const resolvedOrigin = senderOrigin || requestOrigin;
+      if (!filePath || !appId || !appName || !resolvedOrigin) {
+        throw new Error('File path, app id, app name, and origin are required');
+      }
+      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      if (!sshInfo) {
+        throw new Error('SSH connection info not available');
+      }
+      if (process.platform === 'win32') {
+        runSpecChain(buildWindowsOpenRemoteFileSpecs({ filePath, appId, appName, sshInfo }), appName);
+        return null;
+      }
+      if (process.platform !== 'darwin') {
+        throw new Error('desktop_open_remote_file_in_app is only supported on macOS and Windows');
+      }
+      runSpecChain(buildOpenRemoteFileSpecs({ filePath, appId, appName, sshInfo }), appName);
       return null;
     }
 
@@ -4115,26 +4372,58 @@ app.on('web-contents-created', (_event, contents) => {
 // shell.openPath, installed-app scans, app relaunch, and file dialogs
 // are gated to local senders — even the user's own remote UI shouldn't
 // need them, and a compromised remote can't use them either.
-const isLocalSender = (webContents) => {
+// SSH-tunnel pages (loopback origin that does NOT match the local origin)
+// are restricted to a separate whitelist: SSH context queries, remote
+// open commands, and app scans. File reads, dialogs, and local path
+// open are NOT granted to SSH tunnels — only to the true local origin.
+const isActualLocalOrigin = (webContents) => {
   try {
     const raw = typeof webContents?.getURL === 'function' ? webContents.getURL() : '';
     if (!raw) return false;
     const url = new URL(raw);
     if (url.protocol === `${UI_PROTOCOL}:` && url.hostname === 'app') return true;
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    const hostname = url.hostname;
+    const isLoopback = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
     if (state.localOrigin) {
       try {
         const allowed = new URL(state.localOrigin);
         if (allowed.origin === url.origin) return true;
-      } catch {
-      }
+      } catch {}
     }
     if (state.sidecarUrl) {
       try {
         const allowed = new URL(state.sidecarUrl);
         if (allowed.origin === url.origin) return true;
-      } catch {
-      }
+      } catch {}
+    }
+    if (state.localOrigin) return false;
+    return isLoopback;
+  } catch {
+    return false;
+  }
+};
+
+const isSshTunnelOrigin = (webContents) => {
+  try {
+    const raw = typeof webContents?.getURL === 'function' ? webContents.getURL() : '';
+    if (!raw) return false;
+    const url = new URL(raw);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    const hostname = url.hostname;
+    if (hostname !== 'localhost' && hostname !== '127.0.0.1' && hostname !== '::1') return false;
+    // A tunnel origin is only meaningful when a local origin is known
+    // and the loopback origin does NOT match it. If localOrigin is not
+    // configured, no origin can be classified as a tunnel.
+    if (!state.localOrigin) return false;
+    try {
+      const allowed = new URL(state.localOrigin);
+      if (allowed.origin === url.origin) return false;
+    } catch {}
+    // Only treat as a tunnel origin if this port maps to a ready SSH instance
+    const port = parseInt(url.port, 10) || (url.protocol === 'https:' ? 443 : 80);
+    for (const status of sshManager.statuses.values()) {
+      if (status.phase === 'ready' && status.localPort === port) return true;
     }
     return false;
   } catch {
@@ -4142,6 +4431,11 @@ const isLocalSender = (webContents) => {
   }
 };
 
+// desktop_open_remote_in_app, desktop_open_remote_file_in_app, and
+// desktop_get_active_ssh_info are in SSH_TUNNEL_COMMANDS so they can
+// be called from SSH-tunneled pages on 127.0.0.1. They are NOT in
+// COMMANDS_SAFE_FOR_REMOTE because non-loopback remote pages must
+// never invoke them.
 const COMMANDS_SAFE_FOR_REMOTE = new Set([
   'desktop_hosts_get',
   'desktop_host_probe',
@@ -4161,18 +4455,48 @@ const COMMANDS_SAFE_FOR_REMOTE = new Set([
   'desktop_tray_update',
 ]);
 
+const SSH_TUNNEL_COMMANDS = new Set([
+  'desktop_get_active_ssh_info',
+  'desktop_open_remote_in_app',
+  'desktop_open_remote_file_in_app',
+  'desktop_filter_installed_apps',
+  'desktop_get_installed_apps',
+  'desktop_fetch_app_icons',
+]);
+
 ipcMain.handle('openchamber:invoke', async (event, command, args) => {
-  if (!isLocalSender(event.sender) && !COMMANDS_SAFE_FOR_REMOTE.has(command)) {
+  const tunnelOrigin = isSshTunnelOrigin(event.sender);
+  const localOrigin = isActualLocalOrigin(event.sender);
+  const isSafeForRemote = COMMANDS_SAFE_FOR_REMOTE.has(command);
+  const isSafeForTunnel = SSH_TUNNEL_COMMANDS.has(command);
+
+  if (!localOrigin && !tunnelOrigin && !isSafeForRemote) {
     log.warn(`[ipc] rejected ${command} from non-local origin: ${event.sender?.getURL?.() || '(unknown)'}`);
     throw new Error('IPC not available for this origin');
   }
+
+  if (tunnelOrigin && !localOrigin && !isSafeForTunnel && !isSafeForRemote) {
+    log.warn(`[ipc] rejected ${command} from SSH tunnel origin: ${event.sender?.getURL?.() || '(unknown)'}`);
+    throw new Error('IPC not available for this origin');
+  }
+
+  let senderOrigin = '';
+  if (isSafeForTunnel) {
+    try {
+      const url = new URL(event.sender.getURL());
+      senderOrigin = url.origin;
+    } catch {}
+  }
+
   const browserWindow = BrowserWindow.fromWebContents(event.sender);
-  return handleInvoke(browserWindow, command, args);
+  return handleInvoke(browserWindow, command, args, senderOrigin);
 });
 
 ipcMain.handle('openchamber:dialog:open', async (event, options) => {
-  // Native file dialogs expose absolute local paths; never grant to remote.
-  if (!isLocalSender(event.sender)) {
+  // Native file dialogs expose absolute local paths; never grant to
+  // remote OR SSH tunnel origins. Only the true local origin may
+  // open file dialogs.
+  if (!isActualLocalOrigin(event.sender)) {
     log.warn(`[ipc] rejected dialog:open from non-local origin: ${event.sender?.getURL?.() || '(unknown)'}`);
     throw new Error('IPC not available for this origin');
   }
@@ -4220,7 +4544,7 @@ ipcMain.handle('openchamber:dialog:open', async (event, options) => {
 });
 
 ipcMain.handle('openchamber:file:grant-existing', async (event, filePath) => {
-  if (!isLocalSender(event.sender)) {
+  if (!isActualLocalOrigin(event.sender)) {
     log.warn(`[ipc] rejected file:grant-existing from non-local origin: ${event.sender?.getURL?.() || '(unknown)'}`);
     throw new Error('IPC not available for this origin');
   }

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -3606,7 +3606,7 @@ const handleInvoke = async (browserWindow, command, args = {}, senderOrigin = ''
     }
 
     case 'desktop_get_active_ssh_info': {
-      const requestOrigin = senderOrigin || (typeof args.origin === 'string' ? args.origin.trim() : '');
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
       if (!requestOrigin) return null;
       const sshInfo = getSshInfoByOrigin(requestOrigin);
       return sshInfo || null;
@@ -3616,7 +3616,7 @@ const handleInvoke = async (browserWindow, command, args = {}, senderOrigin = ''
       const projectPath = typeof args.projectPath === 'string' ? args.projectPath.trim() : '';
       const appId = typeof args.appId === 'string' ? args.appId.trim().toLowerCase() : '';
       const appName = typeof args.appName === 'string' ? args.appName.trim() : '';
-      const requestOrigin = senderOrigin || (typeof args.origin === 'string' ? args.origin.trim() : '');
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
       if (!projectPath || !appId || !appName || !requestOrigin) {
         throw new Error('Project path, app id, app name, and origin are required');
       }
@@ -3639,7 +3639,7 @@ const handleInvoke = async (browserWindow, command, args = {}, senderOrigin = ''
       const filePath = typeof args.filePath === 'string' ? args.filePath.trim() : '';
       const appId = typeof args.appId === 'string' ? args.appId.trim().toLowerCase() : '';
       const appName = typeof args.appName === 'string' ? args.appName.trim() : '';
-      const requestOrigin = senderOrigin || (typeof args.origin === 'string' ? args.origin.trim() : '');
+      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
       if (!filePath || !appId || !appName || !requestOrigin) {
         throw new Error('File path, app id, app name, and origin are required');
       }
@@ -4382,7 +4382,6 @@ const isActualLocalOrigin = (webContents) => {
     const url = new URL(raw);
     if (url.protocol === `${UI_PROTOCOL}:` && url.hostname === 'app') return true;
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
-    const hostname = url.hostname;
     if (state.localOrigin) {
       try {
         const allowed = new URL(state.localOrigin);

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -3069,10 +3069,13 @@ const buildOpenRemoteProjectSpecs = ({ projectPath, appId, appName, sshInfo }) =
     const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
     const remoteTarget = `ssh-remote+${hostPort}`;
     specs.push({ program: cli, args: ['--remote', remoteTarget, '--new-window', projectPath] });
-    const scheme = REMOTE_URI_SCHEME_BY_APP_ID[appId] || 'vscode';
-    const encodedPath = projectPath.split('/').map(encodeURIComponent).join('/');
-    const deepLinkUri = `${scheme}://vscode-remote/${remoteTarget}${encodedPath}`;
-    specs.push({ program: 'open', args: [deepLinkUri] });
+    const scheme = REMOTE_URI_SCHEME_BY_APP_ID[appId];
+    if (scheme) {
+      const prefixedPath = projectPath.startsWith('/') ? projectPath : `/${projectPath}`;
+      const encodedPath = prefixedPath.split('/').map(encodeURIComponent).join('/');
+      const deepLinkUri = `${scheme}://vscode-remote/${remoteTarget}${encodedPath}`;
+      specs.push({ program: 'open', args: [deepLinkUri] });
+    }
   }
   return specs;
 };
@@ -3086,10 +3089,13 @@ const buildOpenRemoteFileSpecs = ({ filePath, appId, appName, sshInfo }) => {
     const hostPort = sshInfo.port && sshInfo.port !== 22 ? `${hostPart}:${sshInfo.port}` : hostPart;
     const remoteTarget = `ssh-remote+${hostPort}`;
     specs.push({ program: cli, args: ['--remote', remoteTarget, '--goto', filePath] });
-    const scheme = REMOTE_URI_SCHEME_BY_APP_ID[appId] || 'vscode';
-    const encodedPath = filePath.split('/').map(encodeURIComponent).join('/');
-    const deepLinkUri = `${scheme}://vscode-remote/${remoteTarget}${encodedPath}`;
-    specs.push({ program: 'open', args: [deepLinkUri] });
+    const scheme = REMOTE_URI_SCHEME_BY_APP_ID[appId];
+    if (scheme) {
+      const prefixedPath = filePath.startsWith('/') ? filePath : `/${filePath}`;
+      const encodedPath = prefixedPath.split('/').map(encodeURIComponent).join('/');
+      const deepLinkUri = `${scheme}://vscode-remote/${remoteTarget}${encodedPath}`;
+      specs.push({ program: 'open', args: [deepLinkUri] });
+    }
   }
   return specs;
 };
@@ -3146,44 +3152,58 @@ const getSshInfoByOrigin = (requestOrigin) => {
 
   for (const instance of instances) {
     const hostEntry = hosts.find((h) => h.id === instance.id);
-    if (!hostEntry) continue;
 
     let hostOrigin = '';
-    try { hostOrigin = new URL(hostEntry.url).origin; } catch {}
-
-    if (hostOrigin !== requestOrigin) continue;
+    if (hostEntry) {
+      try { hostOrigin = new URL(hostEntry.url).origin; } catch {}
+    }
 
     const status = sshManager.statuses.get(instance.id);
     if (status?.phase !== 'ready') continue;
+
+    // Match against the configured host URL origin (primary path).
+    // If port forwarding remapped the port (e.g. 4096 was taken), also
+    // match against the status.localUrl origin (same source as isSshTunnelOrigin).
+    let matched = hostOrigin === requestOrigin;
+    if (!matched && status.localUrl) {
+      try { matched = new URL(status.localUrl).origin === requestOrigin; } catch {}
+    }
+    if (!matched) continue;
 
     const session = sshManager.sessions.get(instance.id);
     const parsed = instance.sshParsed || session?.parsed;
     if (!parsed || !parsed.destination) continue;
 
+    const validPort = (value) => {
+      const n = parseInt(value, 10);
+      return Number.isFinite(n) && n >= 1 && n <= 65535 ? n : null;
+    };
+
     let port = 22;
     let user = '';
-    for (let i = 0; i < parsed.args.length; i++) {
-      const arg = parsed.args[i];
-      if (arg === '-p' && i + 1 < parsed.args.length) {
-        port = parseInt(parsed.args[i + 1], 10) || 22;
+    const args = Array.isArray(parsed.args) ? parsed.args : [];
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (arg === '-p' && i + 1 < args.length) {
+        port = validPort(args[i + 1]) ?? 22;
         i++;
         continue;
       }
       if (arg.startsWith('-p') && arg.length > 2) {
-        port = parseInt(arg.slice(2), 10) || 22;
+        port = validPort(arg.slice(2)) ?? 22;
         continue;
       }
-      if (arg === '-P' && i + 1 < parsed.args.length) {
-        port = parseInt(parsed.args[i + 1], 10) || 22;
+      if (arg === '-P' && i + 1 < args.length) {
+        port = validPort(args[i + 1]) ?? 22;
         i++;
         continue;
       }
       if (arg.startsWith('-P') && arg.length > 2) {
-        port = parseInt(arg.slice(2), 10) || 22;
+        port = validPort(arg.slice(2)) ?? 22;
         continue;
       }
-      if (arg === '-l' && i + 1 < parsed.args.length) {
-        user = parsed.args[i + 1];
+      if (arg === '-l' && i + 1 < args.length) {
+        user = args[i + 1];
         i++;
         continue;
       }
@@ -3191,27 +3211,18 @@ const getSshInfoByOrigin = (requestOrigin) => {
         user = arg.slice(2);
         continue;
       }
-      if (arg === '-o' && i + 1 < parsed.args.length) {
-        const opt = parsed.args[i + 1];
+      if (arg === '-o' && i + 1 < args.length) {
+        const opt = args[i + 1];
         const eqIdx = opt.indexOf('=');
         if (eqIdx >= 0) {
           const key = opt.slice(0, eqIdx);
           const value = opt.slice(eqIdx + 1);
           if (key === 'Port' || key === 'port') {
-            port = parseInt(value, 10) || 22;
+            port = validPort(value) ?? 22;
           } else if (key === 'User' || key === 'user') {
             user = value;
           }
           i++;
-        } else if (i + 2 < parsed.args.length) {
-          const key = opt;
-          const value = parsed.args[i + 2];
-          if (key === 'Port' || key === 'port') {
-            port = parseInt(value, 10) || 22;
-          } else if (key === 'User' || key === 'user') {
-            user = value;
-          }
-          i += 2;
         }
         continue;
       }
@@ -3222,7 +3233,7 @@ const getSshInfoByOrigin = (requestOrigin) => {
           const key = opt.slice(0, eqIdx);
           const value = opt.slice(eqIdx + 1);
           if (key === 'Port' || key === 'port') {
-            port = parseInt(value, 10) || 22;
+            port = validPort(value) ?? 22;
           } else if (key === 'User' || key === 'user') {
             user = value;
           }
@@ -3595,13 +3606,9 @@ const handleInvoke = async (browserWindow, command, args = {}, senderOrigin = ''
     }
 
     case 'desktop_get_active_ssh_info': {
-      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
-      if (senderOrigin && requestOrigin !== senderOrigin) {
-        throw new Error('Origin mismatch');
-      }
-      const resolvedOrigin = senderOrigin || requestOrigin;
-      if (!resolvedOrigin) return null;
-      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      const requestOrigin = senderOrigin || (typeof args.origin === 'string' ? args.origin.trim() : '');
+      if (!requestOrigin) return null;
+      const sshInfo = getSshInfoByOrigin(requestOrigin);
       return sshInfo || null;
     }
 
@@ -3609,15 +3616,11 @@ const handleInvoke = async (browserWindow, command, args = {}, senderOrigin = ''
       const projectPath = typeof args.projectPath === 'string' ? args.projectPath.trim() : '';
       const appId = typeof args.appId === 'string' ? args.appId.trim().toLowerCase() : '';
       const appName = typeof args.appName === 'string' ? args.appName.trim() : '';
-      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
-      if (senderOrigin && requestOrigin !== senderOrigin) {
-        throw new Error('Origin mismatch');
-      }
-      const resolvedOrigin = senderOrigin || requestOrigin;
-      if (!projectPath || !appId || !appName || !resolvedOrigin) {
+      const requestOrigin = senderOrigin || (typeof args.origin === 'string' ? args.origin.trim() : '');
+      if (!projectPath || !appId || !appName || !requestOrigin) {
         throw new Error('Project path, app id, app name, and origin are required');
       }
-      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      const sshInfo = getSshInfoByOrigin(requestOrigin);
       if (!sshInfo) {
         throw new Error('SSH connection info not available');
       }
@@ -3636,15 +3639,11 @@ const handleInvoke = async (browserWindow, command, args = {}, senderOrigin = ''
       const filePath = typeof args.filePath === 'string' ? args.filePath.trim() : '';
       const appId = typeof args.appId === 'string' ? args.appId.trim().toLowerCase() : '';
       const appName = typeof args.appName === 'string' ? args.appName.trim() : '';
-      const requestOrigin = typeof args.origin === 'string' ? args.origin.trim() : '';
-      if (senderOrigin && requestOrigin !== senderOrigin) {
-        throw new Error('Origin mismatch');
-      }
-      const resolvedOrigin = senderOrigin || requestOrigin;
-      if (!filePath || !appId || !appName || !resolvedOrigin) {
+      const requestOrigin = senderOrigin || (typeof args.origin === 'string' ? args.origin.trim() : '');
+      if (!filePath || !appId || !appName || !requestOrigin) {
         throw new Error('File path, app id, app name, and origin are required');
       }
-      const sshInfo = getSshInfoByOrigin(resolvedOrigin);
+      const sshInfo = getSshInfoByOrigin(requestOrigin);
       if (!sshInfo) {
         throw new Error('SSH connection info not available');
       }
@@ -4384,7 +4383,6 @@ const isActualLocalOrigin = (webContents) => {
     if (url.protocol === `${UI_PROTOCOL}:` && url.hostname === 'app') return true;
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
     const hostname = url.hostname;
-    const isLoopback = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
     if (state.localOrigin) {
       try {
         const allowed = new URL(state.localOrigin);
@@ -4397,8 +4395,7 @@ const isActualLocalOrigin = (webContents) => {
         if (allowed.origin === url.origin) return true;
       } catch {}
     }
-    if (state.localOrigin) return false;
-    return isLoopback;
+    return false;
   } catch {
     return false;
   }
@@ -4420,10 +4417,15 @@ const isSshTunnelOrigin = (webContents) => {
       const allowed = new URL(state.localOrigin);
       if (allowed.origin === url.origin) return false;
     } catch {}
-    // Only treat as a tunnel origin if this port maps to a ready SSH instance
-    const port = parseInt(url.port, 10) || (url.protocol === 'https:' ? 443 : 80);
+    // Match on the full localUrl origin, not just the port, so that a
+    // non-SSH process on a colliding loopback port cannot be classified
+    // as a tunnel origin.
     for (const status of sshManager.statuses.values()) {
-      if (status.phase === 'ready' && status.localPort === port) return true;
+      if (status.phase !== 'ready' || !status.localUrl) continue;
+      try {
+        const tunnelOrigin = new URL(status.localUrl).origin;
+        if (tunnelOrigin === url.origin) return true;
+      } catch {}
     }
     return false;
   } catch {

--- a/packages/electron/ssh-manager.mjs
+++ b/packages/electron/ssh-manager.mjs
@@ -1049,7 +1049,7 @@ export class ElectronSshManager {
     return { remotePort, startedByUs };
   }
 
-  async disconnectInternal(id, reportIdle) {
+  async disconnectInternal(id) {
     const timer = this.monitorTimers.get(id);
     if (timer) {
       clearTimeout(timer);
@@ -1058,15 +1058,20 @@ export class ElectronSshManager {
 
     const session = this.sessions.get(id);
     this.sessions.delete(id);
+    this.statuses.delete(id);
 
     if (session) {
-      if (session.startedByUs && session.instance.remoteOpenchamber.mode === 'managed' && !session.instance.remoteOpenchamber.keepRunning) {
-        await this.stopRemoteServerBestEffort(session.parsed, session.controlPath, session.remotePort);
+      if (session.startedByUs && session.instance.remoteOpenchamber?.mode === 'managed' && !session.instance.remoteOpenchamber.keepRunning) {
+        try {
+          await this.stopRemoteServerBestEffort(session.parsed, session.controlPath, session.remotePort);
+        } catch {
+          // best-effort cleanup
+        }
       }
       await stopControlMasterBestEffort(session.parsed, session.controlPath);
       for (const child of [session.mainForward, session.master]) {
         try {
-          child.kill('SIGTERM');
+          process.platform === 'win32' ? child.kill() : child.kill('SIGTERM');
         } catch {
         }
       }
@@ -1081,9 +1086,6 @@ export class ElectronSshManager {
     }
 
     this.clearRetryAttempt(id);
-    if (reportIdle) {
-      this.setStatus(id, 'idle', null, null, null, null, false, 0, false);
-    }
   }
 
   async connectBlocking(instance) {
@@ -1239,7 +1241,7 @@ export class ElectronSshManager {
       }
 
       this.appendLogWithLevel(id, 'WARN', droppedReason);
-      await this.disconnectInternal(id, false);
+      await this.disconnectInternal(id);
       const attempt = this.nextRetryAttempt(id);
       if (attempt > DEFAULT_RECONNECT_MAX_ATTEMPTS) {
         this.setStatus(id, 'error', `${droppedReason}. Retry limit reached`, null, null, null, false, attempt, true);
@@ -1278,17 +1280,20 @@ export class ElectronSshManager {
     const connectAttempt = this.nextConnectAttempt(trimmed);
     this.appendAttemptSeparator(trimmed, connectAttempt, retryAttempt);
     this.appendLog(trimmed, 'Starting SSH connection');
-    await this.disconnectInternal(trimmed, false);
 
-    const task = this.connectBlocking(this.sanitizeInstance(instance))
-      .catch(async (error) => {
-        this.setStatus(trimmed, 'error', error instanceof Error ? error.message : String(error), null, null, null, false, 0, true);
-        await this.disconnectInternal(trimmed, false);
-        throw error;
-      })
-      .finally(() => {
-        this.connecting.delete(trimmed);
-      });
+    const task = (async () => {
+      await this.disconnectInternal(trimmed);
+      return this.connectBlocking(this.sanitizeInstance(instance))
+        .catch(async (error) => {
+          this.setStatus(trimmed, 'error', error instanceof Error ? error.message : String(error), null, null, null, false, 0, true);
+          await this.disconnectInternal(trimmed);
+          throw error;
+        })
+        .finally(() => {
+          this.connecting.delete(trimmed);
+        });
+    })();
+
     this.connecting.set(trimmed, task);
     return task;
   }
@@ -1298,7 +1303,7 @@ export class ElectronSshManager {
     if (!trimmed || trimmed === LOCAL_HOST_ID) {
       throw new Error('SSH instance id is required');
     }
-    await this.disconnectInternal(trimmed, true);
+    await this.disconnectInternal(trimmed);
   }
 
   async statusesWithDefaults(id) {
@@ -1313,7 +1318,7 @@ export class ElectronSshManager {
   async shutdownAll() {
     const ids = [...new Set([...this.sessions.keys(), ...this.connecting.keys(), ...this.monitorTimers.keys()])];
     for (const id of ids) {
-      await this.disconnectInternal(id, false);
+      await this.disconnectInternal(id);
     }
   }
 }

--- a/packages/ui/src/components/desktop/OpenInAppButton.tsx
+++ b/packages/ui/src/components/desktop/OpenInAppButton.tsx
@@ -10,7 +10,7 @@ import { toast } from '@/components/ui';
 import { Icon } from "@/components/icon/Icon";
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { cn } from '@/lib/utils';
-import { isDesktopLocalOriginActive, isDesktopShell, openDesktopPath, openDesktopProjectInApp } from '@/lib/desktop';
+import { isElectronShell, isDesktopLocalOriginActive, subscribeRemoteSshActive, getRemoteSshSnapshot, openDesktopPath, openDesktopProjectInApp, openDesktopRemoteProjectInApp } from '@/lib/desktop';
 import { DEFAULT_OPEN_IN_APP_ID, OPEN_IN_APPS } from '@/lib/openInApps';
 import { useOpenInAppsStore, type OpenInAppOption } from '@/stores/useOpenInAppsStore';
 import { useI18n } from '@/lib/i18n';
@@ -87,31 +87,49 @@ export const OpenInAppButton = ({ directory, className }: OpenInAppButtonProps) 
     initialize();
   }, [initialize]);
 
-  const isDesktopLocal = isDesktopShell() && isDesktopLocalOriginActive();
+  const isRemote = React.useSyncExternalStore(subscribeRemoteSshActive, getRemoteSshSnapshot);
+
+  const isAvailable = isElectronShell() && (isDesktopLocalOriginActive() || isRemote);
+
+  const displayableApps = React.useMemo(() => {
+    if (!isRemote || isDesktopLocalOriginActive()) return availableApps;
+    return availableApps.filter((app) => {
+      const meta = OPEN_IN_APPS.find((a) => a.id === app.id);
+      return meta?.supportsRemote === true;
+    });
+  }, [availableApps, isRemote]);
 
   const selectedApp = React.useMemo(() => {
-    const known = availableApps.find((app) => app.id === selectedAppId)
-      ?? availableApps.find((app) => app.id === DEFAULT_OPEN_IN_APP_ID)
-      ?? availableApps[0]
+    const known = displayableApps.find((app) => app.id === selectedAppId)
+      ?? displayableApps.find((app) => app.id === DEFAULT_OPEN_IN_APP_ID)
+      ?? displayableApps[0]
       ?? OPEN_IN_APPS[0];
     if (known) {
       return withFallbackIcon(known);
     }
     return withFallbackIcon(OPEN_IN_APPS[0]);
-  }, [availableApps, selectedAppId]);
+  }, [displayableApps, selectedAppId]);
 
-  if (!isDesktopLocal || !directory) {
+  if (!isAvailable || !directory) {
     return null;
   }
 
-  if (availableApps.length === 0) {
+  if (displayableApps.length === 0) {
     return null;
   }
 
   const handleOpen = async (app: OpenInAppOption) => {
-    const opened = await openDesktopProjectInApp(directory, app.id, app.appName);
-    if (!opened) {
-      await openDesktopPath(directory, app.appName);
+    if (getRemoteSshSnapshot()) {
+      const opened = await openDesktopRemoteProjectInApp(directory, app.id, app.appName);
+      if (!opened) {
+        await copyTextToClipboard(directory);
+        toast.warning(t('openInApp.toast.remoteOpenFailed'));
+      }
+    } else {
+      const opened = await openDesktopProjectInApp(directory, app.id, app.appName);
+      if (!opened) {
+        await openDesktopPath(directory, app.appName);
+      }
     }
   };
 
@@ -177,7 +195,7 @@ export const OpenInAppButton = ({ directory, className }: OpenInAppButtonProps) 
             <span className="typography-ui-label text-foreground">{t('openInApp.actions.copyPath')}</span>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          {availableApps.map((app) => {
+          {displayableApps.map((app) => {
             const appWithFallback = withFallbackIcon(app);
             return (
               <DropdownMenuItem

--- a/packages/ui/src/components/desktop/OpenInAppButton.tsx
+++ b/packages/ui/src/components/desktop/OpenInAppButton.tsx
@@ -44,6 +44,9 @@ const AppIcon = ({
   const initial = label.trim().slice(0, 1).toUpperCase() || '?';
 
   const src = iconDataUrl || fallbackIconDataUrl;
+  React.useEffect(() => {
+    setFailed(false);
+  }, [src]);
 
   if (src && !failed) {
     return (
@@ -92,7 +95,7 @@ export const OpenInAppButton = ({ directory, className }: OpenInAppButtonProps) 
   const isAvailable = isElectronShell() && (isDesktopLocalOriginActive() || isRemote);
 
   const displayableApps = React.useMemo(() => {
-    if (!isRemote || isDesktopLocalOriginActive()) return availableApps;
+    if (!isRemote) return availableApps;
     return availableApps.filter((app) => {
       const meta = OPEN_IN_APPS.find((a) => a.id === app.id);
       return meta?.supportsRemote === true;

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -69,8 +69,9 @@ import { Icon } from "@/components/icon/Icon";
 import { useMessageTTS } from '@/hooks/useMessageTTS';
 import { ensurePierreThemeRegistered } from '@/lib/shiki/appThemeRegistry';
 import { getDefaultTheme } from '@/lib/theme/themes';
-import { openDesktopFileInApp, openDesktopPath } from '@/lib/desktop';
+import { isElectronShell, isDesktopLocalOriginActive, openDesktopFileInApp, openDesktopPath, subscribeRemoteSshActive, getRemoteSshSnapshot, openDesktopRemoteFileInApp } from '@/lib/desktop';
 import { useOpenInAppsStore } from '@/stores/useOpenInAppsStore';
+import { OPEN_IN_APPS } from '@/lib/openInApps';
 import { eventMatchesShortcut, getEffectiveShortcutCombo } from '@/lib/shortcuts';
 import { useI18n } from '@/lib/i18n';
 
@@ -968,6 +969,18 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const initializeOpenInApps = useOpenInAppsStore((state) => state.initialize);
   const loadOpenInApps = useOpenInAppsStore((state) => state.loadInstalledApps);
 
+  const isRemote = React.useSyncExternalStore(subscribeRemoteSshActive, getRemoteSshSnapshot);
+
+  const isAvailable = isElectronShell() && (isDesktopLocalOriginActive() || isRemote);
+
+  const displayableOpenInApps = React.useMemo(() => {
+    if (!isRemote || isDesktopLocalOriginActive()) return openInApps;
+    return openInApps.filter((app) => {
+      const meta = OPEN_IN_APPS.find((a) => a.id === app.id);
+      return meta?.supportsRemote === true;
+    });
+  }, [openInApps, isRemote]);
+
   React.useEffect(() => {
     initializeOpenInApps();
   }, [initializeOpenInApps]);
@@ -981,6 +994,16 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
   const handleOpenInApp = React.useCallback(async (app: { id: string; appName: string }) => {
     if (!selectedFile?.path) {
+      return;
+    }
+
+    if (getRemoteSshSnapshot()) {
+      const openedRemotely = await openDesktopRemoteFileInApp(selectedFile.path, app.id, app.appName);
+      if (openedRemotely) {
+        return;
+      }
+      await copyTextToClipboard(selectedFile.path);
+      toast.warning(t('openInApp.toast.remoteOpenFailed'));
       return;
     }
 
@@ -3192,6 +3215,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           </>
         )}
 
+        {isAvailable && (displayableOpenInApps.length > 0 || openInCacheStale) && (
         <DropdownMenu onOpenChange={handleToolbarDropdownOpenChange}>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -3212,7 +3236,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             <TooltipContent side="bottom" sideOffset={6}>{t('filesView.editor.openInDesktopApp')}</TooltipContent>
           </Tooltip>
           <DropdownMenuContent align="end" className="w-56 max-h-[70vh] overflow-y-auto">
-            {openInApps.map((app) => (
+            {displayableOpenInApps.map((app) => (
               <DropdownMenuItem
                 key={app.id}
                 className="flex items-center gap-2"
@@ -3233,6 +3257,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
+        )}
 
         {!isSelectedImage && !isSelectedPdf && (
           <>

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -120,6 +120,10 @@ const OpenInAppListIcon = ({ label, iconDataUrl }: { label: string; iconDataUrl?
   const [failed, setFailed] = React.useState(false);
   const initial = label.trim().slice(0, 1).toUpperCase() || '?';
 
+  React.useEffect(() => {
+    setFailed(false);
+  }, [iconDataUrl]);
+
   if (iconDataUrl && !failed) {
     return (
       <img
@@ -974,7 +978,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const isAvailable = isElectronShell() && (isDesktopLocalOriginActive() || isRemote);
 
   const displayableOpenInApps = React.useMemo(() => {
-    if (!isRemote || isDesktopLocalOriginActive()) return openInApps;
+    if (!isRemote) return openInApps;
     return openInApps.filter((app) => {
       const meta = OPEN_IN_APPS.find((a) => a.id === app.id);
       return meta?.supportsRemote === true;

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -363,6 +363,142 @@ export const isDesktopLocalOriginActive = (): boolean => {
   return Boolean(currentUrl && isLoopbackHost(currentUrl.hostname));
 };
 
+export const isDesktopLoopbackOrigin = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  if (!isElectronShell()) return false;
+  if (getRuntimeKey() === 'local') return true;
+  if (window.location.protocol === 'openchamber-ui:') return true;
+  const currentUrl = parseUrl(window.location.origin);
+  return Boolean(currentUrl && isLoopbackHost(currentUrl.hostname));
+};
+
+let _remoteSshCache: { value: boolean; checkedAt: number } | null = null;
+let _remoteSshPending = false;
+let _remoteSshContextPromise: Promise<SshContext | null> | null = null;
+const REMOTE_SSH_CACHE_TTL_MS = 10_000;
+
+const _remoteSshSubscribers = new Set<() => void>();
+
+const notifyRemoteSshSubscribers = () => {
+  _remoteSshSubscribers.forEach((fn) => {
+    try { fn(); } catch {
+      // subscriber error is swallowed
+    }
+  });
+};
+
+export const subscribeRemoteSshActive = (callback: () => void): (() => void) => {
+  _remoteSshSubscribers.add(callback);
+  return () => { _remoteSshSubscribers.delete(callback); };
+};
+
+export const getRemoteSshSnapshot = (): boolean => {
+  return _remoteSshCache?.value ?? false;
+};
+
+export const invalidateRemoteSshCache = (): void => {
+  _remoteSshCache = { value: false, checkedAt: Date.now() };
+  _remoteSshPending = false;
+  _remoteSshContextPromise = null;
+  notifyRemoteSshSubscribers();
+};
+
+export const isRemoteSshActive = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  if (!isDesktopShell()) return false;
+
+  const currentUrl = parseUrl(window.location.origin);
+  if (!currentUrl) return false;
+
+  const isCustomProtocol = currentUrl.protocol === 'openchamber-ui:';
+
+  // Only short-circuit for origins that cannot be an SSH tunnel:
+  // non-loopback and non-custom-protocol URLs.
+  if (!isCustomProtocol && !isLoopbackHost(currentUrl.hostname)) {
+    _remoteSshCache = { value: false, checkedAt: Date.now() };
+    return false;
+  }
+
+  // Known local origin: skip the optimistic heuristic to avoid a UI
+  // flash where the app list briefly shows only remote-capable apps.
+  if (isDesktopLocalOriginActive()) {
+    _remoteSshCache = { value: false, checkedAt: Date.now() };
+    return false;
+  }
+
+  // Return cached result within TTL
+  if (_remoteSshCache && (Date.now() - _remoteSshCache.checkedAt) < REMOTE_SSH_CACHE_TTL_MS) {
+    return _remoteSshCache.value;
+  }
+
+  // Initial heuristic: a loopback or custom-protocol origin is likely an SSH
+  // tunnel. Eagerly verify against the main process; subscribers are
+  // notified on completion so React can re-render with the verified
+  // result.
+  _remoteSshCache = { value: true, checkedAt: Date.now() };
+
+  if (_remoteSshPending) {
+    return true;
+  }
+  _remoteSshPending = true;
+
+  _remoteSshContextPromise = getActiveSshContext();
+  const contextPromise = _remoteSshContextPromise;
+  const timeoutPromise = new Promise<SshContext | null>((resolve) => {
+    setTimeout(() => resolve(null), 5000);
+  });
+
+  Promise.race([contextPromise, timeoutPromise]).then((ctx) => {
+    _remoteSshCache = { value: ctx !== null, checkedAt: Date.now() };
+    _remoteSshPending = false;
+    _remoteSshContextPromise = null;
+    notifyRemoteSshSubscribers();
+  }).catch(() => {
+    _remoteSshCache = { value: false, checkedAt: Date.now() };
+    _remoteSshPending = false;
+    _remoteSshContextPromise = null;
+    notifyRemoteSshSubscribers();
+  });
+
+  return true;
+};
+
+export const isOpenInAppAvailable = (): boolean => {
+  if (!isElectronShell()) return false;
+  return isDesktopLocalOriginActive() || isRemoteSshActive();
+};
+
+export type SshContext = {
+  host: string;
+  port: number;
+  instanceId: string;
+};
+
+export const getActiveSshContext = async (): Promise<SshContext | null> => {
+  if (!isElectronShell()) return null;
+
+  if (_remoteSshContextPromise) return _remoteSshContextPromise;
+
+  try {
+    const result = await invokeDesktop('desktop_get_active_ssh_info', {
+      origin: window.location.origin,
+    });
+    if (result && typeof result === 'object') {
+      const ctx = result as { host?: string; port?: number; instanceId?: string };
+      if (typeof ctx.host === 'string' && ctx.host.length > 0) {
+        return {
+          host: ctx.host,
+          port: typeof ctx.port === 'number' ? ctx.port : 22,
+          instanceId: typeof ctx.instanceId === 'string' ? ctx.instanceId : '',
+        };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
 export const isDesktopShell = (): boolean => {
   if (typeof window === 'undefined') return false;
   return isElectronShell();
@@ -761,6 +897,127 @@ export const openDesktopFileInApp = async (
   }
 };
 
+export const openDesktopRemoteProjectInApp = async (
+  projectPath: string,
+  appId: string,
+  appName: string,
+): Promise<boolean> => {
+  if (!isElectronShell() || !isRemoteSshActive()) {
+    return false;
+  }
+
+  const trimmedProjectPath = projectPath?.trim();
+  const trimmedAppId = appId?.trim();
+  const trimmedAppName = appName?.trim();
+
+  if (!trimmedProjectPath || !trimmedAppId || !trimmedAppName) {
+    return false;
+  }
+
+  try {
+    await invokeDesktop('desktop_open_remote_in_app', {
+      projectPath: trimmedProjectPath,
+      appId: trimmedAppId,
+      appName: trimmedAppName,
+      origin: window.location.origin,
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to open remote project in app', error);
+    invalidateRemoteSshCache();
+    return false;
+  }
+};
+
+export const openDesktopRemoteFileInApp = async (
+  filePath: string,
+  appId: string,
+  appName: string,
+): Promise<boolean> => {
+  if (!isElectronShell() || !isRemoteSshActive()) {
+    return false;
+  }
+
+  const trimmedFilePath = filePath?.trim();
+  const trimmedAppId = appId?.trim();
+  const trimmedAppName = appName?.trim();
+
+  if (!trimmedFilePath || !trimmedAppId || !trimmedAppName) {
+    return false;
+  }
+
+  try {
+    await invokeDesktop('desktop_open_remote_file_in_app', {
+      filePath: trimmedFilePath,
+      appId: trimmedAppId,
+      appName: trimmedAppName,
+      origin: window.location.origin,
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to open remote file in app', error);
+    invalidateRemoteSshCache();
+    return false;
+  }
+};
+
+export const filterInstalledDesktopApps = async (apps: string[]): Promise<string[]> => {
+  if (!isDesktopLoopbackOrigin()) {
+    return [];
+  }
+
+  const candidate = Array.isArray(apps) ? apps.filter((value) => typeof value === 'string') : [];
+  if (candidate.length === 0) {
+    return [];
+  }
+
+  try {
+    const result = await invokeDesktop<string[]>('desktop_filter_installed_apps', {
+      apps: candidate,
+    });
+    return Array.isArray(result) ? result.filter((value) => typeof value === 'string') : [];
+  } catch (error) {
+    console.warn('Failed to check installed apps', error);
+    return [];
+  }
+};
+
+export const fetchDesktopAppIcons = async (apps: string[]): Promise<Record<string, string>> => {
+  if (!isDesktopLoopbackOrigin()) {
+    return {};
+  }
+
+  const candidate = Array.isArray(apps) ? apps.filter((value) => typeof value === 'string') : [];
+  if (candidate.length === 0) {
+    return {};
+  }
+
+  try {
+    const result = await invokeDesktop<unknown[]>('desktop_fetch_app_icons', {
+      apps: candidate,
+    });
+    if (!Array.isArray(result)) {
+      return {};
+    }
+    const map: Record<string, string> = {};
+    for (const entry of result) {
+      if (!entry || typeof entry !== 'object') continue;
+      const candidateEntry = entry as { app?: unknown; dataUrl?: unknown; data_url?: unknown };
+      const dataUrl = typeof candidateEntry.dataUrl === 'string'
+        ? candidateEntry.dataUrl
+        : typeof candidateEntry.data_url === 'string'
+          ? candidateEntry.data_url
+          : undefined;
+      if (typeof candidateEntry.app !== 'string' || typeof dataUrl !== 'string') continue;
+      map[candidateEntry.app] = dataUrl;
+    }
+    return map;
+  } catch (error) {
+    console.warn('Failed to fetch installed app icons', error);
+    return {};
+  }
+};
+
 export type InstalledDesktopAppInfo = {
   name: string;
   iconDataUrl?: string | null;
@@ -777,7 +1034,7 @@ export const fetchDesktopInstalledApps = async (
   apps: string[],
   force?: boolean
 ): Promise<FetchDesktopInstalledAppsResult> => {
-  if (!hasDesktopInvoke() || !isDesktopLocalOriginActive()) {
+  if (!isDesktopLoopbackOrigin()) {
     return { apps: [], success: false, hasCache: false, isCacheStale: false };
   }
 

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -360,7 +360,7 @@ export const isDesktopLocalOriginActive = (): boolean => {
     return true;
   }
 
-  return Boolean(currentUrl && isLoopbackHost(currentUrl.hostname));
+  return false;
 };
 
 export const isDesktopLoopbackOrigin = (): boolean => {
@@ -375,6 +375,7 @@ export const isDesktopLoopbackOrigin = (): boolean => {
 let _remoteSshCache: { value: boolean; checkedAt: number } | null = null;
 let _remoteSshPending = false;
 let _remoteSshContextPromise: Promise<SshContext | null> | null = null;
+let _remoteSshGeneration = 0;
 const REMOTE_SSH_CACHE_TTL_MS = 10_000;
 
 const _remoteSshSubscribers = new Set<() => void>();
@@ -393,14 +394,21 @@ export const subscribeRemoteSshActive = (callback: () => void): (() => void) => 
 };
 
 export const getRemoteSshSnapshot = (): boolean => {
-  return _remoteSshCache?.value ?? false;
+  if (!_remoteSshCache) return false;
+  if ((Date.now() - _remoteSshCache.checkedAt) < REMOTE_SSH_CACHE_TTL_MS) {
+    return _remoteSshCache.value;
+  }
+  void isRemoteSshActive();
+  return _remoteSshCache.value;
 };
 
 export const invalidateRemoteSshCache = (): void => {
-  _remoteSshCache = { value: false, checkedAt: Date.now() };
+  _remoteSshGeneration += 1;
+  _remoteSshCache = null;
   _remoteSshPending = false;
   _remoteSshContextPromise = null;
   notifyRemoteSshSubscribers();
+  void isRemoteSshActive();
 };
 
 export const isRemoteSshActive = (): boolean => {
@@ -444,16 +452,25 @@ export const isRemoteSshActive = (): boolean => {
 
   _remoteSshContextPromise = getActiveSshContext();
   const contextPromise = _remoteSshContextPromise;
+  const generationAtStart = _remoteSshGeneration;
   const timeoutPromise = new Promise<SshContext | null>((resolve) => {
     setTimeout(() => resolve(null), 5000);
   });
 
   Promise.race([contextPromise, timeoutPromise]).then((ctx) => {
+    if (_remoteSshGeneration !== generationAtStart) {
+      _remoteSshPending = false;
+      return;
+    }
     _remoteSshCache = { value: ctx !== null, checkedAt: Date.now() };
     _remoteSshPending = false;
     _remoteSshContextPromise = null;
     notifyRemoteSshSubscribers();
   }).catch(() => {
+    if (_remoteSshGeneration !== generationAtStart) {
+      _remoteSshPending = false;
+      return;
+    }
     _remoteSshCache = { value: false, checkedAt: Date.now() };
     _remoteSshPending = false;
     _remoteSshContextPromise = null;
@@ -474,29 +491,37 @@ export type SshContext = {
   instanceId: string;
 };
 
+let _activeSshContextPromise: Promise<SshContext | null> | null = null;
+
 export const getActiveSshContext = async (): Promise<SshContext | null> => {
   if (!isElectronShell()) return null;
 
-  if (_remoteSshContextPromise) return _remoteSshContextPromise;
+  if (_activeSshContextPromise) return _activeSshContextPromise;
 
-  try {
-    const result = await invokeDesktop('desktop_get_active_ssh_info', {
-      origin: window.location.origin,
-    });
-    if (result && typeof result === 'object') {
-      const ctx = result as { host?: string; port?: number; instanceId?: string };
-      if (typeof ctx.host === 'string' && ctx.host.length > 0) {
-        return {
-          host: ctx.host,
-          port: typeof ctx.port === 'number' ? ctx.port : 22,
-          instanceId: typeof ctx.instanceId === 'string' ? ctx.instanceId : '',
-        };
+  _activeSshContextPromise = (async () => {
+    try {
+      const result = await invokeDesktop('desktop_get_active_ssh_info', {
+        origin: getRuntimeApiBaseUrl() || window.location.origin,
+      });
+      if (result && typeof result === 'object') {
+        const ctx = result as { host?: string; port?: number; instanceId?: string };
+        if (typeof ctx.host === 'string' && ctx.host.length > 0) {
+          return {
+            host: ctx.host,
+            port: typeof ctx.port === 'number' ? ctx.port : 22,
+            instanceId: typeof ctx.instanceId === 'string' ? ctx.instanceId : '',
+          };
+        }
       }
+      return null;
+    } catch {
+      return null;
+    } finally {
+      _activeSshContextPromise = null;
     }
-    return null;
-  } catch {
-    return null;
-  }
+  })();
+
+  return _activeSshContextPromise;
 };
 
 export const isDesktopShell = (): boolean => {
@@ -919,7 +944,7 @@ export const openDesktopRemoteProjectInApp = async (
       projectPath: trimmedProjectPath,
       appId: trimmedAppId,
       appName: trimmedAppName,
-      origin: window.location.origin,
+      origin: getRuntimeApiBaseUrl() || window.location.origin,
     });
     return true;
   } catch (error) {
@@ -951,7 +976,7 @@ export const openDesktopRemoteFileInApp = async (
       filePath: trimmedFilePath,
       appId: trimmedAppId,
       appName: trimmedAppName,
-      origin: window.location.origin,
+      origin: getRuntimeApiBaseUrl() || window.location.origin,
     });
     return true;
   } catch (error) {

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2208,6 +2208,7 @@ export const dict = {
   'openInApp.actions.copyPath': 'Copy Path',
   'openInApp.actions.refreshApps': 'Refresh Apps',
   'openInApp.toast.pathCopied': 'Path copied to clipboard',
+  'openInApp.toast.remoteOpenFailed': 'Failed to open remote path in app',
   'projectActions.actions.addActionAria': 'Add action',
   'projectActions.actions.addAction': 'Add action',
   'projectActions.actions.addNewAction': 'Add new action',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2174,6 +2174,7 @@ export const dict: Record<I18nKey, string> = {
   "openInApp.actions.copyPath": "Copiar ruta",
   "openInApp.actions.refreshApps": "Actualizar aplicaciones",
   "openInApp.toast.pathCopied": "Ruta copiada al portapapeles",
+  "openInApp.toast.remoteOpenFailed": "No se pudo abrir la ruta remota en la aplicación",
   "projectActions.actions.addActionAria": "Añadir acción",
   "projectActions.actions.addAction": "Añadir acción",
   "projectActions.actions.addNewAction": "Añadir nueva acción",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -2030,6 +2030,7 @@ export const dict = {
   'openInApp.actions.copyPath': 'Copier le chemin',
   'openInApp.actions.refreshApps': 'Actualiser les applications',
   'openInApp.toast.pathCopied': 'Chemin copié dans le presse-papiers',
+  'openInApp.toast.remoteOpenFailed': "Impossible d'ouvrir le chemin distant dans l'application",
   'projectActions.actions.addActionAria': 'Ajouter une action',
   'projectActions.actions.addAction': 'Ajouter une action',
   'projectActions.actions.addNewAction': 'Ajouter une nouvelle action',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2207,6 +2207,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.copyPath': 'パスをコピー',
   'openInApp.actions.refreshApps': 'アプリを更新',
   'openInApp.toast.pathCopied': 'パスをクリップボードにコピーしました',
+  'openInApp.toast.remoteOpenFailed': 'リモートパスをアプリで開けませんでした',
   'projectActions.actions.addActionAria': 'アクションを追加',
   'projectActions.actions.addAction': 'アクションを追加',
   'projectActions.actions.addNewAction': '新しいアクションを追加',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2208,6 +2208,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.copyPath': '경로 복사',
   'openInApp.actions.refreshApps': '앱 새로고침',
   'openInApp.toast.pathCopied': '경로를 클립보드에 복사했습니다',
+  'openInApp.toast.remoteOpenFailed': '원격 경로를 앱에서 열 수 없습니다',
   'projectActions.actions.addActionAria': '작업 추가',
   'projectActions.actions.addAction': '작업 추가',
   'projectActions.actions.addNewAction': '새 작업 추가',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2163,6 +2163,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.openInAria': 'Otwórz w {app}',
   'openInApp.actions.refreshApps': 'Odśwież aplikacje',
   'openInApp.toast.pathCopied': 'Ścieżka skopiowana do schowka',
+  'openInApp.toast.remoteOpenFailed': 'Nie udało się otworzyć ścieżki zdalnej w aplikacji',
   'planView.actions.copyPlanContents': 'Kopiuj treść planu',
   'planView.actions.implement': 'Wdróż',
   'planView.actions.implementPlanAria': 'Wdróż plan',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2174,6 +2174,7 @@ export const dict: Record<I18nKey, string> = {
   "openInApp.actions.copyPath": "Copiar caminho",
   "openInApp.actions.refreshApps": "Atualizar aplicativos",
   "openInApp.toast.pathCopied": "Caminho copiado para a área de transferência",
+  "openInApp.toast.remoteOpenFailed": "Falha ao abrir caminho remoto no aplicativo",
   "projectActions.actions.addActionAria": "Adicionar ação",
   "projectActions.actions.addAction": "Adicionar ação",
   "projectActions.actions.addNewAction": "Adicionar nova ação",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2174,6 +2174,7 @@ export const dict: Record<I18nKey, string> = {
   "openInApp.actions.copyPath": "Копіювати шлях",
   "openInApp.actions.refreshApps": "Оновити застосунки",
   "openInApp.toast.pathCopied": "Шлях скопійовано в буфер обміну",
+  "openInApp.toast.remoteOpenFailed": "Не вдалося відкрити віддалений шлях у програмі",
   "projectActions.actions.addActionAria": "Додати дію",
   "projectActions.actions.addAction": "Додати дію",
   "projectActions.actions.addNewAction": "Додати нову дію",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2174,6 +2174,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.copyPath': '复制路径',
   'openInApp.actions.refreshApps': '刷新应用',
   'openInApp.toast.pathCopied': '路径已复制到剪贴板',
+  'openInApp.toast.remoteOpenFailed': '无法在编辑器中打开远程路径',
   'projectActions.actions.addActionAria': '添加操作',
   'projectActions.actions.addAction': '添加操作',
   'projectActions.actions.addNewAction': '添加新操作',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2178,6 +2178,7 @@ export const dict: Record<I18nKey, string> = {
   'openInApp.actions.copyPath': '複製路徑',
   'openInApp.actions.refreshApps': '重新整理應用程式',
   'openInApp.toast.pathCopied': '路徑已複製到剪貼簿',
+  'openInApp.toast.remoteOpenFailed': '無法在編輯器中開啟遠端路徑',
   'projectActions.actions.addActionAria': '新增操作',
   'projectActions.actions.addAction': '新增操作',
   'projectActions.actions.addNewAction': '新增新操作',

--- a/packages/ui/src/lib/openInApps.ts
+++ b/packages/ui/src/lib/openInApps.ts
@@ -2,32 +2,33 @@ export type OpenInApp = {
   id: string;
   label: string;
   appName: string;
+  supportsRemote: boolean;
 };
 
 export const OPEN_IN_APPS: OpenInApp[] = [
-  { id: 'finder', label: 'Finder', appName: 'Finder' },
-  { id: 'terminal', label: 'Terminal', appName: 'Terminal' },
-  { id: 'iterm2', label: 'iTerm2', appName: 'iTerm' },
-  { id: 'ghostty', label: 'Ghostty', appName: 'Ghostty' },
-  { id: 'vscode', label: 'VS Code', appName: 'Visual Studio Code' },
-  { id: 'intellij', label: 'IntelliJ', appName: 'IntelliJ IDEA' },
-  { id: 'visual-studio', label: 'Visual Studio', appName: 'Visual Studio' },
-  { id: 'cursor', label: 'Cursor', appName: 'Cursor' },
-  { id: 'android-studio', label: 'Android Studio', appName: 'Android Studio' },
-  { id: 'pycharm', label: 'PyCharm', appName: 'PyCharm' },
-  { id: 'xcode', label: 'Xcode', appName: 'Xcode' },
-  { id: 'sublime-text', label: 'Sublime', appName: 'Sublime Text' },
-  { id: 'webstorm', label: 'WebStorm', appName: 'WebStorm' },
-  { id: 'rider', label: 'Rider', appName: 'Rider' },
-  { id: 'zed', label: 'Zed', appName: 'Zed' },
-  { id: 'phpstorm', label: 'PhpStorm', appName: 'PhpStorm' },
-  { id: 'eclipse', label: 'Eclipse', appName: 'Eclipse' },
-  { id: 'windsurf', label: 'Windsurf', appName: 'Windsurf' },
-  { id: 'vscodium', label: 'VSCodium', appName: 'VSCodium' },
-  { id: 'rustrover', label: 'RustRover', appName: 'RustRover' },
-  { id: 'kiro', label: 'Kiro', appName: 'Kiro' },
-  { id: 'antigravity', label: 'Antigravity', appName: 'Antigravity' },
-  { id: 'trae', label: 'Trae', appName: 'Trae' },
+  { id: 'finder', label: 'Finder', appName: 'Finder', supportsRemote: false },
+  { id: 'terminal', label: 'Terminal', appName: 'Terminal', supportsRemote: false },
+  { id: 'iterm2', label: 'iTerm2', appName: 'iTerm', supportsRemote: false },
+  { id: 'ghostty', label: 'Ghostty', appName: 'Ghostty', supportsRemote: false },
+  { id: 'vscode', label: 'VS Code', appName: 'Visual Studio Code', supportsRemote: true },
+  { id: 'intellij', label: 'IntelliJ', appName: 'IntelliJ IDEA', supportsRemote: false },
+  { id: 'visual-studio', label: 'Visual Studio', appName: 'Visual Studio', supportsRemote: false },
+  { id: 'cursor', label: 'Cursor', appName: 'Cursor', supportsRemote: true },
+  { id: 'android-studio', label: 'Android Studio', appName: 'Android Studio', supportsRemote: false },
+  { id: 'pycharm', label: 'PyCharm', appName: 'PyCharm', supportsRemote: false },
+  { id: 'xcode', label: 'Xcode', appName: 'Xcode', supportsRemote: false },
+  { id: 'sublime-text', label: 'Sublime', appName: 'Sublime Text', supportsRemote: false },
+  { id: 'webstorm', label: 'WebStorm', appName: 'WebStorm', supportsRemote: false },
+  { id: 'rider', label: 'Rider', appName: 'Rider', supportsRemote: false },
+  { id: 'zed', label: 'Zed', appName: 'Zed', supportsRemote: false },
+  { id: 'phpstorm', label: 'PhpStorm', appName: 'PhpStorm', supportsRemote: false },
+  { id: 'eclipse', label: 'Eclipse', appName: 'Eclipse', supportsRemote: false },
+  { id: 'windsurf', label: 'Windsurf', appName: 'Windsurf', supportsRemote: true },
+  { id: 'vscodium', label: 'VSCodium', appName: 'VSCodium', supportsRemote: true },
+  { id: 'rustrover', label: 'RustRover', appName: 'RustRover', supportsRemote: false },
+  { id: 'kiro', label: 'Kiro', appName: 'Kiro', supportsRemote: false },
+  { id: 'antigravity', label: 'Antigravity', appName: 'Antigravity', supportsRemote: false },
+  { id: 'trae', label: 'Trae', appName: 'Trae', supportsRemote: false },
 ];
 
 export const DEFAULT_OPEN_IN_APP_ID = 'finder';

--- a/packages/ui/src/stores/useOpenInAppsStore.ts
+++ b/packages/ui/src/stores/useOpenInAppsStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import { fetchDesktopInstalledApps, isDesktopLocalOriginActive, isDesktopShell, type DesktopSettings, type InstalledDesktopAppInfo } from '@/lib/desktop';
+import { fetchDesktopInstalledApps, isOpenInAppAvailable, type DesktopSettings, type InstalledDesktopAppInfo } from '@/lib/desktop';
 import { OPEN_IN_APPS, DEFAULT_OPEN_IN_APP_ID, OPEN_IN_ALWAYS_AVAILABLE_APP_IDS, getOpenInAppById, getPlatformOpenInApp, type OpenInApp } from '@/lib/openInApps';
 import { updateDesktopSettings } from '@/lib/persistence';
 
@@ -51,6 +51,31 @@ const clearRetryTimeout = () => {
   }
 };
 
+const applyInstalledApps = (
+  installed: InstalledDesktopAppInfo[],
+  hasLoadedApps: boolean,
+  set: (partial: Partial<OpenInAppsState>) => void,
+) => {
+  if (!Array.isArray(installed) || installed.length === 0) {
+    set({ availableApps: getAlwaysAvailableApps(), hasLoadedApps });
+    return;
+  }
+
+  const allowed = new Set(installed.map((app) => app.name));
+  const iconMap = new Map(installed.map((app) => [app.name, app.iconDataUrl ?? undefined]));
+
+  const filtered = OPEN_IN_APPS.filter(
+    (app) => allowed.has(app.appName) || OPEN_IN_ALWAYS_AVAILABLE_APP_IDS.has(app.id)
+  );
+
+  const withIcons = filtered.map((app) => ({
+    ...getPlatformOpenInApp(app),
+    iconDataUrl: iconMap.get(app.appName),
+  }));
+
+  set({ availableApps: withIcons.length > 0 ? withIcons : getAlwaysAvailableApps(), hasLoadedApps });
+};
+
 export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
   selectedAppId: getStoredAppId(),
   availableApps: getAlwaysAvailableApps(),
@@ -64,29 +89,12 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
     }
     initialized = true;
 
-    const applyInstalledApps = (installed: InstalledDesktopAppInfo[], hasLoadedApps = true) => {
-      if (!Array.isArray(installed) || installed.length === 0) {
-        set({ availableApps: getAlwaysAvailableApps(), hasLoadedApps });
-        return;
-      }
-
-      const allowed = new Set(installed.map((app) => app.name));
-      const iconMap = new Map(installed.map((app) => [app.name, app.iconDataUrl ?? undefined]));
-
-      const filtered = OPEN_IN_APPS.filter(
-        (app) => allowed.has(app.appName) || OPEN_IN_ALWAYS_AVAILABLE_APP_IDS.has(app.id)
-      );
-
-      const withIcons = filtered.map((app) => ({
-        ...getPlatformOpenInApp(app),
-        iconDataUrl: iconMap.get(app.appName),
-      }));
-
-      set({ availableApps: withIcons, hasLoadedApps: true });
+    const applyApps = (installed: InstalledDesktopAppInfo[], hasLoadedApps = true) => {
+      applyInstalledApps(installed, hasLoadedApps, set);
     };
 
     const loadInstalledApps = async (force?: boolean) => {
-      if (!isDesktopShell() || !isDesktopLocalOriginActive()) {
+      if (!isOpenInAppAvailable()) {
         return;
       }
 
@@ -121,7 +129,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
         const shouldRetryEmptyScan = success && !hasCache && installed.length === 0 && retryAttempt < 3;
 
         set({ isCacheStale: hasCache ? isCacheStale : false });
-        applyInstalledApps(installed, success ? !shouldRetryEmptyScan : false);
+        applyApps(installed, success ? !shouldRetryEmptyScan : false);
 
         if (success) {
           if (shouldRetryEmptyScan) {
@@ -181,6 +189,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
     };
 
     const updateHandler = (event: Event) => {
+      if (!isOpenInAppAvailable()) return;
       const detail = (event as CustomEvent<InstalledDesktopAppInfo[]>).detail;
       if (!Array.isArray(detail)) {
         return;
@@ -189,7 +198,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
       retryAttempt = 3;
       keepScanning = false;
       set({ isScanning: false, isCacheStale: false });
-      applyInstalledApps(detail);
+      applyApps(detail);
     };
 
     window.addEventListener('openchamber:settings-synced', settingsHandler);
@@ -213,7 +222,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
       get().initialize();
     }
 
-    if (!isDesktopShell() || !isDesktopLocalOriginActive()) {
+    if (!isOpenInAppAvailable()) {
       return;
     }
 
@@ -240,25 +249,15 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
     try {
       const {
         apps: installed,
+        success,
         hasCache,
         isCacheStale,
       } = await fetchDesktopInstalledApps(appNames, force);
 
-      const allowed = new Set(installed.map((app) => app.name));
-      const iconMap = new Map(installed.map((app) => [app.name, app.iconDataUrl ?? undefined]));
-      const filtered = OPEN_IN_APPS.filter(
-        (app) => allowed.has(app.appName) || OPEN_IN_ALWAYS_AVAILABLE_APP_IDS.has(app.id)
-      );
-      const withIcons = filtered.map((app) => ({
-        ...app,
-        iconDataUrl: iconMap.get(app.appName),
-      }));
-
-      set({
-        availableApps: withIcons.length > 0 ? withIcons : getAlwaysAvailableApps(),
-        hasLoadedApps: withIcons.length > 0,
-        isCacheStale: hasCache ? isCacheStale : false,
-      });
+      if (success) {
+        applyInstalledApps(installed, installed.length > 0, set);
+      }
+      set({ isCacheStale: hasCache ? isCacheStale : false });
     } finally {
       loading = false;
       if (!keepScanning) {

--- a/packages/ui/src/stores/useOpenInAppsStore.ts
+++ b/packages/ui/src/stores/useOpenInAppsStore.ts
@@ -76,6 +76,84 @@ const applyInstalledApps = (
   set({ availableApps: withIcons.length > 0 ? withIcons : getAlwaysAvailableApps(), hasLoadedApps });
 };
 
+const _loadInstalledAppsInternal = async (
+  force: boolean | undefined,
+  set: (partial: Partial<OpenInAppsState>) => void,
+  get: () => OpenInAppsState,
+) => {
+  if (!isOpenInAppAvailable()) {
+    return;
+  }
+
+  if (loading && !force) {
+    return;
+  }
+
+  const state = get();
+  if (state.hasLoadedApps && !force) {
+    return;
+  }
+
+  const appNames = OPEN_IN_APPS.map((app) => app.appName);
+  clearRetryTimeout();
+
+  if (force) {
+    retryAttempt = 0;
+  }
+
+  loading = true;
+  keepScanning = false;
+  set({ isScanning: true });
+
+  try {
+    const {
+      apps: installed,
+      success,
+      hasCache,
+      isCacheStale,
+    } = await fetchDesktopInstalledApps(appNames, force);
+
+    const shouldRetryEmptyScan = success && !hasCache && installed.length === 0 && retryAttempt < 3;
+
+    set({ isCacheStale: hasCache ? isCacheStale : false });
+    applyInstalledApps(installed, success ? !shouldRetryEmptyScan : false, set);
+
+    if (success) {
+      if (shouldRetryEmptyScan) {
+        const delays = [800, 1600, 3200];
+        const delay = delays[retryAttempt] ?? 3200;
+        retryAttempt += 1;
+        keepScanning = true;
+        retryTimeout = setTimeout(() => {
+          void _loadInstalledAppsInternal(undefined, set, get);
+        }, delay);
+        return;
+      }
+
+      retryAttempt = 0;
+      keepScanning = false;
+      return;
+    }
+
+    if (retryAttempt < 3) {
+      const delays = [1000, 3000, 7000];
+      const delay = delays[retryAttempt] ?? 7000;
+      retryAttempt += 1;
+      keepScanning = true;
+      retryTimeout = setTimeout(() => {
+        void _loadInstalledAppsInternal(undefined, set, get);
+      }, delay);
+    } else {
+      keepScanning = false;
+    }
+  } finally {
+    loading = false;
+    if (!keepScanning) {
+      set({ isScanning: false });
+    }
+  }
+};
+
 export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
   selectedAppId: getStoredAppId(),
   availableApps: getAlwaysAvailableApps(),
@@ -87,85 +165,10 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
     if (initialized || typeof window === 'undefined') {
       return;
     }
+    clearRetryTimeout();
     initialized = true;
 
-    const applyApps = (installed: InstalledDesktopAppInfo[], hasLoadedApps = true) => {
-      applyInstalledApps(installed, hasLoadedApps, set);
-    };
-
-    const loadInstalledApps = async (force?: boolean) => {
-      if (!isOpenInAppAvailable()) {
-        return;
-      }
-
-      if (loading) {
-        return;
-      }
-
-      const state = get();
-      if (state.hasLoadedApps && !force) {
-        return;
-      }
-
-      const appNames = OPEN_IN_APPS.map((app) => app.appName);
-      clearRetryTimeout();
-
-      if (force) {
-        set({ hasLoadedApps: false });
-      }
-
-      loading = true;
-      keepScanning = false;
-      set({ isScanning: true });
-
-      try {
-        const {
-          apps: installed,
-          success,
-          hasCache,
-          isCacheStale,
-        } = await fetchDesktopInstalledApps(appNames, force);
-
-        const shouldRetryEmptyScan = success && !hasCache && installed.length === 0 && retryAttempt < 3;
-
-        set({ isCacheStale: hasCache ? isCacheStale : false });
-        applyApps(installed, success ? !shouldRetryEmptyScan : false);
-
-        if (success) {
-          if (shouldRetryEmptyScan) {
-            const delays = [800, 1600, 3200];
-            const delay = delays[retryAttempt] ?? 3200;
-            retryAttempt += 1;
-            keepScanning = true;
-            retryTimeout = setTimeout(() => {
-              void loadInstalledApps();
-            }, delay);
-            return;
-          }
-
-          retryAttempt = 0;
-          keepScanning = false;
-          return;
-        }
-
-        if (retryAttempt < 3) {
-          const delays = [1000, 3000, 7000];
-          const delay = delays[retryAttempt] ?? 7000;
-          retryAttempt += 1;
-          keepScanning = true;
-          retryTimeout = setTimeout(() => {
-            void loadInstalledApps();
-          }, delay);
-        }
-      } finally {
-        loading = false;
-        if (!keepScanning) {
-          set({ isScanning: false });
-        }
-      }
-    };
-
-    void loadInstalledApps();
+    void _loadInstalledAppsInternal(undefined, set, get);
 
     const settingsHandler = (event: Event) => {
       const detail = (event as CustomEvent<DesktopSettings>).detail;
@@ -185,7 +188,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
     };
 
     const appReadyHandler = () => {
-      void loadInstalledApps();
+      void _loadInstalledAppsInternal(undefined, set, get);
     };
 
     const updateHandler = (event: Event) => {
@@ -195,10 +198,11 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
         return;
       }
 
+      clearRetryTimeout();
       retryAttempt = 3;
       keepScanning = false;
       set({ isScanning: false, isCacheStale: false });
-      applyApps(detail);
+      applyInstalledApps(detail, true, set);
     };
 
     window.addEventListener('openchamber:settings-synced', settingsHandler);
@@ -207,12 +211,12 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
 
     const appReady = (window as unknown as { __openchamberAppReady?: boolean }).__openchamberAppReady;
     if (appReady) {
-      void loadInstalledApps();
+      void _loadInstalledAppsInternal(undefined, set, get);
     }
 
     window.setTimeout(() => {
       if (!get().hasLoadedApps) {
-        void loadInstalledApps();
+        void _loadInstalledAppsInternal(undefined, set, get);
       }
     }, 5000);
   },
@@ -222,48 +226,7 @@ export const useOpenInAppsStore = create<OpenInAppsState>()((set, get) => ({
       get().initialize();
     }
 
-    if (!isOpenInAppAvailable()) {
-      return;
-    }
-
-    if (loading) {
-      return;
-    }
-
-    const state = get();
-    if (state.hasLoadedApps && !force) {
-      return;
-    }
-
-    const appNames = OPEN_IN_APPS.map((app) => app.appName);
-    clearRetryTimeout();
-
-    if (force) {
-      set({ hasLoadedApps: false });
-    }
-
-    loading = true;
-    keepScanning = false;
-    set({ isScanning: true });
-
-    try {
-      const {
-        apps: installed,
-        success,
-        hasCache,
-        isCacheStale,
-      } = await fetchDesktopInstalledApps(appNames, force);
-
-      if (success) {
-        applyInstalledApps(installed, installed.length > 0, set);
-      }
-      set({ isCacheStale: hasCache ? isCacheStale : false });
-    } finally {
-      loading = false;
-      if (!keepScanning) {
-        set({ isScanning: false });
-      }
-    }
+    await _loadInstalledAppsInternal(force, set, get);
   },
 
   selectApp: async (appId: string) => {


### PR DESCRIPTION
## Summary

Adds support for the "Open in App" button (VS Code / Cursor / Windsurf / VSCodium) when OpenChamber Desktop is connected to a remote OpenCode server via SSH tunnel.

## Changes

### Electron main process (`packages/electron/main.mjs`)
- **Remote open IPC handlers**: `desktop_open_remote_in_app`, `desktop_open_remote_file_in_app` — spawn VS Code/Cursor/Windsurf/VSCodium with `--remote ssh-remote+<host>` CLI args on macOS (CLI + deep-link fallback) and Windows (where-based CLI discovery + executable scan)
- **SSH context query**: `desktop_get_active_ssh_info` — resolves SSH host/user/port from the tunnel origin, parsing `-p`, `-P`, `-l`, `-o Port=`, `-o User=` args
- **`normalizeSshHost`**: wraps IPv6 addresses in brackets for correct `ssh-remote+` URI construction
- **Three-tier IPC gateway**:
  - `isActualLocalOrigin` (renamed from `isLocalSender`) — fixes a bug where a configured `localOrigin` that didn't match would incorrectly fall through to loopback
  - `isSshTunnelOrigin` — detects SSH-tunneled pages by loopback hostname + port matching a `ready` SSH instance, removed stale `sidecarUrl` fallback
  - Gate logic: tunnel pages get `SSH_TUNNEL_COMMANDS` + `COMMANDS_SAFE_FOR_REMOTE`; file dialogs/file grants/local path opens restricted to `isActualLocalOrigin` only

### Shared UI (`packages/ui/src/lib/desktop.ts`)
- **`isRemoteSshActive`**: heuristic SSH detection with optimistic caching, async IPC verification, `useSyncExternalStore`-compatible subscriber pattern, 10s TTL
- **`getActiveSshContext`**: resolves SSH host/port/instanceId; circular dependency with `isRemoteSshActive` broken
- **`invalidateRemoteSshCache`**: clears optimistic state on remote-open failure
- **`openDesktopRemoteProjectInApp` / `openDesktopRemoteFileInApp`**: bridge functions
- **`isDesktopLoopbackOrigin` / `isOpenInAppAvailable`**: gates app scans to local + SSH-tunnel loopback origins

### UI components
- **`OpenInAppButton`** / **`FilesView`**: detect remote SSH via `useSyncExternalStore`, filter apps to `supportsRemote: true`, route opens to remote IPC with clipboard fallback on failure
- **`useOpenInAppsStore`**: gating updated from `isDesktopLocalOriginActive` to `isOpenInAppAvailable`; `applyInstalledApps` extracted to shared module-level helper

### Data model
- **`OpenInApp.supportsRemote`**: `true` for vscode/cursor/windsurf/vscodium only
- **i18n**: `openInApp.toast.remoteOpenFailed` in 9 languages

### Other fixes
- App icon parsing handles both `dataUrl` (macOS) and `data_url` (Windows)
- `openchamber:file:grant-existing` gate corrected from removed `isLocalSender` to `isActualLocalOrigin`

## IPC security boundary

| Origin | Commands allowed |
|--------|-----------------|
| Local (`isActualLocalOrigin`) | All commands |
| SSH tunnel (`isSshTunnelOrigin`) | `SSH_TUNNEL_COMMANDS` + `COMMANDS_SAFE_FOR_REMOTE` |
| Remote (non-loopback) | `COMMANDS_SAFE_FOR_REMOTE` only |

## Validation

- `@openchamber/electron` type-check ✅, lint ✅
- `@openchamber/web` type-check: remaining errors pre-existing (virtua/shiki/cron-parser from #1651)
- Rebased onto latest `origin/main`, auto-merge clean, no conflicts