### PR TITLE
fix(discord): actually sync connection status after rebuild

### DIFF
--- a/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
@@ -210,14 +210,11 @@ function DiscordListenerPanel({
     };
   }, [running, refreshStatus, loadRecent]);
 
-  // Reconcile with the live server whenever a bot token is present. Mount-only
-  // effects raced Zustand persist hydration (empty token → early return) and
-  // left the panel stuck on "off" after a server rebuild even when the gateway
-  // was already live.
+  // Reconcile with the live server (settings.json auto-start). Re-run when the
+  // hydrated token appears so we don't race Zustand persist.
   useEffect(() => {
-    if (!conn.botToken) return;
     void useMessengerStore.getState().resyncDiscordStatus();
-    void loadRecent();
+    if (conn.botToken) void loadRecent();
   }, [conn.botToken, loadRecent]);
 
   const historyTarget = conn.defaultChannelId;
@@ -1364,10 +1361,8 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
   const hasTarget = Boolean(target);
 
   // Reconcile badge + listener with the live server when this card opens.
-  // Depends on botToken so we still run after Zustand persist hydration (a
-  // mount-only effect previously raced hydration and skipped the resync).
+  // Depends on botToken so we still run after Zustand persist hydration.
   useEffect(() => {
-    if (!conn.botToken) return;
     void useMessengerStore.getState().resyncDiscordStatus();
   }, [conn.botToken]);
 

--- a/packages/ui/src/hooks/useDiscordStatusResync.ts
+++ b/packages/ui/src/hooks/useDiscordStatusResync.ts
@@ -1,14 +1,15 @@
 import { useEffect, useRef } from 'react';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { useMessengerStore } from '@/stores/useMessengerStore';
+import { useOpenChamberAgentEventsStore } from '@/stores/useOpenChamberAgentEventsStore';
 
 /**
  * Keep Discord settings status aligned with the live server gateway.
  *
  * After a server rebuild/restart the listener often auto-starts and keeps
  * working, but the persisted UI store still says "disconnected". Re-sync when
- * the OpenChamber runtime becomes connected again (and once on mount if we
- * are already connected).
+ * the OpenChamber runtime becomes connected again, and flip to connected as
+ * soon as the gateway emits `listener_ready`.
  */
 export function useDiscordStatusResync() {
   const isConnected = useConfigStore((s) => s.isConnected);
@@ -25,4 +26,23 @@ export function useDiscordStatusResync() {
     lastSyncedConnectedRef.current = true;
     void useMessengerStore.getState().resyncDiscordStatus();
   }, [isConnected]);
+
+  useEffect(() => {
+    return useOpenChamberAgentEventsStore.getState().subscribeToEvents((event) => {
+      if (event.eventType !== 'messenger.discord.listener_ready') return;
+      const data =
+        event.data && typeof event.data === 'object'
+          ? (event.data as { botId?: string; botUsername?: string })
+          : null;
+      useMessengerStore.getState().updateConnection('discord', {
+        status: 'connected',
+        error: null,
+        discordListenerRunning: true,
+        discordListenerConnected: true,
+        lastConnectedAt: Date.now(),
+        ...(data?.botId ? { discordBotId: data.botId } : {}),
+        ...(data?.botUsername ? { discordBotUsername: data.botUsername } : {}),
+      });
+    });
+  }, []);
 }

--- a/packages/ui/src/stores/useMessengerStore.discord-status.test.ts
+++ b/packages/ui/src/stores/useMessengerStore.discord-status.test.ts
@@ -6,6 +6,7 @@ describe('deriveDiscordDisplayStatus', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'disconnected',
+        botToken: 'tok',
         discordListenerRunning: true,
         discordListenerConnected: true,
       }),
