### PR TITLE
fix(chat): render bash output across tool states

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.test.ts
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.test.ts
@@ -1,6 +1,52 @@
 import { describe, expect, test } from 'bun:test';
 
+import { getEffectiveToolOutput, renderTerminalOutput } from './toolOutputHelpers';
 import { readTaskTagSessionIdFromOutput } from './taskSessionIdParser';
+
+describe('getEffectiveToolOutput', () => {
+    test('prefers state.output for completed tools', () => {
+        expect(getEffectiveToolOutput('bash', 'final output', 'partial output')).toBe('final output');
+    });
+
+    test('normalizes completed bash state output while preserving final-output precedence', () => {
+        expect(getEffectiveToolOutput('bash', '\u001B[32mFinal output\u001B[0m', 'partial output')).toBe('Final output');
+    });
+
+    test('falls back to metadata.output for bash tools without state output', () => {
+        expect(getEffectiveToolOutput('bash', undefined, 'partial output')).toBe('partial output');
+    });
+
+    test('normalizes bash metadata output for any lifecycle state', () => {
+        expect(getEffectiveToolOutput('bash', undefined, 'Progress 10%\r\u001B[2KProgress 90%')).toBe('Progress 90%');
+    });
+
+    test('ignores metadata.output for non-bash tools', () => {
+        expect(getEffectiveToolOutput('read', undefined, 'partial output')).toBe(undefined);
+        expect(getEffectiveToolOutput('read', 'final output', 'partial output')).toBe('final output');
+    });
+
+    test('returns undefined when bash has no output', () => {
+        expect(getEffectiveToolOutput('bash', undefined, undefined)).toBe(undefined);
+    });
+
+    test('ignores empty metadata.output for bash', () => {
+        expect(getEffectiveToolOutput('bash', undefined, '')).toBe(undefined);
+    });
+});
+
+describe('renderTerminalOutput', () => {
+    test('renders carriage-return progress updates as their latest value', () => {
+        expect(renderTerminalOutput('Downloading 10%\r\u001B[2KDownloading 90%')).toBe('Downloading 90%');
+    });
+
+    test('removes ANSI styles while preserving the output text', () => {
+        expect(renderTerminalOutput('\u001B[32mComplete\u001B[0m\n')).toBe('Complete\n');
+    });
+
+    test('applies cursor-up progress updates to the prior line', () => {
+        expect(renderTerminalOutput('First\nWorking\u001B[1A\r\u001B[2KDone\n')).toBe('Done\nWorking');
+    });
+});
 
 describe('readTaskTagSessionIdFromOutput', () => {
     test('parses task tags without state attributes', () => {

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -52,6 +52,7 @@ import {
 } from './taskToolModel';
 import { areRenderRelevantPartsEqual } from '../renderCompare';
 import { useI18n } from '@/lib/i18n';
+import { getEffectiveToolOutput } from './toolOutputHelpers';
 import { getDiffPatchEntries, getPatchText, type DiffPatchEntry } from './toolDiffUtils';
 import { isEmbeddedSessionChat } from '@/components/layout/contextPanelEmbeddedChat';
 
@@ -797,6 +798,8 @@ interface ToolScrollableSectionProps {
     className?: string;
     outerClassName?: string;
     disableHorizontal?: boolean;
+    pinToBottom?: boolean;
+    pinKey?: string;
 }
 
 const ToolScrollableSection: React.FC<ToolScrollableSectionProps> = ({
@@ -805,22 +808,40 @@ const ToolScrollableSection: React.FC<ToolScrollableSectionProps> = ({
     className,
     outerClassName,
     disableHorizontal = false,
-}) => (
-    <div className={cn('w-full min-w-0 flex-none overflow-hidden', outerClassName)}>
-        <ScrollShadow
-            className={cn(
-                'tool-output-surface p-2 rounded-xl w-full min-w-0',
-                maxHeightClass,
-                disableHorizontal ? 'overflow-y-auto overflow-x-hidden' : 'overflow-auto',
-                className,
-            )}
-        >
-            <div className="w-full min-w-0">
-                {children}
-            </div>
-        </ScrollShadow>
-    </div>
-);
+    pinToBottom = false,
+    pinKey,
+}) => {
+    const scrollRef = React.useRef<HTMLElement>(null);
+
+    React.useLayoutEffect(() => {
+        if (!pinToBottom) {
+            return;
+        }
+        const el = scrollRef.current;
+        if (!el) {
+            return;
+        }
+        el.scrollTop = el.scrollHeight;
+    }, [pinToBottom, pinKey]);
+
+    return (
+        <div className={cn('w-full min-w-0 flex-none overflow-hidden', outerClassName)}>
+            <ScrollShadow
+                ref={scrollRef}
+                className={cn(
+                    'tool-output-surface p-2 rounded-xl w-full min-w-0',
+                    maxHeightClass,
+                    disableHorizontal ? 'overflow-y-auto overflow-x-hidden' : 'overflow-auto',
+                    className,
+                )}
+            >
+                <div className="w-full min-w-0">
+                    {children}
+                </div>
+            </ScrollShadow>
+        </div>
+    );
+};
 
 const getToolOutputLanguage = (
     output: string,
@@ -1509,7 +1530,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
     const stateWithData = state as ToolStateWithMetadata;
     const metadata = stateWithData.metadata;
     const input = stateWithData.input;
-    const rawOutput = stateWithData.output;
+    const rawOutput = getEffectiveToolOutput(part.tool, stateWithData.output, metadata?.output);
     const hasStringOutput = typeof rawOutput === 'string' && rawOutput.length > 0;
     const outputString = typeof rawOutput === 'string' ? rawOutput : '';
 
@@ -1576,13 +1597,15 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
 
     const renderScrollableBlock = (
         content: React.ReactNode,
-        options?: { maxHeightClass?: string; className?: string; disableHorizontal?: boolean; outerClassName?: string }
+        options?: { maxHeightClass?: string; className?: string; disableHorizontal?: boolean; outerClassName?: string; pinToBottom?: boolean; pinKey?: string }
     ) => (
         <ToolScrollableSection
             maxHeightClass={options?.maxHeightClass}
             className={options?.className}
             disableHorizontal={options?.disableHorizontal}
             outerClassName={options?.outerClassName}
+            pinToBottom={options?.pinToBottom}
+            pinKey={options?.pinKey}
         >
             {content}
         </ToolScrollableSection>
@@ -1799,6 +1822,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
         }
 
         if (hasStringOutput && outputString.trim()) {
+            const isRunningBash = part.tool === 'bash' && state.status === 'running';
             return renderScrollableBlock(
                 <ToolScrollableTextOutput
                     output={coerceToText(outputString)}
@@ -1809,6 +1833,8 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                 {
                     className: part.tool === 'bash' ? 'p-1 rounded-none' : 'p-1',
                     maxHeightClass: part.tool === 'bash' ? 'max-h-[46vh]' : undefined,
+                    pinToBottom: isRunningBash,
+                    pinKey: isRunningBash ? outputString : undefined,
                 }
             );
         }
@@ -1818,6 +1844,9 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
             { maxHeightClass: 'max-h-60' }
         );
     };
+
+    const shouldRenderResult = (state.status === 'completed' && 'output' in state)
+        || (part.tool === 'bash' && hasStringOutput);
 
     if (isTodoTool) {
         if (state.status === 'error' && 'error' in state) {
@@ -1897,7 +1926,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                         </div>
                     ) : null}
 
-                    {state.status === 'completed' && 'output' in state && (
+                    {shouldRenderResult && (
                         <div>
                             {(part.tool === 'edit' || part.tool === 'multiedit' || part.tool === 'apply_patch' || part.tool === 'write') && hasVisualDiffEntry ? (
                                 <div className="mb-1 flex items-center justify-end gap-2">

--- a/packages/ui/src/components/chat/message/parts/toolOutputHelpers.ts
+++ b/packages/ui/src/components/chat/message/parts/toolOutputHelpers.ts
@@ -1,0 +1,122 @@
+const writeTerminalCharacter = (lines: string[], row: number, column: number, character: string): void => {
+    const line = lines[row] ?? '';
+    const padding = column > line.length ? ' '.repeat(column - line.length) : '';
+    lines[row] = `${line.slice(0, column)}${padding}${character}${line.slice(column + 1)}`;
+};
+
+/** Converts the common ANSI progress-update sequences into their visible terminal text. */
+export const renderTerminalOutput = (output: string): string => {
+    if (!output.includes('\u001B') && !output.includes('\r') && !output.includes('\b')) {
+        return output;
+    }
+
+    const lines = [''];
+    let row = 0;
+    let column = 0;
+
+    for (let index = 0; index < output.length; index += 1) {
+        const character = output[index];
+
+        if (character === '\n') {
+            row += 1;
+            column = 0;
+            lines[row] ??= '';
+            continue;
+        }
+        if (character === '\r') {
+            column = 0;
+            continue;
+        }
+        if (character === '\b') {
+            column = Math.max(0, column - 1);
+            continue;
+        }
+        if (character !== '\u001B') {
+            writeTerminalCharacter(lines, row, column, character);
+            column += 1;
+            continue;
+        }
+
+        const nextCharacter = output[index + 1];
+        if (nextCharacter === '[') {
+            const sequenceStart = index + 2;
+            let sequenceEnd = sequenceStart;
+            while (sequenceEnd < output.length && !/[\x40-\x7E]/.test(output[sequenceEnd])) {
+                sequenceEnd += 1;
+            }
+            if (sequenceEnd === output.length) {
+                break;
+            }
+
+            const command = output[sequenceEnd];
+            const parameters = output.slice(sequenceStart, sequenceEnd).split(';').map((value) => Number.parseInt(value, 10) || 0);
+            const count = parameters[0] || 1;
+            if (command === 'A') {
+                row = Math.max(0, row - count);
+            } else if (command === 'B') {
+                row += count;
+                lines[row] ??= '';
+            } else if (command === 'C') {
+                column += count;
+            } else if (command === 'D') {
+                column = Math.max(0, column - count);
+            } else if (command === 'G') {
+                column = Math.max(0, count - 1);
+            } else if (command === 'H' || command === 'f') {
+                row = Math.max(0, (parameters[0] || 1) - 1);
+                column = Math.max(0, (parameters[1] || 1) - 1);
+                lines[row] ??= '';
+            } else if (command === 'K') {
+                const mode = parameters[0];
+                const line = lines[row] ?? '';
+                if (mode === 1) {
+                    lines[row] = line.slice(column);
+                    column = 0;
+                } else if (mode === 2) {
+                    lines[row] = '';
+                } else {
+                    lines[row] = line.slice(0, column);
+                }
+            }
+            index = sequenceEnd;
+            continue;
+        }
+
+        if (nextCharacter === ']') {
+            const terminator = output.indexOf('\u0007', index + 2);
+            const stringTerminator = output.indexOf('\u001B\\', index + 2);
+            const end = terminator === -1
+                ? stringTerminator
+                : stringTerminator === -1
+                    ? terminator
+                    : Math.min(terminator, stringTerminator);
+            if (end === -1) {
+                break;
+            }
+            index = output[end] === '\u0007' ? end : end + 1;
+            continue;
+        }
+
+        index += 1;
+    }
+
+    return lines.join('\n');
+};
+
+export const getEffectiveToolOutput = (
+    tool: string,
+    stateOutput: unknown,
+    metadataOutput: unknown,
+): string | undefined => {
+    const isBash = tool === 'bash';
+
+    if (typeof stateOutput === 'string') {
+        return isBash ? renderTerminalOutput(stateOutput) : stateOutput;
+    }
+
+    if (isBash && typeof metadataOutput === 'string' && metadataOutput.length > 0) {
+        return renderTerminalOutput(metadataOutput);
+    }
+
+    return undefined;
+};


### PR DESCRIPTION
## Summary
- Render streamed `metadata.output` for bash tool calls across their lifecycle, including completed and error states when canonical output is unavailable.
- Prefer authoritative `state.output` whenever present, including completed bash calls.
- Normalize the selected bash output by removing terminal control sequences and applying carriage-return progress updates.
- Keep live auto-scroll limited to running bash output.
- Keep `metadata.output` scoped to bash; non-bash tools continue to use only their state output.
- Add coverage for completed-output precedence, ANSI normalization, lifecycle fallback, empty output, and non-bash exclusion.

Fixes #1997

## Verification
- `bun test packages/ui/src/components/chat/message/parts/ToolPart.test.ts` (12 pass)
- `bun run type-check:ui`
- `bun run lint:ui`
- `git diff --check`

The focused checks were run in the local workspace after applying the same patch. The PR delivery worktree did not have a separate `node_modules` installation.

## Risk Evaluation
- Risk: `2/5` (low)
- Confidence: `4.5/5`
- Shared UI rendering only; no server, API, persistence, security, dependency, or runtime bridge changes.
- The fallback remains bash-only and never replaces authoritative completed output with a potentially truncated metadata snapshot.
- Residual risk is limited to terminal-control rendering and lifecycle presentation; no live UI/e2e screenshot was added.