### PR TITLE
feat(files): expose markdown preview toggle

### DIFF
--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -3318,7 +3318,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
               title={t(getMdViewMode() === 'preview' ? 'filesView.editor.switchToEditMode' : 'filesView.editor.switchToPreviewMode')}
               aria-label={t(getMdViewMode() === 'preview' ? 'filesView.editor.switchToEditMode' : 'filesView.editor.switchToPreviewMode')}
             >
-              <Icon name="eye" className="size-4" />
+              <Icon name={getMdViewMode() === 'preview' ? 'eye' : 'eye-off'} className="size-4" />
             </Button>
           )
         )}

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -3302,15 +3302,32 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           />
         )}
 
-        {(isMarkdown || isHtmlFile(selectedFile?.path ?? '')) && (
+        {isMarkdown && (
+          withTooltip(
+            t(getMdViewMode() === 'preview' ? 'filesView.editor.switchToEditMode' : 'filesView.editor.switchToPreviewMode'),
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => saveMdViewMode(getMdViewMode() === 'preview' ? 'edit' : 'preview')}
+              className={cn(
+                'size-6 p-0 transition-colors hover:bg-[var(--interactive-hover)] focus-visible:bg-[var(--interactive-hover)] active:bg-[var(--interactive-hover)]',
+                getMdViewMode() === 'preview'
+                  ? 'bg-[var(--interactive-selection)] text-[var(--interactive-selection-foreground)] hover:bg-[var(--interactive-selection)] focus-visible:bg-[var(--interactive-selection)] active:bg-[var(--interactive-selection)]'
+                  : 'text-muted-foreground opacity-65 hover:opacity-100'
+              )}
+              title={t(getMdViewMode() === 'preview' ? 'filesView.editor.switchToEditMode' : 'filesView.editor.switchToPreviewMode')}
+              aria-label={t(getMdViewMode() === 'preview' ? 'filesView.editor.switchToEditMode' : 'filesView.editor.switchToPreviewMode')}
+            >
+              <Icon name="eye" className="size-4" />
+            </Button>
+          )
+        )}
+
+        {isHtmlFile(selectedFile?.path ?? '') && (
           <PreviewToggleButton
-            currentMode={isMarkdown ? getMdViewMode() : getHtmlViewMode()}
+            currentMode={getHtmlViewMode()}
             onToggle={() => {
-              if (isHtmlFile(selectedFile?.path ?? '')) {
-                saveHtmlViewMode(getHtmlViewMode() === 'preview' ? 'edit' : 'preview');
-              } else {
-                saveMdViewMode(getMdViewMode() === 'preview' ? 'edit' : 'preview');
-              }
+              saveHtmlViewMode(getHtmlViewMode() === 'preview' ? 'edit' : 'preview');
             }}
           />
         )}
@@ -3716,7 +3733,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           <div
             ref={floatingToolbarRef}
             className="absolute right-3 top-3 z-30"
-            onMouseEnter={() => setIsFloatingToolbarOpen(true)}
+            onMouseEnter={() => {
+              if (isMarkdown) return;
+              setIsFloatingToolbarOpen(true);
+            }}
             onMouseLeave={() => {
               if (toolbarDropdownOpenCountRef.current > 0) return;
               setIsFloatingToolbarOpen(false);
@@ -3725,23 +3745,51 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             {isFloatingToolbarOpen ? (
               renderFloatingFileControls()
             ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setIsFloatingToolbarOpen(true)}
-                      className="size-8 rounded-lg border border-[var(--interactive-border)] bg-[var(--surface-elevated)] p-0 text-muted-foreground shadow-sm hover:text-foreground"
-                      aria-label={t('filesView.editor.showControlsAria')}
-                      title={t('filesView.editor.controlsTitle')}
-                    >
-                      <Icon name="more-2-fill" className="size-4" />
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>{t('filesView.editor.controlsTitle')}</TooltipContent>
-              </Tooltip>
+              <div className="flex items-center gap-1">
+                {isMarkdown ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => saveMdViewMode(getMdViewMode() === 'preview' ? 'edit' : 'preview')}
+                          className={cn(
+                            'size-8 rounded-lg border border-[var(--interactive-border)] bg-[var(--surface-elevated)] p-0 shadow-sm transition-colors',
+                            getMdViewMode() === 'preview'
+                              ? 'bg-[var(--interactive-selection)] text-[var(--interactive-selection-foreground)] hover:bg-[var(--interactive-selection)]'
+                              : 'text-muted-foreground hover:text-foreground'
+                          )}
+                          aria-label={t(getMdViewMode() === 'preview' ? 'filesView.editor.switchToEditMode' : 'filesView.editor.switchToPreviewMode')}
+                          title={t(getMdViewMode() === 'preview' ? 'filesView.editor.switchToEditMode' : 'filesView.editor.switchToPreviewMode')}
+                        >
+                          <Icon name={getMdViewMode() === 'preview' ? 'eye' : 'eye-off'} className="size-4" />
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" sideOffset={6}>
+                      {t(getMdViewMode() === 'preview' ? 'filesView.editor.switchToEditMode' : 'filesView.editor.switchToPreviewMode')}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setIsFloatingToolbarOpen(true)}
+                        className="size-8 rounded-lg border border-[var(--interactive-border)] bg-[var(--surface-elevated)] p-0 text-muted-foreground shadow-sm hover:text-foreground"
+                        aria-label={t('filesView.editor.showControlsAria')}
+                        title={t('filesView.editor.controlsTitle')}
+                      >
+                        <Icon name="more-2-fill" className="size-4" />
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={6}>{t('filesView.editor.controlsTitle')}</TooltipContent>
+                </Tooltip>
+              </div>
             )}
           </div>
         )}

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1165,6 +1165,8 @@ export const dict = {
   'filesView.editor.enableLineWrap': 'Enable line wrap',
   'filesView.editor.findInFile': 'Find in file',
   'filesView.editor.goToLine': 'Go to line',
+  'filesView.editor.switchToEditMode': 'Switch to edit mode',
+  'filesView.editor.switchToPreviewMode': 'Switch to preview mode',
   'filesView.editor.switchToTextView': 'Switch to Text View',
   'filesView.editor.switchToTreeView': 'Switch to Tree View',
   'filesView.toast.copyFailed': 'Copy failed',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1131,6 +1131,8 @@ export const dict: Record<I18nKey, string> = {
   "filesView.editor.enableLineWrap": "Activar ajuste de línea",
   "filesView.editor.findInFile": "Buscar en el archivo",
   "filesView.editor.goToLine": "Ir a línea",
+  "filesView.editor.switchToEditMode": "Cambiar al modo de edición",
+  "filesView.editor.switchToPreviewMode": "Cambiar al modo de vista previa",
   "filesView.editor.switchToTextView": "Cambiar a vista de texto",
   "filesView.editor.switchToTreeView": "Cambiar a vista de árbol",
   "filesView.toast.copyFailed": "No se pudo copiar",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -995,6 +995,8 @@ export const dict = {
   'filesView.editor.enableLineWrap': 'Activer le retour à la ligne',
   'filesView.editor.findInFile': 'Rechercher dans le fichier',
   'filesView.editor.goToLine': 'Aller à la ligne',
+  'filesView.editor.switchToEditMode': 'Passer en mode édition',
+  'filesView.editor.switchToPreviewMode': 'Passer en mode aperçu',
   'filesView.editor.switchToTextView': 'Passer à l\'affichage texte',
   'filesView.editor.switchToTreeView': 'Passer à l\'arborescence',
   'filesView.toast.copyFailed': 'Échec de la copie',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -1161,6 +1161,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.enableLineWrap': '行の折り返しを有効にする',
   'filesView.editor.findInFile': 'ファイル内を検索',
   'filesView.editor.goToLine': '指定行に移動',
+  'filesView.editor.switchToEditMode': '編集モードに切り替え',
+  'filesView.editor.switchToPreviewMode': 'プレビューモードに切り替え',
   'filesView.editor.switchToTextView': 'テキストビューに切り替え',
   'filesView.editor.switchToTreeView': 'ツリービューに切り替え',
   'filesView.toast.copyFailed': 'コピーに失敗しました',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1168,6 +1168,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.enableLineWrap': '줄 바꿈 켜기',
   'filesView.editor.findInFile': '파일에서 찾기',
   'filesView.editor.goToLine': '줄로 이동',
+  'filesView.editor.switchToEditMode': '편집 모드로 전환',
+  'filesView.editor.switchToPreviewMode': '미리보기 모드로 전환',
   'filesView.editor.switchToTextView': '텍스트 보기로 전환',
   'filesView.editor.switchToTreeView': '트리 보기로 전환',
   'filesView.toast.copyFailed': '복사 실패',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1649,6 +1649,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.fullscreen': 'Pełny ekran',
   'filesView.editor.goToLine': 'Przejdź do linii',
   'filesView.editor.htmlPreviewTitle': 'Podgląd HTML',
+  'filesView.editor.switchToEditMode': 'Przełącz na tryb edycji',
+  'filesView.editor.switchToPreviewMode': 'Przełącz na tryb podglądu',
   'filesView.diagram.closeDiagramView': 'Zamknij widok diagramu',
   'filesView.diagram.saveDiagram': 'Zapisz diagram',
   'filesView.editor.imageAltFallback': 'Obraz',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1131,6 +1131,8 @@ export const dict: Record<I18nKey, string> = {
   "filesView.editor.enableLineWrap": "Ativar ajuste de linha",
   "filesView.editor.findInFile": "Buscar no arquivo",
   "filesView.editor.goToLine": "Ir para linha",
+  "filesView.editor.switchToEditMode": "Alternar para o modo de edição",
+  "filesView.editor.switchToPreviewMode": "Alternar para o modo de visualização",
   "filesView.editor.switchToTextView": "Alternar para visualização de texto",
   "filesView.editor.switchToTreeView": "Alternar para visualização em árvore",
   "filesView.toast.copyFailed": "Não foi possível copiar",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1131,6 +1131,8 @@ export const dict: Record<I18nKey, string> = {
   "filesView.editor.enableLineWrap": "Увімкнути перенос рядків",
   "filesView.editor.findInFile": "Знайти у файлі",
   "filesView.editor.goToLine": "Перейти до рядка",
+  "filesView.editor.switchToEditMode": "Перемкнутися в режим редагування",
+  "filesView.editor.switchToPreviewMode": "Перемкнутися в режим попереднього перегляду",
   "filesView.editor.switchToTextView": "Перемкнутися на текстовий перегляд",
   "filesView.editor.switchToTreeView": "Перейти до перегляду дерева",
   "filesView.toast.copyFailed": "Помилка копіювання",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1131,6 +1131,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.enableLineWrap': '开启自动换行',
   'filesView.editor.findInFile': '文件内查找',
   'filesView.editor.goToLine': '跳转到行',
+  'filesView.editor.switchToEditMode': '切换到编辑模式',
+  'filesView.editor.switchToPreviewMode': '切换到预览模式',
   'filesView.editor.switchToTextView': '切换到文本视图',
   'filesView.editor.switchToTreeView': '切换到树视图',
   'filesView.toast.copyFailed': '复制失败',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1142,6 +1142,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.enableLineWrap': '開啟自動換行',
   'filesView.editor.findInFile': '檔案內尋找',
   'filesView.editor.goToLine': '跳轉到行',
+  'filesView.editor.switchToEditMode': '切換到編輯模式',
+  'filesView.editor.switchToPreviewMode': '切換到預覽模式',
   'filesView.editor.switchToTextView': '切換到文字檢視',
   'filesView.editor.switchToTreeView': '切換到樹狀檢視',
   'filesView.toast.copyFailed': '複製失敗',


### PR DESCRIPTION
## Summary

- expose the markdown preview toggle as its own standalone icon next to the collapsed `...` toolbar button
- keep the toggle state visible by switching between `eye` and `eye-off`
- preserve the rest of the file controls behind the existing `...` button
- add localized tooltip / aria strings for switching between edit and preview modes

## Testing

- ran `bun run type-check:ui`
- ran `bun run lint:ui`
- manually verified in browser dev mode:
  - open a `.md` file in Files
  - confirm the preview toggle appears next to `...`
  - confirm clicking the toggle switches markdown between edit and preview
  - confirm the icon changes between `eye-off` and `eye`
  - confirm hovering the toggle does not auto-open the `...` controls
