### PR TITLE
fix: stabilize Electron dev HMR startup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/electron": {
       "name": "@openchamber/electron",
-      "version": "1.13.0",
+      "version": "1.13.2",
       "dependencies": {
         "@openchamber/web": "workspace:*",
         "electron-context-menu": "^4.1.2",
@@ -114,7 +114,7 @@
     },
     "packages/ui": {
       "name": "@openchamber/ui",
-      "version": "1.13.0",
+      "version": "1.13.2",
       "dependencies": {
         "@base-ui/react": "^1.4.0",
         "@codemirror/autocomplete": "^6.20.0",
@@ -214,7 +214,7 @@
     },
     "packages/vscode": {
       "name": "openchamber",
-      "version": "1.13.0",
+      "version": "1.13.2",
       "dependencies": {
         "@openchamber/ui": "workspace:*",
         "@opencode-ai/sdk": "^1.17.7",
@@ -237,7 +237,7 @@
     },
     "packages/web": {
       "name": "@openchamber/web",
-      "version": "1.13.0",
+      "version": "1.13.2",
       "bin": {
         "openchamber": "./bin/cli.js",
       },
@@ -309,6 +309,7 @@
         "react-dom": "^19.1.1",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "shiki": "^3.23.0",
         "sonner": "^2.0.7",
         "strip-json-comments": "^5.0.3",
         "supertest": "^7.2.2",
@@ -3378,8 +3379,6 @@
     "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@npmcli/agent/socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
-
-    "@openchamber/ui/ghostty-web": ["ghostty-web@0.4.0", "", {}, "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg=="],
 
     "@openchamber/web/cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
 

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -1679,7 +1679,7 @@ const switchToHostById = async (rawId) => {
   let apiBaseUrl = null;
   let clientToken = '';
   if (id === LOCAL_HOST_ID) {
-    targetUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
+    targetUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.localOrigin || state.sidecarUrl);
     apiBaseUrl = state.sidecarUrl;
     clientToken = readDesktopLocalClientToken();
   } else {
@@ -2178,7 +2178,7 @@ const openMainWindow = async () => {
   }
 
   const config = readDesktopHostsConfig();
-  const localUiUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
+  const localUiUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.localOrigin || state.sidecarUrl);
   const host = config.defaultHostId && config.defaultHostId !== LOCAL_HOST_ID
     ? config.hosts.find((entry) => entry.id === config.defaultHostId)
     : null;
@@ -2410,7 +2410,7 @@ const resolveInitialUrl = async () => {
   state.sidecarUrl = localUrl;
   const localAvailable = Boolean(localUrl);
 
-  const localOrigin = new URL(localUrl).origin;
+  const localOrigin = new URL(localUiUrl).origin;
   let initialUrl = localUiUrl;
   let apiBaseUrl = localUrl;
   let clientToken = readDesktopLocalClientToken();
@@ -3626,7 +3626,7 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
 
     case 'desktop_new_window': {
       const config = readDesktopHostsConfig();
-      const localUiUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
+      const localUiUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.localOrigin || state.sidecarUrl);
       let targetUrl = localUiUrl;
       let runtimeConfig = {
         apiBaseUrl: state.sidecarUrl || state.localOrigin || '',

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "dev": "bun run build:watch",
-    "dev:server": "bun server/index.js --port ${OPENCHAMBER_PORT:-3001}",
-    "dev:server:watch": "nodemon --watch server --ext js --exec \"bun server/index.js --port ${OPENCHAMBER_PORT:-3001}\"",
+    "dev:server": "node ./scripts/dev-server.mjs",
+    "dev:server:watch": "nodemon --watch server --ext js --exec \"node ./scripts/dev-server.mjs\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "type-check": "tsc --noEmit",
@@ -90,6 +90,7 @@
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "shiki": "^3.23.0",
     "sonner": "^2.0.7",
     "strip-json-comments": "^5.0.3",
     "tailwind-merge": "^3.3.1",

--- a/packages/web/scripts/dev-server.mjs
+++ b/packages/web/scripts/dev-server.mjs
@@ -9,13 +9,31 @@ const child = spawn('bun', ['server/index.js', '--port', port], {
 });
 
 let shuttingDown = false;
+let shutdownTimer = null;
+
+const scheduleForcedExit = (exitCode) => {
+  if (shutdownTimer) {
+    return;
+  }
+  shutdownTimer = setTimeout(() => {
+    process.exit(exitCode);
+  }, 5000);
+  shutdownTimer.unref?.();
+};
 
 const forwardSignal = (signal) => {
   if (shuttingDown || child.exitCode !== null || child.signalCode !== null) {
     return;
   }
   shuttingDown = true;
-  child.kill(signal);
+  try {
+    child.kill(signal);
+  } catch (error) {
+    if (error?.code !== 'ESRCH') {
+      throw error;
+    }
+  }
+  scheduleForcedExit(signal === 'SIGINT' ? 130 : signal === 'SIGHUP' ? 129 : 143);
 };
 
 for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
@@ -23,6 +41,10 @@ for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
 }
 
 child.on('exit', (code, signal) => {
+  if (shutdownTimer) {
+    clearTimeout(shutdownTimer);
+    shutdownTimer = null;
+  }
   if (signal) {
     process.kill(process.pid, signal);
     return;

--- a/packages/web/scripts/dev-server.mjs
+++ b/packages/web/scripts/dev-server.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const port = process.env.OPENCHAMBER_PORT || '3001';
+const child = spawn('bun', ['server/index.js', '--port', port], {
+  cwd: new URL('..', import.meta.url),
+  stdio: 'inherit',
+  env: process.env,
+});
+
+let shuttingDown = false;
+
+const forwardSignal = (signal) => {
+  if (shuttingDown || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  shuttingDown = true;
+  child.kill(signal);
+};
+
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => forwardSignal(signal));
+}
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error('[web:dev-server] failed to start bun server:', error);
+  process.exit(1);
+});

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -76,7 +76,7 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(packageJson.version),
   },
   optimizeDeps: {
-    include: ['@opencode-ai/sdk/v2'],
+    include: ['@opencode-ai/sdk/v2', 'shiki'],
   },
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary

This PR fixes several Electron dev-mode startup issues that were breaking or degrading the HMR workflow:

- fixes Windows dev server port handoff so the HMR proxy targets the actual backend port
- fixes Electron local-origin detection so the HMR UI is treated as a trusted local renderer for desktop IPC
- prevents a second Vite reload during startup by making `shiki` resolvable from the web workspace and pre-optimizing it up front

## Changes

- added `packages/web/scripts/dev-server.mjs` to launch the web dev server with cross-platform `OPENCHAMBER_PORT` handling
- updated `packages/web/package.json` dev scripts to use the Node wrapper instead of Unix-only shell expansion
- updated `packages/electron/main.mjs` so dev HMR uses the local UI origin as the trusted local renderer origin while keeping the local API URL separate
- updated `packages/web/vite.config.ts` to pre-optimize `shiki`
- added `shiki` to `packages/web/package.json` so Vite can resolve it from the web workspace during dependency optimization
- refreshed `bun.lock`

## Why

Before this change:

- Windows dev startup could launch the backend on `3000` while Vite proxied to `3901` or `3903`
- Electron HMR pages loaded from `http://127.0.0.1:5173` were incorrectly rejected by the desktop IPC local-origin gate
- the first use of the markdown Shiki worker caused Vite to discover `shiki` late and force a full reload after initial render

After this change:

- the backend and HMR proxy agree on the same port across platforms
- Electron dev HMR pages can use desktop IPC like the packaged local UI
- `shiki` is optimized during startup instead of triggering a follow-up reload later

## Validation

- ran `node --check packages/electron/main.mjs`
- ran `node --check packages/web/scripts/dev-server.mjs`
- ran `bun run type-check` in `packages/web`
- ran `bun install`
- manually verified `bun run electron:dev` now:
  - starts the backend on the expected HMR API port
  - no longer rejects desktop IPC from the HMR UI origin
  - no longer hits the delayed `shiki` optimize-and-reload cycle

## User Impact

- Electron dev mode is more reliable on Windows
- HMR startup behaves consistently with packaged local UI trust rules
- developers avoid an unnecessary reload shortly after the app first renders