### PR TITLE
feat(multi-host-monitor): implement background multi-host supervisor

### DIFF
--- a/packages/ui/src/multi-host/host-registry.test.ts
+++ b/packages/ui/src/multi-host/host-registry.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+
+import { generateHostId, mergeDescriptor, normalizeDescriptor } from './host-registry';
+import type { HostDescriptor, HostId } from './types';
+
+describe('host-registry', () => {
+  test('generateHostId returns unique ids', () => {
+    const a = generateHostId();
+    const b = generateHostId();
+    expect(a).not.toBe(b);
+    expect(a.startsWith('host_')).toBe(true);
+  });
+
+  test('normalizeDescriptor fills defaults', () => {
+    const desc = normalizeDescriptor({});
+    expect(desc.hostId).toBeTruthy();
+    expect(desc.label).toBeTruthy();
+    expect(desc.transport.kind).toBe('direct');
+  });
+
+  test('normalizeDescriptor preserves provided values', () => {
+    const desc = normalizeDescriptor({
+      hostId: 'h1' as HostId,
+      label: 'My Host',
+      transport: { kind: 'ssh', sshEndpoint: 'http://localhost:3000' },
+    });
+    expect(desc.hostId).toBe('h1');
+    expect(desc.label).toBe('My Host');
+    expect(desc.transport.kind).toBe('ssh');
+    if (desc.transport.kind === 'ssh') {
+      expect(desc.transport.sshEndpoint).toBe('http://localhost:3000');
+    }
+  });
+
+  test('mergeDescriptor only overwrites provided fields', () => {
+    const existing: HostDescriptor = {
+      hostId: 'h1' as HostId,
+      label: 'Original',
+      transport: { kind: 'direct', apiUrl: 'http://old', requestHeaders: { 'X-Old': '1' } },
+    };
+    const merged = mergeDescriptor(existing, { label: 'Updated' });
+    expect(merged.hostId).toBe('h1');
+    expect(merged.label).toBe('Updated');
+    expect(merged.transport.kind).toBe('direct');
+    if (merged.transport.kind === 'direct') {
+      expect(merged.transport.apiUrl).toBe('http://old');
+      expect(merged.transport.requestHeaders).toEqual({ 'X-Old': '1' });
+    }
+  });
+
+  test('mergeDescriptor deep-copies requestHeaders', () => {
+    const headers = { 'X-Test': '1' };
+    const existing: HostDescriptor = {
+      hostId: 'h1' as HostId,
+      label: 'H',
+      transport: { kind: 'direct', apiUrl: 'http://test', requestHeaders: headers },
+    };
+    const merged = mergeDescriptor(existing, { transport: { kind: 'direct', apiUrl: 'http://test', requestHeaders: { 'X-New': '2' } } });
+    if (merged.transport.kind === 'direct') {
+      expect(merged.transport.requestHeaders).toEqual({ 'X-New': '2' });
+      // Ensure mutation isolation.
+      merged.transport.requestHeaders!['X-Evil'] = '3';
+      if (existing.transport.kind === 'direct') {
+        expect(existing.transport.requestHeaders!['X-Evil']).toBe(undefined);
+      }
+    }
+  });
+});

--- a/packages/ui/src/multi-host/host-registry.ts
+++ b/packages/ui/src/multi-host/host-registry.ts
@@ -1,0 +1,112 @@
+/**
+ * Host registry: canonical hostId generation and descriptor normalization.
+ *
+ * This module is pure — no store side-effects, no network calls.
+ */
+
+import type { HostDescriptor, HostId, HostTransport, HostTransportKind } from './types';
+
+// ---------------------------------------------------------------------------
+// HostId generation
+// ---------------------------------------------------------------------------
+
+let idCounter = 0;
+
+/**
+ * Generate a fresh, unique HostId for new hosts.
+ * Format: `host_<timestamp>_<counter>` — stable within a session, easy to
+ * recognise in logs.
+ *
+ * For saved remote instances, use `hostIdFromExistingId()` to derive a stable
+ * HostId from the existing remote instance identity.
+ */
+export const generateHostId = (): HostId => {
+  const id = `host_${Date.now()}_${++idCounter}` as HostId;
+  return id;
+};
+
+/**
+ * Create a stable HostId from an existing remote instance identity.
+ * This ensures the same remote instance maps to the same HostId across
+ * app restarts.
+ *
+ * @param existingId - The stable identifier from the remote instance registry
+ * @returns A branded HostId that is stable across restarts
+ */
+export const hostIdFromExistingId = (existingId: string): HostId => {
+  // Prefix with 'host_' to maintain consistency with generateHostId format
+  // but use a hash of the existing ID for stability
+  return `host_${existingId}` as HostId;
+};
+
+// ---------------------------------------------------------------------------
+// Descriptor normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate and normalize a partial descriptor into a full HostDescriptor.
+ * Throws on missing required fields so callers fail fast.
+ */
+export const normalizeDescriptor = (
+  input: Partial<HostDescriptor> & { hostId?: HostId; label?: string; transport?: HostTransport | HostTransportKind },
+  defaults?: { transport?: HostTransportKind },
+): HostDescriptor => {
+  const hostId = input.hostId ?? generateHostId();
+  const label = input.label?.trim() || `Host ${hostId}`;
+  
+  // Handle transport normalization
+  let transport: HostTransport;
+  if (input.transport && typeof input.transport === 'object' && 'kind' in input.transport) {
+    // Already a HostTransport object
+    transport = input.transport;
+  } else {
+    // Convert HostTransportKind string to HostTransport object
+    const kind: HostTransportKind = (input.transport as HostTransportKind) ?? defaults?.transport ?? 'direct';
+    switch (kind) {
+      case 'local':
+        transport = { kind: 'local' };
+        break;
+      case 'direct':
+        transport = { kind: 'direct', apiUrl: '' };
+        break;
+      case 'ssh':
+        transport = { kind: 'ssh', sshEndpoint: '' };
+        break;
+      case 'relay':
+        transport = { kind: 'relay', relayServerId: '' };
+        break;
+      default:
+        transport = { kind: 'direct', apiUrl: '' };
+    }
+  }
+
+  return {
+    hostId,
+    label,
+    transport,
+  };
+};
+
+/**
+ * Merge an update into an existing descriptor. Only provided fields are
+ * overwritten; the hostId is never changed.
+ */
+export const mergeDescriptor = (
+  existing: HostDescriptor,
+  update: Partial<Omit<HostDescriptor, 'hostId'>>,
+): HostDescriptor => {
+  const next: HostDescriptor = { ...existing };
+
+  if (update.label !== undefined) next.label = update.label;
+  if (update.transport !== undefined) {
+    // Deep merge transport if both are objects with same kind
+    if (typeof update.transport === 'object' && typeof existing.transport === 'object' && 
+        update.transport.kind === existing.transport.kind) {
+      next.transport = { ...existing.transport, ...update.transport };
+    } else {
+      next.transport = update.transport;
+    }
+  }
+
+  return next;
+};

--- a/packages/ui/src/multi-host/index.ts
+++ b/packages/ui/src/multi-host/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Multi-host domain layer — public API.
+ *
+ * Import from '@/multi-host' (or '@openchamber/ui/multi-host') to consume
+ * types, store actions, selectors, and hooks. Do not import internal files
+ * directly; this barrel ensures a stable public surface.
+ */
+
+// -- Types ------------------------------------------------------------------
+export type {
+  HostConnectionState,
+  HostConnectionSummary,
+  HostDescriptor,
+  HostId,
+  HostProjectSummary,
+  HostSessionRef,
+  HostSessionStatus,
+  HostSessionSummary,
+  HostSnapshot,
+  HostTransport,
+  HostTransportKind,
+  ScopedSessionId,
+} from './types';
+
+// -- Host registry ----------------------------------------------------------
+export { generateHostId, hostIdFromExistingId, normalizeDescriptor, mergeDescriptor } from './host-registry';
+
+// -- Store ------------------------------------------------------------------
+export { useMultiHostStore } from './multi-host-store';
+/**
+ * HostRuntimeState is the internal state shape for a single host.
+ * Use this type for reading state only; use store actions for mutations.
+ */
+export type { HostRuntimeState, MultiHostState } from './multi-host-store';
+
+// -- Selectors & hooks ------------------------------------------------------
+export {
+  selectHost,
+  selectHosts,
+  selectHostSessions,
+  selectHostProjects,
+  selectSessionByRef,
+  selectSessionStatusByRef,
+  selectUnreadCountByHost,
+  selectTotalUnreadCount,
+  selectHostsWithActivity,
+  useHost,
+  useHosts,
+  useHostSessions,
+  useHostProjects,
+  useSessionByRef,
+  useSessionStatusByRef,
+  useUnreadCountByHost,
+  useTotalUnreadCount,
+  useHostsWithActivity,
+} from './selectors';

