### PR TITLE
fix(npm): honor configured registry for package metadata lookups (#2296)

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -52,6 +52,8 @@ Select code in the editor, right-click, and find the **OpenChamber** submenu:
 | `openchamber.apiUrl` | _(empty)_ | URL of an external OpenCode API server. Leave empty to auto-start a local instance. |
 | `openchamber.opencodeBinary` | _(empty)_ | Absolute path to the `opencode` CLI binary. Useful when PATH lookup fails. Requires window reload to apply. |
 
+npm metadata checks honor `npm_config_registry`, then `NPM_CONFIG_REGISTRY`, from the extension host environment.
+
 ## Requirements
 
 - [OpenCode CLI](https://opencode.ai) installed and available in PATH (or set `OPENCODE_BINARY` env var)

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -53,6 +53,8 @@ Select code in the editor, right-click, and find the **OpenChamber** submenu:
 | `openchamber.apiUrl` | _(empty)_ | URL of an external OpenCode API server. Leave empty to auto-start a local instance. |
 | `openchamber.opencodeBinary` | _(empty)_ | Absolute path to the `opencode` CLI binary. Useful when PATH lookup fails. Requires window reload to apply. |
 
+npm metadata checks honor `npm_config_registry`, then `NPM_CONFIG_REGISTRY`, from the extension host environment.
+
 ## Requirements
 
 - [OpenCode CLI](https://opencode.ai) installed and available in PATH (or set `OPENCODE_BINARY` env var)

--- a/packages/vscode/src/DOCUMENTATION.md
+++ b/packages/vscode/src/DOCUMENTATION.md
@@ -65,6 +65,9 @@ The webview CSP permits `blob:` only for `worker-src` so shared UI parsers can r
 - `opencode-upgrade-runtime.ts`
   - Owns managed-versus-external capability decisions, latest-version checks, serialized OpenCode self-upgrades, and restart-after-upgrade behavior.
 
+- `npm-registry.ts`
+  - Builds credential-safe npm metadata requests for configured registries, including scoped packages and registry base paths.
+
 - `bridge-permission-auto-accept-runtime.ts`
   - Owns the persisted VS Code permission auto-accept policy and its GET/PUT bridge contract.
   - Serializes reads and read-modify-write updates, persists a monotonic policy revision, and broadcasts the exact committed snapshot to every active OpenChamber webview. Permission replies remain foreground UI-owned because VS Code does not run the OpenChamber server runtime.

--- a/packages/vscode/src/DOCUMENTATION.md
+++ b/packages/vscode/src/DOCUMENTATION.md
@@ -88,6 +88,9 @@ The webview build emits each worker as one self-contained file. VS Code webviews
 - `opencode-upgrade-runtime.ts`
   - Owns managed-versus-external capability decisions, latest-version checks, serialized OpenCode self-upgrades, and restart-after-upgrade behavior.
 
+- `npm-registry.ts`
+  - Builds credential-safe npm metadata requests for configured registries, including scoped packages and registry base paths.
+
 - `bridge-permission-auto-accept-runtime.ts`
   - Owns the persisted VS Code permission auto-accept policy and its GET/PUT bridge contract.
   - Serializes reads and read-modify-write updates, persists a monotonic policy revision, and broadcasts the exact committed snapshot to every active OpenChamber webview. Permission replies remain foreground UI-owned because VS Code does not run the OpenChamber server runtime.

--- a/packages/vscode/src/npm-registry.test.ts
+++ b/packages/vscode/src/npm-registry.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveNpmRegistryRequest } from './npm-registry';
+
+const originalLowerRegistry = process.env.npm_config_registry;
+const originalUpperRegistry = process.env.NPM_CONFIG_REGISTRY;
+
+afterEach(() => {
+  if (originalLowerRegistry === undefined) delete process.env.npm_config_registry;
+  else process.env.npm_config_registry = originalLowerRegistry;
+  if (originalUpperRegistry === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+  else process.env.NPM_CONFIG_REGISTRY = originalUpperRegistry;
+});
+
+describe('VS Code npm registry requests', () => {
+  test('defaults to npm and encodes scoped names as one metadata path segment', () => {
+    delete process.env.npm_config_registry;
+    delete process.env.NPM_CONFIG_REGISTRY;
+    assert.deepEqual(resolveNpmRegistryRequest('@scope/pkg'), {
+      url: 'https://registry.npmjs.org/@scope%2Fpkg',
+      headers: {},
+    });
+  });
+
+  test('preserves base paths, trims slashes, and honors lowercase precedence', () => {
+    process.env.npm_config_registry = 'https://lower.example.com/custom/npm///';
+    process.env.NPM_CONFIG_REGISTRY = 'https://upper.example.com';
+    assert.equal(resolveNpmRegistryRequest('pkg', 'latest').url, 'https://lower.example.com/custom/npm/pkg/latest');
+  });
+
+  test('moves credentials to authorization without exposing them in the URL', () => {
+    delete process.env.npm_config_registry;
+    process.env.NPM_CONFIG_REGISTRY = 'https://test-user:test-password@mirror.example.com/npm/';
+    const request = resolveNpmRegistryRequest('@scope/pkg');
+
+    assert.equal(request.url, 'https://mirror.example.com/npm/@scope%2Fpkg');
+    assert.equal(request.url.includes('test-password'), false);
+    assert.deepEqual(request.headers, {
+      Authorization: `Basic ${Buffer.from('test-user:test-password').toString('base64')}`,
+    });
+  });
+});

--- a/packages/vscode/src/npm-registry.ts
+++ b/packages/vscode/src/npm-registry.ts
@@ -1,0 +1,36 @@
+const DEFAULT_NPM_REGISTRY_BASE = 'https://registry.npmjs.org';
+
+export const resolveNpmRegistryRequest = (
+  packageName: string,
+  metadataPath?: string,
+): { url: string; headers: Record<string, string> } => {
+  const configured = [process.env.npm_config_registry, process.env.NPM_CONFIG_REGISTRY]
+    .map((value) => value?.trim())
+    .find(Boolean) || DEFAULT_NPM_REGISTRY_BASE;
+  let registry: URL;
+  try {
+    registry = new URL(configured);
+    if (!['http:', 'https:'].includes(registry.protocol) || registry.search || registry.hash) throw new Error();
+  } catch {
+    throw new Error('Invalid npm registry URL');
+  }
+
+  let authorization: string | undefined;
+  try {
+    if (registry.username || registry.password) {
+      authorization = `Basic ${Buffer.from(`${decodeURIComponent(registry.username)}:${decodeURIComponent(registry.password)}`).toString('base64')}`;
+    }
+  } catch {
+    throw new Error('Invalid npm registry URL');
+  }
+  registry.username = '';
+  registry.password = '';
+  registry.pathname = `${registry.pathname.replace(/\/+$/, '')}/`;
+
+  const encodedName = encodeURIComponent(packageName).replace(/^%40/i, '@');
+  const suffix = metadataPath ? `/${encodeURIComponent(metadataPath)}` : '';
+  return {
+    url: `${registry.toString()}${encodedName}${suffix}`,
+    headers: authorization ? { Authorization: authorization } : {},
+  };
+};

--- a/packages/vscode/src/opencode-upgrade-runtime.test.ts
+++ b/packages/vscode/src/opencode-upgrade-runtime.test.ts
@@ -3,9 +3,15 @@ import assert from 'node:assert/strict';
 import { getOpenCodeUpgradeStatus, upgradeManagedOpenCode, type OpenCodeUpgradeManager } from './opencode-upgrade-runtime';
 
 const originalFetch = globalThis.fetch;
+const originalLowerRegistry = process.env.npm_config_registry;
+const originalRegistry = process.env.NPM_CONFIG_REGISTRY;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  if (originalLowerRegistry === undefined) delete process.env.npm_config_registry;
+  else process.env.npm_config_registry = originalLowerRegistry;
+  if (originalRegistry === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+  else process.env.NPM_CONFIG_REGISTRY = originalRegistry;
 });
 
 const createManager = (mode: 'managed' | 'external' = 'managed') => {
@@ -35,6 +41,48 @@ describe('VS Code OpenCode upgrades', () => {
       latestVersion: '1.18.9',
       upgrade: { supported: true, manager: 'opencode', reason: null },
     });
+  });
+
+  test('uses authenticated registry metadata without exposing credentials', async () => {
+    const { manager } = createManager();
+    process.env.npm_config_registry = '';
+    process.env.NPM_CONFIG_REGISTRY = 'https://test-user:test-password@mirror.example.com/npm/';
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const url = String(input);
+      calls.push([url, init]);
+      if (url.endsWith('/global/health')) return new Response(JSON.stringify({ version: '1.18.8' }));
+      if (url.includes('mirror.example.com')) return new Response(JSON.stringify({ version: '1.18.9' }));
+      return new Response(JSON.stringify({ tag_name: 'v1.18.9' }));
+    }) as typeof fetch;
+
+    await getOpenCodeUpgradeStatus(manager);
+    const npmCall = calls.find(([url]) => url.includes('mirror.example.com'));
+
+    assert.equal(npmCall?.[0], 'https://mirror.example.com/npm/opencode-ai/latest');
+    assert.equal(npmCall?.[0].includes('test-password'), false);
+    assert.equal((npmCall?.[1]?.headers as Record<string, string>).Authorization, `Basic ${Buffer.from('test-user:test-password').toString('base64')}`);
+  });
+
+  test('falls back to GitHub when the configured registry URL is invalid', async () => {
+    const { manager } = createManager();
+    process.env.npm_config_registry = '';
+    process.env.NPM_CONFIG_REGISTRY = 'not-a-url';
+    const calls: string[] = [];
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith('/global/health')) return new Response(JSON.stringify({ version: '1.18.8' }));
+      return new Response(JSON.stringify({ tag_name: 'v1.18.9' }));
+    }) as typeof fetch;
+
+    assert.deepEqual(await getOpenCodeUpgradeStatus(manager), {
+      available: true,
+      currentVersion: '1.18.8',
+      latestVersion: '1.18.9',
+      upgrade: { supported: true, manager: 'opencode', reason: null },
+    });
+    assert.equal(calls.includes('https://api.github.com/repos/anomalyco/opencode/releases/latest'), true);
   });
 
   test('fails closed for externally managed OpenCode without contacting the updater', async () => {

--- a/packages/vscode/src/opencode-upgrade-runtime.ts
+++ b/packages/vscode/src/opencode-upgrade-runtime.ts
@@ -1,3 +1,5 @@
+import { resolveNpmRegistryRequest } from './npm-registry';
+
 type UpgradeCapability = {
   supported: boolean;
   manager: 'opencode' | 'external' | 'openchamber' | null;
@@ -59,12 +61,13 @@ const getApiUrl = (manager?: OpenCodeUpgradeManager): string | null => {
 
 const fetchLatestVersion = async (): Promise<string> => {
   const results = await Promise.allSettled([
-    fetch('https://registry.npmjs.org/opencode-ai/latest', { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(10_000) })
-      .then(async (response) => {
-        if (!response.ok) throw new Error(`OpenCode npm registry responded with ${response.status}`);
-        const payload = await response.json() as { version?: unknown };
-        return typeof payload.version === 'string' ? payload.version.trim().replace(/^v/, '') : '';
-      }),
+    (async () => {
+      const npmRequest = resolveNpmRegistryRequest('opencode-ai', 'latest');
+      const response = await fetch(npmRequest.url, { headers: { Accept: 'application/json', ...npmRequest.headers }, signal: AbortSignal.timeout(10_000) });
+      if (!response.ok) throw new Error(`OpenCode npm registry responded with ${response.status}`);
+      const payload = await response.json() as { version?: unknown };
+      return typeof payload.version === 'string' ? payload.version.trim().replace(/^v/, '') : '';
+    })(),
     fetch('https://api.github.com/repos/anomalyco/opencode/releases/latest', { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(10_000) })
       .then(async (response) => {
         if (!response.ok) throw new Error(`OpenCode releases responded with ${response.status}`);

--- a/packages/vscode/src/opencodeConfig-npm-registry.test.ts
+++ b/packages/vscode/src/opencodeConfig-npm-registry.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { queryPluginRegistry } from './opencodeConfig';
+
+const originalFetch = globalThis.fetch;
+const originalLowerRegistry = process.env.npm_config_registry;
+const originalRegistry = process.env.NPM_CONFIG_REGISTRY;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalLowerRegistry === undefined) delete process.env.npm_config_registry;
+  else process.env.npm_config_registry = originalLowerRegistry;
+  if (originalRegistry === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+  else process.env.NPM_CONFIG_REGISTRY = originalRegistry;
+});
+
+test('plugin metadata uses a credential-safe scoped registry request', async () => {
+  process.env.npm_config_registry = '';
+  process.env.NPM_CONFIG_REGISTRY = 'https://test-user:test-password@mirror.example.com/custom/npm/';
+  let requestUrl = '';
+  let requestInit: RequestInit | undefined;
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    requestUrl = String(input);
+    requestInit = init;
+    return new Response(JSON.stringify({
+      'dist-tags': { latest: '1.2.3' },
+      versions: { '1.2.3': {} },
+    }));
+  }) as typeof fetch;
+
+  const response = await queryPluginRegistry(['@scope/credential-test']);
+
+  assert.equal(response.results[0]?.kind, 'npm-ok');
+  assert.equal(requestUrl, 'https://mirror.example.com/custom/npm/@scope%2Fcredential-test');
+  assert.equal(requestUrl.includes('test-password'), false);
+  assert.equal((requestInit?.headers as Record<string, string>).Authorization, `Basic ${Buffer.from('test-user:test-password').toString('base64')}`);
+});

--- a/packages/vscode/src/opencodeConfig.ts
+++ b/packages/vscode/src/opencodeConfig.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import os from 'node:os';
 import yaml from 'yaml';
 import { parse as parseJsonc } from 'jsonc-parser';
+import { resolveNpmRegistryRequest } from './npm-registry';
 
 const OPENCODE_CONFIG_DIR = path.join(os.homedir(), '.config', 'opencode');
 const AGENT_DIR = path.join(OPENCODE_CONFIG_DIR, 'agents');
@@ -1064,8 +1065,9 @@ const NPM_CACHE_TTL_MS = 3_600_000;
 
 const lookupNpmPackage = async (name: string): Promise<NpmLookupResult> => {
   try {
-    const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name).replace(/^%40/, '@')}`, {
-      headers: { Accept: 'application/json', 'User-Agent': 'openchamber-vscode/dev' },
+    const request = resolveNpmRegistryRequest(name);
+    const response = await fetch(request.url, {
+      headers: { Accept: 'application/json', 'User-Agent': 'openchamber-vscode/dev', ...request.headers },
       signal: AbortSignal.timeout(5000),
     });
     if (response.ok) {

--- a/packages/vscode/src/opencodeConfig.ts
+++ b/packages/vscode/src/opencodeConfig.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import yaml from 'yaml';
 import { parse as parseJsonc, printParseErrorCode, type ParseError } from 'jsonc-parser';
+import { resolveNpmRegistryRequest } from './npm-registry';
 
 const AGENT_DIR = path.join(OPENCODE_CONFIG_DIR, 'agents');
 const COMMAND_DIR = path.join(OPENCODE_CONFIG_DIR, 'commands');
@@ -1133,8 +1134,9 @@ const NPM_CACHE_TTL_MS = 3_600_000;
 
 const lookupNpmPackage = async (name: string): Promise<NpmLookupResult> => {
   try {
-    const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name).replace(/^%40/, '@')}`, {
-      headers: { Accept: 'application/json', 'User-Agent': 'openchamber-vscode/dev' },
+    const request = resolveNpmRegistryRequest(name);
+    const response = await fetch(request.url, {
+      headers: { Accept: 'application/json', 'User-Agent': 'openchamber-vscode/dev', ...request.headers },
       signal: AbortSignal.timeout(5000),
     });
     if (response.ok) {

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -116,6 +116,7 @@ OPENCODE_HOST=https://myhost:4096 OPENCODE_SKIP_START=true openchamber
 | `OPENCHAMBER_SKIP_API_COMPRESSION` | Set to `true` to disable gzip compression for `/api/*` responses |
 | `OPENCHAMBER_COMPRESS_API` | Set to `true` to force `/api/*` compression, or `false` to disable it. Desktop runtime disables API compression by default to reduce local sidecar CPU use |
 | `OPENCHAMBER_TERMINAL_SHELL` | Preferred terminal shell executable used by the `Auto` setting before platform defaults |
+| `npm_config_registry` / `NPM_CONFIG_REGISTRY` | Registry used for npm metadata checks. The lowercase value takes precedence when both are set. |
 
 </details>
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -117,6 +117,7 @@ OPENCODE_HOST=https://myhost:4096 OPENCODE_SKIP_START=true openchamber
 | `OPENCHAMBER_COMPRESS_API` | Set to `true` to force `/api/*` compression, or `false` to disable it. Desktop runtime disables API compression by default to reduce local sidecar CPU use |
 | `OPENCHAMBER_FS_UPLOAD_MAX_BYTES` | Maximum file upload size in bytes (default: 100 MiB) |
 | `OPENCHAMBER_TERMINAL_SHELL` | Preferred terminal shell executable used by the `Auto` setting before platform defaults |
+| `npm_config_registry` / `NPM_CONFIG_REGISTRY` | Registry used for npm metadata checks. The lowercase value takes precedence when both are set. |
 
 </details>
 

--- a/packages/web/server/lib/npm-registry-config.js
+++ b/packages/web/server/lib/npm-registry-config.js
@@ -1,0 +1,38 @@
+const DEFAULT_NPM_REGISTRY_BASE = 'https://registry.npmjs.org';
+
+/**
+ * @param {string} packageName
+ * @param {string} [metadataPath]
+ * @returns {{ url: string, headers: Record<string, string> }}
+ */
+export function resolveNpmRegistryRequest(packageName, metadataPath) {
+  const configured = [process.env.npm_config_registry, process.env.NPM_CONFIG_REGISTRY]
+    .map((value) => value?.trim())
+    .find(Boolean) || DEFAULT_NPM_REGISTRY_BASE;
+  let registry;
+  try {
+    registry = new URL(configured);
+    if (!['http:', 'https:'].includes(registry.protocol) || registry.search || registry.hash) throw new Error();
+  } catch {
+    throw new Error('Invalid npm registry URL');
+  }
+
+  let authorization;
+  try {
+    if (registry.username || registry.password) {
+      authorization = `Basic ${Buffer.from(`${decodeURIComponent(registry.username)}:${decodeURIComponent(registry.password)}`).toString('base64')}`;
+    }
+  } catch {
+    throw new Error('Invalid npm registry URL');
+  }
+  registry.username = '';
+  registry.password = '';
+  registry.pathname = `${registry.pathname.replace(/\/+$/, '')}/`;
+
+  const encodedName = encodeURIComponent(packageName).replace(/^%40/i, '@');
+  const suffix = metadataPath ? `/${encodeURIComponent(metadataPath)}` : '';
+  return {
+    url: `${registry.toString()}${encodedName}${suffix}`,
+    headers: authorization ? { Authorization: authorization } : {},
+  };
+}

--- a/packages/web/server/lib/npm-registry-config.test.js
+++ b/packages/web/server/lib/npm-registry-config.test.js
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveNpmRegistryRequest } from './npm-registry-config.js';
+
+describe('resolveNpmRegistryRequest', () => {
+  let savedLower;
+  let savedUpper;
+
+  beforeEach(() => {
+    savedLower = process.env.npm_config_registry;
+    savedUpper = process.env.NPM_CONFIG_REGISTRY;
+    delete process.env.npm_config_registry;
+    delete process.env.NPM_CONFIG_REGISTRY;
+  });
+
+  afterEach(() => {
+    if (savedLower === undefined) delete process.env.npm_config_registry;
+    else process.env.npm_config_registry = savedLower;
+    if (savedUpper === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+    else process.env.NPM_CONFIG_REGISTRY = savedUpper;
+  });
+
+  it('defaults to the public npm registry when nothing is configured', () => {
+    expect(resolveNpmRegistryRequest('pkg')).toEqual({
+      url: 'https://registry.npmjs.org/pkg',
+      headers: {},
+    });
+  });
+
+  it('preserves base paths and trims trailing slashes', () => {
+    process.env.NPM_CONFIG_REGISTRY = 'https://mirror.example.com/custom/npm///';
+    expect(resolveNpmRegistryRequest('pkg', 'latest').url).toBe('https://mirror.example.com/custom/npm/pkg/latest');
+  });
+
+  it('prefers npm_config_registry over NPM_CONFIG_REGISTRY', () => {
+    process.env.npm_config_registry = 'https://lower.example.com';
+    process.env.NPM_CONFIG_REGISTRY = 'https://upper.example.com';
+    expect(resolveNpmRegistryRequest('pkg').url).toBe('https://lower.example.com/pkg');
+  });
+
+  it('uses the uppercase value when the lowercase value is blank', () => {
+    process.env.npm_config_registry = '   ';
+    process.env.NPM_CONFIG_REGISTRY = 'https://upper.example.com/npm';
+    expect(resolveNpmRegistryRequest('pkg').url).toBe('https://upper.example.com/npm/pkg');
+  });
+
+  it('falls back to the default for a blank configured value', () => {
+    process.env.NPM_CONFIG_REGISTRY = '   ';
+    expect(resolveNpmRegistryRequest('pkg').url).toBe('https://registry.npmjs.org/pkg');
+  });
+
+  it('encodes scoped names as one metadata path segment', () => {
+    process.env.NPM_CONFIG_REGISTRY = 'https://mirror.example.com/npm/';
+    expect(resolveNpmRegistryRequest('@scope/pkg').url).toBe('https://mirror.example.com/npm/@scope%2Fpkg');
+  });
+
+  it('moves URL credentials to authorization without exposing them in the request URL', () => {
+    process.env.NPM_CONFIG_REGISTRY = 'https://test-user:test-password@mirror.example.com/npm/';
+
+    const request = resolveNpmRegistryRequest('@scope/pkg');
+
+    expect(request.url).toBe('https://mirror.example.com/npm/@scope%2Fpkg');
+    expect(request.url).not.toContain('test-user');
+    expect(request.url).not.toContain('test-password');
+    expect(request.headers).toEqual({
+      Authorization: `Basic ${Buffer.from('test-user:test-password').toString('base64')}`,
+    });
+  });
+
+  it('rejects invalid registry URLs without including their value in the error', () => {
+    process.env.NPM_CONFIG_REGISTRY = 'not-a-url-test-password';
+
+    expect(() => resolveNpmRegistryRequest('pkg')).toThrow('Invalid npm registry URL');
+    try {
+      resolveNpmRegistryRequest('pkg');
+    } catch (error) {
+      expect(String(error)).not.toContain('test-password');
+    }
+  });
+});

--- a/packages/web/server/lib/opencode/npm-registry.js
+++ b/packages/web/server/lib/opencode/npm-registry.js
@@ -2,9 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { resolveNpmRegistryRequest } from '../npm-registry-config.js';
+
 const NPM_CACHE_TTL_MS = 3_600_000;
 const NPM_FETCH_TIMEOUT_MS = 5_000;
-const NPM_REGISTRY_BASE = 'https://registry.npmjs.org';
 
 /**
  * @typedef {Object} NpmPackagePayload
@@ -50,10 +51,6 @@ function _getUserAgent() {
   return _userAgent;
 }
 
-function encodeName(name) {
-  return encodeURIComponent(name).replace(/^%40/, '@');
-}
-
 function parseDistTags(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return {};
@@ -87,10 +84,12 @@ function cacheResult(name, payload) {
  */
 export async function lookupNpmPackage(name) {
   try {
-    const response = await fetch(`${NPM_REGISTRY_BASE}/${encodeName(name)}`, {
+    const request = resolveNpmRegistryRequest(name);
+    const response = await fetch(request.url, {
       headers: {
         'User-Agent': _getUserAgent(),
         Accept: 'application/json',
+        ...request.headers,
       },
       signal: AbortSignal.timeout(NPM_FETCH_TIMEOUT_MS),
     });

--- a/packages/web/server/lib/opencode/npm-registry.test.js
+++ b/packages/web/server/lib/opencode/npm-registry.test.js
@@ -171,6 +171,43 @@ describe('npm registry client', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('https://registry.npmjs.org/@scope%2Fpkg');
   });
 
+  test('configured registry base is used and trailing-slash trimmed', async () => {
+    const previousLower = process.env.npm_config_registry;
+    const previous = process.env.NPM_CONFIG_REGISTRY;
+    process.env.npm_config_registry = '';
+    process.env.NPM_CONFIG_REGISTRY = 'https://mirror.example.com/npm/';
+    try {
+      await npm.getNpmInfo('@scope/pkg');
+
+      expect(fetchMock.mock.calls[0][0]).toBe('https://mirror.example.com/npm/@scope%2Fpkg');
+    } finally {
+      if (previousLower === undefined) delete process.env.npm_config_registry;
+      else process.env.npm_config_registry = previousLower;
+      if (previous === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+      else process.env.NPM_CONFIG_REGISTRY = previous;
+    }
+  });
+
+  test('authenticated registry URLs are redacted and sent with authorization', async () => {
+    const previousLower = process.env.npm_config_registry;
+    const previous = process.env.NPM_CONFIG_REGISTRY;
+    process.env.npm_config_registry = '';
+    process.env.NPM_CONFIG_REGISTRY = 'https://test-user:test-password@mirror.example.com/npm/';
+    try {
+      await npm.getNpmInfo('@scope/private-pkg');
+
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://mirror.example.com/npm/@scope%2Fprivate-pkg');
+      expect(String(url)).not.toContain('test-password');
+      expect(options.headers.Authorization).toBe(`Basic ${Buffer.from('test-user:test-password').toString('base64')}`);
+    } finally {
+      if (previousLower === undefined) delete process.env.npm_config_registry;
+      else process.env.npm_config_registry = previousLower;
+      if (previous === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+      else process.env.NPM_CONFIG_REGISTRY = previous;
+    }
+  });
+
   test('user-agent header is present', async () => {
     await npm.getNpmInfo('foo');
 

--- a/packages/web/server/lib/opencode/routes-upgrade.test.js
+++ b/packages/web/server/lib/opencode/routes-upgrade.test.js
@@ -67,15 +67,52 @@ describe('OpenCode upgrade routes', () => {
     });
   });
 
+  it('checks authenticated registry metadata without exposing credentials', async () => {
+    const previousLower = process.env.npm_config_registry;
+    const previous = process.env.NPM_CONFIG_REGISTRY;
+    process.env.npm_config_registry = '';
+    process.env.NPM_CONFIG_REGISTRY = 'https://test-user:test-password@mirror.example.com/npm/';
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/global/health')) return new Response(JSON.stringify({ version: '1.18.8' }));
+      if (url.includes('mirror.example.com')) return new Response(JSON.stringify({ version: '1.18.9' }));
+      return new Response(JSON.stringify({ tag_name: 'v1.18.9' }));
+    });
+    const { app } = createApp({
+      getOpenCodeUpgradeCapability: () => ({ supported: true, manager: 'opencode', reason: null }),
+    });
+
+    try {
+      await request(app).get('/api/opencode/upgrade-status').expect(200);
+      const npmCall = globalThis.fetch.mock.calls.find(([input]) => String(input).includes('mirror.example.com'));
+
+      expect(npmCall[0]).toBe('https://mirror.example.com/npm/opencode-ai/latest');
+      expect(npmCall[0]).not.toContain('test-password');
+      expect(npmCall[1].headers.Authorization).toBe(`Basic ${Buffer.from('test-user:test-password').toString('base64')}`);
+    } finally {
+      if (previousLower === undefined) delete process.env.npm_config_registry;
+      else process.env.npm_config_registry = previousLower;
+      if (previous === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+      else process.env.NPM_CONFIG_REGISTRY = previous;
+    }
+  });
+
   it('serializes supported upgrades and preserves the in-flight lock', async () => {
     let releaseUpgrade;
+    let signalUpgradeStarted;
+    const upgradeStarted = new Promise((resolve) => {
+      signalUpgradeStarted = resolve;
+    });
     const upstreamResponse = new Promise((resolve) => {
       releaseUpgrade = () => resolve(new Response(JSON.stringify({ success: true, version: '1.18.9' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }));
     });
-    globalThis.fetch = vi.fn(() => upstreamResponse);
+    globalThis.fetch = vi.fn(() => {
+      signalUpgradeStarted();
+      return upstreamResponse;
+    });
     const { app, dependencies } = createApp({
       getOpenCodeUpgradeCapability: () => ({
         supported: true,
@@ -93,9 +130,8 @@ describe('OpenCode upgrade routes', () => {
         restarted: true,
       })
       .then((response) => response);
-    await vi.waitFor(() => {
-      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    });
+    await upgradeStarted;
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
     await request(app)
       .post('/api/opencode/upgrade')

--- a/packages/web/server/lib/opencode/routes-upgrade.test.js
+++ b/packages/web/server/lib/opencode/routes-upgrade.test.js
@@ -74,6 +74,34 @@ describe('OpenCode upgrade routes', () => {
     });
   });
 
+  it('checks authenticated registry metadata without exposing credentials', async () => {
+    const previousLower = process.env.npm_config_registry;
+    const previous = process.env.NPM_CONFIG_REGISTRY;
+    process.env.npm_config_registry = '';
+    process.env.NPM_CONFIG_REGISTRY = 'https://test-user:test-password@mirror.example.com/npm/';
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/global/health')) return jsonResponse({ version: '1.18.8' });
+      if (url.includes('mirror.example.com')) return jsonResponse({ version: '1.18.9' });
+      return jsonResponse({ tag_name: 'v1.18.9' });
+    });
+    const { app } = createApp({ getOpenCodeUpgradeCapability: () => supportedCapability });
+
+    try {
+      await request(app).get('/api/opencode/upgrade-status').expect(200);
+      const npmCall = globalThis.fetch.mock.calls.find(([input]) => String(input).includes('mirror.example.com'));
+
+      expect(npmCall[0]).toBe('https://mirror.example.com/npm/opencode-ai/latest');
+      expect(npmCall[0]).not.toContain('test-password');
+      expect(npmCall[1].headers.Authorization).toBe(`Basic ${Buffer.from('test-user:test-password').toString('base64')}`);
+    } finally {
+      if (previousLower === undefined) delete process.env.npm_config_registry;
+      else process.env.npm_config_registry = previousLower;
+      if (previous === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+      else process.env.NPM_CONFIG_REGISTRY = previous;
+    }
+  });
+
   it('names the latest release as the upgrade target when the caller sends none', async () => {
     const requests = [];
     globalThis.fetch = vi.fn(async (url, init) => {

--- a/packages/web/server/lib/opencode/routes.js
+++ b/packages/web/server/lib/opencode/routes.js
@@ -1,4 +1,5 @@
 import { createProjectIdFromPath } from '../projects/project-id.js';
+import { resolveNpmRegistryRequest } from '../npm-registry-config.js';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -92,8 +93,9 @@ export const registerOpenCodeRoutes = (app, dependencies) => {
   };
 
   const fetchLatestOpenCodeVersionFromNpm = async () => {
-    const response = await fetch('https://registry.npmjs.org/opencode-ai/latest', {
-      headers: { Accept: 'application/json' },
+    const request = resolveNpmRegistryRequest('opencode-ai', 'latest');
+    const response = await fetch(request.url, {
+      headers: { Accept: 'application/json', ...request.headers },
       signal: AbortSignal.timeout(10_000),
     });
     if (!response.ok) {

--- a/packages/web/server/lib/opencode/routes.js
+++ b/packages/web/server/lib/opencode/routes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { createProjectIdFromPath } from '../projects/project-id.js';
+import { resolveNpmRegistryRequest } from '../npm-registry-config.js';
 import fs from 'fs';
 import path from 'path';
 import {
@@ -139,8 +140,9 @@ ${desktopReturn ? `<a class="return" href="openchamber://focus/mcp-auth">Return 
   };
 
   const fetchLatestOpenCodeVersionFromNpm = async () => {
-    const response = await fetch('https://registry.npmjs.org/opencode-ai/latest', {
-      headers: { Accept: 'application/json' },
+    const request = resolveNpmRegistryRequest('opencode-ai', 'latest');
+    const response = await fetch(request.url, {
+      headers: { Accept: 'application/json', ...request.headers },
       signal: AbortSignal.timeout(10_000),
     });
     if (!response.ok) {

--- a/packages/web/server/lib/package-manager.js
+++ b/packages/web/server/lib/package-manager.js
@@ -5,12 +5,13 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { resolveNpmRegistryRequest } from './npm-registry-config.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const PACKAGE_NAME = '@openchamber/web';
 const PACKAGE_PATH_SEGMENTS = PACKAGE_NAME.split('/');
-const NPM_REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}`;
 const CHANGELOG_URL = 'https://raw.githubusercontent.com/openchamber/openchamber/main/CHANGELOG.md';
 const GITHUB_RELEASES_URL = 'https://github.com/openchamber/openchamber/releases';
 const GITHUB_RELEASES_API_URL = 'https://api.github.com/repos/openchamber/openchamber/releases';
@@ -686,8 +687,9 @@ export function getCurrentVersion() {
  */
 async function getLatestVersion() {
   try {
-    const response = await fetch(NPM_REGISTRY_URL, {
-      headers: { Accept: 'application/json' },
+    const request = resolveNpmRegistryRequest(PACKAGE_NAME);
+    const response = await fetch(request.url, {
+      headers: { Accept: 'application/json', ...request.headers },
       signal: AbortSignal.timeout(10000),
     });
 

--- a/packages/web/server/lib/package-manager.js
+++ b/packages/web/server/lib/package-manager.js
@@ -6,12 +6,13 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { fetchUpdateNotes } from './changelog/update-notes.js';
 
+import { resolveNpmRegistryRequest } from './npm-registry-config.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const PACKAGE_NAME = '@openchamber/web';
 const PACKAGE_PATH_SEGMENTS = PACKAGE_NAME.split('/');
-const NPM_REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}`;
 const GITHUB_RELEASES_URL = 'https://github.com/openchamber/openchamber/releases';
 const GITHUB_RELEASES_API_URL = 'https://api.github.com/repos/openchamber/openchamber/releases';
 let cachedDetectedPm = null;
@@ -686,8 +687,9 @@ export function getCurrentVersion() {
  */
 async function getLatestVersion() {
   try {
-    const response = await fetch(NPM_REGISTRY_URL, {
-      headers: { Accept: 'application/json' },
+    const request = resolveNpmRegistryRequest(PACKAGE_NAME);
+    const response = await fetch(request.url, {
+      headers: { Accept: 'application/json', ...request.headers },
       signal: AbortSignal.timeout(10000),
     });
 

--- a/packages/web/server/lib/package-manager.test.js
+++ b/packages/web/server/lib/package-manager.test.js
@@ -81,6 +81,82 @@ describe('checkForUpdates', () => {
     expect(result.currentVersion).toBe('1.9.10');
   });
 
+  // --- Scenario: cross-verification uses the configured npm registry ---
+
+  it('cross-verifies against the configured npm registry, not registry.npmjs.org', async () => {
+    const previousLower = process.env.npm_config_registry;
+    const previous = process.env.NPM_CONFIG_REGISTRY;
+    process.env.npm_config_registry = '';
+    process.env.NPM_CONFIG_REGISTRY = 'https://mirror.example.com/npm';
+    // Only the mirror is mocked. A stray call to registry.npmjs.org would reject,
+    // drop npm cross-verification, and flip available to false.
+    fetchMock
+      .when('api.openchamber.dev', {
+        ok: true,
+        json: async () => ({
+          latestVersion: '1.10.0',
+          updateAvailable: true,
+          releaseNotes: '## [1.10.0]\n\n- New',
+        }),
+      })
+      .when('mirror.example.com/npm/@openchamber%2Fweb', {
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.10.0' },
+        }),
+      })
+      .when('raw.githubusercontent.com', {
+        ok: true,
+        text: async () => '## [1.10.0]\n\n- New',
+      });
+
+    try {
+      const result = await checkForUpdates({ currentVersion: '1.9.10' });
+
+      expect(result.available).toBe(true);
+      expect(result.version).toBe('1.10.0');
+      expect(
+        fetchMock.mock.calls.some(([url]) => String(url) === 'https://mirror.example.com/npm/@openchamber%2Fweb'),
+      ).toBe(true);
+    } finally {
+      if (previousLower === undefined) delete process.env.npm_config_registry;
+      else process.env.npm_config_registry = previousLower;
+      if (previous === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+      else process.env.NPM_CONFIG_REGISTRY = previous;
+    }
+  });
+
+  it('cross-verifies scoped metadata without exposing registry credentials', async () => {
+    const previousLower = process.env.npm_config_registry;
+    const previous = process.env.NPM_CONFIG_REGISTRY;
+    process.env.npm_config_registry = '';
+    process.env.NPM_CONFIG_REGISTRY = 'https://test-user:test-password@mirror.example.com/npm/';
+    fetchMock
+      .when('api.openchamber.dev', {
+        ok: true,
+        json: async () => ({ latestVersion: '1.10.0', updateAvailable: true }),
+      })
+      .when('mirror.example.com/npm/@openchamber%2Fweb', {
+        ok: true,
+        json: async () => ({ 'dist-tags': { latest: '1.10.0' } }),
+      });
+
+    try {
+      const result = await checkForUpdates({ currentVersion: '1.9.10' });
+      const npmCall = fetchMock.mock.calls.find(([url]) => String(url).includes('mirror.example.com'));
+
+      expect(result.available).toBe(true);
+      expect(npmCall[0]).toBe('https://mirror.example.com/npm/@openchamber%2Fweb');
+      expect(npmCall[0]).not.toContain('test-password');
+      expect(npmCall[1].headers.Authorization).toBe(`Basic ${Buffer.from('test-user:test-password').toString('base64')}`);
+    } finally {
+      if (previousLower === undefined) delete process.env.npm_config_registry;
+      else process.env.npm_config_registry = previousLower;
+      if (previous === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+      else process.env.NPM_CONFIG_REGISTRY = previous;
+    }
+  });
+
   // --- Scenario (THE FIX): API says update available, npm does NOT have it ---
 
   it('returns available=false when API claims update but npm has same version', async () => {


### PR DESCRIPTION
> Validated commit: `1b86716c6cd1eafbff43584081f0e1956406f129`.

## Intent

Refs #2296. Web-server and VS Code npm metadata requests now resolve `npm_config_registry`/`NPM_CONFIG_REGISTRY` instead of hardcoding `https://registry.npmjs.org`, including registries mounted under a path and scoped package names.

`Refs` and not `Fixes`: npm exports those variables only to processes it launches (`npm run`, `npm exec`, `npx`). The Windows desktop app, the VS Code extension host, and a globally installed `openchamber` binary all start outside npm and still reach the default registry, so #2296 still reproduces for the reporter and must not be auto-closed by merging this.

Credentials embedded in the configured URL are moved into an `Authorization: Basic` header because a credentialed `registry=` URL is otherwise unusable: Node's `fetch` refuses to construct the request (`Request cannot be constructed from a URL that includes credentials`) and Bun sends the request with no `Authorization` header at all. Keeping credentials out of logged URLs and error text is a secondary benefit.

## Non-goals

No `.npmrc` parsing, and no scoped-registry (`@scope:registry`) support. Verified with a real `npm run`: given an `.npmrc` containing `@myscope:registry` and `//host/:_authToken`, npm exports only `npm_config_registry` to the child process, so scoped and token-authenticated setups still fall through to the default registry. No auth scheme other than Basic credentials taken from the configured URL.

## Affected surfaces

- Web: plugin metadata validation, `@openchamber/web` update checks, OpenCode update checks.
- VS Code: plugin metadata validation and OpenCode update checks.

No UI, persisted-data, or HTTP response-shape changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Adds a runtime helper to two packages | Each runtime owns its resolver with direct wiring tests; the duplication is required because `packages/vscode` has no dependency on `packages/web` and the helper is Node-only (`process.env`, `Buffer`) so it cannot live in `@openchamber/ui`. |
| `ui-api-decoupling` | Server and extension-host outbound requests changed | Registry access stays inside each owning runtime; shared UI keeps consuming unchanged metadata responses. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/vscode/src/npm-registry.test.ts packages/vscode/src/opencode-upgrade-runtime.test.ts packages/vscode/src/opencodeConfig-npm-registry.test.ts` | 10 passed, 0 failed. |
| `bunx vitest run server/lib/npm-registry-config.test.js server/lib/opencode/npm-registry.test.js server/lib/opencode/routes-upgrade.test.js server/lib/package-manager.test.js` in `packages/web` | 4 files, 44 passed, 0 failed. |
| `bun run type-check:web`, `bun run lint:web`, `bun run vscode:type-check` | Exit 0 each. Coverage caveat: `packages/web/tsconfig.json` includes only `src` and `../ui/src`, and `lint:web` globs only `./src/**/*.{ts,tsx}`, so the new `server/lib/npm-registry-config.js` is covered by vitest alone — neither type-check nor lint reads it. |

Not verified: no request was sent to a real authenticated private registry.

## Visual evidence

No rendered UI change; no component, style, or layout is touched. The observable behavioral consequence is on a configured mirror: plugin validation now reports that mirror's `Registry returned 401` or `Package not found` instead of silently answering from the public registry, and a failed update lookup returns `null`, so the update banner stays hidden rather than advertising a public-registry version.

## Risks and failure behavior

Only `http:`/`https:` registries without a query string or fragment are accepted; anything else throws `Invalid npm registry URL`, which carries no credential text. Package name and metadata suffix are encoded independently, so a scoped name keeps its leading `@`.

The current `review:blocked` finding is factually wrong and should not gate this PR. It claims `decodeURIComponent` on `URL.password` corrupts credentials. The `URL.username`/`URL.password` getters return percent-**encoded** values, so decoding is required: for `https://user:p%40ss@host/` the getter yields `p%40ss` and decoding yields the correct `p@ss`, identical under Node 24.15.0 and Bun 1.3.14. The suggested `Buffer.from(\`${username}:${password}\`)` would send `Basic base64('user:p%40ss')` and break every credential containing a reserved character.
