### PR TITLE
feat(otto): /permissions synonym and tool permission settings

### DIFF
--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -38,7 +38,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
-import { useI18n } from '@/lib/i18n';
+import { useI18n, type I18nKey } from '@/lib/i18n';
 import { DiscordOnboardingWizard } from './DiscordOnboardingWizard';
 import { DiscordCommandsButton } from './DiscordCommandPalette';
 
@@ -99,8 +99,8 @@ const VERBOSITY_OPTIONS: { id: MessengerVerbosity; label: string; desc: string }
 
 const PERMISSION_MODE_OPTIONS: {
   id: MessengerPermissionMode;
-  labelKey: string;
-  descKey: string;
+  labelKey: I18nKey;
+  descKey: I18nKey;
 }[] = [
   {
     id: 'ask',

--- a/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/otto-settings/MessengerSection.tsx
@@ -20,6 +20,7 @@ import {
   type MessengerType,
   type MessengerConnection,
   type MessengerVerbosity,
+  type MessengerPermissionMode,
   type MessengerDiagnosisCheck,
   type MessengerInboundMessage,
 } from '@/stores/useMessengerStore';
@@ -93,6 +94,28 @@ const VERBOSITY_OPTIONS: { id: MessengerVerbosity; label: string; desc: string }
     id: 'verbose',
     label: 'Verbose',
     desc: 'Full detail — commands, diffs, outputs and reasoning, formatted for reading',
+  },
+];
+
+const PERMISSION_MODE_OPTIONS: {
+  id: MessengerPermissionMode;
+  labelKey: string;
+  descKey: string;
+}[] = [
+  {
+    id: 'ask',
+    labelKey: 'settings.integrations.discord.bridge.permissionMode.ask.label',
+    descKey: 'settings.integrations.discord.bridge.permissionMode.ask.desc',
+  },
+  {
+    id: 'auto-edit',
+    labelKey: 'settings.integrations.discord.bridge.permissionMode.autoEdit.label',
+    descKey: 'settings.integrations.discord.bridge.permissionMode.autoEdit.desc',
+  },
+  {
+    id: 'yolo',
+    labelKey: 'settings.integrations.discord.bridge.permissionMode.yolo.label',
+    descKey: 'settings.integrations.discord.bridge.permissionMode.yolo.desc',
   },
 ];
 
