### PR TITLE
Prefer nested projects over containing worktrees

### DIFF
--- a/packages/ui/src/lib/projectResolution.test.ts
+++ b/packages/ui/src/lib/projectResolution.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveProjectForSessionDirectory } from './projectResolution';
+
+describe('resolveProjectForSessionDirectory', () => {
+  test('prefers nested project over containing worktree project', () => {
+    const backend = { id: 'backend', path: '/projects/backend' };
+    const api = { id: 'api', path: '/projects/backend/et.api3' };
+    const worktrees = new Map([[
+      backend.path,
+      [{
+        path: api.path,
+        projectDirectory: backend.path,
+        branch: 'et-api3',
+        label: 'et.api3',
+      }],
+    ]]);
+
+    expect(resolveProjectForSessionDirectory([backend, api], worktrees, api.path)).toBe(api);
+  });
+
+  test('prefers external worktree over containing unrelated project', () => {
+    const app = { id: 'app', path: '/projects/app' };
+    const worktreesProject = { id: 'worktrees', path: '/worktrees' };
+    const worktreePath = '/worktrees/app-feature';
+    const worktrees = new Map([[
+      app.path,
+      [{
+        path: worktreePath,
+        projectDirectory: app.path,
+        branch: 'feature',
+        label: 'feature',
+      }],
+    ]]);
+
+    expect(resolveProjectForSessionDirectory([app, worktreesProject], worktrees, `${worktreePath}/src`)).toBe(app);
+  });
+});

--- a/packages/ui/src/lib/projectResolution.ts
+++ b/packages/ui/src/lib/projectResolution.ts
@@ -24,7 +24,7 @@ const resolveProjectFromWorktreeDirectory = (
   projects: ProjectEntry[],
   availableWorktreesByProject: Map<string, WorktreeMetadata[]>,
   directory: string | null,
-): ProjectEntry | null => {
+): { project: ProjectEntry; path: string } | null => {
   const nd = normalizeProjectPath(directory);
   if (!nd) return null;
   let matchedWorktree: WorktreeMetadata | null = null;
@@ -47,9 +47,9 @@ const resolveProjectFromWorktreeDirectory = (
     .filter((v): v is string => Boolean(v));
   for (const c of candidates) {
     const exact = projects.find((p) => normalizeProjectPath(p.path) === c) ?? null;
-    if (exact) return exact;
+    if (exact) return { project: exact, path: normalizeProjectPath(matchedWorktree.path) ?? nd };
     const nested = resolveProjectForDirectory(projects, c);
-    if (nested) return nested;
+    if (nested) return { project: nested, path: normalizeProjectPath(matchedWorktree.path) ?? nd };
   }
   return null;
 };
@@ -58,6 +58,13 @@ export const resolveProjectForSessionDirectory = (
   projects: ProjectEntry[],
   availableWorktreesByProject: Map<string, WorktreeMetadata[]>,
   directory: string | null,
-): ProjectEntry | null =>
-  resolveProjectFromWorktreeDirectory(projects, availableWorktreesByProject, directory) ??
-  resolveProjectForDirectory(projects, directory);
+): ProjectEntry | null => {
+  const worktreeProject = resolveProjectFromWorktreeDirectory(projects, availableWorktreesByProject, directory);
+  const directoryProject = resolveProjectForDirectory(projects, directory);
+  if (!worktreeProject) return directoryProject;
+  if (!directoryProject) return worktreeProject.project;
+
+  const directoryPath = normalizeProjectPath(directoryProject.path);
+  if (directoryPath === worktreeProject.path || directoryPath?.startsWith(`${worktreeProject.path}/`)) return directoryProject;
+  return worktreeProject.project;
+};


### PR DESCRIPTION
## Summary

- resolve session directories to a registered project nested inside a containing worktree
- preserve the owning project for external worktrees located under an unrelated project path
- add regression coverage for both precedence cases