### PR TITLE
feat(skills): system "create-project" skill + agent API that links new projects to Discord

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -83,6 +83,7 @@ import { createNotificationTemplateRuntime } from './lib/notifications/template-
 import { createGracefulShutdownRuntime } from './lib/opencode/shutdown-runtime.js';
 import { createProjectConfigRuntime } from './lib/projects/project-config.js';
 import { createMessengerSyncRouter } from './lib/otto-api/messenger-sync.js';
+import { syncSystemSkills } from './lib/opencode/system-skills.js';
 import {
   createOttoEventsWebSocketRuntime,
   broadcast as ottoEventsBroadcast,
@@ -1357,6 +1358,25 @@ async function main(options = {}) {
     await scheduledTasksRuntime.start();
   } catch (error) {
     console.warn('[ScheduledTasks] Failed to start runtime:', error?.message || error);
+  }
+
+  // Install / refresh OpenChamber-managed system skills (e.g. create-project)
+  // in the user skill dir so OpenCode sessions can load them natively. Runs
+  // after the startup pipeline so the embedded API base URL uses the final
+  // bound port. Best-effort — a failure here must never block startup.
+  try {
+    const results = syncSystemSkills({
+      apiBaseUrl: `http://127.0.0.1:${tunnelRuntimeContext.getActivePort() || port}`,
+    });
+    const changed = results.filter((r) => r.action === 'installed' || r.action === 'updated');
+    if (changed.length > 0) {
+      console.log(
+        '[SystemSkills] Synced:',
+        changed.map((r) => `${r.name} (${r.action})`).join(', '),
+      );
+    }
+  } catch (error) {
+    console.warn('[SystemSkills] Failed to sync system skills:', error?.message || error);
   }
 
   // Auto-start Discord Gateway listener if a bot token is saved in settings.

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -33,6 +33,7 @@ This module provides OpenCode server integration utilities for the web server ru
 - `packages/web/server/lib/opencode/pwa-manifest-routes.js`: PWA manifest route registration with recent-session shortcut resolution and short-lived caching.
 - `packages/web/server/lib/opencode/project-icon-routes.js`: project icon upload/read/discovery route registration and icon storage orchestration.
 - `packages/web/server/lib/opencode/skill-routes.js`: route registration for skill config CRUD, supporting files, and skills catalog scan/install flows.
+- `packages/web/server/lib/opencode/system-skills.js`: OpenChamber-managed system skills (e.g. `create-project`) generated and installed into the user skill dir at server startup.
 - `packages/web/server/lib/opencode/settings-runtime.js`: Settings persistence runtime (disk IO, migrations, normalization, project validation, and persisted update serialization).
 - `packages/web/server/lib/opencode/settings-helpers.js`: Settings payload sanitization/format helpers runtime for response shaping and persisted merge prep.
 - `packages/web/server/lib/opencode/settings-normalization-runtime.js`: path/settings/tunnel normalization and sanitization helpers runtime used by settings/routes/config wiring.
@@ -329,6 +330,10 @@ This module provides OpenCode server integration utilities for the web server ru
   - Skills config CRUD and metadata under `/api/config/skills*`
   - Skills catalog listing/source pagination, scan, and install routes
   - Supporting skill file read/write/delete routes
+
+## Public exports (system-skills.js)
+- `buildSystemSkills({ apiBaseUrl })`: returns the OpenChamber system skill definitions (`{ name, frontmatter, body }`) with the local API base URL embedded. Currently ships `create-project` — bootstrap a new project, write its AGENTS.md, and link a Discord channel via `POST /api/otto/messenger/agent/create-project`.
+- `syncSystemSkills({ apiBaseUrl, skillRootDir? })`: installs/refreshes system skills in the user skill dir (`~/.config/opencode/skills`). Files carrying `managed-by: openchamber` frontmatter are rewritten when content changes (e.g. new port); files without the marker are user-owned and never touched. Called from `server/index.js` after the startup pipeline binds the final port.
 
 ## Public exports (proxy.js)
 - `registerOpenCodeProxy(app, dependencies)`: registers OpenCode proxy routes and middleware.

--- a/packages/web/server/lib/opencode/system-skills.js
+++ b/packages/web/server/lib/opencode/system-skills.js
@@ -1,0 +1,162 @@
+import fs from 'fs';
+import path from 'path';
+import { SKILL_DIR, parseMdFile, writeMdFile } from './shared.js';
+
+/**
+ * OpenChamber-managed "system" skills.
+ *
+ * These skills ship with the OpenChamber server and are installed into the
+ * user-level OpenCode skill directory (`~/.config/opencode/skills/<name>/`)
+ * at startup so the agent can load them natively in every project — web,
+ * desktop, and the Discord bridge all discover them through the same
+ * skill-discovery paths OpenCode itself scans.
+ *
+ * Ownership contract: a system skill carries `managed-by: openchamber` in its
+ * frontmatter and is refreshed on every server start (content is regenerated
+ * with the current local API base URL). A skill file WITHOUT that marker is
+ * user-owned and is never touched — users who want to customize a system
+ * skill can simply remove the marker to take ownership.
+ */
+
+const MANAGED_BY_KEY = 'managed-by';
+const MANAGED_BY_VALUE = 'openchamber';
+
+/**
+ * The `create-project` system skill — bootstraps a brand-new OpenChamber
+ * project from inside a conversation: create/scaffold the folder, register it
+ * with OpenChamber, write an AGENTS.md, and mirror it into Discord as a
+ * channel the user can immediately chat in.
+ */
+function buildCreateProjectSkill({ apiBaseUrl }) {
+  const api = `${apiBaseUrl}/api/otto/messenger/agent`;
+  const body = [
+    '# Create a new OpenChamber project',
+    '',
+    'Use this skill when the user asks to create, bootstrap, scaffold, or clone a **new project** (a new folder / repository / workspace that should become its own OpenChamber project with its own Discord channel).',
+    '',
+    'This skill file is managed by OpenChamber and refreshed on server start. Remove the `managed-by` frontmatter field to take ownership of your edits.',
+    '',
+    '## Workflow',
+    '',
+    '### 1. Resolve the target location — ask, never guess',
+    '',
+    '- If the user already told you where to create the project (a folder or parent directory), use it. Resolve to an **absolute path**.',
+    '- If the user did **not** specify a location, you MUST ask before creating anything. Suggest the OpenChamber projects root (`~/.config/openchamber/projects/<name>`) as the default and let the user confirm or provide a different folder.',
+    '- Also confirm the project name if it is not obvious from the request.',
+    '',
+    '### 2. Create the project folder',
+    '',
+    'Pick the simplest path that matches the request:',
+    '',
+    '- **Empty project**: `mkdir -p <abs-path>` (optionally `git init`).',
+    '- **Framework project**: use the official scaffolding CLI non-interactively (for example `npm create vite@latest <name> -- --template react-ts`, `cargo new <name>`, `uv init <name>`). Run it so the target folder ends up at the confirmed absolute path.',
+    '- **Clone an existing repository**: skip this step — the registration endpoint below can clone for you (`action: "clone"`).',
+    '',
+    '### 3. Register the project with OpenChamber (auto-creates the Discord channel)',
+    '',
+    'Call the local OpenChamber API with bash curl. This registers the project so it appears in the OpenChamber UI **and**, when Discord is connected, finds-or-creates a Discord channel bound to the project:',
+    '',
+    '```bash',
+    '# Folder you created in step 2 (or any existing directory):',
+    `curl -s -X POST ${api}/create-project -H 'Content-Type: application/json' \\`,
+    '  -d \'{"action":"path","path":"<abs-path>","label":"<Project Name>"}\'',
+    '',
+    '# Let the server create an empty directory for you (path optional):',
+    `curl -s -X POST ${api}/create-project -H 'Content-Type: application/json' \\`,
+    '  -d \'{"action":"new","path":"<abs-path>","label":"<Project Name>"}\'',
+    '',
+    '# Clone a git repository as the new project:',
+    `curl -s -X POST ${api}/create-project -H 'Content-Type: application/json' \\`,
+    '  -d \'{"action":"clone","url":"<git-url>","path":"<optional-abs-dest>","label":"<Project Name>"}\'',
+    '```',
+    '',
+    'The response contains `project` (`{ id, path, label }`) and `discord` (`{ ok, channelId, channelName, url }` on success, or `{ ok: false, error }` when Discord is unavailable). Project registration and the Discord channel are independent: a Discord failure never rolls back the project — report it instead.',
+    '',
+    '### 4. Create AGENTS.md for the new project',
+    '',
+    '- Ask the user what kind of AGENTS.md the new project should have. Propose a concrete draft derived from:',
+    '  - the **conversation context** (what the project is for, stack, conventions discussed), and',
+    '  - the **AGENTS.md of the current project** you are running in — read it from the current working directory (or its worktree root) and reuse the sections that transfer (tooling, code style, validation commands), dropping anything project-specific that does not apply.',
+    '- If the current project has no AGENTS.md, propose a minimal one: purpose, tech stack, build/test commands, and code conventions.',
+    '- After the user confirms (or asks you to just do it), write `AGENTS.md` into the new project root.',
+    '',
+    '### 5. Report back',
+    '',
+    'Tell the user, in one compact message:',
+    '',
+    '- the absolute path of the new project and what was scaffolded,',
+    '- that it is registered in OpenChamber (it appears in the project switcher),',
+    '- the Discord channel: include `discord.url` from the response and say they can **start chatting in that channel right away** — messages there open sessions in the new project. If `discord.ok` is false, say the channel was not created and include the error.',
+    '',
+    '## Rules',
+    '',
+    '- Never create the project in a location the user did not confirm.',
+    '- Never ask for or handle the Discord bot token — the server resolves it internally.',
+    '- Use absolute paths in every API call.',
+    '- If curl fails because the OpenChamber API is unreachable, report the error instead of silently skipping registration.',
+  ].join('\n');
+
+  return {
+    name: 'create-project',
+    frontmatter: {
+      name: 'create-project',
+      description:
+        'Use when the user asks to create, bootstrap, scaffold, or clone a NEW project (new folder/repo/workspace). Creates the folder (CLI/scaffold/clone), registers it as an OpenChamber project, writes an AGENTS.md based on the conversation and the current AGENTS.md, and links a Discord channel the user can immediately chat in.',
+      [MANAGED_BY_KEY]: MANAGED_BY_VALUE,
+    },
+    body,
+  };
+}
+
+/** Build every OpenChamber system skill for the given local API base URL. */
+export function buildSystemSkills({ apiBaseUrl }) {
+  return [buildCreateProjectSkill({ apiBaseUrl })];
+}
+
+/**
+ * Install or refresh the OpenChamber system skills in the user skill dir.
+ *
+ * - Missing skill → installed.
+ * - Existing skill with the `managed-by: openchamber` marker → rewritten when
+ *   the generated content differs (e.g. the server port changed).
+ * - Existing skill WITHOUT the marker → left untouched (user-owned).
+ *
+ * Returns per-skill results: { name, path, action } with action one of
+ * 'installed' | 'updated' | 'unchanged' | 'skipped-user-owned'.
+ */
+export function syncSystemSkills({ apiBaseUrl, skillRootDir = SKILL_DIR }) {
+  const results = [];
+  for (const skill of buildSystemSkills({ apiBaseUrl })) {
+    const skillDir = path.join(skillRootDir, skill.name);
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    let action = 'installed';
+
+    if (fs.existsSync(skillPath)) {
+      let existing = { frontmatter: {}, body: '' };
+      try {
+        existing = parseMdFile(skillPath);
+      } catch {
+        // unreadable file — treat as user-owned rather than clobbering it
+        results.push({ name: skill.name, path: skillPath, action: 'skipped-user-owned' });
+        continue;
+      }
+      if (existing.frontmatter?.[MANAGED_BY_KEY] !== MANAGED_BY_VALUE) {
+        results.push({ name: skill.name, path: skillPath, action: 'skipped-user-owned' });
+        continue;
+      }
+      const sameBody = existing.body === skill.body.trim();
+      const sameDescription =
+        existing.frontmatter?.description === skill.frontmatter.description;
+      if (sameBody && sameDescription) {
+        results.push({ name: skill.name, path: skillPath, action: 'unchanged' });
+        continue;
+      }
+      action = 'updated';
+    }
+
+    fs.mkdirSync(skillDir, { recursive: true });
+    writeMdFile(skillPath, skill.frontmatter, skill.body);
+    results.push({ name: skill.name, path: skillPath, action });
+  }
+  return results;
+}

--- a/packages/web/server/lib/opencode/system-skills.test.js
+++ b/packages/web/server/lib/opencode/system-skills.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { buildSystemSkills, syncSystemSkills } from './system-skills.js';
+import { parseMdFile, writeMdFile } from './shared.js';
+
+const API_BASE = 'http://127.0.0.1:3001';
+
+describe('system-skills', () => {
+  let skillRootDir;
+
+  beforeEach(() => {
+    skillRootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-system-skills-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(skillRootDir, { recursive: true, force: true });
+  });
+
+  it('builds the create-project skill with the API base URL embedded', () => {
+    const skills = buildSystemSkills({ apiBaseUrl: API_BASE });
+    const createProject = skills.find((s) => s.name === 'create-project');
+    expect(createProject).toBeTruthy();
+    expect(createProject.frontmatter['managed-by']).toBe('openchamber');
+    expect(createProject.frontmatter.description).toMatch(/new project/i);
+    expect(createProject.body).toContain(`${API_BASE}/api/otto/messenger/agent/create-project`);
+    expect(createProject.body).toContain('AGENTS.md');
+    expect(createProject.body).toContain('Discord');
+  });
+
+  it('installs a missing system skill', () => {
+    const results = syncSystemSkills({ apiBaseUrl: API_BASE, skillRootDir });
+    expect(results).toEqual([
+      {
+        name: 'create-project',
+        path: path.join(skillRootDir, 'create-project', 'SKILL.md'),
+        action: 'installed',
+      },
+    ]);
+    const { frontmatter, body } = parseMdFile(results[0].path);
+    expect(frontmatter.name).toBe('create-project');
+    expect(frontmatter['managed-by']).toBe('openchamber');
+    expect(body).toContain(API_BASE);
+  });
+
+  it('is a no-op when the managed skill is already current', () => {
+    syncSystemSkills({ apiBaseUrl: API_BASE, skillRootDir });
+    const results = syncSystemSkills({ apiBaseUrl: API_BASE, skillRootDir });
+    expect(results[0].action).toBe('unchanged');
+  });
+
+  it('rewrites the managed skill when the API base URL changes', () => {
+    syncSystemSkills({ apiBaseUrl: API_BASE, skillRootDir });
+    const results = syncSystemSkills({ apiBaseUrl: 'http://127.0.0.1:4999', skillRootDir });
+    expect(results[0].action).toBe('updated');
+    const { body } = parseMdFile(results[0].path);
+    expect(body).toContain('http://127.0.0.1:4999');
+    expect(body).not.toContain(API_BASE);
+  });
+
+  it('never touches a user-owned skill without the managed-by marker', () => {
+    const skillDir = path.join(skillRootDir, 'create-project');
+    fs.mkdirSync(skillDir, { recursive: true });
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    writeMdFile(
+      skillPath,
+      { name: 'create-project', description: 'my customized version' },
+      'user content',
+    );
+    const results = syncSystemSkills({ apiBaseUrl: API_BASE, skillRootDir });
+    expect(results[0].action).toBe('skipped-user-owned');
+    const { frontmatter, body } = parseMdFile(skillPath);
+    expect(frontmatter.description).toBe('my customized version');
+    expect(body).toBe('user content');
+  });
+});

--- a/packages/web/server/lib/otto-api/discord-agent-api.js
+++ b/packages/web/server/lib/otto-api/discord-agent-api.js
@@ -14,10 +14,11 @@ import { Router } from 'express';
  *   - returns a ready-to-share Discord deep link for every resolved target.
  *
  * Endpoints (mounted under /api/otto/messenger/agent):
- *   GET  /agent/help      — compact, self-describing usage docs
- *   GET  /agent/targets   — list project channels + live session threads + URLs
- *   POST /agent/resolve   — resolve a single target → { channelId, url } (no post)
- *   POST /agent/post      — post a message to a target → { messageIds, url }
+ *   GET  /agent/help           — compact, self-describing usage docs
+ *   GET  /agent/targets        — list project channels + live session threads + URLs
+ *   POST /agent/resolve        — resolve a single target → { channelId, url } (no post)
+ *   POST /agent/post           — post a message to a target → { messageIds, url }
+ *   POST /agent/create-project — create/register a project + its Discord channel
  */
 
 const DISCORD_LIMIT = 2000;
@@ -86,6 +87,13 @@ export function createDiscordAgentRouter({
   bridge = null,
   broadcastEvent = null,
   getLocalApiBaseUrl = null,
+  // Async ({ action, url, path, label }) => { ok, project?, error? } — creates
+  // or registers a project in OpenChamber settings (see project-bootstrap.js).
+  bootstrapProject = null,
+  // Async (project) => surface results | null — find-or-create the project's
+  // Discord channel and persist the binding. Null means Discord is not
+  // configured. Wraps autoCreateMessengerSurfacesForProject in messenger-sync.
+  autoCreateProjectChannel = null,
 } = {}) {
   const router = Router();
   // The parent router already parses JSON, but keep this self-contained so the
@@ -336,12 +344,15 @@ export function createDiscordAgentRouter({
           'Resolve { project | session | channel } → { channelId, url } without posting.',
         'POST /agent/post':
           'Post { text, project | session | channel, silent? } → { messageIds, url }.',
+        'POST /agent/create-project':
+          "Create/register a project and its Discord channel: { action: 'new'|'clone'|'path', path?, url?, label? } → { project, discord: { channelId, url } }.",
       },
       examples: [
         `curl -s ${api}/targets`,
         `curl -s -X POST ${api}/post -H 'Content-Type: application/json' -d '{"project":"my-app","text":"Build is green ✅"}'`,
         `curl -s -X POST ${api}/post -H 'Content-Type: application/json' -d '{"session":"ses_123","text":"done"}'`,
         `curl -s -X POST ${api}/resolve -H 'Content-Type: application/json' -d '{"channel":"https://discord.com/channels/1/2"}'`,
+        `curl -s -X POST ${api}/create-project -H 'Content-Type: application/json' -d '{"action":"path","path":"/abs/path/to/project","label":"My Project"}'`,
       ],
     };
   }
@@ -378,6 +389,81 @@ export function createDiscordAgentRouter({
       ok: true,
       target: { ...target, url: buildDiscordUrl(target) },
     });
+  });
+
+  /**
+   * Create (or register) an OpenChamber project and mirror it into Discord.
+   *
+   * Body: {
+   *   action?: 'new' | 'clone' | 'path'   (default 'new')
+   *   path?:   string                     (absolute target/existing directory)
+   *   url?:    string                     (git url, required for 'clone')
+   *   label?:  string                     (human project label)
+   * }
+   *
+   * Returns: {
+   *   ok,
+   *   project: { id, path, label },
+   *   discord: { ok, channelId?, channelName?, created?, url?, error? },
+   * }
+   *
+   * Project registration and the Discord channel are two independent steps:
+   * a Discord failure (or Discord not being configured at all) never rolls
+   * back the created project — it is reported explicitly in `discord`.
+   */
+  router.post('/create-project', async (req, res) => {
+    if (typeof bootstrapProject !== 'function') {
+      return res
+        .status(503)
+        .json({ ok: false, error: 'project bootstrap is not wired in this server' });
+    }
+    const { action = 'new', url, path: targetPath, label } = req.body ?? {};
+    if (!['new', 'clone', 'path'].includes(action)) {
+      return res
+        .status(400)
+        .json({ ok: false, error: "action must be one of 'new' | 'clone' | 'path'" });
+    }
+
+    let result;
+    try {
+      result = await bootstrapProject({ action, url, path: targetPath, label });
+    } catch (err) {
+      return res.json({ ok: false, error: err?.message ?? 'project bootstrap failed' });
+    }
+    if (!result?.ok || !result.project) {
+      return res.json({ ok: false, error: result?.error ?? 'project bootstrap failed' });
+    }
+
+    let discord = {
+      ok: false,
+      error: 'Discord is not configured (no bot token / server saved) — no channel was created.',
+    };
+    if (typeof autoCreateProjectChannel === 'function') {
+      try {
+        const surfaces = await autoCreateProjectChannel(result.project);
+        const entry = Array.isArray(surfaces)
+          ? surfaces.find((r) => r?.type === 'discord')
+          : null;
+        if (entry?.ok && entry.channelId) {
+          const cfg = await loadDiscordConfig();
+          const target = { channelId: String(entry.channelId), guildId: cfg?.guildId ?? null };
+          if (cfg?.token) await ensureGuildId(cfg.token, target);
+          discord = {
+            ok: true,
+            channelId: target.channelId,
+            channelName: entry.channelName ?? null,
+            created: Boolean(entry.created),
+            url: buildDiscordUrl(target),
+          };
+        } else if (entry) {
+          discord = { ok: false, error: entry.error ?? 'Discord channel creation failed' };
+        }
+      } catch (err) {
+        discord = { ok: false, error: err?.message ?? 'Discord channel creation failed' };
+      }
+    }
+
+    res.json({ ok: true, project: result.project, discord });
   });
 
   router.post('/post', async (req, res) => {

--- a/packages/web/server/lib/otto-api/discord-agent-api.test.js
+++ b/packages/web/server/lib/otto-api/discord-agent-api.test.js
@@ -35,7 +35,13 @@ function makeBridge(sessions = []) {
   };
 }
 
-function createApp({ readSettings, bridge = null, broadcastEvent = null } = {}) {
+function createApp({
+  readSettings,
+  bridge = null,
+  broadcastEvent = null,
+  bootstrapProject = null,
+  autoCreateProjectChannel = null,
+} = {}) {
   const app = express();
   app.use(express.json());
   app.use(
@@ -45,6 +51,8 @@ function createApp({ readSettings, bridge = null, broadcastEvent = null } = {}) 
       bridge,
       broadcastEvent,
       getLocalApiBaseUrl: () => 'http://127.0.0.1:3001',
+      bootstrapProject,
+      autoCreateProjectChannel,
     }),
   );
   return app;
@@ -282,5 +290,133 @@ describe('discord-agent-api — routes', () => {
     expect(res.body.url).toBe(
       `https://discord.com/channels/${GUILD}/${PROJECT_CHANNEL}/777`,
     );
+  });
+});
+
+describe('discord-agent-api — POST /create-project', () => {
+  const NEW_CHANNEL = '444444444444444444';
+  const NEW_PROJECT = { id: 'proj_1', path: '/home/me/new-app', label: 'New App' };
+
+  it('returns 503 when project bootstrap is not wired', async () => {
+    const app = createApp({ readSettings: async () => makeSettings() });
+    const res = await request(app)
+      .post('/api/otto/messenger/agent/create-project')
+      .send({ action: 'new', label: 'New App' });
+    expect(res.status).toBe(503);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('rejects unknown actions', async () => {
+    const app = createApp({
+      readSettings: async () => makeSettings(),
+      bootstrapProject: vi.fn(),
+    });
+    const res = await request(app)
+      .post('/api/otto/messenger/agent/create-project')
+      .send({ action: 'destroy' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("'new' | 'clone' | 'path'");
+  });
+
+  it('creates the project and the Discord channel, returning both', async () => {
+    const bootstrapProject = vi.fn(async () => ({ ok: true, project: NEW_PROJECT }));
+    const autoCreateProjectChannel = vi.fn(async () => [
+      { type: 'discord', ok: true, channelId: NEW_CHANNEL, channelName: 'new-app', created: true },
+    ]);
+    const app = createApp({
+      readSettings: async () => makeSettings(),
+      bootstrapProject,
+      autoCreateProjectChannel,
+    });
+
+    const res = await request(app)
+      .post('/api/otto/messenger/agent/create-project')
+      .send({ action: 'path', path: '/home/me/new-app', label: 'New App' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.project).toEqual(NEW_PROJECT);
+    expect(res.body.discord).toEqual({
+      ok: true,
+      channelId: NEW_CHANNEL,
+      channelName: 'new-app',
+      created: true,
+      url: `https://discord.com/channels/${GUILD}/${NEW_CHANNEL}`,
+    });
+    expect(bootstrapProject).toHaveBeenCalledWith({
+      action: 'path',
+      url: undefined,
+      path: '/home/me/new-app',
+      label: 'New App',
+    });
+    expect(autoCreateProjectChannel).toHaveBeenCalledWith(NEW_PROJECT);
+  });
+
+  it('reports project success with an explicit discord error when Discord is not configured', async () => {
+    const bootstrapProject = vi.fn(async () => ({ ok: true, project: NEW_PROJECT }));
+    // autoCreateProjectChannel returns null → Discord not configured
+    const app = createApp({
+      readSettings: async () => ({}),
+      bootstrapProject,
+      autoCreateProjectChannel: vi.fn(async () => null),
+    });
+
+    const res = await request(app)
+      .post('/api/otto/messenger/agent/create-project')
+      .send({ action: 'new', label: 'New App' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.project).toEqual(NEW_PROJECT);
+    expect(res.body.discord.ok).toBe(false);
+    expect(res.body.discord.error).toContain('not configured');
+  });
+
+  it('keeps the project when the Discord channel creation fails', async () => {
+    const bootstrapProject = vi.fn(async () => ({ ok: true, project: NEW_PROJECT }));
+    const autoCreateProjectChannel = vi.fn(async () => [
+      { type: 'discord', ok: false, error: 'Discord: 403 — Bot has no access' },
+    ]);
+    const app = createApp({
+      readSettings: async () => makeSettings(),
+      bootstrapProject,
+      autoCreateProjectChannel,
+    });
+
+    const res = await request(app)
+      .post('/api/otto/messenger/agent/create-project')
+      .send({ action: 'new', label: 'New App' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.project).toEqual(NEW_PROJECT);
+    expect(res.body.discord.ok).toBe(false);
+    expect(res.body.discord.error).toContain('403');
+  });
+
+  it('propagates bootstrap failure without touching Discord', async () => {
+    const bootstrapProject = vi.fn(async () => ({ ok: false, error: 'path already exists and is non-empty: /x' }));
+    const autoCreateProjectChannel = vi.fn();
+    const app = createApp({
+      readSettings: async () => makeSettings(),
+      bootstrapProject,
+      autoCreateProjectChannel,
+    });
+
+    const res = await request(app)
+      .post('/api/otto/messenger/agent/create-project')
+      .send({ action: 'path', path: '/x' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toContain('already exists');
+    expect(autoCreateProjectChannel).not.toHaveBeenCalled();
+  });
+
+  it('GET /help documents the create-project endpoint', async () => {
+    const app = createApp({ readSettings: async () => makeSettings() });
+    const res = await request(app).get('/api/otto/messenger/agent/help');
+    expect(res.status).toBe(200);
+    expect(res.body.endpoints).toHaveProperty('POST /agent/create-project');
   });
 });

--- a/packages/web/server/lib/otto-api/messenger-sync.js
+++ b/packages/web/server/lib/otto-api/messenger-sync.js
@@ -402,12 +402,32 @@ export function createMessengerSyncRouter({
   const discordListener = createDiscordListenerRegistry({ broadcastEvent, bridge });
 
   // Agent-facing Discord API — a high-level surface (resolve a project/session
-  // to its Discord URL, post a message there) designed to be delegated to an
-  // AI agent. The bot token is resolved server-side from settings so the agent
-  // never handles the secret.
+  // to its Discord URL, post a message there, create a new project + channel)
+  // designed to be delegated to an AI agent. The bot token is resolved
+  // server-side from settings so the agent never handles the secret.
   router.use(
     '/agent',
-    createDiscordAgentRouter({ readSettings, bridge, broadcastEvent, getLocalApiBaseUrl }),
+    createDiscordAgentRouter({
+      readSettings,
+      bridge,
+      broadcastEvent,
+      getLocalApiBaseUrl,
+      bootstrapProject: projectBootstrap,
+      // Resolve the bot config server-side and reuse the exact same
+      // find-or-create channel flow the UI's project-add path uses, so an
+      // agent-created project lands in Discord identically to a UI-added one.
+      autoCreateProjectChannel: async (project) => {
+        const { discord } = await loadDiscordSettings();
+        if (!discord?.botToken || !discord?.guildId) return null;
+        return autoCreateMessengerSurfacesForProject(project, {
+          discord: {
+            token: discord.botToken,
+            guildId: discord.guildId,
+            parentCategoryId: discord.parentCategoryId ?? null,
+          },
+        });
+      },
+    }),
   );
 
   // Messenger configuration


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ships an OpenChamber-managed **system skill** (`create-project`) so the agent can create a brand-new project from inside any conversation, and a matching agent-facing API endpoint that registers the project **and automatically creates its Discord channel** so the user can immediately start chatting there.

### Agent API — `POST /api/otto/messenger/agent/create-project`
- Accepts `{ action: 'new' | 'clone' | 'path', path?, url?, label? }` and reuses the existing `project-bootstrap` flow (`packages/web/server/lib/projects/project-bootstrap.js`).
- After registration it runs the exact same `autoCreateMessengerSurfacesForProject` flow the UI project-add path uses: find-or-create the Discord channel, persist the `projectBindings` entry, pre-bind the bridge store — and returns the ready-to-share `discord.url`.
- Partial failure is explicit: Discord being unconfigured or failing never rolls back the created project; it is reported in `discord: { ok: false, error }`.
- Bot token stays server-side, consistent with the rest of the `/agent` surface. Documented in `GET /agent/help`.

### System skill — `create-project`
- New `packages/web/server/lib/opencode/system-skills.js` generates the skill with the server's local API base URL embedded and installs it into `~/.config/opencode/skills/create-project/SKILL.md` at startup (after the startup pipeline binds the final port), so OpenCode discovers it natively in every project — web UI, desktop, and the Discord `/skill` picker.
- The skill instructs the agent to:
  1. **Ask for the target folder if the user didn't specify one** (never guess), suggesting the OpenChamber projects root as default.
  2. Create the folder via the simplest CLI (mkdir/scaffold CLI) or let the endpoint clone/create it.
  3. Register the project via curl → auto-creates the Discord channel.
  4. **Ask what kind of AGENTS.md to create**, proposing a draft derived from the conversation context and the current project's AGENTS.md, then write it into the new project root.
  5. Report the project path and the Discord channel URL so the user can start the conversation there right away.
- Ownership contract: the file carries `managed-by: openchamber` frontmatter and is refreshed on boot (e.g. when the port changes). A copy **without** the marker is user-owned and never touched — users take ownership by removing the marker.

## Verification

[create_project_endpoint_and_skill_verification.log](https://cursor.com/agents/bc-6c6b455f-6b16-4017-80c3-3dab6d1449dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_project_endpoint_and_skill_verification.log)

Installed skill file: [installed_create_project_skill.md](https://cursor.com/agents/bc-6c6b455f-6b16-4017-80c3-3dab6d1449dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finstalled_create_project_skill.md)

- ✅ `bunx vitest run server/lib/opencode/system-skills.test.js server/lib/otto-api/discord-agent-api.test.js` (26 new/updated tests pass)
- ✅ `bunx vitest run` (web package) — 6 failures are pre-existing on the base branch (verified via a base-branch worktree; git/service + files API environment issues)
- ✅ `bun run type-check`, `bun run lint` (packages/web)
- ✅ Live server run: skill installed on boot (`[SystemSkills] Synced: create-project (installed)`), re-boot is a no-op, port change rewrites the file, user-owned copy (marker removed) is skipped
- ✅ Live endpoint: `action=path`/`action=new` register the project in settings; with a fake bot token the Discord attempt reaches the Discord API and reports `401 — Invalid bot token` explicitly while keeping the project

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c6b455f-6b16-4017-80c3-3dab6d1449dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c6b455f-6b16-4017-80c3-3dab6d1449dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

