### PR TITLE
fix(engines): enable shell mode on Claude Code sessions

### DIFF
--- a/docs/engines-claude-code-spec.md
+++ b/docs/engines-claude-code-spec.md
@@ -191,6 +191,7 @@ type HarnessDescriptor = {
 | permissions | full | `canUseTool` → `permission.asked` with Always patterns + tool linkage; agent-derived `permissionMode`; fail-closed timeout/abort |
 | images | full | base64 image blocks |
 | file-attachments | full | `data:` embeds; sandboxed `file://` / project-path refs; images, text-like, PDF; reject opaque binaries |
+| shell | full | OpenCode `session.shell` on the shared session id (engine-independent; available while Claude owns prompt turns) |
 | slash-commands | partial | known OpenCode slash/skills blocked on Claude send; CLI-native skills via prompt text only |
 | mcp | partial | whatever Claude loads natively; no OpenChamber MCP editor bridge |
 | subagents | partial | appear in stream if CLI emits; limited UI affordances |
@@ -413,11 +414,13 @@ Status matrix: `ready` / `needs-login` / `missing-cli` / `error`. `unsupported-h
 ```
 sendMessage / routeMessage
   resolve ExecutionTarget (sticky session → pending handoff → last-used)
-  if harnessId === 'opencode':
+  if inputMode === 'shell':
+    opencodeClient.shellSession (shared session infrastructure; all engines)
+  else if harnessId === 'opencode':
     existing opencodeClient path
   else if harnessId === 'claude-code':
     block if catalog status ≠ ready (toast + deep-link Engines)
-    block shell mode and known OpenCode slash/skills
+    block known OpenCode slash/skills
     optimisticSend → POST /api/harness/prompt {
       sessionId, directory, target, text, files?, messageId?, assistantMessageId?, seedFromSessionId?
     }

--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -2639,11 +2639,9 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                     || error.code === 'CLAUDE_MISSING_CLI'
                     || error.code === 'CLAUDE_NEEDS_LOGIN'
                     ? t('chat.engines.notReady')
-                    : error.code === 'CLAUDE_SHELL_UNSUPPORTED'
-                        ? t('chat.engines.shellUnsupported')
-                        : error.code === 'CLAUDE_SLASH_UNSUPPORTED'
-                            ? t('chat.engines.slashUnsupported')
-                            : (rawMessage || t('chat.chatInput.toast.messageSendFailed'));
+                    : error.code === 'CLAUDE_SLASH_UNSUPPORTED'
+                        ? t('chat.engines.slashUnsupported')
+                        : (rawMessage || t('chat.chatInput.toast.messageSendFailed'));
                 if (allAttachments.length > 0) {
                     useInputStore.getState().setAttachedFiles(allAttachments);
                 }

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2210,7 +2210,6 @@ export const dict = {
   'chat.engines.manageEngines': 'Manage engines…',
   'chat.engines.chip.claude': 'Claude · {model}',
   'chat.engines.notReady': 'Claude Code is not ready. Open Settings → Engines to install, log in, or re-detect.',
-  'chat.engines.shellUnsupported': 'Shell mode is not available on Claude Code. Switch to OpenCode or send a normal message.',
   'chat.engines.slashUnsupported': 'Slash commands are not available on Claude Code. Switch to OpenCode or send a normal message.',
   'chat.engines.permissionMode.label': 'Permission mode',
   'chat.engines.permissionMode.default': 'Default',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2176,7 +2176,6 @@ export const dict: Record<I18nKey, string> = {
   "chat.engines.manageEngines": "Administrar motores…",
   "chat.engines.chip.claude": "Claude · {model}",
   "chat.engines.notReady": "Claude Code no está listo. Abre Ajustes → Motores para instalar, iniciar sesión o volver a detectar.",
-  "chat.engines.shellUnsupported": "El modo shell no está disponible en Claude Code. Cambia a OpenCode o envía un mensaje normal.",
   "chat.engines.slashUnsupported": "Los comandos con barra no están disponibles en Claude Code. Cambia a OpenCode o envía un mensaje normal.",
   "chat.engines.permissionMode.label": "Modo de permisos",
   "chat.engines.permissionMode.default": "Predeterminado",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1976,7 +1976,6 @@ export const dict = {
   'chat.engines.manageEngines': 'Gérer les moteurs…',
   'chat.engines.chip.claude': 'Claude · {model}',
   'chat.engines.notReady': 'Claude Code n’est pas prêt. Ouvrez Réglages → Moteurs pour installer, vous connecter ou redétecter.',
-  'chat.engines.shellUnsupported': 'Le mode shell n’est pas disponible sur Claude Code. Passez à OpenCode ou envoyez un message normal.',
   'chat.engines.slashUnsupported': 'Les commandes slash ne sont pas disponibles sur Claude Code. Passez à OpenCode ou envoyez un message normal.',
   'chat.engines.permissionMode.label': 'Mode d’autorisation',
   'chat.engines.permissionMode.default': 'Par défaut',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2209,7 +2209,6 @@ export const dict: Record<I18nKey, string> = {
   'chat.engines.manageEngines': 'エンジンを管理…',
   'chat.engines.chip.claude': 'Claude · {model}',
   'chat.engines.notReady': 'Claude Code の準備ができていません。設定 → エンジンでインストール、ログイン、または再検出してください。',
-  'chat.engines.shellUnsupported': 'シェルモードは Claude Code では利用できません。OpenCode に切り替えるか、通常のメッセージを送信してください。',
   'chat.engines.slashUnsupported': 'スラッシュコマンドは Claude Code では利用できません。OpenCode に切り替えるか、通常のメッセージを送信してください。',
   'chat.engines.permissionMode.label': '権限モード',
   'chat.engines.permissionMode.default': 'デフォルト',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2210,7 +2210,6 @@ export const dict: Record<I18nKey, string> = {
   'chat.engines.manageEngines': '엔진 관리…',
   'chat.engines.chip.claude': 'Claude · {model}',
   'chat.engines.notReady': 'Claude Code가 준비되지 않았습니다. 설정 → 엔진에서 설치, 로그인 또는 다시 감지하세요.',
-  'chat.engines.shellUnsupported': 'Claude Code에서는 셸 모드를 사용할 수 없습니다. OpenCode로 전환하거나 일반 메시지를 보내세요.',
   'chat.engines.slashUnsupported': 'Claude Code에서는 슬래시 명령을 사용할 수 없습니다. OpenCode로 전환하거나 일반 메시지를 보내세요.',
   'chat.engines.permissionMode.label': '권한 모드',
   'chat.engines.permissionMode.default': '기본',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1214,7 +1214,6 @@ export const dict: Record<I18nKey, string> = {
   'chat.engines.manageEngines': 'Zarządzaj silnikami…',
   'chat.engines.chip.claude': 'Claude · {model}',
   'chat.engines.notReady': 'Claude Code nie jest gotowy. Otwórz Ustawienia → Silniki, aby zainstalować, zalogować się lub wykryć ponownie.',
-  'chat.engines.shellUnsupported': 'Tryb powłoki nie jest dostępny w Claude Code. Przełącz na OpenCode lub wyślij zwykłą wiadomość.',
   'chat.engines.slashUnsupported': 'Polecenia slash nie są dostępne w Claude Code. Przełącz na OpenCode lub wyślij zwykłą wiadomość.',
   'chat.engines.permissionMode.label': 'Tryb uprawnień',
   'chat.engines.permissionMode.default': 'Domyślny',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2176,7 +2176,6 @@ export const dict: Record<I18nKey, string> = {
   "chat.engines.manageEngines": "Gerenciar mecanismos…",
   "chat.engines.chip.claude": "Claude · {model}",
   "chat.engines.notReady": "O Claude Code não está pronto. Abra Configurações → Mecanismos para instalar, entrar ou detectar novamente.",
-  "chat.engines.shellUnsupported": "O modo shell não está disponível no Claude Code. Mude para o OpenCode ou envie uma mensagem normal.",
   "chat.engines.slashUnsupported": "Comandos com barra não estão disponíveis no Claude Code. Mude para o OpenCode ou envie uma mensagem normal.",
   "chat.engines.permissionMode.label": "Modo de permissão",
   "chat.engines.permissionMode.default": "Padrão",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2176,7 +2176,6 @@ export const dict: Record<I18nKey, string> = {
   "chat.engines.manageEngines": "Керувати рушіями…",
   "chat.engines.chip.claude": "Claude · {model}",
   "chat.engines.notReady": "Claude Code не готовий. Відкрийте Налаштування → Рушії, щоб встановити, увійти або виявити знову.",
-  "chat.engines.shellUnsupported": "Режим оболонки недоступний у Claude Code. Перейдіть на OpenCode або надішліть звичайне повідомлення.",
   "chat.engines.slashUnsupported": "Команди зі слешем недоступні у Claude Code. Перейдіть на OpenCode або надішліть звичайне повідомлення.",
   "chat.engines.permissionMode.label": "Режим дозволів",
   "chat.engines.permissionMode.default": "Типовий",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2176,7 +2176,6 @@ export const dict: Record<I18nKey, string> = {
   'chat.engines.manageEngines': '管理引擎…',
   'chat.engines.chip.claude': 'Claude · {model}',
   'chat.engines.notReady': 'Claude Code 尚未就绪。请打开设置 → 引擎以安装、登录或重新检测。',
-  'chat.engines.shellUnsupported': 'Claude Code 不支持 Shell 模式。请切换到 OpenCode，或发送普通消息。',
   'chat.engines.slashUnsupported': 'Claude Code 不支持斜杠命令。请切换到 OpenCode，或发送普通消息。',
   'chat.engines.permissionMode.label': '权限模式',
   'chat.engines.permissionMode.default': '默认',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2180,7 +2180,6 @@ export const dict: Record<I18nKey, string> = {
   'chat.engines.manageEngines': '管理引擎…',
   'chat.engines.chip.claude': 'Claude · {model}',
   'chat.engines.notReady': 'Claude Code 尚未就緒。請開啟設定 → 引擎以安裝、登入或重新偵測。',
-  'chat.engines.shellUnsupported': 'Claude Code 不支援 Shell 模式。請切換到 OpenCode，或傳送一般訊息。',
   'chat.engines.slashUnsupported': 'Claude Code 不支援斜線指令。請切換到 OpenCode，或傳送一般訊息。',
   'chat.engines.permissionMode.label': '權限模式',
   'chat.engines.permissionMode.default': '預設',

--- a/packages/ui/src/sync/route-message-harness.test.js
+++ b/packages/ui/src/sync/route-message-harness.test.js
@@ -35,11 +35,14 @@ const { useSkillsStore } = await import('@/stores/useSkillsStore');
 
 describe('routeMessage Claude harness branch', () => {
   const sendMessageCalls = [];
+  const shellSessionCalls = [];
   let originalSendMessage;
+  let originalShellSession;
 
   beforeEach(() => {
     harnessPromptCalls.length = 0;
     sendMessageCalls.length = 0;
+    shellSessionCalls.length = 0;
     harnessPromptMock.mockClear();
 
     const childStore = {
@@ -89,10 +92,16 @@ describe('routeMessage Claude harness branch', () => {
       sendMessageCalls.push(params);
       return 'msg';
     };
+    originalShellSession = opencodeClient.shellSession;
+    opencodeClient.shellSession = async (params) => {
+      shellSessionCalls.push(params);
+      return { info: {}, parts: [] };
+    };
   });
 
   afterEach(() => {
     opencodeClient.sendMessage = originalSendMessage;
+    opencodeClient.shellSession = originalShellSession;
     useSelectionStore.setState({
       sessionTargets: new Map(),
       lastUsedTarget: null,
@@ -127,27 +136,30 @@ describe('routeMessage Claude harness branch', () => {
     expect(sendMessageCalls).toHaveLength(0);
   });
 
-  test('rejects shell mode on Claude instead of OpenCode fallback', async () => {
+  test('routes shell mode through OpenCode session.shell on Claude sessions', async () => {
     useSelectionStore.getState().saveSessionTarget('session-claude', {
       harnessId: 'claude-code',
       modelRef: 'sonnet',
     });
 
-    let caught = null;
-    try {
-      await routeMessage({
-        sessionId: 'session-claude',
-        directory: '/claude/project',
-        content: 'ls',
-        providerID: 'anthropic',
-        modelID: 'claude-sonnet',
-        inputMode: 'shell',
-      });
-    } catch (error) {
-      caught = error;
-    }
+    await routeMessage({
+      sessionId: 'session-claude',
+      directory: '/claude/project',
+      content: 'ls',
+      providerID: 'anthropic',
+      modelID: 'claude-sonnet',
+      agent: 'build',
+      inputMode: 'shell',
+    });
 
-    expect(caught?.code).toBe('CLAUDE_SHELL_UNSUPPORTED');
+    expect(shellSessionCalls).toHaveLength(1);
+    expect(shellSessionCalls[0]).toEqual({
+      sessionId: 'session-claude',
+      directory: '/claude/project',
+      agent: 'build',
+      model: { providerID: 'anthropic', modelID: 'claude-sonnet' },
+      command: 'ls',
+    });
     expect(harnessPromptCalls).toHaveLength(0);
     expect(sendMessageCalls).toHaveLength(0);
   });

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -87,8 +87,6 @@ import type { ExecutionTarget } from "@/types/harness"
 
 export type { AttachedFile }
 
-const CLAUDE_SHELL_UNSUPPORTED =
-  "Shell mode is not available on Claude Code. Switch to OpenCode or send a normal message."
 const CLAUDE_SLASH_UNSUPPORTED =
   "Slash commands are not available on Claude Code. Switch to OpenCode or send a normal message."
 const CLAUDE_NOT_READY_MESSAGE =
@@ -141,12 +139,22 @@ export function routeMessage(params: {
     persistSessionExecutionTarget(params.sessionId, target)
   }
 
-  if (target.harnessId === "claude-code") {
-    if (params.inputMode === "shell") {
-      return Promise.reject(new HarnessClientError(CLAUDE_SHELL_UNSUPPORTED, "CLAUDE_SHELL_UNSUPPORTED", 400))
-    }
+  // Shell mode uses OpenCode session.shell on the shared session id. It is
+  // session infrastructure, not an engine prompt path — available for every
+  // sticky harness (including Claude Code).
+  if (params.inputMode === "shell") {
+    return opencodeClient.shellSession({
+      sessionId: params.sessionId,
+      directory: requestDirectory,
+      agent: params.agent ?? "",
+      model: { providerID: params.providerID, modelID: params.modelID },
+      command: params.content,
+    }).then(() => undefined)
+  }
 
-    // Reject slash/shell on Claude rather than silently falling back to OpenCode.
+  if (target.harnessId === "claude-code") {
+    // Reject known OpenCode slash/skills on Claude rather than silently falling
+    // back to OpenCode command dispatch.
     if (params.content.startsWith("/")) {
       const [head] = params.content.split(" ")
       const cmdName = head.slice(1)
@@ -219,16 +227,6 @@ export function routeMessage(params: {
         seedFromSessionId: params.seedFromSessionId,
       }).then(() => {}),
     })
-  }
-
-  if (params.inputMode === "shell") {
-    return opencodeClient.shellSession({
-      sessionId: params.sessionId,
-      directory: requestDirectory,
-      agent: params.agent ?? "",
-      model: { providerID: params.providerID, modelID: params.modelID },
-      command: params.content,
-    }).then(() => undefined)
   }
 
   // Slash commands — fire and forget, SSE delivers messages and status


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Shell mode (`!` / shell input) was rejected on Claude Code sessions with “Shell mode is not available on Claude Code…”, even though Claude’s capability matrix already advertises `shell: full` and sessions still use OpenCode session IDs. Shell is session infrastructure (`session.shell`), not an engine prompt path, so it should work on every engine.

## Non-goals

- OpenCode slash commands / skills on Claude (still blocked; those are OpenCode command dispatch, not shell).
- New harness `/api/harness` shell endpoint.

## Affected surfaces

- `packages/ui` send routing (`routeMessage`), ChatInput harness error mapping, i18n cleanup.
- Shared UI contract for web / desktop / VS Code / mobile composers that use `routeMessage` — Claude sticky sessions can now run shell via OpenCode `session.shell`.
- `docs/engines-claude-code-spec.md` send-path / capability matrix alignment.
- No persisted binding shape change; no server translator change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Source/contract behavior change in shared UI | Smallest fix: move shell routing before the Claude branch; update owning contract docs + focused tests |
| `sync-state-invariants` | Changes session send routing | Keep slash rejection; do not treat shell as Claude prompt; preserve sticky target persistence |
| `ui-api-decoupling` | Shell remains on official OpenCode SDK | Continue using `opencodeClient.shellSession` / `session.shell`; Claude prompts stay on `/api/harness/prompt` |
| `locale-ui-patterns` | Removed obsolete user-facing error string | Deleted `chat.engines.shellUnsupported` from every locale dictionary and ChatInput mapping |
| `packages/ui/src/sync/DOCUMENTATION.md` | Nearest sync ownership doc | No ownership map change; send entrypoint still `session-ui-store` |
| `docs/engines-claude-code-spec.md` | Engine contract truth changed | Updated capability notes + §8.1 send path to match implementation |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/sync/route-message-harness.test.js packages/ui/src/sync/session-ui-store.test.js` | Pass (22 tests) |
| `bun run type-check:ui` | Pass |
| `bun run lint` (changed UI files from `packages/ui`) | Pass |
| Runtime / manual shell submit on Claude session | Not verified in this environment |
| `bun run dead-code` | Not run (no added/deleted/renamed source files or export/import shape changes) |

## Visual evidence

No rendered layout/CSS change. Behavior change is send routing only: shell submit on a Claude session no longer toasts unsupported and instead calls OpenCode `session.shell` (same path as OpenCode engine).

## Risks and failure behavior

- Shell still depends on OpenCode `session.shell` succeeding for that session id/directory; failures surface as normal send errors (not a Claude-specific unsupported toast).
- Claude readiness is not required for shell (by design); prompt turns still require Claude ready.
- Slash/skills remain rejected on Claude to avoid silent OpenCode command fallback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ea02b61-af05-4cbe-b9c9-f09249a2a52b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ea02b61-af05-4cbe-b9c9-f09249a2a52b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