--- a/packages/ui/src/multi-host/monitor/__tests__/event-normalizer.test.ts
+++ b/packages/ui/src/multi-host/monitor/__tests__/event-normalizer.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeHostEvent } from '../event-normalizer';
+import type { HostId } from '../../types';
+import type { MonitorEventFrame } from '../types';
+
+const hostId = 'host_test_1' as HostId;
+
+function makeFrame(type: string, properties: Record<string, unknown> = {}): MonitorEventFrame {
+  return {
+    directory: '/test/dir',
+    payload: {
+      id: `evt_${Date.now()}`,
+      type,
+      properties,
+    },
+  };
+}
+
+describe('normalizeHostEvent', () => {
+  test('normalizes session.created with complete info', () => {
+    const frame = makeFrame('session.created', {
+      sessionID: 'sess_1',
+      info: {
+        id: 'sess_1',
+        title: 'Test Session',
+        directory: '/test/dir',
+        projectID: 'proj_1',
+        time: { created: 1000, updated: 2000 },
+      },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'session-upsert',
+      hostId,
+      session: {
+        id: 'sess_1',
+        title: 'Test Session',
+        directory: '/test/dir',
+        projectId: 'proj_1',
+        createdAt: 1000,
+        updatedAt: 2000,
+      },
+    });
+  });
+
+  test('normalizes session.updated with complete info', () => {
+    const frame = makeFrame('session.updated', {
+      sessionID: 'sess_1',
+      info: {
+        id: 'sess_1',
+        title: 'Updated',
+        directory: '/dir',
+        projectID: 'proj_1',
+        time: { created: 1000, updated: 3000 },
+      },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('session-upsert');
+  });
+
+  test('returns host-refresh-required for session.created with missing info', () => {
+    const frame = makeFrame('session.created', {
+      sessionID: 'sess_1',
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: 'host-refresh-required', hostId });
+  });
+
+  test('returns host-refresh-required for session.created with no id in info', () => {
+    const frame = makeFrame('session.created', {
+      info: {
+        title: 'No ID',
+      },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: 'host-refresh-required', hostId });
+  });
+
+  test('normalizes session.deleted', () => {
+    const frame = makeFrame('session.deleted', {
+      sessionID: 'sess_1',
+      info: { id: 'sess_1' },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'session-remove',
+      hostId,
+      sessionId: 'sess_1',
+    });
+  });
+
+  test('normalizes session.status with busy', () => {
+    const frame = makeFrame('session.status', {
+      sessionID: 'sess_1',
+      status: { type: 'busy' },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'session-status',
+      hostId,
+      sessionId: 'sess_1',
+      status: 'busy',
+    });
+  });
+
+  test('normalizes session.status with retry', () => {
+    const frame = makeFrame('session.status', {
+      sessionID: 'sess_1',
+      status: { type: 'retry', attempt: 1, message: 'fail', next: 5000 },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'session-status',
+      hostId,
+      sessionId: 'sess_1',
+      status: 'retry',
+    });
+  });
+
+  test('normalizes session.status with idle', () => {
+    const frame = makeFrame('session.status', {
+      sessionID: 'sess_1',
+      status: { type: 'idle' },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'session-status',
+      hostId,
+      sessionId: 'sess_1',
+      status: 'idle',
+    });
+  });
+
+  test('normalizes session.idle', () => {
+    const frame = makeFrame('session.idle', {
+      sessionID: 'sess_1',
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'session-status',
+      hostId,
+      sessionId: 'sess_1',
+      status: 'idle',
+    });
+  });
+
+  test('normalizes session.error to idle', () => {
+    const frame = makeFrame('session.error', {
+      sessionID: 'sess_1',
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'session-status',
+      hostId,
+      sessionId: 'sess_1',
+      status: 'idle',
+    });
+  });
+
+  test('returns empty for high-frequency irrelevant events', () => {
+    const irrelevantTypes = [
+      'message.part.delta',
+      'message.part.updated',
+      'message.part.removed',
+      'message.updated',
+      'session.diff',
+      'lsp.updated',
+      'vcs.branch.updated',
+      'session.next.step.started',
+      'session.next.tool.called',
+      'session.next.text.delta',
+    ];
+
+    for (const type of irrelevantTypes) {
+      const frame = makeFrame(type, { sessionID: 'sess_1' });
+      const events = normalizeHostEvent(hostId, frame);
+      expect(events).toEqual([]);
+    }
+  });
+
+  test('strips trailing .N suffix from event types', () => {
+    const frame = makeFrame('session.status.1', {
+      sessionID: 'sess_1',
+      status: { type: 'busy' },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('session-status');
+  });
+
+  test('normalizes permission.asked without creating session', () => {
+    const frame = makeFrame('permission.asked', {
+      sessionID: 'sess_1',
+      id: 'perm_1',
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toEqual([]);
+  });
+
+  test('normalizes question.asked without creating session', () => {
+    const frame = makeFrame('question.asked', {
+      sessionID: 'sess_1',
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toEqual([]);
+  });
+
+  test('returns host-refresh-required for session.deleted with no sessionID', () => {
+    const frame = makeFrame('session.deleted', {});
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: 'host-refresh-required', hostId });
+  });
+
+  test('returns host-refresh-required for session.status with no sessionID', () => {
+    const frame = makeFrame('session.status', {
+      status: { type: 'busy' },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: 'host-refresh-required', hostId });
+  });
+
+  test('handles session.created with missing optional fields gracefully', () => {
+    const frame = makeFrame('session.created', {
+      info: {
+        id: 'sess_1',
+      },
+    });
+
+    const events = normalizeHostEvent(hostId, frame);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'session-upsert',
+      hostId,
+      session: {
+        id: 'sess_1',
+        title: undefined,
+        directory: undefined,
+        projectId: undefined,
+        createdAt: undefined,
+        updatedAt: undefined,
+      },
+    });
+  });
+});

--- a/packages/ui/src/multi-host/monitor/__tests__/host-monitor.test.ts
+++ b/packages/ui/src/multi-host/monitor/__tests__/host-monitor.test.ts
@@ -1,0 +1,567 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { HostMonitor } from '../host-monitor';
+import { useMultiHostStore } from '../../multi-host-store';
+import type { HostDescriptor, HostId } from '../../types';
+import type { HostMonitorTransport, MonitorEventFrame, MonitorScheduler, ReconnectPolicy } from '../types';
+
+// ---------------------------------------------------------------------------
+// Fake implementations
+// ---------------------------------------------------------------------------
+
+function makeFakeScheduler(): MonitorScheduler & { tick(): void; pending: Map<number, { fn: () => void; id: number }> } {
+  let idCounter = 0;
+  const pending = new Map<number, { fn: () => void; id: number }>();
+  return {
+    pending,
+    setTimeout: (fn) => {
+      const id = ++idCounter;
+      pending.set(id, { fn, id });
+      return { cancel: () => pending.delete(id) };
+    },
+    setInterval: (fn) => {
+      const id = ++idCounter;
+      pending.set(id, { fn, id });
+      return { cancel: () => pending.delete(id) };
+    },
+    now: () => Date.now(),
+    tick() {
+      for (const [, entry] of [...pending]) {
+        entry.fn();
+        pending.delete(entry.id);
+      }
+    },
+  };
+}
+
+function makeFakeReconnectPolicy(): ReconnectPolicy {
+  return {
+    nextDelay: () => ({ delayMs: 0, reason: 'fake' }),
+    reset: () => {},
+  };
+}
+
+function makeFakeTransport(options?: {
+  eventFrames?: MonitorEventFrame[];
+  fetchResponses?: Record<string, { status: number; data: unknown }>;
+}): HostMonitorTransport {
+  const frames = options?.eventFrames ?? [];
+  const fetchResponses = options?.fetchResponses ?? {};
+
+  return {
+    request: async (req) => {
+      const resp = fetchResponses[req.path];
+      if (!resp) return { status: 404, data: null };
+      return resp;
+    },
+    openEventStream: async ({ signal }) => {
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const frame of frames) {
+            if (signal.aborted) break;
+            yield frame;
+          }
+          await new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+        },
+      };
+    },
+    close: () => {},
+  };
+}
+
+function makeDescriptor(hostId: HostId): HostDescriptor {
+  return {
+    hostId,
+    label: `Host ${hostId}`,
+    transport: { kind: 'direct', apiUrl: `http://${hostId}.test:4096` },
+  };
+}
+
+function makeSessionFrame(sessionId: string, title: string): MonitorEventFrame {
+  return {
+    directory: '/test',
+    payload: {
+      id: `evt_${sessionId}`,
+      type: 'session.created',
+      properties: {
+        sessionID: sessionId,
+        info: {
+          id: sessionId,
+          title,
+          directory: '/test',
+          projectID: 'proj_1',
+          time: { created: 1000, updated: 2000 },
+        },
+      },
+    },
+  };
+}
+
+function makeStatusFrame(sessionId: string, status: string): MonitorEventFrame {
+  return {
+    directory: '/test',
+    payload: {
+      id: `evt_status_${sessionId}`,
+      type: 'session.status',
+      properties: {
+        sessionID: sessionId,
+        status: { type: status },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HostMonitor', () => {
+  const hostId = 'host_test' as HostId;
+
+  beforeEach(() => {
+    useMultiHostStore.setState({ hosts: {} });
+  });
+
+  afterEach(() => {
+    useMultiHostStore.setState({ hosts: {} });
+  });
+
+  test('start() sets connection to connecting then connected', async () => {
+    const scheduler = makeFakeScheduler();
+    const transport = makeFakeTransport({
+      eventFrames: [],
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': { status: 200, data: [] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitor = new HostMonitor({
+      hostId,
+      descriptor: makeDescriptor(hostId),
+      transport,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostId));
+    monitor.start();
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state?.connection.state).toBe('connected');
+
+    monitor.dispose();
+  });
+
+  test('two hosts can run simultaneously without interfering', async () => {
+    const scheduler = makeFakeScheduler();
+    const hostA = 'host_a' as HostId;
+    const hostB = 'host_b' as HostId;
+
+    const transportA = makeFakeTransport({
+      eventFrames: [makeSessionFrame('sess_a1', 'Session A1')],
+      fetchResponses: {
+        '/project/list': { status: 200, data: [{ id: 'proj_a', name: 'Project A', worktree: '/a' }] },
+        '/session': { status: 200, data: [{ id: 'sess_a1', title: 'Session A1', directory: '/a', projectID: 'proj_a', time: { created: 1, updated: 2 } }] },
+        '/session/status': { status: 200, data: { sess_a1: { type: 'busy' } } },
+      },
+    });
+
+    const transportB = makeFakeTransport({
+      eventFrames: [makeSessionFrame('sess_b1', 'Session B1')],
+      fetchResponses: {
+        '/project/list': { status: 200, data: [{ id: 'proj_b', name: 'Project B', worktree: '/b' }] },
+        '/session': { status: 200, data: [{ id: 'sess_b1', title: 'Session B1', directory: '/b', projectID: 'proj_b', time: { created: 3, updated: 4 } }] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitorA = new HostMonitor({
+      hostId: hostA,
+      descriptor: makeDescriptor(hostA),
+      transport: transportA,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const monitorB = new HostMonitor({
+      hostId: hostB,
+      descriptor: makeDescriptor(hostB),
+      transport: transportB,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostA));
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostB));
+
+    monitorA.start();
+    monitorB.start();
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const stateA = useMultiHostStore.getState().hosts[hostA];
+    const stateB = useMultiHostStore.getState().hosts[hostB];
+
+    expect(stateA?.connection.state).toBe('connected');
+    expect(stateB?.connection.state).toBe('connected');
+
+    expect(stateA?.projects[0]?.id).toBe('proj_a');
+    expect(stateB?.projects[0]?.id).toBe('proj_b');
+    expect(stateA?.sessions['sess_a1']).toBeDefined();
+    expect(stateB?.sessions['sess_b1']).toBeDefined();
+    expect(stateA?.sessions['sess_b1']).toBeFalsy();
+    expect(stateB?.sessions['sess_a1']).toBeFalsy();
+
+    monitorA.dispose();
+    monitorB.dispose();
+  });
+
+  test('same sessionId on different hosts does not leak data', async () => {
+    const scheduler = makeFakeScheduler();
+    const hostA = 'host_a' as HostId;
+    const hostB = 'host_b' as HostId;
+    const sharedSessionId = 'shared_sess';
+
+    const transportA = makeFakeTransport({
+      eventFrames: [makeSessionFrame(sharedSessionId, 'A Session')],
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': { status: 200, data: [{ id: sharedSessionId, title: 'A Session', directory: '/a', projectID: 'p', time: { created: 1, updated: 2 } }] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const transportB = makeFakeTransport({
+      eventFrames: [makeSessionFrame(sharedSessionId, 'B Session')],
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': { status: 200, data: [{ id: sharedSessionId, title: 'B Session', directory: '/b', projectID: 'p', time: { created: 3, updated: 4 } }] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitorA = new HostMonitor({
+      hostId: hostA,
+      descriptor: makeDescriptor(hostA),
+      transport: transportA,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const monitorB = new HostMonitor({
+      hostId: hostB,
+      descriptor: makeDescriptor(hostB),
+      transport: transportB,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostA));
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostB));
+
+    monitorA.start();
+    monitorB.start();
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const stateA = useMultiHostStore.getState().hosts[hostA];
+    const stateB = useMultiHostStore.getState().hosts[hostB];
+
+    expect(stateA?.sessions[sharedSessionId]?.title).toBe('A Session');
+    expect(stateB?.sessions[sharedSessionId]?.title).toBe('B Session');
+
+    monitorA.dispose();
+    monitorB.dispose();
+  });
+
+  test('host A failure does not affect host B', async () => {
+    const scheduler = makeFakeScheduler();
+    const hostA = 'host_a' as HostId;
+    const hostB = 'host_b' as HostId;
+
+    const failingTransport: HostMonitorTransport = {
+      request: async () => { throw new Error('network error'); },
+      openEventStream: async () => {
+        throw new Error('connection failed');
+      },
+      close: () => {},
+    };
+
+    const transportB = makeFakeTransport({
+      eventFrames: [makeSessionFrame('sess_b1', 'B Session')],
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': { status: 200, data: [] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitorA = new HostMonitor({
+      hostId: hostA,
+      descriptor: makeDescriptor(hostA),
+      transport: failingTransport,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const monitorB = new HostMonitor({
+      hostId: hostB,
+      descriptor: makeDescriptor(hostB),
+      transport: transportB,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostA));
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostB));
+
+    monitorA.start();
+    monitorB.start();
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const stateA = useMultiHostStore.getState().hosts[hostA];
+    const stateB = useMultiHostStore.getState().hosts[hostB];
+
+    expect(stateA?.connection.state).toBe('error');
+    expect(stateB?.connection.state).toBe('connected');
+
+    monitorA.dispose();
+    monitorB.dispose();
+  });
+
+  test('start() is idempotent', async () => {
+    const scheduler = makeFakeScheduler();
+    const transport = makeFakeTransport({
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': { status: 200, data: [] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitor = new HostMonitor({
+      hostId,
+      descriptor: makeDescriptor(hostId),
+      transport,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostId));
+
+    monitor.start();
+    monitor.start();
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state?.connection.state).toBe('connected');
+
+    monitor.dispose();
+  });
+
+  test('stop() cleans up event connection and timers', async () => {
+    const scheduler = makeFakeScheduler();
+    const transport = makeFakeTransport({
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': { status: 200, data: [] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitor = new HostMonitor({
+      hostId,
+      descriptor: makeDescriptor(hostId),
+      transport,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostId));
+    monitor.start();
+    await new Promise((r) => setTimeout(r, 10));
+
+    monitor.stop();
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state?.connection.state).toBe('disconnected');
+
+    monitor.dispose();
+  });
+
+  test('descriptor change restarts connection', async () => {
+    const scheduler = makeFakeScheduler();
+    const transport = makeFakeTransport({
+      fetchResponses: {
+        '/project/list': { status: 200, data: [{ id: 'proj_1', name: 'V1' }] },
+        '/session': { status: 200, data: [] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitor = new HostMonitor({
+      hostId,
+      descriptor: makeDescriptor(hostId),
+      transport,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostId));
+    monitor.start();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const newDescriptor = makeDescriptor(hostId);
+    newDescriptor.transport = { kind: 'ssh', sshEndpoint: 'localhost:2222' };
+    monitor.updateDescriptor(newDescriptor);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state).toBeDefined();
+
+    monitor.dispose();
+  });
+
+  test('dispose() prevents further store writes', async () => {
+    const scheduler = makeFakeScheduler();
+    const transport = makeFakeTransport({
+      eventFrames: [makeSessionFrame('sess_1', 'Session')],
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': { status: 200, data: [] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitor = new HostMonitor({
+      hostId,
+      descriptor: makeDescriptor(hostId),
+      transport,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostId));
+    monitor.start();
+    await new Promise((r) => setTimeout(r, 10));
+
+    monitor.dispose();
+
+    const stateBefore = useMultiHostStore.getState().hosts[hostId];
+    monitor.refresh();
+    await new Promise((r) => setTimeout(r, 10));
+    const stateAfter = useMultiHostStore.getState().hosts[hostId];
+
+    expect(stateAfter).toEqual(stateBefore);
+  });
+
+  test('events update store correctly', async () => {
+    const scheduler = makeFakeScheduler();
+    const eventFrames: MonitorEventFrame[] = [
+      makeSessionFrame('sess_1', 'First Session'),
+      makeStatusFrame('sess_1', 'busy'),
+    ];
+
+    const transport = makeFakeTransport({
+      eventFrames,
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': {
+          status: 200,
+          data: [
+            { id: 'sess_1', title: 'First Session', directory: '/test', projectID: 'proj_1', time: { created: 1000, updated: 2000 } },
+          ],
+        },
+        '/session/status': {
+          status: 200,
+          data: { sess_1: { type: 'busy' } },
+        },
+      },
+    });
+
+    const monitor = new HostMonitor({
+      hostId,
+      descriptor: makeDescriptor(hostId),
+      transport,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostId));
+    monitor.start();
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state?.sessions['sess_1']?.title).toBe('First Session');
+    expect(state?.statuses['sess_1']?.status).toBe('busy');
+
+    monitor.dispose();
+  });
+
+  test('session delete event removes session from store', async () => {
+    const scheduler = makeFakeScheduler();
+    const eventFrames: MonitorEventFrame[] = [
+      makeSessionFrame('sess_1', 'To Delete'),
+      {
+        directory: '/test',
+        payload: {
+          id: 'evt_del',
+          type: 'session.deleted',
+          properties: {
+            sessionID: 'sess_1',
+            info: { id: 'sess_1' },
+          },
+        },
+      },
+    ];
+
+    const transport = makeFakeTransport({
+      eventFrames,
+      fetchResponses: {
+        '/project/list': { status: 200, data: [] },
+        '/session': { status: 200, data: [] },
+        '/session/status': { status: 200, data: {} },
+      },
+    });
+
+    const monitor = new HostMonitor({
+      hostId,
+      descriptor: makeDescriptor(hostId),
+      transport,
+      scheduler,
+      reconnectPolicy: makeFakeReconnectPolicy(),
+      reconciliationIntervalMs: 60_000,
+    });
+
+    useMultiHostStore.getState().registerHost(makeDescriptor(hostId));
+    monitor.start();
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state?.sessions['sess_1']).toBeFalsy();
+    expect(state?.statuses['sess_1']).toBeFalsy();
+
+    monitor.dispose();
+  });
+});

--- a/packages/ui/src/multi-host/monitor/__tests__/multi-host-supervisor.test.ts
+++ b/packages/ui/src/multi-host/monitor/__tests__/multi-host-supervisor.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { createMultiHostSupervisor } from '../multi-host-supervisor';
+import { useMultiHostStore } from '../../multi-host-store';
+import type { HostDescriptor, HostId } from '../../types';
+import type { HostMonitorTransport, MonitorScheduler, ReconnectPolicy, TransportFactory } from '../types';
+
+// ---------------------------------------------------------------------------
+// Fake implementations
+// ---------------------------------------------------------------------------
+
+function makeFakeScheduler(): MonitorScheduler & { tick(): void } {
+  let idCounter = 0;
+  const pending = new Map<number, { fn: () => void; id: number }>();
+  const scheduler: MonitorScheduler & { tick(): void; pending: Map<number, { fn: () => void; id: number }> } = {
+    pending,
+    setTimeout: (fn) => {
+      const id = ++idCounter;
+      pending.set(id, { fn, id });
+      return { cancel: () => pending.delete(id) };
+    },
+    setInterval: (fn) => {
+      const id = ++idCounter;
+      pending.set(id, { fn, id });
+      return { cancel: () => pending.delete(id) };
+    },
+    now: () => Date.now(),
+    tick() {
+      for (const [, entry] of [...pending]) {
+        entry.fn();
+        pending.delete(entry.id);
+      }
+    },
+  };
+  return scheduler;
+}
+
+function makeFakeReconnectPolicy(): ReconnectPolicy {
+  return { nextDelay: () => ({ delayMs: 0, reason: 'fake' }), reset: () => {} };
+}
+
+function makeFakeTransportFactory(): TransportFactory & { transports: Map<HostId, HostMonitorTransport> } {
+  const transports = new Map<HostId, HostMonitorTransport>();
+  const factory: TransportFactory & { transports: Map<HostId, HostMonitorTransport> } = (descriptor) => {
+    const transport: HostMonitorTransport = {
+      request: async (req) => {
+        if (req.path === '/project/list') return { status: 200, data: [] };
+        if (req.path === '/session') return { status: 200, data: [] };
+        if (req.path === '/session/status') return { status: 200, data: {} };
+        return { status: 404, data: null };
+      },
+      openEventStream: async ({ signal }) => {
+        const abortPromise = new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return {
+          async *[Symbol.asyncIterator](): AsyncGenerator<import('../types').MonitorEventFrame> {
+            yield { directory: '', payload: { type: '__noop', properties: {} } };
+            await abortPromise;
+          },
+        };
+      },
+      close: () => {},
+    };
+    transports.set(descriptor.hostId, transport);
+    return transport;
+  };
+  factory.transports = transports;
+  return factory;
+}
+
+function makeDescriptor(hostId: HostId): HostDescriptor {
+  return {
+    hostId,
+    label: `Host ${hostId}`,
+    transport: { kind: 'direct', apiUrl: `http://${hostId}.test:4096` },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createMultiHostSupervisor', () => {
+  beforeEach(() => {
+    useMultiHostStore.setState({ hosts: {} });
+  });
+
+  afterEach(() => {
+    useMultiHostStore.setState({ hosts: {} });
+  });
+
+  test('startHost registers host in store and starts monitoring', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const hostId = 'host_1' as HostId;
+    supervisor.startHost(hostId, makeDescriptor(hostId));
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(supervisor.hasHost(hostId)).toBe(true);
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state).toBeDefined();
+    expect(state?.connection.state).toBe('connected');
+
+    supervisor.dispose();
+  });
+
+  test('two hosts can run simultaneously', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const hostA = 'host_a' as HostId;
+    const hostB = 'host_b' as HostId;
+
+    supervisor.startHost(hostA, makeDescriptor(hostA));
+    supervisor.startHost(hostB, makeDescriptor(hostB));
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(supervisor.hasHost(hostA)).toBe(true);
+    expect(supervisor.hasHost(hostB)).toBe(true);
+
+    const stateA = useMultiHostStore.getState().hosts[hostA];
+    const stateB = useMultiHostStore.getState().hosts[hostB];
+    expect(stateA?.connection.state).toBe('connected');
+    expect(stateB?.connection.state).toBe('connected');
+
+    supervisor.dispose();
+  });
+
+  test('stopHost cleans up the host', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const hostId = 'host_1' as HostId;
+    supervisor.startHost(hostId, makeDescriptor(hostId));
+    await new Promise((r) => setTimeout(r, 10));
+
+    supervisor.stopHost(hostId);
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state?.connection.state).toBe('disconnected');
+
+    supervisor.dispose();
+  });
+
+  test('stopAll cleans up all hosts', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const hostA = 'host_a' as HostId;
+    const hostB = 'host_b' as HostId;
+
+    supervisor.startHost(hostA, makeDescriptor(hostA));
+    supervisor.startHost(hostB, makeDescriptor(hostB));
+    await new Promise((r) => setTimeout(r, 10));
+
+    supervisor.stopAll();
+
+    expect(supervisor.hasHost(hostA)).toBe(false);
+    expect(supervisor.hasHost(hostB)).toBe(false);
+
+    supervisor.dispose();
+  });
+
+  test('startHost is idempotent', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const hostId = 'host_1' as HostId;
+    supervisor.startHost(hostId, makeDescriptor(hostId));
+    supervisor.startHost(hostId, makeDescriptor(hostId));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(transportFactory.transports.size).toBe(1);
+
+    supervisor.dispose();
+  });
+
+  test('dispose prevents further operations', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconciliationIntervalMs: 60_000,
+    });
+
+    supervisor.dispose();
+
+    const hostId = 'host_1' as HostId;
+    supervisor.startHost(hostId, makeDescriptor(hostId));
+
+    expect(supervisor.hasHost(hostId)).toBe(false);
+  });
+
+  test('descriptor change restarts connection', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const hostId = 'host_1' as HostId;
+    supervisor.startHost(hostId, makeDescriptor(hostId));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const desc2 = makeDescriptor(hostId);
+    desc2.transport = { kind: 'ssh', sshEndpoint: 'localhost:2222' };
+    supervisor.restartHost(hostId, desc2);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state).toBeDefined();
+
+    supervisor.dispose();
+  });
+
+  test('descriptor without transport change does not restart connection', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const hostId = 'host_1' as HostId;
+    supervisor.startHost(hostId, makeDescriptor(hostId));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const desc2 = makeDescriptor(hostId);
+    desc2.label = 'Updated Label';
+    supervisor.restartHost(hostId, desc2);
+
+    expect(transportFactory.transports.size).toBe(1);
+
+    supervisor.dispose();
+  });
+
+  test('reconnect policy is per-host', async () => {
+    const scheduler = makeFakeScheduler();
+    const transportFactory = makeFakeTransportFactory();
+    const policiesCreated: string[] = [];
+
+    const supervisor = createMultiHostSupervisor({
+      scheduler,
+      transportFactory,
+      reconnectPolicyFactory: () => {
+        policiesCreated.push('policy');
+        return makeFakeReconnectPolicy();
+      },
+      reconciliationIntervalMs: 60_000,
+    });
+
+    const hostA = 'host_a' as HostId;
+    const hostB = 'host_b' as HostId;
+
+    supervisor.startHost(hostA, makeDescriptor(hostA));
+    supervisor.startHost(hostB, makeDescriptor(hostB));
+
+    expect(policiesCreated.length).toBe(2);
+
+    supervisor.dispose();
+  });
+});

