### PR TITLE
fix(chat): auto-dispatch queued messages after compaction

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1999,9 +1999,13 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             }
             else if (commandName === 'compact' && currentSessionId) {
                 try {
-                    await sessionActions.waitForConnectionOrThrow();
                     const compactDirectory = useSessionUIStore.getState().getDirectoryForSession(currentSessionId) || currentDirectory || undefined;
-                    await opencodeClient.summarizeSession(currentSessionId, currentProviderId, currentModelId, compactDirectory);
+                    await sessionActions.compactSession({
+                        sessionId: currentSessionId,
+                        providerID: currentProviderId,
+                        modelID: currentModelId,
+                        directory: compactDirectory,
+                    });
                 } catch (error) {
                     toast.error(error instanceof Error ? error.message : t('chat.chatInput.toast.compactFailed'));
                 }

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -11,6 +11,17 @@ let questionReplyError: unknown | null = null
 let questionRejectError: unknown | null = null
 let sessionShareResult: { data?: unknown; error?: unknown; response?: { status?: number } } = {}
 const globalUpsertedSessions: unknown[] = []
+const summarizeSessionCalls: Array<{
+  sessionId: string
+  providerID: string
+  modelID: string
+  directory?: string | null
+  statusDuringCall?: string
+}> = []
+let summarizeSessionResult: boolean = true
+let summarizeSessionError: unknown | null = null
+// Lets the summarizeSession mock observe the directory store status at call time
+let compactStoreRef: (() => { session_status: Record<string, { type: string }> }) | null = null
 
 const mockScopedClient = {
   permission: {
@@ -110,6 +121,12 @@ mock.module("@/lib/opencode/client", () => ({
         throw new Error(`session.revert failed${status ? ` (${status})` : ""}: rejected`)
       }
       return Promise.resolve(sessionRevertResult.data)
+    }),
+    summarizeSession: mock((sessionId: string, providerID: string, modelID: string, directory?: string | null) => {
+      const statusDuringCall = compactStoreRef?.().session_status[sessionId]?.type
+      summarizeSessionCalls.push({ sessionId, providerID, modelID, directory, statusDuringCall })
+      if (summarizeSessionError) return Promise.reject(summarizeSessionError)
+      return Promise.resolve(summarizeSessionResult)
     }),
   },
 }))
@@ -758,5 +775,91 @@ describe("dismissOpenQuestionsForSession", () => {
     expect(rejectCalls[0].params.requestID).toBe("q-stale")
     // The stale entry is cleared from the store even though the server reported not-found.
     expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+})
