### PR TITLE
fix(vscode): open notebook links in notebook editor

### DIFF
--- a/packages/vscode/src/bridge-system-runtime.test.js
+++ b/packages/vscode/src/bridge-system-runtime.test.js
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const executeCommand = mock(async () => undefined);
+
+class Position {
+  constructor(line, character) {
+    this.line = line;
+    this.character = character;
+  }
+}
+
+class Range {
+  constructor(start, end) {
+    this.start = start;
+    this.end = end;
+  }
+}
+
+mock.module('vscode', () => ({
+  commands: { executeCommand },
+  workspace: {
+    workspaceFolders: [],
+  },
+  Uri: {
+    file: (fsPath) => ({ scheme: 'file', fsPath }),
+  },
+  Position,
+  Range,
+}));
+
+mock.module('./opencodeConfig', () => ({
+  removeProviderConfig: mock(),
+  getProviderSources: mock(),
+}));
+mock.module('./opencodeAuth', () => ({
+  getProviderAuth: mock(),
+  removeProviderAuth: mock(),
+}));
+mock.module('./quotaProviders', () => ({
+  fetchQuotaForProvider: mock(),
+  listConfiguredQuotaProviders: mock(),
+}));
+mock.module('./opencodeGoQuota', () => ({ fetchOpenCodeGoUsage: mock() }));
+mock.module('./quotaCredentials', () => ({
+  credentialStatus: mock(),
+  deleteCredential: mock(),
+  importCursorCredential: mock(),
+  normalizeCredential: mock(),
+  readCredential: mock(),
+  validateCredential: mock(),
+  writeCredential: mock(),
+}));
+mock.module('./sessionActivityWatcher', () => ({ getSessionActivitySnapshot: mock() }));
+
+const { handleSystemBridgeMessage } = await import('./bridge-system-runtime.ts');
+
+const deps = {
+  resolveUserPath: (value) => value,
+  fetchModelsMetadata: async () => ({}),
+  updateCheckUrl: 'https://example.com/update-check',
+  clientReloadDelayMs: 800,
+};
+
+describe('VS Code system bridge editor:openFile', () => {
+  beforeEach(() => {
+    executeCommand.mockClear();
+  });
+
+  test('uses vscode.open so VS Code can select the notebook editor', async () => {
+    const response = await handleSystemBridgeMessage({
+      id: 'open-notebook',
+      type: 'editor:openFile',
+      payload: { path: '/workspace/notebook.ipynb' },
+    }, undefined, deps);
+
+    expect(response).toEqual({ id: 'open-notebook', type: 'editor:openFile', success: true });
+    expect(executeCommand).toHaveBeenCalledWith(
+      'vscode.open',
+      { scheme: 'file', fsPath: '/workspace/notebook.ipynb' },
+      {},
+    );
+  });
+
+  test('preserves line and column selection for regular files', async () => {
+    await handleSystemBridgeMessage({
+      id: 'open-text',
+      type: 'editor:openFile',
+      payload: { path: '/workspace/source.ts', line: 4, column: 7 },
+    }, undefined, deps);
+
+    const position = new Position(3, 7);
+    expect(executeCommand).toHaveBeenCalledWith(
+      'vscode.open',
+      { scheme: 'file', fsPath: '/workspace/source.ts' },
+      { selection: new Range(position, position) },
+    );
+  });
+});

--- a/packages/vscode/src/bridge-system-runtime.ts
+++ b/packages/vscode/src/bridge-system-runtime.ts
@@ -344,13 +344,12 @@ export async function handleSystemBridgeMessage(
     case 'editor:openFile': {
       const { path: filePath, line, column } = payload as { path: string; line?: number; column?: number };
       try {
-        const doc = await vscode.workspace.openTextDocument(filePath);
         const options: vscode.TextDocumentShowOptions = {};
         if (typeof line === 'number') {
           const pos = new vscode.Position(Math.max(0, line - 1), column || 0);
           options.selection = new vscode.Range(pos, pos);
         }
-        await vscode.window.showTextDocument(doc, options);
+        await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(filePath), options);
         return { id, type, success: true };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Intent

Fixes #2372.

Open local `.ipynb` links from OpenChamber's VS Code chat through VS Code's editor resolver. The enabled Jupyter extension can then select the Notebook editor instead of OpenChamber forcing the raw JSON text editor.

## Non-goals

This PR does not add notebook rendering, notebook execution, Jupyter integration, or a new OpenChamber editor API.

## Affected surfaces

`packages/vscode` extension-host bridge only. The shared `EditorAPI` contract and web, Electron, hosted-mobile, and Capacitor behavior remain unchanged. Existing `line` and `column` options continue to form a text-editor selection for ordinary files; Notebook editors retain their own navigation model.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` | The change modifies VS Code extension source. | Kept the extension-host bridge thin and scoped the behavior to its owning runtime module. |
| `openchamber-change-discipline` | This is an executable platform-runtime change. | Traced the file-reference caller, retained ordinary-file selection behavior, added a focused bridge test, and avoided dependencies or unrelated refactors. |
| `ui-api-decoupling` and runtime-parity reference | The webview invokes a runtime-owned editor capability through `RuntimeAPIs` and an extension-host bridge. | Preserved the shared API and modified only the VS Code native handler. Other runtimes have no behavior change. |
| `packages/vscode/README.md` and `packages/vscode/src/DOCUMENTATION.md` | They document the VS Code package and bridge ownership. | The implementation remains in `bridge-system-runtime.ts`, the documented owner for editor/provider bridge handlers. |

## Validation

| Check | Result |
|---|---|
| Static source review | Confirmed `editor:openFile` now calls `vscode.open` with a file URI and the existing selection options. |
| Focused bridge test | Added two cases for notebook editor resolution and ordinary file line/column selection. Not executed at this PR HEAD. |
| `git diff --check` | Passed. |
| Type-check, lint, build, `dead-code` | Not run. The workspace lacks local `tsc` and ESLint, and the reporter requested no development-environment installation. |
| Manual VS Code plus Jupyter verification | Not run. The reporter requested no Extension Development Host or Jupyter setup. |

## Visual evidence
before
<img width="1244" height="1053" alt="image" src="https://github.com/user-attachments/assets/8367c2f7-e319-4bab-a1c0-ec730f7b5dec" />
after
<img width="1426" height="746" alt="image" src="https://github.com/user-attachments/assets/9b93aca8-9f21-40e5-9206-ef9839852230" />


## Risks and failure behavior

`vscode.open` delegates editor selection to VS Code. An `.ipynb` file still opens as text when the Jupyter extension is disabled or the user configured a text-editor association; OpenChamber no longer forces that result. The bridge preserves its existing error response when VS Code fails to open a resource. No persisted state, credentials, files, or network contracts change.