### PR TITLE
feat(ui): Discord onboarding wizard and messenger UX polish

### DIFF
--- a/packages/ui/src/components/sections/otto-settings/DiscordCommandPalette.tsx
+++ b/packages/ui/src/components/sections/otto-settings/DiscordCommandPalette.tsx
@@ -177,7 +177,6 @@ export function DiscordCommandsButton({ className }: DiscordCommandsButtonProps)
         className={cn('!font-normal', className)}
         onClick={() => setOpen(true)}
       >
-        <Icon name="command" className="size-3.5" />
         {t('settings.integrations.discord.commands.button')}
       </Button>
       <DiscordCommandPalette open={open} onOpenChange={setOpen} />

--- a/packages/ui/src/components/sections/otto-settings/DiscordOnboardingWizard.tsx
+++ b/packages/ui/src/components/sections/otto-settings/DiscordOnboardingWizard.tsx
@@ -147,25 +147,16 @@ export function DiscordOnboardingWizard({
       className="rounded-lg border border-[color-mix(in_srgb,var(--primary-base)_20%,transparent)] bg-[color-mix(in_srgb,var(--primary-base)_5%,var(--background))] p-4 space-y-4"
       data-settings-item="integrations.discord.wizard"
     >
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <h4 className="typography-ui-header font-medium text-foreground">
-            {t('settings.integrations.discord.wizard.title')}
-          </h4>
-          <p className="mt-0.5 text-[11px] text-muted-foreground">
-            {t('settings.integrations.discord.wizard.stepOf', {
-              current: step + 1,
-              total: TOTAL_STEPS,
-            })}
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={handleFinish}
-          className="text-[10px] text-muted-foreground hover:text-foreground"
-        >
-          {t('settings.integrations.discord.wizard.skipToAdvanced')}
-        </button>
+      <div>
+        <h4 className="typography-ui-header font-medium text-foreground">
+          {t('settings.integrations.discord.wizard.title')}
+        </h4>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          {t('settings.integrations.discord.wizard.stepOf', {
+            current: step + 1,
+            total: TOTAL_STEPS,
+          })}
+        </p>
       </div>
 
       {/* Step indicators */}

--- a/packages/ui/src/components/sections/otto-settings/DiscordOnboardingWizard.tsx
+++ b/packages/ui/src/components/sections/otto-settings/DiscordOnboardingWizard.tsx
@@ -15,6 +15,9 @@ const DEVELOPER_PORTAL_URL = 'https://discord.com/developers/applications';
 const DISCORD_ID_GUIDE_URL =
   'https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID';
 
+/** Dense settings actions — same size/weight as Discord header controls. */
+const ACTION_BTN = '!font-normal';
+
 type DiscordOnboardingWizardProps = {
   conn: MessengerConnection;
   onScrollToSection?: (section: 'token' | 'guild' | 'channel' | 'test' | 'advanced') => void;
@@ -22,7 +25,6 @@ type DiscordOnboardingWizardProps = {
 
 export function DiscordOnboardingWizard({
   conn,
-  onScrollToSection,
 }: DiscordOnboardingWizardProps) {
   const { t } = useI18n();
   const step = useMessengerStore((s) => s.onboardingStep) ?? 0;
@@ -66,7 +68,7 @@ export function DiscordOnboardingWizard({
   })();
 
   const inputClass =
-    'w-full rounded-md border border-border bg-background px-3 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+    'w-full rounded-md border border-border bg-background px-3 py-1.5 typography-ui-label text-foreground focus:outline-none focus:ring-1 focus:ring-ring';
 
   const handleSaveToken = () => {
     if (!tokenInput.trim()) return;
@@ -95,13 +97,9 @@ export function DiscordOnboardingWizard({
     ].join('\n');
   };
 
-  const handleFinish = () => {
-    finishOnboarding();
-  };
-
   const handleNext = () => {
     if (step >= TOTAL_STEPS - 1) {
-      handleFinish();
+      finishOnboarding();
       return;
     }
     nextOnboardingStep();
@@ -131,8 +129,10 @@ export function DiscordOnboardingWizard({
         );
         return;
       }
-      if (!useMessengerStore.getState().connections.find((c) => c.type === 'discord')
-        ?.discordListenerConnected) {
+      if (
+        !useMessengerStore.getState().connections.find((c) => c.type === 'discord')
+          ?.discordListenerConnected
+      ) {
         setListenerStatusText(t('settings.integrations.discord.wizard.step4.listenerConnecting'));
         await refreshDiscordListenerStatus();
       }
@@ -141,6 +141,14 @@ export function DiscordOnboardingWizard({
       setStartingListener(false);
     }
   };
+
+  const stepTitle = (key: Parameters<typeof t>[0]) => (
+    <div className="typography-ui-label font-medium text-foreground">{t(key)}</div>
+  );
+
+  const stepDescription = (key: Parameters<typeof t>[0]) => (
+    <p className="mt-1 typography-meta text-muted-foreground leading-snug">{t(key)}</p>
+  );
 
   return (
     <div
@@ -151,7 +159,7 @@ export function DiscordOnboardingWizard({
         <h4 className="typography-ui-header font-medium text-foreground">
           {t('settings.integrations.discord.wizard.title')}
         </h4>
-        <p className="mt-0.5 text-[11px] text-muted-foreground">
+        <p className="mt-0.5 typography-meta text-muted-foreground">
           {t('settings.integrations.discord.wizard.stepOf', {
             current: step + 1,
             total: TOTAL_STEPS,
@@ -159,16 +167,13 @@ export function DiscordOnboardingWizard({
         </p>
       </div>
 
-      {/* Step indicators */}
       <div className="flex gap-1">
         {Array.from({ length: TOTAL_STEPS }, (_, i) => (
           <div
             key={i}
             className={cn(
               'h-1 flex-1 rounded-full transition-colors',
-              i <= step
-                ? 'bg-[var(--primary-base)]'
-                : 'bg-[var(--surface-muted)]',
+              i <= step ? 'bg-[var(--primary-base)]' : 'bg-[var(--surface-muted)]',
             )}
           />
         ))}
@@ -178,22 +183,17 @@ export function DiscordOnboardingWizard({
       {step === 0 && (
         <div className="space-y-4">
           <div>
-            <div className="typography-ui-label font-medium text-foreground">
-              {t('settings.integrations.discord.wizard.step1.title')}
-            </div>
-            <p className="mt-1 typography-meta text-muted-foreground leading-snug">
-              {t('settings.integrations.discord.wizard.step1.description')}
-            </p>
+            {stepTitle('settings.integrations.discord.wizard.step1.title')}
+            {stepDescription('settings.integrations.discord.wizard.step1.description')}
           </div>
 
           <Button
             type="button"
             variant="outline"
-            size="sm"
-            className="!font-normal"
+            size="xs"
+            className={ACTION_BTN}
             onClick={() => window.open(DEVELOPER_PORTAL_URL, '_blank', 'noopener,noreferrer')}
           >
-            <Icon name="external-link" className="size-3.5" />
             {t('settings.integrations.discord.wizard.step1.openPortal')}
           </Button>
 
@@ -261,7 +261,8 @@ export function DiscordOnboardingWizard({
                 />
                 <Button
                   type="button"
-                  size="sm"
+                  size="xs"
+                  className={ACTION_BTN}
                   disabled={!tokenInput.trim()}
                   onClick={handleSaveToken}
                 >
@@ -284,7 +285,7 @@ export function DiscordOnboardingWizard({
                   type="button"
                   variant="outline"
                   size="xs"
-                  className="!font-normal"
+                  className={ACTION_BTN}
                   disabled={conn.status === 'connecting'}
                   onClick={() => void testConnection('discord')}
                 >
@@ -302,29 +303,24 @@ export function DiscordOnboardingWizard({
       {step === 1 && (
         <div className="space-y-3">
           <div>
-            <div className="text-xs font-medium text-foreground">
-              {t('settings.integrations.discord.wizard.step2.title')}
-            </div>
-            <p className="mt-1 text-[11px] text-muted-foreground leading-snug">
-              {t('settings.integrations.discord.wizard.step2.description')}
-            </p>
+            {stepTitle('settings.integrations.discord.wizard.step2.title')}
+            {stepDescription('settings.integrations.discord.wizard.step2.description')}
           </div>
-          <div className="text-[11px] text-muted-foreground">
+          <p className="typography-meta text-muted-foreground">
             {(conn.discordGuilds?.length ?? 0) > 0
               ? t('settings.integrations.discord.wizard.step2.botInServers', {
                   count: conn.discordGuilds?.length ?? 0,
                 })
               : t('settings.integrations.discord.wizard.step2.botNotInServers')}
-          </div>
+          </p>
           {conn.discordInviteUrl ? (
             <Button
               type="button"
               variant="outline"
               size="xs"
-              className="!font-normal"
+              className={ACTION_BTN}
               onClick={() => window.open(conn.discordInviteUrl!, '_blank', 'noopener,noreferrer')}
             >
-              <Icon name="external-link" className="size-3.5" />
               {t('settings.integrations.discord.wizard.step2.openInvite')}
             </Button>
           ) : (
@@ -332,7 +328,7 @@ export function DiscordOnboardingWizard({
               type="button"
               variant="outline"
               size="xs"
-              className="!font-normal"
+              className={ACTION_BTN}
               onClick={() => void fetchDiscordInviteUrl()}
             >
               {t('settings.integrations.discord.wizard.step2.generateInvite')}
@@ -345,28 +341,23 @@ export function DiscordOnboardingWizard({
       {step === 2 && (
         <div className="space-y-3">
           <div>
-            <div className="text-xs font-medium text-foreground">
-              {t('settings.integrations.discord.wizard.step3.title')}
-            </div>
-            <p className="mt-1 text-[11px] text-muted-foreground leading-snug">
-              {t('settings.integrations.discord.wizard.step3.description')}
-            </p>
+            {stepTitle('settings.integrations.discord.wizard.step3.title')}
+            {stepDescription('settings.integrations.discord.wizard.step3.description')}
             <a
               href={DISCORD_ID_GUIDE_URL}
               target="_blank"
               rel="noreferrer"
-              className="mt-1 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+              className="mt-1 inline-flex items-center gap-1 typography-meta text-[var(--primary-base)] hover:underline"
             >
               {t('settings.integrations.discord.wizard.step3.idGuideLink')}
-              <Icon name="external-link" className="size-3" />
             </a>
           </div>
           {!conn.discordGuildId ? (
-            <div className="space-y-1">
-              <label className="text-[11px] font-medium text-foreground">
+            <div className="space-y-1.5">
+              <label className="typography-ui-label font-medium text-foreground">
                 {t('settings.integrations.discord.wizard.step3.guildLabel')}
               </label>
-              <p className="text-[10px] text-muted-foreground">
+              <p className="typography-meta text-muted-foreground leading-snug">
                 {t('settings.integrations.discord.wizard.step3.guildHint')}
               </p>
               <div className="flex gap-2">
@@ -379,7 +370,8 @@ export function DiscordOnboardingWizard({
                 />
                 <Button
                   type="button"
-                  size="sm"
+                  size="xs"
+                  className={ACTION_BTN}
                   disabled={!guildInput.trim()}
                   onClick={() => {
                     const v = guildInput.trim();
@@ -389,45 +381,47 @@ export function DiscordOnboardingWizard({
                     setTimeout(() => void resolveDiscordGuild(), 0);
                   }}
                 >
-                  Save
+                  {t('settings.integrations.discord.wizard.save')}
                 </Button>
               </div>
               {conn.discordGuilds && conn.discordGuilds.length > 0 && (
                 <div className="flex flex-wrap gap-1 pt-1">
                   {conn.discordGuilds.slice(0, 6).map((g) => (
-                    <button
+                    <Button
                       key={g.id}
                       type="button"
+                      variant="chip"
+                      size="xs"
+                      className={ACTION_BTN}
                       onClick={() => {
                         updateConnection('discord', { discordGuildId: g.id, guildName: g.name });
                         setTimeout(() => saveDiscordConfig(), 0);
                         setTimeout(() => void resolveDiscordGuild(), 0);
                       }}
-                      className="rounded-full border border-border bg-background px-2 py-0.5 text-[10px] text-foreground hover:border-[var(--primary-base)]/40"
                     >
                       {g.name}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               )}
             </div>
           ) : (
-            <div className="flex items-center gap-2 text-xs">
+            <div className="flex items-center gap-2 typography-ui-label">
               <Icon name="check" className="size-3.5 text-[var(--status-success)]" />
-              <code className="rounded bg-muted px-1.5 py-0.5 text-[10px]">
+              <code className="rounded bg-[var(--surface-muted)] px-1.5 py-0.5 typography-micro text-foreground">
                 {conn.discordGuildId}
               </code>
               {conn.guildName && (
-                <span className="text-muted-foreground">{conn.guildName}</span>
+                <span className="typography-meta text-muted-foreground">{conn.guildName}</span>
               )}
             </div>
           )}
           {!conn.defaultChannelId && (
-            <div className="space-y-1">
-              <label className="text-[11px] font-medium text-foreground">
+            <div className="space-y-1.5">
+              <label className="typography-ui-label font-medium text-foreground">
                 {t('settings.integrations.discord.wizard.step3.channelLabel')}
               </label>
-              <p className="text-[10px] text-muted-foreground">
+              <p className="typography-meta text-muted-foreground leading-snug">
                 {t('settings.integrations.discord.wizard.step3.channelHint')}
               </p>
               <div className="flex gap-2">
@@ -440,7 +434,8 @@ export function DiscordOnboardingWizard({
                 />
                 <Button
                   type="button"
-                  size="sm"
+                  size="xs"
+                  className={ACTION_BTN}
                   disabled={!channelInput.trim()}
                   onClick={() => {
                     const v = channelInput.trim();
@@ -450,7 +445,7 @@ export function DiscordOnboardingWizard({
                     setTimeout(() => void resolveDiscordChannel(), 0);
                   }}
                 >
-                  Save
+                  {t('settings.integrations.discord.wizard.save')}
                 </Button>
               </div>
             </div>
@@ -461,7 +456,7 @@ export function DiscordOnboardingWizard({
                 type="button"
                 variant="outline"
                 size="xs"
-                className="!font-normal"
+                className={ACTION_BTN}
                 disabled={conn.lastSyncStatus === 'sending'}
                 onClick={() => void sendTestMessage('discord')}
               >
@@ -472,7 +467,7 @@ export function DiscordOnboardingWizard({
                   type="button"
                   variant="outline"
                   size="xs"
-                  className="!font-normal"
+                  className={ACTION_BTN}
                   disabled={conn.lastSyncStatus === 'sending'}
                   onClick={() =>
                     void syncDiscordGuildProjects(buildProjectPayloads(), buildSummary())
@@ -490,12 +485,8 @@ export function DiscordOnboardingWizard({
       {step === 3 && (
         <div className="space-y-3">
           <div>
-            <div className="text-xs font-medium text-foreground">
-              {t('settings.integrations.discord.wizard.step4.title')}
-            </div>
-            <p className="mt-1 text-[11px] text-muted-foreground leading-snug">
-              {t('settings.integrations.discord.wizard.step4.description')}
-            </p>
+            {stepTitle('settings.integrations.discord.wizard.step4.title')}
+            {stepDescription('settings.integrations.discord.wizard.step4.description')}
           </div>
           <label className="flex cursor-pointer items-center gap-2 py-1">
             <Checkbox
@@ -504,7 +495,7 @@ export function DiscordOnboardingWizard({
               onChange={handleEnableBridge}
               ariaLabel={t('settings.integrations.discord.wizard.step4.bridge')}
             />
-            <span className="text-xs text-foreground">
+            <span className="typography-ui-label text-foreground">
               {t('settings.integrations.discord.wizard.step4.bridge')}
             </span>
           </label>
@@ -513,22 +504,20 @@ export function DiscordOnboardingWizard({
               type="button"
               variant="outline"
               size="xs"
-              className="!font-normal"
+              className={ACTION_BTN}
               disabled={startingListener || (listenerRunning && listenerLive)}
               onClick={() => void handleStartListener()}
             >
               {startingListener ? (
                 <Icon name="loader-4" className="size-3.5 animate-spin" />
-              ) : (
-                <Icon name="play" className="size-3.5" />
-              )}
+              ) : null}
               {listenerStuck
                 ? t('settings.integrations.discord.wizard.step4.retryListener')
                 : t('settings.integrations.discord.wizard.step4.startListener')}
             </Button>
             <span
               className={cn(
-                'text-[10px]',
+                'typography-meta',
                 listenerLive
                   ? 'text-[var(--status-success)]'
                   : listenerRunning
@@ -544,40 +533,41 @@ export function DiscordOnboardingWizard({
             </span>
           </div>
           {conn.discordListenerError && (
-            <p className="text-[11px] text-[var(--status-error)]">{conn.discordListenerError}</p>
+            <p className="typography-meta text-[var(--status-error)]">{conn.discordListenerError}</p>
           )}
           {listenerStatusText && (
-            <p className="text-[11px] text-muted-foreground">{listenerStatusText}</p>
+            <p className="typography-meta text-muted-foreground">{listenerStatusText}</p>
           )}
           {canAdvance && (
-            <p className="text-[11px] text-[var(--status-success)]">
+            <p className="typography-meta text-[var(--status-success)]">
               {t('settings.integrations.discord.wizard.step4.complete')}
             </p>
           )}
         </div>
       )}
 
-      {/* Navigation */}
-      <div className="flex items-center justify-between gap-2 border-t border-border/60 pt-3">
+      {/* Navigation — Back is omitted on the first step */}
+      <div
+        className={cn(
+          'flex items-center gap-2 border-t border-border/60 pt-3',
+          step > 0 ? 'justify-between' : 'justify-end',
+        )}
+      >
+        {step > 0 && (
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            className={ACTION_BTN}
+            onClick={() => prevOnboardingStep()}
+          >
+            {t('settings.integrations.discord.wizard.back')}
+          </Button>
+        )}
         <Button
           type="button"
-          variant="ghost"
           size="xs"
-          className="!font-normal"
-          disabled={step === 0}
-          onClick={() => {
-            if (step === 0) return;
-            prevOnboardingStep();
-            if (step === 1) onScrollToSection?.('token');
-            if (step === 2) onScrollToSection?.('guild');
-            if (step === 3) onScrollToSection?.('advanced');
-          }}
-        >
-          {t('settings.integrations.discord.wizard.back')}
-        </Button>
-        <Button
-          type="button"
-          size="sm"
+          className={ACTION_BTN}
           disabled={!canAdvance}
           onClick={handleNext}
         >

--- a/packages/ui/src/components/sections/otto-settings/DiscordOnboardingWizard.tsx
+++ b/packages/ui/src/components/sections/otto-settings/DiscordOnboardingWizard.tsx
@@ -185,53 +185,102 @@ export function DiscordOnboardingWizard({
 
       {/* Step 0: Token */}
       {step === 0 && (
-        <div className="space-y-3">
+        <div className="space-y-4">
           <div>
-            <div className="text-xs font-medium text-foreground">
+            <div className="typography-ui-label font-medium text-foreground">
               {t('settings.integrations.discord.wizard.step1.title')}
             </div>
-            <p className="mt-1 text-[11px] text-muted-foreground leading-snug">
+            <p className="mt-1 typography-meta text-muted-foreground leading-snug">
               {t('settings.integrations.discord.wizard.step1.description')}
             </p>
           </div>
+
           <Button
             type="button"
             variant="outline"
-            size="xs"
+            size="sm"
             className="!font-normal"
             onClick={() => window.open(DEVELOPER_PORTAL_URL, '_blank', 'noopener,noreferrer')}
           >
             <Icon name="external-link" className="size-3.5" />
             {t('settings.integrations.discord.wizard.step1.openPortal')}
           </Button>
-          <ol className="list-decimal space-y-1 pl-4 text-[11px] text-muted-foreground leading-snug">
-            <li>{t('settings.integrations.discord.wizard.step1.stepNewApp')}</li>
-            <li>{t('settings.integrations.discord.wizard.step1.stepNameBot')}</li>
-            <li>{t('settings.integrations.discord.wizard.step1.stepBotMenu')}</li>
-            <li>{t('settings.integrations.discord.wizard.step1.stepResetToken')}</li>
-            <li>{t('settings.integrations.discord.wizard.step1.stepIntent')}</li>
-          </ol>
+
+          <div className="space-y-3">
+            <div className="typography-ui-label font-medium text-foreground">
+              {t('settings.integrations.discord.wizard.step1.guideTitle')}
+            </div>
+            <ol className="space-y-3">
+              {(
+                [
+                  {
+                    title: 'settings.integrations.discord.wizard.step1.stepNewApp.title',
+                    description: 'settings.integrations.discord.wizard.step1.stepNewApp.description',
+                  },
+                  {
+                    title: 'settings.integrations.discord.wizard.step1.stepBotMenu.title',
+                    description: 'settings.integrations.discord.wizard.step1.stepBotMenu.description',
+                  },
+                  {
+                    title: 'settings.integrations.discord.wizard.step1.stepResetToken.title',
+                    description:
+                      'settings.integrations.discord.wizard.step1.stepResetToken.description',
+                  },
+                  {
+                    title: 'settings.integrations.discord.wizard.step1.stepIntent.title',
+                    description: 'settings.integrations.discord.wizard.step1.stepIntent.description',
+                  },
+                ] as const
+              ).map((item, index) => (
+                <li key={item.title} className="flex gap-3">
+                  <span
+                    className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-[color-mix(in_srgb,var(--primary-base)_15%,transparent)] typography-micro font-medium text-[var(--primary-base)] tabular-nums"
+                    aria-hidden
+                  >
+                    {index + 1}
+                  </span>
+                  <div className="min-w-0 space-y-0.5">
+                    <div className="typography-ui-label font-medium text-foreground">
+                      {t(item.title)}
+                    </div>
+                    <p className="typography-meta text-muted-foreground leading-snug">
+                      {t(item.description)}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+
           {!hasToken ? (
-            <div className="flex gap-2">
-              <input
-                type="password"
-                value={tokenInput}
-                onChange={(e) => setTokenInput(e.target.value)}
-                placeholder={t('settings.integrations.discord.wizard.step1.tokenLabel')}
-                className={inputClass}
-              />
-              <Button
-                type="button"
-                size="sm"
-                disabled={!tokenInput.trim()}
-                onClick={handleSaveToken}
-              >
-                Save
-              </Button>
+            <div className="space-y-1.5">
+              <label className="typography-ui-label font-medium text-foreground">
+                {t('settings.integrations.discord.wizard.step1.tokenLabel')}
+              </label>
+              <p className="typography-meta text-muted-foreground leading-snug">
+                {t('settings.integrations.discord.wizard.step1.tokenHint')}
+              </p>
+              <div className="flex gap-2">
+                <input
+                  type="password"
+                  value={tokenInput}
+                  onChange={(e) => setTokenInput(e.target.value)}
+                  placeholder={t('settings.integrations.discord.wizard.step1.tokenLabel')}
+                  className={inputClass}
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={!tokenInput.trim()}
+                  onClick={handleSaveToken}
+                >
+                  {t('settings.integrations.discord.wizard.step1.saveToken')}
+                </Button>
+              </div>
             </div>
           ) : (
             <div className="space-y-2">
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <div className="flex items-center gap-2 typography-ui-label text-muted-foreground">
                 <Icon name="check" className="size-3.5 text-[var(--status-success)]" />
                 {isConnected
                   ? t('settings.integrations.discord.wizard.step1.verified', {

--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -1316,6 +1316,9 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
         <DiscordOnboardingWizard conn={conn} onScrollToSection={scrollToSection} />
       )}
 
+      {/* Token / sync / advanced — only outside the wizard so fields aren't duplicated */}
+      {!showWizard && (
+        <>
       {/* Step 1: Token */}
       {!token ? (
         <div ref={tokenSectionRef} className="space-y-2">
@@ -1459,6 +1462,8 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
             onOpenChange={setAdvancedOpen}
           />
         </div>
+      )}
+        </>
       )}
 
       <Dialog open={disconnectConfirmOpen} onOpenChange={setDisconnectConfirmOpen}>

--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -1204,6 +1204,7 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
 
   const hasToken = Boolean(token);
   const hasTarget = Boolean(target);
+  const isConnected = conn.status === 'connected';
 
   // Auto-save Discord config to server-side settings.json on mount so that
   // the server-side auto-start on reboot picks it up. Runs when the
@@ -1273,18 +1274,21 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
           )}
         </div>
         <div className="flex items-center gap-2">
-          {hasToken && (
+          {isConnected && (
             <>
               <DiscordCommandsButton />
-              <button
+              <Button
                 type="button"
-                onClick={() => testConnection(conn.type)}
+                variant="outline"
+                size="xs"
+                className="!font-normal"
                 disabled={conn.status === 'connecting'}
-                className="rounded px-2 py-1 text-[10px] font-medium text-primary bg-primary/10 hover:bg-primary/20 disabled:opacity-50"
-                title="Verify the bot token by calling the messenger API"
+                onClick={() => void testConnection(conn.type)}
               >
-                {conn.status === 'connecting' ? 'Testing…' : 'Verify token'}
-              </button>
+                {conn.status === 'connecting'
+                  ? t('settings.integrations.discord.verify.testing')
+                  : t('settings.integrations.discord.verify.button')}
+              </Button>
               <Button
                 type="button"
                 variant="destructive"

--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -1273,25 +1273,29 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <DiscordCommandsButton />
-          <button
-            type="button"
-            onClick={() => testConnection(conn.type)}
-            disabled={!token || conn.status === 'connecting'}
-            className="rounded px-2 py-1 text-[10px] font-medium text-primary bg-primary/10 hover:bg-primary/20 disabled:opacity-50"
-            title="Verify the bot token by calling the messenger API"
-          >
-            {conn.status === 'connecting' ? 'Testing…' : 'Verify token'}
-          </button>
-          <Button
-            type="button"
-            variant="destructive"
-            size="xs"
-            className="!font-normal"
-            onClick={() => setDisconnectConfirmOpen(true)}
-          >
-            {t('settings.integrations.discord.disconnect.button')}
-          </Button>
+          {hasToken && (
+            <>
+              <DiscordCommandsButton />
+              <button
+                type="button"
+                onClick={() => testConnection(conn.type)}
+                disabled={conn.status === 'connecting'}
+                className="rounded px-2 py-1 text-[10px] font-medium text-primary bg-primary/10 hover:bg-primary/20 disabled:opacity-50"
+                title="Verify the bot token by calling the messenger API"
+              >
+                {conn.status === 'connecting' ? 'Testing…' : 'Verify token'}
+              </button>
+              <Button
+                type="button"
+                variant="destructive"
+                size="xs"
+                className="!font-normal"
+                onClick={() => setDisconnectConfirmOpen(true)}
+              >
+                {t('settings.integrations.discord.disconnect.button')}
+              </Button>
+            </>
+          )}
         </div>
       </div>
 

--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   RiDiscordLine,
   RiCheckLine,
-  RiCloseLine,
   RiLoader4Line,
   RiAddLine,
   RiSendPlaneLine,
@@ -28,7 +27,17 @@ import { useOttoEventsStore, type OttoUiRealtimeEvent } from '@/stores/useOttoEv
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
+import { useI18n } from '@/lib/i18n';
 import { DiscordOnboardingWizard } from './DiscordOnboardingWizard';
 import { DiscordCommandsButton } from './DiscordCommandPalette';
 
@@ -1144,6 +1153,7 @@ function DiscordAdvancedSettings({
 }
 
 function ConnectionCard({ conn }: { conn: MessengerConnection }) {
+  const { t } = useI18n();
   const onboardingStep = useMessengerStore((s) => s.onboardingStep);
   const onboardingType = useMessengerStore((s) => s.onboardingType);
   const showWizard = onboardingStep !== null && onboardingType === 'discord';
@@ -1187,6 +1197,7 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
   const [showToken, setShowToken] = useState(false);
   const [tokenInput, setTokenInput] = useState('');
   const [showTokenPlain, setShowTokenPlain] = useState(false);
+  const [disconnectConfirmOpen, setDisconnectConfirmOpen] = useState(false);
 
   const token = conn.botToken;
   const target = conn.defaultChannelId;
@@ -1272,14 +1283,15 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
           >
             {conn.status === 'connecting' ? 'Testing…' : 'Verify token'}
           </button>
-          <button
+          <Button
             type="button"
-            onClick={() => removeConnection(conn.type)}
-            className="text-muted-foreground hover:text-destructive"
-            title={`Disconnect ${meta.name}`}
+            variant="destructive"
+            size="xs"
+            className="!font-normal"
+            onClick={() => setDisconnectConfirmOpen(true)}
           >
-            <RiCloseLine className="size-4" />
-          </button>
+            {t('settings.integrations.discord.disconnect.button')}
+          </Button>
         </div>
       </div>
 
@@ -1440,6 +1452,38 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
           />
         </div>
       )}
+
+      <Dialog open={disconnectConfirmOpen} onOpenChange={setDisconnectConfirmOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t('settings.integrations.discord.disconnect.dialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('settings.integrations.discord.disconnect.dialog.description')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setDisconnectConfirmOpen(false)}
+            >
+              {t('settings.common.actions.cancel')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => {
+                removeConnection(conn.type);
+                setDisconnectConfirmOpen(false);
+              }}
+            >
+              {t('settings.integrations.discord.disconnect.dialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -4,8 +4,6 @@ import {
   RiCheckLine,
   RiLoader4Line,
   RiAddLine,
-  RiSendPlaneLine,
-  RiRefreshLine,
   RiAlertLine,
   RiExternalLinkLine,
   RiEyeLine,
@@ -1319,11 +1317,10 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
       {/* Token / sync / advanced — only outside the wizard so fields aren't duplicated */}
       {!showWizard && (
         <>
-      {/* Step 1: Token */}
       {!token ? (
         <div ref={tokenSectionRef} className="space-y-2">
-          <div className="text-xs font-medium text-foreground">{meta.tokenLabel}</div>
-          <div className="text-[11px] text-muted-foreground leading-snug">{meta.tokenHelp}</div>
+          <div className="typography-ui-label font-medium text-foreground">{meta.tokenLabel}</div>
+          <div className="typography-meta text-muted-foreground leading-snug">{meta.tokenHelp}</div>
           <div className="flex gap-2">
             <div className="relative flex-1">
               <input
@@ -1346,100 +1343,101 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
                 )}
               </button>
             </div>
-            <button
+            <Button
               type="button"
+              size="xs"
+              className="!font-normal"
               onClick={handleSaveToken}
               disabled={!tokenInput.trim()}
-              className="shrink-0 rounded bg-primary px-3 py-1.5 text-xs text-primary-foreground disabled:opacity-50"
             >
-              Save
-            </button>
+              {t('settings.integrations.discord.wizard.save')}
+            </Button>
           </div>
         </div>
       ) : (
-        <div ref={tokenSectionRef} className="flex items-center gap-2 text-xs">
-          <RiCheckLine className="size-3 text-green-500" />
+        <div ref={tokenSectionRef} className="flex items-center gap-2 typography-ui-label">
+          <RiCheckLine className="size-3 text-[var(--status-success)]" />
           <span className="text-muted-foreground">Token configured</span>
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="xs"
+            className="!font-normal"
             onClick={() => setShowToken(!showToken)}
-            className="text-primary text-[10px]"
           >
-            {showToken ? 'Cancel' : 'Change'}
-          </button>
+            {showToken ? t('settings.common.actions.cancel') : t('settings.integrations.discord.token.change')}
+          </Button>
           {showToken && (
             <div className="flex gap-2 flex-1">
               <input
                 type="password"
                 value={tokenInput}
                 onChange={(e) => setTokenInput(e.target.value)}
-                placeholder="New token"
+                placeholder={t('settings.integrations.discord.wizard.step1.tokenLabel')}
                 className={inputClass}
               />
-              <button
+              <Button
                 type="button"
+                size="xs"
+                className="!font-normal"
                 onClick={handleSaveToken}
                 disabled={!tokenInput.trim()}
-                className="rounded bg-primary px-2 py-1 text-[10px] text-primary-foreground disabled:opacity-50"
               >
-                Update
-              </button>
+                {t('settings.integrations.discord.token.update')}
+              </Button>
             </div>
           )}
         </div>
       )}
 
-      {/* Step 3: Action buttons - the visible "what next" call to action.
-          For Discord, server-id alone also unlocks the CTA (Sync now works with just guildId). */}
+      {/* Sync actions */}
       {hasToken && (hasTarget || conn.discordGuildId) && (
         <div
           ref={testSectionRef}
-          className="space-y-2 rounded-md border border-primary/20 bg-primary/5 p-3"
+          className="space-y-2 rounded-md border border-[color-mix(in_srgb,var(--primary-base)_20%,transparent)] bg-[color-mix(in_srgb,var(--primary-base)_5%,var(--background))] p-3"
         >
           <div className="flex flex-wrap items-center gap-2">
-            <button
+            <Button
               type="button"
-              onClick={() => sendTestMessage(conn.type)}
+              size="xs"
+              className="!font-normal"
+              onClick={() => void sendTestMessage(conn.type)}
               disabled={conn.lastSyncStatus === 'sending'}
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
             >
               {conn.lastSyncStatus === 'sending' ? (
                 <RiLoader4Line className="size-3.5 animate-spin" />
-              ) : (
-                <RiSendPlaneLine className="size-3.5" />
-              )}
-              Send test message
-            </button>
-            <button
+              ) : null}
+              {t('settings.integrations.discord.wizard.step3.sendTest')}
+            </Button>
+            <Button
               type="button"
+              variant="outline"
+              size="xs"
+              className="!font-normal"
               onClick={() => {
                 if (conn.discordGuildId) {
-                  // Server-wide sync: per-project channel + thread.
-                  syncDiscordGuildProjects(buildProjectPayloads(), buildSummary());
+                  void syncDiscordGuildProjects(buildProjectPayloads(), buildSummary());
                 } else {
-                  sendSyncSummary(conn.type, buildSummary());
+                  void sendSyncSummary(conn.type, buildSummary());
                 }
               }}
               disabled={conn.lastSyncStatus === 'sending'}
-              className="inline-flex items-center gap-1.5 rounded-md border border-primary/40 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 disabled:opacity-50"
             >
               {conn.lastSyncStatus === 'sending' ? (
                 <RiLoader4Line className="size-3.5 animate-spin" />
-              ) : (
-                <RiRefreshLine className="size-3.5" />
-              )}
-              Sync now
-            </button>
-            <div className="ml-auto text-[10px] text-muted-foreground">
+              ) : null}
+              {t('settings.integrations.discord.wizard.step3.syncNow')}
+            </Button>
+            <div className="ml-auto typography-meta text-muted-foreground">
               Last activity: {formatRelative(conn.lastSyncAt)}
             </div>
           </div>
           {conn.lastSyncMessage && (
             <div
               className={cn(
-                'text-[11px] leading-snug',
-                conn.lastSyncStatus === 'error' && 'text-destructive',
-                conn.lastSyncStatus === 'ok' && 'text-green-600 dark:text-green-400',
+                'typography-meta leading-snug',
+                conn.lastSyncStatus === 'error' && 'text-[var(--status-error)]',
+                conn.lastSyncStatus === 'ok' && 'text-[var(--status-success)]',
                 conn.lastSyncStatus === 'sending' && 'text-muted-foreground',
               )}
             >

--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -1513,15 +1513,6 @@ export const MessengerSection: React.FC = () => {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-sm font-medium text-foreground">Messenger Sync</h3>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Chat with your assistant from Discord and mirror project updates into your server.
-          </p>
-        </div>
-      </div>
-
       {connections.map((conn) => (
         <ConnectionCard key={conn.type} conn={conn} />
       ))}

--- a/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
@@ -6,7 +6,6 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.wizard.back': 'Back',
     'settings.integrations.discord.wizard.next': 'Next',
     'settings.integrations.discord.wizard.finish': 'Finish setup',
-    'settings.integrations.discord.wizard.skipToAdvanced': 'Skip to full settings',
     'settings.integrations.discord.wizard.step1.title': 'Create a Discord bot',
     'settings.integrations.discord.wizard.step1.description':
       'Otto connects through a Discord bot you own. Create one in the Developer Portal, copy its token, then paste it below.',
@@ -127,7 +126,6 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.wizard.back': 'Назад',
     'settings.integrations.discord.wizard.next': 'Далі',
     'settings.integrations.discord.wizard.finish': 'Завершити налаштування',
-    'settings.integrations.discord.wizard.skipToAdvanced': 'Перейти до повних налаштувань',
     'settings.integrations.discord.wizard.step1.title': 'Створіть Discord-бота',
     'settings.integrations.discord.wizard.step1.description':
       'Otto підключається через Discord-бота, яким ви володієте. Створіть його в Developer Portal, скопіюйте токен і вставте нижче.',

--- a/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
@@ -107,6 +107,11 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.commands.desc.share': 'Generate public URL for session',
     'settings.integrations.discord.commands.desc.unshare': 'Revoke public session URL',
     'settings.integrations.discord.commands.desc.schedule': 'Schedule a prompt (UTC ISO or cron)',
+    'settings.integrations.discord.disconnect.button': 'Disconnect',
+    'settings.integrations.discord.disconnect.dialog.title': 'Disconnect Discord?',
+    'settings.integrations.discord.disconnect.dialog.description':
+      'This removes the bot token and stops syncing from this device. The listener and bridge will stop. You can reconnect anytime by adding your token again.',
+    'settings.integrations.discord.disconnect.dialog.confirm': 'Disconnect',
   },
   uk: {
     'settings.integrations.discord.wizard.title': 'Налаштування Discord',
@@ -216,5 +221,10 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.commands.desc.share': 'Публічний URL сесії',
     'settings.integrations.discord.commands.desc.unshare': 'Скасувати публічний URL',
     'settings.integrations.discord.commands.desc.schedule': 'Запланувати промпт (UTC або cron)',
+    'settings.integrations.discord.disconnect.button': 'Відключити',
+    'settings.integrations.discord.disconnect.dialog.title': 'Відключити Discord?',
+    'settings.integrations.discord.disconnect.dialog.description':
+      'Це видалить токен бота та зупинить синхронізацію на цьому пристрої. Listener і bridge буде зупинено. Ви зможете підключитися знову, додавши токен.',
+    'settings.integrations.discord.disconnect.dialog.confirm': 'Відключити',
   },
 } as const;

--- a/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
@@ -7,18 +7,26 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.wizard.next': 'Next',
     'settings.integrations.discord.wizard.finish': 'Finish setup',
     'settings.integrations.discord.wizard.skipToAdvanced': 'Skip to full settings',
-    'settings.integrations.discord.wizard.step1.title': 'Create bot and get token',
+    'settings.integrations.discord.wizard.step1.title': 'Create a Discord bot',
     'settings.integrations.discord.wizard.step1.description':
-      'Open the Discord Developer Portal, create a bot, and enable the Message Content intent.',
-    'settings.integrations.discord.wizard.step1.steps':
-      'New Application → name your bot → Bot (left menu) → Reset Token → copy token. Enable Message Content intent under Privileged Gateway Intents.',
-    'settings.integrations.discord.wizard.step1.stepNewApp': 'New Application',
-    'settings.integrations.discord.wizard.step1.stepNameBot': 'Name your bot',
-    'settings.integrations.discord.wizard.step1.stepBotMenu': 'Bot (left menu)',
-    'settings.integrations.discord.wizard.step1.stepResetToken': 'Reset Token → copy token',
-    'settings.integrations.discord.wizard.step1.stepIntent': 'Enable Message Content intent',
+      'Otto connects through a Discord bot you own. Create one in the Developer Portal, copy its token, then paste it below.',
+    'settings.integrations.discord.wizard.step1.guideTitle': 'How to get the token',
+    'settings.integrations.discord.wizard.step1.stepNewApp.title': 'Create an application',
+    'settings.integrations.discord.wizard.step1.stepNewApp.description':
+      'Open the Developer Portal and click New Application. Give it any name — this becomes your bot.',
+    'settings.integrations.discord.wizard.step1.stepBotMenu.title': 'Open Bot settings',
+    'settings.integrations.discord.wizard.step1.stepBotMenu.description':
+      'In the left sidebar, open Bot. Discord creates the bot user for this application automatically.',
+    'settings.integrations.discord.wizard.step1.stepResetToken.title': 'Copy the bot token',
+    'settings.integrations.discord.wizard.step1.stepResetToken.description':
+      'Click Reset Token, confirm, then copy the token. Treat it like a password — anyone with it can control your bot.',
+    'settings.integrations.discord.wizard.step1.stepIntent.title': 'Enable Message Content Intent',
+    'settings.integrations.discord.wizard.step1.stepIntent.description':
+      'Under Privileged Gateway Intents, turn on Message Content Intent and save. Without this, Otto cannot read messages in your server.',
     'settings.integrations.discord.wizard.step1.openPortal': 'Open Developer Portal',
     'settings.integrations.discord.wizard.step1.tokenLabel': 'Bot token',
+    'settings.integrations.discord.wizard.step1.tokenHint': 'Paste the token you copied from the Bot page.',
+    'settings.integrations.discord.wizard.step1.saveToken': 'Save token',
     'settings.integrations.discord.wizard.step1.verify': 'Verify token',
     'settings.integrations.discord.wizard.step1.verifying': 'Verifying…',
     'settings.integrations.discord.wizard.step1.verified': 'Token verified as {username}',
@@ -120,18 +128,26 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.wizard.next': 'Далі',
     'settings.integrations.discord.wizard.finish': 'Завершити налаштування',
     'settings.integrations.discord.wizard.skipToAdvanced': 'Перейти до повних налаштувань',
-    'settings.integrations.discord.wizard.step1.title': 'Створіть бота та отримайте токен',
+    'settings.integrations.discord.wizard.step1.title': 'Створіть Discord-бота',
     'settings.integrations.discord.wizard.step1.description':
-      'Відкрийте Discord Developer Portal, створіть бота та увімкніть Message Content intent.',
-    'settings.integrations.discord.wizard.step1.steps':
-      'New Application → назвіть бота → Bot (ліве меню) → Reset Token → скопіюйте токен. Увімкніть Message Content intent у Privileged Gateway Intents.',
-    'settings.integrations.discord.wizard.step1.stepNewApp': 'New Application',
-    'settings.integrations.discord.wizard.step1.stepNameBot': 'Назвіть бота',
-    'settings.integrations.discord.wizard.step1.stepBotMenu': 'Bot (ліве меню)',
-    'settings.integrations.discord.wizard.step1.stepResetToken': 'Reset Token → скопіюйте токен',
-    'settings.integrations.discord.wizard.step1.stepIntent': 'Увімкніть Message Content intent',
+      'Otto підключається через Discord-бота, яким ви володієте. Створіть його в Developer Portal, скопіюйте токен і вставте нижче.',
+    'settings.integrations.discord.wizard.step1.guideTitle': 'Як отримати токен',
+    'settings.integrations.discord.wizard.step1.stepNewApp.title': 'Створіть застосунок',
+    'settings.integrations.discord.wizard.step1.stepNewApp.description':
+      'Відкрийте Developer Portal і натисніть New Application. Дайте будь-яку назву — це стане вашим ботом.',
+    'settings.integrations.discord.wizard.step1.stepBotMenu.title': 'Відкрийте налаштування Bot',
+    'settings.integrations.discord.wizard.step1.stepBotMenu.description':
+      'У лівому меню відкрийте Bot. Discord автоматично створить користувача-бота для цього застосунку.',
+    'settings.integrations.discord.wizard.step1.stepResetToken.title': 'Скопіюйте токен бота',
+    'settings.integrations.discord.wizard.step1.stepResetToken.description':
+      'Натисніть Reset Token, підтвердіть і скопіюйте токен. Ставтеся до нього як до пароля — хто має токен, той керує ботом.',
+    'settings.integrations.discord.wizard.step1.stepIntent.title': 'Увімкніть Message Content Intent',
+    'settings.integrations.discord.wizard.step1.stepIntent.description':
+      'У розділі Privileged Gateway Intents увімкніть Message Content Intent і збережіть. Без цього Otto не зможе читати повідомлення на сервері.',
     'settings.integrations.discord.wizard.step1.openPortal': 'Відкрити Developer Portal',
     'settings.integrations.discord.wizard.step1.tokenLabel': 'Токен бота',
+    'settings.integrations.discord.wizard.step1.tokenHint': 'Вставте токен, скопійований зі сторінки Bot.',
+    'settings.integrations.discord.wizard.step1.saveToken': 'Зберегти токен',
     'settings.integrations.discord.wizard.step1.verify': 'Перевірити токен',
     'settings.integrations.discord.wizard.step1.verifying': 'Перевірка…',
     'settings.integrations.discord.wizard.step1.verified': 'Токен підтверджено: {username}',

--- a/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
@@ -119,6 +119,8 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.disconnect.dialog.description':
       'This removes the bot token and stops syncing from this device. The listener and bridge will stop. You can reconnect anytime by adding your token again.',
     'settings.integrations.discord.disconnect.dialog.confirm': 'Disconnect',
+    'settings.integrations.discord.verify.button': 'Verify token',
+    'settings.integrations.discord.verify.testing': 'Verifying…',
   },
   uk: {
     'settings.integrations.discord.wizard.title': 'Налаштування Discord',
@@ -240,5 +242,7 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.disconnect.dialog.description':
       'Це видалить токен бота та зупинить синхронізацію на цьому пристрої. Listener і bridge буде зупинено. Ви зможете підключитися знову, додавши токен.',
     'settings.integrations.discord.disconnect.dialog.confirm': 'Відключити',
+    'settings.integrations.discord.verify.button': 'Перевірити токен',
+    'settings.integrations.discord.verify.testing': 'Перевірка…',
   },
 } as const;

--- a/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
@@ -6,6 +6,7 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.wizard.back': 'Back',
     'settings.integrations.discord.wizard.next': 'Next',
     'settings.integrations.discord.wizard.finish': 'Finish setup',
+    'settings.integrations.discord.wizard.save': 'Save',
     'settings.integrations.discord.wizard.step1.title': 'Create a Discord bot',
     'settings.integrations.discord.wizard.step1.description':
       'Otto connects through a Discord bot you own. Create one in the Developer Portal, copy its token, then paste it below.',
@@ -121,6 +122,8 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.disconnect.dialog.confirm': 'Disconnect',
     'settings.integrations.discord.verify.button': 'Verify token',
     'settings.integrations.discord.verify.testing': 'Verifying…',
+    'settings.integrations.discord.token.change': 'Change',
+    'settings.integrations.discord.token.update': 'Update',
   },
   uk: {
     'settings.integrations.discord.wizard.title': 'Налаштування Discord',
@@ -128,6 +131,7 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.wizard.back': 'Назад',
     'settings.integrations.discord.wizard.next': 'Далі',
     'settings.integrations.discord.wizard.finish': 'Завершити налаштування',
+    'settings.integrations.discord.wizard.save': 'Зберегти',
     'settings.integrations.discord.wizard.step1.title': 'Створіть Discord-бота',
     'settings.integrations.discord.wizard.step1.description':
       'Otto підключається через Discord-бота, яким ви володієте. Створіть його в Developer Portal, скопіюйте токен і вставте нижче.',
@@ -244,5 +248,7 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.disconnect.dialog.confirm': 'Відключити',
     'settings.integrations.discord.verify.button': 'Перевірити токен',
     'settings.integrations.discord.verify.testing': 'Перевірка…',
+    'settings.integrations.discord.token.change': 'Змінити',
+    'settings.integrations.discord.token.update': 'Оновити',
   },
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Discord integration UX improvements.

### Latest
- Removed the **Messenger Sync** section title/description
- Wizard **Back** hidden on step 1; Back/Next/Finish and all step actions use the same shared `Button` (`xs`, consistent variants, no mixed icons)
- Typography aligned to project tokens (`typography-ui-label` / `typography-meta`)
- During onboarding only the wizard is shown (no duplicate Bot Token / sync / advanced)
- Header **Commands / Verify / Disconnect** same style; only when connected

### Other
- Red Disconnect with confirmation dialog
- Guild ID in advanced settings; checklist/invite blocks removed
- Sync 429 retries; bash command dedup at normal verbosity
- Listener start/retry polish
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55baecc9-3632-4d69-b5c9-739c484e6358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55baecc9-3632-4d69-b5c9-739c484e6358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

