### PR TITLE
fix(quota): show weekly usage window for z.ai and Zhipu AI providers

### DIFF
--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -183,7 +183,7 @@ const resolveGoogleWindow = (sourceId: GoogleAuthSource['sourceId'], resetAt: nu
   return { label: 'daily', seconds: GOOGLE_DAILY_WINDOW_SECONDS } as const;
 };
 
-const ZAI_TOKEN_WINDOW_SECONDS: Record<number, number> = { 3: 3600 };
+const ZAI_TOKEN_WINDOW_SECONDS: Record<number, number> = { 3: 3600, 6: 604800 };
 
 const readAuthFile = (): AuthFile => {
   if (!fs.existsSync(AUTH_FILE)) {
@@ -1527,14 +1527,14 @@ const fetchZaiQuota = async (): Promise<ProviderResult> => {
 
     const payload = await response.json() as ZaiPayload;
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
-    const tokensLimit = limits.find((limit: Record<string, unknown>) => limit?.type === 'TOKENS_LIMIT');
-    const windowSeconds = resolveWindowSeconds(tokensLimit as Record<string, unknown> | undefined);
-    const windowLabel = resolveWindowLabel(windowSeconds);
-    const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
-    const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
+    const tokensLimits = limits.filter((limit: Record<string, unknown>) => limit?.type === 'TOKENS_LIMIT');
 
     const windows: Record<string, UsageWindow> = {};
-    if (tokensLimit) {
+    for (const tokensLimit of tokensLimits) {
+      const windowSeconds = resolveWindowSeconds(tokensLimit as Record<string, unknown> | undefined);
+      const windowLabel = resolveWindowLabel(windowSeconds);
+      const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
+      const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
       windows[windowLabel] = toUsageWindow({
         usedPercent,
         windowSeconds,
@@ -1597,18 +1597,17 @@ const fetchZhipuaiCodingPlanQuota = async (): Promise<ProviderResult> => {
     const payload = await response.json() as ZhipuaiPayload;
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
 
-    const tokensLimit = limits.find((limit): limit is ZhipuaiTokensLimit => limit?.type === 'TOKENS_LIMIT');
+    const tokensLimits = limits.filter((limit): limit is ZhipuaiTokensLimit => limit?.type === 'TOKENS_LIMIT');
     const mcpToolsTimeLimit = limits.find((limit): limit is ZhipuaiMcpTimeLimit => limit?.type === 'TIME_LIMIT');
 
     const windows: Record<string, UsageWindow> = {};
 
-    // Handle TOKENS_LIMIT (5-hour window for token usage)
-    if (tokensLimit) {
+    for (const tokensLimit of tokensLimits) {
       const windowSeconds = resolveWindowSeconds(tokensLimit);
+      const windowLabel = resolveWindowLabel(windowSeconds);
       const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
       const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
-
-      windows['Tokens'] = toUsageWindow({
+      windows[windowLabel] = toUsageWindow({
         usedPercent,
         windowSeconds,
         resetAt,

--- a/packages/web/server/lib/quota/providers/zai.js
+++ b/packages/web/server/lib/quota/providers/zai.js
@@ -57,14 +57,15 @@ export const fetchQuota = async () => {
 
     const payload = await response.json();
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
-    const tokensLimit = limits.find((limit) => limit?.type === 'TOKENS_LIMIT');
-    const windowSeconds = resolveWindowSeconds(tokensLimit);
-    const windowLabel = resolveWindowLabel(windowSeconds);
-    const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
-    const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
+
+    const tokensLimits = limits.filter((limit) => limit?.type === 'TOKENS_LIMIT');
 
     const windows = {};
-    if (tokensLimit) {
+    for (const tokensLimit of tokensLimits) {
+      const windowSeconds = resolveWindowSeconds(tokensLimit);
+      const windowLabel = resolveWindowLabel(windowSeconds);
+      const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
+      const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
       windows[windowLabel] = toUsageWindow({
         usedPercent,
         windowSeconds,

--- a/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
+++ b/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
@@ -33,6 +33,7 @@ import {
   buildResult,
   toUsageWindow,
   resolveWindowSeconds,
+  resolveWindowLabel,
   normalizeTimestamp
 } from '../utils/index.js';
 
@@ -104,18 +105,18 @@ export const fetchQuota = async () => {
     const payload = await response.json();
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
 
-    const tokensLimit = limits.find((limit) => limit?.type === 'TOKENS_LIMIT');
+    const tokensLimits = limits.filter((limit) => limit?.type === 'TOKENS_LIMIT');
     const mcpToolsTimeLimit = limits.find((limit) => limit?.type === 'TIME_LIMIT');
 
     const windows = {};
 
-    // Handle TOKENS_LIMIT (5-hour window for token usage)
-    if (tokensLimit) {
+    for (const tokensLimit of tokensLimits) {
       const windowSeconds = resolveWindowSeconds(tokensLimit);
+      const windowLabel = resolveWindowLabel(windowSeconds);
       const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
       const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
 
-      windows['Tokens'] = toUsageWindow({
+      windows[windowLabel] = toUsageWindow({
         usedPercent,
         windowSeconds,
         resetAt

--- a/packages/web/server/lib/quota/utils/transformers.js
+++ b/packages/web/server/lib/quota/utils/transformers.js
@@ -35,7 +35,8 @@ export const normalizeTimestamp = (value) => {
 };
 
 export const resolveWindowSeconds = (limit) => {
-  const ZAI_TOKEN_WINDOW_SECONDS = { 3: 3600 };
+  // unit 3 = hour (3600s), unit 6 = week (604800s)
+  const ZAI_TOKEN_WINDOW_SECONDS = { 3: 3600, 6: 604800 };
   if (!limit || !limit.number) return null;
   const unitSeconds = ZAI_TOKEN_WINDOW_SECONDS[limit.unit];
   if (!unitSeconds) return null;


### PR DESCRIPTION
## Problem

The z.ai and Zhipu AI coding plan APIs return **multiple** `TOKENS_LIMIT` entries in the `limits` array — one for the 5-hour rolling window and one for the weekly window. However, both providers used `find()` which only picks the **first** match, silently dropping the weekly quota window.

Additionally, the shared `resolveWindowSeconds` mapping table only knew about `unit: 3` (hour). The weekly window uses `unit: 6`, so even if `find()` were changed to `filter()`, the seconds calculation would return `null` and the label would degrade to `'tokens'`.

## Fix

1. **`transformers.js`** — Added `unit: 6` (week = 604800s) to `ZAI_TOKEN_WINDOW_SECONDS`.
2. **`zai.js`** — Switched `find()` → `filter()` and loop over all `TOKENS_LIMIT` entries, using `resolveWindowLabel` for each window key (`5h`, `weekly`).
3. **`zhipuai-coding-plan.js`** — Same `find()` → `filter()` change, plus replaced the hardcoded `'Tokens'` window key with `resolveWindowLabel` so both `5h` and `weekly` windows get proper labels.
4. **`quotaProviders.ts`** (VS Code) — Applied the identical fix to the extension's independent quota implementations for cross-runtime parity.

## Before / After

**Before** (z.ai & Zhipu AI showed only one card):
- `5h` — 4%

**After** (matches the official z.ai/Zhipu web dashboard):
- `5h` — 4%
- `weekly` — 46%
- `MCP Tools` — 0% (Zhipu AI only, already worked)

## Testing

Verified against live z.ai and Zhipu AI APIs — both return 3 `TOKENS_LIMIT`/`TIME_LIMIT` entries. After the fix, the OpenChamber usage page correctly displays all windows with proper reset times and percentages, matching the official dashboard.