### PR TITLE
ci: add Build Windows Electron workflow

### DIFF
--- a/.github/workflows/build-windows-electron.yml
+++ b/.github/workflows/build-windows-electron.yml
@@ -1,0 +1,75 @@
+name: Build Windows Electron
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to build"
+        required: false
+        default: "main"
+      retention_days:
+        description: "Artifact retention days"
+        required: false
+        default: "7"
+        type: choice
+        options:
+          - "1"
+          - "3"
+          - "7"
+          - "14"
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-electron:
+    name: Build Windows Electron x64
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build web assets
+        working-directory: packages/electron
+        run: bun run build:web-assets
+
+      - name: Bundle Electron main process
+        working-directory: packages/electron
+        run: bun run bundle:main
+
+      - name: Rebuild native modules for Electron
+        working-directory: packages/electron
+        shell: bash
+        run: node ./scripts/rebuild-native.mjs
+
+      - name: Build unsigned Windows installer
+        working-directory: packages/electron
+        shell: bash
+        run: node ./scripts/package.mjs --win --x64 --publish=never
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: openchamber-windows-x64
+          path: |
+            packages/electron/dist/*.exe
+            packages/electron/dist/*.blockmap
+            packages/electron/dist/latest.yml
+          if-no-files-found: error
+          retention-days: ${{ fromJSON(inputs.retention_days) }}

--- a/.github/workflows/build-windows-electron.yml
+++ b/.github/workflows/build-windows-electron.yml
@@ -28,17 +28,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.14"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
 
@@ -64,7 +64,7 @@ jobs:
         run: node ./scripts/package.mjs --win --x64 --publish=never
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openchamber-windows-x64
           path: |

--- a/.github/workflows/build-windows-electron.yml
+++ b/.github/workflows/build-windows-electron.yml
@@ -1,12 +1,12 @@
 name: Build Windows Electron
+run-name: Build Windows Electron (${{ inputs.ref || github.ref_name }})
 
 on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Branch, tag, or commit SHA to build"
+        description: "Optional override. Leave empty to build the branch selected in Run workflow."
         required: false
-        default: "main"
       retention_days:
         description: "Artifact retention days"
         required: false
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/build-windows-electron.yml
+++ b/.github/workflows/build-windows-electron.yml
@@ -32,6 +32,51 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref_name }}
 
+      - name: Compute build naming
+        id: build_naming
+        shell: bash
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const inputRef = (process.env.INPUT_REF || '').trim();
+          const githubRefName = (process.env.GITHUB_REF_NAME || '').trim();
+          const effectiveRef = inputRef || githubRefName || 'main';
+          const comparableRef = effectiveRef.replace(/^refs\/heads\//, '');
+          const isDefaultBranch = comparableRef === 'main';
+
+          let suffix = '';
+          if (!isDefaultBranch) {
+            const refForSuffix = comparableRef.replace(/^refs\/(heads|tags)\//, '');
+            if (/^[0-9a-f]{7,40}$/i.test(refForSuffix)) {
+              suffix = refForSuffix.slice(0, 12).toLowerCase();
+            } else {
+              suffix = refForSuffix
+                .toLowerCase()
+                .replace(/[^a-z0-9._-]+/g, '-')
+                .replace(/-+/g, '-')
+                .replace(/^-|-$/g, '')
+                .slice(0, 40);
+            }
+            if (!suffix) suffix = 'custom';
+          }
+
+          const latestYmlName = isDefaultBranch ? 'latest.yml' : `latest-${suffix}.yml`;
+          const artifactName = isDefaultBranch ? 'openchamber-windows-x64' : `openchamber-windows-x64-${suffix}`;
+          const lines = [
+            `effective_ref=${effectiveRef}`,
+            `is_default_branch=${isDefaultBranch}`,
+            `suffix=${suffix}`,
+            `latest_yml_name=${latestYmlName}`,
+            `artifact_name=${artifactName}`,
+          ];
+          fs.appendFileSync(outputPath, `${lines.join('\n')}\n`);
+          NODE
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -63,13 +108,57 @@ jobs:
         shell: bash
         run: node ./scripts/package.mjs --win --x64 --publish=never
 
+      - name: Rename non-main build outputs
+        if: ${{ steps.build_naming.outputs.is_default_branch != 'true' }}
+        working-directory: packages/electron
+        shell: bash
+        env:
+          BUILD_SUFFIX: ${{ steps.build_naming.outputs.suffix }}
+          LATEST_YML_NAME: ${{ steps.build_naming.outputs.latest_yml_name }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+
+          const distDir = path.join(process.cwd(), 'dist');
+          const suffix = (process.env.BUILD_SUFFIX || '').trim();
+          const latestYmlName = (process.env.LATEST_YML_NAME || 'latest.yml').trim();
+          if (!suffix) {
+            throw new Error('BUILD_SUFFIX is required for branch build renaming');
+          }
+
+          const files = fs.readdirSync(distDir);
+          const installerName = files.find((file) => /^OpenChamber-.*-win-.*\.exe$/i.test(file) && !file.includes('.__uninstaller.'));
+          if (!installerName) {
+            throw new Error('Could not find Windows installer output in dist directory');
+          }
+
+          const renamedInstallerName = installerName.replace(/\.exe$/i, `-${suffix}.exe`);
+          fs.renameSync(path.join(distDir, installerName), path.join(distDir, renamedInstallerName));
+
+          const blockmapName = `${installerName}.blockmap`;
+          const blockmapPath = path.join(distDir, blockmapName);
+          if (fs.existsSync(blockmapPath)) {
+            fs.renameSync(blockmapPath, path.join(distDir, `${renamedInstallerName}.blockmap`));
+          }
+
+          const latestYmlPath = path.join(distDir, 'latest.yml');
+          if (fs.existsSync(latestYmlPath)) {
+            let latestContent = fs.readFileSync(latestYmlPath, 'utf8');
+            latestContent = latestContent.replaceAll(installerName, renamedInstallerName);
+            latestContent = latestContent.replaceAll(blockmapName, `${renamedInstallerName}.blockmap`);
+            fs.writeFileSync(path.join(distDir, latestYmlName), latestContent);
+            fs.rmSync(latestYmlPath);
+          }
+          NODE
+
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: openchamber-windows-x64
+          name: ${{ steps.build_naming.outputs.artifact_name }}
           path: |
             packages/electron/dist/*.exe
             packages/electron/dist/*.blockmap
-            packages/electron/dist/latest.yml
+            packages/electron/dist/${{ steps.build_naming.outputs.latest_yml_name }}
           if-no-files-found: error
           retention-days: ${{ fromJSON(inputs.retention_days) }}


### PR DESCRIPTION
## Summary
- add a manual Windows Electron build workflow
- default workflow dispatch builds to the selected branch instead of always checking out `main`
- give non-`main` builds distinct artifact filenames and `latest.yml` names so branch artifacts do not overwrite stable ones

## Context
This replaces #1696, which was closed after the branch was deleted. The branch has been restored with the follow-up workflow fixes included.

## Validation
- workflow YAML inspected locally
- confirmed the previous branch-selection bug via Actions checkout logs (`win-artifact-pr-fixes` run still checked out `main`)
