### PR TITLE
feat(cli): add resource + scheduled-task commands mirroring app menu functions

### DIFF
--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -40,6 +40,7 @@ import {
   projectCommand,
   configCommand,
 } from './lib/commands-resources.js';
+import { scheduleCommand } from './lib/commands-schedule.js';
 import { readDesktopLocalPortFromSettings } from './lib/cli-paths.js';
 import { resolveExplicitBinary, searchPathFor } from './lib/cli-executables.js';
 import { startupCommand } from './lib/commands-startup.js';
@@ -241,6 +242,7 @@ const RESOURCE_COMMANDS = {
   snippet: snippetCommand,
   provider: providerCommand,
   project: projectCommand,
+  schedule: scheduleCommand,
   config: configCommand,
 };
 
@@ -310,7 +312,7 @@ async function main() {
   if (!commands[command]) {
     const knownCommands = [
       'serve', 'stop', 'restart', 'status', 'tunnel', 'startup', 'logs', 'update',
-      'session', 'agent', 'command', 'skill', 'mcp', 'snippet', 'provider', 'project', 'config',
+      'session', 'agent', 'command', 'skill', 'mcp', 'snippet', 'provider', 'project', 'schedule', 'config',
     ];
     const suggestion = findClosestMatch(command, knownCommands);
     const hint = suggestion ? ` Did you mean '${suggestion}'?` : '';

--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -335,6 +335,16 @@ async function main() {
 const isCliExecution = isModuleCliExecution(process.argv[1], import.meta.url, fs.realpathSync, 'openchamber');
 
 if (isCliExecution) {
+  // Exit cleanly when a downstream consumer closes the pipe (e.g. `| head`).
+  // Without this, writes to a closed stdout throw EPIPE and surface as an
+  // uncaught exception with a stack trace.
+  process.stdout.on('error', (error) => {
+    if (error && error.code === 'EPIPE') {
+      process.exit(0);
+    }
+  });
+  process.stderr.on('error', () => {});
+
   let isHandlingSigint = false;
   process.on('SIGINT', () => {
     if (isHandlingSigint) {

--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -25,9 +25,21 @@ import {
   showStartupHelp,
   showConnectUrlHelp,
   showTunnelHelp,
+  showResourceHelp,
   generateCompletionScript,
   findClosestMatch,
 } from './lib/cli-args.js';
+import { sessionCommand } from './lib/commands-session.js';
+import {
+  agentCommand,
+  commandResourceCommand,
+  skillCommand,
+  mcpCommand,
+  snippetCommand,
+  providerCommand,
+  projectCommand,
+  configCommand,
+} from './lib/commands-resources.js';
 import { readDesktopLocalPortFromSettings } from './lib/cli-paths.js';
 import { resolveExplicitBinary, searchPathFor } from './lib/cli-executables.js';
 import { startupCommand } from './lib/commands-startup.js';
@@ -217,9 +229,24 @@ commands.update = createUpdateCommand({
   serveCommand: commands.serve.bind(commands),
 });
 
+// Resource commands talk to a running instance over HTTP and mirror the
+// app's menu functions. They take (options, action, args) instead of just
+// (options), so they are dispatched separately from the lifecycle commands.
+const RESOURCE_COMMANDS = {
+  session: sessionCommand,
+  agent: agentCommand,
+  command: commandResourceCommand,
+  skill: skillCommand,
+  mcp: mcpCommand,
+  snippet: snippetCommand,
+  provider: providerCommand,
+  project: projectCommand,
+  config: configCommand,
+};
+
 async function main() {
   const parsed = parseArgs();
-  const { command, subcommand, tunnelAction, startupAction, options, removedFlagErrors, helpRequested, versionRequested } = parsed;
+  const { command, subcommand, tunnelAction, startupAction, positionals, options, removedFlagErrors, helpRequested, versionRequested } = parsed;
   activeCommandOptions = options;
 
   if (versionRequested) {
@@ -255,9 +282,18 @@ async function main() {
       showStartupHelp();
     } else if (command === 'connect-url') {
       showConnectUrlHelp();
+    } else if (RESOURCE_COMMANDS[command]) {
+      showResourceHelp(command);
     } else {
       showHelp();
     }
+    return;
+  }
+
+  if (RESOURCE_COMMANDS[command]) {
+    const action = positionals[1];
+    const args = positionals.slice(2);
+    await RESOURCE_COMMANDS[command](options, action, args);
     return;
   }
 
@@ -272,7 +308,10 @@ async function main() {
   }
 
   if (!commands[command]) {
-    const knownCommands = ['serve', 'stop', 'restart', 'status', 'tunnel', 'startup', 'logs', 'update'];
+    const knownCommands = [
+      'serve', 'stop', 'restart', 'status', 'tunnel', 'startup', 'logs', 'update',
+      'session', 'agent', 'command', 'skill', 'mcp', 'snippet', 'provider', 'project', 'config',
+    ];
     const suggestion = findClosestMatch(command, knownCommands);
     const hint = suggestion ? ` Did you mean '${suggestion}'?` : '';
     if (isJsonMode(options)) {

--- a/packages/web/bin/lib/DOCUMENTATION.md
+++ b/packages/web/bin/lib/DOCUMENTATION.md
@@ -54,6 +54,10 @@ Command modules implement user-facing commands and preserve output contracts acr
   - Implements the config/settings resource commands that mirror the Settings menus: `agent`, `command` (slash commands), `skill`, `mcp`, `snippet`, `provider`, `project`, and `config`.
   - Each group exposes read actions (`list`/`show`/`models`/`get`) and, where the server supports it, safe `create`/`delete` mutations. Shared `renderList`/`renderMutation`/`confirmDestructive` helpers keep output and validation consistent across modes.
 
+- `commands-schedule.js`
+  - Implements `openchamber schedule` and its actions: `list`, `show`, `create`, `run`, `enable`, `disable`, `delete`, and `status`. Mirrors the scheduled-tasks menu functions over the per-project `/api/projects/:projectId/scheduled-tasks` routes plus the global `/api/openchamber/scheduled-tasks/status`.
+  - Resolves the OpenChamber project via `resolveProjectId` (explicit `--project`, scope directory, active project, or sole project) and builds schedule objects (daily/weekly/once/cron) from flags. Destructive `delete` is gated by confirmation/`--force` in every mode.
+
 ## Shared Helper Modules
 
 These modules hold reusable, non-presentational logic for commands.

--- a/packages/web/bin/lib/DOCUMENTATION.md
+++ b/packages/web/bin/lib/DOCUMENTATION.md
@@ -47,8 +47,9 @@ Command modules implement user-facing commands and preserve output contracts acr
   - Receives `serveCommand` and `stopCommand` by dependency injection. Do not reach back into `cli.js` command globals from this module.
 
 - `commands-session.js`
-  - Implements `openchamber session` and its actions: `list`, `show`, `create`, `rename`, `archive`, `unarchive`, `share`, `unshare`, `delete`, and `prompt`.
-  - Mirrors the app's session menu functions by talking to a running instance over HTTP (via `cli-api-client.js`). Scopes to the project directory (`--directory`, default cwd), gates deletion behind confirmation/`--force` in every mode, and preserves `--json`/`--quiet` contracts.
+  - Implements `openchamber session` and its actions: `list`, `show`, `rename`, `archive`, `unarchive`, `share`, `unshare`, and `delete`.
+  - Mirrors the app's session read/mutation menu functions by talking to a running instance over HTTP (via `cli-api-client.js`). Scopes to the project directory (`--directory`, default cwd), gates deletion behind confirmation/`--force` in every mode, and preserves `--json`/`--quiet` contracts.
+  - Session creation and initial-prompt dispatch are intentionally excluded: OpenChamber-owned session orchestration (`/api/openchamber/sessions`) is the source of truth for creating sessions and dispatching the first prompt.
 
 - `commands-resources.js`
   - Implements the config/settings resource commands that mirror the Settings menus: `agent`, `command` (slash commands), `skill`, `mcp`, `snippet`, `provider`, `project`, and `config`.

--- a/packages/web/bin/lib/DOCUMENTATION.md
+++ b/packages/web/bin/lib/DOCUMENTATION.md
@@ -46,6 +46,14 @@ Command modules implement user-facing commands and preserve output contracts acr
   - Owns tunnel-specific command flow, interactive prompt decisions, managed-local/managed-remote startup, QR display rules, tunnel start/stop API calls, and tunnel profile command handling.
   - Receives `serveCommand` and `stopCommand` by dependency injection. Do not reach back into `cli.js` command globals from this module.
 
+- `commands-session.js`
+  - Implements `openchamber session` and its actions: `list`, `show`, `create`, `rename`, `archive`, `unarchive`, `share`, `unshare`, `delete`, and `prompt`.
+  - Mirrors the app's session menu functions by talking to a running instance over HTTP (via `cli-api-client.js`). Scopes to the project directory (`--directory`, default cwd), gates deletion behind confirmation/`--force` in every mode, and preserves `--json`/`--quiet` contracts.
+
+- `commands-resources.js`
+  - Implements the config/settings resource commands that mirror the Settings menus: `agent`, `command` (slash commands), `skill`, `mcp`, `snippet`, `provider`, `project`, and `config`.
+  - Each group exposes read actions (`list`/`show`/`models`/`get`) and, where the server supports it, safe `create`/`delete` mutations. Shared `renderList`/`renderMutation`/`confirmDestructive` helpers keep output and validation consistent across modes.
+
 ## Shared Helper Modules
 
 These modules hold reusable, non-presentational logic for commands.
@@ -67,6 +75,12 @@ These modules hold reusable, non-presentational logic for commands.
 
 - `cli-http.js`
   - HTTP helpers for health checks, shutdown requests, JSON API calls, tunnel provider fetches, and system info fetches.
+
+- `cli-api-client.js`
+  - Transport layer for resource commands. Resolves the target instance port (explicit `--port` or single-instance discovery, failing deterministically on none/ambiguous), performs authenticated JSON requests against a running server (throwing `ApiError` on non-2xx so failures are mode-agnostic), and resolves the project scope directory.
+
+- `cli-format.js`
+  - Pure presentation helpers shared by resource commands: string truncation, relative-time formatting, and provider/model identifier formatting. Contains no validation or policy.
 
 - `cli-network.js`
   - Host resolution, URL building, LAN detection, unsafe browser port validation, and UI password/network exposure checks.

--- a/packages/web/bin/lib/cli-api-client.js
+++ b/packages/web/bin/lib/cli-api-client.js
@@ -140,8 +140,89 @@ function resolveScopeDirectory(options = {}) {
   }
 }
 
+function normalizePathForCompare(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim().replace(/\\/g, '/');
+  return trimmed.length > 1 ? trimmed.replace(/\/+$/, '') : trimmed;
+}
+
+/**
+ * Resolve the OpenChamber project id for project-scoped commands (scheduled
+ * tasks). Resolution order: explicit --project (id or path), then the project
+ * whose path matches the scope directory, then the active project, then the
+ * sole project. Fails with guidance when ambiguous.
+ */
+async function resolveProjectId(port, options = {}) {
+  const settings = await apiRequest(port, 'GET', '/api/config/settings', { options });
+  const projects = Array.isArray(settings?.projects) ? settings.projects : [];
+
+  const explicit = typeof options.projectId === 'string' ? options.projectId.trim() : '';
+  if (explicit) {
+    const match = projects.find((project) => project.id === explicit
+      || normalizePathForCompare(project.path) === normalizePathForCompare(explicit));
+    return match ? match.id : explicit;
+  }
+
+  const directory = normalizePathForCompare(resolveScopeDirectory(options));
+  if (directory) {
+    const byPath = projects.find((project) => normalizePathForCompare(project.path) === directory);
+    if (byPath) return byPath.id;
+  }
+
+  if (typeof settings?.activeProjectId === 'string' && settings.activeProjectId.trim()) {
+    return settings.activeProjectId.trim();
+  }
+  if (projects.length === 1 && projects[0]?.id) {
+    return projects[0].id;
+  }
+
+  throw new TunnelCliError(
+    'Could not determine the project. Pass --project <id|path>, run inside a configured project directory, or list projects with `openchamber project list`.',
+    EXIT_CODE.USAGE_ERROR,
+  );
+}
+
+/**
+ * Resolve a provider/model selection from flags, falling back to the server's
+ * configured defaults. Used by `session prompt` and `schedule create`.
+ */
+async function resolveModel(port, options = {}) {
+  if (typeof options.model === 'string' && options.model.includes('/')) {
+    const [providerID, ...rest] = options.model.split('/');
+    return { providerID: providerID.trim(), modelID: rest.join('/').trim() };
+  }
+  if (typeof options.provider === 'string' && options.provider.trim()
+    && typeof options.model === 'string' && options.model.trim()) {
+    return { providerID: options.provider.trim(), modelID: options.model.trim() };
+  }
+
+  const config = await apiRequest(port, 'GET', '/api/config/providers', { options });
+  const defaults = config && typeof config.default === 'object' ? config.default : {};
+  const providers = Array.isArray(config?.providers) ? config.providers : [];
+
+  const preferredProvider = typeof options.provider === 'string' && options.provider.trim()
+    ? options.provider.trim()
+    : Object.keys(defaults)[0] || providers[0]?.id;
+
+  if (!preferredProvider) {
+    throw new TunnelCliError('No model available. Configure a provider, or pass --model <provider/model>.', EXIT_CODE.USAGE_ERROR);
+  }
+
+  const modelID = (typeof options.model === 'string' && options.model.trim())
+    ? options.model.trim()
+    : defaults[preferredProvider];
+
+  if (!modelID) {
+    throw new TunnelCliError(`No default model for provider "${preferredProvider}". Pass --model <provider/model>.`, EXIT_CODE.USAGE_ERROR);
+  }
+
+  return { providerID: preferredProvider, modelID };
+}
+
 export {
   resolveTargetPort,
   apiRequest,
   resolveScopeDirectory,
+  resolveProjectId,
+  resolveModel,
 };

--- a/packages/web/bin/lib/cli-api-client.js
+++ b/packages/web/bin/lib/cli-api-client.js
@@ -1,0 +1,147 @@
+import { requestJson } from './cli-http.js';
+import { discoverLifecycleInstances, discoverDesktopInstance } from './cli-lifecycle.js';
+import { EXIT_CODE, TunnelCliError } from './cli-errors.js';
+
+/**
+ * Error raised when an OpenChamber API request fails. Extends TunnelCliError so
+ * the top-level handler honors its exit code, and carries the HTTP status so
+ * callers can branch on it when needed. Failures are deterministic across all
+ * output modes (--json/--quiet/non-TTY).
+ */
+class ApiError extends TunnelCliError {
+  constructor(message, { status, exitCode } = {}) {
+    super(message, Number.isFinite(exitCode) ? exitCode : EXIT_CODE.GENERAL_ERROR);
+    this.name = 'ApiError';
+    this.status = Number.isFinite(status) ? status : null;
+  }
+}
+
+/**
+ * Resolve the port of the running OpenChamber instance the command should talk
+ * to. Policy (enforced in every output mode):
+ *  - `--port` explicit: use it as-is (caller verifies reachability on request).
+ *  - otherwise discover running CLI/desktop instances:
+ *      - exactly one  -> use it
+ *      - more than one -> fail and require `--port`
+ *      - none          -> fail with guidance to start the server
+ */
+async function resolveTargetPort(options = {}) {
+  if (options.explicitPort && Number.isFinite(options.port)) {
+    return options.port;
+  }
+
+  const [cliInstances, desktopInstance] = await Promise.all([
+    discoverLifecycleInstances(options),
+    discoverDesktopInstance(),
+  ]);
+
+  const ports = [];
+  const seen = new Set();
+  const pushPort = (port) => {
+    if (!Number.isFinite(port) || seen.has(port)) return;
+    seen.add(port);
+    ports.push(port);
+  };
+
+  for (const instance of cliInstances) {
+    pushPort(instance.port);
+  }
+  if (desktopInstance) {
+    pushPort(desktopInstance.port);
+  }
+
+  if (ports.length === 0) {
+    throw new TunnelCliError(
+      'No running OpenChamber server found. Start one with `openchamber serve`, or pass --port <port>.',
+      EXIT_CODE.GENERAL_ERROR,
+    );
+  }
+
+  if (ports.length > 1) {
+    throw new TunnelCliError(
+      `Multiple OpenChamber servers are running (ports: ${ports.join(', ')}). Choose one with --port <port>.`,
+      EXIT_CODE.USAGE_ERROR,
+    );
+  }
+
+  return ports[0];
+}
+
+function buildEndpoint(endpoint, query) {
+  if (!query || typeof query !== 'object') {
+    return endpoint;
+  }
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === '') continue;
+    params.set(key, String(value));
+  }
+  const qs = params.toString();
+  if (!qs) return endpoint;
+  return `${endpoint}${endpoint.includes('?') ? '&' : '?'}${qs}`;
+}
+
+function extractErrorMessage(body, response) {
+  if (body && typeof body === 'object') {
+    if (typeof body.error === 'string' && body.error.trim().length > 0) return body.error;
+    if (typeof body.message === 'string' && body.message.trim().length > 0) return body.message;
+  }
+  const status = response?.status;
+  const statusText = response?.statusText;
+  if (status) {
+    return `Request failed with status ${status}${statusText ? ` (${statusText})` : ''}`;
+  }
+  return 'Request failed';
+}
+
+/**
+ * Perform a JSON API request against a running instance and return the parsed
+ * body. Throws {@link ApiError} on any non-2xx response so callers fail
+ * deterministically regardless of --json/--quiet mode.
+ */
+async function apiRequest(port, method, endpoint, { query, body, options = {}, timeoutMs } = {}) {
+  const requestOptions = {
+    method,
+    uiPassword: options.uiPassword,
+  };
+  if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    requestOptions.timeoutMs = timeoutMs;
+  }
+  if (body !== undefined && body !== null) {
+    requestOptions.body = typeof body === 'string' ? body : JSON.stringify(body);
+  }
+
+  const { response, body: payload } = await requestJson(port, buildEndpoint(endpoint, query), requestOptions);
+
+  if (!response.ok) {
+    const status = response.status;
+    const exitCode = status === 404
+      ? EXIT_CODE.GENERAL_ERROR
+      : (status === 401 || status === 403 ? EXIT_CODE.AUTH_CONFIG_ERROR : EXIT_CODE.GENERAL_ERROR);
+    throw new ApiError(extractErrorMessage(payload, response), { status, exitCode });
+  }
+
+  return payload;
+}
+
+/**
+ * Directory used to scope project-aware API calls (sessions, config entities).
+ * Prefers an explicit --directory/--cwd flag, falling back to the directory the
+ * CLI is invoked from so terminal usage is contextual by default.
+ */
+function resolveScopeDirectory(options = {}) {
+  if (typeof options.directory === 'string' && options.directory.trim().length > 0) {
+    return options.directory.trim();
+  }
+  try {
+    return process.cwd();
+  } catch {
+    return undefined;
+  }
+}
+
+export {
+  resolveTargetPort,
+  apiRequest,
+  resolveScopeDirectory,
+};

--- a/packages/web/bin/lib/cli-args.js
+++ b/packages/web/bin/lib/cli-args.js
@@ -101,6 +101,17 @@ function parseArgs(argv = process.argv.slice(2)) {
     prompt: undefined,
     url: undefined,
     commandStr: undefined,
+    // Scheduled task inputs
+    projectId: undefined,
+    kind: undefined,
+    at: undefined,
+    on: undefined,
+    cron: undefined,
+    date: undefined,
+    time: undefined,
+    timezone: undefined,
+    variant: undefined,
+    disabled: false,
   };
 
   const removedFlagErrors = [];
@@ -330,6 +341,64 @@ function parseArgs(argv = process.argv.slice(2)) {
         options.commandStr = typeof value === 'string' ? value : options.commandStr;
         break;
       }
+      case 'project': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.projectId = typeof value === 'string' ? value : options.projectId;
+        break;
+      }
+      case 'kind': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.kind = typeof value === 'string' ? value : options.kind;
+        break;
+      }
+      case 'at': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.at = typeof value === 'string' ? value : options.at;
+        break;
+      }
+      case 'on': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.on = typeof value === 'string' ? value : options.on;
+        break;
+      }
+      case 'cron': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.cron = typeof value === 'string' ? value : options.cron;
+        break;
+      }
+      case 'date': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.date = typeof value === 'string' ? value : options.date;
+        break;
+      }
+      case 'time': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.time = typeof value === 'string' ? value : options.time;
+        break;
+      }
+      case 'timezone':
+      case 'tz': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.timezone = typeof value === 'string' ? value : options.timezone;
+        break;
+      }
+      case 'variant': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.variant = typeof value === 'string' ? value : options.variant;
+        break;
+      }
+      case 'disabled':
+        options.disabled = true;
+        break;
       case 'yes':
       case 'y':
         options.force = true;
