### PR TITLE
feat(discord): show model modalities as emoji in /model select

### DIFF
--- a/packages/web/server/lib/messenger/discord-model-wizard.js
+++ b/packages/web/server/lib/messenger/discord-model-wizard.js
@@ -87,16 +87,71 @@ function formatCostPerMillion(value) {
   return `$${rounded}`;
 }
 
+/** Discord-friendly modality icons (select descriptions can't render custom SVGs). */
+const MODALITY_EMOJI = {
+  text: '📝',
+  image: '🖼️',
+  video: '🎬',
+  audio: '🔊',
+  pdf: '📄',
+};
+const MODALITY_ORDER = ['text', 'image', 'video', 'audio', 'pdf'];
+/** Prefer richer modalities for the select-option badge when several are present. */
+const MODALITY_BADGE_PRIORITY = ['image', 'video', 'audio', 'pdf', 'text'];
+
+function normalizeModalityList(values) {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const entry of values) {
+    const key = String(entry ?? '').trim().toLowerCase();
+    if (!key || !MODALITY_EMOJI[key] || seen.has(key)) continue;
+    seen.add(key);
+    out.push(key);
+  }
+  return out;
+}
+
 /**
- * Build the Discord select-option description for a model: its context window
- * and (when available) per-million-token input/output price — e.g.
- * `200K ctx · in $3/out $15 /Mtok`. Returns '' when the model exposes no
- * usable metadata. Replaces the old `release_date` formatting that showed a
- * confusing bare date under every model name.
+ * Input modalities the model accepts, as emoji icons (📝🖼️🎬🔊📄).
+ * Falls back to image when only the legacy `attachment` flag is set.
+ */
+export function formatModelModalities(model) {
+  if (!model || typeof model !== 'object') return '';
+  const keys = normalizeModalityList(model?.modalities?.input);
+  if (keys.length === 0 && model.attachment === true) {
+    keys.push('image');
+  }
+  return MODALITY_ORDER.filter((key) => keys.includes(key))
+    .map((key) => MODALITY_EMOJI[key])
+    .join('');
+}
+
+/** Single emoji for the Discord select-option `emoji` field (left of the label). */
+export function primaryModalityEmoji(model) {
+  if (!model || typeof model !== 'object') return null;
+  const keys = normalizeModalityList(model?.modalities?.input);
+  if (keys.length === 0 && model.attachment === true) {
+    keys.push('image');
+  }
+  for (const key of MODALITY_BADGE_PRIORITY) {
+    if (keys.includes(key)) return MODALITY_EMOJI[key];
+  }
+  return null;
+}
+
+/**
+ * Build the Discord select-option description for a model: input modalities
+ * (emoji), context window, and (when available) per-million-token input/output
+ * price — e.g. `📝🖼️ · 200K ctx · in $3/out $15 /Mtok`. Returns '' when the
+ * model exposes no usable metadata. Replaces the old `release_date` formatting
+ * that showed a confusing bare date under every model name.
  */
 export function formatModelMeta(model) {
   if (!model || typeof model !== 'object') return '';
   const parts = [];
+  const modalities = formatModelModalities(model);
+  if (modalities) parts.push(modalities);
   const ctx = formatTokensCompact(model?.limit?.context);
   if (ctx) parts.push(`${ctx} ctx`);
   const input = formatCostPerMillion(model?.cost?.input);
@@ -200,13 +255,19 @@ export function createDiscordModelWizard({ restCall, bridge }) {
   }
 
   function modelOptions(models) {
-    return models.map((m) => ({
-      label: (m.label ?? m.name ?? m.id ?? String(m)).slice(0, 100),
-      value: m.value ?? m.id ?? m.name ?? String(m),
-      // Show context window + pricing under the model name (falling back to an
-      // explicit `description` when one is provided, e.g. favourites).
-      description: ((m.description || formatModelMeta(m)) || ' ').slice(0, 100),
-    }));
+    return models.map((m) => {
+      const emojiName = primaryModalityEmoji(m);
+      return {
+        label: (m.label ?? m.name ?? m.id ?? String(m)).slice(0, 100),
+        value: m.value ?? m.id ?? m.name ?? String(m),
+        // Modalities (emoji) + context window + pricing under the model name
+        // (falling back to an explicit `description` when one is provided,
+        // e.g. favourites that already baked provider context in).
+        description: ((m.description || formatModelMeta(m)) || ' ').slice(0, 100),
+        // Discord select options support a single unicode emoji badge.
+        ...(emojiName ? { emoji: { name: emojiName } } : {}),
+      };
+    });
   }
 
   function renderModelSelect(hash, models, page) {
@@ -519,8 +580,11 @@ export function createDiscordModelWizard({ restCall, bridge }) {
         return {
           value: `${providerID}/${modelID}`,
           label: modelID,
-          // Prefer context/pricing, fall back to the provider id for context.
+          // Prefer context/pricing/modalities, fall back to the provider id.
           description: meta || providerID,
+          // Keep modality fields so the select option can show an emoji badge.
+          modalities: model?.modalities,
+          attachment: model?.attachment,
         };
       });
     } else {

--- a/packages/web/server/lib/messenger/discord-model-wizard.test.js
+++ b/packages/web/server/lib/messenger/discord-model-wizard.test.js
@@ -3,6 +3,8 @@ import {
   buildPagedOptions,
   modelsOf,
   formatModelMeta,
+  formatModelModalities,
+  primaryModalityEmoji,
   PAGE_SIZE,
   PAGE_SIZE_WITH_BUTTON_NAV,
   createDiscordModelWizard,
@@ -30,10 +32,38 @@ describe('formatModelMeta', () => {
     );
   });
 
+  it('prefixes modality icons before context and pricing', () => {
+    expect(
+      formatModelMeta({
+        modalities: { input: ['text', 'image'] },
+        limit: { context: 200000 },
+        cost: { input: 3, output: 15 },
+      }),
+    ).toBe('📝🖼️ · 200K ctx · in $3/out $15 /Mtok');
+  });
+
   it('never renders a date and returns empty when no metadata exists', () => {
     expect(formatModelMeta({ release_date: '2024-01-01' })).toBe('');
     expect(formatModelMeta({})).toBe('');
     expect(formatModelMeta(null)).toBe('');
+  });
+});
+
+describe('formatModelModalities / primaryModalityEmoji', () => {
+  it('renders ordered modality emoji for known inputs', () => {
+    expect(formatModelModalities({ modalities: { input: ['pdf', 'text', 'image'] } })).toBe('📝🖼️📄');
+    expect(formatModelModalities({ modalities: { input: ['audio', 'video'] } })).toBe('🎬🔊');
+  });
+
+  it('falls back to image when only the legacy attachment flag is set', () => {
+    expect(formatModelModalities({ attachment: true })).toBe('🖼️');
+    expect(primaryModalityEmoji({ attachment: true })).toBe('🖼️');
+  });
+
+  it('prefers image/video/audio/pdf over text for the select badge', () => {
+    expect(primaryModalityEmoji({ modalities: { input: ['text', 'image'] } })).toBe('🖼️');
+    expect(primaryModalityEmoji({ modalities: { input: ['text'] } })).toBe('📝');
+    expect(primaryModalityEmoji({})).toBe(null);
   });
 });
 
