### PR TITLE
perf(sidebar): remove redundant path normalization and share directory-match cache (#2173)

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -66,6 +66,7 @@ import {
 } from './sidebar/activitySections';
 import { useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
 import {
+  collectKnownProjectDirectories,
   compareSessionsByPinnedAndTime,
   formatProjectLabel,
   normalizePath,
@@ -937,6 +938,20 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       }>;
   }, [projects]);
 
+  const knownProjectDirectories = React.useMemo(
+    () => collectKnownProjectDirectories(normalizedProjects, availableWorktreesByProject, isVSCode),
+    [normalizedProjects, availableWorktreesByProject, isVSCode],
+  );
+
+  // Create a fresh directory-match cache whenever the set of known
+  // directories changes. The dependency is intentionally the identity
+  // of the set so stale best-match lookups are discarded.
+  const directoryMatchCache = React.useMemo(
+    () => new Map<string, string | null>(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [knownProjectDirectories],
+  );
+
   const normalizedProjectPaths = React.useMemo(
     () => normalizedProjects.map((project) => project.normalizedPath),
     [normalizedProjects],
@@ -1000,9 +1015,11 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     sessions,
     archivedSessions,
     normalizedProjects,
+    knownProjectDirectories,
     isVSCode,
     availableWorktreesByProject,
     cleanupSessions,
+    directoryMatchCache,
   });
 
   const { getSessionsForProject, getArchivedSessionsForProject } = useProjectSessionLists({
@@ -1010,7 +1027,8 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     sessions,
     archivedSessions,
     availableWorktreesByProject,
-    normalizedProjects,
+    knownProjectDirectories,
+    directoryMatchCache,
   });
 
   useArchivedAutoFolders({
@@ -1024,6 +1042,8 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     createFolder,
     addSessionToFolder,
     cleanupSessions,
+    knownProjectDirectories,
+    directoryMatchCache,
   });
 
   // Keep last-known repo status to avoid UI jiggling during project switch

--- a/packages/ui/src/components/session/sidebar/hooks/useArchivedAutoFolders.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useArchivedAutoFolders.ts
@@ -2,7 +2,6 @@ import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
 import type { WorktreeMetadata } from '@/types/worktree';
 import {
-  collectKnownProjectDirectories,
   dedupeSessionsById,
   getArchivedScopeKey,
   isSessionRelatedToProject,
@@ -31,11 +30,23 @@ type Args = {
   createFolder: (scopeKey: string, name: string, parentId?: string | null) => FolderEntry;
   addSessionToFolder: (scopeKey: string, folderId: string, sessionId: string) => void;
   cleanupSessions: (scopeKey: string, existingSessionIds: Set<string>) => void;
+  /**
+   * Pre-normalized set of all project + worktree directories. Passed
+   * from SessionSidebar so it is computed once per render instead of
+   * inside every hook.
+   */
+  knownProjectDirectories: Set<string>;
+  /**
+   * Optional local cache mapping a session directory to its best
+   * matching known directory. Shared across hooks to avoid redundant
+   * path-prefix scans.
+   */
+  directoryMatchCache?: Map<string, string | null>;
 };
 
 const getArchivedSessionsForProject = (
   project: ProjectForArchivedFolders,
-  params: Pick<Args, 'sessions' | 'archivedSessions' | 'availableWorktreesByProject' | 'isVSCode'> & {
+  params: Pick<Args, 'sessions' | 'archivedSessions' | 'availableWorktreesByProject' | 'isVSCode' | 'directoryMatchCache'> & {
     knownProjectDirectories: Set<string>;
   },
 ): Session[] => {
@@ -48,7 +59,7 @@ const getArchivedSessionsForProject = (
   ]);
 
   const collect = (input: Session[]): Session[] => input.filter((session) =>
-    isSessionRelatedToProject(session, project.normalizedPath, validDirectories, params.knownProjectDirectories),
+    isSessionRelatedToProject(session, project.normalizedPath, validDirectories, params.knownProjectDirectories, params.directoryMatchCache),
   );
 
   const archived = collect(params.archivedSessions);
@@ -60,7 +71,7 @@ const getArchivedSessionsForProject = (
     if (sessionDirectory) {
       return false;
     }
-    return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, params.knownProjectDirectories);
+    return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, params.knownProjectDirectories, params.directoryMatchCache);
   });
 
   return dedupeSessionsById([...archived, ...unassignedLive]);