@@ -479,6 +548,7 @@ RESOURCE COMMANDS (talk to a running server):
   snippet        Manage snippets (list/show/create/delete)
   provider       Inspect providers and models (list/models)
   project        List configured projects (list)
+  schedule       Manage scheduled tasks (list/show/create/run/enable/disable/delete/status)
   config         Show OpenChamber settings (get)
 
   Run 'openchamber <command> --help' for resource command details.
@@ -789,6 +859,47 @@ USAGE:
 ACTIONS:
   list                         List configured projects
 `,
+  schedule: `
+ OpenChamber Scheduled Task Commands
+
+USAGE:
+  openchamber schedule <ACTION> [ARGS] [OPTIONS]
+
+ACTIONS:
+  list                         List scheduled tasks for the project
+  show <id|name>               Show a scheduled task
+  create <name>                Create/update a task (see CREATE OPTIONS)
+  run <id|name>                Run a task now
+  enable <id|name>             Enable a task
+  disable <id|name>            Disable a task
+  delete <id|name>             Delete a task (--force to skip confirm)
+  status                       Show global scheduled-task counts
+
+PROJECT SELECTION:
+  --project <id|path>          Target project (default: project for cwd / active)
+  --directory <path>           Match a project by directory
+
+CREATE OPTIONS:
+  --prompt <text>              Prompt to run ("/command args" runs a slash command)
+  --kind <daily|weekly|once|cron>   Schedule kind (inferred from flags below)
+  --at "09:00,17:30"           Run time(s) for daily/weekly
+  --on "mon,wed,fri"           Weekdays for weekly (names or 0..6, 0=Sun)
+  --date YYYY-MM-DD --time HH:mm    One-time run date/time
+  --cron "<expr>"              Cron expression
+  --timezone, --tz <IANA>      Timezone (default: server local)
+  --model <provider/model>     Model (or --provider + --model)
+  --agent <name>               Agent
+  --variant <name>             Thinking variant
+  --disabled                   Create the task disabled
+
+EXAMPLES:
+  openchamber schedule list
+  openchamber schedule create "Daily standup" --prompt "/summarize" --kind daily --at 09:00
+  openchamber schedule create nightly --prompt "Review open PRs" --cron "0 2 * * *" --model anthropic/claude
+  openchamber schedule run "Daily standup"
+  openchamber schedule disable nightly --json
+  openchamber schedule status
+`,
   config: `
  OpenChamber Config Commands
 
@@ -821,7 +932,7 @@ _openchamber_tunnel() {
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-  commands="serve stop restart status tunnel startup logs connect-url update session agent command skill mcp snippet provider project config"
+  commands="serve stop restart status tunnel startup logs connect-url update session agent command skill mcp snippet provider project schedule config"
   tunnel_commands="help providers ready doctor status start stop profile completion"
   profile_commands="list show add remove"
   common_flags="--port --foreground --no-daemon --json --all --help --version --plain --quiet"
@@ -884,6 +995,7 @@ _openchamber() {
     'snippet:Manage snippets'
     'provider:Inspect providers and models'
     'project:List projects'
+    'schedule:Manage scheduled tasks'
     'config:Show settings'
   )
 
@@ -955,6 +1067,7 @@ complete -c openchamber -n '__fish_use_subcommand' -a 'mcp' -d 'Manage MCP serve
 complete -c openchamber -n '__fish_use_subcommand' -a 'snippet' -d 'Manage snippets'
 complete -c openchamber -n '__fish_use_subcommand' -a 'provider' -d 'Inspect providers and models'
 complete -c openchamber -n '__fish_use_subcommand' -a 'project' -d 'List projects'
+complete -c openchamber -n '__fish_use_subcommand' -a 'schedule' -d 'Manage scheduled tasks'
 complete -c openchamber -n '__fish_use_subcommand' -a 'config' -d 'Show settings'
 
 complete -c openchamber -n '__fish_seen_subcommand_from tunnel; and not __fish_seen_subcommand_from help providers ready doctor status start stop profile completion' -a 'help' -d 'Show tunnel help'

--- a/packages/web/bin/lib/cli-args.js
+++ b/packages/web/bin/lib/cli-args.js
@@ -90,7 +90,6 @@ function parseArgs(argv = process.argv.slice(2)) {
     apiOnly: false,
     // Resource command inputs (session/agent/command/mcp/snippet/etc.)
     title: undefined,
-    message: undefined,
     content: undefined,
     description: undefined,
     template: undefined,
@@ -271,13 +270,6 @@ function parseArgs(argv = process.argv.slice(2)) {
         const { value, nextIndex } = consumeValue(i, inlineValue);
         i = nextIndex;
         options.title = typeof value === 'string' ? value : '';
-        break;
-      }
-      case 'message':
-      case 'm': {
-        const { value, nextIndex } = consumeValue(i, inlineValue);
-        i = nextIndex;
-        options.message = typeof value === 'string' ? value : options.message;
         break;
       }
       case 'content': {
@@ -540,7 +532,7 @@ COMMANDS:
   update         Check for and install updates
 
 RESOURCE COMMANDS (talk to a running server):
-  session        Manage sessions (list/show/create/rename/archive/share/delete/prompt)
+  session        Manage sessions (list/show/rename/archive/share/delete)
   agent          Manage agents (list/show/create/delete)
   command        Manage slash commands (list/show/create/delete)
   skill          Inspect skills (list/show)
@@ -742,32 +734,30 @@ USAGE:
 ACTIONS:
   list                         List sessions in the current directory
   show <id>                    Show details for a session
-  create [title]               Create a new session
   rename <id> <title>          Rename a session
   archive <id>                 Archive a session
   unarchive <id>               Restore an archived session
   share <id>                   Create a public share link
   unshare <id>                 Remove the public share link
   delete <id>                  Delete a session (use --force to skip confirm)
-  prompt <id> <message>        Send a prompt to a session
 
 OPTIONS:
   --directory <path>           Project directory to scope to (default: cwd)
   --all                        Include archived sessions in list
-  --title <text>               Title for create/rename
-  --message, -m <text>         Message for prompt
-  --model <provider/model>     Model for prompt
-  --provider <id>              Provider for prompt
-  --agent <name>              Agent for prompt (default: build)
+  --title <text>               Title for rename
   --force, --yes               Skip delete confirmation
   --json                       Machine-readable JSON output
   -q, --quiet                  Minimal output
 
 EXAMPLES:
   openchamber session list
-  openchamber session create "Investigate flaky test"
-  openchamber session prompt ses_abc "summarize the repo" --model anthropic/claude
+  openchamber session show ses_abc
+  openchamber session rename ses_abc "Investigate flaky test"
   openchamber session delete ses_abc --force --json
+
+NOTE:
+  Session creation and prompt dispatch are handled by OpenChamber session
+  orchestration (/api/openchamber/sessions), not this CLI.
 `,
   agent: `
  OpenChamber Agent Commands

--- a/packages/web/bin/lib/cli-args.js
+++ b/packages/web/bin/lib/cli-args.js
@@ -88,6 +88,19 @@ function parseArgs(argv = process.argv.slice(2)) {
     foreground: false,
     lan: false,
     apiOnly: false,
+    // Resource command inputs (session/agent/command/mcp/snippet/etc.)
+    title: undefined,
+    message: undefined,
+    content: undefined,
+    description: undefined,
+    template: undefined,
+    agent: undefined,
+    model: undefined,
+    scope: undefined,
+    directory: undefined,
+    prompt: undefined,
+    url: undefined,
+    commandStr: undefined,
   };
 
   const removedFlagErrors = [];
@@ -243,6 +256,84 @@ function parseArgs(argv = process.argv.slice(2)) {
         options.sessionTtl = typeof value === 'string' ? value : options.sessionTtl;
         break;
       }
+      case 'title': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.title = typeof value === 'string' ? value : '';
+        break;
+      }
+      case 'message':
+      case 'm': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.message = typeof value === 'string' ? value : options.message;
+        break;
+      }
+      case 'content': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.content = typeof value === 'string' ? value : options.content;
+        break;
+      }
+      case 'description': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.description = typeof value === 'string' ? value : options.description;
+        break;
+      }
+      case 'template': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.template = typeof value === 'string' ? value : options.template;
+        break;
+      }
+      case 'agent': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.agent = typeof value === 'string' ? value : options.agent;
+        break;
+      }
+      case 'model': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.model = typeof value === 'string' ? value : options.model;
+        break;
+      }
+      case 'scope': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.scope = typeof value === 'string' ? value : options.scope;
+        break;
+      }
+      case 'directory':
+      case 'cwd': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.directory = typeof value === 'string' ? value : options.directory;
+        break;
+      }
+      case 'prompt': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.prompt = typeof value === 'string' ? value : options.prompt;
+        break;
+      }
+      case 'url': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.url = typeof value === 'string' ? value : options.url;
+        break;
+      }
+      case 'command': {
+        const { value, nextIndex } = consumeValue(i, inlineValue);
+        i = nextIndex;
+        options.commandStr = typeof value === 'string' ? value : options.commandStr;
+        break;
+      }
+      case 'yes':
+      case 'y':
+        options.force = true;
+        break;
       case 'json':
         options.json = true;
         break;
@@ -353,6 +444,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     subcommand,
     tunnelAction,
     startupAction,
+    positionals: positional,
     options,
     removedFlagErrors,
     helpRequested,
@@ -377,6 +469,19 @@ COMMANDS:
   logs           Tail OpenChamber logs
   connect-url    Generate URL/QR for connecting another client
   update         Check for and install updates
+
+RESOURCE COMMANDS (talk to a running server):
+  session        Manage sessions (list/show/create/rename/archive/share/delete/prompt)
+  agent          Manage agents (list/show/create/delete)
+  command        Manage slash commands (list/show/create/delete)
+  skill          Inspect skills (list/show)
+  mcp            Manage MCP servers (list/show/create/delete)
+  snippet        Manage snippets (list/show/create/delete)
+  provider       Inspect providers and models (list/models)
+  project        List configured projects (list)
+  config         Show OpenChamber settings (get)
+
+  Run 'openchamber <command> --help' for resource command details.
 
 OPTIONS:
   -p, --port              Web server port (default: ${DEFAULT_PORT})
