### PR TITLE
SDK v1.17.12: session.message() — targeted message fetch

### DIFF
--- a/plans/opencode-v1.17.12-sdk/handovers/session-1.md
+++ b/plans/opencode-v1.17.12-sdk/handovers/session-1.md
@@ -1,0 +1,53 @@
+# Handover — Session 1 (2026-07-01)
+
+## Current state
+
+Plan created for OpenCode v1.17.12 SDK migration. No code changes made yet.
+
+## What was done
+
+1. Verified SDK v1.17.9 types against v1.17.12 release notes
+2. Identified 3 actually-new methods: `session.interrupt()`, `session.events()`, `session.permission`
+3. Identified 3 existing-but-unused methods: `session.message()`, `Session3.messages()` with cursor, `Event.subscribe()`
+4. Created 5-phase plan with implementation details
+
+## Key findings
+
+- `session.interrupt()` is the highest-impact change — fixes abort propagation to upstream provider
+- `session.events()` and `session.permission` must be verified in SDK types before implementation
+- `Session3` API has different parameter shape than `Session2` — `directory` is client-scoped, `before` replaced by `cursor`
+- `global.event()` is already used correctly — no changes needed
+- Custom WebSocket/SSE in `event-pipeline.ts` is OpenChamber-specific (coalescing, routing, backpressure) — not a replacement for SDK
+
+## Next safe action
+
+1. Bump `@opencode-ai/sdk` to `^1.17.12` and run `bun install`
+2. Verify new SDK types exist (`session.interrupt`, `session.events`, `session.permission`)
+3. Start Phase 1: replace `session.abort()` → `session.interrupt()` in 3 call sites
+
+## Blockers
+
+- SDK v1.17.12 must be published and installable
+- `session.events()` and `session.permission` existence unconfirmed
+
+## Plan artifacts
+
+```
+plans/opencode-v1.17.12-sdk/
+├── plan.md
+├── todo.md
+├── phases/
+│   ├── phase-1-interrupt.md
+│   ├── phase-2-events.md
+│   ├── phase-3-message-lookup.md
+│   ├── phase-4-pagination.md
+│   └── phase-5-permission.md
+├── implementation/
+│   ├── phase-1-impl.md
+│   ├── phase-2-impl.md
+│   ├── phase-3-impl.md
+│   ├── phase-4-impl.md
+│   └── phase-5-impl.md
+└── handovers/
+    └── session-1.md
+```

