### PR TITLE
fix(vscode): persist model favorites

### DIFF
--- a/packages/ui/src/lib/modelPrefsAutoSave.ts
+++ b/packages/ui/src/lib/modelPrefsAutoSave.ts
@@ -1,6 +1,5 @@
 import { useUIStore } from '@/stores/useUIStore';
 import { updateDesktopSettings } from '@/lib/persistence';
-import { isVSCodeRuntime } from '@/lib/desktop';
 
 type ModelRef = { providerID: string; modelID: string };
 type ModelPrefsPayload = {
@@ -70,9 +69,6 @@ const cloneModelPrefs = (prefs: ModelPrefsPayload): ModelPrefsPayload => ({
 
 export const startModelPrefsAutoSave = () => {
   if (typeof window === 'undefined') {
-    return () => {};
-  }
-  if (isVSCodeRuntime()) {
     return () => {};
   }
 


### PR DESCRIPTION
Closes #1994

## What

- Remove the `isVSCodeRuntime()` early return and the now-unused `isVSCodeRuntime` import from `packages/ui/src/lib/modelPrefsAutoSave.ts` so `startModelPrefsAutoSave()` runs in the VS Code extension too.

## Why

`startModelPrefsAutoSave()` already writes through `updateDesktopSettings()`, which resolves the registered runtime settings API at flush time. The VS Code webview already implements that path via `packages/vscode/webview/api/settings.ts` and `packages/vscode/src/bridge-settings-runtime.ts`, so the guard was both unnecessary and the cause of the bug: favorite-model changes only updated the in-memory Zustand state, and the later `syncDesktopSettings()` re-applied persisted settings from the VS Code settings bridge (which did not include the new favorite), overwriting the in-memory favorite list and dropping the OpenAI model from favorites on view switch / webview re-sync.

## How to test

1. Open OpenChamber in the VS Code extension.
2. Open the model picker and favorite an OpenAI provider model.
3. Switch views/screens (or otherwise trigger a `syncDesktopSettings()` re-sync).
4. Re-open the model picker and confirm the OpenAI model is still favorited.
5. Restart the VS Code window and re-open the model picker; the favorite should still be present.

## Validation

- `bun run --cwd packages/ui type-check` — passes
- `bun run --cwd packages/ui lint` — passes

## Notes

- `updateDesktopSettings()` already returns silently for unsubscribable / readonly settings payloads, so the removal of the runtime guard is safe in web contexts that have no settings bridge.
- No other call site in `packages/ui` relied on `modelPrefsAutoSave` no-op'ing in VS Code; `isVSCodeRuntime()` is still imported and used elsewhere in `lib/`.