### PR TITLE
perf(sidebar): index session ownership

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -31,6 +31,7 @@ import { useSidebarPersistence } from './sidebar/hooks/useSidebarPersistence';
 import { useProjectRepoStatus } from './sidebar/hooks/useProjectRepoStatus';
 import { useProjectSessionLists } from './sidebar/hooks/useProjectSessionLists';
 import { useSessionFolderCleanup } from './sidebar/hooks/useSessionFolderCleanup';
+import { createSessionOwnershipIndex } from './sidebar/sessionOwnership';
 import { useStickyProjectHeaders } from './sidebar/hooks/useStickyProjectHeaders';
 import { getGitHubPrStatusKey, usePrVisualSummaryByKeys, useGitHubPrStatusStore } from '@/stores/useGitHubPrStatusStore';
 import { ProjectEditDialog } from '@/components/layout/ProjectEditDialog';
@@ -319,7 +320,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const sync = useSync();
   const liveSessions = useAllLiveSessions();
   const isVSCode = React.useMemo(() => isVSCodeRuntime(), []);
-  const hasLoadedGlobalSessions = useGlobalSessionsStore((state) => state.hasLoaded);
   const hasAuthoritativeGlobalSessions = useGlobalSessionsStore((state) => state.status === 'ready');
   const globalActiveSessions = useGlobalSessionsStore((state) => state.activeSessions);
   const archivedSessions = useGlobalSessionsStore((state) => state.archivedSessions);
@@ -330,7 +330,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const shareSession = useSessionUIStore((state) => state.shareSession);
   const unshareSession = useSessionUIStore((state) => state.unshareSession);
   // sessionAttentionStates removed — now using notification-store directly in SessionNodeItem
-  const worktreeMetadata = useSessionUIStore((state) => state.worktreeMetadata);
   const availableWorktreesByProject = useSessionUIStore((state) => state.availableWorktreesByProject);
   const openNewSessionDraft = useSessionUIStore((state) => state.openNewSessionDraft);
   // The sidebar tree's +-buttons (project / group / folder) open a draft but,
@@ -418,6 +417,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       .join('|'),
     [projects],
   );
+  const [isWorktreeTopologyLoading, setIsWorktreeTopologyLoading] = React.useState(true);
 
   const initialGlobalSessionsRefreshStartedRef = React.useRef(false);
   React.useEffect(() => {
@@ -437,10 +437,14 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
     const discoverWorktrees = async () => {
       const projectEntries = useProjectsStore.getState().projects;
-      if (projectEntries.length === 0) return;
+      if (projectEntries.length === 0) {
+        setIsWorktreeTopologyLoading(false);
+        return;
+      }
 
       const worktreesByProject = new Map<string, WorktreeMetadata[]>();
       const allWorktrees: WorktreeMetadata[] = [];
+      let discoveryFailed = false;
 
       // Constrain fanout: previously `Promise.all(projects.map(...))` could
       // spawn dozens of concurrent `git worktree list` and
@@ -470,7 +474,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
             worktreesByProject.set(projectPath, worktrees);
             allWorktrees.push(...worktrees);
           } catch {
-            // ignore discovery errors
+            discoveryFailed = true;
           }
         }
       });
@@ -486,12 +490,17 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
           availableWorktreesByProject: worktreesByProject,
         });
       }
+      setIsWorktreeTopologyLoading(discoveryFailed);
     };
 
     // Skip if we already discovered worktrees for this exact project set.
     if (discoveredProjectsRef.current === projectWorktreeDiscoveryKey) {
+      if (!projectWorktreeDiscoveryKey) {
+        setIsWorktreeTopologyLoading(false);
+      }
       return;
     }
+    setIsWorktreeTopologyLoading(true);
     discoveredProjectsRef.current = projectWorktreeDiscoveryKey;
     void discoverWorktrees();
 
@@ -525,18 +534,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
   const { isTablet } = useDeviceInfo();
   const alwaysShowSidebarActions = mobileVariant || isTablet;
-
-  const {
-    buildGroupSearchText,
-    filterSessionNodesForSearch,
-    buildGroupedSessions,
-  } = useSessionGrouping({
-    homeDirectory,
-    worktreeMetadata,
-    pinnedSessionIds,
-    gitBranches,
-    isVSCode,
-  });
 
   const { scheduleCollapsedProjectsPersist } = useSidebarPersistence({
     isVSCode,
@@ -994,32 +991,40 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   });
 
   const isSessionsLoading = useSessionUIStore((state) => state.isLoading);
