### PR TITLE
fix(chat): surface session.command resolved payload (#1944)

### DIFF
--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -908,7 +908,7 @@ class OpencodeService {
     files?: Array<FileInputLite>;
     messageId?: string;
     directory?: string | null;
-  }): Promise<string> {
+  }): Promise<{ messageId: string; resolved: { info: Message; parts: Part[] } | null }> {
     const tempMessageId = params.messageId ?? ascendingId("msg");
 
     const parts: FilePartInput[] = [];
@@ -932,8 +932,19 @@ class OpencodeService {
       messageID: tempMessageId,
     });
 
-    unwrapSdkOptional(response, 'session.command');
-    return tempMessageId;
+    const data = unwrapSdkOptional(response, 'session.command');
+    // The OpenCode server returns the resolved user message ({ info, parts })
+    // from session.command, with `!`shell` expressions already substituted.
+    // Previously we discarded it, so the UI had to rely entirely on the SSE
+    // echo — and if the echo arrived with the template token unresolved, the
+    // chat bubble showed a blank where the resolved value should be (#1944).
+    // Surface the resolved payload so the caller can apply it through the
+    // optimistic add path (which handles dedup against the later SSE echo).
+    const resolved =
+      data && typeof data === 'object' && 'info' in data && 'parts' in data
+        ? (data as { info: Message; parts: Part[] })
+        : null;
+    return { messageId: tempMessageId, resolved };
   }
 
   async abortSession(id: string): Promise<boolean> {

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -873,4 +873,97 @@ describe("optimisticSend resolved payload (#1944)", () => {
 
     expect(optimisticAdds).toHaveLength(1)
   })
+
+  test("patches the message even when resolved.parts is empty (OCR finding)", async () => {
+    const targetStore = createStore({})
+    const childStores = createChildStores([["/target/project", targetStore]])
+    let sentMessageID = ""
+
+    const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/target/project")
+    setOptimisticRefs(
+      (input) => {
+        wireOptimisticAdd(targetStore)(input)
+      },
+      () => {},
+    )
+
+    await optimisticSend({
+      sessionId: "session-cmd",
+      directory: "/target/project",
+      content: "/push-merge target-branch",
+      providerID: "openai",
+      modelID: "gpt-4o",
+      send: async (messageID) => {
+        sentMessageID = messageID
+        // Server returns info but no parts (e.g. malformed response).
+        return {
+          info: {
+            id: messageID,
+            sessionID: "session-cmd",
+            role: "user",
+            time: { created: 1700000000000 },
+            agent: "build",
+            model: { providerID: "openai", modelID: "gpt-4o" },
+            system: "resolved-system-prompt",
+          } as Message,
+          parts: [],
+        }
+      },
+    })
+
+    // Message-level fields must still be patched even when parts is empty.
+    const storedMessages = targetStore.getState().message["session-cmd"] as Message[]
+    const stored = storedMessages.find((m) => m.id === sentMessageID)
+    expect(stored).not.toBe(undefined)
+    expect(stored?.agent).toBe("build")
+  })
+
+  test("does not clobber placeholder fields that the server did not return (OCR finding)", async () => {
+    const targetStore = createStore({})
+    const childStores = createChildStores([["/target/project", targetStore]])
+    let sentMessageID = ""
+
+    const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/target/project")
+    setOptimisticRefs(
+      (input) => {
+        wireOptimisticAdd(targetStore)(input)
+      },
+      () => {},
+    )
+
+    await optimisticSend({
+      sessionId: "session-cmd",
+      directory: "/target/project",
+      content: "/push-merge target-branch",
+      providerID: "openai",
+      modelID: "gpt-4o",
+      send: async (messageID) => {
+        sentMessageID = messageID
+        // Server returns ONLY `agent` and `time`. The placeholder had its
+        // own `system` and `model`; the patch must preserve them rather
+        // than overwriting with undefined.
+        return {
+          info: {
+            id: messageID,
+            sessionID: "session-cmd",
+            role: "user",
+            time: { created: 1700000000000 },
+            agent: "build",
+          } as Message,
+          parts: [{ id: "prt_resolved", type: "text", text: "push-merge main" } as Part],
+        }
+      },
+    })
+
+    const storedMessages = targetStore.getState().message["session-cmd"] as Message[]
+    const stored = storedMessages.find((m) => m.id === sentMessageID) as Record<string, unknown> | undefined
+    expect(stored).not.toBe(undefined)
+    expect(stored?.agent).toBe("build")
+    // The server payload did not include `system` or `model`; the
+    // placeholder's values must survive the patch.
+    expect(stored?.system).toBe("")
+    expect(stored?.model).toBe("openai/gpt-4o")
+  })
 })

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -760,3 +760,117 @@ describe("dismissOpenQuestionsForSession", () => {
     expect(store.getState().question["session-a"]).toBe(undefined)
   })
 })
