### PR TITLE
fix(settings): serialize settings.json writes across Electron and the web server

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -18,6 +18,7 @@ import { assertUpdaterCapability } from './updater-capability.mjs';
 import { checkForDesktopUpdate } from './updater-check.mjs';
 import { resolveUpdaterFeed } from './updater-feed.mjs';
 import { mintOutsideFileGrant } from '@openchamber/web/server/lib/fs/routes.js';
+import { withFileWriteLock } from '@openchamber/web/server/lib/fs/settings-file-lock.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -489,14 +490,17 @@ const readJsonFile = (filePath) => {
   }
 };
 
-const writeJsonFile = async (filePath, data) => {
+const writeJsonFile = async (filePath, data) => withFileWriteLock(filePath, async () => {
   await fsp.mkdir(path.dirname(filePath), { recursive: true });
   // Atomic: write to a temp file then rename. Readers never see a partial
-  // JSON file that could parse-error and get coerced to {}.
+  // JSON file that could parse-error and get coerced to {}. withFileWriteLock
+  // also serializes against the in-process OpenChamber web server's own
+  // settings writer (packages/web/server/lib/opencode/settings-runtime.js),
+  // which persists the same settings.json independently of this module.
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   await fsp.writeFile(tmp, JSON.stringify(data, null, 2));
   await fsp.rename(tmp, filePath);
-};
+});
 
 const readSettingsRoot = () => {
   const root = readJsonFile(settingsFilePath());

--- a/packages/web/server/lib/fs/settings-file-lock.js
+++ b/packages/web/server/lib/fs/settings-file-lock.js
@@ -1,0 +1,14 @@
+// Serializes writes to a given file path across every caller in this
+// process. Electron's main process and the in-process OpenChamber web
+// server each persist settings.json through their own module and neither
+// knows about the other's writer — without this, their read-modify-write
+// cycles interleave and can silently drop each other's changes. Keyed by
+// path (not hardcoded to settings.json) so any other shared file can use it.
+const writeLocksByPath = new Map();
+
+export const withFileWriteLock = (filePath, task) => {
+  const previous = writeLocksByPath.get(filePath) || Promise.resolve();
+  const next = previous.then(task, task);
+  writeLocksByPath.set(filePath, next.then(() => {}, () => {}));
+  return next;
+};

--- a/packages/web/server/lib/fs/settings-file-lock.test.js
+++ b/packages/web/server/lib/fs/settings-file-lock.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { withFileWriteLock } from './settings-file-lock.js';
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+describe('withFileWriteLock', () => {
+  it('runs tasks for the same path one at a time, in order', async () => {
+    const path = '/tmp/example-settings.json';
+    const order = [];
+    const first = deferred();
+
+    const a = withFileWriteLock(path, async () => {
+      order.push('a-start');
+      await first.promise;
+      order.push('a-end');
+    });
+    const b = withFileWriteLock(path, async () => {
+      order.push('b-start');
+      order.push('b-end');
+    });
+
+    // b must not start before a finishes, even though a is still pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['a-start']);
+
+    first.resolve();
+    await Promise.all([a, b]);
+    expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+
+  it('does not serialize tasks for different paths', async () => {
+    const order = [];
+    const first = deferred();
+
+    const a = withFileWriteLock('/tmp/one.json', async () => {
+      order.push('a-start');
+      await first.promise;
+      order.push('a-end');
+    });
+    const b = withFileWriteLock('/tmp/two.json', async () => {
+      order.push('b-start');
+      order.push('b-end');
+    });
+
+    await b;
+    expect(order).toEqual(['a-start', 'b-start', 'b-end']);
+    first.resolve();
+    await a;
+    expect(order).toEqual(['a-start', 'b-start', 'b-end', 'a-end']);
+  });
+
+  it('keeps the queue alive and lets later tasks run after an earlier task throws', async () => {
+    const path = '/tmp/example-settings-2.json';
+
+    await expect(
+      withFileWriteLock(path, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    let ran = false;
+    await withFileWriteLock(path, async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+});

--- a/packages/web/server/lib/opencode/settings-runtime.js
+++ b/packages/web/server/lib/opencode/settings-runtime.js
@@ -1,4 +1,5 @@
 import { createProjectIdFromPath } from '../projects/project-id.js';
+import { withFileWriteLock } from '../fs/settings-file-lock.js';
 
 const DEFAULT_NOTIFICATION_TEMPLATES = {
   completion: { title: '{agent_name} is ready', message: '{model_name} completed the task' },
@@ -500,13 +501,17 @@ export const createSettingsRuntime = (deps) => {
     await fsPromises.rm(tmp, { force: true });
   };
 
-  const writeSettingsToDisk = async (settings) => {
+  const writeSettingsToDisk = async (settings) => withFileWriteLock(SETTINGS_FILE_PATH, async () => {
     try {
       await fsPromises.mkdir(path.dirname(SETTINGS_FILE_PATH), { recursive: true });
       // Atomic write: Electron main and ssh-manager read this file via plain
       // readFile + JSON.parse and silently coerce parse errors to {}. A
       // partial read during a non-atomic writeFile would make their next
-      // read-modify-write wipe the settings file.
+      // read-modify-write wipe the settings file. withFileWriteLock further
+      // serializes against every other writer of this same path in this
+      // process (Electron's own settings writer included), so two
+      // read-modify-write cycles can't interleave and drop each other's
+      // changes.
       const tmp = `${SETTINGS_FILE_PATH}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       await fsPromises.writeFile(tmp, JSON.stringify(settings, null, 2), 'utf8');
       await replaceFile(tmp, SETTINGS_FILE_PATH);
@@ -514,7 +519,7 @@ export const createSettingsRuntime = (deps) => {
       console.warn('Failed to write settings file:', error);
       throw error;
     }
-  };
+  });
 
   const validateProjectEntries = async (projects) => {
     if (!Array.isArray(projects)) {

--- a/packages/web/server/lib/opencode/settings-runtime.test.js
+++ b/packages/web/server/lib/opencode/settings-runtime.test.js
@@ -121,4 +121,28 @@ describe('settings runtime', () => {
       await fsPromises.rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it('serializes concurrent writeSettingsToDisk calls so one does not clobber the other mid-write', async () => {
+    // Electron's desktop shell writes settings.json independently of this
+    // runtime but into the same file, in the same process. Simulate that by
+    // firing two writeSettingsToDisk calls back to back without awaiting the
+    // first — the write lock must stop the second write's temp-file rename
+    // from landing between the first write's own temp-file write and rename.
+    const { runtime, settingsFilePath, cleanup } = await createRuntime();
+    try {
+      const first = runtime.writeSettingsToDisk({ theme: 'dark', writer: 'a' });
+      const second = runtime.writeSettingsToDisk({ theme: 'light', writer: 'b' });
+      await Promise.all([first, second]);
+
+      const onDisk = JSON.parse(await fsPromises.readFile(settingsFilePath, 'utf8'));
+      // Whichever call went last should fully win; a race would risk landing
+      // a mix, or leaving an orphaned .tmp-* file next to settings.json.
+      expect(onDisk).toEqual({ theme: 'light', writer: 'b' });
+
+      const siblingFiles = await fsPromises.readdir(path.dirname(settingsFilePath));
+      expect(siblingFiles.some((name) => name.includes('.tmp-'))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`packages/electron/main.mjs` (`writeJsonFile`/`mutateSettingsRoot`) and `packages/web/server/lib/opencode/settings-runtime.js` (`writeSettingsToDisk`) each persist `settings.json` through their own independent atomic write-tmp-then-rename path. Since the desktop app starts the web server in-process (per this repo's own architecture notes), both writers run in the same process against the same file with no coordination between them.

Separately, direct `writeSettingsToDisk` callers outside `persistSettings` (relay signing key, push runtime, notification routes) bypassed the module's own `persistSettingsLock` entirely — only calls that went through `persistSettings` were serialized.

Net effect: concurrent read-modify-write cycles from either side can silently drop each other's changes (last writer wins, earlier changes lost). I hit this after noticing repeated Electron main/renderer crashes on macOS 1.16.1 correlated with several orphaned `settings.json.tmp-<pid>-*` files sitting next to a live `settings.json`, including a 0-byte one from a write that never got to rename.

I want to flag up front: I could not pin the underlying native crash itself (EXC_BREAKPOINT/SIGTRAP inside the Electron/V8 layer) to a specific line — the crash-report stack frames are mis-symbolicated against unrelated bundled libraries, consistent with a stripped release binary, so I didn't want to guess-patch that blind. What I could verify and fix is the write race above, which is real regardless of whether it's the sole cause of what I saw.

## Changes

- Add `packages/web/server/lib/fs/settings-file-lock.js`: a small path-keyed write lock (`withFileWriteLock`), shared by any writer of the same file path within a process.
- `settings-runtime.js`: `writeSettingsToDisk` now goes through the lock, so every caller (not just `persistSettings`) is serialized.
- `main.mjs`: `writeJsonFile` now goes through the same shared lock module, so Electron's own settings writer serializes against the web server's writer.

## Test plan

- [x] `bun run test` in `packages/web` — new `settings-file-lock.test.js` and a new regression test in `settings-runtime.test.js` proving two concurrent `writeSettingsToDisk` calls no longer interleave or leave an orphaned tmp file. Pre-existing suite passes except one unrelated, pre-existing failure on `main` (`env-runtime.test.js`, picks up a locally-installed `opencode` binary via `PATH` on my machine — reproduces identically on a clean `main` checkout before this change).
- [x] `bun run type-check` in `packages/web` — clean.
- [x] `node --check` on all three touched/added JS/mjs files — clean.
- [x] `bun run dead-code` — new file/export not flagged.
- [ ] Did not run a full packaged Electron manual test (no packaging environment here); the `main.mjs` change is a small, mechanical wrap of an already-tested function with the same shape as the server-side change, so risk is low, but flagging this gap explicitly per the repo's own validation guidance for platform/runtime changes.