### PR TITLE
feat(cli): warn when systemd user lingering is disabled on startup enable

### DIFF
--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -11,6 +11,7 @@ import { isModuleCliExecution, normalizeCliEntryPath } from './cli-entry.js';
 import { requestJson } from './lib/cli-http.js';
 import { requestControlAction } from './lib/cli-control.js';
 import { inspectTunnelAttachability } from './lib/cli-lifecycle.js';
+import { startupCommand } from './lib/commands-startup.js';
 import { formatGoal } from './lib/commands-schedule.js';
 import {
   buildSessionCreatePayload,
@@ -34,6 +35,7 @@ import {
   discoverRunningInstances,
   discoverUnconfirmedRegistryInstanceOnPort,
   ensureTunnelProfilesMigrated,
+  EXIT_CODE,
   generateUiPassword,
   getInstanceFilePath,
   getPidFilePath,
@@ -1454,5 +1456,95 @@ describe('Windows startup task command builder', () => {
     const cmd = buildWindowsStartupTaskCommand('C:\\wrapper.ps1');
     expect(cmd).toContain('-File ');
     expect(cmd).not.toContain('-Command ');
+  });
+});
+
+describe('startup command lingering output', () => {
+  const linuxStatus = (lingerEnabled, lingerUser = 'alice') => ({
+    supported: true,
+    platform: 'linux',
+    enabled: true,
+    active: true,
+    activeState: 'active',
+    servicePath: '/home/alice/.config/systemd/user/openchamber.service',
+    lingerEnabled,
+    lingerUser,
+  });
+
+  const dependenciesFor = (status) => ({
+    getStartupStatus: () => status,
+    enableStartupService: () => status,
+    disableStartupService: () => status,
+  });
+
+  const runCommand = (status, options, action) => startupCommand(options, action, dependenciesFor(status));
+
+  it.each([
+    ['enable', true, 'ok', undefined],
+    ['enable', false, 'warning', 'LINGER_DISABLED'],
+    ['enable', null, 'warning', 'LINGER_UNKNOWN'],
+    ['status', true, 'ok', undefined],
+    ['status', false, 'warning', 'LINGER_DISABLED'],
+    ['status', null, 'warning', 'LINGER_UNKNOWN'],
+  ])('reports %s with Linux linger=%s as JSON-only output', async (action, lingerEnabled, expectedStatus, warningCode) => {
+    const output = await captureStdout(() => runCommand(linuxStatus(lingerEnabled), { json: true }, action));
+    const payload = JSON.parse(output);
+
+    expect(payload.status).toBe(expectedStatus);
+    expect(payload.action).toBe(action);
+    expect(payload.lingerEnabled).toBe(lingerEnabled);
+    expect(payload.messages?.[0]?.code).toBe(warningCode);
+  });
+
+  it.each([
+    ['enable', true, 'yes'],
+    ['enable', false, 'no'],
+    ['enable', null, 'unknown'],
+    ['status', true, 'yes'],
+    ['status', false, 'no'],
+    ['status', null, 'unknown'],
+  ])('reports %s with Linux linger=%s in one quiet result line', async (action, lingerEnabled, label) => {
+    const output = await captureStdout(() => runCommand(linuxStatus(lingerEnabled), { quiet: true }, action));
+
+    expect(output.split('\n')).toHaveLength(2);
+    expect(output).toContain(` linger:${label}\n`);
+    expect(output).not.toContain('loginctl');
+  });
+
+  it.each([true, false])('warns with an actionable command in human TTY=%s output', async (isTTY) => {
+    const descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: isTTY });
+    try {
+      const output = await captureStdout(() => runCommand(linuxStatus(false), {}, 'enable'));
+
+      expect(output).toContain('[LINGER_DISABLED]');
+      expect(output).toContain('sudo loginctl enable-linger alice');
+    } finally {
+      if (descriptor) Object.defineProperty(process.stdout, 'isTTY', descriptor);
+      else delete process.stdout.isTTY;
+    }
+  });
+
+  it('reports unknown state without inventing a user when detection is unavailable', async () => {
+    const output = await captureStdout(() => runCommand(linuxStatus(null, null), {}, 'status'));
+
+    expect(output).toContain('[LINGER_UNKNOWN]');
+    expect(output).toContain('loginctl show-user "$USER" -p Linger');
+  });
+
+  it('reports disabled-service linger state without warning or remediation', async () => {
+    const output = await captureStdout(() => runCommand({ ...linuxStatus(false), enabled: false }, {}, 'status'));
+
+    expect(output).toContain('user lingering is disabled');
+    expect(output).not.toContain('[LINGER_DISABLED]');
+    expect(output).not.toContain('loginctl enable-linger');
+  });
+
+  it('does not emit linger guidance for unsupported systems', async () => {
+    await expect(runCommand(
+      { supported: false, platform: 'freebsd', enabled: false, servicePath: null },
+      { json: true },
+      'status'
+    )).rejects.toMatchObject({ exitCode: EXIT_CODE.USAGE_ERROR });
   });
 });

