### PR TITLE
feat(git): let an existing session point its Git tab at another worktree

### DIFF
--- a/packages/ui/src/components/views/GitView.tsx
+++ b/packages/ui/src/components/views/GitView.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { useSessionUIStore } from '@/sync/session-ui-store';
+import { useProjectsStore } from '@/stores/useProjectsStore';
+import { resolveProjectForSessionDirectory } from '@/lib/projectResolution';
+import type { WorktreeTargetOption } from '@/components/views/git/WorktreeTargetDropdown';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { useFireworksCelebration } from '@/contexts/FireworksContext';
 import type { GitIdentityProfile, CommitFileEntry, GitStatus } from '@/lib/api/types';
@@ -209,7 +212,65 @@ export const GitView: React.FC<GitViewProps> = ({ isActive }) => {
   const setDraftBootstrapPendingDirectory = useSessionUIStore((s) => s.setDraftBootstrapPendingDirectory);
   const worktreeMap = useSessionUIStore((s) => s.worktreeMetadata);
   const availableWorktrees = useSessionUIStore((s) => s.availableWorktrees);
+  const availableWorktreesByProject = useSessionUIStore((s) => s.availableWorktreesByProject);
+  const setWorktreeMetadata = useSessionUIStore((s) => s.setWorktreeMetadata);
+  const projects = useProjectsStore((s) => s.projects);
   const normalizedCurrentDirectory = normalizePath(currentDirectory);
+
+  // Lets an existing session point its Git/Diff/Files/Terminal tabs at a
+  // worktree other than the one it was created in (e.g. a worktree created
+  // mid-conversation), without touching the agent's own working directory.
+  const currentProjectForWorktreeTarget = React.useMemo(
+    () => resolveProjectForSessionDirectory(projects, availableWorktreesByProject, currentDirectory ?? null),
+    [availableWorktreesByProject, currentDirectory, projects]
+  );
+
+  const worktreesForCurrentProject = React.useMemo(() => {
+    if (!currentProjectForWorktreeTarget) return [];
+    return Array.from(availableWorktreesByProject.entries()).find(
+      ([key]) => normalizePath(key) === normalizePath(currentProjectForWorktreeTarget.path)
+    )?.[1] ?? [];
+  }, [availableWorktreesByProject, currentProjectForWorktreeTarget]);
+
+  const worktreeTargetOptions = React.useMemo<WorktreeTargetOption[]>(() => {
+    if (!currentSessionId || !normalizedCurrentDirectory || !currentProjectForWorktreeTarget) {
+      return [];
+    }
+    if (worktreesForCurrentProject.length === 0) {
+      return [];
+    }
+
+    const rootOption: WorktreeTargetOption = {
+      path: normalizePath(currentProjectForWorktreeTarget.path),
+      label: t('gitView.header.worktreeTargetRootLabel'),
+      isRoot: true,
+    };
+
+    const worktreeOptions: WorktreeTargetOption[] = worktreesForCurrentProject.map((metadata) => ({
+      path: normalizePath(metadata.path),
+      label: metadata.branch || metadata.label,
+      isRoot: false,
+    }));
+
+    return [rootOption, ...worktreeOptions];
+  }, [currentProjectForWorktreeTarget, currentSessionId, normalizedCurrentDirectory, t, worktreesForCurrentProject]);
+
+  const handleSelectWorktreeTarget = React.useCallback(
+    (option: WorktreeTargetOption) => {
+      if (!currentSessionId) return;
+
+      if (option.isRoot) {
+        setWorktreeMetadata(currentSessionId, null);
+        return;
+      }
+
+      const metadata = worktreesForCurrentProject.find((wt) => normalizePath(wt.path) === option.path);
+      if (metadata) {
+        setWorktreeMetadata(currentSessionId, metadata);
+      }
+    },
+    [currentSessionId, setWorktreeMetadata, worktreesForCurrentProject]
+  );
   const inferredWorktreeMetadata = React.useMemo(() => {
     if (!normalizedCurrentDirectory) {
       return undefined;
@@ -2403,6 +2464,9 @@ export const GitView: React.FC<GitViewProps> = ({ isActive }) => {
         onSelectIdentity={handleApplyIdentity}
         isApplyingIdentity={isSettingIdentity}
             isWorktreeMode={!!worktreeMetadata}
+            worktreeTargetOptions={worktreeTargetOptions}
+            activeWorktreeTargetPath={normalizedCurrentDirectory}
+            onSelectWorktreeTarget={handleSelectWorktreeTarget}
             onOpenHistory={() => setGitLogDialogMode('history')}
             onOpenGraph={() => setGitLogDialogMode('graph')}
             onOpenStashes={openStashes}

--- a/packages/ui/src/components/views/git/GitHeader.tsx
+++ b/packages/ui/src/components/views/git/GitHeader.tsx
@@ -13,6 +13,7 @@ import type { IconName } from "@/components/icon/icons";
 import { BranchSelector } from './BranchSelector';
 import { WorktreeBranchDisplay } from './WorktreeBranchDisplay';
 import { SyncActions } from './SyncActions';
+import { WorktreeTargetDropdown, type WorktreeTargetOption } from './WorktreeTargetDropdown';
 import type {
   GitStatus,
   GitIdentityProfile,
@@ -48,6 +49,9 @@ interface GitHeaderProps {
   actionTabItems?: SortableTabsStripItem[];
   activeActionTab?: string;
   onSelectActionTab?: (tabID: string) => void;
+  worktreeTargetOptions?: WorktreeTargetOption[];
+  activeWorktreeTargetPath?: string | null;
+  onSelectWorktreeTarget?: (option: WorktreeTargetOption) => void;
 }
 
 const IDENTITY_ICON_MAP: Record<string, IconName> = {
@@ -252,6 +256,9 @@ export const GitHeader: React.FC<GitHeaderProps> = ({
   actionTabItems,
   activeActionTab,
   onSelectActionTab,
+  worktreeTargetOptions,
+  activeWorktreeTargetPath,
+  onSelectWorktreeTarget,
 }) => {
   const { t } = useI18n();
   if (!status) {
@@ -338,6 +345,15 @@ export const GitHeader: React.FC<GitHeaderProps> = ({
     />
   );
 
+  const worktreeTargetControl =
+    worktreeTargetOptions && onSelectWorktreeTarget ? (
+      <WorktreeTargetDropdown
+        options={worktreeTargetOptions}
+        activePath={activeWorktreeTargetPath ?? null}
+        onSelect={onSelectWorktreeTarget}
+      />
+    ) : null;
+
   return (
     <header className="@container/git-header px-3 py-2 bg-transparent">
       <div className="flex items-center justify-between gap-2 min-w-0">
@@ -360,6 +376,7 @@ export const GitHeader: React.FC<GitHeaderProps> = ({
           )}
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          {worktreeTargetControl}
           {managementButtons}
           {identityControl}
         </div>

--- a/packages/ui/src/components/views/git/WorktreeTargetDropdown.tsx
+++ b/packages/ui/src/components/views/git/WorktreeTargetDropdown.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Icon } from '@/components/icon/Icon';
+import { useI18n } from '@/lib/i18n';
+
+export interface WorktreeTargetOption {
+  /** Absolute path this option resolves to. */
+  path: string;
+  /** Branch name for worktrees, or a generic label for the repository root. */
+  label: string;
+  isRoot: boolean;
+}
+
+interface WorktreeTargetDropdownProps {
+  options: WorktreeTargetOption[];
+  activePath: string | null;
+  onSelect: (option: WorktreeTargetOption) => void;
+}
+
+/**
+ * Lets a session point its Git/Diff/Files/Terminal tabs at a worktree other
+ * than the one it was created in, without changing where the agent itself
+ * reads and writes files. Only rendered when there is more than one target
+ * to choose from.
+ */
+export const WorktreeTargetDropdown: React.FC<WorktreeTargetDropdownProps> = ({
+  options,
+  activePath,
+  onSelect,
+}) => {
+  const { t } = useI18n();
+
+  if (options.length < 2) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 px-0"
+              aria-label={t('gitView.header.worktreeTargetTooltip')}
+            >
+              <Icon name="git-branch" className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent sideOffset={8}>{t('gitView.header.worktreeTargetTooltip')}</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" className="w-64">
+        {options.map((option) => {
+          const isSelected = activePath === option.path;
+          return (
+            <DropdownMenuItem key={option.path} onSelect={() => onSelect(option)}>
+              <span className="flex min-w-0 items-center gap-2">
+                <Icon
+                  name={option.isRoot ? 'git-repository' : 'git-branch'}
+                  className="size-4 shrink-0 text-muted-foreground"
+                />
+                <span className="min-w-0 truncate typography-ui-label text-foreground">
+                  {option.label}
+                </span>
+                {isSelected ? (
+                  <Icon name="check" className="ml-auto size-4 shrink-0 text-foreground" />
+                ) : null}
+              </span>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -684,6 +684,8 @@ export const dict = {
   'gitView.header.noIdentity': 'No identity',
   'gitView.header.noProfiles': 'No profiles available to apply.',
   'gitView.header.repositoryViews': 'Repository views',
+  'gitView.header.worktreeTargetTooltip': 'Point this tab at another worktree',
+  'gitView.header.worktreeTargetRootLabel': 'Repository root',
   'gitView.header.removeRemoteAria': 'Remove remote {name}',
   'gitView.header.removeRemoteTitle': 'Remove remote {name}',
   'gitView.header.upstreamSynced': 'synced',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -685,6 +685,8 @@ export const dict: Record<I18nKey, string> = {
   "gitView.header.noIdentity": "Sin identidad",
   "gitView.header.noProfiles": "No hay perfiles disponibles para aplicar.",
   "gitView.header.repositoryViews": "Vistas del repositorio",
+  "gitView.header.worktreeTargetTooltip": "Apuntar esta pestaña a otro worktree",
+  "gitView.header.worktreeTargetRootLabel": "Raíz del repositorio",
   "gitView.header.removeRemoteAria": "Eliminar remoto",
   "gitView.header.removeRemoteTitle": "Eliminar remoto",
   "gitView.header.upstreamSynced": "sincronizado",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -526,6 +526,8 @@ export const dict = {
   'gitView.header.noIdentity': 'Aucune identité',
   'gitView.header.noProfiles': 'Aucun profil disponible à appliquer.',
   'gitView.header.repositoryViews': 'Vues du dépôt',
+  'gitView.header.worktreeTargetTooltip': 'Pointer cet onglet vers un autre worktree',
+  'gitView.header.worktreeTargetRootLabel': 'Racine du dépôt',
   'gitView.header.removeRemoteAria': 'Supprimer le remote',
   'gitView.header.removeRemoteTitle': 'Supprimer le remote',
   'gitView.header.upstreamSynced': 'synchronisé',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -682,6 +682,8 @@ export const dict: Record<I18nKey, string> = {
   'gitView.header.noIdentity': 'IDがありません',
   'gitView.header.noProfiles': '適用できるプロファイルがありません。',
   'gitView.header.repositoryViews': 'リポジトリビュー',
+  'gitView.header.worktreeTargetTooltip': 'このタブを別の worktree に切り替える',
+  'gitView.header.worktreeTargetRootLabel': 'リポジトリのルート',
   'gitView.header.removeRemoteAria': 'リモート{name}を削除',
   'gitView.header.removeRemoteTitle': 'リモート{name}を削除',
   'gitView.header.upstreamSynced': '同期済み',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -685,6 +685,8 @@ export const dict: Record<I18nKey, string> = {
   'gitView.header.noIdentity': '인증 정보 없음',
   'gitView.header.noProfiles': '적용할 프로필 없음',
   'gitView.header.repositoryViews': '저장소 보기',
+  'gitView.header.worktreeTargetTooltip': '이 탭을 다른 worktree로 전환',
+  'gitView.header.worktreeTargetRootLabel': '저장소 루트',
   'gitView.header.removeRemoteAria': '리모트 제거',
   'gitView.header.removeRemoteTitle': '리모트 제거',
   'gitView.header.upstreamSynced': '동기화됨',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1793,6 +1793,8 @@ export const dict: Record<I18nKey, string> = {
   'gitView.header.noIdentity': 'No identity',
   'gitView.header.noProfiles': 'No profiles available to apply.',
   'gitView.header.repositoryViews': 'Widoki repozytorium',
+  'gitView.header.worktreeTargetTooltip': 'Skieruj tę kartę na inny worktree',
+  'gitView.header.worktreeTargetRootLabel': 'Katalog główny repozytorium',
   'gitView.header.removeRemoteAria': 'Usuń remote {name}',
   'gitView.header.removeRemoteTitle': 'Usuń remote {name}',
   'gitView.header.upstreamSynced': 'zsynchronizowano',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -685,6 +685,8 @@ export const dict: Record<I18nKey, string> = {
   "gitView.header.noIdentity": "Sem identidade",
   "gitView.header.noProfiles": "Não há perfiles disponíveis para aplicar.",
   "gitView.header.repositoryViews": "Visualizações do repositório",
+  "gitView.header.worktreeTargetTooltip": "Apontar esta aba para outro worktree",
+  "gitView.header.worktreeTargetRootLabel": "Raiz do repositório",
   "gitView.header.removeRemoteAria": "Excluir remoto",
   "gitView.header.removeRemoteTitle": "Excluir remoto",
   "gitView.header.upstreamSynced": "sincronizado",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -685,6 +685,8 @@ export const dict: Record<I18nKey, string> = {
   "gitView.header.noIdentity": "Ідентичність не вибрано",
   "gitView.header.noProfiles": "Немає доступних профілів для застосування.",
   "gitView.header.repositoryViews": "Перегляди репозиторію",
+  "gitView.header.worktreeTargetTooltip": "Спрямувати цю вкладку на інший worktree",
+  "gitView.header.worktreeTargetRootLabel": "Корінь репозиторію",
   "gitView.header.removeRemoteAria": "Видалити remote",
   "gitView.header.removeRemoteTitle": "Видалити remote",
   "gitView.header.upstreamSynced": "синхронізовано",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -685,6 +685,8 @@ export const dict: Record<I18nKey, string> = {
   'gitView.header.noIdentity': '无身份',
   'gitView.header.noProfiles': '没有可应用的配置。',
   'gitView.header.repositoryViews': '仓库视图',
+  'gitView.header.worktreeTargetTooltip': '将此选项卡指向另一个工作树',
+  'gitView.header.worktreeTargetRootLabel': '仓库根目录',
   'gitView.header.removeRemoteAria': '移除远程 {name}',
   'gitView.header.removeRemoteTitle': '移除 {name}',
   'gitView.header.upstreamSynced': '已同步',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -698,6 +698,8 @@ export const dict: Record<I18nKey, string> = {
   'gitView.header.noIdentity': '無身分',
   'gitView.header.noProfiles': '沒有可套用的設定。',
   'gitView.header.repositoryViews': '儲存庫檢視',
+  'gitView.header.worktreeTargetTooltip': '將此分頁指向另一個 worktree',
+  'gitView.header.worktreeTargetRootLabel': '儲存庫根目錄',
   'gitView.header.removeRemoteAria': '移除遠端 {name}',
   'gitView.header.removeRemoteTitle': '移除 {name}',
   'gitView.header.upstreamSynced': '已同步',


### PR DESCRIPTION
Closes #2115

When a worktree is created mid-session, the Git tab (and Files/Diff/Terminal, via the same `useEffectiveDirectory` resolution) kept showing the original session directory. This adds a small picker in the Git tab header to point those tabs at a different worktree of the same project, using the existing session-to-worktree attachment mechanism (`setWorktreeMetadata` / `useSessionWorktreeStore`) that's already wired into `useEffectiveDirectory`'s priority chain. The agent's own working directory is untouched.

Only shown when the project has more than one worktree to choose from.

**Tested:** `bun run type-check` and `bun run lint` clean across `ui`, `web`, `electron`, `mobile`, and `vscode`. `packages/ui/src/lib/i18n/messages.test.ts` (locale key parity) and `session-worktree-store.test.js` pass.