@@ -78,12 +89,9 @@ export const useArchivedAutoFolders = (args: Args): void => {
     createFolder,
     addSessionToFolder,
     cleanupSessions,
+    knownProjectDirectories,
+    directoryMatchCache,
   } = args;
-
-  const knownProjectDirectories = React.useMemo(
-    () => collectKnownProjectDirectories(normalizedProjects, availableWorktreesByProject, isVSCode),
-    [normalizedProjects, availableWorktreesByProject, isVSCode],
-  );
 
   React.useEffect(() => {
     if (isSessionsLoading) {
@@ -98,6 +106,7 @@ export const useArchivedAutoFolders = (args: Args): void => {
         availableWorktreesByProject,
         isVSCode,
         knownProjectDirectories,
+        directoryMatchCache,
       });
       const sessionIds = new Set(projectArchivedSessions.map((session) => session.id));
 
@@ -125,6 +134,7 @@ export const useArchivedAutoFolders = (args: Args): void => {
     sessions,
     archivedSessions,
     availableWorktreesByProject,
+    directoryMatchCache,
     knownProjectDirectories,
     isVSCode,
     isSessionsLoading,

--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionLists.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionLists.ts
@@ -1,11 +1,9 @@
 import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
 import { resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
-import { collectKnownProjectDirectories, dedupeSessionsById, isSessionRelatedToProject, normalizePath } from '../utils';
+import { dedupeSessionsById, isSessionRelatedToProject, normalizePath } from '../utils';
 
 type WorktreeMeta = { path: string };
-
-type NormalizedProject = { id: string; normalizedPath: string };
 
 type Args = {
   isVSCode: boolean;
@@ -13,14 +11,17 @@ type Args = {
   archivedSessions: Session[];
   availableWorktreesByProject: Map<string, WorktreeMeta[]>;
   /**
-   * The set of normalized projects the sidebar will render. Used in
-   * Layer 4.13 to precompute the allowed directory set so the per-row
-   * `sessionsByDirectory` Map only contains buckets the sidebar will
-   * actually consume. With 10 projects × 5 worktrees and 100 sessions
-   * per directory this drops the Map from N entries to the small
-   * subset the sidebar needs.
+   * Pre-normalized set of all project + worktree directories. Passed
+   * from SessionSidebar so it is computed once per render instead of
+   * inside every hook.
    */
-  normalizedProjects: NormalizedProject[];
+  knownProjectDirectories: Set<string>;
+  /**
+   * Optional local cache mapping a session directory to its best
+   * matching known directory. Shared across hooks to avoid redundant
+   * path-prefix scans.
+   */
+  directoryMatchCache?: Map<string, string | null>;
 };
 
 export const useProjectSessionLists = (args: Args) => {
@@ -29,18 +30,12 @@ export const useProjectSessionLists = (args: Args) => {
     sessions,
     archivedSessions,
     availableWorktreesByProject,
-    normalizedProjects,
+    knownProjectDirectories,
+    directoryMatchCache,
   } = args;
 
-  // Precompute the set of directories the sidebar will ever ask about:
-  // every project's normalized path plus the path of each registered
-  // worktree. Walking this set is O(P + W) per Sidebar render and lets
-  // us skip the bulk of `sessions` (whose directory is not associated
-  // with a known project) when building `sessionsByDirectory`.
-  const knownProjectDirectories = React.useMemo(
-    () => collectKnownProjectDirectories(normalizedProjects, availableWorktreesByProject, isVSCode),
-    [normalizedProjects, availableWorktreesByProject, isVSCode],
-  );
+  // `knownProjectDirectories` is computed once in SessionSidebar and
+  // passed in so every hook shares the same pre-normalized set.
 
   const sessionsByDirectory = React.useMemo(() => {
     const next = new Map<string, Session[]>();
@@ -132,7 +127,7 @@ export const useProjectSessionLists = (args: Args) => {
       ]);
 
       const collect = (input: Session[]): Session[] => input.filter((session) =>
-        isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories),
+        isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories, directoryMatchCache),
       );
 
       const archived = collect(archivedSessions);
@@ -148,12 +143,12 @@ export const useProjectSessionLists = (args: Args) => {
         if (!projectWorktree) {
           return false;
         }
-        return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories);
+        return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories, directoryMatchCache);
       });
 
       return dedupeSessionsById([...archived, ...unassignedLive]);
     },
-    [archivedSessions, availableWorktreesByProject, isVSCode, knownProjectDirectories, sessions],
+    [archivedSessions, availableWorktreesByProject, directoryMatchCache, isVSCode, knownProjectDirectories, sessions],
   );
 
   return {

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionFolderCleanup.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionFolderCleanup.ts
@@ -2,7 +2,6 @@ import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
 import { useSessionFoldersStore } from '@/stores/useSessionFoldersStore';
 import {
-  collectKnownProjectDirectories,
   dedupeSessionsById,
   getArchivedScopeKey,
   isSessionRelatedToProject,
@@ -25,6 +24,18 @@ type Args = {
   isVSCode: boolean;
   availableWorktreesByProject: Map<string, WorktreeMeta[]>;
   cleanupSessions: (scopeKey: string, validSessionIds: Set<string>) => void;
+  /**
+   * Pre-normalized set of all project + worktree directories. Passed
+   * from SessionSidebar so it is computed once per render instead of
+   * inside every hook.
+   */
+  knownProjectDirectories: Set<string>;
+  /**
+   * Optional local cache mapping a session directory to its best
+   * matching known directory. Shared across hooks to avoid redundant
+   * path-prefix scans.
+   */
+  directoryMatchCache?: Map<string, string | null>;
 };
 
 export const useSessionFolderCleanup = (args: Args): void => {
@@ -37,12 +48,9 @@ export const useSessionFolderCleanup = (args: Args): void => {
     isVSCode,
     availableWorktreesByProject,
     cleanupSessions,
+    knownProjectDirectories,
+    directoryMatchCache,
   } = args;
-
-  const knownProjectDirectories = React.useMemo(
-    () => collectKnownProjectDirectories(normalizedProjects, availableWorktreesByProject, isVSCode),
-    [normalizedProjects, availableWorktreesByProject, isVSCode],
-  );
 
   React.useEffect(() => {
     if (isSessionsLoading || !hasLoadedGlobalSessions) {
@@ -87,9 +95,9 @@ export const useSessionFolderCleanup = (args: Args): void => {
           if (sessionDirectory) {
             return false;
           }
-          return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories);
+          return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories, directoryMatchCache);
         }),
-      ]).filter((session) => isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories));
+      ]).filter((session) => isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories, directoryMatchCache));
 
       idsByScope.set(scopeKey, new Set(archivedForProject.map((session) => session.id)));
     });
