### PR TITLE
feat(pr-review): apply risk and confidence score labels to reviewed PRs

### DIFF
--- a/.opencode/agent/pr-review.md
+++ b/.opencode/agent/pr-review.md
@@ -117,11 +117,11 @@ Briefly explain what this PR changes and what problem it is trying to solve.
 - Mention whether prior bot/review comments look addressed, if applicable.
 - Mention the most important risk or state that no concrete issue was found.
 
-<details open><summary><h3>Confidence Score: X/5</h3></summary>
+<details open><summary><h3>Confidence Score: X/5 · Risk Score: Y/5</h3></summary>
 
 Merge signal in plain English: safe to merge, safe after a small fix, or not safe to merge yet.
 
-Explain the reason in a short paragraph. If there are findings, name the files that need attention.
+Explain the reason in a short paragraph. If there are findings, name the files that need attention. The X and Y values here are the same ones applied as `confidence:X` and `risk:Y` labels below.
 </details>
 
 <details><summary><h3>Findings</h3></summary>
@@ -145,3 +145,22 @@ If there are no findings, write: No concrete findings in this pass.
 ```
 
 Keep the comment factual and compact. The reader should understand whether the PR is safe, what must be fixed, and why.
+
+## Scoring and labels
+
+The review produces two 1-5 scores. Both appear in the summary block above and are applied as PR labels.
+
+- **Confidence (1-5):** how confident you are in the merge signal.
+  - 5: very confident, verified end to end.
+  - 3: reasonably confident but an important claim could not be fully verified.
+  - 1: low confidence; could not verify key claims.
+- **Risk (1-5):** how risky the change is to the repository if merged.
+  - 5: touches core paths, security-sensitive code, auth/tokens/secrets, data handling, release scripts, CI, or broad cross-module refactors.
+  - 3: moderate surface area, shared contract, or a path with known historical regressions.
+  - 1: trivial, isolated change with no systemic impact.
+
+After posting the final review comment, apply both scores as labels using the exact same X and Y values shown in the summary:
+
+- `gh pr edit "$PR_NUMBER" --add-label "confidence:X,risk:Y"`
+
+If applying fails because a label does not exist yet, create it first with `gh label create "confidence:X"` or `gh label create "risk:Y"` (no color needed), then retry the `--add-label`. Do not add any other labels, and do not remove or change existing labels. Verify the labels landed by re-reading PR metadata only (e.g. `gh pr view "$PR_NUMBER" --json labels`); never verify by posting another comment.


### PR DESCRIPTION
# What

Extends the automated PR review agent (`.opencode/agent/pr-review.md`) to emit a 1-5 **Risk** score alongside the existing **Confidence** score, and to apply both as GitHub labels on the reviewed PR.

- Adds `Risk Score: Y/5` to the review summary block (`Confidence Score: X/5 · Risk Score: Y/5`).
- Adds a "Scoring and labels" section defining both 1-5 scales (confidence = review certainty; risk = blast radius if merged).
- After posting the review comment, the agent runs `gh pr edit "$PR_NUMBER" --add-label "confidence:X,risk:Y"` using the exact values from the summary, creating missing labels via `gh label create` first if needed, and verifying via `--json labels` without posting extra comments.

# Why

Risk and confidence were previously collapsed into a single confidence signal. Surfacing them separately, in the comment and as labels, lets maintainers triage and filter reviewed PRs by how risky a change is and how much the review could actually verify, without re-reading the whole review.

# How to test

1. Trigger the `pr-review` agent on a sample PR and confirm the summary shows both `Confidence Score: X/5 · Risk Score: Y/5`.
2. Confirm `confidence:X` and `risk:Y` labels are applied to the PR (the agent creates them first via `gh label create` if the repo lacks them).
3. Confirm a re-read of `gh pr view "$PR_NUMBER" --json labels` shows both labels and that no additional comment is posted to verify.

# References

- No linked issue.

---

Created with [create-pr](https://github.com/tomzx/agents/blob/117d8c9d087668641bcc783b1938ecc95a2e70d1/skills/create-pr/SKILL.md) via glm-5.2 (117d8c9)