### PR TITLE
fix(cli): verify process identity in isProcessRunning to avoid stale-PID crashloop (#1721)

### DIFF
--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -2390,13 +2390,39 @@ function removeInstanceFile(instanceFilePath) {
   }
 }
 
+function readProcessCmdline(pid) {
+  if (process.platform !== 'linux') {
+    return null;
+  }
+  try {
+    // /proc/<pid>/cmdline is a NUL-delimited argv list.
+    return fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8').replace(/\0/g, ' ').trim();
+  } catch {
+    return null;
+  }
+}
+
+function isOpenchamberCmdline(cmdline) {
+  if (typeof cmdline !== 'string' || cmdline.length === 0) {
+    return false;
+  }
+  // Match the install path, not a generic "cli.js", so a recycled npm-cli.js isn't mistaken for us.
+  return cmdline.toLowerCase().includes('openchamber');
+}
+
 function isProcessRunning(pid) {
   try {
     process.kill(pid, 0);
-    return true;
   } catch {
     return false;
   }
+  // A live PID may be a recycled stranger (issue #1721): confirm identity on Linux,
+  // and fall back to liveness-only when it can't be determined.
+  const cmdline = readProcessCmdline(pid);
+  if (cmdline === null) {
+    return true;
+  }
+  return isOpenchamberCmdline(cmdline);
 }
 
 function waitForProcessExit(pid, timeoutMs) {
@@ -5734,6 +5760,8 @@ export {
   isValidTunnelDoctorResponse,
   readDesktopLocalPortFromSettings,
   getPidFilePath,
+  isProcessRunning,
+  isOpenchamberCmdline,
   resolveTunnelProviders,
   fetchTunnelProvidersFromPort,
   fetchSystemInfoFromPort,

--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import path from 'path';
+import { spawn } from 'child_process';
 import { pathToFileURL } from 'url';
 
 import { isModuleCliExecution, normalizeCliEntryPath } from './cli-entry.js';
-import { assertAuthenticatedNetworkExposure, parseArgs } from './cli.js';
+import { assertAuthenticatedNetworkExposure, isOpenchamberCmdline, isProcessRunning, parseArgs } from './cli.js';
 
 describe('cli args', () => {
   it('accepts legacy daemon flags as no-ops', () => {
@@ -153,5 +154,35 @@ describe('cli entry detection', () => {
     };
 
     expect(normalizeCliEntryPath(unresolvedPath, realpath)).toBe(path.resolve(unresolvedPath));
+  });
+});
+
+describe('isOpenchamberCmdline', () => {
+  it('accepts OpenChamber CLI and daemon cmdlines', () => {
+    expect(isOpenchamberCmdline('node /x/@openchamber/web/bin/cli.js serve')).toBe(true);
+    expect(isOpenchamberCmdline('node /x/@openchamber/web/server/index.js --port 9090')).toBe(true);
+  });
+
+  it('rejects recycled and unrelated processes (issue #1721)', () => {
+    expect(isOpenchamberCmdline('node /home/herjarsa/npm-global/bin/agentmemory')).toBe(false);
+    expect(isOpenchamberCmdline('node /usr/lib/node_modules/npm/bin/npm-cli.js install')).toBe(false);
+    expect(isOpenchamberCmdline('')).toBe(false);
+    expect(isOpenchamberCmdline(null)).toBe(false);
+  });
+});
+
+describe('isProcessRunning', () => {
+  it('returns false for a dead PID', () => {
+    expect(isProcessRunning(2147483646)).toBe(false);
+  });
+
+  it.skipIf(process.platform !== 'linux')('returns false for a live non-OpenChamber PID (issue #1721)', async () => {
+    const child = spawn('sleep', ['30'], { stdio: 'ignore' });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(isProcessRunning(child.pid)).toBe(false);
+    } finally {
+      child.kill('SIGKILL');
+    }
   });
 });


### PR DESCRIPTION
## Why

Fixes #1721.

After an ungraceful shutdown (e.g. `SIGKILL` on reboot), `removePidFile` never runs, so a stale `run/openchamber-<port>.pid` outlives the process. The kernel can recycle that PID to an unrelated process, so `isProcessRunning`'s liveness-only `process.kill(pid, 0)` succeeds and startup aborts with `OpenChamber is already running on port <port> (PID: <stale-pid>)`. Under systemd `Restart=always` this becomes an infinite reboot crashloop while the port is actually free. (Reporter saw stale PID `439` recycled to `node .../agentmemory`.)

## What

Verify process identity, not just liveness:

- Keep the `process.kill(pid, 0)` liveness check, then on Linux confirm the PID is OpenChamber via `/proc/<pid>/cmdline`.
- Where identity can't be determined (non‑Linux, or `/proc` unreadable), fall back to liveness-only, so macOS/Windows behavior is unchanged with no false negatives.
- Match the `openchamber` path segment (present in every install — `@openchamber/web` globals and the `openchamber` repo checkout — for both the foreground `bin/cli.js` and daemon `server/index.js`), so a recycled PID running e.g. `npm-cli.js` isn't mistaken for OpenChamber.

## Testing

`bun run --cwd packages/web test bin/cli.test.js` → 27 passed; `bun run lint:web` clean. Added unit tests for `isOpenchamberCmdline` (incl. the recycled `agentmemory` and `npm-cli.js` cases) plus a Linux test asserting a live `sleep` PID is reported not-running.

## Risk / limitations

Identity verification is Linux-only by design (the reported platform); macOS/Windows keep prior behavior. Cross-user recycled PIDs are handled implicitly: `process.kill(pid, 0)` throws `EPERM` before `/proc` is read.
