### PR TITLE
fix(sidebar): use composedPath() instead of contains() for outside-click detection

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -493,7 +493,7 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
   React.useEffect(() => {
     if (editingId !== session.id) return;
     const handleDocMouseDown = (e: MouseEvent) => {
-      if (formRef.current && !formRef.current.contains(e.target as Node)) {
+      if (formRef.current && !e.composedPath().includes(formRef.current)) {
         handleSaveEditRef.current(renameDraftRef.current);
       }
     };


### PR DESCRIPTION
## Summary

Fixes #2204, Fixes #2316 — inline session rename reverts to the old title (or does not update until restart) after clicking the check button.

## Root cause

The issue was originally misdiagnosed as a `shouldSkipStaleSessionEvent` timestamp comparison problem. Through runtime proxy debugging (fetch hook, EventSource hook, DOM mutation observer, `Node.prototype.contains` proxy), the true root cause was identified:

**`Node.contains()` returns `false` for SVG `<use>` elements** because it does not cross shadow DOM boundaries. When the user clicks the check (submit) button to save a rename, the click target is an SVG `<use>` element inside the `<Icon name="check">` component. The mousedown handler at `SessionNodeItem.tsx:484` uses `formRef.current.contains(e.target)` to detect outside clicks — it returns `false`, so the handler fires `handleSaveEdit` with the stale draft value **before** the form submit fires with the new value. Two unsynchronized PATCH requests race to the server; whichever arrives last wins.

## Why this fix and not the alternatives

The issue proposed three directions:

| Proposal | Verdict | Reason |
|---|---|---|
| **A. Debounce SSE per session** | Not the root cause | No SSE events are broadcast during rename at all |
| **B. Title diff in `shouldSkipStaleSessionEvent`** | Not the root cause | The function is not involved — the server does not send SSE on rename |
| **C. Directory propagation** | Already handled | `mirrorSessionIntoLiveStores` was already added in PR #2043 |

The actual root cause is a DOM API limitation: `Node.contains()` cannot traverse shadow DOM boundaries created by SVG `<use>` elements. The fix uses `e.composedPath()` — the standard Web API designed for crossing shadow DOM boundaries — instead of `contains()`.

## The fix

**One line changed** in `packages/ui/src/components/session/sidebar/SessionNodeItem.tsx:484`:

```diff
-      if (formRef.current && !formRef.current.contains(e.target as Node)) {
+      if (formRef.current && !e.composedPath().includes(formRef.current)) {
```

`e.composedPath()` returns the full event propagation path including nodes inside shadow DOM trees. If `formRef.current` is in the path, the click originated from inside the form — regardless of whether the target is a shadow DOM node.

## Validation

- `bun test session-actions.test.ts` — 22 pass, 0 fail
- `bun test session-event-freshness.test.ts` — 3 pass, 0 fail
- OCR (open-code-review) — 0 comments, "Looks good to me"
- Manual review confirms `composedPath()` is well-supported in all modern browsers and Electron (Chrome 53+, Firefox 59+, Safari 10+, Edge 79+)

## Related

- Issue #2031 — original inline rename revert race
- PR #2043 — previous fix attempt (added `mirrorSessionIntoLiveStores` and `shouldSkipStaleSessionEvent`)
- Issue #2204 — this bug