### PR TITLE
fix(ui): preserve session targets across async routing

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1920,6 +1920,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         const queuedMessagesToSend = queuedMessageId
             ? queuedMessages.filter((message) => message.id === queuedMessageId)
             : queuedMessages;
+        const capturedSessionId = currentSessionId;
+        const capturedDraft = newSessionDraftOpen ? newSessionDraft : null;
+        const capturedDirectory = capturedSessionId
+            ? currentSessionDirectoryForSync ?? currentDirectory
+            : capturedDraft?.bootstrapPendingDirectory ?? capturedDraft?.directoryOverride ?? currentDirectory;
 
         if (queuedOnly && autoReviewRunning) {
             return;
@@ -1964,7 +1969,14 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             }
         }
 
-        const sendMessageOptions = delivery ? { delivery } : undefined;
+        const sendMessageOptions = {
+            ...(delivery ? { delivery } : {}),
+            ...(capturedSessionId
+                ? { sessionId: capturedSessionId, directory: capturedDirectory }
+                : capturedDraft
+                    ? { draftSnapshot: capturedDraft }
+                    : {}),
+        };
 
         // Build the primary message (first part) and additional parts
         let primaryText = '';

--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.test.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.test.ts
@@ -53,6 +53,10 @@ function computeProjectMeta(projectSections: ProjectSection[]) {
   return { metaByProject, firstSessionByProject };
 }
 
+const didSwitchProjects = (previousProjectId: string | null, activeProjectId: string): boolean => (
+  previousProjectId !== null && previousProjectId !== activeProjectId
+);
+
 // ---------------------------------------------------------------------------
 // Test data
 // ---------------------------------------------------------------------------
@@ -182,7 +186,7 @@ describe('useProjectSessionSelection — worktree session click race', () => {
     expect(projectMap?.has('wt-session-1')).toBe(true);
   });
 
