### PR TITLE
feat(tunnels): add managed direct E2EE profile configuration

### DIFF
--- a/.agents/skills/relay-transport/SKILL.md
+++ b/.agents/skills/relay-transport/SKILL.md
@@ -32,6 +32,10 @@ Adding a new WS endpoint (or porting one, e.g. the planned terminal port) requir
 4. **Do not touch origin handling.** The server rejects WS upgrades whose `Origin` it does not trust. Over the tunnel the host dials loopback and presents the loopback origin (`http://127.0.0.1:<port>`), which the server trusts as same-origin — this already covers every allowlisted WS path. **Never reintroduce reliance on `window.location.origin`**: in the iOS WKWebView it is `"null"`/empty for the custom scheme, so forwarding it produces a 403.
 5. **Test over the relay, not just direct/desktop.** A new WS may be the first WebSocket the mobile client runs through the tunnel (events are SSE-locked on Capacitor). Passing on desktop or a direct connection proves nothing about the relay path.
 
+The dedicated `/api/openchamber/direct-e2ee/ws` outer endpoint is an intentional exception to the normal WebSocket rules above.
+It is credential-free, carries only ciphertext, and owns its own authority validation and admission.
+It deliberately stays outside `ALLOWED_WS_PATHS` and `isUrlAuthWebSocketPath`; never add it to either URL-token allowlist.
+
 ## Rules for the tunnel/crypto/codec internals
 
 - **Two implementations must stay byte-compatible.** The E2EE and framing exist as TS (`packages/ui/src/lib/relay/{crypto,handshake,tunnel-codec}.ts`, normative) and a JS host mirror (`packages/web/server/lib/relay/{e2ee,tunnel-codec}.js`). Any wire-format, frame-type, handshake, or batching change must update **both** and keep `packages/web/server/lib/relay/cross-compat.test.js` green.

--- a/packages/ui/src/lib/relay/tunnel-client.test.ts
+++ b/packages/ui/src/lib/relay/tunnel-client.test.ts
@@ -246,12 +246,14 @@ const setupClient = async (
   killWire: () => void;
   sendTextToClient: (text: string) => void;
   clientBinaryCount: () => number;
+  requestedUrls: () => string[];
 }> => {
   const hostKeyPair = await generateEcdhKeyPair();
   const hostPubJwk = await exportPublicKeyJwk(hostKeyPair.publicKey);
   let count = 0;
   let lastClientEndpoint: FakeEndpoint | null = null;
   let lastHostEndpoint: FakeEndpoint | null = null;
+  const urls: string[] = [];
   const client = createRelayTunnelClient({
     relayUrl: 'wss://relay.test/ws',
     serverId: 'server-1',
@@ -262,7 +264,8 @@ const setupClient = async (
     reconnectBaseDelayMs: 20,
     reconnectMaxDelayMs: 80,
     ...clientOverrides,
-    createWireSocket: () => {
+    createWireSocket: (url) => {
+      urls.push(url);
       count += 1;
       const clientEndpoint = new FakeEndpoint();
       const hostEndpoint = new FakeEndpoint();
@@ -278,9 +281,10 @@ const setupClient = async (
   return {
     client,
     connectionCount: () => count,
-    killWire: () => lastClientEndpoint?.close(1006, 'killed'),
+    killWire: (code = 1006, reason = 'killed') => lastClientEndpoint?.close(code, reason),
     sendTextToClient: (text: string) => lastHostEndpoint?.send(text),
     clientBinaryCount: () => lastClientEndpoint?.binarySent ?? 0,
+    requestedUrls: () => urls,
   };
 };
 
@@ -296,6 +300,83 @@ const track = (client: RelayTunnelClient): RelayTunnelClient => {
 };
 
 describe('createRelayTunnelClient', () => {
+  test('does not publish or expose a channel until readiness succeeds', async () => {
+    let release!: () => void;
+    const readiness = new Promise<void>((resolve) => { release = resolve; });
+    const { client } = await setupClient({}, { channelReadiness: async ({ fetch }) => {
+      const health = await fetch('/health');
+      expect(health.status).toBe(200);
+      await readiness;
+    } });
+    track(client);
+    const request = client.fetch('/health');
+    await wait(50);
+    expect(client.getStatus().state).not.toBe('connected');
+    let settled = false;
+    void request.finally(() => { settled = true; });
+    await wait(10);
+    expect(settled).toBe(false);
+    release();
+    expect((await request).status).toBe(200);
+    expect(client.getStatus().state).toBe('connected');
+  });
+
+  test('runs readiness again before queued requests resume after reconnect', async () => {
+    let checks = 0;
+    let releaseSecond!: () => void;
+    const second = new Promise<void>((resolve) => { releaseSecond = resolve; });
+    const { client, killWire } = await setupClient({}, { channelReadiness: async ({ fetch }) => {
+      checks += 1;
+      expect((await fetch('/health')).status).toBe(200);
+      if (checks === 2) await second;
+    } });
+    track(client);
+    await client.fetch('/health');
+    killWire();
+    await wait(10);
+    const queued = client.fetch('/health');
+    await wait(80);
+    expect(checks).toBe(2);
+    expect(client.getStatus().state).not.toBe('connected');
+    releaseSecond();
+    expect((await queued).status).toBe(200);
+  });
+
+  test('keeps public fetch and WebSocket blocked together until readiness publishes', async () => {
+    let release!: () => void;
+    const readiness = new Promise<void>((resolve) => { release = resolve; });
+    const { client } = await setupClient({}, { channelReadiness: async () => readiness });
+    track(client);
+    const request = client.fetch('/health');
+    const socket = client.openWebSocket('/api/event/ws');
+    let fetchSettled = false;
+    let socketOpened = false;
+    void request.then(() => { fetchSettled = true; });
+    socket.onopen = () => { socketOpened = true; };
+    await wait(50);
+    expect(fetchSettled).toBe(false);
+    expect(socketOpened).toBe(false);
+    expect(socket.readyState).toBe(0);
+    release();
+    expect((await request).status).toBe(200);
+    await wait(20);
+    expect(socketOpened).toBe(true);
+  });
+  test('preserves relay URL construction by default and accepts an exact outer URL', async () => {
+    const relay = await setupClient();
+    track(relay.client);
+    await relay.client.fetch('/health');
+    const relayUrl = new URL(relay.requestedUrls()[0]);
+    expect(relayUrl.origin + relayUrl.pathname).toBe('wss://relay.test/ws');
+    expect(relayUrl.searchParams.get('role')).toBe('client');
+    expect(relayUrl.searchParams.get('serverId')).toBe('server-1');
+
+    const direct = await setupClient({}, { outerWebSocketUrl: 'wss://managed.example/api/openchamber/direct-e2ee/ws' });
+    track(direct.client);
+    await direct.client.fetch('/health');
+    expect(direct.requestedUrls()[0]).toBe('wss://managed.example/api/openchamber/direct-e2ee/ws');
+  });
+
   test('performs concurrent fetches over one tunnel', async () => {
     const { client } = await setupClient();
     track(client);
@@ -366,6 +447,10 @@ describe('createRelayTunnelClient', () => {
   test('fails open streams on reconnect and recovers on retry', async () => {
     const { client, connectionCount, killWire } = await setupClient();
     track(client);
+    const failures: string[] = [];
+    client.subscribeStatus((status) => {
+      if (status.failureClassification) failures.push(status.failureClassification);
+    });
     const response = await client.fetch('/never-ends');
     const reader = response.body!.getReader();
     await reader.read();
@@ -380,6 +465,7 @@ describe('createRelayTunnelClient', () => {
     killWire();
     await expect(reader.read()).rejects.toThrow();
     expect(await socketClosed).toBe(1012);
+    expect(failures).toContain('network');
 
     // The client reconnects a fresh wire and works again.
     const health = await client.fetch('/health');
@@ -430,12 +516,17 @@ describe('createRelayTunnelClient', () => {
   test('fails closed on non-ready plaintext after establishment', async () => {
     const { client, connectionCount, sendTextToClient } = await setupClient();
     track(client);
+    const failures: string[] = [];
+    client.subscribeStatus((status) => {
+      if (status.failureClassification) failures.push(status.failureClassification);
+    });
     await client.fetch('/health');
     expect(connectionCount()).toBe(1);
     sendTextToClient('{"anything":"plaintext"}');
     // The channel must reset (fail closed) and the client reconnect a new wire.
     await wait(150);
     expect(connectionCount()).toBeGreaterThan(1);
+    expect(failures).toContain('protocol');
   });
 
   test('publishes status transitions to subscribers', async () => {

--- a/packages/ui/src/lib/relay/tunnel-client.test.ts
+++ b/packages/ui/src/lib/relay/tunnel-client.test.ts
@@ -103,6 +103,7 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
   let batchNegotiated = false;
   const assembler = createFragmentAssembler();
   const httpBodies = new Map<number, Uint8Array[]>();
+  const httpRequests = new Map<number, { method: string; path: string }>();
   const aborted = new Set<number>();
   let sendChain: Promise<void> = Promise.resolve();
   let recvChain: Promise<void> = Promise.resolve();
@@ -123,6 +124,38 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
     sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
   };
 
+  const respondHttp = (streamId: number, path: string, body: Uint8Array): void => {
+    if (path === '/health') {
+      respondJson(streamId, 200, { ok: true });
+    } else if (path === '/echo-body') {
+      sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
+      sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, body));
+      sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
+    } else if (path === '/stream') {
+      sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
+      const emit = (index: number): void => {
+        if (aborted.has(streamId)) return;
+        if (index >= 3) {
+          sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
+          return;
+        }
+        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, textEncoder.encode(`chunk${index};`)));
+        setTimeout(() => emit(index + 1), 10);
+      };
+      emit(0);
+    } else if (path === '/never-ends') {
+      sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
+      const pump = (): void => {
+        if (aborted.has(streamId) || endpoint.closed) return;
+        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, textEncoder.encode('tick;')));
+        setTimeout(pump, 10);
+      };
+      pump();
+    } else {
+      respondJson(streamId, 404, { error: 'not found' });
+    }
+  };
+
   const handleTunnelFrame = (frame: TunnelFrame): void => {
     options.recordFrame?.(frame);
     if (options.silent) return;
@@ -133,8 +166,10 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
     if (frame.frameType === TunnelFrameType.HttpRequest) {
       const req = decodeJsonPayload(frame.payload, isHttpRequestPayload);
       httpBodies.set(frame.streamId, []);
-      (endpoint as FakeEndpoint & { pendingPath?: Map<number, string> }).pendingPath ??= new Map();
-      (endpoint as FakeEndpoint & { pendingPath: Map<number, string> }).pendingPath.set(frame.streamId, req.path);
+      httpRequests.set(frame.streamId, { method: req.method, path: req.path });
+      if (req.method === 'GET' || req.method === 'HEAD') {
+        respondHttp(frame.streamId, req.path, new Uint8Array(0));
+      }
       return;
     }
     if (frame.frameType === TunnelFrameType.HttpBody) {
@@ -146,8 +181,8 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
       return;
     }
     if (frame.frameType === TunnelFrameType.StreamEnd) {
-      const paths = (endpoint as FakeEndpoint & { pendingPath?: Map<number, string> }).pendingPath;
-      const path = paths?.get(frame.streamId) ?? '';
+      const request = httpRequests.get(frame.streamId);
+      if (!request || request.method === 'GET' || request.method === 'HEAD') return;
       const bodyChunks = httpBodies.get(frame.streamId) ?? [];
       const total = bodyChunks.reduce((sum, c) => sum + c.length, 0);
       const body = new Uint8Array(total);
@@ -156,36 +191,7 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
         body.set(c, off);
         off += c.length;
       }
-      const streamId = frame.streamId;
-      if (path === '/health') {
-        respondJson(streamId, 200, { ok: true });
-      } else if (path === '/echo-body') {
-        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
-        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, body));
-        sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
-      } else if (path === '/stream') {
-        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
-        const emit = (index: number): void => {
-          if (aborted.has(streamId)) return;
-          if (index >= 3) {
-            sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
-            return;
-          }
-          sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, textEncoder.encode(`chunk${index};`)));
-          setTimeout(() => emit(index + 1), 10);
-        };
-        emit(0);
-      } else if (path === '/never-ends') {
-        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
-        const pump = (): void => {
-          if (aborted.has(streamId) || endpoint.closed) return;
-          sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, textEncoder.encode('tick;')));
-          setTimeout(pump, 10);
-        };
-        pump();
-      } else {
-        respondJson(streamId, 404, { error: 'not found' });
-      }
+      respondHttp(frame.streamId, request.path, body);
       return;
     }
     if (frame.frameType === TunnelFrameType.WsOpen) {
@@ -390,6 +396,61 @@ describe('createRelayTunnelClient', () => {
     expect(b.status).toBe(200);
     expect(await b.text()).toBe(await new Response('{"ok":true}').text());
     expect(await c.text()).toBe('payload-xyz');
+  });
+
+  test('does not send request body frames or StreamEnd for GET and HEAD', async () => {
+    const received: TunnelFrame[] = [];
+    const { client } = await setupClient({ recordFrame: (frame) => received.push(frame) });
+    track(client);
+
+    await client.fetch('/health');
+    await client.fetch('/health', { method: 'HEAD' });
+    await wait(20);
+
+    const requestStreamIds = received
+      .filter((frame) => frame.frameType === TunnelFrameType.HttpRequest)
+      .map((frame) => frame.streamId);
+    expect(requestStreamIds).toHaveLength(2);
+    expect(received.some((frame) => requestStreamIds.includes(frame.streamId) && frame.frameType === TunnelFrameType.HttpBody)).toBe(false);
+    expect(received.some((frame) => requestStreamIds.includes(frame.streamId) && frame.frameType === TunnelFrameType.StreamEnd)).toBe(false);
+  });
+
+  test('sends StreamEnd immediately after POST and DELETE requests without bodies', async () => {
+    const received: TunnelFrame[] = [];
+    const { client } = await setupClient({ recordFrame: (frame) => received.push(frame) });
+    track(client);
+
+    for (const method of ['POST', 'DELETE']) {
+      const response = await client.fetch('/echo-body', { method });
+      expect(await response.text()).toBe('');
+    }
+
+    const requests = received.filter((frame) => frame.frameType === TunnelFrameType.HttpRequest);
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      const streamFrames = received.filter((frame) => frame.streamId === request.streamId);
+      expect(streamFrames.map((frame) => frame.frameType)).toEqual([
+        TunnelFrameType.HttpRequest,
+        TunnelFrameType.StreamEnd,
+      ]);
+    }
+  });
+
+  test('sends streamed request body frames before StreamEnd', async () => {
+    const received: TunnelFrame[] = [];
+    const { client } = await setupClient({ recordFrame: (frame) => received.push(frame) });
+    track(client);
+
+    const response = await client.fetch('/echo-body', { method: 'POST', body: 'streamed-body' });
+    expect(await response.text()).toBe('streamed-body');
+
+    const request = received.find((frame) => frame.frameType === TunnelFrameType.HttpRequest);
+    expect(request).toBeDefined();
+    const streamFrames = received.filter((frame) => frame.streamId === request?.streamId);
+    expect(streamFrames[0]?.frameType).toBe(TunnelFrameType.HttpRequest);
+    expect(streamFrames.at(-1)?.frameType).toBe(TunnelFrameType.StreamEnd);
+    expect(streamFrames.slice(1, -1).every((frame) => frame.frameType === TunnelFrameType.HttpBody)).toBe(true);
+    expect(streamFrames.slice(1, -1).length).toBeGreaterThan(0);
   });
 
   test('streams a response body incrementally', async () => {

--- a/packages/ui/src/lib/relay/tunnel-client.ts
+++ b/packages/ui/src/lib/relay/tunnel-client.ts
@@ -140,19 +140,44 @@ export const wrapBrowserWebSocket = (ws: WebSocket): RelayTunnelWebSocket => {
 };
 
 export type RelayTunnelState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'error';
+export type RelayTunnelFailureClassification = 'network' | 'protocol' | 'crypto' | 'terminal';
+
+export class TunnelChannelReadinessError extends Error {
+  constructor(
+    message: string,
+    readonly failureClassification: RelayTunnelFailureClassification,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = 'TunnelChannelReadinessError';
+  }
+}
+
+export interface TunnelChannelReadinessContext {
+  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
+}
 
 export interface RelayTunnelStatus {
   state: RelayTunnelState;
   lastError?: string;
+  failureClassification?: RelayTunnelFailureClassification;
 }
 
 export interface RelayTunnelClientOptions {
-  relayUrl: string;
-  serverId: string;
+  relayUrl?: string;
+  serverId?: string;
   hostEncPubJwk: JsonWebKey;
   grant?: string;
-  /** Test hook: replaces native WebSocket construction with a fake wire. */
+  /** Exact outer WebSocket URL. When omitted, the hosted-relay URL is built as before. */
+  outerWebSocketUrl?: string | (() => string);
+  /** Transport seam for constructing the outer socket. */
+  createOuterWebSocket?: (url: string) => TunnelWireSocket;
+  /** Backward-compatible test alias for createOuterWebSocket. */
   createWireSocket?: (url: string) => TunnelWireSocket;
+  /** Override which outer close codes are terminal. Hosted-relay defaults are unchanged. */
+  isTerminalCloseCode?: (code: number) => boolean;
+  /** Override which locally detected failures are terminal. Hosted-relay defaults are unchanged. */
+  isTerminalFailureClassification?: (classification: RelayTunnelFailureClassification) => boolean;
   helloRetryMs?: number;
   helloTimeoutMs?: number;
   pingIntervalMs?: number;
@@ -164,6 +189,8 @@ export interface RelayTunnelClientOptions {
   reconnectBaseDelayMs?: number;
   reconnectMaxDelayMs?: number;
   hiddenOrOfflineMaxDelayMs?: number;
+  /** Verifies the newly encrypted channel before it is exposed to callers. */
+  channelReadiness?: (context: TunnelChannelReadinessContext) => Promise<void>;
 }
 
 export interface RelayTunnelClient {
@@ -230,7 +257,11 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
   const reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? 30_000;
   const hiddenOrOfflineMaxDelayMs = options.hiddenOrOfflineMaxDelayMs ?? 60_000;
 
-  const createWire = options.createWireSocket ?? ((url: string) => wrapNativeWebSocket(new WebSocket(url)));
+  const createWire = options.createOuterWebSocket
+    ?? options.createWireSocket
+    ?? ((url: string) => wrapNativeWebSocket(new WebSocket(url)));
+  const isTerminalCloseCode = options.isTerminalCloseCode ?? ((code: number) => TERMINAL_RELAY_CLOSE_CODES.has(code));
+  const isTerminalFailureClassification = options.isTerminalFailureClassification ?? (() => false);
 
   let closed = false;
   let status: RelayTunnelStatus = { state: 'idle' };
@@ -246,7 +277,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
   let wakeListenersInstalled = false;
 
   const setStatus = (next: RelayTunnelStatus): void => {
-    if (status.state === next.state && status.lastError === next.lastError) return;
+    if (status.state === next.state && status.lastError === next.lastError && status.failureClassification === next.failureClassification) return;
     status = next;
     for (const listener of statusListeners) {
       try {
@@ -332,6 +363,12 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
   };
 
   const buildRelayWsUrl = (): string => {
+    if (options.outerWebSocketUrl) {
+      return typeof options.outerWebSocketUrl === 'function' ? options.outerWebSocketUrl() : options.outerWebSocketUrl;
+    }
+    if (!options.relayUrl || !options.serverId) {
+      throw new Error('relayUrl and serverId are required when outerWebSocketUrl is omitted');
+    }
     const url = new URL(options.relayUrl);
     url.searchParams.set('v', String(RELAY_PROTOCOL_VERSION));
     url.searchParams.set('role', 'client');
@@ -345,14 +382,14 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
     clearReconnectTimer();
     attemptGeneration += 1;
     const generation = attemptGeneration;
-    setStatus({ state: consecutiveFailures > 0 ? 'reconnecting' : 'connecting', lastError: status.lastError });
+    setStatus({ state: consecutiveFailures > 0 ? 'reconnecting' : 'connecting', lastError: status.lastError, failureClassification: status.failureClassification });
 
     let handshake;
     try {
       handshake = await createClientHandshake(options.hostEncPubJwk, { batch: advertiseBatch });
     } catch (error) {
       if (generation !== attemptGeneration || closed) return;
-      failAttempt(generation, toError(error), true);
+      failAttempt(generation, toError(error), 'crypto', true);
       return;
     }
     if (generation !== attemptGeneration || closed) return;
@@ -361,7 +398,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
     try {
       wire = createWire(buildRelayWsUrl());
     } catch (error) {
-      failAttempt(generation, toError(error));
+      failAttempt(generation, toError(error), 'network');
       return;
     }
     currentWire = wire;
@@ -408,7 +445,13 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
     };
     currentAttemptCleanup = cleanupTimers;
 
-    function failAttemptLocal(error: Error, asErrorState = false, terminal = false): void {
+    function failAttemptLocal(
+      error: Error,
+      failureClassification: RelayTunnelFailureClassification,
+      asErrorState = false,
+      terminal = false,
+    ): void {
+      terminal ||= isTerminalFailureClassification(failureClassification);
       if (settled || generation !== attemptGeneration) return;
       settled = true;
       cleanupTimers();
@@ -416,7 +459,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         activeChannel = null;
         failChannelStreams(channel, new Error(`relay tunnel reset: ${error.message}`));
       }
-      rejectWaiters(error);
+      if (terminal) rejectWaiters(error);
       try {
         wire.close();
       } catch {
@@ -428,10 +471,10 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
       // A permanent rejection (auth failed, duplicate, limit) won't resolve by
       // retrying — surface a terminal error instead of reconnecting forever.
       if (terminal) {
-        setStatus({ state: 'error', lastError: error.message });
+        setStatus({ state: 'error', lastError: error.message, failureClassification });
         return;
       }
-      setStatus({ state: asErrorState ? 'error' : 'reconnecting', lastError: error.message });
+      setStatus({ state: asErrorState ? 'error' : 'reconnecting', lastError: error.message, failureClassification });
       scheduleReconnect();
     }
 
@@ -492,12 +535,14 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         },
       };
       channel = channelObj;
-      activeChannel = channelObj;
-      consecutiveFailures = 0;
       lastActivityAt = Date.now();
-      setStatus({ state: 'connected' });
-      resolveWaiters(channelObj);
-      pingTimer = setInterval(() => {
+      const publishChannel = (): void => {
+        if (settled || generation !== attemptGeneration || channelObj.dead) return;
+        activeChannel = channelObj;
+        consecutiveFailures = 0;
+        setStatus({ state: 'connected' });
+        resolveWaiters(channelObj);
+        pingTimer = setInterval(() => {
         const now = Date.now();
         // Only ping when the tunnel has actually been idle; streaming traffic
         // keeps lastActivityAt fresh, so sustained bursts send zero pings.
@@ -507,10 +552,28 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         if (pongDeadline === null) {
           pongDeadline = setTimeout(() => {
             pongDeadline = null;
-            failAttemptLocal(new Error('relay keepalive timeout'));
+            failAttemptLocal(new Error('relay keepalive timeout'), 'network');
           }, pingTimeoutMs);
         }
-      }, pingIntervalMs);
+        }, pingIntervalMs);
+      };
+      if (!options.channelReadiness) {
+        publishChannel();
+        return;
+      }
+      void options.channelReadiness({
+        fetch: (input, init) => tunnelFetchOnChannel(channelObj, input, init),
+      }).then(publishChannel).catch((error: unknown) => {
+        const readinessError = error instanceof TunnelChannelReadinessError
+          ? error
+          : new TunnelChannelReadinessError('tunnel channel readiness callback failed', 'terminal', false);
+        failAttemptLocal(
+          readinessError,
+          readinessError.failureClassification,
+          !readinessError.retryable,
+          !readinessError.retryable,
+        );
+      });
     };
 
     const handleTunnelFrame = (channelObj: ActiveChannel, plaintext: Uint8Array): void => {
@@ -518,7 +581,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
       try {
         frame = decodeTunnelFrame(plaintext);
       } catch (error) {
-        failAttemptLocal(toError(error));
+        failAttemptLocal(toError(error), 'protocol');
         return;
       }
       // Any received frame proves the tunnel is alive — clear the pong deadline.
@@ -540,13 +603,13 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         try {
           complete = channelObj.assembler.push(frame);
         } catch (error) {
-          failAttemptLocal(toError(error));
+          failAttemptLocal(toError(error), 'protocol');
           return;
         }
         if (complete === null) return;
         payload = complete;
       } else if (frame.hasMoreFragments) {
-        failAttemptLocal(new Error('unexpected fragmented tunnel frame'));
+        failAttemptLocal(new Error('unexpected fragmented tunnel frame'), 'protocol');
         return;
       }
 
@@ -577,11 +640,11 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
               if (cryptoChannel) return;
               establish(action.channel, action.batch);
             } else if (action.type === 'fail') {
-              failAttemptLocal(new Error(`relay handshake failed: ${action.reason}`));
+              failAttemptLocal(new Error(`relay handshake failed: ${action.reason}`), 'protocol');
             }
           })
           .catch((error: unknown) => {
-            failAttemptLocal(toError(error));
+            failAttemptLocal(toError(error), 'crypto');
           });
         return;
       }
@@ -594,14 +657,14 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
           const currentChannel = channel;
           const currentCrypto = cryptoChannel;
           if (!currentChannel || !currentCrypto) {
-            failAttemptLocal(new Error('encrypted frame before handshake completed'));
+            failAttemptLocal(new Error('encrypted frame before handshake completed'), 'protocol');
             return;
           }
           let plaintext: Uint8Array;
           try {
             plaintext = await currentCrypto.decryptor.decrypt(bytes);
           } catch (error) {
-            failAttemptLocal(toError(error));
+            failAttemptLocal(toError(error), 'crypto');
             return;
           }
           if (batchNegotiated) {
@@ -611,7 +674,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
             try {
               frames = decodeFrameBatch(plaintext);
             } catch (error) {
-              failAttemptLocal(toError(error));
+              failAttemptLocal(toError(error), 'protocol');
               return;
             }
             for (const frame of frames) {
@@ -623,14 +686,15 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
           handleTunnelFrame(currentChannel, plaintext);
         })
         .catch((error: unknown) => {
-          failAttemptLocal(toError(error));
+          failAttemptLocal(toError(error), 'protocol');
         });
     };
 
     wire.onclose = (event) => {
-      const terminal = TERMINAL_RELAY_CLOSE_CODES.has(event.code);
+      const terminal = isTerminalCloseCode(event.code);
       failAttemptLocal(
         new Error(RELAY_CLOSE_MESSAGES[event.code] ?? `relay socket closed (code ${event.code})`),
+        terminal ? 'terminal' : 'network',
         terminal,
         terminal,
       );
@@ -642,14 +706,20 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
 
     helloDeadline = setTimeout(() => {
       helloDeadline = null;
-      failAttemptLocal(new Error('relay handshake timeout'), true);
+      failAttemptLocal(new Error('relay handshake timeout'), 'network', true);
     }, helloTimeoutMs);
 
-    function failAttempt(gen: number, error: Error, asErrorState = false): void {
+    function failAttempt(gen: number, error: Error, failureClassification: RelayTunnelFailureClassification, asErrorState = false): void {
       if (gen !== attemptGeneration || closed) return;
+      if (isTerminalFailureClassification(failureClassification)) {
+        rejectWaiters(error);
+        consecutiveFailures += 1;
+        setStatus({ state: 'error', lastError: error.message, failureClassification });
+        return;
+      }
       rejectWaiters(error);
       consecutiveFailures += 1;
-      setStatus({ state: asErrorState ? 'error' : 'reconnecting', lastError: error.message });
+      setStatus({ state: asErrorState ? 'error' : 'reconnecting', lastError: error.message, failureClassification });
       scheduleReconnect();
     }
   };
@@ -681,11 +751,10 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
     });
   };
 
-  const tunnelFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+  const tunnelFetchOnChannel = async (channel: ActiveChannel, input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const request = await normalizeTunnelRequest(input, init);
     const signal = request.signal;
     if (signal?.aborted) throw abortError();
-    const channel = await waitForChannel(signal);
     const streamId = channel.nextStreamId();
 
     return await new Promise<Response>((resolve, reject) => {
@@ -828,6 +897,12 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         }
       })();
     });
+  };
+
+  const tunnelFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const signal = input instanceof Request ? input.signal : init?.signal;
+    const channel = await waitForChannel(signal ?? undefined);
+    return tunnelFetchOnChannel(channel, input, init);
   };
 
   const splitPathQuery = (pathWithQuery: string): { path: string; query: string } => {

--- a/packages/ui/src/lib/relay/tunnel-client.ts
+++ b/packages/ui/src/lib/relay/tunnel-client.ts
@@ -878,14 +878,18 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         headers: request.headers,
       };
       channel.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, streamId, encodeJsonPayload(head)));
