### PR TITLE
fix(engines): Claude queue, stop, catalog dedupe, handoff & session titles

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -10,7 +10,7 @@ import { createMessageQueueTarget, getMessageQueueKey, useMessageQueueStore, typ
 import { useAutoReviewStore } from '@/stores/useAutoReviewStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useSelectionStore } from '@/sync/selection-store';
-import { sessionSupports } from '@/lib/harness/capabilities';
+import { sessionSupports, sessionSupportsSteerDelivery } from '@/lib/harness/capabilities';
 import { resolveComposerAttachmentModel } from '@/lib/harness/composer-attachment-model';
 import { useHarnessStore } from '@/stores/useHarnessStore';
 import { useInputStore } from '@/sync/input-store';
@@ -1850,7 +1850,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
     }, [clearPendingDraftPersist, persistChatDraft, persistDraftImmediately]);
 
     // Session activity for queue availability and controls
-    const { phase: sessionPhase } = useCurrentSessionActivity();
+    const { phase: sessionPhase, canAbort: sessionCanAbort } = useCurrentSessionActivity();
     const autoReviewRunning = useAutoReviewStore(React.useCallback((state) => {
         if (!currentSessionId) return false;
         const run = state.runsByOriginalSessionID[currentSessionId];
@@ -1897,7 +1897,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
     const hasQueuedMessages = queuedMessages.length > 0;
     const canSend = hasContent || hasQueuedMessages;
 
-    const canAbort = sessionPhase !== 'idle';
+    // Prefer activity-derived canAbort (keeps Stop available during Claude
+    // permission waits while status remains busy). Fall back to phase for
+    // older callers that only expose phase.
+    const canAbort = sessionCanAbort || sessionPhase !== 'idle';
+    const supportsSteer = sessionSupportsSteerDelivery(currentSessionId);
 
     const getCurrentInputSnapshot = React.useCallback(() => {
         const currentMessage = textareaRef.current?.value ?? message;
@@ -1965,9 +1969,18 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
     }, []);
 
     const handleQueuedMessageSend = React.useCallback((messageId: string) => {
-        // Force-sending from the queue during a busy session counts as steer
-        void handleSubmitRef.current({ queuedOnly: true, queuedMessageId: messageId, delivery: 'steer' });
-    }, []);
+        // Force-sending from the queue during a busy OpenCode session steers
+        // into the turn. Claude rejects concurrent prompts — leave the item
+        // queued for idle auto-send (reorder still works via chips).
+        if (!supportsSteer && sessionPhase !== 'idle') {
+            return;
+        }
+        void handleSubmitRef.current({
+            queuedOnly: true,
+            queuedMessageId: messageId,
+            delivery: supportsSteer ? 'steer' : undefined,
+        });
+    }, [sessionPhase, supportsSteer]);
 
     const handleOpenAgentPanel = React.useCallback(() => {
         setMobileControlsPanel('agent');
@@ -1988,7 +2001,9 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
     const handleSubmit = async (options?: SubmitOptions) => {
         const queuedOnly = options?.queuedOnly ?? false;
         const queuedMessageId = options?.queuedMessageId;
-        const delivery = options?.delivery === 'steer' && sessionPhase !== 'idle' ? 'steer' : undefined;
+        const wantsSteer = options?.delivery === 'steer' && sessionPhase !== 'idle';
+        // Claude has no steer path — concurrent prompts 409 TURN_IN_PROGRESS.
+        const delivery = wantsSteer && supportsSteer ? 'steer' : undefined;
         const inputSnapshot = options?.presetText != null
             ? {
                 message: options.presetText,
@@ -2005,6 +2020,10 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
         if (queuedOnly) {
             if (queuedMessagesToSend.length === 0 || !currentSessionId) return;
+            // Claude cannot accept a second prompt while busy; keep queued.
+            if (!supportsSteer && sessionPhase !== 'idle') {
+                return;
+            }
         } else if ((!inputSnapshot.hasContent && !hasQueuedMessages) || (!currentSessionId && !newSessionDraftOpen)) {
             return;
         }
@@ -2017,6 +2036,19 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
         if (!providerIdToSend || !modelIdToSend) {
             console.warn('Cannot send message: provider or model not selected');
+            return;
+        }
+
+        // Claude has no steer path — while a turn is active, enqueue so the
+        // OpenChamber queue (reorder + idle auto-send) owns follow-ups.
+        if (
+            currentSessionId
+            && !queuedOnly
+            && inputSnapshot.hasContent
+            && (sessionPhase !== 'idle' || autoReviewRunning)
+            && !supportsSteer
+        ) {
+            handleQueueMessage();
             return;
         }
 
@@ -2582,6 +2614,23 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             }
 
             if (error instanceof HarnessClientError) {
+                // Concurrent Claude prompt — restore into the OpenChamber queue
+                // instead of surfacing TURN_IN_PROGRESS as a hard send failure.
+                if (error.code === 'TURN_IN_PROGRESS' && currentSessionId && messageQueueTarget) {
+                    if (primaryText.trim() || allAttachments.length > 0) {
+                        addToQueue(messageQueueTarget, {
+                            content: primaryText,
+                            attachments: allAttachments.length > 0 ? allAttachments : undefined,
+                            sendConfig: providerIdToSend && modelIdToSend ? {
+                                providerID: providerIdToSend,
+                                modelID: modelIdToSend,
+                                agent: agentNameToSend ?? undefined,
+                                variant: variantToSend ?? undefined,
+                            } : undefined,
+                        });
+                    }
+                    return;
+                }
                 const harnessMessage = error.code === 'CLAUDE_NOT_READY'
                     || error.code === 'CLAUDE_MISSING_CLI'
                     || error.code === 'CLAUDE_NEEDS_LOGIN'
@@ -2632,14 +2681,15 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
     const handlePrimaryAction = React.useCallback(() => {
         const inputSnapshot = getCurrentInputSnapshot();
         const canQueue = inputMode === 'normal' && inputSnapshot.hasContent && currentSessionId && (sessionPhase !== 'idle' || autoReviewRunning);
-        if (followUpBehavior === 'queue' && canQueue) {
+        // Claude never steers; always queue while busy.
+        if (canQueue && (!supportsSteer || followUpBehavior === 'queue')) {
             handleQueueMessage();
-        } else if (followUpBehavior === 'steer' && canQueue) {
+        } else if (followUpBehavior === 'steer' && canQueue && supportsSteer) {
             void handleSubmitRef.current({ delivery: 'steer' });
         } else {
             void handleSubmitRef.current();
         }
-    }, [inputMode, getCurrentInputSnapshot, currentSessionId, sessionPhase, autoReviewRunning, followUpBehavior, handleQueueMessage]);
+    }, [inputMode, getCurrentInputSnapshot, currentSessionId, sessionPhase, autoReviewRunning, followUpBehavior, handleQueueMessage, supportsSteer]);
 
     // Draft welcome presets: submit immediately.
     const submitPresetPrompt = React.useCallback((text: string) => {
@@ -2908,10 +2958,10 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             const isCtrlEnter = e.ctrlKey || e.metaKey;
 
             // Queueing / steering only works when there's an existing busy
-            // session (or an active auto-review run).
+            // session (or an active auto-review run). Claude always queues.
             const canQueue = inputMode === 'normal' && hasContent && currentSessionId && (sessionPhase !== 'idle' || autoReviewRunning);
 
-            if (followUpBehavior === 'queue') {
+            if (!supportsSteer || followUpBehavior === 'queue') {
                 if (isCtrlEnter || !canQueue) {
                     handleSubmit();
                 } else {

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -45,7 +45,7 @@ export const useKeyboardShortcuts = () => {
   const currentDirectory = useDirectoryStore((s) => s.currentDirectory);
   const activeProject = useProjectsStore((s) => s.getActiveProject());
   const { themeMode, setThemeMode } = useThemeSystem();
-  const { phase: sessionPhase } = useCurrentSessionActivity();
+  const { phase: sessionPhase, canAbort: sessionCanAbort } = useCurrentSessionActivity();
   const abortPrimedUntilRef = React.useRef<number | null>(null);
   const abortPrimedTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const themeModeRef = React.useRef(themeMode);
@@ -586,7 +586,7 @@ export const useKeyboardShortcuts = () => {
 
         // Double-ESC abort logic - only when on chat tab with no overlays
         const sessionId = currentSessionId;
-        const canAbortNow = sessionPhase !== 'idle' && Boolean(sessionId);
+        const canAbortNow = (sessionCanAbort || sessionPhase !== 'idle') && Boolean(sessionId);
         if (!canAbortNow) {
           resetAbortPriming();
           return;
@@ -649,6 +649,7 @@ export const useKeyboardShortcuts = () => {
     toggleExpandedInput,
     setThemeMode,
     sessionPhase,
+    sessionCanAbort,
     armAbortPrompt,
     resetAbortPriming,
     currentSessionId,

--- a/packages/ui/src/hooks/useSessionActivity.ts
+++ b/packages/ui/src/hooks/useSessionActivity.ts
@@ -10,6 +10,12 @@ export interface SessionActivityResult {
   isWorking: boolean;
   isBusy: boolean;
   isCooldown: boolean;
+  /**
+   * Whether Stop should be available. Unlike `phase`, this stays true while a
+   * turn is busy even if a permission/question card is open (so abort remains
+   * reachable for Claude harness turns bridged through canUseTool).
+   */
+  canAbort: boolean;
 }
 
 const IDLE_RESULT: SessionActivityResult = {
@@ -17,6 +23,7 @@ const IDLE_RESULT: SessionActivityResult = {
   isWorking: false,
   isBusy: false,
   isCooldown: false,
+  canAbort: false,
 };
 
 /**
@@ -36,10 +43,6 @@ function useSessionActivity(sessionId: string | null | undefined, directory?: st
   return React.useMemo<SessionActivityResult>(() => {
     if (!sessionId) return IDLE_RESULT;
 
-    // Permissions or questions pending → idle (the blocking indicator takes
-    // priority and the send button must remain a send, not a stop).
-    if (permissions.length > 0 || questions.length > 0) return IDLE_RESULT;
-
     const phase: SessionActivityPhase = (status?.type ?? 'idle') as SessionActivityPhase;
 
     // Only trust the trailing assistant message as a transient fallback while
@@ -53,6 +56,18 @@ function useSessionActivity(sessionId: string | null | undefined, directory?: st
 
     const hasAuthoritativeStatus = status !== undefined;
     const statusWorking = hasAuthoritativeStatus && phase !== 'idle';
+    const canAbort = statusWorking || (!hasAuthoritativeStatus && hasPendingAssistant);
+
+    // Permissions or questions pending → idle for send UX (the blocking
+    // indicator takes priority and the send button must remain a send), but
+    // keep canAbort when the turn is still authoritatively busy.
+    if (permissions.length > 0 || questions.length > 0) {
+      return {
+        ...IDLE_RESULT,
+        canAbort,
+      };
+    }
+
     const isWorking = statusWorking || hasPendingAssistant;
 
     if (hasAuthoritativeStatus && !statusWorking) return IDLE_RESULT;
@@ -64,6 +79,7 @@ function useSessionActivity(sessionId: string | null | undefined, directory?: st
       isWorking: true,
       isBusy: phase === 'busy' || (!statusWorking && hasPendingAssistant),
       isCooldown: false,
+      canAbort: true,
     };
   }, [sessionId, status, messages, permissions, questions]);
 }

--- a/packages/ui/src/lib/harness/capabilities.test.ts
+++ b/packages/ui/src/lib/harness/capabilities.test.ts
@@ -3,9 +3,11 @@ import type { EngineCatalog, HarnessId } from '@/types/harness';
 import { useSelectionStore } from '@/sync/selection-store';
 import { useHarnessStore } from '@/stores/useHarnessStore';
 import {
+  engineSupportsSteerDelivery,
   getHarnessCapabilityLevel,
   resolveSessionHarnessId,
   sessionSupports,
+  sessionSupportsSteerDelivery,
   STATIC_HARNESS_CAPABILITIES,
 } from './capabilities';
 
@@ -71,6 +73,18 @@ describe('sessionSupports', () => {
     });
     expect(sessionSupports(null, 'goal')).toBe(true);
     expect(sessionSupports(null, 'multirun')).toBe(false);
+  });
+
+  test('Claude sessions do not support steer delivery', () => {
+    expect(engineSupportsSteerDelivery('opencode')).toBe(true);
+    expect(engineSupportsSteerDelivery('claude-code')).toBe(false);
+    useSelectionStore.getState().saveSessionTarget('ses_claude', {
+      harnessId: 'claude-code',
+      modelRef: 'sonnet',
+    });
+    expect(sessionSupportsSteerDelivery('ses_claude')).toBe(false);
+    useSelectionStore.setState({ lastUsedTarget: null });
+    expect(sessionSupportsSteerDelivery('ses_unknown')).toBe(true);
   });
 
   test('prefers catalog capability levels when present', () => {

--- a/packages/ui/src/lib/harness/capabilities.ts
+++ b/packages/ui/src/lib/harness/capabilities.ts
@@ -85,3 +85,16 @@ export function sessionSupports(
   const harnessId = resolveSessionHarnessId(sessionId);
   return getHarnessCapabilityLevel(harnessId, capability) !== 'none';
 }
+
+/**
+ * OpenCode can inject follow-ups into an active turn (`delivery: 'steer'`).
+ * Claude Code rejects concurrent prompts with TURN_IN_PROGRESS — follow-ups
+ * must use the OpenChamber message queue and wait for idle auto-send.
+ */
+export function engineSupportsSteerDelivery(harnessId: HarnessId): boolean {
+  return harnessId === 'opencode';
+}
+
+export function sessionSupportsSteerDelivery(sessionId: string | null | undefined): boolean {
+  return engineSupportsSteerDelivery(resolveSessionHarnessId(sessionId));
+}

--- a/packages/ui/src/lib/harness/client.ts
+++ b/packages/ui/src/lib/harness/client.ts
@@ -42,6 +42,8 @@ export type HarnessAbortResult = {
   ok: boolean;
   sessionId?: string;
   status?: string;
+  aborted?: boolean;
+  reason?: string;
 };
 
 export type HarnessPermissionReply = 'once' | 'always' | 'reject';
@@ -220,6 +222,8 @@ export async function harnessAbort(params: HarnessAbortParams): Promise<HarnessA
     ok: payload.ok !== false,
     ...(typeof payload.sessionId === 'string' ? { sessionId: payload.sessionId } : { sessionId: params.sessionId }),
     ...(typeof payload.status === 'string' ? { status: payload.status } : {}),
+    ...(typeof payload.aborted === 'boolean' ? { aborted: payload.aborted } : {}),
+    ...(typeof payload.reason === 'string' ? { reason: payload.reason } : {}),
   };
 }
 

--- a/packages/ui/src/lib/harness/session-handoff.test.js
+++ b/packages/ui/src/lib/harness/session-handoff.test.js
@@ -120,8 +120,21 @@ describe('createEngineHandoffSession', () => {
     });
 
     expect(createSession).toHaveBeenCalledTimes(1);
+    expect(createSession).toHaveBeenCalledWith(undefined, '/repo');
     expect(result.sessionId).toBe('ses_new');
     expect(result.directory).toBe('/repo');
     expect(result.sessionId).not.toBe('ses_source');
+  });
+
+  test('passes source title through to createSession', async () => {
+    const createSession = mock(async () => ({ id: 'ses_named', directory: '/repo' }));
+    await createEngineHandoffSession({
+      sourceSessionId: 'ses_source',
+      directory: '/repo',
+      title: 'Fix auth flow',
+      sourceHarnessId: 'claude-code',
+      createSession,
+    });
+    expect(createSession).toHaveBeenCalledWith('Fix auth flow', '/repo');
   });
 });

--- a/packages/ui/src/lib/harness/session-handoff.ts
+++ b/packages/ui/src/lib/harness/session-handoff.ts
@@ -100,6 +100,7 @@ function buildHandoffSeedText(
   sessionId: string,
   directory?: string | null,
   budget: number = HANDOFF_SEED_CHAR_BUDGET,
+  sourceHarnessId: HarnessId = 'opencode',
 ): HandoffSeedResult {
   const messages = getSyncMessages(sessionId, directory ?? undefined);
   const turns: string[] = [];
@@ -139,8 +140,9 @@ function buildHandoffSeedText(
     ? `Prior conversation truncated for handoff; ${omittedTurns} earlier turns omitted.\n\n`
     : '';
 
+  const sourceLabel = sourceHarnessId === 'claude-code' ? 'Claude Code' : 'OpenCode';
   const text = [
-    'Prior conversation context from an OpenCode session (handoff). This is background only; respond to the user message that follows.',
+    `Prior conversation context from a ${sourceLabel} session (handoff). This is background only; respond to the user message that follows.`,
     '',
     truncationNote + turns.join('\n\n'),
   ].join('\n');
@@ -181,13 +183,20 @@ export type CreatedHandoffSession = {
 export async function createEngineHandoffSession(args: {
   sourceSessionId: string;
   directory?: string | null;
+  sourceHarnessId?: HarnessId;
+  title?: string;
   createSession: (
     title?: string,
     directoryOverride?: string | null,
   ) => Promise<{ id: string; directory?: string | null } | null>;
 }): Promise<CreatedHandoffSession> {
-  const seed = buildHandoffSeedText(args.sourceSessionId, args.directory);
-  const created = await args.createSession(undefined, args.directory ?? null);
+  const seed = buildHandoffSeedText(
+    args.sourceSessionId,
+    args.directory,
+    HANDOFF_SEED_CHAR_BUDGET,
+    args.sourceHarnessId ?? 'opencode',
+  );
+  const created = await args.createSession(args.title, args.directory ?? null);
   if (!created?.id) {
     throw new Error('Failed to create handoff session');
   }

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -1365,4 +1365,24 @@ describe("abortCurrentOperation", () => {
       directory: "/test/project",
     })
   })
+
+  test("tries harness abort when local target is missing, then OpenCode", async () => {
+    const store = createStore({}, { session: [{ id: "session-a", time: { created: 1 } } as Session] })
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { abortCurrentOperation, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    await abortCurrentOperation("session-a")
+
+    expect(harnessAbortCalls).toEqual([
+      { sessionId: "session-a", directory: "/test/project" },
+    ])
+    const abortCalls = replyCalls.filter((call) => call.method === "session.abort")
+    expect(abortCalls).toHaveLength(1)
+    expect(abortCalls[0].params).toEqual({
+      sessionID: "session-a",
+      directory: "/test/project",
+    })
+  })
 })

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -1066,6 +1066,19 @@ export async function abortCurrentOperation(sessionId: string): Promise<void> {
       })
       return
     }
+
+    // Sticky Claude bindings can outlive local selection (reload / overwrite).
+    // When the local target is missing or unknown, try harness abort first.
+    if (!target || target.harnessId !== "opencode") {
+      const harnessResult = await harnessAbort({
+        sessionId,
+        ...(directory ? { directory } : {}),
+      }).catch(() => null)
+      if (harnessResult?.aborted) {
+        return
+      }
+    }
+
     await sdk().session.abort({ sessionID: sessionId, directory })
   } catch (error) {
     console.error("[session-actions] abort failed", error)

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -176,9 +176,16 @@ export function routeMessage(params: {
     const seedParts = (params.additionalParts ?? [])
       .filter((part) => part.synthetic && typeof part.text === "string" && part.text.trim().length > 0)
       .map((part) => part.text.trim())
-    const harnessText = seedParts.length > 0
-      ? `${seedParts.join("\n\n")}\n\n${params.content}`
-      : params.content
+    // Queued follow-ups arrive as non-synthetic additionalParts. Claude has no
+    // multi-prompt steer, so fold them into one harness turn text (same order
+    // as OpenCode additional parts) rather than dropping them.
+    const queuedParts = (params.additionalParts ?? [])
+      .filter((part) => !part.synthetic && typeof part.text === "string" && part.text.trim().length > 0)
+      .map((part) => part.text.trim())
+    const harnessSections = [...seedParts, params.content, ...queuedParts]
+      .map((text) => text.trim())
+      .filter((text) => text.length > 0)
+    const harnessText = harnessSections.join("\n\n")
 
     // Normal prompt — optimistic insert; transport is /api/harness/prompt (not OpenCode SDK).
     return optimisticSend({
@@ -1252,10 +1259,24 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       && pendingHandoff.harnessId !== sourceHarnessId
     ) {
       const sourceSessionId = targetSessionId
+      const sourceSession = getDirectoryState(currentSessionDirectory ?? undefined)?.session?.find(
+        (session) => session.id === sourceSessionId,
+      )
+      const globalSource = useGlobalSessionsStore.getState().activeSessions.find(
+        (session) => session.id === sourceSessionId,
+      ) ?? useGlobalSessionsStore.getState().archivedSessions.find(
+        (session) => session.id === sourceSessionId,
+      )
+      const handoffTitleCandidate = sourceSession?.title ?? globalSource?.title
+      const handoffTitle = typeof handoffTitleCandidate === "string" && handoffTitleCandidate.trim()
+        ? handoffTitleCandidate.trim()
+        : undefined
       const handoff = await createEngineHandoffSession({
         sourceSessionId,
         directory: currentSessionDirectory,
+        sourceHarnessId,
         createSession: (title, directoryOverride) => get().createSession(title, directoryOverride),
+        title: handoffTitle,
       })
 
       clearPendingHandoffTarget(sourceSessionId)
@@ -1281,6 +1302,9 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
           variant,
         )
       }
+
+      // Continue in the same window: switch UI to the destination session.
+      get().setCurrentSession(handoff.sessionId, createdDirectory)
 
       notifyMessageSent(handoff.sessionId)
       markPendingUserSendAnimation(handoff.sessionId)

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -73,6 +73,7 @@ import { createBootstrapRuntime } from './lib/opencode/bootstrap-runtime.js';
 import { createSessionRuntime } from './lib/opencode/session-runtime.js';
 import { createOpenCodeWatcherRuntime } from './lib/opencode/watcher.js';
 import { createSessionAssistRuntime } from './lib/session-assist/runtime.js';
+import { createSessionTitleRuntime } from './lib/session-title/runtime.js';
 import { createSessionGoalRuntime } from './lib/session-goal/runtime.js';
 import { createContextObligatoryRuntime } from './lib/context-obligatory/runtime.js';
 import { createScheduledTasksRuntime } from './lib/scheduled-tasks/runtime.js';
@@ -740,6 +741,14 @@ const sessionAssistRuntime = createSessionAssistRuntime({
   getSmallModelService: async () => import('./lib/small-model/index.js'),
 });
 
+const sessionTitleRuntime = createSessionTitleRuntime({
+  buildOpenCodeUrl,
+  getOpenCodeAuthHeaders,
+  getSmallModelService: async () => import('./lib/small-model/index.js'),
+  getHarnessRecentMessages,
+  getSessionBinding: (sessionId) => getSessionBinding(sessionId),
+});
+
 const sessionGoalRuntime = createSessionGoalRuntime({
   buildOpenCodeUrl,
   getOpenCodeAuthHeaders,
@@ -810,9 +819,10 @@ notificationTriggerRuntime.setGetIsSessionAutoAccepting(
   (sessionId, directory) => permissionAutoAcceptRuntime.isSessionAutoAccepting(sessionId, directory),
 );
 
-// Harness events are not on the OpenCode global hub — fan them into Goal and
-// permission auto-accept so backend loops work without a connected UI.
+// Harness events are not on the OpenCode global hub — fan them into title,
+// Goal, and permission auto-accept so backend loops work without a connected UI.
 addHarnessEventObserver((payload, directory) => {
+  sessionTitleRuntime.processHarnessPayload(payload, directory);
   sessionGoalRuntime.processPayload(payload, directory);
   permissionAutoAcceptRuntime.processHarnessPayload(payload, directory);
 });
@@ -1210,6 +1220,7 @@ const gracefulShutdownRuntime = createGracefulShutdownRuntime({
   syncToHmrState,
   openCodeWatcherRuntime,
   sessionAssistRuntime,
+  sessionTitleRuntime,
   sessionGoalRuntime,
   contextObligatoryRuntime,
   sessionRuntime,

--- a/packages/web/server/lib/harness/DOCUMENTATION.md
+++ b/packages/web/server/lib/harness/DOCUMENTATION.md
@@ -206,6 +206,22 @@ Capability `goal: partial`. Session-goal listens to harness events through
 turns). Continuations call `harnessRouter.prompt` / `/api/harness/prompt`.
 Token budget accounting is best-effort until Claude usage tokens are mapped.
 
+## Follow-ups while busy
+
+Claude rejects a second `prompt` for the same session with HTTP `409`
+`TURN_IN_PROGRESS` (no second Claude process). The UI must not steer into an
+active Claude turn. Follow-ups use the OpenChamber message queue (reorder +
+idle auto-send). Abort interrupts the active turn and always clears busy via
+`session.status: idle`.
+
+## Session titles on Claude
+
+Claude prompts bypass OpenCode `session.promptAsync`, so upstream
+`ensureTitle` never runs. `session-title/runtime.js` listens to harness idle
+events, generates a title once via the small-model helper from harness turn
+text, and PATCHes the OpenCode shell session. Manual rename still uses
+`session.update`.
+
 ## Claude auth-env policy
 
 `translators/claude-code/auth-env.js` builds child env from `process.env` and

--- a/packages/web/server/lib/harness/registry.js
+++ b/packages/web/server/lib/harness/registry.js
@@ -86,10 +86,11 @@ const CLAUDE_MODEL_MODALITIES = Object.freeze({
  *   id: string,
  *   name: string,
  *   limit: Readonly<{ context: number, output: number }>,
+ *   resolvedId?: string,
  * }} entry
  */
 function buildClaudeModel(entry) {
-  return Object.freeze({
+  const model = {
     id: entry.id,
     name: entry.name,
     supportsImages: true,
@@ -98,23 +99,56 @@ function buildClaudeModel(entry) {
     toolCall: true,
     limit: entry.limit,
     modalities: CLAUDE_MODEL_MODALITIES,
-  });
+  };
+  if (entry.resolvedId) model.resolvedId = entry.resolvedId;
+  return Object.freeze(model);
 }
 
 /**
- * Static Claude Code model catalog for v1 (no provider nesting).
- * Alias rows use current Anthropic API resolutions; pinned full IDs keep older
- * versions selectable (e.g. Opus 4.8) after aliases move forward.
+ * Claude Code model source rows for v1 (no provider nesting). Alias rows use
+ * current Anthropic API resolutions; pinned full IDs keep older versions
+ * selectable after aliases move forward.
  */
-export const CLAUDE_CODE_MODELS = Object.freeze([
+const CLAUDE_CODE_ALIAS_MODELS = Object.freeze([
   buildClaudeModel({ id: 'fable', name: 'Fable 5', limit: CLAUDE_MODEL_LIMIT_1M }),
   buildClaudeModel({ id: 'opus', name: 'Opus 5', limit: CLAUDE_MODEL_LIMIT_1M }),
   buildClaudeModel({ id: 'sonnet', name: 'Sonnet 5', limit: CLAUDE_MODEL_LIMIT_1M }),
-  buildClaudeModel({ id: 'haiku', name: 'Haiku 4.5', limit: CLAUDE_MODEL_LIMIT_200K }),
+  buildClaudeModel({
+    id: 'haiku',
+    name: 'Haiku 4.5',
+    resolvedId: 'claude-haiku-4-5',
+    limit: CLAUDE_MODEL_LIMIT_200K,
+  }),
+]);
+
+const CLAUDE_CODE_PINNED_MODELS = Object.freeze([
   buildClaudeModel({ id: 'claude-opus-4-8', name: 'Opus 4.8', limit: CLAUDE_MODEL_LIMIT_1M }),
   buildClaudeModel({ id: 'claude-sonnet-4-6', name: 'Sonnet 4.6', limit: CLAUDE_MODEL_LIMIT_1M }),
   buildClaudeModel({ id: 'claude-haiku-4-5', name: 'Haiku 4.5', limit: CLAUDE_MODEL_LIMIT_200K }),
 ]);
+
+/**
+ * @returns {ReadonlyArray<ReturnType<typeof buildClaudeModel>>}
+ */
+function buildClaudeCodeModels() {
+  const aliasResolvedIds = new Set(
+    CLAUDE_CODE_ALIAS_MODELS
+      .map((model) => model.resolvedId)
+      .filter((id) => typeof id === 'string' && id.length > 0),
+  );
+  const aliasNames = new Set(CLAUDE_CODE_ALIAS_MODELS.map((model) => model.name));
+  const visiblePins = CLAUDE_CODE_PINNED_MODELS.filter((model) => (
+    !aliasResolvedIds.has(model.id) && !aliasNames.has(model.name)
+  ));
+
+  return Object.freeze([
+    ...CLAUDE_CODE_ALIAS_MODELS,
+    ...visiblePins,
+  ]);
+}
+
+/** Visible Claude Code model catalog for picker/API responses. */
+export const CLAUDE_CODE_MODELS = buildClaudeCodeModels();
 
 /** Named Claude Agent SDK effort levels accepted on ExecutionTarget. */
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);

--- a/packages/web/server/lib/harness/registry.test.js
+++ b/packages/web/server/lib/harness/registry.test.js
@@ -28,11 +28,16 @@ describe('harness registry', () => {
     expect(claude.capabilities['openchamber-tool']).toBe('none');
     expect(CLAUDE_CODE_MODELS.length).toBeGreaterThan(0);
     const byId = Object.fromEntries(CLAUDE_CODE_MODELS.map((model) => [model.id, model]));
+    const displayNames = CLAUDE_CODE_MODELS.map((model) => model.name);
     expect(byId.fable?.name).toBe('Fable 5');
     expect(byId.opus?.name).toBe('Opus 5');
     expect(byId.sonnet?.name).toBe('Sonnet 5');
     expect(byId.haiku?.name).toBe('Haiku 4.5');
+    expect(byId.haiku?.resolvedId).toBe('claude-haiku-4-5');
     expect(byId['claude-opus-4-8']?.name).toBe('Opus 4.8');
+    expect(byId['claude-sonnet-4-6']?.name).toBe('Sonnet 4.6');
+    expect(byId['claude-haiku-4-5']).toBeUndefined();
+    expect(new Set(displayNames).size).toBe(displayNames.length);
     expect(byId.fable?.limit?.context).toBe(1_000_000);
     expect(byId.sonnet?.limit?.context).toBe(1_000_000);
     expect(byId.haiku?.limit?.context).toBe(200_000);

--- a/packages/web/server/lib/harness/translators/claude-code/index.js
+++ b/packages/web/server/lib/harness/translators/claude-code/index.js
@@ -26,6 +26,40 @@ import {
 import { getHarnessCapabilities } from '../../registry.js';
 import { detectClaudeCode } from '../../detect.js';
 
+const ABORT_INTERRUPT_TIMEOUT_MS = 2_000;
+
+/**
+ * @param {object} event
+ * @param {string} sessionId
+ * @returns {boolean}
+ */
+function isIdleStatusEvent(event, sessionId) {
+  return event?.type === 'session.status'
+    && event.properties?.sessionID === sessionId
+    && event.properties?.status?.type === 'idle';
+}
+
+/**
+ * @param {object} handle
+ * @param {number} timeoutMs
+ */
+async function interruptWithTimeout(handle, timeoutMs = ABORT_INTERRUPT_TIMEOUT_MS) {
+  if (typeof handle?.interrupt !== 'function') return;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timer;
+  try {
+    await Promise.race([
+      Promise.resolve().then(() => handle.interrupt()),
+      new Promise((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+        if (typeof timer.unref === 'function') timer.unref();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /**
  * Build SDK prompt: string when text-only; AsyncIterable when attachments present.
  * @param {string} text
@@ -63,7 +97,7 @@ export function buildClaudePrompt(text, files, options = {}) {
  * @param {typeof detectClaudeCode} [deps.detect]
  */
 export function createClaudeCodeTranslator(deps = {}) {
-  /** @type {Map<string, { handle: object, aborting: boolean }>} */
+  /** @type {Map<string, { handle: object, aborting: boolean, idleEmitted: boolean }>} */
   const activeTurns = new Map();
   const getBroadcast = deps.getBroadcast || (() => null);
   const startQuery = deps.startQuery || startClaudeQuery;
@@ -201,7 +235,22 @@ export function createClaudeCodeTranslator(deps = {}) {
       throw wrapped;
     }
 
-    activeTurns.set(sessionId, { handle, aborting: false });
+    const activeTurn = { handle, aborting: false, idleEmitted: false };
+    activeTurns.set(sessionId, activeTurn);
+    const emitEvents = (events) => {
+      if (events.some((event) => isIdleStatusEvent(event, sessionId))) {
+        activeTurn.idleEmitted = true;
+      }
+      emitHarnessEvents(getBroadcast(), directory, events);
+    };
+    const emitIdleOnce = () => {
+      if (activeTurn.idleEmitted) return;
+      activeTurn.idleEmitted = true;
+      emitHarnessEvents(getBroadcast(), directory, [{
+        type: 'session.status',
+        properties: { sessionID: sessionId, status: { type: 'idle' } },
+      }]);
+    };
 
     // Stream in background; HTTP returns accepted immediately.
     void (async () => {
@@ -211,10 +260,14 @@ export function createClaudeCodeTranslator(deps = {}) {
           if (foreignSessionId) {
             setForeignSessionId(sessionId, foreignSessionId);
           }
-          emitHarnessEvents(getBroadcast(), directory, events);
+          emitEvents(events);
         }
         updateSessionBinding(sessionId, { lastError: undefined });
       } catch (error) {
+        const active = activeTurns.get(sessionId);
+        if (active?.aborting || activeTurn.aborting) {
+          return;
+        }
         const rawMessage = error instanceof Error ? error.message : 'Claude Code turn failed';
         const rawCode = error && typeof error === 'object' && 'code' in error
           ? String(error.code)
@@ -227,7 +280,7 @@ export function createClaudeCodeTranslator(deps = {}) {
           code: isEnotdir ? 'CLAUDE_SPAWN_ENOTDIR' : 'CLAUDE_TURN_ERROR',
           message,
         });
-        emitHarnessEvents(getBroadcast(), directory, [
+        emitEvents([
           {
             type: 'session.status',
             properties: { sessionID: sessionId, status: { type: 'idle' } },
@@ -238,7 +291,12 @@ export function createClaudeCodeTranslator(deps = {}) {
           },
         ]);
       } finally {
-        rejectPendingForSession(sessionId);
+        try {
+          rejectPendingForSession(sessionId);
+        } catch {
+          // cleanup must still close the turn and clear busy status
+        }
+        emitIdleOnce();
         try {
           handle.close();
         } catch {
@@ -278,18 +336,24 @@ export function createClaudeCodeTranslator(deps = {}) {
     }
 
     active.aborting = true;
-    rejectPendingForSession(sessionId);
+    active.idleEmitted = true;
     try {
-      await active.handle.interrupt();
+      rejectPendingForSession(sessionId);
     } catch {
-      // ignore
+      // abort cleanup must still close and remove the active turn
     }
     try {
-      active.handle.close();
+      await interruptWithTimeout(active.handle);
     } catch {
       // ignore
+    } finally {
+      try {
+        active.handle.close();
+      } catch {
+        // ignore
+      }
+      activeTurns.delete(sessionId);
     }
-    activeTurns.delete(sessionId);
 
     if (binding?.directory) {
       // Emit MessageAbortedError so session-goal pauses immediately (same

--- a/packages/web/server/lib/harness/translators/claude-code/index.test.js
+++ b/packages/web/server/lib/harness/translators/claude-code/index.test.js
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createClaudeCodeTranslator } from './index.js';
+import {
+  configureSessionBindings,
+  getSessionBinding,
+  resetSessionBindings,
+} from '../../session-bindings.js';
+import { resetHarnessTurnSnapshots } from '../../turn-snapshot.js';
+
+function createControlledStream() {
+  const queue = [];
+  let done = false;
+  let failure;
+  let waiter;
+
+  const settle = () => {
+    if (!waiter) return;
+    const current = waiter;
+    waiter = undefined;
+    if (queue.length > 0) {
+      current.resolve({ done: false, value: queue.shift() });
+      return;
+    }
+    if (failure) {
+      current.reject(failure);
+      return;
+    }
+    if (done) {
+      current.resolve({ done: true, value: undefined });
+    } else {
+      waiter = current;
+    }
+  };
+
+  return {
+    stream: {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next() {
+        if (queue.length > 0) {
+          return Promise.resolve({ done: false, value: queue.shift() });
+        }
+        if (failure) {
+          return Promise.reject(failure);
+        }
+        if (done) {
+          return Promise.resolve({ done: true, value: undefined });
+        }
+        return new Promise((resolve, reject) => {
+          waiter = { resolve, reject };
+        });
+      },
+      return() {
+        done = true;
+        settle();
+        return Promise.resolve({ done: true, value: undefined });
+      },
+    },
+    push(value) {
+      queue.push(value);
+      settle();
+    },
+    end() {
+      done = true;
+      settle();
+    },
+    fail(error) {
+      failure = error;
+      settle();
+    },
+  };
+}
+
+function createHarness(handle) {
+  const events = [];
+  const startQuery = mock(async () => handle);
+  const translator = createClaudeCodeTranslator({
+    detect: mock(async () => ({ status: 'ready' })),
+    startQuery,
+    getBroadcast: () => (payload) => events.push(payload),
+  });
+  return { events, startQuery, translator };
+}
+
+function createHandle(controller, options = {}) {
+  return {
+    stream: controller.stream,
+    interrupt: mock(options.interrupt || (async () => {})),
+    close: mock(options.close || (() => controller.end())),
+  };
+}
+
+function basePrompt(sessionId = 'ses_test') {
+  return {
+    sessionId,
+    directory: '/project',
+    text: 'hello',
+    target: { harnessId: 'claude-code', modelRef: 'sonnet' },
+    messageId: `msg_user_${sessionId}`,
+    assistantMessageId: `msg_assistant_${sessionId}`,
+  };
+}
+
+function eventTypes(events) {
+  return events.map((event) => event.type);
+}
+
+function idleEvents(events, sessionId) {
+  return events.filter((event) => (
+    event.type === 'session.status'
+    && event.properties?.sessionID === sessionId
+    && event.properties?.status?.type === 'idle'
+  ));
+}
+
+async function waitFor(condition) {
+  const deadline = Date.now() + 250;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  expect(condition()).toBe(true);
+}
+
+beforeEach(() => {
+  configureSessionBindings({ persist: false, load: true });
+  resetSessionBindings();
+  resetHarnessTurnSnapshots();
+});
+
+afterEach(() => {
+  resetSessionBindings();
+  resetHarnessTurnSnapshots();
+});
+
+describe('createClaudeCodeTranslator', () => {
+  it('rejects a second prompt while a turn is active', async () => {
+    const controller = createControlledStream();
+    const handle = createHandle(controller);
+    const { startQuery, translator } = createHarness(handle);
+
+    await translator.prompt(basePrompt('ses_active'));
+
+    await expect(translator.prompt(basePrompt('ses_active'))).rejects.toMatchObject({
+      code: 'TURN_IN_PROGRESS',
+      statusCode: 409,
+    });
+    expect(startQuery).toHaveBeenCalledTimes(1);
+
+    controller.end();
+    await waitFor(() => !translator._activeTurns.has('ses_active'));
+  });
+
+  it('abort during an active turn emits idle and MessageAbortedError', async () => {
+    const controller = createControlledStream();
+    const handle = createHandle(controller);
+    const { events, translator } = createHarness(handle);
+
+    await translator.prompt(basePrompt('ses_abort'));
+    await expect(translator.abort({ sessionId: 'ses_abort' })).resolves.toMatchObject({
+      ok: true,
+      aborted: true,
+    });
+
+    expect(handle.interrupt).toHaveBeenCalledTimes(1);
+    expect(handle.close).toHaveBeenCalled();
+    expect(translator._activeTurns.has('ses_abort')).toBe(false);
+    expect(idleEvents(events, 'ses_abort')).toHaveLength(1);
+    expect(events.some((event) => (
+      event.type === 'message.updated'
+      && event.properties?.info?.error?.name === 'MessageAbortedError'
+    ))).toBe(true);
+  });
+
+  it('does not emit session.error when an aborting stream fails', async () => {
+    const controller = createControlledStream();
+    const handle = createHandle(controller, {
+      close: () => controller.fail(new Error('stream closed during abort')),
+    });
+    const { events, translator } = createHarness(handle);
+
+    await translator.prompt(basePrompt('ses_abort_error'));
+    await translator.abort({ sessionId: 'ses_abort_error' });
+    await waitFor(() => handle.close.mock.calls.length >= 2);
+
+    expect(eventTypes(events)).not.toContain('session.error');
+    expect(getSessionBinding('ses_abort_error')?.lastError).toBeUndefined();
+    expect(events.some((event) => (
+      event.type === 'message.updated'
+      && event.properties?.info?.error?.name === 'MessageAbortedError'
+    ))).toBe(true);
+  });
+
+  it('emits idle from finally when the stream ends without a result', async () => {
+    const controller = createControlledStream();
+    const handle = createHandle(controller);
+    const { events, translator } = createHarness(handle);
+
+    await translator.prompt(basePrompt('ses_no_result'));
+    controller.end();
+    await waitFor(() => !translator._activeTurns.has('ses_no_result'));
+
+    expect(idleEvents(events, 'ses_no_result')).toHaveLength(1);
+    expect(eventTypes(events)).not.toContain('session.error');
+  });
+});

--- a/packages/web/server/lib/opencode/shutdown-runtime.js
+++ b/packages/web/server/lib/opencode/shutdown-runtime.js
@@ -9,6 +9,7 @@ export const createGracefulShutdownRuntime = (dependencies) => {
     openCodeWatcherRuntime,
     sessionRuntime,
     sessionAssistRuntime,
+    sessionTitleRuntime,
     sessionGoalRuntime,
     contextObligatoryRuntime,
     scheduledTasksRuntime,
@@ -45,6 +46,7 @@ export const createGracefulShutdownRuntime = (dependencies) => {
     openCodeWatcherRuntime.stop();
     sessionRuntime.dispose();
     sessionAssistRuntime?.stop?.();
+    sessionTitleRuntime?.stop?.();
     sessionGoalRuntime?.stop?.();
     contextObligatoryRuntime?.stop?.();
     scheduledTasksRuntime?.stop?.();

--- a/packages/web/server/lib/session-title/runtime.js
+++ b/packages/web/server/lib/session-title/runtime.js
@@ -1,0 +1,262 @@
+// Session title: Claude harness turns bypass OpenCode session.promptAsync, so
+// upstream ensureTitle never runs. This event-driven helper names a Claude-bound
+// session once after the first user turn, using the harness transcript snapshot.
+
+const FETCH_TIMEOUT_MS = 5_000;
+const TITLE_QUIET_MS = 750;
+const USER_TEXT_CHAR_LIMIT = 4_000;
+const TITLE_CHAR_LIMIT = 80;
+
+const DEFAULT_TITLE_PATTERNS = [
+  /^(New session|Untitled( Session)?)\b/i,
+  /^\d{4}-\d{1,2}-\d{1,2}(?:[ T]\d{1,2}:\d{2}(?::\d{2})?(?:\s?(?:AM|PM))?)?$/i,
+  /^\d{1,2}\/\d{1,2}\/\d{2,4}(?:,?\s+\d{1,2}:\d{2}(?::\d{2})?(?:\s?(?:AM|PM))?)?$/i,
+  /^(?:Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:urday)?|Sun(?:day)?)?,?\s*(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2},?\s+\d{4}(?:,?\s+\d{1,2}:\d{2}(?::\d{2})?(?:\s?(?:AM|PM))?)?$/i,
+];
+
+const buildTitleSystemPrompt = () => [
+  'You write concise titles for coding-agent sessions.',
+  'Return only the title text.',
+  `Maximum ${TITLE_CHAR_LIMIT} characters.`,
+  'No quotes, markdown, bullets, code fences, trailing period, or labels like "Title:".',
+  'Use the same language as the user message.',
+].join('\n');
+
+const isDefaultSessionTitle = (title) => {
+  const value = String(title ?? '').trim();
+  if (!value) return true;
+  return DEFAULT_TITLE_PATTERNS.some((pattern) => pattern.test(value));
+};
+
+const extractSessionStatus = (payload) => {
+  if (!payload || payload.type !== 'session.status') return null;
+  const properties = payload.properties && typeof payload.properties === 'object' ? payload.properties : {};
+  const status = properties.status && typeof properties.status === 'object' ? properties.status : {};
+  const info = properties.info && typeof properties.info === 'object' ? properties.info : {};
+  const sessionId = typeof properties.sessionID === 'string' ? properties.sessionID.trim() : '';
+  const type = typeof status.type === 'string'
+    ? status.type.trim()
+    : (typeof info.type === 'string' ? info.type.trim() : '');
+  if (!sessionId || !type) return null;
+  const directory = typeof properties.directory === 'string' && properties.directory
+    ? properties.directory
+    : (typeof info.directory === 'string' ? info.directory : '');
+  return { sessionId, type, directory };
+};
+
+const extractUserMessage = (payload) => {
+  if (!payload || payload.type !== 'message.updated') return null;
+  const info = payload.properties?.info;
+  if (!info || typeof info !== 'object' || info.role !== 'user') return null;
+  if (typeof info.sessionID !== 'string' || !info.sessionID) return null;
+  return { sessionId: info.sessionID };
+};
+
+const messagePartsToText = (message) => {
+  const parts = Array.isArray(message?.parts) ? message.parts : [];
+  return parts
+    .map((part) => (part?.type === 'text' && typeof part.text === 'string' ? part.text : ''))
+    .filter(Boolean)
+    .join('\n');
+};
+
+const extractHarnessUserText = (messages) => {
+  if (!Array.isArray(messages)) return '';
+  return messages
+    .filter((message) => message?.info?.role === 'user')
+    .map(messagePartsToText)
+    .filter(Boolean)
+    .join('\n\n')
+    .trim()
+    .slice(0, USER_TEXT_CHAR_LIMIT);
+};
+
+const sanitizeTitle = (value) => {
+  let title = String(value ?? '').trim();
+  const fenced = title.match(/```(?:text)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) title = fenced[1].trim();
+  title = title
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean) ?? '';
+  title = title
+    .replace(/^title\s*:\s*/i, '')
+    .replace(/^[-*#\s]+/, '')
+    .replace(/^["'`]+|["'`.]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return title.slice(0, TITLE_CHAR_LIMIT).trim();
+};
+
+export const createSessionTitleRuntime = ({
+  buildOpenCodeUrl,
+  getOpenCodeAuthHeaders,
+  getSmallModelService,
+  getHarnessRecentMessages,
+  getSessionBinding,
+  quietMs = TITLE_QUIET_MS,
+}) => {
+  const timers = new Map();
+  const inflight = new Set();
+  const attempted = new Set();
+  const sessionsWithUserMessage = new Set();
+  const workingSessions = new Set();
+  let stopped = false;
+
+  const clearTimer = (sessionId) => {
+    const existing = timers.get(sessionId);
+    if (existing) {
+      clearTimeout(existing.timer);
+      timers.delete(sessionId);
+    }
+  };
+
+  const isClaudeBoundSession = (sessionId) => {
+    try {
+      return getSessionBinding?.(sessionId)?.harnessId === 'claude-code';
+    } catch (error) {
+      console.warn('[session-title] binding lookup failed:', error?.message || error);
+      return false;
+    }
+  };
+
+  const openCodeFetch = async (fetchPath, { directory, method = 'GET', body } = {}) => {
+    const base = buildOpenCodeUrl(fetchPath, '');
+    const url = directory ? `${base}?directory=${encodeURIComponent(directory)}` : base;
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Accept: 'application/json',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+        ...getOpenCodeAuthHeaders(),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`OpenCode ${method} ${fetchPath} failed with ${response.status}`);
+    }
+    return response.json().catch(() => null);
+  };
+
+  const fetchSession = (sessionId, directory) =>
+    openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, { directory });
+
+  const shouldSkipSession = (session) => {
+    if (!session || typeof session !== 'object') return true;
+    if (typeof session.parentID === 'string' && session.parentID) return true;
+    return !isDefaultSessionTitle(session.title);
+  };
+
+  const generateTitle = async (sessionId, directory) => {
+    if (stopped || attempted.has(sessionId) || !isClaudeBoundSession(sessionId)) return;
+    if (!sessionsWithUserMessage.has(sessionId)) return;
+
+    const session = await fetchSession(sessionId, directory).catch((error) => {
+      console.warn('[session-title] session fetch failed:', error?.message || error);
+      return null;
+    });
+    if (shouldSkipSession(session)) return;
+
+    const userText = extractHarnessUserText(
+      typeof getHarnessRecentMessages === 'function' ? getHarnessRecentMessages(sessionId) : null,
+    );
+    if (!userText) return;
+
+    attempted.add(sessionId);
+    const { generateSmallModelText } = await getSmallModelService();
+    let generated;
+    try {
+      generated = await generateSmallModelText({
+        prompt: `User message text:\n\n${userText}\n\nWrite a concise session title.`,
+        system: buildTitleSystemPrompt(),
+        maxOutputTokens: 32,
+        directory,
+      });
+    } catch (error) {
+      if (Number(error?.statusCode) !== 404) {
+        console.warn('[session-title] generation failed:', error?.message || error);
+      }
+      return;
+    }
+    if (stopped) return;
+
+    const title = sanitizeTitle(generated?.text);
+    if (!title) return;
+
+    const freshSession = await fetchSession(sessionId, directory).catch((error) => {
+      console.warn('[session-title] fresh session fetch failed:', error?.message || error);
+      return null;
+    });
+    if (shouldSkipSession(freshSession)) return;
+    if (stopped) return;
+
+    await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, {
+      directory,
+      method: 'PATCH',
+      body: { title },
+    });
+    console.log(`[session-title] generated for ${sessionId} via ${generated?.providerID ?? 'unknown'}/${generated?.modelID ?? 'unknown'}`);
+  };
+
+  const armTimer = (sessionId, directory) => {
+    if (stopped || attempted.has(sessionId) || inflight.has(sessionId)) return;
+    if (!isClaudeBoundSession(sessionId)) return;
+    clearTimer(sessionId);
+    const timer = setTimeout(() => {
+      timers.delete(sessionId);
+      if (stopped || inflight.has(sessionId)) return;
+      inflight.add(sessionId);
+      generateTitle(sessionId, directory)
+        .catch((error) => {
+          console.warn('[session-title] failed:', error?.message || error);
+        })
+        .finally(() => {
+          inflight.delete(sessionId);
+        });
+    }, quietMs);
+    if (typeof timer?.unref === 'function') timer.unref();
+    timers.set(sessionId, { timer });
+  };
+
+  const processHarnessPayload = (payload, directoryHint = '') => {
+    if (stopped) return;
+
+    const userMessage = extractUserMessage(payload);
+    if (userMessage) {
+      if (!attempted.has(userMessage.sessionId) && isClaudeBoundSession(userMessage.sessionId)) {
+        sessionsWithUserMessage.add(userMessage.sessionId);
+        if (!workingSessions.has(userMessage.sessionId)) {
+          armTimer(userMessage.sessionId, directoryHint);
+        }
+      }
+      return;
+    }
+
+    const status = extractSessionStatus(payload);
+    if (!status) return;
+    if (status.type === 'idle') {
+      workingSessions.delete(status.sessionId);
+      if (sessionsWithUserMessage.has(status.sessionId)) {
+        armTimer(status.sessionId, status.directory || directoryHint);
+      }
+      return;
+    }
+    workingSessions.add(status.sessionId);
+    clearTimer(status.sessionId);
+  };
+
+  const stop = () => {
+    stopped = true;
+    for (const { timer } of timers.values()) {
+      clearTimeout(timer);
+    }
+    timers.clear();
+    inflight.clear();
+    attempted.clear();
+    sessionsWithUserMessage.clear();
+    workingSessions.clear();
+  };
+
+  return { processHarnessPayload, stop };
+};

--- a/packages/web/server/lib/session-title/runtime.test.js
+++ b/packages/web/server/lib/session-title/runtime.test.js
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+
+import { createSessionTitleRuntime } from './runtime.js';
+
+const SESSION_ID = 'ses_claude';
+const DIRECTORY = '/workspace';
+
+const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+const originalFetch = globalThis.fetch;
+
+const waitForRuntime = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+const userMessageEvent = (sessionId = SESSION_ID) => ({
+  type: 'message.updated',
+  properties: {
+    info: {
+      id: 'msg_user',
+      sessionID: sessionId,
+      role: 'user',
+      time: { created: 1 },
+    },
+  },
+});
+
+const idleEvent = (sessionId = SESSION_ID) => ({
+  type: 'session.status',
+  properties: { sessionID: sessionId, status: { type: 'idle' }, directory: DIRECTORY },
+});
+
+const busyEvent = (sessionId = SESSION_ID) => ({
+  type: 'session.status',
+  properties: { sessionID: sessionId, status: { type: 'busy' }, directory: DIRECTORY },
+});
+
+const createRuntimeHarness = ({
+  binding = { harnessId: 'claude-code' },
+  session = { id: SESSION_ID, title: 'Untitled Session' },
+  messages = [{
+    info: { id: 'msg_user', sessionID: SESSION_ID, role: 'user' },
+    parts: [{ type: 'text', text: 'Implement OAuth callback handling' }],
+  }],
+  generatedText = 'OAuth Callback Handling',
+} = {}) => {
+  const requests = [];
+  const fetchImpl = mock(async (input, init = {}) => {
+    const url = new URL(typeof input === 'string' ? input : input.url);
+    requests.push({ url, method: init.method ?? 'GET', body: init.body });
+    if (url.pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+      return jsonResponse({ ...session, title: JSON.parse(init.body).title });
+    }
+    if (url.pathname === `/session/${SESSION_ID}`) {
+      return jsonResponse(session);
+    }
+    throw new Error(`Unexpected request: ${url.pathname}`);
+  });
+  globalThis.fetch = fetchImpl;
+
+  const service = {
+    generateSmallModelText: mock(async () => ({
+      text: generatedText,
+      providerID: 'provider',
+      modelID: 'model',
+    })),
+  };
+  const getSmallModelService = mock(async () => service);
+  const getHarnessRecentMessages = mock(() => messages);
+  const getSessionBinding = mock(() => binding);
+  const runtime = createSessionTitleRuntime({
+    buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+    getOpenCodeAuthHeaders: () => ({ Authorization: 'Bearer test-token' }),
+    getSmallModelService,
+    getHarnessRecentMessages,
+    getSessionBinding,
+    quietMs: 0,
+  });
+
+  return {
+    runtime,
+    requests,
+    service,
+    getSmallModelService,
+    getHarnessRecentMessages,
+    getSessionBinding,
+  };
+};
+
+describe('session title runtime', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    mock.restore();
+  });
+
+  it('skips non-claude bindings', async () => {
+    const { runtime, getSmallModelService, getSessionBinding } = createRuntimeHarness({
+      binding: { harnessId: 'opencode' },
+    });
+
+    runtime.processHarnessPayload(userMessageEvent(), DIRECTORY);
+    runtime.processHarnessPayload(idleEvent(), DIRECTORY);
+    await waitForRuntime();
+
+    expect(getSessionBinding).toHaveBeenCalled();
+    expect(getSmallModelService).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it('skips non-default titles', async () => {
+    const { runtime, requests, getSmallModelService } = createRuntimeHarness({
+      session: { id: SESSION_ID, title: 'Important migration plan' },
+    });
+
+    runtime.processHarnessPayload(userMessageEvent(), DIRECTORY);
+    runtime.processHarnessPayload(idleEvent(), DIRECTORY);
+    await waitForRuntime();
+
+    expect(requests.map((request) => request.method)).toEqual(['GET']);
+    expect(getSmallModelService).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it('patches title on idle after user message using harness recent messages', async () => {
+    const { runtime, requests, service, getHarnessRecentMessages } = createRuntimeHarness();
+
+    runtime.processHarnessPayload(userMessageEvent(), DIRECTORY);
+    runtime.processHarnessPayload(busyEvent(), DIRECTORY);
+    runtime.processHarnessPayload(idleEvent(), DIRECTORY);
+    await waitForRuntime();
+
+    expect(getHarnessRecentMessages).toHaveBeenCalledWith(SESSION_ID);
+    expect(service.generateSmallModelText).toHaveBeenCalledTimes(1);
+    expect(service.generateSmallModelText.mock.calls[0][0].prompt).toContain('Implement OAuth callback handling');
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(patch).toBeDefined();
+    expect(patch.url.searchParams.get('directory')).toBe(DIRECTORY);
+    expect(JSON.parse(patch.body)).toEqual({ title: 'OAuth Callback Handling' });
+    runtime.stop();
+  });
+
+  it('does not double-title same session', async () => {
+    const { runtime, requests, service } = createRuntimeHarness();
+
+    runtime.processHarnessPayload(userMessageEvent(), DIRECTORY);
+    runtime.processHarnessPayload(idleEvent(), DIRECTORY);
+    await waitForRuntime();
+    runtime.processHarnessPayload(idleEvent(), DIRECTORY);
+    await waitForRuntime();
+
+    expect(service.generateSmallModelText).toHaveBeenCalledTimes(1);
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(1);
+    runtime.stop();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Claude Code follow-ups currently fail with `A Claude Code turn is already active for this session` instead of using OpenChamber’s message queue. Stop generation is unreliable, Haiku 4.5 appears twice in the model catalog, engine handoff does not switch the chat window to the destination session, and Claude sessions stay untitled because they bypass OpenCode `ensureTitle`.

This change:

- Routes busy Claude follow-ups into the existing queue (reorder + idle auto-send); never steers concurrent Claude prompts
- Makes Stop available while Claude turns are busy (including permission waits) and hardens harness abort/idle cleanup
- Dedupes Claude catalog aliases vs pins so Haiku 4.5 is listed once
- On engine handoff, switches the UI to the new session, copies the source title, and labels seed context by source engine
- Auto-names Claude sessions once after the first turn via small-model + OpenCode `session.update`

## Non-goals

- In-place rewrite of sticky `harnessId` on a used session (still handoff → new session ID)
- Claude steer/injection into an active Agent SDK turn
- Full reverse-handoff billing notice UX beyond existing seed path

## Affected surfaces

- `packages/ui`: ChatInput queue/steer gating, session activity `canAbort`, abort routing, handoff navigation/title, harness client abort payload
- `packages/web`: Claude translator abort/idle, model catalog dedupe, `session-title` runtime wired to harness observers
- Runtimes: all surfaces that share UI + OpenChamber server (web/desktop/VS Code/mobile via shared packages). No Electron/native-only code paths changed.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` + `openchamber-change-discipline` | Source/contract change across UI + server | Smallest complete fix; focused tests; owning harness docs updated |
| `sync-state-invariants` | Queue, busy/idle, abort, optimistic send | Prefer authoritative busy/idle; queue config captured at enqueue; Claude concurrent prompt remains server-guarded |
| `ui-api-decoupling` | `/api/harness/*` prompt/abort | Still uses `runtimeFetch` harness client; no Anthropic HTTP from UI |
| `locale-ui-patterns` | No new user-facing copy | Reused existing queue/stop/toast paths; TURN_IN_PROGRESS silently re-queues |
| `packages/web/server/lib/harness/DOCUMENTATION.md` | Owning module docs | Documented queue policy, abort idle guarantee, session-title runtime |

## Validation

| Check | Result |
|---|---|
| `bun test packages/web/server/lib/harness/ packages/ui/src/lib/harness/ packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts packages/web/server/lib/session-title/` | Pass (134) |
| `bun test packages/ui/src/sync/session-actions.test.ts` (abort cases) | Pass |
| `bun run type-check:ui` | Pass |
| `bun run type-check:web` | Pass |
| `bun run lint:ui` | Pass |
| `bun run lint:web` | Pass |
| `bun run dead-code` | Exit 0; no new unused session-title/harness modules flagged as blocking |

Not verified: live Claude CLI turn in a packaged Desktop/VS Code host (no subscription CLI in this environment).

## Visual evidence

No intentional visual redesign. Behavioral UI differences:

- Busy Claude session: Stop remains available; Enter queues instead of toasting TURN_IN_PROGRESS; QueuedMessageChips reorder still works
- Model picker: single Haiku 4.5 row under Claude Code
- Engine handoff Send: same window navigates to destination session with prior title when present

## Risks and failure behavior

- Server still returns `409 TURN_IN_PROGRESS` as a hard guard; UI queues on that code as a safety net after optimistic clear
- Abort interrupt is timeout-bounded then force-closed; idle is always emitted in `finally` so queue auto-send can resume
- Session title generation is best-effort (small-model unavailable → leave default title); never overwrites a non-default/manual title
- Handoff still creates a new session ID (sticky binding policy unchanged); only window navigation + seed/title continuity improved

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0d30e76-34ec-4eab-9f27-ec21c390ae0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0d30e76-34ec-4eab-9f27-ec21c390ae0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

