### PR TITLE
fix(mobile): use exact directory matching for session grouping

### DIFF
--- a/packages/ui/src/apps/MobileSessionsSheet.tsx
+++ b/packages/ui/src/apps/MobileSessionsSheet.tsx
@@ -663,11 +663,13 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
       const directory = getSessionDirectory(session);
       if (!directory) continue;
       const node = nodes.find((entry) => {
-        if (pathBelongsToRoot(directory, entry.project.path)) return true;
-        return entry.project.worktrees.some((worktree) => pathBelongsToRoot(directory, worktree.path));
+        const normalizedDir = normalizePath(directory);
+        const normalizedProjectPath = normalizePath(entry.project.path);
+        if (normalizedDir === normalizedProjectPath) return true;
+        return entry.project.worktrees.some((worktree) => normalizePath(worktree.path) === normalizedDir);
       });
       if (!node) continue;
-      const matchedWorktree = node.project.worktrees.find((entry) => pathBelongsToRoot(directory, entry.path));
+      const matchedWorktree = node.project.worktrees.find((entry) => normalizePath(entry.path) === normalizePath(directory));
       const bucket = matchedWorktree
         ? ensureBucket(node, matchedWorktree.path, matchedWorktree)
         : ensureBucket(node, node.project.path, null);
@@ -677,7 +679,7 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     for (const node of nodes) {
       for (const bucket of node.buckets) {
         bucket.sessions.sort((a, b) => getSessionTimestamp(b) - getSessionTimestamp(a));
-        node.totalSessions += bucket.sessions.length;
+        node.totalSessions += bucket.sessions.filter((s) => !getParentId(s)).length;
       }
     }
 

--- a/packages/ui/src/apps/MobileSessionsSheet.tsx
+++ b/packages/ui/src/apps/MobileSessionsSheet.tsx
@@ -154,6 +154,20 @@ const pathBelongsToRoot = (path: string, root: string): boolean => {
   );
 };
 
