### PR TITLE
fix(vscode): parse MiniMax CN remaining percentages

### DIFF
--- a/packages/vscode/src/quotaProviders.minimax.test.ts
+++ b/packages/vscode/src/quotaProviders.minimax.test.ts
@@ -1,0 +1,17 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { remainingPercentToUsedPercent } from './quotaProviders';
+
+describe('remainingPercentToUsedPercent', () => {
+  test('maps MiniMax remaining percentages to used percentages', () => {
+    assert.equal(remainingPercentToUsedPercent(100), 0);
+    assert.equal(remainingPercentToUsedPercent(94), 6);
+  });
+
+  test('clamps invalid remaining percentages', () => {
+    assert.equal(remainingPercentToUsedPercent(120), 0);
+    assert.equal(remainingPercentToUsedPercent(-20), 100);
+    assert.equal(remainingPercentToUsedPercent(null), null);
+  });
+});

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -1242,22 +1242,19 @@ const fetchMiniMaxQuota = async (data: {
     const weeklyStartAt = toTimestamp(firstModel.weekly_start_time);
     const weeklyResetAt = toTimestamp(firstModel.weekly_end_time);
 
-    const intervalUsed = data.usageFieldsAreRemaining && intervalTotal !== null && intervalUsage !== null
-      ? intervalTotal - intervalUsage
-      : intervalUsage;
-    const weeklyUsed = data.usageFieldsAreRemaining && weeklyTotal !== null && weeklyUsage !== null
-      ? weeklyTotal - weeklyUsage
-      : weeklyUsage;
-
-    const intervalUsedPercent = intervalTotal !== null && intervalTotal > 0 && intervalUsed !== null
-      ? Math.max(0, Math.min(100, (intervalUsed / intervalTotal) * 100))
-      : null;
+    const intervalUsedPercent = data.usageFieldsAreRemaining
+      ? remainingPercentToUsedPercent(firstModel.current_interval_remaining_percent)
+      : intervalTotal !== null && intervalTotal > 0 && intervalUsage !== null
+        ? Math.max(0, Math.min(100, (intervalUsage / intervalTotal) * 100))
+        : null;
     const intervalWindowSeconds = intervalStartAt && intervalResetAt && intervalResetAt > intervalStartAt
       ? Math.floor((intervalResetAt - intervalStartAt) / 1000)
       : null;
-    const weeklyUsedPercent = weeklyTotal !== null && weeklyTotal > 0 && weeklyUsed !== null
-      ? Math.max(0, Math.min(100, (weeklyUsed / weeklyTotal) * 100))
-      : null;
+    const weeklyUsedPercent = data.usageFieldsAreRemaining
+      ? remainingPercentToUsedPercent(firstModel.current_weekly_remaining_percent)
+      : weeklyTotal !== null && weeklyTotal > 0 && weeklyUsage !== null
+        ? Math.max(0, Math.min(100, (weeklyUsage / weeklyTotal) * 100))
+        : null;
     const weeklyWindowSeconds = weeklyStartAt && weeklyResetAt && weeklyResetAt > weeklyStartAt
       ? Math.floor((weeklyResetAt - weeklyStartAt) / 1000)
       : null;
@@ -1291,6 +1288,12 @@ const fetchMiniMaxQuota = async (data: {
       error: error instanceof Error ? error.message : 'Request failed',
     });
   }
+};
+
+export const remainingPercentToUsedPercent = (value: unknown): number | null => {
+  const remainingPercent = toNumber(value);
+  if (remainingPercent === null) return null;
+  return Math.max(0, Math.min(100, 100 - remainingPercent));
 };
 
 export const fetchMiniMaxCodingPlanQuota = () => fetchMiniMaxQuota({


### PR DESCRIPTION
## Problem

The MiniMax CN quota endpoint reports real usage through remaining-percent fields, while the count fields stay at `0`.

A live response after using quota looks like this:

```json
{
  "model_remains": [
    {
      "start_time": 1782230400000,
      "end_time": 1782248400000,
      "remains_time": 7557133,
      "current_interval_total_count": 0,
      "current_interval_usage_count": 0,
      "model_name": "general",
      "current_weekly_total_count": 0,
      "current_weekly_usage_count": 0,
      "weekly_start_time": 1782057600000,
      "weekly_end_time": 1782662400000,
      "weekly_remains_time": 421557133,
      "current_interval_status": 1,
      "current_interval_remaining_percent": 93,
      "current_weekly_status": 1,
      "current_weekly_remaining_percent": 97
    }
  ],
  "base_resp": {
    "status_code": 0,
    "status_msg": "success"
  }
}
```

The VS Code parser read these count fields:

```text
current_interval_total_count = 0
current_interval_usage_count = 0
current_weekly_total_count = 0
current_weekly_usage_count = 0
```

That makes both windows resolve to `usedPercent: null` because `total_count` is `0`:

```text
5h: total=0, usage=0 -> usedPercent=null
weekly: total=0, usage=0 -> usedPercent=null
```

As a result, MiniMax CN has no usable percentage for the 5h and weekly windows in the VS Code quota provider, so the quota UI cannot calculate pace/prediction from those windows.

## Fix

For the MiniMax CN path, read the remaining-percent fields instead:

```text
current_interval_remaining_percent = 93
current_weekly_remaining_percent = 97
```

Then convert them into used percentages:

```text
5h: 100 - 93 = 7%
weekly: 100 - 97 = 3%
```

The non-CN MiniMax path still uses the existing count-based calculation.

## Validation

- `bun test packages/vscode/src/quotaProviders.minimax.test.ts`
- `bun run vscode:type-check`
- `bun run --cwd packages/vscode lint`
- Manual smoke: `fetchMiniMaxCnCodingPlanQuota()` returned `5h.usedPercent = 7` and `weekly.usedPercent = 3` from the live MiniMax CN response.