### PR TITLE
fix(git): report commit & push success only when a push happened

### DIFF
--- a/packages/ui/src/apps/MobileChangesSurface.tsx
+++ b/packages/ui/src/apps/MobileChangesSurface.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollShadow } from '@/components/ui/ScrollShadow';
 import { ChangesPanel, type ChangesGroupConfig } from '@/components/views/git/ChangesPanel';
 import { CommitSection } from '@/components/views/git/CommitSection';
+import { pushCommittedChanges } from '@/components/views/git/commitAndPush';
 import { SyncActions } from '@/components/views/git/SyncActions';
 import { PierreDiffViewer } from '@/components/views/PierreDiffViewer';
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
@@ -378,21 +379,13 @@ export const MobileChangesSurface: React.FC<MobileChangesSurfaceProps> = ({ onCl
         const remote = effectiveRemotes.find((entry) => entry.name === trackingRemoteName) ?? effectiveRemotes[0];
         if (!remote) throw new Error(t('mobile.changes.noRemote'));
         setSyncAction('sync');
-        const trackingPrefix = `${remote.name}/`;
-        const trackedBranch = status?.tracking?.startsWith(trackingPrefix)
-          ? status.tracking.slice(trackingPrefix.length)
-          : undefined;
-
-        await git.gitFetch(currentDirectory, { remote: remote.name });
-        const afterFetch = await git.getGitStatus(currentDirectory);
-        if ((afterFetch.behind ?? 0) > 0) {
-          await git.gitPull(currentDirectory, { remote: remote.name, branch: trackedBranch, rebase: true });
-        }
-
-        const afterPull = await git.getGitStatus(currentDirectory);
-        if ((afterPull.ahead ?? 0) > 0) {
-          await git.gitPush(currentDirectory);
-        }
+        await pushCommittedChanges({
+          git,
+          directory: currentDirectory,
+          remote,
+          status,
+          dirtyWorktreeError: t('gitView.toast.commitOrStashBeforeSync'),
+        });
 
         await refreshStatusAndBranches(false);
         await refreshRemotes();

--- a/packages/ui/src/apps/MobileChangesSurface.tsx
+++ b/packages/ui/src/apps/MobileChangesSurface.tsx
@@ -8,6 +8,7 @@ import { ChangesPanel, type ChangesGroupConfig } from '@/components/views/git/Ch
 import { BranchSelector } from '@/components/views/git/BranchSelector';
 import { CommitSection } from '@/components/views/git/CommitSection';
 import { DirtyBranchSwitchDialog } from '@/components/views/git/DirtyBranchSwitchDialog';
+import { pushCommittedChanges } from '@/components/views/git/commitAndPush';
 import { SyncActions } from '@/components/views/git/SyncActions';
 import { PierreDiffViewer } from '@/components/views/PierreDiffViewer';
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
@@ -441,21 +442,13 @@ export const MobileChangesSurface: React.FC<MobileChangesSurfaceProps> = ({ onCl
         const remote = effectiveRemotes.find((entry) => entry.name === trackingRemoteName) ?? effectiveRemotes[0];
         if (!remote) throw new Error(t('mobile.changes.noRemote'));
         setSyncAction('sync');
-        const trackingPrefix = `${remote.name}/`;
-        const trackedBranch = status?.tracking?.startsWith(trackingPrefix)
-          ? status.tracking.slice(trackingPrefix.length)
-          : undefined;
-
-        await git.gitFetch(currentDirectory, { remote: remote.name });
-        const afterFetch = await git.getGitStatus(currentDirectory);
-        if ((afterFetch.behind ?? 0) > 0) {
-          await git.gitPull(currentDirectory, { remote: remote.name, branch: trackedBranch, rebase: true });
-        }
-
-        const afterPull = await git.getGitStatus(currentDirectory);
-        if ((afterPull.ahead ?? 0) > 0) {
-          await git.gitPush(currentDirectory);
-        }
+        await pushCommittedChanges({
+          git,
+          directory: currentDirectory,
+          remote,
+          status,
+          dirtyWorktreeError: t('gitView.toast.commitOrStashBeforeSync'),
+        });
 
         await refreshStatusAndBranches(false);
         await refreshRemotes();

--- a/packages/ui/src/components/views/GitView.tsx
+++ b/packages/ui/src/components/views/GitView.tsx
@@ -60,6 +60,7 @@ import { BranchIntegrationSection, type OperationLogEntry } from './git/BranchIn
 import { deriveBaseBranch } from './git/baseBranch';
 import { getFreshestPrStatusForBranch, useGitHubPrStatusStore } from '@/stores/useGitHubPrStatusStore';
 import { createGitIndexMutationQueue, type GitIndexMutationDirection, type GitIndexMutationQueue } from './git/gitIndexMutationQueue';
+import { pushCommittedChanges } from './git/commitAndPush';
 import type { GitRemote } from '@/lib/gitApi';
 import { getRootBranch } from '@/lib/worktrees/worktreeStatus';
 import { cn } from '@/lib/utils';
@@ -1150,29 +1151,18 @@ export const GitView: React.FC<GitViewProps> = ({ isActive }) => {
         }
 
         setSyncAction('sync');
-        const trackingPrefix = `${remote.name}/`;
-        const trackedBranch = status?.tracking?.startsWith(trackingPrefix)
-          ? status.tracking.slice(trackingPrefix.length)
-          : undefined;
-
-        await git.gitFetch(currentDirectory, { remote: remote.name });
-        const afterFetch = await git.getGitStatus(currentDirectory);
-        if ((afterFetch.behind ?? 0) > 0) {
-          if ((afterFetch.files?.length ?? 0) > 0) {
-            toast.error(t('gitView.toast.commitOrStashBeforeSync'));
-            await refreshStatusAndBranches(false);
-            return;
-          }
-          await git.gitPull(currentDirectory, { remote: remote.name, branch: trackedBranch, rebase: true });
-        }
-
-        const afterPull = await git.getGitStatus(currentDirectory);
-        let result: Awaited<ReturnType<typeof git.gitPush>> | undefined;
-        if ((afterPull.ahead ?? 0) > 0) {
-          result = await git.gitPush(currentDirectory);
-        }
-        toast.success(t('gitView.toast.pushedToUpstream', { name: getPushedRemoteName(result) }));
-        triggerFireworks();
+        await pushCommittedChanges({
+          git,
+          directory: currentDirectory,
+          remote,
+          status,
+          dirtyWorktreeError: t('gitView.toast.commitOrStashBeforeSync'),
+          onPushed: (result) => {
+            if (result.pushed.length === 0) return;
+            toast.success(t('gitView.toast.pushedToUpstream', { name: getPushedRemoteName(result) }));
+            triggerFireworks();
+          },
+        });
         await refreshStatusAndBranches(false);
       } else {
         await refreshStatusAndBranches(false);

--- a/packages/ui/src/components/views/GitView.tsx
+++ b/packages/ui/src/components/views/GitView.tsx
@@ -65,6 +65,7 @@ import { BranchIntegrationSection, type OperationLogEntry } from './git/BranchIn
 import { deriveBaseBranch } from './git/baseBranch';
 import { getFreshestPrStatusForBranch, useGitHubPrStatusStore } from '@/stores/useGitHubPrStatusStore';
 import { createGitIndexMutationQueue, type GitIndexMutationDirection, type GitIndexMutationQueue } from './git/gitIndexMutationQueue';
+import { pushCommittedChanges } from './git/commitAndPush';
 import type { GitRemote } from '@/lib/gitApi';
 import { getRootBranch } from '@/lib/worktrees/worktreeStatus';
 import { cn } from '@/lib/utils';
@@ -1237,29 +1238,18 @@ export const GitView: React.FC<GitViewProps> = ({ isActive }) => {
         }
 
         setSyncAction('sync');
-        const trackingPrefix = `${remote.name}/`;
-        const trackedBranch = status?.tracking?.startsWith(trackingPrefix)
-          ? status.tracking.slice(trackingPrefix.length)
-          : undefined;
-
-        await git.gitFetch(gitDirectory, { remote: remote.name });
-        const afterFetch = await git.getGitStatus(gitDirectory);
-        if ((afterFetch.behind ?? 0) > 0) {
-          if ((afterFetch.files?.length ?? 0) > 0) {
-            toast.error(t('gitView.toast.commitOrStashBeforeSync'));
-            await refreshStatusAndBranches(false);
-            return;
-          }
-          await git.gitPull(gitDirectory, { remote: remote.name, branch: trackedBranch, rebase: true });
-        }
-
-        const afterPull = await git.getGitStatus(gitDirectory);
-        let result: Awaited<ReturnType<typeof git.gitPush>> | undefined;
-        if ((afterPull.ahead ?? 0) > 0) {
-          result = await git.gitPush(gitDirectory);
-        }
-        toast.success(t('gitView.toast.pushedToUpstream', { name: getPushedRemoteName(result) }));
-        triggerFireworks();
+        await pushCommittedChanges({
+          git,
+          directory: gitDirectory,
+          remote,
+          status,
+          dirtyWorktreeError: t('gitView.toast.commitOrStashBeforeSync'),
+          onPushed: (result) => {
+            if (result.pushed.length === 0) return;
+            toast.success(t('gitView.toast.pushedToUpstream', { name: getPushedRemoteName(result) }));
+            triggerFireworks();
+          },
+        });
         await refreshStatusAndBranches(false);
       } else {
         await refreshStatusAndBranches(false);

--- a/packages/ui/src/components/views/git/commitAndPush.test.ts
+++ b/packages/ui/src/components/views/git/commitAndPush.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test';
+import type { GitAPI, GitRemote, GitStatus } from '@/lib/api/types';
+import { pushCommittedChanges } from './commitAndPush';
+
+const remote = (name = 'origin'): GitRemote => ({ name, fetchUrl: '', pushUrl: '' });
+
+const status = (overrides: Partial<GitStatus> = {}): GitStatus => ({
+  current: 'feature',
+  tracking: null,
+  ahead: 0,
+  behind: 0,
+  files: [],
+  isClean: true,
+  ...overrides,
+});
+
+test('publishes a new branch even though status has no upstream ahead count', async () => {
+  const pushes: Array<{ directory: string; remote?: string }> = [];
+  const git = {
+    gitFetch: async () => ({ success: true }),
+    getGitStatus: async () => status(),
+    gitPull: async () => { throw new Error('unexpected pull'); },
+    gitPush: async (directory: string, options?: { remote?: string }) => {
+      pushes.push({ directory, remote: options?.remote });
+      return { success: true, pushed: [{ local: 'feature', remote: 'fork' }], repo: directory, ref: null };
+    },
+  } as Pick<GitAPI, 'gitFetch' | 'getGitStatus' | 'gitPull' | 'gitPush'>;
+
+  await pushCommittedChanges({
+    git,
+    directory: '/repo',
+    remote: remote('fork'),
+    status: status(),
+    dirtyWorktreeError: 'dirty',
+  });
+
+  expect(pushes).toEqual([{ directory: '/repo', remote: 'fork' }]);
+});
+
+for (const [name, remoteStatus, expectedCalls] of [
+  ['ahead', status({ ahead: 1 }), ['fetch', 'push']],
+  ['behind', status({ behind: 1 }), ['fetch', 'pull', 'push']],
+  ['diverged', status({ ahead: 1, behind: 1 }), ['fetch', 'pull', 'push']],
+] as const) {
+  test(`pushes an existing ${name} branch after reconciling remote changes`, async () => {
+    const calls: string[] = [];
+    const git = {
+      gitFetch: async () => { calls.push('fetch'); return { success: true }; },
+      getGitStatus: async () => remoteStatus,
+      gitPull: async () => {
+        calls.push('pull');
+        return { success: true, summary: { changes: 0, insertions: 0, deletions: 0 }, files: [], insertions: 0, deletions: 0 };
+      },
+      gitPush: async (directory: string) => {
+        calls.push('push');
+        return { success: true, pushed: [{ local: 'feature', remote: 'origin' }], repo: directory, ref: null };
+      },
+    } as Pick<GitAPI, 'gitFetch' | 'getGitStatus' | 'gitPull' | 'gitPush'>;
+
+    await pushCommittedChanges({
+      git,
+      directory: '/repo',
+      remote: remote(),
+      status: status({ tracking: 'origin/feature' }),
+      dirtyWorktreeError: 'dirty',
+    });
+
+    expect(calls).toEqual(expectedCalls);
+  });
+}
+
+describe('pushCommittedChanges failures', () => {
+  test('does not pull or push a behind branch with uncommitted changes', async () => {
+    const git = {
+      gitFetch: async () => ({ success: true }),
+      getGitStatus: async () => status({ behind: 1, files: [{ path: 'local.ts', index: ' ', working_dir: 'M' }] }),
+      gitPull: async () => { throw new Error('unexpected pull'); },
+      gitPush: async () => { throw new Error('unexpected push'); },
+    } as Pick<GitAPI, 'gitFetch' | 'getGitStatus' | 'gitPull' | 'gitPush'>;
+
+    await expect(pushCommittedChanges({
+      git,
+      directory: '/repo',
+      remote: remote(),
+      status: status({ tracking: 'origin/feature' }),
+      dirtyWorktreeError: 'commit or stash first',
+    })).rejects.toThrow('commit or stash first');
+  });
+
+  test('does not report a push result when publishing fails', async () => {
+    let reportedSuccess = false;
+    const git = {
+      gitFetch: async () => ({ success: true }),
+      getGitStatus: async () => status({ ahead: 1 }),
+      gitPull: async () => { throw new Error('unexpected pull'); },
+      gitPush: async () => { throw new Error('remote rejected'); },
+    } as Pick<GitAPI, 'gitFetch' | 'getGitStatus' | 'gitPull' | 'gitPush'>;
+
+    await expect(pushCommittedChanges({
+      git,
+      directory: '/repo',
+      remote: remote(),
+      status: status({ tracking: 'origin/feature' }),
+      dirtyWorktreeError: 'dirty',
+      onPushed: () => { reportedSuccess = true; },
+    })).rejects.toThrow('remote rejected');
+
+    expect(reportedSuccess).toBe(false);
+  });
+});

--- a/packages/ui/src/components/views/git/commitAndPush.ts
+++ b/packages/ui/src/components/views/git/commitAndPush.ts
@@ -1,0 +1,39 @@
+import type { GitAPI, GitPushResult, GitRemote, GitStatus } from '@/lib/api/types';
+
+type CommitPushGitAPI = Pick<GitAPI, 'gitFetch' | 'getGitStatus' | 'gitPull' | 'gitPush'>;
+
+type PushCommittedChangesOptions = {
+  git: CommitPushGitAPI;
+  directory: string;
+  remote: GitRemote;
+  status: GitStatus | null | undefined;
+  dirtyWorktreeError: string;
+  onPushed?: (result: GitPushResult) => void;
+};
+
+export const pushCommittedChanges = async ({
+  git,
+  directory,
+  remote,
+  status,
+  dirtyWorktreeError,
+  onPushed,
+}: PushCommittedChangesOptions): Promise<GitPushResult> => {
+  const trackingPrefix = `${remote.name}/`;
+  const trackedBranch = status?.tracking?.startsWith(trackingPrefix)
+    ? status.tracking.slice(trackingPrefix.length)
+    : undefined;
+
+  await git.gitFetch(directory, { remote: remote.name });
+  const afterFetch = await git.getGitStatus(directory);
+  if ((afterFetch.behind ?? 0) > 0) {
+    if ((afterFetch.files?.length ?? 0) > 0) {
+      throw new Error(dirtyWorktreeError);
+    }
+    await git.gitPull(directory, { remote: remote.name, branch: trackedBranch, rebase: true });
+  }
+
+  const result = await git.gitPush(directory, { remote: remote.name });
+  onPushed?.(result);
+  return result;
+};

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -22,6 +22,7 @@ import {
   unstageFiles,
   applyHunk,
   getDiff,
+  push,
 } from './service.js';
 
 // ---------------------------------------------------------------------------
@@ -281,6 +282,35 @@ describe('getStatus', () => {
     runGit(repo, ['commit', '-m', 'Initial commit']);
 
     await expect(getStatus(repo)).resolves.toMatchObject({ current: 'main' });
+  });
+});
+
+describe('push', () => {
+  it('publishes the current branch with an upstream and leaves other local branches alone', async () => {
+    if (!canRunGit()) return;
+
+    const remote = createTempDir();
+    const repo = createTempDir();
+    runGit(remote, ['init', '--bare']);
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'Initial commit']);
+    runGit(repo, ['remote', 'add', 'fork', remote]);
+    runGit(repo, ['branch', 'unrelated']);
+    runGit(repo, ['checkout', '-b', 'feature']);
+    fs.writeFileSync(path.join(repo, 'feature.txt'), 'published\n');
+    runGit(repo, ['add', 'feature.txt']);
+    runGit(repo, ['commit', '-m', 'Add feature']);
+
+    await push(repo, { remote: 'fork' });
+
+    expect(runGit(repo, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}']).trim()).toBe('fork/feature');
+    expect(runGit(remote, ['rev-parse', 'refs/heads/feature']).trim()).toBe(runGit(repo, ['rev-parse', 'HEAD']).trim());
+    expect(() => runGit(remote, ['rev-parse', 'refs/heads/unrelated'])).toThrow();
+    expect(() => runGit(remote, ['rev-parse', 'refs/heads/main'])).toThrow();
   });
 });
 

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -33,6 +33,7 @@ import {
   validateWorktreeCreate,
   parseBranchCreationSource,
   getRangeFiles,
+  push,
 } from './service.js';
 
 // ---------------------------------------------------------------------------
@@ -472,6 +473,35 @@ describe('getStatus', () => {
     } finally {
       process.chdir(previousCwd);
     }
+  });
+});
+
+describe('push', () => {
+  it('publishes the current branch with an upstream and leaves other local branches alone', async () => {
+    if (!canRunGit()) return;
+
+    const remote = createTempDir();
+    const repo = createTempDir();
+    runGit(remote, ['init', '--bare']);
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'Initial commit']);
+    runGit(repo, ['remote', 'add', 'fork', remote]);
+    runGit(repo, ['branch', 'unrelated']);
+    runGit(repo, ['checkout', '-b', 'feature']);
+    fs.writeFileSync(path.join(repo, 'feature.txt'), 'published\n');
+    runGit(repo, ['add', 'feature.txt']);
+    runGit(repo, ['commit', '-m', 'Add feature']);
+
+    await push(repo, { remote: 'fork' });
+
+    expect(runGit(repo, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}']).trim()).toBe('fork/feature');
+    expect(runGit(remote, ['rev-parse', 'refs/heads/feature']).trim()).toBe(runGit(repo, ['rev-parse', 'HEAD']).trim());
+    expect(() => runGit(remote, ['rev-parse', 'refs/heads/unrelated'])).toThrow();
+    expect(() => runGit(remote, ['rev-parse', 'refs/heads/main'])).toThrow();
   });
 });
 


