### PR TITLE
fix(sync): restore pending questions after restart

### DIFF
--- a/packages/ui/src/stores/globalSessions.test.ts
+++ b/packages/ui/src/stores/globalSessions.test.ts
@@ -55,4 +55,44 @@ describe('listGlobalSessionPages', () => {
     expect(session.revert).toEqual({ messageID: 'msg_1' })
     expect(session.summary).toEqual({ additions: 5, deletions: 3, files: 2 })
   })
+
+  test('paginates through all session-list pages', async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const apiClient = {
+      experimental: {
+        session: {
+          list: async (options: Record<string, unknown>) => {
+            calls.push(options)
+            if (options.cursor === undefined) {
+              return {
+                data: [
+                  { id: 'ses_root', time: { updated: 20 } },
+                  { id: 'ses_child_1', time: { updated: 10 } },
+                ],
+                response: { headers: new Headers({ 'x-next-cursor': '10' }) },
+              }
+            }
+            return {
+              data: [
+                { id: 'ses_child_2', time: { updated: 5 } },
+              ],
+              response: { headers: new Headers() },
+            }
+          },
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const sessions = await listGlobalSessionPages(apiClient, {
+      directory: '/repo',
+      archived: false,
+      roots: false,
+      pageSize: 2,
+    })
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).toEqual({ directory: '/repo', archived: false, roots: false, limit: 2 })
+    expect(calls[1]).toEqual({ directory: '/repo', archived: false, roots: false, limit: 2, cursor: 10 })
+    expect(sessions.map((session) => session.id)).toEqual(['ses_root', 'ses_child_1', 'ses_child_2'])
+  })
 })

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1778,21 +1778,18 @@ export function SyncProvider(props: {
                 .filter((s) => !!s?.id)
                 .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
 
-              // Also load child sessions (sub-agent delegations) so they
-              // appear in the sidebar immediately instead of relying on
-              // the async global session store.
+              // Also load child sessions (sub-agent delegations) with pagination
+              // so pending questions can scope to them immediately after restart.
               let allSessions: typeof rootSessions = []
               try {
-                const allResult = await props.sdk.session.list({
+                allSessions = await listGlobalSessionPages(props.sdk, {
                   directory: dir,
-                  limit: 200,
+                  archived: false,
+                  roots: false,
+                  pageSize: 500,
                 })
-                const allError = (allResult as { error?: unknown }).error
-                if (!allError) {
-                  allSessions = ((allResult as { data?: unknown }).data ?? []) as typeof rootSessions
-                }
               } catch {
-                // Child load is best-effort; fall back to roots only
+                // Child load is best-effort; fall back to roots only.
               }
 
               // Merge: keep root sessions from the first query (for accurate


### PR DESCRIPTION
## Summary
This PR fixes issue #1955, where a question asked before an OpenChamber restart could reappear as read-only text instead of an answerable QuestionCard form.

## Problem
- The server still had the pending question after restart.
- The client restored question data, but the interactive form depended on scoped session data being present in the directory store.
- After restart, child or subagent sessions could be missing when question scoping ran, so the question existed in state.question but never reached the interactive renderer.
- The previous child-session load path also relied on a limited session.list call and could miss sessions or fail, which made the form disappear more easily.

## What changed
- Bootstrap now loads child sessions through paginated listGlobalSessionPages with roots: false, instead of using a fixed limit session.list call.
- If child-session loading fails, bootstrap still falls back to the root sessions so the directory can continue loading in a degraded but usable state.
- Added a regression test for paginated session-list fetching in packages/ui/src/stores/globalSessions.test.ts.

## Why this approach
- The bug is in session materialization and scoping, not in the QuestionCard UI itself.
- Keeping the fix in bootstrap preserves the existing rendering flow and avoids exposing raw fallback text to users.
- The fallback keeps startup resilient when child-session discovery is temporarily unavailable.

## Validation
- bun test packages/ui/src/stores/globalSessions.test.ts
- bun test packages/ui/src/sync/scoped-blocking-requests.test.ts
- bun run --cwd packages/ui type-check
- bun run --cwd packages/ui lint

Closes #1955