### PR TITLE
feat(discord): /yolo permission modes, richer /model list, live verbosity, robust interrupts

### DIFF
--- a/packages/web/server/lib/otto-api/discord-command-wizards.js
+++ b/packages/web/server/lib/otto-api/discord-command-wizards.js
@@ -8,6 +8,11 @@ import {
   createWizardStore,
 } from './discord-wizard-shared.js';
 import { VERBOSITY_LEVELS } from './messenger-verbosity.js';
+import {
+  PERMISSION_MODES,
+  PERMISSION_MODE_DESCRIPTIONS,
+  PERMISSION_MODE_LABELS,
+} from './messenger-permissions.js';
 
 /**
  * Interactive select-menu wizards for the Discord `/verbosity`, `/agent` and
@@ -29,6 +34,8 @@ const VERB_SCOPE_PREFIX = 'otto-verb-scope:';
 const AGENT_PICK_PREFIX = 'otto-agent-pick:';
 const AGENT_SCOPE_PREFIX = 'otto-agent-scope:';
 const SKILL_PICK_PREFIX = 'otto-skill-pick:';
+const PERM_MODE_PREFIX = 'otto-perm-mode:';
+const PERM_SCOPE_PREFIX = 'otto-perm-scope:';
 
 const VERBOSITY_DESCRIPTIONS = {
   quiet: 'Final answer only — hides reasoning + tool activity',
@@ -42,6 +49,8 @@ const PREFIXES = [
   AGENT_PICK_PREFIX,
   AGENT_SCOPE_PREFIX,
   SKILL_PICK_PREFIX,
+  PERM_MODE_PREFIX,
+  PERM_SCOPE_PREFIX,
 ];
 
 function isNav(value) {
@@ -179,11 +188,126 @@ export function createDiscordCommandWizards({ restCall, bridge }) {
         // best-effort — still confirm the user's choice below
       }
     }
+    // Apply the change to any turn already streaming on this surface so the new
+    // level takes effect immediately, not only on the next message.
+    try {
+      bridge?.applyPreferencesToActiveTurn?.({
+        type: 'discord',
+        token: wizard.token,
+        channelId: wizard.channelId,
+        threadId: null,
+      });
+    } catch {
+      // best-effort
+    }
     wizards.del(hash);
     await respond(wizard.token, interaction, {
       type: 7,
       data: {
         content: `✓ Verbosity set to **${level}** for ${scopeLabel}.\n_${VERBOSITY_DESCRIPTIONS[level] ?? ''}_`,
+        flags: 64,
+        components: [],
+      },
+    });
+  }
+
+  // ── /yolo (permission mode) ────────────────────────────────────────────────
+  function permissionModeSelect(hash) {
+    const options = PERMISSION_MODES.map((mode) => ({
+      label: PERMISSION_MODE_LABELS[mode] ?? mode,
+      value: mode,
+      description: (PERMISSION_MODE_DESCRIPTIONS[mode] ?? '').slice(0, 100),
+    }));
+    return stringSelect(`${PERM_MODE_PREFIX}${hash}`, options, 'Select a permission mode');
+  }
+
+  async function startPermissions(state, interaction) {
+    const hash = randomWizardHash();
+    wizards.set(hash, {
+      kind: 'permissions',
+      token: state.token,
+      channelId: interaction.channel_id,
+      guildId: interaction.guild_id,
+      appId: interaction.application_id,
+    });
+    await respond(state.token, interaction, {
+      type: 4,
+      data: {
+        content:
+          '**Set tool permission mode**\nHow should Otto handle approval requests (shell, edits, …)?\nYou can still stop any run with `/abort`.',
+        flags: 64,
+        components: [permissionModeSelect(hash)],
+      },
+    });
+  }
+
+  async function onPermissionsMode(token, interaction, hash) {
+    const wizard = wizards.get(hash);
+    if (!wizard) return expired(token, interaction);
+    const value = interaction.data?.values?.[0];
+    if (!value) return;
+    wizard.mode = value;
+    wizards.set(hash, wizard);
+
+    const scopeOptions = [
+      { label: 'This conversation', value: 'surface', description: 'Override for this channel/thread only' },
+      { label: 'This project', value: 'project', description: "Default for this conversation's project" },
+      { label: 'Whole system (default)', value: 'global', description: 'Default for every Discord conversation' },
+    ];
+    await respond(wizard.token, interaction, {
+      type: 7,
+      data: {
+        content: `**Set tool permission mode**\nMode: **${PERMISSION_MODE_LABELS[value] ?? value}** — ${PERMISSION_MODE_DESCRIPTIONS[value] ?? ''}\nApply to:`,
+        flags: 64,
+        components: [stringSelect(`${PERM_SCOPE_PREFIX}${hash}`, scopeOptions, 'Apply to…')],
+      },
+    });
+  }
+
+  async function onPermissionsScope(token, interaction, hash) {
+    const wizard = wizards.get(hash);
+    if (!wizard) return expired(token, interaction);
+    const scope = interaction.data?.values?.[0];
+    const mode = wizard.mode;
+    if (!scope || !mode) return;
+
+    let scopeLabel = 'this conversation';
+    if (bridge?.store) {
+      try {
+        const botTokenHash = botHashFor(wizard.token);
+        const targetKey = String(wizard.channelId);
+        const binding =
+          scope === 'project'
+            ? bridge.store.lookup?.({ type: 'discord', botTokenHash, targetKey })
+            : null;
+        if (scope === 'global') {
+          bridge.store.setPermissionModeDefault?.('discord', mode);
+          scopeLabel = 'every Discord conversation';
+        } else if (scope === 'project' && binding?.projectPath) {
+          bridge.store.setProjectDefaults?.({
+            projectPath: binding.projectPath,
+            projectLabel: binding.projectLabel,
+            permissionModeDefault: mode,
+          });
+          scopeLabel = `project *${binding.projectLabel ?? binding.projectPath}*`;
+        } else {
+          bridge.store.setOverrides?.({
+            type: 'discord',
+            botTokenHash,
+            targetKey,
+            permissionModeOverride: mode,
+          });
+          scopeLabel = scope === 'project' ? 'this conversation (no project bound yet)' : 'this conversation';
+        }
+      } catch {
+        // best-effort — still confirm the user's choice below
+      }
+    }
+    wizards.del(hash);
+    await respond(wizard.token, interaction, {
+      type: 7,
+      data: {
+        content: `✓ Permission mode set to **${PERMISSION_MODE_LABELS[mode] ?? mode}** for ${scopeLabel}.\n_${PERMISSION_MODE_DESCRIPTIONS[mode] ?? ''}_`,
         flags: 64,
         components: [],
       },
@@ -445,7 +569,11 @@ export function createDiscordCommandWizards({ restCall, bridge }) {
       return onAgentScope(token, interaction, customId.slice(AGENT_SCOPE_PREFIX.length));
     if (customId.startsWith(SKILL_PICK_PREFIX))
       return onSkillPick(token, interaction, customId.slice(SKILL_PICK_PREFIX.length));
+    if (customId.startsWith(PERM_MODE_PREFIX))
+      return onPermissionsMode(token, interaction, customId.slice(PERM_MODE_PREFIX.length));
+    if (customId.startsWith(PERM_SCOPE_PREFIX))
+      return onPermissionsScope(token, interaction, customId.slice(PERM_SCOPE_PREFIX.length));
   }
 
-  return { ownsComponent, handleComponent, startVerbosity, startAgent, startSkill };
+  return { ownsComponent, handleComponent, startVerbosity, startAgent, startSkill, startPermissions };
 }

--- a/packages/web/server/lib/otto-api/discord-command-wizards.test.js
+++ b/packages/web/server/lib/otto-api/discord-command-wizards.test.js
@@ -10,8 +10,10 @@ function makeHarness({ agents = [], skills = [] } = {}) {
   };
   const overrides = [];
   const verbosityDefaults = [];
+  const permissionModeDefaults = [];
   const projectDefaults = [];
   const routed = [];
+  const activeTurnRefreshes = [];
   const bridge = {
     listAgents: async () => agents,
     listSurfaceSkills: async () => skills,
@@ -19,15 +21,27 @@ function makeHarness({ agents = [], skills = [] } = {}) {
       routed.push(args);
       return { ok: true };
     },
+    applyPreferencesToActiveTurn: (o) => activeTurnRefreshes.push(o),
     store: {
       setOverrides: (o) => overrides.push(o),
       setVerbosityDefault: (type, level) => verbosityDefaults.push({ type, level }),
+      setPermissionModeDefault: (type, mode) => permissionModeDefaults.push({ type, mode }),
       setProjectDefaults: (o) => projectDefaults.push(o),
       lookup: () => null,
     },
   };
   const wizards = createDiscordCommandWizards({ restCall, bridge });
-  return { wizards, bridge, calls, overrides, verbosityDefaults, projectDefaults, routed };
+  return {
+    wizards,
+    bridge,
+    calls,
+    overrides,
+    verbosityDefaults,
+    permissionModeDefaults,
+    projectDefaults,
+    routed,
+    activeTurnRefreshes,
+  };
 }
 
 function customIdOf(call) {
@@ -85,6 +99,66 @@ describe('verbosity wizard', () => {
       { projectPath: '/proj', projectLabel: 'Proj', verbosityDefault: 'verbose' },
     ]);
     expect(overrides).toHaveLength(0);
+  });
+});
+
+describe('permissions (/yolo) wizard', () => {
+  it('mode → "this conversation" scope writes a surface override', async () => {
+    const { wizards, calls, overrides, permissionModeDefaults } = makeHarness();
+
+    await wizards.startPermissions(state, interaction);
+    const modeCustomId = customIdOf(calls.at(-1));
+    expect(wizards.ownsComponent(modeCustomId)).toBe(true);
+    expect(optionValues(calls.at(-1))).toEqual(['ask', 'auto-edit', 'yolo']);
+
+    await wizards.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['yolo'] } }, modeCustomId);
+    const scopeCustomId = customIdOf(calls.at(-1));
+    expect(optionValues(calls.at(-1))).toEqual(['surface', 'project', 'global']);
+
+    await wizards.handleComponent(state, { id: 'i3', token: 't3', data: { values: ['surface'] } }, scopeCustomId);
+    expect(overrides).toEqual([
+      { type: 'discord', botTokenHash: expect.any(String), targetKey: 'chan-1', permissionModeOverride: 'yolo' },
+    ]);
+    expect(permissionModeDefaults).toHaveLength(0);
+    expect(calls.at(-1).body.data.content).toContain('YOLO');
+  });
+
+  it('mode → "whole system" scope writes the messenger default', async () => {
+    const { wizards, calls, overrides, permissionModeDefaults } = makeHarness();
+    await wizards.startPermissions(state, interaction);
+    const modeCustomId = customIdOf(calls.at(-1));
+    await wizards.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['auto-edit'] } }, modeCustomId);
+    const scopeCustomId = customIdOf(calls.at(-1));
+    await wizards.handleComponent(state, { id: 'i3', token: 't3', data: { values: ['global'] } }, scopeCustomId);
+    expect(permissionModeDefaults).toEqual([{ type: 'discord', mode: 'auto-edit' }]);
+    expect(overrides).toHaveLength(0);
+  });
+
+  it('mode → "project" scope writes a project default when bound', async () => {
+    const { wizards, bridge, calls, projectDefaults } = makeHarness();
+    bridge.store.lookup = () => ({ projectPath: '/proj', projectLabel: 'Proj' });
+    await wizards.startPermissions(state, interaction);
+    const modeCustomId = customIdOf(calls.at(-1));
+    await wizards.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['yolo'] } }, modeCustomId);
+    const scopeCustomId = customIdOf(calls.at(-1));
+    await wizards.handleComponent(state, { id: 'i3', token: 't3', data: { values: ['project'] } }, scopeCustomId);
+    expect(projectDefaults).toEqual([
+      { projectPath: '/proj', projectLabel: 'Proj', permissionModeDefault: 'yolo' },
+    ]);
+  });
+});
+
+describe('verbosity wizard applies to the active turn', () => {
+  it('refreshes the streaming turn after a scope is chosen', async () => {
+    const { wizards, calls, activeTurnRefreshes } = makeHarness();
+    await wizards.startVerbosity(state, interaction);
+    const levelCustomId = customIdOf(calls.at(-1));
+    await wizards.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['verbose'] } }, levelCustomId);
+    const scopeCustomId = customIdOf(calls.at(-1));
+    await wizards.handleComponent(state, { id: 'i3', token: 't3', data: { values: ['surface'] } }, scopeCustomId);
+    expect(activeTurnRefreshes).toEqual([
+      { type: 'discord', token: 'bot-token', channelId: 'chan-1', threadId: null },
+    ]);
   });
 });
 
@@ -149,6 +223,8 @@ describe('component ownership', () => {
     expect(wizards.ownsComponent('otto-verb-level:abc')).toBe(true);
     expect(wizards.ownsComponent('otto-agent-scope:abc')).toBe(true);
     expect(wizards.ownsComponent('otto-skill-pick:abc')).toBe(true);
+    expect(wizards.ownsComponent('otto-perm-mode:abc')).toBe(true);
+    expect(wizards.ownsComponent('otto-perm-scope:abc')).toBe(true);
     expect(wizards.ownsComponent('otto-model-provider:abc')).toBe(false);
     expect(wizards.ownsComponent('otto-approve:abc')).toBe(false);
   });

--- a/packages/web/server/lib/otto-api/discord-commands.js
+++ b/packages/web/server/lib/otto-api/discord-commands.js
@@ -48,6 +48,7 @@ export function buildSlashCommandDefinitions() {
     { name: 'model', description: 'Pick the model + thinking effort (this chat, project, or everywhere)' },
     { name: 'agent', description: 'Pick the agent for this conversation (or set a project default)' },
     { name: 'verbosity', description: 'Choose how much Otto streams back (this chat, project, or everywhere)' },
+    { name: 'yolo', description: 'Set tool permission mode: ask / auto-approve edits / auto-approve all' },
     { name: 'skill', description: 'Pick an available skill and hand it to the agent' },
     { name: 'sessions', description: 'List recent OpenCode sessions for this project' },
     {

--- a/packages/web/server/lib/otto-api/discord-commands.test.js
+++ b/packages/web/server/lib/otto-api/discord-commands.test.js
@@ -6,7 +6,7 @@ describe('buildSlashCommandDefinitions', () => {
 
   it('includes the interactive wizard commands and the new /skill command', () => {
     const names = defs.map((d) => d.name);
-    for (const name of ['model', 'agent', 'verbosity', 'skill', 'help', 'status', 'sessions']) {
+    for (const name of ['model', 'agent', 'verbosity', 'yolo', 'skill', 'help', 'status', 'sessions']) {
       expect(names).toContain(name);
     }
   });

--- a/packages/web/server/lib/otto-api/discord-listener.js
+++ b/packages/web/server/lib/otto-api/discord-listener.js
@@ -368,8 +368,8 @@ function dispatchThreadDelete(state, data, bridge, reason = 'deleted') {
  */
 const KNOWN_SLASH_COMMANDS = new Set([
   'help', 'status', 'abort', 'new', 'undo', 'redo',
-  'compact', 'summary', 'init', 'review',
-  'model', 'agent', 'verbosity', 'skill', 'sessions',
+  'compact', 'summary', 'init', 'review', 'shell',
+  'model', 'agent', 'verbosity', 'yolo', 'skill', 'sessions',
   'session', 'resume', 'fork', 'share', 'unshare',
   'queue', 'clear-queue', 'mention-mode',
   'new-worktree', 'merge-worktree', 'schedule',
@@ -398,6 +398,10 @@ async function handleApplicationCommand(state, interaction, broadcastEvent, brid
     }
     if (cmdName === 'skill') {
       await state.commandWizards.startSkill(state, interaction);
+      return;
+    }
+    if (cmdName === 'yolo') {
+      await state.commandWizards.startPermissions(state, interaction);
       return;
     }
   }

--- a/packages/web/server/lib/otto-api/discord-model-wizard.js
+++ b/packages/web/server/lib/otto-api/discord-model-wizard.js
@@ -52,6 +52,48 @@ export function modelsOf(provider) {
   return Array.isArray(provider.models) ? provider.models : Object.values(provider.models);
 }
 
+/** Compact token count: 200000 → "200K", 1500000 → "1.5M". */
+function formatTokensCompact(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  if (value >= 1_000_000) {
+    const v = value / 1_000_000;
+    return `${Number.isInteger(v) ? v : v.toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    const v = value / 1_000;
+    return `${Number.isInteger(v) ? v : Math.round(v)}K`;
+  }
+  return String(value);
+}
+
+/** Per-million-token USD price: 3 → "$3", 0.15 → "$0.15", 0 → "$0". */
+function formatCostPerMillion(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null;
+  if (value === 0) return '$0';
+  const rounded = Number(value.toFixed(2));
+  return `$${rounded}`;
+}
+
+/**
+ * Build the Discord select-option description for a model: its context window
+ * and (when available) per-million-token input/output price — e.g.
+ * `200K ctx · in $3/out $15 /Mtok`. Returns '' when the model exposes no
+ * usable metadata. Replaces the old `release_date` formatting that showed a
+ * confusing bare date under every model name.
+ */
+export function formatModelMeta(model) {
+  if (!model || typeof model !== 'object') return '';
+  const parts = [];
+  const ctx = formatTokensCompact(model?.limit?.context);
+  if (ctx) parts.push(`${ctx} ctx`);
+  const input = formatCostPerMillion(model?.cost?.input);
+  const output = formatCostPerMillion(model?.cost?.output);
+  if (input && output) parts.push(`in ${input}/out ${output} /Mtok`);
+  else if (input) parts.push(`in ${input} /Mtok`);
+  else if (output) parts.push(`out ${output} /Mtok`);
+  return parts.join(' · ');
+}
+
 /** Normalise a model's reasoning `variants` (array or map) into a flat array of keys. */
 export function variantsOf(model) {
   const v = model?.variants;
@@ -103,6 +145,30 @@ export function createDiscordModelWizard({ restCall, bridge }) {
     return variantsOf(model);
   }
 
+  /** Stable `provider/model` key used to match the UI's hidden-model set. */
+  function modelKey(providerId, model) {
+    const id = model?.id ?? model?.name;
+    return id ? `${providerId}/${id}` : null;
+  }
+
+  /**
+   * A provider's models minus the ones the user hid in the OpenChamber UI, so
+   * the Discord `/model` list matches what the UI shows instead of exposing
+   * every model the provider advertises.
+   */
+  function visibleModelsOf(provider, hiddenSet) {
+    const all = modelsOf(provider);
+    if (!hiddenSet || hiddenSet.size === 0) return all;
+    return all.filter((m) => !hiddenSet.has(modelKey(provider.id, m)));
+  }
+
+  /** Find a model object across all providers (for enriching favourite rows). */
+  function findModel(providersById, providerId, modelId) {
+    const provider = providersById?.get(providerId);
+    if (!provider) return null;
+    return modelsOf(provider).find((m) => (m.id ?? m.name) === modelId) ?? null;
+  }
+
   // ── rendering ─────────────────────────────────────────────────────────────
   function providerOptions(entries) {
     return entries.map((e) => ({
@@ -121,10 +187,9 @@ export function createDiscordModelWizard({ restCall, bridge }) {
     return models.map((m) => ({
       label: (m.label ?? m.name ?? m.id ?? String(m)).slice(0, 100),
       value: m.value ?? m.id ?? m.name ?? String(m),
-      description: (
-        m.description ??
-        (m.release_date ? new Date(m.release_date).toLocaleDateString() : ' ')
-      ).slice(0, 100),
+      // Show context window + pricing under the model name (falling back to an
+      // explicit `description` when one is provided, e.g. favourites).
+      description: ((m.description || formatModelMeta(m)) || ' ').slice(0, 100),
     }));
   }
 
@@ -191,15 +256,31 @@ export function createDiscordModelWizard({ restCall, bridge }) {
     const connected = all.filter((p) => connectedSet.has(p.id));
     const realProviders = connected.length > 0 ? connected : all;
 
-    const favorites = (await bridge?.getFavoriteModels?.().catch(() => [])) ?? [];
+    const rawFavorites = (await bridge?.getFavoriteModels?.().catch(() => [])) ?? [];
+    const hiddenList = (await bridge?.getHiddenModels?.().catch(() => [])) ?? [];
+    const hiddenSet = new Set(
+      hiddenList.map(({ providerID, modelID }) => `${providerID}/${modelID}`),
+    );
 
-    // Provider menu entries: ⭐ Favourites first (when any), then real providers.
+    // Favourites mirror the UI: only models that still exist on a live provider
+    // and are NOT hidden. Prevents Discord from listing favourites the UI has
+    // dropped or hidden.
+    const favorites = rawFavorites.filter(({ providerID, modelID }) => {
+      const key = `${providerID}/${modelID}`;
+      if (hiddenSet.has(key)) return false;
+      return Boolean(findModel(providersById, providerID, modelID));
+    });
+
+    // Provider menu entries: ⭐ Favourites first (when any), then real providers
+    // that have at least one visible (non-hidden) model.
     const entries = [];
     if (favorites.length > 0) {
       entries.push({ id: FAVORITES_ID, name: '⭐ Favourites', count: favorites.length });
     }
     for (const p of realProviders) {
-      entries.push({ id: p.id, name: p.name ?? p.id, count: modelsOf(p).length });
+      const count = visibleModelsOf(p, hiddenSet).length;
+      if (count === 0) continue;
+      entries.push({ id: p.id, name: p.name ?? p.id, count });
     }
 
     const current = (await bridge?.getSurfaceModelInfo?.({
@@ -218,6 +299,7 @@ export function createDiscordModelWizard({ restCall, bridge }) {
       from: { id: user.id, username: user.username, firstName: user.global_name ?? null },
       providersById,
       favorites,
+      hiddenSet,
       entries,
       providerPage: 0,
       modelPage: 0,
@@ -280,18 +362,23 @@ export function createDiscordModelWizard({ restCall, bridge }) {
       wizard.providerName = '⭐ Favourites';
       // Favourite entries carry their full `provider/model` ref as the value so
       // a single menu can mix models from different providers.
-      models = wizard.favorites.map(({ providerID, modelID }) => ({
-        value: `${providerID}/${modelID}`,
-        label: modelID,
-        description: providerID,
-      }));
+      models = wizard.favorites.map(({ providerID, modelID }) => {
+        const model = findModel(wizard.providersById, providerID, modelID);
+        const meta = model ? formatModelMeta(model) : '';
+        return {
+          value: `${providerID}/${modelID}`,
+          label: modelID,
+          // Prefer context/pricing, fall back to the provider id for context.
+          description: meta || providerID,
+        };
+      });
     } else {
       const provider = wizard.providersById?.get(value);
       if (!provider) return;
       wizard.isFavorites = false;
       wizard.providerId = provider.id;
       wizard.providerName = provider.name ?? provider.id;
-      models = modelsOf(provider);
+      models = visibleModelsOf(provider, wizard.hiddenSet);
     }
 
     if (!models || models.length === 0) {

--- a/packages/web/server/lib/otto-api/discord-model-wizard.test.js
+++ b/packages/web/server/lib/otto-api/discord-model-wizard.test.js
@@ -2,9 +2,39 @@ import { describe, it, expect } from 'vitest';
 import {
   buildPagedOptions,
   modelsOf,
+  formatModelMeta,
   PAGE_SIZE,
   createDiscordModelWizard,
 } from './discord-model-wizard.js';
+
+describe('formatModelMeta', () => {
+  it('renders context window + input/output pricing', () => {
+    expect(
+      formatModelMeta({ limit: { context: 200000 }, cost: { input: 3, output: 15 } }),
+    ).toBe('200K ctx · in $3/out $15 /Mtok');
+  });
+
+  it('renders a compact millions context', () => {
+    expect(formatModelMeta({ limit: { context: 1000000 } })).toBe('1M ctx');
+    expect(formatModelMeta({ limit: { context: 1500000 } })).toBe('1.5M ctx');
+  });
+
+  it('shows context only when pricing is absent', () => {
+    expect(formatModelMeta({ limit: { context: 128000 } })).toBe('128K ctx');
+  });
+
+  it('handles fractional prices and only input cost', () => {
+    expect(formatModelMeta({ limit: { context: 8000 }, cost: { input: 0.15 } })).toBe(
+      '8K ctx · in $0.15 /Mtok',
+    );
+  });
+
+  it('never renders a date and returns empty when no metadata exists', () => {
+    expect(formatModelMeta({ release_date: '2024-01-01' })).toBe('');
+    expect(formatModelMeta({})).toBe('');
+    expect(formatModelMeta(null)).toBe('');
+  });
+});
 
 describe('buildPagedOptions', () => {
   const items = Array.from({ length: 60 }, (_, i) => ({
@@ -68,7 +98,7 @@ describe('modelsOf', () => {
 });
 
 /** A restCall recorder + a bridge stub. */
-function makeHarness(providers, { favorites = [], current = null, binding = null } = {}) {
+function makeHarness(providers, { favorites = [], hidden = [], current = null, binding = null } = {}) {
   const calls = [];
   const restCall = async (token, method, path, body) => {
     calls.push({ token, method, path, body });
@@ -81,6 +111,7 @@ function makeHarness(providers, { favorites = [], current = null, binding = null
   const bridge = {
     fetchProviders: async () => ({ all: providers, connected: providers.map((p) => p.id) }),
     getFavoriteModels: async () => favorites,
+    getHiddenModels: async () => hidden,
     getSurfaceModelInfo: async () => current,
     setSurfaceModel: (o) => setModels.push(o),
     setGlobalDefaultModel: async (o) => {
@@ -103,6 +134,10 @@ function makeHarness(providers, { favorites = [], current = null, binding = null
 function lastSelectValues(call) {
   const select = call.body?.data?.components?.[0]?.components?.[0];
   return select?.options?.map((o) => o.value) ?? [];
+}
+function lastSelectOptions(call) {
+  const select = call.body?.data?.components?.[0]?.components?.[0];
+  return select?.options ?? [];
 }
 function lastCustomId(call) {
   return call.body?.data?.components?.[0]?.components?.[0]?.custom_id;
@@ -231,5 +266,47 @@ describe('createDiscordModelWizard flow', () => {
     await wizard.handleComponent(state, { id: 'i5', token: 't5', data: {} }, buttonCustomId);
     expect(resends).toHaveLength(1);
     expect(resends[0]).toMatchObject({ type: 'discord', channelId: 'chan' });
+  });
+
+  it('hides models the UI hid and shows context/pricing in the description', async () => {
+    const richProviders = [
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        models: [
+          { id: 'sonnet', name: 'Sonnet', limit: { context: 200000 }, cost: { input: 3, output: 15 } },
+          { id: 'legacy', name: 'Legacy' },
+        ],
+      },
+    ];
+    const { wizard, calls } = makeHarness(richProviders, {
+      hidden: [{ providerID: 'anthropic', modelID: 'legacy' }],
+    });
+    await wizard.start(state, { id: 'i1', token: 't1', channel_id: 'chan', application_id: 'app' });
+    // Provider count reflects only visible models (1, not 2).
+    const provOpts = lastSelectOptions(calls.at(-1));
+    expect(provOpts[0].description).toContain('1 model');
+    const provCustomId = lastCustomId(calls.at(-1));
+
+    await wizard.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['anthropic'] } }, provCustomId);
+    const modelOpts = lastSelectOptions(calls.at(-1));
+    // The hidden model is gone; the visible one carries context + pricing.
+    expect(modelOpts.map((o) => o.value)).toEqual(['sonnet']);
+    expect(modelOpts[0].description).toBe('200K ctx · in $3/out $15 /Mtok');
+  });
+
+  it('drops a favourite that the UI hid', async () => {
+    const { wizard, calls } = makeHarness(providers, {
+      favorites: [
+        { providerID: 'anthropic', modelID: 'm5' },
+        { providerID: 'anthropic', modelID: 'm6' },
+      ],
+      hidden: [{ providerID: 'anthropic', modelID: 'm6' }],
+    });
+    await wizard.start(state, { id: 'i1', token: 't1', channel_id: 'chan', application_id: 'app' });
+    const provCustomId = lastCustomId(calls.at(-1));
+    await wizard.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['__otto_favorites'] } }, provCustomId);
+    // Only the non-hidden favourite survives.
+    expect(lastSelectValues(calls.at(-1))).toEqual(['anthropic/m5']);
   });
 });

--- a/packages/web/server/lib/otto-api/messenger-bridge-store.js
+++ b/packages/web/server/lib/otto-api/messenger-bridge-store.js
@@ -78,15 +78,17 @@ export class MessengerBridgeStore {
       CREATE INDEX IF NOT EXISTS idx_messenger_session_session
         ON messenger_session_bindings (session_id);
     `);
-    // Per-surface preferences (model + agent override + verbosity) so /model,
-    // /agent and /verbosity commands can scope a choice to a channel/topic
-    // without touching the global OpenChamber settings. ALTER TABLE is run as
-    // separate statements and ignored when the column already exists.
+    // Per-surface preferences (model + agent override + verbosity + permission
+    // mode) so /model, /agent, /verbosity and /yolo commands can scope a choice
+    // to a channel/topic without touching the global OpenChamber settings.
+    // ALTER TABLE is run as separate statements and ignored when the column
+    // already exists.
     for (const col of [
       'model_override TEXT',
       'agent_override TEXT',
       'verbosity_override TEXT',
       'variant_override TEXT',
+      'permission_mode TEXT',
     ]) {
       try {
         this.db.exec(`ALTER TABLE messenger_session_bindings ADD COLUMN ${col}`);
@@ -122,7 +124,7 @@ export class MessengerBridgeStore {
     `);
     // Migrate older project-default tables that predate the verbosity/variant
     // (thinking-effort) project scopes. Ignored when the column already exists.
-    for (const col of ['verbosity_default TEXT', 'variant_default TEXT']) {
+    for (const col of ['verbosity_default TEXT', 'variant_default TEXT', 'permission_mode_default TEXT']) {
       try {
         this.db.exec(`ALTER TABLE messenger_project_defaults ADD COLUMN ${col}`);
       } catch {
@@ -169,6 +171,21 @@ export class MessengerBridgeStore {
     this.setSetting(`verbosity:${type}`, level ?? null);
   }
 
+  /**
+   * Per-messenger default permission mode (`ask` | `auto-edit` | `yolo`) used
+   * when a surface/project has no explicit override. Returns `null` when never
+   * configured so the caller can fall back to its own default.
+   */
+  getPermissionModeDefault(type) {
+    if (!type) return null;
+    return this.getSetting(`permission-mode:${type}`);
+  }
+
+  setPermissionModeDefault(type, mode) {
+    if (!type) return;
+    this.setSetting(`permission-mode:${type}`, mode ?? null);
+  }
+
   /** Read the project-wide defaults for a working directory. */
   getProjectDefaults(projectPath) {
     if (!projectPath) return null;
@@ -177,6 +194,7 @@ export class MessengerBridgeStore {
         `SELECT project_path AS projectPath, project_label AS projectLabel,
                 model_default AS modelDefault, agent_default AS agentDefault,
                 verbosity_default AS verbosityDefault, variant_default AS variantDefault,
+                permission_mode_default AS permissionModeDefault,
                 updated_at AS updatedAt
            FROM messenger_project_defaults
           WHERE project_path = ?`,
@@ -190,7 +208,7 @@ export class MessengerBridgeStore {
    * `verbosityDefault: null` / `variantDefault: null` to clear that field; pass
    * `undefined` to leave it untouched.
    */
-  setProjectDefaults({ projectPath, projectLabel, modelDefault, agentDefault, verbosityDefault, variantDefault }) {
+  setProjectDefaults({ projectPath, projectLabel, modelDefault, agentDefault, verbosityDefault, variantDefault, permissionModeDefault }) {
     if (!projectPath) return;
     const now = new Date().toISOString();
     const existing = this.getProjectDefaults(projectPath);
@@ -199,22 +217,25 @@ export class MessengerBridgeStore {
     const nextVerbosity =
       verbosityDefault === undefined ? existing?.verbosityDefault ?? null : verbosityDefault;
     const nextVariant = variantDefault === undefined ? existing?.variantDefault ?? null : variantDefault;
+    const nextPermissionMode =
+      permissionModeDefault === undefined ? existing?.permissionModeDefault ?? null : permissionModeDefault;
     const nextLabel = projectLabel ?? existing?.projectLabel ?? null;
     this.db
       .prepare(
         `INSERT INTO messenger_project_defaults
             (project_path, project_label, model_default, agent_default,
-             verbosity_default, variant_default, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
+             verbosity_default, variant_default, permission_mode_default, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(project_path)
-         DO UPDATE SET project_label     = excluded.project_label,
-                       model_default     = excluded.model_default,
-                       agent_default     = excluded.agent_default,
-                       verbosity_default = excluded.verbosity_default,
-                       variant_default   = excluded.variant_default,
-                       updated_at        = excluded.updated_at`,
+         DO UPDATE SET project_label           = excluded.project_label,
+                       model_default           = excluded.model_default,
+                       agent_default           = excluded.agent_default,
+                       verbosity_default       = excluded.verbosity_default,
+                       variant_default         = excluded.variant_default,
+                       permission_mode_default = excluded.permission_mode_default,
+                       updated_at              = excluded.updated_at`,
       )
-      .run(projectPath, nextLabel, nextModel, nextAgent, nextVerbosity, nextVariant, now);
+      .run(projectPath, nextLabel, nextModel, nextAgent, nextVerbosity, nextVariant, nextPermissionMode, now);
   }
 
   /** List every project that has bridge defaults configured. */
@@ -224,6 +245,7 @@ export class MessengerBridgeStore {
         `SELECT project_path AS projectPath, project_label AS projectLabel,
                 model_default AS modelDefault, agent_default AS agentDefault,
                 verbosity_default AS verbosityDefault, variant_default AS variantDefault,
+                permission_mode_default AS permissionModeDefault,
                 updated_at AS updatedAt
            FROM messenger_project_defaults
           ORDER BY updated_at DESC`,
@@ -246,7 +268,8 @@ export class MessengerBridgeStore {
                 model_override AS modelOverride,
                 agent_override AS agentOverride,
                 verbosity_override AS verbosityOverride,
-                variant_override AS variantOverride
+                variant_override AS variantOverride,
+                permission_mode AS permissionModeOverride
            FROM messenger_session_bindings
           WHERE type = ? AND bot_token_hash = ? AND target_key = ?`,
       )
@@ -258,7 +281,7 @@ export class MessengerBridgeStore {
    * Update per-surface preferences without touching the session binding.
    * Used by /model and /agent in-chat commands.
    */
-  setOverrides({ type, botTokenHash, targetKey, modelOverride, agentOverride, verbosityOverride, variantOverride }) {
+  setOverrides({ type, botTokenHash, targetKey, modelOverride, agentOverride, verbosityOverride, variantOverride, permissionModeOverride }) {
     const sets = [];
     const params = [];
     if (modelOverride !== undefined) {
@@ -276,6 +299,10 @@ export class MessengerBridgeStore {
     if (variantOverride !== undefined) {
       sets.push('variant_override = ?');
       params.push(variantOverride ?? null);
+    }
+    if (permissionModeOverride !== undefined) {
+      sets.push('permission_mode = ?');
+      params.push(permissionModeOverride ?? null);
     }
     if (sets.length === 0) return;
     params.push(type, botTokenHash, targetKey);

--- a/packages/web/server/lib/otto-api/messenger-bridge-store.test.js
+++ b/packages/web/server/lib/otto-api/messenger-bridge-store.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { MessengerBridgeStore } from './messenger-bridge-store.js';
+
+describe('MessengerBridgeStore — permission mode persistence', () => {
+  let dbPath;
+  let store;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `otto-store-${crypto.randomBytes(6).toString('hex')}.sqlite`);
+    store = new MessengerBridgeStore({ dbPath });
+  });
+
+  afterEach(() => {
+    try {
+      store.db.close();
+    } catch {
+      // ignore
+    }
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(dbPath + suffix);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  const surface = { type: 'discord', botTokenHash: 'hash', targetKey: 'chan-1' };
+
+  it('round-trips a per-surface permission mode override', () => {
+    store.setOverrides({ ...surface, permissionModeOverride: 'yolo' });
+    expect(store.lookup(surface)?.permissionModeOverride).toBe('yolo');
+
+    store.setOverrides({ ...surface, permissionModeOverride: null });
+    expect(store.lookup(surface)?.permissionModeOverride).toBeNull();
+  });
+
+  it('does not clobber other overrides when only setting the permission mode', () => {
+    store.setOverrides({ ...surface, modelOverride: 'anthropic/sonnet', verbosityOverride: 'verbose' });
+    store.setOverrides({ ...surface, permissionModeOverride: 'auto-edit' });
+    const row = store.lookup(surface);
+    expect(row.modelOverride).toBe('anthropic/sonnet');
+    expect(row.verbosityOverride).toBe('verbose');
+    expect(row.permissionModeOverride).toBe('auto-edit');
+  });
+
+  it('round-trips the project-default permission mode', () => {
+    store.setProjectDefaults({ projectPath: '/proj', projectLabel: 'Proj', permissionModeDefault: 'yolo' });
+    expect(store.getProjectDefaults('/proj')?.permissionModeDefault).toBe('yolo');
+
+    // Setting an unrelated project default preserves the permission mode.
+    store.setProjectDefaults({ projectPath: '/proj', modelDefault: 'anthropic/sonnet' });
+    const pd = store.getProjectDefaults('/proj');
+    expect(pd.permissionModeDefault).toBe('yolo');
+    expect(pd.modelDefault).toBe('anthropic/sonnet');
+  });
+
+  it('round-trips the messenger-wide permission mode default', () => {
+    expect(store.getPermissionModeDefault('discord')).toBeNull();
+    store.setPermissionModeDefault('discord', 'auto-edit');
+    expect(store.getPermissionModeDefault('discord')).toBe('auto-edit');
+    store.setPermissionModeDefault('discord', null);
+    expect(store.getPermissionModeDefault('discord')).toBeNull();
+  });
+});

--- a/packages/web/server/lib/otto-api/messenger-commands.js
+++ b/packages/web/server/lib/otto-api/messenger-commands.js
@@ -31,6 +31,12 @@
 
 import crypto from 'node:crypto';
 import { parseVerbosityLevel, VERBOSITY_LEVELS } from './messenger-verbosity.js';
+import {
+  parsePermissionMode,
+  PERMISSION_MODES,
+  PERMISSION_MODE_DESCRIPTIONS,
+  PERMISSION_MODE_LABELS,
+} from './messenger-permissions.js';
 
 const VERBOSITY_DESCRIPTIONS = {
   quiet: 'final answer only — hides reasoning and tool activity',
@@ -94,6 +100,12 @@ const COMMAND_HELP = [
     usage: '/skill [name]',
     summary:
       'List the skills available to the agent / hand one to Otto for the next turn. On Discord, run `/skill` for a dropdown picker.',
+  },
+  {
+    name: 'yolo',
+    usage: '/yolo [ask | auto-edit | yolo | project <mode> | default <mode> | reset]',
+    summary:
+      'How Otto handles tool permissions: `ask` = Approve/Deny buttons, `auto-edit` = auto-approve edits/reads, `yolo` = auto-approve everything. On Discord, run `/yolo` for a dropdown. Stop any run with `/abort`.',
   },
   {
     name: 'sessions',
@@ -619,6 +631,98 @@ export async function executeMessengerCommand({
       await surfaceMutators.setOverrides({ verbosityOverride: level });
       return {
         reply: `✓ Verbosity set to \`${level}\` for this conversation — ${VERBOSITY_DESCRIPTIONS[level]}.`,
+      };
+    }
+
+    case 'yolo':
+    case 'permissions': {
+      const effective =
+        binding?.permissionModeOverride ??
+        binding?.projectDefaults?.permissionModeDefault ??
+        binding?.permissionModeDefault ??
+        'ask';
+      if (!command.args) {
+        const lines = [
+          '**Tool permission mode** — how Otto handles approval requests (shell, edits, …)',
+          '',
+        ];
+        for (const mode of PERMISSION_MODES) {
+          const marker = mode === effective ? '➤ ' : '· ';
+          lines.push(`${marker}\`${mode}\` — ${PERMISSION_MODE_DESCRIPTIONS[mode]}`);
+        }
+        lines.push('');
+        lines.push(
+          'Set with `/yolo yolo` (this conversation), `/yolo project yolo` (this project) or `/yolo default yolo` (every channel/chat on this bot). `/yolo reset` clears the conversation override. You can always stop a run with `/abort`.',
+        );
+        if (binding?.permissionModeOverride) {
+          lines.push('', `Conversation override: \`${binding.permissionModeOverride}\``);
+        }
+        if (binding?.projectDefaults?.permissionModeDefault) {
+          lines.push(`Project default: \`${binding.projectDefaults.permissionModeDefault}\``);
+        }
+        if (binding?.permissionModeDefault) {
+          lines.push(`Messenger default: \`${binding.permissionModeDefault}\``);
+        }
+        return { reply: lines.join('\n') };
+      }
+
+      const raw = command.args.trim();
+      const defaultMatch = raw.match(/^default\s+(.+)$/i);
+      if (defaultMatch) {
+        const value = defaultMatch[1].trim();
+        if (value === 'reset' || value === 'clear') {
+          await surfaceMutators.setPermissionModeDefault(null);
+          return { reply: '✓ Messenger default permission mode cleared — falling back to `ask`.' };
+        }
+        const mode = parsePermissionMode(value);
+        if (!mode) {
+          return { reply: `✗ Unknown mode. Use one of: ${PERMISSION_MODES.map((m) => `\`${m}\``).join(', ')}.` };
+        }
+        await surfaceMutators.setPermissionModeDefault(mode);
+        return {
+          reply: `✓ Messenger default permission mode set to \`${mode}\` (${PERMISSION_MODE_LABELS[mode]}).`,
+        };
+      }
+
+      const projectMatch = raw.match(/^project\s+(.+)$/i);
+      if (projectMatch) {
+        const value = projectMatch[1].trim();
+        if (!binding?.projectPath) {
+          return {
+            reply:
+              '✗ This conversation has no project bound yet. Send a regular message first before setting project defaults.',
+          };
+        }
+        if (value === 'reset' || value === 'clear') {
+          await surfaceMutators.setProjectDefaults({ permissionModeDefault: null });
+          return {
+            reply: `✓ Project default permission mode cleared for *${binding.projectLabel ?? binding.projectPath}*.`,
+          };
+        }
+        const mode = parsePermissionMode(value);
+        if (!mode) {
+          return { reply: `✗ Unknown mode. Use one of: ${PERMISSION_MODES.map((m) => `\`${m}\``).join(', ')}.` };
+        }
+        await surfaceMutators.setProjectDefaults({ permissionModeDefault: mode });
+        return {
+          reply: `✓ Project default permission mode set to \`${mode}\` for *${binding.projectLabel ?? binding.projectPath}* (${PERMISSION_MODE_LABELS[mode]}).`,
+        };
+      }
+
+      if (raw === 'reset' || raw === 'clear') {
+        await surfaceMutators.setOverrides({ permissionModeOverride: null });
+        return { reply: '✓ Conversation permission mode override cleared — falling back to the messenger default.' };
+      }
+
+      const mode = parsePermissionMode(raw);
+      if (!mode) {
+        return {
+          reply: `✗ Unknown mode. Use one of: ${PERMISSION_MODES.map((m) => `\`${m}\``).join(', ')}, or \`/yolo default <mode>\`.`,
+        };
+      }
+      await surfaceMutators.setOverrides({ permissionModeOverride: mode });
+      return {
+        reply: `✓ Permission mode set to \`${mode}\` for this conversation — ${PERMISSION_MODE_DESCRIPTIONS[mode]}.`,
       };
     }
 

