### PR TITLE
fix(vscode): flatten alpha on surface fills so tooltips render opaque (#1851)

### DIFF
--- a/packages/ui/src/lib/theme/vscode/adapter.test.ts
+++ b/packages/ui/src/lib/theme/vscode/adapter.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildVSCodeThemeFromPalette, type VSCodeThemePalette } from './adapter';
+
+const buildPalette = (colors: Partial<VSCodeThemePalette['colors']>): VSCodeThemePalette => ({
+  kind: 'dark',
+  colors,
+});
+
+const isOpaqueHex = (color: string): boolean =>
+  !color.startsWith('#') || color.length <= 7;
+
+describe('buildVSCodeThemeFromPalette surface opacity', () => {
+  test('flattens alpha on muted so tooltip/popover backgrounds are opaque', () => {
+    // VS Code overlay tokens are frequently translucent (e.g. #RRGGBBAA).
+    const palette = buildPalette({
+      'chat.requestBackground': '#1e1e1e66',
+      'list.inactiveSelectionBackground': '#37373d99',
+      'editor.lineHighlightBackground': '#00000033',
+    });
+
+    const theme = buildVSCodeThemeFromPalette(palette);
+    const muted = theme.colors.surface.muted;
+
+    expect(isOpaqueHex(muted)).toBe(true);
+    expect(muted.includes('rgba')).toBe(false);
+  });
+
+  test('flattens rgba() alpha on muted into an opaque rgb()', () => {
+    const palette = buildPalette({
+      'editor.lineHighlightBackground': 'rgba(0, 0, 0, 0.2)',
+    });
+
+    const theme = buildVSCodeThemeFromPalette(palette);
+
+    expect(theme.colors.surface.muted).toBe('rgb(0, 0, 0)');
+  });
+
+  test('flattens alpha on elevated, background, and subtle surface fills', () => {
+    const palette = buildPalette({
+      'chat.list.background': '#1e1e1e55',
+      'editorWidget.background': '#252526aa',
+      'input.background': '#31313380',
+    });
+
+    const theme = buildVSCodeThemeFromPalette(palette);
+    const { background, elevated, subtle } = theme.colors.surface;
+
+    for (const color of [background, elevated, subtle]) {
+      expect(isOpaqueHex(color)).toBe(true);
+      expect(color.includes('rgba')).toBe(false);
+    }
+  });
+
+  test('leaves already-opaque surface colors untouched', () => {
+    const palette = buildPalette({
+      'chat.list.background': '#1e1e1e',
+      'editorWidget.background': '#252526',
+      'list.inactiveSelectionBackground': '#37373d',
+    });
+
+    const theme = buildVSCodeThemeFromPalette(palette);
+
+    expect(theme.colors.surface.background).toBe('#1e1e1e');
+    expect(theme.colors.surface.elevated).toBe('#252526');
+    expect(theme.colors.surface.muted).toBe('#37373d');
+  });
+});

--- a/packages/ui/src/lib/theme/vscode/adapter.ts
+++ b/packages/ui/src/lib/theme/vscode/adapter.ts
@@ -302,6 +302,37 @@ const applyAlpha = (color: string, opacity: number): string => {
   return color;
 };
 
