### PR TITLE
feat(quota): add DeepSeek balance provider

### DIFF
--- a/packages/ui/src/lib/quota/providers/index.ts
+++ b/packages/ui/src/lib/quota/providers/index.ts
@@ -9,6 +9,7 @@ export const QUOTA_PROVIDERS: QuotaProviderMeta[] = [
   { id: 'claude', name: 'Claude' },
   { id: 'codex', name: 'Codex' },
   { id: 'cursor', name: 'Cursor' },
+  { id: 'deepseek', name: 'DeepSeek' },
   { id: 'github-copilot', name: 'GitHub Copilot' },
   { id: 'google', name: 'Google' },
   { id: 'kimi-for-coding', name: 'Kimi for Coding' },

--- a/packages/ui/src/types/quota.ts
+++ b/packages/ui/src/types/quota.ts
@@ -3,6 +3,7 @@ export type QuotaProviderId =
   | 'codex'
   | 'cursor'
   | 'claude'
+  | 'deepseek'
   | 'github-copilot'
   | 'github-copilot-addon'
   | 'google'

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -453,6 +453,11 @@ export const listConfiguredQuotaProviders = () => {
     configured.add('wafer');
   }
 
+  const deepseekAuth = normalizeAuthEntry(getAuthEntry(auth, ['deepseek']));
+  if (deepseekAuth && ((deepseekAuth as Record<string, unknown>).key || (deepseekAuth as Record<string, unknown>).token)) {
+    configured.add('deepseek');
+  }
+
   return Array.from(configured);
 };
 
@@ -1862,12 +1867,118 @@ const fetchWaferQuota = async (): Promise<ProviderResult> => {
   }
 };
 