@@ -541,9 +564,12 @@ function BridgePanel({
   refreshBridgeStatus: (t?: MessengerType) => Promise<void>;
   onToggle: (v: boolean) => void;
 }) {
+  const { t } = useI18n();
   const enabled = conn.bridgeEnabled !== false;
   const bridgeVerbosity = useMessengerStore((s) => s.bridgeVerbosity);
   const setBridgeVerbosity = useMessengerStore((s) => s.setBridgeVerbosity);
+  const bridgePermissionMode = useMessengerStore((s) => s.bridgePermissionMode);
+  const setBridgePermissionMode = useMessengerStore((s) => s.setBridgePermissionMode);
   useEffect(() => {
     refreshBridgeStatus(type);
     const id = setInterval(() => refreshBridgeStatus(type), 8000);
@@ -554,6 +580,10 @@ function BridgePanel({
   const bindings = bridgeStatus.bindings.filter((b) => b.type === type);
   const active = bridgeStatus.active.filter((a) => a.type === type);
   const currentVerbosity: MessengerVerbosity = bridgeVerbosity[type] ?? 'normal';
+  const currentPermissionMode: MessengerPermissionMode = bridgePermissionMode[type] ?? 'ask';
+  const currentPermissionOption =
+    PERMISSION_MODE_OPTIONS.find((o) => o.id === currentPermissionMode) ??
+    PERMISSION_MODE_OPTIONS[0];
 
   return (
     <div className="rounded-md border border-primary/30 bg-primary/5 p-3 space-y-2">
@@ -617,6 +647,35 @@ function BridgePanel({
         </div>
         <div className="text-[10px] text-muted-foreground leading-snug">
           {VERBOSITY_OPTIONS.find((o) => o.id === currentVerbosity)?.desc}.
+        </div>
+      </div>
+
+      {/* Tool permission mode — same defaults as /yolo and /permissions. */}
+      <div className="space-y-1.5 border-t border-border/60 pt-2">
+        <div className="text-[11px] font-medium text-foreground">
+          {t('settings.integrations.discord.bridge.permissionMode.title')}
+        </div>
+        <div className="flex gap-1">
+          {PERMISSION_MODE_OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setBridgePermissionMode(type, opt.id)}
+              disabled={!bridgeStatus.enabled}
+              className={cn(
+                'flex-1 rounded-md px-2 py-1.5 text-[10px] font-medium transition-colors disabled:opacity-50',
+                currentPermissionMode === opt.id
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:text-foreground',
+              )}
+              title={t(opt.descKey)}
+            >
+              {t(opt.labelKey)}
+            </button>
+          ))}
+        </div>
+        <div className="text-[10px] text-muted-foreground leading-snug">
+          {t(currentPermissionOption.descKey)}
         </div>
       </div>
 

--- a/packages/ui/src/components/sections/otto-settings/discord-commands-data.ts
+++ b/packages/ui/src/components/sections/otto-settings/discord-commands-data.ts
@@ -39,6 +39,11 @@ export const DISCORD_COMMANDS: DiscordCommandEntry[] = [
   { name: 'verbosity', descriptionKey: 'settings.integrations.discord.commands.desc.verbosity', category: 'model' },
   { name: 'skill', descriptionKey: 'settings.integrations.discord.commands.desc.skill', category: 'model' },
   { name: 'yolo', descriptionKey: 'settings.integrations.discord.commands.desc.yolo', category: 'model', suggested: true },
+  {
+    name: 'permissions',
+    descriptionKey: 'settings.integrations.discord.commands.desc.permissions',
+    category: 'model',
+  },
   { name: 'shell', descriptionKey: 'settings.integrations.discord.commands.desc.shell', category: 'shell', example: '/shell command:pwd' },
   { name: 'init', descriptionKey: 'settings.integrations.discord.commands.desc.init', category: 'shell' },
   { name: 'review', descriptionKey: 'settings.integrations.discord.commands.desc.review', category: 'shell' },

--- a/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/discord-integration.i18n.ts
@@ -95,7 +95,20 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.commands.desc.agent': 'Pick agent for this conversation',
     'settings.integrations.discord.commands.desc.verbosity': 'Choose how much detail streams back',
     'settings.integrations.discord.commands.desc.skill': 'Pick a skill for the agent',
-    'settings.integrations.discord.commands.desc.yolo': 'Toggle auto-approve for tool permissions',
+    'settings.integrations.discord.commands.desc.yolo':
+      'Set tool permission mode (always ask / non-destructive / allow all)',
+    'settings.integrations.discord.commands.desc.permissions':
+      'Synonym for /yolo — set tool permission mode',
+    'settings.integrations.discord.bridge.permissionMode.title': 'Tool permissions',
+    'settings.integrations.discord.bridge.permissionMode.ask.label': 'Always ask',
+    'settings.integrations.discord.bridge.permissionMode.ask.desc':
+      'Ask for permission on every tool — Approve / Deny buttons each time',
+    'settings.integrations.discord.bridge.permissionMode.autoEdit.label': 'Non-destructive',
+    'settings.integrations.discord.bridge.permissionMode.autoEdit.desc':
+      'Allow non-destructive commands (edits and reads); still ask before shell commands',
+    'settings.integrations.discord.bridge.permissionMode.yolo.label': 'Allow all',
+    'settings.integrations.discord.bridge.permissionMode.yolo.desc':
+      'Allow all commands without prompts — stop a run with /abort',
     'settings.integrations.discord.commands.desc.shell': 'Run a shell command in the project',
     'settings.integrations.discord.commands.desc.init': 'Run OpenCode init (AGENTS.md)',
     'settings.integrations.discord.commands.desc.review': 'Run the review workflow',
@@ -209,7 +222,20 @@ export const discordIntegrationI18n = {
     'settings.integrations.discord.commands.desc.agent': 'Вибір агента для розмови',
     'settings.integrations.discord.commands.desc.verbosity': 'Рівень деталізації виводу',
     'settings.integrations.discord.commands.desc.skill': 'Передати skill агенту',
-    'settings.integrations.discord.commands.desc.yolo': 'Авто-апрув дозволів інструментів',
+    'settings.integrations.discord.commands.desc.yolo':
+      'Режим дозволів інструментів (завжди питати / недеструктивні / дозволити всі)',
+    'settings.integrations.discord.commands.desc.permissions':
+      'Синонім /yolo — режим дозволів інструментів',
+    'settings.integrations.discord.bridge.permissionMode.title': 'Дозволи інструментів',
+    'settings.integrations.discord.bridge.permissionMode.ask.label': 'Завжди питати',
+    'settings.integrations.discord.bridge.permissionMode.ask.desc':
+      'Питати дозвіл на кожен інструмент — кнопки Approve / Deny щоразу',
+    'settings.integrations.discord.bridge.permissionMode.autoEdit.label': 'Недеструктивні',
+    'settings.integrations.discord.bridge.permissionMode.autoEdit.desc':
+      'Дозволити недеструктивні команди (редагування й читання); на shell — питати дозвіл',
+    'settings.integrations.discord.bridge.permissionMode.yolo.label': 'Дозволити всі',
+    'settings.integrations.discord.bridge.permissionMode.yolo.desc':
+      'Дозволити всі команди без запитів — зупинити відповідь через /abort',
     'settings.integrations.discord.commands.desc.shell': 'Shell-команда в проєкті',
     'settings.integrations.discord.commands.desc.init': 'Запустити OpenCode init (AGENTS.md)',
     'settings.integrations.discord.commands.desc.review': 'Запустити review workflow',

--- a/packages/ui/src/stores/useMessengerStore.ts
+++ b/packages/ui/src/stores/useMessengerStore.ts
@@ -8,6 +8,9 @@ export type MessengerType = 'discord';
 export type SyncMode = 'full' | 'notifications' | 'off';
 export type MessengerVerbosity = 'quiet' | 'normal' | 'verbose';
 
+/** Tool permission mode for the OpenCode bridge (`/yolo` / `/permissions`). */
+export type MessengerPermissionMode = 'ask' | 'auto-edit' | 'yolo';
+
 export interface MessengerConnection {
   type: MessengerType;
   enabled: boolean;
@@ -250,6 +253,14 @@ interface MessengerState {
    */
   bridgeVerbosity: Partial<Record<MessengerType, MessengerVerbosity | null>>;
 
+  /**
+   * Per-messenger default tool permission mode for the OpenCode bridge
+   * (`ask` | `auto-edit` | `yolo`). `null` means "never configured — the
+   * bridge uses its built-in `ask` default". Mirrors `/yolo default <mode>`
+   * / `/permissions default <mode>`; refreshed from /bridge/status.
+   */
+  bridgePermissionMode: Partial<Record<MessengerType, MessengerPermissionMode | null>>;
+
   addConnection: (type: MessengerType) => void;
   updateConnection: (type: MessengerType, updates: Partial<MessengerConnection>) => void;
   removeConnection: (type: MessengerType) => void;
@@ -266,6 +277,10 @@ interface MessengerState {
   diagnoseDiscord: () => Promise<boolean>;
   refreshBridgeStatus: (type?: MessengerType) => Promise<void>;
   setBridgeVerbosity: (type: MessengerType, level: MessengerVerbosity) => Promise<boolean>;
+  setBridgePermissionMode: (
+    type: MessengerType,
+    mode: MessengerPermissionMode,
+  ) => Promise<boolean>;
   saveDiscordConfig: () => Promise<void>;
   startDiscordListener: () => Promise<boolean>;
   stopDiscordListener: () => Promise<boolean>;
@@ -352,6 +367,7 @@ export const useMessengerStore = create<MessengerState>()(
       approvals: [],
       bridgeStatus: { enabled: false, bindings: [], active: [] },
       bridgeVerbosity: {},
+      bridgePermissionMode: {},
 
       addConnection: (type) => {
         const existing = get().connections.find((c) => c.type === type);
@@ -754,6 +770,7 @@ export const useMessengerStore = create<MessengerState>()(
             bindings?: MessengerState['bridgeStatus']['bindings'];
             active?: MessengerState['bridgeStatus']['active'];
             verbosity?: Partial<Record<MessengerType, MessengerVerbosity | null>>;
+            permissionMode?: Partial<Record<MessengerType, MessengerPermissionMode | null>>;
           }>('/api/otto/messenger/bridge/status', { type, token });
           set({
             bridgeStatus: {
@@ -762,6 +779,7 @@ export const useMessengerStore = create<MessengerState>()(
               active: data.active ?? [],
             },
             bridgeVerbosity: data.verbosity ?? get().bridgeVerbosity,
+            bridgePermissionMode: data.permissionMode ?? get().bridgePermissionMode,
           });
         } catch {
           // ignore
@@ -777,6 +795,25 @@ export const useMessengerStore = create<MessengerState>()(
           if (!data.ok) return false;
           set({
             bridgeVerbosity: { ...get().bridgeVerbosity, [type]: data.level ?? level },
+          });
+          return true;
+        } catch {
+          return false;
+        }
+      },
+
+      setBridgePermissionMode: async (type, mode) => {
+        try {
+          const data = await postJson<{ ok: boolean; mode?: MessengerPermissionMode | null }>(
+            '/api/otto/messenger/bridge/permission-mode',
+            { type, mode },
+          );
+          if (!data.ok) return false;
+          set({
+            bridgePermissionMode: {
+              ...get().bridgePermissionMode,
+              [type]: data.mode ?? mode,
+            },
           });
           return true;
         } catch {

--- a/packages/web/server/lib/otto-api/discord-command-wizards.js
+++ b/packages/web/server/lib/otto-api/discord-command-wizards.js
@@ -211,7 +211,7 @@ export function createDiscordCommandWizards({ restCall, bridge }) {
     });
   }
 
-  // ── /yolo (permission mode) ────────────────────────────────────────────────
+  // ── /yolo|/permissions (permission mode) ───────────────────────────────────
   function permissionModeSelect(hash) {
     const options = PERMISSION_MODES.map((mode) => ({
       label: PERMISSION_MODE_LABELS[mode] ?? mode,

--- a/packages/web/server/lib/otto-api/discord-command-wizards.test.js
+++ b/packages/web/server/lib/otto-api/discord-command-wizards.test.js
@@ -120,7 +120,7 @@ describe('permissions (/yolo) wizard', () => {
       { type: 'discord', botTokenHash: expect.any(String), targetKey: 'chan-1', permissionModeOverride: 'yolo' },
     ]);
     expect(permissionModeDefaults).toHaveLength(0);
-    expect(calls.at(-1).body.data.content).toContain('YOLO');
+    expect(calls.at(-1).body.data.content).toContain('Allow all');
   });
 
   it('mode → "whole system" scope writes the messenger default', async () => {

--- a/packages/web/server/lib/otto-api/discord-commands.js
+++ b/packages/web/server/lib/otto-api/discord-commands.js
@@ -48,7 +48,8 @@ export function buildSlashCommandDefinitions() {
     { name: 'model', description: 'Pick the model + thinking effort (this chat, project, or everywhere)' },
     { name: 'agent', description: 'Pick the agent for this conversation (or set a project default)' },
     { name: 'verbosity', description: 'Choose how much Otto streams back (this chat, project, or everywhere)' },
-    { name: 'yolo', description: 'Set tool permission mode: ask / auto-approve edits / auto-approve all' },
+    { name: 'yolo', description: 'Set tool permission mode: always ask / non-destructive / allow all' },
+    { name: 'permissions', description: 'Synonym for /yolo — set tool permission mode' },
     { name: 'skill', description: 'Pick an available skill and hand it to the agent' },
     { name: 'sessions', description: 'List recent OpenCode sessions for this project' },
     {

--- a/packages/web/server/lib/otto-api/discord-commands.test.js
+++ b/packages/web/server/lib/otto-api/discord-commands.test.js
@@ -6,7 +6,17 @@ describe('buildSlashCommandDefinitions', () => {
 
   it('includes the interactive wizard commands and the new /skill command', () => {
     const names = defs.map((d) => d.name);
-    for (const name of ['model', 'agent', 'verbosity', 'yolo', 'skill', 'help', 'status', 'sessions']) {
+    for (const name of [
+      'model',
+      'agent',
+      'verbosity',
+      'yolo',
+      'permissions',
+      'skill',
+      'help',
+      'status',
+      'sessions',
+    ]) {
       expect(names).toContain(name);
     }
   });

--- a/packages/web/server/lib/otto-api/discord-listener.js
+++ b/packages/web/server/lib/otto-api/discord-listener.js
@@ -369,7 +369,7 @@ function dispatchThreadDelete(state, data, bridge, reason = 'deleted') {
 const KNOWN_SLASH_COMMANDS = new Set([
   'help', 'status', 'abort', 'new', 'undo', 'redo',
   'compact', 'summary', 'init', 'review', 'shell',
-  'model', 'agent', 'verbosity', 'yolo', 'skill', 'sessions',
+  'model', 'agent', 'verbosity', 'yolo', 'permissions', 'skill', 'sessions',
   'session', 'resume', 'fork', 'share', 'unshare',
   'queue', 'clear-queue', 'mention-mode',
   'new-worktree', 'merge-worktree', 'schedule',
@@ -400,7 +400,7 @@ async function handleApplicationCommand(state, interaction, broadcastEvent, brid
       await state.commandWizards.startSkill(state, interaction);
       return;
     }
-    if (cmdName === 'yolo') {
+    if (cmdName === 'yolo' || cmdName === 'permissions') {
       await state.commandWizards.startPermissions(state, interaction);
       return;
     }

--- a/packages/web/server/lib/otto-api/messenger-commands.js
+++ b/packages/web/server/lib/otto-api/messenger-commands.js
@@ -103,9 +103,9 @@ const COMMAND_HELP = [
   },
   {
     name: 'yolo',
-    usage: '/yolo [ask | auto-edit | yolo | project <mode> | default <mode> | reset]',
+    usage: '/yolo|/permissions [ask | auto-edit | yolo | project <mode> | default <mode> | reset]',
     summary:
-      'How Otto handles tool permissions: `ask` = Approve/Deny buttons, `auto-edit` = auto-approve edits/reads, `yolo` = auto-approve everything. On Discord, run `/yolo` for a dropdown. Stop any run with `/abort`.',
+      'How Otto handles tool permissions: `ask` = always ask, `auto-edit` = allow non-destructive tools (still ask for shell), `yolo` = allow all. `/permissions` is a synonym. On Discord, run `/yolo` or `/permissions` for a dropdown. Stop any run with `/abort`.',
   },
   {
     name: 'sessions',
@@ -158,7 +158,13 @@ const COMMAND_HELP = [
   },
 ];
 
-const KNOWN_TOP_LEVEL = new Set(COMMAND_HELP.map((c) => c.name));
+/** Aliases for COMMAND_HELP entries — recognised by the gate but not listed twice in `/help`. */
+const COMMAND_ALIASES = new Map([['permissions', 'yolo']]);
+
+const KNOWN_TOP_LEVEL = new Set([
+  ...COMMAND_HELP.map((c) => c.name),
+  ...COMMAND_ALIASES.keys(),
+]);
 
 /**
  * Whether `name` is a recognised console command (`/help`, `/status`, …).
@@ -652,7 +658,7 @@ export async function executeMessengerCommand({
         }
         lines.push('');
         lines.push(
-          'Set with `/yolo yolo` (this conversation), `/yolo project yolo` (this project) or `/yolo default yolo` (every channel/chat on this bot). `/yolo reset` clears the conversation override. You can always stop a run with `/abort`.',
+          'Set with `/permissions yolo` (this conversation), `/permissions project yolo` (this project) or `/permissions default yolo` (every channel/chat on this bot). `/permissions reset` clears the conversation override. `/yolo` is a synonym. You can always stop a run with `/abort`.',
         );
         if (binding?.permissionModeOverride) {
           lines.push('', `Conversation override: \`${binding.permissionModeOverride}\``);
@@ -717,7 +723,7 @@ export async function executeMessengerCommand({
       const mode = parsePermissionMode(raw);
       if (!mode) {
         return {
-          reply: `✗ Unknown mode. Use one of: ${PERMISSION_MODES.map((m) => `\`${m}\``).join(', ')}, or \`/yolo default <mode>\`.`,
+          reply: `✗ Unknown mode. Use one of: ${PERMISSION_MODES.map((m) => `\`${m}\``).join(', ')}, or \`/permissions default <mode>\`.`,
         };
       }
       await surfaceMutators.setOverrides({ permissionModeOverride: mode });

--- a/packages/web/server/lib/otto-api/messenger-commands.test.js
+++ b/packages/web/server/lib/otto-api/messenger-commands.test.js
@@ -149,11 +149,12 @@ describe('/model + /status surface the OpenChamber default model', () => {
 });
 
 describe('/help includes verbosity and skill', () => {
-  it('lists the /verbosity, /skill and /yolo commands', async () => {
+  it('lists the /verbosity, /skill and /yolo|/permissions commands', async () => {
     const { result } = await run('/help');
     expect(result.reply).toContain('/verbosity');
     expect(result.reply).toContain('/skill');
     expect(result.reply).toContain('/yolo');
+    expect(result.reply).toContain('/permissions');
   });
 });
 
@@ -201,6 +202,29 @@ describe('/yolo (permission mode) command', () => {
     const { result, surfaceMutators } = await run('/yolo maybe');
     expect(result.reply).toMatch(/Unknown mode/);
     expect(surfaceMutators.setOverrides).not.toHaveBeenCalled();
+  });
+});
+
+describe('/permissions synonym for /yolo', () => {
+  it('lists modes the same way as /yolo', async () => {
+    const { result, surfaceMutators } = await run('/permissions', {
+      binding: { permissionModeDefault: 'ask' },
+    });
+    expect(result.reply).toContain('Tool permission mode');
+    expect(result.reply).toContain('➤ `ask`');
+    expect(surfaceMutators.setOverrides).not.toHaveBeenCalled();
+  });
+
+  it('sets a conversation override', async () => {
+    const { surfaceMutators } = await run('/permissions auto-edit');
+    expect(surfaceMutators.setOverrides).toHaveBeenCalledWith({
+      permissionModeOverride: 'auto-edit',
+    });
+  });
+
+  it('sets the messenger default via `default`', async () => {
+    const { surfaceMutators } = await run('/permissions default yolo');
+    expect(surfaceMutators.setPermissionModeDefault).toHaveBeenCalledWith('yolo');
   });
 });
 

--- a/packages/web/server/lib/otto-api/messenger-permissions.js
+++ b/packages/web/server/lib/otto-api/messenger-permissions.js
@@ -7,16 +7,16 @@
  * permission mode lets a user pre-decide how those requests are handled for
  * a conversation, project, or the whole bot — the "yolo" affordance:
  *
- *   - `ask`       — always prompt with buttons (the default, safest).
- *   - `auto-edit` — auto-approve low-risk edit/read tools (edit, write, patch,
- *                   read, list, grep, glob, webfetch); still prompt for shell
- *                   commands and anything unrecognised.
- *   - `yolo`      — auto-approve everything. Nothing is prompted; the user can
+ *   - `ask`       — always ask for permission (the default, safest).
+ *   - `auto-edit` — allow non-destructive tools (edit, write, patch, read,
+ *                   list, grep, glob, webfetch); still ask for shell commands
+ *                   and anything unrecognised.
+ *   - `yolo`      — allow all commands. Nothing is prompted; the user can
  *                   still stop the run with `/abort`.
  *
- * Both the `/yolo` Discord command (dropdown wizard + text form) and the
- * bridge's `permission.asked` handler read the SAME resolved value, so the
- * policy is enforced in core logic and never only in the UI.
+ * Both `/yolo` and its synonym `/permissions` (dropdown wizard + text form)
+ * and the bridge's `permission.asked` handler read the SAME resolved value,
+ * so the policy is enforced in core logic and never only in the UI.
  */
 
 export const PERMISSION_MODES = ['ask', 'auto-edit', 'yolo'];
@@ -24,16 +24,17 @@ export const PERMISSION_MODES = ['ask', 'auto-edit', 'yolo'];
 export const DEFAULT_PERMISSION_MODE = 'ask';
 
 export const PERMISSION_MODE_DESCRIPTIONS = {
-  ask: 'Ask every time — Approve / Deny buttons for each tool (default)',
-  'auto-edit': 'Auto-approve file edits + reads; still ask before running shell commands',
-  yolo: 'Auto-approve everything — no prompts (stop a run with /abort)',
+  ask: 'Always ask for permission — Approve / Deny buttons for each tool (default)',
+  'auto-edit':
+    'Allow non-destructive commands (edits/reads); still ask before running shell commands',
+  yolo: 'Allow all commands — no prompts (stop a run with /abort)',
 };
 
 /** Short labels for confirmations / status lines. */
 export const PERMISSION_MODE_LABELS = {
-  ask: 'Ask every time',
-  'auto-edit': 'Auto-approve edits',
-  yolo: 'YOLO — auto-approve all',
+  ask: 'Always ask',
+  'auto-edit': 'Non-destructive only',
+  yolo: 'Allow all',
 };
 
 const PERMISSION_ALIASES = new Map([
@@ -77,8 +78,9 @@ const AUTO_EDIT_TOOLS = new Set([
 ]);
 
 /**
- * Map free-text input (from `/yolo <mode>` or a wizard value) to a canonical
- * mode. Returns `null` for unrecognised input so callers can show an error.
+ * Map free-text input (from `/yolo|/permissions <mode>` or a wizard value) to
+ * a canonical mode. Returns `null` for unrecognised input so callers can show
+ * an error.
  */
 export function parsePermissionMode(input) {
   if (typeof input !== 'string') return null;

--- a/packages/web/server/lib/otto-api/messenger-sync.js
+++ b/packages/web/server/lib/otto-api/messenger-sync.js
@@ -7,6 +7,7 @@ import {
 import { createMessengerOpencodeBridge } from './messenger-opencode-bridge.js';
 import { createDiscordAgentRouter } from './discord-agent-api.js';
 import { parseVerbosityLevel, VERBOSITY_LEVELS } from './messenger-verbosity.js';
+import { parsePermissionMode, PERMISSION_MODES } from './messenger-permissions.js';
 import { bootstrapProject as bootstrapProjectFn } from '../projects/project-bootstrap.js';
 import { renderPermissionContext, escapeMd } from './messenger-render.js';
 import { discoverSkills } from '../opencode/skills.js';
@@ -1094,16 +1095,27 @@ export function createMessengerSyncRouter({
   // "Discord channel X is bound to session Y".
   router.post('/bridge/status', (req, res) => {
     if (!bridge) {
-      return res.json({ ok: true, enabled: false, bindings: [], active: [], verbosity: {} });
+      return res.json({
+        ok: true,
+        enabled: false,
+        bindings: [],
+        active: [],
+        verbosity: {},
+        permissionMode: {},
+      });
     }
     const { type, token } = req.body ?? {};
     const verbosity = {
       discord: bridge.store.getVerbosityDefault?.('discord') ?? null,
     };
+    const permissionMode = {
+      discord: bridge.store.getPermissionModeDefault?.('discord') ?? null,
+    };
     return res.json({
       ok: true,
       enabled: true,
       verbosity,
+      permissionMode,
       ...bridge.statusSnapshot({ type, token }),
     });
   });
@@ -1148,6 +1160,54 @@ export function createMessengerSyncRouter({
       levels: VERBOSITY_LEVELS,
       verbosity: {
         discord: bridge.store.getVerbosityDefault?.('discord') ?? null,
+      },
+    });
+  });
+
+  /**
+   * Per-messenger default tool permission mode (`ask` | `auto-edit` | `yolo`).
+   * Same value as `/yolo default <mode>` / `/permissions default <mode>`, so
+   * the OpenChamber UI and Discord stay in sync. A per-conversation
+   * `/permissions <mode>` override always wins over this default.
+   *
+   * POST body: { type: 'discord', mode }  (mode null clears it)
+   * GET query: ?type=discord
+   */
+  router.post('/bridge/permission-mode', (req, res) => {
+    if (!bridge) return res.status(503).json({ ok: false, error: 'bridge unavailable' });
+    const { type, mode } = req.body ?? {};
+    if (type !== 'discord') {
+      return res.status(400).json({ ok: false, error: "type must be 'discord'" });
+    }
+    if (mode == null || mode === '') {
+      bridge.store.setPermissionModeDefault(type, null);
+      return res.json({ ok: true, type, mode: null });
+    }
+    const parsed = parsePermissionMode(mode);
+    if (!parsed) {
+      return res
+        .status(400)
+        .json({ ok: false, error: `mode must be one of: ${PERMISSION_MODES.join(', ')}` });
+    }
+    bridge.store.setPermissionModeDefault(type, parsed);
+    return res.json({ ok: true, type, mode: parsed });
+  });
+
+  router.get('/bridge/permission-mode', (req, res) => {
+    if (!bridge) return res.status(503).json({ ok: false, error: 'bridge unavailable' });
+    const type = typeof req.query?.type === 'string' ? req.query.type : '';
+    if (type === 'discord') {
+      return res.json({
+        ok: true,
+        type,
+        mode: bridge.store.getPermissionModeDefault?.(type) ?? null,
+      });
+    }
+    return res.json({
+      ok: true,
+      modes: PERMISSION_MODES,
+      permissionMode: {
+        discord: bridge.store.getPermissionModeDefault?.('discord') ?? null,
       },
     });
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `/permissions` is a first-class synonym for `/yolo` (text commands + Discord slash + wizard)
- Messenger bridge settings expose three tool-permission modes:
  - **Always ask** (`ask`)
  - **Non-destructive** (`auto-edit`) — allow edits/reads; still ask for shell
  - **Allow all** (`yolo`)
- UI/store sync the messenger-wide default via `POST /api/otto/messenger/bridge/permission-mode` (same value as `/permissions default <mode>`)

## Verification

- `bun test` on otto permission/command suites: 92 pass
- `packages/ui` type-check + lint: green

## Notes

Per-conversation `/permissions <mode>` overrides still win over the settings default. `/abort` remains available in allow-all mode.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6bb8-6d9a-7f0a-8c6b-8f61dbc0b457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6bb8-6d9a-7f0a-8c6b-8f61dbc0b457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

