### PR TITLE
ci: add Build Windows Electron workflow

### DIFF
--- a/.github/workflows/build-windows-electron.yml
+++ b/.github/workflows/build-windows-electron.yml
@@ -1,0 +1,75 @@
+name: Build Windows Electron
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to build"
+        required: false
+        default: "main"
+      retention_days:
+        description: "Artifact retention days"
+        required: false
+        default: "7"
+        type: choice
+        options:
+          - "1"
+          - "3"
+          - "7"
+          - "14"
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-electron:
+    name: Build Windows Electron x64
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build web assets
+        working-directory: packages/electron
+        run: bun run build:web-assets
+
+      - name: Bundle Electron main process
+        working-directory: packages/electron
+        run: bun run bundle:main
+
+      - name: Rebuild native modules for Electron
+        working-directory: packages/electron
+        shell: bash
+        run: node ./scripts/rebuild-native.mjs
+
+      - name: Build unsigned Windows installer
+        working-directory: packages/electron
+        shell: bash
+        run: node ./scripts/package.mjs --win --x64 --publish=never
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: openchamber-windows-x64
+          path: |
+            packages/electron/dist/*.exe
+            packages/electron/dist/*.blockmap
+            packages/electron/dist/latest.yml
+          if-no-files-found: error
+          retention-days: ${{ fromJSON(inputs.retention_days) }}

--- a/.github/workflows/build-windows-electron.yml
+++ b/.github/workflows/build-windows-electron.yml
@@ -28,17 +28,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.14"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
 
@@ -64,7 +64,7 @@ jobs:
         run: node ./scripts/package.mjs --win --x64 --publish=never
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openchamber-windows-x64
           path: |

--- a/.github/workflows/build-windows-electron.yml
+++ b/.github/workflows/build-windows-electron.yml
@@ -1,12 +1,12 @@
 name: Build Windows Electron
+run-name: Build Windows Electron (${{ inputs.ref || github.ref_name }})
 
 on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Branch, tag, or commit SHA to build"
+        description: "Optional override. Leave empty to build the branch selected in Run workflow."
         required: false
-        default: "main"
       retention_days:
         description: "Artifact retention days"
         required: false
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
Adds a reusable workflow to build and package OpenChamber for Windows x64 (unsigned), triggered via `workflow_dispatch`.

- Builds on `windows-2022` with Bun + Node.js 22
- Bundles web assets, Electron main process, rebuilds native modules
- Runs `package.mjs --win --x64 --publish=never`
- Uploads `.exe`, `.blockmap`, and `latest.yml` as artifacts

Allows maintainers to produce test builds on demand without a local Windows environment.