### PR TITLE
fix(vscode): send workspace-relative path to model for attachments (#…

### DIFF
--- a/packages/ui/src/components/chat/FileAttachment.tsx
+++ b/packages/ui/src/components/chat/FileAttachment.tsx
@@ -483,15 +483,19 @@ export const ActiveEditorFileSuggestion = memo(() => {
   // Always show only the filename in the suggestion UI
   const displayName = fileName;
 
+  // agentPath is derived at click time from the existing `relativePath` (+ selection range)
+  // to match the Add-to-Context format. No separate payload field is needed since `relativePath`
+  // already carries the workspace-relative path; `fileName`/`selectionLabel` remain basename-only chip labels.
   const handleAddFile = () => {
-    addVSCodeFileAttachment(filePath, fileName, fileSize);
+    addVSCodeFileAttachment(filePath, fileName, fileSize, relativePath);
   };
 
   const handlePinSelection = async () => {
     if (!selection) return;
     const blob = new Blob([selection.text], { type: 'text/plain' });
     const file = new File([blob], selectionLabel, { type: 'text/plain' });
-    await addVSCodeSelectionAttachment(filePath, file);
+    const agentPath = `${relativePath}:${selectionRange}`;
+    await addVSCodeSelectionAttachment(filePath, file, agentPath);
   };
 
   // If there is a selection, prefer showing the pin-selection UI only.

--- a/packages/ui/src/stores/types/sessionTypes.ts
+++ b/packages/ui/src/stores/types/sessionTypes.ts
@@ -21,6 +21,7 @@ export interface AttachedFile {
     serverPath?: string;
     vscodePath?: string;
     vscodeSource?: 'file' | 'selection';
+    agentPath?: string;
 }
 
 export type EditPermissionMode = 'allow' | 'ask' | 'deny' | 'full';

--- a/packages/ui/src/sync/input-store.ts
+++ b/packages/ui/src/sync/input-store.ts
@@ -107,8 +107,8 @@ export type InputState = {
   removeAttachedFile: (id: string) => void
   setAttachedFiles: (files: AttachedFile[]) => void
   clearAttachedFiles: () => void
-  addVSCodeFileAttachment: (path: string, name: string, fileSize: number | null) => void
-  addVSCodeSelectionAttachment: (path: string, file: File) => Promise<void>
+  addVSCodeFileAttachment: (path: string, name: string, fileSize: number | null, agentPath?: string) => void
+  addVSCodeSelectionAttachment: (path: string, file: File, agentPath?: string) => Promise<void>
   setActiveEditorFile: (file: VSCodeActiveEditorFile | null) => void
   /** Add attachments restored from a reverted message (file already on server) */
   addRestoredAttachment: (file: { url: string; mimeType: string; filename: string }) => void
@@ -186,7 +186,7 @@ export const useInputStore = create<InputState>()((set, get) => ({
     set({ attachedFiles: [] })
   },
 
-  addVSCodeFileAttachment: (path: string, name: string, fileSize: number | null) => {
+  addVSCodeFileAttachment: (path: string, name: string, fileSize: number | null, agentPath?: string) => {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
     const isDuplicate = get().attachedFiles.some(
       (f) => f.source === 'vscode' && f.vscodeSource === 'file' && (f.vscodePath || '') === path
@@ -206,11 +206,12 @@ export const useInputStore = create<InputState>()((set, get) => ({
       source: 'vscode',
       vscodePath: path,
       vscodeSource: 'file',
+      ...(agentPath ? { agentPath } : {}),
     }
     set((s) => ({ attachedFiles: [...s.attachedFiles, attached] }))
   },
 
-  addVSCodeSelectionAttachment: async (path: string, file: File) => {
+  addVSCodeSelectionAttachment: async (path: string, file: File, agentPath?: string) => {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
     const generation = attachmentReadGeneration
     const selectionKey = getVSCodeSelectionKey(path, file.name)
@@ -238,6 +239,7 @@ export const useInputStore = create<InputState>()((set, get) => ({
       source: 'vscode',
       vscodePath: path,
       vscodeSource: 'selection',
+      ...(agentPath ? { agentPath } : {}),
     }
     set((s) => ({ attachedFiles: [...s.attachedFiles, attached] }))
   },

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -1025,11 +1025,13 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
 
       markPendingUserSendAnimation(createdDraftSession.sessionId)
 
+      // VS Code attachments carry a workspace-relative `agentPath`; web/Desktop
+      // attachments have none and fall back to `filename` (basename) by design.
       const files = attachments?.map((a) => ({
         type: "file" as const,
         mime: a.mimeType,
         url: a.dataUrl,
-        filename: a.filename,
+        filename: a.agentPath ?? a.filename,
       }))
 
       await routeMessage({
@@ -1051,7 +1053,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
             type: "file" as const,
             mime: a.mimeType,
             url: a.dataUrl,
-            filename: a.filename,
+            filename: a.agentPath ?? a.filename,  // see agentPath note above
           })),
         })),
       })
@@ -1104,11 +1106,13 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       markPendingUserSendAnimation(targetSessionId)
     }
 
+    // VS Code attachments carry a workspace-relative `agentPath`; web/Desktop
+    // attachments have none and fall back to `filename` (basename) by design.
     const files = attachments?.map((a) => ({
       type: "file" as const,
       mime: a.mimeType,
       url: a.dataUrl,
-      filename: a.filename,
+      filename: a.agentPath ?? a.filename,
     }))
 
     await routeMessage({
@@ -1130,7 +1134,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
           type: "file" as const,
           mime: a.mimeType,
           url: a.dataUrl,
-          filename: a.filename,
+          filename: a.agentPath ?? a.filename,  // see agentPath note above
         })),
       })),
     })

