### PR TITLE
fix(ui): dispatch queued messages when session is already idle

### DIFF
--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
@@ -35,13 +35,17 @@ import {
 
 describe('shouldDispatchQueuedAutoSend', () => {
   test('dispatches only after an active session becomes idle', () => {
-    expect(shouldDispatchQueuedAutoSend('busy', 'idle')).toBe(true);
-    expect(shouldDispatchQueuedAutoSend('retry', 'idle')).toBe(true);
+    expect(shouldDispatchQueuedAutoSend('busy', 'idle', false)).toBe(true);
+    expect(shouldDispatchQueuedAutoSend('retry', 'idle', false)).toBe(true);
   });
 
   test('does not dispatch when idle is only first seen or status is missing', () => {
-    expect(shouldDispatchQueuedAutoSend(undefined, 'idle')).toBe(false);
-    expect(shouldDispatchQueuedAutoSend('idle', 'idle')).toBe(false);
+    expect(shouldDispatchQueuedAutoSend(undefined, 'idle', false)).toBe(false);
+    expect(shouldDispatchQueuedAutoSend('idle', 'idle', false)).toBe(false);
+  });
+
+  test('dispatches when idle→idle and queue has items', () => {
+    expect(shouldDispatchQueuedAutoSend('idle', 'idle', true)).toBe(true);
   });
 });
 

--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
@@ -110,7 +110,9 @@ const resolveSessionSendConfig = (sessionId: string) => {
 export const shouldDispatchQueuedAutoSend = (
   previousStatusType: SessionStatusType | undefined,
   currentStatusType: SessionStatusType,
+  hasQueuedItems: boolean = false,
 ): boolean => {
+  if (hasQueuedItems && currentStatusType === 'idle') return true;
   return (previousStatusType === 'busy' || previousStatusType === 'retry')
     && currentStatusType === 'idle';
 };
@@ -207,7 +209,7 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
       }
 
       if (queue.length > 0 && (
-        shouldDispatchQueuedAutoSend(previousStatusType, currentStatusType)
+        shouldDispatchQueuedAutoSend(previousStatusType, currentStatusType, queue.length > 0)
         || (wasAutoReviewBlocked && !isAutoReviewRunning && currentStatusType === 'idle')
       )) {
         void dispatchSessionQueue(sessionId, queue);


### PR DESCRIPTION
Fixes #1963 — queued messages added while a session is already idle were never dispatched because `shouldDispatchQueuedAutoSend` rejected the `idle → idle` status transition. The fix allows dispatch when the queue has items, regardless of whether the status transition is `busy→idle`/`retry→idle` or `idle→idle`.

### Root cause

`shouldDispatchQueuedAutoSend(previousStatusType, currentStatusType)` only returns `true` when the session transitions from `busy` or `retry` to `idle`. When a user queues a message after an exchange has already terminated — meaning the session is already `idle` — the status pair is `('idle', 'idle')`, which returns `false`. The queued message sits in the store forever with no trigger to send it.

The call site at line 210 already guards on `queue.length > 0`, but the guard is useless if the dispatch function itself rejects the only status pair that applies.

### Changes

**packages/ui/src/hooks/useQueuedMessageAutoSend.ts**

- Add a third parameter `hasQueuedItems: boolean = false` to `shouldDispatchQueuedAutoSend`. When `true`, the function also allows `idle → idle` dispatch.
- Pass `queue.length > 0` as the third argument at line 210.

**packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts**

- Update existing tests to pass the third parameter
- Add new test for `idle→idle` with queue items

### Testing plan

1. Run `bun test packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts` to verify:
   - Existing `busy→idle` and `retry→idle` dispatch still works
   - `idle→idle` without queue items still returns false
   - `idle→idle` with queue items now returns true (regression guard)
2. Manual smoke test: queue message after session goes idle, verify it auto-sends
3. Type check: `bun run type-check` to confirm compatibility

### Acceptance criteria (from issue #1963)

- [x] Root cause identified: queued messages dropped on idle→idle transition
- [x] Queued messages reliably sent after exchange terminates (verified via fix and tests)
- [x] Regression test covering queued-send-after-exchange-termination