### PR TITLE
fix(small-model): include config-authenticated providers in override picker

### DIFF
--- a/packages/web/server/lib/small-model/DOCUMENTATION.md
+++ b/packages/web/server/lib/small-model/DOCUMENTATION.md
@@ -1,7 +1,8 @@
 # Small Model
 
 Server-side direct LLM calls that reuse the user's existing OpenCode provider
-logins (`~/.local/share/opencode/auth.json`). OpenCode uses a "small model"
+credentials from `~/.local/share/opencode/auth.json` or resolved
+`provider.<id>.options.apiKey` configuration. OpenCode uses a "small model"
 internally (titles, summaries) but does not expose it through the SDK or
 plugins — this module replicates that mechanism as an OpenChamber runtime API.
 
@@ -14,7 +15,10 @@ other runtime API.
 
 ## Files
 
-- `index.js` — orchestration: `generateSmallModelText()` / `describeSmallModel()`.
+- `index.js` — orchestration: `generateSmallModelText()` /
+  `describeSmallModel()`, plus provider discovery for the settings override
+  picker. Authenticated providers include usable `auth.json` entries and
+  provider IDs whose configured API keys resolve successfully.
 - `resolve.js` — model selection, mirroring OpenCode's `getSmallModel` chain:
   0. OpenChamber's own settings override (Settings → Sessions → Small Model):
      when `smallModelUseDefault` is `false`, `smallModelOverride`

--- a/packages/web/server/lib/small-model/call.js
+++ b/packages/web/server/lib/small-model/call.js
@@ -349,26 +349,56 @@ const resolveConfigApiKey = (value, workingDirectory, providerID) => {
   }
 };
 
+const parseProviderConfig = (providerCfg, workingDirectory, providerID) => {
+  if (!providerCfg || typeof providerCfg !== 'object') return null;
+  const baseURL = typeof providerCfg?.options?.baseURL === 'string' ? providerCfg.options.baseURL.trim() : null;
+  const rawApiKey = typeof providerCfg?.options?.apiKey === 'string' ? providerCfg.options.apiKey.trim() : null;
+  const apiKey = rawApiKey ? resolveConfigApiKey(rawApiKey, workingDirectory, providerID) : null;
+  return {
+    baseURL,
+    // Shape the config-supplied key as a regular api-key auth entry so it
+    // can win the precedence check below and flow through the dispatch's
+    // `entry.type === 'api' ? entry.key : ...` branch unchanged.
+    auth: apiKey ? { type: 'api', key: apiKey } : null,
+  };
+};
+
 const readProviderConfig = (workingDirectory, providerID) => {
   try {
     const config = readConfig(workingDirectory);
-    const providerCfg = config?.provider?.[providerID];
-    if (!providerCfg || typeof providerCfg !== 'object') return null;
-    const baseURL = typeof providerCfg?.options?.baseURL === 'string' ? providerCfg.options.baseURL.trim() : null;
-    const rawApiKey = typeof providerCfg?.options?.apiKey === 'string' ? providerCfg.options.apiKey.trim() : null;
-    const apiKey = rawApiKey ? resolveConfigApiKey(rawApiKey, workingDirectory, providerID) : null;
-    return {
-      baseURL,
-      // Shape the config-supplied key as a regular api-key auth entry so it
-      // can win the precedence check below and flow through the dispatch's
-      // `entry.type === 'api' ? entry.key : ...` branch unchanged.
-      auth: apiKey ? { type: 'api', key: apiKey } : null,
-    };
+    return parseProviderConfig(config?.provider?.[providerID], workingDirectory, providerID);
   } catch {
     // Provider config is non-essential — continue with catalog-only resolution.
     return null;
   }
-}
+};
+
+/**
+ * Provider ids whose configured API keys resolve successfully. Credential
+ * values stay inside this module and are never returned to picker callers.
+ */
+export const listConfiguredProviderAuthIds = (workingDirectory) => {
+  let providers;
+  try {
+    const config = readConfig(workingDirectory);
+    providers = config?.provider;
+  } catch {
+    return [];
+  }
+
+  if (!providers || typeof providers !== 'object' || Array.isArray(providers)) return [];
+
+  const ids = [];
+  for (const [providerID, providerCfg] of Object.entries(providers)) {
+    try {
+      const providerConfig = parseProviderConfig(providerCfg, workingDirectory, providerID);
+      if (providerConfig?.auth) ids.push(providerID);
+    } catch {
+      // One invalid key reference must not hide other configured providers.
+    }
+  }
+  return ids;
+};
 
 // ---------------------------------------------------------------------------
 // Dispatch

