### PR TITLE
fix(ui): complete VS Code bootstrap detection for directory startup (#2359)

### DIFF
--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -4,6 +4,7 @@ import type { DraftStarterRef } from '@/lib/draftStarters';
 import type { MobileKeyboardMode } from '@/lib/mobileKeyboardMode';
 import { getRuntimeApiBaseUrl, getRuntimeKey } from '@/lib/runtime-switch';
 import { getRegisteredRuntimeAPIs } from '@/contexts/runtimeAPIRegistry';
+import { isVSCodeBootstrapPresent } from '@/lib/vscodeBootstrap';
 
 type ManagedRemoteTunnelPreset = {
   id: string;
@@ -538,6 +539,12 @@ export const startDesktopWindowDrag = async (): Promise<boolean> => {
 };
 
 export const isVSCodeRuntime = (): boolean => {
+  // Prefer extension-host bootstrap config: it is injected in webview HTML
+  // before any store module evaluates, so startup does not depend on
+  // RuntimeAPIs registration order (see #2359).
+  if (isVSCodeBootstrapPresent()) {
+    return true;
+  }
   const apis = getRegisteredRuntimeAPIs();
   return apis?.runtime?.isVSCode === true;
 };

--- a/packages/ui/src/lib/desktop.vscodeRuntime.test.ts
+++ b/packages/ui/src/lib/desktop.vscodeRuntime.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+type RuntimeApisStub = { runtime?: { isVSCode?: boolean } } | null;
+
+let registeredRuntimeApis: RuntimeApisStub = null;
+
+mock.module('@/contexts/runtimeAPIRegistry', () => ({
+  getRegisteredRuntimeAPIs: (): RuntimeApisStub => registeredRuntimeApis,
+}));
+
+const { isVSCodeRuntime } = await import('./desktop');
+
+describe('desktop isVSCodeRuntime bootstrap detection', () => {
+  afterEach(() => {
+    registeredRuntimeApis = null;
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  test('detects VS Code from bootstrap config before RuntimeAPIs register', () => {
+    registeredRuntimeApis = null;
+    (globalThis as { window: unknown }).window = {
+      __VSCODE_CONFIG__: {
+        workspaceFolder: '/Users/me/project-a',
+        workspaceFolders: [{ name: 'project-a', path: '/Users/me/project-a' }],
+      },
+    };
+
+    expect(isVSCodeRuntime()).toBe(true);
+  });
+
+  test('falls back to registered RuntimeAPIs when bootstrap is absent', () => {
+    registeredRuntimeApis = {
+      runtime: { isVSCode: true },
+    };
+    (globalThis as { window: unknown }).window = {};
+
+    expect(isVSCodeRuntime()).toBe(true);
+  });
+
+  test('does not classify an unregistered web runtime as VS Code', () => {
+    registeredRuntimeApis = null;
+    (globalThis as { window: unknown }).window = {};
+
+    expect(isVSCodeRuntime()).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/vscodeBootstrap.test.ts
+++ b/packages/ui/src/lib/vscodeBootstrap.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { getVSCodeBootstrapConfig, isVSCodeBootstrapPresent } from './vscodeBootstrap';
+
+describe('VS Code bootstrap config', () => {
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  test('reads extension-host __VSCODE_CONFIG__ before RuntimeAPIs exist', () => {
+    (globalThis as { window: unknown }).window = {
+      __VSCODE_CONFIG__: {
+        workspaceFolder: '/workspace/project-one',
+        workspaceFolders: [{ name: 'project-one', path: '/workspace/project-one' }],
+      },
+    };
+
+    expect(getVSCodeBootstrapConfig()).toEqual({
+      workspaceFolder: '/workspace/project-one',
+      workspaceFolders: [{ name: 'project-one', path: '/workspace/project-one' }],
+    });
+    expect(isVSCodeBootstrapPresent()).toBe(true);
+  });
+
+  test('treats missing window/bootstrap as not VS Code', () => {
+    expect(getVSCodeBootstrapConfig()).toBeNull();
+    expect(isVSCodeBootstrapPresent()).toBe(false);
+    expect(isVSCodeBootstrapPresent(null)).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/vscodeBootstrap.ts
+++ b/packages/ui/src/lib/vscodeBootstrap.ts
@@ -1,0 +1,20 @@
+/**
+ * Extension-host bootstrap config injected into the VS Code webview HTML
+ * before any bundled module evaluates. Prefer this over RuntimeAPIs for
+ * early VS Code detection during store module initialization.
+ */
+export interface VSCodeBootstrapConfig {
+  workspaceFolder?: unknown;
+  workspaceFolders?: unknown;
+}
+
+export const getVSCodeBootstrapConfig = (): VSCodeBootstrapConfig | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return (window as unknown as { __VSCODE_CONFIG__?: VSCodeBootstrapConfig }).__VSCODE_CONFIG__ ?? null;
+};
+
+export const isVSCodeBootstrapPresent = (
+  bootstrapConfig: VSCodeBootstrapConfig | null = getVSCodeBootstrapConfig(),
+): boolean => Boolean(bootstrapConfig);

--- a/packages/ui/src/stores/useDirectoryStore.ts
+++ b/packages/ui/src/stores/useDirectoryStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { opencodeClient } from '@/lib/opencode/client';
 import { getDesktopHomeDirectory, isVSCodeRuntime } from '@/lib/desktop';
+import { getVSCodeBootstrapConfig } from '@/lib/vscodeBootstrap';
 import { subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import { updateDesktopSettings } from '@/lib/persistence';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
@@ -227,7 +228,7 @@ const getVsCodeWorkspaceFolder = (): string | null => {
   if (!isVSCodeRuntime()) {
     return null;
   }
-  const workspaceFolder = (window as unknown as { __VSCODE_CONFIG__?: { workspaceFolder?: unknown } }).__VSCODE_CONFIG__?.workspaceFolder;
+  const workspaceFolder = getVSCodeBootstrapConfig()?.workspaceFolder;
   if (typeof workspaceFolder !== 'string' || workspaceFolder.trim().length === 0) {
     return null;
   }

--- a/packages/ui/src/stores/utils/vscodeRuntime.test.ts
+++ b/packages/ui/src/stores/utils/vscodeRuntime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { RuntimeAPIs } from '@/lib/api/types';
 import { isVSCodeRuntime } from './vscodeRuntime';
 
 describe('VS Code runtime detection', () => {
@@ -7,6 +8,13 @@ describe('VS Code runtime detection', () => {
       workspaceFolder: '/workspace/project-one',
       workspaceFolders: [{ name: 'project-one', path: '/workspace/project-one' }],
     })).toBe(true);
+  });
+
+  test('uses registered runtime APIs when bootstrap is absent', () => {
+    const runtimeApis = {
+      runtime: { platform: 'vscode', isDesktop: false, isVSCode: true },
+    } as RuntimeAPIs;
+    expect(isVSCodeRuntime(runtimeApis, null)).toBe(true);
   });
 
   test('does not classify an unregistered web runtime as VS Code', () => {

--- a/packages/ui/src/stores/utils/vscodeRuntime.ts
+++ b/packages/ui/src/stores/utils/vscodeRuntime.ts
@@ -1,18 +1,14 @@
 import type { RuntimeAPIs } from '@/lib/api/types';
+import {
+  getVSCodeBootstrapConfig,
+  isVSCodeBootstrapPresent,
+  type VSCodeBootstrapConfig,
+} from '@/lib/vscodeBootstrap';
 
-export interface VSCodeBootstrapConfig {
-  workspaceFolder?: unknown;
-  workspaceFolders?: unknown;
-}
-
-export const getVSCodeBootstrapConfig = (): VSCodeBootstrapConfig | null => {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-  return (window as unknown as { __VSCODE_CONFIG__?: VSCodeBootstrapConfig }).__VSCODE_CONFIG__ ?? null;
-};
+export type { VSCodeBootstrapConfig };
+export { getVSCodeBootstrapConfig };
 
 export const isVSCodeRuntime = (
   runtimeApis: RuntimeAPIs | null,
-  bootstrapConfig = getVSCodeBootstrapConfig(),
-): boolean => Boolean(bootstrapConfig || runtimeApis?.runtime?.isVSCode);
+  bootstrapConfig: VSCodeBootstrapConfig | null = getVSCodeBootstrapConfig(),
+): boolean => Boolean(isVSCodeBootstrapPresent(bootstrapConfig) || runtimeApis?.runtime?.isVSCode);

--- a/packages/ui/src/stores/vscodeStoreInit.2359.test.ts
+++ b/packages/ui/src/stores/vscodeStoreInit.2359.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+/**
+ * Integration-style coverage for #2359: store modules evaluate before
+ * RuntimeAPIs registration, with only extension-host __VSCODE_CONFIG__ present
+ * and a stale lastDirectory in storage.
+ */
+
+const WORKSPACE = '/tmp/oc-ws-project-a';
+const STALE = '/tmp/oc-ws-other';
+
+const storage = new Map<string, string>([
+  ['lastDirectory', STALE],
+  ['homeDirectory', STALE],
+]);
+
+const installWindow = () => {
+  (globalThis as { window: unknown }).window = {
+    __VSCODE_CONFIG__: {
+      workspaceFolder: WORKSPACE,
+      workspaceFolders: [{ name: 'oc-ws-project-a', path: WORKSPACE }],
+    },
+    __OPENCHAMBER_HOME__: WORKSPACE,
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, String(value));
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+    },
+    matchMedia: () => ({ matches: false, addListener() {}, removeListener() {}, addEventListener() {}, removeEventListener() {} }),
+  };
+  (globalThis as { localStorage: unknown }).localStorage = (globalThis as { window: { localStorage: unknown } }).window.localStorage;
+};
+
+mock.module('@/contexts/runtimeAPIRegistry', () => ({
+  getRegisteredRuntimeAPIs: () => null,
+}));
+
+mock.module('@/lib/opencode/client', () => ({
+  opencodeClient: {
+    setDirectory: () => undefined,
+    getDirectory: () => WORKSPACE,
+    getFilesystemHome: async () => WORKSPACE,
+    getSystemInfo: async () => ({ homeDirectory: WORKSPACE }),
+  },
+}));
+
+mock.module('@/lib/persistence', () => ({
+  updateDesktopSettings: async () => undefined,
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  subscribeRuntimeEndpointChanged: () => () => undefined,
+  getRuntimeApiBaseUrl: () => 'http://127.0.0.1:9',
+  getRuntimeKey: () => 'test',
+}));
+
+mock.module('@/stores/useFileSearchStore', () => ({
+  useFileSearchStore: {
+    getState: () => ({ clearCache: () => undefined }),
+  },
+}));
+
+describe('VS Code store init before RuntimeAPIs (#2359)', () => {
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  test('desktop isVSCodeRuntime prefers bootstrap config', async () => {
+    installWindow();
+    const { isVSCodeRuntime } = await import('@/lib/desktop');
+    expect(isVSCodeRuntime()).toBe(true);
+  });
+
+  test('projects helper derives workspace projects without RuntimeAPIs', async () => {
+    installWindow();
+    const { getVSCodeBootstrapConfig, isVSCodeRuntime } = await import('@/stores/utils/vscodeRuntime');
+    const config = getVSCodeBootstrapConfig();
+    expect(isVSCodeRuntime(null, config)).toBe(true);
+    expect(config?.workspaceFolder).toBe(WORKSPACE);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fixes the remaining gap in #2359: after `e9e41139`, `useProjectsStore` correctly used `__VSCODE_CONFIG__` before RuntimeAPIs registration, but `lib/desktop.isVSCodeRuntime()` (consumed by `useDirectoryStore` and other early callers) still required RuntimeAPIs. During VS Code webview startup that left `initialCurrentDirectory` on a stale `localStorage` path from another window instead of the current workspace folder.

This PR makes bootstrap-config detection the shared early VS Code marker for all runtime checks, not only the projects store.

## Non-goals

- Not reopening PR #2362’s dynamic-import / lazy Zustand init approach (maintainers already rejected that for this root cause).
- Not injecting a stub `__OPENCHAMBER_RUNTIME_APIS__` into `webviewHtml.ts`.
- Not changing permission auto-accept static imports in `main.tsx`.

## Affected surfaces

- `packages/ui`: shared bootstrap helper, `isVSCodeRuntime()` in `lib/desktop.ts`, directory-store workspace folder read, projects-store helper re-export.
- VS Code webview startup only for the user-visible change (workspace folder becomes default project/directory before RuntimeAPIs register).
- Web / Electron / mobile: unaffected unless `__VSCODE_CONFIG__` is present; without it behavior is unchanged (`RuntimeAPIs.runtime.isVSCode` fallback).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` runtime boundaries + correctness invariants | Shared runtime detection must be intentional and prefer authoritative early state | Uses extension-host `__VSCODE_CONFIG__` as authoritative early VS Code marker; RuntimeAPIs remain fallback |
| `openchamber-change-discipline` | Source/module contract change in shared UI | Smallest complete fix; package-scoped validation + focused regression tests |
| `ui-api-decoupling` + `references/runtime-parity.md` | Runtime detection / VS Code behavior | Keeps RuntimeAPIs as the registered contract; bootstrap is only the pre-registration marker already injected by the extension host |
| `packages/ui/src/stores/DOCUMENTATION.md` | Directory/projects store init | Preserved store ownership; only fixed early VS Code detection used at module init |

## Validation

| Check | Result |
|---|---|
| Logic repro of pre-RuntimeAPIs timing (directory used stale persisted path; projects already fixed) | Confirmed remaining gap before change; fixed semantics use workspace folder |
| `bun test` focused bootstrap/desktop/vscodeRuntime + `vscodeStoreInit.2359.test.ts` (`packages/ui`) | Pass |
| `bun run type-check` / `bun run lint` (`packages/ui`) | Pass |
| `bun run dead-code` | Ran (non-blocking) |
| `bun run vscode:build` | Pass |
| VS Code 1.130 Extension Development Host with `--extensionDevelopmentPath=packages/vscode` and workspace `/tmp/oc-ws-project-a` | Pass — OpenChamber sidebar shows project **OC WS PROJECT A**; no “Add project directory” modal |

## Visual evidence

VS Code Extension Development Host after opening OpenChamber with workspace `/tmp/oc-ws-project-a`:

![OpenChamber sidebar uses workspace project OC WS PROJECT A](https://cursor.com/artifacts/c/art-3439a29f-0f6a-42d6-b019-2a8e607af22a)

![OpenChamber CHAT panels with workspace project selected](https://cursor.com/artifacts/c/art-7f6c890e-df3c-4318-953e-3dea48993c57)

Observed UI text: Sessions → `OC WS PROJECT A`, status `No sessions in this workspace yet.` No DirectoryExplorer / Add project directory modal.

## Risks and failure behavior

- If `__VSCODE_CONFIG__` is missing, detection falls back to registered RuntimeAPIs exactly as before.
- Presence of any `__VSCODE_CONFIG__` object marks VS Code even when `workspaceFolder` is empty; that matches the existing projects-store helper and the always-injected webview HTML object.
- Web/desktop runtimes do not set `__VSCODE_CONFIG__`, so they cannot be misclassified.
- No persisted schema migration; only which path wins at cold start changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70e6ba94-5191-46b3-be77-684b86633a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70e6ba94-5191-46b3-be77-684b86633a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

