### PR TITLE
fix(discord): /model wizard back buttons + larger model pages

### DIFF
--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -399,11 +399,17 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     const [mobileModelQuery, setMobileModelQuery] = React.useState('');
     const [expandedMobileModelKey, setExpandedMobileModelKey] = React.useState<string | null>(null);
     const [mobileVariantTarget, setMobileVariantTarget] = React.useState<MobileVariantTarget | null>(null);
-    const [mobileFocusedProviderId, setMobileFocusedProviderId] = React.useState<string | null>(null);
     const manualVariantSelectionRef = React.useRef(false);
     const closeMobilePanel = React.useCallback(() => setActiveMobilePanel(null), [setActiveMobilePanel]);
     const closeMobileTooltip = React.useCallback(() => setMobileTooltipOpen(null), []);
     const longPressTimerRef = React.useRef<NodeJS.Timeout | undefined>(undefined);
+    const [expandedMobileProviders, setExpandedMobileProviders] = React.useState<Set<string>>(() => {
+        const initial = new Set<string>();
+        if (currentProviderId) {
+            initial.add(currentProviderId);
+        }
+        return initial;
+    });
     // Use global state for model selector (allows Ctrl+M shortcut)
     const agentMenuOpen = isModelSelectorOpen;
     const setAgentMenuOpen = setModelSelectorOpen;
@@ -423,18 +429,30 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     const [modelPickerRenderVersion, setModelPickerRenderVersion] = React.useState(0);
 
     React.useEffect(() => {
+        if (activeMobilePanel === 'model') {
+            setExpandedMobileProviders(() => {
+                const initial = new Set<string>();
+                if (currentProviderId) {
+                    initial.add(currentProviderId);
+                }
+                return initial;
+            });
+        }
+    }, [activeMobilePanel, currentProviderId]);
+
+    React.useEffect(() => {
         if (activeMobilePanel === null) {
             setExpandedMobileModelKey(null);
-            setMobileFocusedProviderId(null);
-            setMobileModelQuery('');
         }
         if (activeMobilePanel !== 'variant') {
             setMobileVariantTarget(null);
         }
-        if (activeMobilePanel !== 'model' && activeMobilePanel !== 'variant') {
+    }, [activeMobilePanel]);
+
+    React.useEffect(() => {
+        if (activeMobilePanel !== 'model') {
             setMobileModelQuery('');
             setExpandedMobileModelKey(null);
-            setMobileFocusedProviderId(null);
         }
     }, [activeMobilePanel]);
 
@@ -1284,6 +1302,18 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
         return name.charAt(0).toUpperCase() + name.slice(1);
     };
 
