### PR TITLE
refactor(chat): simplify baseDisplayMessages dedup — remove unnecessary reverse()

### DIFF
--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -1339,20 +1339,24 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
 
 
     const baseDisplayMessages = React.useMemo(() => streamPerfMeasure('ui.message_list.base_display_ms', () => {
-        const seenIdsFromTail = new Set<string>();
+        const seenIds = new Set<string>();
         const dedupedMessages: ChatMessageEntry[] = [];
-        for (let index = messages.length - 1; index >= 0; index -= 1) {
+        // Deduplicate from head to tail (oldest to newest) to preserve chronological
+        // order during history pagination (prepend). Older messages have smaller
+        // time-sortable IDs and appear first in the array. Keeping the first
+        // occurrence ensures prepended history isn't incorrectly discarded in favor
+        // of newer duplicates from the existing view.
+        for (let index = 0; index < messages.length; index += 1) {
             const message = messages[index];
             const messageId = message.info?.id;
             if (typeof messageId === 'string') {
-                if (seenIdsFromTail.has(messageId)) {
+                if (seenIds.has(messageId)) {
                     continue;
                 }
-                seenIdsFromTail.add(messageId);
+                seenIds.add(messageId);
             }
             dedupedMessages.push(getNormalizedMessageForDisplay(message));
         }
-        dedupedMessages.reverse();
 
         const output: ChatMessageEntry[] = [];
         const compactionCommandIds = new Set<string>();

--- a/packages/ui/src/components/chat/__tests__/baseDisplayMessagesDedup.test.ts
+++ b/packages/ui/src/components/chat/__tests__/baseDisplayMessagesDedup.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from 'bun:test';
+import type { ChatMessageEntry } from '../lib/turns/types';
+
+/**
+ * Dedup logic extracted from MessageList.tsx baseDisplayMessages.
+ * Tests verify that deduplication preserves chronological order
+ * and keeps the first occurrence of each message ID.
+ */
+function deduplicateMessages(messages: ChatMessageEntry[]): ChatMessageEntry[] {
+    const seenIds = new Set<string>();
+    const dedupedMessages: ChatMessageEntry[] = [];
+
+    for (let index = 0; index < messages.length; index += 1) {
+        const message = messages[index];
+        const messageId = message.info?.id;
+        if (typeof messageId === 'string') {
+            if (seenIds.has(messageId)) {
+                continue;
+            }
+            seenIds.add(messageId);
+        }
+        dedupedMessages.push(message);
+    }
+
+    return dedupedMessages;
+}
+
+function createMessageEntry({
+    id,
+    role,
+    parentID,
+    createdAt,
+}: {
+    id: string;
+    role: 'user' | 'assistant' | 'system';
+    parentID?: string;
+    createdAt: number;
+}): ChatMessageEntry {
+    return {
+        info: {
+            id,
+            role,
+            ...(parentID ? { parentID } : {}),
+            time: { created: createdAt },
+        } as ChatMessageEntry['info'],
+        parts: [],
+    };
+}
+
+describe('baseDisplayMessages dedup', () => {
+    test('removes duplicate message IDs, keeping the first occurrence', () => {
+        const msg1 = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 1 });
+        const msg2 = createMessageEntry({ id: 'msg-2', role: 'assistant', createdAt: 2 });
+        const msg1Duplicate = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 3 });
+
+        const result = deduplicateMessages([msg1, msg2, msg1Duplicate]);
+
+        expect(result).toHaveLength(2);
+        expect(result[0]?.info.id).toBe('msg-1');
+        expect(result[1]?.info.id).toBe('msg-2');
+    });
+
+    test('preserves input order when there are no duplicates', () => {
+        const msg1 = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 1 });
+        const msg2 = createMessageEntry({ id: 'msg-2', role: 'assistant', createdAt: 2 });
+        const msg3 = createMessageEntry({ id: 'msg-3', role: 'user', createdAt: 3 });
+
+        const result = deduplicateMessages([msg1, msg2, msg3]);
+
+        expect(result).toHaveLength(3);
+        expect(result[0]?.info.id).toBe('msg-1');
+        expect(result[1]?.info.id).toBe('msg-2');
+        expect(result[2]?.info.id).toBe('msg-3');
+    });
+
+    test('handles empty input', () => {
+        const result = deduplicateMessages([]);
+        expect(result).toHaveLength(0);
+    });
+
+    test('handles messages without IDs (keeps all)', () => {
+        const msg1 = { info: { role: 'user' } as ChatMessageEntry['info'], parts: [] };
+        const msg2 = { info: { role: 'assistant' } as ChatMessageEntry['info'], parts: [] };
+
+        const result = deduplicateMessages([msg1, msg2]);
+
+        expect(result).toHaveLength(2);
+    });
+
+    test('handles empty string ID (treated as no ID, keeps all)', () => {
+        const msg1 = createMessageEntry({ id: '', role: 'user', createdAt: 1 });
+        const msg2 = createMessageEntry({ id: '', role: 'assistant', createdAt: 2 });
+
+        const result = deduplicateMessages([msg1, msg2]);
+
+        // Empty string passes typeof === 'string' check, so it IS deduplicated
+        expect(result).toHaveLength(1);
+    });
+
+    test('handles single-element input', () => {
+        const msg1 = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 1 });
+
+        const result = deduplicateMessages([msg1]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.info.id).toBe('msg-1');
+    });
+
+    test('all messages sharing same ID keeps only first', () => {
+        const msg1 = createMessageEntry({ id: 'same-id', role: 'user', createdAt: 1 });
+        const msg2 = createMessageEntry({ id: 'same-id', role: 'assistant', createdAt: 2 });
+        const msg3 = createMessageEntry({ id: 'same-id', role: 'user', createdAt: 3 });
+
+        const result = deduplicateMessages([msg1, msg2, msg3]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.info.id).toBe('same-id');
+        expect(result[0]?.info.role).toBe('user');
+    });
+
+    test('deduplication scenario: prepend history with overlapping IDs', () => {
+        // Simulates history pagination where older messages are prepended
+        // and may overlap with existing messages in the view
+        const existingMsg1 = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 1 });
+        const existingMsg2 = createMessageEntry({ id: 'msg-2', role: 'assistant', createdAt: 2 });
+
+        // Prepended history (older) that overlaps with existing view
+        const prependedMsg1 = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 1 });
+        const prependedMsg2 = createMessageEntry({ id: 'msg-0', role: 'assistant', createdAt: 0 });
+
+        // After prepend, array is: [prepended older msgs, existing msgs]
+        const messages = [prependedMsg2, prependedMsg1, existingMsg1, existingMsg2];
+
+        const result = deduplicateMessages(messages);
+
+        // Should keep all unique IDs, first occurrence wins
+        expect(result).toHaveLength(3);
+        expect(result[0]?.info.id).toBe('msg-0'); // prepended (oldest)
+        expect(result[1]?.info.id).toBe('msg-1'); // first occurrence from prepend
+        expect(result[2]?.info.id).toBe('msg-2'); // existing
+    });
+
+    test('handles multiple duplicates of the same ID', () => {
+        const msg1 = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 1 });
+        const msg1Dup1 = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 2 });
+        const msg1Dup2 = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 3 });
+
+        const result = deduplicateMessages([msg1, msg1Dup1, msg1Dup2]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.info.id).toBe('msg-1');
+    });
+
+    test('preserves first occurrence when duplicates appear later', () => {
+        const msg1First = createMessageEntry({ id: 'msg-1', role: 'user', createdAt: 1 });
+        const msg1Later = createMessageEntry({ id: 'msg-1', role: 'assistant', createdAt: 5 });
+
+        const result = deduplicateMessages([msg1First, msg1Later]);
+
+        expect(result).toHaveLength(1);
+        // Should keep the first occurrence (createdAt: 1), not the later one
+        expect(result[0]?.info.role).toBe('user');
+    });
+});


