### PR TITLE
Add SSH remote support for opencode binary validation

### DIFF
--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -280,14 +280,26 @@ function validateConfiguredOpencodeBinaryForManagedStart(): string | null {
     // ignore
   }
 
-  try {
-    const settings = readOpenChamberSettings();
-    const raw = typeof settings.opencodeBinary === 'string' ? settings.opencodeBinary.trim() : '';
-    if (raw) {
-      candidates.push(raw);
+  // support ssh remote
+  if (vscode.env.remoteName) {
+    const result = spawnSync('which', ['opencode'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    if (result.status === 0) {
+      candidates.push(result.stdout.trim());
     }
-  } catch {
-    // ignore
+  } else {
+    try {
+      const settings = readOpenChamberSettings();
+      const raw = typeof settings.opencodeBinary === 'string' ? settings.opencodeBinary.trim() : '';
+      if (raw) {
+        candidates.push(raw);
+      }
+    } catch {
+      // ignore
+    }
   }
 
   const raw = candidates[0];


### PR DESCRIPTION
This pull request updates the logic for validating the configured `opencode` binary in the VS Code extension to better support remote SSH environments. The main improvement is that it now checks for the presence of the `opencode` binary on the remote system when using SSH, making the extension more robust in remote development scenarios.

**Enhancements for SSH remote support:**

* In `packages/vscode/src/opencode.ts`, the `validateConfiguredOpencodeBinaryForManagedStart` function now detects if the extension is running in a remote environment (such as SSH) and attempts to locate the `opencode` binary using the `which` command on the remote system. If found, it adds the binary to the list of candidates.
* The function's logic is updated to ensure that the settings-based binary path is only checked when not in a remote environment, preventing unnecessary local checks during remote sessions.