@@ -103,6 +111,7 @@ export const useSessionFolderCleanup = (args: Args): void => {
     archivedSessions,
     availableWorktreesByProject,
     cleanupSessions,
+    directoryMatchCache,
     hasLoadedGlobalSessions,
     isSessionsLoading,
     isVSCode,

--- a/packages/ui/src/components/session/sidebar/utils.test.ts
+++ b/packages/ui/src/components/session/sidebar/utils.test.ts
@@ -110,4 +110,118 @@ describe('isSessionRelatedToProject', () => {
       isSessionRelatedToProject(session, '/home/user', new Set(['/home/user']), knownProjectDirectories),
     ).toBe(true);
   });
+
+  test('matches Windows normalized paths', () => {
+    const session = {
+      id: 'ses_windows',
+      directory: 'C:/Users/dev/proj/src',
+    } as unknown as Session;
+
+    const knownProjectDirectories = new Set(['C:/Users/dev', 'C:/Users/dev/proj']);
+
+    expect(
+      isSessionRelatedToProject(session, 'C:/Users/dev', new Set(['C:/Users/dev']), knownProjectDirectories),
+    ).toBe(false);
+    expect(
+      isSessionRelatedToProject(
+        session,
+        'C:/Users/dev/proj',
+        new Set(['C:/Users/dev/proj']),
+        knownProjectDirectories,
+      ),
+    ).toBe(true);
+  });
+
+  test('matches root project when no more specific project exists', () => {
+    const session = {
+      id: 'ses_root_child',
+      directory: '/foo/bar/baz',
+    } as unknown as Session;
+
+    const knownProjectDirectories = new Set(['/']);
+
+    expect(
+      isSessionRelatedToProject(session, '/', new Set(['/']), knownProjectDirectories),
+    ).toBe(true);
+  });
+
+  test('more specific project wins over root project', () => {
+    const session = {
+      id: 'ses_specific_wins',
+      directory: '/foo/bar/baz',
+    } as unknown as Session;
+
+    const knownProjectDirectories = new Set(['/', '/foo/bar']);
+
+    expect(
+      isSessionRelatedToProject(session, '/', new Set(['/']), knownProjectDirectories),
+    ).toBe(false);
+    expect(
+      isSessionRelatedToProject(session, '/foo/bar', new Set(['/foo/bar']), knownProjectDirectories),
+    ).toBe(true);
+  });
+
+  test('cache returns the same result on repeated calls', () => {
+    const session = {
+      id: 'ses_cache',
+      directory: '/home/user/proj/foo/src',
+    } as unknown as Session;
+
+    const knownProjectDirectories = new Set(['/home/user', '/home/user/proj/foo']);
+    const cache = new Map<string, string | null>();
+
+    const first = isSessionRelatedToProject(
+      session,
+      '/home/user/proj/foo',
+      new Set(['/home/user/proj/foo']),
+      knownProjectDirectories,
+      cache,
+    );
+    expect(cache.size).toBe(1);
+
+    const second = isSessionRelatedToProject(
+      session,
+      '/home/user/proj/foo',
+      new Set(['/home/user/proj/foo']),
+      knownProjectDirectories,
+      cache,
+    );
+    expect(second).toBe(first);
+    expect(second).toBe(true);
+    expect(cache.size).toBe(1);
+  });
+
+  test('results update when a fresh cache is used after knownProjectDirectories changes', () => {
+    const session = {
+      id: 'ses_invalidate',
+      directory: '/home/user/proj/foo/src',
+    } as unknown as Session;
+
+    const narrowDirectories = new Set(['/home/user/proj/foo']);
+    const broadDirectories = new Set(['/home/user']);
+    const narrowCache = new Map<string, string | null>();
+    const broadCache = new Map<string, string | null>();
+
+    const narrowResult = isSessionRelatedToProject(
+      session,
+      '/home/user/proj/foo',
+      new Set(['/home/user/proj/foo']),
+      narrowDirectories,
+      narrowCache,
+    );
+    expect(narrowResult).toBe(true);
+    expect(narrowCache.get('/home/user/proj/foo/src')).toBe('/home/user/proj/foo');
+
+    // SessionSidebar creates a fresh cache when knownProjectDirectories
+    // changes, so the stale narrow lookup is no longer consulted.
+    const broadResult = isSessionRelatedToProject(
+      session,
+      '/home/user',
+      new Set(['/home/user']),
+      broadDirectories,
+      broadCache,
+    );
+    expect(broadResult).toBe(true);
+    expect(broadCache.get('/home/user/proj/foo/src')).toBe('/home/user');
+  });
 });