### PR DESCRIPTION
## Summary

Simplify the `baseDisplayMessages` dedup loop in `MessageList.tsx` — change iteration from tail-to-head (with `.reverse()`) to head-to-tail (without `.reverse()`). The result is functionally identical because `state.message[sessionID]` is always sorted by ID and deduplicated before reaching MessageList (see data flow below).

## Data flow (no duplicates reach MessageList)

| Stage | File | Guarantee |
|---|---|---|
| `fetchMessages` | `use-sync.ts:333` | Sorts by `cmp(a.id, b.id)` |
| `materializeSessionSnapshots` | `materialization.ts:163` | Sorts by `cmp(left.info.id, right.info.id)` |
| `mergeMessages` | `optimistic.ts:76-86` | Deduplicates by ID via Map, then sorts |
| Event reducer | `event-reducer.ts:312-337` | `Binary.search` inserts in sorted position |

Since `state.message[sessionID]` never contains duplicate IDs, the old dedup (tail→head + reverse) and the new dedup (head→tail, no reverse) produce the **same output**. The change is a pure simplification.

## Why the change is still useful

- Removes the unnecessary `.reverse()` call
- Makes the intent clearer: "deduplicate in chronological order"
- Eliminates a subtle footgun if duplicates ever did appear (the old code would keep the newer duplicate, breaking chronological order)

## Changed files

| File | Change |
|---|---|
| `packages/ui/src/components/chat/MessageList.tsx` | +9 −5 |

## Verification

- `bun run type-check:ui` — ✅ (pre-existing TS errors only)
- `bun test packages/ui/src/sync/__tests__/materialization.test.ts` — ✅ 10/10 pass
- No regression in message deduplication for normal (non-pagination) flows

## Note

The actual root cause of the ordering bug reported in #2088 remains unknown. The data pipeline from store to render is correct — no layer reorders messages. Possible areas for further investigation: virtualizer scroll compensation during prepend, or a server-side ID ordering issue.