### PR TITLE
fix: percent-encode x-opencode-directory for Unicode paths

### DIFF
--- a/packages/ui/src/lib/runtime-fetch.ts
+++ b/packages/ui/src/lib/runtime-fetch.ts
@@ -96,10 +96,40 @@ const shouldAttachRuntimeAuth = (input: string | URL | Request): boolean => {
   }
 };
 
+const sanitizeDirectoryHeader = (headers?: HeadersInit): HeadersInit => {
+  if (!headers) return headers;
+
+  if (headers instanceof Headers) {
+    const dir = headers.get('x-opencode-directory');
+    if (dir && !dir.includes('%')) {
+      const clone = new Headers(headers);
+      clone.set('x-opencode-directory', encodeURIComponent(dir));
+      return clone;
+    }
+    return headers;
+  }
+
+  if (Array.isArray(headers)) {
+    return headers.map(([key, value]) => [
+      key,
+      key.toLowerCase() === 'x-opencode-directory' && typeof value === 'string' && !value.includes('%')
+        ? encodeURIComponent(value)
+        : value,
+    ]);
+  }
+
+  const record = headers as Record<string, string>;
+  const dir = record['x-opencode-directory'];
+  if (typeof dir === 'string' && !dir.includes('%')) {
+    return { ...record, 'x-opencode-directory': encodeURIComponent(dir) };
+  }
+  return headers;
+};
+
 const mergeHeaders = async (inputHeaders?: HeadersInit, initHeaders?: HeadersInit, attachAuth = true): Promise<Headers> => {
-  const headers = new Headers(inputHeaders);
+  const headers = new Headers(sanitizeDirectoryHeader(inputHeaders));
   if (initHeaders) {
-    new Headers(initHeaders).forEach((value, key) => headers.set(key, value));
+    new Headers(sanitizeDirectoryHeader(initHeaders)).forEach((value, key) => headers.set(key, value));
   }
   if (!attachAuth) {
     return headers;

--- a/packages/ui/src/stores/useAgentsStore.ts
+++ b/packages/ui/src/stores/useAgentsStore.ts
@@ -257,7 +257,7 @@ export const useAgentsStore = create<AgentsStore>()(
                       const response = await runtimeFetch(`/api/config/agents/${encodeURIComponent(agent.name)}${queryParams}`, {
                         headers: {
                           'Cache-Control': 'no-cache',
-                          ...(configDirectory ? { 'x-opencode-directory': configDirectory } : {}),
+                          ...(configDirectory ? { 'x-opencode-directory': encodeURIComponent(configDirectory) } : {}),
                         }
                       });
 
@@ -347,7 +347,7 @@ export const useAgentsStore = create<AgentsStore>()(
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
-                ...(configDirectory ? { 'x-opencode-directory': configDirectory } : {}),
+                ...(configDirectory ? { 'x-opencode-directory': encodeURIComponent(configDirectory) } : {}),
               },
               body: JSON.stringify(agentConfig)
             });
@@ -409,7 +409,7 @@ export const useAgentsStore = create<AgentsStore>()(
               method: 'PATCH',
               headers: {
                 'Content-Type': 'application/json',
-                ...(configDirectory ? { 'x-opencode-directory': configDirectory } : {}),
+                ...(configDirectory ? { 'x-opencode-directory': encodeURIComponent(configDirectory) } : {}),
               },
               body: JSON.stringify(agentConfig)
             });
@@ -460,7 +460,7 @@ export const useAgentsStore = create<AgentsStore>()(
               method: 'DELETE',
               headers: {
                 'Content-Type': 'application/json',
-                ...(configDirectory ? { 'x-opencode-directory': configDirectory } : {}),
+                ...(configDirectory ? { 'x-opencode-directory': encodeURIComponent(configDirectory) } : {}),
               },
               body: JSON.stringify({ scope }),
             });

