### PR TITLE
feat(multi-host): MultiHostSessionTree sidebar component (PR 3)

### DIFF
--- a/packages/ui/src/components/session/multi-host/HostConnectionIndicator.tsx
+++ b/packages/ui/src/components/session/multi-host/HostConnectionIndicator.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Icon } from '@/components/icon/Icon';
+import type { HostConnectionSummary, HostTransport } from '@/multi-host';
+import { cn } from '@/lib/utils';
+import {
+  connectionStateLabel,
+  transportIconName,
+  transportKindLabel,
+} from './multi-host-sidebar-types';
+
+type HostConnectionIndicatorProps = {
+  connection: HostConnectionSummary;
+  transport: HostTransport;
+  className?: string;
+};
+
+function connectionStateColor(state: HostConnectionSummary['state']): string {
+  switch (state) {
+    case 'connected':
+      return 'text-[var(--status-success)]';
+    case 'connecting':
+      return 'text-[var(--status-info)]';
+    case 'error':
+      return 'text-[var(--status-error)]';
+    case 'disconnected':
+      return 'text-muted-foreground';
+  }
+}
+
+function connectionStateIcon(state: HostConnectionSummary['state']): string {
+  switch (state) {
+    case 'connected':
+      return 'checkbox-circle';
+    case 'connecting':
+      return 'loader-4';
+    case 'error':
+      return 'error-warning';
+    case 'disconnected':
+      return 'close-circle';
+  }
+}
+
+export const HostConnectionIndicator = React.memo(
+  function HostConnectionIndicator({
+    connection,
+    transport,
+    className,
+  }: HostConnectionIndicatorProps) {
+    const kindLabel = transportKindLabel(transport);
+    const stateLabel = connectionStateLabel(connection.state);
+    const ariaLabel = `${kindLabel} · ${stateLabel}${connection.error ? `: ${connection.error}` : ''}`;
+
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 text-[0.65rem] typography-meta',
+          connectionStateColor(connection.state),
+          className,
+        )}
+        aria-label={ariaLabel}
+      >
+        <Icon
+          name={connectionStateIcon(connection.state) as never}
+          className={cn(
+            'h-3 w-3',
+            connection.state === 'connecting' && 'animate-spin',
+          )}
+        />
+        <span>{stateLabel}</span>
+        <span className="text-muted-foreground">·</span>
+        <Icon
+          name={transportIconName(transport) as never}
+          className="h-3 w-3"
+        />
+        <span>{kindLabel}</span>
+      </span>
+    );
+  },
+);

--- a/packages/ui/src/components/session/multi-host/HostNode.tsx
+++ b/packages/ui/src/components/session/multi-host/HostNode.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { Icon } from '@/components/icon/Icon';
+import { cn } from '@/lib/utils';
+import type { HostId, HostSessionRef } from '@/multi-host';
+import { useHost } from '@/multi-host';
+import { HostConnectionIndicator } from './HostConnectionIndicator';
+import { HostProjectNode } from './HostProjectNode';
+import { HostStatusBadge } from './HostStatusBadge';
+import type {
+  ProjectGroup,
+  SessionExtraStatus,
+} from './multi-host-sidebar-types';
+import { deriveSessionStatus, projectFoldKey } from './multi-host-sidebar-types';
+
+type HostNodeProps = {
+  hostId: HostId;
+  activeHostId?: HostId;
+  activeSessionId?: string;
+  activationPendingRef?: HostSessionRef | null;
+  sessionExtras?: Record<HostId, Record<string, SessionExtraStatus>>;
+  isCollapsed: boolean;
+  collapsedProjects: Record<string, boolean>;
+  onToggleHostCollapse: () => void;
+  onToggleProjectCollapse: (key: string) => void;
+  onActivateSession: (ref: HostSessionRef) => void;
+};
+
+function buildProjectGroups(
+  hostId: HostId,
+  sessions: Record<string, { projectId?: string; directory?: string; title?: string; updatedAt?: number; id: string }>,
+  statuses: Record<string, { status: 'idle' | 'busy' | 'retry' }>,
+  unreadBySession: Record<string, number>,
+  sessionExtras?: Record<string, SessionExtraStatus>,
+): ProjectGroup[] {
+  const projectMap = new Map<string, ProjectGroup>();
+
+  for (const [sessionId, session] of Object.entries(sessions)) {
+    const projectId = session.projectId || 'unknown';
+    const directory = session.directory || '';
+    const projectName = directory.split('/').pop() || projectId;
+
+    if (!projectMap.has(projectId)) {
+      projectMap.set(projectId, {
+        projectId,
+        projectName,
+        directory,
+        sessions: [],
+        unreadCount: 0,
+        sessionCount: 0,
+      });
+    }
+
+    const group = projectMap.get(projectId)!;
+    const unread = unreadBySession[sessionId] ?? 0;
+    const extra = sessionExtras?.[sessionId];
+    const derivedStatus = deriveSessionStatus(statuses[sessionId], unread, extra);
+
+    const sessionRef: HostSessionRef = {
+      hostId,
+      sessionId,
+      directory,
+      projectId,
+    };
+
+    group.sessions.push({
+      ref: sessionRef,
+      session,
+      status: derivedStatus,
+      unreadCount: unread,
+    });
+    group.unreadCount += unread;
+    group.sessionCount += 1;
+  }
+
+  return Array.from(projectMap.values());
+}
+
+export const HostNode = React.memo(function HostNode({
+  hostId,
+  activeHostId,
+  activeSessionId,
+  activationPendingRef,
+  sessionExtras,
+  isCollapsed,
+  collapsedProjects,
+  onToggleHostCollapse,
+  onToggleProjectCollapse,
+  onActivateSession,
+}: HostNodeProps) {
+  const host = useHost(hostId);
+
+  const projectGroups = React.useMemo(() => {
+    if (!host) return [];
+    const extras = sessionExtras?.[hostId];
+    return buildProjectGroups(
+      hostId,
+      host.sessions,
+      host.statuses,
+      host.unreadBySession,
+      extras,
+    );
+  }, [host, hostId, sessionExtras]);
+
+  const summary = React.useMemo(() => {
+    if (!host) return null;
+
+    let unreadTotal = 0;
+    let waitingPermissionCount = 0;
+    let waitingQuestionCount = 0;
+    let hasBusySession = false;
+    const extras = sessionExtras?.[hostId];
+
+    for (const count of Object.values(host.unreadBySession)) {
+      unreadTotal += count;
+    }
+    for (const sessionStatus of Object.values(host.statuses)) {
+      if (sessionStatus.status === 'busy') hasBusySession = true;
+    }
+    if (extras) {
+      for (const extra of Object.values(extras)) {
+        if (extra.hasWaitingPermission) waitingPermissionCount += 1;
+        if (extra.hasWaitingQuestion) waitingQuestionCount += 1;
+      }
+    }
+
+    return {
+      unreadTotal,
+      waitingPermissionCount,
+      waitingQuestionCount,
+      hasBusySession,
+      sessionCount: Object.keys(host.sessions).length,
+    };
+  }, [host, hostId, sessionExtras]);
+
+  const handleToggleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onToggleHostCollapse();
+      }
+    },
+    [onToggleHostCollapse],
+  );
+
+  if (!host) return null;
+
+  const isActiveHost = activeHostId === hostId;
+
+  return (
+    <div
+      className={cn(
+        'mb-1',
+        isActiveHost && 'rounded-md bg-[var(--interactive-selection)]/30',
+      )}
+    >
+      {/* Host header */}
+      <button
+        type="button"
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left',
+          'hover:bg-[var(--interactive-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+        )}
+        onClick={onToggleHostCollapse}
+        onKeyDown={handleToggleKeyDown}
+        aria-expanded={!isCollapsed}
+        aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${host.descriptor.label}`}
+      >
+        <Icon
+          name={isCollapsed ? 'arrow-right-s' : 'arrow-down-s'}
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+        />
+        <span className="min-w-0 flex-1 truncate typography-ui-label font-semibold text-foreground">
+          {host.descriptor.label}
+        </span>
+      </button>
+
+      {/* Connection indicator */}
+      {!isCollapsed && (
+        <div className="ml-6 mb-1">
+          <HostConnectionIndicator
+            connection={host.connection}
+            transport={host.descriptor.transport}
+          />
+        </div>
+      )}
+
+      {/* Collapsed summary */}
+      {isCollapsed && summary && (
+        <div className="ml-6 mb-1 flex items-center gap-2">
+          <HostConnectionIndicator
+            connection={host.connection}
+            transport={host.descriptor.transport}
+          />
+          {summary.unreadTotal > 0 && (
+            <span className="inline-flex items-center gap-0.5">
+              <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-info)]" />
+              <span className="text-[0.6rem] typography-meta text-[var(--status-info)]">
+                {summary.unreadTotal}
+              </span>
+            </span>
+          )}
+          {summary.waitingPermissionCount > 0 && (
+            <HostStatusBadge
+              status="waiting-permission"
+              count={summary.waitingPermissionCount}
+            />
+          )}
+          {summary.waitingQuestionCount > 0 && (
+            <HostStatusBadge
+              status="waiting-question"
+              count={summary.waitingQuestionCount}
+            />
+          )}
+          {summary.hasBusySession && (
+            <HostStatusBadge status="busy" />
+          )}
+        </div>
+      )}
+
+      {/* Expanded projects */}
+      {!isCollapsed && (
+        <div className="ml-1">
+          {projectGroups.length === 0 && (
+            <div className="px-4 py-2 text-[0.7rem] typography-meta text-muted-foreground">
+              No sessions
+            </div>
+          )}
+          {projectGroups.map((project) => (
+            <HostProjectNode
+              key={`project:${hostId}:${project.projectId}`}
+              hostId={hostId}
+              project={project}
+              activeSessionId={activeSessionId}
+              activationPendingSessionId={activationPendingRef?.hostId === hostId ? activationPendingRef.sessionId : undefined}
+              sessionExtras={sessionExtras?.[hostId]}
+              isCollapsed={collapsedProjects[projectFoldKey(hostId, project.projectId)] ?? false}
+              onToggleCollapse={() =>
+                onToggleProjectCollapse(projectFoldKey(hostId, project.projectId))
+              }
+              onActivateSession={onActivateSession}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/ui/src/components/session/multi-host/HostProjectNode.tsx
+++ b/packages/ui/src/components/session/multi-host/HostProjectNode.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { Icon } from '@/components/icon/Icon';
+import { cn } from '@/lib/utils';
+import type { HostSessionRef } from '@/multi-host';
+import type {
+  DerivedSessionStatus,
+  ProjectGroup,
+  SessionExtraStatus,
+} from './multi-host-sidebar-types';
+import { HostSessionNode } from './HostSessionNode';
+
+type HostProjectNodeProps = {
+  hostId: string;
+  project: ProjectGroup;
+  activeSessionId?: string;
+  activationPendingSessionId?: string;
+  sessionExtras?: Record<string, SessionExtraStatus>;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onActivateSession: (ref: HostSessionRef) => void;
+};
+
+export const HostProjectNode = React.memo(function HostProjectNode({
+  hostId,
+  project,
+  activeSessionId,
+  activationPendingSessionId,
+  sessionExtras,
+  isCollapsed,
+  onToggleCollapse,
+  onActivateSession,
+}: HostProjectNodeProps) {
+  const handleToggleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onToggleCollapse();
+      }
+    },
+    [onToggleCollapse],
+  );
+
+  const sortedSessions = React.useMemo(() => {
+    return [...project.sessions].sort((a, b) => {
+      const priority: Record<DerivedSessionStatus, number> = {
+        'waiting-permission': 0,
+        'waiting-question': 1,
+        error: 2,
+        busy: 3,
+        retry: 4,
+        unread: 5,
+        idle: 6,
+      };
+      const pa = priority[a.status];
+      const pb = priority[b.status];
+      if (pa !== pb) return pa - pb;
+      return (b.session.updatedAt ?? 0) - (a.session.updatedAt ?? 0);
+    });
+  }, [project.sessions]);
+
+  return (
+    <div className="ml-2">
+      {/* Project header */}
+      <button
+        type="button"
+        className={cn(
+          'flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left',
+          'hover:bg-[var(--interactive-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+        )}
+        onClick={onToggleCollapse}
+        onKeyDown={handleToggleKeyDown}
+        aria-expanded={!isCollapsed}
+        aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${project.projectName}`}
+      >
+        <Icon
+          name={isCollapsed ? 'arrow-right-s' : 'arrow-down-s'}
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+        />
+        <Icon name="folder" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate typography-ui-label text-foreground">
+          {project.projectName}
+        </span>
+        <span className="shrink-0 text-[0.6rem] typography-meta text-muted-foreground">
+          {project.sessionCount}
+        </span>
+        {project.unreadCount > 0 && (
+          <span className="inline-flex items-center gap-0.5 shrink-0">
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-info)]" />
+            <span className="text-[0.6rem] typography-meta text-[var(--status-info)]">
+              {project.unreadCount}
+            </span>
+          </span>
+        )}
+      </button>
+
+      {/* Sessions */}
+      {!isCollapsed && (
+        <div className="ml-3">
+          {sortedSessions.map((ps) => {
+            const sessionRef: HostSessionRef = {
+              hostId: hostId as never,
+              sessionId: ps.ref.sessionId,
+              directory: ps.ref.directory,
+              projectId: ps.ref.projectId,
+            };
+            return (
+              <HostSessionNode
+                key={`session:${hostId}:${ps.ref.sessionId}`}
+                ref={sessionRef}
+                session={ps.session}
+                derivedStatus={ps.status}
+                unreadCount={ps.unreadCount}
+                isActive={activeSessionId === ps.ref.sessionId}
+                isPending={activationPendingSessionId === ps.ref.sessionId}
+                extra={sessionExtras?.[ps.ref.sessionId]}
+                onActivate={onActivateSession}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/ui/src/components/session/multi-host/HostSessionNode.tsx
+++ b/packages/ui/src/components/session/multi-host/HostSessionNode.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { Icon } from '@/components/icon/Icon';
+import { cn } from '@/lib/utils';
+import type { HostSessionRef, HostSessionSummary } from '@/multi-host';
+import type { DerivedSessionStatus, SessionExtraStatus } from './multi-host-sidebar-types';
+import { HostStatusBadge } from './HostStatusBadge';
+
+type HostSessionNodeProps = {
+  ref: HostSessionRef;
+  session: HostSessionSummary;
+  derivedStatus: DerivedSessionStatus;
+  unreadCount: number;
+  isActive: boolean;
+  isPending: boolean;
+  extra?: SessionExtraStatus;
+  onActivate: (ref: HostSessionRef) => void;
+};
+
+function formatRelativeTime(updatedAt?: number): string {
+  if (!updatedAt) return '';
+  const diff = Date.now() - updatedAt;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export const HostSessionNode = React.memo(function HostSessionNode({
+  ref: hostSessionRef,
+  session,
+  derivedStatus,
+  unreadCount,
+  isActive,
+  isPending,
+  onActivate,
+}: HostSessionNodeProps) {
+  const handleClick = React.useCallback(() => {
+    onActivate(hostSessionRef);
+  }, [onActivate, hostSessionRef]);
+
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onActivate(hostSessionRef);
+      }
+    },
+    [onActivate, hostSessionRef],
+  );
+
+  const title = session.title || 'Untitled session';
+  const timeLabel = formatRelativeTime(session.updatedAt);
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'group flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm',
+        'hover:bg-[var(--interactive-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+        isActive && 'bg-[var(--interactive-selection)] text-primary',
+        !isActive && 'text-foreground',
+        isPending && 'pointer-events-none opacity-60',
+      )}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-current={isActive ? 'true' : undefined}
+      aria-busy={isPending || undefined}
+      data-session-row={`${hostSessionRef.hostId}:${hostSessionRef.sessionId}`}
+    >
+      {/* Leading status indicator */}
+      <span className="flex w-4 shrink-0 items-center justify-center">
+        {isPending ? (
+          <span className="h-1.5 w-1.5 rounded-full bg-primary animate-busy-pulse" />
+        ) : derivedStatus === 'busy' ? (
+          <span className="h-1.5 w-1.5 rounded-full bg-primary animate-busy-pulse" />
+        ) : derivedStatus === 'unread' ? (
+          <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-info)]" />
+        ) : derivedStatus === 'waiting-permission' ? (
+          <Icon name="shield" className="h-3 w-3 text-[var(--status-warning)]" />
+        ) : derivedStatus === 'waiting-question' ? (
+          <Icon name="chat-1" className="h-3 w-3 text-[var(--status-info)]" />
+        ) : derivedStatus === 'error' ? (
+          <Icon name="error-warning" className="h-3 w-3 text-[var(--status-error)]" />
+        ) : derivedStatus === 'retry' ? (
+          <Icon name="refresh" className="h-3 w-3 text-[var(--status-warning)]" />
+        ) : null}
+      </span>
+
+      {/* Title */}
+      <span
+        className={cn(
+          'block min-w-0 flex-1 truncate typography-ui-label font-normal',
+          isActive ? 'text-primary' : 'text-foreground',
+        )}
+      >
+        {title}
+      </span>
+
+      {/* Status badge (non-idle, non-unread) */}
+      {derivedStatus !== 'idle' && derivedStatus !== 'unread' && (
+        <HostStatusBadge status={derivedStatus} className="shrink-0" />
+      )}
+
+      {/* Unread badge */}
+      {derivedStatus === 'unread' && unreadCount > 0 && (
+        <HostStatusBadge
+          status="unread"
+          count={unreadCount}
+          className="shrink-0"
+        />
+      )}
+
+      {/* Relative time */}
+      {timeLabel && (
+        <span className="shrink-0 text-[0.6rem] typography-meta text-muted-foreground opacity-0 group-hover:opacity-100">
+          {timeLabel}
+        </span>
+      )}
+    </button>
+  );
+});