+const DEEPSEEK_BALANCE_URL = 'https://api.deepseek.com/user/balance';
+
+const currencySymbol = (currency: string) => {
+  if (currency === 'CNY') return 'CN\u00a5';
+  if (currency === 'USD') return '$';
+  return currency;
+};
+
+const formatBalanceLabel = (info: Record<string, unknown>) => {
+  const symbol = currencySymbol(info.currency as string);
+  const part = (val: unknown) => formatMoney(toNumber(val));
+  const parts = [`${symbol}${part(info.total_balance)}`];
+  const topped = toNumber(info.topped_up_balance);
+  const granted = toNumber(info.granted_balance);
+  if (topped && granted) {
+    parts.push(`(${symbol}${part(topped)} topped up + ${symbol}${part(granted)} granted)`);
+  } else if (topped) {
+    parts.push(`(${symbol}${part(topped)} topped up)`);
+  } else if (granted) {
+    parts.push(`(${symbol}${part(granted)} granted)`);
+  }
+  return parts.join(' ');
+};
+
+const fetchDeepseekQuota = async (): Promise<ProviderResult> => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, ['deepseek'])) as Record<string, unknown> | null;
+  const apiKey = (entry?.key as string | undefined) ?? (entry?.token as string | undefined);
+
+  if (!apiKey) {
+    return buildResult({
+      providerId: 'deepseek',
+      providerName: 'DeepSeek',
+      ok: false,
+      configured: false,
+      error: 'Not configured',
+    });
+  }
+
+  try {
+    const response = await fetch(DEEPSEEK_BALANCE_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId: 'deepseek',
+        providerName: 'DeepSeek',
+        ok: false,
+        configured: true,
+        error: response.status === 401
+          ? 'Invalid API key \u2014 please re-authenticate with DeepSeek'
+          : `API error: ${response.status}`,
+      });
+    }
+
+    const payload = await response.json() as Record<string, unknown>;
+    const balanceInfos = Array.isArray(payload.balance_infos) ? payload.balance_infos : [];
+
+    if (balanceInfos.length === 0) {
+      return buildResult({
+        providerId: 'deepseek',
+        providerName: 'DeepSeek',
+        ok: false,
+        configured: true,
+        error: 'No balance data returned',
+      });
+    }
+
+    const windows: Record<string, UsageWindow> = {};
+
+    for (const info of balanceInfos) {
+      const entry = info as Record<string, unknown>;
+      if (!entry || typeof entry.currency !== 'string') continue;
+      windows[entry.currency.toUpperCase()] = toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: formatBalanceLabel(entry),
+      });
+    }
+
+    return buildResult({
+      providerId: 'deepseek',
+      providerName: 'DeepSeek',
+      ok: true,
+      configured: true,
+      usage: { windows },
+    });
+  } catch (error) {
+    return buildResult({
+      providerId: 'deepseek',
+      providerName: 'DeepSeek',
+      ok: false,
+      configured: true,
+      error: error instanceof Error ? error.message : 'Request failed',
+    });
+  }
+};
+
 export const fetchQuotaForProvider = async (providerId: string): Promise<ProviderResult> => {
   switch (providerId) {
     case 'claude':
       return fetchClaudeQuota();
     case 'codex':
       return fetchCodexQuota();
+    case 'deepseek':
+      return fetchDeepseekQuota();
     case 'github-copilot':
       return fetchCopilotQuota();
     case 'github-copilot-addon':

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -19,6 +19,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 | `claude` | Claude | `providers/claude.js` | `anthropic`, `claude` |
 | `codex` | Codex | `providers/codex.js` | `openai`, `codex`, `chatgpt` |
 | `cursor` | Cursor | `providers/cursor.js` | `CURSOR_TOKEN` / `CURSOR_ACCESS_TOKEN`, `CURSOR_REFRESH_TOKEN`, optional token files, or Cursor desktop SQLite DB |
+| `deepseek` | DeepSeek | `providers/deepseek.js` | `deepseek` (API key from `auth.json`) |
 | `google` | Google | `providers/google/index.js` | `google`, `google.oauth`, Antigravity accounts file |
 | `github-copilot` | GitHub Copilot | `providers/copilot.js` | `github-copilot`, `copilot` |
 | `github-copilot-addon` | GitHub Copilot Add-on | `providers/copilot.js` | `github-copilot`, `copilot` |

--- a/packages/web/server/lib/quota/index.js
+++ b/packages/web/server/lib/quota/index.js
@@ -13,6 +13,7 @@ export {
   fetchGoogleQuota,
   fetchCodexQuota,
   fetchCursorQuota,
+  fetchDeepseekQuota,
   fetchCopilotQuota,
   fetchCopilotAddonQuota,
   fetchKimiQuota,

--- a/packages/web/server/lib/quota/providers/deepseek.js
+++ b/packages/web/server/lib/quota/providers/deepseek.js
@@ -1,0 +1,123 @@
+import { readAuthFile } from '../../opencode/auth.js';
+import {
+  getAuthEntry,
+  normalizeAuthEntry,
+  buildResult,
+  toUsageWindow,
+  formatMoney
+} from '../utils/index.js';
+
+export const providerId = 'deepseek';
+export const providerName = 'DeepSeek';
+const aliases = ['deepseek'];
+
+const DEEPSEEK_BALANCE_URL = 'https://api.deepseek.com/user/balance';
+
+const currencySymbol = (currency) => {
+  if (currency === 'CNY') return 'CN\u00a5';
+  if (currency === 'USD') return '$';
+  return currency;
+};
+
+const formatBalanceLabel = (info) => {
+  const symbol = currencySymbol(info.currency);
+  const parts = [`${symbol}${formatMoney(Number(info.total_balance))}`];
+  const topped = Number(info.topped_up_balance);
+  const granted = Number(info.granted_balance);
+  if (topped > 0 && granted > 0) {
+    parts.push(`(${symbol}${formatMoney(topped)} topped up + ${symbol}${formatMoney(granted)} granted)`);
+  } else if (topped > 0) {
+    parts.push(`(${symbol}${formatMoney(topped)} topped up)`);
+  } else if (granted > 0) {
+    parts.push(`(${symbol}${formatMoney(granted)} granted)`);
+  }
+  return parts.join(' ');
+};
+
+export const isConfigured = () => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  return Boolean(entry?.key || entry?.token);
+};
+
+export const fetchQuota = async () => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  const apiKey = entry?.key ?? entry?.token;
+
+  if (!apiKey) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: false,
+      error: 'Not configured'
+    });
+  }
+
+  try {
+    const response = await fetch(DEEPSEEK_BALANCE_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: response.status === 401
+          ? 'Invalid API key \u2014 please re-authenticate with DeepSeek'
+          : `API error: ${response.status}`
+      });
+    }
+
+    const payload = await response.json();
+    const balanceInfos = Array.isArray(payload?.balance_infos)
+      ? payload.balance_infos
+      : [];
+
+    if (balanceInfos.length === 0) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'No balance data returned'
+      });
+    }
+
+    const windows = {};
+
+    for (const info of balanceInfos) {
+      if (!info || typeof info.currency !== 'string') continue;
+      const key = info.currency.toUpperCase();
+      windows[key] = toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: formatBalanceLabel(info)
+      });
+    }
+
+    return buildResult({
+      providerId,
+      providerName,
+      ok: true,
+      configured: true,
+      usage: { windows }
+    });
+  } catch (error) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: error instanceof Error ? error.message : 'Request failed'
+    });
+  }
+};

