### PR TITLE
fix(chat): bypass SDK v2 body-omission in session.create and promptAsync

### DIFF
--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -517,14 +517,23 @@ class OpencodeService {
   }
 
   async createSession(params?: { parentID?: string; title?: string; metadata?: Record<string, unknown> }, directory?: string | null): Promise<Session> {
+    // Direct fetch - bypasses SDK v2 bug where session.create omits the body.
+    // The OpenCode server rejects requests with parentID: null in the body.
     const requestDirectory = this.normalizeCandidatePath(directory) ?? this.currentDirectory;
-    const response = await this.client.session.create({
-      ...(requestDirectory ? { directory: requestDirectory } : {}),
-      parentID: params?.parentID,
-      title: params?.title,
-      metadata: params?.metadata,
+    const baseUrl = (this.baseUrl || '/api').replace(/\/$/, '');
+    const dirPath = encodeURIComponent(requestDirectory ?? '');
+    const fallbackUrl = `${baseUrl}/session?directory=${dirPath}`;
+    const body: Record<string, unknown> = { directory: requestDirectory };
+    if (params?.title !== undefined) body.title = params.title;
+    if (params?.parentID) body.parentID = params.parentID;
+    if (params?.metadata) body.metadata = params.metadata;
+    const fallbackResponse = await fetch(fallbackUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
     });
-    return unwrapSdkData(response, 'session.create');
+    const sessionData: Session = await fallbackResponse.json();
+    return sessionData;
   }
 
   async getSession(id: string, directory?: string | null): Promise<Session> {

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -859,61 +859,37 @@ class OpencodeService {
 
     let response!: Response;
 
+    // FIX: SDK v2 omits the body for session.promptAsync (same bug as
+    // session.create). The server returns 400 BadRequest for an empty
+    // body. Skip the SDK entirely and POST directly.
+    const buildFallbackBody = (): Record<string, unknown> => {
+      const fallbackBody: Record<string, unknown> = {
+        sessionID: params.id,
+        model: { providerID: params.providerID, modelID: params.modelID },
+        messageID: messageId,
+        parts,
+      };
+      if (params.agent) fallbackBody.agent = params.agent;
+      if (params.variant) fallbackBody.variant = params.variant;
+      if (requestDirectory) fallbackBody.directory = requestDirectory;
+      if (params.delivery) fallbackBody.delivery = params.delivery;
+      if (params.format) fallbackBody.format = params.format;
+      return fallbackBody;
+    };
+
+    const baseUrl = (this.baseUrl || '/api').replace(/\/$/, '');
+    const dirPath = encodeURIComponent(requestDirectory ?? '');
+    const fallbackUrl = `${baseUrl}/session/${encodeURIComponent(params.id)}/prompt_async?directory=${dirPath}`;
+
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
-        const result = await this.client.session.promptAsync({
-          sessionID: params.id,
-          ...(requestDirectory ? { directory: requestDirectory } : {}),
-          model: {
-            providerID: params.providerID,
-            modelID: params.modelID,
-          },
-          agent: params.agent,
-          variant: params.variant,
-          messageID: messageId,
-          ...(params.delivery ? { delivery: params.delivery } : {}),
-          ...(params.format ? { format: params.format } : {}),
-          parts,
+        response = await fetch(fallbackUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(buildFallbackBody()),
         });
-        if (result.response instanceof Response) {
-          response = result.response;
-        } else if (result.error) {
-          const status = (result as SdkResult<unknown>).response?.status || 500;
-          response = new Response(JSON.stringify(result.error), { status });
-        } else {
-          response = new Response(JSON.stringify(result.data ?? true), { status: 200 });
-        }
-      } catch (sdkError) {
-        // FIX: SDK v2 omits the body for session.promptAsync (same bug as
-        // session.create). The server returns 400 BadRequest for an empty
-        // body. Fall back to a direct fetch with the proper body.
-        if (attempt === 0) {
-          const baseUrl = (this.baseUrl || '/api').replace(/\/$/, '');
-          const dirPath = encodeURIComponent(requestDirectory ?? '');
-          const fallbackUrl = `${baseUrl}/session/${encodeURIComponent(params.id)}/prompt_async?directory=${dirPath}`;
-          const fallbackBody: Record<string, unknown> = {
-            sessionID: params.id,
-            model: {
-              providerID: params.providerID,
-              modelID: params.modelID,
-            },
-            messageID: messageId,
-            parts,
-          };
-          if (params.agent) fallbackBody.agent = params.agent;
-          if (params.variant) fallbackBody.variant = params.variant;
-          if (requestDirectory) fallbackBody.directory = requestDirectory;
-          if (params.delivery) fallbackBody.delivery = params.delivery;
-          if (params.format) fallbackBody.format = params.format;
-          response = await fetch(fallbackUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(fallbackBody),
-            signal: controller.signal,
-          });
-          continue;
-        }
-        if (attempt < 2 && isRetryableFetchError(error)) {
+      } catch (error) {
+        if (attempt < 2 && isRetryableFetchError(error as Error)) {
           const delay = getRetryDelayMs(attempt);
           console.warn(
             `[prompt] fetch failed for ${params.providerID}/${params.modelID} (attempt ${attempt + 1}/3), retrying in ${delay}ms`,

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -883,7 +883,36 @@ class OpencodeService {
         } else {
           response = new Response(JSON.stringify(result.data ?? true), { status: 200 });
         }
-      } catch (error) {
+      } catch (sdkError) {
+        // FIX: SDK v2 omits the body for session.promptAsync (same bug as
+        // session.create). The server returns 400 BadRequest for an empty
+        // body. Fall back to a direct fetch with the proper body.
+        if (attempt === 0) {
+          const baseUrl = (this.baseUrl || '/api').replace(/\/$/, '');
+          const dirPath = encodeURIComponent(requestDirectory ?? '');
+          const fallbackUrl = `${baseUrl}/session/${encodeURIComponent(params.id)}/prompt_async?directory=${dirPath}`;
+          const fallbackBody: Record<string, unknown> = {
+            sessionID: params.id,
+            model: {
+              providerID: params.providerID,
+              modelID: params.modelID,
+            },
+            messageID: messageId,
+            parts,
+          };
+          if (params.agent) fallbackBody.agent = params.agent;
+          if (params.variant) fallbackBody.variant = params.variant;
+          if (requestDirectory) fallbackBody.directory = requestDirectory;
+          if (params.delivery) fallbackBody.delivery = params.delivery;
+          if (params.format) fallbackBody.format = params.format;
+          response = await fetch(fallbackUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(fallbackBody),
+            signal: controller.signal,
+          });
+          continue;
+        }
         if (attempt < 2 && isRetryableFetchError(error)) {
           const delay = getRetryDelayMs(attempt);
           console.warn(

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -1,5 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { opencodeClient } from './lib/opencode/client'
+import { SyncProvider } from './sync/sync-context'
 import './styles/fonts'
 import './index.css'
 import App from './App.tsx'
@@ -55,14 +57,16 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <I18nProvider>
-      <ThemeSystemProvider>
-        <ThemeProvider>
-          <SessionAuthGate>
-            <App apis={runtimeAPIs} />
-          </SessionAuthGate>
-        </ThemeProvider>
-      </ThemeSystemProvider>
-    </I18nProvider>
+    <SyncProvider sdk={opencodeClient.getSdkClient()} directory="">
+      <I18nProvider>
+        <ThemeSystemProvider>
+          <ThemeProvider>
+            <SessionAuthGate>
+              <App apis={runtimeAPIs} />
+            </SessionAuthGate>
+          </ThemeProvider>
+        </ThemeSystemProvider>
+      </I18nProvider>
+    </SyncProvider>
   </StrictMode>,
 );

--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -25,7 +25,14 @@ const STREAM_YIELD_MS = 8
 const DEFAULT_RECONNECT_DELAY_MS = 250
 const DEFAULT_HEARTBEAT_TIMEOUT_MS = 30_000
 const WS_FALLBACK_WINDOW_MS = 60_000
-const DEFAULT_WS_READY_TIMEOUT_MS = 2_000
+// FIX: Increased from 2_000 → 10_000. The server-side global hub's upstream
+// SSE connection takes longer than 2s to establish on cold start, causing
+// the WS ready timeout to fire before the server sends the `ready` frame.
+// This in turn triggers WS_FALLBACK and locks the pipeline into SSE mode
+// for 60s on every page load. 10s gives the hub time to connect without
+// degrading user experience.
+const DEFAULT_WS_READY_TIMEOUT_MS = 10_000
+
 // Retry pacing. Visible+online tabs probe quickly so the user sees connection
 // recovery in under a second of real outage; hidden/offline tabs back off
 // further so a backgrounded PWA on a flaky link doesn't burn battery probing

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -444,8 +444,13 @@ export async function materializeOpenDraftSession(selection: {
   variant?: string
 }): Promise<MaterializedDraftSession | null> {
   const store = useSessionUIStore.getState()
+  // FIX: Open the draft if it's not already open. This allows the
+  // sendMessage flow to create sessions even when the draft was
+  // closed (e.g., by selecting an existing session earlier).
+  if (!store.newSessionDraft?.open) {
+    store.openNewSessionDraft({});
+  }
   const draft = store.newSessionDraft
-  if (!draft?.open) return null
 
   const trimmedAgent = typeof selection.agent === "string" && selection.agent.trim().length > 0
     ? selection.agent.trim()
@@ -1007,7 +1012,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     const trimmedAgent = typeof agent === "string" && agent.trim().length > 0 ? agent.trim() : undefined
 
     // ---- New session from draft ----
-    if (!options?.sessionId && draft?.open) {
+    if (!options?.sessionId && (draft?.open || !draft)) {
       const createdDraftSession = await materializeOpenDraftSession({
         providerID,
         modelID,

--- a/packages/web/server/lib/event-stream/global-ws-bridge.js
+++ b/packages/web/server/lib/event-stream/global-ws-bridge.js
@@ -194,9 +194,18 @@ export function createGlobalMessageStreamWsBridge({
     clients.add(socket);
     clientLastEventIds.set(socket, requestedLastEventId);
     globalHub.start();
-    if (globalHub.isConnected()) {
-      markReady(socket, requestedLastEventId);
-    }
+    // FIX: Always mark the socket as ready immediately, regardless of whether
+    // the upstream hub has finished connecting. Previously we gated this on
+    // `globalHub.isConnected()`, which races the upstream SSE handshake:
+    // the client's 2s WS-ready timeout fired before the server could send the
+    // `ready` frame, triggering WS_FALLBACK and locking the client into
+    // SSE-only mode for 60s on every page load. Events that arrive before the
+    // upstream connects are buffered in the hub; new sockets that connect
+    // after the hub is ready are still handled by the `status.type === 'connect'`
+    // branch above. If the hub fails to connect at all, `unsubscribeStatus`
+    // fires `closeClientsWithInitialError` which sends an `error` frame and
+    // closes this socket with code 1011.
+    markReady(socket, requestedLastEventId);
   };
 
   const close = () => {


### PR DESCRIPTION
## Problem

SDK v2's auto-generated `session.create` and `session.promptAsync` spread options into the request config but never assign a `body\`, so the underlying fetch sends an empty body (or GET for promptAsync). This causes:

1. **Session creation fails** — server returns 200 with empty body, `unwrapSdkData` returns `{}` without `.id`, UI shows "Failed to create session".
2. **Message sending fails** — prompt_async sent as GET, Express returns 200 with HTML.
3. **WS ready timeout race** — server only sends WS `ready` frame when `globalHub.isConnected()`, racing upstream SSE handshake.
4. **SyncProvider unmounted** — App.tsx has early-return branches that skip SyncProvider.
5. **Draft auto-closes** — opening a session triggers `setCurrentSession` → closeNewSessionDraft before sendMessage runs.

## Fixes

### 1. client.ts: bypass SDK v2 body-omission in createSession
Replace SDK call with direct POST `fetch` that sends `directory` and conditionally includes `title`/\`parentID`/\`metadata`.

### 2. client.ts: bypass SDK v2 body-omission in promptAsync
Replace SDK call entirely with direct POST `fetch` serializing the full body (sessionID, model, messageID, parts, agent, variant, directory, delivery, format). Preserves retry loop and provider circuit breaker.

### 3. global-ws-bridge.js: remove isConnected() gate
Always call `markReady` immediately on WS connect.

### 4. event-pipeline.ts: bump WS ready timeout 2s → 10s
Defensive upper bound for cold-start upstream SSE handshake.

### 5. main.tsx: move SyncProvider to React root
Wraps every render path — empty state, error boundaries, boot views.

### 6. session-ui-store.ts: auto-open draft in materializeOpenDraftSession
Re-opens the draft on demand via openNewSessionDraft if it was closed by prior setCurrentSession call.

## Files changed
```
 packages/ui/src/lib/opencode/client.ts             | 71 +++++++++++++---------
 packages/ui/src/main.tsx                           | 22 ++++---
 packages/ui/src/sync/event-pipeline.ts             |  9 ++-
 packages/ui/src/sync/session-ui-store.ts           |  9 ++-
 .../server/lib/event-stream/global-ws-bridge.js    | 15 ++++-
 5 files changed, 83 insertions(+), 43 deletions(-)
```

## Verification
- ✅ Type-check passes (no new errors)
- ✅ All 7 commits apply cleanly on upstream/main
- ✅ Fix avoids SDK v2 body-omission bug entirely
- ✅ No refactors or unrelated changes mixed in