### PR TITLE
feat(providers): redesign provider connect ui

### DIFF
--- a/packages/ui/src/components/sections/providers/ProvidersPage.test.ts
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.test.ts
@@ -1,9 +1,188 @@
 import { describe, expect, test } from 'bun:test';
 import { shouldLoadAvailableProviders } from './providerAvailability';
+import {
+  filterUnconnectedProviders,
+  groupProviderOptions,
+  startProviderOAuth,
+  type ProviderOAuthDetails,
+  type ProviderOption,
+} from './providerConnect';
+
+function createState<T>(initial: T) {
+  let current = initial;
+  const updates: T[] = [];
+
+  return {
+    get value() {
+      return current;
+    },
+    updates,
+    set(next: T | ((value: T) => T)) {
+      current = typeof next === 'function' ? (next as (value: T) => T)(current) : next;
+      updates.push(current);
+    },
+  };
+}
 
 describe('ProvidersPage available provider loading', () => {
   test('loads available providers only in add-provider mode', () => {
     expect(shouldLoadAvailableProviders(false)).toBe(false);
     expect(shouldLoadAvailableProviders(true)).toBe(true);
+  });
+
+  test('empty search preserves the original provider list reference', () => {
+    const providers: ProviderOption[] = [
+      { id: 'openai', name: 'OpenAI' },
+      { id: 'anthropic', name: 'Anthropic' },
+    ];
+
+    expect(filterUnconnectedProviders(providers, '')).toBe(providers);
+    expect(filterUnconnectedProviders(providers, '   ')).toBe(providers);
+  });
+
+  test('search matches provider name and id case-insensitively', () => {
+    const providers: ProviderOption[] = [
+      { id: 'openai-compatible', name: 'Custom OpenAI' },
+      { id: 'anthropic', name: 'Anthropic' },
+      { id: 'gemini', name: 'Google Gemini' },
+    ];
+
+    expect(filterUnconnectedProviders(providers, 'OPENAI')).toEqual([{ id: 'openai-compatible', name: 'Custom OpenAI' }]);
+    expect(filterUnconnectedProviders(providers, 'thro')).toEqual([{ id: 'anthropic', name: 'Anthropic' }]);
+    expect(filterUnconnectedProviders(providers, 'gem')).toEqual([{ id: 'gemini', name: 'Google Gemini' }]);
+  });
+
+  test('groups providers in 0-9, A-Z, then # order', () => {
+    const grouped = groupProviderOptions([
+      { id: 'zeta', name: 'Zeta' },
+      { id: '3p-provider', name: '3P Provider' },
+      { id: 'anthropic', name: 'Anthropic' },
+      { id: 'emoji', name: '🙂 Emoji Cloud' },
+      { id: 'beta', name: 'Beta' },
+    ]);
+
+    expect(grouped).toEqual([
+      ['0-9', [{ id: '3p-provider', name: '3P Provider' }]],
+      ['A', [{ id: 'anthropic', name: 'Anthropic' }]],
+      ['B', [{ id: 'beta', name: 'Beta' }]],
+      ['Z', [{ id: 'zeta', name: 'Zeta' }]],
+      ['#', [{ id: 'emoji', name: '🙂 Emoji Cloud' }]],
+    ]);
+  });
+
+  test('starts provider OAuth once, stores returned details, and does not auto-open a browser window', async () => {
+    const authBusyState = createState<string | null>(null);
+    const oauthDetailsState = createState<Record<string, ProviderOAuthDetails>>({});
+    const pendingState = createState<{ providerId: string; methodIndex: number } | null>(null);
+    const toastMessageCalls: string[] = [];
+    const toastErrorCalls: string[] = [];
+    const windowOpenCalls: unknown[][] = [];
+    const windowOpen = (...args: unknown[]) => {
+      windowOpenCalls.push(args);
+      return null;
+    };
+    (globalThis as { window?: { open: typeof windowOpen } }).window = { open: windowOpen };
+
+    await startProviderOAuth({
+      providerId: 'openai',
+      methodIndex: 0,
+      authorize: async () => ({
+        data: {
+          verification_uri_complete: 'https://example.com/oauth',
+          user_code: 'ABC123',
+        },
+      }),
+      authBusyKeyRef: { current: null },
+      setAuthBusyKey: (value) => authBusyState.set(value as string | null | ((current: string | null) => string | null)),
+      setOauthDetails: (value) => oauthDetailsState.set(value as Record<string, ProviderOAuthDetails> | ((current: Record<string, ProviderOAuthDetails>) => Record<string, ProviderOAuthDetails>)),
+      setPendingOAuth: (value) => pendingState.set(value as { providerId: string; methodIndex: number } | null | ((current: { providerId: string; methodIndex: number } | null) => { providerId: string; methodIndex: number } | null)),
+      toastMessage: (message) => {
+        toastMessageCalls.push(message);
+      },
+      toastError: (message) => {
+        toastErrorCalls.push(message);
+      },
+      t: (key) => key,
+    });
+
+    expect(oauthDetailsState.value).toEqual({
+      'openai:0': {
+        url: 'https://example.com/oauth',
+        userCode: 'ABC123',
+      },
+    });
+    expect(pendingState.value).toEqual({ providerId: 'openai', methodIndex: 0 });
+    expect(authBusyState.updates).toEqual(['oauth:openai:0', null]);
+    expect(toastMessageCalls).toEqual(['settings.providers.page.toast.completeOAuthInBrowser']);
+    expect(toastErrorCalls).toEqual([]);
+    expect(windowOpenCalls).toEqual([]);
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  test('deduplicates concurrent OAuth starts for the same provider key', async () => {
+    const authBusyState = createState<string | null>(null);
+    const oauthDetailsState = createState<Record<string, ProviderOAuthDetails>>({});
+    const pendingState = createState<{ providerId: string; methodIndex: number } | null>(null);
+    const toastMessageCalls: string[] = [];
+    const toastErrorCalls: string[] = [];
+    let authorizeCalls = 0;
+    let resolveAuthorize!: (value: { data: unknown }) => void;
+    const authorize = () => {
+      authorizeCalls += 1;
+      return new Promise<{ data: unknown }>((resolve) => {
+        resolveAuthorize = resolve;
+      });
+    };
+    const authBusyKeyRef = { current: null as string | null };
+
+    const first = startProviderOAuth({
+      providerId: 'openai',
+      methodIndex: 1,
+      authorize,
+      authBusyKeyRef,
+      setAuthBusyKey: (value) => authBusyState.set(value as string | null | ((current: string | null) => string | null)),
+      setOauthDetails: (value) => oauthDetailsState.set(value as Record<string, ProviderOAuthDetails> | ((current: Record<string, ProviderOAuthDetails>) => Record<string, ProviderOAuthDetails>)),
+      setPendingOAuth: (value) => pendingState.set(value as { providerId: string; methodIndex: number } | null | ((current: { providerId: string; methodIndex: number } | null) => { providerId: string; methodIndex: number } | null)),
+      toastMessage: (message) => {
+        toastMessageCalls.push(message);
+      },
+      toastError: (message) => {
+        toastErrorCalls.push(message);
+      },
+      t: (key) => key,
+    });
+    const second = startProviderOAuth({
+      providerId: 'openai',
+      methodIndex: 1,
+      authorize,
+      authBusyKeyRef,
+      setAuthBusyKey: (value) => authBusyState.set(value as string | null | ((current: string | null) => string | null)),
+      setOauthDetails: (value) => oauthDetailsState.set(value as Record<string, ProviderOAuthDetails> | ((current: Record<string, ProviderOAuthDetails>) => Record<string, ProviderOAuthDetails>)),
+      setPendingOAuth: (value) => pendingState.set(value as { providerId: string; methodIndex: number } | null | ((current: { providerId: string; methodIndex: number } | null) => { providerId: string; methodIndex: number } | null)),
+      toastMessage: (message) => {
+        toastMessageCalls.push(message);
+      },
+      toastError: (message) => {
+        toastErrorCalls.push(message);
+      },
+      t: (key) => key,
+    });
+
+    expect(authorizeCalls).toBe(1);
+    expect(authBusyKeyRef.current).toBe('oauth:openai:1');
+
+    resolveAuthorize({ data: { verification_uri: 'https://example.com/device' } });
+    expect(await second).toBe(false);
+    expect(await first).toBe(true);
+
+    expect(oauthDetailsState.value).toEqual({
+      'openai:1': {
+        url: 'https://example.com/device',
+      },
+    });
+    expect(pendingState.value).toEqual({ providerId: 'openai', methodIndex: 1 });
+    expect(authBusyState.updates).toEqual(['oauth:openai:1', null]);
+    expect(toastMessageCalls).toEqual(['settings.providers.page.toast.completeOAuthInBrowser']);
+    expect(toastErrorCalls).toEqual([]);
   });
 });

--- a/packages/ui/src/components/sections/providers/ProvidersPage.tsx
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.tsx
@@ -18,6 +18,15 @@ import { getCurrentIntlLocale, useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { opencodeClient } from '@/lib/opencode/client';
 import { shouldLoadAvailableProviders } from './providerAvailability';
+import {
+  filterUnconnectedProviders,
+  getProviderOptionLabel,
+  groupProviderOptions,
+  startProviderOAuth,
+  type AuthMethod,
+  type ProviderOAuthDetails,
+  type ProviderOption,
+} from './providerConnect';
 import { QuotaCredentials } from './QuotaCredentials';
 
 const formatCompactNumber = (value: number) => new Intl.NumberFormat(getCurrentIntlLocale(), {
@@ -39,34 +48,6 @@ const formatTokens = (value?: number | null) => {
 };
 
 const ADD_PROVIDER_ID = '__add_provider__';
-
-interface AuthMethod {
-  type?: string;
-  name?: string;
-  label?: string;
-  description?: string;
-  help?: string;
-  method?: number;
-  [key: string]: unknown;
-}
-
-interface ProviderOption {
-  id: string;
-  name?: string;
-}
-
-const getProviderOptionLabel = (provider: ProviderOption) => provider.name || provider.id;
-
-const getProviderGroupKey = (provider: ProviderOption) => {
-  const firstCharacter = getProviderOptionLabel(provider).trim().charAt(0).toUpperCase();
-  if (firstCharacter >= 'A' && firstCharacter <= 'Z') {
-    return firstCharacter;
-  }
-  if (firstCharacter >= '0' && firstCharacter <= '9') {
-    return '0-9';
-  }
-  return '#';
-};
 
 interface ProviderSourceInfo {
   exists: boolean;
@@ -169,7 +150,7 @@ export const ProvidersPage: React.FC = () => {
   const [modelQuery, setModelQuery] = React.useState('');
   const [pendingOAuth, setPendingOAuth] = React.useState<{ providerId: string; methodIndex: number } | null>(null);
   const [oauthCodes, setOauthCodes] = React.useState<Record<string, string>>({});
-  const [oauthDetails, setOauthDetails] = React.useState<Record<string, { url?: string; instructions?: string; userCode?: string }>>({});
+  const [oauthDetails, setOauthDetails] = React.useState<Record<string, ProviderOAuthDetails>>({});
   const [availableProviders, setAvailableProviders] = React.useState<ProviderOption[]>([]);
   const [availableLoading, setAvailableLoading] = React.useState(false);
   const [availableError, setAvailableError] = React.useState<string | null>(null);
@@ -273,37 +254,15 @@ export const ProvidersPage: React.FC = () => {
     [availableProviders, connectedProviderIds]
   );
 
-  const filteredUnconnectedProviders = React.useMemo(() => {
-    const query = providerSearchQuery.trim().toLowerCase();
-    if (!query) {
-      return unconnectedProviders;
-    }
+  const filteredUnconnectedProviders = React.useMemo(
+    () => filterUnconnectedProviders(unconnectedProviders, providerSearchQuery),
+    [providerSearchQuery, unconnectedProviders]
+  );
 
-    return unconnectedProviders.filter((provider) => {
-      const label = getProviderOptionLabel(provider).toLowerCase();
-      return label.includes(query) || provider.id.toLowerCase().includes(query);
-    });
-  }, [providerSearchQuery, unconnectedProviders]);
-
-  const groupedUnconnectedProviders = React.useMemo(() => {
-    const groups = new Map<string, ProviderOption[]>();
-
-    for (const provider of filteredUnconnectedProviders) {
-      const groupKey = getProviderGroupKey(provider);
-      const existing = groups.get(groupKey);
-      if (existing) {
-        existing.push(provider);
-      } else {
-        groups.set(groupKey, [provider]);
-      }
-    }
-
-    return Array.from(groups.entries()).sort(([groupA], [groupB]) => {
-      if (groupA === '#') return 1;
-      if (groupB === '#') return -1;
-      return groupA.localeCompare(groupB);
-    });
-  }, [filteredUnconnectedProviders]);
+  const groupedUnconnectedProviders = React.useMemo(
+    () => groupProviderOptions(filteredUnconnectedProviders),
+    [filteredUnconnectedProviders]
+  );
 
   React.useEffect(() => {
     if (selectedProviderId !== ADD_PROVIDER_ID) {
@@ -401,66 +360,21 @@ export const ProvidersPage: React.FC = () => {
   };
 
   const handleOAuthStart = async (providerId: string, methodIndex: number) => {
-    const busyKey = `oauth:${providerId}:${methodIndex}`;
-    if (authBusyKeyRef.current === busyKey) {
-      return;
-    }
-
-    authBusyKeyRef.current = busyKey;
-    setAuthBusyKey(busyKey);
-
-    try {
-      const result = await opencodeClient.getSdkClient().provider.oauth.authorize({
-        providerID: providerId,
-        method: methodIndex,
-      });
-      if (result.error) {
-        throw new Error(t('settings.providers.page.toast.oauthStartFailed'));
-      }
-
-      const payloadRecord: Record<string, unknown> = isRecord(result.data) ? result.data : {};
-      const nestedData = payloadRecord.data;
-      const dataRecord: Record<string, unknown> = isRecord(nestedData) ? nestedData : payloadRecord;
-      const urlCandidate =
-        (typeof dataRecord.url === 'string' && dataRecord.url) ||
-        (typeof dataRecord.verification_uri_complete === 'string' && dataRecord.verification_uri_complete) ||
-        (typeof dataRecord.verification_uri === 'string' && dataRecord.verification_uri) ||
-        undefined;
-      const instructions =
-        (typeof dataRecord.instructions === 'string' && dataRecord.instructions) ||
-        (typeof dataRecord.message === 'string' && dataRecord.message) ||
-        undefined;
-      const userCode =
-        (typeof dataRecord.user_code === 'string' && dataRecord.user_code) ||
-        (typeof dataRecord.code === 'string' && dataRecord.code) ||
-        (typeof dataRecord.userCode === 'string' && dataRecord.userCode) ||
-        undefined;
-
-      if (!urlCandidate && !instructions && !userCode) {
-        throw new Error(t('settings.providers.page.toast.oauthDetailsMissing'));
-      }
-
-      const detailsKey = `${providerId}:${methodIndex}`;
-      setOauthDetails((prev) => ({
-        ...prev,
-        [detailsKey]: {
-          url: urlCandidate,
-          instructions,
-          userCode,
-        },
-      }));
-
-      setPendingOAuth({ providerId, methodIndex });
-      toast.message(t('settings.providers.page.toast.completeOAuthInBrowser'));
-    } catch (error) {
-      console.error('Failed to start OAuth flow:', error);
-      toast.error(t('settings.providers.page.toast.oauthStartFailed'));
-    } finally {
-      if (authBusyKeyRef.current === busyKey) {
-        authBusyKeyRef.current = null;
-      }
-      setAuthBusyKey((current) => (current === busyKey ? null : current));
-    }
+    await startProviderOAuth({
+      providerId,
+      methodIndex,
+      authorize: (input) => opencodeClient.getSdkClient().provider.oauth.authorize(input),
+      authBusyKeyRef,
+      setAuthBusyKey,
+      setOauthDetails,
+      setPendingOAuth,
+      toastMessage: (message) => toast.message(message),
+      toastError: (message) => toast.error(message),
+      t,
+      onError: (error) => {
+        console.error('Failed to start OAuth flow:', error);
+      },
+    });
   };
 
   const handleOAuthComplete = async (providerId: string, methodIndex: number) => {

--- a/packages/ui/src/components/sections/providers/ProvidersPage.tsx
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.tsx
@@ -5,12 +5,6 @@ import { useConfigStore } from '@/stores/useConfigStore';
 import { useUIStore } from '@/stores/useUIStore';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { toast } from '@/components/ui';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Icon } from "@/components/icon/Icon";
@@ -60,6 +54,19 @@ interface ProviderOption {
   id: string;
   name?: string;
 }
+
+const getProviderOptionLabel = (provider: ProviderOption) => provider.name || provider.id;
+
+const getProviderGroupKey = (provider: ProviderOption) => {
+  const firstCharacter = getProviderOptionLabel(provider).trim().charAt(0).toUpperCase();
+  if (firstCharacter >= 'A' && firstCharacter <= 'Z') {
+    return firstCharacter;
+  }
+  if (firstCharacter >= '0' && firstCharacter <= '9') {
+    return '0-9';
+  }
+  return '#';
+};
 
 interface ProviderSourceInfo {
   exists: boolean;
@@ -168,10 +175,11 @@ export const ProvidersPage: React.FC = () => {
   const [availableError, setAvailableError] = React.useState<string | null>(null);
   const [candidateProviderId, setCandidateProviderId] = React.useState('');
   const [providerSearchQuery, setProviderSearchQuery] = React.useState('');
-  const [providerDropdownOpen, setProviderDropdownOpen] = React.useState(false);
   const [providerSources, setProviderSources] = React.useState<Record<string, ProviderSources>>({});
   const [showAuthPanel, setShowAuthPanel] = React.useState(false);
   const isAddMode = selectedProviderId === ADD_PROVIDER_ID;
+  const hasCandidateProvider = candidateProviderId.length > 0;
+  const authBusyKeyRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     if (!selectedProviderId && providers.length > 0) {
@@ -264,6 +272,38 @@ export const ProvidersPage: React.FC = () => {
         }),
     [availableProviders, connectedProviderIds]
   );
+
+  const filteredUnconnectedProviders = React.useMemo(() => {
+    const query = providerSearchQuery.trim().toLowerCase();
+    if (!query) {
+      return unconnectedProviders;
+    }
+
+    return unconnectedProviders.filter((provider) => {
+      const label = getProviderOptionLabel(provider).toLowerCase();
+      return label.includes(query) || provider.id.toLowerCase().includes(query);
+    });
+  }, [providerSearchQuery, unconnectedProviders]);
+
+  const groupedUnconnectedProviders = React.useMemo(() => {
+    const groups = new Map<string, ProviderOption[]>();
+
+    for (const provider of filteredUnconnectedProviders) {
+      const groupKey = getProviderGroupKey(provider);
+      const existing = groups.get(groupKey);
+      if (existing) {
+        existing.push(provider);
+      } else {
+        groups.set(groupKey, [provider]);
+      }
+    }
+
+    return Array.from(groups.entries()).sort(([groupA], [groupB]) => {
+      if (groupA === '#') return 1;
+      if (groupB === '#') return -1;
+      return groupA.localeCompare(groupB);
+    });
+  }, [filteredUnconnectedProviders]);
 
   React.useEffect(() => {
     if (selectedProviderId !== ADD_PROVIDER_ID) {
@@ -362,6 +402,11 @@ export const ProvidersPage: React.FC = () => {
 
   const handleOAuthStart = async (providerId: string, methodIndex: number) => {
     const busyKey = `oauth:${providerId}:${methodIndex}`;
+    if (authBusyKeyRef.current === busyKey) {
+      return;
+    }
+
+    authBusyKeyRef.current = busyKey;
     setAuthBusyKey(busyKey);
 
     try {
@@ -405,16 +450,16 @@ export const ProvidersPage: React.FC = () => {
         },
       }));
 
-      if (urlCandidate) {
-        void openExternalUrl(urlCandidate);
-      }
       setPendingOAuth({ providerId, methodIndex });
       toast.message(t('settings.providers.page.toast.completeOAuthInBrowser'));
     } catch (error) {
       console.error('Failed to start OAuth flow:', error);
       toast.error(t('settings.providers.page.toast.oauthStartFailed'));
     } finally {
-      setAuthBusyKey(null);
+      if (authBusyKeyRef.current === busyKey) {
+        authBusyKeyRef.current = null;
+      }
+      setAuthBusyKey((current) => (current === busyKey ? null : current));
     }
   };
 
@@ -512,250 +557,266 @@ export const ProvidersPage: React.FC = () => {
 
   if (isAddMode) {
     return (
-      <ScrollableOverlay outerClassName="h-full" className="w-full">
-        <div className="mx-auto w-full max-w-3xl p-3 sm:p-6 sm:pt-8">
+      <div className="h-full overflow-hidden">
+        <div className="mx-auto flex h-full w-full max-w-6xl flex-col p-3 sm:p-6 sm:pt-8">
           <div data-settings-item="providers.connect" className="mb-4">
             <h1 className="typography-ui-header font-semibold text-foreground">{t('settings.providers.page.connect.title')}</h1>
           </div>
 
-          <div className="mb-8">
-            <div className="mb-1 px-1">
-              <h2 className="typography-ui-header font-medium text-foreground">{t('settings.providers.page.connect.selectProviderTitle')}</h2>
-            </div>
+          <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 xl:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)]">
+            <section
+              className={cn(
+                'min-h-0 flex-col rounded-xl border border-[var(--surface-subtle)] bg-[var(--surface-elevated)]',
+                hasCandidateProvider ? 'hidden xl:flex' : 'flex'
+              )}
+            >
+              <div className="border-b border-[var(--surface-subtle)] px-4 py-4">
+                <div className="relative">
+                  <Icon name="search" className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={providerSearchQuery}
+                    onChange={(event) => setProviderSearchQuery(event.target.value)}
+                    placeholder={t('settings.providers.page.connect.searchProvidersPlaceholder')}
+                    className="h-10 pl-9"
+                    autoFocus
+                  />
+                </div>
+              </div>
 
-            <section className="px-2 pb-2 pt-0">
-              <div className="flex flex-wrap items-center gap-2 py-1.5">
-                <span className="typography-ui-label text-foreground">{t('settings.providers.page.connect.providerField')}</span>
-                  {availableLoading ? (
-                    <p className="typography-meta text-muted-foreground">{t('settings.providers.page.state.loading')}</p>
-                  ) : availableError ? (
-                    <p className="typography-meta text-muted-foreground">{availableError}</p>
-                  ) : unconnectedProviders.length === 0 ? (
-                    <p className="typography-meta text-muted-foreground">{t('settings.providers.page.connect.allProvidersConnected')}</p>
-                  ) : (
-                    <DropdownMenu open={providerDropdownOpen} onOpenChange={(open) => {
-                      setProviderDropdownOpen(open);
-                      if (!open) setProviderSearchQuery('');
-                    }}>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type="button"
-                          className={cn(
-                            "flex items-center justify-between gap-2 rounded-lg border border-input bg-transparent px-2 py-2 typography-ui-label whitespace-nowrap shadow-none outline-none hover:bg-interactive-hover h-6 w-fit",
-                          )}
-                        >
-                          <span className="flex items-center gap-2 min-w-0">
-                            {candidateProviderId ? <ProviderLogo providerId={candidateProviderId} className="h-3.5 w-3.5 flex-shrink-0" /> : null}
-                            <span className={cn("truncate typography-ui-label font-normal", candidateProviderId ? "text-foreground" : "text-muted-foreground")}>
-                              {candidateProviderId
-                                ? (unconnectedProviders.find(p => p.id === candidateProviderId)?.name || candidateProviderId)
-                                : t('settings.providers.page.connect.selectProviderPlaceholder')}
-                            </span>
-                          </span>
-                          <Icon name="arrow-down-s" className="h-4 w-4 flex-shrink-0 text-muted-foreground/50" />
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent
-                        align="start"
-                        className="w-[280px] p-0"
-                        onCloseAutoFocus={(e) => e.preventDefault()}
-                      >
-                        <div
-                          className="flex items-center gap-2 border-b border-[var(--surface-subtle)] px-3 py-2"
-                          onKeyDown={(e) => e.stopPropagation()}
-                        >
-                          <Icon name="search" className="h-4 w-4 text-muted-foreground" />
-                          <input
-                            type="text"
-                            value={providerSearchQuery}
-                            onChange={(e) => setProviderSearchQuery(e.target.value)}
-                            onKeyDown={(e) => e.stopPropagation()}
-                            placeholder={t('settings.providers.page.connect.searchProvidersPlaceholder')}
-                            className="flex-1 bg-transparent typography-meta outline-none placeholder:text-muted-foreground"
-                            autoFocus
-                          />
+              <div className="min-h-0 flex-1 px-2 py-2">
+                {availableLoading ? (
+                  <div className="px-2 py-3 typography-meta text-muted-foreground">{t('settings.providers.page.state.loading')}</div>
+                ) : availableError ? (
+                  <div className="px-2 py-3 typography-meta text-muted-foreground">{availableError}</div>
+                ) : unconnectedProviders.length === 0 ? (
+                  <div className="px-2 py-3 typography-meta text-muted-foreground">{t('settings.providers.page.connect.allProvidersConnected')}</div>
+                ) : filteredUnconnectedProviders.length === 0 ? (
+                  <div className="px-2 py-6 text-center typography-meta text-muted-foreground">{t('settings.providers.page.connect.noProvidersFound')}</div>
+                ) : (
+                  <ScrollableOverlay outerClassName="h-full" className="space-y-3 pr-1">
+                    {groupedUnconnectedProviders.map(([groupKey, groupProviders]) => (
+                      <div key={groupKey} className="space-y-1">
+                        <div className="px-2 pb-1 pt-1 typography-micro font-semibold uppercase tracking-wide text-muted-foreground">
+                          {groupKey}
                         </div>
-                        <ScrollableOverlay outerClassName="max-h-[240px]" className="p-1">
-                          {(() => {
-                            const filtered = unconnectedProviders.filter(p => {
-                              const query = providerSearchQuery.toLowerCase();
-                              return (p.name || p.id).toLowerCase().includes(query) || p.id.toLowerCase().includes(query);
-                            });
-                            if (filtered.length === 0) {
-                              return <p className="py-4 text-center typography-meta text-muted-foreground">{t('settings.providers.page.connect.noProvidersFound')}</p>;
-                            }
-                            return filtered.map((provider) => (
-                              <DropdownMenuItem
-                                key={provider.id}
-                                onSelect={() => {
-                                  setCandidateProviderId(provider.id);
-                                  setProviderDropdownOpen(false);
-                                  setProviderSearchQuery('');
-                                }}
-                                className="flex items-center justify-between"
-                              >
-                                <span className="flex items-center gap-2 min-w-0">
-                                  <ProviderLogo providerId={provider.id} className="h-4 w-4 flex-shrink-0" />
-                                  <span className="truncate">{provider.name || provider.id}</span>
-                                </span>
-                                {candidateProviderId === provider.id && (
-                                  <Icon name="check" className="h-4 w-4 text-[var(--primary-base)]" />
-                                )}
-                              </DropdownMenuItem>
-                            ));
-                          })()}
-                        </ScrollableOverlay>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                   )}
-              </div>
-            </section>
-          </div>
-
-          {candidateProviderId && (
-            <div data-settings-item="providers.auth" className="mb-8">
-              <div className="mb-1 px-1">
-                <h2 className="typography-ui-header font-medium text-foreground">{t('settings.providers.page.auth.title')}</h2>
-              </div>
-
-              {authLoading ? (
-                <p className="typography-meta text-muted-foreground px-2">{t('settings.providers.page.auth.loadingMethods')}</p>
-              ) : (
-                <section className="px-2 pb-2 pt-0 space-y-4">
-                  <div className="py-1.5">
-                    <label className="typography-ui-label text-foreground flex items-center gap-1.5">
-                      {t('settings.providers.page.auth.apiKeyLabel')}
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Icon name="information" className="h-3.5 w-3.5 text-muted-foreground/60 cursor-help" />
-                        </TooltipTrigger>
-                        <TooltipContent sideOffset={8} className="max-w-xs">
-                          {t('settings.providers.page.auth.apiKeyTooltip')}
-                        </TooltipContent>
-                      </Tooltip>
-                    </label>
-                    <div className="flex flex-col sm:flex-row sm:items-center gap-2 mt-1.5">
-                      <Input
-                        type="password"
-                        value={apiKeyInputs[candidateProviderId] ?? ''}
-                        onChange={(event) =>
-                          setApiKeyInputs((prev) => ({
-                            ...prev,
-                            [candidateProviderId]: event.target.value,
-                          }))
-                        }
-                        placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
-                        className="flex-1 font-mono text-xs"
-                      />
-                      <Button
-                        size="xs"
-                        className="!font-normal shrink-0"
-                        onClick={() => handleSaveApiKey(candidateProviderId)}
-                        disabled={authBusyKey === `api:${candidateProviderId}`}
-                      >
-                        {authBusyKey === `api:${candidateProviderId}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
-                      </Button>
-                    </div>
-                  </div>
-
-                  {(() => {
-                    const candidateAuthMethods = authMethodsByProvider[candidateProviderId] ?? [];
-                    const candidateOAuthMethods = candidateAuthMethods.filter(
-                      (method) => normalizeAuthType(method) === 'oauth'
-                    );
-
-                    if (candidateOAuthMethods.length === 0) {
-                      return null;
-                    }
-
-                    return (
-                      <div className="space-y-4 border-t border-[var(--surface-subtle)] pt-2">
-                        {candidateOAuthMethods.map((method, index) => {
-                          const methodLabel = method.label || method.name || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
-                          const codeKey = `${candidateProviderId}:${index}`;
-                          const isPending =
-                            pendingOAuth?.providerId === candidateProviderId && pendingOAuth?.methodIndex === index;
-
+                        {groupProviders.map((provider) => {
+                          const isSelected = candidateProviderId === provider.id;
                           return (
-                            <div key={`${candidateProviderId}-${methodLabel}`} className="space-y-3">
-                              <div className="flex items-center justify-between gap-2">
-                                <div>
-                                  <div className="typography-ui-label text-foreground">{methodLabel}</div>
-                                  {(method.description || method.help) && (
-                                    <div className="typography-meta text-muted-foreground">
-                                      {String(method.description || method.help)}
-                                    </div>
-                                  )}
+                            <button
+                              key={provider.id}
+                              type="button"
+                              onClick={() => setCandidateProviderId(provider.id)}
+                              className={cn(
+                                'flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors',
+                                isSelected ? 'bg-interactive-selection text-interactive-selection-foreground' : 'hover:bg-interactive-hover'
+                              )}
+                            >
+                              <ProviderLogo providerId={provider.id} className="h-4 w-4 shrink-0" />
+                              <div className="min-w-0 flex-1">
+                                <div className="truncate typography-ui-label font-normal">
+                                  {getProviderOptionLabel(provider)}
                                 </div>
-                                <Button
-                                  variant="outline"
-                                  size="xs"
-                                  className="!font-normal"
-                                  onClick={() => handleOAuthStart(candidateProviderId, index)}
-                                  disabled={authBusyKey === `oauth:${candidateProviderId}:${index}`}
-                                >
-                                  {t('settings.providers.page.actions.connect')}
-                                </Button>
+                                <div className={cn(
+                                  'truncate typography-meta',
+                                  isSelected ? 'text-interactive-selection-foreground/70' : 'text-muted-foreground'
+                                )}>
+                                  {provider.id}
+                                </div>
                               </div>
-
-                              {oauthDetails[codeKey]?.instructions && (
-                                <p className="typography-meta text-[var(--primary-base)] bg-[var(--primary-base)]/10 px-2 py-1.5 rounded">
-                                  {oauthDetails[codeKey]?.instructions}
-                                </p>
-                              )}
-
-                              {oauthDetails[codeKey]?.userCode && (
-                                <div className="flex items-center gap-2 mt-2">
-                                  <Input value={oauthDetails[codeKey]?.userCode} readOnly className="font-mono text-center tracking-widest" />
-                                  <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthCode(oauthDetails[codeKey]?.userCode ?? '')}>{t('settings.providers.page.actions.copyCode')}</Button>
-                                </div>
-                              )}
-
-                              {oauthDetails[codeKey]?.url && (
-                                <div className="flex items-center gap-2 mt-2">
-                                  <Input value={oauthDetails[codeKey]?.url} readOnly className="text-xs text-muted-foreground" />
-                                  <div className="flex gap-1 shrink-0">
-                                    <Button variant="outline" size="xs" className="!font-normal" onClick={() => openExternalUrl(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.open')}</Button>
-                                    <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthLink(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.copy')}</Button>
-                                  </div>
-                                </div>
-                              )}
-
-                              {isPending && (
-                                <div className="flex items-center gap-2 mt-2">
-                                  <Input
-                                    value={oauthCodes[codeKey] ?? ''}
-                                    onChange={(event) =>
-                                      setOauthCodes((prev) => ({
-                                        ...prev,
-                                        [codeKey]: event.target.value,
-                                      }))
-                                    }
-                                    placeholder={t('settings.providers.page.auth.pasteAuthorizationCodePlaceholder')}
-                                    className="font-mono text-xs"
-                                  />
-                                  <Button
-                                    size="xs"
-                                    className="!font-normal"
-                                    onClick={() => handleOAuthComplete(candidateProviderId, index)}
-                                    disabled={authBusyKey === `oauth-complete:${candidateProviderId}:${index}`}
-                                  >
-                                    {authBusyKey === `oauth-complete:${candidateProviderId}:${index}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.complete')}
-                                  </Button>
-                                </div>
-                              )}
-                            </div>
+                              {isSelected ? <Icon name="check" className="h-4 w-4 shrink-0" /> : null}
+                            </button>
                           );
                         })}
                       </div>
-                    );
-                  })()}
-                </section>
+                    ))}
+                  </ScrollableOverlay>
+                )}
+              </div>
+            </section>
+
+            <section
+              data-settings-item="providers.auth"
+              className={cn(
+                'min-h-0 rounded-xl border border-[var(--surface-subtle)] bg-background',
+                hasCandidateProvider ? 'block' : 'hidden xl:block'
               )}
-            </div>
-          )}
+            >
+              {!candidateProviderId ? (
+                <div className="flex h-full min-h-[18rem] items-center justify-center px-6 py-10 text-center text-muted-foreground">
+                  <div>
+                    <Icon name="stack" className="mx-auto mb-3 h-10 w-10 opacity-50" />
+                    <p className="typography-ui-label text-foreground">{t('settings.providers.page.connect.selectProviderPlaceholder')}</p>
+                    <p className="mt-1 typography-meta">{t('settings.providers.page.connect.selectProviderHint')}</p>
+                  </div>
+                </div>
+              ) : (
+                <ScrollableOverlay outerClassName="h-full" className="w-full">
+                  <div className="p-4 sm:p-6">
+                    <div className="mb-4 xl:hidden">
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        className="-ml-2 !font-normal"
+                        onClick={() => setCandidateProviderId('')}
+                      >
+                        <Icon name="arrow-left-s" className="h-4 w-4" />
+                        {t('settings.providers.page.connect.backToProviders')}
+                      </Button>
+                    </div>
+
+                    <div className="mb-4 flex items-center gap-3">
+                      <ProviderLogo providerId={candidateProviderId} className="h-5 w-5 shrink-0" />
+                      <div className="min-w-0">
+                        <h2 className="truncate typography-ui-header font-semibold text-foreground">
+                          {getProviderOptionLabel(unconnectedProviders.find((provider) => provider.id === candidateProviderId) ?? { id: candidateProviderId })}
+                        </h2>
+                        <p className="truncate typography-meta text-muted-foreground">
+                          <span className="font-mono">{candidateProviderId}</span>
+                        </p>
+                      </div>
+                    </div>
+
+                    {authLoading ? (
+                      <p className="typography-meta text-muted-foreground">{t('settings.providers.page.auth.loadingMethods')}</p>
+                    ) : (
+                      <section className="space-y-4">
+                        <div className="py-1.5">
+                          <label className="flex items-center gap-1.5 typography-ui-label text-foreground">
+                            {t('settings.providers.page.auth.apiKeyLabel')}
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Icon name="information" className="h-3.5 w-3.5 cursor-help text-muted-foreground/60" />
+                              </TooltipTrigger>
+                              <TooltipContent sideOffset={8} className="max-w-xs">
+                                {t('settings.providers.page.auth.apiKeyTooltip')}
+                              </TooltipContent>
+                            </Tooltip>
+                          </label>
+                          <div className="mt-1.5 flex flex-col gap-2 sm:flex-row sm:items-center">
+                            <Input
+                              type="password"
+                              value={apiKeyInputs[candidateProviderId] ?? ''}
+                              onChange={(event) =>
+                                setApiKeyInputs((prev) => ({
+                                  ...prev,
+                                  [candidateProviderId]: event.target.value,
+                                }))
+                              }
+                              placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
+                              className="flex-1 font-mono text-xs"
+                            />
+                            <Button
+                              size="xs"
+                              className="shrink-0 !font-normal"
+                              onClick={() => handleSaveApiKey(candidateProviderId)}
+                              disabled={authBusyKey === `api:${candidateProviderId}`}
+                            >
+                              {authBusyKey === `api:${candidateProviderId}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
+                            </Button>
+                          </div>
+                        </div>
+
+                        {(() => {
+                          const candidateAuthMethods = authMethodsByProvider[candidateProviderId] ?? [];
+                          const candidateOAuthMethods = candidateAuthMethods.filter(
+                            (method) => normalizeAuthType(method) === 'oauth'
+                          );
+
+                          if (candidateOAuthMethods.length === 0) {
+                            return null;
+                          }
+
+                          return (
+                            <div className="space-y-4 border-t border-[var(--surface-subtle)] pt-2">
+                              {candidateOAuthMethods.map((method, index) => {
+                                const methodLabel = method.label || method.name || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
+                                const codeKey = `${candidateProviderId}:${index}`;
+                                const isPending =
+                                  pendingOAuth?.providerId === candidateProviderId && pendingOAuth?.methodIndex === index;
+
+                                return (
+                                  <div key={`${candidateProviderId}-${methodLabel}`} className="space-y-3">
+                                    <div className="flex items-center justify-between gap-2">
+                                      <div>
+                                        <div className="typography-ui-label text-foreground">{methodLabel}</div>
+                                        {(method.description || method.help) && (
+                                          <div className="typography-meta text-muted-foreground">
+                                            {String(method.description || method.help)}
+                                          </div>
+                                        )}
+                                      </div>
+                                      <Button
+                                        variant="outline"
+                                        size="xs"
+                                        className="!font-normal"
+                                        onClick={() => handleOAuthStart(candidateProviderId, index)}
+                                        disabled={authBusyKey === `oauth:${candidateProviderId}:${index}`}
+                                      >
+                                        {t('settings.providers.page.actions.connect')}
+                                      </Button>
+                                    </div>
+
+                                    {oauthDetails[codeKey]?.instructions && (
+                                      <p className="rounded bg-[var(--primary-base)]/10 px-2 py-1.5 typography-meta text-[var(--primary-base)]">
+                                        {oauthDetails[codeKey]?.instructions}
+                                      </p>
+                                    )}
+
+                                    {oauthDetails[codeKey]?.userCode && (
+                                      <div className="mt-2 flex items-center gap-2">
+                                        <Input value={oauthDetails[codeKey]?.userCode} readOnly className="font-mono text-center tracking-widest" />
+                                        <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthCode(oauthDetails[codeKey]?.userCode ?? '')}>{t('settings.providers.page.actions.copyCode')}</Button>
+                                      </div>
+                                    )}
+
+                                    {oauthDetails[codeKey]?.url && (
+                                      <div className="mt-2 flex items-center gap-2">
+                                        <Input value={oauthDetails[codeKey]?.url} readOnly className="text-xs text-muted-foreground" />
+                                        <div className="flex shrink-0 gap-1">
+                                          <Button variant="outline" size="xs" className="!font-normal" onClick={() => openExternalUrl(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.open')}</Button>
+                                          <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthLink(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.copy')}</Button>
+                                        </div>
+                                      </div>
+                                    )}
+
+                                    {isPending && (
+                                      <div className="mt-2 flex items-center gap-2">
+                                        <Input
+                                          value={oauthCodes[codeKey] ?? ''}
+                                          onChange={(event) =>
+                                            setOauthCodes((prev) => ({
+                                              ...prev,
+                                              [codeKey]: event.target.value,
+                                            }))
+                                          }
+                                          placeholder={t('settings.providers.page.auth.pasteAuthorizationCodePlaceholder')}
+                                          className="font-mono text-xs"
+                                        />
+                                        <Button
+                                          size="xs"
+                                          className="!font-normal"
+                                          onClick={() => handleOAuthComplete(candidateProviderId, index)}
+                                          disabled={authBusyKey === `oauth-complete:${candidateProviderId}:${index}`}
+                                        >
+                                          {authBusyKey === `oauth-complete:${candidateProviderId}:${index}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.complete')}
+                                        </Button>
+                                      </div>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          );
+                        })()}
+                      </section>
+                    )}
+                  </div>
+                </ScrollableOverlay>
+              )}
+            </section>
+          </div>
         </div>
-      </ScrollableOverlay>
+      </div>
     );
   }
 

--- a/packages/ui/src/components/sections/providers/providerConnect.ts
+++ b/packages/ui/src/components/sections/providers/providerConnect.ts
@@ -1,0 +1,167 @@
+export interface AuthMethod {
+  type?: string;
+  name?: string;
+  label?: string;
+  description?: string;
+  help?: string;
+  method?: number;
+  [key: string]: unknown;
+}
+
+export interface ProviderOption {
+  id: string;
+  name?: string;
+}
+
+export interface ProviderOAuthDetails {
+  url?: string;
+  instructions?: string;
+  userCode?: string;
+}
+
+type ProviderOAuthTranslationKey =
+  | 'settings.providers.page.toast.oauthStartFailed'
+  | 'settings.providers.page.toast.oauthDetailsMissing'
+  | 'settings.providers.page.toast.completeOAuthInBrowser';
+
+type ProviderOAuthPendingState = { providerId: string; methodIndex: number } | null;
+type SetStateAction<T> = T | ((current: T) => T);
+type StateUpdater<T> = (value: SetStateAction<T>) => void;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export const getProviderOptionLabel = (provider: ProviderOption) => provider.name || provider.id;
+
+export const getProviderGroupKey = (provider: ProviderOption) => {
+  const firstCharacter = getProviderOptionLabel(provider).trim().charAt(0).toUpperCase();
+  if (firstCharacter >= 'A' && firstCharacter <= 'Z') {
+    return firstCharacter;
+  }
+  if (firstCharacter >= '0' && firstCharacter <= '9') {
+    return '0-9';
+  }
+  return '#';
+};
+
+export const filterUnconnectedProviders = (providers: ProviderOption[], query: string) => {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return providers;
+  }
+
+  return providers.filter((provider) => {
+    const label = getProviderOptionLabel(provider).toLowerCase();
+    return label.includes(normalizedQuery) || provider.id.toLowerCase().includes(normalizedQuery);
+  });
+};
+
+export const groupProviderOptions = (providers: ProviderOption[]) => {
+  const groups = new Map<string, ProviderOption[]>();
+
+  for (const provider of providers) {
+    const groupKey = getProviderGroupKey(provider);
+    const existing = groups.get(groupKey);
+    if (existing) {
+      existing.push(provider);
+    } else {
+      groups.set(groupKey, [provider]);
+    }
+  }
+
+  return Array.from(groups.entries()).sort(([groupA], [groupB]) => {
+    if (groupA === '#') return 1;
+    if (groupB === '#') return -1;
+    return groupA.localeCompare(groupB);
+  });
+};
+
+const parseProviderOAuthDetails = (payload: unknown): ProviderOAuthDetails => {
+  const payloadRecord: Record<string, unknown> = isRecord(payload) ? payload : {};
+  const nestedData = payloadRecord.data;
+  const dataRecord: Record<string, unknown> = isRecord(nestedData) ? nestedData : payloadRecord;
+
+  return {
+    url:
+      (typeof dataRecord.url === 'string' && dataRecord.url) ||
+      (typeof dataRecord.verification_uri_complete === 'string' && dataRecord.verification_uri_complete) ||
+      (typeof dataRecord.verification_uri === 'string' && dataRecord.verification_uri) ||
+      undefined,
+    instructions:
+      (typeof dataRecord.instructions === 'string' && dataRecord.instructions) ||
+      (typeof dataRecord.message === 'string' && dataRecord.message) ||
+      undefined,
+    userCode:
+      (typeof dataRecord.user_code === 'string' && dataRecord.user_code) ||
+      (typeof dataRecord.code === 'string' && dataRecord.code) ||
+      (typeof dataRecord.userCode === 'string' && dataRecord.userCode) ||
+      undefined,
+  };
+};
+
+export const startProviderOAuth = async ({
+  providerId,
+  methodIndex,
+  authorize,
+  authBusyKeyRef,
+  setAuthBusyKey,
+  setOauthDetails,
+  setPendingOAuth,
+  toastMessage,
+  toastError,
+  t,
+  onError,
+}: {
+  providerId: string;
+  methodIndex: number;
+  authorize: (input: { providerID: string; method: number }) => Promise<{ data: unknown; error?: unknown }>;
+  authBusyKeyRef: { current: string | null };
+  setAuthBusyKey: StateUpdater<string | null>;
+  setOauthDetails: StateUpdater<Record<string, ProviderOAuthDetails>>;
+  setPendingOAuth: StateUpdater<ProviderOAuthPendingState>;
+  toastMessage: (message: string) => void;
+  toastError: (message: string) => void;
+  t: (key: ProviderOAuthTranslationKey) => string;
+  onError?: (error: unknown) => void;
+}) => {
+  const busyKey = `oauth:${providerId}:${methodIndex}`;
+  if (authBusyKeyRef.current === busyKey) {
+    return false;
+  }
+
+  authBusyKeyRef.current = busyKey;
+  setAuthBusyKey(busyKey);
+
+  try {
+    const result = await authorize({
+      providerID: providerId,
+      method: methodIndex,
+    });
+    if (result.error) {
+      throw new Error(t('settings.providers.page.toast.oauthStartFailed'));
+    }
+
+    const details = parseProviderOAuthDetails(result.data);
+    if (!details.url && !details.instructions && !details.userCode) {
+      throw new Error(t('settings.providers.page.toast.oauthDetailsMissing'));
+    }
+
+    const detailsKey = `${providerId}:${methodIndex}`;
+    setOauthDetails((prev) => ({
+      ...prev,
+      [detailsKey]: details,
+    }));
+    setPendingOAuth({ providerId, methodIndex });
+    toastMessage(t('settings.providers.page.toast.completeOAuthInBrowser'));
+    return true;
+  } catch (error) {
+    onError?.(error);
+    toastError(t('settings.providers.page.toast.oauthStartFailed'));
+    return false;
+  } finally {
+    if (authBusyKeyRef.current === busyKey) {
+      authBusyKeyRef.current = null;
+    }
+    setAuthBusyKey((current) => (current === busyKey ? null : current));
+  }
+};

