### PR TITLE
fix: run project start commands in new worktrees

### DIFF
--- a/packages/vscode/src/DOCUMENTATION.md
+++ b/packages/vscode/src/DOCUMENTATION.md
@@ -14,6 +14,7 @@ Keep `bridge.ts` as a thin orchestration layer that delegates message handling t
 
 - `bridge-git-runtime.ts`
   - Standard Git message handlers.
+  - Injects the VS Code OpenCode project-command runtime into worktree creation so bootstrap setup mirrors the web server runtime.
 
 - `bridge-git-special-runtime.ts`
   - Specialized Git flows (`pr-description`, `conflict-details`) and generation helpers.
@@ -23,8 +24,14 @@ Keep `bridge.ts` as a thin orchestration layer that delegates message handling t
 
 - `gitService.ts`
   - Owns VS Code Git and worktree operations.
+  - `createWorktree(directory, input, runtime?)` accepts an injected project-command loader. The service executes an authoritative OpenCode `commands.start` value before any extra `startCommand`, treats authoritative empty commands as “do not run project start”, and falls back to legacy project JSON only when the runtime is absent, unavailable, or unmatched.
   - Fast worktree creation reports bootstrap phases explicitly: `directory-created`, then `git-ready` after Git population/upstream work, and `setup-ready` after setup commands. Existing worktrees without tracked bootstrap state fall back to `ready`/`setup-ready`; shared webview consumers also accept legacy responses without `phase`.
   - Worktree removal waits for an active create/bootstrap task for the same directory so background Git and setup work cannot race deletion or restore stale bootstrap state.
+
+- `project-commands-runtime.ts`
+  - SDK-backed OpenCode project command lookup for VS Code worktree bootstrap.
+  - Creates a fresh `@opencode-ai/sdk/v2` client per lookup from `OpenCodeManager.getApiUrl()` and `getOpenCodeAuthHeaders()`.
+  - Matches projects by exact OpenCode project ID first, then normalized explicit worktree path; unmatched or failed API lookups are reported as unavailable for legacy fallback.
 
 - `bridge-fs-runtime.ts`
   - Bridge handlers for filesystem-related message routes.

--- a/packages/vscode/src/bridge-git-runtime.test.js
+++ b/packages/vscode/src/bridge-git-runtime.test.js
@@ -173,6 +173,26 @@ describe('bridge git runtime index mutations', () => {
     });
     expect(gitService.createWorktree).toHaveBeenCalledWith('/repo', expect.objectContaining({
       returnAfterDirectoryCreated: true,
-    }));
+    }), { projectCommandRuntime: expect.objectContaining({ loadStartCommand: expect.any(Function) }) });
+  });
+
+  it('passes manager-backed project command runtime to worktree creation', async () => {
+    gitService.createWorktree.mockResolvedValue({ path: '/repo-worktree' });
+    const manager = {
+      getApiUrl: mock(() => 'http://127.0.0.1:4096'),
+      getOpenCodeAuthHeaders: mock(() => ({ Authorization: 'Bearer test-token' })),
+    };
+
+    const response = await handleStandardGitBridgeMessage({
+      id: 'create-worktree',
+      type: 'api:git/worktrees',
+      payload: { directory: '/repo', method: 'POST' },
+    }, { manager });
+
+    expect(response?.success).toBe(true);
+    expect(gitService.createWorktree).toHaveBeenCalledWith('/repo', expect.objectContaining({
+      directory: '/repo',
+      method: 'POST',
+    }), { projectCommandRuntime: expect.objectContaining({ loadStartCommand: expect.any(Function) }) });
   });
 });

--- a/packages/vscode/src/bridge-git-runtime.ts
+++ b/packages/vscode/src/bridge-git-runtime.ts
@@ -1,5 +1,6 @@
 import * as gitService from './gitService';
