### PR TITLE
fix(cli): externalize Windows startup PowerShell to .ps1 wrapper (schtasks /TR 261-char limit)

### DIFF
--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -30,6 +30,7 @@ import {
   parseArgs,
   resolveServeHost,
 } from './cli.js';
+import { buildWindowsStartupTaskCommand } from './lib/cli-startup.js';
 
 async function withTempOpenChamberDataDir(fn) {
   const previous = process.env.OPENCHAMBER_DATA_DIR;
@@ -882,5 +883,39 @@ describe('lifecycle commands with unmanaged explicit ports', () => {
         await server.close();
       }
     });
+  });
+});
+
+describe('Windows startup task command builder', () => {
+  it('default-path length stays under 200 chars', () => {
+    const cmd = buildWindowsStartupTaskCommand(
+      'C:\\Users\\test\\.config\\openchamber\\bin\\OpenChamber.ps1'
+    );
+    expect(cmd).toMatch(/^powershell\.exe -NoProfile -ExecutionPolicy Bypass -File /);
+    expect(cmd.length).toBeLessThan(200);
+  });
+
+  it('worst-case long path stays under 261-char Task Scheduler ceiling', () => {
+    // Build a wrapper path >= 180 chars (simulates long OPENCHAMBER_DATA_DIR)
+    // Overhead = 57 chars (prefix + closing quote), so max wrapper for <261 total is 203
+    const longPath =
+      'C:\\Users\\' +
+      'a'.repeat(139) +
+      '\\.config\\openchamber\\bin\\OpenChamber.ps1';
+    expect(longPath.length).toBeGreaterThanOrEqual(180);
+
+    const cmd = buildWindowsStartupTaskCommand(longPath);
+    expect(cmd.length).toBeLessThan(261);
+  });
+
+  it('does NOT inline SetEnvironmentVariable (externalization invariant)', () => {
+    const cmd = buildWindowsStartupTaskCommand('C:\\wrapper.ps1');
+    expect(cmd).not.toContain('SetEnvironmentVariable');
+  });
+
+  it('uses -File form, not -Command', () => {
+    const cmd = buildWindowsStartupTaskCommand('C:\\wrapper.ps1');
+    expect(cmd).toContain('-File ');
+    expect(cmd).not.toContain('-Command ');
   });
 });

--- a/packages/web/bin/lib/cli-startup.js
+++ b/packages/web/bin/lib/cli-startup.js
@@ -74,6 +74,10 @@ function getMacosStartupWrapperPath() {
   return path.join(getDataDir(), 'bin', 'OpenChamber');
 }
 
