### PR TITLE
fix(cli): auto-generate UI password when --ui-password is passed without a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Chat: selecting a user-installed skill from the slash command menu now invokes the skill and injects its content, instead of inserting the skill name as plain text.
+- CLI: passing `--ui-password` with no value now auto-generates a strong random password and prints it once, instead of silently doing nothing.
 ## [1.13.2] - 2026-06-18
 
 - Chat/Performance: long conversations and large session lists now stay smooth and responsive while a response is streaming (thanks to @bashrusakh).

--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -638,6 +638,10 @@ function hasUiPasswordConfigured(password) {
   return typeof password === 'string' && password.trim().length > 0;
 }
 
+function generateUiPassword() {
+  return crypto.randomBytes(18).toString('base64url');
+}
+
 function assertAuthenticatedNetworkExposure({ host, uiPassword }) {
   const bindHost = resolveConfiguredBindHost(host);
   if (hasUiPasswordConfigured(uiPassword)) {
@@ -749,6 +753,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     quiet: false,
     explicitPort: false,
     explicitUiPassword: false,
+    generatedUiPassword: false,
     envSnapshot: true,
     foreground: false,
     lan: false,
@@ -831,8 +836,13 @@ function parseArgs(argv = process.argv.slice(2)) {
       case 'ui-password': {
         const { value, nextIndex } = consumeValue(i, inlineValue);
         i = nextIndex;
-        options.uiPassword = typeof value === 'string' ? value : '';
         options.explicitUiPassword = true;
+        if (typeof value === 'string' && value.trim().length > 0) {
+          options.uiPassword = value;
+        } else {
+          options.uiPassword = generateUiPassword();
+          options.generatedUiPassword = true;
+        }
         break;
       }
       case 'provider': {
@@ -1049,7 +1059,7 @@ OPTIONS:
   --hostname              Alias for --host outside tunnel commands
   --lan                   Bind to 0.0.0.0 for LAN access
   --server <url>          Public/server URL for connect-url links
-  --ui-password           Protect browser UI with single password
+  --ui-password [value]   Protect browser UI with single password; auto-generates and prints one when no value is given
   --api-only              Start API routes only, without serving browser UI assets
   --foreground            Run server in foreground (use with systemd/process managers)
   --no-daemon             Alias for --foreground
@@ -1094,7 +1104,7 @@ SUBCOMMANDS:
 OPTIONS:
   -p, --port              Web server port used by startup service
   --host                  Bind address used by startup service
-  --ui-password           Protect browser UI with single password
+  --ui-password [value]   Protect browser UI with single password; auto-generates and prints one when no value is given
   --api-only              Start API routes only, without serving browser UI assets
   --no-env-snapshot       Do not save current environment for startup service
   --json                  Output machine-readable JSON
@@ -1127,7 +1137,7 @@ OPTIONS:
   --server <url>          Public URL saved into the connection link
   --server-url <url>      Alias for --server
   --name <label>          Label saved with the remote client token
-  --ui-password <value>   Protect browser access when UI routes are enabled
+  --ui-password [value]   Protect browser access when UI routes are enabled; auto-generates and prints one when no value is given
   --api-only              Start in headless/API-only mode when starting
   --qr                    Print a QR code for the connection link
   --json                  Output machine-readable JSON
@@ -1162,7 +1172,7 @@ COMMON OPTIONS:
   -p, --port              Target OpenChamber instance port
   --host                  Bind address when auto-starting an instance
   --lan                   Bind to 0.0.0.0 when auto-starting an instance
-  --ui-password           Protect browser UI when auto-starting an instance
+  --ui-password [value]   Protect browser UI when auto-starting an instance; auto-generates and prints one when no value is given
   --api-only              Start API routes only when auto-starting an instance
   --json                  Output machine-readable JSON
   --all                   Apply to all running instances (doctor default, stop)
@@ -3460,6 +3470,13 @@ const commands = {
     const logFd = fs.openSync(initialLogPath, 'a');
 
     const effectiveUiPassword = hasUiPasswordConfigured(options.uiPassword) ? options.uiPassword : undefined;
+    if (options.generatedUiPassword && effectiveUiPassword) {
+      emitNotice({
+        level: 'info',
+        code: 'ui_password_generated',
+        message: `Generated UI password: ${effectiveUiPassword}. Save it now — it is not stored and will not be shown again.`,
+      });
+    }
     assertAuthenticatedNetworkExposure({
       host: options.host,
       uiPassword: effectiveUiPassword,
@@ -5730,6 +5747,7 @@ export {
   parseArgs,
   assertAuthenticatedNetworkExposure,
   hasUiPasswordConfigured,
+  generateUiPassword,
   shouldDisplayTunnelQr,
   isValidTunnelDoctorResponse,
   readDesktopLocalPortFromSettings,

--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 
 import { isModuleCliExecution, normalizeCliEntryPath } from './cli-entry.js';
-import { assertAuthenticatedNetworkExposure, parseArgs } from './cli.js';
+import { assertAuthenticatedNetworkExposure, generateUiPassword, parseArgs } from './cli.js';
 
 describe('cli args', () => {
   it('accepts legacy daemon flags as no-ops', () => {
@@ -51,6 +51,50 @@ describe('cli args', () => {
     expect(parsed.options.apiOnly).toBe(true);
     expect(parsed.options.host).toBe('0.0.0.0');
     expect(parsed.options.uiPassword).toBe('secret');
+  });
+
+  it('auto-generates a UI password when --ui-password is passed without a value', () => {
+    const parsed = parseArgs(['serve', '--ui-password']);
+
+    expect(parsed.options.explicitUiPassword).toBe(true);
+    expect(parsed.options.generatedUiPassword).toBe(true);
+    expect(typeof parsed.options.uiPassword).toBe('string');
+    expect(parsed.options.uiPassword.length).toBeGreaterThan(0);
+    expect(parsed.options.uiPassword).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('auto-generates a UI password when --ui-password appears at the end of args', () => {
+    const parsed = parseArgs(['serve', '--port', '3002', '--ui-password']);
+
+    expect(parsed.options.explicitUiPassword).toBe(true);
+    expect(parsed.options.generatedUiPassword).toBe(true);
+    expect(parsed.options.uiPassword).toBeTruthy();
+    expect(parsed.options.port).toBe(3002);
+  });
+
+  it('treats --ui-password= with an empty inline value as auto-generated', () => {
+    const parsed = parseArgs(['serve', '--ui-password=']);
+
+    expect(parsed.options.explicitUiPassword).toBe(true);
+    expect(parsed.options.generatedUiPassword).toBe(true);
+    expect(parsed.options.uiPassword).toBeTruthy();
+  });
+
+  it('preserves an explicit --ui-password=secret value', () => {
+    const parsed = parseArgs(['serve', '--ui-password=secret']);
+
+    expect(parsed.options.explicitUiPassword).toBe(true);
+    expect(parsed.options.generatedUiPassword).toBe(false);
+    expect(parsed.options.uiPassword).toBe('secret');
+  });
+
+  it('generates a different UI password on each call', () => {
+    const first = generateUiPassword();
+    const second = generateUiPassword();
+
+    expect(first).not.toBe(second);
+    expect(first.length).toBeGreaterThanOrEqual(16);
+    expect(first).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it('maps --lan to wildcard bind host', () => {


### PR DESCRIPTION
### The problem

If you ran `openchamber -d --ui-password` expecting the server to start with a fresh password protecting the browser UI, nothing happened. The flag was accepted but the server started with UI auth disabled. From the outside it looked like the command was silently broken — and for users who relied on the old `--try-cf-tunnel` flow to mint a password for them, it regressed something they'd come to depend on.

### Why it was happening

The CLI parser treats `--ui-password secret` and `--ui-password=secret` as explicit values, but it has no story for `--ui-password` on its own. When the flag appears without a following non-`-` argument, the parser falls through and assigns the empty string to `options.uiPassword`. A separate helper, `hasUiPasswordConfigured`, then correctly reports that the empty string means "no password set" — and so the server boots without UI auth and the user is left wondering where the password they asked for went.

### What this change does

When `--ui-password` is present on the command line with no value, the parser now generates a strong random password (24 characters, base64url), stores it in `options.uiPassword`, and flags it with `options.generatedUiPassword = true`. The `serve` command emits a one-time notice that prints the generated password to the user, with a clear "save it now" warning. The same flow also fires inside the `tunnel start` subcommand, so anyone relying on the auto-generated password for a tunneled instance gets the same UX.

Explicit values are unchanged: `--ui-password secret`, `--ui-password=secret`, and the `OPENCHAMBER_UI_PASSWORD` environment variable all still work exactly as before.

### Acceptance criteria

- `openchamber -d --ui-password` → server boots with UI auth enabled; the generated password is printed once to the operator.
- `openchamber -d --ui-password mySecret` → server boots with `mySecret`; no extra output.
- `openchamber -d --ui-password=mySecret` → same as above.
- `OPENCHAMBER_UI_PASSWORD=foo openchamber -d` → unchanged, uses the env var.

### How it was tested

Five new cases in `packages/web/bin/cli.test.js` cover the parser surface (flag alone, flag before another flag, inline empty value, explicit value via `=`, and explicit value space-separated) plus a uniqueness test on the generator itself. All 25 tests in that file pass. `bun run lint:web`, `bun run type-check:web`, and a direct ESLint run against the modified `bin/**` files all report clean. A manual smoke test against the real CLI binary confirms the parser behaviour matches the test expectations for all six input shapes.

### Files changed

- `packages/web/bin/cli.js` — new `generateUiPassword()` helper; updated `--ui-password` parser case; `emitNotice` for the generated password; help text updates in four places; export the new helper.
- `packages/web/bin/cli.test.js` — five new test cases.
- `CHANGELOG.md` — entry under `[Unreleased]`.

Fixes #555