### PR TITLE
fix(engines): Claude Stop, Goal visibility, and queue auto-send

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -971,9 +971,12 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ active = true, aut
 
     React.useEffect(() => {
         if (!active || !currentSessionId) return;
-        if (hasRenderableSessionSnapshot) return;
+        // Empty [] is renderable (stops skeletons) but Claude transcripts may
+        // still need a harness overlay fetch. Force one ensure while local
+        // message count is still zero.
+        if (hasRenderableSessionSnapshot && sessionMessageCount > 0) return;
         void ensureSessionRenderable(currentSessionId);
-    }, [active, currentSessionId, ensureSessionRenderable, hasRenderableSessionSnapshot]);
+    }, [active, currentSessionId, ensureSessionRenderable, hasRenderableSessionSnapshot, sessionMessageCount]);
 
 	if (!currentSessionId && !draftOpen) {
 		// With auto-open, the draft welcome opens on the next tick (effect below),

--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { Agent } from '@opencode-ai/sdk/v2';
 import type { QueuedMessage } from '../stores/messageQueueStore';
+import {
+  applyGlobalSessionStatusEvent,
+  useGlobalSessionStatusStore,
+} from '../sync/global-session-status';
 
 let visibleAgents: Agent[] = [];
 const sendMessageCalls: unknown[][] = [];
@@ -31,6 +35,7 @@ import {
   buildQueuedAutoSendPayload,
   getQueuedAutoSendRetryDelayMs,
   isQueuedAutoSendBackedOff,
+  resolveQueuedSessionStatusType,
   sendQueuedAutoSendPayload,
   shouldDispatchQueuedAutoSend,
 } from './useQueuedMessageAutoSend';
@@ -48,6 +53,32 @@ describe('shouldDispatchQueuedAutoSend', () => {
 
   test('dispatches when idle→idle and queue has items', () => {
     expect(shouldDispatchQueuedAutoSend('idle', 'idle', true)).toBe(true);
+  });
+
+  test('busy→idle with queued items still dispatches', () => {
+    expect(shouldDispatchQueuedAutoSend('busy', 'idle', true)).toBe(true);
+  });
+});
+
+describe('resolveQueuedSessionStatusType', () => {
+  beforeEach(() => {
+    useGlobalSessionStatusStore.setState({ statusById: new Map() });
+  });
+
+  test('prefers global busy over directory absence', () => {
+    applyGlobalSessionStatusEvent('/repo', {
+      type: 'session.status',
+      properties: {
+        sessionID: 'ses_1',
+        status: { type: 'busy' },
+      },
+    } as never);
+
+    expect(resolveQueuedSessionStatusType('ses_1', '/repo')).toBe('busy');
+  });
+
+  test('reports idle when global and directory have no busy entry', () => {
+    expect(resolveQueuedSessionStatusType('ses_missing', '/repo')).toBe('idle');
   });
 });
 

--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
@@ -7,9 +7,9 @@ import { useContextStore } from '@/stores/contextStore';
 import { useAutoReviewStore } from '@/stores/useAutoReviewStore';
 import { parseAgentMentions } from '@/lib/messages/agentMentions';
 import { getDirectoryState } from '@/sync/sync-refs';
-import { useDirectorySync } from '@/sync/sync-context';
+import { useGlobalSessionStatusStore } from '@/sync/global-session-status';
 import { getRuntimeKey } from '@/lib/runtime-switch';
-import { useDirectoryStore } from '@/stores/useDirectoryStore';
+import { HarnessClientError } from '@/lib/harness/client';
 
 type SessionStatusType = 'idle' | 'busy' | 'retry';
 
@@ -138,22 +138,55 @@ export const shouldDispatchQueuedAutoSend = (
     && currentStatusType === 'idle';
 };
 
+/**
+ * Prefer the live global busy index (covers Claude harness events even when a
+ * directory child store missed them), then fall back to the directory store.
+ */
+export const resolveQueuedSessionStatusType = (
+  sessionId: string,
+  directory: string,
+): SessionStatusType => {
+  const globalEntry = useGlobalSessionStatusStore.getState().statusById.get(sessionId);
+  if (globalEntry?.status?.type === 'busy' || globalEntry?.status?.type === 'retry') {
+    return globalEntry.status.type;
+  }
+  const directoryStatus = getDirectoryState(directory)?.session_status?.[sessionId]?.type;
+  if (directoryStatus === 'busy' || directoryStatus === 'retry') {
+    return directoryStatus;
+  }
+  // Global absence means idle; directory absence also means idle.
+  return 'idle';
+};
+
+const isTurnInProgressError = (error: unknown): boolean => (
+  error instanceof HarnessClientError && error.code === 'TURN_IN_PROGRESS'
+);
+
 export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?: boolean }) {
   const enabled = typeof enabledOrOptions === 'boolean' ? enabledOrOptions : (enabledOrOptions?.enabled ?? true);
   const queuedMessages = useMessageQueueStore((state) => state.queuedMessages);
   const autoReviewRuns = useAutoReviewStore((state) => state.runsByOriginalSessionID);
-  const sessionStatusRecord = useDirectorySync((state) => state.session_status);
-  const currentDirectory = useDirectoryStore((state) => state.currentDirectory);
+  const globalStatusById = useGlobalSessionStatusStore((state) => state.statusById);
 
   const inFlightSessionsRef = React.useRef<Set<string>>(new Set());
   const sendFailuresRef = React.useRef<Map<string, QueuedAutoSendFailure>>(new Map());
   const previousStatusRef = React.useRef<Map<string, SessionStatusType>>(new Map());
   const autoReviewBlockedSessionsRef = React.useRef<Set<string>>(new Set());
+  const [retryClock, setRetryClock] = React.useState(0);
 
   React.useEffect(() => {
     if (!enabled) {
       return;
     }
+
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    const armRetryTimer = (delayMs: number) => {
+      if (retryTimer) return;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        setRetryClock((value) => value + 1);
+      }, Math.max(delayMs, 0));
+    };
 
     const dispatchSessionQueue = async (target: MessageQueueTarget, queueSnapshot: QueuedMessage[]) => {
       const { sessionId } = target;
@@ -172,7 +205,7 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
         return;
       }
 
-      const currentStatus = getDirectoryState(target.directory)?.session_status?.[sessionId]?.type ?? 'idle';
+      const currentStatus = resolveQueuedSessionStatusType(sessionId, target.directory);
       if (currentStatus !== 'idle') {
         return;
       }
@@ -186,6 +219,7 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
       if (failure && failure.messageId !== payload.queuedMessageId) {
         sendFailuresRef.current.delete(targetKey);
       } else if (isQueuedAutoSendBackedOff(failure, payload.queuedMessageId, Date.now())) {
+        armRetryTimer((failure?.nextAttemptAt ?? Date.now()) - Date.now());
         return;
       }
 
@@ -211,32 +245,33 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
         sendFailuresRef.current.delete(targetKey);
       } catch (error) {
         console.warn('[queue] queued auto-send failed:', error);
+        if (isTurnInProgressError(error)) {
+          // Claude turn still active — leave the item queued and wait for the
+          // next busy→idle edge instead of exponential backoff forever.
+          sendFailuresRef.current.delete(targetKey);
+          return;
+        }
         const priorFailures = failure?.messageId === payload.queuedMessageId ? failure.failures : 0;
         const failures = priorFailures + 1;
+        const nextAttemptAt = Date.now() + getQueuedAutoSendRetryDelayMs(failures);
         sendFailuresRef.current.set(targetKey, {
           messageId: payload.queuedMessageId,
           failures,
-          nextAttemptAt: Date.now() + getQueuedAutoSendRetryDelayMs(failures),
+          nextAttemptAt,
         });
+        armRetryTimer(nextAttemptAt - Date.now());
       } finally {
         inFlightSessionsRef.current.delete(targetKey);
       }
     };
 
