### PR TITLE
fix(vscode): restore previous view when exiting settings (#1776)

### DIFF
--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -108,6 +108,10 @@ export const VSCodeLayout: React.FC = () => {
   }, []);
 
   const [currentView, setCurrentView] = React.useState<VSCodeView>(() => (bootDraftOpen ? 'chat' : 'sessions'));
+  // Mirror currentView so the navigate event handler (registered once) can read the live value.
+  const currentViewRef = React.useRef(currentView);
+  // Snapshot of the view the user was on before opening Settings, so close restores it.
+  const viewBeforeSettingsRef = React.useRef<VSCodeView | null>(null);
   const [containerWidth, setContainerWidth] = React.useState<number>(0);
   const [expandedSidebarWidth, setExpandedSidebarWidth] = React.useState<number>(SESSIONS_SIDEBAR_WIDTH);
   const [isResizingExpandedSidebar, setIsResizingExpandedSidebar] = React.useState(false);
@@ -184,6 +188,11 @@ export const VSCodeLayout: React.FC = () => {
       setCurrentView('chat');
     }
   }, [currentSessionId]);
+
+  // Keep currentViewRef in sync so the stable navigate handler reads the live view.
+  React.useEffect(() => {
+    currentViewRef.current = currentView;
+  }, [currentView]);
 
   React.useEffect(() => {
     const vscodeApi = runtimeApis.vscode;
@@ -347,6 +356,9 @@ export const VSCodeLayout: React.FC = () => {
       const detail = (event as CustomEvent<{ view?: string }>).detail;
       const view = detail?.view;
       if (view === 'settings') {
+        if (currentViewRef.current !== 'settings') {
+          viewBeforeSettingsRef.current = currentViewRef.current;
+        }
         setCurrentView('settings');
       } else if (view === 'chat') {
         setCurrentView('chat');
@@ -532,7 +544,11 @@ export const VSCodeLayout: React.FC = () => {
         // Settings view
         <React.Suspense fallback={null}>
           <SettingsView
-            onClose={() => setCurrentView(usesExpandedLayout ? 'chat' : 'sessions')}
+            onClose={() => {
+              const previousView = viewBeforeSettingsRef.current;
+              viewBeforeSettingsRef.current = null;
+              setCurrentView(previousView ?? (usesExpandedLayout ? 'chat' : 'sessions'));
+            }}
             forceMobile={usesMobileLayout}
           />
         </React.Suspense>


### PR DESCRIPTION
## What

When exiting Settings in the VS Code extension, restore the exact view the user was on before opening Settings (the active chat, or the sessions list) instead of always dropping them on the sessions list.

Fixes #1776.

## Why

`VSCodeLayout` kept `currentView` as a single in-memory value with no notion of a previous view. Two collaborating bugs:

1. **Entry lost the previous view** — the `openchamber:navigate` handler set `currentView = 'settings'` without capturing the prior value.
2. **Exit hardcoded the wrong view** — `SettingsView`'s `onClose` was `setCurrentView(usesExpandedLayout ? 'chat' : 'sessions')`. VS Code's sidebar is always compact (`usesExpandedLayout` is false), so the ternary always evaluated to `'sessions'`, even when an active chat session was open. The auto-routing effect that flips to `'chat'` only fires on `currentSessionId` *changes*, so it did not rescue the close.

Result: open Settings from an active chat → previous view forgotten on entry → close lands on sessions list.

## Fix

`packages/ui/src/components/layout/VSCodeLayout.tsx`:

- Add a `currentViewRef` that mirrors `currentView` (via a `useEffect`) so the navigate handler — which is registered once with `[]` deps and would otherwise close over a stale `currentView` — can read the live view.
- Add a `viewBeforeSettingsRef` snapshot. When the `openchamber:navigate` event requests `view: 'settings'`, snapshot `currentViewRef.current` (guarded so re-entering Settings while already in Settings does not overwrite the snapshot).
- `SettingsView` `onClose` now restores `viewBeforeSettingsRef.current` (clearing it after use), falling back to the previous `usesExpandedLayout ? 'chat' : 'sessions'` behavior when no snapshot exists.

This restores the **exact** previous view: a user who was in chat returns to chat; a user who was on the sessions list returns to the sessions list. It is deterministic (the authoritative previous view) rather than a `currentSessionId` heuristic, so the edge case "on the sessions list with an active session selected" is preserved correctly.

The `openchamber:navigate` `view: 'settings'` event is dispatched only from the VS Code title-bar `showSettings` command (`packages/vscode/webview/main.tsx`), so the snapshot is taken at the right entry point.

## Validation

- `tsc --noEmit` (packages/ui) — pass (exit 0)
- `eslint src/components/layout/VSCodeLayout.tsx` — pass (exit 0)

## Risk / notes

Narrow: two refs + one mirror effect + snapshot/restore at the single settings entry/exit. No change to persistence, the auto-routing effect, or any other view transition. The fallback preserves the prior behavior when no snapshot is present (e.g. Settings opened by a future code path that bypasses the navigate event).