+// VS Code overlay tokens (chat.requestBackground, list.inactiveSelectionBackground,
+// editor.lineHighlightBackground, ...) are frequently *translucent* because VS Code
+// paints them over other surfaces. When we feed those values directly into opaque
+// surface fills (tooltip/popover/card/sidebar backgrounds) the alpha leaks through
+// and the UI text becomes unreadable. Flatten any alpha channel so these surfaces
+// render as solid backgrounds, matching the built-in theme expectations.
+const flattenAlpha = (color: string): string => {
+  const normalized = color.trim();
+  if (!normalized) return normalized;
+
+  const rgbMatch = normalized.match(
+    /^rgba?\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})(?:\s*,\s*([0-9.]+))?\s*\)$/i,
+  );
+  if (rgbMatch) {
+    const r = Math.min(255, Math.max(0, Number(rgbMatch[1])));
+    const g = Math.min(255, Math.max(0, Number(rgbMatch[2])));
+    const b = Math.min(255, Math.max(0, Number(rgbMatch[3])));
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+
+  const hex = normalized.replace(/^#/, '');
+  if (hex.length === 4) {
+    return `#${hex.slice(0, 3)}`;
+  }
+  if (hex.length === 8) {
+    return `#${hex.slice(0, 6)}`;
+  }
+
+  return normalized;
+};
+
 const readKind = (preferred?: VSCodeThemeKind): VSCodeThemeKind => {
   if (preferred === 'light' || preferred === 'dark' || preferred === 'high-contrast') {
     return preferred;
@@ -356,23 +387,25 @@ export const buildVSCodeThemeFromPalette = (palette: VSCodeThemePalette): Theme 
   // ===========================================
   
   // Main chat background: match VS Code's chat list first, then fall back to shell surfaces.
-  const background = read('chat.list.background', read('sideBar.background', base.colors.surface.background));
+  const background = flattenAlpha(read('chat.list.background', read('sideBar.background', base.colors.surface.background)));
   
   // Main foreground text color
   const foreground = read('interactive-session.foreground', read('foreground', read('editor.foreground', base.colors.surface.foreground)));
   
-  // Elevated surfaces: panels, cards, dialogs - use editorWidget or panel
-  const elevated = read('editorWidget.background', read('panel.background', read('editor.background', base.colors.surface.elevated)));
+  // Elevated surfaces: panels, cards, dialogs, popovers, tooltips - use editorWidget or panel
+  const elevated = flattenAlpha(read('editorWidget.background', read('panel.background', read('editor.background', base.colors.surface.elevated))));
   const elevatedForeground = read('editorWidget.foreground', read('panel.foreground', foreground));
   
-  // Muted background: used for inactive/deemphasized areas - use list inactive selection
-  const muted = read('chat.requestBackground', read('list.inactiveSelectionBackground', read('editor.lineHighlightBackground', base.colors.surface.muted)));
+  // Muted background: used for inactive/deemphasized areas AND tooltip fills - use list inactive selection.
+  // Flattened because list.inactiveSelectionBackground / editor.lineHighlightBackground are usually
+  // translucent overlays in VS Code themes, which would render the tooltip background transparent.
+  const muted = flattenAlpha(read('chat.requestBackground', read('list.inactiveSelectionBackground', read('editor.lineHighlightBackground', base.colors.surface.muted))));
   
   // Muted foreground: secondary text - description foreground is perfect semantic match
   const mutedForeground = read('descriptionForeground', read('input.placeholderForeground', base.colors.surface.mutedForeground));
   
   // Subtle: used for input backgrounds, user message bubbles - input.background is the semantic match
-  const subtle = read('input.background', read('dropdown.background', elevated));
+  const subtle = flattenAlpha(read('input.background', read('dropdown.background', elevated)));
   
   // Overlay: modal backdrops, status bar
   const overlay = read('statusBar.background', base.colors.surface.overlay);


### PR DESCRIPTION
## Summary

Fixes #1851.

In the VS Code extension, tooltips (and other opaque surfaces) were rendering with a **transparent/translucent background** because the VS Code theme adapter fed translucent VS Code overlay tokens directly into surface colors that back opaque UI fills.

Most visible cases:
- Hovering a row in the **model picker** (model info tooltip)
- Hovering **message actions** (copy/retry/etc.)

## Root cause

The shared `Tooltip` (`packages/ui/src/components/ui/tooltip.tsx`) uses `bg-muted` → `--muted` → `theme.colors.surface.muted`. In `packages/ui/src/lib/theme/vscode/adapter.ts`, `surface.muted` is derived from VS Code tokens that are frequently **translucent overlays**:

```ts
const muted = read('chat.requestBackground',
  read('list.inactiveSelectionBackground',
    read('editor.lineHighlightBackground', base.colors.surface.muted)));
```

`chat.requestBackground`, `list.inactiveSelectionBackground`, and `editor.lineHighlightBackground` commonly carry an alpha channel (e.g. `#00000033`, `#37373d99`, `rgba(0,0,0,0.2)`). That alpha leaks into tooltip/popover/card/sidebar backgrounds, which the built-in Flexoki/Fields themes define as fully opaque. The same could happen for `surface.background`, `surface.elevated` (popovers/dialogs), and `surface.subtle` (input backgrounds, user message bubbles).

## Fix

Add a `flattenAlpha` helper that drops the alpha channel from `#RRGGBBAA` / `#RGBA` / `rgba()` / `rgb()` values, and apply it to the four surface fills that must be opaque: `background`, `elevated`, `muted`, `subtle`.

- Already-opaque values pass through unchanged (no visual change for themes with opaque tokens).
- The macOS vibrancy / sidebar overlay paths are unaffected — they apply their own alpha separately via `applyAlpha` / the `--sidebar-vibrancy-overlay` token.
- Side benefit: `applyAlpha(muted, 0.5)` (used for tool-card backgrounds) now starts from a clean opaque base instead of an already-translucent value, so the 50% tool-card tint is computed correctly.

## Verification

- `tsc --noEmit -p packages/ui/tsconfig.json` — clean (exit 0)
- `eslint` on changed files — clean (exit 0)
- `bun test packages/ui/src/lib/theme/vscode/adapter.test.ts` — 4 pass / 0 fail

Added a `bun:test` regression (`adapter.test.ts`) covering:
- translucent `#RRGGBBAA` → opaque on `muted`
- `rgba(0,0,0,0.2)` → `rgb(0, 0, 0)` on `muted`
- translucent values flattened across `background`, `elevated`, `subtle`
- already-opaque values untouched

## Change scope

Single-file source change in the VS Code theme adapter + a co-located test. No UI component changes, no contract changes, no behavior change for opaque themes.