### PR TITLE
fix(ui): preserve base URL path prefix when building runtime URLs

### DIFF
--- a/packages/ui/src/lib/runtime-url.test.ts
+++ b/packages/ui/src/lib/runtime-url.test.ts
@@ -32,8 +32,17 @@ describe('createRuntimeUrlResolver', () => {
   test('builds absolute API URLs when an API base URL is configured', () => {
     const urls = createRuntimeUrlResolver({ apiBaseUrl: 'https://server.example/base/' });
 
+    // The base URL's path prefix (/base) is preserved so instances served
+    // under a reverse-proxy sub-path receive requests at the right location.
+    expect(urls.api('/api/config/settings')).toBe('https://server.example/base/api/config/settings');
+    expect(urls.auth('/auth/device', { next: '/app' })).toBe('https://server.example/base/auth/device?next=%2Fapp');
+    expect(urls.health({ probe: true })).toBe('https://server.example/base/health?probe=true');
+  });
+
+  test('builds absolute API URLs from an origin-only API base URL', () => {
+    const urls = createRuntimeUrlResolver({ apiBaseUrl: 'https://server.example' });
+
     expect(urls.api('/api/config/settings')).toBe('https://server.example/api/config/settings');
-    expect(urls.auth('/auth/device', { next: '/app' })).toBe('https://server.example/auth/device?next=%2Fapp');
     expect(urls.health({ probe: true })).toBe('https://server.example/health?probe=true');
   });
 
@@ -43,9 +52,9 @@ describe('createRuntimeUrlResolver', () => {
       realtimeBaseUrl: 'https://realtime.example/root',
     });
 
-    expect(urls.sse('/api/openchamber/events')).toBe('https://realtime.example/api/openchamber/events');
+    expect(urls.sse('/api/openchamber/events')).toBe('https://realtime.example/root/api/openchamber/events');
     expect(urls.websocket('/api/global/event/ws', { lastEventId: 'evt-1' })).toBe(
-      'wss://realtime.example/api/global/event/ws?lastEventId=evt-1',
+      'wss://realtime.example/root/api/global/event/ws?lastEventId=evt-1',
     );
   });
 

--- a/packages/ui/src/lib/runtime-url.ts
+++ b/packages/ui/src/lib/runtime-url.ts
@@ -90,7 +90,11 @@ const buildHttpUrl = (baseUrl: string, path: string, query?: RuntimeUrlQuery): s
     return appendRelativeQuery(normalizedPath, query);
   }
 
-  const url = new URL(normalizedPath, `${baseUrl}/`);
+  // Concatenate instead of new URL(absolutePath, base): resolving an absolute
+  // path against a base keeps only the base's origin and silently drops any
+  // path prefix (e.g. https://host/openchamber -> https://host). Concatenation
+  // is correct for both origin-only bases and bases served under a sub-path.
+  const url = new URL(`${baseUrl.replace(/\/+$/, '')}${normalizedPath}`);
   appendQuery(url, query);
   return url.toString();
 };


### PR DESCRIPTION
## What

`buildHttpUrl` builds absolute URLs with `new URL(absolutePath, base)`, which resolves against the base's **origin only** — any path prefix on the configured API/realtime base URL is silently dropped.

## Why

An instance served under a reverse-proxy sub-path (e.g. `https://host/openchamber`) is unusable today: every API/SSE/WS request goes to the domain root instead of the prefix. A base URL with a path can't mean anything else, so preserving it is strictly a fix — origin-only bases are unaffected (regression test added).

Note this deliberately changes the behavior pinned by two existing resolver tests (they asserted the prefix being dropped); both are updated here.

## Validation

- `bun test packages/ui/src/lib/runtime-url.test.ts` — 14/14 pass
- full `packages/ui` suite: failure set identical to `main` (no new failures)
- `tsc --noEmit` + eslint on touched files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)