### PR TITLE
fix(sync): restore chat timeline after revert

### DIFF
--- a/packages/ui/src/components/chat/revertedMessageDockState.test.ts
+++ b/packages/ui/src/components/chat/revertedMessageDockState.test.ts
@@ -3,6 +3,7 @@ import type { Message, Part } from '@opencode-ai/sdk/v2/client';
 import type { State } from '@/sync/types';
 
 import { EMPTY_REVERTED_MESSAGE_DOCK_STATE, buildRevertedMessageDockState } from './revertedMessageDockState';
+import { addPostRevertBranchReplacement } from '@/sync/message-visibility';
 
 const message = (id: string, role: 'user' | 'assistant'): Message => ({
     id,
@@ -17,10 +18,11 @@ const textPart = (id: string, text: string): Part => ({
     text,
 } as Part);
 
-const state = (partial: Partial<State>): Pick<State, 'session' | 'message' | 'part'> => ({
+const state = (partial: Partial<State>): Pick<State, 'session' | 'message' | 'part' | 'postRevertBranch'> => ({
     session: [],
     message: {},
     part: {},
+    postRevertBranch: {},
     ...partial,
 });
 
@@ -85,5 +87,25 @@ describe('buildRevertedMessageDockState', () => {
 
         expect(second).not.toBe(first);
         expect(second.records).toHaveLength(1);
+    });
+
+    test('does not list a visible replacement branch as reverted history', () => {
+        const result = buildRevertedMessageDockState(
+            state({
+                session: [{ id: 'ses_1', revert: { messageID: 'msg_002' } } as State['session'][number]],
+                message: {
+                    ses_1: [
+                        message('msg_001', 'user'),
+                        message('msg_002', 'user'),
+                        message('msg_003', 'user'),
+                        message('msg_004', 'user'),
+                    ],
+                },
+                postRevertBranch: addPostRevertBranchReplacement({}, 'ses_1', 'msg_002', 'msg_004'),
+            }),
+            'ses_1',
+        );
+
+        expect(result.records.map((record) => record.message.id)).toEqual(['msg_002', 'msg_003']);
     });
 });

--- a/packages/ui/src/components/chat/revertedMessageDockState.ts
+++ b/packages/ui/src/components/chat/revertedMessageDockState.ts
@@ -1,5 +1,6 @@
 import type { Message, Part } from '@opencode-ai/sdk/v2/client';
-import type { State } from '@/sync/types';
+import type { PostRevertBranchOverlay, State } from '@/sync/types';
+import { getSessionRevertMessageID, isEffectivelyVisibleMessage } from '@/sync/message-visibility';
 
 type RevertedMessageRecord = {
     message: Message & { role: 'user' };
@@ -8,6 +9,7 @@ type RevertedMessageRecord = {
 
 export type RevertedMessageDockState = {
     revertMessageID?: string;
+    postRevertBranch?: PostRevertBranchOverlay;
     records: RevertedMessageRecord[];
 };
 
@@ -16,6 +18,7 @@ const EMPTY_REVERTED_RECORDS: RevertedMessageRecord[] = [];
 
 export const EMPTY_REVERTED_MESSAGE_DOCK_STATE: RevertedMessageDockState = {
     revertMessageID: undefined,
+    postRevertBranch: undefined,
     records: EMPTY_REVERTED_RECORDS,
 };
 
@@ -35,7 +38,7 @@ const areRecordsEqual = (left: RevertedMessageRecord[], right: RevertedMessageRe
 };
 
 export const buildRevertedMessageDockState = (
-    state: Pick<State, 'session' | 'message' | 'part'>,
+    state: Pick<State, 'session' | 'message' | 'part' | 'postRevertBranch'>,
     sessionId: string | null,
     previous: RevertedMessageDockState = EMPTY_REVERTED_MESSAGE_DOCK_STATE,
 ): RevertedMessageDockState => {
@@ -44,15 +47,16 @@ export const buildRevertedMessageDockState = (
     }
 
     const session = state.session.find((item) => item.id === sessionId);
-    const revertMessageID = (session as { revert?: { messageID?: string } } | undefined)?.revert?.messageID;
+    const revertMessageID = getSessionRevertMessageID(session);
     if (!revertMessageID) {
         return EMPTY_REVERTED_MESSAGE_DOCK_STATE;
     }
 
     const messages = state.message[sessionId] ?? [];
+    const postRevertBranch = state.postRevertBranch[sessionId];
     const records: RevertedMessageRecord[] = [];
     for (const message of messages) {
-        if (!isUserMessage(message) || message.id < revertMessageID) {
+        if (!isUserMessage(message) || isEffectivelyVisibleMessage(message.id, session, postRevertBranch)) {
             continue;
         }
         records.push({
@@ -62,12 +66,17 @@ export const buildRevertedMessageDockState = (
     }
 
     const next = records.length === 0 ? EMPTY_REVERTED_RECORDS : records;
-    if (previous.revertMessageID === revertMessageID && areRecordsEqual(previous.records, next)) {
+    if (
+        previous.revertMessageID === revertMessageID
+        && previous.postRevertBranch === postRevertBranch
+        && areRecordsEqual(previous.records, next)
+    ) {
         return previous;
     }
 
     return {
         revertMessageID,
+        postRevertBranch,
         records: next,
     };
 };

--- a/packages/ui/src/sync/__tests__/eviction.test.ts
+++ b/packages/ui/src/sync/__tests__/eviction.test.ts
@@ -181,11 +181,15 @@ describe("session cache eviction", () => {
       part: {
         msg_1: [{ id: "prt_1", messageID: "msg_1" } as Part],
       },
+      postRevertBranch: {
+        ses_old: { revertMessageID: "msg_0", replacementMessageIDs: ["msg_1"] },
+      },
     })
 
     dropSessionCaches(store, ["ses_old"])
 
     expect(store.message.ses_old).toBe(undefined)
     expect(store.part.msg_1).toBe(undefined)
+    expect(store.postRevertBranch.ses_old).toBe(undefined)
   })
 })

--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -567,6 +567,7 @@ function trimSessions(draft: State) {
     const candidate = draft.session[0]
     if (hasPermission.has(candidate.id)) break
     draft.session.shift()
+    delete draft.postRevertBranch[candidate.id]
   }
 }
 

--- a/packages/ui/src/sync/message-visibility.ts
+++ b/packages/ui/src/sync/message-visibility.ts
@@ -1,0 +1,194 @@
+import type { Message } from "@opencode-ai/sdk/v2/client"
+import type { PostRevertBranchOverlay, PostRevertBranchOverlays } from "./types"
+
+type SessionRevertMarker = {
+  messageID?: string | null
+}
+
+type SessionWithRevert = {
+  id: string
+  revert?: SessionRevertMarker | null
+}
+
+export function getSessionRevertMessageID(session: Pick<SessionWithRevert, "revert"> | undefined): string | undefined {
+  const marker = session?.revert
+  if (!marker || typeof marker !== "object") return undefined
+  const { messageID } = marker
+  return typeof messageID === "string" && messageID.length > 0 ? messageID : undefined
+}
+
+export function hasEffectivePostRevertBranch(
+  session: Pick<SessionWithRevert, "revert"> | undefined,
+  overlay: PostRevertBranchOverlay | undefined,
+): boolean {
+  return getReplacementBoundary(getSessionRevertMessageID(session), overlay) !== undefined
+}
+
+/**
+ * Derive timeline-visible messages from the authoritative marker plus the
+ * locally optimistic replacement branch. OpenCode message IDs are ascending,
+ * so the first replacement ID is the boundary for later server messages that
+ * belong to that replacement branch.
+ */
+export function getEffectiveVisibleMessages(
+  messages: Message[],
+  session: Pick<SessionWithRevert, "revert"> | undefined,
+  overlay: PostRevertBranchOverlay | undefined,
+): Message[] {
+  const revertMessageID = getSessionRevertMessageID(session)
+  if (!revertMessageID) return messages
+
+  const replacementBoundary = getReplacementBoundary(revertMessageID, overlay)
+  return messages.filter((message) => isVisibleAtBoundary(message.id, revertMessageID, replacementBoundary))
+}
+
+export function isEffectivelyVisibleMessage(
+  messageID: string,
+  session: Pick<SessionWithRevert, "revert"> | undefined,
+  overlay: PostRevertBranchOverlay | undefined,
+): boolean {
+  const revertMessageID = getSessionRevertMessageID(session)
+  if (!revertMessageID) return true
+
+  const replacementBoundary = getReplacementBoundary(revertMessageID, overlay)
+
+  return isVisibleAtBoundary(messageID, revertMessageID, replacementBoundary)
+}
+
+function getReplacementBoundary(
+  revertMessageID: string | undefined,
+  overlay: PostRevertBranchOverlay | undefined,
+): string | undefined {
+  if (
+    !revertMessageID
+    || !overlay
+    || overlay.replacementMessageIDs.length === 0
+    || overlay.revertMessageID !== revertMessageID
+  ) {
+    return undefined
+  }
+  return overlay.replacementMessageIDs[0]
+}
+
+function isVisibleAtBoundary(
+  messageID: string,
+  revertMessageID: string,
+  replacementBoundary: string | undefined,
+): boolean {
+  // OpenCode's Identifier.ascending IDs sort lexicographically by creation
+  // order, and server message snapshots preserve that ordering contract.
+  return (
+    messageID < revertMessageID
+    || (replacementBoundary !== undefined && messageID >= replacementBoundary)
+  )
+}
+
+export function addPostRevertBranchReplacement(
+  overlays: PostRevertBranchOverlays,
+  sessionID: string,
+  revertMessageID: string,
+  replacementMessageID: string,
+): PostRevertBranchOverlays {
+  const current = overlays[sessionID]
+  const replacementMessageIDs = current?.revertMessageID === revertMessageID
+    ? current.replacementMessageIDs
+    : []
+  if (replacementMessageIDs.includes(replacementMessageID)) {
+    return overlays
+  }
+
+  return {
+    ...overlays,
+    [sessionID]: {
+      revertMessageID,
+      // Identifier.ascending makes lexical message-ID order chronological.
+      replacementMessageIDs: [...replacementMessageIDs, replacementMessageID].sort(),
+    },
+  }
+}
+
+export function removePostRevertBranchReplacement(
+  overlays: PostRevertBranchOverlays,
+  sessionID: string,
+  replacementMessageID: string,
+): PostRevertBranchOverlays {
+  const current = overlays[sessionID]
+  if (!current || !current.replacementMessageIDs.includes(replacementMessageID)) return overlays
+
+  const replacementMessageIDs = current.replacementMessageIDs.filter((id) => id !== replacementMessageID)
+  if (replacementMessageIDs.length === 0) {
+    return clearPostRevertBranchOverlay(overlays, sessionID)
+  }
+
+  return {
+    ...overlays,
+    [sessionID]: { ...current, replacementMessageIDs },
+  }
+}
+
+/** Replace one session's local overlay without disturbing concurrent sessions. */
+export function setPostRevertBranchOverlay(
+  overlays: PostRevertBranchOverlays,
+  sessionID: string,
+  overlay: PostRevertBranchOverlay | undefined,
+): PostRevertBranchOverlays {
+  if (!overlay) return clearPostRevertBranchOverlay(overlays, sessionID)
+  return { ...overlays, [sessionID]: overlay }
+}
+
+export function clearPostRevertBranchOverlay(
+  overlays: PostRevertBranchOverlays,
+  sessionID: string,
+): PostRevertBranchOverlays {
+  if (!overlays[sessionID]) return overlays
+  const next = { ...overlays }
+  delete next[sessionID]
+  return next
+}
+
+/**
+ * An overlay is only valid while the exact same authoritative marker remains
+ * in place. A new revert, unrevert, cache reload, or session replacement
+ * retires it instead of allowing it to revive against unrelated state.
+ */
+export function reconcilePostRevertBranchOverlay(
+  overlays: PostRevertBranchOverlays,
+  sessionID: string,
+  previousSession: Pick<SessionWithRevert, "revert"> | undefined,
+  nextSession: Pick<SessionWithRevert, "revert"> | undefined,
+): PostRevertBranchOverlays {
+  const overlay = overlays[sessionID]
+  if (!overlay) return overlays
+
+  const previousRevertMessageID = getSessionRevertMessageID(previousSession)
+  const nextRevertMessageID = getSessionRevertMessageID(nextSession)
+  if (
+    previousRevertMessageID === nextRevertMessageID
+    && nextRevertMessageID === overlay.revertMessageID
+  ) {
+    return overlays
+  }
+
+  return clearPostRevertBranchOverlay(overlays, sessionID)
+}
+
+export function reconcilePostRevertBranchOverlays(
+  overlays: PostRevertBranchOverlays,
+  previousSessions: ReadonlyArray<SessionWithRevert>,
+  nextSessions: ReadonlyArray<SessionWithRevert>,
+): PostRevertBranchOverlays {
+  if (Object.keys(overlays).length === 0) return overlays
+
+  const previousByID = new Map(previousSessions.map((session) => [session.id, session]))
+  const nextByID = new Map(nextSessions.map((session) => [session.id, session]))
+  let next = overlays
+  for (const sessionID of Object.keys(overlays)) {
+    next = reconcilePostRevertBranchOverlay(
+      next,
+      sessionID,
+      previousByID.get(sessionID),
+      nextByID.get(sessionID),
+    )
+  }
+  return next
+}

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -192,9 +192,24 @@ mock.module("@/stores/useGlobalSessionsStore", () => ({
 }))
 
 mock.module("./sync-refs", () => ({
+  emitSyncConfigChanged: () => {},
+  getAllSyncSessionMap: () => new Map(),
+  getAllSyncSessions: () => [],
+  getDirectoryState: () => undefined,
+  getSyncChildStores: () => {
+    throw new Error("ChildStoreManager not initialized")
+  },
+  getSyncConfig: () => undefined,
+  getSyncMessages: () => [],
+  getSyncParts: () => [],
+  getSyncSessionMaterializationStatus: () => ({ hasMessages: false, renderable: false, missingPartMessageIDs: [] }),
+  getSyncSessions: () => [],
+  getSyncSessionStatus: () => undefined,
   registerSessionDirectory: (sessionID: string, directory: string) => {
     registeredSessionDirectories.push({ sessionID, directory })
   },
+  setSyncRefs: () => {},
+  subscribeToSyncConfigChanges: () => () => {},
 }))
 
 import { create, type StoreApi } from "zustand"
@@ -202,7 +217,13 @@ import { INITIAL_STATE } from "./types"
 import type { DirectoryStore } from "./child-store"
 import type { Message, OpencodeClient, Part, Session } from "@opencode-ai/sdk/v2/client"
 
-type OptimisticAddCall = { sessionID: string; directory?: string | null; message: Message; parts: Part[] }
+type OptimisticAddCall = {
+  sessionID: string
+  directory?: string | null
+  message: Message
+  parts: Part[]
+  clearRevert?: { sessionID: string; previousRevert: unknown }
+}
 type OptimisticRemoveCall = { sessionID: string; directory?: string | null; messageID: string }
 type SessionWithDirectory = Session & {
   directory?: string | null
@@ -429,6 +450,131 @@ describe("optimisticSend target directory", () => {
     expect(optimisticRemove).toBe(null)
     expect(targetStore.getState().session_status["session-new"]?.type).toBe("busy")
     expect(currentStore.getState().session_status["session-new"]).toBe(undefined)
+  })
+
+  test("clears and restores only the target session's revert marker around a failed send", async () => {
+    const targetSession = { id: "session-a", time: { created: 1 }, revert: { messageID: "msg_2" } } as Session
+    const otherSession = { id: "session-b", time: { created: 1 }, revert: { messageID: "msg_9" } } as Session
+    const targetStore = createStore({}, { session: [targetSession] })
+    const otherStore = createStore({}, { session: [otherSession] })
+    const childStores = createChildStores([
+      ["/target/project", targetStore],
+      ["/other/project", otherStore],
+    ])
+    let clearRevert: { sessionID: string; previousRevert: unknown } | undefined
+
+    const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/current/project")
+    setOptimisticRefs(
+      (input) => {
+        clearRevert = input.clearRevert
+        const current = targetStore.getState()
+        const session = [...current.session]
+        const index = session.findIndex((item) => item.id === input.clearRevert?.sessionID)
+        if (index >= 0 && (session[index] as { revert?: unknown }).revert === input.clearRevert?.previousRevert) {
+          session[index] = { ...session[index], revert: undefined } as Session
+        }
+        targetStore.setState({ session })
+      },
+      () => {},
+    )
+
+    await expect(optimisticSend({
+      sessionId: "session-a",
+      directory: "/target/project",
+      content: "replacement",
+      providerID: "provider",
+      modelID: "model",
+      send: async () => {
+        throw new Error("validation rejected")
+      },
+    })).rejects.toThrow("validation rejected")
+
+    expect(clearRevert?.sessionID).toBe("session-a")
+    expect((targetStore.getState().session[0] as Session & { revert?: { messageID?: string } }).revert?.messageID).toBe("msg_2")
+    expect((otherStore.getState().session[0] as Session & { revert?: { messageID?: string } }).revert?.messageID).toBe("msg_9")
+  })
+
+  test("keeps the cleared revert marker when an ambiguous send is confirmed", async () => {
+    const targetSession = { id: "session-a", time: { created: 1 }, revert: { messageID: "msg_2" } } as Session
+    const targetStore = createStore({}, { session: [targetSession] })
+    const childStores = createChildStores([["/target/project", targetStore]])
+
+    const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/target/project")
+    setOptimisticRefs(
+      (input) => {
+        const current = targetStore.getState()
+        const session = [...current.session]
+        const index = session.findIndex((item) => item.id === input.clearRevert?.sessionID)
+        if (index >= 0 && (session[index] as { revert?: unknown }).revert === input.clearRevert?.previousRevert) {
+          session[index] = { ...session[index], revert: undefined } as Session
+        }
+        targetStore.setState({ session })
+      },
+      () => {},
+      () => {},
+    )
+
+    await optimisticSend({
+      sessionId: "session-a",
+      directory: "/target/project",
+      content: "replacement",
+      providerID: "provider",
+      modelID: "model",
+      send: async (messageID) => {
+        sessionMessagesResult = {
+          data: [{
+            info: { id: messageID, role: "user", sessionID: "session-a", time: { created: 1 } } as Message,
+            parts: [],
+          }],
+        }
+        const error = new Error("Failed to send message (504): gateway timeout") as Error & { status?: number }
+        error.status = 504
+        throw error
+      },
+    })
+
+    expect((targetStore.getState().session[0] as Session & { revert?: { messageID?: string } }).revert).toBe(undefined)
+  })
+
+  test("does not restore a revert marker after an authoritative session update", async () => {
+    const targetSession = { id: "session-a", title: "local", time: { created: 1 }, revert: { messageID: "msg_2" } } as Session
+    const targetStore = createStore({}, { session: [targetSession] })
+    const childStores = createChildStores([["/target/project", targetStore]])
+
+    const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/target/project")
+    setOptimisticRefs(
+      (input) => {
+        const current = targetStore.getState()
+        targetStore.setState({
+          session: current.session.map((session) => session.id === input.clearRevert?.sessionID
+            ? { ...session, revert: undefined } as Session
+            : session),
+        })
+      },
+      () => {},
+    )
+
+    await expect(optimisticSend({
+      sessionId: "session-a",
+      directory: "/target/project",
+      content: "replacement",
+      providerID: "provider",
+      modelID: "model",
+      send: async () => {
+        const current = targetStore.getState()
+        targetStore.setState({
+          session: [{ ...current.session[0], title: "server", revert: undefined } as Session],
+        })
+        throw new Error("validation rejected")
+      },
+    })).rejects.toThrow("validation rejected")
+
+    const session = targetStore.getState().session[0] as Session & { revert?: { messageID?: string } }
+    expect(session.title).toBe("server")
+    expect(session.revert).toBe(undefined)
   })
 
   test("allows callers to block final send when runtime changes after optimistic insert", async () => {

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -7,6 +7,7 @@ const replyCalls: Array<{ method: string; params: Record<string, unknown> }> = [
 const scopedClientDirectories: string[] = []
 const registeredSessionDirectories: Array<{ sessionID: string; directory: string }> = []
 let sessionRevertResult: { data?: unknown; error?: unknown; response?: { status?: number } } = {}
+let onSessionRevert: (() => void | Promise<void>) | undefined
 let questionReplyError: unknown | null = null
 let questionRejectError: unknown | null = null
 let sessionShareResult: { data?: unknown; error?: unknown; response?: { status?: number } } = {}
@@ -110,16 +111,17 @@ mock.module("@/lib/opencode/client", () => ({
       replyCalls.push({ method: "question.reply", params: { requestID: requestId, answers, directory } })
       return Promise.resolve(true)
     }),
-    revertSession: mock((sessionId: string, messageId: string, partId?: string, directory?: string | null) => {
+    revertSession: mock(async (sessionId: string, messageId: string, partId?: string, directory?: string | null) => {
       replyCalls.push({
         method: "session.revert",
         params: { sessionID: sessionId, messageID: messageId, partID: partId, directory },
       })
+      await onSessionRevert?.()
       if (sessionRevertResult.error) {
         const status = sessionRevertResult.response?.status
         throw new Error(`session.revert failed${status ? ` (${status})` : ""}: rejected`)
       }
-      return Promise.resolve(sessionRevertResult.data)
+      return sessionRevertResult.data
     }),
     updateSession: mock((sessionId: string, changes: Record<string, unknown>, directory?: string | null) => {
       replyCalls.push({ method: "session.update", params: { sessionID: sessionId, ...changes, directory } })
@@ -138,7 +140,8 @@ mock.module("@/stores/useConfigStore", () => ({
   },
 }))
 
-// Mock useSessionUIStore
+// This test module uses Bun module mocks for session-actions dependencies.
+// Run it with `bun test --isolate` alongside tests that import the real store.
 mock.module("./session-ui-store", () => ({
   useSessionUIStore: {
     getState: () => ({
@@ -213,6 +216,7 @@ mock.module("./sync-refs", () => ({
 }))
 
 import { create, type StoreApi } from "zustand"
+import { addPostRevertBranchReplacement, getEffectiveVisibleMessages } from "./message-visibility"
 import { INITIAL_STATE } from "./types"
 import type { DirectoryStore } from "./child-store"
 import type { Message, OpencodeClient, Part, Session } from "@opencode-ai/sdk/v2/client"
@@ -222,7 +226,6 @@ type OptimisticAddCall = {
   directory?: string | null
   message: Message
   parts: Part[]
-  clearRevert?: { sessionID: string; previousRevert: unknown }
 }
 type OptimisticRemoveCall = { sessionID: string; directory?: string | null; messageID: string }
 type SessionWithDirectory = Session & {
@@ -452,7 +455,7 @@ describe("optimisticSend target directory", () => {
     expect(currentStore.getState().session_status["session-new"]).toBe(undefined)
   })
 
-  test("clears and restores only the target session's revert marker around a failed send", async () => {
+  test("keeps the target session's authoritative revert marker around a failed replacement", async () => {
     const targetSession = { id: "session-a", time: { created: 1 }, revert: { messageID: "msg_2" } } as Session
     const otherSession = { id: "session-b", time: { created: 1 }, revert: { messageID: "msg_9" } } as Session
     const targetStore = createStore({}, { session: [targetSession] })
@@ -461,20 +464,13 @@ describe("optimisticSend target directory", () => {
       ["/target/project", targetStore],
       ["/other/project", otherStore],
     ])
-    let clearRevert: { sessionID: string; previousRevert: unknown } | undefined
+    let optimisticAdd: OptimisticAddCall | null = null
 
     const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
     setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/current/project")
     setOptimisticRefs(
       (input) => {
-        clearRevert = input.clearRevert
-        const current = targetStore.getState()
-        const session = [...current.session]
-        const index = session.findIndex((item) => item.id === input.clearRevert?.sessionID)
-        if (index >= 0 && (session[index] as { revert?: unknown }).revert === input.clearRevert?.previousRevert) {
-          session[index] = { ...session[index], revert: undefined } as Session
-        }
-        targetStore.setState({ session })
+        optimisticAdd = input
       },
       () => {},
     )
@@ -490,12 +486,18 @@ describe("optimisticSend target directory", () => {
       },
     })).rejects.toThrow("validation rejected")
 
-    expect(clearRevert?.sessionID).toBe("session-a")
+    expect(optimisticAdd).not.toBeNull()
+    expect(Object.keys(optimisticAdd as unknown as Record<string, unknown>).sort()).toEqual([
+      "directory",
+      "message",
+      "parts",
+      "sessionID",
+    ])
     expect((targetStore.getState().session[0] as Session & { revert?: { messageID?: string } }).revert?.messageID).toBe("msg_2")
     expect((otherStore.getState().session[0] as Session & { revert?: { messageID?: string } }).revert?.messageID).toBe("msg_9")
   })
 
-  test("keeps the cleared revert marker when an ambiguous send is confirmed", async () => {
+  test("keeps the authoritative revert marker when an ambiguous replacement is confirmed", async () => {
     const targetSession = { id: "session-a", time: { created: 1 }, revert: { messageID: "msg_2" } } as Session
     const targetStore = createStore({}, { session: [targetSession] })
     const childStores = createChildStores([["/target/project", targetStore]])
@@ -503,15 +505,7 @@ describe("optimisticSend target directory", () => {
     const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
     setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/target/project")
     setOptimisticRefs(
-      (input) => {
-        const current = targetStore.getState()
-        const session = [...current.session]
-        const index = session.findIndex((item) => item.id === input.clearRevert?.sessionID)
-        if (index >= 0 && (session[index] as { revert?: unknown }).revert === input.clearRevert?.previousRevert) {
-          session[index] = { ...session[index], revert: undefined } as Session
-        }
-        targetStore.setState({ session })
-      },
+      () => {},
       () => {},
       () => {},
     )
@@ -535,10 +529,10 @@ describe("optimisticSend target directory", () => {
       },
     })
 
-    expect((targetStore.getState().session[0] as Session & { revert?: { messageID?: string } }).revert).toBe(undefined)
+    expect((targetStore.getState().session[0] as Session & { revert?: { messageID?: string } }).revert?.messageID).toBe("msg_2")
   })
 
-  test("does not restore a revert marker after an authoritative session update", async () => {
+  test("does not overwrite an authoritative session transition after a failed replacement", async () => {
     const targetSession = { id: "session-a", title: "local", time: { created: 1 }, revert: { messageID: "msg_2" } } as Session
     const targetStore = createStore({}, { session: [targetSession] })
     const childStores = createChildStores([["/target/project", targetStore]])
@@ -546,14 +540,7 @@ describe("optimisticSend target directory", () => {
     const { optimisticSend, setActionRefs, setOptimisticRefs } = await import("./session-actions")
     setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/target/project")
     setOptimisticRefs(
-      (input) => {
-        const current = targetStore.getState()
-        targetStore.setState({
-          session: current.session.map((session) => session.id === input.clearRevert?.sessionID
-            ? { ...session, revert: undefined } as Session
-            : session),
-        })
-      },
+      () => {},
       () => {},
     )
 
@@ -783,6 +770,7 @@ describe("revertToMessage passes session directory", () => {
     replyCalls.length = 0
     scopedClientDirectories.length = 0
     sessionRevertResult = {}
+    onSessionRevert = undefined
     Object.assign(inputState, {
       pendingInputText: "previous draft",
       pendingInputMode: "normal" as const,
@@ -843,6 +831,85 @@ describe("revertToMessage passes session directory", () => {
     expect((thrown as Error).message).toContain("session.revert failed (500)")
     expect((sessionStore.getState().session[0] as Session & { revert?: { messageID?: string } }).revert).toBe(undefined)
     expect(inputState.pendingInputText).toBe("previous draft")
+  })
+
+  test("restores a prior revert marker when the SDK rejects a newer revert", async () => {
+    const previousRevert = { messageID: "msg_previous", snapshot: "before" }
+    const session = { id: "session-a", time: { created: 1 }, revert: previousRevert } as Session
+    const targetMessage = { id: "msg_2", sessionID: "session-a", role: "user", time: { created: 2 } } as Message
+    const sessionStore = createStore({}, {
+      session: [session],
+      message: { "session-a": [targetMessage] },
+      part: { "msg_2": [{ id: "prt_2", messageID: "msg_2", type: "text", text: "edit this" } as Part] },
+    })
+    const childStores = createChildStores([["/test/project", sessionStore]])
+    sessionRevertResult = { error: { message: "rejected" }, response: { status: 500 } }
+
+    const { setActionRefs, revertToMessage } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    await expect(revertToMessage("session-a", "msg_2")).rejects.toThrow("session.revert failed (500)")
+
+    expect(sessionStore.getState().session[0]?.revert).toEqual(previousRevert)
+  })
+
+  test("restores a prior replacement branch after reconciliation clears it during a rejected newer revert", async () => {
+    const previousRevert = { messageID: "msg_002", snapshot: "before" }
+    const session = { id: "session-a", time: { created: 1 }, revert: previousRevert } as Session
+    const otherSession = { id: "session-b", time: { created: 1 } } as Session
+    const messages = [
+      { id: "msg_001", sessionID: "session-a", role: "user", time: { created: 1 } },
+      { id: "msg_002", sessionID: "session-a", role: "user", time: { created: 2 } },
+      { id: "msg_003", sessionID: "session-a", role: "user", time: { created: 3 } },
+      { id: "msg_004", sessionID: "session-a", role: "user", time: { created: 4 } },
+    ] as Message[]
+    const priorOverlay = addPostRevertBranchReplacement({}, "session-a", "msg_002", "msg_004")
+    const sessionStore = createStore({}, {
+      session: [session, otherSession],
+      message: { "session-a": messages },
+      part: { "msg_003": [{ id: "prt_3", messageID: "msg_003", type: "text", text: "edit this" } as Part] },
+      postRevertBranch: priorOverlay,
+    })
+    const childStores = createChildStores([["/test/project", sessionStore]])
+    sessionRevertResult = { error: { message: "rejected" }, response: { status: 500 } }
+
+    const { mirrorSessionIntoLiveStores, setActionRefs, revertToMessage } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    onSessionRevert = () => {
+      const optimistic = sessionStore.getState()
+      expect(optimistic.session[0]?.revert).toEqual({ messageID: "msg_003" })
+
+      // Model an SSE session update confirming Y while the SDK request is pending.
+      // This uses the production reconciliation path, which retires the X-bound overlay.
+      mirrorSessionIntoLiveStores(optimistic.session[0]!, "/test/project")
+      expect(sessionStore.getState().postRevertBranch).toEqual({})
+
+      const concurrentOverlays = addPostRevertBranchReplacement(
+        sessionStore.getState().postRevertBranch,
+        "session-b",
+        "msg_b_002",
+        "msg_b_004",
+      )
+      sessionStore.setState({ postRevertBranch: concurrentOverlays })
+    }
+
+    await expect(revertToMessage("session-a", "msg_003")).rejects.toThrow("session.revert failed (500)")
+
+    const current = sessionStore.getState()
+    expect(current.session[0]?.revert).toEqual(previousRevert)
+    expect(current.postRevertBranch["session-a"]).toEqual(priorOverlay["session-a"])
+    expect(current.postRevertBranch["session-b"]).toEqual({
+      revertMessageID: "msg_b_002",
+      replacementMessageIDs: ["msg_b_004"],
+    })
+    expect(
+      getEffectiveVisibleMessages(
+        current.message["session-a"] ?? [],
+        current.session[0],
+        current.postRevertBranch["session-a"],
+      ).map((message) => message.id),
+    ).toEqual(["msg_001", "msg_004"])
   })
 })
 

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -21,6 +21,11 @@ import { isMobileSurfaceRuntime } from "@/lib/runtimeSurface"
 import { stripMessageDiffSnapshots, stripSessionDiffSnapshots } from "./sanitize"
 import { sessionEvents } from "@/lib/sessionEvents"
 import {
+  clearPostRevertBranchOverlay,
+  reconcilePostRevertBranchOverlay,
+  setPostRevertBranchOverlay,
+} from "./message-visibility"
+import {
   getOriginalSessionID,
   getSessionMetadata,
   isReviewSession,
@@ -45,7 +50,6 @@ type OptimisticAddInput = {
   directory?: string | null
   message: Message
   parts: Part[]
-  clearRevert?: { sessionID: string; previousRevert: unknown }
 }
 type OptimisticRemoveInput = { sessionID: string; directory?: string | null; messageID: string }
 type OptimisticConfirmInput = OptimisticRemoveInput
@@ -177,13 +181,24 @@ function updateLiveSession(session: Session, directory?: string): boolean {
 
   for (const [, store] of candidates) {
     if (!store) continue
-    const current = store.getState().session
+    const state = store.getState()
+    const current = state.session
     const index = current.findIndex((item) => item.id === session.id)
     if (index === -1) continue
 
     const next = [...current]
-    next[index] = mergeSessionDirectoryMetadata(session, current[index])
-    store.setState({ session: next })
+    const nextSession = mergeSessionDirectoryMetadata(session, current[index])
+    next[index] = nextSession
+    const postRevertBranch = reconcilePostRevertBranchOverlay(
+      state.postRevertBranch,
+      session.id,
+      current[index],
+      nextSession,
+    )
+    store.setState({
+      session: next,
+      ...(postRevertBranch !== state.postRevertBranch ? { postRevertBranch } : {}),
+    })
     return true
   }
 
@@ -754,28 +769,14 @@ export async function optimisticSend(input: {
     time: { created: Date.now(), completed: 0 },
   } as unknown as Message
 
-  // A revert marker filters every message at and after its target. Clear the
-  // marker in the same store update as the optimistic insertion so the newly
-  // sent message is visible immediately. Keep the exact cleared session
-  // record: an expected send failure restores the marker only if an
-  // authoritative session update has not superseded this local change.
-  const revertedSession = store.getState().session.find((session) => session.id === input.sessionId) as (Session & { revert?: unknown }) | undefined
-  const clearRevert = revertedSession?.revert && typeof revertedSession.revert === "object"
-    && typeof (revertedSession.revert as { messageID?: unknown }).messageID === "string"
-    ? { sessionID: input.sessionId, previousRevert: revertedSession.revert }
-    : undefined
-
-  // Insert into store + register in shadow Map (for mergeOptimisticPage cleanup)
+  // Keep session.revert authoritative. useSync records replacement visibility
+  // in its directory-scoped overlay while inserting this optimistic message.
   _optimisticAdd({
     sessionID: input.sessionId,
     directory: targetDirectory,
     message: optimisticMessage,
     parts: optimisticParts,
-    clearRevert,
   })
-  const clearedRevertSession = clearRevert
-    ? store.getState().session.find((session) => session.id === input.sessionId)
-    : undefined
   input.onOptimisticInsert?.()
 
   // Set busy status
@@ -810,19 +811,6 @@ export async function optimisticSend(input: {
       directory: targetDirectory,
       messageID,
     })
-    if (clearRevert && clearedRevertSession) {
-      store.setState((current) => {
-        const sessionIndex = current.session.findIndex((session) => session.id === input.sessionId)
-        if (sessionIndex === -1 || current.session[sessionIndex] !== clearedRevertSession) return current
-
-        const session = [...current.session]
-        session[sessionIndex] = {
-          ...session[sessionIndex],
-          revert: clearRevert.previousRevert,
-        } as Session
-        return { session }
-      })
-    }
     const s = store.getState()
     store.setState({
       session_status: {
@@ -1118,25 +1106,24 @@ export async function revertToMessage(sessionId: string, messageId: string): Pro
     submittedFileParts = parts.filter((p) => p.type === "file" && !isSyntheticPart(p)) as Array<Record<string, unknown>>
   }
 
-  // Optimistically set only the revert marker. Keep messages and parts in the
-  // local store; visible-message selectors derive the displayed timeline from
-  // session.revert. This matches the server model and preserves reverted
-  // messages for the restore dock without maintaining a separate shadow copy.
+  // Optimistically set only the revert marker. Keep messages, parts, and a
+  // prior replacement overlay in the local store; visible-message selectors
+  // ignore that overlay while its captured marker does not match this one.
+  const stateBeforeOptimisticRevert = store.getState()
   const prevRevert = (() => {
-    const s = state.session.find((s) => s.id === sessionId)
+    const s = stateBeforeOptimisticRevert.session.find((s) => s.id === sessionId)
     return (s as Session & { revert?: unknown })?.revert
   })()
-  const sessions = [...state.session]
+  const previousPostRevertBranch = stateBeforeOptimisticRevert.postRevertBranch[sessionId]
+  const sessions = [...stateBeforeOptimisticRevert.session]
   const sessionIdx = sessions.findIndex((s) => s.id === sessionId)
-
-  const patch: Record<string, unknown> = {}
 
   if (sessionIdx >= 0) {
     sessions[sessionIdx] = { ...sessions[sessionIdx], revert: { messageID: messageId } } as Session
-    patch.session = sessions
   }
-
-  store.setState(patch)
+  store.setState({
+    ...(sessionIdx >= 0 ? { session: sessions } : {}),
+  })
 
   // Save input store state before mutations — if the API fails we need to
   // roll back both text and attachments to their previous values.
@@ -1165,21 +1152,33 @@ export async function revertToMessage(sessionId: string, messageId: string): Pro
     const idx = updated.findIndex((s) => s.id === sessionId)
     if (idx >= 0) {
       updated[idx] = revertedSession
-      store.setState({ session: updated })
     }
+    // The authoritative marker changed, so the prior replacement branch is stale.
+    const postRevertBranch = clearPostRevertBranchOverlay(current.postRevertBranch, sessionId)
+    store.setState({
+      ...(idx >= 0 ? { session: updated } : {}),
+      ...(postRevertBranch !== current.postRevertBranch ? { postRevertBranch } : {}),
+    })
     if (directory) {
       sessionEvents.requestGitRefresh({ directory })
     }
   } catch (err) {
-    // Rollback: restore removed messages + revert marker
+    // Reconciliation may have retired the prior overlay while Y was active.
+    // Restore only this session's captured overlay with the prior marker.
     const current = store.getState()
     const rollback = [...current.session]
     const idx = rollback.findIndex((s) => s.id === sessionId)
     if (idx >= 0) {
       rollback[idx] = { ...rollback[idx], revert: prevRevert } as Session
     }
+    const postRevertBranch = setPostRevertBranchOverlay(
+      current.postRevertBranch,
+      sessionId,
+      previousPostRevertBranch,
+    )
     store.setState({
-      session: rollback,
+      ...(idx >= 0 ? { session: rollback } : {}),
+      ...(postRevertBranch !== current.postRevertBranch ? { postRevertBranch } : {}),
     })
     // Rollback input store: restore previous text and attachments
     useInputStore.setState({
@@ -1238,8 +1237,12 @@ export async function unrevertSession(sessionId: string): Promise<void> {
   const idx = sessions.findIndex((s) => s.id === sessionId)
   if (idx >= 0) {
     sessions[idx] = unrevertedSession
-    store.setState({ session: sessions })
   }
+  const postRevertBranch = clearPostRevertBranchOverlay(current.postRevertBranch, sessionId)
+  store.setState({
+    ...(idx >= 0 ? { session: sessions } : {}),
+    ...(postRevertBranch !== current.postRevertBranch ? { postRevertBranch } : {}),
+  })
   for (let attempt = 0; attempt < UNREVERT_REFETCH_ATTEMPTS; attempt += 1) {
     if (attempt > 0) await wait(UNREVERT_REFETCH_RETRY_MS)
     await refetchSessionMessages(sessionId)

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -40,7 +40,13 @@ const UNREVERT_REFETCH_RETRY_MS = 150
 let _sdk: OpencodeClient | null = null
 let _childStores: ChildStoreManager | null = null
 let _getDirectory: () => string = () => ""
-type OptimisticAddInput = { sessionID: string; directory?: string | null; message: Message; parts: Part[] }
+type OptimisticAddInput = {
+  sessionID: string
+  directory?: string | null
+  message: Message
+  parts: Part[]
+  clearRevert?: { sessionID: string; previousRevert: unknown }
+}
 type OptimisticRemoveInput = { sessionID: string; directory?: string | null; messageID: string }
 type OptimisticConfirmInput = OptimisticRemoveInput
 
@@ -748,13 +754,28 @@ export async function optimisticSend(input: {
     time: { created: Date.now(), completed: 0 },
   } as unknown as Message
 
+  // A revert marker filters every message at and after its target. Clear the
+  // marker in the same store update as the optimistic insertion so the newly
+  // sent message is visible immediately. Keep the exact cleared session
+  // record: an expected send failure restores the marker only if an
+  // authoritative session update has not superseded this local change.
+  const revertedSession = store.getState().session.find((session) => session.id === input.sessionId) as (Session & { revert?: unknown }) | undefined
+  const clearRevert = revertedSession?.revert && typeof revertedSession.revert === "object"
+    && typeof (revertedSession.revert as { messageID?: unknown }).messageID === "string"
+    ? { sessionID: input.sessionId, previousRevert: revertedSession.revert }
+    : undefined
+
   // Insert into store + register in shadow Map (for mergeOptimisticPage cleanup)
   _optimisticAdd({
     sessionID: input.sessionId,
     directory: targetDirectory,
     message: optimisticMessage,
     parts: optimisticParts,
+    clearRevert,
   })
+  const clearedRevertSession = clearRevert
+    ? store.getState().session.find((session) => session.id === input.sessionId)
+    : undefined
   input.onOptimisticInsert?.()
 
   // Set busy status
@@ -789,6 +810,19 @@ export async function optimisticSend(input: {
       directory: targetDirectory,
       messageID,
     })
+    if (clearRevert && clearedRevertSession) {
+      store.setState((current) => {
+        const sessionIndex = current.session.findIndex((session) => session.id === input.sessionId)
+        if (sessionIndex === -1 || current.session[sessionIndex] !== clearedRevertSession) return current
+
+        const session = [...current.session]
+        session[sessionIndex] = {
+          ...session[sessionIndex],
+          revert: clearRevert.previousRevert,
+        } as Session
+        return { session }
+      })
+    }
     const s = store.getState()
     store.setState({
       session_status: {

--- a/packages/ui/src/sync/session-cache.ts
+++ b/packages/ui/src/sync/session-cache.ts
@@ -6,7 +6,7 @@ import type {
   SessionStatus,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
-import type { FileDiff } from "./types"
+import type { FileDiff, PostRevertBranchOverlays } from "./types"
 
 type SessionCache = {
   session_status: Record<string, SessionStatus | undefined>
@@ -16,6 +16,7 @@ type SessionCache = {
   part: Record<string, Part[] | undefined>
   permission: Record<string, PermissionRequest[] | undefined>
   question: Record<string, QuestionRequest[] | undefined>
+  postRevertBranch?: PostRevertBranchOverlays
 }
 
 export function getProtectedSessionCacheIds(store: SessionCache): Set<string> {
@@ -81,6 +82,7 @@ export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<stri
     delete store.session_status[sessionID]
     delete store.permission[sessionID]
     delete store.question[sessionID]
+    delete store.postRevertBranch?.[sessionID]
   }
 }
 

--- a/packages/ui/src/sync/session-message-records.test.ts
+++ b/packages/ui/src/sync/session-message-records.test.ts
@@ -24,6 +24,31 @@ const state = (partial: Partial<State>): State => ({
 });
 
 describe('buildSessionMessageRecordsSnapshot', () => {
+  test('shows an optimistic replacement after its session revert marker is cleared', () => {
+    const beforeRevert = message('user_1', 'user');
+    const reverted = message('user_2', 'user');
+    const optimisticReplacement = message('user_3', 'user');
+    const previous = buildSessionMessageRecordsSnapshot(
+      state({
+        session: [{ id: 'ses_1', revert: { messageID: 'user_2' } } as State['session'][number]],
+        message: { ses_1: [beforeRevert, reverted] },
+      }),
+      'ses_1',
+    );
+
+    const next = buildSessionMessageRecordsSnapshot(
+      state({
+        session: [{ id: 'ses_1' } as State['session'][number]],
+        message: { ses_1: [beforeRevert, reverted, optimisticReplacement] },
+      }),
+      'ses_1',
+      previous,
+    );
+
+    expect(previous.list.map((record) => record.info.id)).toEqual(['user_1']);
+    expect(next.list.map((record) => record.info.id)).toContain('user_3');
+  });
+
   test('only suspends part updates for the active streaming message', () => {
     const user = message('user_1', 'user');
     const assistant1 = message('assistant_1', 'assistant', 'user_1');

--- a/packages/ui/src/sync/session-message-records.test.ts
+++ b/packages/ui/src/sync/session-message-records.test.ts
@@ -3,6 +3,11 @@ import type { Message, Part } from '@opencode-ai/sdk/v2/client';
 
 import { buildSessionMessageRecordsSnapshot } from './sync-context';
 import { INITIAL_STATE, type State } from './types';
+import {
+  addPostRevertBranchReplacement,
+  reconcilePostRevertBranchOverlay,
+  removePostRevertBranchReplacement,
+} from './message-visibility';
 
 const message = (id: string, role: 'user' | 'assistant', parentID?: string): Message => ({
   id,
@@ -24,29 +29,138 @@ const state = (partial: Partial<State>): State => ({
 });
 
 describe('buildSessionMessageRecordsSnapshot', () => {
-  test('shows an optimistic replacement after its session revert marker is cleared', () => {
-    const beforeRevert = message('user_1', 'user');
-    const reverted = message('user_2', 'user');
-    const optimisticReplacement = message('user_3', 'user');
+  test('keeps an optimistic replacement branch visible without clearing the authoritative marker', () => {
+    const beforeRevert = message('msg_001', 'user');
+    const reverted = message('msg_002', 'user');
+    const discarded = message('msg_003', 'assistant');
+    const optimisticReplacement = message('msg_004', 'user');
+    const session = { id: 'ses_1', revert: { messageID: 'msg_002' } } as State['session'][number];
+    const messages = [beforeRevert, reverted, discarded, optimisticReplacement];
     const previous = buildSessionMessageRecordsSnapshot(
       state({
-        session: [{ id: 'ses_1', revert: { messageID: 'user_2' } } as State['session'][number]],
-        message: { ses_1: [beforeRevert, reverted] },
+        session: [session],
+        message: { ses_1: messages },
       }),
       'ses_1',
     );
 
     const next = buildSessionMessageRecordsSnapshot(
       state({
-        session: [{ id: 'ses_1' } as State['session'][number]],
-        message: { ses_1: [beforeRevert, reverted, optimisticReplacement] },
+        session: [session],
+        message: { ses_1: messages },
+        postRevertBranch: addPostRevertBranchReplacement({}, 'ses_1', 'msg_002', 'msg_004'),
       }),
       'ses_1',
       previous,
     );
 
-    expect(previous.list.map((record) => record.info.id)).toEqual(['user_1']);
-    expect(next.list.map((record) => record.info.id)).toContain('user_3');
+    expect(previous.list.map((record) => record.info.id)).toEqual(['msg_001']);
+    expect(next.list.map((record) => record.info.id)).toEqual(['msg_001', 'msg_004']);
+  });
+
+  test('hides a hard-failed replacement while preserving the reverted branch boundary', () => {
+    const overlay = addPostRevertBranchReplacement({}, 'ses_1', 'msg_002', 'msg_004');
+    const afterHardFailure = removePostRevertBranchReplacement(overlay, 'ses_1', 'msg_004');
+    const snapshot = buildSessionMessageRecordsSnapshot(
+      state({
+        session: [{ id: 'ses_1', revert: { messageID: 'msg_002' } } as State['session'][number]],
+        message: {
+          ses_1: [
+            message('msg_001', 'user'),
+            message('msg_002', 'user'),
+            message('msg_003', 'assistant'),
+          ],
+        },
+        postRevertBranch: afterHardFailure,
+      }),
+      'ses_1',
+    );
+
+    expect(afterHardFailure).toEqual({});
+    expect(snapshot.list.map((record) => record.info.id)).toEqual(['msg_001']);
+  });
+
+  test('keeps confirmed replacement and subsequent branch messages visible while the marker matches', () => {
+    const overlay = addPostRevertBranchReplacement({}, 'ses_1', 'msg_002', 'msg_004');
+    const confirmedOverlay = addPostRevertBranchReplacement(overlay, 'ses_1', 'msg_002', 'msg_006');
+    const snapshot = buildSessionMessageRecordsSnapshot(
+      state({
+        session: [{ id: 'ses_1', revert: { messageID: 'msg_002' } } as State['session'][number]],
+        message: {
+          ses_1: [
+            message('msg_001', 'user'),
+            message('msg_002', 'user'),
+            message('msg_003', 'assistant'),
+            message('msg_004', 'user'),
+            message('msg_005', 'assistant'),
+            message('msg_006', 'user'),
+            message('msg_007', 'assistant'),
+          ],
+        },
+        postRevertBranch: confirmedOverlay,
+      }),
+      'ses_1',
+    );
+
+    expect(snapshot.list.map((record) => record.info.id)).toEqual([
+      'msg_001',
+      'msg_004',
+      'msg_005',
+      'msg_006',
+      'msg_007',
+    ]);
+  });
+
+  test('ignores and retires an overlay after the authoritative marker changes or is removed', () => {
+    const overlay = addPostRevertBranchReplacement({}, 'ses_1', 'msg_002', 'msg_004');
+    const oldSession = { id: 'ses_1', revert: { messageID: 'msg_002' } } as State['session'][number];
+    const messages = [
+      message('msg_001', 'user'),
+      message('msg_002', 'user'),
+      message('msg_003', 'assistant'),
+      message('msg_004', 'user'),
+    ];
+    const movedSession = { id: 'ses_1', revert: { messageID: 'msg_003' } } as State['session'][number];
+
+    const moved = buildSessionMessageRecordsSnapshot(
+      state({ session: [movedSession], message: { ses_1: messages }, postRevertBranch: overlay }),
+      'ses_1',
+    );
+    const restored = buildSessionMessageRecordsSnapshot(
+      state({ session: [{ id: 'ses_1' } as State['session'][number]], message: { ses_1: messages }, postRevertBranch: overlay }),
+      'ses_1',
+    );
+
+    expect(moved.list.map((record) => record.info.id)).toEqual(['msg_001', 'msg_002']);
+    expect(restored.list.map((record) => record.info.id)).toEqual(['msg_001', 'msg_002', 'msg_003', 'msg_004']);
+    expect(reconcilePostRevertBranchOverlay(overlay, 'ses_1', oldSession, movedSession)).toEqual({});
+    expect(reconcilePostRevertBranchOverlay(overlay, 'ses_1', oldSession, undefined)).toEqual({});
+  });
+
+  test('moves the replacement boundary after the first of multiple sends rolls back', () => {
+    const first = addPostRevertBranchReplacement({}, 'ses_1', 'msg_002', 'msg_004');
+    const second = addPostRevertBranchReplacement(first, 'ses_1', 'msg_002', 'msg_006');
+    const afterFirstFailure = removePostRevertBranchReplacement(second, 'ses_1', 'msg_004');
+    const snapshot = buildSessionMessageRecordsSnapshot(
+      state({
+        session: [{ id: 'ses_1', revert: { messageID: 'msg_002' } } as State['session'][number]],
+        message: {
+          ses_1: [
+            message('msg_001', 'user'),
+            message('msg_002', 'user'),
+            message('msg_003', 'assistant'),
+            message('msg_005', 'assistant'),
+            message('msg_006', 'user'),
+            message('msg_007', 'assistant'),
+          ],
+        },
+        postRevertBranch: afterFirstFailure,
+      }),
+      'ses_1',
+    );
+
+    expect(afterFirstFailure.ses_1?.replacementMessageIDs).toEqual(['msg_006']);
+    expect(snapshot.list.map((record) => record.info.id)).toEqual(['msg_001', 'msg_006', 'msg_007']);
   });
 
   test('only suspends part updates for the active streaming message', () => {

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -69,6 +69,11 @@ import { getAttachedSessionDirectory } from "./session-worktree-contract"
 import { setSessionOpener } from "./session-navigation"
 import { getRuntimeKey } from "@/lib/runtime-switch"
 import { rememberRuntimeLiveStatus } from "./runtime-live-memory"
+import {
+  getEffectiveVisibleMessages,
+  getSessionRevertMessageID,
+  hasEffectivePostRevertBranch,
+} from "./message-visibility"
 
 export type { AttachedFile }
 
@@ -1275,22 +1280,17 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
   // handleSlashUndo — reads from sync, records history for redo
   // ---------------------------------------------------------------------------
   handleSlashUndo: async (sessionId) => {
-    const messages = getSyncMessages(sessionId)
-    const sessions = getSyncSessions()
-    const currentSession = sessions.find((s) => s.id === sessionId)
-
-    const userMessages = messages.filter((m) => m.role === "user")
+    const state = getDirectoryState()
+    const currentSession = state?.session.find((session) => session.id === sessionId)
+    const messages = getEffectiveVisibleMessages(
+      state?.message[sessionId] ?? [],
+      currentSession,
+      state?.postRevertBranch[sessionId],
+    )
+    const userMessages = messages.filter((message) => message.role === "user")
     if (userMessages.length === 0) return
 
-    const revertToId = currentSession?.revert?.messageID
-    let targetMessage: typeof messages[number] | undefined
-    if (revertToId) {
-      targetMessage = [...userMessages].reverse().find((m) => m.id < revertToId)
-    } else {
-      targetMessage = userMessages[userMessages.length - 1]
-    }
-
-    if (!targetMessage) return
+    const targetMessage = userMessages[userMessages.length - 1]
 
     // Read target message parts BEFORE calling revertToMessage.
     // revertToMessage optimistically deletes messages from the sync store
@@ -1324,14 +1324,19 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       return
     }
 
-    const sessions = getSyncSessions()
-    const currentSession = sessions.find((s) => s.id === sessionId)
-    const revertToId = currentSession?.revert?.messageID
+    const beforeRefetch = getDirectoryState()
+    const currentSession = beforeRefetch?.session.find((session) => session.id === sessionId)
+    const revertToId = getSessionRevertMessageID(currentSession)
     if (!revertToId) return
+
+    // A replacement branch diverges from the hidden history. Do not let /redo
+    // select a raw discarded target while that branch is still visible.
+    if (hasEffectivePostRevertBranch(currentSession, beforeRefetch?.postRevertBranch[sessionId])) return
 
     await refetchSessionMessages(sessionId)
     const messages = getSyncMessages(sessionId)
     const userMessages = messages.filter((m) => m.role === "user")
+    // Identifier.ascending keeps lexical message IDs in server creation order.
     const targetMessage = userMessages.find((m) => m.id > revertToId)
 
     if (targetMessage) {

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -50,6 +50,12 @@ import { setSessionPrefetch } from "./session-prefetch-cache"
 import { listGlobalSessionPages } from "@/stores/globalSessions"
 import { areRequestArraysReferentiallyEqual, collectScopedBlockingRequests } from "./scoped-blocking-requests"
 import { EMPTY_USER_MESSAGE_HISTORY_SNAPSHOT, buildUserMessageHistorySnapshot, type UserMessageHistorySnapshot } from "./user-message-history"
+import {
+  getEffectiveVisibleMessages,
+  getSessionRevertMessageID,
+  reconcilePostRevertBranchOverlay,
+  reconcilePostRevertBranchOverlays,
+} from "./message-visibility"
 import { runtimeFetch } from "@/lib/runtime-fetch"
 
 // ---------------------------------------------------------------------------
@@ -1302,6 +1308,7 @@ async function resyncDirectoryAfterReconnect(
 
     store.setState((state: DirectoryStore) => {
       const sessionIndex = state.session.findIndex((item) => item.id === nextSession.id)
+      const previousSession = sessionIndex >= 0 ? state.session[sessionIndex] : undefined
       let sessions = state.session
       let sessionChanged = false
       let sessionTotal = state.sessionTotal
@@ -1331,7 +1338,13 @@ async function resyncDirectoryAfterReconnect(
       )
       const messagesChanged = materialized.messagesChanged
       const partsChanged = materialized.partsChanged
-      if (!sessionChanged && !messagesChanged && !partsChanged) {
+      const postRevertBranch = reconcilePostRevertBranchOverlay(
+        state.postRevertBranch,
+        sessionId,
+        previousSession,
+        nextSession,
+      )
+      if (!sessionChanged && !messagesChanged && !partsChanged && postRevertBranch === state.postRevertBranch) {
         return state
       }
 
@@ -1339,6 +1352,7 @@ async function resyncDirectoryAfterReconnect(
         ...(sessionChanged ? { session: sessions, sessionTotal } : {}),
         ...(messagesChanged ? { message: materialized.message } : {}),
         ...(partsChanged ? { part: materialized.part } : {}),
+        ...(postRevertBranch !== state.postRevertBranch ? { postRevertBranch } : {}),
       }
     })
 
@@ -1417,6 +1431,7 @@ function handleEvent(
   }
 
   // Directory events
+  const sessionID = getSessionIdFromPayload(payload) ?? undefined
   let store = childStores.getChild(directory)
   let resolvedDirectory = directory
 
@@ -1424,7 +1439,6 @@ function handleEvent(
     // Store not found for this directory — attempt recovery by scanning
     // child stores for the session. This handles directory mismatches
     // (trailing slashes, case differences, events with wrong directory).
-    const sessionID = getSessionIdFromPayload(payload)
     if (sessionID) {
       const fallbackDir = findSessionInChildStores(sessionID, childStores, routingIndex)
       if (fallbackDir) {
@@ -1539,10 +1553,9 @@ function handleEvent(
   // parent's task tool part reflects the child's completion even when
   // no ToolPart component is mounted.
   if (payload.type === "session.idle") {
-    const idleSessionId = getSessionIdFromPayload(payload)
-    if (idleSessionId && resolvedDirectory && resolvedDirectory !== "global") {
+    if (sessionID && resolvedDirectory && resolvedDirectory !== "global") {
       const sessionState = store.getState()
-      const idleSession = sessionState.session.find((s) => s.id === idleSessionId)
+      const idleSession = sessionState.session.find((s) => s.id === sessionID)
       const parentID = idleSession
         ? (idleSession as Session & { parentID?: string | null }).parentID
         : null
@@ -1563,6 +1576,7 @@ function handleEvent(
     case "session.updated":
     case "session.deleted":
       draft.session = [...current.session]
+      draft.postRevertBranch = { ...current.postRevertBranch }
       draft.permission = { ...current.permission }
       draft.todo = { ...current.todo }
       draft.part = { ...current.part }
@@ -1617,8 +1631,24 @@ function handleEvent(
   const materializationResult = typeof reducerResult === "boolean" ? undefined : reducerResult.materialization
 
   if (reducerChanged) {
+    if (
+      payload.type === "session.created"
+      || payload.type === "session.updated"
+      || payload.type === "session.deleted"
+    ) {
+      if (sessionID) {
+        const postRevertBranch = reconcilePostRevertBranchOverlay(
+          draft.postRevertBranch,
+          sessionID,
+          current.session.find((session) => session.id === sessionID),
+          draft.session.find((session) => session.id === sessionID),
+        )
+        if (postRevertBranch !== draft.postRevertBranch) {
+          draft.postRevertBranch = postRevertBranch
+        }
+      }
+    }
     store.setState(draft)
-    const sessionID = getSessionIdFromPayload(payload) ?? undefined
     const messageID = getMessageIdFromPayload(payload) ?? undefined
     syncDebug.dispatch.eventApplied(payload.type, sessionID, messageID)
 
@@ -1636,7 +1666,6 @@ function handleEvent(
       }
     }
   } else {
-    const sessionID = getSessionIdFromPayload(payload) ?? undefined
     const messageID = getMessageIdFromPayload(payload) ?? undefined
     syncDebug.dispatch.eventNoChange(payload.type, sessionID, messageID)
 
@@ -1646,7 +1675,7 @@ function handleEvent(
   // inferring meaning from a generic false/no-change result.
   if (materializationResult) {
     const materializationSessionID = resolveMaterializationSessionID(
-      materializationResult.sessionID ?? getSessionIdFromPayload(payload) ?? undefined,
+      materializationResult.sessionID ?? sessionID,
       materializationResult.messageID ?? getMessageIdFromPayload(payload) ?? undefined,
       resolvedDirectory,
       routingIndex,
@@ -1834,7 +1863,18 @@ export function SyncProvider(props: {
                 )
                 return
               }
-              store.setState({ session: sessions, sessionTotal: rootSessions.length, limit: Math.max(sessions.length, 50) })
+              const current = store.getState()
+              const postRevertBranch = reconcilePostRevertBranchOverlays(
+                current.postRevertBranch,
+                current.session,
+                sessions,
+              )
+              store.setState({
+                session: sessions,
+                sessionTotal: rootSessions.length,
+                limit: Math.max(sessions.length, 50),
+                ...(postRevertBranch !== current.postRevertBranch ? { postRevertBranch } : {}),
+              })
               ingestDirectoryStateIntoRoutingIndex(routingIndex, directory, store.getState())
             }),
           })
@@ -2020,7 +2060,16 @@ export function SyncProvider(props: {
           const sessions = [...state.session, ...newChildSessions].sort((a, b) =>
             a.id < b.id ? -1 : a.id > b.id ? 1 : 0
           )
-          return { session: sessions, limit: Math.max(sessions.length, 50) }
+          const postRevertBranch = reconcilePostRevertBranchOverlays(
+            state.postRevertBranch,
+            state.session,
+            sessions,
+          )
+          return {
+            session: sessions,
+            limit: Math.max(sessions.length, 50),
+            ...(postRevertBranch !== state.postRevertBranch ? { postRevertBranch } : {}),
+          }
         })
         // Trigger parent session materialization so the task tool part
         // state (metadata, sessionId, output) is refreshed.
@@ -2415,6 +2464,7 @@ type SessionMessageRecordsSnapshot = {
   sourceMessages: Message[]
   visibleMessages: Message[]
   revertMessageID?: string
+  postRevertBranch?: State["postRevertBranch"][string]
   suspendPartUpdates: boolean
   suspendedPartUpdatesMessageID?: string
   list: SessionMessageRecord[]
@@ -2565,10 +2615,12 @@ const getReusableSessionMessageRecordsSnapshot = (
   if (!cached) return undefined
   const sourceMessages = state.message[sessionID] ?? EMPTY_MESSAGES
   const session = state.session.find((candidate) => candidate.id === sessionID)
-  const revertMessageID = (session as { revert?: { messageID?: string } } | undefined)?.revert?.messageID
+  const revertMessageID = getSessionRevertMessageID(session)
+  const postRevertBranch = state.postRevertBranch[sessionID]
   if (
     cached.sourceMessages === sourceMessages
     && cached.revertMessageID === revertMessageID
+    && cached.postRevertBranch === postRevertBranch
     && cached.suspendPartUpdates === suspendPartUpdates
     && cached.suspendedPartUpdatesMessageID === suspendedPartUpdatesMessageID
     && snapshotPartsMatchState(cached, state)
@@ -2582,27 +2634,32 @@ function getVisibleMessagesForSession(state: State, sessionID: string, previous?
   sourceMessages: Message[]
   visibleMessages: Message[]
   revertMessageID?: string
+  postRevertBranch?: State["postRevertBranch"][string]
 } {
   const sourceMessages = state.message[sessionID] ?? EMPTY_MESSAGES
   const session = state.session.find((candidate) => candidate.id === sessionID)
-  const revertMessageID = (session as { revert?: { messageID?: string } } | undefined)?.revert?.messageID
+  const revertMessageID = getSessionRevertMessageID(session)
+  const postRevertBranch = state.postRevertBranch[sessionID]
 
   if (
     previous
     && previous.sourceMessages === sourceMessages
     && previous.revertMessageID === revertMessageID
+    && previous.postRevertBranch === postRevertBranch
   ) {
     return {
       sourceMessages,
       visibleMessages: previous.visibleMessages,
       revertMessageID,
+      postRevertBranch,
     }
   }
 
   return {
     sourceMessages,
-    visibleMessages: revertMessageID ? sourceMessages.filter((message) => message.id < revertMessageID) : sourceMessages,
+    visibleMessages: getEffectiveVisibleMessages(sourceMessages, session, postRevertBranch),
     revertMessageID,
+    postRevertBranch,
   }
 }
 
@@ -2613,7 +2670,7 @@ export function buildSessionMessageRecordsSnapshot(
   suspendPartUpdates = false,
   suspendedPartUpdatesMessageID?: string,
 ): SessionMessageRecordsSnapshot {
-  const { sourceMessages, visibleMessages, revertMessageID } = getVisibleMessagesForSession(state, sessionID, previous)
+  const { sourceMessages, visibleMessages, revertMessageID, postRevertBranch } = getVisibleMessagesForSession(state, sessionID, previous)
   const nextById = new Map<string, SessionMessageRecord>()
   const nextList = visibleMessages.map((message) => {
     const previousRecord = previous?.byId.get(message.id)
@@ -2635,6 +2692,8 @@ export function buildSessionMessageRecordsSnapshot(
 
   const unchanged = Boolean(previous)
     && previous?.visibleMessages === visibleMessages
+    && previous.revertMessageID === revertMessageID
+    && previous.postRevertBranch === postRevertBranch
     && previous.suspendPartUpdates === suspendPartUpdates
     && previous.suspendedPartUpdatesMessageID === suspendedPartUpdatesMessageID
     && previous.list.length === nextList.length
@@ -2649,6 +2708,7 @@ export function buildSessionMessageRecordsSnapshot(
     sourceMessages,
     visibleMessages,
     revertMessageID,
+    postRevertBranch,
     suspendPartUpdates,
     suspendedPartUpdatesMessageID,
     list: nextList,
@@ -2691,7 +2751,17 @@ export function useUserMessageHistory(sessionID: string, directory?: string): st
 
   const subscribe = useCallback((notify: () => void) => {
     if (!sessionID) return () => undefined
-    return store.subscribe(notify)
+    return store.subscribe((state, previous) => {
+      if (
+        state.message === previous.message
+        && state.part === previous.part
+        && state.session === previous.session
+        && state.postRevertBranch[sessionID] === previous.postRevertBranch[sessionID]
+      ) {
+        return
+      }
+      notify()
+    })
   }, [sessionID, store])
 
   return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
@@ -2715,6 +2785,7 @@ export function useSessionMessageRecords(
     sourceMessages: EMPTY_MESSAGES,
     visibleMessages: EMPTY_MESSAGES,
     revertMessageID: undefined,
+    postRevertBranch: undefined,
     suspendPartUpdates: Boolean(options?.suspendPartUpdates),
     suspendedPartUpdatesMessageID: options?.suspendPartUpdatesForMessageId ?? undefined,
     list: [],
@@ -2764,6 +2835,7 @@ export function useSessionMessageRecords(
         state.message === previous.message
         && state.part === previous.part
         && state.session === previous.session
+        && state.postRevertBranch[sessionID] === previous.postRevertBranch[sessionID]
       ) {
         return
       }

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -2759,7 +2759,16 @@ export function useSessionMessageRecords(
 
   const subscribe = useCallback((notify: () => void) => {
     if (!sessionID) return () => undefined
-    return store.subscribe(notify)
+    return store.subscribe((state, previous) => {
+      if (
+        state.message === previous.message
+        && state.part === previous.part
+        && state.session === previous.session
+      ) {
+        return
+      }
+      notify()
+    })
   }, [sessionID, store])
 
   return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot)

--- a/packages/ui/src/sync/types.ts
+++ b/packages/ui/src/sync/types.ts
@@ -38,6 +38,17 @@ export type ProjectMeta = {
   }
 }
 
+/**
+ * Local visibility continuity for a replacement branch sent after a server
+ * revert. It is intentionally directory-store scoped and never persisted.
+ */
+export type PostRevertBranchOverlay = {
+  revertMessageID: string
+  replacementMessageIDs: string[]
+}
+
+export type PostRevertBranchOverlays = Record<string, PostRevertBranchOverlay>
+
 /** Per-directory store state */
 export type State = {
   status: "loading" | "partial" | "complete"
@@ -50,6 +61,7 @@ export type State = {
   config: Config
   path: Path
   session: Session[]
+  postRevertBranch: PostRevertBranchOverlays
   sessionTotal: number
   session_status: Record<string, SessionStatus>
   session_diff: Record<string, FileDiff[]>
@@ -120,6 +132,7 @@ export const INITIAL_STATE: State = {
   agent: [],
   command: [],
   session: [],
+  postRevertBranch: {},
   sessionTotal: 0,
   session_status: {},
   session_diff: {},

--- a/packages/ui/src/sync/use-sync.ts
+++ b/packages/ui/src/sync/use-sync.ts
@@ -649,12 +649,19 @@ export function useSync() {
 
   // Optimistic add (for prompt submission)
   const optimisticAdd = useCallback(
-    (input: { sessionID: string; directory?: string | null; message: Message; parts: Part[] }) => {
+    (input: {
+      sessionID: string
+      directory?: string | null
+      message: Message
+      parts: Part[]
+      clearRevert?: { sessionID: string; previousRevert: unknown }
+    }) => {
       setOptimistic(input.sessionID, { message: input.message, parts: input.parts }, input.directory)
       const targetStore = getOptimisticStore(input.directory)
       const current = targetStore.getState()
       const message = { ...current.message }
       const part = { ...current.part }
+      let session = current.session
 
       // Insert message
       const messages = message[input.sessionID] ? [...message[input.sessionID]] : []
@@ -665,7 +672,19 @@ export function useSync() {
       // Insert parts
       part[input.message.id] = sortParts(input.parts)
 
-      targetStore.setState({ message, part })
+      if (input.clearRevert) {
+        const sessionIndex = session.findIndex((item) => item.id === input.clearRevert?.sessionID)
+        if (sessionIndex >= 0 && (session[sessionIndex] as { revert?: unknown }).revert === input.clearRevert.previousRevert) {
+          session = [...session]
+          session[sessionIndex] = { ...session[sessionIndex], revert: undefined } as typeof session[number]
+        }
+      }
+
+      targetStore.setState({
+        message,
+        part,
+        ...(session !== current.session ? { session } : {}),
+      })
     },
     [getOptimisticStore, setOptimistic],
   )

--- a/packages/ui/src/sync/use-sync.ts
+++ b/packages/ui/src/sync/use-sync.ts
@@ -20,6 +20,13 @@ import {
   clearSessionPrefetch,
 } from "./session-prefetch-cache"
 import { getSessionMaterializationStatus, materializeSessionSnapshots } from "./materialization"
+import {
+  addPostRevertBranchReplacement,
+  clearPostRevertBranchOverlay,
+  getSessionRevertMessageID,
+  reconcilePostRevertBranchOverlay,
+  removePostRevertBranchReplacement,
+} from "./message-visibility"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 const INITIAL_MESSAGE_PAGE_SIZE = 50
@@ -195,6 +202,7 @@ export function useSync() {
         todo: { ...current.todo },
         permission: { ...current.permission },
         question: { ...current.question },
+        postRevertBranch: { ...current.postRevertBranch },
       }
       dropSessionCaches(draft, sessionIDs)
       dropCachedSessionMessageRecordsSnapshots(dirStore, sessionIDs)
@@ -570,13 +578,23 @@ export function useSync() {
                     const s = store.getState()
                     const sessions = [...s.session]
                     const idx = Binary.search(sessions, sessionID, (s) => s.id)
+                    const previousSession = idx.found ? sessions[idx.index] : undefined
                     if (idx.found) {
                       sessions[idx.index] = nextSession
                     } else {
                       sessions.splice(idx.index, 0, nextSession)
                     }
                     if (!isStale()) {
-                      store.setState({ session: sessions })
+                      const postRevertBranch = reconcilePostRevertBranchOverlay(
+                        s.postRevertBranch,
+                        sessionID,
+                        previousSession,
+                        nextSession,
+                      )
+                      store.setState({
+                        session: sessions,
+                        ...(postRevertBranch !== s.postRevertBranch ? { postRevertBranch } : {}),
+                      })
                     }
                   }
                 } catch (e) {
@@ -654,14 +672,12 @@ export function useSync() {
       directory?: string | null
       message: Message
       parts: Part[]
-      clearRevert?: { sessionID: string; previousRevert: unknown }
     }) => {
       setOptimistic(input.sessionID, { message: input.message, parts: input.parts }, input.directory)
       const targetStore = getOptimisticStore(input.directory)
       const current = targetStore.getState()
       const message = { ...current.message }
       const part = { ...current.part }
-      let session = current.session
 
       // Insert message
       const messages = message[input.sessionID] ? [...message[input.sessionID]] : []
@@ -672,18 +688,21 @@ export function useSync() {
       // Insert parts
       part[input.message.id] = sortParts(input.parts)
 
-      if (input.clearRevert) {
-        const sessionIndex = session.findIndex((item) => item.id === input.clearRevert?.sessionID)
-        if (sessionIndex >= 0 && (session[sessionIndex] as { revert?: unknown }).revert === input.clearRevert.previousRevert) {
-          session = [...session]
-          session[sessionIndex] = { ...session[sessionIndex], revert: undefined } as typeof session[number]
-        }
-      }
+      const session = current.session.find((item) => item.id === input.sessionID)
+      const revertMessageID = getSessionRevertMessageID(session)
+      const postRevertBranch = revertMessageID
+        ? addPostRevertBranchReplacement(
+          current.postRevertBranch,
+          input.sessionID,
+          revertMessageID,
+          input.message.id,
+        )
+        : clearPostRevertBranchOverlay(current.postRevertBranch, input.sessionID)
 
       targetStore.setState({
         message,
         part,
-        ...(session !== current.session ? { session } : {}),
+        ...(postRevertBranch !== current.postRevertBranch ? { postRevertBranch } : {}),
       })
     },
     [getOptimisticStore, setOptimistic],
@@ -709,7 +728,17 @@ export function useSync() {
       }
       delete part[input.messageID]
 
-      targetStore.setState({ message, part })
+      const postRevertBranch = removePostRevertBranchReplacement(
+        current.postRevertBranch,
+        input.sessionID,
+        input.messageID,
+      )
+
+      targetStore.setState({
+        message,
+        part,
+        ...(postRevertBranch !== current.postRevertBranch ? { postRevertBranch } : {}),
+      })
     },
     [clearOptimistic, getOptimisticStore],
   )

--- a/packages/ui/src/sync/user-message-history.test.ts
+++ b/packages/ui/src/sync/user-message-history.test.ts
@@ -3,6 +3,8 @@ import type { Message, Part } from '@opencode-ai/sdk/v2/client';
 import type { State } from './types';
 
 import { EMPTY_USER_MESSAGE_HISTORY_SNAPSHOT, buildUserMessageHistorySnapshot } from './user-message-history';
+import { buildSessionMessageRecordsSnapshot } from './sync-context';
+import { addPostRevertBranchReplacement } from './message-visibility';
 
 const message = (id: string, role: 'user' | 'assistant'): Message => ({
   id,
@@ -17,10 +19,11 @@ const textPart = (id: string, text: string): Part => ({
   text,
 } as Part);
 
-const state = (partial: Partial<State>): Pick<State, 'session' | 'message' | 'part'> => ({
+const state = (partial: Partial<State>): Pick<State, 'session' | 'message' | 'part' | 'postRevertBranch'> => ({
   session: [],
   message: {},
   part: {},
+  postRevertBranch: {},
   ...partial,
 });
 
@@ -94,5 +97,34 @@ describe('buildUserMessageHistorySnapshot', () => {
     );
 
     expect(snapshot.history).toEqual(['kept']);
+  });
+
+  test('matches timeline visibility for a post-revert replacement branch', () => {
+    const beforeRevert = message('msg_001', 'user');
+    const reverted = message('msg_002', 'user');
+    const discarded = message('msg_003', 'assistant');
+    const replacement = message('msg_004', 'user');
+    const replacementAssistant = message('msg_005', 'assistant');
+    const input = state({
+      session: [{ id: 'ses_1', revert: { messageID: 'msg_002' } } as State['session'][number]],
+      message: { ses_1: [beforeRevert, reverted, discarded, replacement, replacementAssistant] },
+      part: {
+        msg_001: [textPart('part_1', 'kept')],
+        msg_002: [textPart('part_2', 'discarded')],
+        msg_004: [textPart('part_4', 'replacement')],
+      },
+      postRevertBranch: addPostRevertBranchReplacement({}, 'ses_1', 'msg_002', 'msg_004'),
+    });
+
+    const history = buildUserMessageHistorySnapshot(input, 'ses_1');
+    const timeline = buildSessionMessageRecordsSnapshot(input as State, 'ses_1');
+    const visibleUserIDs = timeline.list
+      .filter((record) => record.info.role === 'user')
+      .map((record) => record.info.id)
+      .reverse();
+
+    expect(timeline.list.map((record) => record.info.id)).toEqual(['msg_001', 'msg_004', 'msg_005']);
+    expect(history.records.map((record) => record.message.id)).toEqual(visibleUserIDs);
+    expect(history.history).toEqual(['replacement', 'kept']);
   });
 });

--- a/packages/ui/src/sync/user-message-history.ts
+++ b/packages/ui/src/sync/user-message-history.ts
@@ -1,5 +1,6 @@
 import type { Message, Part } from '@opencode-ai/sdk/v2/client';
-import type { State } from './types';
+import type { PostRevertBranchOverlay, State } from './types';
+import { getEffectiveVisibleMessages, getSessionRevertMessageID } from './message-visibility';
 
 type UserMessageHistoryRecord = {
   message: Message;
@@ -9,6 +10,7 @@ type UserMessageHistoryRecord = {
 export type UserMessageHistorySnapshot = {
   sessionID: string;
   revertMessageID?: string;
+  postRevertBranch?: PostRevertBranchOverlay;
   records: UserMessageHistoryRecord[];
   history: string[];
 };
@@ -20,6 +22,7 @@ const EMPTY_HISTORY: string[] = [];
 export const EMPTY_USER_MESSAGE_HISTORY_SNAPSHOT: UserMessageHistorySnapshot = {
   sessionID: '',
   revertMessageID: undefined,
+  postRevertBranch: undefined,
   records: EMPTY_RECORDS,
   history: EMPTY_HISTORY,
 };
@@ -50,7 +53,7 @@ const areRecordsEqual = (left: UserMessageHistoryRecord[], right: UserMessageHis
 };
 
 export const buildUserMessageHistorySnapshot = (
-  state: Pick<State, 'session' | 'message' | 'part'>,
+  state: Pick<State, 'session' | 'message' | 'part' | 'postRevertBranch'>,
   sessionID: string,
   previous: UserMessageHistorySnapshot = EMPTY_USER_MESSAGE_HISTORY_SNAPSHOT,
 ): UserMessageHistorySnapshot => {
@@ -60,14 +63,13 @@ export const buildUserMessageHistorySnapshot = (
 
   const messages = state.message[sessionID] ?? [];
   const session = state.session.find((candidate) => candidate.id === sessionID);
-  const revertMessageID = (session as { revert?: { messageID?: string } } | undefined)?.revert?.messageID;
+  const revertMessageID = getSessionRevertMessageID(session);
+  const postRevertBranch = state.postRevertBranch[sessionID];
+  const visibleMessages = getEffectiveVisibleMessages(messages, session, postRevertBranch);
   const records: UserMessageHistoryRecord[] = [];
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
+  for (let index = visibleMessages.length - 1; index >= 0; index -= 1) {
+    const message = visibleMessages[index];
     if (message.role !== 'user') {
-      continue;
-    }
-    if (revertMessageID && message.id >= revertMessageID) {
       continue;
     }
     records.push({
@@ -77,12 +79,20 @@ export const buildUserMessageHistorySnapshot = (
   }
 
   if (records.length === 0) {
-    return previous.sessionID === sessionID && previous.revertMessageID === revertMessageID && previous.records.length === 0
+    return previous.sessionID === sessionID
+      && previous.revertMessageID === revertMessageID
+      && previous.postRevertBranch === postRevertBranch
+      && previous.records.length === 0
       ? previous
-      : { sessionID, revertMessageID, records: EMPTY_RECORDS, history: EMPTY_HISTORY };
+      : { sessionID, revertMessageID, postRevertBranch, records: EMPTY_RECORDS, history: EMPTY_HISTORY };
   }
 
-  if (previous.sessionID === sessionID && previous.revertMessageID === revertMessageID && areRecordsEqual(previous.records, records)) {
+  if (
+    previous.sessionID === sessionID
+    && previous.revertMessageID === revertMessageID
+    && previous.postRevertBranch === postRevertBranch
+    && areRecordsEqual(previous.records, records)
+  ) {
     return previous;
   }
 
@@ -94,5 +104,5 @@ export const buildUserMessageHistorySnapshot = (
     }
   }
 
-  return { sessionID, revertMessageID, records, history };
+  return { sessionID, revertMessageID, postRevertBranch, records, history };
 };


### PR DESCRIPTION
## Summary
- preserve `session.revert` as the server-authoritative boundary for reverted history
- add a directory-scoped post-revert replacement overlay so the new branch is visible without revealing discarded messages
- apply one shared visibility projection to the timeline, message history, reverted-message dock, and slash undo/redo
- restore the captured replacement overlay when a newer revert fails, including after concurrent session reconciliation
- retire stale overlays on authoritative marker transitions and cache eviction

Fixes #2248

## Why this has two commits
The branch keeps its published history instead of rewriting it.

- `f3854676e` made the replacement message visible by locally clearing `session.revert`. That was incomplete: clearing the marker also revealed the discarded branch and coupled rollback to fragile local state timing.
- `21488850c` replaces that approach. It keeps the marker authoritative and uses a local post-revert branch overlay to show only the replacement branch.

## Behavior
After reverting and sending a replacement, the discarded interval remains hidden while the replacement and its subsequent branch stay visible. A failed replacement or failed newer revert restores the prior visible branch without overwriting overlays for other sessions.

## Known boundary
`postRevertBranch` is intentionally in-memory UI continuity state. After a full store reload, correct replacement-branch reconstruction depends on the authoritative server session state changing or clearing the corresponding revert marker; this PR does not introduce a backend persistence contract.

## Revert UI freeze investigation
- **Found:** The original visibility bug was caused by using the server revert marker as the sole timeline filter.
- **Not established:** No macOS performance trace, latency benchmark, or reproducible test attributes the reported UI hang to a specific `revertToMessage` operation.
- **Scope:** This PR fixes the deterministic visibility/state-transition defect; it does not claim to resolve the separate UI-hang report.

## Validation
```text
bun test --isolate packages/ui/src/sync/session-actions.test.ts packages/ui/src/sync/session-ui-store.test.js packages/ui/src/sync/session-message-records.test.ts packages/ui/src/sync/user-message-history.test.ts packages/ui/src/components/chat/revertedMessageDockState.test.ts packages/ui/src/sync/__tests__/eviction.test.ts packages/ui/src/sync/use-sync.test.ts packages/ui/src/sync/__tests__/event-reducer.test.ts packages/ui/src/sync/__tests__/sync-context-session-events.test.ts
# 100 passed, 270 assertions

bun run type-check:ui
bun run lint:ui
bun run dead-code
git diff --check
```

## Review
- Native review: no actionable findings
- OCR: no high or medium findings; only non-blocking maintainability notes