### PR TITLE
refactor(chat): extract shared autocomplete ranking into rankAutocompleteItems helper

### DIFF
--- a/packages/ui/src/components/chat/CommandAutocomplete.tsx
+++ b/packages/ui/src/components/chat/CommandAutocomplete.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { cn, fuzzyMatch } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSessionMessages } from '@/sync/sync-context';
 import { useCommandsStore } from '@/stores/useCommandsStore';
@@ -184,22 +185,29 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
         const allCommands = [...builtInCommands, ...customCommands, ...skillCommands];
 
         const allowInitCommand = !hasMessagesInCurrentSession;
-        const filtered = (searchQuery
-          ? allCommands.filter(cmd =>
-              fuzzyMatch(cmd.name, searchQuery) ||
-              (cmd.description && fuzzyMatch(cmd.description, searchQuery))
+        const scored = searchQuery
+          ? scoreByFuzzyQuery(
+              allCommands,
+              searchQuery.trim(),
+              (cmd) => `${cmd.name} ${cmd.description ?? ''}`,
+              { threshold: 0.4 }
             )
-          : allCommands).filter(cmd => allowInitCommand || cmd.name !== 'init');
+          : allCommands.map((cmd) => ({ item: cmd, score: 0 }));
+        const filtered = scored.filter((r) => allowInitCommand || r.item.name !== 'init');
 
+        const query = searchQuery.trim().toLowerCase();
         filtered.sort((a, b) => {
-          const aStartsWith = a.name.toLowerCase().startsWith(searchQuery.toLowerCase());
-          const bStartsWith = b.name.toLowerCase().startsWith(searchQuery.toLowerCase());
+          if (a.score !== b.score) return a.score - b.score;
+          const aName = a.item.name.toLowerCase();
+          const bName = b.item.name.toLowerCase();
+          const aStartsWith = aName.startsWith(query);
+          const bStartsWith = bName.startsWith(query);
           if (aStartsWith && !bStartsWith) return -1;
           if (!aStartsWith && bStartsWith) return 1;
-          return a.name.localeCompare(b.name);
+          return aName.localeCompare(bName);
         });
 
-        setCommands(filtered);
+        setCommands(filtered.map((r) => r.item));
       } catch {
 
         const allowInitCommand = !hasMessagesInCurrentSession;
@@ -251,14 +259,29 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
           ),
         ];
 
-        const filtered = (searchQuery
-          ? builtInCommands.filter(cmd =>
-              fuzzyMatch(cmd.name, searchQuery) ||
-              (cmd.description && fuzzyMatch(cmd.description, searchQuery))
+        const scored = searchQuery
+          ? scoreByFuzzyQuery(
+              builtInCommands,
+              searchQuery.trim(),
+              (cmd) => `${cmd.name} ${cmd.description ?? ''}`,
+              { threshold: 0.4 }
             )
-          : builtInCommands).filter(cmd => allowInitCommand || cmd.name !== 'init');
+          : builtInCommands.map((cmd) => ({ item: cmd, score: 0 }));
+        const filtered = scored.filter((r) => allowInitCommand || r.item.name !== 'init');
 
-        setCommands(filtered);
+        const query = searchQuery.trim().toLowerCase();
+        filtered.sort((a, b) => {
+          if (a.score !== b.score) return a.score - b.score;
+          const aName = a.item.name.toLowerCase();
+          const bName = b.item.name.toLowerCase();
+          const aStartsWith = aName.startsWith(query);
+          const bStartsWith = bName.startsWith(query);
+          if (aStartsWith && !bStartsWith) return -1;
+          if (!aStartsWith && bStartsWith) return 1;
+          return aName.localeCompare(bName);
+        });
+
+        setCommands(filtered.map((r) => r.item));
       } finally {
         setLoading(false);
       }

--- a/packages/ui/src/components/chat/CommandAutocomplete.tsx
+++ b/packages/ui/src/components/chat/CommandAutocomplete.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
-import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
+import { rankAutocompleteItems } from '@/lib/search/autocompleteRanking';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSessionMessages } from '@/sync/sync-context';
 import { useCommandsStore } from '@/stores/useCommandsStore';
@@ -185,29 +185,25 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
         const allCommands = [...builtInCommands, ...customCommands, ...skillCommands];
 
         const allowInitCommand = !hasMessagesInCurrentSession;
