### PR TITLE
fix(chat): pin message target during async submit

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1897,8 +1897,6 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             }
         }
 
-        const sendMessageOptions = delivery ? { delivery } : undefined;
-
         // Build the primary message (first part) and additional parts
         let primaryText = '';
         let primaryAttachments: AttachedFile[] = [];
@@ -2025,6 +2023,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         }
 
         if (!primaryText && primaryAttachments.length === 0 && additionalParts.length === 0) return;
+
+        const draft = newSessionDraftOpen ? newSessionDraft : undefined;
+        const sendMessageOptions = delivery || draft || currentSessionId
+            ? { delivery, draft, sessionId: currentSessionId ?? undefined }
+            : undefined;
 
         // Clear queue and input
         if (currentSessionId && queuedMessageId) {

--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -111,6 +111,7 @@ Rules:
 1. If an action mutates session list membership or visible session metadata, update `useGlobalSessionsStore` there.
 2. If an action targets a session by ID, resolve the **session's own directory**. Do not assume the current directory is correct.
 3. `session-ui-store.ts` should delegate to `session-actions.ts` for these mutations instead of duplicating SDK calls.
+4. Draft materialization creates without automatic selection, then selects only if no newer draft has replaced it.
 
 Examples of global-store updates performed in `session-actions.ts`:
 

--- a/packages/ui/src/sync/__tests__/issue-2039.test.ts
+++ b/packages/ui/src/sync/__tests__/issue-2039.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test"
 import { togglePermissionAutoAccept } from "../../components/chat/permissionAutoAccept"
 
 const storage = new Map<string, string>()
-const createSessionCalls: Array<{ title?: string; directory: string | null; parentID: string | null; metadata?: unknown }> = []
+const createSessionCalls: Array<{ title?: string; directory: string | null; parentID: string | null; metadata?: unknown; options?: unknown }> = []
 const permissionAutoAcceptCalls: Array<[string, boolean]> = []
+const optimisticSendSessionIds: string[] = []
+const addSessionToFolderCalls: Array<[string, string, string]> = []
 
 const getMockCalls = (fn: unknown): unknown[][] => ((fn as { mock?: { calls: unknown[][] } }).mock?.calls ?? [])
 
@@ -53,6 +55,16 @@ const deferredStorage: Storage = {
 
 mock.module("@/stores/utils/safeStorage", () => ({
   getDeferredSafeStorage: () => deferredStorage,
+  getSafeStorage: () => deferredStorage,
+  getSafeSessionStorage: () => deferredStorage,
+  createDeferredSafeJSONStorage: () => ({
+    getItem: (key: string) => {
+      const value = deferredStorage.getItem(key)
+      return value ? JSON.parse(value) : null
+    },
+    setItem: (key: string, value: unknown) => deferredStorage.setItem(key, JSON.stringify(value)),
+    removeItem: (key: string) => deferredStorage.removeItem(key),
+  }),
 }))
 
 mock.module("@/lib/opencode/client", () => ({
@@ -81,6 +93,27 @@ mock.module("@/stores/useConfigStore", () => ({
       applyDefaultModelAgentSelection: mock(() => undefined),
     }),
   },
+}))
+
+mock.module("@/stores/useUIStore", () => ({
+  useUIStore: {
+    getState: () => ({
+      sessionGoalDefaultBudgetEnabled: false,
+      sessionGoalDefaultBudget: 0,
+    }),
+  },
+}))
+
+mock.module("@/stores/useSessionGoalArmStore", () => ({
+  useSessionGoalArmStore: {
+    getState: () => ({
+      consume: () => ({ armed: false, objectiveOverride: null }),
+    }),
+  },
+}))
+
+mock.module("@/lib/sessionGoalActions", () => ({
+  setSessionGoal: mock(async () => undefined),
 }))
 
 mock.module("@/stores/useProjectsStore", () => ({
@@ -115,7 +148,9 @@ mock.module("@/stores/useGlobalSessionsStore", () => ({
 mock.module("@/stores/useSessionFoldersStore", () => ({
   useSessionFoldersStore: {
     getState: () => ({
-      addSessionToFolder: mock(() => undefined),
+      addSessionToFolder: mock((scopeKey: string, folderId: string, sessionId: string) => {
+        addSessionToFolderCalls.push([scopeKey, folderId, sessionId])
+      }),
     }),
   },
 }))
@@ -227,8 +262,8 @@ mock.module("../sync-refs", () => ({
 }))
 
 mock.module("../session-actions", () => ({
-  createSession: mock(async (title: string | undefined, directory: string | null, parentID: string | null, metadata?: unknown) => {
-    createSessionCalls.push({ title, directory, parentID, metadata })
+  createSession: mock(async (title: string | undefined, directory: string | null, parentID: string | null, metadata?: unknown, options?: unknown) => {
+    createSessionCalls.push({ title, directory, parentID, metadata, options })
     return { id: "ses_issue_2039", directory }
   }),
   deleteSession: mock(async () => true),
@@ -236,12 +271,17 @@ mock.module("../session-actions", () => ({
   updateSessionTitle: mock(async () => undefined),
   shareSession: mock(async () => undefined),
   unshareSession: mock(async () => undefined),
-  optimisticSend: mock(async () => undefined),
+  optimisticSend: mock(async (params: { sessionId: string }) => {
+    optimisticSendSessionIds.push(params.sessionId)
+  }),
   refetchSessionMessages: mock(async () => undefined),
   revertToMessage: mock(async () => undefined),
   unrevertSession: mock(async () => undefined),
   forkFromMessage: mock(async () => undefined),
   fetchMessagesForSession: mock(async () => undefined),
+  getSessionLastAssistantModel: () => null,
+  patchSessionMetadata: mock(async () => undefined),
+  abortCurrentOperation: mock(async () => undefined),
 }))
 
 const { materializeOpenDraftSession, useSessionUIStore } = await import("../session-ui-store")
@@ -298,6 +338,8 @@ describe("issue 2039 draft auto-accept", () => {
     storage.clear()
     createSessionCalls.length = 0
     permissionAutoAcceptCalls.length = 0
+    optimisticSendSessionIds.length = 0
+    addSessionToFolderCalls.length = 0
 
     useSessionUIStore.setState({
       currentSessionId: null,
@@ -347,5 +389,67 @@ describe("issue 2039 draft auto-accept", () => {
     expect(result).toBeNull()
     expect(createSessionCalls).toHaveLength(0)
     expect(permissionAutoAcceptCalls).toHaveLength(0)
+  })
+
+  test("keeps the first draft message pinned to the materialized session", async () => {
+    useSessionUIStore.getState().openNewSessionDraft()
+    const draft = useSessionUIStore.getState().newSessionDraft
+
+    useSessionUIStore.getState().setCurrentSession("ses_old")
+    await useSessionUIStore.getState().sendMessage(
+      "hello",
+      "provider",
+      "model",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "normal",
+      { draft },
+    )
+
+    expect(optimisticSendSessionIds).toEqual(["ses_issue_2039"])
+  })
+
+  test("materializes the same draft only once", async () => {
+    useSessionUIStore.getState().openNewSessionDraft()
+    const draft = useSessionUIStore.getState().newSessionDraft
+    const selection = { providerID: "provider", modelID: "model" }
+
+    const first = materializeOpenDraftSession(selection, draft)
+    useSessionUIStore.getState().setDraftPermissionAutoAcceptEnabled(true)
+    const updatedDraft = useSessionUIStore.getState().newSessionDraft
+    const second = materializeOpenDraftSession(selection, updatedDraft)
+
+    expect(second).toBe(first)
+    await Promise.all([first, second])
+    expect(createSessionCalls).toHaveLength(1)
+  })
+
+  test("does not close a newer draft when an older draft materializes", async () => {
+    useSessionUIStore.getState().openNewSessionDraft({ title: "first" })
+    const firstDraft = useSessionUIStore.getState().newSessionDraft
+    const materialization = materializeOpenDraftSession({ providerID: "provider", modelID: "model" }, firstDraft)
+
+    useSessionUIStore.getState().openNewSessionDraft({ title: "second", targetFolderId: "folder-b" })
+    await materialization
+
+    expect(createSessionCalls[0]?.options).toEqual({ select: false })
+    expect(addSessionToFolderCalls).toHaveLength(0)
+    expect(useSessionUIStore.getState().newSessionDraft.open).toBe(true)
+    expect(useSessionUIStore.getState().newSessionDraft.title).toBe("second")
+    expect(useSessionUIStore.getState().currentSessionId).toBeNull()
+  })
+
+  test("does not reclaim selection after its draft was closed", async () => {
+    useSessionUIStore.getState().openNewSessionDraft()
+    const draft = useSessionUIStore.getState().newSessionDraft
+    const materialization = materializeOpenDraftSession({ providerID: "provider", modelID: "model" }, draft)
+
+    useSessionUIStore.getState().closeNewSessionDraft()
+    await materialization
+
+    expect(useSessionUIStore.getState().currentSessionId).toBeNull()
   })
 })

--- a/packages/ui/src/sync/__tests__/issue-2039.test.ts
+++ b/packages/ui/src/sync/__tests__/issue-2039.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test"
 import { togglePermissionAutoAccept } from "../../components/chat/permissionAutoAccept"
+import {
+  createPendingDraftWorktreeRequest,
+  resolvePendingDraftWorktreeRequest,
+} from "../../lib/worktrees/pendingDraftWorktree"
 
 const storage = new Map<string, string>()
 const createSessionCalls: Array<{ title?: string; directory: string | null; parentID: string | null; metadata?: unknown; options?: unknown }> = []
@@ -451,5 +455,25 @@ describe("issue 2039 draft auto-accept", () => {
     await materialization
 
     expect(useSessionUIStore.getState().currentSessionId).toBeNull()
+  })
+
+  test("uses the resolved worktree target from the live draft", async () => {
+    const requestId = createPendingDraftWorktreeRequest()
+    useSessionUIStore.getState().openNewSessionDraft({
+      directoryOverride: "/project",
+      pendingWorktreeRequestId: requestId,
+    })
+    const capturedDraft = useSessionUIStore.getState().newSessionDraft
+
+    resolvePendingDraftWorktreeRequest(requestId, "/project/.worktrees/feature")
+    useSessionUIStore.getState().resolvePendingDraftWorktreeTarget(requestId, "/project/.worktrees/feature")
+
+    const result = await materializeOpenDraftSession(
+      { providerID: "provider", modelID: "model" },
+      capturedDraft,
+    )
+
+    expect(result?.directory).toBe("/project/.worktrees/feature")
+    expect(createSessionCalls[0]?.directory).toBe("/project/.worktrees/feature")
   })
 })

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -433,6 +433,7 @@ export async function createSession(
   directoryOverride?: string | null,
   parentID?: string | null,
   metadata?: Record<string, unknown>,
+  options?: { select?: boolean },
 ): Promise<Session | null> {
   try {
     const session = await opencodeClient.createSession({
@@ -447,7 +448,9 @@ export async function createSession(
     if (sessionDirectory) {
       registerSessionDirectory(session.id, sessionDirectory)
     }
-    useSessionUIStore.getState().setCurrentSession(session.id, sessionDirectory)
+    if (options?.select !== false) {
+      useSessionUIStore.getState().setCurrentSession(session.id, sessionDirectory)
+    }
     useSessionUIStore.getState().markSessionAsOpenChamberCreated(session.id)
     useGlobalSessionsStore.getState().upsertSession(session)
     return session

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -173,6 +173,12 @@ export function routeMessage(params: {
 type SendMessageOptions = {
   sessionId?: string
   delivery?: 'steer'
+  draft?: NewSessionDraftState
+}
+
+type CreateSessionOptions = {
+  select?: boolean
+  targetFolderId?: string
 }
 
 type AssistantMessageSessionExecution = {
@@ -199,6 +205,7 @@ export type { SessionMemoryState } from "./viewport-store"
 
 export type NewSessionDraftState = {
   open: boolean
+  materializationKey?: object
   selectedProjectId?: string | null
   directoryOverride: string | null
   permissionAutoAcceptEnabled?: boolean
@@ -288,7 +295,7 @@ export type SessionUIState = {
     options?: SendMessageOptions,
   ) => Promise<void>
 
-  createSession: (title?: string, directoryOverride?: string | null, parentID?: string | null, metadata?: Record<string, unknown>) => Promise<Session | null>
+  createSession: (title?: string, directoryOverride?: string | null, parentID?: string | null, metadata?: Record<string, unknown>, options?: CreateSessionOptions) => Promise<Session | null>
   deleteSession: (id: string, options?: Record<string, unknown>) => Promise<boolean>
   deleteSessions: (ids: string[], options?: Record<string, unknown>) => Promise<{ deletedIds: string[]; failedIds: string[] }>
   archiveSession: (id: string) => Promise<boolean>
@@ -437,73 +444,91 @@ const waitForWorktreeBootstrapIfConfigured = async (directory: string | null, pr
   }
 }
 
-export async function materializeOpenDraftSession(selection: {
+const draftMaterializations = new WeakMap<object, Promise<MaterializedDraftSession | null>>()
+
+export function materializeOpenDraftSession(selection: {
   providerID: string
   modelID: string
   agent?: string
   variant?: string
-}): Promise<MaterializedDraftSession | null> {
+}, draftOverride?: NewSessionDraftState): Promise<MaterializedDraftSession | null> {
   const store = useSessionUIStore.getState()
-  const draft = store.newSessionDraft
-  if (!draft?.open) return null
-  const draftPermissionAutoAcceptEnabled = draft.permissionAutoAcceptEnabled === true
+  const draft = draftOverride ?? store.newSessionDraft
+  if (!draft?.open) return Promise.resolve(null)
+  const materializationKey = draft.materializationKey ?? draft
 
-  const trimmedAgent = typeof selection.agent === "string" && selection.agent.trim().length > 0
-    ? selection.agent.trim()
-    : undefined
-  let draftDirectoryOverride = draft.bootstrapPendingDirectory ?? draft.directoryOverride ?? null
-  const draftProjectId = draft.selectedProjectId ?? null
+  const pending = draftMaterializations.get(materializationKey)
+  if (pending) return pending
 
-  if (draft.pendingWorktreeRequestId) {
-    draftDirectoryOverride = await waitForPendingDraftWorktreeRequest(draft.pendingWorktreeRequestId)
-    store.resolvePendingDraftWorktreeTarget(draft.pendingWorktreeRequestId, draftDirectoryOverride)
-  }
+  const materialization = (async () => {
+    const draftPermissionAutoAcceptEnabled = draft.permissionAutoAcceptEnabled === true
+    const trimmedAgent = typeof selection.agent === "string" && selection.agent.trim().length > 0
+      ? selection.agent.trim()
+      : undefined
+    let draftDirectoryOverride = draft.bootstrapPendingDirectory ?? draft.directoryOverride ?? null
+    const draftProjectId = draft.selectedProjectId ?? null
 
-  await waitForWorktreeBootstrapIfConfigured(draftDirectoryOverride, draftProjectId)
+    if (draft.pendingWorktreeRequestId) {
+      draftDirectoryOverride = await waitForPendingDraftWorktreeRequest(draft.pendingWorktreeRequestId)
+      store.resolvePendingDraftWorktreeTarget(draft.pendingWorktreeRequestId, draftDirectoryOverride)
+    }
 
-  const created = await store.createSession(draft.title, draftDirectoryOverride, draft.parentID ?? null)
-  if (!created?.id) throw new Error("Failed to create session")
+    await waitForWorktreeBootstrapIfConfigured(draftDirectoryOverride, draftProjectId)
 
-  persistDraftTarget({
-    projectId: draftProjectId,
-    directory: normalizePath(draftDirectoryOverride ?? created.directory ?? null),
-  })
+    const created = await store.createSession(draft.title, draftDirectoryOverride, draft.parentID ?? null, undefined, {
+      select: false,
+      targetFolderId: draft.targetFolderId,
+    })
+    if (!created?.id) throw new Error("Failed to create session")
 
-  const draftSyntheticParts = draft.syntheticParts
-  const createdDirectory = normalizePath(draftDirectoryOverride ?? created.directory ?? null)
-  const configState = useConfigStore.getState()
-  void activateConfigForDirectory(createdDirectory).catch((error) => {
-    console.warn("Failed to activate directory after creating session:", error)
-  })
+    persistDraftTarget({
+      projectId: draftProjectId,
+      directory: normalizePath(draftDirectoryOverride ?? created.directory ?? null),
+    })
 
-  const effectiveDraftAgent = trimmedAgent ?? configState.currentAgentName
+    const draftSyntheticParts = draft.syntheticParts
+    const createdDirectory = normalizePath(draftDirectoryOverride ?? created.directory ?? null)
+    const configState = useConfigStore.getState()
+    void activateConfigForDirectory(createdDirectory).catch((error) => {
+      console.warn("Failed to activate directory after creating session:", error)
+    })
 
-  useSelectionStore.getState().saveSessionModelSelection(created.id, selection.providerID, selection.modelID)
+    const effectiveDraftAgent = trimmedAgent ?? configState.currentAgentName
 
-  if (effectiveDraftAgent) {
-    useSelectionStore.getState().saveSessionAgentSelection(created.id, effectiveDraftAgent)
-    useSelectionStore.getState().saveAgentModelForSession(created.id, effectiveDraftAgent, selection.providerID, selection.modelID)
-    useSelectionStore.getState().saveAgentModelVariantForSession(created.id, effectiveDraftAgent, selection.providerID, selection.modelID, selection.variant)
-  }
+    useSelectionStore.getState().saveSessionModelSelection(created.id, selection.providerID, selection.modelID)
 
-  store.initializeNewOpenChamberSession(created.id, configState.agents ?? [])
+    if (effectiveDraftAgent) {
+      useSelectionStore.getState().saveSessionAgentSelection(created.id, effectiveDraftAgent)
+      useSelectionStore.getState().saveAgentModelForSession(created.id, effectiveDraftAgent, selection.providerID, selection.modelID)
+      useSelectionStore.getState().saveAgentModelVariantForSession(created.id, effectiveDraftAgent, selection.providerID, selection.modelID, selection.variant)
+    }
 
-  store.setCurrentSession(created.id, createdDirectory)
+    store.initializeNewOpenChamberSession(created.id, configState.agents ?? [])
 
-  if (draftPermissionAutoAcceptEnabled) {
-    void import("@/stores/permissionStore")
-      .then(({ usePermissionStore }) => usePermissionStore.getState().setSessionAutoAccept(created.id, true))
-      .catch((error) => {
-        console.warn("Failed to apply draft permission auto-accept to new session:", error)
-      })
-  }
+    const currentDraft = useSessionUIStore.getState().newSessionDraft
+    if (currentDraft.open && (currentDraft.materializationKey ?? currentDraft) === materializationKey) {
+      store.setCurrentSession(created.id, createdDirectory)
+    }
 
-  return {
-    sessionId: created.id,
-    directory: createdDirectory,
-    agent: effectiveDraftAgent,
-    syntheticParts: draftSyntheticParts,
-  }
+    if (draftPermissionAutoAcceptEnabled) {
+      void import("@/stores/permissionStore")
+        .then(({ usePermissionStore }) => usePermissionStore.getState().setSessionAutoAccept(created.id, true))
+        .catch((error) => {
+          console.warn("Failed to apply draft permission auto-accept to new session:", error)
+        })
+    }
+
+    return {
+      sessionId: created.id,
+      directory: createdDirectory,
+      agent: effectiveDraftAgent,
+      syntheticParts: draftSyntheticParts,
+    }
+  })()
+
+  draftMaterializations.set(materializationKey, materialization)
+  void materialization.catch(() => draftMaterializations.delete(materializationKey))
+  return materialization
 }
 
 // ---------------------------------------------------------------------------
@@ -739,6 +764,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
 
     const nextDraft: NewSessionDraftState = {
       open: true,
+      materializationKey: {},
       selectedProjectId: selectedProject?.id ?? null,
       directoryOverride: directory,
       permissionAutoAcceptEnabled: options?.permissionAutoAcceptEnabled === true,
@@ -1058,13 +1084,13 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     }
 
     // ---- New session from draft ----
-    if (!options?.sessionId && draft?.open) {
+    if (!options?.sessionId && (options?.draft?.open || draft?.open)) {
       const createdDraftSession = await materializeOpenDraftSession({
         providerID,
         modelID,
         agent: trimmedAgent,
         variant,
-      })
+      }, options?.draft)
       if (!createdDraftSession) throw new Error("Failed to create session")
 
       const mergedAdditionalParts = createdDraftSession.syntheticParts?.length
@@ -1193,14 +1219,13 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
   // ---------------------------------------------------------------------------
   // createSession
   // ---------------------------------------------------------------------------
-  createSession: async (title, directoryOverride, parentID, metadata) => {
+  createSession: async (title, directoryOverride, parentID, metadata, options) => {
     const draft = get().newSessionDraft
-    const targetFolderId = draft.targetFolderId
-    get().closeNewSessionDraft()
+    const targetFolderId = options ? options.targetFolderId : draft.targetFolderId
 
     try {
       const dir = directoryOverride ?? opencodeClient.getDirectory()
-      const session = await createSessionAction(title, dir, parentID ?? null, metadata)
+      const session = await createSessionAction(title, dir, parentID ?? null, metadata, { select: options?.select })
       if (!session) return null
 
       if (targetFolderId) {

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -466,11 +466,20 @@ export function materializeOpenDraftSession(selection: {
       ? selection.agent.trim()
       : undefined
     let draftDirectoryOverride = draft.bootstrapPendingDirectory ?? draft.directoryOverride ?? null
+    let pendingWorktreeRequestId = draft.pendingWorktreeRequestId
     const draftProjectId = draft.selectedProjectId ?? null
 
-    if (draft.pendingWorktreeRequestId) {
-      draftDirectoryOverride = await waitForPendingDraftWorktreeRequest(draft.pendingWorktreeRequestId)
-      store.resolvePendingDraftWorktreeTarget(draft.pendingWorktreeRequestId, draftDirectoryOverride)
+    const liveDraft = useSessionUIStore.getState().newSessionDraft
+    if (liveDraft.open
+      && (liveDraft.materializationKey ?? liveDraft) === materializationKey
+      && liveDraft.pendingWorktreeRequestId !== pendingWorktreeRequestId) {
+      pendingWorktreeRequestId = liveDraft.pendingWorktreeRequestId
+      draftDirectoryOverride = liveDraft.bootstrapPendingDirectory ?? liveDraft.directoryOverride ?? draftDirectoryOverride
+    }
+
+    if (pendingWorktreeRequestId) {
+      draftDirectoryOverride = await waitForPendingDraftWorktreeRequest(pendingWorktreeRequestId)
+      store.resolvePendingDraftWorktreeTarget(pendingWorktreeRequestId, draftDirectoryOverride)
     }
 
     await waitForWorktreeBootstrapIfConfigured(draftDirectoryOverride, draftProjectId)


### PR DESCRIPTION
## Summary

- pin the selected session or draft when chat submission begins so async response-style and snippet preparation cannot reroute the message
- deduplicate draft materialization and preserve newer draft/session selections
- prevent captured drafts from inheriting a newer draft's folder target
- add regression coverage for stale session routing and overlapping draft materialization

## Validation

- `bun test packages/ui/src/sync/__tests__/issue-2039.test.ts` (8 passed)
- `bun test packages/ui/src/sync/session-actions.test.ts` (22 passed)
- `bun test packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts` (9 passed)
- `bun test packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.test.ts` (8 passed)
- `bun run type-check` in `packages/ui`
- `bun run lint` in `packages/ui`
- `bun run dead-code` (existing repository findings only)