### PR TITLE
docs(agents): add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,3 +460,11 @@ A single store with N properties means every subscriber re-evaluates on every st
 
 - Releases + high-level changes: `CHANGELOG.md`
 - Recent commits: `git log --oneline` (latest tags: `v1.11.7`, `v1.11.6`)
+
+## Cursor Cloud specific instructions
+
+- Toolchain (`bun` at `~/.bun/bin`, `opencode` CLI at `~/.opencode/bin`) is preinstalled in the VM snapshot and added to PATH via `~/.bashrc`. The startup update script only runs `bun install`. If you launch a process from a non-login shell where PATH isn't picked up, prepend both dirs (e.g. `export PATH="$HOME/.opencode/bin:$HOME/.bun/bin:$PATH"`).
+- Run the web app in dev mode with `bun run dev` (alias of `dev:web:hmr`). It serves the **HMR UI on http://127.0.0.1:5180** and the **Express API on http://127.0.0.1:3902** — open the 5180 URL for the UI, not the API port. Ports are overridable via `OPENCHAMBER_HMR_UI_PORT` / `OPENCHAMBER_HMR_API_PORT`.
+- The web server auto-starts a *managed* `opencode serve` instance on a random port and proxies it; you do NOT need to start OpenCode yourself. This requires the `opencode` binary to be resolvable (PATH or `~/.opencode/bin`). Confirm readiness via `curl -s http://127.0.0.1:3902/health` (`openCodeRunning` / `isOpenCodeReady` should be `true`). To attach to an external OpenCode instead, set `OPENCODE_HOST`/`OPENCODE_PORT` + `OPENCODE_SKIP_START=true`.
+- Chat can be tested with no API key: select an "OpenCode Zen" free model (e.g. "Big Pickle") in the model selector. The `/workspace` repo auto-loads as the default project, so no onboarding step is needed.
+- Electron desktop packaging targets macOS/Windows only; on this Linux VM use the web runtime (`bun run dev`) for end-to-end testing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for cloud agents and records durable, non-obvious startup guidance in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section.

## Environment setup performed

- Installed **Bun 1.3.14** (the repo `packageManager`) and the **OpenCode CLI** (`opencode`), which OpenChamber requires as an external runtime prerequisite (the web server auto-launches a managed `opencode serve`).
- Installed workspace dependencies via `bun install`.
- Configured the startup **update script**: `bun install`.

## Verification

- ✅ `bun run lint` — all 4 workspaces pass
- ✅ `bun run type-check` — all 4 workspaces pass
- ✅ `bun run dev` — Vite HMR UI on `http://127.0.0.1:5180`, Express API on `http://127.0.0.1:3902`, managed OpenCode on a random port (`/health` reports `openCodeRunning: true`, `isOpenCodeReady: true`)
- ✅ End-to-end hello-world chat round-trip using the free OpenCode Zen "Big Pickle" model

[openchamber_hello_world_chat.mp4](https://cursor.com/agents/bc-73b7515b-41c2-41e9-9e74-af30923022fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenchamber_hello_world_chat.mp4)

[Hello world chat round-trip](https://cursor.com/agents/bc-73b7515b-41c2-41e9-9e74-af30923022fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_conversation.webp)

## Notes

- This PR only adds the `AGENTS.md` section. Toolchain (`bun`, `opencode`) is installed into the VM snapshot, and the update script keeps deps fresh on startup.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73b7515b-41c2-41e9-9e74-af30923022fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73b7515b-41c2-41e9-9e74-af30923022fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