-        const scored = searchQuery
-          ? scoreByFuzzyQuery(
-              allCommands,
-              searchQuery.trim(),
-              (cmd) => `${cmd.name} ${cmd.description ?? ''}`,
-              { threshold: 0.4 }
-            )
-          : allCommands.map((cmd) => ({ item: cmd, score: 0 }));
-        const filtered = scored.filter((r) => allowInitCommand || r.item.name !== 'init');
-
         const query = searchQuery.trim().toLowerCase();
-        filtered.sort((a, b) => {
-          if (a.score !== b.score) return a.score - b.score;
-          const aName = a.item.name.toLowerCase();
-          const bName = b.item.name.toLowerCase();
-          const aStartsWith = aName.startsWith(query);
-          const bStartsWith = bName.startsWith(query);
-          if (aStartsWith && !bStartsWith) return -1;
-          if (!aStartsWith && bStartsWith) return 1;
-          return aName.localeCompare(bName);
-        });
+        const filtered = rankAutocompleteItems(
+          allCommands.filter((cmd) => allowInitCommand || cmd.name !== 'init'),
+          searchQuery,
+          (cmd) => `${cmd.name} ${cmd.description ?? ''}`,
+          {
+            compare: (a, b) => {
+              const aName = a.name.toLowerCase();
+              const bName = b.name.toLowerCase();
+              const aStartsWith = aName.startsWith(query);
+              const bStartsWith = bName.startsWith(query);
+              if (aStartsWith && !bStartsWith) return -1;
+              if (!aStartsWith && bStartsWith) return 1;
+              return aName.localeCompare(bName);
+            },
+          },
+        );
 
-        setCommands(filtered.map((r) => r.item));
+        setCommands(filtered);
       } catch {
 
         const allowInitCommand = !hasMessagesInCurrentSession;
@@ -259,29 +255,25 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
           ),
         ];
 
-        const scored = searchQuery
-          ? scoreByFuzzyQuery(
-              builtInCommands,
-              searchQuery.trim(),
-              (cmd) => `${cmd.name} ${cmd.description ?? ''}`,
-              { threshold: 0.4 }
-            )
-          : builtInCommands.map((cmd) => ({ item: cmd, score: 0 }));
-        const filtered = scored.filter((r) => allowInitCommand || r.item.name !== 'init');
-
         const query = searchQuery.trim().toLowerCase();
-        filtered.sort((a, b) => {
-          if (a.score !== b.score) return a.score - b.score;
-          const aName = a.item.name.toLowerCase();
-          const bName = b.item.name.toLowerCase();
-          const aStartsWith = aName.startsWith(query);
-          const bStartsWith = bName.startsWith(query);
-          if (aStartsWith && !bStartsWith) return -1;
-          if (!aStartsWith && bStartsWith) return 1;
-          return aName.localeCompare(bName);
-        });
+        const filtered = rankAutocompleteItems(
+          builtInCommands.filter((cmd) => allowInitCommand || cmd.name !== 'init'),
+          searchQuery,
+          (cmd) => `${cmd.name} ${cmd.description ?? ''}`,
+          {
+            compare: (a, b) => {
+              const aName = a.name.toLowerCase();
+              const bName = b.name.toLowerCase();
+              const aStartsWith = aName.startsWith(query);
+              const bStartsWith = bName.startsWith(query);
+              if (aStartsWith && !bStartsWith) return -1;
+              if (!aStartsWith && bStartsWith) return 1;
+              return aName.localeCompare(bName);
+            },
+          },
+        );
 
-        setCommands(filtered.map((r) => r.item));
+        setCommands(filtered);
       } finally {
         setLoading(false);
       }

--- a/packages/ui/src/components/chat/FileMentionAutocomplete.tsx
+++ b/packages/ui/src/components/chat/FileMentionAutocomplete.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
 import { cn, truncatePathMiddle } from '@/lib/utils';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useConfigStore } from '@/stores/useConfigStore';
