### PR TITLE
feat(pr-review): add risk score to review comment output

### DIFF
--- a/.opencode/agent/pr-review.md
+++ b/.opencode/agent/pr-review.md
@@ -136,6 +136,13 @@ Merge signal in plain English: safe to merge, safe after a small fix, or not saf
 Explain the reason in a short paragraph. If there are findings, name the files that need attention.
 </details>
 
+<details open><summary><h3>Risk Score: X/5</h3></summary>
+
+1 is low risk (isolated, reversible, well-contained change), 5 is high risk (touches security, data persistence, shared state, build/release, or broad cross-runtime contracts).
+
+Explain the score in a short paragraph: which risk dimensions apply (correctness, data loss, security/supply-chain, performance, cross-runtime parity) and what makes the change more or less risky.
+</details>
+
 <details><summary><h3>Findings</h3></summary>
 
 If there are findings, list them like this:


### PR DESCRIPTION
# What

- Add a "Risk Score: X/5" section to the PR-review agent's comment template in `.opencode/agent/pr-review.md`, placed immediately after the existing Confidence Score block.
- The score uses a 1–5 scale anchored on the risk dimensions the agent already evaluates (correctness, data loss, security/supply-chain, performance, cross-runtime parity), with a short paragraph explaining which dimensions apply and what makes the change more or less risky.

# Why

The automated reviewer already produces a confidence/merge signal, but it did not surface an independent assessment of how risky the change itself is. A dedicated risk score gives maintainers a quick read on blast radius (e.g. whether a change touches security, data persistence, shared state, or broad cross-runtime contracts) separate from the merge-readiness confidence, so high-risk changes get appropriate scrutiny even when the reviewer is confident the implementation is correct.

# How to test

1. Inspect `.opencode/agent/pr-review.md` and confirm the new `<details open><summary><h3>Risk Score: X/5</h3></summary>` block sits between the Confidence Score block and the Findings block.
2. Trigger a review run on a sample PR and confirm the posted comment now includes both a Confidence Score and a Risk Score with a short justification paragraph.

---

Created with [create-pr](https://github.com/tomzx/agents/blob/37b68ebb745ee093af3dc02006cbf205b138f022/skills/create-pr/SKILL.md) via glm-5.2 (`37b68eb`)