-    const statusRecord = sessionStatusRecord ?? {};
     const nextStatusMap = new Map(previousStatusRef.current);
-    for (const [sessionId, status] of Object.entries(statusRecord)) {
-      if (status) {
-        nextStatusMap.set(sessionId, status.type as SessionStatusType);
-      }
-    }
-
     const queueEntries = Object.entries(queuedMessages);
     queueEntries.forEach(([key, queue]) => {
       const target = parseMessageQueueKey(key);
-      if (!target || target.runtimeKey !== getRuntimeKey() || target.directory !== currentDirectory) return;
+      if (!target || target.runtimeKey !== getRuntimeKey()) return;
       const { sessionId } = target;
-      const currentStatusType = (statusRecord[sessionId]?.type ?? 'idle') as SessionStatusType;
+      const currentStatusType = resolveQueuedSessionStatusType(sessionId, target.directory);
       const previousStatusType = previousStatusRef.current.get(sessionId);
       const wasAutoReviewBlocked = autoReviewBlockedSessionsRef.current.has(sessionId);
       const isAutoReviewRunning = useAutoReviewStore.getState().isRunningForSession(sessionId);
@@ -257,5 +292,9 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
     });
 
     previousStatusRef.current = nextStatusMap;
-  }, [enabled, queuedMessages, sessionStatusRecord, autoReviewRuns, currentDirectory]);
+
+    return () => {
+      if (retryTimer) clearTimeout(retryTimer);
+    };
+  }, [enabled, queuedMessages, globalStatusById, autoReviewRuns, retryClock]);
 }

--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
@@ -7,6 +7,7 @@ import { useContextStore } from '@/stores/contextStore';
 import { useAutoReviewStore } from '@/stores/useAutoReviewStore';
 import { parseAgentMentions } from '@/lib/messages/agentMentions';
 import { getDirectoryState } from '@/sync/sync-refs';
+import { useDirectorySync } from '@/sync/sync-context';
 import { useGlobalSessionStatusStore } from '@/sync/global-session-status';
 import { getRuntimeKey } from '@/lib/runtime-switch';
 import { HarnessClientError } from '@/lib/harness/client';
@@ -17,6 +18,8 @@ const RECENT_ABORT_WINDOW_MS = 2000;
 
 const AUTO_SEND_RETRY_BASE_DELAY_MS = 2000;
 const AUTO_SEND_RETRY_MAX_DELAY_MS = 60000;
+/** Re-check soon after TURN_IN_PROGRESS when busy/idle edges may be missed. */
+const TURN_IN_PROGRESS_WAKE_MS = 1500;
 
 export type QueuedAutoSendFailure = {
   messageId: string;
@@ -166,6 +169,10 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
   const enabled = typeof enabledOrOptions === 'boolean' ? enabledOrOptions : (enabledOrOptions?.enabled ?? true);
   const queuedMessages = useMessageQueueStore((state) => state.queuedMessages);
   const autoReviewRuns = useAutoReviewStore((state) => state.runsByOriginalSessionID);
+  // Directory child-store status must wake this effect: optimistic busy and
+  // some Claude turns land here first, while global absence alone does not
+  // re-render when the directory flips busy→idle.
+  const directorySessionStatus = useDirectorySync((state) => state.session_status);
   const globalStatusById = useGlobalSessionStatusStore((state) => state.statusById);
 
   const inFlightSessionsRef = React.useRef<Set<string>>(new Set());
@@ -246,9 +253,12 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
       } catch (error) {
         console.warn('[queue] queued auto-send failed:', error);
         if (isTurnInProgressError(error)) {
-          // Claude turn still active — leave the item queued and wait for the
-          // next busy→idle edge instead of exponential backoff forever.
+          // Claude turn still active — leave the item queued. Treat as busy so
+          // the next idle edge (or wake timer) can dispatch instead of stalling
+          // on idle→idle with no status Map change.
           sendFailuresRef.current.delete(targetKey);
+          previousStatusRef.current.set(sessionId, 'busy');
+          armRetryTimer(TURN_IN_PROGRESS_WAKE_MS);
           return;
         }
         const priorFailures = failure?.messageId === payload.queuedMessageId ? failure.failures : 0;
@@ -266,6 +276,13 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
     };
 
     const nextStatusMap = new Map(previousStatusRef.current);
