### PR TITLE
fix(desktop): keep local instance label during boot

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -68,13 +68,14 @@ import { forceKillTerminal } from '@/lib/terminalApi';
 import { useTerminalStore } from '@/stores/useTerminalStore';
 import { ProjectActionsButton } from '@/components/layout/ProjectActionsButton';
 import { SessionSwitcherDropdown } from '@/components/session/SessionSwitcherDropdown';
-import { canUseElectronDesktopIPC, invokeDesktop, isDesktopLocalOriginActive, isDesktopShell, isVSCodeRuntime, startDesktopWindowDrag, type UpdateInfo } from '@/lib/desktop';
-import { desktopHostsGet, getDesktopHostApiUrl, locationMatchesHost, redactSensitiveUrl } from '@/lib/desktopHosts';
+import { canUseElectronDesktopIPC, invokeDesktop, isDesktopShell, isVSCodeRuntime, startDesktopWindowDrag, type UpdateInfo } from '@/lib/desktop';
+import { desktopHostsGet, redactSensitiveUrl } from '@/lib/desktopHosts';
 import { Icon } from "@/components/icon/Icon";
 import { useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { getRuntimeBearerTokenSync } from '@/lib/runtime-auth';
-import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
+import { getRuntimeApiBaseUrl, getRuntimeKey } from '@/lib/runtime-switch';
+import { resolveDesktopInstanceDisplay } from '@/lib/instanceDisplay';
 import type { Session } from '@opencode-ai/sdk/v2/client';
 import type { IconName } from "@/components/icon/icons";
 
@@ -859,7 +860,7 @@ export const Header: React.FC<HeaderProps> = ({
   const [isMobileRateLimitsOpen, setIsMobileRateLimitsOpen] = React.useState(false);
   const [isDesktopServicesOpen, setIsDesktopServicesOpen] = React.useState(false);
   const [isUsageRefreshSpinning, setIsUsageRefreshSpinning] = React.useState(false);
-  const [currentInstanceLabel, setCurrentInstanceLabel] = React.useState('Local');
+  const [currentInstanceLabel, setCurrentInstanceLabel] = React.useState(() => t('desktopHostSwitcher.instance.local'));
   const [currentInstanceIsLocal, setCurrentInstanceIsLocal] = React.useState(true);
   const [remoteUpdateDialogOpen, setRemoteUpdateDialogOpen] = React.useState(false);
   const [remoteUpdateInfo, setRemoteUpdateInfo] = React.useState<UpdateInfo | null>(null);
@@ -888,38 +889,32 @@ export const Header: React.FC<HeaderProps> = ({
     }
 
     try {
-      if (isDesktopLocalOriginActive()) {
-        setCurrentInstanceLabel('Local');
-        setCurrentInstanceIsLocal(true);
-        return;
-      }
-      setCurrentInstanceIsLocal(false);
-
       const cfg = await desktopHostsGet();
-      const localOrigin = window.__OPENCHAMBER_LOCAL_ORIGIN__ || window.location.origin;
-      const runtimeApiBaseUrl = getRuntimeApiBaseUrl();
-
-      if (runtimeApiBaseUrl && locationMatchesHost(runtimeApiBaseUrl, localOrigin)) {
-        setCurrentInstanceLabel('Local');
-        setCurrentInstanceIsLocal(true);
-        return;
-      }
-
-      const match = cfg.hosts.find((host) => {
-        return runtimeApiBaseUrl ? locationMatchesHost(runtimeApiBaseUrl, getDesktopHostApiUrl(host)) : false;
+      const display = resolveDesktopInstanceDisplay({
+        isPackagedElectronPage: window.location.origin === 'openchamber-ui://app',
+        runtimeKey: getRuntimeKey(),
+        runtimeApiBaseUrl: getRuntimeApiBaseUrl(),
+        localOrigin: cfg.localOrigin || window.__OPENCHAMBER_LOCAL_ORIGIN__ || '',
+        hosts: cfg.hosts,
       });
 
-      if (match?.label?.trim()) {
-        setCurrentInstanceLabel(redactSensitiveUrl(match.label.trim()));
+      if (display.kind === 'local') {
+        setCurrentInstanceLabel(t('desktopHostSwitcher.instance.local'));
+        setCurrentInstanceIsLocal(true);
         return;
       }
 
-      setCurrentInstanceLabel('Instance');
+      setCurrentInstanceIsLocal(false);
+      setCurrentInstanceLabel(
+        display.kind === 'host'
+          ? redactSensitiveUrl(display.label)
+          : t('desktopHostSwitcher.instance.fallback'),
+      );
     } catch {
-      setCurrentInstanceLabel('Local');
-      setCurrentInstanceIsLocal(true);
+      // Preserve the last resolved display identity when the authoritative host
+      // config is temporarily unavailable.
     }
-  }, [isDesktopApp]);
+  }, [isDesktopApp, t]);
 
   useEffect(() => {
     void refreshCurrentInstanceLabel();

--- a/packages/ui/src/lib/instanceDisplay.test.ts
+++ b/packages/ui/src/lib/instanceDisplay.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveDesktopInstanceDisplay } from './instanceDisplay';
+
+describe('resolveDesktopInstanceDisplay', () => {
+  test('identifies packaged Electron local runtime when the initial local origin is missing', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: true,
+      runtimeKey: 'url:http://127.0.0.1:43123',
+      runtimeApiBaseUrl: 'http://127.0.0.1:43123',
+      localOrigin: '',
+      hosts: [],
+    })).toEqual({ kind: 'local' });
+  });
+
+  test('identifies Local when the runtime API matches the authoritative local origin', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: false,
+      runtimeKey: 'url:http://127.0.0.1:43123',
+      runtimeApiBaseUrl: 'http://127.0.0.1:43123',
+      localOrigin: 'http://127.0.0.1:43123',
+      hosts: [],
+    })).toEqual({ kind: 'local' });
+  });
+
+  test('does not infer Local from loopback alone outside packaged Electron', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: false,
+      runtimeKey: 'url:http://127.0.0.1:43123',
+      runtimeApiBaseUrl: 'http://127.0.0.1:43123',
+      localOrigin: '',
+      hosts: [],
+    })).toEqual({ kind: 'generic' });
+  });
+
+  test('prefers a host-specific runtime key over the packaged local fallback', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: true,
+      runtimeKey: 'host:ssh-workstation',
+      runtimeApiBaseUrl: 'http://127.0.0.1:43123',
+      localOrigin: '',
+      hosts: [{ id: 'ssh-workstation', label: 'Workstation', url: 'ssh://workstation', apiUrl: 'http://127.0.0.1:43123' }],
+    })).toEqual({ kind: 'host', label: 'Workstation' });
+  });
+
+  test('prefers a configured loopback host label over the packaged local fallback', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: true,
+      runtimeKey: 'url:http://127.0.0.1:43123',
+      runtimeApiBaseUrl: 'http://127.0.0.1:43123',
+      localOrigin: '',
+      hosts: [{ id: 'ssh-workstation', label: 'Workstation', url: 'ssh://workstation', apiUrl: 'http://127.0.0.1:43123' }],
+    })).toEqual({ kind: 'host', label: 'Workstation' });
+  });
+
+  test('keeps configured direct remote URLs labeled with their host', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: true,
+      runtimeKey: 'host:remote',
+      runtimeApiBaseUrl: 'https://remote.example',
+      localOrigin: '',
+      hosts: [{ id: 'remote', label: 'Remote', url: 'https://remote.example' }],
+    })).toEqual({ kind: 'host', label: 'Remote' });
+  });
+
+  test('keeps relay host identity even when its virtual API base is loopback', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: true,
+      runtimeKey: 'host:relay-home',
+      runtimeApiBaseUrl: 'http://127.0.0.1:43123',
+      localOrigin: '',
+      hosts: [{ id: 'relay-home', label: 'Home Relay', url: 'relay://server-id' }],
+    })).toEqual({ kind: 'host', label: 'Home Relay' });
+  });
+
+  test('does not infer Local for an unconfigured direct-E2EE loopback runtime', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: true,
+      runtimeKey: 'http://127.0.0.1:43123',
+      runtimeApiBaseUrl: 'http://127.0.0.1:43123',
+      localOrigin: '',
+      hosts: [],
+    })).toEqual({ kind: 'generic' });
+  });
+
+  test('does not infer Local for an unknown host-specific runtime key', () => {
+    expect(resolveDesktopInstanceDisplay({
+      isPackagedElectronPage: true,
+      runtimeKey: 'host:missing',
+      runtimeApiBaseUrl: 'http://127.0.0.1:43123',
+      localOrigin: '',
+      hosts: [],
+    })).toEqual({ kind: 'generic' });
+  });
+});