+      if (request.method === 'GET' || request.method === 'HEAD') return;
+      if (request.body === null) {
+        channel.send(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, EMPTY_PAYLOAD));
+        return;
+      }
+      const body = request.body;
       void (async () => {
         try {
-          if (request.body) {
-            for await (const chunk of request.body) {
-              if (finished || channel.dead) return;
-              for (const piece of chunkPayload(chunk)) {
-                channel.send(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, piece));
-              }
+          for await (const chunk of body) {
+            if (finished || channel.dead) return;
+            for (const piece of chunkPayload(chunk)) {
+              channel.send(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, piece));
             }
           }
           if (!finished && !channel.dead) {

--- a/packages/web/server/lib/relay/DOCUMENTATION.md
+++ b/packages/web/server/lib/relay/DOCUMENTATION.md
@@ -20,11 +20,16 @@ Traffic is modeled as three stacked layers. The relay understands only Layer 1; 
 
 Host side (`packages/web/server/lib/relay/`):
 - `service.js` — thin entrypoint: relay config (enabled flag + relay URL), the management routes (`GET/POST /api/openchamber/relay/{status,enable,disable}`), a `getPairingCandidate()` accessor (the relay transport candidate folded into pairing-v2 links when enabled, consumed by the pairing-session route in `core-routes.js`), and lifecycle wiring. Started from `packages/web/server/index.js` only when the user has explicitly enabled the relay. The relay endpoint defaults to the OpenChamber-hosted relay but can be pinned to a self-hosted relay via the `OPENCHAMBER_RELAY_URL` env var (must be `ws://`/`wss://`); when set it overrides the stored setting for the host connection, the pairing candidate, and status, so paired clients inherit the endpoint automatically.
-- `identity.js` — the host's stable identity: the long-lived signing keypair (shared with the push relay, defines the routing id) plus a long-lived encryption keypair (the E2EE trust anchor). Reused across restarts; never rotated implicitly.
+- `identity.js` — the host's stable identity: the long-lived signing keypair (shared with the push relay, defines the routing id) plus a long-lived encryption keypair (the E2EE trust anchor).
+  The valid persisted private encryption JWK is authoritative: startup validates its P-256 point,
+  derives the emitted `{kty, crv, x, y}` public representation from it,
+  and repairs missing, mismatched, or over-specified public copies without rotating valid private material.
+  Invalid private material is replaced, and candidates never emit `d` or stored public-JWK extras.
 - `signing-key.js` — storage/derivation of the signing keypair and the routing id, shared with the notifications runtime.
-- `host-client.js` — the long-lived connection manager: one outbound control connection to the relay, a per-client data connection for each connected device, reconnect/backoff, and the E2EE responder handshake per connection.
+- `host-client.js` — the hosted-relay connection manager: one outbound control connection, signed broker URLs, per-client data-socket lifecycle, reconnect/backoff, idle reaping, and status.
+- `encrypted-session.js` — the transport-neutral per-outer-socket E2EE responder session: handshake, serialized decrypt/encrypt counters, negotiated batching, and ownership of one tunnel dispatcher. It does not own broker reconnect or admission policy.
 - `host-lock.js` — the per-machine host claim. Every local instance sharing the data dir shares the relay identity (same serverId), so concurrent relay hosts evict each other at the relay worker (`4001: Control replaced`) and paired devices land on whichever local process won last. The claim file (`<data-dir>/relay-host.lock`, `{ pid }`) makes this deterministic: `service.js` only starts the host when no LIVE process holds the claim (stale claims from dead pids are ignored), goes to `standby` otherwise, and a 30s watcher both takes over when the claimant dies and stands down when another process claims. Explicit user intent — creating a pairing link or hitting `/relay/enable` — force-claims; the previous holder's watcher sees the takeover and backs off instead of fighting. The claim is cooperative (the relay worker still enforces the single host slot); it only decides which process keeps retrying.
-- `tunnel-host.js` — the per-connection dispatcher: decrypts tunnel frames and forwards HTTP/SSE/WS to the local server over loopback, then streams responses back. Enforces a path allowlist and never injects credentials.
+- `tunnel-host.js` — the per-connection dispatcher: forwards decrypted HTTP/SSE/WS to the local server over loopback, then streams responses back. Enforces path allowlists, strips untrusted forwarding/Cloudflare/internal headers, and supports optional transport context, policy hooks, and bounded per-session limits. Omitted options retain hosted-relay behavior; it never injects credentials.
 - `e2ee.js`, `tunnel-codec.js` — host-side (JS) mirrors of the shared crypto and framing (see "Two implementations" below).
 
 Client side (`packages/ui/src/lib/relay/`):
@@ -44,6 +49,14 @@ Everything a client normally sends to the single OpenChamber origin:
 - **WebSocket** — the endpoints that use a real socket (the global event stream on platforms that support WS, terminal I/O, dictation).
 
 The host dispatcher restricts tunneled traffic to explicit path allowlists (one for HTTP, one for WS).
+It canonicalizes each request target before allowlist checks and uses that same
+target for loopback dispatch. Fragment assembly is limited to open nested
+WebSockets, supports aggregate byte budgets, and is cleared on stream/session
+teardown. Outbound fragments for each nested WebSocket are serialized through
+backpressure waits so upstream messages cannot interleave; send-chain failure is
+terminal and drops the affected stream. Direct E2EE supplies a live fragment-byte
+budget that changes on authenticated promotion and enables
+terminal fail-closed policy; hosted-relay stream-local rejection remains compatible.
 
 ## Authentication model
 
@@ -58,7 +71,7 @@ The host dispatcher restricts tunneled traffic to explicit path allowlists (one 
 2. **Presence.** When the relay is enabled, the host opens one outbound control connection and waits.
 3. **Connect.** The client connects for a given routing id; the relay notifies the host over the control connection; the host opens a matching per-client data connection.
 4. **Handshake.** Over that connection pair, client and host run the E2EE handshake and derive a shared encrypted channel the relay cannot read.
-5. **Traffic.** All normal app traffic is multiplexed and encrypted through that channel. On the host, decrypted requests are dispatched to the local server over loopback; responses stream back encrypted. Reconnects re-establish a fresh channel and the app's existing retry machinery recovers.
+5. **Readiness and traffic.** Hosted relay channels retain their existing behavior. A direct-E2EE runtime channel is kept private after every initial handshake and reconnect while the client verifies strict OpenChamber `/health` identity, then promotes that exact encrypted session with bearer-authenticated `GET /auth/session`. Only after both checks succeed does the client publish `connected`, release queued HTTP/WS work, mint URL tokens, or start keepalive. Invalid/revoked bearer credentials and protocol/identity failures are terminal; readiness/network failures retry with backoff. Normal traffic is then multiplexed and encrypted through the promoted channel.
 
 ## Candidate refresh (staying off the relay when direct works)
 
@@ -85,7 +98,7 @@ The E2EE and framing logic exists twice: TypeScript in `packages/ui/src/lib/rela
 
 ## Runtime integration (client)
 
-Relay mode plugs into the existing client transport layer rather than a parallel path: `runtime-switch` activates the tunnel singleton, `runtime-fetch` routes runtime requests through it, `runtime-url`/`runtime-socket` yield tunnel-backed URLs and sockets, and `runtime-auth` mints the URL-scoped token through the tunnel. Direct-URL connections and the Electron realtime-proxy path are unaffected.
+Relay mode plugs into the existing client transport layer rather than a parallel path: `runtime-switch` activates the tunnel singleton, `runtime-fetch` routes runtime requests through it, `runtime-url`/`runtime-socket` yield tunnel-backed URLs and sockets, and `runtime-auth` mints the URL-scoped token through the tunnel. Direct-E2EE activation passes the bearer token separately from its public descriptor so credentials never enter candidate metadata or URLs. Direct-URL connections and the Electron realtime-proxy path are unaffected.
 
 ## Design invariants (do not regress)
 
@@ -94,5 +107,8 @@ Relay mode plugs into the existing client transport layer rather than a parallel
 - The host dispatcher never injects credentials; the server authenticates each tunneled request.
 - The tunnel is transparent to the app: adding relay support to a feature should not require the feature to know the relay exists — it goes through the shared runtime transport helpers.
 - The two implementations stay byte-compatible and the wire format is versioned/negotiated so mixed client/host app versions degrade gracefully rather than break.
+- Hosted relay keeps the shared handshake's legacy pre-establishment ignore behavior.
+  Direct E2EE enables an encrypted-session policy seam that terminal-fails ignored
+  pre-establishment text without changing handshake bytes or hosted-relay behavior.
 
 For the operational rules that keep future changes (new WebSocket endpoints, transport refactors, terminal/voice porting) from breaking this, load the `relay-transport` skill.

--- a/packages/web/server/lib/relay/DOCUMENTATION.md
+++ b/packages/web/server/lib/relay/DOCUMENTATION.md
@@ -58,6 +58,18 @@ terminal and drops the affected stream. Direct E2EE supplies a live fragment-byt
 budget that changes on authenticated promotion and enables
 terminal fail-closed policy; hosted-relay stream-local rejection remains compatible.
 
+### Completed HTTP stream tombstones
+
+When a loopback HTTP response completes before the client finishes uploading its
+request body, the host retains a bounded tombstone for the completed stream ID.
+The default lifetime is 5 seconds, with at most 256 tombstones per outer session;
+expired entries are pruned and the oldest entry is evicted when the capacity is
+full. A body-capable tombstone accepts at most 32 expected late body frames totaling
+at most 1 MiB, and a matching `StreamEnd` consumes it. Body frames for bodyless
+requests, frames beyond either bound, unknown IDs, and reuse of a tombstoned stream
+ID are fatal protocol errors. These bounds tolerate only expected in-flight late
+frames and do not permit a completed stream to be reopened or used indefinitely.
+
 ## Authentication model
 
 - The tunnel is **transport only**. The OpenChamber server still authenticates every tunneled request exactly as it authenticates a direct remote client. The relay path grants reachability, not authorization.

--- a/packages/web/server/lib/relay/encrypted-session.js
+++ b/packages/web/server/lib/relay/encrypted-session.js
@@ -1,0 +1,148 @@
+import { WebSocket } from 'ws';
+
+import { RelayCloseCode, createHostHandshake } from './e2ee.js';
+import { createOutboundFrameBatcher, decodeFrameBatch } from './tunnel-codec.js';
+import { createTunnelHost } from './tunnel-host.js';
+
+/**
+ * Owns one transport-neutral responder handshake and encrypted tunnel session.
+ * The caller retains outer-socket lifecycle and admission accounting ownership.
+ *
+ * @param {{
+ *   socket: WebSocket,
+ *   connectionId: string,
+ *   hostEncPrivateKey: CryptoKey,
+ *   getLocalPort: () => number,
+ *   isActive?: () => boolean,
+ *   onActivity?: () => void,
+ *   onEstablished?: () => void,
+ *   onFailure: (closeCode: number, reason: string) => void,
+ *   logger?: Pick<Console, 'warn'>,
+ *   batch?: boolean,
+ *   failOnIgnoredHandshake?: boolean,
+ *   batchWindowMs: number,
+ *   tunnelOptions?: object,
+ * }} options
+ */
+export const createEncryptedSession = ({
+  socket,
+  connectionId,
+  hostEncPrivateKey,
+  getLocalPort,
+  isActive = () => true,
+  onActivity,
+  onEstablished,
+  onFailure,
+  logger = console,
+  batch = true,
+  failOnIgnoredHandshake = false,
+  batchWindowMs,
+  tunnelOptions = {},
+}) => {
+  const handshake = createHostHandshake(hostEncPrivateKey, { batch });
+  let channel = null;
+  let tunnel = null;
+  let batcher = null;
+  let batchNegotiated = false;
+  let processing = Promise.resolve();
+  let sendChain = Promise.resolve();
+  let closed = false;
+
+  const fail = (closeCode, reason) => {
+    if (closed) return;
+    closed = true;
+    batcher?.dispose();
+    tunnel?.close();
+    onFailure(closeCode, reason);
+  };
+
+  const sendEncryptedPlaintext = (plaintext) => {
+    sendChain = sendChain
+      .then(async () => {
+        if (closed || !isActive() || socket.readyState !== WebSocket.OPEN || !channel) return;
+        const encrypted = await channel.encryptor.encrypt(plaintext);
+        socket.send(encrypted, { binary: true });
+      })
+      .catch((error) => {
+        logger.warn(`[Relay] encrypted session send failed: ${error?.message ?? error}`);
+      });
+  };
+
+  const handleMessage = async (data, isBinary) => {
+    if (closed || !isActive()) return;
+    onActivity?.();
+
+    if (!isBinary) {
+      const action = await handshake.handleText(data.toString('utf8'));
+      if (action.type === 'ignore' && failOnIgnoredHandshake) {
+        fail(RelayCloseCode.ChannelFailure, 'invalid handshake');
+      } else if (action.type === 'send-text') socket.send(action.text);
+      else if (action.type === 'established') {
+        channel = action.channel;
+        batchNegotiated = action.batch === true;
+        batcher = batchNegotiated
+          ? createOutboundFrameBatcher({ windowMs: batchWindowMs, sendBatch: sendEncryptedPlaintext })
+          : null;
+        tunnel = createTunnelHost({
+          connectionId,
+          getLocalPort,
+          getBufferedAmount: () => socket.bufferedAmount,
+          sendFrame: (plaintextFrame) => {
+            if (closed || !isActive() || socket.readyState !== WebSocket.OPEN) return;
+            if (batcher) batcher.enqueue(plaintextFrame);
+            else sendEncryptedPlaintext(plaintextFrame);
+          },
+          onProtocolFailure: () => fail(RelayCloseCode.ChannelFailure, 'protocol failure'),
+          ...tunnelOptions,
+        });
+        onEstablished?.();
+        if (action.replyText) socket.send(action.replyText);
+      } else if (action.type === 'fail') fail(action.closeCode, action.reason);
+      return;
+    }
+
+    if (!channel || !tunnel) {
+      fail(RelayCloseCode.ChannelFailure, 'binary frame before handshake');
+      return;
+    }
+    let plaintext;
+    try {
+      plaintext = await channel.decryptor.decrypt(new Uint8Array(data));
+    } catch {
+      fail(RelayCloseCode.ChannelFailure, 'frame decryption failed');
+      return;
+    }
+    try {
+      const frames = batchNegotiated ? decodeFrameBatch(plaintext) : [plaintext];
+      for (const frame of frames) {
+        if (closed || !isActive()) return;
+        await tunnel.handleFrame(frame);
+      }
+    } catch (error) {
+      logger.warn(`[Relay] tunnel frame handling failed: ${error?.message ?? error}`);
+      fail(RelayCloseCode.ChannelFailure, 'protocol failure');
+    }
+  };
+
+  const receive = (data, isBinary) => {
+    processing = processing
+      .then(() => handleMessage(data, isBinary))
+      .catch((error) => {
+        logger.warn(`[Relay] encrypted session message failed: ${error?.message ?? error}`);
+        fail(RelayCloseCode.ChannelFailure, 'internal error');
+      });
+  };
+
+  return {
+    receive,
+    close() {
+      if (closed) return;
+      closed = true;
+      batcher?.dispose();
+      tunnel?.close();
+    },
+    get tunnel() {
+      return tunnel;
+    },
+  };
+};

--- a/packages/web/server/lib/relay/encrypted-session.test.js
+++ b/packages/web/server/lib/relay/encrypted-session.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createClientHandshake } from '../../../../ui/src/lib/relay/handshake.ts';
+import { createEncryptedSession } from './encrypted-session.js';
+import { exportPublicKeyJwk, generateEcdhKeyPair, RelayCloseCode } from './e2ee.js';
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const createSocket = () => ({
+  readyState: 1,
+  bufferedAmount: 0,
+  sent: [],
+  send(data) { this.sent.push(data); },
+});
+
+describe('encrypted session', () => {
+  const establishedFixture = async (batch) => {
+    const hostKeys = await generateEcdhKeyPair();
+    const client = await createClientHandshake(await exportPublicKeyJwk(hostKeys.publicKey), { batch });
+    const socket = createSocket();
+    const failures = [];
+    const session = createEncryptedSession({
+      socket, connectionId: 'malformed', hostEncPrivateKey: hostKeys.privateKey, batch,
+      getLocalPort: () => 1, batchWindowMs: 0, onFailure: (code, reason) => failures.push({ code, reason }),
+      logger: { warn() {} },
+    });
+    session.receive(client.helloText, false);
+    await settle();
+    const action = await client.handleText(socket.sent[0]);
+    return { session, channel: action.channel, failures };
+  };
+
+  it('closes exactly once for a malformed negotiated batch', async () => {
+    const { session, channel, failures } = await establishedFixture(true);
+    const malformed = await channel.encryptor.encrypt(new Uint8Array([1]));
+    session.receive(malformed, true);
+    session.receive(malformed, true);
+    await settle();
+    expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'protocol failure' }]);
+  });
+
+  it('closes exactly once for a malformed tunnel frame', async () => {
+    const { session, channel, failures } = await establishedFixture(false);
+    const malformed = await channel.encryptor.encrypt(new Uint8Array([1]));
+    session.receive(malformed, true);
+    await settle();
+    expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'protocol failure' }]);
+  });
+
+  it('fails closed on binary before handshake', async () => {
+    const hostKeys = await generateEcdhKeyPair();
+    const failures = [];
+    const session = createEncryptedSession({
+      socket: createSocket(), connectionId: 'binary-first', hostEncPrivateKey: hostKeys.privateKey,
+      getLocalPort: () => 1, batchWindowMs: 0, onFailure: (code, reason) => failures.push({ code, reason }),
+      logger: { warn() {} },
+    });
+    session.receive(new Uint8Array([1]), true);
+    await settle();
+    expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'binary frame before handshake' }]);
+    session.close();
+  });
+
+  it('uses the existing handshake and fails closed on post-establishment plaintext', async () => {
+    const hostKeys = await generateEcdhKeyPair();
+    const client = await createClientHandshake(await exportPublicKeyJwk(hostKeys.publicKey));
+    const socket = createSocket();
+    const failures = [];
+    const session = createEncryptedSession({
+      socket, connectionId: 'plaintext-after', hostEncPrivateKey: hostKeys.privateKey,
+      getLocalPort: () => 1, batchWindowMs: 0, onFailure: (code, reason) => failures.push({ code, reason }),
+      logger: { warn() {} },
+    });
+    session.receive(client.helloText, false);
+    await settle();
+    expect(typeof socket.sent[0]).toBe('string');
+    expect((await client.handleText(socket.sent[0])).type).toBe('established');
+    session.receive('{"t":"unexpected"}', false);
+    await settle();
+    expect(failures[0]?.code).toBe(RelayCloseCode.ChannelFailure);
+    session.close();
+  });
+});

--- a/packages/web/server/lib/relay/encrypted-session.test.js
+++ b/packages/web/server/lib/relay/encrypted-session.test.js
@@ -4,7 +4,13 @@ import { createClientHandshake } from '../../../../ui/src/lib/relay/handshake.ts
 import { createEncryptedSession } from './encrypted-session.js';
 import { exportPublicKeyJwk, generateEcdhKeyPair, RelayCloseCode } from './e2ee.js';
 
-const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+const waitFor = async (predicate) => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error('observable encrypted session outcome not reached');
+};
 
 const createSocket = () => ({
   readyState: 1,
@@ -25,7 +31,7 @@ describe('encrypted session', () => {
       logger: { warn() {} },
     });
     session.receive(client.helloText, false);
-    await settle();
+    await waitFor(() => socket.sent.length > 0);
     const action = await client.handleText(socket.sent[0]);
     return { session, channel: action.channel, failures };
   };
@@ -35,7 +41,7 @@ describe('encrypted session', () => {
     const malformed = await channel.encryptor.encrypt(new Uint8Array([1]));
     session.receive(malformed, true);
     session.receive(malformed, true);
-    await settle();
+    await waitFor(() => failures.length > 0);
     expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'protocol failure' }]);
   });
 
@@ -43,7 +49,7 @@ describe('encrypted session', () => {
     const { session, channel, failures } = await establishedFixture(false);
     const malformed = await channel.encryptor.encrypt(new Uint8Array([1]));
     session.receive(malformed, true);
-    await settle();
+    await waitFor(() => failures.length > 0);
     expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'protocol failure' }]);
   });
 
@@ -56,7 +62,7 @@ describe('encrypted session', () => {
       logger: { warn() {} },
     });
     session.receive(new Uint8Array([1]), true);
-    await settle();
+    await waitFor(() => failures.length > 0);
     expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'binary frame before handshake' }]);
     session.close();
   });
@@ -72,11 +78,11 @@ describe('encrypted session', () => {
       logger: { warn() {} },
     });
     session.receive(client.helloText, false);
-    await settle();
+    await waitFor(() => socket.sent.length > 0);
     expect(typeof socket.sent[0]).toBe('string');
     expect((await client.handleText(socket.sent[0])).type).toBe('established');
     session.receive('{"t":"unexpected"}', false);
-    await settle();
+    await waitFor(() => failures.length > 0);
     expect(failures[0]?.code).toBe(RelayCloseCode.ChannelFailure);
     session.close();
   });

--- a/packages/web/server/lib/relay/encrypted-session.test.js
+++ b/packages/web/server/lib/relay/encrypted-session.test.js
@@ -5,10 +5,12 @@ import { createEncryptedSession } from './encrypted-session.js';
 import { exportPublicKeyJwk, generateEcdhKeyPair, RelayCloseCode } from './e2ee.js';
 
 const waitFor = async (predicate) => {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
     if (predicate()) return;
-    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
+  if (predicate()) return;
   throw new Error('observable encrypted session outcome not reached');
 };
 

--- a/packages/web/server/lib/relay/host-client.js
+++ b/packages/web/server/lib/relay/host-client.js
@@ -5,9 +5,8 @@
 
 import { WebSocket } from 'ws';
 
-import { RELAY_PROTOCOL_VERSION, RelayCloseCode, createHostHandshake } from './e2ee.js';
-import { createOutboundFrameBatcher, decodeFrameBatch } from './tunnel-codec.js';
-import { createTunnelHost } from './tunnel-host.js';
+import { RELAY_PROTOCOL_VERSION } from './e2ee.js';
+import { createEncryptedSession } from './encrypted-session.js';
 
 const BACKOFF_BASE_MS = 1000;
 const BACKOFF_CAP_MS = 30000;
@@ -59,7 +58,7 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
   let controlSocket = null;
   let reconnectTimer = null;
   let consecutiveFailures = 0;
-  /** @type {Map<string, { socket: WebSocket, tunnel: ReturnType<typeof createTunnelHost> | null, openTimer: NodeJS.Timeout | null }>} */
+  /** @type {Map<string, { socket: WebSocket, session: ReturnType<typeof createEncryptedSession> | null, openTimer: NodeJS.Timeout | null, lastActivityAt: number }>} */
   const dataSockets = new Map();
 
   const emitStatus = () => {
@@ -94,8 +93,7 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
     if (!entry) return;
     dataSockets.delete(connectionId);
     if (entry.openTimer) clearTimeout(entry.openTimer);
-    entry.batcher?.dispose();
-    entry.tunnel?.close();
+    entry.session?.close();
     try {
       if (entry.socket.readyState === WebSocket.OPEN || entry.socket.readyState === WebSocket.CONNECTING) {
         if (closeCode) entry.socket.close(closeCode, reason ?? '');
@@ -118,34 +116,12 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
       return;
     }
 
-    const entry = { socket, tunnel: null, openTimer: null, batcher: null, lastActivityAt: Date.now() };
+    const entry = { socket, session: null, openTimer: null, lastActivityAt: Date.now() };
     dataSockets.set(connectionId, entry);
     entry.openTimer = setTimeout(() => {
       logger.warn('[Relay] host-data socket open timeout');
       teardownDataSocket(connectionId);
     }, DATA_SOCKET_OPEN_TIMEOUT_MS);
-
-    const handshake = createHostHandshake(identity.hostEncPrivateKey, { batch: localBatch });
-    let channel = null;
-    let batchNegotiated = false;
-    // Serialize async message handling so encrypted frame order (and the
-    // strictly-increasing decrypt counter) is preserved.
-    let processing = Promise.resolve();
-    // Serialize encrypt+send so the per-direction IV counter reaches the wire in
-    // encryption order. One encrypt() == one WS message == one counter tick,
-    // whether it carries a batch or a lone frame.
-    let sendChain = Promise.resolve();
-    const sendEncryptedPlaintext = (plaintext) => {
-      sendChain = sendChain
-        .then(async () => {
-          if (dataSockets.get(connectionId) !== entry || socket.readyState !== WebSocket.OPEN || !channel) return;
-          const encrypted = await channel.encryptor.encrypt(plaintext);
-          socket.send(encrypted, { binary: true });
-        })
-        .catch((error) => {
-          logger.warn(`[Relay] host-data send failed: ${error?.message ?? error}`);
-        });
-    };
 
     const failChannel = (closeCode, reason) => {
       // connectionId + reason only — never payload contents.
@@ -153,67 +129,18 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
       teardownDataSocket(connectionId, closeCode, reason);
     };
 
-    const handleMessage = async (data, isBinary) => {
-      const current = dataSockets.get(connectionId);
-      if (current !== entry) return;
-      // Any inbound message (including the client's keepalive Ping) proves the
-      // client is alive; the idle sweeper reaps sockets this stops updating.
-      entry.lastActivityAt = Date.now();
-
-      if (!isBinary) {
-        const action = await handshake.handleText(data.toString('utf8'));
-        if (action.type === 'send-text') {
-          socket.send(action.text);
-        } else if (action.type === 'established') {
-          channel = action.channel;
-          batchNegotiated = action.batch === true;
-          entry.batcher = batchNegotiated
-            ? createOutboundFrameBatcher({ windowMs: resolvedBatchWindowMs, sendBatch: sendEncryptedPlaintext })
-            : null;
-          entry.tunnel = createTunnelHost({
-            connectionId,
-            getLocalPort: resolveLocalPort,
-            getBufferedAmount: () => socket.bufferedAmount,
-            sendFrame: (plaintextFrame) => {
-              if (dataSockets.get(connectionId) !== entry || socket.readyState !== WebSocket.OPEN) return;
-              if (entry.batcher) entry.batcher.enqueue(plaintextFrame);
-              else sendEncryptedPlaintext(plaintextFrame);
-            },
-          });
-          if (action.replyText) socket.send(action.replyText);
-        } else if (action.type === 'fail') {
-          failChannel(action.closeCode, action.reason);
-        }
-        return;
-      }
-
-      if (!channel || !entry.tunnel) {
-        // Encrypted traffic before the handshake completed: fail closed.
-        failChannel(RelayCloseCode.ChannelFailure, 'binary frame before handshake');
-        return;
-      }
-      let plaintext;
-      try {
-        plaintext = await channel.decryptor.decrypt(new Uint8Array(data));
-      } catch {
-        failChannel(RelayCloseCode.ChannelFailure, 'frame decryption failed');
-        return;
-      }
-      try {
-        if (batchNegotiated) {
-          // One encrypted message may carry several tunnel frames; dispatch each
-          // in order through the same per-frame handling as legacy.
-          for (const frame of decodeFrameBatch(plaintext)) {
-            if (dataSockets.get(connectionId) !== entry) return;
-            await entry.tunnel.handleFrame(frame);
-          }
-        } else {
-          await entry.tunnel.handleFrame(plaintext);
-        }
-      } catch (error) {
-        logger.warn(`[Relay] tunnel frame handling failed: ${error?.message ?? error}`);
-      }
-    };
+    entry.session = createEncryptedSession({
+      socket,
+      connectionId,
+      hostEncPrivateKey: identity.hostEncPrivateKey,
+      getLocalPort: resolveLocalPort,
+      isActive: () => dataSockets.get(connectionId) === entry,
+      onActivity: () => { entry.lastActivityAt = Date.now(); },
+      onFailure: failChannel,
+      logger,
+      batch: localBatch,
+      batchWindowMs: resolvedBatchWindowMs,
+    });
 
     socket.on('open', () => {
       if (entry.openTimer) {
@@ -223,12 +150,7 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
       emitStatus();
     });
     socket.on('message', (data, isBinary) => {
-      processing = processing
-        .then(() => handleMessage(data, isBinary))
-        .catch((error) => {
-          logger.warn(`[Relay] data socket message failed: ${error?.message ?? error}`);
-          failChannel(RelayCloseCode.ChannelFailure, 'internal error');
-        });
+      entry.session?.receive(data, isBinary);
     });
     socket.on('close', () => {
       teardownDataSocket(connectionId);

--- a/packages/web/server/lib/relay/tunnel-codec.js
+++ b/packages/web/server/lib/relay/tunnel-codec.js
@@ -154,6 +154,7 @@ export const encodeFragmentedMessage = (frameType, streamId, payload) => {
  */
 export const createFragmentAssembler = (maxMessageBytes = 16 * 1024 * 1024) => {
   const pending = new Map();
+  let pendingBytes = 0;
   return {
     /**
      * Returns the complete message payload once all fragments arrived, or null
@@ -169,14 +170,17 @@ export const createFragmentAssembler = (maxMessageBytes = 16 * 1024 * 1024) => {
       const chunks = entry?.chunks ?? [];
       const totalBytes = (entry?.totalBytes ?? 0) + frame.payload.length;
       if (totalBytes > maxMessageBytes) {
+        pendingBytes -= entry?.totalBytes ?? 0;
         pending.delete(key);
         throw new TunnelCodecError('fragmented message exceeds maximum size');
       }
       chunks.push(frame.payload);
       if (frame.hasMoreFragments) {
+        pendingBytes += frame.payload.length;
         pending.set(key, { chunks, totalBytes });
         return null;
       }
+      pendingBytes -= entry?.totalBytes ?? 0;
       pending.delete(key);
       const message = new Uint8Array(totalBytes);
       let offset = 0;
@@ -188,9 +192,19 @@ export const createFragmentAssembler = (maxMessageBytes = 16 * 1024 * 1024) => {
     },
     /** @param {number} streamId */
     dropStream(streamId) {
-      for (const key of pending.keys()) {
-        if (key.startsWith(`${streamId}:`)) pending.delete(key);
+      for (const [key, entry] of pending) {
+        if (key.startsWith(`${streamId}:`)) {
+          pendingBytes -= entry.totalBytes;
+          pending.delete(key);
+        }
       }
+    },
+    clear() {
+      pending.clear();
+      pendingBytes = 0;
+    },
+    get pendingBytes() {
+      return pendingBytes;
     },
   };
 };

--- a/packages/web/server/lib/relay/tunnel-codec.test.js
+++ b/packages/web/server/lib/relay/tunnel-codec.test.js
@@ -55,4 +55,15 @@ describe('relay tunnel codec', () => {
       assembler.push({ frameType: TunnelFrameType.WsText, streamId: 1, payload: chunk, hasMoreFragments: true }),
     ).toThrow(TunnelCodecError);
   });
+
+  it('clears aggregate fragment bytes on stream drop and assembler close cleanup', () => {
+    const assembler = createFragmentAssembler();
+    assembler.push({ frameType: TunnelFrameType.WsText, streamId: 1, payload: new Uint8Array(3), hasMoreFragments: true });
+    assembler.push({ frameType: TunnelFrameType.WsBinary, streamId: 2, payload: new Uint8Array(4), hasMoreFragments: true });
+    expect(assembler.pendingBytes).toBe(7);
+    assembler.dropStream(1);
+    expect(assembler.pendingBytes).toBe(4);
+    assembler.clear();
+    expect(assembler.pendingBytes).toBe(0);
+  });
 });

--- a/packages/web/server/lib/relay/tunnel-host.js
+++ b/packages/web/server/lib/relay/tunnel-host.js
@@ -79,6 +79,10 @@ const STRIPPED_RESPONSE_HEADERS = new Set([
 // relay socket has more than this buffered.
 const BACKPRESSURE_LIMIT_BYTES = 4 * 1024 * 1024;
 const BACKPRESSURE_POLL_MS = 20;
+const COMPLETED_HTTP_STREAM_TTL_MS = 5_000;
+const MAX_COMPLETED_HTTP_STREAMS = 256;
+const MAX_LATE_HTTP_BODY_FRAMES = 32;
+const MAX_LATE_HTTP_BODY_BYTES = 1024 * 1024;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -109,7 +113,7 @@ const isWsClosePayload = (parsed) => Boolean(parsed && typeof parsed === 'object
  *   onResponse?: (response: { kind: 'http', streamId: number, generation: number, status: number }) => void | Promise<void>,
  *   onLimitExceeded?: (reason: string) => void,
  *   onStreamClosed?: (event: { streamId: number, generation: number, kind: 'http' | 'ws', reason: string }) => void,
- *   limits?: { maxStreams?: number, maxWebSockets?: number, maxIncompleteFragments?: number, maxIncompleteFragmentBytes?: number, getMaxIncompleteFragmentBytes?: () => number, maxStreamOpens?: number, streamOpenWindowMs?: number },
+ *   limits?: { maxStreams?: number, maxWebSockets?: number, maxIncompleteFragments?: number, maxIncompleteFragmentBytes?: number, getMaxIncompleteFragmentBytes?: () => number, maxStreamOpens?: number, streamOpenWindowMs?: number, completedHttpStreamTtlMs?: number, maxCompletedHttpStreams?: number, maxLateHttpBodyFrames?: number, maxLateHttpBodyBytes?: number, now?: () => number },
  *   failClosedPolicy?: boolean,
  *   onProtocolFailure?: () => void,
  * }} deps
@@ -133,9 +137,52 @@ export const createTunnelHost = ({
   const streams = new Map();
   const assembler = createFragmentAssembler();
   const incompleteFragments = new Set();
+  /** @type {Map<number, { expiresAt: number, bodyCapable: boolean, lateBodyFrames: number, lateBodyBytes: number }>} */
+  const completedHttpStreams = new Map();
   let closed = false;
   const streamOpenTimes = [];
   let nextGeneration = 1;
+
+  const now = limits.now ?? Date.now;
+  const completedHttpStreamTtlMs = Number.isFinite(limits.completedHttpStreamTtlMs)
+    ? Math.max(0, limits.completedHttpStreamTtlMs)
+    : COMPLETED_HTTP_STREAM_TTL_MS;
+  const maxCompletedHttpStreams = Number.isFinite(limits.maxCompletedHttpStreams)
+    ? Math.max(0, Math.floor(limits.maxCompletedHttpStreams))
+    : MAX_COMPLETED_HTTP_STREAMS;
+  const maxLateHttpBodyFrames = Number.isFinite(limits.maxLateHttpBodyFrames)
+    ? Math.max(0, Math.floor(limits.maxLateHttpBodyFrames))
+    : MAX_LATE_HTTP_BODY_FRAMES;
+  const maxLateHttpBodyBytes = Number.isFinite(limits.maxLateHttpBodyBytes)
+    ? Math.max(0, limits.maxLateHttpBodyBytes)
+    : MAX_LATE_HTTP_BODY_BYTES;
+
+  const pruneCompletedHttpStreams = () => {
+    const currentTime = now();
+    for (const [streamId, tombstone] of completedHttpStreams) {
+      if (tombstone.expiresAt > currentTime) continue;
+      completedHttpStreams.delete(streamId);
+    }
+  };
+
+  const recordCompletedHttpStream = (streamId, stream) => {
+    pruneCompletedHttpStreams();
+    if (maxCompletedHttpStreams === 0 || completedHttpStreamTtlMs === 0) return;
+    while (completedHttpStreams.size >= maxCompletedHttpStreams) {
+      completedHttpStreams.delete(completedHttpStreams.keys().next().value);
+    }
+    completedHttpStreams.set(streamId, {
+      expiresAt: now() + completedHttpStreamTtlMs,
+      bodyCapable: !stream.noBody,
+      lateBodyFrames: 0,
+      lateBodyBytes: 0,
+    });
+  };
+
+  const getCompletedHttpStream = (streamId) => {
+    pruneCompletedHttpStreams();
+    return completedHttpStreams.get(streamId);
+  };
 
   const send = async (frame) => {
     if (closed) return;
@@ -151,6 +198,7 @@ export const createTunnelHost = ({
 
   const dropStream = (streamId, reason = 'completed') => {
     const stream = streams.get(streamId);
+    if (reason === 'completed' && stream?.kind === 'http') recordCompletedHttpStream(streamId, stream);
     streams.delete(streamId);
     assembler.dropStream(streamId);
     for (const key of incompleteFragments) {
@@ -327,6 +375,7 @@ export const createTunnelHost = ({
   };
 
   const handleHttpRequest = (streamId, payload) => {
+    if (getCompletedHttpStream(streamId)) throw new Error('completed stream id reused');
     if (streams.has(streamId)) {
       abortLocalStream(streamId, 'duplicate stream id');
       void sendAbort(streamId, 'duplicate stream id');
@@ -358,7 +407,19 @@ export const createTunnelHost = ({
 
   const handleHttpBody = (streamId, payload) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'http' || stream.noBody) throw new Error('unsolicited http body');
+    if (!stream) {
+      const tombstone = getCompletedHttpStream(streamId);
+      if (!tombstone?.bodyCapable) throw new Error('unsolicited http body');
+      const nextFrames = tombstone.lateBodyFrames + 1;
+      const nextBytes = tombstone.lateBodyBytes + payload.byteLength;
+      if (nextFrames > maxLateHttpBodyFrames || nextBytes > maxLateHttpBodyBytes) {
+        throw new Error('late http body budget exceeded');
+      }
+      tombstone.lateBodyFrames = nextFrames;
+      tombstone.lateBodyBytes = nextBytes;
+      return;
+    }
+    if (stream.kind !== 'http' || stream.noBody) throw new Error('unsolicited http body');
     // The body controller attaches synchronously in runHttpStream before any
     // await, so by the time body frames arrive it is set for body-carrying
     // methods; drop stray body bytes otherwise.
@@ -371,7 +432,12 @@ export const createTunnelHost = ({
 
   const handleStreamEnd = (streamId) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'http') throw new Error('unsolicited stream end');
+    if (!stream) {
+      if (!getCompletedHttpStream(streamId)) throw new Error('unsolicited stream end');
+      completedHttpStreams.delete(streamId);
+      return;
+    }
+    if (stream.kind !== 'http') throw new Error('unsolicited stream end');
     try {
       stream.body?.close();
     } catch {
@@ -385,6 +451,7 @@ export const createTunnelHost = ({
   // -------------------------------------------------------------------------
 
   const handleWsOpen = async (streamId, payload) => {
+    if (getCompletedHttpStream(streamId)) throw new Error('completed stream id reused');
     if (streams.has(streamId)) {
       abortLocalStream(streamId, 'duplicate stream id');
       void sendAbort(streamId, 'duplicate stream id');
@@ -598,6 +665,7 @@ export const createTunnelHost = ({
       abortLocalStream(streamId, 'connection closed');
     }
     streams.clear();
+    completedHttpStreams.clear();
     incompleteFragments.clear();
     assembler.clear();
   };
@@ -607,6 +675,10 @@ export const createTunnelHost = ({
     close,
     get streamCount() {
       return streams.size;
+    },
+    get completedHttpStreamCount() {
+      pruneCompletedHttpStreams();
+      return completedHttpStreams.size;
     },
   };
 };

--- a/packages/web/server/lib/relay/tunnel-host.js
+++ b/packages/web/server/lib/relay/tunnel-host.js
@@ -133,7 +133,7 @@ export const createTunnelHost = ({
   failClosedPolicy = false,
   onProtocolFailure,
 }) => {
-  /** @type {Map<number, { kind: 'http', abort: AbortController, body: ReadableStreamDefaultController | null, responseBody: ReadableStream | null, noBody: boolean } | { kind: 'ws', socket: WebSocket, opened: boolean }>} */
+  /** @type {Map<number, { kind: 'http', abort: AbortController, body: ReadableStreamDefaultController | null, requestBody: ReadableStream | undefined, responseBody: ReadableStream | null, noBody: boolean } | { kind: 'ws', socket: WebSocket, opened: boolean }>} */
   const streams = new Map();
   const assembler = createFragmentAssembler();
   const incompleteFragments = new Set();
@@ -311,17 +311,7 @@ export const createTunnelHost = ({
       return;
     }
 
-    const hasBody = method !== 'GET' && method !== 'HEAD';
-    let requestBody;
-    if (hasBody) {
-      requestBody = new ReadableStream({
-        start(controller) {
-          stream.body = controller;
-        },
-      });
-    } else {
-      stream.body = null;
-    }
+    const hasBody = !stream.noBody;
 
     const url = `http://127.0.0.1:${getLocalPort()}${request.path}${request.query ? `?${request.query}` : ''}`;
     let response;
@@ -329,7 +319,7 @@ export const createTunnelHost = ({
       response = await fetch(url, {
         method,
         headers: buildRequestHeaders(request.headers),
-        body: requestBody,
+        body: stream.requestBody,
         duplex: hasBody ? 'half' : undefined,
         signal: stream.abort.signal,
       });
@@ -390,7 +380,22 @@ export const createTunnelHost = ({
       return;
     }
     const method = request.method.toUpperCase();
-    const stream = { kind: 'http', generation: nextGeneration++, abort: new AbortController(), body: null, responseBody: null, noBody: method === 'GET' || method === 'HEAD' };
+    const stream = {
+      kind: 'http',
+      generation: nextGeneration++,
+      abort: new AbortController(),
+      body: null,
+      requestBody: undefined,
+      responseBody: null,
+      noBody: method === 'GET' || method === 'HEAD',
+    };
+    if (!stream.noBody) {
+      stream.requestBody = new ReadableStream({
+        start(controller) {
+          stream.body = controller;
+        },
+      });
+    }
     if (atStreamLimit('http')) {
       onLimitExceeded?.('stream-limit');
       void sendAbort(streamId, 'stream limit exceeded');
@@ -420,9 +425,8 @@ export const createTunnelHost = ({
       return;
     }
     if (stream.kind !== 'http' || stream.noBody) throw new Error('unsolicited http body');
-    // The body controller attaches synchronously in runHttpStream before any
-    // await, so by the time body frames arrive it is set for body-carrying
-    // methods; drop stray body bytes otherwise.
+    // The body controller attaches synchronously when the stream opens, before
+    // policy evaluation or loopback dispatch can await.
     try {
       stream.body?.enqueue(payload);
     } catch {

--- a/packages/web/server/lib/relay/tunnel-host.js
+++ b/packages/web/server/lib/relay/tunnel-host.js
@@ -35,6 +35,17 @@ const ALLOWED_WS_PATHS = new Set([
   '/api/dictation/ws',
 ]);
 
+const canonicalizeTarget = (path, query) => {
+  if (typeof path !== 'string' || typeof query !== 'string' || !path.startsWith('/') || path.startsWith('//')) return null;
+  if (/[%](?:2f|5c|2e)/i.test(path) || /[\\?#\0-\x1f\x7f]/.test(path) || path.includes('//')) return null;
+  let decoded;
+  try { decoded = decodeURIComponent(path); } catch { return null; }
+  if (decoded.split('/').some((part) => part === '.' || part === '..') || /[\\?#\0-\x1f\x7f]/.test(decoded)) return null;
+  const url = new URL(`${path}${query ? `?${query}` : ''}`, 'http://loopback.invalid');
+  if (url.username || url.password || url.pathname !== path || url.search.slice(1) !== query) return null;
+  return { path: url.pathname, query: url.search.slice(1) };
+};
+
 // Hop-by-hop headers stripped from tunneled requests; `host` is set by fetch
 // to the loopback origin. content-length is dropped too because the body is
 // re-chunked through the tunnel and undici computes framing itself.
@@ -46,6 +57,13 @@ const STRIPPED_REQUEST_HEADERS = new Set([
   'host',
   'content-length',
 ]);
+
+const isUntrustedTransportHeader = (name, stripOrigin) =>
+  name === 'forwarded'
+  || name.startsWith('x-forwarded-')
+  || name.startsWith('cf-')
+  || name.startsWith('x-openchamber-')
+  || (stripOrigin && name === 'origin');
 
 // Response framing headers that no longer apply once the body crosses the
 // tunnel as HttpBody chunks (loopback fetch already decoded content-encoding).
@@ -85,13 +103,39 @@ const isWsClosePayload = (parsed) => Boolean(parsed && typeof parsed === 'object
  *   getLocalPort: () => number,
  *   sendFrame: (plaintextFrame: Uint8Array) => void | Promise<void>,
  *   getBufferedAmount: () => number,
+ *   transportContext?: { requestHeaders?: Record<string, string>, wsHeaders?: Record<string, string>, metadataHeader?: string | null, stripOrigin?: boolean },
+ *   requestPolicy?: (request: { kind: 'http' | 'ws', streamId: number, generation: number, method?: string, path: string, query: string, headers?: Record<string, string> }) => boolean | string | Promise<boolean | string>,
+ *   onRequest?: (request: object) => void,
+ *   onResponse?: (response: { kind: 'http', streamId: number, generation: number, status: number }) => void | Promise<void>,
+ *   onLimitExceeded?: (reason: string) => void,
+ *   onStreamClosed?: (event: { streamId: number, generation: number, kind: 'http' | 'ws', reason: string }) => void,
+ *   limits?: { maxStreams?: number, maxWebSockets?: number, maxIncompleteFragments?: number, maxIncompleteFragmentBytes?: number, getMaxIncompleteFragmentBytes?: () => number, maxStreamOpens?: number, streamOpenWindowMs?: number },
+ *   failClosedPolicy?: boolean,
+ *   onProtocolFailure?: () => void,
  * }} deps
  */
-export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBufferedAmount }) => {
-  /** @type {Map<number, { kind: 'http', abort: AbortController, body: ReadableStreamDefaultController | null } | { kind: 'ws', socket: WebSocket, opened: boolean }>} */
+export const createTunnelHost = ({
+  connectionId,
+  getLocalPort,
+  sendFrame,
+  getBufferedAmount,
+  transportContext = {},
+  requestPolicy,
+  onRequest,
+  onResponse,
+  onLimitExceeded,
+  onStreamClosed,
+  limits = {},
+  failClosedPolicy = false,
+  onProtocolFailure,
+}) => {
+  /** @type {Map<number, { kind: 'http', abort: AbortController, body: ReadableStreamDefaultController | null, responseBody: ReadableStream | null, noBody: boolean } | { kind: 'ws', socket: WebSocket, opened: boolean }>} */
   const streams = new Map();
   const assembler = createFragmentAssembler();
+  const incompleteFragments = new Set();
   let closed = false;
+  const streamOpenTimes = [];
+  let nextGeneration = 1;
 
   const send = async (frame) => {
     if (closed) return;
@@ -105,22 +149,23 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     await sendJson(TunnelFrameType.StreamAbort, streamId, { reason: String(reason ?? 'stream error') });
   };
 
-  const dropStream = (streamId) => {
+  const dropStream = (streamId, reason = 'completed') => {
+    const stream = streams.get(streamId);
     streams.delete(streamId);
     assembler.dropStream(streamId);
+    for (const key of incompleteFragments) {
+      if (key.startsWith(`${streamId}:`)) incompleteFragments.delete(key);
+    }
+    if (stream) onStreamClosed?.({ streamId, generation: stream.generation, kind: stream.kind, reason });
   };
 
   const abortLocalStream = (streamId, reason) => {
     const stream = streams.get(streamId);
     if (!stream) return;
-    dropStream(streamId);
+    dropStream(streamId, String(reason ?? 'aborted'));
     if (stream.kind === 'http') {
-      try {
-        stream.body?.error(new Error(String(reason ?? 'aborted')));
-      } catch {
-        // body already closed
-      }
       stream.abort.abort();
+      void stream.responseBody?.cancel().catch(() => {});
     } else {
       try {
         stream.socket.terminate();
@@ -146,12 +191,43 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     for (const [name, value] of Object.entries(rawHeaders)) {
       if (typeof name !== 'string' || typeof value !== 'string') continue;
       const lower = name.toLowerCase();
-      if (STRIPPED_REQUEST_HEADERS.has(lower)) continue;
+      if (STRIPPED_REQUEST_HEADERS.has(lower) || isUntrustedTransportHeader(lower, transportContext.stripOrigin === true)) continue;
       if (/[\r\n]/.test(name) || /[\r\n]/.test(value)) continue;
       headers[lower] = value;
     }
-    headers['x-openchamber-relay-connection'] = connectionId;
+    const metadataHeader = transportContext.metadataHeader === undefined
+      ? 'x-openchamber-relay-connection'
+      : transportContext.metadataHeader;
+    if (metadataHeader) headers[metadataHeader.toLowerCase()] = connectionId;
+    for (const [name, value] of Object.entries(transportContext.requestHeaders ?? {})) {
+      headers[name.toLowerCase()] = value;
+    }
     return headers;
+  };
+
+  const policyRejection = async (request) => {
+    onRequest?.(request);
+    const result = await requestPolicy?.(request);
+    if (result === false) return 'Request rejected by transport policy';
+    return typeof result === 'string' ? result : null;
+  };
+
+  const exceedsOpenRate = () => {
+    if (!Number.isFinite(limits.maxStreamOpens)) return false;
+    const now = Date.now();
+    const windowMs = Number.isFinite(limits.streamOpenWindowMs) ? limits.streamOpenWindowMs : 10_000;
+    while (streamOpenTimes.length > 0 && now - streamOpenTimes[0] >= windowMs) streamOpenTimes.shift();
+    if (streamOpenTimes.length >= limits.maxStreamOpens) return true;
+    streamOpenTimes.push(now);
+    return false;
+  };
+
+  const atStreamLimit = (kind) => {
+    if (Number.isFinite(limits.maxStreams) && streams.size >= limits.maxStreams) return true;
+    if (kind !== 'ws' || !Number.isFinite(limits.maxWebSockets)) return false;
+    let count = 0;
+    for (const stream of streams.values()) if (stream.kind === 'ws') count += 1;
+    return count >= limits.maxWebSockets;
   };
 
   // Synthetic responses never ship an empty body: `reason` states explicitly
@@ -166,15 +242,26 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
   };
 
   const runHttpStream = async (streamId, request) => {
+    const target = canonicalizeTarget(request.path, request.query);
+    if (!target) throw new Error('invalid request target');
+    request.path = target.path;
+    request.query = target.query;
     const method = request.method.toUpperCase();
     if (!isAllowedHttpPath(request.path)) {
-      dropStream(streamId);
+      dropStream(streamId, 'path-rejected');
+      if (failClosedPolicy) throw new Error('path rejected');
       await syntheticResponse(streamId, 403, 'Path is not allowed through the relay');
       return;
     }
-
     const stream = streams.get(streamId);
     if (!stream || stream.kind !== 'http') return;
+    const rejected = await policyRejection({ kind: 'http', streamId, generation: stream.generation, method, path: request.path, query: request.query, headers: request.headers });
+    if (rejected) {
+      dropStream(streamId, 'policy-rejected');
+      if (failClosedPolicy) throw new Error('request rejected by transport policy');
+      await syntheticResponse(streamId, 403, rejected);
+      return;
+    }
 
     const hasBody = method !== 'GET' && method !== 'HEAD';
     let requestBody;
@@ -186,7 +273,6 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       });
     } else {
       stream.body = null;
-      stream.noBody = true;
     }
 
     const url = `http://127.0.0.1:${getLocalPort()}${request.path}${request.query ? `?${request.query}` : ''}`;
@@ -201,11 +287,12 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       });
     } catch (error) {
       if (streams.get(streamId) === stream) {
-        dropStream(streamId);
+        dropStream(streamId, 'request-failed');
         await sendAbort(streamId, error?.message ?? 'loopback request failed');
       }
       return;
     }
+    stream.responseBody = response.body;
 
     const responseHeaders = {};
     for (const [name, value] of response.headers.entries()) {
@@ -213,6 +300,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       responseHeaders[name] = value;
     }
     await sendJson(TunnelFrameType.HttpResponse, streamId, { status: response.status, headers: responseHeaders });
+    await onResponse?.({ kind: 'http', streamId, generation: stream.generation, status: response.status });
 
     try {
       if (response.body) {
@@ -227,12 +315,12 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
         }
       }
       if (streams.get(streamId) === stream) {
-        dropStream(streamId);
+        dropStream(streamId, 'completed');
         await send(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
       }
     } catch (error) {
       if (streams.get(streamId) === stream) {
-        dropStream(streamId);
+        dropStream(streamId, 'response-failed');
         await sendAbort(streamId, error?.message ?? 'loopback response failed');
       }
     }
@@ -248,17 +336,29 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     try {
       request = decodeJsonPayload(payload, isHttpRequestPayload);
     } catch (error) {
+      if (failClosedPolicy) throw error;
       void sendAbort(streamId, error?.message ?? 'malformed request');
       return;
     }
-    const stream = { kind: 'http', abort: new AbortController(), body: null, noBody: false };
+    const method = request.method.toUpperCase();
+    const stream = { kind: 'http', generation: nextGeneration++, abort: new AbortController(), body: null, responseBody: null, noBody: method === 'GET' || method === 'HEAD' };
+    if (atStreamLimit('http')) {
+      onLimitExceeded?.('stream-limit');
+      void sendAbort(streamId, 'stream limit exceeded');
+      return;
+    }
+    if (exceedsOpenRate()) {
+      onLimitExceeded?.('stream-open-rate');
+      void sendAbort(streamId, 'stream open rate exceeded');
+      return;
+    }
     streams.set(streamId, stream);
-    void runHttpStream(streamId, request);
+    void runHttpStream(streamId, request).catch(() => onProtocolFailure?.());
   };
 
   const handleHttpBody = (streamId, payload) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'http' || stream.noBody) return;
+    if (!stream || stream.kind !== 'http' || stream.noBody) throw new Error('unsolicited http body');
     // The body controller attaches synchronously in runHttpStream before any
     // await, so by the time body frames arrive it is set for body-carrying
     // methods; drop stray body bytes otherwise.
@@ -271,7 +371,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
 
   const handleStreamEnd = (streamId) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'http') return;
+    if (!stream || stream.kind !== 'http') throw new Error('unsolicited stream end');
     try {
       stream.body?.close();
     } catch {
@@ -284,7 +384,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
   // WebSocket
   // -------------------------------------------------------------------------
 
-  const handleWsOpen = (streamId, payload) => {
+  const handleWsOpen = async (streamId, payload) => {
     if (streams.has(streamId)) {
       abortLocalStream(streamId, 'duplicate stream id');
       void sendAbort(streamId, 'duplicate stream id');
@@ -294,11 +394,34 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     try {
       open = decodeJsonPayload(payload, isWsOpenPayload);
     } catch (error) {
+      if (failClosedPolicy) throw error;
       void sendAbort(streamId, error?.message ?? 'malformed ws open');
       return;
     }
+    const target = canonicalizeTarget(open.path, open.query);
+    if (!target) throw new Error('invalid websocket target');
+    open.path = target.path;
+    open.query = target.query;
     if (!ALLOWED_WS_PATHS.has(open.path)) {
+      if (failClosedPolicy) throw new Error('path rejected');
       void sendAbort(streamId, 'Path is not allowed through the relay');
+      return;
+    }
+    const generation = nextGeneration++;
+    const rejected = await policyRejection({ kind: 'ws', streamId, generation, path: open.path, query: open.query });
+    if (rejected) {
+      if (failClosedPolicy) throw new Error('request rejected by transport policy');
+      void sendAbort(streamId, rejected);
+      return;
+    }
+    if (atStreamLimit('ws')) {
+      onLimitExceeded?.('websocket-limit');
+      void sendAbort(streamId, 'stream limit exceeded');
+      return;
+    }
+    if (exceedsOpenRate()) {
+      onLimitExceeded?.('stream-open-rate');
+      void sendAbort(streamId, 'stream open rate exceeded');
       return;
     }
 
@@ -311,9 +434,13 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     // otherwise — a no-origin upgrade is rejected 403. The request itself is still
     // authenticated by the tunneled oc_url_token, not by this origin.
     const dialHeaders = {
-      'x-openchamber-relay-connection': connectionId,
       origin: `http://127.0.0.1:${getLocalPort()}`,
     };
+    const metadataHeader = transportContext.metadataHeader === undefined
+      ? 'x-openchamber-relay-connection'
+      : transportContext.metadataHeader;
+    if (metadataHeader) dialHeaders[metadataHeader.toLowerCase()] = connectionId;
+    Object.assign(dialHeaders, transportContext.wsHeaders ?? {});
     let socket;
     try {
       socket = new WebSocket(url, open.protocols, {
@@ -323,7 +450,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       void sendAbort(streamId, error?.message ?? 'ws dial failed');
       return;
     }
-    const stream = { kind: 'ws', socket, opened: false };
+    const stream = { kind: 'ws', generation, socket, opened: false, sendChain: Promise.resolve() };
     streams.set(streamId, stream);
 
     socket.on('open', () => {
@@ -335,17 +462,21 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       if (streams.get(streamId) !== stream || closed) return;
       const bytes = Buffer.isBuffer(data) ? new Uint8Array(data) : new Uint8Array(Buffer.concat(data));
       const frameType = isBinary ? TunnelFrameType.WsBinary : TunnelFrameType.WsText;
-      void (async () => {
+      stream.sendChain = stream.sendChain.then(async () => {
         for (const frame of encodeFragmentedMessage(frameType, streamId, bytes)) {
           await waitForBackpressure(null);
           if (streams.get(streamId) !== stream || closed) return;
           await send(frame);
         }
-      })();
+      }).catch(() => {
+        if (streams.get(streamId) !== stream) return;
+        abortLocalStream(streamId, 'send-failed');
+        onProtocolFailure?.();
+      });
     });
     socket.on('close', (code, reasonBuffer) => {
       if (streams.get(streamId) !== stream) return;
-      dropStream(streamId);
+      dropStream(streamId, 'upstream-closed');
       const reason = reasonBuffer ? reasonBuffer.toString('utf8') : '';
       if (stream.opened) {
         void sendJson(TunnelFrameType.WsClose, streamId, { code: code || 1000, reason });
@@ -356,7 +487,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     socket.on('error', (error) => {
       if (streams.get(streamId) !== stream) return;
       if (!stream.opened) {
-        dropStream(streamId);
+        dropStream(streamId, 'upstream-error');
         try {
           socket.terminate();
         } catch {
@@ -370,7 +501,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
 
   const handleWsMessage = (streamId, frameType, message) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'ws' || stream.socket.readyState !== WebSocket.OPEN) return;
+    if (!stream || stream.kind !== 'ws' || !stream.opened || stream.socket.readyState !== WebSocket.OPEN) throw new Error('unsolicited websocket data');
     if (frameType === TunnelFrameType.WsText) {
       stream.socket.send(Buffer.from(message).toString('utf8'));
     } else {
@@ -381,7 +512,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
   const handleWsClose = (streamId, payload) => {
     const stream = streams.get(streamId);
     if (!stream || stream.kind !== 'ws') return;
-    dropStream(streamId);
+    dropStream(streamId, 'closed-by-client');
     let close = { code: 1000, reason: '' };
     try {
       close = decodeJsonPayload(payload, isWsClosePayload);
@@ -407,8 +538,26 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
 
     // WS message frames can be fragmented; everything else arrives whole.
     if (frame.frameType === TunnelFrameType.WsText || frame.frameType === TunnelFrameType.WsBinary) {
+      const stream = streams.get(frame.streamId);
+      if (!stream || stream.kind !== 'ws' || !stream.opened || stream.socket.readyState !== WebSocket.OPEN) {
+        throw new Error('unsolicited websocket data');
+      }
+      const fragmentKey = `${frame.streamId}:${frame.frameType}`;
+      if (frame.hasMoreFragments && !incompleteFragments.has(fragmentKey)) {
+        if (Number.isFinite(limits.maxIncompleteFragments) && incompleteFragments.size >= limits.maxIncompleteFragments) {
+          onLimitExceeded?.('fragment-limit');
+          await sendAbort(frame.streamId, 'incomplete fragment limit exceeded');
+          return;
+        }
+        incompleteFragments.add(fragmentKey);
+      }
       const message = assembler.push(frame);
+      const fragmentByteLimit = limits.getMaxIncompleteFragmentBytes?.() ?? limits.maxIncompleteFragmentBytes;
+      if (Number.isFinite(fragmentByteLimit) && assembler.pendingBytes > fragmentByteLimit) {
+        throw new Error('incomplete fragment byte limit exceeded');
+      }
       if (message === null) return;
+      incompleteFragments.delete(fragmentKey);
       handleWsMessage(frame.streamId, frame.frameType, message);
       return;
     }
@@ -427,7 +576,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
         abortLocalStream(frame.streamId, 'aborted by client');
         return;
       case TunnelFrameType.WsOpen:
-        handleWsOpen(frame.streamId, frame.payload);
+        await handleWsOpen(frame.streamId, frame.payload);
         return;
       case TunnelFrameType.WsClose:
         handleWsClose(frame.streamId, frame.payload);
@@ -438,8 +587,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       case TunnelFrameType.Pong:
         return;
       default:
-        // Host never receives HttpResponse/WsOpened; ignore rather than tear down.
-        return;
+        throw new Error('prohibited tunnel frame');
     }
   };
 
@@ -450,6 +598,8 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       abortLocalStream(streamId, 'connection closed');
     }
     streams.clear();
+    incompleteFragments.clear();
+    assembler.clear();
   };
 
   return {

--- a/packages/web/server/lib/relay/tunnel-host.test.js
+++ b/packages/web/server/lib/relay/tunnel-host.test.js
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import http from 'node:http';
+import { WebSocketServer } from 'ws';
+
+import { createTunnelHost } from './tunnel-host.js';
+import { MAX_TUNNEL_PAYLOAD_BYTES, TunnelFrameType, decodeJsonPayload, decodeTunnelFrame, encodeJsonPayload, encodeTunnelFrame } from './tunnel-codec.js';
+
+const servers = [];
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise((resolve) => server.close(resolve))));
+});
+
+const startOrigin = async () => {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    received.push({ headers: req.headers, url: req.url });
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  servers.push(server);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return { port: server.address().port, received };
+};
+
+const startWsOrigin = async (onConnection = () => {}) => {
+  const server = http.createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (req, socket, head) => wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws)));
+  wss.on('connection', onConnection);
+  servers.push({ close: (done) => { for (const ws of wss.clients) ws.terminate(); wss.close(); server.closeAllConnections?.(); server.close(done); } });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return { port: server.address().port, wss };
+};
+
+const openNested = async (host, sent, streamId = 1) => {
+  await host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsOpen, streamId, encodeJsonPayload({ path: '/api/global/event/ws', query: '', protocols: [] })));
+  await waitFor(() => sent.some((raw) => {
+    const frame = decodeTunnelFrame(raw);
+    return frame.streamId === streamId && frame.frameType === TunnelFrameType.WsOpened;
+  }));
+};
+
+const waitFor = async (predicate) => {
+  for (let i = 0; i < 100; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('condition not reached');
+};
+
+describe('tunnel host policy seams', () => {
+  it('strips untrusted forwarding and internal headers before trusted context injection', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({
+      connectionId: 'direct-1',
+      getLocalPort: () => origin.port,
+      getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame),
+      transportContext: {
+        metadataHeader: null,
+        stripOrigin: true,
+        requestHeaders: { 'x-openchamber-transport': 'trusted-marker' },
+      },
+    });
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({
+      method: 'GET', path: '/health', query: '', headers: {
+        forwarded: 'for=attacker', 'x-forwarded-for': 'attacker', 'cf-connecting-ip': 'attacker',
+        origin: 'https://attacker.test', 'x-openchamber-transport': 'attacker', accept: 'application/json',
+      },
+    })));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+    await waitFor(() => origin.received.length === 1);
+    const headers = origin.received[0].headers;
+    expect(headers.forwarded).toBeUndefined();
+    expect(headers['x-forwarded-for']).toBeUndefined();
+    expect(headers['cf-connecting-ip']).toBeUndefined();
+    expect(headers.origin).toBeUndefined();
+    expect(headers['x-openchamber-transport']).toBe('trusted-marker');
+    expect(headers['x-openchamber-relay-connection']).toBeUndefined();
+    host.close();
+  });
+
+  it('fails closed for disallowed HTTP and WebSocket paths', async () => {
+    const origin = await startOrigin();
+    let failures = 0;
+    const host = createTunnelHost({
+      connectionId: 'closed-paths', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame() {}, failClosedPolicy: true, onProtocolFailure: () => { failures += 1; },
+    });
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/forbidden', query: '', headers: {} })));
+    await waitFor(() => failures === 1);
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsOpen, 3, encodeJsonPayload({ path: '/forbidden', query: '', protocols: [] })))).rejects.toThrow('path rejected');
+    host.close();
+  });
+
+  it('rejects unknown-stream fragments before assembly', async () => {
+    const host = createTunnelHost({ connectionId: 'unknown-fragment', getLocalPort: () => 1, getBufferedAmount: () => 0, sendFrame() {} });
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsText, 99, new Uint8Array([1]), true))).rejects.toThrow('unsolicited websocket data');
+    host.close();
+  });
+
+  it('enforces aggregate fragment bytes, frees them on abort, and switches to the authenticated budget', async () => {
+    const origin = await startWsOrigin();
+    const sent = [];
+    let authenticated = false;
+    const host = createTunnelHost({
+      connectionId: 'fragment-budget', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { getMaxIncompleteFragmentBytes: () => authenticated ? 8 : 3 },
+    });
+    await openNested(host, sent, 1);
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsText, 1, new Uint8Array([1, 2, 3]), true));
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsBinary, 1, new Uint8Array([4]), true))).rejects.toThrow('incomplete fragment byte limit exceeded');
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamAbort, 1, new Uint8Array()));
+    await openNested(host, sent, 3);
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsText, 3, new Uint8Array([1, 2, 3]), true));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamAbort, 3, new Uint8Array()));
+    authenticated = true;
+    await openNested(host, sent, 5);
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsText, 5, new Uint8Array(8), true));
+    host.close();
+  });
+
+  it('rejects ambiguous paths while preserving normal paths and encoded query values', async () => {
+    const invalid = ['/api/../auth', '/api/%2e%2e/auth', '/api%2fauth', '/api%5cauth', '/api\\auth', '/api//health', '/api/\0x', '/api/x?hidden'];
+    for (const path of invalid) {
+      let failures = 0;
+      const host = createTunnelHost({ connectionId: 'canonical', getLocalPort: () => 1, getBufferedAmount: () => 0, sendFrame() {}, failClosedPolicy: true, onProtocolFailure: () => { failures += 1; } });
+      await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path, query: '', headers: {} })));
+      await waitFor(() => failures === 1);
+      host.close();
+    }
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({ connectionId: 'canonical-ok', getLocalPort: () => origin.port, getBufferedAmount: () => 0, sendFrame: (frame) => sent.push(frame) });
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/api/config', query: 'value=a%2Fb%3Fc%26d', headers: {} })));
+    await waitFor(() => origin.received.length === 1);
+    expect(origin.received[0].url).toBe('/api/config?value=a%2Fb%3Fc%26d');
+    host.close();
+  });
+
+  it('serializes fragmented text and binary messages through artificial backpressure', async () => {
+    const text = 't'.repeat(MAX_TUNNEL_PAYLOAD_BYTES + 10);
+    const binary = new Uint8Array(MAX_TUNNEL_PAYLOAD_BYTES + 10).fill(7);
+    const origin = await startWsOrigin((ws) => { ws.send(text); ws.send(binary, { binary: true }); });
+    const sent = [];
+    let blocked = true;
+    const host = createTunnelHost({ connectionId: 'serialized', getLocalPort: () => origin.port, getBufferedAmount: () => blocked ? 5 * 1024 * 1024 : 0, sendFrame: (frame) => sent.push(frame) });
+    await openNested(host, sent);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    blocked = false;
+    await waitFor(() => sent.filter((raw) => [TunnelFrameType.WsText, TunnelFrameType.WsBinary].includes(decodeTunnelFrame(raw).frameType)).length === 4);
+    const types = sent.map(decodeTunnelFrame).filter((frame) => [TunnelFrameType.WsText, TunnelFrameType.WsBinary].includes(frame.frameType)).map((frame) => frame.frameType);
+    expect(types).toEqual([TunnelFrameType.WsText, TunnelFrameType.WsText, TunnelFrameType.WsBinary, TunnelFrameType.WsBinary]);
+    host.close();
+  });
+
+  it('turns send-chain rejection into one protocol failure and stream cleanup', async () => {
+    const origin = await startWsOrigin((ws) => ws.send('payload'));
+    const sent = [];
+    let failures = 0;
+    const closed = [];
+    const host = createTunnelHost({
+      connectionId: 'send-reject', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => { if (decodeTunnelFrame(frame).frameType === TunnelFrameType.WsText) return Promise.reject(new Error('blocked')); sent.push(frame); },
+      onProtocolFailure: () => { failures += 1; }, onStreamClosed: (event) => closed.push(event),
+    });
+    await openNested(host, sent);
+    await waitFor(() => failures === 1);
+    expect(host.streamCount).toBe(0);
+    expect(closed.some((event) => event.reason === 'send-failed')).toBe(true);
+    host.close();
+  });
+
+  it('rejects limit + 1 streams without changing omitted relay defaults', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({
+      connectionId: 'limited', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { maxStreams: 1 },
+    });
+    const request = (streamId) => host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, streamId, encodeJsonPayload({
+      method: 'POST', path: '/health', query: '', headers: {},
+    })));
+    await request(1);
+    await request(2);
+    await waitFor(() => sent.some((raw) => {
+      const frame = decodeTunnelFrame(raw);
+      return frame.streamId === 2 && frame.frameType === TunnelFrameType.StreamAbort
+        && decodeJsonPayload(frame.payload, (value) => value).reason === 'stream limit exceeded';
+    }));
+    expect(host.streamCount).toBe(1);
+    host.close();
+  });
+});

