### PR TITLE
fix: correct session selection when switching projects

### DIFF
--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
@@ -103,7 +103,6 @@ export const useProjectSessionSelection = (args: Args): void => {
     if (!section) {
       return;
     }
-    previousActiveProjectRef.current = activeProjectId;
     const projectMap = projectSessionMeta.metaByProject.get(activeProjectId);
 
     if (currentSessionId && projectMap && projectMap.has(currentSessionId)) {
@@ -115,18 +114,11 @@ export const useProjectSessionSelection = (args: Args): void => {
         next.set(activeProjectId, currentSessionId);
         return next;
       });
+      previousActiveProjectRef.current = activeProjectId;
       return;
     }
 
-    // Path A' — currentSessionId is set but not in stale projectMap.
-    // Preserve user's explicit selection when the projectMap exists but
-    // is missing the session (worktree data not yet loaded). For
-    // empty projects (projectMap is undefined), fall through to Path B
-    // so a new session draft is opened.
-    if (currentSessionId && projectMap) {
-      return;
-    }
-
+    
     if (!projectMap || projectMap.size === 0) {
       setActiveMainTab('chat');
       if (mobileVariant) {
@@ -136,6 +128,7 @@ export const useProjectSessionSelection = (args: Args): void => {
         selectedProjectId: section.project.id,
         directoryOverride: section.project.normalizedPath,
       });
+      previousActiveProjectRef.current = activeProjectId;
       return;
     }
 
@@ -146,10 +139,12 @@ export const useProjectSessionSelection = (args: Args): void => {
     const fallback = projectSessionMeta.firstSessionByProject.get(activeProjectId)?.id ?? null;
     const targetSessionId = remembered ?? fallback;
     if (!targetSessionId || targetSessionId === currentSessionId) {
+      previousActiveProjectRef.current = activeProjectId;
       return;
     }
     const targetDirectory = projectMap.get(targetSessionId)?.directory ?? null;
     handleSessionSelect(targetSessionId, targetDirectory);
+    previousActiveProjectRef.current = activeProjectId;
   }, [
     activeProjectId,
     activeSessionByProject,


### PR DESCRIPTION
# fix: correct session selection when switching projects

## Summary
Fixed a bug where switching projects in the desktop app would keep the previously selected session (from the prior project) and send messages to the wrong project. The issue was in the `useProjectSessionSelection` hook: when the project map existed but did not contain the current session (because the session belonged to a different project), the hook would prematurely return and preserve the incorrect session. This was fixed by removing that early return and relying on the earlier check that only preserves the session if it belongs to the active project. Additionally, the `previousActiveProjectRef` is now updated after session selection in all branches to ensure correct tracking of the last processed project.

Fixes #2317

## Changes
- Removed early return in `useProjectSessionSelection` that incorrectly preserved session when projectMap existed but session was not present
- Ensured session is only preserved if it belongs to the active project (checked in prior condition)
- Updated `previousActiveProjectRef.current = activeProjectId` after session selection in all code paths (empty project, remembered/fallback, and session match cases) to correctly track the last processed project

## Testing
- Manual code review confirmed the logic flows correctly:
  * When current session is in projectMap: set active session for project and update ref
  * When projectMap is empty: open new session draft and update ref
  * When remembered/fallback logic applies: either retain current session (update ref) or select new session (update ref)
- No TypeScript compilation errors observed (checked via editor)
- Verified that the change aligns with the issue's plan hints

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PM immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
