### PR TITLE
fix(desktop): restore Linux AppImage auto-update feed handling

### DIFF
--- a/packages/electron/updater-check.mjs
+++ b/packages/electron/updater-check.mjs
@@ -1,8 +1,28 @@
+const MISSING_UPDATE_FEED_RE =
+  /404|ENOTFOUND|Cannot find (?:channel|latest)|latest-linux(?:-arm64)?\.yml|HttpError:\s*404|status code 404/i;
+
+export const isMissingUpdateFeedError = (error) => {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  return MISSING_UPDATE_FEED_RE.test(message);
+};
+
 export const checkForDesktopUpdate = async ({ autoUpdater, currentVersion, pendingUpdate, compareVersions }) => {
   let updateResult;
   try {
     updateResult = await autoUpdater.checkForUpdates();
   } catch (error) {
+    // Before the first Linux (or platform) release publishes its feed, electron-updater
+    // returns 404 for latest-*.yml. Treat that as authoritative "no update" instead of
+    // surfacing a hard failure that looks like a broken updater.
+    if (isMissingUpdateFeedError(error)) {
+      return {
+        available: false,
+        updateInfo: null,
+        updateResult: null,
+        nextVersion: currentVersion,
+        pendingUpdate: null,
+      };
+    }
     const detail = error instanceof Error && error.message ? `: ${error.message}` : '';
     throw new Error(`Unable to check for updates${detail}. Check your network connection and try again.`, { cause: error });
   }

--- a/packages/electron/updater-check.test.mjs
+++ b/packages/electron/updater-check.test.mjs
@@ -19,6 +19,22 @@ test('signals failed checks without replacing an existing pending update', async
   assert.deepEqual(pendingUpdate, { version: '2.0.0', electronUpdate: { id: 'existing' } });
 });
 
+test('treats missing update feed (404) as no update available', async () => {
+  const result = await checkForDesktopUpdate({
+    autoUpdater: {
+      checkForUpdates: async () => {
+        throw new Error('HttpError: 404 Not Found "https://github.com/.../latest-linux.yml"');
+      },
+    },
+    currentVersion: '1.15.0',
+    pendingUpdate: { version: '1.16.0' },
+    compareVersions,
+  });
+  assert.equal(result.available, false);
+  assert.equal(result.pendingUpdate, null);
+  assert.equal(result.nextVersion, '1.15.0');
+});
+
 test('authoritative no-update result clears pending update', async () => {
   const result = await checkForDesktopUpdate({
     autoUpdater: { checkForUpdates: async () => ({ updateInfo: { version: '1.0.0' } }) },

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -626,13 +626,11 @@ export const checkForDesktopUpdates = async (): Promise<UpdateInfo | null> => {
     return null;
   }
 
-  try {
-    const info = await invokeDesktop<UpdateInfo>('desktop_check_for_updates');
-    return info as UpdateInfo;
-  } catch (error) {
-    console.warn('Failed to check for updates', error);
-    return null;
-  }
+  // Propagate updater capability / feed errors so the UI can show actionable
+  // messages (missing AppImage, read-only path, network failure). Missing
+  // latest-linux*.yml is already normalized to available:false in main.
+  const info = await invokeDesktop<UpdateInfo>('desktop_check_for_updates');
+  return info as UpdateInfo;
 };
 
 export const downloadDesktopUpdate = async (
@@ -681,8 +679,8 @@ export const downloadDesktopUpdate = async (
     await invokeDesktop('desktop_download_and_install_update');
     return true;
   } catch (error) {
-    console.warn('Failed to download update', error);
-    return false;
+    // Propagate actionable updater capability / install errors to the UI store.
+    throw error instanceof Error ? error : new Error(String(error));
   } finally {
     if (unlisten) {
       try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the Linux AppImage updater behavior that was lost on `feat/linux-appimage-releases` after diverging from `main` / #2144.

### Problem
- Packaged Linux AppImages check GitHub for `latest-linux.yml` / `latest-linux-arm64.yml`.
- Before the first Linux assets are published, electron-updater returns **404**.
- On this branch that became a hard check failure, while `checkForDesktopUpdates` / `downloadDesktopUpdate` swallowed errors — so the UI either looked broken or silently pretended there was no update / a generic Local-instance failure.
- Capability errors (missing `APPIMAGE`, read-only AppImage) were also swallowed instead of surfacing in About / sidebar.

### Fix
- Restore `isMissingUpdateFeedError`: missing feed → authoritative `available: false` (no update), not a network error.
- Propagate desktop updater check/download errors to the UI store so actionable AppImage messages are visible.
- Re-add unit coverage for the 404 → no-update path.

### Validation
- `packages/electron` `test:updater` — 14/14 pass
- `packages/ui` `type-check` — pass
- Computer-use E2E on DISPLAY=:1 (XFCE): AppImage **1.15.0 → 1.15.1** via sidebar Update → Download → Restart
  - logs: `Found version 1.15.1` → `update-downloaded version=1.15.1` → `quitAndInstall` → restart with `version: '1.15.1'`
  - post-restart check: “Update for version 1.15.1 is not available (latest version: 1.15.1)”

### Notes
- Production updates still require a writable `.AppImage` (`APPIMAGE` set).
- Publishing `latest-linux*.yml` + AppImage assets remains a release-pipeline concern; this PR makes the client behave correctly both before and after that publish.
- QA note: computer-use interacts with `DISPLAY=:1`; launching the AppImage only on a bare `:99` Xvfb makes the window “disappear” from computer-use (env mismatch, not an app bug).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ef897dc-36f0-4461-a535-ad36d9e3d8dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ef897dc-36f0-4461-a535-ad36d9e3d8dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