@@ -364,13 +394,19 @@ describe('createDiscordModelWizard flow', () => {
     expect(resends[0]).toMatchObject({ type: 'discord', channelId: 'chan' });
   });
 
-  it('hides models the UI hid and shows context/pricing in the description', async () => {
+  it('hides models the UI hid and shows modalities/context/pricing in the description', async () => {
     const richProviders = [
       {
         id: 'anthropic',
         name: 'Anthropic',
         models: [
-          { id: 'sonnet', name: 'Sonnet', limit: { context: 200000 }, cost: { input: 3, output: 15 } },
+          {
+            id: 'sonnet',
+            name: 'Sonnet',
+            modalities: { input: ['text', 'image'], output: ['text'] },
+            limit: { context: 200000 },
+            cost: { input: 3, output: 15 },
+          },
           { id: 'legacy', name: 'Legacy' },
         ],
       },
@@ -386,9 +422,10 @@ describe('createDiscordModelWizard flow', () => {
 
     await wizard.handleComponent(state, { id: 'i2', token: 't2', data: { values: ['anthropic'] } }, provCustomId);
     const modelOpts = lastSelectOptions(calls.at(-1));
-    // The hidden model is gone; the visible one carries context + pricing.
+    // The hidden model is gone; the visible one carries modalities + context + pricing.
     expect(modelOpts.map((o) => o.value)).toEqual(['sonnet']);
-    expect(modelOpts[0].description).toBe('200K ctx · in $3/out $15 /Mtok');
+    expect(modelOpts[0].description).toBe('📝🖼️ · 200K ctx · in $3/out $15 /Mtok');
+    expect(modelOpts[0].emoji).toEqual({ name: '🖼️' });
   });
 
   it('drops a favourite that the UI hid', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
In the Discord `/model` picker, each model option now shows **input modalities as emoji icons** alongside context window and pricing.

Example description: `📝🖼️ · 200K ctx · in $3/out $15 /Mtok`

- 📝 text · 🖼️ image · 🎬 video · 🔊 audio · 📄 PDF
- Option badge uses the primary richer modality (image/video/audio/pdf over text)
- Legacy `attachment: true` models fall back to 🖼️

## Test plan
- [ ] `/model` → provider with multimodal models → descriptions include modality emoji + ctx + price
- [ ] Image-capable model gets 🖼️ badge left of the label
- [ ] Text-only model shows 📝
- [ ] Favourites show the same modality badge as the live provider model

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f766f-f36b-7224-add1-cb7e3cf6070c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f766f-f36b-7224-add1-cb7e3cf6070c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

