### PR TITLE
fix: gate Bun terminal PTY backend

### DIFF
--- a/packages/web/server/lib/terminal/DOCUMENTATION.md
+++ b/packages/web/server/lib/terminal/DOCUMENTATION.md
@@ -37,7 +37,7 @@ The WebSocket path must remain in both `isUrlAuthWebSocketPath` and relay `ALLOW
 
 ## Verification
 
-Run:
+The web server can use Bun's built-in `Bun.Terminal` first when `USE_BUN_TERMINAL_PTY=true`; otherwise it falls back to `bun-pty` or `node-pty` to drive full-duplex PTY sessions.
 
 ```sh
 bun test packages/web/server/lib/terminal/runtime.test.js packages/web/server/lib/terminal/terminal-ws-protocol.test.js

--- a/packages/web/server/lib/terminal/bun-terminal-pty.js
+++ b/packages/web/server/lib/terminal/bun-terminal-pty.js
@@ -1,0 +1,92 @@
+class EventEmitter {
+  constructor() {
+    this._listeners = [];
+  }
+
+  on(callback) {
+    this._listeners.push(callback);
+    return {
+      dispose: () => {
+        const idx = this._listeners.indexOf(callback);
+        if (idx !== -1) this._listeners.splice(idx, 1);
+      },
+    };
+  }
+
+  fire(data) {
+    for (const listener of [...this._listeners]) {
+      listener(data);
+    }
+  }
+}
+
+export function spawn(file, args, opts = {}) {
+  const argv = Array.isArray(args) ? args : [];
+  const decoder = new TextDecoder('utf-8');
+  const onDataEmitter = new EventEmitter();
+  const onExitEmitter = new EventEmitter();
+  let _closing = false;
+  let _exited = false;
+  let _terminalClosed = false;
+
+  const cols = opts.cols || 80;
+  const rows = opts.rows || 24;
+  const cwd = opts.cwd || process.cwd();
+  const closeTerminal = () => {
+    if (_terminalClosed) return;
+    _terminalClosed = true;
+    try { proc.terminal?.close(); } catch { /* already closed */ }
+  };
+
+  const proc = Bun.spawn([file, ...argv], {
+    cwd,
+    env: opts.env,
+    terminal: {
+      cols,
+      rows,
+      name: opts.name || 'xterm-256color',
+      data(_terminal, data) {
+        const str = decoder.decode(data, { stream: true });
+        if (str) onDataEmitter.fire(str);
+      },
+    },
+  });
+
+  proc.exited.then((exitCode) => {
+    const remaining = decoder.decode();
+    if (remaining) onDataEmitter.fire(remaining);
+    closeTerminal();
+    if (!_exited) {
+      _exited = true;
+      onExitEmitter.fire({ exitCode, signal: proc.signalCode });
+    }
+  }).catch(() => {
+    closeTerminal();
+    if (!_exited) {
+      _exited = true;
+      onExitEmitter.fire({ exitCode: -1, signal: proc.signalCode ?? null });
+    }
+  });
+
+  return {
+    get pid() { return proc.pid; },
+    onData: (cb) => onDataEmitter.on(cb),
+    onExit: (cb) => onExitEmitter.on(cb),
+    write(data) {
+      if (_closing) return;
+      try { proc.terminal?.write(data); } catch { /* closed */ }
+    },
+    resize(cols, rows) {
+      if (_closing) return;
+      try { proc.terminal?.resize(cols, rows); } catch { /* closed */ }
+    },
+    kill(signal) {
+      if (_closing) return;
+      _closing = true;
+      const sig = signal === 'SIGKILL' ? 'SIGKILL' : 'SIGTERM';
+      try { proc.kill(sig); } catch { closeTerminal(); }
+    },
+    pause() {},
+    resume() {},
+  };
+}

--- a/packages/web/server/lib/terminal/bun-terminal-pty.js
+++ b/packages/web/server/lib/terminal/bun-terminal-pty.js
@@ -86,6 +86,7 @@ export function spawn(file, args, opts = {}) {
       const sig = signal === 'SIGKILL' ? 'SIGKILL' : 'SIGTERM';
       try { proc.kill(sig); } catch { closeTerminal(); }
     },
+    // Bun.Terminal exposes write/resize/close, but no native pause/resume hook.
     pause() {},
     resume() {},
   };

--- a/packages/web/server/lib/terminal/runtime.js
+++ b/packages/web/server/lib/terminal/runtime.js
@@ -40,9 +40,14 @@ export function createTerminalRuntime({
   let wsServer = new WebSocketServer({ noServer: true, maxPayload: TERMINAL_WS_MAX_PAYLOAD_BYTES });
   const shellResolver = createTerminalShellResolver({ fs, path, searchPathFor, isExecutable, buildAugmentedPath });
 
+  const useBunTerminalPty = String(process.env.USE_BUN_TERMINAL_PTY || '').trim().toLowerCase() === 'true';
+
   const getPtyProvider = async () => {
     if (!ptyProviderPromise) {
       ptyProviderPromise = loadPtyProvider ? loadPtyProvider() : (async () => {
+        if (useBunTerminalPty && typeof Bun.Terminal !== 'undefined') {
+          try { const pty = await import('./bun-terminal-pty.js'); return { spawn: pty.spawn, backend: 'bun-terminal' }; } catch { /* fall through */ }
+        }
         if (typeof globalThis.Bun !== 'undefined') {
           try { const pty = await import('bun-pty'); return { spawn: pty.spawn, backend: 'bun-pty' }; } catch { /* fall through */ }
         }


### PR DESCRIPTION
Found the likely cause for #1346: 

portable-pty's close_random_fds() closes the Rust exec-error pipe on Linux, which then corrupts glibc's posix_spawn error reporting in bash sub-process spawning. This was filed as portable-pty issue #7742 but hasn't been fixed in bun-pty's version yet. 

Beyond filing a issue with bun-pty to upgrade, I think moving towards `bun.terminal` may be better as its native to bun. I am not sure the the full impact, and cannot test on MAC. so to be safe I have gated the use of bun.terminal behind a environment variable for now until more people have tried it out. At which point we can remove the environment variable and bun-pty dependencies. 

Tested on Linux that this does in fact overcome issue #1346. With env `USE_BUN_TERMINAL_PTY=true` enabled, everything passes, with it off, I encounter issue #1346 . Also tested the change on Windows. on or off, bun commands are successful - no change as expected. 
