### PR TITLE
[CORS] Add x-opencode-directory-encoding to Access-Control-Allow-Headers

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -1113,7 +1113,7 @@ async function main(options = {}) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader('Access-Control-Allow-Credentials', 'true');
       res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization,Accept,X-Requested-With,Cache-Control,X-OpenCode-Directory');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization,Accept,X-Requested-With,Cache-Control,x-opencode-directory,x-opencode-directory-encoding');
       res.setHeader('Access-Control-Expose-Headers', 'x-next-cursor');
       res.setHeader('Vary', 'Origin');
       if (req.method === 'OPTIONS') {


### PR DESCRIPTION
## Bug

v1.13.6 introduced `x-opencode-directory-encoding` header to mark URI-encoded directory hints, but the server's CORS configuration in `server/index.js:1116` was not updated to allow this new header. All cross-origin API requests fail with:

Access to fetch at 'http://127.0.0.1:57123/api/fs/list?...' from origin 'openchamber-ui://app' has been blocked by CORS policy: Request header field x-opencode-directory-encoding is not allowed by Access-Control-Allow-Headers in preflight response.


## Fix

Add `x-opencode-directory` and `x-opencode-directory-encoding` to the `Access-Control-Allow-Headers` list (the old entry `X-OpenCode-Directory` had the wrong case/name).

```diff
- 'Content-Type,Authorization,Accept,X-Requested-With,Cache-Control,X-OpenCode-Directory'
+ 'Content-Type,Authorization,Accept,X-Requested-With,Cache-Control,x-opencode-directory,x-opencode-directory-encoding'