### PR TITLE
feat(chat): add hover transcript outline

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -22,6 +22,8 @@ import { useChatTimelineController } from './hooks/useChatTimelineController';
 import { TimelineDialog } from './TimelineDialog';
 import { useChatTurnNavigation } from './hooks/useChatTurnNavigation';
 import { useChatSurfaceMode } from './useChatSurfaceMode';
+import { TurnHoverOutline } from './TurnHoverOutline';
+import { buildTurnOutlineItems, type TurnOutlineItem } from './turnHoverOutlineItems';
 import { useDeviceInfo } from '@/lib/device';
 import { Button } from '@/components/ui/button';
 import { OverlayScrollbar } from '@/components/ui/OverlayScrollbar';
@@ -161,6 +163,11 @@ type ChatViewportProps = {
     isProgrammaticFollowActive: boolean;
     showLoadOlderButton: boolean;
     onLoadOlder: () => void;
+    isMobileRuntime: boolean;
+    turnOutlineItems: TurnOutlineItem[];
+    activeTurnId: string | null;
+    onJumpTurn: (turnId: string) => void;
+    onOpenTimeline: () => void;
 };
 
 const ChatViewport = React.memo(({
@@ -187,6 +194,11 @@ const ChatViewport = React.memo(({
     isProgrammaticFollowActive,
     showLoadOlderButton,
     onLoadOlder,
+    isMobileRuntime,
+    turnOutlineItems,
+    activeTurnId,
+    onJumpTurn,
+    onOpenTimeline,
 }: ChatViewportProps) => {
     const { t } = useI18n();
     const focusScrollContainer = React.useCallback((event: React.MouseEvent<HTMLElement>) => {
@@ -277,6 +289,16 @@ const ChatViewport = React.memo(({
                     </div>
                 </ScrollShadow>
                 <OverlayScrollbar containerRef={scrollRef} suppressVisibility={isProgrammaticFollowActive} userIntentOnly observeMutations={false} />
+                {!isMobileRuntime && turnOutlineItems.length > 1 && (
+                    <div className="hidden lg:block absolute left-3 top-[60%] -translate-y-1/2 z-10">
+                        <TurnHoverOutline
+                            items={turnOutlineItems}
+                            activeTurnId={activeTurnId}
+                            onJumpTurn={onJumpTurn}
+                            onOpenTimeline={onOpenTimeline}
+                        />
+                    </div>
+                )}
             </div>
         </div>
     );
@@ -303,7 +325,12 @@ const ChatViewport = React.memo(({
         && prev.sessionPermissions === next.sessionPermissions
         && prev.isProgrammaticFollowActive === next.isProgrammaticFollowActive
         && prev.showLoadOlderButton === next.showLoadOlderButton
-        && prev.onLoadOlder === next.onLoadOlder;
+        && prev.onLoadOlder === next.onLoadOlder
+        && prev.isMobileRuntime === next.isMobileRuntime
+        && prev.turnOutlineItems === next.turnOutlineItems
+        && prev.activeTurnId === next.activeTurnId
+        && prev.onJumpTurn === next.onJumpTurn
+        && prev.onOpenTimeline === next.onOpenTimeline;
 });
 
 ChatViewport.displayName = 'ChatViewport';
@@ -636,7 +663,8 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
     }, [goToBottom]);
     // Mobile loads older history via an explicit top button instead of a
     // scroll-position trigger (see handleHistoryScroll in the controller).
-    const showLoadOlderButton = isMobileSurfaceRuntime()
+    const isMobileRuntime = isMobileSurfaceRuntime();
+    const showLoadOlderButton = isMobileRuntime
         && timelineController.historySignals.canLoadEarlier;
     const timelineLoadEarlier = timelineController.loadEarlier;
     const handleLoadOlderClick = React.useCallback(() => {
@@ -662,6 +690,22 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
         scrollToMessage: timelineController.scrollToMessage,
         resumeToBottom: timelineController.resumeToBottomInstant,
     });
+    const { scrollToTurnId } = navigation;
+    const previousTurnOutlineItemsRef = React.useRef<TurnOutlineItem[] | null>(null);
+    const turnOutlineItems = React.useMemo(() => buildTurnOutlineItems(
+        timelineController.renderedMessages,
+        timelineController.turnWindowModel,
+        previousTurnOutlineItemsRef.current ?? undefined,
+    ), [timelineController.renderedMessages, timelineController.turnWindowModel]);
+    React.useEffect(() => {
+        previousTurnOutlineItemsRef.current = turnOutlineItems;
+    }, [turnOutlineItems]);
+    const handleOpenTimeline = React.useCallback(() => {
+        setTimelineDialogOpen(true);
+    }, [setTimelineDialogOpen]);
+    const handleOutlineJumpTurn = React.useCallback((turnId: string) => {
+        void scrollToTurnId(turnId);
+    }, [scrollToTurnId]);
 
     React.useEffect(() => {
         if (typeof window === 'undefined' || !currentSessionId) return;
@@ -968,6 +1012,11 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
                 isProgrammaticFollowActive={isFollowingProgrammatically}
                 showLoadOlderButton={showLoadOlderButton}
                 onLoadOlder={handleLoadOlderClick}
+                isMobileRuntime={isMobileRuntime}
+                turnOutlineItems={turnOutlineItems}
+                activeTurnId={timelineController.activeTurnId}
+                onJumpTurn={handleOutlineJumpTurn}
+                onOpenTimeline={handleOpenTimeline}
             />
 
             <div

--- a/packages/ui/src/components/chat/TimelineDialog.tsx
+++ b/packages/ui/src/components/chat/TimelineDialog.tsx
@@ -12,10 +12,10 @@ import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSessionMessageRecords } from '@/sync/sync-context';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Icon } from "@/components/icon/Icon";
-import type { Part } from '@opencode-ai/sdk/v2';
 import { getCurrentIntlLocale, useI18n } from '@/lib/i18n';
 import { useDeviceInfo } from '@/lib/device';
 import { cn } from '@/lib/utils';
+import { getMessageFullText, getMessagePreview, getSearchSnippet } from './lib/messagePreview';
 
 interface TimelineDialogProps {
     open: boolean;
@@ -84,7 +84,7 @@ export const TimelineDialog: React.FC<TimelineDialogProps> = ({
 
         const query = trimmedQuery.toLowerCase();
         return userMessages.filter(({ message }) => {
-            const fullText = getFullText(message.parts).toLowerCase();
+            const fullText = getMessageFullText(message.parts).toLowerCase();
             return fullText.includes(query);
         });
     }, [userMessages, searchQuery]);
@@ -285,7 +285,7 @@ export const TimelineDialog: React.FC<TimelineDialogProps> = ({
                             const isSelected = index === selectedIndex;
 
                             const snippet = searchQuery.trim()
-                                ? getSearchSnippet(getFullText(message.parts), searchQuery)
+                                ? getSearchSnippet(getMessageFullText(message.parts), searchQuery)
                                 : null;
 
                             return (
@@ -416,27 +416,3 @@ export const TimelineDialog: React.FC<TimelineDialogProps> = ({
         </Dialog>
     );
 };
-
-function getFullText(parts: Part[]): string {
-    return parts
-        .filter((p): p is Part & { type: 'text'; text: string } => p.type === 'text' && typeof p.text === 'string')
-        .map((p) => p.text)
-        .join('\n');
-}
-
-function getMessagePreview(parts: Part[]): string {
-    const full = getFullText(parts);
-    const singleLine = full.replace(/\n/g, ' ');
-    return singleLine.length > 80 ? singleLine.slice(0, 80) : singleLine;
-}
-
-function getSearchSnippet(text: string, query: string, contextChars: number = 30): string | null {
-    const lowerText = text.toLowerCase();
-    const lowerQuery = query.toLowerCase();
-    const matchIndex = lowerText.indexOf(lowerQuery);
-    if (matchIndex === -1) return null;
-
-    const start = Math.max(0, matchIndex - contextChars);
-    const end = Math.min(text.length, matchIndex + query.length + contextChars);
-    return `${start > 0 ? '…' : ''}${text.slice(start, end).replace(/\n/g, ' ')}${end < text.length ? '…' : ''}`;
-}

--- a/packages/ui/src/components/chat/TurnHoverOutline.test.ts
+++ b/packages/ui/src/components/chat/TurnHoverOutline.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    buildTurnOutlineItems,
+    getRailTurnOutlineItems,
+    type TurnOutlineItem,
+} from './turnHoverOutlineItems';
+import type { ChatMessageEntry } from './lib/turns/types';
+import type { TurnWindowModel } from './lib/turns/windowTurns';
+
+const makeItems = (count: number): TurnOutlineItem[] =>
+    Array.from({ length: count }, (_, index) => ({
+        turnId: `turn-${index + 1}`,
+        preview: `Turn ${index + 1}`,
+    }));
+
+describe('TurnHoverOutline item selection', () => {
+    test('builds outline items in authoritative turn order from user messages', () => {
+        const messages = [
+            {
+                info: {
+                    id: 'turn-1',
+                    sessionID: 'session-1',
+                    role: 'user',
+                    time: { created: 20 },
+                    agent: 'build',
+                    model: { providerID: 'provider-1', modelID: 'model-1' },
+                },
+                parts: [{
+                    id: 'part-1',
+                    sessionID: 'session-1',
+                    messageID: 'turn-1',
+                    type: 'text',
+                    text: 'First\nquestion',
+                }],
+            },
+            {
+                info: {
+                    id: 'assistant-1',
+                    sessionID: 'session-1',
+                    role: 'assistant',
+                    parentID: 'turn-1',
+                    time: { created: 21 },
+                    modelID: 'model-1',
+                    providerID: 'provider-1',
+                    mode: 'build',
+                    agent: 'build',
+                    path: { cwd: '/workspace', root: '/workspace' },
+                    cost: 0,
+                    tokens: {
+                        input: 0,
+                        output: 0,
+                        reasoning: 0,
+                        cache: { read: 0, write: 0 },
+                    },
+                },
+                parts: [{
+                    id: 'part-2',
+                    sessionID: 'session-1',
+                    messageID: 'assistant-1',
+                    type: 'text',
+                    text: 'Answer',
+                }],
+            },
+            {
+                info: {
+                    id: 'turn-2',
+                    sessionID: 'session-1',
+                    role: 'user',
+                    time: { created: 10 },
+                    agent: 'build',
+                    model: { providerID: 'provider-1', modelID: 'model-1' },
+                },
+                parts: [{
+                    id: 'part-3',
+                    sessionID: 'session-1',
+                    messageID: 'turn-2',
+                    type: 'text',
+                    text: 'Second question',
+                }],
+            },
+        ] satisfies ChatMessageEntry[];
+        const turnWindowModel = {
+            turnIds: ['turn-1', 'turn-2'],
+            turnMessageStartIndexes: [0, 2],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+
+        expect(buildTurnOutlineItems(messages, turnWindowModel)).toEqual([
+            { turnId: 'turn-1', preview: 'First question' },
+            { turnId: 'turn-2', preview: 'Second question' },
+        ]);
+    });
+
+    test('returns the previous array for an assistant-only replacement', () => {
+        const messages = [
+            {
+                info: { id: 'turn-1', role: 'user' },
+                parts: [{ type: 'text', text: 'First question' }],
+            },
+            {
+                info: { id: 'assistant-1', role: 'assistant' },
+                parts: [{ type: 'text', text: 'Streaming response' }],
+            },
+        ] as ChatMessageEntry[];
+        const updatedMessages = [
+            messages[0],
+            { ...messages[1], parts: [{ type: 'text', text: 'Updated response' }] },
+        ] as ChatMessageEntry[];
+        const turnWindowModel = {
+            turnIds: ['turn-1'],
+            turnMessageStartIndexes: [0],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+        const initialItems = buildTurnOutlineItems(messages, turnWindowModel);
+        const updatedItems = buildTurnOutlineItems(
+            updatedMessages,
+            turnWindowModel,
+            initialItems,
+        );
+
+        expect(updatedItems).toBe(initialItems);
+        expect(updatedItems[0]).toBe(initialItems[0]);
+    });
+
+    test('replaces only the item whose user preview changes', () => {
+        const messages = [
+            {
+                info: { id: 'turn-1', role: 'user' },
+                parts: [{ type: 'text', text: 'First question' }],
+            },
+            {
+                info: { id: 'turn-2', role: 'user' },
+                parts: [{ type: 'text', text: 'Second question' }],
+            },
+        ] as ChatMessageEntry[];
+        const turnWindowModel = {
+            turnIds: ['turn-1', 'turn-2'],
+            turnMessageStartIndexes: [0, 1],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+        const initialItems = buildTurnOutlineItems(messages, turnWindowModel);
+        const replacementMessages = [{
+            ...messages[0],
+            parts: [{ type: 'text', text: 'Confirmed question' }],
+        }, messages[1]] as ChatMessageEntry[];
+        const replacedItems = buildTurnOutlineItems(
+            replacementMessages,
+            turnWindowModel,
+            initialItems,
+        );
+
+        expect(replacedItems).not.toBe(initialItems);
+        expect(replacedItems[0]).not.toBe(initialItems[0]);
+        expect(replacedItems[1]).toBe(initialItems[1]);
+    });
+
+    test('preserves existing item identity when a turn is appended', () => {
+        const messages = [{
+            info: { id: 'turn-1', role: 'user' },
+            parts: [{ type: 'text', text: 'First question' }],
+        }] as ChatMessageEntry[];
+        const turnWindowModel = {
+            turnIds: ['turn-1'],
+            turnMessageStartIndexes: [0],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+        const initialItems = buildTurnOutlineItems(messages, turnWindowModel);
+        const appendedMessages = [...messages, {
+            info: { id: 'turn-2', role: 'user' },
+            parts: [{ type: 'text', text: 'Second question' }],
+        }] as ChatMessageEntry[];
+        const appendedModel = {
+            turnIds: ['turn-1', 'turn-2'],
+            turnMessageStartIndexes: [0, 1],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+        const appendedItems = buildTurnOutlineItems(
+            appendedMessages,
+            appendedModel,
+            initialItems,
+        );
+
+        expect(appendedItems).not.toBe(initialItems);
+        expect(appendedItems[0]).toBe(initialItems[0]);
+        expect(appendedItems).toEqual([
+            { turnId: 'turn-1', preview: 'First question' },
+            { turnId: 'turn-2', preview: 'Second question' },
+        ]);
+    });
+
+    test('preserves shifted item identity when history is prepended', () => {
+        const messages = [{
+            info: { id: 'turn-1', role: 'user' },
+            parts: [{ type: 'text', text: 'First question' }],
+        }] as ChatMessageEntry[];
+        const turnWindowModel = {
+            turnIds: ['turn-1'],
+            turnMessageStartIndexes: [0],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+        const initialItems = buildTurnOutlineItems(messages, turnWindowModel);
+        const historyMessages = [{
+            info: { id: 'turn-0', role: 'user' },
+            parts: [{ type: 'text', text: 'Earlier question' }],
+        }, ...messages] as ChatMessageEntry[];
+        const historyModel = {
+            turnIds: ['turn-0', 'turn-1'],
+            turnMessageStartIndexes: [0, 1],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+        const historyItems = buildTurnOutlineItems(
+            historyMessages,
+            historyModel,
+            initialItems,
+        );
+
+        expect(historyItems).not.toBe(initialItems);
+        expect(historyItems[1]).toBe(initialItems[0]);
+    });
+
+    test('returns current authoritative order while reusing moved item identities', () => {
+        const messages = [{
+            info: { id: 'turn-1', role: 'user' },
+            parts: [{ type: 'text', text: 'First question' }],
+        }, {
+            info: { id: 'turn-2', role: 'user' },
+            parts: [{ type: 'text', text: 'Second question' }],
+        }] as ChatMessageEntry[];
+        const initialModel = {
+            turnIds: ['turn-1', 'turn-2'],
+            turnMessageStartIndexes: [0, 1],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+        const reorderedModel = {
+            turnIds: ['turn-2', 'turn-1'],
+            turnMessageStartIndexes: [1, 0],
+        } satisfies Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>;
+        const initialItems = buildTurnOutlineItems(messages, initialModel);
+        const reorderedItems = buildTurnOutlineItems(messages, reorderedModel, initialItems);
+
+        expect(reorderedItems).not.toBe(initialItems);
+        expect(reorderedItems.map((item) => item.turnId)).toEqual(['turn-2', 'turn-1']);
+        expect(reorderedItems[0]).toBe(initialItems[1]);
+        expect(reorderedItems[1]).toBe(initialItems[0]);
+    });
+
+    test('keeps every rail marker when there are at most 20 turns', () => {
+        const items = makeItems(20);
+
+        expect(getRailTurnOutlineItems(items, 'turn-17')).toEqual(items);
+    });
+
+    test('samples long sessions to at most 20 source-ordered markers including boundaries and active turn', () => {
+        const items = makeItems(101);
+        const railItems = getRailTurnOutlineItems(items, 'turn-52');
+        const ids = railItems.map((item) => item.turnId);
+
+        expect(railItems).toHaveLength(20);
+        expect(ids).toEqual([...ids].sort((left, right) => Number(left.slice(5)) - Number(right.slice(5))));
+        expect(ids).toContain('turn-1');
+        expect(ids).toContain('turn-52');
+        expect(ids).toContain('turn-101');
+    });
+
+    test('broadly spans a long conversation rather than selecting only a few anchor turns', () => {
+        const items = makeItems(101);
+        const railItems = getRailTurnOutlineItems(items, 'turn-2');
+        const indexes = railItems.map((item) => Number(item.turnId.slice(5)) - 1);
+
+        expect(indexes.some((index) => index >= 20 && index < 40)).toBe(true);
+        expect(indexes.some((index) => index >= 40 && index < 60)).toBe(true);
+        expect(indexes.some((index) => index >= 60 && index < 80)).toBe(true);
+    });
+
+});

--- a/packages/ui/src/components/chat/TurnHoverOutline.tsx
+++ b/packages/ui/src/components/chat/TurnHoverOutline.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Popover } from '@base-ui/react/popover';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useI18n } from '@/lib/i18n';
+import { changedFilesPopoverClassName, changedFilesPopoverStyle } from './changedFilesPopover';
+import {
+    getRailTurnOutlineItems,
+    type TurnOutlineItem,
+} from './turnHoverOutlineItems';
+
+type TurnHoverOutlineProps = {
+    items: TurnOutlineItem[];
+    activeTurnId: string | null;
+    onJumpTurn: (turnId: string) => void;
+    onOpenTimeline: () => void;
+};
+
+const CLOSE_DELAY_MS = 120;
+
+export const TurnHoverOutline = React.memo(({
+    items,
+    activeTurnId,
+    onJumpTurn,
+    onOpenTimeline,
+}: TurnHoverOutlineProps) => {
+    const { t } = useI18n();
+    const railItems = React.useMemo(() => getRailTurnOutlineItems(items, activeTurnId), [items, activeTurnId]);
+
+    if (items.length === 0) return null;
+
+    return (
+        <Popover.Root>
+            <Popover.Trigger
+                openOnHover
+                delay={0}
+                closeDelay={CLOSE_DELAY_MS}
+                render={
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        type="button"
+                        aria-label={t('chat.turnOutline.open')}
+                        className="flex h-24 w-9 flex-col items-center justify-center gap-[2.5px] rounded-md [corner-shape:round] supports-[corner-shape:squircle]:rounded-md px-0 normal-case font-normal tracking-normal text-inherit bg-[var(--surface-background)]/95 hover:bg-[var(--interactive-hover)] focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-[var(--interactive-focus-ring)]"
+                    >
+                        {railItems.map((item) => (
+                            <span
+                                key={item.turnId}
+                                data-current={item.turnId === activeTurnId}
+                                className="h-0.5 w-4 rounded-full bg-[color-mix(in_srgb,var(--surface-muted-foreground)_40%,transparent)] data-[current=true]:bg-[var(--surface-foreground)]"
+                            />
+                        ))}
+                    </Button>
+                }
+            />
+            <Popover.Portal>
+                <Popover.Positioner side="right" align="center" sideOffset={8} collisionPadding={8}>
+                    <Popover.Popup
+                        style={changedFilesPopoverStyle}
+                        className={cn(
+                            changedFilesPopoverClassName,
+                            'flex w-64 flex-col gap-1 rounded-2xl p-1 transition-all duration-150 ease-out',
+                            'data-[starting-style]:opacity-0 data-[starting-style]:scale-95 data-[ending-style]:opacity-0 data-[ending-style]:scale-95',
+                        )}
+                    >
+                        <Popover.Title className="sr-only">{t('chat.turnOutline.open')}</Popover.Title>
+                        <div className="max-h-80 overflow-y-auto">
+                            {items.map((item) => (
+                                <Popover.Close
+                                    key={item.turnId}
+                                    render={
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            type="button"
+                                            aria-current={item.turnId === activeTurnId ? 'location' : undefined}
+                                            className="w-full justify-start rounded-xl [corner-shape:round] supports-[corner-shape:squircle]:rounded-xl px-2 text-left typography-small normal-case font-normal tracking-normal text-inherit hover:bg-[var(--interactive-hover)] hover:text-inherit focus-visible:border-transparent focus-visible:ring-0 focus-visible:bg-[var(--interactive-hover)] aria-current:bg-[var(--interactive-selection)] aria-current:text-[var(--interactive-selection-foreground)] aria-current:hover:text-[var(--interactive-selection-foreground)]"
+                                            onClick={() => onJumpTurn(item.turnId)}
+                                        >
+                                            <span className="line-clamp-1 min-w-0">
+                                                {item.preview || t('chat.timeline.noTextContent')}
+                                            </span>
+                                        </Button>
+                                    }
+                                />
+                            ))}
+                        </div>
+                        <Popover.Close
+                            render={
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    type="button"
+                                    className="mt-0.5 h-auto min-h-7 justify-start rounded-xl [corner-shape:round] supports-[corner-shape:squircle]:rounded-xl px-2 py-1.5 text-left typography-meta normal-case font-normal tracking-normal text-[var(--surface-muted-foreground)] hover:bg-[var(--interactive-hover)] hover:text-[var(--surface-foreground)] focus-visible:border-transparent focus-visible:ring-0 focus-visible:bg-[var(--interactive-hover)]"
+                                    onClick={onOpenTimeline}
+                                >
+                                    {t('chat.turnOutline.openTimeline')}
+                                </Button>
+                            }
+                        />
+                    </Popover.Popup>
+                </Popover.Positioner>
+            </Popover.Portal>
+        </Popover.Root>
+    );
+});
+
+TurnHoverOutline.displayName = 'TurnHoverOutline';

--- a/packages/ui/src/components/chat/lib/messagePreview.test.ts
+++ b/packages/ui/src/components/chat/lib/messagePreview.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import type { Part } from '@opencode-ai/sdk/v2';
+import { getMessageFullText, getMessagePreview, getSearchSnippet } from './messagePreview';
+
+describe('messagePreview', () => {
+    test('joins text parts with newlines and ignores non-text parts', () => {
+        const parts = [
+            { type: 'text', text: 'First line' },
+            { type: 'file', url: 'file:///tmp/example.txt' },
+            { type: 'text', text: 'Second line' },
+            { type: 'text' },
+        ] as Part[];
+
+        expect(getMessageFullText(parts)).toBe('First line\nSecond line');
+    });
+
+    test('creates a single-line preview and truncates at provided max length without adding ellipsis', () => {
+        const parts = [
+            { type: 'text', text: 'Hello\nworld from OpenChamber' },
+        ] as Part[];
+
+        expect(getMessagePreview(parts, 11)).toBe('Hello world');
+    });
+
+    test('creates a search snippet with leading/trailing ellipses around a match', () => {
+        const text = '0123456789 target abcdefghij';
+
+        expect(getSearchSnippet(text, 'target', 3)).toBe('…89 target ab…');
+    });
+});

--- a/packages/ui/src/components/chat/lib/messagePreview.ts
+++ b/packages/ui/src/components/chat/lib/messagePreview.ts
@@ -1,0 +1,25 @@
+import type { Part } from '@opencode-ai/sdk/v2';
+
+export function getMessageFullText(parts: Part[]): string {
+    return parts
+        .filter((part): part is Part & { type: 'text'; text: string } => part.type === 'text' && typeof part.text === 'string')
+        .map((part) => part.text)
+        .join('\n');
+}
+
+export function getMessagePreview(parts: Part[], maxLength = 80): string {
+    const full = getMessageFullText(parts);
+    const singleLine = full.replace(/\n/g, ' ');
+    return singleLine.length > maxLength ? singleLine.slice(0, maxLength) : singleLine;
+}
+
+export function getSearchSnippet(text: string, query: string, contextChars = 30): string | null {
+    const lowerText = text.toLowerCase();
+    const lowerQuery = query.toLowerCase();
+    const matchIndex = lowerText.indexOf(lowerQuery);
+    if (matchIndex === -1) return null;
+
+    const start = Math.max(0, matchIndex - contextChars);
+    const end = Math.min(text.length, matchIndex + query.length + contextChars);
+    return `${start > 0 ? '…' : ''}${text.slice(start, end).replace(/\n/g, ' ')}${end < text.length ? '…' : ''}`;
+}

--- a/packages/ui/src/components/chat/turnHoverOutlineItems.ts
+++ b/packages/ui/src/components/chat/turnHoverOutlineItems.ts
@@ -1,0 +1,66 @@
+import { getMessagePreview } from './lib/messagePreview';
+import type { ChatMessageEntry } from './lib/turns/types';
+import type { TurnWindowModel } from './lib/turns/windowTurns';
+
+export type TurnOutlineItem = {
+    turnId: string;
+    preview: string;
+};
+
+const MAX_RAIL_MARKERS = 20;
+
+export function buildTurnOutlineItems(
+    messages: ChatMessageEntry[],
+    turnWindowModel: Pick<TurnWindowModel, 'turnIds' | 'turnMessageStartIndexes'>,
+    previousItems?: TurnOutlineItem[],
+): TurnOutlineItem[] {
+    const previousItemsByTurnId = previousItems
+        ? new Map(previousItems.map((item) => [item.turnId, item]))
+        : undefined;
+    let unchanged = previousItems?.length === turnWindowModel.turnIds.length;
+    const items = turnWindowModel.turnIds.flatMap((turnId, turnIndex) => {
+        const messageIndex = turnWindowModel.turnMessageStartIndexes[turnIndex];
+        const message = typeof messageIndex === 'number' ? messages[messageIndex] : undefined;
+        if (!message || message.info.id !== turnId) {
+            unchanged = false;
+            return [];
+        }
+
+        const preview = getMessagePreview(message.parts);
+        const previousItem = previousItemsByTurnId?.get(turnId);
+        if (previousItem?.preview === preview) {
+            if (previousItems?.[turnIndex] !== previousItem) unchanged = false;
+            return [previousItem];
+        }
+
+        unchanged = false;
+        return [{ turnId, preview }];
+    });
+
+    return unchanged && previousItems ? previousItems : items;
+}
+
+export function getRailTurnOutlineItems(
+    items: TurnOutlineItem[],
+    activeTurnId: string | null,
+): TurnOutlineItem[] {
+    if (items.length <= MAX_RAIL_MARKERS) return items;
+
+    const activeIndex = activeTurnId ? items.findIndex((item) => item.turnId === activeTurnId) : -1;
+    const indexes = Array.from(
+        { length: MAX_RAIL_MARKERS },
+        (_, markerIndex) => Math.round(markerIndex * (items.length - 1) / (MAX_RAIL_MARKERS - 1)),
+    );
+
+    if (activeIndex > 0 && activeIndex < items.length - 1 && !indexes.includes(activeIndex)) {
+        let replacementIndex = 1;
+        for (let index = 2; index < indexes.length - 1; index += 1) {
+            if (Math.abs(indexes[index] - activeIndex) < Math.abs(indexes[replacementIndex] - activeIndex)) {
+                replacementIndex = index;
+            }
+        }
+        indexes[replacementIndex] = activeIndex;
+    }
+
+    return [...new Set(indexes)].sort((left, right) => left - right).map((index) => items[index]);
+}

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1753,6 +1753,8 @@ export const dict = {
   'chat.draftStarters.sectionSkills': 'Skills',
   'chat.draftStarters.remove': 'Remove',
   'chat.scrollToBottom.aria': 'Scroll to bottom',
+  'chat.turnOutline.open': 'Open transcript outline',
+  'chat.turnOutline.openTimeline': 'Open full timeline',
   'chat.timeline.relative.justNow': 'just now',
   'chat.timeline.relative.minutesAgo': '{count}m ago',
   'chat.timeline.relative.hoursAgo': '{count}h ago',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1731,6 +1731,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.draftStarters.sectionSkills": "Skills",
   "chat.draftStarters.remove": "Remove",
   "chat.scrollToBottom.aria": "Ir al final",
+  "chat.turnOutline.open": "Abrir esquema de transcripción",
+  "chat.turnOutline.openTimeline": "Abrir línea de tiempo completa",
   "chat.timeline.relative.justNow": "ahora mismo",
   "chat.timeline.relative.minutesAgo": "hace {count}m",
   "chat.timeline.relative.hoursAgo": "hace {count}h",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1559,6 +1559,8 @@ export const dict = {
   'chat.emptyState.draftTitle': 'Sur quoi travaillons-nous ?',
   'chat.emptyState.draftTitleWithProject': 'Sur quoi travaillons-nous dans {project} ?',
   'chat.scrollToBottom.aria': 'Faire défiler vers le bas',
+  'chat.turnOutline.open': 'Ouvrir le plan de transcription',
+  'chat.turnOutline.openTimeline': 'Ouvrir la chronologie complète',
   'chat.timeline.relative.justNow': 'à l’instant',
   'chat.timeline.relative.minutesAgo': 'il y a {count} min',
   'chat.timeline.relative.hoursAgo': 'il y a {count} h',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -1749,6 +1749,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.draftStarters.sectionSkills': 'スキル',
   'chat.draftStarters.remove': '削除',
   'chat.scrollToBottom.aria': '一番下にスクロール',
+  'chat.turnOutline.open': '文字起こしアウトラインを開く',
+  'chat.turnOutline.openTimeline': '完全なタイムラインを開く',
   'chat.timeline.relative.justNow': 'たった今',
   'chat.timeline.relative.minutesAgo': '{count}分前',
   'chat.timeline.relative.hoursAgo': '{count}時間前',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1755,6 +1755,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.draftStarters.sectionSkills': 'Skills',
   'chat.draftStarters.remove': 'Remove',
   'chat.scrollToBottom.aria': '맨 아래로 스크롤',
+  'chat.turnOutline.open': '대화 개요 열기',
+  'chat.turnOutline.openTimeline': '전체 타임라인 열기',
   'chat.timeline.relative.justNow': '방금 전',
   'chat.timeline.relative.minutesAgo': '{count}분 전',
   'chat.timeline.relative.hoursAgo': '{count}시간 전',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -650,6 +650,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.draftStarters.sectionSkills': 'Skills',
   'chat.draftStarters.remove': 'Remove',
   'chat.scrollToBottom.aria': 'Przewiń na dół',
+  'chat.turnOutline.open': 'Otwórz zarys transkrypcji',
+  'chat.turnOutline.openTimeline': 'Otwórz pełną oś czasu',
   'chat.timeline.relative.justNow': 'przed chwilą',
   'chat.timeline.relative.minutesAgo': '{count}m temu',
   'chat.timeline.relative.hoursAgo': '{count}h temu',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1731,6 +1731,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.draftStarters.sectionSkills": "Skills",
   "chat.draftStarters.remove": "Remove",
   "chat.scrollToBottom.aria": "Ir ao final",
+  "chat.turnOutline.open": "Abrir contorno da transcrição",
+  "chat.turnOutline.openTimeline": "Abrir linha do tempo completa",
   "chat.timeline.relative.justNow": "agora mesmo",
   "chat.timeline.relative.minutesAgo": "há {count}m",
   "chat.timeline.relative.hoursAgo": "há {count}h",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1731,6 +1731,8 @@ export const dict: Record<I18nKey, string> = {
   "chat.draftStarters.sectionSkills": "Скіли",
   "chat.draftStarters.remove": "Прибрати",
   "chat.scrollToBottom.aria": "Прокрутити вниз",
+  "chat.turnOutline.open": "Відкрити контур стенограми",
+  "chat.turnOutline.openTimeline": "Відкрити повну хронологію",
   "chat.timeline.relative.justNow": "щойно",
   "chat.timeline.relative.minutesAgo": "{count} хв тому",
   "chat.timeline.relative.hoursAgo": "{count} год тому",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1719,6 +1719,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.draftStarters.sectionSkills': 'Skills',
   'chat.draftStarters.remove': 'Remove',
   'chat.scrollToBottom.aria': '滚动到底部',
+  'chat.turnOutline.open': '打开转录大纲',
+  'chat.turnOutline.openTimeline': '打开完整时间线',
   'chat.timeline.relative.justNow': '刚刚',
   'chat.timeline.relative.minutesAgo': '{count} 分钟前',
   'chat.timeline.relative.hoursAgo': '{count} 小时前',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1723,6 +1723,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.draftStarters.sectionSkills': 'Skills',
   'chat.draftStarters.remove': 'Remove',
   'chat.scrollToBottom.aria': '捲動到底部',
+  'chat.turnOutline.open': '開啟轉錄大綱',
+  'chat.turnOutline.openTimeline': '開啟完整時間軸',
   'chat.timeline.relative.justNow': '剛剛',
   'chat.timeline.relative.minutesAgo': '{count} 分鐘前',
   'chat.timeline.relative.hoursAgo': '{count} 小時前',


### PR DESCRIPTION
## Summary
- Add a desktop hover transcript outline that exposes up to 20 representative turn markers and a scrollable 10-row viewport for the full conversation.
- Keep navigation virtualizer-aware by reusing the existing active-turn and `scrollToTurnId` paths; place the rail outside chat scroll content.
- Make conversation navigation available while the composer has draft text or the AI is working, when the existing Timeline command cannot be triggered.
- Reuse shared message-preview logic in the full Timeline dialog and localize the new outline controls.

## After
<img width="385" height="413" alt="ff81f743-05b8-4a44-85aa-d252052c9f05" src="https://github.com/user-attachments/assets/c6aba82a-f7d7-40ea-8c98-b8724a45b066" />

## Test Plan
- [x] `bun test packages/ui/src/components/chat/ChatContainer.test.ts packages/ui/src/components/chat/TurnHoverOutline.test.ts packages/ui/src/components/chat/lib/messagePreview.test.ts packages/ui/src/components/chat/lib/turns/windowTurns.test.ts packages/ui/src/lib/i18n/messages.test.ts`
- [x] `bun run type-check:ui`
- [x] `bun run lint:ui`
- [x] `git diff --check`
- [x] `bun run dead-code` reports the existing broad unused-export baseline; the report does not mention the new outline module or the removed nearby-turn helper.