--- a/packages/ui/src/multi-host/monitor/__tests__/reconciliation.test.ts
+++ b/packages/ui/src/multi-host/monitor/__tests__/reconciliation.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import { reconcileHost } from '../reconciliation';
+import type { HostDescriptor, HostId } from '../../types';
+import type { HostMonitorTransport } from '../types';
+
+function makeDescriptor(hostId: HostId, apiUrl = 'http://localhost:4096'): HostDescriptor {
+  return {
+    hostId,
+    label: `Test ${hostId}`,
+    transport: { kind: 'direct', apiUrl },
+  };
+}
+
+function makeTransport(responses: Record<string, { status: number; data: unknown }>): HostMonitorTransport {
+  return {
+    request: async (req) => {
+      const resp = responses[req.path];
+      if (!resp) return { status: 404, data: null };
+      return resp;
+    },
+    openEventStream: async () => ({
+      async *[Symbol.asyncIterator]() {},
+    }),
+    close: () => {},
+  };
+}
+
+describe('reconcileHost', () => {
+  const hostId = 'host_test' as HostId;
+
+  test('returns a complete snapshot on successful fetch', async () => {
+    const transport = makeTransport({
+      '/project/list': {
+        status: 200,
+        data: [{ id: 'proj_1', name: 'My Project', worktree: '/work/dir' }],
+      },
+      '/session': {
+        status: 200,
+        data: [
+          { id: 'sess_1', title: 'Session 1', directory: '/work/dir', projectID: 'proj_1', time: { created: 1000, updated: 2000 } },
+          { id: 'sess_2', title: 'Session 2', directory: '/work/dir', projectID: 'proj_1', time: { created: 1500, updated: 2500 } },
+        ],
+      },
+      '/session/status': {
+        status: 200,
+        data: { sess_1: { type: 'busy' } },
+      },
+    });
+
+    const descriptor = makeDescriptor(hostId);
+    const result = await reconcileHost(hostId, descriptor, transport);
+
+    expect(result.ok).toBe(true);
+    expect(result.snapshot.projects).toHaveLength(1);
+    expect(result.snapshot.projects[0]!.id).toBe('proj_1');
+    expect(result.snapshot.projects[0]!.directory).toBe('/work/dir');
+    expect(Object.keys(result.snapshot.sessions)).toHaveLength(2);
+    expect(result.snapshot.sessions['sess_1']!.title).toBe('Session 1');
+    expect(result.snapshot.sessions['sess_2']!.title).toBe('Session 2');
+    expect(result.snapshot.statuses['sess_1']!.status).toBe('busy');
+    expect(result.snapshot.statuses['sess_2']).toBeFalsy();
+    expect(result.snapshot.connection.state).toBe('connected');
+  });
+
+  test('returns ok:false on fetch failure', async () => {
+    const transport = makeTransport({
+      '/project/list': { status: 500, data: null },
+      '/session': { status: 500, data: null },
+      '/session/status': { status: 500, data: null },
+    });
+
+    const descriptor = makeDescriptor(hostId);
+    const result = await reconcileHost(hostId, descriptor, transport);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.snapshot.connection.state).toBe('error');
+  });
+
+  test('handles empty session list gracefully', async () => {
+    const transport = makeTransport({
+      '/project/list': { status: 200, data: [] },
+      '/session': { status: 200, data: [] },
+      '/session/status': { status: 200, data: {} },
+    });
+
+    const descriptor = makeDescriptor(hostId);
+    const result = await reconcileHost(hostId, descriptor, transport);
+
+    expect(result.ok).toBe(true);
+    expect(Object.keys(result.snapshot.sessions)).toHaveLength(0);
+  });
+
+  test('omits idle sessions from status map', async () => {
+    const transport = makeTransport({
+      '/project/list': { status: 200, data: [] },
+      '/session': {
+        status: 200,
+        data: [
+          { id: 'sess_1', title: 'Idle Session', directory: '/d', projectID: 'p', time: { created: 1, updated: 2 } },
+        ],
+      },
+      '/session/status': { status: 200, data: {} },
+    });
+
+    const descriptor = makeDescriptor(hostId);
+    const result = await reconcileHost(hostId, descriptor, transport);
+
+    expect(result.ok).toBe(true);
+    expect(result.snapshot.statuses['sess_1']).toBeFalsy();
+  });
+
+  test('preserves connection.connectedAt from existing snapshot', async () => {
+    const transport = makeTransport({
+      '/project/list': { status: 200, data: [] },
+      '/session': { status: 200, data: [] },
+      '/session/status': { status: 200, data: {} },
+    });
+
+    const descriptor = makeDescriptor(hostId);
+    const existing = {
+      descriptor,
+      connection: { state: 'connected' as const, connectedAt: '2025-01-01T00:00:00.000Z' },
+      projects: [],
+      sessions: {},
+      statuses: {},
+      unreadBySession: {},
+    };
+
+    const result = await reconcileHost(hostId, descriptor, transport, existing);
+
+    expect(result.ok).toBe(true);
+    expect(result.snapshot.connection.connectedAt).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  test('filters out projects without valid id', async () => {
+    const transport = makeTransport({
+      '/project/list': {
+        status: 200,
+        data: [
+          { id: 'proj_1', name: 'Valid' },
+          { id: '', name: 'No ID' },
+          { name: 'Missing ID' },
+        ],
+      },
+      '/session': { status: 200, data: [] },
+      '/session/status': { status: 200, data: {} },
+    });
+
+    const descriptor = makeDescriptor(hostId);
+    const result = await reconcileHost(hostId, descriptor, transport);
+
+    expect(result.ok).toBe(true);
+    expect(result.snapshot.projects).toHaveLength(1);
+    expect(result.snapshot.projects[0]!.id).toBe('proj_1');
+  });
+});

--- a/packages/ui/src/multi-host/monitor/__tests__/reconnect-policy.test.ts
+++ b/packages/ui/src/multi-host/monitor/__tests__/reconnect-policy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { createReconnectPolicy } from '../reconnect-policy';
+
+describe('createReconnectPolicy', () => {
+  let policy: ReturnType<typeof createReconnectPolicy>;
+
+  beforeEach(() => {
+    policy = createReconnectPolicy();
+  });
+
+  test('returns a delay on first attempt', () => {
+    const { delayMs, reason } = policy.nextDelay(1, false);
+    expect(delayMs).toBeGreaterThanOrEqual(250);
+    expect(reason).toBe('attempt_1');
+  });
+
+  test('increases delay with more attempts (exponential backoff)', () => {
+    const delays: number[] = [];
+    for (let i = 1; i <= 5; i++) {
+      const { delayMs } = policy.nextDelay(i, false);
+      delays.push(delayMs);
+    }
+    expect(delays[4]).toBeGreaterThanOrEqual(delays[0]);
+  });
+
+  test('caps delay at reasonable bound', () => {
+    for (let i = 1; i <= 10; i++) {
+      const { delayMs } = policy.nextDelay(i, false);
+      expect(delayMs).toBeLessThan(65000);
+    }
+  });
+
+  test('returns long cap for permanent errors', () => {
+    const { delayMs, reason } = policy.nextDelay(1, true);
+    expect(delayMs).toBeGreaterThanOrEqual(60000);
+    expect(reason).toBe('permanent_error');
+  });
+
+  test('reset() resets backoff', () => {
+    policy.nextDelay(5, false);
+    policy.reset();
+    const { delayMs } = policy.nextDelay(1, false);
+    expect(delayMs).toBeLessThan(6000);
+  });
+
+  test('host A backoff does not affect host B', () => {
+    const policyA = createReconnectPolicy();
+    const policyB = createReconnectPolicy();
+
+    for (let i = 1; i <= 5; i++) policyA.nextDelay(i, false);
+
+    const { delayMs } = policyB.nextDelay(1, false);
+    expect(delayMs).toBeLessThan(6000);
+  });
+});

--- a/packages/ui/src/multi-host/monitor/__tests__/unread-preservation.test.ts
+++ b/packages/ui/src/multi-host/monitor/__tests__/unread-preservation.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { useMultiHostStore } from '../../multi-host-store';
+import { reconcileHost } from '../reconciliation';
+import type { HostDescriptor, HostId, HostSnapshot } from '../../types';
+import type { HostMonitorTransport } from '../types';
+
+function makeDescriptor(hostId: HostId): HostDescriptor {
+  return {
+    hostId,
+    label: `Host ${hostId}`,
+    transport: { kind: 'direct', apiUrl: 'http://localhost:4096' },
+  };
+}
+
+function makeTransport(responses: Record<string, { status: number; data: unknown }>): HostMonitorTransport {
+  return {
+    request: async (req) => {
+      const resp = responses[req.path];
+      if (!resp) return { status: 404, data: null };
+      return resp;
+    },
+    openEventStream: async () => ({
+      async *[Symbol.asyncIterator]() {},
+    }),
+    close: () => {},
+  };
+}
+
+describe('replaceHostSnapshot unread preservation', () => {
+  const hostId = 'host_test' as HostId;
+
+  beforeEach(() => {
+    useMultiHostStore.setState({ hosts: {} });
+  });
+
+  afterEach(() => {
+    useMultiHostStore.setState({ hosts: {} });
+  });
+
+  test('replaceHostSnapshot preserves local unread for existing sessions', () => {
+    const store = useMultiHostStore.getState();
+
+    // Register host and add some sessions with unread
+    store.registerHost(makeDescriptor(hostId));
+    store.upsertSession(hostId, { id: 'sess_1', title: 'S1', directory: '/d', projectId: 'p' });
+    store.upsertSession(hostId, { id: 'sess_2', title: 'S2', directory: '/d', projectId: 'p' });
+    store.markSessionUnread(hostId, 'sess_1', 3);
+    store.markSessionUnread(hostId, 'sess_2', 1);
+
+    // Replace with snapshot that still has sess_1 but not sess_2
+    const snapshot: HostSnapshot = {
+      descriptor: makeDescriptor(hostId),
+      connection: { state: 'connected' },
+      projects: [],
+      sessions: {
+        sess_1: { id: 'sess_1', title: 'S1 Updated', directory: '/d', projectId: 'p' },
+      },
+      statuses: {},
+      unreadBySession: {},
+    };
+
+    store.replaceHostSnapshot(hostId, snapshot);
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    // sess_1 unread should be preserved
+    expect(state?.unreadBySession['sess_1']).toBe(3);
+    // sess_2 should be removed (server no longer reports it)
+    expect(state?.sessions['sess_2']).toBeFalsy();
+    expect(state?.unreadBySession['sess_2']).toBeFalsy();
+  });
+
+  test('replaceHostSnapshot removes status for deleted sessions', () => {
+    const store = useMultiHostStore.getState();
+
+    store.registerHost(makeDescriptor(hostId));
+    store.upsertSession(hostId, { id: 'sess_1', title: 'S1', directory: '/d', projectId: 'p' });
+    store.upsertSession(hostId, { id: 'sess_2', title: 'S2', directory: '/d', projectId: 'p' });
+    store.setSessionStatus(hostId, 'sess_1', 'busy');
+    store.setSessionStatus(hostId, 'sess_2', 'busy');
+
+    // Replace with snapshot that only has sess_1
+    const snapshot: HostSnapshot = {
+      descriptor: makeDescriptor(hostId),
+      connection: { state: 'connected' },
+      projects: [],
+      sessions: {
+        sess_1: { id: 'sess_1', title: 'S1', directory: '/d', projectId: 'p' },
+      },
+      statuses: { sess_1: { status: 'busy' } },
+      unreadBySession: {},
+    };
+
+    store.replaceHostSnapshot(hostId, snapshot);
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    expect(state?.statuses['sess_1']?.status).toBe('busy');
+    expect(state?.statuses['sess_2']).toBeFalsy();
+  });
+
+  test('replaceHostSnapshot does not affect other hosts', () => {
+    const store = useMultiHostStore.getState();
+    const hostA = 'host_a' as HostId;
+    const hostB = 'host_b' as HostId;
+
+    store.registerHost(makeDescriptor(hostA));
+    store.registerHost(makeDescriptor(hostB));
+
+    store.upsertSession(hostA, { id: 'sess_a', title: 'A', directory: '/a', projectId: 'pa' });
+    store.upsertSession(hostB, { id: 'sess_b', title: 'B', directory: '/b', projectId: 'pb' });
+    store.markSessionUnread(hostA, 'sess_a', 5);
+    store.markSessionUnread(hostB, 'sess_b', 2);
+
+    // Replace only host A
+    const snapshot: HostSnapshot = {
+      descriptor: makeDescriptor(hostA),
+      connection: { state: 'connected' },
+      projects: [],
+      sessions: {},
+      statuses: {},
+      unreadBySession: {},
+    };
+
+    store.replaceHostSnapshot(hostA, snapshot);
+
+    const stateA = useMultiHostStore.getState().hosts[hostA];
+    const stateB = useMultiHostStore.getState().hosts[hostB];
+
+    expect(stateA?.sessions['sess_a']).toBeFalsy();
+    expect(stateB?.sessions['sess_b']).toBeDefined();
+    expect(stateB?.unreadBySession['sess_b']).toBe(2);
+  });
+
+  test('reconciliation refresh clears server-deleted sessions and statuses', async () => {
+    const hostId = 'host_test' as HostId;
+    const store = useMultiHostStore.getState();
+
+    store.registerHost(makeDescriptor(hostId));
+    store.upsertSession(hostId, { id: 'sess_1', title: 'S1', directory: '/d', projectId: 'p' });
+    store.upsertSession(hostId, { id: 'sess_2', title: 'S2', directory: '/d', projectId: 'p' });
+    store.markSessionUnread(hostId, 'sess_1', 3);
+    store.setSessionStatus(hostId, 'sess_2', 'busy');
+
+    // Server now only reports sess_1
+    const transport = makeTransport({
+      '/project/list': { status: 200, data: [] },
+      '/session': {
+        status: 200,
+        data: [{ id: 'sess_1', title: 'S1 Updated', directory: '/d', projectID: 'p', time: { created: 1, updated: 2 } }],
+      },
+      '/session/status': { status: 200, data: {} },
+    });
+
+    const descriptor = makeDescriptor(hostId);
+    const existingSnapshot: HostSnapshot = {
+      descriptor,
+      connection: { state: 'connected' },
+      projects: [],
+      sessions: {
+        sess_1: { id: 'sess_1', title: 'S1', directory: '/d', projectId: 'p' },
+        sess_2: { id: 'sess_2', title: 'S2', directory: '/d', projectId: 'p' },
+      },
+      statuses: { sess_2: { status: 'busy' } },
+      unreadBySession: { sess_1: 3 },
+    };
+
+    const result = await reconcileHost(hostId, descriptor, transport, existingSnapshot);
+
+    expect(result.ok).toBe(true);
+
+    // Apply the result
+    store.replaceHostSnapshot(hostId, result.snapshot);
+
+    const state = useMultiHostStore.getState().hosts[hostId];
+    // sess_1 unread preserved
+    expect(state?.unreadBySession['sess_1']).toBe(3);
+    // sess_2 removed (server no longer reports)
+    expect(state?.sessions['sess_2']).toBeFalsy();
+    expect(state?.statuses['sess_2']).toBeFalsy();
+    expect(state?.unreadBySession['sess_2']).toBeFalsy();
+  });
+});

--- a/packages/ui/src/multi-host/monitor/event-normalizer.ts
+++ b/packages/ui/src/multi-host/monitor/event-normalizer.ts
@@ -1,0 +1,173 @@
+/**
+ * Event normalizer for multi-host monitor.
+ *
+ * Converts raw server events (same shape as the SDK Event type) into
+ * NormalizedHostEvent instances that can be safely written to the
+ * multi-host store.
+ *
+ * High-frequency / irrelevant events (message deltas, tool progress,
+ * streaming, LSP, etc.) are silently dropped.
+ *
+ * Incomplete events (missing required fields) trigger a host refresh
+ * instead of creating malformed session refs.
+ */
+
+import type { HostId, HostSessionStatus, HostSessionSummary } from '../types';
+import type { MonitorEventFrame, NormalizedHostEvent } from './types';
+
+// ---------------------------------------------------------------------------
+// Status normalization
+// ---------------------------------------------------------------------------
+
+const normalizeStatusType = (type: unknown): HostSessionStatus['status'] | 'idle' => {
+  if (type === 'busy') return 'busy';
+  if (type === 'retry') return 'retry';
+  return 'idle';
+};
+
+// ---------------------------------------------------------------------------
+// Session info extraction (from session.created / session.updated)
+// ---------------------------------------------------------------------------
+
+function extractSessionSummary(
+  properties: Record<string, unknown>,
+): HostSessionSummary | null {
+  const info = properties?.info;
+  if (!info || typeof info !== 'object') return null;
+  const record = info as Record<string, unknown>;
+  if (typeof record.id !== 'string' || record.id.length === 0) return null;
+
+  const time = record.time as Record<string, unknown> | undefined;
+
+  return {
+    id: record.id as string,
+    title: typeof record.title === 'string' ? record.title : undefined,
+    directory: typeof record.directory === 'string' ? record.directory : undefined,
+    projectId: typeof record.projectID === 'string' ? record.projectID : undefined,
+    createdAt: typeof time?.created === 'number' ? time.created : undefined,
+    updatedAt: typeof time?.updated === 'number' ? time.updated : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main normalizer
+// ---------------------------------------------------------------------------
+
+/** Event types we care about for sidebar summary updates. */
+const RELEVANT_EVENT_TYPES = new Set([
+  'session.created',
+  'session.updated',
+  'session.deleted',
+  'session.status',
+  'session.idle',
+  'session.error',
+  'permission.v2.asked',
+  'permission.v2.replied',
+  'permission.asked',
+  'permission.replied',
+  'question.v2.asked',
+  'question.v2.replied',
+  'question.v2.rejected',
+  'question.asked',
+  'question.replied',
+  'question.rejected',
+]);
+
+/**
+ * Normalize a raw event frame from a host's event stream into zero or more
+ * NormalizedHostEvent instances.
+ *
+ * Returns an empty array for irrelevant events (message streaming, tool
+ * progress, LSP, etc.).
+ *
+ * Returns a "host-refresh-required" event if the raw event lacks fields
+ * needed to construct a complete HostSessionSummary — rather than creating
+ * an incomplete session ref.
+ */
+export function normalizeHostEvent(
+  hostId: HostId,
+  frame: MonitorEventFrame,
+): NormalizedHostEvent[] {
+  const { payload } = frame;
+  const eventType = payload.type;
+
+  // Strip trailing ".N" suffix (e.g. "session.status.1" → "session.status")
+  const normalizedType = eventType.replace(/\.\d+$/, '');
+
+  if (!RELEVANT_EVENT_TYPES.has(normalizedType)) {
+    return [];
+  }
+
+  const props = payload.properties ?? {};
+
+  switch (normalizedType) {
+    case 'session.created':
+    case 'session.updated': {
+      const summary = extractSessionSummary(props);
+      if (!summary) {
+        // Incomplete event — trigger refresh rather than create bad state.
+        return [{ type: 'host-refresh-required', hostId }];
+      }
+      return [{ type: 'session-upsert', hostId, session: summary }];
+    }
+
+    case 'session.deleted': {
+      const sessionID =
+        typeof props.sessionID === 'string'
+          ? props.sessionID
+          : typeof (props.info as Record<string, unknown>)?.id === 'string'
+            ? (props.info as Record<string, unknown>).id as string
+            : '';
+      if (!sessionID) {
+        return [{ type: 'host-refresh-required', hostId }];
+      }
+      return [{ type: 'session-remove', hostId, sessionId: sessionID }];
+    }
+
+    case 'session.status': {
+      const sessionID = typeof props.sessionID === 'string' ? props.sessionID : '';
+      if (!sessionID) {
+        return [{ type: 'host-refresh-required', hostId }];
+      }
+      const statusObj = props.status as Record<string, unknown> | undefined;
+      const rawType = statusObj?.type;
+      const normalized = normalizeStatusType(rawType);
+      if (normalized === 'idle') {
+        // idle means the server omits it from status snapshots — treat as idle
+        return [{ type: 'session-status', hostId, sessionId: sessionID, status: 'idle' }];
+      }
+      return [{ type: 'session-status', hostId, sessionId: sessionID, status: normalized }];
+    }
+
+    case 'session.idle':
+    case 'session.error': {
+      const sessionID = typeof props.sessionID === 'string' ? props.sessionID : '';
+      if (!sessionID) {
+        return [{ type: 'host-refresh-required', hostId }];
+      }
+      return [{ type: 'session-status', hostId, sessionId: sessionID, status: 'idle' }];
+    }
+
+    // Permission / question events — we don't track them in session summary,
+    // but they indicate the session has activity. We treat them as "refresh
+    // required" to ensure the sidebar shows the latest state.
+    case 'permission.v2.asked':
+    case 'permission.asked': {
+      const sessionID = typeof props.sessionID === 'string' ? props.sessionID : '';
+      if (!sessionID) return [];
+      // Don't update status — permission events don't change busy/idle.
+      // But we could trigger a status fetch if needed.
+      return [];
+    }
+
+    case 'question.v2.asked':
+    case 'question.asked': {
+      const sessionID = typeof props.sessionID === 'string' ? props.sessionID : '';
+      if (!sessionID) return [];
+      return [];
+    }
+
+    default:
+      return [];
+  }
+}

--- a/packages/ui/src/multi-host/monitor/host-monitor.ts
+++ b/packages/ui/src/multi-host/monitor/host-monitor.ts
@@ -1,0 +1,356 @@
+/**
+ * HostMonitor — manages a single host's connection lifecycle, event
+ * subscription, reconciliation, and reconnect logic.
+ *
+ * Each HostMonitor is fully independent: its failure, reconnect, or refresh
+ * never affects other monitors.
+ *
+ * Lifecycle:
+ * 1. start() → connects transport, subscribes to event stream, starts reconciliation
+ * 2. Events arrive → normalized → written to store
+ * 3. On disconnect → reconnect with exponential backoff
+ * 4. On reconnect → full reconciliation refresh
+ * 5. stop() → cleans up everything
+ * 6. dispose() → prevents further store writes
+ */
+
+import type {
+  HostDescriptor,
+  HostId,
+  HostSnapshot,
+} from '../types';
+import { useMultiHostStore } from '../multi-host-store';
+import {
+  type HostMonitorTransport,
+  type HostMonitorState,
+  type LifecycleGeneration,
+  type MonitorScheduler,
+  type MonitorEventFrame,
+  type NormalizedHostEvent,
+  type ReconnectPolicy,
+  nextGeneration,
+} from './types';
+import { normalizeHostEvent } from './event-normalizer';
+import { reconcileHost } from './reconciliation';
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+type InternalState = {
+  state: HostMonitorState;
+  generation: LifecycleGeneration;
+  eventAbort: AbortController | null;
+  reconciliationTimer: { cancel(): void } | null;
+  reconnectTimer: { cancel(): void } | null;
+  refreshInFlight: Promise<HostSnapshot> | null;
+  lastSuccessAt: number;
+  disposed: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// HostMonitor
+// ---------------------------------------------------------------------------
+
+export class HostMonitor {
+  private hostId: HostId;
+  private descriptor: HostDescriptor;
+  private transport: HostMonitorTransport;
+  private scheduler: MonitorScheduler;
+  private reconnectPolicy: ReconnectPolicy;
+  private reconciliationIntervalMs: number;
+
+  private state: InternalState = {
+    state: 'idle',
+    generation: 0 as LifecycleGeneration,
+    eventAbort: null,
+    reconciliationTimer: null,
+    reconnectTimer: null,
+    refreshInFlight: null,
+    lastSuccessAt: 0,
+    disposed: false,
+  };
+
+  private consecutiveFailures = 0;
+
+  constructor(options: {
+    hostId: HostId;
+    descriptor: HostDescriptor;
+    transport: HostMonitorTransport;
+    scheduler: MonitorScheduler;
+    reconnectPolicy: ReconnectPolicy;
+    reconciliationIntervalMs: number;
+  }) {
+    this.hostId = options.hostId;
+    this.descriptor = options.descriptor;
+    this.transport = options.transport;
+    this.scheduler = options.scheduler;
+    this.reconnectPolicy = options.reconnectPolicy;
+    this.reconciliationIntervalMs = options.reconciliationIntervalMs;
+  }
+
+  // -- Public API -------------------------------------------------------------
+
+  /** Start monitoring this host. Idempotent. */
+  start(): void {
+    if (this.state.disposed) return;
+    if (this.state.state === 'connecting' || this.state.state === 'connected') return;
+
+    this.connect();
+  }
+
+  /** Stop monitoring this host. Cleans up all resources. */
+  stop(): void {
+    this.clearAllTimers();
+    this.closeEventStream();
+    this.state.state = 'idle';
+    this.state.refreshInFlight = null;
+    this.consecutiveFailures = 0;
+    this.reconnectPolicy.reset();
+
+    // Update store
+    if (!this.state.disposed) {
+      useMultiHostStore.getState().setConnectionState(this.hostId, 'disconnected');
+    }
+  }
+
+  /** Update the descriptor. If transport changed, restart the connection. */
+  updateDescriptor(descriptor: HostDescriptor): void {
+    const prevTransport = JSON.stringify(this.descriptor.transport);
+    const nextTransport = JSON.stringify(descriptor.transport);
+    this.descriptor = descriptor;
+
+    if (prevTransport !== nextTransport) {
+      // Transport changed — restart with new generation
+      this.stop();
+      this.state.generation = nextGeneration(this.state.generation);
+      this.start();
+    }
+    // If only label changed, no-op for connection
+  }
+
+  /** Force an immediate reconciliation refresh. */
+  refresh(): void {
+    if (this.state.disposed) return;
+    this.runRefresh(this.state.generation);
+  }
+
+  /** Get the current connection state. */
+  getConnectionState(): HostMonitorState {
+    return this.state.state;
+  }
+
+  /** Dispose and prevent further store writes. */
+  dispose(): void {
+    this.stop();
+    this.state.disposed = true;
+  }
+
+  // -- Connection logic -------------------------------------------------------
+
+  private connect(): void {
+    if (this.state.disposed) return;
+
+    this.state.state = 'connecting';
+    useMultiHostStore.getState().setConnectionState(this.hostId, 'connecting');
+
+    const generation = this.state.generation;
+
+    // Abort any previous event stream
+    this.closeEventStream();
+
+    // Create new abort controller for this connection attempt
+    const abort = new AbortController();
+    this.state.eventAbort = abort;
+
+    // Start event stream and reconciliation
+    this.runEventStream(generation, abort.signal);
+    this.startReconciliationTimer(generation);
+  }
+
+  private async runEventStream(
+    generation: LifecycleGeneration,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (this.state.disposed) return;
+
+    try {
+      const stream = await this.transport.openEventStream({ signal });
+
+      // Check generation is still current
+      if (generation !== this.state.generation) return;
+
+      this.state.state = 'connected';
+      this.consecutiveFailures = 0;
+      this.reconnectPolicy.reset();
+      this.state.lastSuccessAt = this.scheduler.now();
+      useMultiHostStore.getState().setConnectionState(this.hostId, 'connected');
+
+      // Run reconciliation immediately on successful connection
+      this.runRefresh(generation);
+
+      // Consume events
+      for await (const frame of stream) {
+        if (signal.aborted || generation !== this.state.generation) break;
+        this.handleEvent(frame);
+      }
+    } catch (error) {
+      if (signal.aborted || generation !== this.state.generation) return;
+      if (this.state.disposed) return;
+
+      this.state.state = 'error';
+      const errorMessage = error instanceof Error ? error.message : 'Event stream failed';
+      useMultiHostStore.getState().setConnectionState(this.hostId, 'error', errorMessage);
+
+      // Schedule reconnect
+      this.scheduleReconnect(generation);
+    }
+  }
+
+  private handleEvent(frame: MonitorEventFrame): void {
+    if (this.state.disposed) return;
+
+    const events = normalizeHostEvent(this.hostId, frame);
+    const store = useMultiHostStore.getState();
+
+    for (const event of events) {
+      this.applyEvent(store, event);
+    }
+  }
+
+  private applyEvent(
+    store: ReturnType<typeof useMultiHostStore.getState>,
+    event: NormalizedHostEvent,
+  ): void {
+    switch (event.type) {
+      case 'session-upsert':
+        store.upsertSession(event.hostId, event.session);
+        break;
+      case 'session-remove':
+        store.removeSession(event.hostId, event.sessionId);
+        break;
+      case 'session-status':
+        store.setSessionStatus(event.hostId, event.sessionId, event.status);
+        break;
+      case 'host-refresh-required':
+        this.runRefresh(this.state.generation);
+        break;
+    }
+  }
+
+  // -- Reconnect logic --------------------------------------------------------
+
+  private scheduleReconnect(generation: LifecycleGeneration): void {
+    if (this.state.disposed) return;
+    if (generation !== this.state.generation) return;
+
+    this.clearReconnectTimer();
+
+    this.consecutiveFailures += 1;
+    const { delayMs } = this.reconnectPolicy.nextDelay(this.consecutiveFailures, false);
+
+    this.state.reconnectTimer = this.scheduler.setTimeout(() => {
+      if (generation !== this.state.generation || this.state.disposed) return;
+      this.state.reconnectTimer = null;
+      this.connect();
+    }, delayMs);
+  }
+
+  // -- Reconciliation ---------------------------------------------------------
+
+  private startReconciliationTimer(generation: LifecycleGeneration): void {
+    this.clearReconciliationTimer();
+
+    this.state.reconciliationTimer = this.scheduler.setInterval(() => {
+      if (generation !== this.state.generation || this.state.disposed) return;
+      this.runRefresh(generation);
+    }, this.reconciliationIntervalMs);
+  }
+
+  private runRefresh(
+    generation: LifecycleGeneration,
+  ): void {
+    if (this.state.disposed) return;
+    if (generation !== this.state.generation) return;
+
+    // Deduplicate concurrent refreshes
+    if (this.state.refreshInFlight) return;
+
+    const promise = this.doRefresh(generation);
+    this.state.refreshInFlight = promise;
+
+    promise.finally(() => {
+      if (this.state.refreshInFlight === promise) {
+        this.state.refreshInFlight = null;
+      }
+    });
+  }
+
+  private async doRefresh(generation: LifecycleGeneration): Promise<HostSnapshot> {
+    // Capture the abort signal for this generation
+    const signal = this.state.eventAbort?.signal;
+
+    const existingSnapshot: HostSnapshot | undefined = (() => {
+      const hostState = useMultiHostStore.getState().hosts[this.hostId];
+      if (!hostState) return undefined;
+      return {
+        descriptor: hostState.descriptor,
+        connection: hostState.connection,
+        projects: hostState.projects,
+        sessions: hostState.sessions,
+        statuses: hostState.statuses,
+        unreadBySession: hostState.unreadBySession,
+      };
+    })();
+
+    const result = await reconcileHost(
+      this.hostId,
+      this.descriptor,
+      this.transport,
+      existingSnapshot,
+      signal,
+    );
+
+    // Check generation is still current
+    if (generation !== this.state.generation || this.state.disposed) {
+      return result.snapshot;
+    }
+
+    if (result.ok) {
+      // Use replaceHostSnapshot which preserves unread for existing sessions
+      // and removes sessions/statuses that server no longer reports
+      useMultiHostStore.getState().replaceHostSnapshot(this.hostId, result.snapshot);
+    }
+
+    return result.snapshot;
+  }
+
+  // -- Cleanup ----------------------------------------------------------------
+
+  private closeEventStream(): void {
+    if (this.state.eventAbort) {
+      this.state.eventAbort.abort();
+      this.state.eventAbort = null;
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.state.reconnectTimer) {
+      this.state.reconnectTimer.cancel();
+      this.state.reconnectTimer = null;
+    }
+  }
+
+  private clearReconciliationTimer(): void {
+    if (this.state.reconciliationTimer) {
+      this.state.reconciliationTimer.cancel();
+      this.state.reconciliationTimer = null;
+    }
+  }
+
+  private clearAllTimers(): void {
+    this.clearReconnectTimer();
+    this.clearReconciliationTimer();
+    this.closeEventStream();
+  }
+}

--- a/packages/ui/src/multi-host/monitor/index.ts
+++ b/packages/ui/src/multi-host/monitor/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Multi-host monitor — public API barrel.
+ *
+ * Import from '@/multi-host/monitor' to use the supervisor and transport
+ * factory. Do not import internal files directly.
+ */
+
+export { createMultiHostSupervisor } from './multi-host-supervisor';
+export type { MultiHostSupervisor } from './multi-host-supervisor';
+
+export type {
+  HostMonitorTransport,
+  HostMonitorState,
+  MonitorFetchRequest,
+  MonitorFetchResponse,
+  MonitorEventFrame,
+  NormalizedHostEvent,
+  MonitorScheduler,
+  ReconnectPolicy,
+  MultiHostSupervisorOptions,
+  TransportFactory,
+} from './types';
+
+export { normalizeHostEvent } from './event-normalizer';
+export { reconcileHost } from './reconciliation';
+export type { ReconcileResult } from './reconciliation';

--- a/packages/ui/src/multi-host/monitor/multi-host-supervisor.ts
+++ b/packages/ui/src/multi-host/monitor/multi-host-supervisor.ts
@@ -1,0 +1,174 @@
+/**
+ * MultiHostSupervisor — orchestrates multiple HostMonitor instances.
+ *
+ * Each host gets an independent HostMonitor with its own transport,
+ * event stream, reconnect policy, and reconciliation timer.
+ * One host's failure never affects another.
+ *
+ * Non-React code can use the supervisor directly:
+ *
+ *   const supervisor = createMultiHostSupervisor({ transportFactory });
+ *   supervisor.startHost(hostId, descriptor);
+ *   supervisor.stopHost(hostId);
+ *   supervisor.dispose();
+ *
+ * The Integration PR mounts the supervisor and wires it to the remote
+ * instance registry.
+ */
+
+import type { HostDescriptor, HostId } from '../types';
+import { useMultiHostStore } from '../multi-host-store';
+import { HostMonitor } from './host-monitor';
+import {
+  type MonitorScheduler,
+  type MultiHostSupervisorOptions,
+} from './types';
+import { createReconnectPolicy } from './reconnect-policy';
+
+// ---------------------------------------------------------------------------
+// Default scheduler (real timers)
+// ---------------------------------------------------------------------------
+
+const defaultScheduler: MonitorScheduler = {
+  setTimeout: (fn, ms) => {
+    const id = globalThis.setTimeout(fn, ms);
+    return { cancel: () => globalThis.clearTimeout(id) };
+  },
+  setInterval: (fn, ms) => {
+    const id = globalThis.setInterval(fn, ms);
+    return { cancel: () => globalThis.clearInterval(id) };
+  },
+  now: () => Date.now(),
+};
+
+// ---------------------------------------------------------------------------
+// Supervisor
+// ---------------------------------------------------------------------------
+
+export type MultiHostSupervisor = {
+  /** Start monitoring a host. Idempotent: same hostId reuses existing monitor. */
+  startHost(hostId: HostId, descriptor: HostDescriptor): void;
+  /** Stop monitoring a host. Cleans up all resources for that host. */
+  stopHost(hostId: HostId): void;
+  /** Restart a host with an updated descriptor. */
+  restartHost(hostId: HostId, descriptor?: HostDescriptor): void;
+  /** Force an immediate refresh of a host. */
+  refreshHost(hostId: HostId): void;
+  /** Start monitoring all given hosts. */
+  startAll(hosts: Map<HostId, HostDescriptor>): void;
+  /** Stop all monitored hosts. */
+  stopAll(): void;
+  /** Check if a host is being monitored. */
+  hasHost(hostId: HostId): boolean;
+  /** Dispose the supervisor and prevent further store writes. */
+  dispose(): void;
+};
+
+export function createMultiHostSupervisor(
+  options: MultiHostSupervisorOptions,
+): MultiHostSupervisor {
+  const {
+    scheduler = defaultScheduler,
+    transportFactory,
+    reconciliationIntervalMs = 120_000,
+  } = options;
+
+  const monitors = new Map<HostId, HostMonitor>();
+  let disposed = false;
+
+  const getOrCreateMonitor = (
+    hostId: HostId,
+    descriptor: HostDescriptor,
+  ): HostMonitor => {
+    const existing = monitors.get(hostId);
+    if (existing) return existing;
+
+    const reconnectPolicy = options.reconnectPolicyFactory?.() ?? createReconnectPolicy();
+    const transport = transportFactory(descriptor);
+
+    const monitor = new HostMonitor({
+      hostId,
+      descriptor,
+      transport,
+      scheduler,
+      reconnectPolicy,
+      reconciliationIntervalMs,
+    });
+
+    monitors.set(hostId, monitor);
+    return monitor;
+  };
+
+  const startHost = (hostId: HostId, descriptor: HostDescriptor): void => {
+    if (disposed) return;
+
+    // Register in store
+    useMultiHostStore.getState().registerHost(descriptor);
+
+    const monitor = getOrCreateMonitor(hostId, descriptor);
+    monitor.start();
+  };
+
+  const stopHost = (hostId: HostId): void => {
+    const monitor = monitors.get(hostId);
+    if (monitor) {
+      monitor.stop();
+    }
+  };
+
+  const restartHost = (hostId: HostId, descriptor?: HostDescriptor): void => {
+    const monitor = monitors.get(hostId);
+    if (!monitor) {
+      if (descriptor) {
+        startHost(hostId, descriptor);
+      }
+      return;
+    }
+
+    if (descriptor) {
+      monitor.updateDescriptor(descriptor);
+    }
+    monitor.stop();
+    monitor.start();
+  };
+
+  const refreshHost = (hostId: HostId): void => {
+    const monitor = monitors.get(hostId);
+    if (monitor) {
+      monitor.refresh();
+    }
+  };
+
+  const startAll = (hosts: Map<HostId, HostDescriptor>): void => {
+    for (const [hostId, descriptor] of hosts) {
+      startHost(hostId, descriptor);
+    }
+  };
+
+  const stopAll = (): void => {
+    for (const monitor of monitors.values()) {
+      monitor.stop();
+      monitor.dispose();
+    }
+    monitors.clear();
+  };
+
+  const hasHost = (hostId: HostId): boolean => monitors.has(hostId);
+
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    stopAll();
+  };
+
+  return {
+    startHost,
+    stopHost,
+    restartHost,
+    refreshHost,
+    startAll,
+    stopAll,
+    hasHost,
+    dispose,
+  };
+}

--- a/packages/ui/src/multi-host/monitor/reconciliation.ts
+++ b/packages/ui/src/multi-host/monitor/reconciliation.ts
@@ -1,0 +1,184 @@
+/**
+ * Reconciliation logic for a single host monitor.
+ *
+ * Periodically refreshes the host's session/project/status snapshot from the
+ * server to catch missed events. The refresh:
+ * - Replaces server-derived sessions/projects/statuses
+ * - Preserves local unread counts for still-existing sessions
+ * - Removes sessions/statuses for sessions the server no longer reports
+ * - Does NOT affect other hosts
+ */
+
+import type { HostDescriptor, HostId, HostProjectSummary, HostSessionStatus, HostSessionSummary, HostSnapshot } from '../types';
+import type { HostMonitorTransport } from './types';
+
+// ---------------------------------------------------------------------------
+// Refresh result
+// ---------------------------------------------------------------------------
+
+export type ReconcileResult = {
+  snapshot: HostSnapshot;
+  /** True if the fetch succeeded (even if data was empty). */
+  ok: boolean;
+  /** Error message if the fetch failed. */
+  error?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+async function fetchJson(
+  transport: HostMonitorTransport,
+  path: string,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const response = await transport.request({ method: 'GET', path, signal });
+  if (response.status >= 400) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.data;
+}
+
+// ---------------------------------------------------------------------------
+// Project list
+// ---------------------------------------------------------------------------
+
+async function fetchProjects(
+  transport: HostMonitorTransport,
+  signal?: AbortSignal,
+): Promise<HostProjectSummary[]> {
+  const data = await fetchJson(transport, '/project/list', signal);
+  if (!Array.isArray(data)) return [];
+  return data
+    .filter(
+      (p): p is { id: string; name?: string; worktree?: string } =>
+        typeof p === 'object' &&
+        p !== null &&
+        typeof (p as Record<string, unknown>).id === 'string' &&
+        ((p as Record<string, unknown>).id as string).length > 0,
+    )
+    .map((p) => ({
+      id: p.id,
+      name: p.name,
+      directory: p.worktree,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Session list (lightweight)
+// ---------------------------------------------------------------------------
+
+async function fetchSessions(
+  transport: HostMonitorTransport,
+  signal?: AbortSignal,
+): Promise<HostSessionSummary[]> {
+  const data = await fetchJson(transport, '/session', signal);
+  if (!Array.isArray(data)) return [];
+  return data
+    .filter(
+      (s): s is Record<string, unknown> =>
+        typeof s === 'object' &&
+        s !== null &&
+        typeof (s as Record<string, unknown>).id === 'string',
+    )
+    .map((s) => {
+      const time = s.time as Record<string, unknown> | undefined;
+      return {
+        id: s.id as string,
+        title: typeof s.title === 'string' ? s.title : undefined,
+        directory: typeof s.directory === 'string' ? s.directory : undefined,
+        projectId: typeof s.projectID === 'string' ? s.projectID : undefined,
+        createdAt: typeof time?.created === 'number' ? (time.created as number) : undefined,
+        updatedAt: typeof time?.updated === 'number' ? (time.updated as number) : undefined,
+      };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Session status map
+// ---------------------------------------------------------------------------
+
+async function fetchSessionStatuses(
+  transport: HostMonitorTransport,
+  signal?: AbortSignal,
+): Promise<Record<string, HostSessionStatus>> {
+  const data = await fetchJson(transport, '/session/status', signal);
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return {};
+  const raw = data as Record<string, { type?: unknown }>;
+  const result: Record<string, HostSessionStatus> = {};
+  for (const [sessionId, status] of Object.entries(raw)) {
+    if (status?.type === 'busy') {
+      result[sessionId] = { status: 'busy' };
+    } else if (status?.type === 'retry') {
+      result[sessionId] = { status: 'retry' };
+    }
+    // idle is omitted from the map (server convention)
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Full reconciliation refresh
+// ---------------------------------------------------------------------------
+
+/**
+ * Perform a full refresh of a host's state. Returns a complete HostSnapshot
+ * suitable for `replaceHostSnapshot`.
+ *
+ * On fetch failure, returns `ok: false` so the caller can decide whether
+ * to overwrite state.
+ */
+export async function reconcileHost(
+  hostId: HostId,
+  descriptor: HostDescriptor,
+  transport: HostMonitorTransport,
+  existingSnapshot?: HostSnapshot,
+  signal?: AbortSignal,
+): Promise<ReconcileResult> {
+  try {
+    const [projects, sessions, statuses] = await Promise.all([
+      fetchProjects(transport, signal),
+      fetchSessions(transport, signal),
+      fetchSessionStatuses(transport, signal),
+    ]);
+
+    // Build sessions record
+    const sessionsRecord: Record<string, HostSessionSummary> = {};
+    for (const s of sessions) {
+      sessionsRecord[s.id] = s;
+    }
+
+    const snapshot: HostSnapshot = {
+      descriptor,
+      connection: {
+        state: 'connected',
+        connectedAt: existingSnapshot?.connection.connectedAt ?? new Date().toISOString(),
+      },
+      projects,
+      sessions: sessionsRecord,
+      statuses,
+      unreadBySession: {},
+    };
+
+    return { snapshot, ok: true };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Reconciliation failed';
+    return {
+      snapshot: {
+        descriptor,
+        connection: {
+          state: 'error',
+          error: message,
+        },
+        projects: existingSnapshot?.projects ?? [],
+        sessions: existingSnapshot?.sessions ?? {},
+        statuses: existingSnapshot?.statuses ?? {},
+        unreadBySession: existingSnapshot?.unreadBySession ?? {},
+      },
+      ok: false,
+      error: message,
+    };
+  }
+}

--- a/packages/ui/src/multi-host/monitor/reconnect-policy.ts
+++ b/packages/ui/src/multi-host/monitor/reconnect-policy.ts
@@ -1,0 +1,67 @@
+/**
+ * Exponential backoff reconnect policy with jitter.
+ *
+ * Matches the pacing strategy from the main event-pipeline:
+ * - base 250ms, exponential growth, max exponent 8
+ * - visible+online: cap 5s
+ * - hidden/offline: cap 60s
+ * - permanent 4xx (except 408/429): jump to long cap
+ * - jitter added to avoid thundering herd across hosts
+ */
+
+import type { ReconnectPolicy, ReconnectAttempt } from './types';
+
+const BASE_MS = 250;
+const CAP_VISIBLE_MS = 5_000;
+const CAP_HIDDEN_OR_OFFLINE_MS = 60_000;
+const MAX_EXPONENT = 8;
+const AUTH_FAILURE_CAP_MS = 60_000;
+
+const isOffline = (): boolean =>
+  typeof navigator === 'object' && navigator !== null && navigator.onLine === false;
+
+const isHidden = (): boolean =>
+  typeof document !== 'undefined' && document.visibilityState !== 'visible';
+
+/**
+ * Compute jitter in [0, half of base delay) to spread reconnect attempts
+ * across multiple hosts that disconnect simultaneously.
+ */
+const jitter = (baseMs: number): number =>
+  Math.floor(Math.random() * Math.min(baseMs / 2, 1000));
+
+export function createReconnectPolicy(): ReconnectPolicy {
+  const nextDelay = (attemptNumber: number, isPermanentError: boolean): ReconnectAttempt => {
+    const failures = Math.max(1, attemptNumber);
+
+    if (isPermanentError) {
+      return {
+        delayMs: AUTH_FAILURE_CAP_MS + jitter(AUTH_FAILURE_CAP_MS),
+        reason: 'permanent_error',
+      };
+    }
+
+    if (isOffline()) {
+      return {
+        delayMs: CAP_HIDDEN_OR_OFFLINE_MS,
+        reason: 'offline',
+      };
+    }
+
+    const cap = isHidden() ? CAP_HIDDEN_OR_OFFLINE_MS : CAP_VISIBLE_MS;
+    const exponent = Math.min(failures - 1, MAX_EXPONENT);
+    const base = Math.min(cap, BASE_MS * 2 ** exponent);
+    const delay = base + jitter(base);
+
+    return {
+      delayMs: delay,
+      reason: `attempt_${failures}`,
+    };
+  };
+
+  const reset = () => {
+    // No-op: backoff is purely computed from attemptNumber
+  };
+
+  return { nextDelay, reset };
+}

--- a/packages/ui/src/multi-host/monitor/types.ts
+++ b/packages/ui/src/multi-host/monitor/types.ts
@@ -1,0 +1,145 @@
+/**
+ * Internal types for the multi-host monitor layer.
+ *
+ * These types are NOT exported from the public barrel; they are private to the
+ * monitor module and used only by internal implementation files.
+ */
+
+import type { HostDescriptor, HostId, HostSessionStatus, HostSessionSummary } from '../types';
+
+// ---------------------------------------------------------------------------
+// Transport abstraction
+// ---------------------------------------------------------------------------
+
+/** HTTP request options for the monitor transport. */
+export type MonitorFetchRequest = {
+  method?: string;
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  signal?: AbortSignal;
+};
+
+/** Opaque response from a monitor transport HTTP call. */
+export type MonitorFetchResponse = {
+  status: number;
+  data: unknown;
+  headers?: { get?: (name: string) => string | null } | Record<string, unknown>;
+};
+
+/**
+ * Transport abstraction for HostMonitor. Each concrete transport (local,
+ * direct, SSH) implements this interface; relay is injected by the
+ * Integration PR.
+ */
+export interface HostMonitorTransport {
+  /** Perform an HTTP request against the host. */
+  request(fetchReq: MonitorFetchRequest): Promise<MonitorFetchResponse>;
+
+  /**
+   * Open a global event stream (SSE or WebSocket) and return an async
+   * iterable of raw event frames. The caller owns the lifecycle and will
+   * close via abort signal.
+   */
+  openEventStream(options: {
+    signal: AbortSignal;
+    lastEventId?: string;
+  }): Promise<AsyncIterable<MonitorEventFrame>>;
+
+  /** Release all resources held by this transport. */
+  close(): void;
+}
+
+/** Raw event frame from a host's global event stream. */
+export type MonitorEventFrame = {
+  /** The directory the event belongs to (from SSE envelope or WS frame). */
+  directory: string;
+  /** The event payload — same shape as the SDK Event type. */
+  payload: {
+    id?: string;
+    type: string;
+    properties: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Normalized host events (internal event form)
+// ---------------------------------------------------------------------------
+
+export type NormalizedHostEvent =
+  | {
+      type: 'session-upsert';
+      hostId: HostId;
+      session: HostSessionSummary;
+    }
+  | {
+      type: 'session-remove';
+      hostId: HostId;
+      sessionId: string;
+    }
+  | {
+      type: 'session-status';
+      hostId: HostId;
+      sessionId: string;
+      status: HostSessionStatus['status'];
+    }
+  | {
+      type: 'host-refresh-required';
+      hostId: HostId;
+    };
+
+// ---------------------------------------------------------------------------
+// Host monitor internal state
+// ---------------------------------------------------------------------------
+
+export type HostMonitorState = 'idle' | 'connecting' | 'connected' | 'error';
+
+/** Lifecycle generation — bumped on descriptor change to discard stale results. */
+export type LifecycleGeneration = number & { readonly __brand: 'LifecycleGeneration' };
+
+export const nextGeneration = (current: LifecycleGeneration): LifecycleGeneration =>
+  (current + 1) as LifecycleGeneration;
+
+// ---------------------------------------------------------------------------
+// Scheduler abstraction (injectable for testing)
+// ---------------------------------------------------------------------------
+
+export interface MonitorScheduler {
+  setTimeout(fn: () => void, ms: number): { cancel(): void };
+  setInterval(fn: () => void, ms: number): { cancel(): void };
+  now(): number;
+}
+
+// ---------------------------------------------------------------------------
+// Reconnect policy
+// ---------------------------------------------------------------------------
+
+export type ReconnectAttempt = {
+  delayMs: number;
+  reason: string;
+};
+
+export interface ReconnectPolicy {
+  /** Compute the delay before the next reconnect attempt. */
+  nextDelay(attemptNumber: number, isPermanentError: boolean): ReconnectAttempt;
+  /** Reset backoff after a successful connection. */
+  reset(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Supervisor options
+// ---------------------------------------------------------------------------
+
+export type MultiHostSupervisorOptions = {
+  /** Injectable scheduler for testing. Uses real timers by default. */
+  scheduler?: MonitorScheduler;
+  /** Injectable reconnect policy factory. Creates per-host policies. */
+  reconnectPolicyFactory?: () => ReconnectPolicy;
+  /** Injectable transport factory. Creates transports for each host. */
+  transportFactory: TransportFactory;
+  /** Reconciliation interval in ms. Default: 120_000 (2 min). */
+  reconciliationIntervalMs?: number;
+};
+
+export type TransportFactory = (descriptor: HostDescriptor) => HostMonitorTransport;

--- a/packages/ui/src/multi-host/multi-host-store.test.ts
+++ b/packages/ui/src/multi-host/multi-host-store.test.ts
@@ -1,0 +1,539 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { useMultiHostStore } from './multi-host-store';
+import {
+  selectHost,
+  selectHostProjects,
+  selectHostSessions,
+  selectHostsWithActivity,
+  selectSessionByRef,
+  selectSessionStatusByRef,
+  selectTotalUnreadCount,
+  selectUnreadCountByHost,
+} from './selectors';
+import type { HostDescriptor, HostId, HostSessionRef, HostSnapshot } from './types';
+
+const hostA: HostDescriptor = {
+  hostId: 'host-a' as HostId,
+  label: 'Host A',
+  transport: { kind: 'direct', apiUrl: 'http://localhost:3000' },
+};
+
+const hostB: HostDescriptor = {
+  hostId: 'host-b' as HostId,
+  label: 'Host B',
+  transport: { kind: 'ssh', sshEndpoint: 'remote:22' },
+};
+
+beforeEach(() => {
+  useMultiHostStore.setState({ hosts: {} });
+});
+
+// ---------------------------------------------------------------------------
+// 1. Two hosts can have the same sessionId; data doesn't mix
+// ---------------------------------------------------------------------------
+describe('session isolation across hosts', () => {
+  test('two hosts can store the same sessionId without conflict', () => {
+    const { registerHost, upsertSession } = useMultiHostStore.getState();
+    registerHost(hostA);
+    registerHost(hostB);
+
+    upsertSession('host-a' as HostId, { id: 'ses_1', title: 'From A' });
+    upsertSession('host-b' as HostId, { id: 'ses_1', title: 'From B' });
+
+    const state = useMultiHostStore.getState();
+    expect(state.hosts['host-a']!.sessions['ses_1']!.title).toBe('From A');
+    expect(state.hosts['host-b']!.sessions['ses_1']!.title).toBe('From B');
+  });
+
+  test('session status is isolated per host', () => {
+    const { registerHost, setSessionStatus } = useMultiHostStore.getState();
+    registerHost(hostA);
+    registerHost(hostB);
+
+    setSessionStatus('host-a' as HostId, 'ses_1', 'busy');
+    setSessionStatus('host-b' as HostId, 'ses_1', 'retry');
+
+    const state = useMultiHostStore.getState();
+    expect(state.hosts['host-a']!.statuses['ses_1']!.status).toBe('busy');
+    expect(state.hosts['host-b']!.statuses['ses_1']!.status).toBe('retry');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Updating host A doesn't change host B's references or state
+// ---------------------------------------------------------------------------
+describe('update isolation', () => {
+  test('updating host A descriptor does not affect host B', () => {
+    const { registerHost, updateHostDescriptor } = useMultiHostStore.getState();
+    registerHost(hostA);
+    registerHost(hostB);
+
+    const bBefore = useMultiHostStore.getState().hosts['host-b']!;
+    updateHostDescriptor('host-a' as HostId, { label: 'Renamed A' });
+
+    const state = useMultiHostStore.getState();
+    expect(state.hosts['host-a']!.descriptor.label).toBe('Renamed A');
+    expect(state.hosts['host-b']!.descriptor.label).toBe('Host B');
+    // B's runtime state reference should be unchanged.
+    expect(state.hosts['host-b']).toBe(bBefore);
+  });
+
+  test('upserting session in host A does not touch host B', () => {
+    const { registerHost, upsertSession } = useMultiHostStore.getState();
+    registerHost(hostA);
+    registerHost(hostB);
+
+    const bBefore = useMultiHostStore.getState().hosts['host-b']!;
+    upsertSession('host-a' as HostId, { id: 'ses_new', title: 'New' });
+
+    expect(useMultiHostStore.getState().hosts['host-b']).toBe(bBefore);
+  });
+
+  test('setting status in host A does not affect host B', () => {
+    const { registerHost, setSessionStatus } = useMultiHostStore.getState();
+    registerHost(hostA);
+    registerHost(hostB);
+
+    const bBefore = useMultiHostStore.getState().hosts['host-b']!;
+    setSessionStatus('host-a' as HostId, 'ses_1', 'busy');
+
+    expect(useMultiHostStore.getState().hosts['host-b']).toBe(bBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Deleting a host fully cleans it up
+// ---------------------------------------------------------------------------
+describe('removeHost cleanup', () => {
+  test('removing a host removes all its sessions, statuses, and unread', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+    store.upsertSession('host-a' as HostId, { id: 'ses_1', title: 'S1' });
+    store.upsertSession('host-a' as HostId, { id: 'ses_2', title: 'S2' });
+    store.setSessionStatus('host-a' as HostId, 'ses_1', 'busy');
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 3);
+    store.markSessionUnread('host-a' as HostId, 'ses_2', 1);
+
+    useMultiHostStore.getState().removeHost('host-a' as HostId);
+
+    const state = useMultiHostStore.getState();
+    expect(state.hosts['host-a']).toBe(undefined);
+    // host B is untouched.
+    expect(state.hosts['host-b']).toBeDefined();
+  });
+
+  test('removeHost is a no-op for unknown hostId', () => {
+    const before = useMultiHostStore.getState();
+    useMultiHostStore.getState().removeHost('nonexistent' as HostId);
+    expect(useMultiHostStore.getState()).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Unread is isolated by hostId + sessionId
+// ---------------------------------------------------------------------------
+describe('unread isolation', () => {
+  test('unread counts are independent per host', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 5);
+    store.markSessionUnread('host-b' as HostId, 'ses_1', 3);
+
+    expect(selectUnreadCountByHost('host-a' as HostId)).toBe(5);
+    expect(selectUnreadCountByHost('host-b' as HostId)).toBe(3);
+    expect(selectTotalUnreadCount()).toBe(8);
+  });
+
+  test('clearing unread on one host does not affect the other', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 5);
+    store.markSessionUnread('host-b' as HostId, 'ses_1', 3);
+
+    useMultiHostStore.getState().clearSessionUnread('host-a' as HostId, 'ses_1');
+
+    expect(selectUnreadCountByHost('host-a' as HostId)).toBe(0);
+    expect(selectUnreadCountByHost('host-b' as HostId)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Selectors return correct results
+// ---------------------------------------------------------------------------
+describe('selectors', () => {
+  test('selectHost returns the correct host', () => {
+    useMultiHostStore.getState().registerHost(hostA);
+    useMultiHostStore.getState().registerHost(hostB);
+
+    const a = selectHost('host-a' as HostId);
+    const b = selectHost('host-b' as HostId);
+    expect(a?.descriptor.hostId).toBe('host-a');
+    expect(b?.descriptor.hostId).toBe('host-b');
+  });
+
+  test('selectHostSessions returns sessions for the correct host', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+    store.upsertSession('host-a' as HostId, { id: 'ses_a', title: 'A' });
+    store.upsertSession('host-b' as HostId, { id: 'ses_b', title: 'B' });
+
+    const sessionsA = selectHostSessions('host-a' as HostId);
+    const sessionsB = selectHostSessions('host-b' as HostId);
+    expect(Object.keys(sessionsA)).toEqual(['ses_a']);
+    expect(Object.keys(sessionsB)).toEqual(['ses_b']);
+  });
+
+  test('selectHostProjects returns projects for the correct host', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+    store.replaceProjects('host-a' as HostId, [{ id: 'p1', name: 'Proj A' }]);
+    store.replaceProjects('host-b' as HostId, [{ id: 'p2', name: 'Proj B' }]);
+
+    expect(selectHostProjects('host-a' as HostId)).toEqual([{ id: 'p1', name: 'Proj A' }]);
+    expect(selectHostProjects('host-b' as HostId)).toEqual([{ id: 'p2', name: 'Proj B' }]);
+  });
+
+  test('selectSessionByRef returns the correct session', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+    store.upsertSession('host-a' as HostId, { id: 'ses_1', title: 'From A' });
+    store.upsertSession('host-b' as HostId, { id: 'ses_1', title: 'From B' });
+
+    const refA: HostSessionRef = { hostId: 'host-a' as HostId, sessionId: 'ses_1', directory: '/a', projectId: 'p1' };
+    const refB: HostSessionRef = { hostId: 'host-b' as HostId, sessionId: 'ses_1', directory: '/b', projectId: 'p2' };
+    expect(selectSessionByRef(refA)?.title).toBe('From A');
+    expect(selectSessionByRef(refB)?.title).toBe('From B');
+  });
+
+  test('selectSessionStatusByRef returns correct status', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.setSessionStatus('host-a' as HostId, 'ses_1', 'busy');
+
+    const ref: HostSessionRef = { hostId: 'host-a' as HostId, sessionId: 'ses_1', directory: '/a', projectId: 'p1' };
+    expect(selectSessionStatusByRef(ref)?.status).toBe('busy');
+  });
+
+  test('selectHostsWithActivity returns only hosts with non-idle sessions', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+    store.setSessionStatus('host-a' as HostId, 'ses_1', 'busy');
+
+    const active = selectHostsWithActivity();
+    expect(active).toEqual(['host-a']);
+  });
+
+  test('selectTotalUnreadCount sums all hosts', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 2);
+    store.markSessionUnread('host-a' as HostId, 'ses_2', 3);
+    store.markSessionUnread('host-b' as HostId, 'ses_1', 4);
+
+    expect(selectTotalUnreadCount()).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Duplicate register, update, and delete are safe
+// ---------------------------------------------------------------------------
+describe('idempotency', () => {
+  test('registering the same host twice merges descriptor', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.upsertSession('host-a' as HostId, { id: 'ses_1', title: 'S1' });
+
+    useMultiHostStore.getState().registerHost({
+      ...hostA,
+      label: 'Updated A',
+    });
+
+    const state = useMultiHostStore.getState();
+    expect(state.hosts['host-a']!.descriptor.label).toBe('Updated A');
+    // Sessions are preserved.
+    expect(state.hosts['host-a']!.sessions['ses_1']!.title).toBe('S1');
+  });
+
+  test('removeHost twice does not throw', () => {
+    useMultiHostStore.getState().registerHost(hostA);
+    useMultiHostStore.getState().removeHost('host-a' as HostId);
+    // Should not throw.
+    useMultiHostStore.getState().removeHost('host-a' as HostId);
+    expect(useMultiHostStore.getState().hosts['host-a']).toBe(undefined);
+  });
+
+  test('upserting the same session reference is a no-op', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    const session = { id: 'ses_1', title: 'S1' };
+    store.upsertSession('host-a' as HostId, session);
+
+    const before = useMultiHostStore.getState();
+    useMultiHostStore.getState().upsertSession('host-a' as HostId, session);
+    // Same reference → state should be unchanged.
+    expect(useMultiHostStore.getState().hosts['host-a']).toBe(before.hosts['host-a']);
+  });
+
+  test('markSessionUnread with same count is a no-op', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 5);
+
+    const before = useMultiHostStore.getState();
+    useMultiHostStore.getState().markSessionUnread('host-a' as HostId, 'ses_1', 5);
+    expect(useMultiHostStore.getState().hosts['host-a']).toBe(before.hosts['host-a']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. replaceHostSnapshot does not affect other hosts
+// ---------------------------------------------------------------------------
+describe('replaceHostSnapshot isolation', () => {
+  test('replacing snapshot for host A does not change host B', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.registerHost(hostB);
+    store.upsertSession('host-b' as HostId, { id: 'ses_b', title: 'B' });
+    store.markSessionUnread('host-b' as HostId, 'ses_b', 2);
+
+    const bBefore = useMultiHostStore.getState().hosts['host-b']!;
+
+    const snapshot: HostSnapshot = {
+      descriptor: hostA,
+      connection: { state: 'connected', connectedAt: '2025-01-01T00:00:00Z' },
+      projects: [{ id: 'p1', name: 'Project' }],
+      sessions: { ses_a: { id: 'ses_a', title: 'New A' } },
+      statuses: { ses_a: { status: 'busy' } },
+      unreadBySession: { ses_a: 5 },
+    };
+
+    useMultiHostStore.getState().replaceHostSnapshot('host-a' as HostId, snapshot);
+
+    const state = useMultiHostStore.getState();
+    expect(state.hosts['host-b']).toBe(bBefore);
+    expect(state.hosts['host-a']!.sessions['ses_a']!.title).toBe('New A');
+    expect(state.hosts['host-a']!.connection.state).toBe('connected');
+  });
+
+  test('replaceHostSnapshot on unknown host creates the host entry', () => {
+    const snapshot: HostSnapshot = {
+      descriptor: hostA,
+      connection: { state: 'disconnected' },
+      projects: [],
+      sessions: {},
+      statuses: {},
+      unreadBySession: {},
+    };
+
+    useMultiHostStore.getState().replaceHostSnapshot('host-a' as HostId, snapshot);
+
+    const state = useMultiHostStore.getState();
+    expect(state.hosts['host-a']).toBeDefined();
+    expect(state.hosts['host-a']!.descriptor.hostId).toBe('host-a');
+  });
+
+  test('replaceHostSnapshot preserves local unread counts', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.upsertSession('host-a' as HostId, { id: 'ses_1', title: 'S1' });
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 5);
+
+    // Server refresh with same session but no unread data
+    const snapshot: HostSnapshot = {
+      descriptor: hostA,
+      connection: { state: 'connected' },
+      projects: [],
+      sessions: { ses_1: { id: 'ses_1', title: 'S1 Updated' } },
+      statuses: {},
+      unreadBySession: {},
+    };
+
+    useMultiHostStore.getState().replaceHostSnapshot('host-a' as HostId, snapshot);
+
+    const state = useMultiHostStore.getState();
+    // Unread should be preserved
+    expect(state.hosts['host-a']!.unreadBySession['ses_1']).toBe(5);
+    // Session should be updated
+    expect(state.hosts['host-a']!.sessions['ses_1']!.title).toBe('S1 Updated');
+  });
+
+  test('replaceHostSnapshot removes sessions not in snapshot', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.upsertSession('host-a' as HostId, { id: 'ses_1', title: 'S1' });
+    store.upsertSession('host-a' as HostId, { id: 'ses_2', title: 'S2' });
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 3);
+    store.markSessionUnread('host-a' as HostId, 'ses_2', 2);
+
+    // Server refresh without ses_2
+    const snapshot: HostSnapshot = {
+      descriptor: hostA,
+      connection: { state: 'connected' },
+      projects: [],
+      sessions: { ses_1: { id: 'ses_1', title: 'S1' } },
+      statuses: {},
+      unreadBySession: {},
+    };
+
+    useMultiHostStore.getState().replaceHostSnapshot('host-a' as HostId, snapshot);
+
+    const state = useMultiHostStore.getState();
+    // ses_2 should be removed
+    expect(state.hosts['host-a']!.sessions['ses_2']).toBe(undefined);
+    // ses_2 unread should be removed
+    expect(state.hosts['host-a']!.unreadBySession['ses_2']).toBe(undefined);
+    // ses_1 unread should be preserved
+    expect(state.hosts['host-a']!.unreadBySession['ses_1']).toBe(3);
+  });
+
+  test('replaceHostSnapshot preserves existing unread when snapshot has new sessions', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.upsertSession('host-a' as HostId, { id: 'ses_1', title: 'S1' });
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 5);
+
+    // Server refresh with new session ses_2
+    const snapshot: HostSnapshot = {
+      descriptor: hostA,
+      connection: { state: 'connected' },
+      projects: [],
+      sessions: { 
+        ses_1: { id: 'ses_1', title: 'S1' },
+        ses_2: { id: 'ses_2', title: 'S2' }
+      },
+      statuses: {},
+      unreadBySession: { ses_2: 3 },
+    };
+
+    useMultiHostStore.getState().replaceHostSnapshot('host-a' as HostId, snapshot);
+
+    const state = useMultiHostStore.getState();
+    // ses_1 unread should be preserved
+    expect(state.hosts['host-a']!.unreadBySession['ses_1']).toBe(5);
+    // ses_2 unread should be added from snapshot
+    expect(state.hosts['host-a']!.unreadBySession['ses_2']).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connection state
+// ---------------------------------------------------------------------------
+describe('connection state', () => {
+  test('setConnectionState transitions correctly', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+
+    useMultiHostStore.getState().setConnectionState('host-a' as HostId, 'connecting');
+    expect(useMultiHostStore.getState().hosts['host-a']!.connection.state).toBe('connecting');
+
+    useMultiHostStore.getState().setConnectionState('host-a' as HostId, 'connected');
+    expect(useMultiHostStore.getState().hosts['host-a']!.connection.state).toBe('connected');
+    expect(useMultiHostStore.getState().hosts['host-a']!.connection.connectedAt).toBeTruthy();
+
+    useMultiHostStore.getState().setConnectionState('host-a' as HostId, 'error', 'timeout');
+    expect(useMultiHostStore.getState().hosts['host-a']!.connection.state).toBe('error');
+    expect(useMultiHostStore.getState().hosts['host-a']!.connection.error).toBe('timeout');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearHostRuntimeState
+// ---------------------------------------------------------------------------
+describe('clearHostRuntimeState', () => {
+  test('clears sessions, statuses, unread, and connection but keeps descriptor', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.upsertSession('host-a' as HostId, { id: 'ses_1', title: 'S1' });
+    store.setSessionStatus('host-a' as HostId, 'ses_1', 'busy');
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 5);
+    store.setConnectionState('host-a' as HostId, 'connected');
+
+    useMultiHostStore.getState().clearHostRuntimeState('host-a' as HostId);
+
+    const state = useMultiHostStore.getState();
+    const host = state.hosts['host-a']!;
+    expect(host.descriptor).toEqual(hostA);
+    expect(host.connection.state).toBe('disconnected');
+    expect(Object.keys(host.sessions)).toHaveLength(0);
+    expect(Object.keys(host.statuses)).toHaveLength(0);
+    expect(Object.keys(host.unreadBySession)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeSession
+// ---------------------------------------------------------------------------
+describe('removeSession', () => {
+  test('removes session, its status, and its unread', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.upsertSession('host-a' as HostId, { id: 'ses_1', title: 'S1' });
+    store.setSessionStatus('host-a' as HostId, 'ses_1', 'busy');
+    store.markSessionUnread('host-a' as HostId, 'ses_1', 3);
+
+    useMultiHostStore.getState().removeSession('host-a' as HostId, 'ses_1');
+
+    const state = useMultiHostStore.getState();
+    const host = state.hosts['host-a']!;
+    expect(host.sessions['ses_1']).toBe(undefined);
+    expect(host.statuses['ses_1']).toBe(undefined);
+    expect(host.unreadBySession['ses_1']).toBe(undefined);
+  });
+
+  test('removeSession is a no-op for unknown session', () => {
+    useMultiHostStore.getState().registerHost(hostA);
+    const before = useMultiHostStore.getState();
+    useMultiHostStore.getState().removeSession('host-a' as HostId, 'nonexistent');
+    expect(useMultiHostStore.getState().hosts['host-a']).toBe(before.hosts['host-a']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replaceSessions
+// ---------------------------------------------------------------------------
+describe('replaceSessions', () => {
+  test('replaces full session list', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.upsertSession('host-a' as HostId, { id: 'old', title: 'Old' });
+
+    useMultiHostStore.getState().replaceSessions('host-a' as HostId, [
+      { id: 'new_1', title: 'N1' },
+      { id: 'new_2', title: 'N2' },
+    ]);
+
+    const sessions = useMultiHostStore.getState().hosts['host-a']!.sessions;
+    expect(Object.keys(sessions)).toEqual(['new_1', 'new_2']);
+  });
+
+  test('replaceSessions is a no-op for unknown hostId', () => {
+    const before = useMultiHostStore.getState();
+    useMultiHostStore.getState().replaceSessions('nonexistent' as HostId, []);
+    expect(useMultiHostStore.getState()).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setSessionStatus idle removes entry
+// ---------------------------------------------------------------------------
+describe('setSessionStatus idle', () => {
+  test('setting status to idle removes the entry', () => {
+    const store = useMultiHostStore.getState();
+    store.registerHost(hostA);
+    store.setSessionStatus('host-a' as HostId, 'ses_1', 'busy');
+    expect(useMultiHostStore.getState().hosts['host-a']!.statuses['ses_1']).toBeDefined();
+
+    useMultiHostStore.getState().setSessionStatus('host-a' as HostId, 'ses_1', 'idle');
+    expect(useMultiHostStore.getState().hosts['host-a']!.statuses['ses_1']).toBe(undefined);
+  });
+});

--- a/packages/ui/src/multi-host/multi-host-store.ts
+++ b/packages/ui/src/multi-host/multi-host-store.ts
@@ -1,0 +1,455 @@
+/**
+ * Multi-host Zustand store.
+ *
+ * Holds per-host state isolated by hostId. Sessions and statuses are nested
+ * under their host — never flattened into a global sessionId-keyed Map.
+ *
+ * This store is a peer of the existing active-runtime store; it does NOT
+ * modify or replace any existing session or sync store.
+ */
+
+import { create } from 'zustand';
+
+import type {
+  HostConnectionState,
+  HostConnectionSummary,
+  HostDescriptor,
+  HostId,
+  HostProjectSummary,
+  HostSessionStatus,
+  HostSessionSummary,
+  HostSnapshot,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Per-host state shape
+// ---------------------------------------------------------------------------
+
+/** State for a single host, isolated by hostId. */
+export type HostRuntimeState = {
+  descriptor: HostDescriptor;
+  connection: HostConnectionSummary;
+  projects: HostProjectSummary[];
+  /** Sessions keyed by the host-local sessionId. */
+  sessions: Record<string, HostSessionSummary>;
+  /** Per-session status keyed by the host-local sessionId. */
+  statuses: Record<string, HostSessionStatus>;
+  /** Per-session unread count keyed by the host-local sessionId. */
+  unreadBySession: Record<string, number>;
+};
+
+// ---------------------------------------------------------------------------
+// Store state + actions
+// ---------------------------------------------------------------------------
+
+export type MultiHostState = {
+  /** All registered hosts, keyed by HostId. */
+  hosts: Record<string, HostRuntimeState>;
+
+  // -- Host lifecycle -------------------------------------------------------
+
+  /** Register a new host. Idempotent: re-registering an existing hostId
+   *  merges the descriptor and preserves runtime state. */
+  registerHost: (descriptor: HostDescriptor) => void;
+
+  /** Update the descriptor for an existing host. No-op if hostId unknown. */
+  updateHostDescriptor: (hostId: HostId, patch: Partial<Omit<HostDescriptor, 'hostId'>>) => void;
+
+  /** Remove a host and all its sessions, statuses, unread, and connection
+   *  state. No-op if hostId unknown. */
+  removeHost: (hostId: HostId) => void;
+
+  // -- Connection -----------------------------------------------------------
+
+  /** Set the connection state for a host. */
+  setConnectionState: (hostId: HostId, state: HostConnectionState, error?: string) => void;
+
+  // -- Projects -------------------------------------------------------------
+
+  /** Replace the full project list for a host. */
+  replaceProjects: (hostId: HostId, projects: HostProjectSummary[]) => void;
+
+  // -- Sessions -------------------------------------------------------------
+
+  /** Replace the full session list for a host. */
+  replaceSessions: (hostId: HostId, sessions: HostSessionSummary[]) => void;
+
+  /** Insert or update a single session. */
+  upsertSession: (hostId: HostId, session: HostSessionSummary) => void;
+
+  /** Remove a single session. */
+  removeSession: (hostId: HostId, sessionId: string) => void;
+
+  // -- Status ---------------------------------------------------------------
+
+  /** Set session status (busy / retry / idle). Idle removes the entry. */
+  setSessionStatus: (hostId: HostId, sessionId: string, status: HostSessionStatus['status']) => void;
+
+  // -- Unread ---------------------------------------------------------------
+
+  /** Mark a session as having unread activity. */
+  markSessionUnread: (hostId: HostId, sessionId: string, count?: number) => void;
+
+  /** Clear unread for a session. */
+  clearSessionUnread: (hostId: HostId, sessionId: string) => void;
+
+  // -- Bulk operations ------------------------------------------------------
+
+  /**
+   * Replace the entire snapshot for a host. Other hosts are untouched.
+   *
+   * Semantics after full server refresh:
+   * - Sessions deleted by server are removed from the host
+   * - Corresponding stale statuses are cleared
+   * - Local unread counts are PRESERVED (server doesn't track unread)
+   * - Descriptor is NOT accidentally overwritten (snapshot.descriptor is used)
+   *
+   * This function is idempotent: calling with the same snapshot produces no change.
+   */
+  replaceHostSnapshot: (hostId: HostId, snapshot: HostSnapshot) => void;
+
+  /** Clear all runtime state for a host (sessions, statuses, unread,
+   *  connection) while preserving the descriptor. */
+  clearHostRuntimeState: (hostId: HostId) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const hasKey = <K extends string>(record: Record<K, unknown>, key: K): boolean =>
+  key in record;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useMultiHostStore = create<MultiHostState>()((set) => ({
+  hosts: {},
+
+  // -- Host lifecycle -------------------------------------------------------
+
+  registerHost: (descriptor) => {
+    set((state) => {
+      const existing = state.hosts[descriptor.hostId];
+      if (existing) {
+        // Idempotent: merge descriptor, keep runtime state.
+        const nextDescriptor =
+          existing.descriptor === descriptor
+            ? existing.descriptor
+            : { ...existing.descriptor, ...descriptor, hostId: existing.descriptor.hostId };
+        if (nextDescriptor === existing.descriptor) return state;
+        return {
+          hosts: {
+            ...state.hosts,
+            [descriptor.hostId]: { ...existing, descriptor: nextDescriptor },
+          },
+        };
+      }
+      return {
+        hosts: {
+          ...state.hosts,
+          [descriptor.hostId]: {
+            descriptor,
+            connection: { state: 'disconnected' },
+            projects: [],
+            sessions: {},
+            statuses: {},
+            unreadBySession: {},
+          },
+        },
+      };
+    });
+  },
+
+  updateHostDescriptor: (hostId, patch) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      const nextDescriptor = { ...existing.descriptor, ...patch, hostId: existing.descriptor.hostId };
+      if (nextDescriptor === existing.descriptor) return state;
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: { ...existing, descriptor: nextDescriptor },
+        },
+      };
+    });
+  },
+
+  removeHost: (hostId) => {
+    set((state) => {
+      if (!hasKey(state.hosts, hostId)) return state;
+      const next = { ...state.hosts };
+      delete next[hostId];
+      return { hosts: next };
+    });
+  },
+
+  // -- Connection -----------------------------------------------------------
+
+  setConnectionState: (hostId, connectionState, error) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      const prev = existing.connection;
+      const nextConnection: HostConnectionSummary = {
+        state: connectionState,
+        ...(connectionState === 'connected' ? { connectedAt: new Date().toISOString() } : {}),
+        ...(error !== undefined ? { error } : {}),
+      };
+      // Preserve connectedAt from previous connected state unless reconnecting.
+      if (connectionState === 'connected' && prev.connectedAt && prev.state !== 'connected') {
+        nextConnection.connectedAt = prev.connectedAt;
+      }
+      if (
+        prev.state === nextConnection.state &&
+        prev.connectedAt === nextConnection.connectedAt &&
+        prev.error === nextConnection.error
+      ) {
+        return state;
+      }
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: { ...existing, connection: nextConnection },
+        },
+      };
+    });
+  },
+
+  // -- Projects -------------------------------------------------------------
+
+  replaceProjects: (hostId, projects) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      if (existing.projects === projects) return state;
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: { ...existing, projects },
+        },
+      };
+    });
+  },
+
+  // -- Sessions -------------------------------------------------------------
+
+  replaceSessions: (hostId, sessionList) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      const nextSessions: Record<string, HostSessionSummary> = {};
+      for (const s of sessionList) {
+        nextSessions[s.id] = s;
+      }
+      // Skip update if session records are identical.
+      const prev = existing.sessions;
+      const prevKeys = Object.keys(prev);
+      const nextKeys = Object.keys(nextSessions);
+      if (prevKeys.length === nextKeys.length) {
+        let identical = true;
+        for (const key of nextKeys) {
+          if (prev[key] !== nextSessions[key]) {
+            identical = false;
+            break;
+          }
+        }
+        if (identical) return state;
+      }
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: { ...existing, sessions: nextSessions },
+        },
+      };
+    });
+  },
+
+  upsertSession: (hostId, session) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      if (existing.sessions[session.id] === session) return state;
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: {
+            ...existing,
+            sessions: { ...existing.sessions, [session.id]: session },
+          },
+        },
+      };
+    });
+  },
+
+  removeSession: (hostId, sessionId) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      if (!(sessionId in existing.sessions)) return state;
+
+      const nextSessions = { ...existing.sessions };
+      delete nextSessions[sessionId];
+      const nextStatuses = { ...existing.statuses };
+      delete nextStatuses[sessionId];
+      const nextUnread = { ...existing.unreadBySession };
+      delete nextUnread[sessionId];
+
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: {
+            ...existing,
+            sessions: nextSessions,
+            statuses: nextStatuses,
+            unreadBySession: nextUnread,
+          },
+        },
+      };
+    });
+  },
+
+  // -- Status ---------------------------------------------------------------
+
+  setSessionStatus: (hostId, sessionId, status) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+
+      if (status === 'idle') {
+        if (!(sessionId in existing.statuses)) return state;
+        const nextStatuses = { ...existing.statuses };
+        delete nextStatuses[sessionId];
+        return {
+          hosts: {
+            ...state.hosts,
+            [hostId]: { ...existing, statuses: nextStatuses },
+          },
+        };
+      }
+
+      const prev = existing.statuses[sessionId];
+      if (prev && prev.status === status) return state;
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: {
+            ...existing,
+            statuses: { ...existing.statuses, [sessionId]: { status } },
+          },
+        },
+      };
+    });
+  },
+
+  // -- Unread ---------------------------------------------------------------
+
+  markSessionUnread: (hostId, sessionId, count = 1) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      const prev = existing.unreadBySession[sessionId] ?? 0;
+      if (prev === count) return state;
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: {
+            ...existing,
+            unreadBySession: { ...existing.unreadBySession, [sessionId]: count },
+          },
+        },
+      };
+    });
+  },
+
+  clearSessionUnread: (hostId, sessionId) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      if (!(sessionId in existing.unreadBySession)) return state;
+      const nextUnread = { ...existing.unreadBySession };
+      delete nextUnread[sessionId];
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: { ...existing, unreadBySession: nextUnread },
+        },
+      };
+    });
+  },
+
+  // -- Bulk operations ------------------------------------------------------
+
+  replaceHostSnapshot: (hostId, snapshot) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      
+      // Preserve local unread counts for sessions that exist in the snapshot
+      // Remove unread counts for sessions that are NOT in the snapshot
+      const preservedUnread = existing?.unreadBySession ?? {};
+      const nextUnread: Record<string, number> = {};
+      
+      // Keep unread for sessions that exist in the snapshot
+      for (const sessionId of Object.keys(snapshot.sessions)) {
+        if (sessionId in preservedUnread) {
+          nextUnread[sessionId] = preservedUnread[sessionId];
+        }
+      }
+      
+      // Add new unread counts from snapshot for sessions that don't exist locally
+      if (snapshot.unreadBySession) {
+        for (const [sessionId, count] of Object.entries(snapshot.unreadBySession)) {
+          if (!(sessionId in nextUnread)) {
+            nextUnread[sessionId] = count;
+          }
+        }
+      }
+      
+      const next: HostRuntimeState = {
+        descriptor: snapshot.descriptor,
+        connection: snapshot.connection,
+        projects: snapshot.projects,
+        sessions: { ...snapshot.sessions },
+        statuses: { ...snapshot.statuses },
+        unreadBySession: nextUnread,
+      };
+      if (!existing) {
+        return { hosts: { ...state.hosts, [hostId]: next } };
+      }
+      // Shallow comparison for idempotency.
+      if (
+        existing.descriptor === next.descriptor &&
+        existing.connection === next.connection &&
+        existing.projects === next.projects &&
+        existing.sessions === next.sessions &&
+        existing.statuses === next.statuses &&
+        existing.unreadBySession === next.unreadBySession
+      ) {
+        return state;
+      }
+      return { hosts: { ...state.hosts, [hostId]: next } };
+    });
+  },
+
+  clearHostRuntimeState: (hostId) => {
+    set((state) => {
+      const existing = state.hosts[hostId];
+      if (!existing) return state;
+      return {
+        hosts: {
+          ...state.hosts,
+          [hostId]: {
+            ...existing,
+            connection: { state: 'disconnected' },
+            projects: [],
+            sessions: {},
+            statuses: {},
+            unreadBySession: {},
+          },
+        },
+      };
+    });
+  },
+}));

