### PR TITLE
fix(pwa): focus existing window on notification click

### DIFF
--- a/packages/web/src/sw.ts
+++ b/packages/web/src/sw.ts
@@ -67,5 +67,30 @@ self.addEventListener('notificationclick', (event) => {
   const data = (event.notification.data ?? null) as { url?: string } | null;
   const url = data?.url ?? '/';
 
-  event.waitUntil(self.clients.openWindow(url));
+  event.waitUntil((async () => {
+    // Prefer focusing an already-open window (e.g. the installed PWA) and
+    // navigating it to the target, instead of always spawning a new window.
+    const target = new URL(url, self.location.origin).href;
+    const windowClients = await self.clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true,
+    });
+
+    for (const client of windowClients) {
+      try {
+        if ('navigate' in client) {
+          await client.navigate(target);
+        }
+      } catch {
+        // navigate() can reject for uncontrolled clients; fall back to focus.
+      }
+      if ('focus' in client) {
+        return client.focus();
+      }
+    }
+
+    if (self.clients.openWindow) {
+      return self.clients.openWindow(target);
+    }
+  })());
 });


### PR DESCRIPTION
## Problem
Clicking a push notification always opens a **new** window/PWA instance, because `notificationclick` in `packages/web/src/sw.ts` calls `self.clients.openWindow(url)` unconditionally.

## Fix
Enumerate existing window clients; focus one and navigate it to the deep-link, only falling back to `openWindow` when none exist. The deep-link is a relative URL (`/?session=…`), so it's resolved against `self.location.origin` first. `navigate()` is wrapped in try/catch since it can reject for uncontrolled clients.

Verified on a live `@openchamber/web` 1.13.8 instance (exposed via Tailscale) — notification clicks now focus the running PWA instead of spawning a second window.

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)