### PR TITLE
perf(stores): skip redundant setDirectory when path is unchanged (#2096)

### DIFF
--- a/packages/ui/src/stores/useDirectoryStore.ts
+++ b/packages/ui/src/stores/useDirectoryStore.ts
@@ -269,6 +269,16 @@ export const useDirectoryStore = create<DirectoryStore>()(
           console.log('[DirectoryStore] setDirectory called with path:', resolvedPath);
         }
 
+        // Perf guard (#2096): skip when re-entering the already-active
+        // directory after initial persistence. HAR analysis showed 53
+        // redundant /api/config/settings PUT for the same lastDirectory
+        // in a single 18-min session. Keep first-init behavior intact by
+        // gating on hasPersistedDirectory.
+        const currentState = get();
+        if (currentState.currentDirectory === resolvedPath && currentState.hasPersistedDirectory) {
+          return;
+        }
+
         opencodeClient.setDirectory(resolvedPath);
         invalidateFileSearchCache();
 


### PR DESCRIPTION
## What

Adds a same-path no-op guard to `useDirectoryStore.setDirectory` so repeated invocations with the currently-active directory short-circuit before touching the OpenCode client, file-search cache, directory history, `safeStorage`, or `updateDesktopSettings`.

The guard runs only after `hasPersistedDirectory` is true, so the first-ever `setDirectory` still executes the full initialization path.

## Why

While debugging the `blocked >> wait` performance pattern in #2096, I captured an 18‑minute HAR with 5 962 requests. Two of the top-10 repeated payloads are:

- `PUT /api/config/settings` with `{"lastDirectory":"/Users/…/gcp"}` — **53 requests**, all identical.
- `PUT /api/config/settings` with `{"homeDirectory":"/Users/…","lastDirectory":"/Users/…/gcp"}` — **50 requests**, all identical.

The trigger was navigation UI paths (sidebar clicks, session switches, `goBack`/`goForward` roundtrips) re-invoking `setDirectory` with the same resolved path. Each call unconditionally:

- called `opencodeClient.setDirectory` (which round-trips to the runtime),
- invalidated the file-search cache,
- pushed a new entry into `directoryHistory`,
- wrote `lastDirectory` to `safeStorage`,
- fired `updateDesktopSettings`, which becomes a `PUT /api/config/settings`.

With the settings persist layer already under load (bot-confirmed sub-issue 3 in #2096), a hundred no-op writes per session amplify browser queue pressure noticeably. Guarding on the current directory + `hasPersistedDirectory` eliminates them without changing any legitimate navigation.

## What this does not do

- Does not change `goBack` / `goForward` — those move to a different `historyIndex` and never target the current directory in normal use.
- Does not touch `updateDesktopSettings` itself (a separate PR could add same-value coalescing there for other callers, out of scope here).
- Does not attempt to consolidate `/api/global/event/ws` + `/api/notifications/stream` duplicates or fix the `MarkdownRendererImpl` scanner — both tracked in #2096.

## Testing

- `bun run type-check` — pass (all 5 workspaces)
- `bun run lint` — pass (all 5 workspaces)
- `bun run electron:build` — pass; packaged locally and used daily since the patch, no observable regression in project switching, session opening, or navigation controls.
- Manual: repeatedly clicking the currently-active project in the sidebar no longer produces `PUT /api/config/settings` entries in DevTools.

Refs #2096