-  test('guard preserves currentSessionId when projectMap is stale (the bug fix)', () => {
+  test('guard preserves an unindexed worktree session when projectMap is stale', () => {
     const { metaByProject, firstSessionByProject } = computeProjectMeta(staleSections);
     const projectMap = metaByProject.get('project-1')!;
     const currentSessionId = 'wt-session-1';
@@ -191,13 +195,23 @@ describe('useProjectSessionSelection — worktree session click race', () => {
     const pathAHit = Boolean(currentSessionId && projectMap?.has(currentSessionId));
     expect(pathAHit).toBe(false);
 
-    // Guard: if (currentSessionId) return;
-    // This is what prevents the fallthrough to Path C (auto-select wrong session)
-    // Without the guard, Path C would select firstSessionByProject = root-session-1
-    // instead of preserving the user's wt-session-1 selection
+    const switchedProjects = didSwitchProjects(null, 'project-1');
+    expect(switchedProjects).toBe(false);
+
+    // The guard prevents fallthrough to Path C while the worktree data catches up.
     const fallback = firstSessionByProject.get('project-1')?.id ?? null;
     expect(fallback).toBe('root-session-1');
     expect(fallback).not.toBe(currentSessionId);
+  });
+
+  test('project switch does not preserve the previous session', () => {
+    const { metaByProject } = computeProjectMeta(project2Sections);
+    const currentSessionId = 'root-session-1';
+
+    expect(metaByProject.get('project-2')?.has(currentSessionId)).toBe(false);
+    const switchedProjects = didSwitchProjects('project-1', 'project-2');
+    expect(switchedProjects).toBe(true);
+    expect(Boolean(currentSessionId && metaByProject.get('project-2') && !switchedProjects)).toBe(false);
   });
 
   test('second click works correctly when projectSections is updated', () => {

--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
@@ -103,7 +103,10 @@ export const useProjectSessionSelection = (args: Args): void => {
     if (!section) {
       return;
     }
+    const previousActiveProjectId = previousActiveProjectRef.current;
     previousActiveProjectRef.current = activeProjectId;
+    const switchedProjects = previousActiveProjectId !== null
+      && previousActiveProjectId !== activeProjectId;
     const projectMap = projectSessionMeta.metaByProject.get(activeProjectId);
 
     if (currentSessionId && projectMap && projectMap.has(currentSessionId)) {
@@ -118,12 +121,9 @@ export const useProjectSessionSelection = (args: Args): void => {
       return;
     }
 
-    // Path A' — currentSessionId is set but not in stale projectMap.
-    // Preserve user's explicit selection when the projectMap exists but
-    // is missing the session (worktree data not yet loaded). For
-    // empty projects (projectMap is undefined), fall through to Path B
-    // so a new session draft is opened.
-    if (currentSessionId && projectMap) {
+    // Preserve an explicit selection while this project's worktree data catches
+    // up, but never carry that selection across a confirmed project switch.
+    if (currentSessionId && projectMap && !switchedProjects) {
       return;
     }
 

--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -201,6 +201,7 @@ Rules:
 2. If an action targets a session by ID, resolve the **session's own directory**. Do not assume the current directory is correct.
 3. `session-ui-store.ts` should delegate to `session-actions.ts` for these mutations instead of duplicating SDK calls.
 4. Sending after a revert commits the new branch optimistically: remove the reverted tail and marker before inserting the new message, and restore both if the send is rejected.
+5. Async work started from a new-session draft must retain that draft's identity. Session creation still registers and upserts the result, but it activates and closes the draft only when the same logical draft remains current. Callers continue using the created session even when later navigation suppresses activation.
 
 Examples of global-store updates performed in `session-actions.ts`:
 

--- a/packages/ui/src/sync/__tests__/issue-1637-2270.test.ts
+++ b/packages/ui/src/sync/__tests__/issue-1637-2270.test.ts
@@ -115,6 +115,20 @@ describe("issue #1637 — server omits directory, falls back to directoryOverrid
     // registerSessionDirectory is also called with the effective directory
     expect(registerSessionDirectoryCalls).toEqual([{ sessionID: "ses_1637_a", directory: "/projects/alpha" }])
   })
+
+  test("can create and index a session without changing the current selection", async () => {
+    nextCreateSessionResponse = { id: "ses_background", time: { created: 1 } } as Session
+
+    const result = await createSession("test title", "/projects/alpha", null, undefined, {
+      activateSession: false,
+    })
+
+    expect(result?.id).toBe("ses_background")
+    expect(setCurrentSessionCalls).toHaveLength(0)
+    expect(registerSessionDirectoryCalls).toEqual([{ sessionID: "ses_background", directory: "/projects/alpha" }])
+    expect(markSessionAsOpenChamberCreatedCalls).toEqual(["ses_background"])
+    expect(upsertSessionCalls).toEqual([nextCreateSessionResponse])
+  })
 })
 
 describe("issue #1637 — server returns directory, server value wins", () => {

--- a/packages/ui/src/sync/__tests__/issue-2039.test.ts
+++ b/packages/ui/src/sync/__tests__/issue-2039.test.ts
@@ -4,6 +4,9 @@ import { togglePermissionAutoAccept } from "../../components/chat/permissionAuto
 const storage = new Map<string, string>()
 const createSessionCalls: Array<{ title?: string; directory: string | null; parentID: string | null; metadata?: unknown }> = []
 const permissionAutoAcceptCalls: Array<[string, boolean]> = []
+const optimisticSendCalls: Array<{ sessionId: string; directory?: string | null }> = []
+let creationGate: Promise<void> | null = null
+let releaseCreation: (() => void) | null = null
 
 const getMockCalls = (fn: unknown): unknown[][] => ((fn as { mock?: { calls: unknown[][] } }).mock?.calls ?? [])
 
@@ -53,6 +56,11 @@ const deferredStorage: Storage = {
 
 mock.module("@/stores/utils/safeStorage", () => ({
   getDeferredSafeStorage: () => deferredStorage,
+  createDeferredSafeJSONStorage: () => ({
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined,
+  }),
 }))
 
 mock.module("@/lib/opencode/client", () => ({
@@ -79,6 +87,23 @@ mock.module("@/stores/useConfigStore", () => ({
       agents: [],
       activateDirectory: mock(async () => undefined),
       applyDefaultModelAgentSelection: mock(() => undefined),
+    }),
+  },
+}))
+
+mock.module("@/stores/useUIStore", () => ({
+  useUIStore: {
+    getState: () => ({
+      sessionGoalDefaultBudgetEnabled: false,
+      sessionGoalDefaultBudget: 0,
+    }),
+  },
+}))
+
+mock.module("@/stores/useSessionGoalArmStore", () => ({
+  useSessionGoalArmStore: {
+    getState: () => ({
+      consume: () => ({ armed: false, objectiveOverride: null }),
     }),
   },
 }))
@@ -171,6 +196,10 @@ mock.module("@/lib/userSendAnimation", () => ({
   markPendingUserSendAnimation: () => undefined,
 }))
 
+mock.module("@/lib/sessionGoalActions", () => ({
+  setSessionGoal: mock(async () => undefined),
+}))
+
 mock.module("../sync-context", () => ({
   setActiveSession: () => undefined,
 }))
@@ -229,6 +258,7 @@ mock.module("../sync-refs", () => ({
 mock.module("../session-actions", () => ({
   createSession: mock(async (title: string | undefined, directory: string | null, parentID: string | null, metadata?: unknown) => {
     createSessionCalls.push({ title, directory, parentID, metadata })
+    await creationGate
     return { id: "ses_issue_2039", directory }
   }),
   deleteSession: mock(async () => true),
@@ -236,12 +266,15 @@ mock.module("../session-actions", () => ({
   updateSessionTitle: mock(async () => undefined),
   shareSession: mock(async () => undefined),
   unshareSession: mock(async () => undefined),
-  optimisticSend: mock(async () => undefined),
+  optimisticSend: mock(async (input: { sessionId: string; directory?: string | null }) => {
+    optimisticSendCalls.push(input)
+  }),
   refetchSessionMessages: mock(async () => undefined),
   revertToMessage: mock(async () => undefined),
   unrevertSession: mock(async () => undefined),
   forkFromMessage: mock(async () => undefined),
   fetchMessagesForSession: mock(async () => undefined),
+  getSessionLastAssistantModel: () => null,
 }))
 
 const { materializeOpenDraftSession, useSessionUIStore } = await import("../session-ui-store")
@@ -298,6 +331,9 @@ describe("issue 2039 draft auto-accept", () => {
     storage.clear()
     createSessionCalls.length = 0
     permissionAutoAcceptCalls.length = 0
+    optimisticSendCalls.length = 0
+    creationGate = null
+    releaseCreation = null
 
     useSessionUIStore.setState({
       currentSessionId: null,
@@ -347,5 +383,57 @@ describe("issue 2039 draft auto-accept", () => {
     expect(result).toBeNull()
     expect(createSessionCalls).toHaveLength(0)
     expect(permissionAutoAcceptCalls).toHaveLength(0)
+  })
+
+  test("sends a captured draft to its new session after the user switches sessions", async () => {
+    useSessionUIStore.getState().openNewSessionDraft({ directoryOverride: "/projects/alpha" })
+    const capturedDraft = useSessionUIStore.getState().newSessionDraft
+    creationGate = new Promise<void>((resolve) => {
+      releaseCreation = resolve
+    })
+
+    const send = useSessionUIStore.getState().sendMessage(
+      "draft message",
+      "provider",
+      "model",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { draftSnapshot: capturedDraft },
+    )
+    await Promise.resolve()
+    useSessionUIStore.getState().setCurrentSession("existing-session", "/projects/alpha")
+    releaseCreation?.()
+    await send
+
+    expect(optimisticSendCalls).toHaveLength(1)
+    expect(optimisticSendCalls[0]?.sessionId).toBe("ses_issue_2039")
+    expect(useSessionUIStore.getState().currentSessionId).toBe("existing-session")
+  })
+
+  test("does not close a newer draft when an older draft finishes materializing", async () => {
+    useSessionUIStore.getState().openNewSessionDraft({ directoryOverride: "/projects/alpha" })
+    const capturedDraft = useSessionUIStore.getState().newSessionDraft
+    creationGate = new Promise<void>((resolve) => {
+      releaseCreation = resolve
+    })
+
+    const materialize = materializeOpenDraftSession({
+      providerID: "provider",
+      modelID: "model",
+    }, capturedDraft)
+    await Promise.resolve()
+    useSessionUIStore.getState().openNewSessionDraft({ directoryOverride: "/projects/beta" })
+    const newerDraft = useSessionUIStore.getState().newSessionDraft
+    releaseCreation?.()
+    await materialize
+
+    expect(useSessionUIStore.getState().currentSessionId).toBeNull()
+    expect(useSessionUIStore.getState().newSessionDraft.open).toBe(true)
+    expect(useSessionUIStore.getState().newSessionDraft.draftToken).toBe(newerDraft.draftToken)
+    expect(useSessionUIStore.getState().newSessionDraft.draftToken).not.toBe(capturedDraft.draftToken)
   })
 })

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -574,6 +574,7 @@ export async function createSession(
   directoryOverride?: string | null,
   parentID?: string | null,
   metadata?: Record<string, unknown>,
+  options?: { activateSession?: boolean },
 ): Promise<Session | null> {
   try {
     // Capture the effective directory used for session creation so we can fall
@@ -594,7 +595,9 @@ export async function createSession(
     if (sessionDirectory) {
       registerSessionDirectory(session.id, sessionDirectory)
     }
-    useSessionUIStore.getState().setCurrentSession(session.id, sessionDirectory)
+    if (options?.activateSession !== false) {
+      useSessionUIStore.getState().setCurrentSession(session.id, sessionDirectory)
+    }
     useSessionUIStore.getState().markSessionAsOpenChamberCreated(session.id)
     useGlobalSessionsStore.getState().upsertSession(session)
     return session

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -491,7 +491,7 @@ export async function materializeOpenDraftSession(
   if (!created?.id) throw new Error("Failed to create session")
 
   if (draft.targetFolderId) {
-    const scopeKey = draftDirectoryOverride || created.directory || store.lastLoadedDirectory
+    const scopeKey = draftDirectoryOverride || store.lastLoadedDirectory || created.directory
     if (scopeKey) {
       useSessionFoldersStore.getState().addSessionToFolder(scopeKey, draft.targetFolderId, created.id)
     }

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -173,8 +173,9 @@ export function routeMessage(params: {
 
 type SendMessageOptions = {
   sessionId?: string
-  directory?: string
+  directory?: string | null
   delivery?: 'steer'
+  draftSnapshot?: NewSessionDraftState
 }
 
 type AssistantMessageSessionExecution = {
@@ -201,6 +202,7 @@ export type { SessionMemoryState } from "./viewport-store"
 
 export type NewSessionDraftState = {
   open: boolean
+  draftToken?: symbol
   selectedProjectId?: string | null
   directoryOverride: string | null
   permissionAutoAcceptEnabled?: boolean
@@ -389,6 +391,8 @@ const DEFAULT_DRAFT: NewSessionDraftState = {
   parentID: null,
 }
 
+const createDraftToken = (): symbol => Symbol("new-session-draft")
+
 const activeSessionByRuntime = new Map<string, string | null>()
 type RuntimeSessionMemory = {
   sessionId: string | null
@@ -405,6 +409,13 @@ const runtimeMemoryKey = (value?: string | null): string => {
 }
 
 const cloneDraft = (draft: NewSessionDraftState): NewSessionDraftState => ({ ...draft })
+
+const isCurrentLogicalDraft = (draft: NewSessionDraftState): boolean => {
+  const { currentSessionId, newSessionDraft } = useSessionUIStore.getState()
+  if (!draft.open || !newSessionDraft.open || currentSessionId !== null) return false
+  return newSessionDraft === draft
+    || (draft.draftToken !== undefined && newSessionDraft.draftToken === draft.draftToken)
+}
 
 const writeRuntimeSessionMemory = (key: string, patch: Partial<RuntimeSessionMemory>): void => {
   const current = runtimeSessionMemory.get(key)
@@ -443,14 +454,17 @@ const waitForWorktreeBootstrapIfConfigured = async (directory: string | null, pr
   }
 }
 
-export async function materializeOpenDraftSession(selection: {
-  providerID: string
-  modelID: string
-  agent?: string
-  variant?: string
-}): Promise<MaterializedDraftSession | null> {
+export async function materializeOpenDraftSession(
+  selection: {
+    providerID: string
+    modelID: string
+    agent?: string
+    variant?: string
+  },
+  draftOverride?: NewSessionDraftState,
+): Promise<MaterializedDraftSession | null> {
   const store = useSessionUIStore.getState()
-  const draft = store.newSessionDraft
+  const draft = draftOverride ?? store.newSessionDraft
   if (!draft?.open) return null
   const draftPermissionAutoAcceptEnabled = draft.permissionAutoAcceptEnabled === true
 
@@ -467,8 +481,21 @@ export async function materializeOpenDraftSession(selection: {
 
   await waitForWorktreeBootstrapIfConfigured(draftDirectoryOverride, draftProjectId)
 
-  const created = await store.createSession(draft.title, draftDirectoryOverride, draft.parentID ?? null)
+  const created = await createSessionAction(
+    draft.title,
+    draftDirectoryOverride,
+    draft.parentID ?? null,
+    undefined,
+    { activateSession: false },
+  )
   if (!created?.id) throw new Error("Failed to create session")
+
+  if (draft.targetFolderId) {
+    const scopeKey = draftDirectoryOverride || created.directory || store.lastLoadedDirectory
+    if (scopeKey) {
+      useSessionFoldersStore.getState().addSessionToFolder(scopeKey, draft.targetFolderId, created.id)
+    }
+  }
 
   persistDraftTarget({
     projectId: draftProjectId,
@@ -478,9 +505,11 @@ export async function materializeOpenDraftSession(selection: {
   const draftSyntheticParts = draft.syntheticParts
   const createdDirectory = normalizePath(draftDirectoryOverride ?? created.directory ?? null)
   const configState = useConfigStore.getState()
-  void activateConfigForDirectory(createdDirectory).catch((error) => {
-    console.warn("Failed to activate directory after creating session:", error)
-  })
+  if (isCurrentLogicalDraft(draft)) {
+    void activateConfigForDirectory(createdDirectory).catch((error) => {
+      console.warn("Failed to activate directory after creating session:", error)
+    })
+  }
 
   const effectiveDraftAgent = trimmedAgent ?? configState.currentAgentName
 
@@ -494,7 +523,10 @@ export async function materializeOpenDraftSession(selection: {
 
   store.initializeNewOpenChamberSession(created.id, configState.agents ?? [])
 
-  store.setCurrentSession(created.id, createdDirectory)
+  if (isCurrentLogicalDraft(draft)) {
+    store.closeNewSessionDraft()
+    store.setCurrentSession(created.id, createdDirectory)
+  }
 
   if (draftPermissionAutoAcceptEnabled) {
     void import("@/stores/permissionStore")
@@ -728,6 +760,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
 
     const nextDraft: NewSessionDraftState = {
       open: true,
+      draftToken: createDraftToken(),
       selectedProjectId: selectedProject?.id ?? null,
       directoryOverride: directory,
       permissionAutoAcceptEnabled: options?.permissionAutoAcceptEnabled === true,
@@ -1030,7 +1063,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       set({ pendingChangesBarDismissed: map });
     }
 
-    const draft = get().newSessionDraft
+    const draft = options?.draftSnapshot ?? get().newSessionDraft
     const trimmedAgent = typeof agent === "string" && agent.trim().length > 0 ? agent.trim() : undefined
 
     const goalArm = inputMode !== "shell" && content.trim().length > 0
@@ -1070,7 +1103,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
         modelID,
         agent: trimmedAgent,
         variant,
-      })
+      }, options?.draftSnapshot)
       if (!createdDraftSession) throw new Error("Failed to create session")
 
       const mergedAdditionalParts = createdDraftSession.syntheticParts?.length


### PR DESCRIPTION
## Intent

Prevent messages from being routed to a stale session when selection changes around a send.

This fixes two related races:

- After a confirmed project switch, the session-selection hook no longer preserves an unindexed session from the previous project. It proceeds to the new project's remembered session, first session, or new-session draft while retaining the same-project delayed-worktree guard.
- A submit now captures its session or draft target and directory before asynchronous preparation. Draft materialization uses that snapshot, creates the session without implicitly activating it, and activates/closes the draft only if the original logical draft is still current. Switching to an existing session or opening another draft while creation is pending therefore cannot redirect the message or be overwritten by the stale completion.

Fixes #2317. This also covers the reproduced new-draft send race addressed as part of the broader #2242 approach, while keeping this PR limited to target identity and lifecycle rather than importing that PR's larger composer refactor.

## Non-goals

- No changes to queued-message ownership, attachment recovery, goal-arm capture, or other broader composer transaction behavior from #2242.
- No persistence-format, API, database, authentication, transport, or runtime-bridge changes.
- No native Electron or Capacitor shell changes; those runtimes consume the shared UI behavior when rebuilt.

## Affected surfaces

- `packages/ui`: project/session selection, chat submit target capture, draft identity, and session creation activation.
- Web, Electron desktop, VS Code, hosted mobile, and Capacitor Android/iOS consume the shared UI and receive the same routing behavior when rebuilt.
- Existing session creation remains activating by default. Only captured draft materialization opts into background creation and conditionally activates after completion.
- `gitApi.ts` also materializes an open draft for title/PR generation. It continues using the returned session, but no longer forces that session into the UI if the user navigated away during creation.
- Draft tokens are ephemeral in-memory symbols; no persisted data shape changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes executable shared UI source, a session action contract, and direct tests. | The change is limited to target capture and draft lifecycle, adds no dependency or generated file, preserves default callers, and includes focused async state-transition tests. |
| `sync-state-invariants` | The bug involves session selection, directory-scoped sends, and stale async completion. | Provider/model inputs remain captured by the existing flow; this change additionally captures session/draft identity and directory, supplies a directory hint before indexing, and rejects stale draft activation by stable token. |
| `ui-api-decoupling` | Shared UI invokes the official OpenCode session creation/send paths across runtimes. | Calls remain through `opencodeClient`/existing session actions, with no hardcoded runtime URL or runtime-specific transport. |
| Session sidebar `DOCUMENTATION.md` and sync `DOCUMENTATION.md` | These own selection, draft lifecycle, action routing, and directory behavior. | The delayed-worktree guard remains scoped to same-project loading. The sync documentation now defines captured draft identity and conditional activation, while session actions continue to register/upsert every created session. |

## Validation

| Check | Result |
|---|---|
| `bun install --frozen-lockfile` | Passed on the branch base. |
| `bun test packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.test.ts` | Passed: 9 tests, 0 failures. |
| `bun test packages/ui/src/sync/__tests__/issue-1637-2270.test.ts` | Passed: 10 tests, 0 failures, including non-activating session creation while retaining routing/global indexes. |
| `bun test packages/ui/src/sync/__tests__/issue-2039.test.ts` | Passed: 6 tests, 0 failures, including switching to an existing session and opening a newer draft while old creation is pending. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `git diff --check` | Passed. |
| `bun run build:web` | Passed. Vite reported the repository's existing KaTeX font resolution, mixed static/dynamic import, and chunk-size warnings. |
| Windows x64 packaging workflow at final HEAD `feb88c4d` | Passed: native module rebuild, packaged OpenCode CLI verification, unsigned NSIS packaging, checksum generation, and artifact upload. Run: https://github.com/zopenb/openchamber/actions/runs/30288755266 |

Not yet verified on the current HEAD: executing the packaged installer on a Windows desktop, Android/iOS builds, and a real desktop/mobile interaction recording. The final Windows artifact was built from the exact PR HEAD and its downloaded SHA-256/SHA-512 metadata was verified, but packaging is not a substitute for interaction testing.

## Visual evidence

No styling or static rendered state changes. This is interaction routing behavior. The relevant evidence is a recording of both flows: switch projects without selecting a destination session, and send from a new draft then immediately select an existing session/open another draft while creation is pending. That interaction recording has not yet been captured for the current HEAD.

## Risks and failure behavior

The primary risk is suppressing legitimate activation. Existing direct `createSession` callers retain the default activating behavior; only draft materialization passes `activateSession: false`, then activates when the captured draft token is still current. The created session is always registered and inserted into the global session cache, so a background completion remains discoverable even when the user has navigated away.

If creation fails, the captured draft remains open when still current and the send rejects through the existing error path. If the user has navigated elsewhere, a stale failure does not overwrite the newer selection. Folder assignment preserves its prior scope precedence, and draft permission auto-accept remains attached to the captured draft/session. Git generation continues against the created session even if later navigation suppresses UI activation. Rollback is reverting the async-routing/documentation commits plus the original project-switch commit; there is no migration or data cleanup.
