### PR TITLE
ci: add merge-conflict label automation

### DIFF
--- a/.github/workflows/label-merge-conflict.yml
+++ b/.github/workflows/label-merge-conflict.yml
@@ -1,0 +1,31 @@
+name: label-merge-conflict
+
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  label:
+    if: ${{ github.repository == 'openchamber/openchamber' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Generate bot app token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.OC_REVIEW_APP_ID }}
+          private-key: ${{ secrets.OC_REVIEW_APP_PRIVATE_KEY }}
+
+      - name: Label pull requests with merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
+        with:
+          dirtyLabel: "merge-conflict:true"
+          repoToken: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
# What

- Adds `.github/workflows/label-merge-conflict.yml`, a new workflow that labels pull requests with `merge-conflict:true` when they have merge conflicts and removes the label once conflicts are resolved.
- Uses `eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1` (`v3.1.0`, SHA-pinned to the dereferenced commit).

# Why

When the base branch moves under an open PR, the PR can silently fall into a conflicting state with no signal to the author or reviewers. A dedicated `merge-conflict:true` label gives authors a single filter for "needs rebase" and lets maintainers skip conflicting PRs during review triage. This complements the existing `stale` automation with a conflict-specific signal.

# How to test

1. Confirm the workflow appears under the repo's Actions tab after merge and is enabled.
2. Open a PR that conflicts with `main` (edit the same lines on both sides), then push to `main` or synchronize the PR; verify the `merge-conflict:true` label is added.
3. Resolve the conflict and push; verify the label is removed.
4. Trigger via `workflow_dispatch` from the Actions tab to confirm manual runs succeed.

# Implementation notes

- Triggers: `push` to `main`, `pull_request_target` (`opened`, `synchronize`, `reopened`), and `workflow_dispatch` for manual runs.
- Uses `pull_request_target` (not `pull_request`) so fork PR labels can be updated, as recommended by the action.
- Scoped with `if: github.repository == 'openchamber/openchamber'` so it no-ops on forks, matching the `stale` workflow.
- Label writes use the existing bot app token (`OC_REVIEW_APP_ID` / `OC_REVIEW_APP_PRIVATE_KEY`) so attribution is `openchamber-bot[bot]`, consistent with `pr-review` and `triage`.
- The `merge-conflict:true` label must exist in the repo for the action to apply it; it should be created before/around merge.

---

Created with [create-pr](https://github.com/tomzx/agents/blob/37b68ebb745ee093af3dc02006cbf205b138f022/skills/create-pr/SKILL.md) via glm-5.2 (`37b68eb`)