### PR TITLE
fix(preview): keep browser redirects inside the proxy

### DIFF
--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -1819,6 +1819,10 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
               className="absolute inset-0 h-full w-full border-0 bg-background"
               allow="clipboard-read; clipboard-write; fullscreen"
               allowFullScreen
+              // Same-origin proxy pages need scripts + same-origin for inspect.
+              // Omit allow-top-navigation so JS frame-busts cannot leave the panel;
+              // the injected bridge also masks top/parent/frameElement.
+              sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
               onLoad={handleIframeLoad}
             />
             {isInspecting && hoverTarget ? (

--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -518,9 +518,42 @@ const stripPreviewQueryParams = (value: string): string => {
     parsed.searchParams.delete('oc_preview_token');
     parsed.searchParams.delete('oc_client_token');
     parsed.searchParams.delete('oc_url_token');
+    parsed.searchParams.delete('oc_preview_target_origin');
     return parsed.toString();
   } catch {
     return value;
+  }
+};
+
+const PREVIEW_PROXY_PATH_PATTERN = /^\/api\/preview\/proxy\/([a-f0-9]{16,64})(?=\/|$)/i;
+
+const resolveUpstreamUrlFromProxyFrameUrl = (
+  frameUrl: string,
+  fallbackUpstreamOrigin: string,
+): { upstreamUrl: string; proxyBasePath: string; previewToken: string } | null => {
+  if (!frameUrl) return null;
+  try {
+    const parsedFrameUrl = new URL(frameUrl, typeof window !== 'undefined' ? window.location.origin : 'http://localhost');
+    if (typeof window !== 'undefined' && parsedFrameUrl.origin !== window.location.origin) {
+      return null;
+    }
+
+    const match = parsedFrameUrl.pathname.match(PREVIEW_PROXY_PATH_PATTERN);
+    if (!match) return null;
+
+    const proxyBasePath = `/api/preview/proxy/${match[1]}`;
+    const rest = parsedFrameUrl.pathname.slice(proxyBasePath.length) || '/';
+    const previewToken = parsedFrameUrl.searchParams.get('oc_preview_token') || '';
+    const hintedOrigin = parsedFrameUrl.searchParams.get('oc_preview_target_origin') || '';
+    const upstreamOrigin = hintedOrigin || fallbackUpstreamOrigin;
+    if (!upstreamOrigin) return null;
+
+    const upstreamUrl = stripPreviewQueryParams(
+      new URL(`${rest}${parsedFrameUrl.search}${parsedFrameUrl.hash}`, upstreamOrigin).toString(),
+    );
+    return { upstreamUrl, proxyBasePath, previewToken };
+  } catch {
+    return null;
   }
 };
 
@@ -1335,6 +1368,16 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
       setIsLoading(Boolean(nextUrl));
     } else {
       setIsLoading(false);
+      // Cross-origin proxy retargets (e.g. google.com → www.google.com) must
+      // advance loadedUrl so later reloads/proxySrc rebuilds use the new origin,
+      // without treating every same-origin SPA hop as a full remount.
+      try {
+        if (nextUrl && loadedUrl && new URL(nextUrl).origin !== new URL(loadedUrl).origin) {
+          setLoadedUrl(nextUrl);
+        }
+      } catch {
+        // Ignore invalid URL comparisons and keep the in-frame path.
+      }
     }
     persistUrl(nextUrl);
 
@@ -1359,7 +1402,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
       setHistoryIndex(nextHistory.length - 1);
       return nextHistory;
     });
