### PR TITLE
feat(zai): show weekly tokens and MCP tools windows for z.ai

### DIFF
--- a/packages/web/server/lib/quota/providers/zai.js
+++ b/packages/web/server/lib/quota/providers/zai.js
@@ -57,17 +57,33 @@ export const fetchQuota = async () => {
 
     const payload = await response.json();
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
-    const tokensLimit = limits.find((limit) => limit?.type === 'TOKENS_LIMIT');
-    const windowSeconds = resolveWindowSeconds(tokensLimit);
-    const windowLabel = resolveWindowLabel(windowSeconds);
-    const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
-    const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
+    const tokensLimits = limits.filter((limit) => limit?.type === 'TOKENS_LIMIT');
+    const timeLimits = limits.filter((limit) => limit?.type === 'TIME_LIMIT');
 
     const windows = {};
-    if (tokensLimit) {
+    for (const tokensLimit of tokensLimits) {
+      const windowSeconds = resolveWindowSeconds(tokensLimit);
+      if (!windowSeconds) continue;
+      const windowLabel = resolveWindowLabel(windowSeconds);
+      const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
+      const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
+
       windows[windowLabel] = toUsageWindow({
         usedPercent,
         windowSeconds,
+        resetAt
+      });
+    }
+
+    // Handle TIME_LIMIT (MCP tools monthly window — unit=5 means 1 month / 30 days)
+    for (const timeLimit of timeLimits) {
+      const monthSeconds = 30 * 24 * 60 * 60;
+      const resetAt = timeLimit?.nextResetTime ? normalizeTimestamp(timeLimit.nextResetTime) : null;
+      const usedPercent = typeof timeLimit?.percentage === 'number' ? timeLimit.percentage : null;
+
+      windows['MCP Tools'] = toUsageWindow({
+        usedPercent,
+        windowSeconds: monthSeconds,
         resetAt
       });
     }

--- a/packages/web/server/lib/quota/utils/transformers.js
+++ b/packages/web/server/lib/quota/utils/transformers.js
@@ -35,8 +35,12 @@ export const normalizeTimestamp = (value) => {
 };
 
 export const resolveWindowSeconds = (limit) => {
-  const ZAI_TOKEN_WINDOW_SECONDS = { 3: 3600 };
-  if (!limit || !limit.number) return null;
+  if (!limit) return null;
+
+  if (limit.unit === 6) return 604800;
+
+  if (!limit.number) return null;
+  const ZAI_TOKEN_WINDOW_SECONDS = { 3: 3600, 4: 86400 };
   const unitSeconds = ZAI_TOKEN_WINDOW_SECONDS[limit.unit];
   if (!unitSeconds) return null;
   return unitSeconds * limit.number;


### PR DESCRIPTION
## Summary

The z.ai quota provider only surfaced the first `TOKENS_LIMIT` (the 5-hour window) and ignored `TIME_LIMIT` entries entirely. The z.ai API (`api/monitor/usage/quota/limit`) returns both weekly token usage and MCP tools monthly usage with distinct `unit` values, so iterate all entries instead of taking just the first.

## Changes

- `packages/web/server/lib/quota/utils/transformers.js` — extend `resolveWindowSeconds` to handle unit=4 (days, multiplied by `number`) and unit=6 (direct weekly = 604800s)
- `packages/web/server/lib/quota/providers/zai.js` — filter all `TOKENS_LIMIT`/`TIME_LIMIT` entries instead of `find`-ing the first; emit one window per `TOKENS_LIMIT` (5-hour + weekly) and an "MCP Tools" window for each `TIME_LIMIT` (mirrors the existing `zhipuai-coding-plan.js` implementation)

## Result

z.ai quota now displays:

- 5-Hour (5h window)
- Weekly (weekly token limit)
- MCP Tools (monthly, including the `usageDetails` model breakdown under `api`)

<img width="384" height="198" alt="openchamber" src="https://github.com/user-attachments/assets/9a138fb2-576e-4593-b45e-d241358326f2" />
<img width="520" height="674" alt="z.ai(truth)" src="https://github.com/user-attachments/assets/885af180-a579-4023-a900-0d55af28a8ad" />