### PR DESCRIPTION
## Maintainer follow-up

Completed in [04697da25](https://github.com/openchamber/openchamber/commit/04697da25). The server now derives actual ref changes from Git porcelain output, distinguishes no-op pushes from publication/fast-forward/forced updates, and reports the destination remote name. Default push routing and first-upstream setup honor `branch.<name>.pushRemote` and `remote.pushDefault`. Desktop/mobile Sync shares the corrected flow and no longer skips unpublished branches based on `ahead`.

Validated integration HEAD: `0667e739d`. Workspace type-check, lint and build passed. The full test suite passed: root tooling 6 files, SDK 13, UI 504, VS Code 46, Electron 26, and web 217 files with 2423 passed tests and 1 skipped. Real local bare-repository tests cover first publication, no-op, fast-forward, rejection, forced updates and separate fetch/push destinations. UI helper tests cover feedback gating. No external remote, Linux desktop or mobile app was exercised manually. Oxlint findings were confined to existing code; the changed helper/tests were clean. Dead-code output was inspected and contained no new finding for this follow-up.

## Original contribution

> Original PR HEAD reviewed: `4fd235cf57def7d402795018c1dfc4cf005b9d9f`. The original scope and author validation below precede the maintainer follow-up.

## Intent

Fixes #1917. Commit & Push claimed success unconditionally: `GitView` skipped `gitPush` when `ahead === 0`, then still fired the "Pushed to <remote>" toast and the fireworks, so users were told a push happened when none was attempted. Both now fire only when the push result reports at least one pushed ref.

A shared `pushCommittedChanges` helper replaces the duplicated inline sequence in `GitView` and `MobileChangesSurface`: fetch, rebase pull only when behind and the worktree is clean, then push the current branch through the resolved remote. Dropping the `ahead > 0` gate means a branch with no upstream, which reports `ahead: 0`, is now actually pushed; `origin/main`'s server `push` already retries with `--set-upstream` for that case.

## Non-goals

No force-push and no change to explicit single-branch push requests. An earlier revision of this PR rewrote the server push path so a remote-only request published *every* local branch with per-branch `pushed`/`failed` results; that is reverted, because it published unrelated local branches and because main already publishes the current branch with an upstream.

## Affected surfaces

- `packages/ui`: `GitView` Commit & Push (web and desktop) and `MobileChangesSurface` Commit & Push (hosted and Capacitor mobile), plus the new `components/views/git/commitAndPush.ts`.
- Mobile behavior change: it previously pulled even with a dirty worktree. It now refuses, and its existing catch surfaces `gitView.toast.commitOrStashBeforeSync` as an error toast, matching `GitView`.
- `packages/web`: `server/lib/git/service.js` is byte-identical to `origin/main` and does not appear in `git diff origin/main..HEAD`. Only `server/lib/git/service.test.js` changes, adding a regression test. Reviewers expecting a server change from the previous PR title should note there is none, and the `GitAPI` contract is unchanged.
- Electron uses the shared web Git API. VS Code does not mount `GitView` or `MobileChangesSurface`, so this Commit & Push flow is not reachable there.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Shared UI source changed and a module was added | The duplicated push sequence moved into one owning helper; the reverted server rewrite keeps the diff to the actual root cause. |
| `ui-api-decoupling` | Shared UI performs git work through a runtime API | The helper accepts only `Pick<GitAPI, 'gitFetch' \| 'getGitStatus' \| 'gitPull' \| 'gitPush'>`, so no runtime-specific transport, URL, or auth detail leaks into it. |
| `locale-ui-patterns` | The change alters which user-facing toast appears | No new keys; the existing `gitView.toast.pushedToUpstream` and `gitView.toast.commitOrStashBeforeSync` are reused, with the dirty-worktree message passed in by the caller so the helper holds no copy. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/views/git/commitAndPush.test.ts` | 6 passed, 0 failed. |
| `cd packages/web && bunx vitest run server/lib/git/service.test.js` | 1 file, 49 passed, 0 failed. |
| `bun run type-check:ui`, `bun run lint:ui`, `bun run type-check:web`, `bun run lint:web` | All exited 0. |

`packages/web/tsconfig.json` includes only `src` and `../ui/src`, and `lint:web` globs only `./src/**/*.{ts,tsx}`, so `server/**/*.js` is not covered by the web type-check or lint. The vitest run above is the only check covering the changed server test. Not validated: no push against a live remote, and no desktop, VS Code, or mobile run.

## Visual evidence

Not captured. The user-visible change is the absence of a false "Pushed to <remote>" toast and fireworks when nothing was pushed, which requires a live remote in a state where the push is a no-op; no such capture was taken. No component, styling, or layout changed.

## Risks and failure behavior

- A push is now attempted on every Commit & Push, including when the branch looks up to date. A rejected push surfaces the git error instead of a false success toast, and `onPushed` is not invoked when `gitPush` throws.
- The success gate trusts the runtime's `pushed` array. If a runtime reports an empty `pushed` for a real push, the user gets no confirmation toast: it fails quiet rather than falsely positive.
- Mobile now blocks the pull on a dirty worktree, where it previously pulled and could rebase over uncommitted work. This is intentional and matches `GitView`.
- No force-push, and the server push path is untouched, so rollback is reverting one UI-side commit.