-import type { BridgeResponse } from './bridge';
+import type { BridgeContext, BridgeResponse } from './bridge';
+import { createOpenCodeProjectCommandRuntime } from './project-commands-runtime';
 
 type BridgeMessageInput = {
   id: string;
@@ -18,7 +19,7 @@ const isValidCommitHash = (hash: string | undefined): hash is string => (
   typeof hash === 'string' && /^[0-9a-fA-F]{7,40}$/.test(hash)
 );
 
-export async function handleStandardGitBridgeMessage(message: BridgeMessageInput): Promise<BridgeResponse | null> {
+export async function handleStandardGitBridgeMessage(message: BridgeMessageInput, ctx?: BridgeContext): Promise<BridgeResponse | null> {
   const { id, type, payload } = message;
 
   switch (type) {
@@ -124,7 +125,15 @@ export async function handleStandardGitBridgeMessage(message: BridgeMessageInput
       }
 
       if (normalizedMethod === 'POST') {
-        const created = await gitService.createWorktree(directory!, (payload || {}) as gitService.CreateGitWorktreePayload);
+        const projectCommandRuntime = createOpenCodeProjectCommandRuntime({
+          getApiUrl: () => ctx?.manager?.getApiUrl() || null,
+          getOpenCodeAuthHeaders: () => ctx?.manager?.getOpenCodeAuthHeaders() || {},
+        });
+        const created = await gitService.createWorktree(
+          directory!,
+          (payload || {}) as gitService.CreateGitWorktreePayload,
+          { projectCommandRuntime },
+        );
         return { id, type, success: true, data: created };
       }
 

--- a/packages/vscode/src/bridge.ts
+++ b/packages/vscode/src/bridge.ts
@@ -76,7 +76,7 @@ export async function handleBridgeMessage(message: BridgeRequest, ctx?: BridgeCo
     );
     if (permissionAutoAcceptResponse) return permissionAutoAcceptResponse;
 
-    const standardGitResponse = await handleStandardGitBridgeMessage({ id, type, payload });
+    const standardGitResponse = await handleStandardGitBridgeMessage({ id, type, payload }, ctx);
     if (standardGitResponse) {
       return standardGitResponse;
     }

--- a/packages/vscode/src/gitService.ts
+++ b/packages/vscode/src/gitService.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import { spawn, execFile } from 'child_process';
 import { promisify } from 'util';
 import type { API as GitAPI, Repository, GitExtension, Status } from './git.d';
+import type { ProjectCommandRuntime } from './project-commands-runtime';
 
 let gitApi: GitAPI | null = null;
 let gitExtensionEnabled = false;
@@ -1385,6 +1386,22 @@ const loadProjectStartCommand = async (projectID: string): Promise<string> => {
   }
 };
 
+export const resolveWorktreeProjectStartCommand = async (
+  projectID: string,
+  primaryWorktree: string,
+  runtime?: ProjectCommandRuntime,
+  legacyLoader: (projectID: string) => Promise<string> = loadProjectStartCommand,
+): Promise<string> => {
+  if (typeof runtime?.loadStartCommand === 'function') {
+    const result = await runtime.loadStartCommand(projectID, primaryWorktree);
+    if (result.available) {
+      return result.command.trim();
+    }
+  }
+
+  return legacyLoader(projectID);
+};
+
 const getProjectStoragePath = (projectID: string) => {
   return path.join(getOpenCodeDataPath(), 'storage', 'project', `${projectID}.json`);
 };
@@ -1502,8 +1519,14 @@ const cleanupFailedFastWorktreeCreate = async (
   }
 };
 
-const runWorktreeStartScripts = async (directory: string, projectID: string, startCommand: string | undefined) => {
-  const projectStart = await loadProjectStartCommand(projectID);
+const runWorktreeStartScripts = async (
+  directory: string,
+  projectID: string,
+  primaryWorktree: string,
+  startCommand: string | undefined,
+  projectCommandRuntime?: ProjectCommandRuntime,
+) => {
+  const projectStart = await resolveWorktreeProjectStartCommand(projectID, primaryWorktree, projectCommandRuntime);
   if (projectStart) {
     const projectResult = await runWorktreeStartCommand(directory, projectStart);
     if (!projectResult.success) {
@@ -1533,6 +1556,7 @@ const queueWorktreeBootstrap = (args: {
   ensureRemoteName: string;
   ensureRemoteUrl: string;
   startCommand: string | undefined;
+  projectCommandRuntime?: ProjectCommandRuntime;
 }) => {
   const {
     directory,
@@ -1545,6 +1569,7 @@ const queueWorktreeBootstrap = (args: {
     ensureRemoteName,
     ensureRemoteUrl,
     startCommand,
+    projectCommandRuntime,
   } = args;
   const task = new Promise<void>((resolve) => setTimeout(resolve, 0))
     .then(async () => {
@@ -1564,7 +1589,7 @@ const queueWorktreeBootstrap = (args: {
         });
       }
       setWorktreeBootstrapState(directory, WORKTREE_BOOTSTRAP_PENDING, WORKTREE_PHASE_GIT_READY);
-      await runWorktreeStartScripts(directory, projectID, startCommand).catch((error) => {
+      await runWorktreeStartScripts(directory, projectID, primaryWorktree, startCommand, projectCommandRuntime).catch((error) => {
         console.warn('[GitService] Worktree start script task failed:', error instanceof Error ? error.message : String(error));
       });
       setWorktreeBootstrapState(directory, WORKTREE_BOOTSTRAP_READY, WORKTREE_PHASE_SETUP_READY);
@@ -1882,6 +1907,7 @@ async function attachGitWorktreeToCandidate(
   context: Awaited<ReturnType<typeof resolveWorktreeProjectContext>>,
   candidate: { name: string; directory: string; branch: string },
   input: CreateGitWorktreePayload = {},
+  runtime: { projectCommandRuntime?: ProjectCommandRuntime } = {},
 ): Promise<GitWorktreeInfo> {
   const mode = input?.mode === 'existing' ? 'existing' : 'new';
   const preferredBranchName = cleanBranchName(String(input?.branchName || '').trim());
@@ -1995,6 +2021,7 @@ async function attachGitWorktreeToCandidate(
     ensureRemoteName,
     ensureRemoteUrl,
     startCommand: input?.startCommand,
+    projectCommandRuntime: runtime.projectCommandRuntime,
   });
 
   const headResult = await runGitCommand(candidate.directory, ['rev-parse', 'HEAD']);
@@ -2010,7 +2037,11 @@ async function attachGitWorktreeToCandidate(
   };
 }
 
-export async function createWorktree(directory: string, input: CreateGitWorktreePayload = {}): Promise<GitWorktreeInfo> {
+export async function createWorktree(
+  directory: string,
+  input: CreateGitWorktreePayload = {},
+  runtime: { projectCommandRuntime?: ProjectCommandRuntime } = {},
+): Promise<GitWorktreeInfo> {
   const mode = input?.mode === 'existing' ? 'existing' : 'new';
   const context = await resolveWorktreeProjectContext(directory);
 
@@ -2053,7 +2084,7 @@ export async function createWorktree(directory: string, input: CreateGitWorktree
       ? cleanBranchName(String(input?.branchName || input?.existingBranch || candidate.branch || '').trim())
       : candidate.branch;
 
-    const task = attachGitWorktreeToCandidate(context, candidate, input).catch(async (error) => {
+    const task = attachGitWorktreeToCandidate(context, candidate, input, runtime).catch(async (error) => {
       setWorktreeBootstrapFailure(candidate.directory, error);
       await cleanupFailedFastWorktreeCreate(context, candidate);
       console.warn('[GitService] Background worktree creation failed:', error instanceof Error ? error.message : String(error));
@@ -2070,7 +2101,7 @@ export async function createWorktree(directory: string, input: CreateGitWorktree
     };
   }
 
-  return attachGitWorktreeToCandidate(context, candidate, input);
+  return attachGitWorktreeToCandidate(context, candidate, input, runtime);
 }
 
 export async function getWorktreeBootstrapStatus(directory: string): Promise<WorktreeBootstrapStatus> {

--- a/packages/vscode/src/gitService.worktree-bootstrap.test.js
+++ b/packages/vscode/src/gitService.worktree-bootstrap.test.js
@@ -5,7 +5,7 @@ mock.module('vscode', () => ({
   Uri: { file: (fsPath) => ({ fsPath }) },
 }));
 
-const { getWorktreeBootstrapStatus } = await import('./gitService.ts?worktree-bootstrap-test');
+const { getWorktreeBootstrapStatus, resolveWorktreeProjectStartCommand } = await import('./gitService.ts?worktree-bootstrap-test');
 
 describe('VS Code worktree bootstrap phases', () => {
   it('treats missing bootstrap state as fully ready', async () => {
@@ -14,5 +14,36 @@ describe('VS Code worktree bootstrap phases', () => {
       phase: 'setup-ready',
       error: null,
     });
+  });
+
+  it('uses an authoritative project start command without loading legacy JSON', async () => {
+    const runtime = {
+      loadStartCommand: mock(async () => ({ available: true, command: ' bun dev ' })),
+    };
+    const legacyLoader = mock(async () => 'legacy command');
+
+    await expect(resolveWorktreeProjectStartCommand('project-a', '/repo', runtime, legacyLoader)).resolves.toBe('bun dev');
+    expect(runtime.loadStartCommand).toHaveBeenCalledWith('project-a', '/repo');
+    expect(legacyLoader).not.toHaveBeenCalled();
+  });
+
+  it('preserves authoritative empty commands without loading legacy JSON', async () => {
+    const runtime = {
+      loadStartCommand: mock(async () => ({ available: true, command: '' })),
+    };
+    const legacyLoader = mock(async () => 'legacy command');
+
+    await expect(resolveWorktreeProjectStartCommand('project-a', '/repo', runtime, legacyLoader)).resolves.toBe('');
+    expect(legacyLoader).not.toHaveBeenCalled();
+  });
+
+  it('uses legacy project JSON when the API runtime is unavailable', async () => {
+    const runtime = {
+      loadStartCommand: mock(async () => ({ available: false, command: '' })),
+    };
+    const legacyLoader = mock(async () => 'legacy command');
+
+    await expect(resolveWorktreeProjectStartCommand('project-a', '/repo', runtime, legacyLoader)).resolves.toBe('legacy command');
+    expect(legacyLoader).toHaveBeenCalledWith('project-a');
   });
 });

--- a/packages/vscode/src/project-commands-runtime.test.js
+++ b/packages/vscode/src/project-commands-runtime.test.js
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const createOpencodeClient = mock();
+
+const { createOpenCodeProjectCommandRuntime } = await import('./project-commands-runtime');
+
+describe('VS Code project commands runtime', () => {
+  beforeEach(() => {
+    createOpencodeClient.mockReset();
+  });
+
+  const createRuntime = (overrides = {}) => createOpenCodeProjectCommandRuntime({
+    getApiUrl: () => 'http://127.0.0.1:4096/',
+    getOpenCodeAuthHeaders: () => ({ Authorization: 'Bearer test-token' }),
+    createClient: createOpencodeClient,
+    ...overrides,
+  });
+
+  it('loads commands.start from the authoritative current project API by ID', async () => {
+    const project = {
+      current: mock(async () => ({ data: { id: 'project-a', commands: { start: ' bun dev ' } } })),
+      list: mock(),
+    };
+    createOpencodeClient.mockReturnValue({ project });
+
+    expect(await createRuntime().loadStartCommand('project-a', '/repo')).toEqual({
+      available: true,
+      command: 'bun dev',
+    });
+    expect(project.current).toHaveBeenCalledWith({ directory: '/repo' });
+    expect(project.list).not.toHaveBeenCalled();
+  });
+
+  it('preserves authoritative empty commands', async () => {
+    createOpencodeClient.mockReturnValue({
+      project: {
+        current: mock(async () => ({ data: { id: 'project-a', commands: { start: '   ' } } })),
+        list: mock(),
+      },
+    });
+
+    expect(await createRuntime().loadStartCommand('project-a', '/repo')).toEqual({
+      available: true,
+      command: '',
+    });
+  });
+
+  it('falls back to list and prefers exact ID before worktree', async () => {
+    const project = {
+      current: mock(async () => ({ data: { commands: { start: 'wrong' } } })),
+      list: mock(async () => ({
+        data: [
+          { id: 'other', worktree: '/repo', commands: { start: 'by worktree' } },
+          { id: 'project-a', worktree: '/other', commands: { start: 'by id' } },
+        ],
+      })),
+    };
+    createOpencodeClient.mockReturnValue({ project });
+
+    expect(await createRuntime().loadStartCommand('project-a', '/repo')).toEqual({
+      available: true,
+      command: 'by id',
+    });
+    expect(project.list).toHaveBeenCalledWith({ directory: '/repo' });
+  });
+
+  it('reports unavailable for missing URL, API errors, or unmatched projects', async () => {
+    expect(await createRuntime({ getApiUrl: () => null }).loadStartCommand('project-a', '/repo')).toEqual({
+      available: false,
+      command: '',
+    });
+    expect(createOpencodeClient).not.toHaveBeenCalled();
+
+    createOpencodeClient.mockReturnValueOnce({
+      project: { current: mock(async () => { throw new Error('offline'); }), list: mock() },
+    });
+    expect(await createRuntime().loadStartCommand('project-a', '/repo')).toEqual({
+      available: false,
+      command: '',
+    });
+
+    createOpencodeClient.mockReturnValueOnce({
+      project: {
+        current: mock(async () => ({ data: { id: 'other', worktree: '/other' } })),
+        list: mock(async () => ({ data: [{ id: 'elsewhere' }] })),
+      },
+    });
+    expect(await createRuntime().loadStartCommand('project-a', '/repo')).toEqual({
+      available: false,
+      command: '',
+    });
+  });
+
+  it('creates a fresh SDK client with current URL, auth headers, directory, and timeout fetch', async () => {
+    const headers = { Authorization: 'Bearer secret-test-token' };
+    const getApiUrl = mock(() => 'http://127.0.0.1:4096/');
+    const getOpenCodeAuthHeaders = mock(() => headers);
+    createOpencodeClient.mockReturnValue({
+      project: {
+        current: mock(async () => ({ data: { id: 'project-a', commands: { start: 'bun dev' } } })),
+        list: mock(),
+      },
+    });
+
+    await createRuntime({ getApiUrl, getOpenCodeAuthHeaders }).loadStartCommand('project-a', '/repo');
+
+    expect(getApiUrl).toHaveBeenCalledTimes(1);
+    expect(getOpenCodeAuthHeaders).toHaveBeenCalledTimes(1);
+    expect(createOpencodeClient).toHaveBeenCalledTimes(1);
+    const options = createOpencodeClient.mock.calls[0][0];
+    expect(options).toMatchObject({
+      baseUrl: 'http://127.0.0.1:4096',
+      directory: '/repo',
+      headers,
+    });
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = mock(async () => new Response('{}'));
+    globalThis.fetch = fetchMock;
+    try {
+      const controller = new AbortController();
+      const request = new Request('http://127.0.0.1:4096/project', { signal: controller.signal });
+      await options.fetch(request);
+      const fetchSignal = fetchMock.mock.calls[0][1]?.signal;
+      expect(fetchMock).toHaveBeenCalledWith(request, { signal: fetchSignal });
+      expect(fetchSignal).toBeInstanceOf(AbortSignal);
+      expect(fetchSignal).not.toBe(controller.signal);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/vscode/src/project-commands-runtime.ts
+++ b/packages/vscode/src/project-commands-runtime.ts
@@ -1,0 +1,134 @@
+import * as path from 'path';
+import { createOpencodeClient } from '@opencode-ai/sdk/v2';
+
+const OPENCODE_PROJECT_COMMAND_TIMEOUT_MS = 8_000;
+
+export type ProjectCommandResult =
+  | { available: true; command: string }
+  | { available: false; command: '' };
+
+export interface ProjectCommandRuntime {
+  loadStartCommand(projectID: string, primaryWorktree: string): Promise<ProjectCommandResult>;
+}
+
+export interface ProjectCommandRuntimeDependencies {
+  getApiUrl?: () => string | null;
+  getOpenCodeAuthHeaders?: () => Record<string, string>;
+  createClient?: typeof createOpencodeClient;
+}
+
+const unavailableProjectCommandResult = (): ProjectCommandResult => ({ available: false, command: '' });
+
+const availableProjectCommandResult = (command: unknown): ProjectCommandResult => ({
+  available: true,
+  command: typeof command === 'string' ? command.trim() : '',
+});
+
+const normalizeProjectDirectoryForCompare = (value: unknown): string => {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text ? path.resolve(text) : '';
+};
+
+const getProjectDirectory = (project: unknown): string => {
+  if (!project || typeof project !== 'object') return '';
+  const record = project as Record<string, unknown>;
+  for (const key of ['worktree', 'directory', 'path', 'root']) {
+    const value = normalizeProjectDirectoryForCompare(record[key]);
+    if (value) return value;
+  }
+  return '';
+};
+
+const getProjectID = (project: unknown): string => {
+  if (!project || typeof project !== 'object') return '';
+  const id = (project as { id?: unknown }).id;
+  return typeof id === 'string' ? id.trim() : '';
+};
+
+const getProjectStartCommand = (project: unknown): unknown => {
+  if (!project || typeof project !== 'object') return '';
+  const commands = (project as { commands?: unknown }).commands;
+  if (!commands || typeof commands !== 'object') return '';
+  return (commands as { start?: unknown }).start;
+};
+
+const hasProjectID = (project: unknown, projectID: string): boolean => {
+  const id = getProjectID(project);
+  return Boolean(id && id === projectID);
+};
+
+const hasProjectDirectory = (project: unknown, primaryWorktree: string): boolean => {
+  const projectDirectory = getProjectDirectory(project);
+  return Boolean(projectDirectory && projectDirectory === normalizeProjectDirectoryForCompare(primaryWorktree));
+};
+
+const findListedProject = (projects: unknown[], projectID: string, primaryWorktree: string): unknown | null => {
+  return projects.find((project) => hasProjectID(project, projectID))
+    || projects.find((project) => hasProjectDirectory(project, primaryWorktree))
+    || null;
+};
+
+const combineAbortSignals = (existingSignal: AbortSignal | undefined, timeoutSignal: AbortSignal): AbortSignal => {
+  if (!existingSignal) return timeoutSignal;
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([existingSignal, timeoutSignal]);
+  }
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (existingSignal.aborted || timeoutSignal.aborted) {
+    abort();
+    return controller.signal;
+  }
+  existingSignal.addEventListener('abort', abort, { once: true });
+  timeoutSignal.addEventListener('abort', abort, { once: true });
+  return controller.signal;
+};
+
+const getRequestSignal = (request: Parameters<typeof fetch>[0]): AbortSignal | undefined => {
+  return request instanceof Request ? request.signal : undefined;
+};
+
+export const createOpenCodeProjectCommandRuntime = (
+  dependencies: ProjectCommandRuntimeDependencies = {},
+): ProjectCommandRuntime => {
+  const loadStartCommand = async (projectID: string, primaryWorktree: string): Promise<ProjectCommandResult> => {
+    const apiUrl = dependencies.getApiUrl?.();
+    if (!apiUrl) {
+      return unavailableProjectCommandResult();
+    }
+
+    try {
+      const client = (dependencies.createClient ?? createOpencodeClient)({
+        baseUrl: apiUrl.replace(/\/$/, ''),
+        directory: primaryWorktree || undefined,
+        headers: dependencies.getOpenCodeAuthHeaders?.() || {},
+        fetch: (request) => globalThis.fetch(request, {
+          signal: combineAbortSignals(
+            getRequestSignal(request),
+            AbortSignal.timeout(OPENCODE_PROJECT_COMMAND_TIMEOUT_MS),
+          ),
+        }),
+      });
+
+      const currentResponse = await client.project.current({ directory: primaryWorktree });
+      const currentProject = currentResponse?.data;
+      if (currentProject && (hasProjectID(currentProject, projectID) || hasProjectDirectory(currentProject, primaryWorktree))) {
+        return availableProjectCommandResult(getProjectStartCommand(currentProject));
+      }
+
+      const listResponse = await client.project.list({ directory: primaryWorktree });
+      const projects = Array.isArray(listResponse?.data) ? listResponse.data : [];
+      const matchedProject = findListedProject(projects, projectID, primaryWorktree);
+      if (matchedProject) {
+        return availableProjectCommandResult(getProjectStartCommand(matchedProject));
+      }
+    } catch {
+      return unavailableProjectCommandResult();
+    }
+
+    return unavailableProjectCommandResult();
+  };
+
+  return { loadStartCommand };
+};

--- a/packages/web/server/lib/git/DOCUMENTATION.md
+++ b/packages/web/server/lib/git/DOCUMENTATION.md
@@ -46,7 +46,7 @@ The following functions are exported and used by the web server:
 ### Worktree Operations
 - `getWorktrees(directory)`: List all git worktrees for a repository.
 - `validateWorktreeCreate(directory, input)`: Validate worktree creation parameters (mode, branchName, startRef, upstream config).
-- `createWorktree(directory, input)`: Create a new worktree (supports 'new' and 'existing' modes, upstream setup).
+- `createWorktree(directory, input, runtime?)`: Create a new worktree (supports 'new' and 'existing' modes, upstream setup). `runtime.projectCommandRuntime` may provide an authoritative OpenCode project `commands.start` loader for bootstrap setup.
 - `removeWorktree(directory, input)`: Remove a worktree (optionally delete local branch).
 - `isLinkedWorktree(directory)`: Check if directory is a linked worktree (not primary).
 
@@ -124,6 +124,7 @@ The following functions are internal helpers used by exported functions:
 - Fast-create background failures remove OpenCode sandbox metadata for directories that never became Git worktrees, and remove the pre-created directory only if it is still empty. User-created files are never recursively deleted by this cleanup.
 - Worktree removal waits for any active create/bootstrap task for that directory before deleting it, preventing a background Git or setup task from restoring removed state or racing filesystem cleanup.
 - Worktree bootstrap retries transient `index.lock` conflicts. If the lock remains byte-for-byte and metadata-identical across the retry window, it is treated as stale, removed, and population continues automatically; changing locks are left untouched and reported as failures.
+- Worktree bootstrap runs the authoritative OpenCode project `commands.start` before any request `startCommand` when the injected runtime matches the project by exact ID or normalized worktree. An authoritative empty command suppresses legacy fallback. If the API is unavailable, errors, or does not match the project, bootstrap falls back to the legacy project JSON command for compatibility.
 
 ### Log Response
 - `all`: Array of commit objects with hash, date, message, author info, stats.

--- a/packages/web/server/lib/git/routes.js
+++ b/packages/web/server/lib/git/routes.js
@@ -1,4 +1,5 @@
-export function registerGitRoutes(app) {
+export function registerGitRoutes(app, dependencies = {}) {
+  const { projectCommandRuntime } = dependencies;
   let gitLibraries = null;
   const getGitLibraries = async () => {
     if (!gitLibraries) {
@@ -1011,7 +1012,7 @@ export function registerGitRoutes(app) {
         return res.status(400).json({ error: 'directory parameter is required' });
       }
 
-      const created = await createWorktree(directory, req.body || {});
+      const created = await createWorktree(directory, req.body || {}, { projectCommandRuntime });
       res.json(created);
     } catch (error) {
       console.error('Failed to create worktree:', error);

--- a/packages/web/server/lib/git/routes.test.js
+++ b/packages/web/server/lib/git/routes.test.js
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const gitLibraries = {
   stageFiles: vi.fn(),
   unstageFiles: vi.fn(),
+  createWorktree: vi.fn(),
 };
 
 vi.mock('./index.js', () => ({
   stageFiles: gitLibraries.stageFiles,
   unstageFiles: gitLibraries.unstageFiles,
+  createWorktree: gitLibraries.createWorktree,
 }));
 
 const { registerGitRoutes } = await import('./routes.js');
@@ -62,6 +64,7 @@ describe('git routes index mutations', () => {
   beforeEach(() => {
     gitLibraries.stageFiles.mockReset();
     gitLibraries.unstageFiles.mockReset();
+    gitLibraries.createWorktree.mockReset();
   });
 
   it('accepts legacy stage path payloads', async () => {
@@ -133,5 +136,23 @@ describe('git routes index mutations', () => {
     expect(response.statusCode).toBe(400);
     expect(response.body).toEqual({ error: 'path parameter is required' });
     expect(gitLibraries.stageFiles).not.toHaveBeenCalled();
+  });
+
+  it('forwards the injected OpenCode project command runtime to worktree creation', async () => {
+    const { app, getRoute } = createRouteRegistry();
+    const projectCommandRuntime = { loadStartCommand: vi.fn() };
+    gitLibraries.createWorktree.mockResolvedValue({ path: '/repo/worktree' });
+
+    registerGitRoutes(app, { projectCommandRuntime });
+    const response = createMockResponse();
+
+    await getRoute('POST', '/api/git/worktrees')(
+      { query: { directory: '/repo' }, body: { mode: 'new' } },
+      response,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ path: '/repo/worktree' });
+    expect(gitLibraries.createWorktree).toHaveBeenCalledWith('/repo', { mode: 'new' }, { projectCommandRuntime });
   });
 });

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -1597,7 +1597,7 @@ const runWorktreeStartCommand = async (directory, command) => {
   return result;
 };
 
-const loadProjectStartCommand = async (projectID) => {
+const loadLegacyProjectStartCommand = async (projectID) => {
   const storagePath = path.join(getOpenCodeDataPath(), 'storage', 'project', `${projectID}.json`);
   try {
     const raw = await fsp.readFile(storagePath, 'utf8');
@@ -1607,6 +1607,17 @@ const loadProjectStartCommand = async (projectID) => {
   } catch {
     return '';
   }
+};
+
+const loadProjectStartCommand = async (projectID, primaryWorktree, runtime) => {
+  if (typeof runtime?.loadStartCommand === 'function') {
+    const result = await runtime.loadStartCommand(projectID, primaryWorktree);
+    if (result?.available === true) {
+      return typeof result.command === 'string' ? result.command.trim() : '';
+    }
+  }
+
+  return loadLegacyProjectStartCommand(projectID);
 };
 
 const getProjectStoragePath = (projectID) => {
@@ -1737,8 +1748,8 @@ const cleanupFailedFastWorktreeCreate = async (context, candidate) => {
   }
 };
 
-const runWorktreeStartScripts = async (directory, projectID, startCommand) => {
-  const projectStart = await loadProjectStartCommand(projectID);
+const runWorktreeStartScripts = async (directory, projectID, primaryWorktree, startCommand, runtime) => {
+  const projectStart = await loadProjectStartCommand(projectID, primaryWorktree, runtime);
   if (projectStart) {
     const projectResult = await runWorktreeStartCommand(directory, projectStart);
     if (!projectResult.success) {
@@ -1769,6 +1780,7 @@ const queueWorktreeBootstrap = (args) => {
     ensureRemoteName,
     ensureRemoteUrl,
     startCommand,
+    projectCommandRuntime,
   } = args;
   const task = new Promise((resolve) => setTimeout(resolve, 0))
     .then(async () => {
@@ -1792,7 +1804,7 @@ const queueWorktreeBootstrap = (args) => {
         WORKTREE_BOOTSTRAP_PENDING,
         WORKTREE_BOOTSTRAP_PHASE_GIT_READY
       );
-      await runWorktreeStartScripts(directory, projectID, startCommand).catch((error) => {
+      await runWorktreeStartScripts(directory, projectID, primaryWorktree, startCommand, projectCommandRuntime).catch((error) => {
         console.warn('Worktree start script task failed:', error instanceof Error ? error.message : String(error));
       });
       setWorktreeBootstrapState(
@@ -3715,7 +3727,7 @@ export async function previewWorktreeCreate(directory, input = {}) {
   };
 }
 
-async function attachGitWorktreeToCandidate(context, candidate, input = {}) {
+async function attachGitWorktreeToCandidate(context, candidate, input = {}, runtime = {}) {
   const mode = input?.mode === 'existing' ? 'existing' : 'new';
   const preferredBranchName = cleanBranchName(String(input?.branchName || '').trim());
   const startRef = normalizeStartRef(input?.startRef);
@@ -3823,6 +3835,7 @@ async function attachGitWorktreeToCandidate(context, candidate, input = {}) {
     ensureRemoteName,
     ensureRemoteUrl,
     startCommand: input?.startCommand,
+    projectCommandRuntime: runtime.projectCommandRuntime,
   });
 
   const headResult = await runGitCommand(candidate.directory, ['rev-parse', 'HEAD']);
@@ -3838,7 +3851,7 @@ async function attachGitWorktreeToCandidate(context, candidate, input = {}) {
   };
 }
 
-export async function createWorktree(directory, input = {}) {
+export async function createWorktree(directory, input = {}, runtime = {}) {
   const mode = input?.mode === 'existing' ? 'existing' : 'new';
   const context = await resolveWorktreeProjectContext(directory);
 
@@ -3876,7 +3889,7 @@ export async function createWorktree(directory, input = {}) {
       ? cleanBranchName(String(input?.branchName || input?.existingBranch || candidate.branch || '').trim())
       : candidate.branch;
 
-    const task = attachGitWorktreeToCandidate(context, candidate, input).catch(async (error) => {
+    const task = attachGitWorktreeToCandidate(context, candidate, input, runtime).catch(async (error) => {
       setWorktreeBootstrapState(
         candidate.directory,
         WORKTREE_BOOTSTRAP_FAILED,
@@ -3898,7 +3911,7 @@ export async function createWorktree(directory, input = {}) {
     };
   }
 
-  return attachGitWorktreeToCandidate(context, candidate, input);
+  return attachGitWorktreeToCandidate(context, candidate, input, runtime);
 }
 
 export async function getWorktreeBootstrapStatus(directory) {

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -514,6 +514,177 @@ describe('createWorktree', () => {
       }
     }
   });
+
+  it('runs authoritative project command before the extra start command', async () => {
+    if (!canRunGit()) return;
+
+    const previousXdgDataHome = process.env.XDG_DATA_HOME;
+    const dataHome = createTempDir();
+    const orderFile = path.join(dataHome, 'start-order.txt');
+    const projectScript = path.join(dataHome, 'project-start.cjs');
+    const extraScript = path.join(dataHome, 'extra-start.cjs');
+    process.env.XDG_DATA_HOME = dataHome;
+
+    fs.writeFileSync(
+      projectScript,
+      `require('node:fs').appendFileSync(${JSON.stringify(orderFile)}, 'project\\n');\n`,
+    );
+    fs.writeFileSync(
+      extraScript,
+      `require('node:fs').appendFileSync(${JSON.stringify(orderFile)}, 'extra\\n');\n`,
+    );
+
+    try {
+      const repo = createTempDir();
+      runGit(repo, ['init', '-b', 'main']);
+      runGit(repo, ['config', 'user.email', 'test@example.com']);
+      runGit(repo, ['config', 'user.name', 'Test User']);
+      fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+      runGit(repo, ['add', 'README.md']);
+      runGit(repo, ['commit', '-m', 'Initial commit']);
+      const projectID = runGit(repo, ['rev-list', '--max-parents=0', '--all']).trim();
+      const loaderCalls = [];
+
+      const created = await createWorktree(repo, {
+        mode: 'new',
+        branchName: 'feature/api-project-start',
+        worktreeName: 'api-project-start',
+        returnAfterDirectoryCreated: true,
+        startCommand: `${JSON.stringify(process.execPath)} ${JSON.stringify(extraScript)}`,
+      }, {
+        projectCommandRuntime: {
+          loadStartCommand: async (...args) => {
+            loaderCalls.push(args);
+            return {
+              available: true,
+              command: `${JSON.stringify(process.execPath)} ${JSON.stringify(projectScript)}`,
+            };
+          },
+        },
+      });
+
+      await expect.poll(
+        async () => fs.existsSync(orderFile) ? fs.readFileSync(orderFile, 'utf8') : '',
+        { timeout: 5_000 },
+      ).toBe('project\nextra\n');
+      await expect(getWorktreeBootstrapStatus(created.path)).resolves.toMatchObject({
+        status: 'ready',
+        phase: 'setup-ready',
+      });
+      expect(loaderCalls[0]).toEqual([projectID, fs.realpathSync(repo)]);
+    } finally {
+      if (previousXdgDataHome === undefined) {
+        delete process.env.XDG_DATA_HOME;
+      } else {
+        process.env.XDG_DATA_HOME = previousXdgDataHome;
+      }
+    }
+  });
+
+  it('does not fall back to legacy JSON when the API authoritatively returns an empty start command', async () => {
+    if (!canRunGit()) return;
+
+    const previousXdgDataHome = process.env.XDG_DATA_HOME;
+    const dataHome = createTempDir();
+    const marker = path.join(dataHome, 'legacy-started');
+    const legacyScript = path.join(dataHome, 'legacy-start.cjs');
+    process.env.XDG_DATA_HOME = dataHome;
+
+    fs.writeFileSync(
+      legacyScript,
+      `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'started');\n`,
+    );
+
+    try {
+      const repo = createTempDir();
+      runGit(repo, ['init', '-b', 'main']);
+      runGit(repo, ['config', 'user.email', 'test@example.com']);
+      runGit(repo, ['config', 'user.name', 'Test User']);
+      fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+      runGit(repo, ['add', 'README.md']);
+      runGit(repo, ['commit', '-m', 'Initial commit']);
+      const projectID = runGit(repo, ['rev-list', '--max-parents=0', '--all']).trim();
+      const storagePath = path.join(dataHome, 'opencode', 'storage', 'project', `${projectID}.json`);
+      fs.mkdirSync(path.dirname(storagePath), { recursive: true });
+      fs.writeFileSync(storagePath, JSON.stringify({ commands: { start: `${JSON.stringify(process.execPath)} ${JSON.stringify(legacyScript)}` } }));
+      const loaderCalls = [];
+
+      const created = await createWorktree(repo, {
+        mode: 'new',
+        branchName: 'feature/empty-project-start',
+        worktreeName: 'empty-project-start',
+        returnAfterDirectoryCreated: true,
+      }, {
+        projectCommandRuntime: {
+          loadStartCommand: async (...args) => {
+            loaderCalls.push(args);
+            return { available: true, command: '' };
+          },
+        },
+      });
+
+      await expect.poll(
+        async () => (await getWorktreeBootstrapStatus(created.path)).phase,
+        { timeout: 5_000 },
+      ).toBe('setup-ready');
+      expect(fs.existsSync(marker)).toBe(false);
+      expect(loaderCalls[0]).toEqual([projectID, fs.realpathSync(repo)]);
+    } finally {
+      if (previousXdgDataHome === undefined) {
+        delete process.env.XDG_DATA_HOME;
+      } else {
+        process.env.XDG_DATA_HOME = previousXdgDataHome;
+      }
+    }
+  });
+
+  it('falls back to legacy JSON when the API is unavailable', async () => {
+    if (!canRunGit()) return;
+
+    const previousXdgDataHome = process.env.XDG_DATA_HOME;
+    const dataHome = createTempDir();
+    const marker = path.join(dataHome, 'legacy-fallback-started');
+    const legacyScript = path.join(dataHome, 'legacy-fallback.cjs');
+    process.env.XDG_DATA_HOME = dataHome;
+
+    fs.writeFileSync(
+      legacyScript,
+      `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'started');\n`,
+    );
+
+    try {
+      const repo = createTempDir();
+      runGit(repo, ['init', '-b', 'main']);
+      runGit(repo, ['config', 'user.email', 'test@example.com']);
+      runGit(repo, ['config', 'user.name', 'Test User']);
+      fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+      runGit(repo, ['add', 'README.md']);
+      runGit(repo, ['commit', '-m', 'Initial commit']);
+      const projectID = runGit(repo, ['rev-list', '--max-parents=0', '--all']).trim();
+      const storagePath = path.join(dataHome, 'opencode', 'storage', 'project', `${projectID}.json`);
+      fs.mkdirSync(path.dirname(storagePath), { recursive: true });
+      fs.writeFileSync(storagePath, JSON.stringify({ commands: { start: `${JSON.stringify(process.execPath)} ${JSON.stringify(legacyScript)}` } }));
+
+      await createWorktree(repo, {
+        mode: 'new',
+        branchName: 'feature/legacy-fallback',
+        worktreeName: 'legacy-fallback',
+        returnAfterDirectoryCreated: true,
+      }, {
+        projectCommandRuntime: {
+          loadStartCommand: async () => ({ available: false, command: '' }),
+        },
+      });
+
+      await expect.poll(() => fs.existsSync(marker), { timeout: 5_000 }).toBe(true);
+    } finally {
+      if (previousXdgDataHome === undefined) {
+        delete process.env.XDG_DATA_HOME;
+      } else {
+        process.env.XDG_DATA_HOME = previousXdgDataHome;
+      }
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -17,6 +17,7 @@ This module provides OpenCode server integration utilities for the web server ru
 - `packages/web/server/lib/opencode/bootstrap-runtime.js`: base app bootstrap runtime for status/auth/tts/notification/OpenChamber route wiring.
 - `packages/web/server/lib/opencode/network-runtime.js`: OpenCode URL construction, health-probe readiness checks, and API prefix runtime.
 - `packages/web/server/lib/opencode/project-directory-runtime.js`: request-scoped and settings-backed project directory resolution/validation runtime.
+- `packages/web/server/lib/opencode/project-commands-runtime.js`: authoritative OpenCode project startup-command lookup for worktree bootstrap.
 - `packages/web/server/lib/opencode/config-entity-routes.js`: route registration for agent/command/MCP config orchestration and reload semantics.
 - `packages/web/server/lib/opencode/snippets.js`: opencode-snippets-compatible snippet file CRUD, discovery, and hashtag expansion.
 - `packages/web/server/lib/opencode/cli-options.js`: CLI/environment option parsing for server startup arguments.
@@ -291,6 +292,9 @@ This module provides OpenCode server integration utilities for the web server ru
 - `createFeatureRoutesRuntime(dependencies)`: creates runtime for main feature route registration orchestration.
 - Returned API:
   - `registerRoutes(app, routeDependencies)`
+
+## Public exports (project-commands-runtime.js)
+- `createOpenCodeProjectCommandRuntime(dependencies)`: creates an API-backed project startup-command loader that distinguishes authoritative empty commands from unavailable project data.
 
 ## Public exports (opencode-resolution-runtime.js)
 - `createOpenCodeResolutionRuntime(dependencies)`: creates runtime for OpenCode binary/source snapshot resolution.

--- a/packages/web/server/lib/opencode/feature-routes-runtime.js
+++ b/packages/web/server/lib/opencode/feature-routes-runtime.js
@@ -14,6 +14,7 @@ import { registerScheduledTaskRoutes } from '../scheduled-tasks/routes.js';
 import { registerSkillRoutes } from './skill-routes.js';
 import { registerPluginRoutes } from './plugin-routes.js';
 import { getNpmInfo, clearCache as clearNpmCache } from './npm-registry.js';
+import { createOpenCodeProjectCommandRuntime } from './project-commands-runtime.js';
 import { parseNpmSpec, parsePathSpec, isExactSemver } from './plugin-spec.js';
 import { registerOpenCodeRoutes } from './routes.js';
 import { getProviderSources, removeProviderConfig } from './providers.js';
@@ -243,7 +244,12 @@ export const createFeatureRoutesRuntime = (dependencies) => {
     registerSmallModelRoutes(app, { getSmallModelService });
     registerSessionGoalRoutes(app);
     registerGitHubRoutes(app);
-    registerGitRoutes(app);
+    const projectCommandRuntime = createOpenCodeProjectCommandRuntime({
+      buildOpenCodeUrl,
+      getOpenCodeAuthHeaders,
+      getOpenCodePort,
+    });
+    registerGitRoutes(app, { projectCommandRuntime });
     registerMagicPromptRoutes(app, {
       fsPromises,
       path,

--- a/packages/web/server/lib/opencode/project-commands-runtime.js
+++ b/packages/web/server/lib/opencode/project-commands-runtime.js
@@ -1,0 +1,116 @@
+import path from 'node:path';
+import { createOpencodeClient } from '@opencode-ai/sdk/v2';
+
+const OPENCODE_PROJECT_COMMAND_TIMEOUT_MS = 8_000;
+
+const unavailableProjectCommandResult = () => ({ available: false, command: '' });
+const availableProjectCommandResult = (command) => ({
+  available: true,
+  command: typeof command === 'string' ? command.trim() : '',
+});
+
+const normalizeProjectDirectoryForCompare = (value) => {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text ? path.resolve(text) : '';
+};
+
+const getProjectDirectory = (project) => {
+  for (const key of ['worktree', 'directory', 'path', 'root']) {
+    const value = normalizeProjectDirectoryForCompare(project?.[key]);
+    if (value) return value;
+  }
+  return '';
+};
+
+const extractProjectStartCommand = (project) => {
+  const command = project?.commands?.start;
+  return typeof command === 'string' ? command : '';
+};
+
+const hasProjectID = (project, projectID) => {
+  const id = typeof project?.id === 'string' ? project.id.trim() : '';
+  return Boolean(id && id === projectID);
+};
+
+const hasProjectDirectory = (project, primaryWorktree) => {
+  const projectDirectory = getProjectDirectory(project);
+  return Boolean(projectDirectory && projectDirectory === normalizeProjectDirectoryForCompare(primaryWorktree));
+};
+
+const findListedProject = (projects, projectID, primaryWorktree) => {
+  return projects.find((project) => hasProjectID(project, projectID))
+    || projects.find((project) => hasProjectDirectory(project, primaryWorktree))
+    || null;
+};
+
+const combineAbortSignals = (existingSignal, timeoutSignal) => {
+  if (!existingSignal) return timeoutSignal;
+  if (!timeoutSignal) return existingSignal;
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([existingSignal, timeoutSignal]);
+  }
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (existingSignal.aborted || timeoutSignal.aborted) {
+    abort();
+    return controller.signal;
+  }
+  existingSignal.addEventListener('abort', abort, { once: true });
+  timeoutSignal.addEventListener('abort', abort, { once: true });
+  return controller.signal;
+};
+
+const getRequestSignal = (request) => {
+  return request instanceof Request ? request.signal : undefined;
+};
+
+export const createOpenCodeProjectCommandRuntime = (dependencies = {}) => {
+  const {
+    buildOpenCodeUrl,
+    getOpenCodeAuthHeaders,
+    getOpenCodePort,
+  } = dependencies;
+
+  const loadStartCommand = async (projectID, primaryWorktree) => {
+    if (typeof getOpenCodePort === 'function' && !getOpenCodePort()) {
+      return unavailableProjectCommandResult();
+    }
+    if (typeof buildOpenCodeUrl !== 'function' || typeof getOpenCodeAuthHeaders !== 'function') {
+      return unavailableProjectCommandResult();
+    }
+
+    try {
+      const client = createOpencodeClient({
+        baseUrl: buildOpenCodeUrl('/', '').replace(/\/$/, ''),
+        directory: primaryWorktree || undefined,
+        headers: getOpenCodeAuthHeaders(),
+        fetch: (request) => globalThis.fetch(request, {
+          signal: combineAbortSignals(
+            getRequestSignal(request),
+            AbortSignal.timeout(OPENCODE_PROJECT_COMMAND_TIMEOUT_MS),
+          ),
+        }),
+      });
+
+      const currentResponse = await client.project.current({ directory: primaryWorktree });
+      const currentProject = currentResponse?.data;
+      if (currentProject && (hasProjectID(currentProject, projectID) || hasProjectDirectory(currentProject, primaryWorktree))) {
+        return availableProjectCommandResult(extractProjectStartCommand(currentProject));
+      }
+
+      const listResponse = await client.project.list({ directory: primaryWorktree });
+      const projects = Array.isArray(listResponse?.data) ? listResponse.data : [];
+      const matchedProject = findListedProject(projects, projectID, primaryWorktree);
+      if (matchedProject) {
+        return availableProjectCommandResult(extractProjectStartCommand(matchedProject));
+      }
+    } catch {
+      return unavailableProjectCommandResult();
+    }
+
+    return unavailableProjectCommandResult();
+  };
+
+  return { loadStartCommand };
+};

--- a/packages/web/server/lib/opencode/project-commands-runtime.test.js
+++ b/packages/web/server/lib/opencode/project-commands-runtime.test.js
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sdkMocks = vi.hoisted(() => ({
+  createOpencodeClient: vi.fn(),
+}));
+
+vi.mock('@opencode-ai/sdk/v2', () => ({
+  createOpencodeClient: sdkMocks.createOpencodeClient,
+}));
+
+const { createOpenCodeProjectCommandRuntime } = await import('./project-commands-runtime.js');
+
+describe('createOpenCodeProjectCommandRuntime', () => {
+  beforeEach(() => {
+    sdkMocks.createOpencodeClient.mockReset();
+  });
+
+  const createRuntime = (overrides = {}) => createOpenCodeProjectCommandRuntime({
+    buildOpenCodeUrl: (requestPath, prefix) => `http://127.0.0.1:4096${prefix ?? ''}${requestPath}`,
+    getOpenCodeAuthHeaders: () => ({ Authorization: 'Bearer test-token' }),
+    getOpenCodePort: () => 4096,
+    ...overrides,
+  });
+
+  it('loads commands.start from the authoritative current project API by ID', async () => {
+    const project = {
+      current: vi.fn().mockResolvedValue({ data: { id: 'project-a', commands: { start: ' bun dev ' } } }),
+      list: vi.fn(),
+    };
+    sdkMocks.createOpencodeClient.mockReturnValue({ project });
+
+    await expect(createRuntime().loadStartCommand('project-a', '/repo')).resolves.toEqual({
+      available: true,
+      command: 'bun dev',
+    });
+    expect(project.current).toHaveBeenCalledWith({ directory: '/repo' });
+    expect(project.list).not.toHaveBeenCalled();
+  });
+
+  it('returns authoritative empty commands without marking the API unavailable', async () => {
+    sdkMocks.createOpencodeClient.mockReturnValue({
+      project: {
+        current: vi.fn().mockResolvedValue({ data: { worktree: '/repo', commands: { start: '   ' } } }),
+        list: vi.fn(),
+      },
+    });
+
+    await expect(createRuntime().loadStartCommand('project-a', '/repo')).resolves.toEqual({
+      available: true,
+      command: '',
+    });
+  });
+
+  it('falls back from a current project without usable identity or directory to project.list', async () => {
+    const project = {
+      current: vi.fn().mockResolvedValue({ data: { commands: { start: 'wrong' } } }),
+      list: vi.fn().mockResolvedValue({
+        data: [
+          { id: 'other', worktree: '/other', commands: { start: 'wrong' } },
+          { id: 'project-a', commands: { start: 'bun start' } },
+        ],
+      }),
+    };
+    sdkMocks.createOpencodeClient.mockReturnValue({ project });
+
+    await expect(createRuntime().loadStartCommand('project-a', '/repo')).resolves.toEqual({
+      available: true,
+      command: 'bun start',
+    });
+    expect(project.list).toHaveBeenCalledWith({ directory: '/repo' });
+  });
+
+  it('prefers exact ID over exact worktree in project.list', async () => {
+    sdkMocks.createOpencodeClient.mockReturnValue({
+      project: {
+        current: vi.fn().mockResolvedValue({ data: { id: 'other', worktree: '/other' } }),
+        list: vi.fn().mockResolvedValue({
+          data: [
+            { id: 'other', worktree: '/repo', commands: { start: 'by worktree' } },
+            { id: 'project-a', worktree: '/other', commands: { start: 'by id' } },
+          ],
+        }),
+      },
+    });
+
+    await expect(createRuntime().loadStartCommand('project-a', '/repo')).resolves.toEqual({
+      available: true,
+      command: 'by id',
+    });
+  });
+
+  it('reports unavailable for disabled, throwing, or unmatched API lookups', async () => {
+    await expect(createRuntime({ getOpenCodePort: () => null }).loadStartCommand('project-a', '/repo')).resolves.toEqual({
+      available: false,
+      command: '',
+    });
+    expect(sdkMocks.createOpencodeClient).not.toHaveBeenCalled();
+
+    sdkMocks.createOpencodeClient.mockReturnValueOnce({
+      project: {
+        current: vi.fn().mockRejectedValue(new Error('network down')),
+        list: vi.fn(),
+      },
+    });
+    await expect(createRuntime().loadStartCommand('project-a', '/repo')).resolves.toEqual({
+      available: false,
+      command: '',
+    });
+
+    sdkMocks.createOpencodeClient.mockReturnValueOnce({
+      project: {
+        current: vi.fn().mockResolvedValue({ data: { id: 'other', worktree: '/other' } }),
+        list: vi.fn().mockResolvedValue({ data: [{ id: 'elsewhere' }] }),
+      },
+    });
+    await expect(createRuntime().loadStartCommand('project-a', '/repo')).resolves.toEqual({
+      available: false,
+      command: '',
+    });
+  });
+
+  it('creates a fresh SDK client with current URL, auth headers, directory, and timeout fetch', async () => {
+    const headers = { Authorization: 'Bearer secret-test-token' };
+    const buildOpenCodeUrl = vi.fn(() => 'http://127.0.0.1:4096/');
+    const getOpenCodeAuthHeaders = vi.fn(() => headers);
+    sdkMocks.createOpencodeClient.mockReturnValue({
+      project: {
+        current: vi.fn().mockResolvedValue({ data: { id: 'project-a', commands: { start: 'bun dev' } } }),
+        list: vi.fn(),
+      },
+    });
+
+    await createRuntime({ buildOpenCodeUrl, getOpenCodeAuthHeaders }).loadStartCommand('project-a', '/repo');
+
+    expect(buildOpenCodeUrl).toHaveBeenCalledWith('/', '');
+    expect(getOpenCodeAuthHeaders).toHaveBeenCalledTimes(1);
+    expect(sdkMocks.createOpencodeClient).toHaveBeenCalledTimes(1);
+    const options = sdkMocks.createOpencodeClient.mock.calls[0][0];
+    expect(options).toMatchObject({
+      baseUrl: 'http://127.0.0.1:4096',
+      directory: '/repo',
+      headers,
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}'));
+    try {
+      const controller = new AbortController();
+      const request = new Request('http://127.0.0.1:4096/project', { signal: controller.signal });
+      await options.fetch(request);
+      const fetchSignal = fetchSpy.mock.calls[0][1].signal;
+      expect(fetchSpy).toHaveBeenCalledWith(request, { signal: fetchSignal });
+      expect(fetchSignal).toBeInstanceOf(AbortSignal);
+      expect(fetchSignal).not.toBe(controller.signal);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- load `commands.start` from the current OpenCode project API instead of relying on the legacy project JSON mirror
- use the same lookup and fallback behavior in the web/desktop and VS Code worktree paths
- keep legacy JSON support when the API is unavailable or cannot match the project, while treating an explicitly empty command as authoritative

OpenCode 1.18.3 stores project commands in SQLite, so OpenChamber's legacy JSON lookup no longer sees them. This change keeps worktree creation in OpenChamber but gets the project command through the supported SDK API.

The project command still runs before a request-specific `startCommand`.

Fixes #2323

## Testing

- `bun run --cwd packages/web test` (731 passed, 1 skipped)
- `bun test packages/vscode/src/project-commands-runtime.test.js packages/vscode/src/bridge-git-runtime.test.js packages/vscode/src/gitService.worktree-bootstrap.test.js` (18 passed)
- `bun run type-check`
- `bun run lint`
- `bun run build`
- `bun run docs:validate`
- end-to-end web driver with a real Git worktree and fake OpenCode SDK server; verified authenticated `/project/current` lookup and `project\nextra\n` execution order

### Existing test isolation issue

`bun test packages/vscode/src` still exposes the existing Bun cross-file module-mock collision between `bridge-git-runtime.test.js` and `bridge-git-special-runtime.test.js`. The affected test passes in isolation, the conflicting mock predates this change, and all patch-owned VS Code tests pass together.