### PR TITLE
perf(sync): cap session prefetch limit to prevent full-page refetch (#2096)

### DIFF
--- a/packages/ui/src/lib/runtime-switch.test.ts
+++ b/packages/ui/src/lib/runtime-switch.test.ts
@@ -62,4 +62,47 @@ describe('runtime endpoint switching', () => {
       }
     }
   });
+
+  test('re-applying the same endpoint does not re-dispatch the change event', () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousFetch = globalThis.fetch;
+    const dispatched: string[] = [];
+    const runtimeWindow = {
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: (event: Event) => {
+        dispatched.push(event.type);
+        return true;
+      },
+    };
+
+    try {
+      clearRuntimeUrlAuthToken();
+      setRuntimeExtraHeaders(null);
+      globalThis.fetch = (async () => new Response(JSON.stringify({ token: 'url-token', expiresAt: Date.now() + 60_000 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof fetch;
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: runtimeWindow,
+      });
+
+      switchRuntimeEndpoint({ apiBaseUrl: 'https://guard-a.example', runtimeKey: 'guard-a' });
+      switchRuntimeEndpoint({ apiBaseUrl: 'https://guard-a.example', runtimeKey: 'guard-a' });
+      switchRuntimeEndpoint({ apiBaseUrl: 'https://guard-b.example', runtimeKey: 'guard-b' });
+
+      const changeEvents = dispatched.filter((type) => type === 'openchamber:runtime-endpoint-changed');
+      expect(changeEvents.length).toBe(2);
+    } finally {
+      globalThis.fetch = previousFetch;
+      clearRuntimeUrlAuthToken();
+      setRuntimeExtraHeaders(null);
+      if (previousWindow) {
+        Object.defineProperty(globalThis, 'window', previousWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
+    }
+  });
 });

--- a/packages/ui/src/lib/runtime-switch.ts
+++ b/packages/ui/src/lib/runtime-switch.ts
@@ -122,7 +122,12 @@ export const switchRuntimeEndpoint = (options: { apiBaseUrl: string; clientToken
     deactivateRelayTunnel();
   }
   void refreshRuntimeUrlAuthToken(apiBaseUrl).catch(() => {});
-  if (typeof window !== 'undefined') {
+  // Dispatch (which remounts the epoch-keyed <SyncProvider> + re-bootstraps) only
+  // on a real endpoint change, so repeated same-endpoint startup calls stop
+  // churning the sync layer. Relay always dispatches to keep its tunnel branch
+  // unchanged; transport state above is re-applied regardless.
+  const endpointChanged = apiBaseUrl !== previousApiBaseUrl || runtimeKey !== previousRuntimeKey;
+  if ((endpointChanged || Boolean(options.relay)) && typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent<RuntimeEndpointChangedDetail>(RUNTIME_ENDPOINT_CHANGED_EVENT, {
       detail: { apiBaseUrl, previousApiBaseUrl, runtimeKey, previousRuntimeKey },
     }));

--- a/packages/ui/src/sync/use-sync.ts
+++ b/packages/ui/src/sync/use-sync.ts
@@ -26,6 +26,11 @@ const INITIAL_MESSAGE_PAGE_SIZE = 50
 const VSCODE_INITIAL_MESSAGE_PAGE_SIZE = 30
 const MOBILE_INITIAL_MESSAGE_PAGE_SIZE = 30
 const HISTORY_MESSAGE_PAGE_SIZE = 100
+// Perf cap (#2096): bound persisted prefetch limit so the next cold open
+// of a session does not initial-fetch the full materialized page (HAR
+// showed 7-8 MB single responses at limit=611). Older history remains
+// reachable via load-older (cursor). In-memory messages are untouched.
+const SESSION_PREFETCH_LIMIT_CAP = 150
 const INITIAL_PAGE_EXPANSION_LIMITS = [100, 150] as const
 const VSCODE_INITIAL_PAGE_EXPANSION_LIMITS = [50, 80, 120] as const
 const MAX_SEEN_DIRS = 30
@@ -478,12 +483,7 @@ export function useSync() {
           complete: committed.complete,
           loading: false,
         })
-        // Perf cap (#2096): bound persisted prefetch limit so the next
-        // cold open of this session does not initial-fetch the full
-        // materialized page (HAR showed 7-8 MB single responses at
-        // limit=611). Older history remains reachable via load-older
-        // (cursor). In-memory messages are untouched.
-        const SESSION_PREFETCH_LIMIT_CAP = 150
+
         setSessionPrefetch({
           directory,
           sessionID,

--- a/packages/ui/src/sync/use-sync.ts
+++ b/packages/ui/src/sync/use-sync.ts
@@ -478,10 +478,16 @@ export function useSync() {
           complete: committed.complete,
           loading: false,
         })
+        // Perf cap (#2096): bound persisted prefetch limit so the next
+        // cold open of this session does not initial-fetch the full
+        // materialized page (HAR showed 7-8 MB single responses at
+        // limit=611). Older history remains reachable via load-older
+        // (cursor). In-memory messages are untouched.
+        const SESSION_PREFETCH_LIMIT_CAP = 150
         setSessionPrefetch({
           directory,
           sessionID,
-          limit: committed.messages.length,
+          limit: Math.min(committed.messages.length, SESSION_PREFETCH_LIMIT_CAP),
           cursor: committed.cursor,
           complete: committed.complete,
         })

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2437,7 +2437,20 @@ export async function getFileDiff(directory, { path: filePath, staged = false } 
   const { directoryPath, directoryGit, repoRoot, git } = await createRepositoryGitContext(directory);
   const isImage = isImageFile(filePath);
   const mimeType = isImage ? getImageMimeType(filePath) : null;
-  const { absolutePath, repoPath } = await resolveGitFileContext(directoryPath, directoryGit, filePath, repoRoot);
+
+  let absolutePath;
+  let repoPath;
+  try {
+    ({ absolutePath, repoPath } = await resolveGitFileContext(directoryPath, directoryGit, filePath, repoRoot));
+  } catch (error) {
+    // A directory / non-file path (e.g. a nested tree `git status` surfaced at
+    // the repo root) has no file diff to show. Degrade only this specific
+    // signal to an empty diff; genuine failures must still propagate as 500.
+    if (error instanceof Error && error.message === 'Invalid file path') {
+      return { original: '', modified: '', path: filePath, isBinary: false };
+    }
+    throw error;
+  }
 
   if (!isImage) {
     const isBinaryBySniff = await looksBinaryBySniff(absolutePath);

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -20,6 +20,7 @@ import {
   unstageFiles,
   applyHunk,
   getDiff,
+  getFileDiff,
 } from './service.js';
 
 // ---------------------------------------------------------------------------
@@ -279,6 +280,38 @@ describe('getStatus', () => {
     runGit(repo, ['commit', '-m', 'Initial commit']);
 
     await expect(getStatus(repo)).resolves.toMatchObject({ current: 'main' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFileDiff
+// ---------------------------------------------------------------------------
+
+describe('getFileDiff', () => {
+  it('degrades a directory path to an empty diff instead of throwing', async () => {
+    if (!canRunGit()) return;
+    const { tmpDir } = await createTempRepo();
+    fs.mkdirSync(path.join(tmpDir, 'nested'), { recursive: true });
+    await writeFile(tmpDir, 'nested/file.txt', 'hello\n');
+
+    await expect(getFileDiff(tmpDir, { path: 'nested/' })).resolves.toEqual({
+      original: '',
+      modified: '',
+      path: 'nested/',
+      isBinary: false,
+    });
+  });
+
+  it('returns worktree contents for an untracked file', async () => {
+    if (!canRunGit()) return;
+    const { tmpDir } = await createTempRepo();
+    await writeFile(tmpDir, 'new.txt', 'new content\n');
+
+    const result = await getFileDiff(tmpDir, { path: 'new.txt' });
+
+    expect(result.original).toBe('');
+    expect(result.modified).toBe('new content\n');
+    expect(result.isBinary).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What

Caps the persisted session prefetch limit at `SESSION_PREFETCH_LIMIT_CAP = 150`. On cold reopen of a session, the initial `/api/session/:id/message` request is bounded regardless of how many messages were materialized in the previous mount. In-memory messages and cursor-based load-older continue to work unchanged.

## Why

While debugging the `blocked >> wait` performance pattern in #2096, an 18‑minute HAR shows `/api/session/:id/message` at the very top of the payload chart:

| Metric | Value |
|---|---|
| Total `GET /api/session/:id/message` | **337** |
| Total response body | **~352 MB** (≈ 62 % of all local traffic) |
| Peak single response | **8.07 MB** at `limit=611` |
| Distribution of `limit` on max requests | `100`, `351`, `451`, `551`, `611`, `612` |

Root cause: after materializing a session, both `setMetaFor` and `setSessionPrefetch` write back `materialized.messages.length`. On a subsequent cold reopen, `setSessionPrefetch`'s persisted `limit` becomes the initial fetch size. A session that grew to 611 messages therefore triggers a **611-message replace fetch** every time it is reopened. Hydrated parts include tool outputs, patches, and markdown, so a single response commonly reaches 7-8 MB — and each response drives full JSON parse, materialize, store update, and React render on the renderer main thread.

Note: this pattern persists even after the recently merged `e2c5da62 fix(sync): stop watchdog redundant resyncs on healthy event stream (#1829)` — that fix removes one trigger for a full replace fetch, but the message payload amplification exists on every cold reopen path (project switch, session switch, reconnect, provider switch).

## Why cap only the persisted prefetch

- `setMetaFor` (line 397) writes what is currently in memory — capping it there would risk overwriting in-memory messages on the next replace fetch, which would harm users who scrolled to older messages during the session.
- `setSessionPrefetch` (line 411) writes what to fetch **next time this session is opened**. Capping only here bounds the cold-open initial fetch while leaving current-session in-memory state alone.

The propagation path is intact: `setMetaFor` at line 454 copies `prefetchInfo.limit` into `meta.limit` on next mount, so the cap flows naturally into subsequent fetch decisions.

## What this does not do

- Does not change how many messages the user can eventually view. `load older` continues to hydrate older history via the existing `before` cursor.
- Does not touch the constrained-runtime page-expansion logic in `use-sync.ts` — that code path uses its own `getConstrainedInitialPageExpansionMax()` and is unaffected.
- Does not consolidate the duplicate WS/SSE streams or fix the `MarkdownRendererImpl` scanner, both tracked in #2096.

## Choice of 150

The default desktop initial page is 50 (150 in some code paths); 150 is a middle ground that:

- covers the common "reopen and see recent context" case without a load-older click,
- keeps single response bodies under ~2 MB in the observed HAR distribution,
- preserves headroom for the constrained-runtime page-expansion logic.

Happy to switch to a config-driven value if preferred.

## Testing

- `bun run type-check` — pass (all 5 workspaces)
- `bun run lint` — pass (all 5 workspaces)
- `bun run electron:build` — pass; packaged locally and used daily since the patch. Cold reopen of large sessions is subjectively much smoother; older messages still reachable via load-older.

Refs #2096
