### PR TITLE
fix(web): shorten PWA install app name

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -24,7 +24,7 @@
     <!-- Web app manifest (endpoint-first with data URL fallback) -->
     <script>
       const baseUrl = location.origin;
-      const defaultAppName = 'OpenChamber - AI Coding Assistant';
+      const defaultAppName = 'OpenChamber';
       const defaultShortName = 'OpenChamber';
       const pwaNameStorageKey = 'openchamber.pwaName';
       const pwaOrientationStorageKey = 'openchamber.pwaOrientation';

--- a/packages/web/public/site.webmanifest
+++ b/packages/web/public/site.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "OpenChamber - AI Coding Companion",
+  "name": "OpenChamber",
   "short_name": "OpenChamber",
   "description": "OpenChamber desktop companion for the OpenCode AI coding agent",
   "start_url": "/",

--- a/packages/web/server/lib/opencode/pwa-manifest-routes.js
+++ b/packages/web/server/lib/opencode/pwa-manifest-routes.js
@@ -1,4 +1,4 @@
-const DEFAULT_PWA_APP_NAME = 'OpenChamber - AI Coding Assistant';
+const DEFAULT_PWA_APP_NAME = 'OpenChamber';
 const mapPwaOrientationToManifest = (value) => {
   if (value === 'portrait') {
     return 'portrait-primary';


### PR DESCRIPTION
## Summary

Chrome installs the OpenChamber PWA using a long app name. This change shortens the install name to just `OpenChamber`.

## Changes

- set the runtime PWA manifest default app name to `OpenChamber`
- set the client-side fallback manifest default app name to `OpenChamber`
- set the static web manifest `name` to `OpenChamber`

## Testing

- `bun test "packages/web/server/lib/opencode/pwa-manifest-routes.test.js"`

## Notes

- `bun run type-check` and `bun run lint` could not be completed in this environment because `tsc` and `eslint` were not available to the package scripts.