+    // Keep previous busy/retry edges for sessions that only appear in the
+    // directory status map (optimistic send / child-store events).
+    for (const [sessionId, status] of Object.entries(directorySessionStatus ?? {})) {
+      if (status?.type === 'busy' || status?.type === 'retry') {
+        nextStatusMap.set(sessionId, status.type);
+      }
+    }
     const queueEntries = Object.entries(queuedMessages);
     queueEntries.forEach(([key, queue]) => {
       const target = parseMessageQueueKey(key);
@@ -296,5 +313,5 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
     return () => {
       if (retryTimer) clearTimeout(retryTimer);
     };
-  }, [enabled, queuedMessages, globalStatusById, autoReviewRuns, retryClock]);
+  }, [enabled, queuedMessages, directorySessionStatus, globalStatusById, autoReviewRuns, retryClock]);
 }

--- a/packages/ui/src/sync/materialization.ts
+++ b/packages/ui/src/sync/materialization.ts
@@ -289,6 +289,13 @@ export function getSessionMaterializationStatus(
     return { hasMessages: false, renderable: false, missingPartMessageIDs: [] }
   }
 
+  // Explicit empty array means "fetched, no messages" — renderable so empty
+  // OpenCode sessions stop skeletons, but hasMessages stays false so sync can
+  // still attempt Claude harness overlay hydration when appropriate.
+  if (messages.length === 0) {
+    return { hasMessages: false, renderable: true, missingPartMessageIDs: [] }
+  }
+
   const missingPartMessageIDs: string[] = []
   for (const message of messages) {
     if (message.role !== "assistant") continue

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -929,6 +929,7 @@ export async function optimisticSend(input: {
 
   // Set busy status
   const current = store.getState()
+  const previousStatus = current.session_status?.[input.sessionId]
   store.setState({
     session_status: {
       ...current.session_status,
@@ -979,13 +980,20 @@ export async function optimisticSend(input: {
       }
     }
 
+    // Preserve a pre-existing busy/retry status (e.g. TURN_IN_PROGRESS while a
+    // Claude turn is still active). Forcing idle here would hide Stop and stall
+    // queued auto-send until another status edge arrives.
+    const restoredStatus = previousStatus?.type === "busy" || previousStatus?.type === "retry"
+      ? previousStatus
+      : { type: "idle" as const }
+
     store.setState({
       session,
       message,
       part,
       session_status: {
         ...rollbackState.session_status,
-        [input.sessionId]: { type: "idle" as const },
+        [input.sessionId]: restoredStatus,
       },
     })
     throw error

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -3,7 +3,7 @@
  * Replaces the action methods from the old useSessionStore.
  */
 
-import type { OpencodeClient, Session, Message, Part } from "@opencode-ai/sdk/v2/client"
+import type { Event, OpencodeClient, Session, SessionStatus, Message, Part } from "@opencode-ai/sdk/v2/client"
 import { Binary } from "./binary"
 import { useSessionUIStore } from "./session-ui-store"
 import { useInputStore } from "./input-store"
@@ -30,6 +30,7 @@ import { cleanupPersistedSessionState } from "./session-deletion-cleanup"
 import { getRuntimeKey } from "@/lib/runtime-switch"
 import { harnessAbort, harnessPermissionReply } from "@/lib/harness/client"
 import { useSelectionStore } from "./selection-store"
+import { applyGlobalSessionStatusEvent } from "./global-session-status"
 
 const MESSAGE_REFETCH_LIMIT = 100
 const SEND_CONFIRMATION_REFETCH_LIMIT = 30
@@ -927,15 +928,20 @@ export async function optimisticSend(input: {
   })
   input.onOptimisticInsert?.()
 
-  // Set busy status
+  // Set busy status (directory child store + global index so Stop / queue
+  // auto-send both observe the optimistic busy edge immediately).
   const current = store.getState()
   const previousStatus = current.session_status?.[input.sessionId]
+  const optimisticBusy = { type: "busy" as const }
   store.setState({
     session_status: {
       ...current.session_status,
-      [input.sessionId]: { type: "busy" as const },
+      [input.sessionId]: optimisticBusy,
     },
   })
+  if (targetDirectory) {
+    mirrorSessionStatusToGlobal(targetDirectory, input.sessionId, optimisticBusy)
+  }
 
   try {
     await input.send(messageID)
@@ -983,9 +989,10 @@ export async function optimisticSend(input: {
     // Preserve a pre-existing busy/retry status (e.g. TURN_IN_PROGRESS while a
     // Claude turn is still active). Forcing idle here would hide Stop and stall
     // queued auto-send until another status edge arrives.
-    const restoredStatus = previousStatus?.type === "busy" || previousStatus?.type === "retry"
-      ? previousStatus
-      : { type: "idle" as const }
+    const restoredStatus: SessionStatus | { type: "idle" } =
+      previousStatus?.type === "busy" || previousStatus?.type === "retry"
+        ? previousStatus
+        : { type: "idle" as const }
 
     store.setState({
       session,
@@ -996,8 +1003,25 @@ export async function optimisticSend(input: {
         [input.sessionId]: restoredStatus,
       },
     })
+    if (targetDirectory) {
+      mirrorSessionStatusToGlobal(targetDirectory, input.sessionId, restoredStatus)
+    }
     throw error
   }
+}
+
+function mirrorSessionStatusToGlobal(
+  directory: string,
+  sessionId: string,
+  status: SessionStatus | { type: "idle" },
+): void {
+  applyGlobalSessionStatusEvent(directory, {
+    type: "session.status",
+    properties: {
+      sessionID: sessionId,
+      status,
+    },
+  } as Event)
 }
 
 async function fetchRecentSendConfirmationRecords(

--- a/packages/ui/src/sync/session-message-loader.ts
+++ b/packages/ui/src/sync/session-message-loader.ts
@@ -43,6 +43,12 @@ export type SessionMessageLoadState = {
   complete: boolean
   generation: number
   updatedAt: number | undefined
+  /**
+   * An early empty [] snapshot looks renderable and would skip Claude harness
+   * overlay hydration forever. After one empty hydration attempt we stop
+   * retrying until messages appear or force=true.
+   */
+  emptyHydrated: boolean
 }
 
 type LoaderEntry = {
@@ -115,6 +121,7 @@ const createDefaultState = (generation = 0): SessionMessageLoadState => ({
   complete: false,
   generation,
   updatedAt: undefined,
+  emptyHydrated: false,
 })
 
 export const EMPTY_SESSION_MESSAGE_LOAD_STATE = createDefaultState()
@@ -167,13 +174,18 @@ export class SessionMessageLoader {
     const entry = this.getEntry(normalized)
     const store = this.childStores.ensureChild(normalized.directory, { bootstrap: false })
     const materialization = getSessionMaterializationStatus(store.getState(), normalized.sessionID)
-    if (!options?.force && materialization.renderable) {
+    const localCount = store.getState().message[normalized.sessionID]?.length ?? 0
+    // Claude turns are served via the harness message overlay. An early empty
+    // [] snapshot looks "renderable" and would skip hydration forever — force
+    // one fetch when the local transcript is still empty.
+    const needsEmptyHydration = localCount === 0 && !entry.snapshot.emptyHydrated
+    if (!options?.force && materialization.renderable && !needsEmptyHydration) {
       if (!entry.snapshot.resolved) {
         this.patchEntry(entry, {
           status: "ready",
           error: null,
           resolved: true,
-          limit: Math.max(entry.snapshot.limit, store.getState().message[normalized.sessionID]?.length ?? 0),
+          limit: Math.max(entry.snapshot.limit, localCount),
         })
       }
       return entry.inflight ?? Promise.resolve()
@@ -188,6 +200,11 @@ export class SessionMessageLoader {
     const kind: SessionMessageLoadKind = options?.reason === "prefetch" ? "prefetch" : "initial"
     return this.startLoad(normalized, entry, store, kind, async (isCurrent) => {
       await this.loadInitial(normalized, entry, store, isCurrent)
+      if (!isCurrent()) return
+      const hydratedCount = store.getState().message[normalized.sessionID]?.length ?? 0
+      this.patchEntry(entry, {
+        emptyHydrated: hydratedCount === 0,
+      })
       if (!isMobileSurfaceRuntime() && isCurrent()) {
         queueMicrotask(() => {
           if (isCurrent() && entry.snapshot.cursor && !entry.snapshot.complete) {

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -173,8 +173,17 @@ export function routeMessage(params: {
 
     const providerID = "claude-code"
     const modelID = target.modelRef
+    // Goal intro / other <system-reminder> synthetics are OpenCode-oriented.
+    // Folding them into Claude harness text makes them visible as the user
+    // message and confuses the turn. Goal metadata + server continuations
+    // still drive the loop; handoff seed context is kept.
     const seedParts = (params.additionalParts ?? [])
-      .filter((part) => part.synthetic && typeof part.text === "string" && part.text.trim().length > 0)
+      .filter((part) => (
+        part.synthetic
+        && typeof part.text === "string"
+        && part.text.trim().length > 0
+        && !part.text.includes("<system-reminder>")
+      ))
       .map((part) => part.text.trim())
     // Queued follow-ups arrive as non-synthetic additionalParts. Claude has no
     // multi-prompt steer, so fold them into one harness turn text (same order

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -3065,6 +3065,7 @@ export function useEnsureSessionMessages(sessionID: string, directory?: string) 
 
     const state = store.getState()
     // Already loaded into a renderable message/part snapshot — nothing to do.
+    // Empty [] is renderable; Claude empty hydration is owned by SessionMessageLoader.ensure.
     if (getSessionMaterializationStatus(state, sessionID).renderable) return
     // Session doesn't exist — nothing to load
     if (!state.session.some((s) => s.id === sessionID)) return

--- a/packages/web/server/lib/event-stream/DOCUMENTATION.md
+++ b/packages/web/server/lib/event-stream/DOCUMENTATION.md
@@ -46,6 +46,8 @@ This module contains the OpenChamber message-stream WebSocket protocol and runti
 - Health checks are reserved for initial upstream connect failures and explicit upstream-unavailable responses, not for ordinary stall recovery on an already-established stream.
 - Global synthetic events such as `openchamber:session-status`, `openchamber:session-activity`, `openchamber:notification`, and `openchamber:heartbeat` are preserved on the WS path, but heartbeat frames are emitted only while an upstream SSE stream is actively attached.
 - Global UI broadcasts are fan-out capable across both SSE and WS clients.
+- When `options.directory` is provided, SSE payloads are wrapped as
+  `{ directory, payload }` so browser event routing matches WS frames.
 - The reusable upstream reader centralizes SSE fetch/parsing/reconnect behavior for the WS runtime and OpenCode watcher. Additional event consumers should move to it only with parity tests for their lifecycle and error semantics.
 - Browser transport concerns live in the WS bridge modules; server-side global stream ownership lives in `global-hub.js`.
 

--- a/packages/web/server/lib/event-stream/runtime.js
+++ b/packages/web/server/lib/event-stream/runtime.js
@@ -27,10 +27,20 @@ export function createGlobalUiEventBroadcaster({
       return;
     }
 
+    const directory = typeof options.directory === 'string' && options.directory.length > 0
+      ? options.directory
+      : null;
+
     if (hasSseClients) {
+      // Preserve directory for SSE the same way WS frames do. Harness and other
+      // synthetic emitters pass options.directory; without this stamp the UI
+      // event pipeline routes those events to "global" and skips directory stores.
+      const ssePayload = directory
+        ? { directory, payload }
+        : payload;
       for (const res of sseClients) {
         try {
-          writeSseEvent(res, payload);
+          writeSseEvent(res, ssePayload);
         } catch {
         }
       }
@@ -39,7 +49,7 @@ export function createGlobalUiEventBroadcaster({
     if (hasWsClients) {
       for (const socket of Array.from(wsClients)) {
         const sent = sendMessageStreamWsEvent(socket, payload, {
-          directory: typeof options.directory === 'string' && options.directory.length > 0 ? options.directory : 'global',
+          directory: directory || 'global',
           eventId: typeof options.eventId === 'string' && options.eventId.length > 0 ? options.eventId : undefined,
         });
         if (!sent) {

--- a/packages/web/server/lib/event-stream/runtime.test.js
+++ b/packages/web/server/lib/event-stream/runtime.test.js
@@ -89,7 +89,10 @@ describe('event stream broadcaster', () => {
     expect(sseEvents).toEqual([
       {
         res: sseClient,
-        payload: { type: 'openchamber:session-status' },
+        payload: {
+          directory: '/tmp/project',
+          payload: { type: 'openchamber:session-status' },
+        },
       },
     ]);
     expect(wsPayloads).toEqual([

--- a/packages/web/server/lib/harness/DOCUMENTATION.md
+++ b/packages/web/server/lib/harness/DOCUMENTATION.md
@@ -217,7 +217,9 @@ idle auto-send). Abort interrupts the active turn and always clears busy via
 Harness events stamp `properties.directory` and SSE fan-out preserves the
 directory envelope so UI directory stores receive busy/idle (Stop + queue
 auto-send). `GET /api/session/status` overlays active Claude busy entries so
-OpenCode status polls cannot clear harness turns.
+OpenCode status polls cannot clear harness turns. `GET /api/session/:id/message`
+overlays the turn-snapshot last user/assistant so OpenCode's empty message list
+cannot wipe Claude chat on materialization/refetch.
 
 ## Session titles on Claude
 

--- a/packages/web/server/lib/harness/DOCUMENTATION.md
+++ b/packages/web/server/lib/harness/DOCUMENTATION.md
@@ -214,6 +214,11 @@ active Claude turn. Follow-ups use the OpenChamber message queue (reorder +
 idle auto-send). Abort interrupts the active turn and always clears busy via
 `session.status: idle`.
 
+Harness events stamp `properties.directory` and SSE fan-out preserves the
+directory envelope so UI directory stores receive busy/idle (Stop + queue
+auto-send). `GET /api/session/status` overlays active Claude busy entries so
+OpenCode status polls cannot clear harness turns.
+
 ## Session titles on Claude
 
 Claude prompts bypass OpenCode `session.promptAsync`, so upstream

--- a/packages/web/server/lib/harness/events/emit.js
+++ b/packages/web/server/lib/harness/events/emit.js
@@ -29,6 +29,33 @@ export function resetHarnessEventObservers() {
 }
 
 /**
+ * Stamp directory into event properties so SSE consumers (which do not receive
+ * the broadcaster's options.directory) still route into the correct project
+ * store via resolveEventDirectory / parseSseEventEnvelope.
+ * @param {object} payload
+ * @param {string} directory
+ * @returns {object}
+ */
+export function withHarnessEventDirectory(payload, directory) {
+  if (!payload || typeof payload !== 'object' || !directory) {
+    return payload;
+  }
+  const properties = payload.properties && typeof payload.properties === 'object'
+    ? payload.properties
+    : {};
+  if (typeof properties.directory === 'string' && properties.directory.length > 0) {
+    return payload;
+  }
+  return {
+    ...payload,
+    properties: {
+      ...properties,
+      directory,
+    },
+  };
+}
+
+/**
  * @param {(payload: object, options?: { directory?: string, eventId?: string }) => void} broadcast
  * @param {object} payload
  * @param {{ directory?: string, eventId?: string }} [options]
@@ -44,10 +71,12 @@ export function emitHarnessEvent(broadcast, payload, options = {}) {
     ? options.eventId
     : undefined;
 
-  applyHarnessEventToSnapshot(payload, directory);
+  const scopedPayload = withHarnessEventDirectory(payload, directory);
+
+  applyHarnessEventToSnapshot(scopedPayload, directory);
   for (const observer of observers) {
     try {
-      observer(payload, directory);
+      observer(scopedPayload, directory);
     } catch (error) {
       console.warn('[harness] event observer failed:', error?.message || error);
     }
@@ -56,7 +85,7 @@ export function emitHarnessEvent(broadcast, payload, options = {}) {
   if (typeof broadcast !== 'function') {
     return;
   }
-  broadcast(payload, {
+  broadcast(scopedPayload, {
     ...(directory ? { directory } : {}),
     ...(eventId ? { eventId } : {}),
   });

--- a/packages/web/server/lib/harness/index.js
+++ b/packages/web/server/lib/harness/index.js
@@ -58,6 +58,9 @@ export {
   resetHarnessTurnSnapshots,
 } from './turn-snapshot.js';
 
+export { mergeHarnessBusyIntoSessionStatuses } from './session-status.js';
+export { mergeHarnessMessagesIntoSessionMessages } from './session-messages.js';
+
 export { createHarnessRouter } from './router.js';
 export { registerHarnessRoutes } from './routes.js';
 export { createClaudeCodeTranslator, buildClaudePrompt } from './translators/claude-code/index.js';

--- a/packages/web/server/lib/harness/index.js
+++ b/packages/web/server/lib/harness/index.js
@@ -54,6 +54,7 @@ export {
   getHarnessTurnSnapshot,
   getHarnessRecentMessages,
   isHarnessSessionWorking,
+  listHarnessBusyStatuses,
   resetHarnessTurnSnapshots,
 } from './turn-snapshot.js';
 

--- a/packages/web/server/lib/harness/routes.js
+++ b/packages/web/server/lib/harness/routes.js
@@ -11,6 +11,7 @@ import {
 } from './session-bindings.js';
 import { createHarnessRouter } from './router.js';
 import { mergeHarnessBusyIntoSessionStatuses } from './session-status.js';
+import { mergeHarnessMessagesIntoSessionMessages } from './session-messages.js';
 
 /**
  * @param {import('express').Express} app
@@ -62,6 +63,9 @@ export function registerHarnessRoutes(app, deps = {}) {
 
   // Overlay Claude busy onto OpenCode session status so UI poll/resync cannot
   // clear Stop / queue auto-send while a harness turn is active.
+  // Also overlay harness turn-snapshot messages onto /session/:id/message —
+  // OpenCode stores nothing for Claude turns, and an authoritative empty
+  // refetch would wipe optimistic / event-applied chat (and stall the queue).
   if (buildOpenCodeUrl) {
     app.get('/api/session/status', async (req, res, next) => {
       try {
@@ -85,6 +89,36 @@ export function registerHarnessRoutes(app, deps = {}) {
         }
         const openCodeStatuses = await response.json().catch(() => ({}));
         res.json(mergeHarnessBusyIntoSessionStatuses(openCodeStatuses, directory));
+      } catch {
+        next();
+      }
+    });
+
+    app.get('/api/session/:sessionId/message', async (req, res, next) => {
+      try {
+        const sessionId = typeof req.params?.sessionId === 'string' ? req.params.sessionId : '';
+        if (!sessionId) return next();
+        const directory = typeof req.query?.directory === 'string' ? req.query.directory : '';
+        const limit = typeof req.query?.limit === 'string' ? req.query.limit : '';
+        const base = buildOpenCodeUrl(`/session/${encodeURIComponent(sessionId)}/message`, '');
+        const params = new URLSearchParams();
+        if (directory) params.set('directory', directory);
+        if (limit) params.set('limit', limit);
+        const search = params.toString();
+        const url = search ? `${base}?${search}` : base;
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            ...getOpenCodeAuthHeaders(),
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+          return next();
+        }
+        const openCodeMessages = await response.json().catch(() => []);
+        res.json(mergeHarnessMessagesIntoSessionMessages(openCodeMessages, sessionId));
       } catch {
         next();
       }

--- a/packages/web/server/lib/harness/routes.js
+++ b/packages/web/server/lib/harness/routes.js
@@ -10,6 +10,7 @@ import {
   initSessionBindings,
 } from './session-bindings.js';
 import { createHarnessRouter } from './router.js';
+import { mergeHarnessBusyIntoSessionStatuses } from './session-status.js';
 
 /**
  * @param {import('express').Express} app
@@ -21,6 +22,8 @@ import { createHarnessRouter } from './router.js';
  * @param {typeof detectHarness} [deps.detectOne]
  * @param {Parameters<typeof initSessionBindings>[0]} [deps.sessionBindings]
  * @param {boolean} [deps.initBindings]
+ * @param {(path: string, directory?: string) => string} [deps.buildOpenCodeUrl]
+ * @param {() => Record<string, string>} [deps.getOpenCodeAuthHeaders]
  */
 export function registerHarnessRoutes(app, deps = {}) {
   const getBroadcast = typeof deps.getBroadcastGlobalUiEvent === 'function'
@@ -34,6 +37,10 @@ export function registerHarnessRoutes(app, deps = {}) {
   const detectAll = deps.detectAll || detectAllHarnesses;
   const detectOne = deps.detectOne || detectHarness;
   const router = deps.router || createHarnessRouter({ getBroadcast });
+  const buildOpenCodeUrl = typeof deps.buildOpenCodeUrl === 'function' ? deps.buildOpenCodeUrl : null;
+  const getOpenCodeAuthHeaders = typeof deps.getOpenCodeAuthHeaders === 'function'
+    ? deps.getOpenCodeAuthHeaders
+    : () => ({});
 
   if (deps.initBindings !== false) {
     initSessionBindings(deps.sessionBindings);
@@ -52,6 +59,37 @@ export function registerHarnessRoutes(app, deps = {}) {
       ...(error?.status ? { status: error.status } : {}),
     });
   };
+
+  // Overlay Claude busy onto OpenCode session status so UI poll/resync cannot
+  // clear Stop / queue auto-send while a harness turn is active.
+  if (buildOpenCodeUrl) {
+    app.get('/api/session/status', async (req, res, next) => {
+      try {
+        const directory = typeof req.query?.directory === 'string' ? req.query.directory : '';
+        const base = buildOpenCodeUrl('/session/status', '');
+        const url = directory
+          ? `${base}?directory=${encodeURIComponent(directory)}`
+          : base;
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            ...getOpenCodeAuthHeaders(),
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+          // Fall through to generic OpenCode proxy on upstream failure so the
+          // existing error contract is preserved when no harness overlay is needed.
+          return next();
+        }
+        const openCodeStatuses = await response.json().catch(() => ({}));
+        res.json(mergeHarnessBusyIntoSessionStatuses(openCodeStatuses, directory));
+      } catch {
+        next();
+      }
+    });
+  }
 
   app.get('/api/harness', async (_req, res) => {
     try {

--- a/packages/web/server/lib/harness/session-messages.js
+++ b/packages/web/server/lib/harness/session-messages.js
@@ -1,0 +1,67 @@
+/**
+ * Merge Claude harness turn-snapshot messages into OpenCode
+ * `/session/:id/message` responses. Harness turns are broadcast-only into the
+ * UI stream; OpenCode's message list is empty for those sessions, and an
+ * authoritative empty refetch would wipe optimistic / event-applied chat.
+ */
+
+import { getSessionBinding } from './session-bindings.js';
+import { getHarnessRecentMessages } from './turn-snapshot.js';
+
+/**
+ * @param {unknown} openCodeMessages
+ * @param {string} sessionId
+ * @returns {Array<{ info: object, parts?: object[] }>}
+ */
+export function mergeHarnessMessagesIntoSessionMessages(openCodeMessages, sessionId) {
+  const base = Array.isArray(openCodeMessages) ? [...openCodeMessages] : [];
+  if (typeof sessionId !== 'string' || !sessionId) {
+    return base;
+  }
+
+  const binding = getSessionBinding(sessionId);
+  if (binding?.harnessId !== 'claude-code') {
+    return base;
+  }
+
+  const harnessMessages = getHarnessRecentMessages(sessionId);
+  if (!Array.isArray(harnessMessages) || harnessMessages.length === 0) {
+    return base;
+  }
+
+  const byId = new Map();
+  for (const record of base) {
+    const id = record?.info?.id;
+    if (typeof id === 'string' && id) {
+      byId.set(id, record);
+    }
+  }
+
+  for (const record of harnessMessages) {
+    const id = record?.info?.id;
+    if (typeof id !== 'string' || !id) continue;
+    const existing = byId.get(id);
+    if (!existing) {
+      base.push(record);
+      byId.set(id, record);
+      continue;
+    }
+    const existingParts = Array.isArray(existing.parts) ? existing.parts.length : 0;
+    const nextParts = Array.isArray(record.parts) ? record.parts.length : 0;
+    if (nextParts >= existingParts) {
+      const index = base.indexOf(existing);
+      if (index >= 0) base[index] = record;
+      byId.set(id, record);
+    }
+  }
+
+  base.sort((left, right) => {
+    const leftId = typeof left?.info?.id === 'string' ? left.info.id : '';
+    const rightId = typeof right?.info?.id === 'string' ? right.info.id : '';
+    if (leftId < rightId) return -1;
+    if (leftId > rightId) return 1;
+    return 0;
+  });
+
+  return base;
+}

--- a/packages/web/server/lib/harness/session-messages.test.js
+++ b/packages/web/server/lib/harness/session-messages.test.js
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+  bindSession,
+  configureSessionBindings,
+  resetSessionBindings,
+} from './session-bindings.js';
+import {
+  applyHarnessEventToSnapshot,
+  resetHarnessTurnSnapshots,
+} from './turn-snapshot.js';
+import { mergeHarnessMessagesIntoSessionMessages } from './session-messages.js';
+
+describe('mergeHarnessMessagesIntoSessionMessages', () => {
+  beforeEach(() => {
+    resetSessionBindings();
+    configureSessionBindings({ persist: false, load: true });
+    resetHarnessTurnSnapshots();
+  });
+
+  it('returns OpenCode messages unchanged for non-Claude sessions', () => {
+    const openCode = [{ info: { id: 'msg_1', role: 'user', sessionID: 'ses_oc' }, parts: [] }];
+    expect(mergeHarnessMessagesIntoSessionMessages(openCode, 'ses_oc')).toEqual(openCode);
+  });
+
+  it('fills empty OpenCode lists from the Claude turn snapshot', () => {
+    bindSession({
+      sessionId: 'ses_claude',
+      harnessId: 'claude-code',
+      directory: '/repo',
+      target: { harnessId: 'claude-code', modelRef: 'haiku' },
+    });
+    applyHarnessEventToSnapshot({
+      type: 'message.updated',
+      properties: {
+        info: { id: 'msg_01_user', role: 'user', sessionID: 'ses_claude' },
+      },
+    }, '/repo');
+    applyHarnessEventToSnapshot({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'prt_1',
+          sessionID: 'ses_claude',
+          messageID: 'msg_01_user',
+          type: 'text',
+          text: 'hi',
+        },
+      },
+    }, '/repo');
+    applyHarnessEventToSnapshot({
+      type: 'message.updated',
+      properties: {
+        info: { id: 'msg_02_asst', role: 'assistant', sessionID: 'ses_claude' },
+      },
+    }, '/repo');
+    applyHarnessEventToSnapshot({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: 'prt_2',
+          sessionID: 'ses_claude',
+          messageID: 'msg_02_asst',
+          type: 'text',
+          text: 'READY1',
+        },
+      },
+    }, '/repo');
+
+    const merged = mergeHarnessMessagesIntoSessionMessages([], 'ses_claude');
+    expect(merged).toHaveLength(2);
+    expect(merged[0].info.id).toBe('msg_01_user');
+    expect(merged[0].parts?.[0]?.text).toBe('hi');
+    expect(merged[1].info.id).toBe('msg_02_asst');
+    expect(merged[1].parts?.[0]?.text).toBe('READY1');
+  });
+});

--- a/packages/web/server/lib/harness/session-status.js
+++ b/packages/web/server/lib/harness/session-status.js
@@ -1,0 +1,23 @@
+/**
+ * Merge Claude harness busy sessions into OpenCode `/session/status` snapshots.
+ * OpenCode does not own harness turns, so its status poll would otherwise report
+ * those sessions idle and the UI watchdog would clear Stop / queue auto-send.
+ */
+
+import { listHarnessBusyStatuses } from './turn-snapshot.js';
+
+/**
+ * @param {unknown} openCodeStatuses
+ * @param {string} [directory]
+ * @returns {Record<string, { type: string, [key: string]: unknown }>}
+ */
+export function mergeHarnessBusyIntoSessionStatuses(openCodeStatuses, directory) {
+  const base = openCodeStatuses && typeof openCodeStatuses === 'object' && !Array.isArray(openCodeStatuses)
+    ? { ...openCodeStatuses }
+    : {};
+  const harnessBusy = listHarnessBusyStatuses(directory);
+  for (const [sessionId, status] of Object.entries(harnessBusy)) {
+    base[sessionId] = status;
+  }
+  return base;
+}

--- a/packages/web/server/lib/harness/session-status.test.js
+++ b/packages/web/server/lib/harness/session-status.test.js
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+  applyHarnessEventToSnapshot,
+  listHarnessBusyStatuses,
+  resetHarnessTurnSnapshots,
+} from './turn-snapshot.js';
+import { mergeHarnessBusyIntoSessionStatuses } from './session-status.js';
+import { withHarnessEventDirectory } from './events/emit.js';
+
+describe('withHarnessEventDirectory', () => {
+  it('stamps directory onto event properties for SSE routing', () => {
+    const stamped = withHarnessEventDirectory({
+      type: 'session.status',
+      properties: {
+        sessionID: 'ses_1',
+        status: { type: 'busy' },
+      },
+    }, '/repo');
+    expect(stamped.properties.directory).toBe('/repo');
+    expect(stamped.properties.sessionID).toBe('ses_1');
+  });
+
+  it('preserves an existing properties.directory', () => {
+    const stamped = withHarnessEventDirectory({
+      type: 'session.status',
+      properties: {
+        sessionID: 'ses_1',
+        directory: '/kept',
+        status: { type: 'busy' },
+      },
+    }, '/repo');
+    expect(stamped.properties.directory).toBe('/kept');
+  });
+});
+
+describe('mergeHarnessBusyIntoSessionStatuses', () => {
+  beforeEach(() => {
+    resetHarnessTurnSnapshots();
+  });
+
+  it('overlays harness busy onto OpenCode status snapshots', () => {
+    applyHarnessEventToSnapshot({
+      type: 'session.status',
+      properties: { sessionID: 'ses_claude', status: { type: 'busy' } },
+    }, '/repo');
+
+    const merged = mergeHarnessBusyIntoSessionStatuses(
+      { ses_opencode: { type: 'busy' } },
+      '/repo',
+    );
+    expect(merged).toEqual({
+      ses_opencode: { type: 'busy' },
+      ses_claude: { type: 'busy' },
+    });
+    expect(listHarnessBusyStatuses('/repo')).toEqual({
+      ses_claude: { type: 'busy' },
+    });
+  });
+
+  it('does not invent idle harness entries', () => {
+    applyHarnessEventToSnapshot({
+      type: 'session.status',
+      properties: { sessionID: 'ses_claude', status: { type: 'idle' } },
+    }, '/repo');
+    expect(mergeHarnessBusyIntoSessionStatuses({}, '/repo')).toEqual({});
+  });
+});

--- a/packages/web/server/lib/harness/turn-snapshot.js
+++ b/packages/web/server/lib/harness/turn-snapshot.js
@@ -158,6 +158,27 @@ export function isHarnessSessionWorking(sessionId) {
 }
 
 /**
+ * Active harness session statuses for OpenCode `/session/status` overlays.
+ * Matches OpenCode's contract: only non-idle entries are returned.
+ *
+ * @param {string} [directory]
+ * @returns {Record<string, { type: 'busy' }>}
+ */
+export function listHarnessBusyStatuses(directory) {
+  const filter = typeof directory === 'string' && directory.trim()
+    ? directory.trim()
+    : '';
+  /** @type {Record<string, { type: 'busy' }>} */
+  const result = {};
+  for (const snap of snapshots.values()) {
+    if (snap.status !== 'busy') continue;
+    if (filter && snap.directory && snap.directory !== filter) continue;
+    result[snap.sessionId] = { type: 'busy' };
+  }
+  return result;
+}
+
+/**
  * Build OpenCode-shaped message list for session-goal ticks.
  * @param {string} sessionId
  * @returns {Array<{ info: object, parts: object[] }> | null}

--- a/packages/web/server/lib/opencode/feature-routes-runtime.js
+++ b/packages/web/server/lib/opencode/feature-routes-runtime.js
@@ -273,6 +273,8 @@ export const createFeatureRoutesRuntime = (dependencies) => {
       getOpenCodeReady: typeof getOpenCodeReady === 'function'
         ? getOpenCodeReady
         : () => true,
+      buildOpenCodeUrl,
+      getOpenCodeAuthHeaders,
       ...(harnessRouter ? { router: harnessRouter } : {}),
     });
     registerSessionGoalRoutes(app);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

After the previous Claude queue/stop PR, Stop still did not replace Send while Claude was working, Goal showed a literal `<system-reminder>` and looked idle, and queued follow-ups did not auto-send after Claude finished.

Root causes:

1. Harness SSE events dropped `directory`, so the UI routed Claude busy/idle/messages to `global` and skipped the chat directory store.
2. OpenCode `/session/status` polls cleared Claude busy because OpenCode does not own harness turns.
3. Goal intro synthetics were folded into Claude harness user text and rendered in chat.
4. Queue auto-send missed directory-only busy→idle edges and `TURN_IN_PROGRESS` left no wake timer.
5. OpenCode `/session/:id/message` is empty for Claude turns; authoritative empty materialization wiped chat and skipped further hydration because empty `[]` looked renderable / ChatContainer skipped ensure.

This PR stamps harness directories onto SSE, overlays Claude busy onto `/api/session/status`, overlays turn-snapshot messages onto `/api/session/:id/message`, hydrates empty local transcripts from that overlay, excludes Goal system reminders from Claude prompt text, restores/mirrors optimistic busy, and drives queue auto-send from directory + global status with TURN_IN_PROGRESS wake timers.

## Non-goals

- Persisting full multi-turn Claude history beyond the turn-snapshot last user/assistant
- Fixing intermittent hard-refresh paint until viewport resize (observed separately; new sessions paint correctly)
- In-place sticky `harnessId` rewrite on used sessions
- Claude steer into an active Agent SDK turn

## Affected surfaces

- `packages/web`: harness emit, SSE broadcaster, `/api/session/status` + `/api/session/:id/message` overlays, docs
- `packages/ui`: queue auto-send, optimistic send rollback + global busy mirror, empty-transcript hydration, ChatContainer ensure, Claude Goal synthetic filtering
- Runtimes: all shared UI + OpenChamber server surfaces. No Electron/native-only changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` + `openchamber-change-discipline` | Cross UI/server status/message contract | Minimal fix; focused tests; owning docs updated |
| `sync-state-invariants` | Busy/idle, queue auto-send, optimistic rollback, empty≠stuck | Prefer live channels; empty OpenCode list no longer permanently blocks Claude hydration |
| `ui-api-decoupling` | `/api/session/*` overlays before OpenCode proxy | Overlay registered before proxy; no Anthropic HTTP from UI |
| `relay-transport` / event-stream docs | SSE directory envelope | SSE mirrors WS directory scoping for synthetic events |
| Harness DOCUMENTATION.md | Owning module contract | Documented directory stamp + status/message overlays |

## Validation

| Check | Result |
|---|---|
| Focused harness + queue + message-loader tests | Pass |
| `bun run type-check` (`packages/ui`) | Pass |
| Computer-use Haiku: Stop while busy | Pass (new sessions) |
| Computer-use Haiku: queue auto-send after idle | Pass — queued follow-up auto-sent; assistant replied `QUEUED_OK` |
| Computer-use Haiku: hard-refresh existing session paint | Intermittent — messages hydrate but sometimes need viewport resize to paint |

## Visual evidence

Behavioral (no redesign):

- Claude busy: Send becomes Stop
- Queue chip while busy → after idle, first queued message auto-sends
- Goal on Claude: no visible `<system-reminder>` user bubble

## Risks and failure behavior

- `/api/session/status` and `/api/session/:id/message` fall through to the generic OpenCode proxy if upstream fetch fails
- Message overlay only injects the turn-snapshot last user/assistant (not full history)
- Empty local transcripts get one forced hydration attempt (`emptyHydrated`) to avoid infinite refetch loops
- Queue auto-send on `TURN_IN_PROGRESS` marks previous busy and arms a short wake timer

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0d30e76-34ec-4eab-9f27-ec21c390ae0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0d30e76-34ec-4eab-9f27-ec21c390ae0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

