### PR TITLE
fix(sidebar): keep the permission badge clear of hover actions (#2284)

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -25,7 +25,7 @@ import { buildSessionMessageRecordsSnapshot, useDirectoryStore, useGlobalSession
 import { useSync } from '@/sync/use-sync';
 import { useViewportStore, viewportSessionKey } from '@/sync/viewport-store';
 import { DraggableSessionRow } from './sessionFolderDnd';
-import { nodeContainsSessionId } from './sessionNodeItemUtils';
+import { nodeContainsSessionId, resolveRevealPaddingClass } from './sessionNodeItemUtils';
 import type { SessionNodeChildRenderExtras, SessionNodeRenderExtras } from './sessionNodeItemUtils';
 import type { SessionNode } from './types';
 import { formatSessionCompactDateLabel, formatSessionDateLabel, normalizePath, renderHighlightedText } from './utils';
@@ -272,25 +272,6 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
     : 'group-hover:opacity-0 group-focus-within:opacity-0';
   const showOpenInEditorAction = isVSCode;
   const showQuickArchiveAction = !archivedBucket && !mobileVariant;
-  const revealPaddingClass = isMinimalMode
-    ? (isVSCode
-        // VS Code minimal rows reveal up to three actions on hover
-        // (open-in-editor + quick-archive + menu, each h-4). The date sits in the
-        // row flow, so the title must shrink enough to clear the actions or they
-        // overlap the timestamp. Open-in-editor is always present in VS Code.
-        ? (showQuickArchiveAction && showOpenInEditorAction
-            ? 'group-hover:pr-18'
-            : showQuickArchiveAction || showOpenInEditorAction
-              ? 'group-hover:pr-14'
-              : 'group-hover:pr-8')
-        : 'group-hover:pr-2 group-focus-within:pr-2')
-    : (isVSCode
-        ? (showQuickArchiveAction && showOpenInEditorAction
-            ? 'group-hover:pr-18'
-            : showQuickArchiveAction || showOpenInEditorAction
-              ? 'group-hover:pr-12'
-              : 'group-hover:pr-5')
-        : (showQuickArchiveAction ? 'group-hover:pr-12 group-focus-within:pr-12' : 'group-hover:pr-5 group-focus-within:pr-5'));
   const alwaysActionPaddingClass = showQuickArchiveAction ? 'pr-13' : 'pr-7';
   const suppressNextSelectRef = React.useRef(false);
   const [isTouchPressed, setIsTouchPressed] = React.useState(false);
@@ -578,6 +559,15 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
   const statusType = sessionStatus?.type ?? 'idle';
   const isStreaming = statusType === 'busy' || statusType === 'retry';
   const pendingPermissionCount = sessionPermissions.length;
+  // Defined here rather than beside the sibling reveal classes above because the
+  // permission-badge gate depends on `pendingPermissionCount` (#2284).
+  const revealPaddingClass = resolveRevealPaddingClass({
+    isMinimalMode,
+    isVSCode,
+    showQuickArchiveAction,
+    showOpenInEditorAction,
+    hasPendingPermissionBadge: pendingPermissionCount > 0,
+  });
   const showUnreadStatus = !isStreaming && needsAttention && !isActive;
   const showStatusMarker = isStreaming || showUnreadStatus;
   const statusMarkerContent = isStreaming

--- a/packages/ui/src/components/session/sidebar/sessionNodeItemUtils.test.ts
+++ b/packages/ui/src/components/session/sidebar/sessionNodeItemUtils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveRevealPaddingClass } from './sessionNodeItemUtils';
+
+// Minimal, non-VS Code, quick-archive available, no permission badge.
+const base = {
+  isMinimalMode: true,
+  isVSCode: false,
+  showQuickArchiveAction: true,
+  showOpenInEditorAction: false,
+  hasPendingPermissionBadge: false,
+};
+
+describe('resolveRevealPaddingClass', () => {
+  describe('minimal, non-VS Code', () => {
+    test('reserves only pr-2 when no permission badge is shown', () => {
+      expect(resolveRevealPaddingClass(base)).toBe('group-hover:pr-2 group-focus-within:pr-2');
+    });
+
+    test('widens to pr-14 so the permission badge clears the hover actions (#2284)', () => {
+      expect(resolveRevealPaddingClass({ ...base, hasPendingPermissionBadge: true })).toBe(
+        'group-hover:pr-14 group-focus-within:pr-14',
+      );
+    });
+
+    test('badge padding does not depend on the quick-archive action', () => {
+      expect(
+        resolveRevealPaddingClass({ ...base, showQuickArchiveAction: false, hasPendingPermissionBadge: true }),
+      ).toBe('group-hover:pr-14 group-focus-within:pr-14');
+    });
+  });
+
+  describe('standard, non-VS Code (badge does not change padding)', () => {
+    const standard = { ...base, isMinimalMode: false };
+
+    test('keeps pr-12 with the quick-archive action, with or without a badge', () => {
+      expect(resolveRevealPaddingClass(standard)).toBe('group-hover:pr-12 group-focus-within:pr-12');
+      expect(resolveRevealPaddingClass({ ...standard, hasPendingPermissionBadge: true })).toBe(
+        'group-hover:pr-12 group-focus-within:pr-12',
+      );
+    });
+
+    test('falls back to pr-5 without the quick-archive action', () => {
+      expect(resolveRevealPaddingClass({ ...standard, showQuickArchiveAction: false })).toBe(
+        'group-hover:pr-5 group-focus-within:pr-5',
+      );
+    });
+  });
+
+  describe('VS Code (badge does not change padding)', () => {
+    // Open-in-editor is always present in VS Code.
+    const vscode = { ...base, isVSCode: true, showOpenInEditorAction: true };
+
+    test('minimal reserves pr-18 for open-in-editor + quick-archive + menu', () => {
+      expect(resolveRevealPaddingClass(vscode)).toBe('group-hover:pr-18');
+    });
+
+    test('minimal reserves pr-14 for a single action + menu', () => {
+      expect(resolveRevealPaddingClass({ ...vscode, showQuickArchiveAction: false })).toBe('group-hover:pr-14');
+    });
+
+    test('a permission badge does not alter VS Code minimal padding', () => {
+      expect(resolveRevealPaddingClass({ ...vscode, hasPendingPermissionBadge: true })).toBe('group-hover:pr-18');
+    });
+
+    test('standard reserves pr-12 for a single action + menu', () => {
+      expect(resolveRevealPaddingClass({ ...vscode, isMinimalMode: false, showQuickArchiveAction: false })).toBe(
+        'group-hover:pr-12',
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/session/sidebar/sessionNodeItemUtils.ts
+++ b/packages/ui/src/components/session/sidebar/sessionNodeItemUtils.ts
@@ -118,3 +118,49 @@ export const resolveMenuOpenSessionId = (
   nodes.forEach((node) => visit(node));
   return result;
 };
+
+/**
+ * Right padding reserved on the row button so the absolute hover/focus action
+ * icons (quick-archive, open-in-editor, menu — anchored `right-0`) don't overlap
+ * the row's in-flow content.
+ *
+ * Minimal non-VS Code rows normally reserve only `pr-2`: the inline date/goal
+ * label fades out on hover, so the actions take its place and the title barely
+ * shifts. A pending-permission badge, however, stays opaque at the row's right
+ * edge, so `pr-2` lets the actions overlap it (#2284). When the badge is present,
+ * reserve the room the VS Code minimal two-action layout already uses (`pr-14`)
+ * so the title shrinks and the badge shifts clear of the icons.
+ */
+export const resolveRevealPaddingClass = ({
+  isMinimalMode,
+  isVSCode,
+  showQuickArchiveAction,
+  showOpenInEditorAction,
+  hasPendingPermissionBadge,
+}: {
+  isMinimalMode: boolean;
+  isVSCode: boolean;
+  showQuickArchiveAction: boolean;
+  showOpenInEditorAction: boolean;
+  hasPendingPermissionBadge: boolean;
+}): string => {
+  if (isMinimalMode) {
+    // VS Code minimal rows reveal up to three actions (open-in-editor +
+    // quick-archive + menu, each h-4); open-in-editor is always present there.
+    if (isVSCode) {
+      if (showQuickArchiveAction && showOpenInEditorAction) return 'group-hover:pr-18';
+      if (showQuickArchiveAction || showOpenInEditorAction) return 'group-hover:pr-14';
+      return 'group-hover:pr-8';
+    }
+    if (hasPendingPermissionBadge) return 'group-hover:pr-14 group-focus-within:pr-14';
+    return 'group-hover:pr-2 group-focus-within:pr-2';
+  }
+  if (isVSCode) {
+    if (showQuickArchiveAction && showOpenInEditorAction) return 'group-hover:pr-18';
+    if (showQuickArchiveAction || showOpenInEditorAction) return 'group-hover:pr-12';
+    return 'group-hover:pr-5';
+  }
+  return showQuickArchiveAction
+    ? 'group-hover:pr-12 group-focus-within:pr-12'
+    : 'group-hover:pr-5 group-focus-within:pr-5';
+};


### PR DESCRIPTION
## Why

Closes #2284.

In **minimal display mode (the default)**, a session row that has a pending permission request keeps its red shield badge fully visible on hover. But the hover action icons (quick-archive + menu) are absolutely positioned at `right-0`, and minimal non–VS Code rows only reserve `pr-2` (8px) of hover padding — far too little to clear the ~34px of icons. The result is the icons overlapping the badge, exactly as the reporter's screenshot shows.

## Root cause

In `SessionNodeItem`, the inline date/goal label fades out on hover (`group-hover:opacity-0`), so the actions take its place and the title barely shifts — which is why minimal rows only reserve `pr-2`. The permission badge, however, sits at the right edge of the row flow and has **no hover-hide class**, so it stays opaque while the absolute actions render on top of it.

(Standard mode already reserves `pr-12` and VS Code minimal reserves `pr-14`/`pr-18`, so both already clear their icons — only minimal non–VS Code was affected.)

## What

- When a permission badge is present in minimal non–VS Code mode, reserve `group-hover:pr-14 group-focus-within:pr-14` instead of `pr-2`. On hover the title now shrinks and the badge shifts left, clear of the icons — the behavior the issue asks for. `pr-14` is the same padding the VS Code minimal layout already uses for the identical two `h-4` icons (archive + menu), so the value is consistent with existing code.
- Extracted the reveal-padding decision from an inline nested ternary into a pure `resolveRevealPaddingClass` helper in `sessionNodeItemUtils.ts`, using early returns per the CONTRIBUTING style guide. Standard and VS Code padding are byte-for-byte unchanged.

## Testing

- New `sessionNodeItemUtils.test.ts` (9 cases) locks in every branch. The `#2284` case is a genuine regression guard: with the pre-fix logic it returns `pr-2` and fails; with the fix it returns `pr-14` and passes. The 7 non-badge cases pass in both states, confirming the extraction is behavior-preserving.
- `bun test packages/ui/src/components/session/sidebar/` → 31 pass / 0 fail.
- `bun run type-check:ui`, `bun run lint:ui` → clean. `bun run dead-code` → no new findings.

Not run: live-session visual check (needs a backend session in a pending-permission state); the padding value is validated by the unit test and by matching the existing VS Code minimal two-action padding for the same icon geometry.
