### PR TITLE
feat: add Ctrl+Tab MRU session switching and Ctrl+S session picker

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -21,6 +21,7 @@ import { ScrollShadow } from '@/components/ui/ScrollShadow';
 import { useChatAutoFollow, type AnimationHandlers, type ContentChangeReason } from '@/hooks/useChatAutoFollow';
 import { useChatTimelineController } from './hooks/useChatTimelineController';
 import { TimelineDialog } from './TimelineDialog';
+import { SessionPickerDialog } from '@/components/session/SessionPickerDialog';
 import { useChatTurnNavigation } from './hooks/useChatTurnNavigation';
 import { useChatSurfaceMode } from './useChatSurfaceMode';
 import { useDeviceInfo } from '@/lib/device';
@@ -524,6 +525,8 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
     const allowPromptingSubagentSessions = useUIStore((state) => state.allowPromptingSubagentSessions);
     const isTimelineDialogOpen = useUIStore((s) => s.isTimelineDialogOpen);
     const setTimelineDialogOpen = useUIStore((s) => s.setTimelineDialogOpen);
+    const isSessionPickerOpen = useUIStore((s) => s.isSessionPickerOpen);
+    const setSessionPickerOpen = useUIStore((s) => s.setSessionPickerOpen);
 
     // Streaming state
     const streamingMessageId = useStreamingStore(
@@ -1183,6 +1186,10 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ autoOpenDraft = tr
                 canLoadEarlier={timelineController.historySignals.canLoadEarlier}
                 isLoadingEarlier={timelineController.isLoadingOlder}
                 onLoadEarlier={handleLoadOlderClick}
+            />
+            <SessionPickerDialog
+                open={isSessionPickerOpen}
+                onOpenChange={setSessionPickerOpen}
             />
         </div>
     );

