### PR TITLE
fix(electron): use server UI on Windows

### DIFF
--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -79,7 +79,8 @@ The package supports macOS and Windows desktop features. Some native discovery h
 | Variable | Use |
 |----------|-----|
 | `OPENCHAMBER_ELECTRON_DEV=1` | Marks the runtime as desktop development mode |
-| `OPENCHAMBER_ELECTRON_USE_BUNDLED_UI=1` | Uses staged web assets instead of the HMR dev server |
+| `OPENCHAMBER_ELECTRON_LOAD_SERVER_UI=1` | Forces the UI to load through the local web server instead of the packaged custom protocol |
+| `OPENCHAMBER_ELECTRON_USE_BUNDLED_UI=1` | Forces staged web assets through the packaged custom protocol; by default packaged Windows builds use the local server for realtime stability |
 | `OPENCHAMBER_HMR_UI_PORT` | Preferred Vite UI port for desktop dev, default `5173` |
 | `OPENCHAMBER_HMR_API_PORT` | Preferred API port for desktop dev, default `3901` |
 | `OPENCHAMBER_RUNTIME=desktop` | Set by Electron before starting the web server |

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -13,6 +13,7 @@ import updaterPkg from 'electron-updater';
 import { ElectronSshManager } from './ssh-manager.mjs';
 import { createTrayController } from './tray.mjs';
 import { resolveManagedOpenCodeCwd } from './opencode-cwd.mjs';
+import { shouldUsePackagedUi as shouldUsePackagedUiForRuntime } from './packaged-ui-policy.mjs';
 import { mintOutsideFileGrant } from '@openchamber/web/server/lib/fs/routes.js';
 
 const execFileAsync = promisify(execFile);
@@ -838,11 +839,11 @@ const buildLocalUrl = (port) => `http://127.0.0.1:${port}`;
 
 const resourceRoot = () => isDev ? path.join(__dirname, 'resources') : process.resourcesPath;
 const resolveWebDistDir = () => path.join(resourceRoot(), 'web-dist');
-const shouldUsePackagedUi = () => {
-  if (process.env.OPENCHAMBER_ELECTRON_LOAD_SERVER_UI === '1') return false;
-  if (process.env.OPENCHAMBER_ELECTRON_USE_BUNDLED_UI === '1') return true;
-  return app.isPackaged;
-};
+const shouldUsePackagedUi = () => shouldUsePackagedUiForRuntime({
+  env: process.env,
+  isPackaged: app.isPackaged,
+  platform: process.platform,
+});
 const packagedUiOrigin = () => `${UI_PROTOCOL}://app`;
 const buildPackagedUiUrl = (pathname = '/index.html') => new URL(pathname, `${packagedUiOrigin()}/`).toString();
 

--- a/packages/electron/packaged-ui-policy.mjs
+++ b/packages/electron/packaged-ui-policy.mjs
@@ -1,0 +1,15 @@
+export const shouldUsePackagedUi = ({
+  env = process.env,
+  isPackaged = false,
+  platform = process.platform,
+} = {}) => {
+  if (env?.OPENCHAMBER_ELECTRON_LOAD_SERVER_UI === '1') return false;
+  if (env?.OPENCHAMBER_ELECTRON_USE_BUNDLED_UI === '1') return true;
+
+  // On Windows, the packaged custom protocol regresses realtime traffic to the
+  // loopback server. Serve the same bundled assets over the local HTTP server
+  // by default, while keeping the protocol path available for explicit testing.
+  if (platform === 'win32') return false;
+
+  return Boolean(isPackaged);
+};

--- a/packages/electron/packaged-ui-policy.test.mjs
+++ b/packages/electron/packaged-ui-policy.test.mjs
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldUsePackagedUi } from './packaged-ui-policy.mjs';
+
+describe('shouldUsePackagedUi', () => {
+  it('uses packaged UI for packaged non-Windows builds', () => {
+    expect(shouldUsePackagedUi({ env: {}, isPackaged: true, platform: 'darwin' })).toBe(true);
+  });
+
+  it('serves packaged Windows builds through the local server by default', () => {
+    expect(shouldUsePackagedUi({ env: {}, isPackaged: true, platform: 'win32' })).toBe(false);
+  });
+
+  it('keeps development builds on the local server by default', () => {
+    expect(shouldUsePackagedUi({ env: {}, isPackaged: false, platform: 'darwin' })).toBe(false);
+  });
+
+  it('allows explicitly opting into bundled UI on Windows', () => {
+    expect(shouldUsePackagedUi({
+      env: { OPENCHAMBER_ELECTRON_USE_BUNDLED_UI: '1' },
+      isPackaged: true,
+      platform: 'win32',
+    })).toBe(true);
+  });
+
+  it('lets the server UI override win over bundled UI', () => {
+    expect(shouldUsePackagedUi({
+      env: {
+        OPENCHAMBER_ELECTRON_LOAD_SERVER_UI: '1',
+        OPENCHAMBER_ELECTRON_USE_BUNDLED_UI: '1',
+      },
+      isPackaged: true,
+      platform: 'darwin',
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- switch packaged Windows desktop builds to load the bundled UI through the local web server instead of the `openchamber-ui://` custom protocol by default
- keep explicit env overrides: `OPENCHAMBER_ELECTRON_LOAD_SERVER_UI=1` still forces server UI, and `OPENCHAMBER_ELECTRON_USE_BUNDLED_UI=1` can still force the custom protocol path for regression testing
- document the env var behavior and add unit coverage for the packaged UI policy

## Why
Issue #1841 reports that OpenChamber Desktop 1.13.3 on Windows becomes sluggish and loses client-server interactions when loaded from `openchamber-ui://`, while forcing the server UI path with `OPENCHAMBER_ELECTRON_LOAD_SERVER_UI=1` restores normal behavior. The desktop server already serves the same packaged `web-dist` assets from `OPENCHAMBER_DIST_DIR`, so this changes the Windows packaged transport without changing the UI build or server API layer.

## Validation
- `bunx vitest run packages/electron/packaged-ui-policy.test.mjs packages/electron/opencode-cwd.test.mjs`
- `bun run type-check:electron`
- `bun run lint:electron`
- `git diff --check`
- `bun run type-check`
- `bun run lint`
- `bun run build`

Fixes #1841
