### PR TITLE
fix(vscode): keep relative path in Add to Context attachment filename

### DIFF
--- a/packages/ui/src/components/chat/FileAttachment.tsx
+++ b/packages/ui/src/components/chat/FileAttachment.tsx
@@ -471,7 +471,7 @@ export const ActiveEditorFileSuggestion = memo(() => {
       ? `${selection.startLine}`
       : `${selection.startLine}-${selection.endLine}`
   }
-  const selectionLabel = selection ? `${fileName}:${selectionRange}` : ''
+  const selectionLabel = selection ? `${relativePath}:${selectionRange}` : ''
   const isSelectionAttached = !!selectionLabel && attachedFiles.some(
     (f) => f.source === 'vscode' && f.vscodeSource === 'selection' && f.filename === selectionLabel && f.vscodePath === filePath
   )

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -297,13 +297,14 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       // Get file info for context
-      const filePath = vscode.workspace.asRelativePath(editor.document.uri);
+      // false matches the relativePath broadcast for the active editor, so this attachment dedupes against the pin-selection suggestion.
+      const filePath = vscode.workspace.asRelativePath(editor.document.uri, false);
       // Get line numbers (1-based for display)
       const startLine = selection.start.line + 1;
       const endLine = selection.end.line + 1;
       const lineRange = startLine === endLine ? `${startLine}` : `${startLine}-${endLine}`;
 
-      const filename = `${editor.document.fileName.split(/[\\/]/).pop() || filePath}:${lineRange}`;
+      const filename = `${filePath}:${lineRange}`;
       const contextSelection = {
         filePath: editor.document.uri.fsPath,
         filename,


### PR DESCRIPTION
## What
The VS Code "Add to Context" command and the active-editor pin-selection suggestion now keep the workspace-relative path in the selection attachment filename (e.g. `src/assist.ts:47`) instead of the bare basename (`assist.ts:47`).

## Why
Fixes #1914 (data loss). When a code selection is attached, OpenChamber stores the attachment filename and OpenCode synthesizes a `Read` call from it. Both selection-attachment paths set the filename to the basename only, so the synthesized call dropped the directory:

```
Called the Read tool with the following input: {"filePath":"assist.ts:47"}
```

The model then has to search for the file (wasting tokens) and, when multiple files share a name, can read or edit the wrong one.

This addresses the path problem in #1914. The issue also notes a typo in the surrounding `Called the Read tool with the following input: …` wrapper; that text is synthesized by the OpenCode server (it appears nowhere in this repo), so it's out of scope here and would need an upstream fix.

## Fix
- `packages/vscode/src/extension.ts` — build the `addToContext` filename from `vscode.workspace.asRelativePath(uri, false)` instead of `editor.document.fileName.split(/[\\/]/).pop()`.
- `packages/ui/src/components/chat/FileAttachment.tsx` — build the pin-selection `selectionLabel` from `relativePath` instead of `fileName`.

Both VS Code providers already broadcast the active editor's `relativePath` as `asRelativePath(uri, false)`, so using that same form in both paths means a selection attached either way gets an identical filename: the directory reaches the model, and the two paths stay deduped. (Before this, pinning an already-attached selection created a duplicate carrying the old basename-only name.) The compact chip UI still displays just the basename.

## Testing
- `bun run --cwd packages/vscode type-check` -> pass
- `bun run --cwd packages/vscode lint` -> pass
- `bun run --cwd packages/vscode build` -> pass
- `bun run type-check:ui` -> pass
- `bun run lint:ui` -> pass
- `bun test packages/ui/src/sync/input-store.test.ts` -> 6 pass / 0 fail
