### PR TITLE
fix(chat): set scroll position before paint on session-switch replay

### DIFF
--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -411,7 +411,9 @@ export const useChatAutoFollow = ({
     }, [sessionIsWorking, startFollowLoop]);
 
     // Replay a deferred restoreSnapshot once ChatViewport mounts.
-    React.useEffect(() => {
+    // useLayoutEffect ensures scroll position is set before the browser paints,
+    // preventing a visible flash of content at the wrong scroll position.
+    React.useLayoutEffect(() => {
         if (!containerEl) return;
         if (pendingInitialRestoreRef.current && pendingInitialRestoreRef.current === currentSessionId) {
             void restoreSnapshot();


### PR DESCRIPTION
## Problem

When the chat scroll container mounts after session hydration (skeleton -> ChatViewport), the deferred `restoreSnapshot` replay currently runs in `React.useEffect`, which fires **after** the browser has already painted the first frame. That first frame can show content at the wrong scroll position (e.g., scrollTop: 0) before the saved position is applied.

## Fix

Replace `React.useEffect` with `React.useLayoutEffect` in the `pendingInitialRestoreRef` replay so the scroll restore runs synchronously after DOM commit and before the browser paints.

`useLayoutEffect` runs synchronously after DOM commit, before paint. When the scroll container mounts after hydration, `restoreSnapshot` sets `scrollTop` to the bottom before the first paint, eliminating the visible flash.

## Scope

This PR is intentionally minimal — only the replay effect is changed. The full PR #1553 also added a `virtualVersion` counter to bust a stale `useVirtualizer` memo, but that fix is not applicable here because `virtua` (the current virtualizer, since #1651) does not use the `useVirtualizer` useState-based instance pattern that motivated the counter.

Adapted from openchamber/openchamber#1553 (Fix 2).

## Validation

- `bun --cwd packages/ui type-check` — no new errors in `useChatAutoFollow.ts`
- `bun --cwd packages/ui lint` — passed
- 1 file changed, +3/-1 lines