### PR TITLE
fix(chat): action buttons hidden under next turn sticky header

### DIFF
--- a/packages/ui/src/components/chat/components/TurnAssistantBlock.tsx
+++ b/packages/ui/src/components/chat/components/TurnAssistantBlock.tsx
@@ -9,7 +9,7 @@ interface TurnAssistantBlockProps {
 
 const TurnAssistantBlock: React.FC<TurnAssistantBlockProps> = ({ assistantMessages, renderMessage }) => {
     return (
-        <div className="relative z-0">
+        <div className="relative">
             {assistantMessages.map((message) => renderMessage(message))}
         </div>
     );

--- a/packages/ui/src/components/chat/components/TurnItem.tsx
+++ b/packages/ui/src/components/chat/components/TurnItem.tsx
@@ -18,7 +18,7 @@ const TurnItem: React.FC<TurnItemProps> = ({ turn, stickyUserHeader = true, rend
             data-scroll-spy-id={turn.turnId}
         >
             {stickyUserHeader ? (
-                <div className="sticky top-0 z-20 relative bg-[var(--surface-background)] [overflow-anchor:none]">
+                <div className="sticky top-0 z-20 bg-[var(--surface-background)] [overflow-anchor:none]">
                     <div className="relative z-10">
                         {renderMessage(turn.userMessage)}
                     </div>

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -1740,7 +1740,7 @@ const AssistantMessageBody = React.memo(({
                 );
                 if (shouldShowStandaloneMessageActions && i === lastRenderableTextPartIndex) {
                     rendered.push(
-                        <div key={`message-actions-${messageId}`} className={INLINE_MESSAGE_ACTIONS_CLASS_NAME} data-message-actions="true">
+                        <div key={`message-actions-${messageId}`} className={cn(INLINE_MESSAGE_ACTIONS_CLASS_NAME, 'relative z-30')} data-message-actions="true">
                             <div className="flex items-center gap-1.5" data-message-action-group="true">
                                 {messageActionButtons}
                             </div>
@@ -2061,7 +2061,7 @@ const AssistantMessageBody = React.memo(({
                 </div>
                 <MessageFilesDisplay files={parts} onShowPopup={onShowPopup} />
                 {shouldRenderStandaloneActionsAfterContent && (
-                    <div className={INLINE_MESSAGE_ACTIONS_CLASS_NAME} data-message-actions="true">
+                    <div className={cn(INLINE_MESSAGE_ACTIONS_CLASS_NAME, 'relative z-30')} data-message-actions="true">
                         <div className="flex items-center gap-1.5" data-message-action-group="true">
                             {messageActionButtons}
                         </div>
@@ -2069,7 +2069,7 @@ const AssistantMessageBody = React.memo(({
                 )}
                 {shouldShowTurnFooter && (
                     <div
-                        className="mt-2 mb-1 flex flex-wrap items-center justify-start gap-1.5"
+                        className="mt-2 mb-1 flex flex-wrap items-center justify-start gap-1.5 relative z-30"
                         style={MESSAGE_FOOTER_CONTAINER_STYLE}
                     >
                         <div className="flex items-center gap-1.5" data-message-action-group="true">

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -55,7 +55,18 @@ import {
 } from '@/lib/reviewFlow';
 
 
-const CONTAIN_LAYOUT_STYLE = { contain: 'layout' as const, transform: 'translateZ(0)' };
+// Keep transform: translateZ(0) on the user wrapper: it gives the message body
+// its own GPU compositing layer and confines the trapped z-10 action menus
+// (UserTextPart.tsx, MessageBody.tsx action row) inside a self-contained
+// stacking context where they don't need to escape.
+const USER_CONTAIN_LAYOUT_STYLE = { contain: 'layout' as const, transform: 'translateZ(0)' };
+
+// The assistant wrapper must NOT create a stacking context: the action button
+// containers inside it (relative z-30) need to compete with the next turn's
+// sticky user header (z-20) in the shared parent stacking context. Adding
+// `transform: translateZ(0)` here would trap z-30 inside this wrapper and the
+// buttons would be covered by the sticky header again.
+const ASSISTANT_CONTAIN_LAYOUT_STYLE = { contain: 'layout' as const };
 const MESSAGE_FOOTER_CONTAINER_STYLE = { containerType: 'inline-size' as const, containerName: 'message-footer' };
 const INLINE_MESSAGE_ACTIONS_CLASS_NAME = 'mt-2 mb-1 flex items-center justify-start gap-1.5';
 
@@ -638,7 +649,7 @@ const UserMessageBody = React.memo(({ messageId, parts, isMobile, alwaysShowActi
     return (
         <div
             className="relative w-full group/message"
-            style={CONTAIN_LAYOUT_STYLE}
+            style={USER_CONTAIN_LAYOUT_STYLE}
             onTouchStart={isTouchContext && canCopyMessage && hasCopyableText ? revealCopyHint : undefined}
         >
             <div
@@ -2006,7 +2017,7 @@ const AssistantMessageBody = React.memo(({
               className={cn(
                  'relative w-full group/message'
              )}
-              style={CONTAIN_LAYOUT_STYLE}
+              style={ASSISTANT_CONTAIN_LAYOUT_STYLE}
           >
               <TextSelectionMenu containerRef={messageContentRef} />
              {canUseProjectPlanActions ? (


### PR DESCRIPTION
## Summary

Fixes #2095 — action buttons (copy, edit, etc.) at the bottom of assistant messages were hidden/overlapped by the next turn's sticky user header due to a CSS stacking-context conflict. The fix is layered: the parent commit removes the explicit `z-0` isolation and lifts the action button containers to `z-30`; the follow-up commit removes a `transform: translateZ(0)` stacking context on the assistant message-body wrapper that was trapping the new `z-30` and silently undoing the first fix.

## Root cause

Two compounding stacking-context issues, both in the same parent context (ChatContainer's `relative z-0`):

1. **Explicit z-0 isolation** — the assistant block wrapper (`TurnAssistantBlock.tsx`) used `relative z-0`, pinning its descendants to z-index 0. The next turn's sticky user header (`sticky top-0 z-20`) painted on top.
2. **Implicit transform stacking context** — the assistant message-body wrapper (`MessageBody.tsx:2003` pre-follow-up) used `style={CONTAIN_LAYOUT_STYLE}`, which sets `transform: translateZ(0)`. That `transform` value is non-`none`, so per CSS Transforms Level 1 it creates a new stacking context. The `z-30` action button containers (added in the parent commit) are descendants of this wrapper, so their `z-30` is interpreted inside the wrapper's stacking context — not in the parent context. The wrapper itself has no explicit z-index, so it paints at z=0 in the parent, and the next turn's sticky header at z-20 still wins.

```
ChatContainer (relative z-0) ← parent stacking context
├── Turn N section (relative w-full — no stacking context)
│   ├── sticky header (sticky z-20)
│   └── TurnAssistantBlock (relative — no z-index, after fix)
│       └── AssistantMessageBody wrapper (transform: translateZ(0) → SC at z-0)
│           ├── action buttons (relative z-30) ← TRAPPED inside wrapper SC
│           └── text / tools / etc.
├── Turn N+1 section (relative w-full — no stacking context)
│   └── sticky header (sticky z-20) ← paints over the trapped action buttons
```

## Fix

Three minimal CSS-only changes from the parent commit, plus one right-level fix from the follow-up:

| Commit | File | Change |
|---|---|---|
| `8c121920e` | `TurnItem.tsx` | removed redundant `relative` from sticky header (`sticky` is already a positioned element) |
| `8c121920e` | `TurnAssistantBlock.tsx` | removed `z-0` from wrapper div so descendants participate in the parent stacking context |
| `8c121920e` | `MessageBody.tsx` | added `relative z-30` to 3 action button containers (inline actions, standalone actions, turn footer) |
| `0579998ab` | `MessageBody.tsx` | split `CONTAIN_LAYOUT_STYLE` → `USER_CONTAIN_LAYOUT_STYLE` (keeps `transform: translateZ(0)`) and `ASSISTANT_CONTAIN_LAYOUT_STYLE` (drops `transform`, keeps `contain: layout`); the assistant wrapper no longer creates a stacking context, so the `z-30` action buttons now apply in the parent context and paint above the next turn's `z-20` sticky header |

The user-side wrapper keeps `transform: translateZ(0)` because its trapped `z-10` action menus (`UserTextPart.tsx`, `MessageBody.tsx` action row) don't need to escape that context — they only render against siblings inside the same wrapper. This was a deliberate scoping decision flagged by the openchamber-bot review on the parent commit.

## Files changed

| File | Net diff |
|---|---|
| `packages/ui/src/components/chat/components/TurnAssistantBlock.tsx` | +1 / −1 |
| `packages/ui/src/components/chat/components/TurnItem.tsx` | +1 / −1 |
| `packages/ui/src/components/chat/message/MessageBody.tsx` | +17 / −6 |
| **Total** | **+19 / −8 across 3 files** |

No logic, event wiring, or DOM shape changes. CSS-only.

## Validation

| Check | Result |
|-------|--------|
| `bun run type-check:ui` | ✅ pass (exit 0) |
| `bun run lint:ui` | ✅ pass (exit 0) |
| `bun run dead-code` | ✅ pass (exit 0; no `MessageBody` findings) |
| OCR code review (glm-5.2) on follow-up commit | ✅ 0 comments — `Looks good to me` |
| Independent code review (native) | ✅ approve with nits — nits are non-blocking, no action required |

## Notes

- The `transform: translateZ(0)` on the user-side wrapper is a legacy GPU-compositing hint; the new `contain: layout` alone is sufficient for layout isolation. Keeping it on the user side only is a deliberate, minimal scoping decision for this fix; a future cleanup could unify the constants.
- The follow-up commit was prompted by the openchamber-bot review on the parent commit, which correctly flagged the `transform: translateZ(0)` stacking context as a non-blocker concern. The fix landed on the same PR branch rather than a separate PR.
- The `MessageList.tsx` virtualizer already explicitly avoids `transform` for the same reason — see the comment at `MessageList.tsx:1196-1203` ("a transformed ancestor becomes the sticky containing block"). This fix aligns the message-body wrapper with that established pattern.
- Related issue: #2094 (visual order reversed) — same stacking-context family of problems.