--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -11,6 +11,7 @@ import { isModuleCliExecution, normalizeCliEntryPath } from './cli-entry.js';
 import { requestJson } from './lib/cli-http.js';
 import { requestControlAction } from './lib/cli-control.js';
 import { inspectTunnelAttachability } from './lib/cli-lifecycle.js';
+import { startupCommand } from './lib/commands-startup.js';
 import { formatGoal } from './lib/commands-schedule.js';
 import {
   buildSessionCreatePayload,
@@ -34,6 +35,7 @@ import {
   discoverRunningInstances,
   discoverUnconfirmedRegistryInstanceOnPort,
   ensureTunnelProfilesMigrated,
+  EXIT_CODE,
   getInstanceFilePath,
   getPidFilePath,
   isOpenchamberCmdline,
@@ -1380,5 +1382,95 @@ describe('lifecycle commands with unmanaged explicit ports', () => {
         await server.close();
       }
     });
+  });
+});
+
+describe('startup command lingering output', () => {
+  const linuxStatus = (lingerEnabled, lingerUser = 'alice') => ({
+    supported: true,
+    platform: 'linux',
+    enabled: true,
+    active: true,
+    activeState: 'active',
+    servicePath: '/home/alice/.config/systemd/user/openchamber.service',
+    lingerEnabled,
+    lingerUser,
+  });
+
+  const dependenciesFor = (status) => ({
+    getStartupStatus: () => status,
+    enableStartupService: () => status,
+    disableStartupService: () => status,
+  });
+
+  const runCommand = (status, options, action) => startupCommand(options, action, dependenciesFor(status));
+
+  it.each([
+    ['enable', true, 'ok', undefined],
+    ['enable', false, 'warning', 'LINGER_DISABLED'],
+    ['enable', null, 'warning', 'LINGER_UNKNOWN'],
+    ['status', true, 'ok', undefined],
+    ['status', false, 'warning', 'LINGER_DISABLED'],
+    ['status', null, 'warning', 'LINGER_UNKNOWN'],
+  ])('reports %s with Linux linger=%s as JSON-only output', async (action, lingerEnabled, expectedStatus, warningCode) => {
+    const output = await captureStdout(() => runCommand(linuxStatus(lingerEnabled), { json: true }, action));
+    const payload = JSON.parse(output);
+
+    expect(payload.status).toBe(expectedStatus);
+    expect(payload.action).toBe(action);
+    expect(payload.lingerEnabled).toBe(lingerEnabled);
+    expect(payload.messages?.[0]?.code).toBe(warningCode);
+  });
+
+  it.each([
+    ['enable', true, 'yes'],
+    ['enable', false, 'no'],
+    ['enable', null, 'unknown'],
+    ['status', true, 'yes'],
+    ['status', false, 'no'],
+    ['status', null, 'unknown'],
+  ])('reports %s with Linux linger=%s in one quiet result line', async (action, lingerEnabled, label) => {
+    const output = await captureStdout(() => runCommand(linuxStatus(lingerEnabled), { quiet: true }, action));
+
+    expect(output.split('\n')).toHaveLength(2);
+    expect(output).toContain(` linger:${label}\n`);
+    expect(output).not.toContain('loginctl');
+  });
+
+  it.each([true, false])('warns with an actionable command in human TTY=%s output', async (isTTY) => {
+    const descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: isTTY });
+    try {
+      const output = await captureStdout(() => runCommand(linuxStatus(false), {}, 'enable'));
+
+      expect(output).toContain('[LINGER_DISABLED]');
+      expect(output).toContain('sudo loginctl enable-linger alice');
+    } finally {
+      if (descriptor) Object.defineProperty(process.stdout, 'isTTY', descriptor);
+      else delete process.stdout.isTTY;
+    }
+  });
+
+  it('reports unknown state without inventing a user when detection is unavailable', async () => {
+    const output = await captureStdout(() => runCommand(linuxStatus(null, null), {}, 'status'));
+
+    expect(output).toContain('[LINGER_UNKNOWN]');
+    expect(output).toContain('loginctl show-user "$USER" -p Linger');
+  });
+
+  it('reports disabled-service linger state without warning or remediation', async () => {
+    const output = await captureStdout(() => runCommand({ ...linuxStatus(false), enabled: false }, {}, 'status'));
+
+    expect(output).toContain('user lingering is disabled');
+    expect(output).not.toContain('[LINGER_DISABLED]');
+    expect(output).not.toContain('loginctl enable-linger');
+  });
+
+  it('does not emit linger guidance for unsupported systems', async () => {
+    await expect(runCommand(
+      { supported: false, platform: 'freebsd', enabled: false, servicePath: null },
+      { json: true },
+      'status'
+    )).rejects.toMatchObject({ exitCode: EXIT_CODE.USAGE_ERROR });
   });
 });

