### PR TITLE
fix(discord): sync UI worktrees and sessions to Discord threads

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -261,14 +261,14 @@
     },
     "packages/web": {
       "name": "@openchamber/web",
-      "version": "1.13.8",
+      "version": "1.16.3",
       "bin": {
         "openchamber": "./bin/cli.js",
       },
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@octokit/rest": "^22.0.1",
-        "@opencode-ai/sdk": "^1.17.12",
+        "@opencode-ai/sdk": "1.18.4",
         "@simplewebauthn/server": "13.3.1",
         "adm-zip": "^0.5.16",
         "better-sqlite3": "^12.10.0",
@@ -284,6 +284,7 @@
         "openai": "^4.79.0",
         "qrcode-terminal": "^0.12.0",
         "reflect-metadata": "^0.2.2",
+        "sherpa-onnx-node": "1.12.28",
         "simple-git": "^3.28.0",
         "web-push": "^3.6.7",
         "ws": "^8.18.3",
@@ -294,9 +295,6 @@
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-go": "^6.0.1",
         "@eslint/js": "^9.33.0",
-        "@fontsource/ibm-plex-mono": "^5.2.7",
-        "@fontsource/ibm-plex-sans": "^5.1.1",
-        "@ibm/plex": "^6.4.1",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -775,10 +773,6 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
-    "@fontsource/ibm-plex-mono": ["@fontsource/ibm-plex-mono@5.3.0", "", {}, "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q=="],
-
-    "@fontsource/ibm-plex-sans": ["@fontsource/ibm-plex-sans@5.3.0", "", {}, "sha512-CbE4CbbEEZJX860XyUiRpsksXIQR8Rp2XDva2VO53NJox9tVNtusrysd2x5YkUEY3ErQ66W1IiiQL8/wihhw5w=="],
-
     "@formatjs/ecma402-abstract": ["@formatjs/ecma402-abstract@2.3.6", "", { "dependencies": { "@formatjs/fast-memoize": "2.2.7", "@formatjs/intl-localematcher": "0.6.2", "decimal.js": "^10.4.3", "tslib": "^2.8.0" } }, "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw=="],
 
     "@formatjs/fast-memoize": ["@formatjs/fast-memoize@2.2.7", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ=="],
@@ -818,10 +812,6 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
-
-    "@ibm/plex": ["@ibm/plex@6.4.1", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.1" } }, "sha512-fnsipQywHt3zWvsnlyYKMikcVI7E2fEwpiPnIHFqlbByXVfQfANAAeJk1IV4mNnxhppUIDlhU0TzwYwL++Rn2g=="],
-
-    "@ibm/telemetry-js": ["@ibm/telemetry-js@1.11.0", "", { "bin": { "ibmtelemetry": "dist/collect.js" } }, "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -2996,6 +2986,20 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "sherpa-onnx-darwin-arm64": ["sherpa-onnx-darwin-arm64@1.13.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QcYKzyrTzGSx6aKCD6hUODgRS1LetqfG57Z/+i5LCyfMlrgCvDc1lRcl9cdB+TozBsLha9QwLTlI0vmDcf5JKg=="],
+
+    "sherpa-onnx-darwin-x64": ["sherpa-onnx-darwin-x64@1.13.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-6RGeis9K9gV/UQWOgd6Rf3iqXr2/YsBQswxHaCR4hrYkHfEIpHMfFmRWLt6nJJCOWgYW2xFxEd9yzjrafAV/Pw=="],
+
+    "sherpa-onnx-linux-arm64": ["sherpa-onnx-linux-arm64@1.13.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-RMjMRqT82BgTXypNNGmLe6ZFYhc3WEvnAGl3DdkK7qB/kuXwkL3iHhV31wAecbnWPsnEpUoD+8cFovWSBzsCuw=="],
+
+    "sherpa-onnx-linux-x64": ["sherpa-onnx-linux-x64@1.13.4", "", { "os": "linux", "cpu": "x64" }, "sha512-WZh5NCkGPFHHpYSd78iN4OnmxQeSTGyt9uZskH+im/NFHQ7elQ7B0sLzCMeRpvJxiIKvd9C6WxIJ4hYaxClfsQ=="],
+
+    "sherpa-onnx-node": ["sherpa-onnx-node@1.12.28", "", { "optionalDependencies": { "sherpa-onnx-darwin-arm64": "^1.12.28", "sherpa-onnx-darwin-x64": "^1.12.28", "sherpa-onnx-linux-arm64": "^1.12.28", "sherpa-onnx-linux-x64": "^1.12.28", "sherpa-onnx-win-ia32": "^1.12.28", "sherpa-onnx-win-x64": "^1.12.28" } }, "sha512-EHSB3EG6hKyXaTNh6GU/bwh6i3dncCH6ZCU2mScNzkxRbVStZ7QmNj0Oo4E9XrGGo9jX9pKg9MPHEPyjdK+ApA=="],
+
+    "sherpa-onnx-win-ia32": ["sherpa-onnx-win-ia32@1.13.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-/JbPjldrfNv+t+uIS3MlkuhfIf5l3FHUGkRC2oRXgjRqOaVmEyP3vLlQ7dTa4J7raG5oB8c3GoPjuSWSqT9GOQ=="],
+
+    "sherpa-onnx-win-x64": ["sherpa-onnx-win-x64@1.13.4", "", { "os": "win32", "cpu": "x64" }, "sha512-R0PWby1VxC14TDZPq7GcfSyXSY6SAFO8Y4JwdCdqouFmeXkZ1L7Is9m98C9KxQ0dN7ZtDzhAmE/43FUs/elXRQ=="],
 
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 

--- a/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
@@ -687,6 +687,9 @@ function BehaviorPanel({
   const setBridgeCritiqueEnabled = useMessengerStore((s) => s.setBridgeCritiqueEnabled);
   const bridgeInterruptTimeoutMs = useMessengerStore((s) => s.bridgeInterruptTimeoutMs);
   const setBridgeInterruptTimeoutMs = useMessengerStore((s) => s.setBridgeInterruptTimeoutMs);
+  const syncWorktrees = useMessengerStore(
+    (s) => s.connections.find((c) => c.type === 'discord')?.syncWorktrees !== false,
+  );
   useEffect(() => {
     refreshBridgeStatus(type);
     const id = setInterval(() => refreshBridgeStatus(type), 8000);
@@ -789,6 +792,27 @@ function BehaviorPanel({
             </span>
             <span className="block text-xs text-muted-foreground leading-snug">
               {t('settings.integrations.discord.bridge.critique.description')}
+            </span>
+          </span>
+        </label>
+      </div>
+
+      <div data-settings-item="integrations.discord.sync-worktrees" className="space-y-1">
+        <label className="flex cursor-pointer items-start gap-2">
+          <Checkbox
+            checked={syncWorktrees}
+            onChange={(checked) => {
+              useMessengerStore.getState().updateConnection('discord', { syncWorktrees: checked });
+              setTimeout(() => useMessengerStore.getState().saveDiscordConfig(), 0);
+            }}
+            ariaLabel={t('settings.integrations.discord.bridge.syncWorktrees.title')}
+          />
+          <span className="min-w-0">
+            <span className="block text-sm font-medium text-foreground">
+              {t('settings.integrations.discord.bridge.syncWorktrees.title')}
+            </span>
+            <span className="block text-xs text-muted-foreground leading-snug">
+              {t('settings.integrations.discord.bridge.syncWorktrees.description')}
             </span>
           </span>
         </label>

--- a/packages/ui/src/components/sections/openchamber/WorktreeSectionContent.tsx
+++ b/packages/ui/src/components/sections/openchamber/WorktreeSectionContent.tsx
@@ -7,6 +7,7 @@ import { SettingsInfoHint } from '@/components/sections/shared/SettingsInfoHint'
 import { Icon } from "@/components/icon/Icon";
 import type { Session } from '@opencode-ai/sdk/v2';
 import { useProjectsStore } from '@/stores/useProjectsStore';
+import { useMessengerStore } from '@/stores/useMessengerStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSessions } from '@/sync/sync-context';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
@@ -34,6 +35,43 @@ export interface WorktreeSectionContentProps {
 }
 
 const SETUP_COMMANDS_SAVE_DELAY_MS = 450;
+
+/** "Open in Discord" link shown when the worktree has a bound Discord thread. */
+const WorktreeDiscordLink: React.FC<{ worktreePath: string }> = ({ worktreePath }) => {
+  const { t } = useI18n();
+  const fetchWorktreeDiscordUrl = useMessengerStore((state) => state.fetchWorktreeDiscordUrl);
+  const syncWorktrees = useMessengerStore(
+    (state) => state.connections.find((connection) => connection.type === 'discord')?.syncWorktrees !== false,
+  );
+  const [discordUrl, setDiscordUrl] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!syncWorktrees) {
+      setDiscordUrl(null);
+      return;
+    }
+    let cancelled = false;
+    void fetchWorktreeDiscordUrl(worktreePath).then((url) => {
+      if (!cancelled) setDiscordUrl(url);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchWorktreeDiscordUrl, syncWorktrees, worktreePath]);
+
+  if (!discordUrl) return null;
+
+  return (
+    <a
+      href={discordUrl}
+      target="_blank"
+      rel="noreferrer"
+      className="typography-micro text-primary hover:underline flex-shrink-0"
+    >
+      {t('settings.openchamber.worktrees.list.openInDiscord')}
+    </a>
+  );
+};
 
 export const WorktreeSectionContent: React.FC<WorktreeSectionContentProps> = ({ projectRef: projectRefProp = null }) => {
   const { t } = useI18n();
@@ -458,6 +496,7 @@ export const WorktreeSectionContent: React.FC<WorktreeSectionContentProps> = ({ 
                   <p className="typography-micro truncate text-muted-foreground/60">
                     {formatPathForDisplay(worktree.path, homeDirectory)}
                   </p>
+                  <WorktreeDiscordLink worktreePath={worktree.path} />
                 </div>
                 <button
                   type="button"

--- a/packages/ui/src/components/session/NewWorktreeDialog.tsx
+++ b/packages/ui/src/components/session/NewWorktreeDialog.tsx
@@ -895,6 +895,28 @@ export function NewWorktreeDialog({
         onOpenChange(false);
         setIsCreating(false);
 
+        // Re-notify Discord with the session id so the worktree thread binds
+        // this session (the createWorktree call above already ensured the
+        // thread without a session).
+        void import('@/stores/useMessengerStore')
+          .then(({ useMessengerStore }) => {
+            const notify = useMessengerStore.getState().notifyWorktreeAdded;
+            void notify(
+              {
+                id: projectRef.id,
+                path: projectRef.path,
+                label: projectRef.path.split('/').pop() ?? projectRef.path,
+              },
+              {
+                path: metadata.path,
+                branch: metadata.branch,
+                label: metadata.label,
+              },
+              createdSessionId,
+            );
+          })
+          .catch(() => undefined);
+
         void sessionActions.updateSessionTitle(session.id, sessionTitle).catch(() => undefined);
 
         try {

--- a/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
@@ -139,6 +139,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.critique.title': 'Share diffs via critique.work',
     'settings.integrations.discord.bridge.critique.description':
       'Uploads your code diffs to critique.work — an external third-party service — to create shareable review links. Off by default.',
+    'settings.integrations.discord.bridge.syncWorktrees.title': 'Sync worktrees to Discord',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      'Mirror git worktrees as threads under each project channel, with a pinned index. On by default.',
     'settings.integrations.discord.bridge.interruptTimeout.title': 'Interrupt timeout',
     'settings.integrations.discord.bridge.interruptTimeout.description':
       'How long to wait for an interrupted turn to settle before sending the superseding prompt. Default is 8000 ms.',
@@ -392,6 +395,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.notifyOnComplete.description': 'Si está activado, Discord menciona al último usuario que envió un prompt después de que termine una respuesta real del asistente. Desactivado por defecto.',
     'settings.integrations.discord.bridge.critique.title': 'Compartir diffs vía critique.work',
     'settings.integrations.discord.bridge.critique.description': 'Sube tus diffs de código a critique.work, un servicio externo de terceros, para crear enlaces de revisión compartibles. Desactivado por defecto.',
+    'settings.integrations.discord.bridge.syncWorktrees.title': 'Sincronizar worktrees con Discord',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      'Refleja los worktrees de git como hilos dentro del canal de cada proyecto, con un índice fijado. Activado por defecto.',
     'settings.integrations.discord.bridge.interruptTimeout.title': 'Tiempo de espera de interrupción',
     'settings.integrations.discord.bridge.interruptTimeout.description': 'Cuánto esperar a que un turno interrumpido se estabilice antes de enviar el prompt que lo reemplaza. El valor predeterminado es 8000 ms.',
     'settings.integrations.discord.bridge.interruptTimeout.unit': 'ms',
@@ -642,6 +648,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.notifyOnComplete.description': 'Lorsque cette option est activée, Discord mentionne le dernier utilisateur ayant envoyé un prompt après la fin d’une vraie réponse de l’assistant. Désactivé par défaut.',
     'settings.integrations.discord.bridge.critique.title': 'Partager les diffs via critique.work',
     'settings.integrations.discord.bridge.critique.description': 'Envoie vos diffs de code vers critique.work — un service tiers externe — pour créer des liens de révision partageables. Désactivé par défaut.',
+    'settings.integrations.discord.bridge.syncWorktrees.title': 'Synchroniser les worktrees avec Discord',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      'Reflète les worktrees git en fils sous le canal de chaque projet, avec un index épinglé. Activé par défaut.',
     'settings.integrations.discord.bridge.interruptTimeout.title': 'Délai d’interruption',
     'settings.integrations.discord.bridge.interruptTimeout.description': 'Durée d’attente pour qu’un tour interrompu se stabilise avant l’envoi du prompt de remplacement. Par défaut : 8000 ms.',
     'settings.integrations.discord.bridge.interruptTimeout.unit': 'ms',
@@ -892,6 +901,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.notifyOnComplete.description': '有効にすると、実際のアシスタント応答が完了した後、Discord が最後にプロンプトを送ったユーザーをメンションします。既定ではオフです。',
     'settings.integrations.discord.bridge.critique.title': 'critique.work で diff を共有',
     'settings.integrations.discord.bridge.critique.description': 'コードの diff を外部サードパーティサービス critique.work にアップロードし、共有可能なレビューリンクを作成します。既定ではオフです。',
+    'settings.integrations.discord.bridge.syncWorktrees.title': 'worktree を Discord に同期',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      'git worktree を各プロジェクトチャンネル内のスレッドとして同期し、ピン留めされたインデックスを表示します。デフォルトで有効。',
     'settings.integrations.discord.bridge.interruptTimeout.title': '割り込みタイムアウト',
     'settings.integrations.discord.bridge.interruptTimeout.description': '中断されたターンが落ち着くまで、置き換えプロンプトを送る前に待つ時間です。既定は 8000 ms です。',
     'settings.integrations.discord.bridge.interruptTimeout.unit': 'ms',
@@ -1142,6 +1154,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.notifyOnComplete.description': '활성화하면 실제 어시스턴트 응답이 끝난 뒤 Discord가 마지막으로 프롬프트를 보낸 사용자를 멘션합니다. 기본값은 꺼짐입니다.',
     'settings.integrations.discord.bridge.critique.title': 'critique.work로 diff 공유',
     'settings.integrations.discord.bridge.critique.description': '코드 diff를 외부 타사 서비스인 critique.work에 업로드하여 공유 가능한 리뷰 링크를 만듭니다. 기본값은 꺼짐입니다.',
+    'settings.integrations.discord.bridge.syncWorktrees.title': 'worktree를 Discord에 동기화',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      'git worktree를 각 프로젝트 채널의 스레드로 미러링하고 고정된 인덱스를 표시합니다. 기본적으로 활성화됨.',
     'settings.integrations.discord.bridge.interruptTimeout.title': '인터럽트 제한 시간',
     'settings.integrations.discord.bridge.interruptTimeout.description': '중단된 턴이 안정될 때까지 대체 프롬프트를 보내기 전에 기다리는 시간입니다. 기본값은 8000 ms입니다.',
     'settings.integrations.discord.bridge.interruptTimeout.unit': 'ms',
@@ -1392,6 +1407,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.notifyOnComplete.description': 'Gdy włączone, Discord wspomina ostatniego użytkownika, który wysłał prompt, po zakończeniu rzeczywistej odpowiedzi asystenta. Domyślnie wyłączone.',
     'settings.integrations.discord.bridge.critique.title': 'Udostępniaj diffy przez critique.work',
     'settings.integrations.discord.bridge.critique.description': 'Wysyła diffy kodu do critique.work — zewnętrznej usługi firmy trzeciej — aby tworzyć linki do przeglądu, które można udostępniać. Domyślnie wyłączone.',
+    'settings.integrations.discord.bridge.syncWorktrees.title': 'Synchronizuj worktree z Discordem',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      'Odzwierciedla worktree git jako wątki w kanale każdego projektu, z przypiętym indeksem. Domyślnie włączone.',
     'settings.integrations.discord.bridge.interruptTimeout.title': 'Limit czasu przerwania',
     'settings.integrations.discord.bridge.interruptTimeout.description': 'Jak długo czekać, aż przerwany krok się ustabilizuje, zanim zostanie wysłany zastępujący prompt. Domyślnie 8000 ms.',
     'settings.integrations.discord.bridge.interruptTimeout.unit': 'ms',
@@ -1642,6 +1660,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.notifyOnComplete.description': 'Quando ativado, o Discord menciona o último usuário que enviou um prompt depois que uma resposta real do assistente termina. Desativado por padrão.',
     'settings.integrations.discord.bridge.critique.title': 'Compartilhar diffs via critique.work',
     'settings.integrations.discord.bridge.critique.description': 'Envia seus diffs de código para o critique.work — um serviço externo de terceiros — para criar links de revisão compartilháveis. Desativado por padrão.',
+    'settings.integrations.discord.bridge.syncWorktrees.title': 'Sincronizar worktrees com o Discord',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      'Espelha worktrees git como threads no canal de cada projeto, com um índice fixado. Ativado por padrão.',
     'settings.integrations.discord.bridge.interruptTimeout.title': 'Tempo limite de interrupção',
     'settings.integrations.discord.bridge.interruptTimeout.description': 'Quanto tempo esperar um turno interrompido estabilizar antes de enviar o prompt substituto. O padrão é 8000 ms.',
     'settings.integrations.discord.bridge.interruptTimeout.unit': 'ms',
@@ -1891,6 +1912,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.notifyOnComplete.description': '启用后，Discord 会在真实助手回复完成后提及最后发送提示词的用户。默认关闭。',
     'settings.integrations.discord.bridge.critique.title': '通过 critique.work 分享 diff',
     'settings.integrations.discord.bridge.critique.description': '将你的代码 diff 上传到外部第三方服务 critique.work，以创建可分享的审阅链接。默认关闭。',
+    'settings.integrations.discord.bridge.syncWorktrees.title': '将 worktree 同步到 Discord',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      '将 git worktree 镜像为每个项目频道下的线程，并显示置顶索引。默认启用。',
     'settings.integrations.discord.bridge.interruptTimeout.title': '中断超时',
     'settings.integrations.discord.bridge.interruptTimeout.description': '在发送替代提示词前，等待被中断回合稳定的时间。默认 8000 ms。',
     'settings.integrations.discord.bridge.interruptTimeout.unit': 'ms',
@@ -2137,6 +2161,9 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.bridge.notifyOnComplete.description': '啟用後，Discord 會在真正的助理回覆完成後提及最後送出提示詞的使用者。預設關閉。',
     'settings.integrations.discord.bridge.critique.title': '透過 critique.work 分享 diff',
     'settings.integrations.discord.bridge.critique.description': '將你的程式碼 diff 上傳到外部第三方服務 critique.work，以建立可分享的審閱連結。預設關閉。',
+    'settings.integrations.discord.bridge.syncWorktrees.title': '將 worktree 同步到 Discord',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      '將 git worktree 鏡像為每個專案頻道下的討論串，並顯示置頂索引。預設啟用。',
     'settings.integrations.discord.bridge.interruptTimeout.title': '中斷逾時',
     'settings.integrations.discord.bridge.interruptTimeout.description': '送出取代提示詞前，等待被中斷回合穩定的時間。預設為 8000 ms。',
     'settings.integrations.discord.bridge.interruptTimeout.unit': 'ms',
@@ -2400,6 +2427,9 @@ export const discordIntegrationI18n = {
       'Коли увімкнено, Discord згадує останнього користувача, який надіслав промпт, після завершення реальної відповіді асистента. Типово вимкнено.',
     'settings.integrations.discord.bridge.critique.title': 'Ділитися diff через critique.work',
     'settings.integrations.discord.bridge.critique.description': 'Надсилає ваші diff-зміни коду до critique.work — зовнішнього стороннього сервісу — для створення посилань на рецензію, якими можна ділитися. Типово вимкнено.',
+    'settings.integrations.discord.bridge.syncWorktrees.title': 'Синхронізувати worktree з Discord',
+    'settings.integrations.discord.bridge.syncWorktrees.description':
+      'Відображає git worktree як гілки в каналі кожного проєкту, із закріпленим індексом. Увімкнено за замовчуванням.',
     'settings.integrations.discord.bridge.interruptTimeout.title': 'Таймаут переривання',
     'settings.integrations.discord.bridge.interruptTimeout.description':
       'Скільки чекати, поки перервана відповідь завершиться, перед надсиланням нового промпта. Типово 8000 мс.',

--- a/packages/ui/src/lib/i18n/messages/en.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/en.settings.ts
@@ -1290,6 +1290,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': 'No worktrees found for this project',
   'settings.openchamber.worktrees.list.detachedHead': 'Detached HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'Delete worktree {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Open in Discord',
   'settings.agents.modelSelector.title': 'Select model',
   'settings.agents.modelSelector.searchPlaceholder': 'Search models',
   'settings.agents.modelSelector.selectPlaceholder': 'Select model...',

--- a/packages/ui/src/lib/i18n/messages/es.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/es.settings.ts
@@ -1257,6 +1257,7 @@ export const settingsDict = {
   "settings.openchamber.worktrees.list.empty": "No se encontraron worktrees para este proyecto",
   "settings.openchamber.worktrees.list.detachedHead": "HEAD desvinculado",
   "settings.openchamber.worktrees.list.deleteWorktreeAria": "Eliminar worktree {name}",
+  "settings.openchamber.worktrees.list.openInDiscord": "Abrir en Discord",
   "settings.agents.modelSelector.title": "Seleccionar modelo",
   "settings.agents.modelSelector.searchPlaceholder": "Buscar modelos",
   "settings.agents.modelSelector.selectPlaceholder": "Seleccionar modelo...",

--- a/packages/ui/src/lib/i18n/messages/fr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.settings.ts
@@ -1178,6 +1178,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': 'Aucun worktree trouvé pour ce projet',
   'settings.openchamber.worktrees.list.detachedHead': 'HEAD détaché',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'Supprimer le worktree {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Ouvrir dans Discord',
   'settings.agents.modelSelector.title': 'Sélectionnez le modèle',
   'settings.agents.modelSelector.searchPlaceholder': 'Rechercher des modèles',
   'settings.agents.modelSelector.selectPlaceholder': 'Sélectionnez le modèle...',

--- a/packages/ui/src/lib/i18n/messages/ja.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.settings.ts
@@ -1290,6 +1290,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': 'このプロジェクトに Worktree は見つかりません',
   'settings.openchamber.worktrees.list.detachedHead': '分離 HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'Worktree {name} を削除',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Discord で開く',
   'settings.agents.modelSelector.title': 'モデルを選択',
   'settings.agents.modelSelector.searchPlaceholder': 'モデルを検索',
   'settings.agents.modelSelector.selectPlaceholder': 'モデルを選択...',

--- a/packages/ui/src/lib/i18n/messages/ko.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.settings.ts
@@ -1257,6 +1257,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': '이 프로젝트의 worktree를 찾을 수 없습니다',
   'settings.openchamber.worktrees.list.detachedHead': 'Detached HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'worktree {name} 삭제',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Discord에서 열기',
   'settings.agents.modelSelector.title': '모델 선택',
   'settings.agents.modelSelector.searchPlaceholder': '모델 검색',
   'settings.agents.modelSelector.selectPlaceholder': '모델 선택...',

--- a/packages/ui/src/lib/i18n/messages/pl.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.settings.ts
@@ -1182,6 +1182,7 @@ export const settingsDict = {
   'settings.openchamber.visual.section.userMessageRendering': 'Renderowanie wiadomości użytkownika',
   'settings.openchamber.visual.section.userMessageRenderingAria': 'Tryb renderowania wiadomości użytkownika',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': 'Usuń worktree {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': 'Otwórz w Discordzie',
   'settings.openchamber.worktrees.list.detachedHead': 'Odłączony HEAD',
   'settings.openchamber.worktrees.list.empty': 'Nie znaleziono worktree dla tego projektu',
   'settings.openchamber.worktrees.list.loading': 'Ładowanie worktree...',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
@@ -1257,6 +1257,7 @@ export const settingsDict = {
   "settings.openchamber.worktrees.list.empty": "Nenhum worktree encontrado para este projeto",
   "settings.openchamber.worktrees.list.detachedHead": "HEAD desvinculado",
   "settings.openchamber.worktrees.list.deleteWorktreeAria": "Excluir worktree {name}",
+  "settings.openchamber.worktrees.list.openInDiscord": "Abrir no Discord",
   "settings.agents.modelSelector.title": "Selecionar modelo",
   "settings.agents.modelSelector.searchPlaceholder": "Pesquisar modelos",
   "settings.agents.modelSelector.selectPlaceholder": "Selecionar modelo...",

--- a/packages/ui/src/lib/i18n/messages/uk.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.settings.ts
@@ -1257,6 +1257,7 @@ export const settingsDict = {
   "settings.openchamber.worktrees.list.empty": "Для цього проєкту не знайдено worktree",
   "settings.openchamber.worktrees.list.detachedHead": "Відокремлено HEAD",
   "settings.openchamber.worktrees.list.deleteWorktreeAria": "Видалити worktree {name}",
+  "settings.openchamber.worktrees.list.openInDiscord": "Відкрити в Discord",
   "settings.agents.modelSelector.title": "Виберіть модель",
   "settings.agents.modelSelector.searchPlaceholder": "Пошук моделей",
   "settings.agents.modelSelector.selectPlaceholder": "Виберіть модель...",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
@@ -1257,6 +1257,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': '该项目未找到工作树',
   'settings.openchamber.worktrees.list.detachedHead': '分离 HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': '删除工作树 {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': '在 Discord 中打开',
   'settings.agents.modelSelector.title': '选择模型',
   'settings.agents.modelSelector.searchPlaceholder': '搜索模型',
   'settings.agents.modelSelector.selectPlaceholder': '选择模型...',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
@@ -1163,6 +1163,7 @@ export const settingsDict = {
   'settings.openchamber.worktrees.list.empty': '該專案找不到 worktree',
   'settings.openchamber.worktrees.list.detachedHead': '分離 HEAD',
   'settings.openchamber.worktrees.list.deleteWorktreeAria': '刪除 worktree {name}',
+  'settings.openchamber.worktrees.list.openInDiscord': '在 Discord 中開啟',
   'settings.agents.modelSelector.title': '選擇模型',
   'settings.agents.modelSelector.searchPlaceholder': '搜尋模型',
   'settings.agents.modelSelector.selectPlaceholder': '選擇模型...',

--- a/packages/ui/src/lib/worktrees/worktreeManager.ts
+++ b/packages/ui/src/lib/worktrees/worktreeManager.ts
@@ -460,6 +460,27 @@ export async function createWorktree(project: ProjectRef, args: CreateWorktreeAr
     availableWorktrees: [...useSessionUIStore.getState().availableWorktrees, metadata],
   });
 
+  // Mirror the new worktree into Discord (thread under the project channel).
+  // Best-effort: dynamic import keeps the messenger store out of the hot path
+  // and the notify no-ops unless Discord worktree sync is configured.
+  void import('@/stores/useMessengerStore')
+    .then(({ useMessengerStore }) => {
+      const notify = useMessengerStore.getState().notifyWorktreeAdded;
+      void notify(
+        {
+          id: project.id,
+          path: metadataProjectDirectory,
+          label: metadataProjectDirectory.split('/').pop() ?? metadataProjectDirectory,
+        },
+        {
+          path: metadata.path,
+          branch: metadata.branch,
+          label: metadata.label,
+        },
+      );
+    })
+    .catch(() => undefined);
+
   return metadata;
 }
 
@@ -526,4 +547,19 @@ export async function removeProjectWorktree(project: ProjectRef, worktree: Workt
   if (deleteRemote && branchName) {
     await deleteRemoteBranch(projectDirectory, { branch: branchName, remote: remoteName }).catch(() => undefined);
   }
+
+  // Archive the worktree's Discord thread (best-effort).
+  void import('@/stores/useMessengerStore')
+    .then(({ useMessengerStore }) => {
+      const notify = useMessengerStore.getState().notifyWorktreeRemoved;
+      void notify(
+        { id: project.id, path: project.path, label: project.path.split('/').pop() ?? project.path },
+        {
+          path: worktree.path,
+          branch: worktree.branch,
+          label: worktree.label,
+        },
+      );
+    })
+    .catch(() => undefined);
 }

--- a/packages/ui/src/stores/useMessengerStore.ts
+++ b/packages/ui/src/stores/useMessengerStore.ts
@@ -179,6 +179,8 @@ export interface MessengerConnection {
   // Sync config
   syncMode: SyncMode;
   syncProjects: boolean;
+  /** Mirror git worktrees to Discord threads under each project channel. */
+  syncWorktrees: boolean;
   syncTasks: boolean;
   syncSchedule: boolean;
   autoCreateThreads: boolean;
@@ -451,6 +453,28 @@ interface MessengerState {
   ensureProjectChannel: (project: ProjectEntry) => Promise<void>;
   renameProjectChannel: (project: ProjectEntry) => Promise<void>;
   removeProjectChannel: (projectId: string, projectPath: string) => Promise<void>;
+  /**
+   * Worktree lifecycle → Discord thread sync. Called when the UI creates /
+   * removes / merges a worktree so each worktree gets (or loses) its own
+   * thread under the project channel. Best-effort: no-ops unless Discord is
+   * configured and worktree sync is enabled.
+   */
+  notifyWorktreeAdded: (
+    project: ProjectEntry,
+    worktree: { path: string; branch?: string; label?: string },
+    sessionId?: string | null,
+  ) => Promise<void>;
+  notifyWorktreeRemoved: (
+    project: ProjectEntry,
+    worktree: { path: string; branch?: string; label?: string },
+  ) => Promise<void>;
+  notifyWorktreeMerged: (
+    project: ProjectEntry,
+    worktree: { path: string; branch?: string; label?: string },
+    summary?: string | null,
+  ) => Promise<void>;
+  /** Resolve the Discord thread URL for a worktree (null when none is bound). */
+  fetchWorktreeDiscordUrl: (worktreePath: string) => Promise<string | null>;
   startOnboarding: (type: MessengerType) => void;
   nextOnboardingStep: () => void;
   prevOnboardingStep: () => void;
@@ -467,6 +491,7 @@ const DEFAULT_CONNECTION: Omit<MessengerConnection, 'type'> = {
   lastSyncMessage: null,
   syncMode: 'full',
   syncProjects: true,
+  syncWorktrees: true,
   syncTasks: true,
   syncSchedule: true,
   autoCreateThreads: true,
@@ -505,6 +530,50 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
 async function getJson<T>(url: string): Promise<T> {
   const res = await runtimeFetch(url);
   return parseRuntimeJson<T>(res, url);
+}
+
+/**
+ * Full Discord context for the bridge worktree endpoints: the server merges
+ * this with its own settings.json values, so UI-side bindings and the default
+ * channel resolve even before a "Sync now" round persisted them.
+ */
+function buildDiscordBridgePayload(
+  conn: MessengerConnection,
+  projectMappings: ProjectMessengerMapping[],
+): {
+  token: string;
+  guildId?: string;
+  parentCategoryId?: string;
+  defaultUserId?: string;
+  defaultChannelId?: string;
+  syncWorktrees: boolean;
+  projectBindings: { channelId: string; projectPath: string; projectLabel?: string }[];
+} {
+  const projects = useProjectsStore.getState().projects;
+  const projectBindings = projectMappings.flatMap((m) => {
+    if (!m.discord?.channelId) return [];
+    const project = projects.find((p) => p.id === m.projectId);
+    if (!project) return [];
+    return [
+      {
+        channelId: m.discord.channelId,
+        projectPath: project.path,
+        projectLabel: project.label ?? project.path,
+      },
+    ];
+  });
+  const syncGuildId = getDiscordSyncGuildIds(conn)[0];
+  return {
+    token: conn.botToken!,
+    guildId: syncGuildId ?? conn.discordGuildId,
+    parentCategoryId: syncGuildId
+      ? (conn.discordGuildPolicies?.[syncGuildId]?.parentCategoryId ?? conn.discordParentCategoryId)
+      : conn.discordParentCategoryId,
+    defaultUserId: conn.defaultUserId,
+    defaultChannelId: conn.defaultChannelId,
+    syncWorktrees: conn.syncWorktrees !== false,
+    projectBindings,
+  };
 }
 
 /** Dedupes concurrent resync calls from hydration + reconnect + settings mount. */
@@ -1411,6 +1480,7 @@ export const useMessengerStore = create<MessengerState>()(
             projectBindings,
             defaultReplyMode: conn.discordDefaultReplyMode ?? 'always',
             guildPolicies: conn.discordGuildPolicies ?? {},
+            syncWorktrees: conn.syncWorktrees !== false,
           });
         } catch {
           // silent — config save is best-effort
@@ -2049,6 +2119,65 @@ export const useMessengerStore = create<MessengerState>()(
         }
         get().removeProjectMapping(projectId);
         get().saveDiscordConfig();
+      },
+
+      notifyWorktreeAdded: async (project, worktree, sessionId = null) => {
+        const conn = get().connections.find((c) => c.type === 'discord');
+        // Only the bot token + the worktree-sync flag gate this — a project
+        // channel mapping (or the default channel) is resolved server-side.
+        if (!conn?.botToken || conn.syncWorktrees === false) return;
+        try {
+          await postJson('/api/messenger/bridge/worktree-added', {
+            project: { id: project.id, path: project.path, label: project.label ?? project.path },
+            worktree,
+            sessionId,
+            discord: buildDiscordBridgePayload(conn, get().projectMappings),
+          });
+        } catch {
+          // best-effort
+        }
+      },
+
+      notifyWorktreeRemoved: async (project, worktree) => {
+        const conn = get().connections.find((c) => c.type === 'discord');
+        if (!conn?.botToken || conn.syncWorktrees === false) return;
+        try {
+          await postJson('/api/messenger/bridge/worktree-removed', {
+            project: { id: project.id, path: project.path, label: project.label ?? project.path },
+            worktree,
+            discord: buildDiscordBridgePayload(conn, get().projectMappings),
+          });
+        } catch {
+          // best-effort
+        }
+      },
+
+      notifyWorktreeMerged: async (project, worktree, summary = null) => {
+        const conn = get().connections.find((c) => c.type === 'discord');
+        if (!conn?.botToken || conn.syncWorktrees === false) return;
+        try {
+          await postJson('/api/messenger/bridge/worktree-merged', {
+            project: { id: project.id, path: project.path, label: project.label ?? project.path },
+            worktree,
+            summary,
+            discord: buildDiscordBridgePayload(conn, get().projectMappings),
+          });
+        } catch {
+          // best-effort
+        }
+      },
+
+      fetchWorktreeDiscordUrl: async (worktreePath) => {
+        const conn = get().connections.find((c) => c.type === 'discord');
+        if (!conn?.botToken || conn.syncWorktrees === false) return null;
+        try {
+          const data = await getJson<{ ok?: boolean; discordUrl?: string }>(
+            `/api/messenger/bridge/worktree-discord-url?path=${encodeURIComponent(worktreePath)}`,
+          );
+          return data.ok && data.discordUrl ? data.discordUrl : null;
+        } catch {
+          return null;
+        }
       },
 
       startOnboarding: (type) => {

--- a/packages/vscode/webview/api/index.ts
+++ b/packages/vscode/webview/api/index.ts
@@ -11,7 +11,7 @@ import { createVSCodeNotificationsAPI } from './notifications';
 
 // Stub APIs return sensible defaults instead of throwing
 const createStubTerminalAPI = (): TerminalAPI => ({
-  createSession: async () => ({ sessionId: '', cols: 80, rows: 24 }),
+  createSession: async () => ({ sessionId: '', cols: 80, rows: 24, status: 'running' }),
   connect: () => ({ close: () => {} }),
   sendInput: async () => {},
   resize: async () => {},

--- a/packages/web/server/lib/messenger/messenger-bridge-store.js
+++ b/packages/web/server/lib/messenger/messenger-bridge-store.js
@@ -104,6 +104,9 @@ export class MessengerBridgeStore {
       'verbosity_override TEXT',
       'variant_override TEXT',
       'permission_mode TEXT',
+      'project_root TEXT',
+      'worktree_path TEXT',
+      'branch TEXT',
     ]) {
       try {
         this.db.exec(`ALTER TABLE messenger_session_bindings ADD COLUMN ${col}`);
@@ -111,6 +114,26 @@ export class MessengerBridgeStore {
         // ignore — column already exists
       }
     }
+    // Worktree → Discord thread bindings. One row per git worktree so the UI
+    // ("Open in Discord" link), the hub index message and the /open-worktree
+    // command all resolve the same thread regardless of which surface created
+    // the worktree.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS messenger_worktree_bindings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        bot_token_hash TEXT NOT NULL,
+        project_root TEXT NOT NULL,
+        worktree_path TEXT NOT NULL,
+        branch TEXT,
+        channel_id TEXT NOT NULL,
+        thread_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (bot_token_hash, worktree_path)
+      );
+      CREATE INDEX IF NOT EXISTS idx_messenger_worktree_project
+        ON messenger_worktree_bindings (bot_token_hash, project_root);
+    `);
     // Global bridge settings (key/value). Holds the per-messenger verbosity
     // default (key `verbosity:discord` / `verbosity:telegram`) that the
     // OpenChamber UI writes and the `/verbosity` chat command can override
@@ -328,7 +351,9 @@ export class MessengerBridgeStore {
     const row = this.db
       .prepare(
         `SELECT session_id AS sessionId, project_path AS projectPath,
-                project_label AS projectLabel, created_at AS createdAt,
+                project_label AS projectLabel, project_root AS projectRoot,
+                worktree_path AS worktreePath, branch,
+                created_at AS createdAt,
                 last_used_at AS lastUsedAt,
                 model_override AS modelOverride,
                 agent_override AS agentOverride,
@@ -404,17 +429,37 @@ export class MessengerBridgeStore {
       .run(type, botTokenHash, targetKey);
   }
 
-  bind({ type, botTokenHash, targetKey, sessionId, projectPath, projectLabel }) {
+  bind({
+    type,
+    botTokenHash,
+    targetKey,
+    sessionId,
+    projectPath,
+    projectLabel,
+    projectRoot = undefined,
+    worktreePath = undefined,
+    branch = undefined,
+  }) {
     const now = new Date().toISOString();
+    // Preserve the worktree context when a caller re-binds without it (older
+    // call sites pass only session/project) instead of wiping it.
+    const existing = this.lookup({ type, botTokenHash, targetKey });
+    const nextProjectRoot = projectRoot === undefined ? existing?.projectRoot ?? null : projectRoot;
+    const nextWorktreePath = worktreePath === undefined ? existing?.worktreePath ?? null : worktreePath;
+    const nextBranch = branch === undefined ? existing?.branch ?? null : branch;
     this.db
       .prepare(
         `INSERT INTO messenger_session_bindings
-           (type, target_key, session_id, project_path, project_label, bot_token_hash, created_at, last_used_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           (type, target_key, session_id, project_path, project_label, project_root,
+            worktree_path, branch, bot_token_hash, created_at, last_used_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(type, bot_token_hash, target_key)
          DO UPDATE SET session_id = excluded.session_id,
                        project_path = excluded.project_path,
                        project_label = excluded.project_label,
+                       project_root = excluded.project_root,
+                       worktree_path = excluded.worktree_path,
+                       branch = excluded.branch,
                        last_used_at = excluded.last_used_at`,
       )
       .run(
@@ -423,10 +468,97 @@ export class MessengerBridgeStore {
         sessionId,
         projectPath ?? null,
         projectLabel ?? null,
+        nextProjectRoot,
+        nextWorktreePath,
+        nextBranch,
         botTokenHash,
         now,
         now,
       );
+  }
+
+  bindWorktree({ botTokenHash, projectRoot, worktreePath, branch, channelId, threadId }) {
+    if (!botTokenHash || !projectRoot || !worktreePath || !channelId || !threadId) return;
+    const now = new Date().toISOString();
+    this.db
+      .prepare(
+        `INSERT INTO messenger_worktree_bindings
+           (bot_token_hash, project_root, worktree_path, branch, channel_id, thread_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(bot_token_hash, worktree_path)
+         DO UPDATE SET project_root = excluded.project_root,
+                       branch = excluded.branch,
+                       channel_id = excluded.channel_id,
+                       thread_id = excluded.thread_id,
+                       updated_at = excluded.updated_at`,
+      )
+      .run(
+        botTokenHash,
+        projectRoot,
+        worktreePath,
+        branch ?? null,
+        String(channelId),
+        String(threadId),
+        now,
+        now,
+      );
+  }
+
+  lookupWorktreeByPath({ botTokenHash, worktreePath }) {
+    if (!worktreePath) return null;
+    const params = [worktreePath];
+    let sql = `SELECT project_root AS projectRoot, worktree_path AS worktreePath, branch,
+                      channel_id AS channelId, thread_id AS threadId,
+                      created_at AS createdAt, updated_at AS updatedAt
+                 FROM messenger_worktree_bindings
+                WHERE worktree_path = ?`;
+    if (botTokenHash) {
+      sql += ' AND bot_token_hash = ?';
+      params.push(botTokenHash);
+    }
+    const row = this.db.prepare(sql).get(...params);
+    return row ?? null;
+  }
+
+  lookupWorktreeByThread({ botTokenHash, threadId }) {
+    if (!threadId) return null;
+    const params = [String(threadId)];
+    let sql = `SELECT project_root AS projectRoot, worktree_path AS worktreePath, branch,
+                      channel_id AS channelId, thread_id AS threadId
+                 FROM messenger_worktree_bindings
+                WHERE thread_id = ?`;
+    if (botTokenHash) {
+      sql += ' AND bot_token_hash = ?';
+      params.push(botTokenHash);
+    }
+    const row = this.db.prepare(sql).get(...params);
+    return row ?? null;
+  }
+
+  listWorktreesForProject({ botTokenHash, projectRoot }) {
+    if (!projectRoot) return [];
+    const params = [projectRoot];
+    let sql = `SELECT project_root AS projectRoot, worktree_path AS worktreePath, branch,
+                      channel_id AS channelId, thread_id AS threadId
+                 FROM messenger_worktree_bindings
+                WHERE project_root = ?`;
+    if (botTokenHash) {
+      sql += ' AND bot_token_hash = ?';
+      params.push(botTokenHash);
+    }
+    sql += ' ORDER BY branch ASC';
+    return this.db.prepare(sql).all(...params);
+  }
+
+  unbindWorktree({ botTokenHash, worktreePath }) {
+    if (!worktreePath) return;
+    const params = [worktreePath];
+    let sql = 'DELETE FROM messenger_worktree_bindings WHERE worktree_path = ?';
+    if (botTokenHash) {
+      sql += ' AND bot_token_hash = ?';
+      params.push(botTokenHash);
+    }
+    this.db.prepare(sql).run(...params);
   }
 
   touch({ type, botTokenHash, targetKey }) {

--- a/packages/web/server/lib/messenger/messenger-bridge-store.test.js
+++ b/packages/web/server/lib/messenger/messenger-bridge-store.test.js
@@ -111,3 +111,74 @@ describe('MessengerBridgeStore — permission mode persistence', () => {
     expect(store.getInterruptTimeoutMs('discord')).toBe(MESSENGER_INTERRUPT_TIMEOUT_DEFAULT_MS);
   });
 });
+
+describe('MessengerBridgeStore — worktree bindings', () => {
+  let dbPath;
+  let store;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `openchamber-agent-store-${crypto.randomBytes(6).toString('hex')}.sqlite`);
+    store = new MessengerBridgeStore({ dbPath });
+  });
+
+  afterEach(() => {
+    try {
+      store.db.close();
+    } catch {
+      // ignore
+    }
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.unlinkSync(dbPath + suffix);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it('binds and looks up worktrees by path', () => {
+    store.bindWorktree({
+      botTokenHash: 'hash',
+      projectRoot: '/repo',
+      worktreePath: '/repo/.worktrees/feature',
+      branch: 'feature',
+      channelId: 'chan-1',
+      threadId: 'thread-1',
+    });
+    const row = store.lookupWorktreeByPath({
+      botTokenHash: 'hash',
+      worktreePath: '/repo/.worktrees/feature',
+    });
+    expect(row?.threadId).toBe('thread-1');
+    expect(row?.branch).toBe('feature');
+    expect(store.lookupWorktreeByThread({ botTokenHash: 'hash', threadId: 'thread-1' })?.worktreePath).toBe(
+      '/repo/.worktrees/feature',
+    );
+    expect(store.listWorktreesForProject({ botTokenHash: 'hash', projectRoot: '/repo' })).toHaveLength(1);
+    store.unbindWorktree({ botTokenHash: 'hash', worktreePath: '/repo/.worktrees/feature' });
+    expect(
+      store.lookupWorktreeByPath({ botTokenHash: 'hash', worktreePath: '/repo/.worktrees/feature' }),
+    ).toBeNull();
+  });
+
+  it('preserves worktree context on re-bind without worktree fields', () => {
+    const surface = { type: 'discord', botTokenHash: 'hash', targetKey: 'thread-1' };
+    store.bind({
+      ...surface,
+      sessionId: 'ses-1',
+      projectPath: '/repo/.worktrees/feature',
+      projectLabel: 'Repo (feature)',
+      projectRoot: '/repo',
+      worktreePath: '/repo/.worktrees/feature',
+      branch: 'feature',
+    });
+    // Older call sites re-bind with only session/project — the worktree
+    // columns must survive instead of being nulled.
+    store.bind({ ...surface, sessionId: 'ses-2', projectPath: '/repo/.worktrees/feature' });
+    const row = store.lookup(surface);
+    expect(row.sessionId).toBe('ses-2');
+    expect(row.projectRoot).toBe('/repo');
+    expect(row.worktreePath).toBe('/repo/.worktrees/feature');
+    expect(row.branch).toBe('feature');
+  });
+});

--- a/packages/web/server/lib/messenger/messenger-commands.js
+++ b/packages/web/server/lib/messenger/messenger-commands.js
@@ -187,7 +187,17 @@ const COMMAND_HELP = [
   {
     name: 'worktrees',
     usage: '/worktrees',
-    summary: 'List git worktrees for this channel project',
+    summary: 'List git worktrees for this channel project (with Discord thread links)',
+  },
+  {
+    name: 'open-worktree',
+    usage: '/open-worktree <branch-or-name>',
+    summary: 'Open an existing worktree in its Discord thread (UI-created worktrees included)',
+  },
+  {
+    name: 'worktree-status',
+    usage: '/worktree-status',
+    summary: 'Show git status for the worktree bound to this conversation',
   },
   {
     name: 'toggle-worktrees',
@@ -1171,18 +1181,78 @@ export async function executeMessengerCommand({
       }
       const r = await bridgeOps.listWorktrees();
       if (!r.ok) return { reply: `✗ Could not list worktrees: ${r.error ?? 'unknown error'}` };
-      const rows = (r.worktrees ?? []).map((wt, index) => ({
-        n: String(index + 1),
-        branch: wt.branch ?? (wt.detached ? '(detached)' : '(unknown)'),
-        path: wt.path,
-      }));
-      if (rows.length === 0) return { reply: '_(no git worktrees found for this project)_' };
+      const list = r.worktrees ?? [];
+      if (list.length === 0) return { reply: '_(no git worktrees found for this project)_' };
+      const rows = list.map((wt, index) => {
+        const statusParts = [];
+        if (wt.status?.ahead) statusParts.push(`+${wt.status.ahead}`);
+        if (wt.status?.behind) statusParts.push(`-${wt.status.behind}`);
+        if (wt.status?.isDirty) statusParts.push('dirty');
+        return {
+          n: String(index + 1),
+          branch: wt.branch ?? (wt.detached ? '(detached)' : '(unknown)'),
+          status: wt.status ? (statusParts.length > 0 ? statusParts.join('·') : 'clean') : '',
+          thread: wt.threadId ? `<#${wt.threadId}>` : '',
+          path: wt.path,
+        };
+      });
       return {
-        reply: ['**Project worktrees**', '', fmtTable(rows, [
-          { key: 'n' },
-          { key: 'branch', code: true },
-          { key: 'path', code: true },
-        ])].join('\n'),
+        reply: [
+          '**Project worktrees**',
+          '',
+          fmtTable(rows, [
+            { key: 'n' },
+            { key: 'branch', code: true },
+            { key: 'status' },
+            { key: 'thread' },
+            { key: 'path', code: true },
+          ]),
+          '',
+          'Open one with `/open-worktree <branch>`.',
+        ].join('\n'),
+      };
+    }
+
+    case 'open-worktree': {
+      if (!bridgeOps?.openWorktree) {
+        return { reply: '✗ `/open-worktree` is not available on this surface.' };
+      }
+      const query = command.args.trim();
+      if (!query) {
+        return { reply: '✗ Usage: `/open-worktree <branch-or-name>` — run `/worktrees` to see options.' };
+      }
+      const r = await bridgeOps.openWorktree({ query });
+      if (!r.ok) return { reply: `✗ ${r.error ?? 'could not open worktree.'}` };
+      return {
+        reply: [
+          `🌿 Opened worktree \`${r.branch}\``,
+          `📁 \`${r.path}\``,
+          r.threadId ? `Continue in <#${r.threadId}>.` : '',
+        ].filter(Boolean).join('\n'),
+      };
+    }
+
+    case 'worktree-status': {
+      if (!bridgeOps?.worktreeStatus) {
+        return { reply: '✗ `/worktree-status` is not available on this surface.' };
+      }
+      const r = await bridgeOps.worktreeStatus();
+      if (!r.ok) return { reply: `✗ ${r.error ?? 'could not read worktree status.'}` };
+      const statusParts = [];
+      if (r.status?.ahead) statusParts.push(`+${r.status.ahead} ahead`);
+      if (r.status?.behind) statusParts.push(`${r.status.behind} behind`);
+      if (r.status?.isDirty) statusParts.push('dirty');
+      const statusText = statusParts.length > 0 ? statusParts.join(', ') : 'clean';
+      return {
+        reply: [
+          `**Worktree status**`,
+          `Path: \`${r.path}\``,
+          `Project root: \`${r.projectRoot}\``,
+          `Branch: \`${r.branch ?? 'unknown'}\``,
+          `Git: ${statusText}`,
+          r.isWorktree ? '' : '_This conversation is not inside a secondary worktree._',
+          r.threadId ? `Thread: <#${r.threadId}>` : '',
+        ].filter(Boolean).join('\n'),
       };
     }
 

--- a/packages/web/server/lib/messenger/messenger-commands.test.js
+++ b/packages/web/server/lib/messenger/messenger-commands.test.js
@@ -596,6 +596,68 @@ describe('worktree commands', () => {
     expect(result.reply).toContain('Merge conflict detected');
     expect(result.reply).toContain('asked the model');
   });
+  it('worktrees renders status + thread links', async () => {
+    const { result } = await run('/worktrees', {
+      binding: { projectPath: '/repo' },
+      bridgeOps: {
+        listWorktrees: async () => ({
+          ok: true,
+          worktrees: [
+            {
+              branch: 'feature',
+              path: '/repo/wt/feature',
+              status: { ahead: 1, isDirty: true },
+              threadId: 'th-1',
+            },
+          ],
+        }),
+      },
+    });
+    expect(result.reply).toContain('feature');
+    expect(result.reply).toContain('+1·dirty');
+    expect(result.reply).toContain('<#th-1>');
+  });
+  it('open-worktree requires a query', async () => {
+    const { result } = await run('/open-worktree', {
+      binding: { projectPath: '/repo' },
+      bridgeOps: { openWorktree: vi.fn() },
+    });
+    expect(result.reply).toMatch(/Usage/);
+  });
+  it('open-worktree reports the opened thread', async () => {
+    const { result } = await run('/open-worktree feature', {
+      binding: { projectPath: '/repo' },
+      bridgeOps: {
+        openWorktree: async ({ query }) => ({
+          ok: true,
+          path: '/repo/wt/feature',
+          branch: query,
+          threadId: 'th-7',
+        }),
+      },
+    });
+    expect(result.reply).toContain('feature');
+    expect(result.reply).toContain('<#th-7>');
+  });
+  it('worktree-status reports git state', async () => {
+    const { result } = await run('/worktree-status', {
+      binding: { projectPath: '/repo/wt/feature', branch: 'feature' },
+      bridgeOps: {
+        worktreeStatus: async () => ({
+          ok: true,
+          path: '/repo/wt/feature',
+          projectRoot: '/repo',
+          isWorktree: true,
+          branch: 'feature',
+          status: { ahead: 2, behind: 0, isDirty: false },
+          threadId: 'th-9',
+        }),
+      },
+    });
+    expect(result.reply).toContain('feature');
+    expect(result.reply).toContain('+2 ahead');
+    expect(result.reply).toContain('<#th-9>');
+  });
 });
 
 describe('/shell command', () => {

--- a/packages/web/server/lib/messenger/messenger-opencode-bridge.js
+++ b/packages/web/server/lib/messenger/messenger-opencode-bridge.js
@@ -47,6 +47,8 @@ import {
 } from './messenger-worktrees.js';
 import { buildMessengerGitDiffReply } from './messenger-git-diff.js';
 import { buildCritiqueInstructions } from './messenger-critique.js';
+import { createMessengerWorktreeSync } from './messenger-worktree-sync.js';
+import { resolvePrimaryWorktreeRoot } from '../git/service.js';
 import parser from 'cron-parser';
 
 /**
@@ -633,8 +635,27 @@ export function createMessengerOpencodeBridge({
    * sourced items still post the `» queued` marker and go through routeInbound.
    */
   messageQueueRuntime = null,
+  /**
+   * Resolve a project's Discord channel from persisted bindings (used by the
+   * worktree sync to pick the channel a worktree thread belongs to).
+   * Signature: ({ discord, projectPath, bridgeStore? }) => Promise<{ channelId, projectLabel } | null>
+   */
+  resolveProjectChannel = null,
+  /**
+   * Lazy accessor for auto-creating a project's Discord channel when a
+   * worktree thread is ensured but no project channel exists yet.
+   * Signature: () => (project, discordConfig) => Promise<{ channelId, projectLabel } | null>
+   */
+  getEnsureProjectChannel = null,
 }) {
   const bridgeStore = store ?? new MessengerBridgeStore();
+  const worktreeSync = createMessengerWorktreeSync({
+    store: bridgeStore,
+    readSettings,
+    broadcastEvent,
+    resolveProjectChannel,
+    getEnsureProjectChannel,
+  });
 
   /**
    * Resolve the OpenChamber-wide default model/agent (Settings → Defaults).
@@ -1588,6 +1609,16 @@ export function createMessengerOpencodeBridge({
     // No explicit title — OpenCode auto-generates one from the first
     // message and the bridge renames the Discord thread to match.
     const sessionId = await createOpencodeSession({ projectPath: effectivePath });
+    const projectRoot = effectivePath
+      ? (await resolvePrimaryWorktreeRoot(effectivePath).catch(() => ({ root: effectivePath }))).root
+      : null;
+    const normalizedPath = effectivePath?.replace(/\\/g, '/').replace(/\/+$/, '') ?? null;
+    const normalizedRoot = projectRoot?.replace(/\\/g, '/').replace(/\/+$/, '') ?? null;
+    const isWorktree =
+      normalizedPath &&
+      normalizedRoot &&
+      normalizedPath !== normalizedRoot &&
+      (await worktreeSync.isWorktreeDirectory(normalizedPath, normalizedRoot).catch(() => false));
     bridgeStore.bind({
       type,
       botTokenHash: hash,
@@ -1595,7 +1626,18 @@ export function createMessengerOpencodeBridge({
       sessionId,
       projectPath: effectivePath,
       projectLabel: effectiveLabel,
+      projectRoot: normalizedRoot,
+      worktreePath: isWorktree ? normalizedPath : null,
+      branch: null,
     });
+    // When the new session runs inside a linked worktree, make sure the
+    // worktree has its own Discord thread (and bind this session to it) so
+    // Discord mirrors the UI worktree model.
+    void worktreeSync.handleSessionDirectoryBound({
+      sessionId,
+      directory: effectivePath,
+      projectLabel: effectiveLabel,
+    }).catch(() => undefined);
     broadcastEvent?.('messenger.bridge.session_bound', {
       type,
       channelId,
@@ -2626,6 +2668,36 @@ export function createMessengerOpencodeBridge({
           // best-effort — fall through to creating a fresh thread
         }
         if (!threadId) {
+          // Sessions that run inside a linked worktree mirror into the
+          // worktree's own thread (created on demand) instead of a generic
+          // per-session thread — one thread per worktree across surfaces.
+          let worktreeThreadId = null;
+          if (effectiveProjectPath) {
+            try {
+              const root = (
+                await resolvePrimaryWorktreeRoot(effectiveProjectPath).catch(() => ({
+                  root: effectiveProjectPath,
+                }))
+              ).root;
+              const isWorktree = await worktreeSync
+                .isWorktreeDirectory(effectiveProjectPath, root)
+                .catch(() => false);
+              if (isWorktree) {
+                const ensured = await worktreeSync.ensureWorktreeThread({
+                  projectRoot: root,
+                  worktreePath: effectiveProjectPath,
+                  sessionId,
+                  projectLabel: target.projectLabel ?? null,
+                });
+                if (ensured.ok && ensured.threadId) worktreeThreadId = ensured.threadId;
+              }
+            } catch {
+              // best-effort — fall back to a generic mirror thread
+            }
+          }
+          if (worktreeThreadId) {
+            threadId = worktreeThreadId;
+          } else {
           // Thread name preference: the OpenCode-generated session title (when
           // it already exists — title generation often finishes before the
           // mirror thread is created), then the user's first line, then a
@@ -2675,6 +2747,7 @@ export function createMessengerOpencodeBridge({
           }
           // If thread creation failed, threadId stays null and we post into
           // the channel directly — degraded but functional.
+          }
         }
       }
 
@@ -3755,7 +3828,7 @@ export function createMessengerOpencodeBridge({
      * Used by /resume, /fork and /new-worktree. When the command ran inside
      * a thread we hop up to the parent channel first.
      */
-    const createBoundThread = async ({ name, sessionId, projectPath, projectLabel }) => {
+    const createBoundThread = async ({ name, sessionId, projectPath, projectLabel, projectRoot = null, worktreePath = null, branch = null }) => {
       let hostChannelId = channelId;
       const parentId = await resolveParentChannelId({ token, channelId });
       if (parentId) hostChannelId = parentId;
@@ -3768,6 +3841,16 @@ export function createMessengerOpencodeBridge({
       if (!thread.ok || !thread.threadId) {
         return { ok: false, error: thread.error ?? 'thread creation failed' };
       }
+      const normalizedPath = projectPath?.replace(/\\/g, '/').replace(/\/+$/, '') ?? null;
+      const normalizedRoot =
+        projectRoot?.replace(/\\/g, '/').replace(/\/+$/, '') ??
+        (normalizedPath
+          ? (await resolvePrimaryWorktreeRoot(normalizedPath).catch(() => ({ root: normalizedPath }))).root
+          : null);
+      const normalizedWorktree = worktreePath?.replace(/\\/g, '/').replace(/\/+$/, '') ?? null;
+      const effectiveWorktree =
+        normalizedWorktree ??
+        (normalizedPath && normalizedRoot && normalizedPath !== normalizedRoot ? normalizedPath : null);
       bridgeStore.bind({
         type,
         botTokenHash: hash,
@@ -3775,7 +3858,27 @@ export function createMessengerOpencodeBridge({
         sessionId,
         projectPath: projectPath ?? null,
         projectLabel: projectLabel ?? null,
+        projectRoot: normalizedRoot,
+        worktreePath: effectiveWorktree,
+        branch: branch ?? null,
       });
+      if (effectiveWorktree && normalizedRoot) {
+        bridgeStore.bindWorktree?.({
+          botTokenHash: hash,
+          projectRoot: normalizedRoot,
+          worktreePath: effectiveWorktree,
+          branch: branch ?? (name.replace(/^⬦\s*worktree:\s*/i, '').trim() || null),
+          channelId: hostChannelId,
+          threadId: thread.threadId,
+        });
+        void worktreeSync
+          .refreshProjectHub({
+            config: await worktreeSync.loadDiscordConfig(),
+            projectRoot: normalizedRoot,
+            projectLabel,
+          })
+          .catch(() => undefined);
+      }
       return { ok: true, threadId: thread.threadId };
     };
 
@@ -4310,7 +4413,93 @@ export function createMessengerOpencodeBridge({
 
       async listWorktrees() {
         const projectPath = await resolveSurfaceProjectPath();
-        return listBridgeWorktrees({ projectPath });
+        const result = await listBridgeWorktrees({ projectPath });
+        if (!result.ok || !Array.isArray(result.worktrees)) return result;
+        // Enrich with git status + the Discord thread each worktree is bound
+        // to (when worktree sync created one), so `/worktrees` can link out.
+        const hash = tokenHash(token);
+        const enriched = [];
+        for (const wt of result.worktrees) {
+          const binding = wt.path
+            ? bridgeStore.lookupWorktreeByPath?.({ botTokenHash: hash, worktreePath: wt.path })
+            : null;
+          const status = wt.path
+            ? await worktreeSync.readWorktreeGitStatus(wt.path).catch(() => null)
+            : null;
+          enriched.push({ ...wt, status, threadId: binding?.threadId ?? null });
+        }
+        return { ...result, worktrees: enriched };
+      },
+
+      async openWorktree({ query }) {
+        const boundPath = stored?.projectPath ?? null;
+        if (!boundPath) return { ok: false, error: 'no project bound to this conversation.' };
+        const projectRoot = (
+          await resolvePrimaryWorktreeRoot(boundPath).catch(() => ({ root: boundPath }))
+        ).root;
+        const worktrees = await worktreeSync.listProjectWorktrees(projectRoot);
+        const match = worktreeSync.findWorktreeMatch(worktrees, query);
+        if (!match) {
+          return { ok: false, error: `no worktree matched "${query}". Run \`/worktrees\` to see options.` };
+        }
+        let sessionId = stored?.sessionId ?? null;
+        if (!sessionId) {
+          try {
+            sessionId = await createOpencodeSession({ projectPath: match.path });
+          } catch (err) {
+            return { ok: false, error: `session creation failed: ${err?.message ?? 'unknown'}` };
+          }
+        }
+        const ensured = await worktreeSync.ensureWorktreeThread({
+          projectRoot,
+          worktreePath: match.path,
+          branch: match.branch,
+          label: match.label,
+          sessionId,
+          projectLabel: stored?.projectLabel ?? null,
+        });
+        if (!ensured.ok) return ensured;
+        bridgeStore.bind({
+          type,
+          botTokenHash: hash,
+          targetKey: targetKey({ type, channelId, threadId: ensured.threadId }),
+          sessionId,
+          projectPath: match.path,
+          projectLabel: `${stored?.projectLabel ?? 'project'} (${match.branch})`,
+          projectRoot,
+          worktreePath: match.path,
+          branch: match.branch,
+        });
+        return {
+          ok: true,
+          path: match.path,
+          branch: match.branch,
+          threadId: ensured.threadId,
+          created: ensured.created ?? false,
+        };
+      },
+
+      async worktreeStatus() {
+        const worktreeDir = stored?.projectPath ?? null;
+        if (!worktreeDir) return { ok: false, error: 'no project bound to this conversation.' };
+        const projectRoot = (
+          await resolvePrimaryWorktreeRoot(worktreeDir).catch(() => ({ root: worktreeDir }))
+        ).root;
+        const isWorktree = await worktreeSync.isWorktreeDirectory(worktreeDir, projectRoot);
+        const status = await worktreeSync.readWorktreeGitStatus(worktreeDir);
+        const binding = bridgeStore.lookupWorktreeByPath?.({
+          botTokenHash: hash,
+          worktreePath: worktreeDir,
+        });
+        return {
+          ok: true,
+          path: worktreeDir,
+          projectRoot,
+          isWorktree,
+          branch: stored?.branch ?? status.branch ?? null,
+          status,
+          threadId: binding?.threadId ?? null,
+        };
       },
 
       async toggleAutoWorktrees({ enabled }) {
@@ -4458,10 +4647,15 @@ export function createMessengerOpencodeBridge({
       },
 
       async newWorktree({ name }) {
-        const projectPath = stored?.projectPath ?? null;
-        if (!projectPath) return { ok: false, error: 'no project bound to this conversation.' };
+        const boundPath = stored?.projectPath ?? null;
+        if (!boundPath) return { ok: false, error: 'no project bound to this conversation.' };
+        // Create the worktree from the primary root even when this
+        // conversation is itself inside a linked worktree.
+        const projectRoot = (
+          await resolvePrimaryWorktreeRoot(boundPath).catch(() => ({ root: boundPath }))
+        ).root;
         const effectiveName = sanitizeWorktreeName(name || `wt-${Date.now().toString(36)}`);
-        const created = await createBridgeWorktree({ projectPath, name: effectiveName });
+        const created = await createBridgeWorktree({ projectPath: projectRoot, name: effectiveName });
         if (!created.ok) return created;
 
         // Bind a fresh session running inside the worktree to a new thread.
@@ -4477,6 +4671,9 @@ export function createMessengerOpencodeBridge({
           sessionId,
           projectPath: created.path,
           projectLabel: `${stored?.projectLabel ?? 'project'} (${created.branch})`,
+          projectRoot,
+          worktreePath: created.path,
+          branch: created.branch,
         });
         if (!thread.ok) {
           return { ok: false, error: `worktree + session ready, but thread creation failed: ${thread.error}` };
@@ -4579,6 +4776,18 @@ export function createMessengerOpencodeBridge({
         const worktreeDir = stored?.projectPath ?? null;
         if (!worktreeDir) return { ok: false, error: 'no project bound to this conversation.' };
         const result = await mergeBridgeWorktree({ worktreeDir });
+        if (result.ok) {
+          const projectRoot = (
+            await resolvePrimaryWorktreeRoot(worktreeDir).catch(() => ({ root: worktreeDir }))
+          ).root;
+          void worktreeSync
+            .handleWorktreeMerged({
+              project: { path: projectRoot, label: stored?.projectLabel ?? null },
+              worktree: { path: worktreeDir, branch: stored?.branch ?? null },
+              summary: result.summary ?? null,
+            })
+            .catch(() => undefined);
+        }
         if (result.ok || !result.conflict) return result;
 
         // Conflict — hand resolution to the model.
@@ -4607,6 +4816,9 @@ export function createMessengerOpencodeBridge({
         sessionId: stored?.sessionId || null,
         projectPath: stored?.projectPath ?? null,
         projectLabel: stored?.projectLabel ?? null,
+        projectRoot: stored?.projectRoot ?? null,
+        worktreePath: stored?.worktreePath ?? null,
+        branch: stored?.branch ?? null,
         modelOverride: stored?.modelOverride ?? null,
         agentOverride: stored?.agentOverride ?? null,
         variantOverride: stored?.variantOverride ?? null,
@@ -5911,6 +6123,8 @@ export function createMessengerOpencodeBridge({
     getMentionMode,
     /** Whether a surface already has a session binding (mention mode skips bound threads). */
     hasSurfaceBinding,
+    /** Git worktree ↔ Discord thread sync (UI notify endpoints + hub index). */
+    worktreeSync,
     /** Test seam — exposed so tests can drive events without an SSE stream. */
     _handleGlobalEvent: handleGlobalEvent,
     /** Test seam — run one thread-title polling sweep. */

--- a/packages/web/server/lib/messenger/messenger-sync.js
+++ b/packages/web/server/lib/messenger/messenger-sync.js
@@ -473,6 +473,9 @@ export function createMessengerSyncRouter({
       }
     : null;
 
+  /** Set after autoCreateMessengerSurfacesForProject is defined — read at call time. */
+  let ensureProjectChannelForWorktree = null;
+
   const bridge =
     globalEventHub && buildOpenCodeUrl
       ? createMessengerOpencodeBridge({
@@ -493,6 +496,10 @@ export function createMessengerSyncRouter({
               },
             });
           },
+          // Worktree sync: resolve the project channel a worktree thread
+          // belongs to, and auto-create that channel on demand.
+          resolveProjectChannel,
+          getEnsureProjectChannel: () => ensureProjectChannelForWorktree,
           lookupMessengerTarget: makeLookupMessengerTarget(),
           getDefaultMessengerTarget: readSettings ? resolveDefaultDiscordTarget : null,
           // Settings access for voice-message STT (sttServerUrl/sttModel/sttLanguage).
@@ -1704,6 +1711,16 @@ export function createMessengerSyncRouter({
           upsertBinding(bindings, { channelId, projectPath: project.path, projectLabel }),
           discordSettings,
         );
+        // Keep the pinned worktree index in the project channel up to date.
+        if (bridge?.worktreeSync) {
+          void bridge.worktreeSync
+            .refreshProjectHub({
+              config: await bridge.worktreeSync.loadDiscordConfig(),
+              projectRoot: project.path,
+              projectLabel,
+            })
+            .catch(() => undefined);
+        }
       } else {
         results.push({ type: 'discord', ok: false, error: error ?? 'create-channel failed' });
       }
@@ -1716,6 +1733,18 @@ export function createMessengerSyncRouter({
     });
     return results;
   }
+
+  // Lazy hook the bridge's worktree sync uses to create a missing project
+  // channel while ensuring a worktree thread. Reads the freshest bindings.
+  ensureProjectChannelForWorktree = async (project, discord) => {
+    const results = await autoCreateMessengerSurfacesForProject(project, { discord });
+    const created = results.find((r) => r.ok && r.channelId);
+    if (!created?.channelId) return null;
+    return {
+      channelId: created.channelId,
+      projectLabel: project.label ?? project.path.split('/').pop() ?? project.path,
+    };
+  };
 
   /**
    * Explicit endpoint — the UI calls this right after a project is added so
@@ -1893,6 +1922,103 @@ export function createMessengerSyncRouter({
     });
 
     res.json({ ok: !error, channelId, deleted, error });
+  });
+
+  /**
+   * UI created a worktree → ensure a Discord thread + refresh the project hub index.
+   * Body: {
+   *   project: { id?, path, label? },
+   *   worktree: { path, branch?, label? },
+   *   sessionId?: string,
+   *   discord?: { token, guildId?, parentCategoryId?, projectBindings?, defaultChannelId? }
+   * }
+   */
+  router.post('/bridge/worktree-added', async (req, res) => {
+    const { project, worktree, sessionId, discord } = req.body ?? {};
+    if (!project?.path || !worktree?.path) {
+      return res.status(400).json({ ok: false, error: 'project.path and worktree.path required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const result = await bridge.worktreeSync.handleWorktreeAdded({
+      project,
+      worktree,
+      sessionId,
+      discord,
+    });
+    if (!result.ok && !result.skipped) {
+      console.warn('[MESSENGER] worktree-added failed:', result.error ?? result);
+    }
+    res.json(result);
+  });
+
+  /**
+   * UI removed a worktree → archive its Discord thread and refresh the hub index.
+   */
+  router.post('/bridge/worktree-removed', async (req, res) => {
+    const { project, worktree } = req.body ?? {};
+    if (!worktree?.path) {
+      return res.status(400).json({ ok: false, error: 'worktree.path required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const result = await bridge.worktreeSync.handleWorktreeRemoved({ project, worktree });
+    res.json(result);
+  });
+
+  /**
+   * Worktree merged (UI integrate flow or Discord command) → post summary, archive thread.
+   */
+  router.post('/bridge/worktree-merged', async (req, res) => {
+    const { project, worktree, summary } = req.body ?? {};
+    if (!worktree?.path) {
+      return res.status(400).json({ ok: false, error: 'worktree.path required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const result = await bridge.worktreeSync.handleWorktreeMerged({ project, worktree, summary });
+    res.json(result);
+  });
+
+  /**
+   * Lookup the Discord URL for a worktree path (UI "Open in Discord" link).
+   */
+  router.get('/bridge/worktree-discord-url', async (req, res) => {
+    const worktreePath = typeof req.query?.path === 'string' ? req.query.path : null;
+    if (!worktreePath) {
+      return res.status(400).json({ ok: false, error: 'path query parameter required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const discordUrl = await bridge.worktreeSync.lookupWorktreeDiscordUrl(worktreePath);
+    if (!discordUrl) {
+      return res.json({ ok: false, error: 'no Discord thread is bound to this worktree' });
+    }
+    return res.json({ ok: true, discordUrl, path: worktreePath });
+  });
+
+  /**
+   * Refresh the pinned worktree index message for a project channel.
+   */
+  router.post('/bridge/worktree-refresh-index', async (req, res) => {
+    const { project } = req.body ?? {};
+    if (!project?.path) {
+      return res.status(400).json({ ok: false, error: 'project.path required' });
+    }
+    if (!bridge?.worktreeSync) {
+      return res.json({ ok: false, error: 'worktree sync is not available on this server' });
+    }
+    const config = await bridge.worktreeSync.loadDiscordConfig();
+    const result = await bridge.worktreeSync.refreshProjectHub({
+      config,
+      projectRoot: project.path,
+      projectLabel: project.label ?? null,
+    });
+    res.json(result);
   });
 
   /**
@@ -2230,6 +2356,7 @@ export function createMessengerSyncRouter({
       projectBindings,
       defaultReplyMode,
       guildPolicies,
+      syncWorktrees,
     } = req.body ?? {};
     // TEMP DEBUG: capture what the browser actually posts when toggling reply modes
     try {
@@ -2293,6 +2420,10 @@ export function createMessengerSyncRouter({
             guildPolicies && typeof guildPolicies === 'object'
               ? guildPolicies
               : prev.guildPolicies || undefined,
+          // Preserve a previously saved choice when the caller didn't send the
+          // flag (older UIs / partial saves); default stays enabled.
+          syncWorktrees:
+            syncWorktrees === undefined ? prev.syncWorktrees : syncWorktrees !== false,
         },
       });
 

--- a/packages/web/server/lib/messenger/messenger-worktree-sync.js
+++ b/packages/web/server/lib/messenger/messenger-worktree-sync.js
@@ -1,0 +1,723 @@
+/**
+ * Discord ↔ git worktree sync for the OpenChamber messenger bridge.
+ *
+ * Mirrors the UI worktree model in Discord: one project channel, one thread per
+ * worktree, plus a hub index message listing active worktrees. UI-created
+ * worktrees (NewWorktreeDialog / worktreeManager) notify through
+ * /api/messenger/bridge/worktree-added so Discord stays in sync no matter
+ * which surface created the worktree.
+ */
+
+import crypto from 'node:crypto';
+import {
+  getStatus,
+  getWorktrees,
+  resolvePrimaryWorktreeRoot,
+} from '../git/service.js';
+
+const WORKTREE_PREFIX = '⬦ ';
+const DISCORD_THREAD_NAME_MAX = 100;
+const DISCORD_TOPIC_MAX = 1024;
+const DISCORD_MESSAGE_MAX = 2000;
+
+function normalizePath(value) {
+  if (typeof value !== 'string' || !value.trim()) return '';
+  const replaced = value.replace(/\\/g, '/');
+  if (replaced === '/') return '/';
+  return replaced.length > 1 ? replaced.replace(/\/+$/, '') : replaced;
+}
+
+function pathsEqual(a, b) {
+  const left = normalizePath(a);
+  const right = normalizePath(b);
+  return Boolean(left && right && left === right);
+}
+
+function tokenHash(token) {
+  return crypto.createHash('sha256').update(String(token)).digest('hex').slice(0, 12);
+}
+
+function hubIndexSettingKey(projectRoot) {
+  return `worktree-index:${normalizePath(projectRoot)}`;
+}
+
+/** Format a Discord thread title for a worktree. */
+export function formatWorktreeThreadName({ branch, label, statusSummary = null }) {
+  const base = String(branch || label || 'worktree').trim() || 'worktree';
+  const withPrefix = `${WORKTREE_PREFIX}${base}`;
+  const full = statusSummary ? `${withPrefix} (${statusSummary})` : withPrefix;
+  return full.slice(0, DISCORD_THREAD_NAME_MAX);
+}
+
+/** Summarise git status for thread titles / index rows. */
+export function summarizeWorktreeGitStatus(status) {
+  if (!status || typeof status !== 'object') return null;
+  const parts = [];
+  const ahead = Number(status.ahead);
+  const behind = Number(status.behind);
+  if (Number.isFinite(ahead) && ahead > 0) parts.push(`+${ahead}`);
+  if (Number.isFinite(behind) && behind > 0) parts.push(`-${behind}`);
+  if (status.isDirty || status.dirty) parts.push('dirty');
+  return parts.length > 0 ? parts.join('·') : 'clean';
+}
+
+async function discordFetch(path, { token, method = 'GET', body = null } = {}) {
+  const headers = { Authorization: `Bot ${token}` };
+  if (body != null) headers['Content-Type'] = 'application/json';
+  const response = await fetch(`https://discord.com/api/v10${path}`, {
+    method,
+    headers,
+    body: body != null ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(15_000),
+  });
+  const text = await response.text().catch(() => '');
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { ok: response.ok, status: response.status, json, text };
+}
+
+async function addThreadMembers({ token, threadId, userIds }) {
+  const ids = Array.isArray(userIds) ? userIds : userIds ? [userIds] : [];
+  for (const userId of ids.filter(Boolean)) {
+    await discordFetch(`/channels/${encodeURIComponent(threadId)}/thread-members/${encodeURIComponent(userId)}`, {
+      token,
+      method: 'PUT',
+    }).catch(() => undefined);
+  }
+}
+
+async function startStandaloneThread({ token, channelId, name, userIds }) {
+  const safeName = (name || 'Otto worktree').replace(/\s+/g, ' ').slice(0, 90) || 'Otto worktree';
+  const result = await discordFetch(`/channels/${encodeURIComponent(channelId)}/threads`, {
+    token,
+    method: 'POST',
+    body: { name: safeName, type: 11, auto_archive_duration: 1440 },
+  });
+  if (!result.ok) {
+    return { ok: false, error: `Discord ${result.status}: ${result.text.slice(0, 200)}` };
+  }
+  const threadId = result.json?.id ?? null;
+  if (threadId && userIds) await addThreadMembers({ token, threadId, userIds });
+  return { ok: true, threadId, threadName: result.json?.name ?? safeName };
+}
+
+async function deleteThread({ token, threadId }) {
+  if (!threadId) return { ok: false, error: 'no thread id' };
+  const result = await discordFetch(`/channels/${encodeURIComponent(threadId)}`, {
+    token,
+    method: 'DELETE',
+  });
+  if (result.ok || result.status === 404) return { ok: true };
+  return { ok: false, error: `Discord ${result.status}: ${result.text.slice(0, 200)}` };
+}
+
+async function renameThread({ token, threadId, name }) {
+  if (!threadId || !name) return { ok: false };
+  const result = await discordFetch(`/channels/${encodeURIComponent(threadId)}`, {
+    token,
+    method: 'PATCH',
+    body: { name: name.slice(0, DISCORD_THREAD_NAME_MAX) },
+  });
+  return { ok: result.ok, error: result.ok ? null : result.text.slice(0, 200) };
+}
+
+async function postChannelMessage({ token, channelId, content }) {
+  const result = await discordFetch(`/channels/${encodeURIComponent(channelId)}/messages`, {
+    token,
+    method: 'POST',
+    body: { content: String(content).slice(0, DISCORD_MESSAGE_MAX) },
+  });
+  if (!result.ok) return { ok: false, error: result.text.slice(0, 200) };
+  return { ok: true, messageId: result.json?.id ?? null };
+}
+
+async function editChannelMessage({ token, channelId, messageId, content }) {
+  const result = await discordFetch(
+    `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}`,
+    {
+      token,
+      method: 'PATCH',
+      body: { content: String(content).slice(0, DISCORD_MESSAGE_MAX) },
+    },
+  );
+  if (!result.ok) return { ok: false, error: result.text.slice(0, 200) };
+  return { ok: true, messageId };
+}
+
+async function patchChannelTopic({ token, channelId, topic }) {
+  const result = await discordFetch(`/channels/${encodeURIComponent(channelId)}`, {
+    token,
+    method: 'PATCH',
+    body: { topic: String(topic).slice(0, DISCORD_TOPIC_MAX) },
+  });
+  return { ok: result.ok, error: result.ok ? null : result.text.slice(0, 200) };
+}
+
+export function createMessengerWorktreeSync({
+  store,
+  readSettings = null,
+  broadcastEvent = null,
+  /**
+   * Resolve a project's Discord channel from persisted bindings.
+   * Signature: ({ discord, projectPath }) => Promise<{ channelId, projectLabel } | null>
+   * (messenger-sync's exported resolveProjectChannel — it already resolves the
+   * primary worktree root and the bridge-store fallback.)
+   */
+  resolveProjectChannel = null,
+  /**
+   * Lazy accessor for auto-creating a project's Discord channel when a
+   * worktree thread is ensured but no project channel exists yet.
+   * Signature: () => (project, discordConfig) => Promise<{ channelId, projectLabel } | null>
+   */
+  getEnsureProjectChannel = null,
+} = {}) {
+  if (!store) {
+    throw new Error('messenger worktree sync requires a bridge store');
+  }
+
+  async function loadDiscordConfig(requestDiscord = null) {
+    let serverConfig = null;
+    if (typeof readSettings === 'function') {
+      try {
+        const settings = await readSettings();
+        const discord = settings?.discord ?? null;
+        if (discord?.botToken) {
+          serverConfig = {
+            token: discord.botToken,
+            guildId: discord.guildId ?? null,
+            parentCategoryId: discord.parentCategoryId ?? null,
+            defaultUserId: discord.defaultUserId ?? null,
+            defaultChannelId: discord.defaultChannelId ?? null,
+            syncWorktrees: discord.syncWorktrees !== false,
+            projectBindings: Array.isArray(discord.projectBindings) ? discord.projectBindings : [],
+          };
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    const request = requestDiscord && typeof requestDiscord === 'object' ? requestDiscord : null;
+    const requestToken = typeof request?.token === 'string' ? request.token.trim() : '';
+    if (!serverConfig && !requestToken) return null;
+
+    const requestBindings = Array.isArray(request?.projectBindings) ? request.projectBindings : null;
+    const merged = {
+      token: requestToken || serverConfig?.token || null,
+      guildId: request?.guildId ?? serverConfig?.guildId ?? null,
+      parentCategoryId: request?.parentCategoryId ?? serverConfig?.parentCategoryId ?? null,
+      defaultUserId: request?.defaultUserId ?? serverConfig?.defaultUserId ?? null,
+      defaultChannelId: request?.defaultChannelId ?? serverConfig?.defaultChannelId ?? null,
+      syncWorktrees:
+        request?.syncWorktrees !== undefined
+          ? request.syncWorktrees !== false
+          : serverConfig?.syncWorktrees !== false,
+      projectBindings: requestBindings ?? serverConfig?.projectBindings ?? [],
+    };
+
+    if (!merged.token) return null;
+    return merged;
+  }
+
+  function isWorktreeSyncEnabled(config) {
+    return Boolean(config?.token && config.syncWorktrees !== false);
+  }
+
+  async function resolveProjectRoot(directory) {
+    const normalized = normalizePath(directory);
+    if (!normalized) return null;
+    try {
+      const resolved = await resolvePrimaryWorktreeRoot(normalized);
+      return normalizePath(resolved?.root ?? normalized);
+    } catch {
+      return normalized;
+    }
+  }
+
+  async function isWorktreeDirectory(directory, projectRoot = null) {
+    const normalized = normalizePath(directory);
+    const root = normalizePath(projectRoot ?? (await resolveProjectRoot(normalized)));
+    if (!normalized || !root || pathsEqual(normalized, root)) return false;
+    try {
+      const entries = await getWorktrees(root);
+      return entries.some((entry) => pathsEqual(entry.path, normalized));
+    } catch {
+      return false;
+    }
+  }
+
+  async function readWorktreeGitStatus(worktreePath) {
+    try {
+      const status = await getStatus(worktreePath, { mode: 'light' });
+      return {
+        isDirty: status?.isClean === false,
+        ahead: Number(status?.ahead) || 0,
+        behind: Number(status?.behind) || 0,
+        // git service reports the branch as `current` (not `branch`).
+        branch: typeof status?.current === 'string' ? status.current : null,
+      };
+    } catch {
+      return { isDirty: false, ahead: 0, behind: 0, branch: null };
+    }
+  }
+
+  async function listProjectWorktrees(projectRoot) {
+    const root = normalizePath(projectRoot);
+    if (!root) return [];
+    const entries = await getWorktrees(root).catch(() => []);
+    const secondary = entries.filter((entry) => entry?.path && !pathsEqual(entry.path, root));
+    const results = [];
+    for (const entry of secondary) {
+      const path = normalizePath(entry.path);
+      const branch = String(entry.branch || '').replace(/^refs\/heads\//, '').trim();
+      const status = await readWorktreeGitStatus(path);
+      const binding = store.lookupWorktreeByPath?.({
+        botTokenHash: null,
+        worktreePath: path,
+      });
+      results.push({
+        path,
+        branch: branch || status.branch || path.split('/').pop(),
+        label: branch || path.split('/').pop(),
+        status,
+        threadId: binding?.threadId ?? null,
+      });
+    }
+    results.sort((a, b) => a.branch.localeCompare(b.branch));
+    return results;
+  }
+
+  function findWorktreeMatch(worktrees, query) {
+    const needle = String(query ?? '').trim().toLowerCase();
+    if (!needle) return null;
+    return (
+      worktrees.find((wt) => wt.branch.toLowerCase() === needle) ??
+      worktrees.find((wt) => wt.path.toLowerCase().endsWith(`/${needle}`)) ??
+      worktrees.find((wt) => wt.branch.toLowerCase().includes(needle)) ??
+      worktrees.find((wt) => wt.path.toLowerCase().includes(needle)) ??
+      null
+    );
+  }
+
+  async function resolveChannelForProject(config, projectRoot) {
+    if (typeof resolveProjectChannel === 'function') {
+      try {
+        const resolved = await resolveProjectChannel({
+          discord: config,
+          projectPath: projectRoot,
+          bridgeStore: store,
+        });
+        if (resolved?.channelId) return resolved;
+      } catch {
+        // fall through to the local binding scan
+      }
+    }
+    const bindings = Array.isArray(config.projectBindings) ? config.projectBindings : [];
+    const binding = bindings.find(
+      (row) => row?.channelId && pathsEqual(row.projectPath, projectRoot),
+    );
+    if (binding?.channelId) {
+      return { channelId: String(binding.channelId), projectLabel: binding.projectLabel ?? null };
+    }
+    return null;
+  }
+
+  function readHubIndexState(projectRoot) {
+    const raw = store.getSetting?.(hubIndexSettingKey(projectRoot));
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed?.channelId && parsed?.messageId) return parsed;
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+
+  function writeHubIndexState(projectRoot, { channelId, messageId }) {
+    if (!channelId || !messageId) {
+      store.setSetting?.(hubIndexSettingKey(projectRoot), null);
+      return;
+    }
+    store.setSetting?.(
+      hubIndexSettingKey(projectRoot),
+      JSON.stringify({ channelId: String(channelId), messageId: String(messageId) }),
+    );
+  }
+
+  async function buildWorktreeIndexContent({ projectRoot, projectLabel, worktrees }) {
+    const lines = [`**Worktrees** — ${projectLabel ?? projectRoot}`, ''];
+    if (!worktrees || worktrees.length === 0) {
+      lines.push('_(no active worktrees — create one in the UI or with `/new-worktree`)_');
+    } else {
+      for (const wt of worktrees) {
+        const statusText = summarizeWorktreeGitStatus(wt.status) ?? 'unknown';
+        const link = wt.threadId ? `<#${wt.threadId}>` : '_no thread_';
+        lines.push(`• \`${wt.branch}\` — ${statusText} → ${link}`);
+      }
+    }
+    lines.push('', '_Updated automatically by OpenChamber._');
+    return lines.join('\n').slice(0, DISCORD_MESSAGE_MAX);
+  }
+
+  async function refreshProjectHub({ config, projectRoot, projectLabel = null }) {
+    if (!isWorktreeSyncEnabled(config)) return { ok: false, skipped: true };
+    const channel = await resolveChannelForProject(config, projectRoot);
+    if (!channel?.channelId) return { ok: false, error: 'no project channel' };
+
+    const worktrees = await listProjectWorktreesForBindings(config, projectRoot);
+    const content = await buildWorktreeIndexContent({
+      projectRoot,
+      projectLabel: projectLabel ?? channel.projectLabel ?? projectRoot.split('/').pop(),
+      worktrees,
+    });
+
+    const hub = readHubIndexState(projectRoot);
+    let messageId = hub?.messageId ?? null;
+    if (messageId && hub?.channelId === channel.channelId) {
+      const edited = await editChannelMessage({
+        token: config.token,
+        channelId: channel.channelId,
+        messageId,
+        content,
+      });
+      if (!edited.ok) messageId = null;
+    }
+    if (!messageId) {
+      const posted = await postChannelMessage({
+        token: config.token,
+        channelId: channel.channelId,
+        content,
+      });
+      if (!posted.ok) return { ok: false, error: posted.error ?? 'post failed' };
+      messageId = posted.messageId;
+      writeHubIndexState(projectRoot, { channelId: channel.channelId, messageId });
+    }
+
+    const topic = `OpenChamber · ${worktrees.length} worktree${worktrees.length === 1 ? '' : 's'} · ${projectLabel ?? projectRoot.split('/').pop()}`
+      .slice(0, DISCORD_TOPIC_MAX);
+    await patchChannelTopic({ token: config.token, channelId: channel.channelId, topic }).catch(() => undefined);
+
+    broadcastEvent?.('messenger.bridge.worktree_index_updated', {
+      projectRoot,
+      channelId: channel.channelId,
+      worktreeCount: worktrees.length,
+    });
+
+    return { ok: true, messageId, worktreeCount: worktrees.length, topic };
+  }
+
+  async function listProjectWorktreesForBindings(config, projectRoot) {
+    const hash = tokenHash(config.token);
+    const bound = store.listWorktreesForProject?.({ botTokenHash: hash, projectRoot }) ?? [];
+    const boundByPath = new Map(bound.map((row) => [normalizePath(row.worktreePath), row]));
+    const discovered = await listProjectWorktrees(projectRoot);
+    return discovered.map((wt) => {
+      const binding = boundByPath.get(normalizePath(wt.path));
+      return {
+        ...wt,
+        threadId: binding?.threadId ?? wt.threadId ?? null,
+        branch: binding?.branch ?? wt.branch,
+      };
+    });
+  }
+
+  async function ensureWorktreeThread({
+    project,
+    projectRoot,
+    worktreePath,
+    branch,
+    label = null,
+    sessionId = null,
+    projectLabel = null,
+    config: configOverride = null,
+  }) {
+    const config = configOverride ?? (await loadDiscordConfig());
+    if (!isWorktreeSyncEnabled(config)) return { ok: false, skipped: true, reason: 'sync-disabled' };
+
+    const root = normalizePath(projectRoot ?? project?.path ?? (await resolveProjectRoot(worktreePath)));
+    const path = normalizePath(worktreePath);
+    if (!root || !path) return { ok: false, error: 'invalid paths' };
+
+    let channel = await resolveChannelForProject(config, root);
+    if (!channel?.channelId) {
+      const ensureProjectChannel =
+        typeof getEnsureProjectChannel === 'function' ? getEnsureProjectChannel() : null;
+      if (ensureProjectChannel) {
+        const created = await ensureProjectChannel(
+          {
+            id: project?.id ?? root,
+            path: root,
+            label: projectLabel ?? project?.label ?? root.split('/').pop() ?? root,
+          },
+          {
+            token: config.token,
+            guildId: config.guildId,
+            parentCategoryId: config.parentCategoryId ?? null,
+          },
+        );
+        if (created?.channelId) {
+          channel = {
+            channelId: String(created.channelId),
+            projectLabel: created.projectLabel ?? projectLabel ?? null,
+          };
+          config.projectBindings = [
+            ...config.projectBindings.filter((row) => !pathsEqual(row?.projectPath, root)),
+            {
+              channelId: channel.channelId,
+              projectPath: root,
+              projectLabel: channel.projectLabel ?? undefined,
+            },
+          ];
+        }
+      }
+    }
+    if (!channel?.channelId && config.defaultChannelId) {
+      channel = { channelId: String(config.defaultChannelId), projectLabel: projectLabel ?? null };
+    }
+    if (!channel?.channelId) {
+      return { ok: false, error: 'no project channel mapped — sync the project to Discord first' };
+    }
+
+    const hash = tokenHash(config.token);
+    const existing = store.lookupWorktreeByPath?.({ botTokenHash: hash, worktreePath: path });
+    if (existing?.threadId) {
+      if (sessionId) {
+        store.bind?.({
+          type: 'discord',
+          botTokenHash: hash,
+          targetKey: String(existing.threadId),
+          sessionId,
+          projectPath: path,
+          projectLabel: projectLabel ?? `${channel.projectLabel ?? 'project'} (${existing.branch ?? branch ?? 'worktree'})`,
+          projectRoot: root,
+          worktreePath: path,
+          branch: existing.branch ?? branch ?? null,
+        });
+      }
+      return { ok: true, threadId: existing.threadId, created: false, channelId: existing.channelId };
+    }
+
+    const status = await readWorktreeGitStatus(path);
+    const effectiveBranch = branch || status.branch || label || path.split('/').pop();
+    const threadName = formatWorktreeThreadName({
+      branch: effectiveBranch,
+      label,
+      statusSummary: summarizeWorktreeGitStatus(status),
+    });
+
+    const created = await startStandaloneThread({
+      token: config.token,
+      channelId: channel.channelId,
+      name: threadName,
+      userIds: config.defaultUserId,
+    });
+    if (!created.ok || !created.threadId) {
+      return { ok: false, error: created.error ?? 'thread creation failed' };
+    }
+
+    store.bindWorktree?.({
+      botTokenHash: hash,
+      projectRoot: root,
+      worktreePath: path,
+      branch: effectiveBranch,
+      channelId: channel.channelId,
+      threadId: created.threadId,
+    });
+
+    if (sessionId) {
+      store.bind?.({
+        type: 'discord',
+        botTokenHash: hash,
+        targetKey: String(created.threadId),
+        sessionId,
+        projectPath: path,
+        projectLabel: projectLabel ?? `${channel.projectLabel ?? 'project'} (${effectiveBranch})`,
+        projectRoot: root,
+        worktreePath: path,
+        branch: effectiveBranch,
+      });
+    }
+
+    await refreshProjectHub({ config, projectRoot: root, projectLabel: channel.projectLabel ?? projectLabel });
+    broadcastEvent?.('messenger.bridge.worktree_thread_created', {
+      projectRoot: root,
+      worktreePath: path,
+      branch: effectiveBranch,
+      threadId: created.threadId,
+      channelId: channel.channelId,
+      source: sessionId ? 'session' : 'worktree',
+    });
+
+    return {
+      ok: true,
+      threadId: created.threadId,
+      channelId: channel.channelId,
+      created: true,
+      branch: effectiveBranch,
+    };
+  }
+
+  async function removeWorktreeThread({ worktreePath, projectRoot = null }) {
+    const config = await loadDiscordConfig();
+    if (!config?.token) return { ok: false, error: 'discord not configured' };
+    const hash = tokenHash(config.token);
+    const path = normalizePath(worktreePath);
+    const binding = store.lookupWorktreeByPath?.({ botTokenHash: hash, worktreePath: path });
+    if (!binding?.threadId) {
+      store.unbindWorktree?.({ botTokenHash: hash, worktreePath: path });
+      return { ok: true, removed: false };
+    }
+
+    await deleteThread({ token: config.token, threadId: binding.threadId }).catch(() => undefined);
+    store.unbindWorktree?.({ botTokenHash: hash, worktreePath: path });
+
+    const root = normalizePath(projectRoot ?? binding.projectRoot);
+    if (root) {
+      await refreshProjectHub({ config, projectRoot: root });
+    }
+
+    broadcastEvent?.('messenger.bridge.worktree_thread_removed', {
+      projectRoot: root,
+      worktreePath: path,
+      threadId: binding.threadId,
+    });
+
+    return { ok: true, removed: true, threadId: binding.threadId };
+  }
+
+  async function handleWorktreeAdded({
+    project,
+    worktree,
+    sessionId = null,
+    discord = null,
+  }) {
+    const config = await loadDiscordConfig(discord);
+    if (!config) {
+      return { ok: false, error: 'discord is not configured (bot token required)' };
+    }
+    if (!isWorktreeSyncEnabled(config)) return { ok: true, skipped: true, reason: 'sync-disabled' };
+
+    const projectRoot = normalizePath(project?.path);
+    const worktreePath = normalizePath(worktree?.path);
+    if (!projectRoot || !worktreePath) return { ok: false, error: 'project and worktree paths required' };
+
+    return ensureWorktreeThread({
+      project,
+      projectRoot,
+      worktreePath,
+      branch: worktree?.branch ?? worktree?.label ?? null,
+      label: worktree?.label ?? null,
+      sessionId,
+      projectLabel: project?.label ?? null,
+      config,
+    });
+  }
+
+  async function handleWorktreeRemoved({ project, worktree }) {
+    const projectRoot = normalizePath(project?.path);
+    const worktreePath = normalizePath(worktree?.path);
+    if (!worktreePath) return { ok: false, error: 'worktree path required' };
+    return removeWorktreeThread({ worktreePath, projectRoot });
+  }
+
+  async function handleWorktreeMerged({ project, worktree, summary = null }) {
+    const config = await loadDiscordConfig();
+    const projectRoot = normalizePath(project?.path);
+    const worktreePath = normalizePath(worktree?.path);
+    const hash = config?.token ? tokenHash(config.token) : null;
+    const binding =
+      hash && worktreePath
+        ? store.lookupWorktreeByPath?.({ botTokenHash: hash, worktreePath })
+        : null;
+
+    if (binding?.threadId && config?.token) {
+      const content = summary
+        ? `✓ ${summary}\n\n_This worktree thread will be archived._`
+        : '✓ Worktree merged into the default branch.\n\n_This worktree thread will be archived._';
+      await postChannelMessage({
+        token: config.token,
+        channelId: binding.threadId,
+        content,
+      }).catch(() => undefined);
+    }
+
+    // removeWorktreeThread deletes the thread, drops the binding and refreshes
+    // the hub index — no second refresh needed here.
+    return removeWorktreeThread({ worktreePath, projectRoot });
+  }
+
+  async function handleSessionDirectoryBound({
+    sessionId,
+    directory,
+    projectLabel = null,
+    title = null,
+  }) {
+    const config = await loadDiscordConfig();
+    if (!isWorktreeSyncEnabled(config) || !sessionId || !directory) return { ok: true, skipped: true };
+
+    const path = normalizePath(directory);
+    const root = await resolveProjectRoot(path);
+    if (!root || pathsEqual(path, root)) return { ok: true, skipped: true };
+    const isWorktree = await isWorktreeDirectory(path, root);
+    if (!isWorktree) return { ok: true, skipped: true };
+
+    const result = await ensureWorktreeThread({
+      projectRoot: root,
+      worktreePath: path,
+      branch: null,
+      label: title,
+      sessionId,
+      projectLabel,
+      config,
+    });
+
+    if (result.ok && result.threadId && title) {
+      const status = await readWorktreeGitStatus(path);
+      const threadName = formatWorktreeThreadName({
+        branch: result.branch ?? status.branch,
+        label: title,
+        statusSummary: summarizeWorktreeGitStatus(status),
+      });
+      await renameThread({ token: config.token, threadId: result.threadId, name: threadName }).catch(() => undefined);
+    }
+
+    return result;
+  }
+
+  async function lookupWorktreeDiscordUrl(worktreePath) {
+    const config = await loadDiscordConfig();
+    if (!config?.token || !config.guildId) return null;
+    const binding = store.lookupWorktreeByPath?.({
+      botTokenHash: tokenHash(config.token),
+      worktreePath: normalizePath(worktreePath),
+    });
+    if (!binding?.threadId) return null;
+    return `https://discord.com/channels/${config.guildId}/${binding.threadId}`;
+  }
+
+  return {
+    isWorktreeSyncEnabled,
+    loadDiscordConfig,
+    resolveProjectRoot,
+    isWorktreeDirectory,
+    listProjectWorktrees,
+    listProjectWorktreesForBindings,
+    findWorktreeMatch,
+    formatWorktreeThreadName,
+    summarizeWorktreeGitStatus,
+    ensureWorktreeThread,
+    removeWorktreeThread,
+    refreshProjectHub,
+    handleWorktreeAdded,
+    handleWorktreeRemoved,
+    handleWorktreeMerged,
+    handleSessionDirectoryBound,
+    lookupWorktreeDiscordUrl,
+    readWorktreeGitStatus,
+  };
+}

--- a/packages/web/server/lib/messenger/messenger-worktree-sync.test.js
+++ b/packages/web/server/lib/messenger/messenger-worktree-sync.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatWorktreeThreadName,
+  summarizeWorktreeGitStatus,
+} from './messenger-worktree-sync.js';
+
+describe('formatWorktreeThreadName', () => {
+  it('prefixes worktree branches and caps length', () => {
+    expect(formatWorktreeThreadName({ branch: 'feature-auth' })).toBe('⬦ feature-auth');
+    expect(formatWorktreeThreadName({ branch: 'feature-auth', statusSummary: '+2·dirty' })).toBe(
+      '⬦ feature-auth (+2·dirty)',
+    );
+  });
+});
+
+describe('summarizeWorktreeGitStatus', () => {
+  it('summarises ahead/behind/dirty state', () => {
+    expect(summarizeWorktreeGitStatus({ ahead: 2, behind: 1, isDirty: true })).toBe('+2·-1·dirty');
+    expect(summarizeWorktreeGitStatus({ ahead: 0, behind: 0, isDirty: false })).toBe('clean');
+    expect(summarizeWorktreeGitStatus(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Discord worktree sync not firing when worktrees/sessions are created from the UI.

### Root causes
- Server ignored `discord` credentials sent in the UI request body (only read from `settings.json`)
- Worktree sync required `syncProjects` + `discordGuildId` in the UI gate even when a project channel mapping already existed
- No auto-create project channel path when ensuring worktree threads
- `getEnsureProjectChannel` callback was never wired from messenger-sync
- Worktree+session flow didn't re-notify with `sessionId` after session creation

### Fixes
- Merge request-body Discord config (token, guild, bindings, default channel) with server settings
- Wire lazy `ensureProjectChannelForWorktree` → `autoCreateMessengerSurfacesForProject`
- Relax UI `notifyWorktreeAdded` to require only bot token + `syncWorktrees`
- Send full bridge payload (`projectBindings`, `defaultChannelId`, etc.) via `runtimeFetch`
- Re-notify Discord after session creation in `NewWorktreeDialog`
- Resolve primary project root when notifying from `worktreeManager`
- Fall back to `defaultChannelId` when no per-project channel exists

### Testing
- `bun test` messenger-worktree-sync, bridge-store, commands (71 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eece0a20-b8f0-4690-a3d3-f463921759f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eece0a20-b8f0-4690-a3d3-f463921759f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

