### PR TITLE
fix(desktop): dedupe Linux tray D-Bus calls to stop main-thread freeze

### DIFF
--- a/packages/electron/tray.mjs
+++ b/packages/electron/tray.mjs
@@ -99,6 +99,8 @@ const toTemplateImage = (p) => {
 export const createTrayController = ({ idleIconPath, unseenIconPath, breathIconPaths, statusIconPaths, onAction }) => {
   let tray = null;
   let lastTitle = null;
+  let lastTooltip = null;
+  let lastMenuKey = null;
 
   // macOS auto-picks the @2x file next to each path and tints the alpha.
   // Windows uses the regular app icon and ignores template tinting.
@@ -274,6 +276,22 @@ export const createTrayController = ({ idleIconPath, unseenIconPath, breathIconP
     return Menu.buildFromTemplate(template);
   };
 
+  // Lightweight signature of the menu-affecting content — skips nativeImage
+  // and click handlers that can't be serialized. Cheaper than buildMenu itself.
+  const menuKey = (snapshot) => {
+    const sessions = Array.isArray(snapshot.sessions) ? snapshot.sessions : [];
+    const approvals = Array.isArray(snapshot.approvals) ? snapshot.approvals : [];
+    const usage = snapshot.usage && typeof snapshot.usage === 'object' ? snapshot.usage : {};
+    const groups = Array.isArray(usage.groups) ? usage.groups : [];
+    return JSON.stringify({
+      h: typeof snapshot.instanceName === 'string' ? snapshot.instanceName : '',
+      s: sessions.map((s) => `${s.id}|${s.title}|${s.status}|${s.unseen}|${s.hasError}|${s.subtitle}|${s.directory}`),
+      a: approvals.map((a) => `${a.id}|${a.kind}|${a.sessionId}|${a.sessionTitle}|${a.label}|${a.directory}`),
+      u: usage.mode || '',
+      g: groups.map((g) => `${g.provider}|${g.status}|${(Array.isArray(g.rows) ? g.rows : []).map((r) => `${r.label}|${r.value}`).join(',')}`),
+    });
+  };
+
   const update = (rawSnapshot) => {
     const snapshot = rawSnapshot && typeof rawSnapshot === 'object' ? rawSnapshot : {};
     const sessions = Array.isArray(snapshot.sessions) ? snapshot.sessions : [];
@@ -293,8 +311,16 @@ export const createTrayController = ({ idleIconPath, unseenIconPath, breathIconP
       lastTitle = title;
     }
     applyIconState(computeIconState(counts));
-    widget.setToolTip(computeTooltip(counts, sessions.length));
-    widget.setContextMenu(buildMenu(snapshot));
+    const tooltip = computeTooltip(counts, sessions.length);
+    if (tooltip !== lastTooltip) {
+      widget.setToolTip(tooltip);
+      lastTooltip = tooltip;
+    }
+    const key = menuKey(snapshot);
+    if (key !== lastMenuKey) {
+      widget.setContextMenu(buildMenu(snapshot));
+      lastMenuKey = key;
+    }
   };
 
   const destroy = () => {
@@ -304,6 +330,8 @@ export const createTrayController = ({ idleIconPath, unseenIconPath, breathIconP
     }
     tray = null;
     lastTitle = null;
+    lastTooltip = null;
+    lastMenuKey = null;
     iconState = null;
   };
 

--- a/packages/ui/src/hooks/useTraySync.ts
+++ b/packages/ui/src/hooks/useTraySync.ts
@@ -39,7 +39,7 @@ import type { QuestionRequest } from '@/types/question';
 const TRAY_ACTION_EVENT = 'openchamber:tray-action';
 // Event-driven updates do the real work; this is just a slow safety net.
 const POLL_INTERVAL_MS = 5000;
-const FLUSH_DEBOUNCE_MS = 120;
+const FLUSH_DEBOUNCE_MS = 500;
 // Pull the full cross-project session list periodically. SSE keeps the active
 // directory instant; this catches sessions created in directories this client
 // never opened (other worktrees, other projects, the TUI, …).
@@ -468,8 +468,8 @@ export const useTraySync = (): void => {
     };
 
     // Coalesce bursts (e.g. token-by-token streaming updates a store rapidly)
-    // into a single push, while staying near-instant for discrete events like
-    // a new session appearing.
+    // into at most one push per FLUSH_DEBOUNCE_MS; discrete events surface within
+    // that window. The main app UI stays instant via SSE/stores.
     const scheduleFlush = () => {
       if (disposed || flushTimer !== null) return;
       flushTimer = window.setTimeout(() => {


### PR DESCRIPTION
## Intent

The Linux AppImage intermittently froze until it crashed. The freeze had no JS-level log, was intermittent (sometimes slow, sometimes full freeze), and could take a while to manifest.

Root cause: the native tray controller (\`packages/electron/tray.mjs\`) called \`widget.setToolTip(...)\` and \`widget.setContextMenu(...)\` unconditionally on every snapshot push from the renderer. On Linux, both are synchronous D-Bus calls into plasmashell's \`StatusNotifierItem\` host. The renderer's \`useTraySync\` hook debounced pushes at 120ms → up to ~8/sec during token streaming, so each push made 2 blocking D-Bus round-trips even when only \`dockBadgeCount\` changed or a token streamed into an already-listed session — i.e., tooltip and menu content didn't actually change. Native D-Bus block = no JS log, intermittent (depends on plasmashell load), eventually freezes the Electron main thread.

Notably \`setTitle\` and \`setImage\` were already deduped; \`setToolTip\` and \`setContextMenu\` were the gap.

Behavior change: the tray now only invokes \`setToolTip\`/\`setContextMenu\` when the visible content actually changes, and the renderer pushes at most ~2/sec instead of ~8/sec. No user-visible behavior change in the tray itself — the same tooltips and menus appear, just not re-pushed when unchanged.

## Non-goals

- No tray visual change (icons, menu layout, labels, ordering — untouched).
- No tray feature toggle (Linux tray remains on by default).
- No new tray IPC commands or snapshot shape.
- No automated regression test for the dedup (see Risks).
- Other sources of Linux AppImage slowdown, if any remain, are out of scope.

## Affected surfaces

- **\`packages/electron\` (Electron main process, Linux):** tray controller's \`update()\` path. Linux only — macOS and Windows tray calls are not D-Bus and were not the bottleneck, but the dedup is platform-agnostic and applies to all platforms as a no-op cost saving.
- **\`packages/ui\` (\`useTraySync\` hook, all desktop platforms):** flush debounce frequency. Affects how often the renderer pushes a tray snapshot over \`desktop_tray_update\` IPC. Same snapshot shape, same correctness.
- **No persisted contracts, external contracts, or IPC shape changes.**
- **Web, VS Code, mobile:** unaffected (no tray).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| \`AGENTS.md\` → desktop-shell | Modifies Electron main process (\`tray.mjs\`) and a renderer-facing IPC push path. | Kept the change in the existing tray controller; no new IPC commands; no new preload bridge shape; no privileged native operation added. |
| \`AGENTS.md\` → performance-engineering | Hot path: tray \`update()\` fires on every store change during streaming. | Verified \`menuKey\` (string concat) is genuinely cheaper than \`buildMenu\` (allocates closures + native \`Menu.buildFromTemplate\`); dedup skips both the native call and the build on the hot path. |
| \`packages/electron/README.md\` | Tray is owned here (\"Native Features Owned Here: system tray\"); IPC pattern is \`desktop_tray_update\`. | Used the existing IPC contract; no shape change. |
| \`AGENTS.md\` correctness invariant: \"Derive live activity from live channels, not persisted history\" | Tray dedup is over the live snapshot, not history. | \`lastMenuKey\`/\`lastTooltip\` are dedup caches only; the snapshot itself remains the source of truth. |

## Validation

| Check | Result |
|---|---|
| \`bun run type-check:electron\` | PASS (clean) |
| \`bun run type-check:ui\` | PASS (clean) |
| \`bun run lint:electron\` | PASS (clean) |
| \`bun run lint:ui\` | PASS (clean) |
| Adversarial implementation review (subagent) | APPROVE — verified \`menuKey\` covers every field \`buildMenu\` reads (no false negatives); \`computeTooltip\` dedup is exact (pure function of counts); \`destroy()\` resets correct; cache-after-call ordering applied for \`lastMenuKey\` to match existing pattern. |
| Manual A/B test (Linux AppImage, KDE + Wayland, x86_64) | Built an AppImage with the tray hard-disabled → freeze stopped but slowdowns remained. Built an AppImage with this dedup fix applied (tray re-enabled) → freeze eliminated and slowdowns substantially reduced. User confirmed \"way better.\" |
| \`packages/electron/dist/OpenChamber-1.16.3-linux-x86_64.AppImage\` (built from this branch) | Built successfully; tray fix present in \`app.asar\` (verified \`lastMenuKey\` string). |

**Not verified:**
- No automated regression test for the dedup (see Risks). The tray freeze is the visible regression signal.
- macOS/Windows runtime not retested; the dedup is platform-agnostic and the macOS animation path (\`breathIconPaths\` with 16 frames) is untouched.
- ARM64 Linux not built (no arm64 host available).

## Visual evidence

No user-visible change. The tray's icons, tooltip text, menu items, ordering, and click behavior are byte-for-byte identical before and after. The diff only changes *when* the native \`setToolTip\`/\`setContextMenu\` calls fire (now: only on content change; before: on every push). Nothing in \`buildMenu\`, \`computeTooltip\`, \`computeTitle\`, \`computeIconState\`, or the menu template was modified.

## Risks and failure behavior

- **Stale tray if dedup is wrong:** if \`menuKey\` failed to capture a field \`buildMenu\` reads, the tray would show stale content for that field. Adversarial review confirmed complete coverage: all 7 session fields, all 6 approval fields, \`instanceName\`, \`usage.mode\`, and \`usage.groups\` rows. No false-negative path found.
- **\`|\`-delimiter collision in \`menuKey\`** (theoretical): a session title/label containing \`|\` could in principle collide with another field. Verified field-by-field: \`id\` is UUID, \`status\`/\`kind\`/\`mode\` are enums, \`unseen\`/\`hasError\` are number/bool, git branches forbid \`|\`, paths forbid \`|\` on Windows. Only free-text \`title\`/\`label\`/\`subtitle\`/\`directory\` could carry \`|\`, and a collision requires exact cross-field compensation across all sessions simultaneously — contrived to negligibility. Acceptable.
- **No automated regression test:** \`tray.mjs\` imports \`Tray\`/\`Menu\`/\`nativeImage\` from \`electron\`, so a test requires module mocks. The freeze is the visible regression signal; a follow-up test would catch a future revert or a new un-deduped field. Not blocking for this fix.
- **Debounce 120→500ms:** approvals surface in the tray within ≤500ms instead of ≤120ms. Approvals are rare discrete events; the main app shows them instantly via SSE/stores regardless. The tray is a glanceable secondary surface, so 500ms is well within \"responsive.\"
- **Failure/rollback:** if the dedup causes a regression, the fix is a 2-file diff with no schema, IPC, or persistence change; revert is trivial and restores prior behavior.
- **Security/data-loss:** none. No new trust boundary, no secrets, no persistence change.