### PR TITLE
fix(ui): make collapse button sticky on expanded user messages

### DIFF
--- a/packages/ui/src/components/chat/message/parts/UserTextPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/UserTextPart.tsx
@@ -197,7 +197,7 @@ const UserTextPart: React.FC<UserTextPartProps> = ({ part, messageId, agentMenti
     return (
         <div className="relative" key={part.id || `${messageId}-user-text`}>
             {collapsibleUserMessages && isExpanded && (
-                <div className="sticky top-0 z-10 flex justify-end pointer-events-none">
+                <div className="sticky top-0 z-10 flex justify-end pointer-events-none h-0 overflow-visible">
                     <button
                         type="button"
                         onClick={handleCollapse}

--- a/packages/ui/src/components/chat/message/parts/UserTextPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/UserTextPart.tsx
@@ -197,14 +197,16 @@ const UserTextPart: React.FC<UserTextPartProps> = ({ part, messageId, agentMenti
     return (
         <div className="relative" key={part.id || `${messageId}-user-text`}>
             {collapsibleUserMessages && isExpanded && (
-                <button
-                    type="button"
-                    onClick={handleCollapse}
-                    className="absolute top-0 right-0 z-10 flex items-center justify-center rounded-sm bg-[var(--surface-elevated)] p-0.5 text-[var(--surface-mutedForeground)] hover:text-[var(--surface-foreground)] hover:bg-[var(--interactive-hover)] transition-colors"
-                    aria-label={t('chat.message.userText.collapseAria')}
-                >
-                    <Icon name="arrow-up-s" className="h-3.5 w-3.5" />
-                </button>
+                <div className="sticky top-0 z-10 flex justify-end pointer-events-none">
+                    <button
+                        type="button"
+                        onClick={handleCollapse}
+                        className="pointer-events-auto flex items-center justify-center rounded-sm bg-[var(--surface-elevated)] p-0.5 text-[var(--surface-mutedForeground)] hover:text-[var(--surface-foreground)] hover:bg-[var(--interactive-hover)] transition-colors"
+                        aria-label={t('chat.message.userText.collapseAria')}
+                    >
+                        <Icon name="arrow-up-s" className="h-3.5 w-3.5" />
+                    </button>
+                </div>
             )}
             <div
                 className={cn(


### PR DESCRIPTION
## Summary

Fixes #1877.

When a user message is expanded and scrollable, the collapse button previously used absolute positioning (`absolute top-0 right-0`) and scrolled out of view as the user scrolled through the message content. This required scrolling back to the top to collapse the message.

## Changes

- Wrap the collapse button in a sticky container (`sticky top-0`)
- Add `pointer-events-auto` to the button itself so it remains clickable
- The `pointer-events-none` wrapper allows clicks to pass through to the text content beneath
- Use `h-0 overflow-visible` on the wrapper to avoid pushing text content down

## Verification

- Manual: expanded a long user message and scrolled down — the collapse button now remains visible at the top of the scrollable area without adding a visual gap.
- No new hooks, state, or lifecycle logic introduced; minimal surface area for regressions.
- Uses existing theme tokens (`--surface-elevated`, `--surface-mutedForeground`, etc.) and shared `Icon` component.