--- a/packages/web/bin/lib/cli-startup.js
+++ b/packages/web/bin/lib/cli-startup.js
@@ -283,6 +283,53 @@ function runStartupCommand(command, args, options = {}) {
   return result;
 }
 
+function parseLingerState(stdout) {
+  if (typeof stdout !== 'string') {
+    return null;
+  }
+  const match = stdout.match(/^Linger=([A-Za-z]+)\s*$/m);
+  if (!match) {
+    return null;
+  }
+  const value = match[1].toLowerCase();
+  if (value === 'yes') return true;
+  if (value === 'no') return false;
+  return null;
+}
+
+function getCurrentUsername() {
+  try {
+    const name = os.userInfo().username;
+    if (typeof name === 'string' && name.length > 0) {
+      return name;
+    }
+  } catch {
+    // userInfo() can throw when the uid has no passwd entry; fall back to env.
+  }
+  return process.env.USER || process.env.LOGNAME || '';
+}
+
+// A systemd --user service only keeps running without an active login session
+// when the user has lingering enabled. Detect it so `startup enable` can warn
+// that the service may otherwise stop on logout. Returns null when the state
+// cannot be determined (no username, loginctl unavailable, or odd output).
+function getUserLingerEnabled(username) {
+  const user = typeof username === 'string' && username.length > 0 ? username : getCurrentUsername();
+  if (!user) {
+    return null;
+  }
+  let result;
+  try {
+    result = runStartupCommand('loginctl', ['show-user', user, '-p', 'Linger'], { allowFailure: true });
+  } catch {
+    return null;
+  }
+  if (result.status !== 0) {
+    return null;
+  }
+  return parseLingerState(result.stdout);
+}
+
 function getStartupStatus() {
   const paths = getStartupServicePaths();
   if (!paths.servicePath) {
@@ -296,6 +343,7 @@ function getStartupStatus() {
     const enabledResult = runStartupCommand('systemctl', ['--user', 'is-enabled', 'openchamber.service'], { allowFailure: true });
     const activeResult = runStartupCommand('systemctl', ['--user', 'is-active', 'openchamber.service'], { allowFailure: true });
     const activeState = (activeResult.stdout || '').trim() || 'inactive';
+    const lingerUser = getCurrentUsername();
     return {
       supported: true,
       platform: paths.platform,
@@ -303,6 +351,8 @@ function getStartupStatus() {
       active: activeState === 'active',
       activeState,
       servicePath: paths.servicePath,
+      lingerEnabled: getUserLingerEnabled(lingerUser),
+      lingerUser: lingerUser || null,
     };
   }
   return {

--- a/packages/web/bin/lib/cli-startup.js
+++ b/packages/web/bin/lib/cli-startup.js
@@ -261,6 +261,53 @@ function runStartupCommand(command, args, options = {}) {
   return result;
 }
 
+function parseLingerState(stdout) {
+  if (typeof stdout !== 'string') {
+    return null;
+  }
+  const match = stdout.match(/^Linger=([A-Za-z]+)\s*$/m);
+  if (!match) {
+    return null;
+  }
+  const value = match[1].toLowerCase();
+  if (value === 'yes') return true;
+  if (value === 'no') return false;
+  return null;
+}
+
+function getCurrentUsername() {
+  try {
+    const name = os.userInfo().username;
+    if (typeof name === 'string' && name.length > 0) {
+      return name;
+    }
+  } catch {
+    // userInfo() can throw when the uid has no passwd entry; fall back to env.
+  }
+  return process.env.USER || process.env.LOGNAME || '';
+}
+
+// A systemd --user service only keeps running without an active login session
+// when the user has lingering enabled. Detect it so `startup enable` can warn
+// that the service may otherwise stop on logout. Returns null when the state
+// cannot be determined (no username, loginctl unavailable, or odd output).
+function getUserLingerEnabled(username) {
+  const user = typeof username === 'string' && username.length > 0 ? username : getCurrentUsername();
+  if (!user) {
+    return null;
+  }
+  let result;
+  try {
+    result = runStartupCommand('loginctl', ['show-user', user, '-p', 'Linger'], { allowFailure: true });
+  } catch {
+    return null;
+  }
+  if (result.status !== 0) {
+    return null;
+  }
+  return parseLingerState(result.stdout);
+}
+
 function getStartupStatus() {
   const paths = getStartupServicePaths();
   if (!paths.servicePath) {
@@ -274,6 +321,7 @@ function getStartupStatus() {
     const enabledResult = runStartupCommand('systemctl', ['--user', 'is-enabled', 'openchamber.service'], { allowFailure: true });
     const activeResult = runStartupCommand('systemctl', ['--user', 'is-active', 'openchamber.service'], { allowFailure: true });
     const activeState = (activeResult.stdout || '').trim() || 'inactive';
+    const lingerUser = getCurrentUsername();
     return {
       supported: true,
       platform: paths.platform,
@@ -281,6 +329,8 @@ function getStartupStatus() {
       active: activeState === 'active',
       activeState,
       servicePath: paths.servicePath,
+      lingerEnabled: getUserLingerEnabled(lingerUser),
+      lingerUser: lingerUser || null,
     };
   }
   return {

--- a/packages/web/bin/lib/commands-startup.js
+++ b/packages/web/bin/lib/commands-startup.js
@@ -9,7 +9,10 @@ import {
   logStatus,
 } from '../cli-output.js';
 
-async function startupCommand(options, action = 'status') {
+async function startupCommand(options, action = 'status', dependencies = {}) {
+  const getStatus = dependencies.getStartupStatus || getStartupStatus;
+  const enableService = dependencies.enableStartupService || enableStartupService;
+  const disableService = dependencies.disableStartupService || disableStartupService;
   const normalized = typeof action === 'string' ? action.trim().toLowerCase() : 'status';
   if (!['status', 'enable', 'disable'].includes(normalized)) {
     throw new TunnelCliError(
@@ -20,14 +23,14 @@ async function startupCommand(options, action = 'status') {
 
   let status;
   if (normalized === 'enable') {
-    status = enableStartupService(options);
+    status = enableService(options);
   } else if (normalized === 'disable') {
-    status = disableStartupService();
+    status = disableService();
   } else {
-    status = getStartupStatus();
+    status = getStatus();
   }
 
-  const result = { action: normalized, ...status };
+  let result = { action: normalized, ...status };
   if (!result.supported) {
     throw new TunnelCliError(
       `Startup integration is not supported on ${result.platform}.`,
@@ -40,13 +43,30 @@ async function startupCommand(options, action = 'status') {
       EXIT_CODE.GENERAL_ERROR
     );
   }
+  if (result.platform === 'linux' && result.enabled && result.lingerEnabled !== true) {
+    const user = result.lingerUser || '"$USER"';
+    const disabled = result.lingerEnabled === false;
+    result = {
+      ...result,
+      messages: [{
+        level: 'warning',
+        code: disabled ? 'LINGER_DISABLED' : 'LINGER_UNKNOWN',
+        message: disabled
+          ? `User lingering is disabled; the startup service may stop after logout. Run \`sudo loginctl enable-linger ${user}\` to keep it running.`
+          : `Could not verify user lingering; the startup service may stop after logout. Check with \`loginctl show-user ${user} -p Linger\`.`,
+      }],
+    };
+  }
   if (isJsonMode(options)) {
     printJson(result);
     return;
   }
 
   if (isQuietMode(options)) {
-    process.stdout.write(`startup ${result.enabled ? 'enabled' : 'disabled'} platform:${result.platform} supported:${result.supported ? 'yes' : 'no'}${result.servicePath ? ` path:${result.servicePath}` : ''}\n`);
+    const lingerToken = result.platform === 'linux'
+      ? ` linger:${result.lingerEnabled === true ? 'yes' : result.lingerEnabled === false ? 'no' : 'unknown'}`
+      : '';
+    process.stdout.write(`startup ${result.enabled ? 'enabled' : 'disabled'} platform:${result.platform} supported:${result.supported ? 'yes' : 'no'}${result.servicePath ? ` path:${result.servicePath}` : ''}${lingerToken}\n`);
     return;
   }
 
@@ -57,6 +77,21 @@ async function startupCommand(options, action = 'status') {
   }
   if (normalized === 'enable') {
     logStatus('info', 'service command', 'openchamber serve --foreground');
+  }
+  if (result.platform === 'linux') {
+    if (result.lingerEnabled === true) {
+      logStatus('success', 'user lingering enabled');
+    } else if (result.lingerEnabled === false) {
+      logStatus(result.enabled ? 'warning' : 'info', `${result.enabled ? '[LINGER_DISABLED] ' : ''}user lingering is disabled`, result.enabled ? 'startup service may stop after logout' : undefined);
+      if (result.enabled) {
+        logStatus('info', '[ENABLE_LINGER]', `sudo loginctl enable-linger ${result.lingerUser || '"$USER"'}`);
+      }
+    } else {
+      logStatus(result.enabled ? 'warning' : 'info', result.enabled ? '[LINGER_UNKNOWN] could not verify user lingering' : 'user lingering state is unknown', result.enabled ? 'startup service may stop after logout' : undefined);
+      if (result.enabled) {
+        logStatus('info', '[CHECK_LINGER]', `loginctl show-user ${result.lingerUser || '"$USER"'} -p Linger`);
+      }
+    }
   }
   clackOutro(normalized === 'status' ? 'status complete' : `${normalized} complete`);
 }


### PR DESCRIPTION
> Validated commit: `ae0ac79c68a143241d798e9dceda08a769e4c91d`, rebased onto `main` at `feec14545`.

## Intent

Fixes #1842. On Linux, `startup enable` and `startup status` now detect whether the current user has `systemd` lingering enabled. When the service is enabled and lingering is not, human output warns that the service may stop at logout and prints the exact `sudo loginctl enable-linger <user>` remediation. `--quiet` appends a `linger:yes|no|unknown` token; `--json` adds `lingerEnabled`, `lingerUser`, and a `warning`-level `messages[]` entry.

## Non-goals

No privileged command is run automatically and no system-wide service mode is added.

Documenting lingering in `packages/docs/content/docs/opencode-server.mdx` and the README systemd recipe is out of scope, even though issue #1842 also asked for documentation.

## Affected surfaces

Linux `openchamber startup enable` and `openchamber startup status` in human, `--quiet`, and `--json` modes. macOS and Windows output is unchanged. `startupCommand` gained an optional third dependency-injection argument, used only by tests; it is additive, so existing two-argument callers are unaffected. `cli-startup.js` exports are byte-identical to `main` — the new `parseLingerState`, `getCurrentUsername`, and `getUserLingerEnabled` helpers stay module-private and are reached through `getStartupStatus`. No persisted or server contract changes.

## Rebase note

This branch was rebased from its original base onto `feec14545`. The only conflict was in `packages/web/bin/cli.test.js`, where `main` and this branch each appended an import and a trailing `describe` block. Both were kept: `main`'s `Windows startup task command builder` suite and this branch's `startup command lingering output` suite both run. `cli-startup.js` and `commands-startup.js` merged without conflict, and the resulting diff stat is unchanged from the pre-rebase commit (183 insertions, 6 deletions).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | CLI source changed and a command signature gained an optional parameter | Detection is confined to `cli-startup.js` and adds no exports, so the module contract is unchanged. `startupCommand` takes injected dependencies so presentation is testable without spawning subprocesses. Validation was chosen for the touched surface rather than reflexively: because `type-check:web` and `lint:web` do not cover `bin/**`, the CLI suite, `node --check`, `oxlint`, and a real-host run were used instead. |
| `clack-cli-patterns` | Human, quiet, JSON, and non-TTY output changed | Each mode has one stable representation: prefixed `[LINGER_*]` human lines asserted for both TTY and non-TTY, a single quiet result line, and a machine-readable `messages[]` code. `--json` stays JSON-only with the warning carried in `status` and `messages[]`. No prompt and no privileged side effect was added. |

## Validation

| Check | Result |
|---|---|
| `cd packages/web && bun x vitest run bin/cli.test.js` | 1 file, **105 passed**, 0 failed. Includes `main`'s Windows startup suite, confirming the conflict resolution kept both blocks. |
| `... vitest run bin/cli.test.js -t "startup command lingering output"` | **17 passed**, 88 skipped. |
| `node --check` on `cli.test.js`, `cli-startup.js`, `commands-startup.js` | All parse. Needed because `lint:web` globs only `./src/**/*.{ts,tsx}` and never lints `bin/**/*.js`. |
| `bun x oxlint` on the three changed files | 0 warnings, 0 errors (87 rules). |
| `bun run type-check:web` | Exit 0, but it does not cover this diff: `packages/web/tsconfig.json` `include` is `["src", "../ui/src", ...]`, so `bin/**` is never type-checked. |
| `bun run lint:web` | Exit 0, but it does not cover this diff, per the glob above. |
| **Real-host run** on Linux with systemd and `loginctl` | See below. This closes the gap the previous revision of this description declared. |

### Real-host verification

The earlier revision of this PR stated the `loginctl` detection path had never been exercised against a real host. It now has, on a Linux host with a real systemd user session where `openchamber startup` is genuinely enabled and active. Only the read-only `startup status` was run; no service and no lingering state was modified.

`loginctl show-user ibrakhxn -p Linger` → exit 0, stdout `Linger=yes`.

```
$ node packages/web/bin/cli.js startup status
┌  OpenChamber Startup
│
◆  startup enabled
│  /home/ibrakhxn/.config/systemd/user/openchamber.service
│
◆  service active
│
◆  user lingering enabled
│
└  status complete
```

```
$ node packages/web/bin/cli.js startup status --json
{
  "status": "ok",
  "action": "status",
  "supported": true,
  "platform": "linux",
  "enabled": true,
  "active": true,
  "activeState": "active",
  "servicePath": "/home/ibrakhxn/.config/systemd/user/openchamber.service",
  "lingerEnabled": true,
  "lingerUser": "ibrakhxn"
}
```

```
$ node packages/web/bin/cli.js startup status --quiet
startup enabled platform:linux supported:yes path:/home/ibrakhxn/.config/systemd/user/openchamber.service linger:yes
```

The `--json` payload is JSON-only with no `messages[]`, which is correct for the enabled state. `--quiet` is a single line carrying `linger:yes`.

The parser was also checked against genuine `loginctl` output rather than only synthetic strings. `Linger=yes` → `true`, `Linger=no` → `false`, and non-matching output such as `Failed to get user: ...` → `null`. For a user that is neither logged in nor lingering, real `loginctl` exits **1** and writes to stderr, which `getUserLingerEnabled` maps to `null` before parsing, producing `LINGER_UNKNOWN`.

**Not verified end to end:** the `Linger=no` → `[LINGER_DISABLED]` path. Flipping lingering requires `sudo loginctl disable-linger` and would modify the host, so that state is covered by the unit tests plus the parser check against the real `Linger=no` string format, not by a live run. macOS and Windows were not run.

## Visual evidence

CLI change, so terminal transcripts are the correct evidence and they are included above for human, `--json`, and `--quiet` on a real Linux host. No graphical UI is affected, so screenshots do not apply.

The one transcript that is missing is the disabled-lingering warning, for the host-modification reason given above. Its asserted shape is `[LINGER_DISABLED] user lingering is disabled` followed by `[ENABLE_LINGER] sudo loginctl enable-linger <user>`.

## Risks and failure behavior

An unavailable or unrecognized `loginctl` result yields `unknown`, which is not silent: while the service is enabled the CLI still emits a `warning`-level `[LINGER_UNKNOWN]` line and sets the `--json` `status` to `warning`, so a host where detection cannot run is reported as a warning rather than as healthy.

One real-world nuance the host check surfaced: for a user who is not logged in, `loginctl` fails rather than reporting `Linger=no`, so that case reports `unknown` instead of `disabled`. Both warn while the service is enabled, and the user running `startup enable` is by definition logged in, so the actionable `disabled` case is the one that occurs in practice.

When the service is disabled, linger state is reported at `info` level with no remediation. Enable and disable behavior is otherwise unchanged, and the remediation is only printed; the user retains control of the privileged action. Each Linux `startup` invocation now spawns one extra `loginctl show-user` subprocess, alongside the two `systemctl` calls already on that path, and it degrades to `null` if the binary is missing.

Rollback is reverting one commit; no persisted data or server contract is involved.
