### PR TITLE
fix(desktop): allow IPC from Vite HMR UI origin in dev mode

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -2205,7 +2205,14 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
 const activateMainWindow = async (url, localOrigin, bootOutcome, runtimeConfig = {}) => {
   state.localOrigin = localOrigin;
   try {
-    state.localUiOrigin = typeof url === 'string' ? new URL(url).origin : null;
+    if (typeof url === 'string') {
+      const parsed = new URL(url);
+      state.localUiOrigin = (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost' || parsed.hostname === '[::1]' || parsed.hostname === '0.0.0.0')
+        ? parsed.origin
+        : null;
+    } else {
+      state.localUiOrigin = null;
+    }
   } catch {
     state.localUiOrigin = null;
   }
@@ -4565,7 +4572,14 @@ app.whenReady().then(async () => {
     const { localOrigin, localUiUrl, bootOutcome, requestHeaders } = await resolveInitialUrl();
     state.localOrigin = localOrigin;
     try {
-      state.localUiOrigin = localUiUrl ? new URL(localUiUrl).origin : null;
+      if (localUiUrl) {
+        const parsed = new URL(localUiUrl);
+        state.localUiOrigin = (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost' || parsed.hostname === '[::1]' || parsed.hostname === '0.0.0.0')
+          ? parsed.origin
+          : null;
+      } else {
+        state.localUiOrigin = null;
+      }
     } catch {
       state.localUiOrigin = null;
     }

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -169,6 +169,7 @@ const state = {
   serverHandle: null,
   sidecarUrl: null,
   localOrigin: null,
+  localUiOrigin: null,
   apiBaseUrl: null,
   clientToken: null,
   requestHeaders: {},
@@ -2203,6 +2204,11 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
 
 const activateMainWindow = async (url, localOrigin, bootOutcome, runtimeConfig = {}) => {
   state.localOrigin = localOrigin;
+  try {
+    state.localUiOrigin = typeof url === 'string' ? new URL(url).origin : null;
+  } catch {
+    state.localUiOrigin = null;
+  }
   state.apiBaseUrl = typeof runtimeConfig.apiBaseUrl === 'string' ? runtimeConfig.apiBaseUrl : state.apiBaseUrl;
   state.clientToken = typeof runtimeConfig.clientToken === 'string' ? runtimeConfig.clientToken : '';
   state.requestHeaders = sanitizeRuntimeRequestHeaders(runtimeConfig.requestHeaders || {});
@@ -4179,6 +4185,13 @@ const isLocalSender = (webContents) => {
       } catch {
       }
     }
+    if (state.localUiOrigin) {
+      try {
+        const allowed = new URL(state.localUiOrigin);
+        if (allowed.origin === url.origin) return true;
+      } catch {
+      }
+    }
     return false;
   } catch {
     return false;
@@ -4549,8 +4562,13 @@ app.whenReady().then(async () => {
   }
 
   if (isBackgroundStart) {
-    const { localOrigin, bootOutcome, requestHeaders } = await resolveInitialUrl();
+    const { localOrigin, localUiUrl, bootOutcome, requestHeaders } = await resolveInitialUrl();
     state.localOrigin = localOrigin;
+    try {
+      state.localUiOrigin = localUiUrl ? new URL(localUiUrl).origin : null;
+    } catch {
+      state.localUiOrigin = null;
+    }
     state.bootOutcome = bootOutcome ?? null;
     state.requestHeaders = sanitizeRuntimeRequestHeaders(requestHeaders || {});
     state.initScript = buildInitScript(localOrigin, state.bootOutcome, '', '', state.requestHeaders);


### PR DESCRIPTION
In Electron dev mode, the browser window loads from Vite HMR UI (http://127.0.0.1:5173), but isLocalSender only checked state.localOrigin and state.sidecarUrl — both pointing to the API server (http://127.0.0.1:3901). This caused all non-remote-safe IPC commands to be rejected.

Add state.localUiOrigin to track the UI page origin separately and check it in isLocalSender, mirroring the existing localOrigin/sidecarUrl pattern.