### PR TITLE
fix: suppress Rollup eval warnings from onnxruntime-web dependency

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -101,6 +101,10 @@ export default defineConfig({
     emptyOutDir: true,
     chunkSizeWarningLimit: 500,
     rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.message?.includes('onnxruntime-web') || warning.message?.includes('eval in')) return;
+        warn(warning);
+      },
       input: {
         main: path.resolve(__dirname, 'index.html'),
         mobile: path.resolve(__dirname, 'mobile.html'),


### PR DESCRIPTION
Closes #1885

Adds \uild.rollupOptions.onwarn\ handler to \packages/web/vite.config.ts\ that filters Rollup warnings containing \onnxruntime-web\ or \eval in\.

The eval() usage is in onnxruntime-web's WASM compilation fallback path (transitive dependency via @xenova/transformers). No functional impact — this only cleans up build output noise.