--- a/packages/web/server/lib/relay/tunnel-host.test.js
+++ b/packages/web/server/lib/relay/tunnel-host.test.js
@@ -48,6 +48,16 @@ const waitFor = async (predicate) => {
   throw new Error('condition not reached');
 };
 
+const openHttpAndWaitCompleted = async (host, sent, streamId, method) => {
+  await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, streamId, encodeJsonPayload({
+    method, path: '/health', query: '', headers: {},
+  })));
+  await waitFor(() => sent.some((raw) => {
+    const frame = decodeTunnelFrame(raw);
+    return frame.streamId === streamId && frame.frameType === TunnelFrameType.StreamEnd;
+  }));
+};
+
 describe('tunnel host policy seams', () => {
   it('strips untrusted forwarding and internal headers before trusted context injection', async () => {
     const origin = await startOrigin();
@@ -191,5 +201,82 @@ describe('tunnel host policy seams', () => {
     }));
     expect(host.streamCount).toBe(1);
     host.close();
+  });
+
+  it('tolerates bounded late DELETE body frames and consumes the tombstone on StreamEnd', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({
+      connectionId: 'late-delete', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { maxLateHttpBodyFrames: 2, maxLateHttpBodyBytes: 4 },
+    });
+    await openHttpAndWaitCompleted(host, sent, 1, 'DELETE');
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1, 2])));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([3, 4])));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()))).rejects.toThrow('unsolicited stream end');
+    host.close();
+  });
+
+  it('tolerates a late GET StreamEnd but rejects a late GET body', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({ connectionId: 'late-get', getLocalPort: () => origin.port, getBufferedAmount: () => 0, sendFrame: (frame) => sent.push(frame) });
+    await openHttpAndWaitCompleted(host, sent, 1, 'GET');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1])))).rejects.toThrow('unsolicited http body');
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+    host.close();
+  });
+
+  it('keeps unknown IDs and tombstoned ID reuse fatal', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({ connectionId: 'unknown-reuse', getLocalPort: () => origin.port, getBufferedAmount: () => 0, sendFrame: (frame) => sent.push(frame) });
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 99, new Uint8Array()))).rejects.toThrow('unsolicited stream end');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 99, new Uint8Array([1])))).rejects.toThrow('unsolicited http body');
+    await openHttpAndWaitCompleted(host, sent, 1, 'GET');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/health', query: '', headers: {} })))).rejects.toThrow('completed stream id reused');
+    host.close();
+  });
+
+  it('expires and evicts completed HTTP tombstones deterministically', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    let now = 100;
+    const host = createTunnelHost({
+      connectionId: 'tombstone-bounds', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { completedHttpStreamTtlMs: 5, maxCompletedHttpStreams: 1, now: () => now },
+    });
+    await openHttpAndWaitCompleted(host, sent, 1, 'GET');
+    await openHttpAndWaitCompleted(host, sent, 2, 'GET');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()))).rejects.toThrow('unsolicited stream end');
+    now = 106;
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 2, new Uint8Array()))).rejects.toThrow('unsolicited stream end');
+    host.close();
+  });
+
+  it('rejects late body frames that exceed frame or byte budgets', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({
+      connectionId: 'late-body-budget', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { maxLateHttpBodyFrames: 1, maxLateHttpBodyBytes: 2 },
+    });
+    await openHttpAndWaitCompleted(host, sent, 1, 'DELETE');
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1, 2])));
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([3])))).rejects.toThrow('late http body budget exceeded');
+    await openHttpAndWaitCompleted(host, sent, 2, 'DELETE');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 2, new Uint8Array([1, 2, 3])))).rejects.toThrow('late http body budget exceeded');
+    host.close();
+  });
+
+  it('clears completed HTTP tombstones on close', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({ connectionId: 'clear-tombstones', getLocalPort: () => origin.port, getBufferedAmount: () => 0, sendFrame: (frame) => sent.push(frame) });
+    await openHttpAndWaitCompleted(host, sent, 1, 'GET');
+    expect(host.completedHttpStreamCount).toBe(1);
+    host.close();
+    expect(host.completedHttpStreamCount).toBe(0);
   });
 });