--- a/packages/ui/src/stores/useCommandsStore.ts
+++ b/packages/ui/src/stores/useCommandsStore.ts
@@ -182,7 +182,7 @@ export const useCommandsStore = create<CommandsStore>()(
                       const response = await runtimeFetch(`/api/config/commands/${encodeURIComponent(cmd.name)}${queryParams}`, {
                         headers: {
                           'Cache-Control': 'no-cache',
-                          ...(directory ? { 'x-opencode-directory': directory } : {}),
+                          ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}),
                         }
                       });
 
@@ -267,7 +267,7 @@ export const useCommandsStore = create<CommandsStore>()(
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
-                ...(directory ? { 'x-opencode-directory': directory } : {}),
+                ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}),
               },
               body: JSON.stringify(commandConfig)
             });
@@ -329,7 +329,7 @@ export const useCommandsStore = create<CommandsStore>()(
               method: 'PATCH',
               headers: {
                 'Content-Type': 'application/json',
-                ...(directory ? { 'x-opencode-directory': directory } : {}),
+                ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}),
               },
               body: JSON.stringify(commandConfig)
             });
@@ -378,7 +378,7 @@ export const useCommandsStore = create<CommandsStore>()(
 
             const response = await runtimeFetch(`/api/config/commands/${encodeURIComponent(name)}${queryParams}`, {
               method: 'DELETE',
-              headers: directory ? { 'x-opencode-directory': directory } : undefined,
+              headers: directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : undefined,
             });
 
             const payload = await response.json().catch(() => null);

--- a/packages/ui/src/stores/useMcpConfigStore.ts
+++ b/packages/ui/src/stores/useMcpConfigStore.ts
@@ -167,7 +167,7 @@ export const useMcpConfigStore = create<McpConfigStore>()(
             try {
               const queryParams = configDirectory ? `?directory=${encodeURIComponent(configDirectory)}` : '';
               const response = await runtimeFetch(`/api/config/mcp${queryParams}`, {
-                headers: configDirectory ? { 'x-opencode-directory': configDirectory } : undefined,
+                headers: configDirectory ? { 'x-opencode-directory': encodeURIComponent(configDirectory) } : undefined,
               });
               if (!response.ok) {
                 throw new Error('Failed to load MCP configs');
@@ -202,7 +202,7 @@ export const useMcpConfigStore = create<McpConfigStore>()(
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
-                ...(configDirectory ? { 'x-opencode-directory': configDirectory } : {}),
+                ...(configDirectory ? { 'x-opencode-directory': encodeURIComponent(configDirectory) } : {}),
               },
               body: JSON.stringify(body),
             });
@@ -256,7 +256,7 @@ export const useMcpConfigStore = create<McpConfigStore>()(
               method: 'PATCH',
               headers: {
                 'Content-Type': 'application/json',
-                ...(configDirectory ? { 'x-opencode-directory': configDirectory } : {}),
+                ...(configDirectory ? { 'x-opencode-directory': encodeURIComponent(configDirectory) } : {}),
               },
               body: JSON.stringify(body),
             });
@@ -307,7 +307,7 @@ export const useMcpConfigStore = create<McpConfigStore>()(
             const queryParams = configDirectory ? `?directory=${encodeURIComponent(configDirectory)}` : '';
             const response = await runtimeFetch(`/api/config/mcp/${encodeURIComponent(name)}${queryParams}`, {
               method: 'DELETE',
-              headers: configDirectory ? { 'x-opencode-directory': configDirectory } : undefined,
+              headers: configDirectory ? { 'x-opencode-directory': encodeURIComponent(configDirectory) } : undefined,
             });
 
             const payload = await response.json().catch(() => null);

--- a/packages/ui/src/stores/usePluginsStore.ts
+++ b/packages/ui/src/stores/usePluginsStore.ts
@@ -403,13 +403,13 @@ function chunkSpecs(specs: string[]): string[][] {
 }
 
 function buildDirectoryHeaders(directory: string | null): HeadersInit | undefined {
-  return directory ? { 'x-opencode-directory': directory } : undefined;
+  return directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : undefined;
 }
 
 function buildJsonHeaders(directory: string | null): HeadersInit {
   return {
     'Content-Type': 'application/json',
-    ...(directory ? { 'x-opencode-directory': directory } : {}),
+    ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}),
   };
 }
 

