### PR TITLE
fix(agents): show hidden custom subagents in Settings

### DIFF
--- a/packages/ui/src/components/sections/agents/AgentsPage.tsx
+++ b/packages/ui/src/components/sections/agents/AgentsPage.tsx
@@ -227,6 +227,7 @@ export const AgentsPage: React.FC = () => {
         temperature: temperature ?? null,
         top_p: topP ?? null,
         prompt: trimmedPrompt || (isNewAgent ? undefined : null),
+        ...(isNewAgent && agentDraft?.hidden ? { hidden: true } : {}),
         ...(isNewAgent && draftScope ? { scope: draftScope } : {}),
       };
 

--- a/packages/ui/src/components/sections/agents/AgentsPage.tsx
+++ b/packages/ui/src/components/sections/agents/AgentsPage.tsx
@@ -231,6 +231,7 @@ export const AgentsPage: React.FC = () => {
         temperature: temperature ?? null,
         top_p: topP ?? null,
         prompt: trimmedPrompt || (isNewAgent ? undefined : null),
+        ...(isNewAgent && agentDraft?.hidden ? { hidden: true } : {}),
         ...(isNewAgent && draftScope ? { scope: draftScope } : {}),
       };
 

--- a/packages/ui/src/components/sections/agents/AgentsSidebar.tsx
+++ b/packages/ui/src/components/sections/agents/AgentsSidebar.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu';
 import { useSettingsDirectory } from '@/hooks/useSettingsDirectory';
-import { selectAgentsForDirectory, useAgentsStore, isAgentBuiltIn, isAgentHidden, type AgentScope, type AgentDraft } from '@/stores/useAgentsStore';
+import { selectAgentsForDirectory, useAgentsStore, isAgentBuiltIn, isAgentHidden, isAgentManageable, type AgentScope, type AgentDraft } from '@/stores/useAgentsStore';
 import { useShallow } from 'zustand/react/shallow';
 import { cn } from '@/lib/utils';
 import type { Agent } from '@opencode-ai/sdk/v2';
@@ -101,6 +101,27 @@ const rulesetToPermissionConfig = (ruleset: unknown): AgentDraft['permission'] =
   }
 
   return Object.keys(result).length > 0 ? (result as AgentDraft['permission']) : undefined;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components -- Regression tests cover config copied by rename and duplicate flows.
+export const copyAgentConfig = (agent: Agent, name: string) => {
+  const extended = agent as Agent & { scope?: AgentScope; disable?: boolean };
+  return {
+    name,
+    description: agent.description,
+    model: agent.model?.providerID && agent.model?.modelID
+      ? `${agent.model.providerID}/${agent.model.modelID}`
+      : null,
+    variant: agent.variant,
+    temperature: agent.temperature,
+    top_p: agent.topP,
+    prompt: agent.prompt,
+    mode: agent.mode,
+    permission: rulesetToPermissionConfig(agent.permission),
+    disable: extended.disable,
+    ...(isAgentHidden(agent) ? { hidden: true } : {}),
+    scope: extended.scope,
+  };
 };
 
 export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) => {
@@ -230,24 +251,10 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
       newName = `${baseName}-copy-${copyNumber}`;
     }
 
-    // Set draft with prefilled values from source agent
-    const extAgent = agent as Agent & { scope?: AgentScope };
-    const modelStr = agent.model?.providerID && agent.model?.modelID
-      ? `${agent.model.providerID}/${agent.model.modelID}`
-      : null;
-    const draftAgent = agent as Agent & { disable?: boolean };
+    const config = copyAgentConfig(agent, newName);
     setAgentDraft({
-      name: newName,
-      scope: extAgent.scope || 'user',
-      description: agent.description,
-      model: modelStr,
-      variant: agent.variant,
-      temperature: agent.temperature,
-      top_p: agent.topP,
-      prompt: agent.prompt,
-      mode: agent.mode,
-      permission: rulesetToPermissionConfig(agent.permission),
-      disable: draftAgent.disable,
+      ...config,
+      scope: config.scope || 'user',
     });
     setSelectedAgent(newName);
     onItemSelect?.();
@@ -279,28 +286,12 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
       return;
     }
 
