### PR TITLE
fix(sync): route SDK global events through runtime fetch

### DIFF
--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -22,6 +22,13 @@ There are **two distinct session data scopes** in the UI:
 
 These two scopes are intentionally different, but they are no longer equal peers for live UI truth.
 
+### Global SSE fallback transport
+
+The SDK global event stream must use the sync-layer fetch adapter. Exact GET requests to `/global/event` or
+`/api/global/event` are canonicalized to the relative runtime route `/api/global/event`, preserving the query and normalized
+request options. This keeps SSE fallback inside `runtimeFetch` for direct and relayed runtimes; every other SDK request passes
+through unchanged.
+
 ### Why both exist
 
 The directory-scoped sync stores are **not** a complete global view.

--- a/packages/ui/src/sync/event-pipeline.test.ts
+++ b/packages/ui/src/sync/event-pipeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client"
 import { createEventPipeline } from "./event-pipeline"
+import { sdkGlobalEventFetch } from "./sdk-global-event-fetch"
 
 const failAfter = (ms: number) => new Promise<never>((_, reject) => {
   setTimeout(() => reject(new Error("Timed out waiting for event pipeline flush")), ms)
@@ -56,6 +57,39 @@ function createSdk(events: Event[], streamFinished: () => void): OpencodeClient 
 }
 
 describe("createEventPipeline", () => {
+  test("passes the canonical runtime fetch adapter to the SDK SSE stream", async () => {
+    let resolveFetch!: (fetchOverride: typeof fetch | undefined) => void
+    const receivedFetch = new Promise<typeof fetch | undefined>((resolve) => {
+      resolveFetch = resolve
+    })
+    const sdk = {
+      global: {
+        event: async (options: { fetch?: typeof fetch; signal: AbortSignal }) => {
+          resolveFetch(options.fetch)
+          return {
+            stream: (async function* () {
+              await new Promise<void>((resolve) => {
+                options.signal.addEventListener("abort", () => resolve(), { once: true })
+              })
+              yield { payload: undefined }
+            })(),
+          }
+        },
+      },
+    } as unknown as OpencodeClient
+    const pipeline = createEventPipeline({
+      sdk,
+      onEvent: () => undefined,
+      transport: "sse",
+    })
+
+    try {
+      expect(await Promise.race([receivedFetch, failAfter(500)])).toBe(sdkGlobalEventFetch)
+    } finally {
+      pipeline.cleanup()
+    }
+  })
+
   test("preserves part update order around text deltas", async () => {
     let resolveStreamFinished!: () => void
     const streamFinished = new Promise<void>((resolve) => {

--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -19,6 +19,7 @@ import { clearRuntimeUrlAuthToken, refreshRuntimeUrlAuthToken } from "@/lib/runt
 import { type RelayTunnelWebSocket } from "@/lib/relay/tunnel-client"
 import { openRuntimeWebSocket } from "@/lib/relay/runtime-socket"
 import { syncDebug } from "./debug"
+import { sdkGlobalEventFetch } from "./sdk-global-event-fetch"
 
 const FLUSH_FRAME_MS = 33
 const BACKPRESSURE_FLUSH_FRAME_MS = 200
@@ -518,6 +519,7 @@ export function createEventPipeline(input: EventPipelineInput): EventPipeline {
   const runSseAttempt = async (signal: AbortSignal) => {
     const events = await sdk.global.event({
       signal,
+      fetch: sdkGlobalEventFetch,
       ...(lastEventId && lastEventId.length > 0 ? { headers: { "Last-Event-ID": lastEventId } } : {}),
       onSseEvent: (event: { id?: unknown }) => {
         resetHeartbeat()

--- a/packages/ui/src/sync/sdk-global-event-fetch.test.ts
+++ b/packages/ui/src/sync/sdk-global-event-fetch.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+import { createSdkGlobalEventFetch } from "./sdk-global-event-fetch"
+
+type FetchCall = {
+  input: RequestInfo | URL
+  init?: RequestInit
+}
+
+function createRecorder() {
+  const calls: FetchCall[] = []
+  const fetchRuntime: typeof fetch = async (input, init) => {
+    calls.push({ input, init })
+    return new Response(null, { status: 204 })
+  }
+  return { calls, fetchRuntime }
+}
+
+describe("createSdkGlobalEventFetch", () => {
+  const canonicalUrls = [
+    "https://packaged-ui.example/global/event",
+    "https://packaged-ui.example/api/global/event",
+    "https://remote.example/global/event",
+  ]
+  for (const url of canonicalUrls) {
+    test(`canonicalizes the global event route from ${url}`, async () => {
+      const { calls, fetchRuntime } = createRecorder()
+
+      await createSdkGlobalEventFetch(fetchRuntime)(url)
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.input).toBe("/api/global/event")
+      expect(calls[0]?.init?.method).toBe("GET")
+    })
+  }
+
+  test("preserves query, headers, signal, and normalized request options", async () => {
+    const { calls, fetchRuntime } = createRecorder()
+    const abort = new AbortController()
+    const request = new Request("https://packaged-ui.example/global/event?directory=%2Frepo&cursor=two", {
+      headers: { "Last-Event-ID": "evt_42" },
+      signal: abort.signal,
+      cache: "no-store",
+      credentials: "include",
+      integrity: "sha256-test",
+      keepalive: true,
+      mode: "cors",
+      redirect: "manual",
+      referrer: "https://packaged-ui.example/source",
+      referrerPolicy: "strict-origin",
+    })
+
+    await createSdkGlobalEventFetch(fetchRuntime)(request)
+
+    expect(calls[0]?.input).toBe("/api/global/event?directory=%2Frepo&cursor=two")
+    const init = calls[0]?.init
+    expect(new Headers(init?.headers).get("Last-Event-ID")).toBe("evt_42")
+    const forwardedSignal = init?.signal
+    expect(forwardedSignal).toBeDefined()
+    expect(forwardedSignal?.aborted).toBe(false)
+    expect(init?.method).toBe("GET")
+    expect(init?.cache).toBe("no-store")
+    expect(init?.credentials).toBe("include")
+    expect(init?.integrity).toBe(request.integrity)
+    expect(init?.keepalive).toBe(request.keepalive)
+    expect(init?.mode).toBe("cors")
+    expect(init?.redirect).toBe("manual")
+    expect(init?.referrer).toBe(request.referrer)
+    expect(init?.referrerPolicy).toBe(request.referrerPolicy)
+
+    abort.abort()
+    expect(forwardedSignal?.aborted).toBe(true)
+  })
+
+  const passthroughRequests = [
+    new Request("https://packaged-ui.example/global/event", { method: "POST" }),
+    new Request("https://packaged-ui.example/global/events"),
+    new Request("https://packaged-ui.example/api/event"),
+  ]
+  for (const request of passthroughRequests) {
+    test(`passes ${request.method} ${new URL(request.url).pathname} through as its normalized Request`, async () => {
+      const { calls, fetchRuntime } = createRecorder()
+
+      await createSdkGlobalEventFetch(fetchRuntime)(request)
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.input).toBeInstanceOf(Request)
+      const forwarded = calls[0]?.input
+      expect(forwarded).not.toBe(request)
+      expect(forwarded instanceof Request ? forwarded.url : "").toBe(request.url)
+      expect(forwarded instanceof Request ? forwarded.method : "").toBe(request.method)
+      expect(calls[0]?.init).toBe(undefined)
+    })
+  }
+})

--- a/packages/ui/src/sync/sdk-global-event-fetch.ts
+++ b/packages/ui/src/sync/sdk-global-event-fetch.ts
@@ -1,0 +1,32 @@
+import { runtimeFetch } from "@/lib/runtime-fetch"
+
+export function createSdkGlobalEventFetch(fetchRuntime: typeof fetch): typeof fetch {
+  return async (input, init) => {
+    const request = new Request(input, init)
+    const url = new URL(request.url)
+    const isGlobalEvent = request.method === "GET"
+      && (url.pathname === "/global/event" || url.pathname === "/api/global/event")
+
+    if (!isGlobalEvent) {
+      return fetchRuntime(request)
+    }
+
+    const preservedInit: RequestInit = {
+      method: request.method,
+      headers: request.headers,
+      signal: request.signal,
+      cache: request.cache,
+      credentials: request.credentials,
+      integrity: request.integrity,
+      keepalive: request.keepalive,
+      mode: request.mode,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+    }
+
+    return fetchRuntime(`/api/global/event${url.search}`, preservedInit)
+  }
+}
+
+export const sdkGlobalEventFetch: typeof fetch = createSdkGlobalEventFetch(runtimeFetch)


### PR DESCRIPTION
## Summary

Routes SDK global events through `runtimeFetch` to ensure consistent transport behavior across environments. This allows cross-session updates to inherit authentication, proxy, and private relay settings automatically.

## Root cause

The SDK used a direct fetch for global events, bypassing the `runtimeFetch` adapter. This caused event failures in environments where the origin and authentication headers are managed by the runtime, such as the private relay or packaged desktop builds.

## Fix

- Implemented a `runtimeFetch` adapter for global events.
- Updated the event pipeline to use the adapter for all global requests.
- Preserved query strings, headers, and abort signals in the routed requests.
- Documented transport requirements in `packages/ui/src/sync/DOCUMENTATION.md`.

## Validation

- 11 tests pass in `sdk-global-event-fetch.test.ts` and `event-pipeline.test.ts`.
- Verified preservation of query parameters and headers.
- Confirmed abort signals correctly cancel pending event requests.
- `bun run type-check` and `bun run lint` clean.