--- a/packages/web/server/lib/small-model/call.test.js
+++ b/packages/web/server/lib/small-model/call.test.js
@@ -3,16 +3,14 @@ import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// readConfig reads merged opencode config layers from disk; mock it so each
-// test controls the provider config without touching the filesystem. call.js
-// imports only readConfig from shared.js, so the rest of that module is left
-// untouched for this file.
+// These helpers read merged OpenCode config layers from disk; mock them so
+// each test controls provider config without touching real configuration.
 vi.mock('../opencode/shared.js', () => ({
   readConfig: vi.fn(),
   readConfigLayers: vi.fn(),
 }));
 
-const { callSmallModel } = await import('./call.js');
+const { callSmallModel, listConfiguredProviderAuthIds } = await import('./call.js');
 const { readConfig, readConfigLayers } = await import('../opencode/shared.js');
 
 // Minimal catalog fragment used by the catalog-based base URL resolution case.
@@ -61,9 +59,40 @@ describe('callSmallModel — custom provider config', () => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
     delete process.env.OPENCHAMBER_TEST_PROVIDER_KEY;
+    delete process.env.OPENCHAMBER_MISSING_PROVIDER_KEY;
   });
 
   describe('config-supplied credentials (no auth.json entry)', () => {
+    it('lists only providers whose configured API keys resolve', () => {
+      const secretPath = path.join(os.homedir(), '.provider-key');
+      const originalReadFileSync = fs.readFileSync;
+      vi.spyOn(fs, 'readFileSync').mockImplementation((filePath, ...args) => {
+        if (filePath === secretPath) return 'file-key\n';
+        if (filePath === path.join(os.homedir(), '.missing-provider-key')) {
+          throw new Error('missing');
+        }
+        return originalReadFileSync(filePath, ...args);
+      });
+      process.env.OPENCHAMBER_TEST_PROVIDER_KEY = 'environment-key';
+      delete process.env.OPENCHAMBER_MISSING_PROVIDER_KEY;
+      readConfig.mockReturnValue({
+        provider: {
+          literal: { options: { apiKey: 'literal-key' } },
+          environment: { options: { apiKey: '{env:OPENCHAMBER_TEST_PROVIDER_KEY}' } },
+          file: { options: { apiKey: '{file:~/.provider-key}' } },
+          blank: { options: { apiKey: '   ' } },
+          unresolvedEnvironment: { options: { apiKey: '{env:OPENCHAMBER_MISSING_PROVIDER_KEY}' } },
+          unresolvedFile: { options: { apiKey: '{file:~/.missing-provider-key}' } },
+        },
+      });
+
+      expect(listConfiguredProviderAuthIds('/proj')).toEqual([
+        'literal',
+        'environment',
+        'file',
+      ]);
+    });
+
     it('resolves an OpenCode file variable before sending the API key', async () => {
       const secretPath = path.join(os.homedir(), '.secret');
       const originalReadFileSync = fs.readFileSync;

--- a/packages/web/server/lib/small-model/index.js
+++ b/packages/web/server/lib/small-model/index.js
@@ -5,7 +5,7 @@ import { readAuthFile } from '../opencode/auth.js';
 import { readConfigLayers } from '../opencode/shared.js';
 import { getModelCatalog } from './catalog.js';
 import { resolveSmallModel, parseModelRef, isUsableAuthEntry, getAuthEntryForProvider } from './resolve.js';
-import { callSmallModel } from './call.js';
+import { callSmallModel, listConfiguredProviderAuthIds } from './call.js';
 
 const OPENCHAMBER_SETTINGS_FILE = path.join(
   process.env.OPENCHAMBER_DATA_DIR
@@ -129,9 +129,10 @@ export async function generateSmallModelText({ prompt, system, maxOutputTokens, 
 }
 
 /**
- * Provider ids with a usable OpenCode login — the set the small model can
- * actually call. Used by the settings override picker to hide providers that
- * would only ever fail (e.g. opencode free models without a token).
+ * Provider ids with a usable OpenCode login or configured API key — the set
+ * the small model can actually call. Used by the settings override picker to
+ * hide providers that would only ever fail (e.g. opencode free models without
+ * a token).
  */
 export function listAuthenticatedProviders() {
   try {
@@ -139,6 +140,9 @@ export function listAuthenticatedProviders() {
     const ids = new Set(
       Object.keys(auth || {}).filter((providerID) => isUsableAuthEntry(auth[providerID])),
     );
+    for (const providerID of listConfiguredProviderAuthIds()) {
+      ids.add(providerID);
+    }
     // The catalog id is github-copilot while legacy auth entries may sit
     // under the copilot alias.
     if (isUsableAuthEntry(getAuthEntryForProvider(auth, 'github-copilot'))) {

--- a/packages/web/server/lib/small-model/index.test.js
+++ b/packages/web/server/lib/small-model/index.test.js
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../opencode/auth.js', () => ({
+  readAuthFile: vi.fn(),
+  writeAuthFile: vi.fn(),
+}));
+
+vi.mock('../opencode/shared.js', () => ({
+  readConfig: vi.fn(),
+  readConfigLayers: vi.fn(),
+}));
+
+const { readAuthFile } = await import('../opencode/auth.js');
+const { readConfig } = await import('../opencode/shared.js');
+const { listAuthenticatedProviders } = await import('./index.js');
+
+beforeEach(() => {
+  readAuthFile.mockReset();
+  readConfig.mockReset();
+});
+
+describe('listAuthenticatedProviders', () => {
+  it('includes and deduplicates providers authenticated through config', () => {
+    readAuthFile.mockReturnValue({
+      openai: { type: 'api', key: 'auth-key' },
+    });
+    readConfig.mockReturnValue({
+      provider: {
+        custom: { options: { apiKey: 'config-key' } },
+        openai: { options: { apiKey: 'config-openai-key' } },
+      },
+    });
+
+    expect(listAuthenticatedProviders()).toEqual(['openai', 'custom']);
+  });
+
+  it('keeps unusable auth entries out while including config-authenticated ids', () => {
+    readAuthFile.mockReturnValue({
+      anthropic: { type: 'api', key: '' },
+      openai: { type: 'oauth' },
+    });
+    readConfig.mockReturnValue({
+      provider: {
+        custom: { options: { apiKey: 'config-key' } },
+        blank: { options: { apiKey: '   ' } },
+      },
+    });
+
+    expect(listAuthenticatedProviders()).toEqual(['custom']);
+  });
+});


### PR DESCRIPTION
## Summary

Include providers authenticated through `provider.<id>.options.apiKey` in the Small Model override picker.

## Why

The Small Model picker introduced in #2049 limits its provider list to `authenticatedProviders`. After #2134 and #2135, the call path can resolve a custom provider's API key and endpoint directly from OpenCode configuration, but provider discovery still reads only `auth.json`.

As a result, a provider can be callable by `callSmallModel()` while remaining impossible to select in Settings.

This is complementary to #2132 and #2143: those cover providers that require no authentication, while this change covers providers authenticated through configuration.

## What changed

- Reuse the existing literal, `{env:...}`, and `{file:...}` API-key resolution when discovering configured providers.
- Add only provider IDs whose configured keys resolve successfully to `listAuthenticatedProviders()`.
- Keep credential values inside the server module; picker callers receive IDs only.
- Skip one invalid key reference without hiding other valid configured providers.
- Add focused regression tests and update the Small Model module documentation.

## Security and compatibility

- No credential values are returned, persisted, or logged.
- Existing `auth.json` handling and provider aliases are unchanged.
- No route or UI response shape changes are required.
- If #2143 lands, its selectable-provider union will automatically include these config-authenticated providers.

## Verification

- [x] `bun run --cwd packages/web test -- server/lib/small-model` — 37 tests passed
- [x] `bun run type-check`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run dead-code` — completed with the repository's existing non-blocking report; the new export was not flagged

## Related

- Follow-up to #2049
- Completes the picker-side support associated with #2134 and #2135
- Related to #2132 and #2143