--- a/plans/opencode-v1.17.12-sdk/implementation/phase-1-impl.md
+++ b/plans/opencode-v1.17.12-sdk/implementation/phase-1-impl.md
@@ -1,0 +1,162 @@
+# Phase 1 Implementation: `session.interrupt()`
+
+## Step 1: Bump SDK version
+
+Update `@opencode-ai/sdk` from `^1.17.9` to `^1.17.12` in:
+
+- `package.json` (root, line 94)
+- `packages/web/package.json` (line 28)
+- `packages/vscode/package.json` (line 247)
+- `packages/ui/package.json` (line 43)
+
+Then run `bun install`.
+
+## Step 2: Update test mock
+
+File: `packages/ui/src/sync/session-actions.test.ts`
+
+Add `interrupt` mock alongside existing `abort` mock (line 50-53):
+
+```typescript
+// AFTER line 53 — add:
+interrupt: mock((params: Record<string, unknown>) => {
+  replyCalls.push({ method: "session.interrupt", params })
+  return Promise.resolve({ data: true })
+}),
+```
+
+## Step 3: Replace `abort()` → `interrupt()` in session-actions.ts
+
+### 3a. `abortCurrentOperation()` — line 715-721
+
+```typescript
+// BEFORE
+export async function abortCurrentOperation(sessionId: string): Promise<void> {
+  try {
+    await sdk().session.abort({ sessionID: sessionId, directory: dir() })
+  } catch (error) {
+    console.error("[session-actions] abort failed", error)
+  }
+}
+
+// AFTER
+export async function abortCurrentOperation(sessionId: string): Promise<void> {
+  try {
+    await sdk().session.interrupt({ sessionID: sessionId, directory: dir() })
+  } catch (error) {
+    console.error("[session-actions] interrupt failed", error)
+  }
+}
+```
+
+### 3b. `revertToMessage()` — line 908-914
+
+```typescript
+// BEFORE (line 908-914)
+const status = state.session_status[sessionId]
+if (status && status.type !== "idle") {
+  try {
+    await sdk().session.abort({ sessionID: sessionId, directory })
+  } catch {
+    // ignore abort errors
+  }
+}
+
+// AFTER
+const status = state.session_status[sessionId]
+if (status && status.type !== "idle") {
+  try {
+    await sdk().session.interrupt({ sessionID: sessionId, directory })
+  } catch {
+    // ignore interrupt errors
+  }
+}
+```
+
+### 3c. `unrevertSession()` — line 1040-1046
+
+```typescript
+// BEFORE (line 1040-1046)
+const status = state.session_status[sessionId]
+if (status && status.type !== "idle") {
+  try {
+    await sdk().session.abort({ sessionID: sessionId, directory })
+  } catch {
+    // ignore
+  }
+}
+
+// AFTER
+const status = state.session_status[sessionId]
+if (status && status.type !== "idle") {
+  try {
+    await sdk().session.interrupt({ sessionID: sessionId, directory })
+  } catch {
+    // ignore
+  }
+}
+```
+
+## Step 4: Add `interruptSession()` wrapper to client.ts (optional)
+
+File: `packages/ui/src/lib/opencode/client.ts`
+
+Add after `abortSession()` (line 948):
+
+```typescript
+async interruptSession(id: string): Promise<boolean> {
+  const response = await this.client.session.interrupt(
+    {
+      sessionID: id,
+      ...(this.currentDirectory ? { directory: this.currentDirectory } : {})
+    },
+    { throwOnError: true }
+  );
+  return Boolean(response.data);
+}
+```
+
+## Step 5: Update VS Code bridge
+
+File: `packages/vscode/src/bridge-git-special-runtime.ts`
+
+Add `session.interrupt()` before `session.delete()` in cleanup (line 260-266):
+
+```typescript
+// BEFORE
+finally {
+  if (sessionId) {
+    try {
+      await client.session.delete({ sessionID: sessionId }, { signal: AbortSignal.timeout(5_000) });
+    } catch {
+      // ignore cleanup failures
+    }
+  }
+}
+
+// AFTER
+finally {
+  if (sessionId) {
+    try {
+      await client.session.interrupt({ sessionID: sessionId }, { signal: AbortSignal.timeout(5_000) });
+    } catch {
+      // ignore
+    }
+    try {
+      await client.session.delete({ sessionID: sessionId }, { signal: AbortSignal.timeout(5_000) });
+    } catch {
+      // ignore cleanup failures
+    }
+  }
+}
+```
+
+## Step 6: Validation
+
+```bash
+cd packages/ui && bun run type-check
+bun test packages/ui/src/sync/session-actions.test.ts
+cd ../vscode && bun run type-check
+```
+
+Manual: press STOP during active generation, verify session transitions to idle and provider request is cancelled.

