### PR TITLE
fix(providers): preserve add-provider form during background provider reload (#1765)

### DIFF
--- a/packages/ui/src/stores/useConfigStore.test.ts
+++ b/packages/ui/src/stores/useConfigStore.test.ts
@@ -389,6 +389,25 @@ describe('useConfigStore provider persistence', () => {
     expect(state.currentVariant).toBe('fast');
   });
 
+  test('provider reload preserves the add-provider sentinel selection', async () => {
+    // The user has opened the "Add provider" form, which sets selectedProviderId
+    // to the sentinel. A background provider refresh must not navigate them away
+    // (and discard their unsaved input) just because the sentinel is not a real
+    // provider id. See issue #1765.
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      currentProviderId: 'live',
+      currentModelId: 'live-model',
+      selectedProviderId: '__add_provider__',
+      directoryScoped: {},
+    });
+
+    liveProviderId = 'live';
+    await useConfigStore.getState().loadProviders({ source: 'test:add-provider' });
+
+    expect(useConfigStore.getState().selectedProviderId).toBe('__add_provider__');
+  });
+
   test('setAgent applies settings default variant for an agent configured model', () => {
     useSessionUIStore.setState({ currentSessionId: 'ses_agent_default_variant' });
     useConfigStore.setState({

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -30,6 +30,9 @@ const STT_SILENCE_HOLD_MS_MAX = 10000;
 
 const FALLBACK_PROVIDER_ID = "opencode";
 const FALLBACK_MODEL_ID = "big-pickle";
+// Sentinel selectedProviderId used by the providers UI while the "Add provider"
+// form is open. It is intentionally not a real provider id.
+const ADD_PROVIDER_SENTINEL = "__add_provider__";
 const GIT_UTILITY_PROVIDER_ID = "zen";
 const GIT_UTILITY_PREFERRED_MODEL_ID = "big-pickle";
 const PROVIDER_CONFIG_REFRESH_CONCURRENCY = 4;
@@ -1573,7 +1576,10 @@ export const useConfigStore = create<ConfigStore>()(
                                 const currentSelectedProviderId = state.activeDirectoryKey === directoryKey
                                     ? state.selectedProviderId
                                     : baseSnapshot.selectedProviderId;
-                                const selectedProviderId = processedProviders.some((provider) => provider.id === currentSelectedProviderId)
+                                // Preserve the add-provider sentinel so a background refresh does not
+                                // navigate the user out of the in-progress add-provider form (issue #1765).
+                                const selectedProviderId = currentSelectedProviderId === ADD_PROVIDER_SENTINEL
+                                    || processedProviders.some((provider) => provider.id === currentSelectedProviderId)
                                     ? currentSelectedProviderId
                                     : (resolvedModel?.providerId ?? processedProviders[0]?.id ?? "");
 


### PR DESCRIPTION
## What
Preserve the `__add_provider__` sentinel in `loadProviders` so a background provider refresh no longer overwrites `selectedProviderId` and navigates the user out of the in-progress "Add provider" form.

## Why
Fixes #1765 (data loss). When the Add-provider form is open, `selectedProviderId` is set to the `__add_provider__` sentinel. That value is not a real provider id, so `processedProviders.some(...)` returned `false` and, on the next provider refresh (config event, prewarm, reconnect), the selection fell back to the first/resolved provider, discarding the user's unsaved credential/config input.

## Fix
- Add an `ADD_PROVIDER_SENTINEL` module constant next to the existing provider-id constants.
- Extend the existing selection guard with one OR-clause so the sentinel is preserved alongside real provider ids.

No change to model resolution or any other selection path; `currentProviderId`/model still derive from `resolvedModel`.

## Testing
- `bun test packages/ui/src/stores/useConfigStore.test.ts` -> 16 pass / 0 fail. The added regression test fails before the fix (`Received "live"`, `Expected "__add_provider__"`) and passes after.
- `bun run type-check:ui` -> pass
- `bun run lint:ui` -> pass

## Risk / notes
Narrow: a single added OR-clause. The sentinel string `__add_provider__` is still declared locally in the providers UI files; consolidating it into one shared constant is left as a follow-up to keep this change minimal.
