### PR TITLE
fix(ui): cap oversized tool output before rendering to prevent renderer OOM (#2265)

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -33,6 +33,7 @@ import {
     renderTodoOutput,
     tryParseJsonOutput,
     coerceToText,
+    capToolOutputText,
 } from '../toolRenderers';
 import { JsonTreeViewer } from '@/components/ui/JsonTreeViewer';
 import { JsonSummaryView } from './JsonSummaryView';
@@ -841,11 +842,15 @@ const getToolOutputText = (
     part: ToolPartType,
     metadata: Record<string, unknown> | undefined,
 ): string => {
+    // Cap oversized payloads before JSON.parse / syntax highlighting / DOM work
+    // so a single huge tool output can't trigger a V8 Zone-allocation OOM that
+    // hard-crashes the renderer (issue #2265).
+    const capped = capToolOutputText(output);
     if (part.tool === 'bash') {
-        return output;
+        return capped;
     }
 
-    return formatEditOutput(output, part.tool, metadata);
+    return formatEditOutput(capped, part.tool, metadata);
 };
 
 const ToolScrollableTextOutput: React.FC<{

--- a/packages/ui/src/components/chat/message/toolRenderers.test.ts
+++ b/packages/ui/src/components/chat/message/toolRenderers.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from 'bun:test';
+
+import { capToolOutputText, TOOL_OUTPUT_MAX_CHARS } from './toolRenderers';
+
+// Regression coverage for issue #2265: the desktop renderer hard-crashes with a
+// V8 "Zone Allocation failed" OOM when a tool returns oversized external content
+// (e.g. a fetched Google Slides page with full-resolution base64 images inlined),
+// because the whole payload previously flowed through JSON.parse / syntax
+// highlighting / DOM rendering as a single unbounded JS string. capToolOutputText
+// is the bounded size guard that runs before any of that work.
+describe('capToolOutputText (issue #2265 renderer OOM guard)', () => {
+    test('exposes a sane positive default cap', () => {
+        expect(typeof TOOL_OUTPUT_MAX_CHARS).toBe('number');
+        expect(TOOL_OUTPUT_MAX_CHARS).toBeGreaterThan(0);
+    });
+
+    test('returns short output unchanged', () => {
+        const output = 'hello world';
+        expect(capToolOutputText(output)).toBe(output);
+    });
+
+    test('returns output at exactly the cap unchanged', () => {
+        const output = 'a'.repeat(TOOL_OUTPUT_MAX_CHARS);
+        expect(capToolOutputText(output)).toBe(output);
+        expect(capToolOutputText(output).length).toBe(TOOL_OUTPUT_MAX_CHARS);
+    });
+
+    test('caps oversized output and never emits the full string', () => {
+        const oversized = 'x'.repeat(TOOL_OUTPUT_MAX_CHARS + 10_000);
+        const capped = capToolOutputText(oversized);
+
+        // The pathological full-size string must not survive to the renderer.
+        expect(capped.length).toBeLessThan(oversized.length);
+        // Head of the payload is preserved for the user.
+        expect(capped.startsWith('x'.repeat(1000))).toBe(true);
+        // A truncation notice is appended so the truncation is visible.
+        expect(capped).toContain('output truncated');
+        expect(capped).toContain('10000 more characters');
+    });
+
+    test('honors a custom cap', () => {
+        const output = 'abcdefghij'; // 10 chars
+        const capped = capToolOutputText(output, 4);
+        expect(capped.startsWith('abcd')).toBe(true);
+        expect(capped).toContain('output truncated');
+        // Only the first 4 chars of the original body are retained.
+        expect(capped).not.toContain('efghij');
+    });
+
+    test('simulated large webfetch payload is bounded well below original size', () => {
+        // ~6MB single string, matching the 5MB-20MB Zone-allocation trigger range
+        // described in the issue (a Slides page with embedded base64 images).
+        const base64Blob = 'QUJD'.repeat(1_500_000); // 6,000,000 chars
+        const capped = capToolOutputText(base64Blob);
+
+        expect(base64Blob.length).toBeGreaterThan(5_000_000);
+        expect(capped.length).toBeLessThan(TOOL_OUTPUT_MAX_CHARS + 256);
+        expect(capped).toContain('renderer from running out of memory');
+    });
+
+    test('non-string input is returned unchanged (defensive)', () => {
+        // @ts-expect-error verifying runtime robustness against non-string inputs
+        expect(capToolOutputText(undefined)).toBeUndefined();
+        // @ts-expect-error verifying runtime robustness against non-string inputs
+        expect(capToolOutputText(null)).toBeNull();
+    });
+});

--- a/packages/ui/src/components/chat/message/toolRenderers.tsx
+++ b/packages/ui/src/components/chat/message/toolRenderers.tsx
@@ -22,6 +22,28 @@ export const coerceToText = (value: unknown, fallback = ''): string => {
     }
 };
 
+// Guards the renderer process against V8 "Zone Allocation failed" OOM crashes
+// (issue #2265). When a tool returns oversized external content — e.g. a fetched
+// web page with full-resolution base64 images inlined — the entire payload flows
+// through this module as a single JS string that is JSON.parsed, syntax
+// highlighted, and attached to the DOM. A large enough single string exceeds
+// V8's Zone allocator and hard-crashes the renderer before any virtualization or
+// CSS clip can help. Capping the string length before that work happens keeps a
+// useful head of the output while preventing the pathological allocation.
+export const TOOL_OUTPUT_MAX_CHARS = 512 * 1024;
+
+export const capToolOutputText = (
+    output: string,
+    maxChars: number = TOOL_OUTPUT_MAX_CHARS,
+): string => {
+    if (typeof output !== 'string' || output.length <= maxChars) {
+        return output;
+    }
+    const omitted = output.length - maxChars;
+    const notice = `\n\n… [output truncated: ${omitted} more characters not shown to prevent the renderer from running out of memory]`;
+    return output.slice(0, maxChars) + notice;
+};
+
 const hasLspDiagnostics = (output: string): boolean => {
     if (!output) return false;
     return output.includes('<diagnostics')


### PR DESCRIPTION
Fixes #2265

## Intent

The desktop renderer hard-crashes with a V8 `Zone Allocation failed` OOM (issue #2265) when a tool returns oversized external content mid-chat — e.g. a `webfetch` of a Google Slides page with full-resolution base64 images inlined. As reported and confirmed, the entire tool-output payload flows through the tool-output rendering path as a **single unbounded JS string**: it is `JSON.parse`d, syntax highlighted, and attached to the DOM with no size check at any stage. A large enough single string exceeds V8's Zone allocator and kills the renderer process; the existing 1200-line highlight limit, 80-line virtualization threshold, and `max-h` CSS clip all sit downstream of the allocation and cannot prevent it.

This PR adds a bounded size guard and applies it at the single funnel every generic tool-output string passes through before any parsing/highlighting/DOM work. Output under the cap is byte-for-byte unchanged; oversized output keeps a useful head and gains a visible truncation notice instead of crashing the renderer.

## Non-goals

- The `task`-tool markdown path (`SimpleMarkdownRenderer`) is intentionally left unchanged — the reported crash path is generic tool output (webfetch/read/bash), which renders via `ToolScrollableTextOutput`, not the task markdown branch. Keeping this change to the one confirmed funnel keeps the blast radius minimal.
- No change to how tools produce or transport output (server-side payload caps are a separate concern).

## Affected surfaces

- `packages/ui` renderer only. New pure helper `capToolOutputText` / constant `TOOL_OUTPUT_MAX_CHARS` in `toolRenderers.tsx`, applied inside `getToolOutputText` in `parts/ToolPart.tsx`.
- User-visible state: a tool output larger than 512 KiB is now displayed with its first 512 KiB followed by a one-line truncation notice. Outputs at/under the cap are unaffected. No persisted/external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `CONTRIBUTING.md` → "Keep the change focused" | Bug fix touching the UI render path | Single funnel (`getToolOutputText`) guarded; unrelated cleanup/lockfile churn excluded |
| `CONTRIBUTING.md` → Pull Request Contract / Validation | Requires exact commands + results, no runtime claims from lint/type-check alone | Focused unit test added and run; lint + type-check reported below with the OOM-runtime limitation stated explicitly |
| `packages/ui` code style (early returns, no nested ternaries) | UI/TS change | Helper uses an early return; constant + pure function, no new dependencies |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/message/toolRenderers.test.ts` | **7 pass / 0 fail** (17 assertions) — new deterministic guard test |
| `bun test packages/ui/src/components/chat/message` | **49 pass / 0 fail** (11 files) — no regression in colocated message tests |
| `bunx eslint` (both changed files + test) | clean, exit 0 |
| `bunx tsc --noEmit` (packages/ui) | clean, exit 0 |

The new test (`toolRenderers.test.ts`) proves the guard behavior deterministically: short output is returned unchanged, output at exactly the cap is unchanged, oversized output is bounded well below the original length with a visible truncation notice and the full string never passes through, a custom cap is honored, and a simulated ~6 MB webfetch-style base64 payload is bounded to ≈512 KiB.

Not verified here: the actual Electron/V8 Zone-allocation abort cannot be reproduced in a unit test (it requires the packaged desktop renderer under a multi-MB payload). This PR proves the size-cap behavior that removes the unbounded allocation; it does not re-run the live desktop crash.

## Visual evidence

No change for the overwhelming majority of outputs: any tool output ≤ `TOOL_OUTPUT_MAX_CHARS` (512 KiB) is returned identically, so existing rendering is pixel-for-pixel unchanged. The only user-visible difference occurs for a single tool output exceeding 512 KiB, where the rendered text is the first 512 KiB followed by a plain-text line:

```
… [output truncated: <N> more characters not shown to prevent the renderer from running out of memory]
```

A before screenshot of the "before" state is not capturable in the desktop app because the "before" behavior is the renderer process crashing (gray window), which is the bug being fixed. The appended notice is ordinary text inside the existing scrollable output surface; it introduces no new component, style, or layout.

## Risks and failure behavior

- **Truncation of legitimately large outputs:** outputs above 512 KiB are truncated in the display surface. 512 KiB is far above normal tool output (the existing highlight line limit of 1200 lines is ~120 KiB of typical source), so real usage is unaffected while the multi-MB pathological case that triggers the OOM is bounded. The cap is a single named constant, easy to tune.
- **Correctness of downstream parsing:** capping before `tryParseJsonOutput` means an oversized-but-valid JSON blob no longer round-trips through the JSON view; it falls back to the text/highlight view. This is the intended trade — the alternative is a renderer crash.
- **Rollback:** revert is a single commit with no schema/state migration.
- No security, data-loss, or cross-runtime concerns identified: the helper is pure, string-only, and dependency-free.
