### PR TITLE
fix: preview Office documents as PDF

### DIFF
--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -44,7 +44,7 @@ import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useDeviceInfo } from '@/lib/device';
 import { cn, getModifierLabel, getRevealLabelKey, hasModifier } from '@/lib/utils';
-import { getLanguageFromExtension, getImageMimeType, isDrawioFile, isImageFile, isPdfFile } from '@/lib/toolHelpers';
+import { getLanguageFromExtension, getImageMimeType, isDrawioFile, isImageFile, isOfficeDocumentFile, isPdfFile } from '@/lib/toolHelpers';
 import { getRuntimeUrlResolver } from '@/lib/runtime-url';
 import { acquireRuntimeUrlAuthToken, refreshRuntimeUrlAuthToken, subscribeRuntimeUrlAuthToken } from '@/lib/runtime-auth';
 import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
@@ -304,8 +304,26 @@ const isFileMissingError = (error: unknown): boolean => {
 };
 
 const MAX_VIEW_CHARS = 200_000;
+const OFFICE_PREVIEW_BUSY_RETRY_LIMIT = 120;
+const OFFICE_PREVIEW_BUSY_RETRY_MS = 1_000;
 const FILE_EDITOR_AUTO_SAVE_KEY = 'openchamber:files:auto-save-enabled';
 type FileLineEnding = '\n' | '\r\n';
+
+const waitForAbortableTimeout = (delayMs: number, signal: AbortSignal): Promise<void> => new Promise((resolve, reject) => {
+  const handleAbort = () => {
+    window.clearTimeout(timeout);
+    reject(new DOMException('Aborted', 'AbortError'));
+  };
+  const timeout = window.setTimeout(() => {
+    signal.removeEventListener('abort', handleAbort);
+    resolve();
+  }, delayMs);
+  if (signal.aborted) {
+    handleAbort();
+    return;
+  }
+  signal.addEventListener('abort', handleAbort, { once: true });
+});
 
 const detectFileLineEnding = (content: string): FileLineEnding => {
   let crlf = 0;
@@ -906,6 +924,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const [fileError, setFileError] = React.useState<string | null>(null);
   const [desktopImageSrc, setDesktopImageSrc] = React.useState<string>('');
   const desktopImageBlobUrlRef = React.useRef<string>('');
+  const [officePreviewSrc, setOfficePreviewSrc] = React.useState('');
+  const [officePreviewLoading, setOfficePreviewLoading] = React.useState(false);
+  const [officePreviewUnavailable, setOfficePreviewUnavailable] = React.useState(false);
+  const officePreviewBlobUrlRef = React.useRef('');
 
   const [loadedFilePath, setLoadedFilePath] = React.useState<string | null>(null);
 
@@ -978,6 +1000,15 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       toast.error(t('sidebarFilesTree.toast.revealFailed'));
     });
   }, [files, t]);
