### PR TITLE
fix(quota): show weekly window for Zhipu AI Coding Plan

### DIFF
--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -183,7 +183,7 @@ const resolveGoogleWindow = (sourceId: GoogleAuthSource['sourceId'], resetAt: nu
   return { label: 'daily', seconds: GOOGLE_DAILY_WINDOW_SECONDS } as const;
 };
 
-const ZAI_TOKEN_WINDOW_SECONDS: Record<number, number> = { 3: 3600 };
+const ZAI_TOKEN_WINDOW_SECONDS: Record<number, number> = { 3: 3600, 6: 604800 };
 
 const readAuthFile = (): AuthFile => {
   if (!fs.existsSync(AUTH_FILE)) {
@@ -1597,18 +1597,19 @@ const fetchZhipuaiCodingPlanQuota = async (): Promise<ProviderResult> => {
     const payload = await response.json() as ZhipuaiPayload;
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
 
-    const tokensLimit = limits.find((limit): limit is ZhipuaiTokensLimit => limit?.type === 'TOKENS_LIMIT');
+    const tokensLimits = limits.filter((limit): limit is ZhipuaiTokensLimit => limit?.type === 'TOKENS_LIMIT');
     const mcpToolsTimeLimit = limits.find((limit): limit is ZhipuaiMcpTimeLimit => limit?.type === 'TIME_LIMIT');
 
     const windows: Record<string, UsageWindow> = {};
 
-    // Handle TOKENS_LIMIT (5-hour window for token usage)
-    if (tokensLimit) {
+    // Handle TOKENS_LIMIT (multiple windows: 5-hour + weekly)
+    for (const tokensLimit of tokensLimits) {
       const windowSeconds = resolveWindowSeconds(tokensLimit);
+      const windowLabel = resolveWindowLabel(windowSeconds);
       const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
       const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
 
-      windows['Tokens'] = toUsageWindow({
+      windows[windowLabel] = toUsageWindow({
         usedPercent,
         windowSeconds,
         resetAt,

--- a/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
+++ b/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
@@ -4,7 +4,7 @@
  * API: https://open.bigmodel.cn/api/monitor/usage/quota/limit
  *
  * Response limits:
- * - TOKENS_LIMIT: Token usage (5-hour rolling window)
+ * - TOKENS_LIMIT: Token usage (one entry per window: 5-hour + weekly)
  * - TIME_LIMIT: MCP tools usage (monthly window)
  *
  * @typedef {Object} TokensLimit
@@ -33,6 +33,7 @@ import {
   buildResult,
   toUsageWindow,
   resolveWindowSeconds,
+  resolveWindowLabel,
   normalizeTimestamp
 } from '../utils/index.js';
 
@@ -104,18 +105,19 @@ export const fetchQuota = async () => {
     const payload = await response.json();
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
 
-    const tokensLimit = limits.find((limit) => limit?.type === 'TOKENS_LIMIT');
+    const tokensLimits = limits.filter((limit) => limit?.type === 'TOKENS_LIMIT');
     const mcpToolsTimeLimit = limits.find((limit) => limit?.type === 'TIME_LIMIT');
 
     const windows = {};
 
-    // Handle TOKENS_LIMIT (5-hour window for token usage)
-    if (tokensLimit) {
+    // Handle TOKENS_LIMIT (multiple windows: 5-hour + weekly)
+    for (const tokensLimit of tokensLimits) {
       const windowSeconds = resolveWindowSeconds(tokensLimit);
+      const windowLabel = resolveWindowLabel(windowSeconds);
       const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
       const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
 
-      windows['Tokens'] = toUsageWindow({
+      windows[windowLabel] = toUsageWindow({
         usedPercent,
         windowSeconds,
         resetAt

--- a/packages/web/server/lib/quota/utils/transformers.js
+++ b/packages/web/server/lib/quota/utils/transformers.js
@@ -35,7 +35,8 @@ export const normalizeTimestamp = (value) => {
 };
 
 export const resolveWindowSeconds = (limit) => {
-  const ZAI_TOKEN_WINDOW_SECONDS = { 3: 3600 };
+  // unit: 3 = hour, 6 = week (7 days). Shared by zhipuai-coding-plan and z.ai.
+  const ZAI_TOKEN_WINDOW_SECONDS = { 3: 3600, 6: 604800 };
   if (!limit || !limit.number) return null;
   const unitSeconds = ZAI_TOKEN_WINDOW_SECONDS[limit.unit];
   if (!unitSeconds) return null;


### PR DESCRIPTION
## Background

Zhipu AI Coding Plan (`open.bigmodel.cn`) ships **two** concurrent token limits per the official docs ([套餐概览](https://docs.bigmodel.cn/cn/coding-plan/overview), [FAQ](https://docs.bigmodel.cn/cn/coding-plan/faq)):

| Window         | Reset cycle                         |
| -------------- | ----------------------------------- |
| 5-hour rolling | resets 5h after first use           |
| Weekly         | 7-day cycle from subscription start |

The weekly cap was introduced in **Feb 2026**. This provider was written before the weekly limit existed — it only handled the 5-hour window and was never updated when Zhipu introduced the weekly cap, so the weekly quota has been silently ignored.

The `/api/monitor/usage/quota/limit` endpoint reflects both as separate `TOKENS_LIMIT` entries:

```json
"limits": [
  { "type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 14, "...": "..." },
  { "type": "TOKENS_LIMIT", "unit": 6, "number": 1, "percentage": 60, "...": "..." }
]
```

## Changes

Minimal, scoped to the **Zhipu (CN) provider** across web + VS Code runtimes (the shared unit map is also used by `z.ai`, but adding a key is backward-compatible and doesn't change `z.ai` behavior — left untouched per scope).

| File                                                           | Change                                                                        |
| -------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| `packages/web/server/lib/quota/utils/transformers.js`            | Add `6: 604800` (week) to `ZAI_TOKEN_WINDOW_SECONDS`                              |
| `packages/web/server/lib/quota/providers/zhipuai-coding-plan.js` | `find` → `filter` loop; use `resolveWindowLabel` so each window gets `5h` / `weekly` |
| `packages/vscode/src/quotaProviders.ts`                          | Mirror the same two changes for the VS Code bridge                            |

After:
- Both `TOKENS_LIMIT` entries render as separate windows (`5h` + `weekly`).
- Keys are now `5h` / `weekly`, which **already** have full i18n (`quota.window.5h` / `quota.window.weekly`) and are recognized by `inferWindowSeconds` for pace — so this also fixes label localization and pace for legacy 5-hour-only accounts.

## Before / After

|                    | Before               | After                           |
| ------------------ | -------------------- | ------------------------------- |
| Windows shown      | 1 (`Tokens`)           | 2 (`5h` + `weekly`)                 |
| Weekly quota       | ❌ dropped           | ✅ shown                        |
| Label localization | raw `Tokens` (no i18n) | localized `5-Hour` / `Weekly Limit` |
| Pace calculation   | no window duration   | inferred from `5h` / `weekly`       |

## Screenshot

<img width="974" height="844" alt="1" src="https://github.com/user-attachments/assets/81a768ec-8561-41b8-97e1-7223c3d44bc1" />


## Verification

- `bun run lint` — clean (web / electron / ui / vscode)
- `bun run type-check` — no new errors (pre-existing module-resolution errors in `ui` are unrelated)
- Confirmed against a live `open.bigmodel.cn` response containing two `TOKENS_LIMIT` entries; both windows now populate with correct `percentage` and `nextResetTime`.

## Notes

- International (`z.ai`) provider intentionally left unchanged; it already uses `resolveWindowLabel` and will pick up `unit=6` support for free once it's switched to `filter()` in a follow-up.
- No new dependencies, no contract changes — pure provider-logic fix.
