### PR TITLE
fix: keep GitHub settings mounted during refresh

### DIFF
--- a/packages/ui/src/components/sections/openchamber/GitHubSettings.test.tsx
+++ b/packages/ui/src/components/sections/openchamber/GitHubSettings.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { I18nProvider } from "@/lib/i18n";
+import { useGitHubAuthStore } from "@/stores/useGitHubAuthStore";
+
+import { GitHubSettings } from "./GitHubSettings";
+
+const serverAuthState = useGitHubAuthStore.getInitialState();
+
+const resetServerAuthState = () => {
+  Object.assign(serverAuthState, {
+    status: null,
+    isLoading: false,
+    hasChecked: false,
+  });
+};
+
+const renderSettings = () =>
+  renderToStaticMarkup(
+    <I18nProvider>
+      <GitHubSettings />
+    </I18nProvider>,
+  );
+
+describe("GitHubSettings", () => {
+  beforeEach(resetServerAuthState);
+  afterEach(resetServerAuthState);
+
+  test("stays hidden during the initial auth status load", () => {
+    serverAuthState.isLoading = true;
+
+    expect(renderSettings()).toBe("");
+  });
+
+  test("stays mounted while a checked status is refreshing, then shows reconnect state", () => {
+    Object.assign(serverAuthState, {
+      status: {
+        connected: true,
+        user: { login: "octocat" },
+      },
+      isLoading: true,
+      hasChecked: true,
+    });
+
+    const refreshingMarkup = renderSettings();
+    expect(refreshingMarkup).toContain("octocat");
+    expect(refreshingMarkup).toContain("Disconnect");
+
+    Object.assign(serverAuthState, {
+      status: { connected: false },
+      isLoading: false,
+      hasChecked: true,
+    });
+
+    const disconnectedMarkup = renderSettings();
+    expect(disconnectedMarkup).toContain("Not Connected");
+    expect(disconnectedMarkup).toContain("Connect GitHub");
+  });
+});

--- a/packages/ui/src/components/sections/openchamber/GitHubSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/GitHubSettings.tsx
@@ -256,7 +256,7 @@ export const GitHubSettings: React.FC = () => {
     }
   }, [runtimeGitHub, setStatus, t]);
 
