### PR TITLE
fix(ui): register loopback browser URLs without allowExternal

### DIFF
--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -37,6 +37,7 @@ import {
   desktopAnnotationToFile,
   getCachedProxyTarget,
   getBrowserProxyTargetKey,
+  isLoopbackPreviewUrl,
   previewProxyTargetCache,
 } from '@/lib/preview/screenshot-capture';
 
@@ -1310,6 +1311,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
   const [history, setHistory] = React.useState<string[]>(() => startUrl ? [startUrl] : []);
   const [historyIndex, setHistoryIndex] = React.useState(() => startUrl ? 0 : -1);
   const [reloadNonce, bumpReload] = React.useReducer((value: number) => value + 1, 0);
+  const [proxyRegistrationNonce, bumpProxyRegistration] = React.useReducer((value: number) => value + 1, 0);
   const [isLoading, setIsLoading] = React.useState(Boolean(startUrl));
   const [isInspecting, setIsInspecting] = React.useState(false);
   const [hoverTarget, setHoverTarget] = React.useState<PreviewElementMetadata | null>(null);
@@ -1404,11 +1406,17 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
 
     void (async () => {
       try {
+        // Loopback hosts must use the non-external path. allowExternal:true
+        // rejects localhost/private addresses (SSRF guard), which previously
+        // forced a direct iframe fallback that most pages refuse to frame.
+        const allowExternal = !isLoopbackPreviewUrl(loadedUrl);
         const response = await runtimeFetch('/api/preview/targets', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ url: loadedUrl, allowExternal: true }),
+          body: JSON.stringify(allowExternal
+            ? { url: loadedUrl, allowExternal: true }
+            : { url: loadedUrl }),
         });
 
         if (!response.ok) {
@@ -1418,6 +1426,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
             : `HTTP ${response.status}`;
           if (!cancelled) {
             setProxyState({ status: 'error', message });
+            setIsLoading(false);
           }
           return;
         }
@@ -1429,6 +1438,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
         if (!proxyBasePath || !previewToken) {
           if (!cancelled) {
             setProxyState({ status: 'error', message: t('contextPanel.preview.proxyError') });
+            setIsLoading(false);
           }
           return;
         }
@@ -1441,6 +1451,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
         if (!cancelled) {
           const message = error instanceof Error ? error.message : String(error);
           setProxyState({ status: 'error', message });
+          setIsLoading(false);
         }
       }
     })();
@@ -1448,7 +1459,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
     return () => {
       cancelled = true;
     };
-  }, [loadedUrl, t]);
+  }, [loadedUrl, proxyRegistrationNonce, t]);
 
   const proxyUrlAuthKey = loadedUrl && proxyState.status === 'ready'
     ? `${proxyState.proxyBasePath}|${proxyState.previewToken || ''}|${reloadNonce}`
@@ -1464,14 +1475,25 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
     setUrlAuthReadyKey('');
     void refreshRuntimeUrlAuthToken(getRuntimeApiBaseUrl())
       .then((token) => {
-        if (!cancelled && token) setUrlAuthReadyKey(proxyUrlAuthKey);
+        if (cancelled) return;
+        if (token) {
+          setUrlAuthReadyKey(proxyUrlAuthKey);
+          return;
+        }
+        setProxyState({ status: 'error', message: t('contextPanel.browser.authError') });
+        setIsLoading(false);
       })
-      .catch(() => {});
+      .catch((error) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : t('contextPanel.browser.authError');
+        setProxyState({ status: 'error', message });
+        setIsLoading(false);
+      });
 
     return () => {
       cancelled = true;
     };
-  }, [proxyUrlAuthKey]);
+  }, [proxyUrlAuthKey, t]);
 
   const proxySrc = React.useMemo(() => {
     if (urlAuthReadyKey !== proxyUrlAuthKey) return '';
@@ -1491,7 +1513,12 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
     }
   }, [loadedUrl, proxyState, proxyUrlAuthKey, reloadNonce, urlAuthReadyKey]);
 
