### PR TITLE
fix(ui): preserve Markdown code selections

### DIFF
--- a/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
+++ b/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
@@ -15,6 +15,7 @@ import { resolveProjectForSessionDirectory } from '@/lib/projectResolution';
 import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
 import { isVSCodeRuntime } from '@/lib/desktop';
 import { useI18n } from '@/lib/i18n';
+import { rangeToMarkdown, trimSelectionValue, wrapMarkdownSelectionForChat } from './selectionMarkdown';
 
 interface TextSelectionMenuProps {
   containerRef: React.RefObject<HTMLElement | null>;
@@ -44,167 +45,6 @@ const appendDistilledInsightToNotes = (existingNotes: string, insight: string): 
 
 const DESKTOP_MENU_SIDE_MARGIN_PX = 8;
 const DESKTOP_MENU_FALLBACK_WIDTH_PX = 280;
-const BLOCK_TAGS = new Set([
-  'address', 'article', 'aside', 'blockquote', 'dd', 'div', 'dl', 'dt',
-  'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3',
-  'h4', 'h5', 'h6', 'header', 'hr', 'li', 'main', 'nav', 'ol', 'p', 'pre',
-  'section', 'table', 'ul',
-]);
-
-const normalizeLineBreaks = (value: string): string => value.replace(/\r\n?/g, '\n');
-
-const trimSelectionValue = (value: string): string => normalizeLineBreaks(value).trim();
-
-const textToMarkdownInline = (value: string): string => value.replace(/\s+/g, ' ').trim();
-
-const renderInlineMarkdownNode = (node: Node): string => {
-  if (node.nodeType === Node.TEXT_NODE) {
-    return textToMarkdownInline(node.textContent || '');
-  }
-
-  if (node.nodeType !== Node.ELEMENT_NODE) {
-    return '';
-  }
-
-  const element = node as HTMLElement;
-  const tag = element.tagName.toLowerCase();
-  const childText = Array.from(element.childNodes)
-    .map((child) => renderInlineMarkdownNode(child))
-    .join('')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-  if (!childText && tag !== 'br') {
-    return '';
-  }
-
-  if (tag === 'br') return '\n';
-  if (tag === 'strong' || tag === 'b') return `**${childText}**`;
-  if (tag === 'em' || tag === 'i') return `*${childText}*`;
-  if (tag === 'code') return `\`${childText.replace(/`/g, '\\`')}\``;
-  if (tag === 'a') {
-    const href = element.getAttribute('href');
-    return href ? `[${childText}](${href})` : childText;
-  }
-
-  return childText;
-};
-
-const renderListMarkdown = (list: HTMLElement, ordered: boolean): string => {
-  const items = Array.from(list.children).filter(
-    (child): child is HTMLElement => child instanceof HTMLElement && child.tagName.toLowerCase() === 'li'
-  );
-
-  return items
-    .map((item, index) => {
-      const prefix = ordered ? `${index + 1}. ` : '- ';
-      const body = Array.from(item.childNodes)
-        .map((child) => renderInlineMarkdownNode(child))
-        .join('')
-        .replace(/\s+/g, ' ')
-        .trim();
-      return body ? `${prefix}${body}` : '';
-    })
-    .filter(Boolean)
-    .join('\n');
-};
-
-const renderBlockMarkdownNode = (node: Node): string => {
-  if (node.nodeType === Node.TEXT_NODE) {
-    return trimSelectionValue(node.textContent || '');
-  }
-
-  if (node.nodeType !== Node.ELEMENT_NODE) {
-    return '';
-  }
-
-  const element = node as HTMLElement;
-  const tag = element.tagName.toLowerCase();
-
-  if (tag === 'pre') {
-    const codeElement = element.querySelector('code');
-    const languageClass = codeElement?.className || '';
-    const language = (languageClass.match(/language-([\w-]+)/)?.[1] || '').trim();
-    const code = normalizeLineBreaks(codeElement?.textContent || element.textContent || '').replace(/\n$/, '');
-    return `\`\`\`${language}\n${code}\n\`\`\``;
-  }
-
-  if (tag === 'code') {
-    const code = normalizeLineBreaks(element.textContent || '').trim();
-    return code ? `\`${code.replace(/`/g, '\\`')}\`` : '';
-  }
-
-  if (tag === 'ul') return renderListMarkdown(element, false);
-  if (tag === 'ol') return renderListMarkdown(element, true);
-
-  if (tag === 'blockquote') {
-    const content = trimSelectionValue(
-      Array.from(element.childNodes).map((child) => renderBlockMarkdownNode(child)).join('\n')
-    );
-    return content
-      .split('\n')
-      .filter((line) => line.length > 0)
-      .map((line) => `> ${line}`)
-      .join('\n');
-  }
-
-  if (/^h[1-6]$/.test(tag)) {
-    const level = Number.parseInt(tag[1], 10);
-    const text = trimSelectionValue(Array.from(element.childNodes).map((child) => renderInlineMarkdownNode(child)).join(''));
-    return text ? `${'#'.repeat(level)} ${text}` : '';
-  }
-
-  if (tag === 'p' || tag === 'div' || tag === 'li') {
-    return trimSelectionValue(Array.from(element.childNodes).map((child) => renderInlineMarkdownNode(child)).join(''));
-  }
-
-  const blockChildren = Array.from(element.childNodes)
-    .map((child) => renderBlockMarkdownNode(child))
-    .filter((child) => child.length > 0);
-  if (blockChildren.length > 0) {
-    return blockChildren.join('\n\n');
-  }
-
-  return trimSelectionValue(Array.from(element.childNodes).map((child) => renderInlineMarkdownNode(child)).join(''));
-};
-
-const isInlineSelectionFragment = (fragment: DocumentFragment): boolean => {
-  return Array.from(fragment.childNodes).every((node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      return true;
-    }
-    if (node.nodeType !== Node.ELEMENT_NODE) {
-      return true;
-    }
-
-    const element = node as HTMLElement;
-    return !BLOCK_TAGS.has(element.tagName.toLowerCase());
-  });
-};
-
-const rangeToMarkdown = (range: Range, plainText: string): string => {
-  const fragment = range.cloneContents();
-
-  if (isInlineSelectionFragment(fragment)) {
-    const inlineMarkdown = trimSelectionValue(
-      Array.from(fragment.childNodes)
-        .map((node) => renderInlineMarkdownNode(node))
-        .join('')
-    );
-    if (inlineMarkdown) {
-      return inlineMarkdown;
-    }
-  }
-
-  const markdown = Array.from(fragment.childNodes)
-    .map((node) => renderBlockMarkdownNode(node))
-    .filter((value) => value.length > 0)
-    .join('\n\n')
-    .trim();
-
-  return markdown || trimSelectionValue(plainText);
-};
-
 export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerRef }) => {
   const { t } = useI18n();
   const [position, setPosition] = React.useState<MenuPosition>({ x: 0, y: 0, show: false });
@@ -462,7 +302,7 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
   const handleAddToChat = React.useCallback(() => {
     if (!selectedTextMarkdown) return;
 
-    const markdownBlock = `\`\`\`md\n${selectedTextMarkdown}\n\`\`\``;
+    const markdownBlock = wrapMarkdownSelectionForChat(selectedTextMarkdown);
     setPendingInputText(markdownBlock, 'append');
     
     hideMenu();

--- a/packages/ui/src/components/chat/message/selectionMarkdown.test.ts
+++ b/packages/ui/src/components/chat/message/selectionMarkdown.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  formatCodeSelectionMarkdown,
+  selectionNodesToMarkdown,
+  trimSelectionValue,
+  wrapMarkdownSelectionForChat,
+} from './selectionMarkdown';
+
+type TestNode =
+  | { type: 'text'; value: string }
+  | {
+      type: 'element';
+      tag: string;
+      className: string;
+      href: string;
+      component: string;
+      isCodeLines: boolean;
+      isCodeLineNumber: boolean;
+      children: TestNode[];
+    };
+
+const text = (value: string): TestNode => ({ type: 'text', value });
+const element = (
+  tag: string,
+  children: TestNode[],
+  options: Partial<Omit<Extract<TestNode, { type: 'element' }>, 'type' | 'tag' | 'children'>> = {},
+): TestNode => ({
+  type: 'element',
+  tag,
+  className: '',
+  href: '',
+  component: '',
+  isCodeLines: false,
+  isCodeLineNumber: false,
+  children,
+  ...options,
+});
+
+const codeLine = (number: number, content: string): TestNode => element('span', [
+  element('span', [text(String(number))], { isCodeLineNumber: true }),
+  element('span', [text(content)]),
+]);
+
+const codeWrapper = (lines: string[], language = 'ts'): TestNode => element('div', [
+  element('div', [text(language)]),
+  element('div', [
+    element('pre', [
+      element('code', lines.flatMap((line, index) => [
+        codeLine(index + 12, line),
+        ...(index < lines.length - 1 ? [element('span', [text('\n')])] : []),
+      ]), { className: `language-${language}`, isCodeLines: true }),
+    ]),
+  ]),
+], { component: 'markdown-code' });
+
+describe('selectionNodesToMarkdown', () => {
+  test('serializes a complete grid code block without its header or line numbers', () => {
+    expect(selectionNodesToMarkdown([codeWrapper(['range.cloneContents()', 'next()'])], '')).toBe(
+      '```ts\nrange.cloneContents()\nnext()\n```',
+    );
+  });
+
+  test('preserves a partial code block selected after prose', () => {
+    const nodes = [
+      element('p', [
+        text('原生'),
+        element('code', [text('Selection.toString()')]),
+        text('通常不会包含行号，但 Add to Chat 不直接使用它。'),
+      ]),
+      element('p', [text('它还会执行：')]),
+      codeWrapper(['range.cloneContents()']),
+    ];
+
+    expect(selectionNodesToMarkdown(nodes, '')).toBe(
+      '原生`Selection.toString()`通常不会包含行号，但 Add to Chat 不直接使用它。\n\n它还会执行：\n\n```ts\nrange.cloneContents()\n```',
+    );
+  });
+
+  test('preserves a partial code block selected before prose', () => {
+    expect(selectionNodesToMarkdown([
+      codeWrapper(['range.cloneContents()']),
+      element('p', [text('后续说明')]),
+    ], '')).toBe('```ts\nrange.cloneContents()\n```\n\n后续说明');
+  });
+});
+
+describe('formatCodeSelectionMarkdown', () => {
+  test('preserves indentation and blank lines', () => {
+    expect(formatCodeSelectionMarkdown('if (ready) {\n  run();\n\n  stop();\n}', 'ts')).toBe(
+      '```ts\nif (ready) {\n  run();\n\n  stop();\n}\n```',
+    );
+  });
+
+  test('normalizes line endings without duplicating a trailing newline', () => {
+    expect(formatCodeSelectionMarkdown('first\r\nsecond\r\n', 'text')).toBe(
+      '```text\nfirst\nsecond\n```',
+    );
+  });
+
+  test('uses a longer fence when selected code contains backtick fences', () => {
+    expect(formatCodeSelectionMarkdown('before\n```\nafter', 'md')).toBe(
+      '````md\nbefore\n```\nafter\n````',
+    );
+  });
+
+  test('preserves punctuation in language identifiers', () => {
+    expect(selectionNodesToMarkdown([codeWrapper(['std::vector<int> values;'], 'c++')], '')).toBe(
+      '```c++\nstd::vector<int> values;\n```',
+    );
+  });
+});
+
+describe('trimSelectionValue', () => {
+  test('normalizes line endings before trimming the selection', () => {
+    expect(trimSelectionValue('  first\r\nsecond  ')).toBe('first\nsecond');
+  });
+});
+
+describe('wrapMarkdownSelectionForChat', () => {
+  test('uses a longer outer fence when the selection contains fenced code', () => {
+    expect(wrapMarkdownSelectionForChat('```ts\nrun();\n```')).toBe(
+      '````md\n```ts\nrun();\n```\n````',
+    );
+  });
+});

--- a/packages/ui/src/components/chat/message/selectionMarkdown.test.ts
+++ b/packages/ui/src/components/chat/message/selectionMarkdown.test.ts
@@ -15,6 +15,7 @@ type TestNode =
       className: string;
       href: string;
       component: string;
+      markdownLanguage: string;
       isCodeLines: boolean;
       isCodeLineNumber: boolean;
       children: TestNode[];
@@ -32,6 +33,7 @@ const element = (
   className: '',
   href: '',
   component: '',
+  markdownLanguage: '',
   isCodeLines: false,
   isCodeLineNumber: false,
   children,
@@ -50,8 +52,8 @@ const codeWrapper = (lines: string[], language = 'ts'): TestNode => element('div
       element('code', lines.flatMap((line, index) => [
         codeLine(index + 12, line),
         ...(index < lines.length - 1 ? [element('span', [text('\n')])] : []),
-      ]), { className: `language-${language}`, isCodeLines: true }),
-    ]),
+      ]), { isCodeLines: true }),
+    ], { markdownLanguage: language }),
   ]),
 ], { component: 'markdown-code' });
 

