### PR TITLE
fix(chat): clear stale busy state on mobile

### DIFF
--- a/packages/ui/src/hooks/sessionActivity.ts
+++ b/packages/ui/src/hooks/sessionActivity.ts
@@ -1,3 +1,8 @@
+import type { Message, SessionStatus } from '@opencode-ai/sdk/v2/client';
+
+import type { PermissionRequest } from '@/types/permission';
+import type { QuestionRequest } from '@/types/question';
+
 type SessionActivityPhase = 'idle' | 'busy' | 'retry';
 
 export interface SessionActivityResult {
@@ -14,17 +19,14 @@ const IDLE_RESULT: SessionActivityResult = {
   isCooldown: false,
 };
 
-type SessionMessageLike = {
-  role?: string;
-  time?: { completed?: number };
-};
+type SessionMessage = Pick<Message, 'role' | 'time'>;
 
 type SessionActivityInput = {
   sessionId: string | null | undefined;
-  status: { type?: SessionActivityPhase } | undefined;
-  messages: SessionMessageLike[];
-  permissions: unknown[];
-  questions: unknown[];
+  status: SessionStatus | undefined;
+  messages: readonly SessionMessage[];
+  permissions: readonly PermissionRequest[];
+  questions: readonly QuestionRequest[];
 };
 
 export function deriveSessionActivity({
@@ -38,7 +40,7 @@ export function deriveSessionActivity({
 
   if (permissions.length > 0 || questions.length > 0) return IDLE_RESULT;
 
-  const phase: SessionActivityPhase = (status?.type ?? 'idle') as SessionActivityPhase;
+  const phase = status?.type ?? 'idle';
 
   const lastMessage = messages[messages.length - 1];
   const hasCompletedAssistantTurn = Boolean(

--- a/packages/ui/src/hooks/sessionActivity.ts
+++ b/packages/ui/src/hooks/sessionActivity.ts
@@ -21,6 +21,12 @@ const IDLE_RESULT: SessionActivityResult = {
 
 type SessionMessage = Pick<Message, 'role' | 'time'>;
 
+const getAssistantCompletedAt = (message: SessionMessage | undefined): number | undefined => {
+  const time = message?.time;
+  if (!time || !('completed' in time)) return undefined;
+  return typeof time.completed === 'number' ? time.completed : undefined;
+};
+
 type SessionActivityInput = {
   sessionId: string | null | undefined;
   status: SessionStatus | undefined;
@@ -43,21 +49,13 @@ export function deriveSessionActivity({
   const phase = status?.type ?? 'idle';
 
   const lastMessage = messages[messages.length - 1];
-  const hasCompletedAssistantTurn = Boolean(
-    lastMessage
-    && lastMessage.role === 'assistant'
-    && typeof lastMessage.time?.completed === 'number',
-  );
+  const hasCompletedAssistantTurn = lastMessage?.role === 'assistant' && getAssistantCompletedAt(lastMessage) !== undefined;
 
   if (status && phase !== 'idle' && hasCompletedAssistantTurn) {
     return IDLE_RESULT;
   }
 
-  const hasPendingAssistant = Boolean(
-    lastMessage
-    && lastMessage.role === 'assistant'
-    && typeof lastMessage.time?.completed !== 'number',
-  );
+  const hasPendingAssistant = lastMessage?.role === 'assistant' && getAssistantCompletedAt(lastMessage) === undefined;
 
   const hasAuthoritativeStatus = status !== undefined;
   const statusWorking = hasAuthoritativeStatus && phase !== 'idle';

--- a/packages/ui/src/hooks/sessionActivity.ts
+++ b/packages/ui/src/hooks/sessionActivity.ts
@@ -1,0 +1,74 @@
+type SessionActivityPhase = 'idle' | 'busy' | 'retry';
+
+export interface SessionActivityResult {
+  phase: SessionActivityPhase;
+  isWorking: boolean;
+  isBusy: boolean;
+  isCooldown: boolean;
+}
+
+const IDLE_RESULT: SessionActivityResult = {
+  phase: 'idle',
+  isWorking: false,
+  isBusy: false,
+  isCooldown: false,
+};
+
+type SessionMessageLike = {
+  role?: string;
+  time?: { completed?: number };
+};
+
+type SessionActivityInput = {
+  sessionId: string | null | undefined;
+  status: { type?: SessionActivityPhase } | undefined;
+  messages: SessionMessageLike[];
+  permissions: unknown[];
+  questions: unknown[];
+};
+
+export function deriveSessionActivity({
+  sessionId,
+  status,
+  messages,
+  permissions,
+  questions,
+}: SessionActivityInput): SessionActivityResult {
+  if (!sessionId) return IDLE_RESULT;
+
+  if (permissions.length > 0 || questions.length > 0) return IDLE_RESULT;
+
+  const phase: SessionActivityPhase = (status?.type ?? 'idle') as SessionActivityPhase;
+
+  const lastMessage = messages[messages.length - 1];
+  const hasCompletedAssistantTurn = Boolean(
+    lastMessage
+    && lastMessage.role === 'assistant'
+    && typeof lastMessage.time?.completed === 'number',
+  );
+
+  if (status && phase !== 'idle' && hasCompletedAssistantTurn) {
+    return IDLE_RESULT;
+  }
+
+  const hasPendingAssistant = Boolean(
+    lastMessage
+    && lastMessage.role === 'assistant'
+    && typeof lastMessage.time?.completed !== 'number',
+  );
+
+  const hasAuthoritativeStatus = status !== undefined;
+  const statusWorking = hasAuthoritativeStatus && phase !== 'idle';
+  const isWorking = statusWorking || hasPendingAssistant;
+
+  if (hasAuthoritativeStatus && !statusWorking) return IDLE_RESULT;
+
+  if (!isWorking) return IDLE_RESULT;
+
+  return {
+    phase: statusWorking ? phase : 'busy',
+    isWorking: true,
+    isBusy: phase === 'busy' || (!statusWorking && hasPendingAssistant),
+    isCooldown: false,
+  };
+}

--- a/packages/ui/src/hooks/useSessionActivity.test.ts
+++ b/packages/ui/src/hooks/useSessionActivity.test.ts
@@ -1,13 +1,25 @@
 import { describe, expect, test } from 'bun:test';
 
+import type { Message } from '@opencode-ai/sdk/v2/client';
+
 import { deriveSessionActivity } from './sessionActivity';
+
+const completedAssistantMessage: Pick<Message, 'role' | 'time'> = {
+  role: 'assistant',
+  time: { created: 1, completed: 123 },
+};
+
+const incompleteAssistantMessage: Pick<Message, 'role' | 'time'> = {
+  role: 'assistant',
+  time: { created: 1 },
+};
 
 describe('deriveSessionActivity', () => {
   test('treats a completed trailing assistant message as idle even if status is still busy', () => {
     expect(deriveSessionActivity({
       sessionId: 'ses_1',
       status: { type: 'busy' },
-      messages: [{ role: 'assistant', time: { completed: 123 } }],
+      messages: [completedAssistantMessage],
       permissions: [],
       questions: [],
     }).phase).toBe('idle');
@@ -17,7 +29,7 @@ describe('deriveSessionActivity', () => {
     expect(deriveSessionActivity({
       sessionId: 'ses_1',
       status: { type: 'busy' },
-      messages: [{ role: 'assistant', time: {} }],
+      messages: [incompleteAssistantMessage],
       permissions: [],
       questions: [],
     }).isWorking).toBe(true);

--- a/packages/ui/src/hooks/useSessionActivity.test.ts
+++ b/packages/ui/src/hooks/useSessionActivity.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+import { deriveSessionActivity } from './sessionActivity';
+
+describe('deriveSessionActivity', () => {
+  test('treats a completed trailing assistant message as idle even if status is still busy', () => {
+    expect(deriveSessionActivity({
+      sessionId: 'ses_1',
+      status: { type: 'busy' },
+      messages: [{ role: 'assistant', time: { completed: 123 } }],
+      permissions: [],
+      questions: [],
+    }).phase).toBe('idle');
+  });
+
+  test('keeps busy when the trailing assistant message is still incomplete', () => {
+    expect(deriveSessionActivity({
+      sessionId: 'ses_1',
+      status: { type: 'busy' },
+      messages: [{ role: 'assistant', time: {} }],
+      permissions: [],
+      questions: [],
+    }).isWorking).toBe(true);
+  });
+});

--- a/packages/ui/src/hooks/useSessionActivity.ts
+++ b/packages/ui/src/hooks/useSessionActivity.ts
@@ -1,28 +1,13 @@
 import React from 'react';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSessionStatus, useSessionMessages, useSessionPermissions, useSessionQuestions } from '@/sync/sync-context';
-
-// Mirrors OpenCode SessionStatus: busy|retry|idle.
-type SessionActivityPhase = 'idle' | 'busy' | 'retry';
-
-export interface SessionActivityResult {
-  phase: SessionActivityPhase;
-  isWorking: boolean;
-  isBusy: boolean;
-  isCooldown: boolean;
-}
-
-const IDLE_RESULT: SessionActivityResult = {
-  phase: 'idle',
-  isWorking: false,
-  isBusy: false,
-  isCooldown: false,
-};
+import { deriveSessionActivity, type SessionActivityResult } from './sessionActivity';
 
 /**
  * Determines if a session is actively working.
- * Checks session_status and, only when status is missing, falls back to the
- * trailing assistant message when its completion update has not landed yet.
+ * Checks session_status and clears stale busy state once the trailing assistant
+ * message is complete, so delayed idle events do not keep the composer in
+ * follow-up/stop mode.
  * Returns idle when permissions or questions are pending (the permission /
  * question indicator takes priority, and the send button must stay available so
  * the user can supersede the prompt with a new message).
@@ -33,39 +18,13 @@ function useSessionActivity(sessionId: string | null | undefined, directory?: st
   const permissions = useSessionPermissions(sessionId ?? '', directory);
   const questions = useSessionQuestions(sessionId ?? '', directory);
 
-  return React.useMemo<SessionActivityResult>(() => {
-    if (!sessionId) return IDLE_RESULT;
-
-    // Permissions or questions pending → idle (the blocking indicator takes
-    // priority and the send button must remain a send, not a stop).
-    if (permissions.length > 0 || questions.length > 0) return IDLE_RESULT;
-
-    const phase: SessionActivityPhase = (status?.type ?? 'idle') as SessionActivityPhase;
-
-    // Only trust the trailing assistant message as a transient fallback while
-    // waiting for session.status/message.updated to settle.
-    const lastMessage = messages[messages.length - 1];
-    const hasPendingAssistant = Boolean(
-      lastMessage
-      && lastMessage.role === 'assistant'
-      && typeof (lastMessage as { time?: { completed?: number } }).time?.completed !== 'number',
-    );
-
-    const hasAuthoritativeStatus = status !== undefined;
-    const statusWorking = hasAuthoritativeStatus && phase !== 'idle';
-    const isWorking = statusWorking || hasPendingAssistant;
-
-    if (hasAuthoritativeStatus && !statusWorking) return IDLE_RESULT;
-
-    if (!isWorking) return IDLE_RESULT;
-
-    return {
-      phase: statusWorking ? phase : 'busy',
-      isWorking: true,
-      isBusy: phase === 'busy' || (!statusWorking && hasPendingAssistant),
-      isCooldown: false,
-    };
-  }, [sessionId, status, messages, permissions, questions]);
+  return React.useMemo<SessionActivityResult>(() => deriveSessionActivity({
+    sessionId,
+    status,
+    messages,
+    permissions,
+    questions,
+  }), [sessionId, status, messages, permissions, questions]);
 }
 
 export function useCurrentSessionActivity(): SessionActivityResult {


### PR DESCRIPTION
## Summary
- Fixes the mobile composer stale-busy state by deriving session activity from SDK messages and status, and clearing stale active state once the trailing assistant turn is complete.
- Extracts the derivation into a pure helper and adds regression coverage.
- Adds a small typed narrowing helper so the SDK `time` union builds cleanly.

Closes #1983

## Validation
- `bun test src/hooks/useSessionActivity.test.ts` ✅
- `bun test src/hooks/useQueuedMessageAutoSend.test.ts` ⚠️ blocked in this environment: cannot find package 'react'
- `bun run type-check` ⚠️ blocked in this environment: `tsc` not found
- `bun run lint` ⚠️ blocked in this environment: `eslint` / `@eslint/js` not found

## Notes
- Branch was recreated cleanly from `origin/main` to avoid unrelated worktree-store changes from the previous branch.