### PR TITLE
fix(worktree): hide non-matching branches during search

### DIFF
--- a/packages/ui/src/components/session/NewWorktreeDialog.tsx
+++ b/packages/ui/src/components/session/NewWorktreeDialog.tsx
@@ -1145,7 +1145,7 @@ export function NewWorktreeDialog({
                         {!hasExistingBranchQuery && existingBranchRankedGroups.otherLocal.length > 0 && (
                           <div className="space-y-2">
                             <div className="typography-small font-semibold text-foreground px-2">
-                              {hasExistingBranchQuery ? t('session.newWorktree.otherLocalBranches') : t('session.newWorktree.localBranches')}
+                              {t('session.newWorktree.localBranches')}
                             </div>
                             <div className="space-y-1">
                               {existingBranchRankedGroups.otherLocal.map((branch) => (
@@ -1177,7 +1177,7 @@ export function NewWorktreeDialog({
                         {!hasExistingBranchQuery && existingBranchRankedGroups.otherRemote.length > 0 && (
                           <div className="space-y-2">
                             <div className="typography-small font-semibold text-foreground px-2">
-                              {hasExistingBranchQuery ? t('session.newWorktree.otherRemoteBranches') : t('session.newWorktree.remoteBranches')}
+                              {t('session.newWorktree.remoteBranches')}
                             </div>
                             <div className="space-y-1">
                               {existingBranchRankedGroups.otherRemote.map((branch) => (
@@ -1404,7 +1404,7 @@ export function NewWorktreeDialog({
                         {!hasSourceBranchQuery && sourceBranchRankedGroups.otherLocal.length > 0 && (
                           <div className="space-y-2">
                             <div className="typography-small font-semibold text-foreground px-2">
-                              {hasSourceBranchQuery ? t('session.newWorktree.otherLocalBranches') : t('session.newWorktree.localBranches')}
+                              {t('session.newWorktree.localBranches')}
                             </div>
                             <div className="space-y-1">
                               {sourceBranchRankedGroups.otherLocal.map((branch) => (
@@ -1431,7 +1431,7 @@ export function NewWorktreeDialog({
                         {!hasSourceBranchQuery && sourceBranchRankedGroups.otherRemote.length > 0 && (
                           <div className="space-y-2">
                             <div className="typography-small font-semibold text-foreground px-2">
-                              {hasSourceBranchQuery ? t('session.newWorktree.otherRemoteBranches') : t('session.newWorktree.remoteBranches')}
+                              {t('session.newWorktree.remoteBranches')}
                             </div>
                             <div className="space-y-1">
                               {sourceBranchRankedGroups.otherRemote.map((branch) => (
@@ -1609,8 +1609,7 @@ export function NewWorktreeDialog({
 
                               {!hasExistingBranchQuery && existingBranchRankedGroups.otherLocal.length > 0 && (
                                 <>
-                                  {hasExistingBranchQuery && <CommandSeparator />}
-                                  <CommandGroup heading={hasExistingBranchQuery ? t('session.newWorktree.otherLocalBranches') : t('session.newWorktree.localBranches')}>
+                                  <CommandGroup heading={t('session.newWorktree.localBranches')}>
                                     {existingBranchRankedGroups.otherLocal.map((branch) => (
                                       <CommandItem
                                         key={`local-${branch}`}
@@ -1634,10 +1633,10 @@ export function NewWorktreeDialog({
 
                               {!hasExistingBranchQuery && existingBranchRankedGroups.otherRemote.length > 0 && (
                                 <>
-                                  {(existingBranchRankedGroups.otherLocal.length > 0 || hasExistingBranchQuery) && (
+                                  {existingBranchRankedGroups.otherLocal.length > 0 && (
                                     <CommandSeparator />
                                   )}
-                                  <CommandGroup heading={hasExistingBranchQuery ? t('session.newWorktree.otherRemoteBranches') : t('session.newWorktree.remoteBranches')}>
+                                  <CommandGroup heading={t('session.newWorktree.remoteBranches')}>
                                     {existingBranchRankedGroups.otherRemote.map((branch) => (
                                       <CommandItem
                                         key={`remote-${branch}`}
@@ -1845,8 +1844,7 @@ export function NewWorktreeDialog({
 
                               {!hasSourceBranchQuery && sourceBranchRankedGroups.otherLocal.length > 0 && (
                                 <>
-                                  {hasSourceBranchQuery && <CommandSeparator />}
-                                  <CommandGroup heading={hasSourceBranchQuery ? t('session.newWorktree.otherLocalBranches') : t('session.newWorktree.localBranches')}>
+                                  <CommandGroup heading={t('session.newWorktree.localBranches')}>
                                     {sourceBranchRankedGroups.otherLocal.map((branch) => (
                                       <CommandItem
                                         key={`local-${branch}`}
@@ -1865,10 +1863,10 @@ export function NewWorktreeDialog({
 
                               {!hasSourceBranchQuery && sourceBranchRankedGroups.otherRemote.length > 0 && (
                                 <>
-                                  {(sourceBranchRankedGroups.otherLocal.length > 0 || hasSourceBranchQuery) && (
+                                  {sourceBranchRankedGroups.otherLocal.length > 0 && (
                                     <CommandSeparator />
                                   )}
-                                  <CommandGroup heading={hasSourceBranchQuery ? t('session.newWorktree.otherRemoteBranches') : t('session.newWorktree.remoteBranches')}>
+                                  <CommandGroup heading={t('session.newWorktree.remoteBranches')}>
                                     {sourceBranchRankedGroups.otherRemote.map((branch) => (
                                       <CommandItem
                                         key={`remote-${branch}`}

--- a/packages/ui/src/components/session/NewWorktreeDialog.tsx
+++ b/packages/ui/src/components/session/NewWorktreeDialog.tsx
@@ -1142,7 +1142,7 @@ export function NewWorktreeDialog({
                           </div>
                         )}
 
-                        {existingBranchRankedGroups.otherLocal.length > 0 && (
+                        {!hasExistingBranchQuery && existingBranchRankedGroups.otherLocal.length > 0 && (
                           <div className="space-y-2">
                             <div className="typography-small font-semibold text-foreground px-2">
                               {hasExistingBranchQuery ? t('session.newWorktree.otherLocalBranches') : t('session.newWorktree.localBranches')}
@@ -1174,7 +1174,7 @@ export function NewWorktreeDialog({
                           </div>
                         )}
 
-                        {existingBranchRankedGroups.otherRemote.length > 0 && (
+                        {!hasExistingBranchQuery && existingBranchRankedGroups.otherRemote.length > 0 && (
                           <div className="space-y-2">
                             <div className="typography-small font-semibold text-foreground px-2">
                               {hasExistingBranchQuery ? t('session.newWorktree.otherRemoteBranches') : t('session.newWorktree.remoteBranches')}
@@ -1401,7 +1401,7 @@ export function NewWorktreeDialog({
                           </div>
                         )}
 
-                        {sourceBranchRankedGroups.otherLocal.length > 0 && (
+                        {!hasSourceBranchQuery && sourceBranchRankedGroups.otherLocal.length > 0 && (
                           <div className="space-y-2">
                             <div className="typography-small font-semibold text-foreground px-2">
                               {hasSourceBranchQuery ? t('session.newWorktree.otherLocalBranches') : t('session.newWorktree.localBranches')}
@@ -1428,7 +1428,7 @@ export function NewWorktreeDialog({
                           </div>
                         )}
 
-                        {sourceBranchRankedGroups.otherRemote.length > 0 && (
+                        {!hasSourceBranchQuery && sourceBranchRankedGroups.otherRemote.length > 0 && (
                           <div className="space-y-2">
                             <div className="typography-small font-semibold text-foreground px-2">
                               {hasSourceBranchQuery ? t('session.newWorktree.otherRemoteBranches') : t('session.newWorktree.remoteBranches')}
@@ -1607,7 +1607,7 @@ export function NewWorktreeDialog({
                                 </div>
                               )}
 
-                              {existingBranchRankedGroups.otherLocal.length > 0 && (
+                              {!hasExistingBranchQuery && existingBranchRankedGroups.otherLocal.length > 0 && (
                                 <>
                                   {hasExistingBranchQuery && <CommandSeparator />}
                                   <CommandGroup heading={hasExistingBranchQuery ? t('session.newWorktree.otherLocalBranches') : t('session.newWorktree.localBranches')}>
@@ -1632,7 +1632,7 @@ export function NewWorktreeDialog({
                                 </>
                               )}
 
-                              {existingBranchRankedGroups.otherRemote.length > 0 && (
+                              {!hasExistingBranchQuery && existingBranchRankedGroups.otherRemote.length > 0 && (
                                 <>
                                   {(existingBranchRankedGroups.otherLocal.length > 0 || hasExistingBranchQuery) && (
                                     <CommandSeparator />
@@ -1843,7 +1843,7 @@ export function NewWorktreeDialog({
                                 </div>
                               )}
 
-                              {sourceBranchRankedGroups.otherLocal.length > 0 && (
+                              {!hasSourceBranchQuery && sourceBranchRankedGroups.otherLocal.length > 0 && (
                                 <>
                                   {hasSourceBranchQuery && <CommandSeparator />}
                                   <CommandGroup heading={hasSourceBranchQuery ? t('session.newWorktree.otherLocalBranches') : t('session.newWorktree.localBranches')}>
@@ -1863,7 +1863,7 @@ export function NewWorktreeDialog({
                                 </>
                               )}
 
-                              {sourceBranchRankedGroups.otherRemote.length > 0 && (
+                              {!hasSourceBranchQuery && sourceBranchRankedGroups.otherRemote.length > 0 && (
                                 <>
                                   {(sourceBranchRankedGroups.otherLocal.length > 0 || hasSourceBranchQuery) && (
                                     <CommandSeparator />

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1549,8 +1549,6 @@ export const dict = {
   'session.newWorktree.noMatchingBranches': 'No matching branches',
   'session.newWorktree.localBranches': 'Local branches',
   'session.newWorktree.remoteBranches': 'Remote branches',
-  'session.newWorktree.otherLocalBranches': 'Other local branches',
-  'session.newWorktree.otherRemoteBranches': 'Other remote branches',
   'session.newWorktree.branchName': 'Branch Name',
   'session.newWorktree.branchNamePlaceholder': 'feature/my-awesome-feature',
   'session.newWorktree.actions.change': 'Change',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1515,8 +1515,6 @@ export const dict: Record<I18nKey, string> = {
   "session.newWorktree.noMatchingBranches": "No hay ramas coincidentes",
   "session.newWorktree.localBranches": "Ramas locales",
   "session.newWorktree.remoteBranches": "Ramas remotas",
-  "session.newWorktree.otherLocalBranches": "Otras ramas locales",
-  "session.newWorktree.otherRemoteBranches": "Otras ramas remotas",
   "session.newWorktree.branchName": "Nombre de la rama",
   "session.newWorktree.branchNamePlaceholder": "feature/my-awesome-feature",
   "session.newWorktree.actions.change": "Cambiar",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1414,8 +1414,6 @@ export const dict = {
   'session.newWorktree.noMatchingBranches': 'Aucune branche correspondante',
   'session.newWorktree.localBranches': 'Branches locales',
   'session.newWorktree.remoteBranches': 'Branches du dépôt distant',
-  'session.newWorktree.otherLocalBranches': 'Autres branches locales',
-  'session.newWorktree.otherRemoteBranches': 'Autres branches du remote',
   'session.newWorktree.branchName': 'Nom de la branche',
   'session.newWorktree.branchNamePlaceholder': 'fonctionnalité/ma-fonctionnalité-géniale',
   'session.newWorktree.actions.change': 'Changement',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1551,8 +1551,6 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.noMatchingBranches': '일치하는 브랜치가 없습니다',
   'session.newWorktree.localBranches': '로컬 브랜치',
   'session.newWorktree.remoteBranches': '리모트 브랜치',
-  'session.newWorktree.otherLocalBranches': '기타 로컬 브랜치',
-  'session.newWorktree.otherRemoteBranches': '기타 리모트 브랜치',
   'session.newWorktree.branchName': '브랜치 이름',
   'session.newWorktree.branchNamePlaceholder': 'feature/my-awesome-feature',
   'session.newWorktree.actions.change': '변경',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2354,8 +2354,6 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.newSessionTitle': 'Nowa sesja',
   'session.newWorktree.noBranchesFound': 'Nie znaleziono gałęzi',
   'session.newWorktree.noMatchingBranches': 'Brak pasujących gałęzi',
-  'session.newWorktree.otherLocalBranches': 'Pozostałe lokalne gałęzie',
-  'session.newWorktree.otherRemoteBranches': 'Pozostałe zdalne gałęzie',
   'session.newWorktree.prNumber': 'PR #{number}',
   'session.newWorktree.remoteBranches': 'Zdalne gałęzie',
   'session.newWorktree.resetToMatchBranchName': 'Zresetuj do nazwy zgodnej z gałęzią',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1515,8 +1515,6 @@ export const dict: Record<I18nKey, string> = {
   "session.newWorktree.noMatchingBranches": "Não há branches coincidentes",
   "session.newWorktree.localBranches": "Branches locais",
   "session.newWorktree.remoteBranches": "Branches remotas",
-  "session.newWorktree.otherLocalBranches": "Outras branches locais",
-  "session.newWorktree.otherRemoteBranches": "Outras branches remotas",
   "session.newWorktree.branchName": "Nome da branch",
   "session.newWorktree.branchNamePlaceholder": "feature/my-awesome-feature",
   "session.newWorktree.actions.change": "Alterar",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1515,8 +1515,6 @@ export const dict: Record<I18nKey, string> = {
   "session.newWorktree.noMatchingBranches": "Немає відповідних гілок",
   "session.newWorktree.localBranches": "Локальні гілки",
   "session.newWorktree.remoteBranches": "Віддалені гілки",
-  "session.newWorktree.otherLocalBranches": "Інші локальні гілки",
-  "session.newWorktree.otherRemoteBranches": "Інші віддалені гілки",
   "session.newWorktree.branchName": "Назва гілки",
   "session.newWorktree.branchNamePlaceholder": "feature/my-awesome-feature",
   "session.newWorktree.actions.change": "Змінити",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1515,8 +1515,6 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.noMatchingBranches': '没有匹配分支',
   'session.newWorktree.localBranches': '本地分支',
   'session.newWorktree.remoteBranches': '远程分支',
-  'session.newWorktree.otherLocalBranches': '其他本地分支',
-  'session.newWorktree.otherRemoteBranches': '其他远程分支',
   'session.newWorktree.branchName': '分支名',
   'session.newWorktree.branchNamePlaceholder': 'feature/my-awesome-feature',
   'session.newWorktree.actions.change': '更改',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1519,8 +1519,6 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.noMatchingBranches': '沒有符合分支',
   'session.newWorktree.localBranches': '本地分支',
   'session.newWorktree.remoteBranches': '遠端分支',
-  'session.newWorktree.otherLocalBranches': '其他本地分支',
-  'session.newWorktree.otherRemoteBranches': '其他遠端分支',
   'session.newWorktree.branchName': '分支名稱',
   'session.newWorktree.branchNamePlaceholder': 'feature/my-awesome-feature',
   'session.newWorktree.actions.change': '變更',


### PR DESCRIPTION
## Summary
- hide non-matching local and remote branch groups while a branch search query is active
- preserve the existing matching-results and no-match empty state behavior
- apply the same filter behavior across all four worktree branch pickers (mobile/desktop, existing/source)

## Testing
- `bun run lint:ui` ✅
- `bun run type-check:ui` ⚠️ fails on existing unrelated locale key errors in `packages/ui/src/lib/i18n/messages/{es,ko,pl,pt-BR,uk,zh-CN,zh-TW}.ts`

Closes #1736