+
+describe("compactSession", () => {
+  beforeEach(() => {
+    summarizeSessionCalls.length = 0
+    summarizeSessionResult = true
+    summarizeSessionError = null
+    compactStoreRef = null
+  })
+
+  test("marks the session busy during compaction and restores idle on completion", async () => {
+    const store = createStore({}, { session_status: { "session-a": { type: "idle" } } })
+    const childStores = createChildStores([["/test/project", store]])
+    compactStoreRef = () => store.getState()
+
+    const { setActionRefs, compactSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    await compactSession({
+      sessionId: "session-a",
+      providerID: "anthropic",
+      modelID: "claude-3",
+      directory: "/test/project",
+    })
+
+    // summarizeSession was called once, with the session marked busy at call time
+    expect(summarizeSessionCalls).toHaveLength(1)
+    const call = summarizeSessionCalls[0]!
+    expect(call.sessionId).toBe("session-a")
+    expect(call.providerID).toBe("anthropic")
+    expect(call.modelID).toBe("claude-3")
+    expect(call.directory).toBe("/test/project")
+    expect(call.statusDuringCall).toBe("busy")
+    // Status restored to idle after compaction
+    expect(store.getState().session_status["session-a"]).toEqual({ type: "idle" })
+  })
+
+  test("restores idle even when summarizeSession rejects", async () => {
+    const store = createStore({}, { session_status: { "session-a": { type: "idle" } } })
+    const childStores = createChildStores([["/test/project", store]])
+    compactStoreRef = () => store.getState()
+    summarizeSessionError = new Error("summarize blew up")
+
+    const { setActionRefs, compactSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    let thrown: unknown
+    try {
+      await compactSession({ sessionId: "session-a", providerID: "p", modelID: "m", directory: "/test/project" })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message).toBe("summarize blew up")
+    expect(summarizeSessionCalls[0]?.statusDuringCall).toBe("busy")
+    expect(store.getState().session_status["session-a"]).toEqual({ type: "idle" })
+  })
+
+  test("preserves existing busy status when compacting during an active turn", async () => {
+    const store = createStore({}, { session_status: { "session-a": { type: "busy" } } })
+    const childStores = createChildStores([["/test/project", store]])
+    compactStoreRef = () => store.getState()
+
+    const { setActionRefs, compactSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    await compactSession({ sessionId: "session-a", providerID: "p", modelID: "m", directory: "/test/project" })
+
+    expect(summarizeSessionCalls[0]?.statusDuringCall).toBe("busy")
+    expect(store.getState().session_status["session-a"]).toEqual({ type: "busy" })
+  })
+
+  test("falls back to the current directory when none is provided", async () => {
+    const store = createStore({}, { session_status: { "session-a": { type: "idle" } } })
+    const childStores = createChildStores([["/current/project", store]])
+    compactStoreRef = () => store.getState()
+
+    const { setActionRefs, compactSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/current/project")
+
+    await compactSession({ sessionId: "session-a", providerID: "p", modelID: "m" })
+
+    expect(summarizeSessionCalls[0]?.directory).toBe("/current/project")
+    expect(store.getState().session_status["session-a"]).toEqual({ type: "idle" })
   })
 })

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -717,6 +717,56 @@ export async function optimisticSend(input: {
 }
 
 // ---------------------------------------------------------------------------
+// Compaction
+// ---------------------------------------------------------------------------
+
+export async function compactSession(input: {
+  sessionId: string
+  providerID: string
+  modelID: string
+  directory?: string | null
+}): Promise<void> {
+  await waitForConnectionOrThrow()
+
+  const targetDirectory = input.directory ?? dir()
+  const store = targetDirectory ? dirStoreForDirectory(targetDirectory) : dirStore()
+  const previousStatusType = store.getState().session_status[input.sessionId]?.type
+  const shouldManageStatus = previousStatusType === undefined || previousStatusType === "idle"
+
+  if (shouldManageStatus) {
+    // Mark the session busy so lifecycle observers (e.g. queued-message auto-send)
+    // treat compaction as live activity and react to its completion.
+    store.setState({
+      session_status: {
+        ...store.getState().session_status,
+        [input.sessionId]: { type: "busy" as const },
+      },
+    })
+  }
+
+  try {
+    await opencodeClient.summarizeSession(
+      input.sessionId,
+      input.providerID,
+      input.modelID,
+      targetDirectory,
+    )
+  } finally {
+    if (shouldManageStatus) {
+      // Compaction bypasses the normal prompt lifecycle, so the server may not
+      // emit a session.idle event. Restore idle deterministically so observers
+      // see the busy-to-idle transition and queued messages can dispatch.
+      store.setState({
+        session_status: {
+          ...store.getState().session_status,
+          [input.sessionId]: { type: "idle" as const },
+        },
+      })
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Abort
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix #1799

Queued messages were never auto-dispatched after `/compact` because the auto-send hook only fires on a `busy`/`retry` → `idle` session-status transition, and compaction called `summarizeSession` directly without driving `session_status` — so the status stayed `idle` throughout and the transition never occurred.

The new `compactSession` action mirrors the optimistic-busy pattern used by normal message sends (`submit.ts`, `session-actions.ts`): it marks the session `busy` before running compaction and restores `idle` in a `finally`, so observers see the `busy` → `idle` edge and queued messages dispatch on completion. `ChatInput` now calls this action instead of `opencodeClient.summarizeSession` directly.