### PR TITLE
fix(small-model): include no-auth providers in override picker

### DIFF
--- a/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
@@ -235,9 +235,20 @@ export const DefaultsSettings: React.FC = () => {
       try {
         const response = await runtimeFetch('/api/small-model', { method: 'GET', headers: { Accept: 'application/json' } });
         if (!response.ok) return;
-        const payload = await response.json().catch(() => null) as { authenticatedProviders?: unknown } | null;
-        if (!cancelled && Array.isArray(payload?.authenticatedProviders)) {
-          setSmallModelProviders(payload.authenticatedProviders.filter((id): id is string => typeof id === 'string'));
+        const payload = await response.json().catch(() => null) as { availableProviders?: unknown; authenticatedProviders?: unknown } | null;
+        if (cancelled) return;
+        // Prefer the union (auth + no-auth providers like OpenCode zen) so the
+        // picker shows zen/free models as well as authenticated ones. Fall back
+        // to authenticatedProviders for older servers that don't ship the
+        // union, and finally to undefined (picker shows everything).
+        let raw: unknown = null;
+        if (Array.isArray(payload?.availableProviders)) {
+          raw = payload.availableProviders;
+        } else if (Array.isArray(payload?.authenticatedProviders)) {
+          raw = payload.authenticatedProviders;
+        }
+        if (raw) {
+          setSmallModelProviders((raw as unknown[]).filter((id): id is string => typeof id === 'string'));
         }
       } catch {
         // leave undefined — picker falls back to showing all providers

--- a/packages/web/server/lib/small-model/DOCUMENTATION.md
+++ b/packages/web/server/lib/small-model/DOCUMENTATION.md
@@ -51,9 +51,17 @@ other runtime API.
 - `catalog.js` — models.dev catalog via the shared in-process cache
   (`../opencode/models-metadata.js`, also serving
   `/api/openchamber/models-metadata`).
-- `routes.js` — `GET /api/small-model` (resolution preview) and
-  `POST /api/small-model/generate` (`{ prompt, system?, maxOutputTokens?,
+- `routes.js` — `GET /api/small-model` (resolution preview, returns
+  `{ available, model, authenticatedProviders, noAuthProviders, availableProviders }`)
+  and `POST /api/small-model/generate` (`{ prompt, system?, maxOutputTokens?,
   model?, directory? }` → `{ text, providerID, modelID, source }`).
+  `availableProviders` is the deduplicated union of `authenticatedProviders`
+  plus the no-auth providers — what the settings override picker uses as
+  `allowedProviderIds`. `noAuthProviders` lists providers that ship without
+  requiring an auth entry (currently just `opencode` — see "Known
+  limitations" below); callers can use it to render a distinction in the
+  picker (e.g. an "OpenCode zen" badge). `authenticatedProviders` is the
+  strict "callable directly" set, kept for callers that want it.
 
 ## Registration
 
@@ -62,12 +70,20 @@ module is imported on first request, not at server startup.
 
 ## Known limitations
 
-- OpenCode's free models (`opencode/big-pickle`, `*-free`) work without a
-  token only through OpenCode's own server — direct calls are rejected, and
-  piggybacking on their subsidized infra is out of bounds by design. Every
-  resolution step therefore requires a usable auth entry for the provider:
-  a session on an unauthenticated `opencode` provider falls through to the
-  global scan (or a clean 404 on a vanilla setup with no logins).
+- OpenCode's free / zen models (`opencode/big-pickle`, `*-free`) work without
+  a token only through OpenCode's own server — direct calls from this module
+  are rejected, and piggybacking on their subsidized infra is out of bounds
+  by design. The settings override picker, however, is allowed to surface
+  them: `listNoAuthProviders()` exposes the `opencode` provider id on its
+  own, and `listSelectableProviders()` unions it with the authenticated
+  providers — `GET /api/small-model` surfaces those as `noAuthProviders`
+  and `availableProviders` respectively (see `NO_AUTH_PROVIDER_IDS` in
+  `index.js`). A user-selected `opencode/<model>` is honored at the
+  `source: 'settings'` step in `resolveSmallModel()` (which never checks
+  auth). The family-priority scan and the direct `POST /api/small-model/generate`
+  path still require a usable auth entry — picking a zen override is a
+  per-session preference, not a fallback the resolver can use on a vanilla
+  setup with no logins (it returns `null` there, same as before).
 
 - Anthropic OAuth (Claude Pro/Max) entries are not supported — OpenCode itself
   keeps those outside `auth.json` in this generation; only `type: api` keys

--- a/packages/web/server/lib/small-model/index.js
+++ b/packages/web/server/lib/small-model/index.js
@@ -130,7 +130,9 @@ export async function generateSmallModelText({ prompt, system, maxOutputTokens, 
 /**
  * Provider ids with a usable OpenCode login — the set the small model can
  * actually call. Used by the settings override picker to hide providers that
- * would only ever fail (e.g. opencode free models without a token).
+ * would only ever fail. Providers that ship without auth (see
+ * `NO_AUTH_PROVIDER_IDS`) are tracked separately and exposed via
+ * `listNoAuthProviders` / `listSelectableProviders`.
  */
 export function listAuthenticatedProviders() {
   try {
@@ -147,6 +149,42 @@ export function listAuthenticatedProviders() {
   } catch {
     return [];
   }
+}
+
+// OpenCode providers that ship without requiring an auth entry. The `opencode`
+// provider (zen / `big-pickle`, `*-free` models) is served by OpenCode's own
+// infra and works without a token, so the settings override picker can offer
+// it without an auth.json entry. Keep this list narrow: paid providers that
+// just happen to lack a key on this machine are NOT no-auth — they are
+// authenticated providers with a missing credential, which is a different
+// state we must not silently elide.
+const NO_AUTH_PROVIDER_IDS = ['opencode'];
+
+/**
+ * Provider ids that work without any auth entry. Exposed as a sibling to
+ * `listAuthenticatedProviders` so callers can distinguish "no auth needed"
+ * from "no usable credential".
+ */
+export function listNoAuthProviders() {
+  return [...NO_AUTH_PROVIDER_IDS];
+}
+
+/**
+ * Deduplicated union of authenticated providers and no-auth providers —
+ * the set of provider ids the small-model override picker can offer to the
+ * user. A user-selected `opencode/<model>` is honored by the resolver at the
+ * `source: 'settings'` step (which never checks auth) but cannot be used as
+ * a fallback when no explicit override is set. Returned as
+ * `availableProviders` by `GET /api/small-model`; the no-auth subset is
+ * surfaced separately as `noAuthProviders` so callers can render the picker
+ * with distinction.
+ */
+export function listSelectableProviders() {
+  const ids = new Set([
+    ...listNoAuthProviders(),
+    ...listAuthenticatedProviders(),
+  ]);
+  return Array.from(ids);
 }
 
 /**

--- a/packages/web/server/lib/small-model/routes.js
+++ b/packages/web/server/lib/small-model/routes.js
@@ -1,7 +1,12 @@
 export function registerSmallModelRoutes(app, { getSmallModelService }) {
   app.get('/api/small-model', async (req, res) => {
     try {
-      const { describeSmallModel, listAuthenticatedProviders } = await getSmallModelService();
+      const {
+        describeSmallModel,
+        listAuthenticatedProviders,
+        listNoAuthProviders,
+        listSelectableProviders,
+      } = await getSmallModelService();
       const resolved = await describeSmallModel({
         directory: typeof req.query.directory === 'string' ? req.query.directory : undefined,
         preferredProviderID: typeof req.query.providerID === 'string' ? req.query.providerID : undefined,
@@ -11,6 +16,8 @@ export function registerSmallModelRoutes(app, { getSmallModelService }) {
         available: Boolean(resolved),
         model: resolved,
         authenticatedProviders: listAuthenticatedProviders(),
+        noAuthProviders: listNoAuthProviders(),
+        availableProviders: listSelectableProviders(),
       });
     } catch (error) {
       console.error('Failed to resolve small model:', error);

--- a/packages/web/server/lib/small-model/routes.test.js
+++ b/packages/web/server/lib/small-model/routes.test.js
@@ -1,0 +1,88 @@
+/**
+ * Regression for issue #2132: GET /api/small-model now surfaces
+ * `availableProviders` (the union of authenticated + no-auth providers) and
+ * `noAuthProviders` (the no-auth subset) so the settings override picker can
+ * offer OpenCode zen/free models alongside the authenticated ones.
+ */
+import { describe, it, expect, mock } from 'bun:test';
+
+const serviceStub = {
+  describeSmallModel: async () => ({ providerID: 'google', modelID: 'gemini-2.5-flash', source: 'family-scan' }),
+  listAuthenticatedProviders: () => ['google'],
+  listNoAuthProviders: () => ['opencode'],
+  listSelectableProviders: () => ['opencode', 'google'],
+};
+
+mock.module('./index.js', () => serviceStub);
+
+const { registerSmallModelRoutes } = await import('./routes.js');
+
+const createRouteRegistry = () => {
+  const routes = new Map();
+  return {
+    app: {
+      get(routePath, handler) {
+        routes.set(`GET ${routePath}`, handler);
+      },
+      post(routePath, handler) {
+        routes.set(`POST ${routePath}`, handler);
+      },
+    },
+    getRoute(method, routePath) {
+      return routes.get(`${method} ${routePath}`);
+    },
+  };
+};
+
+const createMockResponse = () => {
+  let statusCode = 200;
+  let body = null;
+  return {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(payload) {
+      body = payload;
+      return this;
+    },
+    get statusCode() {
+      return statusCode;
+    },
+    get body() {
+      return body;
+    },
+  };
+};
+
+describe('registerSmallModelRoutes', () => {
+  it('GET /api/small-model includes availableProviders and noAuthProviders in the payload', async () => {
+    const { app, getRoute } = createRouteRegistry();
+    registerSmallModelRoutes(app, { getSmallModelService: async () => serviceStub });
+
+    const handler = getRoute('GET', '/api/small-model');
+    expect(handler).toBeDefined();
+
+    const req = { query: {} };
+    const res = createMockResponse();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body.availableProviders)).toBe(true);
+    expect(res.body.availableProviders).toContain('opencode');
+    expect(res.body.availableProviders).toContain('google');
+    expect(res.body.noAuthProviders).toEqual(['opencode']);
+  });
+
+  it('GET /api/small-model keeps authenticatedProviders for backwards compatibility', async () => {
+    const { app, getRoute } = createRouteRegistry();
+    registerSmallModelRoutes(app, { getSmallModelService: async () => serviceStub });
+
+    const handler = getRoute('GET', '/api/small-model');
+    const req = { query: {} };
+    const res = createMockResponse();
+    await handler(req, res);
+
+    expect(res.body.authenticatedProviders).toEqual(['google']);
+  });
+});

--- a/packages/web/server/lib/small-model/selectable-providers.test.js
+++ b/packages/web/server/lib/small-model/selectable-providers.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { listAuthenticatedProviders, listNoAuthProviders, listSelectableProviders } from './index.js';
+
+// The auth read happens at import time in some paths and lazily in others.
+// We mock the auth module to make the tests deterministic regardless of the
+// host's real auth.json contents.
+const authState = { current: {} };
+
+mock.module('../opencode/auth.js', () => ({
+  readAuthFile: () => authState.current,
+  writeAuthFile: () => {},
+}));
+
+const reloadIndex = async () => {
+  // Bust the module cache so the new auth state is picked up on next call.
+  // Bun's module cache keys by resolved path; re-importing the index file
+  // re-runs its top-level imports, which in turn re-evaluates the mocked
+  // auth module above.
+  return import(`./index.js?case=${Math.random()}`);
+};
+
+beforeEach(() => {
+  authState.current = {};
+});
+
+describe('listNoAuthProviders', () => {
+  it('always includes the opencode provider', async () => {
+    const { listNoAuthProviders } = await reloadIndex();
+    expect(listNoAuthProviders()).toContain('opencode');
+  });
+
+  it('does not depend on auth.json state', async () => {
+    authState.current = {
+      anthropic: { type: 'api', key: 'sk-x' },
+    };
+    const { listNoAuthProviders } = await reloadIndex();
+    expect(listNoAuthProviders()).toEqual(['opencode']);
+  });
+});
+
+describe('listSelectableProviders', () => {
+  it('returns only the no-auth providers when nothing is authenticated', async () => {
+    authState.current = {};
+    const { listSelectableProviders } = await reloadIndex();
+    expect(listSelectableProviders()).toEqual(['opencode']);
+  });
+
+  it('returns the union of authed + no-auth providers', async () => {
+    authState.current = {
+      anthropic: { type: 'api', key: 'sk-x' },
+    };
+    const { listSelectableProviders } = await reloadIndex();
+    const list = listSelectableProviders();
+    expect(list).toContain('opencode');
+    expect(list).toContain('anthropic');
+    expect(list.length).toBe(2);
+  });
+
+  it('deduplicates when an auth entry shadows a no-auth id', async () => {
+    authState.current = {
+      opencode: { type: 'api', key: 'oc-key' },
+    };
+    const { listSelectableProviders } = await reloadIndex();
+    const list = listSelectableProviders();
+    expect(list.filter((id) => id === 'opencode').length).toBe(1);
+  });
+
+  it('omits providers with unusable auth entries', async () => {
+    authState.current = {
+      anthropic: { type: 'api', key: '' },
+      openai: { type: 'oauth' },
+    };
+    const { listSelectableProviders } = await reloadIndex();
+    const list = listSelectableProviders();
+    expect(list).toContain('opencode');
+    expect(list).not.toContain('anthropic');
+    expect(list).not.toContain('openai');
+  });
+});
+
+describe('listAuthenticatedProviders', () => {
+  it('still excludes the no-auth opencode provider when no auth entry is present', async () => {
+    // The contract: this function remains strict — only usable auth entries
+    // are returned. The no-auth "opencode" provider is intentionally
+    // excluded here; the picker uses listSelectableProviders to get the union.
+    authState.current = {
+      anthropic: { type: 'api', key: 'sk-x' },
+    };
+    const { listAuthenticatedProviders } = await reloadIndex();
+    const list = listAuthenticatedProviders();
+    expect(list).toContain('anthropic');
+    expect(list).not.toContain('opencode');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes openchamber/openchamber#2132 — the small-model override picker (Settings → Sessions → Small Model) hid OpenCode's free / zen models because it was filtered by `GET /api/small-model -> authenticatedProviders`, which only includes providers with a usable `auth.json` entry. The `opencode` provider (zen / `big-pickle`, `*-free` models served by OpenCode's own infra) ships without an auth entry, so it was excluded. The resolver's `source: 'settings'` step in `resolveSmallModel()` already honors any `provider/model` ref without checking auth, so the UI was the only thing blocking selection.

This PR widens the picker's filter to include no-auth providers while keeping the strict "callable directly" set available for callers that want it.

## What changes

- **`packages/web/server/lib/small-model/index.js`** — new `NO_AUTH_PROVIDER_IDS = ['opencode']` constant (with rationale comment), new exported `listNoAuthProviders()` and `listSelectableProviders()` (deduplicated union), updated `listAuthenticatedProviders()` jsdoc to clarify the no-auth split. `listAuthenticatedProviders()` behavior is unchanged (still strict, only usable auth entries).
- **`packages/web/server/lib/small-model/routes.js`** — `GET /api/small-model` now returns three fields: the existing `authenticatedProviders` (back-compat) plus `noAuthProviders` and `availableProviders` (the union). Same response shape; just two additional fields.
- **`packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx`** — picker now reads `availableProviders` first, falls back to `authenticatedProviders` for older servers, and to `undefined` (show all providers) when neither is present. Refactored from a nested ternary to an explicit `if / else if` chain (project `AGENTS.md` rule).
- **`packages/web/server/lib/small-model/DOCUMENTATION.md`** — documents the new response shape and the per-session override vs. fallback semantics. The "Known limitations" paragraph now states that the picker surfaces free / zen models, the `source: 'settings'` step honors them, while the family-priority scan and direct `POST /api/small-model/generate` still require a usable auth entry.

## Behavioral contract

- **Natural user action**: open Settings → Sessions → Small Model, uncheck "Use default", pick a model from the opencode provider.
- **Value provider**: the server (`listNoAuthProviders` returns the static `['opencode']` set; `listAuthenticatedProviders` reads `auth.json`).
- **What it changes for callers**: the `GET /api/small-model` response gains two fields. `authenticatedProviders` semantics are unchanged. The `opencode` provider id is now reachable as an override; it is *not* a new fallback the resolver can use on a vanilla setup (the resolver still returns `null` there).
- **What it does not change**: `listAuthenticatedProviders`, the resolver's family-priority scan, the direct call path, the `auth.json` format, or any other picker in the app.

## Tests

Two new test files, plus all existing small-model tests pass:

- **`packages/web/server/lib/small-model/selectable-providers.test.js`** *(new, 7 cases)* — covers `listNoAuthProviders`, `listSelectableProviders` (with / without auth entries, deduplication, unusable auth filtering), and the unchanged `listAuthenticatedProviders` contract. Host-independent via `mock.module` so it works on any machine regardless of the local `auth.json` state.
- **`packages/web/server/lib/small-model/routes.test.js`** *(new, 2 cases)* — asserts the route payload includes `availableProviders` (with the union) and `noAuthProviders` (with the no-auth set), and that `authenticatedProviders` is still present for back-compat.
- **Existing tests** (`resolve.test.js`) still pass.

## Validation

```bash
$ bun test packages/web/server/lib/small-model/
 26 pass
 0 fail
 44 expect() calls
Ran 26 tests across 3 files. [330.00ms]

$ bun run type-check:web # clean
$ bun run lint:web       # clean
```

Also ran `ocr review` (open-code-review) on the working copy: 0 issues after the nested-ternary refactor.

## Acceptance criteria

- **Must** — Zen provider models appear in the Small Model override picker: **satisfied** via `availableProviders` consumed by `ModelSelector`'s `allowedProviderIds`.
- **Must** — Selecting a zen model as the small model override is persisted and honored by the resolver: **satisfied** (resolver's `source: 'settings'` step never checks auth; was already working, the picker was the only blocker).
- **Should** — `GET /api/small-model` distinguishes "no auth needed" providers (zen) from providers that genuinely require credentials, so the picker can include zen without surfacing unauthenticated paid providers: **satisfied** via the new `noAuthProviders` field alongside `authenticatedProviders` and the union as `availableProviders`.
- **Should** — Documentation updated to note that zen models are selectable as a small model override even though they are not callable via the direct small-model path: **satisfied** in `packages/web/server/lib/small-model/DOCUMENTATION.md`.

## Right-level

The fix is at the shared contract boundary (server route + UI consumer), not at the resolver. The constant `NO_AUTH_PROVIDER_IDS` lives in one place (`index.js`); the route reads it via `listNoAuthProviders()`; the UI consumes the union via `availableProviders`. No duplication, no leak.

## Trade-off

`NO_AUTH_PROVIDER_IDS` is a hardcoded constant — currently just `['opencode']`. If OpenCode ships a second no-auth provider in the future, this is a one-line update. The alternative (runtime probe of `config.providers` against `auth.json`) would have ambiguous semantics for paid providers with missing keys, and is rejected as fragile. A narrow constant with a strong rationale comment is the correct small fix.

## Out of scope

- The resolver's family-priority scan still skips providers without usable auth. This is intentional: those providers cannot be called directly by `callSmallModel`, so they cannot be a fallback. Picking a zen override is a per-session preference, not a fallback.
- The `callSmallModel` path itself was not changed. The fix is purely at the picker boundary.

## Notes

- Marked as **draft** because this is a focused bugfix ready for review; happy to mark ready once review feedback is addressed.

