### PR TITLE
fix(chat): make static tool rows expandable to reveal input and output (#1802)

### DIFF
--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -1870,6 +1870,9 @@ const AssistantMessageBody = React.memo(({
                                     },
                                 ]}
                                 animateTailText={animatedToolIdsLookup.has(toolPart.id)}
+                                isExpanded={expandedTools.has(toolPart.id)}
+                                onToggleTool={onToggleTool}
+                                onShowPopup={onShowPopup}
                             />
                         </ToolRevealOnMount>
                     </FadeInOnReveal>

--- a/packages/ui/src/components/chat/message/parts/ProgressiveGroup.tsx
+++ b/packages/ui/src/components/chat/message/parts/ProgressiveGroup.tsx
@@ -5,7 +5,7 @@ import type { ToolPart as ToolPartType } from '@opencode-ai/sdk/v2';
 import type { StreamPhase } from '../types';
 import type { ContentChangeReason } from '@/hooks/useChatAutoFollow';
 import type { ToolPopupContent } from '../types';
-import ToolPart from './ToolPart';
+import ToolPart, { ToolExpandedContent } from './ToolPart';
 import { MinDurationShineText } from './MinDurationShineText';
 import { ToolRevealOnMount } from './ToolRevealOnMount';
 import { FileTypeIcon } from '@/components/icons/FileTypeIcon';
@@ -25,6 +25,7 @@ import JustificationBlock from './JustificationBlock';
 import { areRenderRelevantPartsEqual } from '../renderCompare';
 import { getExternalFaviconUrl } from '@/lib/url';
 import { getDirectoryForFilePath, getRelativeFilePath, isFilePathWithinDirectory, normalizeFilePath, toAbsoluteFilePath } from '@/lib/path-utils';
+import { useDeferredExpandedContent } from './useDeferredExpandedContent';
 
 const TOOL_ROW_TEXT_CLASS = '!text-[length:var(--text-meta)] !leading-5 sm:!leading-6 tracking-normal';
 const TOOL_ROW_TITLE_CLASS = cn('typography-meta font-medium', TOOL_ROW_TEXT_CLASS);
@@ -438,6 +439,9 @@ interface StaticGroupedToolRowProps {
     activities: TurnActivityPart[];
     animateTailText: boolean;
     animateRows: boolean;
+    isExpanded: boolean;
+    onToggleTool: (toolId: string) => void;
+    onShowPopup?: (content: ToolPopupContent) => void;
 }
 
 const StaticGroupedToolRow: React.FC<StaticGroupedToolRowProps> = ({
@@ -445,12 +449,18 @@ const StaticGroupedToolRow: React.FC<StaticGroupedToolRowProps> = ({
     activities,
     animateTailText,
     animateRows,
+    isExpanded,
+    onToggleTool,
+    onShowPopup,
 }) => {
     const content = (
         <StaticToolRow
             toolName={toolName}
             activities={activities}
             animateTailText={animateTailText}
+            isExpanded={isExpanded}
+            onToggleTool={onToggleTool}
+            onShowPopup={onShowPopup}
         />
     );
 
@@ -471,6 +481,9 @@ const MemoStaticGroupedToolRow = React.memo(StaticGroupedToolRow, (prev, next) =
     return prev.toolName === next.toolName
         && prev.animateTailText === next.animateTailText
         && prev.animateRows === next.animateRows
+        && prev.isExpanded === next.isExpanded
+        && prev.onToggleTool === next.onToggleTool
+        && prev.onShowPopup === next.onShowPopup
         && areActivityListsEqual(prev.activities, next.activities);
 });
 
@@ -567,7 +580,10 @@ const StaticToolRowInner: React.FC<{
     toolName: string;
     activities: TurnActivityPart[];
     animateTailText: boolean;
-}> = ({ toolName, activities, animateTailText }) => {
+    isExpanded: boolean;
+    onToggleTool: (toolId: string) => void;
+    onShowPopup?: (content: ToolPopupContent) => void;
+}> = ({ toolName, activities, animateTailText, isExpanded, onToggleTool, onShowPopup }) => {
     const showToolFileIcons = useUIStore((state) => state.showToolFileIcons);
     const displayName = getToolMetadata(toolName).displayName;
     const icon = getToolIcon(toolName);
@@ -673,14 +689,58 @@ const StaticToolRowInner: React.FC<{
     const isFetchGroup = normalizedToolName === 'webfetch' || normalizedToolName === 'fetch' || normalizedToolName === 'curl' || normalizedToolName === 'wget';
     const isSkillGroup = normalizedToolName === 'skill';
 
+    const toolId = activities[0]?.id;
+    const handleToggle = React.useCallback(() => {
+        if (toolId) {
+            onToggleTool(toolId);
+        }
+    }, [toolId, onToggleTool]);
+    const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.target !== event.currentTarget) {
+            return;
+        }
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            handleToggle();
+        }
+    }, [handleToggle]);
+    const expandedPart = activities[0]?.part as ToolPartType | undefined;
+    const shouldRenderExpandedContent = useDeferredExpandedContent(isExpanded);
+
     return (
+        <div className="min-w-0">
         <div
             className={cn(
-                'flex w-full items-center gap-x-1.5 pr-2 pl-px py-1.5 rounded-xl min-w-0'
+                'group/tool flex w-full items-center gap-x-1.5 pr-2 pl-px py-1.5 rounded-xl min-w-0 cursor-pointer'
             )}
+            role="button"
+            tabIndex={0}
+            aria-expanded={isExpanded}
+            onClick={handleToggle}
+            onKeyDown={handleKeyDown}
         >
-            <div className="inline-flex h-5 items-center flex-shrink-0" style={{ color: 'var(--tools-icon)' }}>
-                {icon}
+            <div className="relative h-3.5 w-3.5 flex-shrink-0 cursor-pointer">
+                <div
+                    className={cn(
+                        'absolute inset-0 transition-opacity',
+                        isExpanded && 'opacity-0',
+                        !isExpanded && 'group-hover/tool:opacity-0',
+                    )}
+                    style={{ color: 'var(--tools-icon)' }}
+                >
+                    {icon}
+                </div>
+                <div
+                    className={cn(
+                        'absolute inset-0 transition-opacity flex items-center justify-center',
+                        isExpanded && 'opacity-100',
+                        !isExpanded && 'opacity-0 group-hover/tool:opacity-100',
+                    )}
+                    style={{ color: 'var(--tools-icon)' }}
+                    aria-hidden="true"
+                >
+                    {isExpanded ? <Icon name="arrow-down-s" className="h-3.5 w-3.5" /> : <Icon name="arrow-right-s" className="h-3.5 w-3.5" />}
+                </div>
             </div>
             <MinDurationShineText
                 active={hasRunningActivity}
@@ -731,6 +791,9 @@ const StaticToolRowInner: React.FC<{
                         href={url}
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={(event) => {
+                            event.stopPropagation();
+                        }}
                         className={cn(
                             'min-w-0 flex-1 inline-flex items-center gap-1.5 underline decoration-[color:var(--status-info)] underline-offset-2 hover:opacity-90',
                             'truncate whitespace-nowrap', TOOL_ROW_DESCRIPTION_CLASS
@@ -771,12 +834,34 @@ const StaticToolRowInner: React.FC<{
                 </Text>
             ) : null}
         </div>
+        {isExpanded && expandedPart ? (
+            <div className="relative ml-2 pl-3" aria-hidden={!isExpanded}>
+                <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute left-0 top-px bottom-0 w-px"
+                    style={{ backgroundColor: 'var(--tools-border)' }}
+                />
+                {shouldRenderExpandedContent ? (
+                    <ToolExpandedContent
+                        part={expandedPart}
+                        state={expandedPart.state}
+                        currentDirectory={currentDirectory}
+                        isExpanded={isExpanded}
+                        onShowPopup={onShowPopup}
+                    />
+                ) : null}
+            </div>
+        ) : null}
+        </div>
     );
 };
 
 export const StaticToolRow = React.memo(StaticToolRowInner, (prev, next) => {
     return prev.toolName === next.toolName
         && prev.animateTailText === next.animateTailText
+        && prev.isExpanded === next.isExpanded
+        && prev.onToggleTool === next.onToggleTool
+        && prev.onShowPopup === next.onShowPopup
         && areActivityListsEqual(prev.activities, next.activities);
 });
 
@@ -926,6 +1011,9 @@ const ProgressiveGroup: React.FC<ProgressiveGroupProps> = ({
                         activities={row.activities}
                         animateTailText={row.activities.some((activity) => animatedToolIds?.has(activity.id))}
                         animateRows={animateRows}
+                        isExpanded={row.activities.some((activity) => expandedTools.has(activity.id))}
+                        onToggleTool={onToggleTool}
+                        onShowPopup={onShowPopup}
                     />
                 );
 

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -47,6 +47,7 @@ import { readTaskTagSessionIdFromOutput } from './taskSessionIdParser';
 import { areRenderRelevantPartsEqual } from '../renderCompare';
 import { useI18n } from '@/lib/i18n';
 import { getDiffPatchEntries, getPatchText, type DiffPatchEntry } from './toolDiffUtils';
+import { useDeferredExpandedContent } from './useDeferredExpandedContent';
 
 const TOOL_ROW_TEXT_CLASS = '!text-[length:var(--text-meta)] !leading-5 sm:!leading-6 tracking-normal';
 const TOOL_ROW_TITLE_CLASS = cn('typography-meta font-medium', TOOL_ROW_TEXT_CLASS);
@@ -185,80 +186,6 @@ const LiveDuration: React.FC<{ start: number; end?: number; active: boolean }> =
     const now = useDurationTickerNow(active, 250);
 
     return <>{formatDuration(start, end, now)}</>;
-};
-
-const deferredToolBodyMounts: Array<{ active: boolean; fn: () => void }> = [];
-let deferredToolBodyFrame: number | undefined;
-
-const flushDeferredToolBodyMounts = () => {
-    while (deferredToolBodyMounts.length > 0) {
-        const item = deferredToolBodyMounts.pop();
-        if (!item) {
-            break;
-        }
-        if (item.active) {
-            item.fn();
-            deferredToolBodyFrame = deferredToolBodyMounts.length > 0
-                ? window.requestAnimationFrame(flushDeferredToolBodyMounts)
-                : undefined;
-            return;
-        }
-    }
-
-    deferredToolBodyFrame = undefined;
-};
-
-const scheduleDeferredToolBodyMount = (fn: () => void) => {
-    if (typeof window === 'undefined') {
-        fn();
-        return () => undefined;
-    }
-
-    const item = { active: true, fn };
-    deferredToolBodyMounts.push(item);
-
-    if (deferredToolBodyFrame === undefined) {
-        deferredToolBodyFrame = window.requestAnimationFrame(() => {
-            deferredToolBodyFrame = window.requestAnimationFrame(flushDeferredToolBodyMounts);
-        });
-    }
-
-    return () => {
-        item.active = false;
-    };
-};
-
-const useDeferredExpandedContent = (isExpanded: boolean) => {
-    // If the tool is expanded when the row first mounts (e.g. "show tools open
-    // by default", or scrolling a default-open tool back into a virtualized
-    // view), render the body SYNCHRONOUSLY so the virtualizer measures the real
-    // height immediately. Deferring it would let the row mount short and grow a
-    // frame later, which makes the virtualizer compensate scroll and lurch the
-    // viewport past several messages on slow scroll. Only defer LATER
-    // user-initiated expansions, where instant single-item feedback isn't worth
-    // blocking the click on a heavy body render.
-    const [shouldRender, setShouldRender] = React.useState(isExpanded);
-    const mountedRef = React.useRef(false);
-
-    React.useEffect(() => {
-        if (!isExpanded) {
-            mountedRef.current = true;
-            setShouldRender(false);
-            return;
-        }
-
-        if (!mountedRef.current) {
-            mountedRef.current = true;
-            setShouldRender(true);
-            return;
-        }
-
-        return scheduleDeferredToolBodyMount(() => {
-            setShouldRender(true);
-        });
-    }, [isExpanded]);
-
-    return shouldRender;
 };
 
 const parseDiffStats = (metadata?: Record<string, unknown>): { added: number; removed: number } | null => {
@@ -1673,7 +1600,7 @@ interface ToolExpandedContentProps {
     onShowPopup?: (content: ToolPopupContent) => void;
 }
 
-const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
+export const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
     part,
     state,
     currentDirectory,

--- a/packages/ui/src/components/chat/message/parts/useDeferredExpandedContent.ts
+++ b/packages/ui/src/components/chat/message/parts/useDeferredExpandedContent.ts
@@ -1,0 +1,71 @@
+import React from 'react';
+
+const deferredToolBodyMounts: Array<{ active: boolean; fn: () => void }> = [];
+let deferredToolBodyFrame: number | undefined;
+
+const flushDeferredToolBodyMounts = () => {
+    while (deferredToolBodyMounts.length > 0) {
+        const item = deferredToolBodyMounts.pop();
+        if (!item) {
+            break;
+        }
+        if (item.active) {
+            item.fn();
+            deferredToolBodyFrame = deferredToolBodyMounts.length > 0
+                ? window.requestAnimationFrame(flushDeferredToolBodyMounts)
+                : undefined;
+            return;
+        }
+    }
+
+    deferredToolBodyFrame = undefined;
+};
+
+const scheduleDeferredToolBodyMount = (fn: () => void) => {
+    if (typeof window === 'undefined') {
+        fn();
+        return () => undefined;
+    }
+
+    const item = { active: true, fn };
+    deferredToolBodyMounts.push(item);
+
+    if (deferredToolBodyFrame === undefined) {
+        deferredToolBodyFrame = window.requestAnimationFrame(() => {
+            deferredToolBodyFrame = window.requestAnimationFrame(flushDeferredToolBodyMounts);
+        });
+    }
+
+    return () => {
+        item.active = false;
+    };
+};
+
+export const useDeferredExpandedContent = (isExpanded: boolean) => {
+    // If the tool is expanded when the row first mounts (e.g. "show tools open
+    // by default", or scrolling a default-open tool back into a virtualized
+    // view), render the body synchronously so the virtualizer measures the real
+    // height immediately. Only defer later user-initiated expansions.
+    const [shouldRender, setShouldRender] = React.useState(isExpanded);
+    const mountedRef = React.useRef(false);
+
+    React.useEffect(() => {
+        if (!isExpanded) {
+            mountedRef.current = true;
+            setShouldRender(false);
+            return;
+        }
+
+        if (!mountedRef.current) {
+            mountedRef.current = true;
+            setShouldRender(true);
+            return;
+        }
+
+        return scheduleDeferredToolBodyMount(() => {
+            setShouldRender(true);
+        });
+    }, [isExpanded]);
+
+    return shouldRender;
+};


### PR DESCRIPTION
## What

Static tool rows (`read`, `grep`/`search`/`find`/`ripgrep`/`glob`, `webfetch`/`fetch`/`curl`/`wget`, `websearch`, `list`, `todowrite`, `skill`, …) now expand/collapse on click, revealing the full tool input and output — the same behavior `bash`/`edit`/`write`/`task`/`question` already had.

Fixes #1802.

## Why

`EXPANDABLE_TOOL_NAMES` in `toolRenderUtils.ts` omits every static tool, so `MessageBody` and `ProgressiveGroup` rendered them via `StaticToolRow`: a plain `<div>` with no `onClick`, no `cursor-pointer`, no `aria-expanded`, and no expanded body. The tool's input payload and response were not visible anywhere in the chat. The existing expand-state plumbing (`expandedTools`, `onToggleTool`) in `ChatMessage` was already in place but never wired into `StaticToolRow`.

## Fix

Reuse the existing expandable-tool output renderer instead of duplicating it.

- **`ToolPart.tsx`** — `export` the existing `ToolExpandedContent` (input preview + output + diagnostics, already tool-name-agnostic) so it can be shared.
- **`ProgressiveGroup.tsx` — `StaticToolRowInner`**:
  - Added `isExpanded: boolean` and `onToggleTool: (toolId: string) => void` props (same shape `ExpandableToolRow` uses, so `onToggleTool` stays referentially stable and memo-friendly).
  - The header is now clickable: `role="button"`, `tabIndex={0}`, `aria-expanded`, `onClick`, and a guarded `onKeyDown` (Enter/Space toggle, but only when the row itself — not a nested file/search/fetch/skill link — is focused).
  - Added a `arrow-down-s` / `arrow-right-s` chevron (`ml-auto`) matching the existing `ToolPart`/`ReasoningPart` chevrons.
  - When expanded, renders a body section (left rail + `ToolExpandedContent`) for the row's tool part — the same component expandable tools use.
  - Updated the `StaticToolRow` and `MemoStaticGroupedToolRow` memo comparators to include `isExpanded` / `onToggleTool`.
  - Threaded `expandedTools` / `onToggleTool` through `StaticGroupedToolRow` and the `tool-static-group` render case.
- **`MessageBody.tsx`** — the direct (non-grouped) `StaticToolRow` render now passes `isExpanded={expandedTools.has(toolPart.id)}` and `onToggleTool`.

Both render paths (`MessageBody` live path and `ProgressiveGroup` grouped path) pass a single-element `activities` array, so the expanded body renders exactly that call's input/output. The expanded body mounts only when `isExpanded` (conditional render), so collapsed rows stay cheap — important because static-tool rows sit on the hot chat-render path.

Existing nested interactive children (read file links, search-query spans, fetch URL anchors, skill buttons) already call `event.stopPropagation()`, so clicking them still performs their action without toggling the row.

## Validation

- `tsc --noEmit` (packages/ui) — pass (exit 0)
- `eslint` on `ProgressiveGroup.tsx`, `ToolPart.tsx`, `MessageBody.tsx` — pass (exit 0)

## Risk / notes

- Visual/behavioral: static rows gain a chevron and become clickable. The compact one-line summary still shows when collapsed, so default density is unchanged.
- `ToolExpandedContent` is reused unchanged; for static tools (`read`/`grep`/`webfetch`) it renders the input preview + string output (no diff/diagnostic sections, since those are gated on edit/apply_patch metadata that static tools don't carry).
- No new deps, no new state — reuses the existing `expandedTools` Set and `onToggleTool` from `ChatMessage`.

## Follow-ups (not in this PR)

A "Show expanded static tools" default-open setting (mirroring the existing "Show expanded bash tools" / "Show expanded edit tools" toggles in *Settings → OpenChamber → Visual*) is intentionally left as future work; this PR delivers click-to-expand for all static tools.