### PR TITLE
fix: suppress KaTeX font path warnings in Vite build

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -15,6 +15,17 @@ const enableReactScan = reactScanToggle === '1' || reactScanToggle === 'true' ||
 export default defineConfig({
   root: path.resolve(__dirname, '.'),
   plugins: [
+    {
+      name: 'suppress-katex-warnings',
+      enforce: 'post',
+      configResolved(config) {
+        const origWarn = config.logger.warn;
+        config.logger.warn = (msg, options) => {
+          if (typeof msg === 'string' && msg.includes('fonts/KaTeX_')) return;
+          origWarn(msg, options);
+        };
+      },
+    },
     react({
       babel: {
         plugins: ['babel-plugin-react-compiler'],


### PR DESCRIPTION
Closes #1883

Adds \suppress-katex-warnings\ Vite plugin to filter 9 warnings about KaTeX font paths during \ite build\.

\packages/web/vite.config.ts\ — inline plugin using \configResolved\ hook to intercept \logger.warn\ and skip messages containing \onts/KaTeX_\.

Fonts already resolve correctly at runtime (Chromium resolves them from the bundled location). This change only cleans up build output noise.