### PR TITLE
feat: allow user CA's when validating server's certs under android

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- usesCleartextTraffic: OpenChamber connects to user-hosted servers over
-         plain http:// on the local network (LAN transport). Android blocks all
-         cleartext HTTP by default (targetSdk >= 28), which silently failed every
-         LAN probe and forced Android onto relay-only. This mirrors the iOS ATS
-         exceptions (NSAllowsArbitraryLoadsInWebContent + NSAllowsLocalNetworking). -->
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme">
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"

--- a/packages/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/packages/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Apps under modern Android must opt-in to allow the user's customized CA's. Since this project is mostly for users on their own networks, it's likely desirable for users to have this control.

Personally, I have all my local services signed by my own CA, which make it impossible for the OpenChamber mobile app to connect to my instance.

This resolves the error: chromium handshake failure, returned -1. SSL error code 1, net_error -202.

net_error -202 in Chromium is `ERR_CERT_AUTHORITY_INVALID`.

---

This PR adds `<certificates src="user" />` to the list of the allowed CA stores, `<certificates src="system" />` is default.