--- a/packages/web/server/lib/otto-api/messenger-commands.test.js
+++ b/packages/web/server/lib/otto-api/messenger-commands.test.js
@@ -7,6 +7,7 @@ function makeMutators() {
   return {
     setOverrides: vi.fn(async () => {}),
     setVerbosityDefault: vi.fn(async () => {}),
+    setPermissionModeDefault: vi.fn(async () => {}),
     setProjectDefaults: vi.fn(async () => {}),
     unbindSession: vi.fn(async () => {}),
   };
@@ -148,10 +149,58 @@ describe('/model + /status surface the OpenChamber default model', () => {
 });
 
 describe('/help includes verbosity and skill', () => {
-  it('lists the /verbosity and /skill commands', async () => {
+  it('lists the /verbosity, /skill and /yolo commands', async () => {
     const { result } = await run('/help');
     expect(result.reply).toContain('/verbosity');
     expect(result.reply).toContain('/skill');
+    expect(result.reply).toContain('/yolo');
+  });
+});
+
+describe('/yolo (permission mode) command', () => {
+  it('lists the modes and marks the effective one with no args', async () => {
+    const { result, surfaceMutators } = await run('/yolo', {
+      binding: { permissionModeDefault: 'auto-edit' },
+    });
+    expect(result.reply).toContain('Tool permission mode');
+    expect(result.reply).toContain('yolo');
+    expect(result.reply).toContain('➤ `auto-edit`');
+    expect(surfaceMutators.setOverrides).not.toHaveBeenCalled();
+  });
+
+  it('sets a conversation override', async () => {
+    const { surfaceMutators } = await run('/yolo yolo');
+    expect(surfaceMutators.setOverrides).toHaveBeenCalledWith({ permissionModeOverride: 'yolo' });
+  });
+
+  it('accepts aliases', async () => {
+    const a = await run('/yolo safe');
+    expect(a.surfaceMutators.setOverrides).toHaveBeenCalledWith({ permissionModeOverride: 'auto-edit' });
+    const b = await run('/yolo on');
+    expect(b.surfaceMutators.setOverrides).toHaveBeenCalledWith({ permissionModeOverride: 'yolo' });
+  });
+
+  it('sets the messenger default via `default`', async () => {
+    const { surfaceMutators } = await run('/yolo default yolo');
+    expect(surfaceMutators.setPermissionModeDefault).toHaveBeenCalledWith('yolo');
+  });
+
+  it('sets a project default via `project` when bound', async () => {
+    const { surfaceMutators } = await run('/yolo project yolo', {
+      binding: { projectPath: '/proj', projectLabel: 'Proj' },
+    });
+    expect(surfaceMutators.setProjectDefaults).toHaveBeenCalledWith({ permissionModeDefault: 'yolo' });
+  });
+
+  it('clears the conversation override via reset', async () => {
+    const { surfaceMutators } = await run('/yolo reset');
+    expect(surfaceMutators.setOverrides).toHaveBeenCalledWith({ permissionModeOverride: null });
+  });
+
+  it('rejects unknown modes without mutating', async () => {
+    const { result, surfaceMutators } = await run('/yolo maybe');
+    expect(result.reply).toMatch(/Unknown mode/);
+    expect(surfaceMutators.setOverrides).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/server/lib/otto-api/messenger-opencode-bridge.js
+++ b/packages/web/server/lib/otto-api/messenger-opencode-bridge.js
@@ -5,6 +5,12 @@ import { MessengerBridgeStore } from './messenger-bridge-store.js';
 import { executeMessengerCommand, parseLeadingCommand, isKnownMessengerCommand } from './messenger-commands.js';
 import { DEFAULT_VERBOSITY, normalizeVerbosity } from './messenger-verbosity.js';
 import {
+  DEFAULT_PERMISSION_MODE,
+  PERMISSION_MODE_LABELS,
+  normalizePermissionMode,
+  shouldAutoApprove,
+} from './messenger-permissions.js';
+import {
   renderPartForMessenger,
   renderPermissionContext,
   renderQuestionForMessenger,
@@ -150,6 +156,20 @@ function formatSessionError(raw) {
   // Otherwise keep the first line and drop any stack-trace tail.
   const firstLine = msg.split('\n')[0].trim();
   return firstLine || 'OpenCode session error';
+}
+
+/**
+ * Heuristic: does an error text look like the transient teardown of a turn that
+ * was just aborted/superseded (rather than a genuine, actionable failure)?
+ * These are the exact symptoms users hit when they interrupt a turn or switch
+ * model mid-stream — the aborted turn's connection collapses and OpenCode
+ * reports a stream/provider error for work that was intentionally cancelled.
+ */
+function isTransientTurnError(text) {
+  if (typeof text !== 'string' || !text) return false;
+  return /aborted|abort|cancel|stream(ing)?\s+response\s+failed|provider\s+not\s+available|connection\s+(closed|reset|refused)|fetch failed|network|ECONNRESET|socket hang up|terminated/i.test(
+    text,
+  );
 }
 
 function pickProjectForName(projects, name) {
@@ -644,6 +664,12 @@ export function createMessengerOpencodeBridge({
   /** @type {Map<string, () => Promise<unknown>>} */
   const pendingSupersede = new Map();
   const SUPERSEDE_FALLBACK_MS = 8000;
+  // After a turn is superseded, OpenCode may emit a trailing abort `session.error`
+  // (e.g. "streaming response failed" / "provider not available") for the turn we
+  // just cancelled. If it lands AFTER the stashed send already fired (so it's no
+  // longer in `pendingSupersede`), suppress it within this grace window instead of
+  // surfacing the teardown of a turn the user intentionally interrupted.
+  const SUPERSEDE_ERROR_GRACE_MS = 6000;
 
   /** Run (and clear) a stashed superseding send for a session, if any. */
   function runSupersede(sessionId, ctx) {
@@ -653,6 +679,13 @@ export function createMessengerOpencodeBridge({
     if (ctx) {
       ctx.sentPartIds.clear();
       ctx.startedAt = Date.now();
+      // The resumed turn is now the active one — clear stale error/idle flags,
+      // remember when we superseded (grace window for the aborted turn's late
+      // error), and re-arm the typing pulse so the bot never looks unresponsive.
+      ctx.errored = false;
+      ctx.idleSettled = false;
+      ctx.supersededAt = Date.now();
+      startTypingPulse(ctx);
     }
     busySessions.delete(sessionId);
     void resume();
@@ -2020,6 +2053,40 @@ export function createMessengerOpencodeBridge({
     return normalizeVerbosity(level ?? DEFAULT_VERBOSITY);
   }
 
+  /**
+   * Resolve the effective permission mode for a surface (`ask` | `auto-edit` |
+   * `yolo`). Mirrors {@link resolveVerbosity}'s resolution order: surface
+   * override (`/yolo`) → parent-channel override → per-project default →
+   * per-messenger default → `ask`. Read fresh at each `permission.asked` event
+   * so a `/yolo` change applies without a restart.
+   */
+  function resolvePermissionMode({ type, token, channelId, threadId }) {
+    const hash = tokenHash(token);
+    const stableKey = targetKey({ type, channelId, threadId });
+    let mode = null;
+    try {
+      const row = bridgeStore.lookup({ type, botTokenHash: hash, targetKey: stableKey });
+      let projectPath = row?.projectPath ?? null;
+      mode = row?.permissionModeOverride ?? null;
+      if (!mode && stableKey !== String(channelId)) {
+        const parent = bridgeStore.lookup({
+          type,
+          botTokenHash: hash,
+          targetKey: String(channelId),
+        });
+        mode = parent?.permissionModeOverride ?? null;
+        if (!projectPath) projectPath = parent?.projectPath ?? null;
+      }
+      if (!mode && projectPath) {
+        mode = bridgeStore.getProjectDefaults?.(projectPath)?.permissionModeDefault ?? null;
+      }
+      if (!mode) mode = bridgeStore.getPermissionModeDefault?.(type) ?? null;
+    } catch {
+      // ignore — best-effort, fall back to the safe default (ask)
+    }
+    return normalizePermissionMode(mode ?? DEFAULT_PERMISSION_MODE);
+  }
+
   // --- Outbound: post one message per renderable part --------------------
   async function postToSurface(ctx, content) {
     return postMessengerSurface(ctx, content);
@@ -2580,13 +2647,25 @@ export function createMessengerOpencodeBridge({
         if (defaultCtx) await handleGlobalEvent(normalized);
         return;
       }
+      const errText = formatSessionError(props?.error);
+      const now = Date.now();
+      // A turn superseded moments ago can emit a trailing abort error for the
+      // cancelled work while the replacement turn is already streaming. Don't
+      // surface that teardown as a fault, and keep the typing pulse (the new
+      // turn owns the surface now).
+      if (
+        ctx.supersededAt &&
+        now - ctx.supersededAt < SUPERSEDE_ERROR_GRACE_MS &&
+        isTransientTurnError(errText)
+      ) {
+        ctx.sentPartIds.clear();
+        return;
+      }
       stopTypingPulse(ctx);
       // Mark the turn as errored so the trailing session.idle doesn't tack on a
       // misleading "done · …" footer. The flag clears when the next turn starts
       // producing output (see emitPart) or a new prompt is sent.
       ctx.errored = true;
-      const errText = formatSessionError(props?.error);
-      const now = Date.now();
       // OpenCode emits one session.error per failed write (message + each part),
       // so the same fault can arrive several times in a row. Collapse repeats so
       // the surface isn't spammed with three identical lines.
@@ -2677,6 +2756,37 @@ export function createMessengerOpencodeBridge({
       }
 
       console.log('[PERMISSION]', `session=${sessionId} tool=${permission.permission} dir=${replyDirectory ?? 'none'} patterns=${permission.patterns.join(',')}`);
+
+      // Permission mode (`/yolo`) — pre-decide approvals so the user isn't
+      // prompted for every tool. Enforced here in core logic (not only in the
+      // button UI) so it applies across every surface and execution path.
+      const permissionMode = resolvePermissionMode({
+        type: ctx.type,
+        token: ctx.token,
+        channelId: ctx.channelId,
+        threadId: ctx.threadId,
+      });
+      if (permissionMode !== 'ask' && shouldAutoApprove(permissionMode, permission.permission)) {
+        if (typeof _respondToOpenCode === 'function' && permission.id) {
+          _respondToOpenCode({
+            sessionID: sessionId,
+            requestID: permission.id,
+            reply: 'once',
+            directory: replyDirectory,
+          }).catch((err) =>
+            console.error('[PERMISSION] auto-approve reply failed:', err?.message ?? err),
+          );
+        }
+        // The turn keeps running after an auto-approval — re-arm the typing
+        // pulse that this handler stopped so the bot doesn't look idle.
+        if (startTypingPulse) startTypingPulse(ctx);
+        const label = PERMISSION_MODE_LABELS[permissionMode] ?? permissionMode;
+        void postToSurface(
+          ctx,
+          `⚡ _Auto-approved (${escapeMd(label)}): \`${escapeMd(String(permission.permission))}\`_`,
+        );
+        return;
+      }
 
       sendApprovalToSurface({
         type: ctx.type,
@@ -3452,6 +3562,8 @@ export function createMessengerOpencodeBridge({
         variantOverride: stored?.variantOverride ?? null,
         verbosityOverride: stored?.verbosityOverride ?? null,
         verbosityDefault: bridgeStore.getVerbosityDefault?.(type) ?? null,
+        permissionModeOverride: stored?.permissionModeOverride ?? null,
+        permissionModeDefault: bridgeStore.getPermissionModeDefault?.(type) ?? null,
         projectDefaults,
         globalDefaultModel: globals.model,
         globalDefaultAgent: globals.agent,
@@ -3459,9 +3571,16 @@ export function createMessengerOpencodeBridge({
       surfaceMutators: {
         async setOverrides(changes) {
           bridgeStore.setOverrides({ type, botTokenHash: hash, targetKey: stableKey, ...changes });
+          if (changes.verbosityOverride !== undefined) {
+            applyPreferencesToActiveTurn({ type, token, channelId, threadId });
+          }
         },
         async setVerbosityDefault(level) {
           bridgeStore.setVerbosityDefault(type, level);
+          applyPreferencesToActiveTurn({ type, token, channelId, threadId });
+        },
+        async setPermissionModeDefault(mode) {
+          bridgeStore.setPermissionModeDefault(type, mode);
         },
         async unbindSession() {
           bridgeStore.unbindSession({ type, botTokenHash: hash, targetKey: stableKey });
@@ -3473,6 +3592,9 @@ export function createMessengerOpencodeBridge({
             projectLabel: stored.projectLabel,
             ...changes,
           });
+          if (changes.verbosityDefault !== undefined) {
+            applyPreferencesToActiveTurn({ type, token, channelId, threadId });
+          }
         },
       },
       bridgeOps,
@@ -4368,6 +4490,34 @@ export function createMessengerOpencodeBridge({
   }
 
   /**
+   * The user's UI hidden models (Settings → Providers → hide model). Read from
+   * the SAME `settings.json` the web UI persists to, so the Discord `/model`
+   * wizard hides exactly what the UI hides instead of listing every model the
+   * provider exposes. Returns an array of `{ providerID, modelID }`.
+   */
+  async function getHiddenModels() {
+    if (typeof readSettings !== 'function') return [];
+    try {
+      const settings = await readSettings();
+      const list = Array.isArray(settings?.hiddenModels) ? settings.hiddenModels : [];
+      const out = [];
+      const seen = new Set();
+      for (const m of list) {
+        const providerID = typeof m?.providerID === 'string' ? m.providerID.trim() : '';
+        const modelID = typeof m?.modelID === 'string' ? m.modelID.trim() : '';
+        if (!providerID || !modelID) continue;
+        const key = `${providerID}/${modelID}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push({ providerID, modelID });
+      }
+      return out;
+    } catch {
+      return [];
+    }
+  }
+
+  /**
    * Resolve the effective model + thinking-effort (variant) for a surface, the
    * same way {@link routeInbound} does, so the `/model` wizard can show what's
    * currently in effect before the user changes it.
@@ -4526,6 +4676,41 @@ export function createMessengerOpencodeBridge({
    * last message" button). Goes through {@link routeInbound} so the new model /
    * effort apply and any in-flight turn is superseded.
    */
+  /**
+   * Apply a just-changed preference (verbosity, permission mode) to the turn
+   * that is streaming RIGHT NOW on a surface, instead of only the next one.
+   *
+   * `emitPart` already re-resolves verbosity live per part, but a mid-turn
+   * increase (e.g. `normal` → `verbose`) is otherwise held back by the
+   * one-shot thinking-marker dedup. Refreshing `ctx.verbosity` and clearing
+   * `lastPostedMarker` lets the remainder of the active turn render at the new
+   * level immediately. Best-effort and a no-op when nothing is streaming.
+   */
+  function applyPreferencesToActiveTurn({ type, token, channelId, threadId = null }) {
+    try {
+      const hash = tokenHash(token);
+      const stableKey = targetKey({ type, channelId, threadId });
+      let sessionId = bridgeStore.lookup({ type, botTokenHash: hash, targetKey: stableKey })?.sessionId || null;
+      if (!sessionId && stableKey !== String(channelId)) {
+        sessionId = bridgeStore.lookup({ type, botTokenHash: hash, targetKey: String(channelId) })?.sessionId || null;
+      }
+      if (!sessionId) return;
+      const ctx = sessionContexts.get(sessionId);
+      if (!ctx) return;
+      ctx.verbosity = resolveVerbosity({
+        type: ctx.type,
+        token: ctx.token,
+        channelId: ctx.channelId,
+        threadId: ctx.threadId,
+      });
+      // Let a mid-turn verbosity increase re-post the thinking marker / expand
+      // reasoning on the rest of the current turn.
+      ctx.lastPostedMarker = null;
+    } catch {
+      // best-effort — preferences still apply on the next part / turn
+    }
+  }
+
   async function resendLastMessage({ type, token, channelId, threadId = null, from = null }) {
     const key = lastPromptKey({ type, token, channelId, threadId });
     const text = lastPromptBySurface.get(key) ?? null;
@@ -4548,6 +4733,8 @@ export function createMessengerOpencodeBridge({
     setSurfaceModel,
     setGlobalDefaultModel,
     resendLastMessage,
+    applyPreferencesToActiveTurn,
+    getHiddenModels,
     statusSnapshot,
     isEnabled,
     ensureSubscribed,

--- a/packages/web/server/lib/otto-api/messenger-opencode-bridge.test.js
+++ b/packages/web/server/lib/otto-api/messenger-opencode-bridge.test.js
@@ -135,6 +135,96 @@ describe('approval flow — reply directory', () => {
   });
 });
 
+describe('permission mode (/yolo) auto-approve', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'discord-msg-1' }),
+      text: async () => '',
+    }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function makeBridgeWithMode(mode) {
+    return makeBridge({
+      store: {
+        ...makeFakeStore(),
+        lookup: () => (mode ? { permissionModeOverride: mode } : null),
+        getPermissionModeDefault: () => null,
+      },
+    });
+  }
+
+  async function askPermission(bridge, permissionName) {
+    bridge._handleGlobalEvent({
+      directory: '/envelope/project',
+      payload: {
+        type: 'permission.asked',
+        properties: {
+          id: 'req-1',
+          sessionID: 'ses-1',
+          permission: permissionName,
+          patterns: [],
+          always: [],
+          metadata: {},
+        },
+      },
+    });
+    await flush();
+  }
+
+  it('yolo mode auto-approves without posting buttons', async () => {
+    const bridge = makeBridgeWithMode('yolo');
+    const respond = vi.fn(async () => {});
+    bridge.initApprovalListener(respond);
+
+    await askPermission(bridge, 'bash');
+
+    // No interactive approval message was tracked (auto-approved instead).
+    expect([...bridge.approvalContexts.keys()]).toHaveLength(0);
+    expect(respond).toHaveBeenCalledWith({
+      sessionID: 'ses-1',
+      requestID: 'req-1',
+      reply: 'once',
+      directory: '/envelope/project',
+    });
+  });
+
+  it('auto-edit mode auto-approves edits but still prompts for shell', async () => {
+    const respond1 = vi.fn(async () => {});
+    const editBridge = makeBridgeWithMode('auto-edit');
+    editBridge.initApprovalListener(respond1);
+    await askPermission(editBridge, 'edit');
+    expect(respond1).toHaveBeenCalledWith(expect.objectContaining({ reply: 'once' }));
+    expect([...editBridge.approvalContexts.keys()]).toHaveLength(0);
+
+    const respond2 = vi.fn(async () => {});
+    const shellBridge = makeBridgeWithMode('auto-edit');
+    shellBridge.initApprovalListener(respond2);
+    await askPermission(shellBridge, 'bash');
+    // Shell still requires an explicit decision → an approval message is posted.
+    expect(respond2).not.toHaveBeenCalled();
+    expect([...shellBridge.approvalContexts.keys()]).toHaveLength(1);
+  });
+
+  it('ask mode (default) always posts buttons', async () => {
+    const bridge = makeBridgeWithMode(null);
+    const respond = vi.fn(async () => {});
+    bridge.initApprovalListener(respond);
+    await askPermission(bridge, 'edit');
+    expect(respond).not.toHaveBeenCalled();
+    expect([...bridge.approvalContexts.keys()]).toHaveLength(1);
+  });
+});
+
 describe('discord project sync persistence', () => {
   let originalFetch;
 
@@ -1709,6 +1799,89 @@ describe('plain message supersedes an in-flight turn', () => {
     const sentBodies = promptCalls().map((c) => JSON.parse(c.body).parts[0].text);
     expect(sentBodies).toContain('second');
     expect(promptCalls()).toHaveLength(2);
+  });
+
+  it('suppresses a trailing abort error from the superseded turn (no false failure)', async () => {
+    const calls = [];
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      calls.push({ url: String(url), method: init.method ?? 'GET', body: init.body });
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '' };
+    });
+
+    const bridge = makeBridge({
+      store: {
+        ...makeFakeStore(),
+        lookup: ({ targetKey }) =>
+          targetKey === 'chan-sup2'
+            ? { sessionId: 'ses-sup2', projectPath: '/p', projectLabel: 'P' }
+            : null,
+      },
+    });
+
+    await bridge.routeInbound({
+      type: 'discord', token: 'bot-token', channelId: 'chan-sup2', threadId: null, text: 'first',
+    });
+    await bridge.routeInbound({
+      type: 'discord', token: 'bot-token', channelId: 'chan-sup2', threadId: null, text: 'second',
+    });
+
+    // The aborted turn settles via idle → the deferred prompt fires and the
+    // session is marked recently-superseded.
+    await bridge._handleGlobalEvent({
+      directory: '/p',
+      payload: { type: 'session.idle', properties: { sessionID: 'ses-sup2' } },
+    });
+    await flush();
+
+    // A LATE abort error arrives for the cancelled turn (after supersede cleared).
+    await bridge._handleGlobalEvent({
+      directory: '/p',
+      payload: {
+        type: 'session.error',
+        properties: { sessionID: 'ses-sup2', error: { data: { message: 'streaming response failed' } } },
+      },
+    });
+    await flush();
+
+    const errorLines = calls
+      .filter((c) => c.method === 'POST' && c.url.includes('/channels/chan-sup2/messages'))
+      .map((c) => JSON.parse(c.body).content)
+      .filter((p) => p.startsWith('✗'));
+    expect(errorLines).toHaveLength(0); // the abort teardown is not surfaced as a fault
+  });
+
+  it('still surfaces a genuine error once the supersede grace window passes', async () => {
+    const calls = [];
+    globalThis.fetch = vi.fn(async (url, init = {}) => {
+      calls.push({ url: String(url), method: init.method ?? 'GET', body: init.body });
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '' };
+    });
+    const bridge = makeBridge({
+      store: {
+        ...makeFakeStore(),
+        lookup: ({ targetKey }) =>
+          targetKey === 'chan-sup3' ? { sessionId: 'ses-sup3', projectPath: '/p' } : null,
+      },
+    });
+
+    await bridge.routeInbound({
+      type: 'discord', token: 'bot-token', channelId: 'chan-sup3', threadId: null, text: 'go',
+    });
+    // A genuine, non-transient error (not an abort teardown) is always shown.
+    await bridge._handleGlobalEvent({
+      directory: '/p',
+      payload: {
+        type: 'session.error',
+        properties: { sessionID: 'ses-sup3', error: { data: { message: 'Model returned an invalid tool call' } } },
+      },
+    });
+    await flush();
+
+    const errorLines = calls
+      .filter((c) => c.method === 'POST' && c.url.includes('/channels/chan-sup3/messages'))
+      .map((c) => JSON.parse(c.body).content)
+      .filter((p) => p.startsWith('✗'));
+    expect(errorLines).toHaveLength(1);
   });
 });
 

--- a/packages/web/server/lib/otto-api/messenger-permissions.js
+++ b/packages/web/server/lib/otto-api/messenger-permissions.js
@@ -1,0 +1,105 @@
+/**
+ * Shared permission-mode model for the Discord ↔ OpenCode bridge.
+ *
+ * OpenCode asks for approval before it runs certain tools (shell commands,
+ * file edits/writes, web fetches, …). By default the bridge forwards every
+ * request to Discord as an Approve / Always / Deny button set. The
+ * permission mode lets a user pre-decide how those requests are handled for
+ * a conversation, project, or the whole bot — the "yolo" affordance:
+ *
+ *   - `ask`       — always prompt with buttons (the default, safest).
+ *   - `auto-edit` — auto-approve low-risk edit/read tools (edit, write, patch,
+ *                   read, list, grep, glob, webfetch); still prompt for shell
+ *                   commands and anything unrecognised.
+ *   - `yolo`      — auto-approve everything. Nothing is prompted; the user can
+ *                   still stop the run with `/abort`.
+ *
+ * Both the `/yolo` Discord command (dropdown wizard + text form) and the
+ * bridge's `permission.asked` handler read the SAME resolved value, so the
+ * policy is enforced in core logic and never only in the UI.
+ */
+
+export const PERMISSION_MODES = ['ask', 'auto-edit', 'yolo'];
+
+export const DEFAULT_PERMISSION_MODE = 'ask';
+
+export const PERMISSION_MODE_DESCRIPTIONS = {
+  ask: 'Ask every time — Approve / Deny buttons for each tool (default)',
+  'auto-edit': 'Auto-approve file edits + reads; still ask before running shell commands',
+  yolo: 'Auto-approve everything — no prompts (stop a run with /abort)',
+};
+
+/** Short labels for confirmations / status lines. */
+export const PERMISSION_MODE_LABELS = {
+  ask: 'Ask every time',
+  'auto-edit': 'Auto-approve edits',
+  yolo: 'YOLO — auto-approve all',
+};
+
+const PERMISSION_ALIASES = new Map([
+  ['ask', 'ask'],
+  ['default', 'ask'],
+  ['manual', 'ask'],
+  ['prompt', 'ask'],
+  ['confirm', 'ask'],
+  ['off', 'ask'],
+  ['auto-edit', 'auto-edit'],
+  ['autoedit', 'auto-edit'],
+  ['auto', 'auto-edit'],
+  ['edits', 'auto-edit'],
+  ['edit', 'auto-edit'],
+  ['safe', 'auto-edit'],
+  ['yolo', 'yolo'],
+  ['auto-all', 'yolo'],
+  ['autoall', 'yolo'],
+  ['all', 'yolo'],
+  ['full', 'yolo'],
+  ['on', 'yolo'],
+]);
+
+/**
+ * Tools auto-approved under `auto-edit`. Kept conservative: read/edit style
+ * tools that mutate or read files inside the workspace, plus web fetches.
+ * Shell commands (`bash`) and anything not listed here still prompt.
+ */
+const AUTO_EDIT_TOOLS = new Set([
+  'edit',
+  'write',
+  'patch',
+  'read',
+  'list',
+  'ls',
+  'glob',
+  'grep',
+  'search',
+  'webfetch',
+  'fetch',
+]);
+
+/**
+ * Map free-text input (from `/yolo <mode>` or a wizard value) to a canonical
+ * mode. Returns `null` for unrecognised input so callers can show an error.
+ */
+export function parsePermissionMode(input) {
+  if (typeof input !== 'string') return null;
+  const normalized = input.trim().toLowerCase();
+  if (!normalized) return null;
+  return PERMISSION_ALIASES.get(normalized) ?? null;
+}
+
+/** Coerce any value to a valid mode, falling back to `ask`. */
+export function normalizePermissionMode(value) {
+  return PERMISSION_MODES.includes(value) ? value : DEFAULT_PERMISSION_MODE;
+}
+
+/**
+ * Whether a permission request for `toolName` should be auto-approved under
+ * `mode`. `ask` never auto-approves; `yolo` always does; `auto-edit` only
+ * auto-approves the low-risk edit/read tool set above.
+ */
+export function shouldAutoApprove(mode, toolName) {
+  const m = normalizePermissionMode(mode);
+  if (m === 'yolo') return true;
+  if (m === 'auto-edit') return AUTO_EDIT_TOOLS.has(String(toolName ?? '').trim().toLowerCase());
+  return false;
+}

--- a/packages/web/server/lib/otto-api/messenger-permissions.test.js
+++ b/packages/web/server/lib/otto-api/messenger-permissions.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PERMISSION_MODES,
+  DEFAULT_PERMISSION_MODE,
+  parsePermissionMode,
+  normalizePermissionMode,
+  shouldAutoApprove,
+} from './messenger-permissions.js';
+
+describe('parsePermissionMode', () => {
+  it('maps canonical values to themselves', () => {
+    for (const mode of PERMISSION_MODES) {
+      expect(parsePermissionMode(mode)).toBe(mode);
+    }
+  });
+
+  it('maps aliases to canonical modes', () => {
+    expect(parsePermissionMode('ASK')).toBe('ask');
+    expect(parsePermissionMode('manual')).toBe('ask');
+    expect(parsePermissionMode('off')).toBe('ask');
+    expect(parsePermissionMode('safe')).toBe('auto-edit');
+    expect(parsePermissionMode('edits')).toBe('auto-edit');
+    expect(parsePermissionMode('auto')).toBe('auto-edit');
+    expect(parsePermissionMode('YOLO')).toBe('yolo');
+    expect(parsePermissionMode('all')).toBe('yolo');
+    expect(parsePermissionMode('on')).toBe('yolo');
+  });
+
+  it('returns null for unknown / empty input', () => {
+    expect(parsePermissionMode('nonsense')).toBeNull();
+    expect(parsePermissionMode('')).toBeNull();
+    expect(parsePermissionMode('   ')).toBeNull();
+    expect(parsePermissionMode(null)).toBeNull();
+    expect(parsePermissionMode(42)).toBeNull();
+  });
+});
+
+describe('normalizePermissionMode', () => {
+  it('passes through valid modes and defaults the rest', () => {
+    expect(normalizePermissionMode('yolo')).toBe('yolo');
+    expect(normalizePermissionMode('auto-edit')).toBe('auto-edit');
+    expect(normalizePermissionMode('bogus')).toBe(DEFAULT_PERMISSION_MODE);
+    expect(normalizePermissionMode(undefined)).toBe('ask');
+  });
+});
+
+describe('shouldAutoApprove', () => {
+  it('never auto-approves in ask mode', () => {
+    expect(shouldAutoApprove('ask', 'edit')).toBe(false);
+    expect(shouldAutoApprove('ask', 'bash')).toBe(false);
+  });
+
+  it('auto-approves everything in yolo mode', () => {
+    expect(shouldAutoApprove('yolo', 'bash')).toBe(true);
+    expect(shouldAutoApprove('yolo', 'edit')).toBe(true);
+    expect(shouldAutoApprove('yolo', 'anything-else')).toBe(true);
+  });
+
+  it('auto-approves only low-risk tools in auto-edit mode', () => {
+    expect(shouldAutoApprove('auto-edit', 'edit')).toBe(true);
+    expect(shouldAutoApprove('auto-edit', 'write')).toBe(true);
+    expect(shouldAutoApprove('auto-edit', 'read')).toBe(true);
+    expect(shouldAutoApprove('auto-edit', 'webfetch')).toBe(true);
+    // Shell / unknown tools still require an explicit approval.
+    expect(shouldAutoApprove('auto-edit', 'bash')).toBe(false);
+    expect(shouldAutoApprove('auto-edit', 'unknown-tool')).toBe(false);
+  });
+
+  it('is case-insensitive on the tool name', () => {
+    expect(shouldAutoApprove('auto-edit', 'EDIT')).toBe(true);
+    expect(shouldAutoApprove('auto-edit', 'Bash')).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses four reported issues with the Discord (Otto) bot integration in `packages/web/server/lib/otto-api/`.

### 1. Command review + `/yolo` permissions (dropdown "stop-down" choice)
- **Fixed `/shell` native slash command**: it was registered but missing from `KNOWN_SLASH_COMMANDS`, so `/shell` showed "application did not respond". Now dispatched.
- **New `/yolo` command** (dropdown wizard + text parity form) to set the tool **permission mode** so you don't get prompted for every action:
  - `ask` (default) — Approve/Deny buttons per tool
  - `auto-edit` — auto-approve file edits/reads, still ask before shell commands
  - `yolo` — auto-approve everything (you can always stop a run with `/abort`)
- Scoped to **this conversation / this project / whole system**, mirroring the `/model` and `/verbosity` wizards. Enforced in the bridge's `permission.asked` handler (core logic, not just the UI): when a mode auto-approves, it replies to OpenCode directly and posts a subtle `⚡ Auto-approved` note instead of buttons, and re-arms the typing pulse.

### 2. `/model` dropdown shows context window + prices
- The model select `description` showed a confusing bare `release_date` (`new Date(...).toLocaleDateString()`). It now shows **context window + input/output pricing** (e.g. `200K ctx · in $3/out $15 /Mtok`) via `formatModelMeta`, reusing the web UI's convention. Favourites rows are enriched too.

### 3. Verbosity applied immediately
- Changing verbosity now refreshes the **in-flight turn** (`applyPreferencesToActiveTurn`) — re-resolves the level and clears the one-shot thinking marker so the rest of the current turn renders at the new level, not just the next message. Wired into both the `/verbosity` wizard and the text command.

### 4. Interrupt robustness + UI/Discord model sync
- **Typing indicator**: `runSupersede` now restarts the typing pulse so the bot never looks unresponsive after you interrupt/switch model mid-stream.
- **"streaming response failed" / "provider not available"**: a superseded turn's trailing transient/abort error is now suppressed within a short grace window (`isTransientTurnError`) instead of being surfaced as a fault. Genuine errors still show.
- **Favourites & hidden models now match the UI**: the `/model` wizard reads the same `settings.json` `hiddenModels` the UI persists (`getHiddenModels`) and filters them out per-provider; favourites are filtered to models that still exist on a live provider and aren't hidden. Providers with no visible models are dropped.

New shared module `messenger-permissions.js`; permission mode persisted in `messenger-bridge-store` (surface override, project default, messenger-wide default) mirroring verbosity.

## Testing
- ✅ `bun run test -- otto-api` — **282 passed** (13 files), including new coverage for the permissions module, store persistence, the `/yolo` wizard + text command, `formatModelMeta`, hidden-model filtering, permission-mode auto-approve, and supersede error suppression.
- ✅ `eslint` on all changed server + test files — clean.
- ⚠️ `bun run test` (full web suite) — 5–7 `server/lib/git/service.test.js` tests time out; these are pre-existing sandbox git-timeout flakes unrelated to this change (no git code touched).
- ⚠️ `tsc --noEmit` (web) — only a pre-existing, unrelated i18n error in `packages/ui/src/lib/i18n/messages/ja.ts` (missing `settings.page.integrations.title` key); untouched by this change.

Manual GUI testing isn't feasible for this change (requires a live Discord bot token + OpenCode server, not available in the sandbox). The suite drives the real bridge/wizard/store code end-to-end in-memory.

[otto_api_tests.log](https://cursor.com/agents/bc-a7dcf1ea-fd1c-41e5-acd6-89f938e45abb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fotto_api_tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7dcf1ea-fd1c-41e5-acd6-89f938e45abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7dcf1ea-fd1c-41e5-acd6-89f938e45abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

