### PR TITLE
feat: sync session read status across connected clients

### DIFF
--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -273,9 +273,20 @@ export function createEventPipeline(input: EventPipelineInput): EventPipeline {
   }
 
   const key = (payload: Event): string | undefined => {
+    const rawType = (payload as { type?: unknown }).type
     if (payload.type === "session.status") {
       const props = payload.properties as { sessionID: string }
       return `session.status:${props.sessionID}`
+    }
+    if (rawType === "openchamber:session-attention") {
+      const props = (payload as { properties?: unknown }).properties as { sessionID?: string; sessionId?: string } | undefined
+      if (!props) return undefined
+      const sessionID = typeof props.sessionID === "string" && props.sessionID.length > 0
+        ? props.sessionID
+        : typeof props.sessionId === "string" && props.sessionId.length > 0
+          ? props.sessionId
+          : undefined
+      return sessionID ? `session.attention:${sessionID}` : undefined
     }
     if (payload.type === "session.updated") {
       const props = payload.properties as { info?: { id?: string } }

--- a/packages/ui/src/sync/notification-store.test.ts
+++ b/packages/ui/src/sync/notification-store.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+
+const runtimeFetchCalls: Array<{ input: string | URL | Request; init?: RequestInit }> = []
+let runtimeFetchImpl: (input: string | URL | Request, init?: RequestInit) => Promise<Response> =
+  async () => new Response(null, { status: 200 })
+
+mock.module("@/lib/runtime-fetch", () => ({
+  runtimeFetch: (input: string | URL | Request, init?: RequestInit) => {
+    runtimeFetchCalls.push({ input, init })
+    return runtimeFetchImpl(input, init)
+  },
+}))
+
+import {
+  appendNotification,
+  applySessionAttentionEvent,
+  hydrateSessionAttentionState,
+  resetSessionViewReceiptThrottleForTests,
+  useNotificationStore,
+} from "./notification-store"
+
+const emptyIndex = () => ({
+  session: { unseenCount: {}, unseenHasError: {} },
+  project: { unseenCount: {}, unseenHasError: {} },
+})
+
+describe("notification store attention sync", () => {
+  const baseTime = Date.now()
+
+  beforeEach(() => {
+    runtimeFetchCalls.length = 0
+    runtimeFetchImpl = async () => new Response(null, { status: 200 })
+    resetSessionViewReceiptThrottleForTests()
+    useNotificationStore.setState({ list: [], index: emptyIndex() })
+  })
+
+  test("viewed notifications send a throttled read receipt", () => {
+    appendNotification({
+      type: "turn-complete",
+      directory: "/repo",
+      session: "ses_viewed_append",
+      time: baseTime + 50,
+      viewed: true,
+    })
+    appendNotification({
+      type: "error",
+      directory: "/repo",
+      session: "ses_viewed_append",
+      time: baseTime + 60,
+      viewed: true,
+      error: { message: "same burst" },
+    })
+
+    expect(runtimeFetchCalls).toHaveLength(1)
+    expect(String(runtimeFetchCalls[0]?.input)).toBe("/api/sessions/ses_viewed_append/view")
+    expect(runtimeFetchCalls[0]?.init?.method).toBe("POST")
+  })
+
+  test("clears only notifications at or before the synced read timestamp", () => {
+    appendNotification({
+      type: "turn-complete",
+      directory: "/repo",
+      session: "ses_1",
+      time: baseTime + 100,
+      viewed: false,
+    })
+    appendNotification({
+      type: "error",
+      directory: "/repo",
+      session: "ses_1",
+      time: baseTime + 300,
+      viewed: false,
+      error: { message: "late" },
+    })
+
+    applySessionAttentionEvent({
+      type: "openchamber:session-attention",
+      properties: {
+        sessionID: "ses_1",
+        needsAttention: false,
+        lastReadAt: baseTime + 200,
+        timestamp: baseTime + 200,
+      },
+    })
+
+    const list = useNotificationStore.getState().list
+    expect(list).toHaveLength(2)
+    expect(list[0]?.session).toBe("ses_1")
+    expect(list[0]?.time).toBe(baseTime + 100)
+    expect(list[0]?.viewed).toBe(true)
+    expect(list[1]?.session).toBe("ses_1")
+    expect(list[1]?.time).toBe(baseTime + 300)
+    expect(list[1]?.viewed).toBe(false)
+    expect(useNotificationStore.getState().sessionUnseenCount("ses_1")).toBe(1)
+  })
+
+  test("remote attention clears do not send a local read receipt", () => {
+    appendNotification({
+      type: "turn-complete",
+      directory: "/repo",
+      session: "ses_1",
+      time: baseTime + 100,
+      viewed: false,
+    })
+
+    applySessionAttentionEvent({
+      type: "openchamber:session-attention",
+      properties: {
+        sessionID: "ses_1",
+        needsAttention: false,
+        lastReadAt: baseTime + 100,
+        timestamp: baseTime + 100,
+      },
+    })
+
+    expect(runtimeFetchCalls).toHaveLength(0)
+    expect(useNotificationStore.getState().sessionUnseenCount("ses_1")).toBe(0)
+  })
+
+  test("hydrates read state conservatively from the server snapshot", async () => {
+    appendNotification({
+      type: "turn-complete",
+      directory: "/repo",
+      session: "ses_1",
+      time: baseTime + 100,
+      viewed: false,
+    })
+    appendNotification({
+      type: "turn-complete",
+      directory: "/repo",
+      session: "ses_1",
+      time: baseTime + 400,
+      viewed: false,
+    })
+    appendNotification({
+      type: "error",
+      directory: "/repo",
+      session: "ses_2",
+      time: baseTime + 150,
+      viewed: false,
+      error: { message: "still unread" },
+    })
+
+    runtimeFetchImpl = async () => new Response(JSON.stringify({
+      sessions: {
+        ses_1: {
+          needsAttention: false,
+          lastReadAt: baseTime + 250,
+          timestamp: baseTime + 250,
+        },
+        ses_2: {
+          needsAttention: true,
+          lastReadAt: baseTime + 999,
+          timestamp: baseTime + 999,
+        },
+        ses_3: {
+          needsAttention: false,
+          lastReadAt: baseTime + 999,
+          timestamp: baseTime + 999,
+        },
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+
+    await hydrateSessionAttentionState()
+
+    expect(runtimeFetchCalls).toHaveLength(1)
+    expect(String(runtimeFetchCalls[0]?.input)).toBe("/api/sessions/attention")
+    const list = useNotificationStore.getState().list
+    expect(list).toHaveLength(3)
+    expect(list[0]?.session).toBe("ses_1")
+    expect(list[0]?.time).toBe(baseTime + 100)
+    expect(list[0]?.viewed).toBe(true)
+    expect(list[1]?.session).toBe("ses_1")
+    expect(list[1]?.time).toBe(baseTime + 400)
+    expect(list[1]?.viewed).toBe(false)
+    expect(list[2]?.session).toBe("ses_2")
+    expect(list[2]?.time).toBe(baseTime + 150)
+    expect(list[2]?.viewed).toBe(false)
+    expect(useNotificationStore.getState().sessionUnseenCount("ses_1")).toBe(1)
+    expect(useNotificationStore.getState().sessionUnseenCount("ses_2")).toBe(1)
+  })
+})

--- a/packages/ui/src/sync/notification-store.ts
+++ b/packages/ui/src/sync/notification-store.ts
@@ -6,6 +6,8 @@
 // ---------------------------------------------------------------------------
 
 import { create } from "zustand"
+import { runtimeFetch } from "@/lib/runtime-fetch"
+import { retry } from "./retry"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,6 +48,25 @@ type NotificationIndex = {
 
 const MAX_NOTIFICATIONS = 500
 const NOTIFICATION_TTL_MS = 1000 * 60 * 60 * 24 * 30 // 30 days
+const VIEW_RECEIPT_RETRY_DELAY_MS = 250
+const VIEW_RECEIPT_THROTTLE_MS = 3_000
+
+const EMPTY_INDEX: NotificationIndex = {
+  session: { unseenCount: {}, unseenHasError: {} },
+  project: { unseenCount: {}, unseenHasError: {} },
+}
+const sessionViewReceiptSentAt = new Map<string, number>()
+
+type MarkSessionViewedOptions = {
+  upTo?: number | null
+}
+
+type SessionAttentionState = {
+  needsAttention: boolean
+  lastReadAt: number | null
+  lastActivityAt: number | null
+  timestamp: number | null
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -80,6 +101,115 @@ function buildIndex(list: Notification[]): NotificationIndex {
   return index
 }
 
+function isFiniteTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+}
+
+function viewSessionNotifications(
+  current: NotificationStore,
+  sessionId: string,
+  options?: MarkSessionViewedOptions,
+): boolean {
+  const unseenCount = current.index.session.unseenCount[sessionId] ?? 0
+  if (unseenCount === 0) return false
+
+  const upTo = isFiniteTimestamp(options?.upTo) ? options.upTo : null
+  let changed = false
+  const next = current.list.map((notification) => {
+    if (notification.session !== sessionId || notification.viewed) {
+      return notification
+    }
+    if (upTo !== null && notification.time > upTo) {
+      return notification
+    }
+    changed = true
+    return { ...notification, viewed: true }
+  })
+
+  if (!changed) return false
+  useNotificationStore.setState({ list: next, index: buildIndex(next) })
+  return true
+}
+
+async function postSessionViewReceipt(sessionId: string): Promise<void> {
+  const response = await runtimeFetch(`/api/sessions/${sessionId}/view`, { method: "POST" })
+  if (response.ok) return
+
+  if (response.status === 408 || response.status === 429 || response.status >= 500) {
+    const error = new Error(`session view receipt failed (${response.status})`)
+    ;(error as Error & { status?: number }).status = response.status
+    throw error
+  }
+}
+
+function shouldRetrySessionViewReceipt(error: unknown): boolean {
+  const status = (error as { status?: unknown })?.status
+  if (typeof status === "number") {
+    return status === 408 || status === 429 || (status >= 500 && status < 600)
+  }
+  return true
+}
+
+function shouldSendSessionViewReceipt(sessionId: string): boolean {
+  if (!sessionId) return false
+  const now = Date.now()
+  const lastSentAt = sessionViewReceiptSentAt.get(sessionId) ?? 0
+  if (now - lastSentAt < VIEW_RECEIPT_THROTTLE_MS) {
+    return false
+  }
+  sessionViewReceiptSentAt.set(sessionId, now)
+  return true
+}
+
+export function sendSessionViewReceiptIfNeeded(sessionId: string): void {
+  if (!shouldSendSessionViewReceipt(sessionId)) return
+  void retry(() => postSessionViewReceipt(sessionId), {
+    attempts: 2,
+    delay: VIEW_RECEIPT_RETRY_DELAY_MS,
+    retryIf: shouldRetrySessionViewReceipt,
+  }).catch(() => {
+    // Older runtimes and transient failures should not block local unread clears.
+  })
+}
+
+function parseSessionAttentionState(value: unknown): SessionAttentionState | null {
+  if (!value || typeof value !== "object") return null
+  const record = value as {
+    sessionID?: unknown
+    sessionId?: unknown
+    needsAttention?: unknown
+    lastReadAt?: unknown
+    lastActivityAt?: unknown
+    lastStatusChangeAt?: unknown
+    timestamp?: unknown
+  }
+
+  const sessionId = typeof record.sessionID === "string" && record.sessionID.length > 0
+    ? record.sessionID
+    : typeof record.sessionId === "string" && record.sessionId.length > 0
+      ? record.sessionId
+      : null
+  if (!sessionId) return null
+
+  return {
+    needsAttention: record.needsAttention === true,
+    lastReadAt: isFiniteTimestamp(record.lastReadAt) ? record.lastReadAt : null,
+    lastActivityAt: isFiniteTimestamp(record.lastActivityAt)
+      ? record.lastActivityAt
+      : isFiniteTimestamp(record.lastStatusChangeAt)
+        ? record.lastStatusChangeAt
+        : null,
+    timestamp: isFiniteTimestamp(record.timestamp) ? record.timestamp : null,
+  }
+}
+
+function applySessionAttentionState(sessionId: string, state: SessionAttentionState): boolean {
+  if (state.needsAttention) return false
+  const viewedAt = state.lastReadAt ?? state.timestamp
+  if (!isFiniteTimestamp(viewedAt)) return false
+  return viewSessionNotifications(useNotificationStore.getState(), sessionId, { upTo: viewedAt })
+}
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
@@ -90,7 +220,7 @@ interface NotificationStore {
 
   // Mutations
   append: (notification: Notification) => void
-  markSessionViewed: (sessionId: string) => void
+  markSessionViewed: (sessionId: string, options?: MarkSessionViewedOptions) => boolean
   markProjectViewed: (directory: string) => void
 
   // Selectors
@@ -102,10 +232,7 @@ interface NotificationStore {
 
 export const useNotificationStore = create<NotificationStore>((set, get) => ({
   list: [],
-  index: {
-    session: { unseenCount: {}, unseenHasError: {} },
-    project: { unseenCount: {}, unseenHasError: {} },
-  },
+  index: EMPTY_INDEX,
 
   append: (notification) => {
     const current = get().list
@@ -113,16 +240,7 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
     set({ list: next, index: buildIndex(next) })
   },
 
-  markSessionViewed: (sessionId) => {
-    const current = get()
-    const count = current.index.session.unseenCount[sessionId] ?? 0
-    if (count === 0) return
-
-    const next = current.list.map((n) =>
-      n.session === sessionId && !n.viewed ? { ...n, viewed: true } : n,
-    )
-    set({ list: next, index: buildIndex(next) })
-  },
+  markSessionViewed: (sessionId, options) => viewSessionNotifications(get(), sessionId, options),
 
   markProjectViewed: (directory) => {
     const current = get()
@@ -147,10 +265,56 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
 
 export function appendNotification(notification: Notification) {
   useNotificationStore.getState().append(notification)
+  if (notification.viewed && notification.session) {
+    sendSessionViewReceiptIfNeeded(notification.session)
+  }
 }
 
 export function markSessionViewed(sessionId: string) {
-  useNotificationStore.getState().markSessionViewed(sessionId)
+  if (!sessionId) return
+  const changed = useNotificationStore.getState().markSessionViewed(sessionId)
+  if (!changed) return
+  sendSessionViewReceiptIfNeeded(sessionId)
+}
+
+export function applySessionAttentionEvent(payload: unknown): boolean {
+  if ((payload as { type?: unknown })?.type !== "openchamber:session-attention") {
+    return false
+  }
+
+  const properties = (payload as { properties?: unknown }).properties
+  const state = parseSessionAttentionState(properties)
+  if (!state) return true
+  const sessionId = typeof (properties as { sessionID?: unknown }).sessionID === "string"
+    ? (properties as { sessionID: string }).sessionID
+    : typeof (properties as { sessionId?: unknown }).sessionId === "string"
+      ? (properties as { sessionId: string }).sessionId
+      : ""
+  if (!sessionId) return true
+  applySessionAttentionState(sessionId, state)
+  return true
+}
+
+export function reconcileSessionAttentionSnapshot(snapshot: Record<string, unknown>): void {
+  for (const [sessionId, rawState] of Object.entries(snapshot)) {
+    const state = parseSessionAttentionState({ ...(rawState as object), sessionID: sessionId })
+    if (!state) continue
+    applySessionAttentionState(sessionId, state)
+  }
+}
+
+export async function hydrateSessionAttentionState(): Promise<void> {
+  const response = await runtimeFetch("/api/sessions/attention")
+  if (!response.ok) return
+  const payload = await response.json().catch(() => null)
+  if (!payload || typeof payload !== "object") return
+  const sessions = (payload as { sessions?: unknown }).sessions
+  if (!sessions || typeof sessions !== "object") return
+  reconcileSessionAttentionSnapshot(sessions as Record<string, unknown>)
+}
+
+export function resetSessionViewReceiptThrottleForTests(): void {
+  sessionViewReceiptSentAt.clear()
 }
 
 // ---------------------------------------------------------------------------
@@ -160,4 +324,3 @@ export function markSessionViewed(sessionId: string) {
 export function useSessionUnseenCount(sessionId: string): number {
   return useNotificationStore((s) => s.index.session.unseenCount[sessionId] ?? 0)
 }
-

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -34,7 +34,7 @@ import { processVSCodePermissionAutoAccept } from "./vscode-permission-auto-acce
 import { useConfigStore } from "@/stores/useConfigStore"
 import { useTodosPersistStore } from "@/stores/useTodosPersistStore"
 import { toast } from "@/components/ui"
-import { appendNotification } from "./notification-store"
+import { appendNotification, applySessionAttentionEvent, hydrateSessionAttentionState } from "./notification-store"
 import { applyGlobalSessionStatusEvent } from "./global-session-status"
 import type { State } from "./types"
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
@@ -622,6 +622,7 @@ const normalizeEventDirectory = (rawDirectory: string): string => {
 }
 
 const getSessionIdFromPayload = (event: Event): string | null => {
+  const rawType = (event as { type?: unknown }).type
   const properties = (event as { properties?: unknown }).properties
   if (!properties || typeof properties !== "object") {
     return null
@@ -641,6 +642,7 @@ const getSessionIdFromPayload = (event: Event): string | null => {
   if (
     event.type === "message.removed"
     || event.type === "session.status"
+    || rawType === "openchamber:session-attention"
     || event.type === "todo.updated"
     || event.type === "permission.asked"
     || event.type === "permission.replied"
@@ -1337,6 +1339,10 @@ function handleEvent(
     return
   }
 
+  if (applySessionAttentionEvent(payload)) {
+    return
+  }
+
   applySessionEventToGlobalSessions(payload)
   // Keep the cross-project status map current for ALL directories (mirrors the
   // global-session handling above). Child stores remain the primary source for
@@ -1486,11 +1492,12 @@ function handleEvent(
     if (session && (session as { parentID?: string }).parentID) {
       // subtask — skip notification
     } else if (sessionID) {
+      const viewed = isViewedInCurrentSession(resolvedDirectory, sessionID)
       appendNotification({
         directory: resolvedDirectory,
         session: sessionID,
         time: Date.now(),
-        viewed: isViewedInCurrentSession(resolvedDirectory, sessionID),
+        viewed,
         ...(payload.type === "session.error"
           ? { type: "error" as const, error: props.error }
           : { type: "turn-complete" as const }),
@@ -1863,6 +1870,12 @@ export function SyncProvider(props: {
     }
   }, [props.sdk])
 
+  useEffect(() => {
+    void hydrateSessionAttentionState().catch(() => {
+      // Older servers may not expose attention hydration yet.
+    })
+  }, [props.sdk])
+
   // Event pipeline — created once per mount. No class, no start/stop.
   // Abort controller owned by the pipeline closure. Cleanup aborts + flushes.
   useEffect(() => {
@@ -1897,6 +1910,9 @@ export function SyncProvider(props: {
           hasEverConnected: true,
           connectionPhase: "connected",
         })
+        void hydrateSessionAttentionState().catch(() => {
+          // Attention hydration is best-effort across mixed-version runtimes.
+        })
         const isFirstConnect = !pipelineHasConnectedRef.current
         pipelineHasConnectedRef.current = true
         if (isFirstConnect && !pipelineDisconnectedBeforeFirstConnectRef.current) {
@@ -1927,6 +1943,9 @@ export function SyncProvider(props: {
           isConnected: true,
           hasEverConnected: true,
           connectionPhase: "connected",
+        })
+        void hydrateSessionAttentionState().catch(() => {
+          // Attention hydration is best-effort across mixed-version runtimes.
         })
         for (const dir of childStores.children.keys()) {
           triggerDirectoryResync(dir, "transport-switch")

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -448,6 +448,36 @@ const handleLocalApiRequest = async (input: RequestInfo | URL, url: URL, init: R
     );
   }
 
+  if (/^\/api\/sessions\/[^/]+\/view$/.test(normalizedPathname) && method === 'POST') {
+    const sessionId = normalizedPathname.split('/')[3] || '';
+    return new Response(
+      JSON.stringify({
+        success: true,
+        sessionId,
+        viewed: true,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
+  if (/^\/api\/sessions\/[^/]+\/unview$/.test(normalizedPathname) && method === 'POST') {
+    const sessionId = normalizedPathname.split('/')[3] || '';
+    return new Response(
+      JSON.stringify({
+        success: true,
+        sessionId,
+        viewed: false,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
   if (normalizedPathname === '/api/session-activity' && method === 'GET') {
     const activity = await sendBridgeMessage<Record<string, { type: 'idle' | 'busy' | 'cooldown' }>>('api:session-activity:get')
       .catch(() => ({}));

--- a/packages/web/server/lib/opencode/session-runtime.js
+++ b/packages/web/server/lib/opencode/session-runtime.js
@@ -66,6 +66,7 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
       state = {
         needsAttention: false,
         lastUserMessageAt: null,
+        lastReadAt: null,
         lastStatusChangeAt: Date.now(),
         viewedByClients: new Set(),
         status: 'idle',
@@ -73,6 +74,35 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
       sessionAttentionStates.set(sessionId, state);
     }
     return state;
+  };
+
+  const emitSyntheticEvent = (payload) => {
+    if (typeof broadcastEvent === 'function') {
+      broadcastEvent(payload);
+      return;
+    }
+
+    const clients = getNotificationClients();
+    for (const res of clients) {
+      try {
+        writeSseEvent(res, payload);
+      } catch {
+      }
+    }
+  };
+
+  const broadcastSessionAttention = (sessionId, state, timestamp = Date.now()) => {
+    if (!state) return;
+    emitSyntheticEvent({
+      type: 'openchamber:session-attention',
+      properties: {
+        sessionID: sessionId,
+        needsAttention: state.needsAttention,
+        lastReadAt: state.lastReadAt,
+        lastActivityAt: state.lastStatusChangeAt,
+        timestamp,
+      },
+    });
   };
 
   const setSessionActivityPhase = (sessionId, phase) => {
@@ -119,9 +149,10 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
 
   const updateSessionAttentionStatus = (sessionId, status) => {
     const state = getOrCreateAttentionState(sessionId);
-    if (!state) return;
+    if (!state) return null;
 
     const prevStatus = state.status;
+    const prevNeedsAttention = state.needsAttention;
     state.status = status;
     state.lastStatusChangeAt = Date.now();
 
@@ -130,6 +161,12 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
         state.needsAttention = true;
       }
     }
+
+    return {
+      state,
+      changed: prevNeedsAttention !== state.needsAttention,
+      timestamp: state.lastStatusChangeAt,
+    };
   };
 
   const updateSessionState = (sessionId, status, eventId, metadata = {}) => {
@@ -137,7 +174,6 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
 
     const now = Date.now();
     const existing = sessionStates.get(sessionId);
-    const existingAttentionState = sessionAttentionStates.get(sessionId);
     if (existing && existing.lastUpdateAt > now - 5000 && status === existing.status) {
       return;
     }
@@ -149,10 +185,9 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
       metadata: { ...existing?.metadata, ...metadata },
     });
 
-    updateSessionAttentionStatus(sessionId, status);
-    const attentionState = sessionAttentionStates.get(sessionId);
-    const attentionChanged = !!attentionState && existingAttentionState?.needsAttention !== attentionState.needsAttention;
-    const clients = getNotificationClients();
+    const attentionUpdate = updateSessionAttentionStatus(sessionId, status);
+    const attentionState = attentionUpdate?.state ?? sessionAttentionStates.get(sessionId);
+    const attentionChanged = attentionUpdate?.changed === true;
     if (!existing || existing.status !== status || attentionChanged) {
       const state = sessionStates.get(sessionId);
       const syntheticPayload = {
@@ -166,16 +201,11 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
         },
       };
 
-      if (typeof broadcastEvent === 'function') {
-        broadcastEvent(syntheticPayload);
-      } else if (clients.size > 0) {
-        for (const res of clients) {
-          try {
-            writeSseEvent(res, syntheticPayload);
-          } catch {
-          }
-        }
-      }
+      emitSyntheticEvent(syntheticPayload);
+    }
+
+    if (attentionChanged) {
+      broadcastSessionAttention(sessionId, attentionState, attentionUpdate?.timestamp);
     }
 
     const phase = status === 'busy' || status === 'retry' ? 'busy' : 'idle';
@@ -207,34 +237,27 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
     const state = getOrCreateAttentionState(sessionId);
     if (!state) return;
 
+    const timestamp = Date.now();
     const wasNeedsAttention = state.needsAttention;
     state.viewedByClients.add(clientId);
+    state.lastReadAt = timestamp;
+    state.needsAttention = false;
+
+    broadcastSessionAttention(sessionId, state, timestamp);
 
     if (wasNeedsAttention) {
-      state.needsAttention = false;
-
       const syntheticPayload = {
         type: 'openchamber:session-status',
         properties: {
           sessionID: sessionId,
           status: state.status,
-          timestamp: Date.now(),
+          timestamp,
           metadata: {},
           needsAttention: false,
         },
       };
 
-      if (typeof broadcastEvent === 'function') {
-        broadcastEvent(syntheticPayload);
-      } else {
-        const clients = getNotificationClients();
-        for (const res of clients) {
-          try {
-            writeSseEvent(res, syntheticPayload);
-          } catch {
-          }
-        }
-      }
+      emitSyntheticEvent(syntheticPayload);
     }
   };
 
@@ -242,6 +265,7 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
     const state = sessionAttentionStates.get(sessionId);
     if (!state) return;
     state.viewedByClients.delete(clientId);
+    broadcastSessionAttention(sessionId, state, Date.now());
   };
 
   const markUserMessageSent = (sessionId) => {
@@ -257,7 +281,9 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
       if (now - state.lastStatusChangeAt > SESSION_ATTENTION_MAX_AGE_MS) continue;
       result[sessionId] = {
         needsAttention: state.needsAttention,
+        lastReadAt: state.lastReadAt,
         lastUserMessageAt: state.lastUserMessageAt,
+        lastActivityAt: state.lastStatusChangeAt,
         lastStatusChangeAt: state.lastStatusChangeAt,
         status: state.status,
         isViewed: state.viewedByClients.size > 0,
@@ -272,7 +298,9 @@ export const createSessionRuntime = ({ writeSseEvent, getNotificationClients, br
     if (!state) return null;
     return {
       needsAttention: state.needsAttention,
+      lastReadAt: state.lastReadAt,
       lastUserMessageAt: state.lastUserMessageAt,
+      lastActivityAt: state.lastStatusChangeAt,
       lastStatusChangeAt: state.lastStatusChangeAt,
       status: state.status,
       isViewed: state.viewedByClients.size > 0,

--- a/packages/web/server/lib/opencode/session-runtime.test.js
+++ b/packages/web/server/lib/opencode/session-runtime.test.js
@@ -12,7 +12,7 @@ describe('session runtime', () => {
     runtimes.length = 0;
   });
 
-  it('broadcasts attention clears through the shared broadcaster', () => {
+  it('broadcasts dedicated session attention updates when a session is viewed', () => {
     const events = [];
     const runtime = createSessionRuntime({
       writeSseEvent() {
@@ -53,6 +53,26 @@ describe('session runtime', () => {
         status: 'idle',
         needsAttention: true,
       }),
+    });
+    expect(events).toContainEqual({
+      type: 'openchamber:session-attention',
+      properties: {
+        sessionID: 'session-1',
+        needsAttention: true,
+        lastReadAt: null,
+        lastActivityAt: expect.any(Number),
+        timestamp: expect.any(Number),
+      },
+    });
+    expect(events.at(-2)).toEqual({
+      type: 'openchamber:session-attention',
+      properties: {
+        sessionID: 'session-1',
+        needsAttention: false,
+        lastReadAt: expect.any(Number),
+        lastActivityAt: expect.any(Number),
+        timestamp: expect.any(Number),
+      },
     });
     expect(events.at(-1)).toEqual({
       type: 'openchamber:session-status',


### PR DESCRIPTION
## Summary

With multiple OpenChamber windows (or devices, e.g. a desktop browser and the mobile PWA) connected to the same server, reading a session in one window did not clear its unread indicator in the others. Unread state lived only in each window's in-memory notification list, while live progress already synced through the server event hub.

This PR makes read status sync across all connected clients using the server's existing session-attention runtime.

## Design

- **Dedicated event:** the server now broadcasts `openchamber:session-attention` (`sessionID`, `needsAttention`, `lastReadAt`, `lastActivityAt`, `timestamp`) via the existing broadcaster on view/unview and attention transitions. `openchamber:session-status` is intentionally left untouched for live progress, since its forwarded-progress path hard-codes `needsAttention: false` and would race with read state.
- **Read receipts:** when a client marks a session viewed (opening it, window focus, or a completion that lands while the session is focused and visible), it POSTs the existing `/api/sessions/:id/view` endpoint — fire-and-forget with one retry, throttled per session (3s) to avoid bursts, and silently tolerated on older servers without the endpoint.
- **Remote apply without loops:** incoming attention events clear local notifications through a non-broadcasting reducer; the remote path can never trigger another receipt.
- **Timestamp guard:** only notifications with `time <= lastReadAt` are cleared, so a delayed read event cannot wipe a newer completion.
- **Hydration:** clients fetch `GET /api/sessions/attention` on startup, reconnect, and transport switches, reconciling conservatively (never fabricating unread).
- **Coalescing:** repeated attention events per session collapse in the client event pipeline.
- VS Code webview bridge answers `/view` & `/unview` with no-ops so the shared receipt path stays harmless in constrained runtimes.

## Validation

- `bun run type-check:ui` — pass
- `bun run lint:ui` — pass
- UI tests (`notification-store`, `event-pipeline`) — 7 pass / 0 fail, covering: server-clock cutoff clearing, remote apply sends no receipt (no feedback loop), viewed-at-append sends one throttled receipt, hydration reconciliation
- Server tests (`session-runtime`) — 3 pass, covering attention broadcasts on view and status transitions

## Notes / limitations

- Attention state remains in-memory on the server (existing 24h TTL); persistence across server restarts would be a follow-up.
- Client notification timestamps are client-clock based while `lastReadAt` is server-clock; large clock skew could delay clearing (conservative direction only — never over-clears).