### PR TITLE
fix(model-picker): scroll to and expand the selected model on open in Settings

### DIFF
--- a/packages/ui/src/components/model-picker/ModelPickerList.tsx
+++ b/packages/ui/src/components/model-picker/ModelPickerList.tsx
@@ -365,6 +365,17 @@ interface ModelPickerListProps {
   footerContent?: React.ReactNode | ((activeEntry: ModelPickerEntry | undefined) => React.ReactNode);
   renderVersion?: number;
   tooltipsEnabled?: boolean;
+  /**
+   * When the picker opens (and `selectedModel` is set), auto-expand the
+   * selected model's provider section if it is collapsed, seed keyboard
+   * selection at that row, and scroll it into view. Default: false.
+   *
+   * Intended for configuration surfaces (e.g. Settings → Agents) where the
+   * user needs to confirm the currently configured model. Quick-switch
+   * surfaces (chat) usually want to browse other models, so they leave this
+   * off.
+   */
+  scrollToSelectedOnOpen?: boolean;
 }
 
 export const ModelPickerList: React.FC<ModelPickerListProps> = ({
@@ -405,6 +416,7 @@ export const ModelPickerList: React.FC<ModelPickerListProps> = ({
   footerContent,
   renderVersion,
   tooltipsEnabled = true,
+  scrollToSelectedOnOpen = false,
 }) => {
   const selectionStoreRef = React.useRef<IndexSelectionStore | null>(null);
   if (!selectionStoreRef.current) selectionStoreRef.current = createIndexSelectionStore();
@@ -504,6 +516,37 @@ export const ModelPickerList: React.FC<ModelPickerListProps> = ({
   React.useEffect(() => {
     selectionStore.set(0);
   }, [searchQuery, selectionStore]);
+
+  // On open, if a model is selected and `scrollToSelectedOnOpen` is enabled,
+  // expand its provider section when collapsed, seed keyboard selection at
+  // that row, and scroll it into view. Runs once per mount/open unless the
+  // selected model itself changes before the user types a search query.
+  const didInitialScrollRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!scrollToSelectedOnOpen) return;
+    if (!selectedModel || !selectedModel.providerID || !selectedModel.modelID) return;
+    // Typing a search query is an explicit browse intent; don't fight it.
+    if (searchQuery.trim().length > 0) return;
+    if (didInitialScrollRef.current) return;
+
+    const providerSectionKey = `provider:${selectedModel.providerID}`;
+    if (collapsedSections.has(providerSectionKey)) {
+      toggleSection(providerSectionKey);
+    }
+
+    const selectedIndex = flatModelList.findIndex(
+      (entry) => entry.providerID === selectedModel.providerID && entry.modelID === selectedModel.modelID,
+    );
+    if (selectedIndex === -1) return;
+
+    selectionStore.set(selectedIndex);
+    didInitialScrollRef.current = true;
+
+    // Defer the scroll until the (possibly just-expanded) rows have been
+    // committed to the DOM, otherwise `itemRefs` for the newly visible row
+    // may still be null.
+    requestAnimationFrame(() => scrollIntoView(scrollRef.current, itemRefs.current[selectedIndex]));
+  }, [scrollToSelectedOnOpen, selectedModel, flatModelList, collapsedSections, toggleSection, searchQuery, selectionStore]);
 
   const selectIndex = React.useCallback((index: number) => {
     selectionStore.set(index);

--- a/packages/ui/src/components/sections/agents/ModelSelector.tsx
+++ b/packages/ui/src/components/sections/agents/ModelSelector.tsx
@@ -112,6 +112,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             tooltipsEnabled={tooltipsEnabled && (isActuallyMobile ? isMobilePanelOpen : isDropdownOpen)}
             isFavorite={(entry) => isFavoriteModel(entry.providerID, entry.modelID)}
             onToggleFavorite={(entry) => toggleFavoriteModel(entry.providerID, entry.modelID)}
+            scrollToSelectedOnOpen
         />
     );
 


### PR DESCRIPTION
## Summary

The model picker dropdown in Settings → Agents now seeds keyboard selection at the currently configured model, expands its provider section when collapsed, and scrolls the row into view. The chat quick-switch picker keeps the existing top-of-list behavior.

Fixes #1906.

## Problem

When opening the model picker dropdown, the list scrolled to the top and `selectionStore` always started at index 0. If the selected model lived inside a collapsed provider section, that section stayed collapsed and the user had to manually find and expand it to confirm the configured model.

Root cause (`packages/ui/src/components/model-picker/ModelPickerList.tsx`):
- `createIndexSelectionStore` initialized `value = 0`; the only `selectionStore.set(0)` was tied to `searchQuery` changes — nothing pointed the store at the selected model's index.
- `scrollIntoView` was only invoked from `moveSelection` (keyboard nav); no effect scrolled to the selected model on open.
- `flatModelList` excluded collapsed `provider:*` sections, so a selected model inside a collapsed section was invisible and unreachable without manual expansion.

## Change

- Added opt-in prop `scrollToSelectedOnOpen` (default `false`) on `ModelPickerList`.
- Added a `useEffect` that, on open, when `selectedModel` is set and no search query is active: expands the selected model's `provider:<id>` section via `toggleSection` if collapsed, finds the row index in `flatModelList`, seeds `selectionStore` to that index, and scrolls it into view via `requestAnimationFrame` (so the just-expanded row has been committed to the DOM first).
- Enabled `scrollToSelectedOnOpen` in `packages/ui/src/components/sections/agents/ModelSelector.tsx` (Settings → Agents), where confirming the configured model matters.
- Left the chat quick-switch picker (`packages/ui/src/components/chat/ModelControls.tsx`) unchanged: returning to the current model in a quick-switch context can be disorienting, so that stays a maintainer decision.

## Maintainer decision needed — chat scope

> **Important.** This PR intentionally does **not** change the chat quick-switch model picker. The same `ModelPickerList` component is reused there, so the bug is reproducible in chat as well, but whether auto-scrolling to the current model is desirable in that context is a product call, not a bug fix.

Original note from the issue reporter (`@bashrusakh`, [#1906 (comment)](https://github.com/openchamber/openchamber/issues/1906#issuecomment-4827346247)):

> The same component is used in the chat model picker too, so the bug is reproducible there as well.
>
> However, I'm 50/50 on whether fixing it in chat is the right call — the chat picker is a quick-switch context where scrolling to the current selection might actually be disorienting (you often want to browse other models, not return to the current one). In Settings → Agents, it's clearly a bug because you're configuring a specific agent and need to see which model is selected.
>
> I'd suggest the maintainer decides on the chat scope. The fix for Settings → Agents is unambiguous.

This PR resolves the unambiguous part (Settings → Agents). If the maintainer wants the same behavior in the chat quick-switch picker, it's a one-line change: pass `scrollToSelectedOnOpen` in `packages/ui/src/components/chat/ModelControls.tsx`.

## Verification

- `bun run type-check` (packages/ui) — clean
- `bun run lint` (packages/ui) — clean

Manual checks to confirm before merge:
- Open Settings → Agents with a selected model whose provider section is collapsed → section auto-expands, list scrolls to the row, keyboard highlight lands on it.
- Open with no model selected → no error, selection starts at index 0 (existing behavior preserved).
- Type a search query that excludes the selected model → no scroll jump, selection resets to 0 (existing behavior preserved).