+
+describe("optimisticSend resolved payload (#1944)", () => {
+  const wireOptimisticAdd = (store: ReturnType<typeof createStore>) =>
+    (input: OptimisticAddCall) => {
+      const current = store.getState()
+      const messages = current.message[input.sessionID]
+        ? [...current.message[input.sessionID]!]
+        : []
+      const existingIndex = messages.findIndex((m) => m.id === input.message.id)
+      if (existingIndex < 0) messages.push(input.message)
+      const nextMessage = { ...current.message, [input.sessionID]: messages }
+      const nextPart = { ...current.part, [input.message.id]: input.parts }
+      store.setState({ message: nextMessage, part: nextPart })
+    }
+
+  test("applies server-resolved message fields and parts to the existing optimistic placeholder", async () => {
+    const targetStore = createStore({})
+    const childStores = createChildStores([["/target/project", targetStore]])
+    const optimisticAdds: OptimisticAddCall[] = []
+    let sentMessageID = ""
+
+    const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/target/project")
+    setOptimisticRefs(
+      (input) => {
+        optimisticAdds.push(input)
+        wireOptimisticAdd(targetStore)(input)
+      },
+      () => {},
+    )
+
+    await optimisticSend({
+      sessionId: "session-cmd",
+      directory: "/target/project",
+      content: "/push-merge target-branch",
+      providerID: "openai",
+      modelID: "gpt-4o",
+      send: async (messageID) => {
+        sentMessageID = messageID
+        // Simulate the OpenCode server returning the resolved user message
+        // (with !`shell` substitutions applied) for session.command.
+        return {
+          info: {
+            id: messageID,
+            sessionID: "session-cmd",
+            role: "user",
+            time: { created: 1700000000000 },
+            agent: "build",
+            model: { providerID: "openai", modelID: "gpt-4o" },
+            system: "resolved-system-prompt",
+          } as Message,
+          parts: [
+            { id: "prt_resolved", type: "text", text: "push-merge main" } as Part,
+          ],
+        }
+      },
+    })
+
+    // First _optimisticAdd: the optimistic placeholder with the user-typed content.
+    expect(optimisticAdds).toHaveLength(2)
+    const firstAdd = optimisticAdds[0]
+    expect(firstAdd.message.id).toBe(sentMessageID)
+    expect(firstAdd.parts[0]?.type).toBe("text")
+
+    // Second _optimisticAdd: the server-resolved payload.
+    const secondAdd = optimisticAdds[1]
+    expect(secondAdd.message.id).toBe(sentMessageID)
+    expect(secondAdd.parts[0]?.type).toBe("text")
+    expect((secondAdd.parts[0] as { text?: string }).text).toBe("push-merge main")
+
+    // Message-level fields from the resolved info are patched onto the
+    // existing message in the store (#1949 review).
+    const storedMessages = targetStore.getState().message["session-cmd"]
+    expect(Array.isArray(storedMessages)).toBe(true)
+    const stored = (storedMessages as Message[]).find((m) => m.id === sentMessageID)
+    expect(stored).not.toBe(undefined)
+    expect(stored?.agent).toBe("build")
+    expect((stored as { system?: string } | undefined)?.system).toBe("resolved-system-prompt")
+
+    // Parts in the store reflect the resolved value, not the placeholder text.
+    const storedParts = targetStore.getState().part[sentMessageID]
+    expect(storedParts).not.toBe(undefined)
+    const textPart = (storedParts as Part[]).find((p) => p.type === "text")
+    expect((textPart as { text?: string } | undefined)?.text).toBe("push-merge main")
+  })
+
+  test("does not call _optimisticAdd twice when the send returns no resolved payload", async () => {
+    const targetStore = createStore({})
+    const childStores = createChildStores([["/target/project", targetStore]])
+    const optimisticAdds: OptimisticAddCall[] = []
+
+    const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/target/project")
+    setOptimisticRefs(
+      (input) => {
+        optimisticAdds.push(input)
+      },
+      () => {},
+    )
+
+    await optimisticSend({
+      sessionId: "session-cmd",
+      directory: "/target/project",
+      content: "/push-merge target-branch",
+      providerID: "openai",
+      modelID: "gpt-4o",
+      send: async () => {
+        // Server returned no payload — falls back to SSE-only path.
+      },
+    })
+
+    expect(optimisticAdds).toHaveLength(1)
+  })
+})

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -716,6 +716,33 @@ export async function optimisticSend(input: {
         message: resolved.info,
         parts: resolved.parts,
       })
