### PR TITLE
fix: sidebar worktree drag reorder snap-back due to stale cache

### DIFF
--- a/packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx
+++ b/packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx
@@ -101,6 +101,11 @@ export function SidebarProjectsList(props: Props): React.ReactNode {
   // orderedGroups.filter/find work and any consumer-memoization see a
   // stable reference.
   const orderedGroupsCacheRef = React.useRef<Map<string, { groups: SessionGroup[]; ordered: SessionGroup[] }>>(new Map());
+  const orderedGroupsCacheGetOrderedGroupsRef = React.useRef<typeof props.getOrderedGroups>(props.getOrderedGroups);
+  if (orderedGroupsCacheGetOrderedGroupsRef.current !== props.getOrderedGroups) {
+    orderedGroupsCacheGetOrderedGroupsRef.current = props.getOrderedGroups;
+    orderedGroupsCacheRef.current.clear();
+  }
   const cachedGetOrderedGroups = (projectId: string, groups: SessionGroup[]): SessionGroup[] => {
     const cache = orderedGroupsCacheRef.current;
     const hit = cache.get(projectId);


### PR DESCRIPTION
**Problem**

Dragging a worktree group in the session sidebar to reorder it causes the item to snap back to its original position immediately after dropping. The order is correctly persisted (visible after remount), but the visual feedback is broken.

**Root cause**

`cachedGetOrderedGroups` in `SidebarProjectsList.tsx` (lines 109-125) caches ordered groups by `projectId` + groups array reference. After a drag, `groupOrderByProject` changes, producing a new `getOrderedGroups` callback. But the cache only checks `projectId` and the groups array reference (line 112) — both stable across the re-render because the `projectSections` memo does not depend on `groupOrderByProject`. The cache returns stale pre-drag data, and the UI snaps back.

**Fix**

Track the previous `getOrderedGroups` reference with a ref. When it changes (indicating `groupOrderByProject` changed), clear the cache so the next call recomputes the ordering:

```tsx
const orderedGroupsCacheGetOrderedGroupsRef = React.useRef<typeof props.getOrderedGroups>(props.getOrderedGroups);
if (orderedGroupsCacheGetOrderedGroupsRef.current !== props.getOrderedGroups) {
  orderedGroupsCacheGetOrderedGroupsRef.current = props.getOrderedGroups;
  orderedGroupsCacheRef.current.clear();
}
```

**Changes**

- `packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx` — added `orderedGroupsCacheGetOrderedGroupsRef` to detect `getOrderedGroups` changes and clear the cache.

Closes #1827