--- a/packages/ui/src/stores/useSnippetsStore.ts
+++ b/packages/ui/src/stores/useSnippetsStore.ts
@@ -69,7 +69,7 @@ export const useSnippetsStore = create<SnippetsStore>()(
             const directory = getRequestDirectory();
             const queryParams = directory ? `?directory=${encodeURIComponent(directory)}` : '';
             const response = await runtimeFetch(`/api/config/snippets${queryParams}`, {
-              headers: { 'Cache-Control': 'no-cache', ...(directory ? { 'x-opencode-directory': directory } : {}) },
+              headers: { 'Cache-Control': 'no-cache', ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}) },
             });
             if (!response.ok) throw new Error('Failed to load snippets');
             const snippets: Snippet[] = await response.json();
@@ -97,7 +97,7 @@ export const useSnippetsStore = create<SnippetsStore>()(
           const queryParams = directory ? `?directory=${encodeURIComponent(directory)}` : '';
           const response = await runtimeFetch(`/api/config/snippets/${encodeURIComponent(name)}${queryParams}`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...(directory ? { 'x-opencode-directory': directory } : {}) },
+            headers: { 'Content-Type': 'application/json', ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}) },
             body: JSON.stringify({ content, aliases: options.aliases, description: options.description, scope: options.scope }),
           });
           if (!response.ok) {
@@ -122,7 +122,7 @@ export const useSnippetsStore = create<SnippetsStore>()(
           const queryParams = directory ? `?directory=${encodeURIComponent(directory)}` : '';
           const response = await runtimeFetch(`/api/config/snippets/${encodeURIComponent(name)}${queryParams}`, {
             method: 'PATCH',
-            headers: { 'Content-Type': 'application/json', ...(directory ? { 'x-opencode-directory': directory } : {}) },
+            headers: { 'Content-Type': 'application/json', ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}) },
             body: JSON.stringify(updates),
           });
           if (!response.ok) throw new Error((await response.json().catch(() => null))?.error || 'Failed to update snippet');
@@ -141,7 +141,7 @@ export const useSnippetsStore = create<SnippetsStore>()(
           const queryParams = directory ? `?directory=${encodeURIComponent(directory)}` : '';
           const response = await runtimeFetch(`/api/config/snippets/${encodeURIComponent(name)}${queryParams}`, {
             method: 'DELETE',
-            headers: directory ? { 'x-opencode-directory': directory } : undefined,
+            headers: directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : undefined,
           });
           if (!response.ok) throw new Error((await response.json().catch(() => null))?.error || 'Failed to delete snippet');
           if (get().selectedSnippetName === name) set({ selectedSnippetName: null });
@@ -160,7 +160,7 @@ export const useSnippetsStore = create<SnippetsStore>()(
         const queryParams = directory ? `?directory=${encodeURIComponent(directory)}` : '';
         const response = await runtimeFetch(`/api/config/snippets/expand${queryParams}`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...(directory ? { 'x-opencode-directory': directory } : {}) },
+          headers: { 'Content-Type': 'application/json', ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}) },
           body: JSON.stringify({ text }),
         });
         if (!response.ok) throw new Error((await response.json().catch(() => null))?.error || 'Failed to expand snippets');

