### PR TITLE
fix: discover live remote branches

### DIFF
--- a/packages/ui/src/components/session/NewWorktreeDialog.tsx
+++ b/packages/ui/src/components/session/NewWorktreeDialog.tsx
@@ -353,12 +353,15 @@ export function NewWorktreeDialog({
   const hasSourceBranchMatches = sourceBranchRankedGroups.matching.length > 0;
   const canFetchBranches = Boolean(projectDirectory && git);
 
-  const handleFetchBranches = React.useCallback(() => {
+  const handleFetchBranches = React.useCallback(async () => {
     if (!projectDirectory || !git) {
       return;
     }
-    void fetchBranches(projectDirectory, git);
-  }, [projectDirectory, git, fetchBranches]);
+    const success = await fetchBranches(projectDirectory, git);
+    if (!success) {
+      toast.error(t('session.newWorktree.error.fetchBranchesFailed'));
+    }
+  }, [projectDirectory, git, fetchBranches, t]);
 
   React.useEffect(() => {
     if (!open || !projectDirectory || !git) return;

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1647,6 +1647,7 @@ export const dict = {
   'session.newWorktree.error.worktreeDirectoryRequired': 'Worktree directory is required',
   'session.newWorktree.error.sendGitHubContextFailed': 'Failed to send GitHub context',
   'session.newWorktree.error.createWorktreeFailed': 'Failed to create worktree',
+  'session.newWorktree.error.fetchBranchesFailed': 'Failed to fetch branches',
   'session.newWorktree.toast.sessionFromIssue': 'Session created from issue',
   'session.newWorktree.toast.sessionFromPr': 'Session created from PR',
   'session.newWorktree.toast.worktreeCreated': 'Worktree created',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1625,6 +1625,7 @@ export const dict: Record<I18nKey, string> = {
   "session.newWorktree.error.worktreeDirectoryRequired": "Se requiere el directorio del worktree",
   "session.newWorktree.error.sendGitHubContextFailed": "No se pudo enviar el contexto de GitHub",
   "session.newWorktree.error.createWorktreeFailed": "No se pudo crear el worktree",
+  "session.newWorktree.error.fetchBranchesFailed": "No se pudieron obtener las ramas",
   "session.newWorktree.toast.sessionFromIssue": "Sesión creada desde issue",
   "session.newWorktree.toast.sessionFromPr": "Sesión creada desde PR",
   "session.newWorktree.toast.worktreeCreated": "Worktree creado",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1468,6 +1468,7 @@ export const dict = {
   'session.newWorktree.error.worktreeDirectoryRequired': 'Le répertoire du worktree est requis',
   'session.newWorktree.error.sendGitHubContextFailed': 'Échec de l\'envoi du contexte GitHub',
   'session.newWorktree.error.createWorktreeFailed': 'Échec de la création du worktree',
+  'session.newWorktree.error.fetchBranchesFailed': 'Échec de la récupération des branches',
   'session.newWorktree.toast.sessionFromIssue': 'Session créée à partir du problème',
   'session.newWorktree.toast.sessionFromPr': 'Session créée à partir de PR',
   'session.newWorktree.toast.worktreeCreated': 'Worktree créé',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -1643,6 +1643,7 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.error.worktreeDirectoryRequired': 'ワークツリーディレクトリが必要です',
   'session.newWorktree.error.sendGitHubContextFailed': 'GitHubコンテキストの送信に失敗しました',
   'session.newWorktree.error.createWorktreeFailed': 'ワークツリーの作成に失敗しました',
+  'session.newWorktree.error.fetchBranchesFailed': 'ブランチの取得に失敗しました',
   'session.newWorktree.toast.sessionFromIssue': 'Issueからセッションを作成しました',
   'session.newWorktree.toast.sessionFromPr': 'PRからセッションを作成しました',
   'session.newWorktree.toast.worktreeCreated': 'ワークツリーを作成しました',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1649,6 +1649,7 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.error.worktreeDirectoryRequired': '워크트리 디렉터리 필수',
   'session.newWorktree.error.sendGitHubContextFailed': 'GitHub 컨텍스트 전송에 실패했습니다',
   'session.newWorktree.error.createWorktreeFailed': '워크트리 생성에 실패했습니다',
+  'session.newWorktree.error.fetchBranchesFailed': '브랜치를 가져오지 못했습니다',
   'session.newWorktree.toast.sessionFromIssue': '이슈에서 세션을 생성했습니다',
   'session.newWorktree.toast.sessionFromPr': 'PR에서 세션을 생성했습니다',
   'session.newWorktree.toast.worktreeCreated': '워크트리를 생성했습니다',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2436,6 +2436,7 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.chooseBranch': 'Wybierz gałąź...',
   'session.newWorktree.error.branchNameRequired': 'Nazwa gałęzi jest wymagana',
   'session.newWorktree.error.createWorktreeFailed': 'Nie udało się utworzyć drzewa pracy',
+  'session.newWorktree.error.fetchBranchesFailed': 'Nie udało się pobrać gałęzi',
   'session.newWorktree.error.noActiveProject': 'Brak aktywnego projektu',
   'session.newWorktree.error.noModelSelected': 'Nie wybrano modelu',
   'session.newWorktree.error.sendGitHubContextFailed': 'Nie udało się wysłać kontekstu GitHub',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1625,6 +1625,7 @@ export const dict: Record<I18nKey, string> = {
   "session.newWorktree.error.worktreeDirectoryRequired": "É necessário o diretório do worktree",
   "session.newWorktree.error.sendGitHubContextFailed": "Não foi possível enviar o contexto de GitHub",
   "session.newWorktree.error.createWorktreeFailed": "Não foi possível criar o worktree",
+  "session.newWorktree.error.fetchBranchesFailed": "Não foi possível obter os branches",
   "session.newWorktree.toast.sessionFromIssue": "Sessão criada a partir da issue",
   "session.newWorktree.toast.sessionFromPr": "Sessão criada a partir da PR",
   "session.newWorktree.toast.worktreeCreated": "Worktree criado",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1625,6 +1625,7 @@ export const dict: Record<I18nKey, string> = {
   "session.newWorktree.error.worktreeDirectoryRequired": "Потрібен каталог worktree",
   "session.newWorktree.error.sendGitHubContextFailed": "Не вдалося надіслати контекст GitHub",
   "session.newWorktree.error.createWorktreeFailed": "Не вдалося створити worktree",
+  "session.newWorktree.error.fetchBranchesFailed": "Не вдалося отримати гілки",
   "session.newWorktree.toast.sessionFromIssue": "Сесію створено з issue",
   "session.newWorktree.toast.sessionFromPr": "Сесію створено з PR",
   "session.newWorktree.toast.worktreeCreated": "Створено worktree",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1613,6 +1613,7 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.error.worktreeDirectoryRequired': '工作树目录为必填项',
   'session.newWorktree.error.sendGitHubContextFailed': '发送 GitHub 上下文失败',
   'session.newWorktree.error.createWorktreeFailed': '创建工作树失败',
+  'session.newWorktree.error.fetchBranchesFailed': '拉取分支失败',
   'session.newWorktree.toast.sessionFromIssue': '已从 Issue 创建会话',
   'session.newWorktree.toast.sessionFromPr': '已从 PR 创建会话',
   'session.newWorktree.toast.worktreeCreated': '工作树已创建',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1617,6 +1617,7 @@ export const dict: Record<I18nKey, string> = {
   'session.newWorktree.error.worktreeDirectoryRequired': 'Worktree 目錄是必填項',
   'session.newWorktree.error.sendGitHubContextFailed': '傳送 GitHub 上下文失敗',
   'session.newWorktree.error.createWorktreeFailed': '建立 Worktree 失敗',
+  'session.newWorktree.error.fetchBranchesFailed': 'Fetch 分支失敗',
   'session.newWorktree.toast.sessionFromIssue': '已從 Issue 建立會話',
   'session.newWorktree.toast.sessionFromPr': '已從 PR 建立會話',
   'session.newWorktree.toast.worktreeCreated': 'Worktree 已建立',

--- a/packages/ui/src/stores/useGitStore.test.ts
+++ b/packages/ui/src/stores/useGitStore.test.ts
@@ -250,4 +250,28 @@ describe('useGitStore', () => {
 
     expect(useGitStore.getState().getDirectoryState('/repo')?.status).toBe(initialStatus);
   });
+
+  test('reports branch fetch failure and preserves cached branches', async () => {
+    const previousBranches = { all: ['main'], current: 'main', branches: {} };
+    const directoryState = {
+      ...createDirectoryState(createStatus()),
+      branches: previousBranches,
+    };
+    useGitStore.setState({
+      directories: new Map([['/repo', directoryState]]),
+      activeDirectory: '/repo',
+    });
+    const git = {
+      ...createGitApi(async () => createStatus()),
+      getGitBranches: async () => {
+        throw new Error('remote unavailable');
+      },
+    };
+
+    const result = await useGitStore.getState().fetchBranches('/repo', git);
+
+    expect(result).toBe(false);
+    expect(useGitStore.getState().getDirectoryState('/repo')?.branches).toBe(previousBranches);
+    expect(useGitStore.getState().getDirectoryState('/repo')?.isLoadingBranches).toBe(false);
+  });
 });

--- a/packages/ui/src/stores/useGitStore.ts
+++ b/packages/ui/src/stores/useGitStore.ts
@@ -56,7 +56,7 @@ interface GitStore {
   getDirectoryState: (directory: string) => DirectoryGitState | null;
 
   fetchStatus: (directory: string, git: GitAPI, options?: { silent?: boolean; mode?: 'light' }) => Promise<boolean>;
-  fetchBranches: (directory: string, git: GitAPI) => Promise<void>;
+  fetchBranches: (directory: string, git: GitAPI) => Promise<boolean>;
   fetchLog: (directory: string, git: GitAPI, maxCount?: number) => Promise<void>;
   fetchIdentity: (directory: string, git: GitAPI) => Promise<void>;
   fetchAll: (directory: string, git: GitAPI, options?: { force?: boolean; silentIfCached?: boolean }) => Promise<void>;
@@ -699,12 +699,14 @@ export const useGitStore = create<GitStore>()(
           newDirectories.set(directory, { ...dirState, branches, isLoadingBranches: false, lastBranchesFetch: Date.now() });
           set({ directories: newDirectories });
           writeCachedBranches(directory, branches);
+          return true;
         } catch (error) {
           console.error('Failed to fetch git branches:', error);
           const newDirectories = new Map(get().directories);
           const d = newDirectories.get(directory) ?? createEmptyDirectoryState();
           newDirectories.set(directory, { ...d, isLoadingBranches: false });
           set({ directories: newDirectories });
+          return false;
         }
       },
 
@@ -978,7 +980,7 @@ export const useGitStore = create<GitStore>()(
           const updatedState = get().directories.get(directory);
           if (!updatedState?.isGitRepo) return;
 
-          const fetches: Promise<void>[] = [];
+          const fetches: Promise<unknown>[] = [];
 
           if (!updatedState.branches || now - updatedState.lastBranchesFetch >= BRANCHES_STALE_THRESHOLD) {
             fetches.push(get().fetchBranches(directory, git));

--- a/packages/vscode/src/gitService.test.js
+++ b/packages/vscode/src/gitService.test.js
@@ -1,0 +1,57 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+
+mock.module('vscode', () => ({
+  extensions: { getExtension: () => undefined },
+  Uri: { file: (fsPath) => ({ fsPath }) },
+}));
+
+const { getGitBranches } = await import('./gitService.ts');
+const tempDirs = [];
+
+const createTempDir = () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'openchamber-vscode-git-'));
+  tempDirs.push(directory);
+  return directory;
+};
+
+const runGit = (cwd, args) =>
+  execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+afterEach(() => {
+  for (const directory of tempDirs.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('getGitBranches', () => {
+  it('returns live remote branches that do not have local tracking refs', async () => {
+    const remote = createTempDir();
+    const repo = createTempDir();
+    runGit(remote, ['init', '--bare']);
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'Initial commit']);
+    runGit(repo, ['remote', 'add', 'origin', remote]);
+    runGit(repo, ['push', '-u', 'origin', 'main']);
+
+    const head = runGit(repo, ['rev-parse', 'HEAD']).trim();
+    runGit(remote, ['update-ref', 'refs/heads/remote-only', head]);
+    runGit(repo, ['update-ref', 'refs/remotes/origin/stale', head]);
+
+    const result = await getGitBranches(repo);
+
+    expect(result.all).toContain('remotes/origin/remote-only');
+    expect(result.all).not.toContain('remotes/origin/stale');
+  });
+});

--- a/packages/vscode/src/gitService.test.js
+++ b/packages/vscode/src/gitService.test.js
@@ -54,4 +54,17 @@ describe('getGitBranches', () => {
     expect(result.all).toContain('remotes/origin/remote-only');
     expect(result.all).not.toContain('remotes/origin/stale');
   });
+
+  it('rejects when a remote cannot be reached', async () => {
+    const repo = createTempDir();
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'Initial commit']);
+    runGit(repo, ['remote', 'add', 'broken', path.join(repo, 'missing.git')]);
+
+    await expect(getGitBranches(repo)).rejects.toThrow('Failed to fetch remote branches');
+  });
 });

--- a/packages/vscode/src/gitService.test.js
+++ b/packages/vscode/src/gitService.test.js
@@ -53,6 +53,31 @@ describe('getGitBranches', () => {
 
     expect(result.all).toContain('remotes/origin/remote-only');
     expect(result.all).not.toContain('remotes/origin/stale');
+    expect(result.branches['remotes/origin/remote-only']).toEqual({
+      current: false,
+      name: 'remotes/origin/remote-only',
+      commit: '',
+      label: 'origin/remote-only',
+    });
+  });
+
+  it('returns reachable remote branches when another remote cannot be reached', async () => {
+    const remote = createTempDir();
+    const repo = createTempDir();
+    runGit(remote, ['init', '--bare']);
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'Initial commit']);
+    runGit(repo, ['remote', 'add', 'origin', remote]);
+    runGit(repo, ['push', '-u', 'origin', 'main']);
+    runGit(repo, ['remote', 'add', 'broken', path.join(repo, 'missing.git')]);
+
+    const result = await getGitBranches(repo);
+
+    expect(result.all).toContain('remotes/origin/main');
   });
 
   it('rejects when a remote cannot be reached', async () => {

--- a/packages/vscode/src/gitService.ts
+++ b/packages/vscode/src/gitService.ts
@@ -607,6 +607,33 @@ export interface GitBranchResult {
   branches: Record<string, GitBranchDetails>;
 }
 
+async function getActiveRemoteBranches(directory: string, fallbackBranches: readonly string[]): Promise<string[]> {
+  const remotesResult = await execGit(['remote'], directory);
+  if (remotesResult.exitCode !== 0) {
+    return [...fallbackBranches];
+  }
+
+  const remotes = remotesResult.stdout.split('\n').map((remote) => remote.trim()).filter(Boolean);
+  const branchesByRemote = await Promise.all(remotes.map(async (remote) => {
+    const result = await execGit(['ls-remote', '--heads', remote], directory);
+    if (result.exitCode !== 0) {
+      return [];
+    }
+
+    return result.stdout.split('\n').flatMap((line) => {
+      const marker = '\trefs/heads/';
+      const markerIndex = line.indexOf(marker);
+      if (markerIndex < 0) {
+        return [];
+      }
+      const branchName = line.slice(markerIndex + marker.length);
+      return branchName ? [`remotes/${remote}/${branchName}`] : [];
+    });
+  }));
+
+  return branchesByRemote.flat();
+}
+
 /**
  * Get all branches for a directory
  */
@@ -638,10 +665,11 @@ export async function getGitBranches(directory: string): Promise<GitBranchResult
 
   // Get remote branches
   const remoteRefs = await repo.getBranches({ remote: true });
+  const fallbackRemoteBranches: string[] = [];
   for (const ref of remoteRefs) {
     if (ref.name) {
       const remoteBranchName = `remotes/${ref.name}`;
-      all.push(remoteBranchName);
+      fallbackRemoteBranches.push(remoteBranchName);
       branches[remoteBranchName] = {
         current: false,
         name: remoteBranchName,
@@ -650,6 +678,7 @@ export async function getGitBranches(directory: string): Promise<GitBranchResult
       };
     }
   }
+  all.push(...await getActiveRemoteBranches(directory, fallbackRemoteBranches));
 
   // Add upstream info for HEAD
   if (state.HEAD?.name && state.HEAD?.upstream) {
@@ -668,7 +697,7 @@ export async function getGitBranches(directory: string): Promise<GitBranchResult
  * Fallback: Get branches using raw git commands
  */
 async function getGitBranchesRaw(directory: string): Promise<GitBranchResult> {
-  const result = await execGit(['branch', '-a', '-v', '--format=%(refname:short)|%(objectname:short)|%(upstream:short)|%(HEAD)'], directory);
+  const result = await execGit(['branch', '-a', '-v', '--format=%(refname)|%(objectname:short)|%(upstream:short)|%(HEAD)'], directory);
   
   if (result.exitCode !== 0) {
     return { all: [], current: '', branches: {} };
@@ -677,12 +706,26 @@ async function getGitBranchesRaw(directory: string): Promise<GitBranchResult> {
   const lines = result.stdout.trim().split('\n').filter(Boolean);
   const branches: Record<string, GitBranchDetails> = {};
   const all: string[] = [];
+  const fallbackRemoteBranches: string[] = [];
   let current = '';
 
   for (const line of lines) {
-    const [name, commit, tracking, head] = line.split('|');
+    const [refName, commit, tracking, head] = line.split('|');
+    const localPrefix = 'refs/heads/';
+    const remotePrefix = 'refs/remotes/';
+    let name = '';
+    if (refName?.startsWith(localPrefix)) {
+      name = refName.slice(localPrefix.length);
+    } else if (refName?.startsWith(remotePrefix)) {
+      name = `remotes/${refName.slice(remotePrefix.length)}`;
+    }
     if (name) {
-      all.push(name);
+      const isRemote = name.startsWith('remotes/');
+      if (isRemote) {
+        fallbackRemoteBranches.push(name);
+      } else {
+        all.push(name);
+      }
       const isCurrent = head === '*';
       if (isCurrent) current = name;
       
@@ -695,6 +738,7 @@ async function getGitBranchesRaw(directory: string): Promise<GitBranchResult> {
       };
     }
   }
+  all.push(...await getActiveRemoteBranches(directory, fallbackRemoteBranches));
 
   return { all, current, branches };
 }

--- a/packages/vscode/src/gitService.ts
+++ b/packages/vscode/src/gitService.ts
@@ -617,7 +617,7 @@ async function getActiveRemoteBranches(directory: string): Promise<string[]> {
   const branchesByRemote = await Promise.all(remotes.map(async (remote) => {
     const result = await execGit(['ls-remote', '--heads', remote], directory);
     if (result.exitCode !== 0) {
-      throw new Error('Failed to fetch remote branches');
+      return null;
     }
 
     return result.stdout.split('\n').flatMap((line) => {
@@ -631,7 +631,27 @@ async function getActiveRemoteBranches(directory: string): Promise<string[]> {
     });
   }));
 
-  return branchesByRemote.flat();
+  if (remotes.length > 0 && branchesByRemote.every((branches) => branches === null)) {
+    throw new Error('Failed to fetch remote branches');
+  }
+
+  return branchesByRemote.flatMap((branches) => branches ?? []);
+}
+
+function appendActiveRemoteBranches(
+  all: string[],
+  branches: Record<string, GitBranchDetails>,
+  activeRemoteBranches: readonly string[],
+): void {
+  for (const branchName of activeRemoteBranches) {
+    all.push(branchName);
+    branches[branchName] ??= {
+      current: false,
+      name: branchName,
+      commit: '',
+      label: branchName.replace(/^remotes\//, ''),
+    };
+  }
 }
 
 /**
@@ -676,7 +696,7 @@ export async function getGitBranches(directory: string): Promise<GitBranchResult
       };
     }
   }
-  all.push(...await getActiveRemoteBranches(directory));
+  appendActiveRemoteBranches(all, branches, await getActiveRemoteBranches(directory));
 
   // Add upstream info for HEAD
   if (state.HEAD?.name && state.HEAD?.upstream) {
@@ -733,7 +753,7 @@ async function getGitBranchesRaw(directory: string): Promise<GitBranchResult> {
       };
     }
   }
-  all.push(...await getActiveRemoteBranches(directory));
+  appendActiveRemoteBranches(all, branches, await getActiveRemoteBranches(directory));
 
   return { all, current, branches };
 }

--- a/packages/vscode/src/gitService.ts
+++ b/packages/vscode/src/gitService.ts
@@ -607,17 +607,17 @@ export interface GitBranchResult {
   branches: Record<string, GitBranchDetails>;
 }
 
-async function getActiveRemoteBranches(directory: string, fallbackBranches: readonly string[]): Promise<string[]> {
+async function getActiveRemoteBranches(directory: string): Promise<string[]> {
   const remotesResult = await execGit(['remote'], directory);
   if (remotesResult.exitCode !== 0) {
-    return [...fallbackBranches];
+    throw new Error('Failed to fetch remote branches');
   }
 
   const remotes = remotesResult.stdout.split('\n').map((remote) => remote.trim()).filter(Boolean);
   const branchesByRemote = await Promise.all(remotes.map(async (remote) => {
     const result = await execGit(['ls-remote', '--heads', remote], directory);
     if (result.exitCode !== 0) {
-      return [];
+      throw new Error('Failed to fetch remote branches');
     }
 
     return result.stdout.split('\n').flatMap((line) => {
@@ -665,11 +665,9 @@ export async function getGitBranches(directory: string): Promise<GitBranchResult
 
   // Get remote branches
   const remoteRefs = await repo.getBranches({ remote: true });
-  const fallbackRemoteBranches: string[] = [];
   for (const ref of remoteRefs) {
     if (ref.name) {
       const remoteBranchName = `remotes/${ref.name}`;
-      fallbackRemoteBranches.push(remoteBranchName);
       branches[remoteBranchName] = {
         current: false,
         name: remoteBranchName,
@@ -678,7 +676,7 @@ export async function getGitBranches(directory: string): Promise<GitBranchResult
       };
     }
   }
-  all.push(...await getActiveRemoteBranches(directory, fallbackRemoteBranches));
+  all.push(...await getActiveRemoteBranches(directory));
 
   // Add upstream info for HEAD
   if (state.HEAD?.name && state.HEAD?.upstream) {
@@ -706,7 +704,6 @@ async function getGitBranchesRaw(directory: string): Promise<GitBranchResult> {
   const lines = result.stdout.trim().split('\n').filter(Boolean);
   const branches: Record<string, GitBranchDetails> = {};
   const all: string[] = [];
-  const fallbackRemoteBranches: string[] = [];
   let current = '';
 
   for (const line of lines) {
@@ -721,9 +718,7 @@ async function getGitBranchesRaw(directory: string): Promise<GitBranchResult> {
     }
     if (name) {
       const isRemote = name.startsWith('remotes/');
-      if (isRemote) {
-        fallbackRemoteBranches.push(name);
-      } else {
+      if (!isRemote) {
         all.push(name);
       }
       const isCurrent = head === '*';
@@ -738,7 +733,7 @@ async function getGitBranchesRaw(directory: string): Promise<GitBranchResult> {
       };
     }
   }
-  all.push(...await getActiveRemoteBranches(directory, fallbackRemoteBranches));
+  all.push(...await getActiveRemoteBranches(directory));
 
   return { all, current, branches };
 }

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -3233,13 +3233,11 @@ async function filterActiveRemoteBranches(git, remoteBranches) {
       }
     }));
 
-    return remoteBranches.filter(remoteBranch => {
-      const match = remoteBranch.match(/^remotes\/[^\/]+\/(.+)$/);
-      if (!match) return false;
-      const remoteName = remoteBranch.split('/')[1];
-      const branchName = match[1];
-      return branchesByRemote.get(remoteName)?.has(branchName) ?? false;
-    });
+    return remotes.flatMap((remote) =>
+      Array.from(branchesByRemote.get(remote.name) || [], (branchName) =>
+        `remotes/${remote.name}/${branchName}`
+      )
+    );
   } catch (error) {
     console.warn('Failed to filter active remote branches, returning all:', error.message);
     return remoteBranches;

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -3193,6 +3193,16 @@ export async function getBranches(directory) {
 
     const allBranches = result.all;
     const activeRemoteBranches = await filterActiveRemoteBranches(git);
+    const branches = { ...result.branches };
+
+    for (const branchName of activeRemoteBranches) {
+      branches[branchName] ??= {
+        current: false,
+        name: branchName,
+        commit: '',
+        label: branchName.replace(/^remotes\//, ''),
+      };
+    }
 
     const filteredAll = [
       ...allBranches.filter(branch => !branch.startsWith('remotes/')),
@@ -3202,7 +3212,7 @@ export async function getBranches(directory) {
     return {
       all: filteredAll,
       current: result.current,
-      branches: result.branches
+      branches
     };
   } catch (error) {
     console.error('Failed to get branches:', error);
@@ -3212,31 +3222,26 @@ export async function getBranches(directory) {
 
 async function filterActiveRemoteBranches(git) {
   const remotes = await git.getRemotes();
-  const branchesByRemote = new Map();
-
-  await Promise.all(remotes.map(async (remote) => {
-    let lsRemoteResult;
+  const branchesByRemote = await Promise.all(remotes.map(async (remote) => {
     try {
-      lsRemoteResult = await git.raw(['ls-remote', '--heads', remote.name]);
-    } catch {
-      throw new Error('Failed to fetch remote branches');
-    }
-    const actualRemoteBranches = new Set();
-    const lines = lsRemoteResult.trim().split('\n');
-    for (const line of lines) {
-      if (line.includes('\trefs/heads/')) {
+      const lsRemoteResult = await git.raw(['ls-remote', '--heads', remote.name]);
+      return lsRemoteResult.trim().split('\n').flatMap((line) => {
+        if (!line.includes('\trefs/heads/')) {
+          return [];
+        }
         const branchName = line.split('\t')[1].replace('refs/heads/', '');
-        actualRemoteBranches.add(branchName);
-      }
+        return [`remotes/${remote.name}/${branchName}`];
+      });
+    } catch {
+      return null;
     }
-    branchesByRemote.set(remote.name, actualRemoteBranches);
   }));
 
-  return remotes.flatMap((remote) =>
-    Array.from(branchesByRemote.get(remote.name) || [], (branchName) =>
-      `remotes/${remote.name}/${branchName}`
-    )
-  );
+  if (remotes.length > 0 && branchesByRemote.every((branches) => branches === null)) {
+    throw new Error('Failed to fetch remote branches');
+  }
+
+  return branchesByRemote.flatMap((branches) => branches ?? []);
 }
 
 export async function createBranch(directory, branchName, options = {}) {

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -3192,8 +3192,7 @@ export async function getBranches(directory) {
     const result = await git.branch();
 
     const allBranches = result.all;
-    const remoteBranches = allBranches.filter(branch => branch.startsWith('remotes/'));
-    const activeRemoteBranches = await filterActiveRemoteBranches(git, remoteBranches);
+    const activeRemoteBranches = await filterActiveRemoteBranches(git);
 
     const filteredAll = [
       ...allBranches.filter(branch => !branch.startsWith('remotes/')),
@@ -3211,37 +3210,33 @@ export async function getBranches(directory) {
   }
 }
 
-async function filterActiveRemoteBranches(git, remoteBranches) {
-  try {
-    const remotes = await git.getRemotes();
-    const branchesByRemote = new Map();
+async function filterActiveRemoteBranches(git) {
+  const remotes = await git.getRemotes();
+  const branchesByRemote = new Map();
 
-    await Promise.all(remotes.map(async (remote) => {
-      try {
-        const lsRemoteResult = await git.raw(['ls-remote', '--heads', remote.name]);
-        const actualRemoteBranches = new Set();
-        const lines = lsRemoteResult.trim().split('\n');
-        for (const line of lines) {
-          if (line.includes('\trefs/heads/')) {
-            const branchName = line.split('\t')[1].replace('refs/heads/', '');
-            actualRemoteBranches.add(branchName);
-          }
-        }
-        branchesByRemote.set(remote.name, actualRemoteBranches);
-      } catch {
-        // Skip remotes that fail (e.g., unreachable)
+  await Promise.all(remotes.map(async (remote) => {
+    let lsRemoteResult;
+    try {
+      lsRemoteResult = await git.raw(['ls-remote', '--heads', remote.name]);
+    } catch {
+      throw new Error('Failed to fetch remote branches');
+    }
+    const actualRemoteBranches = new Set();
+    const lines = lsRemoteResult.trim().split('\n');
+    for (const line of lines) {
+      if (line.includes('\trefs/heads/')) {
+        const branchName = line.split('\t')[1].replace('refs/heads/', '');
+        actualRemoteBranches.add(branchName);
       }
-    }));
+    }
+    branchesByRemote.set(remote.name, actualRemoteBranches);
+  }));
 
-    return remotes.flatMap((remote) =>
-      Array.from(branchesByRemote.get(remote.name) || [], (branchName) =>
-        `remotes/${remote.name}/${branchName}`
-      )
-    );
-  } catch (error) {
-    console.warn('Failed to filter active remote branches, returning all:', error.message);
-    return remoteBranches;
-  }
+  return remotes.flatMap((remote) =>
+    Array.from(branchesByRemote.get(remote.name) || [], (branchName) =>
+      `remotes/${remote.name}/${branchName}`
+    )
+  );
 }
 
 export async function createBranch(directory, branchName, options = {}) {

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -307,6 +307,33 @@ describe('getBranches', () => {
 
     expect(result.all).toContain('remotes/origin/remote-only');
     expect(result.all).not.toContain('remotes/origin/stale');
+    expect(result.branches['remotes/origin/remote-only']).toEqual({
+      current: false,
+      name: 'remotes/origin/remote-only',
+      commit: '',
+      label: 'origin/remote-only',
+    });
+  });
+
+  it('returns reachable remote branches when another remote cannot be reached', async () => {
+    if (!canRunGit()) return;
+
+    const remote = createTempDir();
+    const repo = createTempDir();
+    runGit(remote, ['init', '--bare']);
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'Initial commit']);
+    runGit(repo, ['remote', 'add', 'origin', remote]);
+    runGit(repo, ['push', '-u', 'origin', 'main']);
+    runGit(repo, ['remote', 'add', 'broken', path.join(repo, 'missing.git')]);
+
+    const result = await getBranches(repo);
+
+    expect(result.all).toContain('remotes/origin/main');
   });
 
   it('rejects when a remote cannot be reached', async () => {

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -9,6 +9,7 @@ import {
   checkoutCommit,
   cherryPick,
   createWorktree,
+  getBranches,
   getStatus,
   removeWorktree,
   resolvePrimaryWorktreeRoot,
@@ -279,6 +280,33 @@ describe('getStatus', () => {
     runGit(repo, ['commit', '-m', 'Initial commit']);
 
     await expect(getStatus(repo)).resolves.toMatchObject({ current: 'main' });
+  });
+});
+
+describe('getBranches', () => {
+  it('returns live remote branches that do not have local tracking refs', async () => {
+    if (!canRunGit()) return;
+
+    const remote = createTempDir();
+    const repo = createTempDir();
+    runGit(remote, ['init', '--bare']);
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'Initial commit']);
+    runGit(repo, ['remote', 'add', 'origin', remote]);
+    runGit(repo, ['push', '-u', 'origin', 'main']);
+
+    const head = runGit(repo, ['rev-parse', 'HEAD']).trim();
+    runGit(remote, ['update-ref', 'refs/heads/remote-only', head]);
+    runGit(repo, ['update-ref', 'refs/remotes/origin/stale', head]);
+
+    const result = await getBranches(repo);
+
+    expect(result.all).toContain('remotes/origin/remote-only');
+    expect(result.all).not.toContain('remotes/origin/stale');
   });
 });
 

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -308,6 +308,21 @@ describe('getBranches', () => {
     expect(result.all).toContain('remotes/origin/remote-only');
     expect(result.all).not.toContain('remotes/origin/stale');
   });
+
+  it('rejects when a remote cannot be reached', async () => {
+    if (!canRunGit()) return;
+
+    const repo = createTempDir();
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'Initial commit']);
+    runGit(repo, ['remote', 'add', 'broken', path.join(repo, 'missing.git')]);
+
+    await expect(getBranches(repo)).rejects.toThrow('Failed to fetch remote branches');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- include live remote heads even when no local tracking ref exists
- keep web, desktop, and VS Code branch discovery behavior aligned
- preserve cached branches and show localized refresh feedback when remotes are unreachable
- avoid exposing raw Git diagnostics to clients

## Validation
- `bun run type-check`
- `bun run lint`
- `bun run --cwd packages/web test -- server/lib/git/service.test.js` (46 passed)
- `bun test packages/vscode/src/gitService.test.js` (2 passed)
- `bun test packages/ui/src/stores/useGitStore.test.ts` (13 passed)
- Playwright refresh failure QA at 375px, 768px, and 1280px

Fixes #2098