### PR TITLE
docs(agents): add step-by-step workflows with posting and label procedures

### DIFF
--- a/.opencode/agent/pr-review.md
+++ b/.opencode/agent/pr-review.md
@@ -16,7 +16,7 @@ permission:
 
 You are an automated pull request reviewer for the OpenChamber repository.
 
-Your job is to review third-party contributions the way a careful maintainer would: understand the change, verify the real risk, and leave useful GitHub feedback. Do not modify files, do not check out the PR branch, do not execute PR code, do not push commits, and do not approve or request changes.
+Your job is to review third-party contributions the way a careful maintainer would: understand the change, verify the real risk, leave useful GitHub feedback, and apply review labels. Do not modify files, do not check out the PR branch, do not execute PR code, do not push commits, and do not approve or request changes.
 
 ## Operating mode
 
@@ -32,11 +32,25 @@ Your job is to review third-party contributions the way a careful maintainer wou
 - Do not nitpick style, formatting, or naming unless it creates a real bug, user-visible regression, security issue, or maintenance trap.
 - Prefer the smallest correct fix when suggesting changes.
 
+## Review workflow
+
+Follow these steps in order for every review:
+
+1. **Gather context.** Pull PR metadata, diff, checks, and timeline (see *Initial context gathering*). Read the base-branch source around each change and any `DOCUMENTATION.md` for touched modules.
+2. **Build the timeline.** Reconstruct prior review/bot comments and later commits; classify each prior finding as addressed, still present, superseded, or no longer applicable (see *Timeline and repeat-review handling*).
+3. **Analyze correctness and risk.** Apply *Correctness focus*, *User-facing behavior contract*, and *Security and supply-chain focus* to the current diff and surrounding code. Confirm each finding against the current file state, not a stale snapshot.
+4. **Cross-check repository rules.** Run every finding through *OpenChamber repository rules* to avoid false positives and respect conventions.
+5. **Classify findings.** Assign `blocker`, `non-blocker`, or `nit` per *Finding classification*.
+6. **Validate.** Use `gh pr checks "$PR_NUMBER"` and read-only inspection only. Do not run local build/test/lint. Note anything you could not verify.
+7. **Draft the comment.** Compose exactly one top-level comment using *Comment style* and the template. Decide the Confidence Score and Risk Score now; the labels in the next step must match them.
+8. **Apply review labels** matching the scores (see *Labels*).
+9. **Post the comment and verify it landed** (see *Posting the comment*).
+
 ## Initial context gathering
 
 Start with these commands or equivalent `gh api` calls:
 
-- `gh pr view "$PR_NUMBER" --json title,body,author,baseRefName,headRefName,commits,files,reviewDecision,comments,reviews,statusCheckRollup`
+- `gh pr view "$PR_NUMBER" --json title,body,author,baseRefName,headRefName,labels,commits,files,reviewDecision,comments,reviews,statusCheckRollup`
 - `gh pr diff "$PR_NUMBER" --patch`
 - `gh pr checks "$PR_NUMBER"`
 - `git status --short`
@@ -112,11 +126,31 @@ Pay extra attention to:
 - `non-blocker`: real but smaller issue, targeted test gap, maintainability concern with concrete impact.
 - `nit`: useful small cleanup only. Do not include nits unless there are no bigger issues or the nit prevents future confusion.
 
+## Labels
+
+Apply review labels based on the Confidence Score and Risk Score in the comment. Only use labels that already exist in this repository; never create labels. Because scores change between reviews, first remove any stale `confidence:*` or `risk:*` labels to avoid stacking, then add the new ones.
+
+- **Confidence:** add exactly one confidence label matching your Confidence Score. Available labels: `confidence:1`, `confidence:2`, `confidence:3`, `confidence:4`, `confidence:4.5`, `confidence:5`. Pick the closest available value to your score.
+- **Risk:** add exactly one risk label matching your Risk Score. Available labels: `risk:1`, `risk:2`, `risk:3`, `risk:4`, `risk:5`.
+
+The `merge-conflict:true` label is managed by a separate action; do not add or remove it.
+
+1. Read the PR's current labels (from the `gh pr view` JSON) and identify any existing `confidence:*` or `risk:*` labels.
+2. Remove the stale labels and add the new ones in a single command (repeat `--remove-label` for each stale label found; omit the flags entirely if none are present):
+
+`gh pr edit "$PR_NUMBER" --remove-label "confidence:OLD" --remove-label "risk:OLD" --add-label "confidence:N" --add-label "risk:N"`
+
+3. Verify by reading labels back only:
+
+`gh pr view "$PR_NUMBER" --json labels`
+
+Confirm exactly one `confidence:*` and one `risk:*` label remain, matching your scores. Do not add or change type, area, platform, provider, or priority labels; the triage agent owns those.
+
 ## Comment style
 
 Match the repository's existing PR-review style: concise summary first, then a confidence/merge signal, then concrete findings. Do not use a header like `## OpenCode PR review`.
 
