### PR TITLE
chore(issues): tighten issue templates and add issue quality gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,25 +1,35 @@
 name: Bug report
-description: Report something broken
-title: "[Bug] "
-labels: [bug]
+description: Report a reproducible bug or broken behavior.
+title: "bug: "
+labels: ["bug", "needs-triage"]
 body:
-  - type: textarea
-    id: what
+  - type: markdown
     attributes:
-      label: What's wrong? Maybe some steps to reproduce.
-      description: What happened and what you expected.
-      placeholder: "Expected … but got …"
+      value: |
+        Thanks for reporting a bug.
+
+        Keep this short and specific. Do not paste long AI-generated reports.
+        Search existing issues before submitting.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Short summary
+      description: One sentence describing the broken behavior.
+      placeholder: "Queued messages are not sent after /compact"
     validations:
       required: true
 
   - type: dropdown
     id: runtime
     attributes:
-      label: Where does it happen?
+      label: Runtime
+      description: Where does this happen?
       options:
-        - Desktop (macOS)
-        - Desktop Web
-        - Mobile (Web/PWA)
+        - Web
+        - Desktop - macOS
+        - Desktop - Windows
+        - Mobile Web / PWA
         - VS Code extension
         - Not sure
     validations:
@@ -28,18 +38,63 @@ body:
   - type: input
     id: version
     attributes:
-      label: Version (if known)
-      placeholder: "e.g. 1.2.3"
+      label: Version
+      placeholder: "e.g. 1.13.2, latest main, commit SHA, or unknown"
+    validations:
+      required: true
 
   - type: textarea
-    id: screenshots
+    id: steps
     attributes:
-      label: Screenshots / recordings (optional)
-      description: "Anything visual that helps."
+      label: Steps to reproduce
+      description: Use the smallest reproduction you can.
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: "What happened?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "What should have happened?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots or recordings
+      description: Required for visual/UI issues when possible.
+      placeholder: "Drag screenshots or recordings here."
 
   - type: textarea
     id: logs
     attributes:
-      label: Logs (optional)
-      description: "Paste relevant logs."
+      label: Logs
+      description: Paste only relevant logs. Remove secrets, tokens, and private data.
       render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues.
+          required: true
+        - label: I kept this report short and specific.
+          required: true
+        - label: I removed secrets, tokens, and private data.
+          required: true
+        - label: I wrote this issue in English.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Discord
+    url: https://discord.gg/ZYRSdnwwKA
+    about: Ask general questions or get community support.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,22 +1,82 @@
 name: Feature request
-description: Suggest an improvement
-title: "[Feature Request] "
-labels: [enhancement]
+description: Suggest a focused improvement or missing expected behavior.
+title: "feat: "
+labels: ["enhancement", "needs-triage"]
 body:
-  - type: textarea
-    id: request
+  - type: markdown
     attributes:
-      label: What should we add/change?
-      description: What you're trying to do + what you'd like to happen.
-      placeholder: |
-        I'm trying to …
+      value: |
+        Thanks for suggesting an improvement.
 
-        It would be great if OpenChamber …
+        Keep this short and focused. Do not paste long AI-generated proposals.
+        Large UI or core product changes should be discussed before implementation.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Short summary
+      description: One sentence describing the requested behavior.
+      placeholder: "Show a selectable file tree before creating a commit"
     validations:
       required: true
 
   - type: textarea
-    id: context
+    id: problem
     attributes:
-      label: Extra context (optional)
-      description: Links, screenshots, mockups, constraints, etc.
+      label: Problem
+      description: What workflow is blocked or painful today?
+      placeholder: "When I want to commit only part of a change..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should OpenChamber do?
+      placeholder: "Add a file tree with checkboxes..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime
+      description: Where should this work?
+      multiple: true
+      options:
+        - Web
+        - Desktop
+        - Mobile Web / PWA
+        - VS Code extension
+        - All runtimes
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples or references
+      description: Screenshots, mockups, links, or comparable behavior in other tools.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope notes
+      description: Mention what should not be included if the feature could grow too large.
+      placeholder: "This request does not include..."
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues.
+          required: true
+        - label: I kept this request short and focused.
+          required: true
+        - label: I am not submitting a broad multi-feature wishlist.
+          required: true
+        - label: I wrote this issue in English.
+          required: true


### PR DESCRIPTION
## Summary

Replace the existing loose issue templates with structured YAML forms that require a short summary, runtime, version, reproduction steps, and submission checkboxes. Update `config.yml` to add a Discord contact link.

This implements the template and config changes from #1818, which is the first of two proposed PRs.

## Changes

### `.github/ISSUE_TEMPLATE/bug_report.yml`
- Structured form with required short summary, runtime dropdown, version, steps to reproduce, actual behavior, expected behavior, and optional screenshots/logs
- Title defaults to `bug: `
- Labels: `bug`, `needs-triage`
- Pre-submission checkboxes (searched existing issues, kept short, removed secrets, English)

### `.github/ISSUE_TEMPLATE/feature_request.yml`
- Structured form with required short summary, problem description, proposed behavior, and runtime (multi-select)
- Title defaults to `feat: `
- Labels: `enhancement`, `needs-triage`
- Pre-submission checkboxes (searched existing issues, kept focused, no broad wishlists, English)

### `.github/ISSUE_TEMPLATE/config.yml`
- Keeps `blank_issues_enabled: false`
- Adds Discord contact link for general questions/community support

## Notes
- The `needs-triage` label used in the templates needs to be created in the repo if it does not exist yet (GitHub silently skips labels that don't exist in template frontmatter, so this is non-blocking but recommended for consistency)
- The quality gate GitHub Action (PR #2) is not included here — it will be added in a follow-up

Fixes #1818 (first part)