### PR TITLE
fix(git): rank branch pickers by fuzzy query relevance

### DIFF
--- a/packages/ui/src/components/views/git/BranchIntegrationSection.tsx
+++ b/packages/ui/src/components/views/git/BranchIntegrationSection.tsx
@@ -25,6 +25,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Icon } from "@/components/icon/Icon";
 import { cn } from '@/lib/utils';
+import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
+import { BRANCH_FUZZY_THRESHOLD } from '@/lib/worktrees/branchSearch';
 import { useI18n } from '@/lib/i18n';
 
 type OperationType = 'merge' | 'rebase';
@@ -88,21 +90,27 @@ export const BranchIntegrationSection: React.FC<BranchIntegrationSectionProps> =
 
   // Filter branches based on search
   const filteredLocal = React.useMemo(() => {
-    const term = branchSearch.toLowerCase();
+    const term = branchSearch.trim();
     const remoteBranchNames = new Set(
       remoteBranches
         .map((branch) => branch.slice(branch.indexOf('/') + 1))
         .filter(Boolean)
     );
-    const filtered = localBranches.filter((branch) => branch !== currentBranch && !remoteBranchNames.has(branch));
-    if (!term) return filtered;
-    return filtered.filter((b) => b.toLowerCase().includes(term));
+    const excluded = localBranches.filter(
+      (branch) => branch !== currentBranch && !remoteBranchNames.has(branch),
+    );
+    if (!term) return excluded;
+    return scoreByFuzzyQuery(excluded, term, (b) => b, {
+      threshold: BRANCH_FUZZY_THRESHOLD,
+    }).map((entry) => entry.item);
   }, [branchSearch, localBranches, currentBranch, remoteBranches]);
 
   const filteredRemote = React.useMemo(() => {
-    const term = branchSearch.toLowerCase();
+    const term = branchSearch.trim();
     if (!term) return remoteBranches;
-    return remoteBranches.filter((b) => b.toLowerCase().includes(term));
+    return scoreByFuzzyQuery(remoteBranches, term, (b) => b, {
+      threshold: BRANCH_FUZZY_THRESHOLD,
+    }).map((entry) => entry.item);
   }, [branchSearch, remoteBranches]);
 
   const resolveDefaultBranch = React.useCallback(() => {

--- a/packages/ui/src/components/views/git/BranchSelector.tsx
+++ b/packages/ui/src/components/views/git/BranchSelector.tsx
@@ -17,6 +17,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Icon } from "@/components/icon/Icon";
 import type { GitRemote } from '@/lib/api/types';
+import { scoreByFuzzyQuery } from '@/lib/search/fuzzySearch';
+import { BRANCH_FUZZY_THRESHOLD } from '@/lib/worktrees/branchSearch';
 import { useI18n } from '@/lib/i18n';
 
 interface BranchInfo {
@@ -79,15 +81,19 @@ export const BranchSelector: React.FC<BranchSelectorProps> = ({
   );
 
   const filteredLocal = React.useMemo(() => {
-    const term = search.toLowerCase();
+    const term = search.trim();
     if (!term) return localBranches;
-    return localBranches.filter((b) => b.toLowerCase().includes(term));
+    return scoreByFuzzyQuery(localBranches, term, (b) => b, {
+      threshold: BRANCH_FUZZY_THRESHOLD,
+    }).map((entry) => entry.item);
   }, [search, localBranches]);
 
   const filteredRemote = React.useMemo(() => {
-    const term = search.toLowerCase();
+    const term = search.trim();
     if (!term) return remoteBranches;
-    return remoteBranches.filter((b) => b.toLowerCase().includes(term));
+    return scoreByFuzzyQuery(remoteBranches, term, (b) => b, {
+      threshold: BRANCH_FUZZY_THRESHOLD,
+    }).map((entry) => entry.item);
   }, [search, remoteBranches]);
 
   const handleCheckout = (branch: string) => {

--- a/packages/ui/src/lib/worktrees/branchSearch.ts
+++ b/packages/ui/src/lib/worktrees/branchSearch.ts
@@ -1,4 +1,8 @@
-import { partitionByFuzzyQuery } from "@/lib/search/fuzzySearch";
+import { scoreByFuzzyQuery } from "@/lib/search/fuzzySearch";
+
+// Shared across branch pickers (BranchSelector, BranchIntegrationSection, this module).
+// Aligned with `DEFAULT_FUZZY_OPTIONS.threshold` and `rankAutocompleteItems` defaults.
+export const BRANCH_FUZZY_THRESHOLD = 0.4;
 
 export interface RankedBranchGroups {
   matching: Array<{
@@ -26,41 +30,43 @@ export function rankBranchesForQuery(args: {
     };
   }
 
-  const localPartition = partitionByFuzzyQuery(localBranches, normalizedQuery, (branch) => branch);
-  const remotePartition = partitionByFuzzyQuery(remoteBranches, normalizedQuery, (branch) => branch);
-  const matching: RankedBranchGroups['matching'] = [];
-  const otherLocal = localPartition.other;
-  const otherRemote = remotePartition.other;
-
-  for (const branch of localPartition.matching) {
-    matching.push({
-      label: branch,
-      value: branch,
-      source: 'local',
-    });
-  }
-
-  for (const branch of remotePartition.matching) {
-    matching.push({
-      label: branch,
-      value: `remotes/${branch}`,
-      source: 'remote',
-    });
-  }
-
-  matching.sort((a, b) => {
-    const byLabel = a.label.localeCompare(b.label, undefined, { sensitivity: 'accent' });
-    if (byLabel !== 0) {
-      return byLabel;
-    }
-    if (a.source !== b.source) {
-      return a.source.localeCompare(b.source);
-    }
-    return a.value.localeCompare(b.value);
+  // scoreByFuzzyQuery ranks by prefix (score -1) → substring position (idx/1000) → Fuse fuzzy fallback.
+  // Items below the fuzzy threshold are omitted from the result.
+  const localScored = scoreByFuzzyQuery(localBranches, normalizedQuery, (branch) => branch, {
+    threshold: BRANCH_FUZZY_THRESHOLD,
+  });
+  const remoteScored = scoreByFuzzyQuery(remoteBranches, normalizedQuery, (branch) => branch, {
+    threshold: BRANCH_FUZZY_THRESHOLD,
   });
 
+  const localMatched = new Set(localScored.map((entry) => entry.item));
+  const remoteMatched = new Set(remoteScored.map((entry) => entry.item));
+  const otherLocal = localBranches.filter((branch) => !localMatched.has(branch));
+  const otherRemote = remoteBranches.filter((branch) => !remoteMatched.has(branch));
+
+  // Merge scored locals and remotes while preserving relevance order across both groups:
+  // local prefix matches must come before remote prefix matches, etc.
+  const merged: { label: string; value: string; source: 'local' | 'remote'; score: number }[] = [];
+  for (const entry of localScored) {
+    merged.push({
+      label: entry.item,
+      value: entry.item,
+      source: 'local',
+      score: entry.score,
+    });
+  }
+  for (const entry of remoteScored) {
+    merged.push({
+      label: entry.item,
+      value: `remotes/${entry.item}`,
+      source: 'remote',
+      score: entry.score,
+    });
+  }
+  merged.sort((a, b) => a.score - b.score);
+
   return {
-    matching,
+    matching: merged.map(({ label, value, source }) => ({ label, value, source })),
     otherLocal,
     otherRemote,
   };


### PR DESCRIPTION
## Problem

Branch pickers (worktree dialog, GitView checkout, merge/rebase) sort matching results **alphabetically** instead of by relevance. Typing `main` buries `main` under lex-order neighbours.

Same root cause as #1896 (closed by #1897 for chat autocomplete), different surface.

## Solution

Replace boolean `partitionByFuzzyQuery` / `includes()` filters with `scoreByFuzzyQuery` (threshold `0.4`) so matches are ordered **prefix > substring > fuzzy**. Extract the shared threshold into `BRANCH_FUZZY_THRESHOLD` so the three call sites stay in sync.

`scoreByFuzzyQuery` is unchanged — this PR consumes the existing ranking primitive rather than introducing a new helper.

## Why not just reuse `rankAutocompleteItems` from #1897?

`rankAutocompleteItems` returns a flat `T[]`. The worktree dialog needs `{matching, otherLocal, otherRemote}` so it can list matched branches at the top and unmatched ones at the bottom of the picker. The other two pickers (GitView checkout, merge/rebase) are flat lists, but a `T[]`-returning helper would still need an `other` derivation step identical to what `rankBranchesForQuery` already does. Two of the three sites consume the partition shape, so the helper's natural home is the existing `branchSearch.ts` with a shared threshold constant, not a new `lib/search/` module.

## Affected Files

| File | Change |
|---|---|
| `packages/ui/src/lib/worktrees/branchSearch.ts` | `rankBranchesForQuery`: `partitionByFuzzyQuery` → `scoreByFuzzyQuery`; sort by score; derive `otherLocal`/`otherRemote` via Set subtraction. Exports `BRANCH_FUZZY_THRESHOLD = 0.4`. |
| `packages/ui/src/components/views/git/BranchSelector.tsx` | `filteredLocal`/`filteredRemote`: `includes()` → `scoreByFuzzyQuery` via `BRANCH_FUZZY_THRESHOLD`. |
| `packages/ui/src/components/views/git/BranchIntegrationSection.tsx` | Same. |

`NewWorktreeDialog.tsx` consumes `rankBranchesForQuery` unchanged — its interface is preserved.

## Diff Stat

```
3 files changed, 57 insertions(+), 37 deletions(-)
```

## Validation

- `bun run type-check` (in `packages/ui`) — exit 0
- `bun run lint` (in `packages/ui`) — exit 0
- Manual UX: typing `main` in any branch picker now puts exact prefix matches first

## Related

- Closes #1934
- Parallel to #1897 (chat autocomplete)
- See #1896 for the original bug report on the chat surface

## Risk

Low. `RankedBranchGroups` shape unchanged. `scoreByFuzzyQuery` already used in `CommandPalette.tsx`. Threshold `0.4` matches `DEFAULT_FUZZY_OPTIONS` and `rankAutocompleteItems` defaults.