### PR TITLE
feat(quota): z.ai weekly window + DeepSeek balance and burn-rate tracking

### DIFF
--- a/packages/ui/src/apps/MobileApp.tsx
+++ b/packages/ui/src/apps/MobileApp.tsx
@@ -31,7 +31,7 @@ import { useOrientation } from '@/lib/device';
 import { useI18n } from '@/lib/i18n';
 import { isIPadApp } from '@/lib/platform';
 import { resolveProjectForDirectory, resolveProjectForSessionDirectory } from '@/lib/projectResolution';
-import { clampPercent, formatQuotaResetLabel, formatQuotaValueLabel, formatWindowLabel, QUOTA_PROVIDERS, resolveUsageTone } from '@/lib/quota';
+import { clampPercent, formatQuotaResetLabel, formatQuotaValueLabel, formatWindowLabel, formatCreditsNote, QUOTA_PROVIDERS, resolveUsageTone } from '@/lib/quota';
 import { getDisplayModelName } from '@/lib/quota/model-families';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { getRuntimeApiBaseUrl, subscribeRuntimeEndpointChanged, switchRuntimeEndpoint } from '@/lib/runtime-switch';
@@ -1585,19 +1585,25 @@ const MobileUsageLimits: React.FC<{
                     row.window.resetAfterFormatted ?? row.window.resetAtFormatted,
                     timeFormatPreference,
                   );
+                  const creditsNote = formatCreditsNote(row.window.credits);
                   return (
-                    <div key={row.key} className="flex min-w-0 items-baseline justify-between gap-3">
-                      <span className="inline-flex min-w-0 flex-1 items-baseline gap-1.5">
-                        <span className="truncate typography-ui-label text-muted-foreground">
-                          {row.subtitle ? `${row.subtitle} · ${row.label}` : row.label}
+                    <div key={row.key} className="flex min-w-0 flex-col">
+                      <div className="flex min-w-0 items-baseline justify-between gap-3">
+                        <span className="inline-flex min-w-0 flex-1 items-baseline gap-1.5">
+                          <span className="truncate typography-ui-label text-muted-foreground">
+                            {row.subtitle ? `${row.subtitle} · ${row.label}` : row.label}
+                          </span>
+                          {resetLabel ? (
+                            <span className="shrink-0 truncate typography-micro text-muted-foreground/70">{resetLabel}</span>
+                          ) : null}
                         </span>
-                        {resetLabel ? (
-                          <span className="shrink-0 truncate typography-micro text-muted-foreground/70">{resetLabel}</span>
-                        ) : null}
-                      </span>
-                      <span className={cn('shrink-0 typography-ui-label font-semibold tabular-nums', getWindowValueClass(row.window))}>
-                        {metricLabel === '-' ? '' : metricLabel}
-                      </span>
+                        <span className={cn('shrink-0 typography-ui-label font-semibold tabular-nums', getWindowValueClass(row.window))}>
+                          {metricLabel === '-' ? '' : metricLabel}
+                        </span>
+                      </div>
+                      {creditsNote ? (
+                        <span className="truncate typography-micro text-muted-foreground">{creditsNote}</span>
+                      ) : null}
                     </div>
                   );
                 })}

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -39,7 +39,7 @@ import { cn, hasModifier } from '@/lib/utils';
 import { McpDropdownContent } from '@/components/mcp/McpDropdown';
 import { McpIcon } from '@/components/icons/McpIcon';
 import { ProviderLogo } from '@/components/ui/ProviderLogo';
-import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, QUOTA_PROVIDERS, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
+import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, formatCreditsNote, QUOTA_PROVIDERS, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
 import { UsageProgressBar } from '@/components/sections/usage/UsageProgressBar';
 import { PaceIndicator } from '@/components/sections/usage/PaceIndicator';
 import { updateDesktopSettings } from '@/lib/persistence';
