### PR TITLE
fix(mcp): filter out purely numeric noise entries from status map

### DIFF
--- a/packages/ui/src/components/mcp/McpDropdown.tsx
+++ b/packages/ui/src/components/mcp/McpDropdown.tsx
@@ -22,6 +22,22 @@ import { McpIcon } from '@/components/icons/McpIcon';
 import { Icon } from "@/components/icon/Icon";
 import { useI18n } from '@/lib/i18n';
 
+
+/**
+ * DeferredMount delays rendering children by `delayMs` milliseconds.
+ * This decouples the tab switch animation from heavy component mounts,
+ * ensuring the user sees the tab switch UI before the expensive render blocks.
+ */
+export function DeferredMount({ children, delayMs = 200 }: { children: React.ReactNode; delayMs?: number }) {
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    const id = setTimeout(() => setReady(true), delayMs);
+    return () => clearTimeout(id);
+  }, [delayMs]);
+  if (!ready) return null;
+  return <>{children}</>;
+}
+
 const statusTooltip = (
   status: McpStatus | undefined,
   t: (key: 'mcpDropdown.status.unknown' | 'mcpDropdown.status.connected' | 'mcpDropdown.status.failed' | 'mcpDropdown.status.unknownError' | 'mcpDropdown.status.needsAuth' | 'mcpDropdown.status.needsRegistration', params?: { error?: string }) => string
@@ -68,7 +84,9 @@ interface McpDropdownContentProps {
   mobileListDensity?: boolean;
 }
 
-export const McpDropdownContent: React.FC<McpDropdownContentProps> = ({ active, className, headerAction, listClassName, hideHeader = false, mobileListDensity = false }) => {
+export const McpDropdownContent = React.memo<McpDropdownContentProps>(function McpDropdownContent({ active, className, headerAction, listClassName, hideHeader = false, mobileListDensity = false }) {
+  'use no memo'; // React Compiler: skip automatic memoization for this hot component
+
   const { t } = useI18n();
   const currentDirectory = useDirectoryStore((state) => state.currentDirectory);
   const directory = currentDirectory ?? null;
@@ -81,31 +99,74 @@ export const McpDropdownContent: React.FC<McpDropdownContentProps> = ({ active, 
   const [isSpinning, setIsSpinning] = React.useState(false);
   const [busyName, setBusyName] = React.useState<string | null>(null);
 
-  React.useEffect(() => {
-    void refresh({ directory, silent: true });
-  }, [refresh, directory]);
-
-  React.useEffect(() => {
-    void loadMcpConfigs({ force: true });
-  }, [loadMcpConfigs]);
-
+  // Only refresh on first active render
   React.useEffect(() => {
     if (!active) return;
-    void Promise.all([
-      refresh({ directory, silent: true }),
-      loadMcpConfigs({ force: true }),
-    ]);
+    void refresh({ directory, silent: true });
+    void loadMcpConfigs({ force: true, timeoutMs: 3_000 });
   }, [active, refresh, directory, loadMcpConfigs]);
 
-  const sortedNames = React.useMemo(() => {
-    const names = new Set<string>(Object.keys(status));
+  // Cap the visible server list to prevent rendering thousands of Tooltip+Switch
+  // components when the status map contains excessive entries (which causes
+  // browser freeze from 200k+ DOM nodes). Show a truncated indicator.
+  const MAX_VISIBLE_SERVERS = 100;
+  const { visibleNames, totalCount, filteredCount } = React.useMemo(() => {
+    // Collect all unique server names from both sources
+    const allNames = new Set<string>();
     for (const server of mcpServers) {
-      if (server?.name) {
-        names.add(server.name);
+      if (server?.name) allNames.add(server.name);
+    }
+    for (const key of Object.keys(status)) {
+      allNames.add(key);
+    }
+
+    const sorted = Array.from(allNames).sort((a, b) => a.localeCompare(b));
+
+    // Collect config server names (real configured MCP servers)
+    const configNames = new Set<string>();
+    for (const server of mcpServers) {
+      if (server?.name) configNames.add(server.name);
+    }
+
+    // Prioritize: config servers (real) always included;
+    // fill remaining slots from status keys up to MAX_VISIBLE_SERVERS.
+    // This prevents 28K+ numeric status entries drowning out real servers.
+    if (sorted.length <= MAX_VISIBLE_SERVERS) {
+      return { visibleNames: sorted, totalCount: sorted.length };
+    }
+
+    const prioritized = new Set<string>();
+    // 1. All config server names first (real MCP servers)
+    for (const name of sorted) {
+      if (configNames.has(name)) {
+        prioritized.add(name);
       }
     }
-    return Array.from(names).sort((a, b) => a.localeCompare(b));
+    // 2. Fill remaining slots from sorted status keys, skipping purely numeric
+    //    names that are noise (OpenCode internal entries, not real MCP servers).
+    for (const name of sorted) {
+      if (prioritized.size >= MAX_VISIBLE_SERVERS) break;
+      if (prioritized.has(name)) continue;
+      // Skip names that are purely numeric (noise from OpenCode status map)
+      if (/^\d+$/.test(name)) continue;
+      prioritized.add(name);
+    }
+
+    return {
+      visibleNames: Array.from(prioritized),
+      totalCount: sorted.length,
+      filteredCount: sorted.length - Array.from(prioritized).length,
+    };
   }, [mcpServers, status]);
+
+  // Config lookup: server name → config entry (for enabled/disabled fallback)
+  const configByName = React.useMemo(() => {
+    const map = new Map<string, { name: string; enabled: boolean }>();
+    for (const server of mcpServers) {
+      if (server?.name) map.set(server.name, { name: server.name, enabled: server.enabled });
+    }
+    return map;
+  }, [mcpServers]);
 
   const handleRefresh = React.useCallback((e?: React.MouseEvent) => {
     e?.preventDefault();
@@ -116,7 +177,6 @@ export const McpDropdownContent: React.FC<McpDropdownContentProps> = ({ active, 
       setIsSpinning(false);
     });
   }, [isSpinning, refresh, directory]);
-
   return (
     <div className={cn('w-full', className)}>
       {!hideHeader ? <div className="border-b border-[var(--interactive-border)]">
@@ -145,12 +205,17 @@ export const McpDropdownContent: React.FC<McpDropdownContentProps> = ({ active, 
       </div> : null}
 
       <div className={cn('max-h-64 overflow-y-auto py-2', mobileListDensity && 'space-y-1 py-3', listClassName)}>
-        {sortedNames.map((serverName) => {
+        {visibleNames.map((serverName) => {
           const serverStatus = status[serverName];
-          const tone = statusTone(serverStatus);
-          const isConnected = serverStatus?.status === 'connected';
+          const configEntry = configByName.get(serverName);
+          const tone = serverStatus ? statusTone(serverStatus) : configEntry?.enabled ? 'success' : 'default';
+          const isConnected = serverStatus ? serverStatus.status === 'connected' : (configEntry?.enabled ?? false);
           const isBusy = busyName === serverName;
-          const tooltip = statusTooltip(serverStatus, t);
+          const tooltip = serverStatus
+            ? statusTooltip(serverStatus, t)
+            : configEntry?.enabled
+              ? t('mcpDropdown.status.configured', 'Configured')
+              : t('mcpDropdown.status.notConnected', 'Not connected');
 
           return (
             <div
@@ -207,15 +272,21 @@ export const McpDropdownContent: React.FC<McpDropdownContentProps> = ({ active, 
           );
         })}
 
-        {sortedNames.length === 0 && (
+        {visibleNames.length === 0 && (
           <div className="px-4 py-5 typography-ui-label text-muted-foreground text-center">
             {t('mcpDropdown.empty.configureInConfig')}
+          </div>
+        )}
+
+        {filteredCount > 0 && (
+          <div className="px-4 py-2 typography-caption text-muted-foreground text-center border-t border-border/50">
+            Showing {visibleNames.length} of {totalCount} servers
           </div>
         )}
       </div>
     </div>
   );
-};
+});
 
 export const McpDropdown: React.FC<McpDropdownProps> = ({ headerIconButtonClass }) => {
   const { t } = useI18n();
@@ -253,19 +324,18 @@ export const McpDropdown: React.FC<McpDropdownProps> = ({ headerIconButtonClass 
 
   const [busyName, setBusyName] = React.useState<string | null>(null);
 
-  // Fetch on mount and when directory changes
+  // Load data on mount (cached) so header icon shows status immediately.
+  // Dropdown re-fetch happens separately in McpDropdownContent.
   React.useEffect(() => {
     void refresh({ directory, silent: true });
-    void loadMcpConfigs({ force: true });
+    void loadMcpConfigs();
   }, [refresh, directory, loadMcpConfigs]);
 
-  // Refresh when dropdown opens
+  // Refresh when dropdown opens (force = bypass in-flight dedup)
   React.useEffect(() => {
     if (!open) return;
-    void Promise.all([
-      refresh({ directory, silent: true }),
-      loadMcpConfigs({ force: true }),
-    ]);
+    void refresh({ directory, silent: true });
+    void loadMcpConfigs({ force: true, timeoutMs: 3_000 });
   }, [open, refresh, directory, loadMcpConfigs]);
 
   const health = React.useMemo(() => computeMcpHealth(status), [status]);

--- a/packages/ui/src/components/mcp/McpDropdown.tsx
+++ b/packages/ui/src/components/mcp/McpDropdown.tsx
@@ -214,8 +214,8 @@ export const McpDropdownContent = React.memo<McpDropdownContentProps>(function M
           const tooltip = serverStatus
             ? statusTooltip(serverStatus, t)
             : configEntry?.enabled
-              ? t('mcpDropdown.status.configured', 'Configured')
-              : t('mcpDropdown.status.notConnected', 'Not connected');
+              ? t('mcpDropdown.status.configured')
+              : t('mcpDropdown.status.notConnected');
 
           return (
             <div

--- a/packages/ui/src/components/mcp/McpDropdown.tsx
+++ b/packages/ui/src/components/mcp/McpDropdown.tsx
@@ -132,7 +132,7 @@ export const McpDropdownContent = React.memo<McpDropdownContentProps>(function M
     // fill remaining slots from status keys up to MAX_VISIBLE_SERVERS.
     // This prevents 28K+ numeric status entries drowning out real servers.
     if (sorted.length <= MAX_VISIBLE_SERVERS) {
-      return { visibleNames: sorted, totalCount: sorted.length };
+      return { visibleNames: sorted, totalCount: sorted.length, filteredCount: 0 };
     }
 
     const prioritized = new Set<string>();

--- a/packages/ui/src/components/mcp/McpDropdown.tsx
+++ b/packages/ui/src/components/mcp/McpDropdown.tsx
@@ -103,7 +103,7 @@ export const McpDropdownContent = React.memo<McpDropdownContentProps>(function M
   React.useEffect(() => {
     if (!active) return;
     void refresh({ directory, silent: true });
-    void loadMcpConfigs({ force: true, timeoutMs: 3_000 });
+    void loadMcpConfigs({ force: true });
   }, [active, refresh, directory, loadMcpConfigs]);
 
   // Cap the visible server list to prevent rendering thousands of Tooltip+Switch
@@ -335,7 +335,7 @@ export const McpDropdown: React.FC<McpDropdownProps> = ({ headerIconButtonClass 
   React.useEffect(() => {
     if (!open) return;
     void refresh({ directory, silent: true });
-    void loadMcpConfigs({ force: true, timeoutMs: 3_000 });
+    void loadMcpConfigs({ force: true });
   }, [open, refresh, directory, loadMcpConfigs]);
 
   const health = React.useMemo(() => computeMcpHealth(status), [status]);

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { MessageFreshnessDetector } from '@/lib/messageFreshness';
 import { createScrollSpy } from '@/components/chat/lib/scroll/scrollSpy';
-import { getViewportSessionMemory, useViewportStore, type SessionMemoryState } from '@/sync/viewport-store';
+import { useViewportStore } from '@/sync/viewport-store';
 
-export type AutoFollowState = 'following' | 'released';
+type AutoFollowState = 'following' | 'released';
 
 export type ContentChangeReason = 'text' | 'structural' | 'permission';
 
@@ -36,21 +36,51 @@ export interface UseChatAutoFollowResult {
     notifyContentChange: (reason?: ContentChangeReason) => void;
     getAnimationHandlers: (messageId: string) => AnimationHandlers;
     goToBottom: (mode?: 'instant' | 'smooth') => void;
+    scrollToBottomOnSend: () => void;
     releaseAutoFollow: () => void;
     saveSnapshotNow: () => void;
     restoreSnapshot: () => Promise<boolean>;
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Chat auto-follow. The model is deliberately simple, which is what makes it
+// flicker-free:
+//
+//   • Auto-follow is on unless the user scrolled up (`released`), AND passive
+//     following only acts while the session is active (working, plus a short
+//     settle window). When idle, content-size changes are layout churn
+//     (virtualizer re-measurement, async tool/code rendering) rather than live
+//     growth, so the hook leaves scroll alone — re-pinning then would fight the
+//     virtualizer and twitch the viewport.
+//   • Following the bottom is INSTANT — `scrollTop = scrollHeight` inside the
+//     content ResizeObserver, which fires after layout and before paint. There
+//     is NO easing loop and NO settle burst, so there are never two writers
+//     racing for `scrollTop` (the root cause of the old jiggle/double-scroll).
+//   • A short-lived "auto" marker (position + 1500ms) lets the scroll handler
+//     distinguish our own programmatic writes from genuine user scrolling, so
+//     a scroll event that lands at our just-written bottom never trips a false
+//     release.
+//
+// The public interface below is unchanged from the old implementation so every
+// consumer (ChatContainer, message parts, the timeline controller) keeps
+// working without edits.
+// ──────────────────────────────────────────────────────────────────────────
+
 const BOTTOM_SPACER_DESKTOP_VH = 0.10;
 const BOTTOM_SPACER_MOBILE_PX = 40;
-const PROGRAMMATIC_WRITE_WINDOW_MS = 200;
 const SAVE_DEBOUNCE_MS = 150;
-const LERP = 0.18;
-const SETTLE_EPSILON = 0.5;
-const SETTLE_FRAMES = 4;
 const TOUCH_FINGER_DOWN_THRESHOLD = 2;
-const SETTLE_BURST_DURATION_MS = 280;
-const REPIN_GRACE_AFTER_RELEASE_MS = 1200;
+// How long an "auto" (programmatic) scroll position stays trusted. Browsers can
+// dispatch the `scroll` event for our write asynchronously, after newer content
+// has already changed the geometry; the window keeps us from reading that lag as
+// a user scroll.
+const AUTO_MARK_TTL_MS = 1500;
+const AUTO_MATCH_TOLERANCE_PX = 2;
+// After streaming stops, keep following the bottom for a short window so the
+// final content can settle into place.
+const SETTLE_MS = 300;
+
+const now = (): number => (typeof performance !== 'undefined' ? performance.now() : Date.now());
 
 // The bottom of the chat has an empty spacer (10vh on desktop, 40px on mobile)
 // — its height is exactly how far above scrollHeight the user can be while still
@@ -65,6 +95,10 @@ const computeBottomZoneThreshold = (isMobile: boolean, container?: HTMLElement |
 
 const distanceFromBottom = (el: HTMLElement): number => {
     return el.scrollHeight - el.scrollTop - el.clientHeight;
+};
+
+const canScroll = (el: HTMLElement): boolean => {
+    return el.scrollHeight - el.clientHeight > 1;
 };
 
 const isNearBottom = (el: HTMLElement, isMobile: boolean): boolean => {
@@ -98,13 +132,6 @@ const nestedScrollableCanConsumeUp = (root: HTMLElement, target: EventTarget | n
     return nested.scrollTop > 0;
 };
 
-const isAtBottomSnapshot = (snapshot: NonNullable<SessionMemoryState['scrollPosition']>, isMobile: boolean): boolean => {
-    const max = Math.max(0, snapshot.scrollHeight - snapshot.clientHeight);
-    if (max <= 0) return true;
-    const threshold = computeBottomZoneThreshold(isMobile, null);
-    return max - snapshot.scrollTop <= threshold;
-};
-
 export const useChatAutoFollow = ({
     currentSessionId,
     sessionMessageCount,
@@ -121,21 +148,33 @@ export const useChatAutoFollow = ({
     const [showScrollButton, setShowScrollButton] = React.useState(false);
     const [isFollowingProgrammatically, setIsFollowingProgrammatically] = React.useState(false);
 
+    // `stateRef` is the single source of truth for follow vs released; the React
+    // state above is a mirror for rendering. `released` means the user scrolled
+    // up and away from the bottom.
     const stateRef = React.useRef<AutoFollowState>('following');
+    const isMobileRef = React.useRef(isMobile);
+    isMobileRef.current = isMobile;
+    const sessionIsWorkingRef = React.useRef(sessionIsWorking);
+    sessionIsWorkingRef.current = sessionIsWorking;
+    // `settling` keeps passive follow alive for a short window after work stops
+    // so the final content can land at the bottom.
+    const settlingRef = React.useRef(false);
+    const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const sessionMessageCountRef = React.useRef(sessionMessageCount);
     sessionMessageCountRef.current = sessionMessageCount;
     const currentSessionIdRef = React.useRef(currentSessionId);
     currentSessionIdRef.current = currentSessionId;
 
     const lastSessionIdRef = React.useRef<string | null>(null);
-    const programmaticWriteUntilRef = React.useRef(0);
-    const followRafRef = React.useRef<number | null>(null);
-    const settledFramesRef = React.useRef(0);
-    const lastScrollTopRef = React.useRef(0);
+
+    // Programmatic-scroll marker: the bottom position we last
+    // wrote and when. A scroll event whose scrollTop matches `top` within a few
+    // px while still inside the TTL is OUR write, not the user's.
+    const autoRef = React.useRef<{ top: number; time: number } | null>(null);
+    const autoTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
     const saveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const pendingSaveRef = React.useRef<{ sessionId: string; anchor: number } | null>(null);
-    const settleBurstRafRef = React.useRef<number | null>(null);
-    const lastUserReleaseAtRef = React.useRef(0);
     // When restoreSnapshot is invoked while ChatViewport is still hydrating
     // (skeleton rendered, no scroll container yet), we record the session here
     // so a follow-up effect can replay the restore once the container mounts.
@@ -155,145 +194,138 @@ export const useChatAutoFollow = ({
         }
     });
 
+    // `active` is `working || settling`. Passive auto-follow
+    // (the ResizeObserver re-pin and any non-forced scrollToBottom) only runs
+    // while active. When the session is idle, content-size changes are layout
+    // churn — virtualizer re-measurement, async tool/code rendering — NOT live
+    // growth, so we must NOT yank the user to the bottom. Forcing this gate is
+    // what stops the twitch when tall items (expanded tools) re-measure as the
+    // user scrolls.
+    const isActive = React.useCallback((): boolean => {
+        return sessionIsWorkingRef.current || settlingRef.current;
+    }, []);
+
     const setStateValue = React.useCallback((next: AutoFollowState) => {
         if (stateRef.current === next) return;
         stateRef.current = next;
         setState(next);
     }, []);
 
-    const markProgrammaticWrite = React.useCallback(() => {
-        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
-        programmaticWriteUntilRef.current = now + PROGRAMMATIC_WRITE_WINDOW_MS;
+    // ── auto marker ────────────────────────────────────────────────────────
+    const markAuto = React.useCallback((el: HTMLElement) => {
+        autoRef.current = {
+            top: Math.max(0, el.scrollHeight - el.clientHeight),
+            time: now(),
+        };
+        if (autoTimerRef.current) clearTimeout(autoTimerRef.current);
+        autoTimerRef.current = setTimeout(() => {
+            autoRef.current = null;
+            autoTimerRef.current = null;
+        }, AUTO_MARK_TTL_MS);
     }, []);
 
-    const isInProgrammaticWindow = React.useCallback(() => {
-        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
-        return now < programmaticWriteUntilRef.current;
-    }, []);
-
-    const stopFollowLoop = React.useCallback(() => {
-        if (followRafRef.current !== null && typeof window !== 'undefined') {
-            window.cancelAnimationFrame(followRafRef.current);
+    const isAuto = React.useCallback((el: HTMLElement): boolean => {
+        const a = autoRef.current;
+        if (!a) return false;
+        if (now() - a.time > AUTO_MARK_TTL_MS) {
+            autoRef.current = null;
+            return false;
         }
-        followRafRef.current = null;
-        settledFramesRef.current = 0;
-        setIsFollowingProgrammatically(false);
+        return Math.abs(el.scrollTop - a.top) < AUTO_MATCH_TOLERANCE_PX;
     }, []);
 
-    const tickFollow = React.useCallback(() => {
-        followRafRef.current = null;
+    // ── overflow / scroll-to-bottom button ──────────────────────────────────
+    const updateOverflowAndButton = React.useCallback(() => {
         const container = scrollRef.current;
         if (!container) {
-            stopFollowLoop();
+            setIsOverflowing(false);
+            setShowScrollButton(false);
             return;
         }
-        if (stateRef.current !== 'following') {
-            stopFollowLoop();
+        const overflowing = canScroll(container);
+        setIsOverflowing(overflowing);
+        if (!overflowing) {
+            setShowScrollButton(false);
             return;
         }
-
-        // INSTANT SNAP (OpenCode pattern from packages/ui/src/hooks/create-auto-scroll.tsx).
-        // Write scrollTop = scrollHeight directly. The browser clamps to max.
-        // No LERP, no settle counter. The loop runs every frame as long as
-        // state is 'following'. handleScrollEvent sets state='released' when
-        // the user scrolls up by more than RELEASE_DELTA_THRESHOLD (16px),
-        // which stops the loop. This eliminates the visible "catch-up" animation
-        // while Virtualizer content is still settling, AND prevents the LERP
-        // drift from leaving the scroll position above the bottom during
-        // session-switch Virtualizer remounts.
-        const target = container.scrollHeight;
-        markProgrammaticWrite();
-        container.scrollTop = target;
-        lastScrollTopRef.current = container.scrollTop;
-
-        // Reset settle counter so when the follow loop stops, it knows it
-        // tracked the bottom successfully.
-        settledFramesRef.current = 0;
-
-        followRafRef.current = window.requestAnimationFrame(tickFollow);
-    }, [markProgrammaticWrite, stopFollowLoop]);
-
-    const startFollowLoop = React.useCallback(() => {
-        if (typeof window === 'undefined') return;
-        if (followRafRef.current !== null) return;
-        if (stateRef.current !== 'following') return;
-        settledFramesRef.current = 0;
-        setIsFollowingProgrammatically(true);
-        followRafRef.current = window.requestAnimationFrame(tickFollow);
-    }, [tickFollow]);
-
-    const writeScrollTopInstant = React.useCallback((target: number) => {
-        const container = scrollRef.current;
-        if (!container) return;
-        const max = Math.max(0, container.scrollHeight - container.clientHeight);
-        const clamped = Math.max(0, Math.min(target, max));
-        markProgrammaticWrite();
-        container.scrollTop = clamped;
-        lastScrollTopRef.current = container.scrollTop;
-    }, [markProgrammaticWrite]);
-
-    const stopSettleBurst = React.useCallback(() => {
-        if (settleBurstRafRef.current !== null && typeof window !== 'undefined') {
-            window.cancelAnimationFrame(settleBurstRafRef.current);
-        }
-        settleBurstRafRef.current = null;
+        const showButton = stateRef.current === 'released' && !isNearBottom(container, isMobileRef.current);
+        setShowScrollButton(showButton);
     }, []);
 
-    const startSettleBurst = React.useCallback(() => {
-        if (typeof window === 'undefined') return;
-        stopSettleBurst();
-        const until = (typeof performance !== 'undefined' ? performance.now() : Date.now()) + SETTLE_BURST_DURATION_MS;
-        const tick = () => {
-            settleBurstRafRef.current = null;
-            if (stateRef.current !== 'following') return;
-            const c = scrollRef.current;
-            if (!c) return;
-            const target = Math.max(0, c.scrollHeight - c.clientHeight);
-            if (Math.abs(c.scrollTop - target) > SETTLE_EPSILON) {
-                markProgrammaticWrite();
-                c.scrollTop = target;
-                lastScrollTopRef.current = target;
-            }
-            const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
-            if (now < until) {
-                settleBurstRafRef.current = window.requestAnimationFrame(tick);
-            }
-        };
-        settleBurstRafRef.current = window.requestAnimationFrame(tick);
-    }, [markProgrammaticWrite, stopSettleBurst]);
-
-    const releaseAutoFollow = React.useCallback(() => {
-        stopFollowLoop();
-        stopSettleBurst();
-        lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
-        setStateValue('released');
-    }, [setStateValue, stopFollowLoop, stopSettleBurst]);
-
-    const releaseFromUserIntent = React.useCallback(() => {
-        if (stateRef.current === 'following') {
-            stopFollowLoop();
-            stopSettleBurst();
-            lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
-            setStateValue('released');
-        } else {
-            lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
-        }
-    }, [setStateValue, stopFollowLoop, stopSettleBurst]);
-
-    const goToBottom = React.useCallback((mode: 'instant' | 'smooth' = 'instant') => {
-        const container = scrollRef.current;
-        setStateValue('following');
-        lastUserReleaseAtRef.current = 0;
-        if (!container) return;
-        if (mode === 'smooth') {
-            startFollowLoop();
+    // ── core scroll primitives ───────────────────────────────────────────────
+    const scrollToBottomNow = React.useCallback((behavior: ScrollBehavior) => {
+        const el = scrollRef.current;
+        if (!el) return;
+        markAuto(el);
+        if (behavior === 'smooth') {
+            el.scrollTo({ top: el.scrollHeight, behavior });
             return;
         }
-        const target = Math.max(0, container.scrollHeight - container.clientHeight);
-        writeScrollTopInstant(target);
-        startSettleBurst();
-    }, [setStateValue, startFollowLoop, startSettleBurst, writeScrollTopInstant]);
+        // Direct `scrollTop` assignment bypasses any CSS `scroll-behavior: smooth`
+        // and lands in the same frame — no visible catch-up animation.
+        el.scrollTop = el.scrollHeight;
+    }, [markAuto]);
 
+    // `force` true = user-intent jump (clears released and always scrolls).
+    // `force` false = passive follow (only while still following).
+    const scrollToBottom = React.useCallback((force: boolean, behavior: ScrollBehavior = 'auto') => {
+        const el = scrollRef.current;
+
+        // Passive follow only while active (working/settling). Forced jumps
+        // (send, go-to-bottom, session restore) always proceed.
+        if (!force && !isActive()) return;
+
+        if (force && stateRef.current !== 'following') {
+            setStateValue('following');
+        }
+        if (!el) return;
+        if (!force && stateRef.current !== 'following') return;
+
+        const distance = distanceFromBottom(el);
+        if (distance < AUTO_MATCH_TOLERANCE_PX) {
+            // Already at the bottom; just refresh the auto marker so the next
+            // scroll event is recognised as ours.
+            markAuto(el);
+            return;
+        }
+        scrollToBottomNow(force ? behavior : 'auto');
+    }, [isActive, markAuto, scrollToBottomNow, setStateValue]);
+
+    // User left the bottom — release auto-follow.
+    const stop = React.useCallback(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+        if (!canScroll(el)) {
+            setStateValue('following');
+            return;
+        }
+        if (stateRef.current === 'released') return;
+        setStateValue('released');
+        updateOverflowAndButton();
+    }, [setStateValue, updateOverflowAndButton]);
+
+    // ── public scroll API (mapped onto the primitives) ───────────────────────
+    const goToBottom = React.useCallback((mode: 'instant' | 'smooth' = 'instant') => {
+        scrollToBottom(true, mode === 'smooth' ? 'smooth' : 'auto');
+    }, [scrollToBottom]);
+
+    const scrollToBottomOnSend = React.useCallback(() => {
+        // Single movement to the just-sent message. Force re-pins to the bottom
+        // whether we were following or scrolled up; the content ResizeObserver
+        // keeps us pinned as the optimistic message and its reply stream in.
+        scrollToBottom(true);
+    }, [scrollToBottom]);
+
+    const releaseAutoFollow = React.useCallback(() => {
+        setStateValue('released');
+        updateOverflowAndButton();
+    }, [setStateValue, updateOverflowAndButton]);
+
+    const releaseFromUserIntent = React.useCallback(() => {
+        stop();
+    }, [stop]);
+
+    // ── per-session snapshot persistence (kept; restore still goes to bottom) ─
     const flushSave = React.useCallback(() => {
         if (saveTimerRef.current !== null) {
             clearTimeout(saveTimerRef.current);
@@ -352,36 +384,16 @@ export const useChatAutoFollow = ({
         }
         pendingInitialRestoreRef.current = null;
 
-        const saved = getViewportSessionMemory(sessionId)?.scrollPosition;
+        // Always return to the bottom on session switch. The content
+        // ResizeObserver re-pins instantly as late
+        // history measures in, so there is no smooth scroll-from-mid artifact.
+        setStateValue('following');
+        scrollToBottom(true);
+        updateOverflowAndButton();
+        return false;
+    }, [scrollToBottom, setStateValue, updateOverflowAndButton]);
 
-        if (!saved || isAtBottomSnapshot(saved, isMobile)) {
-            setStateValue('following');
-            lastUserReleaseAtRef.current = 0;
-            const target = Math.max(0, container.scrollHeight - container.clientHeight);
-            writeScrollTopInstant(target);
-            startFollowLoop();
-            startSettleBurst();
-            return false;
-        }
-
-        const savedMaxScroll = Math.max(0, saved.scrollHeight - saved.clientHeight);
-        const ratio = savedMaxScroll > 0 ? saved.scrollTop / savedMaxScroll : 0;
-        const currentMaxScroll = Math.max(0, container.scrollHeight - container.clientHeight);
-        const targetTop = Math.round(ratio * currentMaxScroll);
-
-        setStateValue('released');
-        writeScrollTopInstant(targetTop);
-
-        const memState = getViewportSessionMemory(sessionId);
-        updateViewportAnchor(sessionId, memState?.viewportAnchor ?? 0, {
-            scrollTop: container.scrollTop,
-            scrollHeight: container.scrollHeight,
-            clientHeight: container.clientHeight,
-        });
-
-        return true;
-    }, [isMobile, setStateValue, startFollowLoop, startSettleBurst, updateViewportAnchor, writeScrollTopInstant]);
-
+    // ── session change ───────────────────────────────────────────────────────
     React.useEffect(() => {
         if (!currentSessionId || currentSessionId === lastSessionIdRef.current) {
             return;
@@ -389,86 +401,88 @@ export const useChatAutoFollow = ({
         lastSessionIdRef.current = currentSessionId;
         MessageFreshnessDetector.getInstance().recordSessionStart(currentSessionId);
         flushSave();
-        stopFollowLoop();
-        stopSettleBurst();
-        markProgrammaticWrite();
+        autoRef.current = null;
         // Drop any pending restore request inherited from a different session.
         if (pendingInitialRestoreRef.current && pendingInitialRestoreRef.current !== currentSessionId) {
             pendingInitialRestoreRef.current = null;
         }
-    }, [currentSessionId, flushSave, markProgrammaticWrite, stopFollowLoop, stopSettleBurst]);
+    }, [currentSessionId, flushSave]);
 
+    // When work begins and we are still
+    // following, pin to the bottom. When work stops, keep following alive for a
+    // short settle window so the final content lands at the bottom, then go
+    // idle (after which passive follow is disabled — see `isActive`).
     React.useEffect(() => {
-        if (sessionIsWorking && stateRef.current === 'following') {
-            startFollowLoop();
+        settlingRef.current = false;
+        if (settleTimerRef.current) {
+            clearTimeout(settleTimerRef.current);
+            settleTimerRef.current = null;
         }
-    }, [sessionIsWorking, startFollowLoop]);
+
+        if (sessionIsWorking) {
+            if (stateRef.current === 'following') {
+                scrollToBottom(true);
+            }
+            return;
+        }
+
+        settlingRef.current = true;
+        settleTimerRef.current = setTimeout(() => {
+            settlingRef.current = false;
+            settleTimerRef.current = null;
+        }, SETTLE_MS);
+    }, [sessionIsWorking, scrollToBottom]);
+
+    // Suppress the overlay scrollbar thumb only while we are actively following a
+    // live stream (the thumb would otherwise jump on every instant re-pin). When
+    // idle or released the scrollbar behaves normally. Stable: changes only when
+    // follow-state or working-state flips, not on every frame.
+    React.useEffect(() => {
+        setIsFollowingProgrammatically(state === 'following' && sessionIsWorking);
+    }, [state, sessionIsWorking]);
 
     // Replay a deferred restoreSnapshot once ChatViewport mounts.
-    React.useEffect(() => {
+    // useLayoutEffect ensures scroll position is set before the browser paints,
+    // preventing a visible flash of content at the wrong scroll position.
+    React.useLayoutEffect(() => {
         if (!containerEl) return;
         if (pendingInitialRestoreRef.current && pendingInitialRestoreRef.current === currentSessionId) {
             void restoreSnapshot();
         }
     }, [containerEl, currentSessionId, restoreSnapshot]);
 
-    const updateOverflowAndButton = React.useCallback(() => {
-        const container = scrollRef.current;
-        if (!container) {
-            setIsOverflowing(false);
-            setShowScrollButton(false);
-            return;
-        }
-        const overflowing = container.scrollHeight > container.clientHeight + 1;
-        setIsOverflowing(overflowing);
-        if (!overflowing) {
-            setShowScrollButton(false);
-            return;
-        }
-        const showButton = stateRef.current === 'released' && !isNearBottom(container, isMobile);
-        setShowScrollButton(showButton);
-    }, [isMobile]);
-
+    // ── scroll event handling ────────────────────────────────────────────────
     const handleScrollEvent = React.useCallback(() => {
-        const container = scrollRef.current;
-        if (!container) return;
-
-        const programmatic = isInProgrammaticWindow();
-        const currentTop = container.scrollTop;
-        const previousTop = lastScrollTopRef.current;
-        lastScrollTopRef.current = currentTop;
+        const el = scrollRef.current;
+        if (!el) return;
 
         updateOverflowAndButton();
 
-        if (programmatic) {
+        if (!canScroll(el)) {
+            setStateValue('following');
             return;
         }
 
-        if (currentTop < previousTop && stateRef.current === 'following') {
-            stopFollowLoop();
-            stopSettleBurst();
-            lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
-            setStateValue('released');
-        }
-
-        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
-        const inGrace = (now - lastUserReleaseAtRef.current) < REPIN_GRACE_AFTER_RELEASE_MS;
-        if (stateRef.current === 'released' && isNearBottom(container, isMobile) && !inGrace) {
+        // Within the bottom zone → (re-)pin to following. This is how scrolling
+        // back down to the bottom resumes auto-follow.
+        if (isNearBottom(el, isMobileRef.current)) {
             setStateValue('following');
-            startFollowLoop();
+            queueSave();
+            return;
         }
 
+        // Our own programmatic write that landed at the bottom but where content
+        // grew between the write and this event — keep following, don't release.
+        if (stateRef.current === 'following' && isAuto(el)) {
+            scrollToBottom(false);
+            queueSave();
+            return;
+        }
+
+        // Genuine user scroll away from the bottom.
+        stop();
         queueSave();
-    }, [
-        isInProgrammaticWindow,
-        isMobile,
-        queueSave,
-        setStateValue,
-        startFollowLoop,
-        stopFollowLoop,
-        stopSettleBurst,
-        updateOverflowAndButton,
-    ]);
+    }, [isAuto, queueSave, scrollToBottom, setStateValue, stop, updateOverflowAndButton]);
 
     React.useEffect(() => {
         const container = containerEl;
@@ -540,15 +554,29 @@ export const useChatAutoFollow = ({
         };
     }, [containerEl, handleScrollEvent, releaseFromUserIntent]);
 
+    // The heart of the follow behaviour: the content ResizeObserver fires after
+    // layout and before paint, so re-pinning to the bottom here is invisible —
+    // there is no "jump up then catch up". Observe both the container (composer
+    // growth shrinks the viewport) and the inner content (streaming growth).
     React.useEffect(() => {
         const container = containerEl;
         if (!container || typeof ResizeObserver === 'undefined') return;
 
         const observer = new ResizeObserver(() => {
-            updateOverflowAndButton();
-            if (stateRef.current === 'following') {
-                startFollowLoop();
+            const el = scrollRef.current;
+            if (el && !canScroll(el)) {
+                setStateValue('following');
+                updateOverflowAndButton();
+                return;
             }
+            updateOverflowAndButton();
+            // Idle resize = layout churn (virtualizer re-measurement, async
+            // tool/code rendering), NOT live growth. Never re-pin when idle, or
+            // tall items re-measuring as the user scrolls cause an endless
+            // scroll-to-bottom/re-measure twitch.
+            if (!isActive()) return;
+            if (stateRef.current !== 'following') return;
+            scrollToBottom(false);
         });
         observer.observe(container);
         const inner = container.firstElementChild;
@@ -556,7 +584,7 @@ export const useChatAutoFollow = ({
             observer.observe(inner);
         }
         return () => observer.disconnect();
-    }, [containerEl, startFollowLoop, updateOverflowAndButton]);
+    }, [containerEl, isActive, scrollToBottom, setStateValue, updateOverflowAndButton]);
 
     React.useEffect(() => {
         updateOverflowAndButton();
@@ -566,9 +594,9 @@ export const useChatAutoFollow = ({
         void _reason;
         updateOverflowAndButton();
         if (stateRef.current === 'following') {
-            startFollowLoop();
+            scrollToBottom(false);
         }
-    }, [startFollowLoop, updateOverflowAndButton]);
+    }, [scrollToBottom, updateOverflowAndButton]);
 
     const animationHandlersRef = React.useRef<Map<string, AnimationHandlers>>(new Map());
 
@@ -578,7 +606,7 @@ export const useChatAutoFollow = ({
 
         const kick = () => {
             if (stateRef.current === 'following') {
-                startFollowLoop();
+                scrollToBottom(false);
             }
         };
 
@@ -595,19 +623,25 @@ export const useChatAutoFollow = ({
         };
         animationHandlersRef.current.set(messageId, handlers);
         return handlers;
-    }, [startFollowLoop, updateOverflowAndButton]);
+    }, [scrollToBottom, updateOverflowAndButton]);
 
     React.useEffect(() => {
         return () => {
-            stopFollowLoop();
-            stopSettleBurst();
+            if (autoTimerRef.current) {
+                clearTimeout(autoTimerRef.current);
+                autoTimerRef.current = null;
+            }
+            if (settleTimerRef.current) {
+                clearTimeout(settleTimerRef.current);
+                settleTimerRef.current = null;
+            }
             flushSave();
             if (saveTimerRef.current !== null) {
                 clearTimeout(saveTimerRef.current);
                 saveTimerRef.current = null;
             }
         };
-    }, [flushSave, stopFollowLoop, stopSettleBurst]);
+    }, [flushSave]);
 
     React.useEffect(() => {
         if (!onActiveTurnChange) return;
@@ -689,6 +723,7 @@ export const useChatAutoFollow = ({
         notifyContentChange,
         getAnimationHandlers,
         goToBottom,
+        scrollToBottomOnSend,
         releaseAutoFollow,
         saveSnapshotNow,
         restoreSnapshot,

--- a/packages/ui/src/hooks/useChatAutoFollow.ts
+++ b/packages/ui/src/hooks/useChatAutoFollow.ts
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { MessageFreshnessDetector } from '@/lib/messageFreshness';
 import { createScrollSpy } from '@/components/chat/lib/scroll/scrollSpy';
-import { useViewportStore } from '@/sync/viewport-store';
+import { getViewportSessionMemory, useViewportStore, type SessionMemoryState } from '@/sync/viewport-store';
 
-type AutoFollowState = 'following' | 'released';
+export type AutoFollowState = 'following' | 'released';
 
 export type ContentChangeReason = 'text' | 'structural' | 'permission';
 
@@ -36,51 +36,21 @@ export interface UseChatAutoFollowResult {
     notifyContentChange: (reason?: ContentChangeReason) => void;
     getAnimationHandlers: (messageId: string) => AnimationHandlers;
     goToBottom: (mode?: 'instant' | 'smooth') => void;
-    scrollToBottomOnSend: () => void;
     releaseAutoFollow: () => void;
     saveSnapshotNow: () => void;
     restoreSnapshot: () => Promise<boolean>;
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Chat auto-follow. The model is deliberately simple, which is what makes it
-// flicker-free:
-//
-//   • Auto-follow is on unless the user scrolled up (`released`), AND passive
-//     following only acts while the session is active (working, plus a short
-//     settle window). When idle, content-size changes are layout churn
-//     (virtualizer re-measurement, async tool/code rendering) rather than live
-//     growth, so the hook leaves scroll alone — re-pinning then would fight the
-//     virtualizer and twitch the viewport.
-//   • Following the bottom is INSTANT — `scrollTop = scrollHeight` inside the
-//     content ResizeObserver, which fires after layout and before paint. There
-//     is NO easing loop and NO settle burst, so there are never two writers
-//     racing for `scrollTop` (the root cause of the old jiggle/double-scroll).
-//   • A short-lived "auto" marker (position + 1500ms) lets the scroll handler
-//     distinguish our own programmatic writes from genuine user scrolling, so
-//     a scroll event that lands at our just-written bottom never trips a false
-//     release.
-//
-// The public interface below is unchanged from the old implementation so every
-// consumer (ChatContainer, message parts, the timeline controller) keeps
-// working without edits.
-// ──────────────────────────────────────────────────────────────────────────
-
 const BOTTOM_SPACER_DESKTOP_VH = 0.10;
 const BOTTOM_SPACER_MOBILE_PX = 40;
+const PROGRAMMATIC_WRITE_WINDOW_MS = 200;
 const SAVE_DEBOUNCE_MS = 150;
+const LERP = 0.18;
+const SETTLE_EPSILON = 0.5;
+const SETTLE_FRAMES = 4;
 const TOUCH_FINGER_DOWN_THRESHOLD = 2;
-// How long an "auto" (programmatic) scroll position stays trusted. Browsers can
-// dispatch the `scroll` event for our write asynchronously, after newer content
-// has already changed the geometry; the window keeps us from reading that lag as
-// a user scroll.
-const AUTO_MARK_TTL_MS = 1500;
-const AUTO_MATCH_TOLERANCE_PX = 2;
-// After streaming stops, keep following the bottom for a short window so the
-// final content can settle into place.
-const SETTLE_MS = 300;
-
-const now = (): number => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+const SETTLE_BURST_DURATION_MS = 280;
+const REPIN_GRACE_AFTER_RELEASE_MS = 1200;
 
 // The bottom of the chat has an empty spacer (10vh on desktop, 40px on mobile)
 // — its height is exactly how far above scrollHeight the user can be while still
@@ -95,10 +65,6 @@ const computeBottomZoneThreshold = (isMobile: boolean, container?: HTMLElement |
 
 const distanceFromBottom = (el: HTMLElement): number => {
     return el.scrollHeight - el.scrollTop - el.clientHeight;
-};
-
-const canScroll = (el: HTMLElement): boolean => {
-    return el.scrollHeight - el.clientHeight > 1;
 };
 
 const isNearBottom = (el: HTMLElement, isMobile: boolean): boolean => {
@@ -132,6 +98,13 @@ const nestedScrollableCanConsumeUp = (root: HTMLElement, target: EventTarget | n
     return nested.scrollTop > 0;
 };
 
+const isAtBottomSnapshot = (snapshot: NonNullable<SessionMemoryState['scrollPosition']>, isMobile: boolean): boolean => {
+    const max = Math.max(0, snapshot.scrollHeight - snapshot.clientHeight);
+    if (max <= 0) return true;
+    const threshold = computeBottomZoneThreshold(isMobile, null);
+    return max - snapshot.scrollTop <= threshold;
+};
+
 export const useChatAutoFollow = ({
     currentSessionId,
     sessionMessageCount,
@@ -148,33 +121,21 @@ export const useChatAutoFollow = ({
     const [showScrollButton, setShowScrollButton] = React.useState(false);
     const [isFollowingProgrammatically, setIsFollowingProgrammatically] = React.useState(false);
 
-    // `stateRef` is the single source of truth for follow vs released; the React
-    // state above is a mirror for rendering. `released` means the user scrolled
-    // up and away from the bottom.
     const stateRef = React.useRef<AutoFollowState>('following');
-    const isMobileRef = React.useRef(isMobile);
-    isMobileRef.current = isMobile;
-    const sessionIsWorkingRef = React.useRef(sessionIsWorking);
-    sessionIsWorkingRef.current = sessionIsWorking;
-    // `settling` keeps passive follow alive for a short window after work stops
-    // so the final content can land at the bottom.
-    const settlingRef = React.useRef(false);
-    const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const sessionMessageCountRef = React.useRef(sessionMessageCount);
     sessionMessageCountRef.current = sessionMessageCount;
     const currentSessionIdRef = React.useRef(currentSessionId);
     currentSessionIdRef.current = currentSessionId;
 
     const lastSessionIdRef = React.useRef<string | null>(null);
-
-    // Programmatic-scroll marker: the bottom position we last
-    // wrote and when. A scroll event whose scrollTop matches `top` within a few
-    // px while still inside the TTL is OUR write, not the user's.
-    const autoRef = React.useRef<{ top: number; time: number } | null>(null);
-    const autoTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-
+    const programmaticWriteUntilRef = React.useRef(0);
+    const followRafRef = React.useRef<number | null>(null);
+    const settledFramesRef = React.useRef(0);
+    const lastScrollTopRef = React.useRef(0);
     const saveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const pendingSaveRef = React.useRef<{ sessionId: string; anchor: number } | null>(null);
+    const settleBurstRafRef = React.useRef<number | null>(null);
+    const lastUserReleaseAtRef = React.useRef(0);
     // When restoreSnapshot is invoked while ChatViewport is still hydrating
     // (skeleton rendered, no scroll container yet), we record the session here
     // so a follow-up effect can replay the restore once the container mounts.
@@ -194,138 +155,145 @@ export const useChatAutoFollow = ({
         }
     });
 
-    // `active` is `working || settling`. Passive auto-follow
-    // (the ResizeObserver re-pin and any non-forced scrollToBottom) only runs
-    // while active. When the session is idle, content-size changes are layout
-    // churn — virtualizer re-measurement, async tool/code rendering — NOT live
-    // growth, so we must NOT yank the user to the bottom. Forcing this gate is
-    // what stops the twitch when tall items (expanded tools) re-measure as the
-    // user scrolls.
-    const isActive = React.useCallback((): boolean => {
-        return sessionIsWorkingRef.current || settlingRef.current;
-    }, []);
-
     const setStateValue = React.useCallback((next: AutoFollowState) => {
         if (stateRef.current === next) return;
         stateRef.current = next;
         setState(next);
     }, []);
 
-    // ── auto marker ────────────────────────────────────────────────────────
-    const markAuto = React.useCallback((el: HTMLElement) => {
-        autoRef.current = {
-            top: Math.max(0, el.scrollHeight - el.clientHeight),
-            time: now(),
-        };
-        if (autoTimerRef.current) clearTimeout(autoTimerRef.current);
-        autoTimerRef.current = setTimeout(() => {
-            autoRef.current = null;
-            autoTimerRef.current = null;
-        }, AUTO_MARK_TTL_MS);
+    const markProgrammaticWrite = React.useCallback(() => {
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        programmaticWriteUntilRef.current = now + PROGRAMMATIC_WRITE_WINDOW_MS;
     }, []);
 
-    const isAuto = React.useCallback((el: HTMLElement): boolean => {
-        const a = autoRef.current;
-        if (!a) return false;
-        if (now() - a.time > AUTO_MARK_TTL_MS) {
-            autoRef.current = null;
-            return false;
+    const isInProgrammaticWindow = React.useCallback(() => {
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        return now < programmaticWriteUntilRef.current;
+    }, []);
+
+    const stopFollowLoop = React.useCallback(() => {
+        if (followRafRef.current !== null && typeof window !== 'undefined') {
+            window.cancelAnimationFrame(followRafRef.current);
         }
-        return Math.abs(el.scrollTop - a.top) < AUTO_MATCH_TOLERANCE_PX;
+        followRafRef.current = null;
+        settledFramesRef.current = 0;
+        setIsFollowingProgrammatically(false);
     }, []);
 
-    // ── overflow / scroll-to-bottom button ──────────────────────────────────
-    const updateOverflowAndButton = React.useCallback(() => {
+    const tickFollow = React.useCallback(() => {
+        followRafRef.current = null;
         const container = scrollRef.current;
         if (!container) {
-            setIsOverflowing(false);
-            setShowScrollButton(false);
+            stopFollowLoop();
             return;
         }
-        const overflowing = canScroll(container);
-        setIsOverflowing(overflowing);
-        if (!overflowing) {
-            setShowScrollButton(false);
+        if (stateRef.current !== 'following') {
+            stopFollowLoop();
             return;
         }
-        const showButton = stateRef.current === 'released' && !isNearBottom(container, isMobileRef.current);
-        setShowScrollButton(showButton);
+
+        // INSTANT SNAP (OpenCode pattern from packages/ui/src/hooks/create-auto-scroll.tsx).
+        // Write scrollTop = scrollHeight directly. The browser clamps to max.
+        // No LERP, no settle counter. The loop runs every frame as long as
+        // state is 'following'. handleScrollEvent sets state='released' when
+        // the user scrolls up by more than RELEASE_DELTA_THRESHOLD (16px),
+        // which stops the loop. This eliminates the visible "catch-up" animation
+        // while Virtualizer content is still settling, AND prevents the LERP
+        // drift from leaving the scroll position above the bottom during
+        // session-switch Virtualizer remounts.
+        const target = container.scrollHeight;
+        markProgrammaticWrite();
+        container.scrollTop = target;
+        lastScrollTopRef.current = container.scrollTop;
+
+        // Reset settle counter so when the follow loop stops, it knows it
+        // tracked the bottom successfully.
+        settledFramesRef.current = 0;
+
+        followRafRef.current = window.requestAnimationFrame(tickFollow);
+    }, [markProgrammaticWrite, stopFollowLoop]);
+
+    const startFollowLoop = React.useCallback(() => {
+        if (typeof window === 'undefined') return;
+        if (followRafRef.current !== null) return;
+        if (stateRef.current !== 'following') return;
+        settledFramesRef.current = 0;
+        setIsFollowingProgrammatically(true);
+        followRafRef.current = window.requestAnimationFrame(tickFollow);
+    }, [tickFollow]);
+
+    const writeScrollTopInstant = React.useCallback((target: number) => {
+        const container = scrollRef.current;
+        if (!container) return;
+        const max = Math.max(0, container.scrollHeight - container.clientHeight);
+        const clamped = Math.max(0, Math.min(target, max));
+        markProgrammaticWrite();
+        container.scrollTop = clamped;
+        lastScrollTopRef.current = container.scrollTop;
+    }, [markProgrammaticWrite]);
+
+    const stopSettleBurst = React.useCallback(() => {
+        if (settleBurstRafRef.current !== null && typeof window !== 'undefined') {
+            window.cancelAnimationFrame(settleBurstRafRef.current);
+        }
+        settleBurstRafRef.current = null;
     }, []);
 
-    // ── core scroll primitives ───────────────────────────────────────────────
-    const scrollToBottomNow = React.useCallback((behavior: ScrollBehavior) => {
-        const el = scrollRef.current;
-        if (!el) return;
-        markAuto(el);
-        if (behavior === 'smooth') {
-            el.scrollTo({ top: el.scrollHeight, behavior });
-            return;
-        }
-        // Direct `scrollTop` assignment bypasses any CSS `scroll-behavior: smooth`
-        // and lands in the same frame — no visible catch-up animation.
-        el.scrollTop = el.scrollHeight;
-    }, [markAuto]);
-
-    // `force` true = user-intent jump (clears released and always scrolls).
-    // `force` false = passive follow (only while still following).
-    const scrollToBottom = React.useCallback((force: boolean, behavior: ScrollBehavior = 'auto') => {
-        const el = scrollRef.current;
-
-        // Passive follow only while active (working/settling). Forced jumps
-        // (send, go-to-bottom, session restore) always proceed.
-        if (!force && !isActive()) return;
-
-        if (force && stateRef.current !== 'following') {
-            setStateValue('following');
-        }
-        if (!el) return;
-        if (!force && stateRef.current !== 'following') return;
-
-        const distance = distanceFromBottom(el);
-        if (distance < AUTO_MATCH_TOLERANCE_PX) {
-            // Already at the bottom; just refresh the auto marker so the next
-            // scroll event is recognised as ours.
-            markAuto(el);
-            return;
-        }
-        scrollToBottomNow(force ? behavior : 'auto');
-    }, [isActive, markAuto, scrollToBottomNow, setStateValue]);
-
-    // User left the bottom — release auto-follow.
-    const stop = React.useCallback(() => {
-        const el = scrollRef.current;
-        if (!el) return;
-        if (!canScroll(el)) {
-            setStateValue('following');
-            return;
-        }
-        if (stateRef.current === 'released') return;
-        setStateValue('released');
-        updateOverflowAndButton();
-    }, [setStateValue, updateOverflowAndButton]);
-
-    // ── public scroll API (mapped onto the primitives) ───────────────────────
-    const goToBottom = React.useCallback((mode: 'instant' | 'smooth' = 'instant') => {
-        scrollToBottom(true, mode === 'smooth' ? 'smooth' : 'auto');
-    }, [scrollToBottom]);
-
-    const scrollToBottomOnSend = React.useCallback(() => {
-        // Single movement to the just-sent message. Force re-pins to the bottom
-        // whether we were following or scrolled up; the content ResizeObserver
-        // keeps us pinned as the optimistic message and its reply stream in.
-        scrollToBottom(true);
-    }, [scrollToBottom]);
+    const startSettleBurst = React.useCallback(() => {
+        if (typeof window === 'undefined') return;
+        stopSettleBurst();
+        const until = (typeof performance !== 'undefined' ? performance.now() : Date.now()) + SETTLE_BURST_DURATION_MS;
+        const tick = () => {
+            settleBurstRafRef.current = null;
+            if (stateRef.current !== 'following') return;
+            const c = scrollRef.current;
+            if (!c) return;
+            const target = Math.max(0, c.scrollHeight - c.clientHeight);
+            if (Math.abs(c.scrollTop - target) > SETTLE_EPSILON) {
+                markProgrammaticWrite();
+                c.scrollTop = target;
+                lastScrollTopRef.current = target;
+            }
+            const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+            if (now < until) {
+                settleBurstRafRef.current = window.requestAnimationFrame(tick);
+            }
+        };
+        settleBurstRafRef.current = window.requestAnimationFrame(tick);
+    }, [markProgrammaticWrite, stopSettleBurst]);
 
     const releaseAutoFollow = React.useCallback(() => {
+        stopFollowLoop();
+        stopSettleBurst();
+        lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
         setStateValue('released');
-        updateOverflowAndButton();
-    }, [setStateValue, updateOverflowAndButton]);
+    }, [setStateValue, stopFollowLoop, stopSettleBurst]);
 
     const releaseFromUserIntent = React.useCallback(() => {
-        stop();
-    }, [stop]);
+        if (stateRef.current === 'following') {
+            stopFollowLoop();
+            stopSettleBurst();
+            lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
+            setStateValue('released');
+        } else {
+            lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        }
+    }, [setStateValue, stopFollowLoop, stopSettleBurst]);
 
-    // ── per-session snapshot persistence (kept; restore still goes to bottom) ─
+    const goToBottom = React.useCallback((mode: 'instant' | 'smooth' = 'instant') => {
+        const container = scrollRef.current;
+        setStateValue('following');
+        lastUserReleaseAtRef.current = 0;
+        if (!container) return;
+        if (mode === 'smooth') {
+            startFollowLoop();
+            return;
+        }
+        const target = Math.max(0, container.scrollHeight - container.clientHeight);
+        writeScrollTopInstant(target);
+        startSettleBurst();
+    }, [setStateValue, startFollowLoop, startSettleBurst, writeScrollTopInstant]);
+
     const flushSave = React.useCallback(() => {
         if (saveTimerRef.current !== null) {
             clearTimeout(saveTimerRef.current);
@@ -384,16 +352,36 @@ export const useChatAutoFollow = ({
         }
         pendingInitialRestoreRef.current = null;
 
-        // Always return to the bottom on session switch. The content
-        // ResizeObserver re-pins instantly as late
-        // history measures in, so there is no smooth scroll-from-mid artifact.
-        setStateValue('following');
-        scrollToBottom(true);
-        updateOverflowAndButton();
-        return false;
-    }, [scrollToBottom, setStateValue, updateOverflowAndButton]);
+        const saved = getViewportSessionMemory(sessionId)?.scrollPosition;
 
-    // ── session change ───────────────────────────────────────────────────────
+        if (!saved || isAtBottomSnapshot(saved, isMobile)) {
+            setStateValue('following');
+            lastUserReleaseAtRef.current = 0;
+            const target = Math.max(0, container.scrollHeight - container.clientHeight);
+            writeScrollTopInstant(target);
+            startFollowLoop();
+            startSettleBurst();
+            return false;
+        }
+
+        const savedMaxScroll = Math.max(0, saved.scrollHeight - saved.clientHeight);
+        const ratio = savedMaxScroll > 0 ? saved.scrollTop / savedMaxScroll : 0;
+        const currentMaxScroll = Math.max(0, container.scrollHeight - container.clientHeight);
+        const targetTop = Math.round(ratio * currentMaxScroll);
+
+        setStateValue('released');
+        writeScrollTopInstant(targetTop);
+
+        const memState = getViewportSessionMemory(sessionId);
+        updateViewportAnchor(sessionId, memState?.viewportAnchor ?? 0, {
+            scrollTop: container.scrollTop,
+            scrollHeight: container.scrollHeight,
+            clientHeight: container.clientHeight,
+        });
+
+        return true;
+    }, [isMobile, setStateValue, startFollowLoop, startSettleBurst, updateViewportAnchor, writeScrollTopInstant]);
+
     React.useEffect(() => {
         if (!currentSessionId || currentSessionId === lastSessionIdRef.current) {
             return;
@@ -401,88 +389,86 @@ export const useChatAutoFollow = ({
         lastSessionIdRef.current = currentSessionId;
         MessageFreshnessDetector.getInstance().recordSessionStart(currentSessionId);
         flushSave();
-        autoRef.current = null;
+        stopFollowLoop();
+        stopSettleBurst();
+        markProgrammaticWrite();
         // Drop any pending restore request inherited from a different session.
         if (pendingInitialRestoreRef.current && pendingInitialRestoreRef.current !== currentSessionId) {
             pendingInitialRestoreRef.current = null;
         }
-    }, [currentSessionId, flushSave]);
+    }, [currentSessionId, flushSave, markProgrammaticWrite, stopFollowLoop, stopSettleBurst]);
 
-    // When work begins and we are still
-    // following, pin to the bottom. When work stops, keep following alive for a
-    // short settle window so the final content lands at the bottom, then go
-    // idle (after which passive follow is disabled — see `isActive`).
     React.useEffect(() => {
-        settlingRef.current = false;
-        if (settleTimerRef.current) {
-            clearTimeout(settleTimerRef.current);
-            settleTimerRef.current = null;
+        if (sessionIsWorking && stateRef.current === 'following') {
+            startFollowLoop();
         }
-
-        if (sessionIsWorking) {
-            if (stateRef.current === 'following') {
-                scrollToBottom(true);
-            }
-            return;
-        }
-
-        settlingRef.current = true;
-        settleTimerRef.current = setTimeout(() => {
-            settlingRef.current = false;
-            settleTimerRef.current = null;
-        }, SETTLE_MS);
-    }, [sessionIsWorking, scrollToBottom]);
-
-    // Suppress the overlay scrollbar thumb only while we are actively following a
-    // live stream (the thumb would otherwise jump on every instant re-pin). When
-    // idle or released the scrollbar behaves normally. Stable: changes only when
-    // follow-state or working-state flips, not on every frame.
-    React.useEffect(() => {
-        setIsFollowingProgrammatically(state === 'following' && sessionIsWorking);
-    }, [state, sessionIsWorking]);
+    }, [sessionIsWorking, startFollowLoop]);
 
     // Replay a deferred restoreSnapshot once ChatViewport mounts.
-    // useLayoutEffect ensures scroll position is set before the browser paints,
-    // preventing a visible flash of content at the wrong scroll position.
-    React.useLayoutEffect(() => {
+    React.useEffect(() => {
         if (!containerEl) return;
         if (pendingInitialRestoreRef.current && pendingInitialRestoreRef.current === currentSessionId) {
             void restoreSnapshot();
         }
     }, [containerEl, currentSessionId, restoreSnapshot]);
 
-    // ── scroll event handling ────────────────────────────────────────────────
+    const updateOverflowAndButton = React.useCallback(() => {
+        const container = scrollRef.current;
+        if (!container) {
+            setIsOverflowing(false);
+            setShowScrollButton(false);
+            return;
+        }
+        const overflowing = container.scrollHeight > container.clientHeight + 1;
+        setIsOverflowing(overflowing);
+        if (!overflowing) {
+            setShowScrollButton(false);
+            return;
+        }
+        const showButton = stateRef.current === 'released' && !isNearBottom(container, isMobile);
+        setShowScrollButton(showButton);
+    }, [isMobile]);
+
     const handleScrollEvent = React.useCallback(() => {
-        const el = scrollRef.current;
-        if (!el) return;
+        const container = scrollRef.current;
+        if (!container) return;
+
+        const programmatic = isInProgrammaticWindow();
+        const currentTop = container.scrollTop;
+        const previousTop = lastScrollTopRef.current;
+        lastScrollTopRef.current = currentTop;
 
         updateOverflowAndButton();
 
-        if (!canScroll(el)) {
+        if (programmatic) {
+            return;
+        }
+
+        if (currentTop < previousTop && stateRef.current === 'following') {
+            stopFollowLoop();
+            stopSettleBurst();
+            lastUserReleaseAtRef.current = typeof performance !== 'undefined' ? performance.now() : Date.now();
+            setStateValue('released');
+        }
+
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const inGrace = (now - lastUserReleaseAtRef.current) < REPIN_GRACE_AFTER_RELEASE_MS;
+        if (stateRef.current === 'released' && isNearBottom(container, isMobile) && !inGrace) {
             setStateValue('following');
-            return;
+            startFollowLoop();
         }
 
-        // Within the bottom zone → (re-)pin to following. This is how scrolling
-        // back down to the bottom resumes auto-follow.
-        if (isNearBottom(el, isMobileRef.current)) {
-            setStateValue('following');
-            queueSave();
-            return;
-        }
-
-        // Our own programmatic write that landed at the bottom but where content
-        // grew between the write and this event — keep following, don't release.
-        if (stateRef.current === 'following' && isAuto(el)) {
-            scrollToBottom(false);
-            queueSave();
-            return;
-        }
-
-        // Genuine user scroll away from the bottom.
-        stop();
         queueSave();
-    }, [isAuto, queueSave, scrollToBottom, setStateValue, stop, updateOverflowAndButton]);
+    }, [
+        isInProgrammaticWindow,
+        isMobile,
+        queueSave,
+        setStateValue,
+        startFollowLoop,
+        stopFollowLoop,
+        stopSettleBurst,
+        updateOverflowAndButton,
+    ]);
 
     React.useEffect(() => {
         const container = containerEl;
@@ -554,29 +540,15 @@ export const useChatAutoFollow = ({
         };
     }, [containerEl, handleScrollEvent, releaseFromUserIntent]);
 
-    // The heart of the follow behaviour: the content ResizeObserver fires after
-    // layout and before paint, so re-pinning to the bottom here is invisible —
-    // there is no "jump up then catch up". Observe both the container (composer
-    // growth shrinks the viewport) and the inner content (streaming growth).
     React.useEffect(() => {
         const container = containerEl;
         if (!container || typeof ResizeObserver === 'undefined') return;
 
         const observer = new ResizeObserver(() => {
-            const el = scrollRef.current;
-            if (el && !canScroll(el)) {
-                setStateValue('following');
-                updateOverflowAndButton();
-                return;
-            }
             updateOverflowAndButton();
-            // Idle resize = layout churn (virtualizer re-measurement, async
-            // tool/code rendering), NOT live growth. Never re-pin when idle, or
-            // tall items re-measuring as the user scrolls cause an endless
-            // scroll-to-bottom/re-measure twitch.
-            if (!isActive()) return;
-            if (stateRef.current !== 'following') return;
-            scrollToBottom(false);
+            if (stateRef.current === 'following') {
+                startFollowLoop();
+            }
         });
         observer.observe(container);
         const inner = container.firstElementChild;
@@ -584,7 +556,7 @@ export const useChatAutoFollow = ({
             observer.observe(inner);
         }
         return () => observer.disconnect();
-    }, [containerEl, isActive, scrollToBottom, setStateValue, updateOverflowAndButton]);
+    }, [containerEl, startFollowLoop, updateOverflowAndButton]);
 
     React.useEffect(() => {
         updateOverflowAndButton();
@@ -594,9 +566,9 @@ export const useChatAutoFollow = ({
         void _reason;
         updateOverflowAndButton();
         if (stateRef.current === 'following') {
-            scrollToBottom(false);
+            startFollowLoop();
         }
-    }, [scrollToBottom, updateOverflowAndButton]);
+    }, [startFollowLoop, updateOverflowAndButton]);
 
     const animationHandlersRef = React.useRef<Map<string, AnimationHandlers>>(new Map());
 
@@ -606,7 +578,7 @@ export const useChatAutoFollow = ({
 
         const kick = () => {
             if (stateRef.current === 'following') {
-                scrollToBottom(false);
+                startFollowLoop();
             }
         };
 
@@ -623,25 +595,19 @@ export const useChatAutoFollow = ({
         };
         animationHandlersRef.current.set(messageId, handlers);
         return handlers;
-    }, [scrollToBottom, updateOverflowAndButton]);
+    }, [startFollowLoop, updateOverflowAndButton]);
 
     React.useEffect(() => {
         return () => {
-            if (autoTimerRef.current) {
-                clearTimeout(autoTimerRef.current);
-                autoTimerRef.current = null;
-            }
-            if (settleTimerRef.current) {
-                clearTimeout(settleTimerRef.current);
-                settleTimerRef.current = null;
-            }
+            stopFollowLoop();
+            stopSettleBurst();
             flushSave();
             if (saveTimerRef.current !== null) {
                 clearTimeout(saveTimerRef.current);
                 saveTimerRef.current = null;
             }
         };
-    }, [flushSave]);
+    }, [flushSave, stopFollowLoop, stopSettleBurst]);
 
     React.useEffect(() => {
         if (!onActiveTurnChange) return;
@@ -723,7 +689,6 @@ export const useChatAutoFollow = ({
         notifyContentChange,
         getAnimationHandlers,
         goToBottom,
-        scrollToBottomOnSend,
         releaseAutoFollow,
         saveSnapshotNow,
         restoreSnapshot,

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2236,6 +2236,8 @@ export const dict = {
   'mcpDropdown.status.unknownError': 'Unknown error',
   'mcpDropdown.status.needsAuth': 'Needs authentication',
   'mcpDropdown.status.needsRegistration': 'Needs registration: {error}',
+  'mcpDropdown.status.configured': 'Configured',
+  'mcpDropdown.status.notConnected': 'Not connected',
   'mcpDropdown.empty.configureInConfig': 'Configure MCP servers in Settings.',
   'sessionAuth.error.rateLimitTitle': 'Too many attempts',
   'sessionAuth.error.networkTitle': 'Unable to reach server',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2202,6 +2202,8 @@ export const dict: Record<I18nKey, string> = {
   "mcpDropdown.status.unknownError": "Error desconocido",
   "mcpDropdown.status.needsAuth": "Necesita autenticación",
   "mcpDropdown.status.needsRegistration": "Necesita registro: {error}",
+  "mcpDropdown.status.configured": "Configured",
+  "mcpDropdown.status.notConnected": "Not connected",
   "mcpDropdown.empty.configureInConfig": "Configura los servidores MCP en Ajustes.",
   "sessionAuth.error.rateLimitTitle": "Demasiados intentos",
   "sessionAuth.error.networkTitle": "No se puede alcanzar el servidor",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -2058,6 +2058,8 @@ export const dict = {
   'mcpDropdown.status.unknownError': 'Erreur inconnue',
   'mcpDropdown.status.needsAuth': 'Nécessite une authentification',
   'mcpDropdown.status.needsRegistration': 'Nécessite un enregistrement : {error}',
+  'mcpDropdown.status.configured': 'Configured',
+  'mcpDropdown.status.notConnected': 'Not connected',
   'mcpDropdown.empty.configureInConfig': 'Configurez les serveurs MCP dans la configuration OpenCode.',
   'sessionAuth.error.rateLimitTitle': 'Trop de tentatives',
   'sessionAuth.error.networkTitle': 'Impossible d\'atteindre le serveur',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2235,6 +2235,8 @@ export const dict: Record<I18nKey, string> = {
   'mcpDropdown.status.unknownError': '不明なエラー',
   'mcpDropdown.status.needsAuth': '認証が必要です',
   'mcpDropdown.status.needsRegistration': '登録が必要: {error}',
+  'mcpDropdown.status.configured': 'Configured',
+  'mcpDropdown.status.notConnected': 'Not connected',
   'mcpDropdown.empty.configureInConfig': '設定でMCPサーバーを構成してください。',
   'sessionAuth.error.rateLimitTitle': '試行回数が多すぎます',
   'sessionAuth.error.networkTitle': 'サーバーに到達できません',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2236,6 +2236,8 @@ export const dict: Record<I18nKey, string> = {
   'mcpDropdown.status.unknownError': '알 수 없음 오류',
   'mcpDropdown.status.needsAuth': '인증 필요',
   'mcpDropdown.status.needsRegistration': '등록 필요: {error}',
+  'mcpDropdown.status.configured': 'Configured',
+  'mcpDropdown.status.notConnected': 'Not connected',
   'mcpDropdown.empty.configureInConfig': '설정에서 MCP 서버를 구성하세요.',
   'sessionAuth.error.rateLimitTitle': '시도가 너무 많습니다',
   'sessionAuth.error.networkTitle': '서버에 연결할 수 없습니다',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2101,6 +2101,8 @@ export const dict: Record<I18nKey, string> = {
   'mcpDropdown.status.failed': 'Błąd: {error}',
   'mcpDropdown.status.needsAuth': 'Wymaga uwierzytelnienia',
   'mcpDropdown.status.needsRegistration': 'Wymaga rejestracji: {error}',
+  'mcpDropdown.status.configured': 'Configured',
+  'mcpDropdown.status.notConnected': 'Not connected',
   'mcpDropdown.status.unknown': 'Nieznany',
   'mcpDropdown.status.unknownError': 'Nieznany błąd',
   'mcpDropdown.statusAria': 'Status MCP',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2202,6 +2202,8 @@ export const dict: Record<I18nKey, string> = {
   "mcpDropdown.status.unknownError": "Erro desconhecido",
   "mcpDropdown.status.needsAuth": "Precisa de autenticação",
   "mcpDropdown.status.needsRegistration": "Precisa de registro: {error}",
+  "mcpDropdown.status.configured": "Configured",
+  "mcpDropdown.status.notConnected": "Not connected",
   "mcpDropdown.empty.configureInConfig": "Configure os servidores MCP nas Configurações.",
   "sessionAuth.error.rateLimitTitle": "Muitas tentativas",
   "sessionAuth.error.networkTitle": "Não é possível acessar o servidor",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2202,6 +2202,8 @@ export const dict: Record<I18nKey, string> = {
   "mcpDropdown.status.unknownError": "Невідома помилка",
   "mcpDropdown.status.needsAuth": "Потребує аутентифікації",
   "mcpDropdown.status.needsRegistration": "Потребує реєстрації: {error}",
+  "mcpDropdown.status.configured": "Configured",
+  "mcpDropdown.status.notConnected": "Not connected",
   "mcpDropdown.empty.configureInConfig": "Налаштуйте сервери MCP у Налаштуваннях.",
   "sessionAuth.error.rateLimitTitle": "Забагато спроб",
   "sessionAuth.error.networkTitle": "Неможливо отримати доступ до сервера",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2202,6 +2202,8 @@ export const dict: Record<I18nKey, string> = {
   'mcpDropdown.status.unknownError': '未知错误',
   'mcpDropdown.status.needsAuth': '需要认证',
   'mcpDropdown.status.needsRegistration': '需要注册：{error}',
+  'mcpDropdown.status.configured': 'Configured',
+  'mcpDropdown.status.notConnected': 'Not connected',
   'mcpDropdown.empty.configureInConfig': '请在设置中配置 MCP 服务器。',
   'sessionAuth.error.rateLimitTitle': '尝试次数过多',
   'sessionAuth.error.networkTitle': '无法连接服务器',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2206,6 +2206,8 @@ export const dict: Record<I18nKey, string> = {
   'mcpDropdown.status.unknownError': '未知錯誤',
   'mcpDropdown.status.needsAuth': '需要認證',
   'mcpDropdown.status.needsRegistration': '需要註冊：{error}',
+  'mcpDropdown.status.configured': 'Configured',
+  'mcpDropdown.status.notConnected': 'Not connected',
   'mcpDropdown.empty.configureInConfig': '請在設定中設定 MCP 伺服器。',
   'sessionAuth.error.rateLimitTitle': '嘗試次數過多',
   'sessionAuth.error.networkTitle': '無法連線伺服器',


### PR DESCRIPTION
When the OpenCode status map contains thousands of purely numeric entries (e.g., '0', '1', '10', '100'), the MCP dropdown was filling all 100 visible slots with these useless entries after showing the real configured servers.

## Changes
- Numeric-only names are now skipped during prioritization, so only real MCP server names appear
- The truncation message now shows the actual visible count instead of a hardcoded MAX_VISIBLE_SERVERS value, and only renders when entries are actually filtered