### PR TITLE
fix(settings): prevent local state leaking to remote runtimes

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -27,7 +27,12 @@ import { useGroupOrdering } from './sidebar/hooks/useGroupOrdering';
 import { useSessionGrouping } from './sidebar/hooks/useSessionGrouping';
 import { useSessionSearchEffects } from './sidebar/hooks/useSessionSearchEffects';
 import { useSessionActions } from './sidebar/hooks/useSessionActions';
-import { useSidebarPersistence } from './sidebar/hooks/useSidebarPersistence';
+import {
+  readSidebarActiveSessions,
+  readSidebarGroupOrder,
+  readSidebarStringSet,
+  useSidebarPersistence,
+} from './sidebar/hooks/useSidebarPersistence';
 import { useProjectRepoStatus } from './sidebar/hooks/useProjectRepoStatus';
 import { useProjectSessionLists } from './sidebar/hooks/useProjectSessionLists';
 import { useSessionFolderCleanup } from './sidebar/hooks/useSessionFolderCleanup';
@@ -64,7 +69,7 @@ import { type SessionGroup, type SessionNode } from './sidebar/types';
 import {
   deriveRecentSessions,
 } from './sidebar/activitySections';
-import { useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
+import { SESSION_PINNED_STORAGE_KEY, useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
 import {
   compareSessionsByPinnedAndTime,
   formatProjectLabel,
@@ -80,6 +85,7 @@ import {
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
 import { useGitHubAuthStore } from '@/stores/useGitHubAuthStore';
 import { subscribeOpenchamberEvents } from '@/lib/openchamberEvents';
+import { writeRuntimeScopedStorage } from '@/stores/utils/runtimeScopedStorage';
 
 const PROJECT_COLLAPSE_STORAGE_KEY = 'oc.sessions.projectCollapse';
 const GROUP_ORDER_STORAGE_KEY = 'oc.sessions.groupOrder';
@@ -92,7 +98,6 @@ const PROJECT_ACTIVE_SESSION_STORAGE_KEY = 'oc.sessions.activeSessionByProject';
 // id into all four context combinations.
 const SESSION_EXPANDED_STORAGE_KEY = 'oc.sessions.expandedParents.v2';
 const LEGACY_SESSION_EXPANDED_STORAGE_KEY = 'oc.sessions.expandedParents';
-const SESSION_PINNED_STORAGE_KEY = 'oc.sessions.pinned';
 
 type PrVisualState = 'draft' | 'open' | 'blocked' | 'merged' | 'closed';
 
@@ -206,54 +211,15 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
   const pinnedSessionIds = useSessionPinnedStore((state) => state.ids);
   const setPinnedSessionIds = useSessionPinnedStore((state) => state.setIds);
   const togglePinnedSession = useSessionPinnedStore((state) => state.toggle);
-  const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(() => {
-    try {
-      const raw = getDeferredSafeStorage().getItem(GROUP_COLLAPSE_STORAGE_KEY);
-      if (!raw) {
-        return new Set();
-      }
-      const parsed = JSON.parse(raw) as string[];
-      return new Set(Array.isArray(parsed) ? parsed.filter((item) => typeof item === 'string') : []);
-    } catch {
-      return new Set();
-    }
-  });
-  const [groupOrderByProject, setGroupOrderByProject] = React.useState<Map<string, string[]>>(() => {
-    try {
-      const raw = getDeferredSafeStorage().getItem(GROUP_ORDER_STORAGE_KEY);
-      if (!raw) {
-        return new Map();
-      }
-      const parsed = JSON.parse(raw) as Record<string, string[]>;
-      const next = new Map<string, string[]>();
-      Object.entries(parsed).forEach(([projectId, order]) => {
-        if (Array.isArray(order)) {
-          next.set(projectId, order.filter((item) => typeof item === 'string'));
-        }
-      });
-      return next;
-    } catch {
-      return new Map();
-    }
-  });
-  const [activeSessionByProject, setActiveSessionByProject] = React.useState<Map<string, string>>(() => {
-    try {
-      const raw = getDeferredSafeStorage().getItem(PROJECT_ACTIVE_SESSION_STORAGE_KEY);
-      if (!raw) {
-        return new Map();
-      }
-      const parsed = JSON.parse(raw) as Record<string, string>;
-      const next = new Map<string, string>();
-      Object.entries(parsed).forEach(([projectId, sessionId]) => {
-        if (typeof sessionId === 'string' && sessionId.length > 0) {
-          next.set(projectId, sessionId);
-        }
-      });
-      return next;
-    } catch {
-      return new Map();
-    }
-  });
+  const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(() => (
+    readSidebarStringSet(safeStorage, GROUP_COLLAPSE_STORAGE_KEY)
+  ));
+  const [groupOrderByProject, setGroupOrderByProject] = React.useState<Map<string, string[]>>(() => (
+    readSidebarGroupOrder(safeStorage, GROUP_ORDER_STORAGE_KEY)
+  ));
+  const [activeSessionByProject, setActiveSessionByProject] = React.useState<Map<string, string>>(() => (
+    readSidebarActiveSessions(safeStorage, PROJECT_ACTIVE_SESSION_STORAGE_KEY)
+  ));
 
   const [projectRootBranches, setProjectRootBranches] = React.useState<Map<string, string>>(new Map());
   const projectHeaderSentinelRefs = React.useRef<Map<string, HTMLDivElement | null>>(new Map());
@@ -571,8 +537,11 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     pinnedSessionIds,
     setPinnedSessionIds,
     groupOrderByProject,
+    setGroupOrderByProject,
     activeSessionByProject,
+    setActiveSessionByProject,
     collapsedGroups,
+    setCollapsedGroups,
     setExpandedParents,
     setCollapsedProjects,
   });
@@ -766,7 +735,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
       const next = new Set(prev);
       keysToAdd.forEach((k) => next.add(k));
       try {
-        safeStorage.setItem(SESSION_EXPANDED_STORAGE_KEY, JSON.stringify(Array.from(next)));
+        writeRuntimeScopedStorage(safeStorage, SESSION_EXPANDED_STORAGE_KEY, JSON.stringify(Array.from(next)));
       } catch { /* ignored */ }
       return next;
     });
@@ -781,7 +750,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         next.add(expansionKey);
       }
       try {
-        safeStorage.setItem(SESSION_EXPANDED_STORAGE_KEY, JSON.stringify(Array.from(next)));
+        writeRuntimeScopedStorage(safeStorage, SESSION_EXPANDED_STORAGE_KEY, JSON.stringify(Array.from(next)));
       } catch { /* ignored */ }
       return next;
     });