--- a/packages/vscode/src/ChatViewProvider.ts
+++ b/packages/vscode/src/ChatViewProvider.ts
@@ -200,7 +200,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  public addContextSelection(selection: { filePath: string; filename: string; text: string }) {
+  public addContextSelection(selection: { filePath: string; filename: string; text: string; agentPath?: string }) {
     if (!this._view) {
       return;
     }
@@ -213,7 +213,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     });
   }
 
-  public addFileAttachments(files: Array<{ filePath: string; fileName: string; fileSize: number | null }>) {
+  public addFileAttachments(files: Array<{ filePath: string; fileName: string; fileSize: number | null; agentPath?: string }>) {
     if (!this._view) {
       return;
     }

--- a/packages/vscode/src/SessionEditorPanelProvider.ts
+++ b/packages/vscode/src/SessionEditorPanelProvider.ts
@@ -219,7 +219,7 @@ export class SessionEditorPanelProvider {
     return this._panels.get(panelId) ?? null;
   }
 
-  public addContextSelectionToActivePanel(selection: { filePath: string; filename: string; text: string }): boolean {
+  public addContextSelectionToActivePanel(selection: { filePath: string; filename: string; text: string; agentPath?: string }): boolean {
     if (!selection.filePath.trim() || !selection.filename.trim() || !selection.text.trim()) {
       return false;
     }
@@ -257,7 +257,7 @@ export class SessionEditorPanelProvider {
     return true;
   }
 
-  public addFileAttachmentsToActivePanel(files: Array<{ filePath: string; fileName: string; fileSize: number | null }>): boolean {
+  public addFileAttachmentsToActivePanel(files: Array<{ filePath: string; fileName: string; fileSize: number | null; agentPath?: string }>): boolean {
     const cleanedFiles = files.filter((entry) => entry.filePath.trim().length > 0 && entry.fileName.trim().length > 0);
 
     if (cleanedFiles.length === 0) {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -304,9 +304,12 @@ export async function activate(context: vscode.ExtensionContext) {
       const lineRange = startLine === endLine ? `${startLine}` : `${startLine}-${endLine}`;
 
       const filename = `${editor.document.fileName.split(/[\\/]/).pop() || filePath}:${lineRange}`;
+      // Workspace-relative path + line range for SDK disambiguation (basename-only label stays in `filename`).
+      const agentPath = `${filePath}:${lineRange}`;
       const contextSelection = {
         filePath: editor.document.uri.fsPath,
         filename,
+        agentPath,
         text: selectedText,
       };
 
@@ -336,7 +339,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       const uniqueUris = Array.from(new Map(uriCandidates.map((uri) => [uri.toString(), uri])).values());
-      const attachedFiles: Array<{ filePath: string; fileName: string; fileSize: number | null }> = [];
+      const attachedFiles: Array<{ filePath: string; fileName: string; fileSize: number | null; agentPath?: string }> = [];
       const skippedEntries: string[] = [];
 
       for (const uri of uniqueUris) {
@@ -358,6 +361,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
         const filePath = uri.fsPath.trim();
         const fileName = uri.fsPath.replace(/\\/g, '/').split('/').pop() || vscode.workspace.asRelativePath(uri, false).replace(/\\/g, '/').trim();
+        // Workspace-relative path (forward slashes) for SDK file disambiguation.
+        const agentPath = vscode.workspace.asRelativePath(uri, false).replace(/\\/g, '/').trim();
         if (!filePath || !fileName) {
           skippedEntries.push(uri.fsPath || uri.toString());
           continue;
@@ -369,7 +374,7 @@ export async function activate(context: vscode.ExtensionContext) {
         } catch {
           fileSize = null;
         }
-        attachedFiles.push({ filePath, fileName, fileSize });
+        attachedFiles.push({ filePath, fileName, fileSize, agentPath });
       }
 
       if (attachedFiles.length === 0) {

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -1216,9 +1216,14 @@ onCommand('addContextSelection', (payload) => {
     return;
   }
 
+  // Defensive coercion: agentPath is optional and may be absent/unknown shape at the webview boundary.
+  const agentPath = typeof (payload as { agentPath?: unknown }).agentPath === 'string'
+    ? ((payload as { agentPath?: string }).agentPath as string).trim()
+    : undefined;
+
   import('@/sync/input-store').then(({ useInputStore }) => {
     const file = new File([new Blob([text], { type: 'text/plain' })], trimmedFilename, { type: 'text/plain' });
-    void useInputStore.getState().addVSCodeSelectionAttachment(trimmedPath, file);
+    void useInputStore.getState().addVSCodeSelectionAttachment(trimmedPath, file, agentPath || undefined);
   });
 });
 
@@ -1249,13 +1254,14 @@ onCommand('addFileAttachments', (payload) => {
 
   const files = rawFiles
     .map((entry) => {
-      const record = entry as { filePath?: unknown; fileName?: unknown; fileSize?: unknown };
+      const record = entry as { filePath?: unknown; fileName?: unknown; fileSize?: unknown; agentPath?: unknown };
       const filePath = typeof record.filePath === 'string' ? record.filePath.trim() : '';
       const fileName = typeof record.fileName === 'string' ? record.fileName.trim() : '';
       const fileSize = typeof record.fileSize === 'number' && Number.isFinite(record.fileSize) ? record.fileSize : null;
-      return filePath && fileName ? { filePath, fileName, fileSize } : null;
+      const agentPath = typeof record.agentPath === 'string' ? record.agentPath.trim() : '';
+      return filePath && fileName ? { filePath, fileName, fileSize, agentPath } : null;
     })
-    .filter((entry): entry is { filePath: string; fileName: string; fileSize: number | null } => entry !== null);
+    .filter((entry): entry is { filePath: string; fileName: string; fileSize: number | null; agentPath: string } => entry !== null);
 
   if (files.length === 0) {
     return;
@@ -1264,7 +1270,7 @@ onCommand('addFileAttachments', (payload) => {
   import('@/sync/input-store').then(({ useInputStore }) => {
     const inputStore = useInputStore.getState();
     for (const file of files) {
-      inputStore.addVSCodeFileAttachment(file.filePath, file.fileName, file.fileSize);
+      inputStore.addVSCodeFileAttachment(file.filePath, file.fileName, file.fileSize, file.agentPath || undefined);
     }
   });
 });


### PR DESCRIPTION
…1914)

VS Code attachments leaked only path.basename() to the OpenCode SDK filename field, so the model received ambiguous references like `assist.ts:47` instead of `src/assist.ts:47`. With duplicate basenames across directories this caused the model to edit the wrong file.

Add an optional agentPath field to AttachedFile. VS Code computes it at all attachment entry points (Add-to-Context, Explorer attach, active- editor pin). The SDK mapping prefers agentPath over filename at all four send sites. Chip display is unchanged (basename). Web/Desktop attachments have no agentPath and fall back to filename.

Validation: workspace type-check, lint, and dead-code all green; 9/9 end-to-end correctness properties confirmed.

Known limitations (out of scope): the VS Code pickFiles button base64- encodes content and loses the path; web @mentions also leak basename. The "typo" in the synthetic Read-tool text lives in the OpenCode server (separate repo) and is out of scope.

Closes #1914.