### PR TITLE
fix(shortcuts): remove Tab as default agent cycle shortcut

### DIFF
--- a/packages/ui/src/lib/shortcuts.ts
+++ b/packages/ui/src/lib/shortcuts.ts
@@ -300,7 +300,7 @@ const SHORTCUT_ACTIONS: ReadonlyArray<ShortcutAction> = [
   },
   {
     id: 'cycle_agent',
-    defaultCombo: 'tab',
+    defaultCombo: '',
     label: 'Cycle agent',
     description: 'Cycle agent while the model selector is open',
     customizable: true,


### PR DESCRIPTION
Fix #1440