### PR TITLE
feat(attachments): ground model-unsupported attachments to workspace uploads/ instead of failing the send

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
     },
     "packages/electron": {
       "name": "@openchamber/electron",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "dependencies": {
         "@openchamber/web": "workspace:*",
         "electron-context-menu": "^4.1.2",
@@ -133,7 +133,7 @@
     },
     "packages/ui": {
       "name": "@openchamber/ui",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@base-ui/react": "^1.4.0",
@@ -237,7 +237,7 @@
     },
     "packages/vscode": {
       "name": "openchamber",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "dependencies": {
         "@openchamber/ui": "workspace:*",
         "@opencode-ai/sdk": "1.18.3",
@@ -260,7 +260,7 @@
     },
     "packages/web": {
       "name": "@openchamber/web",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "bin": {
         "openchamber": "./bin/cli.js",
       },
@@ -347,6 +347,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "electron",
+  ],
   "patchedDependencies": {
     "@tanstack/virtual-core@3.17.3": "bun-patches/@tanstack+virtual-core+3.17.3.patch",
   },

--- a/packages/ui/src/lib/attachments/attachmentGrounding.test.ts
+++ b/packages/ui/src/lib/attachments/attachmentGrounding.test.ts
@@ -117,6 +117,14 @@ describe('groundAttachmentsForModel', () => {
     expect(result.hints).toHaveLength(0);
   });
 
+  test('image hint tells the agent to suggest a vision-capable model', async () => {
+    const img = { type: 'file' as const, mime: 'image/png', url: 'data:image/png;base64,aGk=', filename: 'photo.png' };
+    const result = await groundAttachmentsForModel({ files: [img], providerID: 'p', modelID: 'textonly', directory: '/repo' });
+    expect(result.hints).toHaveLength(1);
+    expect(result.hints[0]).toContain('vision-capable model');
+    expect(result.hints[0]).not.toContain('e.g. Python');
+  });
+
   test('file:// attachments produce an on-disk hint without uploading', async () => {
     const sheet = { type: 'file' as const, mime: xlsxMime, url: 'file:///repo/data/report.xlsx', filename: 'report.xlsx' };
     const result = await groundAttachmentsForModel({ files: [sheet], providerID: 'p', modelID: 'm', directory: '/repo' });

--- a/packages/ui/src/lib/attachments/attachmentGrounding.test.ts
+++ b/packages/ui/src/lib/attachments/attachmentGrounding.test.ts
@@ -93,12 +93,13 @@ describe('groundAttachmentsForModel', () => {
 
     const write = fetchCalls.find((c) => c.url.includes('/api/fs/write'));
     expect(write).toBeDefined();
+    const stat = fetchCalls.find((c) => c.url.includes('/api/fs/stat'));
+    expect(stat?.url).toContain('directory=%2Frepo');
     const body = JSON.parse(String(write?.init?.body));
     expect(body.path).toBe('uploads/report.xlsx');
     expect(body.encoding).toBe('base64');
     expect(Buffer.from(body.content, 'base64').toString()).toBe('spreadsheet-bytes');
-    const headers = new Headers(write?.init?.headers);
-    expect(headers.get('x-opencode-directory')).toBe('/repo');
+    expect(write?.url).toContain('directory=%2Frepo');
   });
 
   test('name collision picks a suffixed path', async () => {

--- a/packages/ui/src/lib/attachments/attachmentGrounding.test.ts
+++ b/packages/ui/src/lib/attachments/attachmentGrounding.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { ModelMetadata } from '@/types';
+
+let metadataByKey: Record<string, ModelMetadata | undefined> = {};
+
+mock.module('@/stores/useConfigStore', () => ({
+  useConfigStore: {
+    getState: () => ({
+      getModelMetadata: (providerId: string, modelId: string) => metadataByKey[`${providerId}/${modelId}`],
+    }),
+  },
+}));
+
+import { groundAttachmentsForModel, modelAcceptsAttachmentMime } from './attachmentGrounding';
+
+const originalFetch = globalThis.fetch;
+
+type FetchCall = { url: string; init?: RequestInit };
+let fetchCalls: FetchCall[] = [];
+let statExists = false;
+let writeOk = true;
+
+const installFetchStub = () => {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    fetchCalls.push({ url, init });
+    if (url.includes('/api/fs/stat')) {
+      return new Response(statExists ? '{}' : 'missing', { status: statExists ? 200 : 404 });
+    }
+    if (url.includes('/api/fs/write')) {
+      return new Response(writeOk ? '{"success":true}' : 'denied', { status: writeOk ? 200 : 403 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof fetch;
+};
+
+const xlsxMime = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+const xlsxDataUrl = `data:${xlsxMime};base64,${Buffer.from('spreadsheet-bytes').toString('base64')}`;
+
+beforeEach(() => {
+  metadataByKey = {};
+  fetchCalls = [];
+  statExists = false;
+  writeOk = true;
+  installFetchStub();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('modelAcceptsAttachmentMime', () => {
+  test('text/plain always passes', async () => {
+    expect(await modelAcceptsAttachmentMime('text/plain', 'p', 'm')).toBe(true);
+  });
+
+  test('spreadsheets never pass regardless of metadata', async () => {
+    metadataByKey['p/m'] = { modalities: { input: ['text', 'image', 'pdf'] } } as ModelMetadata;
+    expect(await modelAcceptsAttachmentMime(xlsxMime, 'p', 'm')).toBe(false);
+  });
+
+  test('image passes only when the model declares image input', async () => {
+    metadataByKey['p/vision'] = { modalities: { input: ['text', 'image'] } } as ModelMetadata;
+    metadataByKey['p/textonly'] = { modalities: { input: ['text'] } } as ModelMetadata;
+    expect(await modelAcceptsAttachmentMime('image/png', 'p', 'vision')).toBe(true);
+    expect(await modelAcceptsAttachmentMime('image/png', 'p', 'textonly')).toBe(false);
+  });
+
+  test('falls back to the attachment flag when modalities are missing', async () => {
+    metadataByKey['p/flagged'] = { attachment: true } as ModelMetadata;
+    expect(await modelAcceptsAttachmentMime('application/pdf', 'p', 'flagged')).toBe(true);
+    expect(await modelAcceptsAttachmentMime('application/pdf', 'p', 'unknown')).toBe(false);
+  });
+});
+
+describe('groundAttachmentsForModel', () => {
+  test('supported image goes direct, spreadsheet is grounded to uploads/', async () => {
+    metadataByKey['p/vision'] = { modalities: { input: ['text', 'image'] } } as ModelMetadata;
+    const image = { type: 'file' as const, mime: 'image/png', url: 'data:image/png;base64,aGk=', filename: 'shot.png' };
+    const sheet = { type: 'file' as const, mime: xlsxMime, url: xlsxDataUrl, filename: 'report.xlsx' };
+
+    const result = await groundAttachmentsForModel({
+      files: [image, sheet],
+      providerID: 'p',
+      modelID: 'vision',
+      directory: '/repo',
+    });
+
+    expect(result.direct).toEqual([image]);
+    expect(result.hints).toHaveLength(1);
+    expect(result.hints[0]).toContain('uploads/report.xlsx');
+    expect(result.hints[0]).toContain('report.xlsx');
+
+    const write = fetchCalls.find((c) => c.url.includes('/api/fs/write'));
+    expect(write).toBeDefined();
+    const body = JSON.parse(String(write?.init?.body));
+    expect(body.path).toBe('uploads/report.xlsx');
+    expect(body.encoding).toBe('base64');
+    expect(Buffer.from(body.content, 'base64').toString()).toBe('spreadsheet-bytes');
+    const headers = new Headers(write?.init?.headers);
+    expect(headers.get('x-opencode-directory')).toBe('/repo');
+  });
+
+  test('name collision picks a suffixed path', async () => {
+    statExists = true;
+    const sheet = { type: 'file' as const, mime: xlsxMime, url: xlsxDataUrl, filename: 'report.xlsx' };
+    const result = await groundAttachmentsForModel({ files: [sheet], providerID: 'p', modelID: 'm', directory: '/repo' });
+    expect(/uploads\/report-\d+\.xlsx/.test(result.hints[0])).toBe(true);
+  });
+
+  test('write failure falls back to sending the original file part', async () => {
+    writeOk = false;
+    const sheet = { type: 'file' as const, mime: xlsxMime, url: xlsxDataUrl, filename: 'report.xlsx' };
+    const result = await groundAttachmentsForModel({ files: [sheet], providerID: 'p', modelID: 'm', directory: '/repo' });
+    expect(result.direct).toEqual([sheet]);
+    expect(result.hints).toHaveLength(0);
+  });
+
+  test('file:// attachments produce an on-disk hint without uploading', async () => {
+    const sheet = { type: 'file' as const, mime: xlsxMime, url: 'file:///repo/data/report.xlsx', filename: 'report.xlsx' };
+    const result = await groundAttachmentsForModel({ files: [sheet], providerID: 'p', modelID: 'm', directory: '/repo' });
+    expect(result.direct).toHaveLength(0);
+    expect(result.hints[0]).toContain('/repo/data/report.xlsx');
+    expect(fetchCalls.filter((c) => c.url.includes('/api/fs/write'))).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/lib/attachments/attachmentGrounding.ts
+++ b/packages/ui/src/lib/attachments/attachmentGrounding.ts
@@ -117,15 +117,20 @@ const pickUploadPath = async (
   return `${UPLOADS_DIR}/${stem}-${Date.now()}${ext}`;
 };
 
+const readAdvice = (mime: string): string =>
+  mime.startsWith('image/')
+    ? 'The current model cannot view image content, and tools cannot substitute for vision — '
+      + 'if the user needs the image interpreted, tell them to switch to a vision-capable model.'
+    : 'Read it from there with local tools (e.g. Python) when you need its contents.';
+
 const buildSavedHint = (filename: string, mime: string, bytes: number, relativePath: string): string =>
   `[Attachment saved to workspace] The user attached "${filename}" (${mime}, ${formatBytes(bytes)}). `
   + `The current model cannot ingest this file type directly, so it was saved to ${relativePath} `
-  + `in the working directory. Read it from there with local tools (e.g. Python) when you need its contents.`;
+  + `in the working directory. ${readAdvice(mime)}`;
 
 const buildOnDiskHint = (filename: string, mime: string, absolutePath: string): string =>
   `[Attachment on disk] The user attached "${filename}" (${mime}) located at ${absolutePath}. `
-  + `The current model cannot ingest this file type directly. Read it from there with local tools `
-  + `(e.g. Python) when you need its contents.`;
+  + `The current model cannot ingest this file type directly. ${readAdvice(mime)}`;
 
 const groundOne = async (
   file: GroundableFile,

--- a/packages/ui/src/lib/attachments/attachmentGrounding.ts
+++ b/packages/ui/src/lib/attachments/attachmentGrounding.ts
@@ -87,16 +87,17 @@ const splitDataUrl = (url: string): { base64: string; bytes: number } | null => 
   return { base64: payload, bytes: Math.max(0, Math.floor((payload.length * 3) / 4) - padding) };
 };
 
-const directoryHeaders = (directory: string | null | undefined): Record<string, string> => ({
-  'Content-Type': 'application/json',
-  ...(directory ? { 'x-opencode-directory': directory } : {}),
-});
+// Directory rides the query string, not the x-opencode-directory header:
+// header-based scoping is dropped by relay/remote transports, query survives
+// every path (resolveProjectDirectory reads both).
+const directoryQuery = (directory: string | null | undefined, lead: '?' | '&'): string =>
+  directory ? `${lead}directory=${encodeURIComponent(directory)}` : '';
 
 const pathExists = async (relativePath: string, directory: string | null | undefined): Promise<boolean> => {
   try {
-    const res = await runtimeFetch(`/api/fs/stat?path=${encodeURIComponent(relativePath)}`, {
-      headers: directoryHeaders(directory),
-    });
+    const res = await runtimeFetch(
+      `/api/fs/stat?path=${encodeURIComponent(relativePath)}${directoryQuery(directory, '&')}`,
+    );
     return res.ok;
   } catch {
     return false;
@@ -149,9 +150,9 @@ const groundOne = async (
 
   try {
     const relativePath = await pickUploadPath(filename, directory);
-    const res = await runtimeFetch('/api/fs/write', {
+    const res = await runtimeFetch(`/api/fs/write${directoryQuery(directory, '?')}`, {
       method: 'POST',
-      headers: directoryHeaders(directory),
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ path: relativePath, content: data.base64, encoding: 'base64' }),
     });
     if (!res.ok) return { passthrough: true };

--- a/packages/ui/src/lib/attachments/attachmentGrounding.ts
+++ b/packages/ui/src/lib/attachments/attachmentGrounding.ts
@@ -1,0 +1,189 @@
+/**
+ * Attachment grounding — capability-aware attachment routing.
+ *
+ * Providers reject whole messages when a file part's media type is not
+ * supported by the selected model ("file part media type ... functionality not
+ * supported"): spreadsheets and archives are never accepted, and text-only
+ * models (e.g. DeepSeek) reject even images. Instead of forwarding blindly,
+ * attachments the current model cannot ingest are saved into an `uploads/`
+ * folder inside the session working directory and replaced with a synthetic
+ * text part that tells the agent where the file is, so it can read the file
+ * with its own tools.
+ *
+ * Grounding is strictly opt-out-by-capability: a media type is passed through
+ * only when the model's metadata explicitly declares support for it. When the
+ * workspace write fails (e.g. a runtime without the fs API), the original file
+ * part is passed through unchanged — behavior is then no worse than before.
+ */
+import { runtimeFetch } from '@/lib/runtime-fetch';
+
+export type GroundableFile = { id?: string; type: 'file'; mime: string; url: string; filename?: string };
+
+export type GroundedAttachments = {
+  /** Files the model accepts natively — send as file parts. */
+  direct: GroundableFile[];
+  /** Agent-facing hints for grounded files — send as synthetic text parts. */
+  hints: string[];
+};
+
+const UPLOADS_DIR = 'uploads';
+/** /api/fs JSON body limit is 50mb — leave headroom for base64 + envelope. */
+const MAX_GROUNDABLE_BYTES = 30 * 1024 * 1024;
+
+const normalizeMime = (mime: string): string => (mime || '').toLowerCase().split(';')[0].trim();
+
+const formatBytes = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes < 0) return 'unknown size';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+/**
+ * Whether the selected model natively accepts a file part of this media type.
+ * text/plain always passes: the OpenCode server inlines it as a text part
+ * before the provider sees it. Images/PDF require an explicit declaration in
+ * the model metadata (modalities.input, falling back to the coarse
+ * `attachment` flag). Everything else is never provider-ingestible.
+ */
+export async function modelAcceptsAttachmentMime(
+  mime: string,
+  providerID: string,
+  modelID: string,
+): Promise<boolean> {
+  const normalized = normalizeMime(mime);
+  if (normalized === 'text/plain' || normalized === 'application/x-directory') return true;
+  const isImage = normalized.startsWith('image/');
+  const isPdf = normalized === 'application/pdf';
+  if (!isImage && !isPdf) return false;
+  // Dynamic import keeps this transport-adjacent module out of the
+  // client ⇄ config-store import cycle.
+  const { useConfigStore } = await import('@/stores/useConfigStore');
+  const metadata = useConfigStore.getState().getModelMetadata(providerID, modelID);
+  const input = metadata?.modalities?.input;
+  if (Array.isArray(input) && input.length > 0) {
+    return input.includes(isImage ? 'image' : 'pdf');
+  }
+  return metadata?.attachment === true;
+}
+
+const sanitizeFilename = (filename: string | undefined): string => {
+  const base = (filename || '').split(/[\\/]/).pop() || '';
+  // eslint-disable-next-line no-control-regex
+  const cleaned = base.replace(/[\u0000-\u001f<>:"|?*]/g, '').trim();
+  return cleaned || 'attachment';
+};
+
+const splitDataUrl = (url: string): { base64: string; bytes: number } | null => {
+  if (!url.startsWith('data:')) return null;
+  const commaIndex = url.indexOf(',');
+  if (commaIndex < 0) return null;
+  const metadata = url.slice(0, commaIndex).toLowerCase();
+  const payload = url.slice(commaIndex + 1);
+  if (!metadata.endsWith(';base64')) return null;
+  let padding = 0;
+  if (payload.endsWith('==')) padding = 2;
+  else if (payload.endsWith('=')) padding = 1;
+  return { base64: payload, bytes: Math.max(0, Math.floor((payload.length * 3) / 4) - padding) };
+};
+
+const directoryHeaders = (directory: string | null | undefined): Record<string, string> => ({
+  'Content-Type': 'application/json',
+  ...(directory ? { 'x-opencode-directory': directory } : {}),
+});
+
+const pathExists = async (relativePath: string, directory: string | null | undefined): Promise<boolean> => {
+  try {
+    const res = await runtimeFetch(`/api/fs/stat?path=${encodeURIComponent(relativePath)}`, {
+      headers: directoryHeaders(directory),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
+const pickUploadPath = async (
+  filename: string,
+  directory: string | null | undefined,
+): Promise<string> => {
+  const safe = sanitizeFilename(filename);
+  const candidate = `${UPLOADS_DIR}/${safe}`;
+  if (!(await pathExists(candidate, directory))) return candidate;
+  const dot = safe.lastIndexOf('.');
+  const stem = dot > 0 ? safe.slice(0, dot) : safe;
+  const ext = dot > 0 ? safe.slice(dot) : '';
+  return `${UPLOADS_DIR}/${stem}-${Date.now()}${ext}`;
+};
+
+const buildSavedHint = (filename: string, mime: string, bytes: number, relativePath: string): string =>
+  `[Attachment saved to workspace] The user attached "${filename}" (${mime}, ${formatBytes(bytes)}). `
+  + `The current model cannot ingest this file type directly, so it was saved to ${relativePath} `
+  + `in the working directory. Read it from there with local tools (e.g. Python) when you need its contents.`;
+
+const buildOnDiskHint = (filename: string, mime: string, absolutePath: string): string =>
+  `[Attachment on disk] The user attached "${filename}" (${mime}) located at ${absolutePath}. `
+  + `The current model cannot ingest this file type directly. Read it from there with local tools `
+  + `(e.g. Python) when you need its contents.`;
+
+const groundOne = async (
+  file: GroundableFile,
+  directory: string | null | undefined,
+): Promise<{ hint: string } | { passthrough: true }> => {
+  const filename = sanitizeFilename(file.filename);
+  const mime = normalizeMime(file.mime) || 'application/octet-stream';
+
+  if (file.url.startsWith('file://')) {
+    // Already on disk (server-source attachment) — no copy needed.
+    let absolutePath = file.url.slice('file://'.length);
+    try {
+      absolutePath = decodeURIComponent(absolutePath);
+    } catch {
+      // keep raw path
+    }
+    return { hint: buildOnDiskHint(filename, mime, absolutePath) };
+  }
+
+  const data = splitDataUrl(file.url);
+  if (!data || data.bytes > MAX_GROUNDABLE_BYTES) return { passthrough: true };
+
+  try {
+    const relativePath = await pickUploadPath(filename, directory);
+    const res = await runtimeFetch('/api/fs/write', {
+      method: 'POST',
+      headers: directoryHeaders(directory),
+      body: JSON.stringify({ path: relativePath, content: data.base64, encoding: 'base64' }),
+    });
+    if (!res.ok) return { passthrough: true };
+    return { hint: buildSavedHint(filename, mime, data.bytes, relativePath) };
+  } catch {
+    return { passthrough: true };
+  }
+};
+
+/**
+ * Split attachments into model-ingestible file parts and grounded hints.
+ * Never throws; on any grounding failure the file passes through unchanged.
+ */
+export async function groundAttachmentsForModel(input: {
+  files: GroundableFile[];
+  providerID: string;
+  modelID: string;
+  directory?: string | null;
+}): Promise<GroundedAttachments> {
+  const direct: GroundableFile[] = [];
+  const hints: string[] = [];
+  for (const file of input.files) {
+    if (await modelAcceptsAttachmentMime(file.mime, input.providerID, input.modelID)) {
+      direct.push(file);
+      continue;
+    }
+    const result = await groundOne(file, input.directory);
+    if ('hint' in result) {
+      hints.push(result.hint);
+    } else {
+      direct.push(file);
+    }
+  }
+  return { direct, hints };
+}

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -30,6 +30,7 @@ import { runtimeFetch } from "@/lib/runtime-fetch";
 import { getRuntimeKey } from "@/lib/runtime-switch";
 import { getRegisteredRuntimeAPIs } from "@/contexts/runtimeAPIRegistry";
 import { markStartupTrace } from "@/lib/startupTrace";
+import { groundAttachmentsForModel } from "@/lib/attachments/attachmentGrounding";
 import {
   assertProviderCircuitClosed,
   recordProviderSuccess,
@@ -792,12 +793,30 @@ class OpencodeService {
       parts.push(textPart);
     }
 
+    const requestDirectory = this.normalizeCandidatePath(params.directory ?? null) ?? this.currentDirectory;
+
+    // Attachments the selected model cannot ingest are grounded to the
+    // workspace (uploads/) and replaced with synthetic text hints so the
+    // agent reads them with its own tools instead of the provider rejecting
+    // the whole message. See lib/attachments/attachmentGrounding.ts.
+    const appendFiles = async (files: Array<FileInputLite>) => {
+      const grounded = await groundAttachmentsForModel({
+        files,
+        providerID: params.providerID,
+        modelID: params.modelID,
+        directory: requestDirectory,
+      });
+      for (const file of grounded.direct) {
+        parts.push(await this.toNormalizedFilePartInput(file));
+      }
+      for (const hint of grounded.hints) {
+        parts.push({ type: 'text', text: hint, synthetic: true });
+      }
+    };
+
     // Add file parts if provided (normalizing MIME types for compatibility)
     if (params.files && params.files.length > 0) {
-      for (const file of params.files) {
-        const filePart = await this.toNormalizedFilePartInput(file);
-        parts.push(filePart);
-      }
+      await appendFiles(params.files);
     }
 
     // Add additional parts (for batch/queued messages)
@@ -811,10 +830,7 @@ class OpencodeService {
           });
         }
         if (additional.files && additional.files.length > 0) {
-          for (const file of additional.files) {
-            const filePart = await this.toNormalizedFilePartInput(file);
-            parts.push(filePart);
-          }
+          await appendFiles(additional.files);
         }
       }
     }
@@ -834,8 +850,6 @@ class OpencodeService {
     if (parts.length === 0) {
       throw new Error('Message must have at least one part (text or file)');
     }
-
-    const requestDirectory = this.normalizeCandidatePath(params.directory ?? null) ?? this.currentDirectory;
 
     if (params.format) {
       console.info('[git-generation][browser] send structured message', {
@@ -924,20 +938,32 @@ class OpencodeService {
   }): Promise<string> {
     const tempMessageId = params.messageId ?? ascendingId("msg");
 
+    const requestDirectory = this.normalizeCandidatePath(params.directory ?? null) ?? this.currentDirectory;
+
+    // Command parts only accept file parts, so grounded-attachment hints are
+    // appended to the command arguments instead (same grounding as sendMessage).
     const parts: FilePartInput[] = [];
+    let commandArguments = params.arguments ?? '';
     if (params.files && params.files.length > 0) {
-      for (const file of params.files) {
+      const grounded = await groundAttachmentsForModel({
+        files: params.files,
+        providerID: params.providerID,
+        modelID: params.modelID,
+        directory: requestDirectory,
+      });
+      for (const file of grounded.direct) {
         parts.push(await this.toNormalizedFilePartInput(file));
       }
+      if (grounded.hints.length > 0) {
+        commandArguments = [commandArguments, ...grounded.hints].filter(Boolean).join('\n');
+      }
     }
-
-    const requestDirectory = this.normalizeCandidatePath(params.directory ?? null) ?? this.currentDirectory;
 
     const response = await this.client.session.command({
       sessionID: params.id,
       ...(requestDirectory ? { directory: requestDirectory } : {}),
       command: params.command,
-      arguments: params.arguments ?? '',
+      arguments: commandArguments,
       model: `${params.providerID}/${params.modelID}`,
       agent: params.agent,
       variant: params.variant,

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -973,12 +973,24 @@ export const registerFsRoutes = (app, dependencies) => {
   });
 
   app.post('/api/fs/write', async (req, res) => {
-    const { path: filePath, content } = req.body || {};
+    const { path: filePath, content, encoding } = req.body || {};
     if (!filePath || typeof filePath !== 'string') {
       return res.status(400).json({ error: 'Path is required' });
     }
     if (typeof content !== 'string') {
       return res.status(400).json({ error: 'Content is required' });
+    }
+    if (encoding !== undefined && encoding !== 'utf8' && encoding !== 'base64') {
+      return res.status(400).json({ error: 'Unsupported encoding' });
+    }
+    const isBase64 = encoding === 'base64';
+    let payload = content;
+    if (isBase64) {
+      try {
+        payload = Buffer.from(content, 'base64');
+      } catch {
+        return res.status(400).json({ error: 'Invalid base64 content' });
+      }
     }
 
     try {
@@ -1006,9 +1018,16 @@ export const registerFsRoutes = (app, dependencies) => {
         return res.status(403).json({ error: 'Access denied' });
       }
 
-      const existing = await fsPromises.readFile(writePath, 'utf8').catch(() => null);
-      if (existing === content) {
-        return res.json({ success: true, path: resolved.resolved });
+      if (isBase64) {
+        const existing = await fsPromises.readFile(writePath).catch(() => null);
+        if (existing && existing.equals(payload)) {
+          return res.json({ success: true, path: resolved.resolved });
+        }
+      } else {
+        const existing = await fsPromises.readFile(writePath, 'utf8').catch(() => null);
+        if (existing === payload) {
+          return res.json({ success: true, path: resolved.resolved });
+        }
       }
 
       await fsPromises.mkdir(path.dirname(writePath), { recursive: true });
@@ -1017,7 +1036,11 @@ export const registerFsRoutes = (app, dependencies) => {
       // seeing an empty file during the O_TRUNC window of direct writeFile.
       const tmp = `${writePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       try {
-        await fsPromises.writeFile(tmp, content, 'utf8');
+        if (isBase64) {
+          await fsPromises.writeFile(tmp, payload);
+        } else {
+          await fsPromises.writeFile(tmp, payload, 'utf8');
+        }
         await fsPromises.rename(tmp, writePath);
       } catch (error) {
         await fsPromises.unlink(tmp).catch(() => {});

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -266,6 +266,58 @@ describe('fs write', () => {
     expect(fsPromises.unlink).not.toHaveBeenCalled();
   });
 
+  it('writes binary content with base64 encoding', async () => {
+    const payload = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
+    const fsPromises = {
+      readFile: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async () => undefined),
+      rename: vi.fn(async () => undefined),
+      unlink: vi.fn(async () => undefined),
+    };
+    const handler = registerWrite(fsPromises);
+
+    const res = await callWrite(handler, {
+      path: '/repo/uploads/report.xlsx',
+      content: payload.toString('base64'),
+      encoding: 'base64',
+    });
+
+    expect(res.body).toEqual({ success: true, path: '/repo/uploads/report.xlsx' });
+    const [tmp, written] = fsPromises.writeFile.mock.calls[0];
+    expect(tmp).toMatch(/^\/repo\/uploads\/report\.xlsx\.tmp-/);
+    expect(Buffer.isBuffer(written)).toBe(true);
+    expect(written.equals(payload)).toBe(true);
+    expect(fsPromises.writeFile.mock.calls[0].length).toBe(2);
+    expect(fsPromises.rename).toHaveBeenCalledWith(tmp, '/repo/uploads/report.xlsx');
+  });
+
+  it('skips base64 rewrite when binary content is unchanged', async () => {
+    const payload = Buffer.from('same-bytes');
+    const fsPromises = {
+      readFile: vi.fn(async () => Buffer.from(payload)),
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async () => undefined),
+    };
+    const handler = registerWrite(fsPromises);
+
+    const res = await callWrite(handler, {
+      path: '/repo/uploads/report.xlsx',
+      content: payload.toString('base64'),
+      encoding: 'base64',
+    });
+
+    expect(res.body).toEqual({ success: true, path: '/repo/uploads/report.xlsx' });
+    expect(fsPromises.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown encodings', async () => {
+    const handler = registerWrite({});
+    const res = await callWrite(handler, { path: '/repo/f', content: 'x', encoding: 'hex' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Unsupported encoding' });
+  });
+
   it('writes through existing symlinks without replacing the link', async () => {
     const fsPromises = {
       realpath: vi.fn(async (targetPath) => {


### PR DESCRIPTION
## Problem

Attaching a file whose media type the selected model cannot ingest fails the whole message with a provider error:

```
Opencode failed to send message with error: 'file part media type application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' functionality not supported.
```

Spreadsheets, docx, archives etc. are never accepted by any provider, and text-only models (e.g. DeepSeek) reject even images — so today the user just loses the send.

## Approach

Route attachments by model capability at send time (`sendMessage`/`sendCommand`):

- A media type is forwarded as a file part **only when the model's metadata explicitly declares support** — `modalities.input` contains `image`/`pdf`, falling back to the coarse `attachment` flag. `text/plain` always passes (the OpenCode server inlines it as text).
- Everything else is saved to `uploads/` inside the session working directory (name collisions get a timestamp suffix) and replaced with a **synthetic text part** telling the agent where the file is, so the agent reads it with its own tools (Python, etc.). `file://` attachments only get the hint — no copy.
- On any grounding failure (e.g. a runtime without the fs API) the original file part passes through unchanged — behavior is never worse than today.
- `session.command` parts only accept file parts, so grounded hints are appended to the command `arguments` there.

Server side, `POST /api/fs/write` gains an optional `encoding: 'base64'` for binary payloads, reusing the existing workspace-scoping guards and the atomic tmp-rename write.

This makes attachment support metadata-driven: adding a new model only requires correct capability metadata, no code changes.

## Testing

- `packages/ui/src/lib/attachments/attachmentGrounding.test.ts` (bun test ×8): decision table (text/plain pass, image gated on `modalities.input`, xlsx always grounded, `attachment` flag fallback), upload body/headers, collision suffix, write-failure passthrough, `file://` hint.
- `packages/web/server/lib/fs/routes.test.js` (+3 vitest): base64 write decodes and writes a Buffer atomically, unchanged-content skip, unknown encoding → 400.
- `@openchamber/ui` type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)