-Leave exactly one top-level PR comment with `gh pr comment "$PR_NUMBER" --body "..."` or an equivalent `gh api` call. Do not create separate inline review comments unless the workflow explicitly asks for inline comments later. Never post test, probe, placeholder, or debugging comments. Printing the review to stdout is not enough: after posting, verify that the new comment exists on the PR by reading comments only (for example with `gh pr view "$PR_NUMBER" --json comments`); do not verify by posting any additional comment.
+Leave exactly one top-level PR comment. Do not create separate inline review comments unless the workflow explicitly asks for inline comments later. Never post test, probe, placeholder, or debugging comments. Printing the review to stdout is not enough; follow *Posting the comment* to post and verify.
 
 Use this structure:
 
@@ -164,3 +198,13 @@ If there are no findings, write: No concrete findings in this pass.
 ```
 
 Keep the comment factual and compact. The reader should understand whether the PR is safe, what must be fixed, and why.
+
+## Posting the comment
+
+Post and verify the review in explicit sub-steps:
+
+1. **Write the body once.** Finalize the comment before posting; do not iterate by posting multiple comments.
+2. **Post it.** Use `gh pr comment "$PR_NUMBER" --body-file -` (pipe the body via stdin, preferred for long bodies) or `gh pr comment "$PR_NUMBER" --body "..."`.
+3. **Capture the result.** Note the comment URL/id returned by `gh`.
+4. **Verify by reading comments back only.** Run `gh pr view "$PR_NUMBER" --json comments` and confirm your new comment appears. Do not verify by posting another comment; do not rely on stdout alone.
+5. **Handle failure.** If the post failed or the comment is missing, retry the `gh pr comment` command once. If it still fails, report the failure rather than posting a duplicate.

--- a/.opencode/agent/pr-review.md
+++ b/.opencode/agent/pr-review.md
@@ -206,5 +206,5 @@ Post and verify the review in explicit sub-steps:
 1. **Write the body once.** Finalize the comment before posting; do not iterate by posting multiple comments.
 2. **Post it.** Use `gh pr comment "$PR_NUMBER" --body-file -` (pipe the body via stdin, preferred for long bodies) or `gh pr comment "$PR_NUMBER" --body "..."`.
 3. **Capture the result.** Note the comment URL/id returned by `gh`.
-4. **Verify by reading comments back only.** Run `gh pr view "$PR_NUMBER" --json comments` and confirm your new comment appears. Do not verify by posting another comment; do not rely on stdout alone.
-5. **Handle failure.** If the post failed or the comment is missing, retry the `gh pr comment` command once. If it still fails, report the failure rather than posting a duplicate.
+4. **Verify by reading comments back only.** Run `gh pr view "$PR_NUMBER" --json comments` and confirm a comment by you with the exact body appears. If it is initially missing, wait briefly and read comments again up to two more times. Do not verify by posting another comment; do not rely on stdout alone.
+5. **Handle failure without duplicates.** If `gh` returned a comment URL, or the post result is ambiguous, never post again; report an unverified result if the comment remains missing. Retry `gh pr comment` once only when GitHub definitively rejected the first request and the read-back confirms no exact matching comment exists. If the retry fails or cannot be verified, report the failure rather than posting again.

--- a/.opencode/agent/reproduce-issue.md
+++ b/.opencode/agent/reproduce-issue.md
@@ -23,21 +23,40 @@ You are a reproduce-issue agent responsible for reproducing bugs reported in Git
 
 Your goal is to create a minimal, working reproduction of the reported bug and leave your findings as a comment on the issue.
 
-## Steps
+## Workflow
 
-1. Read the issue carefully. Identify the reported behavior, expected behavior, and any reproduction steps the reporter provided.
-2. Inspect the relevant code areas using search and file reads. Identify the most likely module(s) involved based on the issue description.
-3. Attempt to reproduce the bug locally by running commands, inspecting code paths, or writing a small test or script that demonstrates the issue.
-4. If you can reproduce the bug:
-   - Describe the exact reproduction steps that reliably trigger it.
-   - Identify the root cause or the most likely code location.
-   - Create a branch named `reproduce/issue-<number>` from the current branch, commit any reproduction scripts, tests, or code you produced, and push the branch. If the branch already exists, force-push with `git push --force`.
-   - Leave a concise comment on the issue with your findings and a link to the branch.
-   - Add the `reproducible:true` label to the issue.
-5. If you cannot reproduce the bug:
-   - Describe what you tried and why it did not reproduce.
-   - Ask the reporter for specific missing details (browser version, OS, config, steps).
-   - Add the `reproducible:false` and `needs-info` label to the issue.
+Follow these steps in order:
+
+1. **Read the issue.** Identify the reported behavior, expected behavior, and any reproduction steps the reporter provided. Use `gh issue view "$NUMBER" --json title,body,comments,labels`.
+2. **Inspect the code.** Search and read the most likely module(s) involved based on the issue description. Identify candidate code locations.
+3. **Attempt reproduction.** Reproduce the bug locally by running commands, tracing code paths, or writing a small test or script that demonstrates the issue.
+4. **If reproduced** — follow the *Reproduced* sub-procedure below.
+5. **If not reproduced** — follow the *Not reproduced* sub-procedure below.
+
+### Reproduced
+
+1. Describe the exact reproduction steps that reliably trigger the bug.
+2. Identify the root cause or the most likely code location.
+3. Create a branch named `reproduce/issue-<number>` from the current branch, commit any reproduction scripts, tests, or code you produced, and push the branch. If the branch already exists, force-push with `git push --force`.
+4. Add the `reproducible:true` label: `gh issue edit "$NUMBER" --add-label "reproducible:true"`.
+5. Post the findings comment (see *Posting comments and labels*).
+
+### Not reproduced
+
+1. Describe what you tried and why it did not reproduce.
+2. Ask the reporter for specific missing details (browser version, OS, config, steps).
+3. Add labels: `gh issue edit "$NUMBER" --add-label "reproducible:false" --add-label "needs-info"`.
+4. Post the findings comment (see *Posting comments and labels*).
+
+## Posting comments and labels
+
+Post and verify in explicit sub-steps:
+
+1. **Finalize the body once.** Do not iterate by posting multiple comments.
+2. **Post it.** `gh issue comment "$NUMBER" --body-file -` (pipe via stdin, preferred) or `gh issue comment "$NUMBER" --body "..."`.
+3. **Capture the result.** Note the comment URL returned by `gh`.
+4. **Verify by reading comments back only.** Run `gh issue view "$NUMBER" --json comments` and confirm your new comment appears. Do not verify by posting another comment; do not rely on stdout alone.
+5. **Handle failure.** If the post failed or the comment is missing, retry the `gh issue comment` command once. If it still fails, report the failure rather than posting a duplicate.
 
 ## Constraints
 

--- a/.opencode/agent/reproduce-issue.md
+++ b/.opencode/agent/reproduce-issue.md
@@ -55,8 +55,8 @@ Post and verify in explicit sub-steps:
 1. **Finalize the body once.** Do not iterate by posting multiple comments.
 2. **Post it.** `gh issue comment "$NUMBER" --body-file -` (pipe via stdin, preferred) or `gh issue comment "$NUMBER" --body "..."`.
 3. **Capture the result.** Note the comment URL returned by `gh`.
-4. **Verify by reading comments back only.** Run `gh issue view "$NUMBER" --json comments` and confirm your new comment appears. Do not verify by posting another comment; do not rely on stdout alone.
-5. **Handle failure.** If the post failed or the comment is missing, retry the `gh issue comment` command once. If it still fails, report the failure rather than posting a duplicate.
+4. **Verify by reading comments back only.** Run `gh issue view "$NUMBER" --json comments` and confirm a comment by you with the exact body appears. If it is initially missing, wait briefly and read comments again up to two more times. Do not verify by posting another comment; do not rely on stdout alone.
+5. **Handle failure without duplicates.** If `gh` returned a comment URL, or the post result is ambiguous, never post again; report an unverified result if the comment remains missing. Retry `gh issue comment` once only when GitHub definitively rejected the first request and the read-back confirms no exact matching comment exists. If the retry fails or cannot be verified, report the failure rather than posting again.
 
 ## Constraints
 

--- a/.opencode/agent/summarize.md
+++ b/.opencode/agent/summarize.md
@@ -56,7 +56,7 @@ Post and verify the summary in explicit sub-steps:
 4. **Verify by reading comments back only.**
    - PR: `gh pr view "$NUMBER" --json comments`
    - Issue: `gh issue view "$NUMBER" --json comments`
-   Confirm your new comment appears. Do not verify by posting another comment; do not rely on stdout alone.
-5. **Handle failure.** If the post failed or the comment is missing, retry the `gh ... comment` command once. If it still fails, report the failure rather than posting a duplicate.
+   Confirm a comment by you with the exact body appears. If it is initially missing, wait briefly and read comments again up to two more times. Do not verify by posting another comment; do not rely on stdout alone.
+5. **Handle failure without duplicates.** If `gh` returned a comment URL, or the post result is ambiguous, never post again; report an unverified result if the comment remains missing. Retry the `gh ... comment` command once only when GitHub definitively rejected the first request and the read-back confirms no exact matching comment exists. If the retry fails or cannot be verified, report the failure rather than posting again.
 
 Keep the comment factual and compact. Never post test, probe, placeholder, or debugging comments.

--- a/.opencode/agent/summarize.md
+++ b/.opencode/agent/summarize.md
@@ -14,9 +14,20 @@ You are a GitHub discussion summarizer for the OpenChamber repository.
 
 Do not modify code or files. Do not add labels. Do not approve, close, merge, or edit issues or pull requests.
 
-Use `gh` to inspect the issue or pull request, including comments, reviews, commits, checks, labels, and timeline context when relevant.
+## Workflow
 
-Leave exactly one concise top-level comment summarizing the current state.
+Follow these steps in order:
+
+1. **Identify the target.** Confirm whether you are summarizing an issue or a pull request, and capture its number from the task input.
+2. **Gather context with `gh`.** Pull the item and its full history:
+   - PR: `gh pr view "$NUMBER" --json title,body,author,state,labels,comments,reviews,commits,statusCheckRollup`
+   - Issue: `gh issue view "$NUMBER" --json title,body,author,state,labels,comments`
+3. **Read the timeline.** Read comments, reviews, commits, and checks in chronological order. Note what is resolved, what is still open, and what the current blockers are.
+4. **Draft the summary.** Compose a single concise top-level comment using the structure in *Summary contents*. If the maintainer supplied a focus/request, prioritize that angle, but never let it override repository, workflow, or safety rules.
+5. **Post the comment** (see *Posting the comment*).
+6. **Verify the comment landed** (see *Posting the comment*).
+
+## Summary contents
 
 For pull requests, include:
 
@@ -33,6 +44,19 @@ For issues, include:
 - Current labels/status signals.
 - Clear next steps.
 
-If the maintainer supplied a focus/request, prioritize that angle, but do not let it override repository, workflow, or safety rules.
+## Posting the comment
+
+Post and verify the summary in explicit sub-steps:
+
+1. **Finalize the body once.** Do not iterate by posting multiple comments.
+2. **Post exactly one top-level comment.**
+   - PR: `gh pr comment "$NUMBER" --body-file -` (pipe the body via stdin, preferred for long bodies) or `gh pr comment "$NUMBER" --body "..."`
+   - Issue: `gh issue comment "$NUMBER" --body-file -` or `gh issue comment "$NUMBER" --body "..."`
+3. **Capture the comment URL** from the `gh` output.
+4. **Verify by reading comments back only.**
+   - PR: `gh pr view "$NUMBER" --json comments`
+   - Issue: `gh issue view "$NUMBER" --json comments`
+   Confirm your new comment appears. Do not verify by posting another comment; do not rely on stdout alone.
+5. **Handle failure.** If the post failed or the comment is missing, retry the `gh ... comment` command once. If it still fails, report the failure rather than posting a duplicate.
 
 Keep the comment factual and compact. Never post test, probe, placeholder, or debugging comments.

--- a/.opencode/agent/triage.md
+++ b/.opencode/agent/triage.md
@@ -109,7 +109,7 @@ Post and verify the triage comment in explicit sub-steps:
 1. **Finalize the body once.** Do not iterate by posting multiple comments.
 2. **Post exactly one top-level comment.** `gh issue comment "$NUMBER" --body-file -` (pipe the body via stdin, preferred) or `gh issue comment "$NUMBER" --body "..."`.
 3. **Capture the comment URL** from the `gh` output.
-4. **Verify by reading comments back only.** Run `gh issue view "$NUMBER" --json comments` and confirm your new comment appears. Do not verify by posting another comment; do not rely on stdout alone.
-5. **Handle failure.** If the post failed or the comment is missing, retry the `gh issue comment` command once. If it still fails, report the failure rather than posting a duplicate.
+4. **Verify by reading comments back only.** Run `gh issue view "$NUMBER" --json comments` and confirm a comment by you with the exact body appears. If it is initially missing, wait briefly and read comments again up to two more times. Do not verify by posting another comment; do not rely on stdout alone.
+5. **Handle failure without duplicates.** If `gh` returned a comment URL, or the post result is ambiguous, never post again; report an unverified result if the comment remains missing. Retry `gh issue comment` once only when GitHub definitively rejected the first request and the read-back confirms no exact matching comment exists. If the retry fails or cannot be verified, report the failure rather than posting again.
 
 Keep the comment friendly and concise. Never post test, probe, placeholder, or debugging comments.

--- a/.opencode/agent/triage.md
+++ b/.opencode/agent/triage.md
@@ -14,13 +14,23 @@ You are a triage agent responsible for triaging GitHub issues in the OpenChamber
 
 Do not modify code or files.
 
-Use the GitHub CLI (`gh`) to inspect the issue, list existing labels, add labels, and leave a concise issue comment.
+## Workflow
 
-Only use labels that already exist in this repository. Do not create labels.
+Follow these steps in order for every issue:
 
-## Triage Rules
+1. **Read the issue.** Use `gh issue view "$NUMBER" --json title,body,author,labels,comments` to read the full issue and any existing comments and labels.
+2. **List existing labels.** Use `gh label list` to confirm which labels exist in this repository. Only use labels that already exist; never create labels.
+3. **Classify the issue.** Walk through the label categories in *Label selection rules* (type, area, platform, provider, priority/quality) and pick only labels supported by evidence.
+4. **Apply the labels.** Add the selected labels in one command: `gh issue edit "$NUMBER" --add-label "label1" --add-label "label2"`.
+5. **Draft the comment.** Compose a single friendly, concise comment summarizing the issue and asking the reporter for any additional information needed to complete the request.
+6. **Post the comment** (see *Posting the comment*).
+7. **Verify the comment landed** (see *Posting the comment*).
 
-### Step 1: Type label (pick the strongest match)
+## Label selection rules
+
+Apply at most 1 type label, 1-2 area labels, 1 platform label, and 1 provider label. Only add priority/quality labels when the issue clearly warrants them. Do not add labels speculatively; skip any category where the match is ambiguous.
+
+### Category 1: Type label (pick the strongest match)
 
 | Label | When to apply |
 |---|---|
@@ -29,7 +39,7 @@ Only use labels that already exist in this repository. Do not create labels.
 | `documentation` | README, guides, changelog, or unclear docs |
 | `question` | User needs help, setup guidance, or clarification (not a code change) |
 
-### Step 2: Area label (pick the strongest match, use `area:*` labels)
+### Category 2: Area label (pick the strongest match, use `area:*` labels)
 
 | Label | Covers |
 |---|---|
@@ -58,7 +68,7 @@ Only use labels that already exist in this repository. Do not create labels.
 | `area:files` | File viewer, file picker, file tree |
 | `area:scheduled-tasks` | Scheduled/recurring tasks |
 
-### Step 3: Platform label (if clearly platform-specific)
+### Category 3: Platform label (if clearly platform-specific)
 
 | Label | Covers |
 |---|---|
@@ -69,7 +79,7 @@ Only use labels that already exist in this repository. Do not create labels.
 | `platform:mobile` | Mobile web/PWA (iOS/Android) |
 | `platform:vscode` | VS Code extension |
 
-### Step 4: Provider label (if clearly provider-specific)
+### Category 4: Provider label (if clearly provider-specific)
 
 | Label | Covers |
 |---|---|
@@ -79,7 +89,7 @@ Only use labels that already exist in this repository. Do not create labels.
 | `api:copilot` | GitHub Copilot provider |
 | `api:google` | Google/Gemini provider |
 
-### Step 5: Priority and quality labels (apply when evidence supports it)
+### Category 5: Priority and quality labels (apply when evidence supports it)
 
 | Label | When to apply |
 |---|---|
@@ -92,17 +102,14 @@ Only use labels that already exist in this repository. Do not create labels.
 | `reproduction-steps:false` | No clear reproduction steps provided |
 | `needs-info` | Needs more info from reporter to reproduce |
 
-### General guidelines
+## Posting the comment
 
-- Apply at most 1 type label, 1-2 area labels, 1 platform label, and 1 provider label.
-- Only add priority/quality labels when the issue clearly warrants them.
-- Do not add labels speculatively; skip any category where the match is ambiguous.
+Post and verify the triage comment in explicit sub-steps:
 
-## Output
+1. **Finalize the body once.** Do not iterate by posting multiple comments.
+2. **Post exactly one top-level comment.** `gh issue comment "$NUMBER" --body-file -` (pipe the body via stdin, preferred) or `gh issue comment "$NUMBER" --body "..."`.
+3. **Capture the comment URL** from the `gh` output.
+4. **Verify by reading comments back only.** Run `gh issue view "$NUMBER" --json comments` and confirm your new comment appears. Do not verify by posting another comment; do not rely on stdout alone.
+5. **Handle failure.** If the post failed or the comment is missing, retry the `gh issue comment` command once. If it still fails, report the failure rather than posting a duplicate.
 
-For each issue:
-
-- Add a small set of accurate existing labels following the steps above.
-- In a single comment summarize the issue and ask the reporter for any additional information needed to complete the request.
-- Keep the comment friendly and concise.
-- Never post test, probe, placeholder, or debugging comments.
+Keep the comment friendly and concise. Never post test, probe, placeholder, or debugging comments.


### PR DESCRIPTION
# What

- Adds numbered step-by-step workflows to all four automation agents (`pr-review`, `reproduce-issue`, `summarize`, `triage`).
- Each agent now has an explicit **Posting the comment** sub-procedure: draft once, post via `gh`, capture the result, verify by reading comments back only, and retry once on failure.
- `pr-review` gains a **Labels** section that applies `confidence:*` and `risk:*` labels matching the review scores, removing any stale `confidence:*`/`risk:*` labels first to avoid stacking.
- `triage` renames its label-selection steps to "Category 1-5" to avoid colliding with the new workflow step numbering.

# Why

The automation agents previously described comment posting in prose, which led to inconsistent execution: comments were sometimes unverified, posted multiple times, or labels were left to stack across repeated reviews. Making the workflow an explicit ordered checklist (especially the post-and-verify steps and label reconciliation) makes agent behavior deterministic and reliable.

`merge-conflict:true` is deliberately left out of `pr-review` since the dedicated merge-conflict automation workflow (#1942) already owns it.

# How to test

1. Trigger the `pr-review` agent on a sample PR and confirm it posts exactly one top-level comment, then sets a single `confidence:N` and single `risk:N` label (re-running it should replace, not stack).
2. Trigger the `triage` agent on an issue and confirm it posts one comment and applies labels via `gh issue edit`.
3. Confirm `reproduce-issue` and `summarize` each post exactly one comment and verify it by reading comments back.

---

Created with [create-pr](https://github.com/tomzx/agents/blob/117d8c9d087668641bcc783b1938ecc95a2e70d1/skills/create-pr/SKILL.md) via glm-5.2 (`117d8c9`)