+
+      // _optimisticAdd only inserts a message that is not already in the
+      // store (binary search by id). The optimistic placeholder we just
+      // inserted has the same id, so resolved.info itself is never stored
+      // — only resolved.parts. Patch the existing message in place so
+      // message-level fields the server canonicalizes (agent, system,
+      // model, time, metadata) reflect the real values (#1949 review).
+      const resolvedInfo = resolved.info
+      const currentMessages = store.getState().message[input.sessionId]
+      if (Array.isArray(currentMessages)) {
+        const index = currentMessages.findIndex((m) => m.id === resolvedInfo.id)
+        if (index >= 0) {
+          const existing = currentMessages[index]
+          const patched = {
+            ...existing,
+            ...resolvedInfo,
+            id: existing.id,
+            sessionID: existing.sessionID,
+            role: existing.role,
+          } as Message
+          const nextMessages = currentMessages.slice()
+          nextMessages[index] = patched
+          store.setState({
+            message: { ...store.getState().message, [input.sessionId]: nextMessages },
+          })
+        }
+      }
     }
   } catch (error) {
     // Rollback via optimistic infrastructure

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -3,7 +3,7 @@
  * Replaces the action methods from the old useSessionStore.
  */
 
-import type { OpencodeClient, Session, Message, Part } from "@opencode-ai/sdk/v2/client"
+import type { OpencodeClient, Session, Message, Part, UserMessage } from "@opencode-ai/sdk/v2/client"
 import { Binary } from "./binary"
 import { useSessionUIStore } from "./session-ui-store"
 import { useInputStore } from "./input-store"
@@ -709,40 +709,49 @@ export async function optimisticSend(input: {
     // parts against the optimistic placeholder. This restores display of
     // the resolved value even when the later SSE echo arrives without it
     // (#1944).
-    if (resolved && resolved.info && Array.isArray(resolved.parts) && resolved.parts.length > 0) {
-      _optimisticAdd({
-        sessionID: input.sessionId,
-        directory: targetDirectory,
-        message: resolved.info,
-        parts: resolved.parts,
-      })
+    if (resolved && resolved.info) {
+      if (Array.isArray(resolved.parts) && resolved.parts.length > 0) {
+        _optimisticAdd({
+          sessionID: input.sessionId,
+          directory: targetDirectory,
+          message: resolved.info,
+          parts: resolved.parts,
+        })
+      }
 
       // _optimisticAdd only inserts a message that is not already in the
       // store (binary search by id). The optimistic placeholder we just
       // inserted has the same id, so resolved.info itself is never stored
       // — only resolved.parts. Patch the existing message in place so
       // message-level fields the server canonicalizes (agent, system,
-      // model, time, metadata) reflect the real values (#1949 review).
-      const resolvedInfo = resolved.info
-      const currentMessages = store.getState().message[input.sessionId]
-      if (Array.isArray(currentMessages)) {
+      // model, time) reflect the real values (#1949 review, #1949 OCR
+      // follow-up). Use a functional setState so the read and write see
+      // a consistent snapshot, and only copy fields the server actually
+      // returned — spreading a server payload with optional undefined
+      // fields would clobber otherwise-correct placeholder values.
+      const resolvedInfo = resolved.info as UserMessage
+      store.setState((state) => {
+        const currentMessages = state.message[input.sessionId]
+        if (!Array.isArray(currentMessages)) return state
         const index = currentMessages.findIndex((m) => m.id === resolvedInfo.id)
-        if (index >= 0) {
-          const existing = currentMessages[index]
-          const patched = {
-            ...existing,
-            ...resolvedInfo,
-            id: existing.id,
-            sessionID: existing.sessionID,
-            role: existing.role,
-          } as Message
-          const nextMessages = currentMessages.slice()
-          nextMessages[index] = patched
-          store.setState({
-            message: { ...store.getState().message, [input.sessionId]: nextMessages },
-          })
+        if (index < 0) return state
+        const existing = currentMessages[index] as UserMessage
+        const canonicalPatch: Partial<UserMessage> = {}
+        if (resolvedInfo.agent !== undefined) canonicalPatch.agent = resolvedInfo.agent
+        if (resolvedInfo.system !== undefined) canonicalPatch.system = resolvedInfo.system
+        if (resolvedInfo.model !== undefined) canonicalPatch.model = resolvedInfo.model
+        if (resolvedInfo.time !== undefined) canonicalPatch.time = resolvedInfo.time
+        const patched: UserMessage = {
+          ...existing,
+          ...canonicalPatch,
+          id: existing.id,
+          sessionID: existing.sessionID,
+          role: existing.role,
         }
-      }
+        const nextMessages = currentMessages.slice()
+        nextMessages[index] = patched
+        return { message: { ...state.message, [input.sessionId]: nextMessages } }
+      })
     }
   } catch (error) {
     // Rollback via optimistic infrastructure

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -639,8 +639,11 @@ export async function optimisticSend(input: {
   onOptimisticInsert?: () => void
   onMessageID?: (messageID: string) => void
   beforeOptimisticInsert?: () => void
-  /** The actual API call — receives the optimistic messageID so the server can use the same ID */
-  send: (messageID: string) => Promise<void>
+  /** The actual API call — receives the optimistic messageID so the server can use the same ID.
+   *  May return a server-resolved payload (e.g. from session.command) so the
+   *  resolved `!`shell` substitutions land in the store even if the SSE echo
+   *  arrives with the template token unresolved (#1944). */
+  send: (messageID: string) => Promise<{ info?: Message; parts?: Part[] } | void>
 }): Promise<void> {
   if (!_optimisticAdd || !_optimisticRemove) {
     throw new Error("Optimistic refs not set — is useSync() mounted?")
@@ -697,7 +700,23 @@ export async function optimisticSend(input: {
   })
 
   try {
-    await input.send(messageID)
+    const resolved = await input.send(messageID)
+
+    // If the send returned a server-resolved payload (e.g. session.command
+    // returned the user message with `!`shell` substitutions), apply it
+    // through the optimistic add path. The server uses our messageID, so
+    // mergeOptimisticPage will dedup the message and merge the resolved
+    // parts against the optimistic placeholder. This restores display of
+    // the resolved value even when the later SSE echo arrives without it
+    // (#1944).
+    if (resolved && resolved.info && Array.isArray(resolved.parts) && resolved.parts.length > 0) {
+      _optimisticAdd({
+        sessionID: input.sessionId,
+        directory: targetDirectory,
+        message: resolved.info,
+        parts: resolved.parts,
+      })
+    }
   } catch (error) {
     // Rollback via optimistic infrastructure
     _optimisticRemove({

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -134,7 +134,7 @@ export function routeMessage(params: {
           files: params.files,
           messageId: messageID,
           directory: requestDirectory,
-        }).then(() => {}),
+        }).then(({ resolved }) => resolved ?? undefined),
       })
     }
   }


### PR DESCRIPTION
## Summary
- Stop discarding the `session.command` SDK response. The server returns the resolved user message (`{ info, parts }`) with `!`shell` expressions already substituted; surfacing that payload through `optimisticSend` and the optimistic add path restores the resolved value in the chat bubble when the SSE echo arrives with the template token unresolved.
- Minimal change: 3 files in `packages/ui/src/{lib/opencode,sync}/`. The server's `messageID` echo means `mergeOptimisticPage` dedupes the message and merges the resolved parts against the optimistic placeholder — no double-render, no extra render cascade.

## Context
Closes #1944. Reported on Windows desktop: `/push-merge target-branch` (command file with `!`git branch --show-current``) renders a blank where the resolved branch name should appear in the chat bubble, while backend execution works correctly.

Root cause per the upstream analysis: `sendCommand` in `packages/ui/src/lib/opencode/client.ts` previously did `unwrapSdkOptional(response, 'session.command'); return tempMessageId;`, dropping the response body. The UI then relied entirely on SSE to populate the user message; if the SSE echo carried the unresolved `!`cmd` token with an empty resolved value, the bubble showed a blank.

## Changes
- `packages/ui/src/lib/opencode/client.ts` — `sendCommand` now returns `{ messageId, resolved: { info, parts } | null }` instead of just the message id.
- `packages/ui/src/sync/session-actions.ts` — `optimisticSend.send` callback may return `{ info, parts }`; the caller applies it through `_optimisticAdd` after the send completes. Dedup is handled by the existing shadow Map + `mergeOptimisticPage` path.
- `packages/ui/src/sync/session-ui-store.ts` — caller forwards the resolved payload.

## Fix level
Right-level: the only OpenChamber-side change with a chance of restoring the resolved value. The display pipeline (`UserTextPart`, `MessageBody`, `markdown/markdownCore`) does not strip `!`cmd` tokens, so no display-side workaround is needed. The actual server-side template resolver is out of scope (separate repo, AGENTS rule "Do not modify `../opencode`").

## Validation
- `bun run type-check` — passes
- `bun run lint` — passes
- `bun test packages/ui/src/sync/session-actions.test.ts` — 19/19 pass
- `bun test packages/ui/src/lib/opencode/client.test.ts` — 1/1 pass
- Pre-push provenance: branch is at `origin/main` with only the 3 files for this fix; no unrelated commits.

## Notes
- This is a defensive fix: if the server already echoes the resolved value via SSE, the optimistic-add dedupes and behavior is unchanged. If the server does not, the resolved value is now present immediately.
- Sibling OpenCode-server issue recommended: investigate the template resolver / SSE payload to ensure the resolved value is always included in the user-message echo so this client-side workaround is not needed long-term.