### PR TITLE
fix(update): coordinate systemd user service restarts

### DIFF
--- a/packages/ui/src/components/ui/UpdateDialog.tsx
+++ b/packages/ui/src/components/ui/UpdateDialog.tsx
@@ -116,6 +116,19 @@ type InstallWebUpdateResult = {
   autoRestart?: boolean;
 };
 
+type WebServerUpdateStatus = {
+  state: string;
+  currentVersion?: string;
+  targetVersion?: string;
+  launchMode?: string;
+  restartManager?: string;
+};
+
+type WaitForWebUpdateResult =
+  | { outcome: 'applied' }
+  | { outcome: 'failed'; status: WebServerUpdateStatus | null }
+  | { outcome: 'timeout'; status: WebServerUpdateStatus | null };
+
 const WEB_UPDATE_POLL_INTERVAL_MS = 2000;
 const WEB_UPDATE_MAX_WAIT_MS = 10 * 60 * 1000;
 
@@ -153,12 +166,64 @@ async function isServerReachable(): Promise<boolean> {
   }
 }
 
+async function getWebUpdateStatus(): Promise<WebServerUpdateStatus | null> {
+  try {
+    const response = await runtimeFetch('/api/openchamber/update-status', {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const data = await response.json().catch(() => null);
+    return data && typeof data.state === 'string' ? data as WebServerUpdateStatus : null;
+  } catch {
+    return null;
+  }
+}
+
+function isFailedWebUpdateStatus(state?: string): boolean {
+  return state === 'failed_launch'
+    || state === 'failed_stop'
+    || state === 'failed_install'
+    || state === 'failed_restart';
+}
+
+function mapWebUpdateStatusToDialogState(state?: string): WebUpdateState | null {
+  switch (state) {
+    case 'queued':
+    case 'installing_update':
+      return 'updating';
+    case 'stopping_service':
+    case 'restarting_service':
+      return 'restarting';
+    case 'completed':
+      return 'reconnecting';
+    default:
+      return null;
+  }
+}
+
 async function waitForUpdateApplied(
   previousVersion?: string,
+  onStateChange?: (state: WebUpdateState) => void,
   maxAttempts = Math.ceil(WEB_UPDATE_MAX_WAIT_MS / WEB_UPDATE_POLL_INTERVAL_MS),
   intervalMs = WEB_UPDATE_POLL_INTERVAL_MS,
-): Promise<boolean> {
+): Promise<WaitForWebUpdateResult> {
+  let lastStatus: WebServerUpdateStatus | null = null;
   for (let i = 0; i < maxAttempts; i++) {
+    const status = await getWebUpdateStatus();
+    if (status) {
+      lastStatus = status;
+      if (isFailedWebUpdateStatus(status.state)) {
+        return { outcome: 'failed', status };
+      }
+      const nextState = mapWebUpdateStatusToDialogState(status.state);
+      if (nextState) {
+        onStateChange?.(nextState);
+      }
+    }
+
     try {
       const response = await runtimeFetch('/api/openchamber/update-check', {
         method: 'GET',
@@ -167,7 +232,7 @@ async function waitForUpdateApplied(
       if (response.ok) {
         const data = await response.json().catch(() => null);
         if (data && data.available === false) {
-          return true;
+          return { outcome: 'applied' };
         }
         if (
           data &&
@@ -175,17 +240,18 @@ async function waitForUpdateApplied(
           typeof previousVersion === 'string' &&
           data.currentVersion !== previousVersion
         ) {
-          return true;
+          return { outcome: 'applied' };
         }
       } else if ((response.status === 401 || response.status === 403) && await isServerReachable()) {
-        return true;
+        return { outcome: 'applied' };
       }
     } catch {
       // Server may be restarting
+      onStateChange?.('reconnecting');
     }
     await new Promise(resolve => setTimeout(resolve, intervalMs));
   }
-  return false;
+  return { outcome: 'timeout', status: lastStatus };
 }
 
 export const UpdateDialog: React.FC<UpdateDialogProps> = ({
@@ -254,10 +320,13 @@ export const UpdateDialog: React.FC<UpdateDialogProps> = ({
 
     setWebUpdateState('reconnecting');
 
-    const applied = await waitForUpdateApplied(info?.currentVersion);
+    const outcome = await waitForUpdateApplied(info?.currentVersion, setWebUpdateState);
 
-    if (applied) {
+    if (outcome.outcome === 'applied') {
       window.location.reload();
+    } else if (outcome.outcome === 'failed') {
+      setWebUpdateState('error');
+      setWebError(t('updateDialog.error.updateFailed'));
     } else {
       setWebUpdateState('error');
       setWebError(t('updateDialog.error.takingLonger'));

--- a/packages/web/bin/lib/cli-startup.js
+++ b/packages/web/bin/lib/cli-startup.js
@@ -7,6 +7,11 @@ import { EXIT_CODE, TunnelCliError } from './cli-errors.js';
 import { getDataDir } from './cli-paths.js';
 import { hasUiPasswordConfigured } from './cli-network.js';
 import { searchPathFor } from './cli-executables.js';
+import {
+  OPENCHAMBER_SYSTEMD_USER_SERVICE,
+  getSystemdUserServicePath,
+  getSystemdUserServiceStatus,
+} from '../../server/lib/systemd-user-service.js';
 
 const STARTUP_SERVICE_ID = 'dev.openchamber.web';
 
@@ -20,7 +25,7 @@ function getStartupServicePaths() {
   if (process.platform === 'linux') {
     return {
       platform: 'linux',
-      servicePath: path.join(os.homedir(), '.config', 'systemd', 'user', 'openchamber.service'),
+      servicePath: getSystemdUserServicePath(),
     };
   }
   if (process.platform === 'win32') {
@@ -271,16 +276,14 @@ function getStartupStatus() {
     return { supported: true, platform: paths.platform, enabled: result.status === 0, active: null, servicePath: paths.servicePath };
   }
   if (paths.platform === 'linux') {
-    const enabledResult = runStartupCommand('systemctl', ['--user', 'is-enabled', 'openchamber.service'], { allowFailure: true });
-    const activeResult = runStartupCommand('systemctl', ['--user', 'is-active', 'openchamber.service'], { allowFailure: true });
-    const activeState = (activeResult.stdout || '').trim() || 'inactive';
+    const status = getSystemdUserServiceStatus();
     return {
-      supported: true,
+      supported: status.supported,
       platform: paths.platform,
-      enabled: enabledResult.status === 0 || fs.existsSync(paths.servicePath),
-      active: activeState === 'active',
-      activeState,
-      servicePath: paths.servicePath,
+      enabled: status.enabled,
+      active: status.active,
+      activeState: status.activeState,
+      servicePath: status.servicePath,
     };
   }
   return {
@@ -314,7 +317,7 @@ function enableStartupService(options = {}) {
     fs.mkdirSync(path.dirname(paths.servicePath), { recursive: true, mode: 0o700 });
     fs.writeFileSync(paths.servicePath, buildSystemdUserService(options), { mode: 0o600 });
     runStartupCommand('systemctl', ['--user', 'daemon-reload']);
-    runStartupCommand('systemctl', ['--user', 'enable', '--now', 'openchamber.service']);
+    runStartupCommand('systemctl', ['--user', 'enable', '--now', OPENCHAMBER_SYSTEMD_USER_SERVICE]);
     return getStartupStatus();
   }
 
@@ -351,7 +354,7 @@ function disableStartupService() {
   }
 
   if (paths.platform === 'linux') {
-    runStartupCommand('systemctl', ['--user', 'disable', '--now', 'openchamber.service'], { allowFailure: true });
+    runStartupCommand('systemctl', ['--user', 'disable', '--now', OPENCHAMBER_SYSTEMD_USER_SERVICE], { allowFailure: true });
     try { fs.unlinkSync(paths.servicePath); } catch {}
     runStartupCommand('systemctl', ['--user', 'daemon-reload'], { allowFailure: true });
     return getStartupStatus();

--- a/packages/web/bin/lib/commands-update.js
+++ b/packages/web/bin/lib/commands-update.js
@@ -16,7 +16,7 @@ import {
   logStatus,
 } from '../cli-output.js';
 import {
-  getForegroundSystemdUserServiceController,
+  partitionInstancesForUpdateRestart,
   runForegroundSystemdUserServiceControllerAction,
 } from '../../server/lib/systemd-user-service.js';
 
@@ -33,25 +33,12 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
     } = await importFromFilePath(packageManagerPath);
 
     const runningInstances = await discoverRunningInstances();
-    let managedForegroundController = null;
-    for (const instance of runningInstances) {
-      managedForegroundController = getForegroundSystemdUserServiceController({
-        launchMode: instance.launchMode,
-        port: instance.port,
-      });
-      if (managedForegroundController) {
-        break;
-      }
-    }
-    const managedForegroundInstances = managedForegroundController
-      ? runningInstances.filter((instance) => (
-        instance.launchMode === 'foreground'
-        && (!Number.isFinite(managedForegroundController.configuredPort)
-          || managedForegroundController.configuredPort === instance.port)
-      ))
-      : [];
-    const managedForegroundPorts = new Set(managedForegroundInstances.map((instance) => instance.port));
-    const cliManagedInstances = runningInstances.filter((instance) => !managedForegroundPorts.has(instance.port));
+    const {
+      cliManagedInstances,
+      serviceManagedInstances,
+      serviceManagerOwner,
+    } = partitionInstancesForUpdateRestart(runningInstances);
+    const managedForegroundController = serviceManagerOwner?.controller || null;
     const currentVersion = getCurrentVersion();
 
     if (showOutput) {
@@ -118,7 +105,7 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
         runForegroundSystemdUserServiceControllerAction(managedForegroundController, 'stop', {
           stdio: isJsonMode(options) || isQuietMode(options) ? 'pipe' : 'inherit',
         });
-        for (const instance of managedForegroundInstances) {
+        for (const instance of serviceManagedInstances) {
           removePidFile(instance.pidFilePath);
         }
       }
@@ -167,7 +154,7 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
       });
     }
 
-    const restartedByServiceManagerCount = managedForegroundInstances.length;
+    const restartedByServiceManagerCount = serviceManagedInstances.length;
 
     if (showOutput && !updateSpin) {
       logStatus('success', `updated to ${updateInfo.version || 'latest'}`);

--- a/packages/web/bin/lib/commands-update.js
+++ b/packages/web/bin/lib/commands-update.js
@@ -15,6 +15,10 @@ import {
   printJson,
   logStatus,
 } from '../cli-output.js';
+import {
+  getForegroundSystemdUserServiceController,
+  runForegroundSystemdUserServiceControllerAction,
+} from '../../server/lib/systemd-user-service.js';
 
 function createUpdateCommand({ importFromFilePath, packageManagerPath, serveCommand }) {
   return async function updateCommand(options = {}) {
@@ -29,6 +33,25 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
     } = await importFromFilePath(packageManagerPath);
 
     const runningInstances = await discoverRunningInstances();
+    let managedForegroundController = null;
+    for (const instance of runningInstances) {
+      managedForegroundController = getForegroundSystemdUserServiceController({
+        launchMode: instance.launchMode,
+        port: instance.port,
+      });
+      if (managedForegroundController) {
+        break;
+      }
+    }
+    const managedForegroundInstances = managedForegroundController
+      ? runningInstances.filter((instance) => (
+        instance.launchMode === 'foreground'
+        && (!Number.isFinite(managedForegroundController.configuredPort)
+          || managedForegroundController.configuredPort === instance.port)
+      ))
+      : [];
+    const managedForegroundPorts = new Set(managedForegroundInstances.map((instance) => instance.port));
+    const cliManagedInstances = runningInstances.filter((instance) => !managedForegroundPorts.has(instance.port));
     const currentVersion = getCurrentVersion();
 
     if (showOutput) {
@@ -77,7 +100,7 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
 
     if (runningInstances.length > 0) {
       updateSpin?.message(`Stopping ${runningInstances.length} running instance(s)...`);
-      for (const instance of runningInstances) {
+      for (const instance of cliManagedInstances) {
         try {
           const requested = await requestServerShutdown(instance.port, instance.host);
           await stopInstanceProcess(instance.pid, {
@@ -89,11 +112,29 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
         } catch {
         }
       }
+
+      if (managedForegroundController) {
+        updateSpin?.message(`Stopping ${managedForegroundController.label}...`);
+        runForegroundSystemdUserServiceControllerAction(managedForegroundController, 'stop', {
+          stdio: isJsonMode(options) || isQuietMode(options) ? 'pipe' : 'inherit',
+        });
+        for (const instance of managedForegroundInstances) {
+          removePidFile(instance.pidFilePath);
+        }
+      }
     }
 
     const pm = detectPackageManager();
     const result = executeUpdate(pm, { silent: isJsonMode(options) || isQuietMode(options) });
     if (!result.success) {
+      if (managedForegroundController) {
+        try {
+          runForegroundSystemdUserServiceControllerAction(managedForegroundController, 'start', {
+            stdio: isJsonMode(options) || isQuietMode(options) ? 'pipe' : 'inherit',
+          });
+        } catch {
+        }
+      }
       updateSpin?.error('Update failed');
       if (showOutput) {
         clackOutro('update failed');
@@ -101,9 +142,10 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
       throw new Error(`Update failed with exit code ${result.exitCode}`);
     }
 
-    if (runningInstances.length > 0) {
-      updateSpin?.message(`Restarting ${runningInstances.length} instance(s)...`);
-      for (const instance of runningInstances) {
+    let restartedByCliCount = 0;
+    if (cliManagedInstances.length > 0) {
+      updateSpin?.message(`Restarting ${cliManagedInstances.length} CLI-managed instance(s)...`);
+      for (const instance of cliManagedInstances) {
         const storedOptions = readInstanceOptions(instance.instanceFilePath) || { port: instance.port };
         await serveCommand({
           port: storedOptions.port || instance.port,
@@ -114,8 +156,18 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
           suppressUiPasswordWarning: true,
           quiet: true,
         });
+        restartedByCliCount += 1;
       }
     }
+
+    if (managedForegroundController) {
+      updateSpin?.message(`Starting ${managedForegroundController.label}...`);
+      runForegroundSystemdUserServiceControllerAction(managedForegroundController, 'start', {
+        stdio: isJsonMode(options) || isQuietMode(options) ? 'pipe' : 'inherit',
+      });
+    }
+
+    const restartedByServiceManagerCount = managedForegroundInstances.length;
 
     if (showOutput && !updateSpin) {
       logStatus('success', `updated to ${updateInfo.version || 'latest'}`);
@@ -126,7 +178,9 @@ function createUpdateCommand({ importFromFilePath, packageManagerPath, serveComm
         currentVersion,
         latestVersion: updateInfo.version || 'latest',
         updated: true,
-        restartedCount: runningInstances.length,
+        restartedCount: restartedByCliCount + restartedByServiceManagerCount,
+        restartedByCliCount,
+        restartedByServiceManagerCount,
       });
       return;
     }

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -1,4 +1,4 @@
-import { getForegroundSystemdUserServiceController } from '../systemd-user-service.js';
+import { resolveUpdateRestartOwnerForInstance } from '../systemd-user-service.js';
 
 const UPDATE_STATUS_FILE_NAME = 'update-install-status';
 
@@ -190,11 +190,11 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
       } catch {
       }
       const launchMode = storedOptions.launchMode === 'foreground' ? 'foreground' : 'daemon';
-      const isForegroundService = launchMode === 'foreground';
-      const managedForegroundController = getForegroundSystemdUserServiceController({
+      const restartOwner = resolveUpdateRestartOwnerForInstance({
         launchMode,
         port: storedOptions.port,
       });
+      const managedForegroundController = restartOwner.controller;
 
       const isWindows = process.platform === 'win32';
       const quotePosix = (value) => `'${String(value).replace(/'/g, "'\\''")}'`;
@@ -241,9 +241,7 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
       }
       const restartCmd = managedForegroundController
         ? managedForegroundController.start.shellCommand
-        : isForegroundService
-          ? ''
-          : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
+        : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
       const stopCmd = managedForegroundController?.stop.shellCommand || '';
       const useSystemdRunDetachedUpdate = Boolean(managedForegroundController);
       const updateStatusFilePath = getUpdateStatusFilePath(path, openchamberDataDir);
@@ -251,7 +249,7 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         currentVersion: updateInfo.currentVersion || 'unknown',
         targetVersion: updateInfo.version || 'unknown',
         launchMode,
-        restartManager: managedForegroundController ? 'systemd-user-service' : isForegroundService ? 'process-manager' : 'cli',
+        restartManager: restartOwner.kind,
       });
       writeUpdateStatus(path, fs, openchamberDataDir, buildUpdateStatusPayload(statusBase, { state: 'queued' }));
       const statusCmd = (state) => {
@@ -288,7 +286,7 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         version: updateInfo.version,
         packageManager: pm,
         autoRestart: true,
-        restartManager: managedForegroundController ? 'systemd-user-service' : isForegroundService ? 'process-manager' : 'cli',
+        restartManager: restartOwner.kind,
       });
 
         setTimeout(() => {

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -367,16 +367,19 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
           console.warn('Failed to open update log file, continuing without log capture:', logError);
         }
 
+        const systemdRunArgs = [
+          '--user',
+          ...(typeof process.env.PATH === 'string' && process.env.PATH.length > 0 ? ['-E', 'PATH'] : []),
+          '--unit', `openchamber-update-${Date.now()}`,
+          '--collect',
+          '--quiet',
+          'sh',
+          '-lc',
+          script,
+        ];
+
         const child = useSystemdRunDetachedUpdate
-          ? spawnChild('systemd-run', [
-            '--user',
-            '--unit', `openchamber-update-${Date.now()}`,
-            '--collect',
-            '--quiet',
-            'sh',
-            '-lc',
-            script,
-          ], {
+          ? spawnChild('systemd-run', systemdRunArgs, {
             detached: true,
             stdio: logFd !== null ? ['ignore', logFd, logFd] : 'ignore',
             env: process.env,

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -1,3 +1,5 @@
+import { getForegroundSystemdUserServiceController } from '../systemd-user-service.js';
+
 export const registerOpenChamberRoutes = (app, dependencies) => {
   const {
     fs,
@@ -112,6 +114,10 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
       }
       const launchMode = storedOptions.launchMode === 'foreground' ? 'foreground' : 'daemon';
       const isForegroundService = launchMode === 'foreground';
+      const managedForegroundController = getForegroundSystemdUserServiceController({
+        launchMode,
+        port: storedOptions.port,
+      });
 
       const isWindows = process.platform === 'win32';
       const quotePosix = (value) => `'${String(value).replace(/'/g, "'\\''")}'`;
@@ -156,7 +162,13 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         restartCmdPrimary += ' --api-only';
         restartCmdFallback += ' --api-only';
       }
-      const restartCmd = isForegroundService ? '' : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
+      const restartCmd = managedForegroundController
+        ? managedForegroundController.start.shellCommand
+        : isForegroundService
+          ? ''
+          : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
+      const stopCmd = managedForegroundController?.stop.shellCommand || '';
+      const useSystemdRunDetachedUpdate = Boolean(managedForegroundController);
       const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
       const logPreamble = [
         '',
@@ -170,7 +182,10 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         `globalNodeModulesRoot=${pmDetails.globalNodeModulesRoot || 'unknown'}`,
         `mode=${isContainer ? 'container' : 'restart'}`,
         `launchMode=${launchMode}`,
+        `serviceManager=${managedForegroundController?.label || 'none'}`,
+        `launcher=${useSystemdRunDetachedUpdate ? 'systemd-run --user' : 'direct-detached-shell'}`,
         `updateCommand=${updateCmd}`,
+        `stopCommand=${stopCmd || 'pid/process-exit'}`,
         `restartCommand=${restartCmd || 'service-manager'}`,
         `logPath=${updateLogPath}`,
       ].join('\n');
@@ -181,7 +196,7 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         version: updateInfo.version,
         packageManager: pm,
         autoRestart: true,
-        restartManager: isForegroundService ? 'service' : 'cli',
+        restartManager: managedForegroundController ? 'systemd-user-service' : isForegroundService ? 'process-manager' : 'cli',
       });
 
         setTimeout(() => {
@@ -207,12 +222,26 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
           : `
             printf '%s\n' ${quotePosix(logPreamble)}
             sleep 2
+            ${stopCmd || ':'}
+            if [ $? -ne 0 ]; then
+              echo "Failed to stop OpenChamber before update"
+              exit 1
+            fi
             ${updateCmd}
             if [ $? -eq 0 ]; then
               echo "Update successful, restarting OpenChamber..."
               ${restartCmd || 'echo "Service manager will restart OpenChamber."'}
+              ${managedForegroundController ? `
+              if [ $? -ne 0 ]; then
+                echo "Update succeeded but service restart failed"
+                exit 1
+              fi` : ''}
             else
               echo "Update failed"
+              ${managedForegroundController ? `${restartCmd}
+              if [ $? -ne 0 ]; then
+                echo "Update failed and service restart also failed"
+              fi` : ':'}
               exit 1
             fi
           `;
@@ -225,10 +254,27 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
           console.warn('Failed to open update log file, continuing without log capture:', logError);
         }
 
-        const child = spawnChild(shell, [shellFlag, script], {
-          detached: true,
-          stdio: logFd !== null ? ['ignore', logFd, logFd] : 'ignore',
-          env: process.env,
+        const child = useSystemdRunDetachedUpdate
+          ? spawnChild('systemd-run', [
+            '--user',
+            '--unit', `openchamber-update-${Date.now()}`,
+            '--collect',
+            '--quiet',
+            'sh',
+            '-lc',
+            script,
+          ], {
+            detached: true,
+            stdio: logFd !== null ? ['ignore', logFd, logFd] : 'ignore',
+            env: process.env,
+          })
+          : spawnChild(shell, [shellFlag, script], {
+            detached: true,
+            stdio: logFd !== null ? ['ignore', logFd, logFd] : 'ignore',
+            env: process.env,
+          });
+        child.on('error', (error) => {
+          console.error('Failed to launch detached update process:', error);
         });
         child.unref();
 

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -1,5 +1,82 @@
 import { getForegroundSystemdUserServiceController } from '../systemd-user-service.js';
 
+const UPDATE_STATUS_FILE_NAME = 'update-install-status';
+
+function getUpdateStatusFilePath(pathImpl, openchamberDataDir) {
+  return pathImpl.join(openchamberDataDir, UPDATE_STATUS_FILE_NAME);
+}
+
+function serializeUpdateStatusFile(payload) {
+  return Object.entries(payload)
+    .filter(([, value]) => typeof value === 'string' && value.length > 0)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+}
+
+function parseUpdateStatusFile(content) {
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    return null;
+  }
+
+  const payload = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const separator = line.indexOf('=');
+    if (separator <= 0) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (!key || !value) continue;
+    payload[key] = value;
+  }
+
+  return Object.keys(payload).length > 0 ? payload : null;
+}
+
+function readUpdateStatus(pathImpl, fsImpl, openchamberDataDir) {
+  try {
+    const content = fsImpl.readFileSync(getUpdateStatusFilePath(pathImpl, openchamberDataDir), 'utf8');
+    return parseUpdateStatusFile(content);
+  } catch {
+    return null;
+  }
+}
+
+function writeUpdateStatus(pathImpl, fsImpl, openchamberDataDir, payload) {
+  const filePath = getUpdateStatusFilePath(pathImpl, openchamberDataDir);
+  fsImpl.mkdirSync(pathImpl.dirname(filePath), { recursive: true });
+  fsImpl.writeFileSync(filePath, `${serializeUpdateStatusFile(payload)}\n`, 'utf8');
+}
+
+function quoteStatusValue(value) {
+  return String(value || '').replace(/[\r\n]/g, ' ').trim();
+}
+
+function buildUpdateStatusPayload(base, overrides = {}) {
+  const next = {
+    ...base,
+    ...overrides,
+  };
+
+  return Object.fromEntries(
+    Object.entries(next)
+      .filter(([, value]) => value !== null && value !== undefined && String(value).trim().length > 0)
+      .map(([key, value]) => [key, quoteStatusValue(value)]),
+  );
+}
+
+function buildPosixUpdateStatusCommand(statusFilePath, quotePosix, payload) {
+  const lines = Object.entries(payload).map(([key, value]) => `${key}=${value}`);
+  const quotedLines = lines.map((line) => quotePosix(line)).join(' ');
+  return `printf '%s\\n' ${quotedLines} > ${quotePosix(statusFilePath)}`;
+}
+
+function buildWindowsUpdateStatusCommand(statusFilePath, quoteCmd, payload) {
+  const lines = Object.entries(payload).map(([key, value]) => `${key}=${value}`);
+  const body = lines.map((line) => `echo ${line}`).join('\r\n');
+  return `(${body}) > ${quoteCmd(statusFilePath)}`;
+}
+
 export const registerOpenChamberRoutes = (app, dependencies) => {
   const {
     fs,
@@ -169,6 +246,20 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
           : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
       const stopCmd = managedForegroundController?.stop.shellCommand || '';
       const useSystemdRunDetachedUpdate = Boolean(managedForegroundController);
+      const updateStatusFilePath = getUpdateStatusFilePath(path, openchamberDataDir);
+      const statusBase = buildUpdateStatusPayload({
+        currentVersion: updateInfo.currentVersion || 'unknown',
+        targetVersion: updateInfo.version || 'unknown',
+        launchMode,
+        restartManager: managedForegroundController ? 'systemd-user-service' : isForegroundService ? 'process-manager' : 'cli',
+      });
+      writeUpdateStatus(path, fs, openchamberDataDir, buildUpdateStatusPayload(statusBase, { state: 'queued' }));
+      const statusCmd = (state) => {
+        const payload = buildUpdateStatusPayload(statusBase, { state });
+        return isWindows
+          ? buildWindowsUpdateStatusCommand(updateStatusFilePath, quoteCmd, payload)
+          : buildPosixUpdateStatusCommand(updateStatusFilePath, quotePosix, payload);
+      };
       const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
       const logPreamble = [
         '',
@@ -187,6 +278,7 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         `updateCommand=${updateCmd}`,
         `stopCommand=${stopCmd || 'pid/process-exit'}`,
         `restartCommand=${restartCmd || 'service-manager'}`,
+        `statusFile=${updateStatusFilePath}`,
         `logPath=${updateLogPath}`,
       ].join('\n');
 
@@ -210,11 +302,27 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
             ? `
             echo ${quoteCmd(logPreamble)}
             timeout /t 2 /nobreak >nul
+            ${statusCmd('stopping_service')}
+            ${stopCmd || 'rem no service stop required'}
+            if %ERRORLEVEL% NEQ 0 (
+              ${statusCmd('failed_stop')}
+              echo Failed to stop OpenChamber before update
+              exit /b 1
+            )
+            ${statusCmd('installing_update')}
             ${updateCmd}
             if %ERRORLEVEL% EQU 0 (
+              ${statusCmd('restarting_service')}
               echo Update successful, restarting OpenChamber...
               ${restartCmd || 'echo Service manager will restart OpenChamber.'}
+              if %ERRORLEVEL% NEQ 0 (
+                ${statusCmd('failed_restart')}
+                echo Update succeeded but restart failed
+                exit /b 1
+              )
+              ${statusCmd('completed')}
             ) else (
+              ${statusCmd('failed_install')}
               echo Update failed
               exit /b 1
             )
@@ -222,24 +330,31 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
           : `
             printf '%s\n' ${quotePosix(logPreamble)}
             sleep 2
+            ${statusCmd('stopping_service')}
             ${stopCmd || ':'}
             if [ $? -ne 0 ]; then
+              ${statusCmd('failed_stop')}
               echo "Failed to stop OpenChamber before update"
               exit 1
             fi
+            ${statusCmd('installing_update')}
             ${updateCmd}
             if [ $? -eq 0 ]; then
+              ${statusCmd('restarting_service')}
               echo "Update successful, restarting OpenChamber..."
               ${restartCmd || 'echo "Service manager will restart OpenChamber."'}
-              ${managedForegroundController ? `
               if [ $? -ne 0 ]; then
+                ${statusCmd('failed_restart')}
                 echo "Update succeeded but service restart failed"
                 exit 1
-              fi` : ''}
+              fi
+              ${statusCmd('completed')}
             else
+              ${statusCmd('failed_install')}
               echo "Update failed"
               ${managedForegroundController ? `${restartCmd}
               if [ $? -ne 0 ]; then
+                ${statusCmd('failed_restart')}
                 echo "Update failed and service restart also failed"
               fi` : ':'}
               exit 1
@@ -274,6 +389,10 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
             env: process.env,
           });
         child.on('error', (error) => {
+          try {
+            writeUpdateStatus(path, fs, openchamberDataDir, buildUpdateStatusPayload(statusBase, { state: 'failed_launch' }));
+          } catch {
+          }
           console.error('Failed to launch detached update process:', error);
         });
         child.unref();
@@ -296,6 +415,16 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
       res.status(500).json({
         error: error instanceof Error ? error.message : 'Failed to install update',
       });
+    }
+  });
+
+  app.get('/api/openchamber/update-status', async (_req, res) => {
+    try {
+      const status = readUpdateStatus(path, fs, openchamberDataDir);
+      res.json(status || { state: 'idle' });
+    } catch (error) {
+      console.error('Failed to read update status:', error);
+      res.status(500).json({ state: 'unknown', error: error instanceof Error ? error.message : 'Failed to read update status' });
     }
   });
 

--- a/packages/web/server/lib/systemd-user-service.js
+++ b/packages/web/server/lib/systemd-user-service.js
@@ -137,6 +137,69 @@ export function getForegroundSystemdUserServiceController({
   };
 }
 
+export function resolveUpdateRestartOwnerForInstance({
+  launchMode,
+  port,
+  platform = process.platform,
+  homedir = os.homedir(),
+  fsImpl = fs,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  const controller = getForegroundSystemdUserServiceController({
+    launchMode,
+    port,
+    platform,
+    homedir,
+    fsImpl,
+    spawnSyncImpl,
+  });
+
+  if (controller) {
+    return {
+      kind: 'systemd-user-service',
+      label: controller.label,
+      controller,
+    };
+  }
+
+  return {
+    kind: 'cli',
+    label: 'CLI',
+    controller: null,
+  };
+}
+
+export function partitionInstancesForUpdateRestart(instances = [], options = {}) {
+  const cliManagedInstances = [];
+  const serviceManagedInstances = [];
+  let serviceManagerOwner = null;
+
+  for (const instance of instances) {
+    const owner = resolveUpdateRestartOwnerForInstance({
+      launchMode: instance?.launchMode,
+      port: instance?.port,
+      platform: options.platform,
+      homedir: options.homedir,
+      fsImpl: options.fsImpl,
+      spawnSyncImpl: options.spawnSyncImpl,
+    });
+
+    if (owner.controller) {
+      serviceManagerOwner = serviceManagerOwner || owner;
+      serviceManagedInstances.push(instance);
+      continue;
+    }
+
+    cliManagedInstances.push(instance);
+  }
+
+  return {
+    cliManagedInstances,
+    serviceManagedInstances,
+    serviceManagerOwner,
+  };
+}
+
 export function runForegroundSystemdUserServiceControllerAction(
   controller,
   action,

--- a/packages/web/server/lib/systemd-user-service.js
+++ b/packages/web/server/lib/systemd-user-service.js
@@ -1,0 +1,170 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+export const OPENCHAMBER_SYSTEMD_USER_SERVICE = 'openchamber.service';
+
+function getSpawnSyncBaseOptions() {
+  return process.platform === 'win32' ? { windowsHide: true } : {};
+}
+
+export function getSystemdUserServicePath({ homedir = os.homedir() } = {}) {
+  return path.join(homedir, '.config', 'systemd', 'user', OPENCHAMBER_SYSTEMD_USER_SERVICE);
+}
+
+function runSystemdUserCommand(args, { spawnSyncImpl = spawnSync, stdio = 'pipe' } = {}) {
+  const result = spawnSyncImpl('systemctl', ['--user', ...args], {
+    encoding: 'utf8',
+    stdio,
+    ...getSpawnSyncBaseOptions(),
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result;
+}
+
+function readConfiguredPortFromUnit(servicePath, { fsImpl = fs } = {}) {
+  try {
+    const content = fsImpl.readFileSync(servicePath, 'utf8');
+    const match = content.match(/["']?--port["']?\s+["']?(\d+)["']?/);
+    if (!match) return null;
+    const parsed = Number.parseInt(match[1], 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getSystemdUserServiceStatus({
+  platform = process.platform,
+  homedir = os.homedir(),
+  fsImpl = fs,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  if (platform !== 'linux') {
+    return {
+      supported: false,
+      enabled: false,
+      active: false,
+      activeState: 'unsupported',
+      configuredPort: null,
+      servicePath: null,
+    };
+  }
+
+  const servicePath = getSystemdUserServicePath({ homedir });
+  const configuredPort = readConfiguredPortFromUnit(servicePath, { fsImpl });
+
+  let enabledResult;
+  let activeResult;
+  try {
+    enabledResult = runSystemdUserCommand(['is-enabled', OPENCHAMBER_SYSTEMD_USER_SERVICE], {
+      spawnSyncImpl,
+      stdio: 'pipe',
+    });
+    activeResult = runSystemdUserCommand(['is-active', OPENCHAMBER_SYSTEMD_USER_SERVICE], {
+      spawnSyncImpl,
+      stdio: 'pipe',
+    });
+  } catch {
+    return {
+      supported: true,
+      enabled: fsImpl.existsSync(servicePath),
+      active: false,
+      activeState: 'unknown',
+      configuredPort,
+      servicePath,
+    };
+  }
+
+  const activeState = (activeResult.stdout || '').trim() || 'inactive';
+
+  return {
+    supported: true,
+    enabled: enabledResult.status === 0 || fsImpl.existsSync(servicePath),
+    active: activeState === 'active',
+    activeState,
+    configuredPort,
+    servicePath,
+  };
+}
+
+export function getForegroundSystemdUserServiceController({
+  launchMode,
+  port,
+  platform = process.platform,
+  homedir = os.homedir(),
+  fsImpl = fs,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  if (launchMode !== 'foreground' || platform !== 'linux') {
+    return null;
+  }
+
+  const status = getSystemdUserServiceStatus({ platform, homedir, fsImpl, spawnSyncImpl });
+  if (!status.supported || !status.enabled || !status.active) {
+    return null;
+  }
+
+  if (
+    Number.isFinite(port)
+    && Number.isFinite(status.configuredPort)
+    && status.configuredPort !== port
+  ) {
+    return null;
+  }
+
+  return {
+    kind: 'systemd-user',
+    label: 'systemd user service',
+    serviceName: OPENCHAMBER_SYSTEMD_USER_SERVICE,
+    servicePath: status.servicePath,
+    configuredPort: status.configuredPort,
+    stop: {
+      command: 'systemctl',
+      args: ['--user', 'stop', OPENCHAMBER_SYSTEMD_USER_SERVICE],
+      shellCommand: `systemctl --user stop ${OPENCHAMBER_SYSTEMD_USER_SERVICE}`,
+    },
+    start: {
+      command: 'systemctl',
+      args: ['--user', 'start', OPENCHAMBER_SYSTEMD_USER_SERVICE],
+      shellCommand: `systemctl --user start ${OPENCHAMBER_SYSTEMD_USER_SERVICE}`,
+    },
+  };
+}
+
+export function runForegroundSystemdUserServiceControllerAction(
+  controller,
+  action,
+  { spawnSyncImpl = spawnSync, stdio = 'pipe' } = {},
+) {
+  if (!controller || controller.kind !== 'systemd-user') {
+    throw new Error('A systemd user service controller is required.');
+  }
+
+  const step = action === 'stop' ? controller.stop : action === 'start' ? controller.start : null;
+  if (!step) {
+    throw new Error(`Unsupported systemd user service action: ${action}`);
+  }
+
+  const result = spawnSyncImpl(step.command, step.args, {
+    encoding: 'utf8',
+    stdio,
+    ...getSpawnSyncBaseOptions(),
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || '').trim();
+    throw new Error(`${step.command} ${step.args.join(' ')} failed${detail ? `: ${detail}` : ''}`);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Fix update behavior when OpenChamber runs as a Linux systemd user service.

This covers both update entry points:

- `openchamber update`
- client-triggered `POST /api/openchamber/update-install`

## Problem

Foreground OpenChamber instances started via startup integration are owned by `systemd --user` with `Restart=always`.

Before this change:

- the CLI update flow stopped the running process and then restarted it itself, racing with systemd
- the client/server update flow spawned an updater from inside the service process, so any attempt to stop the service risked killing the updater too

That could lead to:

- restart races
- old version coming back up before the install finished
- port conflicts / wrong lifecycle ownership

## Fix

### CLI update

`packages/web/bin/cli.js`

- detect when a foreground instance is the active `openchamber.service` user unit
- stop/start that service through `systemctl --user` instead of PID-level stop + CLI restart
- keep CLI-managed instances on the existing stop/update/restart path
- restart the service again if the package-manager update fails, so the app is not left down

### Client/server update

`packages/web/server/lib/opencode/openchamber-routes.js`

- detect the same systemd-managed foreground case
- launch the updater via a transient `systemd-run --user` unit so it survives stopping `openchamber.service`
- explicitly stop the service before update and start it again after update
- attempt to bring the service back even on update failure

### Shared helper

`packages/web/server/lib/systemd-user-service.js`

- centralizes systemd user-service detection
- matches the configured service port when available
- provides stop/start commands for both CLI and server update flows

## Validation

```bash
node --check packages/web/bin/cli.js
node --check packages/web/server/lib/opencode/openchamber-routes.js
node --check packages/web/server/lib/systemd-user-service.js
```

## Related

Closes #1861