@@ -16,7 +17,19 @@ describe('deriveDiscordDisplayStatus', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'disconnected',
+        botToken: 'tok',
         discordListenerRunning: true,
+        discordListenerConnected: false,
+      }),
+    ).toBe('connecting');
+  });
+
+  test('shows connecting when a token exists but live state is not reconciled yet', () => {
+    expect(
+      deriveDiscordDisplayStatus({
+        status: 'disconnected',
+        botToken: 'tok',
+        discordListenerRunning: false,
         discordListenerConnected: false,
       }),
     ).toBe('connecting');
@@ -26,6 +39,7 @@ describe('deriveDiscordDisplayStatus', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'connecting',
+        botToken: 'tok',
         discordListenerRunning: false,
         discordListenerConnected: false,
       }),
@@ -36,6 +50,7 @@ describe('deriveDiscordDisplayStatus', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'connected',
+        botToken: 'tok',
         discordListenerRunning: false,
         discordListenerConnected: false,
       }),
@@ -43,6 +58,7 @@ describe('deriveDiscordDisplayStatus', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'error',
+        botToken: 'tok',
         discordListenerRunning: false,
         discordListenerConnected: false,
       }),
@@ -50,6 +66,7 @@ describe('deriveDiscordDisplayStatus', () => {
     expect(
       deriveDiscordDisplayStatus({
         status: 'disconnected',
+        botToken: undefined,
         discordListenerRunning: false,
         discordListenerConnected: false,
       }),

--- a/packages/ui/src/stores/useMessengerStore.ts
+++ b/packages/ui/src/stores/useMessengerStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { getSafeStorage } from './utils/safeStorage';
 import { useProjectsStore } from './useProjectsStore';
+import { runtimeFetch } from '@/lib/runtime-fetch';
 import type { ProjectEntry } from '@/lib/api/types';
 
 export type MessengerType = 'discord';
@@ -372,17 +373,65 @@ const DEFAULT_CONNECTION: Omit<MessengerConnection, 'type'> = {
   autoCreateThreads: true,
 };
 
+async function parseRuntimeJson<T>(res: Response, url: string): Promise<T> {
+  let data: T;
+  try {
+    data = (await res.json()) as T;
+  } catch {
+    throw new Error(`Invalid JSON from ${url} (HTTP ${res.status})`);
+  }
+  if (!res.ok) {
+    const error =
+      data &&
+      typeof data === 'object' &&
+      'error' in data &&
+      typeof (data as { error: unknown }).error === 'string'
+        ? (data as { error: string }).error
+        : `HTTP ${res.status}`;
+    throw new Error(error);
+  }
+  return data;
+}
+
+/** Messenger routes must use runtimeFetch so desktop/auth base URL + bearer apply. */
 async function postJson<T>(url: string, body: unknown): Promise<T> {
-  const res = await fetch(url, {
+  const res = await runtimeFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  return (await res.json()) as T;
+  return parseRuntimeJson<T>(res, url);
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await runtimeFetch(url);
+  return parseRuntimeJson<T>(res, url);
 }
 
 /** Dedupes concurrent resync calls from hydration + reconnect + settings mount. */
 let discordStatusResyncInFlight: Promise<void> | null = null;
+
+type DiscordListenerStatusPayload = {
+  ok: boolean;
+  configured?: boolean;
+  running?: boolean;
+  connected?: boolean;
+  autoReply?: boolean;
+  scopeToGuild?: boolean;
+  guildId?: string | null;
+  botId?: string | null;
+  botUsername?: string | null;
+  startedAt?: number;
+  lastUpdateAt?: number | null;
+  totalReceived?: number;
+  totalReplied?: number;
+  totalRawMessages?: number;
+  lastRawMessageAt?: number | null;
+  lastRawMessageGuildId?: string | null;
+  filteredOutCount?: number;
+  lastFilteredGuildId?: string | null;
+  lastError?: string | null;
+};
 
 /**
  * Derive the Discord settings badge from live listener state first, then the
@@ -393,7 +442,7 @@ let discordStatusResyncInFlight: Promise<void> | null = null;
 export function deriveDiscordDisplayStatus(
   conn: Pick<
     MessengerConnection,
-    'status' | 'discordListenerRunning' | 'discordListenerConnected'
+    'status' | 'botToken' | 'discordListenerRunning' | 'discordListenerConnected'
   >,
 ): MessengerConnection['status'] {
   if (conn.discordListenerConnected) return 'connected';
@@ -401,6 +450,9 @@ export function deriveDiscordDisplayStatus(
   if (conn.discordListenerRunning) return 'connecting';
   if (conn.status === 'connected') return 'connected';
   if (conn.status === 'error') return 'error';
+  // Token is configured but live state has not reconciled yet (reload /
+  // rebuild). Never flash "disconnected" for a bot that is still working.
+  if (conn.botToken) return 'connecting';
   return 'disconnected';
 }
 
@@ -1105,28 +1157,27 @@ export const useMessengerStore = create<MessengerState>()(
 
       refreshDiscordListenerStatus: async () => {
         const conn = get().connections.find((c) => c.type === 'discord');
-        if (!conn?.botToken) return;
         try {
-          const data = await postJson<{
-            ok: boolean;
-            running?: boolean;
-            connected?: boolean;
-            autoReply?: boolean;
-            scopeToGuild?: boolean;
-            guildId?: string | null;
-            startedAt?: number;
-            lastUpdateAt?: number | null;
-            totalReceived?: number;
-            totalReplied?: number;
-            totalRawMessages?: number;
-            lastRawMessageAt?: number | null;
-            lastRawMessageGuildId?: string | null;
-            filteredOutCount?: number;
-            lastFilteredGuildId?: string | null;
-            lastError?: string | null;
-          }>('/api/messenger/discord/listener/status', { token: conn.botToken });
-          if (!data.ok) return;
-          get().updateConnection('discord', {
+          // Prefer the server-saved config probe. After rebuild the gateway is
+          // keyed by settings.json; this does not require the UI token body to
+          // match, and works through runtimeFetch auth/base URL.
+          let data: DiscordListenerStatusPayload | null = null;
+          try {
+            data = await getJson<DiscordListenerStatusPayload>(
+              '/api/messenger/discord/runtime-status',
+            );
+          } catch {
+            data = null;
+          }
+          if ((!data || !data.ok || data.configured === false) && conn?.botToken) {
+            data = await postJson<DiscordListenerStatusPayload>(
+              '/api/messenger/discord/listener/status',
+              { token: conn.botToken },
+            );
+          }
+          if (!data?.ok) return;
+
+          const updates: Partial<MessengerConnection> = {
             discordListenerRunning: data.running ?? false,
             discordListenerConnected: data.connected ?? false,
             discordListenerStartedAt: data.startedAt ?? null,
@@ -1141,7 +1192,20 @@ export const useMessengerStore = create<MessengerState>()(
             discordListenerError: data.lastError ?? null,
             discordListenerAutoReply: data.autoReply ?? true,
             discordListenerScopeToGuild: data.scopeToGuild ?? false,
-          });
+          };
+          if (data.botId) updates.discordBotId = data.botId;
+          if (data.botUsername) updates.discordBotUsername = data.botUsername;
+          // Authoritative live gateway → keep the header badge in sync even
+          // when the separate token-verify call has not completed yet.
+          if (data.connected) {
+            updates.status = 'connected';
+            updates.error = null;
+            updates.lastConnectedAt = Date.now();
+          } else if (data.running && conn?.status === 'disconnected') {
+            updates.status = 'connecting';
+            updates.error = null;
+          }
+          get().updateConnection('discord', updates);
         } catch {
           // ignore — keep prior listener fields; a failed probe must not look
           // like an authoritative "listener stopped" result.
@@ -1151,26 +1215,24 @@ export const useMessengerStore = create<MessengerState>()(
       resyncDiscordStatus: async () => {
         if (discordStatusResyncInFlight) return discordStatusResyncInFlight;
         discordStatusResyncInFlight = (async () => {
-          const conn = get().connections.find((c) => c.type === 'discord');
-          if (!conn?.botToken) return;
-
-          // Best-effort: keep server-side settings.json in sync so auto-start
-          // after the next rebuild still has the token/bindings.
-          void get().saveDiscordConfig();
-
-          // Authoritative listener snapshot first — after a server rebuild the
-          // gateway is often already live via auto-start while the UI still
-          // shows persisted "disconnected" / listener-off.
+          // Always probe server runtime status first (settings.json auto-start).
+          // Do not require a hydrated UI token — that raced rebuild/reload and
+          // left the badge stuck on disconnected while Discord kept working.
           await get().refreshDiscordListenerStatus();
 
           const afterRefresh = get().connections.find((c) => c.type === 'discord');
           if (!afterRefresh?.botToken) return;
 
-          // Re-verify the bot token when the persisted badge was cleared.
-          // Skip when already connected/connecting to avoid Discord API churn.
+          // Best-effort: keep server-side settings.json in sync so auto-start
+          // after the next rebuild still has the token/bindings.
+          void get().saveDiscordConfig();
+
+          // Re-verify the bot token when the badge still isn't live/connected.
+          // Skip when the gateway already marked us connected/connecting.
           if (
             afterRefresh.status !== 'connected' &&
-            afterRefresh.status !== 'connecting'
+            afterRefresh.status !== 'connecting' &&
+            !afterRefresh.discordListenerConnected
           ) {
             await get().testConnection('discord');
           }

--- a/packages/web/server/lib/messenger/messenger-sync.js
+++ b/packages/web/server/lib/messenger/messenger-sync.js
@@ -1849,6 +1849,33 @@ export function createMessengerSyncRouter({
     res.json(discordListener.status(token));
   });
 
+  /**
+   * Live Discord gateway status from the server-saved settings.json token.
+   * Used by the UI after rebuild/reload so the badge can reflect the
+   * auto-started listener without requiring a matching client token body.
+   */
+  router.get('/discord/runtime-status', async (req, res) => {
+    try {
+      const settings = readSettings ? await readSettings() : null;
+      const token = settings?.discord?.botToken;
+      if (!token) {
+        return res.json({
+          ok: true,
+          configured: false,
+          running: false,
+          connected: false,
+        });
+      }
+      return res.json({
+        ok: true,
+        configured: true,
+        ...discordListener.status(token),
+      });
+    } catch (err) {
+      return res.status(500).json({ ok: false, error: err?.message ?? 'status failed' });
+    }
+  });
+
   router.post('/discord/listener/recent', (req, res) => {
     const token = req.body?.token;
     if (!token) return res.status(400).json({ error: 'token required' });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #2330. That fix still left the Discord badge on **disconnected** while the bot kept working.

### Why #2330 was not enough
1. Messenger status/test calls used bare `fetch`, so on desktop/auth runtimes they often never hit the OpenChamber API with the correct base URL + bearer.
2. Listener status required the UI to POST its localStorage token. After rebuild the live gateway is keyed by **server** `settings.json`, so the UI probe could miss it.
3. With a configured token, the badge could still render `disconnected` until a successful verify — the false state users reported.

### Fix
- Route messenger HTTP through `runtimeFetch`
- Add `GET /api/messenger/discord/runtime-status` that reports the auto-started listener from saved server config (no client token body required)
- When the gateway is live, set connection `status: 'connected'`
- Derive badge: configured token → at least `connecting`, never a false `disconnected`
- Flip to connected immediately on `messenger.discord.listener_ready`

## Validation
- `bun run type-check` (packages/ui)
- `bun run lint` (packages/ui)
- `bun test src/stores/useMessengerStore.discord-status.test.ts`

## Test plan
- [ ] Restart/rebuild OpenChamber with Discord already configured
- [ ] Open Settings → Integrations → Discord **without** clicking Verify
- [ ] Badge should show `connected` (or briefly `connecting`), not stuck `disconnected`
- [ ] Listener panel should show `live`
- [ ] Discord chat should continue working as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f567e06-a8eb-4620-b7c3-83f2ff9d1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f567e06-a8eb-4620-b7c3-83f2ff9d1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

