### PR TITLE
fix: clean up timed-out opencode startup

### DIFF
--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -15,6 +15,10 @@ const HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES = parsePositiveInt(
 const HEALTH_CHECK_INTERVAL_OVERRIDE_MS = parsePositiveInt(process.env.OPENCHAMBER_OPENCODE_HEALTH_INTERVAL_MS, 0);
 const HEALTH_CHECK_RESULT_CACHE_MS = parsePositiveInt(process.env.OPENCHAMBER_OPENCODE_HEALTH_CACHE_MS, 750);
 const OPENCODE_HEALTH_PATH = '/global/health';
+const MANAGED_OPENCODE_START_TIMEOUT_MS = parsePositiveInt(
+  process.env.OPENCHAMBER_OPENCODE_START_TIMEOUT_MS,
+  30000
+);
 
 export const createOpenCodeLifecycleRuntime = (deps) => {
   const {
@@ -282,61 +286,67 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    const url = await new Promise((resolve, reject) => {
-      let stdout = '';
-      let stderr = '';
-      let done = false;
-      const finish = (handler, value) => {
-        if (done) return;
-        done = true;
-        clearTimeout(timer);
-        child.stdout?.off('data', onStdout);
-        child.stderr?.off('data', onStderr);
-        child.off('exit', onExit);
-        child.off('error', onError);
-        handler(value);
-      };
+    let url;
+    try {
+      url = await new Promise((resolve, reject) => {
+        let stdout = '';
+        let stderr = '';
+        let done = false;
+        const finish = (handler, value) => {
+          if (done) return;
+          done = true;
+          clearTimeout(timer);
+          child.stdout?.off('data', onStdout);
+          child.stderr?.off('data', onStderr);
+          child.off('exit', onExit);
+          child.off('error', onError);
+          handler(value);
+        };
 
-      const onStdout = (chunk) => {
-        stdout += chunk.toString();
-        const lines = stdout.split('\n');
-        for (const line of lines) {
-          if (!line.startsWith('opencode server listening')) continue;
-          const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
-          if (!match) {
-            finish(reject, new Error(`Failed to parse server url from output: ${line}`));
+        const onStdout = (chunk) => {
+          stdout += chunk.toString();
+          const lines = stdout.split('\n');
+          for (const line of lines) {
+            if (!line.startsWith('opencode server listening')) continue;
+            const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
+            if (!match) {
+              finish(reject, new Error(`Failed to parse server url from output: ${line}`));
+              return;
+            }
+            finish(resolve, match[1]);
             return;
           }
-          finish(resolve, match[1]);
-          return;
-        }
-      };
+        };
 
-      const onStderr = (chunk) => {
-        stderr += chunk.toString();
-      };
+        const onStderr = (chunk) => {
+          stderr += chunk.toString();
+        };
 
-      const onExit = (code, signal) => {
-        const reason = signal ? `signal ${signal}` : `code ${code}`;
-        const appBundleHint = process.platform === 'darwin' && /\/OpenCode\.app\/Contents\/MacOS\/(?:OpenCode|opencode-cli)$/i.test(binary)
-          ? ' The configured binary appears to point at the macOS desktop app bundle; OpenChamber needs the standalone opencode CLI.'
-          : '';
-        finish(reject, new Error(`OpenCode process exited before serving with ${reason}. Binary used: ${binary}.${appBundleHint} ${formatCapturedOutput({ stdout, stderr })}`));
-      };
+        const onExit = (code, signal) => {
+          const reason = signal ? `signal ${signal}` : `code ${code}`;
+          const appBundleHint = process.platform === 'darwin' && /\/OpenCode\.app\/Contents\/MacOS\/(?:OpenCode|opencode-cli)$/i.test(binary)
+            ? ' The configured binary appears to point at the macOS desktop app bundle; OpenChamber needs the standalone opencode CLI.'
+            : '';
+          finish(reject, new Error(`OpenCode process exited before serving with ${reason}. Binary used: ${binary}.${appBundleHint} ${formatCapturedOutput({ stdout, stderr })}`));
+        };
 
-      const onError = (error) => {
-        finish(reject, error);
-      };
+        const onError = (error) => {
+          finish(reject, error);
+        };
 
-      const timer = setTimeout(() => {
-        finish(reject, new Error(`Timeout waiting for OpenCode to start after ${timeout}ms`));
-      }, timeout);
+        const timer = setTimeout(() => {
+          finish(reject, new Error(`Timeout waiting for OpenCode to start after ${timeout}ms`));
+        }, timeout);
 
-      child.stdout?.on('data', onStdout);
-      child.stderr?.on('data', onStderr);
-      child.on('exit', onExit);
-      child.on('error', onError);
-    });
+        child.stdout?.on('data', onStdout);
+        child.stderr?.on('data', onStderr);
+        child.on('exit', onExit);
+        child.on('error', onError);
+      });
+    } catch (error) {
+      await closeManagedOpenCodeChild(child);
+      throw error;
+    }
 
     // Record this child so a future run can reap it if we crash before teardown.
     // The web-server lifecycle runs in-process inside multiple hosts, so tag the
@@ -487,7 +497,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
       const serverInstance = await createManagedOpenCodeServerProcess({
         hostname: env.ENV_CONFIGURED_OPENCODE_HOSTNAME,
         port: spawnPort,
-        timeout: 30000,
+        timeout: MANAGED_OPENCODE_START_TIMEOUT_MS,
         cwd: state.openCodeWorkingDirectory,
         shellEnvKeysCount: Object.keys(shellEnv).length,
         env: {

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -8,13 +8,13 @@ vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(),
 }));
 
-const { createOpenCodeLifecycleRuntime } = await import('./lifecycle.js');
-
 const originalOpencodeBinary = process.env.OPENCODE_BINARY;
 const originalPath = process.env.PATH;
+const originalStartTimeout = process.env.OPENCHAMBER_OPENCODE_START_TIMEOUT_MS;
 
 afterEach(() => {
   spawnMock.mockReset();
+  vi.useRealTimers();
   if (typeof originalOpencodeBinary === 'string') {
     process.env.OPENCODE_BINARY = originalOpencodeBinary;
   } else {
@@ -25,6 +25,12 @@ afterEach(() => {
     process.env.PATH = originalPath;
   } else {
     delete process.env.PATH;
+  }
+
+  if (typeof originalStartTimeout === 'string') {
+    process.env.OPENCHAMBER_OPENCODE_START_TIMEOUT_MS = originalStartTimeout;
+  } else {
+    delete process.env.OPENCHAMBER_OPENCODE_START_TIMEOUT_MS;
   }
 });
 
@@ -43,7 +49,8 @@ const createMockChild = () => {
   return child;
 };
 
-const createRuntime = (overrides = {}) => {
+const createRuntime = async (overrides = {}) => {
+  const { createOpenCodeLifecycleRuntime } = await import(`./lifecycle.js?test=${Date.now()}-${Math.random()}`);
   const state = {
     openCodeWorkingDirectory: '/tmp/project',
     openCodeProcess: null,
@@ -115,7 +122,7 @@ describe('OpenCode lifecycle', () => {
       return child;
     });
 
-    const runtime = createRuntime();
+    const runtime = await createRuntime();
     const server = await runtime.startOpenCode();
     const [binary, args, options] = spawnMock.mock.calls[0];
 
@@ -138,7 +145,7 @@ describe('OpenCode lifecycle', () => {
       return child;
     });
 
-    const runtime = createRuntime({
+    const runtime = await createRuntime({
       buildManagedOpenCodePath: undefined,
       buildAugmentedPath: vi.fn(() => '/home/user/.cargo/bin:/usr/local/bin'),
     });
@@ -161,7 +168,7 @@ describe('OpenCode lifecycle', () => {
       return child;
     });
 
-    const runtime = createRuntime({
+    const runtime = await createRuntime({
       buildManagedOpenCodePath: undefined,
       buildAugmentedPath: undefined,
     });
@@ -190,7 +197,7 @@ describe('OpenCode lifecycle', () => {
       return secondChild;
     });
 
-    const runtime = createRuntime();
+    const runtime = await createRuntime();
 
     await expect(runtime.startOpenCode()).rejects.toThrow('OpenCode process exited before serving with signal SIGTERM. Binary used: opencode. No stdout/stderr captured');
     expect(spawnMock).toHaveBeenCalledTimes(2);
@@ -204,7 +211,7 @@ describe('OpenCode lifecycle', () => {
       throw error;
     });
 
-    const runtime = createRuntime({ applyOpencodeBinaryFromSettings });
+    const runtime = await createRuntime({ applyOpencodeBinaryFromSettings });
 
     await expect(runtime.startOpenCode()).rejects.toThrow('Configured OpenCode binary not found: /missing/opencode');
     expect(applyOpencodeBinaryFromSettings).toHaveBeenCalledTimes(1);
@@ -229,10 +236,32 @@ describe('OpenCode lifecycle', () => {
       return secondChild;
     });
 
-    const runtime = createRuntime();
+    const runtime = await createRuntime();
     const server = await runtime.startOpenCode();
 
     expect(spawnMock).toHaveBeenCalledTimes(2);
+    await server.close();
+  });
+
+  it('cleans up a timed-out managed OpenCode attempt before retrying', async () => {
+    delete process.env.OPENCODE_BINARY;
+    const firstChild = createMockChild();
+    const secondChild = createMockChild();
+    const waitForReady = vi.fn(async () => true);
+    spawnMock.mockImplementationOnce(() => firstChild);
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        secondChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:45678\n');
+      });
+      return secondChild;
+    });
+
+    process.env.OPENCHAMBER_OPENCODE_START_TIMEOUT_MS = '10';
+    const runtime = await createRuntime({ waitForReady });
+    const server = await runtime.startOpenCode();
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(firstChild.kill).toHaveBeenCalledWith('SIGTERM');
     await server.close();
   });
 });


### PR DESCRIPTION
## Summary
- clean up managed OpenCode child processes when startup times out before reporting ready
- make the managed OpenCode start timeout configurable via OPENCHAMBER_OPENCODE_START_TIMEOUT_MS
- add regression coverage for timeout cleanup before retry

## Test plan
- bun test packages/web/server/lib/opencode/lifecycle.test.js
- bun run --cwd packages/web lint

## Notes
- bun run --cwd packages/web type-check currently fails on upstream main in packages/ui/src/components/chat/MessageList.tsx due @tanstack/react-virtual type errors unrelated to this change.