### PR TITLE
fix(chat): keep text selection menu in viewport

### DIFF
--- a/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
+++ b/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
@@ -15,6 +15,7 @@ import { resolveProjectForSessionDirectory } from '@/lib/projectResolution';
 import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
 import { isVSCodeRuntime } from '@/lib/desktop';
 import { useI18n } from '@/lib/i18n';
+import { DESKTOP_MENU_SIDE_MARGIN_PX, getDesktopClampedMenuY } from './textSelectionMenuPosition';
 
 interface TextSelectionMenuProps {
   containerRef: React.RefObject<HTMLElement | null>;
@@ -42,8 +43,8 @@ const appendDistilledInsightToNotes = (existingNotes: string, insight: string): 
   return trimmedNotes ? `${trimmedNotes}\n${trimmedInsight}` : trimmedInsight;
 };
 
-const DESKTOP_MENU_SIDE_MARGIN_PX = 8;
 const DESKTOP_MENU_FALLBACK_WIDTH_PX = 280;
+const DESKTOP_MENU_FALLBACK_HEIGHT_PX = 40;
 const BLOCK_TAGS = new Set([
   'address', 'article', 'aside', 'blockquote', 'dd', 'div', 'dl', 'dt',
   'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3',
@@ -215,6 +216,7 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
   const [isAddingToNotes, setIsAddingToNotes] = React.useState(false);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const menuWidthRef = React.useRef(DESKTOP_MENU_FALLBACK_WIDTH_PX);
+  const menuHeightRef = React.useRef(DESKTOP_MENU_FALLBACK_HEIGHT_PX);
   const pendingSelectionRef = React.useRef<SelectionPayload | null>(null);
   const openRafRef = React.useRef<number | null>(null);
   const mouseUpTimeoutRef = React.useRef<number | null>(null);
@@ -282,6 +284,14 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
     return Math.min(Math.max(anchorX, minX), maxX);
   }, []);
 
+  const getDesktopClampedY = React.useCallback((anchorY: number) => {
+    if (typeof window === 'undefined') {
+      return anchorY;
+    }
+
+    return getDesktopClampedMenuY(anchorY, window.innerHeight, menuHeightRef.current);
+  }, []);
+
   const showMenu = React.useCallback(() => {
     if (!pendingSelectionRef.current) return;
 
@@ -292,7 +302,9 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
     const menuX = isMobile
       ? rect.left + rect.width / 2
       : getDesktopClampedX(rect.left + rect.width / 2);
-    const menuY = rect.top - 10;
+    const menuY = isMobile
+      ? rect.top - 10
+      : getDesktopClampedY(rect.top - 10);
 
     setSelectedText(plainText);
     setSelectedTextMarkdown(markdownText);
@@ -313,7 +325,7 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
         openRafRef.current = null;
       });
     }
-  }, [getDesktopClampedX, isMobile, position.show]);
+  }, [getDesktopClampedX, getDesktopClampedY, isMobile, position.show]);
 
   React.useLayoutEffect(() => {
     if (!position.show || isMobile || !menuRef.current) {
@@ -321,16 +333,30 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
     }
 
     const measuredWidth = menuRef.current.offsetWidth;
-    if (!Number.isFinite(measuredWidth) || measuredWidth <= 0 || measuredWidth === menuWidthRef.current) {
+    const measuredHeight = menuRef.current.offsetHeight;
+    const hasMeasuredWidth = Number.isFinite(measuredWidth)
+      && measuredWidth > 0
+      && measuredWidth !== menuWidthRef.current;
+    const hasMeasuredHeight = Number.isFinite(measuredHeight)
+      && measuredHeight > 0
+      && measuredHeight !== menuHeightRef.current;
+
+    if (!hasMeasuredWidth && !hasMeasuredHeight) {
       return;
     }
 
-    menuWidthRef.current = measuredWidth;
+    if (hasMeasuredWidth) {
+      menuWidthRef.current = measuredWidth;
+    }
+    if (hasMeasuredHeight) {
+      menuHeightRef.current = measuredHeight;
+    }
     setPosition((prev) => ({
       ...prev,
       x: getDesktopClampedX(prev.x),
+      y: getDesktopClampedY(prev.y),
     }));
-  }, [getDesktopClampedX, isMobile, position.show]);
+  }, [getDesktopClampedX, getDesktopClampedY, isMobile, position.show]);
 
   React.useEffect(() => {
     if (!position.show || isMobile) {
@@ -341,6 +367,7 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
       setPosition((prev) => ({
         ...prev,
         x: getDesktopClampedX(prev.x),
+        y: getDesktopClampedY(prev.y),
       }));
     };
 
@@ -348,7 +375,7 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
     return () => {
       window.removeEventListener('resize', handleViewportResize);
     };
-  }, [getDesktopClampedX, isMobile, position.show]);
+  }, [getDesktopClampedX, getDesktopClampedY, isMobile, position.show]);
 
   const handleSelectionChange = React.useCallback(() => {
     const selection = window.getSelection();

--- a/packages/ui/src/components/chat/message/textSelectionMenuPosition.test.ts
+++ b/packages/ui/src/components/chat/message/textSelectionMenuPosition.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getDesktopClampedMenuY } from './textSelectionMenuPosition';
+
+describe('getDesktopClampedMenuY', () => {
+  test('clamps negative and near-top anchors below the popup height', () => {
+    expect(getDesktopClampedMenuY(-20, 800, 40)).toBe(48);
+    expect(getDesktopClampedMenuY(47, 800, 40)).toBe(48);
+  });
+
+  test('preserves a normally positioned anchor', () => {
+    expect(getDesktopClampedMenuY(300, 800, 40)).toBe(300);
+  });
+
+  test('clamps anchors at the bottom viewport boundary', () => {
+    expect(getDesktopClampedMenuY(900, 800, 40)).toBe(792);
+  });
+
+  test('centers an oversized popup in a constrained viewport', () => {
+    expect(getDesktopClampedMenuY(0, 40, 60)).toBe(50);
+  });
+});

--- a/packages/ui/src/components/chat/message/textSelectionMenuPosition.ts
+++ b/packages/ui/src/components/chat/message/textSelectionMenuPosition.ts
@@ -1,0 +1,16 @@
+export const DESKTOP_MENU_SIDE_MARGIN_PX = 8;
+
+export const getDesktopClampedMenuY = (
+  anchorY: number,
+  viewportHeight: number,
+  menuHeight: number,
+): number => {
+  const minY = DESKTOP_MENU_SIDE_MARGIN_PX + menuHeight;
+  const maxY = viewportHeight - DESKTOP_MENU_SIDE_MARGIN_PX;
+
+  if (minY > maxY) {
+    return (minY + maxY) / 2;
+  }
+
+  return Math.min(Math.max(anchorY, minY), maxY);
+};


### PR DESCRIPTION
## Summary
- Clamp the desktop text-selection menu vertically so it stays within the viewport.
- Re-clamp after popup measurement and viewport resizing while leaving mobile behavior unchanged.
- Add focused boundary coverage for top, bottom, normal, and constrained viewport positions.

Fixes #2257

## Validation
- `bun test packages/ui/src/components/chat/message/textSelectionMenuPosition.test.ts`
- `bun run type-check:ui`
- `bun run lint:ui`
- `bun run dead-code`

## Manual verification
- Not run: Electron/Windows selection flow.