-  }, [historyIndex, persistUrl]);
+  }, [historyIndex, loadedUrl, persistUrl]);
 
   const goToHistory = React.useCallback((nextIndex: number) => {
     const nextUrl = history[nextIndex];
@@ -1493,24 +1536,39 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
 
   const iframeSrc = proxySrc || (proxyState.status === 'error' ? loadedUrl : '');
 
-  const getCurrentUrlFromFrameUrl = React.useCallback((frameUrl: string): string => {
-    if (!frameUrl || !loadedUrl || proxyState.status !== 'ready') return '';
-    try {
-      const parsedFrameUrl = new URL(frameUrl, window.location.origin);
-      const proxyBasePath = proxyState.proxyBasePath.endsWith('/')
-        ? proxyState.proxyBasePath.slice(0, -1)
-        : proxyState.proxyBasePath;
-      if (parsedFrameUrl.origin !== window.location.origin || !parsedFrameUrl.pathname.startsWith(proxyBasePath)) {
-        return '';
-      }
+  const adoptProxyFrameUrl = React.useCallback((frameUrl: string, options?: { inFrame?: boolean }) => {
+    const resolved = resolveUpstreamUrlFromProxyFrameUrl(
+      frameUrl,
+      loadedUrl ? new URL(loadedUrl).origin : '',
+    );
+    if (!resolved?.upstreamUrl) return false;
 
-      const rest = parsedFrameUrl.pathname.slice(proxyBasePath.length) || '/';
-      const upstreamOrigin = new URL(loadedUrl).origin;
-      return stripPreviewQueryParams(new URL(`${rest}${parsedFrameUrl.search}${parsedFrameUrl.hash}`, upstreamOrigin).toString());
-    } catch {
-      return '';
+    const nextProxyBasePath = resolved.proxyBasePath;
+    const nextPreviewToken = resolved.previewToken || (proxyState.status === 'ready' ? proxyState.previewToken : '') || '';
+    if (nextPreviewToken && (proxyState.status !== 'ready'
+      || proxyState.proxyBasePath !== nextProxyBasePath
+      || proxyState.previewToken !== nextPreviewToken)) {
+      const expiresAt = proxyState.status === 'ready'
+        ? proxyState.expiresAt
+        : Date.now() + 30 * 60 * 1000;
+      previewProxyTargetCache.set(getBrowserProxyTargetKey(resolved.upstreamUrl), {
+        proxyBasePath: nextProxyBasePath,
+        previewToken: nextPreviewToken,
+        expiresAt,
+      });
+      setProxyState({
+        status: 'ready',
+        proxyBasePath: nextProxyBasePath,
+        previewToken: nextPreviewToken,
+        expiresAt,
+      });
     }
-  }, [loadedUrl, proxyState]);
+
+    if (resolved.upstreamUrl !== currentUrl) {
+      applyUrl(resolved.upstreamUrl, { inFrame: options?.inFrame ?? true });
+    }
+    return true;
+  }, [applyUrl, currentUrl, loadedUrl, proxyState]);
 
   const getUpstreamUrlFromLocalFrameUrl = React.useCallback((frameUrl: string): string => {
     if (!frameUrl || !loadedUrl || proxyState.status !== 'ready') return '';
@@ -1524,7 +1582,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
       const proxyBasePath = proxyState.proxyBasePath.endsWith('/')
         ? proxyState.proxyBasePath.slice(0, -1)
         : proxyState.proxyBasePath;
-      if (parsedFrameUrl.pathname.startsWith(proxyBasePath)) {
+      if (parsedFrameUrl.pathname.startsWith(proxyBasePath) || PREVIEW_PROXY_PATH_PATTERN.test(parsedFrameUrl.pathname)) {
         return '';
       }
 
@@ -1619,9 +1677,8 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
 
       if (data.type === 'ready') {
         const frameUrl = typeof data.url === 'string' ? data.url : '';
-        const nextUrl = getCurrentUrlFromFrameUrl(frameUrl);
-        if (nextUrl && nextUrl !== currentUrl) {
-          applyUrl(nextUrl, { inFrame: true });
+        if (frameUrl) {
+          adoptProxyFrameUrl(frameUrl, { inFrame: true });
         }
         return;
       }
@@ -1641,6 +1698,9 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
 
       if (data.type === 'navigate-preview') {
         const nextUrl = typeof data.url === 'string' ? data.url : '';
+        if (nextUrl && adoptProxyFrameUrl(nextUrl, { inFrame: false })) {
+          return;
+        }
         const upstreamUrl = getUpstreamUrlFromLocalFrameUrl(nextUrl);
         if (upstreamUrl) {
           applyUrl(upstreamUrl);
@@ -1654,7 +1714,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
 
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [applyUrl, attachBrowserAnnotation, currentUrl, getCurrentUrlFromFrameUrl, getUpstreamUrlFromLocalFrameUrl, postInspectMode]);
+  }, [adoptProxyFrameUrl, applyUrl, attachBrowserAnnotation, getUpstreamUrlFromLocalFrameUrl, postInspectMode]);
 
   const handleInspect = React.useCallback(() => {
     const iframe = iframeRef.current;
@@ -1690,6 +1750,13 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
   const handleIframeLoad = React.useCallback(() => {
     try {
       const frameUrl = iframeRef.current?.contentWindow?.location.href || '';
+      if (frameUrl && adoptProxyFrameUrl(frameUrl, { inFrame: true })) {
+        setIsLoading(false);
+        if (isInspecting && proxySrc) {
+          postInspectMode(true);
+        }
+        return;
+      }
       const upstreamUrl = getUpstreamUrlFromLocalFrameUrl(frameUrl);
       if (upstreamUrl) {
         applyUrl(upstreamUrl, { inFrame: true });
@@ -1703,7 +1770,7 @@ const IframeBrowserPane: React.FC<DesktopBrowserPaneProps> = ({ initialUrl, dire
     if (isInspecting && proxySrc) {
       postInspectMode(true);
     }
-  }, [applyUrl, getUpstreamUrlFromLocalFrameUrl, isInspecting, postInspectMode, proxySrc]);
+  }, [adoptProxyFrameUrl, applyUrl, getUpstreamUrlFromLocalFrameUrl, isInspecting, postInspectMode, proxySrc]);
 
   return (
     <div className="absolute inset-0 flex flex-col bg-background">

--- a/packages/web/server/lib/preview/proxy-redirect.integration.test.js
+++ b/packages/web/server/lib/preview/proxy-redirect.integration.test.js
@@ -64,5 +64,12 @@ describe('preview proxy redirect integration', () => {
     expect(follow.headers.get('x-frame-options')).toBeNull();
     const body = await follow.text();
     expect(body).toContain('openchamber-preview-bridge');
+    // Frame-bust hardening: bridge keeps a real parent for postMessage, then
+    // masks top/parent/frameElement so same-origin proxied pages cannot escape.
+    expect(body).toContain('const realParent = window.parent');
+    expect(body).toContain("Object.defineProperty(window, 'frameElement'");
+    expect(body).toContain("Object.defineProperty(window, 'parent'");
+    expect(body).toContain("Object.defineProperty(window, 'top'");
+    expect(body).toContain('realParent.postMessage');
   }, 20_000);
 });

--- a/packages/web/server/lib/preview/proxy-redirect.integration.test.js
+++ b/packages/web/server/lib/preview/proxy-redirect.integration.test.js
@@ -1,0 +1,68 @@
+import http from 'node:http';
+import crypto from 'node:crypto';
+import express from 'express';
+import { createProxyMiddleware, responseInterceptor } from 'http-proxy-middleware';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createPreviewProxyRuntime } from './proxy-runtime.js';
+
+describe('preview proxy redirect integration', () => {
+  let server;
+  let base;
+
+  beforeAll(async () => {
+    const app = express();
+    server = http.createServer(app);
+    const runtime = createPreviewProxyRuntime({
+      crypto,
+      URL,
+      createProxyMiddleware,
+      responseInterceptor,
+    });
+    runtime.attach(app, {
+      express,
+      server,
+      uiAuthController: { enabled: false },
+      isRequestOriginAllowed: async () => true,
+      rejectWebSocketUpgrade: () => {},
+    });
+
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it('keeps google.com → www.google.com redirects inside the proxy and frameable', async () => {
+    const create = await fetch(`${base}/api/preview/targets`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'https://google.com/', allowExternal: true }),
+    });
+    expect(create.status).toBe(200);
+    const target = await create.json();
+
+    const proxied = await fetch(
+      `${base}${target.proxyBasePath}/?oc_preview_token=${encodeURIComponent(target.previewToken)}`,
+      { redirect: 'manual' },
+    );
+    expect(proxied.status).toBe(301);
+    const location = proxied.headers.get('location');
+    expect(location).toMatch(/^\/api\/preview\/proxy\/[a-f0-9]+\//i);
+    expect(location).toContain('oc_preview_target_origin=https%3A%2F%2Fwww.google.com');
+    expect(location).not.toBe('https://www.google.com/');
+
+    const cookies = proxied.headers.getSetCookie?.() || [];
+    const cookieHeader = cookies.map((entry) => entry.split(';')[0]).join('; ');
+    const follow = await fetch(`${base}${location}`, {
+      redirect: 'manual',
+      headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+    });
+    expect(follow.status).toBe(200);
+    expect(follow.headers.get('x-frame-options')).toBeNull();
+    const body = await follow.text();
+    expect(body).toContain('openchamber-preview-bridge');
+  }, 20_000);
+});

--- a/packages/web/server/lib/preview/proxy-runtime.js
+++ b/packages/web/server/lib/preview/proxy-runtime.js
@@ -3,6 +3,9 @@ const TOKEN_COOKIE_NAME = 'oc_preview_token';
 const TOKEN_QUERY_PARAM = 'oc_preview_token';
 const CLIENT_TOKEN_QUERY_PARAM = 'oc_client_token';
 const URL_AUTH_TOKEN_QUERY_PARAM = 'oc_url_token';
+// Carried on cross-origin redirect Locations so the browser pane can rebuild the
+// upstream URL after the iframe follows a retargeted proxy path.
+const TARGET_ORIGIN_QUERY_PARAM = 'oc_preview_target_origin';
 const PREVIEW_PASSTHROUGH_REQUEST_HEADERS = ['x-inertia', 'x-inertia-version'];
 const PREVIEW_PASSTHROUGH_RESPONSE_HEADERS = ['x-inertia', 'x-inertia-location'];
 
@@ -13,6 +16,12 @@ const LOOPBACK_HOSTS = new Set([
   '[::1]',
   '0.0.0.0',
 ]);
+
+const isLoopbackHostname = (hostname) => {
+  if (!hostname) return false;
+  const host = hostname.toLowerCase();
+  return LOOPBACK_HOSTS.has(host) || host === 'localhost' || host.endsWith('.localhost');
+};
 
 const PREVIEW_BRIDGE_SCRIPT_ID = 'openchamber-preview-bridge';
 
@@ -1166,18 +1175,95 @@ export const rewritePreviewCspHeader = (cspValue, nonce) => {
   return rebuilt.length > 0 ? rebuilt.join('; ') : null;
 };
 
-export const rewritePreviewRedirectLocation = ({ location, proxyBasePath, targetOrigin, previewToken = '', urlAuthToken = '' }) => {
-  if (typeof location !== 'string' || !location) return location;
+const buildProxiedRedirectLocation = ({
+  proxyBasePath,
+  pathname,
+  search,
+  hash,
+  previewToken = '',
+  urlAuthToken = '',
+  targetOrigin = '',
+}) => {
   const prefix = proxyBasePath.endsWith('/') ? proxyBasePath.slice(0, -1) : proxyBasePath;
+  const withAuth = appendProxyAuthToProxyUrl(`${prefix}${pathname || '/'}${search || ''}${hash || ''}`, {
+    previewToken,
+    urlAuthToken,
+  });
+  if (!targetOrigin) return withAuth;
+  try {
+    const parsed = new URL(withAuth, 'http://openchamber-preview.local');
+    parsed.searchParams.set(TARGET_ORIGIN_QUERY_PARAM, targetOrigin);
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return withAuth;
+  }
+};
+
+// Keep HTTP redirects inside the same-origin preview proxy whenever possible.
+// Same-origin (incl. relative) redirects are rewritten onto the current proxy
+// path. Cross-origin redirects on allowExternal targets create/reuse a proxy
+// target for the new origin so the iframe never navigates to the bare upstream
+// URL (which would hit X-Frame-Options / CSP frame-ancestors).
+export const rewritePreviewRedirectLocation = ({
+  location,
+  proxyBasePath,
+  targetOrigin,
+  previewToken = '',
+  urlAuthToken = '',
+  allowExternal = false,
+  retarget = null,
+}) => {
+  if (typeof location !== 'string' || !location) return location;
   const target = targetOrigin ? new URL(targetOrigin) : null;
   if (!target) return location;
   try {
     const parsed = new URL(location, target);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return location;
-    const host = parsed.hostname;
-    const isLoopback = host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0' || host === '::1' || host === '[::1]';
-    if (!isLoopback || parsed.port !== target.port) return location;
-    return appendProxyAuthToProxyUrl(`${prefix}${parsed.pathname}${parsed.search}${parsed.hash}`, { previewToken, urlAuthToken });
+
+    const redirectIsLoopback = isLoopbackHostname(parsed.hostname);
+    const targetIsLoopback = isLoopbackHostname(target.hostname);
+    const sameOrigin = parsed.origin === target.origin;
+    const sameLoopbackPort = redirectIsLoopback && targetIsLoopback && parsed.port === target.port;
+
+    if (sameOrigin || sameLoopbackPort) {
+      return buildProxiedRedirectLocation({
+        proxyBasePath,
+        pathname: parsed.pathname,
+        search: parsed.search,
+        hash: parsed.hash,
+        previewToken,
+        urlAuthToken,
+      });
+    }
+
+    if (!allowExternal) {
+      // Loopback-only preview targets must not be widened to arbitrary hosts.
+      return location;
+    }
+
+    const normalized = normalizeProxyTargetUrl(parsed.toString(), { allowExternal: true });
+    if (!normalized.ok) {
+      return location;
+    }
+
+    if (typeof retarget !== 'function') {
+      return location;
+    }
+
+    const nextTarget = retarget(normalized.origin);
+    if (!nextTarget || typeof nextTarget.id !== 'string' || typeof nextTarget.token !== 'string') {
+      return location;
+    }
+
+    return buildProxiedRedirectLocation({
+      proxyBasePath: `/api/preview/proxy/${nextTarget.id}`,
+      pathname: parsed.pathname,
+      search: parsed.search,
+      hash: parsed.hash,
+      previewToken: nextTarget.token,
+      urlAuthToken,
+      targetOrigin: normalized.origin,
+    });
   } catch {
     return location;
   }
@@ -1212,7 +1298,7 @@ export const createPreviewProxyRuntime = ({
     sweepTimer.unref?.();
   };
 
-  const createTarget = (origin, ttlMs) => {
+  const createTarget = (origin, ttlMs, { allowExternal = false } = {}) => {
     const id = crypto.randomBytes(16).toString('hex');
     const token = crypto.randomBytes(16).toString('hex');
     const createdAt = now();
@@ -1221,10 +1307,30 @@ export const createPreviewProxyRuntime = ({
       id,
       origin,
       token,
+      allowExternal: allowExternal === true,
       createdAt,
       expiresAt,
     });
-    return { id, token, expiresAt };
+    return { id, token, expiresAt, allowExternal: allowExternal === true };
+  };
+
+  const findTargetByOrigin = (origin, { allowExternal = false } = {}) => {
+    const t = now();
+    for (const entry of targets.values()) {
+      if (entry.expiresAt <= t) continue;
+      if (entry.origin !== origin) continue;
+      if (Boolean(entry.allowExternal) !== Boolean(allowExternal)) continue;
+      return entry;
+    }
+    return null;
+  };
+
+  const retargetExternalOrigin = (origin, ttlMs) => {
+    const existing = findTargetByOrigin(origin, { allowExternal: true });
+    if (existing) {
+      return { id: existing.id, token: existing.token, expiresAt: existing.expiresAt };
+    }
+    return createTarget(origin, ttlMs, { allowExternal: true });
   };
 
   const resolveTargetFromRequest = (req) => {
@@ -1376,7 +1482,7 @@ export const createPreviewProxyRuntime = ({
           return res.status(400).json({ error: normalized.error });
         }
 
-        const target = createTarget(normalized.origin, ttlMs);
+        const target = createTarget(normalized.origin, ttlMs, { allowExternal });
         const cookiePath = `/api/preview/proxy/${target.id}`;
         const secure = Boolean(req.secure);
         res.setHeader('Set-Cookie', buildCookie({
@@ -1439,7 +1545,8 @@ export const createPreviewProxyRuntime = ({
         const withoutPreviewToken = removeRawQueryParam(withoutReloadParam, TOKEN_QUERY_PARAM);
         const withoutClientToken = removeRawQueryParam(withoutPreviewToken, CLIENT_TOKEN_QUERY_PARAM);
         const withoutUrlAuthToken = removeRawQueryParam(withoutClientToken, URL_AUTH_TOKEN_QUERY_PARAM);
-        return `${strippedPath}${withoutUrlAuthToken}`;
+        const withoutTargetOrigin = removeRawQueryParam(withoutUrlAuthToken, TARGET_ORIGIN_QUERY_PARAM);
+        return `${strippedPath}${withoutTargetOrigin}`;
       },
       on: {
         proxyReq: (proxyReq, req) => {
@@ -1468,13 +1575,49 @@ export const createPreviewProxyRuntime = ({
           const proxyBasePath = `/api/preview/proxy/${resolved.id}`;
           const urlAuthToken = resolved.parsed.searchParams.get(URL_AUTH_TOKEN_QUERY_PARAM) || '';
           if (typeof proxyRes.headers?.location === 'string') {
-            proxyRes.headers.location = rewritePreviewRedirectLocation({
+            const remainingTtlMs = Math.max(15_000, resolved.entry.expiresAt - now());
+            const rewrittenLocation = rewritePreviewRedirectLocation({
               location: proxyRes.headers.location,
               proxyBasePath,
               targetOrigin: resolved.entry.origin,
               previewToken: resolved.entry.token,
               urlAuthToken,
+              allowExternal: resolved.entry.allowExternal === true,
+              retarget: resolved.entry.allowExternal === true
+                ? (origin) => {
+                    const next = retargetExternalOrigin(origin, remainingTtlMs);
+                    // Scope the new target's auth cookie so the iframe can follow
+                    // the redirected Location without a second /targets round-trip.
+                    if (typeof res?.appendHeader === 'function') {
+                      res.appendHeader('Set-Cookie', buildCookie({
+                        name: TOKEN_COOKIE_NAME,
+                        value: next.token,
+                        path: `/api/preview/proxy/${next.id}`,
+                        maxAgeSeconds: Math.round((next.expiresAt - now()) / 1000),
+                        secure: Boolean(req.secure),
+                      }));
+                    } else if (typeof res?.setHeader === 'function') {
+                      const existing = res.getHeader?.('Set-Cookie');
+                      const nextCookie = buildCookie({
+                        name: TOKEN_COOKIE_NAME,
+                        value: next.token,
+                        path: `/api/preview/proxy/${next.id}`,
+                        maxAgeSeconds: Math.round((next.expiresAt - now()) / 1000),
+                        secure: Boolean(req.secure),
+                      });
+                      if (!existing) {
+                        res.setHeader('Set-Cookie', nextCookie);
+                      } else if (Array.isArray(existing)) {
+                        res.setHeader('Set-Cookie', [...existing, nextCookie]);
+                      } else {
+                        res.setHeader('Set-Cookie', [String(existing), nextCookie]);
+                      }
+                    }
+                    return next;
+                  }
+                : null,
             });
+            proxyRes.headers.location = rewrittenLocation;
           }
 
           const contentType = String(proxyRes.headers?.['content-type'] || '').toLowerCase();
@@ -1581,6 +1724,7 @@ export const createPreviewProxyRuntime = ({
           parsed.searchParams.delete(TOKEN_QUERY_PARAM);
           parsed.searchParams.delete(CLIENT_TOKEN_QUERY_PARAM);
           parsed.searchParams.delete(URL_AUTH_TOKEN_QUERY_PARAM);
+          parsed.searchParams.delete(TARGET_ORIGIN_QUERY_PARAM);
           const search = parsed.searchParams.toString();
           req.url = `${nextPath}${search ? `?${search}` : ''}`;
           proxy.upgrade(req, socket, head);

--- a/packages/web/server/lib/preview/proxy-runtime.js
+++ b/packages/web/server/lib/preview/proxy-runtime.js
@@ -207,6 +207,20 @@ const PREVIEW_BRIDGE_SCRIPT = String.raw`(() => {
   if (window.__openchamberPreviewBridgeInstalled) return;
   window.__openchamberPreviewBridgeInstalled = true;
 
+  // Keep a real parent handle for postMessage, then mask top/parent/frameElement
+  // so same-origin proxied pages cannot escape the iframe sandbox or navigate
+  // the OpenChamber shell via classic frame-bust checks.
+  const realParent = window.parent;
+  try {
+    Object.defineProperty(window, 'frameElement', { configurable: false, get() { return null; } });
+  } catch {}
+  try {
+    if (realParent && realParent !== window) {
+      Object.defineProperty(window, 'parent', { configurable: false, get() { return window; } });
+      Object.defineProperty(window, 'top', { configurable: false, get() { return window; } });
+    }
+  } catch {}
+
   const SOURCE = 'openchamber-preview-bridge';
   const VERSION = 1;
   const MAX_TEXT = 500;
@@ -233,9 +247,9 @@ const PREVIEW_BRIDGE_SCRIPT = String.raw`(() => {
 
   const post = (payload) => {
     try {
-      if (parentOrigin && window.parent && typeof window.parent.postMessage === 'function') {
+      if (parentOrigin && realParent && typeof realParent.postMessage === 'function') {
         const message = Object.assign({ source: SOURCE, version: VERSION }, payload || {});
-        window.parent.postMessage(message, parentOrigin);
+        realParent.postMessage(message, parentOrigin);
       }
     } catch {}
   };
@@ -867,7 +881,7 @@ const PREVIEW_BRIDGE_SCRIPT = String.raw`(() => {
   });
 
   window.addEventListener('message', (event) => {
-    if (event.source !== window.parent) return;
+    if (event.source !== realParent) return;
     const data = event.data;
     if (!data || data.source !== 'openchamber-preview-parent' || data.version !== VERSION) return;
     if (data.type === 'set-inspect-mode') {
@@ -950,6 +964,32 @@ const buildCookie = ({
   chunks.push('SameSite=Lax');
   if (secure) chunks.push('Secure');
   return chunks.join('; ');
+};
+
+const appendResponseSetCookie = (res, cookie) => {
+  if (!res || typeof cookie !== 'string' || !cookie) return;
+  if (typeof res.appendHeader === 'function') {
+    res.appendHeader('Set-Cookie', cookie);
+    return;
+  }
+  if (typeof res.setHeader !== 'function') return;
+  const existing = typeof res.getHeader === 'function' ? res.getHeader('Set-Cookie') : undefined;
+  if (!existing) {
+    res.setHeader('Set-Cookie', cookie);
+    return;
+  }
+  res.setHeader('Set-Cookie', Array.isArray(existing) ? [...existing, cookie] : [String(existing), cookie]);
+};
+
+// responseInterceptor copies upstream headers onto `res` before our callback, so
+// header mutations must update both proxyRes.headers and the Express response.
+const setProxyResponseHeader = (proxyRes, res, name, value) => {
+  if (proxyRes?.headers && typeof name === 'string') {
+    proxyRes.headers[name] = value;
+  }
+  if (typeof res?.setHeader === 'function') {
+    res.setHeader(name, value);
+  }
 };
 
 // SSRF guard for the `allowExternal` path: refuse to proxy private, loopback and
@@ -1408,26 +1448,56 @@ export const createPreviewProxyRuntime = ({
     }
   };
 
-  // responseInterceptor copies upstream headers onto `res` before our callback,
-  // so frame-busting mutations on proxyRes.headers alone never reach the client.
+  // Mirror stripped frame-busting headers onto the Express response. The
+  // responseInterceptor copies upstream headers onto `res` before our callback.
   const applyFrameBustingHeadersToResponse = (res, proxyHeaders) => {
     if (!res || typeof res.removeHeader !== 'function' || typeof res.setHeader !== 'function') {
       return;
     }
 
     res.removeHeader('x-frame-options');
-
-    const cspNames = ['content-security-policy', 'content-security-policy-report-only'];
-    for (const name of cspNames) {
-      const entry = proxyHeaders
-        ? Object.entries(proxyHeaders).find(([key]) => key.toLowerCase() === name)
-        : undefined;
-      if (!entry) {
+    for (const name of ['content-security-policy', 'content-security-policy-report-only']) {
+      const value = readHeader(proxyHeaders, name);
+      if (value === undefined) {
         res.removeHeader(name);
         continue;
       }
-      res.setHeader(name, entry[1]);
+      res.setHeader(name, value);
     }
+  };
+
+  const issueRetargetCookie = (req, res, target) => {
+    appendResponseSetCookie(res, buildCookie({
+      name: TOKEN_COOKIE_NAME,
+      value: target.token,
+      path: `/api/preview/proxy/${target.id}`,
+      maxAgeSeconds: Math.round((target.expiresAt - now()) / 1000),
+      secure: Boolean(req.secure),
+    }));
+  };
+
+  const rewriteOutgoingRedirect = ({ req, res, proxyRes, resolved, proxyBasePath, urlAuthToken }) => {
+    const location = proxyRes.headers?.location;
+    if (typeof location !== 'string' || !location) return;
+
+    const allowExternal = resolved.entry.allowExternal === true;
+    const remainingTtlMs = Math.max(15_000, resolved.entry.expiresAt - now());
+    const rewrittenLocation = rewritePreviewRedirectLocation({
+      location,
+      proxyBasePath,
+      targetOrigin: resolved.entry.origin,
+      previewToken: resolved.entry.token,
+      urlAuthToken,
+      allowExternal,
+      retarget: allowExternal
+        ? (origin) => {
+            const next = retargetExternalOrigin(origin, remainingTtlMs);
+            issueRetargetCookie(req, res, next);
+            return next;
+          }
+        : null,
+    });
+    setProxyResponseHeader(proxyRes, res, 'location', rewrittenLocation);
   };
 
   const attach = (app, {
@@ -1596,57 +1666,7 @@ export const createPreviewProxyRuntime = ({
 
           const proxyBasePath = `/api/preview/proxy/${resolved.id}`;
           const urlAuthToken = resolved.parsed.searchParams.get(URL_AUTH_TOKEN_QUERY_PARAM) || '';
-          if (typeof proxyRes.headers?.location === 'string') {
-            const remainingTtlMs = Math.max(15_000, resolved.entry.expiresAt - now());
-            const rewrittenLocation = rewritePreviewRedirectLocation({
-              location: proxyRes.headers.location,
-              proxyBasePath,
-              targetOrigin: resolved.entry.origin,
-              previewToken: resolved.entry.token,
-              urlAuthToken,
-              allowExternal: resolved.entry.allowExternal === true,
-              retarget: resolved.entry.allowExternal === true
-                ? (origin) => {
-                    const next = retargetExternalOrigin(origin, remainingTtlMs);
-                    // Scope the new target's auth cookie so the iframe can follow
-                    // the redirected Location without a second /targets round-trip.
-                    if (typeof res?.appendHeader === 'function') {
-                      res.appendHeader('Set-Cookie', buildCookie({
-                        name: TOKEN_COOKIE_NAME,
-                        value: next.token,
-                        path: `/api/preview/proxy/${next.id}`,
-                        maxAgeSeconds: Math.round((next.expiresAt - now()) / 1000),
-                        secure: Boolean(req.secure),
-                      }));
-                    } else if (typeof res?.setHeader === 'function') {
-                      const existing = res.getHeader?.('Set-Cookie');
-                      const nextCookie = buildCookie({
-                        name: TOKEN_COOKIE_NAME,
-                        value: next.token,
-                        path: `/api/preview/proxy/${next.id}`,
-                        maxAgeSeconds: Math.round((next.expiresAt - now()) / 1000),
-                        secure: Boolean(req.secure),
-                      });
-                      if (!existing) {
-                        res.setHeader('Set-Cookie', nextCookie);
-                      } else if (Array.isArray(existing)) {
-                        res.setHeader('Set-Cookie', [...existing, nextCookie]);
-                      } else {
-                        res.setHeader('Set-Cookie', [String(existing), nextCookie]);
-                      }
-                    }
-                    return next;
-                  }
-                : null,
-            });
-            // responseInterceptor copies upstream headers onto `res` before this
-            // callback runs, so mutating proxyRes.headers alone is ignored by the
-            // client. Write the rewritten Location onto both.
-            proxyRes.headers.location = rewrittenLocation;
-            if (typeof res?.setHeader === 'function') {
-              res.setHeader('location', rewrittenLocation);
-            }
-          }
+          rewriteOutgoingRedirect({ req, res, proxyRes, resolved, proxyBasePath, urlAuthToken });
 
           const contentType = String(proxyRes.headers?.['content-type'] || '').toLowerCase();
           const isHtml = contentType.includes('text/html');

--- a/packages/web/server/lib/preview/proxy-runtime.js
+++ b/packages/web/server/lib/preview/proxy-runtime.js
@@ -1381,7 +1381,6 @@ export const createPreviewProxyRuntime = ({
   };
 
   // Drop only CSP directives that prevent framing or the injected preview bridge.
-  // Preview targets are restricted to loopback dev servers.
   const stripFrameBustingHeaders = (headers, bridgeNonce) => {
     if (!headers || typeof headers !== 'object') {
       return;
@@ -1406,6 +1405,28 @@ export const createPreviewProxyRuntime = ({
           headers[key] = Array.isArray(original) ? rewritten : rewritten[0];
         }
       }
+    }
+  };
+
+  // responseInterceptor copies upstream headers onto `res` before our callback,
+  // so frame-busting mutations on proxyRes.headers alone never reach the client.
+  const applyFrameBustingHeadersToResponse = (res, proxyHeaders) => {
+    if (!res || typeof res.removeHeader !== 'function' || typeof res.setHeader !== 'function') {
+      return;
+    }
+
+    res.removeHeader('x-frame-options');
+
+    const cspNames = ['content-security-policy', 'content-security-policy-report-only'];
+    for (const name of cspNames) {
+      const entry = proxyHeaders
+        ? Object.entries(proxyHeaders).find(([key]) => key.toLowerCase() === name)
+        : undefined;
+      if (!entry) {
+        res.removeHeader(name);
+        continue;
+      }
+      res.setHeader(name, entry[1]);
     }
   };
 
@@ -1562,10 +1583,11 @@ export const createPreviewProxyRuntime = ({
           // Per-response nonce lets the injected bridge run under the dev
           // server's CSP without dropping its script restrictions wholesale.
           const bridgeNonce = crypto.randomBytes(16).toString('base64');
-          // Allow the dev server response to be framed inside OpenChamber even
+          // Allow the upstream response to be framed inside OpenChamber even
           // if it normally sets X-Frame-Options or a CSP frame-ancestors rule.
           // The proxy is same-origin so embedding is otherwise safe.
           stripFrameBustingHeaders(proxyRes.headers, bridgeNonce);
+          applyFrameBustingHeadersToResponse(res, proxyRes.headers);
 
           const resolved = resolveTargetFromRequest(req);
           if (!resolved.ok) {
@@ -1617,7 +1639,13 @@ export const createPreviewProxyRuntime = ({
                   }
                 : null,
             });
+            // responseInterceptor copies upstream headers onto `res` before this
+            // callback runs, so mutating proxyRes.headers alone is ignored by the
+            // client. Write the rewritten Location onto both.
             proxyRes.headers.location = rewrittenLocation;
+            if (typeof res?.setHeader === 'function') {
+              res.setHeader('location', rewrittenLocation);
+            }
           }
 
           const contentType = String(proxyRes.headers?.['content-type'] || '').toLowerCase();

--- a/packages/web/server/lib/preview/proxy-runtime.test.js
+++ b/packages/web/server/lib/preview/proxy-runtime.test.js
@@ -248,12 +248,59 @@ describe('preview redirect URL rewriting', () => {
     })).toBe('/api/preview/proxy/abc123/login?next=%2F#top');
   });
 
-  it('leaves external redirects unchanged', () => {
+  it('rewrites same-origin absolute redirects for external targets', () => {
+    expect(rewritePreviewRedirectLocation({
+      location: 'https://google.com/search?q=1',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'https://google.com',
+      previewToken: 'preview-secret',
+      allowExternal: true,
+    })).toBe('/api/preview/proxy/abc123/search?q=1&oc_preview_token=preview-secret');
+  });
+
+  it('rewrites relative redirects for external targets onto the proxy path', () => {
+    expect(rewritePreviewRedirectLocation({
+      location: '/maps',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'https://www.google.com',
+      previewToken: 'preview-secret',
+      allowExternal: true,
+    })).toBe('/api/preview/proxy/abc123/maps?oc_preview_token=preview-secret');
+  });
+
+  it('retargets cross-origin redirects for allowExternal targets', () => {
+    const retargeted = [];
+    expect(rewritePreviewRedirectLocation({
+      location: 'https://www.google.com/',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'https://google.com',
+      previewToken: 'old-token',
+      urlAuthToken: 'url-secret',
+      allowExternal: true,
+      retarget: (origin) => {
+        retargeted.push(origin);
+        return { id: 'deadbeefdeadbeef', token: 'new-token' };
+      },
+    })).toBe('/api/preview/proxy/deadbeefdeadbeef/?oc_preview_token=new-token&oc_url_token=url-secret&oc_preview_target_origin=https%3A%2F%2Fwww.google.com');
+    expect(retargeted).toEqual(['https://www.google.com']);
+  });
+
+  it('leaves cross-origin redirects unchanged for loopback-only targets', () => {
     expect(rewritePreviewRedirectLocation({
       location: 'https://example.com/login',
       proxyBasePath: '/api/preview/proxy/abc123',
       targetOrigin: 'http://127.0.0.1:3000',
     })).toBe('https://example.com/login');
+  });
+
+  it('leaves blocked private cross-origin redirects unchanged even with allowExternal', () => {
+    expect(rewritePreviewRedirectLocation({
+      location: 'http://127.0.0.1:9999/admin',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'https://example.com',
+      allowExternal: true,
+      retarget: () => ({ id: 'should-not-run', token: 'x' }),
+    })).toBe('http://127.0.0.1:9999/admin');
   });
 
   it('adds proxy auth tokens to loopback redirects when provided', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Opening `https://google.com/` in the web browser pane failed with “www.google.com refused to connect”, while `https://www.google.com/` worked. Two bugs stacked:

1. Non-loopback `Location` redirects left the same-origin preview proxy.
2. `responseInterceptor` copies upstream headers onto `res` before our callback, so mutating `proxyRes.headers` alone left bare `https://www.google.com/` and `X-Frame-Options: SAMEORIGIN`.

## Changes

- Rewrite same-origin / relative redirects onto the current proxy path.
- Retarget `allowExternal` cross-origin redirects to a new proxy target + auth cookie.
- Apply rewritten `Location` and stripped frame-busting headers onto `res`.
- Slim the redirect/cookie path into focused helpers (`appendResponseSetCookie`, `setProxyResponseHeader`, `rewriteOutgoingRedirect`).
- Sandbox the web browser iframe without `allow-top-navigation`, and mask `top`/`parent`/`frameElement` in the injected bridge while keeping a real parent for `postMessage`.
- Browser pane adopts retargeted proxy URLs and advances `loadedUrl` on origin change.
- Live `google.com → www.google.com` integration coverage.

## Validation

- Live repro: proxied `301`, follow-up `200`, no `X-Frame-Options`, bridge + frame-bust masks present (`PASS`)
- `bun run --cwd packages/web test server/lib/preview/proxy-runtime.test.js server/lib/preview/proxy-redirect.integration.test.js` (37 passed)
- `bun run --cwd packages/ui type-check` / `lint`
- `bun run --cwd packages/web type-check` / `lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbe5b2ec-8a69-4617-a5d8-dac4c946b993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbe5b2ec-8a69-4617-a5d8-dac4c946b993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