--- a/packages/ui/src/components/session/SessionPickerDialog.tsx
+++ b/packages/ui/src/components/session/SessionPickerDialog.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import type { Session } from '@opencode-ai/sdk/v2';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useSessionUIStore } from '@/sync/session-ui-store';
+import { useGlobalSessionsStore, resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
+import { useProjectsStore } from '@/stores/useProjectsStore';
+import { useI18n } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
+
+interface SessionPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const SessionPickerDialog: React.FC<SessionPickerDialogProps> = ({
+  open,
+  onOpenChange,
+}) => {
+  const { t } = useI18n();
+  const tUnsafe = React.useCallback((key: string) => t(key as Parameters<typeof t>[0]), [t]);
+  const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
+  const setCurrentSession = useSessionUIStore((state) => state.setCurrentSession);
+  const activeSessions = useGlobalSessionsStore((state) => state.activeSessions);
+  const projects = useProjectsStore((state) => state.projects);
+
+  const [searchQuery, setSearchQuery] = React.useState('');
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const itemRefs = React.useRef<(HTMLDivElement | null)[]>([]);
+
+  const sessions = React.useMemo(() => {
+    return activeSessions
+      .filter((s) => !s.time?.archived)
+      .sort((a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0));
+  }, [activeSessions]);
+
+  const filtered = React.useMemo(() => {
+    if (!searchQuery.trim()) return sessions;
+    const q = searchQuery.toLowerCase();
+    return sessions.filter((s) => {
+      const title = (s.title ?? '').toLowerCase();
+      return title.includes(q);
+    });
+  }, [sessions, searchQuery]);
+
+  React.useEffect(() => {
+    if (open) {
+      setSearchQuery('');
+      setSelectedIndex(0);
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    if (selectedIndex >= filtered.length) {
+      setSelectedIndex(0);
+    }
+  }, [filtered.length, selectedIndex]);
+
+  React.useEffect(() => {
+    const el = itemRefs.current[selectedIndex];
+    if (el) {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  }, [selectedIndex]);
+
+  const handleSelect = React.useCallback((sessionId: string) => {
+    const session = sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+    const directory = resolveGlobalSessionDirectory(session);
+    setCurrentSession(sessionId, directory);
+    onOpenChange(false);
+  }, [sessions, setCurrentSession, onOpenChange]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown' || (e.key === 'j' && e.ctrlKey)) {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp' || (e.key === 'k' && e.ctrlKey)) {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const selected = filtered[selectedIndex];
+      if (selected) {
+        handleSelect(selected.id);
+      }
+    }
+  };
+
+  const formatRelativeTime = (timestamp: number | undefined): string => {
+    if (!timestamp) return '';
+    const diff = Date.now() - timestamp;
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return 'just now';
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 7) return `${days}d ago`;
+    return new Date(timestamp).toLocaleDateString();
+  };
+
+  const getProjectLabel = (session: Session): string | null => {
+    const directory = resolveGlobalSessionDirectory(session);
+    if (!directory) return null;
+    const project = projects.find((p) => {
+      const pPath = p.path.replace(/\\/g, '/');
+      return directory.replace(/\\/g, '/').startsWith(pPath);
+    });
+    if (project?.label) return project.label;
+    if (project?.path) {
+      const segments = project.path.split(/[\\/]/).filter(Boolean);
+      return segments[segments.length - 1] ?? null;
+    }
+    const segments = directory.split(/[\\/]/).filter(Boolean);
+    return segments[segments.length - 1] ?? null;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="p-0 gap-0 max-w-[560px] max-h-[480px] overflow-hidden flex flex-col">
+        <DialogHeader className="px-4 pt-4 pb-2">
+          <DialogTitle className="text-base">
+            {tUnsafe('sessions.picker.title') !== 'sessions.picker.title'
+              ? tUnsafe('sessions.picker.title')
+              : 'Switch Session'}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            {tUnsafe('sessions.picker.description') !== 'sessions.picker.description'
+              ? tUnsafe('sessions.picker.description')
+              : 'Search and select a session to switch to'}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="px-4 pb-2">
+          <Input
+            autoFocus
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search sessions..."
+            className="h-8"
+          />
+        </div>
+        <div className="flex-1 overflow-y-auto px-2 pb-2">
+          {filtered.length === 0 ? (
+            <div className="text-center text-muted-foreground py-8 text-sm">
+              {searchQuery.trim() ? 'No matching sessions' : 'No sessions available'}
+            </div>
+          ) : (
+            <div className="space-y-0.5">
+              {filtered.map((session, index) => {
+                const isActive = session.id === currentSessionId;
+                const isSelected = index === selectedIndex;
+                const projectLabel = getProjectLabel(session);
+                return (
+                  <div
+                    key={session.id}
+                    ref={(el) => { itemRefs.current[index] = el; }}
+                    onClick={() => handleSelect(session.id)}
+                    className={cn(
+                      'flex items-center gap-2 px-3 py-2 rounded-md cursor-pointer text-sm',
+                      isSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',
+                    )}
+                  >
+                    <span className="flex-1 truncate font-medium">
+                      {session.title || 'Untitled session'}
+                    </span>
+                    {projectLabel && (
+                      <span className="text-xs text-muted-foreground shrink-0">
+                        {projectLabel}
+                      </span>
+                    )}
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      {formatRelativeTime(session.time?.updated)}
+                    </span>
+                    {isActive && (
+                      <span className="text-xs text-primary shrink-0">●</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -42,6 +42,7 @@ export const useKeyboardShortcuts = () => {
   const setSettingsDialogOpen = useUIStore((s) => s.setSettingsDialogOpen);
   const setModelSelectorOpen = useUIStore((s) => s.setModelSelectorOpen);
   const setTimelineDialogOpen = useUIStore((s) => s.setTimelineDialogOpen);
+  const setSessionPickerOpen = useUIStore((s) => s.setSessionPickerOpen);
   const togglePromptNavigatorPanel = useUIStore((s) => s.togglePromptNavigatorPanel);
   const setPromptNavigatorPanelOpen = useUIStore((s) => s.setPromptNavigatorPanelOpen);
   const toggleExpandedInput = useUIStore((s) => s.toggleExpandedInput);
@@ -137,6 +138,13 @@ export const useKeyboardShortcuts = () => {
       if (eventMatchesShortcut(e, combo('open_timeline_dialog'))) {
         e.preventDefault();
         setTimelineDialogOpen(true);
+        return;
+      }
+
+      if (eventMatchesShortcut(e, combo('switch_session'))) {
+        e.preventDefault();
+        const { isSessionPickerOpen } = useUIStore.getState();
+        setSessionPickerOpen(!isSessionPickerOpen);
         return;
       }
 
@@ -518,6 +526,7 @@ export const useKeyboardShortcuts = () => {
           isImagePreviewOpen,
           isModelSelectorOpen,
           isTimelineDialogOpen,
+          isSessionPickerOpen,
           activeMainTab,
         } = useUIStore.getState();
 
@@ -529,7 +538,8 @@ export const useKeyboardShortcuts = () => {
           || isMultiRunLauncherOpen
           || isImagePreviewOpen
           || isModelSelectorOpen
-          || isTimelineDialogOpen;
+          || isTimelineDialogOpen
+          || isSessionPickerOpen;
         if (hasOverlay || activeMainTab !== 'chat') {
           return;
         }
@@ -712,6 +722,7 @@ export const useKeyboardShortcuts = () => {
     setSettingsDialogOpen,
     setModelSelectorOpen,
     setTimelineDialogOpen,
+    setSessionPickerOpen,
     togglePromptNavigatorPanel,
     setPromptNavigatorPanelOpen,
     toggleExpandedInput,

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -15,12 +15,18 @@ import { readEmbeddedThemeSearchParams } from '@/contexts/theme-embedded-bootstr
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { getCycledPrimaryAgentName } from '@/components/chat/mobileControlsUtils';
+import { sessionMRU } from '@/sync/session-mru';
+import { getAllSyncSessionMap } from '@/sync/sync-refs';
 
 export const useKeyboardShortcuts = () => {
   const openNewSessionDraft = useSessionUIStore((s) => s.openNewSessionDraft);
   const armAbortPrompt = useSessionUIStore((s) => s.armAbortPrompt);
   const clearAbortPrompt = useSessionUIStore((s) => s.clearAbortPrompt);
   const currentSessionId = useSessionUIStore((s) => s.currentSessionId);
+  const currentSessionIdRef = React.useRef(currentSessionId);
+  React.useEffect(() => {
+    currentSessionIdRef.current = currentSessionId;
+  }, [currentSessionId]);
     const abortCurrentOperation = sessionActions.abortCurrentOperation;;
   const toggleCommandPalette = useUIStore((s) => s.toggleCommandPalette);
   const toggleHelpDialog = useUIStore((s) => s.toggleHelpDialog);
@@ -493,6 +499,77 @@ export const useKeyboardShortcuts = () => {
         return;
       }
 
+      if (
+        eventMatchesShortcut(e, combo('cycle_session_mru_forward')) ||
+        eventMatchesShortcut(e, combo('cycle_session_mru_backward'))
+      ) {
+        if (e.repeat) {
+          e.preventDefault();
+          return;
+        }
+
+        const {
+          isSettingsDialogOpen,
+          isCommandPaletteOpen,
+          isHelpDialogOpen,
+          isSessionSwitcherOpen,
+          isAboutDialogOpen,
+          isMultiRunLauncherOpen,
+          isImagePreviewOpen,
+          isModelSelectorOpen,
+          isTimelineDialogOpen,
+          activeMainTab,
+        } = useUIStore.getState();
+
+        const hasOverlay = isSettingsDialogOpen
+          || isCommandPaletteOpen
+          || isHelpDialogOpen
+          || isSessionSwitcherOpen
+          || isAboutDialogOpen
+          || isMultiRunLauncherOpen
+          || isImagePreviewOpen
+          || isModelSelectorOpen
+          || isTimelineDialogOpen;
+        if (hasOverlay || activeMainTab !== 'chat') {
+          return;
+        }
+
+        const direction: 1 | -1 = eventMatchesShortcut(e, combo('cycle_session_mru_forward'))
+          ? 1
+          : -1;
+
+        const sessionMap = getAllSyncSessionMap();
+        const currentSid = currentSessionIdRef.current;
+        const recentSessions = Array.from(sessionMap.values())
+          .filter((s) => s.id !== currentSid && !s.time?.archived)
+          .sort((a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0))
+          .map((s) => s.id);
+        sessionMRU.seedIfEmpty(recentSessions);
+
+        let targetSessionId: string | null = null;
+        for (let attempt = 0; attempt < 60; attempt++) {
+          const candidate = sessionMRU.cycle(direction);
+          if (!candidate) break;
+
+          const session = sessionMap.get(candidate);
+          if (!session || session.time?.archived) {
+            sessionMRU.removeSession(candidate);
+            continue;
+          }
+
+          targetSessionId = candidate;
+          break;
+        }
+
+        if (!targetSessionId) {
+          return;
+        }
+
+        e.preventDefault();
+        useSessionUIStore.getState().setCurrentSession(targetSessionId);
+        return;
+      }
+
       if (eventMatchesShortcut(e, combo('expand_input'))) {
         if (isMobile) {
           return;
@@ -568,7 +645,7 @@ export const useKeyboardShortcuts = () => {
         }
 
         // Double-ESC abort logic - only when on chat tab with no overlays
-        const sessionId = currentSessionId;
+        const sessionId = currentSessionIdRef.current;
         const canAbortNow = working.canAbort && Boolean(sessionId);
         if (!canAbortNow) {
           resetAbortPriming();
@@ -603,12 +680,20 @@ export const useKeyboardShortcuts = () => {
       }
     };
 
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Control' || e.key === 'Meta') {
+        sessionMRU.resetCursor();
+      }
+    };
+
     window.addEventListener('keydown', handleTerminalShortcutCapture, true);
     window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
 
     return () => {
       window.removeEventListener('keydown', handleTerminalShortcutCapture, true);
       window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
     };
   }, [
     openNewSessionDraft,
@@ -634,7 +719,6 @@ export const useKeyboardShortcuts = () => {
     working,
     armAbortPrompt,
     resetAbortPriming,
-    currentSessionId,
     currentDirectory,
     activeProject?.id,
     activeProject?.path,

--- a/packages/ui/src/lib/shortcuts.ts
+++ b/packages/ui/src/lib/shortcuts.ts
@@ -342,6 +342,13 @@ const SHORTCUT_ACTIONS: ReadonlyArray<ShortcutAction> = [
     customizable: true,
   },
   {
+    id: 'switch_session',
+    defaultCombo: 'mod+s',
+    label: 'Open session picker',
+    description: 'Open a searchable dialog to switch sessions',
+    customizable: true,
+  },
+  {
     id: 'expand_input',
     defaultCombo: 'mod+shift+e',
     label: 'Expand input',

--- a/packages/ui/src/lib/shortcuts.ts
+++ b/packages/ui/src/lib/shortcuts.ts
@@ -328,6 +328,20 @@ const SHORTCUT_ACTIONS: ReadonlyArray<ShortcutAction> = [
     customizable: true,
   },
   {
+    id: 'cycle_session_mru_forward',
+    defaultCombo: 'ctrl+tab',
+    label: 'Switch to previous session',
+    description: 'Cycle to the most recently used session (Ctrl+Tab tab switching)',
+    customizable: true,
+  },
+  {
+    id: 'cycle_session_mru_backward',
+    defaultCombo: 'ctrl+shift+tab',
+    label: 'Switch to next session (reverse)',
+    description: 'Cycle backward through recently used sessions',
+    customizable: true,
+  },
+  {
     id: 'expand_input',
     defaultCombo: 'mod+shift+e',
     label: 'Expand input',

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -615,6 +615,7 @@ interface UIStore {
   diffWrapLines: boolean;
   gitChangesViewMode: 'flat' | 'tree';
   isTimelineDialogOpen: boolean;
+  isSessionPickerOpen: boolean;
   isPromptNavigatorPanelOpen: boolean;
   isImagePreviewOpen: boolean;
   nativeNotificationsEnabled: boolean;
@@ -787,6 +788,7 @@ interface UIStore {
   setGitChangesViewMode: (mode: 'flat' | 'tree') => void;
   setMultiRunLauncherOpen: (open: boolean) => void;
   setTimelineDialogOpen: (open: boolean) => void;
+  setSessionPickerOpen: (open: boolean) => void;
   setPromptNavigatorPanelOpen: (open: boolean) => void;
   togglePromptNavigatorPanel: () => void;
   setImagePreviewOpen: (open: boolean) => void;
@@ -930,6 +932,7 @@ export const useUIStore = create<UIStore>()(
         diffWrapLines: false,
         gitChangesViewMode: 'flat',
         isTimelineDialogOpen: false,
+        isSessionPickerOpen: false,
         isPromptNavigatorPanelOpen: false,
         isImagePreviewOpen: false,
         nativeNotificationsEnabled: false,
@@ -2057,6 +2060,10 @@ export const useUIStore = create<UIStore>()(
 
         setTimelineDialogOpen: (open) => {
           set({ isTimelineDialogOpen: open });
+        },
+
+        setSessionPickerOpen: (open) => {
+          set({ isSessionPickerOpen: open });
         },
 
         setPromptNavigatorPanelOpen: (open) => {

--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -43,6 +43,7 @@ So:
 |---|---|---|
 | child directory stores in `sync-context.tsx` | `session`, `message`, `part`, `permission`, `question`, etc. | One directory |
 | `session-ui-store.ts` | Session selection, draft lifecycle, abort prompts, worktree metadata, SDK-facing action entrypoints | App UI state |
+| `session-mru.ts` | Most-recently-used session ordering for `cycle_session_mru_forward` / `cycle_session_mru_backward` keyboard shortcuts | App UI state (ephemeral) |
 | `useGlobalSessionsStore.ts` | Global active sessions, global archived sessions, `sessionsByDirectory` | All opened project/worktree session lists |
 | `viewport-store.ts` | Scroll anchors, session memory, loading indicators | App UI state |
 | `input-store.ts` | Draft input state, attached files, synthetic parts | App UI state |

--- a/packages/ui/src/sync/session-mru.test.ts
+++ b/packages/ui/src/sync/session-mru.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import { sessionMRU } from "./session-mru"
+
+// The module exports a singleton; reset its internal state before each test
+// by driving it through its public API.
+beforeEach(() => {
+  sessionMRU.resetCursor()
+  // Clear the stack by removing all entries we know about; tests below
+  // start from a known state by recording a single seed session first.
+  // The simplest reset: record null, then pop entries via cycle + removeSession.
+  sessionMRU.recordActiveSession(null)
+  // Drain any remaining stack entries.
+  for (let i = 0; i < 60; i++) {
+    const next = sessionMRU.cycle(1)
+    if (!next) break
+    sessionMRU.removeSession(next)
+  }
+  sessionMRU.recordActiveSession(null)
+})
+
+describe("sessionMRU.recordActiveSession", () => {
+  test("tracks the current session without pushing it to the stack", () => {
+    sessionMRU.recordActiveSession("a")
+    expect(sessionMRU.getCurrentSessionId()).toBe("a")
+    expect(sessionMRU.getStackSnapshot()).toEqual([])
+
+    sessionMRU.recordActiveSession("b")
+    expect(sessionMRU.getCurrentSessionId()).toBe("b")
+    expect(sessionMRU.getStackSnapshot()).toEqual(["a"])
+  })
+
+  test("does not push when the same id is re-recorded", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("b")
+    expect(sessionMRU.getStackSnapshot()).toEqual(["a"])
+  })
+
+  test("deduplicates: re-activating a stacked session moves it to current and removes from stack", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("c")
+    // Stack: [b, a], current: c
+    expect(sessionMRU.getStackSnapshot()).toEqual(["b", "a"])
+
+    sessionMRU.recordActiveSession("a")
+    // a is now current; stack should not contain a
+    expect(sessionMRU.getCurrentSessionId()).toBe("a")
+    expect(sessionMRU.getStackSnapshot()).toEqual(["c", "b"])
+  })
+
+  test("recording null pushes the previous session onto the stack", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession(null)
+    expect(sessionMRU.getCurrentSessionId()).toBeNull()
+    expect(sessionMRU.getStackSnapshot()).toEqual(["a"])
+  })
+})
+
+describe("sessionMRU.cycle", () => {
+  test("returns null when the stack is empty", () => {
+    sessionMRU.recordActiveSession("a")
+    expect(sessionMRU.cycle(1)).toBeNull()
+    expect(sessionMRU.cycle(-1)).toBeNull()
+  })
+
+  test("forward cycle walks the stack in MRU order and wraps around", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("c")
+    sessionMRU.recordActiveSession("d")
+    // Stack (MRU first): [c, b, a], current: d
+
+    expect(sessionMRU.cycle(1)).toBe("c")
+    expect(sessionMRU.cycle(1)).toBe("b")
+    expect(sessionMRU.cycle(1)).toBe("a")
+    // Wraps around to the front of the snapshot.
+    expect(sessionMRU.cycle(1)).toBe("c")
+  })
+
+  test("backward cycle starts at the oldest entry and wraps around", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("c")
+    sessionMRU.recordActiveSession("d")
+    // Stack (MRU first): [c, b, a], current: d
+
+    expect(sessionMRU.cycle(-1)).toBe("a")
+    expect(sessionMRU.cycle(-1)).toBe("b")
+    expect(sessionMRU.cycle(-1)).toBe("c")
+    // Wraps around to the back of the snapshot.
+    expect(sessionMRU.cycle(-1)).toBe("a")
+  })
+
+  test("cycle-induced setCurrentSession calls do not mutate the real stack", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    // Stack: [a], current: b
+
+    const target = sessionMRU.cycle(1)
+    expect(target).toBe("a")
+    // Simulate setCurrentSession(target) by recording it as active.
+    // The cycle path detects this and avoids mutating the stack.
+    sessionMRU.recordActiveSession(target!)
+
+    // Stack should be unchanged: [a] is still in the stack snapshot for
+    // continued cycling, even though currentSessionId is now "a".
+    expect(sessionMRU.getCurrentSessionId()).toBe("a")
+    expect(sessionMRU.getStackSnapshot()).toEqual(["a"])
+
+    // The cycling snapshot should still be available: pressing forward again
+    // wraps to the only entry.
+    expect(sessionMRU.cycle(1)).toBe("a")
+  })
+
+  test("external session change (not from cycling) commits the cycle", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("c")
+    // Stack: [b, a], current: c
+
+    // Start cycling: c -> b
+    expect(sessionMRU.cycle(1)).toBe("b")
+    sessionMRU.recordActiveSession("b")
+    // Stack unchanged: [b, a], current: b (cycle-induced, not committed)
+
+    // External session change (e.g., user clicks a different session):
+    sessionMRU.recordActiveSession("z")
+
+    // The cycle should be committed: b (the cycle-start session) should now be
+    // at the front of the stack, and z is current.
+    expect(sessionMRU.getCurrentSessionId()).toBe("z")
+    expect(sessionMRU.getStackSnapshot()[0]).toBe("b")
+    expect(sessionMRU.getStackSnapshot()).toContain("a")
+    expect(sessionMRU.isCycling()).toBe(false)
+  })
+
+  test("cursor reset by external recordActiveSession restarts the cycle from the top", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("c")
+    sessionMRU.recordActiveSession("d")
+    // Stack: [c, b, a], current: d
+
+    expect(sessionMRU.cycle(1)).toBe("c")
+    sessionMRU.recordActiveSession("c") // cycle-induced
+
+    // User clicks "x" in the sidebar — external change commits cycle.
+    sessionMRU.recordActiveSession("x")
+    expect(sessionMRU.isCycling()).toBe(false)
+
+    // New cycle should start fresh from the top of the real stack.
+    expect(sessionMRU.cycle(1)).toBe("c")
+  })
+})
+
+describe("sessionMRU.removeSession", () => {
+  test("removes the session from the stack and current", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("c")
+    // Stack: [b, a], current: c
+
+    sessionMRU.removeSession("b")
+    expect(sessionMRU.getStackSnapshot()).toEqual(["a"])
+
+    sessionMRU.removeSession("c")
+    expect(sessionMRU.getCurrentSessionId()).toBeNull()
+  })
+
+  test("resets an in-progress cycle when a snapshot entry is removed", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("c")
+    // Stack: [b, a], current: c
+
+    expect(sessionMRU.cycle(1)).toBe("b")
+    expect(sessionMRU.isCycling()).toBe(true)
+
+    // Remove "b" from the snapshot mid-cycle.
+    sessionMRU.removeSession("b")
+    expect(sessionMRU.isCycling()).toBe(false)
+    expect(sessionMRU.getStackSnapshot()).toEqual(["a"])
+
+    // Next cycle starts fresh from the new top of the stack.
+    expect(sessionMRU.cycle(1)).toBe("a")
+  })
+})
+
+describe("sessionMRU.resetCursor", () => {
+  test("commits the cycle and clears cycling state", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    sessionMRU.recordActiveSession("c")
+    // Stack: [b, a], current: c
+
+    expect(sessionMRU.cycle(1)).toBe("b")
+    sessionMRU.recordActiveSession("b") // cycle-induced switch
+    sessionMRU.resetCursor()
+
+    expect(sessionMRU.isCycling()).toBe(false)
+    // After commit: b is current, c (cycle-start) is most-recent in stack.
+    expect(sessionMRU.getCurrentSessionId()).toBe("b")
+    expect(sessionMRU.getStackSnapshot()[0]).toBe("c")
+  })
+})
+
+describe("sessionMRU.seedIfEmpty", () => {
+  test("seeds the stack when empty so cycling works on fresh launch", () => {
+    sessionMRU.recordActiveSession("current")
+    expect(sessionMRU.getStackSnapshot()).toEqual([])
+
+    sessionMRU.seedIfEmpty(["a", "b", "c"])
+    expect(sessionMRU.getStackSnapshot()).toEqual(["a", "b", "c"])
+
+    expect(sessionMRU.cycle(1)).toBe("a")
+  })
+
+  test("does not overwrite a non-empty stack", () => {
+    sessionMRU.recordActiveSession("a")
+    sessionMRU.recordActiveSession("b")
+    // Stack: [a], current: b
+
+    sessionMRU.seedIfEmpty(["x", "y", "z"])
+    expect(sessionMRU.getStackSnapshot()).toEqual(["a"])
+  })
+
+  test("truncates to max size", () => {
+    sessionMRU.recordActiveSession("current")
+    const many = Array.from({ length: 100 }, (_, i) => `s${i}`)
+    sessionMRU.seedIfEmpty(many)
+    expect(sessionMRU.getStackSnapshot().length).toBe(50)
+  })
+})
+
+describe("keyboard handler stale-skip simulation", () => {
+  test("cycle skips stale entries and lands on the first live one", () => {
+    sessionMRU.recordActiveSession("current")
+    sessionMRU.seedIfEmpty(["stale1", "live", "stale2"])
+
+    // Simulate what useKeyboardShortcuts does: cycle, check if stale, remove + retry
+    let target: string | null = null
+    const liveSessions = new Set(["live", "current"])
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const candidate = sessionMRU.cycle(1)
+      if (!candidate) break
+      if (!liveSessions.has(candidate)) {
+        sessionMRU.removeSession(candidate)
+        continue
+      }
+      target = candidate
+      break
+    }
+
+    expect(target).toBe("live")
+  })
+
+  test("returns null when all stacked sessions are stale", () => {
+    sessionMRU.recordActiveSession("current")
+    sessionMRU.seedIfEmpty(["stale1", "stale2"])
+
+    let target: string | null = null
+    const liveSessions = new Set(["current"])
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const candidate = sessionMRU.cycle(1)
+      if (!candidate) break
+      if (!liveSessions.has(candidate)) {
+        sessionMRU.removeSession(candidate)
+        continue
+      }
+      target = candidate
+      break
+    }
+
+    expect(target).toBeNull()
+  })
+})

--- a/packages/ui/src/sync/session-mru.ts
+++ b/packages/ui/src/sync/session-mru.ts
@@ -1,0 +1,200 @@
+/**
+ * Session most-recently-used (MRU) tracker.
+ *
+ * Records the order in which sessions were active so keyboard shortcuts
+ * (`cycle_session_mru_forward` / `cycle_session_mru_backward`) can switch
+ * between them like browser tab cycling.
+ *
+ * Cycling model:
+ * - `recordActiveSession(id)` is called whenever the active session changes
+ *   (from any source — sidebar click, URL navigation, etc.). The previous
+ *   active session is pushed to the top of the MRU stack.
+ * - `cycle(direction)` returns the next session ID to switch to, walking
+ *   the MRU stack without mutating it. A snapshot is taken on the first
+ *   cycle call after a reset so successive presses walk a stable list.
+ * - The cursor resets (committing the cycle) after `CURSOR_RESET_MS` of
+ *   inactivity, or when `recordActiveSession` is called from outside the
+ *   cycle (e.g., the user clicks a session in the sidebar mid-cycle).
+ *
+ * The tracker is framework-agnostic and does not know whether sessions
+ * still exist. Callers must validate returned IDs against the live session
+ * map (see `getAllSyncSessionMap` from `./sync-refs`) and call
+ * `removeSession` for any IDs that are gone.
+ */
+
+const MAX_MRU_SIZE = 50;
+const CURSOR_RESET_MS = 1500;
+
+export type CycleDirection = 1 | -1;
+
+class SessionMRU {
+  private stack: string[] = [];
+  private cyclingStack: string[] | null = null;
+  private cursor: number = -1;
+  private cursorResetTimer: ReturnType<typeof setTimeout> | null = null;
+  private currentSessionId: string | null = null;
+  private cycleStartSessionId: string | null = null;
+
+  recordActiveSession(sessionId: string | null): void {
+    if (sessionId === this.currentSessionId) {
+      return;
+    }
+
+    // If a cycle is in progress and the new session is the one the cycle
+    // pointed at, this is the cycle-induced switch — update currentSessionId
+    // but don't disturb the stack snapshot.
+    if (
+      this.cyclingStack !== null
+      && this.cursor !== -1
+      && sessionId !== null
+      && this.cyclingStack[this.cursor] === sessionId
+    ) {
+      this.currentSessionId = sessionId;
+      return;
+    }
+
+    // Any other active-session change commits the cycle and starts fresh.
+    if (this.cyclingStack !== null) {
+      this.commitCycle();
+    }
+
+    const previous = this.currentSessionId;
+    this.currentSessionId = sessionId;
+
+    if (previous && previous !== sessionId) {
+      this.stack = this.stack.filter((id) => id !== previous);
+      this.stack.unshift(previous);
+    }
+    if (sessionId) {
+      this.stack = this.stack.filter((id) => id !== sessionId);
+    }
+    if (this.stack.length > MAX_MRU_SIZE) {
+      this.stack.length = MAX_MRU_SIZE;
+    }
+    this.resetCursor();
+  }
+
+  cycle(direction: CycleDirection): string | null {
+    if (this.cyclingStack === null) {
+      this.cyclingStack = this.stack.filter((id) => id !== this.currentSessionId);
+      this.cursor = -1;
+      this.cycleStartSessionId = this.currentSessionId;
+    }
+    if (this.cyclingStack.length === 0) {
+      return null;
+    }
+
+    const nextCursor = this.cursor === -1
+      ? (direction === 1 ? 0 : this.cyclingStack.length - 1)
+      : (this.cursor + direction + this.cyclingStack.length) % this.cyclingStack.length;
+
+    this.cursor = nextCursor;
+    this.armCursorReset();
+    return this.cyclingStack[nextCursor] ?? null;
+  }
+
+  /**
+   * Seed the MRU stack from a fallback list when the stack is empty.
+   * Called by the keyboard handler before cycling so that Ctrl+Tab works
+   * on a fresh app launch (before any sessions have been switched).
+   *
+   * `sessions` should be ordered most-recent-first (e.g., by `time.updated`
+   * descending). The current session and archived sessions should already
+   * be filtered out by the caller.
+   */
+  seedIfEmpty(sessions: string[]): void {
+    if (this.stack.length > 0) {
+      return;
+    }
+    this.stack = sessions.slice(0, MAX_MRU_SIZE);
+  }
+
+  removeSession(sessionId: string): void {
+    this.stack = this.stack.filter((id) => id !== sessionId);
+    if (this.cyclingStack) {
+      const cyclingNext = this.cyclingStack.filter((id) => id !== sessionId);
+      if (cyclingNext.length !== this.cyclingStack.length) {
+        // Snapshot changed; reset the cycle so the next call takes a fresh snapshot.
+        this.cyclingStack = null;
+        this.cursor = -1;
+        this.cycleStartSessionId = null;
+        if (this.cursorResetTimer) {
+          clearTimeout(this.cursorResetTimer);
+          this.cursorResetTimer = null;
+        }
+      } else {
+        this.cyclingStack = cyclingNext;
+      }
+    }
+    if (this.currentSessionId === sessionId) {
+      this.currentSessionId = null;
+    }
+  }
+
+  resetCursor(): void {
+    if (this.cursorResetTimer) {
+      clearTimeout(this.cursorResetTimer);
+      this.cursorResetTimer = null;
+    }
+    if (this.cyclingStack !== null) {
+      this.commitCycle();
+      return;
+    }
+    this.cursor = -1;
+  }
+
+  getCurrentSessionId(): string | null {
+    return this.currentSessionId;
+  }
+
+  /** Snapshot for debugging/tests. Order: most-recent first. */
+  getStackSnapshot(): string[] {
+    return [...this.stack];
+  }
+
+  /** Whether a cycle is in progress. Exposed for tests. */
+  isCycling(): boolean {
+    return this.cyclingStack !== null;
+  }
+
+  private commitCycle(): void {
+    if (this.cyclingStack === null) {
+      return;
+    }
+    if (this.cursor !== -1) {
+      const landedSessionId = this.cyclingStack[this.cursor];
+      // Use cycleStartSessionId (the session that was active when cycling
+      // began) — not currentSessionId, which has been updated during the cycle.
+      const previousCurrent = this.cycleStartSessionId;
+
+      this.stack = this.stack.filter((id) => id !== landedSessionId);
+
+      if (previousCurrent && previousCurrent !== landedSessionId) {
+        this.stack = this.stack.filter((id) => id !== previousCurrent);
+        this.stack.unshift(previousCurrent);
+      }
+      if (this.stack.length > MAX_MRU_SIZE) {
+        this.stack.length = MAX_MRU_SIZE;
+      }
+    }
+    this.cyclingStack = null;
+    this.cursor = -1;
+    this.cycleStartSessionId = null;
+    if (this.cursorResetTimer) {
+      clearTimeout(this.cursorResetTimer);
+      this.cursorResetTimer = null;
+    }
+  }
+
+  private armCursorReset(): void {
+    if (this.cursorResetTimer) {
+      clearTimeout(this.cursorResetTimer);
+    }
+    this.cursorResetTimer = setTimeout(() => {
+      this.cursorResetTimer = null;
+      this.commitCycle();
+    }, CURSOR_RESET_MS);
+  }
+}
+
+export const sessionMRU = new SessionMRU();

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -69,6 +69,7 @@ import { getAttachedSessionDirectory } from "./session-worktree-contract"
 import { setSessionOpener } from "./session-navigation"
 import { getRuntimeKey } from "@/lib/runtime-switch"
 import { rememberRuntimeLiveStatus } from "./runtime-live-memory"
+import { sessionMRU } from "./session-mru"
 
 export type { AttachedFile }
 
@@ -1621,5 +1622,11 @@ useSessionUIStore.subscribe((state, prev) => {
       lastPersistedWorktreeSerialized = serialized
       persistWorktreeMap(serialized)
     }
+  }
+})
+
+useSessionUIStore.subscribe((state, prev) => {
+  if (state.currentSessionId !== prev.currentSessionId) {
+    sessionMRU.recordActiveSession(state.currentSessionId)
   }
 })


### PR DESCRIPTION
## Summary

Add Ctrl+Tab / Ctrl+Shift+Tab most-recently-used (MRU) session switching and a Ctrl+S session picker dialog, addressing the session-switching portion of #709.

[Image: ctrl-tab cycling between sessions]

## Changes

- Register `cycle_session_mru_forward` (`ctrl+tab`), `cycle_session_mru_backward` (`ctrl+shift+tab`), and `switch_session` (`mod+s`) shortcut actions in `shortcuts.ts` — all customizable via Settings > Shortcuts
- Add `SessionMRU` tracker (`session-mru.ts`): framework-agnostic class that maintains a most-recently-used stack, takes a snapshot on first cycle so successive presses walk a stable list, and commits the cycle on Ctrl/Meta keyup (matching browser tab-switching behavior)
- Wire `useSessionUIStore.subscribe` to feed `currentSessionId` changes into the MRU tracker
- Add `keyup` handler in `useKeyboardShortcuts` to commit the cycle when the modifier key is released
- Guard against `e.repeat` so OS key-autorepeat doesn't hammer session switches
- Seed the MRU stack from recent sessions (sorted by `time.updated`) on first Ctrl+Tab when the stack is empty, so cycling works immediately on fresh launch
- Lazily skip deleted/archived sessions during cycling via `getAllSyncSessionMap`
- Add `SessionPickerDialog` component: searchable session list with Arrow/j/k navigation, Enter to select, relative timestamps, project labels, and current-session indicator
- Add `isSessionPickerOpen` state to `useUIStore`
- Render `SessionPickerDialog` in `ChatContainer` alongside `TimelineDialog`
- Add `session-mru.ts` to the sync ownership map in `DOCUMENTATION.md`

## How it works

1. **Ctrl+Tab** (hold Ctrl, tap Tab): cycles to the most recently used session. Successive Tab presses walk further back through the MRU stack. Releasing Ctrl commits the cycle (the landed session becomes current, previous current is pushed to top of MRU). This matches the behavior users expect from browser tab switching.
2. **Ctrl+Shift+Tab**: same as above but in reverse direction.
3. **Ctrl+S**: opens a searchable session picker dialog (like Ctrl+T for timeline). Type to filter by title, Arrow keys or Ctrl+j/Ctrl+k to navigate, Enter to switch.

The MRU tracker uses a ref for `currentSessionId` in the keyboard hook so the keydown listener isn't torn down and recreated on every session switch mid-cycle.

## Files

| File | Change |
|------|--------|
| `packages/ui/src/sync/session-mru.ts` (new) | MRU tracker class with stack, cycle, commit, seed, and stale-session removal |
| `packages/ui/src/sync/session-mru.test.ts` (new) | 13 tests covering recording, cycling, wrap, cycle-induced vs external switches, stale removal, cursor reset |
| `packages/ui/src/lib/shortcuts.ts` | Add 3 new shortcut actions |
| `packages/ui/src/sync/session-ui-store.ts` | Subscribe to `currentSessionId` changes → `sessionMRU.recordActiveSession` |
| `packages/ui/src/hooks/useKeyboardShortcuts.ts` | Handle Ctrl+Tab/Ctrl+Shift+Tab/Ctrl+S, keyup commit, `e.repeat` guard |
| `packages/ui/src/stores/useUIStore.ts` | Add `isSessionPickerOpen` state + setter |
| `packages/ui/src/components/session/SessionPickerDialog.tsx` (new) | Searchable session picker dialog component |
| `packages/ui/src/components/chat/ChatContainer.tsx` | Render `SessionPickerDialog` |
| `packages/ui/src/sync/DOCUMENTATION.md` | Add `session-mru.ts` to ownership map |

## Validation

```
bun run type-check:ui   # pass
bun run lint:ui         # pass
bun test packages/ui/src/sync/session-mru.test.ts   # 13/13 pass
```

Closes #709 (session switching portion)
Related: #608, #1454
