### PR TITLE
fix: kill process tree on Windows via taskkill before SIGTERM fallback

### DIFF
--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -133,6 +133,19 @@ function shouldUseWindowsShell(binary: string): boolean {
   return !ext && !trimmed.includes('\\') && !trimmed.includes('/');
 }
 
+function killProcessTree(pid: number | undefined): void {
+  if (!Number.isInteger(pid)) return;
+  if (process.platform === 'win32') {
+    try {
+      spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'ignore', timeout: 5000, windowsHide: true,
+      });
+    } catch {
+      // ignore
+    }
+  }
+}
+
 function appendToPath(dir: string) {
   const trimmed = (dir || '').trim();
   if (!trimmed) return;
@@ -695,6 +708,7 @@ async function spawnManagedOpenCodeServer(
   return {
     url,
     close: () => {
+      killProcessTree(child.pid);
       try {
         child.kill('SIGTERM');
       } catch {


### PR DESCRIPTION
## Problem

When OpenChamber spawns \opencode serve\ on Windows and the extension is deactivated (VS Code closes), the child process is not properly terminated. The \close()\ method calls \child.kill('SIGTERM')\, which only kills the \cmd.exe\ wrapper — the inner \opencode.exe serve\ continues running as an orphan.

## Root Cause

On Windows, \shouldUseWindowsShell()\ returns \	rue\ for \.cmd\ binaries, so \opencode\ is launched through \cmd.exe\. Node.js \child.kill('SIGTERM')\ terminates the shell wrapper but not the child process tree.

The codebase already contains correct \	askkill /PID /T /F\ logic in \opencodeProcessRegistry.ts\ (used by the startup orphan reaper), but it is not called in the \close()\ path.

## Fix

Added a \killProcessTree()\ helper that runs \	askkill /PID /T /F\ on Windows (no-op on other platforms) and called it as the first step in the \close()\ method, before the existing \child.kill('SIGTERM')\ fallback.

## Verification

This fix was verified locally on Windows (by patching the bundled \dist/extension.js\ with an equivalent change): no orphan \opencode serve\ processes remain after closing VS Code.

Fixes #1889