### PR TITLE
fix(vscode): break static import chain that prevents VS Code workspace detection

### DIFF
--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -542,7 +542,6 @@ const getVSCodeWorkspaceProject = (): { projects: ProjectEntry[]; activeProjectI
 // because static imports can reach this module before the runtime registry is
 // populated (see #2354). Use getters/functions so the values are computed on
 // first access, after the runtime APIs have been registered.
-const getVSCodeWorkspace = (): ReturnType<typeof getVSCodeWorkspaceProject> => getVSCodeWorkspaceProject();
 const getIsVSCodeProjectsRuntime = (): boolean => {
   if (typeof window === 'undefined') return false;
   return Boolean(getRegisteredRuntimeAPIs()?.runtime?.isVSCode);
@@ -552,7 +551,7 @@ function getInitialProjectsState(): {
   projects: ProjectEntry[];
   activeProjectId: string | null;
 } {
-  const vscodeWorkspace = getVSCodeWorkspace();
+  const vscodeWorkspace = getVSCodeWorkspaceProject();
   const isVSCodeProjectsRuntime = getIsVSCodeProjectsRuntime();
   const effectiveInitialProjects = vscodeWorkspace?.projects ?? (isVSCodeProjectsRuntime ? [] : initialProjects);
   const persistedInitialActiveProjectId = vscodeWorkspace?.activeProjectId ?? (isVSCodeProjectsRuntime ? null : readPersistedActiveProjectId());
@@ -567,12 +566,13 @@ function getInitialProjectsState(): {
   return { projects: effectiveInitialProjects, activeProjectId: initialActiveProjectId };
 }
 
-const initialProjectsState = getInitialProjectsState();
 
 export const useProjectsStore = create<ProjectsStore>()(
-  devtools((set, get) => ({
-    projects: initialProjectsState.projects,
-    activeProjectId: initialProjectsState.activeProjectId,
+  devtools((set, get) => {
+    const initial = getInitialProjectsState();
+    return {
+    projects: initial.projects,
+    activeProjectId: initial.activeProjectId,
     manualProjectOrder: readPersistedManualOrder(),
 
     validateProjectPath: (path: string): ProjectPathValidationResult => {
@@ -1014,7 +1014,8 @@ export const useProjectsStore = create<ProjectsStore>()(
       return projects.find((project) => project.id === activeProjectId) ?? null;
     },
 
-  }), { name: 'projects-store' })
+  };
+  }, { name: 'projects-store' })
 );
 
 if (typeof window !== 'undefined') {

--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -538,27 +538,41 @@ const getVSCodeWorkspaceProject = (): { projects: ProjectEntry[]; activeProjectI
   return { projects: result.projects, activeProjectId: result.activeProjectId };
 };
 
-// VS Code runtime is scoped to the workspace folders opened in VS Code.
-// Always prefer the VS Code workspace projects over any persisted multi-project registry.
-const vscodeWorkspace = getVSCodeWorkspaceProject();
-const isVSCodeProjectsRuntime = (() => {
+// Lazy initialization: these must not be evaluated at module-evaluation time
+// because static imports can reach this module before the runtime registry is
+// populated (see #2354). Use getters/functions so the values are computed on
+// first access, after the runtime APIs have been registered.
+const getVSCodeWorkspace = (): ReturnType<typeof getVSCodeWorkspaceProject> => getVSCodeWorkspaceProject();
+const getIsVSCodeProjectsRuntime = (): boolean => {
   if (typeof window === 'undefined') return false;
   return Boolean(getRegisteredRuntimeAPIs()?.runtime?.isVSCode);
-})();
-const effectiveInitialProjects = vscodeWorkspace?.projects ?? (isVSCodeProjectsRuntime ? [] : initialProjects);
-const persistedInitialActiveProjectId = vscodeWorkspace?.activeProjectId ?? (isVSCodeProjectsRuntime ? null : readPersistedActiveProjectId());
-const initialActiveProjectId = effectiveInitialProjects.some((project) => project.id === persistedInitialActiveProjectId)
-  ? persistedInitialActiveProjectId
-  : effectiveInitialProjects[0]?.id ?? null;
+};
 
-if (vscodeWorkspace) {
-  cacheProjects(effectiveInitialProjects, initialActiveProjectId);
+function getInitialProjectsState(): {
+  projects: ProjectEntry[];
+  activeProjectId: string | null;
+} {
+  const vscodeWorkspace = getVSCodeWorkspace();
+  const isVSCodeProjectsRuntime = getIsVSCodeProjectsRuntime();
+  const effectiveInitialProjects = vscodeWorkspace?.projects ?? (isVSCodeProjectsRuntime ? [] : initialProjects);
+  const persistedInitialActiveProjectId = vscodeWorkspace?.activeProjectId ?? (isVSCodeProjectsRuntime ? null : readPersistedActiveProjectId());
+  const initialActiveProjectId = effectiveInitialProjects.some((project) => project.id === persistedInitialActiveProjectId)
+    ? persistedInitialActiveProjectId
+    : effectiveInitialProjects[0]?.id ?? null;
+
+  if (vscodeWorkspace) {
+    cacheProjects(effectiveInitialProjects, initialActiveProjectId);
+  }
+
+  return { projects: effectiveInitialProjects, activeProjectId: initialActiveProjectId };
 }
+
+const initialProjectsState = getInitialProjectsState();
 
 export const useProjectsStore = create<ProjectsStore>()(
   devtools((set, get) => ({
-    projects: effectiveInitialProjects,
-    activeProjectId: initialActiveProjectId,
+    projects: initialProjectsState.projects,
+    activeProjectId: initialProjectsState.activeProjectId,
     manualProjectOrder: readPersistedManualOrder(),
 
     validateProjectPath: (path: string): ProjectPathValidationResult => {
@@ -575,7 +589,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     addProject: (path: string, options?: { label?: string; id?: string }) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return null;
       }
       const { validateProjectPath } = get();
@@ -616,7 +630,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     removeProject: (id: string) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return;
       }
       const current = get();
@@ -654,7 +668,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     setActiveProject: (id: string) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return;
       }
       const { projects, activeProjectId } = get();
@@ -679,7 +693,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     setActiveProjectIdOnly: (id: string) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return;
       }
       const { projects, activeProjectId } = get();
@@ -701,7 +715,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     renameProject: (id: string, label: string) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return;
       }
       const trimmed = label.trim();
@@ -724,7 +738,7 @@ export const useProjectsStore = create<ProjectsStore>()(
       iconBackground?: string | null;
       defaultModel?: string | null;
     }) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return;
       }
       const { projects, activeProjectId } = get();
@@ -755,7 +769,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     uploadProjectIcon: async (id: string, file: File) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return { ok: false, error: 'Custom icons are not supported in this runtime' };
       }
 
@@ -800,7 +814,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     removeProjectIcon: async (id: string) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return { ok: false, error: 'Custom icons are not supported in this runtime' };
       }
 
@@ -829,7 +843,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     discoverProjectIcon: async (id: string, options?: { force?: boolean }) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return { ok: false, error: 'Custom icons are not supported in this runtime' };
       }
 
@@ -870,7 +884,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     reorderProjects: (fromIndex: number, toIndex: number) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return;
       }
       const { projects, activeProjectId } = get();
