### PR TITLE
fix(quota): refresh Claude subscription OAuth so Usage limits display

### DIFF
--- a/packages/vscode/src/claudeOauth.ts
+++ b/packages/vscode/src/claudeOauth.ts
@@ -1,0 +1,357 @@
+/**
+ * Claude subscription OAuth access for VS Code Usage probes.
+ * Mirrors packages/web/server/lib/quota/providers/claude-oauth.js + claude-cli-auth.js.
+ * Never logs token values.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const OPENCODE_DATA_DIR = path.join(os.homedir(), '.local', 'share', 'opencode');
+const AUTH_FILE = path.join(OPENCODE_DATA_DIR, 'auth.json');
+
+/** Public Claude Code / OpenCode Anthropic OAuth client id (not a secret). */
+const CLAUDE_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const OPENCODE_CLAUDE_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+const CLAUDE_CLI_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+const CLAUDE_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const CLAUDE_OAUTH_BETA = 'oauth-2025-04-20';
+export const CLAUDE_SESSION_EXPIRED_ERROR = 'Session expired — please re-authenticate with Claude';
+
+const AUTH_ALIASES = ['anthropic', 'claude'] as const;
+const REFRESH_BUFFER_MS = 60_000;
+
+type AuthFile = Record<string, Record<string, unknown>>;
+
+export type ClaudeUsageCredential = {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: number | null;
+  source: 'env' | 'claude-cli' | 'opencode-auth';
+  tokenUrl: string | null;
+  authKey?: string;
+  credentialsPath?: string;
+};
+
+export type ClaudeUsageAccess = {
+  accessToken: string;
+  source: ClaudeUsageCredential['source'];
+  canRefresh: boolean;
+};
+
+let claudeRefreshPromise: Promise<ClaudeUsageAccess> | null = null;
+
+const readAuthFile = (): AuthFile => {
+  if (!fs.existsSync(AUTH_FILE)) return {};
+  try {
+    const content = fs.readFileSync(AUTH_FILE, 'utf8');
+    const trimmed = content.trim();
+    if (!trimmed) return {};
+    return JSON.parse(trimmed) as AuthFile;
+  } catch (error) {
+    console.error('Failed to read auth file:', error);
+    throw new Error('Failed to read OpenCode auth configuration');
+  }
+};
+
+const writeAuthFile = (auth: AuthFile): void => {
+  if (!fs.existsSync(OPENCODE_DATA_DIR)) {
+    fs.mkdirSync(OPENCODE_DATA_DIR, { recursive: true, mode: 0o700 });
+  }
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(OPENCODE_DATA_DIR, 0o700); } catch { /* best-effort */ }
+  }
+  if (fs.existsSync(AUTH_FILE)) {
+    const backupFile = `${AUTH_FILE}.openchamber.backup`;
+    fs.copyFileSync(AUTH_FILE, backupFile);
+    if (process.platform !== 'win32') {
+      try { fs.chmodSync(backupFile, 0o600); } catch { /* best-effort */ }
+    }
+  }
+  fs.writeFileSync(AUTH_FILE, JSON.stringify(auth, null, 2), { encoding: 'utf8', mode: 0o600 });
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(AUTH_FILE, 0o600); } catch { /* best-effort */ }
+  }
+};
+
+const listClaudeCredentialsCandidates = (
+  homeDir = os.homedir(),
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): string[] => {
+  const candidates: string[] = [];
+  const configDir = typeof env.CLAUDE_CONFIG_DIR === 'string' ? env.CLAUDE_CONFIG_DIR.trim() : '';
+  if (configDir) {
+    candidates.push(path.join(configDir, '.credentials.json'));
+    candidates.push(path.join(configDir, 'credentials.json'));
+  }
+  candidates.push(
+    path.join(homeDir, '.claude', '.credentials.json'),
+    path.join(homeDir, '.claude', 'credentials.json'),
+    path.join(homeDir, '.config', 'claude', '.credentials.json'),
+  );
+  return candidates;
+};
+
+const toExpiresAtMs = (value: unknown): number | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value < 1_000_000_000_000 ? value * 1000 : value;
+};
+
+const extractClaudeOAuthCredentials = (parsed: unknown): {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: number | null;
+} | null => {
+  if (!parsed || typeof parsed !== 'object') return null;
+  const root = parsed as Record<string, unknown>;
+  const block = (root.claudeAiOauth && typeof root.claudeAiOauth === 'object'
+    ? root.claudeAiOauth
+    : root.claude_ai_oauth && typeof root.claude_ai_oauth === 'object'
+      ? root.claude_ai_oauth
+      : null) as Record<string, unknown> | null;
+  if (!block) return null;
+
+  const accessRaw = block.accessToken ?? block.access_token;
+  if (typeof accessRaw !== 'string' || !accessRaw.trim()) return null;
+  const refreshRaw = block.refreshToken ?? block.refresh_token;
+  return {
+    accessToken: accessRaw.trim(),
+    refreshToken: typeof refreshRaw === 'string' && refreshRaw.trim() ? refreshRaw.trim() : null,
+    expiresAt: toExpiresAtMs(block.expiresAt ?? block.expires_at),
+  };
+};
+
+const writeClaudeCliOAuthCredentials = (
+  filePath: string,
+  tokens: { accessToken: string; refreshToken: string; expiresAt: number },
+): void => {
+  let root: Record<string, unknown> = {};
+  if (fs.existsSync(filePath)) {
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8');
+      if (raw.trim()) {
+        const parsed = JSON.parse(raw) as unknown;
+        if (parsed && typeof parsed === 'object') root = parsed as Record<string, unknown>;
+      }
+    } catch {
+      root = {};
+    }
+  }
+
+  const useSnake = Boolean(root.claude_ai_oauth) && !root.claudeAiOauth;
+  const previous = (useSnake
+    ? root.claude_ai_oauth
+    : root.claudeAiOauth) as Record<string, unknown> | undefined;
+  const base = previous && typeof previous === 'object' ? previous : {};
+  const nextBlock = useSnake
+    ? {
+        ...base,
+        access_token: tokens.accessToken,
+        refresh_token: tokens.refreshToken,
+        expires_at: tokens.expiresAt,
+      }
+    : {
+        ...base,
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        expiresAt: tokens.expiresAt,
+      };
+  const nextRoot = useSnake
+    ? { ...root, claude_ai_oauth: nextBlock }
+    : { ...root, claudeAiOauth: nextBlock };
+
+  const tempPath = `${filePath}.openchamber.tmp`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(nextRoot, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(tempPath, 0o600); } catch { /* best-effort */ }
+  }
+  fs.renameSync(tempPath, filePath);
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(filePath, 0o600); } catch { /* best-effort */ }
+  }
+};
+
+const isClaudeAccessExpired = (expiresAt: number | null | undefined, now = Date.now()): boolean => {
+  if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt)) return false;
+  return expiresAt - REFRESH_BUFFER_MS <= now;
+};
+
+const resolveClaudeUsageCredential = (): ClaudeUsageCredential | null => {
+  const envToken = typeof process.env.CLAUDE_CODE_OAUTH_TOKEN === 'string'
+    ? process.env.CLAUDE_CODE_OAUTH_TOKEN.trim()
+    : '';
+  if (envToken) {
+    return {
+      accessToken: envToken,
+      refreshToken: null,
+      expiresAt: null,
+      source: 'env',
+      tokenUrl: null,
+    };
+  }
+
+  for (const candidate of listClaudeCredentialsCandidates()) {
+    try {
+      if (!fs.existsSync(candidate)) continue;
+      const raw = fs.readFileSync(candidate, 'utf8');
+      if (!raw.trim()) continue;
+      const creds = extractClaudeOAuthCredentials(JSON.parse(raw));
+      if (!creds) continue;
+      return {
+        ...creds,
+        source: 'claude-cli',
+        tokenUrl: CLAUDE_CLI_TOKEN_URL,
+        credentialsPath: candidate,
+      };
+    } catch {
+      // continue
+    }
+  }
+
+  const auth = readAuthFile();
+  for (const alias of AUTH_ALIASES) {
+    const entry = auth[alias];
+    if (!entry || typeof entry !== 'object') continue;
+    const access = typeof entry.access === 'string' && entry.access.trim()
+      ? entry.access.trim()
+      : typeof entry.token === 'string' && entry.token.trim()
+        ? entry.token.trim()
+        : null;
+    if (!access) continue;
+    const refresh = typeof entry.refresh === 'string' && entry.refresh.trim()
+      ? entry.refresh.trim()
+      : null;
+    return {
+      accessToken: access,
+      refreshToken: refresh,
+      expiresAt: toExpiresAtMs(entry.expires),
+      source: 'opencode-auth',
+      tokenUrl: OPENCODE_CLAUDE_TOKEN_URL,
+      authKey: alias,
+    };
+  }
+
+  return null;
+};
+
+const refreshClaudeOAuthToken = async (input: {
+  refreshToken: string;
+  tokenUrl: string;
+}): Promise<{ accessToken: string; refreshToken: string; expiresAt: number }> => {
+  const response = await fetch(input.tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'anthropic-beta': CLAUDE_OAUTH_BETA,
+    },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: input.refreshToken,
+      client_id: CLAUDE_OAUTH_CLIENT_ID,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Claude token refresh failed: ${response.status}`);
+  }
+  const payload = await response.json() as Record<string, unknown>;
+  const accessToken = typeof payload.access_token === 'string' ? payload.access_token.trim() : '';
+  if (!accessToken) {
+    throw new Error('Claude token refresh returned no access token');
+  }
+  const refreshToken = typeof payload.refresh_token === 'string' && payload.refresh_token.trim()
+    ? payload.refresh_token.trim()
+    : input.refreshToken;
+  const expiresIn = Number(payload.expires_in);
+  const expiresAt = Date.now() + (Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 3600) * 1000;
+  return { accessToken, refreshToken, expiresAt };
+};
+
+const persistRefreshedCredential = (
+  credential: ClaudeUsageCredential,
+  tokens: { accessToken: string; refreshToken: string; expiresAt: number },
+): void => {
+  if (credential.source === 'claude-cli' && credential.credentialsPath) {
+    writeClaudeCliOAuthCredentials(credential.credentialsPath, tokens);
+    return;
+  }
+  if (credential.source === 'opencode-auth' && credential.authKey) {
+    const auth = readAuthFile();
+    const previous = auth[credential.authKey] || {};
+    auth[credential.authKey] = {
+      ...previous,
+      type: 'oauth',
+      access: tokens.accessToken,
+      refresh: tokens.refreshToken,
+      expires: tokens.expiresAt,
+    };
+    writeAuthFile(auth);
+  }
+};
+
+export const ensureClaudeUsageAccessToken = async (options: {
+  forceRefresh?: boolean;
+} = {}): Promise<ClaudeUsageAccess | null> => {
+  const forceRefresh = Boolean(options.forceRefresh);
+  const credential = resolveClaudeUsageCredential();
+  if (!credential) return null;
+
+  const canRefresh = Boolean(credential.refreshToken && credential.tokenUrl);
+  const needsRefresh = forceRefresh
+    || !credential.accessToken
+    || isClaudeAccessExpired(credential.expiresAt);
+
+  if (!needsRefresh) {
+    return { accessToken: credential.accessToken, source: credential.source, canRefresh };
+  }
+
+  if (!canRefresh || !credential.refreshToken || !credential.tokenUrl) {
+    return credential.accessToken
+      ? { accessToken: credential.accessToken, source: credential.source, canRefresh: false }
+      : null;
+  }
+
+  if (!claudeRefreshPromise) {
+    claudeRefreshPromise = (async () => {
+      const latest = resolveClaudeUsageCredential() || credential;
+      if (!forceRefresh && latest.accessToken && !isClaudeAccessExpired(latest.expiresAt)) {
+        return {
+          accessToken: latest.accessToken,
+          source: latest.source,
+          canRefresh: Boolean(latest.refreshToken && latest.tokenUrl),
+        };
+      }
+
+      const refreshToken = latest.refreshToken || credential.refreshToken;
+      const tokenUrl = latest.tokenUrl || credential.tokenUrl;
+      if (!refreshToken || !tokenUrl) {
+        throw new Error('Claude OAuth entry has no refresh token');
+      }
+
+      const tokens = await refreshClaudeOAuthToken({ refreshToken, tokenUrl });
+      persistRefreshedCredential({ ...latest, refreshToken, tokenUrl }, tokens);
+      return {
+        accessToken: tokens.accessToken,
+        source: latest.source,
+        canRefresh: true,
+      };
+    })().finally(() => {
+      claudeRefreshPromise = null;
+    });
+  }
+
+  return claudeRefreshPromise;
+};
+
+export const fetchClaudeUsagePayload = async (accessToken: string): Promise<Response> => {
+  return fetch(CLAUDE_USAGE_URL, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'anthropic-beta': CLAUDE_OAUTH_BETA,
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+};

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -1,6 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import {
+  CLAUDE_SESSION_EXPIRED_ERROR,
+  ensureClaudeUsageAccessToken,
+  fetchClaudeUsagePayload,
+  type ClaudeUsageAccess,
+} from './claudeOauth';
 import { fetchOpenCodeGoUsage } from './opencodeGoQuota';
 import { readCredential } from './quotaCredentials';
 
@@ -842,45 +848,65 @@ const fetchGoogleQuota = async (): Promise<ProviderResult> => {
 };
 
 const fetchClaudeQuota = async (): Promise<ProviderResult> => {
-  const auth = readAuthFile();
-  const entry = normalizeAuthEntry(getAuthEntry(auth, ['anthropic', 'claude'])) as Record<string, unknown> | null;
-  const accessToken = (entry?.access as string | undefined) ?? (entry?.token as string | undefined);
-
-  if (!accessToken) {
-    return buildResult({
-      providerId: 'claude',
-      providerName: 'Claude',
-      ok: false,
-      configured: false,
-      error: 'Not configured',
-    });
-  }
-
+  const providerName = 'Claude subscription';
+  let access: ClaudeUsageAccess | null = null;
   try {
-    const response = await fetch('https://api.anthropic.com/api/oauth/usage', {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'anthropic-beta': 'oauth-2025-04-20',
-      },
-    });
+    access = await ensureClaudeUsageAccessToken();
+
+    if (!access?.accessToken) {
+      return buildResult({
+        providerId: 'claude',
+        providerName,
+        ok: false,
+        configured: false,
+        error: 'Not configured',
+      });
+    }
+
+    let response = await fetchClaudeUsagePayload(access.accessToken);
+
+    if (response.status === 401 && access.canRefresh) {
+      try {
+        access = await ensureClaudeUsageAccessToken({ forceRefresh: true });
+      } catch {
+        return buildResult({
+          providerId: 'claude',
+          providerName,
+          ok: false,
+          configured: true,
+          error: CLAUDE_SESSION_EXPIRED_ERROR,
+        });
+      }
+      if (!access?.accessToken) {
+        return buildResult({
+          providerId: 'claude',
+          providerName,
+          ok: false,
+          configured: true,
+          error: CLAUDE_SESSION_EXPIRED_ERROR,
+        });
+      }
+      response = await fetchClaudeUsagePayload(access.accessToken);
+    }
 
     if (!response.ok) {
       return buildResult({
         providerId: 'claude',
-        providerName: 'Claude',
+        providerName,
         ok: false,
         configured: true,
-        error: `API error: ${response.status}`,
+        error: response.status === 401
+          ? CLAUDE_SESSION_EXPIRED_ERROR
+          : `API error: ${response.status}`,
       });
     }
 
     const payload = await response.json() as Record<string, unknown>;
     const windows: Record<string, UsageWindow> = {};
-    const fiveHour = (payload as Record<string, unknown>).five_hour as Record<string, unknown> | undefined;
-    const sevenDay = (payload as Record<string, unknown>).seven_day as Record<string, unknown> | undefined;
-    const sevenDaySonnet = (payload as Record<string, unknown>).seven_day_sonnet as Record<string, unknown> | undefined;
-    const sevenDayOpus = (payload as Record<string, unknown>).seven_day_opus as Record<string, unknown> | undefined;
+    const fiveHour = payload.five_hour as Record<string, unknown> | undefined;
+    const sevenDay = payload.seven_day as Record<string, unknown> | undefined;
+    const sevenDaySonnet = payload.seven_day_sonnet as Record<string, unknown> | undefined;
+    const sevenDayOpus = payload.seven_day_opus as Record<string, unknown> | undefined;
 
     if (fiveHour) {
       windows['5h'] = toUsageWindow({
@@ -913,18 +939,20 @@ const fetchClaudeQuota = async (): Promise<ProviderResult> => {
 
     return buildResult({
       providerId: 'claude',
-      providerName: 'Claude',
+      providerName,
       ok: true,
       configured: true,
       usage: { windows },
     });
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Request failed';
+    const sessionExpired = /token refresh failed|no refresh token|Session expired/i.test(message);
     return buildResult({
       providerId: 'claude',
-      providerName: 'Claude',
+      providerName,
       ok: false,
-      configured: true,
-      error: error instanceof Error ? error.message : 'Request failed',
+      configured: Boolean(access?.accessToken) || sessionExpired,
+      error: sessionExpired ? CLAUDE_SESSION_EXPIRED_ERROR : message,
     });
   }
 };

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -16,7 +16,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 
 | Provider ID | Display name | Module | Auth aliases/keys |
 | --- | --- | --- | --- |
-| `claude` | Claude subscription | `providers/claude.js` (+ `claude-cli-auth.js`) | Claude Code CLI `~/.claude/.credentials.json` OAuth first; fallback OpenCode `auth.json` aliases `anthropic`, `claude` |
+| `claude` | Claude subscription | `providers/claude.js` (+ `claude-cli-auth.js`, `claude-oauth.js`) | Claude Code CLI `~/.claude/.credentials.json` OAuth first; fallback OpenCode `auth.json` aliases `anthropic`, `claude`. Expired access tokens are refreshed via the public Claude Code / OpenCode Anthropic OAuth client before `/api/oauth/usage`; rotated tokens are persisted and concurrent refreshes are single-flighted. |
 | `codex` | Codex | `providers/codex.js` | `openai`, `codex`, `chatgpt` |
 | `cursor` | Cursor | `providers/cursor.js` | Environment/token files, OpenChamber-managed credentials, or explicit one-time Cursor import |
 | `google` | Google | `providers/google/index.js` | `google`, `google.oauth`, Antigravity accounts file |

--- a/packages/web/server/lib/quota/providers/claude-cli-auth.js
+++ b/packages/web/server/lib/quota/providers/claude-cli-auth.js
@@ -1,7 +1,7 @@
 /**
- * Read Claude Code CLI subscription OAuth access token for Usage probes.
- * Never log or return credential file contents beyond the access token value
- * needed for the Anthropic usage request.
+ * Read/write Claude Code CLI subscription OAuth credentials for Usage probes.
+ * Never log or return credential file contents beyond the token fields needed
+ * for Anthropic usage / refresh requests.
  *
  * Resolution order:
  * 1. `CLAUDE_CODE_OAUTH_TOKEN` env (Cursor Use Environment / CI secrets)
@@ -46,27 +46,108 @@ export function listClaudeCredentialsCandidates(homeDir = os.homedir(), env = pr
 }
 
 /**
- * Extract a non-empty OAuth access token from a credentials JSON object.
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function toExpiresAtMs(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value < 1_000_000_000_000 ? value * 1000 : value;
+}
+
+/**
+ * Extract OAuth credential fields from a credentials JSON object.
  * Supports camelCase (current CLI) and snake_case variants.
+ *
+ * @param {unknown} parsed
+ * @returns {{ accessToken: string, refreshToken: string | null, expiresAt: number | null } | null}
+ */
+export function extractClaudeOAuthCredentials(parsed) {
+  if (!parsed || typeof parsed !== 'object') return null;
+  const root = /** @type {Record<string, unknown>} */ (parsed);
+
+  /** @type {Record<string, unknown> | null} */
+  let block = null;
+  if (root.claudeAiOauth && typeof root.claudeAiOauth === 'object') {
+    block = /** @type {Record<string, unknown>} */ (root.claudeAiOauth);
+  } else if (root.claude_ai_oauth && typeof root.claude_ai_oauth === 'object') {
+    block = /** @type {Record<string, unknown>} */ (root.claude_ai_oauth);
+  }
+  if (!block) return null;
+
+  const accessRaw = block.accessToken ?? block.access_token;
+  if (typeof accessRaw !== 'string' || !accessRaw.trim()) return null;
+
+  const refreshRaw = block.refreshToken ?? block.refresh_token;
+  const refreshToken = typeof refreshRaw === 'string' && refreshRaw.trim()
+    ? refreshRaw.trim()
+    : null;
+  const expiresAt = toExpiresAtMs(block.expiresAt ?? block.expires_at);
+
+  return {
+    accessToken: accessRaw.trim(),
+    refreshToken,
+    expiresAt,
+  };
+}
+
+/**
+ * Extract a non-empty OAuth access token from a credentials JSON object.
  *
  * @param {unknown} parsed
  * @returns {string | null}
  */
 export function extractClaudeOAuthAccessToken(parsed) {
-  if (!parsed || typeof parsed !== 'object') return null;
-  const root = /** @type {Record<string, unknown>} */ (parsed);
+  return extractClaudeOAuthCredentials(parsed)?.accessToken ?? null;
+}
 
-  const camel = root.claudeAiOauth;
-  if (camel && typeof camel === 'object') {
-    const access = /** @type {Record<string, unknown>} */ (camel).accessToken;
-    if (typeof access === 'string' && access.trim()) return access.trim();
+/**
+ * @param {{
+ *   homeDir?: string,
+ *   env?: NodeJS.ProcessEnv | Record<string, string | undefined>,
+ *   readFile?: (path: string, encoding: BufferEncoding) => string,
+ *   existsSync?: (path: string) => boolean,
+ * }} [options]
+ * @returns {{
+ *   accessToken: string,
+ *   refreshToken: string | null,
+ *   expiresAt: number | null,
+ *   source: 'env' | 'file',
+ *   credentialsPath: string | null,
+ * } | null}
+ */
+export function readClaudeCliOAuthCredentials(options = {}) {
+  const env = options.env || process.env;
+  const fromEnv = readClaudeCodeOAuthTokenFromEnv(env);
+  if (fromEnv) {
+    return {
+      accessToken: fromEnv,
+      refreshToken: null,
+      expiresAt: null,
+      source: 'env',
+      credentialsPath: null,
+    };
   }
 
-  const snake = root.claude_ai_oauth;
-  if (snake && typeof snake === 'object') {
-    const access = /** @type {Record<string, unknown>} */ (snake).access_token
-      ?? /** @type {Record<string, unknown>} */ (snake).accessToken;
-    if (typeof access === 'string' && access.trim()) return access.trim();
+  const homeDir = options.homeDir || os.homedir();
+  const readFile = options.readFile || ((filePath, encoding) => fs.readFileSync(filePath, encoding));
+  const existsSync = options.existsSync || ((filePath) => fs.existsSync(filePath));
+
+  for (const candidate of listClaudeCredentialsCandidates(homeDir, env)) {
+    try {
+      if (!existsSync(candidate)) continue;
+      const raw = readFile(candidate, 'utf8');
+      if (typeof raw !== 'string' || !raw.trim()) continue;
+      const parsed = JSON.parse(raw);
+      const creds = extractClaudeOAuthCredentials(parsed);
+      if (!creds) continue;
+      return {
+        ...creds,
+        source: 'file',
+        credentialsPath: candidate,
+      };
+    } catch {
+      // continue — malformed / unreadable files are not authoritative success
+    }
   }
 
   return null;
@@ -82,28 +163,93 @@ export function extractClaudeOAuthAccessToken(parsed) {
  * @returns {string | null}
  */
 export function readClaudeCliOAuthAccessToken(options = {}) {
-  const env = options.env || process.env;
-  const fromEnv = readClaudeCodeOAuthTokenFromEnv(env);
-  if (fromEnv) return fromEnv;
+  return readClaudeCliOAuthCredentials(options)?.accessToken ?? null;
+}
 
-  const homeDir = options.homeDir || os.homedir();
-  const readFile = options.readFile || ((filePath, encoding) => fs.readFileSync(filePath, encoding));
-  const existsSync = options.existsSync || ((filePath) => fs.existsSync(filePath));
+/**
+ * Persist refreshed Claude CLI OAuth tokens into an existing credentials file.
+ * Preserves unrelated fields and the existing oauth block key style.
+ *
+ * @param {string} filePath
+ * @param {{ accessToken: string, refreshToken: string, expiresAt: number }} tokens
+ * @param {{
+ *   readFile?: (path: string, encoding: BufferEncoding) => string,
+ *   writeFile?: (path: string, data: string, options?: fs.WriteFileOptions) => void,
+ *   renameSync?: (from: string, to: string) => void,
+ *   existsSync?: (path: string) => boolean,
+ *   chmodSync?: (path: string, mode: number) => void,
+ * }} [options]
+ */
+export function writeClaudeCliOAuthCredentials(filePath, tokens, options = {}) {
+  if (!filePath || typeof filePath !== 'string') {
+    throw new Error('Claude credentials path is required');
+  }
+  if (!tokens?.accessToken || !tokens?.refreshToken || typeof tokens.expiresAt !== 'number') {
+    throw new Error('Claude credentials update is incomplete');
+  }
 
-  for (const candidate of listClaudeCredentialsCandidates(homeDir, env)) {
+  const readFile = options.readFile || ((target, encoding) => fs.readFileSync(target, encoding));
+  const writeFile = options.writeFile || ((target, data, writeOptions) => fs.writeFileSync(target, data, writeOptions));
+  const renameSync = options.renameSync || ((from, to) => fs.renameSync(from, to));
+  const existsSync = options.existsSync || ((target) => fs.existsSync(target));
+  const chmodSync = options.chmodSync || ((target, mode) => fs.chmodSync(target, mode));
+
+  /** @type {Record<string, unknown>} */
+  let root = {};
+  if (existsSync(filePath)) {
     try {
-      if (!existsSync(candidate)) continue;
-      const raw = readFile(candidate, 'utf8');
-      if (typeof raw !== 'string' || !raw.trim()) continue;
-      const parsed = JSON.parse(raw);
-      const token = extractClaudeOAuthAccessToken(parsed);
-      if (token) return token;
+      const raw = readFile(filePath, 'utf8');
+      if (typeof raw === 'string' && raw.trim()) {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') {
+          root = /** @type {Record<string, unknown>} */ (parsed);
+        }
+      }
     } catch {
-      // continue — malformed / unreadable files are not authoritative success
+      root = {};
     }
   }
 
-  return null;
+  const useSnake = Boolean(root.claude_ai_oauth) && !root.claudeAiOauth;
+  const previous = useSnake
+    ? (root.claude_ai_oauth && typeof root.claude_ai_oauth === 'object'
+      ? /** @type {Record<string, unknown>} */ (root.claude_ai_oauth)
+      : {})
+    : (root.claudeAiOauth && typeof root.claudeAiOauth === 'object'
+      ? /** @type {Record<string, unknown>} */ (root.claudeAiOauth)
+      : {});
+
+  const nextBlock = useSnake
+    ? {
+        ...previous,
+        access_token: tokens.accessToken,
+        refresh_token: tokens.refreshToken,
+        expires_at: tokens.expiresAt,
+      }
+    : {
+        ...previous,
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        expiresAt: tokens.expiresAt,
+      };
+
+  const nextRoot = useSnake
+    ? { ...root, claude_ai_oauth: nextBlock }
+    : { ...root, claudeAiOauth: nextBlock };
+
+  const tempPath = `${filePath}.openchamber.tmp`;
+  writeFile(tempPath, `${JSON.stringify(nextRoot, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  try {
+    chmodSync(tempPath, 0o600);
+  } catch {
+    // best-effort on platforms without chmod
+  }
+  renameSync(tempPath, filePath);
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // best-effort
+  }
 }
 
 /**

--- a/packages/web/server/lib/quota/providers/claude-cli-auth.test.js
+++ b/packages/web/server/lib/quota/providers/claude-cli-auth.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import {
   extractClaudeOAuthAccessToken,
+  extractClaudeOAuthCredentials,
   hasClaudeCliOAuthCredentials,
   listClaudeCredentialsCandidates,
   readClaudeCliOAuthAccessToken,
+  readClaudeCliOAuthCredentials,
   readClaudeCodeOAuthTokenFromEnv,
 } from './claude-cli-auth.js';
 
@@ -20,6 +22,20 @@ describe('claude-cli-auth', () => {
     })).toBe('sk-ant-oat01-snake');
   });
 
+  it('extracts refresh token and expiry with access token', () => {
+    expect(extractClaudeOAuthCredentials({
+      claudeAiOauth: {
+        accessToken: 'access',
+        refreshToken: 'refresh',
+        expiresAt: 1_700_000_000_000,
+      },
+    })).toEqual({
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      expiresAt: 1_700_000_000_000,
+    });
+  });
+
   it('returns null for empty or missing oauth blocks', () => {
     expect(extractClaudeOAuthAccessToken(null)).toBeNull();
     expect(extractClaudeOAuthAccessToken({})).toBeNull();
@@ -34,6 +50,16 @@ describe('claude-cli-auth', () => {
       existsSync: () => true,
       readFile: () => JSON.stringify({ claudeAiOauth: { accessToken: 'file-token' } }),
     })).toBe('env-token');
+    expect(readClaudeCliOAuthCredentials({
+      env: { CLAUDE_CODE_OAUTH_TOKEN: 'env-token' },
+      homeDir: '/home/u',
+      existsSync: () => true,
+      readFile: () => JSON.stringify({ claudeAiOauth: { accessToken: 'file-token' } }),
+    })).toMatchObject({
+      accessToken: 'env-token',
+      source: 'env',
+      refreshToken: null,
+    });
   });
 
   it('includes CLAUDE_CONFIG_DIR candidates first', () => {

--- a/packages/web/server/lib/quota/providers/claude-oauth.js
+++ b/packages/web/server/lib/quota/providers/claude-oauth.js
@@ -1,0 +1,339 @@
+/**
+ * Claude subscription OAuth access for Usage probes.
+ * Refreshes expired tokens using the same public client as Claude Code /
+ * OpenCode Anthropic auth, persists rotated credentials, and single-flights
+ * concurrent renewals. Never logs token values.
+ */
+
+import { readAuthFile, writeAuthFile } from '../../opencode/auth.js';
+import { getAuthEntry, normalizeAuthEntry } from '../utils/index.js';
+import {
+  readClaudeCliOAuthCredentials,
+  writeClaudeCliOAuthCredentials,
+} from './claude-cli-auth.js';
+
+/** Public Claude Code / OpenCode Anthropic OAuth client id (not a secret). */
+export const CLAUDE_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+
+/** OpenCode Anthropic plugin token endpoint. */
+export const OPENCODE_CLAUDE_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+
+/** Claude Code CLI token endpoint. */
+export const CLAUDE_CLI_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+
+export const CLAUDE_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+export const CLAUDE_OAUTH_BETA = 'oauth-2025-04-20';
+export const CLAUDE_SESSION_EXPIRED_ERROR = 'Session expired — please re-authenticate with Claude';
+
+const AUTH_ALIASES = ['anthropic', 'claude'];
+const REFRESH_BUFFER_MS = 60_000;
+
+/** @type {Promise<ClaudeUsageAccess> | null} */
+let claudeRefreshPromise = null;
+
+/**
+ * @typedef {{
+ *   accessToken: string,
+ *   refreshToken: string | null,
+ *   expiresAt: number | null,
+ *   source: 'env' | 'claude-cli' | 'opencode-auth',
+ *   tokenUrl: string | null,
+ *   authKey?: string,
+ *   credentialsPath?: string,
+ * }} ClaudeUsageCredential
+ */
+
+/**
+ * @typedef {{
+ *   accessToken: string,
+ *   source: ClaudeUsageCredential['source'],
+ *   canRefresh: boolean,
+ * }} ClaudeUsageAccess
+ */
+
+/**
+ * @param {number | null | undefined} expiresAt
+ * @param {number} [now]
+ * @returns {boolean}
+ */
+export function isClaudeAccessExpired(expiresAt, now = Date.now()) {
+  if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt)) {
+    return false;
+  }
+  return expiresAt - REFRESH_BUFFER_MS <= now;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function toExpiresMs(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value < 1_000_000_000_000 ? value * 1000 : value;
+}
+
+/**
+ * @param {{
+ *   refreshToken: string,
+ *   tokenUrl: string,
+ *   fetchImpl?: typeof fetch,
+ * }} input
+ * @returns {Promise<{ accessToken: string, refreshToken: string, expiresAt: number }>}
+ */
+export async function refreshClaudeOAuthToken(input) {
+  const fetchImpl = input.fetchImpl || fetch;
+  const response = await fetchImpl(input.tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'anthropic-beta': CLAUDE_OAUTH_BETA,
+    },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: input.refreshToken,
+      client_id: CLAUDE_OAUTH_CLIENT_ID,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Claude token refresh failed: ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const accessToken = typeof payload?.access_token === 'string' ? payload.access_token.trim() : '';
+  if (!accessToken) {
+    throw new Error('Claude token refresh returned no access token');
+  }
+
+  const refreshToken = typeof payload?.refresh_token === 'string' && payload.refresh_token.trim()
+    ? payload.refresh_token.trim()
+    : input.refreshToken;
+  const expiresIn = Number(payload?.expires_in);
+  const expiresAt = Date.now() + (Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 3600) * 1000;
+
+  return { accessToken, refreshToken, expiresAt };
+}
+
+/**
+ * @param {{
+ *   env?: NodeJS.ProcessEnv | Record<string, string | undefined>,
+ *   homeDir?: string,
+ *   readFile?: (path: string, encoding: BufferEncoding) => string,
+ *   existsSync?: (path: string) => boolean,
+ *   readAuth?: () => Record<string, unknown>,
+ * }} [options]
+ * @returns {ClaudeUsageCredential | null}
+ */
+export function resolveClaudeUsageCredential(options = {}) {
+  const cli = readClaudeCliOAuthCredentials({
+    env: options.env,
+    homeDir: options.homeDir,
+    readFile: options.readFile,
+    existsSync: options.existsSync,
+  });
+
+  if (cli?.accessToken) {
+    if (cli.source === 'env') {
+      return {
+        accessToken: cli.accessToken,
+        refreshToken: null,
+        expiresAt: null,
+        source: 'env',
+        tokenUrl: null,
+      };
+    }
+
+    return {
+      accessToken: cli.accessToken,
+      refreshToken: cli.refreshToken,
+      expiresAt: cli.expiresAt,
+      source: 'claude-cli',
+      tokenUrl: CLAUDE_CLI_TOKEN_URL,
+      credentialsPath: cli.credentialsPath || undefined,
+    };
+  }
+
+  const readAuth = options.readAuth || readAuthFile;
+  const auth = readAuth();
+  for (const alias of AUTH_ALIASES) {
+    const entry = normalizeAuthEntry(getAuthEntry(auth, [alias]));
+    if (!entry || typeof entry !== 'object') continue;
+    const access = typeof entry.access === 'string' && entry.access.trim()
+      ? entry.access.trim()
+      : typeof entry.token === 'string' && entry.token.trim()
+        ? entry.token.trim()
+        : null;
+    if (!access) continue;
+
+    const refresh = typeof entry.refresh === 'string' && entry.refresh.trim()
+      ? entry.refresh.trim()
+      : null;
+
+    return {
+      accessToken: access,
+      refreshToken: refresh,
+      expiresAt: toExpiresMs(entry.expires),
+      source: 'opencode-auth',
+      tokenUrl: OPENCODE_CLAUDE_TOKEN_URL,
+      authKey: alias,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * @param {ClaudeUsageCredential} credential
+ * @param {{ accessToken: string, refreshToken: string, expiresAt: number }} tokens
+ * @param {{
+ *   writeAuth?: (auth: Record<string, unknown>) => void,
+ *   readAuth?: () => Record<string, unknown>,
+ *   writeCliCredentials?: typeof writeClaudeCliOAuthCredentials,
+ * }} [options]
+ */
+function persistRefreshedCredential(credential, tokens, options = {}) {
+  if (credential.source === 'claude-cli' && credential.credentialsPath) {
+    const writeCli = options.writeCliCredentials || writeClaudeCliOAuthCredentials;
+    writeCli(credential.credentialsPath, {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+    });
+    return;
+  }
+
+  if (credential.source === 'opencode-auth' && credential.authKey) {
+    const readAuth = options.readAuth || readAuthFile;
+    const writeAuth = options.writeAuth || writeAuthFile;
+    const auth = readAuth();
+    const previous = normalizeAuthEntry(auth[credential.authKey]) || {};
+    auth[credential.authKey] = {
+      ...previous,
+      type: 'oauth',
+      access: tokens.accessToken,
+      refresh: tokens.refreshToken,
+      expires: tokens.expiresAt,
+    };
+    writeAuth(auth);
+  }
+}
+
+/**
+ * Resolve a usable Claude subscription access token, refreshing when expired.
+ *
+ * @param {{
+ *   forceRefresh?: boolean,
+ *   env?: NodeJS.ProcessEnv | Record<string, string | undefined>,
+ *   homeDir?: string,
+ *   readFile?: (path: string, encoding: BufferEncoding) => string,
+ *   existsSync?: (path: string) => boolean,
+ *   readAuth?: () => Record<string, unknown>,
+ *   writeAuth?: (auth: Record<string, unknown>) => void,
+ *   writeCliCredentials?: typeof writeClaudeCliOAuthCredentials,
+ *   fetchImpl?: typeof fetch,
+ *   now?: () => number,
+ * }} [options]
+ * @returns {Promise<ClaudeUsageAccess | null>}
+ */
+export async function ensureClaudeUsageAccessToken(options = {}) {
+  const forceRefresh = Boolean(options.forceRefresh);
+  const now = options.now || Date.now;
+
+  const load = () => resolveClaudeUsageCredential(options);
+
+  const credential = load();
+  if (!credential) return null;
+
+  const canRefresh = Boolean(credential.refreshToken && credential.tokenUrl);
+  const needsRefresh = forceRefresh || !credential.accessToken || isClaudeAccessExpired(credential.expiresAt, now());
+
+  if (!needsRefresh) {
+    return {
+      accessToken: credential.accessToken,
+      source: credential.source,
+      canRefresh,
+    };
+  }
+
+  if (!canRefresh || !credential.refreshToken || !credential.tokenUrl) {
+    if (credential.accessToken && !forceRefresh) {
+      return {
+        accessToken: credential.accessToken,
+        source: credential.source,
+        canRefresh: false,
+      };
+    }
+    return credential.accessToken
+      ? {
+          accessToken: credential.accessToken,
+          source: credential.source,
+          canRefresh: false,
+        }
+      : null;
+  }
+
+  if (!claudeRefreshPromise) {
+    claudeRefreshPromise = (async () => {
+      // Re-read under the lock in case another host already rotated tokens.
+      const latest = load() || credential;
+      if (
+        !forceRefresh
+        && latest.accessToken
+        && !isClaudeAccessExpired(latest.expiresAt, now())
+      ) {
+        return {
+          accessToken: latest.accessToken,
+          source: latest.source,
+          canRefresh: Boolean(latest.refreshToken && latest.tokenUrl),
+        };
+      }
+
+      const refreshToken = latest.refreshToken || credential.refreshToken;
+      const tokenUrl = latest.tokenUrl || credential.tokenUrl;
+      if (!refreshToken || !tokenUrl) {
+        throw new Error('Claude OAuth entry has no refresh token');
+      }
+
+      const tokens = await refreshClaudeOAuthToken({
+        refreshToken,
+        tokenUrl,
+        fetchImpl: options.fetchImpl,
+      });
+
+      persistRefreshedCredential({ ...latest, refreshToken, tokenUrl }, tokens, options);
+
+      return {
+        accessToken: tokens.accessToken,
+        source: latest.source,
+        canRefresh: true,
+      };
+    })().finally(() => {
+      claudeRefreshPromise = null;
+    });
+  }
+
+  return claudeRefreshPromise;
+}
+
+/**
+ * @param {string} accessToken
+ * @param {{ fetchImpl?: typeof fetch }} [options]
+ */
+export async function fetchClaudeUsagePayload(accessToken, options = {}) {
+  const fetchImpl = options.fetchImpl || fetch;
+  return fetchImpl(CLAUDE_USAGE_URL, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'anthropic-beta': CLAUDE_OAUTH_BETA,
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+}
+
+/** @internal test helper */
+export function __resetClaudeRefreshLockForTests() {
+  claudeRefreshPromise = null;
+}

--- a/packages/web/server/lib/quota/providers/claude.js
+++ b/packages/web/server/lib/quota/providers/claude.js
@@ -7,6 +7,11 @@ import {
   toNumber,
   toTimestamp
 } from '../utils/index.js';
+import {
+  CLAUDE_SESSION_EXPIRED_ERROR,
+  ensureClaudeUsageAccessToken,
+  fetchClaudeUsagePayload,
+} from './claude-oauth.js';
 import { readClaudeCliOAuthAccessToken } from './claude-cli-auth.js';
 
 export const providerId = 'claude';
@@ -14,30 +19,17 @@ export const providerName = 'Claude subscription';
 const aliases = ['anthropic', 'claude'];
 
 /**
- * Resolve a bearer token for Claude subscription usage windows.
+ * Resolve whether Claude subscription usage can be probed.
  * Prefers Claude Code CLI OAuth (engine-aligned), then OpenCode auth.json.
- * Never logs token values.
  *
- * @returns {{ accessToken: string | null, source: 'claude-cli' | 'opencode-auth' | null }}
+ * @returns {boolean}
  */
-function resolveClaudeUsageAccessToken() {
-  const cliToken = readClaudeCliOAuthAccessToken();
-  if (cliToken) {
-    return { accessToken: cliToken, source: 'claude-cli' };
-  }
-
+export const isConfigured = () => {
+  if (readClaudeCliOAuthAccessToken()) return true;
   const auth = readAuthFile();
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
   const openCodeToken = entry?.access ?? entry?.token;
-  if (typeof openCodeToken === 'string' && openCodeToken.trim()) {
-    return { accessToken: openCodeToken.trim(), source: 'opencode-auth' };
-  }
-
-  return { accessToken: null, source: null };
-}
-
-export const isConfigured = () => {
-  return Boolean(resolveClaudeUsageAccessToken().accessToken);
+  return typeof openCodeToken === 'string' && Boolean(openCodeToken.trim());
 };
 
 /**
@@ -83,10 +75,29 @@ export function mapClaudeUsageWindows(payload) {
   return windows;
 }
 
-export const fetchQuota = async () => {
-  const { accessToken } = resolveClaudeUsageAccessToken();
+/**
+ * @param {number} status
+ */
+function usageAuthError(status) {
+  if (status === 401) return CLAUDE_SESSION_EXPIRED_ERROR;
+  return `API error: ${status}`;
+}
 
-  if (!accessToken) {
+export const fetchQuota = async () => {
+  let access;
+  try {
+    access = await ensureClaudeUsageAccessToken();
+  } catch {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: CLAUDE_SESSION_EXPIRED_ERROR,
+    });
+  }
+
+  if (!access?.accessToken) {
     return buildResult({
       providerId,
       providerName,
@@ -97,13 +108,33 @@ export const fetchQuota = async () => {
   }
 
   try {
-    const response = await fetch('https://api.anthropic.com/api/oauth/usage', {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'anthropic-beta': 'oauth-2025-04-20'
+    let response = await fetchClaudeUsagePayload(access.accessToken);
+
+    if (response.status === 401 && access.canRefresh) {
+      try {
+        access = await ensureClaudeUsageAccessToken({ forceRefresh: true });
+      } catch {
+        return buildResult({
+          providerId,
+          providerName,
+          ok: false,
+          configured: true,
+          error: CLAUDE_SESSION_EXPIRED_ERROR,
+        });
       }
-    });
+
+      if (!access?.accessToken) {
+        return buildResult({
+          providerId,
+          providerName,
+          ok: false,
+          configured: true,
+          error: CLAUDE_SESSION_EXPIRED_ERROR,
+        });
+      }
+
+      response = await fetchClaudeUsagePayload(access.accessToken);
+    }
 
     if (!response.ok) {
       return buildResult({
@@ -111,7 +142,7 @@ export const fetchQuota = async () => {
         providerName,
         ok: false,
         configured: true,
-        error: `API error: ${response.status}`
+        error: usageAuthError(response.status)
       });
     }
 

--- a/packages/web/server/lib/quota/providers/claude.test.js
+++ b/packages/web/server/lib/quota/providers/claude.test.js
@@ -1,7 +1,24 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  CLAUDE_CLI_TOKEN_URL,
+  CLAUDE_OAUTH_CLIENT_ID,
+  CLAUDE_SESSION_EXPIRED_ERROR,
+  CLAUDE_USAGE_URL,
+  OPENCODE_CLAUDE_TOKEN_URL,
+  __resetClaudeRefreshLockForTests,
+  ensureClaudeUsageAccessToken,
+  isClaudeAccessExpired,
+  refreshClaudeOAuthToken,
+  resolveClaudeUsageCredential,
+} from './claude-oauth.js';
+import { extractClaudeOAuthCredentials, writeClaudeCliOAuthCredentials } from './claude-cli-auth.js';
 import { mapClaudeUsageWindows, providerName } from './claude.js';
 
 describe('claude quota provider', () => {
+  afterEach(() => {
+    __resetClaudeRefreshLockForTests();
+  });
+
   it('labels the provider as Claude subscription usage', () => {
     expect(providerName).toBe('Claude subscription');
   });
@@ -20,5 +37,225 @@ describe('claude quota provider', () => {
   it('returns an empty window map for empty payloads', () => {
     expect(mapClaudeUsageWindows(null)).toEqual({});
     expect(mapClaudeUsageWindows({})).toEqual({});
+  });
+
+  it('treats access tokens as expired inside the refresh buffer', () => {
+    const now = 1_000_000;
+    expect(isClaudeAccessExpired(now + 30_000, now)).toBe(true);
+    expect(isClaudeAccessExpired(now + 120_000, now)).toBe(false);
+    expect(isClaudeAccessExpired(null, now)).toBe(false);
+  });
+
+  it('extracts refresh + expiry from Claude CLI credentials', () => {
+    expect(extractClaudeOAuthCredentials({
+      claudeAiOauth: {
+        accessToken: 'access',
+        refreshToken: 'refresh',
+        expiresAt: 1_700_000_000_000,
+      },
+    })).toEqual({
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      expiresAt: 1_700_000_000_000,
+    });
+  });
+
+  it('resolves OpenCode auth credentials for refresh', () => {
+    const resolved = resolveClaudeUsageCredential({
+      env: {},
+      homeDir: '/missing-home',
+      existsSync: () => false,
+      readFile: () => '',
+      readAuth: () => ({
+        anthropic: {
+          type: 'oauth',
+          access: 'stale-access',
+          refresh: 'refresh-token',
+          expires: Date.now() - 60_000,
+        },
+      }),
+    });
+
+    expect(resolved).toMatchObject({
+      accessToken: 'stale-access',
+      refreshToken: 'refresh-token',
+      source: 'opencode-auth',
+      tokenUrl: OPENCODE_CLAUDE_TOKEN_URL,
+      authKey: 'anthropic',
+    });
+  });
+
+  it('refreshes via the OpenCode Anthropic OAuth contract', async () => {
+    const calls = [];
+    const result = await refreshClaudeOAuthToken({
+      refreshToken: 'refresh-token',
+      tokenUrl: OPENCODE_CLAUDE_TOKEN_URL,
+      fetchImpl: async (url, init) => {
+        calls.push({ url, body: JSON.parse(String(init?.body || '{}')) });
+        return new Response(JSON.stringify({
+          access_token: 'new-access',
+          refresh_token: 'rotated-refresh',
+          expires_in: 3600,
+        }), { status: 200 });
+      },
+    });
+
+    expect(calls[0]?.url).toBe(OPENCODE_CLAUDE_TOKEN_URL);
+    expect(calls[0]?.body).toEqual({
+      grant_type: 'refresh_token',
+      refresh_token: 'refresh-token',
+      client_id: CLAUDE_OAUTH_CLIENT_ID,
+    });
+    expect(result.accessToken).toBe('new-access');
+    expect(result.refreshToken).toBe('rotated-refresh');
+    expect(result.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('refreshes expired OpenCode tokens and persists the rotation', async () => {
+    const auth = {
+      anthropic: {
+        type: 'oauth',
+        access: 'expired-access',
+        refresh: 'refresh-token',
+        expires: Date.now() - 60_000,
+      },
+    };
+    let wrote = null;
+
+    const access = await ensureClaudeUsageAccessToken({
+      env: {},
+      homeDir: '/missing-home',
+      existsSync: () => false,
+      readFile: () => '',
+      readAuth: () => auth,
+      writeAuth: (next) => {
+        wrote = next;
+        Object.assign(auth, next);
+      },
+      fetchImpl: async () => new Response(JSON.stringify({
+        access_token: 'fresh-access',
+        refresh_token: 'fresh-refresh',
+        expires_in: 7200,
+      }), { status: 200 }),
+    });
+
+    expect(access).toMatchObject({
+      accessToken: 'fresh-access',
+      source: 'opencode-auth',
+      canRefresh: true,
+    });
+    expect(wrote?.anthropic).toMatchObject({
+      type: 'oauth',
+      access: 'fresh-access',
+      refresh: 'fresh-refresh',
+    });
+    expect(typeof wrote?.anthropic?.expires).toBe('number');
+    expect(wrote.anthropic.expires).toBeGreaterThan(Date.now());
+  });
+
+  it('single-flights concurrent Claude refreshes', async () => {
+    let refreshCalls = 0;
+    const auth = {
+      anthropic: {
+        type: 'oauth',
+        access: 'expired-access',
+        refresh: 'refresh-token',
+        expires: Date.now() - 60_000,
+      },
+    };
+
+    const options = {
+      env: {},
+      homeDir: '/missing-home',
+      existsSync: () => false,
+      readFile: () => '',
+      readAuth: () => auth,
+      writeAuth: (next) => Object.assign(auth, next),
+      fetchImpl: async () => {
+        refreshCalls += 1;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return new Response(JSON.stringify({
+          access_token: 'shared-access',
+          refresh_token: 'shared-refresh',
+          expires_in: 3600,
+        }), { status: 200 });
+      },
+    };
+
+    const [first, second] = await Promise.all([
+      ensureClaudeUsageAccessToken(options),
+      ensureClaudeUsageAccessToken(options),
+    ]);
+
+    expect(refreshCalls).toBe(1);
+    expect(first?.accessToken).toBe('shared-access');
+    expect(second?.accessToken).toBe('shared-access');
+  });
+
+  it('writes refreshed Claude CLI credentials without dropping other fields', () => {
+    const files = new Map([
+      ['/tmp/creds.json', JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'old',
+          refreshToken: 'old-refresh',
+          expiresAt: 1,
+          scopes: ['user:inference'],
+        },
+        other: true,
+      })],
+    ]);
+
+    writeClaudeCliOAuthCredentials('/tmp/creds.json', {
+      accessToken: 'new',
+      refreshToken: 'new-refresh',
+      expiresAt: 99,
+    }, {
+      existsSync: (filePath) => files.has(filePath) || filePath.endsWith('.tmp'),
+      readFile: (filePath) => files.get(filePath) || '',
+      writeFile: (filePath, data) => {
+        files.set(filePath, String(data));
+      },
+      renameSync: (from, to) => {
+        files.set(to, files.get(from) || '');
+        files.delete(from);
+      },
+      chmodSync: () => {},
+    });
+
+    const written = JSON.parse(files.get('/tmp/creds.json'));
+    expect(written.other).toBe(true);
+    expect(written.claudeAiOauth).toEqual({
+      accessToken: 'new',
+      refreshToken: 'new-refresh',
+      expiresAt: 99,
+      scopes: ['user:inference'],
+    });
+  });
+
+  it('uses the Claude CLI token URL for CLI credential sources', () => {
+    const resolved = resolveClaudeUsageCredential({
+      env: {},
+      homeDir: '/home/u',
+      existsSync: (filePath) => filePath.endsWith('.claude/.credentials.json'),
+      readFile: () => JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'cli-access',
+          refreshToken: 'cli-refresh',
+          expiresAt: Date.now() + 120_000,
+        },
+      }),
+      readAuth: () => ({}),
+    });
+
+    expect(resolved).toMatchObject({
+      source: 'claude-cli',
+      tokenUrl: CLAUDE_CLI_TOKEN_URL,
+      refreshToken: 'cli-refresh',
+    });
+  });
+
+  it('exposes a stable session-expired message constant for UI panels', () => {
+    expect(CLAUDE_USAGE_URL).toContain('/api/oauth/usage');
+    expect(CLAUDE_SESSION_EXPIRED_ERROR).toContain('re-authenticate');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fixes Claude subscription Usage showing `API error: 401` in header Services and Settings → Usage when the OAuth access token expired between model calls (#2443).

Before calling `https://api.anthropic.com/api/oauth/usage`, OpenChamber now refreshes expired Claude Code CLI / OpenCode Anthropic OAuth tokens (same public client contract), persists rotated credentials, single-flights concurrent renewals, retries once on 401, and surfaces a clear re-auth message only when refresh cannot recover.

## Non-goals

- No UI redesign of Services or Settings Usage.
- No changes to other quota providers.
- No interactive Claude login flow changes.

## Affected surfaces

- `packages/web` quota provider (`claude.js`, new `claude-oauth.js`, `claude-cli-auth.js`) — powers web/desktop/hosted-mobile Services + Settings Usage.
- `packages/vscode` (`claudeOauth.ts`, `quotaProviders.ts`) — VS Code rate-limits / Usage parity.
- Persisted credentials: may rewrite OpenCode `auth.json` anthropic/claude OAuth entries and Claude CLI `~/.claude/.credentials.json` oauth blocks with rotated access/refresh/expiry. Never returns or logs secrets.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` correctness invariants | Authoritative usage must not treat expired-auth failure as empty success | Refresh or explicit error; no silent empty windows |
| `openchamber-change-discipline` | Source/contract change in quota providers | Smallest fix; focused tests; package checks |
| `ui-api-decoupling` | Server quota route feeds shared UI | Kept OpenChamber route contract; failure remains explicit |
| `packages/web/server/lib/quota/DOCUMENTATION.md` | Claude auth/refresh invariant changed | Documented refresh + persist + single-flight |

## Validation

| Check | Result |
|---|---|
| `bun test packages/web/server/lib/quota/providers/claude.test.js packages/web/server/lib/quota/providers/claude-cli-auth.test.js` | Pass (20 tests) |
| `bun run type-check:web` | Pass |
| `bun run --cwd packages/vscode type-check` | Pass |
| `bun run dead-code` | Inspected; no new actionable Claude quota dead exports after trimming VS Code exports |
| Live Anthropic refresh against a real expired token | Not verified in this environment |

## Visual evidence

No rendered UI chrome changes. Services and Settings Usage already render provider `error` / window cards from the quota API; this restores successful window payloads (or a clearer session-expired error) for Claude subscription.

## Risks and failure behavior

- Refresh requires a stored refresh token. Env-only `CLAUDE_CODE_OAUTH_TOKEN` still cannot renew; users see session-expired instead of raw `API error: 401`.
- Rotated refresh tokens are persisted atomically to the credential source; concurrent usage refreshes share one in-flight renewal to avoid invalidating each other.
- If refresh itself fails, Usage stays configured with an explicit re-auth error and does not clear unrelated providers.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebca2e05-b02f-406f-bae7-c9f207318097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebca2e05-b02f-406f-bae7-c9f207318097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