--- a/packages/ui/src/components/chat/message/selectionMarkdown.test.ts
+++ b/packages/ui/src/components/chat/message/selectionMarkdown.test.ts
@@ -16,6 +16,7 @@ type TestNode =
       href: string;
       component: string;
       markdownLanguage: string;
+      isMarkdownBlock: boolean;
       isCodeLines: boolean;
       isCodeLineNumber: boolean;
       children: TestNode[];
@@ -34,6 +35,7 @@ const element = (
   href: '',
   component: '',
   markdownLanguage: '',
+  isMarkdownBlock: false,
   isCodeLines: false,
   isCodeLineNumber: false,
   children,
@@ -44,6 +46,8 @@ const codeLine = (number: number, content: string): TestNode => element('span', 
   element('span', [text(String(number))], { isCodeLineNumber: true }),
   element('span', [text(content)]),
 ]);
+
+const markdownBlock = (children: TestNode[]): TestNode => element('div', children, { isMarkdownBlock: true });
 
 const codeWrapper = (lines: string[], language = 'ts'): TestNode => element('div', [
   element('div', [text(language)]),
@@ -67,25 +71,25 @@ describe('selectionNodesToMarkdown', () => {
     ));
   });
 
-  test('preserves a partial code block selected after prose', () => {
+  test('preserves a code block nested between production Markdown block wrappers', () => {
     const nodes = [
-      element('p', [
+      markdownBlock([element('p', [
         text('Method:'),
         element('code', [text('Selection.toString()')]),
         text('. Add to Chat uses a cloned range.'),
-      ]),
-      element('p', [text('It also runs:')]),
-      codeWrapper(['range.cloneContents()']),
+      ])]),
+      markdownBlock([codeWrapper(['range.cloneContents()'])]),
+      markdownBlock([element('p', [text('Following explanation')])]),
     ];
 
     expect(selectionNodesToMarkdown(nodes, '')).toBe(multiline(
       'Method:`Selection.toString()`. Add to Chat uses a cloned range.',
       '',
-      'It also runs:',
-      '',
       '```ts',
       'range.cloneContents()',
       '```',
+      '',
+      'Following explanation',
     ));
   });
 

--- a/packages/ui/src/components/chat/message/selectionMarkdown.test.ts
+++ b/packages/ui/src/components/chat/message/selectionMarkdown.test.ts
@@ -20,6 +20,7 @@ type TestNode =
       children: TestNode[];
     };
 
+const multiline = (...lines: string[]): string => lines.join('\n');
 const text = (value: string): TestNode => ({ type: 'text', value });
 const element = (
   tag: string,
@@ -56,71 +57,121 @@ const codeWrapper = (lines: string[], language = 'ts'): TestNode => element('div
 
 describe('selectionNodesToMarkdown', () => {
   test('serializes a complete grid code block without its header or line numbers', () => {
-    expect(selectionNodesToMarkdown([codeWrapper(['range.cloneContents()', 'next()'])], '')).toBe(
-      '```ts\nrange.cloneContents()\nnext()\n```',
-    );
+    expect(selectionNodesToMarkdown([codeWrapper(['range.cloneContents()', 'next()'])], '')).toBe(multiline(
+      '```ts',
+      'range.cloneContents()',
+      'next()',
+      '```',
+    ));
   });
 
   test('preserves a partial code block selected after prose', () => {
     const nodes = [
       element('p', [
-        text('原生'),
+        text('Method:'),
         element('code', [text('Selection.toString()')]),
-        text('通常不会包含行号，但 Add to Chat 不直接使用它。'),
+        text('. Add to Chat uses a cloned range.'),
       ]),
-      element('p', [text('它还会执行：')]),
+      element('p', [text('It also runs:')]),
       codeWrapper(['range.cloneContents()']),
     ];
 
-    expect(selectionNodesToMarkdown(nodes, '')).toBe(
-      '原生`Selection.toString()`通常不会包含行号，但 Add to Chat 不直接使用它。\n\n它还会执行：\n\n```ts\nrange.cloneContents()\n```',
-    );
+    expect(selectionNodesToMarkdown(nodes, '')).toBe(multiline(
+      'Method:`Selection.toString()`. Add to Chat uses a cloned range.',
+      '',
+      'It also runs:',
+      '',
+      '```ts',
+      'range.cloneContents()',
+      '```',
+    ));
   });
 
   test('preserves a partial code block selected before prose', () => {
     expect(selectionNodesToMarkdown([
       codeWrapper(['range.cloneContents()']),
-      element('p', [text('后续说明')]),
-    ], '')).toBe('```ts\nrange.cloneContents()\n```\n\n后续说明');
+      element('p', [text('Following explanation')]),
+    ], '')).toBe(multiline(
+      '```ts',
+      'range.cloneContents()',
+      '```',
+      '',
+      'Following explanation',
+    ));
   });
 });
 
 describe('formatCodeSelectionMarkdown', () => {
   test('preserves indentation and blank lines', () => {
-    expect(formatCodeSelectionMarkdown('if (ready) {\n  run();\n\n  stop();\n}', 'ts')).toBe(
-      '```ts\nif (ready) {\n  run();\n\n  stop();\n}\n```',
-    );
+    expect(formatCodeSelectionMarkdown(multiline(
+      'if (ready) {',
+      '  run();',
+      '',
+      '  stop();',
+      '}',
+    ), 'ts')).toBe(multiline(
+      '```ts',
+      'if (ready) {',
+      '  run();',
+      '',
+      '  stop();',
+      '}',
+      '```',
+    ));
   });
 
   test('normalizes line endings without duplicating a trailing newline', () => {
-    expect(formatCodeSelectionMarkdown('first\r\nsecond\r\n', 'text')).toBe(
-      '```text\nfirst\nsecond\n```',
-    );
+    expect(formatCodeSelectionMarkdown('first\r\nsecond\r\n', 'text')).toBe(multiline(
+      '```text',
+      'first',
+      'second',
+      '```',
+    ));
   });
 
   test('uses a longer fence when selected code contains backtick fences', () => {
-    expect(formatCodeSelectionMarkdown('before\n```\nafter', 'md')).toBe(
-      '````md\nbefore\n```\nafter\n````',
-    );
+    expect(formatCodeSelectionMarkdown(multiline(
+      'before',
+      '```',
+      'after',
+    ), 'md')).toBe(multiline(
+      '````md',
+      'before',
+      '```',
+      'after',
+      '````',
+    ));
   });
 
   test('preserves punctuation in language identifiers', () => {
-    expect(selectionNodesToMarkdown([codeWrapper(['std::vector<int> values;'], 'c++')], '')).toBe(
-      '```c++\nstd::vector<int> values;\n```',
-    );
+    expect(selectionNodesToMarkdown([codeWrapper(['std::vector<int> values;'], 'c++')], '')).toBe(multiline(
+      '```c++',
+      'std::vector<int> values;',
+      '```',
+    ));
   });
 });
 
 describe('trimSelectionValue', () => {
   test('normalizes line endings before trimming the selection', () => {
-    expect(trimSelectionValue('  first\r\nsecond  ')).toBe('first\nsecond');
+    expect(trimSelectionValue('  first\r\nsecond  ')).toBe(multiline('first', 'second'));
   });
 });
 
 describe('wrapMarkdownSelectionForChat', () => {
   test('uses a longer outer fence when the selection contains fenced code', () => {
-    expect(wrapMarkdownSelectionForChat('```ts\nrun();\n```')).toBe(
-      '````md\n```ts\nrun();\n```\n````',
+    const selectedMarkdown = multiline(
+      '```ts',
+      'run();',
+      '```',
     );
+
+    expect(wrapMarkdownSelectionForChat(selectedMarkdown)).toBe(multiline(
+      '````md',
+      '```ts',
+      'run();',
+      '```',
+      '````',
+    ));
   });
 });

--- a/packages/ui/src/components/chat/message/selectionMarkdown.ts
+++ b/packages/ui/src/components/chat/message/selectionMarkdown.ts
@@ -1,0 +1,223 @@
+type SelectionNode =
+  | { type: 'text'; value: string }
+  | {
+      type: 'element';
+      tag: string;
+      className: string;
+      href: string;
+      component: string;
+      isCodeLines: boolean;
+      isCodeLineNumber: boolean;
+      children: SelectionNode[];
+    };
+
+const BLOCK_TAGS = new Set([
+  'address', 'article', 'aside', 'blockquote', 'dd', 'div', 'dl', 'dt',
+  'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3',
+  'h4', 'h5', 'h6', 'header', 'hr', 'li', 'main', 'nav', 'ol', 'p', 'pre',
+  'section', 'table', 'ul',
+]);
+
+const normalizeLineBreaks = (value: string): string => value.replace(/\r\n?/g, '\n');
+export const trimSelectionValue = (value: string): string => normalizeLineBreaks(value).trim();
+const textToMarkdownInline = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const getCodeLanguage = (className: string): string => {
+  return (className.match(/language-([\w+#.-]+)/)?.[1] || '').trim();
+};
+
+const toSelectionNode = (node: Node): SelectionNode | null => {
+  if (node.nodeType === 3) {
+    return { type: 'text', value: node.textContent || '' };
+  }
+  if (node.nodeType !== 1) {
+    return null;
+  }
+
+  const element = node as Element;
+  return {
+    type: 'element',
+    tag: element.tagName.toLowerCase(),
+    className: element.getAttribute('class') || '',
+    href: element.getAttribute('href') || '',
+    component: element.getAttribute('data-component') || '',
+    isCodeLines: element.hasAttribute('data-md-code-lines'),
+    isCodeLineNumber: element.hasAttribute('data-md-code-line-number'),
+    children: Array.from(element.childNodes)
+      .map((child) => toSelectionNode(child))
+      .filter((child): child is SelectionNode => child !== null),
+  };
+};
+
+export const trimSelectionNodes = (nodes: SelectionNode[]): SelectionNode[] => {
+  return nodes
+    .filter((node) => node.type === 'text' || !node.isCodeLineNumber)
+    .map((node) => node.type === 'text'
+      ? node
+      : { ...node, children: trimSelectionNodes(node.children) });
+};
+
+const toSelectionNodes = (root: ParentNode): SelectionNode[] => {
+  return Array.from(root.childNodes)
+    .map((child) => toSelectionNode(child))
+    .filter((child): child is SelectionNode => child !== null);
+};
+
+const getSelectionText = (node: SelectionNode): string => {
+  return node.type === 'text'
+    ? node.value
+    : node.children.map((child) => getSelectionText(child)).join('');
+};
+
+const findElement = (
+  node: SelectionNode,
+  predicate: (element: Extract<SelectionNode, { type: 'element' }>) => boolean,
+): Extract<SelectionNode, { type: 'element' }> | null => {
+  if (node.type === 'text') return null;
+  if (predicate(node)) return node;
+  for (const child of node.children) {
+    const match = findElement(child, predicate);
+    if (match) return match;
+  }
+  return null;
+};
+
+export const formatCodeSelectionMarkdown = (code: string, language = ''): string => {
+  const normalizedCode = normalizeLineBreaks(code).replace(/\n$/, '');
+  const longestBacktickRun = Math.max(0, ...Array.from(normalizedCode.matchAll(/`+/g), (match) => match[0].length));
+  const fence = '`'.repeat(Math.max(3, longestBacktickRun + 1));
+  return `${fence}${language}\n${normalizedCode}\n${fence}`;
+};
+
+const renderInlineMarkdownNode = (node: SelectionNode): string => {
+  if (node.type === 'text') {
+    return textToMarkdownInline(node.value);
+  }
+
+  const childText = node.children
+    .map((child) => renderInlineMarkdownNode(child))
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!childText && node.tag !== 'br') return '';
+  if (node.tag === 'br') return '\n';
+  if (node.tag === 'strong' || node.tag === 'b') return `**${childText}**`;
+  if (node.tag === 'em' || node.tag === 'i') return `*${childText}*`;
+  if (node.tag === 'code') return `\`${childText.replace(/`/g, '\\`')}\``;
+  if (node.tag === 'a') return node.href ? `[${childText}](${node.href})` : childText;
+  return childText;
+};
+
+const renderListMarkdown = (list: Extract<SelectionNode, { type: 'element' }>, ordered: boolean): string => {
+  return list.children
+    .filter((child): child is Extract<SelectionNode, { type: 'element' }> => child.type === 'element' && child.tag === 'li')
+    .map((item, index) => {
+      const body = item.children
+        .map((child) => renderInlineMarkdownNode(child))
+        .join('')
+        .replace(/\s+/g, ' ')
+        .trim();
+      return body ? `${ordered ? `${index + 1}.` : '-'} ${body}` : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+};
+
+const renderBlockMarkdownNode = (node: SelectionNode): string => {
+  if (node.type === 'text') return trimSelectionValue(node.value);
+
+  if (node.component === 'markdown-code') {
+    const pre = findElement(node, (element) => element.tag === 'pre');
+    return pre ? renderBlockMarkdownNode(pre) : '';
+  }
+
+  if (node.tag === 'pre' || (node.tag === 'code' && node.isCodeLines)) {
+    const code = node.tag === 'code'
+      ? node
+      : findElement(node, (element) => element.tag === 'code');
+    return formatCodeSelectionMarkdown(
+      code ? getSelectionText(code) : getSelectionText(node),
+      getCodeLanguage(code?.className || ''),
+    );
+  }
+
+  if (node.tag === 'code') {
+    const code = normalizeLineBreaks(getSelectionText(node)).trim();
+    return code ? `\`${code.replace(/`/g, '\\`')}\`` : '';
+  }
+  if (node.tag === 'ul') return renderListMarkdown(node, false);
+  if (node.tag === 'ol') return renderListMarkdown(node, true);
+
+  if (node.tag === 'blockquote') {
+    const content = trimSelectionValue(node.children.map((child) => renderBlockMarkdownNode(child)).join('\n'));
+    return content
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => `> ${line}`)
+      .join('\n');
+  }
+
+  if (/^h[1-6]$/.test(node.tag)) {
+    const level = Number.parseInt(node.tag[1], 10);
+    const text = trimSelectionValue(node.children.map((child) => renderInlineMarkdownNode(child)).join(''));
+    return text ? `${'#'.repeat(level)} ${text}` : '';
+  }
+
+  if (node.tag === 'p' || node.tag === 'div' || node.tag === 'li') {
+    return trimSelectionValue(node.children.map((child) => renderInlineMarkdownNode(child)).join(''));
+  }
+
+  const blockChildren = node.children
+    .map((child) => renderBlockMarkdownNode(child))
+    .filter((child) => child.length > 0);
+  return blockChildren.length > 0
+    ? blockChildren.join('\n\n')
+    : trimSelectionValue(node.children.map((child) => renderInlineMarkdownNode(child)).join(''));
+};
+
+const isInlineSelectionNode = (node: SelectionNode): boolean => {
+  if (node.type === 'text') return true;
+  return !node.isCodeLines && node.component !== 'markdown-code' && !BLOCK_TAGS.has(node.tag);
+};
+
+export const selectionNodesToMarkdown = (nodes: SelectionNode[], plainText: string): string => {
+  const trimmedNodes = trimSelectionNodes(nodes);
+  if (trimmedNodes.every((node) => isInlineSelectionNode(node))) {
+    const inlineMarkdown = trimSelectionValue(trimmedNodes.map((node) => renderInlineMarkdownNode(node)).join(''));
+    if (inlineMarkdown) return inlineMarkdown;
+  }
+
+  const markdown = trimmedNodes
+    .map((node) => renderBlockMarkdownNode(node))
+    .filter((value) => value.length > 0)
+    .join('\n\n')
+    .trim();
+  return markdown || trimSelectionValue(plainText);
+};
+
+const getContainingBlockCode = (node: Node): HTMLElement | null => {
+  const element = node.nodeType === 1 ? node as Element : node.parentElement;
+  return element?.closest<HTMLElement>('pre code') ?? null;
+};
+
+export const rangeToMarkdown = (range: Range, plainText: string): string => {
+  const startCode = getContainingBlockCode(range.startContainer);
+  const endCode = getContainingBlockCode(range.endContainer);
+  const nodes = trimSelectionNodes(toSelectionNodes(range.cloneContents()));
+
+  if (startCode && startCode === endCode) {
+    return formatCodeSelectionMarkdown(
+      nodes.map((node) => getSelectionText(node)).join(''),
+      getCodeLanguage(startCode.className),
+    );
+  }
+
+  return selectionNodesToMarkdown(nodes, plainText);
+};
+
+export const wrapMarkdownSelectionForChat = (markdown: string): string => {
+  const longestBacktickRun = Math.max(0, ...Array.from(markdown.matchAll(/`+/g), (match) => match[0].length));
+  const fence = '`'.repeat(Math.max(3, longestBacktickRun + 1));
+  return `${fence}md\n${markdown}\n${fence}`;
+};

--- a/packages/ui/src/components/chat/message/selectionMarkdown.ts
+++ b/packages/ui/src/components/chat/message/selectionMarkdown.ts
@@ -6,6 +6,7 @@ type SelectionNode =
       className: string;
       href: string;
       component: string;
+      markdownLanguage: string;
       isCodeLines: boolean;
       isCodeLineNumber: boolean;
       children: SelectionNode[];
@@ -22,8 +23,13 @@ const normalizeLineBreaks = (value: string): string => value.replace(/\r\n?/g, '
 export const trimSelectionValue = (value: string): string => normalizeLineBreaks(value).trim();
 const textToMarkdownInline = (value: string): string => value.replace(/\s+/g, ' ').trim();
 
-const getCodeLanguage = (className: string): string => {
+const getCodeLanguageFromClassName = (className: string): string => {
   return (className.match(/language-([\w+#.-]+)/)?.[1] || '').trim();
+};
+
+const getBlockCodeLanguage = (code: HTMLElement): string => {
+  return code.closest('pre')?.getAttribute('data-md-lang')
+    || getCodeLanguageFromClassName(code.className);
 };
 
 const toSelectionNode = (node: Node): SelectionNode | null => {
@@ -41,6 +47,7 @@ const toSelectionNode = (node: Node): SelectionNode | null => {
     className: element.getAttribute('class') || '',
     href: element.getAttribute('href') || '',
     component: element.getAttribute('data-component') || '',
+    markdownLanguage: element.getAttribute('data-md-lang') || '',
     isCodeLines: element.hasAttribute('data-md-code-lines'),
     isCodeLineNumber: element.hasAttribute('data-md-code-line-number'),
     children: Array.from(element.childNodes)
@@ -138,7 +145,7 @@ const renderBlockMarkdownNode = (node: SelectionNode): string => {
       : findElement(node, (element) => element.tag === 'code');
     return formatCodeSelectionMarkdown(
       code ? getSelectionText(code) : getSelectionText(node),
-      getCodeLanguage(code?.className || ''),
+      node.markdownLanguage || getCodeLanguageFromClassName(code?.className || ''),
     );
   }
 
@@ -209,7 +216,7 @@ export const rangeToMarkdown = (range: Range, plainText: string): string => {
   if (startCode && startCode === endCode) {
     return formatCodeSelectionMarkdown(
       nodes.map((node) => getSelectionText(node)).join(''),
-      getCodeLanguage(startCode.className),
+      getBlockCodeLanguage(startCode),
     );
   }
 

--- a/packages/ui/src/components/chat/message/selectionMarkdown.ts
+++ b/packages/ui/src/components/chat/message/selectionMarkdown.ts
@@ -7,6 +7,7 @@ type SelectionNode =
       href: string;
       component: string;
       markdownLanguage: string;
+      isMarkdownBlock: boolean;
       isCodeLines: boolean;
       isCodeLineNumber: boolean;
       children: SelectionNode[];
@@ -48,6 +49,7 @@ const toSelectionNode = (node: Node): SelectionNode | null => {
     href: element.getAttribute('href') || '',
     component: element.getAttribute('data-component') || '',
     markdownLanguage: element.getAttribute('data-md-lang') || '',
+    isMarkdownBlock: element.hasAttribute('data-md-block'),
     isCodeLines: element.hasAttribute('data-md-code-lines'),
     isCodeLineNumber: element.hasAttribute('data-md-code-line-number'),
     children: Array.from(element.childNodes)
@@ -134,6 +136,13 @@ const renderListMarkdown = (list: Extract<SelectionNode, { type: 'element' }>, o
 const renderBlockMarkdownNode = (node: SelectionNode): string => {
   if (node.type === 'text') return trimSelectionValue(node.value);
 
+  if (node.isMarkdownBlock) {
+    return node.children
+      .map((child) => renderBlockMarkdownNode(child))
+      .filter((child) => child.length > 0)
+      .join('\n\n');
+  }
+
   if (node.component === 'markdown-code') {
     const pre = findElement(node, (element) => element.tag === 'pre');
     return pre ? renderBlockMarkdownNode(pre) : '';
@@ -185,7 +194,7 @@ const renderBlockMarkdownNode = (node: SelectionNode): string => {
 
 const isInlineSelectionNode = (node: SelectionNode): boolean => {
   if (node.type === 'text') return true;
-  return !node.isCodeLines && node.component !== 'markdown-code' && !BLOCK_TAGS.has(node.tag);
+  return !node.isMarkdownBlock && !node.isCodeLines && node.component !== 'markdown-code' && !BLOCK_TAGS.has(node.tag);
 };
 
 export const selectionNodesToMarkdown = (nodes: SelectionNode[], plainText: string): string => {


### PR DESCRIPTION
## Intent

<!-- What user or maintainer problem does this solve? What behavior changes? -->

Fix Markdown selections copied into **Add to Chat** after the code-block grid layout introduced in #2444.

The grid renderer adds language controls, line-number elements, logical line wrappers, and hidden newline nodes around highlighted code. The existing selection serializer still treated the cloned code-block wrapper as generic inline DOM, so a mixed prose/code selection could become content such as `md1## Heading23- item`: the language label and line numbers leaked into the prompt while source newlines were collapsed.

This follow-up converts the cloned selection into a small renderer-independent tree, removes code-line decorations, recognizes the Markdown code wrapper, and preserves language, indentation, blank lines, and partial code selections. Add to Chat also chooses a fence longer than any backtick run in the selected Markdown, so nested fenced code remains valid.

## Non-goals

<!-- What nearby behavior is intentionally outside this PR? Write "None" only when the scope is unambiguous. -->

- No changes to code-block rendering, syntax highlighting, line layout, or clipboard MIME behavior.
- No changes to plain-text Copy or New Session selection actions.
- No unrelated Markdown renderer refactors.

## Affected surfaces

<!-- Name affected packages, runtimes, user-visible states, and persisted/external contracts. Explain why an apparently applicable runtime is unaffected. -->

- Shared `packages/ui` text-selection serialization used by Add to Chat and Add to Notes.
- Web, Electron, VS Code, and Mobile share this UI implementation.
- No persisted data, API, bridge, or external contract changes.

## Repository guidance

<!-- List the AGENTS.md rules, matching project skills, required skill references, and nearest README/DOCUMENTATION.md files used for this change. Explain why each applies and the important constraints you followed. Do not merely list filenames. -->

| Guidance | Application |
|---|---|
| `AGENTS.md` and `openchamber-change-discipline` | Keeps the patch limited to the selection regression introduced by #2444 and its focused tests |
| Message-part documentation | Keeps selection-to-Markdown behavior in the shared message UI owner |
| Cross-runtime contract | Uses one shared serializer without runtime-specific branches |

## Validation

<!-- Report exact commands/manual checks and results. State what was not verified. Do not claim runtime behavior from type-check/lint alone. -->

- `bun test src/components/chat/message/selectionMarkdown.test.ts src/components/chat/markdown/textPosition.test.ts src/lib/clipboard.test.ts`: 14 passed.
- `bun run type-check` in `packages/ui`: passed.
- `bun run lint` in `packages/ui`: passed.
- `bun run build` in `packages/web`: passed with existing font/chunk warnings.
- `bun run dead-code`: completed with existing non-blocking findings.

Not run on the final branch: manual cross-runtime selection verification.

## Visual evidence

<!-- User-visible change: attach current before/after screenshots or recordings for the affected desktop/mobile, narrow/wide, theme, and interaction states. No visible change: explain concretely why the diff cannot affect rendered behavior. -->

### Before

the screenshot showing Add to Chat output containing the `md` language label, code line numbers, and collapsed Markdown lines.

<img width="825" height="901" alt="image" src="https://github.com/user-attachments/assets/15f6afed-663b-4a43-9308-41d76ede7e98" />

### After

<img width="1492" height="392" alt="image" src="https://github.com/user-attachments/assets/9da10fad-af50-4dd1-9b91-aaa5c01c2ced" />

<img width="726" height="525" alt="image" src="https://github.com/user-attachments/assets/3f37cd4e-09ab-4c7f-9594-40d08405f51c" />

## Risks and failure behavior

<!-- Cover relevant failure, rollback, cleanup, compatibility, security, performance, data-loss, and cross-runtime concerns. State "None identified" only with a concrete reason. -->

- Selection DOM is normalized before serialization; unknown elements retain their text through the existing inline/block fallback.
- Dynamic fences preserve selected code that already contains backticks and language identifiers such as `c++`.
- Plain-text selection remains the fallback when Markdown serialization produces no output.
- Rollback is a single commit revert; no data migration or cleanup is required.
