### PR TITLE
fix(cli): use Register-ScheduledTask for Windows startup (no admin, no /TR limit)

### DIFF
--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -2210,6 +2210,47 @@ function runStartupCommand(command, args, options = {}) {
   return result;
 }
 
+// Runs a PowerShell script in the current user's session (hidden, non-interactive).
+function runWindowsPowershell(script, options = {}) {
+  return runStartupCommand('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], options);
+}
+
+// Builds the PowerShell command the scheduled task runs: it loads the persisted
+// startup.env snapshot into the process environment, then starts the foreground
+// server under node. Used as the task action's -Command.
+function buildWindowsStartupActionCommand(options = {}) {
+  const envFilePath = getStartupEnvFilePath();
+  const startupArgs = buildStartupArgs(options).map(powershellQuote).join(', ');
+  return [
+    `$envFile=${powershellQuote(envFilePath)}`,
+    `if (Test-Path $envFile) { Get-Content $envFile | ForEach-Object { if ($_ -match '^([^=]+)=(.*)$') { $v=$matches[2]; if ($v.StartsWith("'") -and $v.EndsWith("'")) { $v=$v.Substring(1,$v.Length-2).Replace("'\\''","'") }; [Environment]::SetEnvironmentVariable($matches[1], $v, 'Process') } } }`,
+    `& ${powershellQuote(process.execPath)} ${startupArgs}`,
+  ].join('; ');
+}
+
+// Builds the Register-ScheduledTask PowerShell script that installs the
+// OpenChamber startup task for the current user WITHOUT elevation.
+// `schtasks.exe /Create /SC ONLOGON` creates a system-level (any-user-logon)
+// trigger that requires administrator rights, so non-admin `startup enable`
+// failed with Access Denied. Register-ScheduledTask with LogonType Interactive
+// + RunLevel Limited, bound to the current user, works without elevation, and
+// takes the action as an object so there is no schtasks /TR 261-char limit.
+// ExecutionTimeLimit is zero so the foreground server is not killed by Task
+// Scheduler's 72-hour default ceiling.
+function buildWindowsRegisterScheduledTaskScript({ taskName, actionCommand }) {
+  const tn = powershellQuote(taskName);
+  const actionArgument = `-NoProfile -ExecutionPolicy Bypass -Command ${powershellQuote(actionCommand)}`;
+  return [
+    `$ErrorActionPreference='Stop'`,
+    `$u=[Security.Principal.WindowsIdentity]::GetCurrent().Name`,
+    `$p=New-ScheduledTaskPrincipal -UserId $u -LogonType Interactive -RunLevel Limited`,
+    `$t=New-ScheduledTaskTrigger -AtLogOn -User $u`,
+    `$a=New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ${powershellQuote(actionArgument)}`,
+    `$s=New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero)`,
+    `Register-ScheduledTask -TaskName ${tn} -Action $a -Trigger $t -Principal $p -Settings $s -Force | Out-Null`,
+  ].join('; ');
+}
+
 function getStartupStatus() {
   const paths = getStartupServicePaths();
   if (!paths.servicePath) {
@@ -2267,23 +2308,14 @@ function enableStartupService(options = {}) {
     return getStartupStatus();
   }
 
-  const envFilePath = writeStartupEnvFile(options);
-  const startupArgs = buildStartupArgs(options).map(powershellQuote).join(', ');
-  const powerShellCommand = [
-    `$envFile=${powershellQuote(envFilePath)}`,
-    `if (Test-Path $envFile) { Get-Content $envFile | ForEach-Object { if ($_ -match '^([^=]+)=(.*)$') { $v=$matches[2]; if ($v.StartsWith("'") -and $v.EndsWith("'")) { $v=$v.Substring(1,$v.Length-2).Replace("'\\''","'") }; [Environment]::SetEnvironmentVariable($matches[1], $v, 'Process') } } }`,
-    `& ${powershellQuote(process.execPath)} ${startupArgs}`,
-  ].join('; ');
-  const taskArgs = `powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "${powerShellCommand.replace(/"/g, '\\"')}"`;
-  runStartupCommand('schtasks.exe', [
-    '/Create',
-    '/TN', STARTUP_SERVICE_ID,
-    '/SC', 'ONLOGON',
-    '/RL', 'LIMITED',
-    '/F',
-    '/TR', taskArgs,
-  ]);
-  runStartupCommand('schtasks.exe', ['/Run', '/TN', STARTUP_SERVICE_ID], { allowFailure: true });
+  writeStartupEnvFile(options);
+  const actionCommand = buildWindowsStartupActionCommand(options);
+  const registerScript = buildWindowsRegisterScheduledTaskScript({
+    taskName: STARTUP_SERVICE_ID,
+    actionCommand,
+  });
+  runWindowsPowershell(registerScript);
+  runWindowsPowershell(`Start-ScheduledTask -TaskName ${powershellQuote(STARTUP_SERVICE_ID)}`, { allowFailure: true });
   return getStartupStatus();
 }
 
@@ -2306,8 +2338,8 @@ function disableStartupService() {
     return getStartupStatus();
   }
 
-  runStartupCommand('schtasks.exe', ['/End', '/TN', STARTUP_SERVICE_ID], { allowFailure: true });
-  runStartupCommand('schtasks.exe', ['/Delete', '/TN', STARTUP_SERVICE_ID, '/F'], { allowFailure: true });
+  runWindowsPowershell(`Stop-ScheduledTask -TaskName ${powershellQuote(STARTUP_SERVICE_ID)} -ErrorAction SilentlyContinue`, { allowFailure: true });
+  runWindowsPowershell(`Unregister-ScheduledTask -TaskName ${powershellQuote(STARTUP_SERVICE_ID)} -Confirm:$false -ErrorAction SilentlyContinue`, { allowFailure: true });
   return getStartupStatus();
 }
 
@@ -5748,4 +5780,6 @@ export {
   TunnelCliError,
   EXIT_CODE,
   warnIfUnsafeFilePermissions,
+  buildWindowsStartupActionCommand,
+  buildWindowsRegisterScheduledTaskScript,
 };

--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -2239,7 +2239,21 @@ function buildWindowsStartupActionCommand(options = {}) {
 // Scheduler's 72-hour default ceiling.
 function buildWindowsRegisterScheduledTaskScript({ taskName, actionCommand }) {
   const tn = powershellQuote(taskName);
-  const actionArgument = `-NoProfile -ExecutionPolicy Bypass -Command ${powershellQuote(actionCommand)}`;
+  // The action payload mixes single and double quotes (the env-file loader uses
+  // double-quoted PowerShell strings). Task Scheduler launches powershell.exe
+  // directly via CreateProcess, whose CommandLineToArgvW tokenization treats
+  // only " as special: single quotes survive verbatim, so wrapping the script
+  // in '...' would collapse it into one inert string literal that PowerShell
+  // evaluates and discards; any literal " in the payload gets stripped/mangled.
+  // -EncodedCommand (base64 UTF-16LE) carries the script with zero quoting
+  // ambiguity and is the standard remedy for nested PowerShell quoting.
+  const encodedActionCommand = Buffer.from(actionCommand, 'utf16le').toString('base64');
+  // No -WindowStyle Hidden: some endpoint security products enforce "hidden
+  // PowerShell execution" rules that silently block scheduled tasks launching
+  // powershell.exe -WindowStyle Hidden, which would stop the server from ever
+  // starting at logon. Leaving the window visible is the reliable choice; the
+  // foreground server keeps its console open for its lifetime by design.
+  const actionArgument = `-NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodedActionCommand}`;
   return [
     `$ErrorActionPreference='Stop'`,
     `$u=[Security.Principal.WindowsIdentity]::GetCurrent().Name`,

--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 
 import { isModuleCliExecution, normalizeCliEntryPath } from './cli-entry.js';
-import { assertAuthenticatedNetworkExposure, parseArgs } from './cli.js';
+import { assertAuthenticatedNetworkExposure, parseArgs, buildWindowsStartupActionCommand, buildWindowsRegisterScheduledTaskScript } from './cli.js';
 
 describe('cli args', () => {
   it('accepts legacy daemon flags as no-ops', () => {
@@ -153,5 +153,73 @@ describe('cli entry detection', () => {
     };
 
     expect(normalizeCliEntryPath(unresolvedPath, realpath)).toBe(path.resolve(unresolvedPath));
+  });
+});
+
+describe('Windows startup scheduled task builder', () => {
+  it('registers a per-user task that does not require elevation', () => {
+    const actionCommand = buildWindowsStartupActionCommand({ port: 3000 });
+    const script = buildWindowsRegisterScheduledTaskScript({
+      taskName: 'dev.openchamber.web',
+      actionCommand,
+    });
+
+    expect(script).toContain('Register-ScheduledTask -TaskName');
+    expect(script).toContain("'dev.openchamber.web'");
+    expect(script).toContain('LogonType Interactive');
+    expect(script).toContain('RunLevel Limited');
+    expect(script).toContain('New-ScheduledTaskTrigger -AtLogOn');
+    expect(script).toContain('ExecutionTimeLimit ([TimeSpan]::Zero)');
+  });
+
+  it('does not use the legacy schtasks.exe /SC ONLOGON path', () => {
+    const script = buildWindowsRegisterScheduledTaskScript({
+      taskName: 'dev.openchamber.web',
+      actionCommand: 'noop',
+    });
+
+    expect(script).not.toMatch(/schtasks/i);
+    expect(script).not.toMatch(/\/SC\s+ONLOGON/i);
+    expect(script).not.toMatch(/\/TR\b/);
+  });
+
+  it('binds the task to the current user via interactive principal', () => {
+    const script = buildWindowsRegisterScheduledTaskScript({
+      taskName: 'dev.openchamber.web',
+      actionCommand: 'noop',
+    });
+
+    expect(script).toContain('[Security.Principal.WindowsIdentity]::GetCurrent().Name');
+    expect(script).toContain('New-ScheduledTaskPrincipal -UserId $u');
+  });
+
+  it('wraps the action as a powershell.exe command that loads env and serves', () => {
+    const actionCommand = buildWindowsStartupActionCommand({ port: 3000 });
+    const script = buildWindowsRegisterScheduledTaskScript({
+      taskName: 'dev.openchamber.web',
+      actionCommand,
+    });
+
+    expect(script).toContain("New-ScheduledTaskAction -Execute 'powershell.exe'");
+    expect(script).toContain('-NoProfile -ExecutionPolicy Bypass -Command');
+  });
+});
+
+describe('Windows startup action command', () => {
+  it('loads the persisted startup env then runs node serve with the port', () => {
+    const command = buildWindowsStartupActionCommand({ port: 3000 });
+
+    expect(command).toContain('Test-Path $envFile');
+    expect(command).toContain('Get-Content $envFile');
+    expect(command).toContain('SetEnvironmentVariable');
+    expect(command).toContain("'--port', '3000'");
+    expect(command).toContain("'serve'");
+    expect(command).toContain("'--foreground'");
+  });
+
+  it('references node to launch the cli entrypoint', () => {
+    const command = buildWindowsStartupActionCommand({ port: 4000 });
+
+    expect(command).toMatch(/&\s+'[^']+'[^;]*'serve'/);
   });
 });

--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -193,7 +193,7 @@ describe('Windows startup scheduled task builder', () => {
     expect(script).toContain('New-ScheduledTaskPrincipal -UserId $u');
   });
 
-  it('wraps the action as a powershell.exe command that loads env and serves', () => {
+  it('passes the action payload to powershell.exe via base64 -EncodedCommand', () => {
     const actionCommand = buildWindowsStartupActionCommand({ port: 3000 });
     const script = buildWindowsRegisterScheduledTaskScript({
       taskName: 'dev.openchamber.web',
@@ -201,7 +201,27 @@ describe('Windows startup scheduled task builder', () => {
     });
 
     expect(script).toContain("New-ScheduledTaskAction -Execute 'powershell.exe'");
-    expect(script).toContain('-NoProfile -ExecutionPolicy Bypass -Command');
+    expect(script).toContain('-NoProfile -ExecutionPolicy Bypass -EncodedCommand');
+    // Deliberately no -WindowStyle Hidden: it trips endpoint-security "hidden
+    // PowerShell execution" rules that silently block the task at logon.
+    // Guard against it sneaking back in.
+    expect(script).not.toMatch(/-WindowStyle\s+Hidden/);
+
+    // Regression guard: the payload must NOT be passed via a single-quote-wrapped
+    // -Command. Task Scheduler's CreateProcess tokenization keeps single quotes
+    // verbatim, so '...script...' collapses into one inert string literal that
+    // PowerShell evaluates and discards (the server would never start).
+    expect(script).not.toMatch(/-Command\s+'/);
+    // No standalone -Command switch at all now that we use -EncodedCommand.
+    expect(script).not.toMatch(/\s-Command\s/);
+
+    // The encoded command must round-trip back to the original action payload
+    // (UTF-16LE base64), proving the env-loading + node-launch script survives
+    // intact through the quoting layers.
+    const encoded = script.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/);
+    expect(encoded).not.toBeNull();
+    const decoded = Buffer.from(encoded[1], 'base64').toString('utf16le');
+    expect(decoded).toBe(actionCommand);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1725.

On Windows, `openchamber startup enable` fails for two reasons:

1. **`schtasks /TR` 261-char limit** — the inlined PowerShell env-loader + absolute paths far exceed it.
2. **`schtasks /Create /SC ONLOGON` requires elevation** — it creates a system-level (any-user-logon) trigger, so non-admin users get "Access Denied" even before the `/TR` length issue.

This PR replaces `schtasks.exe` entirely with the `Register-ScheduledTask` PowerShell cmdlet, which solves **both** problems:

- **No `/TR` limit** — the action is an object (`New-ScheduledTaskAction`), not a string argument.
- **No elevation required** — `LogonType Interactive` + `RunLevel Limited` + bound to the current user installs a per-user logon trigger that works without admin rights.
- `ExecutionTimeLimit` set to zero so Task Scheduler's 72-hour default ceiling cannot kill the foreground server.

`disableStartupService` now uses `Stop-ScheduledTask` / `Unregister-ScheduledTask`. `getStartupStatus` keeps `schtasks /Query` (works without admin for the user's own tasks).

### Supersedes #1727

#1727 proposed keeping `schtasks.exe` and externalizing the PowerShell loader into a `.ps1` wrapper file to stay under the `/TR` 261-char limit. While that works around the length issue, it **does not address the elevation problem** — `schtasks /Create /SC ONLOGON` still requires administrator rights for a system-level trigger. This PR's `Register-ScheduledTask` approach eliminates both issues with a single, more robust solution, so the two approaches are mutually exclusive.

## Changes

- **`packages/web/bin/cli.js`**
  - `enableStartupService` (Windows branch): `Register-ScheduledTask` with `LogonType Interactive` + `RunLevel Limited`, bound to `[WindowsIdentity]::GetCurrent()`. Action is a `New-ScheduledTaskAction` object — no `/TR` string limit.
  - `disableStartupService` (Windows branch): `Stop-ScheduledTask` / `Unregister-ScheduledTask`.
  - New exported helpers: `buildWindowsStartupActionCommand`, `buildWindowsRegisterScheduledTaskScript`.
  - `getStartupStatus` unchanged (keeps `schtasks /Query`).
- **`packages/web/bin/cli.test.js`** — Unit tests for the two new builder functions, pinning: per-user task (no elevation), no `schtasks`/`/SC ONLOGON`/`/TR` in the generated script, current-user principal binding, env-file loading, and node launch.

## Test plan

- [x] `bun run type-check` / `bun run lint` on `packages/web`
- [x] New unit tests pass
- [ ] Manual: on Windows, `openchamber startup enable` creates the task without admin rights and reports `enabled: true`
- [ ] Manual: `openchamber startup disable` removes the task
- [ ] Manual: `openchamber startup status` reports correct state
