### PR TITLE
fix(preview): rewrite relative ES module imports and strip crossorigin in HTML

### DIFF
--- a/packages/web/server/lib/preview/proxy-runtime.js
+++ b/packages/web/server/lib/preview/proxy-runtime.js
@@ -1038,7 +1038,7 @@ const appendProxyAuthToProxyUrl = (value, { previewToken = '', urlAuthToken = ''
 
 const normalizeLoopbackUrl = (rawUrl) => normalizeProxyTargetUrl(rawUrl, { allowExternal: false });
 
-export const rewritePreviewBody = ({ bodyText, proxyBasePath, targetOrigin, kind, previewToken = '', urlAuthToken = '' }) => {
+export const rewritePreviewBody = ({ bodyText, proxyBasePath, targetOrigin, kind, previewToken = '', urlAuthToken = '', modulePath = '' }) => {
   if (typeof bodyText !== 'string' || bodyText.length === 0) {
     return bodyText;
   }
@@ -1072,6 +1072,25 @@ export const rewritePreviewBody = ({ bodyText, proxyBasePath, targetOrigin, kind
     }
     return value;
   };
+  const moduleDir = (() => {
+    if (!modulePath) return '';
+    try {
+      const parsed = new URL(modulePath, 'http://localhost');
+      const dir = parsed.pathname.replace(/[^/]*$/, '');
+      return dir;
+    } catch {
+      return '';
+    }
+  })();
+  const resolveRelativeUrl = (relativePath) => {
+    if (!moduleDir) return relativePath;
+    try {
+      const resolved = new URL(relativePath, `http://localhost${moduleDir}`);
+      return resolved.pathname;
+    } catch {
+      return relativePath;
+    }
+  };
   const stripPreviewCspMeta = (text) => text
     .replace(/<meta\b(?=[^>]*\bhttp-equiv\s*=\s*(['"])content-security-policy\1)[^>]*>/gi, '')
     .replace(/<meta\b(?=[^>]*\bhttp-equiv\s*=\s*content-security-policy\b)[^>]*>/gi, '');
@@ -1083,16 +1102,40 @@ export const rewritePreviewBody = ({ bodyText, proxyBasePath, targetOrigin, kind
     .replace(/@import\s+(['"])\/(?!\/)([^'"]*)\1/gi, (_match, quote, path) => {
       return `@import ${quote}${rewriteResourceUrl(`/${path}`)}${quote}`;
     });
-  const rewriteJavaScript = (text) => text
-    .replace(/\bfrom\s+(['"])\/(?!\/)([^'"]*)\1/gi, (_match, quote, path) => {
-      return `from ${quote}${rewriteResourceUrl(`/${path}`)}${quote}`;
-    })
-    .replace(/\bimport\s+(['"])\/(?!\/)([^'"]*)\1/gi, (_match, quote, path) => {
-      return `import ${quote}${rewriteResourceUrl(`/${path}`)}${quote}`;
-    })
-    .replace(/\bimport\(\s*(['"])\/(?!\/)([^'"]*)\1\s*\)/gi, (_match, quote, path) => {
-      return `import(${quote}${rewriteResourceUrl(`/${path}`)}${quote})`;
-    });
+  const rewriteJavaScript = (text, dir = '') => {
+    const activeDir = dir || moduleDir;
+    let result = text
+      .replace(/\bfrom\s+(['"])\/(?!\/)([^'"]*)\1/gi, (_match, quote, path) => {
+        return `from ${quote}${rewriteResourceUrl(`/${path}`)}${quote}`;
+      })
+      .replace(/\bimport\s+(['"])\/(?!\/)([^'"]*)\1/gi, (_match, quote, path) => {
+        return `import ${quote}${rewriteResourceUrl(`/${path}`)}${quote}`;
+      })
+      .replace(/\bimport\(\s*(['"])\/(?!\/)([^'"]*)\1\s*\)/gi, (_match, quote, path) => {
+        return `import(${quote}${rewriteResourceUrl(`/${path}`)}${quote})`;
+      });
+    if (activeDir) {
+      const resolveRel = (relativePath) => {
+        try {
+          const resolved = new URL(relativePath, `http://localhost${activeDir}`);
+          return resolved.pathname;
+        } catch {
+          return relativePath;
+        }
+      };
+      result = result
+        .replace(/\bfrom\s+(['"])(\.\.?\/[^'"]*)\1/gi, (_match, quote, path) => {
+          return `from ${quote}${rewriteResourceUrl(resolveRel(path))}${quote}`;
+        })
+        .replace(/\bimport\s+(['"])(\.\.?\/[^'"]*)\1/gi, (_match, quote, path) => {
+          return `import ${quote}${rewriteResourceUrl(resolveRel(path))}${quote}`;
+        })
+        .replace(/\bimport\(\s*(['"])(\.\.?\/[^'"]*)\1\s*\)/gi, (_match, quote, path) => {
+          return `import(${quote}${rewriteResourceUrl(resolveRel(path))}${quote})`;
+        });
+    }
+    return result;
+  };
   const rewriteInlineModuleScripts = (text) => text.replace(
     /<script\b([^>]*)>([\s\S]*?)<\/script>/gi,
     (match, attrs, scriptBody) => {
@@ -1102,26 +1145,28 @@ export const rewritePreviewBody = ({ bodyText, proxyBasePath, targetOrigin, kind
       const type = String(typeMatch?.[1] ?? typeMatch?.[2] ?? typeMatch?.[3] ?? '').trim().toLowerCase();
       if (type !== 'module') return match;
 
-      const rewrittenScriptBody = rewriteJavaScript(scriptBody);
+      const rewrittenScriptBody = rewriteJavaScript(scriptBody, '');
       if (rewrittenScriptBody === scriptBody) return match;
       return `<script${attrs}>${rewrittenScriptBody}</script>`;
     },
   );
-  const rewriteHtml = (text) => rewriteInlineModuleScripts(text
-    .replace(/\b(src|href|action)=(['"])([^'"]*)\2/gi, (_match, attr, quote, value) => {
-      return `${attr}=${quote}${rewriteResourceUrl(value)}${quote}`;
-    })
-    .replace(/\bsrcset=(['"])([^'"]*)\1/gi, (_match, quote, value) => {
-      const rewritten = String(value).split(',').map((part) => {
-        const trimmed = part.trim();
-        if (!trimmed) return trimmed;
-        const segments = trimmed.split(/\s+/);
-        const url = segments[0] || '';
-        segments[0] = rewriteResourceUrl(url);
-        return segments.join(' ');
-      }).join(', ');
-      return `srcset=${quote}${rewritten}${quote}`;
-    }));
+  const rewriteHtml = (text) => rewriteInlineModuleScripts(
+    text
+      .replace(/\bcrossorigin(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?/gi, '')
+      .replace(/\b(src|href|action)=(['"])([^'"]*)\2/gi, (_match, attr, quote, value) => {
+        return `${attr}=${quote}${rewriteResourceUrl(value)}${quote}`;
+      })
+      .replace(/\bsrcset=(['"])([^'"]*)\1/gi, (_match, quote, value) => {
+        const rewritten = String(value).split(',').map((part) => {
+          const trimmed = part.trim();
+          if (!trimmed) return trimmed;
+          const segments = trimmed.split(/\s+/);
+          const url = segments[0] || '';
+          segments[0] = rewriteResourceUrl(url);
+          return segments.join(' ');
+        }).join(', ');
+        return `srcset=${quote}${rewritten}${quote}`;
+      }));
 
   if (kind === 'html') return stripPreviewCspMeta(rewriteHtml(bodyText));
   if (kind === 'css') return rewriteCss(bodyText);
@@ -1505,6 +1550,7 @@ export const createPreviewProxyRuntime = ({
               kind: 'javascript',
               previewToken: resolved.entry.token,
               urlAuthToken,
+              modulePath: upstreamPath,
             });
           }
 
@@ -1515,6 +1561,7 @@ export const createPreviewProxyRuntime = ({
             kind: isHtml ? 'html' : isCss ? 'css' : 'javascript',
             previewToken: resolved.entry.token,
             urlAuthToken,
+            modulePath: isJavaScript ? upstreamPath : '',
           });
           return isHtml ? injectPreviewBridge(rewrittenBody, resolved.entry.origin, bridgeNonce) : rewrittenBody;
         }),

--- a/packages/web/server/lib/preview/proxy-runtime.js
+++ b/packages/web/server/lib/preview/proxy-runtime.js
@@ -1152,7 +1152,7 @@ export const rewritePreviewBody = ({ bodyText, proxyBasePath, targetOrigin, kind
   );
   const rewriteHtml = (text) => rewriteInlineModuleScripts(
     text
-      .replace(/\bcrossorigin(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?/gi, '')
+      .replace(/<(script|link)\b[^>]*?>/gi, (match) => match.replace(/\bcrossorigin(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?/gi, ''))
       .replace(/\b(src|href|action)=(['"])([^'"]*)\2/gi, (_match, attr, quote, value) => {
         return `${attr}=${quote}${rewriteResourceUrl(value)}${quote}`;
       })

--- a/packages/web/server/lib/preview/proxy-runtime.js
+++ b/packages/web/server/lib/preview/proxy-runtime.js
@@ -1112,18 +1112,24 @@ export const rewritePreviewBody = ({ bodyText, proxyBasePath, targetOrigin, kind
           const resolved = new URL(relativePath, `http://localhost${activeDir}`);
           return resolved.pathname;
         } catch {
-          return relativePath;
+          return null;
         }
       };
       result = result
         .replace(/\bfrom\s+(['"])(\.\.?\/[^'"]*)\1/gi, (_match, quote, path) => {
-          return `from ${quote}${rewriteResourceUrl(resolveRel(path))}${quote}`;
+          const resolved = resolveRel(path);
+          if (resolved === null) return _match;
+          return `from ${quote}${rewriteResourceUrl(resolved)}${quote}`;
         })
         .replace(/\bimport\s+(['"])(\.\.?\/[^'"]*)\1/gi, (_match, quote, path) => {
-          return `import ${quote}${rewriteResourceUrl(resolveRel(path))}${quote}`;
+          const resolved = resolveRel(path);
+          if (resolved === null) return _match;
+          return `import ${quote}${rewriteResourceUrl(resolved)}${quote}`;
         })
         .replace(/\bimport\(\s*(['"])(\.\.?\/[^'"]*)\1\s*\)/gi, (_match, quote, path) => {
-          return `import(${quote}${rewriteResourceUrl(resolveRel(path))}${quote})`;
+          const resolved = resolveRel(path);
+          if (resolved === null) return _match;
+          return `import(${quote}${rewriteResourceUrl(resolved)}${quote})`;
         });
     }
     return result;

--- a/packages/web/server/lib/preview/proxy-runtime.js
+++ b/packages/web/server/lib/preview/proxy-runtime.js
@@ -1082,15 +1082,7 @@ export const rewritePreviewBody = ({ bodyText, proxyBasePath, targetOrigin, kind
       return '';
     }
   })();
-  const resolveRelativeUrl = (relativePath) => {
-    if (!moduleDir) return relativePath;
-    try {
-      const resolved = new URL(relativePath, `http://localhost${moduleDir}`);
-      return resolved.pathname;
-    } catch {
-      return relativePath;
-    }
-  };
+
   const stripPreviewCspMeta = (text) => text
     .replace(/<meta\b(?=[^>]*\bhttp-equiv\s*=\s*(['"])content-security-policy\1)[^>]*>/gi, '')
     .replace(/<meta\b(?=[^>]*\bhttp-equiv\s*=\s*content-security-policy\b)[^>]*>/gi, '');

--- a/packages/web/server/lib/preview/proxy-runtime.test.js
+++ b/packages/web/server/lib/preview/proxy-runtime.test.js
@@ -450,6 +450,19 @@ describe('preview body URL rewriting', () => {
     expect(output).toContain('crossoriginEnabled');
     expect(output).not.toMatch(/<link[^>]*crossorigin/i);
   });
+  it('preserves relative imports unchanged when modulePath is empty string (issue #2338)', () => {
+    const jsOutput = rewritePreviewBody({
+      bodyText: 'import { defineComponent } from "./chunk.js";',
+      kind: 'javascript',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'http://127.0.0.1:3000',
+      previewToken: 'preview-secret',
+      modulePath: '',
+    });
+
+    // Empty modulePath means relative imports cannot be resolved; preserve original
+    expect(jsOutput).toContain('from "./chunk.js"');
+  });
 });
 
 describe('preview redirect URL rewriting', () => {

--- a/packages/web/server/lib/preview/proxy-runtime.test.js
+++ b/packages/web/server/lib/preview/proxy-runtime.test.js
@@ -437,6 +437,19 @@ describe('preview body URL rewriting', () => {
 
     expect(output).not.toMatch(/crossorigin/i);
   });
+
+  it('does not strip crossorigin from inline script JavaScript identifiers (issue #2338)', () => {
+    const output = rewritePreviewBody({
+      bodyText: '<script type="module">if (window.crossoriginEnabled) { console.log("test"); }</script><link rel="modulepreload" crossorigin="" href="/_nuxt/C2VRKy4g.js">',
+      kind: 'html',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'http://127.0.0.1:3000',
+      previewToken: 'preview-secret',
+    });
+
+    expect(output).toContain('crossoriginEnabled');
+    expect(output).not.toMatch(/<link[^>]*crossorigin/i);
+  });
 });
 
 describe('preview redirect URL rewriting', () => {

--- a/packages/web/server/lib/preview/proxy-runtime.test.js
+++ b/packages/web/server/lib/preview/proxy-runtime.test.js
@@ -373,6 +373,70 @@ describe('preview body URL rewriting', () => {
     expect(jsOutput).toContain('import("/api/preview/proxy/abc123/entry.js?oc_preview_token=preview-secret&oc_url_token=url-secret")');
     expect(jsOutput).toContain('from "/api/preview/proxy/abc123/module.js?oc_preview_token=preview-secret&oc_url_token=url-secret"');
   });
+
+  it('rewrites relative module import paths in JavaScript responses (issue #2338)', () => {
+    const jsOutput = rewritePreviewBody({
+      bodyText: 'import { defineComponent } from "./DlAUqK2U.js";\nconst mod = await import("./chunk-abc123.js");\nimport("../parent.js").then(m => m.default);',
+      kind: 'javascript',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'http://127.0.0.1:3000',
+      previewToken: 'preview-secret',
+      modulePath: '/_nuxt/entry.js',
+    });
+
+    expect(jsOutput).toContain('from "/api/preview/proxy/abc123/_nuxt/DlAUqK2U.js?oc_preview_token=preview-secret"');
+    expect(jsOutput).toContain('import("/api/preview/proxy/abc123/_nuxt/chunk-abc123.js?oc_preview_token=preview-secret")');
+    expect(jsOutput).toContain('import("/api/preview/proxy/abc123/parent.js?oc_preview_token=preview-secret")');
+  });
+
+  it('leaves relative imports unchanged when modulePath is not provided', () => {
+    const jsOutput = rewritePreviewBody({
+      bodyText: 'import { defineComponent } from "./DlAUqK2U.js";',
+      kind: 'javascript',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'http://127.0.0.1:3000',
+    });
+
+    expect(jsOutput).toContain('from "./DlAUqK2U.js"');
+  });
+
+  it('strips crossorigin="" from modulepreload <link> tags (issue #2338)', () => {
+    const output = rewritePreviewBody({
+      bodyText: '<link rel="modulepreload" crossorigin="" href="/_nuxt/C2VRKy4g.js">',
+      kind: 'html',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'http://127.0.0.1:3000',
+      previewToken: 'preview-secret',
+    });
+
+    expect(output).not.toMatch(/crossorigin/i);
+    expect(output).toContain('href="/api/preview/proxy/abc123/_nuxt/C2VRKy4g.js?oc_preview_token=preview-secret"');
+  });
+
+  it('strips crossorigin="" from module <script> tags (issue #2338)', () => {
+    const output = rewritePreviewBody({
+      bodyText: '<script crossorigin="" src="/_nuxt/entry.js" type="module"></script>',
+      kind: 'html',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'http://127.0.0.1:3000',
+      previewToken: 'preview-secret',
+    });
+
+    expect(output).not.toMatch(/crossorigin/i);
+    expect(output).toContain('src="/api/preview/proxy/abc123/_nuxt/entry.js?oc_preview_token=preview-secret"');
+  });
+
+  it('strips crossorigin="anonymous" from tags (issue #2338)', () => {
+    const output = rewritePreviewBody({
+      bodyText: '<link rel="modulepreload" crossorigin="anonymous" href="/_nuxt/C2VRKy4g.js"><script crossorigin=\'anonymous\' src="/_nuxt/app.js" type="module"></script>',
+      kind: 'html',
+      proxyBasePath: '/api/preview/proxy/abc123',
+      targetOrigin: 'http://127.0.0.1:3000',
+      previewToken: 'preview-secret',
+    });
+
+    expect(output).not.toMatch(/crossorigin/i);
+  });
 });
 
 describe('preview redirect URL rewriting', () => {


### PR DESCRIPTION
## Summary

Fixes #2338 — the preview proxy failed to authenticate relative ES module imports in Nuxt 3 production builds, causing `Failed to fetch dynamically imported module` errors with 403 responses.

### Root cause

Two compounding gaps in the proxy's rewriting and authentication logic:

1. **`rewriteJavaScript` did not rewrite relative import paths** — only absolute paths starting with `/` were matched. Relative imports like `./DlAUqK2U.js` were left unchanged, and the browser resolved them against the module URL, dropping the `oc_preview_token` query parameter per the WHATWG URL spec.

2. **`rewriteHtml` did not strip `crossorigin=""`** from `<link>` and `<script>` tags. Since `crossorigin=""` is equivalent to `crossorigin="anonymous"`, the browser sets credentials mode to `"omit"`, preventing the `oc_preview_token` cookie from being sent as a fallback.

3. The client-side `fetch` patch cannot intercept native ES module imports, so neither URL-based nor cookie-based auth worked for relative imports.

### Fix (Option C — both fixes for defense in depth)

- Add `modulePath` parameter to `rewritePreviewBody` (default `""`, backward-compatible). When provided for JavaScript responses, derive `moduleDir` and resolve relative import paths (`./…`, `../…`) against it, then rewrite through `rewriteResourceUrl` with auth tokens.

- Add regex patterns in `rewriteJavaScript` to match relative import specifiers (`from "./…"`, `import "./…"`, `import("./…")`) and resolve them against the module directory before rewriting.

- Pass `upstreamPath` as `modulePath` at call sites for JavaScript responses; leave it empty for HTML/CSS.

- Strip `crossorigin` attributes (empty, `anonymous`, `use-credentials`, or bare boolean) from HTML before rewriting `src`/`href`, so the browser defaults to `credentials: "same-origin"` for same-origin module requests, allowing the `oc_preview_token` cookie fallback.

- Inline module scripts (`rewriteInlineModuleScripts`) pass empty dir to `rewriteJavaScript`, leaving relative imports unchanged since they don't have a module URL context.

### Related

- #1470 — previous fix that added inline module script rewriting (partial fix; did not cover external module scripts with `crossorigin` or relative imports in external JS)
- #1642 — mentions `Failed to fetch dynamically imported module` in a different context (auto-discover error surfacing)