### PR TITLE
fix(chat): anchor prompt navigator to last turn at chat bottom

### DIFF
--- a/packages/ui/src/components/chat/lib/scroll/scrollSpy.ts
+++ b/packages/ui/src/components/chat/lib/scroll/scrollSpy.ts
@@ -16,6 +16,11 @@ type ScrollSpyInput = {
 // stable while scrolling inside a long turn (no visibility-ratio flip-flop).
 const READ_LINE_OFFSET_PX = 100;
 
+// When the container is scrolled to (or almost to) the bottom, the last turn
+// is what the user is reading even if it is too short for its top edge to
+// ever cross the reading line — force-activate it in that case.
+const BOTTOM_ANCHOR_EPSILON_PX = 8;
+
 const pickOffsetTurnId = (list: OffsetTurn[], cutoff: number): string | undefined => {
     if (list.length === 0) {
         return undefined;
@@ -98,7 +103,10 @@ export const createScrollSpy = (input: ScrollSpyInput) => {
             refreshOffsets();
         }
 
-        const next = pickOffsetTurnId(offsets, container.scrollTop + READ_LINE_OFFSET_PX);
+        const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+        const next = distanceFromBottom <= BOTTOM_ANCHOR_EPSILON_PX
+            ? offsets[offsets.length - 1]?.id
+            : pickOffsetTurnId(offsets, container.scrollTop + READ_LINE_OFFSET_PX);
         if (!next || next === active) {
             return;
         }

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -964,7 +964,7 @@ export const useUIStore = create<UIStore>()(
         userMessageRenderingMode: 'markdown',
         collapsibleUserMessages: true,
         stickyUserHeader: false,
-        promptNavigatorEnabled: false,
+        promptNavigatorEnabled: true,
         expandedEditorToolbar: false,
         showSplitAssistantMessageActions: false,
         allowPromptingSubagentSessions: false,


### PR DESCRIPTION
## What

When sitting at the bottom of the chat, the prompt navigator rail kept the previous prompt highlighted if the final user+assistant pair was short. The scroll spy marks active the last turn whose top edge crossed the reading line (100px below the container top) — a short final turn never reaches that line, so it could never win.

## Fix

When the scroll container is at (or within 8px of) the bottom, the last turn is force-activated; everywhere else the monotonic reading-line rule is unchanged.

## Verification

Headless check on a long session: initial load at bottom and explicit scroll-to-bottom both activate the last tick; scrolling up 600px hands the highlight back to the previous turn. `bun run type-check` and `bun run lint` green.