@@ -557,6 +662,153 @@ EXAMPLES:
 `);
 }
 
+const RESOURCE_HELP = {
+  session: `
+ OpenChamber Session Commands
+
+USAGE:
+  openchamber session <ACTION> [ARGS] [OPTIONS]
+
+ACTIONS:
+  list                         List sessions in the current directory
+  show <id>                    Show details for a session
+  create [title]               Create a new session
+  rename <id> <title>          Rename a session
+  archive <id>                 Archive a session
+  unarchive <id>               Restore an archived session
+  share <id>                   Create a public share link
+  unshare <id>                 Remove the public share link
+  delete <id>                  Delete a session (use --force to skip confirm)
+  prompt <id> <message>        Send a prompt to a session
+
+OPTIONS:
+  --directory <path>           Project directory to scope to (default: cwd)
+  --all                        Include archived sessions in list
+  --title <text>               Title for create/rename
+  --message, -m <text>         Message for prompt
+  --model <provider/model>     Model for prompt
+  --provider <id>              Provider for prompt
+  --agent <name>              Agent for prompt (default: build)
+  --force, --yes               Skip delete confirmation
+  --json                       Machine-readable JSON output
+  -q, --quiet                  Minimal output
+
+EXAMPLES:
+  openchamber session list
+  openchamber session create "Investigate flaky test"
+  openchamber session prompt ses_abc "summarize the repo" --model anthropic/claude
+  openchamber session delete ses_abc --force --json
+`,
+  agent: `
+ OpenChamber Agent Commands
+
+USAGE:
+  openchamber agent <ACTION> [ARGS] [OPTIONS]
+
+ACTIONS:
+  list                         List available agents
+  show <name>                  Show agent configuration sources
+  create <name> [prompt]       Create an agent (--prompt, --description, --mode, --model, --scope)
+  delete <name>                Delete an agent (--scope, --force)
+
+EXAMPLES:
+  openchamber agent list
+  openchamber agent create reviewer --description "Code reviewer" --prompt "Review carefully"
+  openchamber agent delete reviewer --scope user --force
+`,
+  command: `
+ OpenChamber Command (slash) Commands
+
+USAGE:
+  openchamber command <ACTION> [ARGS] [OPTIONS]
+
+ACTIONS:
+  list                         List slash commands
+  show <name>                  Show a slash command (incl. template)
+  create <name> [template]     Create a command (--template, --description, --agent, --model, --scope)
+  delete <name>                Delete a command (--force)
+
+EXAMPLES:
+  openchamber command list
+  openchamber command create deploy --template "Deploy the app" --description "Deploy"
+`,
+  skill: `
+ OpenChamber Skill Commands
+
+USAGE:
+  openchamber skill <ACTION> [ARGS] [OPTIONS]
+
+ACTIONS:
+  list                         List available skills
+  show <name>                  Show skill details
+`,
+  mcp: `
+ OpenChamber MCP Server Commands
+
+USAGE:
+  openchamber mcp <ACTION> [ARGS] [OPTIONS]
+
+ACTIONS:
+  list                         List configured MCP servers
+  show <name>                  Show an MCP server
+  create <name>                Create a server (--url <url> | --command "<cmd args>", --scope)
+  delete <name>                Delete a server (--force)
+
+EXAMPLES:
+  openchamber mcp create context7 --url https://mcp.example.com
+  openchamber mcp create local-fs --command "npx -y @modelcontextprotocol/server-filesystem ."
+`,
+  snippet: `
+ OpenChamber Snippet Commands
+
+USAGE:
+  openchamber snippet <ACTION> [ARGS] [OPTIONS]
+
+ACTIONS:
+  list                         List snippets
+  show <name>                  Show a snippet
+  create <name> [content]      Create a snippet (--content, --description, --scope)
+  delete <name>                Delete a snippet (--force)
+`,
+  provider: `
+ OpenChamber Provider Commands
+
+USAGE:
+  openchamber provider <ACTION> [ARGS] [OPTIONS]
+
+ACTIONS:
+  list                         List configured providers
+  models [providerId]          List available models (optionally for one provider)
+`,
+  project: `
+ OpenChamber Project Commands
+
+USAGE:
+  openchamber project list [OPTIONS]
+
+ACTIONS:
+  list                         List configured projects
+`,
+  config: `
+ OpenChamber Config Commands
+
+USAGE:
+  openchamber config get [OPTIONS]
+
+ACTIONS:
+  get                          Show OpenChamber settings (use --json for full settings)
+`,
+};
+
+function showResourceHelp(command) {
+  const help = RESOURCE_HELP[command];
+  if (help) {
+    console.log(help);
+    return;
+  }
+  showHelp();
+}
+
 function generateCompletionScript(shell) {
   const normalized = typeof shell === 'string' ? shell.trim().toLowerCase() : '';
 
@@ -569,7 +821,7 @@ _openchamber_tunnel() {
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-  commands="serve stop restart status tunnel logs update"
+  commands="serve stop restart status tunnel startup logs connect-url update session agent command skill mcp snippet provider project config"
   tunnel_commands="help providers ready doctor status start stop profile completion"
   profile_commands="list show add remove"
   common_flags="--port --foreground --no-daemon --json --all --help --version --plain --quiet"
@@ -624,6 +876,15 @@ _openchamber() {
     'tunnel:Tunnel lifecycle commands'
     'logs:Tail OpenChamber logs'
     'update:Check for and install updates'
+    'session:Manage sessions'
+    'agent:Manage agents'
+    'command:Manage slash commands'
+    'skill:Inspect skills'
+    'mcp:Manage MCP servers'
+    'snippet:Manage snippets'
+    'provider:Inspect providers and models'
+    'project:List projects'
+    'config:Show settings'
   )
 
   tunnel_commands=(
@@ -686,6 +947,15 @@ complete -c openchamber -n '__fish_use_subcommand' -a 'status' -d 'Show server s
 complete -c openchamber -n '__fish_use_subcommand' -a 'tunnel' -d 'Tunnel lifecycle commands'
 complete -c openchamber -n '__fish_use_subcommand' -a 'logs' -d 'Tail logs'
 complete -c openchamber -n '__fish_use_subcommand' -a 'update' -d 'Check for updates'
+complete -c openchamber -n '__fish_use_subcommand' -a 'session' -d 'Manage sessions'
+complete -c openchamber -n '__fish_use_subcommand' -a 'agent' -d 'Manage agents'
+complete -c openchamber -n '__fish_use_subcommand' -a 'command' -d 'Manage slash commands'
+complete -c openchamber -n '__fish_use_subcommand' -a 'skill' -d 'Inspect skills'
+complete -c openchamber -n '__fish_use_subcommand' -a 'mcp' -d 'Manage MCP servers'
+complete -c openchamber -n '__fish_use_subcommand' -a 'snippet' -d 'Manage snippets'
+complete -c openchamber -n '__fish_use_subcommand' -a 'provider' -d 'Inspect providers and models'
+complete -c openchamber -n '__fish_use_subcommand' -a 'project' -d 'List projects'
+complete -c openchamber -n '__fish_use_subcommand' -a 'config' -d 'Show settings'
 
 complete -c openchamber -n '__fish_seen_subcommand_from tunnel; and not __fish_seen_subcommand_from help providers ready doctor status start stop profile completion' -a 'help' -d 'Show tunnel help'
 complete -c openchamber -n '__fish_seen_subcommand_from tunnel; and not __fish_seen_subcommand_from help providers ready doctor status start stop profile completion' -a 'providers' -d 'Show providers'
@@ -721,6 +991,7 @@ export {
   showStartupHelp,
   showConnectUrlHelp,
   showTunnelHelp,
+  showResourceHelp,
   generateCompletionScript,
   findClosestMatch,
 };

--- a/packages/web/bin/lib/cli-format.js
+++ b/packages/web/bin/lib/cli-format.js
@@ -28,6 +28,53 @@ function formatRelativeTime(epochMs, now = Date.now()) {
   return `${years}y ago`;
 }
 
+const WEEKDAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+/**
+ * Format an epoch (ms) as `YYYY-MM-DD HH:mm` in the given IANA timezone (or
+ * local time when none is provided). Returns null for non-positive values.
+ */
+function formatInstant(epochMs, timezone) {
+  if (!Number.isFinite(epochMs) || epochMs <= 0) return null;
+  try {
+    const date = new Date(epochMs);
+    const zoneOpts = timezone ? { timeZone: timezone } : {};
+    const datePart = date.toLocaleDateString('en-CA', zoneOpts);
+    const timePart = date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false, ...zoneOpts });
+    return `${datePart} ${timePart}`;
+  } catch {
+    return new Date(epochMs).toISOString().slice(0, 16).replace('T', ' ');
+  }
+}
+
+/**
+ * Human-readable one-line summary of a scheduled task's schedule object.
+ */
+function formatSchedule(schedule) {
+  if (!schedule || typeof schedule !== 'object') return 'unknown schedule';
+  const tz = typeof schedule.timezone === 'string' && schedule.timezone.trim() ? ` (${schedule.timezone.trim()})` : '';
+  const times = Array.isArray(schedule.times) && schedule.times.length > 0
+    ? schedule.times.join(', ')
+    : (typeof schedule.time === 'string' ? schedule.time : '');
+
+  switch (schedule.kind) {
+    case 'daily':
+      return `daily at ${times || '??:??'}${tz}`;
+    case 'weekly': {
+      const days = Array.isArray(schedule.weekdays) && schedule.weekdays.length > 0
+        ? schedule.weekdays.slice().sort((a, b) => a - b).map((d) => WEEKDAY_NAMES[d] || d).join(', ')
+        : '??';
+      return `weekly on ${days} at ${times || '??:??'}${tz}`;
+    }
+    case 'once':
+      return `once on ${schedule.date || '????-??-??'} ${schedule.time || '??:??'}${tz}`;
+    case 'cron':
+      return `cron "${schedule.cron || ''}"${tz}`;
+    default:
+      return `${schedule.kind || 'unknown'}${tz}`;
+  }
+}
+
 function formatModel(model) {
   if (!model || typeof model !== 'object') return '';
   const provider = typeof model.providerID === 'string' ? model.providerID : '';
@@ -40,4 +87,6 @@ export {
   truncate,
   formatRelativeTime,
   formatModel,
+  formatInstant,
+  formatSchedule,
 };

--- a/packages/web/bin/lib/cli-format.js
+++ b/packages/web/bin/lib/cli-format.js
@@ -1,0 +1,43 @@
+/**
+ * Small presentation helpers shared by resource CLI commands. These are pure
+ * formatting utilities — they must not contain validation or policy.
+ */
+
+function truncate(value, max = 60) {
+  const str = typeof value === 'string' ? value : (value == null ? '' : String(value));
+  if (str.length <= max) return str;
+  if (max <= 1) return str.slice(0, max);
+  return `${str.slice(0, max - 1)}…`;
+}
+
+function formatRelativeTime(epochMs, now = Date.now()) {
+  if (!Number.isFinite(epochMs) || epochMs <= 0) return 'unknown';
+  const deltaMs = now - epochMs;
+  if (deltaMs < 0) return 'just now';
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+function formatModel(model) {
+  if (!model || typeof model !== 'object') return '';
+  const provider = typeof model.providerID === 'string' ? model.providerID : '';
+  const id = typeof model.id === 'string' ? model.id : (typeof model.modelID === 'string' ? model.modelID : '');
+  if (provider && id) return `${provider}/${id}`;
+  return id || provider || '';
+}
+
+export {
+  truncate,
+  formatRelativeTime,
+  formatModel,
+};

--- a/packages/web/bin/lib/cli-resource-commands.test.js
+++ b/packages/web/bin/lib/cli-resource-commands.test.js
@@ -67,11 +67,6 @@ describe('parseArgs resource flags', () => {
     expect(parsed.positionals).toEqual(['session', 'show', 'ses_abc']);
   });
 
-  it('parses prompt message via -m alias', () => {
-    const parsed = parseArgs(['session', 'prompt', 'ses_abc', '-m', 'hello there']);
-    expect(parsed.options.message).toBe('hello there');
-  });
-
   it('maps --yes to force', () => {
     const parsed = parseArgs(['session', 'delete', 'ses_abc', '--yes']);
     expect(parsed.options.force).toBe(true);

--- a/packages/web/bin/lib/cli-resource-commands.test.js
+++ b/packages/web/bin/lib/cli-resource-commands.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { parseArgs } from './cli-args.js';
-import { truncate, formatRelativeTime, formatModel } from './cli-format.js';
+import { truncate, formatRelativeTime, formatModel, formatSchedule, formatInstant } from './cli-format.js';
 import { resolveScopeDirectory } from './cli-api-client.js';
 
 describe('cli-format helpers', () => {
@@ -24,6 +24,24 @@ describe('cli-format helpers', () => {
     expect(formatModel({ providerID: 'google', modelID: 'gemini' })).toBe('google/gemini');
     expect(formatModel({ id: 'solo' })).toBe('solo');
     expect(formatModel(null)).toBe('');
+  });
+
+  it('formats schedule summaries for each kind', () => {
+    expect(formatSchedule({ kind: 'daily', times: ['09:00', '17:30'], timezone: 'UTC' }))
+      .toBe('daily at 09:00, 17:30 (UTC)');
+    expect(formatSchedule({ kind: 'weekly', times: ['08:00'], weekdays: [1, 3, 5], timezone: 'UTC' }))
+      .toBe('weekly on Mon, Wed, Fri at 08:00 (UTC)');
+    expect(formatSchedule({ kind: 'once', date: '2026-04-16', time: '13:30', timezone: 'UTC' }))
+      .toBe('once on 2026-04-16 13:30 (UTC)');
+    expect(formatSchedule({ kind: 'cron', cron: '0 2 * * *', timezone: 'UTC' }))
+      .toBe('cron "0 2 * * *" (UTC)');
+    expect(formatSchedule(null)).toBe('unknown schedule');
+  });
+
+  it('formats instants in a timezone and guards empty values', () => {
+    expect(formatInstant(Date.UTC(2026, 3, 16, 13, 30, 0), 'UTC')).toBe('2026-04-16 13:30');
+    expect(formatInstant(0, 'UTC')).toBeNull();
+    expect(formatInstant(undefined)).toBeNull();
   });
 });
 
@@ -63,6 +81,32 @@ describe('parseArgs resource flags', () => {
     const parsed = parseArgs(['mcp', 'create', 'fs', '--command', 'npx server']);
     expect(parsed.command).toBe('mcp');
     expect(parsed.options.commandStr).toBe('npx server');
+  });
+
+  it('parses schedule flags (project/kind/at/on/cron/timezone/disabled)', () => {
+    const parsed = parseArgs([
+      'schedule', 'create', 'Daily Standup',
+      '--project', '/home/me/app',
+      '--kind', 'weekly',
+      '--at', '09:00,17:30',
+      '--on', 'mon,wed',
+      '--timezone', 'UTC',
+      '--disabled',
+    ]);
+    expect(parsed.command).toBe('schedule');
+    expect(parsed.positionals).toEqual(['schedule', 'create', 'Daily Standup']);
+    expect(parsed.options.projectId).toBe('/home/me/app');
+    expect(parsed.options.kind).toBe('weekly');
+    expect(parsed.options.at).toBe('09:00,17:30');
+    expect(parsed.options.on).toBe('mon,wed');
+    expect(parsed.options.timezone).toBe('UTC');
+    expect(parsed.options.disabled).toBe(true);
+  });
+
+  it('parses --cron and --tz alias for schedule', () => {
+    const parsed = parseArgs(['schedule', 'create', 'nightly', '--cron', '0 2 * * *', '--tz', 'Europe/London']);
+    expect(parsed.options.cron).toBe('0 2 * * *');
+    expect(parsed.options.timezone).toBe('Europe/London');
   });
 
   it('parses scope, template, prompt, content, and description flags', () => {

--- a/packages/web/bin/lib/cli-resource-commands.test.js
+++ b/packages/web/bin/lib/cli-resource-commands.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgs } from './cli-args.js';
+import { truncate, formatRelativeTime, formatModel } from './cli-format.js';
+import { resolveScopeDirectory } from './cli-api-client.js';
+
+describe('cli-format helpers', () => {
+  it('truncates long strings with an ellipsis', () => {
+    expect(truncate('hello', 10)).toBe('hello');
+    expect(truncate('hello world', 5)).toBe('hell…');
+    expect(truncate(undefined, 5)).toBe('');
+  });
+
+  it('formats relative time buckets', () => {
+    const now = 1_000_000_000_000;
+    expect(formatRelativeTime(now, now)).toBe('0s ago');
+    expect(formatRelativeTime(now - 5_000, now)).toBe('5s ago');
+    expect(formatRelativeTime(now - 120_000, now)).toBe('2m ago');
+    expect(formatRelativeTime(now - 3 * 3_600_000, now)).toBe('3h ago');
+    expect(formatRelativeTime(0, now)).toBe('unknown');
+  });
+
+  it('formats provider/model identifiers', () => {
+    expect(formatModel({ providerID: 'google', id: 'gemini' })).toBe('google/gemini');
+    expect(formatModel({ providerID: 'google', modelID: 'gemini' })).toBe('google/gemini');
+    expect(formatModel({ id: 'solo' })).toBe('solo');
+    expect(formatModel(null)).toBe('');
+  });
+});
+
+describe('cli-api-client helpers', () => {
+  it('resolves an explicit directory over cwd', () => {
+    expect(resolveScopeDirectory({ directory: '/explicit' })).toBe('/explicit');
+    expect(resolveScopeDirectory({})).toBe(process.cwd());
+  });
+});
+
+describe('parseArgs resource flags', () => {
+  it('parses session list with directory and all flags into positionals', () => {
+    const parsed = parseArgs(['session', 'list', '--directory', '/repo', '--all', '--json']);
+    expect(parsed.command).toBe('session');
+    expect(parsed.positionals).toEqual(['session', 'list']);
+    expect(parsed.options.directory).toBe('/repo');
+    expect(parsed.options.all).toBe(true);
+    expect(parsed.options.json).toBe(true);
+  });
+
+  it('captures resource action and id positionals', () => {
+    const parsed = parseArgs(['session', 'show', 'ses_abc']);
+    expect(parsed.positionals).toEqual(['session', 'show', 'ses_abc']);
+  });
+
+  it('parses prompt message via -m alias', () => {
+    const parsed = parseArgs(['session', 'prompt', 'ses_abc', '-m', 'hello there']);
+    expect(parsed.options.message).toBe('hello there');
+  });
+
+  it('maps --yes to force', () => {
+    const parsed = parseArgs(['session', 'delete', 'ses_abc', '--yes']);
+    expect(parsed.options.force).toBe(true);
+  });
+
+  it('parses --command into commandStr (distinct from the command positional)', () => {
+    const parsed = parseArgs(['mcp', 'create', 'fs', '--command', 'npx server']);
+    expect(parsed.command).toBe('mcp');
+    expect(parsed.options.commandStr).toBe('npx server');
+  });
+
+  it('parses scope, template, prompt, content, and description flags', () => {
+    const parsed = parseArgs([
+      'agent', 'create', 'rev',
+      '--scope', 'user',
+      '--prompt', 'be careful',
+      '--description', 'reviewer',
+    ]);
+    expect(parsed.options.scope).toBe('user');
+    expect(parsed.options.prompt).toBe('be careful');
+    expect(parsed.options.description).toBe('reviewer');
+  });
+});

--- a/packages/web/bin/lib/commands-resources.js
+++ b/packages/web/bin/lib/commands-resources.js
@@ -1,0 +1,601 @@
+import {
+  intro as clackIntro,
+  outro as clackOutro,
+  cancel as clackCancel,
+  confirm as clackConfirm,
+  isCancel,
+  isJsonMode,
+  isQuietMode,
+  canPrompt,
+  printJson,
+  logStatus,
+} from '../cli-output.js';
+import { EXIT_CODE, TunnelCliError } from './cli-errors.js';
+import { apiRequest, resolveTargetPort, resolveScopeDirectory } from './cli-api-client.js';
+import { truncate } from './cli-format.js';
+
+function requireName(args, options, label) {
+  const name = (typeof args[0] === 'string' && args[0].trim()) || (typeof options.name === 'string' && options.name.trim());
+  if (name) return name;
+  throw new TunnelCliError(`A ${label} name is required.`, EXIT_CODE.USAGE_ERROR);
+}
+
+function resolveScope(options, fallback) {
+  const raw = typeof options.scope === 'string' ? options.scope.trim().toLowerCase() : '';
+  if (!raw) return fallback;
+  if (!['global', 'user', 'project'].includes(raw)) {
+    throw new TunnelCliError(`Invalid --scope "${raw}". Use one of: global, user, project.`, EXIT_CODE.USAGE_ERROR);
+  }
+  return raw;
+}
+
+async function confirmDestructive(options, message) {
+  if (options.force) return;
+  if (canPrompt(options)) {
+    const confirmed = await clackConfirm({ message });
+    if (isCancel(confirmed) || confirmed !== true) {
+      clackCancel('Operation cancelled.');
+      throw new TunnelCliError('Cancelled.', 130);
+    }
+    return;
+  }
+  throw new TunnelCliError('Refusing to delete without confirmation. Re-run with --force (or --yes) to proceed.', EXIT_CODE.USAGE_ERROR);
+}
+
+/**
+ * Render a list of resources consistently across all output modes.
+ *
+ * @param {object} params
+ * @param {object} params.options CLI options
+ * @param {string} params.title Human intro title
+ * @param {Array} params.items Resource items
+ * @param {string} params.jsonKey Key used in JSON output
+ * @param {(item:any)=>string} params.quietLine Compact quiet-mode line
+ * @param {(item:any)=>{message:string,detail?:string}} params.humanLine Human log content
+ * @param {string} params.emptyMessage Message when no items
+ */
+function renderList({ options, title, items, jsonKey, quietLine, humanLine, emptyMessage }) {
+  const list = Array.isArray(items) ? items : [];
+  if (isJsonMode(options)) {
+    printJson({ count: list.length, [jsonKey]: list });
+    return;
+  }
+  if (isQuietMode(options)) {
+    for (const item of list) {
+      process.stdout.write(`${quietLine(item)}\n`);
+    }
+    return;
+  }
+  clackIntro(title);
+  if (list.length === 0) {
+    logStatus('warning', emptyMessage);
+    clackOutro('0 items');
+    return;
+  }
+  for (const item of list) {
+    const { message, detail } = humanLine(item);
+    logStatus('info', message, detail);
+  }
+  clackOutro(`${list.length} item(s)`);
+}
+
+function renderMutation({ options, title, message, detail, payload }) {
+  if (isJsonMode(options)) {
+    printJson(payload);
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${message}\n`);
+    return;
+  }
+  clackIntro(title);
+  logStatus('success', message, detail);
+  clackOutro('done');
+}
+
+// ── agents ──────────────────────────────────────────────────────
+
+async function agentCommand(options, action = 'list', args = []) {
+  const valid = ['list', 'show', 'create', 'delete'];
+  if (!valid.includes(action)) {
+    throw new TunnelCliError(`Unknown agent action '${action}'. Valid: ${valid.join(', ')}.`, EXIT_CODE.USAGE_ERROR);
+  }
+  const port = await resolveTargetPort(options);
+  const directory = resolveScopeDirectory(options);
+
+  if (action === 'list') {
+    const agents = await apiRequest(port, 'GET', '/api/agent', { query: { directory }, options });
+    const list = (Array.isArray(agents) ? agents : []).slice().sort((a, b) => String(a.name).localeCompare(String(b.name)));
+    return renderList({
+      options,
+      title: 'Agents',
+      items: list,
+      jsonKey: 'agents',
+      quietLine: (a) => `${a.name} ${a.mode || 'agent'}${a.native ? ' built-in' : ''}`,
+      humanLine: (a) => ({
+        message: a.name,
+        detail: [a.mode || 'agent', a.native ? 'built-in' : null, truncate(a.description, 70)].filter(Boolean).join(' · '),
+      }),
+      emptyMessage: 'No agents found',
+    });
+  }
+
+  if (action === 'show') {
+    const name = requireName(args, options, 'agent');
+    const info = await apiRequest(port, 'GET', `/api/config/agents/${encodeURIComponent(name)}`, { query: { directory }, options });
+    if (isJsonMode(options)) {
+      printJson({ agent: info });
+      return undefined;
+    }
+    if (isQuietMode(options)) {
+      process.stdout.write(`${info.name} ${info.scope || 'builtin'}${info.isBuiltIn ? ' built-in' : ''}\n`);
+      return undefined;
+    }
+    clackIntro('Agent Details');
+    const lines = [`scope: ${info.scope || 'n/a'}`, `built-in: ${info.isBuiltIn ? 'yes' : 'no'}`];
+    if (info.sources?.md?.path) lines.push(`markdown: ${info.sources.md.path}`);
+    if (info.sources?.json?.path) lines.push(`json: ${info.sources.json.path}`);
+    logStatus('info', info.name, lines.join('\n'));
+    clackOutro('done');
+    return undefined;
+  }
+
+  if (action === 'create') {
+    const name = requireName(args, options, 'agent');
+    const prompt = (typeof options.prompt === 'string' && options.prompt) || args.slice(1).join(' ').trim();
+    if (!prompt) {
+      throw new TunnelCliError('An agent prompt is required. Provide --prompt <text> or pass it after the name.', EXIT_CODE.USAGE_ERROR);
+    }
+    const scope = resolveScope(options, 'user');
+    const body = { prompt, scope };
+    if (typeof options.description === 'string' && options.description.trim()) body.description = options.description.trim();
+    if (typeof options.mode === 'string' && options.mode.trim()) body.mode = options.mode.trim();
+    if (typeof options.model === 'string' && options.model.trim()) body.model = options.model.trim();
+    const result = await apiRequest(port, 'POST', `/api/config/agents/${encodeURIComponent(name)}`, { query: { directory }, body, options });
+    return renderMutation({
+      options,
+      title: 'Create Agent',
+      message: `Created agent ${name}`,
+      detail: result?.message,
+      payload: { created: true, name, scope, result },
+    });
+  }
+
+  // delete
+  const name = requireName(args, options, 'agent');
+  await confirmDestructive(options, `Delete agent ${name}?`);
+  const scope = resolveScope(options, undefined);
+  const result = await apiRequest(port, 'DELETE', `/api/config/agents/${encodeURIComponent(name)}`, {
+    query: { directory },
+    body: scope ? { scope } : undefined,
+    options,
+  });
+  return renderMutation({
+    options,
+    title: 'Delete Agent',
+    message: `Deleted agent ${name}`,
+    detail: result?.message,
+    payload: { deleted: true, name, result },
+  });
+}
+
+// ── commands (slash commands) ───────────────────────────────────
+
+async function commandResourceCommand(options, action = 'list', args = []) {
+  const valid = ['list', 'show', 'create', 'delete'];
+  if (!valid.includes(action)) {
+    throw new TunnelCliError(`Unknown command action '${action}'. Valid: ${valid.join(', ')}.`, EXIT_CODE.USAGE_ERROR);
+  }
+  const port = await resolveTargetPort(options);
+  const directory = resolveScopeDirectory(options);
+
+  if (action === 'list' || action === 'show') {
+    const commands = await apiRequest(port, 'GET', '/api/command', { query: { directory }, options });
+    const list = Array.isArray(commands) ? commands : [];
+    if (action === 'show') {
+      const name = requireName(args, options, 'command');
+      const found = list.find((cmd) => cmd.name === name);
+      if (!found) {
+        throw new TunnelCliError(`Command "${name}" not found.`, EXIT_CODE.GENERAL_ERROR);
+      }
+      if (isJsonMode(options)) {
+        printJson({ command: found });
+        return undefined;
+      }
+      if (isQuietMode(options)) {
+        process.stdout.write(`${found.name} ${found.source || ''}\n`);
+        return undefined;
+      }
+      clackIntro('Command Details');
+      const lines = [];
+      if (found.description) lines.push(`description: ${found.description}`);
+      if (found.agent) lines.push(`agent: ${found.agent}`);
+      if (found.model) lines.push(`model: ${found.model}`);
+      if (found.source) lines.push(`source: ${found.source}`);
+      if (found.template) lines.push(`template:\n${found.template}`);
+      logStatus('info', `/${found.name}`, lines.join('\n'));
+      clackOutro('done');
+      return undefined;
+    }
+    const sorted = list.slice().sort((a, b) => String(a.name).localeCompare(String(b.name)));
+    return renderList({
+      options,
+      title: 'Commands',
+      items: sorted,
+      jsonKey: 'commands',
+      quietLine: (c) => `${c.name} ${c.source || ''}`.trim(),
+      humanLine: (c) => ({
+        message: `/${c.name}`,
+        detail: [c.source, truncate(c.description, 70)].filter(Boolean).join(' · '),
+      }),
+      emptyMessage: 'No commands found',
+    });
+  }
+
+  if (action === 'create') {
+    const name = requireName(args, options, 'command');
+    const template = (typeof options.template === 'string' && options.template) || args.slice(1).join(' ').trim();
+    if (!template) {
+      throw new TunnelCliError('A command template is required. Provide --template <text> or pass it after the name.', EXIT_CODE.USAGE_ERROR);
+    }
+    const scope = resolveScope(options, 'user');
+    const body = { template, scope };
+    if (typeof options.description === 'string' && options.description.trim()) body.description = options.description.trim();
+    if (typeof options.agent === 'string' && options.agent.trim()) body.agent = options.agent.trim();
+    if (typeof options.model === 'string' && options.model.trim()) body.model = options.model.trim();
+    const result = await apiRequest(port, 'POST', `/api/config/commands/${encodeURIComponent(name)}`, { query: { directory }, body, options });
+    return renderMutation({
+      options,
+      title: 'Create Command',
+      message: `Created command /${name}`,
+      detail: result?.message,
+      payload: { created: true, name, scope, result },
+    });
+  }
+
+  const name = requireName(args, options, 'command');
+  await confirmDestructive(options, `Delete command /${name}?`);
+  const result = await apiRequest(port, 'DELETE', `/api/config/commands/${encodeURIComponent(name)}`, { query: { directory }, options });
+  return renderMutation({
+    options,
+    title: 'Delete Command',
+    message: `Deleted command /${name}`,
+    detail: result?.message,
+    payload: { deleted: true, name, result },
+  });
+}
+
+// ── skills ──────────────────────────────────────────────────────
+
+async function skillCommand(options, action = 'list', args = []) {
+  const valid = ['list', 'show'];
+  if (!valid.includes(action)) {
+    throw new TunnelCliError(`Unknown skill action '${action}'. Valid: ${valid.join(', ')}.`, EXIT_CODE.USAGE_ERROR);
+  }
+  const port = await resolveTargetPort(options);
+  const directory = resolveScopeDirectory(options);
+  const skills = await apiRequest(port, 'GET', '/api/skill', { query: { directory }, options });
+  const list = Array.isArray(skills) ? skills : [];
+
+  if (action === 'show') {
+    const name = requireName(args, options, 'skill');
+    const found = list.find((skill) => skill.name === name);
+    if (!found) {
+      throw new TunnelCliError(`Skill "${name}" not found.`, EXIT_CODE.GENERAL_ERROR);
+    }
+    if (isJsonMode(options)) {
+      printJson({ skill: found });
+      return undefined;
+    }
+    if (isQuietMode(options)) {
+      process.stdout.write(`${found.name} ${found.location || ''}\n`);
+      return undefined;
+    }
+    clackIntro('Skill Details');
+    const lines = [];
+    if (found.description) lines.push(`description: ${found.description}`);
+    if (found.location) lines.push(`location: ${found.location}`);
+    logStatus('info', found.name, lines.join('\n'));
+    clackOutro('done');
+    return undefined;
+  }
+
+  const sorted = list.slice().sort((a, b) => String(a.name).localeCompare(String(b.name)));
+  return renderList({
+    options,
+    title: 'Skills',
+    items: sorted,
+    jsonKey: 'skills',
+    quietLine: (s) => `${s.name}`,
+    humanLine: (s) => ({ message: s.name, detail: truncate(s.description, 80) }),
+    emptyMessage: 'No skills found',
+  });
+}
+
+// ── MCP servers ─────────────────────────────────────────────────
+
+function describeMcp(entry) {
+  if (entry?.type === 'remote') return entry.url || 'remote';
+  if (Array.isArray(entry?.command)) return entry.command.join(' ');
+  return entry?.type || 'local';
+}
+
+async function mcpCommand(options, action = 'list', args = []) {
+  const valid = ['list', 'show', 'create', 'delete'];
+  if (!valid.includes(action)) {
+    throw new TunnelCliError(`Unknown mcp action '${action}'. Valid: ${valid.join(', ')}.`, EXIT_CODE.USAGE_ERROR);
+  }
+  const port = await resolveTargetPort(options);
+  const directory = resolveScopeDirectory(options);
+
+  if (action === 'list') {
+    const servers = await apiRequest(port, 'GET', '/api/config/mcp', { query: { directory }, options });
+    const list = Array.isArray(servers) ? servers : [];
+    return renderList({
+      options,
+      title: 'MCP Servers',
+      items: list,
+      jsonKey: 'mcpServers',
+      quietLine: (s) => `${s.name} ${s.type || 'local'} ${s.enabled === false ? 'disabled' : 'enabled'}`,
+      humanLine: (s) => ({
+        message: s.name,
+        detail: [s.type || 'local', s.enabled === false ? 'disabled' : 'enabled', s.scope || null, truncate(describeMcp(s), 60)].filter(Boolean).join(' · '),
+      }),
+      emptyMessage: 'No MCP servers configured',
+    });
+  }
+
+  if (action === 'show') {
+    const name = requireName(args, options, 'mcp');
+    const server = await apiRequest(port, 'GET', `/api/config/mcp/${encodeURIComponent(name)}`, { query: { directory }, options });
+    if (isJsonMode(options)) {
+      printJson({ mcpServer: server });
+      return undefined;
+    }
+    if (isQuietMode(options)) {
+      process.stdout.write(`${server.name} ${server.type || 'local'} ${server.enabled === false ? 'disabled' : 'enabled'}\n`);
+      return undefined;
+    }
+    clackIntro('MCP Server Details');
+    const lines = [`type: ${server.type || 'local'}`, `enabled: ${server.enabled === false ? 'no' : 'yes'}`];
+    if (server.scope) lines.push(`scope: ${server.scope}`);
+    if (server.url) lines.push(`url: ${server.url}`);
+    if (Array.isArray(server.command)) lines.push(`command: ${server.command.join(' ')}`);
+    logStatus('info', server.name, lines.join('\n'));
+    clackOutro('done');
+    return undefined;
+  }
+
+  if (action === 'create') {
+    const name = requireName(args, options, 'mcp');
+    const scope = resolveScope(options, 'user');
+    const url = typeof options.url === 'string' && options.url.trim() ? options.url.trim() : '';
+    const commandStr = typeof options.commandStr === 'string' && options.commandStr.trim() ? options.commandStr.trim() : '';
+    const body = { scope, enabled: true };
+    if (url) {
+      body.type = 'remote';
+      body.url = url;
+    } else if (commandStr) {
+      body.type = 'local';
+      body.command = commandStr.split(/\s+/).filter(Boolean);
+    } else {
+      throw new TunnelCliError('Provide --url <url> for a remote server, or --command "<cmd args>" for a local server.', EXIT_CODE.USAGE_ERROR);
+    }
+    const result = await apiRequest(port, 'POST', `/api/config/mcp/${encodeURIComponent(name)}`, { query: { directory }, body, options });
+    return renderMutation({
+      options,
+      title: 'Create MCP Server',
+      message: `Created MCP server ${name}`,
+      detail: result?.message,
+      payload: { created: true, name, scope, type: body.type, result },
+    });
+  }
+
+  const name = requireName(args, options, 'mcp');
+  await confirmDestructive(options, `Delete MCP server ${name}?`);
+  const result = await apiRequest(port, 'DELETE', `/api/config/mcp/${encodeURIComponent(name)}`, { query: { directory }, options });
+  return renderMutation({
+    options,
+    title: 'Delete MCP Server',
+    message: `Deleted MCP server ${name}`,
+    detail: result?.message,
+    payload: { deleted: true, name, result },
+  });
+}
+
+// ── snippets ────────────────────────────────────────────────────
+
+async function snippetCommand(options, action = 'list', args = []) {
+  const valid = ['list', 'show', 'create', 'delete'];
+  if (!valid.includes(action)) {
+    throw new TunnelCliError(`Unknown snippet action '${action}'. Valid: ${valid.join(', ')}.`, EXIT_CODE.USAGE_ERROR);
+  }
+  const port = await resolveTargetPort(options);
+  const directory = resolveScopeDirectory(options);
+
+  if (action === 'list') {
+    const snippets = await apiRequest(port, 'GET', '/api/config/snippets', { query: { directory }, options });
+    const list = Array.isArray(snippets) ? snippets : [];
+    return renderList({
+      options,
+      title: 'Snippets',
+      items: list,
+      jsonKey: 'snippets',
+      quietLine: (s) => `${s.name} ${s.source || ''}`.trim(),
+      humanLine: (s) => ({
+        message: `#${s.name}`,
+        detail: [s.source, truncate(s.description || s.content, 70)].filter(Boolean).join(' · '),
+      }),
+      emptyMessage: 'No snippets found',
+    });
+  }
+
+  if (action === 'show') {
+    const name = requireName(args, options, 'snippet');
+    const snippet = await apiRequest(port, 'GET', `/api/config/snippets/${encodeURIComponent(name)}`, { query: { directory }, options });
+    if (isJsonMode(options)) {
+      printJson({ snippet });
+      return undefined;
+    }
+    if (isQuietMode(options)) {
+      process.stdout.write(`${snippet.name}\n`);
+      return undefined;
+    }
+    clackIntro('Snippet Details');
+    const lines = [];
+    if (snippet.description) lines.push(`description: ${snippet.description}`);
+    if (Array.isArray(snippet.aliases) && snippet.aliases.length) lines.push(`aliases: ${snippet.aliases.join(', ')}`);
+    if (snippet.source) lines.push(`source: ${snippet.source}`);
+    if (snippet.content) lines.push(`content:\n${snippet.content}`);
+    logStatus('info', `#${snippet.name}`, lines.join('\n'));
+    clackOutro('done');
+    return undefined;
+  }
+
+  if (action === 'create') {
+    const name = requireName(args, options, 'snippet');
+    const content = (typeof options.content === 'string' && options.content) || args.slice(1).join(' ').trim();
+    if (!content) {
+      throw new TunnelCliError('Snippet content is required. Provide --content <text> or pass it after the name.', EXIT_CODE.USAGE_ERROR);
+    }
+    const scope = resolveScope(options, 'global');
+    const body = { content, scope };
+    if (typeof options.description === 'string' && options.description.trim()) body.description = options.description.trim();
+    const result = await apiRequest(port, 'POST', `/api/config/snippets/${encodeURIComponent(name)}`, { query: { directory }, body, options });
+    return renderMutation({
+      options,
+      title: 'Create Snippet',
+      message: `Created snippet #${name}`,
+      detail: undefined,
+      payload: { created: true, name, scope, snippet: result?.snippet },
+    });
+  }
+
+  const name = requireName(args, options, 'snippet');
+  await confirmDestructive(options, `Delete snippet #${name}?`);
+  await apiRequest(port, 'DELETE', `/api/config/snippets/${encodeURIComponent(name)}`, { query: { directory }, options });
+  return renderMutation({
+    options,
+    title: 'Delete Snippet',
+    message: `Deleted snippet #${name}`,
+    detail: undefined,
+    payload: { deleted: true, name },
+  });
+}
+
+// ── providers / models ──────────────────────────────────────────
+
+async function providerCommand(options, action = 'list', args = []) {
+  const valid = ['list', 'models'];
+  if (!valid.includes(action)) {
+    throw new TunnelCliError(`Unknown provider action '${action}'. Valid: ${valid.join(', ')}.`, EXIT_CODE.USAGE_ERROR);
+  }
+  const port = await resolveTargetPort(options);
+  const directory = resolveScopeDirectory(options);
+  const config = await apiRequest(port, 'GET', '/api/config/providers', { query: { directory }, options });
+  const providers = Array.isArray(config?.providers) ? config.providers : [];
+
+  if (action === 'models') {
+    const providerId = (typeof args[0] === 'string' && args[0].trim()) || (typeof options.provider === 'string' && options.provider.trim());
+    const models = [];
+    for (const provider of providers) {
+      if (providerId && provider.id !== providerId) continue;
+      const entries = provider?.models && typeof provider.models === 'object' ? Object.values(provider.models) : [];
+      for (const model of entries) {
+        models.push({ providerID: provider.id, id: model.id, name: model.name || model.id });
+      }
+    }
+    return renderList({
+      options,
+      title: providerId ? `Models · ${providerId}` : 'Models',
+      items: models,
+      jsonKey: 'models',
+      quietLine: (m) => `${m.providerID}/${m.id}`,
+      humanLine: (m) => ({ message: `${m.providerID}/${m.id}`, detail: m.name }),
+      emptyMessage: providerId ? `No models for provider "${providerId}"` : 'No models found',
+    });
+  }
+
+  const list = providers.slice().sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  return renderList({
+    options,
+    title: 'Providers',
+    items: list,
+    jsonKey: 'providers',
+    quietLine: (p) => `${p.id} models:${p.models ? Object.keys(p.models).length : 0}`,
+    humanLine: (p) => ({
+      message: p.id,
+      detail: [p.name, p.source ? `source: ${p.source}` : null, `${p.models ? Object.keys(p.models).length : 0} models`].filter(Boolean).join(' · '),
+    }),
+    emptyMessage: 'No providers configured',
+  });
+}
+
+// ── projects ────────────────────────────────────────────────────
+
+async function projectCommand(options, action = 'list') {
+  const valid = ['list'];
+  if (!valid.includes(action)) {
+    throw new TunnelCliError(`Unknown project action '${action}'. Valid: ${valid.join(', ')}.`, EXIT_CODE.USAGE_ERROR);
+  }
+  const port = await resolveTargetPort(options);
+  const settings = await apiRequest(port, 'GET', '/api/config/settings', { options });
+  const projects = Array.isArray(settings?.projects) ? settings.projects : [];
+  const activeId = settings?.activeProjectId;
+  return renderList({
+    options,
+    title: 'Projects',
+    items: projects,
+    jsonKey: 'projects',
+    quietLine: (p) => `${p.path}${p.id === activeId ? ' active' : ''}`,
+    humanLine: (p) => ({
+      message: p.path,
+      detail: [p.id === activeId ? 'active' : null, p.id].filter(Boolean).join(' · '),
+    }),
+    emptyMessage: 'No projects added',
+  });
+}
+
+// ── config / settings ───────────────────────────────────────────
+
+async function configCommand(options, action = 'get') {
+  const valid = ['get'];
+  if (!valid.includes(action)) {
+    throw new TunnelCliError(`Unknown config action '${action}'. Valid: ${valid.join(', ')}.`, EXIT_CODE.USAGE_ERROR);
+  }
+  const port = await resolveTargetPort(options);
+  const settings = await apiRequest(port, 'GET', '/api/config/settings', { options });
+
+  if (isJsonMode(options)) {
+    printJson({ settings });
+    return undefined;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`theme ${settings?.themeId || 'n/a'}\n`);
+    process.stdout.write(`lastDirectory ${settings?.lastDirectory || 'n/a'}\n`);
+    process.stdout.write(`projects ${Array.isArray(settings?.projects) ? settings.projects.length : 0}\n`);
+    return undefined;
+  }
+  clackIntro('OpenChamber Settings');
+  const lines = [
+    `theme: ${settings?.themeId || 'n/a'}${settings?.themeVariant ? ` (${settings.themeVariant})` : ''}`,
+    `use system theme: ${settings?.useSystemTheme ? 'yes' : 'no'}`,
+    `last directory: ${settings?.lastDirectory || 'n/a'}`,
+    `home directory: ${settings?.homeDirectory || 'n/a'}`,
+    `projects: ${Array.isArray(settings?.projects) ? settings.projects.length : 0}`,
+  ];
+  logStatus('info', 'settings', lines.join('\n'));
+  clackOutro('done');
+  return undefined;
+}
+
+export {
+  agentCommand,
+  commandResourceCommand,
+  skillCommand,
+  mcpCommand,
+  snippetCommand,
+  providerCommand,
+  projectCommand,
+  configCommand,
+};

