### PR TITLE
fix(agents): preserve YAML frontmatter fields when saving agent settings via UI

### DIFF
--- a/packages/ui/src/components/sections/agents/AgentsPage.tsx
+++ b/packages/ui/src/components/sections/agents/AgentsPage.tsx
@@ -624,7 +624,7 @@ export const AgentsPage: React.FC = () => {
       const permissionConfig = buildPermissionConfigWithGlobal(globalPermission, permissionRules);
       const config: AgentConfig = {
         name: agentName,
-        description: description.trim() || undefined,
+        ...(description.trim() ? { description: description.trim() } : {}),
         mode,
         model: trimmedModel === '' ? null : trimmedModel,
         variant: trimmedVariant === '' ? null : trimmedVariant || undefined,
@@ -632,7 +632,7 @@ export const AgentsPage: React.FC = () => {
         top_p: topP ?? null,
         prompt: trimmedPrompt || (isNewAgent ? undefined : null),
         permission: permissionConfig,
-        scope: isNewAgent ? draftScope : undefined,
+        ...(isNewAgent && draftScope ? { scope: draftScope } : {}),
       };
 
       let result: AgentMutationResult;

--- a/packages/vscode/src/opencodeConfig.ts
+++ b/packages/vscode/src/opencodeConfig.ts
@@ -1666,6 +1666,9 @@ export const updateAgent = (agentName: string, updates: Record<string, unknown>,
   const creatingNewMd = isBuiltinOverride;
 
   for (const [field, value] of Object.entries(updates || {})) {
+    // Skip undefined values — they would overwrite existing frontmatter fields with nothing
+    if (value === undefined) continue;
+
     if (field === 'prompt') {
       if (value === null) {
         if (mdExists || creatingNewMd) {

--- a/packages/web/server/lib/opencode/agents.js
+++ b/packages/web/server/lib/opencode/agents.js
@@ -451,6 +451,9 @@ function updateAgent(agentName, updates, workingDirectory) {
   const creatingNewMd = isBuiltinOverride;
 
   for (const [field, value] of Object.entries(updates)) {
+    // Skip undefined values — they would overwrite existing frontmatter fields with nothing
+    if (value === undefined) continue;
+
     if (field === 'prompt') {
       if (value === null) {
         if (mdExists || creatingNewMd) {


### PR DESCRIPTION
## Description

Fixes #2001 — Agent settings UI was silently losing YAML frontmatter fields (`description`, `steps`, `tools`, `color`) when saving through the UI.

### Root cause

Two issues working together:

1. **UI sent `undefined` for empty fields** — `AgentsPage.tsx` set `description: description.trim() || undefined` and `scope: isNewAgent ? draftScope : undefined`. These `undefined` values were included in the PATCH payload.

2. **`updateAgent` wrote `undefined` into frontmatter** — both server (`agents.js`) and VS Code (`opencodeConfig.ts`) iterated over all entries in `updates` and set `mdData.frontmatter[field] = value` even when `value === undefined`. This overwrote existing frontmatter fields with nothing.

The result: `writeMdFile` filters `undefined` via `value != null`, so the field was silently deleted from the file. Fields not in the UI schema (`steps`, `tools`, `color`) were preserved in `mdData.frontmatter` after `parseMdFile`, but the `description` field was explicitly killed.

### Changes

| File | Change |
|------|--------|
| `packages/ui/.../AgentsPage.tsx` | Use spread with condition instead of `\|\| undefined` for `description` and `scope` |
| `packages/web/server/lib/opencode/agents.js` | Skip `undefined` values in `updateAgent` loop |
| `packages/vscode/src/opencodeConfig.ts` | Same guard in VS Code\s