+
+  const handleDownloadFile = React.useCallback((targetPath: string) => {
+    const downloadFile = files.downloadFile;
+    if (!downloadFile) return;
+    void downloadFile(targetPath).catch((error) => {
+      console.error('Download failed:', error);
+      toast.error(t('sidebarFilesTree.toast.operationFailed'));
+    });
+  }, [files.downloadFile, t]);
 
   const handleOpenInApp = React.useCallback(async (app: { id: string; appName: string }) => {
     if (!selectedFile?.path) {
@@ -1792,6 +1823,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
     const selectedIsImage = isImageFile(node.path);
     const isSvg = node.path.toLowerCase().endsWith('.svg');
+    const selectedIsOfficeDocument = isOfficeDocumentFile(node.path);
     const selectedIsPdf = isPdfFile(node.path);
 
     if (isMobile) {
@@ -1815,7 +1847,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       return;
     }
 
-    if (selectedIsPdf) {
+    if (selectedIsPdf || selectedIsOfficeDocument) {
       setFileContent('');
       setDraftContent('');
       setLoadedFilePath(node.path);
@@ -2303,6 +2335,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
   const isSelectedImage = Boolean(selectedFile?.path && isImageFile(selectedFile.path));
   const isSelectedSvg = Boolean(selectedFile?.path && selectedFile.path.toLowerCase().endsWith('.svg'));
+  const isSelectedOfficeDocument = Boolean(selectedFile?.path && isOfficeDocumentFile(selectedFile.path));
   const isSelectedPdf = Boolean(selectedFile?.path && isPdfFile(selectedFile.path));
   const pendingNavigationTargetPath = React.useMemo(
     () => normalizePath(pendingFileNavigation?.path ?? ''),
@@ -2316,6 +2349,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       && !fileLoading
       && !fileError
       && !isSelectedImage
+      && !isSelectedOfficeDocument
       && !isSelectedPdf,
   );
 
@@ -2323,14 +2357,14 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     return getDisplayPath(root, selectedFilePath);
   }, [selectedFilePath, root]);
 
-  const canCopy = Boolean(selectedFile && (!isSelectedImage || isSelectedSvg) && !isSelectedPdf && fileContent.length > 0);
+  const canCopy = Boolean(selectedFile && (!isSelectedImage || isSelectedSvg) && !isSelectedOfficeDocument && !isSelectedPdf && fileContent.length > 0);
   const canCopyPath = Boolean(selectedFile && displaySelectedPath.length > 0);
-  const canEdit = Boolean(selectedFile && !selectedFileIsOutsideWorkspace && !isSelectedImage && !isSelectedPdf && files.writeFile && fileContent.length <= MAX_VIEW_CHARS);
+  const canEdit = Boolean(selectedFile && !selectedFileIsOutsideWorkspace && !isSelectedImage && !isSelectedOfficeDocument && !isSelectedPdf && files.writeFile && fileContent.length <= MAX_VIEW_CHARS);
   const isMarkdown = Boolean(selectedFile?.path && isMarkdownFile(selectedFile.path));
   const isJson = Boolean(selectedFile?.path && isJsonFile(selectedFile.path));
   const isHtml = Boolean(selectedFile?.path && isHtmlFile(selectedFile.path));
   const isDrawio = Boolean(selectedFile?.path && isDrawioFile(selectedFile.path));
-  const isTextFile = Boolean(selectedFile && !isSelectedImage && !isSelectedPdf);
+  const isTextFile = Boolean(selectedFile && !isSelectedImage && !isSelectedOfficeDocument && !isSelectedPdf);
   const canUseShikiFileView = isTextFile && !isMarkdown && !isDrawio && !(isHtml && htmlViewMode === 'preview');
   const isEditingFile = (isMarkdown && mdViewMode === 'edit')
     || (isHtml && htmlViewMode === 'edit')
@@ -2674,7 +2708,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       return;
     }
 
-    if (fileError || isSelectedImage || isSelectedPdf) {
+    if (fileError || isSelectedImage || isSelectedOfficeDocument || isSelectedPdf) {
       setPendingFileNavigation(null);
       pendingNavigationCycleRef.current = { key: '', attempts: 0 };
       return;
@@ -2745,6 +2779,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     fileError,
     fileLoading,
     isSelectedImage,
+    isSelectedOfficeDocument,
     isSelectedPdf,
     loadedFilePath,
     handleSelectFile,
@@ -2780,9 +2815,9 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     }
 
     // Best-effort focus: preview renderers (markdown/html preview, drawio,
-    // JSON tree, images, PDFs) never mount a CodeMirror editor, so the request
-    // must clear regardless — otherwise it lingers and replays on every
-    // dependency change.
+    // JSON tree, images, PDFs, and Office documents) never mount a CodeMirror
+    // editor, so the request must clear regardless — otherwise it lingers and
+    // replays on every dependency change.
     if (!fileError && !isSelectedImage && !isSelectedPdf && canEdit && textViewMode === 'edit') {
       editorViewRef.current?.focus();
     }
@@ -3001,6 +3036,122 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       />
     </div>
   ), [pdfSrc, pdfPreviewNonce]);
+
+  const renderOfficeDocumentPlaceholder = React.useCallback((file: FileNode) => (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+        <FileTypeIcon filePath={file.path} extension={file.extension} className="size-12" />
+        <div className="max-w-full break-words typography-ui-label font-medium text-foreground">
+          {file.name}
+        </div>
+        <p className="typography-ui text-muted-foreground">
+          {t('filesView.documentPreview.unavailable')}
+        </p>
+        {files.downloadFile ? (
+          <Button variant="outline" size="sm" className="gap-1.5" onClick={() => handleDownloadFile(file.path)}>
+            <Icon name="download" className="size-4" />
+            {t('filesView.editor.saveOriginal')}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  ), [files.downloadFile, handleDownloadFile, t]);
+
+  const renderOfficeDocumentPreview = React.useCallback((file: FileNode) => {
+    if (!officePreviewSrc || officePreviewUnavailable) {
+      return renderOfficeDocumentPlaceholder(file);
+    }
+    return (
+      <div className="relative h-full overflow-hidden bg-[var(--surface-background)]">
+        <iframe
+          src={officePreviewSrc}
+          className="h-full w-full border-0"
+          title={file.name}
+        />
+        {files.downloadFile ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="absolute bottom-4 right-4 z-10 gap-1.5 bg-background/95 shadow-sm"
+            onClick={() => handleDownloadFile(file.path)}
+          >
+            <Icon name="download" className="size-4" />
+            {t('filesView.editor.saveOriginal')}
+          </Button>
+        ) : null}
+      </div>
+    );
+  }, [files.downloadFile, handleDownloadFile, officePreviewSrc, officePreviewUnavailable, renderOfficeDocumentPlaceholder, t]);
+
+  React.useEffect(() => {
+    const revokePreviewUrl = () => {
+      if (officePreviewBlobUrlRef.current) {
+        URL.revokeObjectURL(officePreviewBlobUrlRef.current);
+        officePreviewBlobUrlRef.current = '';
+      }
+    };
+
+    if (!selectedFile?.path || !isSelectedOfficeDocument) {
+      revokePreviewUrl();
+      setOfficePreviewSrc('');
+      setOfficePreviewLoading(false);
+      setOfficePreviewUnavailable(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+    revokePreviewUrl();
+    setOfficePreviewSrc('');
+    setOfficePreviewLoading(true);
+    setOfficePreviewUnavailable(false);
+
+    const fetchOfficePreview = async (): Promise<Response> => {
+      for (let attempt = 0; ; attempt += 1) {
+        const response = await runtimeFetch('/api/fs/office-preview', {
+          query: {
+            path: selectedFile.path,
+            allowOutsideWorkspace: selectedFileReadOptions.allowOutsideWorkspace ? 'true' : undefined,
+            outsideFileGrant: selectedFileReadOptions.outsideFileGrant,
+          },
+          headers: root ? { 'x-opencode-directory': root } : undefined,
+          cache: 'no-store',
+          signal: controller.signal,
+        });
+        if (response.status !== 429 || attempt >= OFFICE_PREVIEW_BUSY_RETRY_LIMIT - 1) {
+          return response;
+        }
+        const retryAfterSeconds = Number(response.headers.get('retry-after'));
+        const retryDelayMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+          ? retryAfterSeconds * 1_000
+          : OFFICE_PREVIEW_BUSY_RETRY_MS;
+        await waitForAbortableTimeout(retryDelayMs, controller.signal);
+      }
+    };
+
+    void fetchOfficePreview().then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Office preview failed (${response.status})`);
+      }
+      const blob = await response.blob();
+      if (cancelled) return;
+      const blobUrl = URL.createObjectURL(blob);
+      officePreviewBlobUrlRef.current = blobUrl;
+      setOfficePreviewSrc(blobUrl);
+    }).catch((error) => {
+      if (cancelled || error?.name === 'AbortError') return;
+      console.warn('Office preview unavailable:', error);
+      setOfficePreviewUnavailable(true);
+    }).finally(() => {
+      if (!cancelled) setOfficePreviewLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      revokePreviewUrl();
+    };
+  }, [isSelectedOfficeDocument, root, selectedFile?.path, selectedFileReadOptions.allowOutsideWorkspace, selectedFileReadOptions.outsideFileGrant]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -3245,7 +3396,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {!isSelectedImage && !isSelectedPdf && (
+        {!isSelectedImage && !isSelectedOfficeDocument && !isSelectedPdf && (
           <>
             {withTooltip(wrapLines ? t('filesView.editor.disableLineWrap') : t('filesView.editor.enableLineWrap'),
               <Button
@@ -3493,13 +3644,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => {
-                const fn = files.downloadFile;
-                if (fn) void fn(selectedFile.path).catch((error) => {
-                  console.error('Download failed:', error);
-                  toast.error(t('sidebarFilesTree.toast.operationFailed'));
-                });
-              }}
+              onClick={() => handleDownloadFile(selectedFile.path)}
               className="size-6 p-0 hover:bg-transparent focus-visible:bg-transparent active:bg-transparent"
               title={t('filesView.editor.saveFile')}
               aria-label={t('filesView.editor.saveFile')}
@@ -3804,7 +3949,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
         <ScrollableOverlay outerClassName="h-full min-w-0" className="h-full min-w-0">
           {!selectedFile ? (
             <div className="p-3 typography-ui text-muted-foreground">{t('filesView.editor.pickFileFromTree')}</div>
-          ) : (fileLoading || isImageAssetAuthLoading || isPdfAssetAuthLoading) ? (
+          ) : (fileLoading || officePreviewLoading || isImageAssetAuthLoading || isPdfAssetAuthLoading) ? (
             suppressFileLoadingIndicator
               ? <div className="p-3" />
               : (
@@ -3826,6 +3971,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             </div>
           ) : isSelectedPdf ? (
             renderPdfPreview(selectedFile)
+          ) : isSelectedOfficeDocument ? (
+            renderOfficeDocumentPreview(selectedFile)
           ) : selectedFile && isDrawio && drawioViewMode === 'preview' ? (
             <div className="h-full overflow-hidden" style={{ minHeight: '400px' }}>
               <DiagramEditor
@@ -4175,7 +4322,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           {renderFloatingFileControls({ exitFullscreenOnly: true })}
         </div>
         <ScrollableOverlay outerClassName="h-full min-w-0" className="h-full min-w-0">
-          {(fileLoading || isImageAssetAuthLoading || isPdfAssetAuthLoading) ? (
+          {(fileLoading || officePreviewLoading || isImageAssetAuthLoading || isPdfAssetAuthLoading) ? (
             suppressFileLoadingIndicator
               ? <div className="p-4" />
               : (
@@ -4197,6 +4344,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             </div>
           ) : isSelectedPdf ? (
             renderPdfPreview(selectedFile)
+          ) : isSelectedOfficeDocument ? (
+            renderOfficeDocumentPreview(selectedFile)
           ) : isMarkdown && getMdViewMode() === 'preview' ? (
             <div className="h-full overflow-auto p-4">
               {fileContent.length > 500 * 1024 && (

--- a/packages/ui/src/lib/contextFileOpenGuard.test.ts
+++ b/packages/ui/src/lib/contextFileOpenGuard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import type { FilesAPI } from '@/lib/api/types';
+import { validateContextFileOpen } from './contextFileOpenGuard';
+
+describe('validateContextFileOpen', () => {
+  test('does not read Office documents as text', async () => {
+    let readCount = 0;
+    const files = {
+      readFile: async () => {
+        readCount += 1;
+        return { content: '', path: '/workspace/slides.pptx' };
+      },
+    } as unknown as FilesAPI;
+
+    expect(await validateContextFileOpen(files, '/workspace/slides.pptx')).toEqual({ ok: true });
+    expect(readCount).toBe(0);
+  });
+});

--- a/packages/ui/src/lib/contextFileOpenGuard.ts
+++ b/packages/ui/src/lib/contextFileOpenGuard.ts
@@ -6,6 +6,7 @@ import { formatMessage, useI18nStore } from '@/lib/i18n/store';
 const t = (key: Parameters<typeof formatMessage>[1], params?: Parameters<typeof formatMessage>[2]) =>
   formatMessage(useI18nStore.getState().dictionary, key, params);
 import { runtimeFetch } from '@/lib/runtime-fetch';
+import { isOfficeDocumentFile } from '@/lib/toolHelpers';
 
 export type ContextFileOpenFailureReason = 'too-large' | 'missing' | 'unreadable';
 
@@ -50,6 +51,10 @@ const readFileContent = async (files: FilesAPI, path: string): Promise<string> =
 };
 
 export const validateContextFileOpen = async (files: FilesAPI, path: string): Promise<ContextFileOpenValidationResult> => {
+  if (isOfficeDocumentFile(path)) {
+    return { ok: true };
+  }
+
   try {
     const content = await readFileContent(files, path);
     const lineCount = countLinesWithLimit(content, MAX_OPEN_FILE_LINES);

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1212,6 +1212,8 @@ export const dict = {
   'filesView.error.switchToTextMode': 'Switch to text mode to view raw content.',
   'filesView.warning.largeFilePreviewLimited': 'This file is large ({sizeKb}KB). Preview may be limited.',
   'filesView.error.previewUnavailable': 'Preview unavailable',
+  'filesView.documentPreview.unavailable': 'This document cannot be previewed as text.',
+  'filesView.editor.saveOriginal': 'Save original',
   'filesView.error.switchToEditMode': 'Switch to edit mode to fix the issue.',
   'filesView.error.readFileFailed': 'Failed to read file',
   'filesView.editor.htmlPreviewTitle': 'HTML Preview',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1178,6 +1178,8 @@ export const dict: Record<I18nKey, string> = {
   "filesView.error.switchToTextMode": "Cambia al modo de texto para ver contenido bruto.",
   "filesView.warning.largeFilePreviewLimited": "Este archivo es grande ({sizeKb}KB). La vista previa puede estar limitada.",
   "filesView.error.previewUnavailable": "Vista previa no disponible",
+  "filesView.documentPreview.unavailable": "Este documento no se puede previsualizar como texto.",
+  "filesView.editor.saveOriginal": "Guardar original",
   "filesView.error.switchToEditMode": "Cambia al modo de edición para resolver el problema.",
   "filesView.error.readFileFailed": "No se pudo leer el archivo",
   "filesView.editor.htmlPreviewTitle": "Vista previa HTML",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1040,6 +1040,8 @@ export const dict = {
   'filesView.error.switchToTextMode': 'Passez en mode texte pour afficher le contenu brut.',
   'filesView.warning.largeFilePreviewLimited': 'Ce fichier est volumineux ({sizeKb}KB). L\'aperçu peut être limité.',
   'filesView.error.previewUnavailable': 'Aperçu indisponible',
+  'filesView.documentPreview.unavailable': 'Ce document ne peut pas être prévisualisé sous forme de texte.',
+  'filesView.editor.saveOriginal': 'Enregistrer l’original',
   'filesView.error.switchToEditMode': 'Passez en mode édition pour résoudre le problème.',
   'filesView.error.readFileFailed': 'Échec de la lecture du fichier',
   'filesView.editor.htmlPreviewTitle': 'Aperçu HTML',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -1208,6 +1208,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.error.switchToTextMode': 'テキストモードに切り替えて生の内容を表示してください。',
   'filesView.warning.largeFilePreviewLimited': 'このファイルは大きいです（{sizeKb}KB）。プレビューが制限される場合があります。',
   'filesView.error.previewUnavailable': 'プレビューは利用できません',
+  'filesView.documentPreview.unavailable': 'このドキュメントはテキストとしてプレビューできません。',
+  'filesView.editor.saveOriginal': '元のファイルを保存',
   'filesView.error.switchToEditMode': '編集モードに切り替えて問題を修正してください。',
   'filesView.error.readFileFailed': 'ファイルの読み込みに失敗しました',
   'filesView.editor.htmlPreviewTitle': 'HTMLプレビュー',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1215,6 +1215,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.error.switchToTextMode': '원본 내용을 보려면 텍스트 모드로 전환하세요.',
   'filesView.warning.largeFilePreviewLimited': '이 파일은 큽니다({sizeKb}KB). 미리보기가 제한될 수 있습니다.',
   'filesView.error.previewUnavailable': '미리보기를 사용할 수 없음',
+  'filesView.documentPreview.unavailable': '이 문서는 텍스트로 미리 볼 수 없습니다.',
+  'filesView.editor.saveOriginal': '원본 저장',
   'filesView.error.switchToEditMode': '문제를 수정하려면 편집 모드로 전환하세요.',
   'filesView.error.readFileFailed': '파일 읽기 실패',
   'filesView.editor.htmlPreviewTitle': 'HTML 미리보기',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1695,6 +1695,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.editor.switchToTreeView': 'Przełącz na widok drzewa',
   'filesView.error.jsonViewerUnavailable': 'Podgląd JSON jest niedostępny',
   'filesView.error.previewUnavailable': 'Podgląd jest niedostępny',
+  'filesView.documentPreview.unavailable': 'Tego dokumentu nie można wyświetlić jako tekstu.',
+  'filesView.editor.saveOriginal': 'Zapisz oryginał',
   'filesView.error.readFileFailed': 'Nie udało się odczytać pliku',
   'filesView.error.switchToEditMode': 'Przełącz do trybu edycji, aby naprawić problem.',
   'filesView.error.switchToTextMode': 'Przełącz do trybu tekstowego, aby zobaczyć surową zawartość.',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1178,6 +1178,8 @@ export const dict: Record<I18nKey, string> = {
   "filesView.error.switchToTextMode": "Alterne para o modo de texto para ver o conteúdo bruto.",
   "filesView.warning.largeFilePreviewLimited": "Este arquivo é grande ({sizeKb}KB). A prévia pode estar limitada.",
   "filesView.error.previewUnavailable": "Pré-visualização indisponível",
+  "filesView.documentPreview.unavailable": "Este documento não pode ser visualizado como texto.",
+  "filesView.editor.saveOriginal": "Salvar original",
   "filesView.error.switchToEditMode": "Alterne para o modo de edição para resolver o problema.",
   "filesView.error.readFileFailed": "Não foi possível ler o arquivo",
   "filesView.editor.htmlPreviewTitle": "Pré-visualização HTML",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1178,6 +1178,8 @@ export const dict: Record<I18nKey, string> = {
   "filesView.error.switchToTextMode": "Перейдіть у текстовий режим, щоб переглянути необроблений вміст.",
   "filesView.warning.largeFilePreviewLimited": "Цей файл великий ({sizeKb} КБ). Попередній перегляд може бути обмежений.",
   "filesView.error.previewUnavailable": "Попередній перегляд недоступний",
+  "filesView.documentPreview.unavailable": "Цей документ не можна переглянути як текст.",
+  "filesView.editor.saveOriginal": "Зберегти оригінал",
   "filesView.error.switchToEditMode": "Перейдіть у режим редагування, щоб усунути проблему.",
   "filesView.error.readFileFailed": "Не вдалося прочитати файл",
   "filesView.editor.htmlPreviewTitle": "Попередній перегляд HTML",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1178,6 +1178,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.error.switchToTextMode': '请切换到文本模式查看原始内容。',
   'filesView.warning.largeFilePreviewLimited': '该文件较大（{sizeKb}KB），预览可能受限。',
   'filesView.error.previewUnavailable': '预览不可用',
+  'filesView.documentPreview.unavailable': '无法以文本形式预览此文档。',
+  'filesView.editor.saveOriginal': '下载原件',
   'filesView.error.switchToEditMode': '请切换到编辑模式修复问题。',
   'filesView.error.readFileFailed': '读取文件失败',
   'filesView.editor.htmlPreviewTitle': 'HTML 预览',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1188,6 +1188,8 @@ export const dict: Record<I18nKey, string> = {
   'filesView.error.switchToTextMode': '請切換到文字模式查看原始內容。',
   'filesView.warning.largeFilePreviewLimited': '該檔案較大（{sizeKb}KB），預覽可能受限。',
   'filesView.error.previewUnavailable': '預覽無法使用',
+  'filesView.documentPreview.unavailable': '無法以文字形式預覽此文件。',
+  'filesView.editor.saveOriginal': '下載原件',
   'filesView.error.switchToEditMode': '請切換到編輯模式修復問題。',
   'filesView.error.readFileFailed': '讀取檔案失敗',
   'filesView.editor.htmlPreviewTitle': 'HTML 預覽',

--- a/packages/ui/src/lib/toolHelpers.test.ts
+++ b/packages/ui/src/lib/toolHelpers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isOfficeDocumentFile } from './toolHelpers';
+
+describe('isOfficeDocumentFile', () => {
+  const officeDocuments = [
+    'report.doc',
+    'report.docx',
+    'workbook.xls',
+    'workbook.xlsx',
+    'slides.ppt',
+    'slides.pptx',
+    'document.odt',
+    'workbook.ods',
+    'slides.odp',
+  ];
+
+  for (const filePath of officeDocuments) {
+    test(`recognizes packaged and legacy office document ${filePath}`, () => {
+      expect(isOfficeDocumentFile(filePath)).toBe(true);
+    });
+  }
+
+  test('matches extensions case-insensitively', () => {
+    expect(isOfficeDocumentFile('/workspace/Quarterly Review.PPTX')).toBe(true);
+  });
+
+  const otherFiles = [
+    'notes.txt',
+    'slides.md',
+    'archive.zip',
+    'report.pdf',
+    'presentation.pptx.txt',
+  ];
+
+  for (const filePath of otherFiles) {
+    test(`does not classify non-office file ${filePath}`, () => {
+      expect(isOfficeDocumentFile(filePath)).toBe(false);
+    });
+  }
+});

--- a/packages/ui/src/lib/toolHelpers.ts
+++ b/packages/ui/src/lib/toolHelpers.ts
@@ -688,6 +688,8 @@ export function isDrawioFile(filePath: string): boolean {
 
 const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico', 'bmp', 'avif'];
 
+const OFFICE_DOCUMENT_EXTENSIONS = ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'odt', 'ods', 'odp'];
+
 export function isImageFile(filePath: string): boolean {
   const ext = filePath.split('.').pop()?.toLowerCase();
   return IMAGE_EXTENSIONS.includes(ext || '');
@@ -696,6 +698,11 @@ export function isImageFile(filePath: string): boolean {
 export function isPdfFile(filePath: string): boolean {
   const ext = filePath.split('.').pop()?.toLowerCase();
   return ext === 'pdf';
+}
+
+export function isOfficeDocumentFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return OFFICE_DOCUMENT_EXTENSIONS.includes(ext || '');
 }
 
 export function getImageMimeType(filePath: string): string {

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -1,6 +1,7 @@
 import { createRealpathCache } from '../path-realpath-cache.js';
 import nodeFsPromises from 'node:fs/promises';
 import nodePath from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const EXEC_JOB_TTL_MS = 30 * 60 * 1000;
 const OUTSIDE_FILE_GRANT_TTL_MS = 10 * 60 * 1000;
@@ -129,6 +130,160 @@ const FILE_MIME_MAP = Object.freeze({
 });
 
 const MAX_SERVE_BYTES = 100 * 1024 * 1024;
+const OFFICE_PREVIEW_EXTENSIONS = new Set(['.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.odt', '.ods', '.odp']);
+const OFFICE_PREVIEW_ENV_KEYS = ['LANG', 'LC_ALL', 'LC_CTYPE', 'SystemRoot', 'WINDIR', 'COMSPEC', 'PATHEXT'];
+
+const readPositiveEnvNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+};
+
+const createOfficePreviewError = (message, statusCode) => {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  return error;
+};
+
+const createOfficePreviewEnvironment = ({ profileDir, tempRoot, buildAugmentedPath }) => {
+  const env = {};
+  for (const key of OFFICE_PREVIEW_ENV_KEYS) {
+    if (process.env[key]) env[key] = process.env[key];
+  }
+  env.PATH = buildAugmentedPath ? buildAugmentedPath(process.env.PATH || '') : process.env.PATH;
+  env.HOME = profileDir;
+  env.USERPROFILE = profileDir;
+  env.TMPDIR = tempRoot;
+  env.TEMP = tempRoot;
+  env.TMP = tempRoot;
+  return env;
+};
+
+const runOfficeConversion = async ({
+  sourcePath,
+  sourceStats,
+  fsPromises,
+  path,
+  os,
+  spawn,
+  buildAugmentedPath,
+  timeoutMs,
+  maxInputBytes,
+  maxOutputBytes,
+}) => {
+  const tempRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'openchamber-office-preview-'));
+  const inputDir = path.join(tempRoot, 'input');
+  const outputDir = path.join(tempRoot, 'output');
+  const profileDir = path.join(tempRoot, 'profile');
+
+  try {
+    await Promise.all([
+      fsPromises.mkdir(inputDir, { recursive: true }),
+      fsPromises.mkdir(outputDir, { recursive: true }),
+      fsPromises.mkdir(profileDir, { recursive: true }),
+    ]);
+
+    const snapshotPath = path.join(inputDir, path.basename(sourcePath));
+    await fsPromises.copyFile(sourcePath, snapshotPath);
+    const snapshotStats = await fsPromises.stat(snapshotPath);
+    if (!snapshotStats.isFile() || snapshotStats.size > maxInputBytes) {
+      throw createOfficePreviewError('Office document is too large to preview', 413);
+    }
+
+    const libreOfficeBinary = process.env.OPENCHAMBER_LIBREOFFICE_BINARY || 'libreoffice';
+    const args = [
+      '--headless',
+      '--nologo',
+      '--nodefault',
+      '--nofirststartwizard',
+      `-env:UserInstallation=${pathToFileURL(profileDir).href}`,
+      '--convert-to',
+      'pdf',
+      '--outdir',
+      outputDir,
+      snapshotPath,
+    ];
+
+    await new Promise((resolve, reject) => {
+      let stderr = '';
+      let timedOut = false;
+      let settled = false;
+      let timeout = null;
+      const finish = (callback) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        callback();
+      };
+      const child = spawn(libreOfficeBinary, args, {
+        cwd: tempRoot,
+        env: createOfficePreviewEnvironment({ profileDir, tempRoot, buildAugmentedPath }),
+        shell: false,
+        windowsHide: true,
+        stdio: ['ignore', 'ignore', 'pipe'],
+      });
+
+      child.stderr?.on('data', (chunk) => {
+        if (stderr.length < 64 * 1024) stderr += chunk.toString();
+      });
+      child.on('error', (error) => {
+        const statusCode = error?.code === 'ENOENT' ? 503 : 422;
+        finish(() => reject(createOfficePreviewError(
+          error?.code === 'ENOENT' ? 'Office preview converter is unavailable' : 'Office preview conversion failed',
+          statusCode,
+        )));
+      });
+      child.on('close', (code) => {
+        if (timedOut) {
+          finish(() => reject(createOfficePreviewError('Office preview conversion timed out', 504)));
+          return;
+        }
+        if (code !== 0) {
+          const detail = stderr.trim();
+          finish(() => reject(createOfficePreviewError(
+            detail ? `Office preview conversion failed: ${detail}` : 'Office preview conversion failed',
+            422,
+          )));
+          return;
+        }
+        finish(resolve);
+      });
+
+      timeout = setTimeout(() => {
+        timedOut = true;
+        try {
+          child.kill('SIGKILL');
+        } catch {
+        }
+      }, timeoutMs);
+    });
+
+    const outputNames = await fsPromises.readdir(outputDir);
+    const pdfNames = outputNames.filter((name) => path.extname(name).toLowerCase() === '.pdf');
+    if (pdfNames.length !== 1) {
+      throw createOfficePreviewError('Office preview converter did not produce a PDF', 422);
+    }
+
+    const outputPath = path.join(outputDir, pdfNames[0]);
+    const outputStats = await fsPromises.stat(outputPath);
+    if (!outputStats.isFile() || outputStats.size <= 0 || outputStats.size > maxOutputBytes) {
+      throw createOfficePreviewError('Office preview PDF is invalid or too large', 422);
+    }
+
+    const pdf = await fsPromises.readFile(outputPath);
+    if (!Buffer.isBuffer(pdf) || pdf.subarray(0, 5).toString('ascii') !== '%PDF-') {
+      throw createOfficePreviewError('Office preview converter returned an invalid PDF', 422);
+    }
+
+    const finalSourceStats = await fsPromises.stat(sourcePath);
+    if (finalSourceStats.size !== sourceStats.size || finalSourceStats.mtimeMs !== sourceStats.mtimeMs) {
+      throw createOfficePreviewError('Source file changed during preview conversion', 409);
+    }
+
+    return pdf;
+  } finally {
+    await fsPromises.rm(tempRoot, { recursive: true, force: true }).catch(() => undefined);
+  }
+};
 
 // Only deterministic, side-effect-free git plumbing path queries are cacheable.
 // Anything outside this allowlist (including any non-git command) runs normally
@@ -399,6 +554,12 @@ export const registerFsRoutes = (app, dependencies) => {
   const gitCheckIgnoreTimeoutMs = createGitCheckIgnoreTimeoutMs();
   const gitReadCache = new Map();
   const inFlightGitReadCache = new Map();
+  const officePreviewInFlight = new Map();
+  let activeOfficePreviewConversions = 0;
+  const officePreviewTimeoutMs = readPositiveEnvNumber('OPENCHAMBER_OFFICE_PREVIEW_TIMEOUT_MS', 60 * 1000);
+  const officePreviewMaxBytes = readPositiveEnvNumber('OPENCHAMBER_OFFICE_PREVIEW_MAX_BYTES', 50 * 1024 * 1024);
+  const officePreviewMaxOutputBytes = readPositiveEnvNumber('OPENCHAMBER_OFFICE_PREVIEW_MAX_OUTPUT_BYTES', 100 * 1024 * 1024);
+  const officePreviewMaxConcurrency = readPositiveEnvNumber('OPENCHAMBER_OFFICE_PREVIEW_MAX_CONCURRENCY', 1);
 
   const pruneExecJobs = () => {
     const now = Date.now();
@@ -908,6 +1069,98 @@ export const registerFsRoutes = (app, dependencies) => {
       }
       console.error('Failed to read raw file:', error);
       return res.status(500).json({ error: (error && error.message) || 'Failed to read file' });
+    }
+  });
+
+  app.get('/api/fs/office-preview', async (req, res) => {
+    const filePath = typeof req.query.path === 'string' ? req.query.path.trim() : '';
+    if (!filePath) {
+      return res.status(400).json({ error: 'Path is required' });
+    }
+
+    try {
+      const resolved = await resolveReadPathFromContext({
+        req,
+        targetPath: filePath,
+        scope: 'raw',
+        resolveProjectDirectory,
+        path,
+        os,
+        fsPromises,
+        normalizeDirectoryPath,
+        openchamberUserConfigRoot,
+      });
+      if (!resolved.ok) {
+        return res.status(400).json({ error: resolved.error });
+      }
+
+      const [canonicalPath, canonicalBase] = await Promise.all([
+        fsPromises.realpath(resolved.resolved),
+        fsPromises.realpath(resolved.base).catch(() => path.resolve(resolved.base)),
+      ]);
+      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os)) {
+        return res.status(403).json({ error: 'Access to file denied' });
+      }
+
+      const extension = path.extname(canonicalPath).toLowerCase();
+      if (!OFFICE_PREVIEW_EXTENSIONS.has(extension)) {
+        return res.status(415).json({ error: 'File type is not supported for Office preview' });
+      }
+
+      const sourceStats = await fsPromises.stat(canonicalPath);
+      if (!sourceStats.isFile()) {
+        return res.status(400).json({ error: 'Specified path is not a file' });
+      }
+      if (sourceStats.size > officePreviewMaxBytes) {
+        return res.status(413).json({ error: 'Office document is too large to preview' });
+      }
+
+      const previewKey = `${canonicalPath}\0${sourceStats.size}\0${sourceStats.mtimeMs}`;
+      let previewPromise = officePreviewInFlight.get(previewKey);
+      if (!previewPromise) {
+        if (activeOfficePreviewConversions >= officePreviewMaxConcurrency) {
+          res.setHeader('Retry-After', '1');
+          return res.status(429).json({ error: 'Office preview converter is busy' });
+        }
+        activeOfficePreviewConversions += 1;
+        previewPromise = runOfficeConversion({
+          sourcePath: canonicalPath,
+          sourceStats,
+          fsPromises,
+          path,
+          os,
+          spawn,
+          buildAugmentedPath,
+          timeoutMs: officePreviewTimeoutMs,
+          maxInputBytes: officePreviewMaxBytes,
+          maxOutputBytes: officePreviewMaxOutputBytes,
+        }).finally(() => {
+          activeOfficePreviewConversions -= 1;
+          officePreviewInFlight.delete(previewKey);
+        });
+        officePreviewInFlight.set(previewKey, previewPromise);
+      }
+
+      const pdf = await previewPromise;
+      res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      if (resolved.granted) {
+        res.setHeader('Referrer-Policy', 'no-referrer');
+      }
+      return res.type('application/pdf').send(pdf);
+    } catch (error) {
+      const err = error;
+      if (err && typeof err === 'object' && err.code === 'ENOENT') {
+        return res.status(404).json({ error: 'File not found' });
+      }
+      if (err && typeof err === 'object' && err.code === 'EACCES') {
+        return res.status(403).json({ error: 'Access to file denied' });
+      }
+      const statusCode = Number.isInteger(err?.statusCode) ? err.statusCode : 500;
+      if (statusCode >= 500) {
+        console.error('Failed to generate Office preview:', error);
+      }
+      return res.status(statusCode).json({ error: err?.message || 'Failed to generate Office preview' });
     }
   });
 

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -180,6 +180,26 @@ const registerRaw = (fsPromises) => {
   return getRoute('GET', '/api/fs/raw');
 };
 
+const registerOfficePreview = (fsPromises, spawn) => {
+  const { app, getRoute } = createRouteRegistry();
+  registerFsRoutes(app, {
+    os: { homedir: () => '/home/user', tmpdir: () => '/tmp' },
+    path: path.posix,
+    fsPromises: {
+      realpath: async (targetPath) => targetPath,
+      ...fsPromises,
+    },
+    spawn,
+    crypto: { randomUUID: () => 'job-0' },
+    normalizeDirectoryPath: (p) => p,
+    resolveProjectDirectory: async () => ({ directory: '/repo' }),
+    buildAugmentedPath: () => '/usr/bin',
+    resolveGitBinaryForSpawn: () => 'git',
+    openchamberUserConfigRoot: '/home/user/.config',
+  });
+  return getRoute('GET', '/api/fs/office-preview');
+};
+
 const registerMkdir = (fsPromises) => {
   const { app, getRoute } = createRouteRegistry();
   registerFsRoutes(app, {
@@ -219,6 +239,12 @@ const callRead = async (handler, query) => {
 };
 
 const callRaw = async (handler, query) => {
+  const res = createMockResponse();
+  await handler({ query }, res);
+  return res;
+};
+
+const callOfficePreview = async (handler, query) => {
   const res = createMockResponse();
   await handler({ query }, res);
   return res;
@@ -633,5 +659,98 @@ describe('fs raw download Content-Disposition', () => {
     const cd = res.getHeader('content-disposition');
     expect(cd).toContain('filename="readme.txt"');
     expect(cd).toContain("filename*=UTF-8''readme.txt");
+  });
+});
+
+describe('fs Office preview', () => {
+  it('converts an isolated snapshot and returns a PDF without modifying the source', async () => {
+    const sourceStats = { isFile: () => true, size: 12, mtimeMs: 123 };
+    const pdf = Buffer.from('%PDF-1.4');
+    const fsPromises = {
+      mkdtemp: vi.fn(async () => '/tmp/preview-job'),
+      mkdir: vi.fn(async () => undefined),
+      copyFile: vi.fn(async () => undefined),
+      readdir: vi.fn(async () => ['slides.pdf']),
+      stat: vi.fn(async (targetPath) => targetPath.endsWith('.pdf')
+        ? { isFile: () => true, size: pdf.length }
+        : sourceStats),
+      readFile: vi.fn(async () => pdf),
+      rm: vi.fn(async () => undefined),
+      writeFile: vi.fn(),
+      rename: vi.fn(),
+    };
+    const { spawn } = createSpawn();
+    const handler = registerOfficePreview(fsPromises, spawn);
+
+    process.env.OPENCHAMBER_OFFICE_PREVIEW_TEST_SECRET = 'not-forwarded';
+    let res;
+    try {
+      res = await callOfficePreview(handler, { path: '/repo/slides.pptx' });
+    } finally {
+      delete process.env.OPENCHAMBER_OFFICE_PREVIEW_TEST_SECRET;
+    }
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(pdf);
+    expect(fsPromises.copyFile).toHaveBeenCalledWith(
+      '/repo/slides.pptx',
+      '/tmp/preview-job/input/slides.pptx',
+    );
+    expect(fsPromises.writeFile).not.toHaveBeenCalled();
+    expect(fsPromises.rename).not.toHaveBeenCalled();
+    expect(fsPromises.rm).toHaveBeenCalledWith('/tmp/preview-job', { recursive: true, force: true });
+
+    const [binary, args, options] = spawn.mock.calls[0];
+    expect(binary).toBe('libreoffice');
+    expect(args).toContain('--headless');
+    expect(args).toContain('-env:UserInstallation=file:///tmp/preview-job/profile');
+    expect(args).toContain('/tmp/preview-job/input/slides.pptx');
+    expect(options.shell).toBe(false);
+    expect(options.cwd).toBe('/tmp/preview-job');
+    expect(options.env.HOME).toBe('/tmp/preview-job/profile');
+    expect(options.env.TMPDIR).toBe('/tmp/preview-job');
+    expect(options.env.OPENCHAMBER_OFFICE_PREVIEW_TEST_SECRET).toBeUndefined();
+  });
+
+  it('returns retry guidance while the converter is busy', async () => {
+    const sourceStats = { isFile: () => true, size: 12, mtimeMs: 123 };
+    const pdf = Buffer.from('%PDF-1.4');
+    const fsPromises = {
+      mkdtemp: vi.fn(async () => '/tmp/preview-job'),
+      mkdir: vi.fn(async () => undefined),
+      copyFile: vi.fn(async () => undefined),
+      readdir: vi.fn(async () => ['slides.pdf']),
+      stat: vi.fn(async (targetPath) => targetPath.endsWith('.pdf')
+        ? { isFile: () => true, size: pdf.length }
+        : sourceStats),
+      readFile: vi.fn(async () => pdf),
+      rm: vi.fn(async () => undefined),
+    };
+    const { spawn, closeNext } = createDeferredSpawn();
+    const handler = registerOfficePreview(fsPromises, spawn);
+
+    const firstResponse = callOfficePreview(handler, { path: '/repo/slides.pptx' });
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(1));
+    const busyResponse = await callOfficePreview(handler, { path: '/repo/report.xlsx' });
+
+    expect(busyResponse.statusCode).toBe(429);
+    expect(busyResponse.getHeader('retry-after')).toBe('1');
+    closeNext();
+    expect((await firstResponse).statusCode).toBe(200);
+  });
+
+  it('rejects unsupported extensions before starting a conversion', async () => {
+    const fsPromises = {
+      stat: vi.fn(async () => ({ isFile: () => true, size: 10, mtimeMs: 123 })),
+      mkdtemp: vi.fn(),
+    };
+    const spawn = vi.fn();
+    const handler = registerOfficePreview(fsPromises, spawn);
+
+    const res = await callOfficePreview(handler, { path: '/repo/readme.txt' });
+
+    expect(res.statusCode).toBe(415);
+    expect(spawn).not.toHaveBeenCalled();
+    expect(fsPromises.mkdtemp).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- classify Office and OpenDocument files as binary content instead of opening them in the text editor
- add a workspace-authorized `/api/fs/office-preview` route that converts an isolated snapshot with headless LibreOffice
- enforce input/output limits, timeout, single-flight concurrency, temporary-profile cleanup, PDF validation, and a minimal converter environment
- render the derived PDF in Files view while preserving byte-identical original downloads and a safe fallback
- retry temporary converter contention without requiring users to reselect the file

## Validation

- `bun test packages/ui/src/lib/contextFileOpenGuard.test.ts packages/ui/src/lib/toolHelpers.test.ts` (16 passed)
- `bun run --cwd packages/web test -- server/lib/fs/routes.test.js` (26 passed)
- `bun run lint`
- `bun run type-check`
- `bun run --cwd packages/web build`
- browser E2E for PPTX, XLSX, and DOCX preview plus original-download SHA-256 equality
- rapid PPTX-to-XLSX switch verified 429 retry recovery to a rendered PDF