-  const iframeSrc = proxySrc || (proxyState.status === 'error' ? loadedUrl : '');
+  // Only fall back to a direct iframe for public hosts when proxy registration
+  // fails. Loopback must stay on the proxy path — a direct localhost iframe
+  // loses inspect/bridge and often fails framing when auth is required.
+  const iframeSrc = proxySrc
+    || (proxyState.status === 'error' && loadedUrl && !isLoopbackPreviewUrl(loadedUrl) ? loadedUrl : '');
+  const showProxyError = proxyState.status === 'error' && !iframeSrc;
 
   const getCurrentUrlFromFrameUrl = React.useCallback((frameUrl: string): string => {
     if (!frameUrl || !loadedUrl || proxyState.status !== 'ready') return '';
@@ -1770,6 +1797,24 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
               </div>
             ) : null}
           </div>
+        ) : showProxyError ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background p-6 text-center">
+            <div className="typography-ui-header text-muted-foreground">{t('contextPanel.preview.proxyError')}</div>
+            {proxyState.status === 'error' && proxyState.message ? (
+              <div className="max-w-md typography-micro text-muted-foreground">{proxyState.message}</div>
+            ) : null}
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                setProxyState({ status: 'idle' });
+                bumpProxyRegistration();
+              }}
+            >
+              {t('contextPanel.preview.actions.retry')}
+            </Button>
+          </div>
         ) : (
           <div className="absolute inset-0 flex flex-col items-center justify-center gap-6 bg-background p-6 text-center">
             <OpenChamberLogo width={140} height={140} className="opacity-20" />
@@ -1778,7 +1823,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
             <span className="max-w-md typography-micro leading-relaxed text-status-warning/70">{t('contextPanel.browser.trustNotice')}</span>
           </div>
         )}
