### PR TITLE
feat(sidebar): add toggle to hide subagent/delegated sessions

### DIFF
--- a/packages/ui/src/apps/MobileSessionsSheet.tsx
+++ b/packages/ui/src/apps/MobileSessionsSheet.tsx
@@ -45,6 +45,7 @@ import { PROJECT_COLOR_MAP, PROJECT_ICON_MAP, ProjectIconImage } from '@/lib/pro
 import { cn } from '@/lib/utils';
 import { listProjectWorktrees } from '@/lib/worktrees/worktreeManager';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
+import { useUIStore } from '@/stores/useUIStore';
 import { mergeLiveSessionWithGlobalSession, refreshGlobalSessions, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
 import { useMobileSessionExpansionStore } from '@/stores/useMobileSessionExpansionStore';
 import { useMobileSessionTreeStore } from '@/stores/useMobileSessionTreeStore';
@@ -531,6 +532,8 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   const worktreeExpandedMap = useMobileSessionTreeStore((state) => state.worktreeExpanded);
   const setProjectExpanded = useMobileSessionTreeStore((state) => state.setProjectExpanded);
   const setWorktreeExpanded = useMobileSessionTreeStore((state) => state.setWorktreeExpanded);
+  const showSubagentSessionsInSidebar = useUIStore((state) => state.showSubagentSessionsInSidebar);
+  const setShowSubagentSessionsInSidebar = useUIStore((state) => state.setShowSubagentSessionsInSidebar);
   const worktreeOrderByProject = useWorktreeOrderStore((state) => state.orderByProject);
   const expandedParents = useMobileSessionExpansionStore((state) => state.expandedParents);
   const toggleParent = useMobileSessionExpansionStore((state) => state.toggleParent);
@@ -753,11 +756,15 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   const renderBucketSessions = (node: ProjectNode, bucket: WorktreeBucket, indent: number) => {
     const bucketKey = `${node.project.id}::${bucket.key}`;
 
+    const effectiveSessions = showSubagentSessionsInSidebar
+      ? bucket.sessions
+      : bucket.sessions.filter((s) => !getParentId(s));
+
     // Group children by parent within this bucket, and treat sessions whose parent
     // is not in this bucket as top-level so nothing is hidden.
-    const idsInBucket = new Set(bucket.sessions.map((entry) => entry.id));
+    const idsInBucket = new Set(effectiveSessions.map((entry) => entry.id));
     const childrenByParent = new Map<string, Session[]>();
-    for (const candidate of bucket.sessions) {
+    for (const candidate of effectiveSessions) {
       const parentId = getParentId(candidate);
       if (parentId && idsInBucket.has(parentId)) {
         const list = childrenByParent.get(parentId) ?? [];
@@ -765,7 +772,7 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
         childrenByParent.set(parentId, list);
       }
     }
-    const roots = bucket.sessions.filter((entry) => {
+    const roots = effectiveSessions.filter((entry) => {
       const parentId = getParentId(entry);
       return !parentId || !idsInBucket.has(parentId);
     });
@@ -1030,6 +1037,27 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
             ) : null}
           </div>
         </div>
+
+        <div className="flex items-center gap-2 px-4 py-1.5">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={showSubagentSessionsInSidebar}
+            onClick={() => setShowSubagentSessionsInSidebar(!showSubagentSessionsInSidebar)}
+            className={cn("relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+              showSubagentSessionsInSidebar ? "bg-[var(--primary-base)]" : "bg-[var(--interactive-border)]"
+            )}
+          >
+            <span className={cn("pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transform ring-0 transition-transform",
+              showSubagentSessionsInSidebar ? "translate-x-4" : "translate-x-0"
+            )} />
+          </button>
+          <span className="text-xs text-muted-foreground select-none" onClick={() => setShowSubagentSessionsInSidebar(!showSubagentSessionsInSidebar)}>
+            {t('sidebar.subagent.toggleLabel')}
+          </span>
+        </div>
+
+
 
         <ScrollShadow className="min-h-0 flex-1 overflow-y-auto pb-4">
           {projectsMeta.length === 0 ? (

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -281,6 +281,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const showDeletionDialog = useUIStore((state) => state.showDeletionDialog);
   const setShowDeletionDialog = useUIStore((state) => state.setShowDeletionDialog);
   const showSubagentSessionsInSidebar = useUIStore((state) => state.showSubagentSessionsInSidebar);
+  const setShowSubagentSessionsInSidebar = useUIStore((state) => state.setShowSubagentSessionsInSidebar);
 
   const debouncedSessionSearchQuery = useDebouncedValue(sessionSearchQuery, 120);
   const normalizedSessionSearchQuery = React.useMemo(
@@ -1564,6 +1565,22 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         selectionModeEnabled={selectionModeEnabled}
         onToggleSelectionMode={handleToggleSelectionMode}
       />
+
+      <div className="flex items-center gap-2 px-3 py-1">
+        <label className="flex items-center gap-2 cursor-pointer" onClick={() => setShowSubagentSessionsInSidebar(!showSubagentSessionsInSidebar)}>
+          <div className={cn("h-4 w-7 rounded-full transition-colors duration-150 flex-shrink-0",
+            showSubagentSessionsInSidebar ? "bg-[var(--primary-base)]" : "bg-[var(--interactive-border)]"
+          )}>
+            <div className={cn("h-3.5 w-3.5 rounded-full bg-white transition-transform duration-150 mt-[1px]",
+              showSubagentSessionsInSidebar ? "translate-x-3.5" : "translate-x-0.5"
+            )} />
+          </div>
+          <span className="typography-caption text-muted-foreground select-none">
+            {t('sidebar.subagent.toggleLabel')}
+          </span>
+        </label>
+      </div>
+
 
       <SidebarProjectsList
         topContent={topContent}

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -280,6 +280,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const notifyOnSubtasks = useUIStore((state) => state.notifyOnSubtasks);
   const showDeletionDialog = useUIStore((state) => state.showDeletionDialog);
   const setShowDeletionDialog = useUIStore((state) => state.setShowDeletionDialog);
+  const showSubagentSessionsInSidebar = useUIStore((state) => state.showSubagentSessionsInSidebar);
 
   const debouncedSessionSearchQuery = useDebouncedValue(sessionSearchQuery, 120);
   const normalizedSessionSearchQuery = React.useMemo(
@@ -522,6 +523,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     worktreeMetadata,
     pinnedSessionIds,
     gitBranches,
+    showSubagentSessionsInSidebar,
     isVSCode,
   });
 

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
@@ -19,7 +19,8 @@ type Args = {
   pinnedSessionIds: Set<string>;
   gitBranches: Map<string, string | null>;
   isVSCode: boolean;
-};
+  showSubagentSessionsInSidebar: boolean;
+  };
 
 const isArchivedSession = (session: Session): boolean => Boolean(session.time?.archived);
 
@@ -70,9 +71,19 @@ export const useSessionGrouping = (args: Args) => {
       const sortedProjectSessions = dedupeSessionsById(projectSessions)
         .sort((a, b) => compareSessionsByPinnedAndTime(a, b, args.pinnedSessionIds));
 
-      const sessionMap = new Map(sortedProjectSessions.map((session) => [session.id, session]));
+      // Filter out subagent/delegated sessions (those with parentID) unless the
+      // user explicitly opts to show them. Subagent sessions are noise — the
+      // parent session contains the full context.
+      const effectiveSessions = args.showSubagentSessionsInSidebar
+        ? sortedProjectSessions
+        : sortedProjectSessions.filter((session) => {
+            const parentID = (session as Session & { parentID?: string | null }).parentID;
+            return !parentID;
+          });
+
+      const sessionMap = new Map(effectiveSessions.map((session) => [session.id, session]));
       const childrenMap = new Map<string, Session[]>();
-      sortedProjectSessions.forEach((session) => {
+      effectiveSessions.forEach((session) => {
         const parentID = (session as Session & { parentID?: string | null }).parentID;
         if (!parentID) return;
         const parentSession = sessionMap.get(parentID);
@@ -111,7 +122,7 @@ export const useSessionGrouping = (args: Args) => {
         return { session, children: children.map((child) => buildProjectNode(child)), worktree: getSessionWorktree(session) };
       };
 
-      const roots = sortedProjectSessions.filter((session) => {
+      const roots = effectiveSessions.filter((session) => {
         const parentID = (session as Session & { parentID?: string | null }).parentID;
         if (!parentID) return true;
         const parentSession = sessionMap.get(parentID);

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -103,6 +103,8 @@ export const dict = {
   'mobile.sessions.sheet.title': 'Sessions',
   'mobile.sessions.sheet.description': 'Switch projects, open sessions, or start a new chat.',
   'mobile.sessions.search.placeholder': 'Search sessions',
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   'mobile.sessions.empty': 'No sessions found.',
   'mobile.sessions.unassignedProject': 'Other sessions',
   'mobile.sessions.newSessionAria': 'Start a new session in this project',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2558,6 +2558,8 @@ export const dict: Record<I18nKey, string> = {
   "textarea.resizeHandleAria": "Ajustar textarea",
   "sidebar.resize.leftPanelAria": "Ajustar panel izquierdo",
   "sidebar.resize.rightPanelAria": "Ajustar panel derecho",
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   "mainLayout.mobile.closeDrawerAria": "Cerrar drawer",
   "sortableTabsStrip.aria.tabs": "Pestañas",
   "openChamberLogo.aria.logo": "Logo de OpenChamber",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -2558,6 +2558,8 @@ export const dict = {
   'mobile.settings.placeholder.description': 'Les paramètres mobiles ciblés de connexion et d’application seront ici.',
   'sessions.sidebar.header.displayMode.showArchived': 'Afficher les sessions archivées',
   'sessions.sidebar.group.showMore': 'Afficher plus de sessions',
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   'gitView.changes.revertDirectoryAria': 'Annuler les modifications dans {path}',
   'gitView.changes.revertDirectory': 'Annuler le dossier',
   'gitView.changes.revertDirectoryDescriptionPlural': 'Cela supprimera les modifications locales dans {count} fichiers sous {path}.',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2588,6 +2588,8 @@ export const dict: Record<I18nKey, string> = {
   'textarea.resizeHandleAria': 'テキストエリアのサイズを変更',
   'sidebar.resize.leftPanelAria': '左パネルのサイズを変更',
   'sidebar.resize.rightPanelAria': '右パネルのサイズを変更',
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   'mainLayout.mobile.closeDrawerAria': 'ドロワーを閉じる',
   'sortableTabsStrip.aria.tabs': 'タブ',
   'openChamberLogo.aria.logo': 'OpenChamberロゴ',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2592,6 +2592,8 @@ export const dict: Record<I18nKey, string> = {
   'textarea.resizeHandleAria': '텍스트 영역 크기 조정',
   'sidebar.resize.leftPanelAria': '왼쪽 패널 크기 조정',
   'sidebar.resize.rightPanelAria': '오른쪽 패널 크기 조정',
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   'mainLayout.mobile.closeDrawerAria': '드로어 닫기',
   'sortableTabsStrip.aria.tabs': '탭',
   'openChamberLogo.aria.logo': 'OpenChamber 로고',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2413,6 +2413,8 @@ export const dict: Record<I18nKey, string> = {
   'sessions.sidebar.folders.none': 'Brak folderów',
   'sidebar.resize.leftPanelAria': 'Zmień rozmiar lewego panelu',
   'sidebar.resize.rightPanelAria': 'Zmień rozmiar prawego panelu',
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   'sidebarFilesTree.actions.newFileTitle': 'Nowy plik',
   'sidebarFilesTree.actions.newFolderTitle': 'Nowy folder',
   'sidebarFilesTree.actions.refreshTitle': 'Odśwież',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2558,6 +2558,8 @@ export const dict: Record<I18nKey, string> = {
   "textarea.resizeHandleAria": "Ajustar área de texto",
   "sidebar.resize.leftPanelAria": "Ajustar painel esquerdo",
   "sidebar.resize.rightPanelAria": "Ajustar painel direito",
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   "mainLayout.mobile.closeDrawerAria": "Fechar gaveta",
   "sortableTabsStrip.aria.tabs": "Abas",
   "openChamberLogo.aria.logo": "Logo do OpenChamber",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2558,6 +2558,8 @@ export const dict: Record<I18nKey, string> = {
   "textarea.resizeHandleAria": "Змінити розмір текстового поля",
   "sidebar.resize.leftPanelAria": "Змінити розмір лівої панелі",
   "sidebar.resize.rightPanelAria": "Змінити розмір правої панелі",
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   "mainLayout.mobile.closeDrawerAria": "Закрити панель",
   "sortableTabsStrip.aria.tabs": "Вкладки",
   "openChamberLogo.aria.logo": "Логотип OpenChamber",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2558,6 +2558,8 @@ export const dict: Record<I18nKey, string> = {
   'textarea.resizeHandleAria': '调整文本区域大小',
   'sidebar.resize.leftPanelAria': '调整左侧面板大小',
   'sidebar.resize.rightPanelAria': '调整右侧面板大小',
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   'mainLayout.mobile.closeDrawerAria': '关闭抽屉',
   'sortableTabsStrip.aria.tabs': '标签页',
   'openChamberLogo.aria.logo': 'OpenChamber 标志',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2555,6 +2555,8 @@ export const dict: Record<I18nKey, string> = {
   'textarea.resizeHandleAria': '調整文字區域大小',
   'sidebar.resize.leftPanelAria': '調整左側面板大小',
   'sidebar.resize.rightPanelAria': '調整右側面板大小',
+  'sidebar.subagent.toggleLabel': 'Show subagent sessions',
+  'sidebar.subagent.toggleDescription': 'When off, only top-level sessions are shown in the sidebar.',
   'mainLayout.mobile.closeDrawerAria': '關閉抽屜',
   'sortableTabsStrip.aria.tabs': '分頁',
   'openChamberLogo.aria.logo': 'OpenChamber 標誌',

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -531,6 +531,7 @@ interface UIStore {
   todoPanelHeight: number;
   isSessionSwitcherOpen: boolean;
   isSessionDropdownOpen: boolean;
+  showSubagentSessionsInSidebar: boolean;
   activeMainTab: MainTab;
   mainTabGuard: MainTabGuard | null;
   sidebarOpenBeforeFullscreenTab: boolean | null;
@@ -676,6 +677,7 @@ interface UIStore {
   setTodoPanelHeight: (height: number) => void;
   setSessionSwitcherOpen: (open: boolean) => void;
   setSessionDropdownOpen: (open: boolean) => void;
+  setShowSubagentSessionsInSidebar: (show: boolean) => void;
   setActiveMainTab: (tab: MainTab) => void;
   prepareForRuntimeSwitch: (runtimeKey?: string | null) => void;
   restoreForRuntimeSwitch: (runtimeKey?: string | null) => void;
@@ -824,6 +826,7 @@ export const useUIStore = create<UIStore>()(
         todoPanelHeight: 259,
         isSessionSwitcherOpen: false,
         isSessionDropdownOpen: false,
+        showSubagentSessionsInSidebar: false,
         activeMainTab: 'chat',
         mainTabGuard: null,
         sidebarOpenBeforeFullscreenTab: null,
@@ -1381,6 +1384,13 @@ export const useUIStore = create<UIStore>()(
             return;
           }
           set({ isSessionDropdownOpen: open });
+        },
+
+        setShowSubagentSessionsInSidebar: (show) => {
+          if (get().showSubagentSessionsInSidebar === show) {
+            return;
+          }
+          set({ showSubagentSessionsInSidebar: show });
         },
 
         setMainTabGuard: (guard) => {


### PR DESCRIPTION
## Summary

Adds a user-preference toggle that hides subagent and delegated sessions (sessions with a parentID) from both the desktop sidebar and the mobile sessions sheet. When enabled, only top-level parent sessions are shown — the child sessions that contain delegated subtask execution are filtered out.

## Changes

- **useUIStore**: Added `showSubagentSessionsInSidebar` boolean state with `setShowSubagentSessionsInSidebar` setter, defaulting to `false` (subagent sessions hidden)
- **useSessionGrouping**: Filters out sessions with `parentID` when the setting is `false`, preventing child sessions from appearing anywhere in the project tree
- **MobileSessionsSheet**: Same filter applied — subagent sessions excluded from bucket rendering, with a toggle in the mobile sheet UI below the search bar
- **SessionSidebar**: Toggle switch added between the header and the projects list
- **i18n**: `sidebar.subagent.toggleLabel` and `sidebar.subagent.toggleDescription` keys added to all 10 locales

## Testing

- Setting defaults to `false` (subagents hidden) — matches existing behavior in the "Recent" section, session switcher, and tray sync which already filter out subtask sessions
- When toggled on, all sessions including subagents appear
- Mobile sessions sheet and desktop sidebar are both affected by the same setting