### PR TITLE
feat(clients): support direct E2EE pairing and restore

### DIFF
--- a/.agents/skills/relay-transport/SKILL.md
+++ b/.agents/skills/relay-transport/SKILL.md
@@ -32,6 +32,10 @@ Adding a new WS endpoint (or porting one, e.g. the planned terminal port) requir
 4. **Do not touch origin handling.** The server rejects WS upgrades whose `Origin` it does not trust. Over the tunnel the host dials loopback and presents the loopback origin (`http://127.0.0.1:<port>`), which the server trusts as same-origin — this already covers every allowlisted WS path. **Never reintroduce reliance on `window.location.origin`**: in the iOS WKWebView it is `"null"`/empty for the custom scheme, so forwarding it produces a 403.
 5. **Test over the relay, not just direct/desktop.** A new WS may be the first WebSocket the mobile client runs through the tunnel (events are SSE-locked on Capacitor). Passing on desktop or a direct connection proves nothing about the relay path.
 
+The dedicated `/api/openchamber/direct-e2ee/ws` outer endpoint is an intentional exception to the normal WebSocket rules above.
+It is credential-free, carries only ciphertext, and owns its own authority validation and admission.
+It deliberately stays outside `ALLOWED_WS_PATHS` and `isUrlAuthWebSocketPath`; never add it to either URL-token allowlist.
+
 ## Rules for the tunnel/crypto/codec internals
 
 - **Two implementations must stay byte-compatible.** The E2EE and framing exist as TS (`packages/ui/src/lib/relay/{crypto,handshake,tunnel-codec}.ts`, normative) and a JS host mirror (`packages/web/server/lib/relay/{e2ee,tunnel-codec}.js`). Any wire-format, frame-type, handshake, or batching change must update **both** and keep `packages/web/server/lib/relay/cross-compat.test.js` green.

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -12,6 +12,10 @@ Desktop starts the OpenChamber web server in the same Electron main process. The
 
 The preload bridge exposes desktop-only APIs to the web UI through `window.__OPENCHAMBER_DESKTOP__`. Privileged commands are checked in `main.mjs`, not only in the UI.
 
+Runtime bearer tokens and credential-bearing headers never travel in renderer command-line arguments. At document start, preload synchronously requests a small per-window runtime bootstrap from main; main derives the sender BrowserWindow itself and returns credentials only for the exact packaged UI or configured local runtime origins. Remote pages receive no runtime bootstrap.
+
+Remote pages may render the Desktop Host Switcher, but `desktop_hosts_get` returns only redacted display metadata and normalized public transport descriptors. Tokens, runtime headers, pairing material, grants, private JWK members, and unknown nested fields remain main-process-only. Host activation from a remote page delegates an opaque saved-host ID back to main, which opens a local UI window and resolves credentials from main-owned settings.
+
 ## Main Files
 
 | File | Purpose |
@@ -144,9 +148,12 @@ Electron uses `electron-log`. In development, console logs are also visible in t
 
 Development builds use a separate user data directory named `OpenChamber Dev`, so dev state does not overwrite normal packaged app state.
 
+The shared settings file can contain desktop bearer tokens and private key material. POSIX writes use an owner-only atomic temporary file and leave the final file at `0600`. The default app-owned `~/.config/openchamber` directory is created privately; a user-provided `OPENCHAMBER_DATA_DIR` is never chmod-ed by Desktop.
+
 ## Things To Be Careful With
 
 - Keep desktop-specific code in this package. Do not move OpenCode feature backend logic into Electron.
+- OS-level Pairing v2 deep links are accepted only when every candidate is plain HTTP(S). Links containing relay or direct-E2EE candidates are rejected as a whole so Electron cannot silently downgrade by dropping encrypted descriptors; paste those links into the shared UI pairing flow instead.
 - Use hidden Windows process launches for background helpers. Avoid visible console flashes.
 - Keep `@openchamber/web`, `bun-pty`, `node-pty`, and native modules external in `bundle-main.mjs`; bundling them can break Electron startup.
 - Rebuild native modules after dependency or Electron version changes.

--- a/packages/electron/host-public-config.mjs
+++ b/packages/electron/host-public-config.mjs
@@ -17,10 +17,21 @@ const sanitizePublicUrl = (value, protocols) => {
   }
 };
 
+const sanitizePublicLabel = (value) => {
+  const label = typeof value === 'string' ? value.trim() : '';
+  if (!label) return '';
+  try {
+    const url = new URL(label);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.origin : label;
+  } catch {
+    return label;
+  }
+};
+
 const redactHost = (host) => {
   if (!host || typeof host !== 'object' || Array.isArray(host)) return null;
   const id = typeof host.id === 'string' ? host.id.trim() : '';
-  const label = typeof host.label === 'string' ? host.label.trim() : '';
+  const label = sanitizePublicLabel(host.label);
   if (!id || !label) return null;
   const url = sanitizePublicUrl(host.url, new Set(['http:', 'https:'])) || (typeof host.url === 'string' && /^(?:relay|direct-e2ee):\/\/[a-zA-Z0-9._-]+$/.test(host.url) ? host.url : null);
   const apiUrl = sanitizePublicUrl(host.apiUrl, new Set(['http:', 'https:']));

--- a/packages/electron/host-public-config.mjs
+++ b/packages/electron/host-public-config.mjs
@@ -17,21 +17,40 @@ const sanitizePublicUrl = (value, protocols) => {
   }
 };
 
-const sanitizePublicLabel = (value) => {
-  const label = typeof value === 'string' ? value.trim() : '';
-  if (!label) return '';
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
+const SYNTHETIC_LABEL = /^(?:relay|direct-e2ee):\/\/[a-zA-Z0-9._-]+$/;
+const SYNTHETIC_LABEL_PREFIX = /^(?:relay|direct-e2ee):/i;
+const URL_SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+const sanitizePublicLabel = (value, fallback) => {
+  if (typeof value !== 'string' || CONTROL_CHARACTERS.test(value)) return fallback;
+  const label = value.trim();
+  if (!label) return fallback;
+  if (SYNTHETIC_LABEL.test(label)) return label;
+  if (SYNTHETIC_LABEL_PREFIX.test(label)) return fallback;
+
+  if (label.startsWith('//')) {
+    try {
+      const url = new URL(label, 'https://public-label.invalid');
+      return url.host ? `//${url.host}` : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  if (!URL_SCHEME_PREFIX.test(label)) return label;
   try {
     const url = new URL(label);
-    return url.protocol === 'http:' || url.protocol === 'https:' ? url.origin : label;
+    return url.host ? `${url.protocol}//${url.host}` : fallback;
   } catch {
-    return label;
+    return fallback;
   }
 };
 
 const redactHost = (host) => {
   if (!host || typeof host !== 'object' || Array.isArray(host)) return null;
   const id = typeof host.id === 'string' ? host.id.trim() : '';
-  const label = sanitizePublicLabel(host.label);
+  const label = sanitizePublicLabel(host.label, id);
   if (!id || !label) return null;
   const url = sanitizePublicUrl(host.url, new Set(['http:', 'https:'])) || (typeof host.url === 'string' && /^(?:relay|direct-e2ee):\/\/[a-zA-Z0-9._-]+$/.test(host.url) ? host.url : null);
   const apiUrl = sanitizePublicUrl(host.apiUrl, new Set(['http:', 'https:']));

--- a/packages/electron/host-public-config.mjs
+++ b/packages/electron/host-public-config.mjs
@@ -1,0 +1,53 @@
+import { isRuntimeBootstrapSenderAllowed } from './runtime-bootstrap.mjs';
+import { sanitizeHostDirectE2eeForStorage, sanitizeHostRelayForStorage } from './host-storage-sanitizer.mjs';
+
+const sanitizePublicUrl = (value, protocols) => {
+  if (typeof value !== 'string') return null;
+  try {
+    const url = new URL(value.trim());
+    if (!protocols.has(url.protocol)) return null;
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    const normalized = url.toString();
+    return url.pathname === '/' ? normalized.replace(/\/$/, '') : normalized;
+  } catch {
+    return null;
+  }
+};
+
+const redactHost = (host) => {
+  if (!host || typeof host !== 'object' || Array.isArray(host)) return null;
+  const id = typeof host.id === 'string' ? host.id.trim() : '';
+  const label = typeof host.label === 'string' ? host.label.trim() : '';
+  if (!id || !label) return null;
+  const url = sanitizePublicUrl(host.url, new Set(['http:', 'https:'])) || (typeof host.url === 'string' && /^(?:relay|direct-e2ee):\/\/[a-zA-Z0-9._-]+$/.test(host.url) ? host.url : null);
+  const apiUrl = sanitizePublicUrl(host.apiUrl, new Set(['http:', 'https:']));
+  const relay = sanitizeHostRelayForStorage(host.relay);
+  const directE2ee = sanitizeHostDirectE2eeForStorage(host.directE2ee);
+  if (!url && !apiUrl && !relay && !directE2ee) return null;
+  const publicRelay = relay ? {
+    ...relay,
+    relayUrl: sanitizePublicUrl(relay.relayUrl, new Set(['ws:', 'wss:'])),
+  } : null;
+  return {
+    id,
+    label,
+    ...(url ? { url } : {}),
+    ...(apiUrl ? { apiUrl } : {}),
+    ...(publicRelay?.relayUrl ? { relay: publicRelay } : {}),
+    ...(directE2ee ? { directE2ee } : {}),
+  };
+};
+
+export const redactDesktopHostsConfig = (config) => ({
+  hosts: Array.isArray(config?.hosts) ? config.hosts.map(redactHost).filter(Boolean) : [],
+  defaultHostId: typeof config?.defaultHostId === 'string' ? config.defaultHostId : null,
+  initialHostChoiceCompleted: config?.initialHostChoiceCompleted === true,
+  localOrigin: sanitizePublicUrl(config?.localOrigin, new Set(['http:', 'https:'])),
+});
+
+export const resolveDesktopHostsForSender = (senderUrl, fullConfig, allowed) => (
+  isRuntimeBootstrapSenderAllowed(senderUrl, allowed) ? fullConfig : redactDesktopHostsConfig(fullConfig)
+);

--- a/packages/electron/host-public-config.mjs
+++ b/packages/electron/host-public-config.mjs
@@ -41,12 +41,16 @@ const redactHost = (host) => {
   };
 };
 
-export const redactDesktopHostsConfig = (config) => ({
-  hosts: Array.isArray(config?.hosts) ? config.hosts.map(redactHost).filter(Boolean) : [],
-  defaultHostId: typeof config?.defaultHostId === 'string' ? config.defaultHostId : null,
-  initialHostChoiceCompleted: config?.initialHostChoiceCompleted === true,
-  localOrigin: sanitizePublicUrl(config?.localOrigin, new Set(['http:', 'https:'])),
-});
+export const redactDesktopHostsConfig = (config) => {
+  const hosts = Array.isArray(config?.hosts) ? config.hosts.map(redactHost).filter(Boolean) : [];
+  const defaultHostId = typeof config?.defaultHostId === 'string' ? config.defaultHostId.trim() : '';
+  return {
+    hosts,
+    defaultHostId: defaultHostId && hosts.some((host) => host.id === defaultHostId) ? defaultHostId : null,
+    initialHostChoiceCompleted: config?.initialHostChoiceCompleted === true,
+    localOrigin: sanitizePublicUrl(config?.localOrigin, new Set(['http:', 'https:'])),
+  };
+};
 
 export const resolveDesktopHostsForSender = (senderUrl, fullConfig, allowed) => (
   isRuntimeBootstrapSenderAllowed(senderUrl, allowed) ? fullConfig : redactDesktopHostsConfig(fullConfig)

--- a/packages/electron/host-public-config.test.mjs
+++ b/packages/electron/host-public-config.test.mjs
@@ -42,6 +42,39 @@ describe('desktop host public config', () => {
     ]);
   });
 
+  test('reduces URL-shaped labels to origins while preserving safe labels and transport paths', () => {
+    const result = resolveDesktopHostsForSender('https://evil.example/path', {
+      hosts: [
+        {
+          id: 'url-label',
+          label: 'https://user:password@remote.example:8443/custom/path-token?token=query-secret#fragment-secret',
+          url: 'https://user:password@remote.example:8443/custom/base?token=query-secret#fragment-secret',
+          apiUrl: 'https://api-user:api-password@remote.example:8443/custom/base/api?key=query-secret#fragment-secret',
+        },
+        { id: 'friendly', label: 'Friendly workstation', url: 'https://friendly.example/custom/base' },
+        { id: 'relay', label: 'relay://server-one', relay: fullConfig.hosts[0].relay },
+      ],
+      defaultHostId: 'url-label',
+    }, allowed);
+
+    expect(result.hosts).toEqual([
+      {
+        id: 'url-label',
+        label: 'https://remote.example:8443',
+        url: 'https://remote.example:8443/custom/base',
+        apiUrl: 'https://remote.example:8443/custom/base/api',
+      },
+      { id: 'friendly', label: 'Friendly workstation', url: 'https://friendly.example/custom/base' },
+      {
+        id: 'relay',
+        label: 'relay://server-one',
+        relay: { relayUrl: 'wss://relay.example/ws', serverId: 'server-one', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'rx', y: 'ry' } },
+      },
+    ]);
+    expect(result.defaultHostId).toBe('url-label');
+    expect(JSON.stringify(result)).not.toMatch(/password|path-token|query-secret|fragment-secret/i);
+  });
+
   test('preserves a normalized default only when its redacted host survives', () => {
     const result = resolveDesktopHostsForSender('https://evil.example/path', {
       ...fullConfig,

--- a/packages/electron/host-public-config.test.mjs
+++ b/packages/electron/host-public-config.test.mjs
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveDesktopHostsForSender } from './host-public-config.mjs';
+
+const fullConfig = {
+  hosts: [{
+    id: 'host-one', label: 'Remote', url: 'https://user:pass@remote.example/path?token=secret#fragment', apiUrl: 'https://remote.example/api?key=secret',
+    clientToken: 'bearer-secret', requestHeaders: { Authorization: 'Bearer secret', 'CF-Access-Client-Secret': 'secret' }, pairingSecret: 'pairing-secret',
+    relay: { relayUrl: 'wss://relay.example/ws', serverId: 'server-one', grant: 'grant-secret', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'rx', y: 'ry', d: 'private', unknown: 'strip' } },
+    directE2ee: { wssUrl: 'wss://direct.example/api/openchamber/direct-e2ee/ws', pairing: { secret: 'nested' }, hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'dx', y: 'dy', d: 'private' } },
+    unknown: { clientToken: 'nested-secret' },
+  }],
+  defaultHostId: 'host-one', initialHostChoiceCompleted: true, localClientToken: 'local-secret', privateJwk: { d: 'private' }, localOrigin: 'http://127.0.0.1:3901',
+};
+const allowed = { localOrigin: 'http://127.0.0.1:3901', sidecarUrl: 'http://127.0.0.1:57123' };
+
+describe('desktop host public config', () => {
+  test('returns the exact full config only to exact local senders', () => {
+    expect(resolveDesktopHostsForSender('http://127.0.0.1:3901/settings', fullConfig, allowed)).toBe(fullConfig);
+    expect(resolveDesktopHostsForSender('openchamber-ui://app/index.html', fullConfig, allowed)).toBe(fullConfig);
+  });
+
+  test('redacts hostile remote callers and strips nested unknown credential fields', () => {
+    for (const sender of ['https://evil.example/path', 'http://127.0.0.1:3901.evil.example/path']) {
+      const result = resolveDesktopHostsForSender(sender, fullConfig, allowed);
+      expect(result).toEqual({
+        hosts: [{
+          id: 'host-one', label: 'Remote', url: 'https://remote.example/path', apiUrl: 'https://remote.example/api',
+          relay: { relayUrl: 'wss://relay.example/ws', serverId: 'server-one', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'rx', y: 'ry' } },
+          directE2ee: { wssUrl: 'wss://direct.example/api/openchamber/direct-e2ee/ws', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'dx', y: 'dy' } },
+        }],
+        defaultHostId: 'host-one', initialHostChoiceCompleted: true, localOrigin: 'http://127.0.0.1:3901',
+      });
+      expect(JSON.stringify(result)).not.toMatch(/secret|clientToken|requestHeaders|grant|privateJwk|"d"/i);
+    }
+  });
+
+  test('uses only the supplied window config without crossing per-window host state', () => {
+    const other = { ...fullConfig, hosts: [{ id: 'host-two', label: 'Two', url: 'https://two.example', clientToken: 'two-secret' }] };
+    expect(resolveDesktopHostsForSender('https://evil.example/path', other, allowed).hosts).toEqual([
+      { id: 'host-two', label: 'Two', url: 'https://two.example' },
+    ]);
+  });
+});

--- a/packages/electron/host-public-config.test.mjs
+++ b/packages/electron/host-public-config.test.mjs
@@ -75,6 +75,46 @@ describe('desktop host public config', () => {
     expect(JSON.stringify(result)).not.toMatch(/password|path-token|query-secret|fragment-secret/i);
   });
 
+  test('redacts hierarchical and unsafe URL-shaped labels without changing transport paths', () => {
+    const publicUrl = 'https://runtime.example/custom/base?token=url-secret#url-fragment';
+    const publicApiUrl = 'https://runtime.example/custom/base/api?token=api-secret#api-fragment';
+    const labels = [
+      ['wss-label', 'wss://user:wss-secret@socket.example:9443/private?token=wss-query#wss-fragment', 'wss://socket.example:9443'],
+      ['ws-label', 'ws://user:ws-secret@socket.example:8080/private?token=ws-query#ws-fragment', 'ws://socket.example:8080'],
+      ['ssh-label', 'ssh://user:ssh-secret@ssh.example:2222/home?token=ssh-query#ssh-fragment', 'ssh://ssh.example:2222'],
+      ['ftp-label', 'ftp://user:ftp-secret@ftp.example:2121/files?token=ftp-query#ftp-fragment', 'ftp://ftp.example:2121'],
+      ['custom-label', 'custom+transport://user:custom-secret@custom.example:4321/private?token=custom-query#custom-fragment', 'custom+transport://custom.example:4321'],
+      ['relative-label', '//user:relative-secret@relative.example:8443/private?token=relative-query#relative-fragment', '//relative.example:8443'],
+      ['javascript-label', 'javascript:alert("javascript-secret")', 'javascript-label'],
+      ['data-label', 'data:text/plain,data-secret', 'data-label'],
+      ['file-label', 'file:///Users/private/file-secret', 'file-label'],
+      ['file-host-label', 'file://fileserver/private/file-secret', 'file://fileserver'],
+      ['malformed-label', 'https://user:malformed-secret@[invalid/path?token=secret', 'malformed-label'],
+      ['relay-label', 'relay://server-one', 'relay://server-one'],
+      ['direct-label', 'direct-e2ee://device_1.test-safe', 'direct-e2ee://device_1.test-safe'],
+      ['relay-userinfo', 'relay://user:secret@server-one', 'relay-userinfo'],
+      ['relay-path', 'relay://server-one/private', 'relay-path'],
+      ['direct-query', 'direct-e2ee://device-one?token=secret', 'direct-query'],
+      ['direct-fragment', 'direct-e2ee://device-one#secret', 'direct-fragment'],
+      ['synthetic-control', 'relay://server\n-one', 'synthetic-control'],
+      ['friendly-label', 'Friendly workstation', 'Friendly workstation'],
+    ];
+    const result = resolveDesktopHostsForSender('https://evil.example/path', {
+      hosts: labels.map(([id, label]) => ({ id, label, url: publicUrl, apiUrl: publicApiUrl })),
+      defaultHostId: 'javascript-label',
+    }, allowed);
+
+    expect(Object.fromEntries(result.hosts.map((host) => [host.id, host.label]))).toEqual(
+      Object.fromEntries(labels.map(([id, , expected]) => [id, expected])),
+    );
+    expect(result.hosts.find((host) => host.id === 'javascript-label')).toMatchObject({
+      url: 'https://runtime.example/custom/base',
+      apiUrl: 'https://runtime.example/custom/base/api',
+    });
+    expect(result.defaultHostId).toBe('javascript-label');
+    expect(JSON.stringify(result)).not.toMatch(/wss-secret|ws-secret|ssh-secret|ftp-secret|relative-secret|javascript-secret|data-secret|file-secret|malformed-secret/i);
+  });
+
   test('preserves a normalized default only when its redacted host survives', () => {
     const result = resolveDesktopHostsForSender('https://evil.example/path', {
       ...fullConfig,

--- a/packages/electron/host-public-config.test.mjs
+++ b/packages/electron/host-public-config.test.mjs
@@ -41,4 +41,43 @@ describe('desktop host public config', () => {
       { id: 'host-two', label: 'Two', url: 'https://two.example' },
     ]);
   });
+
+  test('preserves a normalized default only when its redacted host survives', () => {
+    const result = resolveDesktopHostsForSender('https://evil.example/path', {
+      ...fullConfig,
+      defaultHostId: ' host-one ',
+    }, allowed);
+    expect(result.defaultHostId).toBe('host-one');
+  });
+
+  test('clears defaults for filtered or missing hosts and preserves null', () => {
+    const cases = [
+      {
+        config: { hosts: [{ id: 'filtered', label: 'Filtered' }], defaultHostId: 'filtered' },
+        expectedHosts: [],
+      },
+      {
+        config: { hosts: fullConfig.hosts, defaultHostId: 'missing' },
+        expectedHosts: [{
+          id: 'host-one', label: 'Remote', url: 'https://remote.example/path', apiUrl: 'https://remote.example/api',
+          relay: { relayUrl: 'wss://relay.example/ws', serverId: 'server-one', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'rx', y: 'ry' } },
+          directE2ee: { wssUrl: 'wss://direct.example/api/openchamber/direct-e2ee/ws', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'dx', y: 'dy' } },
+        }],
+      },
+      {
+        config: { hosts: fullConfig.hosts, defaultHostId: null },
+        expectedHosts: [{
+          id: 'host-one', label: 'Remote', url: 'https://remote.example/path', apiUrl: 'https://remote.example/api',
+          relay: { relayUrl: 'wss://relay.example/ws', serverId: 'server-one', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'rx', y: 'ry' } },
+          directE2ee: { wssUrl: 'wss://direct.example/api/openchamber/direct-e2ee/ws', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'dx', y: 'dy' } },
+        }],
+      },
+    ];
+
+    for (const { config, expectedHosts } of cases) {
+      const result = resolveDesktopHostsForSender('https://evil.example/path', config, allowed);
+      expect(result.hosts).toEqual(expectedHosts);
+      expect(result.defaultHostId).toBeNull();
+    }
+  });
 });

--- a/packages/electron/host-storage-sanitizer.mjs
+++ b/packages/electron/host-storage-sanitizer.mjs
@@ -1,0 +1,58 @@
+export const sanitizeHostRelayForStorage = (value) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const relayUrl = typeof value.relayUrl === 'string' ? value.relayUrl.trim() : '';
+  const serverId = typeof value.serverId === 'string' ? value.serverId.trim() : '';
+  const jwk = value.hostEncPubJwk;
+  if (!relayUrl || !serverId || !jwk || typeof jwk !== 'object' || Array.isArray(jwk)) return null;
+  if (jwk.kty !== 'EC' || jwk.crv !== 'P-256' || typeof jwk.x !== 'string' || !jwk.x || typeof jwk.y !== 'string' || !jwk.y) return null;
+  try {
+    const parsed = new URL(relayUrl);
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') return null;
+  } catch {
+    return null;
+  }
+  return { relayUrl, serverId, hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y } };
+};
+
+export const sanitizeHostDirectE2eeForStorage = (value) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const wssUrl = typeof value.wssUrl === 'string' ? value.wssUrl.trim() : '';
+  const jwk = value.hostEncPubJwk;
+  if (!wssUrl || !jwk || typeof jwk !== 'object' || Array.isArray(jwk)) return null;
+  try {
+    const url = new URL(wssUrl);
+    if (url.protocol !== 'wss:' || url.pathname !== '/api/openchamber/direct-e2ee/ws' || url.search || url.hash || url.username || url.password) return null;
+    if (jwk.kty !== 'EC' || jwk.crv !== 'P-256' || typeof jwk.x !== 'string' || !jwk.x || typeof jwk.y !== 'string' || !jwk.y) return null;
+    return { wssUrl: url.toString(), hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y } };
+  } catch {
+    return null;
+  }
+};
+
+export const buildStoredHostEntry = (entry, dependencies) => {
+  const id = typeof entry?.id === 'string' ? entry.id.trim() : '';
+  if (!id || id === dependencies.localHostId) return null;
+  const clientToken = dependencies.sanitizeClientToken(entry?.clientToken);
+  const requestHeaders = dependencies.sanitizeRequestHeaders(entry?.requestHeaders);
+  const headerFields = Object.keys(requestHeaders).length > 0 ? { requestHeaders } : {};
+  const tokenField = clientToken ? { clientToken } : {};
+  const labelRaw = typeof entry?.label === 'string' && entry.label.trim() ? entry.label.trim() : '';
+  const relay = sanitizeHostRelayForStorage(entry?.relay);
+  const directUrl = dependencies.sanitizeHostUrl(entry?.url);
+  const apiUrl = dependencies.sanitizeHostUrl(entry?.apiUrl) || directUrl;
+  const directE2ee = sanitizeHostDirectE2eeForStorage(entry?.directE2ee);
+  const displayUrl = directUrl
+    || (directE2ee ? `direct-e2ee://${new URL(directE2ee.wssUrl).hostname}` : null)
+    || (relay ? `relay://${relay.serverId}` : null);
+  if (!displayUrl) return null;
+  return {
+    id,
+    label: labelRaw || displayUrl,
+    url: displayUrl,
+    ...(apiUrl ? { apiUrl } : {}),
+    ...tokenField,
+    ...headerFields,
+    ...(directE2ee ? { directE2ee } : {}),
+    ...(relay ? { relay } : {}),
+  };
+};

--- a/packages/electron/host-storage-sanitizer.mjs
+++ b/packages/electron/host-storage-sanitizer.mjs
@@ -29,6 +29,15 @@ export const sanitizeHostDirectE2eeForStorage = (value) => {
   }
 };
 
+const directHostFallbackLabel = (value) => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.origin : null;
+  } catch {
+    return null;
+  }
+};
+
 export const buildStoredHostEntry = (entry, dependencies) => {
   const id = typeof entry?.id === 'string' ? entry.id.trim() : '';
   if (!id || id === dependencies.localHostId) return null;
@@ -45,9 +54,10 @@ export const buildStoredHostEntry = (entry, dependencies) => {
     || (directE2ee ? `direct-e2ee://${new URL(directE2ee.wssUrl).hostname}` : null)
     || (relay ? `relay://${relay.serverId}` : null);
   if (!displayUrl) return null;
+  const fallbackLabel = directUrl ? directHostFallbackLabel(directUrl) : displayUrl;
   return {
     id,
-    label: labelRaw || displayUrl,
+    label: labelRaw || fallbackLabel || displayUrl,
     url: displayUrl,
     ...(apiUrl ? { apiUrl } : {}),
     ...tokenField,

--- a/packages/electron/host-storage-sanitizer.test.mjs
+++ b/packages/electron/host-storage-sanitizer.test.mjs
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildStoredHostEntry } from './host-storage-sanitizer.mjs';
+
+const dependencies = {
+  localHostId: 'local',
+  sanitizeHostUrl(value) {
+    if (typeof value !== 'string') return null;
+    try {
+      const url = new URL(value);
+      return url.protocol === 'http:' || url.protocol === 'https:' ? value : null;
+    } catch {
+      return null;
+    }
+  },
+  sanitizeClientToken(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : null;
+  },
+  sanitizeRequestHeaders() {
+    return {};
+  },
+};
+
+const descriptor = {
+  wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'public-x', y: 'public-y', d: 'PRIVATE', unknown: true },
+};
+const relay = {
+  relayUrl: 'wss://relay.example/ws',
+  serverId: 'server-1',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'relay-x', y: 'relay-y', d: 'PRIVATE', unknown: true },
+};
+
+describe('Electron host storage sanitization', () => {
+  test('retains only the direct public descriptor and bearer token', () => {
+    const stored = buildStoredHostEntry({
+      id: 'host-1',
+      label: 'Host',
+      clientToken: ' oc_client_token ',
+      pairingSecret: 'one-time-secret',
+      secret: 'also-secret',
+      directE2ee: descriptor,
+    }, dependencies);
+    expect(stored).toEqual({
+      id: 'host-1',
+      label: 'Host',
+      url: 'direct-e2ee://host.example',
+      clientToken: 'oc_client_token',
+      directE2ee: {
+        wssUrl: descriptor.wssUrl,
+        hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'public-x', y: 'public-y' },
+      },
+    });
+    expect(JSON.stringify(stored)).not.toContain('one-time-secret');
+    expect(JSON.stringify(stored)).not.toContain('PRIVATE');
+  });
+
+  test('rejects credentials, query, fragment, wrong path, non-WSS, and malformed keys', () => {
+    const unsafe = [
+      'wss://user:pass@host.example/api/openchamber/direct-e2ee/ws',
+      'wss://host.example/api/openchamber/direct-e2ee/ws?token=x',
+      'wss://host.example/api/openchamber/direct-e2ee/ws#fragment',
+      'wss://host.example/wrong',
+      'ws://host.example/api/openchamber/direct-e2ee/ws',
+    ];
+    for (const wssUrl of unsafe) {
+      expect(buildStoredHostEntry({ id: 'host', label: 'Host', directE2ee: { ...descriptor, wssUrl } }, dependencies)).toBeNull();
+    }
+    expect(buildStoredHostEntry({
+      id: 'host',
+      label: 'Host',
+      directE2ee: { ...descriptor, hostEncPubJwk: { kty: 'EC', crv: 'P-384', x: 'x', y: 'y' } },
+    }, dependencies)).toBeNull();
+  });
+
+  test('preserves relay and direct E2EE together without fabricating HTTP', () => {
+    expect(buildStoredHostEntry({ id: 'host', directE2ee: descriptor, relay }, dependencies)).toEqual({
+      id: 'host',
+      label: 'direct-e2ee://host.example',
+      url: 'direct-e2ee://host.example',
+      directE2ee: {
+        wssUrl: descriptor.wssUrl,
+        hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'public-x', y: 'public-y' },
+      },
+      relay: {
+        relayUrl: relay.relayUrl,
+        serverId: relay.serverId,
+        hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'relay-x', y: 'relay-y' },
+      },
+    });
+  });
+
+  test('preserves all three independent transport legs', () => {
+    const stored = buildStoredHostEntry({
+      id: 'host',
+      url: 'https://lan.example',
+      apiUrl: 'https://api.example',
+      directE2ee: descriptor,
+      relay,
+    }, dependencies);
+    expect(stored?.url).toBe('https://lan.example');
+    expect(stored?.apiUrl).toBe('https://api.example');
+    expect(stored?.directE2ee).toBeDefined();
+    expect(stored?.relay).toBeDefined();
+  });
+
+  test('drops only a malformed leg and keeps the other valid descriptors', () => {
+    const stored = buildStoredHostEntry({
+      id: 'host',
+      url: 'not-http',
+      directE2ee: { ...descriptor, wssUrl: 'ws://unsafe.example/wrong' },
+      relay,
+    }, dependencies);
+    expect(stored).toEqual({
+      id: 'host',
+      label: 'relay://server-1',
+      url: 'relay://server-1',
+      relay: {
+        relayUrl: relay.relayUrl,
+        serverId: relay.serverId,
+        hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'relay-x', y: 'relay-y' },
+      },
+    });
+  });
+});

--- a/packages/electron/host-storage-sanitizer.test.mjs
+++ b/packages/electron/host-storage-sanitizer.test.mjs
@@ -104,6 +104,23 @@ describe('Electron host storage sanitization', () => {
     expect(stored?.relay).toBeDefined();
   });
 
+  test('uses only the direct URL origin for fallback labels without changing stored transport URLs', () => {
+    const urls = [
+      'https://user:password@host.example:8443/custom/path-token?token=query-secret#fragment-secret',
+      'https://host.example/path-secret',
+      'https://host.example?query-secret=yes',
+      'https://host.example/#fragment-secret',
+    ];
+    for (const url of urls) {
+      const stored = buildStoredHostEntry({ id: `host-${urls.indexOf(url)}`, url, apiUrl: `${url}/api` }, dependencies);
+      expect(stored?.label).toBe(new URL(url).origin);
+      expect(stored?.url).toBe(url);
+      expect(stored?.apiUrl).toBe(`${url}/api`);
+      expect(stored?.label).not.toMatch(/user|password|token|secret|query|fragment|\/custom|\/path/i);
+    }
+    expect(buildStoredHostEntry({ id: 'friendly', label: 'Friendly workstation', url: urls[0] }, dependencies)?.label).toBe('Friendly workstation');
+  });
+
   test('drops only a malformed leg and keeps the other valid descriptors', () => {
     const stored = buildStoredHostEntry({
       id: 'host',

--- a/packages/electron/initial-runtime-plan.mjs
+++ b/packages/electron/initial-runtime-plan.mjs
@@ -1,0 +1,50 @@
+import { sanitizeRuntimeRequestHeaders } from './runtime-request-headers.mjs';
+
+export const planInitialRuntime = ({
+  envTarget = '',
+  defaultHostId = '',
+  hosts = [],
+  localUiUrl,
+  localUrl,
+  localClientToken = '',
+  useRemoteUi = false,
+} = {}) => {
+  const localPlan = {
+    initialUrl: localUiUrl,
+    apiBaseUrl: localUrl,
+    clientToken: localClientToken,
+    requestHeaders: {},
+    relayHostId: '',
+    probeRemote: false,
+  };
+
+  if (envTarget) {
+    return {
+      ...localPlan,
+      initialUrl: useRemoteUi ? envTarget : localUiUrl,
+      apiBaseUrl: envTarget,
+      clientToken: '',
+      probeRemote: true,
+    };
+  }
+
+  if (!defaultHostId || defaultHostId === 'local') return localPlan;
+
+  const host = hosts.find((entry) => entry.id === defaultHostId);
+  if (!host) return localPlan;
+
+  if ((host.relay && typeof host.relay === 'object') || (host.directE2ee && typeof host.directE2ee === 'object')) {
+    return { ...localPlan, relayHostId: host.id };
+  }
+
+  if (!host.url) return localPlan;
+
+  return {
+    initialUrl: useRemoteUi ? host.url : localUiUrl,
+    apiBaseUrl: host.apiUrl || host.url,
+    clientToken: host.clientToken || '',
+    requestHeaders: sanitizeRuntimeRequestHeaders(host.requestHeaders || {}),
+    relayHostId: '',
+    probeRemote: true,
+  };
+};

--- a/packages/electron/initial-runtime-plan.mjs
+++ b/packages/electron/initial-runtime-plan.mjs
@@ -1,5 +1,67 @@
 import { sanitizeRuntimeRequestHeaders } from './runtime-request-headers.mjs';
 
+const localRuntimePlan = ({ localUiUrl, localUrl, localClientToken = '' }) => ({
+  initialUrl: localUiUrl,
+  apiBaseUrl: localUrl,
+  clientToken: localClientToken,
+  requestHeaders: {},
+  relayHostId: '',
+  probeRemote: false,
+});
+
+const isHttpRuntimeUrl = (value) => {
+  if (typeof value !== 'string' || !value) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const planRuntimeForHost = ({
+  hostId,
+  hosts = [],
+  localUiUrl,
+  localUrl,
+  localClientToken = '',
+  useRemoteUi = false,
+} = {}) => {
+  const localPlan = localRuntimePlan({ localUiUrl, localUrl, localClientToken });
+  if (hostId === 'local') return localPlan;
+  if (!hostId) return null;
+
+  const host = hosts.find((entry) => entry.id === hostId);
+  if (!host) return null;
+
+  const encrypted = (host.relay && typeof host.relay === 'object')
+    || (host.directE2ee && typeof host.directE2ee === 'object');
+  const directUrl = host.apiUrl || host.url;
+  const hasDirect = isHttpRuntimeUrl(directUrl);
+  if (encrypted) {
+    return {
+      ...localPlan,
+      ...(hasDirect ? {
+        apiBaseUrl: directUrl,
+        clientToken: host.clientToken || '',
+        requestHeaders: sanitizeRuntimeRequestHeaders(host.requestHeaders || {}),
+        probeRemote: true,
+      } : {}),
+      relayHostId: host.id,
+    };
+  }
+  if (!hasDirect) return null;
+
+  return {
+    initialUrl: useRemoteUi ? (host.url || directUrl) : localUiUrl,
+    apiBaseUrl: directUrl,
+    clientToken: host.clientToken || '',
+    requestHeaders: sanitizeRuntimeRequestHeaders(host.requestHeaders || {}),
+    relayHostId: '',
+    probeRemote: true,
+  };
+};
+
 export const planInitialRuntime = ({
   envTarget = '',
   defaultHostId = '',
@@ -9,14 +71,7 @@ export const planInitialRuntime = ({
   localClientToken = '',
   useRemoteUi = false,
 } = {}) => {
-  const localPlan = {
-    initialUrl: localUiUrl,
-    apiBaseUrl: localUrl,
-    clientToken: localClientToken,
-    requestHeaders: {},
-    relayHostId: '',
-    probeRemote: false,
-  };
+  const localPlan = localRuntimePlan({ localUiUrl, localUrl, localClientToken });
 
   if (envTarget) {
     return {
@@ -28,23 +83,6 @@ export const planInitialRuntime = ({
     };
   }
 
-  if (!defaultHostId || defaultHostId === 'local') return localPlan;
-
-  const host = hosts.find((entry) => entry.id === defaultHostId);
-  if (!host) return localPlan;
-
-  if ((host.relay && typeof host.relay === 'object') || (host.directE2ee && typeof host.directE2ee === 'object')) {
-    return { ...localPlan, relayHostId: host.id };
-  }
-
-  if (!host.url) return localPlan;
-
-  return {
-    initialUrl: useRemoteUi ? host.url : localUiUrl,
-    apiBaseUrl: host.apiUrl || host.url,
-    clientToken: host.clientToken || '',
-    requestHeaders: sanitizeRuntimeRequestHeaders(host.requestHeaders || {}),
-    relayHostId: '',
-    probeRemote: true,
-  };
+  if (!defaultHostId) return localPlan;
+  return planRuntimeForHost({ hostId: defaultHostId, hosts, localUiUrl, localUrl, localClientToken, useRemoteUi }) || localPlan;
 };

--- a/packages/electron/initial-runtime-plan.test.mjs
+++ b/packages/electron/initial-runtime-plan.test.mjs
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+
+import { planInitialRuntime } from './initial-runtime-plan.mjs';
+
+const local = {
+  localUiUrl: 'openchamber-ui://app/index.html',
+  localUrl: 'http://127.0.0.1:3901',
+  localClientToken: 'local-runtime-token',
+};
+
+describe('initial runtime plan', () => {
+  test.each([
+    ['direct E2EE', { id: 'host-e2ee', url: 'direct-e2ee://workspace.example', clientToken: 'remote-secret', directE2ee: { authority: 'workspace.example' } }],
+    ['relay', { id: 'host-relay', url: 'relay://workspace.example', clientToken: 'remote-secret', relay: { hostId: 'opaque' } }],
+  ])('boots the local runtime for a persisted %s host without an HTTP probe', (_label, host) => {
+    expect(planInitialRuntime({ ...local, defaultHostId: host.id, hosts: [host] })).toEqual({
+      initialUrl: local.localUiUrl,
+      apiBaseUrl: local.localUrl,
+      clientToken: local.localClientToken,
+      requestHeaders: {},
+      relayHostId: host.id,
+      probeRemote: false,
+    });
+  });
+
+  test('keeps direct HTTP hosts on the remote probe path', () => {
+    expect(planInitialRuntime({
+      ...local,
+      defaultHostId: 'host-http',
+      hosts: [{
+        id: 'host-http',
+        url: 'https://ui.example',
+        apiUrl: 'https://api.example',
+        clientToken: 'remote-token',
+        requestHeaders: { 'CF-Access-Client-Id': 'client-id' },
+      }],
+    })).toEqual({
+      initialUrl: 'openchamber-ui://app/index.html',
+      apiBaseUrl: 'https://api.example',
+      clientToken: 'remote-token',
+      requestHeaders: { 'CF-Access-Client-Id': 'client-id' },
+      relayHostId: '',
+      probeRemote: true,
+    });
+  });
+
+  test('keeps the environment target above the persisted default host', () => {
+    expect(planInitialRuntime({
+      ...local,
+      envTarget: 'https://env.example',
+      defaultHostId: 'host-relay',
+      hosts: [{ id: 'host-relay', relay: {} }],
+    })).toEqual({
+      initialUrl: local.localUiUrl,
+      apiBaseUrl: 'https://env.example',
+      clientToken: '',
+      requestHeaders: {},
+      relayHostId: '',
+      probeRemote: true,
+    });
+  });
+
+  test.each([
+    ['unconfigured', '', []],
+    ['local default', 'local', [{ id: 'remote', url: 'https://remote.example' }]],
+  ])('uses the local runtime for %s startup', (_label, defaultHostId, hosts) => {
+    expect(planInitialRuntime({ ...local, defaultHostId, hosts })).toEqual({
+      initialUrl: local.localUiUrl,
+      apiBaseUrl: local.localUrl,
+      clientToken: local.localClientToken,
+      requestHeaders: {},
+      relayHostId: '',
+      probeRemote: false,
+    });
+  });
+});

--- a/packages/electron/initial-runtime-plan.test.mjs
+++ b/packages/electron/initial-runtime-plan.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { planInitialRuntime } from './initial-runtime-plan.mjs';
+import { planInitialRuntime, planRuntimeForHost } from './initial-runtime-plan.mjs';
 
 const local = {
   localUiUrl: 'openchamber-ui://app/index.html',
@@ -72,5 +72,65 @@ describe('initial runtime plan', () => {
       relayHostId: '',
       probeRemote: false,
     });
+  });
+
+  test('keeps mixed direct and relay host data in one runtime plan', () => {
+    expect(planRuntimeForHost({
+      ...local,
+      hostId: 'mixed',
+      hosts: [{
+        id: 'mixed',
+        url: 'https://ui.example',
+        apiUrl: 'https://api.example',
+        clientToken: 'remote-token',
+        requestHeaders: { 'CF-Access-Client-Id': 'client-id' },
+        relay: { serverId: 'server' },
+      }],
+    })).toEqual({
+      initialUrl: local.localUiUrl,
+      apiBaseUrl: 'https://api.example',
+      clientToken: 'remote-token',
+      requestHeaders: { 'CF-Access-Client-Id': 'client-id' },
+      relayHostId: 'mixed',
+      probeRemote: true,
+    });
+  });
+
+  test('uses remote UI for direct hosts only when requested by development mode', () => {
+    const host = { id: 'direct', url: 'https://ui.example', apiUrl: 'https://api.example' };
+    expect(planRuntimeForHost({ ...local, hostId: host.id, hosts: [host], useRemoteUi: true })?.initialUrl).toBe('https://ui.example');
+    expect(planRuntimeForHost({ ...local, hostId: host.id, hosts: [host], useRemoteUi: false })?.initialUrl).toBe(local.localUiUrl);
+  });
+
+  test('plans local, relay-only, and direct-E2EE-only hosts without remote UI navigation', () => {
+    const relay = { id: 'relay', url: 'relay://server', relay: { serverId: 'server' } };
+    const directE2ee = { id: 'e2ee', url: 'direct-e2ee://server', directE2ee: { wssUrl: 'wss://server/ws' } };
+    expect(planRuntimeForHost({ ...local, hostId: 'local', hosts: [] })).toEqual({
+      initialUrl: local.localUiUrl,
+      apiBaseUrl: local.localUrl,
+      clientToken: local.localClientToken,
+      requestHeaders: {},
+      relayHostId: '',
+      probeRemote: false,
+    });
+    expect(planRuntimeForHost({ ...local, hostId: relay.id, hosts: [relay], useRemoteUi: true })).toMatchObject({
+      initialUrl: local.localUiUrl,
+      apiBaseUrl: local.localUrl,
+      clientToken: local.localClientToken,
+      relayHostId: relay.id,
+      probeRemote: false,
+    });
+    expect(planRuntimeForHost({ ...local, hostId: directE2ee.id, hosts: [directE2ee], useRemoteUi: true })).toMatchObject({
+      initialUrl: local.localUiUrl,
+      apiBaseUrl: local.localUrl,
+      clientToken: local.localClientToken,
+      relayHostId: directE2ee.id,
+      probeRemote: false,
+    });
+  });
+
+  test('returns null for missing or invalid hosts', () => {
+    expect(planRuntimeForHost({ ...local, hostId: 'missing', hosts: [] })).toBeNull();
+    expect(planRuntimeForHost({ ...local, hostId: 'invalid', hosts: [{ id: 'invalid', url: 'relay://missing-descriptor' }] })).toBeNull();
   });
 });

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -22,7 +22,7 @@ import { writeSecureAtomicJson } from './secure-json-file.mjs';
 import { buildDesktopAdditionalArguments, buildRuntimeBootMetadataScript, isRuntimeBootstrapSenderAllowed, resolveRuntimeBootstrap } from './runtime-bootstrap.mjs';
 import { resolveDesktopHostsForSender } from './host-public-config.mjs';
 import { decidePairingV2DeepLink } from './pairing-deep-link.mjs';
-import { planInitialRuntime } from './initial-runtime-plan.mjs';
+import { planInitialRuntime, planRuntimeForHost } from './initial-runtime-plan.mjs';
 import { mintOutsideFileGrant } from '@openchamber/web/server/lib/fs/routes.js';
 
 const execFileAsync = promisify(execFile);
@@ -1866,35 +1866,29 @@ const switchToHostById = async (rawId) => {
   const id = typeof rawId === 'string' ? rawId.trim() : '';
   if (!id) return;
   const config = readDesktopHostsConfig();
-  let targetUrl = null;
-  let apiBaseUrl = null;
-  let clientToken = '';
-  let requestHeaders = {};
-  if (id === LOCAL_HOST_ID) {
-    targetUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
-    apiBaseUrl = state.sidecarUrl;
-    clientToken = readDesktopLocalClientToken();
-    requestHeaders = {};
-  } else {
-    const host = config.hosts.find((entry) => entry.id === id);
-    if (!host) {
-      log.warn('[electron] deep-link host not found:', id);
-      return;
-    }
-    targetUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : host.url;
-    apiBaseUrl = host.apiUrl || host.url;
-    clientToken = host.clientToken || '';
-    requestHeaders = sanitizeRuntimeRequestHeaders(host.requestHeaders || {});
-  }
-  if (!targetUrl || !apiBaseUrl) {
+  const localUiUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
+  const plan = planRuntimeForHost({
+    hostId: id,
+    hosts: config.hosts,
+    localUiUrl,
+    localUrl: state.sidecarUrl || state.localOrigin,
+    localClientToken: readDesktopLocalClientToken(),
+    useRemoteUi: !shouldUsePackagedUi(),
+  });
+  if (!plan?.initialUrl || !plan.apiBaseUrl) {
     log.warn('[electron] deep-link host has no target URL:', id);
     return;
   }
   const bootOutcome = id === LOCAL_HOST_ID
     ? { target: 'local', status: 'ok' }
-    : { target: 'remote', status: 'ok', hostId: id, url: apiBaseUrl };
+    : { target: 'remote', status: 'ok', hostId: id, url: plan.apiBaseUrl };
   log.info('[electron] switching to host', { id, bootOutcome });
-  await activateMainWindow(targetUrl, state.localOrigin, bootOutcome, { apiBaseUrl, clientToken, requestHeaders });
+  await activateMainWindow(plan.initialUrl, state.localOrigin, bootOutcome, {
+    apiBaseUrl: plan.apiBaseUrl,
+    clientToken: plan.clientToken,
+    requestHeaders: plan.requestHeaders,
+    relayHostId: plan.relayHostId,
+  });
 };
 
 const confirmConnectDeepLink = async (payload) => {
@@ -3948,36 +3942,22 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       // tunnel fallback) via the injected relay host id — a fixed apiBaseUrl
       // would strand the window when the direct leg is unreachable.
       const hostId = typeof args.hostId === 'string' ? args.hostId.trim() : '';
-      if (hostId === LOCAL_HOST_ID) {
-        const localUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
-        if (!localUrl) throw new Error('Local UI is not available');
-        await createAdditionalWindow(localUrl, {
-          apiBaseUrl: state.sidecarUrl || state.localOrigin || '',
-          clientToken: readDesktopLocalClientToken(),
-          requestHeaders: {},
-        });
-        return null;
-      }
       const config = readDesktopHostsConfig();
-      const host = config.hosts.find((entry) => entry.id === hostId);
-      if (!host) throw new Error('Host not found');
-       if (host.relay || host.directE2ee) {
-        const windowUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
-        await createAdditionalWindow(windowUrl, {
-          apiBaseUrl: '',
-          clientToken: host.clientToken || '',
-          requestHeaders: sanitizeRuntimeRequestHeaders(host.requestHeaders || {}),
-          relayHostId: host.id,
-        });
-        return null;
-      }
-      const targetUrl = normalizeHostUrl(host.apiUrl || host.url);
-      if (!targetUrl) throw new Error('Invalid URL');
-      const windowUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : targetUrl;
-      await createAdditionalWindow(windowUrl, {
-        apiBaseUrl: targetUrl,
-        clientToken: host.clientToken || '',
-        requestHeaders: sanitizeRuntimeRequestHeaders(host.requestHeaders || {}),
+      const localUiUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
+      const plan = planRuntimeForHost({
+        hostId,
+        hosts: config.hosts,
+        localUiUrl,
+        localUrl: state.sidecarUrl || state.localOrigin,
+        localClientToken: readDesktopLocalClientToken(),
+        useRemoteUi: !shouldUsePackagedUi(),
+      });
+      if (!plan?.initialUrl || !plan.apiBaseUrl) throw new Error(hostId === LOCAL_HOST_ID ? 'Local UI is not available' : 'Host not found');
+      await createAdditionalWindow(plan.initialUrl, {
+        apiBaseUrl: plan.apiBaseUrl,
+        clientToken: plan.clientToken,
+        requestHeaders: plan.requestHeaders,
+        relayHostId: plan.relayHostId,
       });
       return null;
     }

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -22,6 +22,7 @@ import { writeSecureAtomicJson } from './secure-json-file.mjs';
 import { buildDesktopAdditionalArguments, buildRuntimeBootMetadataScript, isRuntimeBootstrapSenderAllowed, resolveRuntimeBootstrap } from './runtime-bootstrap.mjs';
 import { resolveDesktopHostsForSender } from './host-public-config.mjs';
 import { decidePairingV2DeepLink } from './pairing-deep-link.mjs';
+import { planInitialRuntime } from './initial-runtime-plan.mjs';
 import { mintOutsideFileGrant } from '@openchamber/web/server/lib/fs/routes.js';
 
 const execFileAsync = promisify(execFile);
@@ -2162,6 +2163,7 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
     apiBaseUrl: desktopApiBaseUrl,
     clientToken: desktopClientToken,
     requestHeaders: desktopRequestHeaders,
+    relayHostId: rendererRuntimeConfig.relayHostId || '',
     homeDirectory: desktopHome,
   };
   browserWindow.__ocInitScript = buildInitScript(state.bootOutcome);
@@ -2401,8 +2403,8 @@ const activateMainWindow = async (url, localOrigin, bootOutcome, runtimeConfig =
 
 const openMainWindow = async () => {
   if (!state.localOrigin) {
-    const { initialUrl, localOrigin, bootOutcome, apiBaseUrl, clientToken, requestHeaders } = await resolveInitialUrl();
-    return activateMainWindow(initialUrl, localOrigin, bootOutcome, { apiBaseUrl, clientToken, requestHeaders });
+    const { initialUrl, localOrigin, bootOutcome, apiBaseUrl, clientToken, requestHeaders, relayHostId } = await resolveInitialUrl();
+    return activateMainWindow(initialUrl, localOrigin, bootOutcome, { apiBaseUrl, clientToken, requestHeaders, relayHostId });
   }
 
   const config = readDesktopHostsConfig();
@@ -2666,30 +2668,22 @@ const resolveInitialUrl = async () => {
   const localAvailable = Boolean(localUrl);
 
   const localOrigin = new URL(localUrl).origin;
-  let initialUrl = localUiUrl;
-  let apiBaseUrl = localUrl;
-  let clientToken = readDesktopLocalClientToken();
-  let requestHeaders = {};
   let remoteProbe = null;
 
   const envTarget = normalizeHostUrl(process.env.OPENCHAMBER_SERVER_URL || '');
   const config = readDesktopHostsConfig();
-  if (envTarget) {
-    apiBaseUrl = envTarget;
-    clientToken = '';
-    requestHeaders = {};
-    initialUrl = shouldUsePackagedUi() ? localUiUrl : envTarget;
-  } else if (config.defaultHostId && config.defaultHostId !== LOCAL_HOST_ID) {
-    const host = config.hosts.find((entry) => entry.id === config.defaultHostId);
-    if (host?.url) {
-      apiBaseUrl = host.apiUrl || host.url;
-      clientToken = host.clientToken || '';
-      requestHeaders = sanitizeRuntimeRequestHeaders(host.requestHeaders || {});
-      initialUrl = shouldUsePackagedUi() ? localUiUrl : host.url;
-    }
-  }
+  const initialPlan = planInitialRuntime({
+    envTarget,
+    defaultHostId: config.defaultHostId,
+    hosts: config.hosts,
+    localUiUrl,
+    localUrl,
+    localClientToken: readDesktopLocalClientToken(),
+    useRemoteUi: !shouldUsePackagedUi(),
+  });
+  let { initialUrl, apiBaseUrl, clientToken, requestHeaders, relayHostId } = initialPlan;
 
-  if (apiBaseUrl && apiBaseUrl !== localUrl) {
+  if (initialPlan.probeRemote && apiBaseUrl && apiBaseUrl !== localUrl) {
     remoteProbe = await probeHostWithTimeout(apiBaseUrl, 2_000, clientToken, requestHeaders);
     if (remoteProbe.status === 'unreachable') {
       remoteProbe = await probeHostWithTimeout(apiBaseUrl, 10_000, clientToken, requestHeaders);
@@ -2710,7 +2704,7 @@ const resolveInitialUrl = async () => {
     localAvailable,
   });
 
-  return { initialUrl, localOrigin, localUiUrl, bootOutcome, apiBaseUrl, clientToken, requestHeaders };
+  return { initialUrl, localOrigin, localUiUrl, bootOutcome, apiBaseUrl, clientToken, requestHeaders, relayHostId };
 };
 
 const compareSemver = (left, right) => {
@@ -4842,8 +4836,8 @@ app.whenReady().then(async () => {
   const initial = extractInitialDeepLinks();
   if (initial.length > 0) handleDeepLinks(initial);
 
-  const { initialUrl, localOrigin, bootOutcome, apiBaseUrl, clientToken, requestHeaders } = await resolveInitialUrl();
-  await activateMainWindow(initialUrl, localOrigin, bootOutcome, { apiBaseUrl, clientToken, requestHeaders });
+  const { initialUrl, localOrigin, bootOutcome, apiBaseUrl, clientToken, requestHeaders, relayHostId } = await resolveInitialUrl();
+  await activateMainWindow(initialUrl, localOrigin, bootOutcome, { apiBaseUrl, clientToken, requestHeaders, relayHostId });
 
   // Notify renderer on OS wake-from-sleep so the SSE event pipeline can
   // reconnect immediately instead of waiting for the heartbeat watchdog.

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -19,7 +19,7 @@ import { checkForDesktopUpdate } from './updater-check.mjs';
 import { resolveUpdaterFeed } from './updater-feed.mjs';
 import { buildStoredHostEntry as sanitizeStoredHostEntry } from './host-storage-sanitizer.mjs';
 import { writeSecureAtomicJson } from './secure-json-file.mjs';
-import { buildDesktopAdditionalArguments, resolveRuntimeBootstrap } from './runtime-bootstrap.mjs';
+import { buildDesktopAdditionalArguments, buildRuntimeBootMetadataScript, isRuntimeBootstrapSenderAllowed, resolveRuntimeBootstrap } from './runtime-bootstrap.mjs';
 import { resolveDesktopHostsForSender } from './host-public-config.mjs';
 import { decidePairingV2DeepLink } from './pairing-deep-link.mjs';
 import { mintOutsideFileGrant } from '@openchamber/web/server/lib/fs/routes.js';
@@ -999,15 +999,6 @@ const shouldUsePackagedUi = () => {
 const packagedUiOrigin = () => `${UI_PROTOCOL}://app`;
 const buildPackagedUiUrl = (pathname = '/index.html') => new URL(pathname, `${packagedUiOrigin()}/`).toString();
 
-const injectRuntimeConfigIntoHtml = (html) => {
-  const apiBaseUrl = state.apiBaseUrl || state.sidecarUrl || '';
-  const localOrigin = state.localOrigin || state.sidecarUrl || '';
-  const initScript = `<script>if(window.__OPENCHAMBER_LOCAL_ORIGIN__===undefined){window.__OPENCHAMBER_LOCAL_ORIGIN__=${JSON.stringify(localOrigin)};}if(window.__OPENCHAMBER_API_BASE_URL__===undefined){window.__OPENCHAMBER_API_BASE_URL__=${JSON.stringify(apiBaseUrl)};}if(window.__OPENCHAMBER_CLIENT_TOKEN__===undefined&&${JSON.stringify(state.clientToken || '')}){window.__OPENCHAMBER_CLIENT_TOKEN__=${JSON.stringify(state.clientToken || '')};}</script>`;
-  if (html.includes('<head>')) return html.replace('<head>', `<head>${initScript}`);
-  if (html.includes('</head>')) return html.replace('</head>', `${initScript}</head>`);
-  return `${initScript}${html}`;
-};
-
 const registerPackagedUiProtocol = () => {
   if (!shouldUsePackagedUi()) return;
   protocol.handle(UI_PROTOCOL, async (request) => {
@@ -1029,8 +1020,7 @@ const registerPackagedUiProtocol = () => {
       if (info.isFile()) {
         if (filePath.endsWith('.html')) {
           const html = await fsp.readFile(filePath, 'utf8');
-          const body = injectRuntimeConfigIntoHtml(html);
-          return new Response(body, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+          return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
         }
         return electronNet.fetch(pathToFileURL(filePath).toString());
       }
@@ -1038,8 +1028,7 @@ const registerPackagedUiProtocol = () => {
     }
     const indexPath = path.join(distPath, 'index.html');
     const html = await fsp.readFile(indexPath, 'utf8');
-    const body = injectRuntimeConfigIntoHtml(html);
-    return new Response(body, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+    return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
   });
 };
 
@@ -1475,21 +1464,10 @@ const macosMajorVersion = () => {
   return major === 10 ? minor : major;
 };
 
-const buildInitScript = (localOrigin, bootOutcome, apiBaseUrl = '', clientToken = '', requestHeaders = {}) => {
-  const home = JSON.stringify(os.homedir() || '');
-  const local = JSON.stringify(localOrigin || '');
-  const apiBase = JSON.stringify(apiBaseUrl || '');
-  const token = JSON.stringify(clientToken || '');
-  const headers = JSON.stringify(sanitizeRuntimeRequestHeaders(requestHeaders));
-  const packagedOrigin = JSON.stringify(packagedUiOrigin());
-  const macVersion = macosMajorVersion();
-  const outcome = JSON.stringify(bootOutcome ?? null);
-  return [
-    '(function(){',
-    `try{var __oc_local=${local};var __oc_api=${apiBase};var __oc_headers=${headers};var __oc_packaged=${packagedOrigin};var __oc_origin=window.location&&window.location.origin||'';var __oc_is_packaged=__oc_origin===__oc_packaged;var __oc_is_local=__oc_local&&__oc_origin===new URL(__oc_local).origin;window.__OPENCHAMBER_MACOS_MAJOR__=${macVersion};window.__OPENCHAMBER_LOCAL_ORIGIN__=__oc_local;window.__OPENCHAMBER_API_BASE_URL__=__oc_api;if(__oc_is_local||__oc_is_packaged){window.__OPENCHAMBER_HOME__=${home};window.__OPENCHAMBER_RUNTIME_HEADERS__=__oc_headers;}if((__oc_is_local||__oc_is_packaged)&&${token}){window.__OPENCHAMBER_CLIENT_TOKEN__=${token};}var __oc_bo=${outcome};if(__oc_bo){window.__OPENCHAMBER_DESKTOP_BOOT_OUTCOME__=__oc_bo;}}catch(_e){}`,
-    '}())',
-  ].join('');
-};
+const buildInitScript = (bootOutcome) => buildRuntimeBootMetadataScript({
+  macosMajor: macosMajorVersion(),
+  bootOutcome,
+});
 
 const computeBootOutcome = ({ envTargetUrl, probe, config, localAvailable }) => {
   if (envTargetUrl) {
@@ -2161,7 +2139,6 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
     webPreferences: {
       additionalArguments: buildDesktopAdditionalArguments({
         localOrigin: desktopLocalOrigin,
-        homeDirectory: desktopHome,
         macosMajor: desktopMacosMajor,
         macVibrancy: useVibrancy,
         bootOutcome: state.bootOutcome || null,
@@ -2185,9 +2162,9 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
     apiBaseUrl: desktopApiBaseUrl,
     clientToken: desktopClientToken,
     requestHeaders: desktopRequestHeaders,
-    relayHostId: rendererRuntimeConfig.relayHostId || '',
+    homeDirectory: desktopHome,
   };
-  browserWindow.__ocInitScript = buildInitScript(desktopLocalOrigin, state.bootOutcome, desktopApiBaseUrl, desktopClientToken, desktopRequestHeaders);
+  browserWindow.__ocInitScript = buildInitScript(state.bootOutcome);
   browserWindow.__ocTitleBarOverlayEnabled = titleBarOverlayEnabled;
 
   if (useSaved && saved.maximized) {
@@ -2349,6 +2326,10 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
   });
 
   browserWindow.webContents.on('dom-ready', () => {
+    if (!isRuntimeBootstrapSenderAllowed(browserWindow.webContents.getURL(), {
+      localOrigin: state.localOrigin,
+      sidecarUrl: state.sidecarUrl,
+    })) return;
     const initScript = browserWindow.__ocInitScript || state.initScript;
     if (initScript) {
       void browserWindow.webContents.executeJavaScript(initScript).catch(() => {});
@@ -2394,17 +2375,14 @@ const activateMainWindow = async (url, localOrigin, bootOutcome, runtimeConfig =
     requestHeaders: state.requestHeaders || {},
     relayHostId: typeof runtimeConfig.relayHostId === 'string' ? runtimeConfig.relayHostId : '',
   });
-  state.initScript = buildInitScript(
-    localOrigin,
-    state.bootOutcome,
-    rendererRuntimeConfig.apiBaseUrl,
-    rendererRuntimeConfig.clientToken,
-    rendererRuntimeConfig.requestHeaders,
-  );
+  state.initScript = buildInitScript(state.bootOutcome);
 
   const mainWindow = state.mainWindow;
   if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.__ocRuntimeConfig = rendererRuntimeConfig;
+    mainWindow.__ocRuntimeConfig = {
+      ...rendererRuntimeConfig,
+      homeDirectory: os.homedir() || '',
+    };
     mainWindow.__ocInitScript = state.initScript;
     await navigateWindow(mainWindow, url, { allowAbort: true });
     mainWindow.show();
@@ -2525,9 +2503,6 @@ const createMiniChatWindow = async ({ mode, sessionId = '', directory = '', proj
   }
 
   const desktopLocalOrigin = state.localOrigin || '';
-  const desktopApiBaseUrl = effectiveRuntimeConfig.apiBaseUrl || '';
-  const desktopClientToken = effectiveRuntimeConfig.clientToken || '';
-  const desktopRequestHeaders = effectiveRuntimeConfig.requestHeaders || {};
   const desktopHome = os.homedir() || '';
   const desktopMacosMajor = String(macosMajorVersion());
   const usesFramelessChrome = process.platform === 'win32' || process.platform === 'linux';
@@ -2553,7 +2528,6 @@ const createMiniChatWindow = async ({ mode, sessionId = '', directory = '', proj
     webPreferences: {
       additionalArguments: buildDesktopAdditionalArguments({
         localOrigin: desktopLocalOrigin,
-        homeDirectory: desktopHome,
         macosMajor: desktopMacosMajor,
       }),
       preload: isDev ? path.join(__dirname, 'preload.mjs') : path.join(app.getAppPath(), 'preload.mjs'),
@@ -2566,8 +2540,11 @@ const createMiniChatWindow = async ({ mode, sessionId = '', directory = '', proj
     },
   });
   browserWindow.__ocLabel = nextWindowLabel();
-  browserWindow.__ocRuntimeConfig = effectiveRuntimeConfig;
-  browserWindow.__ocInitScript = buildInitScript(desktopLocalOrigin, state.bootOutcome, desktopApiBaseUrl, desktopClientToken, desktopRequestHeaders);
+  browserWindow.__ocRuntimeConfig = {
+    ...effectiveRuntimeConfig,
+    homeDirectory: desktopHome,
+  };
+  browserWindow.__ocInitScript = buildInitScript(state.bootOutcome);
   browserWindow.__ocMiniChat = true;
   browserWindow.__ocMiniChatSessionId = sessionWindowKey;
   browserWindow.__ocPinned = false;
@@ -2621,6 +2598,10 @@ const createMiniChatWindow = async ({ mode, sessionId = '', directory = '', proj
     void shell.openExternal(url).catch(() => {});
   });
   browserWindow.webContents.on('dom-ready', () => {
+    if (!isRuntimeBootstrapSenderAllowed(browserWindow.webContents.getURL(), {
+      localOrigin: state.localOrigin,
+      sidecarUrl: state.sidecarUrl,
+    })) return;
     const initScript = browserWindow.__ocInitScript || state.initScript;
     if (initScript) {
       void browserWindow.webContents.executeJavaScript(initScript).catch(() => {});
@@ -3748,7 +3729,7 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
         config: updatedConfig,
         localAvailable: Boolean(state.sidecarUrl || state.localOrigin),
       });
-      state.initScript = buildInitScript(state.localOrigin, state.bootOutcome, state.apiBaseUrl, state.clientToken, state.requestHeaders || {});
+      state.initScript = buildInitScript(state.bootOutcome);
       log.info('[electron] hosts config updated, recomputed bootOutcome', state.bootOutcome);
       return null;
     }
@@ -4847,7 +4828,7 @@ app.whenReady().then(async () => {
     state.localOrigin = localOrigin;
     state.bootOutcome = bootOutcome ?? null;
     state.requestHeaders = sanitizeRuntimeRequestHeaders(requestHeaders || {});
-    state.initScript = buildInitScript(localOrigin, state.bootOutcome, '', '', state.requestHeaders);
+    state.initScript = buildInitScript(state.bootOutcome);
     log.info('[electron] started in background without window');
     return;
   }

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -17,6 +17,11 @@ import { sanitizeRuntimeRequestHeaders } from './runtime-request-headers.mjs';
 import { assertUpdaterCapability } from './updater-capability.mjs';
 import { checkForDesktopUpdate } from './updater-check.mjs';
 import { resolveUpdaterFeed } from './updater-feed.mjs';
+import { buildStoredHostEntry as sanitizeStoredHostEntry } from './host-storage-sanitizer.mjs';
+import { writeSecureAtomicJson } from './secure-json-file.mjs';
+import { buildDesktopAdditionalArguments, resolveRuntimeBootstrap } from './runtime-bootstrap.mjs';
+import { resolveDesktopHostsForSender } from './host-public-config.mjs';
+import { decidePairingV2DeepLink } from './pairing-deep-link.mjs';
 import { mintOutsideFileGrant } from '@openchamber/web/server/lib/fs/routes.js';
 
 const execFileAsync = promisify(execFile);
@@ -490,12 +495,8 @@ const readJsonFile = (filePath) => {
 };
 
 const writeJsonFile = async (filePath, data) => {
-  await fsp.mkdir(path.dirname(filePath), { recursive: true });
-  // Atomic: write to a temp file then rename. Readers never see a partial
-  // JSON file that could parse-error and get coerced to {}.
-  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  await fsp.writeFile(tmp, JSON.stringify(data, null, 2));
-  await fsp.rename(tmp, filePath);
+  const isDefaultSettingsFile = !process.env.OPENCHAMBER_DATA_DIR && filePath === settingsFilePath();
+  await writeSecureAtomicJson(filePath, data, { privateDirectory: isDefaultSettingsFile });
 };
 
 const readSettingsRoot = () => {
@@ -645,54 +646,18 @@ const isLocalRuntimeUrl = (targetUrl) => {
   }
 };
 
-// A relay host is reached over the E2EE tunnel: it has no http(s) apiUrl, only a
-// { relayUrl (ws/wss), serverId, hostEncPubJwk } descriptor. The relay grant is a
-// one-time pairing artifact and is never persisted.
-const sanitizeHostRelayForStorage = (value) => {
-  if (!value || typeof value !== 'object') return null;
-  const relayUrl = typeof value.relayUrl === 'string' ? value.relayUrl.trim() : '';
-  const serverId = typeof value.serverId === 'string' ? value.serverId.trim() : '';
-  const jwk = value.hostEncPubJwk;
-  if (!relayUrl || !serverId || !jwk || typeof jwk !== 'object' || Array.isArray(jwk)) return null;
-  // Minimal EC public JWK shape check so a malformed descriptor is rejected at
-  // storage time instead of surfacing later as a tunnel handshake failure.
-  if (typeof jwk.kty !== 'string' || typeof jwk.crv !== 'string' || typeof jwk.x !== 'string') return null;
-  try {
-    const parsed = new URL(relayUrl);
-    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') return null;
-  } catch {
-    return null;
-  }
-  return { relayUrl, serverId, hostEncPubJwk: jwk };
-};
-
 // Shared storage shape for a persisted host. A host may carry a direct HTTP
 // transport, a relay transport, or BOTH (a multi-transport device: direct on
 // the home network, relay away — mirrors the mobile connection model). Returns
 // null for entries that can't be stored (missing id, reserved 'local', or no
 // usable transport at all).
 const buildStoredHostEntry = (entry) => {
-  const id = typeof entry?.id === 'string' ? entry.id.trim() : '';
-  if (!id || id === LOCAL_HOST_ID) return null;
-  const clientToken = sanitizeClientTokenForStorage(entry?.clientToken);
-  const requestHeaders = sanitizeRuntimeRequestHeaders(entry?.requestHeaders);
-  const headerFields = Object.keys(requestHeaders).length > 0 ? { requestHeaders } : {};
-  const tokenField = clientToken ? { clientToken } : {};
-  const labelRaw = typeof entry?.label === 'string' && entry.label.trim() ? entry.label.trim() : '';
-
-  const relay = sanitizeHostRelayForStorage(entry?.relay);
-  const relayField = relay ? { relay } : {};
-  const directUrl = sanitizeHostUrlForStorage(entry?.url);
-  const apiUrl = directUrl ? (sanitizeHostUrlForStorage(entry?.apiUrl) || directUrl) : null;
-
-  if (directUrl) {
-    return { id, label: labelRaw || directUrl, url: directUrl, apiUrl, ...tokenField, ...headerFields, ...relayField };
-  }
-  if (relay) {
-    const url = `relay://${relay.serverId}`;
-    return { id, label: labelRaw || url, url, ...tokenField, ...headerFields, relay };
-  }
-  return null;
+  return sanitizeStoredHostEntry(entry, {
+    localHostId: LOCAL_HOST_ID,
+    sanitizeHostUrl: sanitizeHostUrlForStorage,
+    sanitizeClientToken: sanitizeClientTokenForStorage,
+    sanitizeRequestHeaders: sanitizeRuntimeRequestHeaders,
+  });
 };
 
 const readDesktopHostsConfig = () => {
@@ -1837,58 +1802,6 @@ const parseDeepLink = (raw) => {
   }
 };
 
-const decodeBase64UrlJson = (value) => {
-  if (typeof value !== 'string' || !value.trim()) return null;
-  try {
-    const json = Buffer.from(value.trim(), 'base64url').toString('utf8');
-    return JSON.parse(json);
-  } catch {
-    return null;
-  }
-};
-
-const parseConnectPairingDeepLinkPayload = (raw) => {
-  if (typeof raw !== 'string') return null;
-  try {
-    const url = new URL(raw.trim());
-    if (url.protocol !== `${DEEP_LINK_PROTOCOL}:` || url.hostname !== 'connect') return null;
-    if (url.searchParams.get('v') !== '2') return null;
-    const payload = decodeBase64UrlJson(url.searchParams.get('p') || '');
-    if (!payload || payload.v !== 2 || typeof payload !== 'object') return null;
-    const pairingId = typeof payload.pairingId === 'string' ? payload.pairingId.trim() : '';
-    const secret = typeof payload.secret === 'string' ? payload.secret.trim() : '';
-    if (!pairingId || !secret) return null;
-    const candidates = Array.isArray(payload.candidates)
-      ? payload.candidates.flatMap((candidate) => {
-        if (!candidate || typeof candidate !== 'object') return [];
-        const type = candidate.type === 'lan' || candidate.type === 'tunnel' || candidate.type === 'relay'
-          ? candidate.type
-          : null;
-        const candidateUrl = normalizeHostUrl(candidate.url || '');
-        if (!type || !candidateUrl) return [];
-        const priority = Number.isFinite(candidate.priority) ? candidate.priority : 100;
-        return [{ type, url: candidateUrl, priority }];
-      })
-      : [];
-    if (candidates.length === 0) return null;
-    const expiresAt = typeof payload.expiresAt === 'string' ? payload.expiresAt.trim() : '';
-    if (expiresAt) {
-      const expiresTime = Date.parse(expiresAt);
-      if (!Number.isFinite(expiresTime) || expiresTime <= Date.now()) return null;
-    }
-    return {
-      pairingId,
-      secret,
-      label: typeof payload.label === 'string' && payload.label.trim() ? payload.label.trim() : 'OpenChamber',
-      fingerprint: typeof payload.fingerprint === 'string' && payload.fingerprint.trim() ? payload.fingerprint.trim() : '',
-      expiresAt: expiresAt || null,
-      candidates: candidates.sort((left, right) => left.priority - right.priority),
-    };
-  } catch {
-    return null;
-  }
-};
-
 const importConnectDeepLink = async (payload) => {
   if (!payload?.serverUrl || !payload?.token) return null;
   const serverUrl = normalizeHostUrl(payload.serverUrl);
@@ -1939,6 +1852,10 @@ const selectPairingCandidateUrl = async (payload) => {
       const health = await requestJsonWithTimeout(`${candidate.url.replace(/\/+$/g, '')}/health`, { method: 'GET' }, 3500);
       if (health.ok) return candidate.url.replace(/\/+$/g, '');
     } catch {
+      // Health check failed for this candidate; try the next one.
+      // Transient network errors, timeouts, and unreachable hosts are expected
+      // when probing multiple plain HTTP(S) candidates (deep-link payloads contain
+      // only direct HTTP/HTTPS URLs; relay and direct-E2EE candidates are rejected).
     }
   }
   return null;
@@ -2037,9 +1954,10 @@ const dispatchDeepLink = (link) => {
   if (!link) return;
   log.info('[electron] dispatching deep-link', { type: link.type, valueLen: link.value?.length || 0 });
   if (link.type === 'connect') {
-    const pairingPayload = parseConnectPairingDeepLinkPayload(link.raw);
-    if (pairingPayload) {
-      const previewUrl = pairingPayload.candidates[0]?.url || pairingPayload.label;
+    const decision = decidePairingV2DeepLink(link.raw);
+    if (decision.kind === 'accept') {
+      const pairingPayload = decision.payload;
+      const previewUrl = pairingPayload.candidates[0].url;
       void confirmConnectDeepLink({
         serverUrl: previewUrl,
         token: 'pairing-v2',
@@ -2067,7 +1985,7 @@ const dispatchDeepLink = (link) => {
       });
       return;
     }
-    log.warn('[electron] invalid connect deep-link payload');
+    log.warn(`[electron] connect pairing deep-link rejected: ${decision.reason}`);
     return;
   }
   if (link.type === 'session' && link.value) {
@@ -2241,17 +2159,13 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
     titleBarOverlay: titleBarOverlayEnabled,
     trafficLightPosition: process.platform === 'darwin' ? { x: 16, y: 17 } : undefined,
     webPreferences: {
-      additionalArguments: [
-        `--openchamber-local-origin=${desktopLocalOrigin}`,
-        `--openchamber-api-base-url=${desktopApiBaseUrl}`,
-        `--openchamber-client-token=${desktopClientToken}`,
-        `--openchamber-runtime-headers=${JSON.stringify(desktopRequestHeaders)}`,
-        `--openchamber-home=${desktopHome}`,
-        `--openchamber-macos-major=${desktopMacosMajor}`,
-        `--openchamber-mac-vibrancy=${useVibrancy ? '1' : '0'}`,
-        `--openchamber-boot-outcome=${JSON.stringify(state.bootOutcome || null)}`,
-        `--openchamber-relay-host-id=${rendererRuntimeConfig.relayHostId || ''}`,
-      ],
+      additionalArguments: buildDesktopAdditionalArguments({
+        localOrigin: desktopLocalOrigin,
+        homeDirectory: desktopHome,
+        macosMajor: desktopMacosMajor,
+        macVibrancy: useVibrancy,
+        bootOutcome: state.bootOutcome || null,
+      }),
       preload: isDev ? path.join(__dirname, 'preload.mjs') : path.join(app.getAppPath(), 'preload.mjs'),
       backgroundThrottling: false,
       contextIsolation: true,
@@ -2267,7 +2181,12 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
 
   const browserWindow = new BrowserWindow(options);
   browserWindow.__ocLabel = label || nextWindowLabel();
-  browserWindow.__ocRuntimeConfig = { apiBaseUrl: desktopApiBaseUrl, clientToken: desktopClientToken, requestHeaders: desktopRequestHeaders };
+  browserWindow.__ocRuntimeConfig = {
+    apiBaseUrl: desktopApiBaseUrl,
+    clientToken: desktopClientToken,
+    requestHeaders: desktopRequestHeaders,
+    relayHostId: rendererRuntimeConfig.relayHostId || '',
+  };
   browserWindow.__ocInitScript = buildInitScript(desktopLocalOrigin, state.bootOutcome, desktopApiBaseUrl, desktopClientToken, desktopRequestHeaders);
   browserWindow.__ocTitleBarOverlayEnabled = titleBarOverlayEnabled;
 
@@ -2473,6 +2392,7 @@ const activateMainWindow = async (url, localOrigin, bootOutcome, runtimeConfig =
     apiBaseUrl: state.apiBaseUrl || '',
     clientToken: state.clientToken || '',
     requestHeaders: state.requestHeaders || {},
+    relayHostId: typeof runtimeConfig.relayHostId === 'string' ? runtimeConfig.relayHostId : '',
   });
   state.initScript = buildInitScript(
     localOrigin,
@@ -2512,7 +2432,7 @@ const openMainWindow = async () => {
   const host = config.defaultHostId && config.defaultHostId !== LOCAL_HOST_ID
     ? config.hosts.find((entry) => entry.id === config.defaultHostId)
     : null;
-  const relayHost = host && host.relay && typeof host.relay === 'object' ? host : null;
+  const relayHost = host && ((host.relay && typeof host.relay === 'object') || (host.directE2ee && typeof host.directE2ee === 'object')) ? host : null;
   if (relayHost) {
     // Relay hosts have no reachable HTTP base. Boot the LOCAL UI with the local
     // runtime; the renderer re-opens the E2EE tunnel on startup by reading the
@@ -2524,6 +2444,7 @@ const openMainWindow = async () => {
       apiBaseUrl: localApiBaseUrl,
       clientToken: localToken,
       requestHeaders: {},
+      relayHostId: relayHost.id,
     });
   }
   const apiBaseUrl = host?.apiUrl || host?.url || state.sidecarUrl || state.apiBaseUrl || '';
@@ -2572,6 +2493,7 @@ const getWindowRuntimeConfig = (browserWindow) => {
     apiBaseUrl: state.apiBaseUrl || state.localOrigin || state.sidecarUrl || '',
     clientToken: state.clientToken || '',
     requestHeaders: state.requestHeaders || {},
+    relayHostId: '',
   };
   if (!browserWindow || browserWindow.isDestroyed()) return fallback;
   const config = browserWindow.__ocRuntimeConfig;
@@ -2579,6 +2501,7 @@ const getWindowRuntimeConfig = (browserWindow) => {
     apiBaseUrl: typeof config?.apiBaseUrl === 'string' ? config.apiBaseUrl : fallback.apiBaseUrl,
     clientToken: typeof config?.clientToken === 'string' ? config.clientToken : fallback.clientToken,
     requestHeaders: sanitizeRuntimeRequestHeaders(config?.requestHeaders || fallback.requestHeaders),
+    relayHostId: typeof config?.relayHostId === 'string' ? config.relayHostId : fallback.relayHostId,
   };
 };
 
@@ -2587,6 +2510,7 @@ const createMiniChatWindow = async ({ mode, sessionId = '', directory = '', proj
     apiBaseUrl: normalizeHostUrl(runtimeConfig.apiBaseUrl || state.apiBaseUrl || state.localOrigin || state.sidecarUrl || ''),
     clientToken: sanitizeClientTokenForStorage(runtimeConfig.clientToken || state.clientToken || ''),
     requestHeaders: sanitizeRuntimeRequestHeaders(runtimeConfig.requestHeaders || state.requestHeaders || {}),
+    relayHostId: typeof runtimeConfig.relayHostId === 'string' ? runtimeConfig.relayHostId : '',
   };
   const sessionWindowKey = mode === 'session' && sessionId ? miniChatSessionWindowKey(effectiveRuntimeConfig, sessionId) : '';
   if (mode === 'session' && sessionId) {
@@ -2627,14 +2551,11 @@ const createMiniChatWindow = async ({ mode, sessionId = '', directory = '', proj
     titleBarStyle: process.platform === 'darwin' || usesFramelessChrome ? 'hidden' : 'default',
     trafficLightPosition: process.platform === 'darwin' ? { x: 16, y: 17 } : undefined,
     webPreferences: {
-      additionalArguments: [
-        `--openchamber-local-origin=${desktopLocalOrigin}`,
-        `--openchamber-api-base-url=${desktopApiBaseUrl}`,
-        `--openchamber-client-token=${desktopClientToken}`,
-        `--openchamber-runtime-headers=${JSON.stringify(desktopRequestHeaders)}`,
-        `--openchamber-home=${desktopHome}`,
-        `--openchamber-macos-major=${desktopMacosMajor}`,
-      ],
+      additionalArguments: buildDesktopAdditionalArguments({
+        localOrigin: desktopLocalOrigin,
+        homeDirectory: desktopHome,
+        macosMajor: desktopMacosMajor,
+      }),
       preload: isDev ? path.join(__dirname, 'preload.mjs') : path.join(app.getAppPath(), 'preload.mjs'),
       backgroundThrottling: false,
       contextIsolation: true,
@@ -4052,10 +3973,20 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       // tunnel fallback) via the injected relay host id — a fixed apiBaseUrl
       // would strand the window when the direct leg is unreachable.
       const hostId = typeof args.hostId === 'string' ? args.hostId.trim() : '';
+      if (hostId === LOCAL_HOST_ID) {
+        const localUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
+        if (!localUrl) throw new Error('Local UI is not available');
+        await createAdditionalWindow(localUrl, {
+          apiBaseUrl: state.sidecarUrl || state.localOrigin || '',
+          clientToken: readDesktopLocalClientToken(),
+          requestHeaders: {},
+        });
+        return null;
+      }
       const config = readDesktopHostsConfig();
       const host = config.hosts.find((entry) => entry.id === hostId);
       if (!host) throw new Error('Host not found');
-      if (host.relay) {
+       if (host.relay || host.directE2ee) {
         const windowUrl = shouldUsePackagedUi() ? buildPackagedUiUrl('/index.html') : (state.sidecarUrl || state.localOrigin);
         await createAdditionalWindow(windowUrl, {
           apiBaseUrl: '',
@@ -4476,7 +4407,9 @@ app.on('web-contents-created', (_event, contents) => {
 //
 // Strategy: commands fall into two buckets by capability, not by origin.
 // Window/host-switcher operations (probe a URL, open a new window, set
-// title, read the hosts list) are safe for any renderer. Filesystem,
+// title, read a credential-free hosts list) are safe for any renderer. Local
+// pages receive the full host config; remote pages receive only display-safe
+// metadata and public transport descriptors selected by main. Filesystem,
 // shell.openPath, installed-app scans, app relaunch, and file dialogs
 // are gated to local senders — even the user's own remote UI shouldn't
 // need them, and a compromised remote can't use them either.
@@ -4528,12 +4461,35 @@ const COMMANDS_SAFE_FOR_REMOTE = new Set([
 ]);
 
 ipcMain.handle('openchamber:invoke', async (event, command, args) => {
-  if (!isLocalSender(event.sender) && !COMMANDS_SAFE_FOR_REMOTE.has(command)) {
+  const localSender = isLocalSender(event.sender);
+  if (!localSender && !COMMANDS_SAFE_FOR_REMOTE.has(command)) {
     log.warn(`[ipc] rejected ${command} from non-local origin: ${event.sender?.getURL?.() || '(unknown)'}`);
     throw new Error('IPC not available for this origin');
   }
   const browserWindow = BrowserWindow.fromWebContents(event.sender);
+  if (command === 'desktop_hosts_get') {
+    const fullConfig = {
+      ...readDesktopHostsConfig(),
+      localOrigin: state.localOrigin || state.sidecarUrl || null,
+    };
+    return resolveDesktopHostsForSender(event.sender?.getURL?.() || '', fullConfig, {
+      localOrigin: state.localOrigin,
+      sidecarUrl: state.sidecarUrl,
+    });
+  }
   return handleInvoke(browserWindow, command, args);
+});
+
+// Synchronous by design: preload runs at document start and the web runtime
+// reads these globals during module initialization. Main chooses both the
+// sender and its BrowserWindow config; the renderer supplies no target.
+ipcMain.on('openchamber:runtime-bootstrap', (event) => {
+  const browserWindow = BrowserWindow.fromWebContents(event.sender);
+  const config = browserWindow && !browserWindow.isDestroyed() ? browserWindow.__ocRuntimeConfig : null;
+  event.returnValue = resolveRuntimeBootstrap(event.sender?.getURL?.() || '', config, {
+    localOrigin: state.localOrigin,
+    sidecarUrl: state.sidecarUrl,
+  });
 });
 
 ipcMain.handle('openchamber:dialog:open', async (event, options) => {

--- a/packages/electron/pairing-deep-link.mjs
+++ b/packages/electron/pairing-deep-link.mjs
@@ -1,0 +1,52 @@
+const decodePayload = (value) => {
+  try {
+    return JSON.parse(Buffer.from(value, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+};
+
+const normalizeHttpCandidate = (candidate) => {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
+  if (candidate.type !== 'lan' && candidate.type !== 'tunnel') return null;
+  try {
+    const url = new URL(typeof candidate.url === 'string' ? candidate.url.trim() : '');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    if (url.username || url.password || url.search || url.hash) return null;
+    return { type: candidate.type, url: url.toString(), priority: Number.isFinite(candidate.priority) ? candidate.priority : 100 };
+  } catch {
+    return null;
+  }
+};
+
+export const decidePairingV2DeepLink = (raw, now = Date.now()) => {
+  try {
+    const url = new URL(typeof raw === 'string' ? raw.trim() : '');
+    if (url.protocol !== 'openchamber:' || url.hostname !== 'connect' || url.searchParams.get('v') !== '2') return { kind: 'reject', reason: 'invalid' };
+    const payload = decodePayload(url.searchParams.get('p') || '');
+    if (!payload || payload.v !== 2 || typeof payload !== 'object' || Array.isArray(payload)) return { kind: 'reject', reason: 'invalid' };
+    const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+    if (candidates.some((candidate) => candidate?.type === 'direct-e2ee' || candidate?.type === 'relay')) {
+      return { kind: 'reject', reason: 'encrypted-candidate' };
+    }
+    const normalizedCandidates = candidates.map(normalizeHttpCandidate);
+    if (normalizedCandidates.length === 0 || normalizedCandidates.some((candidate) => !candidate)) return { kind: 'reject', reason: 'invalid' };
+    const pairingId = typeof payload.pairingId === 'string' ? payload.pairingId.trim() : '';
+    const secret = typeof payload.secret === 'string' ? payload.secret.trim() : '';
+    const expiresAt = typeof payload.expiresAt === 'string' ? payload.expiresAt.trim() : '';
+    if (!pairingId || !secret || (expiresAt && (!Number.isFinite(Date.parse(expiresAt)) || Date.parse(expiresAt) <= now))) return { kind: 'reject', reason: 'invalid' };
+    return {
+      kind: 'accept',
+      payload: {
+        pairingId,
+        secret,
+        label: typeof payload.label === 'string' && payload.label.trim() ? payload.label.trim() : 'OpenChamber',
+        fingerprint: typeof payload.fingerprint === 'string' ? payload.fingerprint.trim() : '',
+        expiresAt: expiresAt || null,
+        candidates: normalizedCandidates.sort((left, right) => left.priority - right.priority),
+      },
+    };
+  } catch {
+    return { kind: 'reject', reason: 'invalid' };
+  }
+};

--- a/packages/electron/pairing-deep-link.test.mjs
+++ b/packages/electron/pairing-deep-link.test.mjs
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+
+import { decidePairingV2DeepLink } from './pairing-deep-link.mjs';
+
+const link = (candidates, extra = {}) => {
+  const payload = { v: 2, pairingId: 'pairing-id', secret: 'never-log-me', label: 'Friendly label', candidates, ...extra };
+  return `openchamber://connect?v=2&p=${Buffer.from(JSON.stringify(payload)).toString('base64url')}`;
+};
+const lan = { type: 'lan', url: 'http://192.168.1.10:3000', priority: 10 };
+const direct = { type: 'direct-e2ee', wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y', d: 'private' }, priority: 1 };
+const relay = { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'server', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' }, priority: 2 };
+
+describe('Pairing v2 Electron deep-link decision', () => {
+  test('rejects direct-E2EE-only before any lower-level handling', () => expect(decidePairingV2DeepLink(link([direct]))).toEqual({ kind: 'reject', reason: 'encrypted-candidate' }));
+  test('rejects LAN plus direct-E2EE without plaintext downgrade', () => expect(decidePairingV2DeepLink(link([lan, direct]))).toEqual({ kind: 'reject', reason: 'encrypted-candidate' }));
+  test('rejects relay plus LAN without plaintext downgrade', () => expect(decidePairingV2DeepLink(link([relay, lan]))).toEqual({ kind: 'reject', reason: 'encrypted-candidate' }));
+  test('accepts valid HTTP-only Pairing v2 and keeps label separate from URL', () => {
+    const result = decidePairingV2DeepLink(link([lan]));
+    expect(result.kind).toBe('accept');
+    if (result.kind === 'accept') {
+      expect(result.payload.label).toBe('Friendly label');
+      expect(result.payload.candidates).toEqual([{ ...lan, url: 'http://192.168.1.10:3000/' }]);
+    }
+  });
+  test('rejects invalid and unknown candidates with fixed non-secret reasons', () => {
+    for (const raw of ['not-a-link', link([{ type: 'unknown', url: 'https://secret.example' }])]) {
+      const result = decidePairingV2DeepLink(raw);
+      expect(result).toEqual({ kind: 'reject', reason: 'invalid' });
+      expect(JSON.stringify(result)).not.toContain('never-log-me');
+    }
+  });
+});

--- a/packages/electron/preload-security.test.mjs
+++ b/packages/electron/preload-security.test.mjs
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import fsp from 'node:fs/promises';
+
+describe('preload runtime bootstrap source', () => {
+  test('does not read credential argv and gates bootstrap to its local page decision', async () => {
+    const source = await fsp.readFile(new URL('./preload.mjs', import.meta.url), 'utf8');
+    expect(source).not.toContain("readArgValue('--openchamber-client-token')");
+    expect(source).not.toContain("readArgValue('--openchamber-runtime-headers')");
+    expect(source).not.toContain("readArgValue('--openchamber-relay-host-id')");
+    expect(source).toContain("const runtimeBootstrap = isLocalPage\n  ? ipcRenderer.sendSync('openchamber:runtime-bootstrap')\n  : null;");
+  });
+});

--- a/packages/electron/preload.mjs
+++ b/packages/electron/preload.mjs
@@ -12,7 +12,6 @@ const readArgValue = (name) => {
 };
 
 const localOrigin = readArgValue('--openchamber-local-origin');
-const homeDirectory = readArgValue('--openchamber-home');
 const macosMajorRaw = readArgValue('--openchamber-macos-major');
 const macosMajor = Number.parseInt(macosMajorRaw, 10);
 const macVibrancySupported = process.platform === 'darwin';
@@ -47,6 +46,7 @@ const runtimeBootstrap = isLocalPage
   : null;
 const apiBaseUrl = typeof runtimeBootstrap?.apiBaseUrl === 'string' ? runtimeBootstrap.apiBaseUrl : '';
 const clientToken = typeof runtimeBootstrap?.clientToken === 'string' ? runtimeBootstrap.clientToken : '';
+const homeDirectory = typeof runtimeBootstrap?.homeDirectory === 'string' ? runtimeBootstrap.homeDirectory : '';
 
 // Remote pages need __OPENCHAMBER_LOCAL_ORIGIN__ so the HostSwitcher knows
 // the URL of the Local entry (isDesktopLocalOriginActive() falls back to

--- a/packages/electron/preload.mjs
+++ b/packages/electron/preload.mjs
@@ -12,9 +12,6 @@ const readArgValue = (name) => {
 };
 
 const localOrigin = readArgValue('--openchamber-local-origin');
-const apiBaseUrl = readArgValue('--openchamber-api-base-url');
-const clientToken = readArgValue('--openchamber-client-token');
-const runtimeHeadersRaw = readArgValue('--openchamber-runtime-headers');
 const homeDirectory = readArgValue('--openchamber-home');
 const macosMajorRaw = readArgValue('--openchamber-macos-major');
 const macosMajor = Number.parseInt(macosMajorRaw, 10);
@@ -45,6 +42,12 @@ const isLocalPage = currentOrigin !== 'null'
   && (currentOrigin === 'openchamber-ui://app'
   || (localOrigin && currentOrigin === localOrigin));
 
+const runtimeBootstrap = isLocalPage
+  ? ipcRenderer.sendSync('openchamber:runtime-bootstrap')
+  : null;
+const apiBaseUrl = typeof runtimeBootstrap?.apiBaseUrl === 'string' ? runtimeBootstrap.apiBaseUrl : '';
+const clientToken = typeof runtimeBootstrap?.clientToken === 'string' ? runtimeBootstrap.clientToken : '';
+
 // Remote pages need __OPENCHAMBER_LOCAL_ORIGIN__ so the HostSwitcher knows
 // the URL of the Local entry (isDesktopLocalOriginActive() falls back to
 // window.location.origin otherwise — wrong on remote). Low risk: the value
@@ -65,19 +68,13 @@ if (clientToken && isLocalPage) {
 // Which saved host this window should connect to over the relay-capable path
 // (direct probe first, E2EE tunnel fallback). Local pages only — the id is
 // only useful together with the desktop IPC channel anyway.
-const relayHostId = readArgValue('--openchamber-relay-host-id');
+const relayHostId = typeof runtimeBootstrap?.relayHostId === 'string' ? runtimeBootstrap.relayHostId : '';
 if (relayHostId && isLocalPage) {
   contextBridge.exposeInMainWorld('__OPENCHAMBER_RELAY_HOST_ID__', relayHostId);
 }
 
-if (runtimeHeadersRaw && isLocalPage) {
-  try {
-    const runtimeHeaders = JSON.parse(runtimeHeadersRaw);
-    if (runtimeHeaders && typeof runtimeHeaders === 'object') {
-      contextBridge.exposeInMainWorld('__OPENCHAMBER_RUNTIME_HEADERS__', runtimeHeaders);
-    }
-  } catch {
-  }
+if (runtimeBootstrap?.requestHeaders && typeof runtimeBootstrap.requestHeaders === 'object' && isLocalPage) {
+  contextBridge.exposeInMainWorld('__OPENCHAMBER_RUNTIME_HEADERS__', runtimeBootstrap.requestHeaders);
 }
 
 // Home directory leaks the OS username — keep local-only. Remote pages

--- a/packages/electron/runtime-bootstrap.mjs
+++ b/packages/electron/runtime-bootstrap.mjs
@@ -1,0 +1,40 @@
+import { sanitizeRuntimeRequestHeaders } from './runtime-request-headers.mjs';
+
+const originOf = (raw) => {
+  try { return new URL(raw).origin; } catch { return ''; }
+};
+
+export const isRuntimeBootstrapSenderAllowed = (senderUrl, { localOrigin, sidecarUrl } = {}) => {
+  try {
+    const parsed = new URL(senderUrl);
+    if (parsed.protocol === 'openchamber-ui:' && parsed.hostname === 'app') return true;
+  } catch {
+    return false;
+  }
+  const senderOrigin = originOf(senderUrl);
+  if (!senderOrigin || senderOrigin === 'null') return false;
+  return [localOrigin, sidecarUrl].some((allowed) => allowed && originOf(allowed) === senderOrigin);
+};
+
+export const sanitizeRuntimeBootstrapConfig = (config) => ({
+  apiBaseUrl: typeof config?.apiBaseUrl === 'string' ? config.apiBaseUrl : '',
+  clientToken: typeof config?.clientToken === 'string' ? config.clientToken : '',
+  requestHeaders: sanitizeRuntimeRequestHeaders(config?.requestHeaders || {}),
+  relayHostId: typeof config?.relayHostId === 'string' ? config.relayHostId : '',
+});
+
+export const resolveRuntimeBootstrap = (senderUrl, windowConfig, allowed) => (
+  isRuntimeBootstrapSenderAllowed(senderUrl, allowed)
+    ? sanitizeRuntimeBootstrapConfig(windowConfig)
+    : null
+);
+
+export const buildDesktopAdditionalArguments = ({
+  localOrigin = '', homeDirectory = '', macosMajor = 0, macVibrancy, bootOutcome,
+} = {}) => [
+  `--openchamber-local-origin=${localOrigin}`,
+  `--openchamber-home=${homeDirectory}`,
+  `--openchamber-macos-major=${macosMajor}`,
+  ...(typeof macVibrancy === 'boolean' ? [`--openchamber-mac-vibrancy=${macVibrancy ? '1' : '0'}`] : []),
+  ...(bootOutcome !== undefined ? [`--openchamber-boot-outcome=${JSON.stringify(bootOutcome)}`] : []),
+];

--- a/packages/electron/runtime-bootstrap.mjs
+++ b/packages/electron/runtime-bootstrap.mjs
@@ -21,6 +21,7 @@ export const sanitizeRuntimeBootstrapConfig = (config) => ({
   clientToken: typeof config?.clientToken === 'string' ? config.clientToken : '',
   requestHeaders: sanitizeRuntimeRequestHeaders(config?.requestHeaders || {}),
   relayHostId: typeof config?.relayHostId === 'string' ? config.relayHostId : '',
+  homeDirectory: typeof config?.homeDirectory === 'string' ? config.homeDirectory : '',
 });
 
 export const resolveRuntimeBootstrap = (senderUrl, windowConfig, allowed) => (
@@ -30,11 +31,16 @@ export const resolveRuntimeBootstrap = (senderUrl, windowConfig, allowed) => (
 );
 
 export const buildDesktopAdditionalArguments = ({
-  localOrigin = '', homeDirectory = '', macosMajor = 0, macVibrancy, bootOutcome,
+  localOrigin = '', macosMajor = 0, macVibrancy, bootOutcome,
 } = {}) => [
   `--openchamber-local-origin=${localOrigin}`,
-  `--openchamber-home=${homeDirectory}`,
   `--openchamber-macos-major=${macosMajor}`,
   ...(typeof macVibrancy === 'boolean' ? [`--openchamber-mac-vibrancy=${macVibrancy ? '1' : '0'}`] : []),
   ...(bootOutcome !== undefined ? [`--openchamber-boot-outcome=${JSON.stringify(bootOutcome)}`] : []),
 ];
+
+export const buildRuntimeBootMetadataScript = ({ macosMajor = 0, bootOutcome } = {}) => {
+  const macVersion = Number.isFinite(Number(macosMajor)) ? Number(macosMajor) : 0;
+  const outcome = JSON.stringify(bootOutcome ?? null);
+  return `(function(){try{window.__OPENCHAMBER_MACOS_MAJOR__=${macVersion};var __oc_bo=${outcome};if(__oc_bo){window.__OPENCHAMBER_DESKTOP_BOOT_OUTCOME__=__oc_bo;}}catch(_e){}}())`;
+};

--- a/packages/electron/runtime-bootstrap.test.mjs
+++ b/packages/electron/runtime-bootstrap.test.mjs
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildDesktopAdditionalArguments, resolveRuntimeBootstrap } from './runtime-bootstrap.mjs';
+
+describe('runtime bootstrap', () => {
+  test('never places runtime credentials in renderer arguments', () => {
+    const args = buildDesktopAdditionalArguments({
+      localOrigin: 'http://127.0.0.1:3901',
+      apiBaseUrl: 'https://remote.example',
+      clientToken: 'bearer-secret',
+      requestHeaders: { Authorization: 'Bearer header-secret', 'X-Secret': 'value' },
+      relayHostId: 'relay-secret-id',
+      homeDirectory: '/Users/test',
+      macosMajor: 15,
+    });
+    const serialized = args.join(' ');
+    expect(serialized).not.toContain('bearer-secret');
+    expect(serialized).not.toContain('header-secret');
+    expect(serialized).not.toContain('Authorization');
+    expect(serialized).not.toContain('openchamber-client-token');
+    expect(serialized).not.toContain('openchamber-runtime-headers');
+    expect(serialized).not.toContain('openchamber-relay-host-id');
+  });
+
+  test('allows only exact packaged/local/sidecar origins and isolates window config', () => {
+    const allowed = {
+      localOrigin: 'http://127.0.0.1:3901',
+      sidecarUrl: 'http://127.0.0.1:57123',
+    };
+    const first = { apiBaseUrl: 'https://one.example', clientToken: 'one', requestHeaders: { 'CF-Access-Client-Secret': 'header-one' }, relayHostId: 'host-one', privateJwk: { d: 'secret' }, unknown: 'strip' };
+    const second = { apiBaseUrl: 'https://two.example', clientToken: 'two', requestHeaders: {}, relayHostId: 'host-two' };
+
+    expect(resolveRuntimeBootstrap('openchamber-ui://app/index.html', first, allowed)).toEqual({
+      apiBaseUrl: 'https://one.example', clientToken: 'one', requestHeaders: { 'CF-Access-Client-Secret': 'header-one' }, relayHostId: 'host-one',
+    });
+    expect(resolveRuntimeBootstrap('http://127.0.0.1:3901/mini-chat.html', second, allowed)?.clientToken).toBe('two');
+    expect(resolveRuntimeBootstrap('http://127.0.0.1:57123/', first, allowed)?.clientToken).toBe('one');
+    for (const denied of [
+      'openchamber-ui://app.evil/index.html',
+      'http://127.0.0.1:3902/',
+      'http://127.0.0.1:3901.evil.example/',
+      'https://remote.example/',
+    ]) expect(resolveRuntimeBootstrap(denied, first, allowed)).toBeNull();
+  });
+});

--- a/packages/electron/runtime-bootstrap.test.mjs
+++ b/packages/electron/runtime-bootstrap.test.mjs
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 
-import { buildDesktopAdditionalArguments, resolveRuntimeBootstrap } from './runtime-bootstrap.mjs';
+import {
+  buildDesktopAdditionalArguments,
+  buildRuntimeBootMetadataScript,
+  isRuntimeBootstrapSenderAllowed,
+  resolveRuntimeBootstrap,
+} from './runtime-bootstrap.mjs';
 
 describe('runtime bootstrap', () => {
   test('never places runtime credentials in renderer arguments', () => {
@@ -20,6 +26,8 @@ describe('runtime bootstrap', () => {
     expect(serialized).not.toContain('openchamber-client-token');
     expect(serialized).not.toContain('openchamber-runtime-headers');
     expect(serialized).not.toContain('openchamber-relay-host-id');
+    expect(serialized).not.toContain('/Users/test');
+    expect(serialized).not.toContain('openchamber-home');
   });
 
   test('allows only exact packaged/local/sidecar origins and isolates window config', () => {
@@ -31,7 +39,7 @@ describe('runtime bootstrap', () => {
     const second = { apiBaseUrl: 'https://two.example', clientToken: 'two', requestHeaders: {}, relayHostId: 'host-two' };
 
     expect(resolveRuntimeBootstrap('openchamber-ui://app/index.html', first, allowed)).toEqual({
-      apiBaseUrl: 'https://one.example', clientToken: 'one', requestHeaders: { 'CF-Access-Client-Secret': 'header-one' }, relayHostId: 'host-one',
+      apiBaseUrl: 'https://one.example', clientToken: 'one', requestHeaders: { 'CF-Access-Client-Secret': 'header-one' }, relayHostId: 'host-one', homeDirectory: '',
     });
     expect(resolveRuntimeBootstrap('http://127.0.0.1:3901/mini-chat.html', second, allowed)?.clientToken).toBe('two');
     expect(resolveRuntimeBootstrap('http://127.0.0.1:57123/', first, allowed)?.clientToken).toBe('one');
@@ -41,5 +49,43 @@ describe('runtime bootstrap', () => {
       'http://127.0.0.1:3901.evil.example/',
       'https://remote.example/',
     ]) expect(resolveRuntimeBootstrap(denied, first, allowed)).toBeNull();
+  });
+
+  test('returns home path only through sender-validated bootstrap', () => {
+    const allowed = { localOrigin: 'http://127.0.0.1:3901' };
+    const config = { homeDirectory: '/Users/private', clientToken: 'secret' };
+    expect(resolveRuntimeBootstrap('http://127.0.0.1:3901/', config, allowed)?.homeDirectory).toBe('/Users/private');
+    expect(resolveRuntimeBootstrap('https://malicious.example/', config, allowed)).toBeNull();
+  });
+
+  test('builds credential-free boot metadata without renderer-side URL authorization', () => {
+    const script = buildRuntimeBootMetadataScript({
+      macosMajor: 15,
+      bootOutcome: { target: 'local', status: 'ok' },
+      apiBaseUrl: 'https://remote.example',
+      clientToken: 'bearer-secret',
+      requestHeaders: { Authorization: 'Bearer header-secret' },
+      homeDirectory: '/Users/private',
+      relayHostId: 'relay-secret-id',
+    });
+    expect(script).toContain('__OPENCHAMBER_DESKTOP_BOOT_OUTCOME__');
+    expect(script).not.toContain('bearer-secret');
+    expect(script).not.toContain('header-secret');
+    expect(script).not.toContain('/Users/private');
+    expect(script).not.toContain('relay-secret-id');
+    expect(script).not.toContain('window.URL');
+    expect(script).not.toContain('new URL');
+  });
+
+  test('main authorizes the committed webContents URL before metadata execution', () => {
+    const allowed = { localOrigin: 'http://127.0.0.1:3901', sidecarUrl: 'http://127.0.0.1:57123' };
+    expect(isRuntimeBootstrapSenderAllowed('http://127.0.0.1:3901/', allowed)).toBe(true);
+    expect(isRuntimeBootstrapSenderAllowed('https://malicious.example/', allowed)).toBe(false);
+
+    const mainSource = readFileSync(new URL('./main.mjs', import.meta.url), 'utf8');
+    expect(mainSource).not.toContain('injectRuntimeConfigIntoHtml');
+    expect(mainSource).not.toContain('__OPENCHAMBER_CLIENT_TOKEN__');
+    expect(mainSource).not.toContain('__OPENCHAMBER_RUNTIME_HEADERS__');
+    expect(mainSource).toContain('isRuntimeBootstrapSenderAllowed(browserWindow.webContents.getURL()');
   });
 });

--- a/packages/electron/secure-json-file.mjs
+++ b/packages/electron/secure-json-file.mjs
@@ -1,0 +1,20 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+const OWNER_ONLY_FILE_MODE = 0o600;
+
+export const writeSecureAtomicJson = async (filePath, value, options = {}) => {
+  const fsPromises = options.fsPromises || fsp;
+  const directoryOptions = { recursive: true, ...(options.privateDirectory ? { mode: 0o700 } : {}) };
+  await fsPromises.mkdir(path.dirname(filePath), directoryOptions);
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  try {
+    await fsPromises.writeFile(tmp, JSON.stringify(value, null, 2), { encoding: 'utf8', mode: OWNER_ONLY_FILE_MODE });
+    if (process.platform !== 'win32') await fsPromises.chmod(tmp, OWNER_ONLY_FILE_MODE);
+    await fsPromises.rename(tmp, filePath);
+    if (process.platform !== 'win32') await fsPromises.chmod(filePath, OWNER_ONLY_FILE_MODE);
+  } catch (error) {
+    await fsPromises.rm(tmp, { force: true }).catch(() => {});
+    throw error;
+  }
+};

--- a/packages/electron/secure-json-file.test.mjs
+++ b/packages/electron/secure-json-file.test.mjs
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { writeSecureAtomicJson } from './secure-json-file.mjs';
+
+const roots = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fsp.rm(root, { recursive: true, force: true })));
+});
+
+describe.skipIf(process.platform === 'win32')('writeSecureAtomicJson', () => {
+  test('writes owner-only and repairs a pre-existing permissive file', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'oc-secure-json-'));
+    roots.push(root);
+    const target = path.join(root, 'settings.json');
+    await fsp.writeFile(target, '{}', { mode: 0o644 });
+
+    await writeSecureAtomicJson(target, { secret: true });
+
+    expect((await fsp.stat(target)).mode & 0o777).toBe(0o600);
+  });
+
+  test('removes its temporary file when replacement fails', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'oc-secure-json-'));
+    roots.push(root);
+    const target = path.join(root, 'settings.json');
+    const fsPromises = { ...fsp, rename: async () => { throw new Error('replace failed'); } };
+
+    await expect(writeSecureAtomicJson(target, { secret: true }, { fsPromises })).rejects.toThrow('replace failed');
+    expect((await fsp.readdir(root)).filter((entry) => entry.includes('.tmp-'))).toEqual([]);
+  });
+});

--- a/packages/electron/ssh-manager.mjs
+++ b/packages/electron/ssh-manager.mjs
@@ -4,6 +4,7 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { writeSecureAtomicJson } from './secure-json-file.mjs';
 
 const LOCAL_HOST_ID = 'local';
 const DEFAULT_CONNECTION_TIMEOUT_SEC = 60;
@@ -72,13 +73,7 @@ const readJsonRoot = (settingsFilePath) => {
 };
 
 const writeJsonRoot = async (settingsFilePath, root) => {
-  await fsp.mkdir(path.dirname(settingsFilePath), { recursive: true });
-  // Atomic write: concurrent readers (main.mjs, web server) would otherwise
-  // see partial JSON and readJsonRoot()'s catch would silently coerce to {},
-  // causing the next read-modify-write to wipe the entire settings file.
-  const tmp = `${settingsFilePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  await fsp.writeFile(tmp, JSON.stringify(root, null, 2));
-  await fsp.rename(tmp, settingsFilePath);
+  await writeSecureAtomicJson(settingsFilePath, root);
 };
 
 const defaultTrue = () => true;

--- a/packages/electron/ssh-manager.test.mjs
+++ b/packages/electron/ssh-manager.test.mjs
@@ -66,5 +66,8 @@ describe('ElectronSshManager', () => {
       issueClientToken: true,
     });
     expect(settings.desktopHosts).toEqual([{ id: 'ssh-1', label: 'SSH Host', url: localUrl, apiUrl: localUrl, clientToken: 'ssh-client-token' }]);
+    if (process.platform !== 'win32') {
+      expect((await fsp.stat(settingsFilePath)).mode & 0o777).toBe(0o600);
+    }
   });
 });

--- a/packages/ui/src/apps/mobileConnections.test.ts
+++ b/packages/ui/src/apps/mobileConnections.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
 
-import { loadMobileConnections, upsertMobileConnection, validateMobileConnectionSession, type MobileRelayConfig } from './mobileConnections';
+import { deleteMobileConnection, loadMobileConnections, probeConnectionCandidates, upsertMobileConnection, validateMobileConnectionSession, type MobileDirectE2eeConfig, type MobileRelayConfig } from './mobileConnections';
+import type { RelayTunnelClient, RelayTunnelFailureClassification } from '@/lib/relay/tunnel-client';
 
 const originalFetch = globalThis.fetch;
 const originalWindow = globalThis.window;
@@ -14,13 +15,13 @@ const createLocalStorageStub = () => {
   };
 };
 
-const installTestWindow = () => {
+const installTestWindow = (protocol = 'https:') => {
   Object.defineProperty(globalThis, 'window', {
     configurable: true,
     value: {
       setTimeout: globalThis.setTimeout.bind(globalThis),
       clearTimeout: globalThis.clearTimeout.bind(globalThis),
-      location: { protocol: 'https:' },
+      location: { protocol },
       localStorage: createLocalStorageStub(),
     },
   });
@@ -40,6 +41,43 @@ const testRelay: MobileRelayConfig = {
 };
 
 describe('mobile connection storage', () => {
+  test('native secure storage operations and migration never log connection descriptors or secrets', async () => {
+    const sentinels = [
+      'sentinel.example',
+      'wss://sentinel.example/api/openchamber/direct-e2ee/ws',
+      'sentinel-token',
+      'sentinel-jwk-x',
+      'sentinel-jwk-y',
+    ];
+    const logs: unknown[][] = [];
+    const originalInfo = console.info;
+    const originalWarn = console.warn;
+    console.info = (...args: unknown[]) => { logs.push(args); };
+    console.warn = (...args: unknown[]) => { logs.push(args); };
+    try {
+      installTestWindow('capacitor:');
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify([{
+        id: 'legacy', label: 'Legacy', url: 'https://sentinel.example', lastUsedAt: 1, clientToken: 'sentinel-token',
+      }]));
+      await loadMobileConnections();
+      const saved = await upsertMobileConnection({
+        label: 'Sentinel',
+        candidates: [{ kind: 'direct-e2ee', directE2ee: {
+          wssUrl: sentinels[1]!,
+          hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: sentinels[3], y: sentinels[4] },
+        } }],
+        clientToken: sentinels[2],
+      });
+      await deleteMobileConnection(saved[0]!.id);
+      const output = JSON.stringify(logs);
+      for (const sentinel of sentinels) expect(output).not.toContain(sentinel);
+    } finally {
+      console.info = originalInfo;
+      console.warn = originalWarn;
+      restoreGlobals();
+    }
+  });
+
   test('entries persisted before candidates migrate to a single direct candidate', async () => {
     try {
       installTestWindow();
@@ -96,6 +134,26 @@ describe('mobile connection storage', () => {
 
       const connections = await loadMobileConnections();
       expect(connections[0]?.candidates.map((c) => c.kind)).toEqual(['direct', 'relay']);
+    } finally {
+      restoreGlobals();
+    }
+  });
+
+  test('a direct E2EE device persists only its public pinned descriptor and token', async () => {
+    try {
+      installTestWindow();
+      await upsertMobileConnection({
+        label: 'E2EE',
+        candidates: [{ kind: 'direct-e2ee', directE2ee: {
+          wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws',
+          hostEncPubJwk: testRelay.hostEncPubJwk,
+        } }],
+        clientToken: 'oc_client_token',
+      });
+      const raw = window.localStorage.getItem(STORAGE_KEY) || '';
+      expect(raw).toContain('direct-e2ee');
+      expect(raw).not.toContain('pairingId');
+      expect(raw).not.toContain('one-time');
     } finally {
       restoreGlobals();
     }
@@ -182,5 +240,48 @@ describe('validateMobileConnectionSession', () => {
     } finally {
       restoreGlobals();
     }
+  });
+});
+
+describe('mobile encrypted candidate fallback policy', () => {
+  const directE2ee: MobileDirectE2eeConfig = {
+    wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws',
+    hostEncPubJwk: testRelay.hostEncPubJwk,
+  };
+
+  const failingClient = (failureClassification: RelayTunnelFailureClassification): RelayTunnelClient => ({
+    fetch: async () => { throw new Error('direct failed'); },
+    openWebSocket: () => { throw new Error('unused'); },
+    getStatus: () => ({ state: failureClassification === 'network' ? 'reconnecting' : 'error', failureClassification }),
+    subscribeStatus: () => () => {},
+    close: () => {},
+  });
+
+  test('does not probe relay after direct crypto, protocol, or terminal failure', async () => {
+    for (const failureClassification of ['crypto', 'protocol', 'terminal'] as const) {
+      let relayCalls = 0;
+      const result = await probeConnectionCandidates([
+        { kind: 'direct-e2ee', directE2ee },
+        { kind: 'relay', relay: testRelay },
+      ], 'token', {
+        createDirectE2eeClient: () => failingClient(failureClassification),
+        probeRelay: async () => { relayCalls += 1; return 'ok'; },
+      });
+      expect(result.status).toBe('security');
+      expect(relayCalls).toBe(0);
+    }
+  });
+
+  test('probes relay after an ordinary unreachable direct failure', async () => {
+    let relayCalls = 0;
+    const result = await probeConnectionCandidates([
+      { kind: 'direct-e2ee', directE2ee },
+      { kind: 'relay', relay: testRelay },
+    ], 'token', {
+      createDirectE2eeClient: () => failingClient('network'),
+      probeRelay: async () => { relayCalls += 1; return 'ok'; },
+    });
+    expect(result.status).toBe('ok');
+    expect(relayCalls).toBe(1);
   });
 });

--- a/packages/ui/src/apps/mobileConnections.test.ts
+++ b/packages/ui/src/apps/mobileConnections.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, mock, test } from 'bun:test';
 
-import { deleteMobileConnection, loadMobileConnections, probeConnectionCandidates, upsertMobileConnection, validateMobileConnectionSession, type MobileDirectE2eeConfig, type MobileRelayConfig } from './mobileConnections';
+import { deleteMobileConnection, loadMobileConnections, mobilePairingFailureKey, probeConnectionCandidates, upsertMobileConnection, validateMobileConnectionSession, type MobileDirectE2eeConfig, type MobileRelayConfig } from './mobileConnections';
 import type { RelayTunnelClient, RelayTunnelFailureClassification } from '@/lib/relay/tunnel-client';
+import { PairingRedemptionError } from '@/lib/pairingCandidateRedemption';
+import { dict as englishMessages } from '@/lib/i18n/messages/en';
 
 const originalFetch = globalThis.fetch;
 const originalWindow = globalThis.window;
@@ -283,5 +285,41 @@ describe('mobile encrypted candidate fallback policy', () => {
     });
     expect(result.status).toBe('ok');
     expect(relayCalls).toBe(1);
+  });
+});
+
+describe('mobile pairing failure messages', () => {
+  test('maps every pairing classification and unknown errors to fixed localized keys', () => {
+    const cases = [
+      ['unreachable', 'mobile.connect.error.unreachable'],
+      ['security', 'mobile.connect.error.pairingSecurity'],
+      ['credential', 'mobile.connect.error.authRequired'],
+      ['ambiguous', 'mobile.connect.error.pairingUncertain'],
+      ['authorization', 'mobile.connect.error.authRequired'],
+    ] as const;
+
+    for (const [classification, expected] of cases) {
+      expect(mobilePairingFailureKey(new PairingRedemptionError(classification, 'sensitive detail'))).toBe(expected);
+    }
+    expect(mobilePairingFailureKey(new Error('unknown sensitive detail'))).toBe('mobile.connect.error.pairingUncertain');
+  });
+
+  test('mobile pairing errors render safe copy without raw failure details or classification tokens', () => {
+    const sensitive = 'wss://private.example crypto protocol credential authorization';
+    const errors = [
+      new PairingRedemptionError('security', sensitive),
+      new PairingRedemptionError('ambiguous', sensitive),
+      new Error(sensitive),
+    ];
+
+    for (const error of errors) {
+      const message = englishMessages[mobilePairingFailureKey(error)];
+      expect(message).toBeTruthy();
+      expect(message).not.toContain('private.example');
+      expect(message).not.toContain('crypto');
+      expect(message).not.toContain('protocol');
+      expect(message).not.toContain('credential');
+      expect(message).not.toContain('authorization');
+    }
   });
 });

--- a/packages/ui/src/apps/mobileConnections.ts
+++ b/packages/ui/src/apps/mobileConnections.ts
@@ -20,9 +20,11 @@ import React from 'react';
 
 import { useI18n } from '@/lib/i18n';
 import type { PairingConnectionPayload, PairingEndpointCandidate } from '@/lib/connectionPayload';
+import { redeemPairingCandidate } from '@/lib/pairingCandidateRedemption';
 import { isCapacitorApp } from '@/lib/platform';
 import { adoptRelayTunnel, isRelayModeActive } from '@/lib/relay/runtime-tunnel';
-import { createRelayTunnelClient } from '@/lib/relay/tunnel-client';
+import { createDirectE2eeTunnelClient } from '@/lib/relay/direct-e2ee-tunnel-client';
+import { createRelayTunnelClient, type RelayTunnelClient } from '@/lib/relay/tunnel-client';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { getRuntimeApiBaseUrl, getRuntimeKey, switchRuntimeEndpoint } from '@/lib/runtime-switch';
 
@@ -83,6 +85,11 @@ export type MobileRelayConfig = {
   hostEncPubJwk: JsonWebKey;
 };
 
+export type MobileDirectE2eeConfig = {
+  wssUrl: string;
+  hostEncPubJwk: JsonWebKey;
+};
+
 // One reachable transport for a saved device: a direct HTTP URL, or the E2EE
 // relay tunnel. A saved connection holds an ORDERED SET of these (index 0 tried
 // first — LAN preferred, relay fallback) plus a single client token, and the app
@@ -90,7 +97,8 @@ export type MobileRelayConfig = {
 // (direct) and away (relay) without re-pairing.
 export type MobileTransportCandidate =
   | { kind: 'direct'; url: string }
-  | { kind: 'relay'; relay: MobileRelayConfig };
+  | { kind: 'relay'; relay: MobileRelayConfig }
+  | { kind: 'direct-e2ee'; directE2ee: MobileDirectE2eeConfig };
 
 export type MobileSavedConnection = {
   id: string;
@@ -135,13 +143,6 @@ type MobileSessionStatus = {
   authenticated?: boolean;
   disabled?: boolean;
   scope?: string;
-};
-
-type PairingRedeemResponse = {
-  ok?: boolean;
-  clientToken?: unknown;
-  client?: { label?: unknown } | null;
-  server?: { label?: unknown; url?: unknown } | null;
 };
 
 // ---------------------------------------------------------------------------
@@ -200,13 +201,20 @@ const relayCandidateOf = (connection: { candidates: MobileTransportCandidate[] }
   return found && found.kind === 'relay' ? found.relay : null;
 };
 
+const directE2eeCandidateOf = (connection: { candidates: MobileTransportCandidate[] }): MobileDirectE2eeConfig | null => {
+  const found = connection.candidates.find((candidate) => candidate.kind === 'direct-e2ee');
+  return found?.kind === 'direct-e2ee' ? found.directE2ee : null;
+};
+
 // Display URL for a saved connection: the first direct URL, else the relay
 // pseudo-URL. Used only for the connections list UI.
 export const connectionDisplayUrl = (connection: { candidates: MobileTransportCandidate[] }): string => {
   const direct = directCandidates(connection)[0];
   if (direct) return direct.url;
   const relay = relayCandidateOf(connection);
-  return relay ? canonicalRelayUrl(relay) : '';
+  if (relay) return canonicalRelayUrl(relay);
+  const directE2ee = directE2eeCandidateOf(connection);
+  return directE2ee ? directE2ee.wssUrl : '';
 };
 
 // Secure-store / dedupe key for a saved device. A device has ONE token that
@@ -216,6 +224,8 @@ export const connectionDisplayUrl = (connection: { candidates: MobileTransportCa
 const secureTokenKeyOf = (connection: { candidates: MobileTransportCandidate[] }): string => {
   const relay = relayCandidateOf(connection);
   if (relay) return relayConnectionRuntimeKey(relay);
+  const directE2ee = directE2eeCandidateOf(connection);
+  if (directE2ee) return `direct-e2ee:${directE2ee.wssUrl}`;
   const direct = directCandidates(connection)[0];
   return direct ? getConnectionStorageKey(direct.url) : '';
 };
@@ -228,6 +238,9 @@ const candidateSetsMatch = (a: MobileTransportCandidate[], b: MobileTransportCan
   const aUrls = new Set(a.filter((c) => c.kind === 'direct').map((c) => getConnectionStorageKey((c as { url: string }).url)));
   return b.some((c) => {
     if (c.kind === 'relay') return aServerId !== null && c.relay.serverId === aServerId;
+    if (c.kind === 'direct-e2ee') {
+      return a.some((candidate) => candidate.kind === 'direct-e2ee' && candidate.directE2ee.wssUrl === c.directE2ee.wssUrl);
+    }
     return aUrls.has(getConnectionStorageKey(c.url));
   });
 };
@@ -272,6 +285,23 @@ const parseRelayConfig = (value: unknown): MobileRelayConfig | null => {
     serverId: record.serverId,
     hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: key.x, y: key.y },
   };
+};
+
+const parseDirectE2eeConfig = (value: unknown): MobileDirectE2eeConfig | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.wssUrl !== 'string') return null;
+  const jwk = record.hostEncPubJwk;
+  if (!jwk || typeof jwk !== 'object' || Array.isArray(jwk)) return null;
+  const key = jwk as Record<string, unknown>;
+  try {
+    const url = new URL(record.wssUrl);
+    if (url.protocol !== 'wss:' || url.pathname !== '/api/openchamber/direct-e2ee/ws' || url.search || url.hash || url.username || url.password) return null;
+    if (key.kty !== 'EC' || key.crv !== 'P-256' || typeof key.x !== 'string' || typeof key.y !== 'string') return null;
+    return { wssUrl: url.toString(), hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: key.x, y: key.y } };
+  } catch {
+    return null;
+  }
 };
 
 // ---------------------------------------------------------------------------
@@ -332,15 +362,15 @@ const nativeHttpRequest = async (url: string, init?: RequestInit): Promise<Mobil
       source: 'native-http',
       json: async () => parseMaybeJson(response.data),
     };
-  } catch (error) {
-    console.warn('[mobile-connect]', 'native-http failed', logDetail({ url, error: error instanceof Error ? error.message : String(error) }));
+  } catch {
+    console.warn('[mobile-connect]', 'native-http failed', logDetail({ failed: true }));
     return null;
   }
 };
 
 const browserFetchRequest = async (url: string, init?: RequestInit): Promise<MobileFetchResponse | null> => {
-  const response = await fetch(url, init).catch((error) => {
-    console.warn('[mobile-connect]', 'browser-fetch failed', logDetail({ url, error: error instanceof Error ? error.message : String(error) }));
+  const response = await fetch(url, init).catch(() => {
+    console.warn('[mobile-connect]', 'browser-fetch failed', logDetail({ failed: true }));
     return null;
   });
   if (!response) return null;
@@ -504,6 +534,10 @@ const parseCandidate = (value: unknown): MobileTransportCandidate | null => {
     const relay = parseRelayConfig(c.relay);
     return relay ? { kind: 'relay', relay } : null;
   }
+  if (c.kind === 'direct-e2ee') {
+    const directE2ee = parseDirectE2eeConfig(c.directE2ee);
+    return directE2ee ? { kind: 'direct-e2ee', directE2ee } : null;
+  }
   return null;
 };
 
@@ -554,7 +588,9 @@ const readConnections = (): MobileSavedConnection[] => {
 const serializeCandidate = (c: MobileTransportCandidate): unknown =>
   c.kind === 'relay'
     ? { kind: 'relay', relay: { relayUrl: c.relay.relayUrl, serverId: c.relay.serverId, hostEncPubJwk: c.relay.hostEncPubJwk } }
-    : { kind: 'direct', url: c.url };
+    : c.kind === 'direct-e2ee'
+      ? { kind: 'direct-e2ee', directE2ee: c.directE2ee }
+      : { kind: 'direct', url: c.url };
 
 const writeConnections = (connections: MobileSavedConnection[]): void => {
   if (typeof window === 'undefined') return;
@@ -573,8 +609,8 @@ const writeConnections = (connections: MobileSavedConnection[]): void => {
   });
   try {
     window.localStorage.setItem(MOBILE_CONNECTIONS_STORAGE_KEY, JSON.stringify(serialized));
-  } catch (error) {
-    console.warn('[mobile-storage] failed to persist connection metadata', error);
+  } catch {
+    console.warn('[mobile-storage]', 'metadata:write-failed');
   }
 };
 
@@ -643,8 +679,8 @@ const withTimeout = async <T,>(operation: Promise<T>, fallback: T): Promise<T> =
 const boundedSecure = async <T,>(label: string, run: () => Promise<T>, fallback: T): Promise<T> => {
   if (!isCapacitorApp()) return fallback;
   return withTimeout(
-    run().catch((error) => {
-      console.warn(`[mobile-storage] ${label} failed`, error);
+    run().catch(() => {
+      console.warn('[mobile-storage]', `${label}:failed`);
       return fallback;
     }),
     fallback,
@@ -652,19 +688,19 @@ const boundedSecure = async <T,>(label: string, run: () => Promise<T>, fallback:
 };
 
 const readSecureToken = async (key: string): Promise<string | undefined> => {
-  logStorage('secure:read-start', { key });
+  logStorage('secure:read-start');
   const value = await boundedSecure(
     'secure:read',
     async () => (await nativeSecure.internalGetItem({ prefixedKey: prefixedTokenKey(key), sync: false })).data,
     null,
   );
   const token = typeof value === 'string' && value.trim() ? value : undefined;
-  logStorage('secure:read', { key, hasToken: Boolean(token) });
+  logStorage('secure:read', { hasToken: Boolean(token) });
   return token;
 };
 
 const writeSecureToken = async (key: string, token: string): Promise<boolean> => {
-  logStorage('secure:write-start', { key });
+  logStorage('secure:write-start');
   const ok = await boundedSecure('secure:write', async () => {
     await nativeSecure.internalSetItem({
       prefixedKey: prefixedTokenKey(key),
@@ -674,7 +710,7 @@ const writeSecureToken = async (key: string, token: string): Promise<boolean> =>
     });
     return true;
   }, false);
-  logStorage('secure:write', { key, ok });
+  logStorage('secure:write', { ok });
   return ok;
 };
 
@@ -744,11 +780,13 @@ export const deleteMobileConnection = async (id: string): Promise<MobileSavedCon
 // tunnel instead of dialing a fresh one.
 type ChosenTransport =
   | { kind: 'direct'; url: string }
-  | { kind: 'relay'; relay: MobileRelayConfig; tunnel?: ReturnType<typeof createRelayTunnelClient> };
+  | { kind: 'relay'; relay: MobileRelayConfig; tunnel?: ReturnType<typeof createRelayTunnelClient> }
+  | { kind: 'direct-e2ee'; directE2ee: MobileDirectE2eeConfig };
 
 type ProbeResult =
   | { status: 'ok'; transport: ChosenTransport }
   | { status: 'needs-login' }
+  | { status: 'security' }
   | { status: 'unreachable' };
 
 // How long the direct (LAN/tunnel) candidates keep the track to themselves
@@ -758,18 +796,30 @@ type ProbeResult =
 // (which alone cost up to MOBILE_CONNECT_TIMEOUT_MS per stale address).
 const RELAY_RACE_HEADSTART_MS = 1_500;
 
+const tunnelSecurityFailure = (tunnel: ReturnType<typeof createDirectE2eeTunnelClient>): boolean => {
+  const classification = tunnel.getStatus().failureClassification;
+  return classification === 'crypto' || classification === 'protocol' || classification === 'terminal';
+};
+
 // Probe a saved device's candidates and return the first transport that is both
-// reachable AND accepts the token. This is the heart of "one device, many
-// transports": at home the LAN candidate answers; away it is unreachable so we
-// fall through to relay — no re-pairing. Direct candidates are probed in order
-// and keep priority; the relay probe races them after a short headstart instead
-// of waiting for every direct timeout. An explicit auth rejection (401 /
-// authenticated:false) applies to every transport (same token), so it
-// short-circuits to needs-login; a merely unreachable candidate is skipped.
-const probeConnectionCandidates = async (
+// reachable and accepts the token. Existing LAN+relay devices keep the relay
+// head-start race. A direct-E2EE candidate is tried in persisted order before a
+// later relay candidate so crypto/protocol/terminal failures can fail closed;
+// ordinary network failure may still advance to the next candidate.
+export const probeConnectionCandidates = async (
   candidates: MobileTransportCandidate[],
   token: string | undefined,
-  options?: { fast?: boolean },
+  options?: {
+    fast?: boolean;
+    probeRelay?: (
+      relay: MobileRelayConfig,
+      token?: string,
+      grant?: string,
+      timeoutMs?: number,
+      options?: { keepTunnel?: boolean },
+    ) => Promise<RelayProbeOutcome | RelayProbeResult>;
+    createDirectE2eeClient?: (descriptor: MobileDirectE2eeConfig) => RelayTunnelClient;
+  },
 ): Promise<ProbeResult> => {
   const requestOptions = options?.fast ? { totalTimeoutMs: MOBILE_FAST_PROBE_TIMEOUT_MS } : undefined;
   // Identity gate for direct probes: when the device knows its server's identity
@@ -781,33 +831,57 @@ const probeConnectionCandidates = async (
   const relayCandidate = candidates.find((c): c is Extract<MobileTransportCandidate, { kind: 'relay' }> => c.kind === 'relay') ?? null;
   const directList = candidates.filter((c): c is Extract<MobileTransportCandidate, { kind: 'direct' }> => c.kind === 'direct');
 
+  const probeDirect = async (candidate: Extract<MobileTransportCandidate, { kind: 'direct' }>): Promise<ProbeResult> => {
+    const url = normalizeConnectionUrl(candidate.url) || candidate.url;
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+    // /health is unauthenticated by design — never send the bearer token to an
+    // address whose identity has not been checked yet.
+    const health = await requestWithTimeout(`${url}/health`, { method: 'GET' }, requestOptions);
+    if (!health?.ok) return { status: 'unreachable' };
+    if (expectedServerId) {
+      const payload = await health.json().catch(() => null);
+      const reported = payload && typeof payload === 'object' ? (payload as Record<string, unknown>).serverId : null;
+      if (typeof reported === 'string' && reported && reported !== expectedServerId) {
+        logConnect('probe:server-id-mismatch', { url });
+        return { status: 'unreachable' };
+      }
+    }
+    const session = await requestWithTimeout(`${url}/auth/session`, { method: 'GET', credentials: 'include', headers }, requestOptions);
+    if (session?.status === 401) return { status: 'needs-login' };
+    if (!session || (!session.ok && session.status !== 404)) return { status: 'unreachable' };
+    const status = await readSessionStatus(session);
+    if (status && status.disabled !== true && status.authenticated === false) return { status: 'needs-login' };
+    // A cookie-only native session (authenticated, but not a `client` bearer scope
+    // and not auth-disabled) is not enough — the native runtime transport needs a
+    // bearer token, so fall through to the password flow to mint one.
+    const authDisabled = status?.disabled === true;
+    if (!token && isCapacitorApp() && !authDisabled && status?.scope !== 'client') return { status: 'needs-login' };
+    return { status: 'ok', transport: { kind: 'direct', url } };
+  };
+
+  const probeDirectE2ee = async (
+    candidate: Extract<MobileTransportCandidate, { kind: 'direct-e2ee' }>,
+  ): Promise<ProbeResult> => {
+    const tunnel = options?.createDirectE2eeClient?.(candidate.directE2ee) ?? createDirectE2eeTunnelClient(candidate.directE2ee);
+    try {
+      const health = await raceWithTimeout(RELAY_CONNECT_TIMEOUT_MS, tunnel.fetch('/health').catch(() => null));
+      if (tunnelSecurityFailure(tunnel)) return { status: 'security' };
+      if (!health?.ok) return { status: 'unreachable' };
+      const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+      const session = await raceWithTimeout(RELAY_CONNECT_TIMEOUT_MS, tunnel.fetch('/auth/session', { headers }).catch(() => null));
+      if (tunnelSecurityFailure(tunnel)) return { status: 'security' };
+      if (session?.ok) return { status: 'ok', transport: { kind: 'direct-e2ee', directE2ee: candidate.directE2ee } };
+      if (session?.status === 401) return { status: 'needs-login' };
+      return { status: 'unreachable' };
+    } finally {
+      tunnel.close();
+    }
+  };
+
   const probeDirectChain = async (): Promise<ProbeResult> => {
     for (const candidate of directList) {
-      const url = normalizeConnectionUrl(candidate.url) || candidate.url;
-      const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
-      // /health is unauthenticated by design — never send the bearer token to an
-      // address whose identity has not been checked yet.
-      const health = await requestWithTimeout(`${url}/health`, { method: 'GET' }, requestOptions);
-      if (!health?.ok) continue;
-      if (expectedServerId) {
-        const payload = await health.json().catch(() => null);
-        const reported = payload && typeof payload === 'object' ? (payload as Record<string, unknown>).serverId : null;
-        if (typeof reported === 'string' && reported && reported !== expectedServerId) {
-          logConnect('probe:server-id-mismatch', { url });
-          continue;
-        }
-      }
-      const session = await requestWithTimeout(`${url}/auth/session`, { method: 'GET', credentials: 'include', headers }, requestOptions);
-      if (session?.status === 401) return { status: 'needs-login' };
-      if (!session || (!session.ok && session.status !== 404)) continue;
-      const status = await readSessionStatus(session);
-      if (status && status.disabled !== true && status.authenticated === false) return { status: 'needs-login' };
-      // A cookie-only native session (authenticated, but not a `client` bearer scope
-      // and not auth-disabled) is not enough — the native runtime transport needs a
-      // bearer token, so fall through to the password flow to mint one.
-      const authDisabled = status?.disabled === true;
-      if (!token && isCapacitorApp() && !authDisabled && status?.scope !== 'client') return { status: 'needs-login' };
-      return { status: 'ok', transport: { kind: 'direct', url } };
+      const result = await probeDirect(candidate);
+      if (result.status !== 'unreachable') return result;
     }
     return { status: 'unreachable' };
   };
@@ -816,17 +890,30 @@ const probeConnectionCandidates = async (
     if (!relayCandidate) return { status: 'unreachable' };
     // keepTunnel: an 'ok' probe hands its live tunnel to switchToTransport,
     // which adopts it as the runtime tunnel — no second connect + handshake.
-    const { outcome, tunnel } = await probeRelaySession(
+    const result = await (options?.probeRelay ?? probeRelaySession)(
       relayCandidate.relay,
       token,
       undefined,
       options?.fast ? MOBILE_FAST_PROBE_TIMEOUT_MS : undefined,
       { keepTunnel: true },
     );
+    const { outcome, tunnel } = typeof result === 'string' ? { outcome: result, tunnel: undefined } : result;
     if (outcome === 'ok') return { status: 'ok', transport: { kind: 'relay', relay: relayCandidate.relay, tunnel } };
     if (outcome === 'needs-login' || outcome === 'auth-failed') return { status: 'needs-login' };
     return { status: 'unreachable' };
   };
+
+  if (candidates.some((candidate) => candidate.kind === 'direct-e2ee')) {
+    for (const candidate of candidates) {
+      const result = candidate.kind === 'direct'
+        ? await probeDirect(candidate)
+        : candidate.kind === 'direct-e2ee'
+          ? await probeDirectE2ee(candidate)
+          : await probeRelay();
+      if (result.status !== 'unreachable') return result;
+    }
+    return { status: 'unreachable' };
+  }
 
   if (!relayCandidate) return probeDirectChain();
   if (directList.length === 0) return probeRelay();
@@ -905,6 +992,13 @@ const switchToTransport = (
 ): void => {
   if (transport.kind === 'relay') {
     switchToRelayRuntime(transport.relay, token, options?.grant, options?.runtimeKey, transport.tunnel);
+  } else if (transport.kind === 'direct-e2ee') {
+    switchRuntimeEndpoint({
+      apiBaseUrl: typeof window !== 'undefined' ? window.location.origin : '',
+      clientToken: token,
+      runtimeKey: options?.runtimeKey,
+      tunnel: { type: 'direct-e2ee', ...transport.directE2ee },
+    });
   } else {
     switchRuntimeEndpoint({ apiBaseUrl: transport.url, clientToken: token, runtimeKey: options?.runtimeKey });
   }
@@ -993,7 +1087,11 @@ const pairingCandidatesToMobile = (candidates: PairingEndpointCandidate[]): Mobi
     .sort((left, right) => {
       const delta = (left.priority ?? 100) - (right.priority ?? 100);
       if (delta !== 0) return delta;
-      const rank = (c: PairingEndpointCandidate): number => (c.type === 'relay' ? 2 : c.url.startsWith('https://') ? 0 : 1);
+      const rank = (c: PairingEndpointCandidate): number => {
+        if (c.type === 'relay') return 3;
+        if (c.type === 'direct-e2ee') return 2;
+        return c.url.startsWith('https://') ? 0 : 1;
+      };
       return rank(left) - rank(right);
     })
     .flatMap((c): MobileTransportCandidate[] => {
@@ -1001,6 +1099,7 @@ const pairingCandidatesToMobile = (candidates: PairingEndpointCandidate[]): Mobi
         const relay = parseRelayConfig({ relayUrl: c.relayUrl, serverId: c.serverId, hostEncPubJwk: c.hostEncPubJwk });
         return relay ? [{ kind: 'relay', relay }] : [];
       }
+      if (c.type === 'direct-e2ee') return [{ kind: 'direct-e2ee', directE2ee: { wssUrl: c.wssUrl, hostEncPubJwk: c.hostEncPubJwk } }];
       return directCandidatesFromUrl(c.url);
     });
 
@@ -1022,6 +1121,7 @@ const establishLiveTransport = async (
       tunnel.close();
       continue;
     }
+    if (candidate.kind === 'direct-e2ee') continue;
     const url = normalizeConnectionUrl(candidate.url) || candidate.url;
     const health = await requestWithTimeout(`${url}/health`, { method: 'GET' });
     logConnect('establish:direct:health', { ok: health?.ok === true, status: health?.status ?? null });
@@ -1065,7 +1165,7 @@ export const validateActiveRuntimeSession = async (input: {
 // from the runtime's mode instead: relay when the tunnel is active, else the
 // direct base URL.
 const transportMatchesCurrentRuntime = (transport: ChosenTransport): boolean =>
-  transport.kind === 'relay'
+  transport.kind === 'relay' || transport.kind === 'direct-e2ee'
     ? isRelayModeActive()
     : !isRelayModeActive() && isSameConnectionUrl(transport.url, getRuntimeApiBaseUrl());
 
@@ -1105,7 +1205,13 @@ export const reprobeActiveConnection = async (): Promise<ReprobeOutcome> => {
   if (!token) return 'unreachable';
 
   const currentIndex = active.candidates.findIndex(
-    (candidate) => transportMatchesCurrentRuntime(candidate.kind === 'relay' ? { kind: 'relay', relay: candidate.relay } : { kind: 'direct', url: candidate.url }),
+    (candidate) => transportMatchesCurrentRuntime(
+      candidate.kind === 'relay'
+        ? { kind: 'relay', relay: candidate.relay }
+        : candidate.kind === 'direct-e2ee'
+          ? { kind: 'direct-e2ee', directE2ee: candidate.directE2ee }
+          : { kind: 'direct', url: candidate.url },
+    ),
   );
 
   // 1. A higher-priority transport becoming reachable means "came home" (relay → LAN).
@@ -1344,7 +1450,7 @@ export const useMobileConnection = (onConnected: () => void): UseMobileConnectio
       const result = await probeConnectionCandidates(candidates, token);
       logConnect('connect:probe', { status: result.status });
 
-      if (result.status === 'unreachable') {
+       if (result.status === 'unreachable' || result.status === 'security') {
         setError(t('mobile.connect.error.unreachable'));
         return;
       }
@@ -1368,8 +1474,8 @@ export const useMobileConnection = (onConnected: () => void): UseMobileConnectio
       persistMetadata({ id: saved?.id, label, candidates, clientToken: token });
       switchToTransport(result.transport, token ?? null, { runtimeKey: secureTokenKeyOf({ candidates }), grant });
       onConnected();
-    } catch (error) {
-      console.warn('[mobile-connect] connect threw', error);
+    } catch {
+      console.warn('[mobile-connect]', 'connect:failed');
       setError(t('mobile.connect.error.invalidUrl'));
     } finally {
       endBusy('connect');
@@ -1381,23 +1487,8 @@ export const useMobileConnection = (onConnected: () => void): UseMobileConnectio
     setError(null);
     beginBusy('pairing');
     const deviceCandidates = pairingCandidatesToMobile(payload.candidates);
-    // A chosen relay transport owns an open tunnel; close it unless the switch
-    // adopted it as the runtime tunnel.
-    let chosen: LiveTransport | null = null;
-    let adopted = false;
     try {
-      // 1. Find the first reachable transport across all candidates.
-      chosen = await establishLiveTransport(deviceCandidates);
-      if (!chosen) {
-        setError(t('mobile.connect.error.unreachable'));
-        return;
-      }
-
-      // 2. Redeem the one-time secret over that transport. Single-use: we never
-      // retry other candidates once redeem runs (the secret is consumed).
-      const redeemBody = JSON.stringify({
-        pairingId: payload.pairingId,
-        secret: payload.secret,
+      const redeemed = await redeemPairingCandidate(payload, { redeemBody: {
         clientLabel: 'OpenChamber Mobile',
         clientKind: 'mobile',
         deviceName: 'OpenChamber Mobile',
@@ -1405,30 +1496,9 @@ export const useMobileConnection = (onConnected: () => void): UseMobileConnectio
         // Re-pairing this same phone reuses its one device record instead of
         // adding a duplicate row on the server.
         dedupeKey: mobileClientDedupeKey(),
-      });
-      const redeemInit = {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: redeemBody,
-      } as const;
-      const response = chosen.kind === 'relay'
-        ? await raceWithTimeout(RELAY_CONNECT_TIMEOUT_MS, chosen.tunnel.fetch('/api/client-auth/pairing/redeem', redeemInit).catch(() => null))
-        : await requestWithTimeout(`${chosen.url}/api/client-auth/pairing/redeem`, redeemInit);
-      if (!response?.ok) {
-        setError(t('mobile.connect.error.authRequired'));
-        return;
-      }
-      const result = await response.json().catch(() => null) as PairingRedeemResponse | null;
-      const issuedToken = typeof result?.clientToken === 'string' ? result.clientToken.trim() : '';
-      if (!issuedToken) {
-        setError(t('mobile.connect.error.authRequired'));
-        return;
-      }
-      // Name the connection by the issuing server (its hostname), not the
-      // per-device pairing label — that label is the operator's name for THIS
-      // phone in their device list, not a name for the server we connect to.
-      const serverLabel = typeof result?.server?.label === 'string' ? result.server.label : '';
-      const label = payload.label || serverLabel || getConnectionLabel(connectionDisplayUrl({ candidates: deviceCandidates }));
+      } });
+      const issuedToken = redeemed.token;
+      const label = payload.label || getConnectionLabel(connectionDisplayUrl({ candidates: deviceCandidates }));
 
       // 3. Persist the device with ALL its candidates + one token, then switch to
       // whichever transport answered. Reconnect re-probes the full set so the
@@ -1441,20 +1511,22 @@ export const useMobileConnection = (onConnected: () => void): UseMobileConnectio
         }
       }
       persistMetadata({ label, candidates: deviceCandidates, clientToken: issuedToken });
-      // A relay transport hands its live redeem tunnel to the runtime (adopted
-      // inside switchToTransport) — closing it here would tear down the runtime.
+      // The redemption helper closes its temporary transport deterministically;
+      // switch the runtime using the verified public descriptor it returned.
       switchToTransport(
-        chosen.kind === 'relay' ? { kind: 'relay', relay: chosen.relay, tunnel: chosen.tunnel } : { kind: 'direct', url: chosen.url },
+        redeemed.transport.kind === 'relay'
+          ? { kind: 'relay', relay: redeemed.transport }
+          : redeemed.transport.kind === 'direct-e2ee'
+            ? { kind: 'direct-e2ee', directE2ee: redeemed.transport }
+            : { kind: 'direct', url: redeemed.transport.url },
         issuedToken,
         { runtimeKey: secureTokenKeyOf({ candidates: deviceCandidates }) },
       );
-      adopted = chosen.kind === 'relay';
       onConnected();
-    } catch (error) {
-      console.warn('[mobile-connect] pairing threw', error);
+    } catch {
+      console.warn('[mobile-connect]', 'pairing:failed');
       setError(t('mobile.connect.error.authRequired'));
     } finally {
-      if (!adopted && chosen?.kind === 'relay') chosen.tunnel.close();
       endBusy('pairing');
     }
   }, [beginBusy, endBusy, onConnected, persistMetadata, t]);
@@ -1528,8 +1600,8 @@ export const useMobileConnection = (onConnected: () => void): UseMobileConnectio
       );
       adopted = chosen.kind === 'relay';
       onConnected();
-    } catch (error) {
-      console.warn('[mobile-connect] password threw', error);
+    } catch {
+      console.warn('[mobile-connect]', 'password:failed');
       setError(t('mobile.connect.error.passwordFailed'));
     } finally {
       if (!adopted && chosen?.kind === 'relay') chosen.tunnel.close();

--- a/packages/ui/src/apps/mobileConnections.ts
+++ b/packages/ui/src/apps/mobileConnections.ts
@@ -20,7 +20,7 @@ import React from 'react';
 
 import { useI18n } from '@/lib/i18n';
 import type { PairingConnectionPayload, PairingEndpointCandidate } from '@/lib/connectionPayload';
-import { redeemPairingCandidate } from '@/lib/pairingCandidateRedemption';
+import { PairingRedemptionError, redeemPairingCandidate } from '@/lib/pairingCandidateRedemption';
 import { isCapacitorApp } from '@/lib/platform';
 import { adoptRelayTunnel, isRelayModeActive } from '@/lib/relay/runtime-tunnel';
 import { createDirectE2eeTunnelClient } from '@/lib/relay/direct-e2ee-tunnel-client';
@@ -130,6 +130,27 @@ export type MobileConnectInput = {
   label?: string;
   relay?: MobileRelayConfig;
   relayGrant?: string;
+};
+
+export type MobilePairingFailureKey =
+  | 'mobile.connect.error.unreachable'
+  | 'mobile.connect.error.authRequired'
+  | 'mobile.connect.error.pairingSecurity'
+  | 'mobile.connect.error.pairingUncertain';
+
+export const mobilePairingFailureKey = (error: unknown): MobilePairingFailureKey => {
+  if (!(error instanceof PairingRedemptionError)) return 'mobile.connect.error.pairingUncertain';
+  switch (error.classification) {
+    case 'unreachable':
+      return 'mobile.connect.error.unreachable';
+    case 'credential':
+    case 'authorization':
+      return 'mobile.connect.error.authRequired';
+    case 'security':
+      return 'mobile.connect.error.pairingSecurity';
+    case 'ambiguous':
+      return 'mobile.connect.error.pairingUncertain';
+  }
 };
 
 type MobileFetchResponse = {
@@ -1523,9 +1544,9 @@ export const useMobileConnection = (onConnected: () => void): UseMobileConnectio
         { runtimeKey: secureTokenKeyOf({ candidates: deviceCandidates }) },
       );
       onConnected();
-    } catch {
+    } catch (error) {
       console.warn('[mobile-connect]', 'pairing:failed');
-      setError(t('mobile.connect.error.authRequired'));
+      setError(t(mobilePairingFailureKey(error)));
     } finally {
       endBusy('pairing');
     }

--- a/packages/ui/src/components/desktop/DesktopHostSwitcher.tsx
+++ b/packages/ui/src/components/desktop/DesktopHostSwitcher.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { toast } from '@/components/ui';
-import { isElectronShell, isDesktopShell } from '@/lib/desktop';
+import { isDesktopLocalOriginActive, isElectronShell, isDesktopShell } from '@/lib/desktop';
 import { Icon } from "@/components/icon/Icon";
 import { useUIStore } from '@/stores/useUIStore';
 import { useI18n } from '@/lib/i18n';
@@ -25,15 +25,16 @@ import {
   getDesktopHostApiUrl,
   locationMatchesHost,
   normalizeHostUrl,
-  probeRelayDesktopHost,
+  getDesktopHostRuntimeSwitchOptions,
+  probeDesktopHostTransports,
   redactSensitiveUrl,
   resolveDesktopHostUrl,
+  shouldDelegateDesktopHostActivation,
   type DesktopHost,
   type HostProbeResult,
 } from '@/lib/desktopHosts';
 import { scheduleDesktopHostCandidateRefresh } from '@/lib/desktopRelayRestore';
 import { adoptRelayTunnel } from '@/lib/relay/runtime-tunnel';
-import { createRelayTunnelClient } from '@/lib/relay/tunnel-client';
 import { getRuntimeApiBaseUrl, getRuntimeKey, subscribeRuntimeEndpointChanged, switchRuntimeEndpoint } from '@/lib/runtime-switch';
 import {
   desktopSshConnect,
@@ -56,7 +57,7 @@ type HostStatus = {
   status: HostProbeResult['status'];
   latencyMs: number;
   /** Which transport the successful probe used (multi-transport hosts). */
-  via?: 'relay';
+  via?: 'direct' | 'relay' | 'direct-e2ee';
 };
 
 // Last known statuses survive the dropdown unmounting (it remounts on every
@@ -253,7 +254,7 @@ const resolveCurrentHost = (hosts: DesktopHost[]) => {
   // matching can't distinguish them — identify the active relay host by its
   // stable runtime key instead.
   const activeRuntimeKey = getRuntimeKey();
-  const relayMatch = hosts.find((h) => h.relay && runtimeKeyForHost(h) === activeRuntimeKey);
+  const relayMatch = hosts.find((h) => (h.relay || h.directE2ee) && runtimeKeyForHost(h) === activeRuntimeKey);
   if (relayMatch) {
     return { id: relayMatch.id, label: relayMatch.label, url: relayMatch.url };
   }
@@ -429,32 +430,15 @@ export function DesktopHostSwitcherDialog({
 
   const probeAll = React.useCallback(async (hosts: DesktopHost[]) => {
     if (!isDesktopShell()) return;
+    if (isElectronShell() && !isDesktopLocalOriginActive()) return;
     setIsProbing(true);
     try {
       const localClientToken = await getLocalClientToken();
       const results = await Promise.all(
         hosts.map(async (h) => {
-          const probeRelayLeg = async (): Promise<HostStatus> => {
-            const res = await probeRelayDesktopHost(h.relay!).catch((): HostProbeResult => ({ status: 'unreachable', latencyMs: 0 }));
-            return { status: res.status, latencyMs: res.latencyMs, ...(res.status === 'ok' ? { via: 'relay' as const } : {}) };
-          };
-          // Relay-only host: no HTTP address — probe through the E2EE tunnel.
-          if (h.relay && !h.apiUrl) {
-            return [h.id, await probeRelayLeg()] as const;
-          }
-          const url = normalizeHostUrl(isElectronShell() ? getDesktopHostApiUrl(h) : h.url);
-          if (!url) {
-            return [h.id, { status: 'unreachable' as const, latencyMs: 0 } satisfies HostStatus] as const;
-          }
           const clientToken = h.id === LOCAL_HOST_ID ? localClientToken : (h.clientToken || '');
-          const res = await desktopHostProbe(url, { clientToken: clientToken || null, requestHeaders: h.requestHeaders || null }).catch((): HostProbeResult => ({ status: 'unreachable', latencyMs: 0 }));
-          // Multi-transport host away from its network: the direct leg fails
-          // but the relay may still reach it.
-          if (isBlockedHostStatus(res.status) && h.relay) {
-            const relayStatus = await probeRelayLeg();
-            if (relayStatus.status === 'ok') return [h.id, relayStatus] as const;
-          }
-          return [h.id, { status: res.status, latencyMs: res.latencyMs } satisfies HostStatus] as const;
+          const selection = await probeDesktopHostTransports({ ...h, ...(clientToken ? { clientToken } : {}) });
+          return [h.id, { ...selection.probe, ...(selection.transport ? { via: selection.transport.kind } : {}) } satisfies HostStatus] as const;
         })
       );
       const next: Record<string, HostStatus> = {};
@@ -512,34 +496,51 @@ export function DesktopHostSwitcherDialog({
   }, [open]);
 
   const handleSwitch = React.useCallback(async (host: DesktopHost) => {
+    if (isElectronShell() && shouldDelegateDesktopHostActivation(isDesktopLocalOriginActive())) {
+      setSwitchingHostId(host.id);
+      try {
+        await desktopOpenNewWindowForHost(host.id);
+        onHostSwitched?.();
+      } finally {
+        setSwitchingHostId(null);
+      }
+      return;
+    }
     // Relay legs ride the E2EE tunnel activated in-renderer via
     // switchRuntimeEndpoint({ relay }); the runtime fetch/socket layers route
     // through the tunnel from the singleton registry.
-    const activateRelay = (relay: NonNullable<DesktopHost['relay']>, liveTunnel?: ReturnType<typeof createRelayTunnelClient>) => {
-      // Adopt the probe's live tunnel (when it kept one) BEFORE the switch: the
-      // activate call inside switchRuntimeEndpoint sees an equal descriptor and
-      // reuses it — no second WebSocket connect + E2EE handshake.
-      if (liveTunnel) {
-        adoptRelayTunnel({ relayUrl: relay.relayUrl, serverId: relay.serverId, hostEncPubJwk: relay.hostEncPubJwk }, liveTunnel);
+    const activateTransport = (
+      transport: NonNullable<Awaited<ReturnType<typeof probeDesktopHostTransports>>['transport']>,
+      clientToken: string,
+    ): boolean => {
+      const options = getDesktopHostRuntimeSwitchOptions(
+        { ...host, clientToken: clientToken || undefined },
+        transport,
+        window.location.origin,
+        runtimeKeyForHost(host),
+      );
+      if (!options) {
+        if (transport.kind === 'relay') transport.tunnel?.close();
+        return false;
       }
-      switchRuntimeEndpoint({
-        apiBaseUrl: typeof window !== 'undefined' ? window.location.origin : '',
-        clientToken: host.clientToken || null,
-        runtimeKey: runtimeKeyForHost(host),
-        relay,
-      });
-      // On the relay: learn the server's current LAN address in the background
-      // and hot-switch back to direct if the stored one merely went stale.
-      scheduleDesktopHostCandidateRefresh(host.id);
+      // Adopt the probe's live relay tunnel before switching so activation does
+      // not pay for a second WebSocket connection and E2EE handshake.
+      if (transport.kind === 'relay' && transport.tunnel) {
+        adoptRelayTunnel(transport.descriptor, transport.tunnel);
+      }
+      switchRuntimeEndpoint(options);
+      if (transport.kind === 'relay') {
+        scheduleDesktopHostCandidateRefresh(host.id);
+      }
+      return true;
     };
-
     const origin = host.id === LOCAL_HOST_ID ? localOrigin : (normalizeHostUrl(host.url) || '');
     const apiOrigin = host.id === LOCAL_HOST_ID ? localOrigin : (normalizeHostUrl(getDesktopHostApiUrl(host)) || '');
-    const relayOnly = Boolean(host.relay) && !host.apiUrl && host.id !== LOCAL_HOST_ID;
+    const relayOnly = Boolean(host.relay || host.directE2ee) && !host.apiUrl && host.id !== LOCAL_HOST_ID;
     if (!origin && !relayOnly) return;
 
     if (isElectronShell()) {
-      if (!apiOrigin && !host.relay) return;
+      if (!apiOrigin && !host.relay && !host.directE2ee) return;
       setSwitchingHostId(host.id);
       const clientToken = host.id === LOCAL_HOST_ID ? await getLocalClientToken() : (host.clientToken || '');
 
@@ -548,12 +549,16 @@ export function DesktopHostSwitcherDialog({
       // flashed transient Unreachable states over a known-good host).
       const cached = statusById[host.id];
       if (cached?.status === 'ok') {
-        if (cached.via === 'relay' && host.relay) {
-          activateRelay(host.relay);
-        } else if (apiOrigin) {
-          switchRuntimeEndpoint({ apiBaseUrl: apiOrigin, clientToken: clientToken || null, requestHeaders: host.requestHeaders || null, runtimeKey: runtimeKeyForHost(host) });
-        } else if (host.relay) {
-          activateRelay(host.relay);
+        const transport = cached.via === 'direct-e2ee' && host.directE2ee
+          ? { kind: 'direct-e2ee' as const, descriptor: host.directE2ee }
+          : cached.via === 'relay' && host.relay
+            ? { kind: 'relay' as const, descriptor: host.relay }
+            : cached.via === 'direct' && apiOrigin
+              ? { kind: 'direct' as const, url: apiOrigin }
+              : null;
+        if (!transport || !activateTransport(transport, clientToken)) {
+          setSwitchingHostId(null);
+          return;
         }
         onHostSwitched?.();
         setSwitchingHostId(null);
@@ -563,34 +568,30 @@ export function DesktopHostSwitcherDialog({
       // No usable probe result — probe now: direct first, relay fallback.
       // Statuses are written once, with the final outcome, so the row never
       // flashes intermediate failures while the fallback is still running.
-      let finalStatus: HostStatus = { status: 'unreachable', latencyMs: 0 };
-      let transport: 'direct' | 'relay' | null = null;
-      if (apiOrigin) {
-        const probe = await desktopHostProbe(apiOrigin, { clientToken: clientToken || null, requestHeaders: host.requestHeaders || null }).catch((): HostProbeResult => ({ status: 'unreachable', latencyMs: 0 }));
-        finalStatus = { status: probe.status, latencyMs: probe.latencyMs };
-        if (!isBlockedHostStatus(probe.status)) transport = 'direct';
-      }
-      let relayProbeTunnel: ReturnType<typeof createRelayTunnelClient> | undefined;
-      if (!transport && host.relay) {
-        const probe = await probeRelayDesktopHost(host.relay, { keepTunnel: true })
-          .catch((): HostProbeResult => ({ status: 'unreachable', latencyMs: 0 }));
-        if (probe.status === 'ok') {
-          finalStatus = { status: probe.status, latencyMs: probe.latencyMs, via: 'relay' };
-          transport = 'relay';
-          relayProbeTunnel = 'tunnel' in probe ? probe.tunnel : undefined;
-        }
-      }
+      const selection = await probeDesktopHostTransports({ ...host, ...(clientToken ? { clientToken } : {}) });
+      const finalStatus: HostStatus = { ...selection.probe, ...(selection.transport ? { via: selection.transport.kind } : {}) };
       setStatusById((prev) => ({ ...prev, [host.id]: finalStatus }));
 
-      if (!transport) {
+      if (!selection.transport) {
         toast.error(t('desktopHostSwitcher.toast.instanceUnreachable', { host: redactSensitiveUrl(host.label) }));
         setSwitchingHostId(null);
         return;
       }
-      if (transport === 'relay' && host.relay) {
-        activateRelay(host.relay, relayProbeTunnel);
-      } else {
-        switchRuntimeEndpoint({ apiBaseUrl: apiOrigin, clientToken: clientToken || null, requestHeaders: host.requestHeaders || null, runtimeKey: runtimeKeyForHost(host) });
+      if (!activateTransport(selection.transport, clientToken)) {
+        setSwitchingHostId(null);
+        return;
+      }
+      if (selection.lateDirect && selection.directUrl) {
+        void selection.lateDirect.then((probe) => {
+          if (isBlockedHostStatus(probe.status)) return;
+          if (getRuntimeKey() !== runtimeKeyForHost(host)) return;
+          switchRuntimeEndpoint({
+            apiBaseUrl: selection.directUrl!,
+            clientToken: clientToken || null,
+            requestHeaders: host.requestHeaders || null,
+            runtimeKey: runtimeKeyForHost(host),
+          });
+        });
       }
       onHostSwitched?.();
       setSwitchingHostId(null);
@@ -752,9 +753,13 @@ export function DesktopHostSwitcherDialog({
         description: err instanceof Error ? err.message : String(err),
       });
     };
+    if (isElectronShell() && shouldDelegateDesktopHostActivation(isDesktopLocalOriginActive())) {
+      desktopOpenNewWindowForHost(host.id).catch(reportFailure);
+      return;
+    }
     // Relay-capable hosts can't be expressed as a fixed window URL — the new
     // window boots the local UI and picks direct-vs-tunnel itself.
-    if (host.relay && host.id !== LOCAL_HOST_ID) {
+    if ((host.relay || host.directE2ee) && host.id !== LOCAL_HOST_ID) {
       desktopOpenNewWindowForHost(host.id).catch(reportFailure);
       return;
     }
@@ -943,7 +948,7 @@ export function DesktopHostSwitcherDialog({
                 // Relay-only hosts have a relay:// pseudo-URL that means nothing
                 // to a person — say how the connection works instead. Hosts with
                 // a direct leg show their address.
-                const displayUrl = host.relay && !host.apiUrl ? t('mobile.connect.relay.badge') : redactSensitiveUrl(effectiveUrl);
+                 const displayUrl = (host.relay || host.directE2ee) && !host.apiUrl ? t('mobile.connect.relay.badge') : redactSensitiveUrl(effectiveUrl);
 
                 return (
                   <div

--- a/packages/ui/src/components/desktop/DesktopHostSwitcher.tsx
+++ b/packages/ui/src/components/desktop/DesktopHostSwitcher.tsx
@@ -27,6 +27,7 @@ import {
   normalizeHostUrl,
   getDesktopHostRuntimeSwitchOptions,
   probeDesktopHostTransports,
+  probeDesktopHostTransportsForActivation,
   redactSensitiveUrl,
   resolveDesktopHostUrl,
   shouldDelegateDesktopHostActivation,
@@ -548,14 +549,8 @@ export function DesktopHostSwitcherDialog({
       // result instead of re-probing (re-probes doubled the switch latency and
       // flashed transient Unreachable states over a known-good host).
       const cached = statusById[host.id];
-      if (cached?.status === 'ok') {
-        const transport = cached.via === 'direct-e2ee' && host.directE2ee
-          ? { kind: 'direct-e2ee' as const, descriptor: host.directE2ee }
-          : cached.via === 'relay' && host.relay
-            ? { kind: 'relay' as const, descriptor: host.relay }
-            : cached.via === 'direct' && apiOrigin
-              ? { kind: 'direct' as const, url: apiOrigin }
-              : null;
+      if (cached?.status === 'ok' && cached.via === 'direct') {
+        const transport = apiOrigin ? { kind: 'direct' as const, url: apiOrigin } : null;
         if (!transport || !activateTransport(transport, clientToken)) {
           setSwitchingHostId(null);
           return;
@@ -568,7 +563,7 @@ export function DesktopHostSwitcherDialog({
       // No usable probe result — probe now: direct first, relay fallback.
       // Statuses are written once, with the final outcome, so the row never
       // flashes intermediate failures while the fallback is still running.
-      const selection = await probeDesktopHostTransports({ ...host, ...(clientToken ? { clientToken } : {}) });
+      const selection = await probeDesktopHostTransportsForActivation({ ...host, ...(clientToken ? { clientToken } : {}) });
       const finalStatus: HostStatus = { ...selection.probe, ...(selection.transport ? { via: selection.transport.kind } : {}) };
       setStatusById((prev) => ({ ...prev, [host.id]: finalStatus }));
 

--- a/packages/ui/src/components/sections/remote-instances/RemoteInstancesPage.tsx
+++ b/packages/ui/src/components/sections/remote-instances/RemoteInstancesPage.tsx
@@ -600,6 +600,11 @@ export const RemoteInstancesPage: React.FC = () => {
         }
         continue;
       }
+      if (candidate.type === 'direct-e2ee') {
+        // PR D teaches shared clients to parse the encrypted candidate; the
+        // managed-tunnel pairing UI is enabled by the following settings layer.
+        continue;
+      }
       // Direct: the remote instance is a user-provided URL, so a plain
       // cross-origin fetch is correct here (not the active runtime).
       const candidateUrl = normalizeHostUrl(candidate.url);

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -1177,6 +1177,7 @@ export interface ClientAuthAPI {
     // produces a relay-only link (no direct candidate).
     includeRelay?: boolean;
     includeDirect?: boolean;
+    includeDirectE2ee?: boolean;
   }): Promise<PairingSessionCreateResult>;
   purgeRevokedClients(): Promise<RemoteClientPurgeRevokedResult>;
   revokeClient(id: string): Promise<RemoteClientRevokeResult>;
@@ -1185,7 +1186,7 @@ export interface ClientAuthAPI {
   cancelPairing(id: string): Promise<{ cancelled: boolean }>;
   // Direct transports the server can be reached on, for the create-device dialog.
   // LAN reflects the server's actual bind, independent of the UI origin.
-  getPairingTransports(): Promise<{ local: string | null; lan: string | null; relayAvailable: boolean }>;
+  getPairingTransports(): Promise<{ local: string | null; lan: string | null; relayAvailable: boolean; directE2eeAvailable?: boolean }>;
 }
 
 export interface RuntimeAPIs {

--- a/packages/ui/src/lib/connectionPayload.test.ts
+++ b/packages/ui/src/lib/connectionPayload.test.ts
@@ -74,6 +74,38 @@ describe('connection payload helpers', () => {
     expect(parsed?.candidates[0]).toEqual({ type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'srv', hostEncPubJwk });
   });
 
+  test('normalizes a strict direct E2EE candidate and drops private JWK fields', () => {
+    const encoded = Buffer.from(JSON.stringify({
+      v: 2,
+      pairingId: 'pair_direct_e2ee',
+      secret: 'secret',
+      candidates: [{
+        type: 'direct-e2ee',
+        wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws',
+        hostEncPubJwk: { ...hostEncPubJwk, d: 'private', unknown: true },
+      }],
+    })).toString('base64url');
+    expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${encoded}`)?.candidates).toEqual([{
+      type: 'direct-e2ee',
+      wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws',
+      hostEncPubJwk,
+    }]);
+  });
+
+  test('drops unsafe direct E2EE candidates and unknown candidate types', () => {
+    for (const wssUrl of [
+      'https://host.example/api/openchamber/direct-e2ee/ws',
+      'ws://host.example/api/openchamber/direct-e2ee/ws',
+      'wss://user:pass@host.example/api/openchamber/direct-e2ee/ws',
+      'wss://host.example/api/openchamber/direct-e2ee/ws?token=x',
+      'wss://host.example/api/openchamber/direct-e2ee/ws#fragment',
+      'wss://host.example/wrong',
+    ]) {
+      const encoded = Buffer.from(JSON.stringify({ v: 2, pairingId: 'p', secret: 's', candidates: [{ type: 'direct-e2ee', wssUrl, hostEncPubJwk }] })).toString('base64url');
+      expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${encoded}`)).toBeNull();
+    }
+  });
+
   test('rejects invalid v2 pairing payloads', () => {
     expect(parsePairingConnectionPayload('openchamber://connect?v=1&server=https://runtime.example&token=t')).toBeNull();
     expect(parsePairingConnectionPayload('openchamber://connect?v=2&p=not-json')).toBeNull();

--- a/packages/ui/src/lib/connectionPayload.ts
+++ b/packages/ui/src/lib/connectionPayload.ts
@@ -26,7 +26,14 @@ export type PairingRelayCandidate = {
   priority?: number;
 };
 
-export type PairingEndpointCandidate = PairingDirectCandidate | PairingRelayCandidate;
+export type PairingDirectE2eeCandidate = {
+  type: 'direct-e2ee';
+  wssUrl: string;
+  hostEncPubJwk: JsonWebKey;
+  priority?: number;
+};
+
+export type PairingEndpointCandidate = PairingDirectCandidate | PairingRelayCandidate | PairingDirectE2eeCandidate;
 
 export type PairingConnectionPayload = {
   v: 2;
@@ -105,7 +112,7 @@ const isNonEmptyString = (value: unknown): value is string => typeof value === '
 
 // EC P-256 public JWK (the relay E2EE trust anchor). Strict: only the four
 // public-key members are retained; a private `d` or any other member is dropped.
-const normalizeEcPublicJwk = (value: unknown): JsonWebKey | null => {
+export const normalizeEcPublicJwk = (value: unknown): JsonWebKey | null => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const jwk = value as Record<string, unknown>;
   if (jwk.kty !== 'EC' || jwk.crv !== 'P-256') return null;
@@ -113,10 +120,39 @@ const normalizeEcPublicJwk = (value: unknown): JsonWebKey | null => {
   return { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y };
 };
 
+export const normalizeDirectE2eeCandidate = (
+  value: unknown,
+  options: { allowInsecureLocal?: boolean } = {},
+): PairingDirectE2eeCandidate | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (record.type !== 'direct-e2ee' || typeof record.wssUrl !== 'string') return null;
+  try {
+    const url = new URL(record.wssUrl.trim());
+    const localTestUrl = options.allowInsecureLocal === true
+      && url.protocol === 'ws:'
+      && (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1');
+    if (url.protocol !== 'wss:' && !localTestUrl) return null;
+    if (url.username || url.password || url.search || url.hash) return null;
+    if (url.pathname !== '/api/openchamber/direct-e2ee/ws') return null;
+    const hostEncPubJwk = normalizeEcPublicJwk(record.hostEncPubJwk);
+    if (!hostEncPubJwk) return null;
+    const priority = normalizePriority(record.priority);
+    return {
+      type: 'direct-e2ee',
+      wssUrl: url.toString(),
+      hostEncPubJwk,
+      ...(priority === undefined ? {} : { priority }),
+    };
+  } catch {
+    return null;
+  }
+};
+
 const normalizePriority = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 
-const normalizePairingCandidate = (value: unknown): PairingEndpointCandidate | null => {
+export const normalizePairingCandidate = (value: unknown): PairingEndpointCandidate | null => {
   if (!value || typeof value !== 'object') return null;
   const record = value as Record<string, unknown>;
   const priority = normalizePriority(record.priority);
@@ -144,6 +180,8 @@ const normalizePairingCandidate = (value: unknown): PairingEndpointCandidate | n
       ...(priority === undefined ? {} : { priority }),
     };
   }
+
+  if (record.type === 'direct-e2ee') return normalizeDirectE2eeCandidate(record);
 
   return null;
 };

--- a/packages/ui/src/lib/desktopDirectE2eeRestore.test.ts
+++ b/packages/ui/src/lib/desktopDirectE2eeRestore.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { restoreDesktopRuntimeWithDependencies } from './desktopRelayRestore';
+import type { DesktopHost, DesktopHostSelection, DesktopHostsConfig } from './desktopHosts';
+
+const directE2ee = { wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } };
+const relay = { relayUrl: 'wss://relay.example/ws', serverId: 'server', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'rx', y: 'ry' } };
+const host: DesktopHost = { id: 'host-1', label: 'Host', url: 'https://lan.example', apiUrl: 'https://lan.example', clientToken: 'bearer', requestHeaders: { 'X-Test': 'yes' }, directE2ee, relay };
+
+describe('desktop encrypted runtime restore', () => {
+  let config: DesktopHostsConfig;
+  let selection: DesktopHostSelection;
+  let selectedHost: DesktopHost | null;
+  let switchCalls: Array<Record<string, unknown>>;
+
+  const restore = async (targetHostId?: string): Promise<void> => restoreDesktopRuntimeWithDependencies({
+    isElectronShell: () => true,
+    getHosts: async () => config,
+    selectTransport: async (value) => { selectedHost = value; return selection; },
+    getRuntimeKey: () => 'local',
+    switchRuntime: (options) => { switchCalls.push(options); },
+    windowOrigin: () => 'openchamber-ui://app',
+  }, targetHostId);
+
+  beforeEach(() => {
+    config = { hosts: [host], defaultHostId: host.id, initialHostChoiceCompleted: true };
+    selection = { probe: { status: 'unreachable', latencyMs: 0 }, transport: null };
+    selectedHost = null;
+    switchCalls = [];
+  });
+
+  test('restores direct first when selected', async () => {
+    selection = { probe: { status: 'ok', latencyMs: 1 }, transport: { kind: 'direct', url: host.apiUrl! } };
+    await restore();
+    expect(selectedHost).toEqual(host);
+    expect(switchCalls).toEqual([{ apiBaseUrl: host.apiUrl, clientToken: 'bearer', requestHeaders: host.requestHeaders, runtimeKey: 'host:host-1' }]);
+  });
+
+  test('restores direct E2EE after direct fallback', async () => {
+    selection = { probe: { status: 'ok', latencyMs: 2 }, transport: { kind: 'direct-e2ee', descriptor: directE2ee } };
+    await restore();
+    expect(switchCalls[0]?.tunnel).toEqual({ type: 'direct-e2ee', ...directE2ee });
+  });
+
+  test('restores hosted relay after direct and direct E2EE fallback', async () => {
+    selection = { probe: { status: 'ok', latencyMs: 3 }, transport: { kind: 'relay', descriptor: relay } };
+    await restore();
+    expect(switchCalls[0]?.relay).toEqual(relay);
+  });
+
+  test('does not switch when every transport fails', async () => {
+    await restore();
+    expect(switchCalls).toEqual([]);
+  });
+
+  test('does not publish a migrated tokenless direct-E2EE selection', async () => {
+    config = { hosts: [{ ...host, clientToken: undefined, apiUrl: undefined, url: 'direct-e2ee://host.example', relay: undefined }], defaultHostId: host.id, initialHostChoiceCompleted: true };
+    selection = { probe: { status: 'ok', latencyMs: 1 }, transport: { kind: 'direct-e2ee', descriptor: directE2ee } };
+    await restore();
+    expect(switchCalls).toEqual([]);
+  });
+
+  test('explicit target and restart with both descriptors preserve runtime-key semantics', async () => {
+    const other = { ...host, id: 'other', apiUrl: undefined, url: 'direct-e2ee://host.example' };
+    config = { hosts: [host, other], defaultHostId: host.id, initialHostChoiceCompleted: true };
+    selection = { probe: { status: 'ok', latencyMs: 2 }, transport: { kind: 'direct-e2ee', descriptor: directE2ee } };
+    await restore(other.id);
+    expect(selectedHost?.id).toBe(other.id);
+    expect(switchCalls[0]?.runtimeKey).toBe('host:other');
+  });
+});

--- a/packages/ui/src/lib/desktopHosts.test.ts
+++ b/packages/ui/src/lib/desktopHosts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { desktopHostProbe, desktopHostsGet, desktopHostsSet, directE2eeHostFingerprint, getDesktopHostRuntimeSwitchOptions, probeDesktopHostTransports, redactSensitiveUrl, resolveDesktopHostUrl, shouldDelegateDesktopHostActivation } from './desktopHosts';
+import { desktopHostProbe, desktopHostsGet, desktopHostsSet, directE2eeHostFingerprint, getDesktopHostRuntimeSwitchOptions, probeDesktopHostTransports, probeDesktopHostTransportsForActivation, redactSensitiveUrl, resolveDesktopHostUrl, shouldDelegateDesktopHostActivation } from './desktopHosts';
 import type { DesktopHost, HostProbeResult } from './desktopHosts';
 
 const withDesktopBridge = async <T>(handler: (cmd: string, args: Record<string, unknown>) => unknown | Promise<unknown>, run: () => Promise<T>): Promise<T> => {
@@ -236,6 +236,35 @@ describe('probeDesktopHostTransports', () => {
 
   test('runtime options refuse tokenless direct E2EE activation', () => {
     expect(getDesktopHostRuntimeSwitchOptions({ id: 'host', label: 'Host', url: 'direct-e2ee://host.example', directE2ee }, { kind: 'direct-e2ee', descriptor: directE2ee }, 'openchamber-ui://app', 'host:host')).toBeNull();
+  });
+
+  test('status probes close and omit relay tunnels by default', async () => {
+    let closeCalls = 0;
+    const close = () => { closeCalls += 1; };
+    const tunnel = { close } as never;
+    const selected = await probeDesktopHostTransports({ id: 'host', label: 'Host', url: 'relay://server', relay }, {
+      probeDirect: async () => result('unreachable'),
+      probeDirectE2ee: async () => result('unreachable'),
+      probeRelay: async () => ({ ...result('ok'), tunnel }),
+    });
+
+    expect(selected.transport).toEqual({ kind: 'relay', descriptor: relay });
+    expect('tunnel' in selected.probe).toBe(false);
+    expect(closeCalls).toBe(1);
+  });
+
+  test('activation probes retain and return the live relay tunnel', async () => {
+    let closeCalls = 0;
+    const close = () => { closeCalls += 1; };
+    const tunnel = { close } as never;
+    const selected = await probeDesktopHostTransportsForActivation({ id: 'host', label: 'Host', url: 'relay://server', relay }, {
+      probeDirect: async () => result('unreachable'),
+      probeDirectE2ee: async () => result('unreachable'),
+      probeRelay: async (_descriptor, _token, options) => ({ ...result('ok'), tunnel: options.keepTunnel ? tunnel : undefined }),
+    });
+
+    expect(selected.transport).toEqual({ kind: 'relay', descriptor: relay, tunnel });
+    expect(closeCalls).toBe(0);
   });
 });
 

--- a/packages/ui/src/lib/desktopHosts.test.ts
+++ b/packages/ui/src/lib/desktopHosts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { desktopHostProbe, desktopHostsGet, desktopHostsSet, redactSensitiveUrl, resolveDesktopHostUrl } from './desktopHosts';
+import { desktopHostProbe, desktopHostsGet, desktopHostsSet, directE2eeHostFingerprint, getDesktopHostRuntimeSwitchOptions, probeDesktopHostTransports, redactSensitiveUrl, resolveDesktopHostUrl, shouldDelegateDesktopHostActivation } from './desktopHosts';
+import type { DesktopHost, HostProbeResult } from './desktopHosts';
 
 const withDesktopBridge = async <T>(handler: (cmd: string, args: Record<string, unknown>) => unknown | Promise<unknown>, run: () => Promise<T>): Promise<T> => {
   const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
@@ -55,6 +56,19 @@ describe('resolveDesktopHostUrl', () => {
 });
 
 describe('desktop host runtime headers', () => {
+  test('strictly parses a direct E2EE descriptor and drops private key fields', async () => {
+    await withDesktopBridge(async () => ({
+      hosts: [{ id: 'e2ee', label: 'E2EE', url: 'direct-e2ee://host.example', directE2ee: {
+        wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws',
+        hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y', d: 'private' },
+      } }],
+      defaultHostId: 'e2ee',
+    }), async () => {
+      const host = (await desktopHostsGet()).hosts[0]!;
+      expect(host.directE2ee?.hostEncPubJwk).toEqual({ kty: 'EC', crv: 'P-256', x: 'x', y: 'y' });
+      expect(directE2eeHostFingerprint(host.directE2ee!)).toBe('p256:x.y');
+    });
+  });
   test('parses persisted request headers from desktop config', async () => {
     await withDesktopBridge(async (cmd) => {
       expect(cmd).toBe('desktop_hosts_get');
@@ -113,5 +127,121 @@ describe('desktop host runtime headers', () => {
         requestHeaders: { 'CF-Access-Client-Id': 'client-id' },
       },
     });
+  });
+});
+
+describe('probeDesktopHostTransports', () => {
+  const directE2ee = { wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } };
+  const relay = { relayUrl: 'wss://relay.example/ws', serverId: 'server', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'rx', y: 'ry' } };
+  const host: DesktopHost = { id: 'host', label: 'Host', url: 'https://direct.example', apiUrl: 'https://direct.example', clientToken: 'bearer', requestHeaders: { 'X-Test': 'yes' }, directE2ee, relay };
+  const result = (status: HostProbeResult['status']): HostProbeResult => ({ status, latencyMs: 1 });
+
+  test('direct success skips encrypted transports', async () => {
+    const calls: string[] = [];
+    const selected = await probeDesktopHostTransports(host, {
+      probeDirect: async (_url, options) => { calls.push(`direct:${options.clientToken}:${options.requestHeaders?.['X-Test']}`); return result('ok'); },
+      probeDirectE2ee: async () => { calls.push('direct-e2ee'); return result('ok'); },
+      probeRelay: async () => { calls.push('relay'); return result('ok'); },
+    });
+    expect(calls).toEqual(['direct:bearer:yes']);
+    expect(selected.transport).toEqual({ kind: 'direct', url: 'https://direct.example' });
+  });
+
+  test('blocked direct falls through to direct E2EE and skips relay', async () => {
+    const calls: string[] = [];
+    const selected = await probeDesktopHostTransports(host, {
+      probeDirect: async () => { calls.push('direct'); return result('wrong-service'); },
+      probeDirectE2ee: async (_descriptor, token) => { calls.push(`direct-e2ee:${token}`); return result('ok'); },
+      probeRelay: async () => { calls.push('relay'); return result('ok'); },
+    });
+    expect(calls).toEqual(['direct', 'direct-e2ee:bearer']);
+    expect(selected.transport?.kind).toBe('direct-e2ee');
+  });
+
+  test('direct E2EE auth or reachability failure falls through to relay', async () => {
+    for (const status of ['auth', 'unreachable'] as const) {
+      const calls: string[] = [];
+      const selected = await probeDesktopHostTransports({ ...host, apiUrl: undefined, url: 'direct-e2ee://host.example' }, {
+        probeDirect: async () => { calls.push('direct'); return result('ok'); },
+        probeDirectE2ee: async () => { calls.push('direct-e2ee'); return result(status); },
+        probeRelay: async (_descriptor, token) => { calls.push(`relay:${token}`); return result('ok'); },
+      });
+      expect(calls).toEqual(['direct-e2ee', 'relay:bearer']);
+      expect(selected.transport?.kind).toBe('relay');
+    }
+  });
+
+  test('direct E2EE security failures do not probe relay', async () => {
+    for (const failureClassification of ['crypto', 'protocol', 'terminal'] as const) {
+      const calls: string[] = [];
+      const selected = await probeDesktopHostTransports({ ...host, apiUrl: undefined, url: 'direct-e2ee://host.example' }, {
+        probeDirect: async () => result('ok'),
+        probeDirectE2ee: async () => { calls.push('direct-e2ee'); return { ...result('unreachable'), failureClassification }; },
+        probeRelay: async () => { calls.push('relay'); return result('ok'); },
+      });
+      expect(calls).toEqual(['direct-e2ee']);
+      expect(selected).toEqual({ probe: { ...result('unreachable'), failureClassification }, transport: null });
+    }
+  });
+
+  test('returns the final failure when every candidate fails', async () => {
+    const selected = await probeDesktopHostTransports(host, {
+      probeDirect: async () => result('unreachable'),
+      probeDirectE2ee: async () => result('auth'),
+      probeRelay: async () => result('unreachable'),
+    });
+    expect(selected).toEqual({ probe: result('unreachable'), transport: null });
+  });
+
+  test('direct-only host probes its HTTP descriptor', async () => {
+    const directOnly: DesktopHost = { id: 'direct', label: 'Direct', url: 'https://direct.example', apiUrl: 'https://direct.example' };
+    let probed = '';
+    const selected = await probeDesktopHostTransports(directOnly, {
+      probeDirect: async (url) => { probed = url; return result('ok'); },
+      probeDirectE2ee: async () => result('unreachable'),
+      probeRelay: async () => result('unreachable'),
+    });
+    expect(probed).toBe('https://direct.example');
+    expect(selected.transport?.kind).toBe('direct');
+  });
+
+  test('cached selected transport activates the exact descriptor', () => {
+    expect(getDesktopHostRuntimeSwitchOptions(host, { kind: 'relay', descriptor: relay }, 'openchamber-ui://app', 'host:host')).toEqual({
+      apiBaseUrl: 'openchamber-ui://app', clientToken: 'bearer', runtimeKey: 'host:host', relay,
+    });
+    expect(getDesktopHostRuntimeSwitchOptions(host, { kind: 'direct-e2ee', descriptor: directE2ee }, 'openchamber-ui://app', 'host:host')?.tunnel).toEqual({ type: 'direct-e2ee', ...directE2ee });
+  });
+
+  test('direct-only without a token returns auth without opening a tunnel', async () => {
+    let directE2eeCalls = 0;
+    const selected = await probeDesktopHostTransports({ id: 'host', label: 'Host', url: 'direct-e2ee://host.example', directE2ee }, {
+      probeDirect: async () => result('unreachable'),
+      probeDirectE2ee: async () => { directE2eeCalls += 1; return result('ok'); },
+      probeRelay: async () => result('ok'),
+    });
+    expect(directE2eeCalls).toBe(0);
+    expect(selected).toEqual({ probe: result('auth'), transport: null });
+  });
+
+  test('direct plus relay without a token skips direct E2EE and selects a valid relay', async () => {
+    const calls: string[] = [];
+    const selected = await probeDesktopHostTransports({ id: 'host', label: 'Host', url: 'direct-e2ee://host.example', directE2ee, relay }, {
+      probeDirect: async () => result('unreachable'),
+      probeDirectE2ee: async () => { calls.push('direct-e2ee'); return result('ok'); },
+      probeRelay: async (_descriptor, token) => { calls.push(`relay:${token}`); return result('ok'); },
+    });
+    expect(calls).toEqual(['relay:null']);
+    expect(selected.transport?.kind).toBe('relay');
+  });
+
+  test('runtime options refuse tokenless direct E2EE activation', () => {
+    expect(getDesktopHostRuntimeSwitchOptions({ id: 'host', label: 'Host', url: 'direct-e2ee://host.example', directE2ee }, { kind: 'direct-e2ee', descriptor: directE2ee }, 'openchamber-ui://app', 'host:host')).toBeNull();
+  });
+});
+
+describe('remote desktop host activation', () => {
+  test('delegates by opaque host id outside the local desktop origin', () => {
+    expect(shouldDelegateDesktopHostActivation(false)).toBe(true);
+    expect(shouldDelegateDesktopHostActivation(true)).toBe(false);
   });
 });

--- a/packages/ui/src/lib/desktopHosts.ts
+++ b/packages/ui/src/lib/desktopHosts.ts
@@ -371,8 +371,11 @@ export const probeRelayDesktopHost = async (
   // With `keepTunnel`, an 'ok' probe RETURNS its live tunnel (the caller owns
   // it — typically adopting it as the runtime tunnel, skipping a second
   // WebSocket connect + E2EE handshake); every other outcome closes it.
-  options?: { keepTunnel?: boolean; clientToken?: string | null },
+  optionsOrClientToken?: { keepTunnel?: boolean; clientToken?: string | null } | string | null,
 ): Promise<HostProbeResult & { tunnel?: ReturnType<typeof createRelayTunnelClient> }> => {
+  const options = typeof optionsOrClientToken === 'object'
+    ? optionsOrClientToken
+    : { clientToken: optionsOrClientToken };
   const tunnel = createRelayTunnelClient({
     relayUrl: relay.relayUrl,
     serverId: relay.serverId,

--- a/packages/ui/src/lib/desktopHosts.ts
+++ b/packages/ui/src/lib/desktopHosts.ts
@@ -111,6 +111,8 @@ export type DesktopHostTransport =
 export type DesktopHostSelection = {
   probe: HostProbeResult;
   transport: DesktopHostTransport | null;
+  lateDirect?: Promise<HostProbeResult>;
+  directUrl?: string;
 };
 
 export type DesktopHostRuntimeSwitchOptions = {
@@ -355,6 +357,7 @@ export const desktopInstallIdGet = async (): Promise<string> => {
 };
 
 const RELAY_PROBE_TIMEOUT_MS = 8_000;
+const RELAY_RACE_HEADSTART_MS = 1_500;
 
 /**
  * Reachability check for a relay host: open a throwaway E2EE tunnel and hit
@@ -457,17 +460,33 @@ export const probeDesktopHostTransports = async (
 ): Promise<DesktopHostSelection> => {
   let finalProbe = unreachableProbe();
   const directUrl = normalizeHostUrl(host.apiUrl || host.url);
-  if (directUrl) {
-    finalProbe = await dependencies.probeDirect(directUrl, {
+  const probeDirect = async (): Promise<HostProbeResult> => {
+    if (!directUrl) return unreachableProbe();
+    return dependencies.probeDirect(directUrl, {
       clientToken: host.clientToken || null,
       requestHeaders: host.requestHeaders || null,
       expectedServerId: host.relay?.serverId || null,
     }).catch(unreachableProbe);
-    if (!blockedDirectStatus(finalProbe.status)) {
-      return { probe: finalProbe, transport: { kind: 'direct', url: directUrl } };
-    }
-  }
+  };
+  const probeRelay = async (): Promise<DesktopHostSelection> => {
+    if (!host.relay) return { probe: unreachableProbe(), transport: null };
+    const probe: HostProbeResult & { tunnel?: ReturnType<typeof createRelayTunnelClient> } = await dependencies
+      .probeRelay(host.relay, host.clientToken || null)
+      .catch(unreachableProbe);
+    return !failedEncryptedStatus(probe.status)
+      ? { probe, transport: { kind: 'relay', descriptor: host.relay, tunnel: probe.tunnel } }
+      : { probe, transport: null };
+  };
+
+  // A managed direct-E2EE leg has terminal security semantics, so keep explicit
+  // candidate order and never let a relay race win before its verdict.
   if (host.directE2ee) {
+    if (directUrl) {
+      finalProbe = await probeDirect();
+      if (!blockedDirectStatus(finalProbe.status)) {
+        return { probe: finalProbe, transport: { kind: 'direct', url: directUrl } };
+      }
+    }
     if (!host.clientToken) {
       finalProbe = { status: 'auth', latencyMs: 1 };
     } else {
@@ -477,14 +496,54 @@ export const probeDesktopHostTransports = async (
       }
       if (terminalEncryptedFailure(finalProbe)) return { probe: finalProbe, transport: null };
     }
+    if (!host.relay) return { probe: finalProbe, transport: null };
+    return probeRelay();
   }
-  if (host.relay) {
-    finalProbe = await dependencies.probeRelay(host.relay, host.clientToken || null).catch(unreachableProbe);
-    if (!failedEncryptedStatus(finalProbe.status)) {
-      return { probe: finalProbe, transport: { kind: 'relay', descriptor: host.relay, tunnel: finalProbe.tunnel } };
+
+  if (!directUrl) return probeRelay();
+  if (!host.relay) {
+    finalProbe = await probeDirect();
+    return !blockedDirectStatus(finalProbe.status)
+      ? { probe: finalProbe, transport: { kind: 'direct', url: directUrl } }
+      : { probe: finalProbe, transport: null };
+  }
+
+  // Existing LAN+relay hosts retain direct priority while avoiding a full dead
+  // LAN timeout before relay startup. The relay selection carries the live probe
+  // tunnel, and the still-running LAN probe is exposed for a late hot-switch.
+  const directPromise = probeDirect();
+  const headstart = await Promise.race([
+    directPromise.then((probe) => ({ probe })),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), RELAY_RACE_HEADSTART_MS)),
+  ]);
+  if (headstart) {
+    if (!blockedDirectStatus(headstart.probe.status)) {
+      return { probe: headstart.probe, transport: { kind: 'direct', url: directUrl } };
     }
+    return probeRelay();
   }
-  return { probe: finalProbe, transport: null };
+
+  const relayPromise = probeRelay();
+  const first = await Promise.race([
+    directPromise.then((probe) => ({ kind: 'direct' as const, probe })),
+    relayPromise.then((selection) => ({ kind: 'relay' as const, selection })),
+  ]);
+  if (first.kind === 'direct') {
+    if (!blockedDirectStatus(first.probe.status)) {
+      void relayPromise.then((selection) => {
+        if (selection.transport?.kind === 'relay') selection.transport.tunnel?.close();
+      });
+      return { probe: first.probe, transport: { kind: 'direct', url: directUrl } };
+    }
+    return relayPromise;
+  }
+  if (first.selection.transport) {
+    return { ...first.selection, lateDirect: directPromise, directUrl };
+  }
+  const lateDirect = await directPromise;
+  return !blockedDirectStatus(lateDirect.status)
+    ? { probe: lateDirect, transport: { kind: 'direct', url: directUrl } }
+    : first.selection;
 };
 
 export const desktopHostProbe = async (url: string, options?: { clientToken?: string | null; requestHeaders?: Record<string, string> | null; expectedServerId?: string | null }): Promise<HostProbeResult> => {

--- a/packages/ui/src/lib/desktopHosts.ts
+++ b/packages/ui/src/lib/desktopHosts.ts
@@ -1,5 +1,7 @@
 import { hasDesktopInvoke, invokeDesktop } from '@/lib/desktop';
-import { createRelayTunnelClient } from '@/lib/relay/tunnel-client';
+import { createRelayTunnelClient, type RelayTunnelFailureClassification } from '@/lib/relay/tunnel-client';
+import { createDirectE2eeTunnelClient } from '@/lib/relay/direct-e2ee-tunnel-client';
+import { normalizeDirectE2eeCandidate } from '@/lib/connectionPayload';
 
 type DesktopInvoke = (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
 
@@ -37,6 +39,11 @@ export type DesktopHostRelay = {
   hostEncPubJwk: JsonWebKey;
 };
 
+export type DesktopHostDirectE2ee = {
+  wssUrl: string;
+  hostEncPubJwk: JsonWebKey;
+};
+
 export type DesktopHost = {
   id: string;
   label: string;
@@ -50,6 +57,7 @@ export type DesktopHost = {
   requestHeaders?: Record<string, string>;
   /** When set, this host is reached over the private relay tunnel. */
   relay?: DesktopHostRelay;
+  directE2ee?: DesktopHostDirectE2ee;
 };
 
 /** Display-only pseudo-URL for a relay host (never fetched). */
@@ -62,6 +70,16 @@ const parseHostRelay = (value: unknown): DesktopHostRelay | null => {
   const jwk = value.hostEncPubJwk ?? value.host_enc_pub_jwk;
   if (!relayUrl || !serverId || !isRecord(jwk)) return null;
   return { relayUrl, serverId, hostEncPubJwk: jwk as JsonWebKey };
+};
+
+const parseHostDirectE2ee = (value: unknown): DesktopHostDirectE2ee | null => {
+  const normalized = normalizeDirectE2eeCandidate(isRecord(value) ? { type: 'direct-e2ee', ...value } : value);
+  return normalized ? { wssUrl: normalized.wssUrl, hostEncPubJwk: normalized.hostEncPubJwk } : null;
+};
+
+export const directE2eeHostFingerprint = (descriptor: DesktopHostDirectE2ee): string => {
+  const key = descriptor.hostEncPubJwk;
+  return `p256:${key.x || ''}.${key.y || ''}`;
 };
 
 export type DesktopHostsConfig = {
@@ -82,6 +100,50 @@ export type DesktopHostsConfigInput = {
 export type HostProbeResult = {
   status: 'ok' | 'auth' | 'update-recommended' | 'incompatible' | 'wrong-service' | 'unreachable';
   latencyMs: number;
+  failureClassification?: RelayTunnelFailureClassification;
+};
+
+export type DesktopHostTransport =
+  | { kind: 'direct'; url: string }
+  | { kind: 'direct-e2ee'; descriptor: DesktopHostDirectE2ee }
+  | { kind: 'relay'; descriptor: DesktopHostRelay; tunnel?: ReturnType<typeof createRelayTunnelClient> };
+
+export type DesktopHostSelection = {
+  probe: HostProbeResult;
+  transport: DesktopHostTransport | null;
+};
+
+export type DesktopHostRuntimeSwitchOptions = {
+  apiBaseUrl: string;
+  clientToken: string | null;
+  runtimeKey: string;
+  requestHeaders?: Record<string, string> | null;
+  relay?: DesktopHostRelay;
+  tunnel?: { type: 'direct-e2ee' } & DesktopHostDirectE2ee;
+};
+
+export const shouldDelegateDesktopHostActivation = (isLocalDesktopOrigin: boolean): boolean => !isLocalDesktopOrigin;
+
+export const getDesktopHostRuntimeSwitchOptions = (
+  host: DesktopHost,
+  transport: DesktopHostTransport,
+  localUiOrigin: string,
+  runtimeKey: string,
+): DesktopHostRuntimeSwitchOptions | null => {
+  if (transport.kind === 'direct') {
+    return { apiBaseUrl: transport.url, clientToken: host.clientToken || null, requestHeaders: host.requestHeaders || null, runtimeKey };
+  }
+  if (transport.kind === 'direct-e2ee') {
+    if (!host.clientToken) return null;
+    return { apiBaseUrl: localUiOrigin, clientToken: host.clientToken || null, runtimeKey, tunnel: { type: 'direct-e2ee', ...transport.descriptor } };
+  }
+  return { apiBaseUrl: localUiOrigin, clientToken: host.clientToken || null, runtimeKey, relay: transport.descriptor };
+};
+
+export type DesktopHostProbeDependencies = {
+  probeDirect: (url: string, options: { clientToken: string | null; requestHeaders: Record<string, string> | null; expectedServerId?: string | null }) => Promise<HostProbeResult>;
+  probeDirectE2ee: (descriptor: DesktopHostDirectE2ee, clientToken: string | null) => Promise<HostProbeResult>;
+  probeRelay: (descriptor: DesktopHostRelay, clientToken: string | null) => Promise<HostProbeResult & { tunnel?: ReturnType<typeof createRelayTunnelClient> }>;
 };
 
 export type DesktopHostUrlResolution = {
@@ -205,7 +267,8 @@ const parseHost = (value: unknown): DesktopHost | null => {
   const clientToken = readString(value, 'clientToken') || readString(value, 'client_token');
   const requestHeaders = sanitizeRequestHeaders(value.requestHeaders);
   const relay = parseHostRelay(value.relay);
-  if (!id || !label || !url) return null;
+  const directE2ee = parseHostDirectE2ee(value.directE2ee ?? value.direct_e2ee);
+  if (!id || !label || !url || (!apiUrl && !relay && !directE2ee && !normalizeHostUrl(url))) return null;
   return {
     id,
     label,
@@ -214,6 +277,7 @@ const parseHost = (value: unknown): DesktopHost | null => {
     ...(clientToken ? { clientToken } : {}),
     ...(requestHeaders ? { requestHeaders } : {}),
     ...(relay ? { relay } : {}),
+    ...(directE2ee ? { directE2ee } : {}),
   };
 };
 
@@ -304,7 +368,7 @@ export const probeRelayDesktopHost = async (
   // With `keepTunnel`, an 'ok' probe RETURNS its live tunnel (the caller owns
   // it — typically adopting it as the runtime tunnel, skipping a second
   // WebSocket connect + E2EE handshake); every other outcome closes it.
-  options?: { keepTunnel?: boolean },
+  options?: { keepTunnel?: boolean; clientToken?: string | null },
 ): Promise<HostProbeResult & { tunnel?: ReturnType<typeof createRelayTunnelClient> }> => {
   const tunnel = createRelayTunnelClient({
     relayUrl: relay.relayUrl,
@@ -324,6 +388,21 @@ export const probeRelayDesktopHost = async (
       }),
     ]);
     if (!response?.ok) return { status: 'unreachable', latencyMs: 0 };
+    if (options?.clientToken) {
+      const session = await Promise.race([
+        tunnel.fetch('/auth/session', { headers: { Authorization: `Bearer ${options.clientToken}` } }),
+        new Promise<null>((resolve) => { globalThis.setTimeout(() => resolve(null), RELAY_PROBE_TIMEOUT_MS); }),
+      ]);
+      if (!session) return { status: 'unreachable', latencyMs: 0 };
+      if (session.status === 401 || session.status === 403) return { status: 'auth', latencyMs: Math.max(0, Date.now() - startedAt) };
+      // Older relay hosts may not expose session verification. Preserve their
+      // existing health-only behavior while verifying credentials where supported.
+      if (!session.ok && session.status !== 404) return { status: 'unreachable', latencyMs: 0 };
+      if (session.ok) {
+        const body: unknown = await session.json().catch(() => null);
+        if (!isRecord(body) || body.authenticated !== true) return { status: 'auth', latencyMs: Math.max(0, Date.now() - startedAt) };
+      }
+    }
     keep = options?.keepTunnel === true;
     return { status: 'ok', latencyMs: Math.max(0, Date.now() - startedAt), ...(keep ? { tunnel } : {}) };
   } catch {
@@ -331,6 +410,81 @@ export const probeRelayDesktopHost = async (
   } finally {
     if (!keep) tunnel.close();
   }
+};
+
+const probeDirectE2eeDesktopHost = async (descriptor: DesktopHostDirectE2ee, clientToken?: string | null): Promise<HostProbeResult> => {
+  const tunnel = createDirectE2eeTunnelClient(descriptor, clientToken);
+  const startedAt = Date.now();
+  try {
+    const response = await Promise.race([
+      tunnel.fetch('/health'),
+      new Promise<null>((resolve) => { window.setTimeout(() => resolve(null), RELAY_PROBE_TIMEOUT_MS); }),
+    ]);
+    const result: HostProbeResult = response?.status === 200
+      ? { status: 'ok', latencyMs: Math.max(0, Date.now() - startedAt) }
+      : { status: 'unreachable', latencyMs: 0 };
+    const failureClassification = tunnel.getStatus().failureClassification;
+    return failureClassification ? { ...result, failureClassification } : result;
+  } catch {
+    const failureClassification = tunnel.getStatus().failureClassification;
+    return failureClassification
+      ? { status: 'unreachable', latencyMs: 0, failureClassification }
+      : { status: 'unreachable', latencyMs: 0 };
+  } finally {
+    tunnel.close();
+  }
+};
+
+const blockedDirectStatus = (status: HostProbeResult['status']): boolean =>
+  status === 'unreachable' || status === 'wrong-service' || status === 'incompatible';
+
+const failedEncryptedStatus = (status: HostProbeResult['status']): boolean => status !== 'ok' && status !== 'update-recommended';
+
+const terminalEncryptedFailure = (probe: HostProbeResult): boolean =>
+  probe.failureClassification === 'crypto'
+  || probe.failureClassification === 'protocol'
+  || probe.failureClassification === 'terminal';
+
+const unreachableProbe = (): HostProbeResult => ({ status: 'unreachable', latencyMs: 0 });
+
+export const probeDesktopHostTransports = async (
+  host: DesktopHost,
+  dependencies: DesktopHostProbeDependencies = {
+    probeDirect: desktopHostProbe,
+    probeDirectE2ee: probeDirectE2eeDesktopHost,
+    probeRelay: (descriptor, clientToken) => probeRelayDesktopHost(descriptor, { clientToken, keepTunnel: true }),
+  },
+): Promise<DesktopHostSelection> => {
+  let finalProbe = unreachableProbe();
+  const directUrl = normalizeHostUrl(host.apiUrl || host.url);
+  if (directUrl) {
+    finalProbe = await dependencies.probeDirect(directUrl, {
+      clientToken: host.clientToken || null,
+      requestHeaders: host.requestHeaders || null,
+      expectedServerId: host.relay?.serverId || null,
+    }).catch(unreachableProbe);
+    if (!blockedDirectStatus(finalProbe.status)) {
+      return { probe: finalProbe, transport: { kind: 'direct', url: directUrl } };
+    }
+  }
+  if (host.directE2ee) {
+    if (!host.clientToken) {
+      finalProbe = { status: 'auth', latencyMs: 1 };
+    } else {
+      finalProbe = await dependencies.probeDirectE2ee(host.directE2ee, host.clientToken).catch(unreachableProbe);
+      if (!failedEncryptedStatus(finalProbe.status)) {
+        return { probe: finalProbe, transport: { kind: 'direct-e2ee', descriptor: host.directE2ee } };
+      }
+      if (terminalEncryptedFailure(finalProbe)) return { probe: finalProbe, transport: null };
+    }
+  }
+  if (host.relay) {
+    finalProbe = await dependencies.probeRelay(host.relay, host.clientToken || null).catch(unreachableProbe);
+    if (!failedEncryptedStatus(finalProbe.status)) {
+      return { probe: finalProbe, transport: { kind: 'relay', descriptor: host.relay, tunnel: finalProbe.tunnel } };
+    }
+  }
+  return { probe: finalProbe, transport: null };
 };
 
 export const desktopHostProbe = async (url: string, options?: { clientToken?: string | null; requestHeaders?: Record<string, string> | null; expectedServerId?: string | null }): Promise<HostProbeResult> => {

--- a/packages/ui/src/lib/desktopHosts.ts
+++ b/packages/ui/src/lib/desktopHosts.ts
@@ -145,7 +145,11 @@ export const getDesktopHostRuntimeSwitchOptions = (
 export type DesktopHostProbeDependencies = {
   probeDirect: (url: string, options: { clientToken: string | null; requestHeaders: Record<string, string> | null; expectedServerId?: string | null }) => Promise<HostProbeResult>;
   probeDirectE2ee: (descriptor: DesktopHostDirectE2ee, clientToken: string | null) => Promise<HostProbeResult>;
-  probeRelay: (descriptor: DesktopHostRelay, clientToken: string | null) => Promise<HostProbeResult & { tunnel?: ReturnType<typeof createRelayTunnelClient> }>;
+  probeRelay: (descriptor: DesktopHostRelay, clientToken: string | null, options: { keepTunnel: boolean }) => Promise<HostProbeResult & { tunnel?: ReturnType<typeof createRelayTunnelClient> }>;
+};
+
+export type DesktopHostTransportProbeOptions = {
+  retainRelayTunnel?: boolean;
 };
 
 export type DesktopHostUrlResolution = {
@@ -458,9 +462,11 @@ export const probeDesktopHostTransports = async (
   dependencies: DesktopHostProbeDependencies = {
     probeDirect: desktopHostProbe,
     probeDirectE2ee: probeDirectE2eeDesktopHost,
-    probeRelay: (descriptor, clientToken) => probeRelayDesktopHost(descriptor, { clientToken, keepTunnel: true }),
+    probeRelay: (descriptor, clientToken, options) => probeRelayDesktopHost(descriptor, { clientToken, keepTunnel: options.keepTunnel }),
   },
+  options: DesktopHostTransportProbeOptions = {},
 ): Promise<DesktopHostSelection> => {
+  const retainRelayTunnel = options.retainRelayTunnel === true;
   let finalProbe = unreachableProbe();
   const directUrl = normalizeHostUrl(host.apiUrl || host.url);
   const probeDirect = async (): Promise<HostProbeResult> => {
@@ -474,11 +480,18 @@ export const probeDesktopHostTransports = async (
   const probeRelay = async (): Promise<DesktopHostSelection> => {
     if (!host.relay) return { probe: unreachableProbe(), transport: null };
     const probe: HostProbeResult & { tunnel?: ReturnType<typeof createRelayTunnelClient> } = await dependencies
-      .probeRelay(host.relay, host.clientToken || null)
+      .probeRelay(host.relay, host.clientToken || null, { keepTunnel: retainRelayTunnel })
       .catch(unreachableProbe);
+    const tunnel = probe.tunnel;
+    if (tunnel && !retainRelayTunnel) tunnel.close();
+    const statusProbe: HostProbeResult = {
+      status: probe.status,
+      latencyMs: probe.latencyMs,
+      ...(probe.failureClassification ? { failureClassification: probe.failureClassification } : {}),
+    };
     return !failedEncryptedStatus(probe.status)
-      ? { probe, transport: { kind: 'relay', descriptor: host.relay, tunnel: probe.tunnel } }
-      : { probe, transport: null };
+      ? { probe: statusProbe, transport: { kind: 'relay', descriptor: host.relay, ...(retainRelayTunnel && tunnel ? { tunnel } : {}) } }
+      : { probe: statusProbe, transport: null };
   };
 
   // A managed direct-E2EE leg has terminal security semantics, so keep explicit
@@ -548,6 +561,15 @@ export const probeDesktopHostTransports = async (
     ? { probe: lateDirect, transport: { kind: 'direct', url: directUrl } }
     : first.selection;
 };
+
+export const probeDesktopHostTransportsForActivation = (
+  host: DesktopHost,
+  dependencies?: DesktopHostProbeDependencies,
+): Promise<DesktopHostSelection> => probeDesktopHostTransports(
+  host,
+  dependencies,
+  { retainRelayTunnel: true },
+);
 
 export const desktopHostProbe = async (url: string, options?: { clientToken?: string | null; requestHeaders?: Record<string, string> | null; expectedServerId?: string | null }): Promise<HostProbeResult> => {
   const invoke = getInvoke();

--- a/packages/ui/src/lib/desktopRelayRestore.ts
+++ b/packages/ui/src/lib/desktopRelayRestore.ts
@@ -1,5 +1,5 @@
 import { isElectronShell } from '@/lib/desktop';
-import { desktopHostProbe, desktopHostsGet, desktopHostsSet, getDesktopHostRuntimeSwitchOptions, normalizeHostUrl, probeDesktopHostTransports } from '@/lib/desktopHosts';
+import { desktopHostProbe, desktopHostsGet, desktopHostsSet, getDesktopHostRuntimeSwitchOptions, normalizeHostUrl, probeDesktopHostTransportsForActivation } from '@/lib/desktopHosts';
 import { adoptRelayTunnel } from '@/lib/relay/runtime-tunnel';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { getRuntimeKey, switchRuntimeEndpoint } from '@/lib/runtime-switch';
@@ -172,7 +172,7 @@ export const restoreDesktopRelayRuntime = async (targetHostId?: string): Promise
   restoreDesktopRuntimeWithDependencies({
     isElectronShell,
     getHosts: desktopHostsGet,
-    selectTransport: probeDesktopHostTransports,
+    selectTransport: probeDesktopHostTransportsForActivation,
     getRuntimeKey,
     switchRuntime: switchRuntimeEndpoint,
     windowOrigin: () => typeof window !== 'undefined' ? window.location.origin : '',

--- a/packages/ui/src/lib/desktopRelayRestore.ts
+++ b/packages/ui/src/lib/desktopRelayRestore.ts
@@ -1,15 +1,21 @@
 import { isElectronShell } from '@/lib/desktop';
-import { desktopHostProbe, desktopHostsGet, desktopHostsSet, getDesktopHostApiUrl, normalizeHostUrl } from '@/lib/desktopHosts';
+import { desktopHostProbe, desktopHostsGet, desktopHostsSet, getDesktopHostRuntimeSwitchOptions, normalizeHostUrl, probeDesktopHostTransports } from '@/lib/desktopHosts';
+import { adoptRelayTunnel } from '@/lib/relay/runtime-tunnel';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { getRuntimeKey, switchRuntimeEndpoint } from '@/lib/runtime-switch';
+import type { DesktopHost, DesktopHostSelection, DesktopHostsConfig } from '@/lib/desktopHosts';
+
+type DesktopRestoreDependencies = {
+  isElectronShell: () => boolean;
+  getHosts: () => Promise<DesktopHostsConfig>;
+  selectTransport: (host: DesktopHost) => Promise<DesktopHostSelection>;
+  getRuntimeKey: () => string;
+  switchRuntime: typeof switchRuntimeEndpoint;
+  windowOrigin: () => string;
+};
 
 // Let the post-switch bootstrap traffic settle before the background refresh.
 const CANDIDATE_REFRESH_DELAY_MS = 5_000;
-
-// How long the stored direct address keeps startup to itself before the relay
-// takes over. A live LAN probe answers well inside this window; a dead one no
-// longer stalls startup for the probe's full timeout.
-const DIRECT_PROBE_HEADSTART_MS = 1_500;
 
 let candidateRefreshInFlight = false;
 
@@ -111,81 +117,63 @@ export const scheduleDesktopHostCandidateRefresh = (hostId: string): void => {
  * Safe to call unconditionally; it is a no-op outside the Electron shell and when
  * the default host is local or already active.
  */
-export const restoreDesktopRelayRuntime = async (targetHostId?: string): Promise<void> => {
-  if (!isElectronShell()) return;
-  const config = await desktopHostsGet().catch(() => null);
+export const restoreDesktopRuntimeWithDependencies = async (
+  dependencies: DesktopRestoreDependencies,
+  targetHostId?: string,
+): Promise<void> => {
+  if (!dependencies.isElectronShell()) return;
+  const config = await dependencies.getHosts().catch(() => null);
   if (!config) return;
   // An explicit target (a "new window for host X") wins over the default-host
   // relaunch logic.
   const hostId = targetHostId || (config.defaultHostId !== 'local' ? config.defaultHostId : null);
   if (!hostId) return;
   const host = config.hosts.find((entry) => entry.id === hostId);
-  if (!host?.relay) return;
+  if (!host || (!host.relay && !host.directE2ee)) return;
   // Must match runtimeKeyForHost() in DesktopHostSwitcher so switch/resolve agree.
   const runtimeKey = `host:${host.id}`;
-  if (getRuntimeKey() === runtimeKey) return;
+  if (dependencies.getRuntimeKey() === runtimeKey) return;
 
-  const switchToDirect = (url: string) => {
-    switchRuntimeEndpoint({
-      apiBaseUrl: url,
-      clientToken: host.clientToken || null,
-      requestHeaders: host.requestHeaders || null,
-      runtimeKey,
-    });
-  };
-  const switchToRelay = () => {
-    switchRuntimeEndpoint({
-      apiBaseUrl: typeof window !== 'undefined' ? window.location.origin : '',
-      clientToken: host.clientToken || null,
-      runtimeKey,
-      relay: host.relay ?? undefined,
-    });
-    // On the relay because the stored direct address did not answer (yet) —
-    // ask the server for its current LAN address in the background and
-    // hot-switch back to direct if it simply moved (DHCP re-lease).
+  const selection = await dependencies.selectTransport(host).catch(() => null);
+  if (!selection?.transport) return;
+  const options = getDesktopHostRuntimeSwitchOptions(host, selection.transport, dependencies.windowOrigin(), runtimeKey);
+  if (!options) {
+    if (selection.transport.kind === 'relay') selection.transport.tunnel?.close();
+    return;
+  }
+  if (selection.transport.kind === 'relay' && selection.transport.tunnel) {
+    adoptRelayTunnel(selection.transport.descriptor, selection.transport.tunnel);
+  }
+  dependencies.switchRuntime(options);
+  if (selection.transport.kind === 'relay') {
+    // Candidate refresh is meaningful only while the authenticated relay
+    // transport is active; direct-E2EE descriptors do not expose LAN metadata.
     scheduleDesktopHostCandidateRefresh(host.id);
-  };
-
-  const directUrl = host.apiUrl ? normalizeHostUrl(getDesktopHostApiUrl(host)) : null;
-  if (!directUrl) {
-    switchToRelay();
-    return;
   }
 
-  // Race the direct probe against a short headstart instead of serializing the
-  // full probe timeout in front of the relay fallback: a live LAN answers well
-  // inside the window (direct keeps priority); a dead one no longer delays
-  // startup — the relay takes over and a late direct success hot-switches back
-  // (stable runtimeKey → transport-only swap, same as the candidate refresh).
-  const probeOk = (probe: { status: string }) =>
-    probe.status !== 'unreachable' && probe.status !== 'wrong-service' && probe.status !== 'incompatible';
-  const probePromise = desktopHostProbe(directUrl, {
-    clientToken: host.clientToken || null,
-    requestHeaders: host.requestHeaders || null,
-    // Identity gate: a re-leased LAN address may now belong to a different
-    // machine; the probe must not send the token on a serverId mismatch.
-    expectedServerId: host.relay.serverId,
-  }).catch(() => ({ status: 'unreachable' as const, latencyMs: 0 }));
-
-  const winner = await Promise.race([
-    probePromise,
-    new Promise<null>((resolve) => setTimeout(() => resolve(null), DIRECT_PROBE_HEADSTART_MS)),
-  ]);
-  if (winner) {
-    if (probeOk(winner)) {
-      switchToDirect(directUrl);
-      return;
-    }
-    switchToRelay();
-    return;
+  // A relay may win after the LAN head-start while the identity-gated direct
+  // probe is still running. Adopt that direct leg only if this host remains the
+  // active runtime when the late result arrives.
+  if (selection.lateDirect && selection.directUrl) {
+    void selection.lateDirect.then((probe) => {
+      if (probe.status === 'unreachable' || probe.status === 'wrong-service' || probe.status === 'incompatible') return;
+      if (dependencies.getRuntimeKey() !== runtimeKey) return;
+      dependencies.switchRuntime({
+        apiBaseUrl: selection.directUrl!,
+        clientToken: host.clientToken || null,
+        requestHeaders: host.requestHeaders || null,
+        runtimeKey,
+      });
+    });
   }
-
-  // Headstart expired: connect via relay now; adopt the direct transport if the
-  // still-running probe succeeds a moment later.
-  switchToRelay();
-  void probePromise.then((probe) => {
-    if (!probeOk(probe)) return;
-    if (getRuntimeKey() !== runtimeKey) return; // user switched away meanwhile
-    switchToDirect(directUrl);
-  });
 };
+
+export const restoreDesktopRelayRuntime = async (targetHostId?: string): Promise<void> =>
+  restoreDesktopRuntimeWithDependencies({
+    isElectronShell,
+    getHosts: desktopHostsGet,
+    selectTransport: probeDesktopHostTransports,
+    getRuntimeKey,
+    switchRuntime: switchRuntimeEndpoint,
+    windowOrigin: () => typeof window !== 'undefined' ? window.location.origin : '',
+  }, targetHostId);

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -59,6 +59,8 @@ export const dict = {
   'mobile.connect.error.invalidUrl': 'That server URL is not valid.',
   'mobile.connect.error.unreachable': 'Could not reach that OpenChamber server.',
   'mobile.connect.error.authRequired': 'This server needs a password or client token.',
+  'mobile.connect.error.pairingSecurity': 'Could not verify this server’s secure connection. Check the pairing code and try again.',
+  'mobile.connect.error.pairingUncertain': 'Pairing may have completed, but confirmation was lost. Check saved connections before trying again.',
   'mobile.connect.error.passwordFailed': 'Could not unlock that server. Check the password.',
   'mobile.instances.addTitle': 'Add instance',
   'mobile.instances.addManual': 'Add by address',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -60,6 +60,8 @@ export const dict: Record<I18nKey, string> = {
   "mobile.connect.error.invalidUrl": "Esa URL de servidor no es válida.",
   "mobile.connect.error.unreachable": "No se pudo conectar con ese servidor de OpenChamber.",
   "mobile.connect.error.authRequired": "Este servidor requiere una contraseña o un token de cliente.",
+  "mobile.connect.error.pairingSecurity": "No se pudo verificar la conexión segura de este servidor. Comprueba el código de emparejamiento e inténtalo de nuevo.",
+  "mobile.connect.error.pairingUncertain": "Es posible que el emparejamiento se haya completado, pero se perdió la confirmación. Comprueba las conexiones guardadas antes de volver a intentarlo.",
   "mobile.connect.error.passwordFailed": "No se pudo desbloquear ese servidor. Revisa la contraseña.",
   "mobile.instances.addTitle": "Agregar instancia",
   "mobile.instances.addManual": "Añadir por dirección",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -2568,6 +2568,8 @@ export const dict = {
   'mobile.connect.error.invalidUrl': 'Cette URL de serveur n\'est pas valide.',
   'mobile.connect.error.unreachable': 'Impossible de joindre ce serveur OpenChamber.',
   'mobile.connect.error.authRequired': 'Ce serveur nécessite un mot de passe ou un jeton client.',
+  'mobile.connect.error.pairingSecurity': 'Impossible de vérifier la connexion sécurisée de ce serveur. Vérifiez le code d’appairage et réessayez.',
+  'mobile.connect.error.pairingUncertain': 'L’appairage a peut-être réussi, mais la confirmation a été perdue. Vérifiez les connexions enregistrées avant de réessayer.',
   'mobile.connect.error.passwordFailed': 'Impossible de déverrouiller ce serveur. Vérifiez le mot de passe.',
   'mobile.instances.addTitle': 'Ajouter une instance',
   'mobile.instances.addManual': 'Ajouter par adresse',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -59,6 +59,8 @@ export const dict: Record<I18nKey, string> = {
   'mobile.connect.error.invalidUrl': 'そのサーバー URL は無効です。',
   'mobile.connect.error.unreachable': 'その OpenChamber サーバーに接続できませんでした。',
   'mobile.connect.error.authRequired': 'このサーバーにはパスワードまたはクライアントトークンが必要です。',
+  'mobile.connect.error.pairingSecurity': 'このサーバーの安全な接続を確認できませんでした。ペアリングコードを確認して、もう一度お試しください。',
+  'mobile.connect.error.pairingUncertain': 'ペアリングが完了した可能性がありますが、確認結果を受信できませんでした。再試行する前に保存済みの接続を確認してください。',
   'mobile.connect.error.passwordFailed': 'サーバーのロックを解除できませんでした。パスワードを確認してください。',
   'mobile.connect.scan.unsupported': 'QR スキャンはインストール済みのモバイルアプリでのみ利用できます。',
   'mobile.connect.scan.permissionDenied': 'カメラへのアクセスがオフになっています。QR コードを読み取るには設定で有効にしてください。',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -60,6 +60,8 @@ export const dict: Record<I18nKey, string> = {
   'mobile.connect.error.invalidUrl': '유효하지 않은 서버 URL입니다.',
   'mobile.connect.error.unreachable': '해당 OpenChamber 서버에 연결할 수 없습니다.',
   'mobile.connect.error.authRequired': '이 서버에는 비밀번호 또는 클라이언트 토큰이 필요합니다.',
+  'mobile.connect.error.pairingSecurity': '이 서버의 보안 연결을 확인할 수 없습니다. 페어링 코드를 확인한 후 다시 시도하세요.',
+  'mobile.connect.error.pairingUncertain': '페어링이 완료되었을 수 있지만 확인 응답이 유실되었습니다. 다시 시도하기 전에 저장된 연결을 확인하세요.',
   'mobile.connect.error.passwordFailed': '서버 잠금을 해제할 수 없습니다. 비밀번호를 확인하세요.',
   'mobile.instances.addTitle': '인스턴스 추가',
   'mobile.instances.addManual': '주소로 추가',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -61,6 +61,8 @@ export const dict: Record<I18nKey, string> = {
   'mobile.connect.error.invalidUrl': 'Ten adres URL serwera jest nieprawidłowy.',
   'mobile.connect.error.unreachable': 'Nie udało się połączyć z tym serwerem OpenChamber.',
   'mobile.connect.error.authRequired': 'Ten serwer wymaga hasła lub tokenu klienta.',
+  'mobile.connect.error.pairingSecurity': 'Nie udało się zweryfikować bezpiecznego połączenia z tym serwerem. Sprawdź kod parowania i spróbuj ponownie.',
+  'mobile.connect.error.pairingUncertain': 'Parowanie mogło się zakończyć, ale potwierdzenie zostało utracone. Przed ponowną próbą sprawdź zapisane połączenia.',
   'mobile.connect.error.passwordFailed': 'Nie udało się odblokować tego serwera. Sprawdź hasło.',
   'mobile.instances.addTitle': 'Dodaj instancję',
   'mobile.instances.addManual': 'Dodaj przez adres',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -60,6 +60,8 @@ export const dict: Record<I18nKey, string> = {
   "mobile.connect.error.invalidUrl": "Essa URL de servidor não é válida.",
   "mobile.connect.error.unreachable": "Não foi possível acessar esse servidor OpenChamber.",
   "mobile.connect.error.authRequired": "Este servidor requer uma senha ou token do cliente.",
+  "mobile.connect.error.pairingSecurity": "Não foi possível verificar a conexão segura deste servidor. Confira o código de pareamento e tente novamente.",
+  "mobile.connect.error.pairingUncertain": "O pareamento pode ter sido concluído, mas a confirmação foi perdida. Verifique as conexões salvas antes de tentar novamente.",
   "mobile.connect.error.passwordFailed": "Não foi possível desbloquear esse servidor. Verifique a senha.",
   "mobile.instances.addTitle": "Adicionar instância",
   "mobile.instances.addManual": "Adicionar por endereço",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -60,6 +60,8 @@ export const dict: Record<I18nKey, string> = {
   "mobile.connect.error.invalidUrl": "Ця адреса сервера некоректна.",
   "mobile.connect.error.unreachable": "Не вдалося достукатись до цього OpenChamber сервера.",
   "mobile.connect.error.authRequired": "Цьому серверу потрібен пароль або client token.",
+  "mobile.connect.error.pairingSecurity": "Не вдалося перевірити захищене з’єднання з цим сервером. Перевірте код сполучення та повторіть спробу.",
+  "mobile.connect.error.pairingUncertain": "Сполучення могло завершитися, але підтвердження було втрачено. Перевірте збережені з’єднання, перш ніж повторювати спробу.",
   "mobile.connect.error.passwordFailed": "Не вдалося розблокувати сервер. Перевір пароль.",
   "mobile.instances.addTitle": "Додати інстанс",
   "mobile.instances.addManual": "Додати за адресою",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -60,6 +60,8 @@ export const dict: Record<I18nKey, string> = {
   'mobile.connect.error.invalidUrl': '该服务器 URL 无效。',
   'mobile.connect.error.unreachable': '无法连接到该 OpenChamber 服务器。',
   'mobile.connect.error.authRequired': '该服务器需要密码或客户端令牌。',
+  'mobile.connect.error.pairingSecurity': '无法验证此服务器的安全连接。请检查配对码后重试。',
+  'mobile.connect.error.pairingUncertain': '配对可能已完成，但确认信息已丢失。重试前请检查已保存的连接。',
   'mobile.connect.error.passwordFailed': '无法解锁该服务器。请检查密码。',
   'mobile.instances.addTitle': '添加实例',
   'mobile.instances.addManual': '通过地址添加',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -60,6 +60,8 @@ export const dict: Record<I18nKey, string> = {
   'mobile.connect.error.invalidUrl': '該伺服器網址無效。',
   'mobile.connect.error.unreachable': '無法連線至該 OpenChamber 伺服器。',
   'mobile.connect.error.authRequired': '此伺服器需要密碼或用戶端權杖。',
+  'mobile.connect.error.pairingSecurity': '無法驗證此伺服器的安全連線。請檢查配對碼後再試一次。',
+  'mobile.connect.error.pairingUncertain': '配對可能已完成，但確認資訊已遺失。重試前請檢查已儲存的連線。',
   'mobile.connect.error.passwordFailed': '無法解鎖該伺服器。請檢查密碼。',
   'mobile.instances.addTitle': '新增執行個體',
   'mobile.instances.addManual': '透過位址新增',

--- a/packages/ui/src/lib/openchamberEvents.test.ts
+++ b/packages/ui/src/lib/openchamberEvents.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  resetOpenchamberEventsForTests,
+  setOpenchamberEventsDependenciesForTests,
+  subscribeOpenchamberEvents,
+} from './openchamberEvents';
+
+let tunnelActive = false;
+let fetchImplementation: (signal: AbortSignal) => Promise<Response>;
+const runtimeFetchCalls: Array<{ path: string; init: RequestInit }> = [];
+let runtimeChangeListener: (() => void) | null = null;
+
+class FakeEventSource {
+  static readonly CLOSED = 2;
+  static instances: FakeEventSource[] = [];
+  readonly url: string;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+}
+
+type StreamHandle = {
+  response: Response;
+  enqueue(text: string): void;
+  close(): void;
+  error(reason: Error): void;
+};
+
+const createStream = (): StreamHandle => {
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  const stream = new ReadableStream<Uint8Array>({
+    start(nextController) {
+      controller = nextController;
+    },
+  });
+  const encoder = new TextEncoder();
+  return {
+    response: new Response(stream, { headers: { 'Content-Type': 'text/event-stream; charset=utf-8' } }),
+    enqueue(text) {
+      controller?.enqueue(encoder.encode(text));
+    },
+    close() {
+      controller?.close();
+    },
+    error(reason) {
+      controller?.error(reason);
+    },
+  };
+};
+
+const flushPromises = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+type ScheduledTimer = { at: number; callback: () => void };
+const nativeSetTimeout = globalThis.setTimeout;
+const nativeClearTimeout = globalThis.clearTimeout;
+let currentTime = 0;
+const timers = new Map<ReturnType<typeof setTimeout>, ScheduledTimer>();
+const advanceTimersByTime = async (duration: number): Promise<void> => {
+  const target = currentTime + duration;
+  while (true) {
+    const next = Array.from(timers.entries())
+      .filter(([, timer]) => timer.at <= target)
+      .sort((left, right) => left[1].at - right[1].at)[0];
+    if (!next) break;
+    const [id, timer] = next;
+    timers.delete(id);
+    currentTime = timer.at;
+    timer.callback();
+    await flushPromises();
+  }
+  currentTime = target;
+};
+
+let unsubscribe: (() => void) | null = null;
+
+beforeEach(() => {
+  currentTime = 0;
+  timers.clear();
+  setOpenchamberEventsDependenciesForTests({
+    isBrowserAvailable: () => true,
+    isTunnelActive: () => tunnelActive,
+    runtimeFetch: async (path, init) => {
+      runtimeFetchCalls.push({ path: String(path), init: init ?? {} });
+      if (!init?.signal) throw new Error('Expected an abort signal');
+      return fetchImplementation(init.signal);
+    },
+    getSseUrl: (path) => `https://runtime.test${path}`,
+    subscribeRuntimeSwitch: (listener) => {
+      runtimeChangeListener = listener;
+      return () => {
+        runtimeChangeListener = null;
+      };
+    },
+    createEventSource: (url) => new FakeEventSource(url),
+    eventSourceClosedState: FakeEventSource.CLOSED,
+    setTimer: (callback, delay) => {
+      const handle = nativeSetTimeout(() => {}, 2_147_483_647);
+      nativeClearTimeout(handle);
+      timers.set(handle, { at: currentTime + delay, callback });
+      return handle;
+    },
+    clearTimer: (handle) => {
+      timers.delete(handle);
+    },
+  });
+  tunnelActive = false;
+  runtimeFetchCalls.length = 0;
+  runtimeChangeListener = null;
+  FakeEventSource.instances = [];
+  fetchImplementation = async () => new Response(null, { status: 500 });
+});
+
+afterEach(() => {
+  unsubscribe?.();
+  unsubscribe = null;
+  resetOpenchamberEventsForTests();
+});
+
+describe('subscribeOpenchamberEvents transport', () => {
+  test('keeps native EventSource behavior when no tunnel is active', () => {
+    unsubscribe = subscribeOpenchamberEvents(() => {});
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]?.url).toBe('https://runtime.test/api/openchamber/events');
+  });
+
+  test('uses runtimeFetch in tunnel mode and dispatches fragmented frames in order', async () => {
+    tunnelActive = true;
+    const stream = createStream();
+    const signals: AbortSignal[] = [];
+    fetchImplementation = async (signal) => {
+      signals.push(signal);
+      return stream.response;
+    };
+    const events: Array<{ taskId: string }> = [];
+    unsubscribe = subscribeOpenchamberEvents((event) => events.push(event));
+    await flushPromises();
+
+    stream.enqueue('data: {"type":"openchamber:scheduled-task-ran","pro');
+    stream.enqueue('perties":{"projectId":"p","taskId":"one","ranAt":1,"status":"success"}}\n\n');
+    stream.enqueue('data: {"type":"openchamber:scheduled-task-ran","properties":{"projectId":"p","taskId":"two","ranAt":2,"status":"success"}}\r\n\r\n');
+    await flushPromises();
+
+    expect(events.map((event) => event.taskId)).toEqual(['one', 'two']);
+    expect(runtimeFetchCalls).toHaveLength(1);
+    expect(runtimeFetchCalls[0]?.path).toBe('/api/openchamber/events');
+    expect(new Headers(runtimeFetchCalls[0]?.init.headers).get('accept')).toBe('text/event-stream');
+    expect(runtimeFetchCalls[0]?.init.signal).toBeInstanceOf(AbortSignal);
+    expect(signals[0]?.aborted).toBe(false);
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+
+  test('heartbeat watchdog aborts silent streams and complete heartbeat frames reset it', async () => {
+    tunnelActive = true;
+    const silentStream = createStream();
+    const heartbeatStream = createStream();
+    const streams = [silentStream, heartbeatStream];
+    const signals: AbortSignal[] = [];
+    let calls = 0;
+    fetchImplementation = async (signal) => {
+      signals.push(signal);
+      return streams[calls++]!.response;
+    };
+    unsubscribe = subscribeOpenchamberEvents(() => {});
+    await flushPromises();
+
+    await advanceTimersByTime(44_999);
+    expect(signals[0]?.aborted).toBe(false);
+    await advanceTimersByTime(1);
+    expect(signals[0]?.aborted).toBe(true);
+    await advanceTimersByTime(999);
+    expect(calls).toBe(1);
+    await advanceTimersByTime(1);
+    expect(calls).toBe(2);
+
+    await advanceTimersByTime(44_000);
+    heartbeatStream.enqueue('data: {"type":"openchamber:heartbeat","properties":{}}\n\n');
+    await flushPromises();
+    await advanceTimersByTime(44_999);
+    expect(signals[1]?.aborted).toBe(false);
+    await advanceTimersByTime(1);
+    expect(signals[1]?.aborted).toBe(true);
+  });
+
+  test('reconnects after invalid responses and EOF without falling back to EventSource', async () => {
+    tunnelActive = true;
+    const stream = createStream();
+    let calls = 0;
+    fetchImplementation = async () => {
+      calls += 1;
+      return calls === 1
+        ? new Response('wrong', { headers: { 'Content-Type': 'text/html' } })
+        : stream.response;
+    };
+    unsubscribe = subscribeOpenchamberEvents(() => {});
+    await flushPromises();
+
+    expect(calls).toBe(1);
+    await advanceTimersByTime(1_000);
+    expect(calls).toBe(2);
+    stream.close();
+    await flushPromises();
+    await advanceTimersByTime(2_000);
+
+    expect(calls).toBe(3);
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+
+  test('reconnects after parser overflow without falling back to EventSource', async () => {
+    tunnelActive = true;
+    const overflowingStream = createStream();
+    const recoveredStream = createStream();
+    let calls = 0;
+    fetchImplementation = async () => {
+      calls += 1;
+      return calls === 1 ? overflowingStream.response : recoveredStream.response;
+    };
+    unsubscribe = subscribeOpenchamberEvents(() => {});
+    await flushPromises();
+
+    overflowingStream.enqueue(`data: ${'x'.repeat(64 * 1024)}x`);
+    await flushPromises();
+    await advanceTimersByTime(1_000);
+
+    expect(calls).toBe(2);
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+
+  test('last unsubscribe aborts the active tunnel reader and prevents reconnect', async () => {
+    tunnelActive = true;
+    const stream = createStream();
+    const signals: AbortSignal[] = [];
+    let calls = 0;
+    fetchImplementation = async (nextSignal) => {
+      calls += 1;
+      signals.push(nextSignal);
+      return stream.response;
+    };
+    unsubscribe = subscribeOpenchamberEvents(() => {});
+    await flushPromises();
+
+    unsubscribe();
+    unsubscribe = null;
+    stream.error(new Error('late failure'));
+    await flushPromises();
+    await advanceTimersByTime(30_000);
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  test('runtime switch suppresses stale chunks and starts a new tunnel reader', async () => {
+    tunnelActive = true;
+    const oldStream = createStream();
+    const newStream = createStream();
+    const streams = [oldStream, newStream];
+    let calls = 0;
+    fetchImplementation = async () => streams[calls++]!.response;
+    const taskIds: string[] = [];
+    unsubscribe = subscribeOpenchamberEvents((event) => taskIds.push(event.taskId));
+    await flushPromises();
+
+    runtimeChangeListener?.();
+    await flushPromises();
+    oldStream.enqueue('data: {"type":"openchamber:scheduled-task-ran","properties":{"projectId":"p","taskId":"stale","ranAt":1,"status":"success"}}\n\n');
+    newStream.enqueue('data: {"type":"openchamber:scheduled-task-ran","properties":{"projectId":"p","taskId":"fresh","ranAt":1,"status":"success"}}\n\n');
+    await flushPromises();
+
+    expect(calls).toBe(2);
+    expect(taskIds).toEqual(['fresh']);
+  });
+
+  test('ready frame resets reconnect backoff', async () => {
+    tunnelActive = true;
+    const readyStream = createStream();
+    const finalStream = createStream();
+    let calls = 0;
+    fetchImplementation = async () => {
+      calls += 1;
+      if (calls === 1) return new Response(null, { status: 503 });
+      return calls === 2 ? readyStream.response : finalStream.response;
+    };
+    unsubscribe = subscribeOpenchamberEvents(() => {});
+    await flushPromises();
+    await advanceTimersByTime(1_000);
+
+    readyStream.enqueue('data: {"type":"openchamber:event-stream-ready","properties":{}}\n\n');
+    await flushPromises();
+    readyStream.close();
+    await flushPromises();
+    await advanceTimersByTime(999);
+    expect(calls).toBe(2);
+    await advanceTimersByTime(1);
+    expect(calls).toBe(3);
+  });
+});

--- a/packages/ui/src/lib/openchamberEvents.ts
+++ b/packages/ui/src/lib/openchamberEvents.ts
@@ -1,5 +1,8 @@
+import { getActiveRelayTunnel } from './relay/runtime-tunnel';
+import { runtimeFetch } from './runtime-fetch';
 import { getRuntimeUrlResolver } from './runtime-url';
 import { subscribeRuntimeEndpointChanged } from './runtime-switch';
+import { createSseDataParser } from './sse-data-parser';
 
 type ScheduledTaskRanEvent = {
   type: 'scheduled-task-ran';
@@ -13,7 +16,42 @@ type ScheduledTaskRanEvent = {
 type OpenChamberEvent = ScheduledTaskRanEvent;
 type Listener = (event: OpenChamberEvent) => void;
 
-let eventSource: EventSource | null = null;
+interface OpenChamberEventSource {
+  readyState: number;
+  onopen: ((event: Event) => void) | null;
+  onmessage: ((event: MessageEvent<string>) => void) | null;
+  onerror: ((event: Event) => void) | null;
+  close(): void;
+}
+
+interface OpenChamberEventsDependencies {
+  isBrowserAvailable(): boolean;
+  isTunnelActive(): boolean;
+  runtimeFetch: typeof runtimeFetch;
+  getSseUrl(path: string): string;
+  subscribeRuntimeSwitch(listener: () => void): () => void;
+  createEventSource(url: string): OpenChamberEventSource | null;
+  eventSourceClosedState: number;
+  setTimer(callback: () => void, delay: number): ReturnType<typeof setTimeout>;
+  clearTimer(timer: ReturnType<typeof setTimeout>): void;
+}
+
+const productionDependencies: OpenChamberEventsDependencies = {
+  isBrowserAvailable: () => typeof window !== 'undefined',
+  isTunnelActive: () => Boolean(getActiveRelayTunnel()),
+  runtimeFetch,
+  getSseUrl: (path) => getRuntimeUrlResolver().sse(path),
+  subscribeRuntimeSwitch: subscribeRuntimeEndpointChanged,
+  createEventSource: (url) => typeof EventSource === 'function' ? new EventSource(url) : null,
+  eventSourceClosedState: typeof EventSource === 'function' ? EventSource.CLOSED : 2,
+  setTimer: (callback, delay) => setTimeout(callback, delay),
+  clearTimer: (timer) => clearTimeout(timer),
+};
+
+let dependencies = productionDependencies;
+let eventSource: OpenChamberEventSource | null = null;
+let streamAbortController: AbortController | null = null;
+let connectionGeneration = 0;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempt = 0;
@@ -27,7 +65,7 @@ const clearHeartbeatTimer = () => {
   if (!heartbeatTimer) {
     return;
   }
-  clearTimeout(heartbeatTimer);
+  dependencies.clearTimer(heartbeatTimer);
   heartbeatTimer = null;
 };
 
@@ -36,7 +74,7 @@ const scheduleReconnect = () => {
     return;
   }
   const delay = Math.min(1_000 * Math.pow(2, Math.min(reconnectAttempt, 5)), MAX_RECONNECT_DELAY_MS);
-  reconnectTimer = setTimeout(() => {
+  reconnectTimer = dependencies.setTimer(() => {
     reconnectTimer = null;
     reconnectAttempt += 1;
     connect();
@@ -44,11 +82,22 @@ const scheduleReconnect = () => {
 };
 
 const cleanupSource = () => {
+  connectionGeneration += 1;
   clearHeartbeatTimer();
+  streamAbortController?.abort();
+  streamAbortController = null;
   if (eventSource) {
     eventSource.close();
   }
   eventSource = null;
+};
+
+const isCurrentConnection = (generation: number): boolean => generation === connectionGeneration && listeners.size > 0;
+
+const failConnection = (generation: number): void => {
+  if (!isCurrentConnection(generation)) return;
+  cleanupSource();
+  scheduleReconnect();
 };
 
 const resetHeartbeatTimer = () => {
@@ -56,7 +105,7 @@ const resetHeartbeatTimer = () => {
   if (listeners.size === 0) {
     return;
   }
-  heartbeatTimer = setTimeout(() => {
+  heartbeatTimer = dependencies.setTimer(() => {
     cleanupSource();
     scheduleReconnect();
   }, HEARTBEAT_TIMEOUT_MS);
@@ -119,25 +168,74 @@ const dispatchFromEnvelope = (envelope: { type: string; properties: unknown }) =
   }
 };
 
+const connectTunnelStream = (generation: number, controller: AbortController): void => {
+  void (async () => {
+    try {
+      const response = await dependencies.runtimeFetch('/api/openchamber/events', {
+        signal: controller.signal,
+        headers: { Accept: 'text/event-stream' },
+      });
+      if (!isCurrentConnection(generation)) return;
+
+      const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+      if (!response.ok || !response.body || !contentType.startsWith('text/event-stream')) {
+        failConnection(generation);
+        return;
+      }
+
+      resetHeartbeatTimer();
+      const parser = createSseDataParser((data) => {
+        if (!isCurrentConnection(generation)) return;
+        resetHeartbeatTimer();
+        const envelope = parseEnvelope(data);
+        if (envelope) dispatchFromEnvelope(envelope);
+      });
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+
+      while (isCurrentConnection(generation)) {
+        const { done, value } = await reader.read();
+        if (!isCurrentConnection(generation)) return;
+        if (done) {
+          parser.end();
+          failConnection(generation);
+          return;
+        }
+        parser.push(decoder.decode(value, { stream: true }));
+      }
+    } catch {
+      failConnection(generation);
+    }
+  })();
+};
+
 const connect = () => {
-  if (typeof window === 'undefined' || listeners.size === 0) {
-    return;
-  }
-  if (typeof EventSource !== 'function') {
+  if (!dependencies.isBrowserAvailable() || listeners.size === 0) {
     return;
   }
 
-  if (eventSource && eventSource.readyState !== EventSource.CLOSED) {
+  if (streamAbortController || (eventSource && eventSource.readyState !== dependencies.eventSourceClosedState)) {
     return;
   }
 
   cleanupSource();
+  const generation = connectionGeneration;
 
-  const source = new EventSource(getRuntimeUrlResolver().sse('/api/openchamber/events'));
+  if (dependencies.isTunnelActive()) {
+    const controller = new AbortController();
+    streamAbortController = controller;
+    connectTunnelStream(generation, controller);
+    return;
+  }
+
+  const source = dependencies.createEventSource(dependencies.getSseUrl('/api/openchamber/events'));
+  if (!source) return;
   source.onopen = () => {
+    if (!isCurrentConnection(generation)) return;
     resetHeartbeatTimer();
   };
   source.onmessage = (event) => {
+    if (!isCurrentConnection(generation)) return;
     resetHeartbeatTimer();
     const envelope = parseEnvelope(event.data);
     if (!envelope) {
@@ -147,16 +245,15 @@ const connect = () => {
   };
 
   source.onerror = () => {
-    cleanupSource();
-    scheduleReconnect();
+    failConnection(generation);
   };
 
   eventSource = source;
 };
 
 const ensureRuntimeChangeSubscription = () => {
-  if (runtimeChangeUnsubscribe || typeof window === 'undefined') return;
-  runtimeChangeUnsubscribe = subscribeRuntimeEndpointChanged(() => {
+  if (runtimeChangeUnsubscribe || !dependencies.isBrowserAvailable()) return;
+  runtimeChangeUnsubscribe = dependencies.subscribeRuntimeSwitch(() => {
     cleanupSource();
     reconnectAttempt = 0;
     connect();
@@ -177,7 +274,7 @@ export const subscribeOpenchamberEvents = (listener: Listener): (() => void) => 
     listeners.delete(listener);
     if (listeners.size === 0) {
       if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
+        dependencies.clearTimer(reconnectTimer);
         reconnectTimer = null;
       }
       reconnectAttempt = 0;
@@ -185,4 +282,20 @@ export const subscribeOpenchamberEvents = (listener: Listener): (() => void) => 
       cleanupRuntimeChangeSubscription();
     }
   };
+};
+
+export const setOpenchamberEventsDependenciesForTests = (
+  overrides: Partial<OpenChamberEventsDependencies>,
+): void => {
+  dependencies = { ...productionDependencies, ...overrides };
+};
+
+export const resetOpenchamberEventsForTests = (): void => {
+  listeners.clear();
+  if (reconnectTimer) dependencies.clearTimer(reconnectTimer);
+  reconnectTimer = null;
+  reconnectAttempt = 0;
+  cleanupSource();
+  cleanupRuntimeChangeSubscription();
+  dependencies = productionDependencies;
 };

--- a/packages/ui/src/lib/pairingCandidateRedemption.test.ts
+++ b/packages/ui/src/lib/pairingCandidateRedemption.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { PairingConnectionPayload } from './connectionPayload';
-import { firstHttpPairingCandidateUrl, PairingRedemptionError, redeemPairingCandidate } from './pairingCandidateRedemption';
+import { PairingRedemptionError, redeemPairingCandidate } from './pairingCandidateRedemption';
 import type { RelayTunnelClient, RelayTunnelStatus } from './relay/tunnel-client';
 
 const jwk = { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' };
@@ -203,13 +203,5 @@ describe('pairing candidate redemption', () => {
       createDirectE2eeClient: () => wrongHealth,
     }).catch((value: unknown) => value);
     expect((error as PairingRedemptionError).classification).toBe('security');
-  });
-
-  test('selects only LAN or tunnel candidates as HTTP URLs', () => {
-    expect(firstHttpPairingCandidateUrl(payload.candidates)).toBe(undefined);
-    expect(firstHttpPairingCandidateUrl([
-      payload.candidates[0]!,
-      { type: 'lan', url: 'https://lan.example' },
-    ])).toBe('https://lan.example');
   });
 });

--- a/packages/ui/src/lib/pairingCandidateRedemption.test.ts
+++ b/packages/ui/src/lib/pairingCandidateRedemption.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { PairingConnectionPayload } from './connectionPayload';
+import { firstHttpPairingCandidateUrl, PairingRedemptionError, redeemPairingCandidate } from './pairingCandidateRedemption';
+import type { RelayTunnelClient, RelayTunnelStatus } from './relay/tunnel-client';
+
+const jwk = { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' };
+const payload: PairingConnectionPayload = {
+  v: 2,
+  pairingId: 'pair',
+  secret: 'one-time',
+  candidates: [{ type: 'direct-e2ee', wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws', hostEncPubJwk: jwk }],
+};
+
+const healthBody = { status: 'ok', openchamberVersion: '1.15.0' };
+
+const client = (requests: string[], failAt?: string, status: RelayTunnelStatus = { state: 'connected' }): RelayTunnelClient => ({
+  async fetch(path, init) {
+    requests.push(String(path));
+    if (path === failAt) throw new Error('lost');
+    if (path === '/health') return Response.json(healthBody);
+    if (path === '/api/client-auth/pairing/redeem') {
+      expect(String(init?.body)).toContain('one-time');
+      return Response.json({ clientToken: 'oc_client_token' });
+    }
+    return Response.json({ authenticated: true });
+  },
+  openWebSocket: () => { throw new Error('unused'); },
+  getStatus: () => status,
+  subscribeStatus: () => () => {},
+  close: () => {},
+});
+
+describe('pairing candidate redemption', () => {
+  test('verifies encrypted health, redeems, then authorizes in order', async () => {
+    const requests: string[] = [];
+    const result = await redeemPairingCandidate(payload, {
+      redeemBody: { clientKind: 'mobile' },
+      createDirectE2eeClient: () => client(requests),
+    });
+    expect(requests).toEqual(['/health', '/api/client-auth/pairing/redeem', '/auth/session']);
+    expect(result.token).toBe('oc_client_token');
+  });
+
+  test('retries a 503 on the same encrypted client and succeeds without recreating it', async () => {
+    const requests: string[] = [];
+    const recovering = client(requests);
+    let healthCalls = 0;
+    recovering.fetch = async (path, init) => {
+      requests.push(String(path));
+      if (path === '/health' && healthCalls++ === 0) return new Response(null, { status: 503 });
+      if (path === '/health') return Response.json(healthBody);
+      if (path === '/api/client-auth/pairing/redeem') return Response.json({ clientToken: 'token' });
+      expect(init?.headers).toBeDefined();
+      return Response.json({ authenticated: true });
+    };
+    let clientCreations = 0;
+    const result = await redeemPairingCandidate(payload, {
+      redeemBody: {},
+      createDirectE2eeClient: () => { clientCreations += 1; return recovering; },
+      healthRetryDelayMs: 0,
+    });
+    expect(result.token).toBe('token');
+    expect(clientCreations).toBe(1);
+    expect(requests).toEqual(['/health', '/health', '/api/client-auth/pairing/redeem', '/auth/session']);
+  });
+
+  test('falls through after repeated encrypted 503 responses without redeeming the first candidate', async () => {
+    const firstRequests: string[] = [];
+    const relayRequests: string[] = [];
+    const unavailable = client(firstRequests);
+    unavailable.fetch = async (path) => {
+      firstRequests.push(String(path));
+      return new Response(null, { status: 503 });
+    };
+    const multi: PairingConnectionPayload = {
+      ...payload,
+      candidates: [payload.candidates[0]!, { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'server', hostEncPubJwk: jwk }],
+    };
+    const result = await redeemPairingCandidate(multi, {
+      redeemBody: {},
+      createDirectE2eeClient: () => unavailable,
+      createRelayClient: () => client(relayRequests),
+      healthRetryCount: 2,
+      healthRetryDelayMs: 0,
+    });
+    expect(result.transport.kind).toBe('relay');
+    expect(firstRequests).toEqual(['/health', '/health', '/health']);
+    expect(relayRequests).toEqual(['/health', '/api/client-auth/pairing/redeem', '/auth/session']);
+  });
+
+  test('retries encrypted 429 and falls through on encrypted 404 without classifying either as security', async () => {
+    for (const status of [429, 404]) {
+      const requests: string[] = [];
+      const unavailable = client(requests);
+      unavailable.fetch = async (path) => {
+        requests.push(String(path));
+        return new Response(null, { status });
+      };
+      const multi: PairingConnectionPayload = {
+        ...payload,
+        candidates: [payload.candidates[0]!, { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'server', hostEncPubJwk: jwk }],
+      };
+      const result = await redeemPairingCandidate(multi, {
+        redeemBody: {},
+        createDirectE2eeClient: () => unavailable,
+        createRelayClient: () => client([]),
+        healthRetryCount: 1,
+        healthRetryDelayMs: 0,
+      });
+      expect(result.transport.kind).toBe('relay');
+      expect(requests).toEqual(status === 429 ? ['/health', '/health'] : ['/health']);
+    }
+  });
+
+  test('classifies a lost redemption response as ambiguous and never falls back', async () => {
+    const requests: string[] = [];
+    const error = await redeemPairingCandidate(payload, {
+      redeemBody: {},
+      createDirectE2eeClient: () => client(requests, '/api/client-auth/pairing/redeem'),
+    }).catch((value: unknown) => value);
+    expect(error).toBeInstanceOf(PairingRedemptionError);
+    expect((error as PairingRedemptionError).classification).toBe('ambiguous');
+    expect(requests).toEqual(['/health', '/api/client-auth/pairing/redeem']);
+  });
+
+  test('bounds an unreachable direct E2EE candidate and falls through to another encrypted candidate', async () => {
+    const requests: string[] = [];
+    const multi: PairingConnectionPayload = {
+      ...payload,
+      candidates: [
+        payload.candidates[0]!,
+        { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'server', hostEncPubJwk: jwk },
+      ],
+    };
+    const hanging = client(requests, undefined, { state: 'reconnecting', failureClassification: 'network' });
+    hanging.fetch = async (_path, init) => new Promise<Response>((_, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true });
+    });
+    const result = await redeemPairingCandidate(multi, {
+      redeemBody: {},
+      attemptTimeoutMs: 5,
+      createDirectE2eeClient: () => hanging,
+      createRelayClient: () => client(requests),
+    });
+    expect(result.transport.kind).toBe('relay');
+  });
+
+  test('treats pre-handshake protocol and crypto failures as terminal without fallback', async () => {
+    for (const failureClassification of ['protocol', 'crypto'] as const) {
+      let relayCreated = false;
+      const multi: PairingConnectionPayload = {
+        ...payload,
+        candidates: [payload.candidates[0]!, { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'server', hostEncPubJwk: jwk }],
+      };
+      const failing = client([], '/health', { state: 'error', failureClassification });
+      const error = await redeemPairingCandidate(multi, {
+        redeemBody: {},
+        createDirectE2eeClient: () => failing,
+        createRelayClient: () => {
+          relayCreated = true;
+          return client([]);
+        },
+      }).catch((value: unknown) => value);
+      expect((error as PairingRedemptionError).classification).toBe('security');
+      expect(relayCreated).toBe(false);
+    }
+  });
+
+  test('classifies a redemption timeout as ambiguous and does not fall back', async () => {
+    let relayCreated = false;
+    const requests: string[] = [];
+    const hanging = client(requests);
+    hanging.fetch = async (path, init) => {
+      requests.push(String(path));
+      if (path === '/health') return Response.json(healthBody);
+      return new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true });
+      });
+    };
+    const multi: PairingConnectionPayload = {
+      ...payload,
+      candidates: [payload.candidates[0]!, { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'server', hostEncPubJwk: jwk }],
+    };
+    const error = await redeemPairingCandidate(multi, {
+      redeemBody: {},
+      attemptTimeoutMs: 5,
+      createDirectE2eeClient: () => hanging,
+      createRelayClient: () => {
+        relayCreated = true;
+        return client([]);
+      },
+    }).catch((value: unknown) => value);
+    expect((error as PairingRedemptionError).classification).toBe('ambiguous');
+    expect(relayCreated).toBe(false);
+  });
+
+  test('rejects HTTP 200 with a non-OpenChamber health body as a security failure', async () => {
+    const wrongHealth = client([]);
+    wrongHealth.fetch = async () => Response.json({ ok: true });
+    const error = await redeemPairingCandidate(payload, {
+      redeemBody: {},
+      createDirectE2eeClient: () => wrongHealth,
+    }).catch((value: unknown) => value);
+    expect((error as PairingRedemptionError).classification).toBe('security');
+  });
+
+  test('selects only LAN or tunnel candidates as HTTP URLs', () => {
+    expect(firstHttpPairingCandidateUrl(payload.candidates)).toBe(undefined);
+    expect(firstHttpPairingCandidateUrl([
+      payload.candidates[0]!,
+      { type: 'lan', url: 'https://lan.example' },
+    ])).toBe('https://lan.example');
+  });
+});

--- a/packages/ui/src/lib/pairingCandidateRedemption.ts
+++ b/packages/ui/src/lib/pairingCandidateRedemption.ts
@@ -1,0 +1,179 @@
+import type { PairingConnectionPayload, PairingEndpointCandidate } from './connectionPayload';
+import { createDirectE2eeTunnelClient } from './relay/direct-e2ee-tunnel-client';
+import { createRelayTunnelClient, type RelayTunnelClient, type RelayTunnelStatus } from './relay/tunnel-client';
+
+export type PairingRedeemedTransport =
+  | { kind: 'direct'; url: string }
+  | { kind: 'relay'; relayUrl: string; serverId: string; hostEncPubJwk: JsonWebKey }
+  | { kind: 'direct-e2ee'; wssUrl: string; hostEncPubJwk: JsonWebKey };
+
+export class PairingRedemptionError extends Error {
+  constructor(
+    public readonly classification: 'unreachable' | 'security' | 'credential' | 'ambiguous' | 'authorization',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'PairingRedemptionError';
+  }
+}
+
+export interface PairingRedemptionOptions {
+  redeemBody: Record<string, unknown>;
+  directFetch?: typeof fetch;
+  createRelayClient?: (candidate: Extract<PairingEndpointCandidate, { type: 'relay' }>) => RelayTunnelClient;
+  createDirectE2eeClient?: (candidate: Extract<PairingEndpointCandidate, { type: 'direct-e2ee' }>) => RelayTunnelClient;
+  attemptTimeoutMs?: number;
+  healthRetryCount?: number;
+  healthRetryDelayMs?: number;
+  delay?: (milliseconds: number) => Promise<void>;
+}
+
+const candidateRank = (candidate: PairingEndpointCandidate): number => {
+  if (candidate.type === 'lan' || candidate.type === 'tunnel') return candidate.url.startsWith('https://') ? 0 : 1;
+  if (candidate.type === 'direct-e2ee') return 2;
+  return 3;
+};
+
+const orderPairingCandidates = (candidates: PairingEndpointCandidate[]): PairingEndpointCandidate[] =>
+  [...candidates].sort((left, right) => (left.priority ?? 100) - (right.priority ?? 100) || candidateRank(left) - candidateRank(right));
+
+const validHealthBody = async (response: Response): Promise<boolean> => {
+  const body = await response.clone().json().catch(() => null) as { status?: unknown; openchamberVersion?: unknown } | null;
+  return body?.status === 'ok' && typeof body.openchamberVersion === 'string' && body.openchamberVersion.length > 0;
+};
+
+const retryableHealthStatus = (status: number): boolean => status === 408 || status === 429 || status >= 500;
+
+const securityFailure = (status: RelayTunnelStatus | undefined): boolean =>
+  status?.failureClassification === 'crypto'
+  || status?.failureClassification === 'protocol'
+  || status?.failureClassification === 'terminal';
+
+class PairingAttemptTimeoutError extends Error {
+  constructor() {
+    super('Pairing candidate attempt timed out');
+    this.name = 'PairingAttemptTimeoutError';
+  }
+}
+
+const requestWithTimeout = async (
+  request: (path: string, init?: RequestInit) => Promise<Response>,
+  path: string,
+  init: RequestInit | undefined,
+  timeoutMs: number,
+): Promise<Response> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const externalSignal = init?.signal;
+  const onExternalAbort = (): void => controller.abort();
+  externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+  try {
+    return await Promise.race([
+      request(path, { ...init, signal: controller.signal }),
+      new Promise<Response>((_, reject) => {
+        controller.signal.addEventListener('abort', () => reject(new PairingAttemptTimeoutError()), { once: true });
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+    externalSignal?.removeEventListener('abort', onExternalAbort);
+  }
+};
+
+export const firstHttpPairingCandidateUrl = (candidates: PairingEndpointCandidate[]): string | undefined =>
+  candidates.find((candidate): candidate is Extract<PairingEndpointCandidate, { type: 'lan' | 'tunnel' }> =>
+    candidate.type === 'lan' || candidate.type === 'tunnel')?.url;
+
+export const redeemPairingCandidate = async (
+  payload: PairingConnectionPayload,
+  options: PairingRedemptionOptions,
+): Promise<{ token: string; transport: PairingRedeemedTransport }> => {
+  const directFetch = options.directFetch ?? fetch;
+  const attemptTimeoutMs = options.attemptTimeoutMs ?? 10_000;
+  const healthRetryCount = Math.max(0, options.healthRetryCount ?? 2);
+  const healthRetryDelayMs = Math.max(0, options.healthRetryDelayMs ?? 100);
+  const delay = options.delay ?? ((milliseconds) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+  for (const candidate of orderPairingCandidates(payload.candidates)) {
+    let tunnel: RelayTunnelClient | null = null;
+    let request: ((path: string, init?: RequestInit) => Promise<Response>) | null = null;
+    try {
+      if (candidate.type === 'relay') {
+        tunnel = options.createRelayClient?.(candidate) ?? createRelayTunnelClient(candidate);
+        request = tunnel.fetch;
+      } else if (candidate.type === 'direct-e2ee') {
+        tunnel = options.createDirectE2eeClient?.(candidate) ?? createDirectE2eeTunnelClient(candidate);
+        request = tunnel.fetch;
+      } else {
+        request = (path, init) => directFetch(`${candidate.url}${path}`, init);
+      }
+
+      let health: Response | null = null;
+      for (let healthAttempt = 0; healthAttempt <= healthRetryCount; healthAttempt += 1) {
+        try {
+          health = await requestWithTimeout(request, '/health', undefined, attemptTimeoutMs);
+        } catch (error) {
+          if (securityFailure(tunnel?.getStatus())) {
+            throw new PairingRedemptionError('security', error instanceof Error ? error.message : 'E2EE verification failed');
+          }
+          health = null;
+          break;
+        }
+        if (!retryableHealthStatus(health.status) || healthAttempt === healthRetryCount) break;
+        await delay(healthRetryDelayMs);
+      }
+      if (!health || health.status !== 200) continue;
+      if (!(await validHealthBody(health))) {
+        if (candidate.type === 'direct-e2ee' || candidate.type === 'relay') {
+          throw new PairingRedemptionError('security', 'Encrypted host health verification failed');
+        }
+        continue;
+      }
+
+      let redeemResponse: Response;
+      try {
+        redeemResponse = await requestWithTimeout(request, '/api/client-auth/pairing/redeem', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify({ pairingId: payload.pairingId, secret: payload.secret, ...options.redeemBody }),
+        }, attemptTimeoutMs);
+      } catch (error) {
+        if (securityFailure(tunnel?.getStatus())) {
+          throw new PairingRedemptionError('security', error instanceof Error ? error.message : 'E2EE verification failed');
+        }
+        throw new PairingRedemptionError('ambiguous', error instanceof Error ? error.message : 'Pairing response was lost');
+      }
+      if (!redeemResponse.ok) throw new PairingRedemptionError('credential', 'Pairing secret was rejected');
+      const body = await redeemResponse.json().catch(() => null) as { clientToken?: unknown } | null;
+      const token = typeof body?.clientToken === 'string' ? body.clientToken.trim() : '';
+      if (!token) throw new PairingRedemptionError('credential', 'Pairing response did not contain a client token');
+
+      let session: Response;
+      try {
+        session = await requestWithTimeout(request, '/auth/session', { headers: { Authorization: `Bearer ${token}` } }, attemptTimeoutMs);
+      } catch (error) {
+        if (securityFailure(tunnel?.getStatus())) {
+          throw new PairingRedemptionError('security', error instanceof Error ? error.message : 'E2EE verification failed');
+        }
+        throw new PairingRedemptionError('authorization', error instanceof Error ? error.message : 'Client token authorization timed out');
+      }
+      const sessionBody = await session.clone().json().catch(() => null) as { authenticated?: unknown } | null;
+      if (!session.ok || sessionBody?.authenticated !== true) {
+        throw new PairingRedemptionError('authorization', 'Client token authorization failed');
+      }
+      const transport: PairingRedeemedTransport = candidate.type === 'relay'
+        ? { kind: 'relay', relayUrl: candidate.relayUrl, serverId: candidate.serverId, hostEncPubJwk: candidate.hostEncPubJwk }
+        : candidate.type === 'direct-e2ee'
+          ? { kind: 'direct-e2ee', wssUrl: candidate.wssUrl, hostEncPubJwk: candidate.hostEncPubJwk }
+          : { kind: 'direct', url: candidate.url };
+      return { token, transport };
+    } catch (error) {
+      if (error instanceof PairingRedemptionError && error.classification !== 'unreachable') throw error;
+      if ((candidate.type === 'direct-e2ee' || candidate.type === 'relay') && securityFailure(tunnel?.getStatus())) {
+        throw new PairingRedemptionError('security', error instanceof Error ? error.message : 'Direct E2EE verification failed');
+      }
+    } finally {
+      tunnel?.close();
+    }
+  }
+  throw new PairingRedemptionError('unreachable', 'No pairing candidate was reachable');
+};

--- a/packages/ui/src/lib/pairingCandidateRedemption.ts
+++ b/packages/ui/src/lib/pairingCandidateRedemption.ts
@@ -80,10 +80,6 @@ const requestWithTimeout = async (
   }
 };
 
-export const firstHttpPairingCandidateUrl = (candidates: PairingEndpointCandidate[]): string | undefined =>
-  candidates.find((candidate): candidate is Extract<PairingEndpointCandidate, { type: 'lan' | 'tunnel' }> =>
-    candidate.type === 'lan' || candidate.type === 'tunnel')?.url;
-
 export const redeemPairingCandidate = async (
   payload: PairingConnectionPayload,
   options: PairingRedemptionOptions,

--- a/packages/ui/src/lib/relay/direct-e2ee-tunnel-client.test.ts
+++ b/packages/ui/src/lib/relay/direct-e2ee-tunnel-client.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+
+import { exportPublicKeyJwk, generateEcdhKeyPair } from './crypto';
+import { createDirectE2eeChannelReadiness, createDirectE2eeTunnelClient } from './direct-e2ee-tunnel-client';
+import { RelayCloseCode } from './protocol';
+import { TunnelChannelReadinessError, type TunnelWireSocket } from './tunnel-client';
+
+const json = (body: unknown, status = 200): Response => new Response(JSON.stringify(body), {
+  status, headers: { 'content-type': 'application/json' },
+});
+
+const runReadiness = (responses: Response[], token = 'secret-token') => {
+  const requests: Request[] = [];
+  const readiness = createDirectE2eeChannelReadiness(token);
+  return {
+    requests,
+    result: readiness({ fetch: async (input, init) => {
+      requests.push(new Request(new URL(String(input), 'https://direct.example.test'), init));
+      const response = responses.shift();
+      if (!response) throw new Error('missing response');
+      return response;
+    } }),
+  };
+};
+
+const expectReadinessError = async (
+  result: Promise<void>,
+  failureClassification: TunnelChannelReadinessError['failureClassification'],
+  retryable: boolean,
+): Promise<void> => {
+  try {
+    await result;
+    throw new Error('expected readiness failure');
+  } catch (error) {
+    expect(error).toBeInstanceOf(TunnelChannelReadinessError);
+    const readinessError = error as TunnelChannelReadinessError;
+    expect(readinessError.failureClassification).toBe(failureClassification);
+    expect(readinessError.retryable).toBe(retryable);
+  }
+};
+
+describe('direct E2EE tunnel client factory', () => {
+  test('rejects descriptors outside the pinned production endpoint contract', () => {
+    expect(() => createDirectE2eeTunnelClient({
+      wssUrl: 'ws://host.example/api/openchamber/direct-e2ee/ws',
+      hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
+    })).toThrow('Invalid direct E2EE descriptor');
+  });
+
+  test('strict health and bearer session success unlock readiness', async () => {
+    const { requests, result } = runReadiness([
+      json({ status: 'ok', openchamberVersion: '1.2.3' }),
+      json({ authenticated: true }),
+    ]);
+    await result;
+    expect(requests.map((request) => request.url)).toEqual([
+      'https://direct.example.test/health', 'https://direct.example.test/auth/session',
+    ]);
+    expect(requests[1].headers.get('authorization')).toBe('Bearer secret-token');
+  });
+
+  test('health 503 is typed retryable network failure', async () => {
+    const { result } = runReadiness([json({}, 503)]);
+    await expectReadinessError(result, 'network', true);
+  });
+
+  test('wrong health shape is terminal protocol failure', async () => {
+    const { result } = runReadiness([json({ ok: true })]);
+    await expectReadinessError(result, 'protocol', false);
+  });
+
+  test('bearer 401 is terminal', async () => {
+    const { result } = runReadiness([json({ status: 'ok', openchamberVersion: '1' }), json({}, 401)]);
+    await expectReadinessError(result, 'terminal', false);
+  });
+
+  test('malformed session body is terminal protocol failure', async () => {
+    const { result } = runReadiness([json({ status: 'ok', openchamberVersion: '1' }), json({ authenticated: false })]);
+    await expectReadinessError(result, 'protocol', false);
+  });
+
+  test('readiness errors do not include the bearer token', async () => {
+    const { result } = runReadiness([json({ status: 'ok', openchamberVersion: '1' }), json({}, 401)]);
+    try { await result; } catch (error) {
+      expect(error).toBeInstanceOf(TunnelChannelReadinessError);
+      expect(String(error)).not.toContain('secret-token');
+    }
+  });
+
+  test('treats direct ChannelFailure and RekeyMismatch closes as terminal', async () => {
+    for (const code of [RelayCloseCode.ChannelFailure, RelayCloseCode.RekeyMismatch]) {
+      const keyPair = await generateEcdhKeyPair();
+      const hostEncPubJwk = await exportPublicKeyJwk(keyPair.publicKey);
+      const socket: { wire: TunnelWireSocket | null } = { wire: null };
+      const client = createDirectE2eeTunnelClient({
+        wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws',
+        hostEncPubJwk,
+      }, null, {
+        createOuterWebSocket: () => {
+          socket.wire = { readyState: 1, send: () => {}, close: () => {}, onopen: null, onmessage: null, onclose: null, onerror: null };
+          return socket.wire;
+        },
+      });
+      const request = client.fetch('/health');
+      while (!socket.wire?.onclose) await Promise.resolve();
+      socket.wire.onclose({ code, reason: 'security failure' });
+      await expect(request).rejects.toThrow(`code ${code}`);
+      expect(client.getStatus().state).toBe('error');
+      expect(client.getStatus().failureClassification).toBe('terminal');
+      client.close();
+    }
+  });
+
+  test('classifies malformed direct handshake traffic as terminal protocol failure', async () => {
+    const keyPair = await generateEcdhKeyPair();
+    const hostEncPubJwk = await exportPublicKeyJwk(keyPair.publicKey);
+    const socket: { wire: TunnelWireSocket | null } = { wire: null };
+    const client = createDirectE2eeTunnelClient({
+      wssUrl: 'wss://host.example/api/openchamber/direct-e2ee/ws',
+      hostEncPubJwk,
+    }, null, {
+      createOuterWebSocket: () => {
+        socket.wire = { readyState: 1, send: () => {}, close: () => {}, onopen: null, onmessage: null, onclose: null, onerror: null };
+        return socket.wire;
+      },
+    });
+    const request = client.fetch('/health');
+    while (!socket.wire?.onmessage) await Promise.resolve();
+    socket.wire.onmessage({ data: new Uint8Array([1, 2, 3]) });
+    await expect(request).rejects.toThrow();
+    expect(client.getStatus().state).toBe('error');
+    expect(client.getStatus().failureClassification).toBe('protocol');
+    client.close();
+  });
+});

--- a/packages/ui/src/lib/relay/direct-e2ee-tunnel-client.ts
+++ b/packages/ui/src/lib/relay/direct-e2ee-tunnel-client.ts
@@ -1,0 +1,74 @@
+import { normalizeDirectE2eeCandidate, type PairingDirectE2eeCandidate } from '@/lib/connectionPayload';
+
+import {
+  createRelayTunnelClient,
+  TunnelChannelReadinessError,
+  type RelayTunnelClient,
+  type RelayTunnelClientOptions,
+  type TunnelChannelReadinessContext,
+} from './tunnel-client';
+import { RelayCloseCode } from './protocol';
+
+export type DirectE2eeRuntimeDescriptor = Omit<PairingDirectE2eeCandidate, 'type' | 'priority'>;
+
+export const createDirectE2eeChannelReadiness = (runtimeBearerToken: string) => async ({ fetch }: TunnelChannelReadinessContext): Promise<void> => {
+  let health: Response;
+  try {
+    health = await fetch('/health');
+  } catch {
+    throw new TunnelChannelReadinessError('direct E2EE health request failed', 'network', true);
+  }
+  if (health.status === 408 || health.status === 429 || health.status >= 500) {
+    throw new TunnelChannelReadinessError(`direct E2EE health unavailable (${health.status})`, 'network', true);
+  }
+  if (health.status !== 200) {
+    throw new TunnelChannelReadinessError(`direct E2EE health rejected (${health.status})`, 'protocol', false);
+  }
+  const healthBody: unknown = await health.json().catch(() => null);
+  if (!healthBody || typeof healthBody !== 'object'
+    || (healthBody as Record<string, unknown>).status !== 'ok'
+    || typeof (healthBody as Record<string, unknown>).openchamberVersion !== 'string') {
+    throw new TunnelChannelReadinessError('direct E2EE health response is not OpenChamber', 'protocol', false);
+  }
+
+  let session: Response;
+  try {
+    session = await fetch('/auth/session', { headers: { Authorization: `Bearer ${runtimeBearerToken}` } });
+  } catch {
+    throw new TunnelChannelReadinessError('direct E2EE session verification failed', 'network', true);
+  }
+  if (session.status === 401 || session.status === 403) {
+    throw new TunnelChannelReadinessError('direct E2EE bearer token rejected', 'terminal', false);
+  }
+  if (session.status === 408 || session.status === 429 || session.status >= 500) {
+    throw new TunnelChannelReadinessError(`direct E2EE session unavailable (${session.status})`, 'network', true);
+  }
+  if (session.status !== 200) {
+    throw new TunnelChannelReadinessError(`direct E2EE session rejected (${session.status})`, 'protocol', false);
+  }
+  const sessionBody: unknown = await session.json().catch(() => null);
+  if (!sessionBody || typeof sessionBody !== 'object' || (sessionBody as Record<string, unknown>).authenticated !== true) {
+    throw new TunnelChannelReadinessError('direct E2EE session response is invalid', 'protocol', false);
+  }
+};
+
+export const createDirectE2eeTunnelClient = (
+  descriptor: DirectE2eeRuntimeDescriptor,
+  runtimeBearerToken?: string | null,
+  options: Omit<RelayTunnelClientOptions, 'hostEncPubJwk' | 'outerWebSocketUrl' | 'relayUrl' | 'serverId' | 'grant'> = {},
+): RelayTunnelClient => {
+  const normalized = normalizeDirectE2eeCandidate({ type: 'direct-e2ee', ...descriptor });
+  if (!normalized) throw new Error('Invalid direct E2EE descriptor');
+  return createRelayTunnelClient({
+    ...options,
+    outerWebSocketUrl: normalized.wssUrl,
+    hostEncPubJwk: normalized.hostEncPubJwk,
+    isTerminalCloseCode: options.isTerminalCloseCode ?? ((code) =>
+      code === RelayCloseCode.RekeyMismatch || code === RelayCloseCode.ChannelFailure),
+    isTerminalFailureClassification: options.isTerminalFailureClassification ?? ((classification) =>
+      classification === 'crypto' || classification === 'protocol'),
+    ...(runtimeBearerToken ? {
+      channelReadiness: createDirectE2eeChannelReadiness(runtimeBearerToken),
+    } : {}),
+  });
+};

--- a/packages/ui/src/lib/relay/runtime-tunnel.test.ts
+++ b/packages/ui/src/lib/relay/runtime-tunnel.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  activateRuntimeTunnel,
+  deactivateRelayTunnel,
+  setRuntimeTunnelClientFactoriesForTests,
+  type RuntimeTunnelDescriptor,
+} from './runtime-tunnel';
+import type { RelayTunnelClient } from './tunnel-client';
+
+const direct: RuntimeTunnelDescriptor = {
+  type: 'direct-e2ee',
+  wssUrl: 'wss://direct.example.test/api/openchamber/direct-e2ee/ws',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
+};
+const hosted: RuntimeTunnelDescriptor = {
+  type: 'relay', relayUrl: 'wss://relay.example.test', serverId: 'server',
+  hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
+};
+
+const fakeClient = (closed: { value: boolean }): RelayTunnelClient => ({
+  fetch: async () => new Response(),
+  openWebSocket: () => { throw new Error('unused'); },
+  getStatus: () => ({ state: 'idle' }),
+  subscribeStatus: () => () => {},
+  close: () => { closed.value = true; },
+});
+
+afterEach(() => setRuntimeTunnelClientFactoriesForTests(null));
+
+describe('runtime tunnel activation identity', () => {
+  test('reuses the same direct descriptor with the same token', () => {
+    let calls = 0;
+    setRuntimeTunnelClientFactoriesForTests({ createDirect: () => { calls += 1; return fakeClient({ value: false }); } });
+    const first = activateRuntimeTunnel(direct, 'token-a');
+    expect(activateRuntimeTunnel(direct, 'token-a')).toBe(first);
+    expect(calls).toBe(1);
+  });
+
+  test('changed direct token closes and recreates with the new token', () => {
+    const tokens: Array<string | null | undefined> = [];
+    const closes: Array<{ value: boolean }> = [];
+    setRuntimeTunnelClientFactoriesForTests({ createDirect: (_descriptor, token) => {
+      tokens.push(token); const closed = { value: false }; closes.push(closed); return fakeClient(closed);
+    } });
+    activateRuntimeTunnel(direct, 'token-a');
+    activateRuntimeTunnel(direct, 'token-b');
+    expect(tokens).toEqual(['token-a', 'token-b']);
+    expect(closes[0].value).toBe(true);
+  });
+
+  test('hosted relay reuse ignores client token and receives no readiness token', () => {
+    let calls = 0;
+    setRuntimeTunnelClientFactoriesForTests({ createHosted: () => { calls += 1; return fakeClient({ value: false }); } });
+    const first = activateRuntimeTunnel(hosted, 'token-a');
+    expect(activateRuntimeTunnel(hosted, 'token-b')).toBe(first);
+    expect(calls).toBe(1);
+  });
+
+  test('deactivation clears direct token identity', () => {
+    const tokens: Array<string | null | undefined> = [];
+    setRuntimeTunnelClientFactoriesForTests({ createDirect: (_descriptor, token) => { tokens.push(token); return fakeClient({ value: false }); } });
+    activateRuntimeTunnel(direct, 'token-a');
+    deactivateRelayTunnel();
+    activateRuntimeTunnel(direct, 'token-a');
+    expect(tokens).toEqual(['token-a', 'token-a']);
+  });
+});

--- a/packages/ui/src/lib/relay/runtime-tunnel.ts
+++ b/packages/ui/src/lib/relay/runtime-tunnel.ts
@@ -4,22 +4,25 @@
 // (runtime-switch <-> runtime-url).
 
 import { createRelayTunnelClient, type RelayTunnelClient } from './tunnel-client';
+import { createDirectE2eeTunnelClient, type DirectE2eeRuntimeDescriptor } from './direct-e2ee-tunnel-client';
 
 export interface RelayRuntimeDescriptor {
+  type?: 'relay';
   relayUrl: string;
   serverId: string;
   hostEncPubJwk: JsonWebKey;
   grant?: string;
 }
 
-let activeTunnel: RelayTunnelClient | null = null;
-let activeDescriptor: RelayRuntimeDescriptor | null = null;
+export type RuntimeTunnelDescriptor = RelayRuntimeDescriptor | ({ type: 'direct-e2ee' } & DirectE2eeRuntimeDescriptor);
 
-const descriptorsEqual = (a: RelayRuntimeDescriptor, b: RelayRuntimeDescriptor): boolean =>
-  a.relayUrl === b.relayUrl &&
-  a.serverId === b.serverId &&
-  a.grant === b.grant &&
-  JSON.stringify(a.hostEncPubJwk) === JSON.stringify(b.hostEncPubJwk);
+let activeTunnel: RelayTunnelClient | null = null;
+let activeDescriptor: RuntimeTunnelDescriptor | null = null;
+let activeDirectToken: string | null = null;
+let createHostedClient = createRelayTunnelClient;
+let createDirectClient = createDirectE2eeTunnelClient;
+
+const descriptorsEqual = (a: RuntimeTunnelDescriptor, b: RuntimeTunnelDescriptor): boolean => JSON.stringify(a) === JSON.stringify(b);
 
 export const getActiveRelayTunnel = (): RelayTunnelClient | null => activeTunnel;
 
@@ -30,31 +33,51 @@ export const isRelayModeActive = (): boolean => activeTunnel !== null;
  * Reuses the existing client when the descriptor is unchanged so a redundant
  * runtime switch does not tear down a live tunnel.
  */
-export const activateRelayTunnel = (descriptor: RelayRuntimeDescriptor): RelayTunnelClient => {
-  if (activeTunnel && activeDescriptor && descriptorsEqual(activeDescriptor, descriptor)) {
+export const activateRuntimeTunnel = (descriptor: RuntimeTunnelDescriptor, clientToken?: string | null): RelayTunnelClient => {
+  const directToken = descriptor.type === 'direct-e2ee' ? clientToken || null : null;
+  if (activeTunnel && activeDescriptor && descriptorsEqual(activeDescriptor, descriptor)
+    && (descriptor.type !== 'direct-e2ee' || activeDirectToken === directToken)) {
     return activeTunnel;
   }
   activeTunnel?.close();
   activeDescriptor = descriptor;
-  activeTunnel = createRelayTunnelClient(descriptor);
+  activeDirectToken = directToken;
+  activeTunnel = descriptor.type === 'direct-e2ee'
+    ? createDirectClient(descriptor, directToken)
+    : createHostedClient(descriptor);
   return activeTunnel;
 };
 
 /**
  * Adopts an ALREADY-OPEN tunnel client (e.g. the connect flow's probe tunnel)
  * as the active runtime tunnel, so the immediately following
- * `activateRelayTunnel` with an equal descriptor reuses it instead of paying a
+ * `activateRuntimeTunnel` with an equal descriptor reuses it instead of paying a
  * second WebSocket connect + E2EE handshake. Replaces any previous tunnel.
  */
-export const adoptRelayTunnel = (descriptor: RelayRuntimeDescriptor, client: RelayTunnelClient): void => {
+export const adoptRelayTunnel = (
+  descriptor: RuntimeTunnelDescriptor,
+  client: RelayTunnelClient,
+  clientToken?: string | null,
+): void => {
   if (activeTunnel === client) return;
   activeTunnel?.close();
   activeDescriptor = descriptor;
+  activeDirectToken = descriptor.type === 'direct-e2ee' ? clientToken || null : null;
   activeTunnel = client;
+};
+
+export const setRuntimeTunnelClientFactoriesForTests = (factories: {
+  createHosted?: typeof createRelayTunnelClient;
+  createDirect?: typeof createDirectE2eeTunnelClient;
+} | null): void => {
+  deactivateRelayTunnel();
+  createHostedClient = factories?.createHosted ?? createRelayTunnelClient;
+  createDirectClient = factories?.createDirect ?? createDirectE2eeTunnelClient;
 };
 
 export const deactivateRelayTunnel = (): void => {
   activeTunnel?.close();
   activeTunnel = null;
   activeDescriptor = null;
+  activeDirectToken = null;
 };

--- a/packages/ui/src/lib/relay/tunnel-client.test.ts
+++ b/packages/ui/src/lib/relay/tunnel-client.test.ts
@@ -246,12 +246,14 @@ const setupClient = async (
   killWire: () => void;
   sendTextToClient: (text: string) => void;
   clientBinaryCount: () => number;
+  requestedUrls: () => string[];
 }> => {
   const hostKeyPair = await generateEcdhKeyPair();
   const hostPubJwk = await exportPublicKeyJwk(hostKeyPair.publicKey);
   let count = 0;
   let lastClientEndpoint: FakeEndpoint | null = null;
   let lastHostEndpoint: FakeEndpoint | null = null;
+  const urls: string[] = [];
   const client = createRelayTunnelClient({
     relayUrl: 'wss://relay.test/ws',
     serverId: 'server-1',
@@ -262,7 +264,8 @@ const setupClient = async (
     reconnectBaseDelayMs: 20,
     reconnectMaxDelayMs: 80,
     ...clientOverrides,
-    createWireSocket: () => {
+    createWireSocket: (url) => {
+      urls.push(url);
       count += 1;
       const clientEndpoint = new FakeEndpoint();
       const hostEndpoint = new FakeEndpoint();
@@ -278,9 +281,10 @@ const setupClient = async (
   return {
     client,
     connectionCount: () => count,
-    killWire: () => lastClientEndpoint?.close(1006, 'killed'),
+    killWire: (code = 1006, reason = 'killed') => lastClientEndpoint?.close(code, reason),
     sendTextToClient: (text: string) => lastHostEndpoint?.send(text),
     clientBinaryCount: () => lastClientEndpoint?.binarySent ?? 0,
+    requestedUrls: () => urls,
   };
 };
 
@@ -296,6 +300,83 @@ const track = (client: RelayTunnelClient): RelayTunnelClient => {
 };
 
 describe('createRelayTunnelClient', () => {
+  test('does not publish or expose a channel until readiness succeeds', async () => {
+    let release!: () => void;
+    const readiness = new Promise<void>((resolve) => { release = resolve; });
+    const { client } = await setupClient({}, { channelReadiness: async ({ fetch }) => {
+      const health = await fetch('/health');
+      expect(health.status).toBe(200);
+      await readiness;
+    } });
+    track(client);
+    const request = client.fetch('/health');
+    await wait(50);
+    expect(client.getStatus().state).not.toBe('connected');
+    let settled = false;
+    void request.finally(() => { settled = true; });
+    await wait(10);
+    expect(settled).toBe(false);
+    release();
+    expect((await request).status).toBe(200);
+    expect(client.getStatus().state).toBe('connected');
+  });
+
+  test('runs readiness again before queued requests resume after reconnect', async () => {
+    let checks = 0;
+    let releaseSecond!: () => void;
+    const second = new Promise<void>((resolve) => { releaseSecond = resolve; });
+    const { client, killWire } = await setupClient({}, { channelReadiness: async ({ fetch }) => {
+      checks += 1;
+      expect((await fetch('/health')).status).toBe(200);
+      if (checks === 2) await second;
+    } });
+    track(client);
+    await client.fetch('/health');
+    killWire();
+    await wait(10);
+    const queued = client.fetch('/health');
+    await wait(80);
+    expect(checks).toBe(2);
+    expect(client.getStatus().state).not.toBe('connected');
+    releaseSecond();
+    expect((await queued).status).toBe(200);
+  });
+
+  test('keeps public fetch and WebSocket blocked together until readiness publishes', async () => {
+    let release!: () => void;
+    const readiness = new Promise<void>((resolve) => { release = resolve; });
+    const { client } = await setupClient({}, { channelReadiness: async () => readiness });
+    track(client);
+    const request = client.fetch('/health');
+    const socket = client.openWebSocket('/api/event/ws');
+    let fetchSettled = false;
+    let socketOpened = false;
+    void request.then(() => { fetchSettled = true; });
+    socket.onopen = () => { socketOpened = true; };
+    await wait(50);
+    expect(fetchSettled).toBe(false);
+    expect(socketOpened).toBe(false);
+    expect(socket.readyState).toBe(0);
+    release();
+    expect((await request).status).toBe(200);
+    await wait(20);
+    expect(socketOpened).toBe(true);
+  });
+  test('preserves relay URL construction by default and accepts an exact outer URL', async () => {
+    const relay = await setupClient();
+    track(relay.client);
+    await relay.client.fetch('/health');
+    const relayUrl = new URL(relay.requestedUrls()[0]);
+    expect(relayUrl.origin + relayUrl.pathname).toBe('wss://relay.test/ws');
+    expect(relayUrl.searchParams.get('role')).toBe('client');
+    expect(relayUrl.searchParams.get('serverId')).toBe('server-1');
+
+    const direct = await setupClient({}, { outerWebSocketUrl: 'wss://managed.example/api/openchamber/direct-e2ee/ws' });
+    track(direct.client);
+    await direct.client.fetch('/health');
+    expect(direct.requestedUrls()[0]).toBe('wss://managed.example/api/openchamber/direct-e2ee/ws');
+  });
+
   test('performs concurrent fetches over one tunnel', async () => {
     const { client } = await setupClient();
     track(client);
@@ -366,6 +447,10 @@ describe('createRelayTunnelClient', () => {
   test('fails open streams on reconnect and recovers on retry', async () => {
     const { client, connectionCount, killWire } = await setupClient();
     track(client);
+    const failures: string[] = [];
+    client.subscribeStatus((status) => {
+      if (status.failureClassification) failures.push(status.failureClassification);
+    });
     const response = await client.fetch('/never-ends');
     const reader = response.body!.getReader();
     await reader.read();
@@ -380,6 +465,7 @@ describe('createRelayTunnelClient', () => {
     killWire();
     await expect(reader.read()).rejects.toThrow();
     expect(await socketClosed).toBe(1012);
+    expect(failures).toContain('network');
 
     // The client reconnects a fresh wire and works again.
     const health = await client.fetch('/health');
@@ -430,12 +516,17 @@ describe('createRelayTunnelClient', () => {
   test('fails closed on non-ready plaintext after establishment', async () => {
     const { client, connectionCount, sendTextToClient } = await setupClient();
     track(client);
+    const failures: string[] = [];
+    client.subscribeStatus((status) => {
+      if (status.failureClassification) failures.push(status.failureClassification);
+    });
     await client.fetch('/health');
     expect(connectionCount()).toBe(1);
     sendTextToClient('{"anything":"plaintext"}');
     // The channel must reset (fail closed) and the client reconnect a new wire.
     await wait(150);
     expect(connectionCount()).toBeGreaterThan(1);
+    expect(failures).toContain('protocol');
   });
 
   test('publishes status transitions to subscribers', async () => {

--- a/packages/ui/src/lib/relay/tunnel-client.test.ts
+++ b/packages/ui/src/lib/relay/tunnel-client.test.ts
@@ -103,6 +103,7 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
   let batchNegotiated = false;
   const assembler = createFragmentAssembler();
   const httpBodies = new Map<number, Uint8Array[]>();
+  const httpRequests = new Map<number, { method: string; path: string }>();
   const aborted = new Set<number>();
   let sendChain: Promise<void> = Promise.resolve();
   let recvChain: Promise<void> = Promise.resolve();
@@ -123,6 +124,38 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
     sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
   };
 
+  const respondHttp = (streamId: number, path: string, body: Uint8Array): void => {
+    if (path === '/health') {
+      respondJson(streamId, 200, { ok: true });
+    } else if (path === '/echo-body') {
+      sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
+      sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, body));
+      sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
+    } else if (path === '/stream') {
+      sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
+      const emit = (index: number): void => {
+        if (aborted.has(streamId)) return;
+        if (index >= 3) {
+          sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
+          return;
+        }
+        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, textEncoder.encode(`chunk${index};`)));
+        setTimeout(() => emit(index + 1), 10);
+      };
+      emit(0);
+    } else if (path === '/never-ends') {
+      sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
+      const pump = (): void => {
+        if (aborted.has(streamId) || endpoint.closed) return;
+        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, textEncoder.encode('tick;')));
+        setTimeout(pump, 10);
+      };
+      pump();
+    } else {
+      respondJson(streamId, 404, { error: 'not found' });
+    }
+  };
+
   const handleTunnelFrame = (frame: TunnelFrame): void => {
     options.recordFrame?.(frame);
     if (options.silent) return;
@@ -133,8 +166,10 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
     if (frame.frameType === TunnelFrameType.HttpRequest) {
       const req = decodeJsonPayload(frame.payload, isHttpRequestPayload);
       httpBodies.set(frame.streamId, []);
-      (endpoint as FakeEndpoint & { pendingPath?: Map<number, string> }).pendingPath ??= new Map();
-      (endpoint as FakeEndpoint & { pendingPath: Map<number, string> }).pendingPath.set(frame.streamId, req.path);
+      httpRequests.set(frame.streamId, { method: req.method, path: req.path });
+      if (req.method === 'GET' || req.method === 'HEAD') {
+        respondHttp(frame.streamId, req.path, new Uint8Array(0));
+      }
       return;
     }
     if (frame.frameType === TunnelFrameType.HttpBody) {
@@ -146,8 +181,8 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
       return;
     }
     if (frame.frameType === TunnelFrameType.StreamEnd) {
-      const paths = (endpoint as FakeEndpoint & { pendingPath?: Map<number, string> }).pendingPath;
-      const path = paths?.get(frame.streamId) ?? '';
+      const request = httpRequests.get(frame.streamId);
+      if (!request || request.method === 'GET' || request.method === 'HEAD') return;
       const bodyChunks = httpBodies.get(frame.streamId) ?? [];
       const total = bodyChunks.reduce((sum, c) => sum + c.length, 0);
       const body = new Uint8Array(total);
@@ -156,36 +191,7 @@ const attachMiniHost = (endpoint: FakeEndpoint, hostPrivateKey: CryptoKey, optio
         body.set(c, off);
         off += c.length;
       }
-      const streamId = frame.streamId;
-      if (path === '/health') {
-        respondJson(streamId, 200, { ok: true });
-      } else if (path === '/echo-body') {
-        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
-        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, body));
-        sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
-      } else if (path === '/stream') {
-        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
-        const emit = (index: number): void => {
-          if (aborted.has(streamId)) return;
-          if (index >= 3) {
-            sendFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
-            return;
-          }
-          sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, textEncoder.encode(`chunk${index};`)));
-          setTimeout(() => emit(index + 1), 10);
-        };
-        emit(0);
-      } else if (path === '/never-ends') {
-        sendFrame(encodeTunnelFrame(TunnelFrameType.HttpResponse, streamId, encodeJsonPayload({ status: 200, headers: {} })));
-        const pump = (): void => {
-          if (aborted.has(streamId) || endpoint.closed) return;
-          sendFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, textEncoder.encode('tick;')));
-          setTimeout(pump, 10);
-        };
-        pump();
-      } else {
-        respondJson(streamId, 404, { error: 'not found' });
-      }
+      respondHttp(frame.streamId, request.path, body);
       return;
     }
     if (frame.frameType === TunnelFrameType.WsOpen) {
@@ -390,6 +396,61 @@ describe('createRelayTunnelClient', () => {
     expect(b.status).toBe(200);
     expect(await b.text()).toBe(await new Response('{"ok":true}').text());
     expect(await c.text()).toBe('payload-xyz');
+  });
+
+  test('does not send request body frames or StreamEnd for GET and HEAD', async () => {
+    const received: TunnelFrame[] = [];
+    const { client } = await setupClient({ recordFrame: (frame) => received.push(frame) });
+    track(client);
+
+    await client.fetch('/health');
+    await client.fetch('/health', { method: 'HEAD' });
+    await wait(20);
+
+    const requestStreamIds = received
+      .filter((frame) => frame.frameType === TunnelFrameType.HttpRequest)
+      .map((frame) => frame.streamId);
+    expect(requestStreamIds).toHaveLength(2);
+    expect(received.some((frame) => requestStreamIds.includes(frame.streamId) && frame.frameType === TunnelFrameType.HttpBody)).toBe(false);
+    expect(received.some((frame) => requestStreamIds.includes(frame.streamId) && frame.frameType === TunnelFrameType.StreamEnd)).toBe(false);
+  });
+
+  test('sends StreamEnd immediately after POST and DELETE requests without bodies', async () => {
+    const received: TunnelFrame[] = [];
+    const { client } = await setupClient({ recordFrame: (frame) => received.push(frame) });
+    track(client);
+
+    for (const method of ['POST', 'DELETE']) {
+      const response = await client.fetch('/echo-body', { method });
+      expect(await response.text()).toBe('');
+    }
+
+    const requests = received.filter((frame) => frame.frameType === TunnelFrameType.HttpRequest);
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      const streamFrames = received.filter((frame) => frame.streamId === request.streamId);
+      expect(streamFrames.map((frame) => frame.frameType)).toEqual([
+        TunnelFrameType.HttpRequest,
+        TunnelFrameType.StreamEnd,
+      ]);
+    }
+  });
+
+  test('sends streamed request body frames before StreamEnd', async () => {
+    const received: TunnelFrame[] = [];
+    const { client } = await setupClient({ recordFrame: (frame) => received.push(frame) });
+    track(client);
+
+    const response = await client.fetch('/echo-body', { method: 'POST', body: 'streamed-body' });
+    expect(await response.text()).toBe('streamed-body');
+
+    const request = received.find((frame) => frame.frameType === TunnelFrameType.HttpRequest);
+    expect(request).toBeDefined();
+    const streamFrames = received.filter((frame) => frame.streamId === request?.streamId);
+    expect(streamFrames[0]?.frameType).toBe(TunnelFrameType.HttpRequest);
+    expect(streamFrames.at(-1)?.frameType).toBe(TunnelFrameType.StreamEnd);
+    expect(streamFrames.slice(1, -1).every((frame) => frame.frameType === TunnelFrameType.HttpBody)).toBe(true);
+    expect(streamFrames.slice(1, -1).length).toBeGreaterThan(0);
   });
 
   test('streams a response body incrementally', async () => {

--- a/packages/ui/src/lib/relay/tunnel-client.ts
+++ b/packages/ui/src/lib/relay/tunnel-client.ts
@@ -140,19 +140,44 @@ export const wrapBrowserWebSocket = (ws: WebSocket): RelayTunnelWebSocket => {
 };
 
 export type RelayTunnelState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'error';
+export type RelayTunnelFailureClassification = 'network' | 'protocol' | 'crypto' | 'terminal';
+
+export class TunnelChannelReadinessError extends Error {
+  constructor(
+    message: string,
+    readonly failureClassification: RelayTunnelFailureClassification,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = 'TunnelChannelReadinessError';
+  }
+}
+
+export interface TunnelChannelReadinessContext {
+  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
+}
 
 export interface RelayTunnelStatus {
   state: RelayTunnelState;
   lastError?: string;
+  failureClassification?: RelayTunnelFailureClassification;
 }
 
 export interface RelayTunnelClientOptions {
-  relayUrl: string;
-  serverId: string;
+  relayUrl?: string;
+  serverId?: string;
   hostEncPubJwk: JsonWebKey;
   grant?: string;
-  /** Test hook: replaces native WebSocket construction with a fake wire. */
+  /** Exact outer WebSocket URL. When omitted, the hosted-relay URL is built as before. */
+  outerWebSocketUrl?: string | (() => string);
+  /** Transport seam for constructing the outer socket. */
+  createOuterWebSocket?: (url: string) => TunnelWireSocket;
+  /** Backward-compatible test alias for createOuterWebSocket. */
   createWireSocket?: (url: string) => TunnelWireSocket;
+  /** Override which outer close codes are terminal. Hosted-relay defaults are unchanged. */
+  isTerminalCloseCode?: (code: number) => boolean;
+  /** Override which locally detected failures are terminal. Hosted-relay defaults are unchanged. */
+  isTerminalFailureClassification?: (classification: RelayTunnelFailureClassification) => boolean;
   helloRetryMs?: number;
   helloTimeoutMs?: number;
   pingIntervalMs?: number;
@@ -164,6 +189,8 @@ export interface RelayTunnelClientOptions {
   reconnectBaseDelayMs?: number;
   reconnectMaxDelayMs?: number;
   hiddenOrOfflineMaxDelayMs?: number;
+  /** Verifies the newly encrypted channel before it is exposed to callers. */
+  channelReadiness?: (context: TunnelChannelReadinessContext) => Promise<void>;
 }
 
 export interface RelayTunnelClient {
@@ -230,7 +257,11 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
   const reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? 30_000;
   const hiddenOrOfflineMaxDelayMs = options.hiddenOrOfflineMaxDelayMs ?? 60_000;
 
-  const createWire = options.createWireSocket ?? ((url: string) => wrapNativeWebSocket(new WebSocket(url)));
+  const createWire = options.createOuterWebSocket
+    ?? options.createWireSocket
+    ?? ((url: string) => wrapNativeWebSocket(new WebSocket(url)));
+  const isTerminalCloseCode = options.isTerminalCloseCode ?? ((code: number) => TERMINAL_RELAY_CLOSE_CODES.has(code));
+  const isTerminalFailureClassification = options.isTerminalFailureClassification ?? (() => false);
 
   let closed = false;
   let status: RelayTunnelStatus = { state: 'idle' };
@@ -246,7 +277,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
   let wakeListenersInstalled = false;
 
   const setStatus = (next: RelayTunnelStatus): void => {
-    if (status.state === next.state && status.lastError === next.lastError) return;
+    if (status.state === next.state && status.lastError === next.lastError && status.failureClassification === next.failureClassification) return;
     status = next;
     for (const listener of statusListeners) {
       try {
@@ -332,6 +363,12 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
   };
 
   const buildRelayWsUrl = (): string => {
+    if (options.outerWebSocketUrl) {
+      return typeof options.outerWebSocketUrl === 'function' ? options.outerWebSocketUrl() : options.outerWebSocketUrl;
+    }
+    if (!options.relayUrl || !options.serverId) {
+      throw new Error('relayUrl and serverId are required when outerWebSocketUrl is omitted');
+    }
     const url = new URL(options.relayUrl);
     url.searchParams.set('v', String(RELAY_PROTOCOL_VERSION));
     url.searchParams.set('role', 'client');
@@ -345,14 +382,14 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
     clearReconnectTimer();
     attemptGeneration += 1;
     const generation = attemptGeneration;
-    setStatus({ state: consecutiveFailures > 0 ? 'reconnecting' : 'connecting', lastError: status.lastError });
+    setStatus({ state: consecutiveFailures > 0 ? 'reconnecting' : 'connecting', lastError: status.lastError, failureClassification: status.failureClassification });
 
     let handshake;
     try {
       handshake = await createClientHandshake(options.hostEncPubJwk, { batch: advertiseBatch });
     } catch (error) {
       if (generation !== attemptGeneration || closed) return;
-      failAttempt(generation, toError(error), true);
+      failAttempt(generation, toError(error), 'crypto', true);
       return;
     }
     if (generation !== attemptGeneration || closed) return;
@@ -361,7 +398,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
     try {
       wire = createWire(buildRelayWsUrl());
     } catch (error) {
-      failAttempt(generation, toError(error));
+      failAttempt(generation, toError(error), 'network');
       return;
     }
     currentWire = wire;
@@ -408,7 +445,13 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
     };
     currentAttemptCleanup = cleanupTimers;
 
-    function failAttemptLocal(error: Error, asErrorState = false, terminal = false): void {
+    function failAttemptLocal(
+      error: Error,
+      failureClassification: RelayTunnelFailureClassification,
+      asErrorState = false,
+      terminal = false,
+    ): void {
+      terminal ||= isTerminalFailureClassification(failureClassification);
       if (settled || generation !== attemptGeneration) return;
       settled = true;
       cleanupTimers();
@@ -416,7 +459,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         activeChannel = null;
         failChannelStreams(channel, new Error(`relay tunnel reset: ${error.message}`));
       }
-      rejectWaiters(error);
+      if (terminal) rejectWaiters(error);
       try {
         wire.close();
       } catch {
@@ -428,10 +471,10 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
       // A permanent rejection (auth failed, duplicate, limit) won't resolve by
       // retrying — surface a terminal error instead of reconnecting forever.
       if (terminal) {
-        setStatus({ state: 'error', lastError: error.message });
+        setStatus({ state: 'error', lastError: error.message, failureClassification });
         return;
       }
-      setStatus({ state: asErrorState ? 'error' : 'reconnecting', lastError: error.message });
+      setStatus({ state: asErrorState ? 'error' : 'reconnecting', lastError: error.message, failureClassification });
       scheduleReconnect();
     }
 
@@ -492,12 +535,14 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         },
       };
       channel = channelObj;
-      activeChannel = channelObj;
-      consecutiveFailures = 0;
       lastActivityAt = Date.now();
-      setStatus({ state: 'connected' });
-      resolveWaiters(channelObj);
-      pingTimer = setInterval(() => {
+      const publishChannel = (): void => {
+        if (settled || generation !== attemptGeneration || channelObj.dead) return;
+        activeChannel = channelObj;
+        consecutiveFailures = 0;
+        setStatus({ state: 'connected' });
+        resolveWaiters(channelObj);
+        pingTimer = setInterval(() => {
         const now = Date.now();
         // Only ping when the tunnel has actually been idle; streaming traffic
         // keeps lastActivityAt fresh, so sustained bursts send zero pings.
@@ -507,10 +552,28 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         if (pongDeadline === null) {
           pongDeadline = setTimeout(() => {
             pongDeadline = null;
-            failAttemptLocal(new Error('relay keepalive timeout'));
+            failAttemptLocal(new Error('relay keepalive timeout'), 'network');
           }, pingTimeoutMs);
         }
-      }, pingIntervalMs);
+        }, pingIntervalMs);
+      };
+      if (!options.channelReadiness) {
+        publishChannel();
+        return;
+      }
+      void options.channelReadiness({
+        fetch: (input, init) => tunnelFetchOnChannel(channelObj, input, init),
+      }).then(publishChannel).catch((error: unknown) => {
+        const readinessError = error instanceof TunnelChannelReadinessError
+          ? error
+          : new TunnelChannelReadinessError('tunnel channel readiness callback failed', 'terminal', false);
+        failAttemptLocal(
+          readinessError,
+          readinessError.failureClassification,
+          !readinessError.retryable,
+          !readinessError.retryable,
+        );
+      });
     };
 
     const handleTunnelFrame = (channelObj: ActiveChannel, plaintext: Uint8Array): void => {
@@ -518,7 +581,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
       try {
         frame = decodeTunnelFrame(plaintext);
       } catch (error) {
-        failAttemptLocal(toError(error));
+        failAttemptLocal(toError(error), 'protocol');
         return;
       }
       // Any received frame proves the tunnel is alive — clear the pong deadline.
@@ -540,13 +603,13 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         try {
           complete = channelObj.assembler.push(frame);
         } catch (error) {
-          failAttemptLocal(toError(error));
+          failAttemptLocal(toError(error), 'protocol');
           return;
         }
         if (complete === null) return;
         payload = complete;
       } else if (frame.hasMoreFragments) {
-        failAttemptLocal(new Error('unexpected fragmented tunnel frame'));
+        failAttemptLocal(new Error('unexpected fragmented tunnel frame'), 'protocol');
         return;
       }
 
@@ -577,11 +640,11 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
               if (cryptoChannel) return;
               establish(action.channel, action.batch);
             } else if (action.type === 'fail') {
-              failAttemptLocal(new Error(`relay handshake failed: ${action.reason}`));
+              failAttemptLocal(new Error(`relay handshake failed: ${action.reason}`), 'protocol');
             }
           })
           .catch((error: unknown) => {
-            failAttemptLocal(toError(error));
+            failAttemptLocal(toError(error), 'crypto');
           });
         return;
       }
@@ -594,14 +657,14 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
           const currentChannel = channel;
           const currentCrypto = cryptoChannel;
           if (!currentChannel || !currentCrypto) {
-            failAttemptLocal(new Error('encrypted frame before handshake completed'));
+            failAttemptLocal(new Error('encrypted frame before handshake completed'), 'protocol');
             return;
           }
           let plaintext: Uint8Array;
           try {
             plaintext = await currentCrypto.decryptor.decrypt(bytes);
           } catch (error) {
-            failAttemptLocal(toError(error));
+            failAttemptLocal(toError(error), 'crypto');
             return;
           }
           if (batchNegotiated) {
@@ -611,7 +674,7 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
             try {
               frames = decodeFrameBatch(plaintext);
             } catch (error) {
-              failAttemptLocal(toError(error));
+              failAttemptLocal(toError(error), 'protocol');
               return;
             }
             for (const frame of frames) {
@@ -623,14 +686,15 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
           handleTunnelFrame(currentChannel, plaintext);
         })
         .catch((error: unknown) => {
-          failAttemptLocal(toError(error));
+          failAttemptLocal(toError(error), 'protocol');
         });
     };
 
     wire.onclose = (event) => {
-      const terminal = TERMINAL_RELAY_CLOSE_CODES.has(event.code);
+      const terminal = isTerminalCloseCode(event.code);
       failAttemptLocal(
         new Error(RELAY_CLOSE_MESSAGES[event.code] ?? `relay socket closed (code ${event.code})`),
+        terminal ? 'terminal' : 'network',
         terminal,
         terminal,
       );
@@ -642,14 +706,20 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
 
     helloDeadline = setTimeout(() => {
       helloDeadline = null;
-      failAttemptLocal(new Error('relay handshake timeout'), true);
+      failAttemptLocal(new Error('relay handshake timeout'), 'network', true);
     }, helloTimeoutMs);
 
-    function failAttempt(gen: number, error: Error, asErrorState = false): void {
+    function failAttempt(gen: number, error: Error, failureClassification: RelayTunnelFailureClassification, asErrorState = false): void {
       if (gen !== attemptGeneration || closed) return;
+      if (isTerminalFailureClassification(failureClassification)) {
+        rejectWaiters(error);
+        consecutiveFailures += 1;
+        setStatus({ state: 'error', lastError: error.message, failureClassification });
+        return;
+      }
       rejectWaiters(error);
       consecutiveFailures += 1;
-      setStatus({ state: asErrorState ? 'error' : 'reconnecting', lastError: error.message });
+      setStatus({ state: asErrorState ? 'error' : 'reconnecting', lastError: error.message, failureClassification });
       scheduleReconnect();
     }
   };
@@ -681,11 +751,10 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
     });
   };
 
-  const tunnelFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+  const tunnelFetchOnChannel = async (channel: ActiveChannel, input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const request = await normalizeTunnelRequest(input, init);
     const signal = request.signal;
     if (signal?.aborted) throw abortError();
-    const channel = await waitForChannel(signal);
     const streamId = channel.nextStreamId();
 
     return await new Promise<Response>((resolve, reject) => {
@@ -828,6 +897,12 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         }
       })();
     });
+  };
+
+  const tunnelFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const signal = input instanceof Request ? input.signal : init?.signal;
+    const channel = await waitForChannel(signal ?? undefined);
+    return tunnelFetchOnChannel(channel, input, init);
   };
 
   const splitPathQuery = (pathWithQuery: string): { path: string; query: string } => {

--- a/packages/ui/src/lib/relay/tunnel-client.ts
+++ b/packages/ui/src/lib/relay/tunnel-client.ts
@@ -878,14 +878,18 @@ export const createRelayTunnelClient = (options: RelayTunnelClientOptions): Rela
         headers: request.headers,
       };
       channel.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, streamId, encodeJsonPayload(head)));
+      if (request.method === 'GET' || request.method === 'HEAD') return;
+      if (request.body === null) {
+        channel.send(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, EMPTY_PAYLOAD));
+        return;
+      }
+      const body = request.body;
       void (async () => {
         try {
-          if (request.body) {
-            for await (const chunk of request.body) {
-              if (finished || channel.dead) return;
-              for (const piece of chunkPayload(chunk)) {
-                channel.send(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, piece));
-              }
+          for await (const chunk of body) {
+            if (finished || channel.dead) return;
+            for (const piece of chunkPayload(chunk)) {
+              channel.send(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, piece));
             }
           }
           if (!finished && !channel.dead) {

--- a/packages/ui/src/lib/runtime-switch.test.ts
+++ b/packages/ui/src/lib/runtime-switch.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { getRuntimeApiBaseUrl, switchRuntimeEndpoint } from './runtime-switch';
+import { getActiveRelayTunnel, getRuntimeApiBaseUrl, switchRuntimeEndpoint } from './runtime-switch';
 import { clearRuntimeUrlAuthToken, setRuntimeExtraHeaders } from './runtime-auth';
+import { setRuntimeTunnelClientFactoriesForTests } from './relay/runtime-tunnel';
+import type { RelayTunnelClient } from './relay/tunnel-client';
 
 describe('runtime endpoint switching', () => {
   test('does not throw when Electron preload globals are read-only', () => {
@@ -62,4 +64,59 @@ describe('runtime endpoint switching', () => {
       }
     }
   });
+
+test('passes direct token separately and URL-token refresh waits behind tunnel readiness', async () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    let receivedToken: string | null | undefined;
+    let release!: () => void;
+    const ready = new Promise<void>((resolve) => { release = resolve; });
+    let completedFetches = 0;
+    const client: RelayTunnelClient = {
+      fetch: async () => { await ready; completedFetches += 1; return new Response(JSON.stringify({ token: 'url', expiresAt: Date.now() + 60_000 }), { status: 200 }); },
+      openWebSocket: () => { throw new Error('unused'); },
+      getStatus: () => ({ state: completedFetches ? 'connected' : 'connecting' }),
+      subscribeStatus: () => () => {},
+      close: () => {},
+    };
+    try {
+      Object.defineProperty(globalThis, 'window', { configurable: true, value: { dispatchEvent: () => true } });
+      setRuntimeTunnelClientFactoriesForTests({ createDirect: (_descriptor, token) => { receivedToken = token; return client; } });
+      switchRuntimeEndpoint({
+        apiBaseUrl: 'https://virtual.example', clientToken: 'direct-secret',
+        tunnel: { type: 'direct-e2ee', wssUrl: 'wss://direct.example.test/api/openchamber/direct-e2ee/ws', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } },
+      });
+      await Promise.resolve();
+      expect(receivedToken).toBe('direct-secret');
+      expect(completedFetches).toBe(0);
+      release();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(completedFetches).toBe(1);
+    } finally {
+      setRuntimeTunnelClientFactoriesForTests(null);
+      if (previousWindow) Object.defineProperty(globalThis, 'window', previousWindow);
+      else Reflect.deleteProperty(globalThis, 'window');
+    }
+  });
+});
+
+test('does not publish or construct a tokenless direct-E2EE tunnel', () => {
+  let factoryCalls = 0;
+  const client: RelayTunnelClient = {
+    fetch: async () => new Response(null, { status: 200 }),
+    openWebSocket: () => { throw new Error('unused'); },
+    getStatus: () => ({ state: 'connected' }),
+    subscribeStatus: () => () => {},
+    close: () => {},
+  };
+  setRuntimeTunnelClientFactoriesForTests({
+    createDirect: () => { factoryCalls += 1; return client; },
+  });
+  switchRuntimeEndpoint({
+    apiBaseUrl: 'https://virtual.example',
+    clientToken: null,
+    tunnel: { type: 'direct-e2ee', wssUrl: 'wss://direct.example.test/api/openchamber/direct-e2ee/ws', hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } },
+  });
+  expect(factoryCalls).toBe(0);
+  expect(getActiveRelayTunnel()).toBeNull();
+  setRuntimeTunnelClientFactoriesForTests(null);
 });

--- a/packages/ui/src/lib/runtime-switch.ts
+++ b/packages/ui/src/lib/runtime-switch.ts
@@ -1,10 +1,10 @@
 import { refreshRuntimeUrlAuthToken, setRuntimeBearerToken, setRuntimeExtraHeaders } from '@/lib/runtime-auth';
 import { configureRuntimeUrlResolver } from '@/lib/runtime-url';
 import {
-  activateRelayTunnel,
+  activateRuntimeTunnel,
   deactivateRelayTunnel,
   getActiveRelayTunnel,
-  type RelayRuntimeDescriptor,
+  type RuntimeTunnelDescriptor,
 } from '@/lib/relay/runtime-tunnel';
 
 export { getActiveRelayTunnel };
@@ -93,7 +93,11 @@ export const initializeRuntimeEndpoint = (options: { apiBaseUrl?: string | null;
   activeRuntimeKey = options.runtimeKey?.trim() || (sameOrigin(apiBaseUrl, readInjectedLocalOrigin()) ? 'local' : normalizeRuntimeUrlKey(apiBaseUrl));
 };
 
-export const switchRuntimeEndpoint = (options: { apiBaseUrl: string; clientToken?: string | null; runtimeKey?: string | null; requestHeaders?: Record<string, string> | null; relay?: RelayRuntimeDescriptor | null }): void => {
+export const switchRuntimeEndpoint = (options: { apiBaseUrl: string; clientToken?: string | null; runtimeKey?: string | null; requestHeaders?: Record<string, string> | null; relay?: RuntimeTunnelDescriptor | null; tunnel?: RuntimeTunnelDescriptor | null }): void => {
+  if (options.tunnel?.type === 'direct-e2ee' && !options.clientToken) {
+    deactivateRelayTunnel();
+    return;
+  }
   const apiBaseUrl = options.apiBaseUrl.trim();
   const previousApiBaseUrl = getRuntimeApiBaseUrl();
   const previousRuntimeKey = getRuntimeKey();
@@ -116,8 +120,9 @@ export const switchRuntimeEndpoint = (options: { apiBaseUrl: string; clientToken
   // Relay mode routes runtime HTTP/WS through an E2EE tunnel instead of the
   // network. Activate the tunnel BEFORE minting the url token, since the mint
   // itself rides the tunnel (runtimeFetch -> tunnel.fetch).
-  if (options.relay) {
-    activateRelayTunnel(options.relay);
+  const tunnel = options.tunnel ?? options.relay;
+  if (tunnel) {
+    activateRuntimeTunnel(tunnel, options.clientToken);
   } else {
     deactivateRelayTunnel();
   }

--- a/packages/ui/src/lib/sse-data-parser.test.ts
+++ b/packages/ui/src/lib/sse-data-parser.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test';
+import { createSseDataParser } from './sse-data-parser';
+
+describe('createSseDataParser', () => {
+  test('parses arbitrary chunk boundaries and multiple line ending styles', () => {
+    const frames: string[] = [];
+    const parser = createSseDataParser((data) => frames.push(data));
+
+    for (const chunk of ['da', 'ta: one\r', '\n\r', '\ndata: two\r\r', 'data: three\n\n']) {
+      parser.push(chunk);
+    }
+
+    expect(frames).toEqual(['one', 'two', 'three']);
+  });
+
+  test('joins multiline data and removes at most one optional space', () => {
+    const frames: string[] = [];
+    const parser = createSseDataParser((data) => frames.push(data));
+
+    parser.push('data:first\ndata: second\ndata:  third\n\n');
+
+    expect(frames).toEqual(['first\nsecond\n third']);
+  });
+
+  test('dispatches empty data and ignores non-data fields and comments', () => {
+    const frames: string[] = [];
+    const parser = createSseDataParser((data) => frames.push(data));
+
+    parser.push(': comment\nevent: named\nid: 1\nretry: 1000\ndata:\n\n');
+
+    expect(frames).toEqual(['']);
+  });
+
+  test('does not dispatch an incomplete event on EOF', () => {
+    const frames: string[] = [];
+    const parser = createSseDataParser((data) => frames.push(data));
+
+    parser.push('data: incomplete\n');
+    parser.end();
+
+    expect(frames).toEqual([]);
+  });
+
+  test('throws when a persistent unterminated line exceeds its code-unit limit', () => {
+    const parser = createSseDataParser(() => {}, {
+      maxUnterminatedLineCodeUnits: 4,
+      maxPendingEventDataCodeUnits: 20,
+    });
+
+    parser.push('data');
+    expect(() => parser.push(':')).toThrow('unterminated line');
+  });
+
+  test('throws when multiline pending event data exceeds its aggregate limit', () => {
+    const parser = createSseDataParser(() => {}, {
+      maxUnterminatedLineCodeUnits: 20,
+      maxPendingEventDataCodeUnits: 5,
+    });
+
+    parser.push('data: ab\n');
+    expect(() => parser.push('data: cde\n')).toThrow('pending event data');
+  });
+
+  test('accepts exact line and pending-event code-unit boundaries', () => {
+    const frames: string[] = [];
+    const parser = createSseDataParser((data) => frames.push(data), {
+      maxUnterminatedLineCodeUnits: 8,
+      maxPendingEventDataCodeUnits: 5,
+    });
+
+    parser.push('data: ab');
+    parser.push('\ndata: cd\n\n');
+
+    expect(frames).toEqual(['ab\ncd']);
+  });
+
+  test('continues parsing normal chunks with small limits', () => {
+    const frames: string[] = [];
+    const parser = createSseDataParser((data) => frames.push(data), {
+      maxUnterminatedLineCodeUnits: 16,
+      maxPendingEventDataCodeUnits: 8,
+    });
+
+    parser.push('data: one\n\ndata: ');
+    parser.push('two\n\n');
+
+    expect(frames).toEqual(['one', 'two']);
+  });
+
+  for (const invalidLimit of [Number.NaN, Number.POSITIVE_INFINITY, 1.5, -1]) {
+    test(`rejects invalid unterminated-line limit ${String(invalidLimit)}`, () => {
+      expect(() => createSseDataParser(() => {}, {
+        maxUnterminatedLineCodeUnits: invalidLimit,
+        maxPendingEventDataCodeUnits: 1,
+      })).toThrow('finite non-negative integers');
+    });
+
+    test(`rejects invalid pending-event limit ${String(invalidLimit)}`, () => {
+      expect(() => createSseDataParser(() => {}, {
+        maxUnterminatedLineCodeUnits: 1,
+        maxPendingEventDataCodeUnits: invalidLimit,
+      })).toThrow('finite non-negative integers');
+    });
+  }
+});

--- a/packages/ui/src/lib/sse-data-parser.ts
+++ b/packages/ui/src/lib/sse-data-parser.ts
@@ -1,0 +1,84 @@
+interface SseDataParser {
+  push(chunk: string): void;
+  end(): void;
+}
+
+interface SseDataParserLimits {
+  /** Maximum JavaScript UTF-16 code units retained for an unterminated SSE line. */
+  maxUnterminatedLineCodeUnits: number;
+  /** Maximum JavaScript UTF-16 code units retained across data lines for one pending SSE event, including joining newlines. */
+  maxPendingEventDataCodeUnits: number;
+}
+
+const DEFAULT_SSE_DATA_PARSER_LIMITS: Readonly<SseDataParserLimits> = {
+  maxUnterminatedLineCodeUnits: 64 * 1024,
+  maxPendingEventDataCodeUnits: 1024 * 1024,
+};
+
+export const createSseDataParser = (
+  onData: (data: string) => void,
+  limits: SseDataParserLimits = DEFAULT_SSE_DATA_PARSER_LIMITS,
+): SseDataParser => {
+  const configuredLimits = [limits.maxUnterminatedLineCodeUnits, limits.maxPendingEventDataCodeUnits];
+  if (configuredLimits.some((limit) => !Number.isFinite(limit) || !Number.isInteger(limit) || limit < 0)) {
+    throw new Error('SSE parser limits must be finite non-negative integers');
+  }
+  let buffer = '';
+  let dataLines: string[] = [];
+  let pendingEventDataCodeUnits = 0;
+
+  const processLine = (line: string): void => {
+    if (line.length === 0) {
+      if (dataLines.length > 0) {
+        onData(dataLines.join('\n'));
+        dataLines = [];
+        pendingEventDataCodeUnits = 0;
+      }
+      return;
+    }
+
+    if (line.startsWith(':')) return;
+    const colonIndex = line.indexOf(':');
+    const field = colonIndex === -1 ? line : line.slice(0, colonIndex);
+    if (field !== 'data') return;
+
+    let value = colonIndex === -1 ? '' : line.slice(colonIndex + 1);
+    if (value.startsWith(' ')) value = value.slice(1);
+    const nextCodeUnits = pendingEventDataCodeUnits + value.length + (dataLines.length > 0 ? 1 : 0);
+    if (nextCodeUnits > limits.maxPendingEventDataCodeUnits) {
+      throw new Error('SSE pending event data exceeded the configured code-unit limit');
+    }
+    dataLines.push(value);
+    pendingEventDataCodeUnits = nextCodeUnits;
+  };
+
+  const drain = (): void => {
+    let lineStart = 0;
+    for (let index = 0; index < buffer.length; index += 1) {
+      const character = buffer[index];
+      if (character !== '\n' && character !== '\r') continue;
+      if (character === '\r' && index === buffer.length - 1) break;
+
+      processLine(buffer.slice(lineStart, index));
+      if (character === '\r' && buffer[index + 1] === '\n') index += 1;
+      lineStart = index + 1;
+    }
+    buffer = buffer.slice(lineStart);
+  };
+
+  return {
+    push(chunk) {
+      if (chunk.length === 0) return;
+      buffer += chunk;
+      drain();
+      if (buffer.length > limits.maxUnterminatedLineCodeUnits) {
+        throw new Error('SSE unterminated line exceeded the configured code-unit limit');
+      }
+    },
+    end() {
+      buffer = '';
+      dataLines = [];
+      pendingEventDataCodeUnits = 0;
+    },
+  };
+};

--- a/packages/web/server/lib/direct-e2ee/DOCUMENTATION.md
+++ b/packages/web/server/lib/direct-e2ee/DOCUMENTATION.md
@@ -47,6 +47,13 @@ promotion. All fragment state is discarded with its stream or outer session.
 Before promotion only encrypted `GET /health`, pairing redemption, and
 bearer-authenticated `GET /auth/session` are dispatched. Pairing alone never
 promotes. A successful session response binds the authenticated client ID.
+After promotion, `/auth` traffic has an exact no-query allowlist: `GET /auth/session`,
+`POST /auth/url-token`, and `GET /auth/passkey/status`. The status response exposes
+only passkey enablement, relying-party metadata, and credential count; browser
+passkey ceremonies remain unavailable. The exact `/auth` path and every other
+`/auth/*` target, method, query, subpath, unknown route, or case variant fail closed
+by terminating the outer session before loopback dispatch. Non-authenticated-route
+policy is unchanged.
 Unlike hosted relay sessions, direct sessions treat every ignored textual frame
 before establishment (malformed JSON, unsupported version, non-hello type, or empty
 text) as terminal. An identical valid hello retry still receives the same ready

--- a/packages/web/server/lib/direct-e2ee/DOCUMENTATION.md
+++ b/packages/web/server/lib/direct-e2ee/DOCUMENTATION.md
@@ -1,0 +1,91 @@
+# Direct E2EE service
+
+`service.js` owns the direct-E2EE outer WebSocket endpoint.
+It is a `WebSocketServer({ noServer: true, perMessageDeflate: false })` with explicit attach/detach lifecycle.
+`runtime.js` owns production dependency injection, exact active-profile resolution, canonical candidate construction,
+and listener cleanup.
+`server/index.js` initializes that runtime and does not implement endpoint policy itself.
+Runtime refreshes are generation-fenced and publish unavailable state while authoritative profile reads are pending or failed.
+Legacy controllers without a retained profile ID may resolve only one enabled saved profile matching the canonical live hostname;
+an explicit unknown ID or ambiguous hostname never falls back.
+
+The service validates the exact path, active enabled managed-remote profile,
+and canonical public authority before allocating a WebSocket. It reuses the
+relay identity, encrypted session, crypto, codec, and tunnel host unchanged on
+the wire. A random process-local marker is injected only after tunnel-host has
+removed client forwarding, Cloudflare, Origin, and `x-openchamber-*` headers.
+`tunnel-auth.js` recognizes only the exact marker as `remote-client`; the marker
+is routing context, never a credential.
+
+The outer upgrade owns only the exact raw origin-form target
+`/api/openchamber/direct-e2ee/ws`. Query, fragment, trailing-slash, absolute-form,
+dot-segment, and encoded aliases are rejected without normalization; unrelated
+upgrade paths remain available to coexisting listeners.
+
+Browser and WebView clients necessarily send `Origin`. The outer endpoint accepts
+one syntactically valid Origin value as untrusted metadata and never uses it for
+authority, authentication, profile selection, or admission identity. It is stripped
+before loopback dispatch. Conventional CSWSH ambient-auth reasoning does not apply:
+the outer socket accepts no cookie or query credential, and authorization occurs
+only through a bearer token inside ciphertext authenticated to the pinned host key.
+Admission and handshake deadlines bound unsolicited browser handshakes.
+
+Admission defaults are 16 pending handshakes, 16 ordinary pre-authenticated
+sessions, 4 reconnect-reserve pre-authenticated sessions, and 64 authenticated
+sessions. Handshake timeout is 15 seconds; ordinary authentication has 20
+seconds. Reserve sessions have 2 seconds and permit health plus bearer session
+confirmation, but not pairing redemption. This keeps short-lived reconnect
+capacity available under ordinary pre-auth saturation without letting Ping or
+health extend either deadline. Per session: 24 streams, 4 nested WebSockets, 8
+fragment assemblies, and 40 opens per 10 seconds.
+
+Incomplete fragments are admitted only for an already-open nested WebSocket and
+share a 256 KiB pre-authenticated byte budget, in addition to the existing count
+and per-message limits. The live budget switches to 16 MiB only after bearer
+promotion. All fragment state is discarded with its stream or outer session.
+
+Before promotion only encrypted `GET /health`, pairing redemption, and
+bearer-authenticated `GET /auth/session` are dispatched. Pairing alone never
+promotes. A successful session response binds the authenticated client ID.
+Unlike hosted relay sessions, direct sessions treat every ignored textual frame
+before establishment (malformed JSON, unsupported version, non-hello type, or empty
+text) as terminal. An identical valid hello retry still receives the same ready
+response; established rekey mismatch behavior is unchanged.
+Runtime clients therefore gate each newly handshaken channel, including every
+automatic reconnect: they require the strict health identity
+`{ status: "ok", openchamberVersion: string }`, then HTTP 200 with
+`{ authenticated: true }` from bearer-authenticated `GET /auth/session`, before
+publishing connected state or permitting ordinary HTTP/SSE/WebSocket traffic.
+Bearer tokens are activation-only transport state and are never stored in the
+direct candidate descriptor or URL. A rejected/revoked token is terminal;
+readiness 408/429/5xx and transport failures retry with backoff, while malformed
+identity/session responses fail closed as protocol errors.
+Pre-auth policy violations and malformed, unsolicited, replayed, oversized, or
+otherwise undecodable tunnel traffic fail closed by terminating the outer session.
+Request targets are canonicalized before policy and loopback dispatch; ambiguous
+slashes, traversal, encoded separators, controls, and path/query confusion are
+rejected. Authentication bookkeeping uses a unique request generation so numeric
+stream-ID reuse cannot promote a stale result.
+
+Outer upgrades carrying a browser `Origin` are accepted as untrusted metadata and
+stripped before loopback dispatch. Pending, ordinary pre-authenticated, and reserved
+handshakes are bounded per source. A syntactically valid `CF-Connecting-IP` is
+accepted only when the TCP peer is loopback (the local cloudflared connector);
+otherwise the validated socket peer address is authoritative.
+Oldest same-source probation is evicted at a source cap, the oldest pending entry
+is evicted at the global pending cap, and a full reserve turns over its oldest
+entry for the newest short-lived probation. Source values are never logged.
+Reconnect reserve entries must complete the exact encrypted `GET /health`
+generation with status 200 before bearer session confirmation and remain subject
+to their two-second deadline.
+Profile disable/stop/switch and client revocation hooks close outer sessions;
+the tunnel host then aborts all inner HTTP/SSE/WebSocket work. Logs contain only
+fixed reason categories and opaque connection IDs.
+
+The endpoint is supported only while the production runtime is initialized.
+It is available only for the exact active `managed-remote` profile when that saved profile has
+`directE2eeEnabled === true` and its canonical HTTPS hostname matches the live tunnel URL.
+Pairing emits the canonical `wss://<hostname>/api/openchamber/direct-e2ee/ws` candidate only on explicit request.
+The authoritative runtime publishes the same-origin suppression authority separately from identity construction,
+so an unavailable identity cannot expose the plaintext managed-tunnel candidate for an active E2EE profile.
+Stopping, switching, or disabling closes affected direct outer sessions without revoking paired-device tokens.

--- a/packages/web/server/lib/direct-e2ee/integration.test.js
+++ b/packages/web/server/lib/direct-e2ee/integration.test.js
@@ -3,6 +3,7 @@ import http from 'node:http';
 import { WebSocket, WebSocketServer } from 'ws';
 
 import { createClientHandshake } from '../../../../ui/src/lib/relay/handshake.ts';
+import { createDirectE2eeTunnelClient } from '../../../../ui/src/lib/relay/direct-e2ee-tunnel-client.ts';
 import { createTunnelAuth, createInternalTransportMarker, DIRECT_E2EE_TRANSPORT_HEADER } from '../opencode/tunnel-auth.js';
 import { createUiAuth } from '../ui-auth/ui-auth.js';
 import { exportPublicKeyJwk, generateEcdhKeyPair } from '../relay/e2ee.js';
@@ -115,6 +116,21 @@ const startFixture = async ({ authDeadlineMs = 500, limits = {}, logs = [], reje
   return { service, outer, keys, received, marker, lifecycle, mintUrlToken, logs };
 };
 
+const wrapActualClientSocket = (url, port) => {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test' }, perMessageDeflate: false });
+  const wire = {
+    get readyState() { return ws.readyState; },
+    send(data) { ws.send(data); },
+    close(code, reason) { ws.close(code, reason); },
+    onopen: null, onmessage: null, onclose: null, onerror: null,
+  };
+  ws.on('open', () => wire.onopen?.());
+  ws.on('message', (data, binary) => wire.onmessage?.({ data: binary ? new Uint8Array(data) : data.toString() }));
+  ws.on('close', (code, reason) => wire.onclose?.({ code, reason: reason.toString() }));
+  ws.on('error', () => wire.onerror?.());
+  return wire;
+};
+
 const connectEncrypted = async (fx) => {
   const client = await createClientHandshake(await exportPublicKeyJwk(fx.keys.publicKey), { batch: false });
   const ws = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test' }, perMessageDeflate: false });
@@ -146,6 +162,49 @@ const connectEncrypted = async (fx) => {
 };
 
 describe('direct E2EE encrypted integration', () => {
+  it('shared direct client promotes every replacement channel before queued API traffic', async () => {
+    const authState = { valid: true };
+    const fx = await startFixture({ authState, authDeadlineMs: 1_000 });
+    const descriptor = {
+      wssUrl: 'wss://direct.example.test/api/openchamber/direct-e2ee/ws',
+      hostEncPubJwk: await exportPublicKeyJwk(fx.keys.publicKey),
+    };
+    const outerUrls = [];
+    const client = createDirectE2eeTunnelClient(descriptor, 'valid-client', {
+      createOuterWebSocket: (url) => { outerUrls.push(url); return wrapActualClientSocket(url, fx.outer.address().port); },
+      reconnectBaseDelayMs: 10,
+      reconnectMaxDelayMs: 20,
+      helloRetryMs: 10,
+      helloTimeoutMs: 1_000,
+      pingIntervalMs: 5_000,
+    });
+    cleanups.push(() => client.close());
+
+    const api = () => client.fetch('/api/test', { headers: { Authorization: 'Bearer valid-client' } });
+    expect((await api()).status).toBe(200);
+    expect(JSON.stringify({ descriptor, outerUrls, status: client.getStatus() })).not.toContain('valid-client');
+    const healthCount = () => fx.received.filter((request) => request.url === '/health').length;
+    const authCount = () => fx.received.filter((request) => request.url === '/auth/session').length;
+    const apiCount = () => fx.received.filter((request) => request.url === '/api/test').length;
+    expect([healthCount(), authCount(), apiCount()]).toEqual([1, 1, 1]);
+
+    fx.service.closeAll('test-disconnect');
+    await waitFor(() => client.getStatus().state === 'reconnecting');
+    const queued = api();
+    expect((await queued).status).toBe(200);
+    expect([healthCount(), authCount(), apiCount()]).toEqual([2, 2, 2]);
+
+    authState.valid = false;
+    fx.service.closeAll('test-disconnect');
+    await waitFor(() => client.getStatus().state === 'reconnecting');
+    const blocked = expect(api()).rejects.toThrow('direct E2EE bearer token rejected');
+    await waitFor(() => client.getStatus().state === 'error');
+    expect(client.getStatus()).toMatchObject({ state: 'error', failureClassification: 'terminal' });
+    expect(healthCount()).toBe(3);
+    expect(authCount()).toBe(3);
+    expect(apiCount()).toBe(2);
+    await blocked;
+  });
   it('closes the outer session for a disallowed HTTP path', async () => {
     const fx = await startFixture();
     const client = await connectEncrypted(fx);

--- a/packages/web/server/lib/direct-e2ee/integration.test.js
+++ b/packages/web/server/lib/direct-e2ee/integration.test.js
@@ -365,9 +365,12 @@ describe('direct E2EE encrypted integration', () => {
 
     expect((await open(3, '')).frameType).toBe(TunnelFrameType.StreamAbort);
     const originalNow = Date.now;
-    Date.now = () => originalNow() + 61_000;
-    expect((await open(5, `oc_url_token=${encodeURIComponent(token)}`)).frameType).toBe(TunnelFrameType.StreamAbort);
-    Date.now = originalNow;
+    try {
+      Date.now = () => originalNow() + 61_000;
+      expect((await open(5, `oc_url_token=${encodeURIComponent(token)}`)).frameType).toBe(TunnelFrameType.StreamAbort);
+    } finally {
+      Date.now = originalNow;
+    }
 
     const fresh = await fx.mintUrlToken();
     expect((await open(7, `oc_url_token=${encodeURIComponent(fresh)}`)).frameType).toBe(TunnelFrameType.WsOpened);

--- a/packages/web/server/lib/direct-e2ee/integration.test.js
+++ b/packages/web/server/lib/direct-e2ee/integration.test.js
@@ -1,0 +1,489 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import http from 'node:http';
+import { WebSocket, WebSocketServer } from 'ws';
+
+import { createClientHandshake } from '../../../../ui/src/lib/relay/handshake.ts';
+import { createTunnelAuth, createInternalTransportMarker, DIRECT_E2EE_TRANSPORT_HEADER } from '../opencode/tunnel-auth.js';
+import { createUiAuth } from '../ui-auth/ui-auth.js';
+import { exportPublicKeyJwk, generateEcdhKeyPair } from '../relay/e2ee.js';
+import { TunnelFrameType, decodeJsonPayload, decodeTunnelFrame, encodeJsonPayload, encodeTunnelFrame } from '../relay/tunnel-codec.js';
+import { createDirectE2eeService, DIRECT_E2EE_PATH } from './service.js';
+
+const cleanups = [];
+afterEach(async () => Promise.all(cleanups.splice(0).map((fn) => fn())));
+const listen = (server) => new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const waitFor = async (predicate) => {
+  for (let i = 0; i < 200; i += 1) { if (predicate()) return; await new Promise((resolve) => setTimeout(resolve, 5)); }
+  throw new Error('condition not reached');
+};
+
+const startFixture = async ({ authDeadlineMs = 500, limits = {}, logs = [], rejectPairing = false, authResponseDelayMs = 0, pairingResponseDelayMs = 0, authState = { valid: true } } = {}) => {
+  const marker = createInternalTransportMarker();
+  const tunnelAuth = createTunnelAuth({ internalRemoteClientMarker: marker });
+  const keys = await generateEcdhKeyPair();
+  const received = [];
+  const lifecycle = {
+    aborted: 0,
+    authResponses: 0,
+    closedResponses: 0,
+    pairingResponses: 0,
+    sseClosed: 0,
+    wsClosed: 0,
+    innerClosed: [],
+  };
+  const authenticateBearerToken = async (token) => authState.valid && token === 'valid-client' ? { ok: true, clientId: 'client-1' } : null;
+  const uiAuth = createUiAuth({ requireClientAuth: true, clientAuthController: { authenticateBearerToken } });
+  const origin = http.createServer((req, res) => {
+    const scope = tunnelAuth.classifyRequestScope(req);
+    received.push({ method: req.method, url: req.url, headers: req.headers, scope });
+    req.on('aborted', () => { lifecycle.aborted += 1; });
+    res.on('close', () => { if (!res.writableEnded) lifecycle.closedResponses += 1; });
+    if (req.url === '/health') return res.end(JSON.stringify({ status: 'ok', openchamberVersion: 'test' }));
+    if (req.url === '/auth/session' && authState.valid && req.headers.authorization === 'Bearer valid-client') {
+      return void setTimeout(() => {
+        lifecycle.authResponses += 1;
+        res.end(JSON.stringify({ authenticated: true, scope: 'client' }));
+      }, authResponseDelayMs);
+    }
+    if (req.url === '/auth/session') { res.statusCode = 401; return res.end(JSON.stringify({ authenticated: false })); }
+    if (req.url === '/auth/url-token') return res.end(JSON.stringify({ token: 'url-token' }));
+    if (req.url === '/auth/passkey/status') return res.end(JSON.stringify({ enabled: true, rpId: 'direct.example.test', passkeyCount: 1 }));
+    if (req.url === '/api/client-auth/pairing/redeem') {
+      if (rejectPairing) res.statusCode = 400;
+      return void setTimeout(() => {
+        lifecycle.pairingResponses += 1;
+        res.end(JSON.stringify(rejectPairing ? { error: 'rejected' } : { token: 'valid-client' }));
+      }, pairingResponseDelayMs);
+    }
+    if (req.url?.startsWith('/api/config/settings')) {
+      return void uiAuth.requireAuth(req, {
+        status(code) { res.statusCode = code; return this; },
+        json(value) { res.end(JSON.stringify(value)); return this; },
+        setHeader: (...args) => res.setHeader(...args),
+      }, () => { res.statusCode = 204; res.end(); });
+    }
+    if (req.url === '/api/test' && authState.valid && req.headers.authorization === 'Bearer valid-client') return res.end(JSON.stringify({ ok: true }));
+    if (req.url === '/api/stream') { res.write('one\n'); setTimeout(() => res.end('two\n'), 10); return; }
+    if (req.url === '/api/slow') { res.write('first\n'); return; }
+    if (req.url === '/api/sse') {
+      res.on('close', () => { lifecycle.sseClosed += 1; });
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.write('data: one\n\n');
+      setTimeout(() => res.write('data: two\n\n'), 10);
+      return;
+    }
+    res.statusCode = 401; res.end('{}');
+  });
+  const nestedWss = new WebSocketServer({ noServer: true });
+  origin.on('upgrade', async (req, socket, head) => {
+    const context = await uiAuth.resolveAuthContext(req, null);
+    if (!context) { socket.end('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n'); return; }
+    nestedWss.handleUpgrade(req, socket, head, (ws) => nestedWss.emit('connection', ws));
+  });
+  nestedWss.on('connection', (ws) => {
+    ws.on('message', (data, binary) => ws.send(data, { binary }));
+    ws.on('close', () => { lifecycle.wsClosed += 1; });
+  });
+  await listen(origin);
+  const outer = http.createServer();
+  const service = createDirectE2eeService({
+    getActiveProfile: () => ({ id: 'p1', mode: 'managed-remote', hostname: 'direct.example.test', directE2eeEnabled: true }),
+    getRelayIdentity: async () => ({ hostEncPrivateKey: keys.privateKey }),
+    getLocalPort: () => origin.address().port,
+    internalTransportMarker: marker,
+    authenticateBearerToken,
+    limits: { authenticationDeadlineMs: authDeadlineMs, ...limits },
+    logger: { warn: (...args) => logs.push(args) },
+    onInnerStreamClosed: (event) => lifecycle.innerClosed.push(event),
+  });
+  service.attach(outer);
+  await listen(outer);
+  cleanups.push(() => new Promise((resolve) => {
+    service.detach();
+    for (const socket of nestedWss.clients) socket.terminate();
+    nestedWss.close();
+    outer.closeAllConnections?.();
+    origin.closeAllConnections?.();
+    outer.close(() => origin.close(resolve));
+  }));
+  const mintUrlToken = async () => {
+    let body;
+    const response = { setHeader() {}, status() { return this; }, json(value) { body = value; return this; }, type() { return this; }, send() { return this; } };
+    await uiAuth.handleUrlAuthToken({ method: 'POST', path: '/auth/url-token', headers: { authorization: 'Bearer valid-client', accept: 'application/json' } }, response);
+    return body.token;
+  };
+  return { service, outer, keys, received, marker, lifecycle, mintUrlToken, logs };
+};
+
+const connectEncrypted = async (fx) => {
+  const client = await createClientHandshake(await exportPublicKeyJwk(fx.keys.publicKey), { batch: false });
+  const ws = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test' }, perMessageDeflate: false });
+  let channel;
+  const frames = [];
+  ws.on('message', async (data, binary) => {
+    if (!binary) {
+      const action = await client.handleText(data.toString());
+      if (action.type === 'established') channel = action.channel;
+      return;
+    }
+    frames.push(decodeTunnelFrame(await channel.decryptor.decrypt(new Uint8Array(data))));
+  });
+  await new Promise((resolve) => ws.once('open', resolve));
+  ws.send(client.helloText);
+  await waitFor(() => channel);
+  const encrypt = (frame) => channel.encryptor.encrypt(frame);
+  const sendEncrypted = (encrypted) => ws.send(encrypted, { binary: true });
+  const send = async (frame) => sendEncrypted(await encrypt(frame));
+  const request = async (id, method, path, headers = {}, query = '') => {
+    await send(encodeTunnelFrame(TunnelFrameType.HttpRequest, id, encodeJsonPayload({ method, path, query, headers })));
+    await send(encodeTunnelFrame(TunnelFrameType.StreamEnd, id, new Uint8Array()));
+    await waitFor(() => frames.some((frame) => frame.streamId === id && frame.frameType === TunnelFrameType.StreamEnd));
+    const response = frames.find((frame) => frame.streamId === id && frame.frameType === TunnelFrameType.HttpResponse);
+    return decodeJsonPayload(response.payload, (value) => value);
+  };
+  const promote = () => request(99, 'GET', '/auth/session', { authorization: 'Bearer valid-client' });
+  return { ws, frames, send, encrypt, sendEncrypted, request, promote };
+};
+
+describe('direct E2EE encrypted integration', () => {
+  it('closes the outer session for a disallowed HTTP path', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/forbidden', query: '', headers: {} })));
+    await new Promise((resolve) => client.ws.once('close', resolve));
+    expect(fx.received).toHaveLength(0);
+  });
+
+  it('closes the outer session for a disallowed WebSocket path', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    await client.send(encodeTunnelFrame(TunnelFrameType.WsOpen, 1, encodeJsonPayload({ path: '/forbidden', query: '', protocols: [] })));
+    await new Promise((resolve) => client.ws.once('close', resolve));
+    expect(fx.service.getCounts().total).toBe(0);
+  });
+
+  it('closes the outer session for an unsolicited unknown-stream fragment', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    await client.send(encodeTunnelFrame(TunnelFrameType.WsText, 77, new Uint8Array([1]), true));
+    await new Promise((resolve) => client.ws.once('close', resolve));
+    expect(fx.service.getCounts().total).toBe(0);
+  });
+
+  it('confirms health, remote-client marker classification, and bearer-only promotion', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    expect((await client.request(1, 'GET', '/health')).status).toBe(200);
+    expect(fx.received[0].scope).toBe('remote-client');
+    expect(fx.received[0].headers[DIRECT_E2EE_TRANSPORT_HEADER]).toBe(fx.marker);
+
+    expect((await client.request(2, 'POST', '/api/client-auth/pairing/redeem')).status).toBe(200);
+    expect(fx.service.getCounts().preauthenticated).toBe(1);
+    expect((await client.request(3, 'GET', '/auth/session', { authorization: 'Bearer valid-client' })).status).toBe(200);
+    expect(fx.service.getCounts().authenticated).toBe(1);
+    expect((await client.request(4, 'GET', '/api/stream', { authorization: 'Bearer valid-client' })).status).toBe(200);
+    expect(client.frames.filter((frame) => frame.streamId === 4 && frame.frameType === TunnelFrameType.HttpBody).length).toBe(2);
+    fx.service.revokeClient('client-1');
+    await new Promise((resolve) => client.ws.once('close', resolve));
+    expect(fx.service.getActiveSessionCount()).toBe(0);
+  });
+
+  it('blocks pre-auth routes and spoofed transport headers before loopback', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    const before = fx.received.length;
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'POST', path: '/auth/session', query: '', headers: {
+      cookie: 'oc_ui_session=secret', forwarded: 'for=attacker', 'x-forwarded-for': 'attacker',
+      'cf-connecting-ip': 'attacker', origin: 'https://attacker.test', [DIRECT_E2EE_TRANSPORT_HEADER]: 'attacker',
+    } })));
+    await new Promise((resolve) => client.ws.once('close', resolve));
+    expect(fx.received.length).toBe(before);
+  });
+
+  it('allows only the three exact authenticated auth requests and keeps the channel usable', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    await client.promote();
+
+    expect((await client.request(1, 'GET', '/auth/session', { authorization: 'Bearer valid-client' })).status).toBe(200);
+    expect((await client.request(3, 'POST', '/auth/url-token')).status).toBe(200);
+    expect((await client.request(5, 'GET', '/auth/passkey/status')).status).toBe(200);
+    expect((await client.request(7, 'GET', '/api/test', { authorization: 'Bearer valid-client' })).status).toBe(200);
+    expect(fx.received.map((request) => request.url)).toEqual(expect.arrayContaining([
+      '/auth/session',
+      '/auth/url-token',
+      '/auth/passkey/status',
+    ]));
+    client.ws.terminate();
+  });
+
+  it('fails closed on preauthenticated passkey status without origin dispatch', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/auth/passkey/status', query: '', headers: {} })));
+    await new Promise((resolve) => client.ws.once('close', resolve));
+    expect(fx.received.some((request) => request.url === '/auth/passkey/status')).toBe(false);
+  });
+
+  it('fails closed on every other authenticated auth target using fresh channels', async () => {
+    const fx = await startFixture();
+    const cases = [
+      { method: 'GET', path: '/auth/session', query: 'refresh=1' },
+      { method: 'POST', path: '/auth/session', query: '' },
+      { method: 'POST', path: '/auth/url-token', query: 'scope=ws' },
+      { method: 'GET', path: '/auth/url-token', query: '' },
+      { method: 'GET', path: '/auth/passkey/status', query: 'refresh=1' },
+      { method: 'POST', path: '/auth/passkey/status', query: '' },
+      { method: 'POST', path: '/auth/passkey/register', query: '' },
+      { method: 'GET', path: '/auth/passkey/status/details', query: '' },
+      { method: 'GET', path: '/auth', query: '' },
+      { method: 'GET', path: '/auth/unknown', query: '' },
+      { method: 'GET', path: '/Auth/session', query: '' },
+    ];
+
+    for (const testCase of cases) {
+      const client = await connectEncrypted(fx);
+      await client.promote();
+      const before = fx.received.length;
+      await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ ...testCase, headers: {} })));
+      await new Promise((resolve) => client.ws.once('close', resolve));
+      expect(fx.received).toHaveLength(before);
+    }
+  });
+
+  it('logs only fixed categories for auth and pairing rejection', async () => {
+    const logs = [];
+    const fx = await startFixture({ logs, rejectPairing: true });
+    const client = await connectEncrypted(fx);
+    const authSecret = 'auth-secret\r\nforged\u2028line';
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/auth/session', query: '', headers: { authorization: `Bearer ${authSecret}`, cookie: 'oc_ui_session=cookie-secret' } })));
+    await new Promise((resolve) => client.ws.once('close', resolve));
+    const serialized = JSON.stringify(logs);
+    for (const secret of [authSecret, 'cookie-secret']) expect(serialized).not.toContain(secret);
+    expect(logs.map((entry) => entry[1].reason)).toContain('preauth-auth-rejected');
+  });
+
+  it('keeps the authentication deadline independent from encrypted Ping', async () => {
+    const fx = await startFixture({ authDeadlineMs: 40 });
+    const client = await connectEncrypted(fx);
+    const timer = setInterval(() => void client.send(encodeTunnelFrame(TunnelFrameType.Ping, 0, new Uint8Array())), 5);
+    await new Promise((resolve) => client.ws.once('close', resolve));
+    clearInterval(timer);
+    expect(fx.service.getCounts().total).toBe(0);
+  });
+
+  it('streams ordered SSE and aborts it when the outer connection closes', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    await client.promote();
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/api/sse', query: '', headers: { authorization: 'Bearer valid-client' } })));
+    await waitFor(() => client.frames.filter((frame) => frame.streamId === 1 && frame.frameType === TunnelFrameType.HttpBody).map((frame) => Buffer.from(frame.payload).toString()).join('').includes('data: two'));
+    const body = client.frames.filter((frame) => frame.streamId === 1 && frame.frameType === TunnelFrameType.HttpBody).map((frame) => Buffer.from(frame.payload).toString()).join('');
+    expect(body).toBe('data: one\n\ndata: two\n\n');
+    client.ws.terminate();
+    await waitFor(() => fx.lifecycle.innerClosed.some((event) => event.streamId === 1 && event.kind === 'http' && event.reason === 'connection closed'));
+    expect(fx.service.getCounts().total).toBe(0);
+  });
+
+  it('runs nested WebSocket text, binary, close, and real URL-token gates', async () => {
+    const fx = await startFixture();
+    const client = await connectEncrypted(fx);
+    await client.promote();
+    const token = await fx.mintUrlToken();
+    const open = async (streamId, query) => {
+      await client.send(encodeTunnelFrame(TunnelFrameType.WsOpen, streamId, encodeJsonPayload({ path: '/api/global/event/ws', query, protocols: [] })));
+      await waitFor(() => client.frames.some((frame) => frame.streamId === streamId && [TunnelFrameType.WsOpened, TunnelFrameType.StreamAbort].includes(frame.frameType)));
+      return client.frames.find((frame) => frame.streamId === streamId && [TunnelFrameType.WsOpened, TunnelFrameType.StreamAbort].includes(frame.frameType));
+    };
+    expect((await open(1, `oc_url_token=${encodeURIComponent(token)}`)).frameType).toBe(TunnelFrameType.WsOpened);
+    await client.send(encodeTunnelFrame(TunnelFrameType.WsText, 1, Buffer.from('hello')));
+    await client.send(encodeTunnelFrame(TunnelFrameType.WsBinary, 1, new Uint8Array([1, 2, 3])));
+    await waitFor(() => client.frames.filter((frame) => frame.streamId === 1 && [TunnelFrameType.WsText, TunnelFrameType.WsBinary].includes(frame.frameType)).length === 2);
+    expect(Buffer.from(client.frames.find((frame) => frame.streamId === 1 && frame.frameType === TunnelFrameType.WsText).payload).toString()).toBe('hello');
+    expect([...client.frames.find((frame) => frame.streamId === 1 && frame.frameType === TunnelFrameType.WsBinary).payload]).toEqual([1, 2, 3]);
+    await client.send(encodeTunnelFrame(TunnelFrameType.WsClose, 1, encodeJsonPayload({ code: 1000, reason: 'done' })));
+    await waitFor(() => fx.lifecycle.wsClosed === 1);
+
+    expect((await open(3, '')).frameType).toBe(TunnelFrameType.StreamAbort);
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 61_000;
+    expect((await open(5, `oc_url_token=${encodeURIComponent(token)}`)).frameType).toBe(TunnelFrameType.StreamAbort);
+    Date.now = originalNow;
+
+    const fresh = await fx.mintUrlToken();
+    expect((await open(7, `oc_url_token=${encodeURIComponent(fresh)}`)).frameType).toBe(TunnelFrameType.WsOpened);
+    expect((await open(9, `oc_url_token=${encodeURIComponent(fresh)}`)).frameType).toBe(TunnelFrameType.WsOpened);
+    expect((await client.request(11, 'GET', '/api/config/settings', {}, `oc_url_token=${encodeURIComponent(fresh)}`)).status).toBe(401);
+    client.ws.terminate();
+  });
+
+  it('fails closed on replayed, reordered, and old-session encrypted ciphertext', async () => {
+    const fx = await startFixture();
+    const first = await connectEncrypted(fx);
+    const ping = encodeTunnelFrame(TunnelFrameType.Ping, 0, new Uint8Array());
+    const encrypted1 = await first.encrypt(ping);
+    const encrypted2 = await first.encrypt(ping);
+    first.sendEncrypted(encrypted2);
+    first.sendEncrypted(encrypted1);
+    await new Promise((resolve) => first.ws.once('close', resolve));
+    expect(fx.service.getCounts().total).toBe(0);
+
+    const second = await connectEncrypted(fx);
+    second.sendEncrypted(encrypted1);
+    await new Promise((resolve) => second.ws.once('close', resolve));
+    expect(fx.service.getCounts().total).toBe(0);
+
+    const third = await connectEncrypted(fx);
+    const replay = await third.encrypt(ping);
+    third.sendEncrypted(replay);
+    await waitFor(() => third.frames.some((frame) => frame.frameType === TunnelFrameType.Pong));
+    third.sendEncrypted(replay);
+    await new Promise((resolve) => third.ws.once('close', resolve));
+  });
+
+  it('cleans disconnects during health, redemption, streamed output, nested WS, and never-ended bodies', async () => {
+    for (const operation of ['health', 'redeem', 'stream', 'ws', 'body']) {
+      const fx = await startFixture();
+      const client = await connectEncrypted(fx);
+      if (operation === 'stream' || operation === 'ws' || operation === 'body') await client.promote();
+      if (operation === 'health') await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/health', query: '', headers: {} })));
+      if (operation === 'redeem') await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'POST', path: '/api/client-auth/pairing/redeem', query: '', headers: {} })));
+      if (operation === 'stream') await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/api/slow', query: '', headers: { authorization: 'Bearer valid-client' } })));
+      if (operation === 'ws') {
+        const token = await fx.mintUrlToken();
+        await client.send(encodeTunnelFrame(TunnelFrameType.WsOpen, 1, encodeJsonPayload({ path: '/api/global/event/ws', query: `oc_url_token=${encodeURIComponent(token)}`, protocols: [] })));
+      }
+      if (operation === 'body') await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'POST', path: '/api/slow', query: '', headers: { authorization: 'Bearer valid-client' } })));
+      if (operation === 'redeem' || operation === 'body') {
+        await client.send(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1])));
+      }
+      await waitFor(() => fx.received.some((request) => request.url === (operation === 'health' ? '/health' : operation === 'redeem' ? '/api/client-auth/pairing/redeem' : '/api/slow')) || operation === 'ws');
+      client.ws.terminate();
+      await waitFor(() => fx.service.getCounts().total === 0);
+    }
+  });
+
+  it('enforces HTTP, nested WS, fragment, and open-rate limit + 1 with cleanup', async () => {
+    const cases = [
+      { limits: { maxStreams: 1 }, frames: [
+        [TunnelFrameType.HttpRequest, 1, { method: 'POST', path: '/api/slow', query: '', headers: { authorization: 'Bearer valid-client' } }],
+        [TunnelFrameType.HttpRequest, 3, { method: 'POST', path: '/api/slow', query: '', headers: { authorization: 'Bearer valid-client' } }],
+      ] },
+      { limits: { maxWebSockets: 1 }, ws: true },
+      { limits: { maxIncompleteFragments: 1 }, fragments: true },
+      { limits: { maxStreamOpens: 1, streamOpenWindowMs: 60_000 }, opens: true },
+    ];
+    for (const testCase of cases) {
+      const fx = await startFixture({ limits: testCase.limits });
+      const client = await connectEncrypted(fx);
+      await client.promote();
+      if (testCase.frames) for (const [type, id, payload] of testCase.frames) await client.send(encodeTunnelFrame(type, id, encodeJsonPayload(payload)));
+      if (testCase.ws) {
+        const token = await fx.mintUrlToken();
+        for (const id of [1, 3]) await client.send(encodeTunnelFrame(TunnelFrameType.WsOpen, id, encodeJsonPayload({ path: '/api/global/event/ws', query: `oc_url_token=${token}`, protocols: [] })));
+      }
+      if (testCase.fragments) {
+        await client.send(encodeTunnelFrame(TunnelFrameType.WsText, 1, new Uint8Array([1]), true));
+        await client.send(encodeTunnelFrame(TunnelFrameType.WsBinary, 3, new Uint8Array([2]), true));
+      }
+      if (testCase.opens) {
+        await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'POST', path: '/api/slow', query: '', headers: { authorization: 'Bearer valid-client' } })));
+        await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 3, encodeJsonPayload({ method: 'GET', path: '/api/slow', query: '', headers: { authorization: 'Bearer valid-client' } })));
+      }
+      await new Promise((resolve) => client.ws.once('close', resolve));
+      expect(fx.service.getCounts().total).toBe(0);
+    }
+  });
+
+  it('preserves reconnect reserve under pre-auth saturation and enforces authenticated capacity', async () => {
+    const fx = await startFixture({ authDeadlineMs: 5_000, limits: { maxPreauthenticated: 1, reconnectReserve: 1, maxAuthenticated: 1, reconnectDeadlineMs: 1_000 } });
+    const attacker = await connectEncrypted(fx);
+    expect(fx.service.getCounts()).toMatchObject({ preauthenticated: 1, reserved: 0 });
+    const reconnect = await connectEncrypted(fx);
+    expect(fx.service.getCounts()).toMatchObject({ preauthenticated: 2, reserved: 1 });
+    await reconnect.request(1, 'GET', '/health');
+    await reconnect.promote();
+    expect(fx.service.getCounts()).toMatchObject({ authenticated: 1, preauthenticated: 1, reserved: 0 });
+    const excess = await connectEncrypted(fx);
+    await excess.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/auth/session', query: '', headers: { authorization: 'Bearer valid-client' } })));
+    await excess.send(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+    await new Promise((resolve) => excess.ws.once('close', resolve));
+    expect(fx.service.getCounts().authenticated).toBe(1);
+    attacker.ws.terminate(); reconnect.ws.terminate();
+  });
+
+  it('does not promote a stale aborted auth generation after stream ID reuse', async () => {
+    const fx = await startFixture({ authResponseDelayMs: 40, authDeadlineMs: 500 });
+    const client = await connectEncrypted(fx);
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/auth/session', query: '', headers: { authorization: 'Bearer valid-client' } })));
+    await waitFor(() => fx.received.some((request) => request.url === '/auth/session'));
+    await client.send(encodeTunnelFrame(TunnelFrameType.StreamAbort, 1, new Uint8Array()));
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/health', query: '', headers: {} })));
+    await client.send(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+    await waitFor(() => fx.lifecycle.authResponses === 1);
+    expect(fx.service.getCounts()).toMatchObject({ authenticated: 0, preauthenticated: 1 });
+    client.ws.terminate();
+  });
+
+  it('cleans pairing generation bookkeeping when its stream aborts', async () => {
+    const logs = [];
+    const fx = await startFixture({ logs, rejectPairing: true, pairingResponseDelayMs: 40 });
+    const client = await connectEncrypted(fx);
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'POST', path: '/api/client-auth/pairing/redeem', query: '', headers: {} })));
+    await client.send(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1])));
+    await waitFor(() => fx.received.some((request) => request.url === '/api/client-auth/pairing/redeem'));
+    await client.send(encodeTunnelFrame(TunnelFrameType.StreamAbort, 1, new Uint8Array()));
+    await waitFor(() => fx.lifecycle.pairingResponses === 1);
+    expect(logs.map((entry) => entry[1].reason)).not.toContain('pairing-rejected');
+    client.ws.terminate();
+  });
+
+  it('switches from the preauth fragment budget to the configured authenticated budget', async () => {
+    const fx = await startFixture({ limits: { maxPreauthFragmentBytes: 3, maxAuthenticatedFragmentBytes: 8 } });
+    const client = await connectEncrypted(fx);
+    await client.promote();
+    const token = await fx.mintUrlToken();
+    await client.send(encodeTunnelFrame(TunnelFrameType.WsOpen, 1, encodeJsonPayload({ path: '/api/global/event/ws', query: `oc_url_token=${token}`, protocols: [] })));
+    await waitFor(() => client.frames.some((frame) => frame.streamId === 1 && frame.frameType === TunnelFrameType.WsOpened));
+    await client.send(encodeTunnelFrame(TunnelFrameType.WsBinary, 1, new Uint8Array(6), true));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(client.ws.readyState).toBe(WebSocket.OPEN);
+    client.ws.terminate();
+  });
+
+  it('enforces per-source preauth caps by evicting the oldest same-source probation', async () => {
+    const fx = await startFixture({ authDeadlineMs: 5_000, limits: { maxPreauthenticated: 3, maxPreauthenticatedPerSource: 1 } });
+    const oldest = await connectEncrypted(fx);
+    const closed = new Promise((resolve) => oldest.ws.once('close', resolve));
+    const newest = await connectEncrypted(fx);
+    await closed;
+    expect(fx.service.getCounts()).toMatchObject({ preauthenticated: 1, reserved: 0 });
+    newest.ws.terminate();
+  });
+
+  it('turns over full hostile reserve occupancy so prompt health and bearer can progress', async () => {
+    const fx = await startFixture({ authDeadlineMs: 5_000, limits: { maxPreauthenticated: 1, reconnectReserve: 1, maxReservedPerSource: 1, reconnectDeadlineMs: 1_000 } });
+    const ordinary = await connectEncrypted(fx);
+    const slowReserve = await connectEncrypted(fx);
+    const evicted = new Promise((resolve) => slowReserve.ws.once('close', resolve));
+    const prompt = await connectEncrypted(fx);
+    await evicted;
+    expect((await prompt.request(1, 'GET', '/health')).status).toBe(200);
+    expect((await prompt.request(3, 'GET', '/auth/session', { authorization: 'Bearer valid-client' })).status).toBe(200);
+    expect(fx.service.getCounts()).toMatchObject({ authenticated: 1, preauthenticated: 1, reserved: 0 });
+    ordinary.ws.terminate(); prompt.ws.terminate();
+  });
+
+  it('survives repeated saturation, fragment churn, and disconnect cycles without accounting drift', async () => {
+    const fx = await startFixture({ limits: { maxPreauthenticated: 1, reconnectReserve: 1, maxIncompleteFragments: 1, reconnectDeadlineMs: 100 } });
+    for (let cycle = 0; cycle < 10; cycle += 1) {
+      const first = await connectEncrypted(fx);
+      const second = await connectEncrypted(fx);
+      await second.send(encodeTunnelFrame(TunnelFrameType.WsText, 1, new Uint8Array([1]), true));
+      await second.send(encodeTunnelFrame(TunnelFrameType.WsBinary, 3, new Uint8Array([2]), true));
+      first.ws.terminate();
+      await waitFor(() => fx.service.getCounts().total === 0);
+    }
+    expect(fx.service.getCounts()).toEqual({ pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: 0 });
+  });
+});

--- a/packages/web/server/lib/direct-e2ee/runtime.js
+++ b/packages/web/server/lib/direct-e2ee/runtime.js
@@ -85,6 +85,17 @@ export const createDirectE2eeRuntime = ({
     ? `${profile.id}\n${profile.mode}\n${profile.hostname}\n${profile.publicUrl}`
     : null;
 
+  const clearAuthorityAfterRefreshFailure = (generation) => {
+    if (generation !== refreshGeneration) return;
+    activeProfile = null;
+    lastPublishedProfile = null;
+    try {
+      service.closeAll('authority-refresh-failed');
+    } catch {
+      // The service performs per-session best-effort cleanup; authority stays revoked.
+    }
+  };
+
   const refresh = async ({ closePreviousReason = null, reason = null } = {}) => {
     const effectiveCloseReason = closePreviousReason || reason;
     const generation = ++refreshGeneration;
@@ -94,13 +105,19 @@ export const createDirectE2eeRuntime = ({
     try {
       config = await readManagedRemoteTunnelConfigFromDisk();
     } catch (error) {
-      if (generation === refreshGeneration) activeProfile = null;
+      clearAuthorityAfterRefreshFailure(generation);
       throw error;
     }
     if (generation !== refreshGeneration || snapshotKey(snapshot) !== snapshotKey(controllerSnapshot())) {
       return activeProfile;
     }
-    const nextProfile = resolveActiveProfile(snapshot, config);
+    let nextProfile;
+    try {
+      nextProfile = resolveActiveProfile(snapshot, config);
+    } catch (error) {
+      clearAuthorityAfterRefreshFailure(generation);
+      throw error;
+    }
     if (effectiveCloseReason && lastPublishedProfile
       && activeProfileKey(lastPublishedProfile) !== activeProfileKey(nextProfile)) {
       service.closeProfile(lastPublishedProfile.id, effectiveCloseReason);

--- a/packages/web/server/lib/direct-e2ee/runtime.js
+++ b/packages/web/server/lib/direct-e2ee/runtime.js
@@ -19,6 +19,14 @@ const canonicalPublicUrl = (value) => {
   }
 };
 
+const authorityDriftError = () => Object.assign(
+  new Error('Direct E2EE authority changed during refresh'),
+  {
+    name: 'DirectE2eeAuthorityDriftError',
+    code: 'direct_e2ee_authority_drift',
+  },
+);
+
 export const createDirectE2eeRuntime = ({
   crypto,
   httpServer,
@@ -108,8 +116,13 @@ export const createDirectE2eeRuntime = ({
       clearAuthorityAfterRefreshFailure(generation);
       throw error;
     }
-    if (generation !== refreshGeneration || snapshotKey(snapshot) !== snapshotKey(controllerSnapshot())) {
+    if (generation !== refreshGeneration) {
       return activeProfile;
+    }
+    const currentSnapshot = controllerSnapshot();
+    if (snapshot.controller !== currentSnapshot.controller || snapshotKey(snapshot) !== snapshotKey(currentSnapshot)) {
+      clearAuthorityAfterRefreshFailure(generation);
+      throw authorityDriftError();
     }
     let nextProfile;
     try {
@@ -130,6 +143,7 @@ export const createDirectE2eeRuntime = ({
   const service = createService({
     getActiveProfile: () => activeProfile,
     getRelayIdentity: () => identityRuntime.getRelayIdentity(),
+    abandonPendingRelayIdentity: () => identityRuntime.abandonPendingRelayIdentity?.() ?? false,
     getLocalPort,
     internalTransportMarker,
     authenticateBearerToken: async (token) => {

--- a/packages/web/server/lib/direct-e2ee/runtime.js
+++ b/packages/web/server/lib/direct-e2ee/runtime.js
@@ -1,0 +1,178 @@
+import { domainToASCII } from 'node:url';
+
+import { createRelayIdentityRuntime } from '../relay/identity.js';
+import { createDirectE2eeService, DIRECT_E2EE_PATH } from './service.js';
+
+const canonicalPublicUrl = (value) => {
+  if (typeof value !== 'string' || value !== value.trim()) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash) return null;
+    const hostname = url.hostname.toLowerCase();
+    if (!hostname || hostname.endsWith('.') || domainToASCII(hostname) !== hostname) return null;
+    if (url.port && url.port !== '443') return null;
+    url.pathname = '/';
+    url.port = '';
+    return url;
+  } catch {
+    return null;
+  }
+};
+
+export const createDirectE2eeRuntime = ({
+  crypto,
+  httpServer,
+  readSettingsFromDiskMigrated,
+  writeSettingsToDisk,
+  readManagedRemoteTunnelConfigFromDisk,
+  getActiveTunnelController,
+  getLocalPort,
+  internalTransportMarker,
+  authenticateBearerToken,
+  logger = console,
+  createService = createDirectE2eeService,
+}) => {
+  const identityRuntime = createRelayIdentityRuntime({ crypto, readSettingsFromDiskMigrated, writeSettingsToDisk });
+  let activeProfile = null;
+  let lastPublishedProfile = null;
+  let initialized = false;
+  let refreshGeneration = 0;
+  let lifecycleGeneration = 0;
+
+  const controllerSnapshot = () => {
+    const controller = getActiveTunnelController();
+    const publicUrl = canonicalPublicUrl(controller?.getPublicUrl?.());
+    const profileId = typeof controller?.managedRemoteTunnelPresetId === 'string'
+      ? controller.managedRemoteTunnelPresetId
+      : '';
+    return { controller, mode: controller?.mode, profileId, publicUrl };
+  };
+
+  const snapshotKey = (snapshot) => snapshot
+    ? `${snapshot.mode || ''}\n${snapshot.profileId}\n${snapshot.publicUrl?.toString() || ''}`
+    : null;
+
+  const resolveActiveProfile = (snapshot, config) => {
+    const { mode, profileId, publicUrl } = snapshot;
+    if (mode !== 'managed-remote' || !publicUrl) return null;
+    let profile = null;
+    if (profileId) {
+      profile = config.tunnels.find((entry) => entry.id === profileId) || null;
+    } else {
+      const matches = config.tunnels.filter((entry) =>
+        entry.directE2eeEnabled === true && entry.hostname === publicUrl.hostname);
+      if (matches.length === 1) profile = matches[0];
+    }
+    if (!profile || profile.directE2eeEnabled !== true || profile.hostname !== publicUrl.hostname) return null;
+    return {
+      id: profile.id,
+      name: profile.name,
+      hostname: profile.hostname,
+      directE2eeEnabled: true,
+      mode,
+      publicUrl: publicUrl.toString().replace(/\/$/, ''),
+    };
+  };
+
+  const activeProfileKey = (profile) => profile
+    ? `${profile.id}\n${profile.mode}\n${profile.hostname}\n${profile.publicUrl}`
+    : null;
+
+  const refresh = async ({ closePreviousReason = null, reason = null } = {}) => {
+    const effectiveCloseReason = closePreviousReason || reason;
+    const generation = ++refreshGeneration;
+    const snapshot = controllerSnapshot();
+    activeProfile = null;
+    let config;
+    try {
+      config = await readManagedRemoteTunnelConfigFromDisk();
+    } catch (error) {
+      if (generation === refreshGeneration) activeProfile = null;
+      throw error;
+    }
+    if (generation !== refreshGeneration || snapshotKey(snapshot) !== snapshotKey(controllerSnapshot())) {
+      return activeProfile;
+    }
+    const nextProfile = resolveActiveProfile(snapshot, config);
+    if (effectiveCloseReason && lastPublishedProfile
+      && activeProfileKey(lastPublishedProfile) !== activeProfileKey(nextProfile)) {
+      service.closeProfile(lastPublishedProfile.id, effectiveCloseReason);
+    }
+    activeProfile = nextProfile;
+    lastPublishedProfile = nextProfile;
+    return activeProfile;
+  };
+
+  const service = createService({
+    getActiveProfile: () => activeProfile,
+    getRelayIdentity: () => identityRuntime.getRelayIdentity(),
+    getLocalPort,
+    internalTransportMarker,
+    authenticateBearerToken: async (token) => {
+      const result = await authenticateBearerToken(token);
+      return result ? { ok: true, ...result } : null;
+    },
+    logger,
+  });
+
+  return {
+    async initialize() {
+      if (initialized) return;
+      const generation = lifecycleGeneration;
+      await refresh();
+      if (generation !== lifecycleGeneration) return;
+      service.attach(httpServer);
+      initialized = true;
+    },
+    stop() {
+      lifecycleGeneration += 1;
+      refreshGeneration += 1;
+      initialized = false;
+      activeProfile = null;
+      lastPublishedProfile = null;
+      service.detach();
+    },
+    async refresh(options) {
+      return refresh(options);
+    },
+    async getPairingCandidate() {
+      const profile = activeProfile;
+      if (!initialized || !profile) return null;
+      const identity = await identityRuntime.getRelayIdentity();
+      return {
+        type: 'direct-e2ee',
+        wssUrl: `wss://${profile.hostname}${DIRECT_E2EE_PATH}`,
+        hostEncPubJwk: identity.hostEncPubJwk,
+        priority: 20,
+      };
+    },
+    isAvailable() {
+      return initialized && activeProfile !== null;
+    },
+    getPairingState() {
+      if (!initialized || !activeProfile) return null;
+      return { suppressOrigin: activeProfile.publicUrl };
+    },
+    deactivate(reason = 'tunnel-stopped') {
+      lifecycleGeneration += 1;
+      refreshGeneration += 1;
+      activeProfile = null;
+      lastPublishedProfile = null;
+      service.closeAll(reason);
+    },
+    isAvailableFor({ profile, publicUrl, activeMode }) {
+      const canonical = canonicalPublicUrl(publicUrl);
+      return initialized
+        && activeMode === 'managed-remote'
+        && profile?.id === activeProfile?.id
+        && profile?.directE2eeEnabled === true
+        && canonical?.hostname === profile.hostname
+        && canonical.hostname === activeProfile.hostname;
+    },
+    closeProfile: (profileId, reason) => service.closeProfile(profileId, reason),
+    closeAll: (reason) => service.closeAll(reason),
+    revokeClient: (clientId) => service.revokeClient(clientId),
+    getActiveSessionCount: (profileId) => service.getActiveSessionCount(profileId),
+    get initialized() { return initialized; },
+  };
+};

--- a/packages/web/server/lib/direct-e2ee/runtime.js
+++ b/packages/web/server/lib/direct-e2ee/runtime.js
@@ -23,6 +23,7 @@ export const createDirectE2eeRuntime = ({
   crypto,
   httpServer,
   readSettingsFromDiskMigrated,
+  readSettingsStrict,
   writeSettingsToDisk,
   readManagedRemoteTunnelConfigFromDisk,
   getActiveTunnelController,
@@ -31,8 +32,14 @@ export const createDirectE2eeRuntime = ({
   authenticateBearerToken,
   logger = console,
   createService = createDirectE2eeService,
+  identityRuntime: injectedIdentityRuntime,
 }) => {
-  const identityRuntime = createRelayIdentityRuntime({ crypto, readSettingsFromDiskMigrated, writeSettingsToDisk });
+  const identityRuntime = injectedIdentityRuntime ?? createRelayIdentityRuntime({
+    crypto,
+    readSettingsFromDiskMigrated,
+    writeSettingsToDisk,
+    readSettingsStrict,
+  });
   let activeProfile = null;
   let lastPublishedProfile = null;
   let initialized = false;

--- a/packages/web/server/lib/direct-e2ee/runtime.test.js
+++ b/packages/web/server/lib/direct-e2ee/runtime.test.js
@@ -262,4 +262,65 @@ describe('direct E2EE production runtime', () => {
     expect(fx.runtime.isAvailable()).toBe(false);
     expect(fx.runtime.getPairingState()).toBeNull();
   });
+
+  it('closes established sessions and clears authority before rethrowing a refresh read failure', async () => {
+    const refreshFailure = new Error('fixed authority refresh failure');
+    let fail = false;
+    let establishedSessions = 2;
+    let serviceOptions;
+    const closeAll = vi.fn(() => { establishedSessions = 0; });
+    const fx = await fixture({
+      readManagedRemoteTunnelConfigFromDisk: async () => {
+        if (fail) throw refreshFailure;
+        return { tunnels: [{ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true }] };
+      },
+      createService: (options) => {
+        serviceOptions = options;
+        return {
+          attach: vi.fn(), detach: vi.fn(), closeProfile: vi.fn(), closeAll, revokeClient: vi.fn(),
+          getActiveSessionCount: vi.fn(() => establishedSessions),
+        };
+      },
+    });
+    await fx.runtime.initialize();
+    await fx.runtime.refresh();
+    expect(closeAll).not.toHaveBeenCalled();
+    expect(serviceOptions.getActiveProfile()?.id).toBe('profile-a');
+
+    fail = true;
+    await expect(fx.runtime.refresh()).rejects.toBe(refreshFailure);
+    expect(closeAll).toHaveBeenCalledWith('authority-refresh-failed');
+    expect(establishedSessions).toBe(0);
+    expect(serviceOptions.getActiveProfile()).toBeNull();
+    expect(fx.runtime.isAvailable()).toBe(false);
+    expect(fx.runtime.getPairingState()).toBeNull();
+    expect(await fx.runtime.getPairingCandidate()).toBeNull();
+    expect(fx.runtime.initialized).toBe(true);
+  });
+
+  it('fails closed and preserves the validation failure when refreshed profile data is malformed', async () => {
+    const validationFailure = new Error('fixed profile validation failure');
+    let malformed = false;
+    let serviceOptions;
+    const closeAll = vi.fn();
+    const fx = await fixture({
+      readManagedRemoteTunnelConfigFromDisk: async () => malformed
+        ? { get tunnels() { throw validationFailure; } }
+        : { tunnels: [{ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true }] },
+      createService: (options) => {
+        serviceOptions = options;
+        return {
+          attach: vi.fn(), detach: vi.fn(), closeProfile: vi.fn(), closeAll, revokeClient: vi.fn(),
+          getActiveSessionCount: vi.fn(() => 1),
+        };
+      },
+    });
+    await fx.runtime.initialize();
+    malformed = true;
+
+    await expect(fx.runtime.refresh()).rejects.toBe(validationFailure);
+    expect(closeAll).toHaveBeenCalledWith('authority-refresh-failed');
+    expect(serviceOptions.getActiveProfile()).toBeNull();
+    expect(fx.runtime.getPairingState()).toBeNull();
+  });
 });

--- a/packages/web/server/lib/direct-e2ee/runtime.test.js
+++ b/packages/web/server/lib/direct-e2ee/runtime.test.js
@@ -52,7 +52,9 @@ describe('direct E2EE production runtime', () => {
       getRelayIdentity: vi.fn(async () => ({
         hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
       })),
+      abandonPendingRelayIdentity: vi.fn(() => true),
     };
+    let serviceOptions;
     const readSettingsFromDiskMigrated = vi.fn(async () => { throw new Error('local identity read should not run'); });
     const readSettingsStrict = vi.fn(async () => { throw new Error('strict identity read should not run'); });
     const writeSettingsToDisk = vi.fn(async () => { throw new Error('local identity write should not run'); });
@@ -61,6 +63,13 @@ describe('direct E2EE production runtime', () => {
       readSettingsFromDiskMigrated,
       readSettingsStrict,
       writeSettingsToDisk,
+      createService: (options) => {
+        serviceOptions = options;
+        return {
+          attach: vi.fn(), detach: vi.fn(), closeProfile: vi.fn(), closeAll: vi.fn(), revokeClient: vi.fn(),
+          getActiveSessionCount: vi.fn(() => 0),
+        };
+      },
     });
 
     await fx.runtime.initialize();
@@ -68,6 +77,8 @@ describe('direct E2EE production runtime', () => {
 
     expect(candidate?.hostEncPubJwk).toEqual({ kty: 'EC', crv: 'P-256', x: 'x', y: 'y' });
     expect(identityRuntime.getRelayIdentity).toHaveBeenCalledTimes(1);
+    expect(serviceOptions.abandonPendingRelayIdentity()).toBe(true);
+    expect(identityRuntime.abandonPendingRelayIdentity).toHaveBeenCalledTimes(1);
     expect(readSettingsFromDiskMigrated).not.toHaveBeenCalled();
     expect(readSettingsStrict).not.toHaveBeenCalled();
     expect(writeSettingsToDisk).not.toHaveBeenCalled();
@@ -217,13 +228,14 @@ describe('direct E2EE production runtime', () => {
     const second = deferred();
     let reads = 0;
     const closeProfile = vi.fn();
+    const closeAll = vi.fn();
     const fx = await fixture({
       readManagedRemoteTunnelConfigFromDisk: () => {
         reads += 1;
         return reads === 1 ? first.promise : second.promise;
       },
       createService: () => ({
-        attach: vi.fn(), detach: vi.fn(), closeProfile, closeAll: vi.fn(), revokeClient: vi.fn(),
+        attach: vi.fn(), detach: vi.fn(), closeProfile, closeAll, revokeClient: vi.fn(),
         getActiveSessionCount: vi.fn(() => 0),
       }),
     });
@@ -236,6 +248,7 @@ describe('direct E2EE production runtime', () => {
     await initializing;
     expect(fx.runtime.getPairingState()?.suppressOrigin).toBe('https://b.example.com');
     expect(closeProfile).not.toHaveBeenCalled();
+    expect(closeAll).not.toHaveBeenCalled();
 
     const pending = deferred();
     fx.runtime.stop();
@@ -245,6 +258,48 @@ describe('direct E2EE production runtime', () => {
     pending.resolve({ tunnels: [{ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true }] });
     await refresh;
     expect(stoppedFx.runtime.isAvailable()).toBe(false);
+  });
+
+  it('revokes sessions when the captured controller authority drifts without a newer refresh', async () => {
+    const pending = deferred();
+    let deferRead = false;
+    const closeAll = vi.fn();
+    let serviceOptions;
+    const controller = {
+      mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', getPublicUrl: () => 'https://a.example.com',
+    };
+    const fx = await fixture({
+      readManagedRemoteTunnelConfigFromDisk: () => deferRead
+        ? pending.promise
+        : Promise.resolve({ tunnels: [{ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true }] }),
+      createService: (options) => {
+        serviceOptions = options;
+        return {
+          attach: vi.fn(), detach: vi.fn(), closeProfile: vi.fn(), closeAll, revokeClient: vi.fn(),
+          getActiveSessionCount: vi.fn(() => 2),
+        };
+      },
+    });
+    fx.setController(controller);
+    await fx.runtime.initialize();
+    expect(serviceOptions.getActiveProfile()?.id).toBe('profile-a');
+
+    deferRead = true;
+    const refreshing = fx.runtime.refresh();
+    controller.managedRemoteTunnelPresetId = 'profile-b';
+    controller.getPublicUrl = () => 'https://b.example.com';
+    pending.resolve({ tunnels: [{ id: 'profile-b', name: 'B', hostname: 'b.example.com', directE2eeEnabled: true }] });
+
+    await expect(refreshing).rejects.toMatchObject({
+      name: 'DirectE2eeAuthorityDriftError',
+      code: 'direct_e2ee_authority_drift',
+      message: 'Direct E2EE authority changed during refresh',
+    });
+    expect(closeAll).toHaveBeenCalledWith('authority-refresh-failed');
+    expect(serviceOptions.getActiveProfile()).toBeNull();
+    expect(fx.runtime.isAvailable()).toBe(false);
+    expect(fx.runtime.getPairingState()).toBeNull();
+    expect(await fx.runtime.getPairingCandidate()).toBeNull();
   });
 
   it('publishes safe unavailable state when the latest refresh fails', async () => {

--- a/packages/web/server/lib/direct-e2ee/runtime.test.js
+++ b/packages/web/server/lib/direct-e2ee/runtime.test.js
@@ -47,6 +47,32 @@ const fixture = async (overrides = {}) => {
 };
 
 describe('direct E2EE production runtime', () => {
+  it('uses an injected relay identity runtime without reading or generating local identity settings', async () => {
+    const identityRuntime = {
+      getRelayIdentity: vi.fn(async () => ({
+        hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
+      })),
+    };
+    const readSettingsFromDiskMigrated = vi.fn(async () => { throw new Error('local identity read should not run'); });
+    const readSettingsStrict = vi.fn(async () => { throw new Error('strict identity read should not run'); });
+    const writeSettingsToDisk = vi.fn(async () => { throw new Error('local identity write should not run'); });
+    const fx = await fixture({
+      identityRuntime,
+      readSettingsFromDiskMigrated,
+      readSettingsStrict,
+      writeSettingsToDisk,
+    });
+
+    await fx.runtime.initialize();
+    const candidate = await fx.runtime.getPairingCandidate();
+
+    expect(candidate?.hostEncPubJwk).toEqual({ kty: 'EC', crv: 'P-256', x: 'x', y: 'y' });
+    expect(identityRuntime.getRelayIdentity).toHaveBeenCalledTimes(1);
+    expect(readSettingsFromDiskMigrated).not.toHaveBeenCalled();
+    expect(readSettingsStrict).not.toHaveBeenCalled();
+    expect(writeSettingsToDisk).not.toHaveBeenCalled();
+  });
+
   it('reports support only after initialization and owns one removable upgrade listener', async () => {
     const fx = await fixture();
     expect(fx.runtime.initialized).toBe(false);

--- a/packages/web/server/lib/direct-e2ee/runtime.test.js
+++ b/packages/web/server/lib/direct-e2ee/runtime.test.js
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from 'bun:test';
+import http from 'node:http';
+import crypto from 'node:crypto';
+
+import { createDirectE2eeRuntime } from './runtime.js';
+
+const runtimes = [];
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((onResolve, onReject) => { resolve = onResolve; reject = onReject; });
+  return { promise, resolve, reject };
+};
+afterEach(() => {
+  for (const runtime of runtimes.splice(0)) runtime.stop();
+});
+
+const fixture = async (overrides = {}) => {
+  const server = http.createServer();
+  let settings = {};
+  let profiles = [{
+    id: 'profile-a', name: 'A', hostname: 'a.example.com', token: 'secret', directE2eeEnabled: true,
+  }];
+  let controller = {
+    mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', getPublicUrl: () => 'https://a.example.com',
+  };
+  const runtime = createDirectE2eeRuntime({
+    crypto,
+    httpServer: server,
+    readSettingsFromDiskMigrated: async () => settings,
+    writeSettingsToDisk: async (next) => { settings = next; },
+    readManagedRemoteTunnelConfigFromDisk: async () => ({ tunnels: profiles }),
+    getActiveTunnelController: () => controller,
+    getLocalPort: () => 3000,
+    internalTransportMarker: 'marker',
+    authenticateBearerToken: async () => null,
+    ...overrides,
+  });
+  runtimes.push(runtime);
+  return {
+    runtime,
+    server,
+    setProfile: (next) => { profiles = next ? [next] : []; },
+    setProfiles: (next) => { profiles = next; },
+    setController: (next) => { controller = next; },
+  };
+};
+
+describe('direct E2EE production runtime', () => {
+  it('reports support only after initialization and owns one removable upgrade listener', async () => {
+    const fx = await fixture();
+    expect(fx.runtime.initialized).toBe(false);
+    expect(fx.server.listenerCount('upgrade')).toBe(0);
+    await fx.runtime.initialize();
+    await fx.runtime.initialize();
+    expect(fx.runtime.initialized).toBe(true);
+    expect(fx.server.listenerCount('upgrade')).toBe(1);
+    fx.runtime.stop();
+    expect(fx.runtime.initialized).toBe(false);
+    expect(fx.server.listenerCount('upgrade')).toBe(0);
+  });
+
+  it('coexists with an existing upgrade listener and removes only its own listener on stop', async () => {
+    const fx = await fixture();
+    let existingCalls = 0;
+    const existing = (req, socket) => {
+      if (req.url === '/other') {
+        existingCalls += 1;
+        socket.end('handled');
+      }
+    };
+    const emitOtherUpgrade = () => {
+      let output = '';
+      const socket = { destroyed: false, end: (value = '') => { output += value; } };
+      fx.server.emit('upgrade', { url: '/other', rawHeaders: ['Host', 'localhost'], headers: { host: 'localhost' } }, socket, Buffer.alloc(0));
+      return output;
+    };
+    fx.server.on('upgrade', existing);
+    await fx.runtime.initialize();
+    expect(fx.server.listeners('upgrade')).toEqual([existing, expect.any(Function)]);
+    expect(emitOtherUpgrade()).toBe('handled');
+    expect(existingCalls).toBe(1);
+    fx.runtime.stop();
+    expect(fx.server.listeners('upgrade')).toEqual([existing]);
+    expect(emitOtherUpgrade()).toBe('handled');
+    expect(existingCalls).toBe(2);
+  });
+
+  it('emits a canonical candidate only for the exact active enabled managed profile', async () => {
+    const fx = await fixture();
+    await fx.runtime.initialize();
+    const candidate = await fx.runtime.getPairingCandidate();
+    expect(candidate).toMatchObject({
+      type: 'direct-e2ee',
+      wssUrl: 'wss://a.example.com/api/openchamber/direct-e2ee/ws',
+      priority: 20,
+    });
+    expect(candidate.hostEncPubJwk).not.toHaveProperty('d');
+    expect(fx.runtime.isAvailableFor({
+      profile: { id: 'profile-a', hostname: 'a.example.com', directE2eeEnabled: true },
+      publicUrl: 'https://a.example.com',
+      activeMode: 'managed-remote',
+    })).toBe(true);
+
+    fx.setController({ mode: 'quick', managedRemoteTunnelPresetId: 'profile-a', getPublicUrl: () => 'https://a.example.com' });
+    await fx.runtime.refresh();
+    expect(await fx.runtime.getPairingCandidate()).toBeNull();
+    fx.setController({ mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-b', getPublicUrl: () => 'https://a.example.com' });
+    await fx.runtime.refresh();
+    expect(await fx.runtime.getPairingCandidate()).toBeNull();
+    fx.setController({ mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', getPublicUrl: () => 'https://other.example.com' });
+    await fx.runtime.refresh();
+    expect(await fx.runtime.getPairingCandidate()).toBeNull();
+    fx.setController({ mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', getPublicUrl: () => 'https://a.example.com' });
+    fx.setProfile({ id: 'profile-a', name: 'A', hostname: 'a.example.com', token: 'secret', directE2eeEnabled: false });
+    await fx.runtime.refresh();
+    expect(await fx.runtime.getPairingCandidate()).toBeNull();
+  });
+
+  it('deactivates authoritative availability until an active tunnel is refreshed', async () => {
+    const authenticateBearerToken = vi.fn(async () => null);
+    const fx = await fixture({ authenticateBearerToken });
+    await fx.runtime.initialize();
+    expect(fx.runtime.isAvailable()).toBe(true);
+    fx.runtime.deactivate('tunnel-stopped');
+    expect(fx.runtime.isAvailable()).toBe(false);
+    expect(await fx.runtime.getPairingCandidate()).toBeNull();
+    expect(authenticateBearerToken).not.toHaveBeenCalled();
+    await fx.runtime.refresh();
+    expect(fx.runtime.isAvailable()).toBe(true);
+    expect(await fx.runtime.getPairingCandidate()).not.toBeNull();
+  });
+
+  it('closes the previous profile sessions when authority changes under the same profile id', async () => {
+    const closeProfile = vi.fn();
+    let serviceOptions;
+    const fx = await fixture({
+      createService: (options) => {
+        serviceOptions = options;
+        return {
+          attach: vi.fn(), detach: vi.fn(), closeProfile, closeAll: vi.fn(), revokeClient: vi.fn(),
+          getActiveSessionCount: vi.fn(() => 0),
+        };
+      },
+    });
+    await fx.runtime.initialize();
+    expect(serviceOptions.getActiveProfile()).toEqual({
+      id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true,
+      mode: 'managed-remote', publicUrl: 'https://a.example.com',
+    });
+    expect(serviceOptions.getActiveProfile()).not.toHaveProperty('token');
+
+    fx.setProfile({
+      id: 'profile-a', name: 'A', hostname: 'b.example.com', token: 'new-secret', directE2eeEnabled: true,
+    });
+    fx.setController({
+      mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', getPublicUrl: () => 'https://b.example.com',
+    });
+    await fx.runtime.refresh({ closePreviousReason: 'profile-switched' });
+    expect(closeProfile).toHaveBeenCalledWith('profile-a', 'profile-switched');
+    expect(serviceOptions.getActiveProfile()).not.toHaveProperty('token');
+  });
+
+  it('uses a unique enabled hostname match only when the active controller has no profile id', async () => {
+    const fx = await fixture();
+    fx.setController({ mode: 'managed-remote', getPublicUrl: () => 'https://a.example.com' });
+    await fx.runtime.initialize();
+    expect(fx.runtime.isAvailable()).toBe(true);
+
+    fx.setProfiles([
+      { id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true },
+      { id: 'profile-b', name: 'B', hostname: 'a.example.com', directE2eeEnabled: true },
+    ]);
+    await fx.runtime.refresh();
+    expect(fx.runtime.isAvailable()).toBe(false);
+
+    fx.setProfile(null);
+    await fx.runtime.refresh();
+    expect(fx.runtime.isAvailable()).toBe(false);
+  });
+
+  it('never falls back by hostname when an explicit wrong profile id is present', async () => {
+    const fx = await fixture();
+    fx.setController({ mode: 'managed-remote', managedRemoteTunnelPresetId: 'missing', getPublicUrl: () => 'https://a.example.com' });
+    await fx.runtime.initialize();
+    expect(fx.runtime.isAvailable()).toBe(false);
+  });
+
+  it('generation-fences interleaved refreshes and stop during refresh', async () => {
+    const first = deferred();
+    const second = deferred();
+    let reads = 0;
+    const closeProfile = vi.fn();
+    const fx = await fixture({
+      readManagedRemoteTunnelConfigFromDisk: () => {
+        reads += 1;
+        return reads === 1 ? first.promise : second.promise;
+      },
+      createService: () => ({
+        attach: vi.fn(), detach: vi.fn(), closeProfile, closeAll: vi.fn(), revokeClient: vi.fn(),
+        getActiveSessionCount: vi.fn(() => 0),
+      }),
+    });
+    const initializing = fx.runtime.initialize();
+    fx.setController({ mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-b', getPublicUrl: () => 'https://b.example.com' });
+    const newer = fx.runtime.refresh();
+    second.resolve({ tunnels: [{ id: 'profile-b', name: 'B', hostname: 'b.example.com', directE2eeEnabled: true }] });
+    await newer;
+    first.resolve({ tunnels: [{ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true }] });
+    await initializing;
+    expect(fx.runtime.getPairingState()?.suppressOrigin).toBe('https://b.example.com');
+    expect(closeProfile).not.toHaveBeenCalled();
+
+    const pending = deferred();
+    fx.runtime.stop();
+    const stoppedFx = await fixture({ readManagedRemoteTunnelConfigFromDisk: () => pending.promise });
+    const refresh = stoppedFx.runtime.initialize();
+    stoppedFx.runtime.stop();
+    pending.resolve({ tunnels: [{ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true }] });
+    await refresh;
+    expect(stoppedFx.runtime.isAvailable()).toBe(false);
+  });
+
+  it('publishes safe unavailable state when the latest refresh fails', async () => {
+    let fail = false;
+    const fx = await fixture({
+      readManagedRemoteTunnelConfigFromDisk: async () => {
+        if (fail) throw new Error('config unavailable');
+        return { tunnels: [{ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: true }] };
+      },
+    });
+    await fx.runtime.initialize();
+    expect(fx.runtime.isAvailable()).toBe(true);
+    fail = true;
+    await expect(fx.runtime.refresh()).rejects.toThrow('config unavailable');
+    expect(fx.runtime.isAvailable()).toBe(false);
+    expect(fx.runtime.getPairingState()).toBeNull();
+  });
+});

--- a/packages/web/server/lib/direct-e2ee/service.js
+++ b/packages/web/server/lib/direct-e2ee/service.js
@@ -224,8 +224,14 @@ export const createDirectE2eeService = ({
       logReason('preauth-route-rejected', entry.id);
       return 'Authentication required';
     }
-    if (request.path === '/auth/session' && method !== 'GET') return 'Browser authentication is unavailable';
-    if (request.path.startsWith('/auth/passkey')) return 'Browser authentication is unavailable';
+    const authenticatedAuthRequestAllowed = !request.query && (
+      (method === 'GET' && request.path === '/auth/session')
+      || (method === 'POST' && request.path === '/auth/url-token')
+      || (method === 'GET' && request.path === '/auth/passkey/status')
+    );
+    if (authenticatedAuthRequestAllowed) return true;
+    const normalizedPath = request.path.toLowerCase();
+    if (normalizedPath === '/auth' || normalizedPath.startsWith('/auth/')) return 'Browser authentication is unavailable';
     return true;
   };
 

--- a/packages/web/server/lib/direct-e2ee/service.js
+++ b/packages/web/server/lib/direct-e2ee/service.js
@@ -142,7 +142,17 @@ export const createDirectE2eeService = ({
     return result;
   };
 
-  const logReason = (reason, connectionId) => logger.warn?.('[DirectE2EE]', { reason, connectionId });
+  const logReason = (reason, connectionId) => {
+    const safeReason = typeof reason === 'string' && /^[a-z0-9-]+$/.test(reason) ? reason : 'internal-failure';
+    const safeConnectionId = typeof connectionId === 'string' && /^[a-zA-Z0-9-]{1,128}$/.test(connectionId)
+      ? connectionId
+      : 'unknown';
+    try {
+      logger.warn?.('[DirectE2EE]', { reason: safeReason, connectionId: safeConnectionId });
+    } catch {
+      // Logging is never allowed to interrupt security cleanup.
+    }
+  };
 
   const sourceKey = (req) => {
     const remote = req.socket?.remoteAddress;
@@ -155,28 +165,40 @@ export const createDirectE2eeService = ({
   const closeEntry = (entry, reason, code = 1008) => {
     if (!entry || entry.released) return;
     entry.released = true;
-    entry.identityAttempt?.waiters.delete(entry);
+    sessions.delete(entry.id);
+    try {
+      entry.identityAttempt?.waiters.delete(entry);
+    } catch {
+      // Continue releasing the remaining entry state.
+    }
     entry.identityAttempt = null;
     entry.pendingFrames.length = 0;
-    entry.socket.off?.('message', entry.onMessage);
-    entry.socket.off?.('close', entry.onClose);
-    entry.socket.off?.('error', entry.onError);
-    sessions.delete(entry.id);
-    clearTimeout(entry.handshakeTimer);
-    clearTimeout(entry.authTimer);
-    clearInterval(entry.idleTimer);
+    for (const [event, handler] of [['message', entry.onMessage], ['close', entry.onClose], ['error', entry.onError]]) {
+      try {
+        entry.socket.off?.(event, handler);
+      } catch {
+        // Socket listener cleanup is isolated per event.
+      }
+    }
+    try { clearTimeout(entry.handshakeTimer); } catch {}
+    try { clearTimeout(entry.authTimer); } catch {}
+    try { clearInterval(entry.idleTimer); } catch {}
     try {
       entry.encrypted?.close();
     } catch {
       // Continue releasing every owned resource and session.
     }
-    entry.authChecks.clear();
-    entry.pairingChecks.clear();
-    entry.requestPurposes.clear();
+    try { entry.authChecks.clear(); } catch {}
+    try { entry.pairingChecks.clear(); } catch {}
+    try { entry.requestPurposes.clear(); } catch {}
     if (entry.clientId) {
-      const set = byClient.get(entry.clientId);
-      set?.delete(entry);
-      if (set?.size === 0) byClient.delete(entry.clientId);
+      try {
+        const set = byClient.get(entry.clientId);
+        set?.delete(entry);
+        if (set?.size === 0) byClient.delete(entry.clientId);
+      } catch {
+        // Client index cleanup must not block session release.
+      }
     }
     if (reason) logReason(reason, entry.id);
     try {
@@ -184,6 +206,17 @@ export const createDirectE2eeService = ({
       else if (entry.socket.readyState === WebSocket.CONNECTING) entry.socket.terminate();
     } catch {
       // Best-effort close; accounting is already released exactly once.
+    }
+  };
+
+  const closeEntries = (entries, reason, code) => {
+    for (const entry of entries) {
+      try {
+        closeEntry(entry, reason, code);
+      } catch {
+        sessions.delete(entry?.id);
+        logReason('session-cleanup-failed', entry?.id);
+      }
     }
   };
 
@@ -532,17 +565,17 @@ export const createDirectE2eeService = ({
       detached = true;
       server.off('upgrade', upgradeHandler);
       server = null;
-      for (const entry of [...sessions.values()]) closeEntry(entry, 'service-detached', 1001);
+      closeEntries([...sessions.values()], 'service-detached', 1001);
       for (const socket of wss.clients) socket.terminate();
     },
     closeProfile(profileId, reason = 'profile-disabled') {
-      for (const entry of [...sessions.values()]) if (entry.profileId === profileId) closeEntry(entry, reason, 1001);
+      closeEntries([...sessions.values()].filter((entry) => entry.profileId === profileId), reason, 1001);
     },
     closeAll(reason = 'tunnel-stopped') {
-      for (const entry of [...sessions.values()]) closeEntry(entry, reason, 1001);
+      closeEntries([...sessions.values()], reason, 1001);
     },
     revokeClient(clientId) {
-      for (const entry of [...(byClient.get(clientId) ?? [])]) closeEntry(entry, 'client-revoked', 1008);
+      closeEntries([...(byClient.get(clientId) ?? [])], 'client-revoked', 1008);
     },
     getActiveSessionCount(profileId) {
       let count = 0;

--- a/packages/web/server/lib/direct-e2ee/service.js
+++ b/packages/web/server/lib/direct-e2ee/service.js
@@ -18,6 +18,8 @@ const DIRECT_E2EE_LIMITS = Object.freeze({
   maxPreauthenticated: 16,
   reconnectReserve: 4,
   maxAuthenticated: 64,
+  identityDeadlineMs: 10_000,
+  identityRetryCooldownMs: 1_000,
   handshakeTimeoutMs: 15_000,
   authenticationDeadlineMs: 20_000,
   reconnectDeadlineMs: 2_000,
@@ -121,6 +123,9 @@ export const createDirectE2eeService = ({
   const byClient = new Map();
   let server = null;
   let detached = false;
+  let cachedIdentity = null;
+  let identityAttempt = null;
+  let identityRetryAfter = 0;
 
   const counts = () => {
     const result = { pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: sessions.size };
@@ -148,11 +153,21 @@ export const createDirectE2eeService = ({
   const closeEntry = (entry, reason, code = 1008) => {
     if (!entry || entry.released) return;
     entry.released = true;
+    entry.identityAttempt?.waiters.delete(entry);
+    entry.identityAttempt = null;
+    entry.pendingFrames.length = 0;
+    entry.socket.off?.('message', entry.onMessage);
+    entry.socket.off?.('close', entry.onClose);
+    entry.socket.off?.('error', entry.onError);
     sessions.delete(entry.id);
     clearTimeout(entry.handshakeTimer);
     clearTimeout(entry.authTimer);
     clearInterval(entry.idleTimer);
-    entry.encrypted?.close();
+    try {
+      entry.encrypted?.close();
+    } catch {
+      // Continue releasing every owned resource and session.
+    }
     entry.authChecks.clear();
     entry.pairingChecks.clear();
     entry.requestPurposes.clear();
@@ -260,12 +275,156 @@ export const createDirectE2eeService = ({
     entry.authTimer.unref?.();
   };
 
-  const acceptConnection = async (socket, profile) => {
+  const initializeEncryptedEntry = (entry, identity) => {
+    if (entry.released) return;
+    entry.identityAttempt?.waiters.delete(entry);
+    entry.identityAttempt = null;
+    try {
+      entry.encrypted = createEncryptedSession({
+        socket: entry.socket,
+        connectionId: entry.id,
+        hostEncPrivateKey: identity.hostEncPrivateKey,
+        getLocalPort,
+        isActive: () => sessions.get(entry.id) === entry && !entry.released,
+        onActivity: () => { entry.lastActivityAt = Date.now(); },
+        onEstablished: () => establish(entry),
+        onFailure: (code) => closeEntry(entry, 'channel-failure', code),
+        logger: { warn: () => logReason('encrypted-session-failure', entry.id) },
+        failOnIgnoredHandshake: true,
+        batchWindowMs,
+        tunnelOptions: {
+          transportContext: {
+            metadataHeader: null,
+            stripOrigin: true,
+            requestHeaders: { [DIRECT_E2EE_TRANSPORT_HEADER]: internalTransportMarker },
+            wsHeaders: { [DIRECT_E2EE_TRANSPORT_HEADER]: internalTransportMarker },
+          },
+          requestPolicy: requestPolicy(entry),
+          onResponse: ({ generation, status }) => {
+            const purpose = entry.requestPurposes.get(generation);
+            entry.requestPurposes.delete(generation);
+            if (entry.reserved && purpose === 'health' && status === 200 && entry.state === 'preauthenticated') entry.healthSeen = true;
+            if (entry.pairingChecks.delete(generation) && status >= 400) logReason('pairing-rejected', entry.id);
+            const clientId = entry.authChecks.get(generation);
+            entry.authChecks.delete(generation);
+            if (status === 200 && clientId) promote(entry, clientId);
+          },
+          onLimitExceeded: (reason) => closeEntry(entry, reason, RelayCloseCode.ChannelFailure),
+          onStreamClosed: (event) => {
+            entry.authChecks.delete(event.generation);
+            entry.pairingChecks.delete(event.generation);
+            entry.requestPurposes.delete(event.generation);
+            onInnerStreamClosed?.(event);
+          },
+          limits: {
+            maxStreams: limits.maxStreams,
+            maxWebSockets: limits.maxWebSockets,
+            maxIncompleteFragments: limits.maxIncompleteFragments,
+            getMaxIncompleteFragmentBytes: () => entry.state === 'authenticated' ? limits.maxAuthenticatedFragmentBytes : limits.maxPreauthFragmentBytes,
+            maxStreamOpens: limits.maxStreamOpens,
+            streamOpenWindowMs: limits.streamOpenWindowMs,
+          },
+          failClosedPolicy: true,
+        },
+      });
+      for (const [data, isBinary] of entry.pendingFrames.splice(0)) entry.encrypted.receive(data, isBinary);
+    } catch {
+      closeEntry(entry, 'identity-unavailable', 1011);
+      logReason('identity-unavailable', 'upgrade');
+    }
+  };
+
+  const closeIdentityWaiters = (attempt, reason) => {
+    const waiters = [...attempt.waiters];
+    attempt.waiters.clear();
+    for (const entry of waiters) {
+      closeEntry(entry, reason, 1011);
+      logReason(reason, 'upgrade');
+    }
+  };
+
+  const settleIdentitySuccess = (attempt, identity) => {
+    if (!identity?.hostEncPrivateKey) {
+      settleIdentityRejection(attempt);
+      return;
+    }
+    clearTimeout(attempt.deadlineTimer);
+    attempt.deadlineTimer = null;
+    cachedIdentity = identity;
+    if (identityAttempt === attempt) identityAttempt = null;
+    const waiters = [...attempt.waiters];
+    attempt.waiters.clear();
+    for (const entry of waiters) initializeEncryptedEntry(entry, identity);
+  };
+
+  const settleIdentityRejection = (attempt) => {
+    clearTimeout(attempt.deadlineTimer);
+    attempt.deadlineTimer = null;
+    closeIdentityWaiters(attempt, 'identity-unavailable');
+    if (identityAttempt === attempt) identityAttempt = null;
+    identityRetryAfter = Date.now() + limits.identityRetryCooldownMs;
+  };
+
+  const startIdentityAttempt = (attempt) => {
+    attempt.deadlineTimer = setTimeout(() => {
+      if (identityAttempt !== attempt || attempt.state !== 'pending') return;
+      attempt.state = 'timed-out';
+      attempt.deadlineTimer = null;
+      closeIdentityWaiters(attempt, 'identity-timeout');
+    }, limits.identityDeadlineMs);
+    attempt.deadlineTimer.unref?.();
+
+    let pendingIdentity;
+    try {
+      pendingIdentity = getRelayIdentity();
+    } catch {
+      settleIdentityRejection(attempt);
+      return;
+    }
+    Promise.resolve(pendingIdentity).then(
+      (identity) => settleIdentitySuccess(attempt, identity),
+      () => settleIdentityRejection(attempt),
+    );
+  };
+
+  const waitForIdentity = (entry) => {
+    if (cachedIdentity) {
+      initializeEncryptedEntry(entry, cachedIdentity);
+      return;
+    }
+    if (identityAttempt?.state === 'timed-out') {
+      closeEntry(entry, 'identity-timeout', 1011);
+      return;
+    }
+    if (Date.now() < identityRetryAfter) {
+      closeEntry(entry, 'identity-cooldown', 1011);
+      return;
+    }
+
+    let attempt = identityAttempt;
+    if (!attempt) {
+      attempt = { state: 'pending', waiters: new Set(), deadlineTimer: null, started: false };
+      identityAttempt = attempt;
+    }
+    if (attempt.waiters.size >= limits.maxPending) {
+      closeEntry(entry, 'identity-capacity', 1011);
+      return;
+    }
+    attempt.waiters.add(entry);
+    entry.identityAttempt = attempt;
+    if (!attempt.started) {
+      attempt.started = true;
+      startIdentityAttempt(attempt);
+    }
+  };
+
+  const acceptConnection = (socket, profile) => {
     const id = crypto.randomUUID();
     const entry = {
       id, socket, profileId: profile.id, state: 'pending', reserved: false, released: false,
       clientId: null, encrypted: null, handshakeMessages: 0, authChecks: new Map(), pairingChecks: new Set(), requestPurposes: new Map(), healthSeen: false, source: profile.source, createdAt: Date.now(), lastActivityAt: Date.now(),
-      handshakeTimer: null, authTimer: null, idleTimer: null, pendingFrames: [],
+      handshakeTimer: null, authTimer: null, idleTimer: null, pendingFrames: [], identityAttempt: null,
+      onMessage: null, onClose: null, onError: null,
     };
     sessions.set(id, entry);
     entry.handshakeTimer = setTimeout(() => closeEntry(entry, 'handshake-timeout', 1008), limits.handshakeTimeoutMs);
@@ -274,7 +433,8 @@ export const createDirectE2eeService = ({
       if (Date.now() - entry.lastActivityAt > limits.idleTimeoutMs) closeEntry(entry, 'idle-timeout', 1001);
     }, Math.min(30_000, limits.idleTimeoutMs));
     entry.idleTimer.unref?.();
-    socket.on('message', (data, isBinary) => {
+    entry.onMessage = (data, isBinary) => {
+      if (entry.released) return;
       if (entry.state === 'pending') {
         entry.handshakeMessages += 1;
         const size = typeof data === 'string' ? Buffer.byteLength(data) : data.length;
@@ -288,66 +448,13 @@ export const createDirectE2eeService = ({
         return;
       }
       entry.encrypted.receive(data, isBinary);
-    });
-    socket.once('close', () => closeEntry(entry, 'disconnect', 1000));
-    socket.once('error', () => closeEntry(entry, 'socket-error', 1011));
-
-    let identity;
-    try {
-      identity = await getRelayIdentity();
-    } catch (error) {
-      closeEntry(entry, 'identity-unavailable', 1011);
-      throw error;
-    }
-    if (entry.released) return;
-    entry.encrypted = createEncryptedSession({
-      socket,
-      connectionId: id,
-      hostEncPrivateKey: identity.hostEncPrivateKey,
-      getLocalPort,
-      isActive: () => sessions.get(id) === entry && !entry.released,
-      onActivity: () => { entry.lastActivityAt = Date.now(); },
-      onEstablished: () => establish(entry),
-      onFailure: (code) => closeEntry(entry, 'channel-failure', code),
-      logger: { warn: () => logReason('encrypted-session-failure', id) },
-      failOnIgnoredHandshake: true,
-      batchWindowMs,
-      tunnelOptions: {
-        transportContext: {
-          metadataHeader: null,
-          stripOrigin: true,
-          requestHeaders: { [DIRECT_E2EE_TRANSPORT_HEADER]: internalTransportMarker },
-          wsHeaders: { [DIRECT_E2EE_TRANSPORT_HEADER]: internalTransportMarker },
-        },
-        requestPolicy: requestPolicy(entry),
-        onResponse: ({ generation, status }) => {
-          const purpose = entry.requestPurposes.get(generation);
-          entry.requestPurposes.delete(generation);
-          if (entry.reserved && purpose === 'health' && status === 200 && entry.state === 'preauthenticated') entry.healthSeen = true;
-          if (entry.pairingChecks.delete(generation) && status >= 400) logReason('pairing-rejected', entry.id);
-          const clientId = entry.authChecks.get(generation);
-          entry.authChecks.delete(generation);
-          if (status === 200 && clientId) promote(entry, clientId);
-        },
-        onLimitExceeded: (reason) => closeEntry(entry, reason, RelayCloseCode.ChannelFailure),
-        onStreamClosed: (event) => {
-          entry.authChecks.delete(event.generation);
-          entry.pairingChecks.delete(event.generation);
-          entry.requestPurposes.delete(event.generation);
-          onInnerStreamClosed?.(event);
-        },
-        limits: {
-          maxStreams: limits.maxStreams,
-          maxWebSockets: limits.maxWebSockets,
-          maxIncompleteFragments: limits.maxIncompleteFragments,
-          getMaxIncompleteFragmentBytes: () => entry.state === 'authenticated' ? limits.maxAuthenticatedFragmentBytes : limits.maxPreauthFragmentBytes,
-          maxStreamOpens: limits.maxStreamOpens,
-          streamOpenWindowMs: limits.streamOpenWindowMs,
-        },
-        failClosedPolicy: true,
-      },
-    });
-    for (const [data, isBinary] of entry.pendingFrames.splice(0)) entry.encrypted.receive(data, isBinary);
+    };
+    entry.onClose = () => closeEntry(entry, 'disconnect', 1000);
+    entry.onError = () => closeEntry(entry, 'socket-error', 1011);
+    socket.on('message', entry.onMessage);
+    socket.once('close', entry.onClose);
+    socket.once('error', entry.onError);
+    waitForIdentity(entry);
   };
 
   const upgradeHandler = (req, socket, head) => {
@@ -385,13 +492,7 @@ export const createDirectE2eeService = ({
     }
     wss.handleUpgrade(req, socket, head, (ws) => {
       wss.emit('connection', ws, req);
-      void acceptConnection(ws, { ...profile, source }).catch(() => {
-        try {
-          if (ws.readyState === WebSocket.OPEN) ws.close(1011, 'direct session unavailable');
-          else if (ws.readyState === WebSocket.CONNECTING) ws.terminate();
-        } catch { ws.terminate(); }
-        logReason('identity-unavailable', 'upgrade');
-      });
+      acceptConnection(ws, { ...profile, source });
     });
   };
 
@@ -426,6 +527,8 @@ export const createDirectE2eeService = ({
       return count;
     },
     getCounts: counts,
+    _getPendingFrameCount: () => [...sessions.values()]
+      .reduce((total, entry) => total + entry.pendingFrames.length, 0),
     _webSocketServer: wss,
   };
 };

--- a/packages/web/server/lib/direct-e2ee/service.js
+++ b/packages/web/server/lib/direct-e2ee/service.js
@@ -108,6 +108,7 @@ const bearerToken = (headers) => {
 export const createDirectE2eeService = ({
   getActiveProfile,
   getRelayIdentity,
+  abandonPendingRelayIdentity = () => false,
   getLocalPort,
   internalTransportMarker,
   authenticateBearerToken,
@@ -126,6 +127,7 @@ export const createDirectE2eeService = ({
   let cachedIdentity = null;
   let identityAttempt = null;
   let identityRetryAfter = 0;
+  let nextIdentityGeneration = 1;
 
   const counts = () => {
     const result = { pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: sessions.size };
@@ -344,6 +346,7 @@ export const createDirectE2eeService = ({
   };
 
   const settleIdentitySuccess = (attempt, identity) => {
+    if (identityAttempt !== attempt || attempt.state !== 'pending') return;
     if (!identity?.hostEncPrivateKey) {
       settleIdentityRejection(attempt);
       return;
@@ -358,6 +361,7 @@ export const createDirectE2eeService = ({
   };
 
   const settleIdentityRejection = (attempt) => {
+    if (identityAttempt !== attempt || attempt.state !== 'pending') return;
     clearTimeout(attempt.deadlineTimer);
     attempt.deadlineTimer = null;
     closeIdentityWaiters(attempt, 'identity-unavailable');
@@ -371,6 +375,7 @@ export const createDirectE2eeService = ({
       attempt.state = 'timed-out';
       attempt.deadlineTimer = null;
       closeIdentityWaiters(attempt, 'identity-timeout');
+      identityRetryAfter = Date.now() + limits.identityRetryCooldownMs;
     }, limits.identityDeadlineMs);
     attempt.deadlineTimer.unref?.();
 
@@ -392,18 +397,36 @@ export const createDirectE2eeService = ({
       initializeEncryptedEntry(entry, cachedIdentity);
       return;
     }
-    if (identityAttempt?.state === 'timed-out') {
-      closeEntry(entry, 'identity-timeout', 1011);
-      return;
-    }
     if (Date.now() < identityRetryAfter) {
       closeEntry(entry, 'identity-cooldown', 1011);
       return;
     }
 
+    if (identityAttempt?.state === 'timed-out') {
+      const timedOutAttempt = identityAttempt;
+      if (!timedOutAttempt.resetInvoked) {
+        timedOutAttempt.resetInvoked = true;
+        try {
+          abandonPendingRelayIdentity();
+        } catch {
+          identityRetryAfter = Date.now() + limits.identityRetryCooldownMs;
+          closeEntry(entry, 'identity-cooldown', 1011);
+          return;
+        }
+      }
+      if (identityAttempt === timedOutAttempt) identityAttempt = null;
+    }
+
     let attempt = identityAttempt;
     if (!attempt) {
-      attempt = { state: 'pending', waiters: new Set(), deadlineTimer: null, started: false };
+      attempt = {
+        generation: nextIdentityGeneration++,
+        state: 'pending',
+        waiters: new Set(),
+        deadlineTimer: null,
+        started: false,
+        resetInvoked: false,
+      };
       identityAttempt = attempt;
     }
     if (attempt.waiters.size >= limits.maxPending) {

--- a/packages/web/server/lib/direct-e2ee/service.js
+++ b/packages/web/server/lib/direct-e2ee/service.js
@@ -292,7 +292,13 @@ export const createDirectE2eeService = ({
     socket.once('close', () => closeEntry(entry, 'disconnect', 1000));
     socket.once('error', () => closeEntry(entry, 'socket-error', 1011));
 
-    const identity = await getRelayIdentity();
+    let identity;
+    try {
+      identity = await getRelayIdentity();
+    } catch (error) {
+      closeEntry(entry, 'identity-unavailable', 1011);
+      throw error;
+    }
     if (entry.released) return;
     entry.encrypted = createEncryptedSession({
       socket,
@@ -380,7 +386,10 @@ export const createDirectE2eeService = ({
     wss.handleUpgrade(req, socket, head, (ws) => {
       wss.emit('connection', ws, req);
       void acceptConnection(ws, { ...profile, source }).catch(() => {
-        try { ws.close(1011, 'direct session unavailable'); } catch { ws.terminate(); }
+        try {
+          if (ws.readyState === WebSocket.OPEN) ws.close(1011, 'direct session unavailable');
+          else if (ws.readyState === WebSocket.CONNECTING) ws.terminate();
+        } catch { ws.terminate(); }
         logReason('identity-unavailable', 'upgrade');
       });
     });

--- a/packages/web/server/lib/direct-e2ee/service.js
+++ b/packages/web/server/lib/direct-e2ee/service.js
@@ -1,0 +1,416 @@
+import crypto from 'node:crypto';
+import net from 'node:net';
+import { domainToASCII } from 'node:url';
+import { WebSocket, WebSocketServer } from 'ws';
+
+import { RelayCloseCode, MAX_PLAINTEXT_FRAME_BYTES } from '../relay/e2ee.js';
+import { createEncryptedSession } from '../relay/encrypted-session.js';
+import { DIRECT_E2EE_TRANSPORT_HEADER } from '../opencode/tunnel-auth.js';
+
+export const DIRECT_E2EE_PATH = '/api/openchamber/direct-e2ee/ws';
+
+// Conservative production values. Four short-lived reserve slots remain
+// available when the normal pre-auth pool is full. Reserve sessions may perform
+// encrypted health and bearer session confirmation only, and get two seconds;
+// pairing and Ping traffic cannot hold reconnect capacity.
+const DIRECT_E2EE_LIMITS = Object.freeze({
+  maxPending: 16,
+  maxPreauthenticated: 16,
+  reconnectReserve: 4,
+  maxAuthenticated: 64,
+  handshakeTimeoutMs: 15_000,
+  authenticationDeadlineMs: 20_000,
+  reconnectDeadlineMs: 2_000,
+  idleTimeoutMs: 90_000,
+  maxHandshakeMessages: 2,
+  maxHandshakeBytes: 8 * 1024,
+  maxStreams: 24,
+  maxWebSockets: 4,
+  maxIncompleteFragments: 8,
+  maxPreauthFragmentBytes: 256 * 1024,
+  maxAuthenticatedFragmentBytes: 16 * 1024 * 1024,
+  maxPendingPerSource: 4,
+  maxPreauthenticatedPerSource: 4,
+  maxReservedPerSource: 1,
+  maxStreamOpens: 40,
+  streamOpenWindowMs: 10_000,
+});
+
+const rejectUpgrade = (socket, status, reason) => {
+  if (!socket.destroyed) {
+    const response = `HTTP/1.1 ${status}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`;
+    socket.write(response, () => socket.end());
+  }
+  return reason;
+};
+
+const rawHostHeader = (req) => {
+  const values = [];
+  for (let index = 0; index < req.rawHeaders.length; index += 2) {
+    if (String(req.rawHeaders[index]).toLowerCase() === 'host') values.push(req.rawHeaders[index + 1]);
+  }
+  return values.length === 1 && typeof values[0] === 'string' ? values[0] : null;
+};
+
+const hasValidOriginHeaders = (req) => {
+  const values = [];
+  for (let index = 0; index < req.rawHeaders.length; index += 2) {
+    if (String(req.rawHeaders[index]).toLowerCase() === 'origin') values.push(req.rawHeaders[index + 1]);
+  }
+  return values.length <= 1 && values.every((value) => typeof value === 'string' && !/[\0-\x1f\x7f]/.test(value));
+};
+
+const targetsDirectEndpoint = (rawTarget) => {
+  if (typeof rawTarget !== 'string') return false;
+  if (rawTarget.startsWith(DIRECT_E2EE_PATH)) return true;
+  try {
+    const parsed = new URL(rawTarget, 'http://direct.invalid');
+    if (parsed.pathname === DIRECT_E2EE_PATH) return true;
+    const decoded = decodeURIComponent(parsed.pathname);
+    return new URL(decoded, 'http://direct.invalid').pathname === DIRECT_E2EE_PATH;
+  } catch {
+    return false;
+  }
+};
+
+const canonicalProfileHostname = (value) => {
+  if (typeof value !== 'string' || value !== value.trim() || value.endsWith('.') || value.includes(':')) return null;
+  const lower = value.toLowerCase();
+  if (!/^[a-z0-9.-]+$/.test(lower) || domainToASCII(lower) !== lower) return null;
+  if (lower === 'localhost' || lower.split('.').length < 2) return null;
+  return lower;
+};
+
+const validAuthority = (req, expectedHostname) => {
+  const raw = rawHostHeader(req);
+  if (!raw || raw !== raw.trim() || /[^\x21-\x7e]/.test(raw)) return false;
+  let parsed;
+  try {
+    parsed = new URL(`https://${raw}`);
+  } catch {
+    return false;
+  }
+  if (parsed.username || parsed.password || parsed.pathname !== '/' || parsed.search || parsed.hash) return false;
+  if (parsed.hostname !== expectedHostname || (parsed.port && parsed.port !== '443')) return false;
+  return raw.toLowerCase() === expectedHostname || raw.toLowerCase() === `${expectedHostname}:443`;
+};
+
+const bearerToken = (headers) => {
+  const value = headers?.authorization;
+  if (typeof value !== 'string') return null;
+  const match = /^Bearer\s+([^\s]+)$/i.exec(value);
+  return match?.[1] || null;
+};
+
+/** Owns the production direct-E2EE outer WebSocket endpoint. */
+export const createDirectE2eeService = ({
+  getActiveProfile,
+  getRelayIdentity,
+  getLocalPort,
+  internalTransportMarker,
+  authenticateBearerToken,
+  logger = console,
+  onInnerStreamClosed,
+  limits: overrides = {},
+  batchWindowMs = 0,
+}) => {
+  if (!internalTransportMarker) throw new Error('direct E2EE requires an internal transport marker');
+  const limits = { ...DIRECT_E2EE_LIMITS, ...overrides };
+  const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false, maxPayload: MAX_PLAINTEXT_FRAME_BYTES + 64 });
+  const sessions = new Map();
+  const byClient = new Map();
+  let server = null;
+  let detached = false;
+
+  const counts = () => {
+    const result = { pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: sessions.size };
+    for (const entry of sessions.values()) {
+      if (entry.state === 'pending') result.pending += 1;
+      else if (entry.state === 'authenticated') result.authenticated += 1;
+      else {
+        result.preauthenticated += 1;
+        if (entry.reserved) result.reserved += 1;
+      }
+    }
+    return result;
+  };
+
+  const logReason = (reason, connectionId) => logger.warn?.('[DirectE2EE]', { reason, connectionId });
+
+  const sourceKey = (req) => {
+    const remote = req.socket?.remoteAddress;
+    const loopback = remote === '127.0.0.1' || remote === '::1' || remote === '::ffff:127.0.0.1';
+    const cf = req.headers?.['cf-connecting-ip'];
+    if (loopback && typeof cf === 'string' && net.isIP(cf.trim())) return cf.trim();
+    return net.isIP(remote) ? remote : 'unknown';
+  };
+
+  const closeEntry = (entry, reason, code = 1008) => {
+    if (!entry || entry.released) return;
+    entry.released = true;
+    sessions.delete(entry.id);
+    clearTimeout(entry.handshakeTimer);
+    clearTimeout(entry.authTimer);
+    clearInterval(entry.idleTimer);
+    entry.encrypted?.close();
+    entry.authChecks.clear();
+    entry.pairingChecks.clear();
+    entry.requestPurposes.clear();
+    if (entry.clientId) {
+      const set = byClient.get(entry.clientId);
+      set?.delete(entry);
+      if (set?.size === 0) byClient.delete(entry.clientId);
+    }
+    if (reason) logReason(reason, entry.id);
+    try {
+      if (entry.socket.readyState === WebSocket.OPEN) entry.socket.close(code, 'direct session closed');
+      else if (entry.socket.readyState === WebSocket.CONNECTING) entry.socket.terminate();
+    } catch {
+      // Best-effort close; accounting is already released exactly once.
+    }
+  };
+
+  const bindClient = (entry, clientId) => {
+    if (typeof clientId !== 'string' || !clientId) return;
+    entry.clientId = clientId;
+    const set = byClient.get(clientId) ?? new Set();
+    set.add(entry);
+    byClient.set(clientId, set);
+  };
+
+  const promote = (entry, clientId) => {
+    if (entry.state !== 'preauthenticated') return;
+    if (counts().authenticated >= limits.maxAuthenticated) {
+      closeEntry(entry, 'authenticated-capacity');
+      return;
+    }
+    entry.state = 'authenticated';
+    entry.reserved = false;
+    clearTimeout(entry.authTimer);
+    bindClient(entry, clientId);
+  };
+
+  const requestPolicy = (entry) => async (request) => {
+    if (entry.state === 'pending') return 'Handshake is not established';
+    const method = request.method?.toUpperCase();
+    if (entry.state === 'preauthenticated') {
+      if (request.kind !== 'http') return 'Authentication required';
+      if (method === 'GET' && request.path === '/health' && !request.query) {
+        entry.requestPurposes.set(request.generation, 'health');
+        return true;
+      }
+      if (!entry.reserved && method === 'POST' && request.path === '/api/client-auth/pairing/redeem' && !request.query) {
+        entry.pairingChecks.add(request.generation);
+        entry.requestPurposes.set(request.generation, 'pairing');
+        return true;
+      }
+      if (method === 'GET' && request.path === '/auth/session' && !request.query) {
+        const token = bearerToken(request.headers);
+        if (!token) {
+          logReason('preauth-auth-rejected', entry.id);
+          return 'Bearer authentication required';
+        }
+        const auth = await authenticateBearerToken(token);
+        if (!auth?.ok) {
+          logReason('preauth-auth-rejected', entry.id);
+          entry.requestPurposes.set(request.generation, 'auth');
+          return true;
+        }
+        if (entry.reserved && !entry.healthSeen) return 'Health confirmation required';
+        entry.authChecks.set(request.generation, auth.client?.id || auth.clientId || null);
+        entry.requestPurposes.set(request.generation, 'auth');
+        return true;
+      }
+      logReason('preauth-route-rejected', entry.id);
+      return 'Authentication required';
+    }
+    if (request.path === '/auth/session' && method !== 'GET') return 'Browser authentication is unavailable';
+    if (request.path.startsWith('/auth/passkey')) return 'Browser authentication is unavailable';
+    return true;
+  };
+
+  const establish = (entry) => {
+    if (entry.state !== 'pending') return;
+    clearTimeout(entry.handshakeTimer);
+    const sameSourceOrdinary = [...sessions.values()].filter((candidate) => candidate !== entry && candidate.state === 'preauthenticated' && !candidate.reserved && candidate.source === entry.source);
+    const sameSourceReserved = [...sessions.values()].filter((candidate) => candidate !== entry && candidate.state === 'preauthenticated' && candidate.reserved && candidate.source === entry.source);
+    if (sameSourceOrdinary.length >= limits.maxPreauthenticatedPerSource) {
+      closeEntry(sameSourceOrdinary.sort((a, b) => a.createdAt - b.createdAt)[0], 'source-preauth-evicted', 1008);
+    }
+    const afterSourceEviction = counts();
+    if (afterSourceEviction.preauthenticated - afterSourceEviction.reserved < limits.maxPreauthenticated) {
+      entry.reserved = false;
+    } else {
+      if (sameSourceReserved.length >= limits.maxReservedPerSource) {
+        closeEntry(sameSourceReserved.sort((a, b) => a.createdAt - b.createdAt)[0], 'source-reserve-evicted', 1008);
+      } else if (afterSourceEviction.reserved >= limits.reconnectReserve) {
+        const oldestReserve = [...sessions.values()].filter((candidate) => candidate !== entry && candidate.state === 'preauthenticated' && candidate.reserved).sort((a, b) => a.createdAt - b.createdAt)[0];
+        closeEntry(oldestReserve, 'reserve-probation-evicted', 1008);
+      }
+      entry.reserved = true;
+    }
+    entry.state = 'preauthenticated';
+    entry.authTimer = setTimeout(() => closeEntry(entry, 'authentication-deadline', 1008), entry.reserved ? limits.reconnectDeadlineMs : limits.authenticationDeadlineMs);
+    entry.authTimer.unref?.();
+  };
+
+  const acceptConnection = async (socket, profile) => {
+    const id = crypto.randomUUID();
+    const entry = {
+      id, socket, profileId: profile.id, state: 'pending', reserved: false, released: false,
+      clientId: null, encrypted: null, handshakeMessages: 0, authChecks: new Map(), pairingChecks: new Set(), requestPurposes: new Map(), healthSeen: false, source: profile.source, createdAt: Date.now(), lastActivityAt: Date.now(),
+      handshakeTimer: null, authTimer: null, idleTimer: null, pendingFrames: [],
+    };
+    sessions.set(id, entry);
+    entry.handshakeTimer = setTimeout(() => closeEntry(entry, 'handshake-timeout', 1008), limits.handshakeTimeoutMs);
+    entry.handshakeTimer.unref?.();
+    entry.idleTimer = setInterval(() => {
+      if (Date.now() - entry.lastActivityAt > limits.idleTimeoutMs) closeEntry(entry, 'idle-timeout', 1001);
+    }, Math.min(30_000, limits.idleTimeoutMs));
+    entry.idleTimer.unref?.();
+    socket.on('message', (data, isBinary) => {
+      if (entry.state === 'pending') {
+        entry.handshakeMessages += 1;
+        const size = typeof data === 'string' ? Buffer.byteLength(data) : data.length;
+        if (entry.handshakeMessages > limits.maxHandshakeMessages || size > limits.maxHandshakeBytes) {
+          closeEntry(entry, 'handshake-limit', 1008);
+          return;
+        }
+      }
+      if (!entry.encrypted) {
+        entry.pendingFrames.push([data, isBinary]);
+        return;
+      }
+      entry.encrypted.receive(data, isBinary);
+    });
+    socket.once('close', () => closeEntry(entry, 'disconnect', 1000));
+    socket.once('error', () => closeEntry(entry, 'socket-error', 1011));
+
+    const identity = await getRelayIdentity();
+    if (entry.released) return;
+    entry.encrypted = createEncryptedSession({
+      socket,
+      connectionId: id,
+      hostEncPrivateKey: identity.hostEncPrivateKey,
+      getLocalPort,
+      isActive: () => sessions.get(id) === entry && !entry.released,
+      onActivity: () => { entry.lastActivityAt = Date.now(); },
+      onEstablished: () => establish(entry),
+      onFailure: (code) => closeEntry(entry, 'channel-failure', code),
+      logger: { warn: () => logReason('encrypted-session-failure', id) },
+      failOnIgnoredHandshake: true,
+      batchWindowMs,
+      tunnelOptions: {
+        transportContext: {
+          metadataHeader: null,
+          stripOrigin: true,
+          requestHeaders: { [DIRECT_E2EE_TRANSPORT_HEADER]: internalTransportMarker },
+          wsHeaders: { [DIRECT_E2EE_TRANSPORT_HEADER]: internalTransportMarker },
+        },
+        requestPolicy: requestPolicy(entry),
+        onResponse: ({ generation, status }) => {
+          const purpose = entry.requestPurposes.get(generation);
+          entry.requestPurposes.delete(generation);
+          if (entry.reserved && purpose === 'health' && status === 200 && entry.state === 'preauthenticated') entry.healthSeen = true;
+          if (entry.pairingChecks.delete(generation) && status >= 400) logReason('pairing-rejected', entry.id);
+          const clientId = entry.authChecks.get(generation);
+          entry.authChecks.delete(generation);
+          if (status === 200 && clientId) promote(entry, clientId);
+        },
+        onLimitExceeded: (reason) => closeEntry(entry, reason, RelayCloseCode.ChannelFailure),
+        onStreamClosed: (event) => {
+          entry.authChecks.delete(event.generation);
+          entry.pairingChecks.delete(event.generation);
+          entry.requestPurposes.delete(event.generation);
+          onInnerStreamClosed?.(event);
+        },
+        limits: {
+          maxStreams: limits.maxStreams,
+          maxWebSockets: limits.maxWebSockets,
+          maxIncompleteFragments: limits.maxIncompleteFragments,
+          getMaxIncompleteFragmentBytes: () => entry.state === 'authenticated' ? limits.maxAuthenticatedFragmentBytes : limits.maxPreauthFragmentBytes,
+          maxStreamOpens: limits.maxStreamOpens,
+          streamOpenWindowMs: limits.streamOpenWindowMs,
+        },
+        failClosedPolicy: true,
+      },
+    });
+    for (const [data, isBinary] of entry.pendingFrames.splice(0)) entry.encrypted.receive(data, isBinary);
+  };
+
+  const upgradeHandler = (req, socket, head) => {
+    const rawTarget = req.url;
+    if (rawTarget !== DIRECT_E2EE_PATH) {
+      if (targetsDirectEndpoint(rawTarget)) logReason(rejectUpgrade(socket, '400 Bad Request', 'target-rejected'), 'upgrade');
+      return;
+    }
+    if (!hasValidOriginHeaders(req)) {
+      logReason(rejectUpgrade(socket, '400 Bad Request', 'origin-malformed'), 'upgrade');
+      return;
+    }
+    const profile = getActiveProfile();
+    const hostname = canonicalProfileHostname(profile?.hostname);
+    if (!profile || profile.mode !== 'managed-remote' || profile.directE2eeEnabled !== true || !profile.id || !hostname) {
+      logReason(rejectUpgrade(socket, '404 Not Found', 'profile-inactive'), 'upgrade');
+      return;
+    }
+    if (!validAuthority(req, hostname)) {
+      logReason(rejectUpgrade(socket, '421 Misdirected Request', 'authority-rejected'), 'upgrade');
+      return;
+    }
+    const source = sourceKey(req);
+    const sourcePending = [...sessions.values()].filter((entry) => entry.state === 'pending' && entry.source === source);
+    if (sourcePending.length >= limits.maxPendingPerSource) {
+      closeEntry(sourcePending.sort((a, b) => a.createdAt - b.createdAt)[0], 'source-probation-evicted', 1008);
+    }
+    if (counts().pending >= limits.maxPending) {
+      const oldest = [...sessions.values()].filter((entry) => entry.state === 'pending').sort((a, b) => a.createdAt - b.createdAt)[0];
+      closeEntry(oldest, 'probation-evicted', 1008);
+    }
+    if (counts().total >= limits.maxPending + limits.maxPreauthenticated + limits.reconnectReserve + limits.maxAuthenticated) {
+      logReason(rejectUpgrade(socket, '503 Service Unavailable', 'admission-capacity'), 'upgrade');
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, req);
+      void acceptConnection(ws, { ...profile, source }).catch(() => {
+        try { ws.close(1011, 'direct session unavailable'); } catch { ws.terminate(); }
+        logReason('identity-unavailable', 'upgrade');
+      });
+    });
+  };
+
+  return {
+    attach(httpServer) {
+      if (server) throw new Error('direct E2EE service is already attached');
+      detached = false;
+      server = httpServer;
+      server.on('upgrade', upgradeHandler);
+      return () => this.detach();
+    },
+    detach() {
+      if (!server || detached) return;
+      detached = true;
+      server.off('upgrade', upgradeHandler);
+      server = null;
+      for (const entry of [...sessions.values()]) closeEntry(entry, 'service-detached', 1001);
+      for (const socket of wss.clients) socket.terminate();
+    },
+    closeProfile(profileId, reason = 'profile-disabled') {
+      for (const entry of [...sessions.values()]) if (entry.profileId === profileId) closeEntry(entry, reason, 1001);
+    },
+    closeAll(reason = 'tunnel-stopped') {
+      for (const entry of [...sessions.values()]) closeEntry(entry, reason, 1001);
+    },
+    revokeClient(clientId) {
+      for (const entry of [...(byClient.get(clientId) ?? [])]) closeEntry(entry, 'client-revoked', 1008);
+    },
+    getActiveSessionCount(profileId) {
+      let count = 0;
+      for (const entry of sessions.values()) if (!profileId || entry.profileId === profileId) count += 1;
+      return count;
+    },
+    getCounts: counts,
+    _webSocketServer: wss,
+  };
+};

--- a/packages/web/server/lib/direct-e2ee/service.test.js
+++ b/packages/web/server/lib/direct-e2ee/service.test.js
@@ -12,6 +12,12 @@ afterEach(async () => {
 });
 
 const listen = (server) => new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((onResolve, onReject) => { resolve = onResolve; reject = onReject; });
+  return { promise, resolve, reject };
+};
 
 const fixture = async ({ profile, limits, logs = [], getRelayIdentity } = {}) => {
   const keys = await generateEcdhKeyPair();
@@ -52,6 +58,15 @@ const connect = async (fx, headers = {}) => {
   const ws = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test', ...headers }, perMessageDeflate: false });
   await new Promise((resolve) => ws.once('open', resolve));
   return ws;
+};
+
+const connectTracked = (fx, headers = {}) => {
+  const ws = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test', ...headers }, perMessageDeflate: false });
+  return {
+    ws,
+    opened: new Promise((resolve) => ws.once('open', resolve)),
+    closed: new Promise((resolve) => ws.once('close', resolve)),
+  };
 };
 
 describe('direct E2EE upgrade and lifecycle', () => {
@@ -203,6 +218,83 @@ describe('direct E2EE upgrade and lifecycle', () => {
       clearTimeoutSpy.mockRestore();
       clearIntervalSpy.mockRestore();
     }
+  });
+
+  it('shares one bounded identity attempt, clears timed-out waiters, and caches late success without revival', async () => {
+    const identity = deferred();
+    let identityCalls = 0;
+    const fx = await fixture({
+      getRelayIdentity: () => {
+        identityCalls += 1;
+        return identity.promise;
+      },
+      limits: { identityDeadlineMs: 60, identityRetryCooldownMs: 40, handshakeTimeoutMs: 1_000 },
+    });
+    const first = connectTracked(fx);
+    const second = connectTracked(fx);
+    await Promise.all([first.opened, second.opened]);
+    first.ws.send('first-pending-frame');
+    second.ws.send('second-pending-frame');
+    await Promise.all([first.closed, second.closed]);
+
+    expect(identityCalls).toBe(1);
+    expect(fx.service.getCounts()).toEqual({ pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: 0 });
+    expect(fx.service._getPendingFrameCount()).toBe(0);
+
+    const fastFailure = connectTracked(fx);
+    await fastFailure.opened;
+    await fastFailure.closed;
+    expect(identityCalls).toBe(1);
+
+    identity.resolve({ hostEncPrivateKey: fx.keys.privateKey });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fx.service.getCounts().total).toBe(0);
+
+    const client = await createClientHandshake(await exportPublicKeyJwk(fx.keys.publicKey), { batch: false });
+    const live = await connect(fx);
+    const ready = new Promise((resolve) => live.once('message', (data) => resolve(data.toString())));
+    live.send(client.helloText);
+    expect(JSON.parse(await ready)).toMatchObject({ t: 'ready', v: 1 });
+    expect(identityCalls).toBe(1);
+    live.terminate();
+  });
+
+  it('fails fast during identity rejection cooldown and permits exactly one shared retry', async () => {
+    const firstIdentity = deferred();
+    const retryIdentity = deferred();
+    let identityCalls = 0;
+    const fx = await fixture({
+      getRelayIdentity: () => {
+        identityCalls += 1;
+        return identityCalls === 1 ? firstIdentity.promise : retryIdentity.promise;
+      },
+      limits: { identityDeadlineMs: 1_000, identityRetryCooldownMs: 40, handshakeTimeoutMs: 1_000 },
+    });
+
+    const rejected = connectTracked(fx);
+    await rejected.opened;
+    firstIdentity.reject(new Error('identity backend unavailable'));
+    await rejected.closed;
+    expect(fx.service.getCounts().total).toBe(0);
+
+    const cooldown = connectTracked(fx);
+    await cooldown.opened;
+    await cooldown.closed;
+    expect(identityCalls).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const retryOne = connectTracked(fx);
+    const retryTwo = connectTracked(fx);
+    await Promise.all([retryOne.opened, retryTwo.opened]);
+    const client = await createClientHandshake(await exportPublicKeyJwk(fx.keys.publicKey), { batch: false });
+    const ready = new Promise((resolve) => retryOne.ws.once('message', (data) => resolve(data.toString())));
+    retryOne.ws.send(client.helloText);
+    expect(identityCalls).toBe(2);
+    retryIdentity.resolve({ hostEncPrivateKey: fx.keys.privateKey });
+    expect(JSON.parse(await ready)).toMatchObject({ t: 'ready', v: 1 });
+    expect(identityCalls).toBe(2);
+    retryOne.ws.terminate();
+    retryTwo.ws.terminate();
   });
 
   it('enforces the per-source pending cap by evicting the oldest probation', async () => {

--- a/packages/web/server/lib/direct-e2ee/service.test.js
+++ b/packages/web/server/lib/direct-e2ee/service.test.js
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import http from 'node:http';
+import { WebSocket } from 'ws';
+
+import { createClientHandshake } from '../../../../ui/src/lib/relay/handshake.ts';
+import { exportPublicKeyJwk, generateEcdhKeyPair } from '../relay/e2ee.js';
+import { createDirectE2eeService, DIRECT_E2EE_PATH } from './service.js';
+
+const cleanups = [];
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+const listen = (server) => new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+const fixture = async ({ profile, limits, logs = [] } = {}) => {
+  const keys = await generateEcdhKeyPair();
+  let activeProfile = profile ?? { id: 'profile-1', mode: 'managed-remote', hostname: 'direct.example.test', directE2eeEnabled: true };
+  const origin = http.createServer((_req, res) => res.end('{}'));
+  await listen(origin);
+  const outer = http.createServer((_req, res) => res.end('outer'));
+  const service = createDirectE2eeService({
+    getActiveProfile: () => activeProfile,
+    getRelayIdentity: async () => ({ hostEncPrivateKey: keys.privateKey }),
+    getLocalPort: () => origin.address().port,
+    internalTransportMarker: 'test-process-marker',
+    authenticateBearerToken: async () => null,
+    limits,
+    logger: { warn: (...args) => logs.push(args) },
+  });
+  service.attach(outer);
+  await listen(outer);
+  cleanups.push(() => new Promise((resolve) => { service.detach(); outer.closeAllConnections?.(); outer.close(() => origin.close(resolve)); }));
+  return { service, outer, keys, setProfile: (value) => { activeProfile = value; } };
+};
+
+const mockUpgrade = (server, { path = DIRECT_E2EE_PATH, host = 'direct.example.test', duplicateHost = false, origins = [] } = {}) => {
+  let data = '';
+  const socket = {
+    destroyed: false,
+    write(value, callback) { data += value; callback?.(); },
+    end(value = '') { data += value; },
+  };
+  const rawHeaders = ['Host', host];
+  if (duplicateHost) rawHeaders.push('Host', host);
+  for (const origin of origins) rawHeaders.push('Origin', origin);
+  server.emit('upgrade', { url: path, rawHeaders, headers: { host, ...(origins[0] ? { origin: origins[0] } : {}) } }, socket, Buffer.alloc(0));
+  return data;
+};
+
+const connect = async (fx, headers = {}) => {
+  const ws = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test', ...headers }, perMessageDeflate: false });
+  await new Promise((resolve) => ws.once('open', resolve));
+  return ws;
+};
+
+describe('direct E2EE upgrade and lifecycle', () => {
+  it('rejects inactive profiles and strictly validates authority', async () => {
+    const fx = await fixture({ profile: { id: 'p', mode: 'quick', hostname: 'direct.example.test', directE2eeEnabled: true } });
+    expect(mockUpgrade(fx.outer)).toContain('404 Not Found');
+    fx.setProfile({ id: 'p', mode: 'managed-remote', hostname: 'direct.example.test', directE2eeEnabled: true });
+    for (const host of ['localhost', 'other.example.test', 'direct.example.test.', 'direct.example.test:444', 'dírect.example.test']) {
+      expect(mockUpgrade(fx.outer, { host })).toContain('421 Misdirected Request');
+    }
+    expect(mockUpgrade(fx.outer, { duplicateHost: true })).toContain('421 Misdirected Request');
+    expect(mockUpgrade(fx.outer, { path: `${DIRECT_E2EE_PATH}?token=secret` })).toContain('400 Bad Request');
+  });
+
+  it('fails ignored pre-establishment text immediately and releases pending admission exactly once', async () => {
+    const cases = ['{', JSON.stringify({ t: 'hello', v: 999 }), JSON.stringify({ t: 'ready', v: 1 }), JSON.stringify({ t: 'prohibited', v: 1 }), ''];
+    for (const text of cases) {
+      const fx = await fixture({ limits: { handshakeTimeoutMs: 5_000 } });
+      const ws = await connect(fx);
+      let closes = 0;
+      ws.on('close', () => { closes += 1; });
+      ws.send(text);
+      await new Promise((resolve) => ws.once('close', resolve));
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(closes).toBe(1);
+      expect(fx.service.getCounts()).toEqual({ pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: 0 });
+    }
+  });
+
+  it('accepts an identical valid hello retry and repeats readiness without rekeying', async () => {
+    const fx = await fixture();
+    const client = await createClientHandshake(await exportPublicKeyJwk(fx.keys.publicKey), { batch: false });
+    const ws = await connect(fx);
+    const replies = [];
+    ws.on('message', (data, binary) => { if (!binary) replies.push(data.toString()); });
+    ws.send(client.helloText);
+    while (replies.length < 1) await new Promise((resolve) => setTimeout(resolve, 5));
+    ws.send(client.helloText);
+    while (replies.length < 2) await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(replies[1]).toBe(replies[0]);
+    expect(fx.service.getCounts()).toMatchObject({ pending: 0, preauthenticated: 1 });
+    ws.terminate();
+  });
+
+  it('accepts browser and WebView Origin metadata without using it for authorization', async () => {
+    for (const origin of ['http://127.0.0.1:5180', 'capacitor://localhost', 'openchamber-ui://app', 'null']) {
+      const fx = await fixture();
+      const client = await createClientHandshake(await exportPublicKeyJwk(fx.keys.publicKey), { batch: false });
+      const ws = await connect(fx, { Origin: origin });
+      const ready = new Promise((resolve) => ws.once('message', (data) => resolve(data.toString())));
+      ws.send(client.helloText);
+      expect(JSON.parse(await ready)).toMatchObject({ t: 'ready', v: 1 });
+      expect(fx.service.getCounts().preauthenticated).toBe(1);
+      ws.terminate();
+    }
+  });
+
+  it('rejects duplicate or control-bearing Origin headers without weakening authority checks', async () => {
+    const fx = await fixture();
+    expect(mockUpgrade(fx.outer, { origins: ['https://one.test', 'https://two.test'] })).toContain('400 Bad Request');
+    expect(mockUpgrade(fx.outer, { origins: ['https://good.test\r\nInjected: yes'] })).toContain('400 Bad Request');
+    expect(mockUpgrade(fx.outer, { host: 'other.example.test', origins: ['https://good.test'] })).toContain('421 Misdirected Request');
+  });
+
+  it('handles only the exact raw origin-form target and rejects related normalized aliases', async () => {
+    const fx = await fixture();
+    const related = [
+      `${DIRECT_E2EE_PATH}?`, `${DIRECT_E2EE_PATH}#fragment`, `${DIRECT_E2EE_PATH}/`,
+      '/api/openchamber/x/../direct-e2ee/ws', '/api/openchamber/x/%2e%2e/direct-e2ee/ws',
+      '/api/openchamber/direct-e2ee%2fws', `http://direct.example.test${DIRECT_E2EE_PATH}`,
+    ];
+    for (const target of related) expect(mockUpgrade(fx.outer, { path: target })).toMatch(/400 Bad Request|404 Not Found/);
+    let fallback = 0;
+    const listener = (_req, socket) => { fallback += 1; socket.end('HTTP/1.1 418 Teapot\r\nContent-Length: 0\r\n\r\n'); };
+    fx.outer.on('upgrade', listener);
+    expect(mockUpgrade(fx.outer, { path: '/unrelated/ws' })).toContain('418 Teapot');
+    expect(fallback).toBe(1);
+    fx.outer.off('upgrade', listener);
+  });
+
+  it('ignores other upgrade paths and detach removes ownership', async () => {
+    const fx = await fixture();
+    let fallback = 0;
+    const handler = (req, socket) => {
+      if (req.url === '/other') { fallback += 1; socket.end('HTTP/1.1 418 Teapot\r\nContent-Length: 0\r\n\r\n'); }
+    };
+    fx.outer.on('upgrade', handler);
+    expect(mockUpgrade(fx.outer, { path: '/other' })).toContain('418 Teapot');
+    expect(fallback).toBe(1);
+    fx.outer.off('upgrade', handler);
+    fx.service.detach();
+  });
+
+  it('releases pending accounting exactly once and closes profile sessions', async () => {
+    const fx = await fixture({ limits: { handshakeTimeoutMs: 30 } });
+    const ws = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test' }, perMessageDeflate: false });
+    await new Promise((resolve) => ws.once('open', resolve));
+    expect(fx.service.getCounts().pending).toBe(1);
+    fx.service.closeProfile('profile-1');
+    await new Promise((resolve) => ws.once('close', resolve));
+    expect(fx.service.getCounts()).toEqual({ pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: 0 });
+    fx.service.closeProfile('profile-1');
+    expect(fx.service.getActiveSessionCount()).toBe(0);
+  });
+
+  it('enforces the per-source pending cap by evicting the oldest probation', async () => {
+    const fx = await fixture({ limits: { maxPending: 4, maxPendingPerSource: 1, handshakeTimeoutMs: 5_000 } });
+    const first = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test' }, perMessageDeflate: false });
+    await new Promise((resolve) => first.once('open', resolve));
+    const firstClosed = new Promise((resolve) => first.once('close', resolve));
+    const second = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test' }, perMessageDeflate: false });
+    await new Promise((resolve) => second.once('open', resolve));
+    await firstClosed;
+    expect(fx.service.getCounts()).toMatchObject({ pending: 1, total: 1 });
+    second.terminate();
+  });
+
+  it('uses noServer with compression disabled and reason-only logs', async () => {
+    const logs = [];
+    const fx = await fixture({ logs });
+    expect(fx.service._webSocketServer.options.noServer).toBe(true);
+    expect(fx.service._webSocketServer.options.perMessageDeflate).toBe(false);
+    mockUpgrade(fx.outer, { path: `${DIRECT_E2EE_PATH}?bearer=do-not-log-me` });
+    expect(JSON.stringify(logs)).not.toContain('do-not-log-me');
+  });
+
+  it('supports injected profile disable, stop, and switch lifecycle hooks', async () => {
+    const fx = await fixture();
+    const lifecycle = {
+      disable: (id) => fx.service.closeProfile(id, 'profile-disabled'),
+      stop: () => fx.service.closeAll('tunnel-stopped'),
+      switch: (oldId) => fx.service.closeProfile(oldId, 'profile-switched'),
+      revoke: (clientId) => fx.service.revokeClient(clientId),
+    };
+    const connect = async () => {
+      const ws = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, { headers: { Host: 'direct.example.test' }, perMessageDeflate: false });
+      await new Promise((resolve) => ws.once('open', resolve));
+      return ws;
+    };
+    for (const action of [() => lifecycle.disable('profile-1'), lifecycle.stop, () => lifecycle.switch('profile-1')]) {
+      const ws = await connect();
+      action();
+      await new Promise((resolve) => ws.once('close', resolve));
+      expect(fx.service.getCounts().total).toBe(0);
+    }
+    lifecycle.revoke('unbound-client');
+    expect(fx.service.getCounts().total).toBe(0);
+  });
+
+  it('never logs attacker-controlled handshake, header, cookie, payload, key-like, or line-injection values', async () => {
+    const logs = [];
+    const fx = await fixture({ logs });
+    const secrets = [
+      'bearer-secret', 'cookie-secret', 'payload-secret', 'private-key-secret',
+      'header-secret', 'crlf-secret\r\nforged-record', 'unicode-secret\u2028forged', 'unicode-secret-2\u2029forged',
+    ];
+    mockUpgrade(fx.outer, { path: `${DIRECT_E2EE_PATH}?token=${encodeURIComponent(secrets.join('|'))}` });
+    const ws = new WebSocket(`ws://127.0.0.1:${fx.outer.address().port}${DIRECT_E2EE_PATH}`, {
+      headers: { Host: 'direct.example.test', Authorization: `Bearer ${secrets[0]}`, Cookie: `x=${secrets[1]}`, 'X-Attacker': secrets[4] },
+      perMessageDeflate: false,
+    });
+    await new Promise((resolve) => ws.once('open', resolve));
+    ws.send(JSON.stringify({ t: 'hello', payload: secrets[2], privateJwk: { d: secrets[3] }, lines: secrets.slice(5) }));
+    ws.send(Buffer.from(secrets.join('|')));
+    await new Promise((resolve) => ws.once('close', resolve));
+    const serialized = JSON.stringify(logs);
+    for (const secret of secrets) expect(serialized).not.toContain(secret);
+    for (const entry of logs) {
+      expect(entry[0]).toBe('[DirectE2EE]');
+      expect(Object.keys(entry[1]).sort()).toEqual(['connectionId', 'reason']);
+      expect(entry[1].reason).toMatch(/^[a-z-]+$/);
+    }
+  });
+});

--- a/packages/web/server/lib/direct-e2ee/service.test.js
+++ b/packages/web/server/lib/direct-e2ee/service.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 import http from 'node:http';
 import { WebSocket } from 'ws';
 
@@ -13,7 +13,7 @@ afterEach(async () => {
 
 const listen = (server) => new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
 
-const fixture = async ({ profile, limits, logs = [] } = {}) => {
+const fixture = async ({ profile, limits, logs = [], getRelayIdentity } = {}) => {
   const keys = await generateEcdhKeyPair();
   let activeProfile = profile ?? { id: 'profile-1', mode: 'managed-remote', hostname: 'direct.example.test', directE2eeEnabled: true };
   const origin = http.createServer((_req, res) => res.end('{}'));
@@ -21,7 +21,7 @@ const fixture = async ({ profile, limits, logs = [] } = {}) => {
   const outer = http.createServer((_req, res) => res.end('outer'));
   const service = createDirectE2eeService({
     getActiveProfile: () => activeProfile,
-    getRelayIdentity: async () => ({ hostEncPrivateKey: keys.privateKey }),
+    getRelayIdentity: getRelayIdentity ?? (async () => ({ hostEncPrivateKey: keys.privateKey })),
     getLocalPort: () => origin.address().port,
     internalTransportMarker: 'test-process-marker',
     authenticateBearerToken: async () => null,
@@ -155,6 +155,54 @@ describe('direct E2EE upgrade and lifecycle', () => {
     expect(fx.service.getCounts()).toEqual({ pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: 0 });
     fx.service.closeProfile('profile-1');
     expect(fx.service.getActiveSessionCount()).toBe(0);
+  });
+
+  it('releases admission immediately when relay identity initialization fails', async () => {
+    const identityError = new Error('sensitive identity backend detail');
+    const logs = [];
+    const fx = await fixture({
+      logs,
+      getRelayIdentity: async () => { throw identityError; },
+      limits: { handshakeTimeoutMs: 25, idleTimeoutMs: 25 },
+    });
+    const closes = [];
+    const socket = {
+      readyState: WebSocket.OPEN,
+      on: () => socket,
+      once: () => socket,
+      close: (code, reason) => {
+        closes.push({ code, reason });
+        socket.readyState = WebSocket.CLOSING;
+      },
+      terminate: () => { socket.readyState = WebSocket.CLOSED; },
+    };
+    fx.service._webSocketServer.handleUpgrade = (_req, _rawSocket, _head, accept) => accept(socket);
+    const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
+    const clearIntervalSpy = spyOn(globalThis, 'clearInterval');
+
+    try {
+      mockUpgrade(fx.outer);
+      for (let attempt = 0; attempt < 10 && logs.length < 2; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      expect(fx.service.getCounts()).toEqual({ pending: 0, preauthenticated: 0, authenticated: 0, reserved: 0, total: 0 });
+      expect(closes).toEqual([{ code: 1011, reason: 'direct session closed' }]);
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      expect(logs).toEqual([
+        ['[DirectE2EE]', { reason: 'identity-unavailable', connectionId: expect.any(String) }],
+        ['[DirectE2EE]', { reason: 'identity-unavailable', connectionId: 'upgrade' }],
+      ]);
+      expect(JSON.stringify(logs)).not.toContain(identityError.message);
+
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      expect(closes).toHaveLength(1);
+      expect(logs).toHaveLength(2);
+    } finally {
+      clearTimeoutSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
   });
 
   it('enforces the per-source pending cap by evicting the oldest probation', async () => {

--- a/packages/web/server/lib/direct-e2ee/service.test.js
+++ b/packages/web/server/lib/direct-e2ee/service.test.js
@@ -19,7 +19,7 @@ const deferred = () => {
   return { promise, resolve, reject };
 };
 
-const fixture = async ({ profile, limits, logs = [], getRelayIdentity } = {}) => {
+const fixture = async ({ profile, limits, logs = [], getRelayIdentity, abandonPendingRelayIdentity } = {}) => {
   const keys = await generateEcdhKeyPair();
   let activeProfile = profile ?? { id: 'profile-1', mode: 'managed-remote', hostname: 'direct.example.test', directE2eeEnabled: true };
   const origin = http.createServer((_req, res) => res.end('{}'));
@@ -28,6 +28,7 @@ const fixture = async ({ profile, limits, logs = [], getRelayIdentity } = {}) =>
   const service = createDirectE2eeService({
     getActiveProfile: () => activeProfile,
     getRelayIdentity: getRelayIdentity ?? (async () => ({ hostEncPrivateKey: keys.privateKey })),
+    abandonPendingRelayIdentity,
     getLocalPort: () => origin.address().port,
     internalTransportMarker: 'test-process-marker',
     authenticateBearerToken: async () => null,
@@ -220,15 +221,19 @@ describe('direct E2EE upgrade and lifecycle', () => {
     }
   });
 
-  it('shares one bounded identity attempt, clears timed-out waiters, and caches late success without revival', async () => {
-    const identity = deferred();
+  it('retires a timed-out identity generation after cooldown and ignores its late success', async () => {
+    const firstIdentity = deferred();
+    const retryIdentity = deferred();
+    const staleKeys = await generateEcdhKeyPair();
     let identityCalls = 0;
+    let resetCalls = 0;
     const fx = await fixture({
       getRelayIdentity: () => {
         identityCalls += 1;
-        return identity.promise;
+        return identityCalls === 1 ? firstIdentity.promise : retryIdentity.promise;
       },
-      limits: { identityDeadlineMs: 60, identityRetryCooldownMs: 40, handshakeTimeoutMs: 1_000 },
+      abandonPendingRelayIdentity: () => { resetCalls += 1; return true; },
+      limits: { identityDeadlineMs: 30, identityRetryCooldownMs: 20, handshakeTimeoutMs: 1_000 },
     });
     const first = connectTracked(fx);
     const second = connectTracked(fx);
@@ -245,18 +250,60 @@ describe('direct E2EE upgrade and lifecycle', () => {
     await fastFailure.opened;
     await fastFailure.closed;
     expect(identityCalls).toBe(1);
+    expect(resetCalls).toBe(0);
 
-    identity.resolve({ hostEncPrivateKey: fx.keys.privateKey });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(fx.service.getCounts().total).toBe(0);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const retryOne = connectTracked(fx);
+    const retryTwo = connectTracked(fx);
+    await Promise.all([retryOne.opened, retryTwo.opened]);
+    expect(identityCalls).toBe(2);
+    expect(resetCalls).toBe(1);
 
     const client = await createClientHandshake(await exportPublicKeyJwk(fx.keys.publicKey), { batch: false });
-    const live = await connect(fx);
-    const ready = new Promise((resolve) => live.once('message', (data) => resolve(data.toString())));
-    live.send(client.helloText);
+    const ready = new Promise((resolve) => retryOne.ws.once('message', (data) => resolve(data.toString())));
+    retryOne.ws.send(client.helloText);
+    retryIdentity.resolve({ hostEncPrivateKey: fx.keys.privateKey });
     expect(JSON.parse(await ready)).toMatchObject({ t: 'ready', v: 1 });
-    expect(identityCalls).toBe(1);
+    firstIdentity.resolve({ hostEncPrivateKey: staleKeys.privateKey });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    retryOne.ws.terminate();
+    retryTwo.ws.terminate();
+    const cachedClient = await createClientHandshake(await exportPublicKeyJwk(fx.keys.publicKey), { batch: false });
+    const live = await connect(fx);
+    const cachedReady = new Promise((resolve) => live.once('message', (data) => resolve(data.toString())));
+    live.send(cachedClient.helloText);
+    expect(JSON.parse(await cachedReady)).toMatchObject({ t: 'ready', v: 1 });
+    expect(identityCalls).toBe(2);
+    expect(resetCalls).toBe(1);
     live.terminate();
+  });
+
+  it('bounds repeated identity timeouts to one getter and reset per generation', async () => {
+    const identities = Array.from({ length: 4 }, deferred);
+    let identityCalls = 0;
+    let resetCalls = 0;
+    const fx = await fixture({
+      getRelayIdentity: () => identities[identityCalls++].promise,
+      abandonPendingRelayIdentity: () => { resetCalls += 1; return true; },
+      limits: { identityDeadlineMs: 15, identityRetryCooldownMs: 10, handshakeTimeoutMs: 1_000 },
+    });
+
+    for (let generation = 0; generation < 3; generation += 1) {
+      const first = connectTracked(fx);
+      const second = connectTracked(fx);
+      await Promise.all([first.opened, second.opened]);
+      await Promise.all([first.closed, second.closed]);
+      expect(identityCalls).toBe(generation + 1);
+      expect(resetCalls).toBe(generation);
+      await new Promise((resolve) => setTimeout(resolve, 15));
+    }
+
+    const fourth = connectTracked(fx);
+    await fourth.opened;
+    expect(identityCalls).toBe(4);
+    expect(resetCalls).toBe(3);
+    await fourth.closed;
   });
 
   it('fails fast during identity rejection cooldown and permits exactly one shared retry', async () => {

--- a/packages/web/server/lib/direct-e2ee/service.test.js
+++ b/packages/web/server/lib/direct-e2ee/service.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { afterEach, describe, expect, it, vi } from 'bun:test';
 import http from 'node:http';
 import { WebSocket } from 'ws';
 
@@ -19,7 +19,7 @@ const deferred = () => {
   return { promise, resolve, reject };
 };
 
-const fixture = async ({ profile, limits, logs = [], getRelayIdentity, abandonPendingRelayIdentity } = {}) => {
+const fixture = async ({ profile, limits, logs = [], logger, getRelayIdentity, abandonPendingRelayIdentity } = {}) => {
   const keys = await generateEcdhKeyPair();
   let activeProfile = profile ?? { id: 'profile-1', mode: 'managed-remote', hostname: 'direct.example.test', directE2eeEnabled: true };
   const origin = http.createServer((_req, res) => res.end('{}'));
@@ -33,7 +33,7 @@ const fixture = async ({ profile, limits, logs = [], getRelayIdentity, abandonPe
     internalTransportMarker: 'test-process-marker',
     authenticateBearerToken: async () => null,
     limits,
-    logger: { warn: (...args) => logs.push(args) },
+    logger: logger ?? { warn: (...args) => logs.push(args) },
   });
   service.attach(outer);
   await listen(outer);
@@ -67,6 +67,30 @@ const connectTracked = (fx, headers = {}) => {
     ws,
     opened: new Promise((resolve) => ws.once('open', resolve)),
     closed: new Promise((resolve) => ws.once('close', resolve)),
+  };
+};
+
+const createCleanupSocket = ({ throws = false } = {}) => {
+  const handlers = new Map();
+  return {
+    readyState: WebSocket.OPEN,
+    closed: false,
+    on(event, handler) { handlers.set(event, handler); return this; },
+    once(event, handler) { handlers.set(event, handler); return this; },
+    off(event) {
+      handlers.delete(event);
+      if (throws) throw new Error('socket cleanup detail');
+      return this;
+    },
+    close() {
+      this.closed = true;
+      if (throws) throw new Error('socket close detail');
+      this.readyState = WebSocket.CLOSED;
+    },
+    terminate() {
+      this.closed = true;
+      this.readyState = WebSocket.CLOSED;
+    },
   };
 };
 
@@ -193,8 +217,8 @@ describe('direct E2EE upgrade and lifecycle', () => {
       terminate: () => { socket.readyState = WebSocket.CLOSED; },
     };
     fx.service._webSocketServer.handleUpgrade = (_req, _rawSocket, _head, accept) => accept(socket);
-    const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
-    const clearIntervalSpy = spyOn(globalThis, 'clearInterval');
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
 
     try {
       mockUpgrade(fx.outer);
@@ -386,6 +410,30 @@ describe('direct E2EE upgrade and lifecycle', () => {
     }
     lifecycle.revoke('unbound-client');
     expect(fx.service.getCounts().total).toBe(0);
+  });
+
+  it('isolates logger and socket cleanup failures while releasing every matching session', async () => {
+    for (const action of ['profile', 'all']) {
+      const pendingIdentity = deferred();
+      const fx = await fixture({
+        getRelayIdentity: () => pendingIdentity.promise,
+        logger: { warn: () => { throw new Error('logger cleanup detail'); } },
+      });
+      const throwingSocket = createCleanupSocket({ throws: true });
+      const healthySocket = createCleanupSocket();
+      const sockets = [throwingSocket, healthySocket];
+      fx.service._webSocketServer.handleUpgrade = (_req, _rawSocket, _head, accept) => accept(sockets.shift());
+
+      mockUpgrade(fx.outer);
+      mockUpgrade(fx.outer);
+      expect(fx.service.getCounts().total).toBe(2);
+      expect(() => {
+        if (action === 'profile') fx.service.closeProfile('profile-1', 'profile-disabled');
+        else fx.service.closeAll('tunnel-stopped');
+      }).not.toThrow();
+      expect(fx.service.getCounts().total).toBe(0);
+      expect(healthySocket.closed).toBe(true);
+    }
   });
 
   it('never logs attacker-controlled handshake, header, cookie, payload, key-like, or line-injection values', async () => {

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -34,6 +34,7 @@ This module provides OpenCode server integration utilities for the web server ru
 - `packages/web/server/lib/opencode/project-icon-routes.js`: project icon upload/read/discovery route registration and icon storage orchestration.
 - `packages/web/server/lib/opencode/skill-routes.js`: route registration for skill config CRUD, supporting files, and skills catalog scan/install flows.
 - `packages/web/server/lib/opencode/settings-runtime.js`: Settings persistence runtime (disk IO, migrations, normalization, project validation, and persisted update serialization).
+  Settings replacement is atomic, cleans failed temporary files, and enforces owner-only `0600` files on POSIX. Only the default app-owned data directory is created with private directory mode; custom data roots are not chmod-ed.
 - `packages/web/server/lib/opencode/settings-helpers.js`: Settings payload sanitization/format helpers runtime for response shaping and persisted merge prep.
 - `packages/web/server/lib/opencode/settings-normalization-runtime.js`: path/settings/tunnel normalization and sanitization helpers runtime used by settings/routes/config wiring.
 - `packages/web/server/lib/opencode/theme-runtime.js`: custom theme JSON validation and theme directory loading runtime for settings utility routes.

--- a/packages/web/server/lib/opencode/tunnel-auth.js
+++ b/packages/web/server/lib/opencode/tunnel-auth.js
@@ -2,6 +2,9 @@ import crypto from 'crypto';
 
 const BOOTSTRAP_TOKEN_COOKIE_SAFE_BYTES = 32;
 const TUNNEL_SESSION_COOKIE_NAME = 'oc_tunnel_session';
+export const DIRECT_E2EE_TRANSPORT_HEADER = 'x-openchamber-internal-transport';
+
+export const createInternalTransportMarker = () => crypto.randomBytes(32).toString('base64url');
 
 const CONNECT_RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000;
 const CONNECT_RATE_LIMIT_LOCK_MS = 10 * 60 * 1000;
@@ -213,7 +216,7 @@ const rateLimitMaxForKey = (key) => {
   return CONNECT_RATE_LIMIT_MAX_ATTEMPTS;
 };
 
-export const createTunnelAuth = () => {
+export const createTunnelAuth = ({ internalRemoteClientMarker = null } = {}) => {
   let activeTunnelId = null;
   let activeTunnelHost = null;
   let activeTunnelMode = null;
@@ -247,6 +250,12 @@ export const createTunnelAuth = () => {
   };
 
   const classifyRequestScope = (req) => {
+    const marker = req?.headers?.[DIRECT_E2EE_TRANSPORT_HEADER];
+    if (internalRemoteClientMarker && typeof marker === 'string') {
+      const actual = Buffer.from(marker);
+      const expected = Buffer.from(internalRemoteClientMarker);
+      if (actual.length === expected.length && crypto.timingSafeEqual(actual, expected)) return 'remote-client';
+    }
     const hostHeader = normalizeHost(typeof req.headers.host === 'string' ? req.headers.host : '');
     const reqHost = normalizeHost(typeof req.hostname === 'string' ? req.hostname : '') || hostHeader;
 

--- a/packages/web/server/lib/relay/DOCUMENTATION.md
+++ b/packages/web/server/lib/relay/DOCUMENTATION.md
@@ -20,11 +20,16 @@ Traffic is modeled as three stacked layers. The relay understands only Layer 1; 
 
 Host side (`packages/web/server/lib/relay/`):
 - `service.js` — thin entrypoint: relay config (enabled flag + relay URL), the management routes (`GET/POST /api/openchamber/relay/{status,enable,disable}`), a `getPairingCandidate()` accessor (the relay transport candidate folded into pairing-v2 links when enabled, consumed by the pairing-session route in `core-routes.js`), and lifecycle wiring. Started from `packages/web/server/index.js` only when the user has explicitly enabled the relay. The relay endpoint defaults to the OpenChamber-hosted relay but can be pinned to a self-hosted relay via the `OPENCHAMBER_RELAY_URL` env var (must be `ws://`/`wss://`); when set it overrides the stored setting for the host connection, the pairing candidate, and status, so paired clients inherit the endpoint automatically.
-- `identity.js` — the host's stable identity: the long-lived signing keypair (shared with the push relay, defines the routing id) plus a long-lived encryption keypair (the E2EE trust anchor). Reused across restarts; never rotated implicitly.
+- `identity.js` — the host's stable identity: the long-lived signing keypair (shared with the push relay, defines the routing id) plus a long-lived encryption keypair (the E2EE trust anchor).
+  The valid persisted private encryption JWK is authoritative: startup validates its P-256 point,
+  derives the emitted `{kty, crv, x, y}` public representation from it,
+  and repairs missing, mismatched, or over-specified public copies without rotating valid private material.
+  Invalid private material is replaced, and candidates never emit `d` or stored public-JWK extras.
 - `signing-key.js` — storage/derivation of the signing keypair and the routing id, shared with the notifications runtime.
-- `host-client.js` — the long-lived connection manager: one outbound control connection to the relay, a per-client data connection for each connected device, reconnect/backoff, and the E2EE responder handshake per connection.
+- `host-client.js` — the hosted-relay connection manager: one outbound control connection, signed broker URLs, per-client data-socket lifecycle, reconnect/backoff, idle reaping, and status.
+- `encrypted-session.js` — the transport-neutral per-outer-socket E2EE responder session: handshake, serialized decrypt/encrypt counters, negotiated batching, and ownership of one tunnel dispatcher. It does not own broker reconnect or admission policy.
 - `host-lock.js` — the per-machine host claim. Every local instance sharing the data dir shares the relay identity (same serverId), so concurrent relay hosts evict each other at the relay worker (`4001: Control replaced`) and paired devices land on whichever local process won last. The claim file (`<data-dir>/relay-host.lock`, `{ pid }`) makes this deterministic: `service.js` only starts the host when no LIVE process holds the claim (stale claims from dead pids are ignored), goes to `standby` otherwise, and a 30s watcher both takes over when the claimant dies and stands down when another process claims. Explicit user intent — creating a pairing link or hitting `/relay/enable` — force-claims; the previous holder's watcher sees the takeover and backs off instead of fighting. The claim is cooperative (the relay worker still enforces the single host slot); it only decides which process keeps retrying.
-- `tunnel-host.js` — the per-connection dispatcher: decrypts tunnel frames and forwards HTTP/SSE/WS to the local server over loopback, then streams responses back. Enforces a path allowlist and never injects credentials.
+- `tunnel-host.js` — the per-connection dispatcher: forwards decrypted HTTP/SSE/WS to the local server over loopback, then streams responses back. Enforces path allowlists, strips untrusted forwarding/Cloudflare/internal headers, and supports optional transport context, policy hooks, and bounded per-session limits. Omitted options retain hosted-relay behavior; it never injects credentials.
 - `e2ee.js`, `tunnel-codec.js` — host-side (JS) mirrors of the shared crypto and framing (see "Two implementations" below).
 
 Client side (`packages/ui/src/lib/relay/`):
@@ -44,6 +49,14 @@ Everything a client normally sends to the single OpenChamber origin:
 - **WebSocket** — the endpoints that use a real socket (the global event stream on platforms that support WS, terminal I/O, dictation).
 
 The host dispatcher restricts tunneled traffic to explicit path allowlists (one for HTTP, one for WS).
+It canonicalizes each request target before allowlist checks and uses that same
+target for loopback dispatch. Fragment assembly is limited to open nested
+WebSockets, supports aggregate byte budgets, and is cleared on stream/session
+teardown. Outbound fragments for each nested WebSocket are serialized through
+backpressure waits so upstream messages cannot interleave; send-chain failure is
+terminal and drops the affected stream. Direct E2EE supplies a live fragment-byte
+budget that changes on authenticated promotion and enables
+terminal fail-closed policy; hosted-relay stream-local rejection remains compatible.
 
 ## Authentication model
 
@@ -58,7 +71,7 @@ The host dispatcher restricts tunneled traffic to explicit path allowlists (one 
 2. **Presence.** When the relay is enabled, the host opens one outbound control connection and waits.
 3. **Connect.** The client connects for a given routing id; the relay notifies the host over the control connection; the host opens a matching per-client data connection.
 4. **Handshake.** Over that connection pair, client and host run the E2EE handshake and derive a shared encrypted channel the relay cannot read.
-5. **Traffic.** All normal app traffic is multiplexed and encrypted through that channel. On the host, decrypted requests are dispatched to the local server over loopback; responses stream back encrypted. Reconnects re-establish a fresh channel and the app's existing retry machinery recovers.
+5. **Readiness and traffic.** Hosted relay channels retain their existing behavior. A direct-E2EE runtime channel is kept private after every initial handshake and reconnect while the client verifies strict OpenChamber `/health` identity, then promotes that exact encrypted session with bearer-authenticated `GET /auth/session`. Only after both checks succeed does the client publish `connected`, release queued HTTP/WS work, mint URL tokens, or start keepalive. Invalid/revoked bearer credentials and protocol/identity failures are terminal; readiness/network failures retry with backoff. Normal traffic is then multiplexed and encrypted through the promoted channel.
 
 ## Candidate refresh (staying off the relay when direct works)
 
@@ -85,7 +98,7 @@ The E2EE and framing logic exists twice: TypeScript in `packages/ui/src/lib/rela
 
 ## Runtime integration (client)
 
-Relay mode plugs into the existing client transport layer rather than a parallel path: `runtime-switch` activates the tunnel singleton, `runtime-fetch` routes runtime requests through it, `runtime-url`/`runtime-socket` yield tunnel-backed URLs and sockets, and `runtime-auth` mints the URL-scoped token through the tunnel. Direct-URL connections and the Electron realtime-proxy path are unaffected.
+Relay mode plugs into the existing client transport layer rather than a parallel path: `runtime-switch` activates the tunnel singleton, `runtime-fetch` routes runtime requests through it, `runtime-url`/`runtime-socket` yield tunnel-backed URLs and sockets, and `runtime-auth` mints the URL-scoped token through the tunnel. Direct-E2EE activation passes the bearer token separately from its public descriptor so credentials never enter candidate metadata or URLs. Direct-URL connections and the Electron realtime-proxy path are unaffected.
 
 ## Design invariants (do not regress)
 
@@ -94,5 +107,8 @@ Relay mode plugs into the existing client transport layer rather than a parallel
 - The host dispatcher never injects credentials; the server authenticates each tunneled request.
 - The tunnel is transparent to the app: adding relay support to a feature should not require the feature to know the relay exists — it goes through the shared runtime transport helpers.
 - The two implementations stay byte-compatible and the wire format is versioned/negotiated so mixed client/host app versions degrade gracefully rather than break.
+- Hosted relay keeps the shared handshake's legacy pre-establishment ignore behavior.
+  Direct E2EE enables an encrypted-session policy seam that terminal-fails ignored
+  pre-establishment text without changing handshake bytes or hosted-relay behavior.
 
 For the operational rules that keep future changes (new WebSocket endpoints, transport refactors, terminal/voice porting) from breaking this, load the `relay-transport` skill.

--- a/packages/web/server/lib/relay/DOCUMENTATION.md
+++ b/packages/web/server/lib/relay/DOCUMENTATION.md
@@ -58,6 +58,18 @@ terminal and drops the affected stream. Direct E2EE supplies a live fragment-byt
 budget that changes on authenticated promotion and enables
 terminal fail-closed policy; hosted-relay stream-local rejection remains compatible.
 
+### Completed HTTP stream tombstones
+
+When a loopback HTTP response completes before the client finishes uploading its
+request body, the host retains a bounded tombstone for the completed stream ID.
+The default lifetime is 5 seconds, with at most 256 tombstones per outer session;
+expired entries are pruned and the oldest entry is evicted when the capacity is
+full. A body-capable tombstone accepts at most 32 expected late body frames totaling
+at most 1 MiB, and a matching `StreamEnd` consumes it. Body frames for bodyless
+requests, frames beyond either bound, unknown IDs, and reuse of a tombstoned stream
+ID are fatal protocol errors. These bounds tolerate only expected in-flight late
+frames and do not permit a completed stream to be reopened or used indefinitely.
+
 ## Authentication model
 
 - The tunnel is **transport only**. The OpenChamber server still authenticates every tunneled request exactly as it authenticates a direct remote client. The relay path grants reachability, not authorization.

--- a/packages/web/server/lib/relay/encrypted-session.js
+++ b/packages/web/server/lib/relay/encrypted-session.js
@@ -1,0 +1,148 @@
+import { WebSocket } from 'ws';
+
+import { RelayCloseCode, createHostHandshake } from './e2ee.js';
+import { createOutboundFrameBatcher, decodeFrameBatch } from './tunnel-codec.js';
+import { createTunnelHost } from './tunnel-host.js';
+
+/**
+ * Owns one transport-neutral responder handshake and encrypted tunnel session.
+ * The caller retains outer-socket lifecycle and admission accounting ownership.
+ *
+ * @param {{
+ *   socket: WebSocket,
+ *   connectionId: string,
+ *   hostEncPrivateKey: CryptoKey,
+ *   getLocalPort: () => number,
+ *   isActive?: () => boolean,
+ *   onActivity?: () => void,
+ *   onEstablished?: () => void,
+ *   onFailure: (closeCode: number, reason: string) => void,
+ *   logger?: Pick<Console, 'warn'>,
+ *   batch?: boolean,
+ *   failOnIgnoredHandshake?: boolean,
+ *   batchWindowMs: number,
+ *   tunnelOptions?: object,
+ * }} options
+ */
+export const createEncryptedSession = ({
+  socket,
+  connectionId,
+  hostEncPrivateKey,
+  getLocalPort,
+  isActive = () => true,
+  onActivity,
+  onEstablished,
+  onFailure,
+  logger = console,
+  batch = true,
+  failOnIgnoredHandshake = false,
+  batchWindowMs,
+  tunnelOptions = {},
+}) => {
+  const handshake = createHostHandshake(hostEncPrivateKey, { batch });
+  let channel = null;
+  let tunnel = null;
+  let batcher = null;
+  let batchNegotiated = false;
+  let processing = Promise.resolve();
+  let sendChain = Promise.resolve();
+  let closed = false;
+
+  const fail = (closeCode, reason) => {
+    if (closed) return;
+    closed = true;
+    batcher?.dispose();
+    tunnel?.close();
+    onFailure(closeCode, reason);
+  };
+
+  const sendEncryptedPlaintext = (plaintext) => {
+    sendChain = sendChain
+      .then(async () => {
+        if (closed || !isActive() || socket.readyState !== WebSocket.OPEN || !channel) return;
+        const encrypted = await channel.encryptor.encrypt(plaintext);
+        socket.send(encrypted, { binary: true });
+      })
+      .catch((error) => {
+        logger.warn(`[Relay] encrypted session send failed: ${error?.message ?? error}`);
+      });
+  };
+
+  const handleMessage = async (data, isBinary) => {
+    if (closed || !isActive()) return;
+    onActivity?.();
+
+    if (!isBinary) {
+      const action = await handshake.handleText(data.toString('utf8'));
+      if (action.type === 'ignore' && failOnIgnoredHandshake) {
+        fail(RelayCloseCode.ChannelFailure, 'invalid handshake');
+      } else if (action.type === 'send-text') socket.send(action.text);
+      else if (action.type === 'established') {
+        channel = action.channel;
+        batchNegotiated = action.batch === true;
+        batcher = batchNegotiated
+          ? createOutboundFrameBatcher({ windowMs: batchWindowMs, sendBatch: sendEncryptedPlaintext })
+          : null;
+        tunnel = createTunnelHost({
+          connectionId,
+          getLocalPort,
+          getBufferedAmount: () => socket.bufferedAmount,
+          sendFrame: (plaintextFrame) => {
+            if (closed || !isActive() || socket.readyState !== WebSocket.OPEN) return;
+            if (batcher) batcher.enqueue(plaintextFrame);
+            else sendEncryptedPlaintext(plaintextFrame);
+          },
+          onProtocolFailure: () => fail(RelayCloseCode.ChannelFailure, 'protocol failure'),
+          ...tunnelOptions,
+        });
+        onEstablished?.();
+        if (action.replyText) socket.send(action.replyText);
+      } else if (action.type === 'fail') fail(action.closeCode, action.reason);
+      return;
+    }
+
+    if (!channel || !tunnel) {
+      fail(RelayCloseCode.ChannelFailure, 'binary frame before handshake');
+      return;
+    }
+    let plaintext;
+    try {
+      plaintext = await channel.decryptor.decrypt(new Uint8Array(data));
+    } catch {
+      fail(RelayCloseCode.ChannelFailure, 'frame decryption failed');
+      return;
+    }
+    try {
+      const frames = batchNegotiated ? decodeFrameBatch(plaintext) : [plaintext];
+      for (const frame of frames) {
+        if (closed || !isActive()) return;
+        await tunnel.handleFrame(frame);
+      }
+    } catch (error) {
+      logger.warn(`[Relay] tunnel frame handling failed: ${error?.message ?? error}`);
+      fail(RelayCloseCode.ChannelFailure, 'protocol failure');
+    }
+  };
+
+  const receive = (data, isBinary) => {
+    processing = processing
+      .then(() => handleMessage(data, isBinary))
+      .catch((error) => {
+        logger.warn(`[Relay] encrypted session message failed: ${error?.message ?? error}`);
+        fail(RelayCloseCode.ChannelFailure, 'internal error');
+      });
+  };
+
+  return {
+    receive,
+    close() {
+      if (closed) return;
+      closed = true;
+      batcher?.dispose();
+      tunnel?.close();
+    },
+    get tunnel() {
+      return tunnel;
+    },
+  };
+};

--- a/packages/web/server/lib/relay/encrypted-session.test.js
+++ b/packages/web/server/lib/relay/encrypted-session.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createClientHandshake } from '../../../../ui/src/lib/relay/handshake.ts';
+import { createEncryptedSession } from './encrypted-session.js';
+import { exportPublicKeyJwk, generateEcdhKeyPair, RelayCloseCode } from './e2ee.js';
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const createSocket = () => ({
+  readyState: 1,
+  bufferedAmount: 0,
+  sent: [],
+  send(data) { this.sent.push(data); },
+});
+
+describe('encrypted session', () => {
+  const establishedFixture = async (batch) => {
+    const hostKeys = await generateEcdhKeyPair();
+    const client = await createClientHandshake(await exportPublicKeyJwk(hostKeys.publicKey), { batch });
+    const socket = createSocket();
+    const failures = [];
+    const session = createEncryptedSession({
+      socket, connectionId: 'malformed', hostEncPrivateKey: hostKeys.privateKey, batch,
+      getLocalPort: () => 1, batchWindowMs: 0, onFailure: (code, reason) => failures.push({ code, reason }),
+      logger: { warn() {} },
+    });
+    session.receive(client.helloText, false);
+    await settle();
+    const action = await client.handleText(socket.sent[0]);
+    return { session, channel: action.channel, failures };
+  };
+
+  it('closes exactly once for a malformed negotiated batch', async () => {
+    const { session, channel, failures } = await establishedFixture(true);
+    const malformed = await channel.encryptor.encrypt(new Uint8Array([1]));
+    session.receive(malformed, true);
+    session.receive(malformed, true);
+    await settle();
+    expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'protocol failure' }]);
+  });
+
+  it('closes exactly once for a malformed tunnel frame', async () => {
+    const { session, channel, failures } = await establishedFixture(false);
+    const malformed = await channel.encryptor.encrypt(new Uint8Array([1]));
+    session.receive(malformed, true);
+    await settle();
+    expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'protocol failure' }]);
+  });
+
+  it('fails closed on binary before handshake', async () => {
+    const hostKeys = await generateEcdhKeyPair();
+    const failures = [];
+    const session = createEncryptedSession({
+      socket: createSocket(), connectionId: 'binary-first', hostEncPrivateKey: hostKeys.privateKey,
+      getLocalPort: () => 1, batchWindowMs: 0, onFailure: (code, reason) => failures.push({ code, reason }),
+      logger: { warn() {} },
+    });
+    session.receive(new Uint8Array([1]), true);
+    await settle();
+    expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'binary frame before handshake' }]);
+    session.close();
+  });
+
+  it('uses the existing handshake and fails closed on post-establishment plaintext', async () => {
+    const hostKeys = await generateEcdhKeyPair();
+    const client = await createClientHandshake(await exportPublicKeyJwk(hostKeys.publicKey));
+    const socket = createSocket();
+    const failures = [];
+    const session = createEncryptedSession({
+      socket, connectionId: 'plaintext-after', hostEncPrivateKey: hostKeys.privateKey,
+      getLocalPort: () => 1, batchWindowMs: 0, onFailure: (code, reason) => failures.push({ code, reason }),
+      logger: { warn() {} },
+    });
+    session.receive(client.helloText, false);
+    await settle();
+    expect(typeof socket.sent[0]).toBe('string');
+    expect((await client.handleText(socket.sent[0])).type).toBe('established');
+    session.receive('{"t":"unexpected"}', false);
+    await settle();
+    expect(failures[0]?.code).toBe(RelayCloseCode.ChannelFailure);
+    session.close();
+  });
+});

--- a/packages/web/server/lib/relay/encrypted-session.test.js
+++ b/packages/web/server/lib/relay/encrypted-session.test.js
@@ -4,7 +4,13 @@ import { createClientHandshake } from '../../../../ui/src/lib/relay/handshake.ts
 import { createEncryptedSession } from './encrypted-session.js';
 import { exportPublicKeyJwk, generateEcdhKeyPair, RelayCloseCode } from './e2ee.js';
 
-const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+const waitFor = async (predicate) => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error('observable encrypted session outcome not reached');
+};
 
 const createSocket = () => ({
   readyState: 1,
@@ -25,7 +31,7 @@ describe('encrypted session', () => {
       logger: { warn() {} },
     });
     session.receive(client.helloText, false);
-    await settle();
+    await waitFor(() => socket.sent.length > 0);
     const action = await client.handleText(socket.sent[0]);
     return { session, channel: action.channel, failures };
   };
@@ -35,7 +41,7 @@ describe('encrypted session', () => {
     const malformed = await channel.encryptor.encrypt(new Uint8Array([1]));
     session.receive(malformed, true);
     session.receive(malformed, true);
-    await settle();
+    await waitFor(() => failures.length > 0);
     expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'protocol failure' }]);
   });
 
@@ -43,7 +49,7 @@ describe('encrypted session', () => {
     const { session, channel, failures } = await establishedFixture(false);
     const malformed = await channel.encryptor.encrypt(new Uint8Array([1]));
     session.receive(malformed, true);
-    await settle();
+    await waitFor(() => failures.length > 0);
     expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'protocol failure' }]);
   });
 
@@ -56,7 +62,7 @@ describe('encrypted session', () => {
       logger: { warn() {} },
     });
     session.receive(new Uint8Array([1]), true);
-    await settle();
+    await waitFor(() => failures.length > 0);
     expect(failures).toEqual([{ code: RelayCloseCode.ChannelFailure, reason: 'binary frame before handshake' }]);
     session.close();
   });
@@ -72,11 +78,11 @@ describe('encrypted session', () => {
       logger: { warn() {} },
     });
     session.receive(client.helloText, false);
-    await settle();
+    await waitFor(() => socket.sent.length > 0);
     expect(typeof socket.sent[0]).toBe('string');
     expect((await client.handleText(socket.sent[0])).type).toBe('established');
     session.receive('{"t":"unexpected"}', false);
-    await settle();
+    await waitFor(() => failures.length > 0);
     expect(failures[0]?.code).toBe(RelayCloseCode.ChannelFailure);
     session.close();
   });

--- a/packages/web/server/lib/relay/encrypted-session.test.js
+++ b/packages/web/server/lib/relay/encrypted-session.test.js
@@ -5,10 +5,12 @@ import { createEncryptedSession } from './encrypted-session.js';
 import { exportPublicKeyJwk, generateEcdhKeyPair, RelayCloseCode } from './e2ee.js';
 
 const waitFor = async (predicate) => {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
     if (predicate()) return;
-    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
+  if (predicate()) return;
   throw new Error('observable encrypted session outcome not reached');
 };
 

--- a/packages/web/server/lib/relay/host-client.js
+++ b/packages/web/server/lib/relay/host-client.js
@@ -5,9 +5,8 @@
 
 import { WebSocket } from 'ws';
 
-import { RELAY_PROTOCOL_VERSION, RelayCloseCode, createHostHandshake } from './e2ee.js';
-import { createOutboundFrameBatcher, decodeFrameBatch } from './tunnel-codec.js';
-import { createTunnelHost } from './tunnel-host.js';
+import { RELAY_PROTOCOL_VERSION } from './e2ee.js';
+import { createEncryptedSession } from './encrypted-session.js';
 
 const BACKOFF_BASE_MS = 1000;
 const BACKOFF_CAP_MS = 30000;
@@ -59,7 +58,7 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
   let controlSocket = null;
   let reconnectTimer = null;
   let consecutiveFailures = 0;
-  /** @type {Map<string, { socket: WebSocket, tunnel: ReturnType<typeof createTunnelHost> | null, openTimer: NodeJS.Timeout | null }>} */
+  /** @type {Map<string, { socket: WebSocket, session: ReturnType<typeof createEncryptedSession> | null, openTimer: NodeJS.Timeout | null, lastActivityAt: number }>} */
   const dataSockets = new Map();
 
   const emitStatus = () => {
@@ -94,8 +93,7 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
     if (!entry) return;
     dataSockets.delete(connectionId);
     if (entry.openTimer) clearTimeout(entry.openTimer);
-    entry.batcher?.dispose();
-    entry.tunnel?.close();
+    entry.session?.close();
     try {
       if (entry.socket.readyState === WebSocket.OPEN || entry.socket.readyState === WebSocket.CONNECTING) {
         if (closeCode) entry.socket.close(closeCode, reason ?? '');
@@ -118,34 +116,12 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
       return;
     }
 
-    const entry = { socket, tunnel: null, openTimer: null, batcher: null, lastActivityAt: Date.now() };
+    const entry = { socket, session: null, openTimer: null, lastActivityAt: Date.now() };
     dataSockets.set(connectionId, entry);
     entry.openTimer = setTimeout(() => {
       logger.warn('[Relay] host-data socket open timeout');
       teardownDataSocket(connectionId);
     }, DATA_SOCKET_OPEN_TIMEOUT_MS);
-
-    const handshake = createHostHandshake(identity.hostEncPrivateKey, { batch: localBatch });
-    let channel = null;
-    let batchNegotiated = false;
-    // Serialize async message handling so encrypted frame order (and the
-    // strictly-increasing decrypt counter) is preserved.
-    let processing = Promise.resolve();
-    // Serialize encrypt+send so the per-direction IV counter reaches the wire in
-    // encryption order. One encrypt() == one WS message == one counter tick,
-    // whether it carries a batch or a lone frame.
-    let sendChain = Promise.resolve();
-    const sendEncryptedPlaintext = (plaintext) => {
-      sendChain = sendChain
-        .then(async () => {
-          if (dataSockets.get(connectionId) !== entry || socket.readyState !== WebSocket.OPEN || !channel) return;
-          const encrypted = await channel.encryptor.encrypt(plaintext);
-          socket.send(encrypted, { binary: true });
-        })
-        .catch((error) => {
-          logger.warn(`[Relay] host-data send failed: ${error?.message ?? error}`);
-        });
-    };
 
     const failChannel = (closeCode, reason) => {
       // connectionId + reason only — never payload contents.
@@ -153,67 +129,18 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
       teardownDataSocket(connectionId, closeCode, reason);
     };
 
-    const handleMessage = async (data, isBinary) => {
-      const current = dataSockets.get(connectionId);
-      if (current !== entry) return;
-      // Any inbound message (including the client's keepalive Ping) proves the
-      // client is alive; the idle sweeper reaps sockets this stops updating.
-      entry.lastActivityAt = Date.now();
-
-      if (!isBinary) {
-        const action = await handshake.handleText(data.toString('utf8'));
-        if (action.type === 'send-text') {
-          socket.send(action.text);
-        } else if (action.type === 'established') {
-          channel = action.channel;
-          batchNegotiated = action.batch === true;
-          entry.batcher = batchNegotiated
-            ? createOutboundFrameBatcher({ windowMs: resolvedBatchWindowMs, sendBatch: sendEncryptedPlaintext })
-            : null;
-          entry.tunnel = createTunnelHost({
-            connectionId,
-            getLocalPort: resolveLocalPort,
-            getBufferedAmount: () => socket.bufferedAmount,
-            sendFrame: (plaintextFrame) => {
-              if (dataSockets.get(connectionId) !== entry || socket.readyState !== WebSocket.OPEN) return;
-              if (entry.batcher) entry.batcher.enqueue(plaintextFrame);
-              else sendEncryptedPlaintext(plaintextFrame);
-            },
-          });
-          if (action.replyText) socket.send(action.replyText);
-        } else if (action.type === 'fail') {
-          failChannel(action.closeCode, action.reason);
-        }
-        return;
-      }
-
-      if (!channel || !entry.tunnel) {
-        // Encrypted traffic before the handshake completed: fail closed.
-        failChannel(RelayCloseCode.ChannelFailure, 'binary frame before handshake');
-        return;
-      }
-      let plaintext;
-      try {
-        plaintext = await channel.decryptor.decrypt(new Uint8Array(data));
-      } catch {
-        failChannel(RelayCloseCode.ChannelFailure, 'frame decryption failed');
-        return;
-      }
-      try {
-        if (batchNegotiated) {
-          // One encrypted message may carry several tunnel frames; dispatch each
-          // in order through the same per-frame handling as legacy.
-          for (const frame of decodeFrameBatch(plaintext)) {
-            if (dataSockets.get(connectionId) !== entry) return;
-            await entry.tunnel.handleFrame(frame);
-          }
-        } else {
-          await entry.tunnel.handleFrame(plaintext);
-        }
-      } catch (error) {
-        logger.warn(`[Relay] tunnel frame handling failed: ${error?.message ?? error}`);
-      }
-    };
+    entry.session = createEncryptedSession({
+      socket,
+      connectionId,
+      hostEncPrivateKey: identity.hostEncPrivateKey,
+      getLocalPort: resolveLocalPort,
+      isActive: () => dataSockets.get(connectionId) === entry,
+      onActivity: () => { entry.lastActivityAt = Date.now(); },
+      onFailure: failChannel,
+      logger,
+      batch: localBatch,
+      batchWindowMs: resolvedBatchWindowMs,
+    });
 
     socket.on('open', () => {
       if (entry.openTimer) {
@@ -223,12 +150,7 @@ export const startRelayHost = ({ relayUrl, identity, localPort, getLocalPort, on
       emitStatus();
     });
     socket.on('message', (data, isBinary) => {
-      processing = processing
-        .then(() => handleMessage(data, isBinary))
-        .catch((error) => {
-          logger.warn(`[Relay] data socket message failed: ${error?.message ?? error}`);
-          failChannel(RelayCloseCode.ChannelFailure, 'internal error');
-        });
+      entry.session?.receive(data, isBinary);
     });
     socket.on('close', () => {
       teardownDataSocket(connectionId);

--- a/packages/web/server/lib/relay/identity.js
+++ b/packages/web/server/lib/relay/identity.js
@@ -11,9 +11,18 @@ import {
   getOrCreateRelaySigningKeypair,
   signRelayMessage,
 } from './signing-key.js';
-import { exportPublicKeyJwk, generateEcdhKeyPair, importEcdhPrivateKey } from './e2ee.js';
+import { exportPublicKeyJwk, generateEcdhKeyPair, importEcdhPrivateKey, importEcdhPublicKey } from './e2ee.js';
 
-const isJwkPair = (value) => Boolean(value && typeof value === 'object' && value.privateJwk && value.publicJwk);
+const publicJwkFromPrivate = (privateJwk) => ({
+  kty: privateJwk?.kty,
+  crv: privateJwk?.crv,
+  x: privateJwk?.x,
+  y: privateJwk?.y,
+});
+
+const samePublicJwk = (left, right) =>
+  left?.kty === right.kty && left?.crv === right.crv && left?.x === right.x && left?.y === right.y
+  && Object.keys(left).every((key) => ['kty', 'crv', 'x', 'y'].includes(key));
 
 /**
  * @param {{
@@ -28,12 +37,29 @@ export const createRelayIdentityRuntime = (deps) => {
 
   let cachedIdentity = null;
 
+  const importPersistedEncryptionKeypair = async (settings) => {
+    const existing = settings?.relayEncryptionKey;
+    if (!existing?.privateJwk) return null;
+    try {
+      const privateKey = await importEcdhPrivateKey(existing.privateJwk);
+      const publicJwk = publicJwkFromPrivate(existing.privateJwk);
+      await importEcdhPublicKey(publicJwk);
+      if (!samePublicJwk(existing.publicJwk, publicJwk)) {
+        await writeSettingsToDisk({ ...settings, relayEncryptionKey: { privateJwk: existing.privateJwk, publicJwk } });
+      }
+      return { privateJwk: existing.privateJwk, publicJwk, privateKey };
+    } catch {
+      // Invalid private material cannot be repaired; replace the keypair only
+      // after the strict settings read confirms regeneration is safe.
+      return null;
+    }
+  };
+
   const getOrCreateEncryptionKeypair = async () => {
     const settings = await readSettingsFromDiskMigrated();
-    const existing = settings?.relayEncryptionKey;
-    if (isJwkPair(existing)) {
-      return existing;
-    }
+    const existing = await importPersistedEncryptionKeypair(settings);
+    if (existing) return existing;
+
     // Same regeneration gate as the signing key: never mint a replacement
     // identity key off a swallowed read failure — a new encryption key breaks
     // the E2EE trust anchor pinned by every paired device. Verify "missing" via
@@ -41,10 +67,8 @@ export const createRelayIdentityRuntime = (deps) => {
     let verifiedSettings = settings;
     if (readSettingsStrict) {
       verifiedSettings = await readSettingsStrict();
-      const verified = verifiedSettings?.relayEncryptionKey;
-      if (isJwkPair(verified)) {
-        return verified;
-      }
+      const verified = await importPersistedEncryptionKeypair(verifiedSettings);
+      if (verified) return verified;
     }
     // Loud on purpose: a new encryption key invalidates the E2EE trust anchor of
     // every paired device. Expected exactly once, on first relay use.
@@ -53,7 +77,7 @@ export const createRelayIdentityRuntime = (deps) => {
     const privateJwk = await globalThis.crypto.subtle.exportKey('jwk', keyPair.privateKey);
     const publicJwk = await exportPublicKeyJwk(keyPair.publicKey);
     await writeSettingsToDisk({ ...settings, ...(verifiedSettings || {}), relayEncryptionKey: { privateJwk, publicJwk } });
-    return { privateJwk, publicJwk };
+    return { privateJwk, publicJwk, privateKey: keyPair.privateKey };
   };
 
   /**
@@ -69,7 +93,7 @@ export const createRelayIdentityRuntime = (deps) => {
     const signing = await getOrCreateRelaySigningKeypair({ crypto, readSettingsFromDiskMigrated, writeSettingsToDisk, readSettingsStrict });
     const serverId = deriveServerId({ crypto }, signing.publicJwk);
     const encryption = await getOrCreateEncryptionKeypair();
-    const hostEncPrivateKey = await importEcdhPrivateKey(encryption.privateJwk);
+    const hostEncPrivateKey = encryption.privateKey || await importEcdhPrivateKey(encryption.privateJwk);
     const pk = Buffer.from(canonicalPublicJwkString(signing.publicJwk), 'utf8').toString('base64url');
 
     // Relay-layer auth for host-control / host-data upgrades. Signature payload

--- a/packages/web/server/lib/relay/identity.js
+++ b/packages/web/server/lib/relay/identity.js
@@ -36,9 +36,29 @@ export const createRelayIdentityRuntime = (deps) => {
   const { crypto, readSettingsFromDiskMigrated, writeSettingsToDisk, readSettingsStrict } = deps;
 
   let cachedIdentity = null;
+  let cachedIdentityGeneration = null;
   let pendingIdentity = null;
+  let identityGeneration = 0;
 
-  const importPersistedEncryptionKeypair = async (settings) => {
+  const generationSupersededError = () => Object.assign(
+    new Error('Relay identity initialization superseded'),
+    {
+      name: 'RelayIdentityGenerationSupersededError',
+      code: 'relay_identity_generation_superseded',
+    },
+  );
+
+  const assertCurrentGeneration = (generation) => {
+    if (generation !== identityGeneration) throw generationSupersededError();
+  };
+
+  const writeSettingsForGeneration = async (generation, settings) => {
+    assertCurrentGeneration(generation);
+    await writeSettingsToDisk(settings);
+    assertCurrentGeneration(generation);
+  };
+
+  const importPersistedEncryptionKeypair = async (generation, settings) => {
     const existing = settings?.relayEncryptionKey;
     if (!existing?.privateJwk) return null;
     try {
@@ -46,7 +66,7 @@ export const createRelayIdentityRuntime = (deps) => {
       const publicJwk = publicJwkFromPrivate(existing.privateJwk);
       await importEcdhPublicKey(publicJwk);
       if (!samePublicJwk(existing.publicJwk, publicJwk)) {
-        await writeSettingsToDisk({ ...settings, relayEncryptionKey: { privateJwk: existing.privateJwk, publicJwk } });
+        await writeSettingsForGeneration(generation, { ...settings, relayEncryptionKey: { privateJwk: existing.privateJwk, publicJwk } });
       }
       return { privateJwk: existing.privateJwk, publicJwk, privateKey };
     } catch {
@@ -56,9 +76,10 @@ export const createRelayIdentityRuntime = (deps) => {
     }
   };
 
-  const getOrCreateEncryptionKeypair = async () => {
+  const getOrCreateEncryptionKeypair = async (generation) => {
     const settings = await readSettingsFromDiskMigrated();
-    const existing = await importPersistedEncryptionKeypair(settings);
+    assertCurrentGeneration(generation);
+    const existing = await importPersistedEncryptionKeypair(generation, settings);
     if (existing) return existing;
 
     // Same regeneration gate as the signing key: never mint a replacement
@@ -68,7 +89,8 @@ export const createRelayIdentityRuntime = (deps) => {
     let verifiedSettings = settings;
     if (readSettingsStrict) {
       verifiedSettings = await readSettingsStrict();
-      const verified = await importPersistedEncryptionKeypair(verifiedSettings);
+      assertCurrentGeneration(generation);
+      const verified = await importPersistedEncryptionKeypair(generation, verifiedSettings);
       if (verified) return verified;
     }
     // Loud on purpose: a new encryption key invalidates the E2EE trust anchor of
@@ -77,7 +99,7 @@ export const createRelayIdentityRuntime = (deps) => {
     const keyPair = await generateEcdhKeyPair();
     const privateJwk = await globalThis.crypto.subtle.exportKey('jwk', keyPair.privateKey);
     const publicJwk = await exportPublicKeyJwk(keyPair.publicKey);
-    await writeSettingsToDisk({ ...settings, ...(verifiedSettings || {}), relayEncryptionKey: { privateJwk, publicJwk } });
+    await writeSettingsForGeneration(generation, { ...settings, ...(verifiedSettings || {}), relayEncryptionKey: { privateJwk, publicJwk } });
     return { privateJwk, publicJwk, privateKey: keyPair.privateKey };
   };
 
@@ -89,11 +111,17 @@ export const createRelayIdentityRuntime = (deps) => {
    *   signRelayAuth: (role: string, connectionId?: string | null) => { ts: number, sig: string, pk: string },
    * }>}
    */
-  const initializeRelayIdentity = async () => {
-    if (cachedIdentity) return cachedIdentity;
-    const signing = await getOrCreateRelaySigningKeypair({ crypto, readSettingsFromDiskMigrated, writeSettingsToDisk, readSettingsStrict });
+  const initializeRelayIdentity = async (generation) => {
+    if (cachedIdentity && cachedIdentityGeneration === generation) return cachedIdentity;
+    const signing = await getOrCreateRelaySigningKeypair({
+      crypto,
+      readSettingsFromDiskMigrated,
+      writeSettingsToDisk: (settings) => writeSettingsForGeneration(generation, settings),
+      readSettingsStrict,
+    });
+    assertCurrentGeneration(generation);
     const serverId = deriveServerId({ crypto }, signing.publicJwk);
-    const encryption = await getOrCreateEncryptionKeypair();
+    const encryption = await getOrCreateEncryptionKeypair(generation);
     const hostEncPrivateKey = encryption.privateKey || await importEcdhPrivateKey(encryption.privateJwk);
     const pk = Buffer.from(canonicalPublicJwkString(signing.publicJwk), 'utf8').toString('base64url');
 
@@ -105,24 +133,39 @@ export const createRelayIdentityRuntime = (deps) => {
       return { ts, sig, pk };
     };
 
+    assertCurrentGeneration(generation);
     cachedIdentity = {
       serverId,
       hostEncPubJwk: encryption.publicJwk,
       hostEncPrivateKey,
       signRelayAuth,
     };
+    cachedIdentityGeneration = generation;
     return cachedIdentity;
   };
 
   const getRelayIdentity = () => {
-    if (cachedIdentity) return Promise.resolve(cachedIdentity);
-    if (pendingIdentity) return pendingIdentity;
+    if (cachedIdentity && cachedIdentityGeneration === identityGeneration) return Promise.resolve(cachedIdentity);
+    if (pendingIdentity?.generation === identityGeneration) return pendingIdentity.promise;
 
-    pendingIdentity = initializeRelayIdentity().finally(() => {
-      pendingIdentity = null;
+    const generation = identityGeneration;
+    const promise = initializeRelayIdentity(generation).catch((error) => {
+      if (generation !== identityGeneration) throw generationSupersededError();
+      throw error;
+    }).finally(() => {
+      if (pendingIdentity?.generation === generation) pendingIdentity = null;
     });
-    return pendingIdentity;
+    pendingIdentity = { generation, promise };
+    return promise;
   };
 
-  return { getRelayIdentity };
+  const abandonPendingRelayIdentity = () => {
+    if (cachedIdentity && cachedIdentityGeneration === identityGeneration) return false;
+    if (pendingIdentity?.generation !== identityGeneration) return false;
+    identityGeneration += 1;
+    pendingIdentity = null;
+    return true;
+  };
+
+  return { abandonPendingRelayIdentity, getRelayIdentity };
 };

--- a/packages/web/server/lib/relay/identity.js
+++ b/packages/web/server/lib/relay/identity.js
@@ -36,6 +36,7 @@ export const createRelayIdentityRuntime = (deps) => {
   const { crypto, readSettingsFromDiskMigrated, writeSettingsToDisk, readSettingsStrict } = deps;
 
   let cachedIdentity = null;
+  let pendingIdentity = null;
 
   const importPersistedEncryptionKeypair = async (settings) => {
     const existing = settings?.relayEncryptionKey;
@@ -88,7 +89,7 @@ export const createRelayIdentityRuntime = (deps) => {
    *   signRelayAuth: (role: string, connectionId?: string | null) => { ts: number, sig: string, pk: string },
    * }>}
    */
-  const getRelayIdentity = async () => {
+  const initializeRelayIdentity = async () => {
     if (cachedIdentity) return cachedIdentity;
     const signing = await getOrCreateRelaySigningKeypair({ crypto, readSettingsFromDiskMigrated, writeSettingsToDisk, readSettingsStrict });
     const serverId = deriveServerId({ crypto }, signing.publicJwk);
@@ -111,6 +112,16 @@ export const createRelayIdentityRuntime = (deps) => {
       signRelayAuth,
     };
     return cachedIdentity;
+  };
+
+  const getRelayIdentity = () => {
+    if (cachedIdentity) return Promise.resolve(cachedIdentity);
+    if (pendingIdentity) return pendingIdentity;
+
+    pendingIdentity = initializeRelayIdentity().finally(() => {
+      pendingIdentity = null;
+    });
+    return pendingIdentity;
   };
 
   return { getRelayIdentity };

--- a/packages/web/server/lib/relay/identity.js
+++ b/packages/web/server/lib/relay/identity.js
@@ -39,6 +39,7 @@ export const createRelayIdentityRuntime = (deps) => {
   let cachedIdentityGeneration = null;
   let pendingIdentity = null;
   let identityGeneration = 0;
+  let settingsWriteTail = Promise.resolve();
 
   const generationSupersededError = () => Object.assign(
     new Error('Relay identity initialization superseded'),
@@ -52,10 +53,18 @@ export const createRelayIdentityRuntime = (deps) => {
     if (generation !== identityGeneration) throw generationSupersededError();
   };
 
-  const writeSettingsForGeneration = async (generation, settings) => {
+  const writeSettingsForGeneration = (generation, settings) => {
     assertCurrentGeneration(generation);
-    await writeSettingsToDisk(settings);
-    assertCurrentGeneration(generation);
+    const operation = settingsWriteTail.then(async () => {
+      assertCurrentGeneration(generation);
+      await writeSettingsToDisk(settings);
+      assertCurrentGeneration(generation);
+    });
+    settingsWriteTail = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
   };
 
   const importPersistedEncryptionKeypair = async (generation, settings) => {

--- a/packages/web/server/lib/relay/identity.test.js
+++ b/packages/web/server/lib/relay/identity.test.js
@@ -75,4 +75,30 @@ describe('relay identity', () => {
     );
     expect(ok).toBe(true);
   });
+
+  it('derives and repairs the public encryption JWK from a valid persisted private key', async () => {
+    const pair = await globalThis.crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits']);
+    const privateJwk = await globalThis.crypto.subtle.exportKey('jwk', pair.privateKey);
+    const other = await globalThis.crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits']);
+    const mismatched = await globalThis.crypto.subtle.exportKey('jwk', other.publicKey);
+    const store = makeSettingsStore({ relayEncryptionKey: { privateJwk, publicJwk: { ...mismatched, d: 'leak' } } });
+    const identity = await createRelayIdentityRuntime({ crypto, ...store }).getRelayIdentity();
+    expect(identity.hostEncPubJwk).toEqual({ kty: 'EC', crv: 'P-256', x: privateJwk.x, y: privateJwk.y });
+    expect(identity.hostEncPubJwk).not.toHaveProperty('d');
+    expect(store.peek().relayEncryptionKey.privateJwk.d).toBe(privateJwk.d);
+    expect(store.peek().relayEncryptionKey.publicJwk).toEqual(identity.hostEncPubJwk);
+  });
+
+  it('replaces an invalid persisted private encryption point', async () => {
+    const store = makeSettingsStore({
+      relayEncryptionKey: {
+        privateJwk: { kty: 'EC', crv: 'P-256', x: 'bad', y: 'bad', d: 'bad' },
+        publicJwk: { kty: 'EC', crv: 'P-256', x: 'bad', y: 'bad', d: 'leak' },
+      },
+    });
+    const identity = await createRelayIdentityRuntime({ crypto, ...store }).getRelayIdentity();
+    expect(identity.hostEncPubJwk).not.toHaveProperty('d');
+    expect(identity.hostEncPubJwk.x).not.toBe('bad');
+    expect(store.peek().relayEncryptionKey.privateJwk.d).not.toBe('bad');
+  });
 });

--- a/packages/web/server/lib/relay/identity.test.js
+++ b/packages/web/server/lib/relay/identity.test.js
@@ -16,7 +16,82 @@ const makeSettingsStore = (initial = {}) => {
   };
 };
 
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
+
 describe('relay identity', () => {
+  it('abandons a pending generation without allowing its late success to write or replace fresh identity', async () => {
+    const store = makeSettingsStore();
+    const firstRead = deferred();
+    let reads = 0;
+    let writes = 0;
+    const runtime = createRelayIdentityRuntime({
+      crypto,
+      ...store,
+      readSettingsFromDiskMigrated: async () => {
+        reads += 1;
+        if (reads === 1) return firstRead.promise;
+        return { ...store.peek() };
+      },
+      writeSettingsToDisk: async (settings) => {
+        writes += 1;
+        await store.writeSettingsToDisk(settings);
+      },
+    });
+
+    const staleResult = runtime.getRelayIdentity().catch((error) => error);
+    expect(runtime.abandonPendingRelayIdentity()).toBe(true);
+    const freshIdentity = await runtime.getRelayIdentity();
+    const writesAfterFreshIdentity = writes;
+
+    firstRead.resolve({});
+    const staleError = await staleResult;
+
+    expect(staleError).toMatchObject({
+      name: 'RelayIdentityGenerationSupersededError',
+      code: 'relay_identity_generation_superseded',
+    });
+    expect(writes).toBe(writesAfterFreshIdentity);
+    expect(await runtime.getRelayIdentity()).toBe(freshIdentity);
+    expect(runtime.abandonPendingRelayIdentity()).toBe(false);
+  });
+
+  it('normalizes a late rejection from an abandoned generation without clearing the fresh cache', async () => {
+    const store = makeSettingsStore();
+    const firstRead = deferred();
+    let reads = 0;
+    const runtime = createRelayIdentityRuntime({
+      crypto,
+      ...store,
+      readSettingsFromDiskMigrated: async () => {
+        reads += 1;
+        if (reads === 1) return firstRead.promise;
+        return { ...store.peek() };
+      },
+    });
+
+    const staleResult = runtime.getRelayIdentity().catch((error) => error);
+    expect(runtime.abandonPendingRelayIdentity()).toBe(true);
+    const freshIdentity = await runtime.getRelayIdentity();
+    firstRead.reject(new Error('private-key-detail'));
+    const staleError = await staleResult;
+
+    expect(staleError).toMatchObject({
+      name: 'RelayIdentityGenerationSupersededError',
+      code: 'relay_identity_generation_superseded',
+      message: 'Relay identity initialization superseded',
+    });
+    expect(staleError.message).not.toContain('private-key-detail');
+    expect(await runtime.getRelayIdentity()).toBe(freshIdentity);
+  });
+
   it('shares one cold initialization across concurrent callers', async () => {
     let writes = 0;
     const store = makeSettingsStore();

--- a/packages/web/server/lib/relay/identity.test.js
+++ b/packages/web/server/lib/relay/identity.test.js
@@ -17,6 +17,58 @@ const makeSettingsStore = (initial = {}) => {
 };
 
 describe('relay identity', () => {
+  it('shares one cold initialization across concurrent callers', async () => {
+    let writes = 0;
+    const store = makeSettingsStore();
+    const runtime = createRelayIdentityRuntime({
+      crypto,
+      ...store,
+      writeSettingsToDisk: async (next) => {
+        writes += 1;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        await store.writeSettingsToDisk(next);
+      },
+    });
+
+    const identities = await Promise.all(Array.from({ length: 8 }, () => runtime.getRelayIdentity()));
+
+    expect(identities.every((identity) => identity === identities[0])).toBe(true);
+    expect(writes).toBe(2);
+  });
+
+  it('clears a rejected initialization so a later call can retry', async () => {
+    const store = makeSettingsStore();
+    let reads = 0;
+    const runtime = createRelayIdentityRuntime({
+      crypto,
+      ...store,
+      readSettingsFromDiskMigrated: async () => {
+        reads += 1;
+        if (reads === 1) throw new Error('temporary read failure');
+        return { ...store.peek() };
+      },
+    });
+
+    await expect(runtime.getRelayIdentity()).rejects.toThrow('temporary read failure');
+    const identity = await runtime.getRelayIdentity();
+
+    expect(identity.serverId).toBeTruthy();
+    expect(reads).toBeGreaterThan(1);
+  });
+
+  it('does not regenerate or write when the strict settings read fails', async () => {
+    let writes = 0;
+    const runtime = createRelayIdentityRuntime({
+      crypto,
+      readSettingsFromDiskMigrated: async () => ({}),
+      readSettingsStrict: async () => { throw new Error('strict read failed'); },
+      writeSettingsToDisk: async () => { writes += 1; },
+    });
+
+    await expect(runtime.getRelayIdentity()).rejects.toThrow('strict read failed');
+    expect(writes).toBe(0);
+  });
+
   it('derives a stable serverId from the signing key and persists both keypairs', async () => {
     const store = makeSettingsStore();
     const runtime = createRelayIdentityRuntime({ crypto, ...store });

--- a/packages/web/server/lib/relay/identity.test.js
+++ b/packages/web/server/lib/relay/identity.test.js
@@ -27,6 +27,85 @@ const deferred = () => {
 };
 
 describe('relay identity', () => {
+  it('serializes a fresh generation behind an already-started abandoned write', async () => {
+    const store = makeSettingsStore();
+    const staleWriteStarted = deferred();
+    const releaseStaleWrite = deferred();
+    const writes = [];
+    const runtime = createRelayIdentityRuntime({
+      crypto,
+      ...store,
+      writeSettingsToDisk: async (settings) => {
+        writes.push(settings);
+        if (writes.length === 1) {
+          staleWriteStarted.resolve();
+          await releaseStaleWrite.promise;
+        }
+        await store.writeSettingsToDisk(settings);
+      },
+    });
+
+    const staleResult = runtime.getRelayIdentity().catch((error) => error);
+    await staleWriteStarted.promise;
+    expect(runtime.abandonPendingRelayIdentity()).toBe(true);
+    const freshResult = runtime.getRelayIdentity();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(writes).toHaveLength(1);
+    releaseStaleWrite.resolve();
+
+    const staleError = await staleResult;
+    const freshIdentity = await freshResult;
+    const stored = store.peek();
+    const storedServerId = crypto
+      .createHash('sha256')
+      .update(canonicalPublicJwkString(stored.relaySigningKey.publicJwk))
+      .digest('base64url');
+
+    expect(staleError).toMatchObject({ code: 'relay_identity_generation_superseded' });
+    expect(storedServerId).toBe(freshIdentity.serverId);
+    expect(stored.relayEncryptionKey.publicJwk).toEqual(freshIdentity.hostEncPubJwk);
+  });
+
+  it('continues fresh generation writes after an abandoned queued write rejects', async () => {
+    const store = makeSettingsStore();
+    const staleWriteStarted = deferred();
+    const rejectStaleWrite = deferred();
+    const writes = [];
+    const runtime = createRelayIdentityRuntime({
+      crypto,
+      ...store,
+      writeSettingsToDisk: async (settings) => {
+        writes.push(settings);
+        if (writes.length === 1) {
+          staleWriteStarted.resolve();
+          await rejectStaleWrite.promise;
+        }
+        await store.writeSettingsToDisk(settings);
+      },
+    });
+
+    const staleResult = runtime.getRelayIdentity().catch((error) => error);
+    await staleWriteStarted.promise;
+    expect(runtime.abandonPendingRelayIdentity()).toBe(true);
+    const freshResult = runtime.getRelayIdentity();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(writes).toHaveLength(1);
+    rejectStaleWrite.reject(new Error('stale deferred write failed'));
+
+    const staleError = await staleResult;
+    const freshIdentity = await freshResult;
+    const stored = store.peek();
+
+    expect(staleError).toMatchObject({ code: 'relay_identity_generation_superseded' });
+    expect(freshIdentity.serverId).toBeTruthy();
+    expect(stored.relaySigningKey).toBeDefined();
+    expect(stored.relayEncryptionKey.publicJwk).toEqual(freshIdentity.hostEncPubJwk);
+  });
+
   it('abandons a pending generation without allowing its late success to write or replace fresh identity', async () => {
     const store = makeSettingsStore();
     const firstRead = deferred();

--- a/packages/web/server/lib/relay/service-identity.test.js
+++ b/packages/web/server/lib/relay/service-identity.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'bun:test';
+import crypto from 'node:crypto';
+
+import { createRelayService } from './service.js';
+
+describe('relay service identity runtime', () => {
+  it('uses the injected identity runtime without running the fallback identity path', async () => {
+    const identity = {
+      serverId: 'shared-server-id',
+      hostEncPubJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
+    };
+    const identityRuntime = { getRelayIdentity: vi.fn(async () => identity) };
+    const readSettingsStrict = vi.fn(async () => { throw new Error('fallback identity path should not run'); });
+    const writeSettingsToDisk = vi.fn(async () => { throw new Error('identity settings should not be generated'); });
+    const service = createRelayService({
+      crypto,
+      identityRuntime,
+      readSettingsFromDiskMigrated: async () => ({
+        privateRelay: { enabled: false, relayUrl: 'wss://relay.example/ws' },
+      }),
+      readSettingsStrict,
+      writeSettingsToDisk,
+      getLocalPort: () => 3000,
+    });
+
+    expect(await service.getServerId()).toBe('shared-server-id');
+    expect(await service.getStatus()).toMatchObject({
+      enabled: false,
+      state: 'disabled',
+      serverId: 'shared-server-id',
+    });
+    expect(identityRuntime.getRelayIdentity).toHaveBeenCalledTimes(2);
+    expect(readSettingsStrict).not.toHaveBeenCalled();
+    expect(writeSettingsToDisk).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/server/lib/relay/service.js
+++ b/packages/web/server/lib/relay/service.js
@@ -50,6 +50,8 @@ const envRelayUrlOverride = () => {
  *   crypto: typeof import('node:crypto'),
  *   readSettingsFromDiskMigrated: () => Promise<object>,
  *   writeSettingsToDisk: (settings: object) => Promise<void>,
+ *   readSettingsStrict?: () => Promise<object>,
+ *   identityRuntime?: { getRelayIdentity: () => Promise<object> },
  *   getLocalPort: () => number,
  *   logger?: Pick<Console, 'warn'>,
  * }} deps
@@ -71,8 +73,14 @@ export const createRelayService = ({
   // on a random instance. Optional: without it, behavior is pre-lock.
   hostLock = null,
   logger = console,
+  identityRuntime: injectedIdentityRuntime,
 }) => {
-  const identityRuntime = createRelayIdentityRuntime({ crypto, readSettingsFromDiskMigrated, writeSettingsToDisk, readSettingsStrict });
+  const identityRuntime = injectedIdentityRuntime ?? createRelayIdentityRuntime({
+    crypto,
+    readSettingsFromDiskMigrated,
+    writeSettingsToDisk,
+    readSettingsStrict,
+  });
 
   let hostClient = null;
   let status = { state: 'disabled', lastError: null, connectedClients: 0 };

--- a/packages/web/server/lib/relay/tunnel-codec.js
+++ b/packages/web/server/lib/relay/tunnel-codec.js
@@ -154,6 +154,7 @@ export const encodeFragmentedMessage = (frameType, streamId, payload) => {
  */
 export const createFragmentAssembler = (maxMessageBytes = 16 * 1024 * 1024) => {
   const pending = new Map();
+  let pendingBytes = 0;
   return {
     /**
      * Returns the complete message payload once all fragments arrived, or null
@@ -169,14 +170,17 @@ export const createFragmentAssembler = (maxMessageBytes = 16 * 1024 * 1024) => {
       const chunks = entry?.chunks ?? [];
       const totalBytes = (entry?.totalBytes ?? 0) + frame.payload.length;
       if (totalBytes > maxMessageBytes) {
+        pendingBytes -= entry?.totalBytes ?? 0;
         pending.delete(key);
         throw new TunnelCodecError('fragmented message exceeds maximum size');
       }
       chunks.push(frame.payload);
       if (frame.hasMoreFragments) {
+        pendingBytes += frame.payload.length;
         pending.set(key, { chunks, totalBytes });
         return null;
       }
+      pendingBytes -= entry?.totalBytes ?? 0;
       pending.delete(key);
       const message = new Uint8Array(totalBytes);
       let offset = 0;
@@ -188,9 +192,19 @@ export const createFragmentAssembler = (maxMessageBytes = 16 * 1024 * 1024) => {
     },
     /** @param {number} streamId */
     dropStream(streamId) {
-      for (const key of pending.keys()) {
-        if (key.startsWith(`${streamId}:`)) pending.delete(key);
+      for (const [key, entry] of pending) {
+        if (key.startsWith(`${streamId}:`)) {
+          pendingBytes -= entry.totalBytes;
+          pending.delete(key);
+        }
       }
+    },
+    clear() {
+      pending.clear();
+      pendingBytes = 0;
+    },
+    get pendingBytes() {
+      return pendingBytes;
     },
   };
 };

--- a/packages/web/server/lib/relay/tunnel-codec.test.js
+++ b/packages/web/server/lib/relay/tunnel-codec.test.js
@@ -55,4 +55,15 @@ describe('relay tunnel codec', () => {
       assembler.push({ frameType: TunnelFrameType.WsText, streamId: 1, payload: chunk, hasMoreFragments: true }),
     ).toThrow(TunnelCodecError);
   });
+
+  it('clears aggregate fragment bytes on stream drop and assembler close cleanup', () => {
+    const assembler = createFragmentAssembler();
+    assembler.push({ frameType: TunnelFrameType.WsText, streamId: 1, payload: new Uint8Array(3), hasMoreFragments: true });
+    assembler.push({ frameType: TunnelFrameType.WsBinary, streamId: 2, payload: new Uint8Array(4), hasMoreFragments: true });
+    expect(assembler.pendingBytes).toBe(7);
+    assembler.dropStream(1);
+    expect(assembler.pendingBytes).toBe(4);
+    assembler.clear();
+    expect(assembler.pendingBytes).toBe(0);
+  });
 });

--- a/packages/web/server/lib/relay/tunnel-host.js
+++ b/packages/web/server/lib/relay/tunnel-host.js
@@ -79,6 +79,10 @@ const STRIPPED_RESPONSE_HEADERS = new Set([
 // relay socket has more than this buffered.
 const BACKPRESSURE_LIMIT_BYTES = 4 * 1024 * 1024;
 const BACKPRESSURE_POLL_MS = 20;
+const COMPLETED_HTTP_STREAM_TTL_MS = 5_000;
+const MAX_COMPLETED_HTTP_STREAMS = 256;
+const MAX_LATE_HTTP_BODY_FRAMES = 32;
+const MAX_LATE_HTTP_BODY_BYTES = 1024 * 1024;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -109,7 +113,7 @@ const isWsClosePayload = (parsed) => Boolean(parsed && typeof parsed === 'object
  *   onResponse?: (response: { kind: 'http', streamId: number, generation: number, status: number }) => void | Promise<void>,
  *   onLimitExceeded?: (reason: string) => void,
  *   onStreamClosed?: (event: { streamId: number, generation: number, kind: 'http' | 'ws', reason: string }) => void,
- *   limits?: { maxStreams?: number, maxWebSockets?: number, maxIncompleteFragments?: number, maxIncompleteFragmentBytes?: number, getMaxIncompleteFragmentBytes?: () => number, maxStreamOpens?: number, streamOpenWindowMs?: number },
+ *   limits?: { maxStreams?: number, maxWebSockets?: number, maxIncompleteFragments?: number, maxIncompleteFragmentBytes?: number, getMaxIncompleteFragmentBytes?: () => number, maxStreamOpens?: number, streamOpenWindowMs?: number, completedHttpStreamTtlMs?: number, maxCompletedHttpStreams?: number, maxLateHttpBodyFrames?: number, maxLateHttpBodyBytes?: number, now?: () => number },
  *   failClosedPolicy?: boolean,
  *   onProtocolFailure?: () => void,
  * }} deps
@@ -133,9 +137,52 @@ export const createTunnelHost = ({
   const streams = new Map();
   const assembler = createFragmentAssembler();
   const incompleteFragments = new Set();
+  /** @type {Map<number, { expiresAt: number, bodyCapable: boolean, lateBodyFrames: number, lateBodyBytes: number }>} */
+  const completedHttpStreams = new Map();
   let closed = false;
   const streamOpenTimes = [];
   let nextGeneration = 1;
+
+  const now = limits.now ?? Date.now;
+  const completedHttpStreamTtlMs = Number.isFinite(limits.completedHttpStreamTtlMs)
+    ? Math.max(0, limits.completedHttpStreamTtlMs)
+    : COMPLETED_HTTP_STREAM_TTL_MS;
+  const maxCompletedHttpStreams = Number.isFinite(limits.maxCompletedHttpStreams)
+    ? Math.max(0, Math.floor(limits.maxCompletedHttpStreams))
+    : MAX_COMPLETED_HTTP_STREAMS;
+  const maxLateHttpBodyFrames = Number.isFinite(limits.maxLateHttpBodyFrames)
+    ? Math.max(0, Math.floor(limits.maxLateHttpBodyFrames))
+    : MAX_LATE_HTTP_BODY_FRAMES;
+  const maxLateHttpBodyBytes = Number.isFinite(limits.maxLateHttpBodyBytes)
+    ? Math.max(0, limits.maxLateHttpBodyBytes)
+    : MAX_LATE_HTTP_BODY_BYTES;
+
+  const pruneCompletedHttpStreams = () => {
+    const currentTime = now();
+    for (const [streamId, tombstone] of completedHttpStreams) {
+      if (tombstone.expiresAt > currentTime) continue;
+      completedHttpStreams.delete(streamId);
+    }
+  };
+
+  const recordCompletedHttpStream = (streamId, stream) => {
+    pruneCompletedHttpStreams();
+    if (maxCompletedHttpStreams === 0 || completedHttpStreamTtlMs === 0) return;
+    while (completedHttpStreams.size >= maxCompletedHttpStreams) {
+      completedHttpStreams.delete(completedHttpStreams.keys().next().value);
+    }
+    completedHttpStreams.set(streamId, {
+      expiresAt: now() + completedHttpStreamTtlMs,
+      bodyCapable: !stream.noBody,
+      lateBodyFrames: 0,
+      lateBodyBytes: 0,
+    });
+  };
+
+  const getCompletedHttpStream = (streamId) => {
+    pruneCompletedHttpStreams();
+    return completedHttpStreams.get(streamId);
+  };
 
   const send = async (frame) => {
     if (closed) return;
@@ -151,6 +198,7 @@ export const createTunnelHost = ({
 
   const dropStream = (streamId, reason = 'completed') => {
     const stream = streams.get(streamId);
+    if (reason === 'completed' && stream?.kind === 'http') recordCompletedHttpStream(streamId, stream);
     streams.delete(streamId);
     assembler.dropStream(streamId);
     for (const key of incompleteFragments) {
@@ -327,6 +375,7 @@ export const createTunnelHost = ({
   };
 
   const handleHttpRequest = (streamId, payload) => {
+    if (getCompletedHttpStream(streamId)) throw new Error('completed stream id reused');
     if (streams.has(streamId)) {
       abortLocalStream(streamId, 'duplicate stream id');
       void sendAbort(streamId, 'duplicate stream id');
@@ -358,7 +407,19 @@ export const createTunnelHost = ({
 
   const handleHttpBody = (streamId, payload) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'http' || stream.noBody) throw new Error('unsolicited http body');
+    if (!stream) {
+      const tombstone = getCompletedHttpStream(streamId);
+      if (!tombstone?.bodyCapable) throw new Error('unsolicited http body');
+      const nextFrames = tombstone.lateBodyFrames + 1;
+      const nextBytes = tombstone.lateBodyBytes + payload.byteLength;
+      if (nextFrames > maxLateHttpBodyFrames || nextBytes > maxLateHttpBodyBytes) {
+        throw new Error('late http body budget exceeded');
+      }
+      tombstone.lateBodyFrames = nextFrames;
+      tombstone.lateBodyBytes = nextBytes;
+      return;
+    }
+    if (stream.kind !== 'http' || stream.noBody) throw new Error('unsolicited http body');
     // The body controller attaches synchronously in runHttpStream before any
     // await, so by the time body frames arrive it is set for body-carrying
     // methods; drop stray body bytes otherwise.
@@ -371,7 +432,12 @@ export const createTunnelHost = ({
 
   const handleStreamEnd = (streamId) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'http') throw new Error('unsolicited stream end');
+    if (!stream) {
+      if (!getCompletedHttpStream(streamId)) throw new Error('unsolicited stream end');
+      completedHttpStreams.delete(streamId);
+      return;
+    }
+    if (stream.kind !== 'http') throw new Error('unsolicited stream end');
     try {
       stream.body?.close();
     } catch {
@@ -385,6 +451,7 @@ export const createTunnelHost = ({
   // -------------------------------------------------------------------------
 
   const handleWsOpen = async (streamId, payload) => {
+    if (getCompletedHttpStream(streamId)) throw new Error('completed stream id reused');
     if (streams.has(streamId)) {
       abortLocalStream(streamId, 'duplicate stream id');
       void sendAbort(streamId, 'duplicate stream id');
@@ -598,6 +665,7 @@ export const createTunnelHost = ({
       abortLocalStream(streamId, 'connection closed');
     }
     streams.clear();
+    completedHttpStreams.clear();
     incompleteFragments.clear();
     assembler.clear();
   };
@@ -607,6 +675,10 @@ export const createTunnelHost = ({
     close,
     get streamCount() {
       return streams.size;
+    },
+    get completedHttpStreamCount() {
+      pruneCompletedHttpStreams();
+      return completedHttpStreams.size;
     },
   };
 };

--- a/packages/web/server/lib/relay/tunnel-host.js
+++ b/packages/web/server/lib/relay/tunnel-host.js
@@ -133,7 +133,7 @@ export const createTunnelHost = ({
   failClosedPolicy = false,
   onProtocolFailure,
 }) => {
-  /** @type {Map<number, { kind: 'http', abort: AbortController, body: ReadableStreamDefaultController | null, responseBody: ReadableStream | null, noBody: boolean } | { kind: 'ws', socket: WebSocket, opened: boolean }>} */
+  /** @type {Map<number, { kind: 'http', abort: AbortController, body: ReadableStreamDefaultController | null, requestBody: ReadableStream | undefined, responseBody: ReadableStream | null, noBody: boolean } | { kind: 'ws', socket: WebSocket, opened: boolean }>} */
   const streams = new Map();
   const assembler = createFragmentAssembler();
   const incompleteFragments = new Set();
@@ -311,17 +311,7 @@ export const createTunnelHost = ({
       return;
     }
 
-    const hasBody = method !== 'GET' && method !== 'HEAD';
-    let requestBody;
-    if (hasBody) {
-      requestBody = new ReadableStream({
-        start(controller) {
-          stream.body = controller;
-        },
-      });
-    } else {
-      stream.body = null;
-    }
+    const hasBody = !stream.noBody;
 
     const url = `http://127.0.0.1:${getLocalPort()}${request.path}${request.query ? `?${request.query}` : ''}`;
     let response;
@@ -329,7 +319,7 @@ export const createTunnelHost = ({
       response = await fetch(url, {
         method,
         headers: buildRequestHeaders(request.headers),
-        body: requestBody,
+        body: stream.requestBody,
         duplex: hasBody ? 'half' : undefined,
         signal: stream.abort.signal,
       });
@@ -390,7 +380,22 @@ export const createTunnelHost = ({
       return;
     }
     const method = request.method.toUpperCase();
-    const stream = { kind: 'http', generation: nextGeneration++, abort: new AbortController(), body: null, responseBody: null, noBody: method === 'GET' || method === 'HEAD' };
+    const stream = {
+      kind: 'http',
+      generation: nextGeneration++,
+      abort: new AbortController(),
+      body: null,
+      requestBody: undefined,
+      responseBody: null,
+      noBody: method === 'GET' || method === 'HEAD',
+    };
+    if (!stream.noBody) {
+      stream.requestBody = new ReadableStream({
+        start(controller) {
+          stream.body = controller;
+        },
+      });
+    }
     if (atStreamLimit('http')) {
       onLimitExceeded?.('stream-limit');
       void sendAbort(streamId, 'stream limit exceeded');
@@ -420,9 +425,8 @@ export const createTunnelHost = ({
       return;
     }
     if (stream.kind !== 'http' || stream.noBody) throw new Error('unsolicited http body');
-    // The body controller attaches synchronously in runHttpStream before any
-    // await, so by the time body frames arrive it is set for body-carrying
-    // methods; drop stray body bytes otherwise.
+    // The body controller attaches synchronously when the stream opens, before
+    // policy evaluation or loopback dispatch can await.
     try {
       stream.body?.enqueue(payload);
     } catch {

--- a/packages/web/server/lib/relay/tunnel-host.js
+++ b/packages/web/server/lib/relay/tunnel-host.js
@@ -35,6 +35,17 @@ const ALLOWED_WS_PATHS = new Set([
   '/api/dictation/ws',
 ]);
 
+const canonicalizeTarget = (path, query) => {
+  if (typeof path !== 'string' || typeof query !== 'string' || !path.startsWith('/') || path.startsWith('//')) return null;
+  if (/[%](?:2f|5c|2e)/i.test(path) || /[\\?#\0-\x1f\x7f]/.test(path) || path.includes('//')) return null;
+  let decoded;
+  try { decoded = decodeURIComponent(path); } catch { return null; }
+  if (decoded.split('/').some((part) => part === '.' || part === '..') || /[\\?#\0-\x1f\x7f]/.test(decoded)) return null;
+  const url = new URL(`${path}${query ? `?${query}` : ''}`, 'http://loopback.invalid');
+  if (url.username || url.password || url.pathname !== path || url.search.slice(1) !== query) return null;
+  return { path: url.pathname, query: url.search.slice(1) };
+};
+
 // Hop-by-hop headers stripped from tunneled requests; `host` is set by fetch
 // to the loopback origin. content-length is dropped too because the body is
 // re-chunked through the tunnel and undici computes framing itself.
@@ -46,6 +57,13 @@ const STRIPPED_REQUEST_HEADERS = new Set([
   'host',
   'content-length',
 ]);
+
+const isUntrustedTransportHeader = (name, stripOrigin) =>
+  name === 'forwarded'
+  || name.startsWith('x-forwarded-')
+  || name.startsWith('cf-')
+  || name.startsWith('x-openchamber-')
+  || (stripOrigin && name === 'origin');
 
 // Response framing headers that no longer apply once the body crosses the
 // tunnel as HttpBody chunks (loopback fetch already decoded content-encoding).
@@ -85,13 +103,39 @@ const isWsClosePayload = (parsed) => Boolean(parsed && typeof parsed === 'object
  *   getLocalPort: () => number,
  *   sendFrame: (plaintextFrame: Uint8Array) => void | Promise<void>,
  *   getBufferedAmount: () => number,
+ *   transportContext?: { requestHeaders?: Record<string, string>, wsHeaders?: Record<string, string>, metadataHeader?: string | null, stripOrigin?: boolean },
+ *   requestPolicy?: (request: { kind: 'http' | 'ws', streamId: number, generation: number, method?: string, path: string, query: string, headers?: Record<string, string> }) => boolean | string | Promise<boolean | string>,
+ *   onRequest?: (request: object) => void,
+ *   onResponse?: (response: { kind: 'http', streamId: number, generation: number, status: number }) => void | Promise<void>,
+ *   onLimitExceeded?: (reason: string) => void,
+ *   onStreamClosed?: (event: { streamId: number, generation: number, kind: 'http' | 'ws', reason: string }) => void,
+ *   limits?: { maxStreams?: number, maxWebSockets?: number, maxIncompleteFragments?: number, maxIncompleteFragmentBytes?: number, getMaxIncompleteFragmentBytes?: () => number, maxStreamOpens?: number, streamOpenWindowMs?: number },
+ *   failClosedPolicy?: boolean,
+ *   onProtocolFailure?: () => void,
  * }} deps
  */
-export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBufferedAmount }) => {
-  /** @type {Map<number, { kind: 'http', abort: AbortController, body: ReadableStreamDefaultController | null } | { kind: 'ws', socket: WebSocket, opened: boolean }>} */
+export const createTunnelHost = ({
+  connectionId,
+  getLocalPort,
+  sendFrame,
+  getBufferedAmount,
+  transportContext = {},
+  requestPolicy,
+  onRequest,
+  onResponse,
+  onLimitExceeded,
+  onStreamClosed,
+  limits = {},
+  failClosedPolicy = false,
+  onProtocolFailure,
+}) => {
+  /** @type {Map<number, { kind: 'http', abort: AbortController, body: ReadableStreamDefaultController | null, responseBody: ReadableStream | null, noBody: boolean } | { kind: 'ws', socket: WebSocket, opened: boolean }>} */
   const streams = new Map();
   const assembler = createFragmentAssembler();
+  const incompleteFragments = new Set();
   let closed = false;
+  const streamOpenTimes = [];
+  let nextGeneration = 1;
 
   const send = async (frame) => {
     if (closed) return;
@@ -105,22 +149,23 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     await sendJson(TunnelFrameType.StreamAbort, streamId, { reason: String(reason ?? 'stream error') });
   };
 
-  const dropStream = (streamId) => {
+  const dropStream = (streamId, reason = 'completed') => {
+    const stream = streams.get(streamId);
     streams.delete(streamId);
     assembler.dropStream(streamId);
+    for (const key of incompleteFragments) {
+      if (key.startsWith(`${streamId}:`)) incompleteFragments.delete(key);
+    }
+    if (stream) onStreamClosed?.({ streamId, generation: stream.generation, kind: stream.kind, reason });
   };
 
   const abortLocalStream = (streamId, reason) => {
     const stream = streams.get(streamId);
     if (!stream) return;
-    dropStream(streamId);
+    dropStream(streamId, String(reason ?? 'aborted'));
     if (stream.kind === 'http') {
-      try {
-        stream.body?.error(new Error(String(reason ?? 'aborted')));
-      } catch {
-        // body already closed
-      }
       stream.abort.abort();
+      void stream.responseBody?.cancel().catch(() => {});
     } else {
       try {
         stream.socket.terminate();
@@ -146,12 +191,43 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     for (const [name, value] of Object.entries(rawHeaders)) {
       if (typeof name !== 'string' || typeof value !== 'string') continue;
       const lower = name.toLowerCase();
-      if (STRIPPED_REQUEST_HEADERS.has(lower)) continue;
+      if (STRIPPED_REQUEST_HEADERS.has(lower) || isUntrustedTransportHeader(lower, transportContext.stripOrigin === true)) continue;
       if (/[\r\n]/.test(name) || /[\r\n]/.test(value)) continue;
       headers[lower] = value;
     }
-    headers['x-openchamber-relay-connection'] = connectionId;
+    const metadataHeader = transportContext.metadataHeader === undefined
+      ? 'x-openchamber-relay-connection'
+      : transportContext.metadataHeader;
+    if (metadataHeader) headers[metadataHeader.toLowerCase()] = connectionId;
+    for (const [name, value] of Object.entries(transportContext.requestHeaders ?? {})) {
+      headers[name.toLowerCase()] = value;
+    }
     return headers;
+  };
+
+  const policyRejection = async (request) => {
+    onRequest?.(request);
+    const result = await requestPolicy?.(request);
+    if (result === false) return 'Request rejected by transport policy';
+    return typeof result === 'string' ? result : null;
+  };
+
+  const exceedsOpenRate = () => {
+    if (!Number.isFinite(limits.maxStreamOpens)) return false;
+    const now = Date.now();
+    const windowMs = Number.isFinite(limits.streamOpenWindowMs) ? limits.streamOpenWindowMs : 10_000;
+    while (streamOpenTimes.length > 0 && now - streamOpenTimes[0] >= windowMs) streamOpenTimes.shift();
+    if (streamOpenTimes.length >= limits.maxStreamOpens) return true;
+    streamOpenTimes.push(now);
+    return false;
+  };
+
+  const atStreamLimit = (kind) => {
+    if (Number.isFinite(limits.maxStreams) && streams.size >= limits.maxStreams) return true;
+    if (kind !== 'ws' || !Number.isFinite(limits.maxWebSockets)) return false;
+    let count = 0;
+    for (const stream of streams.values()) if (stream.kind === 'ws') count += 1;
+    return count >= limits.maxWebSockets;
   };
 
   // Synthetic responses never ship an empty body: `reason` states explicitly
@@ -166,15 +242,26 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
   };
 
   const runHttpStream = async (streamId, request) => {
+    const target = canonicalizeTarget(request.path, request.query);
+    if (!target) throw new Error('invalid request target');
+    request.path = target.path;
+    request.query = target.query;
     const method = request.method.toUpperCase();
     if (!isAllowedHttpPath(request.path)) {
-      dropStream(streamId);
+      dropStream(streamId, 'path-rejected');
+      if (failClosedPolicy) throw new Error('path rejected');
       await syntheticResponse(streamId, 403, 'Path is not allowed through the relay');
       return;
     }
-
     const stream = streams.get(streamId);
     if (!stream || stream.kind !== 'http') return;
+    const rejected = await policyRejection({ kind: 'http', streamId, generation: stream.generation, method, path: request.path, query: request.query, headers: request.headers });
+    if (rejected) {
+      dropStream(streamId, 'policy-rejected');
+      if (failClosedPolicy) throw new Error('request rejected by transport policy');
+      await syntheticResponse(streamId, 403, rejected);
+      return;
+    }
 
     const hasBody = method !== 'GET' && method !== 'HEAD';
     let requestBody;
@@ -186,7 +273,6 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       });
     } else {
       stream.body = null;
-      stream.noBody = true;
     }
 
     const url = `http://127.0.0.1:${getLocalPort()}${request.path}${request.query ? `?${request.query}` : ''}`;
@@ -201,11 +287,12 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       });
     } catch (error) {
       if (streams.get(streamId) === stream) {
-        dropStream(streamId);
+        dropStream(streamId, 'request-failed');
         await sendAbort(streamId, error?.message ?? 'loopback request failed');
       }
       return;
     }
+    stream.responseBody = response.body;
 
     const responseHeaders = {};
     for (const [name, value] of response.headers.entries()) {
@@ -213,6 +300,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       responseHeaders[name] = value;
     }
     await sendJson(TunnelFrameType.HttpResponse, streamId, { status: response.status, headers: responseHeaders });
+    await onResponse?.({ kind: 'http', streamId, generation: stream.generation, status: response.status });
 
     try {
       if (response.body) {
@@ -227,12 +315,12 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
         }
       }
       if (streams.get(streamId) === stream) {
-        dropStream(streamId);
+        dropStream(streamId, 'completed');
         await send(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array(0)));
       }
     } catch (error) {
       if (streams.get(streamId) === stream) {
-        dropStream(streamId);
+        dropStream(streamId, 'response-failed');
         await sendAbort(streamId, error?.message ?? 'loopback response failed');
       }
     }
@@ -248,17 +336,29 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     try {
       request = decodeJsonPayload(payload, isHttpRequestPayload);
     } catch (error) {
+      if (failClosedPolicy) throw error;
       void sendAbort(streamId, error?.message ?? 'malformed request');
       return;
     }
-    const stream = { kind: 'http', abort: new AbortController(), body: null, noBody: false };
+    const method = request.method.toUpperCase();
+    const stream = { kind: 'http', generation: nextGeneration++, abort: new AbortController(), body: null, responseBody: null, noBody: method === 'GET' || method === 'HEAD' };
+    if (atStreamLimit('http')) {
+      onLimitExceeded?.('stream-limit');
+      void sendAbort(streamId, 'stream limit exceeded');
+      return;
+    }
+    if (exceedsOpenRate()) {
+      onLimitExceeded?.('stream-open-rate');
+      void sendAbort(streamId, 'stream open rate exceeded');
+      return;
+    }
     streams.set(streamId, stream);
-    void runHttpStream(streamId, request);
+    void runHttpStream(streamId, request).catch(() => onProtocolFailure?.());
   };
 
   const handleHttpBody = (streamId, payload) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'http' || stream.noBody) return;
+    if (!stream || stream.kind !== 'http' || stream.noBody) throw new Error('unsolicited http body');
     // The body controller attaches synchronously in runHttpStream before any
     // await, so by the time body frames arrive it is set for body-carrying
     // methods; drop stray body bytes otherwise.
@@ -271,7 +371,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
 
   const handleStreamEnd = (streamId) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'http') return;
+    if (!stream || stream.kind !== 'http') throw new Error('unsolicited stream end');
     try {
       stream.body?.close();
     } catch {
@@ -284,7 +384,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
   // WebSocket
   // -------------------------------------------------------------------------
 
-  const handleWsOpen = (streamId, payload) => {
+  const handleWsOpen = async (streamId, payload) => {
     if (streams.has(streamId)) {
       abortLocalStream(streamId, 'duplicate stream id');
       void sendAbort(streamId, 'duplicate stream id');
@@ -294,11 +394,34 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     try {
       open = decodeJsonPayload(payload, isWsOpenPayload);
     } catch (error) {
+      if (failClosedPolicy) throw error;
       void sendAbort(streamId, error?.message ?? 'malformed ws open');
       return;
     }
+    const target = canonicalizeTarget(open.path, open.query);
+    if (!target) throw new Error('invalid websocket target');
+    open.path = target.path;
+    open.query = target.query;
     if (!ALLOWED_WS_PATHS.has(open.path)) {
+      if (failClosedPolicy) throw new Error('path rejected');
       void sendAbort(streamId, 'Path is not allowed through the relay');
+      return;
+    }
+    const generation = nextGeneration++;
+    const rejected = await policyRejection({ kind: 'ws', streamId, generation, path: open.path, query: open.query });
+    if (rejected) {
+      if (failClosedPolicy) throw new Error('request rejected by transport policy');
+      void sendAbort(streamId, rejected);
+      return;
+    }
+    if (atStreamLimit('ws')) {
+      onLimitExceeded?.('websocket-limit');
+      void sendAbort(streamId, 'stream limit exceeded');
+      return;
+    }
+    if (exceedsOpenRate()) {
+      onLimitExceeded?.('stream-open-rate');
+      void sendAbort(streamId, 'stream open rate exceeded');
       return;
     }
 
@@ -311,9 +434,13 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     // otherwise — a no-origin upgrade is rejected 403. The request itself is still
     // authenticated by the tunneled oc_url_token, not by this origin.
     const dialHeaders = {
-      'x-openchamber-relay-connection': connectionId,
       origin: `http://127.0.0.1:${getLocalPort()}`,
     };
+    const metadataHeader = transportContext.metadataHeader === undefined
+      ? 'x-openchamber-relay-connection'
+      : transportContext.metadataHeader;
+    if (metadataHeader) dialHeaders[metadataHeader.toLowerCase()] = connectionId;
+    Object.assign(dialHeaders, transportContext.wsHeaders ?? {});
     let socket;
     try {
       socket = new WebSocket(url, open.protocols, {
@@ -323,7 +450,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       void sendAbort(streamId, error?.message ?? 'ws dial failed');
       return;
     }
-    const stream = { kind: 'ws', socket, opened: false };
+    const stream = { kind: 'ws', generation, socket, opened: false, sendChain: Promise.resolve() };
     streams.set(streamId, stream);
 
     socket.on('open', () => {
@@ -335,17 +462,21 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       if (streams.get(streamId) !== stream || closed) return;
       const bytes = Buffer.isBuffer(data) ? new Uint8Array(data) : new Uint8Array(Buffer.concat(data));
       const frameType = isBinary ? TunnelFrameType.WsBinary : TunnelFrameType.WsText;
-      void (async () => {
+      stream.sendChain = stream.sendChain.then(async () => {
         for (const frame of encodeFragmentedMessage(frameType, streamId, bytes)) {
           await waitForBackpressure(null);
           if (streams.get(streamId) !== stream || closed) return;
           await send(frame);
         }
-      })();
+      }).catch(() => {
+        if (streams.get(streamId) !== stream) return;
+        abortLocalStream(streamId, 'send-failed');
+        onProtocolFailure?.();
+      });
     });
     socket.on('close', (code, reasonBuffer) => {
       if (streams.get(streamId) !== stream) return;
-      dropStream(streamId);
+      dropStream(streamId, 'upstream-closed');
       const reason = reasonBuffer ? reasonBuffer.toString('utf8') : '';
       if (stream.opened) {
         void sendJson(TunnelFrameType.WsClose, streamId, { code: code || 1000, reason });
@@ -356,7 +487,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
     socket.on('error', (error) => {
       if (streams.get(streamId) !== stream) return;
       if (!stream.opened) {
-        dropStream(streamId);
+        dropStream(streamId, 'upstream-error');
         try {
           socket.terminate();
         } catch {
@@ -370,7 +501,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
 
   const handleWsMessage = (streamId, frameType, message) => {
     const stream = streams.get(streamId);
-    if (!stream || stream.kind !== 'ws' || stream.socket.readyState !== WebSocket.OPEN) return;
+    if (!stream || stream.kind !== 'ws' || !stream.opened || stream.socket.readyState !== WebSocket.OPEN) throw new Error('unsolicited websocket data');
     if (frameType === TunnelFrameType.WsText) {
       stream.socket.send(Buffer.from(message).toString('utf8'));
     } else {
@@ -381,7 +512,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
   const handleWsClose = (streamId, payload) => {
     const stream = streams.get(streamId);
     if (!stream || stream.kind !== 'ws') return;
-    dropStream(streamId);
+    dropStream(streamId, 'closed-by-client');
     let close = { code: 1000, reason: '' };
     try {
       close = decodeJsonPayload(payload, isWsClosePayload);
@@ -407,8 +538,26 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
 
     // WS message frames can be fragmented; everything else arrives whole.
     if (frame.frameType === TunnelFrameType.WsText || frame.frameType === TunnelFrameType.WsBinary) {
+      const stream = streams.get(frame.streamId);
+      if (!stream || stream.kind !== 'ws' || !stream.opened || stream.socket.readyState !== WebSocket.OPEN) {
+        throw new Error('unsolicited websocket data');
+      }
+      const fragmentKey = `${frame.streamId}:${frame.frameType}`;
+      if (frame.hasMoreFragments && !incompleteFragments.has(fragmentKey)) {
+        if (Number.isFinite(limits.maxIncompleteFragments) && incompleteFragments.size >= limits.maxIncompleteFragments) {
+          onLimitExceeded?.('fragment-limit');
+          await sendAbort(frame.streamId, 'incomplete fragment limit exceeded');
+          return;
+        }
+        incompleteFragments.add(fragmentKey);
+      }
       const message = assembler.push(frame);
+      const fragmentByteLimit = limits.getMaxIncompleteFragmentBytes?.() ?? limits.maxIncompleteFragmentBytes;
+      if (Number.isFinite(fragmentByteLimit) && assembler.pendingBytes > fragmentByteLimit) {
+        throw new Error('incomplete fragment byte limit exceeded');
+      }
       if (message === null) return;
+      incompleteFragments.delete(fragmentKey);
       handleWsMessage(frame.streamId, frame.frameType, message);
       return;
     }
@@ -427,7 +576,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
         abortLocalStream(frame.streamId, 'aborted by client');
         return;
       case TunnelFrameType.WsOpen:
-        handleWsOpen(frame.streamId, frame.payload);
+        await handleWsOpen(frame.streamId, frame.payload);
         return;
       case TunnelFrameType.WsClose:
         handleWsClose(frame.streamId, frame.payload);
@@ -438,8 +587,7 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       case TunnelFrameType.Pong:
         return;
       default:
-        // Host never receives HttpResponse/WsOpened; ignore rather than tear down.
-        return;
+        throw new Error('prohibited tunnel frame');
     }
   };
 
@@ -450,6 +598,8 @@ export const createTunnelHost = ({ connectionId, getLocalPort, sendFrame, getBuf
       abortLocalStream(streamId, 'connection closed');
     }
     streams.clear();
+    incompleteFragments.clear();
+    assembler.clear();
   };
 
   return {

--- a/packages/web/server/lib/relay/tunnel-host.test.js
+++ b/packages/web/server/lib/relay/tunnel-host.test.js
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import http from 'node:http';
+import { WebSocketServer } from 'ws';
+
+import { createTunnelHost } from './tunnel-host.js';
+import { MAX_TUNNEL_PAYLOAD_BYTES, TunnelFrameType, decodeJsonPayload, decodeTunnelFrame, encodeJsonPayload, encodeTunnelFrame } from './tunnel-codec.js';
+
+const servers = [];
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise((resolve) => server.close(resolve))));
+});
+
+const startOrigin = async () => {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    received.push({ headers: req.headers, url: req.url });
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  servers.push(server);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return { port: server.address().port, received };
+};
+
+const startWsOrigin = async (onConnection = () => {}) => {
+  const server = http.createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (req, socket, head) => wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws)));
+  wss.on('connection', onConnection);
+  servers.push({ close: (done) => { for (const ws of wss.clients) ws.terminate(); wss.close(); server.closeAllConnections?.(); server.close(done); } });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return { port: server.address().port, wss };
+};
+
+const openNested = async (host, sent, streamId = 1) => {
+  await host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsOpen, streamId, encodeJsonPayload({ path: '/api/global/event/ws', query: '', protocols: [] })));
+  await waitFor(() => sent.some((raw) => {
+    const frame = decodeTunnelFrame(raw);
+    return frame.streamId === streamId && frame.frameType === TunnelFrameType.WsOpened;
+  }));
+};
+
+const waitFor = async (predicate) => {
+  for (let i = 0; i < 100; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('condition not reached');
+};
+
+describe('tunnel host policy seams', () => {
+  it('strips untrusted forwarding and internal headers before trusted context injection', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({
+      connectionId: 'direct-1',
+      getLocalPort: () => origin.port,
+      getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame),
+      transportContext: {
+        metadataHeader: null,
+        stripOrigin: true,
+        requestHeaders: { 'x-openchamber-transport': 'trusted-marker' },
+      },
+    });
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({
+      method: 'GET', path: '/health', query: '', headers: {
+        forwarded: 'for=attacker', 'x-forwarded-for': 'attacker', 'cf-connecting-ip': 'attacker',
+        origin: 'https://attacker.test', 'x-openchamber-transport': 'attacker', accept: 'application/json',
+      },
+    })));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+    await waitFor(() => origin.received.length === 1);
+    const headers = origin.received[0].headers;
+    expect(headers.forwarded).toBeUndefined();
+    expect(headers['x-forwarded-for']).toBeUndefined();
+    expect(headers['cf-connecting-ip']).toBeUndefined();
+    expect(headers.origin).toBeUndefined();
+    expect(headers['x-openchamber-transport']).toBe('trusted-marker');
+    expect(headers['x-openchamber-relay-connection']).toBeUndefined();
+    host.close();
+  });
+
+  it('fails closed for disallowed HTTP and WebSocket paths', async () => {
+    const origin = await startOrigin();
+    let failures = 0;
+    const host = createTunnelHost({
+      connectionId: 'closed-paths', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame() {}, failClosedPolicy: true, onProtocolFailure: () => { failures += 1; },
+    });
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/forbidden', query: '', headers: {} })));
+    await waitFor(() => failures === 1);
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsOpen, 3, encodeJsonPayload({ path: '/forbidden', query: '', protocols: [] })))).rejects.toThrow('path rejected');
+    host.close();
+  });
+
+  it('rejects unknown-stream fragments before assembly', async () => {
+    const host = createTunnelHost({ connectionId: 'unknown-fragment', getLocalPort: () => 1, getBufferedAmount: () => 0, sendFrame() {} });
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsText, 99, new Uint8Array([1]), true))).rejects.toThrow('unsolicited websocket data');
+    host.close();
+  });
+
+  it('enforces aggregate fragment bytes, frees them on abort, and switches to the authenticated budget', async () => {
+    const origin = await startWsOrigin();
+    const sent = [];
+    let authenticated = false;
+    const host = createTunnelHost({
+      connectionId: 'fragment-budget', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { getMaxIncompleteFragmentBytes: () => authenticated ? 8 : 3 },
+    });
+    await openNested(host, sent, 1);
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsText, 1, new Uint8Array([1, 2, 3]), true));
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsBinary, 1, new Uint8Array([4]), true))).rejects.toThrow('incomplete fragment byte limit exceeded');
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamAbort, 1, new Uint8Array()));
+    await openNested(host, sent, 3);
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsText, 3, new Uint8Array([1, 2, 3]), true));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamAbort, 3, new Uint8Array()));
+    authenticated = true;
+    await openNested(host, sent, 5);
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.WsText, 5, new Uint8Array(8), true));
+    host.close();
+  });
+
+  it('rejects ambiguous paths while preserving normal paths and encoded query values', async () => {
+    const invalid = ['/api/../auth', '/api/%2e%2e/auth', '/api%2fauth', '/api%5cauth', '/api\\auth', '/api//health', '/api/\0x', '/api/x?hidden'];
+    for (const path of invalid) {
+      let failures = 0;
+      const host = createTunnelHost({ connectionId: 'canonical', getLocalPort: () => 1, getBufferedAmount: () => 0, sendFrame() {}, failClosedPolicy: true, onProtocolFailure: () => { failures += 1; } });
+      await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path, query: '', headers: {} })));
+      await waitFor(() => failures === 1);
+      host.close();
+    }
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({ connectionId: 'canonical-ok', getLocalPort: () => origin.port, getBufferedAmount: () => 0, sendFrame: (frame) => sent.push(frame) });
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/api/config', query: 'value=a%2Fb%3Fc%26d', headers: {} })));
+    await waitFor(() => origin.received.length === 1);
+    expect(origin.received[0].url).toBe('/api/config?value=a%2Fb%3Fc%26d');
+    host.close();
+  });
+
+  it('serializes fragmented text and binary messages through artificial backpressure', async () => {
+    const text = 't'.repeat(MAX_TUNNEL_PAYLOAD_BYTES + 10);
+    const binary = new Uint8Array(MAX_TUNNEL_PAYLOAD_BYTES + 10).fill(7);
+    const origin = await startWsOrigin((ws) => { ws.send(text); ws.send(binary, { binary: true }); });
+    const sent = [];
+    let blocked = true;
+    const host = createTunnelHost({ connectionId: 'serialized', getLocalPort: () => origin.port, getBufferedAmount: () => blocked ? 5 * 1024 * 1024 : 0, sendFrame: (frame) => sent.push(frame) });
+    await openNested(host, sent);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    blocked = false;
+    await waitFor(() => sent.filter((raw) => [TunnelFrameType.WsText, TunnelFrameType.WsBinary].includes(decodeTunnelFrame(raw).frameType)).length === 4);
+    const types = sent.map(decodeTunnelFrame).filter((frame) => [TunnelFrameType.WsText, TunnelFrameType.WsBinary].includes(frame.frameType)).map((frame) => frame.frameType);
+    expect(types).toEqual([TunnelFrameType.WsText, TunnelFrameType.WsText, TunnelFrameType.WsBinary, TunnelFrameType.WsBinary]);
+    host.close();
+  });
+
+  it('turns send-chain rejection into one protocol failure and stream cleanup', async () => {
+    const origin = await startWsOrigin((ws) => ws.send('payload'));
+    const sent = [];
+    let failures = 0;
+    const closed = [];
+    const host = createTunnelHost({
+      connectionId: 'send-reject', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => { if (decodeTunnelFrame(frame).frameType === TunnelFrameType.WsText) return Promise.reject(new Error('blocked')); sent.push(frame); },
+      onProtocolFailure: () => { failures += 1; }, onStreamClosed: (event) => closed.push(event),
+    });
+    await openNested(host, sent);
+    await waitFor(() => failures === 1);
+    expect(host.streamCount).toBe(0);
+    expect(closed.some((event) => event.reason === 'send-failed')).toBe(true);
+    host.close();
+  });
+
+  it('rejects limit + 1 streams without changing omitted relay defaults', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({
+      connectionId: 'limited', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { maxStreams: 1 },
+    });
+    const request = (streamId) => host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, streamId, encodeJsonPayload({
+      method: 'POST', path: '/health', query: '', headers: {},
+    })));
+    await request(1);
+    await request(2);
+    await waitFor(() => sent.some((raw) => {
+      const frame = decodeTunnelFrame(raw);
+      return frame.streamId === 2 && frame.frameType === TunnelFrameType.StreamAbort
+        && decodeJsonPayload(frame.payload, (value) => value).reason === 'stream limit exceeded';
+    }));
+    expect(host.streamCount).toBe(1);
+    host.close();
+  });
+});

--- a/packages/web/server/lib/relay/tunnel-host.test.js
+++ b/packages/web/server/lib/relay/tunnel-host.test.js
@@ -48,6 +48,16 @@ const waitFor = async (predicate) => {
   throw new Error('condition not reached');
 };
 
+const openHttpAndWaitCompleted = async (host, sent, streamId, method) => {
+  await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, streamId, encodeJsonPayload({
+    method, path: '/health', query: '', headers: {},
+  })));
+  await waitFor(() => sent.some((raw) => {
+    const frame = decodeTunnelFrame(raw);
+    return frame.streamId === streamId && frame.frameType === TunnelFrameType.StreamEnd;
+  }));
+};
+
 describe('tunnel host policy seams', () => {
   it('strips untrusted forwarding and internal headers before trusted context injection', async () => {
     const origin = await startOrigin();
@@ -191,5 +201,82 @@ describe('tunnel host policy seams', () => {
     }));
     expect(host.streamCount).toBe(1);
     host.close();
+  });
+
+  it('tolerates bounded late DELETE body frames and consumes the tombstone on StreamEnd', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({
+      connectionId: 'late-delete', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { maxLateHttpBodyFrames: 2, maxLateHttpBodyBytes: 4 },
+    });
+    await openHttpAndWaitCompleted(host, sent, 1, 'DELETE');
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1, 2])));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([3, 4])));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()))).rejects.toThrow('unsolicited stream end');
+    host.close();
+  });
+
+  it('tolerates a late GET StreamEnd but rejects a late GET body', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({ connectionId: 'late-get', getLocalPort: () => origin.port, getBufferedAmount: () => 0, sendFrame: (frame) => sent.push(frame) });
+    await openHttpAndWaitCompleted(host, sent, 1, 'GET');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1])))).rejects.toThrow('unsolicited http body');
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+    host.close();
+  });
+
+  it('keeps unknown IDs and tombstoned ID reuse fatal', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({ connectionId: 'unknown-reuse', getLocalPort: () => origin.port, getBufferedAmount: () => 0, sendFrame: (frame) => sent.push(frame) });
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 99, new Uint8Array()))).rejects.toThrow('unsolicited stream end');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 99, new Uint8Array([1])))).rejects.toThrow('unsolicited http body');
+    await openHttpAndWaitCompleted(host, sent, 1, 'GET');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({ method: 'GET', path: '/health', query: '', headers: {} })))).rejects.toThrow('completed stream id reused');
+    host.close();
+  });
+
+  it('expires and evicts completed HTTP tombstones deterministically', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    let now = 100;
+    const host = createTunnelHost({
+      connectionId: 'tombstone-bounds', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { completedHttpStreamTtlMs: 5, maxCompletedHttpStreams: 1, now: () => now },
+    });
+    await openHttpAndWaitCompleted(host, sent, 1, 'GET');
+    await openHttpAndWaitCompleted(host, sent, 2, 'GET');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()))).rejects.toThrow('unsolicited stream end');
+    now = 106;
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 2, new Uint8Array()))).rejects.toThrow('unsolicited stream end');
+    host.close();
+  });
+
+  it('rejects late body frames that exceed frame or byte budgets', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({
+      connectionId: 'late-body-budget', getLocalPort: () => origin.port, getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame), limits: { maxLateHttpBodyFrames: 1, maxLateHttpBodyBytes: 2 },
+    });
+    await openHttpAndWaitCompleted(host, sent, 1, 'DELETE');
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1, 2])));
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([3])))).rejects.toThrow('late http body budget exceeded');
+    await openHttpAndWaitCompleted(host, sent, 2, 'DELETE');
+    await expect(host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 2, new Uint8Array([1, 2, 3])))).rejects.toThrow('late http body budget exceeded');
+    host.close();
+  });
+
+  it('clears completed HTTP tombstones on close', async () => {
+    const origin = await startOrigin();
+    const sent = [];
+    const host = createTunnelHost({ connectionId: 'clear-tombstones', getLocalPort: () => origin.port, getBufferedAmount: () => 0, sendFrame: (frame) => sent.push(frame) });
+    await openHttpAndWaitCompleted(host, sent, 1, 'GET');
+    expect(host.completedHttpStreamCount).toBe(1);
+    host.close();
+    expect(host.completedHttpStreamCount).toBe(0);
   });
 });

--- a/packages/web/server/lib/relay/tunnel-host.test.js
+++ b/packages/web/server/lib/relay/tunnel-host.test.js
@@ -22,6 +22,22 @@ const startOrigin = async () => {
   return { port: server.address().port, received };
 };
 
+const startBodyOrigin = async () => {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      received.push({ body: Buffer.concat(chunks), headers: req.headers, url: req.url });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+  });
+  servers.push(server);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return { port: server.address().port, received };
+};
+
 const startWsOrigin = async (onConnection = () => {}) => {
   const server = http.createServer();
   const wss = new WebSocketServer({ noServer: true });
@@ -52,6 +68,10 @@ const openHttpAndWaitCompleted = async (host, sent, streamId, method) => {
   await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, streamId, encodeJsonPayload({
     method, path: '/health', query: '', headers: {},
   })));
+  if (method !== 'GET' && method !== 'HEAD') {
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, streamId, new Uint8Array([0])));
+  }
+  await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, streamId, new Uint8Array()));
   await waitFor(() => sent.some((raw) => {
     const frame = decodeTunnelFrame(raw);
     return frame.streamId === streamId && frame.frameType === TunnelFrameType.StreamEnd;
@@ -59,6 +79,32 @@ const openHttpAndWaitCompleted = async (host, sent, streamId, method) => {
 };
 
 describe('tunnel host policy seams', () => {
+  it('retains an immediate request body frame while policy approval is pending', async () => {
+    const origin = await startBodyOrigin();
+    const sent = [];
+    let approvePolicy;
+    const policyResult = new Promise((resolve) => { approvePolicy = resolve; });
+    const host = createTunnelHost({
+      connectionId: 'early-body',
+      getLocalPort: () => origin.port,
+      getBufferedAmount: () => 0,
+      sendFrame: (frame) => sent.push(frame),
+      requestPolicy: () => policyResult,
+    });
+
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpRequest, 1, encodeJsonPayload({
+      method: 'DELETE', path: '/health', query: '', headers: {},
+    })));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.HttpBody, 1, new Uint8Array([1, 2, 3])));
+    await host.handleFrame(encodeTunnelFrame(TunnelFrameType.StreamEnd, 1, new Uint8Array()));
+
+    expect(origin.received).toHaveLength(0);
+    approvePolicy(true);
+    await waitFor(() => origin.received.length === 1);
+    expect([...origin.received[0].body]).toEqual([1, 2, 3]);
+    host.close();
+  });
+
   it('strips untrusted forwarding and internal headers before trusted context injection', async () => {
     const origin = await startOrigin();
     const sent = [];

--- a/packages/web/server/lib/tunnels/DOCUMENTATION.md
+++ b/packages/web/server/lib/tunnels/DOCUMENTATION.md
@@ -7,7 +7,7 @@ This module contains tunnel provider orchestration for OpenChamber, including pr
 - `packages/web/server/lib/tunnels/index.js`: tunnel service orchestration.
 - `packages/web/server/lib/tunnels/executable-search.js`: cross-platform executable discovery, including Windows Store app aliases.
 - `packages/web/server/lib/tunnels/registry.js`: provider registry.
-- `packages/web/server/lib/tunnels/managed-config.js`: managed remote tunnel token/preset persistence runtime.
+- `packages/web/server/lib/tunnels/managed-config.js`: managed remote tunnel token/preset persistence runtime, including the per-profile direct-E2EE opt-in flag and serialized flag mutation.
 - `packages/web/server/lib/tunnels/install-help.js`: provider/platform install command metadata for missing tunnel dependencies.
 - `packages/web/server/lib/tunnels/routes.js`: tunnel API route registration and request orchestration runtime.
 - `packages/web/server/lib/tunnels/types.js`: tunnel constants, normalization, and shared type helpers.
@@ -19,3 +19,24 @@ This module contains tunnel provider orchestration for OpenChamber, including pr
 - Returned API:
   - `registerRoutes(app)`
   - `startTunnelWithNormalizedRequest(request)`
+
+## Managed remote profile contract
+- Saved profiles normalize `directE2eeEnabled` strictly: only boolean `true` enables it; legacy or invalid values become `false`.
+- Token upserts preserve the current flag when the field is omitted. The config file remains mode `0o600`.
+- Managed config reads return an empty config only when both the current and legacy files are absent. Parse, root/schema, permission, I/O, and legacy migration write failures propagate so mutations cannot replace an unreadable authoritative config.
+- Managed profile persistence writes an owner-only temporary file, applies mode
+  `0o600`, atomically renames it over the destination, repairs the final POSIX mode,
+  and removes the temporary file on failure. The serialized mutation lock recovers
+  after write failures. Parent mode `0o700` is requested/repaired only when injected
+  runtime context identifies the directory as app-owned; arbitrary parents are not
+  chmodded. Windows skips POSIX chmod while retaining temp-and-rename replacement.
+- `PATCH /api/openchamber/tunnel/managed-remote-profile/:id` mutates only this flag and never returns the connector token.
+- Active managed tunnel identity is carried as `managedRemoteTunnelPresetId` in normalized start state and provider metadata. Profile identity is part of tunnel reuse, so switching profiles replaces the connector even when mode, provider, and hostname match.
+- Tunnel status exposes profile flags, `activeManagedRemoteProfileId`, and the non-secret `directE2eeConfigured`, `directE2eeSupported`, `directE2eeAvailable`, and `directE2eeActiveSessions` fields.
+- Support is true only while the production direct-E2EE runtime is initialized.
+  Availability additionally requires the exact enabled active managed-remote profile and a matching canonical HTTPS public URL.
+- Route dependencies carry direct-session count, profile disable, tunnel replacement, and stop lifecycle hooks.
+  This module invokes those hooks but does not own encrypted sessions or revoke paired-device tokens.
+- Managed profile writes await a direct-runtime refresh with an explicit mutation reason and profile ID.
+  Failed tunnel startup clears tunnel authority and deactivates direct sessions before returning an error.
+- Legacy active tunnels without retained profile metadata use hostname fallback only when exactly one enabled saved profile matches.

--- a/packages/web/server/lib/tunnels/index.js
+++ b/packages/web/server/lib/tunnels/index.js
@@ -84,8 +84,13 @@ export function createTunnelService({
       let publicUrl = provider.resolvePublicUrl(getController());
       const activeMode = resolveActiveMode();
       const activeProvider = resolveActiveProvider();
+      const activeManagedRemoteTunnelPresetId = getController()?.managedRemoteTunnelPresetId || '';
+      const profileChanged = request.mode === 'managed-remote'
+        && activeMode === request.mode
+        && activeProvider === request.provider
+        && activeManagedRemoteTunnelPresetId !== request.managedRemoteTunnelPresetId;
 
-      if (publicUrl && (activeMode !== request.mode || activeProvider !== request.provider)) {
+      if (publicUrl && (activeMode !== request.mode || activeProvider !== request.provider || profileChanged)) {
         stop();
         publicUrl = null;
       }
@@ -121,6 +126,8 @@ export function createTunnelService({
           throw new TunnelServiceError('startup_failed', message);
         }
         controller.provider = request.provider;
+        controller.mode = request.mode;
+        controller.managedRemoteTunnelPresetId = request.managedRemoteTunnelPresetId || null;
         setController(controller);
 
         publicUrl = provider.resolvePublicUrl(controller);

--- a/packages/web/server/lib/tunnels/index.test.js
+++ b/packages/web/server/lib/tunnels/index.test.js
@@ -4,6 +4,7 @@ import { createTunnelService } from './index.js';
 import {
   TUNNEL_INTENT_EPHEMERAL_PUBLIC,
   TUNNEL_MODE_QUICK,
+  TUNNEL_MODE_MANAGED_REMOTE,
   TUNNEL_PROVIDER_CLOUDFLARE,
   TUNNEL_PROVIDER_NGROK,
 } from './types.js';
@@ -89,5 +90,44 @@ describe('createTunnelService', () => {
     expect(ngrokStarted).toBe(true);
     expect(result.provider).toBe(TUNNEL_PROVIDER_NGROK);
     expect(result.publicUrl).toBe('https://demo.ngrok-free.app');
+  });
+
+  it('replaces an active managed remote tunnel when the profile identity changes', async () => {
+    let stopCount = 0;
+    let startCount = 0;
+    let controller = {
+      provider: TUNNEL_PROVIDER_CLOUDFLARE,
+      mode: TUNNEL_MODE_MANAGED_REMOTE,
+      managedRemoteTunnelPresetId: 'profile-a',
+      getPublicUrl: () => 'https://shared.example.com',
+    };
+    const provider = {
+      ...createProvider({ provider: TUNNEL_PROVIDER_CLOUDFLARE }),
+      capabilities: {
+        provider: TUNNEL_PROVIDER_CLOUDFLARE,
+        modes: [{ key: TUNNEL_MODE_MANAGED_REMOTE, intent: 'persistent-public', requires: ['token', 'hostname'] }],
+      },
+      stop: () => { stopCount += 1; },
+      start: async () => {
+        startCount += 1;
+        return { getPublicUrl: () => 'https://shared.example.com' };
+      },
+      getMetadata: (value) => ({ managedRemoteTunnelPresetId: value.managedRemoteTunnelPresetId }),
+    };
+    const service = createTunnelService({
+      registry: createRegistry({ [TUNNEL_PROVIDER_CLOUDFLARE]: provider }),
+      getController: () => controller,
+      setController: (next) => { controller = next; },
+      getActivePort: () => 3000,
+    });
+
+    const result = await service.start({
+      provider: TUNNEL_PROVIDER_CLOUDFLARE, mode: TUNNEL_MODE_MANAGED_REMOTE,
+      hostname: 'shared.example.com', token: 'secret', managedRemoteTunnelPresetId: 'profile-b',
+    });
+    expect(stopCount).toBe(1);
+    expect(startCount).toBe(1);
+    expect(result.providerMetadata.managedRemoteTunnelPresetId).toBe('profile-b');
+    expect(controller.managedRemoteTunnelPresetId).toBe('profile-b');
   });
 });

--- a/packages/web/server/lib/tunnels/managed-config.js
+++ b/packages/web/server/lib/tunnels/managed-config.js
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 export const createManagedTunnelConfigRuntime = (deps) => {
   const {
     fsPromises,
@@ -5,6 +7,8 @@ export const createManagedTunnelConfigRuntime = (deps) => {
     normalizeManagedRemoteTunnelHostname,
     normalizeManagedRemoteTunnelPresets,
     constants,
+    platform = process.platform,
+    managedConfigDirectoryIsPrivate = false,
   } = deps;
 
   const {
@@ -43,22 +47,48 @@ export const createManagedTunnelConfigRuntime = (deps) => {
 
       seenIds.add(id);
       seenHostnames.add(hostname);
-      result.push({ id, name, hostname, token, updatedAt });
+      result.push({
+        id,
+        name,
+        hostname,
+        token,
+        updatedAt,
+        directE2eeEnabled: entry.directE2eeEnabled === true,
+      });
     }
 
     return result;
   };
 
+  const parseManagedRemoteTunnelConfig = (raw) => {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || !Array.isArray(parsed.tunnels)) {
+      throw new TypeError('Managed remote tunnel config must be an object with a tunnels array');
+    }
+    return parsed;
+  };
+
   const writeManagedRemoteTunnelConfigToDisk = async (data) => {
-    await fsPromises.mkdir(path.dirname(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH), { recursive: true });
-    await fsPromises.writeFile(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH, JSON.stringify(data, null, 2), { encoding: 'utf8', mode: 0o600 });
+    const directory = path.dirname(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH);
+    await fsPromises.mkdir(directory, { recursive: true, ...(managedConfigDirectoryIsPrivate ? { mode: 0o700 } : {}) });
+    if (managedConfigDirectoryIsPrivate && platform !== 'win32') await fsPromises.chmod(directory, 0o700);
+    const temporaryPath = `${CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await fsPromises.writeFile(temporaryPath, JSON.stringify(data, null, 2), { encoding: 'utf8', mode: 0o600 });
+      if (platform !== 'win32') await fsPromises.chmod(temporaryPath, 0o600);
+      await fsPromises.rename(temporaryPath, CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH);
+      if (platform !== 'win32') await fsPromises.chmod(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH, 0o600);
+    } catch (error) {
+      await fsPromises.unlink(temporaryPath).catch(() => {});
+      throw error;
+    }
   };
 
   const migrateManagedRemoteTunnelConfigFromLegacyFile = async () => {
     try {
       const legacyRaw = await fsPromises.readFile(CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH, 'utf8');
-      const parsed = JSON.parse(legacyRaw);
-      const tunnels = sanitizeManagedRemoteTunnelConfigEntries(parsed?.tunnels);
+      const parsed = parseManagedRemoteTunnelConfig(legacyRaw);
+      const tunnels = sanitizeManagedRemoteTunnelConfigEntries(parsed.tunnels);
       const migrated = {
         version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION,
         tunnels,
@@ -69,18 +99,14 @@ export const createManagedTunnelConfigRuntime = (deps) => {
       if (error && typeof error === 'object' && error.code === 'ENOENT') {
         return { version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION, tunnels: [] };
       }
-      console.warn('Failed to migrate legacy named tunnel config file:', error);
-      return { version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION, tunnels: [] };
+      throw error;
     }
   };
 
   const readManagedRemoteTunnelConfigFromDisk = async () => {
     try {
       const raw = await fsPromises.readFile(CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH, 'utf8');
-      const parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== 'object') {
-        return { version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION, tunnels: [] };
-      }
+      const parsed = parseManagedRemoteTunnelConfig(raw);
 
       return {
         version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION,
@@ -90,13 +116,12 @@ export const createManagedTunnelConfigRuntime = (deps) => {
       if (error && typeof error === 'object' && error.code === 'ENOENT') {
         return migrateManagedRemoteTunnelConfigFromLegacyFile();
       }
-      console.warn('Failed to read managed remote tunnel config file:', error);
-      return { version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION, tunnels: [] };
+      throw error;
     }
   };
 
   const updateManagedRemoteTunnelConfig = async (mutate) => {
-    persistManagedRemoteTunnelConfigLock = persistManagedRemoteTunnelConfigLock.then(async () => {
+    persistManagedRemoteTunnelConfigLock = persistManagedRemoteTunnelConfigLock.catch(() => {}).then(async () => {
       const current = await readManagedRemoteTunnelConfigFromDisk();
       const next = mutate({
         version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION,
@@ -141,7 +166,7 @@ export const createManagedTunnelConfigRuntime = (deps) => {
     });
   };
 
-  const upsertManagedRemoteTunnelToken = async ({ id, name, hostname, token }) => {
+  const upsertManagedRemoteTunnelToken = async ({ id, name, hostname, token, directE2eeEnabled }) => {
     if (typeof id !== 'string' || typeof name !== 'string' || typeof hostname !== 'string' || typeof token !== 'string') {
       return;
     }
@@ -154,6 +179,9 @@ export const createManagedTunnelConfigRuntime = (deps) => {
     }
 
     await updateManagedRemoteTunnelConfig((current) => {
+      const existing = current.tunnels.find((entry) => entry.id === normalizedId)
+        || current.tunnels.find((entry) => entry.hostname === normalizedHostname)
+        || null;
       const withoutConflicts = current.tunnels.filter((entry) => entry.id !== normalizedId && entry.hostname !== normalizedHostname);
       withoutConflicts.push({
         id: normalizedId,
@@ -161,6 +189,9 @@ export const createManagedTunnelConfigRuntime = (deps) => {
         hostname: normalizedHostname,
         token: normalizedToken,
         updatedAt: Date.now(),
+        directE2eeEnabled: typeof directE2eeEnabled === 'boolean'
+          ? directE2eeEnabled
+          : existing?.directE2eeEnabled === true,
       });
 
       return {
@@ -168,6 +199,26 @@ export const createManagedTunnelConfigRuntime = (deps) => {
         tunnels: withoutConflicts,
       };
     });
+  };
+
+  const setManagedRemoteTunnelDirectE2eeEnabled = async ({ id, directE2eeEnabled }) => {
+    const normalizedId = typeof id === 'string' ? id.trim() : '';
+    if (!normalizedId || typeof directE2eeEnabled !== 'boolean') {
+      return null;
+    }
+
+    let updatedProfile = null;
+    await updateManagedRemoteTunnelConfig((current) => ({
+      version: CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION,
+      tunnels: current.tunnels.map((entry) => {
+        if (entry.id !== normalizedId) {
+          return entry;
+        }
+        updatedProfile = { ...entry, directE2eeEnabled };
+        return updatedProfile;
+      }),
+    }));
+    return updatedProfile;
   };
 
   const resolveManagedRemoteTunnelToken = async ({ presetId, hostname }) => {
@@ -196,6 +247,7 @@ export const createManagedTunnelConfigRuntime = (deps) => {
     readManagedRemoteTunnelConfigFromDisk,
     syncManagedRemoteTunnelConfigWithPresets,
     upsertManagedRemoteTunnelToken,
+    setManagedRemoteTunnelDirectE2eeEnabled,
     resolveManagedRemoteTunnelToken,
   };
 };

--- a/packages/web/server/lib/tunnels/managed-config.test.js
+++ b/packages/web/server/lib/tunnels/managed-config.test.js
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from 'bun:test';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import nodePath from 'node:path';
+
+import { createManagedTunnelConfigRuntime } from './managed-config.js';
+
+const createRuntime = (initial) => {
+  let stored = initial === undefined ? null : JSON.stringify(initial);
+  let writeOptions = null;
+  const temporary = new Map();
+  const runtime = createManagedTunnelConfigRuntime({
+    fsPromises: {
+      mkdir: async () => {},
+      readFile: async (file) => {
+        if (file.endsWith('legacy.json') || stored === null) {
+          const error = new Error('missing');
+          error.code = 'ENOENT';
+          throw error;
+        }
+        return stored;
+      },
+      writeFile: async (_file, value, options) => {
+        temporary.set(_file, value);
+        writeOptions = options;
+      },
+      chmod: async () => {},
+      rename: async (from) => { stored = temporary.get(from); temporary.delete(from); },
+      unlink: async (file) => { temporary.delete(file); },
+    },
+    path: { dirname: () => '/config' },
+    normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+    normalizeManagedRemoteTunnelPresets: (value) => value,
+    constants: {
+      CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: '/config/current.json',
+      CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: '/config/legacy.json',
+      CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1,
+    },
+  });
+  return { runtime, getStored: () => JSON.parse(stored), getWriteOptions: () => writeOptions };
+};
+
+const profile = (overrides = {}) => ({
+  id: 'profile-a', name: 'A', hostname: 'a.example.com', token: 'secret-a', updatedAt: 1, ...overrides,
+});
+
+const createRuntimeWithFs = (fs) => createManagedTunnelConfigRuntime({
+  fsPromises: fs,
+  path: { dirname: () => '/config' },
+  normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+  normalizeManagedRemoteTunnelPresets: (value) => value,
+  constants: {
+    CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: '/config/current.json',
+    CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: '/config/legacy.json',
+    CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1,
+  },
+});
+
+describe('managed remote tunnel config', () => {
+  it('returns empty only when both current and legacy configs are genuinely missing', async () => {
+    const readFile = vi.fn(async () => {
+      const error = new Error('missing');
+      error.code = 'ENOENT';
+      throw error;
+    });
+    const runtime = createRuntimeWithFs({ readFile });
+
+    await expect(runtime.readManagedRemoteTunnelConfigFromDisk()).resolves.toEqual({ version: 1, tunnels: [] });
+    expect(readFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates malformed JSON and non-ENOENT current read failures', async () => {
+    const malformed = createRuntimeWithFs({ readFile: async () => '{invalid' });
+    await expect(malformed.readManagedRemoteTunnelConfigFromDisk()).rejects.toBeInstanceOf(SyntaxError);
+
+    const denied = new Error('permission denied');
+    denied.code = 'EACCES';
+    const unreadable = createRuntimeWithFs({ readFile: async () => { throw denied; } });
+    await expect(unreadable.readManagedRemoteTunnelConfigFromDisk()).rejects.toBe(denied);
+  });
+
+  it('rejects valid JSON with malformed current config shapes', async () => {
+    for (const value of [null, [], { tunnels: {} }]) {
+      const runtime = createRuntimeWithFs({ readFile: async () => JSON.stringify(value) });
+      await expect(runtime.readManagedRemoteTunnelConfigFromDisk()).rejects.toThrow(
+        'Managed remote tunnel config must be an object with a tunnels array',
+      );
+    }
+  });
+
+  it('rejects valid JSON with a malformed legacy config shape', async () => {
+    const runtime = createRuntimeWithFs({
+      readFile: async (file) => {
+        if (file.endsWith('current.json')) {
+          const missing = new Error('missing');
+          missing.code = 'ENOENT';
+          throw missing;
+        }
+        return JSON.stringify({ tunnels: {} });
+      },
+    });
+
+    await expect(runtime.readManagedRemoteTunnelConfigFromDisk()).rejects.toThrow(
+      'Managed remote tunnel config must be an object with a tunnels array',
+    );
+  });
+
+  it('propagates non-ENOENT legacy reads and migration writes', async () => {
+    const denied = new Error('legacy permission denied');
+    denied.code = 'EACCES';
+    const legacyUnreadable = createRuntimeWithFs({
+      readFile: async (file) => {
+        if (file.endsWith('current.json')) {
+          const missing = new Error('missing');
+          missing.code = 'ENOENT';
+          throw missing;
+        }
+        throw denied;
+      },
+    });
+    await expect(legacyUnreadable.readManagedRemoteTunnelConfigFromDisk()).rejects.toBe(denied);
+
+    const writeFailure = new Error('migration write failed');
+    const migrationWriteFailed = createRuntimeWithFs({
+      readFile: async (file) => {
+        if (file.endsWith('current.json')) {
+          const missing = new Error('missing');
+          missing.code = 'ENOENT';
+          throw missing;
+        }
+        return JSON.stringify({ version: 1, tunnels: [profile()] });
+      },
+      mkdir: async () => {},
+      writeFile: async () => { throw writeFailure; },
+      unlink: async () => {},
+    });
+    await expect(migrationWriteFailed.readManagedRemoteTunnelConfigFromDisk()).rejects.toBe(writeFailure);
+  });
+
+  it('does not run the mutation write after an authoritative read failure', async () => {
+    const readFailure = new Error('read failed');
+    const writeFile = vi.fn(async () => {});
+    const readPresetId = vi.fn(() => 'profile-a');
+    const presets = [{ get id() { return readPresetId(); } }];
+    const runtime = createRuntimeWithFs({
+      readFile: async () => { throw readFailure; },
+      writeFile,
+    });
+
+    await expect(runtime.syncManagedRemoteTunnelConfigWithPresets(presets)).rejects.toBe(readFailure);
+    expect(readPresetId).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('preserves malformed valid-JSON real-disk bytes when a mutation fails to read them', async () => {
+    const directory = await fsPromises.mkdtemp(nodePath.join(os.tmpdir(), 'openchamber-managed-config-corrupt-'));
+    const current = nodePath.join(directory, 'current.json');
+    const legacy = nodePath.join(directory, 'legacy.json');
+    const corruptBytes = Buffer.from('{"version":1,"tunnels":{}}');
+    await fsPromises.writeFile(current, corruptBytes);
+    const runtime = createManagedTunnelConfigRuntime({
+      fsPromises,
+      path: nodePath,
+      normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+      normalizeManagedRemoteTunnelPresets: (value) => value,
+      constants: {
+        CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: current,
+        CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: legacy,
+        CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1,
+      },
+    });
+    try {
+      await expect(runtime.upsertManagedRemoteTunnelToken(profile())).rejects.toBeInstanceOf(TypeError);
+      expect(await fsPromises.readFile(current)).toEqual(corruptBytes);
+      expect((await fsPromises.readdir(directory)).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    } finally {
+      await fsPromises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes missing and non-boolean direct E2EE flags to false', async () => {
+    const { runtime } = createRuntime({ version: 1, tunnels: [profile(), profile({ id: 'profile-b', hostname: 'b.example.com', directE2eeEnabled: 'true' })] });
+    const config = await runtime.readManagedRemoteTunnelConfigFromDisk();
+    expect(config.tunnels.map((entry) => entry.directE2eeEnabled)).toEqual([false, false]);
+  });
+
+  it('preserves the flag when an upsert omits it and writes mode 0600', async () => {
+    const { runtime, getStored, getWriteOptions } = createRuntime({ version: 1, tunnels: [profile({ directE2eeEnabled: true })] });
+    await runtime.upsertManagedRemoteTunnelToken({ id: 'profile-a', name: 'Renamed', hostname: 'a.example.com', token: 'new-secret' });
+    expect(getStored().tunnels[0]).toMatchObject({ name: 'Renamed', token: 'new-secret', directE2eeEnabled: true });
+    expect(getWriteOptions().mode).toBe(0o600);
+  });
+
+  it('serially mutates only the selected profile flag', async () => {
+    const { runtime, getStored } = createRuntime({
+      version: 1,
+      tunnels: [profile(), profile({ id: 'profile-b', hostname: 'b.example.com', token: 'secret-b' })],
+    });
+    await runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-b', directE2eeEnabled: true });
+    expect(getStored().tunnels.map(({ id, directE2eeEnabled }) => ({ id, directE2eeEnabled }))).toEqual([
+      { id: 'profile-a', directE2eeEnabled: false },
+      { id: 'profile-b', directE2eeEnabled: true },
+    ]);
+  });
+
+  it('recovers the serialization lock after a failed write', async () => {
+    let writes = 0;
+    let stored = JSON.stringify({ version: 1, tunnels: [profile()] });
+    const runtime = createManagedTunnelConfigRuntime({
+      fsPromises: {
+        mkdir: async () => {},
+        readFile: async () => stored,
+        writeFile: async (_file, value) => {
+          writes += 1;
+          if (writes === 1) throw new Error('disk full');
+          stored = value;
+        },
+        chmod: async () => {},
+        rename: async () => {},
+        unlink: async () => {},
+      },
+      path: { dirname: () => '/config' },
+      normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+      normalizeManagedRemoteTunnelPresets: (value) => value,
+      constants: {
+        CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: '/config/current.json',
+        CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: '/config/legacy.json',
+        CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1,
+      },
+    });
+    await expect(runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-a', directE2eeEnabled: true })).rejects.toThrow('disk full');
+    await runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-a', directE2eeEnabled: true });
+    expect(JSON.parse(stored).tunnels[0].directE2eeEnabled).toBe(true);
+  });
+
+  it('atomically replaces a pre-existing 0644 config with owner-only 0600 permissions', async () => {
+    if (process.platform === 'win32') return;
+    const directory = await fsPromises.mkdtemp(nodePath.join(os.tmpdir(), 'openchamber-managed-config-'));
+    const current = nodePath.join(directory, 'current.json');
+    const legacy = nodePath.join(directory, 'legacy.json');
+    await fsPromises.writeFile(current, JSON.stringify({ version: 1, tunnels: [profile()] }), { mode: 0o644 });
+    const runtime = createManagedTunnelConfigRuntime({
+      fsPromises, path: nodePath, managedConfigDirectoryIsPrivate: true,
+      normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+      normalizeManagedRemoteTunnelPresets: (value) => value,
+      constants: { CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: current, CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: legacy, CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1 },
+    });
+    try {
+      await runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-a', directE2eeEnabled: true });
+      expect((await fsPromises.stat(current)).mode & 0o777).toBe(0o600);
+      expect((await fsPromises.stat(directory)).mode & 0o777).toBe(0o700);
+      expect((await fsPromises.readdir(directory)).filter((name) => name.endsWith('.tmp'))).toEqual([]);
+    } finally {
+      await fsPromises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('cleans the temporary file when atomic rename fails and surfaces the error', async () => {
+    const files = new Set();
+    const runtime = createManagedTunnelConfigRuntime({
+      fsPromises: {
+        mkdir: async () => {}, readFile: async () => JSON.stringify({ version: 1, tunnels: [profile()] }),
+        writeFile: async (file) => { files.add(file); }, chmod: async () => {},
+        rename: async () => { throw new Error('rename failed'); }, unlink: async (file) => { files.delete(file); },
+      },
+      path: { dirname: () => '/config' },
+      normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.trim().toLowerCase() : '',
+      normalizeManagedRemoteTunnelPresets: (value) => value,
+      constants: { CLOUDFLARE_MANAGED_REMOTE_TUNNELS_FILE_PATH: '/config/current.json', CLOUDFLARE_LEGACY_NAMED_TUNNELS_FILE_PATH: '/config/legacy.json', CLOUDFLARE_MANAGED_REMOTE_TUNNELS_VERSION: 1 },
+    });
+    await expect(runtime.setManagedRemoteTunnelDirectE2eeEnabled({ id: 'profile-a', directE2eeEnabled: true })).rejects.toThrow('rename failed');
+    expect(files.size).toBe(0);
+  });
+});

--- a/packages/web/server/lib/tunnels/providers/cloudflare.js
+++ b/packages/web/server/lib/tunnels/providers/cloudflare.js
@@ -261,6 +261,7 @@ export function createCloudflareTunnelProvider() {
     getMetadata: (controller) => ({
       configPath: controller?.getEffectiveConfigPath?.() ?? null,
       resolvedHostname: controller?.getResolvedHostname?.() ?? null,
+      managedRemoteTunnelPresetId: controller?.managedRemoteTunnelPresetId ?? null,
     }),
   };
 }

--- a/packages/web/server/lib/tunnels/routes.js
+++ b/packages/web/server/lib/tunnels/routes.js
@@ -1,3 +1,22 @@
+const allowedLifecycleErrorNames = new Set(['Error', 'TypeError', 'RangeError', 'AbortError']);
+const allowedLifecycleErrorCodes = new Set([
+  'EACCES',
+  'EBUSY',
+  'ECONNRESET',
+  'EIO',
+  'ENOENT',
+  'EPERM',
+  'ETIMEDOUT',
+  'ERR_ABORTED',
+]);
+
+const lifecycleErrorMetadata = (error) => {
+  const metadata = {};
+  if (allowedLifecycleErrorNames.has(error?.name)) metadata.name = error.name;
+  if (allowedLifecycleErrorCodes.has(error?.code)) metadata.code = error.code;
+  return metadata;
+};
+
 export const createTunnelRoutesRuntime = (dependencies) => {
   const {
     crypto,
@@ -40,13 +59,51 @@ export const createTunnelRoutesRuntime = (dependencies) => {
     ? directE2eeSupported() === true
     : directE2eeSupported === true;
 
-  const awaitLifecycleCallback = async (category, callback, ...args) => {
+  const settleLifecycleCallback = async ({ category, callback, args, includeMetadata }) => {
     try {
       await callback(...args);
+      return true;
     } catch (error) {
-      console.error(`Tunnel lifecycle callback failed (${category})`, error);
+      const message = `Tunnel lifecycle callback failed (${category})`;
+      const metadata = includeMetadata ? lifecycleErrorMetadata(error) : {};
+      if (Object.keys(metadata).length > 0) {
+        console.error(message, metadata);
+      } else {
+        console.error(message);
+      }
+      return false;
     }
   };
+
+  // Production refresh clears direct-E2EE admission state before fallible reads,
+  // so notification failure remains fail-closed while the primary mutation succeeds.
+  const awaitBestEffortNotification = (category, callback, ...args) => settleLifecycleCallback({
+    category,
+    callback,
+    args,
+    includeMetadata: true,
+  });
+
+  const awaitCriticalCleanup = (category, callback, ...args) => settleLifecycleCallback({
+    category,
+    callback,
+    args,
+    includeMetadata: true,
+  });
+
+  const awaitStartFailureCleanup = (category, callback, ...args) => settleLifecycleCallback({
+    category,
+    callback,
+    args,
+    includeMetadata: false,
+  });
+
+  const sendLifecycleCleanupFailure = (res, fields = {}) => res.status(500).json({
+    ok: false,
+    error: 'Tunnel lifecycle cleanup failed',
+    code: 'lifecycle_callback_failed',
+    ...fields,
+  });
 
   const resolveActiveNormalizedTunnelMode = () => {
     const mode = tunnelService.resolveActiveMode();
@@ -104,7 +161,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname,
           token,
         });
-        await awaitLifecycleCallback('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId });
+        await awaitBestEffortNotification('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId });
       }
     }
 
@@ -117,7 +174,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       hostname,
       managedRemoteTunnelPresetId: selectedPresetId,
     });
-    await awaitLifecycleCallback('tunnel-changed:profile-switched', onTunnelChanged, { reason: 'profile-switched' });
+    await awaitBestEffortNotification('tunnel-changed:profile-switched', onTunnelChanged, { reason: 'profile-switched' });
 
     console.log(`Tunnel active (${result.provider}): ${result.publicUrl}`);
     return {
@@ -503,7 +560,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname: managedRemoteTunnelHostname,
           token: managedRemoteTunnelToken,
         });
-        await awaitLifecycleCallback('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId: presetId });
+        await awaitBestEffortNotification('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId: presetId });
 
         const managedRemoteTunnelConfig = await readManagedRemoteTunnelConfigFromDisk();
         return res.json({ ok: true, managedRemoteTunnelTokenPresetIds: managedRemoteTunnelConfig.tunnels.map((entry) => entry.id) });
@@ -536,10 +593,12 @@ export const createTunnelRoutesRuntime = (dependencies) => {
             directE2eeEnabled: req.body.directE2eeEnabled,
           });
         }
-        if (!req.body.directE2eeEnabled) {
-          await awaitLifecycleCallback('direct-e2ee-disabled', onManagedRemoteDirectE2eeDisabled, profile.id);
+        const cleanupSucceeded = req.body.directE2eeEnabled
+          || await awaitCriticalCleanup('direct-e2ee-disabled', onManagedRemoteDirectE2eeDisabled, profile.id);
+        await awaitBestEffortNotification('tunnel-changed:profile-direct-e2ee-updated', onTunnelChanged, { reason: 'profile-direct-e2ee-updated', profileId: profile.id });
+        if (!cleanupSucceeded) {
+          return sendLifecycleCleanupFailure(res);
         }
-        await awaitLifecycleCallback('tunnel-changed:profile-direct-e2ee-updated', onTunnelChanged, { reason: 'profile-direct-e2ee-updated', profileId: profile.id });
         return res.json({
           ok: true,
           profile: summarizeManagedRemoteProfile({ ...profile, directE2eeEnabled: req.body.directE2eeEnabled }),
@@ -682,7 +741,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         console.error('Failed to start tunnel:', error);
         setActiveTunnelController(null);
         tunnelAuthController.clearActiveTunnel();
-        await awaitLifecycleCallback('tunnel-stopped:start-failed', onTunnelStopped, 'tunnel-start-failed');
+        await awaitStartFailureCleanup('tunnel-stopped:start-failed', onTunnelStopped, 'tunnel-start-failed');
         if (error instanceof TunnelServiceError) {
           const status = error.code === 'missing_dependency'
             ? 400
@@ -712,8 +771,11 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       }
 
       tunnelAuthController.clearActiveTunnel();
-      await awaitLifecycleCallback('tunnel-stopped:stop', onTunnelStopped, 'tunnel-stopped');
-      res.json({ ok: true, revokedBootstrapCount, invalidatedSessionCount });
+      const cleanupSucceeded = await awaitCriticalCleanup('tunnel-stopped:stop', onTunnelStopped, 'tunnel-stopped');
+      if (!cleanupSucceeded) {
+        return sendLifecycleCleanupFailure(res, { revokedBootstrapCount, invalidatedSessionCount });
+      }
+      return res.json({ ok: true, revokedBootstrapCount, invalidatedSessionCount });
     });
   };
 

--- a/packages/web/server/lib/tunnels/routes.js
+++ b/packages/web/server/lib/tunnels/routes.js
@@ -40,6 +40,14 @@ export const createTunnelRoutesRuntime = (dependencies) => {
     ? directE2eeSupported() === true
     : directE2eeSupported === true;
 
+  const awaitLifecycleCallback = async (category, callback, ...args) => {
+    try {
+      await callback(...args);
+    } catch (error) {
+      console.error(`Tunnel lifecycle callback failed (${category})`, error);
+    }
+  };
+
   const resolveActiveNormalizedTunnelMode = () => {
     const mode = tunnelService.resolveActiveMode();
     if (mode === TUNNEL_MODE_MANAGED_LOCAL) {
@@ -96,7 +104,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname,
           token,
         });
-        await onTunnelChanged({ reason: 'profile-upserted', profileId });
+        await awaitLifecycleCallback('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId });
       }
     }
 
@@ -109,7 +117,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       hostname,
       managedRemoteTunnelPresetId: selectedPresetId,
     });
-    await onTunnelChanged({ reason: 'profile-switched' });
+    await awaitLifecycleCallback('tunnel-changed:profile-switched', onTunnelChanged, { reason: 'profile-switched' });
 
     console.log(`Tunnel active (${result.provider}): ${result.publicUrl}`);
     return {
@@ -495,7 +503,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname: managedRemoteTunnelHostname,
           token: managedRemoteTunnelToken,
         });
-        await onTunnelChanged({ reason: 'profile-upserted', profileId: presetId });
+        await awaitLifecycleCallback('tunnel-changed:profile-upserted', onTunnelChanged, { reason: 'profile-upserted', profileId: presetId });
 
         const managedRemoteTunnelConfig = await readManagedRemoteTunnelConfigFromDisk();
         return res.json({ ok: true, managedRemoteTunnelTokenPresetIds: managedRemoteTunnelConfig.tunnels.map((entry) => entry.id) });
@@ -529,9 +537,9 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           });
         }
         if (!req.body.directE2eeEnabled) {
-          await onManagedRemoteDirectE2eeDisabled(profile.id);
+          await awaitLifecycleCallback('direct-e2ee-disabled', onManagedRemoteDirectE2eeDisabled, profile.id);
         }
-        await onTunnelChanged({ reason: 'profile-direct-e2ee-updated', profileId: profile.id });
+        await awaitLifecycleCallback('tunnel-changed:profile-direct-e2ee-updated', onTunnelChanged, { reason: 'profile-direct-e2ee-updated', profileId: profile.id });
         return res.json({
           ok: true,
           profile: summarizeManagedRemoteProfile({ ...profile, directE2eeEnabled: req.body.directE2eeEnabled }),
@@ -674,7 +682,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         console.error('Failed to start tunnel:', error);
         setActiveTunnelController(null);
         tunnelAuthController.clearActiveTunnel();
-        await onTunnelStopped('tunnel-start-failed');
+        await awaitLifecycleCallback('tunnel-stopped:start-failed', onTunnelStopped, 'tunnel-start-failed');
         if (error instanceof TunnelServiceError) {
           const status = error.code === 'missing_dependency'
             ? 400
@@ -704,7 +712,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       }
 
       tunnelAuthController.clearActiveTunnel();
-      await onTunnelStopped('tunnel-stopped');
+      await awaitLifecycleCallback('tunnel-stopped:stop', onTunnelStopped, 'tunnel-stopped');
       res.json({ ok: true, revokedBootstrapCount, invalidatedSessionCount });
     });
   };

--- a/packages/web/server/lib/tunnels/routes.js
+++ b/packages/web/server/lib/tunnels/routes.js
@@ -15,7 +15,14 @@ export const createTunnelRoutesRuntime = (dependencies) => {
     normalizeTunnelSessionTtlMs,
     isSupportedTunnelMode,
     upsertManagedRemoteTunnelToken,
+    setManagedRemoteTunnelDirectE2eeEnabled,
     resolveManagedRemoteTunnelToken,
+    getDirectE2eeActiveSessionCount = () => 0,
+    onManagedRemoteDirectE2eeDisabled = () => {},
+    onTunnelStopped = () => {},
+    onTunnelChanged = async () => {},
+    directE2eeSupported = false,
+    isDirectE2eeAvailable = () => false,
     TUNNEL_MODE_QUICK,
     TUNNEL_MODE_MANAGED_LOCAL,
     TUNNEL_MODE_MANAGED_REMOTE,
@@ -29,6 +36,9 @@ export const createTunnelRoutesRuntime = (dependencies) => {
     getActiveTunnelController,
     setActiveTunnelController,
   } = dependencies;
+  const isDirectE2eeSupported = () => typeof directE2eeSupported === 'function'
+    ? directE2eeSupported() === true
+    : directE2eeSupported === true;
 
   const resolveActiveNormalizedTunnelMode = () => {
     const mode = tunnelService.resolveActiveMode();
@@ -79,12 +89,14 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       setRuntimeManagedRemoteTunnelToken(token);
 
       if (token && hostname) {
+        const profileId = selectedPresetId || hostname;
         await upsertManagedRemoteTunnelToken({
-          id: selectedPresetId || hostname,
+          id: profileId,
           name: selectedPresetName || hostname,
           hostname,
           token,
         });
+        await onTunnelChanged({ reason: 'profile-upserted', profileId });
       }
     }
 
@@ -95,7 +107,9 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       configPath,
       token,
       hostname,
+      managedRemoteTunnelPresetId: selectedPresetId,
     });
+    await onTunnelChanged({ reason: 'profile-switched' });
 
     console.log(`Tunnel active (${result.provider}): ${result.publicUrl}`);
     return {
@@ -146,6 +160,30 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         .filter((entry) => entry.status === 'fail' && entry.id !== 'startup_readiness')
         .map((entry) => entry.detail || entry.label || entry.id),
     };
+  };
+
+  const summarizeManagedRemoteProfile = (entry) => ({
+    id: entry.id,
+    name: entry.name,
+    hostname: entry.hostname,
+    directE2eeEnabled: entry.directE2eeEnabled === true,
+  });
+
+  const resolveActiveManagedRemoteProfile = ({ config, providerMetadata, publicUrl, activeMode }) => {
+    if (activeMode !== TUNNEL_MODE_MANAGED_REMOTE) {
+      return null;
+    }
+    const activeId = typeof providerMetadata?.managedRemoteTunnelPresetId === 'string'
+      ? providerMetadata.managedRemoteTunnelPresetId
+      : '';
+    if (activeId) {
+      return config.tunnels.find((entry) => entry.id === activeId) || null;
+    }
+    const activeHostname = resolveNormalizedTunnelHost(publicUrl);
+    if (!activeHostname) return null;
+    const matches = config.tunnels.filter((entry) =>
+      entry.directE2eeEnabled === true && entry.hostname === activeHostname);
+    return matches.length === 1 ? matches[0] : null;
   };
 
   const runTunnelDoctor = async ({ providerId, modeFilter, doctorRequest }) => {
@@ -332,11 +370,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         const normalizedMode = normalizeTunnelMode(settings?.tunnelMode);
         const managedRemoteHostname = normalizeManagedRemoteTunnelHostname(settings?.managedRemoteTunnelHostname);
         const managedRemoteTunnelConfig = await readManagedRemoteTunnelConfigFromDisk();
-        const managedRemoteTunnelPresetSummaries = managedRemoteTunnelConfig.tunnels.map((entry) => ({
-          id: entry.id,
-          name: entry.name,
-          hostname: entry.hostname,
-        }));
+        const managedRemoteTunnelPresetSummaries = managedRemoteTunnelConfig.tunnels.map(summarizeManagedRemoteProfile);
         const hasStoredManagedRemoteToken = typeof settings?.managedRemoteTunnelToken === 'string' && settings.managedRemoteTunnelToken.trim().length > 0;
         const hasManagedRemoteTunnelToken = getRuntimeManagedRemoteTunnelToken().length > 0 || managedRemoteTunnelConfig.tunnels.length > 0 || hasStoredManagedRemoteToken;
         const bootstrapTtlMs = settings?.tunnelBootstrapTtlMs === null
@@ -355,6 +389,11 @@ export const createTunnelRoutesRuntime = (dependencies) => {
             mode: normalizedMode,
             provider,
             providerMetadata: null,
+            activeManagedRemoteProfileId: null,
+            directE2eeActiveSessions: 0,
+            directE2eeConfigured: false,
+            directE2eeSupported: isDirectE2eeSupported(),
+            directE2eeAvailable: false,
             hasManagedRemoteTunnelToken,
             managedRemoteTunnelHostname: managedRemoteHostname || null,
             managedRemoteTunnelPresets: managedRemoteTunnelPresetSummaries,
@@ -392,6 +431,21 @@ export const createTunnelRoutesRuntime = (dependencies) => {
 
         const bootstrapStatus = tunnelAuthController.getBootstrapStatus();
         const providerMetadata = tunnelService.getProviderMetadata();
+        const activeManagedRemoteProfile = resolveActiveManagedRemoteProfile({
+          config: managedRemoteTunnelConfig,
+          providerMetadata,
+          publicUrl,
+          activeMode: activeNormalizedMode,
+        });
+        const directE2eeConfigured = activeManagedRemoteProfile?.directE2eeEnabled === true;
+        const directE2eeActiveSessions = activeManagedRemoteProfile
+          ? getDirectE2eeActiveSessionCount(activeManagedRemoteProfile.id)
+          : 0;
+        const directE2eeAvailable = isDirectE2eeAvailable({
+          profile: activeManagedRemoteProfile,
+          publicUrl,
+          activeMode: activeNormalizedMode,
+        });
 
         return res.json({
           active: true,
@@ -399,6 +453,11 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           mode: activeNormalizedMode,
           provider,
           providerMetadata,
+          activeManagedRemoteProfileId: activeManagedRemoteProfile?.id || null,
+          directE2eeActiveSessions,
+          directE2eeConfigured,
+          directE2eeSupported: isDirectE2eeSupported(),
+          directE2eeAvailable,
           hasManagedRemoteTunnelToken,
           managedRemoteTunnelHostname: managedRemoteHostname || null,
           managedRemoteTunnelPresets: managedRemoteTunnelPresetSummaries,
@@ -436,11 +495,49 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           hostname: managedRemoteTunnelHostname,
           token: managedRemoteTunnelToken,
         });
+        await onTunnelChanged({ reason: 'profile-upserted', profileId: presetId });
 
         const managedRemoteTunnelConfig = await readManagedRemoteTunnelConfigFromDisk();
         return res.json({ ok: true, managedRemoteTunnelTokenPresetIds: managedRemoteTunnelConfig.tunnels.map((entry) => entry.id) });
       } catch (error) {
         return res.status(500).json({ ok: false, error: 'Failed to save managed remote tunnel token' });
+      }
+    });
+
+    app.patch('/api/openchamber/tunnel/managed-remote-profile/:id', async (req, res) => {
+      if (typeof req?.body?.directE2eeEnabled !== 'boolean') {
+        return res.status(400).json({ ok: false, error: 'directE2eeEnabled must be a boolean' });
+      }
+      try {
+        const config = await readManagedRemoteTunnelConfigFromDisk();
+        const profile = config.tunnels.find((entry) => entry.id === req.params.id);
+        if (!profile) {
+          return res.status(404).json({ ok: false, error: 'Managed remote profile not found' });
+        }
+        if (typeof setManagedRemoteTunnelDirectE2eeEnabled === 'function') {
+          await setManagedRemoteTunnelDirectE2eeEnabled({
+            id: profile.id,
+            directE2eeEnabled: req.body.directE2eeEnabled,
+          });
+        } else {
+          await upsertManagedRemoteTunnelToken({
+            id: profile.id,
+            name: profile.name,
+            hostname: profile.hostname,
+            token: profile.token,
+            directE2eeEnabled: req.body.directE2eeEnabled,
+          });
+        }
+        if (!req.body.directE2eeEnabled) {
+          await onManagedRemoteDirectE2eeDisabled(profile.id);
+        }
+        await onTunnelChanged({ reason: 'profile-direct-e2ee-updated', profileId: profile.id });
+        return res.json({
+          ok: true,
+          profile: summarizeManagedRemoteProfile({ ...profile, directE2eeEnabled: req.body.directE2eeEnabled }),
+        });
+      } catch {
+        return res.status(500).json({ ok: false, error: 'Failed to update managed remote profile' });
       }
     });
 
@@ -501,6 +598,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         const previousMode = tunnelAuthController.getActiveTunnelMode();
         const previousProvider = tunnelService.resolveActiveProvider();
         const previousUrl = tunnelService.getPublicUrl();
+        const previousProviderMetadata = tunnelService.getProviderMetadata();
 
         const { publicUrl, provider: activeProvider, providerMetadata } = await startTunnelWithNormalizedRequest({
           provider,
@@ -513,10 +611,16 @@ export const createTunnelRoutesRuntime = (dependencies) => {
           selectedPresetName,
         });
 
+        const previousManagedRemoteProfileId = previousProviderMetadata?.managedRemoteTunnelPresetId || null;
+        const activeManagedRemoteProfileId = providerMetadata?.managedRemoteTunnelPresetId || null;
+        const managedRemoteProfileChanged = previousMode === TUNNEL_MODE_MANAGED_REMOTE
+          && mode === TUNNEL_MODE_MANAGED_REMOTE
+          && previousManagedRemoteProfileId !== activeManagedRemoteProfileId;
         const replacedTunnel = Boolean(previousTunnelId) && (
           previousMode !== mode
           || previousProvider !== activeProvider
           || previousUrl !== publicUrl
+          || managedRemoteProfileChanged
         );
         let revokedBootstrapCount = 0;
         let invalidatedSessionCount = 0;
@@ -570,6 +674,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
         console.error('Failed to start tunnel:', error);
         setActiveTunnelController(null);
         tunnelAuthController.clearActiveTunnel();
+        await onTunnelStopped('tunnel-start-failed');
         if (error instanceof TunnelServiceError) {
           const status = error.code === 'missing_dependency'
             ? 400
@@ -582,7 +687,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       }
     });
 
-    app.post('/api/openchamber/tunnel/stop', (_req, res) => {
+    app.post('/api/openchamber/tunnel/stop', async (_req, res) => {
       let revokedBootstrapCount = 0;
       let invalidatedSessionCount = 0;
       const activeTunnelId = tunnelAuthController.getActiveTunnelId();
@@ -599,6 +704,7 @@ export const createTunnelRoutesRuntime = (dependencies) => {
       }
 
       tunnelAuthController.clearActiveTunnel();
+      await onTunnelStopped('tunnel-stopped');
       res.json({ ok: true, revokedBootstrapCount, invalidatedSessionCount });
     });
   };

--- a/packages/web/server/lib/tunnels/routes.test.js
+++ b/packages/web/server/lib/tunnels/routes.test.js
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'bun:test';
+import express from 'express';
+import request from 'supertest';
+
+import { createTunnelRoutesRuntime } from './routes.js';
+import { TunnelServiceError } from './types.js';
+
+const profile = { id: 'profile-a', name: 'A', hostname: 'a.example.com', token: 'connector-secret', directE2eeEnabled: true };
+
+const createApp = (overrides = {}) => {
+  const app = express();
+  app.use(express.json());
+  const dependencies = {
+    crypto: { randomUUID: () => 'tunnel-id' },
+    URL,
+    tunnelService: {
+      resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+      getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+    },
+    tunnelProviderRegistry: { get: () => null, listCapabilities: () => [] },
+    tunnelAuthController: {
+      listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => 'tunnel-id',
+      getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+    },
+    readSettingsFromDiskMigrated: async () => ({ tunnelMode: 'managed-remote', tunnelProvider: 'cloudflare' }),
+    readManagedRemoteTunnelConfigFromDisk: async () => ({ version: 1, tunnels: [profile] }),
+    normalizeTunnelProvider: (value) => value || 'cloudflare', normalizeTunnelMode: (value) => value || 'quick',
+    normalizeOptionalPath: (value) => value, normalizeManagedRemoteTunnelHostname: (value) => typeof value === 'string' ? value.toLowerCase() : '',
+    normalizeTunnelBootstrapTtlMs: (value) => value ?? 1, normalizeTunnelSessionTtlMs: (value) => value ?? 1,
+    isSupportedTunnelMode: () => true, upsertManagedRemoteTunnelToken: vi.fn(async () => {}),
+    setManagedRemoteTunnelDirectE2eeEnabled: vi.fn(async () => profile), resolveManagedRemoteTunnelToken: async () => '',
+    TUNNEL_MODE_QUICK: 'quick', TUNNEL_MODE_MANAGED_LOCAL: 'managed-local', TUNNEL_MODE_MANAGED_REMOTE: 'managed-remote',
+    TUNNEL_PROVIDER_CLOUDFLARE: 'cloudflare', TunnelServiceError, getActivePort: () => 3000,
+    getRuntimeManagedRemoteTunnelHostname: () => '', setRuntimeManagedRemoteTunnelHostname: () => {},
+    getRuntimeManagedRemoteTunnelToken: () => '', setRuntimeManagedRemoteTunnelToken: () => {},
+    getActiveTunnelController: () => null, setActiveTunnelController: () => {},
+    getDirectE2eeActiveSessionCount: () => 3,
+    directE2eeSupported: true,
+    isDirectE2eeAvailable: ({ profile: activeProfile }) => activeProfile?.id === 'profile-a' && activeProfile.directE2eeEnabled === true,
+    ...overrides,
+  };
+  createTunnelRoutesRuntime(dependencies).registerRoutes(app);
+  return { app, dependencies };
+};
+
+describe('tunnel routes direct E2EE configuration', () => {
+  it('patches only the selected flag and never returns the token', async () => {
+    const { app, dependencies } = createApp();
+    const response = await request(app).patch('/api/openchamber/tunnel/managed-remote-profile/profile-a').send({ directE2eeEnabled: false }).expect(200);
+    expect(dependencies.setManagedRemoteTunnelDirectE2eeEnabled).toHaveBeenCalledWith({ id: 'profile-a', directE2eeEnabled: false });
+    expect(response.body.profile).toEqual({ id: 'profile-a', name: 'A', hostname: 'a.example.com', directE2eeEnabled: false });
+    expect(JSON.stringify(response.body)).not.toContain('connector-secret');
+  });
+
+  it('rejects invalid values and unknown profiles', async () => {
+    const { app } = createApp();
+    await request(app).patch('/api/openchamber/tunnel/managed-remote-profile/profile-a').send({ directE2eeEnabled: 1 }).expect(400);
+    await request(app).patch('/api/openchamber/tunnel/managed-remote-profile/missing').send({ directE2eeEnabled: true }).expect(404);
+  });
+
+  it('returns explicit server failures instead of empty status or profile-not-found on config read errors', async () => {
+    const readFailure = new Error('managed config unreadable');
+    const setManagedRemoteTunnelDirectE2eeEnabled = vi.fn(async () => profile);
+    const { app } = createApp({
+      readManagedRemoteTunnelConfigFromDisk: async () => { throw readFailure; },
+      setManagedRemoteTunnelDirectE2eeEnabled,
+    });
+
+    await request(app).get('/api/openchamber/tunnel/status').expect(500, { error: 'Failed to get tunnel status' });
+    await request(app)
+      .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
+      .send({ directE2eeEnabled: false })
+      .expect(500, { ok: false, error: 'Failed to update managed remote profile' });
+    expect(setManagedRemoteTunnelDirectE2eeEnabled).not.toHaveBeenCalled();
+  });
+
+  it('fails token writes explicitly when the authoritative mutation rejects', async () => {
+    const onTunnelChanged = vi.fn(async () => {});
+    const upsertManagedRemoteTunnelToken = vi.fn(async () => { throw new Error('managed config corrupt'); });
+    const { app } = createApp({ upsertManagedRemoteTunnelToken, onTunnelChanged });
+
+    await request(app).put('/api/openchamber/tunnel/managed-remote-token').send({
+      presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
+    }).expect(500, { ok: false, error: 'Failed to save managed remote tunnel token' });
+    expect(onTunnelChanged).not.toHaveBeenCalled();
+  });
+
+  it('refreshes direct runtime after a managed profile token upsert', async () => {
+    const onTunnelChanged = vi.fn(async () => {});
+    const { app } = createApp({ onTunnelChanged });
+    await request(app).put('/api/openchamber/tunnel/managed-remote-token').send({
+      presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
+    }).expect(200);
+    expect(onTunnelChanged).toHaveBeenCalledWith({ reason: 'profile-upserted', profileId: 'profile-a' });
+  });
+
+  it('reports production support and availability for the exact active profile', async () => {
+    const { app } = createApp();
+    const response = await request(app).get('/api/openchamber/tunnel/status').expect(200);
+    expect(response.body).toMatchObject({
+      activeManagedRemoteProfileId: 'profile-a', directE2eeActiveSessions: 3,
+      directE2eeConfigured: true, directE2eeSupported: true, directE2eeAvailable: true,
+    });
+    expect(response.body.managedRemoteTunnelPresets[0].directE2eeEnabled).toBe(true);
+    expect(JSON.stringify(response.body)).not.toContain('connector-secret');
+  });
+
+  it('replaces route artifacts and tunnel identity when the managed profile changes at the same URL', async () => {
+    const revokeTunnelArtifacts = vi.fn(() => ({ revokedBootstrapCount: 2, invalidatedSessionCount: 3 }));
+    const setActiveTunnel = vi.fn();
+    const onTunnelChanged = vi.fn(async () => {});
+    const { app } = createApp({
+      crypto: { randomUUID: () => 'fresh-tunnel-id' },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote',
+        resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://shared.example.com',
+        getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        start: async () => ({
+          publicUrl: 'https://shared.example.com',
+          activeMode: 'managed-remote',
+          provider: 'cloudflare',
+          providerMetadata: { managedRemoteTunnelPresetId: 'profile-b' },
+        }),
+      },
+      tunnelProviderRegistry: { get: () => ({}), listCapabilities: () => [] },
+      tunnelAuthController: {
+        listTunnelSessions: () => [],
+        getActiveTunnelMode: () => 'managed-remote',
+        getActiveTunnelId: () => 'old-tunnel-id',
+        revokeTunnelArtifacts,
+        setActiveTunnel,
+        issueBootstrapToken: () => ({ token: 'bootstrap', expiresAt: 123 }),
+      },
+      resolveManagedRemoteTunnelToken: async () => 'connector-secret',
+      onTunnelChanged,
+      readManagedRemoteTunnelConfigFromDisk: async () => ({ version: 1, tunnels: [
+        profile,
+        { ...profile, id: 'profile-b', name: 'B' },
+      ] }),
+    });
+
+    const response = await request(app).post('/api/openchamber/tunnel/start').send({
+      provider: 'cloudflare',
+      mode: 'managed-remote',
+      managedRemoteTunnelPresetId: 'profile-b',
+      managedRemoteTunnelPresetName: 'B',
+      hostname: 'shared.example.com',
+    }).expect(200);
+
+    expect(response.body).toMatchObject({
+      replacedTunnel: true,
+      revokedBootstrapCount: 2,
+      invalidatedSessionCount: 3,
+    });
+    expect(revokeTunnelArtifacts).toHaveBeenCalledWith('old-tunnel-id');
+    expect(setActiveTunnel).toHaveBeenCalledWith({
+      tunnelId: 'fresh-tunnel-id',
+      publicUrl: 'https://shared.example.com',
+      mode: 'managed-remote',
+    });
+    expect(onTunnelChanged).toHaveBeenCalledWith({ reason: 'profile-switched' });
+  });
+
+  it('invokes direct-session lifecycle callbacks on disable and stop', async () => {
+    const onManagedRemoteDirectE2eeDisabled = vi.fn();
+    const onTunnelChanged = vi.fn(async () => {});
+    const onTunnelStopped = vi.fn();
+    const { app } = createApp({
+      onManagedRemoteDirectE2eeDisabled,
+      onTunnelChanged,
+      onTunnelStopped,
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote',
+        resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com',
+        getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        stop: vi.fn(),
+      },
+      getActiveTunnelController: () => ({ stop: vi.fn() }),
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => null,
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        clearActiveTunnel: vi.fn(),
+      },
+    });
+
+    await request(app)
+      .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
+      .send({ directE2eeEnabled: false })
+      .expect(200);
+    expect(onManagedRemoteDirectE2eeDisabled).toHaveBeenCalledWith('profile-a');
+    expect(onTunnelChanged).toHaveBeenCalledWith({ reason: 'profile-direct-e2ee-updated', profileId: 'profile-a' });
+
+    await request(app).post('/api/openchamber/tunnel/stop').expect(200);
+    expect(onTunnelStopped).toHaveBeenCalledWith('tunnel-stopped');
+  });
+
+  it('deactivates direct runtime when provider startup fails', async () => {
+    let directAvailable = true;
+    let closedDirectSessions = 0;
+    const onTunnelStopped = vi.fn(async () => {
+      directAvailable = false;
+      closedDirectSessions += 2;
+    });
+    const clearActiveTunnel = vi.fn();
+    const setActiveTunnelController = vi.fn();
+    const { app } = createApp({
+      onTunnelStopped,
+      isDirectE2eeAvailable: () => directAvailable,
+      setActiveTunnelController,
+      tunnelProviderRegistry: { get: () => ({}), listCapabilities: () => [] },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        start: async () => { throw new TunnelServiceError('startup_failed', 'provider failed'); },
+      },
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => 'old',
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        clearActiveTunnel,
+      },
+    });
+    await request(app).post('/api/openchamber/tunnel/start').send({
+      provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
+    }).expect(500);
+    expect(setActiveTunnelController).toHaveBeenCalledWith(null);
+    expect(clearActiveTunnel).toHaveBeenCalled();
+    expect(onTunnelStopped).toHaveBeenCalledWith('tunnel-start-failed');
+    expect(closedDirectSessions).toBe(2);
+    expect((await request(app).get('/api/openchamber/tunnel/status').expect(200)).body.directE2eeAvailable).toBe(false);
+  });
+
+  it('uses only a unique enabled hostname fallback for legacy active metadata', async () => {
+    const { app } = createApp({
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({}),
+      },
+    });
+    expect((await request(app).get('/api/openchamber/tunnel/status').expect(200)).body.activeManagedRemoteProfileId).toBe('profile-a');
+
+    const ambiguous = createApp({
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({}),
+      },
+      readManagedRemoteTunnelConfigFromDisk: async () => ({ tunnels: [profile, { ...profile, id: 'profile-b' }] }),
+    });
+    expect((await request(ambiguous.app).get('/api/openchamber/tunnel/status').expect(200)).body.activeManagedRemoteProfileId).toBeNull();
+
+    const wrongId = createApp({
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'missing' }),
+      },
+    });
+    expect((await request(wrongId.app).get('/api/openchamber/tunnel/status').expect(200)).body.activeManagedRemoteProfileId).toBeNull();
+  });
+});

--- a/packages/web/server/lib/tunnels/routes.test.js
+++ b/packages/web/server/lib/tunnels/routes.test.js
@@ -231,6 +231,129 @@ describe('tunnel routes direct E2EE configuration', () => {
     expect((await request(app).get('/api/openchamber/tunnel/status').expect(200)).body.directE2eeAvailable).toBe(false);
   });
 
+  it('preserves structured start failures when the stopped callback rejects', async () => {
+    const callbackError = new Error('callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({
+      onTunnelStopped: async () => { throw callbackError; },
+      tunnelProviderRegistry: { get: () => ({}), listCapabilities: () => [] },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        start: async () => { throw new TunnelServiceError('startup_failed', 'provider failed'); },
+      },
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => 'old',
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        clearActiveTunnel: vi.fn(),
+      },
+    });
+
+    try {
+      await request(app).post('/api/openchamber/tunnel/start').send({
+        provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
+      }).expect(500, { ok: false, error: 'provider failed', code: 'startup_failed' });
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:start-failed)', callbackError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves stop responses when the stopped callback rejects', async () => {
+    const callbackError = new Error('callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({
+      onTunnelStopped: async () => { throw callbackError; },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        stop: vi.fn(),
+      },
+      getActiveTunnelController: () => ({ stop: vi.fn() }),
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => null,
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        clearActiveTunnel: vi.fn(),
+      },
+    });
+
+    try {
+      await request(app).post('/api/openchamber/tunnel/stop').expect(200, {
+        ok: true, revokedBootstrapCount: 0, invalidatedSessionCount: 0,
+      });
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:stop)', callbackError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves token upsert responses when the changed callback rejects', async () => {
+    const callbackError = new Error('callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({ onTunnelChanged: async () => { throw callbackError; } });
+
+    try {
+      await request(app).put('/api/openchamber/tunnel/managed-remote-token').send({
+        presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
+      }).expect(200, { ok: true, managedRemoteTunnelTokenPresetIds: ['profile-a'] });
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-upserted)', callbackError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves profile responses when notification callbacks reject', async () => {
+    const disabledError = new Error('disable callback failed');
+    const changedError = new Error('changed callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({
+      onManagedRemoteDirectE2eeDisabled: async () => { throw disabledError; },
+      onTunnelChanged: async () => { throw changedError; },
+    });
+
+    try {
+      await request(app)
+        .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
+        .send({ directE2eeEnabled: false })
+        .expect(200);
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (direct-e2ee-disabled)', disabledError);
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-direct-e2ee-updated)', changedError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves successful start responses when the changed callback rejects', async () => {
+    const callbackError = new Error('callback failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({
+      onTunnelChanged: async () => { throw callbackError; },
+      tunnelProviderRegistry: { get: () => ({}), listCapabilities: () => [] },
+      tunnelService: {
+        resolveActiveMode: () => 'managed-remote', resolveActiveProvider: () => 'cloudflare',
+        getPublicUrl: () => 'https://a.example.com', getProviderMetadata: () => ({ managedRemoteTunnelPresetId: 'profile-a' }),
+        start: async () => ({
+          publicUrl: 'https://a.example.com', activeMode: 'managed-remote', provider: 'cloudflare',
+          providerMetadata: { managedRemoteTunnelPresetId: 'profile-a' },
+        }),
+      },
+      tunnelAuthController: {
+        listTunnelSessions: () => [], getActiveTunnelMode: () => 'managed-remote', getActiveTunnelId: () => null,
+        getActiveTunnelHost: () => 'a.example.com', getBootstrapStatus: () => ({ hasBootstrapToken: false, bootstrapExpiresAt: null }),
+        setActiveTunnel: vi.fn(), issueBootstrapToken: () => ({ token: 'bootstrap', expiresAt: 123 }),
+      },
+    });
+
+    try {
+      await request(app).post('/api/openchamber/tunnel/start').send({
+        provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
+      }).expect(200);
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-switched)', callbackError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('uses only a unique enabled hostname fallback for legacy active metadata', async () => {
     const { app } = createApp({
       tunnelService: {

--- a/packages/web/server/lib/tunnels/routes.test.js
+++ b/packages/web/server/lib/tunnels/routes.test.js
@@ -232,7 +232,7 @@ describe('tunnel routes direct E2EE configuration', () => {
   });
 
   it('preserves structured start failures when the stopped callback rejects', async () => {
-    const callbackError = new Error('callback failed');
+    const callbackError = new Error('callback-secret=https://private.example/?token=secret');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { app } = createApp({
       onTunnelStopped: async () => { throw callbackError; },
@@ -253,14 +253,15 @@ describe('tunnel routes direct E2EE configuration', () => {
       await request(app).post('/api/openchamber/tunnel/start').send({
         provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
       }).expect(500, { ok: false, error: 'provider failed', code: 'startup_failed' });
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:start-failed)', callbackError);
+      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:start-failed)');
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('callback-secret');
     } finally {
       consoleError.mockRestore();
     }
   });
 
-  it('preserves stop responses when the stopped callback rejects', async () => {
-    const callbackError = new Error('callback failed');
+  it('returns a structured lifecycle failure with revocation counts when stop cleanup rejects', async () => {
+    const callbackError = Object.assign(new Error('stop-secret=https://private.example/?token=secret'), { code: 'ETIMEDOUT' });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { app } = createApp({
       onTunnelStopped: async () => { throw callbackError; },
@@ -278,17 +279,25 @@ describe('tunnel routes direct E2EE configuration', () => {
     });
 
     try {
-      await request(app).post('/api/openchamber/tunnel/stop').expect(200, {
-        ok: true, revokedBootstrapCount: 0, invalidatedSessionCount: 0,
+      await request(app).post('/api/openchamber/tunnel/stop').expect(500, {
+        ok: false,
+        error: 'Tunnel lifecycle cleanup failed',
+        code: 'lifecycle_callback_failed',
+        revokedBootstrapCount: 0,
+        invalidatedSessionCount: 0,
       });
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-stopped:stop)', callbackError);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (tunnel-stopped:stop)',
+        { name: 'Error', code: 'ETIMEDOUT' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('stop-secret');
     } finally {
       consoleError.mockRestore();
     }
   });
 
   it('preserves token upsert responses when the changed callback rejects', async () => {
-    const callbackError = new Error('callback failed');
+    const callbackError = Object.assign(new Error('token-secret=https://private.example/?token=secret'), { code: 'ETIMEDOUT' });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { app } = createApp({ onTunnelChanged: async () => { throw callbackError; } });
 
@@ -296,35 +305,70 @@ describe('tunnel routes direct E2EE configuration', () => {
       await request(app).put('/api/openchamber/tunnel/managed-remote-token').send({
         presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
       }).expect(200, { ok: true, managedRemoteTunnelTokenPresetIds: ['profile-a'] });
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-upserted)', callbackError);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (tunnel-changed:profile-upserted)',
+        { name: 'Error', code: 'ETIMEDOUT' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('token-secret');
     } finally {
       consoleError.mockRestore();
     }
   });
 
-  it('preserves profile responses when notification callbacks reject', async () => {
-    const disabledError = new Error('disable callback failed');
-    const changedError = new Error('changed callback failed');
+  it('keeps a disabled profile persisted but returns a lifecycle failure when revocation rejects', async () => {
+    const disabledError = Object.assign(new Error('disable-secret=https://private.example/?token=secret'), { code: 'EIO' });
+    const onTunnelChanged = vi.fn(async () => {});
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { app } = createApp({
+    const { app, dependencies } = createApp({
       onManagedRemoteDirectE2eeDisabled: async () => { throw disabledError; },
-      onTunnelChanged: async () => { throw changedError; },
+      onTunnelChanged,
     });
 
     try {
       await request(app)
         .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
         .send({ directE2eeEnabled: false })
+        .expect(500, {
+          ok: false,
+          error: 'Tunnel lifecycle cleanup failed',
+          code: 'lifecycle_callback_failed',
+        });
+      expect(dependencies.setManagedRemoteTunnelDirectE2eeEnabled).toHaveBeenCalledWith({
+        id: 'profile-a', directE2eeEnabled: false,
+      });
+      expect(onTunnelChanged).toHaveBeenCalledWith({ reason: 'profile-direct-e2ee-updated', profileId: 'profile-a' });
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (direct-e2ee-disabled)',
+        { name: 'Error', code: 'EIO' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('disable-secret');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('preserves profile responses when the changed notification rejects', async () => {
+    const changedError = new TypeError('changed-secret=https://private.example/?token=secret');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { app } = createApp({ onTunnelChanged: async () => { throw changedError; } });
+
+    try {
+      await request(app)
+        .patch('/api/openchamber/tunnel/managed-remote-profile/profile-a')
+        .send({ directE2eeEnabled: true })
         .expect(200);
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (direct-e2ee-disabled)', disabledError);
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-direct-e2ee-updated)', changedError);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (tunnel-changed:profile-direct-e2ee-updated)',
+        { name: 'TypeError' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('changed-secret');
     } finally {
       consoleError.mockRestore();
     }
   });
 
   it('preserves successful start responses when the changed callback rejects', async () => {
-    const callbackError = new Error('callback failed');
+    const callbackError = new Error('start-secret=https://private.example/?token=secret');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { app } = createApp({
       onTunnelChanged: async () => { throw callbackError; },
@@ -348,7 +392,43 @@ describe('tunnel routes direct E2EE configuration', () => {
       await request(app).post('/api/openchamber/tunnel/start').send({
         provider: 'cloudflare', mode: 'managed-remote', managedRemoteTunnelPresetId: 'profile-a', hostname: 'a.example.com',
       }).expect(200);
-      expect(consoleError).toHaveBeenCalledWith('Tunnel lifecycle callback failed (tunnel-changed:profile-switched)', callbackError);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Tunnel lifecycle callback failed (tunnel-changed:profile-switched)',
+        { name: 'Error' },
+      );
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('start-secret');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('awaits best-effort notification settlement before sending the response', async () => {
+    let rejectCallback;
+    let responseSettled = false;
+    const callbackError = new Error('settlement-secret');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onTunnelChanged = vi.fn(() => new Promise((_resolve, reject) => {
+      rejectCallback = reject;
+    }));
+    const { app } = createApp({ onTunnelChanged });
+
+    try {
+      const responsePromise = request(app)
+        .put('/api/openchamber/tunnel/managed-remote-token')
+        .send({
+          presetId: 'profile-a', presetName: 'A', managedRemoteTunnelHostname: 'a.example.com', managedRemoteTunnelToken: 'new-secret',
+        })
+        .then((response) => {
+          responseSettled = true;
+          return response;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(onTunnelChanged).toHaveBeenCalled();
+      expect(responseSettled).toBe(false);
+      rejectCallback(callbackError);
+      const response = await responsePromise;
+      expect(response.status).toBe(200);
+      expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('settlement-secret');
     } finally {
       consoleError.mockRestore();
     }

--- a/packages/web/server/lib/tunnels/routes.test.js
+++ b/packages/web/server/lib/tunnels/routes.test.js
@@ -7,6 +7,14 @@ import { TunnelServiceError } from './types.js';
 
 const profile = { id: 'profile-a', name: 'A', hostname: 'a.example.com', token: 'connector-secret', directE2eeEnabled: true };
 
+const waitFor = async (predicate) => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error('observable lifecycle outcome not reached');
+};
+
 const createApp = (overrides = {}) => {
   const app = express();
   app.use(express.json());
@@ -422,10 +430,11 @@ describe('tunnel routes direct E2EE configuration', () => {
           responseSettled = true;
           return response;
         });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(onTunnelChanged).toHaveBeenCalled();
+      await waitFor(() => onTunnelChanged.mock.calls.length === 1);
+      expect(onTunnelChanged).toHaveBeenCalledTimes(1);
       expect(responseSettled).toBe(false);
       rejectCallback(callbackError);
+      await waitFor(() => responseSettled);
       const response = await responsePromise;
       expect(response.status).toBe(200);
       expect(consoleError.mock.calls.flat().map(String).join(' ')).not.toContain('settlement-secret');

--- a/packages/web/server/lib/tunnels/types.js
+++ b/packages/web/server/lib/tunnels/types.js
@@ -174,6 +174,9 @@ export function normalizeTunnelStartRequest(input = {}, defaults = {}) {
   const hostname = typeof (input.hostname ?? defaults.hostname) === 'string'
     ? (input.hostname ?? defaults.hostname).trim().toLowerCase()
     : '';
+  const managedRemoteTunnelPresetId = typeof (input.managedRemoteTunnelPresetId ?? defaults.managedRemoteTunnelPresetId) === 'string'
+    ? (input.managedRemoteTunnelPresetId ?? defaults.managedRemoteTunnelPresetId).trim()
+    : '';
 
   return {
     provider,
@@ -182,6 +185,7 @@ export function normalizeTunnelStartRequest(input = {}, defaults = {}) {
     configPath,
     token,
     hostname,
+    managedRemoteTunnelPresetId,
   };
 }
 

--- a/packages/web/server/lib/ui-auth/ui-auth.test.js
+++ b/packages/web/server/lib/ui-auth/ui-auth.test.js
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, it } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { createInternalTransportMarker, createTunnelAuth, DIRECT_E2EE_TRANSPORT_HEADER } from '../opencode/tunnel-auth.js';
 
 const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchamber-ui-auth-test-'));
 process.env.OPENCHAMBER_DATA_DIR = dataDir;
@@ -45,6 +46,14 @@ const createResponse = () => {
 };
 
 describe('ui auth client credential seam', () => {
+  it('classifies only the exact process marker as remote-client', () => {
+    const marker = createInternalTransportMarker();
+    const auth = createTunnelAuth({ internalRemoteClientMarker: marker });
+    const request = (value) => ({ headers: { host: '127.0.0.1', [DIRECT_E2EE_TRANSPORT_HEADER]: value }, socket: { remoteAddress: '127.0.0.1' } });
+    expect(auth.classifyRequestScope(request(marker))).toBe('remote-client');
+    expect(auth.classifyRequestScope(request('attacker'))).toBe('local');
+    expect(auth.classifyRequestScope(request(undefined))).toBe('local');
+  });
   it('accepts bearer client credentials when UI password auth is enabled', async () => {
     const createUiAuth = await loadCreateUiAuth();
     const auth = createUiAuth({

--- a/packages/web/src/api/clientAuth.test.ts
+++ b/packages/web/src/api/clientAuth.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtimeFetchMock = vi.fn();
+
+vi.mock('@openchamber/ui/lib/runtime-fetch', () => ({ runtimeFetch: runtimeFetchMock }));
+
+const pairingResponse = () => Response.json({
+  pairing: { id: 'pair', secret: 'one-time' },
+  server: { label: 'Host', candidates: [] },
+});
+
+describe('createWebClientAuthAPI', () => {
+  beforeEach(() => runtimeFetchMock.mockReset());
+
+  it('omits direct E2EE by default without changing existing transport fields', async () => {
+    runtimeFetchMock.mockResolvedValue(pairingResponse());
+    const { createWebClientAuthAPI } = await import('./clientAuth');
+    await createWebClientAuthAPI().createPairingSession({ includeDirect: false, includeRelay: true });
+    const init = runtimeFetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({ label: '', includeRelay: true, includeDirect: false });
+  });
+
+  it('forwards includeDirectE2ee only when explicitly requested and preserves body semantics', async () => {
+    runtimeFetchMock.mockResolvedValue(pairingResponse());
+    const { createWebClientAuthAPI } = await import('./clientAuth');
+    await createWebClientAuthAPI().createPairingSession({
+      label: 'Phone',
+      allowedClientKinds: ['mobile'],
+      serverUrl: 'https://lan.example',
+      includeDirect: true,
+      includeRelay: false,
+      includeDirectE2ee: true,
+    });
+    const [path, init] = runtimeFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe('/api/client-auth/pairing/sessions');
+    expect(JSON.parse(String(init.body))).toEqual({
+      label: 'Phone',
+      allowedClientKinds: ['mobile'],
+      serverUrl: 'https://lan.example',
+      includeRelay: false,
+      includeDirect: true,
+      includeDirectE2ee: true,
+    });
+  });
+
+  it('forwards an explicit false independently', async () => {
+    runtimeFetchMock.mockResolvedValue(pairingResponse());
+    const { createWebClientAuthAPI } = await import('./clientAuth');
+    await createWebClientAuthAPI().createPairingSession({ includeDirectE2ee: false });
+    const init = runtimeFetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({ label: '', includeDirectE2ee: false });
+  });
+
+  it('throws on HTTP and malformed-response failures', async () => {
+    const { createWebClientAuthAPI } = await import('./clientAuth');
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ error: 'denied' }, { status: 403 }));
+    await expect(createWebClientAuthAPI().createPairingSession()).rejects.toThrow('denied');
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ pairing: {} }));
+    await expect(createWebClientAuthAPI().createPairingSession()).rejects.toThrow('Failed to create pairing session');
+  });
+});

--- a/packages/web/src/api/clientAuth.ts
+++ b/packages/web/src/api/clientAuth.ts
@@ -49,6 +49,7 @@ export const createWebClientAuthAPI = (): ClientAuthAPI => ({
         ...(input.serverUrl ? { serverUrl: input.serverUrl } : {}),
         ...(typeof input.includeRelay === 'boolean' ? { includeRelay: input.includeRelay } : {}),
         ...(typeof input.includeDirect === 'boolean' ? { includeDirect: input.includeDirect } : {}),
+        ...(typeof input.includeDirectE2ee === 'boolean' ? { includeDirectE2ee: input.includeDirectE2ee } : {}),
       }),
     });
     const payload = await jsonOrNull<PairingSessionCreateResult & { error?: string }>(response);
@@ -70,16 +71,16 @@ export const createWebClientAuthAPI = (): ClientAuthAPI => ({
     return Array.isArray(payload.pending) ? payload.pending : [];
   },
 
-  async getPairingTransports(): Promise<{ local: string | null; lan: string | null; relayAvailable: boolean }> {
+  async getPairingTransports(): Promise<{ local: string | null; lan: string | null; relayAvailable: boolean; directE2eeAvailable?: boolean }> {
     const response = await runtimeFetch('/api/client-auth/pairing/transports', {
       method: 'GET',
       headers: { Accept: 'application/json' },
     });
-    const payload = await jsonOrNull<{ local?: string | null; lan?: string | null; relayAvailable?: boolean; error?: string }>(response);
+    const payload = await jsonOrNull<{ local?: string | null; lan?: string | null; relayAvailable?: boolean; directE2eeAvailable?: boolean; error?: string }>(response);
     if (!response.ok || !payload) {
       throw new Error(payload?.error || response.statusText || 'Failed to load pairing transports');
     }
-    return { local: payload.local ?? null, lan: payload.lan ?? null, relayAvailable: payload.relayAvailable !== false };
+    return { local: payload.local ?? null, lan: payload.lan ?? null, relayAvailable: payload.relayAvailable !== false, directE2eeAvailable: !!payload.directE2eeAvailable };
   },
 
   async cancelPairing(id: string): Promise<{ cancelled: boolean }> {

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
+      '@': fileURLToPath(new URL('../ui/src', import.meta.url)),
       'bun:test': fileURLToPath(new URL('./test/bun-test-shim.ts', import.meta.url)),
     },
   },


### PR DESCRIPTION
## Summary
This adds client-side direct-E2EE pairing and session restoration across mobile and desktop.

## Stack
- Layer 4 of 6
- Predecessor: #2237
- Part of #2234
- Status: Ready for review
- This PR currently shows the cumulative stack against `main`; the diff narrows as predecessors merge.

## Dependency
This layer depends on #2216. SDK global-event SSE must use `runtimeFetch` to traverse the encrypted tunnel. The temporary #2216 patch is not included in this stack. #2217 is related test coverage but is not required here.

## What changed
- Implemented Pairing v2 candidate validation for direct E2EE.
- Shared fail-closed encrypted redemption between mobile and desktop.
- Handled host switching and restoration without plaintext probing.
- Kept Electron credentials behind sender-validated preload IPC.
- Routed OpenChamber event streams through active tunnels.
- Bounded incremental SSE parsing.
- Kept status probes from retaining tunnels; activation explicitly retains or adopts them.
- Used shared Electron runtime planning for encrypted host links.
- Classified pairing failures without exposing sensitive details.

## Verification
- UI, Electron, and server test matrices pass.
- Remote navigation receives no local tokens or Relay metadata.
- The final stack passes all 835 web tests; web type-check, lint, and build are clean.
