### PR TITLE
fix(sidebar): keep file tree expanded while refreshing root

### DIFF
--- a/packages/ui/src/components/layout/SidebarFilesTree.tsx
+++ b/packages/ui/src/components/layout/SidebarFilesTree.tsx
@@ -437,6 +437,7 @@ export const SidebarFilesTree: React.FC = () => {
   const [loadErrorsByDir, setLoadErrorsByDir] = React.useState<Record<string, string>>({});
   const loadedDirsRef = React.useRef<Set<string>>(new Set());
   const inFlightDirsRef = React.useRef<Set<string>>(new Set());
+  const refreshAbortRef = React.useRef<AbortController | null>(null);
 
   // Hydrate the per-root cache on mount or root change. The cache is
   // module-scoped so it survives close-and-reopen of the right sidebar;
@@ -623,12 +624,62 @@ export const SidebarFilesTree: React.FC = () => {
   const refreshRoot = React.useCallback(async () => {
     if (!root) return;
 
-    loadedDirsRef.current = new Set();
-    inFlightDirsRef.current = new Set();
-    setLoadErrorsByDir({});
-    setChildrenByDir((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+    // Cancel any previous refresh so stale results for the old root don't
+    // land after the user switches projects.
+    refreshAbortRef.current?.abort();
+    const controller = new AbortController();
+    refreshAbortRef.current = controller;
 
-    await loadDirectory(root);
+    try {
+      // Refresh root and every expanded directory under it, but keep the
+      // cached children visible while re-fetching so the tree stays expanded
+      // and does not flash/collapse. Read expanded paths from the store at
+      // call time so this callback stays stable when directories are toggled.
+      const currentExpanded = useFilesViewTabsStore.getState().byRoot[root]?.expandedPaths ?? [];
+      const normalizedExpanded = currentExpanded
+        .map((p) => normalizePath(p))
+        .filter((normalized): normalized is string =>
+          Boolean(normalized) && normalized !== root && normalized.startsWith(`${root}/`),
+        );
+      const pathsToRefresh = [root, ...normalizedExpanded];
+
+      loadedDirsRef.current = new Set(loadedDirsRef.current);
+      inFlightDirsRef.current = new Set(inFlightDirsRef.current);
+      for (const dirPath of pathsToRefresh) {
+        loadedDirsRef.current.delete(dirPath);
+        inFlightDirsRef.current.delete(dirPath);
+      }
+
+      setLoadErrorsByDir((prev) => {
+        if (Object.keys(prev).length === 0) return prev;
+        const next = { ...prev };
+        let changed = false;
+        for (const dirPath of pathsToRefresh) {
+          if (dirPath in next) {
+            delete next[dirPath];
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+
+      const isCancelled = () => controller.signal.aborted;
+
+      // Load root first, then expanded children with the same 3-at-a-time
+      // concurrency limit used on startup to avoid API stampede.
+      await loadDirectory(root, isCancelled);
+      for (let i = 0; i < normalizedExpanded.length && !controller.signal.aborted; i += 3) {
+        const batch = normalizedExpanded.slice(i, i + 3);
+        await Promise.all(batch.map((dirPath) => loadDirectory(dirPath, isCancelled)));
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      console.error('Failed to refresh sidebar tree:', error);
+    } finally {
+      if (refreshAbortRef.current === controller) {
+        refreshAbortRef.current = null;
+      }
+    }
   }, [loadDirectory, root]);
 
   /**
@@ -652,6 +703,9 @@ export const SidebarFilesTree: React.FC = () => {
   React.useEffect(() => {
     if (!root) return;
 
+    // Cancel any pending refresh so stale directory listings don't land after
+    // the user switches projects or toggles showHidden / showGitignored.
+    refreshAbortRef.current?.abort();
     loadedDirsRef.current = new Set();
     inFlightDirsRef.current = new Set();
     setLoadErrorsByDir({});


### PR DESCRIPTION
Fixes #2036

## Problem

Clicking the refresh button in the desktop file tree collapsed the entire directory tree back to the root. The old `refreshRoot()` implementation reset all loaded state (`childrenByDir`, `loadedDirsRef`, `inFlightDirsRef`, `loadErrorsByDir`) and only re-fetched the root directory, so every expanded directory disappeared on refresh.

## Change

`refreshRoot()` now performs an **incremental, stable refresh**:
- It keeps `childrenByDir` intact, so the tree stays expanded while new data is loading.
- It marks the root and every expanded directory under the current root as needing a reload.
- It clears load errors only for the directories being refreshed.
- It re-fetches the root first, then refreshes expanded children in batches of 3 (matching the startup concurrency limit) to avoid an API stampede.
- It reads the current expanded paths from the store at call time, so the callback does **not** get recreated on every expand/collapse toggle.
- It aborts any in-flight refresh when the user switches projects, preventing stale results from the old root from landing after the reset effect runs.
- It catches and logs unexpected refresh errors (other than cancellation) instead of producing an unhandled rejection.

## Scope

Only `packages/ui/src/components/layout/SidebarFilesTree.tsx` is changed. Worktree/project switching is unaffected because `refreshRoot()` is not part of the switch flow — the separate `useEffect` that runs on `root` change still does a full reset when the project actually changes.

## Verification

```bash
bunx eslint packages/ui/src/components/layout/SidebarFilesTree.tsx --config eslint.config.js
# exit=0, no errors
```

`bun run --cwd packages/ui type-check` currently reports pre-existing errors in unrelated files (`ChatInput.tsx`, `OpenChamberPage.tsx`, `OpenChamberVisualSettings.tsx`, `ja.ts`). `SidebarFilesTree.tsx` itself introduces no new TypeScript errors.

## What is intentionally not fixed here

This PR only fixes the manual-refresh collapse bug. The second part of #2036 — automatic refresh when the agent creates/modifies files — is left for a follow-up issue because it requires a server-side filesystem watcher and a new SSE event type (`files.changed`).
