### PR TITLE
feat(chat): drag to reorder queued messages

### DIFF
--- a/packages/ui/src/components/chat/QueuedMessageChips.tsx
+++ b/packages/ui/src/components/chat/QueuedMessageChips.tsx
@@ -1,10 +1,26 @@
 import React, { memo } from 'react';
+import {
+    DndContext,
+    MouseSensor,
+    TouchSensor,
+    useSensor,
+    useSensors,
+    closestCenter,
+    type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+    SortableContext,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useMessageQueueStore, type QueuedMessage } from '@/stores/messageQueueStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useInputStore } from '@/sync/input-store';
 import { useI18n } from '@/lib/i18n';
 import { Icon } from "@/components/icon/Icon";
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 interface QueuedMessageChipProps {
     message: QueuedMessage;
@@ -16,6 +32,7 @@ interface QueuedMessageChipProps {
 const QueuedMessageChip = memo(({ message, sessionId, onEdit, onSend }: QueuedMessageChipProps) => {
     const { t } = useI18n();
     const removeFromQueue = useMessageQueueStore((state) => state.removeFromQueue);
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: message.id });
 
     // Get first line of message, truncated
     const firstLine = React.useMemo(() => {
@@ -31,7 +48,21 @@ const QueuedMessageChip = memo(({ message, sessionId, onEdit, onSend }: QueuedMe
     const attachmentCount = message.attachments?.length ?? 0;
 
     return (
-        <div className="flex min-w-0 items-center gap-2 py-1">
+        <div
+            ref={setNodeRef}
+            // Translate only (no scaleX/scaleY) so the lifted row keeps its size.
+            style={{ transform: CSS.Translate.toString(transform), transition }}
+            className={cn('flex min-w-0 items-center gap-2 py-1', isDragging && 'z-10 opacity-60')}
+        >
+            <button
+                type="button"
+                {...attributes}
+                {...listeners}
+                className="flex flex-shrink-0 cursor-grab touch-none select-none items-center justify-center text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                aria-label={t('chat.queuedMessage.reorderAria')}
+            >
+                <Icon name="draggable" className="h-4 w-4" aria-hidden="true" />
+            </button>
             <span className="min-w-0 flex-1 truncate typography-ui-label text-foreground">
                 {firstLine || t('chat.queuedMessage.empty')}
                 {attachmentCount > 0 && (
@@ -90,6 +121,20 @@ export const QueuedMessageChips = memo(({ onEditMessage, onSendMessage }: Queued
         )
     );
     const popToInput = useMessageQueueStore((state) => state.popToInput);
+    const reorderQueue = useMessageQueueStore((state) => state.reorderQueue);
+
+    const sensors = useSensors(
+        // Desktop: drag after a small move so other clicks still register.
+        useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+        // Touch: long-press to drag (tap still hits buttons, swipe scrolls).
+        useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 6 } }),
+    );
+
+    const handleDragEnd = React.useCallback((event: DragEndEvent) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id || !currentSessionId) return;
+        reorderQueue(currentSessionId, String(active.id), String(over.id));
+    }, [currentSessionId, reorderQueue]);
 
     const handleEdit = React.useCallback((message: QueuedMessage) => {
         if (!currentSessionId) return;
@@ -121,17 +166,28 @@ export const QueuedMessageChips = memo(({ onEditMessage, onSendMessage }: Queued
                     </span>
                     <Icon name="time" className="ml-auto h-4 w-4 text-muted-foreground" aria-hidden="true" />
                 </div>
-                <div className="px-3 pb-3 flex flex-col gap-1.5 max-h-[10.5rem] overflow-y-auto">
-                    {queuedMessages.map((message) => (
-                        <QueuedMessageChip
-                            key={message.id}
-                            message={message}
-                            sessionId={currentSessionId}
-                            onEdit={handleEdit}
-                            onSend={handleSend}
-                        />
-                    ))}
-                </div>
+                <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleDragEnd}
+                >
+                    <SortableContext
+                        items={queuedMessages.map((m) => m.id)}
+                        strategy={verticalListSortingStrategy}
+                    >
+                        <div className="px-3 pb-3 flex flex-col gap-1.5 max-h-[10.5rem] overflow-y-auto">
+                            {queuedMessages.map((message) => (
+                                <QueuedMessageChip
+                                    key={message.id}
+                                    message={message}
+                                    sessionId={currentSessionId}
+                                    onEdit={handleEdit}
+                                    onSend={handleSend}
+                                />
+                            ))}
+                        </div>
+                    </SortableContext>
+                </DndContext>
             </div>
         </div>
     );

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1720,6 +1720,7 @@ export const dict = {
   'chat.queuedMessage.edit': 'edit',
   'chat.queuedMessage.send': 'send',
   'chat.queuedMessage.removeAria': 'Remove from queue',
+  'chat.queuedMessage.reorderAria': 'Drag to reorder',
   'chat.container.returnToParent.aria': 'Return to parent session',
   'chat.container.returnToParent.titleNamed': 'Return to: {title}',
   'chat.container.returnToParent.title': 'Return to parent session',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1686,6 +1686,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.queuedMessage.edit": "edit",
   "chat.queuedMessage.send": "send",
   "chat.queuedMessage.removeAria": "Eliminar de la cola",
+  "chat.queuedMessage.reorderAria": "Arrastra para reordenar",
   "chat.container.returnToParent.aria": "Volver a la sesión principal",
   "chat.container.returnToParent.titleNamed": "Volver a: {title}",
   "chat.container.returnToParent.title": "Volver a la sesión principal",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1565,6 +1565,7 @@ export const dict = {
   'chat.queuedMessage.edit': 'modifier',
   'chat.queuedMessage.send': 'envoyer',
   'chat.queuedMessage.removeAria': 'Supprimer de la file d\'attente',
+  'chat.queuedMessage.reorderAria': 'Glisser pour réorganiser',
   'chat.container.returnToParent.aria': 'Retour à la session parents',
   'chat.container.returnToParent.titleNamed': 'Retourner à : {title}',
   'chat.container.returnToParent.title': 'Retour à la session parents',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1722,6 +1722,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.queuedMessage.edit': 'edit',
   'chat.queuedMessage.send': 'send',
   'chat.queuedMessage.removeAria': '큐에서 제거',
+  'chat.queuedMessage.reorderAria': '드래그하여 순서 변경',
   'chat.container.returnToParent.aria': '상위 세션으로 돌아가기',
   'chat.container.returnToParent.titleNamed': '돌아가기: {title}',
   'chat.container.returnToParent.title': '상위 세션으로 돌아가기',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -663,6 +663,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.queuedMessage.edit': 'edit',
   'chat.queuedMessage.send': 'send',
   'chat.queuedMessage.removeAria': 'Usuń z kolejki',
+  'chat.queuedMessage.reorderAria': 'Przeciągnij, aby zmienić kolejność',
   'chat.container.returnToParent.aria': 'Powrót do sesji nadrzędnej',
   'chat.container.returnToParent.titleNamed': 'Powrót do: {title}',
   'chat.container.returnToParent.title': 'Powrót do sesji nadrzędnej',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1686,6 +1686,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.queuedMessage.edit": "edit",
   "chat.queuedMessage.send": "send",
   "chat.queuedMessage.removeAria": "Excluir da fila",
+  "chat.queuedMessage.reorderAria": "Arraste para reordenar",
   "chat.container.returnToParent.aria": "Voltar para a sessão principal",
   "chat.container.returnToParent.titleNamed": "Voltar para: {title}",
   "chat.container.returnToParent.title": "Voltar para a sessão principal",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1686,6 +1686,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.queuedMessage.edit": "edit",
   "chat.queuedMessage.send": "send",
   "chat.queuedMessage.removeAria": "Видалити з черги",
+  "chat.queuedMessage.reorderAria": "Перетягніть, щоб змінити порядок",
   "chat.container.returnToParent.aria": "Повернутися до батьківської сесії",
   "chat.container.returnToParent.titleNamed": "Повернутися до: {title}",
   "chat.container.returnToParent.title": "Повернутися до батьківської сесії",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1686,6 +1686,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.queuedMessage.edit': 'edit',
   'chat.queuedMessage.send': 'send',
   'chat.queuedMessage.removeAria': '从队列移除',
+  'chat.queuedMessage.reorderAria': '拖动以重新排序',
   'chat.container.returnToParent.aria': '返回父会话',
   'chat.container.returnToParent.titleNamed': '返回到：{title}',
   'chat.container.returnToParent.title': '返回父会话',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1690,6 +1690,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.queuedMessage.edit': 'edit',
   'chat.queuedMessage.send': 'send',
   'chat.queuedMessage.removeAria': '從佇列移除',
+  'chat.queuedMessage.reorderAria': '拖曳以重新排序',
   'chat.container.returnToParent.aria': '返回父會話',
   'chat.container.returnToParent.titleNamed': '返回到：{title}',
   'chat.container.returnToParent.title': '返回父會話',

--- a/packages/ui/src/stores/messageQueueStore.ts
+++ b/packages/ui/src/stores/messageQueueStore.ts
@@ -26,6 +26,7 @@ interface MessageQueueState {
 interface MessageQueueActions {
     addToQueue: (sessionId: string, message: Omit<QueuedMessage, 'id' | 'createdAt'>) => void;
     removeFromQueue: (sessionId: string, messageId: string) => void;
+    reorderQueue: (sessionId: string, fromId: string, toId: string) => void;
     popToInput: (sessionId: string, messageId: string) => QueuedMessage | null;
     clearQueue: (sessionId: string) => void;
     clearAllQueues: () => void;
@@ -74,6 +75,28 @@ export const useMessageQueueStore = create<MessageQueueStore>()(
                             return { queuedMessages: rest };
                         }
                         
+                        return {
+                            queuedMessages: {
+                                ...state.queuedMessages,
+                                [sessionId]: newQueue,
+                            },
+                        };
+                    });
+                },
+
+                reorderQueue: (sessionId, fromId, toId) => {
+                    if (fromId === toId) return;
+                    set((state) => {
+                        const currentQueue = state.queuedMessages[sessionId];
+                        if (!currentQueue) return state;
+                        const fromIndex = currentQueue.findIndex((m) => m.id === fromId);
+                        const toIndex = currentQueue.findIndex((m) => m.id === toId);
+                        if (fromIndex === -1 || toIndex === -1) return state;
+
+                        const newQueue = currentQueue.slice();
+                        const [moved] = newQueue.splice(fromIndex, 1);
+                        newQueue.splice(toIndex, 0, moved);
+
                         return {
                             queuedMessages: {
                                 ...state.queuedMessages,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Queued messages can now be dragged to change their order in the queue. Previously the queue was strictly insertion-order (FIFO) with no way to reprioritize. Since both the auto-send path (drains `queue[0]` on each idle transition) and the manual full-submit path (index `0` → primary, `1+` → additional parts) rely on array order, reordering now directly controls send priority.

## Changes

- **`messageQueueStore.ts`**: New `reorderQueue(sessionId, fromId, toId)` action. Looks items up by id (not index), moves the dragged item to the target position, and preserves the references of untouched items by only rebuilding the affected session array.
- **`QueuedMessageChips.tsx`**: Wrapped the list in `@dnd-kit` `DndContext` + `SortableContext` (`verticalListSortingStrategy`, since this is a single vertical column). Each row gets a grab-handle (`draggable` sprite icon) carrying the drag listeners; Edit / Send / Remove buttons stay independently clickable.
  - Follows the project drag-to-reorder skill: split `MouseSensor` (distance 8) + `TouchSensor` (long-press 200ms) sensors for desktop + touch, `touch-none select-none` on the handle, `CSS.Translate.toString` (no scale stretch), and reorder once on `onDragEnd`.
- **i18n**: Added `chat.queuedMessage.reorderAria` ("Drag to reorder") to all 9 locale dictionaries.

## Validation

- `bun run type-check` (packages/ui) — pass
- `bun run lint` (packages/ui) — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4305ac0-194e-42f1-85ee-14b7d61570fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4305ac0-194e-42f1-85ee-14b7d61570fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

