### PR TITLE
fix: load KaTeX CSS via JS import to resolve font file paths correctly

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -3,12 +3,9 @@
 @import "./styles/design-system.css";
 @import "./styles/typography.css";
 @import "./styles/mobile.css";
-/* Load KaTeX styles eagerly with the main bundle. Importing them inside the
-   lazy MarkdownRendererImpl chunk meant a stylesheet was injected late on the
-   first markdown render of a session; that late injection triggered a style
-   recalc during which the layered `.chat-message-column` width clamp briefly
-   lost, flashing message text to full width before it snapped back. */
-@import "katex/dist/katex.min.css";
+/* KaTeX CSS is now imported via JS entry points (katex-css.ts) so that
+   Vite's JS-import pipeline correctly resolves the font file URLs and
+   copies the .woff2 files to the build output. See katex-css.ts. */
 @source "./**/*.{ts,tsx,css}";
 
 /* KaTeX theme overrides for light/dark mode */

--- a/packages/ui/src/styles/katex-css.ts
+++ b/packages/ui/src/styles/katex-css.ts
@@ -1,0 +1,1 @@
+import 'katex/dist/katex.min.css';

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -6,6 +6,7 @@ import { getStoredMobileLayoutPreference } from '@openchamber/ui/lib/mobileLayou
 import type { HostedSurface } from '@openchamber/ui/lib/runtimeSurface';
 import '@openchamber/ui/index.css';
 import '@openchamber/ui/styles/fonts';
+import '@openchamber/ui/styles/katex-css';
 
 declare global {
   interface Window {

--- a/packages/web/src/mini-chat-main.tsx
+++ b/packages/web/src/mini-chat-main.tsx
@@ -2,6 +2,7 @@ import { createConfiguredWebAPIs } from './runtimeConfig';
 import type { RuntimeAPIs } from '@openchamber/ui/lib/api/types';
 import '@openchamber/ui/index.css';
 import '@openchamber/ui/styles/fonts';
+import '@openchamber/ui/styles/katex-css';
 
 declare global {
   interface Window {

--- a/packages/web/src/mobile-main.tsx
+++ b/packages/web/src/mobile-main.tsx
@@ -2,6 +2,7 @@ import { createConfiguredWebAPIs } from './runtimeConfig';
 import type { RuntimeAPIs } from '@openchamber/ui/lib/api/types';
 import '@openchamber/ui/index.css';
 import '@openchamber/ui/styles/fonts';
+import '@openchamber/ui/styles/katex-css';
 
 declare global {
   interface Window {


### PR DESCRIPTION
Closes #1880

## Root cause

KaTeX CSS was loaded via CSS `@import` in `packages/ui/src/index.css`. Lightning CSS inlines the CSS content but does not resolve relative `url(fonts/...)` references to KaTeX font files, causing 404s at runtime and fallback to upright (roman) font.

## Fix

1. Remove `@import "katex/dist/katex.min.css"` from `packages/ui/src/index.css`
2. Create `packages/ui/src/styles/katex-css.ts` with a JS import of the KaTeX CSS
3. Import it from all three app entry points (`main.tsx`, `mobile-main.tsx`, `mini-chat-main.tsx`)

This ensures Vite's JS-import pipeline correctly resolves the font file URLs (copies `.woff2` to `dist/assets/` and rewrites URLs), while keeping the CSS loaded eagerly with the main bundle.
