### PR TITLE
fix(ci): pin node-gyp v12 to avoid undici/webidl incompatibility

### DIFF
--- a/.github/workflows/oc-review.yml
+++ b/.github/workflows/oc-review.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Pin node-gyp
+        run: npm install -g node-gyp@12
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
`bun install --frozen-lockfile` breaks on `ubuntu-latest` because
`bunx node-gyp@latest` resolves to `node-gyp@13.0.1`, which bundles an
`undici` version that removed `webidl.util.markAsUncloneable`.
`better-sqlite3` native compilation fails with:

    gyp ERR! TypeError: webidl.util.markAsUncloneable is not a function

This regressed between Jul 2 (all green) and Jul 3 (every PR breaks).
Two affected PRs:

- #2014 — feat(quota): add DeepSeek balance provider
- #2015 — Share project edit form; add per-project default model

The fix: globally install `node-gyp@12` before `bun install`. Bun checks
PATH for `node-gyp` first and uses it when found, skipping the broken
`bunx node-gyp@latest` fallback.
