### PR TITLE
fix(ui): allow scrollbar drag to release auto-follow and prevent thinking-block LERP flicker

### DIFF
--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -212,10 +212,16 @@ export const useChatAutoFollow = ({
         }
 
         settledFramesRef.current = 0;
-        const next = current + delta * LERP;
-        markProgrammaticWrite();
-        container.scrollTop = next;
-        lastScrollTopRef.current = container.scrollTop;
+        if (delta < 0) {
+            markProgrammaticWrite();
+            container.scrollTop = target;
+            lastScrollTopRef.current = target;
+        } else {
+            const next = current + delta * LERP;
+            markProgrammaticWrite();
+            container.scrollTop = next;
+            lastScrollTopRef.current = container.scrollTop;
+        }
         followRafRef.current = window.requestAnimationFrame(tickFollow);
     }, [markProgrammaticWrite, stopFollowLoop]);
 
@@ -447,6 +453,12 @@ export const useChatAutoFollow = ({
         updateOverflowAndButton();
 
         if (programmatic) {
+            if (currentTop < previousTop && stateRef.current === 'following') {
+                stopFollowLoop();
+                stopSettleBurst();
+                lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
+                setStateValue('released');
+            }
             return;
         }
 


### PR DESCRIPTION
Closes #1793.

### Problem 1 & 2 — Scrollbar drag cannot release auto-follow

`tickFollow()` calls `markProgrammaticWrite()` every ~16ms, keeping the 200ms programmatic-write window perpetually fresh. `handleScrollEvent()` checks this window and returns early when inside it, discarding all user-intent detection. While wheel, touch, and keyboard handlers bypass this guard, scroll events (scrollbar drag) do not — making scrollbar drag the only input channel with no escape from auto-follow.

Fix: in `handleScrollEvent`, detect user-initiated upward scrolling (`currentTop < previousTop`) even inside the programmatic window, and release the follow state if the user is scrolling up.

### Problem 3 — Thinking-block height animation causes LERP oscillation

When a thinking block animates its height (expand/contract per frame), `scrollHeight` oscillates. On contraction, `scrollHeight` decreases → `target` moves up → `delta < 0` → the LERP pulls `scrollTop` *upward*, away from the new bottom. On the next expansion frame, `delta > 0` → LERP pulls back down. This creates a 0.3–0.5s-period visible flicker during thinking-block animation.

Fix: in `tickFollow()`, when `delta < 0` (content contracted), snap directly to `target` instead of lerping. Expansion (normal streaming, `delta >= 0`) retains the smooth LERP behavior.