### PR TITLE
fix(git): prefer open upstream PR over merged fork PR (#1771)

### DIFF
--- a/packages/web/server/lib/github/pr-status.js
+++ b/packages/web/server/lib/github/pr-status.js
@@ -423,7 +423,17 @@ const searchFallbackPr = async ({ octokit, branch, repoNames }) => {
   return null;
 };
 
-const findFirstMatchingPr = async ({ octokit, target, branch, sourceCandidates }) => {
+// Find the best PR for the given target/branch filtered by state ('open' or
+// 'closed'). Ordering inside a single target is preserved: direct owner match
+// first, then fallback (any head), then source-rank sort. Returning the state
+// explicitly lets the outer loop prefer open PRs across multiple targets — see
+// #1771: an open upstream PR must win over a merged fork PR even when the fork
+// target is queried first.
+//
+// Exported for direct unit testing in pr-status.test.js — keeping the unit
+// tests close to the helper avoids a fully-mocked e2e harness for what is
+// otherwise a pure function over an octokit-like object.
+export const findFirstMatchingPr = async ({ octokit, target, branch, sourceCandidates, state }) => {
   const matcher = buildSourceMatcher(sourceCandidates);
   const sourceOwners = [];
   sourceCandidates.forEach((candidate) => pushUnique(sourceOwners, candidate.repo?.owner));
@@ -433,34 +443,27 @@ const findFirstMatchingPr = async ({ octokit, target, branch, sourceCandidates }
     .filter((pr) => matcher.matches(pr, target.repo.repo))
     .sort((left, right) => matcher.compare(left, right, target.repo.repo))[0] ?? null;
 
-  for (const state of ['open', 'closed']) {
-    for (const owner of sourceOwners) {
-      const directCandidates = await safeListPulls(octokit, {
-        owner: target.repo.owner,
-        repo: target.repo.repo,
-        state,
-        head: `${owner}:${branch}`,
-        per_page: 100,
-      });
-      const direct = pickPreferred(directCandidates);
-      if (direct) {
-        return direct;
-      }
-    }
-
-    const fallbackCandidates = await safeListPulls(octokit, {
+  for (const owner of sourceOwners) {
+    const directCandidates = await safeListPulls(octokit, {
       owner: target.repo.owner,
       repo: target.repo.repo,
       state,
+      head: `${owner}:${branch}`,
       per_page: 100,
     });
-    const fallback = pickPreferred(fallbackCandidates);
-    if (fallback) {
-      return fallback;
+    const direct = pickPreferred(directCandidates);
+    if (direct) {
+      return direct;
     }
   }
 
-  return null;
+  const fallbackCandidates = await safeListPulls(octokit, {
+    owner: target.repo.owner,
+    repo: target.repo.repo,
+    state,
+    per_page: 100,
+  });
+  return pickPreferred(fallbackCandidates);
 };
 
 export async function resolveGitHubPrStatus({ octokit, directory, branch, remoteName }) {
@@ -507,37 +510,60 @@ export async function resolveGitHubPrStatus({ octokit, directory, branch, remote
 
   const sourceCandidates = resolvedTargets.slice();
 
+  // Precompute the default branch for every target in parallel. The PR-lookup
+  // loop below runs in two phases (open, then closed — see #1771) and the
+  // default-branch value is invariant across phases. `getRepoDefaultBranch`
+  // already caches via defaultBranchCache / repoMetadataCache, so the only
+  // remaining cost is the network latency of the first hit per repo — which is
+  // why we fan the calls out concurrently instead of awaiting serially.
+  const targetDefaultBranches = new Map(
+    await Promise.all(
+      resolvedTargets.map(async (target) => [target, await getRepoDefaultBranch(octokit, target.repo)]),
+    ),
+  );
+
   let fallbackRepo = resolvedTargets[0].repo;
   let fallbackRemoteName = resolvedTargets[0].remoteName;
-  let fallbackDefaultBranch = await getRepoDefaultBranch(octokit, fallbackRepo);
+  let fallbackDefaultBranch = targetDefaultBranches.get(resolvedTargets[0]) ?? null;
 
-  for (const target of resolvedTargets) {
-    const defaultBranch = await getRepoDefaultBranch(octokit, target.repo);
-    if (!fallbackRepo) {
-      fallbackRepo = target.repo;
-      fallbackRemoteName = target.remoteName;
-      fallbackDefaultBranch = defaultBranch;
-    }
-
-    const hasCrossRepoSource = sourceCandidates.some((candidate) => normalizeRepoKey(candidate.repo?.owner, candidate.repo?.repo) !== normalizeRepoKey(target.repo?.owner, target.repo?.repo));
-    for (const candidateBranch of branchCandidates) {
-      if (defaultBranch && defaultBranch === candidateBranch && !hasCrossRepoSource) {
-        continue;
+  // Run the PR lookup in two phases: prefer any open PR across every target
+  // before falling back to closed/merged. Without this split, a merged PR on
+  // a fork target hides an open PR on the upstream target — see #1771.
+  for (const state of ['open', 'closed']) {
+    for (const target of resolvedTargets) {
+      const targetDefaultBranch = targetDefaultBranches.get(target) ?? null;
+      // Preserved from the pre-#1771 loop: `fallbackRepo` is initialized from
+      // `resolvedTargets[0].repo` above, so this guard never fires in practice.
+      // Kept as-is to keep the diff scoped to the open-over-closed fix; any
+      // fallback-rewrite of dead branches belongs in a separate change.
+      if (!fallbackRepo) {
+        fallbackRepo = target.repo;
+        fallbackRemoteName = target.remoteName;
+        fallbackDefaultBranch = targetDefaultBranch;
       }
 
-      const pr = await findFirstMatchingPr({
-        octokit,
-        target,
-        branch: candidateBranch,
-        sourceCandidates,
-      });
-      if (pr) {
-        return {
-          repo: target.repo,
-          pr,
-          defaultBranch,
-          resolvedRemoteName: target.remoteName,
-        };
+      const hasCrossRepoSource = sourceCandidates.some((candidate) => normalizeRepoKey(candidate.repo?.owner, candidate.repo?.repo) !== normalizeRepoKey(target.repo?.owner, target.repo?.repo));
+
+      for (const candidateBranch of branchCandidates) {
+        if (targetDefaultBranch && targetDefaultBranch === candidateBranch && !hasCrossRepoSource) {
+          continue;
+        }
+
+        const pr = await findFirstMatchingPr({
+          octokit,
+          target,
+          branch: candidateBranch,
+          sourceCandidates,
+          state,
+        });
+        if (pr) {
+          return {
+            repo: target.repo,
+            pr,
+            defaultBranch: targetDefaultBranch,
+            resolvedRemoteName: target.remoteName,
+          };
+        }
       }
     }
   }

--- a/packages/web/server/lib/github/pr-status.test.js
+++ b/packages/web/server/lib/github/pr-status.test.js
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock side-effect-free dependencies so the module under test can load.
+// safeListPulls is internal — we exercise it through real octokit objects.
+vi.mock('node:fs/promises', () => ({
+  stat: vi.fn(),
+}));
+
+vi.mock('../git/index.js', () => ({
+  getStatus: vi.fn(),
+  getRemotes: vi.fn(),
+}));
+
+vi.mock('./repo/index.js', () => ({
+  resolveGitHubRepoFromDirectory: vi.fn(),
+}));
+
+vi.mock('./rate-limit.js', () => ({
+  noteIfGitHubRateLimit: vi.fn(),
+}));
+
+const { findFirstMatchingPr, resolveGitHubPrStatus } = await import('./pr-status.js');
+
+const makeOctokit = (responses) => {
+  const pullsList = vi.fn(async (options) => {
+    const state = options.state;
+    const headKey = options.head ?? '*';
+    const key = `${state}|${headKey}`;
+    const handler = responses[key];
+    if (handler) {
+      return { data: typeof handler === 'function' ? handler(options) : handler };
+    }
+    return { data: [] };
+  });
+  return {
+    rest: {
+      pulls: { list: pullsList },
+      repos: {
+        get: vi.fn(async () => ({ data: { default_branch: 'main' } })),
+      },
+    },
+  };
+};
+
+const makePr = ({ number, owner, repo, branch, state, headLabel }) => ({
+  number,
+  state,
+  head: {
+    ref: branch,
+    label: headLabel ?? `${owner}:${branch}`,
+    repo: { owner: { login: owner }, name: repo },
+    user: { login: owner },
+  },
+  base: {
+    repo: { owner: { login: 'openchamber' }, name: 'openchamber' },
+  },
+});
+
+describe('findFirstMatchingPr', () => {
+  const branch = 'fix/git-tab-pr-priority';
+  const upstreamTarget = { repo: { owner: 'openchamber', repo: 'openchamber' } };
+  const forkTarget = { repo: { owner: 'bashrusakh', repo: 'openchamber' } };
+  const sourceCandidates = [upstreamTarget, forkTarget];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the upstream open PR even when a merged fork PR exists (#1771)', async () => {
+    const upstreamOpenPr = makePr({
+      number: 1772,
+      owner: 'bashrusakh',
+      repo: 'openchamber',
+      branch,
+      state: 'open',
+    });
+    const mergedForkPr = makePr({
+      number: 10,
+      owner: 'bashrusakh',
+      repo: 'openchamber',
+      branch,
+      state: 'closed',
+      headLabel: 'bashrusakh:fix/git-tab-pr-priority',
+    });
+
+    // Target is the upstream repo. Source candidates cover both upstream + fork.
+    const octokit = makeOctokit({
+      'open|bashrusakh:fix/git-tab-pr-priority': [upstreamOpenPr],
+      'open|openchamber:fix/git-tab-pr-priority': [],
+      'open|*': [upstreamOpenPr],
+      'closed|bashrusakh:fix/git-tab-pr-priority': [mergedForkPr],
+      'closed|*': [mergedForkPr],
+    });
+
+    const pr = await findFirstMatchingPr({
+      octokit,
+      target: upstreamTarget,
+      branch,
+      sourceCandidates,
+      state: 'open',
+    });
+
+    expect(pr).not.toBeNull();
+    expect(pr.number).toBe(1772);
+    expect(pr.state).toBe('open');
+  });
+
+  it('falls back to closed/merged when no open PR exists', async () => {
+    const mergedForkPr = makePr({
+      number: 10,
+      owner: 'bashrusakh',
+      repo: 'openchamber',
+      branch,
+      state: 'closed',
+    });
+    const octokit = makeOctokit({
+      'open|bashrusakh:fix/git-tab-pr-priority': [],
+      'open|openchamber:fix/git-tab-pr-priority': [],
+      'open|*': [],
+      'closed|bashrusakh:fix/git-tab-pr-priority': [mergedForkPr],
+      'closed|*': [mergedForkPr],
+    });
+
+    const pr = await findFirstMatchingPr({
+      octokit,
+      target: upstreamTarget,
+      branch,
+      sourceCandidates,
+      state: 'closed',
+    });
+
+    expect(pr).not.toBeNull();
+    expect(pr.number).toBe(10);
+  });
+
+  it('returns null when no matching PR exists for any state', async () => {
+    const octokit = makeOctokit({});
+    const pr = await findFirstMatchingPr({
+      octokit,
+      target: upstreamTarget,
+      branch,
+      sourceCandidates,
+      state: 'open',
+    });
+    expect(pr).toBeNull();
+  });
+
+  it('prefers upstream source when multiple open candidates match', async () => {
+    const forkOpenPr = makePr({
+      number: 5,
+      owner: 'bashrusakh',
+      repo: 'openchamber',
+      branch,
+      state: 'open',
+      headLabel: 'bashrusakh:fix/git-tab-pr-priority',
+    });
+    const upstreamOpenPr = makePr({
+      number: 6,
+      owner: 'openchamber',
+      repo: 'openchamber',
+      branch,
+      state: 'open',
+      headLabel: 'openchamber:fix/git-tab-pr-priority',
+    });
+
+    const octokit = makeOctokit({
+      'open|bashrusakh:fix/git-tab-pr-priority': [forkOpenPr],
+      'open|openchamber:fix/git-tab-pr-priority': [upstreamOpenPr],
+      'open|*': [forkOpenPr, upstreamOpenPr],
+    });
+
+    const pr = await findFirstMatchingPr({
+      octokit,
+      target: upstreamTarget,
+      branch,
+      sourceCandidates,
+      state: 'open',
+    });
+
+    // Upstream PR is preferred because it ranks first in sourceCandidates.
+    expect(pr).not.toBeNull();
+    expect(pr.number).toBe(6);
+  });
+});
+
+describe('resolveGitHubPrStatus — #1771 cross-target priority', () => {
+  const branch = 'fix/git-tab-pr-priority';
+  const dir = '/tmp/some-worktree';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the open upstream PR even when the fork target is queried first', async () => {
+    const { stat } = await import('node:fs/promises');
+    const { getStatus, getRemotes } = await import('../git/index.js');
+    const { resolveGitHubRepoFromDirectory } = await import('./repo/index.js');
+
+    stat.mockResolvedValue({});
+    getStatus.mockResolvedValue({ tracking: 'origin/fix/git-tab-pr-priority' });
+    getRemotes.mockResolvedValue([
+      { name: 'origin', url: 'https://github.com/bashrusakh/openchamber' },
+      { name: 'upstream', url: 'https://github.com/openchamber/openchamber' },
+    ]);
+
+    // First remote in the resolved list is the fork (origin), then upstream.
+    resolveGitHubRepoFromDirectory
+      .mockResolvedValueOnce({
+        repo: { owner: 'bashrusakh', repo: 'openchamber' },
+      })
+      .mockResolvedValueOnce({
+        repo: { owner: 'openchamber', repo: 'openchamber' },
+      });
+
+    const upstreamOpenPr = makePr({
+      number: 1772,
+      owner: 'bashrusakh',
+      repo: 'openchamber',
+      branch,
+      state: 'open',
+    });
+    const mergedForkPr = makePr({
+      number: 10,
+      owner: 'bashrusakh',
+      repo: 'openchamber',
+      branch,
+      state: 'closed',
+    });
+
+    // respond by (target_owner, head_owner, state) so both targets get the
+    // right payload. We need the fork target's "open" to be empty (so the
+    // outer loop advances to the upstream target) and the upstream's "open"
+    // to surface the upstream PR.
+    const calls = [];
+    const pullsList = vi.fn(async (options) => {
+      calls.push(options);
+      const isForkTarget = options.owner === 'bashrusakh';
+      const headOwner = options.head?.split(':')[0];
+      const state = options.state;
+
+      if (state === 'open') {
+        if (isForkTarget) {
+          return { data: [] };
+        }
+        if (headOwner === 'bashrusakh') {
+          return { data: [upstreamOpenPr] };
+        }
+        if (headOwner === 'openchamber') {
+          return { data: [] };
+        }
+        return { data: [upstreamOpenPr] };
+      }
+
+      // closed — only fork has a merged PR
+      if (headOwner === 'bashrusakh') {
+        return { data: [mergedForkPr] };
+      }
+      return { data: [mergedForkPr] };
+    });
+
+    const octokit = {
+      rest: {
+        pulls: { list: pullsList },
+        repos: {
+          get: vi.fn(async ({ owner, repo }) => ({
+            data: {
+              default_branch: 'main',
+              parent: { owner: { login: 'openchamber' }, name: 'openchamber' },
+            },
+          })),
+        },
+      },
+    };
+
+    const result = await resolveGitHubPrStatus({
+      octokit,
+      directory: dir,
+      branch,
+      remoteName: 'origin',
+    });
+
+    expect(result.pr).not.toBeNull();
+    expect(result.pr.number).toBe(1772);
+    expect(result.pr.state).toBe('open');
+    // Critical: we must have queried an "open" state for the upstream target,
+    // proving the two-phase loop did not stop at the fork target's merged PR.
+    const queriedUpstreamOpen = calls.some(
+      (c) => c.state === 'open' && c.owner === 'openchamber',
+    );
+    expect(queriedUpstreamOpen).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fix git tab PR selection priority: when a branch has both a merged PR on the fork and an open PR on the upstream (main) repo, the git tab was hiding the open upstream PR and showing the merged fork PR instead.

Fixes #1771.

## Problem

`packages/web/server/lib/github/pr-status.js#findFirstMatchingPr` returned at the first match per `(state, target)` iteration. `resolveGitHubPrStatus` then iterated over `resolvedTargets` in fork-first order, so:

- On the fork target, the **open** phase matched nothing (the fork PR was merged, not open).
- The same call then ran the **closed** phase, matched the merged fork PR, and returned it.
- The outer loop never advanced to the upstream target, where an open PR existed.

The result: an open upstream PR was shadowed by a merged fork PR on the same branch.

## Approach

Two-phase PR lookup, open first across every target, then closed as a fallback:

- `findFirstMatchingPr` now takes an explicit `state` filter (`'open'` or `'closed'`). Source-rank ordering inside a single target is preserved (direct owner match first, then any-head fallback, then upstream > fork sort by `matcher.compare`).
- `resolveGitHubPrStatus` runs the PR lookup in two phases: first `'open'` across every target, then `'closed'` as a fallback. This makes open PRs globally preferred over merged PRs regardless of target order.
- `targetDefaultBranches` is precomputed once via `Promise.all` before the state loop — the value is invariant across phases, and `getRepoDefaultBranch` only does a real GitHub API call on a cache miss, so parallelizing the precompute is cheap and avoids serial network latency when there are multiple targets.

## Implementation notes (from `open-code-review`)

The OCR pass produced 2 medium-priority notes. Both are addressed:

- **Sequential `await` in precompute loop** → switched to `Promise.all`.
- **Dead `if (!fallbackRepo)` guard inside the PR-lookup loop** → preserved as-is from the pre-#1771 code, with a comment explaining that any fallback-rewrite of dead branches is out of scope for this fix. (See "Out of scope" below.)
- **Export of `findFirstMatchingPr`** → kept (with a comment). It's a pure helper, and exporting it lets the unit tests stay close to the function instead of requiring a fully-mocked e2e harness.

## Out of scope (deliberately)

- The `if (!fallbackRepo)` branch in `resolveGitHubPrStatus` is unreachable (`fallbackRepo` is initialized from `resolvedTargets[0].repo` before the loop, and `resolvedTargets.length === 0` returns early). It has been preserved verbatim to keep this PR strictly scoped to the open-over-closed priority fix.
- Any future cleanup of that dead branch (or related fallback-rewrite) belongs in a separate change.

## Reproduction (from the issue)

1. Fork the repo.
2. Open a PR on upstream (`openchamber/openchamber`).
3. Open a second PR on your fork targeting the fork.
4. Merge the fork PR.
5. Git tab shows the merged fork PR; the open upstream PR is hidden.

After this fix, the git tab shows the open upstream PR.

## Tests

New `packages/web/server/lib/github/pr-status.test.js` (vitest) with 5 cases:

1. `findFirstMatchingPr` returns the upstream open PR when both upstream open and fork merged exist (the #1771 scenario).
2. Falls back to closed/merged when no open PR exists.
3. Returns `null` when no matching PR exists for any state.
4. Prefers the upstream source when multiple open candidates match.
5. End-to-end `resolveGitHubPrStatus` test: with fork target queried first and only a merged fork PR + open upstream PR in the fixture, the result is the open upstream PR (proving the two-phase loop does not stop at the fork target's merged PR).

## Validation

- `bun x vitest run` in `packages/web` — **569 passed, 2 skipped (pre-existing), 0 failures**.
- `bun x eslint` on the touched files — **clean**.
- `open-code-review` (`ocr review --audience agent --from origin/main --to HEAD`) on the diff — **0 high-priority, 2 medium (both addressed in code as noted above)**.

## Files

```
 packages/web/server/lib/github/pr-status.js      | 120 +++++----
 packages/web/server/lib/github/pr-status.test.js | 292 +++++++++++++++++++++++
 2 files changed, 365 insertions(+), 47 deletions(-)
```

## Related

- Issue #1771 — root cause analysis
- Closes superseded PR #1772 (the original branch contained unrelated commits from a different task)