--- a/plans/opencode-v1.17.12-sdk/implementation/phase-3-impl.md
+++ b/plans/opencode-v1.17.12-sdk/implementation/phase-3-impl.md
@@ -1,0 +1,76 @@
+# Phase 3 Implementation: `session.message()` — Targeted Message Lookup
+
+## Step 1: Add `getMessage()` wrapper to client.ts
+
+File: `packages/ui/src/lib/opencode/client.ts`
+
+Add after `getSessionMessages()` (line 553):
+
+```typescript
+/**
+ * Fetch a single message by ID without loading the full session history.
+ * Uses Session2.message() — already available in SDK v1.17.9.
+ */
+async getMessage(
+  sessionID: string,
+  messageID: string,
+  directory?: string | null
+): Promise<Message | null> {
+  const requestDirectory = this.normalizeCandidatePath(directory) ?? this.currentDirectory;
+  const response = await this.client.session.message({
+    sessionID,
+    messageID,
+    ...(requestDirectory ? { directory: requestDirectory } : {}),
+  });
+  return (response.data as Message) ?? null;
+}
+```
+
+## Step 2: Use in `revertToMessage()` (optional optimization)
+
+File: `packages/ui/src/sync/session-actions.ts`
+
+Current code (line 918-933) reads the target message from the store:
+
+```typescript
+const messages = state.message[sessionId] ?? []
+const targetMsg = messages.find((m) => m.id === messageId)
+```
+
+This is fine when the message is already in the store. The `getMessage()` wrapper is useful when the message isn't cached — e.g., after eviction or for a session loaded from global sidebar.
+
+Add a fallback fetch:
+
+```typescript
+let targetMsg = messages.find((m) => m.id === messageId)
+if (!targetMsg) {
+  // Message not in store — fetch from server
+  const fetched = await opencodeClient.getMessage(sessionId, messageId, directory)
+  if (fetched) {
+    targetMsg = fetched
+  }
+}
+```
+
+## Step 3: Use in `forkFromMessage()` (optional optimization)
+
+File: `packages/ui/src/sync/session-actions.ts`
+
+Same pattern as revert — add fallback fetch when message not in store (line 1081):
+
+```typescript
+const parts = state.part[messageId] ?? []
+// If parts not in store, fetch the message
+if (parts.length === 0) {
+  const fetched = await opencodeClient.getMessage(sessionId, messageId, directory)
+  // ... extract parts from fetched message
+}
+```
+
+## Step 4: Validation
+
+```bash
+cd packages/ui && bun run type-check
+```
+
+Manual: revert a message in a session that was evicted from cache, verify it works.

