### PR TITLE
fix(vscode): reset settings page to home on settings entry (#1764)

### DIFF
--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -359,6 +359,7 @@ export const VSCodeLayout: React.FC = () => {
         if (currentViewRef.current !== 'settings') {
           viewBeforeSettingsRef.current = currentViewRef.current;
         }
+        useUIStore.getState().setSettingsPage('home');
         setCurrentView('settings');
       } else if (view === 'chat') {
         setCurrentView('chat');


### PR DESCRIPTION
## What

Reset the persisted `settingsPage` to `'home'` when Settings is opened via the VS Code title-bar Settings command, so the settings home/menu is shown instead of the last-visited section.

Fixes #1764.

## Why

In the VS Code extension, once a non-default settings section (e.g. Providers) had been visited, `settingsPage` was persisted to localStorage and never reset. Clicking **Settings** in the title bar only set `currentView = 'settings'` via the `openchamber:navigate` event, so `SettingsView` re-rendered with the stale persisted section slug. The only way back to the settings menu was the in-section back affordance.

## Fix

`packages/ui/src/components/layout/VSCodeLayout.tsx` — in the `openchamber:navigate` handler, reset `settingsPage` to `'home'` before switching to the settings view:

```ts
if (view === 'settings') {
  useUIStore.getState().setSettingsPage('home');
  setCurrentView('settings');
}
```

The `openchamber:navigate` event with `view: 'settings'` is dispatched **only** from the VS Code title-bar `showSettings` command (`packages/vscode/webview/main.tsx`). In-settings section navigation does not use this event — it calls `setSettingsPage` directly inside `SettingsView` — so resetting to `'home'` here does not interfere with within-settings navigation. This single-source fix covers every caller of the navigate event (Option A from the issue analysis).

`useUIStore` and `setSettingsPage` are already imported/used elsewhere; this is a one-line addition with no new deps or state.

## Validation

- `tsc --noEmit` (packages/ui) — pass (exit 0)
- `eslint src/components/layout/VSCodeLayout.tsx` — pass (exit 0)

## Risk / notes

Narrow: a single added statement. No change to within-settings navigation, persistence shape, or any other view. The `home` value is the existing default (`useUIStore` initial state).