### PR TITLE
test(sync): isolate browser globals

### DIFF
--- a/packages/ui/src/sync/__tests__/browser-global-stubs.js
+++ b/packages/ui/src/sync/__tests__/browser-global-stubs.js
@@ -1,0 +1,27 @@
+export function createBrowserGlobalStubScope() {
+  const originalDescriptors = new Map();
+
+  const install = (property, value) => {
+    if (!originalDescriptors.has(property)) {
+      originalDescriptors.set(property, Object.getOwnPropertyDescriptor(globalThis, property));
+    }
+    Object.defineProperty(globalThis, property, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  };
+
+  const restore = () => {
+    for (const [property, descriptor] of originalDescriptors) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, property, descriptor);
+      } else {
+        delete globalThis[property];
+      }
+    }
+    originalDescriptors.clear();
+  };
+
+  return { install, restore };
+}

--- a/packages/ui/src/sync/__tests__/event-pipeline-online.test.js
+++ b/packages/ui/src/sync/__tests__/event-pipeline-online.test.js
@@ -1,14 +1,11 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { createEventPipeline } from '../event-pipeline';
+import { createBrowserGlobalStubScope } from './browser-global-stubs';
 
-const savedDocument = globalThis.document;
-const savedWindow = globalThis.window;
-const savedNavigator = globalThis.navigator;
+const browserGlobals = createBrowserGlobalStubScope();
 
 afterEach(() => {
-  globalThis.document = savedDocument;
-  globalThis.window = savedWindow;
-  globalThis.navigator = savedNavigator;
+  browserGlobals.restore();
 });
 
 // Multi-listener event-target stub. The simpler single-slot stub used in
