### PR TITLE
fix(discord): show correct connection status after server rebuild

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -16,6 +16,7 @@ import { usePushVisibilityBeacon } from '@/hooks/usePushVisibilityBeacon';
 import { useOpenChamberAgentWebSocket } from '@/hooks/useOpenChamberAgentWebSocket';
 import { useMessengerBridgeToasts } from '@/hooks/useMessengerBridgeToasts';
 import { useMessengerProjectChannelSync } from '@/hooks/useMessengerProjectChannelSync';
+import { useDiscordStatusResync } from '@/hooks/useDiscordStatusResync';
 import { useDiscordSupersedeMessages } from '@/hooks/useDiscordSupersedeMessages';
 import { useWebNotificationStream } from '@/hooks/useWebNotificationStream';
 import { usePwaInstallPrompt } from '@/hooks/usePwaInstallPrompt';
@@ -712,6 +713,8 @@ function App({ apis }: AppProps) {
   useMessengerBridgeToasts();
   // Mirror UI project add/rename/remove to Discord channels (two-way sync).
   useMessengerProjectChannelSync();
+  // After server rebuild/reconnect, refresh Discord badge + listener from live state.
+  useDiscordStatusResync();
   // Show incoming Discord supersede messages immediately in the chat.
   useDiscordSupersedeMessages();
   useWebNotificationStream({ enabled: embeddedBackgroundWorkEnabled });

--- a/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
@@ -19,6 +19,7 @@ import {
   MESSENGER_INTERRUPT_TIMEOUT_DEFAULT_MS,
   MESSENGER_INTERRUPT_TIMEOUT_MAX_MS,
   MESSENGER_INTERRUPT_TIMEOUT_MIN_MS,
+  deriveDiscordDisplayStatus,
   useMessengerStore,
   type MessengerType,
   type MessengerConnection,
@@ -209,33 +210,15 @@ function DiscordListenerPanel({
     };
   }, [running, refreshStatus, loadRecent]);
 
+  // Reconcile with the live server whenever a bot token is present. Mount-only
+  // effects raced Zustand persist hydration (empty token → early return) and
+  // left the panel stuck on "off" after a server rebuild even when the gateway
+  // was already live.
   useEffect(() => {
-    refreshStatus();
-    loadRecent();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Auto-save Discord config to server-side settings.json on mount so that
-  // the server-side auto-start on reboot picks it up. This handles the case
-  // where the user configured Discord (localStorage) but never triggered
-  // saveDiscordConfig (e.g. first visit after a server restart).
-  useEffect(() => {
-    if (conn.botToken) {
-      useMessengerStore.getState().saveDiscordConfig();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Auto-start the Discord listener on mount if it's configured but not running.
-  // Server auto-starts on boot (from saved config), but this handles first-time
-  // setup so the user doesn't need to click "Start listening" manually.
-  useEffect(() => {
-    if (!running && conn.botToken && (conn.discordGuildId || conn.defaultChannelId)) {
-      startListener();
-    }
-    // Only run once on mount — user can manually stop/start after that.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (!conn.botToken) return;
+    void useMessengerStore.getState().resyncDiscordStatus();
+    void loadRecent();
+  }, [conn.botToken, loadRecent]);
 
   const historyTarget = conn.defaultChannelId;
 
@@ -1367,6 +1350,7 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
 
   const meta = MESSENGER_META[conn.type];
   const Icon = meta.icon;
+  const displayStatus = deriveDiscordDisplayStatus(conn);
 
   const [showToken, setShowToken] = useState(false);
   const [tokenInput, setTokenInput] = useState('');
@@ -1379,22 +1363,13 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
   const hasToken = Boolean(token);
   const hasTarget = Boolean(target);
 
-  // Auto-save Discord config to server-side settings.json on mount so that
-  // the server-side auto-start on reboot picks it up. Runs when the
-  // ConnectionCard first renders (user visits Messenger settings page).
-  //
-  // Also re-verify the saved token so the working status reflects reality on
-  // open. The persisted store resets `status` to 'disconnected' on every reload
-  // (the token is the only durable signal), which otherwise made the page show
-  // the integration as "not working" until the user manually clicked Verify.
+  // Reconcile badge + listener with the live server when this card opens.
+  // Depends on botToken so we still run after Zustand persist hydration (a
+  // mount-only effect previously raced hydration and skipped the resync).
   useEffect(() => {
     if (!conn.botToken) return;
-    saveDiscordConfig();
-    if (conn.status !== 'connected' && conn.status !== 'connecting') {
-      testConnection('discord');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    void useMessengerStore.getState().resyncDiscordStatus();
+  }, [conn.botToken]);
 
   const handleSaveToken = () => {
     if (!tokenInput.trim()) return;
@@ -1436,7 +1411,7 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
         <div className="flex items-center gap-2">
           <Icon className={cn('size-5', meta.color)} />
           <span className="text-sm font-medium text-foreground">{meta.name}</span>
-          <StatusBadge status={conn.status} />
+          <StatusBadge status={displayStatus} />
           {conn.discordBotUsername && (
             <span className="text-[10px] text-muted-foreground">
               {conn.discordBotUsername}
@@ -1450,7 +1425,7 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
           <div data-settings-item="integrations.discord.commands">
             <DiscordCommandsButton />
           </div>
-          {conn.status !== 'disconnected' && (
+          {hasToken && (
             <>
               <Button
                 type="button"

--- a/packages/ui/src/hooks/useDiscordStatusResync.ts
+++ b/packages/ui/src/hooks/useDiscordStatusResync.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+import { useConfigStore } from '@/stores/useConfigStore';
+import { useMessengerStore } from '@/stores/useMessengerStore';
+
+/**
+ * Keep Discord settings status aligned with the live server gateway.
+ *
+ * After a server rebuild/restart the listener often auto-starts and keeps
+ * working, but the persisted UI store still says "disconnected". Re-sync when
+ * the OpenChamber runtime becomes connected again (and once on mount if we
+ * are already connected).
+ */
+export function useDiscordStatusResync() {
+  const isConnected = useConfigStore((s) => s.isConnected);
+  const lastSyncedConnectedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isConnected) {
+      lastSyncedConnectedRef.current = false;
+      return;
+    }
+    // Only fire on the rising edge (and the initial connected mount). Avoids
+    // re-hitting Discord on unrelated re-renders while already connected.
+    if (lastSyncedConnectedRef.current) return;
+    lastSyncedConnectedRef.current = true;
+    void useMessengerStore.getState().resyncDiscordStatus();
+  }, [isConnected]);
+}

--- a/packages/ui/src/stores/useMessengerStore.discord-status.test.ts
+++ b/packages/ui/src/stores/useMessengerStore.discord-status.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'bun:test';
 import { deriveDiscordDisplayStatus } from './useMessengerStore';
 
 describe('deriveDiscordDisplayStatus', () => {
-  it('prefers a live gateway over persisted disconnected verify status', () => {
+  test('prefers a live gateway over persisted disconnected verify status', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'disconnected',
@@ -12,7 +12,7 @@ describe('deriveDiscordDisplayStatus', () => {
     ).toBe('connected');
   });
 
-  it('shows connecting while the gateway is running but not yet READY', () => {
+  test('shows connecting while the gateway is running but not yet READY', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'disconnected',
@@ -22,7 +22,7 @@ describe('deriveDiscordDisplayStatus', () => {
     ).toBe('connecting');
   });
 
-  it('keeps an in-flight token verify as connecting', () => {
+  test('keeps an in-flight token verify as connecting', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'connecting',
@@ -32,7 +32,7 @@ describe('deriveDiscordDisplayStatus', () => {
     ).toBe('connecting');
   });
 
-  it('falls back to the last token-verify result when the listener is off', () => {
+  test('falls back to the last token-verify result when the listener is off', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'connected',

--- a/packages/ui/src/stores/useMessengerStore.discord-status.test.ts
+++ b/packages/ui/src/stores/useMessengerStore.discord-status.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { deriveDiscordDisplayStatus } from './useMessengerStore';
+
+describe('deriveDiscordDisplayStatus', () => {
+  it('prefers a live gateway over persisted disconnected verify status', () => {
+    expect(
+      deriveDiscordDisplayStatus({
+        status: 'disconnected',
+        discordListenerRunning: true,
+        discordListenerConnected: true,
+      }),
+    ).toBe('connected');
+  });
+
+  it('shows connecting while the gateway is running but not yet READY', () => {
+    expect(
+      deriveDiscordDisplayStatus({
+        status: 'disconnected',
+        discordListenerRunning: true,
+        discordListenerConnected: false,
+      }),
+    ).toBe('connecting');
+  });
+
+  it('keeps an in-flight token verify as connecting', () => {
+    expect(
+      deriveDiscordDisplayStatus({
+        status: 'connecting',
+        discordListenerRunning: false,
+        discordListenerConnected: false,
+      }),
+    ).toBe('connecting');
+  });
+
+  it('falls back to the last token-verify result when the listener is off', () => {
+    expect(
+      deriveDiscordDisplayStatus({
+        status: 'connected',
+        discordListenerRunning: false,
+        discordListenerConnected: false,
+      }),
+    ).toBe('connected');
+    expect(
+      deriveDiscordDisplayStatus({
+        status: 'error',
+        discordListenerRunning: false,
+        discordListenerConnected: false,
+      }),
+    ).toBe('error');
+    expect(
+      deriveDiscordDisplayStatus({
+        status: 'disconnected',
+        discordListenerRunning: false,
+        discordListenerConnected: false,
+      }),
+    ).toBe('disconnected');
+  });
+});

--- a/packages/ui/src/stores/useMessengerStore.ts
+++ b/packages/ui/src/stores/useMessengerStore.ts
@@ -307,6 +307,12 @@ interface MessengerState {
   startDiscordListener: () => Promise<boolean>;
   stopDiscordListener: () => Promise<boolean>;
   refreshDiscordListenerStatus: () => Promise<void>;
+  /**
+   * Reconcile UI Discord status with the live server after reload / server
+   * rebuild. Persisted store fields intentionally reset listener + verify
+   * status to "disconnected"; this pulls authoritative state back.
+   */
+  resyncDiscordStatus: () => Promise<void>;
   loadRecentDiscordMessages: () => Promise<void>;
   ingestDiscordInbound: (msg: MessengerInboundMessage) => void;
   loadDiscordHistory: (channelId: string, limit?: number) => Promise<boolean>;
@@ -373,6 +379,29 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
   });
   return (await res.json()) as T;
+}
+
+/** Dedupes concurrent resync calls from hydration + reconnect + settings mount. */
+let discordStatusResyncInFlight: Promise<void> | null = null;
+
+/**
+ * Derive the Discord settings badge from live listener state first, then the
+ * last token-verify result. Persisted verify status is forced to
+ * `disconnected` on every reload, while the server-side gateway may already be
+ * live after auto-start — prefer that stronger signal.
+ */
+export function deriveDiscordDisplayStatus(
+  conn: Pick<
+    MessengerConnection,
+    'status' | 'discordListenerRunning' | 'discordListenerConnected'
+  >,
+): MessengerConnection['status'] {
+  if (conn.discordListenerConnected) return 'connected';
+  if (conn.status === 'connecting') return 'connecting';
+  if (conn.discordListenerRunning) return 'connecting';
+  if (conn.status === 'connected') return 'connected';
+  if (conn.status === 'error') return 'error';
+  return 'disconnected';
 }
 
 export const useMessengerStore = create<MessengerState>()(
@@ -1114,8 +1143,50 @@ export const useMessengerStore = create<MessengerState>()(
             discordListenerScopeToGuild: data.scopeToGuild ?? false,
           });
         } catch {
-          // ignore
+          // ignore — keep prior listener fields; a failed probe must not look
+          // like an authoritative "listener stopped" result.
         }
+      },
+
+      resyncDiscordStatus: async () => {
+        if (discordStatusResyncInFlight) return discordStatusResyncInFlight;
+        discordStatusResyncInFlight = (async () => {
+          const conn = get().connections.find((c) => c.type === 'discord');
+          if (!conn?.botToken) return;
+
+          // Best-effort: keep server-side settings.json in sync so auto-start
+          // after the next rebuild still has the token/bindings.
+          void get().saveDiscordConfig();
+
+          // Authoritative listener snapshot first — after a server rebuild the
+          // gateway is often already live via auto-start while the UI still
+          // shows persisted "disconnected" / listener-off.
+          await get().refreshDiscordListenerStatus();
+
+          const afterRefresh = get().connections.find((c) => c.type === 'discord');
+          if (!afterRefresh?.botToken) return;
+
+          // Re-verify the bot token when the persisted badge was cleared.
+          // Skip when already connected/connecting to avoid Discord API churn.
+          if (
+            afterRefresh.status !== 'connected' &&
+            afterRefresh.status !== 'connecting'
+          ) {
+            await get().testConnection('discord');
+          }
+
+          const latest = get().connections.find((c) => c.type === 'discord');
+          if (
+            latest?.botToken &&
+            !latest.discordListenerRunning &&
+            (latest.discordGuildId || latest.defaultChannelId)
+          ) {
+            await get().startDiscordListener();
+          }
+        })().finally(() => {
+          discordStatusResyncInFlight = null;
+        });
+        return discordStatusResyncInFlight;
       },
 
       loadRecentDiscordMessages: async () => {
@@ -1454,6 +1525,14 @@ export const useMessengerStore = create<MessengerState>()(
         })),
         projectMappings: state.projectMappings,
       }),
+      onRehydrateStorage: () => (_state, error) => {
+        if (error) return;
+        // After localStorage rehydrate, pull live listener + token status from
+        // the server. Defer so the store API is fully wired before we call in.
+        queueMicrotask(() => {
+          void useMessengerStore.getState().resyncDiscordStatus();
+        });
+      },
     },
   ),
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a server rebuild/restart, Discord settings could keep showing **disconnected** even though the gateway auto-started and was still handling messages.

Root cause: persisted messenger state intentionally clears verify/listener status on reload, and mount-only resync effects raced Zustand hydration (empty token → early return), so the UI never pulled the live server status.

## Changes

- Add `resyncDiscordStatus()` to refresh listener status, re-verify the token when needed, and start the listener if configured but not running
- Run that resync on store rehydrate, runtime reconnect (`useDiscordStatusResync`), and when the settings card/listener panel sees a bot token
- Derive the Discord status badge from live gateway state first (`deriveDiscordDisplayStatus`)
- Keep Verify/Disconnect visible whenever a token is present (not only when status ≠ disconnected)

## Validation

- `bun run type-check` (packages/ui) — pass
- `bun run lint` (packages/ui) — pass
- `bun test src/stores/useMessengerStore.discord-status.test.ts` — pass

## Test plan

- [ ] Configure Discord, confirm status shows connected/live
- [ ] Restart/rebuild the OpenChamber server (listener auto-starts)
- [ ] Reload the UI / reopen Settings → Integrations → Discord
- [ ] Confirm badge shows connected (or connecting while gateway READY is in flight), not stuck disconnected
- [ ] Confirm listener panel shows `live` when the gateway is up
- [ ] Confirm Verify + Disconnect remain available when a token is saved
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f567e06-a8eb-4620-b7c3-83f2ff9d1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f567e06-a8eb-4620-b7c3-83f2ff9d1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