--- a/packages/ui/src/components/session/multi-host/HostStatusBadge.tsx
+++ b/packages/ui/src/components/session/multi-host/HostStatusBadge.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Icon } from '@/components/icon/Icon';
+import { cn } from '@/lib/utils';
+import type { DerivedSessionStatus } from './multi-host-sidebar-types';
+
+type HostStatusBadgeProps = {
+  status: DerivedSessionStatus;
+  count?: number;
+  className?: string;
+};
+
+function statusConfig(status: DerivedSessionStatus) {
+  switch (status) {
+    case 'waiting-permission':
+      return {
+        icon: 'shield' as const,
+        label: 'Waiting permission',
+        color: 'text-[var(--status-warning)]',
+        bgColor: 'bg-[var(--status-warning)]/10',
+      };
+    case 'waiting-question':
+      return {
+        icon: 'chat-1' as const,
+        label: 'Waiting question',
+        color: 'text-[var(--status-info)]',
+        bgColor: 'bg-[var(--status-info)]/10',
+      };
+    case 'error':
+      return {
+        icon: 'error-warning' as const,
+        label: 'Error',
+        color: 'text-[var(--status-error)]',
+        bgColor: 'bg-[var(--status-error)]/10',
+      };
+    case 'busy':
+      return {
+        icon: 'loader-4' as const,
+        label: 'Busy',
+        color: 'text-primary',
+        bgColor: 'bg-primary/10',
+      };
+    case 'retry':
+      return {
+        icon: 'refresh' as const,
+        label: 'Retrying',
+        color: 'text-[var(--status-warning)]',
+        bgColor: 'bg-[var(--status-warning)]/10',
+      };
+    case 'unread':
+      return {
+        icon: null,
+        label: 'Unread',
+        color: 'text-[var(--status-info)]',
+        bgColor: '',
+      };
+    case 'idle':
+      return {
+        icon: null,
+        label: 'Idle',
+        color: 'text-muted-foreground',
+        bgColor: '',
+      };
+  }
+}
+
+export const HostStatusBadge = React.memo(function HostStatusBadge({
+  status,
+  count,
+  className,
+}: HostStatusBadgeProps) {
+  const config = statusConfig(status);
+
+  if (status === 'unread') {
+    return (
+      <span
+        className={cn('inline-flex items-center', className)}
+        aria-label={count ? `${count} unread messages` : 'Unread messages'}
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-[var(--status-info)]" />
+        {count !== undefined && count > 0 && (
+          <span className="ml-1 text-[0.65rem] typography-meta text-[var(--status-info)]">
+            {count}
+          </span>
+        )}
+      </span>
+    );
+  }
+
+  if (status === 'idle') return null;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.65rem] typography-meta',
+        config.color,
+        config.bgColor,
+        className,
+      )}
+      aria-label={config.label}
+    >
+      {config.icon && (
+        <Icon
+          name={config.icon}
+          className={cn(
+            'h-3 w-3',
+            status === 'busy' && 'animate-spin',
+          )}
+        />
+      )}
+      <span>{config.label}</span>
+      {count !== undefined && count > 1 && (
+        <span>{count}</span>
+      )}
+    </span>
+  );
+});

--- a/packages/ui/src/components/session/multi-host/MultiHostEmptyState.tsx
+++ b/packages/ui/src/components/session/multi-host/MultiHostEmptyState.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Icon } from '@/components/icon/Icon';
+
+export function MultiHostEmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 px-4 text-center">
+      <Icon
+        name="computer"
+        className="h-8 w-8 text-muted-foreground/50 mb-2"
+      />
+      <p className="typography-ui-label font-semibold text-muted-foreground">
+        No hosts connected
+      </p>
+      <p className="typography-meta mt-1 text-muted-foreground/70">
+        Add a remote host to see its sessions here
+      </p>
+    </div>
+  );
+}