--- a/packages/web/bin/lib/commands-schedule.js
+++ b/packages/web/bin/lib/commands-schedule.js
@@ -1,0 +1,446 @@
+import {
+  intro as clackIntro,
+  outro as clackOutro,
+  cancel as clackCancel,
+  confirm as clackConfirm,
+  isCancel,
+  isJsonMode,
+  isQuietMode,
+  canPrompt,
+  createSpinner,
+  printJson,
+  logStatus,
+} from '../cli-output.js';
+import { EXIT_CODE, TunnelCliError } from './cli-errors.js';
+import {
+  apiRequest,
+  resolveTargetPort,
+  resolveProjectId,
+  resolveModel,
+} from './cli-api-client.js';
+import { truncate, formatSchedule, formatInstant, formatRelativeTime } from './cli-format.js';
+
+const SCHEDULE_ACTIONS = ['list', 'show', 'create', 'run', 'enable', 'disable', 'delete', 'status'];
+
+const WEEKDAY_LOOKUP = {
+  sun: 0, sunday: 0,
+  mon: 1, monday: 1,
+  tue: 2, tues: 2, tuesday: 2,
+  wed: 3, weds: 3, wednesday: 3,
+  thu: 4, thur: 4, thurs: 4, thursday: 4,
+  fri: 5, friday: 5,
+  sat: 6, saturday: 6,
+};
+
+const TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+function usage(message) {
+  return new TunnelCliError(message, EXIT_CODE.USAGE_ERROR);
+}
+
+function requireTaskRef(args, options) {
+  const ref = (typeof args[0] === 'string' && args[0].trim()) || (typeof options.name === 'string' && options.name.trim());
+  if (ref) return ref;
+  throw usage('A task id or name is required. Usage: openchamber schedule <action> <task-id|name>');
+}
+
+function findTask(tasks, ref) {
+  if (!Array.isArray(tasks)) return null;
+  return tasks.find((task) => task.id === ref)
+    || tasks.find((task) => typeof task.name === 'string' && task.name.toLowerCase() === ref.toLowerCase())
+    || null;
+}
+
+function parseTimes(value) {
+  const raw = typeof value === 'string' ? value : '';
+  const parts = raw.split(',').map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0) {
+    throw usage('At least one time is required. Provide --at "HH:mm" (comma-separated for multiple).');
+  }
+  for (const part of parts) {
+    if (!TIME_PATTERN.test(part)) {
+      throw usage(`Invalid time "${part}". Use 24h HH:mm (e.g. 09:00, 17:30).`);
+    }
+  }
+  return Array.from(new Set(parts)).sort((a, b) => a.localeCompare(b));
+}
+
+function parseWeekdays(value) {
+  const raw = typeof value === 'string' ? value : '';
+  const parts = raw.split(',').map((part) => part.trim().toLowerCase()).filter(Boolean);
+  if (parts.length === 0) {
+    throw usage('At least one weekday is required for a weekly schedule. Provide --on "mon,wed,fri" or 0..6.');
+  }
+  const days = new Set();
+  for (const part of parts) {
+    if (/^[0-6]$/.test(part)) {
+      days.add(Number(part));
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(WEEKDAY_LOOKUP, part)) {
+      days.add(WEEKDAY_LOOKUP[part]);
+      continue;
+    }
+    throw usage(`Invalid weekday "${part}". Use mon..sun or 0..6 (0 = Sunday).`);
+  }
+  return Array.from(days).sort((a, b) => a - b);
+}
+
+function inferKind(options) {
+  const explicit = typeof options.kind === 'string' ? options.kind.trim().toLowerCase() : '';
+  if (explicit) return explicit;
+  if (options.cron) return 'cron';
+  if (options.date || options.time) return 'once';
+  if (options.on) return 'weekly';
+  if (options.at) return 'daily';
+  return '';
+}
+
+function buildScheduleFromOptions(options) {
+  const kind = inferKind(options);
+  if (!kind) {
+    throw usage('Specify a schedule: --kind daily|weekly|once|cron (or use --at / --on / --cron / --date+--time).');
+  }
+  const timezone = typeof options.timezone === 'string' && options.timezone.trim() ? options.timezone.trim() : undefined;
+  const tz = timezone ? { timezone } : {};
+
+  if (kind === 'daily') {
+    return { kind, times: parseTimes(options.at), ...tz };
+  }
+  if (kind === 'weekly') {
+    return { kind, times: parseTimes(options.at), weekdays: parseWeekdays(options.on), ...tz };
+  }
+  if (kind === 'once') {
+    const date = typeof options.date === 'string' ? options.date.trim() : '';
+    const time = typeof options.time === 'string' ? options.time.trim() : '';
+    if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw usage('A one-time schedule needs --date YYYY-MM-DD.');
+    }
+    if (!TIME_PATTERN.test(time)) {
+      throw usage('A one-time schedule needs --time HH:mm.');
+    }
+    return { kind, date, time, ...tz };
+  }
+  if (kind === 'cron') {
+    const cron = typeof options.cron === 'string' ? options.cron.trim() : '';
+    if (!cron) {
+      throw usage('A cron schedule needs --cron "<expression>".');
+    }
+    return { kind, cron, ...tz };
+  }
+  throw usage(`Invalid --kind "${kind}". Use daily, weekly, once, or cron.`);
+}
+
+async function confirmDestructive(options, message) {
+  if (options.force) return;
+  if (canPrompt(options)) {
+    const confirmed = await clackConfirm({ message });
+    if (isCancel(confirmed) || confirmed !== true) {
+      clackCancel('Operation cancelled.');
+      throw new TunnelCliError('Cancelled.', 130);
+    }
+    return;
+  }
+  throw usage('Refusing to delete without confirmation. Re-run with --force (or --yes) to proceed.');
+}
+
+function serializeTask(task) {
+  return {
+    id: task.id,
+    name: task.name,
+    enabled: Boolean(task.enabled),
+    schedule: task.schedule,
+    execution: task.execution,
+    state: task.state,
+  };
+}
+
+function taskStatusLevel(task) {
+  if (!task.enabled) return 'warning';
+  const status = task?.state?.lastStatus;
+  if (status === 'error') return 'error';
+  if (status === 'success') return 'success';
+  return 'info';
+}
+
+function taskDetailLine(task) {
+  const parts = [task.enabled ? 'enabled' : 'disabled', formatSchedule(task.schedule)];
+  const next = formatInstant(task?.state?.nextRunAt, task?.schedule?.timezone);
+  if (task.enabled && next) parts.push(`next ${next}`);
+  const status = task?.state?.lastStatus;
+  if (status && status !== 'idle') {
+    const when = formatRelativeTime(task?.state?.lastRunAt);
+    parts.push(`last ${status}${when !== 'unknown' ? ` ${when}` : ''}`);
+  }
+  return parts.join(' · ');
+}
+
+async function handleStatus(port, options) {
+  const status = await apiRequest(port, 'GET', '/api/openchamber/scheduled-tasks/status', { options });
+  if (isJsonMode(options)) {
+    printJson({ scheduledTasks: status });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`enabled ${status?.enabledScheduledTasksCount ?? 0} running ${status?.runningScheduledTasksCount ?? 0}\n`);
+    return;
+  }
+  clackIntro('Scheduled Tasks Status');
+  logStatus('info', 'summary', [
+    `enabled: ${status?.enabledScheduledTasksCount ?? 0}`,
+    `running: ${status?.runningScheduledTasksCount ?? 0}`,
+  ].join('\n'));
+  clackOutro('done');
+}
+
+async function loadTasks(port, projectId, options) {
+  const payload = await apiRequest(port, 'GET', `/api/projects/${encodeURIComponent(projectId)}/scheduled-tasks`, { options });
+  return Array.isArray(payload?.tasks) ? payload.tasks : [];
+}
+
+async function handleList(port, projectId, options) {
+  const tasks = await loadTasks(port, projectId, options);
+  tasks.sort((a, b) => Number(b.enabled) - Number(a.enabled) || String(a.name).localeCompare(String(b.name)));
+
+  if (isJsonMode(options)) {
+    printJson({ projectId, count: tasks.length, tasks: tasks.map(serializeTask) });
+    return;
+  }
+  if (isQuietMode(options)) {
+    for (const task of tasks) {
+      process.stdout.write(`${task.id} ${task.enabled ? 'enabled' : 'disabled'} ${task?.state?.lastStatus || 'idle'} ${task.name}\n`);
+    }
+    return;
+  }
+  clackIntro('Scheduled Tasks');
+  if (tasks.length === 0) {
+    logStatus('warning', 'No scheduled tasks', `project: ${projectId}`);
+    clackOutro('0 tasks');
+    return;
+  }
+  for (const task of tasks) {
+    logStatus(taskStatusLevel(task), `${truncate(task.name, 56)}  ${task.id}`, taskDetailLine(task));
+  }
+  clackOutro(`${tasks.length} task(s) · ${projectId}`);
+}
+
+async function handleShow(port, projectId, options, args) {
+  const ref = requireTaskRef(args, options);
+  const tasks = await loadTasks(port, projectId, options);
+  const task = findTask(tasks, ref);
+  if (!task) {
+    throw new TunnelCliError(`Scheduled task "${ref}" not found.`, EXIT_CODE.GENERAL_ERROR);
+  }
+
+  if (isJsonMode(options)) {
+    printJson({ task: serializeTask(task) });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${task.id} ${task.enabled ? 'enabled' : 'disabled'} ${task?.state?.lastStatus || 'idle'} ${task.name}\n`);
+    return;
+  }
+  clackIntro('Scheduled Task');
+  const lines = [
+    `id: ${task.id}`,
+    `enabled: ${task.enabled ? 'yes' : 'no'}`,
+    `schedule: ${formatSchedule(task.schedule)}`,
+    `model: ${task.execution?.providerID}/${task.execution?.modelID}`,
+  ];
+  if (task.execution?.agent) lines.push(`agent: ${task.execution.agent}`);
+  if (task.execution?.variant) lines.push(`variant: ${task.execution.variant}`);
+  const next = formatInstant(task?.state?.nextRunAt, task?.schedule?.timezone);
+  if (next) lines.push(`next run: ${next}`);
+  if (task?.state?.lastStatus && task.state.lastStatus !== 'idle') {
+    lines.push(`last run: ${task.state.lastStatus} (${formatRelativeTime(task.state.lastRunAt)})`);
+  }
+  if (task?.state?.lastError) lines.push(`last error: ${task.state.lastError}`);
+  if (task?.state?.lastSessionId) lines.push(`last session: ${task.state.lastSessionId}`);
+  if (task.execution?.prompt) lines.push(`prompt:\n${task.execution.prompt}`);
+  logStatus('info', task.name, lines.join('\n'));
+  clackOutro('done');
+}
+
+async function handleCreate(port, projectId, options, args) {
+  const name = (typeof args[0] === 'string' && args[0].trim()) || (typeof options.name === 'string' && options.name.trim());
+  if (!name) {
+    throw usage('A task name is required. Usage: openchamber schedule create <name> --prompt <text> --kind <daily|weekly|once|cron> ...');
+  }
+  const prompt = typeof options.prompt === 'string' ? options.prompt.trim() : '';
+  if (!prompt) {
+    throw usage('A prompt is required. Provide --prompt <text> (use "/command args" to run a slash command).');
+  }
+
+  const schedule = buildScheduleFromOptions(options);
+  const model = await resolveModel(port, options);
+
+  const execution = {
+    prompt,
+    providerID: model.providerID,
+    modelID: model.modelID,
+  };
+  if (typeof options.agent === 'string' && options.agent.trim()) execution.agent = options.agent.trim();
+  if (typeof options.variant === 'string' && options.variant.trim()) execution.variant = options.variant.trim();
+
+  const task = {
+    name,
+    enabled: !options.disabled,
+    schedule,
+    execution,
+  };
+
+  const spin = createSpinner(options);
+  spin?.start('Saving scheduled task…');
+  const payload = await apiRequest(port, 'PUT', `/api/projects/${encodeURIComponent(projectId)}/scheduled-tasks`, {
+    body: { task },
+    options,
+  });
+  spin?.stop('Scheduled task saved');
+
+  const saved = payload?.task || task;
+  if (isJsonMode(options)) {
+    printJson({ created: payload?.created !== false, task: serializeTask(saved) });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${saved.id}\n`);
+    return;
+  }
+  clackIntro('Create Scheduled Task');
+  logStatus('success', `Saved ${saved.name}`, [
+    `id: ${saved.id}`,
+    `schedule: ${formatSchedule(saved.schedule)}`,
+    saved.enabled ? null : 'created disabled',
+  ].filter(Boolean).join('\n'));
+  clackOutro(saved.id);
+}
+
+async function handleToggle(port, projectId, options, args, enabled) {
+  const ref = requireTaskRef(args, options);
+  const tasks = await loadTasks(port, projectId, options);
+  const task = findTask(tasks, ref);
+  if (!task) {
+    throw new TunnelCliError(`Scheduled task "${ref}" not found.`, EXIT_CODE.GENERAL_ERROR);
+  }
+  if (Boolean(task.enabled) === enabled) {
+    if (!isJsonMode(options) && !isQuietMode(options)) {
+      clackIntro(enabled ? 'Enable Scheduled Task' : 'Disable Scheduled Task');
+      logStatus('info', `${task.name} is already ${enabled ? 'enabled' : 'disabled'}`);
+      clackOutro('no change');
+      return;
+    }
+  }
+
+  const payload = await apiRequest(port, 'PUT', `/api/projects/${encodeURIComponent(projectId)}/scheduled-tasks`, {
+    body: { task: { ...task, enabled } },
+    options,
+  });
+  const saved = payload?.task || { ...task, enabled };
+
+  if (isJsonMode(options)) {
+    printJson({ updated: true, task: serializeTask(saved) });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${saved.id} ${enabled ? 'enabled' : 'disabled'}\n`);
+    return;
+  }
+  clackIntro(enabled ? 'Enable Scheduled Task' : 'Disable Scheduled Task');
+  const next = formatInstant(saved?.state?.nextRunAt, saved?.schedule?.timezone);
+  logStatus('success', `${enabled ? 'Enabled' : 'Disabled'} ${saved.name}`, enabled && next ? `next run: ${next}` : undefined);
+  clackOutro('done');
+}
+
+async function handleRun(port, projectId, options, args) {
+  const ref = requireTaskRef(args, options);
+  const tasks = await loadTasks(port, projectId, options);
+  const task = findTask(tasks, ref);
+  if (!task) {
+    throw new TunnelCliError(`Scheduled task "${ref}" not found.`, EXIT_CODE.GENERAL_ERROR);
+  }
+
+  const spin = createSpinner(options);
+  spin?.start('Running scheduled task…');
+  let payload;
+  try {
+    payload = await apiRequest(port, 'POST', `/api/projects/${encodeURIComponent(projectId)}/scheduled-tasks/${encodeURIComponent(task.id)}/run`, {
+      options,
+      timeoutMs: 600000,
+    });
+  } finally {
+    spin?.stop('Done');
+  }
+
+  const sessionId = payload?.sessionId || null;
+  if (isJsonMode(options)) {
+    printJson({ ran: true, id: task.id, sessionId });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${task.id} ran${sessionId ? ` ${sessionId}` : ''}\n`);
+    return;
+  }
+  clackIntro('Run Scheduled Task');
+  logStatus('success', `Ran ${task.name}`, sessionId ? `session: ${sessionId}` : undefined);
+  clackOutro('done');
+}
+
+async function handleDelete(port, projectId, options, args) {
+  const ref = requireTaskRef(args, options);
+  const tasks = await loadTasks(port, projectId, options);
+  const task = findTask(tasks, ref);
+  if (!task) {
+    throw new TunnelCliError(`Scheduled task "${ref}" not found.`, EXIT_CODE.GENERAL_ERROR);
+  }
+
+  await confirmDestructive(options, `Delete scheduled task "${task.name}" (${task.id})?`);
+  await apiRequest(port, 'DELETE', `/api/projects/${encodeURIComponent(projectId)}/scheduled-tasks/${encodeURIComponent(task.id)}`, { options });
+
+  if (isJsonMode(options)) {
+    printJson({ deleted: true, id: task.id });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${task.id} deleted\n`);
+    return;
+  }
+  clackIntro('Delete Scheduled Task');
+  logStatus('success', `Deleted ${task.name}`);
+  clackOutro('done');
+}
+
+async function scheduleCommand(options = {}, action = 'list', args = []) {
+  const normalizedAction = typeof action === 'string' && action.trim().length > 0 ? action.trim() : 'list';
+  if (!SCHEDULE_ACTIONS.includes(normalizedAction)) {
+    throw usage(`Unknown schedule action '${normalizedAction}'. Valid actions: ${SCHEDULE_ACTIONS.join(', ')}.`);
+  }
+
+  const port = await resolveTargetPort(options);
+
+  if (normalizedAction === 'status') {
+    return handleStatus(port, options);
+  }
+
+  const projectId = await resolveProjectId(port, options);
+
+  switch (normalizedAction) {
+    case 'list':
+      return handleList(port, projectId, options);
+    case 'show':
+      return handleShow(port, projectId, options, args);
+    case 'create':
+      return handleCreate(port, projectId, options, args);
+    case 'run':
+      return handleRun(port, projectId, options, args);
+    case 'enable':
+      return handleToggle(port, projectId, options, args, true);
+    case 'disable':
+      return handleToggle(port, projectId, options, args, false);
+    case 'delete':
+      return handleDelete(port, projectId, options, args);
+    default:
+      return undefined;
+  }
+}
+
+export { scheduleCommand };

--- a/packages/web/bin/lib/commands-session.js
+++ b/packages/web/bin/lib/commands-session.js
@@ -13,7 +13,7 @@ import {
   logStatus,
 } from '../cli-output.js';
 import { EXIT_CODE, TunnelCliError } from './cli-errors.js';
-import { apiRequest, resolveTargetPort, resolveScopeDirectory } from './cli-api-client.js';
+import { apiRequest, resolveTargetPort, resolveScopeDirectory, resolveModel } from './cli-api-client.js';
 import { truncate, formatRelativeTime, formatModel } from './cli-format.js';
 
 const SESSION_ACTIONS = ['list', 'show', 'create', 'rename', 'archive', 'unarchive', 'share', 'unshare', 'delete', 'prompt'];
@@ -318,39 +318,6 @@ async function handleDelete(port, directory, options, args) {
   clackOutro('done');
 }
 
-async function resolveDefaultModel(port, options) {
-  if (typeof options.model === 'string' && options.model.includes('/')) {
-    const [providerID, ...rest] = options.model.split('/');
-    return { providerID: providerID.trim(), modelID: rest.join('/').trim() };
-  }
-  if (typeof options.provider === 'string' && typeof options.model === 'string'
-    && options.provider.trim() && options.model.trim()) {
-    return { providerID: options.provider.trim(), modelID: options.model.trim() };
-  }
-
-  const config = await apiRequest(port, 'GET', '/api/config/providers', { options });
-  const defaults = config && typeof config.default === 'object' ? config.default : {};
-  const providers = Array.isArray(config?.providers) ? config.providers : [];
-
-  const preferredProvider = typeof options.provider === 'string' && options.provider.trim()
-    ? options.provider.trim()
-    : Object.keys(defaults)[0] || providers[0]?.id;
-
-  if (!preferredProvider) {
-    throw new TunnelCliError('No model available. Configure a provider, or pass --model <provider/model>.', EXIT_CODE.USAGE_ERROR);
-  }
-
-  const modelID = (typeof options.model === 'string' && options.model.trim())
-    ? options.model.trim()
-    : defaults[preferredProvider];
-
-  if (!modelID) {
-    throw new TunnelCliError(`No default model for provider "${preferredProvider}". Pass --model <provider/model>.`, EXIT_CODE.USAGE_ERROR);
-  }
-
-  return { providerID: preferredProvider, modelID };
-}
-
 async function handlePrompt(port, directory, options, args) {
   const id = requireSessionId(args, options);
   let message = args.slice(1).join(' ').trim();
@@ -367,7 +334,7 @@ async function handlePrompt(port, directory, options, args) {
     throw new TunnelCliError('A prompt message is required. Usage: openchamber session prompt <id> <message> (or --message).', EXIT_CODE.USAGE_ERROR);
   }
 
-  const model = await resolveDefaultModel(port, options);
+  const model = await resolveModel(port, options);
   const agent = typeof options.agent === 'string' && options.agent.trim() ? options.agent.trim() : 'build';
   const messageID = generateMessageId();
 

--- a/packages/web/bin/lib/commands-session.js
+++ b/packages/web/bin/lib/commands-session.js
@@ -1,0 +1,440 @@
+import {
+  intro as clackIntro,
+  outro as clackOutro,
+  cancel as clackCancel,
+  confirm as clackConfirm,
+  text as clackText,
+  isCancel,
+  isJsonMode,
+  isQuietMode,
+  canPrompt,
+  createSpinner,
+  printJson,
+  logStatus,
+} from '../cli-output.js';
+import { EXIT_CODE, TunnelCliError } from './cli-errors.js';
+import { apiRequest, resolveTargetPort, resolveScopeDirectory } from './cli-api-client.js';
+import { truncate, formatRelativeTime, formatModel } from './cli-format.js';
+
+const SESSION_ACTIONS = ['list', 'show', 'create', 'rename', 'archive', 'unarchive', 'share', 'unshare', 'delete', 'prompt'];
+
+function isArchived(session) {
+  const archived = session?.time?.archived;
+  return Number.isFinite(archived) && archived > 0;
+}
+
+function requireSessionId(args, options) {
+  const id = typeof args[0] === 'string' ? args[0].trim() : '';
+  if (id) return id;
+  if (typeof options.name === 'string' && options.name.trim().length > 0) return options.name.trim();
+  throw new TunnelCliError('A session id is required. Usage: openchamber session <action> <session-id>', EXIT_CODE.USAGE_ERROR);
+}
+
+function generateMessageId() {
+  const time = Date.now().toString(16).padStart(12, '0').slice(-12);
+  const random = Math.random().toString(36).slice(2, 10).padEnd(8, '0');
+  return `msg_${time}${random}`;
+}
+
+function serializeSession(session) {
+  return {
+    id: session.id,
+    title: session.title || '',
+    slug: session.slug,
+    directory: session.directory,
+    agent: session.agent,
+    model: session.model || null,
+    archived: isArchived(session),
+    shareUrl: session?.share?.url || null,
+    created: session?.time?.created ?? null,
+    updated: session?.time?.updated ?? null,
+  };
+}
+
+async function listSessions(port, directory, options) {
+  const sessions = await apiRequest(port, 'GET', '/api/session', {
+    query: { directory },
+    options,
+  });
+  const all = Array.isArray(sessions) ? sessions : [];
+  const includeArchived = Boolean(options.all);
+  const filtered = includeArchived ? all : all.filter((session) => !isArchived(session));
+  filtered.sort((a, b) => (b?.time?.updated ?? 0) - (a?.time?.updated ?? 0));
+  return filtered;
+}
+
+async function handleList(port, directory, options) {
+  const sessions = await listSessions(port, directory, options);
+
+  if (isJsonMode(options)) {
+    printJson({ directory, count: sessions.length, sessions: sessions.map(serializeSession) });
+    return;
+  }
+
+  if (isQuietMode(options)) {
+    for (const session of sessions) {
+      process.stdout.write(`${session.id} ${isArchived(session) ? 'archived' : 'active'} ${session.title || '(untitled)'}\n`);
+    }
+    return;
+  }
+
+  clackIntro('OpenChamber Sessions');
+  if (sessions.length === 0) {
+    logStatus('warning', 'No sessions found', `directory: ${directory}`);
+    clackOutro('0 sessions');
+    return;
+  }
+  for (const session of sessions) {
+    const detailParts = [];
+    if (session.agent) detailParts.push(String(session.agent));
+    const model = formatModel(session.model);
+    if (model) detailParts.push(model);
+    detailParts.push(formatRelativeTime(session?.time?.updated));
+    if (isArchived(session)) detailParts.push('archived');
+    logStatus('info', `${session.id}  ${truncate(session.title || '(untitled)', 64)}`, detailParts.join(' · '));
+  }
+  clackOutro(`${sessions.length} session(s) · ${directory}`);
+}
+
+async function handleShow(port, directory, options, args) {
+  const id = requireSessionId(args, options);
+  const session = await apiRequest(port, 'GET', `/api/session/${encodeURIComponent(id)}`, {
+    query: { directory },
+    options,
+  });
+  let messageCount = null;
+  try {
+    const messages = await apiRequest(port, 'GET', `/api/session/${encodeURIComponent(id)}/message`, {
+      query: { directory },
+      options,
+    });
+    messageCount = Array.isArray(messages) ? messages.length : null;
+  } catch {
+    messageCount = null;
+  }
+
+  if (isJsonMode(options)) {
+    printJson({ session: { ...serializeSession(session), messageCount } });
+    return;
+  }
+
+  if (isQuietMode(options)) {
+    process.stdout.write(`${session.id} ${isArchived(session) ? 'archived' : 'active'} ${session.title || '(untitled)'}\n`);
+    return;
+  }
+
+  clackIntro('Session Details');
+  logStatus('info', session.id, session.title || '(untitled)');
+  const lines = [];
+  if (session.slug) lines.push(`slug: ${session.slug}`);
+  if (session.agent) lines.push(`agent: ${session.agent}`);
+  const model = formatModel(session.model);
+  if (model) lines.push(`model: ${model}`);
+  lines.push(`directory: ${session.directory || directory}`);
+  lines.push(`archived: ${isArchived(session) ? 'yes' : 'no'}`);
+  if (session?.share?.url) lines.push(`share: ${session.share.url}`);
+  if (Number.isFinite(messageCount)) lines.push(`messages: ${messageCount}`);
+  if (session?.time?.created) lines.push(`created: ${formatRelativeTime(session.time.created)}`);
+  if (session?.time?.updated) lines.push(`updated: ${formatRelativeTime(session.time.updated)}`);
+  logStatus('neutral', 'details', lines.join('\n'));
+  clackOutro('done');
+}
+
+async function resolveTitleForCreate(options, args) {
+  const fromArg = args.join(' ').trim();
+  if (fromArg) return fromArg;
+  if (typeof options.title === 'string' && options.title.trim().length > 0) return options.title.trim();
+  if (canPrompt(options)) {
+    const value = await clackText({
+      message: 'Session title (optional)',
+      placeholder: 'Leave blank for an untitled session',
+    });
+    if (isCancel(value)) {
+      clackCancel('Operation cancelled.');
+      throw new TunnelCliError('Cancelled.', 130);
+    }
+    return typeof value === 'string' ? value.trim() : '';
+  }
+  return '';
+}
+
+async function handleCreate(port, directory, options, args) {
+  const title = await resolveTitleForCreate(options, args);
+  const spin = createSpinner(options);
+  spin?.start('Creating session…');
+  const session = await apiRequest(port, 'POST', '/api/session', {
+    query: { directory },
+    body: title ? { title } : {},
+    options,
+    timeoutMs: 15000,
+  });
+  spin?.stop('Session created');
+
+  if (isJsonMode(options)) {
+    printJson({ created: true, session: serializeSession(session) });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${session.id}\n`);
+    return;
+  }
+  clackIntro('Create Session');
+  logStatus('success', `Created ${session.id}`, session.title ? `title: ${session.title}` : 'untitled');
+  clackOutro(session.id);
+}
+
+async function handleRename(port, directory, options, args) {
+  const id = requireSessionId(args, options);
+  let title = args.slice(1).join(' ').trim();
+  if (!title && typeof options.title === 'string') title = options.title.trim();
+  if (!title) {
+    if (canPrompt(options)) {
+      const value = await clackText({ message: 'New session title', placeholder: 'Enter a title' });
+      if (isCancel(value)) {
+        clackCancel('Operation cancelled.');
+        throw new TunnelCliError('Cancelled.', 130);
+      }
+      title = typeof value === 'string' ? value.trim() : '';
+    }
+  }
+  if (!title) {
+    throw new TunnelCliError('A new title is required. Usage: openchamber session rename <id> <title> (or --title).', EXIT_CODE.USAGE_ERROR);
+  }
+
+  const session = await apiRequest(port, 'PATCH', `/api/session/${encodeURIComponent(id)}`, {
+    query: { directory },
+    body: { title },
+    options,
+  });
+
+  if (isJsonMode(options)) {
+    printJson({ renamed: true, session: serializeSession(session) });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${id} ${title}\n`);
+    return;
+  }
+  clackIntro('Rename Session');
+  logStatus('success', `Renamed ${id}`, `title: ${title}`);
+  clackOutro('done');
+}
+
+async function handleArchiveToggle(port, directory, options, args, archive) {
+  const id = requireSessionId(args, options);
+  const session = await apiRequest(port, 'PATCH', `/api/session/${encodeURIComponent(id)}`, {
+    query: { directory },
+    body: { time: { archived: archive ? Date.now() : 0 } },
+    options,
+  });
+  const verb = archive ? 'Archived' : 'Unarchived';
+  if (isJsonMode(options)) {
+    printJson({ archived: archive, session: serializeSession(session) });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${id} ${archive ? 'archived' : 'active'}\n`);
+    return;
+  }
+  clackIntro(`${verb} Session`);
+  logStatus('success', `${verb} ${id}`);
+  clackOutro('done');
+}
+
+async function handleShare(port, directory, options, args, share) {
+  const id = requireSessionId(args, options);
+  if (share) {
+    const session = await apiRequest(port, 'POST', `/api/session/${encodeURIComponent(id)}/share`, {
+      query: { directory },
+      options,
+      timeoutMs: 15000,
+    });
+    const url = session?.share?.url || null;
+    if (isJsonMode(options)) {
+      printJson({ shared: true, session: serializeSession(session) });
+      return;
+    }
+    if (isQuietMode(options)) {
+      process.stdout.write(`${url || id}\n`);
+      return;
+    }
+    clackIntro('Share Session');
+    if (url) {
+      logStatus('success', `Shared ${id}`, url);
+    } else {
+      logStatus('success', `Shared ${id}`);
+    }
+    clackOutro('done');
+    return;
+  }
+
+  await apiRequest(port, 'DELETE', `/api/session/${encodeURIComponent(id)}/share`, {
+    query: { directory },
+    options,
+    timeoutMs: 15000,
+  });
+  if (isJsonMode(options)) {
+    printJson({ unshared: true, id });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${id} unshared\n`);
+    return;
+  }
+  clackIntro('Unshare Session');
+  logStatus('success', `Unshared ${id}`);
+  clackOutro('done');
+}
+
+async function handleDelete(port, directory, options, args) {
+  const id = requireSessionId(args, options);
+
+  if (!options.force && canPrompt(options)) {
+    const confirmed = await clackConfirm({ message: `Delete session ${id}? This cannot be undone.` });
+    if (isCancel(confirmed) || confirmed !== true) {
+      clackCancel('Operation cancelled.');
+      throw new TunnelCliError('Cancelled.', 130);
+    }
+  } else if (!options.force && !canPrompt(options)) {
+    throw new TunnelCliError('Refusing to delete without confirmation. Re-run with --force (or --yes) to proceed.', EXIT_CODE.USAGE_ERROR);
+  }
+
+  await apiRequest(port, 'DELETE', `/api/session/${encodeURIComponent(id)}`, {
+    query: { directory },
+    options,
+    timeoutMs: 15000,
+  });
+
+  if (isJsonMode(options)) {
+    printJson({ deleted: true, id });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${id} deleted\n`);
+    return;
+  }
+  clackIntro('Delete Session');
+  logStatus('success', `Deleted ${id}`);
+  clackOutro('done');
+}
+
+async function resolveDefaultModel(port, options) {
+  if (typeof options.model === 'string' && options.model.includes('/')) {
+    const [providerID, ...rest] = options.model.split('/');
+    return { providerID: providerID.trim(), modelID: rest.join('/').trim() };
+  }
+  if (typeof options.provider === 'string' && typeof options.model === 'string'
+    && options.provider.trim() && options.model.trim()) {
+    return { providerID: options.provider.trim(), modelID: options.model.trim() };
+  }
+
+  const config = await apiRequest(port, 'GET', '/api/config/providers', { options });
+  const defaults = config && typeof config.default === 'object' ? config.default : {};
+  const providers = Array.isArray(config?.providers) ? config.providers : [];
+
+  const preferredProvider = typeof options.provider === 'string' && options.provider.trim()
+    ? options.provider.trim()
+    : Object.keys(defaults)[0] || providers[0]?.id;
+
+  if (!preferredProvider) {
+    throw new TunnelCliError('No model available. Configure a provider, or pass --model <provider/model>.', EXIT_CODE.USAGE_ERROR);
+  }
+
+  const modelID = (typeof options.model === 'string' && options.model.trim())
+    ? options.model.trim()
+    : defaults[preferredProvider];
+
+  if (!modelID) {
+    throw new TunnelCliError(`No default model for provider "${preferredProvider}". Pass --model <provider/model>.`, EXIT_CODE.USAGE_ERROR);
+  }
+
+  return { providerID: preferredProvider, modelID };
+}
+
+async function handlePrompt(port, directory, options, args) {
+  const id = requireSessionId(args, options);
+  let message = args.slice(1).join(' ').trim();
+  if (!message && typeof options.message === 'string') message = options.message.trim();
+  if (!message && canPrompt(options)) {
+    const value = await clackText({ message: 'Prompt to send', placeholder: 'Type your message' });
+    if (isCancel(value)) {
+      clackCancel('Operation cancelled.');
+      throw new TunnelCliError('Cancelled.', 130);
+    }
+    message = typeof value === 'string' ? value.trim() : '';
+  }
+  if (!message) {
+    throw new TunnelCliError('A prompt message is required. Usage: openchamber session prompt <id> <message> (or --message).', EXIT_CODE.USAGE_ERROR);
+  }
+
+  const model = await resolveDefaultModel(port, options);
+  const agent = typeof options.agent === 'string' && options.agent.trim() ? options.agent.trim() : 'build';
+  const messageID = generateMessageId();
+
+  const spin = createSpinner(options);
+  spin?.start('Sending prompt…');
+  await apiRequest(port, 'POST', `/api/session/${encodeURIComponent(id)}/message`, {
+    query: { directory },
+    body: {
+      messageID,
+      model,
+      agent,
+      parts: [{ type: 'text', text: message }],
+    },
+    options,
+    timeoutMs: 600000,
+  });
+  spin?.stop('Prompt sent');
+
+  if (isJsonMode(options)) {
+    printJson({ sent: true, id, messageID, model, agent });
+    return;
+  }
+  if (isQuietMode(options)) {
+    process.stdout.write(`${id} ${messageID}\n`);
+    return;
+  }
+  clackIntro('Send Prompt');
+  logStatus('success', `Sent to ${id}`, `${model.providerID}/${model.modelID} · agent ${agent}`);
+  clackOutro(messageID);
+}
+
+async function sessionCommand(options = {}, action = 'list', args = []) {
+  const normalizedAction = typeof action === 'string' && action.trim().length > 0 ? action.trim() : 'list';
+  if (!SESSION_ACTIONS.includes(normalizedAction)) {
+    throw new TunnelCliError(
+      `Unknown session action '${normalizedAction}'. Valid actions: ${SESSION_ACTIONS.join(', ')}.`,
+      EXIT_CODE.USAGE_ERROR,
+    );
+  }
+
+  const port = await resolveTargetPort(options);
+  const directory = resolveScopeDirectory(options);
+
+  switch (normalizedAction) {
+    case 'list':
+      return handleList(port, directory, options);
+    case 'show':
+      return handleShow(port, directory, options, args);
+    case 'create':
+      return handleCreate(port, directory, options, args);
+    case 'rename':
+      return handleRename(port, directory, options, args);
+    case 'archive':
+      return handleArchiveToggle(port, directory, options, args, true);
+    case 'unarchive':
+      return handleArchiveToggle(port, directory, options, args, false);
+    case 'share':
+      return handleShare(port, directory, options, args, true);
+    case 'unshare':
+      return handleShare(port, directory, options, args, false);
+    case 'delete':
+      return handleDelete(port, directory, options, args);
+    case 'prompt':
+      return handlePrompt(port, directory, options, args);
+    default:
+      return undefined;
+  }
+}
+
+export { sessionCommand };