--- a/packages/ui/src/lib/instanceDisplay.ts
+++ b/packages/ui/src/lib/instanceDisplay.ts
@@ -1,0 +1,66 @@
+import { getDesktopHostApiUrl, locationMatchesHost, type DesktopHost } from '@/lib/desktopHosts';
+import { isLoopbackHttpUrl } from '@/lib/url';
+
+export type DesktopInstanceDisplay =
+  | { kind: 'local' }
+  | { kind: 'host'; label: string }
+  | { kind: 'generic' };
+
+export type DesktopInstanceDisplayInput = {
+  isPackagedElectronPage: boolean;
+  runtimeKey: string;
+  runtimeApiBaseUrl: string;
+  localOrigin: string;
+  hosts: DesktopHost[];
+};
+
+export const resolveDesktopInstanceDisplay = ({
+  isPackagedElectronPage,
+  runtimeKey,
+  runtimeApiBaseUrl,
+  localOrigin,
+  hosts,
+}: DesktopInstanceDisplayInput): DesktopInstanceDisplay => {
+  const normalizedRuntimeKey = runtimeKey.trim();
+  if (normalizedRuntimeKey.startsWith('host:')) {
+    const hostId = normalizedRuntimeKey.slice('host:'.length);
+    const host = hosts.find((candidate) => candidate.id === hostId);
+    return host?.label.trim()
+      ? { kind: 'host', label: host.label.trim() }
+      : { kind: 'generic' };
+  }
+
+  const configuredHost = hosts.find((host) => (
+    runtimeApiBaseUrl
+      ? locationMatchesHost(runtimeApiBaseUrl, getDesktopHostApiUrl(host))
+      : false
+  ));
+  if (configuredHost) {
+    return configuredHost.label.trim()
+      ? { kind: 'host', label: configuredHost.label.trim() }
+      : { kind: 'generic' };
+  }
+
+  const canResolveAsLocal = (
+    normalizedRuntimeKey === 'local'
+    || !normalizedRuntimeKey
+    || normalizedRuntimeKey.startsWith('url:')
+  );
+  if (!canResolveAsLocal) {
+    return { kind: 'generic' };
+  }
+
+  if (normalizedRuntimeKey === 'local') {
+    return { kind: 'local' };
+  }
+
+  if (runtimeApiBaseUrl && localOrigin && locationMatchesHost(runtimeApiBaseUrl, localOrigin)) {
+    return { kind: 'local' };
+  }
+
+  if (isPackagedElectronPage && isLoopbackHttpUrl(runtimeApiBaseUrl)) {
+    return { kind: 'local' };
+  }
+
+  return { kind: 'generic' };
+};