--- a/packages/ui/src/multi-host/selectors.ts
+++ b/packages/ui/src/multi-host/selectors.ts
@@ -1,0 +1,167 @@
+/**
+ * Memoized selectors for the multi-host store.
+ *
+ * Every selector returns stable references when the underlying slice has not
+ * changed, so React consumers re-render only when their data actually changes.
+ */
+
+import { useMultiHostStore, type HostRuntimeState } from './multi-host-store';
+import type { HostId, HostProjectSummary, HostSessionRef, HostSessionStatus, HostSessionSummary } from './types';
+
+// ---------------------------------------------------------------------------
+// Stable empty values for referential stability
+// ---------------------------------------------------------------------------
+
+const EMPTY_SESSIONS: Record<string, HostSessionSummary> = {};
+const EMPTY_PROJECTS: HostProjectSummary[] = [];
+
+// ---------------------------------------------------------------------------
+// Primitive selectors
+// ---------------------------------------------------------------------------
+
+/** Select a single host's runtime state. */
+export const selectHost = (hostId: HostId): HostRuntimeState | undefined =>
+  useMultiHostStore.getState().hosts[hostId];
+
+/** Select all hosts as a record. */
+export const selectHosts = (): Record<string, HostRuntimeState> =>
+  useMultiHostStore.getState().hosts;
+
+// ---------------------------------------------------------------------------
+// Derived selectors (return stable references when inputs are unchanged)
+// ---------------------------------------------------------------------------
+
+/** Select the sessions map for a host. */
+export const selectHostSessions = (hostId: HostId): Record<string, HostSessionSummary> => {
+  const host = useMultiHostStore.getState().hosts[hostId];
+  return host?.sessions ?? EMPTY_SESSIONS;
+};
+
+/** Select the projects list for a host. */
+export const selectHostProjects = (hostId: HostId): HostRuntimeState['projects'] => {
+  const host = useMultiHostStore.getState().hosts[hostId];
+  return host?.projects ?? EMPTY_PROJECTS;
+};
+
+/** Look up a session by its scoped ref (hostId + sessionId). */
+export const selectSessionByRef = (ref: HostSessionRef): HostSessionSummary | undefined => {
+  const host = useMultiHostStore.getState().hosts[ref.hostId];
+  return host?.sessions[ref.sessionId];
+};
+
+/** Look up session status by its scoped ref. */
+export const selectSessionStatusByRef = (ref: HostSessionRef): HostSessionStatus | undefined => {
+  const host = useMultiHostStore.getState().hosts[ref.hostId];
+  return host?.statuses[ref.sessionId];
+};
+
+/** Total unread count for a specific host. */
+export const selectUnreadCountByHost = (hostId: HostId): number => {
+  const host = useMultiHostStore.getState().hosts[hostId];
+  if (!host) return 0;
+  let total = 0;
+  for (const count of Object.values(host.unreadBySession)) {
+    total += count;
+  }
+  return total;
+};
+
+/** Grand total unread across all hosts. */
+export const selectTotalUnreadCount = (): number => {
+  const hosts = useMultiHostStore.getState().hosts;
+  let total = 0;
+  for (const host of Object.values(hosts)) {
+    for (const count of Object.values(host.unreadBySession)) {
+      total += count;
+    }
+  }
+  return total;
+};
+
+/**
+ * Select hostIds that have at least one non-idle session.
+ * Returns a new array only when the set of active hostIds changes.
+ */
+export const selectHostsWithActivity = (): HostId[] => {
+  const hosts = useMultiHostStore.getState().hosts;
+  const active: HostId[] = [];
+  for (const [hostId, host] of Object.entries(hosts)) {
+    for (const sessionStatus of Object.values(host.statuses)) {
+      if (sessionStatus.status !== 'idle') {
+        active.push(hostId as HostId);
+        break;
+      }
+    }
+  }
+  return active;
+};
+
+// ---------------------------------------------------------------------------
+// React hooks (thin wrappers around useStore with selectors)
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe to a specific host's runtime state. Re-renders only when this
+ * host's reference changes.
+ */
+export const useHost = (hostId: HostId): HostRuntimeState | undefined =>
+  useMultiHostStore((s) => s.hosts[hostId]);
+
+/** Subscribe to the full hosts map. */
+export const useHosts = (): Record<string, HostRuntimeState> =>
+  useMultiHostStore((s) => s.hosts);
+
+/** Subscribe to a host's sessions. */
+export const useHostSessions = (hostId: HostId): Record<string, HostSessionSummary> =>
+  useMultiHostStore((s) => s.hosts[hostId]?.sessions ?? EMPTY_SESSIONS);
+
+/** Subscribe to a host's projects. */
+export const useHostProjects = (hostId: HostId): HostRuntimeState['projects'] =>
+  useMultiHostStore((s) => s.hosts[hostId]?.projects ?? EMPTY_PROJECTS);
+
+/** Subscribe to a session by scoped ref. */
+export const useSessionByRef = (ref: HostSessionRef): HostSessionSummary | undefined =>
+  useMultiHostStore((s) => s.hosts[ref.hostId]?.sessions[ref.sessionId]);
+
+/** Subscribe to session status by scoped ref. */
+export const useSessionStatusByRef = (ref: HostSessionRef): HostSessionStatus | undefined =>
+  useMultiHostStore((s) => s.hosts[ref.hostId]?.statuses[ref.sessionId]);
+
+/** Subscribe to a host's total unread count. */
+export const useUnreadCountByHost = (hostId: HostId): number =>
+  useMultiHostStore((s) => {
+    const host = s.hosts[hostId];
+    if (!host) return 0;
+    let total = 0;
+    for (const count of Object.values(host.unreadBySession)) {
+      total += count;
+    }
+    return total;
+  });
+
+/** Subscribe to the grand total unread count. */
+export const useTotalUnreadCount = (): number =>
+  useMultiHostStore((s) => {
+    let total = 0;
+    for (const host of Object.values(s.hosts)) {
+      for (const count of Object.values(host.unreadBySession)) {
+        total += count;
+      }
+    }
+    return total;
+  });
+
+/** Subscribe to the list of hostIds with active (non-idle) sessions. */
+export const useHostsWithActivity = (): HostId[] =>
+  useMultiHostStore((s) => {
+    const active: HostId[] = [];
+    for (const [hostId, host] of Object.entries(s.hosts)) {
+      for (const sessionStatus of Object.values(host.statuses)) {
+        if (sessionStatus.status !== 'idle') {
+          active.push(hostId as HostId);
+          break;
+        }
+      }
+    }
+    return active;
+  });

