### PR TITLE
fix(electron): gracefully stop server before desktop quit

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -161,6 +161,7 @@ const DISCORD_INVITE_URL = 'https://discord.gg/ZYRSdnwwKA';
 const INSTALLED_APPS_CACHE_TTL_SECS = 60 * 60 * 24;
 const INSTALLED_APPS_CACHE_FILE = 'discovered-apps.json';
 const OPENCODE_SHUTDOWN_GRACE_MS = 100;
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10_000;
 
 const { autoUpdater } = updaterPkg;
 
@@ -223,14 +224,25 @@ const quitConfirmationMessage = () => {
   return `OpenChamber detected ${reasons.join(', ')}. Quitting now will stop sidecar/background processes and may interrupt pending work.`;
 };
 
-const shutdownBackgroundServices = () => {
+const shutdownBackgroundServices = async () => {
   if (state.backgroundShutdownComplete) return;
   state.backgroundShutdownComplete = true;
   if (state.installingUpdate) return;
-  killSidecar();
-  setImmediate(() => {
-    void shutdownSshSessions();
-  });
+
+  // Graceful server shutdown — stops SSE watcher, terminal, opencode process, etc.
+  const handle = state.serverHandle;
+  if (handle) {
+    try {
+      await handle.stop({ exitProcess: false });
+    } catch (error) {
+      log.warn('[electron] graceful server shutdown failed, using fallback:', error);
+      killSidecar();
+    }
+  } else {
+    killSidecar();
+  }
+
+  await shutdownSshSessions();
 };
 
 const shutdownSshSessions = async () => {
@@ -248,7 +260,7 @@ const shutdownSshSessions = async () => {
   await state.sshShutdownPromise;
 };
 
-const prepareForQuit = ({ installingUpdate = false } = {}) => {
+const prepareForQuit = async ({ installingUpdate = false } = {}) => {
   state.quitRequested = true;
   state.quitConfirmed = true;
   state.installingUpdate = installingUpdate;
@@ -274,14 +286,28 @@ const prepareForQuit = ({ installingUpdate = false } = {}) => {
     return;
   }
 
-  shutdownBackgroundServices();
+  await shutdownBackgroundServices();
 };
 
-const performConfirmedQuit = () => {
+const performConfirmedQuit = async () => {
   if (state.quitInProgress) return;
   state.quitInProgress = true;
 
-  prepareForQuit();
+  let shutdownCompleted = false;
+  try {
+    shutdownCompleted = await Promise.race([
+      prepareForQuit().then(() => true),
+      new Promise((resolve) => setTimeout(() => resolve(false), GRACEFUL_SHUTDOWN_TIMEOUT_MS)),
+    ]);
+  } catch (error) {
+    log.warn('[electron] graceful shutdown failed, using fallback:', error);
+  }
+
+  if (!shutdownCompleted) {
+    log.warn('[electron] graceful shutdown timed out, using fallback');
+    killSidecar();
+  }
+
   app.exit(0);
 };
 
@@ -289,7 +315,7 @@ const requestQuitWithConfirmation = async () => {
   await refreshQuitRiskFlags();
 
   if (!shouldRequireQuitConfirmation()) {
-    performConfirmedQuit();
+    await performConfirmedQuit();
     return;
   }
 
@@ -320,7 +346,7 @@ const requestQuitWithConfirmation = async () => {
     });
     state.quitConfirmationPending = false;
     if (result.response === 0) {
-      performConfirmedQuit();
+      await performConfirmedQuit();
     }
   } catch (error) {
     state.quitConfirmationPending = false;
@@ -1848,8 +1874,8 @@ const openDevToolsForMenuTarget = () => {
   target.webContents.toggleDevTools();
 };
 
-const relaunchFromMenu = () => {
-  prepareForQuit();
+const relaunchFromMenu = async () => {
+  await prepareForQuit();
   app.relaunch();
   app.exit(0);
 };
@@ -2043,7 +2069,7 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
         if (state.installingUpdate) {
           app.quit();
         } else {
-          performConfirmedQuit();
+          void performConfirmedQuit();
         }
       }
     }
@@ -3490,9 +3516,9 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       await mutateSettingsRoot((root) => {
         root.desktopVibrancy = enabled;
       });
-      setImmediate(() => {
+      setImmediate(async () => {
         try {
-          prepareForQuit();
+          await prepareForQuit();
           app.relaunch();
           app.exit(0);
         } catch (err) {
@@ -3604,13 +3630,13 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       // Defer so the IPC reply flushes before the app starts shutting down.
       // Without this, quitAndInstall() can race with the renderer's pending
       // invoke and the restart appears to do nothing from the UI side.
-      setImmediate(() => {
+      setImmediate(async () => {
         try {
           if (applyUpdate) {
             killSidecar();
             autoUpdater.quitAndInstall();
           } else {
-            prepareForQuit();
+            await prepareForQuit();
             app.relaunch();
             app.exit(0);
           }
@@ -4343,7 +4369,7 @@ app.on('window-all-closed', () => {
     if (state.installingUpdate) {
       app.quit();
     } else {
-      performConfirmedQuit();
+      void performConfirmedQuit();
     }
   }
 });
@@ -4361,9 +4387,11 @@ app.on('before-quit', (event) => {
     return;
   }
 
-  if (!state.backgroundShutdownComplete) {
+  if (state.quitInProgress || !state.backgroundShutdownComplete) {
     event.preventDefault();
-    performConfirmedQuit();
+    if (!state.quitInProgress) {
+      void performConfirmedQuit();
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes Desktop quit/relaunch cleanup so Electron gives the embedded web server a chance to run its graceful shutdown path before the process exits.

Previously Desktop quit relied on `killSidecar()` only: a fire-and-forget SIGTERM plus short SIGKILL fallback followed by `app.exit(0)`. That bypassed the server handle's `stop()` path, which owns shutting down the OpenCode process, SSE watcher, terminal runtime, message streams, and HTTP server.

## CPU / memory impact

Orphaned OpenCode processes can keep consuming CPU and memory after Desktop exits or relaunches. This PR addresses that confirmed cleanup path by ensuring the embedded server gets a graceful shutdown opportunity before Electron terminates.

This should help cases where persistent background CPU/memory usage is caused by orphaned managed OpenCode processes. It does not claim to fix separate active-session renderer performance issues while AI is streaming.

Related: #665

## Previous shutdown flow

Before this change, Desktop quit/relaunch used this path:

```text
performConfirmedQuit()
  → prepareForQuit()
    → shutdownBackgroundServices()
      → killSidecar()
        → launchDetachedOpenCodeKiller()  // fire-and-forget
          → SIGTERM
          → detached killer script
          → sleep 100ms
          → SIGKILL
  → app.exit(0)
```

This meant Electron could exit before the server-owned graceful cleanup path ran.

## New shutdown flow

```text
performConfirmedQuit()
  → prepareForQuit()
    → shutdownBackgroundServices()
      → serverHandle.stop({ exitProcess: false })
        → gracefulShutdown()
          → stop watcher / terminal / message streams / HTTP server
          → close OpenCode process
      → fallback killSidecar() on failure or timeout
  → app.exit(0)
```

This PR:

- calls `serverHandle.stop({ exitProcess: false })` before Desktop quit/relaunch
- falls back to `killSidecar()` if graceful shutdown fails or times out
- keeps a 10s Electron-level shutdown timeout so quit cannot hang indefinitely
- prevents `before-quit` re-entry from bypassing the controlled shutdown path
- updates menu/restart/vibrancy/window-close flows to await cleanup before relaunch/exit

## Verification

- `node -c packages/electron/main.mjs`
- `bun run lint:electron`
- Manual: Desktop Quit verified
- Manual: Desktop Relaunch verified

## Notes

This fixes the confirmed orphaned opencode process cleanup path. It does not attempt to fix separate renderer CPU/memory pressure; that still needs profiling data before code changes.