### PR TITLE
fix(ui): move window controls position setting to Appearance

### DIFF
--- a/packages/ui/src/components/desktop/WindowsWindowControls.tsx
+++ b/packages/ui/src/components/desktop/WindowsWindowControls.tsx
@@ -48,10 +48,19 @@ export const WindowsWindowControls = React.memo(function WindowsWindowControls({
     return null;
   }
 
-  const buttonClassName = 'app-region-no-drag inline-flex h-12 w-11 items-center justify-center text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary';
-  const containerClassName = position === 'left'
-    ? 'app-region-no-drag -ml-3 mr-2 flex h-12 shrink-0 items-center'
-    : 'app-region-no-drag -mr-3 ml-2 flex h-12 shrink-0 items-center';
+  // Left-side controls sit in the same cluster as h-8 titlebar icon buttons
+  // (app menu / sidebar / project actions). Match that size and avoid negative
+  // margins so TitlebarLeftControls can publish an accurate reserved width —
+  // otherwise the project-actions chevron overlaps the session title.
+  // Right-side controls keep a taller Windows-style hit target.
+  const isLeft = position === 'left';
+  const buttonClassName = cn(
+    'app-region-no-drag inline-flex items-center justify-center text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+    isLeft ? 'h-8 w-8 rounded-md' : 'h-12 w-11',
+  );
+  const containerClassName = isLeft
+    ? 'app-region-no-drag mr-1 flex h-8 shrink-0 items-center'
+    : 'app-region-no-drag ml-1 flex h-12 shrink-0 items-center';
 
   return (
     <div className={containerClassName} aria-label={t('header.windowControls.groupAria')}>

--- a/packages/ui/src/components/layout/TitlebarLeftControls.tsx
+++ b/packages/ui/src/components/layout/TitlebarLeftControls.tsx
@@ -56,7 +56,9 @@ export const TitlebarLeftControls: React.FC = () => {
     }
 
     const publishWidth = () => {
-      const width = node.getBoundingClientRect().width;
+      // Prefer scrollWidth so negative child margins / overflow cannot under-report
+      // the space the overlay actually occupies over the header.
+      const width = Math.max(node.getBoundingClientRect().width, node.scrollWidth);
       document.documentElement.style.setProperty('--oc-titlebar-controls-width', `${Math.round(width)}px`);
     };
 

--- a/packages/ui/src/components/sections/openchamber/DesktopNetworkSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/DesktopNetworkSettings.tsx
@@ -14,40 +14,24 @@ import {
   setDesktopKeepAwake,
   setDesktopLaunchAtLogin,
   setDesktopMinimizeToTray,
-  usesFramelessElectronChrome,
-  type DesktopWindowControlsPosition,
 } from '@/lib/desktop';
 import { useI18n } from '@/lib/i18n';
-import { updateDesktopSettings } from '@/lib/persistence';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
-import { useUIStore } from '@/stores/useUIStore';
 import {
   SettingsSection,
   SettingsCheckboxRow,
-  SettingsChipGroup,
-  SettingsFieldRow,
   SETTINGS_OPTION_STACK_CLASS,
   SettingsStackedField,
   SETTINGS_ICON_BUTTON_CLASS,
 } from '@/components/sections/shared/SettingsSection';
 
-const WINDOW_CONTROLS_POSITION_OPTIONS: Array<{ id: DesktopWindowControlsPosition; labelKey: string }> = [
-  { id: 'auto', labelKey: 'settings.openchamber.desktopNetwork.option.windowControlsAuto' },
-  { id: 'left', labelKey: 'settings.openchamber.desktopNetwork.option.windowControlsLeft' },
-  { id: 'right', labelKey: 'settings.openchamber.desktopNetwork.option.windowControlsRight' },
-];
-
 export const DesktopNetworkSettings: React.FC = () => {
   const { t } = useI18n();
-  const tUnsafe = React.useCallback((key: string) => t(key as Parameters<typeof t>[0]), [t]);
   const isLocalDesktop = isDesktopShell() && isDesktopLocalOriginActive();
   const isMacDesktop = isLocalDesktop
     && typeof window !== 'undefined'
     && window.__OPENCHAMBER_PLATFORM__ === 'darwin';
-  const showWindowControlsPosition = usesFramelessElectronChrome();
-  const desktopWindowControlsPosition = useUIStore((state) => state.desktopWindowControlsPosition);
-  const setDesktopWindowControlsPosition = useUIStore((state) => state.setDesktopWindowControlsPosition);
   const [savedValue, setSavedValue] = React.useState(false);
   const [draftValue, setDraftValue] = React.useState(false);
   const [savedPassword, setSavedPassword] = React.useState('');
@@ -242,11 +226,6 @@ export const DesktopNetworkSettings: React.FC = () => {
     }
   }, []);
 
-  const handleWindowControlsPositionChange = React.useCallback((value: DesktopWindowControlsPosition) => {
-    setDesktopWindowControlsPosition(value);
-    void updateDesktopSettings({ desktopWindowControlsPosition: value });
-  }, [setDesktopWindowControlsPosition]);
-
   const handleLaunchAtLoginToggle = React.useCallback(async () => {
     if (!launchAtLoginSupported || isSavingLaunchAtLogin) {
       return;
@@ -362,181 +341,156 @@ export const DesktopNetworkSettings: React.FC = () => {
     }
   }, [draftMacMenuBarEnabled, draftPassword, draftValue, isDirty, t]);
 
-  if (!isLocalDesktop && !showWindowControlsPosition) {
+  if (!isLocalDesktop) {
     return null;
   }
 
   return (
-    <>
-      {showWindowControlsPosition ? (
-        <SettingsSection title={t('settings.openchamber.desktopNetwork.field.windowControlsPosition')}>
-          <SettingsFieldRow
-            settingsItem="sessions.desktop-window-controls-position"
-            label={t('settings.openchamber.desktopNetwork.field.windowControlsPositionDescription')}
-            alignEnd={false}
-            controlClassName="flex-col items-stretch"
-          >
-            <SettingsChipGroup
-              value={desktopWindowControlsPosition}
-              options={WINDOW_CONTROLS_POSITION_OPTIONS.map((option) => ({
-                value: option.id,
-                label: tUnsafe(option.labelKey),
-              }))}
-              onChange={handleWindowControlsPositionChange}
-              aria-label={t('settings.openchamber.desktopNetwork.field.windowControlsPositionAria')}
-            />
-          </SettingsFieldRow>
-        </SettingsSection>
-      ) : null}
-
-      {isLocalDesktop ? (
-        <SettingsSection title={t('settings.openchamber.desktopNetwork.title')}>
-          <div className="space-y-3">
-            {(launchAtLoginSupported || isMacDesktop || minimizeToTraySupported || keepAwakeSupported) ? (
-              <div className={SETTINGS_OPTION_STACK_CLASS}>
-                {launchAtLoginSupported ? (
-                  <SettingsCheckboxRow
-                    settingsItem="sessions.desktop-launch-at-login"
-                    checked={launchAtLoginEnabled}
-                    onChange={(checked) => {
-                      if (checked === launchAtLoginEnabled) return;
-                      void handleLaunchAtLoginToggle();
-                    }}
-                    disabled={isSavingLaunchAtLogin}
-                    label={t('settings.openchamber.desktopNetwork.field.launchAtLogin')}
-                    info={t('settings.openchamber.desktopNetwork.field.launchAtLoginDescription')}
-                    ariaLabel={t('settings.openchamber.desktopNetwork.field.launchAtLoginAria')}
-                  />
-                ) : null}
-
-                {isMacDesktop ? (
-                  <SettingsCheckboxRow
-                    settingsItem="sessions.desktop-mac-menu-bar"
-                    checked={draftMacMenuBarEnabled}
-                    onChange={setDraftMacMenuBarEnabled}
-                    disabled={isLoading || isSaving}
-                    label={t('settings.openchamber.desktopNetwork.field.macMenuBar')}
-                    info={t('settings.openchamber.desktopNetwork.field.macMenuBarDescription')}
-                    ariaLabel={t('settings.openchamber.desktopNetwork.field.macMenuBarAria')}
-                  />
-                ) : null}
-
-                {minimizeToTraySupported ? (
-                  <SettingsCheckboxRow
-                    settingsItem="sessions.desktop-minimize-to-tray"
-                    checked={minimizeToTrayEnabled}
-                    onChange={(checked) => {
-                      if (checked === minimizeToTrayEnabled) return;
-                      void handleMinimizeToTrayToggle();
-                    }}
-                    disabled={isSavingMinimizeToTray}
-                    label={t('settings.openchamber.desktopNetwork.field.minimizeToTray')}
-                    info={t('settings.openchamber.desktopNetwork.field.minimizeToTrayDescription')}
-                    ariaLabel={t('settings.openchamber.desktopNetwork.field.minimizeToTrayAria')}
-                  />
-                ) : null}
-
-                {keepAwakeSupported ? (
-                  <SettingsCheckboxRow
-                    settingsItem="sessions.desktop-keep-awake"
-                    checked={keepAwakeEnabled}
-                    onChange={(checked) => {
-                      if (checked === keepAwakeEnabled) return;
-                      void handleKeepAwakeToggle();
-                    }}
-                    disabled={isSavingKeepAwake}
-                    label={t('settings.openchamber.desktopNetwork.field.keepAwake')}
-                    info={t('settings.openchamber.desktopNetwork.field.keepAwakeDescription')}
-                    ariaLabel={t('settings.openchamber.desktopNetwork.field.keepAwakeAria')}
-                  />
-                ) : null}
-              </div>
-            ) : null}
-
-            <SettingsStackedField
-              settingsItem="sessions.desktop-ui-password"
-              label={(
-                <label htmlFor="desktop-ui-password">
-                  {t('settings.openchamber.desktopPassword.field.password')}
-                </label>
-              )}
-              info={t('settings.openchamber.desktopPassword.field.passwordDescription')}
-            >
-              <Input
-                id="desktop-ui-password"
-                type={showPassword ? 'text' : 'password'}
-                className="h-8 min-w-0 flex-1"
-                value={draftPassword}
-                onChange={(event) => handlePasswordChange(event.target.value)}
-                placeholder={t('settings.openchamber.desktopPassword.field.passwordPlaceholder')}
-                disabled={isLoading || isSaving}
-                required={draftValue}
-                aria-invalid={lanRequiresPassword}
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                onClick={() => setShowPassword((current: boolean) => !current)}
-                className={SETTINGS_ICON_BUTTON_CLASS}
-                aria-label={t(showPassword ? 'settings.openchamber.desktopPassword.actions.hidePassword' : 'settings.openchamber.desktopPassword.actions.showPassword')}
-                aria-pressed={showPassword}
-              >
-                <Icon name={showPassword ? 'eye-off' : 'eye'} className="h-4 w-4" />
-              </Button>
-            </SettingsStackedField>
-
-            <div className={SETTINGS_OPTION_STACK_CLASS}>
+    <SettingsSection title={t('settings.openchamber.desktopNetwork.title')}>
+      <div className="space-y-3">
+        {(launchAtLoginSupported || isMacDesktop || minimizeToTraySupported || keepAwakeSupported) ? (
+          <div className={SETTINGS_OPTION_STACK_CLASS}>
+            {launchAtLoginSupported ? (
               <SettingsCheckboxRow
-                settingsItem="sessions.desktop-lan-access"
-                checked={draftValue}
-                onChange={setDraftValue}
-                disabled={isLoading || isSaving}
-                label={t('settings.openchamber.desktopNetwork.field.allowLanAccess')}
-                info={t('settings.openchamber.desktopNetwork.field.allowLanAccessDescription')}
-                description={(
-                  <>
-                    <span className="block text-[var(--status-warning)]/85">
-                      {t('settings.openchamber.desktopNetwork.field.warning')}
-                    </span>
-                    {lanRequiresPassword || lanBlockedByMissingPassword ? (
-                      <span className="block text-[var(--status-warning)]/85">
-                        {t('settings.openchamber.desktopNetwork.field.passwordRequiredWarning')}
-                      </span>
-                    ) : null}
-                  </>
-                )}
-                ariaLabel={t('settings.openchamber.desktopNetwork.field.allowLanAccessAria')}
+                settingsItem="sessions.desktop-launch-at-login"
+                checked={launchAtLoginEnabled}
+                onChange={(checked) => {
+                  if (checked === launchAtLoginEnabled) return;
+                  void handleLaunchAtLoginToggle();
+                }}
+                disabled={isSavingLaunchAtLogin}
+                label={t('settings.openchamber.desktopNetwork.field.launchAtLogin')}
+                info={t('settings.openchamber.desktopNetwork.field.launchAtLoginDescription')}
+                ariaLabel={t('settings.openchamber.desktopNetwork.field.launchAtLoginAria')}
               />
-            </div>
-
-            {error ? (
-              <div className="typography-micro text-[var(--status-error)]">{error}</div>
             ) : null}
 
-            {lanUrl ? (
-              <div className="typography-micro text-muted-foreground/80">
-                {isDirty && !savedValue
-                  ? t('settings.openchamber.desktopNetwork.hint.openAfterRestart')
-                  : t('settings.openchamber.desktopNetwork.hint.openNow')}
-                <span className="font-mono text-foreground">{lanUrl}</span>
-              </div>
+            {isMacDesktop ? (
+              <SettingsCheckboxRow
+                settingsItem="sessions.desktop-mac-menu-bar"
+                checked={draftMacMenuBarEnabled}
+                onChange={setDraftMacMenuBarEnabled}
+                disabled={isLoading || isSaving}
+                label={t('settings.openchamber.desktopNetwork.field.macMenuBar')}
+                info={t('settings.openchamber.desktopNetwork.field.macMenuBarDescription')}
+                ariaLabel={t('settings.openchamber.desktopNetwork.field.macMenuBarAria')}
+              />
             ) : null}
 
-            <div className="flex justify-start py-1.5">
-              <Button
-                type="button"
-                size="xs"
-                onClick={handleSaveAndRestart}
-                disabled={saveDisabled}
-                className="shrink-0 !font-normal"
-              >
-                {isSaving ? t('settings.common.actions.saving') : t('settings.openchamber.desktopNetwork.actions.saveAndRestart')}
-              </Button>
-            </div>
+            {minimizeToTraySupported ? (
+              <SettingsCheckboxRow
+                settingsItem="sessions.desktop-minimize-to-tray"
+                checked={minimizeToTrayEnabled}
+                onChange={(checked) => {
+                  if (checked === minimizeToTrayEnabled) return;
+                  void handleMinimizeToTrayToggle();
+                }}
+                disabled={isSavingMinimizeToTray}
+                label={t('settings.openchamber.desktopNetwork.field.minimizeToTray')}
+                info={t('settings.openchamber.desktopNetwork.field.minimizeToTrayDescription')}
+                ariaLabel={t('settings.openchamber.desktopNetwork.field.minimizeToTrayAria')}
+              />
+            ) : null}
+
+            {keepAwakeSupported ? (
+              <SettingsCheckboxRow
+                settingsItem="sessions.desktop-keep-awake"
+                checked={keepAwakeEnabled}
+                onChange={(checked) => {
+                  if (checked === keepAwakeEnabled) return;
+                  void handleKeepAwakeToggle();
+                }}
+                disabled={isSavingKeepAwake}
+                label={t('settings.openchamber.desktopNetwork.field.keepAwake')}
+                info={t('settings.openchamber.desktopNetwork.field.keepAwakeDescription')}
+                ariaLabel={t('settings.openchamber.desktopNetwork.field.keepAwakeAria')}
+              />
+            ) : null}
           </div>
-        </SettingsSection>
-      ) : null}
-    </>
+        ) : null}
+
+        <SettingsStackedField
+          settingsItem="sessions.desktop-ui-password"
+          label={(
+            <label htmlFor="desktop-ui-password">
+              {t('settings.openchamber.desktopPassword.field.password')}
+            </label>
+          )}
+          info={t('settings.openchamber.desktopPassword.field.passwordDescription')}
+        >
+          <Input
+            id="desktop-ui-password"
+            type={showPassword ? 'text' : 'password'}
+            className="h-8 min-w-0 flex-1"
+            value={draftPassword}
+            onChange={(event) => handlePasswordChange(event.target.value)}
+            placeholder={t('settings.openchamber.desktopPassword.field.passwordPlaceholder')}
+            disabled={isLoading || isSaving}
+            required={draftValue}
+            aria-invalid={lanRequiresPassword}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => setShowPassword((current: boolean) => !current)}
+            className={SETTINGS_ICON_BUTTON_CLASS}
+            aria-label={t(showPassword ? 'settings.openchamber.desktopPassword.actions.hidePassword' : 'settings.openchamber.desktopPassword.actions.showPassword')}
+            aria-pressed={showPassword}
+          >
+            <Icon name={showPassword ? 'eye-off' : 'eye'} className="h-4 w-4" />
+          </Button>
+        </SettingsStackedField>
+
+        <div className={SETTINGS_OPTION_STACK_CLASS}>
+          <SettingsCheckboxRow
+            settingsItem="sessions.desktop-lan-access"
+            checked={draftValue}
+            onChange={setDraftValue}
+            disabled={isLoading || isSaving}
+            label={t('settings.openchamber.desktopNetwork.field.allowLanAccess')}
+            info={t('settings.openchamber.desktopNetwork.field.allowLanAccessDescription')}
+            description={(
+              <>
+                <span className="block text-[var(--status-warning)]/85">
+                  {t('settings.openchamber.desktopNetwork.field.warning')}
+                </span>
+                {lanRequiresPassword || lanBlockedByMissingPassword ? (
+                  <span className="block text-[var(--status-warning)]/85">
+                    {t('settings.openchamber.desktopNetwork.field.passwordRequiredWarning')}
+                  </span>
+                ) : null}
+              </>
+            )}
+            ariaLabel={t('settings.openchamber.desktopNetwork.field.allowLanAccessAria')}
+          />
+        </div>
+
+        {error ? (
+          <div className="typography-micro text-[var(--status-error)]">{error}</div>
+        ) : null}
+
+        {lanUrl ? (
+          <div className="typography-micro text-muted-foreground/80">
+            {isDirty && !savedValue
+              ? t('settings.openchamber.desktopNetwork.hint.openAfterRestart')
+              : t('settings.openchamber.desktopNetwork.hint.openNow')}
+            <span className="font-mono text-foreground">{lanUrl}</span>
+          </div>
+        ) : null}
+
+        <div className="flex justify-start py-1.5">
+          <Button
+            type="button"
+            size="xs"
+            onClick={handleSaveAndRestart}
+            disabled={saveDisabled}
+            className="shrink-0 !font-normal"
+          >
+            {isSaving ? t('settings.common.actions.saving') : t('settings.openchamber.desktopNetwork.actions.saveAndRestart')}
+          </Button>
+        </div>
+      </div>
+    </SettingsSection>
   );
 };

--- a/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx
@@ -14,7 +14,7 @@ import { DesktopNetworkSettings } from './DesktopNetworkSettings';
 import { KeyboardShortcutsSettings } from './KeyboardShortcutsSettings';
 import { SettingsPageLayout } from '@/components/sections/shared/SettingsPageLayout';
 import { useDeviceInfo } from '@/lib/device';
-import { isDesktopLocalOriginActive, isDesktopShell, isVSCodeRuntime, isWebRuntime, usesFramelessElectronChrome } from '@/lib/desktop';
+import { isDesktopLocalOriginActive, isDesktopShell, isVSCodeRuntime, isWebRuntime } from '@/lib/desktop';
 import { isCapacitorApp } from '@/lib/platform';
 import { useI18n } from '@/lib/i18n';
 import { subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
@@ -42,7 +42,7 @@ export const OpenChamberPage: React.FC<OpenChamberPageProps> = ({ section }) => 
     const showAbout = isMobile && isWebRuntime();
     const isVSCode = isVSCodeRuntime();
     void runtimeEndpointEpoch;
-    const showDesktopNetworkSettings = isDesktopShell() && (isDesktopLocalOriginActive() || usesFramelessElectronChrome());
+    const showDesktopNetworkSettings = isDesktopShell() && isDesktopLocalOriginActive();
 
     // If no section specified, show all (mobile/legacy behavior)
     if (!section) {
@@ -135,7 +135,7 @@ const GeneralSectionContent: React.FC = () => {
     const isVSCode = isVSCodeRuntime();
     const runtimeEndpointEpoch = useRuntimeEndpointEpoch();
     void runtimeEndpointEpoch;
-    const showDesktopNetworkSettings = isDesktopShell() && (isDesktopLocalOriginActive() || usesFramelessElectronChrome());
+    const showDesktopNetworkSettings = isDesktopShell() && isDesktopLocalOriginActive();
     // Passkeys only work against the browser's WebAuthn UI on the web surface —
     // desktop shell, VS Code, and the Capacitor app never show the login screen.
     const showPasskeySettings = isWebRuntime() && !isDesktopShell() && !isVSCode && !isCapacitorApp();
@@ -162,6 +162,7 @@ const VisualSectionContent: React.FC = () => {
     const isVSCode = isVSCodeRuntime();
     return <OpenChamberVisualSettings visibleSettings={[
         'theme',
+        'windowControlsPosition',
         'pwaInstallName',
         'pwaOrientation',
         'mobileKeyboardMode',

--- a/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
@@ -17,7 +17,14 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Icon } from "@/components/icon/Icon";
-import { invokeDesktop, isDesktopShell, isVSCodeRuntime, isWebRuntime } from '@/lib/desktop';
+import {
+    invokeDesktop,
+    isDesktopShell,
+    isVSCodeRuntime,
+    isWebRuntime,
+    usesFramelessElectronChrome,
+    type DesktopWindowControlsPosition,
+} from '@/lib/desktop';
 import { useDeviceInfo } from '@/lib/device';
 import { usePwaDetection } from '@/hooks/usePwaDetection';
 import { updateDesktopSettings } from '@/lib/persistence';
@@ -271,7 +278,13 @@ const normalizeUserMessageRenderingMode = (mode: unknown): 'markdown' | 'plain' 
     return mode === 'markdown' ? 'markdown' : 'plain';
 };
 
-type VisibleSetting = 'sessionAssist' | 'sessionGoal' | 'theme' | 'pwaInstallName' | 'pwaOrientation' | 'mobileKeyboardMode' | 'timeFormat' | 'weekStart' | 'fontSize' | 'terminalFontSize' | 'terminalShell' | 'terminalLoginShell' | 'editorFontSize' | 'spacing' | 'inputBarOffset' | 'mermaidRendering' | 'userMessageRendering' | 'chatRenderMode' | 'messageTransport' | 'activityRenderMode' | 'collapsibleUserMessages' | 'stickyUserHeader' | 'promptNavigatorEnabled' | 'wideChatLayout' | 'codeBlockLineWrap' | 'splitAssistantMessageActions' | 'subagentReadOnlyBanner' | 'diffLayout' | 'mobileStatusBar' | 'dotfiles' | 'fileViewerPreview' | 'reasoning' | 'showToolFileIcons' | 'showTurnChangedFiles' | 'expandedTools' | 'followUpBehavior' | 'terminalQuickKeys' | 'fileEditorKeymap' | 'persistDraft' | 'inputSpellcheck' | 'reportUsage' | 'expandedEditorToolbar';
+type VisibleSetting = 'sessionAssist' | 'sessionGoal' | 'theme' | 'windowControlsPosition' | 'pwaInstallName' | 'pwaOrientation' | 'mobileKeyboardMode' | 'timeFormat' | 'weekStart' | 'fontSize' | 'terminalFontSize' | 'terminalShell' | 'terminalLoginShell' | 'editorFontSize' | 'spacing' | 'inputBarOffset' | 'mermaidRendering' | 'userMessageRendering' | 'chatRenderMode' | 'messageTransport' | 'activityRenderMode' | 'collapsibleUserMessages' | 'stickyUserHeader' | 'promptNavigatorEnabled' | 'wideChatLayout' | 'codeBlockLineWrap' | 'splitAssistantMessageActions' | 'subagentReadOnlyBanner' | 'diffLayout' | 'mobileStatusBar' | 'dotfiles' | 'fileViewerPreview' | 'reasoning' | 'showToolFileIcons' | 'showTurnChangedFiles' | 'expandedTools' | 'followUpBehavior' | 'terminalQuickKeys' | 'fileEditorKeymap' | 'persistDraft' | 'inputSpellcheck' | 'reportUsage' | 'expandedEditorToolbar';
+
+const WINDOW_CONTROLS_POSITION_OPTIONS: Array<{ id: DesktopWindowControlsPosition; labelKey: string }> = [
+    { id: 'auto', labelKey: 'settings.openchamber.desktopNetwork.option.windowControlsAuto' },
+    { id: 'left', labelKey: 'settings.openchamber.desktopNetwork.option.windowControlsLeft' },
+    { id: 'right', labelKey: 'settings.openchamber.desktopNetwork.option.windowControlsRight' },
+];
 
 interface OpenChamberVisualSettingsProps {
     /** Which settings to show. If undefined, shows all. */
@@ -408,6 +421,9 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
     );
     const dockBadgeEnabled = useUIStore(state => state.dockBadgeEnabled);
     const setDockBadgeEnabled = useUIStore(state => state.setDockBadgeEnabled);
+    const showWindowControlsPosition = usesFramelessElectronChrome();
+    const desktopWindowControlsPosition = useUIStore((state) => state.desktopWindowControlsPosition);
+    const setDesktopWindowControlsPosition = useUIStore((state) => state.setDesktopWindowControlsPosition);
     const [chatRenderPreviewTick, setChatRenderPreviewTick] = React.useState(0);
     const reportUsage = useUIStore(state => state.reportUsage);
     const setReportUsage = useUIStore(state => state.setReportUsage);
@@ -417,6 +433,11 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
         setReportUsage(enabled);
         void updateDesktopSettings({ reportUsage: enabled });
     }, [setReportUsage]);
+
+    const handleWindowControlsPositionChange = React.useCallback((value: DesktopWindowControlsPosition) => {
+        setDesktopWindowControlsPosition(value);
+        void updateDesktopSettings({ desktopWindowControlsPosition: value });
+    }, [setDesktopWindowControlsPosition]);
 
     const shouldAnimateChatPreview = (isSettingsDialogOpen || isMobile || isVSCodeRuntime())
         && (visibleSettings ? visibleSettings.includes('chatRenderMode') : true);
@@ -596,11 +617,12 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
 
     const isVSCode = isVSCodeRuntime();
     const hasThemeSettings = shouldShow('theme') && !isVSCode;
+    const showWindowControlsPositionSetting = shouldShow('windowControlsPosition') && showWindowControlsPosition;
     const hasLocalizationSettings = shouldShow('theme') || shouldShow('timeFormat') || shouldShow('weekStart');
     const showMobileLayoutSetting = isMobile && isWebRuntime() && !isDesktopShell() && !isVSCode;
     const hasAppearanceSettings = isVSCode
         ? hasLocalizationSettings
-        : (shouldShow('theme') || showMobileLayoutSetting || shouldShow('pwaInstallName') || shouldShow('pwaOrientation') || shouldShow('timeFormat') || shouldShow('weekStart'));
+        : (shouldShow('theme') || showWindowControlsPositionSetting || showMobileLayoutSetting || shouldShow('pwaInstallName') || shouldShow('pwaOrientation') || shouldShow('timeFormat') || shouldShow('weekStart'));
     const hasLayoutSettings = shouldShow('fontSize') || shouldShow('terminalFontSize') || shouldShow('editorFontSize') || shouldShow('spacing') || (shouldShow('inputBarOffset') && isMobile);
     const hasNavigationSettings = (shouldShow('terminalQuickKeys') && !isMobile) || ((shouldShow('terminalShell') || shouldShow('terminalLoginShell')) && !isVSCode) || shouldShow('fileEditorKeymap') || (shouldShow('expandedEditorToolbar') && !isVSCode);
     const hasBehaviorSettings = shouldShow('mermaidRendering')
@@ -977,6 +999,30 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
                                         />
                                     </SettingsInset>
                                 )}
+                            </SettingsSection>
+                        )}
+
+                        {showWindowControlsPositionSetting && (
+                            <SettingsSection
+                                title={t('settings.openchamber.desktopNetwork.field.windowControlsPosition')}
+                                divider={hasThemeSettings}
+                            >
+                                <SettingsFieldRow
+                                    settingsItem="sessions.desktop-window-controls-position"
+                                    label={t('settings.openchamber.desktopNetwork.field.windowControlsPositionDescription')}
+                                    alignEnd={false}
+                                    controlClassName="flex-col items-stretch"
+                                >
+                                    <SettingsChipGroup
+                                        value={desktopWindowControlsPosition}
+                                        options={WINDOW_CONTROLS_POSITION_OPTIONS.map((option) => ({
+                                            value: option.id,
+                                            label: tUnsafe(option.labelKey),
+                                        }))}
+                                        onChange={handleWindowControlsPositionChange}
+                                        aria-label={t('settings.openchamber.desktopNetwork.field.windowControlsPositionAria')}
+                                    />
+                                </SettingsFieldRow>
                             </SettingsSection>
                         )}
 

--- a/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/OpenChamberVisualSettings.tsx
@@ -1005,24 +1005,19 @@ export const OpenChamberVisualSettings: React.FC<OpenChamberVisualSettingsProps>
                         {showWindowControlsPositionSetting && (
                             <SettingsSection
                                 title={t('settings.openchamber.desktopNetwork.field.windowControlsPosition')}
+                                description={t('settings.openchamber.desktopNetwork.field.windowControlsPositionDescription')}
                                 divider={hasThemeSettings}
+                                settingsItem="sessions.desktop-window-controls-position"
                             >
-                                <SettingsFieldRow
-                                    settingsItem="sessions.desktop-window-controls-position"
-                                    label={t('settings.openchamber.desktopNetwork.field.windowControlsPositionDescription')}
-                                    alignEnd={false}
-                                    controlClassName="flex-col items-stretch"
-                                >
-                                    <SettingsChipGroup
-                                        value={desktopWindowControlsPosition}
-                                        options={WINDOW_CONTROLS_POSITION_OPTIONS.map((option) => ({
-                                            value: option.id,
-                                            label: tUnsafe(option.labelKey),
-                                        }))}
-                                        onChange={handleWindowControlsPositionChange}
-                                        aria-label={t('settings.openchamber.desktopNetwork.field.windowControlsPositionAria')}
-                                    />
-                                </SettingsFieldRow>
+                                <SettingsChipGroup
+                                    value={desktopWindowControlsPosition}
+                                    options={WINDOW_CONTROLS_POSITION_OPTIONS.map((option) => ({
+                                        value: option.id,
+                                        label: tUnsafe(option.labelKey),
+                                    }))}
+                                    onChange={handleWindowControlsPositionChange}
+                                    aria-label={t('settings.openchamber.desktopNetwork.field.windowControlsPositionAria')}
+                                />
                             </SettingsSection>
                         )}
 

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -246,8 +246,8 @@ export const getElectronPlatform = (): string | null => {
   return typeof platform === 'string' ? platform : null;
 };
 
-/** Width of the three in-app window control buttons (3 × w-11). */
-export const DESKTOP_WINDOW_CONTROLS_WIDTH_PX = 132;
+/** Width of the three in-app window control buttons when placed on the left (3 × w-8). */
+export const DESKTOP_WINDOW_CONTROLS_WIDTH_PX = 96;
 
 /** Windows and Linux use frameless windows with in-app minimize/maximize/close controls. */
 export const usesFramelessElectronChrome = (): boolean => {

--- a/packages/ui/src/lib/settings/search.ts
+++ b/packages/ui/src/lib/settings/search.ts
@@ -392,7 +392,7 @@ const SETTINGS_SEARCH_ITEMS: readonly SettingsSearchItem[] = [
   },
   {
     id: 'sessions.desktop-window-controls-position',
-    page: 'general',
+    page: 'appearance',
     titleKey: 'settings.openchamber.desktopNetwork.field.windowControlsPosition',
     descriptionKey: 'settings.openchamber.desktopNetwork.field.windowControlsPositionDescription',
     keywords: ['desktop', 'window', 'controls', 'minimize', 'maximize', 'close', 'titlebar', 'linux', 'windows'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Move the **Window controls position** setting from Settings → General to Settings → Appearance so desktop chrome layout lives with other visual settings.

Also fix Linux titlebar layout regressions and polish the Appearance control layout:

- left-side window controls were taller than neighboring icons and used negative margins that under-reported reserved titlebar width, so the project-actions chooser collided with **New session**
- the Appearance helper copy is now full-width under the section title, with Auto / Left / Right chips beneath it

## Non-goals

- Moving launch-at-login, minimize-to-tray, or macOS menu bar controls out of General.
- Changing the control’s options, defaults, or platform availability.
- Renaming i18n keys or the stable search item id.
- Changing right-side (Windows-style) full-height window control hit targets beyond removing negative margins.

## Affected surfaces

- **`packages/ui` Settings Appearance / General**: window-controls position rendered from `OpenChamberVisualSettings` on Appearance; removed from General; description uses section `description` (full width) with chips below.
- **`WindowsWindowControls` / `TitlebarLeftControls`**: left-side controls sized to the h-8 icon row; reserved width measurement hardened.
- **Settings search**: item `sessions.desktop-window-controls-position` keeps the same id/anchor; `page` updated to `appearance`.
- **Unaffected**: Electron main/preload behavior beyond UI chrome sizing; VS Code; web/mobile.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `.agents/skills/settings-ui-patterns/SKILL.md` (+ search/layout/controls refs) | Moving a Settings control between pages and restacking label/control | Shared `SettingsSection` description + `SettingsChipGroup`; search `page` updated; anchor preserved |
| `.agents/skills/theme-system/SKILL.md` | Titlebar chrome / icon button styling | Theme tokens for hover/status; no hardcoded colors; left controls match existing h-8 icon buttons |
| `.agents/skills/locale-ui-patterns/SKILL.md` | Settings labels remain user-facing | Reuses existing localized keys; no new strings |
| `CONTRIBUTING.md` + `.github/PULL_REQUEST_TEMPLATE.md` | Required PR handoff | This body completes the contract |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui type-check` | Pass |
| `bun run --cwd packages/ui lint` | Pass |
| Linux AppImage rebuild + `verify:linux-appimage` | Pass (`OpenChamber-1.16.3-linux-x86_64.AppImage`) |
| Interactive titlebar check (controls alignment + New session overlap) | Pass via computer-use on rebuilt AppImage |
| Appearance window-controls layout (full-width description, chips below) | Rebuilt and relaunched AppImage with the stacked layout |

## Visual evidence

[Titlebar window controls aligned with icon row](https://cursor.com/agents/bc-399fcc4c-b6d6-429a-b45b-e446e66c7845/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftitlebar-window-controls-aligned.webp)
[New session header without actions overlap (sidebar collapsed)](https://cursor.com/agents/bc-399fcc4c-b6d6-429a-b45b-e446e66c7845/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fheader-new-session-no-overlap-collapsed.webp)
[New session header without actions overlap (sidebar open)](https://cursor.com/agents/bc-399fcc4c-b6d6-429a-b45b-e446e66c7845/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fheader-new-session-no-overlap-open.webp)

Rebuilt AppImage was launched with `APPIMAGE_EXTRACT_AND_RUN=1`. Titlebar controls align with the icon row; project-actions no longer collide with **New session**. Appearance now shows the helper copy full-width above Auto/Left/Right.

## Risks and failure behavior

- **Settings search bookmarks**: id stays stable; only the target page changes to Appearance.
- **Titlebar width**: if overlay measurement fails, header falls back to `5.5rem`; left controls are now smaller so overflow risk is reduced.
- **Rollback**: revert this branch to restore prior General placement and previous control sizing/layout.
- **Cross-runtime**: still gated by `usesFramelessElectronChrome()`; macOS traffic lights unchanged.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-399fcc4c-b6d6-429a-b45b-e446e66c7845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-399fcc4c-b6d6-429a-b45b-e446e66c7845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

