### PR TITLE
fix(files): prevent HTML preview auth token cycling

### DIFF
--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -855,6 +855,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const [pdfAssetAuthReadyKey, setPdfAssetAuthReadyKey] = React.useState('');
 
   const [htmlPreviewNonce, setHtmlPreviewNonce] = React.useState(0);
+  const [imagePreviewNonce, setImagePreviewNonce] = React.useState(0);
+  const [pdfPreviewNonce, setPdfPreviewNonce] = React.useState(0);
 
   const [loadedFilePath, setLoadedFilePath] = React.useState<string | null>(null);
 
@@ -2890,16 +2892,33 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
     let cancelled = false;
     setImageAssetAuthReadyKey('');
-    void refreshRuntimeUrlAuthToken(getRuntimeApiBaseUrl())
-      .then((token) => {
-        if (!cancelled && token) setImageAssetAuthReadyKey(imageAssetAuthKey);
-      })
-      .catch(() => {});
+
+    const refreshToken = () => {
+      clearRuntimeUrlAuthToken();
+      void refreshRuntimeUrlAuthToken(getRuntimeApiBaseUrl())
+        .then((token) => {
+          if (!cancelled && token) {
+            setImageAssetAuthReadyKey(imageAssetAuthKey);
+            setImagePreviewNonce((n) => n + 1);
+            setFileError(null);
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            setFileError(error instanceof Error ? error.message : t('filesView.error.readFileFailed'));
+            setImageAssetAuthReadyKey(imageAssetAuthKey);
+          }
+        });
+    };
+
+    refreshToken();
+    const id = setInterval(refreshToken, 45_000);
 
     return () => {
       cancelled = true;
+      clearInterval(id);
     };
-  }, [imageAssetAuthKey]);
+  }, [imageAssetAuthKey, t]);
 
   const isImageAssetAuthLoading = Boolean(imageAssetAuthKey && imageAssetAuthReadyKey !== imageAssetAuthKey);
 
@@ -2919,6 +2938,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           if (!cancelled && token) {
             setHtmlAssetAuthReadyKey(htmlAssetAuthKey);
             setHtmlPreviewNonce((n) => n + 1);
+            setFileError(null);
           }
         })
         .catch((error) => {
@@ -2947,19 +2967,31 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
     let cancelled = false;
     setPdfAssetAuthReadyKey('');
-    void refreshRuntimeUrlAuthToken(getRuntimeApiBaseUrl())
-      .then((token) => {
-        if (!cancelled && token) setPdfAssetAuthReadyKey(pdfAssetAuthKey);
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setFileError(error instanceof Error ? error.message : t('filesView.error.readFileFailed'));
-          setPdfAssetAuthReadyKey(pdfAssetAuthKey);
-        }
-      });
+
+    const refreshToken = () => {
+      clearRuntimeUrlAuthToken();
+      void refreshRuntimeUrlAuthToken(getRuntimeApiBaseUrl())
+        .then((token) => {
+          if (!cancelled && token) {
+            setPdfAssetAuthReadyKey(pdfAssetAuthKey);
+            setPdfPreviewNonce((n) => n + 1);
+            setFileError(null);
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            setFileError(error instanceof Error ? error.message : t('filesView.error.readFileFailed'));
+            setPdfAssetAuthReadyKey(pdfAssetAuthKey);
+          }
+        });
+    };
+
+    refreshToken();
+    const id = setInterval(refreshToken, 45_000);
 
     return () => {
       cancelled = true;
+      clearInterval(id);
     };
   }, [pdfAssetAuthKey, t]);
 
