### PR TITLE
fix(vscode,ui): stop postMessage crash when opening chat in Cursor

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -715,10 +715,15 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
     const promptReadOnly = parentSession ? !allowPromptingSubagentSessions : readOnly;
 
     React.useEffect(() => {
-        if (typeof window === 'undefined' || window.parent === window) {
+        // VS Code/Cursor/Positron webviews delete window.parent (and window.top).
+        // The old `window.parent === window` check does not catch that, so
+        // `window.parent.postMessage(...)` threw on chat open:
+        // TypeError: Cannot read properties of undefined (reading 'postMessage')
+        if (typeof window === 'undefined' || !window.parent || window.parent === window) {
             return;
         }
 
+        const parentWindow = window.parent;
         const applySetting = (value: boolean) => {
             useUIStore.getState().setAllowPromptingSubagentSessions(value);
         };
@@ -729,7 +734,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
             applySetting(payload.allowPromptingSubagentSessions);
         };
         const handleMessage = (event: MessageEvent) => {
-            if (event.source !== window.parent || event.origin !== window.location.origin) return;
+            if (event.source !== parentWindow || event.origin !== window.location.origin) return;
             const data = event.data as { type?: unknown; payload?: { allowPromptingSubagentSessions?: unknown } };
             if (data?.type !== 'openchamber:chat-settings-sync'
                 || typeof data.payload?.allowPromptingSubagentSessions !== 'boolean') return;
@@ -738,7 +743,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
 
         scopedWindow.__openchamberApplyChatSettingsSync = applySync;
         window.addEventListener('message', handleMessage);
-        window.parent.postMessage({ type: 'openchamber:chat-settings-request' }, window.location.origin);
+        parentWindow.postMessage({ type: 'openchamber:chat-settings-request' }, window.location.origin);
         return () => {
             window.removeEventListener('message', handleMessage);
             if (scopedWindow.__openchamberApplyChatSettingsSync === applySync) {

--- a/packages/ui/src/components/chat/__tests__/parentFramePostMessageGuard.test.ts
+++ b/packages/ui/src/components/chat/__tests__/parentFramePostMessageGuard.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * Mirrors the ChatContainer chat-settings-sync guard.
+ * VS Code/Cursor/Positron webviews delete `window.parent`, so the old
+ * `window.parent === window` check still fell through to `.postMessage` and
+ * crashed chat open with:
+ * TypeError: Cannot read properties of undefined (reading 'postMessage')
+ */
+const canPostMessageToParentFrame = (win: { parent?: unknown } | undefined): boolean => {
+  if (typeof win === 'undefined' || !win) return false;
+  return Boolean(win.parent) && win.parent !== win;
+};
+
+describe('parent-frame postMessage guard (VS Code webview)', () => {
+  test('rejects when parent was deleted (VS Code webview injector behavior)', () => {
+    const vscodeLikeWindow = { parent: undefined };
+    expect(canPostMessageToParentFrame(vscodeLikeWindow)).toBe(false);
+  });
+
+  test('rejects when parent is null', () => {
+    expect(canPostMessageToParentFrame({ parent: null })).toBe(false);
+  });
+
+  test('rejects top-level windows where parent === self', () => {
+    const topLevel = {} as { parent?: unknown };
+    topLevel.parent = topLevel;
+    expect(canPostMessageToParentFrame(topLevel)).toBe(false);
+  });
+
+  test('allows real embedded iframe parent windows', () => {
+    const parent = {};
+    const child = { parent };
+    expect(canPostMessageToParentFrame(child)).toBe(true);
+  });
+
+  test('old guard incorrectly allows deleted parent', () => {
+    const vscodeLikeWindow = { parent: undefined as unknown };
+    const oldGuardWouldSkip = vscodeLikeWindow.parent === vscodeLikeWindow;
+    expect(oldGuardWouldSkip).toBe(false);
+  });
+});

--- a/packages/vscode/src/SessionEditorPanelProvider.ts
+++ b/packages/vscode/src/SessionEditorPanelProvider.ts
@@ -437,7 +437,8 @@ export class SessionEditorPanelProvider {
         headers: this._buildSseHeaders(headers),
         signal: controller.signal,
         onChunk: (chunk) => {
-          entry.panel.webview.postMessage({ type: 'api:sse:chunk', streamId, chunk });
+          // Panel may be disposed before SSE callbacks fire.
+          entry.panel?.webview?.postMessage({ type: 'api:sse:chunk', streamId, chunk });
         },
       });
 
@@ -445,12 +446,12 @@ export class SessionEditorPanelProvider {
 
       start.run
         .then(() => {
-          entry.panel.webview.postMessage({ type: 'api:sse:end', streamId });
+          entry.panel?.webview?.postMessage({ type: 'api:sse:end', streamId });
         })
         .catch((error) => {
           if (!controller.signal.aborted) {
             const messageText = error instanceof Error ? error.message : String(error);
-            entry.panel.webview.postMessage({ type: 'api:sse:end', streamId, error: messageText });
+            entry.panel?.webview?.postMessage({ type: 'api:sse:end', streamId, error: messageText });
           }
         })
         .finally(() => {

--- a/packages/vscode/webview/api/bridge-acquire-fallback.test.ts
+++ b/packages/vscode/webview/api/bridge-acquire-fallback.test.ts
@@ -1,0 +1,51 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * When acquireVsCodeApi() returns undefined (broken Cursor/VSCodium webview slot),
+ * getVSCodeAPI().postMessage used to throw:
+ * TypeError: Cannot read properties of undefined (reading 'postMessage')
+ *
+ * The bridge must fall back to a noop API and fail via normal request timeout instead.
+ */
+describe('VS Code webview bridge acquireVsCodeApi fallback', () => {
+  test('does not throw TypeError when acquireVsCodeApi returns undefined', async () => {
+    const originalWindow = globalThis.window;
+    const originalAcquire = (globalThis as typeof globalThis & { acquireVsCodeApi?: unknown }).acquireVsCodeApi;
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+
+    try {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: new EventTarget(),
+      });
+      Object.defineProperty(globalThis, 'acquireVsCodeApi', {
+        configurable: true,
+        value: () => undefined,
+      });
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args);
+      };
+
+      const { sendBridgeMessageWithOptions } = await import(`./bridge?acquire-fallback-${Date.now()}`);
+
+      const result = await sendBridgeMessageWithOptions('api:proxy', { path: '/health' }, { timeoutMs: 20 }).then(
+        () => 'resolved' as const,
+        (error: unknown) => error,
+      );
+
+      assert.ok(result instanceof Error, `expected Error, got ${String(result)}`);
+      assert.notEqual((result as Error).name, 'TypeError');
+      assert.match((result as Error).message, /timed out/i);
+      assert.ok(
+        warnings.some((entry) => String(entry[0] ?? '').includes('VS Code API unavailable')),
+        'expected a one-time warning that the VS Code API was unavailable',
+      );
+    } finally {
+      console.warn = originalWarn;
+      Object.defineProperty(globalThis, 'window', { configurable: true, value: originalWindow });
+      Object.defineProperty(globalThis, 'acquireVsCodeApi', { configurable: true, value: originalAcquire });
+    }
+  });
+});

--- a/packages/vscode/webview/api/bridge.ts
+++ b/packages/vscode/webview/api/bridge.ts
@@ -9,10 +9,24 @@ interface VSCodeAPI {
 }
 
 let vscodeApi: VSCodeAPI | null = null;
+let noopWarned = false;
+
+const noopVSCodeApi: VSCodeAPI = {
+  postMessage: (message) => {
+    // acquireVsCodeApi() can return undefined in broken/non-standard webview slots
+    // (Cursor after extension update, VSCodium, headless). Drop the message instead
+    // of throwing TypeError: Cannot read properties of undefined (reading 'postMessage').
+    if (!noopWarned) {
+      noopWarned = true;
+      console.warn('[openchamber] VS Code API unavailable; dropping postMessage', message);
+    }
+  },
+};
 
 function getVSCodeAPI(): VSCodeAPI {
   if (!vscodeApi) {
-    vscodeApi = acquireVsCodeApi();
+    const acquired = typeof acquireVsCodeApi === 'function' ? acquireVsCodeApi() : undefined;
+    vscodeApi = acquired ?? noopVSCodeApi;
   }
   return vscodeApi;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `TypeError: Cannot read properties of undefined (reading 'postMessage')` when opening the OpenChamber chat panel in Cursor / VS Code / Positron / VSCodium (closes #2181, closes #2190, closes #2223).

## Root cause

VS Code’s webview injector **deletes** `window.parent` / `window.top` (see [microsoft/vscode#253635](https://github.com/microsoft/vscode/pull/253635)). After #2054 / subagent settings sync landed, `ChatContainer` mounted this effect on every chat open:

```ts
if (window.parent === window) return;
window.parent.postMessage({ type: 'openchamber:chat-settings-request' }, ...);
```

When `window.parent` is `undefined`, `undefined === window` is `false`, so execution continues and throws. That matches reports that **v1.15.0 works** and newer builds fail on open.

Secondary crash paths (same error text):

1. `acquireVsCodeApi()` returning `undefined` in a broken webview slot → `getVSCodeAPI().postMessage(...)` throws
2. Session editor SSE callbacks posting after panel disposal

## Fix

- **ChatContainer**: guard with `!window.parent || window.parent === window` (same pattern as `useKeyboardShortcuts`)
- **webview bridge**: fall back to a warn-once noop API when `acquireVsCodeApi` is missing/undefined
- **SessionEditorPanelProvider**: optional-chain SSE `postMessage` callbacks

## Validation

- `bun test packages/ui/src/components/chat/__tests__/parentFramePostMessageGuard.test.ts`
- `bun test packages/vscode/webview/api/bridge.test.ts packages/vscode/webview/api/bridge-acquire-fallback.test.ts`
- `bun run type-check` in `packages/ui` and `packages/vscode`
- `bun run lint` in `packages/ui` and `packages/vscode`
- `bun run dead-code` (non-blocking; inspected)

Not validated: live Cursor/VS Code webview runtime (no IDE host in this environment).

## Note

Overlaps with open PR #2189; this branch adds focused regression tests and the typed `parentWindow` capture on the chat-open path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a5a38fa-0d4c-451f-b20a-1c49f50dbc3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a5a38fa-0d4c-451f-b20a-1c49f50dbc3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