### PR DESCRIPTION
## Summary

On packaged Electron desktop, the header briefly shows the generic `Instance` label at startup even when the current runtime is Local. The instance picker itself already reads `Local`, so the mismatch is visible at every boot until the label settles.

## Root cause

Label resolution in `Header.tsx` first checked `isDesktopLocalOriginActive()`, then matched the current runtime API base against `__OPENCHAMBER_LOCAL_ORIGIN__` (posted by the Electron preload). On packaged builds the renderer can begin resolving the header before that preload hint has been posted, so both checks miss and resolution falls through to the generic `Instance` branch.

## Fix

Move resolution into a pure `resolveDesktopInstanceDisplay` helper and apply the checks in the following order:

1. Host-specific runtime keys (`host:*`). SSH, Relay, and direct-URL hosts keep their configured label.
2. Configured host URLs. Any host whose `apiUrl` matches the current runtime API base wins over the local fallback, including relay identities whose virtual API base is loopback.
3. Authoritative local origin. Matches the preload hint once it has arrived.
4. Packaged Electron loopback fallback. Treats a loopback API base on the `openchamber-ui://app` page as `Local` when nothing above resolved. This is what fixes the boot race; remotes are already handled by (1) and (2), so they can't be mislabeled here.

If none of the above resolves, the helper returns `generic` and the header shows the localized fallback string.

The consumer also stops overwriting the current label with `Local` when the host-config fetch fails, so a transient failure no longer replaces a valid remote label.

## Validation

- 49 focused tests pass, including packaged boot fallback, host precedence, relay-over-loopback identity, and unconfigured direct-E2EE loopback.
- 91-test extended QA suite green.
- `bun run type-check` and `bun run lint` clean in `packages/ui`.
- Web assets build clean.
- LSP diagnostics clean on changed files.
- Packaged Electron CDP reproduction: the header reads `Local` from the first paint on cold boot.