--- a/packages/web/server/lib/relay/tunnel-host.test.js
+++ b/packages/web/server/lib/relay/tunnel-host.test.js
@@ -22,6 +22,22 @@ const startOrigin = async () => {
   return { port: server.address().port, received };
 };
 
+const startBodyOrigin = async () => {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      received.push({ body: Buffer.concat(chunks), headers: req.headers, url: req.url });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+  });
+  servers.push(server);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return { port: server.address().port, received };
+};
+
 const startWsOrigin = async (onConnection = () => {}) => {
   const server = http.createServer();
   const wss = new WebSocketServer({ noServer: true });
@@ -52,6 +68,10 @@ const openHttpAndWaitCompleted = async (host, sent, streamId, method) => {
   await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, streamId, encodeJsonPayload({
     method, path: '/health', query: '', headers: {},
   })));
+  if (method !== 'GET' && method !== 'HEAD') {
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, new Uint8Array([0])));
+  }
+  await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array()));
   await waitFor(() => sent.some((raw) => {
     const frame = decodeTunnelFrame(raw);
     return frame.streamId === streamId && frame.frameType === TunnelFrameType.StreamEnd;
@@ -59,6 +79,32 @@ const openHttpAndWaitCompleted = async (host, sent, streamId, method) => {
 };
 
 describe('tunnel host policy seams', () => {
+  it('retains an immediate request body frame while policy approval is pending', async () => {
+    const origin = await startBodyOrigin();
+    const sent = [];
+    let approvePolicy;
+    const policyResult = new Promise((resolve) => { approvePolicy = resolve; });
+    const host = createTunnelHost({
+      connectionId: 'early-body',
+      getLocalPort: () => origin.port,
+      getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame),
+      requestPolicy: () => policyResult,
+    });
+
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({
+      method: 'DELETE', path: '/health', query: '', headers: {},
+    })));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1, 2, 3])));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+
+    expect(origin.received).toHaveLength(0);
+    approvePolicy(true);
+    await waitFor(() => origin.received.length === 1);
+    expect([...origin.received[0].body]).toEqual([1, 2, 3]);
+    host.close();
+  });
+
   it('strips untrusted forwarding and internal headers before trusted context injection', async () => {
     const origin = await startOrigin();
     const sent = [];

--- a/packages/web/server/lib/tunnels/DOCUMENTATION.md
+++ b/packages/web/server/lib/tunnels/DOCUMENTATION.md
@@ -7,7 +7,7 @@ This module contains tunnel provider orchestration for OpenChamber, including pr
 - `packages/web/server/lib/tunnels/index.js`: tunnel service orchestration.
 - `packages/web/server/lib/tunnels/executable-search.js`: cross-platform executable discovery, including Windows Store app aliases.
 - `packages/web/server/lib/tunnels/registry.js`: provider registry.
-- `packages/web/server/lib/tunnels/managed-config.js`: managed remote tunnel token/preset persistence runtime.
+- `packages/web/server/lib/tunnels/managed-config.js`: managed remote tunnel token/preset persistence runtime, including the per-profile direct-E2EE opt-in flag and serialized flag mutation.
 - `packages/web/server/lib/tunnels/install-help.js`: provider/platform install command metadata for missing tunnel dependencies.
 - `packages/web/server/lib/tunnels/routes.js`: tunnel API route registration and request orchestration runtime.
 - `packages/web/server/lib/tunnels/types.js`: tunnel constants, normalization, and shared type helpers.
@@ -19,3 +19,24 @@ This module contains tunnel provider orchestration for OpenChamber, including pr
 - Returned API:
   - `registerRoutes(app)`
   - `startTunnelWithNormalizedRequest(request)`
+
+## Managed remote profile contract
+- Saved profiles normalize `directE2eeEnabled` strictly: only boolean `true` enables it; legacy or invalid values become `false`.
+- Token upserts preserve the current flag when the field is omitted. The config file remains mode `0o600`.
+- Managed config reads return an empty config only when both the current and legacy files are absent. Parse, root/schema, permission, I/O, and legacy migration write failures propagate so mutations cannot replace an unreadable authoritative config.
+- Managed profile persistence writes an owner-only temporary file, applies mode
+  `0o600`, atomically renames it over the destination, repairs the final POSIX mode,
+  and removes the temporary file on failure. The serialized mutation lock recovers
+  after write failures. Parent mode `0o700` is requested/repaired only when injected
+  runtime context identifies the directory as app-owned; arbitrary parents are not
+  chmodded. Windows skips POSIX chmod while retaining temp-and-rename replacement.
+- `PATCH /api/openchamber/tunnel/managed-remote-profile/:id` mutates only this flag and never returns the connector token.
+- Active managed tunnel identity is carried as `managedRemoteTunnelPresetId` in normalized start state and provider metadata. Profile identity is part of tunnel reuse, so switching profiles replaces the connector even when mode, provider, and hostname match.
+- Tunnel status exposes profile flags, `activeManagedRemoteProfileId`, and the non-secret `directE2eeConfigured`, `directE2eeSupported`, `directE2eeAvailable`, and `directE2eeActiveSessions` fields.
+- Support is true only while the production direct-E2EE runtime is initialized.
+  Availability additionally requires the exact enabled active managed-remote profile and a matching canonical HTTPS public URL.
+- Route dependencies carry direct-session count, profile disable, tunnel replacement, and stop lifecycle hooks.
+  This module invokes those hooks but does not own encrypted sessions or revoke paired-device tokens.
+- Managed profile writes await a direct-runtime refresh with an explicit mutation reason and profile ID.
+  Failed tunnel startup clears tunnel authority and deactivates direct sessions before returning an error.
+- Legacy active tunnels without retained profile metadata use hostname fallback only when exactly one enabled saved profile matches.

--- a/packages/web/server/lib/tunnels/index.js
+++ b/packages/web/server/lib/tunnels/index.js
@@ -84,8 +84,13 @@ export function createTunnelService({
       let publicUrl = provider.resolvePublicUrl(getController());
       const activeMode = resolveActiveMode();
       const activeProvider = resolveActiveProvider();
+      const activeManagedRemoteTunnelPresetId = getController()?.managedRemoteTunnelPresetId || '';
+      const profileChanged = request.mode === 'managed-remote'
+        && activeMode === request.mode
+        && activeProvider === request.provider
+        && activeManagedRemoteTunnelPresetId !== request.managedRemoteTunnelPresetId;
 
-      if (publicUrl && (activeMode !== request.mode || activeProvider !== request.provider)) {
+      if (publicUrl && (activeMode !== request.mode || activeProvider !== request.provider || profileChanged)) {
         stop();
         publicUrl = null;
       }
@@ -121,6 +126,8 @@ export function createTunnelService({
           throw new TunnelServiceError('startup_failed', message);
         }
         controller.provider = request.provider;
+        controller.mode = request.mode;
+        controller.managedRemoteTunnelPresetId = request.managedRemoteTunnelPresetId || null;
         setController(controller);
 
         publicUrl = provider.resolvePublicUrl(controller);

--- a/packages/web/server/lib/tunnels/index.test.js
+++ b/packages/web/server/lib/tunnels/index.test.js
@@ -4,6 +4,7 @@ import { createTunnelService } from './index.js';
 import {
   TUNNEL_INTENT_EPHEMERAL_PUBLIC,
   TUNNEL_MODE_QUICK,
+  TUNNEL_MODE_MANAGED_REMOTE,
   TUNNEL_PROVIDER_CLOUDFLARE,
   TUNNEL_PROVIDER_NGROK,
 } from './types.js';
@@ -89,5 +90,44 @@ describe('createTunnelService', () => {
     expect(ngrokStarted).toBe(true);
     expect(result.provider).toBe(TUNNEL_PROVIDER_NGROK);
     expect(result.publicUrl).toBe('https://demo.ngrok-free.app');
+  });
+
+  it('replaces an active managed remote tunnel when the profile identity changes', async () => {
+    let stopCount = 0;
+    let startCount = 0;
+    let controller = {
+      provider: TUNNEL_PROVIDER_CLOUDFLARE,
+      mode: TUNNEL_MODE_MANAGED_REMOTE,
+      managedRemoteTunnelPresetId: 'profile-a',
+      getPublicUrl: () => 'https://shared.example.com',
+    };
+    const provider = {
+      ...createProvider({ provider: TUNNEL_PROVIDER_CLOUDFLARE }),
+      capabilities: {
+        provider: TUNNEL_PROVIDER_CLOUDFLARE,
+        modes: [{ key: TUNNEL_MODE_MANAGED_REMOTE, intent: 'persistent-public', requires: ['token', 'hostname'] }],
+      },
+      stop: () => { stopCount += 1; },
+      start: async () => {
+        startCount += 1;
+        return { getPublicUrl: () => 'https://shared.example.com' };
+      },
+      getMetadata: (value) => ({ managedRemoteTunnelPresetId: value.managedRemoteTunnelPresetId }),
+    };
+    const service = createTunnelService({
+      registry: createRegistry({ [TUNNEL_PROVIDER_CLOUDFLARE]: provider }),
+      getController: () => controller,
+      setController: (next) => { controller = next; },
+      getActivePort: () => 3000,
+    });
+
+    const result = await service.start({
+      provider: TUNNEL_PROVIDER_CLOUDFLARE, mode: TUNNEL_MODE_MANAGED_REMOTE,
+      hostname: 'shared.example.com', token: 'secret', managedRemoteTunnelPresetId: 'profile-b',
+    });
+    expect(stopCount).toBe(1);
+    expect(startCount).toBe(1);
+    expect(result.providerMetadata.managedRemoteTunnelPresetId).toBe('profile-b');
+    expect(controller.managedRemoteTunnelPresetId).toBe('profile-b');
   });
 });

--- a/packages/web/server/lib/tunnels/managed-config.js
+++ b/packages/web/server/lib/tunnels/managed-config.js
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 export const createManagedTunnelConfigRuntime = (deps) => {
   const {
     fsPromises,
@@ -5,6 +7,8 @@ export const createManagedTunnelConfigRuntime = (deps) => {
     normalizeManagedRemoteTunnelHostname,
     normalizeManagedRemoteTunnelPresets,
     constants,
+    platform = process.platform,
+    managedConfigDirectoryIsPrivate = false,
   } = deps;
 
   const {
@@ -43,22 +47,48 @@ export const createManagedTunnelConfigRuntime = (deps) => {
 
       seenIds.add(id);
       seenHostnames.add(hostname);
-      result.push({ id, name, hostname, token, updatedAt });
+      result.push({
+        id,
+        name,
+        hostname,
+        token,
+        updatedAt,
+        directE2eeEnabled: entry.directE2eeEnabled === true,
+      });
     }
 
     return result;
   };
 
+  const parseManagedRemoteTunnelConfig = (raw) => {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || !Array.isArray(parsed.tunnels)) {
+      throw new TypeError('Managed remote tunnel config must be an object with a tunnels array');
+    }
+    return parsed;
+  };
+
   const writeManagedRemoteTunnelConfigToDisk = async (data) => {
-    await fsPromises.mkdir(path.dirname(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH), { recursive: true });
-    await fsPromises.writeFile(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH, JSON.stringify(data, null, 2), { encoding: 'utf8', mode: 0o600 });
+    const directory = path.dirname(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH);
+    await fsPromises.mkdir(directory, { recursive: true, ...(managedConfigDirectoryIsPrivate ? { mode: 0o700 } : {}) });
+    if (managedConfigDirectoryIsPrivate && platform !== 'win32') await fsPromises.chmod(directory, 0o700);
+    const temporaryPath = `${CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await fsPromises.writeFile(temporaryPath, JSON.stringify(data, null, 2), { encoding: 'utf8', mode: 0o600 });
+      if (platform !== 'win32') await fsPromises.chmod(temporaryPath, 0o600);
+      await fsPromises.rename(temporaryPath, CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH);
+      if (platform !== 'win32') await fsPromises.chmod(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH, 0o600);
+    } catch (error) {
+      await fsPromises.unlink(temporaryPath).catch(() => {});
+      throw error;
+    }
   };
 
   const migrateManagedRemoteTunnelConfigFromLegacyFile = async () => {
     try {
       const legacyRaw = await fsPromises.readFile(CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH, 'utf8');
-      const parsed = JSON.parse(legacyRaw);
-      const tunnels = sanitizeManagedRemoteTunnelConfigEntries(parsed?.tunnels);
+      const parsed = parseManagedRemoteTunnelConfig(legacyRaw);
+      const tunnels = sanitizeManagedRemoteTunnelConfigEntries(parsed.tunnels);
       const migrated = {
         version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION,
         tunnels,
@@ -69,18 +99,14 @@ export const createManagedTunnelConfigRuntime = (deps) => {
       if (error && typeof error === 'object' && error.code === 'ENOENT') {
         return { version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION, tunnels: [] };
       }
-      console.warn('Failed to migrate legacy named tunnel config file:', error);
-      return { version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION, tunnels: [] };
+      throw error;
     }
   };
 
   const readManagedRemoteTunnelConfigFromDisk = async () => {
     try {
       const raw = await fsPromises.readFile(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH, 'utf8');
-      const parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== 'object') {
-        return { version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION, tunnels: [] };
-      }
+      const parsed = parseManagedRemoteTunnelConfig(raw);
 
       return {
         version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION,
@@ -90,13 +116,12 @@ export const createManagedTunnelConfigRuntime = (deps) => {
       if (error && typeof error === 'object' && error.code === 'ENOENT') {
         return migrateManagedRemoteTunnelConfigFromLegacyFile();
       }
-      console.warn('Failed to read managed remote tunnel config file:', error);
-      return { version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION, tunnels: [] };
+      throw error;
     }
   };
 
   const updateManagedRemoteTunnelConfig = async (mutate) => {
-    persistManagedRemoteTunnelConfigLock = persistManagedRemoteTunnelConfigLock.then(async () => {
+    persistManagedRemoteTunnelConfigLock = persistManagedRemoteTunnelConfigLock.catch(() => {}).then(async () => {
       const current = await readManagedRemoteTunnelConfigFromDisk();
       const next = mutate({
         version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION,
@@ -141,7 +166,7 @@ export const createManagedTunnelConfigRuntime = (deps) => {
     });
   };
 
-  const upsertManagedRemoteTunnelToken = async ({ id, name, hostname, token }) => {
+  const upsertManagedRemoteTunnelToken = async ({ id, name, hostname, token, directE2eeEnabled }) => {
     if (typeof id !== 'string' || typeof name !== 'string' || typeof hostname !== 'string' || typeof token !== 'string') {
       return;
     }
@@ -154,6 +179,9 @@ export const createManagedTunnelConfigRuntime = (deps) => {
     }
 
     await updateManagedRemoteTunnelConfig((current) => {
+      const existing = current.tunnels.find((entry) => entry.id === normalizedId)
+        || current.tunnels.find((entry) => entry.hostname === normalizedHostname)
+        || null;
       const withoutConflicts = current.tunnels.filter((entry) => entry.id !== normalizedId && entry.hostname !== normalizedHostname);
       withoutConflicts.push({
         id: normalizedId,
@@ -161,6 +189,9 @@ export const createManagedTunnelConfigRuntime = (deps) => {
         hostname: normalizedHostname,
         token: normalizedToken,
         updatedAt: Date.now(),
+        directE2eeEnabled: typeof directE2eeEnabled === 'boolean'
+          ? directE2eeEnabled
+          : existing?.directE2eeEnabled === true,
       });
 
       return {
@@ -168,6 +199,26 @@ export const createManagedTunnelConfigRuntime = (deps) => {
         tunnels: withoutConflicts,
       };
     });
+  };
+
+  const setManagedRemoteTunnelDirectE2eeEnabled = async ({ id, directE2eeEnabled }) => {
+    const normalizedId = typeof id === 'string' ? id.trim() : '';
+    if (!normalizedId || typeof directE2eeEnabled !== 'boolean') {
+      return null;
+    }
+
+    let updatedProfile = null;
+    await updateManagedRemoteTunnelConfig((current) => ({
+      version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION,
+      tunnels: current.tunnels.map((entry) => {
+        if (entry.id !== normalizedId) {
+          return entry;
+        }
+        updatedProfile = { ...entry, directE2eeEnabled };
+        return updatedProfile;
+      }),
+    }));
+    return updatedProfile;
   };
 
   const resolveManagedRemoteTunnelToken = async ({ presetId, hostname }) => {
@@ -196,6 +247,7 @@ export const createManagedTunnelConfigRuntime = (deps) => {
     readManagedRemoteTunnelConfigFromDisk,
     syncManagedRemoteTunnelConfigWithPresets,
     upsertManagedRemoteTunnelToken,
+    setManagedRemoteTunnelDirectE2eeEnabled,
     resolveManagedRemoteTunnelToken,
   };
 };

--- a/packages/web/server/lib/tunnels/managed-config.test.js
+++ b/packages/web/server/lib/tunnels/managed-config.test.js
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from 'bun:test';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import nodePath from 'node:path';
+
+import { createManagedTunnelConfigRuntime } from './managed-config.js';
+
+const createRuntime = (initial) => {
+  let stored = initial === undefined ? null : JSON.stringify(initial);
+  let writeOptions = null;
+  const temporary = new Map();
+  const runtime = createManagedTunnelConfigRuntime({
+    fsPromises: {
+      mkdir: async () => {},
+      readFile: async (file) => {
+        if (file.endsWith('legacy.json') || stored === null) {
+          const error = new Error('missing');
+          error.code = 'ENOENT';
+          throw error;
+        }
+        return stored;
+      },
+      writeFile: async (_file, value, options) => {
+        temporary.set(_file, value);
+        writeOptions = options;
+      },
+      chmod: async () => {},
+      rename: async (from) => { stored = temporary.get(from); temporary.delete(from); },
+      unlink: async (file) => { temporary.delete(file); },
+    },
+    path: { dirname: () => '/config' },
+    normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+    normalizeManagedRemoteTunnelPresets: (value) => value,
+    constants: {
+      CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: '/config/current.json',
+      CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: '/config/legacy.json',
+      CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1,
+    },
+  });
+  return { runtime, getStored: () => JSON.parse(stored), getWriteOptions: () => writeOptions };
+};
+
+const profile = (overrides = {}) => ({
+  id: 'profile-a', name: 'A', hostname: 'a.example.com', token: 'secret-a', updatedAt: 1, ...overrides,
+});
+
+const createRuntimeWithFs = (fs) => createManagedTunnelConfigRuntime({
+  fsPromises: fs,
+  path: { dirname: () => '/config' },
+  normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+  normalizeManagedRemoteTunnelPresets: (value) => value,
+  constants: {
+    CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: '/config/current.json',
+    CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: '/config/legacy.json',
+    CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1,
+  },
+});
+
+describe('managed remote tunnel config', () => {
+  it('returns empty only when both current and legacy configs are genuinely missing', async () => {
+    const readFile = vi.fn(async () => {
+      const error = new Error('missing');
+      error.code = 'ENOENT';
+      throw error;
+    });
+    const runtime = createRuntimeWithFs({ readFile });
+
+    await expect(runtime.readManagedRemoteTunnelConfigFromDisk()).resolves.toEqual({ version: 1, tunnels: [] });
+    expect(readFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates malformed JSON and non-ENOENT current read failures', async () => {
+    const malformed = createRuntimeWithFs({ readFile: async () => '{invalid' });
+    await expect(malformed.readManagedRemoteTunnelConfigFromDisk()).rejects.toBeInstanceOf(SyntaxError);
+
+    const denied = new Error('permission denied');
+    denied.code = 'EACCES';
+    const unreadable = createRuntimeWithFs({ readFile: async () => { throw denied; } });
+    await expect(unreadable.readManagedRemoteTunnelConfigFromDisk()).rejects.toBe(denied);
+  });
+
+  it('rejects valid JSON with malformed current config shapes', async () => {
+    for (const value of [null, [], { tunnels: {} }]) {
+      const runtime = createRuntimeWithFs({ readFile: async () => JSON.stringify(value) });
+      await expect(runtime.readManagedRemoteTunnelConfigFromDisk()).rejects.toThrow(
+        'Managed remote tunnel config must be an object with a tunnels array',
+      );
+    }
+  });
+
+  it('rejects valid JSON with a malformed legacy config shape', async () => {
+    const runtime = createRuntimeWithFs({
+      readFile: async (file) => {
+        if (file.endsWith('current.json')) {
+          const missing = new Error('missing');
+          missing.code = 'ENOENT';
+          throw missing;
+        }
+        return JSON.stringify({ tunnels: {} });
+      },
+    });
+
+    await expect(runtime.readManagedRemoteTunnelConfigFromDisk()).rejects.toThrow(
+      'Managed remote tunnel config must be an object with a tunnels array',
+    );
+  });
+
+  it('propagates non-ENOENT legacy reads and migration writes', async () => {
+    const denied = new Error('legacy permission denied');
+    denied.code = 'EACCES';
+    const legacyUnreadable = createRuntimeWithFs({
+      readFile: async (file) => {
+        if (file.endsWith('current.json')) {
+          const missing = new Error('missing');
+          missing.code = 'ENOENT';
+          throw missing;
+        }
+        throw denied;
+      },
+    });
+    await expect(legacyUnreadable.readManagedRemoteTunnelConfigFromDisk()).rejects.toBe(denied);
+
+    const writeFailure = new Error('migration write failed');
+    const migrationWriteFailed = createRuntimeWithFs({
+      readFile: async (file) => {
+        if (file.endsWith('current.json')) {
+          const missing = new Error('missing');
+          missing.code = 'ENOENT';
+          throw missing;
+        }
+        return JSON.stringify({ version: 1, tunnels: [profile()] });
+      },
+      mkdir: async () => {},
+      writeFile: async () => { throw writeFailure; },
+      unlink: async () => {},
+    });
+    await expect(migrationWriteFailed.readManagedRemoteTunnelConfigFromDisk()).rejects.toBe(writeFailure);
+  });
+
+  it('does not run the mutation write after an authoritative read failure', async () => {
+    const readFailure = new Error('read failed');
+    const writeFile = vi.fn(async () => {});
+    const readPresetId = vi.fn(() => 'profile-a');
+    const presets = [{ get id() { return readPresetId(); } }];
+    const runtime = createRuntimeWithFs({
+      readFile: async () => { throw readFailure; },
+      writeFile,
+    });
+
+    await expect(runtime.syncManagedRemoteTunnelConfigWithPresets(presets)).rejects.toBe(readFailure);
+    expect(readPresetId).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('preserves malformed valid-JSON real-disk bytes when a mutation fails to read them', async () => {
+    const directory = await fsPromises.mkdtemp(nodePath.join(os.tmpdir(), 'openchamber-managed-config-corrupt-'));
+    const current = nodePath.join(directory, 'current.json');
+    const legacy = nodePath.join(directory, 'legacy.json');
+    const corruptBytes = Buffer.from('{"version":1,"tunnels":{}}');
+    await fsPromises.writeFile(current, corruptBytes);
+    const runtime = createManagedTunnelConfigRuntime({
+      fsPromises,
+      path: nodePath,
+      normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+      normalizeManagedRemoteTunnelPresets: (value) => value,
+      constants: {
+        CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: current,
+        CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: legacy,
+        CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1,
+      },
+    });
+    try {
+      await expect(runtime.upsertManagedRemoteTunnelToken(profile())).rejects.toBeInstanceOf(TypeError);
+      expect(await fsPromises.readFile(current)).toEqual(corruptBytes);
+      expect((await fsPromises.readdir(directory)).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    } finally {
+      await fsPromises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes missing and non-boolean direct E2EE flags to false', async () => {
+    const { runtime } = createRuntime({ version: 1, tunnels: [profile(), profile({ id: 'profile-b', hostname: 'b.example.com', directE2eeEnabled: 'true' })] });
+    const config = await runtime.readManagedRemoteTunnelConfigFromDisk();
+    expect(config.tunnels.map((entry) => entry.directE2eeEnabled)).toEqual([false, false]);
+  });
+
+  it('preserves the flag when an upsert omits it and writes mode 0600', async () => {
+    const { runtime, getStored, getWriteOptions } = createRuntime({ version: 1, tunnels: [profile({ directE2eeEnabled: true })] });
+    await runtime.upsertManagedRemoteTunnelToken({ id: 'profile-a', name: 'Renamed', hostname: 'a.example.com', token: 'new-secret' });
+    expect(getStored().tunnels[0]).toMatchObject({ name: 'Renamed', token: 'new-secret', directE2eeEnabled: true });
+    expect(getWriteOptions().mode).toBe(0o600);
+  });
+
+  it('serially mutates only the selected profile flag', async () => {
+    const { runtime, getStored } = createRuntime({
+      version: 1,
+      tunnels: [profile(), profile({ id: 'profile-b', hostname: 'b.example.com', token: 'secret-b' })],
+    });
+    await runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-b', directE2eeEnabled: true });
+    expect(getStored().tunnels.map(({ id, directE2eeEnabled }) => ({ id, directE2eeEnabled }))).toEqual([
+      { id: 'profile-a', directE2eeEnabled: false },
+      { id: 'profile-b', directE2eeEnabled: true },
+    ]);
+  });
+
+  it('recovers the serialization lock after a failed write', async () => {
+    let writes = 0;
+    let stored = JSON.stringify({ version: 1, tunnels: [profile()] });
+    const runtime = createManagedTunnelConfigRuntime({
+      fsPromises: {
+        mkdir: async () => {},
+        readFile: async () => stored,
+        writeFile: async (_file, value) => {
+          writes += 1;
+          if (writes === 1) throw new Error('disk full');
+          stored = value;
+        },
+        chmod: async () => {},
+        rename: async () => {},
+        unlink: async () => {},
+      },
+      path: { dirname: () => '/config' },
+      normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+      normalizeManagedRemoteTunnelPresets: (value) => value,
+      constants: {
+        CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: '/config/current.json',
+        CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: '/config/legacy.json',
+        CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1,
+      },
+    });
+    await expect(runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-a', directE2eeEnabled: true })).rejects.toThrow('disk full');
+    await runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-a', directE2eeEnabled: true });
+    expect(JSON.parse(stored).tunnels[0].directE2eeEnabled).toBe(true);
+  });
+
+  it('atomically replaces a pre-existing 0644 config with owner-only 0600 permissions', async () => {
+    if (process.platform === 'win32') return;
+    const directory = await fsPromises.mkdtemp(nodePath.join(os.tmpdir(), 'openchamber-managed-config-'));
+    const current = nodePath.join(directory, 'current.json');
+    const legacy = nodePath.join(directory, 'legacy.json');
+    await fsPromises.writeFile(current, JSON.stringify({ version: 1, tunnels: [profile()] }), { mode: 0o644 });
+    const runtime = createManagedTunnelConfigRuntime({
+      fsPromises, path: nodePath, managedConfigDirectoryIsPrivate: true,
+      normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+      normalizeManagedRemoteTunnelPresets: (value) => value,
+      constants: { CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: current, CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: legacy, CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1 },
+    });
+    try {
+      await runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-a', directE2eeEnabled: true });
+      expect((await fsPromises.stat(current)).mode & 0o777).toBe(0o600);
+      expect((await fsPromises.stat(directory)).mode & 0o777).toBe(0o700);
+      expect((await fsPromises.readdir(directory)).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    } finally {
+      await fsPromises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('cleans the temporary file when atomic rename fails and surfaces the error', async () => {
+    const files = new Set();
+    const runtime = createManagedTunnelConfigRuntime({
+      fsPromises: {
+        mkdir: async () => {}, readFile: async () => JSON.stringify({ version: 1, tunnels: [profile()] }),
+        writeFile: async (file) => { files.add(file); }, chmod: async () => {},
+        rename: async () => { throw new Error('rename failed'); }, unlink: async (file) => { files.delete(file); },
+      },
+      path: { dirname: () => '/config' },
+      normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+      normalizeManagedRemoteTunnelPresets: (value) => value,
+      constants: { CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: '/config/current.json', CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: '/config/legacy.json', CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1 },
+    });
+    await expect(runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-a', directE2eeEnabled: true })).rejects.toThrow('rename failed');
+    expect(files.size).toBe(0);
+  });
+});

--- a/packages/web/server/lib/tunnels/providers/cloudflare.js
+++ b/packages/web/server/lib/tunnels/providers/cloudflare.js
@@ -261,6 +261,7 @@ export function createCloudflareTunnelProvider() {
     getMetadata: (controller) => ({
       configPath: controller?.getEffectiveConfigPath?.() ?? null,
       resolvedHostname: controller?.getResolvedHostname?.() ?? null,
+      managedRemoteTunnelPresetId: controller?.managedRemoteTunnelPresetId ?? null,
     }),
   };
 }

--- a/packages/web/server/lib/tunnels/routes.js
+++ b/packages/web/server/lib/tunnels/routes.js
@@ -1,3 +1,22 @@
+const allowedLifecycleErrorNames = new Set(['Error', 'TypeError', 'RangeError', 'AbortError']);
+const allowedLifecycleErrorCodes = new Set([
+  'EACCES',
+  'EBUSY',
+  'ECONNRESET',
+  'EIO',
+  'ENOENT',
+  'EPERM',
+  'ETIMEDOUT',
+  'ERR_ABORTED',
+]);
+
+const lifecycleErrorMetadata = (error) => {
+  const metadata = {};
+  if (allowedLifecycleErrorNames.has(error?.name)) metadata.name = error.name;
+  if (allowedLifecycleErrorCodes.has(error?.code)) metadata.code = error.code;
+  return metadata;
+};
+
 export const createTunnelRoutesRuntime = (dependencies) => {
   const {
     crypto,
@@ -40,13 +59,51 @@ export const createTunnelRoutesRuntime = (dependencies) => {
     ? directE2eeSupported() === true
     : directE2eeSupported === true;
 
-  const awaitLifecycleCallback = async (category, callback, ...args) => {
+  const settleLifecycleCallback = async ({ category, callback, args, includeMetadata }) => {
     try {
       await callback(...args);
+      return true;
     } catch (error) {
-      console.error(`Tunnel lifecycle callback failed (${category})`, error);
+      const message = `Tunnel lifecycle callback failed (${category})`;
+      const metadata = includeMetadata ? lifecycleErrorMetadata(error) : {};
+      if (Object.keys(metadata).length > 0) {
+        console.error(message, metadata);
+      } else {
+        console.error(message);
+      }
+      return false;
     }
   };
+
+  // Production refresh clears direct-E2EE admission state before fallible reads,
+  // so notification failure remains fail-closed while the primary mutation succeeds.
+  const awaitBestEffortNotification = (category, callback, ...args) => settleLifecycleCallback({
+    category,
+    callback,
+    args,
+    includeMetadata: true,
+  });
+
+  const awaitCriticalCleanup = (category, callback, ...args) => settleLifecycleCallback({
+    category,
+    callback,
+    args,
+    includeMetadata: true,
+  });
+
+  const awaitStartFailureCleanup = (category, callback, ...args) => settleLifecycleCallback({
+    category,
+    callback,
+    args,
+    includeMetadata: false,
+  });
+
+  const sendLifecycleCleanupFailure = (res, fields = {}) => res.status(500).json({
+    ok: false,
+    error: 'Tunnel lifecycle cleanup failed',
+    code: 'lifecycle_callback_failed',
+    ...fields,
+  });
 
   const resolveActiveNormalizedTunnelMode = () => {
     const mode = tunnelService.resolveActiveMode();
@@ -104,7 +161,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname,
           token,
         });
-        await awaitLifecycleCallback('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId });
+        await awaitBestEffortNotification('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId });
       }
     }
 
@@ -117,7 +174,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       hostname,
       managedRemoteTunnelPresetId: selectedPresetId,
     });
-    await awaitLifecycleCallback('tunnel-changed:profile-switched', onTunnelChanged, { reason: 'profile-switched' });
+    await awaitBestEffortNotification('tunnel-changed:profile-switched', onTunnelChanged, { reason: 'profile-switched' });
 
     console.log(`Tunnel active (${result.provider}): ${result.publicUrl}`);
     return {
@@ -503,7 +560,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname: managedRemoteTunnelHostname,
           token: managedRemoteTunnelToken,
         });
-        await awaitLifecycleCallback('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId: presetId });
+        await awaitBestEffortNotification('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId: presetId });
 
         const managedRemoteTunnelConfig = await readManagedRemoteTunnelConfigFromDisk();
         return res.json({ ok: true, managedRemoteTunnelTokenPresetIds: managedRemoteTunnelConfig.tunnels.map((entry) => entry.id) });
@@ -536,10 +593,12 @@ export const createTunnelRoutesRuntime = (dependencies) => {
             directE2eeEnabled: req.body.directE2eeEnabled,
           });
         }
-        if (!req.body.directE2eeEnabled) {
-          await awaitLifecycleCallback('direct-e2ee-disabled', onManagedRemoteDirectE2eeDisabled, profile.id);
+        const cleanupSucceeded = req.body.directE2eeEnabled
+          || await awaitCriticalCleanup('direct-e2ee-disabled', onManagedRemoteDirectE2eeDisabled, profile.id);
+        await awaitBestEffortNotification('tunnel-changed:profile-direct-e2ee-updated', onTunnelChanged, { reason: 'profile-direct-e2ee-updated', profileId: profile.id });
+        if (!cleanupSucceeded) {
+          return sendLifecycleCleanupFailure(res);
         }
-        await awaitLifecycleCallback('tunnel-changed:profile-direct-e2ee-updated', onTunnelChanged, { reason: 'profile-direct-e2ee-updated', profileId: profile.id });
         return res.json({
           ok: true,
           profile: summarizeManagedRemoteProfile({ ...profile, directE2eeEnabled: req.body.directE2eeEnabled }),
@@ -682,7 +741,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         console.error('Failed to start tunnel:', error);
         setActiveTunnelController(null);
         tunnelAuthController.clearActiveTunnel();
-        await awaitLifecycleCallback('tunnel-stopped:start-failed', onTunnelStopped, 'tunnel-start-failed');
+        await awaitStartFailureCleanup('tunnel-stopped:start-failed', onTunnelStopped, 'tunnel-start-failed');
         if (error instanceof TunnelServiceError) {
           const status = error.code === 'missing_dependency'
             ? 400
@@ -712,8 +771,11 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       }
 
       tunnelAuthController.clearActiveTunnel();
-      await awaitLifecycleCallback('tunnel-stopped:stop', onTunnelStopped, 'tunnel-stopped');
-      res.json({ ok: true, revokedBootstrapCount, invalidatedSessionCount });
+      const cleanupSucceeded = await awaitCriticalCleanup('tunnel-stopped:stop', onTunnelStopped, 'tunnel-stopped');
+      if (!cleanupSucceeded) {
+        return sendLifecycleCleanupFailure(res, { revokedBootstrapCount, invalidatedSessionCount });
+      }
+      return res.json({ ok: true, revokedBootstrapCount, invalidatedSessionCount });
     });
   };
 

--- a/packages/web/server/lib/tunnels/routes.js
+++ b/packages/web/server/lib/tunnels/routes.js
@@ -40,6 +40,14 @@ export const createTunnelRoutesRuntime = (dependencies) => {
     ? directE2eeSupported() === true
     : directE2eeSupported === true;
 
+  const awaitLifecycleCallback = async (category, callback, ...args) => {
+    try {
+      await callback(...args);
+    } catch (error) {
+      console.error(`Tunnel lifecycle callback failed (${category})`, error);
+    }
+  };
+
   const resolveActiveNormalizedTunnelMode = () => {
     const mode = tunnelService.resolveActiveMode();
     if (mode === TUNNEL_MODE_MANAGED_LOCAL) {
@@ -96,7 +104,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname,
           token,
         });
-        await onTunnelChanged({ reason: 'profile-upserted', profileId });
+        await awaitLifecycleCallback('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId });
       }
     }
 
@@ -109,7 +117,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       hostname,
       managedRemoteTunnelPresetId: selectedPresetId,
     });
-    await onTunnelChanged({ reason: 'profile-switched' });
+    await awaitLifecycleCallback('tunnel-changed:profile-switched', onTunnelChanged, { reason: 'profile-switched' });
 
     console.log(`Tunnel active (${result.provider}): ${result.publicUrl}`);
     return {
@@ -495,7 +503,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname: managedRemoteTunnelHostname,
           token: managedRemoteTunnelToken,
         });
-        await onTunnelChanged({ reason: 'profile-upserted', profileId: presetId });
+        await awaitLifecycleCallback('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId: presetId });
 
         const managedRemoteTunnelConfig = await readManagedRemoteTunnelConfigFromDisk();
         return res.json({ ok: true, managedRemoteTunnelTokenPresetIds: managedRemoteTunnelConfig.tunnels.map((entry) => entry.id) });
@@ -529,9 +537,9 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           });
         }
         if (!req.body.directE2eeEnabled) {
-          await onManagedRemoteDirectE2eeDisabled(profile.id);
+          await awaitLifecycleCallback('direct-e2ee-disabled', onManagedRemoteDirectE2eeDisabled, profile.id);
         }
-        await onTunnelChanged({ reason: 'profile-direct-e2ee-updated', profileId: profile.id });
+        await awaitLifecycleCallback('tunnel-changed:profile-direct-e2ee-updated', onTunnelChanged, { reason: 'profile-direct-e2ee-updated', profileId: profile.id });
         return res.json({
           ok: true,
           profile: summarizeManagedRemoteProfile({ ...profile, directE2eeEnabled: req.body.directE2eeEnabled }),
@@ -674,7 +682,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         console.error('Failed to start tunnel:', error);
         setActiveTunnelController(null);
         tunnelAuthController.clearActiveTunnel();
-        await onTunnelStopped('tunnel-start-failed');
+        await awaitLifecycleCallback('tunnel-stopped:start-failed', onTunnelStopped, 'tunnel-start-failed');
         if (error instanceof TunnelServiceError) {
           const status = error.code === 'missing_dependency'
             ? 400
@@ -704,7 +712,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       }
 
       tunnelAuthController.clearActiveTunnel();
-      await onTunnelStopped('tunnel-stopped');
+      await awaitLifecycleCallback('tunnel-stopped:stop', onTunnelStopped, 'tunnel-stopped');
       res.json({ ok: true, revokedBootstrapCount, invalidatedSessionCount });
     });
   };

--- a/packages/web/server/lib/tunnels/routes.js
+++ b/packages/web/server/lib/tunnels/routes.js
@@ -15,7 +15,14 @@ export const createTunnelRoutesRuntime = (dependencies) => {
     normalizeTunnelSessionTtlMs,
     isSupportedTunnelMode,
     upsertManagedRemoteTunnelToken,
+    setManagedRemoteTunnelDirectE2eeEnabled,
     resolveManagedRemoteTunnelToken,
+    getDirectE2eeActiveSessionCount = () => 0,
+    onManagedRemoteDirectE2eeDisabled = () => {},
+    onTunnelStopped = () => {},
+    onTunnelChanged = async () => {},
+    directE2eeSupported = false,
+    isDirectE2eeAvailable = () => false,
     TUNNEL_MODE_QUICK,
     TUNNEL_MODE_MANAGED_LOCAL,
     TUNNEL_MODE_MANAGED_REMOTE,
@@ -29,6 +36,9 @@ export const createTunnelRoutesRuntime = (dependencies) => {
     getActiveTunnelController,
     setActiveTunnelController,
   } = dependencies;
+  const isDirectE2eeSupported = () => typeof directE2eeSupported === 'function'
+    ? directE2eeSupported() === true
+    : directE2eeSupported === true;
 
   const resolveActiveNormalizedTunnelMode = () => {
     const mode = tunnelService.resolveActiveMode();
@@ -79,12 +89,14 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       setRuntimeManagedRemoteTunnelToken(token);
 
       if (token && hostname) {
+        const profileId = selectedPresetId || hostname;
         await upsertManagedRemoteTunnelToken({
-          id: selectedPresetId || hostname,
+          id: profileId,
           name: selectedPresetName || hostname,
           hostname,
           token,
         });
+        await onTunnelChanged({ reason: 'profile-upserted', profileId });
       }
     }
 
@@ -95,7 +107,9 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       configPath,
       token,
       hostname,
+      managedRemoteTunnelPresetId: selectedPresetId,
     });
+    await onTunnelChanged({ reason: 'profile-switched' });
 
     console.log(`Tunnel active (${result.provider}): ${result.publicUrl}`);
     return {
@@ -146,6 +160,30 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         .filter((entry) => entry.status === 'fail' && entry.id !== 'startup_readiness')
         .map((entry) => entry.detail || entry.label || entry.id),
     };
+  };
+
+  const summarizeManagedRemoteProfile = (entry) => ({
+    id: entry.id,
+    name: entry.name,
+    hostname: entry.hostname,
+    directE2eeEnabled: entry.directE2eeEnabled === true,
+  });
+
+  const resolveActiveManagedRemoteProfile = ({ config, providerMetadata, publicUrl, activeMode }) => {
+    if (activeMode !== TUNNEL_MODE_MANAGED_REMOTE) {
+      return null;
+    }
+    const activeId = typeof providerMetadata?.managedRemoteTunnelPresetId === 'string'
+      ? providerMetadata.managedRemoteTunnelPresetId
+      : '';
+    if (activeId) {
+      return config.tunnels.find((entry) => entry.id === activeId) || null;
+    }
+    const activeHostname = resolveNormalizedTunnelHost(publicUrl);
+    if (!activeHostname) return null;
+    const matches = config.tunnels.filter((entry) =>
+      entry.directE2eeEnabled === true && entry.hostname === activeHostname);
+    return matches.length === 1 ? matches[0] : null;
   };
 
   const runTunnelDoctor = async ({ providerId, modeFilter, doctorRequest }) => {
@@ -332,11 +370,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         const normalizedMode = normalizeTunnelMode(settings?.tunnelMode);
         const managedRemoteHostname = normalizeManagedRemoteTunnelHostname(settings?.managedRemoteTunnelHostname);
         const managedRemoteTunnelConfig = await readManagedRemoteTunnelConfigFromDisk();
-        const managedRemoteTunnelPresetSummaries = managedRemoteTunnelConfig.tunnels.map((entry) => ({
-          id: entry.id,
-          name: entry.name,
-          hostname: entry.hostname,
-        }));
+        const managedRemoteTunnelPresetSummaries = managedRemoteTunnelConfig.tunnels.map(summarizeManagedRemoteProfile);
         const hasStoredManagedRemoteToken = typeof settings?.managedRemoteTunnelToken === 'string' && settings.managedRemoteTunnelToken.trim().length > 0;
         const hasManagedRemoteTunnelToken = getRuntimeManagedRemoteTunnelToken().length > 0 || managedRemoteTunnelConfig.tunnels.length > 0 || hasStoredManagedRemoteToken;
         const bootstrapTtlMs = settings?.tunnelBootstrapTtlMs === null
@@ -355,6 +389,11 @@ export const createTunnelRoutesRuntime = (dependencies) => {
             mode: normalizedMode,
             provider,
             providerMetadata: null,
+            activeManagedRemoteProfileId: null,
+            directE2eeActiveSessions: 0,
+            directE2eeConfigured: false,
+            directE2eeSupported: isDirectE2eeSupported(),
+            directE2eeAvailable: false,
             hasManagedRemoteTunnelToken,
             managedRemoteTunnelHostname: managedRemoteHostname || null,
             managedRemoteTunnelPresets: managedRemoteTunnelPresetSummaries,
@@ -392,6 +431,21 @@ export const createTunnelRoutesRuntime = (dependencies) => {
 
         const bootstrapStatus = tunnelAuthController.getBootstrapStatus();
         const providerMetadata = tunnelService.getProviderMetadata();
+        const activeManagedRemoteProfile = resolveActiveManagedRemoteProfile({
+          config: managedRemoteTunnelConfig,
+          providerMetadata,
+          publicUrl,
+          activeMode: activeNormalizedMode,
+        });
+        const directE2eeConfigured = activeManagedRemoteProfile?.directE2eeEnabled === true;
+        const directE2eeActiveSessions = activeManagedRemoteProfile
+          ? getDirectE2eeActiveSessionCount(activeManagedRemoteProfile.id)
+          : 0;
+        const directE2eeAvailable = isDirectE2eeAvailable({
+          profile: activeManagedRemoteProfile,
+          publicUrl,
+          activeMode: activeNormalizedMode,
+        });
 
         return res.json({
           active: true,
@@ -399,6 +453,11 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           mode: activeNormalizedMode,
           provider,
           providerMetadata,
+          activeManagedRemoteProfileId: activeManagedRemoteProfile?.id || null,
+          directE2eeActiveSessions,
+          directE2eeConfigured,
+          directE2eeSupported: isDirectE2eeSupported(),
+          directE2eeAvailable,
           hasManagedRemoteTunnelToken,
           managedRemoteTunnelHostname: managedRemoteHostname || null,
           managedRemoteTunnelPresets: managedRemoteTunnelPresetSummaries,
@@ -436,11 +495,49 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname: managedRemoteTunnelHostname,
           token: managedRemoteTunnelToken,
         });
+        await onTunnelChanged({ reason: 'profile-upserted', profileId: presetId });
 
         const managedRemoteTunnelConfig = await readManagedRemoteTunnelConfigFromDisk();
         return res.json({ ok: true, managedRemoteTunnelTokenPresetIds: managedRemoteTunnelConfig.tunnels.map((entry) => entry.id) });
       } catch (error) {
         return res.status(500).json({ ok: false, error: 'Failed to save managed remote tunnel token' });
+      }
+    });
+
+    app.patch('/api/openchamber/tunnel/managed-remote-profile/:id', async (req, res) => {
+      if (typeof req?.body?.directE2eeEnabled !== 'boolean') {
+        return res.status(400).json({ ok: false, error: 'directE2eeEnabled must be a boolean' });
+      }
+      try {
+        const config = await readManagedRemoteTunnelConfigFromDisk();
+        const profile = config.tunnels.find((entry) => entry.id === req.params.id);
+        if (!profile) {
+          return res.status(404).json({ ok: false, error: 'Managed remote profile not found' });
+        }
+        if (typeof setManagedRemoteTunnelDirectE2eeEnabled === 'function') {
+          await setManagedRemoteTunnelDirectE2eeEnabled({
+            id: profile.id,
+            directE2eeEnabled: req.body.directE2eeEnabled,
+          });
+        } else {
+          await upsertManagedRemoteTunnelToken({
+            id: profile.id,
+            name: profile.name,
+            hostname: profile.hostname,
+            token: profile.token,
+            directE2eeEnabled: req.body.directE2eeEnabled,
+          });
+        }
+        if (!req.body.directE2eeEnabled) {
+          await onManagedRemoteDirectE2eeDisabled(profile.id);
+        }
+        await onTunnelChanged({ reason: 'profile-direct-e2ee-updated', profileId: profile.id });
+        return res.json({
+          ok: true,
+          profile: summarizeManagedRemoteProfile({ ...profile, directE2eeEnabled: req.body.directE2eeEnabled }),
+        });
+      } catch {
+        return res.status(500).json({ ok: false, error: 'Failed to update managed remote profile' });
       }
     });
 
@@ -501,6 +598,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         const previousMode = tunnelAuthController.getActiveTunnelMode();
         const previousProvider = tunnelService.resolveActiveProvider();
         const previousUrl = tunnelService.getPublicUrl();
+        const previousProviderMetadata = tunnelService.getProviderMetadata();
 
         const { publicUrl, provider: activeProvider, providerMetadata } = await startTunnelWithNormalizedRequest({
           provider,
@@ -513,10 +611,16 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           selectedPresetName,
         });
 
+        const previousManagedRemoteProfileId = previousProviderMetadata?.managedRemoteTunnelPresetId || null;
+        const activeManagedRemoteProfileId = providerMetadata?.managedRemoteTunnelPresetId || null;
+        const managedRemoteProfileChanged = previousMode === TUNNEL_MODE_MANAGED_REMOTE
+          && mode === TUNNEL_MODE_MANAGED_REMOTE
+          && previousManagedRemoteProfileId !== activeManagedRemoteProfileId;
         const replacedTunnel = Boolean(previousTunnelId) && (
           previousMode !== mode
           || previousProvider !== activeProvider
           || previousUrl !== publicUrl
+          || managedRemoteProfileChanged
         );
         let revokedBootstrapCount = 0;
         let invalidatedSessionCount = 0;
@@ -570,6 +674,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         console.error('Failed to start tunnel:', error);
         setActiveTunnelController(null);
         tunnelAuthController.clearActiveTunnel();
+        await onTunnelStopped('tunnel-start-failed');
         if (error instanceof TunnelServiceError) {
           const status = error.code === 'missing_dependency'
             ? 400
@@ -582,7 +687,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       }
     });
 
-    app.post('/api/openchamber/tunnel/stop', (_req, res) => {
+    app.post('/api/openchamber/tunnel/stop', async (_req, res) => {
       let revokedBootstrapCount = 0;
       let invalidatedSessionCount = 0;
       const activeTunnelId = tunnelAuthController.getActiveTunnelId();
@@ -599,6 +704,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       }
 
       tunnelAuthController.clearActiveTunnel();
+      await onTunnelStopped('tunnel-stopped');
       res.json({ ok: true, revokedBootstrapCount, invalidatedSessionCount });
     });
   };

--- a/packages/web/server/lib/tunnels/routes.test.js
+++ b/packages/web/server/lib/tunnels/routes.test.js
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'bun:test';
+import express from 'express';
+import request from 'supertest';
+
+import { createTunnelRoutesRuntime } from './routes.js';
+import { TunnelServiceError } from './types.js';
+
+const profile = { id: 'profile-a', name: 'A', hostname: 'a.example.com', token: 'connector-secret', directE2eeEnabled: true };
+
+const createApp = (overrides = {}) => {
+  const app = express();
+  app.use(express.json());
+  const dependencies = {
+    crypto: { randomUUID: () => 'tunnel-id' },
+    URL,
+    tunnelService: {
+      resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+      getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+    },
+    tunnelProviderRegistry: { get: () => null, listCapabilities: () => [] },
+    tunnelAuthController: {
+      listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => 'tunnel-id',
+      getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+    },
+    readSettingsFromDiskMigrated: async () => ({ tunnelMode: 'managed-remote', tunnelProvider: 'cloudflare' }),
+    readManagedRemoteTunnelConfigFromDisk: async () => ({ version: 1, tunnels: [profile] }),
+    normalizeTunnelProvider: (value) => value || 'cloudflare', normalizeTunnelMode: (value) => value || 'quick',
+    normalizeOptionalPath: (value) => value, normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.toLowerCase() : '',
+    normalizeTunnelBootstrapTtlMs: (value) => value ?? 1, normalizeTunnelSessionTtlMs: (value) => value ?? 1,
+    isSupportedTunnelMode: () => true, upsertManagedRemoteTunnelToken: vi.fn(async () => {}),
+    setManagedRemoteTunnelDirectE2eeEnabled: vi.fn(async () => profile), resolveManagedRemoteTunnelToken: async () => '',
+    TUNNEL_MODE_QUICK: 'quick', TUNNEL_MODE_MANAGED_LOCAL: 'managed-local', TUNNEL_MODE_MANAGED_REMOTE: 'managed-remote',
+    TUNNEL_PROVIDER_CLOUDFLARE: 'cloudflare', TunnelServiceError, getActivePort: () => 3000,
+    getRuntimeManagedRemoteTunnelHostname: () => '', setRuntimeManagedRemoteTunnelHostname: () => {},
+    getRuntimeManagedRemoteTunnelToken: () => '', setRuntimeManagedRemoteTunnelToken: () => {},
+    getActiveTunnelController: () => null, setActiveTunnelController: () => {},
+    getDirectE2eeActiveSessionCount: () => 3,
+    directE2eeSupported: true,
+    isDirectE2eeAvailable: ({ profile: activeProfile }) => activeProfile?.id === 'profile-a' && activeProfile.directE2eeEnabled === true,
+    ...overrides,
+  };
+  createTunnelRoutesRuntime(dependencies).registerRoutes(app);
+  return { app, dependencies };
+};
+
+describe('tunnel routes direct E2EE configuration', () => {
+  it('patches only the selected flag and never returns the token', async () => {
+    const { app, dependencies } = createApp();
+    const response = await request(app).patch('/api/openchamber/tunnel/managed-remote-profile/profile-a').send({ directE2eeEnabled: false }).expect(200);
+    expect(dependencies.setManagedRemoteTunnelDirectE2eeEnabled).toHaveBeenCalledWith({ id: 'profile-a', directE2eeEnabled: false });
+    expect(response.body.profile).toEqual({ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: false });
+    expect(JSON.stringify(response.body)).not.toContain('connector-secret');
+  });
+
+  it('rejects invalid values and unknown profiles', async () => {
+    const { app } = createApp();
+    await request(app).patch('/api/openchamber/tunnel/managed-remote-profile/profile-a').send({ directE2eeEnabled: 1 }).expect(400);
+    await request(app).patch('/api/openchamber/tunnel/managed-remote-profile/missing').send({ directE2eeEnabled: true }).expect(404);
+  });
+
+  it('returns explicit server failures instead of empty status or profile-not-found on config read errors', async () => {
+    const readFailure = new Error('managed config unreadable');
+    const setManagedRemoteTunnelDirectE2eeEnabled = vi.fn(async () => profile);
+    const { app } = createApp({
+      readManagedRemoteTunnelConfigFromDisk: async () => { throw readFailure; },
+      setManagedRemoteTunnelDirectE2eeEnabled,
+    });
+
+    await request(app).get('/api/openchamber/tunnel/status').expect(500, { error: 'Failed to get tunnel status' });
+    await request(app)
+      .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
+      .send({ directE2eeEnabled: false })
+      .expect(500, { ok: false, error: 'Failed to update managed remote profile' });
+    expect(setManagedRemoteTunnelDirectE2eeEnabled).not.toHaveBeenCalled();
+  });
+
+  it('fails token writes explicitly when the authoritative mutation rejects', async () => {
+    const onTunnelChanged = vi.fn(async () => {});
+    const upsertManagedRemoteTunnelToken = vi.fn(async () => { throw new Error('managed config corrupt'); });
+    const { app } = createApp({ upsertManagedRemoteTunnelToken, onTunnelChanged });
+
+    await request(app).put('/api/openchamber/tunnel/managed-remote-token').send({
+      presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
+    }).expect(500, { ok: false, error: 'Failed to save managed remote tunnel token' });
+    expect(onTunnelChanged).not.toHaveBeenCalled();
+  });
+
+  it('refreshes direct runtime after a managed profile token upsert', async () => {
+    const onTunnelChanged = vi.fn(async () => {});
+    const { app } = createApp({ onTunnelChanged });
+    await request(app).put('/api/openchamber/tunnel/managed-remote-token').send({
+      presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
+    }).expect(200);
+    expect(onTunnelChanged).toHaveBeenCalledWith({ reason: 'profile-upserted', profileId: 'profile-a' });
+  });
+
+  it('reports production support and availability for the exact active profile', async () => {
+    const { app } = createApp();
+    const response = await request(app).get('/api/openchamber/tunnel/status').expect(200);
+    expect(response.body).toMatchObject({
+      activeManagedRemoteProfileId: 'profile-a', directE2eeActiveSessions: 3,
+      directE2eeConfigured: true, directE2eeSupported: true, directE2eeAvailable: true,
+    });
+    expect(response.body.managedRemoteTunnelPresets[0].directE2eeEnabled).toBe(true);
+    expect(JSON.stringify(response.body)).not.toContain('connector-secret');
+  });
+
+  it('replaces route artifacts and tunnel identity when the managed profile changes at the same URL', async () => {
+    const revokeTunnelArtifacts = vi.fn(() => ({ revokedBootstrapCount: 2, invalidatedSessionCount: 3 }));
+    const setActiveTunnel = vi.fn();
+    const onTunnelChanged = vi.fn(async () => {});
+    const { app } = createApp({
+      crypto: { randomUUID: () => 'fresh-tunnel-id' },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote',
+        resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://shared.example.com',
+        getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        start: async () => ({
+          publicUrl: 'https://shared.example.com',
+          activeMode: 'managed-remote',
+          provider: 'cloudflare',
+          providerMetadata: { managedRemoteTunnelPresetId: 'profile-b' },
+        }),
+      },
+      tunnelProviderRegistry: { get: () => ({}), listCapabilities: () => [] },
+      tunnelAuthController: {
+        listTunnelSessions: () => [],
+        getActiveTunnelMode: () => 'managed-remote',
+        getActiveTunnelId: () => 'old-tunnel-id',
+        revokeTunnelArtifacts,
+        setActiveTunnel,
+        issueBootstrapToken: () => ({ token: 'bootstrap', expiresAt: 123 }),
+      },
+      resolveManagedRemoteTunnelToken: async () => 'connector-secret',
+      onTunnelChanged,
+      readManagedRemoteTunnelConfigFromDisk: async () => ({ version: 1, tunnels: [
+        profile,
+        { ...profile, id: 'profile-b', name: 'B' },
+      ] }),
+    });
+
+    const response = await request(app).post('/api/openchamber/tunnel/start').send({
+      provider: 'cloudflare',
+      mode: 'managed-remote',
+      managedRemoteTunnelPresetId: 'profile-b',
+      managedRemoteTunnelPresetName: 'B',
+      hostname: 'shared.example.com',
+    }).expect(200);
+
+    expect(response.body).toMatchObject({
+      replacedTunnel: true,
+      revokedBootstrapCount: 2,
+      invalidatedSessionCount: 3,
+    });
+    expect(revokeTunnelArtifacts).toHaveBeenCalledWith('old-tunnel-id');
+    expect(setActiveTunnel).toHaveBeenCalledWith({
+      tunnelId: 'fresh-tunnel-id',
+      publicUrl: 'https://shared.example.com',
+      mode: 'managed-remote',
+    });
+    expect(onTunnelChanged).toHaveBeenCalledWith({ reason: 'profile-switched' });
+  });
+
+  it('invokes direct-session lifecycle callbacks on disable and stop', async () => {
+    const onManagedRemoteDirectE2eeDisabled = vi.fn();
+    const onTunnelChanged = vi.fn(async () => {});
+    const onTunnelStopped = vi.fn();
+    const { app } = createApp({
+      onManagedRemoteDirectE2eeDisabled,
+      onTunnelChanged,
+      onTunnelStopped,
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote',
+        resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com',
+        getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        stop: vi.fn(),
+      },
+      getActiveTunnelController: () => ({ stop: vi.fn() }),
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => null,
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        clearActiveTunnel: vi.fn(),
+      },
+    });
+
+    await request(app)
+      .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
+      .send({ directE2eeEnabled: false })
+      .expect(200);
+    expect(onManagedRemoteDirectE2eeDisabled).toHaveBeenCalledWith('profile-a');
+    expect(onTunnelChanged).toHaveBeenCalledWith({ reason: 'profile-direct-e2ee-updated', profileId: 'profile-a' });
+
+    await request(app).post('/api/openchamber/tunnel/stop').expect(200);
+    expect(onTunnelStopped).toHaveBeenCalledWith('tunnel-stopped');
+  });
+
+  it('deactivates direct runtime when provider startup fails', async () => {
+    let directAvailable = true;
+    let closedDirectSessions = 0;
+    const onTunnelStopped = vi.fn(async () => {
+      directAvailable = false;
+      closedDirectSessions += 2;
+    });
+    const clearActiveTunnel = vi.fn();
+    const setActiveTunnelController = vi.fn();
+    const { app } = createApp({
+      onTunnelStopped,
+      isDirectE2eeAvailable: () => directAvailable,
+      setActiveTunnelController,
+      tunnelProviderRegistry: { get: () => ({}), listCapabilities: () => [] },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        start: async () => { throw new TunnelServiceError('startup_failed', 'provider failed'); },
+      },
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => 'old',
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        clearActiveTunnel,
+      },
+    });
+    await request(app).post('/api/openchamber/tunnel/start').send({
+      provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
+    }).expect(500);
+    expect(setActiveTunnelController).toHaveBeenCalledWith(null);
+    expect(clearActiveTunnel).toHaveBeenCalled();
+    expect(onTunnelStopped).toHaveBeenCalledWith('tunnel-start-failed');
+    expect(closedDirectSessions).toBe(2);
+    expect((await request(app).get('/api/openchamber/tunnel/status').expect(200)).body.directE2eeAvailable).toBe(false);
+  });
+
+  it('uses only a unique enabled hostname fallback for legacy active metadata', async () => {
+    const { app } = createApp({
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({}),
+      },
+    });
+    expect((await request(app).get('/api/openchamber/tunnel/status').expect(200)).body.activeManagedRemoteProfileId).toBe('profile-a');
+
+    const ambiguous = createApp({
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({}),
+      },
+      readManagedRemoteTunnelConfigFromDisk: async () => ({ tunnels: [profile, { ...profile, id: 'profile-b' }] }),
+    });
+    expect((await request(ambiguous.app).get('/api/openchamber/tunnel/status').expect(200)).body.activeManagedRemoteProfileId).toBeNull();
+
+    const wrongId = createApp({
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'missing' }),
+      },
+    });
+    expect((await request(wrongId.app).get('/api/openchamber/tunnel/status').expect(200)).body.activeManagedRemoteProfileId).toBeNull();
+  });
+});

--- a/packages/web/server/lib/tunnels/routes.test.js
+++ b/packages/web/server/lib/tunnels/routes.test.js
@@ -231,6 +231,129 @@ describe('tunnel routes direct E2EE configuration', () => {
     expect((await request(app).get('/api/openchamber/tunnel/status').expect(200)).body.directE2eeAvailable).toBe(false);
   });
 
+  it('preserves structured start failures when the stopped callback rejects', async () => {
+    const callbackError = new Error('callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({
+      onTunnelStopped: async () => { throw callbackError; },
+      tunnelProviderRegistry: { get: () => ({}), listCapabilities: () => [] },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        start: async () => { throw new TunnelServiceError('startup_failed', 'provider failed'); },
+      },
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => 'old',
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        clearActiveTunnel: vi.fn(),
+      },
+    });
+
+    try {
+      await request(app).post('/api/openchamber/tunnel/start').send({
+        provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
+      }).expect(500, { ok: false, error: 'provider failed', code: 'startup_failed' });
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:start-failed)', callbackError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves stop responses when the stopped callback rejects', async () => {
+    const callbackError = new Error('callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({
+      onTunnelStopped: async () => { throw callbackError; },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        stop: vi.fn(),
+      },
+      getActiveTunnelController: () => ({ stop: vi.fn() }),
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => null,
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        clearActiveTunnel: vi.fn(),
+      },
+    });
+
+    try {
+      await request(app).post('/api/openchamber/tunnel/stop').expect(200, {
+        ok: true, revokedBootstrapCount: 0, invalidatedSessionCount: 0,
+      });
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:stop)', callbackError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves token upsert responses when the changed callback rejects', async () => {
+    const callbackError = new Error('callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({ onTunnelChanged: async () => { throw callbackError; } });
+
+    try {
+      await request(app).put('/api/openchamber/tunnel/managed-remote-token').send({
+        presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
+      }).expect(200, { ok: true, managedRemoteTunnelTokenPresetIds: ['profile-a'] });
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-upserted)', callbackError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves profile responses when notification callbacks reject', async () => {
+    const disabledError = new Error('disable callback failed');
+    const changedError = new Error('changed callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({
+      onManagedRemoteDirectE2eeDisabled: async () => { throw disabledError; },
+      onTunnelChanged: async () => { throw changedError; },
+    });
+
+    try {
+      await request(app)
+        .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
+        .send({ directE2eeEnabled: false })
+        .expect(200);
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (direct-e2ee-disabled)', disabledError);
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-direct-e2ee-updated)', changedError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves successful start responses when the changed callback rejects', async () => {
+    const callbackError = new Error('callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({
+      onTunnelChanged: async () => { throw callbackError; },
+      tunnelProviderRegistry: { get: () => ({}), listCapabilities: () => [] },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        start: async () => ({
+          publicUrl: 'https://a.example.com', activeMode: 'managed-remote', provider: 'cloudflare',
+          providerMetadata: { managedRemoteTunnelPresetId: 'profile-a' },
+        }),
+      },
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => null,
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        setActiveTunnel: vi.fn(), issueBootstrapToken: () => ({ token: 'bootstrap', expiresAt: 123 }),
+      },
+    });
+
+    try {
+      await request(app).post('/api/openchamber/tunnel/start').send({
+        provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
+      }).expect(200);
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-switched)', callbackError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('uses only a unique enabled hostname fallback for legacy active metadata', async () => {
     const { app } = createApp({
       tunnelService: {

--- a/packages/web/server/lib/tunnels/routes.test.js
+++ b/packages/web/server/lib/tunnels/routes.test.js
@@ -232,7 +232,7 @@ describe('tunnel routes direct E2EE configuration', () => {
   });
 
   it('preserves structured start failures when the stopped callback rejects', async () => {
-    const callbackError = new Error('callback failed');
+    const callbackError = new Error('callback-secret=https://private.example/?token=secret');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { app } = createApp({
       onTunnelStopped: async () => { throw callbackError; },
@@ -253,14 +253,15 @@ describe('tunnel routes direct E2EE configuration', () => {
       await request(app).post('/api/openchamber/tunnel/start').send({
         provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
       }).expect(500, { ok: false, error: 'provider failed', code: 'startup_failed' });
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:start-failed)', callbackError);
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:start-failed)');
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('callback-secret');
     } finally {
       consoleError.mockRestore();
     }
   });
 
-  it('preserves stop responses when the stopped callback rejects', async () => {
-    const callbackError = new Error('callback failed');
+  it('returns a structured lifecycle failure with revocation counts when stop cleanup rejects', async () => {
+    const callbackError = Object.assign(new Error('stop-secret=https://private.example/?token=secret'), { code: 'ETIMEDOUT' });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { app } = createApp({
       onTunnelStopped: async () => { throw callbackError; },
@@ -278,17 +279,25 @@ describe('tunnel routes direct E2EE configuration', () => {
     });
 
     try {
-      await request(app).post('/api/openchamber/tunnel/stop').expect(200, {
-        ok: true, revokedBootstrapCount: 0, invalidatedSessionCount: 0,
+      await request(app).post('/api/openchamber/tunnel/stop').expect(500, {
+        ok: false,
+        error: 'Tunnel lifecycle cleanup failed',
+        code: 'lifecycle_callback_failed',
+        revokedBootstrapCount: 0,
+        invalidatedSessionCount: 0,
       });
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:stop)', callbackError);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (tunnel-stopped:stop)',
+        { name: 'Error', code: 'ETIMEDOUT' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('stop-secret');
     } finally {
       consoleError.mockRestore();
     }
   });
 
   it('preserves token upsert responses when the changed callback rejects', async () => {
-    const callbackError = new Error('callback failed');
+    const callbackError = Object.assign(new Error('token-secret=https://private.example/?token=secret'), { code: 'ETIMEDOUT' });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { app } = createApp({ onTunnelChanged: async () => { throw callbackError; } });
 
@@ -296,35 +305,70 @@ describe('tunnel routes direct E2EE configuration', () => {
       await request(app).put('/api/openchamber/tunnel/managed-remote-token').send({
         presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
       }).expect(200, { ok: true, managedRemoteTunnelTokenPresetIds: ['profile-a'] });
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-upserted)', callbackError);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (tunnel-changed:profile-upserted)',
+        { name: 'Error', code: 'ETIMEDOUT' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('token-secret');
     } finally {
       consoleError.mockRestore();
     }
   });
 
-  it('preserves profile responses when notification callbacks reject', async () => {
-    const disabledError = new Error('disable callback failed');
-    const changedError = new Error('changed callback failed');
+  it('keeps a disabled profile persisted but returns a lifecycle failure when revocation rejects', async () => {
+    const disabledError = Object.assign(new Error('disable-secret=https://private.example/?token=secret'), { code: 'EIO' });
+    const onTunnelChanged = vi.fn(async () => {});
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { app } = createApp({
+    const { app, dependencies } = createApp({
       onManagedRemoteDirectE2eeDisabled: async () => { throw disabledError; },
-      onTunnelChanged: async () => { throw changedError; },
+      onTunnelChanged,
     });
 
     try {
       await request(app)
         .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
         .send({ directE2eeEnabled: false })
+        .expect(500, {
+          ok: false,
+          error: 'Tunnel lifecycle cleanup failed',
+          code: 'lifecycle_callback_failed',
+        });
+      expect(dependencies.setManagedRemoteTunnelDirectE2eeEnabled).toHaveBeenCalledWith({
+        id: 'profile-a', directE2eeEnabled: false,
+      });
+      expect(onTunnelChanged).toHaveBeenCalledWith({ reason: 'profile-direct-e2ee-updated', profileId: 'profile-a' });
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (direct-e2ee-disabled)',
+        { name: 'Error', code: 'EIO' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('disable-secret');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves profile responses when the changed notification rejects', async () => {
+    const changedError = new TypeError('changed-secret=https://private.example/?token=secret');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({ onTunnelChanged: async () => { throw changedError; } });
+
+    try {
+      await request(app)
+        .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
+        .send({ directE2eeEnabled: true })
         .expect(200);
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (direct-e2ee-disabled)', disabledError);
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-direct-e2ee-updated)', changedError);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (tunnel-changed:profile-direct-e2ee-updated)',
+        { name: 'TypeError' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('changed-secret');
     } finally {
       consoleError.mockRestore();
     }
   });
 
   it('preserves successful start responses when the changed callback rejects', async () => {
-    const callbackError = new Error('callback failed');
+    const callbackError = new Error('start-secret=https://private.example/?token=secret');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { app } = createApp({
       onTunnelChanged: async () => { throw callbackError; },
@@ -348,7 +392,43 @@ describe('tunnel routes direct E2EE configuration', () => {
       await request(app).post('/api/openchamber/tunnel/start').send({
         provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
       }).expect(200);
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-switched)', callbackError);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (tunnel-changed:profile-switched)',
+        { name: 'Error' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('start-secret');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('awaits best-effort notification settlement before sending the response', async () => {
+    let rejectCallback;
+    let responseSettled = false;
+    const callbackError = new Error('settlement-secret');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onTunnelChanged = vi.fn(() => new Promise((_resolve, reject) => {
+      rejectCallback = reject;
+    }));
+    const { app } = createApp({ onTunnelChanged });
+
+    try {
+      const responsePromise = request(app)
+        .put('/api/openchamber/tunnel/managed-remote-token')
+        .send({
+          presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
+        })
+        .then((response) => {
+          responseSettled = true;
+          return response;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(onTunnelChanged).toHaveBeenCalled();
+      expect(responseSettled).toBe(false);
+      rejectCallback(callbackError);
+      const response = await responsePromise;
+      expect(response.status).toBe(200);
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('settlement-secret');
     } finally {
       consoleError.mockRestore();
     }

--- a/packages/web/server/lib/tunnels/routes.test.js
+++ b/packages/web/server/lib/tunnels/routes.test.js
@@ -7,6 +7,14 @@ import { TunnelServiceError } from './types.js';
 
 const profile = { id: 'profile-a', name: 'A', hostname: 'a.example.com', token: 'connector-secret', directE2eeEnabled: true };
 
+const waitFor = async (predicate) => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error('observable lifecycle outcome not reached');
+};
+
 const createApp = (overrides = {}) => {
   const app = express();
   app.use(express.json());
@@ -422,10 +430,11 @@ describe('tunnel routes direct E2EE configuration', () => {
           responseSettled = true;
           return response;
         });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(onTunnelChanged).toHaveBeenCalled();
+      await waitFor(() => onTunnelChanged.mock.calls.length === 1);
+      expect(onTunnelChanged).toHaveBeenCalledTimes(1);
       expect(responseSettled).toBe(false);
       rejectCallback(callbackError);
+      await waitFor(() => responseSettled);
       const response = await responsePromise;
       expect(response.status).toBe(200);
       expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('settlement-secret');

--- a/packages/web/server/lib/tunnels/types.js
+++ b/packages/web/server/lib/tunnels/types.js
@@ -174,6 +174,9 @@ export function normalizeTunnelStartRequest(input = {}, defaults = {}) {
   const hostname = typeof (input.hostname ?? defaults.hostname) === 'string'
     ? (input.hostname ?? defaults.hostname).trim().toLowerCase()
     : '';
+  const managedRemoteTunnelPresetId = typeof (input.managedRemoteTunnelPresetId ?? defaults.managedRemoteTunnelPresetId) === 'string'
+    ? (input.managedRemoteTunnelPresetId ?? defaults.managedRemoteTunnelPresetId).trim()
+    : '';
 
   return {
     provider,
@@ -182,6 +185,7 @@ export function normalizeTunnelStartRequest(input = {}, defaults = {}) {
     configPath,
     token,
     hostname,
+    managedRemoteTunnelPresetId,
   };
 }
 

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
+      '@': fileURLToPath(new URL('../ui/src', import.meta.url)),
       'bun:test': fileURLToPath(new URL('./test/bun-test-shim.ts', import.meta.url)),
     },
   },


### PR DESCRIPTION
## Summary
This adds the configuration layer for managed direct E2EE. Users can opt in per managed profile, and the server persists and reports that choice without exposing connector tokens.

## Stack
- Layer 2 of 6
- Predecessor: #2235
- Part of #2234
- Status: Ready for review
- This PR currently shows the cumulative stack against `main`; the diff narrows as predecessors merge.

## What changed
- Added a per-profile direct-E2EE opt-in flag.
- Exposed redacted status and mutation routes.
- Tracked the active managed-profile identity.
- Protected unreadable configs from being overwritten.
- Set `controller.mode` from the normalized start request, fixing active-mode resolution for newly started tunnels.

## Review follow-up
- Lifecycle callback failures are classified and logged without leaking callback details.
- Start failures still return a deterministic HTTP response when notification cleanup fails.
- Stop treats direct-E2EE cleanup as critical and returns an explicit `lifecycle_callback_failed` response if cleanup cannot complete.
- Tests wait for callback and response settlement instead of relying on a single timer turn.

## Verification
- Managed-config, tunnel-index, and route tests pass.
- The final stack passes all 835 web tests; web type-check, lint, and build are clean.