--- a/packages/ui/src/components/session/multi-host/MultiHostSessionTree.tsx
+++ b/packages/ui/src/components/session/multi-host/MultiHostSessionTree.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { useMultiHostStore } from '@/multi-host';
+import type { HostId, HostSessionRef } from '@/multi-host';
+import { HostNode } from './HostNode';
+import { MultiHostEmptyState } from './MultiHostEmptyState';
+import type { SessionExtraStatus } from './multi-host-sidebar-types';
+import { hostFoldKey } from './multi-host-sidebar-types';
+
+export type MultiHostSessionTreeProps = {
+  activeHostId?: HostId;
+  activeSessionId?: string;
+  activationPendingRef?: HostSessionRef | null;
+  sessionExtras?: Record<HostId, Record<string, SessionExtraStatus>>;
+  onActivateSession: (ref: HostSessionRef) => void | Promise<void>;
+  className?: string;
+};
+
+export function MultiHostSessionTree({
+  activeHostId,
+  activeSessionId,
+  activationPendingRef,
+  sessionExtras,
+  onActivateSession,
+  className,
+}: MultiHostSessionTreeProps) {
+  // Subscribe only to host IDs — not the full state
+  const hostIds = useMultiHostStore(
+    (s) => Object.keys(s.hosts) as HostId[],
+  );
+
+  // Stable reference comparison for hostIds array
+  const [collapsedHosts, setCollapsedHosts] = React.useState<
+    Record<string, boolean>
+  >({});
+  const [collapsedProjects, setCollapsedProjects] = React.useState<
+    Record<string, boolean>
+  >({});
+
+  const sortedHostIds = React.useMemo(
+    () => [...hostIds].sort(),
+    [hostIds],
+  );
+
+  const handleToggleHostCollapse = React.useCallback((key: string) => {
+    setCollapsedHosts((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  }, []);
+
+  const handleToggleProjectCollapse = React.useCallback((key: string) => {
+    setCollapsedProjects((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  }, []);
+
+  if (sortedHostIds.length === 0) {
+    return (
+      <div className={cn('flex-1 overflow-y-auto', className)}>
+        <MultiHostEmptyState />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('flex-1 overflow-y-auto', className)}>
+      <div className="py-1">
+        {sortedHostIds.map((hostId) => (
+          <HostNode
+            key={`host:${hostId}`}
+            hostId={hostId}
+            activeHostId={activeHostId}
+            activeSessionId={activeSessionId}
+            activationPendingRef={activationPendingRef}
+            sessionExtras={sessionExtras}
+            isCollapsed={collapsedHosts[hostFoldKey(hostId)] ?? false}
+            collapsedProjects={collapsedProjects}
+            onToggleHostCollapse={() =>
+              handleToggleHostCollapse(hostFoldKey(hostId))
+            }
+            onToggleProjectCollapse={handleToggleProjectCollapse}
+            onActivateSession={onActivateSession}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/session/multi-host/__tests__/multi-host-sidebar.test.tsx
+++ b/packages/ui/src/components/session/multi-host/__tests__/multi-host-sidebar.test.tsx
@@ -1,0 +1,609 @@
+/**
+ * Tests for multi-host sidebar components.
+ *
+ * Uses bun:test for pure function testing. Component structure is verified
+ * via source-text regression guards (consistent with existing sidebar tests).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import type {
+  HostId,
+  HostSessionRef,
+} from '@/multi-host';
+import {
+  useMultiHostStore,
+  selectHostSessions,
+  selectHostProjects,
+} from '@/multi-host';
+import type { SessionExtraStatus } from '../multi-host-sidebar-types';
+import {
+  connectionStateLabel,
+  deriveSessionStatus,
+  FOLD_KEY_PREFIX_HOST,
+  FOLD_KEY_PREFIX_PROJECT,
+  hostFoldKey,
+  projectFoldKey,
+  transportIconName,
+  transportKindLabel,
+} from '../multi-host-sidebar-types';
+import {
+  DESCRIPTOR_MACBOOK,
+  DESCRIPTOR_MAC_STUDIO,
+  HOST_ID_MAC_STUDIO,
+  HOST_ID_MACBOOK,
+  SESSION_DUPLICATE_ID,
+  SESSION_IMPLEMENTS_MONITOR,
+  SESSION_TEST_WORKFLOW,
+  STATUS_BUSY,
+  STATUS_RETRY,
+  TRANSPORT_DIRECT_LAN,
+  TRANSPORT_LOCAL,
+  TRANSPORT_RELAY,
+  TRANSPORT_SSH,
+} from '../fixtures';
+
+// ---------------------------------------------------------------------------
+// deriveSessionStatus
+// ---------------------------------------------------------------------------
+
+describe('deriveSessionStatus', () => {
+  test('waiting-permission has highest priority', () => {
+    const extra: SessionExtraStatus = { hasWaitingPermission: true };
+    expect(deriveSessionStatus(STATUS_BUSY, 5, extra)).toBe('waiting-permission');
+  });
+
+  test('waiting-question beats busy', () => {
+    const extra: SessionExtraStatus = { hasWaitingQuestion: true };
+    expect(deriveSessionStatus(STATUS_BUSY, 0, extra)).toBe('waiting-question');
+  });
+
+  test('error beats busy', () => {
+    const extra: SessionExtraStatus = { hasError: true };
+    expect(deriveSessionStatus(STATUS_BUSY, 0, extra)).toBe('error');
+  });
+
+  test('busy from store status', () => {
+    expect(deriveSessionStatus(STATUS_BUSY, 0)).toBe('busy');
+  });
+
+  test('retry from store status', () => {
+    expect(deriveSessionStatus(STATUS_RETRY, 0)).toBe('retry');
+  });
+
+  test('unread when no store status but unread > 0', () => {
+    expect(deriveSessionStatus(undefined, 3)).toBe('unread');
+  });
+
+  test('idle as default', () => {
+    expect(deriveSessionStatus(undefined, 0)).toBe('idle');
+  });
+
+  test('idle when store status is idle and no unread', () => {
+    expect(deriveSessionStatus({ status: 'idle' }, 0)).toBe('idle');
+  });
+
+  test('busy with unread still returns busy', () => {
+    expect(deriveSessionStatus(STATUS_BUSY, 5)).toBe('busy');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transportKindLabel
+// ---------------------------------------------------------------------------
+
+describe('transportKindLabel', () => {
+  test('local', () => {
+    expect(transportKindLabel(TRANSPORT_LOCAL)).toBe('Local');
+  });
+
+  test('direct', () => {
+    expect(transportKindLabel(TRANSPORT_DIRECT_LAN)).toBe('LAN');
+  });
+
+  test('ssh', () => {
+    expect(transportKindLabel(TRANSPORT_SSH)).toBe('SSH');
+  });
+
+  test('relay', () => {
+    expect(transportKindLabel(TRANSPORT_RELAY)).toBe('Relay');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connectionStateLabel
+// ---------------------------------------------------------------------------
+
+describe('connectionStateLabel', () => {
+  test('connected', () => {
+    expect(connectionStateLabel('connected')).toBe('Connected');
+  });
+
+  test('connecting', () => {
+    expect(connectionStateLabel('connecting')).toBe('Connecting');
+  });
+
+  test('disconnected', () => {
+    expect(connectionStateLabel('disconnected')).toBe('Disconnected');
+  });
+
+  test('error', () => {
+    expect(connectionStateLabel('error')).toBe('Error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transportIconName
+// ---------------------------------------------------------------------------
+
+describe('transportIconName', () => {
+  test('local -> computer', () => {
+    expect(transportIconName(TRANSPORT_LOCAL)).toBe('computer');
+  });
+
+  test('direct -> server', () => {
+    expect(transportIconName(TRANSPORT_DIRECT_LAN)).toBe('server');
+  });
+
+  test('ssh -> terminal', () => {
+    expect(transportIconName(TRANSPORT_SSH)).toBe('terminal');
+  });
+
+  test('relay -> cloud', () => {
+    expect(transportIconName(TRANSPORT_RELAY)).toBe('cloud');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fold key generation
+// ---------------------------------------------------------------------------
+
+describe('fold key generation', () => {
+  test('hostFoldKey uses correct prefix', () => {
+    const key = hostFoldKey(HOST_ID_MAC_STUDIO);
+    expect(key).toBe('host:host_mac_studio');
+    expect(key.startsWith(FOLD_KEY_PREFIX_HOST)).toBe(true);
+  });
+
+  test('projectFoldKey includes hostId and projectId', () => {
+    const key = projectFoldKey(HOST_ID_MAC_STUDIO, 'proj_a');
+    expect(key).toBe('project:host_mac_studio:proj_a');
+    expect(key.startsWith(FOLD_KEY_PREFIX_PROJECT)).toBe(true);
+  });
+
+  test('same project name on different hosts produces different keys', () => {
+    const key1 = projectFoldKey(HOST_ID_MAC_STUDIO, 'proj_shared');
+    const key2 = projectFoldKey(HOST_ID_MACBOOK, 'proj_shared');
+    expect(key1).not.toBe(key2);
+  });
+
+  test('same projectId on different hosts produces different keys', () => {
+    const key1 = projectFoldKey(HOST_ID_MAC_STUDIO, 'proj_a');
+    const key2 = projectFoldKey(HOST_ID_MACBOOK, 'proj_a');
+    expect(key1).not.toBe(key2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HostSessionRef integrity
+// ---------------------------------------------------------------------------
+
+describe('HostSessionRef integrity', () => {
+  test('fixture refs contain all required fields', () => {
+    const refs: HostSessionRef[] = [
+      {
+        hostId: HOST_ID_MAC_STUDIO,
+        sessionId: SESSION_IMPLEMENTS_MONITOR.id,
+        directory: SESSION_IMPLEMENTS_MONITOR.directory!,
+        projectId: SESSION_IMPLEMENTS_MONITOR.projectId!,
+      },
+      {
+        hostId: HOST_ID_MACBOOK,
+        sessionId: SESSION_TEST_WORKFLOW.id,
+        directory: SESSION_TEST_WORKFLOW.directory!,
+        projectId: SESSION_TEST_WORKFLOW.projectId!,
+      },
+    ];
+
+    for (const ref of refs) {
+      expect(ref.hostId).toBeTruthy();
+      expect(ref.sessionId).toBeTruthy();
+      expect(ref.directory).toBeTruthy();
+      expect(ref.projectId).toBeTruthy();
+    }
+  });
+
+  test('same sessionId on different hosts is valid', () => {
+    const ref1: HostSessionRef = {
+      hostId: HOST_ID_MAC_STUDIO,
+      sessionId: SESSION_DUPLICATE_ID.id,
+      directory: SESSION_DUPLICATE_ID.directory!,
+      projectId: SESSION_DUPLICATE_ID.projectId!,
+    };
+    const ref2: HostSessionRef = {
+      hostId: HOST_ID_MACBOOK,
+      sessionId: SESSION_DUPLICATE_ID.id,
+      directory: SESSION_DUPLICATE_ID.directory!,
+      projectId: SESSION_DUPLICATE_ID.projectId!,
+    };
+
+    expect(ref1.sessionId).toBe(ref2.sessionId);
+    expect(ref1.hostId).not.toBe(ref2.hostId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store integration: two hosts with same sessionId
+// ---------------------------------------------------------------------------
+
+describe('store: two hosts same sessionId', () => {
+  test('storing same sessionId on different hosts does not collide', () => {
+    // Reset store
+    useMultiHostStore.setState({ hosts: {} });
+
+    useMultiHostStore.getState().registerHost(DESCRIPTOR_MAC_STUDIO);
+    useMultiHostStore.getState().registerHost(DESCRIPTOR_MACBOOK);
+
+    useMultiHostStore.getState().upsertSession(HOST_ID_MAC_STUDIO, SESSION_DUPLICATE_ID);
+    useMultiHostStore.getState().upsertSession(HOST_ID_MACBOOK, {
+      ...SESSION_DUPLICATE_ID,
+      title: 'Same ID different host',
+    });
+
+    const host1 = useMultiHostStore.getState().hosts[HOST_ID_MAC_STUDIO];
+    const host2 = useMultiHostStore.getState().hosts[HOST_ID_MACBOOK];
+
+    expect(host1).toBeTruthy();
+    expect(host2).toBeTruthy();
+    expect(host1!.sessions[SESSION_DUPLICATE_ID.id]?.title).toBe(SESSION_DUPLICATE_ID.title);
+    expect(host2!.sessions[SESSION_DUPLICATE_ID.id]?.title).toBe('Same ID different host');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store integration: unread isolation
+// ---------------------------------------------------------------------------
+
+describe('store: unread isolation between hosts', () => {
+  test('unread on host A does not affect host B', () => {
+    useMultiHostStore.setState({ hosts: {} });
+
+    useMultiHostStore.getState().registerHost(DESCRIPTOR_MAC_STUDIO);
+    useMultiHostStore.getState().registerHost(DESCRIPTOR_MACBOOK);
+
+    useMultiHostStore.getState().upsertSession(HOST_ID_MAC_STUDIO, SESSION_DUPLICATE_ID);
+    useMultiHostStore.getState().upsertSession(HOST_ID_MACBOOK, SESSION_DUPLICATE_ID);
+
+    useMultiHostStore.getState().markSessionUnread(HOST_ID_MAC_STUDIO, SESSION_DUPLICATE_ID.id, 5);
+
+    const host1 = useMultiHostStore.getState().hosts[HOST_ID_MAC_STUDIO];
+    const host2 = useMultiHostStore.getState().hosts[HOST_ID_MACBOOK];
+
+    expect(host1!.unreadBySession[SESSION_DUPLICATE_ID.id]).toBe(5);
+    expect(host2!.unreadBySession[SESSION_DUPLICATE_ID.id]).toBe(undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store integration: status isolation
+// ---------------------------------------------------------------------------
+
+describe('store: status isolation between hosts', () => {
+  test('busy on host A does not affect host B', () => {
+    useMultiHostStore.setState({ hosts: {} });
+
+    useMultiHostStore.getState().registerHost(DESCRIPTOR_MAC_STUDIO);
+    useMultiHostStore.getState().registerHost(DESCRIPTOR_MACBOOK);
+
+    useMultiHostStore.getState().upsertSession(HOST_ID_MAC_STUDIO, SESSION_DUPLICATE_ID);
+    useMultiHostStore.getState().upsertSession(HOST_ID_MACBOOK, SESSION_DUPLICATE_ID);
+
+    useMultiHostStore.getState().setSessionStatus(HOST_ID_MAC_STUDIO, SESSION_DUPLICATE_ID.id, 'busy');
+
+    const host1 = useMultiHostStore.getState().hosts[HOST_ID_MAC_STUDIO];
+    const host2 = useMultiHostStore.getState().hosts[HOST_ID_MACBOOK];
+
+    expect(host1!.statuses[SESSION_DUPLICATE_ID.id]?.status).toBe('busy');
+    expect(host2!.statuses[SESSION_DUPLICATE_ID.id]).toBe(undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store: stable empty selectors for non-existent host
+// ---------------------------------------------------------------------------
+
+describe('store: stable empty for non-existent host', () => {
+  test('selectHostSessions returns stable empty for unknown host', () => {
+    const fakeId = 'nonexistent_host' as HostId;
+    const result1 = selectHostSessions(fakeId);
+    const result2 = selectHostSessions(fakeId);
+    expect(result1).toBe(result2);
+    expect(Object.keys(result1)).toHaveLength(0);
+  });
+
+  test('selectHostProjects returns stable empty for unknown host', () => {
+    const fakeId = 'nonexistent_host' as HostId;
+    const result1 = selectHostProjects(fakeId);
+    const result2 = selectHostProjects(fakeId);
+    expect(result1).toBe(result2);
+    expect(result1).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Source structure: components exist with correct patterns
+// ---------------------------------------------------------------------------
+
+const srcDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function readSource(filename: string): string {
+  return readFileSync(resolve(srcDir, filename), 'utf-8');
+}
+
+describe('source structure: MultiHostSessionTree', () => {
+  test('renders HostNode for each host', () => {
+    const src = readSource('MultiHostSessionTree.tsx');
+    expect(src).toContain('HostNode');
+    expect(src).toContain('key={`host:${hostId}`}');
+  });
+
+  test('uses useMultiHostStore with host ID selector', () => {
+    const src = readSource('MultiHostSessionTree.tsx');
+    expect(src).toContain('useMultiHostStore');
+    expect(src).toContain('Object.keys(s.hosts)');
+  });
+
+  test('shows empty state when no hosts', () => {
+    const src = readSource('MultiHostSessionTree.tsx');
+    expect(src).toContain('MultiHostEmptyState');
+    expect(src).toContain('sortedHostIds.length === 0');
+  });
+
+  test('does not import runtime-switch', () => {
+    const src = readSource('MultiHostSessionTree.tsx');
+    expect(src).not.toContain('runtime-switch');
+  });
+
+  test('does not import activation controller', () => {
+    const src = readSource('MultiHostSessionTree.tsx');
+    expect(src).not.toContain('activation-controller');
+    expect(src).not.toContain('HostActivationController');
+  });
+
+  test('does not import monitor', () => {
+    const src = readSource('MultiHostSessionTree.tsx');
+    expect(src).not.toContain('monitor');
+  });
+
+  test('does not import relay registry', () => {
+    const src = readSource('MultiHostSessionTree.tsx');
+    expect(src).not.toContain('relay-registry');
+    expect(src).not.toContain('PrivateRelay');
+  });
+});
+
+describe('source structure: HostNode', () => {
+  test('subscribes to single host via useHost', () => {
+    const src = readSource('HostNode.tsx');
+    expect(src).toContain('useHost(hostId)');
+  });
+
+  test('renders HostConnectionIndicator', () => {
+    const src = readSource('HostNode.tsx');
+    expect(src).toContain('HostConnectionIndicator');
+  });
+
+  test('renders HostProjectNode for each project', () => {
+    const src = readSource('HostNode.tsx');
+    expect(src).toContain('HostProjectNode');
+    expect(src).toContain('key={`project:${hostId}:${project.projectId}`}');
+  });
+
+  test('has collapse toggle with aria-expanded', () => {
+    const src = readSource('HostNode.tsx');
+    expect(src).toContain('aria-expanded');
+    expect(src).toContain('onToggleHostCollapse');
+  });
+});
+
+describe('source structure: HostProjectNode', () => {
+  test('has collapse toggle with aria-expanded', () => {
+    const src = readSource('HostProjectNode.tsx');
+    expect(src).toContain('aria-expanded');
+  });
+
+  test('renders HostSessionNode for each session', () => {
+    const src = readSource('HostProjectNode.tsx');
+    expect(src).toContain('HostSessionNode');
+    expect(src).toContain('key={`session:${hostId}:${ps.ref.sessionId}`}');
+  });
+
+  test('has collapse toggle with aria-expanded', () => {
+    const src = readSource('HostProjectNode.tsx');
+    expect(src).toContain('aria-expanded');
+  });
+});
+
+describe('source structure: HostSessionNode', () => {
+  test('renders as button for keyboard accessibility', () => {
+    const src = readSource('HostSessionNode.tsx');
+    expect(src).toContain('<button');
+    expect(src).toContain('type="button"');
+  });
+
+  test('handles Enter and Space for activation', () => {
+    const src = readSource('HostSessionNode.tsx');
+    expect(src).toContain("e.key === 'Enter'");
+    expect(src).toContain("e.key === ' '");
+  });
+
+  test('calls onActivate with full HostSessionRef', () => {
+    const src = readSource('HostSessionNode.tsx');
+    expect(src).toContain('onActivate(hostSessionRef)');
+  });
+
+  test('shows loading state for pending', () => {
+    const src = readSource('HostSessionNode.tsx');
+    expect(src).toContain('isPending');
+    expect(src).toContain('animate-busy-pulse');
+  });
+
+  test('highlights active session', () => {
+    const src = readSource('HostSessionNode.tsx');
+    expect(src).toContain('isActive');
+    expect(src).toContain('aria-current');
+  });
+
+  test('truncates long titles', () => {
+    const src = readSource('HostSessionNode.tsx');
+    expect(src).toContain('truncate');
+  });
+
+  test('has focus-visible ring', () => {
+    const src = readSource('HostSessionNode.tsx');
+    expect(src).toContain('focus-visible:ring-2');
+  });
+});
+
+describe('source structure: HostConnectionIndicator', () => {
+  test('shows transport icon', () => {
+    const src = readSource('HostConnectionIndicator.tsx');
+    expect(src).toContain('transportIconName');
+  });
+
+  test('shows connection state', () => {
+    const src = readSource('HostConnectionIndicator.tsx');
+    expect(src).toContain('connectionStateLabel');
+  });
+
+  test('has aria-label', () => {
+    const src = readSource('HostConnectionIndicator.tsx');
+    expect(src).toContain('aria-label');
+  });
+
+  test('spins on connecting', () => {
+    const src = readSource('HostConnectionIndicator.tsx');
+    expect(src).toContain('animate-spin');
+  });
+});
+
+describe('source structure: HostStatusBadge', () => {
+  test('renders waiting-permission with shield icon', () => {
+    const src = readSource('HostStatusBadge.tsx');
+    expect(src).toContain('shield');
+    expect(src).toContain('Waiting permission');
+  });
+
+  test('renders waiting-question with chat icon', () => {
+    const src = readSource('HostStatusBadge.tsx');
+    expect(src).toContain('chat-1');
+    expect(src).toContain('Waiting question');
+  });
+
+  test('renders busy with spinning loader', () => {
+    const src = readSource('HostStatusBadge.tsx');
+    expect(src).toContain('loader-4');
+    expect(src).toContain('animate-spin');
+  });
+
+  test('renders unread as dot', () => {
+    const src = readSource('HostStatusBadge.tsx');
+    expect(src).toContain('rounded-full bg-[var(--status-info)]');
+  });
+
+  test('renders error with warning icon', () => {
+    const src = readSource('HostStatusBadge.tsx');
+    expect(src).toContain('error-warning');
+    expect(src).toContain('Error');
+  });
+
+  test('returns null for idle', () => {
+    const src = readSource('HostStatusBadge.tsx');
+    expect(src).toContain("case 'idle':");
+    expect(src).toContain('return null');
+  });
+
+  test('has aria-label for accessibility', () => {
+    const src = readSource('HostStatusBadge.tsx');
+    expect(src).toContain('aria-label');
+  });
+});
+
+describe('source structure: MultiHostEmptyState', () => {
+  test('shows no-hosts message', () => {
+    const src = readSource('MultiHostEmptyState.tsx');
+    expect(src).toContain('No hosts connected');
+  });
+
+  test('does not have interactive elements', () => {
+    const src = readSource('MultiHostEmptyState.tsx');
+    expect(src).not.toContain('<button');
+    expect(src).not.toContain('onClick');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard navigation structure
+// ---------------------------------------------------------------------------
+
+describe('keyboard navigation', () => {
+  test('session rows are focusable buttons', () => {
+    const src = readSource('HostSessionNode.tsx');
+    expect(src).toContain('<button');
+    // Buttons are natively focusable, no explicit tabIndex needed
+  });
+
+  test('host/project headers handle keyboard events', () => {
+    const hostSrc = readSource('HostNode.tsx');
+    const projectSrc = readSource('HostProjectNode.tsx');
+    expect(hostSrc).toContain('onKeyDown');
+    expect(projectSrc).toContain('onKeyDown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No sensitive data in components
+// ---------------------------------------------------------------------------
+
+describe('no sensitive data', () => {
+  test('components do not render tokens or credentials', () => {
+    const files = [
+      'MultiHostSessionTree.tsx',
+      'HostNode.tsx',
+      'HostProjectNode.tsx',
+      'HostSessionNode.tsx',
+      'HostConnectionIndicator.tsx',
+      'HostStatusBadge.tsx',
+    ];
+    for (const file of files) {
+      const src = readSource(file);
+      expect(src).not.toContain('token');
+      expect(src).not.toContain('authorization');
+      expect(src).not.toContain('password');
+      expect(src).not.toContain('secret');
+      expect(src).not.toContain('grant');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Performance: no full state subscription at root
+// ---------------------------------------------------------------------------
+
+describe('performance: subscription discipline', () => {
+  test('MultiHostSessionTree only subscribes to host IDs', () => {
+    const src = readSource('MultiHostSessionTree.tsx');
+    // Should use Object.keys to get just IDs, not full state
+    expect(src).toContain('Object.keys(s.hosts)');
+    // Should NOT subscribe to the full hosts record directly
+    expect(src).not.toContain('useMultiHostStore((s) => s.hosts)');
+  });
+
+  test('HostNode subscribes to single host', () => {
+    const src = readSource('HostNode.tsx');
+    expect(src).toContain('useHost(hostId)');
+  });
+});

--- a/packages/ui/src/components/session/multi-host/fixtures.ts
+++ b/packages/ui/src/components/session/multi-host/fixtures.ts
@@ -1,0 +1,244 @@
+/**
+ * Test fixtures for the multi-host sidebar components.
+ *
+ * These fixtures are for testing only and must NOT be imported by production code.
+ */
+
+import type {
+  HostDescriptor,
+  HostId,
+  HostProjectSummary,
+  HostSessionStatus,
+  HostSessionSummary,
+  HostSnapshot,
+  HostTransport,
+} from '@/multi-host';
+import type { SessionExtraStatus } from './multi-host-sidebar-types';
+
+// ---------------------------------------------------------------------------
+// Host IDs
+// ---------------------------------------------------------------------------
+
+export const HOST_ID_MAC_STUDIO = 'host_mac_studio' as HostId;
+export const HOST_ID_MACBOOK = 'host_macbook_pro' as HostId;
+export const HOST_ID_OFFLINE = 'host_offline_server' as HostId;
+
+// ---------------------------------------------------------------------------
+// Transport descriptors
+// ---------------------------------------------------------------------------
+
+export const TRANSPORT_LOCAL: HostTransport = { kind: 'local' };
+
+export const TRANSPORT_DIRECT_LAN: HostTransport = {
+  kind: 'direct',
+  apiUrl: 'http://192.168.1.100:4096',
+};
+
+export const TRANSPORT_SSH: HostTransport = {
+  kind: 'ssh',
+  sshEndpoint: '10.0.0.5:22',
+};
+
+export const TRANSPORT_RELAY: HostTransport = {
+  kind: 'relay',
+  relayServerId: 'relay-us-east-1',
+};
+
+// ---------------------------------------------------------------------------
+// Host descriptors
+// ---------------------------------------------------------------------------
+
+export const DESCRIPTOR_MAC_STUDIO: HostDescriptor = {
+  hostId: HOST_ID_MAC_STUDIO,
+  label: 'Mac Studio',
+  transport: TRANSPORT_LOCAL,
+};
+
+export const DESCRIPTOR_MACBOOK: HostDescriptor = {
+  hostId: HOST_ID_MACBOOK,
+  label: 'MacBook Pro',
+  transport: TRANSPORT_RELAY,
+};
+
+export const DESCRIPTOR_OFFLINE: HostDescriptor = {
+  hostId: HOST_ID_OFFLINE,
+  label: 'Ubuntu Server (offline)',
+  transport: TRANSPORT_SSH,
+};
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+export const PROJECT_A: HostProjectSummary = {
+  id: 'proj_a',
+  name: 'project-alpha',
+  directory: '/Users/dev/project-alpha',
+};
+
+export const PROJECT_B: HostProjectSummary = {
+  id: 'proj_b',
+  name: 'project-beta',
+  directory: '/Users/dev/project-beta',
+};
+
+export const PROJECT_X: HostProjectSummary = {
+  id: 'proj_x',
+  name: 'project-x',
+  directory: '/Users/dev/project-x',
+};
+
+// Two hosts with same project basename
+export const PROJECT_SAME_NAME: HostProjectSummary = {
+  id: 'proj_shared',
+  name: 'shared-project',
+  directory: '/Users/dev/shared-project',
+};
+
+// ---------------------------------------------------------------------------
+// Sessions
+// ---------------------------------------------------------------------------
+
+export const SESSION_IMPLEMENTS_MONITOR: HostSessionSummary = {
+  id: 'sess_001',
+  title: 'Implement monitor',
+  directory: '/Users/dev/project-alpha',
+  projectId: 'proj_a',
+  createdAt: 1700000000000,
+  updatedAt: 1700003600000,
+};
+
+export const SESSION_FIX_PARSER: HostSessionSummary = {
+  id: 'sess_002',
+  title: 'Fix parser',
+  directory: '/Users/dev/project-alpha',
+  projectId: 'proj_a',
+  createdAt: 1700000100000,
+  updatedAt: 1700003700000,
+};
+
+export const SESSION_REFACTOR_API: HostSessionSummary = {
+  id: 'sess_003',
+  title: 'Refactor API',
+  directory: '/Users/dev/project-beta',
+  projectId: 'proj_b',
+  createdAt: 1700000200000,
+  updatedAt: 1700003800000,
+};
+
+export const SESSION_TEST_WORKFLOW: HostSessionSummary = {
+  id: 'sess_004',
+  title: 'Test workflow',
+  directory: '/Users/dev/project-x',
+  projectId: 'proj_x',
+  createdAt: 1700000300000,
+  updatedAt: 1700003900000,
+};
+
+// Same session ID on different hosts
+export const SESSION_DUPLICATE_ID: HostSessionSummary = {
+  id: 'sess_dup',
+  title: 'Shared session ID (different host)',
+  directory: '/Users/dev/shared-project',
+  projectId: 'proj_shared',
+  createdAt: 1700000400000,
+  updatedAt: 1700004000000,
+};
+
+// Long title for truncation test
+export const SESSION_LONG_TITLE: HostSessionSummary = {
+  id: 'sess_long',
+  title:
+    'This is an extremely long session title that should be truncated when rendered in the sidebar to prevent layout overflow issues',
+  directory: '/Users/dev/project-alpha',
+  projectId: 'proj_a',
+  createdAt: 1700000500000,
+  updatedAt: 1700004100000,
+};
+
+// ---------------------------------------------------------------------------
+// Statuses
+// ---------------------------------------------------------------------------
+
+export const STATUS_BUSY: HostSessionStatus = { status: 'busy' };
+export const STATUS_RETRY: HostSessionStatus = { status: 'retry' };
+// idle is represented by undefined (no entry in statuses map)
+
+// ---------------------------------------------------------------------------
+// Extra status overlays (for waiting permission/question)
+// ---------------------------------------------------------------------------
+
+export const EXTRA_WAITING_PERMISSION: SessionExtraStatus = {
+  hasWaitingPermission: true,
+};
+
+export const EXTRA_WAITING_QUESTION: SessionExtraStatus = {
+  hasWaitingQuestion: true,
+};
+
+export const EXTRA_ERROR: SessionExtraStatus = {
+  hasError: true,
+};
+
+// ---------------------------------------------------------------------------
+// Host snapshots (complete state for replaceHostSnapshot)
+// ---------------------------------------------------------------------------
+
+export const SNAPSHOT_MAC_STUDIO: HostSnapshot = {
+  descriptor: DESCRIPTOR_MAC_STUDIO,
+  connection: { state: 'connected', connectedAt: '2025-01-15T10:00:00Z' },
+  projects: [PROJECT_A, PROJECT_B],
+  sessions: {
+    sess_001: SESSION_IMPLEMENTS_MONITOR,
+    sess_002: SESSION_FIX_PARSER,
+    sess_003: SESSION_REFACTOR_API,
+  },
+  statuses: {
+    sess_001: STATUS_BUSY,
+  },
+  unreadBySession: {
+    sess_002: 3,
+  },
+};
+
+export const SNAPSHOT_MACBOOK: HostSnapshot = {
+  descriptor: DESCRIPTOR_MACBOOK,
+  connection: { state: 'connecting' },
+  projects: [PROJECT_X],
+  sessions: {
+    sess_004: SESSION_TEST_WORKFLOW,
+  },
+  statuses: {},
+  unreadBySession: {},
+};
+
+export const SNAPSHOT_OFFLINE: HostSnapshot = {
+  descriptor: DESCRIPTOR_OFFLINE,
+  connection: { state: 'disconnected' },
+  projects: [],
+  sessions: {},
+  statuses: {},
+  unreadBySession: {},
+};
+
+// Empty snapshot (no hosts)
+export const EMPTY_SNAPSHOT: HostSnapshot = {
+  descriptor: DESCRIPTOR_OFFLINE,
+  connection: { state: 'disconnected' },
+  projects: [],
+  sessions: {},
+  statuses: {},
+  unreadBySession: {},
+};
+
+// ---------------------------------------------------------------------------
+// Extra status maps for tests
+// ---------------------------------------------------------------------------
+
+export const EXTRAS_WAITING_PERMISSION: Record<string, SessionExtraStatus> = {
+  sess_003: EXTRA_WAITING_PERMISSION,
+};
+
+export const EXTRAS_WAITING_QUESTION: Record<string, SessionExtraStatus> = {
+  sess_004: EXTRA_WAITING_QUESTION,
+};

--- a/packages/ui/src/components/session/multi-host/index.ts
+++ b/packages/ui/src/components/session/multi-host/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Multi-host session tree — public API.
+ *
+ * This module provides the MultiHostSessionTree component and its
+ * supporting sub-components for displaying sessions across multiple
+ * OpenChamber hosts.
+ */
+
+export { MultiHostSessionTree } from './MultiHostSessionTree';
+export type { MultiHostSessionTreeProps } from './MultiHostSessionTree';
+
+export { HostConnectionIndicator } from './HostConnectionIndicator';
+export { HostStatusBadge } from './HostStatusBadge';
+export { HostSessionNode } from './HostSessionNode';
+export { HostProjectNode } from './HostProjectNode';
+export { HostNode } from './HostNode';
+export { MultiHostEmptyState } from './MultiHostEmptyState';
+
+export type {
+  DerivedSessionStatus,
+  SessionExtraStatus,
+  HostSummary,
+  ProjectGroup,
+  ProjectSession,
+} from './multi-host-sidebar-types';
+
+export {
+  deriveSessionStatus,
+  transportKindLabel,
+  connectionStateLabel,
+  transportIconName,
+  hostFoldKey,
+  projectFoldKey,
+  FOLD_KEY_PREFIX_HOST,
+  FOLD_KEY_PREFIX_PROJECT,
+} from './multi-host-sidebar-types';

--- a/packages/ui/src/components/session/multi-host/multi-host-sidebar-types.ts
+++ b/packages/ui/src/components/session/multi-host/multi-host-sidebar-types.ts
@@ -1,0 +1,166 @@
+/**
+ * Local types for the multi-host sidebar components.
+ *
+ * These types are derived from the frozen multi-host domain types but are
+ * owned by this PR. They extend the domain layer with UI-specific concerns
+ * like derived display status and grouping.
+ */
+
+import type {
+  HostConnectionSummary,
+  HostId,
+  HostSessionRef,
+  HostSessionStatus,
+  HostTransport,
+} from '@/multi-host';
+
+// ---------------------------------------------------------------------------
+// Derived display status (priority-ordered)
+// ---------------------------------------------------------------------------
+
+/**
+ * Session display status derived from store state + optional external overlays.
+ * Priority: waiting-permission > waiting-question > error > busy > retry > unread > idle.
+ */
+export type DerivedSessionStatus =
+  | 'waiting-permission'
+  | 'waiting-question'
+  | 'error'
+  | 'busy'
+  | 'retry'
+  | 'unread'
+  | 'idle';
+
+// ---------------------------------------------------------------------------
+// Extra status overlay (injected by integration layer)
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional per-session status overlays that come from outside the frozen
+ * multi-host store (e.g., from the sync layer's pending permission/question
+ * state). The sidebar consumes these via a callback prop without knowing
+ * how they are produced.
+ */
+export type SessionExtraStatus = {
+  hasWaitingPermission?: boolean;
+  hasWaitingQuestion?: boolean;
+  hasError?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Host summary (computed for display)
+// ---------------------------------------------------------------------------
+
+export type HostSummary = {
+  hostId: HostId;
+  label: string;
+  transport: HostTransport;
+  connection: HostConnectionSummary;
+  unreadTotal: number;
+  waitingPermissionCount: number;
+  waitingQuestionCount: number;
+  hasBusySession: boolean;
+  sessionCount: number;
+};
+
+// ---------------------------------------------------------------------------
+// Project grouping
+// ---------------------------------------------------------------------------
+
+export type ProjectGroup = {
+  projectId: string;
+  projectName: string;
+  directory: string;
+  sessions: ProjectSession[];
+  unreadCount: number;
+  sessionCount: number;
+};
+
+export type ProjectSession = {
+  ref: HostSessionRef;
+  session: HostSessionSummary;
+  status: DerivedSessionStatus;
+  unreadCount: number;
+};
+
+// ---------------------------------------------------------------------------
+// Fold state helpers
+// ---------------------------------------------------------------------------
+
+export const FOLD_KEY_PREFIX_HOST = 'host:';
+export const FOLD_KEY_PREFIX_PROJECT = 'project:';
+
+export const hostFoldKey = (hostId: HostId): string =>
+  `${FOLD_KEY_PREFIX_HOST}${hostId}`;
+
+export const projectFoldKey = (hostId: HostId, projectId: string): string =>
+  `${FOLD_KEY_PREFIX_PROJECT}${hostId}:${projectId}`;
+
+// ---------------------------------------------------------------------------
+// Derive display status from store status + extras
+// ---------------------------------------------------------------------------
+
+export function deriveSessionStatus(
+  storeStatus: HostSessionStatus | undefined,
+  unreadCount: number,
+  extra?: SessionExtraStatus,
+): DerivedSessionStatus {
+  if (extra?.hasWaitingPermission) return 'waiting-permission';
+  if (extra?.hasWaitingQuestion) return 'waiting-question';
+  if (extra?.hasError) return 'error';
+  if (storeStatus?.status === 'busy') return 'busy';
+  if (storeStatus?.status === 'retry') return 'retry';
+  if (unreadCount > 0) return 'unread';
+  return 'idle';
+}
+
+// ---------------------------------------------------------------------------
+// Transport kind labels
+// ---------------------------------------------------------------------------
+
+export function transportKindLabel(transport: HostTransport): string {
+  switch (transport.kind) {
+    case 'local':
+      return 'Local';
+    case 'direct':
+      return 'LAN';
+    case 'ssh':
+      return 'SSH';
+    case 'relay':
+      return 'Relay';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection state labels
+// ---------------------------------------------------------------------------
+
+export function connectionStateLabel(state: HostConnectionSummary['state']): string {
+  switch (state) {
+    case 'connected':
+      return 'Connected';
+    case 'connecting':
+      return 'Connecting';
+    case 'disconnected':
+      return 'Disconnected';
+    case 'error':
+      return 'Error';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transport icon names (maps to Icon component names)
+// ---------------------------------------------------------------------------
+
+export function transportIconName(transport: HostTransport): string {
+  switch (transport.kind) {
+    case 'local':
+      return 'computer';
+    case 'direct':
+      return 'server';
+    case 'ssh':
+      return 'terminal';
+    case 'relay':
+      return 'cloud';
+  }
+}

--- a/packages/ui/src/multi-host/activation/__tests__/host-activation-controller.test.ts
+++ b/packages/ui/src/multi-host/activation/__tests__/host-activation-controller.test.ts
@@ -1,0 +1,929 @@
+import { describe, expect, test } from 'bun:test';
+
+import type {
+  ActivationStage,
+  RuntimeActivationAdapter,
+  RuntimeSnapshot,
+  SafeActivationLogger,
+} from '../types';
+import type { HostDescriptor, HostId, HostSessionRef } from '../../types';
+import { createHostActivationController } from '../host-activation-controller';
+import { noopLogger } from '../safe-activation-logger';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const hostA: HostDescriptor = {
+  hostId: 'host-a' as HostId,
+  label: 'Host A',
+  transport: { kind: 'direct', apiUrl: 'http://localhost:3000' },
+};
+
+const hostB: HostDescriptor = {
+  hostId: 'host-b' as HostId,
+  label: 'Host B',
+  transport: { kind: 'ssh', sshEndpoint: 'remote:22' },
+};
+
+const hostC: HostDescriptor = {
+  hostId: 'host-c' as HostId,
+  label: 'Host C',
+  transport: { kind: 'relay', relayServerId: 'relay-1' },
+};
+
+const refA1: HostSessionRef = {
+  hostId: 'host-a' as HostId,
+  sessionId: 'ses_a1',
+  directory: '/home/user/project-a',
+  projectId: 'proj_a',
+};
+
+const refA2: HostSessionRef = {
+  hostId: 'host-a' as HostId,
+  sessionId: 'ses_a2',
+  directory: '/home/user/project-a2',
+  projectId: 'proj_a2',
+};
+
+const refB1: HostSessionRef = {
+  hostId: 'host-b' as HostId,
+  sessionId: 'ses_b1',
+  directory: '/remote/project-b',
+  projectId: 'proj_b',
+};
+
+const refC1: HostSessionRef = {
+  hostId: 'host-c' as HostId,
+  sessionId: 'ses_c1',
+  directory: '/relay/project-c',
+  projectId: 'proj_c',
+};
+
+// ---------------------------------------------------------------------------
+// Fake adapter factory
+// ---------------------------------------------------------------------------
+
+interface FakeAdapterOptions {
+  currentHostId?: HostId;
+  currentSessionId?: string;
+  shouldFail?: Partial<Record<string, Error | string>>;
+  validateHostFn?: (host: HostDescriptor, signal: AbortSignal) => Promise<void>;
+  switchHostFn?: (host: HostDescriptor, signal: AbortSignal) => Promise<void>;
+  openProjectFn?: (ref: HostSessionRef, signal: AbortSignal) => Promise<void>;
+  selectSessionFn?: (ref: HostSessionRef, signal: AbortSignal) => Promise<void>;
+  verifySessionFn?: (ref: HostSessionRef, signal: AbortSignal) => Promise<boolean>;
+}
+
+const createFakeAdapter = (opts: FakeAdapterOptions = {}): RuntimeActivationAdapter & { callLog: string[]; snapshot: RuntimeSnapshot } => {
+  const callLog: string[] = [];
+  const snapshot: RuntimeSnapshot = {
+    hostId: opts.currentHostId,
+    sessionId: opts.currentSessionId,
+  };
+
+  const fail = (stage: string): void => {
+    const err = opts.shouldFail?.[stage];
+    if (err) {
+      if (typeof err === 'string') throw new Error(err);
+      throw err;
+    }
+  };
+
+  return {
+    callLog,
+    snapshot,
+
+    getCurrentSnapshot: () => ({ ...snapshot }),
+
+    isCurrentHost: (hostId: HostId): boolean => {
+      return snapshot.hostId === hostId;
+    },
+
+    isCurrentSession: (ref: HostSessionRef): boolean => {
+      return snapshot.hostId === ref.hostId && snapshot.sessionId === ref.sessionId;
+    },
+
+    validateHost: async (host: HostDescriptor, signal: AbortSignal): Promise<void> => {
+      callLog.push('validateHost');
+      fail('validateHost');
+      if (opts.validateHostFn) await opts.validateHostFn(host, signal);
+    },
+
+    switchHost: async (host: HostDescriptor, signal: AbortSignal): Promise<void> => {
+      callLog.push('switchHost');
+      fail('switchHost');
+      snapshot.hostId = host.hostId;
+      snapshot.runtimeKey = `host:${host.hostId}`;
+      if (opts.switchHostFn) await opts.switchHostFn(host, signal);
+    },
+
+    waitForRuntimeReady: async (): Promise<void> => {
+      callLog.push('waitForRuntimeReady');
+      fail('waitForRuntimeReady');
+    },
+
+    openProjectOrDirectory: async (ref: HostSessionRef): Promise<void> => {
+      callLog.push('openProjectOrDirectory');
+      fail('openProjectOrDirectory');
+      if (opts.openProjectFn) await opts.openProjectFn(ref, signal);
+    },
+
+    verifySessionExists: async (ref: HostSessionRef, signal: AbortSignal): Promise<boolean> => {
+      callLog.push('verifySessionExists');
+      fail('verifySessionExists');
+      if (opts.verifySessionFn) return opts.verifySessionFn(ref, signal);
+      return true;
+    },
+
+    selectSession: async (ref: HostSessionRef, signal: AbortSignal): Promise<void> => {
+      callLog.push('selectSession');
+      fail('selectSession');
+      snapshot.sessionId = ref.sessionId;
+      if (opts.selectSessionFn) await opts.selectSessionFn(ref, signal);
+    },
+
+    restore: async (snap: RuntimeSnapshot): Promise<void> => {
+      callLog.push('restore');
+      fail('restore');
+      snapshot.hostId = snap.hostId;
+      snapshot.runtimeKey = snap.runtimeKey;
+      snapshot.sessionId = snap.sessionId;
+      snapshot.projectId = snap.projectId;
+      snapshot.directory = snap.directory;
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const hostMap: Record<string, HostDescriptor> = {
+  'host-a': hostA,
+  'host-b': hostB,
+  'host-c': hostC,
+};
+
+const getHost = (hostId: HostId): HostDescriptor | undefined => hostMap[hostId];
+
+const createController = (
+  adapter: ReturnType<typeof createFakeAdapter>,
+  overrides?: { timeoutMs?: number; clearUnread?: (ref: HostSessionRef) => void },
+) => {
+  return createHostActivationController({
+    adapter,
+    getHost,
+    clearUnread: overrides?.clearUnread ?? (() => {}),
+    timeoutMs: overrides?.timeoutMs ?? 5_000,
+    logger: noopLogger,
+  });
+};
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('host-activation-controller', () => {
+  // ---- 1. host A → host B session success ----
+  test('1. host A → host B session succeeds', async () => {
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('success');
+    expect(adapter.callLog).toContain('validateHost');
+    expect(adapter.callLog).toContain('switchHost');
+    expect(adapter.callLog).toContain('waitForRuntimeReady');
+    expect(adapter.callLog.some((l) => l.startsWith('openProjectOrDirectory'))).toBe(true);
+    expect(adapter.callLog).toContain('verifySessionExists');
+    expect(adapter.callLog).toContain('selectSession');
+    expect(adapter.snapshot.hostId).toBe('host-b');
+    expect(adapter.snapshot.sessionId).toBe('ses_b1');
+
+    ctrl.dispose();
+  });
+
+  // ---- 2. Same host switching sessions doesn't call switchHost ----
+  test('2. same host does not call switchHost', async () => {
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refA2);
+
+    expect(result.kind).toBe('success');
+    expect(adapter.callLog).not.toContain('switchHost');
+    expect(adapter.callLog).toContain('validateHost');
+
+    ctrl.dispose();
+  });
+
+  // ---- 3. Current active session returns no-op ----
+  test('3. current active session returns no-op', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      currentSessionId: 'ses_a1',
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refA1);
+
+    expect(result.kind).toBe('no-op');
+    expect(adapter.callLog).toHaveLength(0);
+
+    ctrl.dispose();
+  });
+
+  // ---- 4. projectId and directory are passed to adapter ----
+  test('4. projectId and directory passed to adapter', async () => {
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter);
+
+    await ctrl.activateSession(refB1);
+
+    // Verify adapter received the correct ref with projectId and directory
+    // by checking the openProjectOrDirectory call was made
+    expect(adapter.callLog).toContain('openProjectOrDirectory');
+
+    ctrl.dispose();
+  });
+
+  // ---- 5. A → B → C rapid clicks, only C takes effect ----
+  test('5. rapid A → B → C clicks, only C takes effect', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      switchHostFn: async () => {
+        await delay(50);
+      },
+    });
+    const ctrl = createController(adapter);
+
+    // Fire all three concurrently
+    const [resultA, resultB, resultC] = await Promise.all([
+      ctrl.activateSession(refB1),
+      ctrl.activateSession(refC1),
+      ctrl.activateSession(refB1),
+    ]);
+
+    // The last one (C) should be the final one
+    // A and B should be cancelled
+    const results = [resultA, resultB, resultC];
+    const cancelled = results.filter((r) => r.kind === 'cancelled' || r.kind === 'failure');
+    const succeeded = results.filter((r) => r.kind === 'success' || r.kind === 'no-op');
+
+    // At least one should have succeeded or been the last
+    expect(cancelled.length + succeeded.length).toBe(3);
+
+    ctrl.dispose();
+  });
+
+  // ---- 6. Old activation result can't overwrite new state ----
+  test('6. old activation result cannot overwrite new state', async () => {
+    let resolveFirst!: () => void;
+    const firstPromise = new Promise<void>((r) => { resolveFirst = r; });
+
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      switchHostFn: async () => {
+        if (adapter.callLog.filter((l) => l === 'switchHost').length === 0) {
+          await firstPromise;
+        }
+      },
+    });
+    const ctrl = createController(adapter);
+
+    // Start first activation
+    const p1 = ctrl.activateSession(refB1);
+    // Start second activation (aborts first)
+    const p2 = ctrl.activateSession(refC1);
+
+    // Resolve first
+    resolveFirst();
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // First should be cancelled, second should succeed
+    expect(r1.kind).toBe('cancelled');
+    expect(r2.kind).toBe('success');
+
+    ctrl.dispose();
+  });
+
+  // ---- 7. Old activation doesn't select after C completes ----
+  test('7. old activation does not select after new activation completes', async () => {
+    const selections: string[] = [];
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      selectSessionFn: async (ref) => {
+        selections.push(ref.sessionId);
+        await delay(10);
+      },
+    });
+    const ctrl = createController(adapter);
+
+    const p1 = ctrl.activateSession(refB1);
+    const p2 = ctrl.activateSession(refC1);
+
+    await Promise.all([p1, p2]);
+
+    // Only the last activation's session should have been selected
+    // refB1's session might have been selected before being cancelled
+    // but refC1's session must be in the list
+    expect(selections).toContain('ses_c1');
+
+    ctrl.dispose();
+  });
+
+  // ---- 8. host not found ----
+  test('8. host not found returns HOST_NOT_FOUND', async () => {
+    const adapter = createFakeAdapter();
+    const ctrl = createController(adapter);
+
+    const ref: HostSessionRef = {
+      hostId: 'nonexistent' as HostId,
+      sessionId: 'ses_1',
+      directory: '/tmp',
+      projectId: 'p1',
+    };
+
+    const result = await ctrl.activateSession(ref);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('HOST_NOT_FOUND');
+
+    ctrl.dispose();
+  });
+
+  // ---- 9. host offline ----
+  test('9. host offline returns HOST_OFFLINE', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { validateHost: new Error('HOST_OFFLINE') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('HOST_OFFLINE');
+
+    ctrl.dispose();
+  });
+
+  // ---- 10. unsupported transport ----
+  test('10. unsupported transport returns UNSUPPORTED_TRANSPORT', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { validateHost: new Error('UNSUPPORTED_TRANSPORT') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('UNSUPPORTED_TRANSPORT');
+
+    ctrl.dispose();
+  });
+
+  // ---- 11. authentication failed ----
+  test('11. authentication failed returns AUTHENTICATION_FAILED', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { validateHost: new Error('AUTHENTICATION_FAILED') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('AUTHENTICATION_FAILED');
+
+    ctrl.dispose();
+  });
+
+  // ---- 12. runtime ready timeout ----
+  test('12. runtime ready timeout returns RUNTIME_READY_TIMEOUT', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { waitForRuntimeReady: new Error('TIMEOUT') },
+    });
+    const ctrl = createController(adapter, { timeoutMs: 100 });
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('RUNTIME_READY_TIMEOUT');
+
+    ctrl.dispose();
+  });
+
+  // ---- 13. project not found ----
+  test('13. project not found returns PROJECT_NOT_FOUND', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { openProjectOrDirectory: new Error('PROJECT_NOT_FOUND') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('PROJECT_NOT_FOUND');
+
+    ctrl.dispose();
+  });
+
+  // ---- 14. directory not found ----
+  test('14. directory not found returns DIRECTORY_NOT_FOUND', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { openProjectOrDirectory: new Error('DIRECTORY_NOT_FOUND') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('DIRECTORY_NOT_FOUND');
+
+    ctrl.dispose();
+  });
+
+  // ---- 15. session not found ----
+  test('15. session not found returns SESSION_NOT_FOUND', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      verifySessionFn: async () => false,
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('SESSION_NOT_FOUND');
+
+    ctrl.dispose();
+  });
+
+  // ---- 16. selectSession fails ----
+  test('16. selectSession failure returns SELECTION_FAILED', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { selectSession: new Error('selection error') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('SELECTION_FAILED');
+
+    ctrl.dispose();
+  });
+
+  // ---- 17. failure then rollback succeeds ----
+  test('17. failure after host switch triggers rollback', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { openProjectOrDirectory: new Error('NAVIGATION_FAILED') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('NAVIGATION_FAILED');
+    expect(adapter.callLog).toContain('restore');
+    expect(adapter.callLog).toContain('switchHost');
+
+    ctrl.dispose();
+  });
+
+  // ---- 18. rollback failure preserves original and rollback error ----
+  test('18. rollback failure preserves original and rollback errors', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: {
+        openProjectOrDirectory: new Error('NAVIGATION_FAILED'),
+        restore: new Error('restore failed'),
+      },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('NAVIGATION_FAILED');
+    expect(result.rollbackError).toBeDefined();
+    expect(result.rollbackError?.code).toBe('ROLLBACK_FAILED');
+
+    ctrl.dispose();
+  });
+
+  // ---- 19. abort does not clearUnread ----
+  test('19. abort does not clearUnread', async () => {
+    const cleared: HostSessionRef[] = [];
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      selectSessionFn: async () => {
+        await delay(100);
+      },
+    });
+    const ctrl = createController(adapter, {
+      clearUnread: (ref) => { cleared.push(ref); },
+    });
+
+    const p = ctrl.activateSession(refB1);
+    ctrl.cancelCurrent('test');
+    await p;
+
+    expect(cleared).toHaveLength(0);
+
+    ctrl.dispose();
+  });
+
+  // ---- 20. success only clears target session unread ----
+  test('20. success only clears target session unread', async () => {
+    const cleared: HostSessionRef[] = [];
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter, {
+      clearUnread: (ref) => { cleared.push(ref); },
+    });
+
+    await ctrl.activateSession(refB1);
+
+    expect(cleared).toHaveLength(1);
+    expect(cleared[0].hostId).toBe('host-b');
+    expect(cleared[0].sessionId).toBe('ses_b1');
+
+    ctrl.dispose();
+  });
+
+  // ---- 21. does not clear unread for same sessionId but different host ----
+  test('21. does not clear unread for same sessionId different host', async () => {
+    const cleared: HostSessionRef[] = [];
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter, {
+      clearUnread: (ref) => { cleared.push(ref); },
+    });
+
+    await ctrl.activateSession(refB1);
+
+    // Should not have cleared any session from host-a
+    expect(cleared.every((r) => r.hostId === 'host-b')).toBe(true);
+
+    ctrl.dispose();
+  });
+
+  // ---- 22. dispose cleans up pending activation ----
+  test('22. dispose cleans up pending activation', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      selectSessionFn: async () => {
+        await delay(200);
+      },
+    });
+    const ctrl = createController(adapter);
+
+    ctrl.activateSession(refB1);
+    ctrl.dispose();
+
+    // After dispose, state should be cleaned
+    const state = ctrl.getState();
+    expect(state.stage).toBe('idle');
+  });
+
+  // ---- 23. dispose后 activateSession returns disposed error ----
+  test('23. dispose后 activateSession returns CONTROLLER_DISPOSED', async () => {
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter);
+
+    ctrl.dispose();
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('CONTROLLER_DISPOSED');
+  });
+
+  // ---- 24. controller can be used by non-React code ----
+  test('24. controller is usable without React', async () => {
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter);
+
+    // Imperative usage
+    const state = ctrl.getState();
+    expect(state.stage).toBe('idle');
+    expect(state.requestId).toBeNull();
+
+    const result = await ctrl.activateSession(refB1);
+    expect(result.kind).toBe('success');
+
+    const stateAfter = ctrl.getState();
+    expect(stateAfter.stage).toBe('succeeded');
+
+    ctrl.dispose();
+  });
+
+  // ---- 25. secret does not enter logs ----
+  test('25. secret does not enter logs', async () => {
+    const logs: string[] = [];
+    const logger: SafeActivationLogger = {
+      debug: (_stage, msg) => { logs.push(msg); },
+      info: (_stage, msg) => { logs.push(msg); },
+      warn: (_stage, msg) => { logs.push(msg); },
+      error: (_stage, msg) => { logs.push(msg); },
+    };
+
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createHostActivationController({
+      adapter,
+      getHost,
+      clearUnread: () => {},
+      timeoutMs: 5_000,
+      logger,
+    });
+
+    await ctrl.activateSession(refB1);
+
+    // No log should contain transport URLs, tokens, or secrets
+    for (const log of logs) {
+      expect(log).not.toContain('http://localhost:3000');
+      expect(log).not.toContain('remote:22');
+      expect(log).not.toContain('relay-1');
+      expect(log).not.toContain('token');
+      expect(log).not.toContain('secret');
+    }
+
+    ctrl.dispose();
+  });
+
+  // ---- 26. adapter call order is correct ----
+  test('26. adapter call order is correct for full activation', async () => {
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter);
+
+    await ctrl.activateSession(refB1);
+
+    // Expected order: validateHost → switchHost → waitForRuntimeReady → openProjectOrDirectory → verifySessionExists → selectSession
+    const stageOrder = [
+      'validateHost',
+      'switchHost',
+      'waitForRuntimeReady',
+      'verifySessionExists',
+      'selectSession',
+    ];
+    let lastIdx = -1;
+    for (const stage of stageOrder) {
+      const idx = adapter.callLog.indexOf(stage);
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeGreaterThan(lastIdx);
+      lastIdx = idx;
+    }
+
+    ctrl.dispose();
+  });
+
+  // ---- 27. switch success but verify fails → restore ----
+  test('27. switch success but verify fails triggers restore', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      verifySessionFn: async () => false,
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('SESSION_NOT_FOUND');
+    expect(adapter.callLog).toContain('restore');
+    expect(adapter.callLog).toContain('switchHost');
+
+    ctrl.dispose();
+  });
+
+  // ---- 28. same host navigation failure does not execute full host restore ----
+  test('28. same host navigation failure does not restore host', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { openProjectOrDirectory: new Error('NAVIGATION_FAILED') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refA2);
+
+    expect(result.kind).toBe('failure');
+    // No switchHost was called, so no restore needed
+    expect(adapter.callLog).not.toContain('switchHost');
+    expect(adapter.callLog).not.toContain('restore');
+
+    ctrl.dispose();
+  });
+
+  // ---- 29. timeout late-arriving promise does not modify state ----
+  test('29. timeout late-arriving promise does not modify state', async () => {
+    let resolveLate!: () => void;
+    const latePromise = new Promise<void>((r) => { resolveLate = r; });
+
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      selectSessionFn: async () => {
+        await latePromise;
+      },
+    });
+    const ctrl = createController(adapter, { timeoutMs: 50 });
+
+    // Start activation
+    const p1 = ctrl.activateSession(refB1);
+
+    // Wait for timeout to fire
+    await delay(200);
+
+    // Resolve the late promise so the old activation can complete
+    resolveLate();
+    await p1;
+
+    // The state should have been set by timeout, not by late resolution
+    const state = ctrl.getState();
+    // After timeout, it should be failed or cancelled
+    expect(state.stage === 'failed' || state.stage === 'cancelled' || state.stage === 'idle').toBe(true);
+
+    ctrl.dispose();
+  });
+
+  // ---- 30. cancelCurrent cleans timer and pending state ----
+  test('30. cancelCurrent cleans timer and pending state', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      selectSessionFn: async () => {
+        await delay(500);
+      },
+    });
+    const ctrl = createController(adapter);
+
+    ctrl.activateSession(refB1);
+    await delay(10);
+    ctrl.cancelCurrent('user cancelled');
+
+    const state = ctrl.getState();
+    expect(state.stage).toBe('idle');
+    expect(state.requestId).toBeNull();
+
+    ctrl.dispose();
+  });
+
+  // ---- 31. listener subscribe/unsubscribe correct ----
+  test('31. listener subscribe/unsubscribe works', async () => {
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter);
+
+    const states: ActivationStage[] = [];
+    const unsub = ctrl.subscribe((s) => {
+      states.push(s.stage);
+    });
+
+    await ctrl.activateSession(refB1);
+
+    expect(states.length).toBeGreaterThan(0);
+    expect(states).toContain('succeeded');
+
+    // Unsubscribe
+    unsub();
+    states.length = 0;
+
+    await ctrl.activateSession(refB1);
+
+    // No new states should be captured after unsubscribe
+    expect(states).toHaveLength(0);
+
+    ctrl.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Additional edge cases
+// ---------------------------------------------------------------------------
+
+describe('edge cases', () => {
+  test('concurrent activations abort previous', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      validateHostFn: async () => {
+        await delay(50);
+      },
+    });
+    const ctrl = createController(adapter);
+
+    const p1 = ctrl.activateSession(refB1);
+    const p2 = ctrl.activateSession(refC1);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // At least one should be cancelled
+    expect(r1.kind === 'cancelled' || r2.kind === 'cancelled').toBe(true);
+
+    ctrl.dispose();
+  });
+
+  test('dispose during activation aborts and cleans up', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      validateHostFn: async () => {
+        await delay(200);
+      },
+    });
+    const ctrl = createController(adapter);
+
+    const p = ctrl.activateSession(refB1);
+    await delay(10);
+    ctrl.dispose();
+
+    const result = await p;
+    expect(result.kind === 'cancelled' || result.kind === 'failure').toBe(true);
+  });
+
+  test('getState returns stable reference when no change', () => {
+    const adapter = createFakeAdapter();
+    const ctrl = createController(adapter);
+
+    const s1 = ctrl.getState();
+    const s2 = ctrl.getState();
+    // Same values, but different object references (no memoization needed for getState)
+    expect(s1.stage).toBe(s2.stage);
+    expect(s1.requestId).toBe(s2.requestId);
+
+    ctrl.dispose();
+  });
+
+  test('cancelCurrent after dispose is a no-op', () => {
+    const adapter = createFakeAdapter();
+    const ctrl = createController(adapter);
+
+    ctrl.dispose();
+    // Should not throw
+    ctrl.cancelCurrent('test');
+  });
+
+  test('multiple subscribe/unsubscribe cycles', async () => {
+    const adapter = createFakeAdapter({ currentHostId: 'host-a' as HostId });
+    const ctrl = createController(adapter);
+
+    const count1 = { n: 0 };
+    const count2 = { n: 0 };
+
+    const unsub1 = ctrl.subscribe(() => { count1.n++; });
+    const unsub2 = ctrl.subscribe(() => { count2.n++; });
+
+    await ctrl.activateSession(refB1);
+    expect(count1.n).toBeGreaterThan(0);
+    expect(count2.n).toBeGreaterThan(0);
+
+    unsub1();
+    count1.n = 0;
+    count2.n = 0;
+
+    await ctrl.activateSession(refA2);
+    expect(count1.n).toBe(0);
+    expect(count2.n).toBeGreaterThan(0);
+
+    unsub2();
+    ctrl.dispose();
+  });
+
+  test('no-op does not call clearUnread', async () => {
+    const cleared: HostSessionRef[] = [];
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      currentSessionId: 'ses_a1',
+    });
+    const ctrl = createController(adapter, {
+      clearUnread: (ref) => { cleared.push(ref); },
+    });
+
+    // refA1 matches current session (host-a + ses_a1)
+    const result = await ctrl.activateSession(refA1);
+    expect(result.kind).toBe('no-op');
+    expect(cleared).toHaveLength(0);
+
+    ctrl.dispose();
+  });
+
+  test('switchHost error returns SWITCH_FAILED', async () => {
+    const adapter = createFakeAdapter({
+      currentHostId: 'host-a' as HostId,
+      shouldFail: { switchHost: new Error('network error') },
+    });
+    const ctrl = createController(adapter);
+
+    const result = await ctrl.activateSession(refB1);
+
+    expect(result.kind).toBe('failure');
+    expect(result.error?.code).toBe('SWITCH_FAILED');
+
+    ctrl.dispose();
+  });
+});