@@ -2992,12 +3024,13 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const renderPdfPreview = React.useCallback((file: FileNode) => (
     <div className="h-full overflow-hidden bg-[var(--surface-background)]">
       <iframe
+        key={pdfPreviewNonce}
         src={pdfSrc}
         className="h-full w-full border-0"
         title={file.name}
       />
     </div>
-  ), [pdfSrc]);
+  ), [pdfSrc, pdfPreviewNonce]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -3768,6 +3801,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           ) : isSelectedImage ? (
             <div className="flex h-full items-center justify-center p-3">
               <img
+                key={imagePreviewNonce}
                 src={imageSrc}
                 alt={selectedFile?.name ?? t('filesView.editor.imageAltFallback')}
                 className="max-w-full max-h-[70vh] object-contain rounded-md border border-border/30 bg-primary/10"
@@ -4138,6 +4172,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           ) : isSelectedImage ? (
             <div className="flex h-full items-center justify-center p-4">
               <img
+                key={imagePreviewNonce}
                 src={imageSrc}
                 alt={selectedFile.name}
                 className="max-w-full max-h-full object-contain rounded-md border border-border/30 bg-primary/10"

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -46,7 +46,7 @@ import { useDeviceInfo } from '@/lib/device';
 import { cn, getModifierLabel, getRevealLabelKey, hasModifier } from '@/lib/utils';
 import { getLanguageFromExtension, getImageMimeType, isDrawioFile, isImageFile, isPdfFile } from '@/lib/toolHelpers';
 import { getRuntimeUrlResolver } from '@/lib/runtime-url';
-import { refreshRuntimeUrlAuthToken } from '@/lib/runtime-auth';
+import { clearRuntimeUrlAuthToken, refreshRuntimeUrlAuthToken } from '@/lib/runtime-auth';
 import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
 import { getOutsideFileGrant } from '@/lib/outsideFileGrants';
 import { DiagramEditor } from '@/components/diagram';
@@ -853,6 +853,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const [imageAssetAuthReadyKey, setImageAssetAuthReadyKey] = React.useState('');
   const [htmlAssetAuthReadyKey, setHtmlAssetAuthReadyKey] = React.useState('');
   const [pdfAssetAuthReadyKey, setPdfAssetAuthReadyKey] = React.useState('');
+
+  const [htmlPreviewNonce, setHtmlPreviewNonce] = React.useState(0);
 
   const [loadedFilePath, setLoadedFilePath] = React.useState<string | null>(null);
 
@@ -2909,20 +2911,29 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
     let cancelled = false;
     setHtmlAssetAuthReadyKey('');
-    void refreshRuntimeUrlAuthToken(getRuntimeApiBaseUrl())
-      .then((token) => {
-        if (!cancelled && token) {
-          setHtmlAssetAuthReadyKey(htmlAssetAuthKey);
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setFileError(error instanceof Error ? error.message : t('filesView.error.readFileFailed'));
-        }
-      });
+
+    const refreshToken = () => {
+      clearRuntimeUrlAuthToken();
+      void refreshRuntimeUrlAuthToken(getRuntimeApiBaseUrl())
+        .then((token) => {
+          if (!cancelled && token) {
+            setHtmlAssetAuthReadyKey(htmlAssetAuthKey);
+            setHtmlPreviewNonce((n) => n + 1);
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            setFileError(error instanceof Error ? error.message : t('filesView.error.readFileFailed'));
+          }
+        });
+    };
+
+    refreshToken();
+    const id = setInterval(refreshToken, 45_000);
 
     return () => {
       cancelled = true;
+      clearInterval(id);
     };
   }, [htmlAssetAuthKey, t]);
 
@@ -3834,6 +3845,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
                   if (!basePath) return fileContent;
                   return fileContent.replace(/<head([^>]*)>/i, `<head$1><base href="${basePath}">`);
                 })() : undefined}
+                key={htmlPreviewNonce}
                 className="w-full h-full border-none"
                 sandbox="allow-scripts allow-same-origin allow-forms"
                 title={t('filesView.editor.htmlPreviewTitle')}


### PR DESCRIPTION
## Summary

The HTML file preview in the right sidebar cycles between showing the page and displaying "authentication required" every ~50 seconds. Image and PDF previews have the exact same issue.

## Root cause

1. URL auth tokens (`oc_url_token`) have a 60-second server TTL with a 10-second client-side skew window, making them effectively valid for ~50 seconds
2. The token was fetched **once** at mount time and never refreshed periodically
3. When the token expired inside the skew window, `getRuntimeUrlAuthTokenSync()` returned `""` and fired a fire-and-forget async refresh — but nothing triggered a re-render when the new token arrived
4. The iframe/img `src` kept the URL without `oc_url_token`, the server returned 401, and the preview showed "authentication required"
5. Eventually an unrelated file-poll re-render (every 2s) would pick up the new token, restoring the preview — until the next expiry, creating the cycling pattern

## Fix

- Added a 45-second `setInterval` in all three asset auth effects (HTML, image, PDF)
- Each tick calls `clearRuntimeUrlAuthToken()` then `refreshRuntimeUrlAuthToken()` to force a fresh token fetch
- A nonce counter is incremented on each successful refresh, used as `key` on the iframe/img to force React to remount with the new authenticated URL
- The image effect previously swallowed errors silently (`.catch(() => {})`) — now reports them properly
- All three effects clear stale `fileError` on successful refresh so transient network errors don't permanently block the preview
- Intervals are properly cleaned up on unmount and file change

## Validation

- `diff` reviewed — only `packages/ui/src/components/views/FilesView.tsx` changed
- Pre-existing type-check errors are unrelated (missing `virtua`, `shiki`, `cron-parser` module declarations)
- No new dependencies or architectural changes