### PR TITLE
fix(lifecycle): prevent false Windows health-check restart of live OpenCode child

### DIFF
--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -60,7 +60,13 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     }
   };
 
-  const hasChildProcessExited = (child) => !child || child.exitCode !== null || child.signalCode !== null;
+  const hasChildProcessExited = (child) => {
+    if (!child) return true;
+    // Wrapper object from createManagedOpenCodeServerProcess — no exitCode/signalCode.
+    // Fall through to process.kill probe instead.
+    if (!('exitCode' in child) && !('signalCode' in child)) return false;
+    return child.exitCode !== null || child.signalCode !== null;
+  };
 
   const isManagedOpenCodeProcessAlive = () => {
     const child = state.openCodeProcess;
@@ -69,8 +75,9 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     try {
       process.kill(child.pid, 0);
       return true;
-    } catch {
-      return false;
+    } catch (error) {
+      // EPERM = process exists but we lack permission to signal it → still alive.
+      return error?.code === 'EPERM';
     }
   };
 

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -67,7 +67,7 @@ const createRuntime = (overrides = {}) => {
     resolvedWslDistro: null,
   };
 
-  return createOpenCodeLifecycleRuntime({
+  const runtime = createOpenCodeLifecycleRuntime({
     state,
     env: {
       ENV_CONFIGURED_OPENCODE_PORT: 45678,
@@ -102,6 +102,8 @@ const createRuntime = (overrides = {}) => {
     })),
     ...overrides,
   });
+
+  return { runtime, state };
 };
 
 describe('OpenCode lifecycle', () => {
@@ -115,7 +117,7 @@ describe('OpenCode lifecycle', () => {
       return child;
     });
 
-    const runtime = createRuntime();
+    const { runtime } = createRuntime();
     const server = await runtime.startOpenCode();
     const [binary, args, options] = spawnMock.mock.calls[0];
 
@@ -138,7 +140,7 @@ describe('OpenCode lifecycle', () => {
       return child;
     });
 
-    const runtime = createRuntime({
+    const { runtime } = createRuntime({
       buildManagedOpenCodePath: undefined,
       buildAugmentedPath: vi.fn(() => '/home/user/.cargo/bin:/usr/local/bin'),
     });
@@ -161,7 +163,7 @@ describe('OpenCode lifecycle', () => {
       return child;
     });
 
-    const runtime = createRuntime({
+    const { runtime } = createRuntime({
       buildManagedOpenCodePath: undefined,
       buildAugmentedPath: undefined,
     });
@@ -190,7 +192,7 @@ describe('OpenCode lifecycle', () => {
       return secondChild;
     });
 
-    const runtime = createRuntime();
+    const { runtime } = createRuntime();
 
     await expect(runtime.startOpenCode()).rejects.toThrow('OpenCode process exited before serving with signal SIGTERM. Binary used: opencode. No stdout/stderr captured');
     expect(spawnMock).toHaveBeenCalledTimes(2);
@@ -204,7 +206,7 @@ describe('OpenCode lifecycle', () => {
       throw error;
     });
 
-    const runtime = createRuntime({ applyOpencodeBinaryFromSettings });
+    const { runtime } = createRuntime({ applyOpencodeBinaryFromSettings });
 
     await expect(runtime.startOpenCode()).rejects.toThrow('Configured OpenCode binary not found: /missing/opencode');
     expect(applyOpencodeBinaryFromSettings).toHaveBeenCalledTimes(1);
@@ -229,10 +231,108 @@ describe('OpenCode lifecycle', () => {
       return secondChild;
     });
 
-    const runtime = createRuntime();
+    const { runtime } = createRuntime();
     const server = await runtime.startOpenCode();
 
     expect(spawnMock).toHaveBeenCalledTimes(2);
     await server.close();
+  });
+
+  it('hasChildProcessExited returns false for wrapper object', async () => {
+    const { runtime, state } = createRuntime();
+    const wrapper = { url: 'http://127.0.0.1:45678', pid: 12345, close: vi.fn() };
+    state.openCodeProcess = wrapper;
+    state.openCodePort = 45678;
+
+    // Mock fetch to return unhealthy
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ healthy: false }),
+    });
+
+    // Mock process.kill to succeed (process is alive)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (signal === 0) return true;
+    });
+
+    await runtime.triggerHealthCheck();
+
+    // Process should NOT be restarted — wrapper was correctly identified as alive
+    expect(state.openCodeProcess).toBe(wrapper);
+    expect(wrapper.close).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('does not restart when process.kill throws EPERM (Windows)', async () => {
+    const { runtime, state } = createRuntime();
+    const wrapperPid = 12345;
+    const wrapper = {
+      url: 'http://127.0.0.1:45678',
+      pid: wrapperPid,
+      close: vi.fn(),
+    };
+    state.openCodeProcess = wrapper;
+    state.openCodePort = 45678;
+
+    // Mock fetch to return unhealthy
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ healthy: false }),
+    });
+
+    // Mock process.kill to throw EPERM (Windows behavior: process alive but un-signalable)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (signal === 0) {
+        const err = new Error('EPERM');
+        err.code = 'EPERM';
+        throw err;
+      }
+    });
+
+    await runtime.triggerHealthCheck();
+
+    // Process should still be considered alive — no restart triggered
+    expect(state.openCodeProcess).toBe(wrapper);
+    expect(wrapper.close).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('restarts when process.kill throws ESRCH (process actually dead)', async () => {
+    const { runtime, state } = createRuntime();
+    const wrapperPid = 12345;
+    const wrapper = {
+      url: 'http://127.0.0.1:45678',
+      pid: wrapperPid,
+      close: vi.fn(),
+    };
+    state.openCodeProcess = wrapper;
+    state.openCodePort = 45678;
+
+    // Mock fetch to return unhealthy
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ healthy: false }),
+    });
+
+    // Mock process.kill to throw ESRCH (process does not exist)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (signal === 0) {
+        const err = new Error('ESRCH');
+        err.code = 'ESRCH';
+        throw err;
+      }
+    });
+
+    await runtime.triggerHealthCheck();
+
+    // Process should be considered dead — restart should be triggered (state.openCodeProcess set to null)
+    expect(state.openCodeProcess).toBeNull();
+
+    killSpy.mockRestore();
+    fetchSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2258. Two independent bugs in `isManagedOpenCodeProcessAlive()` caused the periodic health check to take the immediate restart path on Windows, bypassing the consecutive-failure counter and busy-session guard added for #1294/#1295. This resulted in OpenChamber sending SIGTERM to a still-running child and restarting it unnecessarily during active sessions.

