### PR TITLE
fix(settings): preserve notification template edits

### DIFF
--- a/packages/ui/src/components/sections/openchamber/NotificationSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/NotificationSettings.tsx
@@ -152,13 +152,13 @@ export const NotificationSettings: React.FC = () => {
     field: 'title' | 'message',
     value: string,
   ) => {
-    setNotificationTemplates({
-      ...notificationTemplates,
+    setNotificationTemplates((current) => ({
+      ...current,
       [event]: {
-        ...notificationTemplates[event],
+        ...current[event],
         [field]: value,
       },
-    });
+    }));
   };
 
   const base64UrlToUint8Array = (base64Url: string): Uint8Array<ArrayBuffer> => {

--- a/packages/ui/src/stores/useUIStore.notificationTemplates.test.ts
+++ b/packages/ui/src/stores/useUIStore.notificationTemplates.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { useUIStore } from './useUIStore';
+
+const initialTemplates = useUIStore.getState().notificationTemplates;
+
+afterEach(() => {
+  useUIStore.setState({ notificationTemplates: initialTemplates });
+});
+
+describe('useUIStore notification templates', () => {
+  test('preserves rapid updates to separate template fields', () => {
+    const { setNotificationTemplates } = useUIStore.getState();
+
+    setNotificationTemplates((current) => ({
+      ...current,
+      completion: { ...current.completion, title: 'Completed' },
+    }));
+    setNotificationTemplates((current) => ({
+      ...current,
+      error: { ...current.error, message: 'Failed' },
+    }));
+
+    expect(useUIStore.getState().notificationTemplates).toEqual({
+      ...initialTemplates,
+      completion: { ...initialTemplates.completion, title: 'Completed' },
+      error: { ...initialTemplates.error, message: 'Failed' },
+    });
+  });
+});

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -842,7 +842,9 @@ interface UIStore {
   setNotifyOnCompletion: (value: boolean) => void;
   setNotifyOnError: (value: boolean) => void;
   setNotifyOnQuestion: (value: boolean) => void;
-  setNotificationTemplates: (templates: UIStore['notificationTemplates']) => void;
+  setNotificationTemplates: (
+    templates: UIStore['notificationTemplates'] | ((current: UIStore['notificationTemplates']) => UIStore['notificationTemplates']),
+  ) => void;
   setSummarizeLastMessage: (value: boolean) => void;
   setSummaryThreshold: (value: number) => void;
   setSummaryLength: (value: number) => void;
@@ -2135,7 +2137,13 @@ export const useUIStore = create<UIStore>()(
         setNotifyOnCompletion: (value) => { set({ notifyOnCompletion: value }); },
         setNotifyOnError: (value) => { set({ notifyOnError: value }); },
         setNotifyOnQuestion: (value) => { set({ notifyOnQuestion: value }); },
-        setNotificationTemplates: (templates) => { set({ notificationTemplates: templates }); },
+        setNotificationTemplates: (templates) => {
+          set((state) => ({
+            notificationTemplates: typeof templates === 'function'
+              ? templates(state.notificationTemplates)
+              : templates,
+          }));
+        },
         setSummarizeLastMessage: (value) => { set({ summarizeLastMessage: value }); },
         setSummaryThreshold: (value) => { set({ summaryThreshold: value }); },
         setSummaryLength: (value) => { set({ summaryLength: value }); },


### PR DESCRIPTION
## Intent

Prevent rapid consecutive notification-template updates from overwriting one another by applying each edit against the latest store state.

## Non-goals

No notification template UI, copy, persistence format, or cross-runtime behavior changes.

## Affected surfaces

- Shared UI notification settings state and edit handling.
- The existing persistence caller continues to pass a template object and retains its prior behavior.

## Repository guidance

| Source | Applied guidance |
| --- | --- |
| `AGENTS.md` | Kept the consistency guarantee in the UI store rather than the component alone. |
| `packages/ui/src/stores/DOCUMENTATION.md` | Preserve unaffected notification-template entries while updating one event. |
| `openchamber-change-discipline` | Covered the functional setter path with a focused store regression test and inspected `dead-code` because the setter contract and test-file inventory changed. |

## Validation

- `bun test packages/ui/src/stores/useUIStore.notificationTemplates.test.ts` - passed: 1 test across 1 file, 0 failures.
- `bun run type-check:ui` - passed.
- `bun run lint:ui` - passed.
- `bun run dead-code` - completed successfully; reported the pre-existing repository-wide inventory of 179 unused exported types, 1 duplicate export, and 4 configuration hints. This PR did not add an item to that report.

## Visual evidence

No rendered markup or visual styling changed, so a screenshot would be identical. This fix changes only the state-merge source used by the existing controlled inputs: rapid or IME-composed consecutive edits now merge against current Zustand state instead of an earlier render snapshot, preventing intermittent value or caret displacement.

## Risks and failure behavior

`setNotificationTemplates` now accepts either a complete template object or a functional updater. The existing persistence hydration path still supplies the complete object and follows the unchanged object branch. The regression test verifies that two consecutive functional updates to different fields retain both changes; failure would otherwise present as a later edit clobbering an earlier one.