@@ -855,7 +824,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     setCollapsedProjects(() => {
       const allIds = new Set(projects.map((p) => p.id));
       try {
-        safeStorage.setItem(PROJECT_COLLAPSE_STORAGE_KEY, JSON.stringify(Array.from(allIds)));
+        writeRuntimeScopedStorage(safeStorage, PROJECT_COLLAPSE_STORAGE_KEY, JSON.stringify(Array.from(allIds)));
       } catch { /* ignored */ }
       if (!isVSCode) {
         scheduleCollapsedProjectsPersist(allIds);
@@ -870,7 +839,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
     setCollapsedProjects(() => {
       const empty = new Set<string>();
       try {
-        safeStorage.setItem(PROJECT_COLLAPSE_STORAGE_KEY, JSON.stringify([]));
+        writeRuntimeScopedStorage(safeStorage, PROJECT_COLLAPSE_STORAGE_KEY, JSON.stringify([]));
       } catch { /* ignored */ }
       if (!isVSCode) {
         scheduleCollapsedProjectsPersist(empty);
@@ -891,7 +860,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({
         next.add(projectId);
       }
       try {
-        safeStorage.setItem(PROJECT_COLLAPSE_STORAGE_KEY, JSON.stringify(Array.from(next)));
+        writeRuntimeScopedStorage(safeStorage, PROJECT_COLLAPSE_STORAGE_KEY, JSON.stringify(Array.from(next)));
       } catch { /* ignored */ }
 
       // Persist collapse state to server settings (web + desktop local/remote).

--- a/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
+++ b/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
@@ -46,7 +46,8 @@
 - `hooks/useProjectSessionSelection.ts`: Resolves active/current project-session selection logic and session-directory context.
 - `hooks/useGroupOrdering.ts`: Applies persisted/custom group order with stable fallback ordering; archived groups are reorderable.
 - `hooks/useArchivedAutoFolders.ts`: Maintains archived auto-folder structure and assignment behavior.
-- `hooks/useSidebarPersistence.ts`: Persists sidebar UI state (expanded/collapsed/pinned/group order/active session) to storage + desktop settings.
+- `hooks/useSidebarPersistence.ts`: Persists sidebar UI state (expanded/collapsed/pinned/group order/active session) to runtime-scoped storage + desktop settings. Legacy unscoped values are local-only migration fallbacks; runtime switches reload scoped state and reject stale delayed collapse writes.
+- `hooks/sidebarRuntimeContext.ts`: Captures runtime key plus switch generation so delayed sidebar housekeeping effects cannot mutate the next runtime after a switch.
 - `hooks/useProjectRepoStatus.ts`: Tracks per-project git-repo state and root branch metadata.
 - `hooks/useProjectSessionLists.ts`: Reads live and archived project buckets from the shared ownership index.
 - `hooks/useSessionFolderCleanup.ts`: Cleans stale folder session IDs by reconciling known sessions/archived scopes.

--- a/packages/ui/src/components/session/sidebar/hooks/sidebarRuntimeContext.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/sidebarRuntimeContext.ts
@@ -1,0 +1,25 @@
+import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
+
+export type SidebarRuntimeContext = {
+  runtimeKey: string;
+  generation: number;
+};
+
+let sidebarRuntimeGeneration = 0;
+
+export const captureSidebarRuntimeContext = (): SidebarRuntimeContext => ({
+  runtimeKey: getRuntimeKey(),
+  generation: sidebarRuntimeGeneration,
+});
+
+export const isSidebarRuntimeContextCurrent = (context: SidebarRuntimeContext): boolean => (
+  context.runtimeKey === getRuntimeKey() && context.generation === sidebarRuntimeGeneration
+);
+
+if (typeof window !== 'undefined') {
+  subscribeRuntimeEndpointChanged((detail) => {
+    if (detail.runtimeKey !== detail.previousRuntimeKey) {
+      sidebarRuntimeGeneration += 1;
+    }
+  });
+}

--- a/packages/ui/src/components/session/sidebar/hooks/useArchivedAutoFolders.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useArchivedAutoFolders.ts
@@ -4,6 +4,7 @@ import {
   resolveArchivedFolderName,
 } from '../utils';
 import type { SessionOwnershipIndex } from '../sessionOwnership';
+import { captureSidebarRuntimeContext, isSidebarRuntimeContextCurrent } from './sidebarRuntimeContext';
 
 type ProjectForArchivedFolders = {
   id: string;
@@ -42,13 +43,26 @@ export const useArchivedAutoFolders = (args: Args): void => {
     addSessionToFolder,
     cleanupSessions,
   } = args;
+  const runtimeContextAtRender = captureSidebarRuntimeContext();
+  const runtimeKeyAtRender = runtimeContextAtRender.runtimeKey;
+  const runtimeGenerationAtRender = runtimeContextAtRender.generation;
 
   React.useEffect(() => {
+    const isRuntimeContextCurrent = () => isSidebarRuntimeContextCurrent({
+      runtimeKey: runtimeKeyAtRender,
+      generation: runtimeGenerationAtRender,
+    });
+    if (!isRuntimeContextCurrent()) {
+      return;
+    }
     if (isSessionsLoading || !hasAuthoritativeGlobalSessions || isWorktreeTopologyLoading) {
       return;
     }
 
     normalizedProjects.forEach((project) => {
+      if (!isRuntimeContextCurrent()) {
+        return;
+      }
       if (unresolvedWorktreeProjectPaths.has(project.normalizedPath)) {
         return;
       }
@@ -60,6 +74,9 @@ export const useArchivedAutoFolders = (args: Args): void => {
       const folderByName = new Map(existingFolders.map((folder) => [folder.name.toLowerCase(), folder]));
 
       projectArchivedSessions.forEach((session) => {
+        if (!isRuntimeContextCurrent()) {
+          return;
+        }
         const folderName = resolveArchivedFolderName(session, project.normalizedPath);
         const key = folderName.toLowerCase();
         let folder = folderByName.get(key);
@@ -73,7 +90,9 @@ export const useArchivedAutoFolders = (args: Args): void => {
         }
       });
 
-      cleanupSessions(scopeKey, sessionIds);
+      if (isRuntimeContextCurrent()) {
+        cleanupSessions(scopeKey, sessionIds);
+      }
     });
   }, [
     normalizedProjects,
@@ -86,5 +105,7 @@ export const useArchivedAutoFolders = (args: Args): void => {
     createFolder,
     addSessionToFolder,
     cleanupSessions,
+    runtimeGenerationAtRender,
+    runtimeKeyAtRender,
   ]);
 };

--- a/packages/ui/src/components/session/sidebar/hooks/useSessionFolderCleanup.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSessionFolderCleanup.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { getArchivedScopeKey, normalizePath } from '../utils';
 import type { SessionOwnershipIndex } from '../sessionOwnership';
+import { captureSidebarRuntimeContext, isSidebarRuntimeContextCurrent } from './sidebarRuntimeContext';
 
 type WorktreeMeta = { path: string };
 
@@ -31,8 +32,18 @@ export const useSessionFolderCleanup = (args: Args): void => {
     unresolvedWorktreeProjectPaths,
     cleanupSessions,
   } = args;
+  const runtimeContextAtRender = captureSidebarRuntimeContext();
+  const runtimeKeyAtRender = runtimeContextAtRender.runtimeKey;
+  const runtimeGenerationAtRender = runtimeContextAtRender.generation;
 
   React.useEffect(() => {
+    const isRuntimeContextCurrent = () => isSidebarRuntimeContextCurrent({
+      runtimeKey: runtimeKeyAtRender,
+      generation: runtimeGenerationAtRender,
+    });
+    if (!isRuntimeContextCurrent()) {
+      return;
+    }
     if (isSessionsLoading || !hasAuthoritativeGlobalSessions || isWorktreeTopologyLoading) {
       return;
     }
@@ -65,6 +76,9 @@ export const useSessionFolderCleanup = (args: Args): void => {
     });
 
     idsByScope.forEach((sessionIds, scopeKey) => {
+      if (!isRuntimeContextCurrent()) {
+        return;
+      }
       cleanupSessions(scopeKey, sessionIds);
     });
   }, [
@@ -75,6 +89,8 @@ export const useSessionFolderCleanup = (args: Args): void => {
     isSessionsLoading,
     normalizedProjects,
     ownership,
+    runtimeGenerationAtRender,
+    runtimeKeyAtRender,
     unresolvedWorktreeProjectPaths,
   ]);
 };

--- a/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.test.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.test.ts
@@ -1,8 +1,214 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { Session } from '@opencode-ai/sdk/v2';
+import type { SessionOwnershipIndex } from '../sessionOwnership';
 import { prunePinnedSessionIds } from './pinnedSessionCleanup';
 
+type RuntimeEndpointDetail = {
+  runtimeKey: string;
+  previousRuntimeKey: string;
+};
+
+type StateAction<T> = T | ((previous: T) => T);
+
+const PROJECT_COLLAPSE_KEY = 'project-collapse';
+const EXPANDED_KEY = 'expanded';
+const EXPANDED_LEGACY_KEY = 'expanded-legacy';
+const GROUP_ORDER_KEY = 'group-order';
+const ACTIVE_SESSION_KEY = 'project-active-session';
+const GROUP_COLLAPSE_KEY = 'group-collapse';
+
+let runtimeKey = 'local';
+let projects = [{ id: 'local-project', path: '/Users/local-user/projects/app' }];
+let nextTimerId = 0;
+const scheduledTimers = new Map<number, () => void>();
+const runtimeListeners = new Set<(detail: RuntimeEndpointDetail) => void>();
+const storageValues = new Map<string, string>();
+const updateDesktopSettings = mock(async () => undefined);
+const events = new EventTarget();
+const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const effectCleanups: Array<() => void> = [];
+const deferredEffects: Array<() => void | (() => void)> = [];
+let deferEffects = false;
+
+const runtimeWindow = {
+  addEventListener: events.addEventListener.bind(events),
+  removeEventListener: events.removeEventListener.bind(events),
+  dispatchEvent: events.dispatchEvent.bind(events),
+  clearTimeout: () => undefined,
+  setTimeout: (callback: () => void) => {
+    nextTimerId += 1;
+    scheduledTimers.set(nextTimerId, callback);
+    return nextTimerId;
+  },
+};
+
+Object.defineProperty(globalThis, 'window', {
+  configurable: true,
+  value: runtimeWindow,
+});
+
+const runEffect = (effect: () => void | (() => void)): void => {
+  const cleanup = effect();
+  if (typeof cleanup === 'function') {
+    effectCleanups.push(cleanup);
+  }
+};
+
+const flushDeferredEffects = (): void => {
+  while (deferredEffects.length > 0) {
+    const effect = deferredEffects.shift();
+    if (effect) {
+      runEffect(effect);
+    }
+  }
+};
+
+const reactHooks = {
+  useRef: <T,>(initial: T) => ({ current: initial }),
+  useCallback: <T,>(callback: T) => callback,
+  useEffect: (effect: () => void | (() => void)) => {
+    if (deferEffects) {
+      deferredEffects.push(effect);
+      return;
+    }
+    runEffect(effect);
+  },
+};
+
+mock.module('react', () => ({
+  default: reactHooks,
+  ...reactHooks,
+}));
+
+mock.module('@/lib/persistence', () => ({
+  updateDesktopSettings,
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeApiBaseUrl: () => '',
+  getRuntimeKey: () => runtimeKey,
+  subscribeRuntimeEndpointChanged: (listener: (detail: RuntimeEndpointDetail) => void) => {
+    runtimeListeners.add(listener);
+    return () => runtimeListeners.delete(listener);
+  },
+}));
+
+mock.module('@/stores/useProjectsStore', () => ({
+  useProjectsStore: {
+    getState: () => ({ projects }),
+  },
+}));
+
+mock.module('../utils', () => ({
+  getArchivedScopeKey: (projectPath: string) => `__archived__:${projectPath}`,
+  normalizePath: (path: string | null | undefined) => path?.replace(/\\/g, '/') || null,
+  resolveArchivedFolderName: () => 'archived',
+}));
+
+const { useSidebarPersistence } = await import('./useSidebarPersistence');
+const { useSessionFolderCleanup } = await import('./useSessionFolderCleanup');
+const { useArchivedAutoFolders } = await import('./useArchivedAutoFolders');
+
 const makeSession = (id: string): Pick<Session, 'id'> => ({ id });
+
+const scopedKey = (key: string, targetRuntimeKey = runtimeKey): string => (
+  `${key}:${encodeURIComponent(targetRuntimeKey)}`
+);
+
+const safeStorage = {
+  getItem: (key: string) => storageValues.get(key) ?? null,
+  setItem: (key: string, value: string) => storageValues.set(key, value),
+  removeItem: (key: string) => storageValues.delete(key),
+};
+
+type PersistenceState = {
+  expandedParents: Set<string>;
+  collapsedProjects: Set<string>;
+  groupOrderByProject: Map<string, string[]>;
+  activeSessionByProject: Map<string, string>;
+  collapsedGroups: Set<string>;
+};
+
+const applyStateAction = <T,>(current: T, next: StateAction<T>): T => (
+  typeof next === 'function' ? (next as (previous: T) => T)(current) : next
+);
+
+const createPersistence = (initial: Partial<PersistenceState> = {}) => {
+  const state: PersistenceState = {
+    expandedParents: initial.expandedParents ?? new Set(),
+    collapsedProjects: initial.collapsedProjects ?? new Set(),
+    groupOrderByProject: initial.groupOrderByProject ?? new Map(),
+    activeSessionByProject: initial.activeSessionByProject ?? new Map(),
+    collapsedGroups: initial.collapsedGroups ?? new Set(),
+  };
+
+  const result = useSidebarPersistence({
+    isVSCode: false,
+    hasAuthoritativeGlobalSessions: false,
+    safeStorage,
+    keys: {
+      sessionExpanded: EXPANDED_KEY,
+      sessionExpandedLegacy: EXPANDED_LEGACY_KEY,
+      projectCollapse: PROJECT_COLLAPSE_KEY,
+      sessionPinned: 'pinned',
+      groupOrder: GROUP_ORDER_KEY,
+      projectActiveSession: ACTIVE_SESSION_KEY,
+      groupCollapse: GROUP_COLLAPSE_KEY,
+    },
+    sessions: [],
+    pinnedSessionIds: new Set<string>(),
+    setPinnedSessionIds: () => undefined,
+    groupOrderByProject: state.groupOrderByProject,
+    setGroupOrderByProject: (next) => {
+      state.groupOrderByProject = applyStateAction(state.groupOrderByProject, next);
+    },
+    activeSessionByProject: state.activeSessionByProject,
+    setActiveSessionByProject: (next) => {
+      state.activeSessionByProject = applyStateAction(state.activeSessionByProject, next);
+    },
+    collapsedGroups: state.collapsedGroups,
+    setCollapsedGroups: (next) => {
+      state.collapsedGroups = applyStateAction(state.collapsedGroups, next);
+    },
+    setExpandedParents: (next) => {
+      state.expandedParents = applyStateAction(state.expandedParents, next);
+    },
+    setCollapsedProjects: (next) => {
+      state.collapsedProjects = applyStateAction(state.collapsedProjects, next);
+    },
+  });
+
+  return { state, ...result };
+};
+
+const emitRuntimeEndpointChanged = (nextRuntimeKey: string, previousRuntimeKey = runtimeKey): void => {
+  runtimeKey = nextRuntimeKey;
+  runtimeListeners.forEach((listener) => listener({ runtimeKey: nextRuntimeKey, previousRuntimeKey }));
+};
+
+const runTimer = (id: number): void => {
+  const callback = scheduledTimers.get(id);
+  if (callback) {
+    callback();
+  }
+};
+
+const createOwnership = (): SessionOwnershipIndex => {
+  const owner = {
+    projectId: 'project-a',
+    projectRoot: '/workspace/project',
+    scopeDirectory: '/workspace/project',
+    kind: 'project' as const,
+  };
+  const archivedSession = { id: 'archived-a', directory: '/workspace/project/archive' } as Session;
+  return {
+    bySessionId: new Map([['session-a', owner]]),
+    sessionsByProject: new Map(),
+    archivedSessionsByProject: new Map([['project-a', [archivedSession]]]),
+    sessionsByScope: new Map([['/workspace/project', new Set(['session-a'])]]),
+    directoryResolutions: 1,
+  };
+};
 
 describe('prunePinnedSessionIds', () => {
   test('keeps pinned ids that still exist in the authoritative session list', () => {
@@ -22,5 +228,226 @@ describe('prunePinnedSessionIds', () => {
     const next = prunePinnedSessionIds(sessions, pinnedSessionIds);
 
     expect(next).toBe(pinnedSessionIds);
+  });
+});
+
+describe('sidebar runtime persistence', () => {
+  beforeEach(() => {
+    while (effectCleanups.length > 0) {
+      effectCleanups.pop()?.();
+    }
+    deferredEffects.length = 0;
+    deferEffects = false;
+    runtimeKey = 'local';
+    projects = [{ id: 'local-project', path: '/Users/local-user/projects/app' }];
+    nextTimerId = 0;
+    scheduledTimers.clear();
+    storageValues.clear();
+    updateDesktopSettings.mockClear();
+  });
+
+  afterAll(() => {
+    while (effectCleanups.length > 0) {
+      effectCleanups.pop()?.();
+    }
+    if (previousWindow) {
+      Object.defineProperty(globalThis, 'window', previousWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
+  });
+
+  test('keeps all sidebar metadata isolated when project and session IDs collide', () => {
+    runtimeKey = 'runtime-a';
+    const projectId = 'shared-project';
+    storageValues.set(scopedKey(EXPANDED_KEY, 'runtime-a'), JSON.stringify(['project:active:session-a']));
+    storageValues.set(scopedKey(PROJECT_COLLAPSE_KEY, 'runtime-a'), JSON.stringify([projectId]));
+    storageValues.set(scopedKey(GROUP_ORDER_KEY, 'runtime-a'), JSON.stringify({ [projectId]: ['group-a'] }));
+    storageValues.set(scopedKey(ACTIVE_SESSION_KEY, 'runtime-a'), JSON.stringify({ [projectId]: 'session-a' }));
+    storageValues.set(scopedKey(GROUP_COLLAPSE_KEY, 'runtime-a'), JSON.stringify(['group-a']));
+    storageValues.set(EXPANDED_KEY, JSON.stringify(['legacy-parent']));
+    storageValues.set(PROJECT_COLLAPSE_KEY, JSON.stringify(['legacy-project']));
+
+    storageValues.set(scopedKey(EXPANDED_KEY, 'runtime-b'), JSON.stringify(['project:active:session-b']));
+    storageValues.set(scopedKey(PROJECT_COLLAPSE_KEY, 'runtime-b'), JSON.stringify([]));
+    storageValues.set(scopedKey(GROUP_ORDER_KEY, 'runtime-b'), JSON.stringify({ [projectId]: ['group-b'] }));
+    storageValues.set(scopedKey(ACTIVE_SESSION_KEY, 'runtime-b'), JSON.stringify({ [projectId]: 'session-b' }));
+    storageValues.set(scopedKey(GROUP_COLLAPSE_KEY, 'runtime-b'), JSON.stringify(['group-b']));
+
+    const { state } = createPersistence({
+      expandedParents: new Set(['project:active:session-a']),
+      collapsedProjects: new Set([projectId]),
+      groupOrderByProject: new Map([[projectId, ['group-a']]]),
+      activeSessionByProject: new Map([[projectId, 'session-a']]),
+      collapsedGroups: new Set(['group-a']),
+    });
+
+    expect(state.collapsedProjects).toEqual(new Set([projectId]));
+    emitRuntimeEndpointChanged('runtime-b', 'runtime-a');
+
+    expect(state.expandedParents).toEqual(new Set(['project:active:session-b']));
+    expect(state.collapsedProjects).toEqual(new Set());
+    expect(state.groupOrderByProject).toEqual(new Map([[projectId, ['group-b']]]));
+    expect(state.activeSessionByProject).toEqual(new Map([[projectId, 'session-b']]));
+    expect(state.collapsedGroups).toEqual(new Set(['group-b']));
+  });
+
+  test('uses unscoped sidebar metadata only as a local migration fallback', () => {
+    storageValues.set(EXPANDED_KEY, JSON.stringify(['project:active:local-session']));
+    storageValues.set(PROJECT_COLLAPSE_KEY, JSON.stringify(['local-project']));
+    storageValues.set(GROUP_ORDER_KEY, JSON.stringify({ 'local-project': ['local-group'] }));
+    storageValues.set(ACTIVE_SESSION_KEY, JSON.stringify({ 'local-project': 'local-session' }));
+    storageValues.set(GROUP_COLLAPSE_KEY, JSON.stringify(['local-group']));
+
+    const { state } = createPersistence();
+
+    expect(state.expandedParents).toEqual(new Set(['project:active:local-session']));
+    expect(state.collapsedProjects).toEqual(new Set(['local-project']));
+    expect(state.groupOrderByProject).toEqual(new Map([['local-project', ['local-group']]]));
+    expect(state.activeSessionByProject).toEqual(new Map([['local-project', 'local-session']]));
+    expect(state.collapsedGroups).toEqual(new Set(['local-group']));
+
+    emitRuntimeEndpointChanged('remote-runtime', 'local');
+
+    expect(state.expandedParents).toEqual(new Set());
+    expect(state.collapsedProjects).toEqual(new Set());
+    expect(state.groupOrderByProject).toEqual(new Map());
+    expect(state.activeSessionByProject).toEqual(new Map());
+    expect(state.collapsedGroups).toEqual(new Set());
+  });
+
+  test('applies authoritative project collapse metadata for the active runtime', () => {
+    runtimeKey = 'remote-runtime';
+    const { state } = createPersistence();
+
+    runtimeWindow.dispatchEvent(new CustomEvent('openchamber:settings-synced', {
+      detail: {
+        projects: [
+          { id: 'remote-project', sidebarCollapsed: true },
+          { id: 'expanded-project', sidebarCollapsed: false },
+        ],
+      },
+    }));
+
+    expect(state.collapsedProjects).toEqual(new Set(['remote-project']));
+    expect(storageValues.get(scopedKey(PROJECT_COLLAPSE_KEY, 'remote-runtime'))).toBe(JSON.stringify(['remote-project']));
+  });
+
+  test('does not send a local collapsed-project update after switching to a remote runtime', () => {
+    const { scheduleCollapsedProjectsPersist } = createPersistence();
+    scheduleCollapsedProjectsPersist(new Set(['local-project']));
+
+    runtimeKey = 'remote-runtime';
+    runTimer(1);
+
+    expect(updateDesktopSettings).not.toHaveBeenCalled();
+  });
+
+  test('rejects an old A callback after an A-to-B-to-A switch', () => {
+    runtimeKey = 'runtime-a';
+    projects = [{ id: 'shared-project', path: '/workspace/a' }];
+    const { scheduleCollapsedProjectsPersist } = createPersistence();
+    scheduleCollapsedProjectsPersist(new Set(['old-a']));
+
+    emitRuntimeEndpointChanged('runtime-b', 'runtime-a');
+    emitRuntimeEndpointChanged('runtime-a', 'runtime-b');
+    scheduleCollapsedProjectsPersist(new Set(['new-a']));
+
+    runTimer(1);
+    expect(updateDesktopSettings).not.toHaveBeenCalled();
+
+    runTimer(2);
+    expect(updateDesktopSettings).toHaveBeenCalledWith({
+      projects: [{
+        id: 'shared-project',
+        path: '/workspace/a',
+        sidebarCollapsed: false,
+      }],
+    });
+  });
+
+  test('keeps collapsed-project persistence for updates scheduled on the active remote runtime', () => {
+    runtimeKey = 'remote-runtime';
+    projects = [{ id: 'remote-project', path: '/home/remote-user/project' }];
+    const { scheduleCollapsedProjectsPersist } = createPersistence();
+    scheduleCollapsedProjectsPersist(new Set(['remote-project']));
+
+    runTimer(1);
+
+    expect(updateDesktopSettings).toHaveBeenCalledWith({
+      projects: [{
+        id: 'remote-project',
+        path: '/home/remote-user/project',
+        sidebarCollapsed: true,
+      }],
+    });
+  });
+
+  test('rejects stale folder cleanup and archived-folder effects after an A-to-B-to-A switch', () => {
+    runtimeKey = 'runtime-a';
+    const ownership = createOwnership();
+    const cleanupSessions = mock(() => undefined);
+    const createFolder = mock(() => ({ id: 'folder-a', name: 'archived', sessionIds: [] }));
+    const addSessionToFolder = mock(() => undefined);
+    deferEffects = true;
+
+    useSessionFolderCleanup({
+      isSessionsLoading: false,
+      hasAuthoritativeGlobalSessions: true,
+      isWorktreeTopologyLoading: false,
+      normalizedProjects: [{ id: 'project-a', normalizedPath: '/workspace/project' }],
+      ownership,
+      availableWorktreesByProject: new Map(),
+      unresolvedWorktreeProjectPaths: new Set(),
+      cleanupSessions,
+    });
+    useArchivedAutoFolders({
+      normalizedProjects: [{ id: 'project-a', normalizedPath: '/workspace/project' }],
+      ownership,
+      isSessionsLoading: false,
+      hasAuthoritativeGlobalSessions: true,
+      isWorktreeTopologyLoading: false,
+      unresolvedWorktreeProjectPaths: new Set(),
+      foldersMap: {},
+      createFolder,
+      addSessionToFolder,
+      cleanupSessions,
+    });
+
+    emitRuntimeEndpointChanged('runtime-b', 'runtime-a');
+    emitRuntimeEndpointChanged('runtime-a', 'runtime-b');
+    deferEffects = false;
+    flushDeferredEffects();
+
+    expect(cleanupSessions).not.toHaveBeenCalled();
+    expect(createFolder).not.toHaveBeenCalled();
+    expect(addSessionToFolder).not.toHaveBeenCalled();
+
+    useSessionFolderCleanup({
+      isSessionsLoading: false,
+      hasAuthoritativeGlobalSessions: true,
+      isWorktreeTopologyLoading: false,
+      normalizedProjects: [{ id: 'project-a', normalizedPath: '/workspace/project' }],
+      ownership,
+      availableWorktreesByProject: new Map(),
+      unresolvedWorktreeProjectPaths: new Set(),
+      cleanupSessions,
+    });
+    useArchivedAutoFolders({
+      normalizedProjects: [{ id: 'project-a', normalizedPath: '/workspace/project' }],
+      ownership,
+      isSessionsLoading: false,
+      hasAuthoritativeGlobalSessions: true,
+      isWorktreeTopologyLoading: false,
+      unresolvedWorktreeProjectPaths: new Set(),
+      foldersMap: {},
+      createFolder,
+      addSessionToFolder,
+      cleanupSessions,
+    });
+
+    expect(cleanupSessions).toHaveBeenCalled();
+    expect(createFolder).toHaveBeenCalledWith('__archived__:/workspace/project', 'archived');
+    expect(addSessionToFolder).toHaveBeenCalledWith('__archived__:/workspace/project', 'folder-a', 'archived-a');
   });
 });

--- a/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.test.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.test.ts
@@ -133,7 +133,7 @@ const applyStateAction = <T,>(current: T, next: StateAction<T>): T => (
   typeof next === 'function' ? (next as (previous: T) => T)(current) : next
 );
 
-const createPersistence = (initial: Partial<PersistenceState> = {}) => {
+const usePersistenceHarness = (initial: Partial<PersistenceState> = {}) => {
   const state: PersistenceState = {
     expandedParents: initial.expandedParents ?? new Set(),
     collapsedProjects: initial.collapsedProjects ?? new Set(),
@@ -274,7 +274,7 @@ describe('sidebar runtime persistence', () => {
     storageValues.set(scopedKey(ACTIVE_SESSION_KEY, 'runtime-b'), JSON.stringify({ [projectId]: 'session-b' }));
     storageValues.set(scopedKey(GROUP_COLLAPSE_KEY, 'runtime-b'), JSON.stringify(['group-b']));
 
-    const { state } = createPersistence({
+    const { state } = usePersistenceHarness({
       expandedParents: new Set(['project:active:session-a']),
       collapsedProjects: new Set([projectId]),
       groupOrderByProject: new Map([[projectId, ['group-a']]]),
@@ -299,7 +299,7 @@ describe('sidebar runtime persistence', () => {
     storageValues.set(ACTIVE_SESSION_KEY, JSON.stringify({ 'local-project': 'local-session' }));
     storageValues.set(GROUP_COLLAPSE_KEY, JSON.stringify(['local-group']));
 
-    const { state } = createPersistence();
+    const { state } = usePersistenceHarness();
 
     expect(state.expandedParents).toEqual(new Set(['project:active:local-session']));
     expect(state.collapsedProjects).toEqual(new Set(['local-project']));
@@ -318,7 +318,7 @@ describe('sidebar runtime persistence', () => {
 
   test('applies authoritative project collapse metadata for the active runtime', () => {
     runtimeKey = 'remote-runtime';
-    const { state } = createPersistence();
+    const { state } = usePersistenceHarness();
 
     runtimeWindow.dispatchEvent(new CustomEvent('openchamber:settings-synced', {
       detail: {
@@ -334,7 +334,7 @@ describe('sidebar runtime persistence', () => {
   });
 
   test('does not send a local collapsed-project update after switching to a remote runtime', () => {
-    const { scheduleCollapsedProjectsPersist } = createPersistence();
+    const { scheduleCollapsedProjectsPersist } = usePersistenceHarness();
     scheduleCollapsedProjectsPersist(new Set(['local-project']));
 
     runtimeKey = 'remote-runtime';
@@ -346,7 +346,7 @@ describe('sidebar runtime persistence', () => {
   test('rejects an old A callback after an A-to-B-to-A switch', () => {
     runtimeKey = 'runtime-a';
     projects = [{ id: 'shared-project', path: '/workspace/a' }];
-    const { scheduleCollapsedProjectsPersist } = createPersistence();
+    const { scheduleCollapsedProjectsPersist } = usePersistenceHarness();
     scheduleCollapsedProjectsPersist(new Set(['old-a']));
 
     emitRuntimeEndpointChanged('runtime-b', 'runtime-a');
@@ -369,7 +369,7 @@ describe('sidebar runtime persistence', () => {
   test('keeps collapsed-project persistence for updates scheduled on the active remote runtime', () => {
     runtimeKey = 'remote-runtime';
     projects = [{ id: 'remote-project', path: '/home/remote-user/project' }];
-    const { scheduleCollapsedProjectsPersist } = createPersistence();
+    const { scheduleCollapsedProjectsPersist } = usePersistenceHarness();
     scheduleCollapsedProjectsPersist(new Set(['remote-project']));
 
     runTimer(1);

--- a/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.ts
@@ -198,6 +198,8 @@ export const useSidebarPersistence = (args: Args) => {
     context.generation === runtimeGeneration.current && context.runtimeKey === getRuntimeKey()
   ), []);
   const runtimeContextAtRender = captureRuntimeContext();
+  const runtimeKeyAtRender = runtimeContextAtRender.runtimeKey;
+  const runtimeGenerationAtRender = runtimeContextAtRender.generation;
 
   const reloadRuntimeState = React.useCallback((runtimeContext: SidebarRuntimeContext): void => {
     if (!isRuntimeContextCurrent(runtimeContext)) {
@@ -353,12 +355,15 @@ export const useSidebarPersistence = (args: Args) => {
   }, [hasAuthoritativeGlobalSessions, sessions, setPinnedSessionIds]);
 
   React.useEffect(() => {
-    if (!isRuntimeContextCurrent(runtimeContextAtRender)) {
+    if (!isRuntimeContextCurrent({
+      runtimeKey: runtimeKeyAtRender,
+      generation: runtimeGenerationAtRender,
+    })) {
       return;
     }
     try {
       const serialized = Object.fromEntries(groupOrderByProject.entries());
-      writeRuntimeScopedStorage(safeStorage, keys.groupOrder, JSON.stringify(serialized), runtimeContextAtRender.runtimeKey);
+      writeRuntimeScopedStorage(safeStorage, keys.groupOrder, JSON.stringify(serialized), runtimeKeyAtRender);
     } catch {
       // ignored
     }
@@ -366,18 +371,21 @@ export const useSidebarPersistence = (args: Args) => {
     groupOrderByProject,
     isRuntimeContextCurrent,
     keys.groupOrder,
-    runtimeContextAtRender.generation,
-    runtimeContextAtRender.runtimeKey,
+    runtimeGenerationAtRender,
+    runtimeKeyAtRender,
     safeStorage,
   ]);
 
   React.useEffect(() => {
-    if (!isRuntimeContextCurrent(runtimeContextAtRender)) {
+    if (!isRuntimeContextCurrent({
+      runtimeKey: runtimeKeyAtRender,
+      generation: runtimeGenerationAtRender,
+    })) {
       return;
     }
     try {
       const serialized = Object.fromEntries(activeSessionByProject.entries());
-      writeRuntimeScopedStorage(safeStorage, keys.projectActiveSession, JSON.stringify(serialized), runtimeContextAtRender.runtimeKey);
+      writeRuntimeScopedStorage(safeStorage, keys.projectActiveSession, JSON.stringify(serialized), runtimeKeyAtRender);
     } catch {
       // ignored
     }
@@ -385,13 +393,16 @@ export const useSidebarPersistence = (args: Args) => {
     activeSessionByProject,
     isRuntimeContextCurrent,
     keys.projectActiveSession,
-    runtimeContextAtRender.generation,
-    runtimeContextAtRender.runtimeKey,
+    runtimeGenerationAtRender,
+    runtimeKeyAtRender,
     safeStorage,
   ]);
 
   React.useEffect(() => {
-    if (!isRuntimeContextCurrent(runtimeContextAtRender)) {
+    if (!isRuntimeContextCurrent({
+      runtimeKey: runtimeKeyAtRender,
+      generation: runtimeGenerationAtRender,
+    })) {
       return;
     }
     try {
@@ -399,7 +410,7 @@ export const useSidebarPersistence = (args: Args) => {
         safeStorage,
         keys.groupCollapse,
         JSON.stringify(Array.from(collapsedGroups)),
-        runtimeContextAtRender.runtimeKey,
+        runtimeKeyAtRender,
       );
     } catch {
       // ignored
@@ -408,8 +419,8 @@ export const useSidebarPersistence = (args: Args) => {
     collapsedGroups,
     isRuntimeContextCurrent,
     keys.groupCollapse,
-    runtimeContextAtRender.generation,
-    runtimeContextAtRender.runtimeKey,
+    runtimeGenerationAtRender,
+    runtimeKeyAtRender,
     safeStorage,
   ]);
 

--- a/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useSidebarPersistence.ts
@@ -1,6 +1,8 @@
 import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
 import { updateDesktopSettings } from '@/lib/persistence';
+import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
+import { readRuntimeScopedStorage, writeRuntimeScopedStorage } from '@/stores/utils/runtimeScopedStorage';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { prunePinnedSessionIds } from './pinnedSessionCleanup';
 
@@ -24,12 +26,127 @@ type Keys = {
   groupCollapse: string;
 };
 
+type SidebarRuntimeContext = {
+  runtimeKey: string;
+  generation: number;
+};
+
 const LEGACY_EXPANSION_CONTEXT_PREFIXES = [
   'project:active:',
   'project:archived:',
   'recent:active:',
   'recent:archived:',
 ];
+
+const parseStringSet = (raw: string | null): Set<string> => {
+  if (!raw) {
+    return new Set();
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return new Set(Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : []);
+  } catch {
+    return new Set();
+  }
+};
+
+export const readSidebarStringSet = (
+  safeStorage: SafeStorageLike,
+  key: string,
+  runtimeKey = getRuntimeKey(),
+): Set<string> => {
+  return parseStringSet(readRuntimeScopedStorage(safeStorage, key, runtimeKey));
+};
+
+export const readSidebarGroupOrder = (
+  safeStorage: SafeStorageLike,
+  key: string,
+  runtimeKey = getRuntimeKey(),
+): Map<string, string[]> => {
+  try {
+    const raw = readRuntimeScopedStorage(safeStorage, key, runtimeKey);
+    if (!raw) {
+      return new Map();
+    }
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return new Map();
+    }
+    const next = new Map<string, string[]>();
+    Object.entries(parsed).forEach(([projectId, order]) => {
+      if (Array.isArray(order)) {
+        next.set(projectId, order.filter((item): item is string => typeof item === 'string'));
+      }
+    });
+    return next;
+  } catch {
+    return new Map();
+  }
+};
+
+export const readSidebarActiveSessions = (
+  safeStorage: SafeStorageLike,
+  key: string,
+  runtimeKey = getRuntimeKey(),
+): Map<string, string> => {
+  try {
+    const raw = readRuntimeScopedStorage(safeStorage, key, runtimeKey);
+    if (!raw) {
+      return new Map();
+    }
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return new Map();
+    }
+    const next = new Map<string, string>();
+    Object.entries(parsed).forEach(([projectId, sessionId]) => {
+      if (typeof sessionId === 'string' && sessionId.length > 0) {
+        next.set(projectId, sessionId);
+      }
+    });
+    return next;
+  } catch {
+    return new Map();
+  }
+};
+
+const readExpandedParents = (
+  safeStorage: SafeStorageLike,
+  sessionExpandedKey: string,
+  sessionExpandedLegacyKey: string,
+  runtimeKey: string,
+): Set<string> => {
+  const storedParents = readRuntimeScopedStorage(safeStorage, sessionExpandedKey, runtimeKey);
+  if (storedParents !== null) {
+    return parseStringSet(storedParents);
+  }
+
+  const legacyRaw = readRuntimeScopedStorage(safeStorage, sessionExpandedLegacyKey, runtimeKey);
+  if (legacyRaw === null) {
+    return new Set();
+  }
+
+  const legacyParents = parseStringSet(legacyRaw);
+  const migrated = new Set<string>();
+  legacyParents.forEach((item) => {
+    LEGACY_EXPANSION_CONTEXT_PREFIXES.forEach((prefix) => migrated.add(`${prefix}${item}`));
+  });
+  if (migrated.size > 0) {
+    try {
+      writeRuntimeScopedStorage(safeStorage, sessionExpandedKey, JSON.stringify(Array.from(migrated)), runtimeKey);
+    } catch {
+      // ignored
+    }
+  }
+  if (runtimeKey === 'local') {
+    try {
+      safeStorage.removeItem?.(sessionExpandedLegacyKey);
+    } catch {
+      // ignored
+    }
+  }
+  return migrated;
+};
 
 type Args = {
   isVSCode: boolean;
@@ -40,8 +157,11 @@ type Args = {
   pinnedSessionIds: Set<string>;
   setPinnedSessionIds: React.Dispatch<React.SetStateAction<Set<string>>>;
   groupOrderByProject: Map<string, string[]>;
+  setGroupOrderByProject: React.Dispatch<React.SetStateAction<Map<string, string[]>>>;
   activeSessionByProject: Map<string, string>;
+  setActiveSessionByProject: React.Dispatch<React.SetStateAction<Map<string, string>>>;
   collapsedGroups: Set<string>;
+  setCollapsedGroups: React.Dispatch<React.SetStateAction<Set<string>>>;
   setExpandedParents: React.Dispatch<React.SetStateAction<Set<string>>>;
   setCollapsedProjects: React.Dispatch<React.SetStateAction<Set<string>>>;
 };
@@ -55,47 +175,121 @@ export const useSidebarPersistence = (args: Args) => {
     sessions,
     setPinnedSessionIds,
     groupOrderByProject,
+    setGroupOrderByProject,
     activeSessionByProject,
+    setActiveSessionByProject,
     collapsedGroups,
+    setCollapsedGroups,
     setExpandedParents,
     setCollapsedProjects,
   } = args;
 
   const persistCollapsedProjectsTimer = React.useRef<number | null>(null);
-  const pendingCollapsedProjects = React.useRef<Set<string> | null>(null);
+  const pendingCollapsedProjects = React.useRef<{
+    collapsed: Set<string>;
+    runtimeContext: SidebarRuntimeContext;
+  } | null>(null);
+  const runtimeGeneration = React.useRef(0);
+  const captureRuntimeContext = React.useCallback((): SidebarRuntimeContext => ({
+    runtimeKey: getRuntimeKey(),
+    generation: runtimeGeneration.current,
+  }), []);
+  const isRuntimeContextCurrent = React.useCallback((context: SidebarRuntimeContext): boolean => (
+    context.generation === runtimeGeneration.current && context.runtimeKey === getRuntimeKey()
+  ), []);
+  const runtimeContextAtRender = captureRuntimeContext();
 
-  const flushCollapsedProjectsPersist = React.useCallback(() => {
+  const reloadRuntimeState = React.useCallback((runtimeContext: SidebarRuntimeContext): void => {
+    if (!isRuntimeContextCurrent(runtimeContext)) {
+      return;
+    }
+
+    setExpandedParents(readExpandedParents(
+      safeStorage,
+      keys.sessionExpanded,
+      keys.sessionExpandedLegacy,
+      runtimeContext.runtimeKey,
+    ));
+    setCollapsedProjects(readSidebarStringSet(safeStorage, keys.projectCollapse, runtimeContext.runtimeKey));
+    setGroupOrderByProject(readSidebarGroupOrder(safeStorage, keys.groupOrder, runtimeContext.runtimeKey));
+    setActiveSessionByProject(readSidebarActiveSessions(safeStorage, keys.projectActiveSession, runtimeContext.runtimeKey));
+    setCollapsedGroups(readSidebarStringSet(safeStorage, keys.groupCollapse, runtimeContext.runtimeKey));
+  }, [
+    isRuntimeContextCurrent,
+    keys.groupCollapse,
+    keys.groupOrder,
+    keys.projectActiveSession,
+    keys.projectCollapse,
+    keys.sessionExpanded,
+    keys.sessionExpandedLegacy,
+    safeStorage,
+    setActiveSessionByProject,
+    setCollapsedGroups,
+    setCollapsedProjects,
+    setExpandedParents,
+    setGroupOrderByProject,
+  ]);
+
+  const flushCollapsedProjectsPersist = React.useCallback((expectedRuntimeContext: SidebarRuntimeContext) => {
     if (isVSCode) {
       return;
     }
-    const collapsed = pendingCollapsedProjects.current;
-    pendingCollapsedProjects.current = null;
-    persistCollapsedProjectsTimer.current = null;
-    if (!collapsed) {
+    const pending = pendingCollapsedProjects.current;
+    if (
+      !pending
+      || pending.runtimeContext.runtimeKey !== expectedRuntimeContext.runtimeKey
+      || pending.runtimeContext.generation !== expectedRuntimeContext.generation
+      || !isRuntimeContextCurrent(pending.runtimeContext)
+    ) {
       return;
     }
+    pendingCollapsedProjects.current = null;
+    persistCollapsedProjectsTimer.current = null;
 
+    const { collapsed } = pending;
     const { projects } = useProjectsStore.getState();
     const updatedProjects = projects.map((project) => ({
       ...project,
       sidebarCollapsed: collapsed.has(project.id),
     }));
     void updateDesktopSettings({ projects: updatedProjects }).catch(() => {});
-  }, [isVSCode]);
+  }, [isRuntimeContextCurrent, isVSCode]);
 
   const scheduleCollapsedProjectsPersist = React.useCallback((collapsed: Set<string>) => {
     if (typeof window === 'undefined' || isVSCode) {
       return;
     }
 
-    pendingCollapsedProjects.current = collapsed;
+    const runtimeContext = captureRuntimeContext();
+    pendingCollapsedProjects.current = {
+      collapsed: new Set(collapsed),
+      runtimeContext,
+    };
     if (persistCollapsedProjectsTimer.current !== null) {
       window.clearTimeout(persistCollapsedProjectsTimer.current);
     }
     persistCollapsedProjectsTimer.current = window.setTimeout(() => {
-      flushCollapsedProjectsPersist();
+      flushCollapsedProjectsPersist(runtimeContext);
     }, 700);
-  }, [isVSCode, flushCollapsedProjectsPersist]);
+  }, [captureRuntimeContext, isVSCode, flushCollapsedProjectsPersist]);
+
+  React.useEffect(() => {
+    const initialContext = captureRuntimeContext();
+    reloadRuntimeState(initialContext);
+
+    return subscribeRuntimeEndpointChanged((detail) => {
+      if (detail.runtimeKey === detail.previousRuntimeKey) {
+        return;
+      }
+      runtimeGeneration.current += 1;
+      if (typeof window !== 'undefined' && persistCollapsedProjectsTimer.current !== null) {
+        window.clearTimeout(persistCollapsedProjectsTimer.current);
+      }
+      persistCollapsedProjectsTimer.current = null;
+      pendingCollapsedProjects.current = null;
+      reloadRuntimeState(captureRuntimeContext());
+    });
+  }, [captureRuntimeContext, reloadRuntimeState]);
 
   React.useEffect(() => {
     return () => {
@@ -108,47 +302,45 @@ export const useSidebarPersistence = (args: Args) => {
   }, []);
 
   React.useEffect(() => {
-    try {
-      const storedParents = safeStorage.getItem(keys.sessionExpanded);
-      if (storedParents) {
-        const parsed = JSON.parse(storedParents);
-        if (Array.isArray(parsed)) {
-          setExpandedParents(new Set(parsed.filter((item) => typeof item === 'string')));
-        }
-      } else {
-        // No v2 data — migrate from v1 (bare session ids) if present.
-        const legacyRaw = safeStorage.getItem(keys.sessionExpandedLegacy);
-        if (legacyRaw) {
-          try {
-            const parsedLegacy = JSON.parse(legacyRaw);
-            if (Array.isArray(parsedLegacy)) {
-              const migrated = new Set<string>();
-              parsedLegacy.forEach((item) => {
-                if (typeof item !== 'string' || item.length === 0) return;
-                LEGACY_EXPANSION_CONTEXT_PREFIXES.forEach((prefix) => migrated.add(`${prefix}${item}`));
-              });
-              if (migrated.size > 0) {
-                setExpandedParents(migrated);
-                try { safeStorage.setItem(keys.sessionExpanded, JSON.stringify(Array.from(migrated))); } catch { /* ignored */ }
-              }
-            }
-          } catch {
-            // legacy data was malformed; ignore and let it expire
-          }
-          try { safeStorage.removeItem?.(keys.sessionExpandedLegacy); } catch { /* ignored */ }
-        }
-      }
-      const storedProjects = safeStorage.getItem(keys.projectCollapse);
-      if (storedProjects) {
-        const parsed = JSON.parse(storedProjects);
-        if (Array.isArray(parsed)) {
-          setCollapsedProjects(new Set(parsed.filter((item) => typeof item === 'string')));
-        }
-      }
-    } catch {
-      // ignored
+    if (typeof window === 'undefined') {
+      return;
     }
-  }, [keys.projectCollapse, keys.sessionExpanded, keys.sessionExpandedLegacy, safeStorage, setCollapsedProjects, setExpandedParents]);
+
+    const onSettingsSynced = (event: Event) => {
+      const settings = (event as CustomEvent<{ projects?: unknown }>).detail;
+      if (!settings || !Array.isArray(settings.projects)) {
+        return;
+      }
+      const runtimeContext = captureRuntimeContext();
+      if (!isRuntimeContextCurrent(runtimeContext)) {
+        return;
+      }
+      const collapsed = new Set(
+        settings.projects
+          .filter((project): project is { id: string; sidebarCollapsed?: boolean } => (
+            Boolean(project)
+            && typeof project === 'object'
+            && typeof (project as { id?: unknown }).id === 'string'
+          ))
+          .filter((project) => project.sidebarCollapsed === true)
+          .map((project) => project.id),
+      );
+      setCollapsedProjects(collapsed);
+      try {
+        writeRuntimeScopedStorage(
+          safeStorage,
+          keys.projectCollapse,
+          JSON.stringify(Array.from(collapsed)),
+          runtimeContext.runtimeKey,
+        );
+      } catch {
+        // ignored
+      }
+    };
+
+    window.addEventListener('openchamber:settings-synced', onSettingsSynced);
+    return () => window.removeEventListener('openchamber:settings-synced', onSettingsSynced);
+  }, [captureRuntimeContext, isRuntimeContextCurrent, keys.projectCollapse, safeStorage, setCollapsedProjects]);
 
   React.useEffect(() => {
     if (!hasAuthoritativeGlobalSessions) {
@@ -161,30 +353,65 @@ export const useSidebarPersistence = (args: Args) => {
   }, [hasAuthoritativeGlobalSessions, sessions, setPinnedSessionIds]);
 
   React.useEffect(() => {
+    if (!isRuntimeContextCurrent(runtimeContextAtRender)) {
+      return;
+    }
     try {
       const serialized = Object.fromEntries(groupOrderByProject.entries());
-      safeStorage.setItem(keys.groupOrder, JSON.stringify(serialized));
+      writeRuntimeScopedStorage(safeStorage, keys.groupOrder, JSON.stringify(serialized), runtimeContextAtRender.runtimeKey);
     } catch {
       // ignored
     }
-  }, [groupOrderByProject, keys.groupOrder, safeStorage]);
+  }, [
+    groupOrderByProject,
+    isRuntimeContextCurrent,
+    keys.groupOrder,
+    runtimeContextAtRender.generation,
+    runtimeContextAtRender.runtimeKey,
+    safeStorage,
+  ]);
 
   React.useEffect(() => {
+    if (!isRuntimeContextCurrent(runtimeContextAtRender)) {
+      return;
+    }
     try {
       const serialized = Object.fromEntries(activeSessionByProject.entries());
-      safeStorage.setItem(keys.projectActiveSession, JSON.stringify(serialized));
+      writeRuntimeScopedStorage(safeStorage, keys.projectActiveSession, JSON.stringify(serialized), runtimeContextAtRender.runtimeKey);
     } catch {
       // ignored
     }
-  }, [activeSessionByProject, keys.projectActiveSession, safeStorage]);
+  }, [
+    activeSessionByProject,
+    isRuntimeContextCurrent,
+    keys.projectActiveSession,
+    runtimeContextAtRender.generation,
+    runtimeContextAtRender.runtimeKey,
+    safeStorage,
+  ]);
 
   React.useEffect(() => {
+    if (!isRuntimeContextCurrent(runtimeContextAtRender)) {
+      return;
+    }
     try {
-      safeStorage.setItem(keys.groupCollapse, JSON.stringify(Array.from(collapsedGroups)));
+      writeRuntimeScopedStorage(
+        safeStorage,
+        keys.groupCollapse,
+        JSON.stringify(Array.from(collapsedGroups)),
+        runtimeContextAtRender.runtimeKey,
+      );
     } catch {
       // ignored
     }
-  }, [collapsedGroups, keys.groupCollapse, safeStorage]);
+  }, [
+    collapsedGroups,
+    isRuntimeContextCurrent,
+    keys.groupCollapse,
+    runtimeContextAtRender.generation,
+    runtimeContextAtRender.runtimeKey,
+    safeStorage,
+  ]);
 
   return { scheduleCollapsedProjectsPersist };
 };

--- a/packages/ui/src/lib/directoryPersistence.test.ts
+++ b/packages/ui/src/lib/directoryPersistence.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  installRuntimeSettingsTestWindow,
+  resetRuntimeSettingsTestState,
+  restoreRuntimeSettingsTestWindow,
+  runtimeWindow,
+  setRuntimeKey,
+  updateDesktopSettings,
+} from '../stores/runtimeSettingsTestSupport';
+
+installRuntimeSettingsTestWindow();
+
+const { useDirectoryStore } = await import('@/stores/useDirectoryStore');
+const { applyPersistedDirectoryPreferences } = await import('./directoryPersistence');
+
+describe('applyPersistedDirectoryPreferences', () => {
+  beforeEach(() => {
+    resetRuntimeSettingsTestState();
+    setRuntimeKey('remote-runtime');
+    updateDesktopSettings.mockClear();
+    useDirectoryStore.setState({
+      currentDirectory: '/',
+      directoryHistory: ['/'],
+      historyIndex: 0,
+      homeDirectory: '/',
+      hasPersistedDirectory: false,
+      isHomeReady: false,
+      isSwitchingDirectory: false,
+    });
+    Object.assign(runtimeWindow, {
+      localStorage: {
+        getItem: (key: string) => key === 'lastDirectory' ? '/Users/local-user/projects/app' : null,
+      },
+    });
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(runtimeWindow, 'localStorage');
+    restoreRuntimeSettingsTestWindow();
+  });
+
+  test('does not apply a browser-local last directory to a remote runtime', async () => {
+    await applyPersistedDirectoryPreferences();
+
+    expect(useDirectoryStore.getState().currentDirectory).toBe('/');
+    expect(updateDesktopSettings).not.toHaveBeenCalled();
+  });
+
+  test('continues to restore the browser-local last directory for the local runtime', async () => {
+    setRuntimeKey('local');
+
+    await applyPersistedDirectoryPreferences();
+
+    expect(useDirectoryStore.getState().currentDirectory).toBe('/Users/local-user/projects/app');
+    expect(updateDesktopSettings).toHaveBeenCalledWith({ lastDirectory: '/Users/local-user/projects/app' });
+  });
+});

--- a/packages/ui/src/lib/directoryPersistence.ts
+++ b/packages/ui/src/lib/directoryPersistence.ts
@@ -1,8 +1,13 @@
 import { isVSCodeRuntime } from '@/lib/desktop';
+import { getRuntimeKey } from '@/lib/runtime-switch';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 
 export const applyPersistedDirectoryPreferences = async (): Promise<void> => {
   if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (getRuntimeKey() !== 'local' || isVSCodeRuntime()) {
     return;
   }
 
@@ -21,7 +26,7 @@ export const applyPersistedDirectoryPreferences = async (): Promise<void> => {
   // desktop settings, overriding the authoritative resolution
   // (initializeHomeDirectory → /api/fs/home) that runs on every startup.
 
-  if (savedDirectory && !isVSCodeRuntime()) {
+  if (savedDirectory) {
     useDirectoryStore.getState().setDirectory(savedDirectory, { showOverlay: false });
   }
 };

--- a/packages/ui/src/lib/opencode/client.test.ts
+++ b/packages/ui/src/lib/opencode/client.test.ts
@@ -6,6 +6,7 @@ type ConfigResponse = { data: Record<string, unknown> };
 
 const configResolvers: Array<(response: ConfigResponse) => void> = [];
 let configCalls = 0;
+let runtimeKey = 'test-runtime';
 const promptAsyncCalls: unknown[][] = [];
 const promptAsyncResults: Array<unknown> = [];
 
@@ -26,8 +27,15 @@ mock.module('@opencode-ai/sdk/v2', () => ({
         });
       }),
     },
+    path: {
+      get: mock(async () => ({ data: undefined })),
+    },
+    project: {
+      current: mock(async () => ({ data: undefined })),
+    },
     session: {
       promptAsync: promptAsyncMock,
+      list: mock(async () => ({ data: [] })),
     },
   })),
 }));
@@ -44,7 +52,7 @@ mock.module('@/lib/runtime-url', () => ({
 
 mock.module('@/lib/runtime-switch', () => ({
   getRuntimeApiBaseUrl: mock(() => ''),
-  getRuntimeKey: mock(() => 'test-runtime'),
+  getRuntimeKey: mock(() => runtimeKey),
 }));
 
 mock.module('@/lib/runtime-fetch', () => ({
@@ -87,6 +95,35 @@ describe('opencodeClient getConfig cache', () => {
     const cached = await opencodeClient.getConfig('/workspace/project');
     expect(cached).toEqual({ model: 'new/model' });
     expect(configCalls).toBe(2);
+  });
+});
+
+describe('opencodeClient system-info fallbacks', () => {
+  test('does not derive a remote home directory from browser-local storage', async () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    try {
+      runtimeKey = 'remote-runtime';
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+          localStorage: {
+            getItem: (key: string) => key === 'homeDirectory' ? '/Users/local-user' : '/Users/local-user/projects/app',
+          },
+        },
+      });
+      opencodeClient.setDirectory(undefined);
+
+      const info = await opencodeClient.getSystemInfo();
+
+      expect(info.homeDirectory).toBe('/');
+    } finally {
+      runtimeKey = 'test-runtime';
+      if (previousWindow) {
+        Object.defineProperty(globalThis, 'window', previousWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
+    }
   });
 });
 

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -429,6 +429,7 @@ class OpencodeService {
   // Get system information including home directory
   async getSystemInfo(): Promise<{ homeDirectory: string; username?: string }> {
     const candidates = new Set<string>();
+    const allowLocalFallback = getRuntimeKey() === 'local';
     const addCandidate = (value?: string | null) => {
       const normalized = this.normalizeCandidatePath(value);
       if (normalized) {
@@ -470,19 +471,21 @@ class OpencodeService {
       }
     }
 
-    addCandidate(this.currentDirectory);
+    if (allowLocalFallback) {
+      addCandidate(this.currentDirectory);
 
-    if (typeof window !== 'undefined') {
-      try {
-        addCandidate(window.localStorage.getItem('lastDirectory'));
-        addCandidate(window.localStorage.getItem('homeDirectory'));
-      } catch {
-        // Access to storage failed (e.g. privacy mode)
+      if (typeof window !== 'undefined') {
+        try {
+          addCandidate(window.localStorage.getItem('lastDirectory'));
+          addCandidate(window.localStorage.getItem('homeDirectory'));
+        } catch {
+          // Access to storage failed (e.g. privacy mode)
+        }
       }
-    }
 
-    if (!candidates.size && typeof process !== 'undefined' && typeof process.cwd === 'function') {
-      addCandidate(process.cwd());
+      if (!candidates.size && typeof process !== 'undefined' && typeof process.cwd === 'function') {
+        addCandidate(process.cwd());
+      }
     }
 
     if (!candidates.size) {

--- a/packages/ui/src/lib/persistence.test.ts
+++ b/packages/ui/src/lib/persistence.test.ts
@@ -5,6 +5,7 @@ import { registerRuntimeAPIs } from '@/contexts/runtimeAPIRegistry';
 import { startModelPrefsAutoSave } from '@/lib/modelPrefsAutoSave';
 import { startAppearanceAutoSave } from '@/lib/appearanceAutoSave';
 import { useUIStore } from '@/stores/useUIStore';
+import { createProjectIdFromPath } from './projectId';
 import {
   applyPersistedHomeDirectoryToWindow,
   getSettingsSaveState,
@@ -149,6 +150,7 @@ describe('applyPersistedHomeDirectoryToWindow', () => {
 describe('updateDesktopSettings', () => {
   beforeEach(() => {
     getWindow();
+    localStorage.clear();
     registerRuntimeAPIs(null);
     invalidateSettingsCache();
     resetModelPrefsState();
@@ -353,6 +355,86 @@ describe('updateDesktopSettings', () => {
 
     expect(useUIStore.getState().terminalShell).toBe('zsh');
     expect(useUIStore.getState().terminalLoginShells).toEqual(['zsh', 'fish']);
+  });
+
+  test('does not copy remote path and project settings into unscoped browser storage', async () => {
+    const localProjects = JSON.stringify([{ id: 'local-project', path: '/Users/local-user/projects/app' }]);
+    const settings = {
+      homeDirectory: '/home/remote-user',
+      lastDirectory: '/home/remote-user/projects/app',
+      projects: [{ id: 'remote-project', path: '/home/remote-user/projects/app' }],
+      activeProjectId: 'remote-project',
+      draftStartersCraftGoalAdded: true,
+    } satisfies SettingsPayload;
+    const synced: SettingsPayload[] = [];
+    const listener = (event: Event) => {
+      synced.push((event as CustomEvent<SettingsPayload>).detail);
+    };
+    delete getWindow().__OPENCHAMBER_HOME__;
+    localStorage.setItem('homeDirectory', '/Users/local-user');
+    localStorage.setItem('lastDirectory', '/Users/local-user/projects/app');
+    localStorage.setItem('projects', localProjects);
+    localStorage.setItem('activeProjectId', 'local-project');
+    getWindow().addEventListener('openchamber:settings-synced', listener);
+    switchRuntimeEndpoint({ apiBaseUrl: 'https://remote-storage.example', runtimeKey: 'remote-storage' });
+    registerSettingsApi(async () => ({}), async () => ({ settings, source: 'web' }));
+
+    try {
+      await syncDesktopSettings();
+
+      expect(localStorage.getItem('homeDirectory')).toBe('/Users/local-user');
+      expect(localStorage.getItem('lastDirectory')).toBe('/Users/local-user/projects/app');
+      expect(localStorage.getItem('projects')).toBe(localProjects);
+      expect(localStorage.getItem('activeProjectId')).toBe('local-project');
+      expect(getWindow().__OPENCHAMBER_HOME__).toBeUndefined();
+      expect(synced).toHaveLength(1);
+      expect(synced[0]?.homeDirectory).toBe('/home/remote-user');
+    } finally {
+      getWindow().removeEventListener('openchamber:settings-synced', listener);
+    }
+  });
+
+  test('migrates local project collapse metadata to its runtime-scoped browser key', async () => {
+    localStorage.setItem('oc.sessions.projectCollapse', JSON.stringify(['stale-project']));
+    switchRuntimeEndpoint({ apiBaseUrl: 'https://local-settings.example', runtimeKey: 'local' });
+    registerSettingsApi(async () => ({}), async () => ({
+      settings: {
+        projects: [
+          { id: 'local-project', path: '/Users/local-user/projects/app', sidebarCollapsed: true },
+        ],
+        draftStartersCraftGoalAdded: true,
+      },
+      source: 'web',
+    }));
+
+    await syncDesktopSettings();
+
+    expect(localStorage.getItem('oc.sessions.projectCollapse:local')).toBe(JSON.stringify([
+      createProjectIdFromPath('/Users/local-user/projects/app'),
+    ]));
+    expect(localStorage.getItem('oc.sessions.projectCollapse')).toBeNull();
+  });
+
+  test('preserves an authoritative empty remote project list for runtime hydration', async () => {
+    const synced: SettingsPayload[] = [];
+    const listener = (event: Event) => {
+      synced.push((event as CustomEvent<SettingsPayload>).detail);
+    };
+    getWindow().addEventListener('openchamber:settings-synced', listener);
+    switchRuntimeEndpoint({ apiBaseUrl: 'https://remote-empty-projects.example', runtimeKey: 'remote-empty-projects' });
+    registerSettingsApi(async () => ({}), async () => ({
+      settings: { projects: [], draftStartersCraftGoalAdded: true },
+      source: 'web',
+    }));
+
+    try {
+      await syncDesktopSettings();
+
+      expect(synced).toHaveLength(1);
+      expect(synced[0]?.projects).toEqual([]);
+    } finally {
+      getWindow().removeEventListener('openchamber:settings-synced', listener);
+    }
   });
 
   test('autosaves all model selector settings fields', async () => {

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -12,6 +12,7 @@ import { normalizeMobileKeyboardMode, setStoredMobileKeyboardMode } from '@/lib/
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { isTerminalShell } from '@/lib/terminalShell';
 import { getRuntimeKey, subscribeRuntimeEndpointChanged, subscribeRuntimeEndpointWillChange } from '@/lib/runtime-switch';
+import { getRuntimeScopedStorageKey, writeRuntimeScopedStorage } from '@/stores/utils/runtimeScopedStorage';
 
 export const applyPersistedHomeDirectoryToWindow = (homeDirectory: string): void => {
   if (typeof window === 'undefined') {
@@ -33,6 +34,8 @@ const persistToLocalStorage = (settings: DesktopSettings) => {
     return;
   }
 
+  const isLocalRuntime = getRuntimeKey() === 'local';
+
   if (settings.themeId) {
     localStorage.setItem('selectedThemeId', settings.themeId);
   }
@@ -48,38 +51,42 @@ const persistToLocalStorage = (settings: DesktopSettings) => {
   if (typeof settings.useSystemTheme === 'boolean') {
     localStorage.setItem('useSystemTheme', String(settings.useSystemTheme));
   }
-  if (settings.lastDirectory) {
-    localStorage.setItem('lastDirectory', settings.lastDirectory);
-  }
-  if (settings.homeDirectory) {
-    localStorage.setItem('homeDirectory', settings.homeDirectory);
-    applyPersistedHomeDirectoryToWindow(settings.homeDirectory);
-  }
-  if (Array.isArray(settings.projects) && settings.projects.length > 0) {
-    localStorage.setItem('projects', JSON.stringify(settings.projects));
-  } else {
-    localStorage.removeItem('projects');
-  }
-  if (settings.activeProjectId) {
-    localStorage.setItem('activeProjectId', settings.activeProjectId);
-  } else {
-    localStorage.removeItem('activeProjectId');
-  }
-  if (Array.isArray(settings.pinnedDirectories) && settings.pinnedDirectories.length > 0) {
-    localStorage.setItem('pinnedDirectories', JSON.stringify(settings.pinnedDirectories));
-  } else {
-    localStorage.removeItem('pinnedDirectories');
-  }
-
-  if (Array.isArray(settings.projects) && settings.projects.length > 0) {
-    const collapsed = settings.projects
-      .filter((project) => (project as unknown as { sidebarCollapsed?: boolean }).sidebarCollapsed === true)
-      .map((project) => project.id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
-    if (collapsed.length > 0) {
-      localStorage.setItem('oc.sessions.projectCollapse', JSON.stringify(collapsed));
+  if (isLocalRuntime) {
+    if (settings.lastDirectory) {
+      localStorage.setItem('lastDirectory', settings.lastDirectory);
+    }
+    if (settings.homeDirectory) {
+      localStorage.setItem('homeDirectory', settings.homeDirectory);
+      applyPersistedHomeDirectoryToWindow(settings.homeDirectory);
+    }
+    if (Array.isArray(settings.projects) && settings.projects.length > 0) {
+      localStorage.setItem('projects', JSON.stringify(settings.projects));
     } else {
-      localStorage.removeItem('oc.sessions.projectCollapse');
+      localStorage.removeItem('projects');
+    }
+    if (settings.activeProjectId) {
+      localStorage.setItem('activeProjectId', settings.activeProjectId);
+    } else {
+      localStorage.removeItem('activeProjectId');
+    }
+    if (Array.isArray(settings.pinnedDirectories) && settings.pinnedDirectories.length > 0) {
+      localStorage.setItem('pinnedDirectories', JSON.stringify(settings.pinnedDirectories));
+    } else {
+      localStorage.removeItem('pinnedDirectories');
+    }
+
+    if (Array.isArray(settings.projects) && settings.projects.length > 0) {
+      const collapsed = settings.projects
+        .filter((project) => (project as unknown as { sidebarCollapsed?: boolean }).sidebarCollapsed === true)
+        .map((project) => project.id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0);
+      if (collapsed.length > 0) {
+        writeRuntimeScopedStorage(localStorage, 'oc.sessions.projectCollapse', JSON.stringify(collapsed));
+        localStorage.removeItem('oc.sessions.projectCollapse');
+      } else {
+        localStorage.removeItem(getRuntimeScopedStorageKey('oc.sessions.projectCollapse', 'local'));
+        localStorage.removeItem('oc.sessions.projectCollapse');
+      }
     }
   }
   if (typeof settings.gitmojiEnabled === 'boolean') {
@@ -851,9 +858,11 @@ const sanitizeWebSettings = (payload: unknown): DesktopSettings | null => {
     result.desktopMinimizeToTrayEnabled = candidate.desktopMinimizeToTrayEnabled;
   }
 
-  const projects = sanitizeProjects(candidate.projects);
-  if (projects) {
-    result.projects = projects;
+  if (Array.isArray(candidate.projects)) {
+    const projects = sanitizeProjects(candidate.projects);
+    if (projects || candidate.projects.length === 0) {
+      result.projects = projects ?? [];
+    }
   }
   if (typeof candidate.activeProjectId === 'string' && candidate.activeProjectId.length > 0) {
     result.activeProjectId = candidate.activeProjectId;

--- a/packages/ui/src/stores/runtimeSettingsTestSupport.ts
+++ b/packages/ui/src/stores/runtimeSettingsTestSupport.ts
@@ -1,0 +1,165 @@
+import { mock } from 'bun:test';
+
+export type RuntimeEndpointDetail = {
+  runtimeKey: string;
+  previousRuntimeKey: string;
+};
+
+export type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+export const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+export const storageValues = new Map<string, string>();
+export const updateDesktopSettings = mock(async () => undefined);
+export const setDirectory = mock(() => undefined);
+
+let runtimeKey = 'local';
+let runtimeApiBaseUrl = 'http://local.example';
+let desktopHome = '/Users/local-user';
+let filesystemHomeResolver: () => Promise<string | null> = async () => desktopHome;
+let runtimeFetchResolver: () => Promise<Response> = async () => new Response('{}', {
+  headers: { 'Content-Type': 'application/json' },
+});
+
+const runtimeEndpointChangedListeners = new Set<(detail: RuntimeEndpointDetail) => void>();
+const events = new EventTarget();
+const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+export const runtimeWindow = {
+  __OPENCHAMBER_HOME__: desktopHome,
+  addEventListener: events.addEventListener.bind(events),
+  removeEventListener: events.removeEventListener.bind(events),
+  dispatchEvent: events.dispatchEvent.bind(events),
+};
+
+export const installRuntimeSettingsTestWindow = (): void => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: runtimeWindow,
+  });
+};
+
+export const restoreRuntimeSettingsTestWindow = (): void => {
+  if (previousWindow) {
+    Object.defineProperty(globalThis, 'window', previousWindow);
+  } else {
+    Reflect.deleteProperty(globalThis, 'window');
+  }
+};
+
+const safeStorage = {
+  getItem: (key: string) => storageValues.get(key) ?? null,
+  setItem: (key: string, value: string) => storageValues.set(key, value),
+  removeItem: (key: string) => storageValues.delete(key),
+  clear: () => storageValues.clear(),
+  key: (index: number) => Array.from(storageValues.keys())[index] ?? null,
+  get length() {
+    return storageValues.size;
+  },
+} as Storage;
+
+mock.module('./utils/safeStorage', () => ({
+  getDeferredSafeStorage: () => safeStorage,
+}));
+
+mock.module('@/lib/opencode/client', () => ({
+  opencodeClient: {
+    getFilesystemHome: mock(() => filesystemHomeResolver()),
+    getSystemInfo: mock(async () => ({ homeDirectory: '/' })),
+    setDirectory,
+  },
+}));
+
+mock.module('@/lib/desktop', () => ({
+  getDesktopHomeDirectory: mock(async () => desktopHome),
+  isVSCodeRuntime: () => false,
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeApiBaseUrl: () => runtimeApiBaseUrl,
+  getRuntimeKey: () => runtimeKey,
+  subscribeRuntimeEndpointChanged: (listener: (detail: RuntimeEndpointDetail) => void) => {
+    runtimeEndpointChangedListeners.add(listener);
+    return () => runtimeEndpointChangedListeners.delete(listener);
+  },
+}));
+
+mock.module('@/lib/persistence', () => ({
+  updateDesktopSettings,
+}));
+
+mock.module('@/stores/useFileSearchStore', () => ({
+  useFileSearchStore: {
+    getState: () => ({ invalidateDirectory: () => undefined }),
+  },
+}));
+
+mock.module('@/stores/utils/streamDebug', () => ({
+  streamDebugEnabled: () => false,
+}));
+
+mock.module('@/contexts/runtimeAPIRegistry', () => ({
+  getRegisteredRuntimeAPIs: () => null,
+}));
+
+mock.module('@/lib/projectMeta', () => ({
+  PROJECT_COLORS: [{ key: 'blue' }],
+}));
+
+mock.module('@/sync/session-ui-store', () => ({
+  useSessionUIStore: {
+    setState: () => undefined,
+  },
+}));
+
+mock.module('@/lib/runtime-fetch', () => ({
+  runtimeFetch: mock(() => runtimeFetchResolver()),
+}));
+
+export const setRuntimeKey = (value: string): void => {
+  runtimeKey = value;
+};
+
+export const setRuntimeApiBaseUrl = (value: string): void => {
+  runtimeApiBaseUrl = value;
+};
+
+export const setDesktopHome = (value: string): void => {
+  desktopHome = value;
+  runtimeWindow.__OPENCHAMBER_HOME__ = value;
+};
+
+export const setFilesystemHomeResolver = (resolver: () => Promise<string | null>): void => {
+  filesystemHomeResolver = resolver;
+};
+
+export const setRuntimeFetchResolver = (resolver: () => Promise<Response>): void => {
+  runtimeFetchResolver = resolver;
+};
+
+export const emitRuntimeEndpointChanged = (detail: RuntimeEndpointDetail): void => {
+  runtimeEndpointChangedListeners.forEach((listener) => listener(detail));
+};
+
+export const resetRuntimeSettingsTestState = (): void => {
+  storageValues.clear();
+  runtimeKey = 'local';
+  runtimeApiBaseUrl = 'http://local.example';
+  desktopHome = '/Users/local-user';
+  runtimeWindow.__OPENCHAMBER_HOME__ = desktopHome;
+  filesystemHomeResolver = async () => desktopHome;
+  runtimeFetchResolver = async () => new Response('{}', {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  updateDesktopSettings.mockClear();
+  setDirectory.mockClear();
+};

--- a/packages/ui/src/stores/useDirectoryStore.test.ts
+++ b/packages/ui/src/stores/useDirectoryStore.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  deferred,
+  emitRuntimeEndpointChanged,
+  installRuntimeSettingsTestWindow,
+  resetRuntimeSettingsTestState,
+  restoreRuntimeSettingsTestWindow,
+  runtimeWindow,
+  setFilesystemHomeResolver,
+  setRuntimeKey,
+  storageValues,
+  updateDesktopSettings,
+} from './runtimeSettingsTestSupport';
+import type { Deferred } from './runtimeSettingsTestSupport';
+
+installRuntimeSettingsTestWindow();
+
+const { useDirectoryStore } = await import('./useDirectoryStore');
+
+const flushAsyncWork = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+};
+
+const resetDirectoryStore = () => {
+  useDirectoryStore.setState({
+    currentDirectory: '/Users/local-user/projects/app',
+    directoryHistory: ['/Users/local-user/projects/app'],
+    historyIndex: 0,
+    homeDirectory: '/Users/local-user',
+    hasPersistedDirectory: true,
+    isHomeReady: true,
+    isSwitchingDirectory: false,
+  });
+};
+
+describe('useDirectoryStore runtime switching', () => {
+  afterAll(() => {
+    restoreRuntimeSettingsTestWindow();
+  });
+
+  beforeEach(async () => {
+    resetRuntimeSettingsTestState();
+    storageValues.set('homeDirectory', '/Users/local-user');
+    storageValues.set('lastDirectory', '/Users/local-user/projects/app');
+    resetDirectoryStore();
+    await flushAsyncWork();
+    updateDesktopSettings.mockClear();
+  });
+
+  test('keeps every unscoped directory key local while persisting remote-derived values remotely', async () => {
+    setRuntimeKey('remote-runtime');
+    setFilesystemHomeResolver(async () => '/home/remote-user');
+    emitRuntimeEndpointChanged({ runtimeKey: 'remote-runtime', previousRuntimeKey: 'local' });
+    await flushAsyncWork();
+
+    expect(useDirectoryStore.getState().homeDirectory).toBe('/home/remote-user');
+    expect(storageValues.get('homeDirectory')).toBe('/Users/local-user');
+    expect(storageValues.get('lastDirectory')).toBe('/Users/local-user/projects/app');
+    expect(updateDesktopSettings).toHaveBeenCalledWith({ homeDirectory: '/home/remote-user' });
+
+    useDirectoryStore.getState().setDirectory('/home/remote-user/one');
+    useDirectoryStore.getState().setDirectory('/home/remote-user/two');
+    useDirectoryStore.getState().goBack();
+    useDirectoryStore.getState().goForward();
+    useDirectoryStore.getState().synchronizeHomeDirectory('/home/remote-user/synced');
+
+    expect(storageValues.get('homeDirectory')).toBe('/Users/local-user');
+    expect(storageValues.get('lastDirectory')).toBe('/Users/local-user/projects/app');
+    expect(updateDesktopSettings).toHaveBeenCalledWith({ lastDirectory: '/home/remote-user/one' });
+    expect(updateDesktopSettings).toHaveBeenCalledWith({ lastDirectory: '/home/remote-user/two' });
+    expect(updateDesktopSettings).toHaveBeenCalledWith({ homeDirectory: '/home/remote-user/synced' });
+
+    runtimeWindow.dispatchEvent(new CustomEvent('openchamber:settings-synced', {
+      detail: {
+        homeDirectory: '/home/remote-user',
+        lastDirectory: '/home/remote-user/projects/app',
+      },
+    }));
+
+    expect(useDirectoryStore.getState().currentDirectory).toBe('/home/remote-user/projects/app');
+    expect(storageValues.get('lastDirectory')).toBe('/Users/local-user/projects/app');
+  });
+
+  test('rejects a stale home resolution after an A-to-B-to-A switch', async () => {
+    const requests: Deferred<string | null>[] = [];
+    setFilesystemHomeResolver(() => {
+      const request = deferred<string | null>();
+      requests.push(request);
+      return request.promise;
+    });
+
+    setRuntimeKey('runtime-a');
+    emitRuntimeEndpointChanged({ runtimeKey: 'runtime-a', previousRuntimeKey: 'local' });
+    await Promise.resolve();
+    setRuntimeKey('runtime-b');
+    emitRuntimeEndpointChanged({ runtimeKey: 'runtime-b', previousRuntimeKey: 'runtime-a' });
+    await Promise.resolve();
+    setRuntimeKey('runtime-a');
+    emitRuntimeEndpointChanged({ runtimeKey: 'runtime-a', previousRuntimeKey: 'runtime-b' });
+    await Promise.resolve();
+    updateDesktopSettings.mockClear();
+
+    requests[0]?.resolve('/home/runtime-a-stale');
+    await flushAsyncWork();
+
+    expect(useDirectoryStore.getState().homeDirectory).toBe('/');
+    expect(updateDesktopSettings).not.toHaveBeenCalledWith({ homeDirectory: '/home/runtime-a-stale' });
+
+    requests[2]?.resolve('/home/runtime-a-current');
+    await flushAsyncWork();
+
+    expect(useDirectoryStore.getState().homeDirectory).toBe('/home/runtime-a-current');
+    expect(updateDesktopSettings).toHaveBeenCalledWith({ homeDirectory: '/home/runtime-a-current' });
+  });
+});

--- a/packages/ui/src/stores/useDirectoryStore.ts
+++ b/packages/ui/src/stores/useDirectoryStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { opencodeClient } from '@/lib/opencode/client';
 import { getDesktopHomeDirectory, isVSCodeRuntime } from '@/lib/desktop';
-import { subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
+import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import { updateDesktopSettings } from '@/lib/persistence';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { streamDebugEnabled } from '@/stores/utils/streamDebug';
@@ -23,13 +23,32 @@ interface DirectoryStore {
   goForward: () => void;
   goToParent: () => void;
   goHome: () => Promise<void>;
-  synchronizeHomeDirectory: (path: string) => void;
+  synchronizeHomeDirectory: (path: string, options?: { persistDirectory?: boolean; runtimeContext?: HomeResolutionContext }) => void;
 }
+
+type HomeResolutionContext = { runtimeKey: string; generation: number };
 
 let cachedHomeDirectory: string | null = null;
 let homeResolveGeneration = 0;
 const safeStorage = getDeferredSafeStorage();
-const persistedLastDirectory = safeStorage.getItem('lastDirectory');
+const captureHomeResolutionContext = (): HomeResolutionContext => ({
+  runtimeKey: getRuntimeKey(),
+  generation: homeResolveGeneration,
+});
+const isHomeResolutionContextCurrent = (context: HomeResolutionContext): boolean => (
+  context.runtimeKey === getRuntimeKey() && context.generation === homeResolveGeneration
+);
+const persistLocalHomeDirectory = (value: string, context?: HomeResolutionContext): void => {
+  if (getRuntimeKey() === 'local' && (!context || isHomeResolutionContextCurrent(context))) {
+    safeStorage.setItem('homeDirectory', value);
+  }
+};
+const persistLocalLastDirectory = (value: string): void => {
+  if (getRuntimeKey() === 'local') {
+    safeStorage.setItem('lastDirectory', value);
+  }
+};
+const persistedLastDirectory = getRuntimeKey() === 'local' ? safeStorage.getItem('lastDirectory') : null;
 const initialHasPersistedDirectory =
   typeof persistedLastDirectory === 'string' && persistedLastDirectory.length > 0;
 
@@ -114,9 +133,13 @@ const getProcessHomeDirectory = (): string | null => {
   return null;
 };
 
-const getHomeDirectory = () => {
+const getHomeDirectory = (context?: HomeResolutionContext) => {
+  if (context && !isHomeResolutionContextCurrent(context)) {
+    return '/';
+  }
+  const isLocalRuntime = getRuntimeKey() === 'local';
 
-  if (typeof window !== 'undefined') {
+  if (isLocalRuntime && typeof window !== 'undefined') {
     if (cachedHomeDirectory) return cachedHomeDirectory;
 
     const desktopHome =
@@ -125,21 +148,29 @@ const getHomeDirectory = () => {
         : null);
 
     if (desktopHome && desktopHome.length > 0) {
+      if (context && !isHomeResolutionContextCurrent(context)) {
+        return '/';
+      }
       cachedHomeDirectory = desktopHome;
-      safeStorage.setItem('homeDirectory', desktopHome);
+      persistLocalHomeDirectory(desktopHome, context);
       return desktopHome;
     }
 
     const storedHome = getStoredHomeDirectory();
     if (storedHome && !isVSCodeRuntime()) {
+      if (context && !isHomeResolutionContextCurrent(context)) {
+        return '/';
+      }
       cachedHomeDirectory = storedHome;
       return storedHome;
     }
   }
 
-  const processHome = getProcessHomeDirectory();
-  if (processHome) {
-    return processHome;
+  if (isLocalRuntime) {
+    const processHome = getProcessHomeDirectory();
+    if (processHome) {
+      return processHome;
+    }
   }
   return '/';
 };
@@ -169,23 +200,35 @@ const normalizeHomeCandidate = (value?: string | null) => {
   return normalized;
 };
 
-const persistResolvedHome = (resolved: string) => {
-  cachedHomeDirectory = resolved;
-  if (typeof window !== 'undefined') {
-    safeStorage.setItem('homeDirectory', resolved);
+const persistResolvedHome = (resolved: string, context: HomeResolutionContext): string | null => {
+  if (!isHomeResolutionContextCurrent(context)) {
+    return null;
   }
-  void updateDesktopSettings({ homeDirectory: resolved });
-  return resolved;
+  cachedHomeDirectory = resolved;
+  if (typeof window !== 'undefined' && isHomeResolutionContextCurrent(context)) {
+    persistLocalHomeDirectory(resolved, context);
+  }
+  if (isHomeResolutionContextCurrent(context)) {
+    void updateDesktopSettings({ homeDirectory: resolved });
+  }
+  return isHomeResolutionContextCurrent(context) ? resolved : null;
 };
 
-const initializeHomeDirectory = async () => {
+const initializeHomeDirectory = async (
+  context = captureHomeResolutionContext(),
+): Promise<string | null> => {
+  const isCurrentRuntime = () => isHomeResolutionContextCurrent(context);
   const acceptCandidate = (candidate?: string | null) => {
+    if (!isCurrentRuntime()) {
+      return null;
+    }
     const normalized = normalizeHomeCandidate(candidate);
-    return normalized ? persistResolvedHome(normalized) : null;
+    return normalized ? persistResolvedHome(normalized, context) : null;
   };
 
   try {
     const fsHome = await opencodeClient.getFilesystemHome();
+    if (!isCurrentRuntime()) return null;
     const resolved = acceptCandidate(fsHome);
     if (resolved) {
       return resolved;
@@ -193,9 +236,11 @@ const initializeHomeDirectory = async () => {
   } catch (filesystemError) {
     console.warn('Failed to obtain filesystem home directory:', filesystemError);
   }
+  if (!isCurrentRuntime()) return null;
 
   try {
     const info = await opencodeClient.getSystemInfo();
+    if (!isCurrentRuntime()) return null;
     const resolved = acceptCandidate(info?.homeDirectory);
     if (resolved) {
       return resolved;
@@ -203,24 +248,30 @@ const initializeHomeDirectory = async () => {
   } catch (error) {
     console.warn('Failed to get home directory from system info:', error);
   }
+  if (!isCurrentRuntime()) return null;
 
-  try {
-    const desktopHome = await getDesktopHomeDirectory();
-    const resolved = acceptCandidate(desktopHome);
-    if (resolved) {
-      return resolved;
+  if (context.runtimeKey === 'local') {
+    try {
+      const desktopHome = await getDesktopHomeDirectory();
+      if (!isCurrentRuntime()) return null;
+      const resolved = acceptCandidate(desktopHome);
+      if (resolved) {
+        return resolved;
+      }
+    } catch (desktopError) {
+      console.warn('Failed to obtain desktop-integrated home directory:', desktopError);
     }
-  } catch (desktopError) {
-    console.warn('Failed to obtain desktop-integrated home directory:', desktopError);
+
+    const fallback = getHomeDirectory(context);
+    const resolvedFallback = acceptCandidate(fallback);
+    if (resolvedFallback) {
+      return resolvedFallback;
+    }
+
+    return fallback;
   }
 
-  const fallback = getHomeDirectory();
-  const resolvedFallback = acceptCandidate(fallback);
-  if (resolvedFallback) {
-    return resolvedFallback;
-  }
-
-  return fallback;
+  return null;
 };
 
 const getVsCodeWorkspaceFolder = (): string | null => {
@@ -237,7 +288,7 @@ const getVsCodeWorkspaceFolder = (): string | null => {
 
 const initialHomeDirectory = getVsCodeWorkspaceFolder() || getHomeDirectory();
 const initialCurrentDirectory = (() => {
-  const persisted = getStoredLastDirectory();
+  const persisted = getRuntimeKey() === 'local' ? getStoredLastDirectory() : null;
   if (persisted && !isVSCodeRuntime()) {
     return resolveDirectoryPath(persisted, initialHomeDirectory);
   }
@@ -263,7 +314,8 @@ export const useDirectoryStore = create<DirectoryStore>()(
 
       setDirectory: (path: string, options?: { showOverlay?: boolean }) => {
         void options;
-        const homeDir = cachedHomeDirectory || get().homeDirectory || safeStorage.getItem('homeDirectory');
+        const storedHomeDirectory = getRuntimeKey() === 'local' ? safeStorage.getItem('homeDirectory') : null;
+        const homeDir = cachedHomeDirectory || get().homeDirectory || storedHomeDirectory;
         const resolvedPath = resolveDirectoryPath(path, homeDir);
         if (streamDebugEnabled()) {
           console.log('[DirectoryStore] setDirectory called with path:', resolvedPath);
@@ -275,7 +327,7 @@ export const useDirectoryStore = create<DirectoryStore>()(
         set((state) => {
           const newHistory = [...state.directoryHistory.slice(0, state.historyIndex + 1), resolvedPath];
 
-          safeStorage.setItem('lastDirectory', resolvedPath);
+          persistLocalLastDirectory(resolvedPath);
           void updateDesktopSettings({ lastDirectory: resolvedPath });
 
           return {
@@ -298,7 +350,7 @@ export const useDirectoryStore = create<DirectoryStore>()(
           opencodeClient.setDirectory(newDirectory);
           invalidateFileSearchCache();
 
-          safeStorage.setItem('lastDirectory', newDirectory);
+          persistLocalLastDirectory(newDirectory);
 
           void updateDesktopSettings({ lastDirectory: newDirectory });
 
@@ -321,7 +373,7 @@ export const useDirectoryStore = create<DirectoryStore>()(
           opencodeClient.setDirectory(newDirectory);
           invalidateFileSearchCache();
 
-          safeStorage.setItem('lastDirectory', newDirectory);
+          persistLocalLastDirectory(newDirectory);
 
           void updateDesktopSettings({ lastDirectory: newDirectory });
 
@@ -363,15 +415,23 @@ export const useDirectoryStore = create<DirectoryStore>()(
           cachedHomeDirectory ||
           get().homeDirectory ||
           (await initializeHomeDirectory());
-        get().setDirectory(homeDir);
+        if (homeDir) {
+          get().setDirectory(homeDir);
+        }
       },
 
-      synchronizeHomeDirectory: (homePath: string) => {
+      synchronizeHomeDirectory: (homePath: string, options?: { persistDirectory?: boolean; runtimeContext?: HomeResolutionContext }) => {
+        const isCurrentResolution = () => (
+          !options?.runtimeContext || isHomeResolutionContextCurrent(options.runtimeContext)
+        );
+        if (!isCurrentResolution()) {
+          return;
+        }
         const state = get();
         const resolvedHome = homePath;
         cachedHomeDirectory = resolvedHome;
         const needsUpdate = state.homeDirectory !== resolvedHome;
-        const savedLastDirectory = safeStorage.getItem('lastDirectory');
+        const savedLastDirectory = getRuntimeKey() === 'local' ? safeStorage.getItem('lastDirectory') : null;
         const hasSavedLastDirectory = typeof savedLastDirectory === 'string' && savedLastDirectory.length > 0;
         const shouldReplaceCurrent =
           !hasSavedLastDirectory &&
@@ -382,7 +442,7 @@ export const useDirectoryStore = create<DirectoryStore>()(
           );
 
         if (!needsUpdate && !shouldReplaceCurrent) {
-          if (!state.isHomeReady) {
+          if (!state.isHomeReady && isCurrentResolution()) {
             set({ isHomeReady: true });
           }
           return;
@@ -415,18 +475,27 @@ export const useDirectoryStore = create<DirectoryStore>()(
           updates.isSwitchingDirectory = false;
         }
 
+        if (!isCurrentResolution()) {
+          return;
+        }
         set(() => updates as Partial<DirectoryStore>);
 
-        if ((shouldReplaceCurrent || currentChanged) && resolvedReady) {
+        if ((shouldReplaceCurrent || currentChanged) && resolvedReady && isCurrentResolution()) {
           const nextDirectory = shouldReplaceCurrent ? resolvedHome : (resolvedCurrent as string);
           opencodeClient.setDirectory(nextDirectory);
           invalidateFileSearchCache();
-          safeStorage.setItem('lastDirectory', nextDirectory);
-          void updateDesktopSettings({ lastDirectory: nextDirectory });
+          if (options?.persistDirectory !== false) {
+            persistLocalLastDirectory(nextDirectory);
+            if (isCurrentResolution()) {
+              void updateDesktopSettings({ lastDirectory: nextDirectory });
+            }
+          }
 
         }
 
-        void updateDesktopSettings({ homeDirectory: resolvedHome });
+        if (resolvedReady && isCurrentResolution()) {
+          void updateDesktopSettings({ homeDirectory: resolvedHome });
+        }
       }
     }),
     {
@@ -436,19 +505,62 @@ export const useDirectoryStore = create<DirectoryStore>()(
 );
 
 if (typeof window !== 'undefined') {
-  initializeHomeDirectory().then((home) => {
-    useDirectoryStore.getState().synchronizeHomeDirectory(home);
+  const initialResolutionContext = captureHomeResolutionContext();
+  initializeHomeDirectory(initialResolutionContext).then((home) => {
+    if (home && isHomeResolutionContextCurrent(initialResolutionContext)) {
+      useDirectoryStore.getState().synchronizeHomeDirectory(home, { runtimeContext: initialResolutionContext });
+    }
   });
 
   // Host switches happen in place (no page reload), so the home directory
   // must be re-resolved from the new runtime's authoritative source instead
   // of keeping the previous host's value cached.
-  subscribeRuntimeEndpointChanged(() => {
+  subscribeRuntimeEndpointChanged((detail) => {
+    if (detail.runtimeKey === detail.previousRuntimeKey) {
+      return;
+    }
     cachedHomeDirectory = null;
-    const generation = ++homeResolveGeneration;
-    initializeHomeDirectory().then((home) => {
-      if (generation !== homeResolveGeneration) return;
-      useDirectoryStore.getState().synchronizeHomeDirectory(home);
+    homeResolveGeneration += 1;
+    const context = captureHomeResolutionContext();
+    useDirectoryStore.setState({
+      currentDirectory: '/',
+      directoryHistory: ['/'],
+      historyIndex: 0,
+      homeDirectory: '/',
+      hasPersistedDirectory: false,
+      isHomeReady: false,
+      isSwitchingDirectory: true,
     });
+    opencodeClient.setDirectory(undefined);
+    initializeHomeDirectory(context).then((home) => {
+      if (!isHomeResolutionContextCurrent(context)) return;
+      if (!home) {
+        if (useDirectoryStore.getState().isSwitchingDirectory) {
+          useDirectoryStore.setState({ isSwitchingDirectory: false, isHomeReady: false });
+        }
+        return;
+      }
+      useDirectoryStore.getState().synchronizeHomeDirectory(home, {
+        persistDirectory: false,
+        runtimeContext: context,
+      });
+    });
+  });
+
+  window.addEventListener('openchamber:settings-synced', (event: Event) => {
+    const settings = (event as CustomEvent<{ homeDirectory?: unknown; lastDirectory?: unknown }>).detail;
+    if (!settings || typeof settings !== 'object') {
+      return;
+    }
+
+    const homeDirectory = typeof settings.homeDirectory === 'string' ? settings.homeDirectory : null;
+    if (homeDirectory) {
+      useDirectoryStore.getState().synchronizeHomeDirectory(homeDirectory);
+    }
+
+    const lastDirectory = typeof settings.lastDirectory === 'string' ? settings.lastDirectory : null;
+    if (lastDirectory && lastDirectory !== useDirectoryStore.getState().currentDirectory) {
+      useDirectoryStore.getState().setDirectory(lastDirectory, { showOverlay: false });
+    }
   });
 }

--- a/packages/ui/src/stores/useProjectsStore.test.ts
+++ b/packages/ui/src/stores/useProjectsStore.test.ts
@@ -1,0 +1,194 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  deferred,
+  emitRuntimeEndpointChanged,
+  installRuntimeSettingsTestWindow,
+  resetRuntimeSettingsTestState,
+  restoreRuntimeSettingsTestWindow,
+  setDirectory,
+  setRuntimeApiBaseUrl,
+  setRuntimeFetchResolver,
+  setRuntimeKey,
+  storageValues,
+  updateDesktopSettings,
+} from './runtimeSettingsTestSupport';
+
+installRuntimeSettingsTestWindow();
+
+const { useDirectoryStore } = await import('./useDirectoryStore');
+const { useProjectsStore } = await import('./useProjectsStore');
+const { createProjectIdFromPath } = await import('@/lib/projectId');
+
+describe('useProjectsStore runtime-scoped persistence', () => {
+  afterAll(() => {
+    restoreRuntimeSettingsTestWindow();
+  });
+
+  beforeEach(() => {
+    resetRuntimeSettingsTestState();
+    setRuntimeKey('remote-runtime');
+    setRuntimeApiBaseUrl('https://shared-runtime-origin.example');
+    useDirectoryStore.setState({
+      homeDirectory: '/home/remote-user',
+      isHomeReady: true,
+    });
+    useProjectsStore.getState().resetForRuntimeSwitch();
+    useProjectsStore.setState({
+      projects: [],
+      activeProjectId: null,
+      manualProjectOrder: [],
+    });
+  });
+
+  test('expands remote project paths with the remote home instead of browser-local storage', () => {
+    storageValues.set('homeDirectory', '/Users/local-user');
+
+    const project = useProjectsStore.getState().addProject('~/projects/app');
+
+    expect(project?.path).toBe('/home/remote-user/projects/app');
+    expect(updateDesktopSettings).toHaveBeenCalledWith(expect.objectContaining({
+      projects: [expect.objectContaining({ path: '/home/remote-user/projects/app' })],
+    }));
+  });
+
+  test('does not restore an unscoped local project list after switching to a remote runtime', () => {
+    storageValues.set('projects', JSON.stringify([
+      { id: 'local', path: '/Users/local-user/projects/app' },
+    ]));
+    storageValues.set('activeProjectId', 'local');
+
+    useProjectsStore.getState().resetForRuntimeSwitch();
+
+    expect(useProjectsStore.getState().projects).toEqual([]);
+    expect(useProjectsStore.getState().activeProjectId).toBeNull();
+  });
+
+  test('does not persist a project list left over from a previous runtime', () => {
+    setRuntimeKey('local');
+    useProjectsStore.getState().resetForRuntimeSwitch();
+    useProjectsStore.setState({
+      projects: [{ id: 'local-project', path: '/Users/local-user/projects/app' }],
+      activeProjectId: null,
+    });
+    updateDesktopSettings.mockClear();
+
+    setRuntimeKey('remote-runtime');
+    emitRuntimeEndpointChanged({ runtimeKey: 'remote-runtime', previousRuntimeKey: 'local' });
+    useProjectsStore.getState().updateProjectMeta('local-project', { label: 'Local App' });
+
+    expect(updateDesktopSettings).not.toHaveBeenCalled();
+  });
+
+  test('does not retain a previous runtime project list when remote settings are explicitly empty', () => {
+    const remoteProjectsStorageKey = `projects:${encodeURIComponent('remote-runtime')}`;
+    storageValues.set(remoteProjectsStorageKey, JSON.stringify([
+      { id: 'stale-remote-project', path: '/home/remote-user/stale-project' },
+    ]));
+
+    setRuntimeKey('local');
+    useProjectsStore.getState().resetForRuntimeSwitch();
+    useProjectsStore.setState({
+      projects: [{ id: 'local-project', path: '/Users/local-user/projects/app' }],
+      activeProjectId: 'local-project',
+    });
+    setRuntimeKey('remote-runtime');
+    emitRuntimeEndpointChanged({ runtimeKey: 'remote-runtime', previousRuntimeKey: 'local' });
+    useProjectsStore.getState().resetForRuntimeSwitch();
+    expect(useProjectsStore.getState().projects).toHaveLength(1);
+
+    useProjectsStore.getState().synchronizeFromSettings({ projects: [] });
+
+    expect(useProjectsStore.getState().projects).toEqual([]);
+    expect(useProjectsStore.getState().activeProjectId).toBeNull();
+  });
+
+  test('isolates caches for runtimes sharing one API origin', () => {
+    setRuntimeKey('runtime-a');
+    useProjectsStore.getState().resetForRuntimeSwitch();
+    useProjectsStore.getState().synchronizeFromSettings({
+      projects: [{ id: 'project-a', path: '/home/runtime-a/project' }],
+    });
+
+    setRuntimeKey('runtime-b');
+    emitRuntimeEndpointChanged({ runtimeKey: 'runtime-b', previousRuntimeKey: 'runtime-a' });
+    useProjectsStore.getState().resetForRuntimeSwitch();
+
+    expect(useProjectsStore.getState().projects).toEqual([]);
+  });
+
+  test('ignores an old icon response after a runtime switch round trip', async () => {
+    const localPath = '/Users/local-user/projects/app';
+    const localProject = {
+      id: createProjectIdFromPath(localPath),
+      path: localPath,
+    };
+    setRuntimeKey('runtime-a');
+    useProjectsStore.getState().resetForRuntimeSwitch();
+    useProjectsStore.setState({ projects: [localProject], activeProjectId: localProject.id });
+    const response = deferred<Response>();
+    setRuntimeFetchResolver(async () => response.promise);
+    setDirectory.mockClear();
+
+    const request = useProjectsStore.getState().discoverProjectIcon(localProject.id);
+    setRuntimeKey('runtime-b');
+    emitRuntimeEndpointChanged({ runtimeKey: 'runtime-b', previousRuntimeKey: 'runtime-a' });
+    setRuntimeKey('runtime-a');
+    emitRuntimeEndpointChanged({ runtimeKey: 'runtime-a', previousRuntimeKey: 'runtime-b' });
+    useProjectsStore.setState({
+      projects: [{ id: 'remote-project', path: '/home/remote-user/project' }],
+      activeProjectId: 'remote-project',
+    });
+    response.resolve(new Response(JSON.stringify({
+      settings: {
+        projects: [localProject],
+        activeProjectId: localProject.id,
+      },
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    expect(await request).toEqual({ ok: false });
+    expect(useProjectsStore.getState().projects).toEqual([
+      { id: 'remote-project', path: '/home/remote-user/project' },
+    ]);
+    expect(setDirectory).not.toHaveBeenCalledWith(localPath);
+  });
+
+  test('restores each runtime manual project order after a round trip', () => {
+    const projectA = { id: 'project-a', path: '/home/runtime-a/project-a' };
+    const projectB = { id: 'project-b', path: '/home/runtime-a/project-b' };
+    setRuntimeKey('runtime-a');
+    useProjectsStore.getState().resetForRuntimeSwitch();
+    useProjectsStore.setState({
+      projects: [projectA, projectB],
+      activeProjectId: projectA.id,
+      manualProjectOrder: [],
+    });
+    useProjectsStore.getState().reorderProjects(0, 1);
+
+    setRuntimeKey('runtime-b');
+    emitRuntimeEndpointChanged({ runtimeKey: 'runtime-b', previousRuntimeKey: 'runtime-a' });
+    useProjectsStore.getState().resetForRuntimeSwitch();
+    expect(useProjectsStore.getState().manualProjectOrder).toEqual([]);
+
+    setRuntimeKey('runtime-a');
+    emitRuntimeEndpointChanged({ runtimeKey: 'runtime-a', previousRuntimeKey: 'runtime-b' });
+    useProjectsStore.getState().resetForRuntimeSwitch();
+
+    expect(useProjectsStore.getState().manualProjectOrder).toEqual([projectB.id, projectA.id]);
+  });
+
+  test('reads the legacy manual order only for the local runtime', () => {
+    storageValues.set('projects:manualOrder', JSON.stringify(['local-b', 'local-a']));
+    setRuntimeKey('local');
+    useProjectsStore.getState().resetForRuntimeSwitch();
+
+    expect(useProjectsStore.getState().manualProjectOrder).toEqual(['local-b', 'local-a']);
+
+    setRuntimeKey('remote-runtime');
+    emitRuntimeEndpointChanged({ runtimeKey: 'remote-runtime', previousRuntimeKey: 'local' });
+    useProjectsStore.getState().resetForRuntimeSwitch();
+
+    expect(useProjectsStore.getState().manualProjectOrder).toEqual([]);
+  });
+});

--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -12,7 +12,7 @@ import { streamDebugEnabled } from '@/stores/utils/streamDebug';
 import { PROJECT_COLORS } from '@/lib/projectMeta';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { runtimeFetch } from '@/lib/runtime-fetch';
-import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
+import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 
 /** Pick a color key that's least used among existing projects */
 const pickAutoColor = (projects: ProjectEntry[]): string => {
@@ -74,17 +74,27 @@ interface ProjectsStore {
 const safeStorage = getDeferredSafeStorage();
 const PROJECTS_STORAGE_KEY = 'projects';
 const ACTIVE_PROJECT_STORAGE_KEY = 'activeProjectId';
+const LEGACY_MANUAL_PROJECT_ORDER_STORAGE_KEY = `${PROJECTS_STORAGE_KEY}:manualOrder`;
+type ProjectsRuntimeContext = { runtimeKey: string; generation: number };
 
-const getLocalRuntimeOrigin = (): string => {
-  if (typeof window === 'undefined') return '';
-  const value = (window as typeof window & { __OPENCHAMBER_LOCAL_ORIGIN__?: string }).__OPENCHAMBER_LOCAL_ORIGIN__;
-  return typeof value === 'string' ? value.trim().replace(/\/+$/, '') : '';
-};
+let projectsRuntimeGeneration = 0;
+const captureProjectsRuntimeContext = (): ProjectsRuntimeContext => ({
+  runtimeKey: getRuntimeKey(),
+  generation: projectsRuntimeGeneration,
+});
+const isSameProjectsRuntimeContext = (left: ProjectsRuntimeContext, right: ProjectsRuntimeContext): boolean => (
+  left.runtimeKey === right.runtimeKey && left.generation === right.generation
+);
+const isProjectsRuntimeContextCurrent = (context: ProjectsRuntimeContext): boolean => (
+  isSameProjectsRuntimeContext(context, captureProjectsRuntimeContext())
+);
+
+// The store can outlive an in-place endpoint switch until runtime settings hydrate.
+// Only persist a project snapshot when it belongs to the active runtime.
+let projectsRuntimeContext = captureProjectsRuntimeContext();
 
 const getProjectsStorageNamespace = (): string => {
-  const apiBaseUrl = getRuntimeApiBaseUrl().trim().replace(/\/+$/, '');
-  if (!apiBaseUrl) return '';
-  return apiBaseUrl;
+  return getRuntimeKey().trim();
 };
 
 const getProjectsStorageKey = (): string => {
@@ -98,10 +108,7 @@ const getActiveProjectStorageKey = (): string => {
 };
 
 const shouldReadLegacyProjectsCache = (): boolean => {
-  const namespace = getProjectsStorageNamespace();
-  if (!namespace) return true;
-  const localOrigin = getLocalRuntimeOrigin();
-  return Boolean(localOrigin && namespace === localOrigin);
+  return getRuntimeKey() === 'local';
 };
 
 const resolveTildePath = (value: string, homeDir?: string | null): string => {
@@ -155,7 +162,10 @@ const normalizeProjectPath = (value: string): string => {
     return '';
   }
 
-  const homeDirectory = safeStorage.getItem('homeDirectory') || useDirectoryStore.getState().homeDirectory || '';
+  const directoryState = useDirectoryStore.getState();
+  const homeDirectory = getRuntimeKey() === 'local'
+    ? safeStorage.getItem('homeDirectory') || directoryState.homeDirectory || ''
+    : directoryState.isHomeReady ? directoryState.homeDirectory : '';
   const expanded = resolveTildePath(trimmed, homeDirectory);
 
   const normalized = expanded.replace(/\\/g, '/');
@@ -318,7 +328,8 @@ const readPersistedProjects = (): ProjectEntry[] => {
 
 const readPersistedManualOrder = (): string[] => {
   try {
-    const raw = safeStorage.getItem(getProjectsStorageKey() + ':manualOrder');
+    const raw = safeStorage.getItem(getProjectsStorageKey() + ':manualOrder')
+      || (shouldReadLegacyProjectsCache() ? safeStorage.getItem(LEGACY_MANUAL_PROJECT_ORDER_STORAGE_KEY) : null);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
@@ -360,6 +371,9 @@ const cacheProjects = (projects: ProjectEntry[], activeProjectId: string | null)
 };
 
 const persistProjects = (projects: ProjectEntry[], activeProjectId: string | null, manualOrder?: string[]) => {
+  if (!isProjectsRuntimeContextCurrent(projectsRuntimeContext)) {
+    return;
+  }
   cacheProjects(projects, activeProjectId);
   if (manualOrder) {
     persistManualProjectOrder(manualOrder);
@@ -770,8 +784,12 @@ export const useProjectsStore = create<ProjectsStore>()(
         return { ok: false, error: 'Icon exceeds size limit (5 MB)' };
       }
 
+      const runtimeContext = captureProjectsRuntimeContext();
       try {
         const dataUrl = await readFileAsDataUrl(file);
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         const normalizedDataUrl = dataUrl.replace(/^data:[^;]+;/i, `data:${mime};`);
 
         const response = await runtimeFetch(`/api/projects/${encodeURIComponent(id)}/icon`, {
@@ -783,17 +801,29 @@ export const useProjectsStore = create<ProjectsStore>()(
           body: JSON.stringify({ dataUrl: normalizedDataUrl }),
         });
 
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         if (!response.ok) {
           const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+          if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+            return { ok: false };
+          }
           return { ok: false, error: payload?.error || 'Failed to upload project icon' };
         }
 
         const payload = (await response.json().catch(() => null)) as { settings?: DesktopSettings } | null;
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         if (payload?.settings) {
           get().synchronizeFromSettings(payload.settings);
         }
         return { ok: true };
       } catch (error) {
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         const message = error instanceof Error ? error.message : String(error);
         return { ok: false, error: message || 'Failed to upload project icon' };
       }
@@ -804,6 +834,7 @@ export const useProjectsStore = create<ProjectsStore>()(
         return { ok: false, error: 'Custom icons are not supported in this runtime' };
       }
 
+      const runtimeContext = captureProjectsRuntimeContext();
       try {
         const response = await runtimeFetch(`/api/projects/${encodeURIComponent(id)}/icon`, {
           method: 'DELETE',
@@ -812,17 +843,29 @@ export const useProjectsStore = create<ProjectsStore>()(
           },
         });
 
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         if (!response.ok) {
           const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+          if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+            return { ok: false };
+          }
           return { ok: false, error: payload?.error || 'Failed to remove project icon' };
         }
 
         const payload = (await response.json().catch(() => null)) as { settings?: DesktopSettings } | null;
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         if (payload?.settings) {
           get().synchronizeFromSettings(payload.settings);
         }
         return { ok: true };
       } catch (error) {
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         const message = error instanceof Error ? error.message : String(error);
         return { ok: false, error: message || 'Failed to remove project icon' };
       }
@@ -833,6 +876,7 @@ export const useProjectsStore = create<ProjectsStore>()(
         return { ok: false, error: 'Custom icons are not supported in this runtime' };
       }
 
+      const runtimeContext = captureProjectsRuntimeContext();
       try {
         const response = await runtimeFetch(`/api/projects/${encodeURIComponent(id)}/icon/discover`, {
           method: 'POST',
@@ -850,6 +894,9 @@ export const useProjectsStore = create<ProjectsStore>()(
           settings?: DesktopSettings;
         } | null;
 
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         if (!response.ok) {
           return { ok: false, error: payload?.error || 'Failed to discover project icon' };
         }
@@ -864,6 +911,9 @@ export const useProjectsStore = create<ProjectsStore>()(
           reason: typeof payload?.reason === 'string' ? payload.reason : undefined,
         };
       } catch (error) {
+        if (!isProjectsRuntimeContextCurrent(runtimeContext)) {
+          return { ok: false };
+        }
         const message = error instanceof Error ? error.message : String(error);
         return { ok: false, error: message || 'Failed to discover project icon' };
       }
@@ -902,25 +952,34 @@ export const useProjectsStore = create<ProjectsStore>()(
       const nextActiveProjectId = projects.some((project) => project.id === activeProjectId)
         ? activeProjectId
         : projects[0]?.id ?? null;
-      set({ projects, activeProjectId: nextActiveProjectId, manualProjectOrder: [] });
+      const manualProjectOrder = readPersistedManualOrder();
+      projectsRuntimeContext = captureProjectsRuntimeContext();
+      set({ projects, activeProjectId: nextActiveProjectId, manualProjectOrder });
     },
 
     synchronizeFromSettings: (settings: DesktopSettings) => {
       if (isVSCodeProjectsRuntime) {
         return;
       }
+      const hasAuthoritativeProjects = Array.isArray(settings.projects);
       const incomingProjects = sanitizeProjects(settings.projects ?? []);
       const incomingActive = typeof settings.activeProjectId === 'string' && settings.activeProjectId.trim()
         ? settings.activeProjectId.trim()
         : null;
 
       const current = get();
+      const runtimeContext = captureProjectsRuntimeContext();
 
-      // Race guard: settings load can return empty projects during app
-      // rebuild/reinstall or an incomplete settings read. Don't clobber
-      // a populated cache with empty — the sidebar would go blank and
-      // localStorage would be overwritten, losing the list entirely.
-      if (incomingProjects.length === 0 && current.projects.length > 0) {
+      // Preserve a populated cache only when an incomplete settings payload
+      // omitted projects. An explicit empty array is authoritative and must
+      // clear a stale list after a runtime switch.
+      if (
+        !hasAuthoritativeProjects
+        &&
+        incomingProjects.length === 0
+        && current.projects.length > 0
+        && isSameProjectsRuntimeContext(projectsRuntimeContext, runtimeContext)
+      ) {
         if (incomingActive !== current.activeProjectId) {
           // Active project may still be valid within the cached list.
           const activeExists = incomingActive
@@ -932,6 +991,7 @@ export const useProjectsStore = create<ProjectsStore>()(
             persistManualProjectOrder(get().manualProjectOrder);
           }
         }
+        projectsRuntimeContext = runtimeContext;
         return;
       }
 
@@ -939,11 +999,13 @@ export const useProjectsStore = create<ProjectsStore>()(
       const activeChanged = current.activeProjectId !== incomingActive;
 
       if (!projectsChanged && !activeChanged) {
+        projectsRuntimeContext = runtimeContext;
         return;
       }
 
       const incomingIds = new Set(incomingProjects.map((p) => p.id));
       const cleanedOrder = get().manualProjectOrder.filter((id) => incomingIds.has(id));
+      projectsRuntimeContext = runtimeContext;
       set({ projects: incomingProjects, activeProjectId: incomingActive, manualProjectOrder: cleanedOrder });
       cacheProjects(incomingProjects, incomingActive);
       persistManualProjectOrder(cleanedOrder);
@@ -1004,6 +1066,12 @@ export const useProjectsStore = create<ProjectsStore>()(
 );
 
 if (typeof window !== 'undefined') {
+  subscribeRuntimeEndpointChanged((detail) => {
+    if (detail.runtimeKey !== detail.previousRuntimeKey) {
+      projectsRuntimeGeneration += 1;
+    }
+  });
+
   window.addEventListener('openchamber:settings-synced', (event: Event) => {
     const detail = (event as CustomEvent<DesktopSettings>).detail;
     if (detail && typeof detail === 'object') {

--- a/packages/ui/src/stores/useSessionFoldersStore.test.ts
+++ b/packages/ui/src/stores/useSessionFoldersStore.test.ts
@@ -1,7 +1,22 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const storage = new Map<string, string>();
 let storageSetCount = 0;
+let runtimeKey = 'local';
+const runtimeListeners = new Set<(detail: { runtimeKey: string; previousRuntimeKey: string }) => void>();
+const events = new EventTarget();
+const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+const runtimeWindow = {
+  addEventListener: events.addEventListener.bind(events),
+  removeEventListener: events.removeEventListener.bind(events),
+  dispatchEvent: events.dispatchEvent.bind(events),
+};
+
+Object.defineProperty(globalThis, 'window', {
+  configurable: true,
+  value: runtimeWindow,
+});
 
 const safeStorage = {
   getItem: (key: string) => storage.get(key) ?? null,
@@ -34,18 +49,40 @@ mock.module('@/lib/runtime-fetch', () => ({
   runtimeFetch: mock(async () => new Response('{}', { headers: { 'Content-Type': 'application/json' } })),
 }));
 
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeKey: () => runtimeKey,
+  subscribeRuntimeEndpointChanged: (listener: (detail: { runtimeKey: string; previousRuntimeKey: string }) => void) => {
+    runtimeListeners.add(listener);
+    return () => runtimeListeners.delete(listener);
+  },
+}));
+
 const { useSessionFoldersStore } = await import('./useSessionFoldersStore');
 
 const waitForPersist = () => new Promise((resolve) => setTimeout(resolve, 350));
+const scopedKey = (key: string, targetRuntimeKey = runtimeKey): string => `${key}:${encodeURIComponent(targetRuntimeKey)}`;
+const emitRuntimeEndpointChanged = (nextRuntimeKey: string, previousRuntimeKey = runtimeKey): void => {
+  runtimeKey = nextRuntimeKey;
+  runtimeListeners.forEach((listener) => listener({ runtimeKey: nextRuntimeKey, previousRuntimeKey }));
+};
 
 describe('useSessionFoldersStore folder assignments', () => {
   beforeEach(() => {
     storage.clear();
     storageSetCount = 0;
+    runtimeKey = 'local';
     useSessionFoldersStore.setState({
       foldersMap: {},
       collapsedFolderIds: new Set<string>(),
     });
+  });
+
+  afterAll(() => {
+    if (previousWindow) {
+      Object.defineProperty(globalThis, 'window', previousWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
   });
 
   test('repeated addSessionToFolder to the same folder preserves foldersMap reference', async () => {
@@ -76,5 +113,121 @@ describe('useSessionFoldersStore folder assignments', () => {
 
     expect(useSessionFoldersStore.getState().foldersMap).toBe(before);
     expect(storageSetCount).toBe(0);
+  });
+
+  test('isolates folder assignments and collapse state across runtime switches', () => {
+    runtimeKey = 'runtime-a';
+    const projectScope = '/workspace/project';
+    useSessionFoldersStore.setState({
+      foldersMap: {
+        [projectScope]: [{ id: 'shared-folder', name: 'Runtime A', sessionIds: ['shared-session'], createdAt: 1 }],
+      },
+      collapsedFolderIds: new Set(['shared-folder']),
+    });
+    storage.set('oc.sessions.folders', JSON.stringify({
+      [projectScope]: [{ id: 'legacy-folder', name: 'Legacy', sessionIds: ['shared-session'], createdAt: 1 }],
+    }));
+    storage.set(scopedKey('oc.sessions.folders', 'runtime-b'), JSON.stringify({
+      [projectScope]: [{ id: 'shared-folder', name: 'Runtime B', sessionIds: ['shared-session'], createdAt: 2 }],
+    }));
+    storage.set(scopedKey('oc.sessions.folderCollapse', 'runtime-b'), JSON.stringify([]));
+
+    emitRuntimeEndpointChanged('runtime-b', 'runtime-a');
+
+    expect(useSessionFoldersStore.getState().foldersMap).toEqual({
+      [projectScope]: [{
+        id: 'shared-folder',
+        name: 'Runtime B',
+        sessionIds: ['shared-session'],
+        createdAt: 2,
+        parentId: null,
+      }],
+    });
+    expect(useSessionFoldersStore.getState().collapsedFolderIds).toEqual(new Set());
+  });
+
+  test('writes folder state under the current runtime key', async () => {
+    runtimeKey = 'runtime-a';
+    const folder = useSessionFoldersStore.getState().createFolder('/workspace/project', 'Scoped');
+    useSessionFoldersStore.getState().toggleFolderCollapse(folder.id);
+
+    await waitForPersist();
+
+    expect(storage.get(scopedKey('oc.sessions.folders', 'runtime-a'))).toContain('Scoped');
+    expect(storage.get(scopedKey('oc.sessions.folderCollapse', 'runtime-a'))).toBe(JSON.stringify([folder.id]));
+    expect(storage.get('oc.sessions.folders')).toBeUndefined();
+    expect(storage.get('oc.sessions.folderCollapse')).toBeUndefined();
+  });
+
+  test('uses legacy folder state only for the local runtime', () => {
+    const projectScope = '/workspace/project';
+    storage.set('oc.sessions.folders', JSON.stringify({
+      [projectScope]: [{ id: 'legacy-folder', name: 'Legacy', sessionIds: ['legacy-session'], createdAt: 1 }],
+    }));
+    storage.set('oc.sessions.folderCollapse', JSON.stringify(['legacy-folder']));
+
+    emitRuntimeEndpointChanged('remote-runtime', 'local');
+    expect(useSessionFoldersStore.getState().foldersMap).toEqual({});
+    expect(useSessionFoldersStore.getState().collapsedFolderIds).toEqual(new Set());
+
+    emitRuntimeEndpointChanged('local', 'remote-runtime');
+    expect(useSessionFoldersStore.getState().foldersMap).toEqual({
+      [projectScope]: [{
+        id: 'legacy-folder',
+        name: 'Legacy',
+        sessionIds: ['legacy-session'],
+        createdAt: 1,
+        parentId: null,
+      }],
+    });
+    expect(useSessionFoldersStore.getState().collapsedFolderIds).toEqual(new Set(['legacy-folder']));
+  });
+
+  test('rejects delayed folder and collapse callbacks after an A-to-B-to-A switch', () => {
+    runtimeKey = 'runtime-a';
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const activeTimers = new Map<number, () => void>();
+    const cancelledTimers = new Map<number, () => void>();
+    let nextTimerId = 0;
+
+    globalThis.setTimeout = ((callback: () => void) => {
+      nextTimerId += 1;
+      activeTimers.set(nextTimerId, callback);
+      return nextTimerId;
+    }) as unknown as typeof setTimeout;
+    globalThis.clearTimeout = ((timer: unknown) => {
+      const timerId = Number(timer);
+      const callback = activeTimers.get(timerId);
+      if (callback) {
+        activeTimers.delete(timerId);
+        cancelledTimers.set(timerId, callback);
+      }
+    }) as unknown as typeof clearTimeout;
+
+    try {
+      const oldFolder = useSessionFoldersStore.getState().createFolder('/workspace/project', 'Old');
+      useSessionFoldersStore.getState().toggleFolderCollapse(oldFolder.id);
+
+      emitRuntimeEndpointChanged('runtime-b', 'runtime-a');
+      emitRuntimeEndpointChanged('runtime-a', 'runtime-b');
+      const staleCallbacks = Array.from(cancelledTimers.values());
+
+      const currentFolder = useSessionFoldersStore.getState().createFolder('/workspace/project', 'Current');
+      useSessionFoldersStore.getState().toggleFolderCollapse(currentFolder.id);
+      storageSetCount = 0;
+
+      staleCallbacks.forEach((callback) => callback());
+      expect(storageSetCount).toBe(0);
+      expect(storage.get(scopedKey('oc.sessions.folders', 'runtime-a'))).toBeUndefined();
+      expect(storage.get(scopedKey('oc.sessions.folderCollapse', 'runtime-a'))).toBeUndefined();
+
+      Array.from(activeTimers.values()).forEach((callback) => callback());
+      expect(storage.get(scopedKey('oc.sessions.folders', 'runtime-a'))).toContain('Current');
+      expect(storage.get(scopedKey('oc.sessions.folderCollapse', 'runtime-a'))).toBe(JSON.stringify([currentFolder.id]));
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
   });
 });

--- a/packages/ui/src/stores/useSessionFoldersStore.ts
+++ b/packages/ui/src/stores/useSessionFoldersStore.ts
@@ -3,6 +3,8 @@ import { devtools } from 'zustand/middleware';
 import { getDeferredSafeStorage } from './utils/safeStorage';
 import { isVSCodeRuntime } from '@/lib/desktop';
 import { runtimeFetch } from '@/lib/runtime-fetch';
+import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
+import { readRuntimeScopedStorage, writeRuntimeScopedStorage } from './utils/runtimeScopedStorage';
 
 // --- Types ---
 
@@ -46,14 +48,31 @@ const SESSION_FOLDERS_API_PATH = '/api/session-folders';
 const DISK_WRITE_DEBOUNCE_MS = 250;
 const ARCHIVED_SCOPE_PREFIX = '__archived__:';
 
+type FoldersRuntimeContext = {
+  runtimeKey: string;
+  generation: number;
+};
+
+let foldersRuntimeGeneration = 0;
+const captureFoldersRuntimeContext = (): FoldersRuntimeContext => ({
+  runtimeKey: getRuntimeKey(),
+  generation: foldersRuntimeGeneration,
+});
+const isSameFoldersRuntimeContext = (left: FoldersRuntimeContext, right: FoldersRuntimeContext): boolean => (
+  left.runtimeKey === right.runtimeKey && left.generation === right.generation
+);
+const isFoldersRuntimeContextCurrent = (context: FoldersRuntimeContext): boolean => (
+  context.generation === foldersRuntimeGeneration && context.runtimeKey === getRuntimeKey()
+);
+
 const safeStorage = getDeferredSafeStorage();
 let diskWriteTimer: ReturnType<typeof setTimeout> | null = null;
-let diskHydrated = false;
-let diskHydrationInFlight = false;
+let diskHydratedContext: FoldersRuntimeContext | null = null;
+let diskHydrationInFlight: FoldersRuntimeContext | null = null;
 let persistFoldersTimer: ReturnType<typeof setTimeout> | undefined;
 let persistCollapsedTimer: ReturnType<typeof setTimeout> | undefined;
-let pendingFoldersMap: SessionFoldersMap | null = null;
-let pendingCollapsedIds: Set<string> | null = null;
+let pendingFoldersMap: { foldersMap: SessionFoldersMap; context: FoldersRuntimeContext } | null = null;
+let pendingCollapsedIds: { ids: Set<string>; context: FoldersRuntimeContext } | null = null;
 
 const isVSCodeWebview = (): boolean => {
   if (typeof window === 'undefined') {
@@ -67,7 +86,11 @@ const isVSCodeWebview = (): boolean => {
   return (window as { __VSCODE_CONFIG__?: unknown }).__VSCODE_CONFIG__ !== undefined;
 };
 
-const schedulePersistToDisk = (foldersMap: SessionFoldersMap, collapsedFolderIds: Set<string>): void => {
+const schedulePersistToDisk = (
+  foldersMap: SessionFoldersMap,
+  collapsedFolderIds: Set<string>,
+  context = captureFoldersRuntimeContext(),
+): void => {
   if (typeof window === 'undefined') {
     return;
   }
@@ -85,6 +108,9 @@ const schedulePersistToDisk = (foldersMap: SessionFoldersMap, collapsedFolderIds
 
   diskWriteTimer = setTimeout(() => {
     diskWriteTimer = null;
+    if (!isFoldersRuntimeContextCurrent(context)) {
+      return;
+    }
     const payload = {
       version: 1,
       foldersMap: foldersSnapshot,
@@ -99,9 +125,9 @@ const schedulePersistToDisk = (foldersMap: SessionFoldersMap, collapsedFolderIds
   }, DISK_WRITE_DEBOUNCE_MS);
 };
 
-const readPersistedFolders = (): SessionFoldersMap => {
+const readPersistedFolders = (runtimeKey = getRuntimeKey()): SessionFoldersMap => {
   try {
-    const raw = safeStorage.getItem(FOLDERS_STORAGE_KEY);
+    const raw = readRuntimeScopedStorage(safeStorage, FOLDERS_STORAGE_KEY, runtimeKey);
     if (!raw) {
       return {};
     }
@@ -138,9 +164,9 @@ const readPersistedFolders = (): SessionFoldersMap => {
   }
 };
 
-const readPersistedCollapsed = (): Set<string> => {
+const readPersistedCollapsed = (runtimeKey = getRuntimeKey()): Set<string> => {
   try {
-    const raw = safeStorage.getItem(COLLAPSED_STORAGE_KEY);
+    const raw = readRuntimeScopedStorage(safeStorage, COLLAPSED_STORAGE_KEY, runtimeKey);
     if (!raw) {
       return new Set();
     }
@@ -154,26 +180,52 @@ const readPersistedCollapsed = (): Set<string> => {
   }
 };
 
-const persistFolders = (foldersMap: SessionFoldersMap): void => {
-  pendingFoldersMap = foldersMap;
+const persistFolders = (foldersMap: SessionFoldersMap, context = captureFoldersRuntimeContext()): void => {
+  pendingFoldersMap = { foldersMap, context };
   clearTimeout(persistFoldersTimer);
   persistFoldersTimer = setTimeout(() => {
+    const pending = pendingFoldersMap;
+    if (
+      !pending
+      || !isSameFoldersRuntimeContext(pending.context, context)
+      || !isFoldersRuntimeContextCurrent(pending.context)
+    ) {
+      return;
+    }
+    pendingFoldersMap = null;
     try {
-      safeStorage.setItem(FOLDERS_STORAGE_KEY, JSON.stringify(foldersMap));
-      pendingFoldersMap = null;
+      writeRuntimeScopedStorage(
+        safeStorage,
+        FOLDERS_STORAGE_KEY,
+        JSON.stringify(pending.foldersMap),
+        pending.context.runtimeKey,
+      );
     } catch {
       // ignored
     }
   }, 300);
 };
 
-const persistCollapsed = (collapsedFolderIds: Set<string>): void => {
-  pendingCollapsedIds = collapsedFolderIds;
+const persistCollapsed = (collapsedFolderIds: Set<string>, context = captureFoldersRuntimeContext()): void => {
+  pendingCollapsedIds = { ids: collapsedFolderIds, context };
   clearTimeout(persistCollapsedTimer);
   persistCollapsedTimer = setTimeout(() => {
+    const pending = pendingCollapsedIds;
+    if (
+      !pending
+      || !isSameFoldersRuntimeContext(pending.context, context)
+      || !isFoldersRuntimeContextCurrent(pending.context)
+    ) {
+      return;
+    }
+    pendingCollapsedIds = null;
     try {
-      safeStorage.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify(Array.from(collapsedFolderIds)));
-      pendingCollapsedIds = null;
+      writeRuntimeScopedStorage(
+        safeStorage,
+        COLLAPSED_STORAGE_KEY,
+        JSON.stringify(Array.from(pending.ids)),
+        pending.context.runtimeKey,
+      );
     } catch {
       // ignored
     }
@@ -184,25 +236,40 @@ if (typeof window !== 'undefined') {
   window.addEventListener('beforeunload', () => {
     if (pendingFoldersMap !== null) {
       clearTimeout(persistFoldersTimer);
-      try {
-        safeStorage.setItem(FOLDERS_STORAGE_KEY, JSON.stringify(pendingFoldersMap));
-      } catch { /* ignored */ }
+      if (isFoldersRuntimeContextCurrent(pendingFoldersMap.context)) {
+        try {
+          writeRuntimeScopedStorage(
+            safeStorage,
+            FOLDERS_STORAGE_KEY,
+            JSON.stringify(pendingFoldersMap.foldersMap),
+            pendingFoldersMap.context.runtimeKey,
+          );
+        } catch { /* ignored */ }
+      }
       pendingFoldersMap = null;
     }
     if (pendingCollapsedIds !== null) {
       clearTimeout(persistCollapsedTimer);
-      try {
-        safeStorage.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify(Array.from(pendingCollapsedIds)));
-      } catch { /* ignored */ }
+      if (isFoldersRuntimeContextCurrent(pendingCollapsedIds.context)) {
+        try {
+          writeRuntimeScopedStorage(
+            safeStorage,
+            COLLAPSED_STORAGE_KEY,
+            JSON.stringify(Array.from(pendingCollapsedIds.ids)),
+            pendingCollapsedIds.context.runtimeKey,
+          );
+        } catch { /* ignored */ }
+      }
       pendingCollapsedIds = null;
     }
   });
 }
 
 const persistState = (foldersMap: SessionFoldersMap, collapsedFolderIds: Set<string>): void => {
-  persistFolders(foldersMap);
-  persistCollapsed(collapsedFolderIds);
-  schedulePersistToDisk(foldersMap, collapsedFolderIds);
+  const context = captureFoldersRuntimeContext();
+  persistFolders(foldersMap, context);
+  persistCollapsed(collapsedFolderIds, context);
+  schedulePersistToDisk(foldersMap, collapsedFolderIds, context);
 };
 
 const createFolderId = (): string => {
@@ -525,21 +592,28 @@ export const useSessionFoldersStore = create<SessionFoldersStore>()(
   ),
 );
 
-const hydrateSessionFoldersFromDisk = async (): Promise<void> => {
-  if (diskHydrated || diskHydrationInFlight || typeof window === 'undefined') {
+const hydrateSessionFoldersFromDisk = async (
+  context = captureFoldersRuntimeContext(),
+): Promise<void> => {
+  if (
+    typeof window === 'undefined'
+    || !isFoldersRuntimeContextCurrent(context)
+    || (diskHydratedContext && isSameFoldersRuntimeContext(diskHydratedContext, context))
+    || (diskHydrationInFlight && isSameFoldersRuntimeContext(diskHydrationInFlight, context))
+  ) {
     return;
   }
 
   if (isVSCodeWebview()) {
-    diskHydrated = true;
+    diskHydratedContext = context;
     return;
   }
 
-  diskHydrationInFlight = true;
+  diskHydrationInFlight = context;
 
   try {
     const response = await runtimeFetch(SESSION_FOLDERS_API_PATH).catch(() => null);
-    if (!response || !response.ok) {
+    if (!isFoldersRuntimeContextCurrent(context) || !response || !response.ok) {
       return;
     }
 
@@ -548,7 +622,7 @@ const hydrateSessionFoldersFromDisk = async (): Promise<void> => {
       collapsedFolderIds?: string[];
     } | null;
 
-    if (!parsed) {
+    if (!isFoldersRuntimeContextCurrent(context) || !parsed) {
       return;
     }
 
@@ -560,7 +634,7 @@ const hydrateSessionFoldersFromDisk = async (): Promise<void> => {
       : new Set<string>();
 
     const hasDiskData = Object.keys(diskFolders).length > 0 || diskCollapsed.size > 0;
-    if (!hasDiskData) {
+    if (!isFoldersRuntimeContextCurrent(context) || !hasDiskData) {
       return;
     }
 
@@ -569,13 +643,17 @@ const hydrateSessionFoldersFromDisk = async (): Promise<void> => {
       collapsedFolderIds: diskCollapsed,
     });
 
-    persistFolders(diskFolders);
-    persistCollapsed(diskCollapsed);
+    persistFolders(diskFolders, context);
+    persistCollapsed(diskCollapsed, context);
   } catch {
     // ignored
   } finally {
-    diskHydrationInFlight = false;
-    diskHydrated = true;
+    if (diskHydrationInFlight && isSameFoldersRuntimeContext(diskHydrationInFlight, context)) {
+      diskHydrationInFlight = null;
+    }
+    if (isFoldersRuntimeContextCurrent(context)) {
+      diskHydratedContext = context;
+    }
   }
 };
 
@@ -588,3 +666,30 @@ const bootstrapSessionFoldersDiskHydration = (): void => {
 };
 
 bootstrapSessionFoldersDiskHydration();
+
+if (typeof window !== 'undefined') {
+  subscribeRuntimeEndpointChanged((detail) => {
+    if (detail.runtimeKey === detail.previousRuntimeKey) {
+      return;
+    }
+    foldersRuntimeGeneration += 1;
+    if (diskWriteTimer) {
+      clearTimeout(diskWriteTimer);
+      diskWriteTimer = null;
+    }
+    clearTimeout(persistFoldersTimer);
+    clearTimeout(persistCollapsedTimer);
+    persistFoldersTimer = undefined;
+    persistCollapsedTimer = undefined;
+    pendingFoldersMap = null;
+    pendingCollapsedIds = null;
+    diskHydratedContext = null;
+
+    const context = captureFoldersRuntimeContext();
+    useSessionFoldersStore.setState({
+      foldersMap: readPersistedFolders(context.runtimeKey),
+      collapsedFolderIds: readPersistedCollapsed(context.runtimeKey),
+    });
+    void hydrateSessionFoldersFromDisk(context);
+  });
+}

--- a/packages/ui/src/stores/useSessionPinnedStore.test.ts
+++ b/packages/ui/src/stores/useSessionPinnedStore.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type RuntimeEndpointDetail = {
+  runtimeKey: string;
+  previousRuntimeKey: string;
+};
+
+const PINNED_KEY = 'oc.sessions.pinned';
+const storageValues = new Map<string, string>();
+const runtimeListeners = new Set<(detail: RuntimeEndpointDetail) => void>();
+const events = new EventTarget();
+const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+let runtimeKey = 'local';
+
+const runtimeWindow = {
+  addEventListener: events.addEventListener.bind(events),
+  removeEventListener: events.removeEventListener.bind(events),
+  dispatchEvent: events.dispatchEvent.bind(events),
+};
+
+Object.defineProperty(globalThis, 'window', {
+  configurable: true,
+  value: runtimeWindow,
+});
+
+const safeStorage = {
+  getItem: (key: string) => storageValues.get(key) ?? null,
+  setItem: (key: string, value: string) => storageValues.set(key, value),
+  removeItem: (key: string) => storageValues.delete(key),
+  clear: () => storageValues.clear(),
+  key: (index: number) => Array.from(storageValues.keys())[index] ?? null,
+  get length() {
+    return storageValues.size;
+  },
+} as Storage;
+
+mock.module('./utils/safeStorage', () => ({
+  getDeferredSafeStorage: () => safeStorage,
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeKey: () => runtimeKey,
+  subscribeRuntimeEndpointChanged: (listener: (detail: RuntimeEndpointDetail) => void) => {
+    runtimeListeners.add(listener);
+    return () => runtimeListeners.delete(listener);
+  },
+}));
+
+const { useSessionPinnedStore } = await import('./useSessionPinnedStore');
+
+const scopedKey = (targetRuntimeKey = runtimeKey): string => `${PINNED_KEY}:${encodeURIComponent(targetRuntimeKey)}`;
+
+const emitRuntimeEndpointChanged = (nextRuntimeKey: string, previousRuntimeKey = runtimeKey): void => {
+  runtimeKey = nextRuntimeKey;
+  runtimeListeners.forEach((listener) => listener({ runtimeKey: nextRuntimeKey, previousRuntimeKey }));
+};
+
+describe('useSessionPinnedStore runtime persistence', () => {
+  beforeEach(() => {
+    storageValues.clear();
+    runtimeKey = 'local';
+    useSessionPinnedStore.setState({ ids: new Set<string>() });
+  });
+
+  afterAll(() => {
+    if (previousWindow) {
+      Object.defineProperty(globalThis, 'window', previousWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
+  });
+
+  test('stores and restores pinned sessions by runtime identity', () => {
+    runtimeKey = 'runtime-a';
+    useSessionPinnedStore.getState().setIds(new Set(['shared-session']));
+    storageValues.set(scopedKey('runtime-b'), JSON.stringify(['remote-session']));
+    storageValues.set(PINNED_KEY, JSON.stringify(['legacy-session']));
+
+    emitRuntimeEndpointChanged('runtime-b', 'runtime-a');
+
+    expect(storageValues.get(scopedKey('runtime-a'))).toBe(JSON.stringify(['shared-session']));
+    expect(storageValues.get(PINNED_KEY)).toBe(JSON.stringify(['legacy-session']));
+    expect(useSessionPinnedStore.getState().ids).toEqual(new Set(['remote-session']));
+  });
+
+  test('uses the legacy pinned value only when returning to local', () => {
+    storageValues.set(PINNED_KEY, JSON.stringify(['local-session']));
+    runtimeKey = 'remote-runtime';
+
+    emitRuntimeEndpointChanged('local', 'remote-runtime');
+
+    expect(useSessionPinnedStore.getState().ids).toEqual(new Set(['local-session']));
+  });
+
+  test('does not use the legacy pinned value for a remote runtime without scoped state', () => {
+    storageValues.set(PINNED_KEY, JSON.stringify(['local-session']));
+
+    emitRuntimeEndpointChanged('remote-runtime', 'local');
+
+    expect(useSessionPinnedStore.getState().ids).toEqual(new Set());
+  });
+});

--- a/packages/ui/src/stores/useSessionPinnedStore.ts
+++ b/packages/ui/src/stores/useSessionPinnedStore.ts
@@ -1,11 +1,13 @@
 import { create } from 'zustand';
+import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import { getDeferredSafeStorage } from './utils/safeStorage';
+import { readRuntimeScopedStorage, writeRuntimeScopedStorage } from './utils/runtimeScopedStorage';
 
-const SESSION_PINNED_STORAGE_KEY = 'oc.sessions.pinned';
+export const SESSION_PINNED_STORAGE_KEY = 'oc.sessions.pinned';
 
-const readPinned = (storage: Storage): Set<string> => {
+const readPinned = (storage: Storage, runtimeKey = getRuntimeKey()): Set<string> => {
   try {
-    const raw = storage.getItem(SESSION_PINNED_STORAGE_KEY);
+    const raw = readRuntimeScopedStorage(storage, SESSION_PINNED_STORAGE_KEY, runtimeKey);
     if (!raw) return new Set();
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return new Set();
@@ -15,9 +17,9 @@ const readPinned = (storage: Storage): Set<string> => {
   }
 };
 
-const persistPinned = (storage: Storage, ids: Set<string>): void => {
+const persistPinned = (storage: Storage, ids: Set<string>, runtimeKey = getRuntimeKey()): void => {
   try {
-    storage.setItem(SESSION_PINNED_STORAGE_KEY, JSON.stringify([...ids]));
+    writeRuntimeScopedStorage(storage, SESSION_PINNED_STORAGE_KEY, JSON.stringify([...ids]), runtimeKey);
   } catch {
     // ignore
   }
@@ -52,3 +54,12 @@ export const useSessionPinnedStore = create<SessionPinnedStore>((set, get) => ({
     persistPinned(safeStorage, next);
   },
 }));
+
+if (typeof window !== 'undefined') {
+  subscribeRuntimeEndpointChanged((detail) => {
+    if (detail.runtimeKey === detail.previousRuntimeKey) {
+      return;
+    }
+    useSessionPinnedStore.setState({ ids: readPinned(safeStorage, detail.runtimeKey) });
+  });
+}

--- a/packages/ui/src/stores/utils/runtimeScopedStorage.test.ts
+++ b/packages/ui/src/stores/utils/runtimeScopedStorage.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+let runtimeKey = 'local';
+let getRuntimeKeyCalls = 0;
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeKey: () => {
+    getRuntimeKeyCalls += 1;
+    return runtimeKey;
+  },
+}));
+
+const {
+  getRuntimeScopedStorageKey,
+  readRuntimeScopedStorage,
+  writeRuntimeScopedStorage,
+} = await import('./runtimeScopedStorage');
+
+const createStorage = () => {
+  const values = new Map<string, string>();
+  const getItemCalls: string[] = [];
+  return {
+    getItem: (key: string) => {
+      getItemCalls.push(key);
+      return values.get(key) ?? null;
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+    getItemCalls,
+  };
+};
+
+describe('runtimeScopedStorage', () => {
+  test('isolates local and remote runtime values', () => {
+    const storage = createStorage();
+    const key = 'oc.sessions.expanded';
+    const remoteRuntimeKey = 'url:https://remote.example';
+
+    writeRuntimeScopedStorage(storage, key, 'local-value', 'local');
+    writeRuntimeScopedStorage(storage, key, 'remote-value', remoteRuntimeKey);
+
+    expect(readRuntimeScopedStorage(storage, key, 'local')).toBe('local-value');
+    expect(readRuntimeScopedStorage(storage, key, remoteRuntimeKey)).toBe('remote-value');
+    expect(getRuntimeScopedStorageKey(key, 'local')).toBe(`${key}:local`);
+    expect(getRuntimeScopedStorageKey(key, remoteRuntimeKey)).toBe(`${key}:${encodeURIComponent(remoteRuntimeKey)}`);
+  });
+
+  test('uses getRuntimeKey when no runtime key is supplied', () => {
+    const key = 'oc.sessions.expanded';
+    runtimeKey = 'local';
+    expect(getRuntimeScopedStorageKey(key)).toBe(`${key}:local`);
+
+    runtimeKey = 'url:https://remote.example';
+    expect(getRuntimeScopedStorageKey(key)).toBe(`${key}:${encodeURIComponent(runtimeKey)}`);
+  });
+
+  test('uses unscoped legacy storage only for the local runtime', () => {
+    const storage = createStorage();
+    const key = 'oc.sessions.expanded';
+    storage.setItem(key, 'legacy-local-value');
+
+    expect(readRuntimeScopedStorage(storage, key, 'local')).toBe('legacy-local-value');
+    expect(readRuntimeScopedStorage(storage, key, 'url:https://remote.example')).toBeNull();
+  });
+
+  test('resolves null through getRuntimeKey and preserves local legacy storage', () => {
+    const storage = createStorage();
+    const key = 'oc.sessions.expanded';
+    runtimeKey = 'local';
+    getRuntimeKeyCalls = 0;
+    storage.setItem(key, 'legacy-local-value');
+
+    expect(readRuntimeScopedStorage(storage, key, null)).toBe('legacy-local-value');
+    expect(getRuntimeKeyCalls).toBe(1);
+    expect(storage.getItemCalls).toEqual([`${key}:local`, key]);
+  });
+
+  test('rejects blank explicit runtime keys before writing a shared bucket', () => {
+    const storage = createStorage();
+    const key = 'oc.sessions.expanded';
+
+    expect(() => getRuntimeScopedStorageKey(key, '')).toThrow('Runtime storage key must be non-empty when explicitly provided');
+    expect(() => writeRuntimeScopedStorage(storage, key, 'value', '   ')).toThrow('Runtime storage key must be non-empty when explicitly provided');
+    expect(storage.getItem(`${key}:default`)).toBeNull();
+  });
+
+  test('rejects blank explicit read runtime keys before inspecting storage', () => {
+    const storage = createStorage();
+    const key = 'oc.sessions.expanded';
+
+    expect(() => readRuntimeScopedStorage(storage, key, '')).toThrow('Runtime storage key must be non-empty when explicitly provided');
+    expect(() => readRuntimeScopedStorage(storage, key, ' \t ')).toThrow('Runtime storage key must be non-empty when explicitly provided');
+    expect(storage.getItemCalls).toEqual([]);
+  });
+});

--- a/packages/ui/src/stores/utils/runtimeScopedStorage.ts
+++ b/packages/ui/src/stores/utils/runtimeScopedStorage.ts
@@ -15,8 +15,12 @@ const normalizeRuntimeStorageKey = (value?: string | null): string => {
   return key;
 };
 
+const getRuntimeScopedStorageKeyFromNormalizedRuntimeKey = (key: string, normalizedRuntimeKey: string): string => {
+  return `${key}:${encodeURIComponent(normalizedRuntimeKey)}`;
+};
+
 export const getRuntimeScopedStorageKey = (key: string, runtimeKey?: string | null): string => {
-  return `${key}:${encodeURIComponent(normalizeRuntimeStorageKey(runtimeKey))}`;
+  return getRuntimeScopedStorageKeyFromNormalizedRuntimeKey(key, normalizeRuntimeStorageKey(runtimeKey));
 };
 
 export const readRuntimeScopedStorage = (
@@ -25,7 +29,7 @@ export const readRuntimeScopedStorage = (
   runtimeKey?: string | null,
 ): string | null => {
   const normalizedRuntimeKey = normalizeRuntimeStorageKey(runtimeKey);
-  const scoped = storage.getItem(getRuntimeScopedStorageKey(key, normalizedRuntimeKey));
+  const scoped = storage.getItem(getRuntimeScopedStorageKeyFromNormalizedRuntimeKey(key, normalizedRuntimeKey));
   if (scoped !== null) {
     return scoped;
   }

--- a/packages/ui/src/stores/utils/runtimeScopedStorage.ts
+++ b/packages/ui/src/stores/utils/runtimeScopedStorage.ts
@@ -1,0 +1,36 @@
+import { getRuntimeKey } from '@/lib/runtime-switch';
+
+type ReadableStorage = Pick<Storage, 'getItem'>;
+type WritableStorage = Pick<Storage, 'setItem'>;
+
+const normalizeRuntimeStorageKey = (value?: string | null): string => {
+  const key = (value ?? getRuntimeKey()).trim();
+  return key || 'default';
+};
+
+export const getRuntimeScopedStorageKey = (key: string, runtimeKey?: string | null): string => {
+  return `${key}:${encodeURIComponent(normalizeRuntimeStorageKey(runtimeKey))}`;
+};
+
+export const readRuntimeScopedStorage = (
+  storage: ReadableStorage,
+  key: string,
+  runtimeKey?: string | null,
+): string | null => {
+  const normalizedRuntimeKey = normalizeRuntimeStorageKey(runtimeKey);
+  const scoped = storage.getItem(getRuntimeScopedStorageKey(key, normalizedRuntimeKey));
+  if (scoped !== null) {
+    return scoped;
+  }
+
+  return normalizedRuntimeKey === 'local' ? storage.getItem(key) : null;
+};
+
+export const writeRuntimeScopedStorage = (
+  storage: WritableStorage,
+  key: string,
+  value: string,
+  runtimeKey?: string | null,
+): void => {
+  storage.setItem(getRuntimeScopedStorageKey(key, runtimeKey), value);
+};

--- a/packages/ui/src/stores/utils/runtimeScopedStorage.ts
+++ b/packages/ui/src/stores/utils/runtimeScopedStorage.ts
@@ -4,8 +4,15 @@ type ReadableStorage = Pick<Storage, 'getItem'>;
 type WritableStorage = Pick<Storage, 'setItem'>;
 
 const normalizeRuntimeStorageKey = (value?: string | null): string => {
-  const key = (value ?? getRuntimeKey()).trim();
-  return key || 'default';
+  if (value === undefined || value === null) {
+    return getRuntimeKey().trim() || 'default';
+  }
+
+  const key = value.trim();
+  if (!key) {
+    throw new Error('Runtime storage key must be non-empty when explicitly provided');
+  }
+  return key;
 };
 
 export const getRuntimeScopedStorageKey = (key: string, runtimeKey?: string | null): string => {

--- a/packages/ui/src/types/bun-test.d.ts
+++ b/packages/ui/src/types/bun-test.d.ts
@@ -2,36 +2,46 @@
 // Only the subset used by our test files is declared.
 
 declare module "bun:test" {
-  export function describe(name: string, fn: () => void): void;
-  export function test(name: string, fn: () => void | Promise<void>): void;
-  export function expect(value: unknown): {
+  type Matchers = {
     toEqual(expected: unknown): void;
     toBe(expected: unknown): void;
     toBeTruthy(): void;
     toBeFalsy(): void;
     toBeNull(): void;
+    toBeUndefined(): void;
     toThrow(expected?: string | RegExp | (new (...args: never[]) => unknown)): void;
     toContain(expected: unknown): void;
     toBeDefined(): void;
-    rejects: {
-      toThrow(expected?: string | RegExp | (new (...args: never[]) => unknown)): Promise<void>;
-    };
     toBeGreaterThan(expected: number): void;
     toBeGreaterThanOrEqual(expected: number): void;
     toBeLessThan(expected: number): void;
     toHaveLength(expected: number): void;
     toBeInstanceOf(expected: unknown): void;
-    not: {
-      toEqual(expected: unknown): void;
-      toBe(expected: unknown): void;
-      toContain(expected: unknown): void;
-      toBeNull(): void;
-    };
+    toHaveBeenCalled(): void;
+    toHaveBeenCalledWith(...args: unknown[]): void;
   };
+
+  type Mock<T extends (...args: never[]) => unknown> = T & {
+    mockClear(): void;
+  };
+
+  export function describe(name: string, fn: () => void): void;
+  export function test(name: string, fn: () => void | Promise<void>): void;
+  export function expect(value: unknown): {
+    [K in keyof Matchers]: Matchers[K];
+  } & {
+    rejects: {
+      toThrow(expected?: string | RegExp | (new (...args: never[]) => unknown)): Promise<void>;
+    };
+    not: Matchers;
+  };
+  export namespace expect {
+    function objectContaining(expected: Record<string, unknown>): unknown;
+  }
   export function beforeEach(fn: () => void | Promise<void>): void;
   export function afterEach(fn: () => void | Promise<void>): void;
   export function afterAll(fn: () => void | Promise<void>): void;
-  export function mock<T extends (...args: never[]) => unknown>(fn?: T): T;
+  export function mock<T extends (...args: never[]) => unknown>(fn?: T): Mock<T>;
   export namespace mock {
     function module(moduleName: string, factory: () => Record<string, unknown>): void;
   }


### PR DESCRIPTION
## Problem

Switching an Electron or web client between runtimes happens in place. Browser and desktop fallback state from the previous runtime could therefore be rehydrated or persisted under the next runtime, corrupting remote paths, projects, and sidebar metadata.

Fixes #2298

## What changed

### Runtime-scoped persistence
- Scope directory, project, pinned-session, folder, and sidebar persistence by `getRuntimeKey()`.
- Keep legacy unscoped browser storage readable only for the local runtime.
- Reload destination-runtime state on endpoint changes instead of carrying previous-runtime UI state forward.

### Stale-work protection
- Reject stale home resolution, project-icon, folder-cleanup, and debounced sidebar writes using runtime identity plus a monotonic generation.
- Cover local → remote and A → B → A runtime switches so an old completion cannot write into the current runtime.

### Review follow-up
- Reject explicit empty or whitespace runtime storage keys before any storage read or write. This fails closed instead of collapsing state into a shared `default` namespace.
- Preserve normal omitted/null key resolution through `getRuntimeKey()` and the local-only legacy fallback.

## Validation
- `bun test packages/ui/src/stores/utils/runtimeScopedStorage.test.ts` — 6 passed.
- Focused non-isolated persistence regression batch — 42 passed.
- Focused isolated runtime regression batch — 44 passed.
- `bun run type-check:ui` — passed.
- `bun run lint:ui` — passed.
- `bun run dead-code` — completed; its configured non-blocking report contains existing cleanup candidates.

## Notes
- No raw runtime/path input is exposed to users; runtime identity remains system-derived.
- The existing no-argument `getRuntimeKey()` behavior is intentionally unchanged.