+  const sessionOwnership = React.useMemo(
+    () => createSessionOwnershipIndex(sessions, normalizedProjects, availableWorktreesByProject, isVSCode, archivedSessions),
+    [archivedSessions, availableWorktreesByProject, isVSCode, normalizedProjects, sessions],
+  );
+  const {
+    buildGroupSearchText,
+    filterSessionNodesForSearch,
+    buildGroupedSessions,
+  } = useSessionGrouping({
+    homeDirectory,
+    pinnedSessionIds,
+    gitBranches,
+    isVSCode,
+    ownership: sessionOwnership,
+  });
   useSessionFolderCleanup({
     isSessionsLoading,
-    hasLoadedGlobalSessions,
-    sessions,
-    archivedSessions,
+    hasAuthoritativeGlobalSessions,
+    isWorktreeTopologyLoading,
     normalizedProjects,
-    isVSCode,
-    availableWorktreesByProject,
+    ownership: sessionOwnership,
     cleanupSessions,
   });
 
   const { getSessionsForProject, getArchivedSessionsForProject } = useProjectSessionLists({
-    isVSCode,
-    sessions,
-    archivedSessions,
-    availableWorktreesByProject,
-    normalizedProjects,
+    ownership: sessionOwnership,
   });
 
   useArchivedAutoFolders({
     normalizedProjects,
-    sessions,
-    archivedSessions,
-    availableWorktreesByProject,
-    isVSCode,
+    ownership: sessionOwnership,
     isSessionsLoading,
+    hasAuthoritativeGlobalSessions,
+    isWorktreeTopologyLoading,
     foldersMap,
     createFolder,
     addSessionToFolder,

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -444,7 +444,6 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
 
       const worktreesByProject = new Map<string, WorktreeMetadata[]>();
       const allWorktrees: WorktreeMetadata[] = [];
-      let discoveryFailed = false;
 
       // Constrain fanout: previously `Promise.all(projects.map(...))` could
       // spawn dozens of concurrent `git worktree list` and
@@ -474,7 +473,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
             worktreesByProject.set(projectPath, worktrees);
             allWorktrees.push(...worktrees);
           } catch {
-            discoveryFailed = true;
+            // A single unavailable project must not leave discovery loading forever.
           }
         }
       });
@@ -490,7 +489,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
           availableWorktreesByProject: worktreesByProject,
         });
       }
-      setIsWorktreeTopologyLoading(discoveryFailed);
+      setIsWorktreeTopologyLoading(false);
     };
 
     // Skip if we already discovered worktrees for this exact project set.

--- a/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
+++ b/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
@@ -33,6 +33,7 @@
 - `ConfirmDialogs.tsx`: Shared confirm dialog wrappers for session delete and folder delete flows.
 - `sortableItems.tsx`: DnD sortable wrappers for project and group ordering plus project-row action affordances.
 - `sessionFolderDnd.tsx`: Folder/session DnD scope and wrappers for dropping/moving sessions into folders.
+- `sessionOwnership.ts`: Resolves each session directory to one project/worktree owner and provides reusable project/scope buckets for the sidebar.
 
 ### Hooks
 
@@ -46,7 +47,7 @@
 - `hooks/useArchivedAutoFolders.ts`: Maintains archived auto-folder structure and assignment behavior.
 - `hooks/useSidebarPersistence.ts`: Persists sidebar UI state (expanded/collapsed/pinned/group order/active session) to storage + desktop settings.
 - `hooks/useProjectRepoStatus.ts`: Tracks per-project git-repo state and root branch metadata.
-- `hooks/useProjectSessionLists.ts`: Builds live and archived session lists for a given project (including worktrees + dedupe).
+- `hooks/useProjectSessionLists.ts`: Reads live and archived session buckets for a project from the shared ownership index.
 - `hooks/useSessionFolderCleanup.ts`: Cleans stale folder session IDs by reconciling known sessions/archived scopes.
 - `hooks/useStickyProjectHeaders.ts`: Tracks which project headers are sticky/stuck via `IntersectionObserver`.
 

--- a/packages/ui/src/components/session/sidebar/hooks/useArchivedAutoFolders.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useArchivedAutoFolders.ts
@@ -1,16 +1,12 @@
 import React from 'react';
-import type { Session } from '@opencode-ai/sdk/v2';
-import type { WorktreeMetadata } from '@/types/worktree';
 import {
-  collectKnownProjectDirectories,
-  dedupeSessionsById,
   getArchivedScopeKey,
-  isSessionRelatedToProject,
-  normalizePath,
   resolveArchivedFolderName,
 } from '../utils';
+import type { SessionOwnershipIndex } from '../sessionOwnership';
 
 type ProjectForArchivedFolders = {
+  id: string;
   normalizedPath: string;
 };
 