-        {isLoading ? (
+        {isLoading && !showProxyError ? (
           <div className="absolute inset-0 flex items-center justify-center bg-background/70 typography-micro text-muted-foreground">
             {t('common.loading')}
           </div>

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1025,6 +1025,7 @@ export const dict = {
   'contextPanel.browser.empty': 'Web browser',
   'contextPanel.browser.emptyHint': 'Enter an address above to start browsing the web',
   'contextPanel.browser.inspectUnavailable': 'This page cannot be inspected from the browser panel.',
+  'contextPanel.browser.authError': 'Could not authenticate the browser proxy.',
   'contextPanel.browser.trustNotice': 'Pages opened here run with full access to OpenChamber — needed for inspect and screenshots. Only open sites you trust: a malicious page could read your data or act on your behalf.',
   'contextPanel.tab.closeTabAria': 'Close {label} tab',
   'contextPanel.actions.collapsePanel': 'Collapse panel',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1026,6 +1026,7 @@ export const dict: Record<I18nKey, string> = {
   "contextPanel.browser.empty": "Navegador web",
   "contextPanel.browser.emptyHint": "Ingrese una dirección arriba para comenzar a navegar",
   "contextPanel.browser.inspectUnavailable": "Esta página no se puede inspeccionar desde el panel del navegador.",
+  "contextPanel.browser.authError": "No se pudo autenticar el proxy del navegador.",
   "contextPanel.browser.trustNotice": "Las páginas que abras aquí se ejecutan con acceso completo a OpenChamber: necesario para la inspección y las capturas. Abre solo sitios de confianza: una página maliciosa podría leer tus datos o actuar en tu nombre.",
   "contextPanel.tab.closeTabAria": "Cerrar pestaña {label}",
   "contextPanel.actions.collapsePanel": "Colapsar panel",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -2654,6 +2654,7 @@ export const dict = {
   'worktree.bootstrap.toast.failedDescription': 'Le worktree a été créé, mais la configuration en arrière-plan ne s’est pas terminée.',
   'worktree.bootstrap.toast.timeoutDescription': 'Le worktree a été créé, mais la configuration en arrière-plan a expiré.',
   'contextPanel.browser.inspectUnavailable': 'Cette page ne peut pas être inspectée depuis le panneau de navigateur.',
+  'contextPanel.browser.authError': 'Impossible d\'authentifier le proxy du navigateur.',
   'contextPanel.browser.trustNotice': 'Les pages ouvertes ici s’exécutent avec un accès complet à OpenChamber — nécessaire pour l’inspection et les captures d’écran. N’ouvrez que des sites de confiance : une page malveillante pourrait lire vos données ou agir en votre nom.',
   'filesView.diagram.closeDiagramView': 'Fermer la vue diagramme',
   'filesView.diagram.saveDiagram': 'Enregistrer le diagramme',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -1022,6 +1022,7 @@ export const dict: Record<I18nKey, string> = {
   'contextPanel.browser.empty': 'ウェブブラウザ',
   'contextPanel.browser.emptyHint': '上のアドレスバーにURLを入力してウェブを閲覧',
   'contextPanel.browser.inspectUnavailable': 'このページはブラウザパネルから検査できません。',
+  'contextPanel.browser.authError': 'ブラウザプロキシの認証に失敗しました。',
   'contextPanel.browser.trustNotice': 'ここで開かれたページはOpenChamberへの完全なアクセス権を持ちます — 検査とスクリーンショットに必要です。信頼できるサイトのみを開いてください: 悪意のあるページがデータを読み取ったりあなたの代わりに行動したりする可能性があります。',
   'contextPanel.tab.closeTabAria': '{label}タブを閉じる',
   'contextPanel.actions.collapsePanel': 'パネルを折りたたむ',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1026,6 +1026,7 @@ export const dict: Record<I18nKey, string> = {
   'contextPanel.browser.empty': '웹 브라우저',
   'contextPanel.browser.emptyHint': '위에 주소를 입력하여 탐색을 시작하세요',
   'contextPanel.browser.inspectUnavailable': '브라우저 패널에서 이 페이지를 검사할 수 없습니다.',
+  'contextPanel.browser.authError': '브라우저 프록시를 인증할 수 없습니다.',
   'contextPanel.browser.trustNotice': '여기서 여는 페이지는 OpenChamber에 대한 전체 액세스 권한으로 실행됩니다 — 검사와 스크린샷에 필요합니다. 신뢰하는 사이트만 여세요: 악성 페이지가 데이터를 읽거나 사용자를 대신해 동작할 수 있습니다.',
   'contextPanel.preview.actions.reload': '미리보기 새로고침',
   'contextPanel.preview.actions.openExternal': '브라우저에서 열기',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1338,6 +1338,7 @@ export const dict: Record<I18nKey, string> = {
   'contextPanel.browser.empty': 'Przeglądarka internetowa',
   'contextPanel.browser.emptyHint': 'Wprowadź adres powyżej, aby rozpocząć przeglądanie',
   'contextPanel.browser.inspectUnavailable': 'Nie można sprawdzić tej strony z panelu przeglądarki.',
+  'contextPanel.browser.authError': 'Nie udało się uwierzytelnić proxy przeglądarki.',
   'contextPanel.browser.trustNotice': 'Strony otwierane tutaj działają z pełnym dostępem do OpenChamber — jest to wymagane do inspekcji i zrzutów ekranu. Otwieraj tylko zaufane witryny: złośliwa strona może odczytać Twoje dane lub działać w Twoim imieniu.',
   'contextPanel.preview.actions.openExternal': 'Otwórz w przeglądarce',
   'contextPanel.preview.actions.reload': 'Odśwież podgląd',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1026,6 +1026,7 @@ export const dict: Record<I18nKey, string> = {
   "contextPanel.browser.empty": "Navegador web",
   "contextPanel.browser.emptyHint": "Digite um endereço acima para começar a navegar",
   "contextPanel.browser.inspectUnavailable": "Esta página não pode ser inspecionada pelo painel do navegador.",
+  "contextPanel.browser.authError": "Não foi possível autenticar o proxy do navegador.",
   "contextPanel.browser.trustNotice": "As páginas abertas aqui são executadas com acesso total ao OpenChamber — necessário para inspeção e capturas de tela. Abra apenas sites confiáveis: uma página maliciosa pode ler seus dados ou agir em seu nome.",
   "contextPanel.tab.closeTabAria": "Fechar aba {label}",
   "contextPanel.actions.collapsePanel": "Recolher painel",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1026,6 +1026,7 @@ export const dict: Record<I18nKey, string> = {
   "contextPanel.browser.empty": "Веб-браузер",
   "contextPanel.browser.emptyHint": "Введіть адресу вище, щоб почати перегляд",
   "contextPanel.browser.inspectUnavailable": "Цю сторінку неможливо інспектувати з панелі браузера.",
+  "contextPanel.browser.authError": "Не вдалося автентифікувати проксі браузера.",
   "contextPanel.browser.trustNotice": "Сторінки, відкриті тут, працюють із повним доступом до OpenChamber — це потрібно для inspect і скріншотів. Відкривайте лише сайти, яким довіряєте: шкідлива сторінка може прочитати ваші дані чи діяти від вашого імені.",
   "contextPanel.tab.closeTabAria": "Закрити вкладку {label}",
   "contextPanel.actions.collapsePanel": "Згорнути панель",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1026,6 +1026,7 @@ export const dict: Record<I18nKey, string> = {
   'contextPanel.browser.empty': '网页浏览器',
   'contextPanel.browser.emptyHint': '在上方输入网址开始浏览',
   'contextPanel.browser.inspectUnavailable': '无法从浏览器面板检查此页面。',
+  'contextPanel.browser.authError': '无法验证浏览器代理。',
   'contextPanel.browser.trustNotice': '在此打开的页面以对 OpenChamber 的完全访问权限运行 — 检查和截图需要此权限。仅打开你信任的站点：恶意页面可能读取你的数据或以你的身份执行操作。',
   'contextPanel.tab.closeTabAria': '关闭 {label} 标签',
   'contextPanel.actions.collapsePanel': '折叠面板',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1038,6 +1038,7 @@ export const dict: Record<I18nKey, string> = {
   'contextPanel.browser.empty': '網頁瀏覽器',
   'contextPanel.browser.emptyHint': '在上方輸入網址開始瀏覽',
   'contextPanel.browser.inspectUnavailable': '無法從瀏覽器面板檢查此頁面。',
+  'contextPanel.browser.authError': '無法驗證瀏覽器代理。',
   'contextPanel.browser.trustNotice': '在此開啟的頁面以對 OpenChamber 的完整存取權限執行 — 檢查與截圖需要此權限。僅開啟你信任的網站：惡意頁面可能讀取你的資料或以你的身分執行操作。',
   'contextPanel.tab.closeTabAria': '關閉 {label} 分頁',
   'contextPanel.actions.collapsePanel': '摺疊面板',

--- a/packages/ui/src/lib/preview/screenshot-capture.loopback.test.ts
+++ b/packages/ui/src/lib/preview/screenshot-capture.loopback.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  isLoopbackPreviewHostname,
+  isLoopbackPreviewUrl,
+} from './screenshot-capture';
+
+describe('isLoopbackPreviewHostname', () => {
+  test('accepts the same loopback hosts as the preview proxy non-external path', () => {
+    for (const host of ['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0', 'LOCALHOST']) {
+      expect(isLoopbackPreviewHostname(host)).toBe(true);
+    }
+  });
+
+  test('rejects public and private non-loopback hosts', () => {
+    for (const host of ['example.com', '192.168.1.1', '10.0.0.5', 'docs.openchamber.dev']) {
+      expect(isLoopbackPreviewHostname(host)).toBe(false);
+    }
+  });
+});
+
+describe('isLoopbackPreviewUrl', () => {
+  test('detects loopback http(s) URLs used by the web browser pane', () => {
+    expect(isLoopbackPreviewUrl('http://localhost:5173/app')).toBe(true);
+    expect(isLoopbackPreviewUrl('http://127.0.0.1:3000')).toBe(true);
+    expect(isLoopbackPreviewUrl('https://example.com')).toBe(false);
+    expect(isLoopbackPreviewUrl('not a url')).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/preview/screenshot-capture.ts
+++ b/packages/ui/src/lib/preview/screenshot-capture.ts
@@ -223,6 +223,26 @@ export const getBrowserProxyTargetKey = (url: string): string => {
   }
 };
 
+// Matches the server's LOOPBACK_HOSTS set used by /api/preview/targets when
+// allowExternal is false. The browser pane must use that path for these hosts —
+// allowExternal:true rejects loopback/private addresses as SSRF.
+export const isLoopbackPreviewHostname = (hostname: string): boolean => {
+  const host = hostname.toLowerCase();
+  return host === 'localhost'
+    || host === '127.0.0.1'
+    || host === '::1'
+    || host === '[::1]'
+    || host === '0.0.0.0';
+};
+
+export const isLoopbackPreviewUrl = (url: string): boolean => {
+  try {
+    return isLoopbackPreviewHostname(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+};
+
 function getCaptureBackgroundColor(document: Document): string {
   const fallback = '#ffffff';
   const view = document.defaultView ?? window;
@@ -475,11 +495,16 @@ const getExternalResourceProxyUrl = async (url: URL): Promise<string> => {
   const existingRequest = previewProxyTargetRequests.get(targetKey);
   const request = existingRequest ?? (async () => {
     try {
+      // Loopback must use the non-external registration path; allowExternal
+      // rejects private/loopback hosts and would leave screenshot fetches broken.
+      const requestBody = isLoopbackPreviewHostname(url.hostname)
+        ? { url: url.toString() }
+        : { url: url.toString(), allowExternal: true };
       const response = await runtimeFetch('/api/preview/targets', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ url: url.toString(), allowExternal: true }),
+        body: JSON.stringify(requestBody),
       });
 
       if (!response.ok) {

--- a/packages/web/server/lib/preview/proxy-runtime.test.js
+++ b/packages/web/server/lib/preview/proxy-runtime.test.js
@@ -348,6 +348,13 @@ describe('proxy target normalization (SSRF guard)', () => {
     }
   });
 
+  it('still accepts loopback on the non-external path used by local preview/browser', () => {
+    expect(normalizeProxyTargetUrl('http://localhost:5173/', { allowExternal: false }))
+      .toEqual({ ok: true, origin: 'http://127.0.0.1:5173' });
+    expect(normalizeProxyTargetUrl('http://127.0.0.1:3000/', { allowExternal: false }))
+      .toEqual({ ok: true, origin: 'http://127.0.0.1:3000' });
+  });
+
   it('still blocks private hosts even via IPv4-mapped IPv6', () => {
     expect(normalizeProxyTargetUrl('http://[::ffff:127.0.0.1]/', { allowExternal: true }).ok).toBe(false);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The web UI browser pane always registered preview proxy targets with `allowExternal: true`. That path's SSRF guard rejects localhost/private hosts, so local URLs never got the same-origin proxy and fell back to a direct iframe that most pages refuse to frame.

## Changes

- Detect loopback hosts in the web browser pane and call `/api/preview/targets` **without** `allowExternal` (same path as the preview pane).
- Keep `allowExternal: true` only for public hosts.
- Stop falling back to a direct iframe for loopback failures; show a proxy error + retry instead.
- Surface URL-auth mint failures instead of leaving the pane stuck loading.
- Apply the same loopback registration rule to screenshot resource proxying.
- Add unit coverage for loopback helpers and the non-external proxy path.

## Validation

- `bun test packages/ui/src/lib/preview/screenshot-capture.loopback.test.ts packages/ui/src/lib/i18n/messages.test.ts`
- `bun run --cwd packages/ui type-check`
- `bun run --cwd packages/ui lint`
- `bun run --cwd packages/web test server/lib/preview/proxy-runtime.test.js`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbe5b2ec-8a69-4617-a5d8-dac4c946b993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbe5b2ec-8a69-4617-a5d8-dac4c946b993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

