### PR TITLE
feat(mobile): swipe to open/close session drawer + swipe up for recents

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -38,6 +38,7 @@ import { MobileAgentButton } from './MobileAgentButton';
 import { MobileModelButton } from './MobileModelButton';
 import { MobileSessionStatusBar, MobileSessionPanelTrigger } from './MobileSessionStatusBar';
 import { useCurrentSessionActivity } from '@/hooks/useSessionActivity';
+import { useSwipeUpToOpen } from '@/hooks/useSwipeUpToOpen';
 import { toast } from '@/components/ui';
 import { Button } from '@/components/ui/button';
 // useMessageStore removed — messages now come from sync system
@@ -1068,6 +1069,9 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
     const isExpandedInput = useUIStore((state) => state.isExpandedInput);
     const setExpandedInput = useUIStore((state) => state.setExpandedInput);
     const setTimelineDialogOpen = useUIStore((state) => state.setTimelineDialogOpen);
+    const setMobileSessionPanelOpen = useUIStore((state) => state.setMobileSessionPanelOpen);
+    const openMobileSessionPanelFromSwipe = React.useCallback(() => setMobileSessionPanelOpen(true), [setMobileSessionPanelOpen]);
+    const { onPointerDown: onComposerFooterSwipeUp } = useSwipeUpToOpen({ enabled: isMobile, onOpen: openMobileSessionPanelFromSwipe });
     const { git: runtimeGit, vscode: vscodeApi } = useRuntimeAPIs();
     const cycleAgentShortcutOverride = useUIStore((state) => state.shortcutOverrides.cycle_agent);
     const cycleAgentShortcut = React.useMemo(() => (
@@ -4519,8 +4523,10 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                         style={{
                             borderBottomLeftRadius: chatInputRadius,
                             borderBottomRightRadius: chatInputRadius,
+                            touchAction: isMobile ? 'pan-x' : undefined,
                         }}
                         data-chat-input-footer="true"
+                        onPointerDown={onComposerFooterSwipeUp}
                     >
                         {isMobile ? (
                             <>

--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -21,6 +21,7 @@ import { DrawerProvider } from '@/contexts/DrawerContext';
 import { useUIStore } from '@/stores/useUIStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useUpdatePolling } from '@/hooks/useUpdatePolling';
+import { useMobileDrawerSwipe } from '@/hooks/useMobileDrawerSwipe';
 import { useDeviceInfo } from '@/lib/device';
 import { cn } from '@/lib/utils';
 import { lazyWithChunkRecovery } from '@/lib/chunkLoadRecovery';
@@ -356,6 +357,20 @@ export const MainLayout: React.FC = () => {
         setMobileRightSidebarOpen(!mobileRightSidebarOpen);
     }, [mobileLeftDrawerOpen, mobileRightSidebarOpen, setMobileSessionPanelOpen]);
 
+    // Edge swipe-right opens the session drawer; swipe-left closes it.
+    const {
+        onEdgePointerDown: onMobileLeftDrawerEdgePointerDown,
+        onDrawerPointerDown: onMobileLeftDrawerPointerDown,
+    } = useMobileDrawerSwipe({
+        isMobile,
+        isSettingsDialogOpen,
+        rightDrawerOpen: mobileRightSidebarOpen,
+        drawerOpen: mobileLeftDrawerOpen,
+        drawerX: leftDrawerX,
+        drawerWidthRef: leftDrawerWidth,
+        setDrawerOpen: setMobileSessionPanelOpen,
+    });
+
     const secondaryView = React.useMemo(() => {
         switch (activeMainTab) {
             case 'plan':
@@ -458,7 +473,7 @@ export const MainLayout: React.FC = () => {
                                 </div>
                             )}
                             {mobileLeftDrawerVisible && (
-                                <motion.div className="absolute inset-0 z-20 bg-sidebar" data-page-scroll-lock="true" style={{ x: leftDrawerX }} aria-hidden={!mobileLeftDrawerOpen}>
+                                <motion.div className="oc-mobile-session-drawer absolute inset-0 z-20 bg-sidebar" data-page-scroll-lock="true" style={{ x: leftDrawerX }} aria-hidden={!mobileLeftDrawerOpen} onPointerDown={onMobileLeftDrawerPointerDown}>
                                     <ErrorBoundary>
                                         <SessionSidebar mobileVariant />
                                     </ErrorBoundary>
@@ -470,6 +485,14 @@ export const MainLayout: React.FC = () => {
                                         <React.Suspense fallback={null}><GitView isActive={mobileRightSidebarOpen} /></React.Suspense>
                                     </ErrorBoundary>
                                 </motion.div>
+                            )}
+                            {!mobileLeftDrawerOpen && !mobileRightSidebarOpen && !isSettingsDialogOpen && (
+                                <div
+                                    className="absolute left-0 top-0 z-30 h-full w-7"
+                                    style={{ touchAction: 'pan-y' }}
+                                    onPointerDown={onMobileLeftDrawerEdgePointerDown}
+                                    aria-hidden
+                                />
                             )}
                         </main>
                     </div>

--- a/packages/ui/src/hooks/useMobileDrawerSwipe.ts
+++ b/packages/ui/src/hooks/useMobileDrawerSwipe.ts
@@ -1,0 +1,247 @@
+import * as React from 'react';
+import { animate, type MotionValue } from 'motion/react';
+
+/**
+ * Touch/pointer swipe gesture for the mobile left session drawer.
+ *
+ * Drives the EXISTING `leftDrawerX` motion value in MainLayout — it does not own
+ * the drawer, its visibility, or its resting animation. Two entry points:
+ *
+ * - `onEdgePointerDown`: attach to an invisible strip on the left screen edge.
+ *   A rightward, horizontal-dominant drag opens the (closed) drawer, finger-following.
+ * - `onDrawerPointerDown`: attach to the open drawer overlay. A leftward,
+ *   horizontal-dominant drag closes it, finger-following.
+ *
+ * On release the drawer settles open/closed by position threshold (past 40% of its
+ * width) or a velocity flick. Vertical-dominant gestures are abandoned immediately so
+ * native scrolling (chat list, session list) is never hijacked. All per-move work runs
+ * through the motion value with zero React re-renders.
+ */
+
+const CLAIM_THRESHOLD_PX = 8;
+// Open when the drawer is revealed past 40% (x > -width * 0.6).
+const OPEN_POSITION_RATIO = 0.6;
+// px/ms flick that decides direction regardless of how far the drawer travelled.
+const FLICK_VELOCITY = 0.5;
+// Mirrors the spring used by MainLayout's own drawer animations.
+const SPRING = { type: 'spring', stiffness: 400, damping: 35, mass: 0.8 } as const;
+
+type SwipeSource = 'edge' | 'drawer';
+
+interface GestureState {
+  pointerId: number;
+  source: SwipeSource;
+  originEl: Element;
+  startClientX: number;
+  startClientY: number;
+  startValue: number;
+  claimed: boolean;
+  lastX: number;
+  lastT: number;
+  velocity: number;
+}
+
+export interface MobileDrawerSwipeOptions {
+  isMobile: boolean;
+  isSettingsDialogOpen: boolean;
+  /** The right drawer being open suppresses the left-drawer gesture. */
+  rightDrawerOpen: boolean;
+  drawerOpen: boolean;
+  drawerX: MotionValue<number>;
+  drawerWidthRef: React.MutableRefObject<number>;
+  setDrawerOpen: (open: boolean) => void;
+}
+
+export interface MobileDrawerSwipeHandlers {
+  onEdgePointerDown: React.PointerEventHandler<HTMLDivElement>;
+  onDrawerPointerDown: React.PointerEventHandler<HTMLDivElement>;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+export function useMobileDrawerSwipe(
+  options: MobileDrawerSwipeOptions,
+): MobileDrawerSwipeHandlers {
+  // Latest options, read synchronously at gesture time so release logic sees the
+  // current open state without re-creating the (stable) handlers.
+  const optionsRef = React.useRef(options);
+  optionsRef.current = options;
+
+  const gestureRef = React.useRef<GestureState | null>(null);
+
+  const api = React.useMemo(() => {
+    const resolveWidth = (): number => {
+      const width = optionsRef.current.drawerWidthRef.current;
+      if (width && width > 0) {
+        return width;
+      }
+      return typeof window === 'undefined' ? 0 : window.innerWidth;
+    };
+
+    const teardown = (): void => {
+      const gesture = gestureRef.current;
+      gestureRef.current = null;
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('pointermove', onWindowMove);
+        window.removeEventListener('pointerup', onWindowEnd);
+        window.removeEventListener('pointercancel', onWindowCancel);
+      }
+      if (gesture?.claimed) {
+        try {
+          gesture.originEl.releasePointerCapture(gesture.pointerId);
+        } catch {
+          // Capture may already be released.
+        }
+      }
+    };
+
+    const settle = (target: boolean): void => {
+      const { drawerOpen, setDrawerOpen, drawerX } = optionsRef.current;
+      const width = resolveWidth();
+      if (target !== drawerOpen) {
+        // State change: MainLayout's effect springs the motion value to rest.
+        setDrawerOpen(target);
+      } else {
+        // Unchanged state: the effect won't fire, so snap back here.
+        animate(drawerX, target ? 0 : -width, SPRING);
+      }
+    };
+
+    function onWindowMove(event: PointerEvent): void {
+      const gesture = gestureRef.current;
+      if (!gesture || event.pointerId !== gesture.pointerId) {
+        return;
+      }
+
+      const dx = event.clientX - gesture.startClientX;
+      const dy = event.clientY - gesture.startClientY;
+
+      if (!gesture.claimed) {
+        if (Math.abs(dx) < CLAIM_THRESHOLD_PX && Math.abs(dy) < CLAIM_THRESHOLD_PX) {
+          return;
+        }
+        // Vertical-dominant → let native scrolling take over.
+        if (Math.abs(dy) >= Math.abs(dx)) {
+          teardown();
+          return;
+        }
+        // Wrong horizontal direction for this source → abandon (edge opens on
+        // rightward drags, the open drawer closes on leftward drags).
+        const rightward = dx > 0;
+        if (
+          (gesture.source === 'edge' && !rightward) ||
+          (gesture.source === 'drawer' && rightward)
+        ) {
+          teardown();
+          return;
+        }
+        gesture.claimed = true;
+        optionsRef.current.drawerX.stop();
+        try {
+          gesture.originEl.setPointerCapture(gesture.pointerId);
+        } catch {
+          // Non-fatal: capture is a best-effort robustness aid.
+        }
+      }
+
+      // Only claim horizontal movement once we own the gesture.
+      event.preventDefault();
+
+      const now = performance.now();
+      const dt = now - gesture.lastT;
+      if (dt > 0) {
+        const instant = (event.clientX - gesture.lastX) / dt;
+        gesture.velocity = gesture.velocity * 0.7 + instant * 0.3;
+        gesture.lastX = event.clientX;
+        gesture.lastT = now;
+      }
+
+      const width = resolveWidth();
+      optionsRef.current.drawerX.set(clamp(gesture.startValue + dx, -width, 0));
+    }
+
+    function onWindowEnd(event: PointerEvent): void {
+      const gesture = gestureRef.current;
+      if (!gesture || event.pointerId !== gesture.pointerId) {
+        return;
+      }
+      if (gesture.claimed) {
+        const width = resolveWidth();
+        const x = optionsRef.current.drawerX.get();
+        let target: boolean;
+        if (gesture.velocity > FLICK_VELOCITY) {
+          target = true;
+        } else if (gesture.velocity < -FLICK_VELOCITY) {
+          target = false;
+        } else {
+          target = x > -width * OPEN_POSITION_RATIO;
+        }
+        settle(target);
+      }
+      teardown();
+    }
+
+    function onWindowCancel(event: PointerEvent): void {
+      const gesture = gestureRef.current;
+      if (!gesture || event.pointerId !== gesture.pointerId) {
+        return;
+      }
+      if (gesture.claimed) {
+        // Return to whichever resting state we started from.
+        settle(optionsRef.current.drawerOpen);
+      }
+      teardown();
+    }
+
+    const begin = (event: React.PointerEvent<HTMLDivElement>, source: SwipeSource): void => {
+      const opts = optionsRef.current;
+      if (!opts.isMobile || opts.isSettingsDialogOpen || opts.rightDrawerOpen) {
+        return;
+      }
+      if (source === 'edge' && opts.drawerOpen) {
+        return;
+      }
+      if (source === 'drawer' && !opts.drawerOpen) {
+        return;
+      }
+      // Ignore secondary pointers while a gesture is active.
+      if (gestureRef.current || typeof window === 'undefined') {
+        return;
+      }
+
+      gestureRef.current = {
+        pointerId: event.pointerId,
+        source,
+        originEl: event.currentTarget,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        startValue: opts.drawerX.get(),
+        claimed: false,
+        lastX: event.clientX,
+        lastT: performance.now(),
+        velocity: 0,
+      };
+
+      // Track on window: the pointer leaves the 24px edge strip almost immediately.
+      // Non-passive so we can preventDefault once the horizontal gesture is claimed.
+      window.addEventListener('pointermove', onWindowMove, { passive: false });
+      window.addEventListener('pointerup', onWindowEnd);
+      window.addEventListener('pointercancel', onWindowCancel);
+    };
+
+    return {
+      onEdgePointerDown: (event: React.PointerEvent<HTMLDivElement>) => begin(event, 'edge'),
+      onDrawerPointerDown: (event: React.PointerEvent<HTMLDivElement>) => begin(event, 'drawer'),
+      teardown,
+    };
+  }, []);
+
+  // Drop any in-flight gesture + listeners if the host unmounts mid-drag.
+  React.useEffect(() => api.teardown, [api]);
+
+  return {
+    onEdgePointerDown: api.onEdgePointerDown,
+    onDrawerPointerDown: api.onDrawerPointerDown,
+  };
+}

--- a/packages/ui/src/hooks/useSwipeUpToOpen.ts
+++ b/packages/ui/src/hooks/useSwipeUpToOpen.ts
@@ -1,0 +1,139 @@
+import * as React from 'react';
+
+/**
+ * Detects an upward swipe and fires `onOpen` when it clears a distance or velocity
+ * threshold. Used to open the mobile recents panel by swiping up from the composer
+ * footer. Non-blocking: taps and horizontal/downward drags are never claimed, so the
+ * footer's own buttons keep working; only a deliberate upward swipe fires.
+ *
+ * Threshold-based (not finger-following) because the recents sheet animates via CSS
+ * transition — the swipe decides open/no-op, the sheet handles its own slide-up.
+ */
+
+const CLAIM_THRESHOLD_PX = 8;
+const OPEN_DISTANCE_PX = 40;
+const FLICK_VELOCITY = 0.5; // px/ms, upward is negative
+
+interface SwipeUpToOpenOptions {
+  enabled: boolean;
+  onOpen: () => void;
+}
+
+interface GestureState {
+  pointerId: number;
+  originEl: Element;
+  startX: number;
+  startY: number;
+  claimed: boolean;
+  lastY: number;
+  lastT: number;
+  velocity: number;
+}
+
+export function useSwipeUpToOpen(options: SwipeUpToOpenOptions): {
+  onPointerDown: React.PointerEventHandler<HTMLDivElement>;
+} {
+  const optionsRef = React.useRef(options);
+  optionsRef.current = options;
+
+  const gestureRef = React.useRef<GestureState | null>(null);
+
+  const api = React.useMemo(() => {
+    const teardown = (): void => {
+      const gesture = gestureRef.current;
+      gestureRef.current = null;
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onEnd);
+        window.removeEventListener('pointercancel', onCancel);
+      }
+      if (gesture?.claimed) {
+        try {
+          gesture.originEl.releasePointerCapture(gesture.pointerId);
+        } catch {
+          // Capture may already be released.
+        }
+      }
+    };
+
+    function onMove(event: PointerEvent): void {
+      const gesture = gestureRef.current;
+      if (!gesture || event.pointerId !== gesture.pointerId) return;
+
+      const dx = event.clientX - gesture.startX;
+      const dy = event.clientY - gesture.startY;
+
+      if (!gesture.claimed) {
+        if (Math.abs(dx) < CLAIM_THRESHOLD_PX && Math.abs(dy) < CLAIM_THRESHOLD_PX) {
+          return;
+        }
+        // Only an upward-dominant drag counts; horizontal/downward releases the pointer
+        // so taps, footer scrolling, and button presses proceed untouched.
+        if (dy >= 0 || Math.abs(dx) >= Math.abs(dy)) {
+          teardown();
+          return;
+        }
+        gesture.claimed = true;
+        try {
+          gesture.originEl.setPointerCapture(gesture.pointerId);
+        } catch {
+          // Non-fatal robustness aid.
+        }
+      }
+
+      event.preventDefault();
+
+      const now = performance.now();
+      const dt = now - gesture.lastT;
+      if (dt > 0) {
+        gesture.velocity = gesture.velocity * 0.7 + ((event.clientY - gesture.lastY) / dt) * 0.3;
+        gesture.lastY = event.clientY;
+        gesture.lastT = now;
+      }
+    }
+
+    function onEnd(event: PointerEvent): void {
+      const gesture = gestureRef.current;
+      if (!gesture || event.pointerId !== gesture.pointerId) return;
+      if (gesture.claimed) {
+        const dy = event.clientY - gesture.startY;
+        if (dy <= -OPEN_DISTANCE_PX || gesture.velocity < -FLICK_VELOCITY) {
+          optionsRef.current.onOpen();
+        }
+      }
+      teardown();
+    }
+
+    function onCancel(event: PointerEvent): void {
+      const gesture = gestureRef.current;
+      if (!gesture || event.pointerId !== gesture.pointerId) return;
+      teardown();
+    }
+
+    const onPointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+      if (!optionsRef.current.enabled) return;
+      if (gestureRef.current || typeof window === 'undefined') return;
+
+      gestureRef.current = {
+        pointerId: event.pointerId,
+        originEl: event.currentTarget,
+        startX: event.clientX,
+        startY: event.clientY,
+        claimed: false,
+        lastY: event.clientY,
+        lastT: performance.now(),
+        velocity: 0,
+      };
+
+      window.addEventListener('pointermove', onMove, { passive: false });
+      window.addEventListener('pointerup', onEnd);
+      window.addEventListener('pointercancel', onCancel);
+    };
+
+    return { onPointerDown, teardown };
+  }, []);
+
+  React.useEffect(() => api.teardown, [api]);
+
+  return { onPointerDown: api.onPointerDown };
+}

--- a/packages/ui/src/styles/mobile.css
+++ b/packages/ui/src/styles/mobile.css
@@ -24,6 +24,15 @@
   display: none;
 }
 
+/* Mobile session drawer swipe-to-close: the browser will steal a horizontal
+   drag that starts on a vertically-scrollable element, cancelling the gesture.
+   Reserving horizontal for JS with pan-y on the drawer AND its scroll container
+   fixes close while leaving vertical scroll (and vertical dnd reorder) intact. */
+.oc-mobile-session-drawer,
+.oc-mobile-session-drawer .overlay-scrollbar-container {
+  touch-action: pan-y;
+}
+
 @media (max-width: 1024px) {
   :root.mobile-pointer:not(.desktop-runtime) .desktop-only {
     display: none !important;


### PR DESCRIPTION
## What

Adds finger-following swipe gestures to the mobile web/PWA:

- **Session drawer** — edge swipe-right (left ~28px zone) opens it; swipe-left on the open drawer closes it. Both drive the existing `leftDrawerX` motion value via a new `useMobileDrawerSwipe` hook, wired in `MainLayout`.
- **Recents panel** — swipe up on the composer footer opens the existing `mobileSessionPanelOpen` sheet via a new `useSwipeUpToOpen` hook, wired in `ChatInput`.

## Why / notes

- The close drag starts on the drawer's vertically-scrollable session list, and browsers steal a horizontal drag that begins on a scroll container (cancelling the gesture). A `touch-action: pan-y` rule on the drawer **and** its scroll container (`mobile.css`) reserves horizontal for the JS gesture while leaving vertical scroll and dnd reorder intact.
- The recents swipe is **threshold-based** (not finger-following): the shared `MobileOverlayPanel` animates via CSS transition, so the swipe fires the open and the sheet runs its own slide-up. Finger-following would require reworking that shared component.
- Both gestures are gated to `isMobile` and non-blocking (taps on the edge column / footer buttons still work). No desktop or VS Code behavior change.

## Verification

- `type-check`, `lint`, and `dead-code` (knip) all pass on `@openchamber/ui`.
- Gesture logic verified in real Chrome via touch-emulated harnesses: edge open/close, vertical-scroll-doesn't-close, direction lock + threshold, and swipe-up-opens / tap-passes-through.

## Not yet covered / follow-ups

- **Real-device QA** — the mechanics are validated under touch emulation but not on a physical phone. Worth a sanity pass on iOS Safari / Android Chrome (drawer + list scroll + dnd reorder; footer swipe-up + button taps).
- Optional polish: finger-following for recents (needs `MobileOverlayPanel` to be motion-driven) and swipe-down-to-close on the recents sheet.
