### PR TITLE
fix(sync): treat part snapshot as a delta coalescing barrier

### DIFF
--- a/packages/ui/src/sync/event-pipeline.test.ts
+++ b/packages/ui/src/sync/event-pipeline.test.ts
@@ -97,6 +97,51 @@ describe("createEventPipeline", () => {
     })).toEqual(["updated:a", "delta:b", "updated:ab"])
   })
 
+  test("does not merge deltas across an intervening part snapshot", async () => {
+    let resolveStreamFinished!: () => void
+    const streamFinished = new Promise<void>((resolve) => {
+      resolveStreamFinished = resolve
+    })
+    let resolveDelivered!: () => void
+    const deliveredAll = new Promise<void>((resolve) => {
+      resolveDelivered = resolve
+    })
+    const delivered: Event[] = []
+    const pipeline = createEventPipeline({
+      sdk: createSdk([
+        partUpdatedEvent("a"),
+        deltaEvent("b"),
+        partUpdatedEvent("ab"),
+        deltaEvent("c"),
+      ], resolveStreamFinished),
+      onEvent: (_directory, payload) => {
+        delivered.push(payload)
+        if (delivered.length === 4) {
+          resolveDelivered()
+        }
+      },
+      transport: "sse",
+      heartbeatTimeoutMs: 1_000,
+    })
+
+    try {
+      await streamFinished
+      await Promise.race([deliveredAll, new Promise<void>((resolve) => setTimeout(resolve, 300))])
+    } finally {
+      pipeline.cleanup()
+    }
+
+    // The "ab" snapshot is a coalescing barrier: the trailing "c" delta must
+    // stay a separate event after it, not merge into the "b" delta queued
+    // before the snapshot (which the snapshot would then overwrite).
+    expect(delivered.map((event) => {
+      if (event.type === "message.part.delta") {
+        return `delta:${(event.properties as { delta: string }).delta}`
+      }
+      return `updated:${((event.properties as { part: { text: string } }).part).text}`
+    })).toEqual(["updated:a", "delta:b", "updated:ab", "delta:c"])
+  })
+
   test("normalizes openchamber session status events", async () => {
     let resolveStreamFinished!: () => void
     const streamFinished = new Promise<void>((resolve) => {

--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -447,6 +447,26 @@ export function createEventPipeline(input: EventPipelineInput): EventPipeline {
     const normalizedPayload = normalizeEventType(payload)
     const routedDirectory = routeDirectory?.(directory, normalizedPayload) || directory
     const d = getOrCreateDir(routedDirectory)
+
+    // A full part snapshot is a coalescing barrier for that part's deltas:
+    // drop its pending delta coalescing keys so a delta arriving after the
+    // snapshot starts a fresh queue entry instead of merging into a delta
+    // queued before the snapshot, which the snapshot would then overwrite and
+    // drop the later delta's text. The already-queued delta event stays.
+    if (normalizedPayload.type === "message.part.updated") {
+      const part = (normalizedPayload.properties as { part?: { id?: unknown; messageID?: unknown } }).part
+      const messageID = typeof part?.messageID === "string" ? part.messageID : undefined
+      const partID = typeof part?.id === "string" ? part.id : undefined
+      if (messageID && partID) {
+        const deltaPrefix = `message.part.delta:${messageID}:${partID}:`
+        for (const coalesceKey of d.coalesced.keys()) {
+          if (coalesceKey.startsWith(deltaPrefix)) {
+            d.coalesced.delete(coalesceKey)
+          }
+        }
+      }
+    }
+
     const k = key(normalizedPayload)
     if (k) {
       const i = d.coalesced.get(k)


### PR DESCRIPTION
## What

A `message.part.updated` snapshot now acts as a **coalescing barrier** for that part's deltas. When a snapshot is enqueued, the pipeline drops the pending `message.part.delta:<messageID>:<partID>:<field>` coalescing keys for that message/part (the already-queued delta event is left in place). A delta arriving after an intervening snapshot therefore starts a fresh queue entry instead of merging into a delta queued *before* the snapshot.

## Why

Fixes #1647 (data-loss). `message.part.delta` events are coalesced by `message.part.delta:<messageID>:<partID>:<field>`, and that key stayed active across an intervening `message.part.updated` snapshot. Given the stream:

```
message.part.updated text="a"
message.part.delta   delta="b"
message.part.updated text="ab"
message.part.delta   delta="c"
```

the pipeline delivered:

```
updated:a
delta:bc        <- "c" merged into the pre-snapshot "b"
updated:ab
```

The final snapshot then overwrote the merged slot, so the text settled at `ab` instead of `abc` and the trailing `c` was lost.

This builds on #1167, which stopped coalescing `message.part.updated` snapshots; #1647 is the remaining edge case where delta coalescing itself could still cross a later snapshot boundary.

## How

In `enqueueEvent` (`packages/ui/src/sync/event-pipeline.ts`), when the event is `message.part.updated`, delete the part's pending delta coalescing keys (matched by the `message.part.delta:<messageID>:<partID>:` prefix, covering all fields) without removing the already-queued delta event. Normal same-run delta coalescing and all other coalesced event types are unchanged. The block is a no-op when the snapshot lacks `part.id`/`messageID`.

## Testing

- Added a regression test in `packages/ui/src/sync/event-pipeline.test.ts` covering `updated:a, delta:b, updated:ab, delta:c`, asserting the trailing `delta:c` survives the second snapshot. It fails before the change (delivers `delta:bc` and drops `delta:c`) and passes after.
- `bun run type-check` — passes (ui, web, electron, root).
- `bun run lint` — passes (ui, web, electron, root).
- `bun run build` — succeeds (ui, web, electron, root).

Closes #1647
