### PR TITLE
fix(discord): show Disconnect when connected

### DIFF
--- a/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
+++ b/packages/ui/src/components/sections/openchamber-agent-settings/MessengerSection.tsx
@@ -1431,11 +1431,13 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <div data-settings-item="integrations.discord.commands">
             <DiscordCommandsButton />
           </div>
-          {hasToken && (
+          {/* Setup-only header actions. When connected, Disconnect lives with
+              Change token / Advanced below so it stays visible. */}
+          {hasToken && !isConnectedView && (
             <>
               <Button
                 type="button"
@@ -1478,7 +1480,7 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
 
       {isConnectedView ? (
         <>
-          {/* Connected: no setup chrome — change token + advanced entry points. */}
+          {/* Connected: change token, advanced, and disconnect — always visible. */}
           <div ref={tokenSectionRef} className="flex flex-wrap items-center gap-2">
             <Button
               type="button"
@@ -1499,6 +1501,15 @@ function ConnectionCard({ conn }: { conn: MessengerConnection }) {
               onClick={() => setAdvancedOpen((open) => !open)}
             >
               {t('settings.integrations.discord.actions.advancedSettings')}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              className="!font-normal text-[var(--status-error)] hover:text-[var(--status-error)]"
+              onClick={() => setDisconnectConfirmOpen(true)}
+            >
+              {t('settings.integrations.discord.disconnect.button')}
             </Button>
           </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When Discord is connected, Disconnect was easy to miss in the crowded header (or absent from the connected action row). It should be obvious whenever the integration is live.

## Changes

- Connected view: show **Disconnect** next to **Change token** and **Advanced settings**
- Setup view: keep Verify + Disconnect in the header
- Connected header drops Verify (not needed once live)

## Test plan

- [ ] Connect Discord until badge shows `connected`
- [ ] Confirm Disconnect appears with Change token / Advanced settings
- [ ] Disconnect still opens the confirmation dialog and removes the connection
- [ ] During setup (token present, not yet connected), Verify + Disconnect remain in the header

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f567e06-a8eb-4620-b7c3-83f2ff9d1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f567e06-a8eb-4620-b7c3-83f2ff9d1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

