### PR TITLE
fix(markdown): restore paragraph block spacing in chat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Chat: adjacent paragraphs in assistant messages now render with a visible gap instead of collapsing into a single visual line, matching the spacing users see when copying the text out.
+
 ## [1.13.1] - 2026-06-17
 
 - Chat: inline math delimiters no longer incorrectly treat currency amounts like `$50` as LaTeX math expressions — only `$$...$$` display math and `\(...\)` inline math are recognized.

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -932,6 +932,16 @@ html:not(.dark) .chat-scroll {
   line-height: inherit;
 }
 
+/* Restore paragraph block spacing inside markdown content.
+   --markdown-paragraph-spacing is defined in design-system.css but
+   was never wired up, so adjacent <p> blocks collapsed to a single
+   visual line. Callers (MessageBody, UserTextPart) already nullify
+   the first/last child margins via the [&_.markdown-content>*] pattern,
+   so this rule is safe to apply unconditionally. */
+.markdown-content p {
+  margin: 0 0 var(--markdown-paragraph-spacing) 0;
+}
+
 /* Tool markdown should render at code size to match tool card typography. */
 .markdown-content.markdown-tool {
   font-size: var(--text-code) !important;

--- a/packages/ui/src/styles/design-system.css
+++ b/packages/ui/src/styles/design-system.css
@@ -328,7 +328,7 @@
   --markdown-blockquote-border: var(--markdown-blockquote-border);
 
   /* Markdown spacing defaults */
-  --markdown-paragraph-spacing: 0.35rem;
+  --markdown-paragraph-spacing: 0.75rem;
   --markdown-heading-primary-top: 0.75rem;
   --markdown-heading-primary-bottom: 0.35rem;
   --markdown-heading-secondary-top: 0.6rem;


### PR DESCRIPTION
When the assistant writes more than one paragraph in a single response, the paragraphs are squashed together on screen — the second one starts on the line right after the first, with no gap. It looks like one long paragraph, even though the text underneath is clearly two separate ones.

The giveaway is to copy the message out: paste it into another app and the blank lines between paragraphs are right there. So the source data is fine, the rendering is what's broken.

## Root cause

A missing CSS rule. The design system defines a token called `--markdown-paragraph-spacing` for exactly this purpose, but no rule ever applied it. `.markdown-content` sets font and line-height but nothing about `<p>` margins, so adjacent paragraph blocks collapse to a zero-gap stack. The streaming path renders into the same container, so the bug is visible the whole time a response is coming in, not just at the end.

## Fix

- Wire the existing `--markdown-paragraph-spacing` token to `.markdown-content p` with a bottom margin.
- Bump the token value from `0.35rem` to `0.75rem` so the gap is unambiguous, not just barely-visible.
- No JS, no React, no markdown parser changes. The data path was already correct.

Callers like `MessageBody` and `UserTextPart` already nullify the first and last child's margin through the `[&_.markdown-content>*]` pattern, so adding the rule here doesn't double-up spacing at the top or bottom of a message. Reasoning and tool variants have their own margin overrides that win by specificity, so this rule only affects assistant-text paragraphs.

## Files changed

- `packages/ui/src/index.css` — added `.markdown-content p` margin rule
- `packages/ui/src/styles/design-system.css` — bumped `--markdown-paragraph-spacing` from `0.35rem` to `0.75rem`
- `CHANGELOG.md` — added entry under `[Unreleased]`

3 files, +13/-1.