## Root cause

**Bug 1 — `hasChildProcessExited` wrapper mismatch**

`state.openCodeProcess` stores a wrapper object `{ url, pid, close }` from `createManagedOpenCodeServerProcess()`. The wrapper has no `exitCode` or `signalCode` properties, so the original check `child.exitCode !== null || child.signalCode !== null` always evaluated to `true` (since `undefined !== null` is `true`). The `process.kill` probe was never reached on any platform.

**Bug 2 — `process.kill` EPERM not handled**

On Windows, `process.kill(pid, 0)` throws `EPERM` when the caller lacks permission to signal the target process — even though the process is still alive. The bare `catch { return false }` unconditionally treated this as process death.

## Fix

1. **`hasChildProcessExited`** now checks for the presence of `exitCode`/`signalCode` properties before comparing them. Wrapper objects (no such properties) return `false`, causing the caller to fall through to the `process.kill` probe.

2. **`process.kill` catch block** now returns `true` on `EPERM`, matching the existing pattern in `managed-process-registry.js:118-119`.

## Tests

Three regression tests added to `lifecycle.test.js`:

- **Wrapper object** — verifies `{ url, pid, close }` is correctly identified as not-exited, falling through to `process.kill`.
- **EPERM (Windows)** — verifies `process.kill(pid, 0)` throwing EPERM is treated as "process alive", preventing false restarts.
- **ESRCH (dead process)** — verifies ESRCH correctly triggers a restart.

## Verification

- All 87 test files pass (696 tests, 2 skipped).
- All 6 callers of `hasChildProcessExited` verified safe: only `isManagedOpenCodeProcessAlive` receives the wrapper; the other 5 receive raw `ChildProcess` objects and are unaffected.
- EPERM pattern matches the project convention used in `managed-process-registry.js` and the VS Code parity implementation.

## Related

- #1294, #1295 — health request timeouts under load
- #1721 — false results from PID-only liveness checks (different code path)