### PR TITLE
fix(discord): unify header buttons and hide when disconnected

### DIFF
--- a/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
@@ -1450,24 +1450,31 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
           <div data-settings-item="integrations.discord.commands">
             <DiscordCommandsButton />
           </div>
-          <button
-            type="button"
-            onClick={() => testConnection(conn.type)}
-            disabled={!token || conn.status === 'connecting'}
-            className="rounded px-2 py-1 text-[10px] font-medium text-primary bg-primary/10 hover:bg-primary/20 disabled:opacity-50"
-            title="Verify the bot token by calling the messenger API"
-          >
-            {conn.status === 'connecting' ? 'Testing…' : 'Verify token'}
-          </button>
-          <Button
-            type="button"
-            variant="destructive"
-            size="xs"
-            className="!font-normal"
-            onClick={() => setDisconnectConfirmOpen(true)}
-          >
-            {t('settings.integrations.discord.disconnect.button')}
-          </Button>
+          {conn.status !== 'disconnected' && (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                className="!font-normal"
+                onClick={() => testConnection(conn.type)}
+                disabled={!token || conn.status === 'connecting'}
+              >
+                {conn.status === 'connecting'
+                  ? t('settings.integrations.discord.wizard.step1.verifying')
+                  : t('settings.integrations.discord.wizard.step1.verify')}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                className="!font-normal text-[var(--status-error)] hover:text-[var(--status-error)]"
+                onClick={() => setDisconnectConfirmOpen(true)}
+              >
+                {t('settings.integrations.discord.disconnect.button')}
+              </Button>
+            </>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Align Discord header actions (**Discord commands**, **Verify token**, **Disconnect**) on the shared `Button` `outline` / `xs` style.
- Hide **Verify token** and **Disconnect** when connection status is `disconnected`; **Discord commands** stays visible.
- Reuse existing i18n keys for verify/verifying labels (no hardcoded English).

## Test plan
- [ ] Open Settings → Integrations → Discord while disconnected: only **Discord commands** shows in the header.
- [ ] Connect / verify successfully: all three buttons appear with matching outline size/style; Disconnect keeps error text color.
- [ ] While verifying (`connecting`), Verify is disabled and shows verifying label.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e1716ad-c4d9-43c2-a058-f705498cbd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e1716ad-c4d9-43c2-a058-f705498cbd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

