### PR TITLE
fix(chat): surface session.error to the user viewing the session

### DIFF
--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1502,15 +1502,35 @@ function handleEvent(
     if (session && (session as { parentID?: string }).parentID) {
       // subtask — skip notification
     } else if (sessionID) {
+      const viewed = isViewedInCurrentSession(resolvedDirectory, sessionID)
       appendNotification({
         directory: resolvedDirectory,
         session: sessionID,
         time: Date.now(),
-        viewed: isViewedInCurrentSession(resolvedDirectory, sessionID),
+        viewed,
         ...(payload.type === "session.error"
           ? { type: "error" as const, error: props.error }
           : { type: "turn-complete" as const }),
       })
+      // For the session currently being viewed, this toast is the ONLY surface
+      // for session.error: the event reducer drops the error payload (it only
+      // flips status back to idle) and the notification above is born viewed,
+      // so it never produces a badge. Without it a provider 401 / network
+      // failure ends the turn in total silence for the user watching the chat.
+      if (payload.type === "session.error" && viewed) {
+        const err = props.error as
+          | { name?: string; message?: string; data?: { message?: string; statusCode?: number } }
+          | undefined
+        const detail = err?.data?.message?.trim()
+          || err?.message?.trim()
+          || (err?.data?.statusCode ? `HTTP ${err.data.statusCode}` : "")
+          || err?.name
+          || "Unknown error"
+        toast.error("Agent stopped with an error", {
+          id: `session-error-${sessionID}`,
+          description: detail,
+        })
+      }
     }
   }
 


### PR DESCRIPTION
## What

Show an error toast when `session.error` arrives for the session the user is currently viewing.

## Why

Today `session.error` reaches the user through exactly one surface: the notification store. But for the **viewed** session the notification is created `viewed: true` (no badge), and the event reducer only flips the session status back to idle — the error payload itself is dropped. Net effect: a provider 401, exhausted quota, or network failure ends the turn in complete silence for the person watching the chat; the spinner just stops.

The toast is keyed by session ID (`session-error-<id>`) so repeated errors replace rather than stack, and picks the most specific detail available (`error.data.message` → `error.message` → HTTP status → error name).

Background/unviewed sessions are unchanged — they already get the badge + notification path.

## Validation

- `tsc --noEmit` (packages/ui) clean
- eslint on the touched file clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)