--- a/packages/vscode/src/bridge-config-runtime.ts
+++ b/packages/vscode/src/bridge-config-runtime.ts
@@ -78,11 +78,13 @@ type ConfigRuntimeDeps = {
 const AGENTS_MD_PATH = path.join(os.homedir(), '.config', 'opencode', 'AGENTS.md');
 const MAX_BEHAVIOR_PROMPT_SIZE = 1024 * 1024;
 
-const resolveWorkingDirectory = (ctx: BridgeContext | undefined, directory?: string): string | undefined => (
-  (typeof directory === 'string' && directory.trim())
-    ? directory.trim()
-    : (ctx?.manager?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath)
-);
+const resolveWorkingDirectory = (ctx: BridgeContext | undefined, directory?: string): string | undefined => {
+  const decodedDirectory = (typeof directory === 'string' && directory.trim())
+    ? decodeURIComponent(directory.trim())
+    : undefined;
+  return decodedDirectory
+    || (ctx?.manager?.getWorkingDirectory() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath);
+};
 
 const pluginMutationPayload = async (
   ctx: BridgeContext | undefined,

--- a/packages/web/server/lib/opencode/project-directory-runtime.js
+++ b/packages/web/server/lib/opencode/project-directory-runtime.js
@@ -50,7 +50,8 @@ export const createProjectDirectoryRuntime = (dependencies) => {
   };
 
   const resolveProjectDirectory = async (req) => {
-    const headerDirectory = typeof req.get === 'function' ? req.get('x-opencode-directory') : null;
+    const rawHeaderDirectory = typeof req.get === 'function' ? req.get('x-opencode-directory') : null;
+    const headerDirectory = rawHeaderDirectory ? decodeURIComponent(rawHeaderDirectory) : null;
     const queryDirectory = Array.isArray(req.query?.directory)
       ? req.query.directory[0]
       : req.query?.directory;
@@ -103,7 +104,8 @@ export const createProjectDirectoryRuntime = (dependencies) => {
   };
 
   const resolveOptionalProjectDirectory = async (req) => {
-    const headerDirectory = typeof req.get === 'function' ? req.get('x-opencode-directory') : null;
+    const rawHeaderDirectory = typeof req.get === 'function' ? req.get('x-opencode-directory') : null;
+    const headerDirectory = rawHeaderDirectory ? decodeURIComponent(rawHeaderDirectory) : null;
     const queryDirectory = Array.isArray(req.query?.directory)
       ? req.query.directory[0]
       : req.query?.directory;

--- a/packages/web/server/lib/opencode/project-directory-runtime.test.js
+++ b/packages/web/server/lib/opencode/project-directory-runtime.test.js
@@ -128,6 +128,24 @@ describe('project directory runtime', () => {
       expect(result).toEqual({ directory: '/real/workspace/project', error: null });
     });
 
+    it('decodes percent-encoded Unicode paths in x-opencode-directory header', async () => {
+      const runtime = createTestRuntime({
+        fsPromises: {
+          stat: async () => ({ isDirectory: () => true }),
+          realpath: async () => '/real/中文路径',
+        },
+      });
+
+      const req = {
+        get: (header) => header === 'x-opencode-directory' ? encodeURIComponent('/home/user/中文路径') : null,
+        query: {},
+      };
+
+      const result = await runtime.resolveProjectDirectory(req);
+
+      expect(result).toEqual({ directory: '/real/中文路径', error: null });
+    });
+
     it('resolves symlinks in query directory parameter', async () => {
       const runtime = createTestRuntime({
         fsPromises: {

--- a/packages/web/server/lib/opencode/routes.js
+++ b/packages/web/server/lib/opencode/routes.js
@@ -346,10 +346,7 @@ export const registerOpenCodeRoutes = (app, dependencies) => {
       }
 
       const headerDirectory = typeof req.get === 'function' ? req.get('x-opencode-directory') : null;
-      const queryDirectory = Array.isArray(req.query?.directory)
-        ? req.query.directory[0]
-        : req.query?.directory;
-      const requestedDirectory = headerDirectory || queryDirectory || null;
+      const requestedDirectory = (headerDirectory ? decodeURIComponent(headerDirectory) : null) || queryDirectory || null;
 
       let directory = null;
       const resolved = await resolveProjectDirectory(req);
@@ -383,10 +380,7 @@ export const registerOpenCodeRoutes = (app, dependencies) => {
 
       const scope = typeof req.query?.scope === 'string' ? req.query.scope : 'auth';
       const headerDirectory = typeof req.get === 'function' ? req.get('x-opencode-directory') : null;
-      const queryDirectory = Array.isArray(req.query?.directory)
-        ? req.query.directory[0]
-        : req.query?.directory;
-      const requestedDirectory = headerDirectory || queryDirectory || null;
+      const requestedDirectory = (headerDirectory ? decodeURIComponent(headerDirectory) : null) || queryDirectory || null;
       let directory = null;
 
       if (scope === 'project' || requestedDirectory) {

--- a/packages/web/src/api/files.test.ts
+++ b/packages/web/src/api/files.test.ts
@@ -33,7 +33,7 @@ describe('createWebFilesAPI', () => {
     await api.statFile?.('/worktree-b/file.txt', { directory: '/worktree-a' });
 
     expect(runtimeFetchMock).toHaveBeenLastCalledWith('/api/fs/stat?path=%2Fworktree-b%2Ffile.txt', {
-      headers: { 'x-opencode-directory': '/worktree-a' },
+      headers: { 'x-opencode-directory': encodeURIComponent('/worktree-a') },
     });
 
     runtimeFetchMock.mockResolvedValueOnce(new Response('content'));
@@ -41,7 +41,19 @@ describe('createWebFilesAPI', () => {
 
     expect(runtimeFetchMock).toHaveBeenLastCalledWith('/api/fs/read?path=%2Fworktree-b%2Ffile.txt', {
       cache: 'default',
-      headers: { 'x-opencode-directory': '/worktree-a' },
+      headers: { 'x-opencode-directory': encodeURIComponent('/worktree-a') },
+    });
+  });
+
+  it('encodes Unicode workspace directory for header safety', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/stale-workspace' });
+
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ path: '/中文/file.txt', isFile: true, size: 12 }));
+    await api.statFile?.('/中文/file.txt', { directory: '/中文路径' });
+
+    expect(runtimeFetchMock).toHaveBeenLastCalledWith('/api/fs/stat?path=%2F%E4%B8%AD%E6%96%87%2Ffile.txt', {
+      headers: { 'x-opencode-directory': encodeURIComponent('/中文路径') },
     });
   });
 
@@ -54,7 +66,7 @@ describe('createWebFilesAPI', () => {
 
     expect(runtimeFetchMock).toHaveBeenLastCalledWith('/api/fs/raw', {
       query: { path: '/current-workspace/file.txt', download: true },
-      headers: { 'x-opencode-directory': '/current-workspace' },
+      headers: { 'x-opencode-directory': encodeURIComponent('/current-workspace') },
     });
   });
 });

--- a/packages/web/src/api/files.ts
+++ b/packages/web/src/api/files.ts
@@ -48,7 +48,7 @@ const toDirectoryListResult = (fallbackDirectory: string, payload: WebDirectoryL
 
 const directoryHeaders = (getDirectory?: () => string | undefined, override?: string): Record<string, string> | undefined => {
   const directory = override || getDirectory?.();
-  return directory ? { 'x-opencode-directory': directory } : undefined;
+  return directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : undefined;
 };
 
 export const createWebFilesAPI = ({ urls, getDirectory }: WebFilesAPIOptions): FilesAPI => ({


### PR DESCRIPTION
Fixes #1686

**Bug**
When the current working directory contains Unicode characters (e.g.  or ), any fetch that sends the  header throws:



This breaks the file-system view and any runtime fetch in non-ASCII project paths.

**Root cause**
 spec restricts header values to ISO-8859-1. We were passing the raw filesystem path (which can be arbitrary UTF-8) straight into the header, so the browser/runtime rightfully rejected it.

**What this PR does**
- **Client-side** – percent-encode the path with  before attaching it to .
- **Server-side** – decode the header with  so the rest of the pipeline still sees the real path.
- **Safety net** – add a guard in  that strips/disallows raw Unicode in the header and falls back to a safe encoded value.

**Files changed (12)**
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 

Tested locally with directories named , , and  — all resolve correctly now.