### PR TITLE
Preserve archived session cache entries

### DIFF
--- a/packages/ui/src/sync/__tests__/event-reducer.test.ts
+++ b/packages/ui/src/sync/__tests__/event-reducer.test.ts
@@ -199,6 +199,50 @@ describe("applyDirectoryEvent", () => {
     expect((draft.session_status.ses_1 as Extract<SessionStatus, { type: "retry" }>).attempt).toBe(2)
   })
 
+  test("archives sessions without dropping materialized messages", () => {
+    const message = { id: "msg_1", sessionID: "ses_1", role: "assistant", time: { created: 2 } } as never
+    const part = { id: "prt_1", messageID: "msg_1", sessionID: "ses_1", type: "text", text: "hello" } as Part
+    const draft = state({
+      sessionTotal: 1,
+      session: [
+        { id: "ses_1", time: { created: 1, updated: 2 } } as never,
+      ],
+      message: { ses_1: [message] },
+      part: { msg_1: [part] },
+      todo: { ses_1: [] },
+      session_status: { ses_1: { type: "idle" } as SessionStatus },
+      session_diff: { ses_1: [] },
+      permission: { ses_1: [{ id: "perm_1", sessionID: "ses_1" } as PermissionRequest] },
+      question: { ses_1: [{ id: "ques_1", sessionID: "ses_1" } as QuestionRequest] },
+    })
+    let clearedTodo: { sessionID: string; todos: unknown } | undefined
+
+    const result = applyDirectoryEvent(
+      draft,
+      {
+        type: "session.updated",
+        properties: { info: { id: "ses_1", time: { created: 1, updated: 3, archived: 4 } } },
+      } as Event,
+      {
+        onSetSessionTodo: (sessionID, todos) => {
+          clearedTodo = { sessionID, todos }
+        },
+      },
+    )
+
+    expect(result).toBe(true)
+    expect(draft.session).toEqual([])
+    expect(draft.sessionTotal).toBe(0)
+    expect(draft.message.ses_1).toEqual([message])
+    expect(draft.part.msg_1).toEqual([part])
+    expect(draft.todo.ses_1).toBeUndefined()
+    expect(draft.session_status.ses_1).toBeUndefined()
+    expect(draft.session_diff.ses_1).toBeUndefined()
+    expect(draft.permission.ses_1).toBeUndefined()
+    expect(draft.question.ses_1).toBeUndefined()
+    expect(clearedTodo).toEqual({ sessionID: "ses_1", todos: undefined })
+  })
+
   test("updates permission request arrays immutably", () => {
     const initialPermissions = [
       { id: "perm_1", sessionID: "ses_1" } as PermissionRequest,

--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -230,7 +230,7 @@ export function applyDirectoryEvent(
 
       if (info.time.archived) {
         if (result.found) sessions.splice(result.index, 1)
-        cleanupSessionCaches(draft, info.id, callbacks?.onSetSessionTodo)
+        cleanupArchivedSessionCaches(draft, info.id, callbacks?.onSetSessionTodo)
         if (!info.parentID) draft.sessionTotal = Math.max(0, draft.sessionTotal - 1)
         return true
       }
@@ -554,4 +554,18 @@ function cleanupSessionCaches(
   if (!sessionID) return
   setSessionTodo?.(sessionID, undefined)
   dropSessionCaches(draft, [sessionID])
+}
+
+function cleanupArchivedSessionCaches(
+  draft: State,
+  sessionID: string,
+  setSessionTodo?: (sessionID: string, todos: Todo[] | undefined) => void,
+) {
+  if (!sessionID) return
+  setSessionTodo?.(sessionID, undefined)
+  delete draft.todo[sessionID]
+  delete draft.session_diff[sessionID]
+  delete draft.session_status[sessionID]
+  delete draft.permission[sessionID]
+  delete draft.question[sessionID]
 }


### PR DESCRIPTION
Fixes #1577.

## Summary
- Preserve archived session cache entries during event reducer cleanup.
- Add regression coverage for archived sessions so AI responses remain available after archive transitions.

## Verification
- `bun test packages/ui/src/sync/__tests__/event-reducer.test.ts`

`bun run type-check:ui` was started but stopped after running too long in the local handover environment.
