### PR TITLE
fix(server): allow x-opencode-directory-encoding header in CORS

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -1113,7 +1113,7 @@ async function main(options = {}) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader('Access-Control-Allow-Credentials', 'true');
       res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization,Accept,X-Requested-With,Cache-Control,X-OpenCode-Directory');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization,Accept,X-Requested-With,Cache-Control,X-OpenCode-Directory,X-OpenCode-Directory-Encoding');
       res.setHeader('Access-Control-Expose-Headers', 'x-next-cursor');
       res.setHeader('Vary', 'Origin');
       if (req.method === 'OPTIONS') {


### PR DESCRIPTION
## Summary

Allow `x-opencode-directory-encoding` in the CORS `Access-Control-Allow-Headers` response header so that preflight requests from the packaged Electron UI (`openchamber-ui://app`) pass when the directory path contains non-ISO-8859-1 characters (e.g. CJK paths like `D:\文件`).

## Root cause

PR #1673 added `sanitizeHeadersForBrowser` in the fetch bridge to handle non-ISO-8859-1 directory paths by encoding the value with `encodeURIComponent` and attaching a `x-opencode-directory-encoding: uri` header. The server has had the corresponding decoder (`safeDecodeMarkedURIComponent`) since `dee43181` (server-side read of the encoding header).

However, the CORS `Access-Control-Allow-Headers` list on the Express server at `packages/web/server/index.js:1116` was not updated to include `x-opencode-directory-encoding`. When a user opens a directory with CJK characters via the packaged Electron desktop app:

1. The fetch bridge encodes the path and adds `x-opencode-directory-encoding: uri`
2. The browser sends a CORS preflight `OPTIONS` request with `x-opencode-directory-encoding` in `Access-Control-Request-Headers`
3. The server responds with `Access-Control-Allow-Headers` that does not include it
4. The preflight fails → all subsequent API requests (file listing, config, etc.) are blocked with CORS errors → `Failed to fetch`

This only affects the packaged/bundled Electron UI (`openchamber-ui://app` origin). It does not affect the dev HMR mode because Vite's dev proxy handles the cross-origin requests transparently.

## Changes

- `packages/web/server/index.js` — Add `X-OpenCode-Directory-Encoding` to the `Access-Control-Allow-Headers` for the `openchamber-ui://app` origin.

## Validation

- Built and tested with `bun run electron:dev:bundled` using the non-ASCII path `D:\文件` — Files tab loads correctly, no CORS errors in DevTools console.
- All existing API endpoints continue to work with ASCII paths.
- `bun run type-check` and `bun run lint` pass across all workspaces.
