### PR TITLE
fix(sidebar): pass explicit selectedProjectId before active-project switch

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -82,7 +82,7 @@ type Props = {
   setActiveProjectIdOnly: (id: string) => void;
   setActiveMainTab: (tab: MainTab) => void;
   setSessionSwitcherOpen: (open: boolean) => void;
-  openNewSessionDraft: (options?: { directoryOverride?: string | null; targetFolderId?: string }) => void;
+  openNewSessionDraft: (options?: { selectedProjectId?: string | null; directoryOverride?: string | null; targetFolderId?: string }) => void;
   addSessionToFolder: (scopeKey: string, folderId: string, sessionId: string) => void;
   createFolderAndStartRename: (scopeKey: string, parentId?: string | null) => { id: string } | null;
   renamingFolderId: string | null;
@@ -894,10 +894,10 @@ function SessionGroupSectionBase(props: Props): React.ReactNode {
             isDropTarget={isDropTarget}
             depth={depth}
             onNewSession={() => {
+              openNewSessionDraft({ selectedProjectId: projectId ?? null, directoryOverride: group.directory, targetFolderId: folder.id });
               if (projectId && projectId !== activeProjectId) setActiveProjectIdOnly(projectId);
               setActiveMainTab('chat');
               if (mobileVariant) setSessionSwitcherOpen(false);
-              openNewSessionDraft({ directoryOverride: group.directory, targetFolderId: folder.id });
             }}
             onNewSubFolder={depth === 0 ? () => {
               if (!folderScopeKey) return;
@@ -1266,10 +1266,10 @@ function SessionGroupSectionBase(props: Props): React.ReactNode {
                   type="button"
                   onClick={(event) => {
                     event.stopPropagation();
+                    openNewSessionDraft({ selectedProjectId: projectId ?? null, directoryOverride: group.directory });
                     if (projectId && projectId !== activeProjectId) setActiveProjectIdOnly(projectId);
                     setActiveMainTab('chat');
                     if (mobileVariant) setSessionSwitcherOpen(false);
-                    openNewSessionDraft({ directoryOverride: group.directory });
                   }}
                   className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
                   aria-label={t('sessions.sidebar.group.actions.newDraftInGroupAria', { label: group.label })}

--- a/packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx
+++ b/packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React from 'react';
 import {
   DndContext,
   DragOverlay,
@@ -64,7 +64,7 @@ type Props = {
   setActiveProjectIdOnly: (id: string) => void;
   setActiveMainTab: (tab: MainTab) => void;
   setSessionSwitcherOpen: (open: boolean) => void;
-  openNewSessionDraft: (options?: { directoryOverride?: string | null }) => void;
+  openNewSessionDraft: (options?: { selectedProjectId?: string | null; directoryOverride?: string | null }) => void;
   openNewWorktreeDialog: () => void;
   openProjectEditDialog: (id: string) => void;
   removeProject: (id: string) => void;
@@ -240,10 +240,13 @@ export function SidebarProjectsList(props: Props): React.ReactNode {
                     alwaysShowActions={props.alwaysShowActions}
                     onToggle={() => props.toggleProject(projectKey)}
                     onNewSession={() => {
+                      props.openNewSessionDraft({
+                        selectedProjectId: projectKey,
+                        directoryOverride: project.normalizedPath,
+                      });
                       if (projectKey !== props.activeProjectId) props.setActiveProjectIdOnly(projectKey);
                       props.setActiveMainTab('chat');
                       if (props.mobileVariant) props.setSessionSwitcherOpen(false);
-                      props.openNewSessionDraft({ directoryOverride: project.normalizedPath });
                     }}
                     onNewWorktreeSession={() => {
                       if (projectKey !== props.activeProjectId) props.setActiveProjectIdOnly(projectKey);


### PR DESCRIPTION
## Summary

Pressing the **+** button for a project, group, or folder in the sessions sidebar could open a new session draft for the wrong project, such as the previously active project.

## Root cause

The handlers changed `activeProjectId` before opening the target draft. That could trigger `useProjectSessionSelection`'s layout effect and replace the requested context before the draft initialized.

## Fix

- Open the draft before changing the active project.
- Pass `selectedProjectId` explicitly with the target directory.
- Apply the same ordering to project, group, and folder creation actions.

## Verification

- `bun run type-check:ui`
- `bun run lint:ui`
- PR CI checks

Closes #1787