-    // Create new agent with new name and all existing config
-    const renameModelStr = renameDialogAgent.model?.providerID && renameDialogAgent.model?.modelID
-      ? `${renameDialogAgent.model.providerID}/${renameDialogAgent.model.modelID}`
-      : null;
-    const renameExt = renameDialogAgent as Agent & { scope?: AgentScope; disable?: boolean };
-    const createResult = await createAgent({
-      name: sanitizedName,
-      description: renameDialogAgent.description,
-      model: renameModelStr,
-      variant: renameDialogAgent.variant,
-      temperature: renameDialogAgent.temperature,
-      top_p: renameDialogAgent.topP,
-      prompt: renameDialogAgent.prompt,
-      mode: renameDialogAgent.mode,
-      permission: rulesetToPermissionConfig(renameDialogAgent.permission),
-      disable: renameExt.disable,
-      scope: renameExt.scope,
-    }, settingsDirectory);
+    const renameConfig = copyAgentConfig(renameDialogAgent, sanitizedName);
+    const createResult = await createAgent(renameConfig, settingsDirectory);
 
     if (createResult.ok) {
       // Delete old agent
-      const deleteResult = await deleteAgent(renameDialogAgent.name, renameExt.scope, settingsDirectory);
+      const deleteResult = await deleteAgent(renameDialogAgent.name, renameConfig.scope, settingsDirectory);
       if (deleteResult.ok) {
         if (createResult.requiresManualRestart || deleteResult.requiresManualRestart) {
           toast.warning(t('settings.agents.page.toast.savedManualRestart'));
@@ -331,10 +322,10 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
     }
   };
 
-  // Filter out hidden agents (internal agents like title, compaction, summary)
-  const visibleAgents = agents.filter((agent) => !isAgentHidden(agent));
-  const builtInAgents = visibleAgents.filter(isAgentBuiltIn);
-  const customAgents = visibleAgents.filter((agent) => !isAgentBuiltIn(agent));
+  // Hidden custom agents stay manageable here even though pickers exclude them.
+  const manageableAgents = agents.filter(isAgentManageable);
+  const builtInAgents = manageableAgents.filter(isAgentBuiltIn);
+  const customAgents = manageableAgents.filter((agent) => !isAgentBuiltIn(agent));
 
   // Group custom agents by subfolder
   const { groupedCustomAgents, ungroupedCustomAgents } = useMemo(() => {
@@ -361,7 +352,7 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
         <h2 className={`${SETTINGS_PANEL_TITLE_CLASS} mb-3`}>{t('settings.agents.sidebar.title')}</h2>
         <SettingsProjectSelector className="mb-3" />
         <div className="flex items-center justify-between gap-2">
-          <span className="typography-meta text-muted-foreground">{t('settings.agents.sidebar.total', { count: visibleAgents.length })}</span>
+          <span className="typography-meta text-muted-foreground">{t('settings.agents.sidebar.total', { count: manageableAgents.length })}</span>
           <Button size="sm"
             data-settings-item="agents.create"
             variant="ghost"
@@ -374,7 +365,7 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
       </div>
 
       <ScrollableOverlay outerClassName="flex-1 min-h-0" className="space-y-1 px-3 py-2 overflow-x-hidden">
-        {visibleAgents.length === 0 ? (
+        {manageableAgents.length === 0 ? (
           <div className="py-12 px-4 text-center text-muted-foreground">
             <Icon name="robot-2" className="mx-auto mb-3 h-10 w-10 opacity-50" />
             <p className="typography-ui-label font-medium">{t('settings.agents.sidebar.empty.title')}</p>

--- a/packages/ui/src/components/sections/agents/AgentsSidebar.tsx
+++ b/packages/ui/src/components/sections/agents/AgentsSidebar.tsx
@@ -18,7 +18,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu';
-import { useAgentsStore, isAgentBuiltIn, isAgentHidden, type AgentScope, type AgentDraft } from '@/stores/useAgentsStore';
+import { useAgentsStore, isAgentBuiltIn, isAgentHidden, isAgentManageable, type AgentScope, type AgentDraft } from '@/stores/useAgentsStore';
 import { useShallow } from 'zustand/react/shallow';
 import { cn } from '@/lib/utils';
 import type { Agent } from '@opencode-ai/sdk/v2';
@@ -100,6 +100,27 @@ const rulesetToPermissionConfig = (ruleset: unknown): AgentDraft['permission'] =
   }
 
   return Object.keys(result).length > 0 ? (result as AgentDraft['permission']) : undefined;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components -- Regression tests cover config copied by rename and duplicate flows.
+export const copyAgentConfig = (agent: Agent, name: string) => {
+  const extended = agent as Agent & { scope?: AgentScope; disable?: boolean };
+  return {
+    name,
+    description: agent.description,
+    model: agent.model?.providerID && agent.model?.modelID
+      ? `${agent.model.providerID}/${agent.model.modelID}`
+      : null,
+    variant: agent.variant,
+    temperature: agent.temperature,
+    top_p: agent.topP,
+    prompt: agent.prompt,
+    mode: agent.mode,
+    permission: rulesetToPermissionConfig(agent.permission),
+    disable: extended.disable,
+    ...(isAgentHidden(agent) ? { hidden: true } : {}),
+    scope: extended.scope,
+  };
 };
 
 export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) => {
@@ -224,24 +245,10 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
       newName = `${baseName}-copy-${copyNumber}`;
     }
 
-    // Set draft with prefilled values from source agent
-    const extAgent = agent as Agent & { scope?: AgentScope };
-    const modelStr = agent.model?.providerID && agent.model?.modelID
-      ? `${agent.model.providerID}/${agent.model.modelID}`
-      : null;
-    const draftAgent = agent as Agent & { disable?: boolean };
+    const config = copyAgentConfig(agent, newName);
     setAgentDraft({
-      name: newName,
-      scope: extAgent.scope || 'user',
-      description: agent.description,
-      model: modelStr,
-      variant: agent.variant,
-      temperature: agent.temperature,
-      top_p: agent.topP,
-      prompt: agent.prompt,
-      mode: agent.mode,
-      permission: rulesetToPermissionConfig(agent.permission),
-      disable: draftAgent.disable,
+      ...config,
+      scope: config.scope || 'user',
     });
     setSelectedAgent(newName);
 
@@ -272,28 +279,12 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
       return;
     }
 
-    // Create new agent with new name and all existing config
-    const renameModelStr = renameDialogAgent.model?.providerID && renameDialogAgent.model?.modelID
-      ? `${renameDialogAgent.model.providerID}/${renameDialogAgent.model.modelID}`
-      : null;
-    const renameExt = renameDialogAgent as Agent & { scope?: AgentScope; disable?: boolean };
-    const createResult = await createAgent({
-      name: sanitizedName,
-      description: renameDialogAgent.description,
-      model: renameModelStr,
-      variant: renameDialogAgent.variant,
-      temperature: renameDialogAgent.temperature,
-      top_p: renameDialogAgent.topP,
-      prompt: renameDialogAgent.prompt,
-      mode: renameDialogAgent.mode,
-      permission: rulesetToPermissionConfig(renameDialogAgent.permission),
-      disable: renameExt.disable,
-      scope: renameExt.scope,
-    });
+    const renameConfig = copyAgentConfig(renameDialogAgent, sanitizedName);
+    const createResult = await createAgent(renameConfig);
 
     if (createResult.ok) {
       // Delete old agent
-      const deleteResult = await deleteAgent(renameDialogAgent.name, renameExt.scope);
+      const deleteResult = await deleteAgent(renameDialogAgent.name, renameConfig.scope);
       if (deleteResult.ok) {
         if (createResult.requiresManualRestart || deleteResult.requiresManualRestart) {
           toast.warning(t('settings.agents.page.toast.savedManualRestart'));
@@ -324,10 +315,10 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
     }
   };
 
-  // Filter out hidden agents (internal agents like title, compaction, summary)
-  const visibleAgents = agents.filter((agent) => !isAgentHidden(agent));
-  const builtInAgents = visibleAgents.filter(isAgentBuiltIn);
-  const customAgents = visibleAgents.filter((agent) => !isAgentBuiltIn(agent));
+  // Hidden custom agents stay manageable here even though pickers exclude them.
+  const manageableAgents = agents.filter(isAgentManageable);
+  const builtInAgents = manageableAgents.filter(isAgentBuiltIn);
+  const customAgents = manageableAgents.filter((agent) => !isAgentBuiltIn(agent));
 
   // Group custom agents by subfolder
   const { groupedCustomAgents, ungroupedCustomAgents } = useMemo(() => {
@@ -354,7 +345,7 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
         <h2 className={`${SETTINGS_PANEL_TITLE_CLASS} mb-3`}>{t('settings.agents.sidebar.title')}</h2>
         <SettingsProjectSelector className="mb-3" />
         <div className="flex items-center justify-between gap-2">
-          <span className="typography-meta text-muted-foreground">{t('settings.agents.sidebar.total', { count: visibleAgents.length })}</span>
+          <span className="typography-meta text-muted-foreground">{t('settings.agents.sidebar.total', { count: manageableAgents.length })}</span>
           <Button size="sm"
             data-settings-item="agents.create"
             variant="ghost"
@@ -367,7 +358,7 @@ export const AgentsSidebar: React.FC<AgentsSidebarProps> = ({ onItemSelect }) =>
       </div>
 
       <ScrollableOverlay outerClassName="flex-1 min-h-0" className="space-y-1 px-3 py-2 overflow-x-hidden">
-        {visibleAgents.length === 0 ? (
+        {manageableAgents.length === 0 ? (
           <div className="py-12 px-4 text-center text-muted-foreground">
             <Icon name="robot-2" className="mx-auto mb-3 h-10 w-10 opacity-50" />
             <p className="typography-ui-label font-medium">{t('settings.agents.sidebar.empty.title')}</p>

--- a/packages/ui/src/stores/useAgentsStore.subagents.test.tsx
+++ b/packages/ui/src/stores/useAgentsStore.subagents.test.tsx
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { Agent } from '@opencode-ai/sdk/v2';
+
+type TestAgent = Agent & {
+  native?: boolean;
+  hidden?: boolean;
+  options?: { hidden?: boolean };
+  description?: string;
+};
+
+let liveAgents: TestAgent[] = [];
+let lastCreatedAgent: Partial<TestAgent> | null = null;
+
+mock.module('./utils/safeStorage', () => ({
+  createDeferredSafeJSONStorage: () => ({
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined,
+  }),
+}));
+
+mock.module('@/lib/opencode/client', () => ({
+  opencodeClient: {
+    getDirectory: () => undefined,
+    listAgents: mock(async () => liveAgents),
+    checkHealth: mock(async () => true),
+  },
+}));
+
+mock.module('@/lib/runtime-fetch', () => ({
+  runtimeFetch: mock(async (url: string, init?: RequestInit) => {
+    if (url === '/api/config/reload') {
+      return Response.json({ requiresReload: false });
+    }
+
+    const match = /\/api\/config\/agents\/([^?]+)/.exec(url);
+    const name = match ? decodeURIComponent(match[1]) : 'unknown';
+    if (init?.method === 'POST') {
+      lastCreatedAgent = JSON.parse(String(init.body)) as Partial<TestAgent>;
+      return Response.json({ requiresManualRestart: true });
+    }
+    if (init?.method === 'PATCH') {
+      const update = JSON.parse(String(init.body)) as Partial<TestAgent>;
+      liveAgents = liveAgents.map((item) => item.name === name ? { ...item, ...update } : item);
+      return Response.json({ requiresReload: false });
+    }
+
+    return Response.json({
+      name,
+      scope: 'user',
+      sources: { md: { exists: true, scope: 'user', path: `/home/u/.config/opencode/agents/${name}.md` } },
+    });
+  }),
+}));
+
+mock.module('@/lib/configSync', () => ({
+  emitConfigChange: mock(() => undefined),
+  scopeMatches: mock(() => false),
+  subscribeToConfigChanges: mock(() => () => undefined),
+}));
+
+mock.module('@/lib/configUpdate', () => ({
+  startConfigUpdate: mock(() => undefined),
+  finishConfigUpdate: mock(() => undefined),
+  updateConfigUpdateMessage: mock(() => undefined),
+}));
+
+const emptyStore = { getState: () => ({}) };
+mock.module('@/stores/useConfigStore', () => ({ useConfigStore: emptyStore }));
+mock.module('@/stores/useCommandsStore', () => ({ useCommandsStore: emptyStore, invalidateCommandsLoadCache: () => undefined }));
+mock.module('@/stores/useSkillsCatalogStore', () => ({ useSkillsCatalogStore: emptyStore }));
+mock.module('@/stores/useSkillsStore', () => ({ useSkillsStore: emptyStore, invalidateSkillsLoadCache: () => undefined }));
+mock.module('@/stores/useProjectsStore', () => ({
+  useProjectsStore: { getState: () => ({ getActiveProject: () => null, projects: [] }) },
+}));
+
+const { useAgentsStore, reloadOpenCodeConfiguration, isAgentBuiltIn, isAgentManageable } = await import('@/stores/useAgentsStore');
+const { copyAgentConfig } = await import('@/components/sections/agents/AgentsSidebar');
+
+// Mirrors the Settings list derivation in AgentsSidebar.
+const deriveSettingsAgentLists = (agents: Agent[]) => {
+  const manageableAgents = agents.filter(isAgentManageable);
+  return {
+    manageableAgents,
+    customAgents: manageableAgents.filter((item) => !isAgentBuiltIn(item)),
+  };
+};
+
+const agent = (name: string, mode: Agent['mode'], extra: Partial<TestAgent> = {}): TestAgent =>
+  ({ name, mode, permission: [], options: {}, ...extra } as TestAgent);
+
+describe('Settings hidden custom subagents', () => {
+  beforeEach(() => {
+    useAgentsStore.setState({ agents: [], isLoading: false, selectedAgentName: null, agentDraft: null });
+    lastCreatedAgent = null;
+    liveAgents = [
+      agent('build', 'primary', { native: true }),
+      agent('title', 'primary', { native: true, hidden: true }),
+      agent('summary', 'primary', { native: true, hidden: true }),
+      agent('compaction', 'primary', { native: true, hidden: true }),
+      agent('visible-custom', 'primary'),
+      agent('hidden-custom', 'subagent', { hidden: true, description: 'Original description' }),
+      agent('options-hidden-custom', 'subagent', { options: { hidden: true } }),
+    ];
+  });
+
+  test('derives hidden custom agents as manageable without exposing hidden native agents to Settings or pickers', async () => {
+    await useAgentsStore.getState().loadAgents();
+
+    const { manageableAgents, customAgents } = deriveSettingsAgentLists(useAgentsStore.getState().agents);
+    expect(manageableAgents.map((item) => item.name)).toEqual([
+      'build',
+      'visible-custom',
+      'hidden-custom',
+      'options-hidden-custom',
+    ]);
+    expect(customAgents.map((item) => item.name)).toEqual([
+      'visible-custom',
+      'hidden-custom',
+      'options-hidden-custom',
+    ]);
+
+    const pickerNames = useAgentsStore.getState().getVisibleAgents().map((item) => item.name);
+    expect(pickerNames).toContain('visible-custom');
+    expect(pickerNames).not.toContain('hidden-custom');
+    expect(pickerNames).not.toContain('options-hidden-custom');
+  });
+
+  test('keeps a hidden custom agent manageable after an update', async () => {
+    await useAgentsStore.getState().loadAgents();
+    await useAgentsStore.getState().updateAgent('hidden-custom', { description: 'Updated description' });
+
+    const { customAgents } = deriveSettingsAgentLists(useAgentsStore.getState().agents);
+    expect(customAgents.find((item) => item.name === 'hidden-custom')?.description).toBe('Updated description');
+    expect(customAgents.map((item) => item.name)).toContain('visible-custom');
+    expect(customAgents.map((item) => item.name)).not.toContain('title');
+  });
+
+  test('preserves hidden custom agent configuration when copying for rename or duplicate', async () => {
+    const renameConfig = copyAgentConfig(
+      agent('hidden-custom', 'subagent', { hidden: true }),
+      'renamed-hidden-custom',
+    );
+    expect(renameConfig.name).toBe('renamed-hidden-custom');
+    expect(renameConfig.hidden).toBe(true);
+    const duplicateConfig = copyAgentConfig(
+      agent('options-hidden-custom', 'subagent', { options: { hidden: true } }),
+      'duplicated-hidden-custom',
+    );
+    expect(duplicateConfig.name).toBe('duplicated-hidden-custom');
+    expect(duplicateConfig.hidden).toBe(true);
+
+    await useAgentsStore.getState().createAgent(renameConfig);
+    expect(lastCreatedAgent?.hidden).toBe(true);
+  });
+
+  test('derives Settings rows from the refreshed store snapshot', async () => {
+    await useAgentsStore.getState().loadAgents();
+    liveAgents = [...liveAgents, agent('reloaded-hidden-custom', 'subagent', { hidden: true })];
+
+    await reloadOpenCodeConfiguration({ scopes: ['agents'], mode: 'active' });
+
+    const { customAgents } = deriveSettingsAgentLists(useAgentsStore.getState().agents);
+    expect(customAgents.map((item) => item.name)).toContain('reloaded-hidden-custom');
+    expect(customAgents.map((item) => item.name)).toContain('visible-custom');
+    expect(customAgents.map((item) => item.name)).not.toContain('summary');
+  });
+});

--- a/packages/ui/src/stores/useAgentsStore.ts
+++ b/packages/ui/src/stores/useAgentsStore.ts
@@ -112,6 +112,7 @@ export interface AgentConfig {
   permission?: PermissionConfig | null;
 
   disable?: boolean;
+  hidden?: boolean;
   scope?: AgentScope;
 }
 
@@ -168,6 +169,10 @@ export const isAgentHidden = (agent: Agent): boolean => {
 export const filterVisibleAgents = (agents: Agent[]): Agent[] =>
   agents.filter((agent) => !isAgentHidden(agent));
 
+// Hidden custom agents remain manageable even though pickers exclude them.
+export const isAgentManageable = (agent: Agent): boolean =>
+  !isAgentHidden(agent) || !isAgentBuiltIn(agent);
+
 const CONFIG_EVENT_SOURCE = "useAgentsStore";
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const MAX_HEALTH_WAIT_MS = 20000;
@@ -191,6 +196,7 @@ export interface AgentDraft {
   mode?: "primary" | "subagent" | "all";
   permission?: PermissionConfig;
   disable?: boolean;
+  hidden?: boolean;
 }
 
 interface AgentsStore {
@@ -352,6 +358,7 @@ export const useAgentsStore = create<AgentsStore>()(
             if (config.prompt) agentConfig.prompt = config.prompt;
             if (config.permission) agentConfig.permission = config.permission;
             if (config.disable !== undefined) agentConfig.disable = config.disable;
+            if (config.hidden !== undefined) agentConfig.hidden = config.hidden;
             if (config.scope) agentConfig.scope = config.scope;
 
             console.log('[AgentsStore] Agent config to save:', agentConfig);

--- a/packages/ui/src/stores/useAgentsStore.ts
+++ b/packages/ui/src/stores/useAgentsStore.ts
@@ -126,6 +126,7 @@ export interface AgentConfig {
   permission?: PermissionConfig | null;
 
   disable?: boolean;
+  hidden?: boolean;
   scope?: AgentScope;
 }
 
@@ -184,6 +185,10 @@ export const isAgentHidden = (agent: Agent): boolean => {
 // Helper to filter only visible (non-hidden) agents
 export const filterVisibleAgents = (agents: Agent[]): Agent[] =>
   agents.filter((agent) => !isAgentHidden(agent));
+
+// Hidden custom agents remain manageable even though pickers exclude them.
+export const isAgentManageable = (agent: Agent): boolean =>
+  !isAgentHidden(agent) || !isAgentBuiltIn(agent);
 
 const CONFIG_EVENT_SOURCE = "useAgentsStore";
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -265,6 +270,7 @@ export interface AgentDraft {
   mode?: "primary" | "subagent" | "all";
   permission?: PermissionConfig;
   disable?: boolean;
+  hidden?: boolean;
 }
 
 interface AgentsStore {
@@ -452,6 +458,7 @@ export const useAgentsStore = create<AgentsStore>()(
             if (config.prompt) agentConfig.prompt = config.prompt;
             if (config.permission) agentConfig.permission = config.permission;
             if (config.disable !== undefined) agentConfig.disable = config.disable;
+            if (config.hidden !== undefined) agentConfig.hidden = config.hidden;
             if (config.scope) agentConfig.scope = config.scope;
 
             console.log('[AgentsStore] Agent config to save:', agentConfig);


### PR DESCRIPTION
> Validated commit: `41e470c14fbd3787629330d466f7e415d4d5310f`, rebased onto `main` at `feec14545`.

## Intent

Fixes #2305. Upstream OpenCode defines `hidden` as "hide this subagent from the @ autocomplete menu", but OpenChamber read it as "internal agent, never show" and filtered `isAgentHidden` out of the Settings agent list. A user-defined subagent marked `hidden` therefore became unreachable: it could not be edited, duplicated, renamed, or deleted from the UI at all. The defect is still present on `main`, where `AgentsSidebar.tsx` filters with `!isAgentHidden(agent)`.

Settings now filters with `isAgentManageable` (`!isAgentHidden(agent) || !isAgentBuiltIn(agent)`), so the only agents still excluded are hidden *and* built-in. Internal agents such as title, compaction, and summary are additionally `native: true`, which `isAgentBuiltIn` covers, so excluding just `hidden && (native || builtIn)` keeps them out while making hidden custom agents manageable.

`hidden` is now part of `AgentConfig` and `AgentDraft` and is persisted on create, and `copyAgentConfig` carries it through both the rename and duplicate paths, which are newly reachable for these agents.

## Non-goals

No UI affordance to view or toggle `hidden` was added; the flag is only preserved, never edited from Settings. Pickers still exclude hidden agents through the existing `isAgentHidden`/`filterVisibleAgents` predicates, so this does not put hidden subagents back into the composer or `@` menu. No agent discovery or config-file ownership change. No locale file is touched.

## Affected surfaces

- `packages/ui` Settings agent list and agent mutation flows, shared by web, desktop, VS Code, and mobile: `AgentsSidebar.tsx` (list, count label, empty state, duplicate, rename), `AgentsPage.tsx` (create), and `useAgentsStore.ts` (`isAgentManageable`, `hidden` on `AgentConfig`/`AgentDraft`, create persistence).
- User-visible states: hidden custom agents now appear as ordinary rows, and the sidebar total counts them. Hidden built-in/native agents remain absent, and the empty state now keys off the manageable list.
- Persisted contract: `hidden: true` is written into the agent config file on create and preserved on rename and duplicate. No server or transport change.

## Rebase note

`main` moved under this branch, and two upstream changes had to be threaded through rather than merged mechanically:

1. **Directory-scoped agents.** `main` replaced the flat list with `agents = useAgentsStore((state) => selectAgentsForDirectory(state, settingsDirectory))`. I verified `selectAgentsForDirectory` returns the raw stored array and performs **no** hidden filtering of its own, so the fix is still load-bearing; `filterVisibleAgents` is applied separately by the picker call sites (`sections/commands/AgentSelector.tsx`, `useConfigStore.ts`, and the `getVisibleAgents` store getter). This is exactly the management/picker split the change relies on, and it remains intact.
2. **`settingsDirectory` argument.** `main` added a directory argument to `createAgent(config, directory)` and `deleteAgent(name, scope, directory)`. The rename path now combines both: `copyAgentConfig(...)` supplies the config and `settingsDirectory` is passed through to both calls.

`isAgentHidden` is still imported and used inside `copyAgentConfig`, so no import became dead. The resulting diff stat is unchanged from the pre-rebase commit (210 insertions, 43 deletions).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Shared store exports and Settings behavior changed | Management and picker visibility stay separate predicates rather than one overloaded filter. The one `react-refresh/only-export-components` suppression covers `copyAgentConfig`, which is production code shared by the rename and duplicate paths, not a test hook. `bun run dead-code` was run because a file and two exports were added. |
| `settings-ui-patterns` | The Settings agents pane content and its count changed | Hidden custom agents reuse the existing list rows, grouping, and editing surfaces instead of a parallel UI, so no new page chrome, control, or info hint was introduced. Filtering happens inline with the already-exported store predicate. No control was added or moved, so the Settings search registry in `lib/settings/search.ts` needs no new entry and the existing `data-settings-item="agents.create"` anchor is unchanged. Narrow and wide pane states are both captured below. |

## Validation

| Check | Result |
|---|---|
| `bun test src/stores/useAgentsStore.subagents.test.tsx` | **4 passed**, 0 failed, 16 assertions. |
| `bun test` on the agent suites (`useAgentsStore.subagents`, `AgentPermissionsEditor`, `useAgentMemoryStore`) | **27 passed**, 0 failed. Run because the rebase moved the agents list onto `main`'s directory-scoped selector. |
| `bun run type-check:ui` | Exit 0. |
| `bun run lint:ui` | Exit 0. One `react-hooks/exhaustive-deps` warning remains in `packages/ui/src/apps/MobileChangesSurface.tsx`, which this PR does not touch; that file is byte-identical to `origin/main`, so the warning is pre-existing upstream. |
| `bun run dead-code` | Neither `isAgentManageable`, `copyAgentConfig`, nor the new test file appears in the unused report. |
| Rendered Settings pane, wide and narrow | See Visual evidence. |

The test asserts the exact derived lists: manageable resolves to `build, visible-custom, hidden-custom, options-hidden-custom` while `getVisibleAgents()` (the picker path) still excludes both hidden custom agents; it covers a hidden custom agent surviving an update, `copyAgentConfig` preserving `hidden` for both the top-level and `options.hidden` shapes, `createAgent` sending `hidden: true`, and derivation from a refreshed snapshot. It exercises the derivation predicate rather than the component's store wiring.

**Not validated:** no `hidden: true` agent was written against a live OpenCode server, so config write-through and restart behavior are unproven. Light theme was not captured; this change alters list contents only and adds no color, icon, or style.

## Visual evidence

Captured against the current HEAD by running the real Settings pane in a headless Chromium at 1440x950 and 900x950. The agents response (`GET /api/agent`) was stubbed so the same fixture renders in both states: `build` and `plan` (native visible), `title`/`summary`/`compaction` (native hidden), `visible-helper` (custom visible), `hidden-helper` (custom, `hidden: true`), and `options-hidden-helper` (custom, `options.hidden: true`). The stub is the data source; everything rendered is the real component, styling, and grouping. The before frame was produced by reverting only the filter predicate to `main`'s `!isAgentHidden(agent)` on the same running app, then restoring it.

**Before — hidden custom subagents unreachable (`Total 3`, only `visible-helper` under Custom Agents):**

![Settings Agents before the fix](https://raw.githubusercontent.com/IbrahimKhan12/openchamber/1bbbf8b28db922f31f8a5d43617ce7981afc7e21/pr-2311/before-wide.png)

**After — hidden custom subagents manageable (`Total 5`, `hidden-helper` and `options-hidden-helper` now listed):**

![Settings Agents after the fix](https://raw.githubusercontent.com/IbrahimKhan12/openchamber/1bbbf8b28db922f31f8a5d43617ce7981afc7e21/pr-2311/after-wide.png)

**After, narrow settings pane (900px) — added rows render correctly in the narrow layout:**

![Settings Agents after the fix, narrow pane](https://raw.githubusercontent.com/IbrahimKhan12/openchamber/1bbbf8b28db922f31f8a5d43617ce7981afc7e21/pr-2311/after-narrow.png)

Both frames keep Built-in Agents at `build` and `plan`, which is the important negative result: the three hidden **native** agents stay excluded before and after, so the fix does not leak internal agents into Settings.

A narrow *before* frame was not captured. The difference is list membership, which is width-independent and already shown in the wide pair; the narrow frame exists to show the added rows lay out correctly in the compact pane.

Screenshots are hosted on the `pr-evidence` branch of the fork so they stay out of this PR's diff.

## Risks and failure behavior

- Manageability is derived from the authoritative `hidden` plus `native`/`builtIn` flags. If an internal agent ever ships hidden without `native` or `builtIn`, it would become visible in Settings; that combination does not exist in the agents this change was tested against but is not defended against in code.
- Rename creates the new agent before deleting the old one, so a failed delete leaves both, with `hidden` preserved on the copy. That failure path is pre-existing and unchanged.
- Pickers are unaffected because they use a different predicate (`filterVisibleAgents`), so this cannot leak hidden agents into selection surfaces. The rebase onto `main`'s directory-scoped selector preserves that separation.
- Rollback is reverting one commit; the only persisted side effect is a `hidden` key written on newly created or copied agents, which upstream already understands.
