### PR TITLE
chore(cloud): pin VS Code in Cursor cloud environment update

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "bun install && bash .cursor/install-vscode.sh",
+  "agentCanUpdateSnapshot": true
+}

--- a/.cursor/install-vscode.sh
+++ b/.cursor/install-vscode.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Idempotent VS Code CLI install for Cursor Cloud agent VMs.
+# Used by `.cursor/environment.json` so Extension Development Host testing
+# is available without a one-off apt install each run.
+set -euo pipefail
+
+if command -v code >/dev/null 2>&1; then
+  echo "[install-vscode] already present: $(command -v code) ($(code --version | head -n1))"
+  exit 0
+fi
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "[install-vscode] ERROR: apt-get is required to install VS Code" >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "[install-vscode] installing Microsoft VS Code apt repository + package"
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends ca-certificates curl gnupg
+
+sudo install -d -m 0755 /etc/apt/keyrings
+curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL \
+  https://packages.microsoft.com/keys/microsoft.asc \
+  | gpg --dearmor \
+  | sudo tee /etc/apt/keyrings/packages.microsoft.gpg >/dev/null
+sudo chmod a+r /etc/apt/keyrings/packages.microsoft.gpg
+
+arch="$(dpkg --print-architecture)"
+codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+echo "deb [arch=${arch} signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" \
+  | sudo tee /etc/apt/sources.list.d/vscode.list >/dev/null
+
+# Avoid interactive "add Microsoft apt repository?" prompt from the code package.
+echo 'code code/add-microsoft-repo boolean true' | sudo debconf-set-selections
+
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends code
+
+if ! command -v code >/dev/null 2>&1; then
+  echo "[install-vscode] ERROR: code not on PATH after install" >&2
+  exit 1
+fi
+
+echo "[install-vscode] installed: $(command -v code) ($(code --version | head -n1))"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,13 @@ Pure code-reading or explanation does not require implementation skills unless n
 - For docs-only or isolated config changes, run the narrowest relevant validation.
 - Report exactly what was and was not validated. Static checks alone do not prove runtime, relay, performance, or platform correctness.
 
+## Cursor Cloud specific instructions
+
+- Cloud VM update installs VS Code via `.cursor/environment.json` → `.cursor/install-vscode.sh` (`code` on PATH).
+- For VS Code extension manual checks: `bun run vscode:build`, then launch
+  `code --user-data-dir=/tmp/oc-vscode-userdata --extensions-dir=/tmp/oc-vscode-exts --extensionDevelopmentPath="$PWD/packages/vscode" --disable-workspace-trust <workspace>`.
+- Prefer DISPLAY=:1 / computer-use for Extension Development Host UI verification.
+
 ## Pull Request Handoff
 
 Before creating or updating a pull request, read `CONTRIBUTING.md` and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Pin Microsoft VS Code (`code`) into the Cursor Cloud agent environment update path so future cloud runs can always do Extension Development Host testing without a one-off `apt` install.

## Non-goals

- Not changing OpenChamber VS Code extension product behavior.
- Not baking a specific VS Code version into a Dockerfile snapshot ID (install remains apt-based and idempotent).
- Not modifying product fix PRs (#2359 / engines work).

## Affected surfaces

- `.cursor/environment.json`: cloud `install`/update command now runs `bun install` plus VS Code ensure.
- `.cursor/install-vscode.sh`: idempotent apt install of `code`.
- `AGENTS.md`: short Cursor Cloud instructions for launching Extension Development Host.
- App packages / runtimes: unaffected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Cursor Cloud setup docs | Env tools persist via snapshot + update (`install`) / repo `environment.json` | Adds repo-level `environment.json` with idempotent VS Code install and `agentCanUpdateSnapshot` |
| `AGENTS.md` | Cloud-specific agent instructions belong here | Documents that `code` is expected and how to launch EDH |
| Change discipline (config-only) | Narrowest validation for isolated config | JSON + shell syntax + idempotent install dry-run |

## Validation

| Check | Result |
|---|---|
| `python3 -m json.tool .cursor/environment.json` | Valid |
| `bash -n .cursor/install-vscode.sh` | Pass |
| `bash .cursor/install-vscode.sh` with `code` already installed | Idempotent skip; reports `/usr/bin/code` `1.130.0` |
| Fresh cloud boot after merge (no prior `code`) | Not verified in this run — first boot after merge will apt-install |

## Visual evidence

No product UI change. This only affects cloud VM tooling availability (`code` on PATH).

## Risks and failure behavior

- Repo `.cursor/environment.json` overrides the personal SETUP_FLOW env for agents that start from a commit containing this file. Existing `bun install` is preserved; VS Code ensure is additive.
- First boot after merge may take longer while apt installs VS Code; later boots should hit the idempotent early-return / update checkpoint cache.
- If Microsoft apt is unreachable, update fails and the agent boot surfaces an environment warning; local/dev machines without sudo apt are unaffected unless they intentionally run the script.
- `agentCanUpdateSnapshot: true` allows Cursor to refresh the environment snapshot after successful updates when supported.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70e6ba94-5191-46b3-be77-684b86633a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70e6ba94-5191-46b3-be77-684b86633a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

