### PR TITLE
fix(ui): stop chat entry animation replaying on session switch

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -573,6 +573,17 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
         return freshnessDetector.shouldAnimateMessage(message.info, message.info.sessionID);
     }, [message.info, isUser]);
 
+    // Once a fresh assistant message has rendered, record it so it is not animated
+    // again when the chat viewport remounts on a session switch (issue #2124).
+    // Marking runs in a committed effect rather than inside shouldAnimateMessage
+    // (which runs in a useMemo during render): under React StrictMode the render is
+    // invoked twice, so marking there would flip the memoized result to false on the
+    // second pass and suppress the first animation.
+    React.useEffect(() => {
+        if (!shouldAnimateMessage) return;
+        MessageFreshnessDetector.getInstance().markMessageAsAnimated(message.info.id, message.info.time.created);
+    }, [shouldAnimateMessage, message.info.id, message.info.time.created]);
+
     const [hasStartedStreamingHeader, setHasStartedStreamingHeader] = React.useState(false);
 
     const nextRole = React.useMemo(() => {

--- a/packages/ui/src/lib/messageFreshness.test.ts
+++ b/packages/ui/src/lib/messageFreshness.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for issue #2124: chat entry animation replays on session switch.
+ *
+ * `MessageFreshnessDetector` decides, once, whether an assistant message is new
+ * enough to play its entry animation. The replay happened because a message that
+ * was judged "fresh" was never recorded as shown, so after a session switch (the
+ * chat viewport remounts and `recordSessionStart` runs only in a post-render
+ * effect, leaving a stale start time in place) the same message re-passed the
+ * freshness check. The fix records the message from a committed effect in
+ * `ChatMessage` via `markMessageAsAnimated`; marking after commit (rather than
+ * inside the memoized `shouldAnimateMessage` call) avoids flipping the decision to
+ * false under React StrictMode's double-invoked render.
+ *
+ * These tests guard the detector-level contract the fix relies on: the freshness
+ * query must stay decision-stable when re-run without an intervening mark, and a
+ * mark must permanently prevent re-animation. The `ChatMessage` effect wiring
+ * itself is not exercised here (the repo's React tests use SSR, which runs no
+ * effects); it is covered by type-check and review.
+ */
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { MessageFreshnessDetector } from './messageFreshness';
+import type { Message } from '@opencode-ai/sdk/v2';
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'msg-1',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'hello' }],
+        time: { created: Date.now() + 10_000 },
+        ...overrides,
+    } as unknown as Message;
+}
+
+describe('MessageFreshnessDetector - issue #2124', () => {
+    let detector: MessageFreshnessDetector;
+
+    beforeEach(() => {
+        detector = MessageFreshnessDetector.getInstance();
+        detector.clearAll();
+    });
+
+    test('evaluating a fresh message is a pure query and does not record it (safe under StrictMode double-render)', () => {
+        const session = 'session-A';
+        detector.recordSessionStart(session);
+        const fresh = makeMessage({ id: 'fresh-1' });
+
+        // Recording during shouldAnimateMessage would flip the result to false on
+        // StrictMode's second render invocation and suppress the first animation.
+        expect(detector.shouldAnimateMessage(fresh, session)).toBe(true);
+        expect(detector.hasBeenAnimated('fresh-1')).toBe(false);
+        expect(detector.shouldAnimateMessage(fresh, session)).toBe(true);
+    });
+
+    test('marking a fresh message after render stops it replaying on a stale-timing session revisit', () => {
+        const session = 'session-A';
+        detector.recordSessionStart(session);
+        const fresh = makeMessage({ id: 'fresh-2' });
+
+        // First visit: eligible to animate.
+        expect(detector.shouldAnimateMessage(fresh, session)).toBe(true);
+
+        // Reproduce #2124: switching away and back remounts the viewport, but
+        // recordSessionStart runs in a post-render effect, so the first render
+        // after the switch still sees the stale (still-fresh) start time. Absent a
+        // record of the earlier animation, the message re-animates.
+        expect(detector.shouldAnimateMessage(fresh, session)).toBe(true);
+
+        // The fix: ChatMessage marks the message in a committed effect after it
+        // renders. Once marked, the stale-timing revisit no longer re-animates.
+        detector.markMessageAsAnimated(fresh.id, fresh.time.created);
+        expect(detector.shouldAnimateMessage(fresh, session)).toBe(false);
+    });
+});
+
+describe('MessageFreshnessDetector - contract', () => {
+    let detector: MessageFreshnessDetector;
+
+    beforeEach(() => {
+        detector = MessageFreshnessDetector.getInstance();
+        detector.clearAll();
+    });
+
+    test('non-assistant messages never animate', () => {
+        detector.recordSessionStart('session-A');
+        const user = makeMessage({ id: 'user-1', role: 'user' });
+
+        expect(detector.shouldAnimateMessage(user, 'session-A')).toBe(false);
+    });
+
+    test('a historical (non-fresh) message never animates', () => {
+        detector.recordSessionStart('session-A');
+        const old = makeMessage({ id: 'old-1', time: { created: Date.now() - 60_000 } as Message['time'] });
+
+        expect(detector.shouldAnimateMessage(old, 'session-A')).toBe(false);
+        expect(detector.shouldAnimateMessage(old, 'session-A')).toBe(false);
+    });
+
+    test('a message without recorded session timing never animates', () => {
+        const message = makeMessage({ id: 'no-timing-1' });
+
+        expect(detector.shouldAnimateMessage(message, 'session-A')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Intent

Fixes #2124. Switching sessions replays the entry-animation decision for already-seen assistant messages.

`MessageFreshnessDetector` should mark an assistant message animation-eligible only once, but a message judged "fresh" was never recorded as shown. On a session switch the chat viewport remounts and `recordSessionStart()` runs in a post-render effect, so the first render still sees the stale start time, the message re-passes the freshness check, and it re-animates.

## Fix

Record the message from a committed effect in `ChatMessage`, via the existing `markMessageAsAnimated` API, once it has rendered. Marking after commit rather than inside the memoized `shouldAnimateMessage` call avoids flipping the decision to `false` on React StrictMode's second render pass, which would suppress the first animation. The detector is unchanged.

## Non-goals / accuracy note

Not re-enabling or reworking downstream animation wiring. On `main` much of the entry-animation pipeline is currently inert (`FADE_ANIMATION_ENABLED = false`, `allowAnimation` is `void`-ed in the assistant `MessageBody`, reservation/animation-start handlers are no-ops), so this change restores the one-shot freshness latch those consumers (and the live scroll-space reservation) depend on rather than guaranteeing a visual delta on the current build.

## Affected surfaces

`packages/ui` shared chat UI: `ChatMessage` (new effect) and `MessageFreshnessDetector` (unchanged, now marked by the consumer). Applies across runtimes via the shared singleton. No public API/type/export change.

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/lib/messageFreshness.test.ts` | 5 pass |
| Same tests vs a rejected render-mutation variant | 2 fail (guards the StrictMode-safe design) |
| `bun run type-check:ui` | Pass |
| ESLint (changed files) | Clean |

Not covered: a full `ChatMessage` render test. The repo's React tests use `renderToStaticMarkup` (no effects) and there is no DOM test runner; adding one needs a new dependency, which AGENTS.md disallows. The tests guard the detector contract and StrictMode-safety property the fix relies on; the effect wiring is verified by type-check, lint, and review.

## Risks and failure behavior

Pure in-memory logic; no I/O or persistence. The effect adds two idempotent `Set`/`Map` writes after a fresh assistant message renders (safe under StrictMode's double-invoked effects). Fresh message IDs are now retained in the detector for the tab's lifetime (historical messages already were); growth is bounded by messages seen per tab session and is negligible. No behavior change for user, historical, or already-seen messages.
