### PR TITLE
fix(cli): export ngrok tunnel capabilities

### DIFF
--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -10,6 +10,7 @@ import { pathToFileURL } from 'url';
 import { isModuleCliExecution, normalizeCliEntryPath } from './cli-entry.js';
 import { requestJson } from './lib/cli-http.js';
 import { inspectTunnelAttachability } from './lib/cli-lifecycle.js';
+import { DEFAULT_TUNNEL_PROVIDER_CAPABILITIES } from './lib/cli-tunnel-capabilities.js';
 import {
   assertAuthenticatedNetworkExposure,
   commands,
@@ -303,6 +304,12 @@ describe('serve host resolution', () => {
 });
 
 describe('compatibility exports', () => {
+  it('exports fallback tunnel provider capabilities for both cloudflare and ngrok', () => {
+    expect(DEFAULT_TUNNEL_PROVIDER_CAPABILITIES.map((entry) => entry.provider)).toEqual(
+      expect.arrayContaining(['cloudflare', 'ngrok']),
+    );
+  });
+
   it('allows tunnel profile migration before command options are initialized', async () => {
     await withTempOpenChamberDataDir(async () => {
       const store = ensureTunnelProfilesMigrated();

--- a/packages/web/server/lib/tunnels/providers/ngrok.js
+++ b/packages/web/server/lib/tunnels/providers/ngrok.js
@@ -13,7 +13,7 @@ import {
 } from '../types.js';
 import { getTunnelDependencyInstallInfo } from '../install-help.js';
 
-const ngrokTunnelProviderCapabilities = {
+export const ngrokTunnelProviderCapabilities = {
   provider: TUNNEL_PROVIDER_NGROK,
   defaults: {
     mode: TUNNEL_MODE_QUICK,


### PR DESCRIPTION
## Summary
- export `ngrokTunnelProviderCapabilities` from the ngrok provider module
- add focused CLI regression coverage for `DEFAULT_TUNNEL_PROVIDER_CAPABILITIES`
- preserves the existing cloudflare/ngrok fallback provider path

## Validation
- `bun run lint`
- `bun run --cwd packages/web type-check`
- `bunx vitest run packages/web/bin/cli.test.js`
- `node --input-type=module -e "import('./packages/web/bin/lib/cli-tunnel-capabilities.js').then(m=>console.log(m.DEFAULT_TUNNEL_PROVIDER_CAPABILITIES.map(x=>x.provider)))"`

## Notes
- Posted a temporary installed-CLI workaround on issue #1857 while this PR is in flight.
- `bun run type-check` at the repo root printed successful workspace exits but the wrapper process did not terminate within the shorter timeout used in this environment, so I validated the touched workspace directly.