@@ -507,6 +507,7 @@ const DesktopServicesMenu = React.memo(function DesktopServicesMenu({
                             : null;
                           const metricLabel = formatQuotaValueLabel(window.valueLabel, displayPercent);
                           const resetLabel = formatQuotaResetLabel(window.resetAt, window.resetAfterFormatted ?? window.resetAtFormatted, timeFormatPreference);
+                          const creditsNote = formatCreditsNote(window.credits);
                           return (
                             <div key={`${group.providerId}-${label}`} className="flex flex-col gap-1.5">
                               <div className="flex min-w-0 items-center justify-between gap-3">
@@ -528,6 +529,9 @@ const DesktopServicesMenu = React.memo(function DesktopServicesMenu({
                                 className="h-1.5"
                                 expectedMarkerPercent={expectedMarker}
                               />
+                              {creditsNote ? (
+                                <span className="truncate typography-micro text-muted-foreground">{creditsNote}</span>
+                              ) : null}
                               {paceInfo && showPredValues ? <PaceIndicator paceInfo={paceInfo} compact /> : null}
                             </div>
                           );
@@ -558,6 +562,7 @@ const DesktopServicesMenu = React.memo(function DesktopServicesMenu({
                                               : calculateExpectedUsagePercent(paceInfo.elapsedRatio))
                                           : null;
                                         const metricLabel = formatQuotaValueLabel(window.valueLabel, displayPercent);
+                                        const creditsNote = formatCreditsNote(window.credits);
                                         return (
                                           <div key={`${group.providerId}-${modelName}`} className="flex flex-col gap-1.5">
                                             <div className="flex min-w-0 items-center justify-between gap-3">
@@ -572,6 +577,9 @@ const DesktopServicesMenu = React.memo(function DesktopServicesMenu({
                                               className="h-1.5"
                                               expectedMarkerPercent={expectedMarker}
                                             />
+                                            {creditsNote ? (
+                                              <span className="truncate typography-micro text-muted-foreground">{creditsNote}</span>
+                                            ) : null}
                                             {paceInfo && showPredValues ? <PaceIndicator paceInfo={paceInfo} compact /> : null}
                                           </div>
                                         );
@@ -2515,6 +2523,7 @@ export const Header: React.FC<HeaderProps> = ({
                                     : null;
                                   const metricLabel = formatQuotaValueLabel(window.valueLabel, displayPercent);
                                   const resetLabel = formatQuotaResetLabel(window.resetAt, window.resetAfterFormatted ?? window.resetAtFormatted, timeFormatPreference);
+                                  const creditsNote = formatCreditsNote(window.credits);
                                   return (
                                     <div key={`${group.providerId}-${label}`} className="flex flex-col gap-1.5">
                                       <div className="flex min-w-0 items-center justify-between gap-3">
@@ -2536,6 +2545,9 @@ export const Header: React.FC<HeaderProps> = ({
                                         className="h-1.5"
                                         expectedMarkerPercent={expectedMarker}
                                       />
+                                      {creditsNote ? (
+                                        <span className="truncate typography-micro text-muted-foreground">{creditsNote}</span>
+                                      ) : null}
                                       {paceInfo && showPredValues ? (
                                         <PaceIndicator paceInfo={paceInfo} compact />
                                       ) : null}
@@ -2579,6 +2591,7 @@ export const Header: React.FC<HeaderProps> = ({
                                                       : calculateExpectedUsagePercent(paceInfo.elapsedRatio))
                                                   : null;
                                                 const metricLabel = formatQuotaValueLabel(window.valueLabel, displayPercent);
+                                                const creditsNote = formatCreditsNote(window.credits);
                                                 return (
                                                   <div key={`${group.providerId}-${modelName}`} className="flex flex-col gap-1.5">
                                                     <div className="flex min-w-0 items-center justify-between gap-3">
@@ -2593,6 +2606,9 @@ export const Header: React.FC<HeaderProps> = ({
                                                       className="h-1.5"
                                                       expectedMarkerPercent={expectedMarker}
                                                     />
+                                                    {creditsNote ? (
+                                                      <span className="truncate typography-micro text-muted-foreground">{creditsNote}</span>
+                                                    ) : null}
                                                     {paceInfo && showPredValues ? (
                                                       <PaceIndicator paceInfo={paceInfo} compact />
                                                     ) : null}

--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -32,7 +32,7 @@ import { ProviderLogo } from '@/components/ui/ProviderLogo';
 import { UsageProgressBar } from '@/components/sections/usage/UsageProgressBar';
 import { PaceIndicator } from '@/components/sections/usage/PaceIndicator';
 import { Icon } from "@/components/icon/Icon";
-import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, QUOTA_PROVIDERS, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
+import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, formatCreditsNote, QUOTA_PROVIDERS, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
 import { useQuotaAutoRefresh, useQuotaStore } from '@/stores/useQuotaStore';
 import { updateDesktopSettings } from '@/lib/persistence';
 import { formatTimeForPreference } from '@/lib/timeFormat';
@@ -978,6 +978,7 @@ const VSCodeHeader: React.FC<VSCodeHeaderProps> = ({ title, showBack, onBack, on
                           : calculateExpectedUsagePercent(paceInfo.elapsedRatio))
                       : null;
                     const metricLabel = formatQuotaValueLabel(window.valueLabel, displayPercent);
+                    const creditsNote = formatCreditsNote(window.credits);
                     return (
                     <DropdownMenuItem
                       key={`${group.providerId}-${label}`}
@@ -997,6 +998,9 @@ const VSCodeHeader: React.FC<VSCodeHeaderProps> = ({ title, showBack, onBack, on
                                 className="h-1"
                                 expectedMarkerPercent={expectedMarker}
                               />
+                              {creditsNote ? (
+                                <span className="truncate typography-micro text-muted-foreground">{creditsNote}</span>
+                              ) : null}
                               {paceInfo && showPredValues && (
                                 <div className="mt-0.5">
                                   <PaceIndicator paceInfo={paceInfo} compact />

--- a/packages/ui/src/components/sections/usage/UsageCard.tsx
+++ b/packages/ui/src/components/sections/usage/UsageCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { UsageWindow } from '@/types';
-import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
+import { formatQuotaValueLabel, formatQuotaResetLabel, formatWindowLabel, formatCreditsNote, calculatePace, calculateExpectedUsagePercent } from '@/lib/quota';
 import { UsageProgressBar } from './UsageProgressBar';
 import { PaceIndicator } from './PaceIndicator';
 import { useQuotaStore } from '@/stores/useQuotaStore';
@@ -32,6 +32,7 @@ export const UsageCard: React.FC<UsageCardProps> = ({
   const percentLabel = formatQuotaValueLabel(window.valueLabel, displayPercent);
   const resetLabel = formatQuotaResetLabel(window.resetAt, window.resetAfterFormatted ?? window.resetAtFormatted, timeFormatPreference);
   const windowLabel = formatWindowLabel(title);
+  const creditsNote = formatCreditsNote(window.credits);
 
   const paceInfo = React.useMemo(() => {
     return calculatePace(window.usedPercent, window.resetAt, window.windowSeconds, title);
@@ -83,6 +84,11 @@ export const UsageCard: React.FC<UsageCardProps> = ({
             {barLabel}
           </span>
         </div>
+        {creditsNote && (
+          <div className="mt-1">
+            <span className="typography-micro text-muted-foreground">{creditsNote}</span>
+          </div>
+        )}
       </div>
 
       {paceInfo && showPredValues && (

--- a/packages/ui/src/hooks/useTraySync.ts
+++ b/packages/ui/src/hooks/useTraySync.ts
@@ -15,7 +15,7 @@ import {
   resolveGlobalSessionDirectory,
 } from '@/stores/useGlobalSessionsStore';
 import { useQuotaStore } from '@/stores/useQuotaStore';
-import { QUOTA_PROVIDERS, formatWindowLabel, formatQuotaValueLabel } from '@/lib/quota';
+import { QUOTA_PROVIDERS, formatWindowLabel, formatQuotaValueLabel, formatCreditsNote } from '@/lib/quota';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useGitStore } from '@/stores/useGitStore';
@@ -179,7 +179,9 @@ const buildUsage = (): TrayUsage => {
     const rows: TrayUsageRow[] = [];
     for (const [label, window] of Object.entries(result.usage?.windows ?? {})) {
       const percent = mode === 'remaining' ? window.remainingPercent : window.usedPercent;
-      rows.push({ label: formatWindowLabel(label), value: formatQuotaValueLabel(window.valueLabel, percent) });
+      const metric = formatQuotaValueLabel(window.valueLabel, percent);
+      const creditsNote = formatCreditsNote(window.credits);
+      rows.push({ label: formatWindowLabel(label), value: creditsNote ? `${metric} · ${creditsNote}` : metric });
     }
 
     const status = !result.ok && result.error

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2766,6 +2766,7 @@ export const dict = {
   'quota.window.daily': 'Daily',
   'quota.window.monthly': 'Monthly Limit',
   'quota.window.credits': 'Credits',
+  'quota.note.runwayLeft': '~{duration} left',
   'quota.window.creditsBalance': 'Credits Balance',
   'quota.window.billingCycle': 'Billing Cycle',
   'quota.window.auto': 'Auto',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2767,6 +2767,7 @@ export const dict: Record<I18nKey, string> = {
   "quota.window.daily": "Daily",
   "quota.window.monthly": "Monthly Limit",
   "quota.window.credits": "Credits",
+  "quota.note.runwayLeft": "~{duration} restante",
   "quota.window.creditsBalance": "Credits Balance",
   "quota.window.billingCycle": "Billing Cycle",
   "quota.window.auto": "Auto",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -2525,6 +2525,7 @@ export const dict = {
   'quota.window.daily': 'Quotidien',
   'quota.window.monthly': 'Limite mensuelle',
   'quota.window.credits': 'Crédits',
+  'quota.note.runwayLeft': '~{duration} restant',
   'quota.window.creditsBalance': 'Solde de crédits',
   'quota.window.billingCycle': 'Cycle de facturation',
   'quota.window.auto': 'Auto',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2762,6 +2762,7 @@ export const dict: Record<I18nKey, string> = {
   'quota.window.daily': '日次',
   'quota.window.monthly': '月間制限',
   'quota.window.credits': 'クレジット',
+  'quota.note.runwayLeft': '残り約{duration}',
   'quota.window.creditsBalance': 'クレジット残高',
   'quota.window.billingCycle': '請求サイクル',
   'quota.window.auto': '自動',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2766,6 +2766,7 @@ export const dict: Record<I18nKey, string> = {
   'quota.window.daily': 'Daily',
   'quota.window.monthly': 'Monthly Limit',
   'quota.window.credits': 'Credits',
+  'quota.note.runwayLeft': '~{duration} 남음',
   'quota.window.creditsBalance': 'Credits Balance',
   'quota.window.billingCycle': 'Billing Cycle',
   'quota.window.auto': 'Auto',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2783,6 +2783,7 @@ export const dict: Record<I18nKey, string> = {
   'quota.window.daily': 'Daily',
   'quota.window.monthly': 'Monthly Limit',
   'quota.window.credits': 'Credits',
+  'quota.note.runwayLeft': '~{duration} pozostało',
   'quota.window.creditsBalance': 'Credits Balance',
   'quota.window.billingCycle': 'Billing Cycle',
   'quota.window.auto': 'Auto',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2767,6 +2767,7 @@ export const dict: Record<I18nKey, string> = {
   "quota.window.daily": "Daily",
   "quota.window.monthly": "Monthly Limit",
   "quota.window.credits": "Credits",
+  "quota.note.runwayLeft": "~{duration} restante",
   "quota.window.creditsBalance": "Credits Balance",
   "quota.window.billingCycle": "Billing Cycle",
   "quota.window.auto": "Auto",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2767,6 +2767,7 @@ export const dict: Record<I18nKey, string> = {
   "quota.window.daily": "Daily",
   "quota.window.monthly": "Monthly Limit",
   "quota.window.credits": "Credits",
+  "quota.note.runwayLeft": "~{duration} залишилось",
   "quota.window.creditsBalance": "Credits Balance",
   "quota.window.billingCycle": "Billing Cycle",
   "quota.window.auto": "Auto",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2767,6 +2767,7 @@ export const dict: Record<I18nKey, string> = {
   'quota.window.daily': 'Daily',
   'quota.window.monthly': 'Monthly Limit',
   'quota.window.credits': 'Credits',
+  'quota.note.runwayLeft': '剩余约{duration}',
   'quota.window.creditsBalance': 'Credits Balance',
   'quota.window.billingCycle': 'Billing Cycle',
   'quota.window.auto': 'Auto',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2766,6 +2766,7 @@ export const dict: Record<I18nKey, string> = {
   'quota.window.daily': 'Daily',
   'quota.window.monthly': 'Monthly Limit',
   'quota.window.credits': 'Credits',
+  'quota.note.runwayLeft': '剩餘約{duration}',
   'quota.window.creditsBalance': 'Credits Balance',
   'quota.window.billingCycle': 'Billing Cycle',
   'quota.window.auto': 'Auto',

--- a/packages/ui/src/lib/quota/index.ts
+++ b/packages/ui/src/lib/quota/index.ts
@@ -5,6 +5,7 @@ export {
   formatQuotaResetLabel,
   resolveUsageTone,
   formatWindowLabel,
+  formatCreditsNote,
   calculatePace,
   getPaceStatusColor,
   formatRemainingTime,

--- a/packages/ui/src/lib/quota/providers/index.ts
+++ b/packages/ui/src/lib/quota/providers/index.ts
@@ -21,4 +21,5 @@ export const QUOTA_PROVIDERS: QuotaProviderMeta[] = [
   { id: 'ollama-cloud', name: 'Ollama Cloud' },
   { id: 'wafer', name: 'Wafer.ai' },
   { id: 'opencode-go', name: 'OpenCode Go' },
+  { id: 'deepseek', name: 'DeepSeek' },
 ];

--- a/packages/ui/src/lib/quota/utils.ts
+++ b/packages/ui/src/lib/quota/utils.ts
@@ -1,6 +1,7 @@
 import { formatMessage, useI18nStore } from '@/lib/i18n/store';
 import { formatDateTimeForPreference, formatTimeForPreference } from '@/lib/timeFormat';
 import type { TimeFormatPreference } from '@/stores/useUIStore';
+import type { CreditsBurn } from '../../types/quota';
 
 const t = (key: Parameters<typeof formatMessage>[1]) => formatMessage(useI18nStore.getState().dictionary, key);
 
@@ -281,6 +282,20 @@ export const formatRemainingTime = (seconds: number): string => {
     return '<1m';
   }
   return `${minutes}m`;
+};
+
+/**
+ * Format a burn-rate + runway note for credit-based quotas (e.g. DeepSeek).
+ * Returns null when no credits data is present.
+ */
+export const formatCreditsNote = (credits: CreditsBurn | null | undefined): string | null => {
+  if (!credits) {
+    return null;
+  }
+  const runwayLeft = formatMessage(useI18nStore.getState().dictionary, 'quota.note.runwayLeft', {
+    duration: formatRemainingTime(credits.runwaySeconds),
+  });
+  return `~${credits.symbol}${credits.burnPerHour.toFixed(2)}/h \u00b7 ${runwayLeft}`;
 };
 
 /**

--- a/packages/ui/src/types/quota.ts
+++ b/packages/ui/src/types/quota.ts
@@ -15,7 +15,14 @@ export type QuotaProviderId =
   | 'minimax-cn-coding-plan'
   | 'ollama-cloud'
   | 'wafer'
-  | 'opencode-go';
+  | 'opencode-go'
+  | 'deepseek';
+
+export interface CreditsBurn {
+  burnPerHour: number;
+  runwaySeconds: number;
+  symbol: string;
+}
 
 export interface UsageWindow {
   usedPercent: number | null;
@@ -26,6 +33,7 @@ export interface UsageWindow {
   resetAtFormatted: string | null;
   resetAfterFormatted: string | null;
   valueLabel?: string | null;
+  credits?: CreditsBurn | null;
 }
 
 export interface UsageWindows {

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -32,6 +32,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 | `ollama-cloud` | Ollama Cloud | `providers/ollama-cloud.js` | Cookie file at `~/.config/ollama-quota/cookie` (raw session cookie string) |
 | `wafer` | Wafer.ai | `providers/wafer.js` | `wafer`, `wafer-ai`, `wafer_ai`, `wafer.ai` |
 | `opencode-go` | OpenCode Go | `providers/opencode-go.js` | Manual workspace ID and auth cookie stored under `~/.config/openchamber/quota/` |
+| `deepseek` | DeepSeek | `providers/deepseek.js` (+ `providers/deepseek-burn.js`) | `deepseek` |
 
 ## Internal-only provider module
 - `providers/openai.js` exists for logic parity/reuse but is intentionally not registered for dispatcher ID routing.
@@ -67,6 +68,14 @@ In 2025/2026 MiniMax rebranded "Coding Plan" to "Token Plan" alongside the M3 mo
 - **Percentage-based plans**: Legacy Coding Plan accounts return `current_interval_total_count: 0` but include `current_interval_remaining_percent`. The provider prefers this field when count fields are absent.
 - **model_remains array**: Now contains entries for multiple model categories (chat, speech, video, image). The provider selects the chat-model entry by matching `MiniMax-M*`, then `general`/`chat`/`text` by name, then any entry with a remaining percent.
 - **Window status**: The `current_interval_status` and `current_weekly_status` fields indicate whether a window is active. Status `3` means the window is not applicable for the current plan tier (e.g. legacy plans without weekly limits). The provider omits inactive windows.
+
+## z.ai / Zhipu token windows
+
+The GLM Coding Plan surfaces **two** token windows from `/monitor/usage/quota/limit` as separate `TOKENS_LIMIT` entries, distinguished by the (undocumented) `unit` field: `unit 3` = hour (5h window, `number 5`) and `unit 6` = week (weekly window). `resolveWindowSeconds` maps `unit` to seconds (`3`=hour, `4`=day, `6`=week, `5`=month) and returns null for unknown units so `buildZaiWindows` skips them instead of emitting a bogus window. `percentage` is consumed percent; `nextResetTime` is epoch ms and may be absent for an idle window. The `TIME_LIMIT` entry (monthly MCP/tools count) is intentionally not surfaced by this provider.
+
+## DeepSeek balance + burn tracking
+
+DeepSeek Platform (`api.deepseek.com`) exposes only `GET /user/balance` (prepaid credit balance) and no usage/spend-over-time API. To show a burn rate we sample the balance ourselves: each `fetchQuota` appends `{ balance, currency, at }` to `deepseek-balance-history.json` under `OPENCODE_DATA_DIR`, pruned to the last 24h and 200 samples, best-effort (a write failure never breaks the fetch). Sampling is **on-fetch only** — it piggybacks the existing quota refresh rather than a scheduled job, so no background timer spends credits while idle. `computeBurn` (in `deepseek-burn.js`) derives `$/hour` from the most recent monotonically-decreasing segment (a balance rise is treated as a top-up boundary, never negative burn) and a runway estimate. The result rides the `credits_balance` window as a structured `credits: { burnPerHour, runwaySeconds, symbol }` field; the UI formats and localizes the note.
 
 ## Notes for contributors
 - Keep provider IDs stable; clients use them directly.

--- a/packages/web/server/lib/quota/providers/deepseek-burn.js
+++ b/packages/web/server/lib/quota/providers/deepseek-burn.js
@@ -1,0 +1,31 @@
+const MS_PER_HOUR = 3_600_000;
+const MIN_SAMPLE_SPAN_MS = 60_000;
+
+export const computeBurn = (samples) => {
+  const empty = { burnPerHour: null, runwaySeconds: null };
+  if (!Array.isArray(samples) || samples.length < 2) return empty;
+
+  const last = samples.length - 1;
+  let segStart = last;
+  for (let i = last - 1; i >= 0; i -= 1) {
+    // Walk back only while balance is non-increasing forward in time; a rise
+    // means a top-up, so anchor on the post-top-up segment to avoid negative burn.
+    if (samples[i].balanceUsd >= samples[i + 1].balanceUsd) {
+      segStart = i;
+    } else {
+      break;
+    }
+  }
+
+  const start = samples[segStart];
+  const end = samples[last];
+  const dtMs = end.at - start.at;
+  if (segStart === last || dtMs < MIN_SAMPLE_SPAN_MS) return empty;
+
+  const delta = start.balanceUsd - end.balanceUsd;
+  if (delta <= 0) return empty;
+
+  const burnPerHour = delta / (dtMs / MS_PER_HOUR);
+  const runwaySeconds = burnPerHour > 0 ? (end.balanceUsd / burnPerHour) * 3600 : null;
+  return { burnPerHour, runwaySeconds };
+};

--- a/packages/web/server/lib/quota/providers/deepseek-burn.test.js
+++ b/packages/web/server/lib/quota/providers/deepseek-burn.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeBurn } from './deepseek-burn.js';
+
+const HOUR = 3_600_000;
+
+describe('computeBurn', () => {
+  it('computes hourly burn and runway from a decreasing balance', () => {
+    const { burnPerHour, runwaySeconds } = computeBurn([
+      { balanceUsd: 44, at: 0 },
+      { balanceUsd: 43, at: 2 * HOUR }
+    ]);
+    expect(burnPerHour).toBeCloseTo(0.5, 6);
+    expect(runwaySeconds).toBeCloseTo((43 / 0.5) * 3600, 3);
+  });
+
+  it('returns nulls with fewer than two samples', () => {
+    expect(computeBurn([{ balanceUsd: 44, at: 0 }])).toEqual({ burnPerHour: null, runwaySeconds: null });
+    expect(computeBurn([])).toEqual({ burnPerHour: null, runwaySeconds: null });
+  });
+
+  it('never reports negative burn across a top-up', () => {
+    const { burnPerHour } = computeBurn([
+      { balanceUsd: 40, at: 0 },
+      { balanceUsd: 50, at: HOUR },
+      { balanceUsd: 48, at: 2 * HOUR }
+    ]);
+    expect(burnPerHour).toBeCloseTo(2, 6);
+    expect(burnPerHour).toBeGreaterThan(0);
+  });
+
+  it('returns nulls when samples span less than the minimum window', () => {
+    expect(computeBurn([
+      { balanceUsd: 44, at: 0 },
+      { balanceUsd: 43, at: 30_000 }
+    ])).toEqual({ burnPerHour: null, runwaySeconds: null });
+  });
+
+  it('returns nulls when the balance is flat', () => {
+    expect(computeBurn([
+      { balanceUsd: 44, at: 0 },
+      { balanceUsd: 44, at: 2 * HOUR }
+    ])).toEqual({ burnPerHour: null, runwaySeconds: null });
+  });
+});

--- a/packages/web/server/lib/quota/providers/deepseek.js
+++ b/packages/web/server/lib/quota/providers/deepseek.js
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import path from 'path';
+
+import { readAuthFile, OPENCODE_DATA_DIR } from '../../opencode/auth.js';
+import { getAuthEntry, normalizeAuthEntry, buildResult, toUsageWindow, toNumber } from '../utils/index.js';
+import { computeBurn } from './deepseek-burn.js';
+
+export const providerId = 'deepseek';
+export const providerName = 'DeepSeek';
+const aliases = ['deepseek'];
+
+const HISTORY_FILE = path.join(OPENCODE_DATA_DIR, 'deepseek-balance-history.json');
+const HISTORY_RETENTION_MS = 24 * 60 * 60 * 1000;
+const HISTORY_MAX_SAMPLES = 200;
+
+const getApiKey = () => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  return entry?.key ?? entry?.token ?? null;
+};
+
+export const isConfigured = () => Boolean(getApiKey());
+
+const currencySymbol = (currency) => {
+  if (currency === 'USD') return '$';
+  if (currency === 'CNY') return '\u00a5';
+  return currency ? `${currency} ` : '';
+};
+
+const readHistory = () => {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(HISTORY_FILE, 'utf8'));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const recordSample = (balance, currency, now) => {
+  const history = readHistory()
+    .filter((s) => typeof s?.balance === 'number' && typeof s?.at === 'number' && now - s.at <= HISTORY_RETENTION_MS);
+  history.push({ balance, currency, at: now });
+  const trimmed = history.slice(-HISTORY_MAX_SAMPLES);
+  try {
+    if (!fs.existsSync(OPENCODE_DATA_DIR)) fs.mkdirSync(OPENCODE_DATA_DIR, { recursive: true });
+    fs.writeFileSync(HISTORY_FILE, JSON.stringify(trimmed), 'utf8');
+  } catch {
+    // Persistence is best-effort; a write failure must not break the quota fetch.
+  }
+  return trimmed;
+};
+
+export const buildDeepseekWindow = (balanceInfo, history) => {
+  const balance = toNumber(balanceInfo?.total_balance);
+  const symbol = currencySymbol(balanceInfo?.currency);
+  const valueLabel = balance !== null ? `${symbol}${balance.toFixed(2)}` : null;
+  const { burnPerHour, runwaySeconds } = computeBurn(
+    (Array.isArray(history) ? history : []).map((s) => ({ balanceUsd: s.balance, at: s.at }))
+  );
+  const credits = burnPerHour !== null ? { burnPerHour, runwaySeconds, symbol } : null;
+  return toUsageWindow({ usedPercent: null, windowSeconds: null, resetAt: null, valueLabel, credits });
+};
+
+export const fetchQuota = async () => {
+  const apiKey = getApiKey();
+
+  if (!apiKey) {
+    return buildResult({ providerId, providerName, ok: false, configured: false, error: 'Not configured' });
+  }
+
+  try {
+    const response = await fetch('https://api.deepseek.com/user/balance', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${apiKey}`, Accept: 'application/json' }
+    });
+
+    if (!response.ok) {
+      return buildResult({ providerId, providerName, ok: false, configured: true, error: `API error: ${response.status}` });
+    }
+
+    const payload = await response.json();
+    const balanceInfo = Array.isArray(payload?.balance_infos) ? payload.balance_infos[0] : null;
+    const balance = toNumber(balanceInfo?.total_balance);
+
+    if (!balanceInfo || balance === null) {
+      return buildResult({ providerId, providerName, ok: true, configured: true, usage: { windows: {} } });
+    }
+
+    const history = recordSample(balance, balanceInfo.currency, Date.now());
+    const windows = { credits_balance: buildDeepseekWindow(balanceInfo, history) };
+
+    return buildResult({ providerId, providerName, ok: true, configured: true, usage: { windows } });
+  } catch (error) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: error instanceof Error ? error.message : 'Request failed'
+    });
+  }
+};

--- a/packages/web/server/lib/quota/providers/deepseek.test.js
+++ b/packages/web/server/lib/quota/providers/deepseek.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDeepseekWindow } from './deepseek.js';
+
+const HOUR = 3_600_000;
+
+describe('buildDeepseekWindow', () => {
+  it('formats a USD balance as the value label', () => {
+    const w = buildDeepseekWindow({ currency: 'USD', total_balance: '43.53' }, []);
+    expect(w.valueLabel).toBe('$43.53');
+  });
+
+  it('omits credits burn until there are enough samples', () => {
+    const w = buildDeepseekWindow({ currency: 'USD', total_balance: '43.53' }, [
+      { balance: 43.53, currency: 'USD', at: Date.now() }
+    ]);
+    expect(w.credits).toBeUndefined();
+  });
+
+  it('emits burn + runway once the balance has decreased over time', () => {
+    const now = Date.now();
+    const w = buildDeepseekWindow({ currency: 'USD', total_balance: '43.00' }, [
+      { balance: 44, currency: 'USD', at: now - 2 * HOUR },
+      { balance: 43, currency: 'USD', at: now }
+    ]);
+    expect(w.credits).not.toBeNull();
+    expect(w.credits.symbol).toBe('$');
+    expect(w.credits.burnPerHour).toBeCloseTo(0.5, 6);
+    expect(w.credits.runwaySeconds).toBeGreaterThan(0);
+  });
+
+  it('uses the yuan symbol for CNY accounts', () => {
+    const w = buildDeepseekWindow({ currency: 'CNY', total_balance: '110.00' }, []);
+    expect(w.valueLabel).toBe('\u00a5110.00');
+  });
+});

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -23,6 +23,7 @@ import * as minimaxCnCodingPlan from './minimax-cn-coding-plan.js';
 import * as ollamaCloud from './ollama-cloud.js';
 import * as wafer from './wafer.js';
 import * as opencodeGo from './opencode-go.js';
+import * as deepseek from './deepseek.js';
 
 const registry = {
   claude: {
@@ -120,6 +121,12 @@ const registry = {
     providerName: opencodeGo.providerName,
     isConfigured: opencodeGo.isConfigured,
     fetchQuota: opencodeGo.fetchQuota
+  },
+  deepseek: {
+    providerId: deepseek.providerId,
+    providerName: deepseek.providerName,
+    isConfigured: deepseek.isConfigured,
+    fetchQuota: deepseek.fetchQuota
   }
 };
 
@@ -182,3 +189,4 @@ export const fetchMinimaxCnCodingPlanQuota = minimaxCnCodingPlan.fetchQuota;
 export const fetchOllamaCloudQuota = ollamaCloud.fetchQuota;
 export const fetchWaferQuota = wafer.fetchQuota;
 export const fetchZhipuaiQuota = zhipuaiCodingPlan.fetchQuota;
+export const fetchDeepseekQuota = deepseek.fetchQuota;

--- a/packages/web/server/lib/quota/providers/zai.js
+++ b/packages/web/server/lib/quota/providers/zai.js
@@ -4,8 +4,6 @@ import {
   normalizeAuthEntry,
   buildResult,
   toUsageWindow,
-  toNumber,
-  toTimestamp,
   resolveWindowSeconds,
   resolveWindowLabel,
   normalizeTimestamp
@@ -19,6 +17,22 @@ export const isConfigured = () => {
   const auth = readAuthFile();
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   return Boolean(entry?.key || entry?.token);
+};
+
+export const buildZaiWindows = (limits) => {
+  const windows = {};
+  for (const limit of Array.isArray(limits) ? limits : []) {
+    if (limit?.type !== 'TOKENS_LIMIT') continue;
+    const windowSeconds = resolveWindowSeconds(limit);
+    if (windowSeconds === null) continue;
+    const label = resolveWindowLabel(windowSeconds);
+    windows[label] = toUsageWindow({
+      usedPercent: typeof limit.percentage === 'number' ? limit.percentage : null,
+      windowSeconds,
+      resetAt: limit.nextResetTime ? normalizeTimestamp(limit.nextResetTime) : null
+    });
+  }
+  return windows;
 };
 
 export const fetchQuota = async () => {
@@ -56,21 +70,7 @@ export const fetchQuota = async () => {
     }
 
     const payload = await response.json();
-    const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
-    const tokensLimit = limits.find((limit) => limit?.type === 'TOKENS_LIMIT');
-    const windowSeconds = resolveWindowSeconds(tokensLimit);
-    const windowLabel = resolveWindowLabel(windowSeconds);
-    const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
-    const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
-
-    const windows = {};
-    if (tokensLimit) {
-      windows[windowLabel] = toUsageWindow({
-        usedPercent,
-        windowSeconds,
-        resetAt
-      });
-    }
+    const windows = buildZaiWindows(payload?.data?.limits);
 
     return buildResult({
       providerId,

--- a/packages/web/server/lib/quota/providers/zai.test.js
+++ b/packages/web/server/lib/quota/providers/zai.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildZaiWindows } from './zai.js';
+
+const LIVE_LIMITS = [
+  { type: 'TIME_LIMIT', unit: 5, number: 1, usage: 4000, remaining: 4000, percentage: 0, nextResetTime: 1784338722981 },
+  { type: 'TOKENS_LIMIT', unit: 3, number: 5, percentage: 0 },
+  { type: 'TOKENS_LIMIT', unit: 6, number: 1, percentage: 77, nextResetTime: 1784165922979 }
+];
+
+describe('buildZaiWindows', () => {
+  it('emits both the 5h and weekly token windows', () => {
+    const windows = buildZaiWindows(LIVE_LIMITS);
+    expect(Object.keys(windows).sort()).toEqual(['5h', 'weekly']);
+  });
+
+  it('maps the weekly window usage and reset', () => {
+    const windows = buildZaiWindows(LIVE_LIMITS);
+    expect(windows.weekly.usedPercent).toBe(77);
+    expect(windows.weekly.resetAt).toBe(1784165922979);
+    expect(windows.weekly.windowSeconds).toBe(604800);
+  });
+
+  it('tolerates a 5h window with no reset time when idle', () => {
+    const windows = buildZaiWindows(LIVE_LIMITS);
+    expect(windows['5h'].usedPercent).toBe(0);
+    expect(windows['5h'].resetAt).toBeNull();
+    expect(windows['5h'].windowSeconds).toBe(18000);
+  });
+
+  it('ignores TIME_LIMIT and unknown-unit entries', () => {
+    const windows = buildZaiWindows([
+      ...LIVE_LIMITS,
+      { type: 'TOKENS_LIMIT', unit: 99, number: 1, percentage: 10 }
+    ]);
+    expect(Object.keys(windows).sort()).toEqual(['5h', 'weekly']);
+  });
+
+  it('returns an empty object for missing or non-array limits', () => {
+    expect(buildZaiWindows(undefined)).toEqual({});
+    expect(buildZaiWindows(null)).toEqual({});
+  });
+});

--- a/packages/web/server/lib/quota/utils/formatters.js
+++ b/packages/web/server/lib/quota/utils/formatters.js
@@ -37,7 +37,7 @@ export const calculateResetAfterSeconds = (resetAt) => {
   return delta < 0 ? 0 : delta;
 };
 
-export const toUsageWindow = ({ usedPercent, windowSeconds, resetAt, valueLabel }) => {
+export const toUsageWindow = ({ usedPercent, windowSeconds, resetAt, valueLabel, credits }) => {
   const resetAfterSeconds = calculateResetAfterSeconds(resetAt);
   const resetFormatted = hasResetTimestamp(resetAt) ? formatResetTime(resetAt) : null;
   const hasFiniteUsedPercent = typeof usedPercent === 'number' && Number.isFinite(usedPercent);
@@ -49,7 +49,8 @@ export const toUsageWindow = ({ usedPercent, windowSeconds, resetAt, valueLabel 
     resetAt,
     resetAtFormatted: resetFormatted,
     resetAfterFormatted: resetFormatted,
-    ...(valueLabel ? { valueLabel } : {})
+    ...(valueLabel ? { valueLabel } : {}),
+    ...(credits ? { credits } : {})
   };
 };
 

--- a/packages/web/server/lib/quota/utils/transformers.js
+++ b/packages/web/server/lib/quota/utils/transformers.js
@@ -34,10 +34,12 @@ export const normalizeTimestamp = (value) => {
   return value < 1_000_000_000_000 ? value * 1000 : value;
 };
 
+// z.ai `unit` enum (undocumented): 3=hour, 4=day, 6=week, 5=month. Unknown -> null.
+const ZAI_UNIT_SECONDS = { 3: 3600, 4: 86400, 6: 604800, 5: 2592000 };
+
 export const resolveWindowSeconds = (limit) => {
-  const ZAI_TOKEN_WINDOW_SECONDS = { 3: 3600 };
   if (!limit || !limit.number) return null;
-  const unitSeconds = ZAI_TOKEN_WINDOW_SECONDS[limit.unit];
+  const unitSeconds = ZAI_UNIT_SECONDS[limit.unit];
   if (!unitSeconds) return null;
   return unitSeconds * limit.number;
 };

--- a/packages/web/server/lib/quota/utils/transformers.test.js
+++ b/packages/web/server/lib/quota/utils/transformers.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveWindowSeconds, resolveWindowLabel } from './transformers.js';
+
+describe('resolveWindowSeconds', () => {
+  it('resolves the z.ai 5-hour token window (unit 3)', () => {
+    expect(resolveWindowSeconds({ unit: 3, number: 5 })).toBe(18000);
+  });
+
+  it('resolves the z.ai weekly token window (unit 6)', () => {
+    expect(resolveWindowSeconds({ unit: 6, number: 1 })).toBe(604800);
+  });
+
+  it('resolves day (unit 4) and month (unit 5) windows', () => {
+    expect(resolveWindowSeconds({ unit: 4, number: 1 })).toBe(86400);
+    expect(resolveWindowSeconds({ unit: 5, number: 1 })).toBe(2592000);
+  });
+
+  it('returns null for unknown units', () => {
+    expect(resolveWindowSeconds({ unit: 99, number: 1 })).toBeNull();
+  });
+
+  it('returns null when number or limit is missing', () => {
+    expect(resolveWindowSeconds({ unit: 3 })).toBeNull();
+    expect(resolveWindowSeconds(null)).toBeNull();
+  });
+});
+
+describe('resolveWindowLabel', () => {
+  it('labels the 5-hour and weekly windows', () => {
+    expect(resolveWindowLabel(18000)).toBe('5h');
+    expect(resolveWindowLabel(604800)).toBe('weekly');
+  });
+});


### PR DESCRIPTION
## Summary

Adds proper usage/credit tracking for two providers.

### z.ai (fix)
The provider read only the first TOKENS_LIMIT entry, so the weekly window was silently dropped, and the window-seconds resolver only knew the hourly unit. It now iterates all TOKENS_LIMIT entries and maps the day/week/month units (skipping unknown units), surfacing both the 5h and weekly windows.

### DeepSeek (feature)
New provider for DeepSeek Platform. Shows the prepaid credit balance plus a predicted burn rate and runway. DeepSeek exposes no usage-over-time API, so the rate is derived by sampling the balance on each quota fetch into a capped, corrupt-tolerant history file, using the most recent monotonically-decreasing segment (top-ups never produce a negative rate). The balance and a structured credits field ride the credits_balance window; the UI renders a localized 'burn/h - runway left' sub-line across all quota surfaces (usage card, header, VS Code, mobile, tray).

## Verification

- 30 unit tests pass (z.ai multi-window parsing, computeBurn edge cases including top-up, DeepSeek window build).
- Web and UI type-check and lint pass; dead-code clean.
- Verified live against real keys via GET /api/quota/providers and GET /api/quota/:providerId: z.ai returns both 5h and weekly windows, DeepSeek returns the balance window, and DeepSeek now appears in the UI provider catalog.

## Out of scope

z.ai also returns a monthly TIME_LIMIT (tools) window; it is documented but not surfaced, since only the weekly limit was requested.