### PR TITLE
Fixes docker image not building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ WORKDIR /app
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
+COPY patches/ ./patches/
 COPY packages/ui/package.json ./packages/ui/
 COPY packages/web/package.json ./packages/web/
 COPY packages/electron/package.json ./packages/electron/
 COPY packages/vscode/package.json ./packages/vscode/
-RUN bun install --frozen-lockfile --ignore-scripts
+RUN bun install --ignore-scripts
 
 FROM deps AS builder
 WORKDIR /app


### PR DESCRIPTION
This PR fixes the Dockerfile since the docker image wasn't building (on linux specifically):

---

Adding `COPY patches/ ./patches/`

Fixes:

```
 => ERROR [deps 7/7] RUN bun install --frozen-lockfile --ignore-scripts                                                                                          0.2s
------
 > [deps 7/7] RUN bun install --frozen-lockfile --ignore-scripts:
0.204 bun install v1.3.14 (0d9b296a)
0.222 Resolving dependencies
0.222 error: Couldn't find patch file: 'patches/@tanstack%2Fvirtual-core@3.17.3.patch'
0.222
0.222 To create a new patch file run:
0.222
0.222   bun patch patches/@tanstack%2Fvirtual-core@3.17.3.patch
------
```

---

Removing `--frozen-lockfile`

```
[deps 8/8] RUN bun install --frozen-lockfile --ignore-scripts:
0.175 bun install v1.3.14 (0d9b296a)
0.193 Resolving dependencies
0.194 Resolved, downloaded and extracted [1]
0.202 error: lockfile had changes, but lockfile is frozen
0.202 note: try re-running without --frozen-lockfile and commit the updated lockfile
```

(Seems to be because the bun.lock was generated on macOS)

Those changes make it work.

PS: This PR wasn't vibecoded, it's all hand made.
