### PR TITLE
fix(ui): deny open permission prompts on send

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1957,8 +1957,20 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         }
 
         if (currentSessionId && !queuedOnly) {
-            const dismissedQuestions = await sessionActions.dismissOpenQuestionsForSession(currentSessionId);
-            if (dismissedQuestions) {
+            // Sending is authoritative for blocking prompts: deny pending
+            // permissions and dismiss open questions for the session subtree,
+            // then queue the message once if either was open. The deny/clear
+            // vanishes the card instantly (optimistic); rejecting unblocks the
+            // agent's tool but does NOT end its turn, so a direct send would
+            // race with the still-active run and be silently discarded by the
+            // OpenCode runner. Instead we queue; the queued-message auto-send
+            // hook delivers it as the next turn once the rejected turn winds
+            // down and the session returns to idle (parity with #1740).
+            const [deniedPermissions, dismissedQuestions] = await Promise.all([
+                sessionActions.dismissOpenPermissionsForSession(currentSessionId),
+                sessionActions.dismissOpenQuestionsForSession(currentSessionId),
+            ]);
+            if (deniedPermissions || dismissedQuestions) {
                 handleQueueMessage();
                 return;
             }

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -9,6 +9,7 @@ const registeredSessionDirectories: Array<{ sessionID: string; directory: string
 let sessionRevertResult: { data?: unknown; error?: unknown; response?: { status?: number } } = {}
 let questionReplyError: unknown | null = null
 let questionRejectError: unknown | null = null
+let permissionReplyError: unknown | null = null
 let sessionShareResult: { data?: unknown; error?: unknown; response?: { status?: number } } = {}
 let sessionUpdateResult: { data?: unknown; error?: unknown; response?: { status?: number } } = {}
 let sessionMessagesResult: { data?: unknown; error?: unknown; response?: { status?: number } } = { data: [] }
@@ -22,6 +23,10 @@ const mockScopedClient = {
   permission: {
     reply: mock((params: Record<string, unknown>) => {
       replyCalls.push({ method: "permission.reply", params })
+      if (permissionReplyError) {
+        const status = (permissionReplyError as { status?: number })?.status ?? 404
+        return Promise.resolve({ error: permissionReplyError, response: { status } })
+      }
       return Promise.resolve({ data: true })
     }),
   },
@@ -85,6 +90,10 @@ const mockSdk = {
   permission: {
     reply: mock((params: Record<string, unknown>) => {
       replyCalls.push({ method: "permission.reply", params })
+      if (permissionReplyError) {
+        const status = (permissionReplyError as { status?: number })?.status ?? 404
+        return Promise.resolve({ error: permissionReplyError, response: { status } })
+      }
       return Promise.resolve({ data: true })
     }),
   },
@@ -970,6 +979,7 @@ describe("dismissPermission passes directory", () => {
     replyCalls.length = 0
     scopedClientDirectories.length = 0
     questionReplyError = null
+    permissionReplyError = null
   })
 
   test("passes directory and reply=reject", async () => {
@@ -1084,6 +1094,17 @@ function buildQuestion(id: string, sessionId: string): QuestionRequest {
   }
 }
 
+function buildPermission(id: string, sessionId: string): PermissionRequest {
+  return {
+    id,
+    sessionID: sessionId,
+    permission: "edit",
+    patterns: [],
+    metadata: {},
+    always: [],
+  }
+}
+
 describe("dismissOpenQuestionsForSession", () => {
   beforeEach(() => {
     replyCalls.length = 0
@@ -1155,5 +1176,143 @@ describe("dismissOpenQuestionsForSession", () => {
     expect(rejectCalls[0].params.requestID).toBe("q-stale")
     // The stale entry is cleared from the store even though the server reported not-found.
     expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+})
+
+describe("dismissPermission not-found handling", () => {
+  beforeEach(() => {
+    replyCalls.length = 0
+    scopedClientDirectories.length = 0
+    permissionReplyError = null
+  })
+
+  test("clears the stale permission and rethrows on PermissionNotFoundError", async () => {
+    const permission = buildPermission("perm-stale", "session-a")
+    const store = createStore({ "session-a": [permission] })
+    const childStores = createChildStores([["/test/project", store]])
+    permissionReplyError = Object.assign(new Error("permission.reply failed (404): PermissionNotFoundError"), { status: 404 })
+
+    const { setActionRefs, dismissPermission } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    await expect(dismissPermission("session-a", "perm-stale")).rejects.toThrow()
+    expect(replyCalls.filter((call) => call.method === "permission.reply")).toHaveLength(1)
+    // The stale entry is cleared from the store even though the server reported not-found.
+    expect(store.getState().permission["session-a"]).toBe(undefined)
+  })
+
+  test("does not clear the store on a non-not-found failure (rethrow only)", async () => {
+    const permission = buildPermission("perm-500", "session-a")
+    const store = createStore({ "session-a": [permission] })
+    const childStores = createChildStores([["/test/project", store]])
+    permissionReplyError = Object.assign(new Error("permission.reply failed (500)"), { status: 500 })
+
+    const { setActionRefs, dismissPermission } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    await expect(dismissPermission("session-a", "perm-500")).rejects.toThrow()
+    // A non-not-found failure leaves store reconciliation to the next server event.
+    expect(store.getState().permission["session-a"]).toHaveLength(1)
+  })
+})
+
+describe("dismissOpenPermissionsForSession", () => {
+  beforeEach(() => {
+    replyCalls.length = 0
+    scopedClientDirectories.length = 0
+    permissionReplyError = null
+  })
+
+  test("returns false and rejects nothing when no permissions are pending", async () => {
+    const store = createStore({}, { session: [{ id: "session-a", time: { created: 1 } } as Session] })
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { setActionRefs, dismissOpenPermissionsForSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    const dismissed = await dismissOpenPermissionsForSession("session-a")
+
+    expect(dismissed).toBe(false)
+    expect(replyCalls.filter((call) => call.method === "permission.reply")).toHaveLength(0)
+  })
+
+  test("rejects every pending permission in the session subtree (root + subagent child)", async () => {
+    const rootPermission = buildPermission("perm-root", "session-a")
+    const childPermission = buildPermission("perm-child", "session-child")
+    const store = createStore({
+      "session-a": [rootPermission],
+      "session-child": [childPermission],
+    }, {
+      session: [
+        { id: "session-a", time: { created: 1 } } as Session,
+        { id: "session-child", parentID: "session-a", time: { created: 2 } } as Session,
+      ],
+    })
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { setActionRefs, dismissOpenPermissionsForSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    const dismissed = await dismissOpenPermissionsForSession("session-a")
+
+    expect(dismissed).toBe(true)
+    const replyCallsForPermissions = replyCalls.filter((call) => call.method === "permission.reply")
+    expect(replyCallsForPermissions).toHaveLength(2)
+    const rejectedIds = replyCallsForPermissions.map((call) => call.params.requestID).sort()
+    expect(rejectedIds).toEqual(["perm-child", "perm-root"])
+    expect(replyCallsForPermissions.every((call) => call.params.reply === "reject")).toBe(true)
+    // Optimistic clear: the permissions are removed from the local store so the
+    // prompt disappears instantly, without waiting for the reject round-trip.
+    expect(store.getState().permission["session-a"]).toBe(undefined)
+    expect(store.getState().permission["session-child"]).toBe(undefined)
+  })
+
+  test("swallows PermissionNotFoundError so a stranded permission never blocks the send", async () => {
+    const stalePermission = buildPermission("perm-stale", "session-a")
+    const store = createStore({ "session-a": [stalePermission] }, {
+      session: [{ id: "session-a", time: { created: 1 } } as Session],
+    })
+    const childStores = createChildStores([["/test/project", store]])
+    permissionReplyError = Object.assign(new Error("permission.reply failed (404): PermissionNotFoundError"), { status: 404 })
+
+    const { setActionRefs, dismissOpenPermissionsForSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    const dismissed = await dismissOpenPermissionsForSession("session-a")
+
+    expect(dismissed).toBe(true)
+    const replyCallsForPermissions = replyCalls.filter((call) => call.method === "permission.reply")
+    expect(replyCallsForPermissions).toHaveLength(1)
+    expect(replyCallsForPermissions[0].params.requestID).toBe("perm-stale")
+    // The stale entry is cleared from the store even though the server reported not-found.
+    expect(store.getState().permission["session-a"]).toBe(undefined)
+  })
+
+  test("swallows and logs a non-not-found reject failure so the send is never blocked", async () => {
+    const permission = buildPermission("perm-500", "session-a")
+    const store = createStore({ "session-a": [permission] }, {
+      session: [{ id: "session-a", time: { created: 1 } } as Session],
+    })
+    const childStores = createChildStores([["/test/project", store]])
+    permissionReplyError = Object.assign(new Error("permission.reply failed (500)"), { status: 500 })
+
+    const { setActionRefs, dismissOpenPermissionsForSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project")
+
+    const errors: unknown[][] = []
+    const originalError = console.error
+    console.error = (...args: unknown[]) => { errors.push(args) }
+    try {
+      const dismissed = await dismissOpenPermissionsForSession("session-a")
+
+      expect(dismissed).toBe(true)
+      const replyCallsForPermissions = replyCalls.filter((call) => call.method === "permission.reply")
+      expect(replyCallsForPermissions).toHaveLength(1)
+      expect(replyCallsForPermissions[0].params.requestID).toBe("perm-500")
+      expect(errors).toHaveLength(1)
+      expect(String(errors[0]?.[0])).toContain("[session-actions]")
+    } finally {
+      console.error = originalError
+    }
   })
 })

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -553,6 +553,56 @@ function removeQuestionRequestFromChildStores(sessionId: string, requestId: stri
   return removed
 }
 
+function isPermissionRequestNotFoundError(error: unknown): boolean {
+  if (error && typeof error === "object") {
+    const status = (error as { status?: unknown }).status
+    if (status === 404) return true
+  }
+
+  let message = ""
+  if (error instanceof Error) {
+    message = error.message
+  } else if (typeof error === "string") {
+    message = error
+  }
+
+  return /Permission(?:\.)?NotFoundError|Permission request not found/i.test(message)
+}
+
+function removePermissionRequestFromChildStores(sessionId: string, requestId: string): boolean {
+  const stores = _childStores
+  if (!stores || !requestId) return false
+
+  let removed = false
+  for (const [, store] of stores.children) {
+    const current = store.getState().permission ?? {}
+    let nextPermission: typeof current | null = null
+    const sessionIds = new Set([sessionId, ...Object.keys(current)].filter(Boolean))
+
+    for (const candidateSessionId of sessionIds) {
+      const requests = current[candidateSessionId]
+      if (!requests?.length) continue
+
+      const nextRequests = requests.filter((request) => request.id !== requestId)
+      if (nextRequests.length === requests.length) continue
+
+      nextPermission ??= { ...current }
+      if (nextRequests.length > 0) {
+        nextPermission[candidateSessionId] = nextRequests
+      } else {
+        delete nextPermission[candidateSessionId]
+      }
+      removed = true
+    }
+
+    if (nextPermission) {
+      store.setState({ permission: nextPermission })
+    }
+  }
+
+  return removed
+}
+
 function getRequestReplyClient(
   type: "permission" | "question",
   sessionId: string,
@@ -1093,14 +1143,87 @@ export async function dismissPermission(
   const directory = resolveDirectoryForBlockingRequest("permission", sessionId, requestId)
     || getSessionDirectory(sessionId)
     || dir()
-  const result = await getRequestReplyClient("permission", sessionId, requestId).permission.reply({
-    requestID: requestId,
-    reply: "reject",
-    ...(directory ? { directory } : {}),
-  })
-  if (assertSdkData(result, "permission.reply") !== true) {
-    throw new Error("Permission dismissal failed")
+  try {
+    const result = await getRequestReplyClient("permission", sessionId, requestId).permission.reply({
+      requestID: requestId,
+      reply: "reject",
+      ...(directory ? { directory } : {}),
+    })
+    if (assertSdkData(result, "permission.reply") !== true) {
+      throw new Error("Permission dismissal failed")
+    }
+  } catch (error) {
+    if (isPermissionRequestNotFoundError(error)) {
+      removePermissionRequestFromChildStores(sessionId, requestId)
+    }
+    throw error
   }
+}
+
+/**
+ * Dismiss every pending permission for the session subtree rooted at `sessionId`
+ * (the session itself plus any subagent children). Used by the chat send path:
+ * sending a message while a permission prompt is open must cancel/supersede the
+ * open permission so it cannot linger or block the new turn.
+ *
+ * The permissions are removed from the local store OPTIMISTICALLY (before any
+ * network call) so the prompt disappears instantly instead of waiting on the
+ * `permission.reply` round-trip. Each permission is then formally rejected on
+ * the backend via `permission.reply` with `reply: "reject"`, which fires
+ * `permission.replied` for reconciliation.
+ *
+ * Returns true when at least one permission was dismissed. Rejection failures are
+ * swallowed (a stranded permission must never block the send);
+ * PermissionNotFoundError also clears the stale entry from the child store via
+ * {@link dismissPermission}.
+ *
+ * NOTE: rejecting unblocks the agent's tool but does NOT end its turn. Callers
+ * that need to send the next message right away (the chat send path) must also
+ * queue the message so the OpenCode runner reaches `idle` — otherwise the new
+ * prompt arrives while the run is still active and is discarded by the runner's
+ * `ensureRunning`.
+ */
+export async function dismissOpenPermissionsForSession(sessionId: string): Promise<boolean> {
+  if (!sessionId) return false
+  const stores = _childStores
+  if (!stores) return false
+
+  const toDismiss: Array<{ sessionId: string; requestId: string }> = []
+  for (const [, store] of stores.children) {
+    const state = store.getState()
+    const scopedIds = computeSubtreeIds(state.session, sessionId)
+    if (scopedIds.size === 0) continue
+    const permissionsBySession = state.permission ?? {}
+    for (const scopedId of scopedIds) {
+      const requests = permissionsBySession[scopedId]
+      if (!requests) continue
+      for (const request of requests) {
+        toDismiss.push({ sessionId: scopedId, requestId: request.id })
+      }
+    }
+  }
+
+  if (toDismiss.length === 0) return false
+
+  // Optimistically clear the permissions from the local store so the prompt
+  // disappears immediately, before the reject round-trip.
+  for (const { sessionId: scopedSessionId, requestId } of toDismiss) {
+    removePermissionRequestFromChildStores(scopedSessionId, requestId)
+  }
+
+  await Promise.all(
+    toDismiss.map(async ({ sessionId: scopedSessionId, requestId }) => {
+      try {
+        await dismissPermission(scopedSessionId, requestId)
+      } catch (error) {
+        if (isPermissionRequestNotFoundError(error)) return
+        // Swallow: a failed dismissal must not block the send. The next
+        // permission.asked / permission.replied event reconciles the store.
+        console.error("[session-actions] Failed to dismiss open permission on send:", error)
+      }
+    }),
+  )
+  return true
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Intent

Sending a message while a permission prompt is open did not deny the pending permission, so the user could send straight into a still-active, permission-blocked agent turn. The new prompt then raced with the run and could be silently discarded by the OpenCode runner's `ensureRunning`, the exact collision #1740 avoided for question prompts by dismissing questions on send.

This PR makes the send action authoritative for permission prompts, mirroring #1740: hitting send while a permission prompt is open denies every pending permission in the session subtree (optimistically, then formally via `permission.reply` reject) and queues the message for next-turn delivery via the existing `useQueuedMessageAutoSend` hook.

## Non-goals

- No change to the permission card UI, toasts, or the `permission.asked`/`permission.replied` wire format.
- No change to auto-accept/auto-deny policy; this only denies on an explicit user send.
- The queued-only and auto-review send paths are untouched (the deny runs only on the non-queued path, matching #1740).
- No server-side OpenCode runner change; the `ensureRunning` discard race is avoided by queueing, inherited from #1740.

## Affected surfaces

- **Package:** `packages/ui` only (shared, consumed by web, desktop, VS Code, hosted and Capacitor mobile).
- **Files:** `packages/ui/src/sync/session-actions.ts`, `packages/ui/src/components/chat/ChatInput.tsx`, `packages/ui/src/sync/session-actions.test.ts`.
- **Runtimes:** all runtimes that mount the shared app via `AppEffects`, where `useQueuedMessageAutoSend` is already mounted. No per-runtime code is added.
- **User-visible state:** when a permission card is open and the user presses send, the card vanishes immediately and the message is queued, delivered as the next turn once the rejected turn winds down.
- **Persisted/external contracts:** none changed. Reuses the existing `permission.reply` SDK call and the existing `state.permission` store shape.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Source change in `packages/ui` (module-contract: new exported function) | Classified as module-contract risk; smallest complete change; new export `dismissOpenPermissionsForSession` has a real consumer (`ChatInput`); `isPermissionRequestNotFoundError` kept private (no external consumer) after `bun run dead-code` flagged a dead export |
| `ui-api-decoupling` | Shared UI calls the OpenCode SDK via `permission.reply` | Reuses the existing `permission.reply` path through `getRequestReplyClient` / scoped client; no direct fetch, no new runtime API |
| `sync-state-invariants` | Optimistic store mutation + event reconciliation on the send path | Optimistic clear precedes the reject round-trip; `permission.replied` reconciles; not-found/already-resolved clears the stale local entry; a failed deny never blocks the send (swallow + log), next event reconciles |
| `AGENTS.md` correctness invariants | "Never let fetch failure masquerade as authoritative empty success"; "Make partial results/rollback explicit" | Each reject failure is swallowed-and-logged, not treated as success; the stale-entry clear is explicit; one failed permission does not block sibling rejects (`Promise.all`) |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/sync/session-actions.test.ts` | 35 pass / 0 fail (165 expectations), incl. 6 new tests (no-op, subtree root+child optimistic clear, not-found, 500/log, `dismissPermission` not-found, `dismissPermission` 500 no-clear) |
| `bun run type-check:ui` (`tsc --noEmit`) | clean |
| `bun run lint` on the three touched files | clean |
| `bun run dead-code` (knip) | no flags for new code after making `isPermissionRequestNotFoundError` private |
| `bun test packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts` | 9 pass / 0 fail (no regression in the delivery hook) |

Not verified: full root `bun run build`. Runtime before/after behavior IS verified — see Visual evidence. Static checks alone do not prove runtime correctness.

## Visual evidence

Runtime-verified against this branch's fixed UI (worktree HMR dev server + managed OpenCode): a bash command targeting an external path (`cat /etc/hostname`) triggers an `external_directory` permission prompt; pressing Enter on a second message denies the pending permission and queues the message (the send button is disabled while a prompt is open, so Enter invokes `handleSubmit` directly — the exact path the fix intercepts). DOM assertions confirmed the card `appeared → vanished` on send, and the new user message queued.

Two before/after screenshots are captured locally.
The permission card vanishes within the same tick as the send (optimistic clear in `dismissOpenPermissionsForSession`), matching the question-dismiss parity from #1740.

<img width="1440" height="900" alt="pr-1958-before" src="https://github.com/user-attachments/assets/1e767faf-e71a-4c70-90f3-05bf3b81b79e" />

<img width="1440" height="900" alt="pr-1958-after" src="https://github.com/user-attachments/assets/3e6b596d-b6f3-410f-b8c9-a19a78921cf8" />


## Risks and failure behavior

- **Failed deny never blocks the send:** `dismissOpenPermissionsForSession` swallows non-not-found reject errors and logs them (`console.error`); the message still queues and auto-sends. The next `permission.asked`/`permission.replied` event reconciles the store.
- **Not-found / already-resolved:** detected via HTTP 404 / `PermissionNotFoundError`; the stale local entry is cleared so the card does not linger; swallowed, never blocks send.
- **Both a permission and a question open:** both are dismissed in one `Promise.all` (disjoint store slices) and the message queues exactly once (`handleQueueMessage()` called once on the OR of the two booleans).
- **Turn not ending after deny:** inherited from #1740's queue design. Rejecting unblocks the tool but does not end the turn, so the message is queued and `useQueuedMessageAutoSend` delivers it when the session returns to idle regardless of how the turn ends.
- **Rollback/cleanup:** all changes are additive (new function, two private helpers, one extended primitive with unchanged success path, one localized `handleSubmit` block); reverting the branch restores prior behavior with no migration.
- **Cross-runtime:** the change is in shared `packages/ui`; no runtime-specific code or wiring is added.

Closes #1958

---

SDLC phase: pr (FEAT-1958 #1958)
Created with [create-pr](https://github.com/tomzx/agents/blob/37401e76e3f3145f5aad7354694974d4246f126b/skills/create-pr/SKILL.md) via glm-5.2 (`37401e7`)