@@ -38,11 +35,11 @@ function createEventTarget(extras = {}) {
 
 describe('createEventPipeline — online event', () => {
   it('cuts the inter-attempt wait short when `online` fires after disconnect', async () => {
-    globalThis.document = createEventTarget({ visibilityState: 'visible' });
-    globalThis.window = createEventTarget({
+    browserGlobals.install('document', createEventTarget({ visibilityState: 'visible' }));
+    browserGlobals.install('window', createEventTarget({
       location: { href: 'http://127.0.0.1:3000/', origin: 'http://127.0.0.1:3000' },
-    });
-    globalThis.navigator = { onLine: false };
+    }));
+    browserGlobals.install('navigator', { onLine: false });
 
     let sdkCallIndex = 0;
     const sdk = {
@@ -85,7 +82,7 @@ describe('createEventPipeline — online event', () => {
           // Flip the browser back online and fire the event; waitForRetry
           // should resolve early and the next attempt should fire.
           setTimeout(() => {
-            globalThis.navigator = { onLine: true };
+            browserGlobals.install('navigator', { onLine: true });
             globalThis.window.dispatch('online');
           }, 30);
         },

--- a/packages/ui/src/sync/__tests__/event-pipeline-permanent-error.test.js
+++ b/packages/ui/src/sync/__tests__/event-pipeline-permanent-error.test.js
@@ -1,14 +1,11 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { createEventPipeline } from '../event-pipeline';
+import { createBrowserGlobalStubScope } from './browser-global-stubs';
 
-const savedDocument = globalThis.document;
-const savedWindow = globalThis.window;
-const savedNavigator = globalThis.navigator;
+const browserGlobals = createBrowserGlobalStubScope();
 
 afterEach(() => {
-  globalThis.document = savedDocument;
-  globalThis.window = savedWindow;
-  globalThis.navigator = savedNavigator;
+  browserGlobals.restore();
 });
 
 function createEventTarget(extras = {}) {
@@ -35,11 +32,11 @@ function createEventTarget(extras = {}) {
 
 describe('createEventPipeline — permanent server errors', () => {
   it('uses the long backoff cap for 4xx so we do not hammer at 5s intervals', async () => {
-    globalThis.document = createEventTarget({ visibilityState: 'visible' });
-    globalThis.window = createEventTarget({
+    browserGlobals.install('document', createEventTarget({ visibilityState: 'visible' }));
+    browserGlobals.install('window', createEventTarget({
       location: { href: 'http://127.0.0.1:3000/', origin: 'http://127.0.0.1:3000' },
-    });
-    globalThis.navigator = { onLine: true };
+    }));
+    browserGlobals.install('navigator', { onLine: true });
 
     let sdkCallIndex = 0;
     const sdk = {
@@ -128,11 +125,11 @@ describe('createEventPipeline — permanent server errors', () => {
   });
 
   it('retries 408 and 429 on the normal exponential path (not the permanent cap)', async () => {
-    globalThis.document = createEventTarget({ visibilityState: 'visible' });
-    globalThis.window = createEventTarget({
+    browserGlobals.install('document', createEventTarget({ visibilityState: 'visible' }));
+    browserGlobals.install('window', createEventTarget({
       location: { href: 'http://127.0.0.1:3000/', origin: 'http://127.0.0.1:3000' },
-    });
-    globalThis.navigator = { onLine: true };
+    }));
+    browserGlobals.install('navigator', { onLine: true });
 
     let sdkCallIndex = 0;
     const sdk = {

--- a/packages/ui/src/sync/__tests__/event-pipeline-resume.test.js
+++ b/packages/ui/src/sync/__tests__/event-pipeline-resume.test.js
@@ -1,30 +1,29 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { createEventPipeline } from '../event-pipeline';
+import { createBrowserGlobalStubScope } from './browser-global-stubs';
 
-const savedDocument = globalThis.document;
-const savedWindow = globalThis.window;
+const browserGlobals = createBrowserGlobalStubScope();
 
 afterEach(() => {
-  globalThis.document = savedDocument;
-  globalThis.window = savedWindow;
+  browserGlobals.restore();
 });
 
 describe('createEventPipeline — system resume reconnect', () => {
   it('reconnects immediately on openchamber:system-resume event', async () => {
     const winListeners = {};
-    globalThis.document = {
+    browserGlobals.install('document', {
       visibilityState: 'visible',
       addEventListener() {},
       removeEventListener() {},
-    };
-    globalThis.window = {
+    });
+    browserGlobals.install('window', {
       location: {
         href: 'http://127.0.0.1:3000/',
         origin: 'http://127.0.0.1:3000',
       },
       addEventListener(event, handler) { winListeners[event] = handler; },
       removeEventListener(event) { delete winListeners[event]; },
-    };
+    });
 
     const disconnectReasons = [];
     let reconnectCount = 0;

--- a/packages/ui/src/sync/__tests__/event-pipeline.test.js
+++ b/packages/ui/src/sync/__tests__/event-pipeline.test.js
@@ -1,25 +1,26 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { createEventPipeline } from '../event-pipeline';
+import { setRuntimeUrlAuthToken } from '../../lib/runtime-auth';
+import { createBrowserGlobalStubScope } from './browser-global-stubs';
 
-const originalDocument = globalThis.document;
-const originalWindow = globalThis.window;
-const originalWebSocket = globalThis.WebSocket;
+const browserGlobals = createBrowserGlobalStubScope();
 
 function installDomStubs() {
-  globalThis.document = {
+  setRuntimeUrlAuthToken('event-pipeline-test-token', Date.now() + 60_000);
+  browserGlobals.install('document', {
     visibilityState: 'visible',
     addEventListener() {},
     removeEventListener() {},
-  };
+  });
 
-  globalThis.window = {
+  browserGlobals.install('window', {
     location: {
       href: 'http://127.0.0.1:3000/',
       origin: 'http://127.0.0.1:3000',
     },
     addEventListener() {},
     removeEventListener() {},
-  };
+  });
 }
 
 class FakeWebSocket {
@@ -50,14 +51,13 @@ class FakeWebSocket {
 
   emitClose() {
     this.readyState = 3;
-    this.onclose?.();
+    this.onclose?.({ code: 1000, reason: 'test close' });
   }
 }
 
 afterEach(() => {
-  globalThis.document = originalDocument;
-  globalThis.window = originalWindow;
-  globalThis.WebSocket = originalWebSocket;
+  setRuntimeUrlAuthToken(null, null);
+  browserGlobals.restore();
   FakeWebSocket.instances = [];
 });
 
@@ -536,7 +536,7 @@ describe('createEventPipeline', () => {
 
   it('consumes websocket message stream frames when transport is ws', async () => {
     installDomStubs();
-    globalThis.WebSocket = FakeWebSocket;
+    browserGlobals.install('WebSocket', FakeWebSocket);
 
     const received = [];
     const sdk = {
@@ -595,7 +595,7 @@ describe('createEventPipeline', () => {
 
   it('falls back to SSE when websocket closes before ready in auto mode', async () => {
     installDomStubs();
-    globalThis.WebSocket = FakeWebSocket;
+    browserGlobals.install('WebSocket', FakeWebSocket);
 
     let releaseStream;
     const hold = new Promise((resolve) => {
@@ -642,7 +642,7 @@ describe('createEventPipeline', () => {
 
   it('falls back to SSE when websocket does not become ready in auto mode', async () => {
     installDomStubs();
-    globalThis.WebSocket = FakeWebSocket;
+    browserGlobals.install('WebSocket', FakeWebSocket);
 
     let releaseStream;
     const hold = new Promise((resolve) => {
@@ -695,7 +695,7 @@ describe('createEventPipeline', () => {
 
   it('passes the last websocket event id when falling back to SSE', async () => {
     installDomStubs();
-    globalThis.WebSocket = FakeWebSocket;
+    browserGlobals.install('WebSocket', FakeWebSocket);
     const originalConsoleError = console.error;
     console.error = () => {};
 
@@ -774,7 +774,7 @@ describe('createEventPipeline', () => {
 
   it('marks the pipeline disconnected on heartbeat timeout and recovers on the next websocket connect', async () => {
     installDomStubs();
-    globalThis.WebSocket = FakeWebSocket;
+    browserGlobals.install('WebSocket', FakeWebSocket);
 
     const disconnectReasons = [];
     let reconnectCount = 0;

--- a/packages/ui/src/sync/__tests__/event-pipeline.test.js
+++ b/packages/ui/src/sync/__tests__/event-pipeline.test.js
@@ -6,6 +6,8 @@ import { createBrowserGlobalStubScope } from './browser-global-stubs';
 const browserGlobals = createBrowserGlobalStubScope();
 
 function installDomStubs() {
+  // WS tests refresh URL auth before connecting; seed the cache so they don't
+  // issue a real /auth/url-token request.
   setRuntimeUrlAuthToken('event-pipeline-test-token', Date.now() + 60_000);
   browserGlobals.install('document', {
     visibilityState: 'visible',


### PR DESCRIPTION
## Summary

Isolates browser global overrides in sync tests using scoped stubs. This ensures that modifications to global state are correctly restored after each test, preventing cross-test interference.

## Problem

The `event-pipeline` tests simulate network and visibility changes by overriding `navigator.onLine` and `document.visibilityState`. Since these properties are often read-only, direct assignment can fail or leave the global state inconsistent for subsequent tests, leading to flakiness in the test suite.

## Fix

- Added a `browser-global-stubs.js` helper that uses `Object.defineProperty` to safely swap global values.
- Implemented property descriptor preservation to restore original values after test completion.
- Updated `event-pipeline` tests to use the stub helper in setup and teardown blocks.

## Validation

- All 26 tests in the `event-pipeline` suite pass.
- `bun run type-check` and `bun run lint` clean.
- Verified that `navigator.onLine` and `document.visibilityState` are restored to original values after test execution.