### PR TITLE
[KaTeX] Fix math formula font loading — eager JS import instead of CSS @import

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -3,12 +3,6 @@
 @import "./styles/design-system.css";
 @import "./styles/typography.css";
 @import "./styles/mobile.css";
-/* Load KaTeX styles eagerly with the main bundle. Importing them inside the
-   lazy MarkdownRendererImpl chunk meant a stylesheet was injected late on the
-   first markdown render of a session; that late injection triggered a style
-   recalc during which the layered `.chat-message-column` width clamp briefly
-   lost, flashing message text to full width before it snapped back. */
-@import "katex/dist/katex.min.css";
 @source "./**/*.{ts,tsx,css}";
 
 /* KaTeX theme overrides for light/dark mode */

--- a/packages/ui/src/styles/katex-css.ts
+++ b/packages/ui/src/styles/katex-css.ts
@@ -1,0 +1,5 @@
+// Eagerly import KaTeX CSS so Vite correctly copies font files and rewrites URLs.
+// This is imported from each app entry point (main.tsx, mobile-main.tsx, etc.),
+// NOT from MarkdownRendererImpl (lazy chunk) — avoids the 1.13.1 flash issue.
+// NOT via CSS @import — avoids the 1.13.2+ font file resolution bug.
+import 'katex/dist/katex.min.css';

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -5,6 +5,7 @@ import type { RuntimeAPIs } from '@openchamber/ui/lib/api/types';
 import { getStoredMobileLayoutPreference } from '@openchamber/ui/lib/mobileLayoutPreference';
 import type { HostedSurface } from '@openchamber/ui/lib/runtimeSurface';
 import '@openchamber/ui/index.css';
+import '@openchamber/ui/styles/katex-css';
 import '@openchamber/ui/styles/fonts';
 
 declare global {

--- a/packages/web/src/mini-chat-main.tsx
+++ b/packages/web/src/mini-chat-main.tsx
@@ -1,6 +1,7 @@
 import { createConfiguredWebAPIs } from './runtimeConfig';
 import type { RuntimeAPIs } from '@openchamber/ui/lib/api/types';
 import '@openchamber/ui/index.css';
+import '@openchamber/ui/styles/katex-css';
 import '@openchamber/ui/styles/fonts';
 
 declare global {

--- a/packages/web/src/mobile-main.tsx
+++ b/packages/web/src/mobile-main.tsx
@@ -1,6 +1,7 @@
 import { createConfiguredWebAPIs } from './runtimeConfig';
 import type { RuntimeAPIs } from '@openchamber/ui/lib/api/types';
 import '@openchamber/ui/index.css';
+import '@openchamber/ui/styles/katex-css';
 import '@openchamber/ui/styles/fonts';
 
 declare global {


### PR DESCRIPTION
## Bug

Since v1.13.2, math formulas render in upright font instead of italic. The KaTeX `@font-face` declarations for math fonts (KaTeX_Math-Italic.woff2, etc.) fail to load because they are referenced via relative `url()` paths inside `katex.min.css`, which is loaded via CSS `@import` in `index.css:11`.

Lightning CSS (Tailwind v4's CSS processor) inlines the CSS content but does not resolve or copy the font file assets, causing 404s at runtime.

## Fix

Move the KaTeX CSS import from a CSS `@import` to a JavaScript `import` in each app entry point. Vite's JS-import pipeline correctly copies the `.woff2` font files to the build output and rewrites the `url()` references.

Changes:
- `packages/ui/src/index.css` — remove `@import "katex/dist/katex.min.css"`
- `packages/ui/src/styles/katex-css.ts` — new file with `import 'katex/dist/katex.min.css'`
- `packages/web/src/main.tsx` — add eager import
- `packages/web/src/mobile-main.tsx` — add eager import
- `packages/web/src/mini-chat-main.tsx` — add eager import