--- a/packages/ui/src/components/session/sidebar/utils.tsx
+++ b/packages/ui/src/components/session/sidebar/utils.tsx
@@ -83,6 +83,13 @@ export const formatSessionCompactDateLabel = (updatedMs: number): string => {
 export const isPathWithinProject = (directory?: string | null, projectPath?: string | null): boolean => {
   const normalizedDirectory = normalizePath(directory);
   const normalizedProjectPath = normalizePath(projectPath);
+  return isPathWithinNormalizedProject(normalizedDirectory, normalizedProjectPath);
+};
+
+const isPathWithinNormalizedProject = (
+  normalizedDirectory?: string | null,
+  normalizedProjectPath?: string | null,
+): boolean => {
   if (!normalizedDirectory || !normalizedProjectPath) return false;
   if (normalizedDirectory === normalizedProjectPath) return true;
   if (normalizedProjectPath === '/') return normalizedDirectory.startsWith('/');
@@ -121,26 +128,37 @@ export const collectKnownProjectDirectories = (
   return knownDirectories;
 };
 
+/**
+ * Find the longest known directory that contains `value`. All entries in
+ * `knownDirectories` must already be normalized paths. The optional `cache`
+ * is local to a single render/evaluation and maps a resolved directory to
+ * its best matching known directory (or `null` when none matches).
+ */
 const findBestProjectDirectoryMatch = (
   value: string | null,
   knownDirectories?: Iterable<string>,
+  cache?: Map<string, string | null>,
 ): string | null => {
   if (!value || !knownDirectories) {
     return null;
   }
 
+  if (cache?.has(value)) {
+    return cache.get(value) ?? null;
+  }
+
   let bestMatch: string | null = null;
   for (const candidate of knownDirectories) {
-    const normalizedCandidate = normalizePath(candidate);
-    if (!normalizedCandidate || !isPathWithinProject(value, normalizedCandidate)) {
+    if (!candidate || !isPathWithinNormalizedProject(value, candidate)) {
       continue;
     }
 
-    if (!bestMatch || normalizedCandidate.length > bestMatch.length) {
-      bestMatch = normalizedCandidate;
+    if (!bestMatch || candidate.length > bestMatch.length) {
+      bestMatch = candidate;
     }
   }
 
+  cache?.set(value, bestMatch);
   return bestMatch;
 };
 
@@ -228,6 +246,7 @@ export const isSessionRelatedToProject = (
   projectRoot: string,
   validDirectories?: Set<string>,
   knownDirectories?: Iterable<string>,
+  cache?: Map<string, string | null>,
 ): boolean => {
   const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
   const projectWorktree = normalizePath((session as Session & { project?: { worktree?: string | null } | null }).project?.worktree ?? null);
@@ -241,7 +260,7 @@ export const isSessionRelatedToProject = (
     return false;
   }
 
-  const bestMatch = findBestProjectDirectoryMatch(resolvedDirectory, knownDirectories);
+  const bestMatch = findBestProjectDirectoryMatch(resolvedDirectory, knownDirectories, cache);
   if (bestMatch) {
     return validDirectories ? validDirectories.has(bestMatch) : bestMatch === projectRoot;
   }


### PR DESCRIPTION
Fixes #2173

## Summary

Fixes a v1.16.0 session-sidebar renderer performance regression where `findBestProjectDirectoryMatch()` re-normalized already-normalized candidates on every call, and `isPathWithinProject()` re-normalized both arguments, multiplied across `sessions × projects × 3 sidebar hooks`.

This hotfix removes redundant normalization and shares a single per-render directory-match cache across the three consumers without changing assignment semantics or redesigning the sidebar data flow.

## What changed

- `packages/ui/src/components/session/sidebar/utils.tsx`
  - Added internal `isPathWithinNormalizedProject` helper for pre-normalized inputs.
  - `findBestProjectDirectoryMatch` now accepts an optional `Map<string, string | null>` cache and skips per-candidate `normalizePath` calls (all candidates are already normalized via `collectKnownProjectDirectories`).
  - Public `isPathWithinProject` is unchanged.
  - `isSessionRelatedToProject` threads the cache through.

- `packages/ui/src/components/session/SessionSidebar.tsx`
  - Computes `knownProjectDirectories` once with `useMemo`.
  - Creates a fresh `directoryMatchCache` whenever `knownProjectDirectories` identity changes, so stale best-match entries are discarded automatically.
  - Passes both to `useProjectSessionLists`, `useArchivedAutoFolders`, and `useSessionFolderCleanup`.

- Three sidebar hooks
  - Removed duplicated `collectKnownProjectDirectories()` `useMemo` calls.
  - All `isSessionRelatedToProject` calls now use the shared cache.

- `packages/ui/src/components/session/sidebar/utils.test.ts`
  - Added coverage for Windows normalized paths, root `/` matching, nested-project precedence, cache reuse, and cache freshness after directory-set changes.

## Performance

Measured on a synthetic dataset matching the user's scale (15 projects, 67 worktrees, 14,561 sessions), running the sidebar matching loop across all sessions, all projects, and 3 consumers:

| Variant | Avg | Min | Max |
|---|---|---|---|
| Before (no cache, redundant normalization) | **7,523.9 ms** | 4,743.7 ms | 10,022.9 ms |
| After (shared directory-match cache, no redundant normalization) | **450.6 ms** | 395.6 ms | 477.2 ms |

**~16.7× faster** on this worst-case scan, saving ~7 seconds per full evaluation. Actual React render cost is lower because the hooks do not run the full cross-product on every frame.

## Validation

- `bun test packages/ui/src/components/session/sidebar/utils.test.ts` — 15 pass, 0 fail
- `bun run --filter @openchamber/ui type-check` — pass
- `bun run --filter @openchamber/ui lint` — pass

## Follow-up

This is an intentional quick hotfix. A separate follow-up PR should pre-assign every session to its owning project once per render (Option A discussed in #2173): build a `Map<sessionId, { resolvedDirectory, bestMatch }>` in `SessionSidebar`, share it with the hooks, and replace the remaining `sessions × projects` filters with `O(1)` lookups. That will drop the worst-case per-render cost from hundreds of ms to single-digit ms and remove the current per-render `Map` allocation entirely.
