### PR TITLE
fix(git): materialize draft session for PR share comments / failed checks / single comment

### DIFF
--- a/packages/ui/src/components/views/git/PullRequestSection.tsx
+++ b/packages/ui/src/components/views/git/PullRequestSection.tsx
@@ -29,7 +29,7 @@ import { SimpleMarkdownRenderer } from '@/components/chat/MarkdownRenderer';
 import { Icon } from "@/components/icon/Icon";
 import { useUIStore } from '@/stores/useUIStore';
 import { formatDateTimeForPreference } from '@/lib/timeFormat';
-import { materializeOpenDraftSession, useSessionUIStore } from '@/sync/session-ui-store';
+import { materializeOpenDraftSession, useSessionUIStore, type SyntheticContextPart } from '@/sync/session-ui-store';
 import { useSelectionStore } from '@/sync/selection-store';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { useGitHubAuthStore } from '@/stores/useGitHubAuthStore';
@@ -244,6 +244,7 @@ type ChatDispatchTarget = {
   modelID: string;
   currentAgentName: string | null;
   currentVariant: string | null;
+  carriedSyntheticParts?: SyntheticContextPart[];
 };
 
 const pullRequestDraftSnapshots = new Map<string, PullRequestDraftSnapshot>();
@@ -695,49 +696,58 @@ export const PullRequestSection: React.FC<{
   }, [commentsDetails, t]);
 
   const resolveChatDispatchTarget = React.useCallback(async (): Promise<ChatDispatchTarget | null> => {
-    let sessionId = currentSessionId;
+    try {
+      let sessionId = currentSessionId;
+      let carriedSyntheticParts: SyntheticContextPart[] | undefined;
 
-    if (!sessionId) {
-      const draft = useSessionUIStore.getState().newSessionDraft;
-      if (draft?.open) {
-        const config = useConfigStore.getState();
-        if (!config.currentProviderId || !config.currentModelId) {
-          toast.error(t('gitView.pr.toast.noModelSelected'));
-          return null;
-        }
-        const materialized = await materializeOpenDraftSession({
-          providerID: config.currentProviderId,
-          modelID: config.currentModelId,
-          agent: config.currentAgentName || undefined,
-          variant: config.currentVariant || undefined,
-        });
-        if (!materialized) {
+      if (!sessionId) {
+        const draft = useSessionUIStore.getState().newSessionDraft;
+        if (draft?.open) {
+          const config = useConfigStore.getState();
+          if (!config.currentProviderId || !config.currentModelId) {
+            toast.error(t('gitView.pr.toast.noModelSelected'));
+            return null;
+          }
+          const materialized = await materializeOpenDraftSession({
+            providerID: config.currentProviderId,
+            modelID: config.currentModelId,
+            agent: config.currentAgentName || undefined,
+            variant: config.currentVariant || undefined,
+          });
+          if (!materialized) {
+            toast.error(t('gitView.pr.toast.noActiveSession'), { description: t('gitView.pr.toast.noActiveSessionDescription') });
+            return null;
+          }
+          sessionId = materialized.sessionId;
+          carriedSyntheticParts = materialized.syntheticParts;
+        } else {
           toast.error(t('gitView.pr.toast.noActiveSession'), { description: t('gitView.pr.toast.noActiveSessionDescription') });
           return null;
         }
-        sessionId = materialized.sessionId;
-      } else {
-        toast.error(t('gitView.pr.toast.noActiveSession'), { description: t('gitView.pr.toast.noActiveSessionDescription') });
+      }
+
+      const { currentProviderId, currentModelId, currentAgentName, currentVariant } = useConfigStore.getState();
+      const lastUsedProvider = useSelectionStore.getState().lastUsedProvider;
+      const providerID = currentProviderId || lastUsedProvider?.providerID;
+      const modelID = currentModelId || lastUsedProvider?.modelID;
+      if (!providerID || !modelID) {
+        toast.error(t('gitView.pr.toast.noModelSelected'));
         return null;
       }
-    }
 
-    const { currentProviderId, currentModelId, currentAgentName, currentVariant } = useConfigStore.getState();
-    const lastUsedProvider = useSelectionStore.getState().lastUsedProvider;
-    const providerID = currentProviderId || lastUsedProvider?.providerID;
-    const modelID = currentModelId || lastUsedProvider?.modelID;
-    if (!providerID || !modelID) {
-      toast.error(t('gitView.pr.toast.noModelSelected'));
+      return {
+        sessionId,
+        providerID,
+        modelID,
+        currentAgentName: currentAgentName ?? null,
+        currentVariant: currentVariant ?? null,
+        carriedSyntheticParts,
+      };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(t('gitView.pr.toast.sendMessageFailed'), { description: message });
       return null;
     }
-
-    return {
-      sessionId,
-      providerID,
-      modelID,
-      currentAgentName: currentAgentName ?? null,
-      currentVariant: currentVariant ?? null,
-    };
   }, [currentSessionId, t]);
 
   const dispatchSyntheticPrompt = React.useCallback((
@@ -746,6 +756,12 @@ export const PullRequestSection: React.FC<{
     instructionsText: string,
     payloadText: string,
   ) => {
+    const syntheticParts: SyntheticContextPart[] = [
+      { text: instructionsText, synthetic: true },
+      { text: payloadText, synthetic: true },
+      ...(target.carriedSyntheticParts ?? []),
+    ];
+
     void useSessionUIStore.getState().sendMessage(
       visibleText,
       target.providerID,
@@ -753,11 +769,10 @@ export const PullRequestSection: React.FC<{
       target.currentAgentName ?? undefined,
       undefined,
       undefined,
-      [
-        { text: instructionsText, synthetic: true },
-        { text: payloadText, synthetic: true },
-      ],
+      syntheticParts,
       target.currentVariant ?? undefined,
+      undefined,
+      { sessionId: target.sessionId },
     ).catch((e) => {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(t('gitView.pr.toast.sendMessageFailed'), { description: message });
@@ -902,10 +917,6 @@ export const PullRequestSection: React.FC<{
       return;
     }
     if (!directory || !pr) return;
-    const target = await resolveChatDispatchTarget();
-    if (!target) {
-      return;
-    }
 
     try {
       const context = await github.prContext(directory, pr.number, { includeDiff: false, includeCheckDetails: true });
@@ -943,6 +954,11 @@ export const PullRequestSection: React.FC<{
         failedAnnotations,
       }, null, 2)}`;
 
+      const target = await resolveChatDispatchTarget();
+      if (!target) {
+        return;
+      }
+
       dispatchSyntheticPrompt(target, visibleText, instructionsText, payloadText);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -958,10 +974,6 @@ export const PullRequestSection: React.FC<{
       return;
     }
     if (!directory || !pr) return;
-    const target = await resolveChatDispatchTarget();
-    if (!target) {
-      return;
-    }
 
     try {
       const context = await github.prContext(directory, pr.number, { includeDiff: false, includeCheckDetails: false });
@@ -982,6 +994,11 @@ export const PullRequestSection: React.FC<{
         reviewComments,
       }, null, 2)}`;
 
+      const target = await resolveChatDispatchTarget();
+      if (!target) {
+        return;
+      }
+
       dispatchSyntheticPrompt(target, visibleText, instructionsText, payloadText);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -993,21 +1010,26 @@ export const PullRequestSection: React.FC<{
     setCommentsDialogOpen(false);
     setActiveMainTab('chat');
 
-    const target = await resolveChatDispatchTarget();
-    if (!target) {
-      return;
+    try {
+      const visibleText = await renderMagicPrompt('github.pr.comment.single.visible');
+      const instructionsText = await renderMagicPrompt('github.pr.comment.single.instructions');
+      const payloadText = `GitHub PR comment (JSON)\n${JSON.stringify({
+        repo: commentsDetails?.repo ?? null,
+        pr: commentsDetails?.pr ?? pr ?? null,
+        comment,
+      }, null, 2)}`;
+
+      const target = await resolveChatDispatchTarget();
+      if (!target) {
+        return;
+      }
+
+      dispatchSyntheticPrompt(target, visibleText, instructionsText, payloadText);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(t('gitView.pr.toast.sendMessageFailed'), { description: message });
     }
-
-    const visibleText = await renderMagicPrompt('github.pr.comment.single.visible');
-    const instructionsText = await renderMagicPrompt('github.pr.comment.single.instructions');
-    const payloadText = `GitHub PR comment (JSON)\n${JSON.stringify({
-      repo: commentsDetails?.repo ?? null,
-      pr: commentsDetails?.pr ?? pr ?? null,
-      comment,
-    }, null, 2)}`;
-
-    dispatchSyntheticPrompt(target, visibleText, instructionsText, payloadText);
-  }, [commentsDetails, dispatchSyntheticPrompt, pr, resolveChatDispatchTarget, setActiveMainTab]);
+  }, [commentsDetails, dispatchSyntheticPrompt, pr, resolveChatDispatchTarget, setActiveMainTab, t]);
 
   const refresh = React.useCallback(async (options?: { force?: boolean; onlyExistingPr?: boolean; silent?: boolean; markInitialResolved?: boolean }) => {
     await refreshPrStatus(prStatusKey, options);

--- a/packages/ui/src/components/views/git/PullRequestSection.tsx
+++ b/packages/ui/src/components/views/git/PullRequestSection.tsx
@@ -474,6 +474,7 @@ export const PullRequestSection: React.FC<{
   const [commentsDialogOpen, setCommentsDialogOpen] = React.useState(false);
   const [commentsDetails, setCommentsDetails] = React.useState<GitHubPullRequestContextResult | null>(null);
   const [isLoadingCommentsDetails, setIsLoadingCommentsDetails] = React.useState(false);
+  const [isSendingComments, setIsSendingComments] = React.useState(false);
 
   const attemptedBodyHydrationRef = React.useRef<Set<string>>(new Set());
   const lastSyncedPrNumberRef = React.useRef<number | null>(null);
@@ -975,6 +976,8 @@ export const PullRequestSection: React.FC<{
     }
     if (!directory || !pr) return;
 
+    setIsSendingComments(true);
+
     try {
       const context = await github.prContext(directory, pr.number, { includeDiff: false, includeCheckDetails: false });
       const issueComments = context.issueComments ?? [];
@@ -1003,6 +1006,8 @@ export const PullRequestSection: React.FC<{
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(t('gitView.pr.toast.loadPrCommentsFailed'), { description: message });
+    } finally {
+      setIsSendingComments(false);
     }
   }, [directory, dispatchSyntheticPrompt, github, pr, resolveChatDispatchTarget, setActiveMainTab, t]);
 
@@ -1704,9 +1709,10 @@ export const PullRequestSection: React.FC<{
                             size="sm"
                             className="h-7 w-7 px-0 border-[var(--status-success-border)] bg-[var(--status-success-background)] text-[var(--status-success)]"
                             onClick={sendCommentsToChat}
+                            disabled={isSendingComments}
                             aria-label={t('gitView.pr.actions.shareCommentsAria')}
                           >
-                            <Icon name="ai-generate-2" className="size-4" />
+                            {isSendingComments ? <Icon name="loader-4" className="size-4 animate-spin" /> : <Icon name="ai-generate-2" className="size-4" />}
                           </Button>
                         </TooltipTrigger>
                         <TooltipContent><p>{t('gitView.pr.actions.shareComments')}</p></TooltipContent>

--- a/packages/ui/src/components/views/git/PullRequestSection.tsx
+++ b/packages/ui/src/components/views/git/PullRequestSection.tsx
@@ -29,7 +29,7 @@ import { SimpleMarkdownRenderer } from '@/components/chat/MarkdownRenderer';
 import { Icon } from "@/components/icon/Icon";
 import { useUIStore } from '@/stores/useUIStore';
 import { formatDateTimeForPreference } from '@/lib/timeFormat';
-import { useSessionUIStore } from '@/sync/session-ui-store';
+import { materializeOpenDraftSession, useSessionUIStore } from '@/sync/session-ui-store';
 import { useSelectionStore } from '@/sync/selection-store';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { useGitHubAuthStore } from '@/stores/useGitHubAuthStore';
@@ -694,10 +694,32 @@ export const PullRequestSection: React.FC<{
     return all;
   }, [commentsDetails, t]);
 
-  const resolveChatDispatchTarget = React.useCallback((): ChatDispatchTarget | null => {
-    if (!currentSessionId) {
-      toast.error(t('gitView.pr.toast.noActiveSession'), { description: t('gitView.pr.toast.noActiveSessionDescription') });
-      return null;
+  const resolveChatDispatchTarget = React.useCallback(async (): Promise<ChatDispatchTarget | null> => {
+    let sessionId = currentSessionId;
+
+    if (!sessionId) {
+      const draft = useSessionUIStore.getState().newSessionDraft;
+      if (draft?.open) {
+        const config = useConfigStore.getState();
+        if (!config.currentProviderId || !config.currentModelId) {
+          toast.error(t('gitView.pr.toast.noModelSelected'));
+          return null;
+        }
+        const materialized = await materializeOpenDraftSession({
+          providerID: config.currentProviderId,
+          modelID: config.currentModelId,
+          agent: config.currentAgentName || undefined,
+          variant: config.currentVariant || undefined,
+        });
+        if (!materialized) {
+          toast.error(t('gitView.pr.toast.noActiveSession'), { description: t('gitView.pr.toast.noActiveSessionDescription') });
+          return null;
+        }
+        sessionId = materialized.sessionId;
+      } else {
+        toast.error(t('gitView.pr.toast.noActiveSession'), { description: t('gitView.pr.toast.noActiveSessionDescription') });
+        return null;
+      }
     }
 
     const { currentProviderId, currentModelId, currentAgentName, currentVariant } = useConfigStore.getState();
@@ -710,7 +732,7 @@ export const PullRequestSection: React.FC<{
     }
 
     return {
-      sessionId: currentSessionId,
+      sessionId,
       providerID,
       modelID,
       currentAgentName: currentAgentName ?? null,
@@ -880,7 +902,7 @@ export const PullRequestSection: React.FC<{
       return;
     }
     if (!directory || !pr) return;
-    const target = resolveChatDispatchTarget();
+    const target = await resolveChatDispatchTarget();
     if (!target) {
       return;
     }
@@ -936,7 +958,7 @@ export const PullRequestSection: React.FC<{
       return;
     }
     if (!directory || !pr) return;
-    const target = resolveChatDispatchTarget();
+    const target = await resolveChatDispatchTarget();
     if (!target) {
       return;
     }
@@ -971,7 +993,7 @@ export const PullRequestSection: React.FC<{
     setCommentsDialogOpen(false);
     setActiveMainTab('chat');
 
-    const target = resolveChatDispatchTarget();
+    const target = await resolveChatDispatchTarget();
     if (!target) {
       return;
     }

--- a/packages/ui/src/components/views/git/PullRequestSection.tsx
+++ b/packages/ui/src/components/views/git/PullRequestSection.tsx
@@ -920,6 +920,11 @@ export const PullRequestSection: React.FC<{
     if (!directory || !pr) return;
 
     try {
+      const target = await resolveChatDispatchTarget();
+      if (!target) {
+        return;
+      }
+
       const context = await github.prContext(directory, pr.number, { includeDiff: false, includeCheckDetails: true });
       const runs = context.checkRuns ?? [];
       const failed = runs.filter((r) => {
@@ -955,11 +960,6 @@ export const PullRequestSection: React.FC<{
         failedAnnotations,
       }, null, 2)}`;
 
-      const target = await resolveChatDispatchTarget();
-      if (!target) {
-        return;
-      }
-
       dispatchSyntheticPrompt(target, visibleText, instructionsText, payloadText);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -979,6 +979,11 @@ export const PullRequestSection: React.FC<{
     setIsSendingComments(true);
 
     try {
+      const target = await resolveChatDispatchTarget();
+      if (!target) {
+        return;
+      }
+
       const context = await github.prContext(directory, pr.number, { includeDiff: false, includeCheckDetails: false });
       const issueComments = context.issueComments ?? [];
       const reviewComments = context.reviewComments ?? [];
@@ -996,11 +1001,6 @@ export const PullRequestSection: React.FC<{
         issueComments,
         reviewComments,
       }, null, 2)}`;
-
-      const target = await resolveChatDispatchTarget();
-      if (!target) {
-        return;
-      }
 
       dispatchSyntheticPrompt(target, visibleText, instructionsText, payloadText);
     } catch (e) {


### PR DESCRIPTION
## Summary

Closes #1859.

This PR fixes PR-to-chat actions when the user only has an open draft session, and adds visible in-progress feedback for the PR-level **Share comments** action.

## What changed

- made `resolveChatDispatchTarget()` async
- when `currentSessionId` is null, detect an open draft session and materialize it via `materializeOpenDraftSession()`
- carry any draft synthetic parts through the eventual send
- updated the affected PR actions to `await` the resolved dispatch target
- added a loading state to the PR-level **Share comments** button so it disables and shows a spinner while the async send is in progress

## Why

Before this change:

- PR share/send actions could fail with **No active session** when the user had a draft session open but no materialized session yet
- the PR-level **Share comments** button provided no visible feedback during the async dispatch flow, so repeated clicks were easy and it was unclear whether the action had started

## Validation

- `bun run type-check:ui` ✅
- `bun run lint:ui` ✅