### PR TITLE
fix(terminal): auto-focus hidden input overlay on mobile web

### DIFF
--- a/packages/ui/src/components/views/TerminalView.tsx
+++ b/packages/ui/src/components/views/TerminalView.tsx
@@ -1140,7 +1140,7 @@ export const TerminalView: React.FC<TerminalViewProps> = ({ visible }) => {
                             fontFamily={resolvedFontStack}
                             fontSize={terminalFontSize}
                             enableTouchScroll={useTouchTerminalInput}
-                            autoFocus={!useTouchTerminalInput && isTerminalVisible}
+                            autoFocus={isTerminalVisible}
                             isVisible={isTerminalVisible}
                         />
                     ) : null}


### PR DESCRIPTION
## Summary

Fixes #2319 — the terminal could not accept keyboard input on mobile web/PWA.

## Root cause

On mobile web, `useTouchTerminalInput` is `true`, which gated the `autoFocus` prop passed to `<TerminalViewport>` behind `!useTouchTerminalInput`. This caused `autoFocus` to be `false` on mobile, so the `autoFocus` effect in TerminalViewport.tsx (line 215) never ran and Ghostty's terminal was never focused when the terminal became visible.

## Fix

Remove the `!useTouchTerminalInput` condition from the `autoFocus` prop so that Ghostty's native `terminal.focus()` is called via the `autoFocus` effect when the terminal becomes visible on mobile, just as it already does on desktop.

**Changed:** `packages/ui/src/components/views/TerminalView.tsx` (1 line)

## Verification

- Desktop behavior is unchanged (there `useTouchTerminalInput` was already `false`, so `!useTouchTerminalInput \u0026\u0026 isTerminalVisible` was equivalent to `isTerminalVisible`).
- Manual mobile verification recommended: confirm that the virtual keyboard appears reliably when the terminal panel opens on mobile web/PWA.