+    const toggleMobileProviderExpansion = React.useCallback((providerId: string) => {
+        setExpandedMobileProviders((prev) => {
+            const next = new Set(prev);
+            if (next.has(providerId)) {
+                next.delete(providerId);
+            } else {
+                next.add(providerId);
+            }
+            return next;
+        });
+    }, []);
+
     const handleLongPressStart = React.useCallback((type: 'model' | 'agent') => {
         if (longPressTimerRef.current) {
             clearTimeout(longPressTimerRef.current);
@@ -1767,85 +1797,41 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
         };
 
         const hasResults = filteredFavorites.length > 0 || filteredRecents.length > 0 || filteredProviders.length > 0;
-        const isSearching = normalizedQuery.length > 0;
-        const focusedProvider = !isSearching && mobileFocusedProviderId
-            ? visibleProviders.find((provider) => provider.id === mobileFocusedProviderId) ?? null
-            : null;
-        const focusedProviderModels = focusedProvider
-            ? (Array.isArray(focusedProvider.models) ? focusedProvider.models : [])
-            : [];
-        const panelTitle = focusedProvider
-            ? (focusedProvider.name || focusedProvider.id)
-            : t('chat.modelControls.selectModel');
-
-        const handleProviderBack = () => {
-            setMobileFocusedProviderId(null);
-            setExpandedMobileModelKey(null);
-        };
-
-        const openProviderMenu = (providerId: string) => {
-            setMobileFocusedProviderId(providerId);
-            setExpandedMobileModelKey(null);
-        };
 
         return (
             <MobileOverlayPanel
                 open={activeMobilePanel === 'model'}
                 onClose={closeMobilePanel}
-                title={panelTitle}
-                renderHeader={focusedProvider ? ((closeButton) => (
-                    <div className="flex items-center justify-between px-3 py-2 border-b border-border/40">
-                        <button
-                            type="button"
-                            onClick={handleProviderBack}
-                            className="flex items-center gap-1 rounded-lg px-1.5 py-1 typography-meta text-muted-foreground hover:bg-interactive-hover"
-                        >
-                            <Icon name="arrow-go-back" className="size-4" />
-                            <span>{t('onboarding.common.actions.back')}</span>
-                        </button>
-                        <div className="flex min-w-0 items-center gap-1.5">
-                            <ProviderLogo providerId={focusedProvider.id} className="size-3.5 flex-shrink-0" />
-                            <h2 className="typography-ui-label font-semibold text-foreground truncate">
-                                {focusedProvider.name || focusedProvider.id}
-                            </h2>
-                        </div>
-                        {closeButton}
-                    </div>
-                )) : undefined}
+                title={t('chat.modelControls.selectModel')}
             >
                 <div className="flex flex-col gap-2">
-                    {!focusedProvider ? (
-                        <div>
-                            <div className="relative">
-                                <Icon name="search" className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
-                                <Input
-                                    value={mobileModelQuery}
-                                    onChange={(event) => {
-                                        setMobileModelQuery(event.target.value);
+                    <div>
+                        <div className="relative">
+                            <Icon name="search" className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+                            <Input
+                                value={mobileModelQuery}
+                                onChange={(event) => {
+                                    setMobileModelQuery(event.target.value);
+                                    setExpandedMobileModelKey(null);
+                                }}
+                                        placeholder={t('chat.modelControls.searchProvidersOrModels')}
+                                className="pl-7 h-9 rounded-xl border-border/40 bg-[var(--surface-elevated)] typography-meta"
+                            />
+                            {mobileModelQuery && (
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setMobileModelQuery('');
                                         setExpandedMobileModelKey(null);
-                                        if (event.target.value.trim().length > 0) {
-                                            setMobileFocusedProviderId(null);
-                                        }
                                     }}
-                                    placeholder={t('chat.modelControls.searchProvidersOrModels')}
-                                    className="pl-7 h-9 rounded-xl border-border/40 bg-[var(--surface-elevated)] typography-meta"
-                                />
-                                {mobileModelQuery && (
-                                    <button
-                                        type="button"
-                                        onClick={() => {
-                                            setMobileModelQuery('');
-                                            setExpandedMobileModelKey(null);
-                                        }}
-                                        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                                        aria-label={t('chat.modelControls.clearSearch')}
-                                    >
-                                        <Icon name="close-circle" className="size-4" />
-                                    </button>
-                                )}
-                            </div>
+                                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                                    aria-label={t('chat.modelControls.clearSearch')}
+                                >
+                                    <Icon name="close-circle" className="size-4" />
+                                </button>
+                            )}
                         </div>
-                    ) : null}
+                    </div>
 
                     {!hasResults && (
                         <div className="px-3 py-8 text-center typography-meta text-muted-foreground">
@@ -1853,116 +1839,95 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                         </div>
                     )}
 
-                    {focusedProvider ? (
-                        focusedProviderModels.length > 0 ? (
-                            <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
-                                <div className="flex flex-col">
-                                    {focusedProviderModels.map((model: ProviderModel) => renderMobileModelRow({
-                                        model,
-                                        providerId: focusedProvider.id as string,
-                                        modelId: model.id as string,
-                                        showProviderLogo: false,
-                                    }))}
-                                </div>
+                    {/* Favorites Section for Mobile */}
+                    {filteredFavorites.length > 0 && (
+                        <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
+                            <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                                <Icon name="star-fill" className="size-3 inline-block mr-1.5 text-primary" />
+                                {t('chat.modelControls.favorites')}
                             </div>
-                        ) : (
-                            <div className="px-3 py-8 text-center typography-meta text-muted-foreground">
-                                {t('chat.modelControls.noProvidersOrModelsFound')}
+                            <div className="flex flex-col border-t border-border/30">
+                                {filteredFavorites.map(({ model, providerID, modelID }) => renderMobileModelRow({
+                                    model,
+                                    providerId: providerID,
+                                    modelId: modelID,
+                                    showProviderLogo: true,
+                                }))}
                             </div>
-                        )
-                    ) : (
-                        <>
-                            {/* Favorites Section for Mobile */}
-                            {filteredFavorites.length > 0 && (
-                                <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
-                                    <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                                        <Icon name="star-fill" className="size-3 inline-block mr-1.5 text-primary" />
-                                        {t('chat.modelControls.favorites')}
-                                    </div>
-                                    <div className="flex flex-col border-t border-border/30">
-                                        {filteredFavorites.map(({ model, providerID, modelID }) => renderMobileModelRow({
-                                            model,
-                                            providerId: providerID,
-                                            modelId: modelID,
-                                            showProviderLogo: true,
-                                        }))}
-                                    </div>
-                                </div>
-                            )}
+                        </div>
+                    )}
 
-                            {/* Recent Section for Mobile */}
-                            {filteredRecents.length > 0 && (
-                                <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
-                                    <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                                        <Icon name="time" className="size-3 inline-block mr-1.5" />
-                                        {t('chat.modelControls.recent')}
-                                    </div>
-                                    <div className="flex flex-col border-t border-border/30">
-                                        {filteredRecents.map(({ model, providerID, modelID }) => renderMobileModelRow({
-                                            model,
-                                            providerId: providerID,
-                                            modelId: modelID,
-                                            showProviderLogo: true,
-                                        }))}
-                                    </div>
-                                </div>
-                            )}
+                    {/* Recent Section for Mobile */}
+                    {filteredRecents.length > 0 && (
+                        <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
+                            <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                                <Icon name="time" className="size-3 inline-block mr-1.5" />
+                                {t('chat.modelControls.recent')}
+                            </div>
+                            <div className="flex flex-col border-t border-border/30">
+                                {filteredRecents.map(({ model, providerID, modelID }) => renderMobileModelRow({
+                                    model,
+                                    providerId: providerID,
+                                    modelId: modelID,
+                                    showProviderLogo: true,
+                                }))}
+                            </div>
+                        </div>
+                    )}
 
-                            {filteredProviders.map(({ provider, providerModels }) => {
-                                if (providerModels.length === 0) {
-                                    return null;
-                                }
+                    {filteredProviders.map(({ provider, providerModels }) => {
+                        if (providerModels.length === 0) {
+                            return null;
+                        }
 
-                                const isActiveProvider = provider.id === currentProviderId;
-                                const showInlineModels = isSearching;
+                        const isActiveProvider = provider.id === currentProviderId;
+                        const isExpanded = expandedMobileProviders.has(provider.id) || normalizedQuery.length > 0;
 
-                                return (
-                                    <div key={provider.id} className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
-                                        <button
-                                            type="button"
-                                            onClick={() => {
-                                                if (isSearching) {
-                                                    return;
-                                                }
-                                                openProviderMenu(provider.id);
-                                            }}
-                                            className="flex w-full items-center justify-between gap-1.5 px-2 py-1.5 text-left"
-                                            aria-expanded={showInlineModels}
-                                        >
-                                            <div className="flex items-center gap-2">
-                                                <ProviderLogo
-                                                    providerId={provider.id}
-                                                    className="size-3.5"
-                                                />
-                                                <span className="typography-meta font-medium text-foreground">
-                                                    {provider.name}
-                                                </span>
-                                                {isActiveProvider && (
-                                                    <span className="typography-micro text-primary/80">{t('chat.modelControls.current')}</span>
-                                                )}
-                                            </div>
-                                            {showInlineModels ? (
-                                                <Icon name="arrow-down-s" className="size-3 text-muted-foreground" />
-                                            ) : (
-                                                <Icon name="arrow-right-s" className="size-3 text-muted-foreground" />
-                                            )}
-                                        </button>
-
-                                        {showInlineModels && providerModels.length > 0 && (
-                                            <div className="flex flex-col border-t border-border/30">
-                                                {providerModels.map((model: ProviderModel) => renderMobileModelRow({
-                                                    model,
-                                                    providerId: provider.id as string,
-                                                    modelId: model.id as string,
-                                                    showProviderLogo: false,
-                                                }))}
-                                            </div>
+                         return (
+                             <div key={provider.id} className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        if (normalizedQuery.length > 0) {
+                                            return;
+                                        }
+                                        toggleMobileProviderExpansion(provider.id);
+                                    }}
+                                    className="flex w-full items-center justify-between gap-1.5 px-2 py-1.5 text-left"
+                                    aria-expanded={isExpanded}
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <ProviderLogo
+                                            providerId={provider.id}
+                                            className="size-3.5"
+                                        />
+                                        <span className="typography-meta font-medium text-foreground">
+                                            {provider.name}
+                                        </span>
+                                        {isActiveProvider && (
+                                            <span className="typography-micro text-primary/80">{t('chat.modelControls.current')}</span>
                                         )}
                                     </div>
-                                );
-                            })}
-                        </>
-                    )}
+                                    {isExpanded ? (
+                                        <Icon name="arrow-down-s" className="size-3 text-muted-foreground" />
+                                    ) : (
+                                        <Icon name="arrow-right-s" className="size-3 text-muted-foreground" />
+                                    )}
+                                </button>
+
+                                {isExpanded && providerModels.length > 0 && (
+                                    <div className="flex flex-col border-t border-border/30">
+                                        {providerModels.map((model: ProviderModel) => renderMobileModelRow({
+                                            model,
+                                            providerId: provider.id as string,
+                                            modelId: model.id as string,
+                                            showProviderLogo: false,
+                                        }))}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    })}
                 </div>
             </MobileOverlayPanel>
         );

--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -399,17 +399,11 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     const [mobileModelQuery, setMobileModelQuery] = React.useState('');
     const [expandedMobileModelKey, setExpandedMobileModelKey] = React.useState<string | null>(null);
     const [mobileVariantTarget, setMobileVariantTarget] = React.useState<MobileVariantTarget | null>(null);
+    const [mobileFocusedProviderId, setMobileFocusedProviderId] = React.useState<string | null>(null);
     const manualVariantSelectionRef = React.useRef(false);
     const closeMobilePanel = React.useCallback(() => setActiveMobilePanel(null), [setActiveMobilePanel]);
     const closeMobileTooltip = React.useCallback(() => setMobileTooltipOpen(null), []);
     const longPressTimerRef = React.useRef<NodeJS.Timeout | undefined>(undefined);
-    const [expandedMobileProviders, setExpandedMobileProviders] = React.useState<Set<string>>(() => {
-        const initial = new Set<string>();
-        if (currentProviderId) {
-            initial.add(currentProviderId);
-        }
-        return initial;
-    });
     // Use global state for model selector (allows Ctrl+M shortcut)
     const agentMenuOpen = isModelSelectorOpen;
     const setAgentMenuOpen = setModelSelectorOpen;
@@ -429,30 +423,18 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     const [modelPickerRenderVersion, setModelPickerRenderVersion] = React.useState(0);
 
     React.useEffect(() => {
-        if (activeMobilePanel === 'model') {
-            setExpandedMobileProviders(() => {
-                const initial = new Set<string>();
-                if (currentProviderId) {
-                    initial.add(currentProviderId);
-                }
-                return initial;
-            });
-        }
-    }, [activeMobilePanel, currentProviderId]);
-
-    React.useEffect(() => {
         if (activeMobilePanel === null) {
             setExpandedMobileModelKey(null);
+            setMobileFocusedProviderId(null);
+            setMobileModelQuery('');
         }
         if (activeMobilePanel !== 'variant') {
             setMobileVariantTarget(null);
         }
-    }, [activeMobilePanel]);
-
-    React.useEffect(() => {
-        if (activeMobilePanel !== 'model') {
+        if (activeMobilePanel !== 'model' && activeMobilePanel !== 'variant') {
             setMobileModelQuery('');
             setExpandedMobileModelKey(null);
+            setMobileFocusedProviderId(null);
         }
     }, [activeMobilePanel]);
 
@@ -1302,18 +1284,6 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
         return name.charAt(0).toUpperCase() + name.slice(1);
     };
 
-    const toggleMobileProviderExpansion = React.useCallback((providerId: string) => {
-        setExpandedMobileProviders((prev) => {
-            const next = new Set(prev);
-            if (next.has(providerId)) {
-                next.delete(providerId);
-            } else {
-                next.add(providerId);
-            }
-            return next;
-        });
-    }, []);
-
     const handleLongPressStart = React.useCallback((type: 'model' | 'agent') => {
         if (longPressTimerRef.current) {
             clearTimeout(longPressTimerRef.current);
@@ -1797,41 +1767,85 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
         };
 
         const hasResults = filteredFavorites.length > 0 || filteredRecents.length > 0 || filteredProviders.length > 0;
+        const isSearching = normalizedQuery.length > 0;
+        const focusedProvider = !isSearching && mobileFocusedProviderId
+            ? visibleProviders.find((provider) => provider.id === mobileFocusedProviderId) ?? null
+            : null;
+        const focusedProviderModels = focusedProvider
+            ? (Array.isArray(focusedProvider.models) ? focusedProvider.models : [])
+            : [];
+        const panelTitle = focusedProvider
+            ? (focusedProvider.name || focusedProvider.id)
+            : t('chat.modelControls.selectModel');
+
+        const handleProviderBack = () => {
+            setMobileFocusedProviderId(null);
+            setExpandedMobileModelKey(null);
+        };
+
+        const openProviderMenu = (providerId: string) => {
+            setMobileFocusedProviderId(providerId);
+            setExpandedMobileModelKey(null);
+        };
 
         return (
             <MobileOverlayPanel
                 open={activeMobilePanel === 'model'}
                 onClose={closeMobilePanel}
-                title={t('chat.modelControls.selectModel')}
+                title={panelTitle}
+                renderHeader={focusedProvider ? ((closeButton) => (
+                    <div className="flex items-center justify-between px-3 py-2 border-b border-border/40">
+                        <button
+                            type="button"
+                            onClick={handleProviderBack}
+                            className="flex items-center gap-1 rounded-lg px-1.5 py-1 typography-meta text-muted-foreground hover:bg-interactive-hover"
+                        >
+                            <Icon name="arrow-go-back" className="size-4" />
+                            <span>{t('onboarding.common.actions.back')}</span>
+                        </button>
+                        <div className="flex min-w-0 items-center gap-1.5">
+                            <ProviderLogo providerId={focusedProvider.id} className="size-3.5 flex-shrink-0" />
+                            <h2 className="typography-ui-label font-semibold text-foreground truncate">
+                                {focusedProvider.name || focusedProvider.id}
+                            </h2>
+                        </div>
+                        {closeButton}
+                    </div>
+                )) : undefined}
             >
                 <div className="flex flex-col gap-2">
-                    <div>
-                        <div className="relative">
-                            <Icon name="search" className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
-                            <Input
-                                value={mobileModelQuery}
-                                onChange={(event) => {
-                                    setMobileModelQuery(event.target.value);
-                                    setExpandedMobileModelKey(null);
-                                }}
-                                        placeholder={t('chat.modelControls.searchProvidersOrModels')}
-                                className="pl-7 h-9 rounded-xl border-border/40 bg-[var(--surface-elevated)] typography-meta"
-                            />
-                            {mobileModelQuery && (
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        setMobileModelQuery('');
+                    {!focusedProvider ? (
+                        <div>
+                            <div className="relative">
+                                <Icon name="search" className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+                                <Input
+                                    value={mobileModelQuery}
+                                    onChange={(event) => {
+                                        setMobileModelQuery(event.target.value);
                                         setExpandedMobileModelKey(null);
+                                        if (event.target.value.trim().length > 0) {
+                                            setMobileFocusedProviderId(null);
+                                        }
                                     }}
-                                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                                    aria-label={t('chat.modelControls.clearSearch')}
-                                >
-                                    <Icon name="close-circle" className="size-4" />
-                                </button>
-                            )}
+                                    placeholder={t('chat.modelControls.searchProvidersOrModels')}
+                                    className="pl-7 h-9 rounded-xl border-border/40 bg-[var(--surface-elevated)] typography-meta"
+                                />
+                                {mobileModelQuery && (
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setMobileModelQuery('');
+                                            setExpandedMobileModelKey(null);
+                                        }}
+                                        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                                        aria-label={t('chat.modelControls.clearSearch')}
+                                    >
+                                        <Icon name="close-circle" className="size-4" />
+                                    </button>
+                                )}
+                            </div>
                         </div>
-                    </div>
+                    ) : null}
 
                     {!hasResults && (
                         <div className="px-3 py-8 text-center typography-meta text-muted-foreground">
@@ -1839,95 +1853,116 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                         </div>
                     )}
 
-                    {/* Favorites Section for Mobile */}
-                    {filteredFavorites.length > 0 && (
-                        <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
-                            <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                                <Icon name="star-fill" className="size-3 inline-block mr-1.5 text-primary" />
-                                {t('chat.modelControls.favorites')}
+                    {focusedProvider ? (
+                        focusedProviderModels.length > 0 ? (
+                            <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
+                                <div className="flex flex-col">
+                                    {focusedProviderModels.map((model: ProviderModel) => renderMobileModelRow({
+                                        model,
+                                        providerId: focusedProvider.id as string,
+                                        modelId: model.id as string,
+                                        showProviderLogo: false,
+                                    }))}
+                                </div>
                             </div>
-                            <div className="flex flex-col border-t border-border/30">
-                                {filteredFavorites.map(({ model, providerID, modelID }) => renderMobileModelRow({
-                                    model,
-                                    providerId: providerID,
-                                    modelId: modelID,
-                                    showProviderLogo: true,
-                                }))}
+                        ) : (
+                            <div className="px-3 py-8 text-center typography-meta text-muted-foreground">
+                                {t('chat.modelControls.noProvidersOrModelsFound')}
                             </div>
-                        </div>
-                    )}
-
-                    {/* Recent Section for Mobile */}
-                    {filteredRecents.length > 0 && (
-                        <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
-                            <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                                <Icon name="time" className="size-3 inline-block mr-1.5" />
-                                {t('chat.modelControls.recent')}
-                            </div>
-                            <div className="flex flex-col border-t border-border/30">
-                                {filteredRecents.map(({ model, providerID, modelID }) => renderMobileModelRow({
-                                    model,
-                                    providerId: providerID,
-                                    modelId: modelID,
-                                    showProviderLogo: true,
-                                }))}
-                            </div>
-                        </div>
-                    )}
-
-                    {filteredProviders.map(({ provider, providerModels }) => {
-                        if (providerModels.length === 0) {
-                            return null;
-                        }
-
-                        const isActiveProvider = provider.id === currentProviderId;
-                        const isExpanded = expandedMobileProviders.has(provider.id) || normalizedQuery.length > 0;
-
-                         return (
-                             <div key={provider.id} className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        if (normalizedQuery.length > 0) {
-                                            return;
-                                        }
-                                        toggleMobileProviderExpansion(provider.id);
-                                    }}
-                                    className="flex w-full items-center justify-between gap-1.5 px-2 py-1.5 text-left"
-                                    aria-expanded={isExpanded}
-                                >
-                                    <div className="flex items-center gap-2">
-                                        <ProviderLogo
-                                            providerId={provider.id}
-                                            className="size-3.5"
-                                        />
-                                        <span className="typography-meta font-medium text-foreground">
-                                            {provider.name}
-                                        </span>
-                                        {isActiveProvider && (
-                                            <span className="typography-micro text-primary/80">{t('chat.modelControls.current')}</span>
-                                        )}
+                        )
+                    ) : (
+                        <>
+                            {/* Favorites Section for Mobile */}
+                            {filteredFavorites.length > 0 && (
+                                <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
+                                    <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                                        <Icon name="star-fill" className="size-3 inline-block mr-1.5 text-primary" />
+                                        {t('chat.modelControls.favorites')}
                                     </div>
-                                    {isExpanded ? (
-                                        <Icon name="arrow-down-s" className="size-3 text-muted-foreground" />
-                                    ) : (
-                                        <Icon name="arrow-right-s" className="size-3 text-muted-foreground" />
-                                    )}
-                                </button>
-
-                                {isExpanded && providerModels.length > 0 && (
                                     <div className="flex flex-col border-t border-border/30">
-                                        {providerModels.map((model: ProviderModel) => renderMobileModelRow({
+                                        {filteredFavorites.map(({ model, providerID, modelID }) => renderMobileModelRow({
                                             model,
-                                            providerId: provider.id as string,
-                                            modelId: model.id as string,
-                                            showProviderLogo: false,
+                                            providerId: providerID,
+                                            modelId: modelID,
+                                            showProviderLogo: true,
                                         }))}
                                     </div>
-                                )}
-                            </div>
-                        );
-                    })}
+                                </div>
+                            )}
+
+                            {/* Recent Section for Mobile */}
+                            {filteredRecents.length > 0 && (
+                                <div className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
+                                    <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                                        <Icon name="time" className="size-3 inline-block mr-1.5" />
+                                        {t('chat.modelControls.recent')}
+                                    </div>
+                                    <div className="flex flex-col border-t border-border/30">
+                                        {filteredRecents.map(({ model, providerID, modelID }) => renderMobileModelRow({
+                                            model,
+                                            providerId: providerID,
+                                            modelId: modelID,
+                                            showProviderLogo: true,
+                                        }))}
+                                    </div>
+                                </div>
+                            )}
+
+                            {filteredProviders.map(({ provider, providerModels }) => {
+                                if (providerModels.length === 0) {
+                                    return null;
+                                }
+
+                                const isActiveProvider = provider.id === currentProviderId;
+                                const showInlineModels = isSearching;
+
+                                return (
+                                    <div key={provider.id} className="rounded-xl border border-border/40 bg-[var(--surface-elevated)] overflow-hidden">
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                if (isSearching) {
+                                                    return;
+                                                }
+                                                openProviderMenu(provider.id);
+                                            }}
+                                            className="flex w-full items-center justify-between gap-1.5 px-2 py-1.5 text-left"
+                                            aria-expanded={showInlineModels}
+                                        >
+                                            <div className="flex items-center gap-2">
+                                                <ProviderLogo
+                                                    providerId={provider.id}
+                                                    className="size-3.5"
+                                                />
+                                                <span className="typography-meta font-medium text-foreground">
+                                                    {provider.name}
+                                                </span>
+                                                {isActiveProvider && (
+                                                    <span className="typography-micro text-primary/80">{t('chat.modelControls.current')}</span>
+                                                )}
+                                            </div>
+                                            {showInlineModels ? (
+                                                <Icon name="arrow-down-s" className="size-3 text-muted-foreground" />
+                                            ) : (
+                                                <Icon name="arrow-right-s" className="size-3 text-muted-foreground" />
+                                            )}
+                                        </button>
+
+                                        {showInlineModels && providerModels.length > 0 && (
+                                            <div className="flex flex-col border-t border-border/30">
+                                                {providerModels.map((model: ProviderModel) => renderMobileModelRow({
+                                                    model,
+                                                    providerId: provider.id as string,
+                                                    modelId: model.id as string,
+                                                    showProviderLogo: false,
+                                                }))}
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </>
+                    )}
                 </div>
             </MobileOverlayPanel>
         );

--- a/packages/web/server/lib/messenger/discord-model-wizard.js
+++ b/packages/web/server/lib/messenger/discord-model-wizard.js
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import {
   WIZARD_TTL_MS,
   PAGE_SIZE,
+  PAGE_SIZE_WITH_BUTTON_NAV,
   PREV_VALUE,
   NEXT_VALUE,
   buildPagedOptions,
@@ -18,16 +19,19 @@ import {
  *   /model → (shows the current model + thinking-effort)
  *          → pick provider (⭐ Favourites pseudo-provider first when the UI has
  *            any favourite models)
- *          → pick model
+ *          → pick model (Back → providers; page nav via buttons)
  *          → pick thinking-effort (only when the model exposes reasoning
- *            variants; skipped otherwise)
- *          → pick scope (this conversation / this project / whole system)
+ *            variants; skipped otherwise; Back → models)
+ *          → pick scope (this conversation / this project / whole system;
+ *            Back → effort or models)
  *          → confirmation + a "Send last message" button that replays the
  *            conversation's last prompt under the freshly-chosen model.
  *
- * Discord string-select menus are capped at 25 options, so provider / model
- * lists are paged via the shared helpers. Wizard state is keyed by a short
- * random hash embedded in each component's `custom_id` and expires after
+ * Discord string-select menus are capped at 25 options. Provider lists keep
+ * in-select prev/next paging; model lists use the full 25 slots with Back /
+ * page buttons underneath so users can always return to the previous menu
+ * section even while paginating. Wizard state is keyed by a short random
+ * hash embedded in each component's `custom_id` and expires after
  * {@link WIZARD_TTL_MS}.
  *
  * Kept free of gateway/WebSocket plumbing so it can be unit-tested in
@@ -35,16 +39,25 @@ import {
  */
 
 // Re-exported for callers/tests that import the paging helpers from here.
-export { WIZARD_TTL_MS, PAGE_SIZE, buildPagedOptions };
+export { WIZARD_TTL_MS, PAGE_SIZE, PAGE_SIZE_WITH_BUTTON_NAV, buildPagedOptions };
 
 const PROVIDER_PREFIX = 'openchamber-agent-model-provider:';
 const MODEL_PREFIX = 'openchamber-agent-model-model:';
 const EFFORT_PREFIX = 'openchamber-agent-model-effort:';
 const SCOPE_PREFIX = 'openchamber-agent-model-scope:';
 const RESEND_PREFIX = 'openchamber-agent-model-resend:';
+const BACK_PREFIX = 'openchamber-agent-model-back:';
+const MODEL_PAGE_PREV_PREFIX = 'openchamber-agent-model-page-prev:';
+const MODEL_PAGE_NEXT_PREFIX = 'openchamber-agent-model-page-next:';
 
 const FAVORITES_ID = '__openchamber_agent_favorites';
 const EFFORT_NONE = '__openchamber_agent_effort_none';
+
+/** Wizard stages that support a Back button (provider select is the root). */
+const STAGE_PROVIDER = 'provider';
+const STAGE_MODEL = 'model';
+const STAGE_EFFORT = 'effort';
+const STAGE_SCOPE = 'scope';
 
 /** Normalise a provider's `models` (array or map) into a flat array. */
 export function modelsOf(provider) {
@@ -134,7 +147,10 @@ export function createDiscordModelWizard({ restCall, bridge }) {
         customId.startsWith(MODEL_PREFIX) ||
         customId.startsWith(EFFORT_PREFIX) ||
         customId.startsWith(SCOPE_PREFIX) ||
-        customId.startsWith(RESEND_PREFIX))
+        customId.startsWith(RESEND_PREFIX) ||
+        customId.startsWith(BACK_PREFIX) ||
+        customId.startsWith(MODEL_PAGE_PREV_PREFIX) ||
+        customId.startsWith(MODEL_PAGE_NEXT_PREFIX))
     );
   }
 
@@ -194,8 +210,28 @@ export function createDiscordModelWizard({ restCall, bridge }) {
   }
 
   function renderModelSelect(hash, models, page) {
-    const { options } = buildPagedOptions(modelOptions(models), page);
-    return stringSelect(`${MODEL_PREFIX}${hash}`, options, 'Select a model');
+    const { options, page: safePage, totalPages } = buildPagedOptions(modelOptions(models), page, {
+      includeNav: false,
+      pageSize: PAGE_SIZE_WITH_BUTTON_NAV,
+    });
+    const components = [stringSelect(`${MODEL_PREFIX}${hash}`, options, 'Select a model')];
+    const navButtons = [{ label: '← Back', customId: `${BACK_PREFIX}${hash}`, style: 2 }];
+    if (safePage > 0) {
+      navButtons.push({
+        label: `◀ Page ${safePage}/${totalPages}`,
+        customId: `${MODEL_PAGE_PREV_PREFIX}${hash}`,
+        style: 2,
+      });
+    }
+    if (safePage < totalPages - 1) {
+      navButtons.push({
+        label: `More ▶ (${safePage + 2}/${totalPages})`,
+        customId: `${MODEL_PAGE_NEXT_PREFIX}${hash}`,
+        style: 2,
+      });
+    }
+    components.push(buttonRow(navButtons));
+    return { components, page: safePage, totalPages };
   }
 
   function renderEffortSelect(hash, variants) {
@@ -203,7 +239,12 @@ export function createDiscordModelWizard({ restCall, bridge }) {
       { label: 'Default (no thinking effort)', value: EFFORT_NONE, description: 'Let the model decide' },
       ...variants.map((v) => ({ label: v, value: v, description: `Thinking effort: ${v}`.slice(0, 100) })),
     ];
-    return stringSelect(`${EFFORT_PREFIX}${hash}`, options, 'Select thinking effort');
+    return {
+      components: [
+        stringSelect(`${EFFORT_PREFIX}${hash}`, options, 'Select thinking effort'),
+        buttonRow([{ label: '← Back', customId: `${BACK_PREFIX}${hash}`, style: 2 }]),
+      ],
+    };
   }
 
   function renderScopeSelect(hash) {
@@ -212,7 +253,49 @@ export function createDiscordModelWizard({ restCall, bridge }) {
       { label: 'This project', value: 'project', description: "Default for this conversation's project" },
       { label: 'Whole system (default)', value: 'global', description: 'OpenChamber default model everywhere' },
     ];
-    return stringSelect(`${SCOPE_PREFIX}${hash}`, options, 'Apply to…');
+    return {
+      components: [
+        stringSelect(`${SCOPE_PREFIX}${hash}`, options, 'Apply to…'),
+        buttonRow([{ label: '← Back', customId: `${BACK_PREFIX}${hash}`, style: 2 }]),
+      ],
+    };
+  }
+
+  function renderProviderStep(hash, wizard) {
+    return {
+      content: '**Set model**\nSelect a provider:',
+      flags: 64,
+      components: [renderProviderSelect(hash, wizard.entries, wizard.providerPage ?? 0)],
+    };
+  }
+
+  function renderModelStep(hash, wizard) {
+    const { components } = renderModelSelect(hash, wizard.models, wizard.modelPage ?? 0);
+    return {
+      content: `**Set model**\nProvider: **${wizard.providerName}**\nSelect a model:`,
+      flags: 64,
+      components,
+    };
+  }
+
+  function renderEffortStep(hash, wizard) {
+    const variants = modelVariants(wizard, wizard.selectedProviderId, wizard.selectedModelLocal);
+    const { components } = renderEffortSelect(hash, variants);
+    return {
+      content: `**Set model**\nModel: \`${wizard.selectedModelId}\`\nSelect thinking effort:`,
+      flags: 64,
+      components,
+    };
+  }
+
+  function renderScopeStep(hash, wizard) {
+    const effortLine = wizard.selectedVariant ? ` · effort \`${wizard.selectedVariant}\`` : '';
+    const { components } = renderScopeSelect(hash);
+    return {
+      content: `**Set model**\nModel: \`${wizard.selectedModelId}\`${effortLine}\nApply to:`,
+      flags: 64,
+      components,
+    };
   }
 
   function currentLine(info) {
@@ -303,6 +386,8 @@ export function createDiscordModelWizard({ restCall, bridge }) {
       entries,
       providerPage: 0,
       modelPage: 0,
+      stage: STAGE_PROVIDER,
+      hadEffortStep: false,
     });
 
     await respond(state.token, interaction, {
@@ -330,9 +415,78 @@ export function createDiscordModelWizard({ restCall, bridge }) {
     if (customId.startsWith(SCOPE_PREFIX)) {
       return onScopeSelect(token, interaction, customId.slice(SCOPE_PREFIX.length));
     }
+    if (customId.startsWith(BACK_PREFIX)) {
+      return onBack(token, interaction, customId.slice(BACK_PREFIX.length));
+    }
+    if (customId.startsWith(MODEL_PAGE_PREV_PREFIX)) {
+      return onModelPage(token, interaction, customId.slice(MODEL_PAGE_PREV_PREFIX.length), -1);
+    }
+    if (customId.startsWith(MODEL_PAGE_NEXT_PREFIX)) {
+      return onModelPage(token, interaction, customId.slice(MODEL_PAGE_NEXT_PREFIX.length), 1);
+    }
     if (customId.startsWith(RESEND_PREFIX)) {
       return onResend(token, interaction, customId.slice(RESEND_PREFIX.length));
     }
+  }
+
+  async function onBack(token, interaction, hash) {
+    const wizard = getWizard(hash);
+    if (!wizard) return expired(token, interaction);
+
+    if (wizard.stage === STAGE_SCOPE) {
+      if (wizard.hadEffortStep) {
+        wizard.stage = STAGE_EFFORT;
+        wizard.selectedVariant = null;
+        setWizard(hash, wizard);
+        await respond(wizard.token, interaction, { type: 7, data: renderEffortStep(hash, wizard) });
+        return;
+      }
+      wizard.stage = STAGE_MODEL;
+      wizard.selectedModelId = null;
+      wizard.selectedProviderId = null;
+      wizard.selectedModelLocal = null;
+      wizard.selectedVariant = null;
+      setWizard(hash, wizard);
+      await respond(wizard.token, interaction, { type: 7, data: renderModelStep(hash, wizard) });
+      return;
+    }
+
+    if (wizard.stage === STAGE_EFFORT) {
+      wizard.stage = STAGE_MODEL;
+      wizard.selectedModelId = null;
+      wizard.selectedProviderId = null;
+      wizard.selectedModelLocal = null;
+      wizard.selectedVariant = null;
+      wizard.hadEffortStep = false;
+      setWizard(hash, wizard);
+      await respond(wizard.token, interaction, { type: 7, data: renderModelStep(hash, wizard) });
+      return;
+    }
+
+    // Model step (and any unexpected stage) → provider list. No back on the
+    // provider menu itself — that is the root of the wizard.
+    wizard.stage = STAGE_PROVIDER;
+    wizard.isFavorites = false;
+    wizard.providerId = null;
+    wizard.providerName = null;
+    wizard.models = null;
+    wizard.modelPage = 0;
+    wizard.selectedModelId = null;
+    wizard.selectedProviderId = null;
+    wizard.selectedModelLocal = null;
+    wizard.selectedVariant = null;
+    wizard.hadEffortStep = false;
+    setWizard(hash, wizard);
+    await respond(wizard.token, interaction, { type: 7, data: renderProviderStep(hash, wizard) });
+  }
+
+  async function onModelPage(token, interaction, hash, delta) {
+    const wizard = getWizard(hash);
+    if (!wizard) return expired(token, interaction);
+    wizard.modelPage = Math.max(0, (wizard.modelPage ?? 0) + delta);
+    wizard.stage = STAGE_MODEL;
+    setWizard(hash, wizard);
+    await respond(wizard.token, interaction, { type: 7, data: renderModelStep(hash, wizard) });
   }
 
   async function onProviderSelect(token, interaction, hash) {
@@ -343,14 +497,11 @@ export function createDiscordModelWizard({ restCall, bridge }) {
 
     if (value === PREV_VALUE || value === NEXT_VALUE) {
       wizard.providerPage = (wizard.providerPage ?? 0) + (value === NEXT_VALUE ? 1 : -1);
+      wizard.stage = STAGE_PROVIDER;
       setWizard(hash, wizard);
       await respond(wizard.token, interaction, {
         type: 7,
-        data: {
-          content: '**Set model**\nSelect a provider:',
-          flags: 64,
-          components: [renderProviderSelect(hash, wizard.entries, wizard.providerPage)],
-        },
+        data: renderProviderStep(hash, wizard),
       });
       return;
     }
@@ -395,15 +546,13 @@ export function createDiscordModelWizard({ restCall, bridge }) {
 
     wizard.models = models;
     wizard.modelPage = 0;
+    wizard.stage = STAGE_MODEL;
+    wizard.hadEffortStep = false;
     setWizard(hash, wizard);
 
     await respond(wizard.token, interaction, {
       type: 7,
-      data: {
-        content: `**Set model**\nProvider: **${wizard.providerName}**\nSelect a model:`,
-        flags: 64,
-        components: [renderModelSelect(hash, models, 0)],
-      },
+      data: renderModelStep(hash, wizard),
     });
   }
 
@@ -413,16 +562,15 @@ export function createDiscordModelWizard({ restCall, bridge }) {
     const value = interaction.data?.values?.[0];
     if (!value) return;
 
+    // Legacy in-select page nav (kept so older messages still page); new UI
+    // uses dedicated page buttons and keeps Back available on every page.
     if (value === PREV_VALUE || value === NEXT_VALUE) {
       wizard.modelPage = (wizard.modelPage ?? 0) + (value === NEXT_VALUE ? 1 : -1);
+      wizard.stage = STAGE_MODEL;
       setWizard(hash, wizard);
       await respond(wizard.token, interaction, {
         type: 7,
-        data: {
-          content: `**Set model**\nProvider: **${wizard.providerName}**\nSelect a model:`,
-          flags: 64,
-          components: [renderModelSelect(hash, wizard.models, wizard.modelPage)],
-        },
+        data: renderModelStep(hash, wizard),
       });
       return;
     }
@@ -440,19 +588,19 @@ export function createDiscordModelWizard({ restCall, bridge }) {
 
     const variants = modelVariants(wizard, providerId, localId);
     if (variants.length > 0) {
+      wizard.stage = STAGE_EFFORT;
+      wizard.hadEffortStep = true;
+      setWizard(hash, wizard);
       await respond(wizard.token, interaction, {
         type: 7,
-        data: {
-          content: `**Set model**\nModel: \`${modelId}\`\nSelect thinking effort:`,
-          flags: 64,
-          components: [renderEffortSelect(hash, variants)],
-        },
+        data: renderEffortStep(hash, wizard),
       });
       return;
     }
 
     // No reasoning variants — go straight to the scope picker.
     wizard.selectedVariant = null;
+    wizard.hadEffortStep = false;
     await promptScope(wizard, hash, interaction);
   }
 
@@ -462,19 +610,16 @@ export function createDiscordModelWizard({ restCall, bridge }) {
     const value = interaction.data?.values?.[0];
     if (!value) return;
     wizard.selectedVariant = value === EFFORT_NONE ? null : value;
+    wizard.hadEffortStep = true;
     await promptScope(wizard, hash, interaction);
   }
 
   async function promptScope(wizard, hash, interaction) {
+    wizard.stage = STAGE_SCOPE;
     setWizard(hash, wizard);
-    const effortLine = wizard.selectedVariant ? ` · effort \`${wizard.selectedVariant}\`` : '';
     await respond(wizard.token, interaction, {
       type: 7,
-      data: {
-        content: `**Set model**\nModel: \`${wizard.selectedModelId}\`${effortLine}\nApply to:`,
-        flags: 64,
-        components: [renderScopeSelect(hash)],
-      },
+      data: renderScopeStep(hash, wizard),
     });
   }
 

--- a/packages/web/server/lib/messenger/discord-model-wizard.test.js
+++ b/packages/web/server/lib/messenger/discord-model-wizard.test.js
@@ -4,6 +4,7 @@ import {
   modelsOf,
   formatModelMeta,
   PAGE_SIZE,
+  PAGE_SIZE_WITH_BUTTON_NAV,
   createDiscordModelWizard,
 } from './discord-model-wizard.js';
 
@@ -82,6 +83,14 @@ describe('buildPagedOptions', () => {
     expect(options.length).toBe(5);
     expect(options.some((o) => o.label.includes('▶') || o.label.includes('◀'))).toBe(false);
   });
+
+  it('can fill all 25 select slots when in-select nav is disabled', () => {
+    const { options, totalPages, pageSize } = buildPagedOptions(items, 0, { includeNav: false });
+    expect(pageSize).toBe(PAGE_SIZE_WITH_BUTTON_NAV);
+    expect(totalPages).toBe(Math.ceil(60 / PAGE_SIZE_WITH_BUTTON_NAV));
+    expect(options.length).toBe(PAGE_SIZE_WITH_BUTTON_NAV);
+    expect(options.every((o) => o.value.startsWith('v'))).toBe(true);
+  });
 });
 
 describe('modelsOf', () => {
@@ -142,6 +151,24 @@ function lastSelectOptions(call) {
 function lastCustomId(call) {
   return call.body?.data?.components?.[0]?.components?.[0]?.custom_id;
 }
+function buttonLabels(call) {
+  const rows = call.body?.data?.components ?? [];
+  return rows
+    .flatMap((row) => row.components ?? [])
+    .filter((c) => c.type === 2)
+    .map((c) => c.label);
+}
+function buttonCustomIdByLabel(call, labelIncludes) {
+  const rows = call.body?.data?.components ?? [];
+  for (const row of rows) {
+    for (const c of row.components ?? []) {
+      if (c.type === 2 && String(c.label ?? '').includes(labelIncludes)) {
+        return c.custom_id;
+      }
+    }
+  }
+  return null;
+}
 
 describe('createDiscordModelWizard flow', () => {
   const state = { token: 'bot-token' };
@@ -160,23 +187,31 @@ describe('createDiscordModelWizard flow', () => {
     const provCustomId = lastCustomId(providerSelect);
     expect(wizard.ownsComponent(provCustomId)).toBe(true);
 
-    // pick the provider → first page of models (23 + "More ▶")
+    // pick the provider → first page of models (25) + Back / More buttons
     await wizard.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['anthropic'] } }, provCustomId);
     const modelPage0 = calls.at(-1);
     const modelCustomId = lastCustomId(modelPage0);
     expect(lastSelectValues(modelPage0)).toContain('m0');
-    expect(lastSelectValues(modelPage0)).toContain('__openchamber_agent_next');
-    expect(lastSelectValues(modelPage0)).not.toContain(`m${PAGE_SIZE}`);
+    expect(lastSelectValues(modelPage0)).toHaveLength(PAGE_SIZE_WITH_BUTTON_NAV);
+    expect(lastSelectValues(modelPage0)).not.toContain(`m${PAGE_SIZE_WITH_BUTTON_NAV}`);
+    expect(buttonLabels(modelPage0)).toEqual(expect.arrayContaining(['← Back']));
+    expect(buttonLabels(modelPage0).some((l) => l.includes('More ▶'))).toBe(true);
+    const nextCustomId = buttonCustomIdByLabel(modelPage0, 'More ▶');
+    expect(wizard.ownsComponent(nextCustomId)).toBe(true);
 
-    // page forward → second page reveals models past the first 23
-    await wizard.handleComponent(state, { id: 'i3', token: 't3', data: { values: ['__openchamber_agent_next'] } }, modelCustomId);
-    expect(lastSelectValues(calls.at(-1))).toContain(`m${PAGE_SIZE}`);
-    expect(lastSelectValues(calls.at(-1))).toContain('__openchamber_agent_prev');
+    // page forward via button → second page reveals models past the first 25,
+    // and Back remains available while paginating
+    await wizard.handleComponent(state, { id: 'i3', token: 't3', data: {} }, nextCustomId);
+    const modelPage1 = calls.at(-1);
+    expect(lastSelectValues(modelPage1)).toContain(`m${PAGE_SIZE_WITH_BUTTON_NAV}`);
+    expect(buttonLabels(modelPage1)).toEqual(expect.arrayContaining(['← Back']));
+    expect(buttonLabels(modelPage1).some((l) => l.includes('Page'))).toBe(true);
 
     // pick a model with no variants → scope picker (conversation/project/system)
     await wizard.handleComponent(state, { id: 'i4', token: 't4', data: { values: ['m30'] } }, modelCustomId);
     const scopeSelect = calls.at(-1);
     expect(lastSelectValues(scopeSelect)).toEqual(['conversation', 'project', 'global']);
+    expect(buttonLabels(scopeSelect)).toContain('← Back');
     const scopeCustomId = lastCustomId(scopeSelect);
 
     // choose "this conversation" → surface override stored + resend button
@@ -188,6 +223,67 @@ describe('createDiscordModelWizard flow', () => {
     const button = final.body.data.components[0].components[0];
     expect(button.type).toBe(2);
     expect(wizard.ownsComponent(button.custom_id)).toBe(true);
+  });
+
+  it('lets users step back from model/effort/scope, including while paginating models', async () => {
+    const withVariants = [
+      {
+        id: 'gpt',
+        name: 'GPT',
+        models: Array.from({ length: 40 }, (_, i) => ({
+          id: `m${i}`,
+          name: `m${i}`,
+          variants: i === 30 ? { low: {}, high: {} } : undefined,
+        })),
+      },
+    ];
+    const { wizard, calls } = makeHarness(withVariants);
+    await wizard.start(state, { id: 'i1', token: 't1', channel_id: 'chan', application_id: 'app' });
+    const provCustomId = lastCustomId(calls.at(-1));
+
+    await wizard.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['gpt'] } }, provCustomId);
+    const modelPage0 = calls.at(-1);
+    const nextCustomId = buttonCustomIdByLabel(modelPage0, 'More ▶');
+    await wizard.handleComponent(state, { id: 'i3', token: 't3', data: {} }, nextCustomId);
+    expect(calls.at(-1).body.data.content).toContain('Select a model');
+
+    // Back from a later model page returns to the provider menu (root has no Back).
+    const backFromModels = buttonCustomIdByLabel(calls.at(-1), '← Back');
+    await wizard.handleComponent(state, { id: 'i4', token: 't4', data: {} }, backFromModels);
+    expect(calls.at(-1).body.data.content).toContain('Select a provider');
+    expect(buttonLabels(calls.at(-1))).not.toContain('← Back');
+
+    // Re-enter provider → model → effort → scope, then walk back step by step.
+    await wizard.handleComponent(state, { id: 'i5', token: 't5', data: { values: ['gpt'] } }, provCustomId);
+    const modelCustomId = lastCustomId(calls.at(-1));
+    const nextAgain = buttonCustomIdByLabel(calls.at(-1), 'More ▶');
+    await wizard.handleComponent(state, { id: 'i6', token: 't6', data: {} }, nextAgain);
+    await wizard.handleComponent(state, { id: 'i7', token: 't7', data: { values: ['m30'] } }, modelCustomId);
+    expect(calls.at(-1).body.data.content).toContain('thinking effort');
+    expect(buttonLabels(calls.at(-1))).toContain('← Back');
+
+    await wizard.handleComponent(
+      state,
+      { id: 'i8', token: 't8', data: { values: ['high'] } },
+      lastCustomId(calls.at(-1)),
+    );
+    expect(calls.at(-1).body.data.content).toContain('Apply to');
+    expect(buttonLabels(calls.at(-1))).toContain('← Back');
+
+    await wizard.handleComponent(
+      state,
+      { id: 'i9', token: 't9', data: {} },
+      buttonCustomIdByLabel(calls.at(-1), '← Back'),
+    );
+    expect(calls.at(-1).body.data.content).toContain('thinking effort');
+
+    await wizard.handleComponent(
+      state,
+      { id: 'i10', token: 't10', data: {} },
+      buttonCustomIdByLabel(calls.at(-1), '← Back'),
+    );
+    expect(calls.at(-1).body.data.content).toContain('Select a model');
+    expect(buttonLabels(calls.at(-1))).toEqual(expect.arrayContaining(['← Back']));
   });
 
   it('asks for thinking effort when the model has variants, then scope', async () => {

--- a/packages/web/server/lib/messenger/discord-wizard-shared.js
+++ b/packages/web/server/lib/messenger/discord-wizard-shared.js
@@ -13,12 +13,17 @@ import crypto from 'node:crypto';
  */
 
 export const WIZARD_TTL_MS = 10 * 60 * 1000;
-// Real choices per page. Up to two slots are reserved for prev/next navigation,
-// so the rendered menu never exceeds Discord's hard limit of 25 select options.
+// Discord string-select menus hard-cap at 25 options.
+export const DISCORD_SELECT_MAX = 25;
+// Default real choices per page when prev/next live inside the select
+// (up to two slots reserved for in-menu navigation).
 export const PAGE_SIZE = 23;
+// When page nav is moved to buttons, the select can use the full 25 slots.
+export const PAGE_SIZE_WITH_BUTTON_NAV = DISCORD_SELECT_MAX;
 
 export const PREV_VALUE = '__openchamber_agent_prev';
 export const NEXT_VALUE = '__openchamber_agent_next';
+export const BACK_VALUE = '__openchamber_agent_back';
 
 /**
  * Rewrite deprecated Otto Discord component ids / select values to the
@@ -52,29 +57,41 @@ export function normalizeLegacyDiscordSelectValue(value) {
  *
  * @param {Array<{label:string,value:string,description?:string}>} items
  * @param {number} page zero-based page index (clamped into range)
+ * @param {{ pageSize?: number, includeNav?: boolean }} [opts]
+ *   - `pageSize` defaults to {@link PAGE_SIZE} (23) when in-select nav is on,
+ *     or {@link PAGE_SIZE_WITH_BUTTON_NAV} (25) when `includeNav` is false.
+ *   - `includeNav` (default true) embeds ◀ Previous / More ▶ inside the select.
  * @returns {{ options: Array, page: number, totalPages: number }}
  */
-export function buildPagedOptions(items, page) {
+export function buildPagedOptions(items, page, opts = {}) {
+  const includeNav = opts.includeNav !== false;
+  const pageSize = Math.max(
+    1,
+    Math.min(
+      DISCORD_SELECT_MAX,
+      opts.pageSize ?? (includeNav ? PAGE_SIZE : PAGE_SIZE_WITH_BUTTON_NAV),
+    ),
+  );
   const total = Array.isArray(items) ? items.length : 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const safePage = Math.min(Math.max(0, page | 0), totalPages - 1);
-  const start = safePage * PAGE_SIZE;
-  const options = items.slice(start, start + PAGE_SIZE).map((o) => ({ ...o }));
-  if (safePage > 0) {
+  const start = safePage * pageSize;
+  const options = items.slice(start, start + pageSize).map((o) => ({ ...o }));
+  if (includeNav && safePage > 0) {
     options.unshift({
       label: '◀ Previous',
       value: PREV_VALUE,
       description: `Page ${safePage} of ${totalPages}`,
     });
   }
-  if (safePage < totalPages - 1) {
+  if (includeNav && safePage < totalPages - 1) {
     options.push({
       label: 'More ▶',
       value: NEXT_VALUE,
       description: `Page ${safePage + 2} of ${totalPages}`,
     });
   }
-  return { options, page: safePage, totalPages };
+  return { options, page: safePage, totalPages, pageSize };
 }
 
 /** A single-row string-select component. Options are clamped to Discord's 25 max. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Discord `/model` wizard now has a **← Back** button on every step after provider select (model, thinking effort, scope).
- Back stays available while paginating models — page nav moved to buttons so it no longer competes with “return to previous menu”.
- Model pages now show **25** models each (Discord’s select max) instead of 23.
- Provider select remains the root step (no Back there).

## Test plan
- [ ] `/model` → pick provider → confirm Back returns to provider list
- [ ] With >25 models: page forward with More ▶, confirm Back still returns to providers
- [ ] Pick a model with thinking variants → Back from scope → effort → models → providers
- [ ] Pick a model without variants → Back from scope returns to models
- [ ] Completing scope still applies the override and shows Send last message

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f766f-f36b-7224-add1-cb7e3cf6070c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f766f-f36b-7224-add1-cb7e3cf6070c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