--- a/packages/web/server/lib/quota/providers/deepseek.test.js
+++ b/packages/web/server/lib/quota/providers/deepseek.test.js
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+let mockAuth = {};
+const mockAuthModule = {
+  readAuthFile: () => mockAuth
+};
+
+vi.mock('../../opencode/auth.js', () => ({
+  readAuthFile: () => mockAuthModule.readAuthFile()
+}));
+
+const { fetchQuota } = await import('./deepseek.js');
+const { isConfigured } = await import('./deepseek.js');
+
+const BALANCE_RESPONSE = {
+  is_available: true,
+  balance_infos: [
+    {
+      currency: 'CNY',
+      total_balance: '110.00',
+      granted_balance: '10.00',
+      topped_up_balance: '100.00'
+    }
+  ]
+};
+
+describe('deepseek quota provider', () => {
+  beforeEach(() => {
+    mockAuth = {};
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('isConfigured', () => {
+    it('returns false when auth.json has no deepseek entry', () => {
+      expect(isConfigured()).toBe(false);
+    });
+
+    it('returns true when API key is present in auth.json', () => {
+      mockAuth.deepseek = { key: 'sk-test' };
+      expect(isConfigured()).toBe(true);
+    });
+  });
+
+  describe('fetchQuota', () => {
+    it('returns not configured when no API key is found', async () => {
+      const result = await fetchQuota();
+      expect(result.configured).toBe(false);
+      expect(result.ok).toBe(false);
+    });
+
+    it('returns API error on non-200 response', async () => {
+      mockAuth.deepseek = { key: 'sk-test' };
+      fetch.mockResolvedValueOnce({ ok: false, status: 401 });
+
+      const result = await fetchQuota();
+      expect(result.configured).toBe(true);
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Invalid API key');
+    });
+
+    it('fetches and parses balance on success', async () => {
+      mockAuth.deepseek = { key: 'sk-test' };
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => BALANCE_RESPONSE
+      });
+
+      const result = await fetchQuota();
+      expect(result.ok).toBe(true);
+      expect(result.configured).toBe(true);
+      expect(result.usage.windows.CNY).toBeDefined();
+      expect(result.usage.windows.CNY.valueLabel).toContain('CN\u00a5');
+      expect(result.usage.windows.CNY.valueLabel).toContain('110.00');
+      expect(result.usage.windows.CNY.usedPercent).toBeNull();
+    });
+
+    it('handles multiple currencies', async () => {
+      mockAuth.deepseek = { key: 'sk-test' };
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          is_available: true,
+          balance_infos: [
+            { currency: 'CNY', total_balance: '100', granted_balance: '0', topped_up_balance: '100' },
+            { currency: 'USD', total_balance: '50', granted_balance: '0', topped_up_balance: '50' }
+          ]
+        })
+      });
+
+      const result = await fetchQuota();
+      expect(result.usage.windows.CNY).toBeDefined();
+      expect(result.usage.windows.USD).toBeDefined();
+    });
+
+    it('handles empty balance_infos gracefully', async () => {
+      mockAuth.deepseek = { key: 'sk-test' };
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ is_available: false, balance_infos: [] })
+      });
+
+      const result = await fetchQuota();
+      expect(result.ok).toBe(false);
+      expect(result.configured).toBe(true);
+      expect(result.error).toContain('No balance data');
+    });
+
+    it('handles network errors gracefully', async () => {
+      mockAuth.deepseek = { key: 'sk-test' };
+      fetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await fetchQuota();
+      expect(result.ok).toBe(false);
+      expect(result.configured).toBe(true);
+      expect(result.error).toBe('Network error');
+    });
+  });
+});

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -11,6 +11,7 @@ import * as claude from './claude.js';
 import * as codex from './codex.js';
 import * as copilot from './copilot.js';
 import * as cursor from './cursor.js';