--- a/packages/ui/src/multi-host/types.ts
+++ b/packages/ui/src/multi-host/types.ts
@@ -1,0 +1,149 @@
+/**
+ * Multi-host domain types for monitoring multiple OpenChamber servers
+ * concurrently. This module is a standalone, lightweight, UI-free, network-free
+ * domain layer — no transport, event subscription, or runtime switching logic.
+ */
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/** Stable identifier for a remote (or local) OpenChamber host. */
+export type HostId = string & { readonly __brand: 'HostId' };
+
+/** Branded session identifier scoped to a single host. */
+export type ScopedSessionId = string & { readonly __brand: 'ScopedSessionId' };
+
+// ---------------------------------------------------------------------------
+// Transport descriptors (discriminated union for type safety)
+// ---------------------------------------------------------------------------
+
+/** How a host is reached. Discriminated union ensures type-safe transport configuration. */
+export type HostTransportKind = 'local' | 'direct' | 'ssh' | 'relay';
+
+/** Base transport configuration shared by all transport types. */
+type HostTransportBase = {
+  /** Extra request headers sent with API calls to this host. */
+  requestHeaders?: Record<string, string>;
+};
+
+/** Local transport - connects to a local OpenChamber instance. */
+type HostTransportLocal = HostTransportBase & {
+  kind: 'local';
+  /** Base URL for local connection. */
+  apiUrl?: string;
+};
+
+/** Direct transport - connects directly to a remote instance via URL. */
+type HostTransportDirect = HostTransportBase & {
+  kind: 'direct';
+  /** Base URL for direct connection. */
+  apiUrl: string;
+};
+
+/** SSH transport - connects via SSH tunnel. */
+type HostTransportSsh = HostTransportBase & {
+  kind: 'ssh';
+  /** SSH forwarded endpoint (host:port). */
+  sshEndpoint: string;
+};
+
+/** Relay transport - connects via private relay. */
+type HostTransportRelay = HostTransportBase & {
+  kind: 'relay';
+  /** Relay server id. */
+  relayServerId: string;
+};
+
+/** Discriminated union of all transport types. */
+export type HostTransport = HostTransportLocal | HostTransportDirect | HostTransportSsh | HostTransportRelay;
+
+export type HostDescriptor = {
+  /** Application-assigned stable id. */
+  readonly hostId: HostId;
+  /** Human-readable display name. */
+  label: string;
+  /** How the client reaches this host. Discriminated union ensures type safety. */
+  transport: HostTransport;
+};
+
+// ---------------------------------------------------------------------------
+// Connection state
+// ---------------------------------------------------------------------------
+
+export type HostConnectionState =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'error';
+
+export type HostConnectionSummary = {
+  state: HostConnectionState;
+  /** ISO-8601 timestamp of last successful connection, if any. */
+  connectedAt?: string;
+  /** Human-readable error message when state is 'error'. */
+  error?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Project / session summaries
+// ---------------------------------------------------------------------------
+
+/** Lightweight project identity reported by a host. */
+export type HostProjectSummary = {
+  readonly id: string;
+  name?: string;
+  directory?: string;
+};
+
+/**
+ * A session reference that is always scoped to a specific host.
+ * The combination (hostId, sessionId) is unique; sessionId alone is NOT
+ * globally unique across hosts.
+ *
+ * This ref must contain enough information for the activation controller to:
+ * 1. Switch to the correct host
+ * 2. Open the corresponding project/worktree
+ * 3. Select the session
+ */
+export type HostSessionRef = {
+  readonly hostId: HostId;
+  readonly sessionId: string;
+  /** Directory path for the project/worktree. Required for activation controller. */
+  readonly directory: string;
+  /** Project identifier. Required for activation controller. */
+  readonly projectId: string;
+};
+
+/** Summary of a session as reported by its host. */
+export type HostSessionSummary = {
+  readonly id: string;
+  title?: string;
+  directory?: string;
+  projectId?: string;
+  createdAt?: number;
+  updatedAt?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Session status
+// ---------------------------------------------------------------------------
+
+/** Per-session busy / retry status reported by a host. */
+export type HostSessionStatus = {
+  status: 'idle' | 'busy' | 'retry';
+};
+
+// ---------------------------------------------------------------------------
+// Host snapshot (full state for a single host)
+// ---------------------------------------------------------------------------
+
+/** Complete local state for a single host, used by replaceHostSnapshot. */
+export type HostSnapshot = {
+  descriptor: HostDescriptor;
+  connection: HostConnectionSummary;
+  projects: HostProjectSummary[];
+  sessions: Record<string, HostSessionSummary>;
+  statuses: Record<string, HostSessionStatus>;
+  unreadBySession: Record<string, number>;
+};


### PR DESCRIPTION
## Summary

Implement the multi-host monitor layer for concurrent monitoring of multiple OpenChamber servers. This is PR 2 of 4 in the multi-host feature.

## What this PR adds

### New files in `packages/ui/src/multi-host/monitor/`

| File | Purpose |
|------|---------|
| `types.ts` | Internal types: transport abstraction, normalized events, scheduler, reconnect policy |
| `reconnect-policy.ts` | Exponential backoff with jitter, per-host isolated |
| `event-normalizer.ts` | Converts server events to `NormalizedHostEvent`, drops irrelevant events |
| `reconciliation.ts` | Periodic full refresh with unread preservation |
| `host-monitor.ts` | Per-host monitor with independent lifecycle, transport, event stream |
| `multi-host-supervisor.ts` | Orchestrator: start/stop/refresh per host |
| `index.ts` | Public API barrel |

### Tests (52 tests, all passing)

- `reconnect-policy.test.ts` — backoff timing, reset, per-host isolation
- `event-normalizer.test.ts` — session CRUD, status, irrelevant event filtering
- `reconciliation.test.ts` — snapshot construction, error handling
- `host-monitor.test.ts` — dual-host isolation, event processing, lifecycle
- `multi-host-supervisor.test.ts` — orchestrator operations, idempotency
- `unread-preservation.test.ts` — replaceHostSnapshot unread semantics

## Architecture

```
MultiHostSupervisor
  ├── HostMonitor(host A)
  ├── HostMonitor(host B)
  └── HostMonitor(host C)
```

Each `HostMonitor` independently manages:
- Transport connection (local/direct/SSH)
- Event stream subscription
- Reconnect with exponential backoff
- Periodic reconciliation
- Store writes via frozen public API

## What this PR does NOT implement

- Unified sidebar UI
- Host/session activation
- Runtime switching
- Private Relay multi-connection registry
- Final app wiring
- Electron lifecycle integration

## Frozen contract compliance

- Frozen files (`types.ts`, `host-registry.ts`, `multi-host-store.ts`, `selectors.ts`, `index.ts`) are NOT modified
- `HostTransport` discriminated union used correctly
- `HostSessionRef` always has `hostId`, `sessionId`, `directory`, `projectId`
- `replaceHostSnapshot` preserves unread, removes stale sessions/statuses
- Selectors use stable `EMPTY_SESSIONS`/`EMPTY_PROJECTS` references
- All imports go through `@/multi-host`

## Server endpoints used

| Endpoint | Purpose |
|----------|---------|
| `GET /project/list` | Project summaries |
| `GET /session` | Session list |
| `GET /session/status` | Session status map |

## Event types processed

| Event | Action |
|-------|--------|
| `session.created` | Upsert session |
| `session.updated` | Upsert session |
| `session.deleted` | Remove session |
| `session.status` | Update status |
| `session.idle` | Set idle |
| `session.error` | Set idle |

All other events (message deltas, tool progress, LSP, etc.) are silently dropped.

## Reconnect strategy

- Base: 250ms, exponential growth, max exponent 8
- Visible+online: cap 5s
- Hidden/offline: cap 60s
- Permanent auth errors: 60s cap
- Jitter added per-host to avoid thundering herd

## Integration PR guidance

The Integration PR should:
1. Import `createMultiHostSupervisor` from `@/multi-host/monitor`
2. Create a `TransportFactory` that builds transports from `HostDescriptor`
3. Call `supervisor.startHost(hostId, descriptor)` for each saved remote instance
4. Listen for store changes to drive the sidebar UI