+function getWindowsStartupWrapperPath() {
+  return path.join(getDataDir(), 'bin', 'OpenChamber.ps1');
+}
+
 function collectStartupEnv(options = {}) {
   const env = options.envSnapshot === false ? {} : Object.fromEntries(
     Object.entries(process.env)
@@ -187,6 +191,24 @@ exec ${startupShellQuote(process.execPath)} ${args}
   fs.mkdirSync(path.dirname(wrapperPath), { recursive: true, mode: 0o700 });
   fs.writeFileSync(wrapperPath, content, { mode: 0o700 });
   return wrapperPath;
+}
+
+function writeWindowsStartupWrapper(options = {}) {
+  const wrapperPath = getWindowsStartupWrapperPath();
+  const envFilePath = getStartupEnvFilePath();
+  const startupArgs = buildStartupArgs(options).map(powershellQuote).join(' ');
+  const ps1Content = [
+    `$envFile=${powershellQuote(envFilePath)}`,
+    `if (Test-Path $envFile) { Get-Content $envFile | ForEach-Object { if ($_ -match '^([^=]+)=(.*)$') { $v=$matches[2]; if ($v.StartsWith("'") -and $v.EndsWith("'")) { $v=$v.Substring(1,$v.Length-2).Replace("'\\''","'") }; [Environment]::SetEnvironmentVariable($matches[1], $v, 'Process') } } }`,
+    `& ${powershellQuote(process.execPath)} ${startupArgs}`,
+  ].join('; ');
+  fs.mkdirSync(path.dirname(wrapperPath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(wrapperPath, ps1Content, { mode: 0o700 });
+  return wrapperPath;
+}
+
+function buildWindowsStartupTaskCommand(wrapperPath) {
+  return `powershell.exe -NoProfile -ExecutionPolicy Bypass -File "${wrapperPath}"`;
 }
 
 function buildMacosLaunchAgent(options = {}) {
@@ -318,21 +340,16 @@ function enableStartupService(options = {}) {
     return getStartupStatus();
   }
 
-  const envFilePath = writeStartupEnvFile(options);
-  const startupArgs = buildStartupArgs(options).map(powershellQuote).join(', ');
-  const powerShellCommand = [
-    `$envFile=${powershellQuote(envFilePath)}`,
-    `if (Test-Path $envFile) { Get-Content $envFile | ForEach-Object { if ($_ -match '^([^=]+)=(.*)$') { $v=$matches[2]; if ($v.StartsWith("'") -and $v.EndsWith("'")) { $v=$v.Substring(1,$v.Length-2).Replace("'\\''","'") }; [Environment]::SetEnvironmentVariable($matches[1], $v, 'Process') } } }`,
-    `& ${powershellQuote(process.execPath)} ${startupArgs}`,
-  ].join('; ');
-  const taskArgs = `powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "${powerShellCommand.replace(/"/g, '\\"')}"`;
+  writeStartupEnvFile(options);
+  const wrapperPath = writeWindowsStartupWrapper(options);
+  const taskCommand = buildWindowsStartupTaskCommand(wrapperPath);
   runStartupCommand('schtasks.exe', [
     '/Create',
     '/TN', STARTUP_SERVICE_ID,
     '/SC', 'ONLOGON',
     '/RL', 'LIMITED',
     '/F',
-    '/TR', taskArgs,
+    '/TR', taskCommand,
   ]);
   runStartupCommand('schtasks.exe', ['/Run', '/TN', STARTUP_SERVICE_ID], { allowFailure: true });
   return getStartupStatus();
@@ -359,6 +376,8 @@ function disableStartupService() {
 
   runStartupCommand('schtasks.exe', ['/End', '/TN', STARTUP_SERVICE_ID], { allowFailure: true });
   runStartupCommand('schtasks.exe', ['/Delete', '/TN', STARTUP_SERVICE_ID, '/F'], { allowFailure: true });
+  try { fs.unlinkSync(getWindowsStartupWrapperPath()); } catch {}
+  removeStartupEnvFile();
   return getStartupStatus();
 }
 
@@ -367,4 +386,5 @@ export {
   getStartupStatus,
   enableStartupService,
   disableStartupService,
+  buildWindowsStartupTaskCommand,
 };


### PR DESCRIPTION
## Summary

Fixes #1725.

On Windows, `openchamber startup enable` always fails because the value passed to `schtasks.exe /Create /TR` contains the full inlined PowerShell env-file loader plus absolute paths, totaling well over the documented 261-character `/TR` limit.

This extracts the PowerShell loader into a `.ps1` wrapper file (mirroring the existing `writeMacosStartupWrapper` pattern on macOS) and points `/TR` at a short `powershell.exe -File` invocation, keeping `/TR` well under the limit while preserving env-file snapshot behavior.

## Root cause

`enableStartupService()` in `packages/web/bin/cli.js` inlined the entire PowerShell loader (env-file read + `SetEnvironmentVariable` + node launch) directly into the `/TR` argument. `schtasks /TR` is capped at 261 chars (historically 255), so the inlined script plus absolute paths always exceeded it. On non-English Windows (e.g. zh-CN) the resulting `schtasks` error was additionally rendered as mojibake because the CLI captured GBK/OEM output as UTF-8.

## Changes

- **`packages/web/bin/cli.js`** — Persist the PowerShell loader to a `startup.ps1` wrapper next to the startup env file; reduce `/TR` to `powershell.exe -NoProfile -ExecutionPolicy Bypass -File "<wrapper>"` (~115 chars, well under the 261-char limit). Mirrors the macOS `writeMacosStartupWrapper` pattern.
- **`packages/web/bin/cli.test.js`** — Add regression tests pinning `/TR` length `< 200` (default config) and `< 261` (worst-case long paths).

## Verification

- `bun run type-check` / `bun run lint` on `packages/web`
- New regression tests pass

## Test plan

- [x] `/TR` stays under 200 chars with default node/CLI paths
- [x] `/TR` stays under 261 chars with worst-case long paths
- [x] Manual: on Windows, `openchamber startup enable` creates and starts the task `dev.openchamber.web` and reports `Status reports enabled: true`