### PR TITLE
fix(about): show manual copy fallback when clipboard API fails for diagnostics

### DIFF
--- a/packages/ui/src/components/ui/AboutDialog.tsx
+++ b/packages/ui/src/components/ui/AboutDialog.tsx
@@ -29,12 +29,14 @@ export const AboutDialog: React.FC<AboutDialogProps> = ({
   const [copiedDiagnostics, setCopiedDiagnostics] = React.useState(false);
   const [diagnosticsReport, setDiagnosticsReport] = React.useState<string | null>(null);
   const [isPreparingDiagnostics, setIsPreparingDiagnostics] = React.useState(false);
+  const [showManualCopyFallback, setShowManualCopyFallback] = React.useState(false);
 
   const handleCopyDiagnostics = React.useCallback(async () => {
     if (!showDiagnostics) return;
     if (isCopyingDiagnostics) return;
     setIsCopyingDiagnostics(true);
     setCopiedDiagnostics(false);
+    setShowManualCopyFallback(false);
     try {
       if (!diagnosticsReport) {
         toast.error(t('aboutDialog.toast.copyFailed'), {
@@ -48,12 +50,10 @@ export const AboutDialog: React.FC<AboutDialogProps> = ({
         setCopiedDiagnostics(true);
         toast.success(t('aboutDialog.toast.diagnosticsCopied'));
       } else {
-        toast.error(t('aboutDialog.toast.copyFailed'), {
-          description: result.error,
-        });
+        setShowManualCopyFallback(true);
       }
     } catch (error) {
-      toast.error(t('aboutDialog.toast.copyFailed'));
+      setShowManualCopyFallback(true);
       console.error('Failed to copy diagnostics:', error);
     } finally {
       setIsCopyingDiagnostics(false);
@@ -178,6 +178,19 @@ export const AboutDialog: React.FC<AboutDialogProps> = ({
               <p className="typography-micro text-muted-foreground">
                 {t('aboutDialog.diagnosticsDescription')}
               </p>
+            </div>
+          )}
+
+          {showDiagnostics && showManualCopyFallback && diagnosticsReport && (
+            <div className="flex flex-col items-center gap-2 w-full pt-1">
+              <p className="typography-micro text-muted-foreground">
+                {t('aboutDialog.manualCopyFallback')}
+              </p>
+              <div className="w-full max-h-48 overflow-auto rounded-md bg-secondary p-2">
+                <pre className="typography-nano whitespace-pre-wrap break-all select-all">
+                  {diagnosticsReport}
+                </pre>
+              </div>
             </div>
           )}
 

--- a/packages/ui/src/lib/clipboard.ts
+++ b/packages/ui/src/lib/clipboard.ts
@@ -21,7 +21,9 @@ export async function copyTextToClipboard(text: string): Promise<ClipboardCopyRe
     textarea.style.position = 'fixed';
     textarea.style.top = '-1000px';
     textarea.style.left = '-1000px';
+    textarea.tabIndex = -1;
     document.body.appendChild(textarea);
+    textarea.focus();
     textarea.select();
     textarea.setSelectionRange(0, textarea.value.length);
     const copied = document.execCommand('copy');

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1438,6 +1438,7 @@ export const dict = {
   'aboutDialog.toast.copyFailed': 'Copy failed',
   'aboutDialog.toast.diagnosticsNotReady': 'Diagnostics not ready yet. Wait a second and retry.',
   'aboutDialog.toast.diagnosticsCopied': 'Diagnostics copied',
+  'aboutDialog.manualCopyFallback': 'Automatic copy failed — select the text below and copy it manually.',
   'helpDialog.title': 'Keyboard Shortcuts',
   'helpDialog.description': 'Use these keyboard shortcuts to navigate OpenChamber efficiently',
   'helpDialog.section.navigationCommands': 'Navigation & Commands',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1404,6 +1404,7 @@ export const dict: Record<I18nKey, string> = {
   "aboutDialog.toast.copyFailed": "No se pudo copiar",
   "aboutDialog.toast.diagnosticsNotReady": "Los diagnósticos aún no están listos. Espera un segundo y vuelve a intentarlo.",
   "aboutDialog.toast.diagnosticsCopied": "Diagnósticos copiados",
+  "aboutDialog.manualCopyFallback": "Fallo en la copia automática — selecciona el texto a continuación y cópialo manualmente.",
   "helpDialog.title": "Atajos de teclado",
   "helpDialog.description": "Usa estos atajos de teclado para navegar por OpenChamber de manera eficiente",
   "helpDialog.section.navigationCommands": "Navegación y comandos",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1304,6 +1304,7 @@ export const dict = {
   'aboutDialog.toast.copyFailed': 'Échec de la copie',
   'aboutDialog.toast.diagnosticsNotReady': 'Les diagnostics ne sont pas encore prêts. Attendez une seconde et réessayez.',
   'aboutDialog.toast.diagnosticsCopied': 'Diagnostic copié',
+  'aboutDialog.manualCopyFallback': 'Échec de la copie automatique — sélectionnez le texte ci-dessous et copiez-le manuellement.',
   'helpDialog.title': 'Raccourcis clavier',
   'helpDialog.description': 'Utilisez ces raccourcis clavier pour naviguer efficacement dans OpenChamber',
   'helpDialog.section.navigationCommands': 'Navigation et commandes',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -1434,6 +1434,7 @@ export const dict: Record<I18nKey, string> = {
   'aboutDialog.toast.copyFailed': 'コピーに失敗しました',
   'aboutDialog.toast.diagnosticsNotReady': '診断情報の準備ができていません。しばらく待ってから再試行してください。',
   'aboutDialog.toast.diagnosticsCopied': '診断情報をコピーしました',
+  'aboutDialog.manualCopyFallback': '自動コピーに失敗しました — 以下のテキストを選択して手動でコピーしてください。',
   'helpDialog.title': 'キーボードショートカット',
   'helpDialog.description': 'これらのキーボードショートカットを使ってOpenChamberを効率的に操作できます',
   'helpDialog.section.navigationCommands': 'ナビゲーションとコマンド',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1440,6 +1440,7 @@ export const dict: Record<I18nKey, string> = {
   'aboutDialog.toast.copyFailed': '복사 실패',
   'aboutDialog.toast.diagnosticsNotReady': '진단 정보가 아직 준비되지 않았습니다. 잠시 후 다시 시도하세요.',
   'aboutDialog.toast.diagnosticsCopied': '진단 정보 복사됨',
+  'aboutDialog.manualCopyFallback': '자동 복사 실패 — 아래 텍스트를 선택하여 수동으로 복사하세요.',
   'helpDialog.title': '키보드 단축키',
   'helpDialog.description': '이 단축키로 OpenChamber를 빠르게 탐색하세요',
   'helpDialog.section.navigationCommands': '내비게이션 및 명령',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -895,6 +895,7 @@ export const dict: Record<I18nKey, string> = {
   'aboutDialog.footerNote': 'Stworzone z sercem dla społeczności',
   'aboutDialog.toast.copyFailed': 'Nie udało się skopiować',
   'aboutDialog.toast.diagnosticsCopied': 'Diagnostyka skopiowana',
+  'aboutDialog.manualCopyFallback': 'Automatyczne kopiowanie nie powiodło się — zaznacz poniższy tekst i skopiuj go ręcznie.',
   'aboutDialog.toast.diagnosticsNotReady': 'Diagnostyka nie jest jeszcze gotowa. Poczekaj chwilę i spróbuj ponownie.',
   'aboutDialog.versionLabel': 'Wersja {version}',
   'aboutDialog.openChamberVersionLabel': 'Wersja OpenChamber {version}',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1404,6 +1404,7 @@ export const dict: Record<I18nKey, string> = {
   "aboutDialog.toast.copyFailed": "Não foi possível copiar",
   "aboutDialog.toast.diagnosticsNotReady": "Os diagnósticos ainda não estão prontos. Aguarde um segundo e tente novamente.",
   "aboutDialog.toast.diagnosticsCopied": "Diagnósticos copiados",
+  "aboutDialog.manualCopyFallback": "Falha na cópia automática — selecione o texto abaixo e copie-o manualmente.",
   "helpDialog.title": "Atalhos de teclado",
   "helpDialog.description": "Use estes atalhos de teclado para navegar pelo OpenChamber com eficiência",
   "helpDialog.section.navigationCommands": "Navegação e comandos",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1404,6 +1404,7 @@ export const dict: Record<I18nKey, string> = {
   "aboutDialog.toast.copyFailed": "Помилка копіювання",
   "aboutDialog.toast.diagnosticsNotReady": "Діагностика ще не готова. Зачекайте секунду та повторіть спробу.",
   "aboutDialog.toast.diagnosticsCopied": "Діагностику скопійовано",
+  "aboutDialog.manualCopyFallback": "Автоматичне копіювання не вдалося — виберіть текст нижче та скопіюйте його вручну.",
   "helpDialog.title": "Комбінації клавіш",
   "helpDialog.description": "Використовуйте ці комбінації клавіш для ефективної навігації OpenChamber",
   "helpDialog.section.navigationCommands": "Навігація та команди",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1404,6 +1404,7 @@ export const dict: Record<I18nKey, string> = {
   'aboutDialog.toast.copyFailed': '复制失败',
   'aboutDialog.toast.diagnosticsNotReady': '诊断信息尚未就绪。请稍候重试。',
   'aboutDialog.toast.diagnosticsCopied': '诊断信息已复制',
+  'aboutDialog.manualCopyFallback': '自动复制失败 — 请选中下方文字并手动复制。',
   'helpDialog.title': '键盘快捷键',
   'helpDialog.description': '使用这些快捷键可更高效地导航 OpenChamber',
   'helpDialog.section.navigationCommands': '导航与命令',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1408,6 +1408,7 @@ export const dict: Record<I18nKey, string> = {
   'aboutDialog.toast.copyFailed': '複製失敗',
   'aboutDialog.toast.diagnosticsNotReady': '診斷資訊尚未就緒。請稍後重試。',
   'aboutDialog.toast.diagnosticsCopied': '診斷資訊已複製',
+  'aboutDialog.manualCopyFallback': '自動複製失敗 — 請選取下方文字並手動複製。',
   'helpDialog.title': '鍵盤快速鍵',
   'helpDialog.description': '使用這些快速鍵可更有效率地導覽 OpenChamber',
   'helpDialog.section.navigationCommands': '導覽與命令',


### PR DESCRIPTION
## Summary

Fixes #449 — the Copy Diagnostics button in About dialog fails silently on some browsers/platforms (reported on Chrome/Android, Firefox/Linux) because `navigator.clipboard.writeText` is not available in non-secure contexts or is blocked.

## What changed

When `debugUtils.copyTextToClipboard()` returns `ok: false`, instead of showing a toast error and losing the user, the dialog now renders the diagnostics text inline in a scrollable `<pre>` block inside the About dialog. The user can visually inspect the content, select it, and copy it themselves.

### Files changed

- **`packages/ui/src/components/ui/AboutDialog.tsx`** — Added `showManualCopyFallback` state and a fallback `<pre>` render block that displays the full diagnostics text when clipboard copy fails. Replaced the error toast path with showing the fallback.
- **`packages/ui/src/lib/clipboard.ts`** — Added `focus()` and `tabIndex = -1` to the `execCommand` fallback for better browser compatibility.
- **`packages/ui/src/lib/i18n/messages/*.ts`** — Added `aboutDialog.manualCopyFallback` string with the instruction "Automatic copy failed — select the text below and copy it manually."

## Validation

- `bun run --cwd packages/ui type-check` ✅
- `bun run --cwd packages/ui lint` ✅