### PR TITLE
fix(ui): respect Markdown text range boundaries

### DIFF
--- a/packages/ui/src/components/chat/MarkdownRendererImpl.tsx
+++ b/packages/ui/src/components/chat/MarkdownRendererImpl.tsx
@@ -32,6 +32,7 @@ import {
   type MermaidControlOptions,
   type MermaidRender,
 } from './markdown/decorate';
+import { findTextPosition } from './markdown/textPosition';
 import { createMermaidViewerRegistry, MERMAID_BLOCK_SELECTOR, shouldRefreshMermaidViewers } from './markdown/mermaidViewer';
 import {
   BLOCK_PATH_TOKEN_RE,
@@ -228,21 +229,6 @@ const isLikelyFilePath = (value: string): boolean => {
   return isLikelyFilePathValue(parsed.path);
 };
 
-const findTextPosition = (textNodes: Text[], targetOffset: number): { node: Text; offset: number } | null => {
-  let currentOffset = 0;
-
-  for (const node of textNodes) {
-    const nextOffset = currentOffset + node.data.length;
-    if (targetOffset <= nextOffset) {
-      return { node, offset: Math.max(0, targetOffset - currentOffset) };
-    }
-    currentOffset = nextOffset;
-  }
-
-  const lastNode = textNodes.at(-1);
-  return lastNode ? { node: lastNode, offset: lastNode.data.length } : null;
-};
-
 const unwrapBlockCodePathTokens = (container: HTMLElement): void => {
   const tokenSpans = container.querySelectorAll<HTMLElement>(BLOCK_PATH_TOKEN_SELECTOR);
   for (const span of Array.from(tokenSpans)) {
@@ -326,8 +312,8 @@ const wrapBlockCodePathTokens = (container: HTMLElement): void => {
     }
 
     for (const { start, end, raw } of matches.reverse()) {
-      const startPosition = findTextPosition(textNodes, start);
-      const endPosition = findTextPosition(textNodes, end);
+      const startPosition = findTextPosition(textNodes, start, 'right');
+      const endPosition = findTextPosition(textNodes, end, 'left');
       if (!startPosition || !endPosition) {
         continue;
       }

--- a/packages/ui/src/components/chat/markdown/decorate.ts
+++ b/packages/ui/src/components/chat/markdown/decorate.ts
@@ -3,6 +3,7 @@ import { getExternalFaviconUrl, isExternalHttpUrl, isLoopbackHttpUrl } from '@/l
 import { dropdownMenuItemClass, dropdownMenuPopupClass } from '@/components/ui/dropdown-menu.styles';
 import type { IconName } from '@/components/icon/icons';
 import { getMermaidViewerController } from './mermaidViewer';
+import { findTextPosition } from './textPosition';
 
 // ---------------------------------------------------------------------------
 // Shared decoration context
@@ -138,19 +139,6 @@ const collectTextNodes = (root: HTMLElement): Text[] => {
   return nodes;
 };
 
-const findTextPosition = (nodes: Text[], targetOffset: number): { node: Text; offset: number } | null => {
-  let offset = 0;
-  for (const node of nodes) {
-    const nextOffset = offset + node.data.length;
-    if (targetOffset <= nextOffset) {
-      return { node, offset: Math.max(0, targetOffset - offset) };
-    }
-    offset = nextOffset;
-  }
-  const last = nodes.at(-1);
-  return last ? { node: last, offset: last.data.length } : null;
-};
-
 export const syncMarkdownCodeLineNumbers = (root: HTMLElement): void => {
   const wrappers = root.querySelectorAll<HTMLElement>('[data-component="markdown-code"]');
   for (const wrapper of Array.from(wrappers)) {
@@ -174,8 +162,8 @@ export const syncMarkdownCodeLineNumbers = (root: HTMLElement): void => {
       const lineEl = numbers[index];
       if (!lineEl) continue;
 
-      const start = findTextPosition(textNodes, lineStart);
-      const end = findTextPosition(textNodes, lineEnd);
+      const start = findTextPosition(textNodes, lineStart, 'right');
+      const end = findTextPosition(textNodes, lineEnd, 'left');
       if (!start || !end || lineStart === lineEnd) {
         lineEl.style.height = `${lineHeight}px`;
         lineEl.style.lineHeight = `${lineHeight}px`;

--- a/packages/ui/src/components/chat/markdown/textPosition.test.ts
+++ b/packages/ui/src/components/chat/markdown/textPosition.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+
+import { findTextPosition } from './textPosition';
+
+describe('findTextPosition', () => {
+  for (const { label, trailingNodes } of [
+    { label: 'without a trailing newline', trailingNodes: [] },
+    { label: 'with a trailing newline', trailingNodes: [{ data: '\n' }] },
+  ]) {
+    test(`maps a second-line match start to visible content ${label}`, () => {
+      const firstLine = { data: 'output:' };
+      const lineBreak = { data: '\n' };
+      const secondLine = { data: 'src/index.ts:12' };
+      const nodes = [firstLine, lineBreak, secondLine, ...trailingNodes];
+      const startOffset = firstLine.data.length + lineBreak.data.length;
+
+      expect(findTextPosition(nodes, startOffset, 'right')).toEqual({ node: secondLine, offset: 0 });
+      expect(findTextPosition(nodes, startOffset + secondLine.data.length, 'left')).toEqual({
+        node: secondLine,
+        offset: secondLine.data.length,
+      });
+    });
+  }
+
+  test('keeps an end boundary on the preceding text node', () => {
+    const firstLine = { data: 'src/index.ts:12' };
+    const lineBreak = { data: '\n' };
+
+    expect(findTextPosition([firstLine, lineBreak], firstLine.data.length, 'left')).toEqual({
+      node: firstLine,
+      offset: firstLine.data.length,
+    });
+  });
+});

--- a/packages/ui/src/components/chat/markdown/textPosition.ts
+++ b/packages/ui/src/components/chat/markdown/textPosition.ts
@@ -1,0 +1,22 @@
+type TextNodeLike = { data: string };
+
+type TextBoundaryAffinity = 'left' | 'right';
+
+export const findTextPosition = <T extends TextNodeLike>(
+  textNodes: T[],
+  targetOffset: number,
+  affinity: TextBoundaryAffinity,
+): { node: T; offset: number } | null => {
+  let currentOffset = 0;
+
+  for (const node of textNodes) {
+    const nextOffset = currentOffset + node.data.length;
+    if (targetOffset < nextOffset || (targetOffset === nextOffset && affinity === 'left')) {
+      return { node, offset: Math.max(0, targetOffset - currentOffset) };
+    }
+    currentOffset = nextOffset;
+  }
+
+  const lastNode = textNodes.at(-1);
+  return lastNode ? { node: lastNode, offset: lastNode.data.length } : null;
+};


### PR DESCRIPTION
## Intent

<!-- What user or maintainer problem does this solve? What behavior changes? -->

Fix exact text-node boundary mapping in Markdown code blocks. A range start immediately after `\n` previously resolved to the preceding newline node, which can mis-measure wrapped line heights in WebKit and can move a second-line file reference into the wrong DOM container.

Range starts now use right affinity and range ends use left affinity. This is the minimal alternative to the structural grid/rendering optimization in #2444; maintainers can choose between the targeted boundary fix here and the broader layout simplification there.

## Non-goals

<!-- What nearby behavior is intentionally outside this PR? Write "None" only when the scope is unambiguous. -->

- No code-block DOM, CSS, clipboard, screenshot, Shiki, or runtime changes.
- No removal of the existing Range/RAF/ResizeObserver line-height measurement path.

## Affected surfaces

<!-- Name affected packages, runtimes, user-visible states, and persisted/external contracts. Explain why an apparently applicable runtime is unaffected. -->

- Shared Markdown code-block line-number measurement and file-reference annotation in `packages/ui`.
- Applies to all UI runtimes through the existing shared renderer; no persisted or external contracts change.

## Repository guidance

<!-- List the AGENTS.md rules, matching project skills, required skill references, and nearest README/DOCUMENTATION.md files used for this change. Explain why each applies and the important constraints you followed. Do not merely list filenames. -->

| Guidance | Application |
|---|---|
| `AGENTS.md` and `openchamber-change-discipline` | Keeps the fix limited to the confirmed boundary invariant and focused tests |
| `performance-engineering` | Preserves the existing measurement path without adding work; #2444 contains the separate structural optimization |
| Message-part documentation | Keeps the change in the shared Markdown renderer owner |

## Validation

<!-- Report exact commands/manual checks and results. State what was not verified. Do not claim runtime behavior from type-check/lint alone. -->

- `bun test src/components/chat/markdown/textPosition.test.ts src/components/chat/MarkdownRendererImpl.test.ts`: 16 passed.
- `bun run type-check` in `packages/ui`: passed.
- `bun run lint` in `packages/ui`: passed.
- `bun run dead-code`: completed with existing non-blocking findings.

Not run: Safari or Electron manual regression.

## Visual evidence

<!-- User-visible change: attach current before/after screenshots or recordings for the affected desktop/mobile, narrow/wide, theme, and interaction states. No visible change: explain concretely why the diff cannot affect rendered behavior. -->

The original mismatch and the structural alternative are documented in #2444. No dedicated current-HEAD screenshot is attached for this minimal branch.

## Risks and failure behavior

<!-- Cover relevant failure, rollback, cleanup, compatibility, security, performance, data-loss, and cross-runtime concerns. State "None identified" only with a concrete reason. -->

- The helper is shared by line-height measurement and file-reference annotation, with focused tests covering second-line starts, trailing newlines, and end boundaries.
- Rollback is a single commit revert; no data, network, auth, or runtime boundary changes are involved.
