### PR TITLE
fix(vscode): allow Shiki module worker by adding worker-src to CSP

### DIFF
--- a/packages/ui/src/components/chat/markdown/markdown-worker.ts
+++ b/packages/ui/src/components/chat/markdown/markdown-worker.ts
@@ -29,7 +29,8 @@ const getWorker = (): Worker | undefined => {
   if (typeof window === 'undefined' || typeof Worker === 'undefined') return undefined;
   try {
     worker = new Worker(MarkdownShikiWorkerUrl, { type: 'module' });
-  } catch {
+  } catch (err) {
+    console.error('Failed to create Shiki worker:', err);
     return undefined;
   }
   worker.onmessage = (event: MessageEvent<MarkdownWorkerResponse>) => {

--- a/packages/vscode/src/webviewHtml.ts
+++ b/packages/vscode/src/webviewHtml.ts
@@ -68,6 +68,7 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
   const connectSrc = uniqueTokens(['*', 'ws:', 'wss:', 'http:', 'https:', devServerOrigin]);
   const imgSrc = uniqueTokens([webview.cspSource, 'data:', 'https:', devServerOrigin]);
   const fontSrc = uniqueTokens([webview.cspSource, 'data:', devServerOrigin]);
+  const workerSrc = uniqueTokens([webview.cspSource, devServerOrigin]);
 
   const themeKind = getThemeKindName(vscode.window.activeColorTheme.kind);
 
@@ -84,7 +85,7 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${styleSrc}; script-src ${scriptSrc}; connect-src ${connectSrc}; img-src ${imgSrc}; font-src ${fontSrc};">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${styleSrc}; script-src ${scriptSrc}; connect-src ${connectSrc}; img-src ${imgSrc}; font-src ${fontSrc}; worker-src ${workerSrc};">
   <style>
     html, body, #root { height: 100%; width: 100%; margin: 0; padding: 0; }
     body { 


### PR DESCRIPTION
## Summary

Fixes #2047

In the VS Code extension, all code blocks rendered as plain gray text because the Shiki syntax-highlighting Web Worker failed to load.

## Root cause

The VS Code webview CSP (`packages/vscode/src/webviewHtml.ts`) declared `default-src 'none'` but did not include a `worker-src` directive. When `markdown-worker.ts` tried to instantiate the module worker via `new Worker(..., { type: 'module' })`, the browser blocked it silently. The existing `catch` block swallowed the error, making the failure invisible in DevTools.

## Changes

- **`packages/vscode/src/webviewHtml.ts`**  
  Added `worker-src` to the CSP meta tag, scoped to `webview.cspSource` and `devServerOrigin` (mirrors existing `script-src` / `img-src` patterns).

- **`packages/ui/src/components/chat/markdown/markdown-worker.ts`**  
  Added `console.error` in the worker-creation `catch` block so future load failures are visible in DevTools.

## Verification

- `bun run type-check` — no new errors in modified files.
- Manual reviewer + OCR review approved; no issues flagged.

## Notes

- `'unsafe-inline'` / `blob:` are intentionally omitted from `worker-src` because the worker is loaded from a file URL, not inline or blob-constructed.
- The fix applies to all VS Code webviews that render markdown (chat panel, session editor, agent manager).
