### PR TITLE
feat(discord): bidirectional worktree sync with Discord threads

### DIFF
--- a/packages/ui/src/components/sections/openchamber/WorktreeSectionContent.tsx
+++ b/packages/ui/src/components/sections/openchamber/WorktreeSectionContent.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Icon } from "@/components/icon/Icon";
 import type { Session } from '@opencode-ai/sdk/v2';
 import { useProjectsStore } from '@/stores/useProjectsStore';
+import { useMessengerStore } from '@/stores/useMessengerStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSessions } from '@/sync/sync-context';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
@@ -27,6 +28,42 @@ import { useI18n } from '@/lib/i18n';
 export interface WorktreeSectionContentProps {
   projectRef?: { id: string; path: string } | null;
 }
+
+const WorktreeDiscordLink: React.FC<{ worktreePath: string }> = ({ worktreePath }) => {
+  const { t } = useI18n();
+  const fetchWorktreeDiscordUrl = useMessengerStore((state) => state.fetchWorktreeDiscordUrl);
+  const syncWorktrees = useMessengerStore(
+    (state) => state.connections.find((connection) => connection.type === 'discord')?.syncWorktrees !== false,
+  );
+  const [discordUrl, setDiscordUrl] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!syncWorktrees) {
+      setDiscordUrl(null);
+      return;
+    }
+    let cancelled = false;
+    void fetchWorktreeDiscordUrl(worktreePath).then((url) => {
+      if (!cancelled) setDiscordUrl(url);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchWorktreeDiscordUrl, syncWorktrees, worktreePath]);
+
+  if (!discordUrl) return null;
+
+  return (
+    <a
+      href={discordUrl}
+      target="_blank"
+      rel="noreferrer"
+      className="typography-micro text-primary hover:underline flex-shrink-0"
+    >
+      {t('settings.openchamber.worktrees.list.openInDiscord')}
+    </a>
+  );
+};
 
 export const WorktreeSectionContent: React.FC<WorktreeSectionContentProps> = ({ projectRef: projectRefProp = null }) => {
   const { t } = useI18n();
@@ -411,6 +448,7 @@ export const WorktreeSectionContent: React.FC<WorktreeSectionContentProps> = ({ 
                   <p className="typography-micro text-muted-foreground/60 truncate">
                     {formatPathForDisplay(worktree.path, homeDirectory)}
                   </p>
+                  <WorktreeDiscordLink worktreePath={worktree.path} />
                 </div>
                   <button
                     type="button"

--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -1455,6 +1455,21 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
               <label className="flex items-center gap-1.5 text-[11px] cursor-pointer">
                 <input
                   type="checkbox"
+                  checked={conn.syncWorktrees !== false}
+                  onChange={(e) => {
+                    updateConnection('discord', { syncWorktrees: e.target.checked });
+                    setTimeout(() => saveDiscordConfig(), 0);
+                  }}
+                  className="rounded border-border accent-primary"
+                />
+                <span className="text-muted-foreground">
+                  Sync worktrees to Discord threads
+                </span>
+              </label>
+
+              <label className="flex items-center gap-1.5 text-[11px] cursor-pointer">
+                <input
+                  type="checkbox"
                   checked={conn.discordCreateThreads !== false}
                   onChange={(e) =>
                     updateConnection('discord', { discordCreateThreads: e.target.checked })

--- a/packages/ui/src/lib/i18n/messages/en.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/en.settings.ts
@@ -1147,6 +1147,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': 'No worktrees found for this project',
   'settings.openchamber.worktrees.list.detachedHead': 'Detached HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'Delete worktree {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Open in Discord',
   'settings.agents.modelSelector.title': 'Select model',
   'settings.agents.modelSelector.searchPlaceholder': 'Search models',
   'settings.agents.modelSelector.selectPlaceholder': 'Select model...',

--- a/packages/ui/src/lib/i18n/messages/es.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/es.settings.ts
@@ -1114,6 +1114,7 @@ export const settingsDict = {
   "settings.openchamber.worktrees.list.empty": "No se encontraron worktrees para este proyecto",
   "settings.openchamber.worktrees.list.detachedHead": "HEAD desvinculado",
   "settings.openchamber.worktrees.list.deleteWorktreeAria": "Eliminar worktree {name}",
+  "settings.openchamber.worktrees.list.openInDiscord": "Abrir en Discord",
   "settings.agents.modelSelector.title": "Seleccionar modelo",
   "settings.agents.modelSelector.searchPlaceholder": "Buscar modelos",
   "settings.agents.modelSelector.selectPlaceholder": "Seleccionar modelo...",

--- a/packages/ui/src/lib/i18n/messages/fr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.settings.ts
@@ -1097,6 +1097,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': 'Aucun worktree trouvé pour ce projet',
   'settings.openchamber.worktrees.list.detachedHead': 'HEAD détaché',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'Supprimer le worktree {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Ouvrir dans Discord',
   'settings.agents.modelSelector.title': 'Sélectionnez le modèle',
   'settings.agents.modelSelector.searchPlaceholder': 'Rechercher des modèles',
   'settings.agents.modelSelector.selectPlaceholder': 'Sélectionnez le modèle...',

--- a/packages/ui/src/lib/i18n/messages/ja.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.settings.ts
@@ -1146,6 +1146,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': 'このプロジェクトに Worktree は見つかりません',
   'settings.openchamber.worktrees.list.detachedHead': '分離 HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'Worktree {name} を削除',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Discord で開く',
   'settings.agents.modelSelector.title': 'モデルを選択',
   'settings.agents.modelSelector.searchPlaceholder': 'モデルを検索',
   'settings.agents.modelSelector.selectPlaceholder': 'モデルを選択...',

--- a/packages/ui/src/lib/i18n/messages/ko.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.settings.ts
@@ -1114,6 +1114,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': '이 프로젝트의 worktree를 찾을 수 없습니다',
   'settings.openchamber.worktrees.list.detachedHead': 'Detached HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'worktree {name} 삭제',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Discord에서 열기',
   'settings.agents.modelSelector.title': '모델 선택',
   'settings.agents.modelSelector.searchPlaceholder': '모델 검색',
   'settings.agents.modelSelector.selectPlaceholder': '모델 선택...',

--- a/packages/ui/src/lib/i18n/messages/pl.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.settings.ts
@@ -1070,6 +1070,7 @@ export const settingsDict = {
   'settings.openchamber.visual.section.userMessageRendering': 'Renderowanie wiadomości użytkownika',
   'settings.openchamber.visual.section.userMessageRenderingAria': 'Tryb renderowania wiadomości użytkownika',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'Usuń worktree {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Otwórz w Discordzie',
   'settings.openchamber.worktrees.list.detachedHead': 'Odłączony HEAD',
   'settings.openchamber.worktrees.list.empty': 'Nie znaleziono worktree dla tego projektu',
   'settings.openchamber.worktrees.list.loading': 'Ładowanie worktree...',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
@@ -1114,6 +1114,7 @@ export const settingsDict = {
   "settings.openchamber.worktrees.list.empty": "Nenhum worktree encontrado para este projeto",
   "settings.openchamber.worktrees.list.detachedHead": "HEAD desvinculado",
   "settings.openchamber.worktrees.list.deleteWorktreeAria": "Excluir worktree {name}",
+  "settings.openchamber.worktrees.list.openInDiscord": "Abrir no Discord",
   "settings.agents.modelSelector.title": "Selecionar modelo",
   "settings.agents.modelSelector.searchPlaceholder": "Pesquisar modelos",
   "settings.agents.modelSelector.selectPlaceholder": "Selecionar modelo...",

--- a/packages/ui/src/lib/i18n/messages/uk.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.settings.ts
@@ -1114,6 +1114,7 @@ export const settingsDict = {
   "settings.openchamber.worktrees.list.empty": "Для цього проєкту не знайдено worktree",
   "settings.openchamber.worktrees.list.detachedHead": "Відокремлено HEAD",
   "settings.openchamber.worktrees.list.deleteWorktreeAria": "Видалити worktree {name}",
+  "settings.openchamber.worktrees.list.openInDiscord": "Відкрити в Discord",
   "settings.agents.modelSelector.title": "Виберіть модель",
   "settings.agents.modelSelector.searchPlaceholder": "Пошук моделей",
   "settings.agents.modelSelector.selectPlaceholder": "Виберіть модель...",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
@@ -1114,6 +1114,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': '该项目未找到工作树',
   'settings.openchamber.worktrees.list.detachedHead': '分离 HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': '删除工作树 {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': '在 Discord 中打开',
   'settings.agents.modelSelector.title': '选择模型',
   'settings.agents.modelSelector.searchPlaceholder': '搜索模型',
   'settings.agents.modelSelector.selectPlaceholder': '选择模型...',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
@@ -1030,6 +1030,7 @@
   'settings.openchamber.worktrees.list.empty': '該專案找不到 worktree',
   'settings.openchamber.worktrees.list.detachedHead': '分離 HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': '刪除 worktree {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': '在 Discord 中開啟',
   'settings.agents.modelSelector.title': '選擇模型',
   'settings.agents.modelSelector.searchPlaceholder': '搜尋模型',
   'settings.agents.modelSelector.selectPlaceholder': '選擇模型...',

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -385,6 +385,20 @@ export async function createWorktree(project: ProjectRef, args: CreateWorktreeAr
     availableWorktrees: [...useSessionUIStore.getState().availableWorktrees, metadata],
   });
 
+  void import('@/stores/useMessengerStore')
+    .then(({ useMessengerStore }) => {
+      const notify = useMessengerStore.getState().notifyWorktreeAdded;
+      void notify(
+        { id: project.id, path: project.path, label: project.path.split('/').pop() ?? project.path },
+        {
+          path: metadata.path,
+          branch: metadata.branch,
+          label: metadata.label,
+        },
+      );
+    })
+    .catch(() => undefined);
+
   return metadata;
 }
 
@@ -451,4 +465,18 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
   if (deleteRemote && branchName) {
     await deleteRemoteBranch(projectDirectory, { branch: branchName, remote: remoteName }).catch(() => undefined);
   }
+
+  void import('@/stores/useMessengerStore')
+    .then(({ useMessengerStore }) => {
+      const notify = useMessengerStore.getState().notifyWorktreeRemoved;
+      void notify(
+        { id: project.id, path: project.path, label: project.path.split('/').pop() ?? project.path },
+        {
+          path: worktree.path,
+          branch: worktree.branch,
+          label: worktree.label,
+        },
+      );
+    })
+    .catch(() => undefined);
 }

--- a/packages/ui/src/stores/useMessengerStore.ts
+++ b/packages/ui/src/stores/useMessengerStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { getSafeStorage } from './utils/safeStorage';
 import { useProjectsStore } from './useProjectsStore';
+import { runtimeFetch } from '@/lib/runtime-fetch';
 import type { ProjectEntry } from '@/lib/api/types';
 
 export type MessengerType = 'discord';
@@ -105,6 +106,8 @@ export interface MessengerConnection {
   // Sync config
   syncMode: SyncMode;
   syncProjects: boolean;
+  /** Mirror git worktrees to Discord threads under each project channel. */
+  syncWorktrees: boolean;
   syncTasks: boolean;
   syncSchedule: boolean;
   autoCreateThreads: boolean;
@@ -308,6 +311,21 @@ interface MessengerState {
   ensureProjectChannel: (project: ProjectEntry) => Promise<void>;
   renameProjectChannel: (project: ProjectEntry) => Promise<void>;
   removeProjectChannel: (projectId: string, projectPath: string) => Promise<void>;
+  notifyWorktreeAdded: (
+    project: ProjectEntry,
+    worktree: { path: string; branch?: string; label?: string },
+    sessionId?: string | null,
+  ) => Promise<void>;
+  notifyWorktreeRemoved: (
+    project: ProjectEntry,
+    worktree: { path: string; branch?: string; label?: string },
+  ) => Promise<void>;
+  notifyWorktreeMerged: (
+    project: ProjectEntry,
+    worktree: { path: string; branch?: string; label?: string },
+    summary?: string | null,
+  ) => Promise<void>;
+  fetchWorktreeDiscordUrl: (worktreePath: string) => Promise<string | null>;
   startOnboarding: (type: MessengerType) => void;
   nextOnboardingStep: () => void;
   finishOnboarding: () => void;
@@ -323,6 +341,7 @@ const DEFAULT_CONNECTION: Omit<MessengerConnection, 'type'> = {
   lastSyncMessage: null,
   syncMode: 'full',
   syncProjects: true,
+  syncWorktrees: true,
   syncTasks: true,
   syncSchedule: true,
   autoCreateThreads: true,
@@ -824,6 +843,7 @@ export const useMessengerStore = create<MessengerState>()(
             defaultChannelId: conn.defaultChannelId,
             defaultUserId: conn.defaultUserId,
             projectBindings,
+            syncWorktrees: conn.syncWorktrees !== false,
           });
         } catch {
           // silent — config save is best-effort
@@ -1239,6 +1259,69 @@ export const useMessengerStore = create<MessengerState>()(
         }
         get().removeProjectMapping(projectId);
         get().saveDiscordConfig();
+      },
+
+      notifyWorktreeAdded: async (project, worktree, sessionId = null) => {
+        const conn = get().connections.find((c) => c.type === 'discord');
+        if (!conn?.botToken || !conn.discordGuildId || conn.syncProjects === false || conn.syncWorktrees === false) {
+          return;
+        }
+        try {
+          await postJson('/api/otto/messenger/bridge/worktree-added', {
+            project: { id: project.id, path: project.path, label: project.label ?? project.path },
+            worktree,
+            sessionId,
+            discord: {
+              token: conn.botToken,
+              guildId: conn.discordGuildId,
+              parentCategoryId: conn.discordParentCategoryId,
+            },
+          });
+        } catch {
+          // best-effort
+        }
+      },
+
+      notifyWorktreeRemoved: async (project, worktree) => {
+        const conn = get().connections.find((c) => c.type === 'discord');
+        if (!conn?.botToken || conn.syncWorktrees === false) return;
+        try {
+          await postJson('/api/otto/messenger/bridge/worktree-removed', {
+            project: { id: project.id, path: project.path, label: project.label ?? project.path },
+            worktree,
+          });
+        } catch {
+          // best-effort
+        }
+      },
+
+      notifyWorktreeMerged: async (project, worktree, summary = null) => {
+        const conn = get().connections.find((c) => c.type === 'discord');
+        if (!conn?.botToken || conn.syncWorktrees === false) return;
+        try {
+          await postJson('/api/otto/messenger/bridge/worktree-merged', {
+            project: { id: project.id, path: project.path, label: project.label ?? project.path },
+            worktree,
+            summary,
+          });
+        } catch {
+          // best-effort
+        }
+      },
+
+      fetchWorktreeDiscordUrl: async (worktreePath) => {
+        const conn = get().connections.find((c) => c.type === 'discord');
+        if (!conn?.botToken || !conn.discordGuildId || conn.syncWorktrees === false) return null;
+        try {
+          const response = await runtimeFetch(
+            `/api/otto/messenger/bridge/worktree-discord-url?path=${encodeURIComponent(worktreePath)}`,
+          );
+          if (!response.ok) return null;
+          const data = (await response.json()) as { ok?: boolean; discordUrl?: string };
+          return data.ok && data.discordUrl ? data.discordUrl : null;
+        } catch {
+          return null;
+        }
       },
 
       startOnboarding: (type) => {

--- a/packages/web/server/lib/otto-api/discord-commands.js
+++ b/packages/web/server/lib/otto-api/discord-commands.js
@@ -91,6 +91,15 @@ export function buildSlashCommandDefinitions() {
       ],
     },
     { name: 'merge-worktree', description: 'Squash-merge this worktree into the default branch' },
+    { name: 'list-worktrees', description: 'List git worktrees for this project with Discord thread links' },
+    {
+      name: 'open-worktree',
+      description: 'Open an existing worktree in its Discord thread',
+      options: [
+        { type: STRING_OPTION, name: 'branch', description: 'Branch or worktree name', required: true },
+      ],
+    },
+    { name: 'worktree-status', description: 'Show git status for the worktree in this conversation' },
     {
       name: 'schedule',
       description: 'Schedule a prompt: UTC ISO date or cron — list / delete <id> to manage',

--- a/packages/web/server/lib/otto-api/messenger-bridge-store.js
+++ b/packages/web/server/lib/otto-api/messenger-bridge-store.js
@@ -89,6 +89,9 @@ export class MessengerBridgeStore {
       'verbosity_override TEXT',
       'variant_override TEXT',
       'permission_mode TEXT',
+      'project_root TEXT',
+      'worktree_path TEXT',
+      'branch TEXT',
     ]) {
       try {
         this.db.exec(`ALTER TABLE messenger_session_bindings ADD COLUMN ${col}`);
@@ -96,6 +99,22 @@ export class MessengerBridgeStore {
         // ignore — column already exists
       }
     }
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS messenger_worktree_bindings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        bot_token_hash TEXT NOT NULL,
+        project_root TEXT NOT NULL,
+        worktree_path TEXT NOT NULL,
+        branch TEXT,
+        channel_id TEXT NOT NULL,
+        thread_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (bot_token_hash, worktree_path)
+      );
+      CREATE INDEX IF NOT EXISTS idx_messenger_worktree_project
+        ON messenger_worktree_bindings (bot_token_hash, project_root);
+    `);
     // Global bridge settings (key/value). Holds the per-messenger verbosity
     // default (key `verbosity:discord` / `verbosity:telegram`) that the
     // OpenChamber UI writes and the `/verbosity` chat command can override
@@ -263,8 +282,9 @@ export class MessengerBridgeStore {
     const row = this.db
       .prepare(
         `SELECT session_id AS sessionId, project_path AS projectPath,
-                project_label AS projectLabel, created_at AS createdAt,
-                last_used_at AS lastUsedAt,
+                project_label AS projectLabel, project_root AS projectRoot,
+                worktree_path AS worktreePath, branch,
+                created_at AS createdAt, last_used_at AS lastUsedAt,
                 model_override AS modelOverride,
                 agent_override AS agentOverride,
                 verbosity_override AS verbosityOverride,
@@ -339,17 +359,35 @@ export class MessengerBridgeStore {
       .run(type, botTokenHash, targetKey);
   }
 
-  bind({ type, botTokenHash, targetKey, sessionId, projectPath, projectLabel }) {
+  bind({
+    type,
+    botTokenHash,
+    targetKey,
+    sessionId,
+    projectPath,
+    projectLabel,
+    projectRoot = undefined,
+    worktreePath = undefined,
+    branch = undefined,
+  }) {
     const now = new Date().toISOString();
+    const existing = this.lookup({ type, botTokenHash, targetKey });
+    const nextProjectRoot = projectRoot === undefined ? existing?.projectRoot ?? null : projectRoot;
+    const nextWorktreePath = worktreePath === undefined ? existing?.worktreePath ?? null : worktreePath;
+    const nextBranch = branch === undefined ? existing?.branch ?? null : branch;
     this.db
       .prepare(
         `INSERT INTO messenger_session_bindings
-           (type, target_key, session_id, project_path, project_label, bot_token_hash, created_at, last_used_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           (type, target_key, session_id, project_path, project_label, project_root,
+            worktree_path, branch, bot_token_hash, created_at, last_used_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(type, bot_token_hash, target_key)
          DO UPDATE SET session_id = excluded.session_id,
                        project_path = excluded.project_path,
                        project_label = excluded.project_label,
+                       project_root = excluded.project_root,
+                       worktree_path = excluded.worktree_path,
+                       branch = excluded.branch,
                        last_used_at = excluded.last_used_at`,
       )
       .run(
@@ -358,10 +396,97 @@ export class MessengerBridgeStore {
         sessionId,
         projectPath ?? null,
         projectLabel ?? null,
+        nextProjectRoot,
+        nextWorktreePath,
+        nextBranch,
         botTokenHash,
         now,
         now,
       );
+  }
+
+  bindWorktree({ botTokenHash, projectRoot, worktreePath, branch, channelId, threadId }) {
+    if (!botTokenHash || !projectRoot || !worktreePath || !channelId || !threadId) return;
+    const now = new Date().toISOString();
+    this.db
+      .prepare(
+        `INSERT INTO messenger_worktree_bindings
+           (bot_token_hash, project_root, worktree_path, branch, channel_id, thread_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(bot_token_hash, worktree_path)
+         DO UPDATE SET project_root = excluded.project_root,
+                       branch = excluded.branch,
+                       channel_id = excluded.channel_id,
+                       thread_id = excluded.thread_id,
+                       updated_at = excluded.updated_at`,
+      )
+      .run(
+        botTokenHash,
+        projectRoot,
+        worktreePath,
+        branch ?? null,
+        String(channelId),
+        String(threadId),
+        now,
+        now,
+      );
+  }
+
+  lookupWorktreeByPath({ botTokenHash, worktreePath }) {
+    if (!worktreePath) return null;
+    const params = [worktreePath];
+    let sql = `SELECT project_root AS projectRoot, worktree_path AS worktreePath, branch,
+                      channel_id AS channelId, thread_id AS threadId,
+                      created_at AS createdAt, updated_at AS updatedAt
+                 FROM messenger_worktree_bindings
+                WHERE worktree_path = ?`;
+    if (botTokenHash) {
+      sql += ' AND bot_token_hash = ?';
+      params.push(botTokenHash);
+    }
+    const row = this.db.prepare(sql).get(...params);
+    return row ?? null;
+  }
+
+  lookupWorktreeByThread({ botTokenHash, threadId }) {
+    if (!threadId) return null;
+    const params = [String(threadId)];
+    let sql = `SELECT project_root AS projectRoot, worktree_path AS worktreePath, branch,
+                      channel_id AS channelId, thread_id AS threadId
+                 FROM messenger_worktree_bindings
+                WHERE thread_id = ?`;
+    if (botTokenHash) {
+      sql += ' AND bot_token_hash = ?';
+      params.push(botTokenHash);
+    }
+    const row = this.db.prepare(sql).get(...params);
+    return row ?? null;
+  }
+
+  listWorktreesForProject({ botTokenHash, projectRoot }) {
+    if (!projectRoot) return [];
+    const params = [projectRoot];
+    let sql = `SELECT project_root AS projectRoot, worktree_path AS worktreePath, branch,
+                      channel_id AS channelId, thread_id AS threadId
+                 FROM messenger_worktree_bindings
+                WHERE project_root = ?`;
+    if (botTokenHash) {
+      sql += ' AND bot_token_hash = ?';
+      params.push(botTokenHash);
+    }
+    sql += ' ORDER BY branch ASC';
+    return this.db.prepare(sql).all(...params);
+  }
+
+  unbindWorktree({ botTokenHash, worktreePath }) {
+    if (!worktreePath) return;
+    const params = [worktreePath];
+    let sql = 'DELETE FROM messenger_worktree_bindings WHERE worktree_path = ?';
+    if (botTokenHash) {
+      sql += ' AND bot_token_hash = ?';
+      params.push(botTokenHash);
+    }
+    this.db.prepare(sql).run(...params);
   }
 
   touch({ type, botTokenHash, targetKey }) {

--- a/packages/web/server/lib/otto-api/messenger-bridge-store.test.js
+++ b/packages/web/server/lib/otto-api/messenger-bridge-store.test.js
@@ -67,3 +67,48 @@ describe('MessengerBridgeStore — permission mode persistence', () => {
     expect(store.getPermissionModeDefault('discord')).toBeNull();
   });
 });
+
+describe('MessengerBridgeStore — worktree bindings', () => {
+  let dbPath;
+  let store;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `otto-store-${crypto.randomBytes(6).toString('hex')}.sqlite`);
+    store = new MessengerBridgeStore({ dbPath });
+  });
+
+  afterEach(() => {
+    try {
+      store.db.close();
+    } catch {
+      // ignore
+    }
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(dbPath + suffix);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it('binds and looks up worktrees by path', () => {
+    store.bindWorktree({
+      botTokenHash: 'hash',
+      projectRoot: '/repo',
+      worktreePath: '/repo/.worktrees/feature',
+      branch: 'feature',
+      channelId: 'chan-1',
+      threadId: 'thread-1',
+    });
+    const row = store.lookupWorktreeByPath({
+      botTokenHash: 'hash',
+      worktreePath: '/repo/.worktrees/feature',
+    });
+    expect(row?.threadId).toBe('thread-1');
+    expect(row?.branch).toBe('feature');
+    expect(store.listWorktreesForProject({ botTokenHash: 'hash', projectRoot: '/repo' })).toHaveLength(1);
+    store.unbindWorktree({ botTokenHash: 'hash', worktreePath: '/repo/.worktrees/feature' });
+    expect(store.lookupWorktreeByPath({ botTokenHash: 'hash', worktreePath: '/repo/.worktrees/feature' })).toBeNull();
+  });
+});

--- a/packages/web/server/lib/otto-api/messenger-commands.js
+++ b/packages/web/server/lib/otto-api/messenger-commands.js
@@ -151,6 +151,21 @@ const COMMAND_HELP = [
     summary: 'Squash-merge this worktree\'s commits into the default branch',
   },
   {
+    name: 'list-worktrees',
+    usage: '/list-worktrees',
+    summary: 'List git worktrees for this project with Discord thread links',
+  },
+  {
+    name: 'open-worktree',
+    usage: '/open-worktree <branch-or-name>',
+    summary: 'Open an existing worktree in its Discord thread (UI-created worktrees included)',
+  },
+  {
+    name: 'worktree-status',
+    usage: '/worktree-status',
+    summary: 'Show git status for the worktree bound to this conversation',
+  },
+  {
     name: 'schedule',
     usage: '/schedule <when> [model=p/m] [agent=name] <prompt> | list | delete <id>',
     summary:
@@ -1033,6 +1048,72 @@ export async function executeMessengerCommand({
         };
       }
       return { reply: `✗ Merge failed: ${r.error ?? 'unknown error'}` };
+    }
+
+    case 'list-worktrees': {
+      if (!bridgeOps?.listWorktrees) {
+        return { reply: '✗ `/list-worktrees` is not available on this surface.' };
+      }
+      const r = await bridgeOps.listWorktrees();
+      if (!r.ok) return { reply: `✗ ${r.error ?? 'could not list worktrees.'}` };
+      if (!r.worktrees || r.worktrees.length === 0) {
+        return { reply: '_(no worktrees found for this project — create one in the UI or with `/new-worktree`)_' };
+      }
+      const lines = ['**Worktrees**', ''];
+      for (const [index, wt] of r.worktrees.entries()) {
+        const statusParts = [];
+        if (wt.status?.ahead) statusParts.push(`+${wt.status.ahead}`);
+        if (wt.status?.behind) statusParts.push(`-${wt.status.behind}`);
+        if (wt.status?.isDirty) statusParts.push('dirty');
+        const statusText = statusParts.length > 0 ? statusParts.join('·') : 'clean';
+        const link = wt.threadId ? `<#${wt.threadId}>` : '_no thread_';
+        lines.push(`${index + 1}. \`${wt.branch}\` — ${statusText} → ${link}`);
+      }
+      lines.push('', 'Open one with `/open-worktree <branch>`.');
+      return { reply: lines.join('\n') };
+    }
+
+    case 'open-worktree': {
+      if (!bridgeOps?.openWorktree) {
+        return { reply: '✗ `/open-worktree` is not available on this surface.' };
+      }
+      const query = command.args.trim();
+      if (!query) {
+        return { reply: '✗ Usage: `/open-worktree <branch-or-name>` — run `/list-worktrees` to see options.' };
+      }
+      const r = await bridgeOps.openWorktree({ query });
+      if (!r.ok) return { reply: `✗ ${r.error ?? 'could not open worktree.'}` };
+      return {
+        reply: [
+          `🌿 Opened worktree \`${r.branch}\``,
+          `📁 \`${r.path}\``,
+          r.threadId ? `Continue in <#${r.threadId}>.` : '',
+        ].filter(Boolean).join('\n'),
+      };
+    }
+
+    case 'worktree-status': {
+      if (!bridgeOps?.worktreeStatus) {
+        return { reply: '✗ `/worktree-status` is not available on this surface.' };
+      }
+      const r = await bridgeOps.worktreeStatus();
+      if (!r.ok) return { reply: `✗ ${r.error ?? 'could not read worktree status.'}` };
+      const statusParts = [];
+      if (r.status?.ahead) statusParts.push(`+${r.status.ahead} ahead`);
+      if (r.status?.behind) statusParts.push(`${r.status.behind} behind`);
+      if (r.status?.isDirty) statusParts.push('dirty');
+      const statusText = statusParts.length > 0 ? statusParts.join(', ') : 'clean';
+      return {
+        reply: [
+          `**Worktree status**`,
+          `Path: \`${r.path}\``,
+          `Project root: \`${r.projectRoot}\``,
+          `Branch: \`${r.branch ?? 'unknown'}\``,
+          `Git: ${statusText}`,
+          r.isWorktree ? '' : '_This conversation is not inside a secondary worktree._',
+          r.threadId ? `Thread: <#${r.threadId}>` : '',
+        ].filter(Boolean).join('\n'),
+      };
     }
 
     default:

--- a/packages/web/server/lib/otto-api/messenger-commands.test.js
+++ b/packages/web/server/lib/otto-api/messenger-commands.test.js
@@ -441,6 +441,44 @@ describe('worktree commands', () => {
     expect(result.reply).toContain('Merge conflict detected');
     expect(result.reply).toContain('asked the model');
   });
+  it('list-worktrees renders project worktrees', async () => {
+    const { result } = await run('/list-worktrees', {
+      binding: { projectPath: '/repo' },
+      bridgeOps: {
+        listWorktrees: async () => ({
+          ok: true,
+          worktrees: [{ branch: 'feature', path: '/repo/wt/feature', status: { ahead: 1, isDirty: true }, threadId: 'th-1' }],
+        }),
+      },
+    });
+    expect(result.reply).toContain('feature');
+    expect(result.reply).toContain('<#th-1>');
+  });
+  it('open-worktree requires a query', async () => {
+    const { result } = await run('/open-worktree', {
+      binding: { projectPath: '/repo' },
+      bridgeOps: { openWorktree: vi.fn() },
+    });
+    expect(result.reply).toMatch(/Usage/);
+  });
+  it('worktree-status reports git state', async () => {
+    const { result } = await run('/worktree-status', {
+      binding: { projectPath: '/repo/wt/feature', branch: 'feature' },
+      bridgeOps: {
+        worktreeStatus: async () => ({
+          ok: true,
+          path: '/repo/wt/feature',
+          projectRoot: '/repo',
+          isWorktree: true,
+          branch: 'feature',
+          status: { ahead: 2, behind: 0, isDirty: false },
+          threadId: 'th-9',
+        }),
+      },
+    });
+    expect(result.reply).toContain('feature');
+    expect(result.reply).toContain('<#th-9>');
+  });
 });
 
 describe('/shell command', () => {
@@ -500,7 +538,21 @@ describe('/shell command', () => {
 describe('/help lists the extended command set', () => {
   it('mentions queue, fork, share, resume, worktrees and mention-mode', async () => {
     const { result } = await run('/help');
-    for (const cmd of ['/queue', '/fork', '/share', '/resume', '/new-worktree', '/merge-worktree', '/mention-mode', '/clear-queue', '/session', '/shell']) {
+    for (const cmd of [
+      '/queue',
+      '/fork',
+      '/share',
+      '/resume',
+      '/new-worktree',
+      '/merge-worktree',
+      '/list-worktrees',
+      '/open-worktree',
+      '/worktree-status',
+      '/mention-mode',
+      '/clear-queue',
+      '/session',
+      '/shell',
+    ]) {
       expect(result.reply).toContain(cmd);
     }
   });

--- a/packages/web/server/lib/otto-api/messenger-opencode-bridge.js
+++ b/packages/web/server/lib/otto-api/messenger-opencode-bridge.js
@@ -31,6 +31,8 @@ import {
   sanitizeWorktreeName,
   MERGE_CONFLICT_PROMPT,
 } from './messenger-worktrees.js';
+import { createMessengerWorktreeSync } from './messenger-worktree-sync.js';
+import { resolvePrimaryWorktreeRoot } from '../git/service.js';
 import parser from 'cron-parser';
 
 /**
@@ -572,8 +574,20 @@ export function createMessengerOpencodeBridge({
    * timers after the Discord `/schedule` command mutates its tasks.
    */
   scheduledTasksRuntime = null,
+  /**
+   * Resolve a project's Discord channel from persisted bindings.
+   * Signature: ({ discord, projectPath }) => { channelId, projectLabel } | null
+   */
+  resolveProjectChannel = null,
 }) {
   const bridgeStore = store ?? new MessengerBridgeStore();
+  const worktreeSync = createMessengerWorktreeSync({
+    store: bridgeStore,
+    readSettings,
+    persistSettings,
+    broadcastEvent,
+    resolveProjectChannel,
+  });
 
   /**
    * Resolve the OpenChamber-wide default model/agent (Settings → Defaults).
@@ -1313,6 +1327,16 @@ export function createMessengerOpencodeBridge({
     // No explicit title — OpenCode auto-generates one from the first
     // message and the bridge renames the Discord thread to match.
     const sessionId = await createOpencodeSession({ projectPath: effectivePath });
+    const projectRoot = effectivePath
+      ? (await resolvePrimaryWorktreeRoot(effectivePath).catch(() => ({ root: effectivePath }))).root
+      : null;
+    const normalizedPath = effectivePath?.replace(/\\/g, '/').replace(/\/+$/, '') ?? null;
+    const normalizedRoot = projectRoot?.replace(/\\/g, '/').replace(/\/+$/, '') ?? null;
+    const isWorktree =
+      normalizedPath &&
+      normalizedRoot &&
+      normalizedPath !== normalizedRoot &&
+      (await worktreeSync.isWorktreeDirectory(normalizedPath, normalizedRoot).catch(() => false));
     bridgeStore.bind({
       type,
       botTokenHash: hash,
@@ -1320,7 +1344,15 @@ export function createMessengerOpencodeBridge({
       sessionId,
       projectPath: effectivePath,
       projectLabel: effectiveLabel,
+      projectRoot: normalizedRoot,
+      worktreePath: isWorktree ? normalizedPath : null,
+      branch: null,
     });
+    void worktreeSync.handleSessionDirectoryBound({
+      sessionId,
+      directory: effectivePath,
+      projectLabel: effectiveLabel,
+    }).catch(() => undefined);
     broadcastEvent?.('messenger.bridge.session_bound', {
       type,
       channelId,
@@ -2195,6 +2227,34 @@ export function createMessengerOpencodeBridge({
           // best-effort — fall through to creating a fresh thread
         }
         if (!threadId) {
+          const hash = tokenHash(token);
+          let worktreeThreadId = null;
+          if (effectiveProjectPath) {
+            try {
+              const root = (
+                await resolvePrimaryWorktreeRoot(effectiveProjectPath).catch(() => ({
+                  root: effectiveProjectPath,
+                }))
+              ).root;
+              const isWorktree = await worktreeSync
+                .isWorktreeDirectory(effectiveProjectPath, root)
+                .catch(() => false);
+              if (isWorktree) {
+                const ensured = await worktreeSync.ensureWorktreeThread({
+                  projectRoot: root,
+                  worktreePath: effectiveProjectPath,
+                  sessionId,
+                  projectLabel: target.projectLabel ?? null,
+                });
+                if (ensured.ok && ensured.threadId) worktreeThreadId = ensured.threadId;
+              }
+            } catch {
+              // best-effort
+            }
+          }
+          if (worktreeThreadId) {
+            threadId = worktreeThreadId;
+          } else {
           // Thread name preference: the OpenCode-generated session title (when
           // it already exists — title generation often finishes before the
           // mirror thread is created), then the user's first line, then a
@@ -2244,6 +2304,7 @@ export function createMessengerOpencodeBridge({
           }
           // If thread creation failed, threadId stays null and we post into
           // the channel directly — degraded but functional.
+          }
         }
       }
 
@@ -3130,7 +3191,7 @@ export function createMessengerOpencodeBridge({
      * Used by /resume, /fork and /new-worktree. When the command ran inside
      * a thread we hop up to the parent channel first.
      */
-    const createBoundThread = async ({ name, sessionId, projectPath, projectLabel }) => {
+    const createBoundThread = async ({ name, sessionId, projectPath, projectLabel, projectRoot = null, worktreePath = null, branch = null }) => {
       let hostChannelId = channelId;
       const parentId = await resolveParentChannelId({ token, channelId });
       if (parentId) hostChannelId = parentId;
@@ -3143,6 +3204,16 @@ export function createMessengerOpencodeBridge({
       if (!thread.ok || !thread.threadId) {
         return { ok: false, error: thread.error ?? 'thread creation failed' };
       }
+      const normalizedPath = projectPath?.replace(/\\/g, '/').replace(/\/+$/, '') ?? null;
+      const normalizedRoot =
+        projectRoot?.replace(/\\/g, '/').replace(/\/+$/, '') ??
+        (normalizedPath
+          ? (await resolvePrimaryWorktreeRoot(normalizedPath).catch(() => ({ root: normalizedPath }))).root
+          : null);
+      const normalizedWorktree = worktreePath?.replace(/\\/g, '/').replace(/\/+$/, '') ?? null;
+      const effectiveWorktree =
+        normalizedWorktree ??
+        (normalizedPath && normalizedRoot && normalizedPath !== normalizedRoot ? normalizedPath : null);
       bridgeStore.bind({
         type,
         botTokenHash: hash,
@@ -3150,7 +3221,27 @@ export function createMessengerOpencodeBridge({
         sessionId,
         projectPath: projectPath ?? null,
         projectLabel: projectLabel ?? null,
+        projectRoot: normalizedRoot,
+        worktreePath: effectiveWorktree,
+        branch: branch ?? null,
       });
+      if (effectiveWorktree && normalizedRoot) {
+        bridgeStore.bindWorktree?.({
+          botTokenHash: hash,
+          projectRoot: normalizedRoot,
+          worktreePath: effectiveWorktree,
+          branch: branch ?? (name.replace(/^⬦\s*worktree:\s*/i, '').trim() || null),
+          channelId: hostChannelId,
+          threadId: thread.threadId,
+        });
+        void worktreeSync
+          .refreshProjectHub({
+            config: await worktreeSync.loadDiscordConfig(),
+            projectRoot: normalizedRoot,
+            projectLabel,
+          })
+          .catch(() => undefined);
+      }
       return { ok: true, threadId: thread.threadId };
     };
 
@@ -3408,10 +3499,13 @@ export function createMessengerOpencodeBridge({
       },
 
       async newWorktree({ name }) {
-        const projectPath = stored?.projectPath ?? null;
-        if (!projectPath) return { ok: false, error: 'no project bound to this conversation.' };
+        const boundPath = stored?.projectPath ?? null;
+        if (!boundPath) return { ok: false, error: 'no project bound to this conversation.' };
+        const projectRoot = (
+          await resolvePrimaryWorktreeRoot(boundPath).catch(() => ({ root: boundPath }))
+        ).root;
         const effectiveName = sanitizeWorktreeName(name || `wt-${Date.now().toString(36)}`);
-        const created = await createBridgeWorktree({ projectPath, name: effectiveName });
+        const created = await createBridgeWorktree({ projectPath: projectRoot, name: effectiveName });
         if (!created.ok) return created;
 
         // Bind a fresh session running inside the worktree to a new thread.
@@ -3427,6 +3521,9 @@ export function createMessengerOpencodeBridge({
           sessionId,
           projectPath: created.path,
           projectLabel: `${stored?.projectLabel ?? 'project'} (${created.branch})`,
+          projectRoot,
+          worktreePath: created.path,
+          branch: created.branch,
         });
         if (!thread.ok) {
           return { ok: false, error: `worktree + session ready, but thread creation failed: ${thread.error}` };
@@ -3525,10 +3622,106 @@ export function createMessengerOpencodeBridge({
 
       describeSchedule,
 
+      async listWorktrees() {
+        const boundPath = stored?.projectPath ?? null;
+        if (!boundPath) return { ok: false, error: 'no project bound to this conversation.' };
+        const projectRoot = (
+          await resolvePrimaryWorktreeRoot(boundPath).catch(() => ({ root: boundPath }))
+        ).root;
+        const config = await worktreeSync.loadDiscordConfig();
+        if (!config) return { ok: false, error: 'discord is not configured.' };
+        const worktrees = await worktreeSync.listProjectWorktreesForBindings(config, projectRoot);
+        return { ok: true, projectRoot, worktrees };
+      },
+
+      async openWorktree({ query }) {
+        const boundPath = stored?.projectPath ?? null;
+        if (!boundPath) return { ok: false, error: 'no project bound to this conversation.' };
+        const projectRoot = (
+          await resolvePrimaryWorktreeRoot(boundPath).catch(() => ({ root: boundPath }))
+        ).root;
+        const worktrees = await worktreeSync.listProjectWorktrees(projectRoot);
+        const match = worktreeSync.findWorktreeMatch(worktrees, query);
+        if (!match) {
+          return { ok: false, error: `no worktree matched "${query}". Run \`/list-worktrees\` to see options.` };
+        }
+        let sessionId = stored?.sessionId ?? null;
+        if (!sessionId) {
+          try {
+            sessionId = await createOpencodeSession({ projectPath: match.path });
+          } catch (err) {
+            return { ok: false, error: `session creation failed: ${err?.message ?? 'unknown'}` };
+          }
+        }
+        const ensured = await worktreeSync.ensureWorktreeThread({
+          projectRoot,
+          worktreePath: match.path,
+          branch: match.branch,
+          label: match.label,
+          sessionId,
+          projectLabel: stored?.projectLabel ?? null,
+        });
+        if (!ensured.ok) return ensured;
+        const hash = tokenHash(token);
+        bridgeStore.bind({
+          type,
+          botTokenHash: hash,
+          targetKey: targetKey({ type, channelId, threadId: ensured.threadId }),
+          sessionId,
+          projectPath: match.path,
+          projectLabel: `${stored?.projectLabel ?? 'project'} (${match.branch})`,
+          projectRoot,
+          worktreePath: match.path,
+          branch: match.branch,
+        });
+        return {
+          ok: true,
+          path: match.path,
+          branch: match.branch,
+          threadId: ensured.threadId,
+          created: ensured.created ?? false,
+        };
+      },
+
+      async worktreeStatus() {
+        const worktreeDir = stored?.projectPath ?? null;
+        if (!worktreeDir) return { ok: false, error: 'no project bound to this conversation.' };
+        const projectRoot = (
+          await resolvePrimaryWorktreeRoot(worktreeDir).catch(() => ({ root: worktreeDir }))
+        ).root;
+        const isWorktree = await worktreeSync.isWorktreeDirectory(worktreeDir, projectRoot);
+        const status = await worktreeSync.readWorktreeGitStatus(worktreeDir);
+        const binding = bridgeStore.lookupWorktreeByPath?.({
+          botTokenHash: hash,
+          worktreePath: worktreeDir,
+        });
+        return {
+          ok: true,
+          path: worktreeDir,
+          projectRoot,
+          isWorktree,
+          branch: stored?.branch ?? status.branch ?? null,
+          status,
+          threadId: binding?.threadId ?? null,
+        };
+      },
+
       async mergeWorktree() {
         const worktreeDir = stored?.projectPath ?? null;
         if (!worktreeDir) return { ok: false, error: 'no project bound to this conversation.' };
         const result = await mergeBridgeWorktree({ worktreeDir });
+        if (result.ok) {
+          const projectRoot = (
+            await resolvePrimaryWorktreeRoot(worktreeDir).catch(() => ({ root: worktreeDir }))
+          ).root;
+          void worktreeSync
+            .handleWorktreeMerged({
+              project: { path: projectRoot, label: stored?.projectLabel ?? null },
+              worktree: { path: worktreeDir, branch: stored?.branch ?? null },
+              summary: result.summary ?? null,
+            })
+            .catch(() => undefined);
+        }
         if (result.ok || !result.conflict) return result;
 
         // Conflict — hand resolution to the model.
@@ -4749,6 +4942,7 @@ export function createMessengerOpencodeBridge({
     getMentionMode,
     /** Whether a surface already has a session binding (mention mode skips bound threads). */
     hasSurfaceBinding,
+    worktreeSync,
     /** Test seam — exposed so tests can drive events without an SSE stream. */
     _handleGlobalEvent: handleGlobalEvent,
     /** Test seam — run one thread-title polling sweep. */

--- a/packages/web/server/lib/otto-api/messenger-sync.js
+++ b/packages/web/server/lib/otto-api/messenger-sync.js
@@ -359,6 +359,9 @@ export function createMessengerSyncRouter({
                 }
               }
             : null,
+          resolveProjectChannel: readSettings
+            ? ({ discord, projectPath }) => resolveProjectChannel({ discord, projectPath })
+            : null,
         })
       : null;
   if (bridge) {
@@ -1249,6 +1252,15 @@ export function createMessengerSyncRouter({
           upsertBinding(bindings, { channelId, projectPath: project.path, projectLabel }),
           discordSettings,
         );
+        if (bridge?.worktreeSync) {
+          void bridge.worktreeSync
+            .refreshProjectHub({
+              config: await bridge.worktreeSync.loadDiscordConfig(),
+              projectRoot: project.path,
+              projectLabel,
+            })
+            .catch(() => undefined);
+        }
       } else {
         results.push({ type: 'discord', ok: false, error: error ?? 'create-channel failed' });
       }
@@ -1441,6 +1453,95 @@ export function createMessengerSyncRouter({
   });
 
   /**
+   * UI created a worktree → ensure a Discord thread + refresh the project hub index.
+   * Body: {
+   *   project: { id?, path, label? },
+   *   worktree: { path, branch?, label? },
+   *   sessionId?: string,
+   *   discord?: { token, guildId?, parentCategoryId? }
+   * }
+   */
+  router.post('/bridge/worktree-added', async (req, res) => {
+    const { project, worktree, sessionId } = req.body ?? {};
+    if (!project?.path || !worktree?.path) {
+      return res.status(400).json({ ok: false, error: 'project.path and worktree.path required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const result = await bridge.worktreeSync.handleWorktreeAdded({ project, worktree, sessionId });
+    res.json(result);
+  });
+
+  /**
+   * UI removed a worktree → archive its Discord thread and refresh the hub index.
+   */
+  router.post('/bridge/worktree-removed', async (req, res) => {
+    const { project, worktree } = req.body ?? {};
+    if (!worktree?.path) {
+      return res.status(400).json({ ok: false, error: 'worktree.path required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const result = await bridge.worktreeSync.handleWorktreeRemoved({ project, worktree });
+    res.json(result);
+  });
+
+  /**
+   * Worktree merged (UI integrate flow or Discord command) → post summary, archive thread.
+   */
+  router.post('/bridge/worktree-merged', async (req, res) => {
+    const { project, worktree, summary } = req.body ?? {};
+    if (!worktree?.path) {
+      return res.status(400).json({ ok: false, error: 'worktree.path required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const result = await bridge.worktreeSync.handleWorktreeMerged({ project, worktree, summary });
+    res.json(result);
+  });
+
+  /**
+   * Lookup the Discord URL for a worktree path (UI helper).
+   */
+  router.get('/bridge/worktree-discord-url', async (req, res) => {
+    const worktreePath = typeof req.query?.path === 'string' ? req.query.path : null;
+    if (!worktreePath) {
+      return res.status(400).json({ ok: false, error: 'path query parameter required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const discordUrl = await bridge.worktreeSync.lookupWorktreeDiscordUrl(worktreePath);
+    if (!discordUrl) {
+      return res.json({ ok: false, error: 'no Discord thread is bound to this worktree' });
+    }
+    return res.json({ ok: true, discordUrl, path: worktreePath });
+  });
+
+  /**
+   * Refresh the pinned worktree index message for a project channel.
+   */
+  router.post('/bridge/worktree-refresh-index', async (req, res) => {
+    const { project } = req.body ?? {};
+    if (!project?.path) {
+      return res.status(400).json({ ok: false, error: 'project.path required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const config = await bridge.worktreeSync.loadDiscordConfig();
+    const result = await bridge.worktreeSync.refreshProjectHub({
+      config,
+      projectRoot: project.path,
+      projectLabel: project.label ?? null,
+    });
+    res.json(result);
+  });
+
+  /**
    * Bootstrap a new OpenChamber project from a Discord conversation
    * (or programmatically). Body: { action: 'clone'|'path'|'new', url?, path?, label? }.
    * Returns { ok, project } on success or { ok: false, error } on failure.
@@ -1596,7 +1697,7 @@ export function createMessengerSyncRouter({
    * Body matches the start endpoint: { botToken, guildId, autoReply, scopeToGuild, bridgeEnabled, defaultChannelId }.
    */
   router.post('/discord/save-config', async (req, res) => {
-    const { botToken, guildId, autoReply, scopeToGuild, bridgeEnabled, defaultChannelId, defaultUserId, projectBindings } =
+    const { botToken, guildId, autoReply, scopeToGuild, bridgeEnabled, defaultChannelId, defaultUserId, projectBindings, syncWorktrees } =
       req.body ?? {};
     try {
       // Merge with the previous discord block so this best-effort save (fired
@@ -1623,6 +1724,7 @@ export function createMessengerSyncRouter({
           bridgeEnabled: bridgeEnabled !== false,
           defaultChannelId: defaultChannelId || prev.defaultChannelId || undefined,
           defaultUserId: defaultUserId || prev.defaultUserId || undefined,
+          syncWorktrees: syncWorktrees !== false,
           projectBindings:
             normalizedBindings && normalizedBindings.length > 0
               ? normalizedBindings

--- a/packages/web/server/lib/otto-api/messenger-worktree-sync.js
+++ b/packages/web/server/lib/otto-api/messenger-worktree-sync.js
@@ -1,0 +1,636 @@
+/**
+ * Discord ↔ git worktree sync for the OpenChamber messenger bridge.
+ *
+ * Mirrors the UI worktree model in Discord: one project channel, one thread per
+ * worktree, plus a hub index message listing active worktrees.
+ */
+
+import crypto from 'node:crypto';
+import {
+  getStatus,
+  getWorktrees,
+  resolvePrimaryWorktreeRoot,
+} from '../git/service.js';
+
+const WORKTREE_PREFIX = '⬦ ';
+const DISCORD_THREAD_NAME_MAX = 100;
+const DISCORD_TOPIC_MAX = 1024;
+const DISCORD_MESSAGE_MAX = 2000;
+
+function normalizePath(value) {
+  if (typeof value !== 'string' || !value.trim()) return '';
+  const replaced = value.replace(/\\/g, '/');
+  if (replaced === '/') return '/';
+  return replaced.length > 1 ? replaced.replace(/\/+$/, '') : replaced;
+}
+
+function pathsEqual(a, b) {
+  const left = normalizePath(a);
+  const right = normalizePath(b);
+  return Boolean(left && right && left === right);
+}
+
+function tokenHash(token) {
+  return crypto.createHash('sha256').update(String(token)).digest('hex').slice(0, 12);
+}
+
+function hubIndexSettingKey(projectRoot) {
+  return `worktree-index:${normalizePath(projectRoot)}`;
+}
+
+/** Format a Discord thread title for a worktree. */
+export function formatWorktreeThreadName({ branch, label, statusSummary = null }) {
+  const base = String(branch || label || 'worktree').trim() || 'worktree';
+  const withPrefix = `${WORKTREE_PREFIX}${base}`;
+  const full = statusSummary ? `${withPrefix} (${statusSummary})` : withPrefix;
+  return full.slice(0, DISCORD_THREAD_NAME_MAX);
+}
+
+/** Summarise git status for thread titles / index rows. */
+export function summarizeWorktreeGitStatus(status) {
+  if (!status || typeof status !== 'object') return null;
+  const parts = [];
+  const ahead = Number(status.ahead);
+  const behind = Number(status.behind);
+  if (Number.isFinite(ahead) && ahead > 0) parts.push(`+${ahead}`);
+  if (Number.isFinite(behind) && behind > 0) parts.push(`-${behind}`);
+  if (status.isDirty || status.dirty) parts.push('dirty');
+  return parts.length > 0 ? parts.join('·') : 'clean';
+}
+
+async function discordFetch(path, { token, method = 'GET', body = null } = {}) {
+  const headers = { Authorization: `Bot ${token}` };
+  if (body != null) headers['Content-Type'] = 'application/json';
+  const response = await fetch(`https://discord.com/api/v10${path}`, {
+    method,
+    headers,
+    body: body != null ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(15_000),
+  });
+  const text = await response.text().catch(() => '');
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { ok: response.ok, status: response.status, json, text };
+}
+
+async function addThreadMembers({ token, threadId, userIds }) {
+  const ids = Array.isArray(userIds) ? userIds : userIds ? [userIds] : [];
+  for (const userId of ids.filter(Boolean)) {
+    await discordFetch(`/channels/${encodeURIComponent(threadId)}/thread-members/${encodeURIComponent(userId)}`, {
+      token,
+      method: 'PUT',
+    }).catch(() => undefined);
+  }
+}
+
+async function startStandaloneThread({ token, channelId, name, userIds }) {
+  const safeName = (name || 'Otto worktree').replace(/\s+/g, ' ').slice(0, 90) || 'Otto worktree';
+  const result = await discordFetch(`/channels/${encodeURIComponent(channelId)}/threads`, {
+    token,
+    method: 'POST',
+    body: { name: safeName, type: 11, auto_archive_duration: 1440 },
+  });
+  if (!result.ok) {
+    return { ok: false, error: `Discord ${result.status}: ${result.text.slice(0, 200)}` };
+  }
+  const threadId = result.json?.id ?? null;
+  if (threadId && userIds) await addThreadMembers({ token, threadId, userIds });
+  return { ok: true, threadId, threadName: result.json?.name ?? safeName };
+}
+
+async function deleteThread({ token, threadId }) {
+  if (!threadId) return { ok: false, error: 'no thread id' };
+  const result = await discordFetch(`/channels/${encodeURIComponent(threadId)}`, {
+    token,
+    method: 'DELETE',
+  });
+  if (result.ok || result.status === 404) return { ok: true };
+  return { ok: false, error: `Discord ${result.status}: ${result.text.slice(0, 200)}` };
+}
+
+async function renameThread({ token, threadId, name }) {
+  if (!threadId || !name) return { ok: false };
+  const result = await discordFetch(`/channels/${encodeURIComponent(threadId)}`, {
+    token,
+    method: 'PATCH',
+    body: { name: name.slice(0, DISCORD_THREAD_NAME_MAX) },
+  });
+  return { ok: result.ok, error: result.ok ? null : result.text.slice(0, 200) };
+}
+
+async function postChannelMessage({ token, channelId, content }) {
+  const result = await discordFetch(`/channels/${encodeURIComponent(channelId)}/messages`, {
+    token,
+    method: 'POST',
+    body: { content: String(content).slice(0, DISCORD_MESSAGE_MAX) },
+  });
+  if (!result.ok) return { ok: false, error: result.text.slice(0, 200) };
+  return { ok: true, messageId: result.json?.id ?? null };
+}
+
+async function editChannelMessage({ token, channelId, messageId, content }) {
+  const result = await discordFetch(
+    `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}`,
+    {
+      token,
+      method: 'PATCH',
+      body: { content: String(content).slice(0, DISCORD_MESSAGE_MAX) },
+    },
+  );
+  if (!result.ok) return { ok: false, error: result.text.slice(0, 200) };
+  return { ok: true, messageId };
+}
+
+async function patchChannelTopic({ token, channelId, topic }) {
+  const result = await discordFetch(`/channels/${encodeURIComponent(channelId)}`, {
+    token,
+    method: 'PATCH',
+    body: { topic: String(topic).slice(0, DISCORD_TOPIC_MAX) },
+  });
+  return { ok: result.ok, error: result.ok ? null : result.text.slice(0, 200) };
+}
+
+export function createMessengerWorktreeSync({
+  store,
+  readSettings = null,
+  persistSettings = null,
+  broadcastEvent = null,
+  resolveProjectChannel = null,
+} = {}) {
+  if (!store) {
+    throw new Error('messenger worktree sync requires a bridge store');
+  }
+
+  async function loadDiscordConfig() {
+    if (typeof readSettings !== 'function') return null;
+    try {
+      const settings = await readSettings();
+      const discord = settings?.discord ?? null;
+      if (!discord?.botToken) return null;
+      return {
+        token: discord.botToken,
+        guildId: discord.guildId ?? null,
+        defaultUserId: discord.defaultUserId ?? null,
+        syncWorktrees: discord.syncWorktrees !== false,
+        syncProjects: discord.syncProjects !== false,
+        projectBindings: Array.isArray(discord.projectBindings) ? discord.projectBindings : [],
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  function isSyncEnabled(config) {
+    return Boolean(config?.token && config.syncWorktrees !== false && config.syncProjects !== false);
+  }
+
+  async function resolveProjectRoot(directory) {
+    const normalized = normalizePath(directory);
+    if (!normalized) return null;
+    try {
+      const resolved = await resolvePrimaryWorktreeRoot(normalized);
+      return normalizePath(resolved?.root ?? normalized);
+    } catch {
+      return normalized;
+    }
+  }
+
+  async function isWorktreeDirectory(directory, projectRoot = null) {
+    const normalized = normalizePath(directory);
+    const root = normalizePath(projectRoot ?? (await resolveProjectRoot(normalized)));
+    if (!normalized || !root || pathsEqual(normalized, root)) return false;
+    try {
+      const entries = await getWorktrees(root);
+      return entries.some((entry) => pathsEqual(entry.path, normalized));
+    } catch {
+      return false;
+    }
+  }
+
+  async function readWorktreeGitStatus(worktreePath) {
+    try {
+      const status = await getStatus(worktreePath, { mode: 'light' });
+      return {
+        isDirty: status?.isClean === false,
+        ahead: Number(status?.ahead) || 0,
+        behind: Number(status?.behind) || 0,
+        branch: typeof status?.branch === 'string' ? status.branch : null,
+      };
+    } catch {
+      return { isDirty: false, ahead: 0, behind: 0, branch: null };
+    }
+  }
+
+  async function listProjectWorktrees(projectRoot) {
+    const root = normalizePath(projectRoot);
+    if (!root) return [];
+    const entries = await getWorktrees(root).catch(() => []);
+    const secondary = entries.filter((entry) => entry?.path && !pathsEqual(entry.path, root));
+    const results = [];
+    for (const entry of secondary) {
+      const path = normalizePath(entry.path);
+      const branch = String(entry.branch || '').replace(/^refs\/heads\//, '').trim();
+      const status = await readWorktreeGitStatus(path);
+      const binding = store.lookupWorktreeByPath?.({
+        botTokenHash: null,
+        worktreePath: path,
+      });
+      results.push({
+        path,
+        branch: branch || status.branch || path.split('/').pop(),
+        label: branch || path.split('/').pop(),
+        status,
+        threadId: binding?.threadId ?? null,
+      });
+    }
+    results.sort((a, b) => a.branch.localeCompare(b.branch));
+    return results;
+  }
+
+  function findWorktreeMatch(worktrees, query) {
+    const needle = String(query ?? '').trim().toLowerCase();
+    if (!needle) return null;
+    return (
+      worktrees.find((wt) => wt.branch.toLowerCase() === needle) ??
+      worktrees.find((wt) => wt.path.toLowerCase().endsWith(`/${needle}`)) ??
+      worktrees.find((wt) => wt.branch.toLowerCase().includes(needle)) ??
+      worktrees.find((wt) => wt.path.toLowerCase().includes(needle)) ??
+      null
+    );
+  }
+
+  function resolveChannelForProject(config, projectRoot) {
+    if (typeof resolveProjectChannel === 'function') {
+      const resolved = resolveProjectChannel({ discord: config, projectPath: projectRoot });
+      if (resolved?.channelId) return resolved;
+    }
+    const binding = config.projectBindings.find(
+      (row) => row?.channelId && pathsEqual(row.projectPath, projectRoot),
+    );
+    if (binding?.channelId) {
+      return { channelId: String(binding.channelId), projectLabel: binding.projectLabel ?? null };
+    }
+    return null;
+  }
+
+  function readHubIndexState(projectRoot) {
+    const raw = store.getSetting?.(hubIndexSettingKey(projectRoot));
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed?.channelId && parsed?.messageId) return parsed;
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+
+  function writeHubIndexState(projectRoot, { channelId, messageId }) {
+    if (!channelId || !messageId) {
+      store.setSetting?.(hubIndexSettingKey(projectRoot), null);
+      return;
+    }
+    store.setSetting?.(
+      hubIndexSettingKey(projectRoot),
+      JSON.stringify({ channelId: String(channelId), messageId: String(messageId) }),
+    );
+  }
+
+  async function buildWorktreeIndexContent({ projectRoot, projectLabel, worktrees }) {
+    const lines = [`**Worktrees** — ${projectLabel ?? projectRoot}`, ''];
+    if (!worktrees || worktrees.length === 0) {
+      lines.push('_(no active worktrees — create one in the UI or with `/new-worktree`)_');
+    } else {
+      for (const wt of worktrees) {
+        const statusText = summarizeWorktreeGitStatus(wt.status) ?? 'unknown';
+        const link = wt.threadId ? `<#${wt.threadId}>` : '_no thread_';
+        lines.push(`• \`${wt.branch}\` — ${statusText} → ${link}`);
+      }
+    }
+    lines.push('', '_Updated automatically by OpenChamber._');
+    return lines.join('\n').slice(0, DISCORD_MESSAGE_MAX);
+  }
+
+  async function refreshProjectHub({ config, projectRoot, projectLabel = null }) {
+    if (!isSyncEnabled(config)) return { ok: false, skipped: true };
+    const channel = resolveChannelForProject(config, projectRoot);
+    if (!channel?.channelId) return { ok: false, error: 'no project channel' };
+
+    const worktrees = await listProjectWorktreesForBindings(config, projectRoot);
+    const content = await buildWorktreeIndexContent({
+      projectRoot,
+      projectLabel: projectLabel ?? channel.projectLabel ?? projectRoot.split('/').pop(),
+      worktrees,
+    });
+
+    const hub = readHubIndexState(projectRoot);
+    let messageId = hub?.messageId ?? null;
+    if (messageId && hub?.channelId === channel.channelId) {
+      const edited = await editChannelMessage({
+        token: config.token,
+        channelId: channel.channelId,
+        messageId,
+        content,
+      });
+      if (!edited.ok) messageId = null;
+    }
+    if (!messageId) {
+      const posted = await postChannelMessage({
+        token: config.token,
+        channelId: channel.channelId,
+        content,
+      });
+      if (!posted.ok) return { ok: false, error: posted.error ?? 'post failed' };
+      messageId = posted.messageId;
+      writeHubIndexState(projectRoot, { channelId: channel.channelId, messageId });
+    }
+
+    const defaultBranch = worktrees[0]?.status?.branch ?? 'main';
+    const topic = `OpenChamber · ${worktrees.length} worktree${worktrees.length === 1 ? '' : 's'} · ${projectLabel ?? projectRoot.split('/').pop()}`
+      .slice(0, DISCORD_TOPIC_MAX);
+    await patchChannelTopic({ token: config.token, channelId: channel.channelId, topic }).catch(() => undefined);
+
+    broadcastEvent?.('messenger.bridge.worktree_index_updated', {
+      projectRoot,
+      channelId: channel.channelId,
+      worktreeCount: worktrees.length,
+    });
+
+    return { ok: true, messageId, worktreeCount: worktrees.length, topic };
+  }
+
+  async function listProjectWorktreesForBindings(config, projectRoot) {
+    const hash = tokenHash(config.token);
+    const bound = store.listWorktreesForProject?.({ botTokenHash: hash, projectRoot }) ?? [];
+    const boundByPath = new Map(bound.map((row) => [normalizePath(row.worktreePath), row]));
+    const discovered = await listProjectWorktrees(projectRoot);
+    return discovered.map((wt) => {
+      const binding = boundByPath.get(normalizePath(wt.path));
+      return {
+        ...wt,
+        threadId: binding?.threadId ?? wt.threadId ?? null,
+        branch: binding?.branch ?? wt.branch,
+      };
+    });
+  }
+
+  async function ensureWorktreeThread({
+    projectRoot,
+    worktreePath,
+    branch,
+    label = null,
+    sessionId = null,
+    projectLabel = null,
+    config: configOverride = null,
+  }) {
+    const config = configOverride ?? (await loadDiscordConfig());
+    if (!isSyncEnabled(config)) return { ok: false, skipped: true, reason: 'sync-disabled' };
+
+    const root = normalizePath(projectRoot ?? (await resolveProjectRoot(worktreePath)));
+    const path = normalizePath(worktreePath);
+    if (!root || !path) return { ok: false, error: 'invalid paths' };
+
+    const channel = resolveChannelForProject(config, root);
+    if (!channel?.channelId) return { ok: false, error: 'no project channel mapped' };
+
+    const hash = tokenHash(config.token);
+    const existing = store.lookupWorktreeByPath?.({ botTokenHash: hash, worktreePath: path });
+    if (existing?.threadId) {
+      if (sessionId) {
+        store.bind?.({
+          type: 'discord',
+          botTokenHash: hash,
+          targetKey: String(existing.threadId),
+          sessionId,
+          projectPath: path,
+          projectLabel: projectLabel ?? `${channel.projectLabel ?? 'project'} (${existing.branch ?? branch ?? 'worktree'})`,
+          projectRoot: root,
+          worktreePath: path,
+          branch: existing.branch ?? branch ?? null,
+        });
+      }
+      return { ok: true, threadId: existing.threadId, created: false, channelId: existing.channelId };
+    }
+
+    const status = await readWorktreeGitStatus(path);
+    const effectiveBranch = branch || status.branch || label || path.split('/').pop();
+    const threadName = formatWorktreeThreadName({
+      branch: effectiveBranch,
+      label,
+      statusSummary: summarizeWorktreeGitStatus(status),
+    });
+
+    const created = await startStandaloneThread({
+      token: config.token,
+      channelId: channel.channelId,
+      name: threadName,
+      userIds: config.defaultUserId,
+    });
+    if (!created.ok || !created.threadId) {
+      return { ok: false, error: created.error ?? 'thread creation failed' };
+    }
+
+    store.bindWorktree?.({
+      botTokenHash: hash,
+      projectRoot: root,
+      worktreePath: path,
+      branch: effectiveBranch,
+      channelId: channel.channelId,
+      threadId: created.threadId,
+    });
+
+    if (sessionId) {
+      store.bind?.({
+        type: 'discord',
+        botTokenHash: hash,
+        targetKey: String(created.threadId),
+        sessionId,
+        projectPath: path,
+        projectLabel: projectLabel ?? `${channel.projectLabel ?? 'project'} (${effectiveBranch})`,
+        projectRoot: root,
+        worktreePath: path,
+        branch: effectiveBranch,
+      });
+    }
+
+    await refreshProjectHub({ config, projectRoot: root, projectLabel: channel.projectLabel ?? projectLabel });
+    broadcastEvent?.('messenger.bridge.worktree_thread_created', {
+      projectRoot: root,
+      worktreePath: path,
+      branch: effectiveBranch,
+      threadId: created.threadId,
+      channelId: channel.channelId,
+      source: sessionId ? 'session' : 'worktree',
+    });
+
+    return {
+      ok: true,
+      threadId: created.threadId,
+      channelId: channel.channelId,
+      created: true,
+      branch: effectiveBranch,
+    };
+  }
+
+  async function removeWorktreeThread({ worktreePath, projectRoot = null, archiveOnly = true }) {
+    const config = await loadDiscordConfig();
+    if (!config?.token) return { ok: false, error: 'discord not configured' };
+    const hash = tokenHash(config.token);
+    const path = normalizePath(worktreePath);
+    const binding = store.lookupWorktreeByPath?.({ botTokenHash: hash, worktreePath: path });
+    if (!binding?.threadId) {
+      store.unbindWorktree?.({ botTokenHash: hash, worktreePath: path });
+      return { ok: true, removed: false };
+    }
+
+    if (archiveOnly) {
+      await deleteThread({ token: config.token, threadId: binding.threadId }).catch(() => undefined);
+    }
+    store.unbindWorktree?.({ botTokenHash: hash, worktreePath: path });
+
+    const root = normalizePath(projectRoot ?? binding.projectRoot);
+    if (root) {
+      await refreshProjectHub({ config, projectRoot: root });
+    }
+
+    broadcastEvent?.('messenger.bridge.worktree_thread_removed', {
+      projectRoot: root,
+      worktreePath: path,
+      threadId: binding.threadId,
+    });
+
+    return { ok: true, removed: true, threadId: binding.threadId };
+  }
+
+  async function handleWorktreeAdded({
+    project,
+    worktree,
+    sessionId = null,
+  }) {
+    const config = await loadDiscordConfig();
+    if (!isSyncEnabled(config)) return { ok: true, skipped: true };
+
+    const projectRoot = normalizePath(project?.path);
+    const worktreePath = normalizePath(worktree?.path);
+    if (!projectRoot || !worktreePath) return { ok: false, error: 'project and worktree paths required' };
+
+    return ensureWorktreeThread({
+      projectRoot,
+      worktreePath,
+      branch: worktree?.branch ?? worktree?.label ?? null,
+      label: worktree?.label ?? null,
+      sessionId,
+      projectLabel: project?.label ?? null,
+      config,
+    });
+  }
+
+  async function handleWorktreeRemoved({ project, worktree }) {
+    const projectRoot = normalizePath(project?.path);
+    const worktreePath = normalizePath(worktree?.path);
+    if (!worktreePath) return { ok: false, error: 'worktree path required' };
+    return removeWorktreeThread({ worktreePath, projectRoot });
+  }
+
+  async function handleWorktreeMerged({ project, worktree, summary = null }) {
+    const config = await loadDiscordConfig();
+    const projectRoot = normalizePath(project?.path);
+    const worktreePath = normalizePath(worktree?.path);
+    const hash = config?.token ? tokenHash(config.token) : null;
+    const binding =
+      hash && worktreePath
+        ? store.lookupWorktreeByPath?.({ botTokenHash: hash, worktreePath })
+        : null;
+
+    if (binding?.threadId && config?.token) {
+      const content = summary
+        ? `✓ ${summary}\n\n_This worktree thread will be archived._`
+        : '✓ Worktree merged into the default branch.\n\n_This worktree thread will be archived._';
+      await postChannelMessage({
+        token: config.token,
+        channelId: binding.threadId,
+        content,
+      }).catch(() => undefined);
+    }
+
+    const removed = await removeWorktreeThread({ worktreePath, projectRoot });
+    if (projectRoot && config) {
+      await refreshProjectHub({ config, projectRoot, projectLabel: project?.label ?? null });
+    }
+    return removed;
+  }
+
+  async function handleSessionDirectoryBound({
+    sessionId,
+    directory,
+    projectLabel = null,
+    title = null,
+  }) {
+    const config = await loadDiscordConfig();
+    if (!isSyncEnabled(config) || !sessionId || !directory) return { ok: true, skipped: true };
+
+    const path = normalizePath(directory);
+    const root = await resolveProjectRoot(path);
+    if (!root || pathsEqual(path, root)) return { ok: true, skipped: true };
+    const isWorktree = await isWorktreeDirectory(path, root);
+    if (!isWorktree) return { ok: true, skipped: true };
+
+    const result = await ensureWorktreeThread({
+      projectRoot: root,
+      worktreePath: path,
+      branch: null,
+      label: title,
+      sessionId,
+      projectLabel,
+      config,
+    });
+
+    if (result.ok && result.threadId && title) {
+      const status = await readWorktreeGitStatus(path);
+      const threadName = formatWorktreeThreadName({
+        branch: result.branch ?? status.branch,
+        label: title,
+        statusSummary: summarizeWorktreeGitStatus(status),
+      });
+      await renameThread({ token: config.token, threadId: result.threadId, name: threadName }).catch(() => undefined);
+    }
+
+    return result;
+  }
+
+  async function lookupWorktreeDiscordUrl(worktreePath) {
+    const config = await loadDiscordConfig();
+    if (!config?.token || !config.guildId) return null;
+    const binding = store.lookupWorktreeByPath?.({
+      botTokenHash: tokenHash(config.token),
+      worktreePath: normalizePath(worktreePath),
+    });
+    if (!binding?.threadId) return null;
+    return `https://discord.com/channels/${config.guildId}/${binding.threadId}`;
+  }
+
+  return {
+    isSyncEnabled,
+    loadDiscordConfig,
+    resolveProjectRoot,
+    isWorktreeDirectory,
+    listProjectWorktrees,
+    listProjectWorktreesForBindings,
+    findWorktreeMatch,
+    formatWorktreeThreadName,
+    summarizeWorktreeGitStatus,
+    ensureWorktreeThread,
+    removeWorktreeThread,
+    refreshProjectHub,
+    handleWorktreeAdded,
+    handleWorktreeRemoved,
+    handleWorktreeMerged,
+    handleSessionDirectoryBound,
+    lookupWorktreeDiscordUrl,
+    readWorktreeGitStatus,
+  };
+}

--- a/packages/web/server/lib/otto-api/messenger-worktree-sync.test.js
+++ b/packages/web/server/lib/otto-api/messenger-worktree-sync.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatWorktreeThreadName,
+  summarizeWorktreeGitStatus,
+} from './messenger-worktree-sync.js';
+
+describe('formatWorktreeThreadName', () => {
+  it('prefixes worktree branches and caps length', () => {
+    expect(formatWorktreeThreadName({ branch: 'feature-auth' })).toBe('⬦ feature-auth');
+    expect(formatWorktreeThreadName({ branch: 'feature-auth', statusSummary: '+2·dirty' })).toBe(
+      '⬦ feature-auth (+2·dirty)',
+    );
+  });
+});
+
+describe('summarizeWorktreeGitStatus', () => {
+  it('summarises ahead/behind/dirty state', () => {
+    expect(summarizeWorktreeGitStatus({ ahead: 2, behind: 1, isDirty: true })).toBe('+2·-1·dirty');
+    expect(summarizeWorktreeGitStatus({ ahead: 0, behind: 0, isDirty: false })).toBe('clean');
+    expect(summarizeWorktreeGitStatus(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements full Discord ↔ worktree parity so git worktrees used heavily in the UI are also visible and navigable in Discord.

### Phase 1 — Bidirectional lifecycle sync
- New `messenger_worktree_bindings` SQLite table mapping `worktree_path → thread_id`
- Extended session bindings with `project_root`, `worktree_path`, and `branch`
- UI hooks in `worktreeManager` notify Discord on create/delete via `/api/otto/messenger/bridge/worktree-*`
- `/new-worktree` now resolves the **primary project root** before creating (avoids nested worktrees)

### Phase 2 — Discovery commands
- `/list-worktrees` — list worktrees with git status + thread links
- `/open-worktree <branch>` — bind to an existing UI-created worktree
- `/worktree-status` — show git state for the current conversation
- Registered as native Discord slash commands too

### Phase 3 — Project channel hub
- Auto-maintained **Worktrees index message** per project channel (edited in place)
- Channel topic updated with active worktree count

### Phase 4 — Session event hooks
- Web sessions in worktrees reuse/create the worktree thread (not a generic session thread)
- New Discord sessions in worktrees trigger `handleSessionDirectoryBound`
- `/merge-worktree` archives the thread and refreshes the hub

### Phase 5 — Settings & UI
- **Sync worktrees to Discord threads** toggle in Messenger settings
- **Open in Discord** link on worktree rows in Settings → Worktrees

## Architecture

```
Project channel (#my-project)
├── pinned: Worktrees index message
├── thread: ⬦ feature-auth
└── thread: ⬦ fix-login
```

Git remains the source of truth for worktree existence; the bridge store only holds Discord mappings.

## Testing

- `bun test` on `messenger-worktree-sync`, `messenger-bridge-store`, `messenger-commands`, `messenger-worktrees`
- Web package lint passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eece0a20-b8f0-4690-a3d3-f463921759f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eece0a20-b8f0-4690-a3d3-f463921759f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