@@ -894,7 +908,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     resetForRuntimeSwitch: () => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return;
       }
       const projects = readPersistedProjects();
@@ -906,7 +920,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     synchronizeFromSettings: (settings: DesktopSettings) => {
-      if (isVSCodeProjectsRuntime) {
+      if (getIsVSCodeProjectsRuntime()) {
         return;
       }
       const incomingProjects = sanitizeProjects(settings.projects ?? []);
@@ -958,7 +972,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     syncVSCodeWorkspaceFolders: (folders, activePath) => {
-      if (!isVSCodeProjectsRuntime) {
+      if (!getIsVSCodeProjectsRuntime()) {
         return null;
       }
 

--- a/packages/vscode/webview/api/bridge.ts
+++ b/packages/vscode/webview/api/bridge.ts
@@ -218,7 +218,7 @@ window.addEventListener('message', (event: MessageEvent) => {
   if (message?.type === 'command' && message.command) {
     const handler = commandHandlers.get(message.command);
     if (handler) {
-      handler(message.payload);
+      Promise.resolve(handler(message.payload)).catch((error) => { console.error(`[OpenChamber] Unhandled error in command handler "${message.command}":`, error); });
     }
   }
 });

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -13,8 +13,6 @@ import {
 } from '@openchamber/ui/lib/theme/vscode/adapter';
 import { getBootstrapMessages, readStoredLocaleForBootstrap } from '@openchamber/ui/lib/i18n';
 import type { VSCodeActiveEditorFile } from '@/sync/input-store';
-import { usePermissionStore } from '@openchamber/ui/stores/permissionStore';
-import { processVSCodePermissionAutoAccept } from '@openchamber/ui/sync/vscode-permission-auto-accept';
 import type { PermissionRequest } from '@opencode-ai/sdk/v2/client';
 
 type ConnectionStatus = 'connecting' | 'connected' | 'error' | 'disconnected';
@@ -1776,6 +1774,7 @@ window.addEventListener('openchamber:vscode-notification-event', (event) => {
       if (!settings.notifyOnQuestion) return;
       const requestId = getPayloadString(properties.id);
       if (requestId) {
+        const { processVSCodePermissionAutoAccept } = await import('@openchamber/ui/sync/vscode-permission-auto-accept');
         const accepted = await processVSCodePermissionAutoAccept(
           properties as unknown as PermissionRequest,
           detail?.directory,
@@ -1806,10 +1805,11 @@ onCommand('settingsSynced', () => {
   });
 });
 
-onCommand('permissionAutoAcceptSynced', (payload) => {
+onCommand('permissionAutoAcceptSynced', async (payload) => {
   if (!payload || typeof payload !== 'object') return;
   const sessions = (payload as { sessions?: unknown }).sessions;
   if (!sessions || typeof sessions !== 'object') return;
+  const { usePermissionStore } = await import('@openchamber/ui/stores/permissionStore');
   usePermissionStore.getState().applySnapshot({ sessions: sessions as Record<string, boolean> });
 });
 


### PR DESCRIPTION
## Summary

Fixes #2354, Fixes #2359 — regression where the "Add project directory" modal auto-opens in VS Code since v1.16.2 because the workspace folder is no longer auto-detected.

## Root Cause

Commit `94326f22` added two static imports to `packages/vscode/webview/main.tsx`:

```
import { usePermissionStore } from "@openchamber/ui/stores/permissionStore";
import { processVSCodePermissionAutoAccept } from "@openchamber/ui/sync/vscode-permission-auto-accept";
```

This created a transitive import chain:

```
main.tsx → permissionStore → session-ui-store → useProjectsStore
```

ES module semantics evaluate all static imports **before** the module body runs. `useProjectsStore` initialized before `main.tsx:62` set `window.__OPENCHAMBER_RUNTIME_APIS__ = createVSCodeAPIs()`. `getRegisteredRuntimeAPIs()` returned `null`, so `vscodeWorkspace = null`, `isVSCodeProjectsRuntime = false`, and `effectiveInitialProjects = []`. The `SessionDialogs` effect then opened the dialog because `projects.length === 0`.

## Fix (Three Parts)

### 1. Break the import chain in `main.tsx`

Convert the two static imports to dynamic `await import()` at their usage sites:
- `processVSCodePermissionAutoAccept` → dynamic import in the `permission.asked` notification handler (already async)
- `usePermissionStore` → dynamic import in the `permissionAutoAcceptSynced` command handler (made async)

`import type { PermissionRequest }` is kept as type-only since it does not trigger module evaluation.

### 2. Lazy initialization in `useProjectsStore`

Convert module-level constants (`vscodeWorkspace`, `isVSCodeProjectsRuntime`) to getter functions (`getVSCodeWorkspaceProject()` directly, `getIsVSCodeProjectsRuntime()`) and compute initial state inside `getInitialProjectsState()`. Move the computation from module-level `const initialProjectsState = getInitialProjectsState()` into the Zustand creator body (`const initial = getInitialProjectsState()` inside `devtools((set, get) => { ... })`). This ensures the state is computed when the store is created, not at module evaluation time.

### 3. Guard async command handlers

Wrap `handler(message.payload)` in `Promise.resolve().catch()` in `bridge.ts` to prevent unhandled promise rejections when async handlers (like `permissionAutoAcceptSynced`) throw. The `CommandHandler` type is `(payload: unknown) => void`, so async handlers silently drop rejections without this guard.

## Note on #1884 / PR #1945

PR #1945 replaces dynamic imports with static ones in `session-ui-store.ts` to silence Rollup mixed-import warnings. That change is **orthogonal** to this fix — `session-ui-store`'s mixed imports are a different set of modules (`sonner`, `i18n/store`, `session-actions`). Our lazy-init hardening in `useProjectsStore` ensures that even if `session-ui-store` gets more static imports, the projects store won't be affected because `getRegisteredRuntimeAPIs()` is no longer called at module-evaluation time.

If both PRs merge, the Rollup warnings from #1884 would be resolved by #1945's approach (static imports in `session-ui-store`), and the runtime race condition from #2354 would be resolved by our approach (dynamic imports in `main.tsx` + lazy init in `useProjectsStore`). They complement each other.

## Changed Files

- `packages/vscode/webview/main.tsx` — removed 2 static imports, added 2 dynamic imports
- `packages/ui/src/stores/useProjectsStore.ts` — converted module-level constants to getter functions, moved initial state computation into Zustand creator, removed trivial `getVSCodeWorkspace` wrapper
- `packages/vscode/webview/api/bridge.ts` — wrapped command handler dispatch in `Promise.resolve().catch()` to guard async handlers

## Verification

- TypeScript type-check passes for both `packages/ui` and `packages/vscode` (webview tsconfig)
- 81 permission/project/runtime-related tests pass
- OCR review passed — all medium/high findings addressed
- CI checks: all green (checks, review, label)