### PR TITLE
fix(chat): restore editor font size styling in chat input

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1128,6 +1128,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
     const inputBarOffset = useUIStore((state) => state.inputBarOffset);
     const persistChatDraft = useUIStore((state) => state.persistChatDraft);
     const inputSpellcheckEnabled = useUIStore((state) => state.inputSpellcheckEnabled);
+    const editorFontSize = useUIStore((state) => state.editorFontSize);
     const isExpandedInput = useUIStore((state) => state.isExpandedInput);
     const setExpandedInput = useUIStore((state) => state.setExpandedInput);
     const setTimelineDialogOpen = useUIStore((state) => state.setTimelineDialogOpen);
@@ -5311,6 +5312,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                                     maxHeight: !isComposerExpanded && textareaSize ? `${textareaSize.maxHeight}px` : undefined,
                                     borderTopLeftRadius: chatInputRadius,
                                     borderTopRightRadius: chatInputRadius,
+                                    fontSize: `${editorFontSize}px`,
                                 }}
                                 rows={1}
                             />


### PR DESCRIPTION
## Description

Fixes #2198.

Commit `37e6bcded` removed the `editorFontSize` reading and inline `fontSize` styling from `ChatInput.tsx`, calling it "unused". However this code was the core of the editor font size feature (added in `1f7d15685`) — it applies the user's chosen font size to the chat input textarea.

Without it, changing **Settings → Appearance → Editor font size** has no effect on the chat input textarea. The CodeMirror editor (FilesView, PlanView) was unaffected because its font size path was not touched.

## Changes

Restores the two lines removed by `37e6bcded` in `packages/ui/src/components/chat/ChatInput.tsx`:

1. Store selector: `const editorFontSize = useUIStore((state) => state.editorFontSize);`
2. Inline style: `fontSize: \`${editorFontSize}px\`,`

## Validation

- `editorFontSize` field and `setEditorFontSize` action exist in `useUIStore` — verified.
- Type-check: pre-existing `@types/dom-speech-recognition` error only, no new errors.
- The same pattern (store selector + inline px style) is used by `terminalFontSize` in the same component.