--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -607,6 +607,17 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
       useConfigStore.getState().setSelectedProvider(ADD_PROVIDER_SETTINGS_ID);
     }
 
+    if (result.id === 'providers.auth') {
+      const configStore = useConfigStore.getState();
+      const isNarrowProvidersAddFlow = configStore.selectedProviderId === ADD_PROVIDER_SETTINGS_ID
+        && typeof window !== 'undefined'
+        && window.matchMedia('(max-width: 1279.98px)').matches;
+
+      if (isNarrowProvidersAddFlow) {
+        return 'providers.connect';
+      }
+    }
+
     if (result.id === 'plugins.create') {
       return 'plugins.spec';
     }

--- a/packages/ui/src/lib/i18n/messages/en.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/en.settings.ts
@@ -1261,6 +1261,8 @@ export const settingsDict = {
   'settings.providers.page.connect.selectProviderTitle': 'Select Provider',
   'settings.providers.page.connect.providerField': 'Provider',
   'settings.providers.page.connect.selectProviderPlaceholder': 'Select provider',
+  'settings.providers.page.connect.selectProviderHint': 'Choose a provider to configure authentication.',
+  'settings.providers.page.connect.backToProviders': 'Back to providers',
   'settings.providers.page.connect.searchProvidersPlaceholder': 'Search...',
   'settings.providers.page.connect.noProvidersFound': 'No providers found',
   'settings.providers.page.connect.allProvidersConnected': 'All providers connected.',

--- a/packages/ui/src/lib/i18n/messages/es.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/es.settings.ts
@@ -1228,6 +1228,8 @@ export const settingsDict = {
   "settings.providers.page.connect.selectProviderTitle": "Seleccionar proveedor",
   "settings.providers.page.connect.providerField": "Proveedor",
   "settings.providers.page.connect.selectProviderPlaceholder": "Seleccionar proveedor",
+  "settings.providers.page.connect.selectProviderHint": "Elige un proveedor para configurar la autenticacion.",
+  "settings.providers.page.connect.backToProviders": "Volver a proveedores",
   "settings.providers.page.connect.searchProvidersPlaceholder": "Buscar...",
   "settings.providers.page.connect.noProvidersFound": "No se encontraron proveedores",
   "settings.providers.page.connect.allProvidersConnected": "Todos los proveedores están conectados.",

--- a/packages/ui/src/lib/i18n/messages/fr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.settings.ts
@@ -1153,6 +1153,8 @@ export const settingsDict = {
   'settings.providers.page.connect.selectProviderTitle': 'Sélectionnez le fournisseur',
   'settings.providers.page.connect.providerField': 'Fournisseur',
   'settings.providers.page.connect.selectProviderPlaceholder': 'Sélectionnez le fournisseur',
+  'settings.providers.page.connect.selectProviderHint': 'Choisissez un fournisseur pour configurer l\'authentification.',
+  'settings.providers.page.connect.backToProviders': 'Retour aux fournisseurs',
   'settings.providers.page.connect.searchProvidersPlaceholder': 'Recherche...',
   'settings.providers.page.connect.noProvidersFound': 'Aucun fournisseur trouvé',
   'settings.providers.page.connect.allProvidersConnected': 'Tous les fournisseurs connectés.',

--- a/packages/ui/src/lib/i18n/messages/ja.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.settings.ts
@@ -1261,6 +1261,8 @@ export const settingsDict = {
   'settings.providers.page.connect.selectProviderTitle': 'Provider を選択',
   'settings.providers.page.connect.providerField': 'プロバイダー',
   'settings.providers.page.connect.selectProviderPlaceholder': 'Provider を選択',
+  'settings.providers.page.connect.selectProviderHint': '認証を設定するプロバイダーを選択してください。',
+  'settings.providers.page.connect.backToProviders': 'プロバイダー一覧に戻る',
   'settings.providers.page.connect.searchProvidersPlaceholder': '検索...',
   'settings.providers.page.connect.noProvidersFound': 'Provider が見つかりません',
   'settings.providers.page.connect.allProvidersConnected': 'すべての Provider が接続されています。',

--- a/packages/ui/src/lib/i18n/messages/ko.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.settings.ts
@@ -1228,6 +1228,8 @@ export const settingsDict = {
   'settings.providers.page.connect.selectProviderTitle': '프로바이더 선택',
   'settings.providers.page.connect.providerField': '프로바이더',
   'settings.providers.page.connect.selectProviderPlaceholder': '프로바이더 선택',
+  'settings.providers.page.connect.selectProviderHint': '인증을 구성할 프로바이더를 선택하세요.',
+  'settings.providers.page.connect.backToProviders': '프로바이더 목록으로',
   'settings.providers.page.connect.searchProvidersPlaceholder': '검색...',
   'settings.providers.page.connect.noProvidersFound': '프로바이더를 찾을 수 없습니다',
   'settings.providers.page.connect.allProvidersConnected': '모든 프로바이더가 연결되었습니다.',

--- a/packages/ui/src/lib/i18n/messages/pl.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.settings.ts
@@ -1294,6 +1294,8 @@ export const settingsDict = {
   'settings.providers.page.connect.providerField': 'Dostawca',
   'settings.providers.page.connect.searchProvidersPlaceholder': 'Szukaj...',
   'settings.providers.page.connect.selectProviderPlaceholder': 'Wybierz dostawcę',
+  'settings.providers.page.connect.selectProviderHint': 'Wybierz dostawcę, aby skonfigurować uwierzytelnianie.',
+  'settings.providers.page.connect.backToProviders': 'Powrót do dostawców',
   'settings.providers.page.connect.selectProviderTitle': 'Wybierz dostawcę',
   'settings.providers.page.connect.title': 'Połącz dostawcę',
   'settings.providers.page.connectionDetails.configuredIn': 'Skonfigurowano w:',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
@@ -1228,7 +1228,7 @@ export const settingsDict = {
   "settings.providers.page.connect.selectProviderTitle": "Selecionar provedor",
   "settings.providers.page.connect.providerField": "Provedor",
   "settings.providers.page.connect.selectProviderPlaceholder": "Selecionar provedor",
-  "settings.providers.page.connect.selectProviderHint": "Escolha um provedor para configurar a autenticacao.",
+  "settings.providers.page.connect.selectProviderHint": "Escolha um provedor para configurar a autenticação.",
   "settings.providers.page.connect.backToProviders": "Voltar para provedores",
   "settings.providers.page.connect.searchProvidersPlaceholder": "Buscar...",
   "settings.providers.page.connect.noProvidersFound": "Nenhum provedores",

--- a/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
@@ -1228,6 +1228,8 @@ export const settingsDict = {
   "settings.providers.page.connect.selectProviderTitle": "Selecionar provedor",
   "settings.providers.page.connect.providerField": "Provedor",
   "settings.providers.page.connect.selectProviderPlaceholder": "Selecionar provedor",
+  "settings.providers.page.connect.selectProviderHint": "Escolha um provedor para configurar a autenticacao.",
+  "settings.providers.page.connect.backToProviders": "Voltar para provedores",
   "settings.providers.page.connect.searchProvidersPlaceholder": "Buscar...",
   "settings.providers.page.connect.noProvidersFound": "Nenhum provedores",
   "settings.providers.page.connect.allProvidersConnected": "Todos os provedores estão conectados.",

--- a/packages/ui/src/lib/i18n/messages/uk.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.settings.ts
@@ -1228,6 +1228,8 @@ export const settingsDict = {
   "settings.providers.page.connect.selectProviderTitle": "Вибрати провайдера",
   "settings.providers.page.connect.providerField": "Провайдер",
   "settings.providers.page.connect.selectProviderPlaceholder": "Виберіть провайдера",
+  "settings.providers.page.connect.selectProviderHint": "Виберіть провайдера, щоб налаштувати автентифікацію.",
+  "settings.providers.page.connect.backToProviders": "Назад до провайдерів",
   "settings.providers.page.connect.searchProvidersPlaceholder": "Пошук...",
   "settings.providers.page.connect.noProvidersFound": "Немає провайдерів",
   "settings.providers.page.connect.allProvidersConnected": "Усі провайдери підключені.",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
@@ -1228,6 +1228,8 @@ export const settingsDict = {
   'settings.providers.page.connect.selectProviderTitle': '选择提供商',
   'settings.providers.page.connect.providerField': '提供商',
   'settings.providers.page.connect.selectProviderPlaceholder': '选择提供商',
+  'settings.providers.page.connect.selectProviderHint': '选择一个提供商以配置身份验证。',
+  'settings.providers.page.connect.backToProviders': '返回提供商列表',
   'settings.providers.page.connect.searchProvidersPlaceholder': '搜索...',
   'settings.providers.page.connect.noProvidersFound': '未找到提供商',
   'settings.providers.page.connect.allProvidersConnected': '所有提供商均已连接。',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
@@ -1139,6 +1139,8 @@
   'settings.providers.page.connect.selectProviderTitle': '選擇供應商',
   'settings.providers.page.connect.providerField': '供應商',
   'settings.providers.page.connect.selectProviderPlaceholder': '選擇供應商',
+  'settings.providers.page.connect.selectProviderHint': '選擇要設定驗證的供應商。',
+  'settings.providers.page.connect.backToProviders': '返回供應商列表',
   'settings.providers.page.connect.searchProvidersPlaceholder': '搜尋...',
   'settings.providers.page.connect.noProvidersFound': '找不到供應商',
   'settings.providers.page.connect.allProvidersConnected': '所有供應商均已連線。',


### PR DESCRIPTION
## Summary
- replace the add-provider dropdown with a searchable provider browser and dedicated configuration pane
- switch to a single-pane selector/detail flow earlier on narrower screens and keep the two panes independently scrollable
- fix settings search targeting for provider auth on narrow screens while the add-provider flow is active
- stop manually reopening OAuth URLs after authorize so the client no longer triggers duplicate browser launches; opening now relies on the authorize flow itself, with the returned URL still available for manual use

## Testing
- bun run type-check:ui
- bun run lint:ui