+import * as deepseek from './deepseek.js';
 import * as google from './google/index.js';
 import * as kimi from './kimi.js';
 import * as nanogpt from './nanogpt.js';
@@ -41,6 +42,12 @@ const registry = {
     providerName: cursor.providerName,
     isConfigured: cursor.isConfigured,
     fetchQuota: cursor.fetchQuota
+  },
+  deepseek: {
+    providerId: deepseek.providerId,
+    providerName: deepseek.providerName,
+    isConfigured: deepseek.isConfigured,
+    fetchQuota: deepseek.fetchQuota
   },
   google: {
     providerId: google.providerId,
@@ -163,6 +170,7 @@ export const fetchOpenaiQuota = openai.fetchQuota;
 export const fetchGoogleQuota = google.fetchGoogleQuota;
 export const fetchCodexQuota = codex.fetchQuota;
 export const fetchCursorQuota = cursor.fetchQuota;
+export const fetchDeepseekQuota = deepseek.fetchQuota;
 export const fetchCopilotQuota = copilot.fetchQuota;
 export const fetchCopilotAddonQuota = copilot.fetchQuotaAddon;
 export const fetchKimiQuota = kimi.fetchQuota;

--- a/packages/web/server/lib/quota/providers/index.test.js
+++ b/packages/web/server/lib/quota/providers/index.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import * as deepseek from './deepseek.js';
 import * as google from './google/index.js';
 import { listConfiguredQuotaProviders } from './index.js';
 
@@ -9,6 +10,12 @@ describe('quota provider registry', () => {
     expect(google.providerName).toBe('Google');
     expect(typeof google.isConfigured).toBe('function');
     expect(typeof google.resolveGoogleAuthSources).toBe('function');
+  });
+
+  it('exposes deepseek provider configuration helpers through the provider module', () => {
+    expect(deepseek.providerId).toBe('deepseek');
+    expect(deepseek.providerName).toBe('DeepSeek');
+    expect(typeof deepseek.isConfigured).toBe('function');
   });
 
   it('can list configured providers without missing provider exports', () => {


### PR DESCRIPTION
## Summary

Adds a DeepSeek quota provider that displays account balance in the Usage page and
header bar. Uses the official `GET https://api.deepseek.com/user/balance` REST API
with the same Bearer token already stored in `auth.json` — no separate credentials,
no scraping.

## What changed

**Server-side provider** (`packages/web/server/lib/quota/providers/deepseek.js`)
- Authenticates via the `deepseek` entry in `auth.json` (same key used for chat).
- Calls `GET https://api.deepseek.com/user/balance` and maps `balance_infos` into
  `UsageWindow` entries keyed by currency code (CNY, USD).
- Displays valueLabels like `CN¥110.00 (¥100 topped up + ¥10 granted)`.
- Currency is dynamic — reads `info.currency` from the API response, not hardcoded.

**Frontend registration** (`QUOTA_PROVIDERS` metadata + `QuotaProviderId` type)
- Added `deepseek` to the provider list so it renders in the Usage page, sidebar,
  header dropdown, and tray.

**VS Code parity** (`packages/vscode/src/quotaProviders.ts`)
- Added `fetchDeepseekQuota`, `listConfiguredQuotaProviders` entry, and dispatch
  case — mirrors the web server provider so VS Code shows DeepSeek usage too.

**Tests** (`deepseek.test.js` + `index.test.js`)
- 11 tests: `isConfigured`, API success (single + multi-currency), API errors,
  network errors, empty balance, and provider module shape.

**Docs** — added DeepSeek row to `DOCUMENTATION.md`.

## Design note

DeepSeek is a prepaid balance model, not a subscription window model. The
`/user/balance` endpoint returns balance amounts, not rolling/weekly/monthly
usage percentages. The provider uses `valueLabel`-only windows (null percent,
null reset timers) — same pattern as OpenRouter credits. The DeepSeek API does
not expose a usage-history endpoint, so tokens-spent-over-time is not available.

## Validation

- `bun run lint` — clean (web + vscode + eslint on changed files)
- `bun run type-check` (web + vscode) — clean
- `bun run test` (web) — 70/70 files, 588 tests passing
