### PR TITLE
fix(behavior): read AGENTS.md before settings.json so external edits are reflected

### DIFF
--- a/packages/ui/src/components/sections/behavior/BehaviorPage.tsx
+++ b/packages/ui/src/components/sections/behavior/BehaviorPage.tsx
@@ -118,8 +118,9 @@ export const BehaviorPage: React.FC = () => {
         ]);
 
         let nextSettings: BehaviorSettingsState = DEFAULT_BEHAVIOR_SETTINGS;
+        let settingsGlobalBehaviorPrompt: string | undefined;
         if (settingsRes.ok) {
-          const data = await settingsRes.json();
+          const data = (await settingsRes.json()) as Record<string, unknown>;
           nextSettings = {
             ...nextSettings,
             responseStyleEnabled: data.responseStyleEnabled === true,
@@ -129,15 +130,22 @@ export const BehaviorPage: React.FC = () => {
               : '',
           };
           if (typeof data.globalBehaviorPrompt === 'string') {
-            nextSettings = { ...nextSettings, prompt: data.globalBehaviorPrompt };
+            settingsGlobalBehaviorPrompt = data.globalBehaviorPrompt;
           }
         }
 
-        if (!nextSettings.prompt.trim() && agentsMdRes.ok) {
+        // AGENTS.md is the source of truth for the system prompt — read it
+        // first so that external edits are always reflected. Only fall back to
+        // the persisted copy (globalBehaviorPrompt) when the file is missing
+        // or empty.
+        if (agentsMdRes.ok) {
           const agentsData = await agentsMdRes.json();
-          if (typeof agentsData.content === 'string') {
+          if (typeof agentsData.content === 'string' && agentsData.content.trim()) {
             nextSettings = { ...nextSettings, prompt: agentsData.content };
           }
+        }
+        if (!nextSettings.prompt.trim() && typeof settingsGlobalBehaviorPrompt === 'string') {
+          nextSettings = { ...nextSettings, prompt: settingsGlobalBehaviorPrompt };
         }
 
         setPrompt(nextSettings.prompt);

--- a/packages/ui/src/components/sections/behavior/BehaviorPage.tsx
+++ b/packages/ui/src/components/sections/behavior/BehaviorPage.tsx
@@ -30,6 +30,7 @@ import {
   SETTINGS_SELECT_ROW_TRIGGER_CLASS,
   SETTINGS_SELECT_SIZE,
 } from '@/components/sections/shared/SettingsSection';
+import { resolveBehaviorPrompt, type BehaviorPromptSource } from './behaviorPrompt';
 
 const agentsMdResponseSchema = z.object({
   content: z.string(),
@@ -139,21 +140,23 @@ export const BehaviorPage: React.FC = () => {
           }
         }
 
-        // AGENTS.md is the source of truth for the system prompt — read it
-        // first so that external edits are always reflected. Only fall back to
-        // the persisted copy (globalBehaviorPrompt) when the file is missing
-        // or empty.
+        // AGENTS.md is the source of truth OpenCode reads at runtime, so an
+        // existing file is authoritative even when it is empty. The persisted
+        // copy (globalBehaviorPrompt) is only a fallback for a missing file or
+        // a failed read.
+        let promptSource: BehaviorPromptSource = { kind: 'missing' };
         if (agentsMdRes.ok) {
           const agentsData = agentsMdResponseSchema.parse(await agentsMdRes.json());
           if (abort.signal.aborted) return;
           setAgentsMdPath(agentsData.path ?? 'AGENTS.md');
-          if (agentsData.content.trim()) {
-            nextSettings = { ...nextSettings, prompt: agentsData.content };
+          if (agentsData.exists) {
+            promptSource = { kind: 'file', content: agentsData.content };
           }
         }
-        if (!nextSettings.prompt.trim() && settingsGlobalBehaviorPrompt !== undefined) {
-          nextSettings = { ...nextSettings, prompt: settingsGlobalBehaviorPrompt };
-        }
+        nextSettings = {
+          ...nextSettings,
+          prompt: resolveBehaviorPrompt(promptSource, settingsGlobalBehaviorPrompt),
+        };
 
         setPrompt(nextSettings.prompt);
         setOptimizeSystemPrompt(nextSettings.optimizeSystemPrompt);

--- a/packages/ui/src/components/sections/behavior/BehaviorPage.tsx
+++ b/packages/ui/src/components/sections/behavior/BehaviorPage.tsx
@@ -125,6 +125,7 @@ export const BehaviorPage: React.FC = () => {
         ]);
 
         let nextSettings: BehaviorSettingsState = DEFAULT_BEHAVIOR_SETTINGS;
+        let settingsGlobalBehaviorPrompt: string | undefined;
         if (data) {
           nextSettings = {
             ...nextSettings,
@@ -134,17 +135,24 @@ export const BehaviorPage: React.FC = () => {
             responseStyleCustomInstructions: data.responseStyleCustomInstructions ?? '',
           };
           if (data.globalBehaviorPrompt !== undefined) {
-            nextSettings = { ...nextSettings, prompt: data.globalBehaviorPrompt };
+            settingsGlobalBehaviorPrompt = data.globalBehaviorPrompt;
           }
         }
 
+        // AGENTS.md is the source of truth for the system prompt — read it
+        // first so that external edits are always reflected. Only fall back to
+        // the persisted copy (globalBehaviorPrompt) when the file is missing
+        // or empty.
         if (agentsMdRes.ok) {
           const agentsData = agentsMdResponseSchema.parse(await agentsMdRes.json());
           if (abort.signal.aborted) return;
           setAgentsMdPath(agentsData.path ?? 'AGENTS.md');
-          if (!nextSettings.prompt.trim()) {
+          if (agentsData.content.trim()) {
             nextSettings = { ...nextSettings, prompt: agentsData.content };
           }
+        }
+        if (!nextSettings.prompt.trim() && settingsGlobalBehaviorPrompt !== undefined) {
+          nextSettings = { ...nextSettings, prompt: settingsGlobalBehaviorPrompt };
         }
 
         setPrompt(nextSettings.prompt);

--- a/packages/ui/src/components/sections/behavior/behaviorPrompt.test.ts
+++ b/packages/ui/src/components/sections/behavior/behaviorPrompt.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveBehaviorPrompt } from './behaviorPrompt';
+
+describe('resolveBehaviorPrompt', () => {
+  test('uses an existing non-empty file over the persisted prompt', () => {
+    expect(resolveBehaviorPrompt({ kind: 'file', content: 'from file' }, 'from settings'))
+      .toBe('from file');
+  });
+
+  test('keeps an existing empty file authoritative', () => {
+    expect(resolveBehaviorPrompt({ kind: 'file', content: '' }, 'from settings'))
+      .toBe('');
+  });
+
+  test('preserves whitespace-only file content as-is', () => {
+    expect(resolveBehaviorPrompt({ kind: 'file', content: '  \n' }, 'from settings'))
+      .toBe('  \n');
+  });
+
+  test('falls back to the persisted prompt when the file is missing', () => {
+    expect(resolveBehaviorPrompt({ kind: 'missing' }, 'from settings'))
+      .toBe('from settings');
+  });
+
+  test('resolves to an empty string when neither source has content', () => {
+    expect(resolveBehaviorPrompt({ kind: 'missing' }, undefined))
+      .toBe('');
+  });
+});

--- a/packages/ui/src/components/sections/behavior/behaviorPrompt.ts
+++ b/packages/ui/src/components/sections/behavior/behaviorPrompt.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolve the behavior system prompt from the two sources that can carry it.
+ *
+ * The AGENTS.md file is the source of truth OpenCode reads at runtime, so an
+ * existing file is authoritative even when it is empty; the persisted
+ * `globalBehaviorPrompt` copy is only a fallback for a missing file or a
+ * failed read.
+ */
+
+export type BehaviorPromptSource =
+  | { readonly kind: 'file'; readonly content: string }
+  | { readonly kind: 'missing' };
+
+export function resolveBehaviorPrompt(
+  source: BehaviorPromptSource,
+  persistedPrompt: string | undefined,
+): string {
+  if (source.kind === 'file') {
+    return source.content;
+  }
+  return persistedPrompt ?? '';
+}


### PR DESCRIPTION
## Intent

External edits to `~/.config/opencode/AGENTS.md` did not show up in Settings -> Behavior. The page read `globalBehaviorPrompt` from `settings.json` first, and because every UI save wrote that field back, the AGENTS.md fallback never ran. The page showed stale text and a save could overwrite the real file.

The load path now treats AGENTS.md as the source of truth. An existing file is authoritative even when it is empty or whitespace-only, so externally clearing the file is reflected too. The persisted `globalBehaviorPrompt` is used only when the file does not exist or the read fails.

Branch history: the original fix was rebased onto current `main` (`111c4bf9d`) and adapted to the refactored load block, where `loadDesktopSettings()` replaced the direct settings fetch. A second commit makes the empty-file case authoritative and adds the regression test.

## Non-goals

- Save behavior is unchanged. The page still writes AGENTS.md through `PUT /api/behavior/agents-md` and keeps the `settings.json` copy in sync.
- No changes to the agents-md API routes, the settings registry, or the VS Code bridge.

## Affected surfaces

- `packages/ui/src/components/sections/behavior/BehaviorPage.tsx`
- `packages/ui/src/components/sections/behavior/behaviorPrompt.ts` (new, pure prompt-source resolver)
- `packages/ui/src/components/sections/behavior/behaviorPrompt.test.ts` (new)
- Web, Electron, VS Code, and mobile all render this shared component. VS Code serves AGENTS.md through its bridge with the same missing-file response, so the fallback applies there too.
- No persisted format or API contract change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Executable source change in shared UI | Smallest complete change; a small pure helper keeps the decision testable; no new dependency or entrypoint |
| `settings-ui-patterns` | The change lives on a Settings page | Logic-only; no primitive, layout, string, or search surface touched |
| `ui-api-decoupling` | Prompt data comes from the settings API and `runtimeFetch` | Keeps `loadDesktopSettings()` and the explicit route; parses the response through `agentsMdResponseSchema`; the domain decision uses a discriminated union instead of raw payload fields |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/sections/behavior/behaviorPrompt.test.ts` | 5 pass, 0 fail (non-empty file, empty file, whitespace-only file, missing file fallback, no sources) |
| `bun run --cwd packages/ui type-check` | exit 0 |
| `bun run --cwd packages/ui lint` | exit 0 |
| `bunx oxlint` on the changed files | only pre-existing anti-slop findings (BehaviorPage.tsx lines 42, 43, 72, 77, 174), none in the changed block or new files |
| `bun run dead-code` | no findings for the new file or exports; the long pre-existing backlog elsewhere is unchanged |
| CI `checks` on `9515b3d6` | pass, 7m42s: build, type-check, lint, changelog check, tests, Electron unit tests |

Not verified: an in-app manual reproduction with a real `~/.config/opencode/AGENTS.md`. The component wiring (`ok`/`exists` mapping) is covered by inspection because module mocking is banned by the anti-slop lint rules.

## Visual evidence

No layout, styling, or copy change. The only user-visible difference is which text loads into the existing textarea, covered by the focused resolver tests and the code path checks above.

## Risks and failure behavior

- AGENTS.md read failure falls back to the persisted copy, same as before.
- An existing empty file now shows empty instead of the stale copy; saving it writes that empty content, which matches what the file actually contains.
- A malformed successful response still aborts the load through the existing catch, identical to current `main`.
- Rollback is a revert of the commits; there is no stored-format or migration impact.