+const findExactWorktreeMatch = (project: ProjectMeta, normalizedDirectory: string): WorktreeMetadata | null => (
+  project.worktrees.find((worktree) => normalizePath(worktree.path) === normalizedDirectory) ?? null
+);
+
+const projectMatchesExactDirectory = (project: ProjectMeta, normalizedDirectory: string): boolean => (
+  normalizedDirectory === project.path || Boolean(findExactWorktreeMatch(project, normalizedDirectory))
+);
+
+const findExactProjectMatch = (projects: ProjectMeta[], directory: string): ProjectMeta | null => {
+  const normalizedDirectory = normalizePath(directory);
+  if (!normalizedDirectory) return null;
+  return projects.find((project) => projectMatchesExactDirectory(project, normalizedDirectory)) ?? null;
+};
+
 const sessionMatchesQuery = (session: Session, projectLabel: string, query: string): boolean => {
   if (!query) return true;
   const haystack = `${session.title ?? ''} ${session.id} ${getSessionDirectory(session)} ${projectLabel}`.toLowerCase();
@@ -662,14 +676,10 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     for (const session of sessions) {
       const directory = getSessionDirectory(session);
       if (!directory) continue;
-      const node = nodes.find((entry) => {
-        const normalizedDir = normalizePath(directory);
-        const normalizedProjectPath = normalizePath(entry.project.path);
-        if (normalizedDir === normalizedProjectPath) return true;
-        return entry.project.worktrees.some((worktree) => normalizePath(worktree.path) === normalizedDir);
-      });
+      const normalizedDirectory = normalizePath(directory);
+      const node = nodes.find((entry) => projectMatchesExactDirectory(entry.project, normalizedDirectory));
       if (!node) continue;
-      const matchedWorktree = node.project.worktrees.find((entry) => normalizePath(entry.path) === normalizePath(directory));
+      const matchedWorktree = findExactWorktreeMatch(node.project, normalizedDirectory);
       const bucket = matchedWorktree
         ? ensureBucket(node, matchedWorktree.path, matchedWorktree)
         : ensureBucket(node, node.project.path, null);
@@ -679,7 +689,9 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     for (const node of nodes) {
       for (const bucket of node.buckets) {
         bucket.sessions.sort((a, b) => getSessionTimestamp(b) - getSessionTimestamp(a));
-        node.totalSessions += bucket.sessions.filter((s) => !getParentId(s)).length;
+        for (const session of bucket.sessions) {
+          if (!getParentId(session)) node.totalSessions += 1;
+        }
       }
     }
 
@@ -818,10 +830,7 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     // Switching session switches the working directory (handled by
     // setCurrentSession) — also move the active project so the rest of the app
     // and the active highlight follow the selected session, not just the draft.
-    const project = projectsMeta.find((entry) => {
-      if (pathBelongsToRoot(directory ?? '', entry.path)) return true;
-      return entry.worktrees.some((worktree) => pathBelongsToRoot(directory ?? '', worktree.path));
-    });
+    const project = findExactProjectMatch(projectsMeta, directory ?? '');
     if (project) setActiveProjectIdOnly(project.id);
     void setCurrentSession(session.id, directory);
     onOpenChange(false);
@@ -880,12 +889,9 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   const buildSessionContextLabel = React.useCallback(
     (session: Session): string => {
       const directory = getSessionDirectory(session);
-      const project = projectsMeta.find((entry) => {
-        if (pathBelongsToRoot(directory, entry.path)) return true;
-        return entry.worktrees.some((worktree) => pathBelongsToRoot(directory, worktree.path));
-      });
+      const project = findExactProjectMatch(projectsMeta, directory);
       if (!project) return getProjectLabel(directory) || directory;
-      const matchedWorktree = project.worktrees.find((entry) => pathBelongsToRoot(directory, entry.path));
+      const matchedWorktree = findExactWorktreeMatch(project, normalizePath(directory));
       if (matchedWorktree?.branch) return `${project.label} · ${matchedWorktree.branch}`;
       return project.label;
     },
@@ -917,10 +923,7 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     return sessions
       .filter((session) => {
         const directory = getSessionDirectory(session);
-        const project = projectsMeta.find((entry) => {
-          if (pathBelongsToRoot(directory, entry.path)) return true;
-          return entry.worktrees.some((worktree) => pathBelongsToRoot(directory, worktree.path));
-        });
+        const project = findExactProjectMatch(projectsMeta, directory);
         return sessionMatchesQuery(session, project?.label ?? '', normalizedQuery);
       })
       .sort((a, b) => getSessionTimestamp(b) - getSessionTimestamp(a));
@@ -933,9 +936,9 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
       .map((project) => ({
         ...project,
         sessionCount: sessions.filter((session) => {
-          const directory = getSessionDirectory(session);
-          if (pathBelongsToRoot(directory, project.path)) return true;
-          return project.worktrees.some((worktree) => pathBelongsToRoot(directory, worktree.path));
+          if (getParentId(session)) return false;
+          const directory = normalizePath(getSessionDirectory(session));
+          return projectMatchesExactDirectory(project, directory);
         }).length,
       }));
   }, [normalizedQuery, projectsMeta, sessions]);


### PR DESCRIPTION
## Problem

The new mobile sessions sheet (`MobileSessionsSheet.tsx`) uses `startsWith` prefix matching to assign sessions to projects. This causes sessions from child directories (e.g. `/root/repos/opencode`, `/root/repos/openchamber`) to be grouped into parent projects (e.g. `/root/repos`), inflating the session count (e.g. 211 sessions for `/root/repos` when it should show far fewer).

Additionally, sub-agent sessions (those with `parentID`) are included in the `totalSessions` badge count, further inflating the displayed number.

## Fix

1. **Exact directory matching**: Changed session-to-project assignment from `startsWith` prefix matching to exact path comparison against the project root and its registered worktree paths. This matches the desktop sidebar behavior in `useProjectSessionLists.ts`.

2. **Exclude sub-agent sessions from count**: The `totalSessions` badge now counts only root sessions (no `parentID`), consistent with how the rendering layer already organizes sessions into parent/child trees.

## Changed files

- `packages/ui/src/apps/MobileSessionsSheet.tsx`: Session grouping logic (lines 662-681)