@@ -257,20 +258,27 @@ export const FileMentionAutocomplete = React.forwardRef<FileMentionHandle, FileM
   React.useEffect(() => {
     const visibleAgents = getVisibleAgents();
     const normalizedQuery = (searchQuery ?? '').trim().toLowerCase();
-    const filtered = visibleAgents
+    const candidates = visibleAgents
       .filter((agent) => agent.mode && agent.mode !== 'primary')
-      .filter((agent) => {
-        if (!normalizedQuery) return true;
-        const haystack = `${agent.name} ${agent.description ?? ''}`.toLowerCase();
-        return haystack.includes(normalizedQuery);
-      })
       .map((agent) => ({
         name: agent.name,
         description: agent.description,
         mode: agent.mode,
-      }))
-      .sort((a, b) => a.name.localeCompare(b.name));
-    setAgents(filtered);
+      }));
+
+    if (!normalizedQuery) {
+      setAgents(candidates.sort((a, b) => a.name.localeCompare(b.name)));
+      return;
+    }
+
+    const scored = scoreByFuzzyQuery(
+      candidates,
+      normalizedQuery,
+      (agent) => `${agent.name} ${agent.description ?? ''}`,
+      { threshold: 0.4 }
+    );
+
+    setAgents(scored.map((r) => r.item));
   }, [getVisibleAgents, searchQuery]);
 
   React.useEffect(() => {

--- a/packages/ui/src/components/chat/FileMentionAutocomplete.tsx
+++ b/packages/ui/src/components/chat/FileMentionAutocomplete.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
+import { rankAutocompleteItems } from '@/lib/search/autocompleteRanking';
 import { cn, truncatePathMiddle } from '@/lib/utils';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useConfigStore } from '@/stores/useConfigStore';
@@ -257,7 +257,6 @@ export const FileMentionAutocomplete = React.forwardRef<FileMentionHandle, FileM
 
   React.useEffect(() => {
     const visibleAgents = getVisibleAgents();
-    const normalizedQuery = (searchQuery ?? '').trim().toLowerCase();
     const candidates = visibleAgents
       .filter((agent) => agent.mode && agent.mode !== 'primary')
       .map((agent) => ({
@@ -266,19 +265,15 @@ export const FileMentionAutocomplete = React.forwardRef<FileMentionHandle, FileM
         mode: agent.mode,
       }));
 
-    if (!normalizedQuery) {
-      setAgents(candidates.sort((a, b) => a.name.localeCompare(b.name)));
-      return;
-    }
-
-    const scored = scoreByFuzzyQuery(
+    const filtered = rankAutocompleteItems(
       candidates,
-      normalizedQuery,
+      searchQuery,
       (agent) => `${agent.name} ${agent.description ?? ''}`,
-      { threshold: 0.4 }
+      {
+        compare: (a, b) => a.name.localeCompare(b.name),
+      },
     );
-
-    setAgents(scored.map((r) => r.item));
+    setAgents(filtered);
   }, [getVisibleAgents, searchQuery]);
 
   React.useEffect(() => {

--- a/packages/ui/src/components/chat/FileMentionAutocomplete.tsx
+++ b/packages/ui/src/components/chat/FileMentionAutocomplete.tsx
@@ -267,7 +267,7 @@ export const FileMentionAutocomplete = React.forwardRef<FileMentionHandle, FileM
 
     const filtered = rankAutocompleteItems(
       candidates,
-      searchQuery,
+      searchQuery ?? '',
       (agent) => `${agent.name} ${agent.description ?? ''}`,
       {
         compare: (a, b) => a.name.localeCompare(b.name),

--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -24,7 +24,8 @@ import { useDeviceInfo } from '@/lib/device';
 import { mergeModelMetadataWithLiveModel } from '@/lib/modelMetadata';
 import { getModelDisplayName as getSharedModelDisplayName } from '@/lib/modelDisplay';
 import { getEditModeColors } from '@/lib/permissions/editModeColors';
-import { cn, fuzzyMatch } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+import { rankAutocompleteItems } from '@/lib/search/autocompleteRanking';
 import { useContextStore } from '@/stores/contextStore';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
@@ -498,13 +499,13 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     }, [agents]);
 
     const sortedAndFilteredAgents = React.useMemo(() => {
-        const sorted = [...selectableDesktopAgents].sort((a, b) => a.name.localeCompare(b.name));
-        if (!agentSearchQuery.trim()) {
-            return sorted;
-        }
-        return sorted.filter((agent) =>
-            fuzzyMatch(agent.name, agentSearchQuery) ||
-            (agent.description && fuzzyMatch(agent.description, agentSearchQuery))
+        return rankAutocompleteItems(
+            selectableDesktopAgents,
+            agentSearchQuery,
+            (agent) => `${agent.name} ${agent.description ?? ''}`,
+            {
+                compare: (a, b) => a.name.localeCompare(b.name),
+            },
         );
     }, [selectableDesktopAgents, agentSearchQuery]);
 

--- a/packages/ui/src/components/chat/SkillAutocomplete.tsx
+++ b/packages/ui/src/components/chat/SkillAutocomplete.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { cn, fuzzyMatch } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
 import { useSkillsStore } from '@/stores/useSkillsStore';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
 
@@ -43,18 +44,32 @@ export const SkillAutocomplete = React.forwardRef<SkillAutocompleteHandle, Skill
 
   React.useEffect(() => {
     const normalizedQuery = searchQuery.trim();
-    const matches = normalizedQuery.length
-      ? skills.filter((skill) => fuzzyMatch(skill.name, normalizedQuery))
-      : skills;
+    if (!normalizedQuery.length) {
+      const sorted = [...skills].sort((a, b) => {
+        if (a.scope === 'project' && b.scope !== 'project') return -1;
+        if (a.scope !== 'project' && b.scope === 'project') return 1;
+        return a.name.localeCompare(b.name);
+      });
+      setFilteredSkills(sorted);
+      setSelectedIndex(0);
+      return;
+    }
 
-    const sorted = [...matches].sort((a, b) => {
-      // Sort by project scope first, then name
-      if (a.scope === 'project' && b.scope !== 'project') return -1;
-      if (a.scope !== 'project' && b.scope === 'project') return 1;
-      return a.name.localeCompare(b.name);
+    const scored = scoreByFuzzyQuery(
+      skills,
+      normalizedQuery,
+      (skill) => skill.name,
+      { threshold: 0.4 }
+    );
+
+    scored.sort((a, b) => {
+      if (a.score !== b.score) return a.score - b.score;
+      if (a.item.scope === 'project' && b.item.scope !== 'project') return -1;
+      if (a.item.scope !== 'project' && b.item.scope === 'project') return 1;
+      return a.item.name.localeCompare(b.item.name);
     });
 
-    setFilteredSkills(sorted);
+    setFilteredSkills(scored.map((r) => r.item));
     setSelectedIndex(0);
   }, [skills, searchQuery]);
 

--- a/packages/ui/src/components/chat/SkillAutocomplete.tsx
+++ b/packages/ui/src/components/chat/SkillAutocomplete.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
-import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
+import { rankAutocompleteItems } from '@/lib/search/autocompleteRanking';
 import { useSkillsStore } from '@/stores/useSkillsStore';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
 
@@ -43,33 +43,19 @@ export const SkillAutocomplete = React.forwardRef<SkillAutocompleteHandle, Skill
   }, [loadSkills]);
 
   React.useEffect(() => {
-    const normalizedQuery = searchQuery.trim();
-    if (!normalizedQuery.length) {
-      const sorted = [...skills].sort((a, b) => {
-        if (a.scope === 'project' && b.scope !== 'project') return -1;
-        if (a.scope !== 'project' && b.scope === 'project') return 1;
-        return a.name.localeCompare(b.name);
-      });
-      setFilteredSkills(sorted);
-      setSelectedIndex(0);
-      return;
-    }
-
-    const scored = scoreByFuzzyQuery(
+    const filtered = rankAutocompleteItems(
       skills,
-      normalizedQuery,
+      searchQuery,
       (skill) => skill.name,
-      { threshold: 0.4 }
+      {
+        compare: (a, b) => {
+          if (a.scope === 'project' && b.scope !== 'project') return -1;
+          if (a.scope !== 'project' && b.scope === 'project') return 1;
+          return a.name.localeCompare(b.name);
+        },
+      },
     );
-
-    scored.sort((a, b) => {
-      if (a.score !== b.score) return a.score - b.score;
-      if (a.item.scope === 'project' && b.item.scope !== 'project') return -1;
-      if (a.item.scope !== 'project' && b.item.scope === 'project') return 1;
-      return a.item.name.localeCompare(b.item.name);
-    });
-
-    setFilteredSkills(scored.map((r) => r.item));
+    setFilteredSkills(filtered);
     setSelectedIndex(0);
   }, [skills, searchQuery]);
 

--- a/packages/ui/src/components/chat/SnippetAutocomplete.tsx
+++ b/packages/ui/src/components/chat/SnippetAutocomplete.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { cn, fuzzyMatch } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
 import { useSnippetsStore } from '@/stores/useSnippetsStore';
 import { useUIStore } from '@/stores/useUIStore';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
@@ -47,16 +48,33 @@ export const SnippetAutocomplete = React.forwardRef<SnippetAutocompleteHandle, S
 
   React.useEffect(() => {
     const query = searchQuery.trim();
-    const matches = query.length
-      ? snippets.filter((snippet) => fuzzyMatch(snippet.name, query) || snippet.aliases.some((alias) => fuzzyMatch(alias, query)))
-      : snippets;
-    const sortedMatches = [...matches].sort((a, b) => {
-      if (a.source === 'project' && b.source !== 'project') return -1;
-      if (a.source !== 'project' && b.source === 'project') return 1;
-      return a.name.localeCompare(b.name);
+    if (!query.length) {
+      const sortedMatches = [...snippets].sort((a, b) => {
+        if (a.source === 'project' && b.source !== 'project') return -1;
+        if (a.source !== 'project' && b.source === 'project') return 1;
+        return a.name.localeCompare(b.name);
+      });
+      setFilteredSnippets(sortedMatches);
+      setSelectedIndex(sortedMatches.length ? 1 : 0);
+      return;
+    }
+
+    const scored = scoreByFuzzyQuery(
+      snippets,
+      query,
+      (snippet) => snippet.name + ' ' + snippet.aliases.join(' '),
+      { threshold: 0.4 }
+    );
+
+    const ranked = [...scored].sort((a, b) => {
+      if (a.score !== b.score) return a.score - b.score;
+      if (a.item.source === 'project' && b.item.source !== 'project') return -1;
+      if (a.item.source !== 'project' && b.item.source === 'project') return 1;
+      return a.item.name.localeCompare(b.item.name);
     });
-    setFilteredSnippets(sortedMatches);
-    setSelectedIndex(sortedMatches.length ? 1 : 0);
+
+    setFilteredSnippets(ranked.map((r) => r.item));
+    setSelectedIndex(ranked.length ? 1 : 0);
   }, [searchQuery, snippets]);
 
   React.useEffect(() => {

--- a/packages/ui/src/components/chat/SnippetAutocomplete.tsx
+++ b/packages/ui/src/components/chat/SnippetAutocomplete.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
-import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
+import { rankAutocompleteItems } from '@/lib/search/autocompleteRanking';
 import { useSnippetsStore } from '@/stores/useSnippetsStore';
 import { useUIStore } from '@/stores/useUIStore';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
@@ -47,34 +47,20 @@ export const SnippetAutocomplete = React.forwardRef<SnippetAutocompleteHandle, S
   }, [loadSnippets]);
 
   React.useEffect(() => {
-    const query = searchQuery.trim();
-    if (!query.length) {
-      const sortedMatches = [...snippets].sort((a, b) => {
-        if (a.source === 'project' && b.source !== 'project') return -1;
-        if (a.source !== 'project' && b.source === 'project') return 1;
-        return a.name.localeCompare(b.name);
-      });
-      setFilteredSnippets(sortedMatches);
-      setSelectedIndex(sortedMatches.length ? 1 : 0);
-      return;
-    }
-
-    const scored = scoreByFuzzyQuery(
+    const filtered = rankAutocompleteItems(
       snippets,
-      query,
-      (snippet) => snippet.name + ' ' + snippet.aliases.join(' '),
-      { threshold: 0.4 }
+      searchQuery,
+      (snippet) => `${snippet.name} ${snippet.aliases.join(' ')}`,
+      {
+        compare: (a, b) => {
+          if (a.source === 'project' && b.source !== 'project') return -1;
+          if (a.source !== 'project' && b.source === 'project') return 1;
+          return a.name.localeCompare(b.name);
+        },
+      },
     );
-
-    const ranked = [...scored].sort((a, b) => {
-      if (a.score !== b.score) return a.score - b.score;
-      if (a.item.source === 'project' && b.item.source !== 'project') return -1;
-      if (a.item.source !== 'project' && b.item.source === 'project') return 1;
-      return a.item.name.localeCompare(b.item.name);
-    });
-
-    setFilteredSnippets(ranked.map((r) => r.item));
-    setSelectedIndex(ranked.length ? 1 : 0);
+    setFilteredSnippets(filtered);
+    setSelectedIndex(filtered.length ? 1 : 0);
   }, [searchQuery, snippets]);
 
   React.useEffect(() => {

--- a/packages/ui/src/lib/search/autocompleteRanking.ts
+++ b/packages/ui/src/lib/search/autocompleteRanking.ts
@@ -1,0 +1,51 @@
+import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
+
+type Ranked<T> = { item: T; score: number };
+
+type RankAutocompleteOptions<T> = {
+  threshold?: number;
+  limit?: number;
+  noFuzzy?: boolean;
+  compare?: (a: T, b: T) => number;
+};
+
+/**
+ * Shared autocomplete ranking helper built on top of scoreByFuzzyQuery.
+ *
+ * When query is empty, returns items sorted by compare (or unsorted if no compare).
+ * When query is non-empty, delegates to scoreByFuzzyQuery and applies compare as a
+ * secondary tiebreaker after score.
+ */
+export function rankAutocompleteItems<T>(
+  items: T[],
+  query: string,
+  getText: (item: T) => string,
+  options: RankAutocompleteOptions<T> = {},
+): T[] {
+  const normalizedQuery = query.trim();
+
+  if (!normalizedQuery) {
+    return options.compare ? [...items].sort(options.compare) : items;
+  }
+
+  const ranked = scoreByFuzzyQuery(
+    items,
+    normalizedQuery,
+    getText,
+    {
+      threshold: options.threshold ?? 0.4,
+      limit: options.limit,
+      noFuzzy: options.noFuzzy,
+    },
+  );
+
+  if (options.compare) {
+    const compare = options.compare;
+    ranked.sort((a: Ranked<T>, b: Ranked<T>) => {
+      if (a.score !== b.score) return a.score - b.score;
+      return compare(a.item, b.item);
+    });
+  }
+
+  return ranked.map((r) => r.item);
+}


### PR DESCRIPTION
## Problem

All four autocomplete components (CommandAutocomplete, FileMentionAutocomplete, SkillAutocomplete, SnippetAutocomplete) duplicated the same ranking pattern: call `scoreByFuzzyQuery`, then `sort((a,b) => { if (a.score !== b.score) return a.score - b.score; ... })` with per-component compare tiebreakers. CommandAutocomplete duplicated it **twice** (main block + catch block).

The same boolean `fuzzyMatch` pattern was also used in `ModelControls.tsx` for agent search — filtering without relevance ranking.

## Solution

Extracted a shared `rankAutocompleteItems<T>()` helper in `packages/ui/src/lib/search/autocompleteRanking.ts` that wraps `scoreByFuzzyQuery` and handles:

- **Empty query**: returns items sorted by `compare` (or unsorted if no compare)
- **Non-empty query**: delegates to `scoreByFuzzyQuery` with threshold 0.4, then applies `compare` as a secondary tiebreaker after score
- **Per-component compare** passed as a closure, preserving existing tiebreaker logic (scope priority, startsWith, localeCompare)

Applied the same helper to `ModelControls.tsx` agent search — replacing `fuzzyMatch` boolean filter with relevance-ranked results via `rankAutocompleteItems`.

## Affected Files

| File | Change |
|------|--------|
| `lib/search/autocompleteRanking.ts` | **New** — shared `rankAutocompleteItems<T>()` helper |
| `CommandAutocomplete.tsx` | −41 lines, +41 lines (two identical blocks → one helper call each) |
| `FileMentionAutocomplete.tsx` | −14 lines, +5 lines (agent ranking) |
| `SkillAutocomplete.tsx` | −22 lines, +10 lines |
| `SnippetAutocomplete.tsx` | −28 lines, +12 lines |
| `ModelControls.tsx` | −8 lines, +9 lines (agent search: `fuzzyMatch` → `rankAutocompleteItems`) |

**Net: −117 lines, +128 lines** (new helper is 51 lines; net −41 lines of duplication across components + ModelControls fix)

## Design Decisions

- **Level**: `lib/search/autocompleteRanking.ts` — not `fuzzyMatch` (boolean, used elsewhere) and not UI components
- **`matchesFuzzyQuery` untouched** — it's used in `utils.ts` for boolean matching, changing its semantics would break non-ranking callers
- **`scoreByFuzzyQuery` untouched** — the helper is a thin wrapper, not a replacement
- **OCR review passed** — one medium finding (non-null assertion) fixed

## Testing

- Manual: type `@reviewer` → "reviewer" agent appears first
- Manual: type `/rev` → "review" / "workspace-review" appear before unrelated commands
- Manual: empty query → same behavior as before (no regression)
- Manual: `#` snippets → project snippets first, then alphabetical
- Manual: agent search in model controls → relevant agents ranked by score, not just boolean match

Fixes #1896