### PR TITLE
fix(providers): hide/show all buttons respect active model filter

### DIFF
--- a/packages/ui/src/components/sections/providers/ProvidersPage.tsx
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.tsx
@@ -777,6 +777,10 @@ export const ProvidersPage: React.FC = () => {
     return name.toLowerCase().includes(query) || id.toLowerCase().includes(query);
   });
 
+  const visibleModelIds = filteredModels
+    .map((model) => (typeof model?.id === 'string' ? model.id : ''))
+    .filter((id) => id.length > 0);
+
   return (
     <ScrollableOverlay outerClassName="h-full" className="w-full">
       <div className="mx-auto w-full max-w-3xl p-3 sm:p-6 sm:pt-8">
@@ -994,11 +998,12 @@ export const ProvidersPage: React.FC = () => {
                 variant="outline"
                 size="xs"
                 className="!font-normal"
+                disabled={visibleModelIds.length === 0}
                 onClick={() => {
-                  const allIds = providerModels
-                    .map((model) => (typeof model?.id === 'string' ? model.id : ''))
-                    .filter((id) => id.length > 0);
-                  hideAllModels(selectedProvider.id, allIds);
+                  if (visibleModelIds.length === 0) {
+                    return;
+                  }
+                  hideAllModels(selectedProvider.id, visibleModelIds);
                 }}
               >
                 {t('settings.providers.page.actions.hideAll')}
@@ -1007,7 +1012,13 @@ export const ProvidersPage: React.FC = () => {
                 variant="outline"
                 size="xs"
                 className="!font-normal"
-                onClick={() => showAllModels(selectedProvider.id)}
+                disabled={visibleModelIds.length === 0}
+                onClick={() => {
+                  if (visibleModelIds.length === 0) {
+                    return;
+                  }
+                  showAllModels(selectedProvider.id, visibleModelIds);
+                }}
               >
                 {t('settings.providers.page.actions.showAll')}
               </Button>

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -730,7 +730,7 @@ interface UIStore {
   toggleHiddenModel: (providerID: string, modelID: string) => void;
   isHiddenModel: (providerID: string, modelID: string) => boolean;
   hideAllModels: (providerID: string, modelIDs: string[]) => void;
-  showAllModels: (providerID: string) => void;
+  showAllModels: (providerID: string, modelIDs?: string[]) => void;
   toggleModelProviderCollapsed: (providerID: string) => void;
   setModelProvidersCollapsed: (providerIDs: string[], collapsed: boolean) => void;
   isFavoriteModel: (providerID: string, modelID: string) => boolean;
@@ -1772,10 +1772,20 @@ export const useUIStore = create<UIStore>()(
           });
         },
 
-        showAllModels: (providerID) => {
-          set((state) => ({
-            hiddenModels: state.hiddenModels.filter((item) => item.providerID !== providerID),
-          }));
+        showAllModels: (providerID, modelIDs) => {
+          set((state) => {
+            if (modelIDs === undefined) {
+              return {
+                hiddenModels: state.hiddenModels.filter((item) => item.providerID !== providerID),
+              };
+            }
+            const idsSet = new Set(modelIDs.filter((id) => typeof id === 'string' && id.length > 0));
+            return {
+              hiddenModels: state.hiddenModels.filter(
+                (item) => !(item.providerID === providerID && idsSet.has(item.modelID))
+              ),
+            };
+          });
         },
 
         toggleModelProviderCollapsed: (providerID) => {


### PR DESCRIPTION
## Summary

Fix #1691 — the "Hide all" and "Show all" actions on the Providers page now respect the active model search filter.

Previously, clicking either button operated on the **entire** provider model list, ignoring the `modelQuery` filter and silently affecting models the user could not see. This was most painful for providers with many models (e.g. OpenRouter), where a single click could hide hundreds of unrelated models.

## Changes

- `ProvidersPage.tsx`
  - Derive `visibleModelIds` from the search-filtered list (`filteredModels`).
  - Pass it to both `hideAllModels` and `showAllModels`.
  - Disable the buttons when the filter has no matches, and short-circuit `onClick` to avoid silently un-hiding everything on an empty filter (regression found during PR review).
- `useUIStore.ts`
  - `showAllModels(providerID)` gains an optional `modelIDs?: string[]` argument. When provided, only the supplied models are un-hidden. When omitted, the previous behavior (un-hide all models for the provider) is preserved for back-compat.

## Validation

- `bunx tsc --noEmit` local repro fails on missing `@types/dom-speech-recognition` and `baseUrl` deprecation — both reproduce on a clean `origin/main` checkout (pre-existing, unrelated to this diff).
- `pr checks` and `pr review` workflows on PR #1704 are the canonical signal; both passed before the guard amend and are re-running now.
- Manual: filter to a subset → click "Hide all" / "Show all" → only filtered models are affected.
- Edge: empty filter result → buttons are disabled and no store mutation occurs.

## Out of scope

- The issue's "alternative" suggestions (rename buttons to `hide all provider models` / split into `hide filtered`) are deliberately **not** addressed here. This PR keeps the existing button labels and intent; the second-line guard is the smallest correct change.