### PR TITLE
feat(ui): Discord onboarding wizard and messenger UX polish

### DIFF
--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   RiDiscordLine,
   RiCheckLine,
-  RiCloseLine,
   RiLoader4Line,
   RiAddLine,
   RiSendPlaneLine,
@@ -28,7 +27,17 @@ import { useOttoEventsStore, type OttoUiRealtimeEvent } from '@/stores/useOttoEv
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
+import { useI18n } from '@/lib/i18n';
 import { DiscordOnboardingWizard } from './DiscordOnboardingWizard';
 import { DiscordCommandsButton } from './DiscordCommandPalette';
 
@@ -1144,6 +1153,7 @@ function DiscordAdvancedSettings({
 }
 
 function ConnectionCard({ conn }: { conn: MessengerConnection }) {
+  const { t } = useI18n();
   const onboardingStep = useMessengerStore((s) => s.onboardingStep);
   const onboardingType = useMessengerStore((s) => s.onboardingType);
   const showWizard = onboardingStep !== null && onboardingType === 'discord';
@@ -1187,6 +1197,7 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
   const [showToken, setShowToken] = useState(false);
   const [tokenInput, setTokenInput] = useState('');
   const [showTokenPlain, setShowTokenPlain] = useState(false);
+  const [disconnectConfirmOpen, setDisconnectConfirmOpen] = useState(false);
 
   const token = conn.botToken;
   const target = conn.defaultChannelId;
@@ -1272,14 +1283,15 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
           >
             {conn.status === 'connecting' ? 'Testing…' : 'Verify token'}
           </button>
-          <button
+          <Button
             type="button"
-            onClick={() => removeConnection(conn.type)}
-            className="text-muted-foreground hover:text-destructive"
-            title={`Disconnect ${meta.name}`}
+            variant="destructive"
+            size="xs"
+            className="!font-normal"
+            onClick={() => setDisconnectConfirmOpen(true)}
           >
-            <RiCloseLine className="size-4" />
-          </button>
+            {t('settings.integrations.discord.disconnect.button')}
+          </Button>
         </div>
       </div>
 
@@ -1440,6 +1452,38 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
           />
         </div>
       )}
+
+      <Dialog open={disconnectConfirmOpen} onOpenChange={setDisconnectConfirmOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t('settings.integrations.discord.disconnect.dialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('settings.integrations.discord.disconnect.dialog.description')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setDisconnectConfirmOpen(false)}
+            >
+              {t('settings.common.actions.cancel')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => {
+                removeConnection(conn.type);
+                setDisconnectConfirmOpen(false);
+              }}
+            >
+              {t('settings.integrations.discord.disconnect.dialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
@@ -107,6 +107,11 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.commands.desc.share': 'Generate public URL for session',
     'settings.integrations.discord.commands.desc.unshare': 'Revoke public session URL',
     'settings.integrations.discord.commands.desc.schedule': 'Schedule a prompt (UTC ISO or cron)',
+    'settings.integrations.discord.disconnect.button': 'Disconnect',
+    'settings.integrations.discord.disconnect.dialog.title': 'Disconnect Discord?',
+    'settings.integrations.discord.disconnect.dialog.description':
+      'This removes the bot token and stops syncing from this device. The listener and bridge will stop. You can reconnect anytime by adding your token again.',
+    'settings.integrations.discord.disconnect.dialog.confirm': 'Disconnect',
   },
   uk: {
     'settings.integrations.discord.wizard.title': 'Налаштування Discord',
@@ -216,5 +221,10 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.commands.desc.share': 'Публічний URL сесії',
     'settings.integrations.discord.commands.desc.unshare': 'Скасувати публічний URL',
     'settings.integrations.discord.commands.desc.schedule': 'Запланувати промпт (UTC або cron)',
+    'settings.integrations.discord.disconnect.button': 'Відключити',
+    'settings.integrations.discord.disconnect.dialog.title': 'Відключити Discord?',
+    'settings.integrations.discord.disconnect.dialog.description':
+      'Це видалить токен бота та зупинить синхронізацію на цьому пристрої. Listener і bridge буде зупинено. Ви зможете підключитися знову, додавши токен.',
+    'settings.integrations.discord.disconnect.dialog.confirm': 'Відключити',
   },
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Discord integration UX improvements.

### Disconnect UX (new)
- Replaced the header ✕ icon with a red **Disconnect** button (`variant="destructive"`)
- Added a confirmation dialog before removing the bot token and stopping sync/listener

### Prior changes
- Onboarding wizard polish, guild ID in advanced settings, sync 429 retries
- Bash command dedup fix at normal verbosity
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55baecc9-3632-4d69-b5c9-739c484e6358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55baecc9-3632-4d69-b5c9-739c484e6358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