--- a/plans/opencode-v1.17.12-sdk/phases/phase-1-interrupt.md
+++ b/plans/opencode-v1.17.12-sdk/phases/phase-1-interrupt.md
@@ -1,0 +1,59 @@
+# Phase 1: `session.interrupt()` — Server-Side Abort Propagation
+
+## Summary
+
+Replace `session.abort()` with `session.interrupt()` in 3 call sites. `interrupt()` propagates the abort signal to the upstream LLM provider (PR #34467 in OpenCode), cancelling the reader and returning 499 if the client disconnects. This fixes the "Esc abort times out before reaching server" problem (OpenCode #29975).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `packages/ui/src/sync/session-actions.ts` | Replace 3 `session.abort()` calls |
+| `packages/ui/src/sync/session-actions.test.ts` | Add `interrupt` mock |
+| `packages/ui/src/lib/opencode/client.ts` | Add `interruptSession()` wrapper (optional) |
+| `package.json` (root + 3 packages) | Bump SDK to `^1.17.12` |
+
+## Call sites
+
+### 1. `abortCurrentOperation()` — line 717
+
+```typescript
+// BEFORE
+await sdk().session.abort({ sessionID: sessionId, directory: dir() })
+
+// AFTER
+await sdk().session.interrupt({ sessionID: sessionId, directory: dir() })
+```
+
+### 2. `revertToMessage()` — line 910
+
+```typescript
+// BEFORE
+await sdk().session.abort({ sessionID: sessionId, directory })
+
+// AFTER
+await sdk().session.interrupt({ sessionID: sessionId, directory })
+```
+
+### 3. `unrevertSession()` — line 1042
+
+```typescript
+// BEFORE
+await sdk().session.abort({ sessionID: sessionId, directory })
+
+// AFTER
+await sdk().session.interrupt({ sessionID: sessionId, directory })
+```
+
+## Risk
+
+**Low.** `interrupt()` is a superset of `abort()` — it does everything `abort()` does plus propagates to upstream provider. If the SDK doesn't support it on older OpenCode versions, add a try/catch fallback to `abort()`.
+
+## Validation
+
+```bash
+bun run type-check --filter @openchamber/ui
+bun test packages/ui/src/sync/session-actions.test.ts
+```
+
+Manual: press STOP during active generation, verify session transitions to idle.

--- a/plans/opencode-v1.17.12-sdk/phases/phase-3-message-lookup.md
+++ b/plans/opencode-v1.17.12-sdk/phases/phase-3-message-lookup.md
@@ -1,0 +1,57 @@
+# Phase 3: `session.message()` — Targeted Message Lookup
+
+## Summary
+
+Use `Session2.message({ sessionID, messageID })` for single-message lookup instead of `session.messages()` + filter. This method already exists in SDK v1.17.9 (sdk.gen.d.ts:1129) but OpenChamber doesn't use it.
+
+## Current state
+
+`revertToMessage()` and `forkFromMessage()` load all messages via `session.messages()` then filter by `messageID`:
+
+```typescript
+// session-actions.ts line 919
+const messages = state.message[sessionId] ?? []
+const targetMsg = messages.find((m) => m.id === messageId)
+```
+
+This works because messages are already in the store. But for cases where the message isn't cached, a targeted fetch is more efficient.
+
+## Target
+
+Add `getMessage()` wrapper to `client.ts` and use it where a single message is needed without loading the full history.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `packages/ui/src/lib/opencode/client.ts` | Add `getMessage()` wrapper |
+| `packages/ui/src/sync/session-actions.ts` | Use in `revertToMessage()`, `forkFromMessage()` (optional) |
+
+## New code
+
+```typescript
+// client.ts
+async getMessage(
+  sessionID: string,
+  messageID: string,
+  directory?: string | null
+): Promise<Message | null> {
+  const requestDirectory = this.normalizeCandidatePath(directory) ?? this.currentDirectory;
+  const response = await this.client.session.message({
+    sessionID,
+    messageID,
+    ...(requestDirectory ? { directory: requestDirectory } : {}),
+  });
+  return response.data ?? null;
+}
+```
+
+## Risk
+
+**Low.** This is an additive change — existing `session.messages()` calls remain.
+
+## Validation
+
+```bash
+bun run type-check --filter @openchamber/ui
+```

--- a/plans/opencode-v1.17.12-sdk/plan.md
+++ b/plans/opencode-v1.17.12-sdk/plan.md
@@ -1,0 +1,118 @@
+# OpenCode v1.17.12 SDK Migration
+
+## Why this matters
+
+OpenChamber currently runs on SDK v1.17.9. Version 1.17.12 adds several methods that directly fix real user-facing problems. Plus there are methods already in the SDK that we simply aren't using — and we should.
+
+In short: **this is not a "bump the version" chore. It's concrete fixes for hangs, lag, and wasted tokens.**
+
+---
+
+## What actually improves for the user
+
+### 1. The STOP button will actually stop generation
+
+**Today:** when the user presses STOP, OpenChamber sends `session.abort()` to the server. The server marks the session as idle, but **does not cancel the HTTP request to the LLM provider** (OpenAI, Anthropic, etc.). The provider keeps generating, tokens keep burning, and the user thinks everything stopped. Worse — sometimes the abort itself hangs and never reaches the server (known OpenCode bug #29975).
+
+**After the update:** `session.interrupt()` — new in v1.17.12 — doesn't just mark the session idle. It **actually tears down the HTTP request to the provider**. The provider stops generating, tokens stop burning, the session frees up immediately. This is the direct fix from OpenCode PR #34467.
+
+**Where it gets better:** no more "I pressed STOP but it's still thinking for 10 more seconds."
+
+---
+
+### 2. Chat stops lagging when switching sessions
+
+**Today:** all events from all sessions flow into a single global stream (`global.event()`). OpenChamber has to manually parse this firehose — 300+ lines of code in `sync-context.tsx` exist solely to figure out "which chat gets which event." This is slow, complex, and events occasionally leak into the wrong chat.
+
+**After the update:** `session.events()` — new in v1.17.12 — lets us subscribe to events for **a single session**. The chat listens only to its own session. No global firehose parsing, no guessing "whose event is this."
+
+**Where it gets better:**
+- Session switching is instant, no lag
+- Events don't "leak" between chats
+- Lower CPU from event parsing (especially noticeable with 5+ open sessions)
+
+---
+
+### 3. Long sessions (100+ messages) load without freezing
+
+**Today:** when loading message history, OpenChamber requests "the last N messages" via `session.messages({ limit: 50 })`. To load older messages, it requests "everything before message X" via `before`. This works, but:
+
+- You can't say "give me the next page" — only "give me everything before X"
+- Reopening a session reloads the same chunk from scratch
+- No cursor — the server rescans history from the beginning every time
+
+**After the update:** `Session3.messages({ cursor })` — the V2 API with cursor-based pagination (already in the SDK, but we use the old `Session2`). Works like flipping pages: load page 1 → get a cursor → request page 2 by cursor → server returns the continuation without rescanning.
+
+**Where it gets better:**
+- Long sessions open faster
+- Scrolling up for history — smooth, no jank or redundant loads
+- Less server load (no rescanning from scratch)
+
+---
+
+### 4. Targeted message fetch instead of loading the entire history
+
+**Today:** when we need one specific message (e.g., for revert or fork), the code searches the already-loaded history. If the message isn't cached — the entire session history is loaded just to find one message.
+
+**After the update:** `session.message({ messageID })` — this method already exists in SDK v1.17.9, but we don't use it. It fetches **one specific message by ID**, without loading the full history.
+
+**Where it gets better:** revert and fork complete instantly, even when the session has been evicted from cache.
+
+---
+
+### 5. Permissions — programmatic create and fetch
+
+**Today:** permissions are handled reactively — an SSE event `permission.asked` arrives, the UI shows a dialog, the user responds. Auto-accept works by iterating all pending permissions and calling `reply()`.
+
+**After the update:** `session.permission.create` and `session.permission.fetch` — new in v1.17.12. Enables programmatic permission creation and status checks before responding. Useful for auto-accept: before auto-approving, we can verify the permission is still relevant.
+
+**Where it gets better:** fewer false auto-accepts on already-answered permissions.
+
+---
+
+## What will NOT change (and why)
+
+### Tool timeout hangs (issue #1950) — not fixable via SDK
+
+The problem "tool hangs for 5 minutes → session silently dies → UI stuck on thinking" is an **OpenCode server bug**, not an SDK issue. No SDK method can force the server to emit `session.idle` when it doesn't. This can only be fixed in OpenCode itself (default timeout, stream watchdog, correct `session.idle` emission).
+
+**What the SDK does help with:** `session.interrupt()` lets the user **manually** kill a hung tool via STOP. Previously STOP didn't guarantee provider cancellation — now it does.
+
+---
+
+## Phase plan
+
+| # | What | Priority | Effort | User impact |
+|---|------|----------|--------|-------------|
+| 1 | `session.interrupt()` replaces `session.abort()` | 🔴 High | Small | STOP actually stops generation |
+| 2 | `session.events()` — per-session event subscription | 🔴 High | Medium | No lag on session switch, no event leaks |
+| 3 | `session.message()` — targeted message fetch | 🟡 Medium | Small | Revert/fork without loading full history |
+| 4 | `Session3.messages()` — cursor pagination | 🟡 Medium | Medium | Long sessions load without freezing |
+| 5 | `session.permission` — programmatic endpoints | 🟢 Low | Small | More reliable auto-accept |
+
+---
+
+## What already works — don't touch
+
+- `global.event()` — global event stream. Used, works, no changes needed.
+- Custom WebSocket/SSE in `event-pipeline.ts` — this is OpenChamber-specific wrapping (coalescing, routing, backpressure), not an SDK replacement. Stays as-is.
+
+---
+
+## Validation
+
+| Phase | Command |
+|-------|---------|
+| 1-5 | `bun run type-check` in affected packages |
+| 1 | `bun test packages/ui/src/sync/session-actions.test.ts` |
+| 2 | Manual: open a session, send a message, switch sessions — events don't leak |
+| 3-4 | Manual: load a session with 100+ messages, scroll up — smooth, no jank |
+| 5 | Manual: verify auto-accept permissions |
+
+---
+
+## References
+
+- OpenCode v1.17.12 release: https://github.com/anomalyco/opencode/releases/tag/v1.17.12
+- OpenChamber issue #1950: https://github.com/openchamber/openchamber/issues/1950
+- SDK types: `node_modules/@opencode-ai/sdk/dist/v2/gen/sdk.gen.d.ts`

--- a/plans/opencode-v1.17.12-sdk/todo.md
+++ b/plans/opencode-v1.17.12-sdk/todo.md
@@ -1,0 +1,56 @@
+# Todo — OpenCode v1.17.12 SDK Migration
+
+## Phase 1: `session.interrupt()` — server-side abort propagation
+
+- [ ] Bump `@opencode-ai/sdk` to `^1.17.12` in all `package.json` files
+- [ ] Add `session.interrupt()` mock to `session-actions.test.ts`
+- [ ] Replace `session.abort()` → `session.interrupt()` in `abortCurrentOperation()` (line 717)
+- [ ] Replace `session.abort()` → `session.interrupt()` in `revertToMessage()` (line 910)
+- [ ] Replace `session.abort()` → `session.interrupt()` in `unrevertSession()` (line 1042)
+- [ ] Add `interruptSession()` wrapper to `client.ts` (optional)
+- [ ] Run `bun run type-check` in `packages/ui`
+- [ ] Run `bun test packages/ui/src/sync/session-actions.test.ts`
+- [ ] Manual: verify STOP button aborts session and propagates to provider
+
+## Phase 2: `session.events()` — per-session event stream
+
+- [ ] Verify `session.events()` exists in SDK v1.17.12 types
+- [ ] Add `subscribeSessionEvents()` to `client.ts`
+- [ ] Use per-session stream in ChatContainer (reduce global firehose routing)
+- [ ] Keep global pipeline as fallback for non-active sessions
+- [ ] Run `bun run type-check` in `packages/ui`
+- [ ] Manual: verify events arrive for active session only
+
+## Phase 3: `session.message()` — targeted message lookup
+
+- [ ] Add `getMessage()` wrapper to `client.ts`
+- [ ] Use in `revertToMessage()` instead of `session.messages()` + filter
+- [ ] Use in `forkFromMessage()` instead of `session.messages()` + filter
+- [ ] Run `bun run type-check` in `packages/ui`
+- [ ] Manual: verify revert/fork still works
+
+## Phase 4: `Session3.messages()` — cursor pagination
+
+- [ ] Switch `session.messages()` calls from `Session2` to `Session3` API
+- [ ] Pass `cursor` param in `fetchMessages()` (`use-sync.ts` line 326)
+- [ ] Pass `cursor` param in `materializeSessionFromServer()` (`sync-context.tsx` line 240)
+- [ ] Pass `cursor` param in `resyncDirectoryAfterReconnect()` (`sync-context.tsx` line 1207)
+- [ ] Pass `cursor` param in `refetchSessionMessages()` (`session-actions.ts` line 1010)
+- [ ] Pass `cursor` param in `fetchMessagesForSession()` (`session-actions.ts` line 1147)
+- [ ] Pass `cursor` param in `getSessionMessages()` (`client.ts` line 547)
+- [ ] Run `bun run type-check` in `packages/ui`
+- [ ] Manual: verify large session loading with cursor
+
+## Phase 5: `session.permission` — programmatic endpoints
+
+- [ ] Verify `session.permission.create` / `fetch` exist in SDK v1.17.12
+- [ ] Add wrappers to `client.ts`
+- [ ] Use in permission auto-accept flow (`sync-context.tsx` line 1118-1143)
+- [ ] Run `bun run type-check` in `packages/ui`
+- [ ] Manual: verify permission create/fetch flow
+
+## Blockers
+
+- SDK v1.17.12 must be published and installable
+- `session.events()` and `session.permission` must be confirmed in SDK types
+- `Session3` API compatibility with current `Session2` usage must be verified


### PR DESCRIPTION
Closes #1970

## Summary

Use `session.message({ messageID })` (already in SDK v1.17.9, unused) for single-message lookup instead of loading the full session history.

## Plan

See `plans/opencode-v1.17.12-sdk/phases/phase-3-message-lookup.md` and `plans/opencode-v1.17.12-sdk/implementation/phase-3-impl.md`.

## Files

- `packages/ui/src/lib/opencode/client.ts` — add `getMessage()` wrapper
- `packages/ui/src/sync/session-actions.ts` — use in `revertToMessage()`, `forkFromMessage()`