--- a/packages/web/bin/lib/commands-session.js
+++ b/packages/web/bin/lib/commands-session.js
@@ -8,15 +8,19 @@ import {
   isJsonMode,
   isQuietMode,
   canPrompt,
-  createSpinner,
   printJson,
   logStatus,
 } from '../cli-output.js';
 import { EXIT_CODE, TunnelCliError } from './cli-errors.js';
-import { apiRequest, resolveTargetPort, resolveScopeDirectory, resolveModel } from './cli-api-client.js';
+import { apiRequest, resolveTargetPort, resolveScopeDirectory } from './cli-api-client.js';
 import { truncate, formatRelativeTime, formatModel } from './cli-format.js';
 
-const SESSION_ACTIONS = ['list', 'show', 'create', 'rename', 'archive', 'unarchive', 'share', 'unshare', 'delete', 'prompt'];
+// Session creation and initial-prompt dispatch are intentionally NOT exposed
+// here. OpenChamber-owned session orchestration lives behind
+// /api/openchamber/sessions (separate work) and is the source of truth for
+// creating sessions and optionally dispatching the first prompt. These CLI
+// commands only read and mutate existing sessions.
+const SESSION_ACTIONS = ['list', 'show', 'rename', 'archive', 'unarchive', 'share', 'unshare', 'delete'];
 
 function isArchived(session) {
   const archived = session?.time?.archived;
@@ -28,12 +32,6 @@ function requireSessionId(args, options) {
   if (id) return id;
   if (typeof options.name === 'string' && options.name.trim().length > 0) return options.name.trim();
   throw new TunnelCliError('A session id is required. Usage: openchamber session <action> <session-id>', EXIT_CODE.USAGE_ERROR);
-}
-
-function generateMessageId() {
-  const time = Date.now().toString(16).padStart(12, '0').slice(-12);
-  const random = Math.random().toString(36).slice(2, 10).padEnd(8, '0');
-  return `msg_${time}${random}`;
 }
 
 function serializeSession(session) {
@@ -138,49 +136,6 @@ async function handleShow(port, directory, options, args) {
   if (session?.time?.updated) lines.push(`updated: ${formatRelativeTime(session.time.updated)}`);
   logStatus('neutral', 'details', lines.join('\n'));
   clackOutro('done');
-}
-
-async function resolveTitleForCreate(options, args) {
-  const fromArg = args.join(' ').trim();
-  if (fromArg) return fromArg;
-  if (typeof options.title === 'string' && options.title.trim().length > 0) return options.title.trim();
-  if (canPrompt(options)) {
-    const value = await clackText({
-      message: 'Session title (optional)',
-      placeholder: 'Leave blank for an untitled session',
-    });
-    if (isCancel(value)) {
-      clackCancel('Operation cancelled.');
-      throw new TunnelCliError('Cancelled.', 130);
-    }
-    return typeof value === 'string' ? value.trim() : '';
-  }
-  return '';
-}
-
-async function handleCreate(port, directory, options, args) {
-  const title = await resolveTitleForCreate(options, args);
-  const spin = createSpinner(options);
-  spin?.start('Creating session…');
-  const session = await apiRequest(port, 'POST', '/api/session', {
-    query: { directory },
-    body: title ? { title } : {},
-    options,
-    timeoutMs: 15000,
-  });
-  spin?.stop('Session created');
-
-  if (isJsonMode(options)) {
-    printJson({ created: true, session: serializeSession(session) });
-    return;
-  }
-  if (isQuietMode(options)) {
-    process.stdout.write(`${session.id}\n`);
-    return;
-  }
-  clackIntro('Create Session');
-  logStatus('success', `Created ${session.id}`, session.title ? `title: ${session.title}` : 'untitled');
-  clackOutro(session.id);
 }
 
 async function handleRename(port, directory, options, args) {
@@ -318,54 +273,6 @@ async function handleDelete(port, directory, options, args) {
   clackOutro('done');
 }
 
-async function handlePrompt(port, directory, options, args) {
-  const id = requireSessionId(args, options);
-  let message = args.slice(1).join(' ').trim();
-  if (!message && typeof options.message === 'string') message = options.message.trim();
-  if (!message && canPrompt(options)) {
-    const value = await clackText({ message: 'Prompt to send', placeholder: 'Type your message' });
-    if (isCancel(value)) {
-      clackCancel('Operation cancelled.');
-      throw new TunnelCliError('Cancelled.', 130);
-    }
-    message = typeof value === 'string' ? value.trim() : '';
-  }
-  if (!message) {
-    throw new TunnelCliError('A prompt message is required. Usage: openchamber session prompt <id> <message> (or --message).', EXIT_CODE.USAGE_ERROR);
-  }
-
-  const model = await resolveModel(port, options);
-  const agent = typeof options.agent === 'string' && options.agent.trim() ? options.agent.trim() : 'build';
-  const messageID = generateMessageId();
-
-  const spin = createSpinner(options);
-  spin?.start('Sending prompt…');
-  await apiRequest(port, 'POST', `/api/session/${encodeURIComponent(id)}/message`, {
-    query: { directory },
-    body: {
-      messageID,
-      model,
-      agent,
-      parts: [{ type: 'text', text: message }],
-    },
-    options,
-    timeoutMs: 600000,
-  });
-  spin?.stop('Prompt sent');
-
-  if (isJsonMode(options)) {
-    printJson({ sent: true, id, messageID, model, agent });
-    return;
-  }
-  if (isQuietMode(options)) {
-    process.stdout.write(`${id} ${messageID}\n`);
-    return;
-  }
-  clackIntro('Send Prompt');
-  logStatus('success', `Sent to ${id}`, `${model.providerID}/${model.modelID} · agent ${agent}`);
-  clackOutro(messageID);
-}
-
 async function sessionCommand(options = {}, action = 'list', args = []) {
   const normalizedAction = typeof action === 'string' && action.trim().length > 0 ? action.trim() : 'list';
   if (!SESSION_ACTIONS.includes(normalizedAction)) {
@@ -383,8 +290,6 @@ async function sessionCommand(options = {}, action = 'list', args = []) {
       return handleList(port, directory, options);
     case 'show':
       return handleShow(port, directory, options, args);
-    case 'create':
-      return handleCreate(port, directory, options, args);
     case 'rename':
       return handleRename(port, directory, options, args);
     case 'archive':
@@ -397,8 +302,6 @@ async function sessionCommand(options = {}, action = 'list', args = []) {
       return handleShare(port, directory, options, args, false);
     case 'delete':
       return handleDelete(port, directory, options, args);
-    case 'prompt':
-      return handlePrompt(port, directory, options, args);
     default:
       return undefined;
   }

--- a/packages/web/server/lib/scheduled-tasks/DOCUMENTATION.md
+++ b/packages/web/server/lib/scheduled-tasks/DOCUMENTATION.md
@@ -11,7 +11,8 @@ Server-owned scheduled task runtime and routes for OpenChamber-only automation.
 ## Files
 
 - `packages/web/server/lib/scheduled-tasks/runtime.js`
-  - Next-run computation (daily/weekly/cron compatibility)
+  - Next-run computation (daily/weekly/once/cron compatibility)
+  - One-time task expiry: enabled `once` tasks whose instant has passed are auto-disabled on sync (`isOneTimeTaskExpired`)
   - Timer scheduling and queueing
   - Concurrency controls
   - Session create + prompt_async execution

--- a/packages/web/server/lib/scheduled-tasks/runtime.js
+++ b/packages/web/server/lib/scheduled-tasks/runtime.js
@@ -201,6 +201,29 @@ export const computeNextRunAt = (task, nowMs = Date.now()) => {
   return null;
 };
 
+/**
+ * Whether a one-time task's scheduled instant has already passed. Such a task
+ * can never be scheduled again (computeNextRunAt returns null), so leaving it
+ * enabled is misleading; callers disable it on sync.
+ */
+export const isOneTimeTaskExpired = (task, nowMs = Date.now()) => {
+  if (task?.schedule?.kind !== 'once') {
+    return false;
+  }
+  const { date, time, timezone } = task.schedule;
+  if (typeof date !== 'string' || typeof time !== 'string') {
+    return false;
+  }
+  const zone = typeof timezone === 'string' && timezone.trim().length > 0
+    ? timezone.trim()
+    : DateTime.local().zoneName;
+  const parsed = DateTime.fromFormat(`${date} ${time}`, 'yyyy-LL-dd HH:mm', { zone });
+  if (!parsed.isValid) {
+    return false;
+  }
+  return parsed.toMillis() <= nowMs;
+};
+
 export const formatScheduledSessionTitle = (task, nowMs = Date.now()) => {
   const timezone = typeof task?.schedule?.timezone === 'string' && task.schedule.timezone.trim().length > 0
     ? task.schedule.timezone.trim()
@@ -320,10 +343,38 @@ export const createScheduledTasksRuntime = (deps) => {
     if (!task) {
       return;
     }
-    const nextRunAt = computeNextRunAt(task, Date.now());
+    const nowMs = Date.now();
+
+    // Auto-expire one-time tasks whose scheduled instant has already passed
+    // (e.g. the server was offline when it was due). They can never run again,
+    // so disable them instead of leaving a dead "enabled" task in the UI/CLI.
+    if (task.enabled && isOneTimeTaskExpired(task, nowMs)) {
+      try {
+        const consumed = await projectConfigRuntime.upsertScheduledTask(projectID, {
+          ...task,
+          enabled: false,
+        });
+        if (consumed.task) {
+          updateInMemoryTask(projectID, consumed.task);
+        }
+        logger.info?.('[ScheduledTasks] disabled expired one-time task', {
+          projectID,
+          taskID: task.id,
+        });
+      } catch (error) {
+        logger.warn?.('[ScheduledTasks] failed to expire one-time task', {
+          projectID,
+          taskID: task.id,
+          error: safeErrorMessage(error),
+        });
+      }
+      return;
+    }
+
+    const nextRunAt = computeNextRunAt(task, nowMs);
     const statePatch = {
       nextRunAt: Number.isFinite(nextRunAt) ? nextRunAt : undefined,
-      updatedAt: Date.now(),
+      updatedAt: nowMs,
     };
     const result = await projectConfigRuntime.updateScheduledTaskState(projectID, task.id, statePatch);
     if (result.task) {

--- a/packages/web/server/lib/scheduled-tasks/runtime.test.js
+++ b/packages/web/server/lib/scheduled-tasks/runtime.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeNextRunAt, formatScheduledSessionTitle, parseScheduledCommandPrompt } from './runtime.js';
+import { computeNextRunAt, formatScheduledSessionTitle, parseScheduledCommandPrompt, isOneTimeTaskExpired } from './runtime.js';
 
 describe('scheduled-tasks runtime helpers', () => {
   it('computes next daily run in timezone', () => {
@@ -96,5 +96,26 @@ describe('scheduled-tasks runtime helpers', () => {
   it('returns null when prompt is not a slash command', () => {
     expect(parseScheduledCommandPrompt('Summarize open issues')).toBeNull();
     expect(parseScheduledCommandPrompt('/')).toBeNull();
+  });
+
+  describe('isOneTimeTaskExpired', () => {
+    const baseOnce = {
+      schedule: { kind: 'once', date: '2026-04-16', time: '13:30', timezone: 'UTC' },
+    };
+
+    it('is true when the one-time instant has passed', () => {
+      expect(isOneTimeTaskExpired(baseOnce, Date.UTC(2026, 3, 16, 14, 0, 0))).toBe(true);
+      expect(isOneTimeTaskExpired(baseOnce, Date.UTC(2026, 3, 16, 13, 30, 0))).toBe(true);
+    });
+
+    it('is false when the one-time instant is in the future', () => {
+      expect(isOneTimeTaskExpired(baseOnce, Date.UTC(2026, 3, 16, 13, 0, 0))).toBe(false);
+    });
+
+    it('is false for recurring or malformed schedules', () => {
+      expect(isOneTimeTaskExpired({ schedule: { kind: 'daily', times: ['09:00'] } }, Date.now())).toBe(false);
+      expect(isOneTimeTaskExpired({ schedule: { kind: 'once', date: 'bad', time: '13:30' } }, Date.now())).toBe(false);
+      expect(isOneTimeTaskExpired(null, Date.now())).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the OpenChamber CLI beyond server lifecycle (`serve`/`stop`/`status`/`tunnel`/…) with **resource commands that mirror the app's menu functions**, talking to a running instance over its HTTP API. All commands are TUI-friendly (clack) and enforce strict parity/safety across interactive TTY, non-TTY, `--quiet`, and `--json` modes per the `clack-cli-patterns` policy.

### New command groups

| Command | Actions |
|---|---|
| `session` | `list`, `show`, `rename`, `archive`, `unarchive`, `share`, `unshare`, `delete` |
| `agent` | `list`, `show`, `create`, `delete` |
| `command` (slash) | `list`, `show`, `create`, `delete` |
| `skill` | `list`, `show` |
| `mcp` | `list`, `show`, `create`, `delete` |
| `snippet` | `list`, `show`, `create`, `delete` |
| `provider` | `list`, `models` |
| `project` | `list` |
| `schedule` | `list`, `show`, `create`, `run`, `enable`, `disable`, `delete`, `status` |
| `config` | `get` |

### Session scope note (create/prompt intentionally excluded)

`session` exposes only read/mutation actions on existing sessions. **Session creation and initial-prompt dispatch are deliberately not in this PR** — OpenChamber-owned session orchestration via `/api/openchamber/sessions` will be the source of truth for creating normal sessions and optionally dispatching the first prompt. Keeping direct OpenCode-backed create/prompt here would overlap with that design.

### Scheduled tasks (TUI + CLI + runtime improvement)

- **`schedule` command group** mirrors the scheduled-tasks menu over `/api/projects/:projectId/scheduled-tasks` + `/api/openchamber/scheduled-tasks/status`. `create` builds daily/weekly/once/cron schedules from flags (`--kind`, `--at`, `--on mon,wed`, `--date/--time`, `--cron`, `--tz`), resolves the model from flags or server defaults, and supports `--disabled`. Project is resolved via `--project <id|path>`, the scope directory, the active project, or the sole project.
- **Runtime fix:** enabled one-time (`once`) tasks whose instant has already passed (e.g. server was offline when due) can never run again but still displayed as enabled. They are now auto-disabled on sync via the new `isOneTimeTaskExpired` helper, so UI/CLI/state reflect reality.

### Design

- **`cli-api-client.js`** — transport: resolves the target instance (explicit `--port`, else single-instance discovery; deterministic failure on none/ambiguous), authenticated JSON requests (throws `ApiError extends TunnelCliError` so exit codes are honored), plus `resolveProjectId`/`resolveModel`.
- **`cli-format.js`** — pure helpers (truncate / relative-time / model id / `formatSchedule` / `formatInstant`).
- **`commands-session.js`**, **`commands-resources.js`**, **`commands-schedule.js`** — command logic with shared `renderList`/`renderMutation`/`confirmDestructive`; destructive actions require confirmation or `--force`/`--yes` in **every** mode.
- **`cli-args.js`** — new flags, positionals, per-command `--help`, shell completions.
- **`cli.js`** — dispatches resource commands `(options, action, args)`; fixes a latent **EPIPE** crash so piping to `head` exits cleanly.

Project scoping defaults to the current working directory (`--directory` to override), so terminal usage is contextual.

## Scope note

This delivers the highest-value, fully server-backed menu domains (session read/mutation, the Settings config entities, and scheduled tasks) on a reusable foundation. The same `cli-api-client` + render-helper pattern extends cleanly to the remaining domains (git, files, GitHub, terminal). Layout-only menu items (sidebar toggles, theme) have no server backing and are intentionally excluded.

## Testing

- ✅ `npx vitest run bin/ server/lib/scheduled-tasks/ server/lib/projects/` (incl. schedule/expiry coverage)
- ✅ `eslint` on all new/changed files
- ✅ `bun run dead-code` (knip) — no unused exports in new code
- ✅ End-to-end against a live server (`serve --port 4500` + OpenCode):
  - Session read/mutation: list/show/rename/archive/unarchive/share/unshare/delete (sessions created out-of-band for setup); `session create`/`session prompt` now report unknown action with exit 2.
  - Other resources: agent/command/mcp/snippet create→delete roundtrips (no residue), provider/model/project/config reads.
  - Scheduled tasks: create (daily/weekly/once/cron), list/show (TUI), enable/disable, run (created a session), delete; deterministic non-zero exits for unconfirmed delete (2) and not-found (1).
  - Runtime fix verified after restart: a past `once` task is auto-disabled on sync (`[ScheduledTasks] disabled expired one-time task`), while a future `once` task stays enabled with a valid `nextRunAt`.

Walkthrough logs:
[openchamber_cli_demo_v2.log](https://cursor.com/agents/bc-84bc7766-3823-4c54-8322-9010ff5a258d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenchamber_cli_demo_v2.log)
[openchamber_schedule_cli_demo.log](https://cursor.com/agents/bc-84bc7766-3823-4c54-8322-9010ff5a258d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenchamber_schedule_cli_demo.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84bc7766-3823-4c54-8322-9010ff5a258d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84bc7766-3823-4c54-8322-9010ff5a258d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