@@ -22,83 +18,39 @@ type FolderEntry = {
 
 type Args = {
   normalizedProjects: ProjectForArchivedFolders[];
-  sessions: Session[];
-  archivedSessions: Session[];
-  availableWorktreesByProject: Map<string, WorktreeMetadata[]>;
-  isVSCode: boolean;
+  ownership: SessionOwnershipIndex;
   isSessionsLoading: boolean;
+  hasAuthoritativeGlobalSessions: boolean;
+  isWorktreeTopologyLoading: boolean;
   foldersMap: Record<string, FolderEntry[]>;
   createFolder: (scopeKey: string, name: string, parentId?: string | null) => FolderEntry;
   addSessionToFolder: (scopeKey: string, folderId: string, sessionId: string) => void;
   cleanupSessions: (scopeKey: string, existingSessionIds: Set<string>) => void;
 };
 
-const getArchivedSessionsForProject = (
-  project: ProjectForArchivedFolders,
-  params: Pick<Args, 'sessions' | 'archivedSessions' | 'availableWorktreesByProject' | 'isVSCode'> & {
-    knownProjectDirectories: Set<string>;
-  },
-): Session[] => {
-  const worktreesForProject = params.isVSCode ? [] : (params.availableWorktreesByProject.get(project.normalizedPath) ?? []);
-  const validDirectories = new Set<string>([
-    project.normalizedPath,
-    ...worktreesForProject
-      .map((meta) => normalizePath(meta.path) ?? meta.path)
-      .filter((value): value is string => Boolean(value)),
-  ]);
-
-  const collect = (input: Session[]): Session[] => input.filter((session) =>
-    isSessionRelatedToProject(session, project.normalizedPath, validDirectories, params.knownProjectDirectories),
-  );
-
-  const archived = collect(params.archivedSessions);
-  const unassignedLive = params.sessions.filter((session) => {
-    if (session.time?.archived) {
-      return false;
-    }
-    const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
-    if (sessionDirectory) {
-      return false;
-    }
-    return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, params.knownProjectDirectories);
-  });
-
-  return dedupeSessionsById([...archived, ...unassignedLive]);
-};
-
 export const useArchivedAutoFolders = (args: Args): void => {
   const {
     normalizedProjects,
-    sessions,
-    archivedSessions,
-    availableWorktreesByProject,
-    isVSCode,
+    ownership,
     isSessionsLoading,
+    hasAuthoritativeGlobalSessions,
+    isWorktreeTopologyLoading,
     foldersMap,
     createFolder,
     addSessionToFolder,
     cleanupSessions,
   } = args;
 
-  const knownProjectDirectories = React.useMemo(
-    () => collectKnownProjectDirectories(normalizedProjects, availableWorktreesByProject, isVSCode),
-    [normalizedProjects, availableWorktreesByProject, isVSCode],
-  );
-
   React.useEffect(() => {
-    if (isSessionsLoading) {
+    if (isSessionsLoading || !hasAuthoritativeGlobalSessions || isWorktreeTopologyLoading) {
       return;
     }
 
     normalizedProjects.forEach((project) => {
       const scopeKey = getArchivedScopeKey(project.normalizedPath);
-      const projectArchivedSessions = getArchivedSessionsForProject(project, {
-        sessions,
-        archivedSessions,
-        availableWorktreesByProject,
-        isVSCode,
-        knownProjectDirectories,
-      });
+      const projectArchivedSessions = [
+        ...(ownership.archivedSessionsByProject.get(project.id) ?? []),
+      ];
       const sessionIds = new Set(projectArchivedSessions.map((session) => session.id));
 
       const existingFolders = foldersMap[scopeKey] ?? [];
@@ -122,12 +74,10 @@ export const useArchivedAutoFolders = (args: Args): void => {
     });
   }, [
     normalizedProjects,
-    sessions,
-    archivedSessions,
-    availableWorktreesByProject,
-    knownProjectDirectories,
-    isVSCode,
+    ownership,
     isSessionsLoading,
+    hasAuthoritativeGlobalSessions,
+    isWorktreeTopologyLoading,
     foldersMap,
     createFolder,
     addSessionToFolder,

--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionLists.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionLists.ts
@@ -1,159 +1,27 @@
 import React from 'react';
-import type { Session } from '@opencode-ai/sdk/v2';
-import { resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
-import { collectKnownProjectDirectories, dedupeSessionsById, isSessionRelatedToProject, normalizePath } from '../utils';
-
-type WorktreeMeta = { path: string };
-
-type NormalizedProject = { id: string; normalizedPath: string };
+import type { SessionOwnershipIndex } from '../sessionOwnership';
 
 type Args = {
-  isVSCode: boolean;
-  sessions: Session[];
-  archivedSessions: Session[];
-  availableWorktreesByProject: Map<string, WorktreeMeta[]>;
-  /**
-   * The set of normalized projects the sidebar will render. Used in
-   * Layer 4.13 to precompute the allowed directory set so the per-row
-   * `sessionsByDirectory` Map only contains buckets the sidebar will
-   * actually consume. With 10 projects × 5 worktrees and 100 sessions
-   * per directory this drops the Map from N entries to the small
-   * subset the sidebar needs.
-   */
-  normalizedProjects: NormalizedProject[];
+  ownership: SessionOwnershipIndex;
 };
 
 export const useProjectSessionLists = (args: Args) => {
   const {
-    isVSCode,
-    sessions,
-    archivedSessions,
-    availableWorktreesByProject,
-    normalizedProjects,
+    ownership,
   } = args;
 
-  // Precompute the set of directories the sidebar will ever ask about:
-  // every project's normalized path plus the path of each registered
-  // worktree. Walking this set is O(P + W) per Sidebar render and lets
-  // us skip the bulk of `sessions` (whose directory is not associated
-  // with a known project) when building `sessionsByDirectory`.
-  const knownProjectDirectories = React.useMemo(
-    () => collectKnownProjectDirectories(normalizedProjects, availableWorktreesByProject, isVSCode),
-    [normalizedProjects, availableWorktreesByProject, isVSCode],
-  );
-
-  const sessionsByDirectory = React.useMemo(() => {
-    const next = new Map<string, Session[]>();
-    sessions.forEach((session) => {
-      const directory = resolveGlobalSessionDirectory(session);
-      if (!directory) {
-        return;
-      }
-      // Skip sessions whose directory doesn't belong to any known
-      // project or worktree. Without this filter the Map grows with
-      // every session the server has ever seen, even ones for
-      // long-removed worktrees; the sidebar's downstream filters
-      // would then drop them anyway.
-      if (!knownProjectDirectories.has(directory)) {
-        return;
-      }
-
-      const collection = next.get(directory) ?? [];
-      collection.push(session);
-      next.set(directory, collection);
-    });
-    return next;
-  }, [sessions, knownProjectDirectories]);
-
   const getSessionsForProject = React.useCallback(
-    (project: { normalizedPath: string }) => {
-      const worktreesForProject = isVSCode ? [] : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
-      const directories = [
-        project.normalizedPath,
-        ...worktreesForProject
-          .map((meta) => normalizePath(meta.path) ?? meta.path)
-          .filter((value): value is string => Boolean(value)),
-      ];
-
-      const seen = new Set<string>();
-      const collected: Session[] = [];
-
-      directories.forEach((directory) => {
-        const sessionsForDirectory: Session[] = sessionsByDirectory.get(directory) ?? [];
-        sessionsForDirectory.forEach((session) => {
-          if (seen.has(session.id)) {
-            return;
-          }
-          seen.add(session.id);
-          collected.push(session);
-        });
-      });
-
-      return collected;
+    (projectId: string) => {
+      return ownership.sessionsByProject.get(projectId) ?? [];
     },
-    [availableWorktreesByProject, isVSCode, sessionsByDirectory],
+    [ownership],
   );
 
   const getArchivedSessionsForProject = React.useCallback(
-    (project: { normalizedPath: string }) => {
-      if (isVSCode) {
-        const archived = archivedSessions.filter((session) => {
-          const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
-          const projectWorktree = normalizePath((session as Session & { project?: { worktree?: string | null } | null }).project?.worktree ?? null);
-
-          if (sessionDirectory) {
-            return sessionDirectory === project.normalizedPath;
-          }
-
-          return projectWorktree === project.normalizedPath;
-        });
-
-        const unassignedLive = sessions.filter((session) => {
-          if (session.time?.archived) {
-            return false;
-          }
-          const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
-          if (sessionDirectory) {
-            return false;
-          }
-          const projectWorktree = normalizePath((session as Session & { project?: { worktree?: string | null } | null }).project?.worktree ?? null);
-          return projectWorktree === project.normalizedPath;
-        });
-
-        return dedupeSessionsById([...archived, ...unassignedLive]);
-      }
-
-      const worktreesForProject = isVSCode ? [] : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
-      const validDirectories = new Set<string>([
-        project.normalizedPath,
-        ...worktreesForProject
-          .map((meta) => normalizePath(meta.path) ?? meta.path)
-          .filter((value): value is string => Boolean(value)),
-      ]);
-
-      const collect = (input: Session[]): Session[] => input.filter((session) =>
-        isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories),
-      );
-
-      const archived = collect(archivedSessions);
-      const unassignedLive = sessions.filter((session) => {
-        if (session.time?.archived) {
-          return false;
-        }
-        const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
-        if (sessionDirectory) {
-          return false;
-        }
-        const projectWorktree = normalizePath((session as Session & { project?: { worktree?: string | null } | null }).project?.worktree ?? null);
-        if (!projectWorktree) {
-          return false;
-        }
-        return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories);
-      });
-
-      return dedupeSessionsById([...archived, ...unassignedLive]);
+    (projectId: string) => {
+      return ownership.archivedSessionsByProject.get(projectId) ?? [];
     },
-    [archivedSessions, availableWorktreesByProject, isVSCode, knownProjectDirectories, sessions],
+    [ownership],
   );
 
   return {

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionFolderCleanup.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionFolderCleanup.ts
@@ -1,97 +1,54 @@
 import React from 'react';
-import type { Session } from '@opencode-ai/sdk/v2';
 import { useSessionFoldersStore } from '@/stores/useSessionFoldersStore';
 import {
-  collectKnownProjectDirectories,
-  dedupeSessionsById,
   getArchivedScopeKey,
-  isSessionRelatedToProject,
-  normalizePath,
 } from '../utils';
+import type { SessionOwnershipIndex } from '../sessionOwnership';
 
 type NormalizedProject = {
   id: string;
   normalizedPath: string;
 };
 
-type WorktreeMeta = { path: string };
-
 type Args = {
   isSessionsLoading: boolean;
-  hasLoadedGlobalSessions: boolean;
-  sessions: Session[];
-  archivedSessions: Session[];
+  hasAuthoritativeGlobalSessions: boolean;
+  isWorktreeTopologyLoading: boolean;
   normalizedProjects: NormalizedProject[];
-  isVSCode: boolean;
-  availableWorktreesByProject: Map<string, WorktreeMeta[]>;
+  ownership: SessionOwnershipIndex;
   cleanupSessions: (scopeKey: string, validSessionIds: Set<string>) => void;
 };
 
 export const useSessionFolderCleanup = (args: Args): void => {
   const {
     isSessionsLoading,
-    hasLoadedGlobalSessions,
-    sessions,
-    archivedSessions,
+    hasAuthoritativeGlobalSessions,
+    isWorktreeTopologyLoading,
     normalizedProjects,
-    isVSCode,
-    availableWorktreesByProject,
+    ownership,
     cleanupSessions,
   } = args;
 
-  const knownProjectDirectories = React.useMemo(
-    () => collectKnownProjectDirectories(normalizedProjects, availableWorktreesByProject, isVSCode),
-    [normalizedProjects, availableWorktreesByProject, isVSCode],
-  );
-
   React.useEffect(() => {
-    if (isSessionsLoading || !hasLoadedGlobalSessions) {
+    if (isSessionsLoading || !hasAuthoritativeGlobalSessions || isWorktreeTopologyLoading) {
       return;
     }
 
-    if (sessions.length === 0 && archivedSessions.length === 0) {
+    if (ownership.bySessionId.size === 0) {
       return;
     }
 
     const idsByScope = new Map<string, Set<string>>();
-    sessions.forEach((session) => {
-      const directory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
-      if (!directory) {
-        return;
-      }
-      const existing = idsByScope.get(directory);
-      if (existing) {
-        existing.add(session.id);
-        return;
-      }
-      idsByScope.set(directory, new Set([session.id]));
+    ownership.sessionsByScope.forEach((sessionIds, scopeDirectory) => {
+      idsByScope.set(scopeDirectory, new Set(sessionIds));
     });
 
     normalizedProjects.forEach((project) => {
       const scopeKey = getArchivedScopeKey(project.normalizedPath);
-      const worktreesForProject = isVSCode ? [] : (availableWorktreesByProject.get(project.normalizedPath) ?? []);
-      const validDirectories = new Set<string>([
-        project.normalizedPath,
-        ...worktreesForProject
-          .map((meta) => normalizePath(meta.path) ?? meta.path)
-          .filter((value): value is string => Boolean(value)),
+      const archivedIds = new Set([
+        ...(ownership.archivedSessionsByProject.get(project.id) ?? []).map((session) => session.id),
       ]);
-
-      const archivedForProject = dedupeSessionsById([
-        ...archivedSessions,
-        ...sessions.filter((session) => {
-          if (session.time?.archived) {
-            return false;
-          }
-          const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
-          if (sessionDirectory) {
-            return false;
-          }
-          return isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories);
-        }),
-      ]).filter((session) => isSessionRelatedToProject(session, project.normalizedPath, validDirectories, knownProjectDirectories));
-
-      idsByScope.set(scopeKey, new Set(archivedForProject.map((session) => session.id)));
+      idsByScope.set(scopeKey, archivedIds);
     });
 
     const currentFoldersMap = useSessionFoldersStore.getState().foldersMap;
@@ -100,14 +57,11 @@ export const useSessionFolderCleanup = (args: Args): void => {
       cleanupSessions(scopeKey, idsByScope.get(scopeKey) ?? new Set<string>());
     });
   }, [
-    archivedSessions,
-    availableWorktreesByProject,
     cleanupSessions,
-    hasLoadedGlobalSessions,
+    hasAuthoritativeGlobalSessions,
+    isWorktreeTopologyLoading,
     isSessionsLoading,
-    isVSCode,
-    knownProjectDirectories,
     normalizedProjects,
-    sessions,
+    ownership,
   ]);
 };

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionGrouping.ts
@@ -11,14 +11,14 @@ import {
 } from '../utils';
 import { formatDirectoryName, formatPathForDisplay } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
-import { resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
+import type { SessionOwnershipIndex } from '../sessionOwnership';
 
 type Args = {
   homeDirectory: string | null;
-  worktreeMetadata: Map<string, WorktreeMetadata>;
   pinnedSessionIds: Set<string>;
   gitBranches: Map<string, string | null>;
   isVSCode: boolean;
+  ownership: SessionOwnershipIndex;
 };
 
 const isArchivedSession = (session: Session): boolean => Boolean(session.time?.archived);
@@ -94,16 +94,11 @@ export const useSessionGrouping = (args: Args) => {
       });
 
       const getSessionWorktree = (session: Session): WorktreeMetadata | null => {
-        const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);
-        const sessionWorktreeMeta = args.worktreeMetadata.get(session.id) ?? null;
-        if (sessionWorktreeMeta) return sessionWorktreeMeta;
-        if (sessionDirectory) {
-          const worktree = worktreeByPath.get(sessionDirectory) ?? null;
-          if (worktree && sessionDirectory !== normalizedProjectRoot) {
-            return worktree;
-          }
+        const scopeDirectory = args.ownership.bySessionId.get(session.id)?.scopeDirectory;
+        if (!scopeDirectory || scopeDirectory === normalizedProjectRoot) {
+          return null;
         }
-        return null;
+        return worktreeByPath.get(scopeDirectory) ?? null;
       };
 
       const buildProjectNode = (session: Session): SessionNode => {
@@ -129,11 +124,9 @@ export const useSessionGrouping = (args: Args) => {
         // Worktrees aren't registered in VS Code, so the desktop directory-match
         // below would otherwise dump these sessions into the archived bucket.
         if (args.isVSCode) return normalizedProjectRoot ?? '__project_root__';
-        const metadataPath = normalizePath(args.worktreeMetadata.get(session.id)?.path ?? null);
-        const normalizedDir = metadataPath ?? resolveGlobalSessionDirectory(session);
-        if (!normalizedDir) return archivedKey;
-        if (normalizedDir !== normalizedProjectRoot && worktreeByPath.has(normalizedDir)) return normalizedDir;
-        if (normalizedDir === normalizedProjectRoot) return normalizedProjectRoot ?? '__project_root__';
+        const scopeDirectory = args.ownership.bySessionId.get(session.id)?.scopeDirectory;
+        if (scopeDirectory && scopeDirectory !== normalizedProjectRoot && worktreeByPath.has(scopeDirectory)) return scopeDirectory;
+        if (scopeDirectory === normalizedProjectRoot) return normalizedProjectRoot ?? '__project_root__';
         return archivedKey;
       };
 
@@ -246,7 +239,7 @@ export const useSessionGrouping = (args: Args) => {
 
       return groups;
     },
-    [args.homeDirectory, args.worktreeMetadata, args.pinnedSessionIds, args.gitBranches, args.isVSCode, t],
+    [args.homeDirectory, args.ownership, args.pinnedSessionIds, args.gitBranches, args.isVSCode, t],
   );
 
   return {

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionSidebarSections.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionSidebarSections.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
 import type { SessionGroup, SessionNode, GroupSearchData } from '../types';
-import { dedupeSessionsById, normalizePath } from '../utils';
+import { normalizePath } from '../utils';
 import type { WorktreeMetadata } from '@/types/worktree';
 import type { SessionFoldersMap } from '@/stores/useSessionFoldersStore';
 
@@ -23,8 +23,8 @@ type ProjectSection = {
 
 type Args = {
   normalizedProjects: ProjectItem[];
-  getSessionsForProject: (project: { normalizedPath: string }) => Session[];
-  getArchivedSessionsForProject: (project: { normalizedPath: string }) => Session[];
+  getSessionsForProject: (projectId: string) => Session[];
+  getArchivedSessionsForProject: (projectId: string) => Session[];
   availableWorktreesByProject: Map<string, WorktreeMetadata[]>;
   projectRepoStatus: Map<string, boolean | null>;
   projectRootBranches: Map<string, string | null>;
@@ -62,10 +62,10 @@ export const useSessionSidebarSections = (args: Args) => {
 
   const projectSections = React.useMemo<ProjectSection[]>(() => {
     return normalizedProjects.map((project) => {
-      const projectSessions = dedupeSessionsById([
-        ...getSessionsForProject(project),
-        ...getArchivedSessionsForProject(project),
-      ]);
+      const projectSessions = [
+        ...getSessionsForProject(project.id),
+        ...getArchivedSessionsForProject(project.id),
+      ];
       const worktreesForProject = availableWorktreesByProject.get(project.normalizedPath) ?? [];
       const isRepo = projectRepoStatus.has(project.id)
         ? Boolean(projectRepoStatus.get(project.id))

--- a/packages/ui/src/components/session/sidebar/sessionOwnership.test.ts
+++ b/packages/ui/src/components/session/sidebar/sessionOwnership.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import type { Session } from '@opencode-ai/sdk/v2';
+
+import { createSessionOwnershipIndex } from './sessionOwnership';
+
+describe('createSessionOwnershipIndex', () => {
+  test('caches unique directories and returns active project and scope buckets', () => {
+    const sessions = [
+      { id: 'nested', directory: '/projects/app/packages/admin/src' },
+      { id: 'external-worktree', directory: '/worktrees/app-feature/src' },
+      { id: 'worktree-fallback', project: { worktree: '/worktrees/app-feature/src' } },
+      { id: 'directory-wins', directory: '/projects/app/packages/admin', project: { worktree: '/projects/app' } },
+      { id: 'windows', directory: 'c:\\Projects\\App\\src' },
+      { id: 'unassigned', directory: '/elsewhere' },
+      { id: 'same-directory', directory: '/projects/app/packages/admin/src' },
+    ] as unknown as Session[];
+    const normalizedProjects = [
+      { id: 'app', normalizedPath: '/projects/app' },
+      { id: 'admin', normalizedPath: '/projects/app/packages/admin' },
+      { id: 'windows-app', normalizedPath: 'C:/Projects/App' },
+    ];
+    const worktreesByProject = new Map([
+      ['/projects/app', [{ path: '/worktrees/app-feature' }]],
+    ]);
+
+    const ownership = createSessionOwnershipIndex(sessions, normalizedProjects, worktreesByProject, false);
+
+    expect(ownership.bySessionId.get('nested')?.projectId).toBe('admin');
+    expect(ownership.bySessionId.get('external-worktree')).toEqual({
+      projectId: 'app',
+      projectRoot: '/projects/app',
+      scopeDirectory: '/worktrees/app-feature',
+      kind: 'worktree',
+    });
+    expect(ownership.bySessionId.get('directory-wins')?.projectId).toBe('admin');
+    expect(ownership.bySessionId.get('worktree-fallback')?.scopeDirectory).toBe('/worktrees/app-feature');
+    expect(ownership.bySessionId.get('windows')?.projectId).toBe('windows-app');
+    expect(ownership.bySessionId.has('unassigned')).toBe(false);
+    expect(ownership.directoryResolutions).toBe(5);
+    expect(ownership.sessionsByProject.get('admin')?.map((session) => session.id)).toEqual([
+      'nested',
+      'directory-wins',
+      'same-directory',
+    ]);
+    expect(ownership.sessionsByProject.get('app')?.map((session) => session.id)).toEqual([
+      'external-worktree',
+      'worktree-fallback',
+    ]);
+    expect(ownership.sessionsByScope.get('/worktrees/app-feature')).toEqual(new Set([
+      'external-worktree',
+      'worktree-fallback',
+    ]));
+    expect(ownership.sessionsByScope.get('/projects/app/packages/admin')).toEqual(new Set([
+      'nested',
+      'directory-wins',
+      'same-directory',
+    ]));
+  });
+
+  test('keeps the deepest project owner when a worktree path exactly collides with it', () => {
+    const ownership = createSessionOwnershipIndex(
+      [{ id: 'nested-session', directory: '/projects/app/packages/admin/src' } as Session],
+      [
+        { id: 'app', normalizedPath: '/projects/app' },
+        { id: 'admin', normalizedPath: '/projects/app/packages/admin' },
+      ],
+      new Map([
+        ['/projects/app', [{ path: '/projects/app/packages/admin' }]],
+      ]),
+      false,
+    );
+
+    expect(ownership.bySessionId.get('nested-session')).toEqual({
+      projectId: 'admin',
+      projectRoot: '/projects/app/packages/admin',
+      scopeDirectory: '/projects/app/packages/admin',
+      kind: 'project',
+    });
+  });
+
+  test('keeps archived sessions in the resolved project and worktree buckets', () => {
+    const ownership = createSessionOwnershipIndex(
+      [],
+      [{ id: 'app', normalizedPath: '/projects/app' }],
+      new Map([
+        ['/projects/app', [{ path: '/worktrees/app-feature' }]],
+      ]),
+      false,
+      [
+        { id: 'archived-child', directory: '/worktrees/app-feature/src', time: { archived: 1 } },
+        { id: 'archived-fallback', project: { worktree: '/worktrees/app-feature' }, time: { archived: 1 } },
+      ] as unknown as Session[],
+    );
+
+    expect(ownership.archivedSessionsByProject.get('app')?.map((session) => session.id)).toEqual([
+      'archived-child',
+      'archived-fallback',
+    ]);
+  });
+
+  test('only assigns VS Code sessions to an exact workspace directory', () => {
+    const ownership = createSessionOwnershipIndex(
+      [
+        { id: 'workspace', directory: '/projects/app' },
+        { id: 'nested', directory: '/projects/app/packages/ui' },
+      ] as Session[],
+      [{ id: 'app', normalizedPath: '/projects/app' }],
+      new Map(),
+      true,
+    );
+
+    expect(ownership.bySessionId.get('workspace')?.projectId).toBe('app');
+    expect(ownership.bySessionId.has('nested')).toBe(false);
+  });
+});

--- a/packages/ui/src/components/session/sidebar/sessionOwnership.ts
+++ b/packages/ui/src/components/session/sidebar/sessionOwnership.ts
@@ -1,0 +1,183 @@
+import type { Session } from '@opencode-ai/sdk/v2';
+import { normalizePath } from '@/lib/pathNormalization';
+
+type Project = {
+  id: string;
+  normalizedPath: string;
+};
+
+type Worktree = {
+  path: string;
+};
+
+export type DirectoryOwner = {
+  projectId: string;
+  projectRoot: string;
+  scopeDirectory: string;
+  kind: 'project' | 'worktree';
+};
+
+export type SessionOwnershipIndex = {
+  bySessionId: Map<string, DirectoryOwner>;
+  sessionsByProject: Map<string, Session[]>;
+  archivedSessionsByProject: Map<string, Session[]>;
+  sessionsByScope: Map<string, Set<string>>;
+  directoryResolutions: number;
+};
+
+const shouldReplaceOwner = (existing: DirectoryOwner | undefined, candidate: DirectoryOwner): boolean => {
+  if (!existing) return true;
+  if (candidate.kind !== existing.kind) {
+    return candidate.kind === 'project';
+  }
+  if (candidate.projectRoot.length !== existing.projectRoot.length) {
+    return candidate.projectRoot.length > existing.projectRoot.length;
+  }
+  return candidate.projectId.localeCompare(existing.projectId) < 0;
+};
+
+const setOwner = (owners: Map<string, DirectoryOwner>, directory: string, candidate: DirectoryOwner): void => {
+  const existing = owners.get(directory);
+  if (shouldReplaceOwner(existing, candidate)) {
+    owners.set(directory, candidate);
+  }
+};
+
+const resolveSessionDirectory = (session: Session): string | null => {
+  const record = session as Session & {
+    directory?: string | null;
+    project?: { worktree?: string | null } | null;
+  };
+
+  const directory = normalizePath(record.directory);
+  if (directory) {
+    return directory;
+  }
+  return normalizePath(record.project?.worktree);
+};
+
+const getParentDirectory = (directory: string): string | null => {
+  if (directory === '/' || /^[A-Z]:\/$/.test(directory)) {
+    return null;
+  }
+  const separator = directory.lastIndexOf('/');
+  if (separator < 0) {
+    return null;
+  }
+  if (separator === 0) {
+    return '/';
+  }
+  return directory.slice(0, separator);
+};
+
+export const createSessionOwnershipIndex = (
+  sessions: Session[],
+  projects: Project[],
+  availableWorktreesByProject: Map<string, Worktree[]>,
+  isVSCode: boolean,
+  archivedSessions: Session[] = [],
+): SessionOwnershipIndex => {
+  const ownerByDirectory = new Map<string, DirectoryOwner>();
+  const projectByRoot = new Map<string, Project>();
+
+  for (const project of projects) {
+    const projectRoot = normalizePath(project.normalizedPath);
+    if (!projectRoot) continue;
+    const existingProject = projectByRoot.get(projectRoot);
+    if (!existingProject || project.id.localeCompare(existingProject.id) < 0) {
+      projectByRoot.set(projectRoot, project);
+    }
+    setOwner(ownerByDirectory, projectRoot, {
+      projectId: project.id,
+      projectRoot,
+      scopeDirectory: projectRoot,
+      kind: 'project',
+    });
+  }
+
+  if (!isVSCode) {
+    for (const [projectPath, worktrees] of availableWorktreesByProject) {
+      const projectRoot = normalizePath(projectPath);
+      const project = projectRoot ? projectByRoot.get(projectRoot) : undefined;
+      if (!project || !projectRoot) continue;
+      for (const worktree of worktrees) {
+        const directory = normalizePath(worktree.path);
+        if (!directory) continue;
+        setOwner(ownerByDirectory, directory, {
+          projectId: project.id,
+          projectRoot,
+          scopeDirectory: directory,
+          kind: 'worktree',
+        });
+      }
+    }
+  }
+
+  const resolvedOwners = new Map<string, DirectoryOwner | null>();
+  const bySessionId = new Map<string, DirectoryOwner>();
+  const sessionsByProject = new Map<string, Session[]>();
+  const archivedSessionsByProject = new Map<string, Session[]>();
+  const sessionsByScope = new Map<string, Set<string>>();
+
+  const resolveOwner = (directory: string | null): DirectoryOwner | null => {
+    if (!directory) return null;
+    if (resolvedOwners.has(directory)) {
+      return resolvedOwners.get(directory) ?? null;
+    }
+
+    if (isVSCode) {
+      const owner = ownerByDirectory.get(directory) ?? null;
+      resolvedOwners.set(directory, owner);
+      return owner;
+    }
+
+    let current: string | null = directory;
+    while (current) {
+      const owner = ownerByDirectory.get(current);
+      if (owner) {
+        resolvedOwners.set(directory, owner);
+        return owner;
+      }
+      current = getParentDirectory(current);
+    }
+    resolvedOwners.set(directory, null);
+    return null;
+  };
+
+  const bucket = (
+    input: Session[],
+    target: Map<string, Session[]>,
+    scopeTarget?: Map<string, Set<string>>,
+  ) => {
+    for (const session of input) {
+      const directory = resolveSessionDirectory(session);
+      const owner = resolveOwner(directory);
+      if (!owner) continue;
+      bySessionId.set(session.id, owner);
+      const projectSessions = target.get(owner.projectId);
+      if (projectSessions) {
+        projectSessions.push(session);
+      } else {
+        target.set(owner.projectId, [session]);
+      }
+      if (!scopeTarget) continue;
+      const scopeSessions = scopeTarget.get(owner.scopeDirectory);
+      if (scopeSessions) {
+        scopeSessions.add(session.id);
+      } else {
+        scopeTarget.set(owner.scopeDirectory, new Set([session.id]));
+      }
+    }
+  };
+
+  bucket(sessions, sessionsByProject, sessionsByScope);
+  bucket(archivedSessions, archivedSessionsByProject);
+
+  return {
+    bySessionId,
+    sessionsByProject,
+    archivedSessionsByProject,
+    sessionsByScope,
+    directoryResolutions: resolvedOwners.size,
+  };
+};


### PR DESCRIPTION
## Summary

- Replace repeated project/session relationship scans with a shared ownership index derived from the current project and worktree topology.
- Resolve each unique session directory once, then expose direct project and scope buckets to sidebar grouping, folder cleanup, and archived-folder assignment.
- Keep directory precedence and platform semantics explicit: session directory before project worktree, deepest desktop owner, exact VS Code workspace matching, external worktrees, and deterministic project precedence for directory collisions.
- Only reconcile persisted folder assignments after an authoritative session snapshot and complete worktree topology are available.

The sidebar data model now represents the actual domain relationship directly: each session has one resolved project/worktree owner. This makes consumers simpler and reduces ownership work from repeated project-by-session scans to one topology build, one unique-directory resolution pass, and direct bucket reads.

## Validation

- bun test v1.3.14 (0d9b296a)
- 
- 

 could not run locally because the  binary is unavailable in the workspace environment.