-  if (isLoading) {
+  if (isLoading && !hasChecked) {
     return null;
   }
 


### PR DESCRIPTION
## Intent

Fixes #2312.

Keep the GitHub Settings section mounted after the initial auth-status check while a forced refresh is in flight. In the disconnect flow, the last known connected state remains visible with the existing disabled actions, then transitions in place to **Not Connected** / **Connect GitHub** when the refreshed status resolves.

## Non-goals

- No change to GitHub OAuth, runtime APIs, auth-store persistence, account switching, or request/error handling.
- No new loading indicator or Settings layout/style change.
- No new copy, locale keys, theme tokens, dependency, or external contract.

## Affected surfaces

| Surface/state | Effect |
| --- | --- |
| Shared `packages/ui` GitHub Settings | One render guard is narrowed from every load to the initial unchecked load. |
| Initial auth-status load | Unchanged: the section remains hidden while `isLoading && !hasChecked`. |
| Checked status refresh | The existing connected/disconnected view stays mounted; locally initiated actions remain disabled through the existing `isBusy` state. |
| Refresh completion | The section updates in place to the refreshed auth status. |
| Web, desktop, VS Code, and mobile consumers | Receive the same shared-UI behavior; no runtime API boundary changes. |

## Repository guidance

| Guidance | Applied | Notes |
| --- | --- | --- |
| `CONTRIBUTING.md` + `.github/PULL_REQUEST_TEMPLATE.md` | Yes | Completed the current intent, non-goals, affected-surfaces, guidance, validation-results, visual-evidence, and risk/failure handoff contract. |
| `AGENTS.md` | Yes | Kept the source change minimal and prepared explicit validation/evidence handoff. |
| `openchamber-change-discipline` | Yes | Reproduced on current `main`, used RED → GREEN, and limited production code to one predicate. |
| `settings-ui-patterns` + `references/layout.md` | Yes | Preserved the existing Settings section/group structure and actions. |
| `theme-system` | Yes | No theme tokens or styling changed. |
| `ui-api-decoupling` | Yes | Runtime API registration and auth-store boundaries are unchanged. |
| `sync-state-invariants` | Yes | Preserved the existing in-flight refresh deduplication, last-known authoritative status, and checked failure-state semantics; no store lifecycle code changed. |
| `locale-ui-patterns` | Yes | Reused existing localized strings; no locale files changed. |
| `packages/ui/src/stores/DOCUMENTATION.md` | Yes | Verified `hasChecked` and refresh-state ownership in the existing store. |
| Nearer owning documentation | None found | No `packages/ui/README.md` or component-level `DOCUMENTATION.md` exists for this path. |

## Validation

Final tested head: `62996c898519bc5efd21941a9da1c702f24134d1`

| Check | Result |
| --- | --- |
| Regression RED on current `main` with the test only | **Expected failure:** 1 pass / 1 fail; checked refresh rendered empty markup instead of `octocat`. |
| `bun test packages/ui/src/components/sections/openchamber/GitHubSettings.test.tsx` | **Passed:** 2 pass / 0 fail, 5 expectations. |
| Focused isolation stress (`--rerun-each=20`) | **Passed:** 40 / 40, 100 expectations. |
| Randomized coexistence with the tablet-layout and five neighboring SSR/component suites | **Passed:** 20 / 20 seeds. |
| `bun run type-check:ui` | **Passed.** |
| `bun run build:ui` | **Passed** (`tsc --noEmit`, same implementation as UI type-check). |
| `bun run lint:ui` | **Passed.** |
| `bun run type-check` | **Passed:** UI, web, Electron, and mobile all exited 0. |
| `bun run lint` | **Passed:** all workspaces exited 0. |
| `bun run build` | **Passed:** full monorepo build exited 0; existing Vite chunk/dynamic-import warnings remain. |
| Electron `test:architecture` | **Passed:** 38 / 38. |
| Electron `test:updater` | **Passed:** 18 / 18. |
| Electron `type-check` | **Passed.** |
| `bun run dead-code` | Completed with exit 0 (`--no-exit-code`). It reports existing repository-wide findings: 259 unused exports, 186 unused exported types, and 2 duplicate exports; neither changed path appears in the report. |
| `git diff --check` | **Passed.** |

Local Bun was `1.3.13`; the repository declares `bun@1.3.14`. Dependencies were installed with `bun install --frozen-lockfile`.

## Visual evidence

Evidence was captured from a controlled local fixture against current `main` and the final candidate, using only the synthetic account `demo-user`. No real OAuth token, callback URL, avatar, email, or personal account data was used.

- Short final-candidate disconnect flow: [animated evidence](https://raw.githubusercontent.com/floze-the-genius/openchamber/e7cb8a0a47f5342bb01dfb871c3aa9ad88614022/pr-evidence/2314/candidate-disconnect-flow-verified.gif)
- Current `main`, refresh in flight (section disappears): [baseline, 1280×800](https://raw.githubusercontent.com/floze-the-genius/openchamber/e7cb8a0a47f5342bb01dfb871c3aa9ad88614022/pr-evidence/2314/baseline-refreshing-wide.jpg)
- Final candidate, refresh in flight at 1280×800 (section remains mounted and actions are disabled): [candidate](https://raw.githubusercontent.com/floze-the-genius/openchamber/e7cb8a0a47f5342bb01dfb871c3aa9ad88614022/pr-evidence/2314/candidate-refreshing-wide.jpg)
- Final candidate at 390×844: [connected](https://raw.githubusercontent.com/floze-the-genius/openchamber/e7cb8a0a47f5342bb01dfb871c3aa9ad88614022/pr-evidence/2314/candidate-connected-narrow.jpg) · [refreshing / disabled](https://raw.githubusercontent.com/floze-the-genius/openchamber/e7cb8a0a47f5342bb01dfb871c3aa9ad88614022/pr-evidence/2314/candidate-refreshing-narrow.jpg) · [disconnected](https://raw.githubusercontent.com/floze-the-genius/openchamber/e7cb8a0a47f5342bb01dfb871c3aa9ad88614022/pr-evidence/2314/candidate-disconnected-narrow.jpg)

The patch does not touch styling or theme behavior, so one theme is the proportionate visual scope.

## Risks and failure behavior

- Functional risk is low and limited to rendering: the auth/network/store code is unchanged.
- During a checked refresh, the last known status intentionally remains visible. Existing `isBusy` handling disables relevant actions until the operation and forced refresh settle.
- The store already clears `isLoading` and records a checked disconnected/error state if status refresh fails, so the section does not remain permanently hidden.
- The focused SSR regression test models the relevant store transitions; the controlled browser run separately verifies the real click, disabled mid-flight state, and final reconnect state at wide and narrow viewports.
- Rollback is the single render-guard predicate plus its focused test; there is no persistence or migration rollback.
- Fork-origin GitHub Actions may still require maintainer approval after the refreshed head is pushed; those remote checks are not represented as locally passed.