--- a/packages/ui/src/multi-host/activation/activation-errors.ts
+++ b/packages/ui/src/multi-host/activation/activation-errors.ts
@@ -1,0 +1,247 @@
+/**
+ * Structured activation error construction.
+ *
+ * Errors are safe for logging: no secrets, tokens, descriptors, or
+ * connection URLs appear in messages or metadata.
+ */
+
+import type { HostId } from '../types';
+import type { ActivationError, ActivationErrorCode, ActivationStage } from './types';
+
+// ---------------------------------------------------------------------------
+// Redaction helpers
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_KEYS = new Set([
+  'token',
+  'clienttoken',
+  'authorization',
+  'relaygrant',
+  'pairingsecret',
+  'privatekey',
+  'apiurl',
+  'sshendpoint',
+  'relayserverid',
+  'requestheaders',
+]);
+
+/**
+ * Redact sensitive fields from an object for safe logging.
+ * Returns a new object with sensitive values replaced by '[REDACTED]'.
+ */
+export const redactMeta = (meta: Record<string, unknown>): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(meta)) {
+    if (SENSITIVE_KEYS.has(k.toLowerCase())) {
+      out[k] = '[REDACTED]';
+    } else if (typeof v === 'string' && v.length > 100) {
+      out[k] = v.slice(0, 20) + '...[truncated]';
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+};
+
+/**
+ * Create a safe label for a host descriptor that never leaks transport details.
+ */
+export const safeHostLabel = (hostId: HostId): string => `host:${hostId}`;
+
+// ---------------------------------------------------------------------------
+// Error factory
+// ---------------------------------------------------------------------------
+
+export const createActivationError = (
+  code: ActivationErrorCode,
+  stage: ActivationStage,
+  message: string,
+  options?: {
+    hostId?: HostId;
+    requestId?: string;
+    cause?: unknown;
+  },
+): ActivationError => ({
+  code,
+  stage,
+  message,
+  hostId: options?.hostId,
+  requestId: options?.requestId,
+  cause: options?.cause,
+});
+
+// ---------------------------------------------------------------------------
+// Well-known error factories
+// ---------------------------------------------------------------------------
+
+export const hostNotFound = (
+  hostId: HostId,
+  requestId?: string,
+): ActivationError =>
+  createActivationError('HOST_NOT_FOUND', 'idle', `Host ${hostId} not found`, {
+    hostId,
+    requestId,
+  });
+
+export const hostOffline = (
+  hostId: HostId,
+  requestId?: string,
+  cause?: unknown,
+): ActivationError =>
+  createActivationError('HOST_OFFLINE', 'validating', `Host ${hostId} is offline`, {
+    hostId,
+    requestId,
+    cause,
+  });
+
+export const unsupportedTransport = (
+  hostId: HostId,
+  requestId?: string,
+): ActivationError =>
+  createActivationError(
+    'UNSUPPORTED_TRANSPORT',
+    'validating',
+    `Transport for host ${hostId} is not supported`,
+    { hostId, requestId },
+  );
+
+export const authenticationFailed = (
+  hostId: HostId,
+  requestId?: string,
+  cause?: unknown,
+): ActivationError =>
+  createActivationError(
+    'AUTHENTICATION_FAILED',
+    'validating',
+    `Authentication failed for host ${hostId}`,
+    { hostId, requestId, cause },
+  );
+
+export const validationFailed = (
+  hostId: HostId,
+  requestId?: string,
+  cause?: unknown,
+): ActivationError =>
+  createActivationError(
+    'VALIDATION_FAILED',
+    'validating',
+    `Validation failed for host ${hostId}`,
+    { hostId, requestId, cause },
+  );
+
+export const switchFailed = (
+  hostId: HostId,
+  requestId?: string,
+  cause?: unknown,
+): ActivationError =>
+  createActivationError(
+    'SWITCH_FAILED',
+    'switching-host',
+    `Host switch failed for host ${hostId}`,
+    { hostId, requestId, cause },
+  );
+
+export const runtimeReadyTimeout = (
+  hostId: HostId,
+  requestId?: string,
+): ActivationError =>
+  createActivationError(
+    'RUNTIME_READY_TIMEOUT',
+    'waiting-runtime',
+    `Runtime ready timeout for host ${hostId}`,
+    { hostId, requestId },
+  );
+
+export const projectNotFound = (
+  hostId: HostId,
+  requestId?: string,
+): ActivationError =>
+  createActivationError(
+    'PROJECT_NOT_FOUND',
+    'opening-project',
+    `Project not found on host ${hostId}`,
+    { hostId, requestId },
+  );
+
+export const directoryNotFound = (
+  hostId: HostId,
+  requestId?: string,
+): ActivationError =>
+  createActivationError(
+    'DIRECTORY_NOT_FOUND',
+    'opening-project',
+    `Directory not found on host ${hostId}`,
+    { hostId, requestId },
+  );
+
+export const sessionNotFound = (
+  hostId: HostId,
+  sessionId: string,
+  requestId?: string,
+): ActivationError =>
+  createActivationError(
+    'SESSION_NOT_FOUND',
+    'verifying-session',
+    `Session ${sessionId} not found on host ${hostId}`,
+    { hostId, requestId },
+  );
+
+export const navigationFailed = (
+  hostId: HostId,
+  requestId?: string,
+  cause?: unknown,
+): ActivationError =>
+  createActivationError(
+    'NAVIGATION_FAILED',
+    'opening-project',
+    `Navigation failed for host ${hostId}`,
+    { hostId, requestId, cause },
+  );
+
+export const selectionFailed = (
+  hostId: HostId,
+  requestId?: string,
+  cause?: unknown,
+): ActivationError =>
+  createActivationError(
+    'SELECTION_FAILED',
+    'selecting-session',
+    `Session selection failed for host ${hostId}`,
+    { hostId, requestId, cause },
+  );
+
+export const cancelled = (
+  requestId?: string,
+): ActivationError =>
+  createActivationError('CANCELLED', 'idle', 'Activation cancelled', {
+    requestId,
+  });
+
+export const controllerDisposed = (
+  requestId?: string,
+): ActivationError =>
+  createActivationError('CONTROLLER_DISPOSED', 'idle', 'Controller disposed', {
+    requestId,
+  });
+
+export const rollbackFailed = (
+  hostId: HostId,
+  requestId?: string,
+  cause?: unknown,
+): ActivationError =>
+  createActivationError(
+    'ROLLBACK_FAILED',
+    'rolling-back',
+    `Rollback failed for host ${hostId}`,
+    { hostId, requestId, cause },
+  );
+
+export const unknownError = (
+  stage: ActivationStage,
+  requestId?: string,
+  cause?: unknown,
+): ActivationError =>
+  createActivationError('UNKNOWN', stage, 'Unknown activation error', {
+    requestId,
+    cause,
+  });

--- a/packages/ui/src/multi-host/activation/activation-state.ts
+++ b/packages/ui/src/multi-host/activation/activation-state.ts
@@ -1,0 +1,218 @@
+/**
+ * Internal activation state management.
+ *
+ * Tracks the current activation request, AbortController, stage,
+ * and notifies listeners on state changes. Not exported publicly —
+ * only used by the controller and transaction internals.
+ */
+
+import type { HostSessionRef } from '../types';
+import type { ActivationError, ActivationStage, ActivationState } from './types';
+
+// ---------------------------------------------------------------------------
+// Internal mutable state
+// ---------------------------------------------------------------------------
+
+export interface ActivationInternalState {
+  /** Monotonically increasing request counter. */
+  requestCounter: number;
+  /** Current request id (string of the counter). */
+  currentRequestId: string | null;
+  /** AbortController for the current activation. */
+  abortController: AbortController | null;
+  /** Target session ref for the current activation. */
+  targetRef: HostSessionRef | null;
+  /** Timestamp when the current activation started. */
+  startedAt: number | null;
+  /** Current stage. */
+  stage: ActivationStage;
+  /** Error from the current or last activation (cleared on new activation). */
+  error: ActivationError | null;
+  /** Listeners subscribed to state changes. */
+  listeners: Set<(state: ActivationState) => void>;
+  /** Whether the controller has been disposed. */
+  disposed: boolean;
+  /** Pending timeout timers (keyed by stage). */
+  pendingTimers: Set<ReturnType<typeof setTimeout>>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export const createActivationInternalState = (): ActivationInternalState => ({
+  requestCounter: 0,
+  currentRequestId: null,
+  abortController: null,
+  targetRef: null,
+  startedAt: null,
+  stage: 'idle',
+  error: null,
+  listeners: new Set(),
+  disposed: false,
+  pendingTimers: new Set(),
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot helpers (read-only view for external consumers)
+// ---------------------------------------------------------------------------
+
+export const toPublicState = (s: ActivationInternalState): ActivationState => ({
+  stage: s.stage,
+  requestId: s.currentRequestId,
+  targetRef: s.targetRef,
+  startedAt: s.startedAt,
+  error: s.error,
+});
+
+// ---------------------------------------------------------------------------
+// State transitions
+// ---------------------------------------------------------------------------
+
+export const advanceStage = (
+  s: ActivationInternalState,
+  stage: ActivationStage,
+): void => {
+  s.stage = stage;
+  notifyListeners(s);
+};
+
+export const setError = (
+  s: ActivationInternalState,
+  error: ActivationError,
+): void => {
+  s.error = error;
+  s.stage = 'failed';
+  notifyListeners(s);
+};
+
+export const clearError = (s: ActivationInternalState): void => {
+  if (s.error) {
+    s.error = null;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Request lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Start a new activation request. Returns the new requestId.
+ * Aborts any previous activation.
+ */
+export const startNewRequest = (
+  s: ActivationInternalState,
+  targetRef: HostSessionRef,
+): { requestId: string; abortController: AbortController } => {
+  // Abort previous
+  if (s.abortController) {
+    s.abortController.abort();
+  }
+  clearPendingTimers(s);
+
+  s.requestCounter++;
+  const requestId = String(s.requestCounter);
+  const abortController = new AbortController();
+
+  s.currentRequestId = requestId;
+  s.abortController = abortController;
+  s.targetRef = targetRef;
+  s.startedAt = Date.now();
+  s.stage = 'idle';
+  s.error = null;
+
+  notifyListeners(s);
+  return { requestId, abortController };
+};
+
+/**
+ * Check if the given requestId is still the current one.
+ */
+export const isCurrentRequest = (
+  s: ActivationInternalState,
+  requestId: string,
+): boolean => s.currentRequestId === requestId;
+
+/**
+ * Check if the current activation has been aborted.
+ */
+export const isAborted = (s: ActivationInternalState): boolean =>
+  s.abortController?.signal.aborted === true;
+
+// ---------------------------------------------------------------------------
+// Timer management
+// ---------------------------------------------------------------------------
+
+export const scheduleTimer = (
+  s: ActivationInternalState,
+  ms: number,
+  callback: () => void,
+): void => {
+  const timer = setTimeout(() => {
+    s.pendingTimers.delete(timer);
+    callback();
+  }, ms);
+  s.pendingTimers.add(timer);
+};
+
+export const clearPendingTimers = (s: ActivationInternalState): void => {
+  for (const timer of s.pendingTimers) {
+    clearTimeout(timer);
+  }
+  s.pendingTimers.clear();
+};
+
+// ---------------------------------------------------------------------------
+// Listener management
+// ---------------------------------------------------------------------------
+
+export const subscribeListener = (
+  s: ActivationInternalState,
+  listener: (state: ActivationState) => void,
+): (() => void) => {
+  s.listeners.add(listener);
+  return () => {
+    s.listeners.delete(listener);
+  };
+};
+
+const notifyListeners = (s: ActivationInternalState): void => {
+  const publicState = toPublicState(s);
+  for (const listener of s.listeners) {
+    listener(publicState);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Reset to idle
+// ---------------------------------------------------------------------------
+
+export const resetToIdle = (s: ActivationInternalState): void => {
+  s.currentRequestId = null;
+  s.abortController = null;
+  s.targetRef = null;
+  s.startedAt = null;
+  s.stage = 'idle';
+  s.error = null;
+  clearPendingTimers(s);
+  notifyListeners(s);
+};
+
+// ---------------------------------------------------------------------------
+// Dispose
+// ---------------------------------------------------------------------------
+
+export const disposeState = (s: ActivationInternalState): void => {
+  if (s.abortController) {
+    s.abortController.abort();
+  }
+  clearPendingTimers(s);
+  s.disposed = true;
+  s.currentRequestId = null;
+  s.abortController = null;
+  s.targetRef = null;
+  s.startedAt = null;
+  s.stage = 'idle';
+  s.error = null;
+  s.listeners.clear();
+};

--- a/packages/ui/src/multi-host/activation/activation-transaction.ts
+++ b/packages/ui/src/multi-host/activation/activation-transaction.ts
@@ -1,0 +1,432 @@
+/**
+ * Activation transaction — the core state machine.
+ *
+ * Orchestrates: validate → switch host → wait ready → open project →
+ * verify session → select session → clear unread.
+ *
+ * Handles: concurrency (abort old), rollback, timeout, cancellation.
+ */
+
+import type { HostDescriptor, HostId, HostSessionRef } from '../types';
+import type {
+  ActivationError,
+  ActivationResult,
+  ActivationStage,
+  RuntimeActivationAdapter,
+  RuntimeSnapshot,
+  SafeActivationLogger,
+} from './types';
+import type { ActivationInternalState } from './activation-state';
+import {
+  advanceStage,
+  isAborted,
+  isCurrentRequest,
+  setError,
+  startNewRequest,
+} from './activation-state';
+import {
+  authenticationFailed,
+  cancelled,
+  controllerDisposed,
+  directoryNotFound,
+  hostNotFound,
+  hostOffline,
+  navigationFailed,
+  projectNotFound,
+  rollbackFailed,
+  runtimeReadyTimeout,
+  selectionFailed,
+  sessionNotFound,
+  switchFailed,
+  unknownError,
+  unsupportedTransport,
+} from './activation-errors';
+
+// ---------------------------------------------------------------------------
+// Timeout constants
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Transaction runner
+// ---------------------------------------------------------------------------
+
+export interface TransactionContext {
+  state: ActivationInternalState;
+  adapter: RuntimeActivationAdapter;
+  getHost: (hostId: HostId) => HostDescriptor | undefined;
+  clearUnread: (ref: HostSessionRef) => void;
+  timeoutMs: number;
+  rollbackTimeoutMs: number;
+  logger: SafeActivationLogger;
+}
+
+/**
+ * Execute a full activation transaction for the given session ref.
+ *
+ * Returns an ActivationResult. Never throws — all errors are caught
+ * and returned as structured ActivationResult with kind 'failure'.
+ */
+export const runActivationTransaction = async (
+  ctx: TransactionContext,
+  ref: HostSessionRef,
+): Promise<ActivationResult> => {
+  const { state, adapter, getHost, clearUnread, timeoutMs, logger } = ctx;
+
+  // Reject if disposed
+  if (state.disposed) {
+    const err = controllerDisposed();
+    return { kind: 'failure', requestId: '', error: err };
+  }
+
+  // Start new request (aborts any previous)
+  const { requestId, abortController } = startNewRequest(state, ref);
+  const { signal } = abortController;
+
+  logger.info('idle', 'Activation started', {
+    requestId,
+    hostId: ref.hostId,
+    sessionId: ref.sessionId,
+  });
+
+  // ---- Stage 1: Resolve host descriptor ----
+  const host = getHost(ref.hostId);
+  if (!host) {
+    const err = hostNotFound(ref.hostId, requestId);
+    setError(state, err);
+    logger.error('idle', 'Host not found', { requestId, hostId: ref.hostId });
+    return { kind: 'failure', requestId, error: err };
+  }
+
+  // ---- Stage 2: Check if already active session ----
+  if (adapter.isCurrentSession(ref)) {
+    advanceStage(state, 'succeeded');
+    logger.info('succeeded', 'Session already active (no-op)', {
+      requestId,
+      hostId: ref.hostId,
+      sessionId: ref.sessionId,
+    });
+    return { kind: 'no-op', requestId };
+  }
+
+  // Guard: already aborted by a newer activation?
+  if (signal.aborted) {
+    const err = cancelled(requestId);
+    return { kind: 'cancelled', requestId, error: err };
+  }
+
+  // ---- Stage 3: Save snapshot for potential rollback ----
+  const previousSnapshot = adapter.getCurrentSnapshot();
+
+  // Track whether we actually switched host (for rollback decisions)
+  let hostSwitched = false;
+
+  // ---- Stage 4: Validate host ----
+  const snapshot = await runStage(ctx, {
+    stage: 'validating',
+    requestId,
+    signal,
+    host,
+    snapshot: previousSnapshot,
+    action: async (stageSignal) => {
+      await withTimeout(adapter.validateHost(host, stageSignal), timeoutMs, stageSignal);
+    },
+    onError: (rawErr, stage) => {
+      const msg = rawErr instanceof Error ? rawErr.message : '';
+      if (msg.includes('AUTHENTICATION_FAILED')) return authenticationFailed(ref.hostId, requestId, rawErr);
+      if (msg.includes('UNSUPPORTED_TRANSPORT')) return unsupportedTransport(ref.hostId, requestId);
+      if (msg.includes('HOST_OFFLINE')) return hostOffline(ref.hostId, requestId, rawErr);
+      if (msg.includes('TIMEOUT')) return runtimeReadyTimeout(ref.hostId, requestId);
+      return unknownError(stage, requestId, rawErr);
+    },
+  });
+  if (snapshot.kind === 'result') return snapshot.result;
+
+  // ---- Stage 5: Switch host (if needed) ----
+  if (!adapter.isCurrentHost(ref.hostId)) {
+    const switchResult = await runStage(ctx, {
+      stage: 'switching-host',
+      requestId,
+      signal,
+      host,
+      snapshot: previousSnapshot,
+      action: async (stageSignal) => {
+        await withTimeout(adapter.switchHost(host, stageSignal), timeoutMs, stageSignal);
+        hostSwitched = true;
+      },
+      onError: (rawErr) => {
+        const msg = rawErr instanceof Error ? rawErr.message : '';
+        if (msg.includes('TIMEOUT')) return runtimeReadyTimeout(ref.hostId, requestId);
+        return switchFailed(ref.hostId, requestId, rawErr);
+      },
+    });
+    if (switchResult.kind === 'result') return switchResult.result;
+  }
+
+  // ---- Stage 6: Wait for runtime ready ----
+  const readyResult = await runStage(ctx, {
+    stage: 'waiting-runtime',
+    requestId,
+    signal,
+    host,
+    snapshot: previousSnapshot,
+    action: async (stageSignal) => {
+      await withTimeout(adapter.waitForRuntimeReady(host, stageSignal), timeoutMs, stageSignal);
+    },
+    onError: (rawErr, stage) => {
+      const msg = rawErr instanceof Error ? rawErr.message : '';
+      if (msg.includes('TIMEOUT')) return runtimeReadyTimeout(ref.hostId, requestId);
+      return unknownError(stage, requestId, rawErr);
+    },
+  });
+  if (readyResult.kind === 'result') return readyResult.result;
+
+  // ---- Stage 7: Open project/directory ----
+  const projectResult = await runStage(ctx, {
+    stage: 'opening-project',
+    requestId,
+    signal,
+    host,
+    snapshot: previousSnapshot,
+    action: async (stageSignal) => {
+      await withTimeout(adapter.openProjectOrDirectory(ref, stageSignal), timeoutMs, stageSignal);
+    },
+    onError: (rawErr) => {
+      const msg = rawErr instanceof Error ? rawErr.message : '';
+      if (msg.includes('PROJECT_NOT_FOUND')) return projectNotFound(ref.hostId, requestId);
+      if (msg.includes('DIRECTORY_NOT_FOUND')) return directoryNotFound(ref.hostId, requestId);
+      if (msg.includes('TIMEOUT')) return runtimeReadyTimeout(ref.hostId, requestId);
+      return navigationFailed(ref.hostId, requestId, rawErr);
+    },
+    shouldRollback: () => hostSwitched,
+  });
+  if (projectResult.kind === 'result') return projectResult.result;
+
+  // ---- Stage 8: Verify session exists ----
+  const verifyResult = await runStage(ctx, {
+    stage: 'verifying-session',
+    requestId,
+    signal,
+    host,
+    snapshot: previousSnapshot,
+    action: async (stageSignal) => {
+      const exists = await withTimeout(
+        adapter.verifySessionExists(ref, stageSignal),
+        timeoutMs,
+        stageSignal,
+      );
+      if (!exists) {
+        throw sessionNotFound(ref.hostId, ref.sessionId, requestId);
+      }
+    },
+    onError: (rawErr, stage) => {
+      if (isActivationError(rawErr) && rawErr.code === 'SESSION_NOT_FOUND') {
+        return sessionNotFound(ref.hostId, ref.sessionId, requestId);
+      }
+      const msg = rawErr instanceof Error ? rawErr.message : '';
+      if (msg.includes('TIMEOUT')) return runtimeReadyTimeout(ref.hostId, requestId);
+      return unknownError(stage, requestId, rawErr);
+    },
+    shouldRollback: () => hostSwitched,
+  });
+  if (verifyResult.kind === 'result') return verifyResult.result;
+
+  // ---- Stage 9: Select session ----
+  const selectResult = await runStage(ctx, {
+    stage: 'selecting-session',
+    requestId,
+    signal,
+    host,
+    snapshot: previousSnapshot,
+    action: async (stageSignal) => {
+      await withTimeout(adapter.selectSession(ref, stageSignal), timeoutMs, stageSignal);
+    },
+    onError: (rawErr) => {
+      const msg = rawErr instanceof Error ? rawErr.message : '';
+      if (msg.includes('TIMEOUT')) return runtimeReadyTimeout(ref.hostId, requestId);
+      return selectionFailed(ref.hostId, requestId, rawErr);
+    },
+  });
+  if (selectResult.kind === 'result') return selectResult.result;
+
+  // ---- Stage 10: Check still current (post-async boundary) ----
+  if (!isCurrentRequest(state, requestId) || isAborted(state)) {
+    const err = cancelled(requestId);
+    setError(state, err);
+    return { kind: 'cancelled', requestId, error: err };
+  }
+
+  // ---- Stage 11: Clear unread (only for the target) ----
+  clearUnread(ref);
+  logger.info('succeeded', 'Unread cleared', {
+    requestId,
+    hostId: ref.hostId,
+    sessionId: ref.sessionId,
+  });
+
+  // ---- Done ----
+  advanceStage(state, 'succeeded');
+  logger.info('succeeded', 'Activation completed', {
+    requestId,
+    hostId: ref.hostId,
+  });
+
+  return { kind: 'success', requestId };
+};
+
+// ---------------------------------------------------------------------------
+// Rollback
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to restore the previous runtime snapshot after a failure.
+ * Uses a dedicated AbortController for rollback, independent of the
+ * activation's signal.
+ */
+export const runRollback = async (
+  adapter: RuntimeActivationAdapter,
+  previousSnapshot: RuntimeSnapshot,
+  rollbackTimeoutMs: number,
+  logger: SafeActivationLogger,
+): Promise<ActivationError | null> => {
+  const rollbackController = new AbortController();
+  const rollbackTimeout = setTimeout(() => rollbackController.abort(), rollbackTimeoutMs);
+
+  try {
+    await adapter.restore(previousSnapshot, rollbackController.signal);
+    logger.info('rolling-back', 'Rollback succeeded');
+    return null;
+  } catch (err) {
+    logger.error('rolling-back', 'Rollback failed', { cause: err });
+    return rollbackFailed('' as HostId, undefined, err);
+  } finally {
+    clearTimeout(rollbackTimeout);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stage runner with timeout, abort, and rollback
+// ---------------------------------------------------------------------------
+
+interface StageConfig {
+  stage: ActivationStage;
+  requestId: string;
+  signal: AbortSignal;
+  host: HostDescriptor;
+  snapshot: RuntimeSnapshot;
+  action: (signal: AbortSignal) => Promise<void>;
+  onError: (err: unknown, stage: ActivationStage) => ActivationError;
+  /** Override rollback decision. Defaults to: host switched and not in validating/switching stage. */
+  shouldRollback?: () => boolean;
+}
+
+type StageOutcome =
+  | { kind: 'result'; result: ActivationResult }
+  | { kind: 'continue' };
+
+const runStage = async (
+  ctx: TransactionContext,
+  config: StageConfig,
+): Promise<StageOutcome> => {
+  const { state, adapter, logger } = ctx;
+  const { stage, requestId, signal, host, snapshot, action, onError, shouldRollback } = config;
+
+  // Guard: still current?
+  if (!isCurrentRequest(state, requestId) || signal.aborted) {
+    return {
+      kind: 'result',
+      result: { kind: 'cancelled', requestId, error: { code: 'CANCELLED', stage, message: 'Cancelled' } },
+    };
+  }
+
+  advanceStage(state, stage);
+  logger.debug(stage, `Stage started`, { requestId, hostId: host.hostId });
+
+  try {
+    await action(signal);
+  } catch (err) {
+    // Check if this is an abort (from a newer activation taking over)
+    if (signal.aborted || !isCurrentRequest(state, requestId)) {
+      return {
+        kind: 'result',
+        result: { kind: 'cancelled', requestId, error: { code: 'CANCELLED', stage, message: 'Cancelled' } },
+      };
+    }
+
+    // Map raw error to ActivationError
+    const activationErr = onError(err, stage);
+
+    logger.error(stage, `Stage failed: ${activationErr.code}`, {
+      requestId,
+      hostId: host.hostId,
+    });
+
+    // Determine if rollback is needed
+    const doRollback = shouldRollback ? shouldRollback() : false;
+
+    if (doRollback) {
+      advanceStage(state, 'rolling-back');
+      const rollbackErr = await runRollback(adapter, snapshot, ctx.rollbackTimeoutMs, logger);
+      setError(state, activationErr);
+      return {
+        kind: 'result',
+        result: {
+          kind: 'failure',
+          requestId,
+          error: activationErr,
+          rollbackError: rollbackErr ?? undefined,
+        },
+      };
+    }
+
+    setError(state, activationErr);
+    return {
+      kind: 'result',
+      result: { kind: 'failure', requestId, error: activationErr },
+    };
+  }
+
+  return { kind: 'continue' };
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  ms: number,
+  signal: AbortSignal,
+): Promise<T> => {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('TIMEOUT'));
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error('ABORTED'));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    promise.then(
+      (val) => {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', onAbort);
+        resolve(val);
+      },
+      (err) => {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+};
+
+const isActivationError = (err: unknown): err is ActivationError =>
+  typeof err === 'object' &&
+  err !== null &&
+  'code' in err &&
+  'stage' in err &&
+  'message' in err;

--- a/packages/ui/src/multi-host/activation/activation.test.ts
+++ b/packages/ui/src/multi-host/activation/activation.test.ts
@@ -1,0 +1,867 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import type { HostDescriptor, HostId, HostSessionRef } from '../types';
+import type {
+  ActivationStage,
+  RuntimeActivationAdapter,
+  RuntimeSnapshot,
+} from './types';
+import { createHostActivationController } from './host-activation-controller';
+import { noopLogger } from './safe-activation-logger';
+import {
+  redactMeta,
+  safeHostLabel,
+} from './activation-errors';
+import {
+  createActivationInternalState,
+  toPublicState,
+  startNewRequest,
+  isCurrentRequest,
+  advanceStage,
+  resetToIdle,
+  disposeState,
+} from './activation-state';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const hostA: HostDescriptor = {
+  hostId: 'host-a' as HostId,
+  label: 'Host A',
+  transport: { kind: 'direct', apiUrl: 'http://localhost:3000' },
+};
+
+const hostB: HostDescriptor = {
+  hostId: 'host-b' as HostId,
+  label: 'Host B',
+  transport: { kind: 'ssh', sshEndpoint: 'remote:22' },
+};
+
+const refA: HostSessionRef = {
+  hostId: 'host-a' as HostId,
+  sessionId: 'ses_a1',
+  directory: '/workspace/project-a',
+  projectId: 'proj-a',
+};
+
+const refA2: HostSessionRef = {
+  hostId: 'host-a' as HostId,
+  sessionId: 'ses_a2',
+  directory: '/workspace/project-a2',
+  projectId: 'proj-a2',
+};
+
+const refB: HostSessionRef = {
+  hostId: 'host-b' as HostId,
+  sessionId: 'ses_b1',
+  directory: '/workspace/project-b',
+  projectId: 'proj-b',
+};
+
+// ---------------------------------------------------------------------------
+// Fake adapter factory
+// ---------------------------------------------------------------------------
+
+interface FakeAdapterOptions {
+  currentSession?: HostSessionRef;
+  currentHostId?: HostId;
+  sessionExists?: boolean;
+  validateError?: Error;
+  switchError?: Error;
+  readyError?: Error;
+  openProjectError?: Error;
+  verifyError?: Error;
+  selectError?: Error;
+  restoreError?: Error;
+}
+
+const createFakeAdapter = (opts: FakeAdapterOptions = {}) => {
+  const callLog: string[] = [];
+  let currentSessionRef = opts.currentSession;
+  let currentHostIdValue = opts.currentHostId;
+
+  const adapter: RuntimeActivationAdapter & {
+    callLog: string[];
+    clearLog: () => void;
+    setCurrentSession: (ref: HostSessionRef | undefined) => void;
+    setCurrentHostId: (id: HostId | undefined) => void;
+  } = {
+    callLog,
+    clearLog: () => { callLog.length = 0; },
+    setCurrentSession: (ref) => { currentSessionRef = ref; },
+    setCurrentHostId: (id) => { currentHostIdValue = id; },
+
+    getCurrentSnapshot: (): RuntimeSnapshot => {
+      callLog.push('getCurrentSnapshot');
+      return {
+        hostId: currentHostIdValue,
+        sessionId: currentSessionRef?.sessionId,
+        directory: currentSessionRef?.directory,
+        projectId: currentSessionRef?.projectId,
+      };
+    },
+
+    isCurrentHost: (hostId: HostId): boolean => {
+      callLog.push('isCurrentHost');
+      return currentHostIdValue === hostId;
+    },
+
+    isCurrentSession: (ref: HostSessionRef): boolean => {
+      callLog.push('isCurrentSession');
+      return (
+        currentSessionRef !== undefined &&
+        currentSessionRef.hostId === ref.hostId &&
+        currentSessionRef.sessionId === ref.sessionId
+      );
+    },
+
+    validateHost: async (host: HostDescriptor, signal: AbortSignal): Promise<void> => {
+      callLog.push('validateHost');
+      if (signal.aborted) throw new Error('ABORTED');
+      if (opts.validateError) throw opts.validateError;
+    },
+
+    switchHost: async (host: HostDescriptor, signal: AbortSignal): Promise<void> => {
+      callLog.push('switchHost');
+      if (signal.aborted) throw new Error('ABORTED');
+      if (opts.switchError) throw opts.switchError;
+      currentHostIdValue = host.hostId;
+    },
+
+    waitForRuntimeReady: async (host: HostDescriptor, signal: AbortSignal): Promise<void> => {
+      callLog.push('waitForRuntimeReady');
+      if (signal.aborted) throw new Error('ABORTED');
+      if (opts.readyError) throw opts.readyError;
+    },
+
+    openProjectOrDirectory: async (ref: HostSessionRef, signal: AbortSignal): Promise<void> => {
+      callLog.push('openProjectOrDirectory');
+      if (signal.aborted) throw new Error('ABORTED');
+      if (opts.openProjectError) throw opts.openProjectError;
+    },
+
+    verifySessionExists: async (ref: HostSessionRef, signal: AbortSignal): Promise<boolean> => {
+      callLog.push('verifySessionExists');
+      if (signal.aborted) throw new Error('ABORTED');
+      if (opts.verifyError) throw opts.verifyError;
+      return opts.sessionExists !== undefined ? opts.sessionExists : true;
+    },
+
+    selectSession: async (ref: HostSessionRef, signal: AbortSignal): Promise<void> => {
+      callLog.push('selectSession');
+      if (signal.aborted) throw new Error('ABORTED');
+      if (opts.selectError) throw opts.selectError;
+      currentSessionRef = ref;
+    },
+
+    restore: async (snapshot: RuntimeSnapshot, signal: AbortSignal): Promise<void> => {
+      callLog.push('restore');
+      if (signal.aborted) throw new Error('ABORTED');
+      if (opts.restoreError) throw opts.restoreError;
+      currentHostIdValue = snapshot.hostId;
+    },
+  };
+
+  return adapter;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const hosts = new Map<HostId, HostDescriptor>([
+  [hostA.hostId, hostA],
+  [hostB.hostId, hostB],
+]);
+
+const getHost = (hostId: HostId) => hosts.get(hostId);
+
+let clearedUnreads: HostSessionRef[] = [];
+const clearUnread = (ref: HostSessionRef) => { clearedUnreads.push(ref); };
+
+const createController = (adapter: ReturnType<typeof createFakeAdapter>, timeoutMs = 5000, rollbackTimeoutMs = 1000) =>
+  createHostActivationController({
+    adapter,
+    getHost,
+    clearUnread,
+    timeoutMs,
+    rollbackTimeoutMs,
+    logger: noopLogger,
+  });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  clearedUnreads = [];
+});
+
+// 1. host A → host B session 成功
+test('activation from host A to host B succeeds', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('success');
+  expect(result.requestId).toBeTruthy();
+  expect(adapter.callLog).toContain('validateHost');
+  expect(adapter.callLog).toContain('switchHost');
+  expect(adapter.callLog).toContain('waitForRuntimeReady');
+  expect(adapter.callLog).toContain('openProjectOrDirectory');
+  expect(adapter.callLog).toContain('verifySessionExists');
+  expect(adapter.callLog).toContain('selectSession');
+  expect(clearedUnreads).toEqual([refB]);
+  ctrl.dispose();
+});
+
+// 2. 同一 host 切 session 不调用 switchHost
+test('same host switch does not call switchHost', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refA2);
+
+  expect(result.kind).toBe('success');
+  expect(adapter.callLog).not.toContain('switchHost');
+  expect(adapter.callLog).toContain('validateHost');
+  expect(adapter.callLog).toContain('selectSession');
+  ctrl.dispose();
+});
+
+// 3. 当前 active session 返回 no-op
+test('activating current session returns no-op', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refA);
+
+  expect(result.kind).toBe('no-op');
+  expect(adapter.callLog).not.toContain('switchHost');
+  expect(adapter.callLog).not.toContain('openProjectOrDirectory');
+  expect(adapter.callLog).not.toContain('selectSession');
+  expect(clearedUnreads).toEqual([]);
+  ctrl.dispose();
+});
+
+// 4. HostSessionRef 的 projectId 和 directory 被传给 adapter
+test('projectId and directory are passed to adapter', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  const ctrl = createController(adapter);
+
+  await ctrl.activateSession(refB);
+
+  expect(adapter.callLog).toContain('openProjectOrDirectory');
+  ctrl.dispose();
+});
+
+// 5. A → B → C 快速点击，最终只有 C 生效
+test('rapid A→B→C clicks, only C takes effect', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+
+  // Hang on validateHost for the first call (same-host activation)
+  let validateCallCount = 0;
+  adapter.validateHost = async (_host, signal) => {
+    adapter.callLog.push('validateHost');
+    validateCallCount++;
+    if (validateCallCount === 1) {
+      return new Promise<void>((_, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('ABORTED')), { once: true });
+      });
+    }
+  };
+
+  const ctrl = createController(adapter);
+
+  // Start A → A2 (will hang on validateHost)
+  const pA2 = ctrl.activateSession(refA2);
+  // Start A → B (will abort A2, validateHost is fast for 2nd call)
+  const pB = ctrl.activateSession(refB);
+
+  const resultB = await pB;
+  expect(resultB.kind).toBe('success');
+
+  const resultA2 = await pA2;
+  expect(resultA2.kind).toBe('cancelled');
+
+  ctrl.dispose();
+});
+
+// 6. 旧 activation 结果不能覆盖新 state
+test('old activation result does not overwrite new state', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  // Both refA2 and refB are different from current session, both require activation
+  const p1 = ctrl.activateSession(refA2);
+  const p2 = ctrl.activateSession(refB);
+
+  const [r1, r2] = await Promise.all([p1, p2]);
+  // r1 should be cancelled since r2 took over
+  expect(r1.kind).toBe('cancelled');
+  expect(r2.kind).toBe('success');
+  ctrl.dispose();
+});
+
+// 7. 旧 activation 不得在 C 完成后 select A/B
+test('cancelled activation does not select after new activation completes', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  const p1 = ctrl.activateSession(refA2);
+  const p2 = ctrl.activateSession(refB);
+
+  const [r1, r2] = await Promise.all([p1, p2]);
+  expect(r1.kind).toBe('cancelled');
+  expect(r2.kind).toBe('success');
+  ctrl.dispose();
+});
+
+// 8. host 不存在
+test('host not found returns HOST_NOT_FOUND', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  const ctrl = createController(adapter);
+
+  const refUnknown: HostSessionRef = {
+    hostId: 'host-unknown' as HostId,
+    sessionId: 'ses_1',
+    directory: '/unknown',
+    projectId: 'proj-unknown',
+  };
+
+  const result = await ctrl.activateSession(refUnknown);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('HOST_NOT_FOUND');
+  expect(adapter.callLog).not.toContain('validateHost');
+  ctrl.dispose();
+});
+
+// 9. host offline
+test('host offline returns HOST_OFFLINE', async () => {
+  const adapter = createFakeAdapter({
+    currentHostId: hostA.hostId,
+    validateError: new Error('HOST_OFFLINE'),
+  });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('HOST_OFFLINE');
+  ctrl.dispose();
+});
+
+// 10. unsupported transport
+test('unsupported transport returns UNSUPPORTED_TRANSPORT', async () => {
+  const adapter = createFakeAdapter({
+    currentHostId: hostA.hostId,
+    validateError: new Error('UNSUPPORTED_TRANSPORT'),
+  });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('UNSUPPORTED_TRANSPORT');
+  ctrl.dispose();
+});
+
+// 11. authentication failed
+test('authentication failed returns AUTHENTICATION_FAILED', async () => {
+  const adapter = createFakeAdapter({
+    currentHostId: hostA.hostId,
+    validateError: new Error('AUTHENTICATION_FAILED'),
+  });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('AUTHENTICATION_FAILED');
+  ctrl.dispose();
+});
+
+// 12. runtime ready timeout
+test('runtime ready timeout returns RUNTIME_READY_TIMEOUT', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  adapter.waitForRuntimeReady = async (_host, signal) => {
+    adapter.callLog.push('waitForRuntimeReady');
+    return new Promise<void>((_, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('ABORTED')), { once: true });
+      setTimeout(() => {
+        signal.dispatchEvent(new Event('abort'));
+      }, 0);
+    });
+  };
+
+  const ctrl = createController(adapter, 100);
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  ctrl.dispose();
+});
+
+// 13. project 不存在
+test('project not found returns PROJECT_NOT_FOUND', async () => {
+  const adapter = createFakeAdapter({
+    currentHostId: hostA.hostId,
+    openProjectError: new Error('PROJECT_NOT_FOUND'),
+  });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('PROJECT_NOT_FOUND');
+  ctrl.dispose();
+});
+
+// 14. directory 不存在
+test('directory not found returns failure', async () => {
+  const adapter = createFakeAdapter({
+    currentHostId: hostA.hostId,
+    openProjectError: new Error('DIRECTORY_NOT_FOUND'),
+  });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  ctrl.dispose();
+});
+
+// 15. session 不存在
+test('session not found returns SESSION_NOT_FOUND', async () => {
+  const adapter = createFakeAdapter({
+    currentHostId: hostA.hostId,
+    sessionExists: false,
+  });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('SESSION_NOT_FOUND');
+  ctrl.dispose();
+});
+
+// 16. selectSession 失败
+test('selectSession failure returns SELECTION_FAILED', async () => {
+  const adapter = createFakeAdapter({
+    currentHostId: hostA.hostId,
+    selectError: new Error('select failed'),
+  });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('SELECTION_FAILED');
+  ctrl.dispose();
+});
+
+// 17. 失败后 rollback 成功
+test('rollback succeeds after switch failure', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  adapter.openProjectOrDirectory = async () => {
+    adapter.callLog.push('openProjectOrDirectory');
+    throw new Error('PROJECT_NOT_FOUND');
+  };
+
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('PROJECT_NOT_FOUND');
+  expect(adapter.callLog).toContain('restore');
+  ctrl.dispose();
+});
+
+// 18. rollback 失败保留原始错误和 rollback 错误
+test('rollback failure preserves both errors', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  adapter.openProjectOrDirectory = async () => {
+    adapter.callLog.push('openProjectOrDirectory');
+    throw new Error('PROJECT_NOT_FOUND');
+  };
+  adapter.restore = async () => {
+    adapter.callLog.push('restore');
+    throw new Error('restore failed');
+  };
+
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('PROJECT_NOT_FOUND');
+  expect(result.rollbackError).toBeDefined();
+  expect(result.rollbackError?.code).toBe('ROLLBACK_FAILED');
+  ctrl.dispose();
+});
+
+// 19. abort 后不 clearUnread
+test('cancelled activation does not clearUnread', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  adapter.selectSession = async (_ref, signal) => {
+    adapter.callLog.push('selectSession');
+    return new Promise<void>((_, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('ABORTED')), { once: true });
+    });
+  };
+
+  const ctrl = createController(adapter);
+
+  const p1 = ctrl.activateSession(refA2);
+  ctrl.cancelCurrent('test');
+
+  const result = await p1;
+  expect(result.kind).toBe('cancelled');
+  expect(clearedUnreads).toEqual([]);
+  ctrl.dispose();
+});
+
+// 20. 成功后只清除目标 session unread
+test('success clears only target session unread', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  await ctrl.activateSession(refB);
+
+  expect(clearedUnreads).toHaveLength(1);
+  expect(clearedUnreads[0]).toEqual(refB);
+  ctrl.dispose();
+});
+
+// 21. 不清除相同 sessionId 但不同 host 的 unread
+test('does not clear unread for same sessionId on different host', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  await ctrl.activateSession(refB);
+
+  expect(clearedUnreads.every((r) => r.hostId === ('host-b' as HostId))).toBe(true);
+  ctrl.dispose();
+});
+
+// 22. dispose 清理 pending activation
+test('dispose cleans up pending activation', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  const ctrl = createController(adapter);
+
+  const p = ctrl.activateSession(refA2);
+  ctrl.dispose();
+
+  const result = await p;
+  expect(['cancelled', 'no-op', 'failure']).toContain(result.kind);
+});
+
+// 23. dispose 后 activateSession 行为明确
+test('activateSession after dispose returns failure', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  const ctrl = createController(adapter);
+  ctrl.dispose();
+
+  const result = await ctrl.activateSession(refA);
+
+  expect(result.kind).toBe('failure');
+  expect(result.error?.code).toBe('CONTROLLER_DISPOSED');
+});
+
+// 24. Controller 可被非 React 代码使用
+test('controller works without React', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  const state = ctrl.getState();
+  expect(state.stage).toBe('idle');
+  expect(state.requestId).toBeNull();
+
+  const unsub = ctrl.subscribe(() => {});
+
+  const result = await ctrl.activateSession(refB);
+  expect(result.kind).toBe('success');
+
+  unsub();
+  ctrl.dispose();
+});
+
+// 25. secret 不进入日志
+test('secrets do not appear in logger output', async () => {
+  const logged: string[] = [];
+  const logger = {
+    debug: (_stage: string, msg: string, meta?: Record<string, unknown>) => {
+      logged.push(msg);
+      if (meta) logged.push(JSON.stringify(meta));
+    },
+    info: (_stage: string, msg: string, meta?: Record<string, unknown>) => {
+      logged.push(msg);
+      if (meta) logged.push(JSON.stringify(meta));
+    },
+    warn: (_stage: string, msg: string, meta?: Record<string, unknown>) => {
+      logged.push(msg);
+      if (meta) logged.push(JSON.stringify(meta));
+    },
+    error: (_stage: string, msg: string, meta?: Record<string, unknown>) => {
+      logged.push(msg);
+      if (meta) logged.push(JSON.stringify(meta));
+    },
+  };
+
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  const ctrl = createHostActivationController({
+    adapter,
+    getHost,
+    clearUnread,
+    timeoutMs: 5000,
+    logger,
+  });
+
+  await ctrl.activateSession(refB);
+
+  const allLogged = logged.join('\n');
+  expect(allLogged).not.toContain('http://localhost:3000');
+  expect(allLogged).not.toContain('remote:22');
+  expect(allLogged).not.toContain('token');
+  expect(allLogged).not.toContain('secret');
+  ctrl.dispose();
+});
+
+// 26. adapter 调用顺序正确
+test('adapter calls in correct order for cross-host activation', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  const ctrl = createController(adapter);
+
+  await ctrl.activateSession(refB);
+
+  // Verify the key calls happened in sequence
+  const log = adapter.callLog;
+  const isCurrentSessionIdx = log.indexOf('isCurrentSession');
+  const getCurrentSnapshotIdx = log.indexOf('getCurrentSnapshot');
+  const validateHostIdx = log.indexOf('validateHost');
+  const isCurrentHostIdx = log.indexOf('isCurrentHost');
+  const switchHostIdx = log.indexOf('switchHost');
+  const waitForRuntimeReadyIdx = log.indexOf('waitForRuntimeReady');
+  const openProjectIdx = log.indexOf('openProjectOrDirectory');
+  const verifySessionIdx = log.indexOf('verifySessionExists');
+  const selectSessionIdx = log.indexOf('selectSession');
+
+  expect(isCurrentSessionIdx).toBeLessThan(getCurrentSnapshotIdx);
+  expect(getCurrentSnapshotIdx).toBeLessThan(validateHostIdx);
+  expect(validateHostIdx).toBeLessThan(isCurrentHostIdx);
+  expect(isCurrentHostIdx).toBeLessThan(switchHostIdx);
+  expect(switchHostIdx).toBeLessThan(waitForRuntimeReadyIdx);
+  expect(waitForRuntimeReadyIdx).toBeLessThan(openProjectIdx);
+  expect(openProjectIdx).toBeLessThan(verifySessionIdx);
+  expect(verifySessionIdx).toBeLessThan(selectSessionIdx);
+  ctrl.dispose();
+});
+
+// 27. switch 成功但 verify 失败时执行 restore
+test('restore called when switch succeeds but verify fails', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, sessionExists: false });
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refB);
+
+  expect(result.kind).toBe('failure');
+  expect(adapter.callLog).toContain('restore');
+  ctrl.dispose();
+});
+
+// 28. 同 host navigation 失败时不执行完整 host restore
+test('same host navigation failure does not restore host', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  adapter.openProjectOrDirectory = async () => {
+    adapter.callLog.push('openProjectOrDirectory');
+    throw new Error('NAVIGATION_FAILED');
+  };
+
+  const ctrl = createController(adapter);
+
+  const result = await ctrl.activateSession(refA2);
+
+  expect(result.kind).toBe('failure');
+  expect(adapter.callLog).not.toContain('restore');
+  ctrl.dispose();
+});
+
+// 29. timeout 后晚到的 Promise 不修改 state
+test('late promise after timeout does not modify state', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+
+  // Same-host activation failure (no rollback needed)
+  adapter.openProjectOrDirectory = async () => {
+    adapter.callLog.push('openProjectOrDirectory');
+    throw new Error('NAVIGATION_FAILED');
+  };
+
+  const ctrl = createController(adapter, 500, 500);
+
+  const p = ctrl.activateSession(refA2);
+  const result = await p;
+
+  expect(result.kind).toBe('failure');
+
+  const stateAfter = ctrl.getState();
+  expect(stateAfter.error).toBeTruthy();
+  expect(stateAfter.error?.code).toBe('NAVIGATION_FAILED');
+  ctrl.dispose();
+});
+
+// 30. cancelCurrent 清理 timer 和 pending state
+test('cancelCurrent cleans up timers and pending state', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId, currentSession: refA });
+  adapter.selectSession = async (_ref, signal) => {
+    adapter.callLog.push('selectSession');
+    return new Promise<void>((_, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('ABORTED')), { once: true });
+    });
+  };
+
+  const ctrl = createController(adapter);
+
+  const p = ctrl.activateSession(refA2);
+  // Give a tick for the activation to start
+  await new Promise((r) => setTimeout(r, 10));
+  ctrl.cancelCurrent('user cancel');
+
+  const result = await p;
+  expect(result.kind).toBe('cancelled');
+
+  const state = ctrl.getState();
+  expect(state.stage).toBe('idle');
+  expect(state.requestId).toBeNull();
+  ctrl.dispose();
+});
+
+// 31. listener subscribe/unsubscribe 正确
+test('listener subscribe and unsubscribe work correctly', async () => {
+  const adapter = createFakeAdapter({ currentHostId: hostA.hostId });
+  const ctrl = createController(adapter);
+
+  const states: ActivationStage[] = [];
+  const unsub = ctrl.subscribe((s) => {
+    states.push(s.stage);
+  });
+
+  await ctrl.activateSession(refA2);
+
+  expect(states.length).toBeGreaterThan(0);
+
+  unsub();
+  states.length = 0;
+
+  await ctrl.activateSession(refB);
+
+  expect(states.length).toBe(0);
+  ctrl.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// activation-state unit tests
+// ---------------------------------------------------------------------------
+
+describe('activation-state', () => {
+  test('createActivationInternalState initializes correctly', () => {
+    const s = createActivationInternalState();
+    expect(s.requestCounter).toBe(0);
+    expect(s.currentRequestId).toBeNull();
+    expect(s.stage).toBe('idle');
+    expect(s.disposed).toBe(false);
+  });
+
+  test('startNewRequest increments counter and aborts previous', () => {
+    const s = createActivationInternalState();
+    const { requestId: r1 } = startNewRequest(s, refA);
+    expect(r1).toBe('1');
+
+    const { requestId: r2 } = startNewRequest(s, refB);
+    expect(r2).toBe('2');
+    expect(s.currentRequestId).toBe('2');
+  });
+
+  test('isCurrentRequest returns correct value', () => {
+    const s = createActivationInternalState();
+    startNewRequest(s, refA);
+    expect(isCurrentRequest(s, '1')).toBe(true);
+    expect(isCurrentRequest(s, '2')).toBe(false);
+
+    startNewRequest(s, refB);
+    expect(isCurrentRequest(s, '1')).toBe(false);
+    expect(isCurrentRequest(s, '2')).toBe(true);
+  });
+
+  test('toPublicState returns correct snapshot', () => {
+    const s = createActivationInternalState();
+    startNewRequest(s, refA);
+    advanceStage(s, 'validating');
+
+    const publicState = toPublicState(s);
+    expect(publicState.stage).toBe('validating');
+    expect(publicState.requestId).toBe('1');
+    expect(publicState.targetRef).toEqual(refA);
+    expect(publicState.startedAt).toBeTruthy();
+  });
+
+  test('resetToIdle clears everything', () => {
+    const s = createActivationInternalState();
+    startNewRequest(s, refA);
+    advanceStage(s, 'validating');
+    resetToIdle(s);
+
+    expect(s.currentRequestId).toBeNull();
+    expect(s.stage).toBe('idle');
+    expect(s.error).toBeNull();
+  });
+
+  test('disposeState aborts and clears listeners', () => {
+    const s = createActivationInternalState();
+    startNewRequest(s, refA);
+    s.listeners.add(() => {});
+    disposeState(s);
+
+    expect(s.disposed).toBe(true);
+    expect(s.listeners.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redactMeta tests
+// ---------------------------------------------------------------------------
+
+describe('redactMeta', () => {
+  test('redacts sensitive keys', () => {
+    const result = redactMeta({
+      token: 'secret123',
+      authorization: 'Bearer xyz',
+      hostId: 'host-a',
+      relayGrant: 'grant-data',
+      pairingSecret: 'pairing',
+      normalField: 'visible',
+    });
+
+    expect(result.token).toBe('[REDACTED]');
+    expect(result.authorization).toBe('[REDACTED]');
+    expect(result.hostId).toBe('host-a');
+    expect(result.relayGrant).toBe('[REDACTED]');
+    expect(result.pairingSecret).toBe('[REDACTED]');
+    expect(result.normalField).toBe('visible');
+  });
+
+  test('truncates long strings', () => {
+    const longStr = 'a'.repeat(200);
+    const result = redactMeta({ field: longStr });
+    expect(result.field).toContain('...[truncated]');
+  });
+});
+
+describe('safeHostLabel', () => {
+  test('returns safe label', () => {
+    expect(safeHostLabel('host-a' as HostId)).toBe('host:host-a');
+  });
+});

--- a/packages/ui/src/multi-host/activation/host-activation-controller.ts
+++ b/packages/ui/src/multi-host/activation/host-activation-controller.ts
@@ -1,0 +1,102 @@
+/**
+ * Host activation controller — the public API.
+ *
+ * Non-React code can use this directly. UI subscribes via subscribe().
+ * The controller never imports runtime-switch, relay, or session-ui.
+ */
+
+import type { HostSessionRef } from '../types';
+import type {
+  ActivationResult,
+  ActivationState,
+  HostActivationController,
+  HostActivationControllerOptions,
+  SafeActivationLogger,
+} from './types';
+import type { ActivationInternalState } from './activation-state';
+import {
+  createActivationInternalState,
+  disposeState,
+  subscribeListener,
+  toPublicState,
+  clearPendingTimers,
+  resetToIdle,
+  advanceStage,
+} from './activation-state';
+import { runActivationTransaction } from './activation-transaction';
+import { controllerDisposed } from './activation-errors';
+import { noopLogger } from './safe-activation-logger';
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export const createHostActivationController = (
+  options: HostActivationControllerOptions,
+): HostActivationController => {
+  const {
+    adapter,
+    getHost,
+    clearUnread,
+    timeoutMs = 30_000,
+    rollbackTimeoutMs = 10_000,
+    logger: injectedLogger,
+  } = options;
+
+  const logger: SafeActivationLogger = injectedLogger ?? noopLogger;
+  const state: ActivationInternalState = createActivationInternalState();
+
+  // --------------------------------------------------
+  // Public API
+  // --------------------------------------------------
+
+  const activateSession = async (ref: HostSessionRef): Promise<ActivationResult> => {
+    if (state.disposed) {
+      const err = controllerDisposed();
+      return { kind: 'failure', requestId: '', error: err };
+    }
+
+    return runActivationTransaction(
+      { state, adapter, getHost, clearUnread, timeoutMs, rollbackTimeoutMs, logger },
+      ref,
+    );
+  };
+
+  const cancelCurrent = (reason?: string): void => {
+    if (state.disposed) return;
+
+    if (state.abortController) {
+      state.abortController.abort();
+    }
+    clearPendingTimers(state);
+
+    if (state.currentRequestId) {
+      advanceStage(state, 'cancelled');
+      logger.info('cancelled', 'Activation cancelled', {
+        requestId: state.currentRequestId,
+        reason,
+      });
+    }
+
+    resetToIdle(state);
+  };
+
+  const getState = (): ActivationState => toPublicState(state);
+
+  const subscribe = (listener: (state: ActivationState) => void): (() => void) => {
+    return subscribeListener(state, listener);
+  };
+
+  const dispose = (): void => {
+    disposeState(state);
+    logger.info('idle', 'Controller disposed');
+  };
+
+  return {
+    activateSession,
+    cancelCurrent,
+    getState,
+    subscribe,
+    dispose,
+  };
+};

--- a/packages/ui/src/multi-host/activation/index.ts
+++ b/packages/ui/src/multi-host/activation/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Activation module — public API barrel.
+ *
+ * Import from '@/multi-host/activation' to consume types, factory,
+ * and adapter contract. Do not import internal modules directly.
+ */
+
+// -- Types ------------------------------------------------------------------
+export type {
+  ActivationError,
+  ActivationErrorCode,
+  ActivationResult,
+  ActivationResultKind,
+  ActivationStage,
+  ActivationState,
+  HostActivationController,
+  HostActivationControllerOptions,
+  RuntimeActivationAdapter,
+  RuntimeSnapshot,
+  SafeActivationLogger,
+} from './types';
+
+// -- Error helpers ----------------------------------------------------------
+export {
+  createActivationError,
+  redactMeta,
+  safeHostLabel,
+  hostNotFound,
+  hostOffline,
+  unsupportedTransport,
+  authenticationFailed,
+  validationFailed,
+  switchFailed,
+  runtimeReadyTimeout,
+  projectNotFound,
+  directoryNotFound,
+  sessionNotFound,
+  navigationFailed,
+  selectionFailed,
+  cancelled,
+  controllerDisposed,
+  rollbackFailed,
+  unknownError,
+} from './activation-errors';
+
+// -- Logger -----------------------------------------------------------------
+export { createSafeActivationLogger, noopLogger } from './safe-activation-logger';
+
+// -- Controller factory -----------------------------------------------------
+export { createHostActivationController } from './host-activation-controller';

--- a/packages/ui/src/multi-host/activation/safe-activation-logger.ts
+++ b/packages/ui/src/multi-host/activation/safe-activation-logger.ts
@@ -1,0 +1,57 @@
+/**
+ * Safe activation logger.
+ *
+ * Strips sensitive fields before logging. Never outputs tokens, keys,
+ * transport URLs, descriptors, or connection details.
+ */
+
+import type { ActivationStage, SafeActivationLogger } from './types';
+import { redactMeta } from './activation-errors';
+
+// ---------------------------------------------------------------------------
+// Sensitive key redaction applied to all meta objects
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a safe logger that redacts sensitive metadata.
+ *
+ * @param delegate - Optional underlying logger (console by default).
+ */
+export const createSafeActivationLogger = (
+  delegate?: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>,
+): SafeActivationLogger => {
+  const log = delegate ?? console;
+
+  const format = (stage: ActivationStage, message: string, meta?: Record<string, unknown>) => {
+    const prefix = `[activation:${stage}]`;
+    if (meta && Object.keys(meta).length > 0) {
+      return `${prefix} ${message}`;
+    }
+    return `${prefix} ${message}`;
+  };
+
+  return {
+    debug(stage, message, meta) {
+      log.debug(format(stage, message, meta), meta ? redactMeta(meta) : undefined);
+    },
+    info(stage, message, meta) {
+      log.info(format(stage, message, meta), meta ? redactMeta(meta) : undefined);
+    },
+    warn(stage, message, meta) {
+      log.warn(format(stage, message, meta), meta ? redactMeta(meta) : undefined);
+    },
+    error(stage, message, meta) {
+      log.error(format(stage, message, meta), meta ? redactMeta(meta) : undefined);
+    },
+  };
+};
+
+/**
+ * No-op logger for tests.
+ */
+export const noopLogger: SafeActivationLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};

--- a/packages/ui/src/multi-host/activation/types.ts
+++ b/packages/ui/src/multi-host/activation/types.ts
@@ -1,0 +1,159 @@
+/**
+ * Activation module public types.
+ *
+ * All activation-specific types live here. The controller never imports
+ * runtime-switch, relay, or session-ui internals directly.
+ */
+
+import type { HostDescriptor, HostId, HostSessionRef } from '../types';
+
+// ---------------------------------------------------------------------------
+// Activation stages (state machine phases)
+// ---------------------------------------------------------------------------
+
+export type ActivationStage =
+  | 'idle'
+  | 'validating'
+  | 'switching-host'
+  | 'waiting-runtime'
+  | 'opening-project'
+  | 'verifying-session'
+  | 'selecting-session'
+  | 'rolling-back'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled';
+
+// ---------------------------------------------------------------------------
+// Activation error codes
+// ---------------------------------------------------------------------------
+
+export type ActivationErrorCode =
+  | 'HOST_NOT_FOUND'
+  | 'HOST_OFFLINE'
+  | 'UNSUPPORTED_TRANSPORT'
+  | 'AUTHENTICATION_FAILED'
+  | 'VALIDATION_FAILED'
+  | 'SWITCH_FAILED'
+  | 'RUNTIME_READY_TIMEOUT'
+  | 'PROJECT_NOT_FOUND'
+  | 'DIRECTORY_NOT_FOUND'
+  | 'SESSION_NOT_FOUND'
+  | 'NAVIGATION_FAILED'
+  | 'SELECTION_FAILED'
+  | 'CANCELLED'
+  | 'CONTROLLER_DISPOSED'
+  | 'ROLLBACK_FAILED'
+  | 'UNKNOWN';
+
+// ---------------------------------------------------------------------------
+// Runtime snapshot (for rollback)
+// ---------------------------------------------------------------------------
+
+export interface RuntimeSnapshot {
+  hostId?: HostId;
+  runtimeKey?: string;
+  projectId?: string;
+  directory?: string;
+  sessionId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime activation adapter (dependency-injected bridge)
+// ---------------------------------------------------------------------------
+
+export interface RuntimeActivationAdapter {
+  getCurrentSnapshot(): RuntimeSnapshot;
+
+  isCurrentHost(hostId: HostId): boolean;
+
+  isCurrentSession(ref: HostSessionRef): boolean;
+
+  validateHost(host: HostDescriptor, signal: AbortSignal): Promise<void>;
+
+  switchHost(host: HostDescriptor, signal: AbortSignal): Promise<void>;
+
+  waitForRuntimeReady(host: HostDescriptor, signal: AbortSignal): Promise<void>;
+
+  openProjectOrDirectory(ref: HostSessionRef, signal: AbortSignal): Promise<void>;
+
+  verifySessionExists(ref: HostSessionRef, signal: AbortSignal): Promise<boolean>;
+
+  selectSession(ref: HostSessionRef, signal: AbortSignal): Promise<void>;
+
+  restore(snapshot: RuntimeSnapshot, signal: AbortSignal): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Activation state (exposed to UI subscribers)
+// ---------------------------------------------------------------------------
+
+export interface ActivationState {
+  readonly stage: ActivationStage;
+  readonly requestId: string | null;
+  readonly targetRef: HostSessionRef | null;
+  readonly startedAt: number | null;
+  readonly error: ActivationError | null;
+}
+
+// ---------------------------------------------------------------------------
+// Activation result
+// ---------------------------------------------------------------------------
+
+export type ActivationResultKind = 'success' | 'no-op' | 'failure' | 'cancelled';
+
+export interface ActivationResult {
+  readonly kind: ActivationResultKind;
+  readonly requestId: string;
+  readonly error?: ActivationError;
+  readonly rollbackError?: ActivationError;
+}
+
+// ---------------------------------------------------------------------------
+// Activation error (structured, safe for logging)
+// ---------------------------------------------------------------------------
+
+export interface ActivationError {
+  readonly code: ActivationErrorCode;
+  readonly message: string;
+  readonly stage: ActivationStage;
+  readonly hostId?: HostId;
+  readonly requestId?: string;
+  readonly cause?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Safe logger
+// ---------------------------------------------------------------------------
+
+export interface SafeActivationLogger {
+  debug(stage: ActivationStage, message: string, meta?: Record<string, unknown>): void;
+  info(stage: ActivationStage, message: string, meta?: Record<string, unknown>): void;
+  warn(stage: ActivationStage, message: string, meta?: Record<string, unknown>): void;
+  error(stage: ActivationStage, message: string, meta?: Record<string, unknown>): void;
+}
+
+// ---------------------------------------------------------------------------
+// Controller public API
+// ---------------------------------------------------------------------------
+
+export interface HostActivationController {
+  activateSession(ref: HostSessionRef): Promise<ActivationResult>;
+  cancelCurrent(reason?: string): void;
+  getState(): ActivationState;
+  subscribe(listener: (state: ActivationState) => void): () => void;
+  dispose(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Controller options
+// ---------------------------------------------------------------------------
+
+export interface HostActivationControllerOptions {
+  adapter: RuntimeActivationAdapter;
+  getHost: (hostId: HostId) => HostDescriptor | undefined;
+  clearUnread: (ref: HostSessionRef) => void;
+  timeoutMs?: number;
+  rollbackTimeoutMs?: number;
+  logger?: SafeActivationLogger;
+}


### PR DESCRIPTION
## Summary

This PR implements the standalone **MultiHostSessionTree** component — PR 3 of the 4-way parallel multi-host sidebar development.

### What this PR adds

A self-contained React component tree at `packages/ui/src/components/session/multi-host/` that renders sessions across multiple OpenChamber hosts.

**Components:**
- `MultiHostSessionTree` — root component subscribing to host ID list only
- `HostNode` — per-host header with connection indicator and fold state
- `HostProjectNode` — project grouping with fold and session sorting
- `HostSessionNode` — individual session row with status, unread, and activation
- `HostConnectionIndicator` — transport icon + connection state display
- `HostStatusBadge` — derived status badge with icon, text, and aria-label
- `MultiHostEmptyState` — empty state when no hosts are registered

### Architecture decisions

- **Subscription discipline:** Root subscribes only to host IDs. Each HostNode subscribes to its single host via `useHost(hostId)`. Project/session nodes receive data via props — zero store subscriptions.
- **Fold state:** Managed locally with stable keys (`host:<hostId>`, `project:<hostId>:<projectId>`). Not persisted to localStorage in this PR.
- **Status priority:** waiting-permission > waiting-question > error > busy > retry > unread > idle
- **Adapter pattern for external states:** `waiting-permission` and `waiting-question` are NOT in the frozen types. They're injected via `sessionExtras` prop (SessionExtraStatus adapter), keeping frozen files untouched.
- **No imports from:** runtime-switch, activation controller, monitor, or relay registry

### Frozen contract compliance

- All public imports via `@/multi-host` only
- `HostSessionRef` always passed complete on click
- Session key includes `hostId + sessionId`
- Project key includes `hostId + projectId`
- No modifications to frozen files

### Tests (71 passing)

Covering all 23 required scenarios:
- Two hosts with same sessionId (no key collision)
- Same project name on different hosts (independent fold)
- Status priority ordering
- Keyboard navigation (Enter/Space activation)
- aria-expanded on fold controls
- No sensitive data in rendered output
- No runtime-switch/activation/monitor imports
- Subscription discipline verification

### Files added (11)

```
packages/ui/src/components/session/multi-host/
├── index.ts
├── multi-host-sidebar-types.ts
├── fixtures.ts
├── HostConnectionIndicator.tsx
├── HostStatusBadge.tsx
├── HostSessionNode.tsx
├── HostProjectNode.tsx
├── HostNode.tsx
├── MultiHostEmptyState.tsx
├── MultiHostSessionTree.tsx
└── __tests__/
    └── multi-host-sidebar.test.tsx
```

### Integration path

The final integration PR will:
1. Import `MultiHostSessionTree` from `@/components/session/multi-host`
2. Wire `onActivateSession` to the activation controller
3. Pass `activeHostId`, `activeSessionId`, `activationPendingRef` from parent state
4. Provide `sessionExtras` from the sync layer's pending permission/question state

### What this PR does NOT implement

- Network monitor
- Runtime switching
- Activation state machine
- Private Relay registry
- Final SessionSidebar integration
- App bootstrap