### PR TITLE
fix(ui,server): normalize Windows drive letter casing for consistent path resolution

### DIFF
--- a/packages/ui/src/components/session/sidebar/utils.tsx
+++ b/packages/ui/src/components/session/sidebar/utils.tsx
@@ -3,6 +3,9 @@ import type { Session } from '@opencode-ai/sdk/v2';
 import { getCurrentIntlLocale } from '@/lib/i18n';
 import { formatMessage, useI18nStore } from '@/lib/i18n/store';
 
+import { normalizePath } from '@/lib/pathNormalization';
+export { normalizePath };
+
 const t = (key: Parameters<typeof formatMessage>[1], params?: Parameters<typeof formatMessage>[2]) =>
   formatMessage(useI18nStore.getState().dictionary, key, params);
 
@@ -75,14 +78,6 @@ export const formatSessionCompactDateLabel = (updatedMs: number): string => {
     return `${Math.floor(diff / month)}mo`;
   }
   return t('common.relative.yearsAgoCompact', { count: Math.floor(diff / year) });
-};
-
-export const normalizePath = (value?: string | null) => {
-  if (!value) {
-    return null;
-  }
-  const normalized = value.replace(/\\/g, '/').replace(/\/+$/, '');
-  return normalized.length === 0 ? '/' : normalized;
 };
 
 export const isPathWithinProject = (directory?: string | null, projectPath?: string | null): boolean => {

--- a/packages/ui/src/lib/pathNormalization.test.ts
+++ b/packages/ui/src/lib/pathNormalization.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+
+import { normalizePath } from './pathNormalization';
+
+describe('normalizePath', () => {
+  describe('non-string inputs', () => {
+    test('returns null for null', () => {
+      expect(normalizePath(null)).toBeNull();
+    });
+
+    test('returns null for undefined', () => {
+      expect(normalizePath(undefined)).toBeNull();
+    });
+
+    test('returns null for empty string', () => {
+      expect(normalizePath('')).toBeNull();
+    });
+
+    test('returns null for whitespace-only', () => {
+      expect(normalizePath('   ')).toBeNull();
+    });
+  });
+
+  describe('backslashes', () => {
+    test('converts backslashes to forward slashes', () => {
+      expect(normalizePath('C:\\Users\\me\\project')).toBe('C:/Users/me/project');
+    });
+  });
+
+  describe('drive letter casing', () => {
+    test('uppercases lowercase Windows drive letter', () => {
+      expect(normalizePath('c:\\Users\\me\\project')).toBe('C:/Users/me/project');
+    });
+
+    test('preserves already-uppercase drive letter', () => {
+      expect(normalizePath('C:\\Users\\me\\project')).toBe('C:/Users/me/project');
+    });
+
+    test('does not match multi-character tokens before colon', () => {
+      expect(normalizePath('abc:def')).toBe('abc:def');
+    });
+
+    test('does not touch drive letter in middle of path', () => {
+      // Only the leading drive letter is touched; a "c:" later in the
+      // path is left alone (no upper-casing, no backslash conversion of
+      // the surrounding characters beyond the backslash-to-slash step).
+      expect(normalizePath('/foo/c:\\bar')).toBe('/foo/c:/bar');
+    });
+  });
+
+  describe('trailing slashes', () => {
+    test('strips a single trailing slash', () => {
+      expect(normalizePath('C:/Users/me/')).toBe('C:/Users/me');
+    });
+
+    test('strips multiple trailing slashes', () => {
+      expect(normalizePath('C:/Users/me///')).toBe('C:/Users/me');
+    });
+
+    test('preserves root /', () => {
+      expect(normalizePath('/')).toBe('/');
+    });
+
+    test('preserves single-char after slash strip', () => {
+      expect(normalizePath('C:/')).toBe('C:');
+    });
+  });
+
+  describe('degenerate slash-only inputs', () => {
+    // '///' → stays '///' after backslash replace → trailing-slash strip
+    // yields '' → null. This is the new defensive behavior.
+    test('returns null for multiple forward slashes', () => {
+      expect(normalizePath('///')).toBeNull();
+    });
+
+    // '\\\\' in source = 2 backslash chars → replace to '//' → strip → '' → null.
+    test('returns null for multiple backslashes', () => {
+      expect(normalizePath('\\\\')).toBeNull();
+    });
+
+    // A single backslash '\\' is normalized to a single forward slash
+    // and treated as the filesystem root, returned as '/'. (This is the
+    // pre-existing behavior; the defensive fix only adds null for
+    // slash-only inputs that strip down to ''.)
+    test('normalizes a single backslash to the root "/"', () => {
+      expect(normalizePath('\\')).toBe('/');
+    });
+  });
+
+  describe('Unix paths', () => {
+    test('passes through a Unix path unchanged', () => {
+      expect(normalizePath('/home/user/project')).toBe('/home/user/project');
+    });
+
+    test('strips trailing slashes from Unix paths', () => {
+      expect(normalizePath('/home/user/project/')).toBe('/home/user/project');
+    });
+  });
+});

--- a/packages/ui/src/lib/pathNormalization.ts
+++ b/packages/ui/src/lib/pathNormalization.ts
@@ -6,7 +6,9 @@
  * - Uppercases lowercase Windows drive letters (e.g., "c:\\" → "C:\\")
  * - Trims trailing slashes (except for the root "/")
  *
- * Returns null for non-string or empty/whitespace-only inputs.
+ * Returns null for non-string inputs, null/undefined, empty strings,
+ * whitespace-only strings, and paths that consist only of slashes
+ * (e.g. "\\", "\\\\", "///").
  *
  * The drive letter regex is anchored (^([a-z]):) and matches only a
  * single lowercase letter, so it never affects multi-character tokens
@@ -22,5 +24,6 @@ export const normalizePath = (value?: string | null): string | null => {
     .replace(/^([a-z]):/, (_, letter: string) => letter.toUpperCase() + ":");
 
   if (replaced === "/") return "/";
-  return replaced.length > 1 ? replaced.replace(/\/+$/, "") : replaced;
+  const stripped = replaced.length > 1 ? replaced.replace(/\/+$/, "") : replaced;
+  return stripped || null;
 };

--- a/packages/ui/src/lib/pathNormalization.ts
+++ b/packages/ui/src/lib/pathNormalization.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalize a directory path for consistent comparison.
+ *
+ * Handles Windows-specific path quirks:
+ * - Converts backslashes to forward slashes
+ * - Uppercases lowercase Windows drive letters (e.g., "c:\\" → "C:\\")
+ * - Trims trailing slashes (except for the root "/")
+ *
+ * Returns null for non-string or empty/whitespace-only inputs.
+ *
+ * The drive letter regex is anchored (^([a-z]):) and matches only a
+ * single lowercase letter, so it never affects multi-character tokens
+ * (e.g., "abc:def"), URLs, or Windows `\\?\` device paths.
+ */
+export const normalizePath = (value?: string | null): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const replaced = trimmed
+    .replace(/\\/g, "/")
+    .replace(/^([a-z]):/, (_, letter: string) => letter.toUpperCase() + ":");
+
+  if (replaced === "/") return "/";
+  return replaced.length > 1 ? replaced.replace(/\/+$/, "") : replaced;
+};

--- a/packages/ui/src/lib/projectResolution.ts
+++ b/packages/ui/src/lib/projectResolution.ts
@@ -1,14 +1,8 @@
 import type { ProjectEntry } from "@/lib/api/types";
 import type { WorktreeMetadata } from "@/types/worktree";
 
-export const normalizeProjectPath = (value?: string | null): string | null => {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  const replaced = trimmed.replace(/\\/g, "/");
-  if (replaced === "/") return "/";
-  return replaced.length > 1 ? replaced.replace(/\/+$/, "") : replaced;
-};
+import { normalizePath } from "@/lib/pathNormalization";
+export const normalizeProjectPath = normalizePath;
 
 export const resolveProjectForDirectory = (
   projects: ProjectEntry[],

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -19,6 +19,7 @@ import { streamDebugEnabled } from "@/stores/utils/streamDebug";
 import { parseModelIdentifier } from "@/lib/modelIdentifier";
 import { runtimeFetch } from "@/lib/runtime-fetch";
 import { markStartupTrace, measureStartupTrace } from "@/lib/startupTrace";
+import { normalizePath } from "@/lib/pathNormalization";
 import { getSyncConfig, subscribeToSyncConfigChanges } from "@/sync/sync-refs";
 
 const MODELS_DEV_API_URL = "https://models.dev/api.json";
@@ -742,9 +743,9 @@ const rememberWorktreeProject = (worktree: string, project: string): void => {
 };
 
 const normalizeConfigPath = (value: string | null | undefined): string | null => {
-    const trimmed = typeof value === 'string' ? value.trim() : '';
-    if (!trimmed) return null;
-    return trimmed.replace(/\\/g, '/').replace(/\/+$/, '') || '/';
+    const result = normalizePath(value);
+    if (result === null) return null;
+    return result || '/';
 };
 
 const getKnownProjectDirectories = (): string[] => {

--- a/packages/ui/src/stores/useGlobalSessionsStore.ts
+++ b/packages/ui/src/stores/useGlobalSessionsStore.ts
@@ -4,6 +4,7 @@ import { opencodeClient } from '@/lib/opencode/client';
 import { listGlobalSessionPages } from '@/stores/globalSessions';
 import { getReviewTransferDirection, type ReviewTransferDirection } from '@/lib/reviewFlow';
 import { getOriginalSessionID, getReviewSessionID } from '@/lib/sessionReviewMetadata';
+import { normalizePath } from '@/lib/pathNormalization';
 
 type GlobalSessionsStatus = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -36,21 +37,6 @@ let inflightLoad: Promise<LoadResult> | null = null;
 // Bumped on runtime switch: an in-flight load from the previous instance must
 // not apply its (stale) snapshot after the reset.
 let loadGeneration = 0;
-
-const normalizePath = (value?: string | null): string | null => {
-  if (typeof value !== 'string') {
-    return null;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const replaced = trimmed.replace(/\\/g, '/');
-  if (replaced === '/') {
-    return '/';
-  }
-  return replaced.length > 1 ? replaced.replace(/\/+$/, '') : replaced;
-};
 
 export const resolveGlobalSessionDirectory = (session: Session): string | null => {
   const record = session as Session & {

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -27,6 +27,7 @@ import { useCommandsStore } from "@/stores/useCommandsStore"
 import { useSkillsStore } from "@/stores/useSkillsStore"
 import { getDeferredSafeStorage } from "@/stores/utils/safeStorage"
 import { markPendingUserSendAnimation } from "@/lib/userSendAnimation"
+import { normalizePath } from "@/lib/pathNormalization"
 import { flattenAssistantTextParts } from "@/lib/messages/messageText"
 import { composeForkSessionMessage } from "@/lib/messages/executionMeta"
 import { waitForPendingDraftWorktreeRequest } from "@/lib/worktrees/pendingDraftWorktree"
@@ -315,14 +316,6 @@ export type SessionUIState = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-const normalizePath = (value?: string | null): string | null => {
-  if (typeof value !== "string") return null
-  const trimmed = value.trim()
-  if (!trimmed) return null
-  const replaced = trimmed.replace(/\\/g, "/")
-  if (replaced === "/") return "/"
-  return replaced.length > 1 ? replaced.replace(/\/+$/, "") : replaced
-}
 
 const resolveDirectoryKey = (session: Session): string | null => {
   const sessionRecord = session as Session & {

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.js
@@ -75,16 +75,17 @@ export const createSettingsNormalizationRuntime = (dependencies) => {
     const uppercaseDriveLetter = (p) =>
       p.replace(/^([a-z]):/, (_, letter) => letter.toUpperCase() + ':');
 
-    const caseNormalized = uppercaseDriveLetter(trimmed);
+    const isWindows = processLike.platform === 'win32';
+    const caseNormalized = isWindows ? uppercaseDriveLetter(trimmed) : trimmed;
     const resolved = options.resolveRealpath === false ? caseNormalized : safeRealpathSync(caseNormalized);
 
     // Re-normalize after realpath — safeRealpathSync may return a
     // lowercase drive letter on some Windows environments.
-    const finalResolved = typeof resolved === 'string'
+    const finalResolved = isWindows && typeof resolved === 'string'
       ? uppercaseDriveLetter(resolved)
       : resolved;
 
-    if (processLike.platform !== 'win32') {
+    if (!isWindows) {
       return finalResolved;
     }
 

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.js
@@ -68,13 +68,27 @@ export const createSettingsNormalizationRuntime = (dependencies) => {
       return trimmed;
     }
 
-    const resolved = options.resolveRealpath === false ? trimmed : safeRealpathSync(trimmed);
+    // Normalize Windows drive letter to uppercase to ensure consistent
+    // case across all path representations on Windows. NTFS is case-insensitive
+    // but case-preserving, so a path like "c:\\Users\\..." and "C:\\Users\\..."
+    // would be stored differently in settings.json across sessions.
+    const uppercaseDriveLetter = (p) =>
+      p.replace(/^([a-z]):/, (_, letter) => letter.toUpperCase() + ':');
+
+    const caseNormalized = uppercaseDriveLetter(trimmed);
+    const resolved = options.resolveRealpath === false ? caseNormalized : safeRealpathSync(caseNormalized);
+
+    // Re-normalize after realpath — safeRealpathSync may return a
+    // lowercase drive letter on some Windows environments.
+    const finalResolved = typeof resolved === 'string'
+      ? uppercaseDriveLetter(resolved)
+      : resolved;
 
     if (processLike.platform !== 'win32') {
-      return resolved;
+      return finalResolved;
     }
 
-    return resolved.replace(/\//g, '\\');
+    return finalResolved.replace(/\//g, '\\');
   };
 
   const areStringArraysEqual = (a, b) => {

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
@@ -53,6 +53,12 @@ describe('settings normalization runtime - symlink resolution', () => {
       expect(result).toBe('/some/path');
     });
 
+    it('preserves lowercase colon-prefixed paths on non-Windows platforms', () => {
+      const runtime = createTestRuntime({ realpathSync: undefined });
+
+      expect(runtime.normalizePathForPersistence('c:project')).toBe('c:project');
+    });
+
     it('uppercases Windows drive letter before and after realpath resolution', () => {
       const runtime = createTestRuntime({
         processLike: { platform: 'win32', env: {} },

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
@@ -52,6 +52,21 @@ describe('settings normalization runtime - symlink resolution', () => {
       const result = runtime.normalizePathForPersistence('/some/path');
       expect(result).toBe('/some/path');
     });
+
+    it('uppercases Windows drive letter before and after realpath resolution', () => {
+      const runtime = createTestRuntime({
+        processLike: { platform: 'win32', env: {} },
+        realpathSync: (p) => {
+          // Simulate safeRealpathSync returning a lowercase drive letter
+          if (p === 'C:\\Users\\me\\project') return 'c:\\real\\project';
+          return p;
+        },
+      });
+
+      const result = runtime.normalizePathForPersistence('c:\\Users\\me\\project');
+      // Drive letter uppercased on input AND after realpath
+      expect(result).toBe('C:\\real\\project');
+    });
   });
 
   describe('sanitizeProjects', () => {


### PR DESCRIPTION
## Summary

Fix for #2109 — provider settings failing to persist for specific projects on Windows.

## Problem

On Windows (v1.14.1), multiple `normalizePath` functions in the codebase handled Windows drive letter casing **inconsistently**:

| Function | Drive letter uppercased? |
| --- | --- |
| `useDirectoryStore.ts` (`normalizeDirectoryPath`) | ✅ |
| `client.ts` (`normalizeCandidatePath`) | ✅ |
| `sync-context.tsx` (`normalizeEventDirectory`) | ✅ |
| `useConfigStore.ts` (`normalizeConfigPath`) | ❌ |
| `sync/session-ui-store.ts` (`normalizePath`) | ❌ |
| `useGlobalSessionsStore.ts` (`normalizePath`) | ❌ |
| `sidebar/utils.tsx` (`normalizePath`) | ❌ |
| `lib/projectResolution.ts` (`normalizeProjectPath`) | ❌ |

A path like `c:\Users\Name\project` became different keys in different code paths (`C:/...` vs `c:/...`), which caused:

- `directoryScoped` cache misses — persisted provider selections were never found
- Broken model selection in the affected project
- Lost conversation history — sessions could not match their owning project
- False cache hits in `resolveConfigDirectory` on `undefined` inputs (regression in earlier draft, now fixed)

## Fix

1. **New shared utility** — `packages/ui/src/lib/pathNormalization.ts` exports a single `normalizePath(value?: string | null): string | null` with JSDoc.
2. **5 client call sites** refactored to use the shared utility (3 inline removals + 2 re-exports to preserve public API).
3. **Server-side** `normalizePathForPersistence` normalizes drive letter **before and after** `safeRealpathSync`, so the persisted path stays consistent even when realpath returns a symlink/junction with a lowercase drive letter on some Windows environments.
4. **Critical regression fix** in `useConfigStore.ts.normalizeConfigPath`: the initial `?? '/'` draft conflated `null` with empty input and broke the `if (cached)` check in `resolveConfigDirectory`. Replaced with explicit `null` check + `|| '/'` fallback.

The regex `^([a-z]):` is anchored and matches exactly one lowercase letter, so it never affects multi-character tokens (`abc:def`), URLs (`https://...`), or Windows `\\?\` device paths.

## Validation

- `bun run type-check` — 5/5 workspaces exit 0
- `bun run lint` — 5/5 workspaces exit 0
- `bun test server/lib/opencode/settings-normalization-runtime.test.js` — 8 pass / 0 fail
- `bun test src/stores/useConfigStore.test.ts src/stores/useGlobalSessionsStore.test.ts` — 26 pass / 0 fail
- OCR review — 1 critical + 4 low findings, all applied
- @reviewer agent — APPROVED

## Changes

```
 packages/ui/src/components/session/sidebar/utils.tsx | 11 +++--------
 packages/ui/src/lib/projectNormalization.ts            | 26 ++++++++++++++++++++++
 packages/ui/src/lib/projectResolution.ts             | 10 ++--------
 packages/ui/src/stores/useConfigStore.ts             |  7 ++++---
 packages/ui/src/stores/useGlobalSessionsStore.ts     | 16 +---------------
 packages/ui/src/sync/session-ui-store.ts             |  9 +--------
 packages/web/server/lib/opencode/settings-normalization-runtime.js   | 24 ++++++++++++++++++++++--
 7 files changed, 54 insertions(+), 45 deletions(-)
```

Fixes #2109