### PR TITLE
fix(discord): show /model modalities from OpenCode capabilities

### DIFF
--- a/packages/web/server/lib/messenger/discord-model-wizard.js
+++ b/packages/web/server/lib/messenger/discord-model-wizard.js
@@ -130,17 +130,14 @@ function mapCapabilityModalities(cap) {
 /** Resolved input modality keys for a provider model (ordered, de-duped). */
 export function inputModalityKeys(model) {
   if (!model || typeof model !== 'object') return [];
-  const fromModalities = normalizeModalityList(model?.modalities?.input);
-  if (fromModalities.length > 0) return fromModalities;
-
-  const fromCapabilities = mapCapabilityModalities(model?.capabilities?.input);
-  if (fromCapabilities.length > 0) return fromCapabilities;
-
-  // Legacy top-level attachment, or OpenCode capabilities.attachment.
-  if (model.attachment === true || model?.capabilities?.attachment === true) {
-    return ['image'];
+  let keys = normalizeModalityList(model?.modalities?.input);
+  if (keys.length === 0) {
+    keys = mapCapabilityModalities(model?.capabilities?.input);
   }
-  return [];
+  if (keys.length === 0 && (model.attachment === true || model?.capabilities?.attachment === true)) {
+    keys = ['image'];
+  }
+  return MODALITY_ORDER.filter((key) => keys.includes(key));
 }
 
 /**
@@ -164,9 +161,10 @@ export function primaryModalityEmoji(model) {
 /**
  * Build the Discord select-option description for a model: input modalities
  * (emoji), context window, and (when available) per-million-token input/output
- * price — e.g. `📝🖼️ · 200K ctx · in $3/out $15 /Mtok`. Returns '' when the
- * model exposes no usable metadata. Replaces the old `release_date` formatting
- * that showed a confusing bare date under every model name.
+ * price — e.g. `📝🖼️ · 200K ctx · in $3/out $15 /Mtok`. Modalities come from
+ * OpenCode `capabilities.input` or legacy `modalities.input`. Returns '' when
+ * the model exposes no usable metadata. Replaces the old `release_date`
+ * formatting that showed a confusing bare date under every model name.
  */
 export function formatModelMeta(model) {
   if (!model || typeof model !== 'object') return '';

--- a/packages/web/server/lib/messenger/discord-model-wizard.js
+++ b/packages/web/server/lib/messenger/discord-model-wizard.js
@@ -113,27 +113,48 @@ function normalizeModalityList(values) {
 }
 
 /**
+ * OpenCode `/provider` models expose input modalities as a boolean map under
+ * `capabilities.input` (`{ text, image, … }`). models.dev / older payloads may
+ * instead use `modalities.input` as a string array. Accept both so Discord
+ * `/model` shows the same modalities the UI does.
+ */
+function mapCapabilityModalities(cap) {
+  if (!cap || typeof cap !== 'object' || Array.isArray(cap)) return [];
+  const out = [];
+  for (const key of MODALITY_ORDER) {
+    if (cap[key] === true) out.push(key);
+  }
+  return out;
+}
+
+/** Resolved input modality keys for a provider model (ordered, de-duped). */
+export function inputModalityKeys(model) {
+  if (!model || typeof model !== 'object') return [];
+  const fromModalities = normalizeModalityList(model?.modalities?.input);
+  if (fromModalities.length > 0) return fromModalities;
+
+  const fromCapabilities = mapCapabilityModalities(model?.capabilities?.input);
+  if (fromCapabilities.length > 0) return fromCapabilities;
+
+  // Legacy top-level attachment, or OpenCode capabilities.attachment.
+  if (model.attachment === true || model?.capabilities?.attachment === true) {
+    return ['image'];
+  }
+  return [];
+}
+
+/**
  * Input modalities the model accepts, as emoji icons (📝🖼️🎬🔊📄).
  * Falls back to image when only the legacy `attachment` flag is set.
  */
 export function formatModelModalities(model) {
-  if (!model || typeof model !== 'object') return '';
-  const keys = normalizeModalityList(model?.modalities?.input);
-  if (keys.length === 0 && model.attachment === true) {
-    keys.push('image');
-  }
-  return MODALITY_ORDER.filter((key) => keys.includes(key))
-    .map((key) => MODALITY_EMOJI[key])
-    .join('');
+  const keys = inputModalityKeys(model);
+  return keys.map((key) => MODALITY_EMOJI[key]).join('');
 }
 
 /** Single emoji for the Discord select-option `emoji` field (left of the label). */
 export function primaryModalityEmoji(model) {
-  if (!model || typeof model !== 'object') return null;
-  const keys = normalizeModalityList(model?.modalities?.input);
-  if (keys.length === 0 && model.attachment === true) {
-    keys.push('image');
-  }
+  const keys = inputModalityKeys(model);
   for (const key of MODALITY_BADGE_PRIORITY) {
     if (keys.includes(key)) return MODALITY_EMOJI[key];
   }
@@ -582,8 +603,10 @@ export function createDiscordModelWizard({ restCall, bridge }) {
           label: modelID,
           // Prefer context/pricing/modalities, fall back to the provider id.
           description: meta || providerID,
-          // Keep modality fields so the select option can show an emoji badge.
+          // Keep modality fields so the select option can show an emoji badge
+          // (OpenCode capabilities map and/or models.dev modalities array).
           modalities: model?.modalities,
+          capabilities: model?.capabilities,
           attachment: model?.attachment,
         };
       });

--- a/packages/web/server/lib/messenger/discord-model-wizard.test.js
+++ b/packages/web/server/lib/messenger/discord-model-wizard.test.js
@@ -42,6 +42,18 @@ describe('formatModelMeta', () => {
     ).toBe('📝🖼️ · 200K ctx · in $3/out $15 /Mtok');
   });
 
+  it('prefixes modality icons from OpenCode capabilities.input', () => {
+    expect(
+      formatModelMeta({
+        capabilities: {
+          input: { text: true, image: true, audio: false, video: false, pdf: false },
+        },
+        limit: { context: 200000 },
+        cost: { input: 3, output: 15 },
+      }),
+    ).toBe('📝🖼️ · 200K ctx · in $3/out $15 /Mtok');
+  });
+
   it('never renders a date and returns empty when no metadata exists', () => {
     expect(formatModelMeta({ release_date: '2024-01-01' })).toBe('');
     expect(formatModelMeta({})).toBe('');
@@ -55,15 +67,41 @@ describe('formatModelModalities / primaryModalityEmoji', () => {
     expect(formatModelModalities({ modalities: { input: ['audio', 'video'] } })).toBe('🎬🔊');
   });
 
+  it('maps OpenCode capabilities.input boolean flags to emoji', () => {
+    expect(
+      formatModelModalities({
+        capabilities: {
+          input: { text: true, image: true, audio: false, video: false, pdf: true },
+          attachment: true,
+        },
+      }),
+    ).toBe('📝🖼️📄');
+    expect(
+      primaryModalityEmoji({
+        capabilities: { input: { text: true, image: true, audio: false, video: false, pdf: false } },
+      }),
+    ).toBe('🖼️');
+  });
+
   it('falls back to image when only the legacy attachment flag is set', () => {
     expect(formatModelModalities({ attachment: true })).toBe('🖼️');
     expect(primaryModalityEmoji({ attachment: true })).toBe('🖼️');
+    expect(formatModelModalities({ capabilities: { attachment: true } })).toBe('🖼️');
   });
 
   it('prefers image/video/audio/pdf over text for the select badge', () => {
     expect(primaryModalityEmoji({ modalities: { input: ['text', 'image'] } })).toBe('🖼️');
     expect(primaryModalityEmoji({ modalities: { input: ['text'] } })).toBe('📝');
     expect(primaryModalityEmoji({})).toBe(null);
+  });
+
+  it('prefers modalities.input arrays over capabilities when both are present', () => {
+    expect(
+      formatModelModalities({
+        modalities: { input: ['text'] },
+        capabilities: { input: { text: true, image: true, audio: false, video: false, pdf: false } },
+      }),
+    ).toBe('📝');
   });
 });
 
@@ -403,7 +441,15 @@ describe('createDiscordModelWizard flow', () => {
           {
             id: 'sonnet',
             name: 'Sonnet',
-            modalities: { input: ['text', 'image'], output: ['text'] },
+            // OpenCode `/provider` shape: boolean capability map, not modalities[].
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, image: true, audio: false, video: false, pdf: false },
+              output: { text: true, image: false, audio: false, video: false, pdf: false },
+            },
             limit: { context: 200000 },
             cost: { input: 3, output: 15 },
           },
@@ -424,6 +470,42 @@ describe('createDiscordModelWizard flow', () => {
     const modelOpts = lastSelectOptions(calls.at(-1));
     // The hidden model is gone; the visible one carries modalities + context + pricing.
     expect(modelOpts.map((o) => o.value)).toEqual(['sonnet']);
+    expect(modelOpts[0].description).toBe('📝🖼️ · 200K ctx · in $3/out $15 /Mtok');
+    expect(modelOpts[0].emoji).toEqual({ name: '🖼️' });
+  });
+
+  it('shows modality badges for favourites sourced from OpenCode capabilities', async () => {
+    const richProviders = [
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        models: [
+          {
+            id: 'sonnet',
+            name: 'Sonnet',
+            capabilities: {
+              attachment: true,
+              input: { text: true, image: true, audio: false, video: false, pdf: false },
+              output: { text: true, image: false, audio: false, video: false, pdf: false },
+            },
+            limit: { context: 200000 },
+            cost: { input: 3, output: 15 },
+          },
+        ],
+      },
+    ];
+    const { wizard, calls } = makeHarness(richProviders, {
+      favorites: [{ providerID: 'anthropic', modelID: 'sonnet' }],
+    });
+    await wizard.start(state, { id: 'i1', token: 't1', channel_id: 'chan', application_id: 'app' });
+    const provCustomId = lastCustomId(calls.at(-1));
+    await wizard.handleComponent(
+      state,
+      { id: 'i2', token: 't2', data: { values: ['__openchamber_agent_favorites'] } },
+      provCustomId,
+    );
+    const modelOpts = lastSelectOptions(calls.at(-1));
+    expect(modelOpts).toHaveLength(1);
     expect(modelOpts[0].description).toBe('📝🖼️ · 200K ctx · in $3/out $15 /Mtok');
     expect(modelOpts[0].emoji).toEqual({ name: '🖼️' });
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Discord `/model` select options were supposed to show input modalities (📝🖼️🎬🔊📄) next to context/pricing, but live OpenCode `/provider` models expose modalities as `capabilities.input` boolean maps (`{ text, image, … }`), not `modalities.input` string arrays. The picker therefore never rendered modality icons for real providers.

This change maps `capabilities.input` (and `capabilities.attachment`) into the existing emoji formatting, while still accepting legacy `modalities.input` / top-level `attachment` payloads.

## Non-goals

- Changing Discord UI copy, wizard flow, or select paging
- Surfacing output modalities (still input-only, matching the previous design)
- Changing shared UI model-picker modality rendering

## Affected surfaces

- `packages/web` Discord gateway `/model` wizard only
- Unaffected: web/desktop/VS Code/mobile UI model pickers (already derive modalities from `capabilities` in `useConfigStore`)
- No persisted settings or external API contract changes

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` change discipline | Source change in web messenger | Smallest fix in owning module; focused tests; no new deps |
| `openchamber-change-discipline` | Executable server JS change | Local implementation risk; preserve existing emoji/meta formatting contract; validate with focused vitest |
| Nearest docs | No messenger `DOCUMENTATION.md`; `packages/web/README.md` is package overview | Behavior lives in `discord-model-wizard.js` comments/tests; no ownership/doc invariant change |

## Validation

| Check | Result |
|---|---|
| `cd packages/web && bun run test -- server/lib/messenger/discord-model-wizard.test.js` | Passed — 30/30 |
| Live Discord `/model` against a real OpenCode provider | Not verified in this environment |

## Visual evidence

No rendered web UI change. Discord ephemeral select options gain modality emoji in descriptions/badges when provider data includes capabilities; cannot capture Discord interaction UI in this cloud environment.

## Risks and failure behavior

- Unknown modality keys are ignored (same as before)
- If a model has neither `modalities.input` nor `capabilities.input`/`attachment`, description falls back to ctx/pricing only (or blank) — same as pre-#2308 empty meta
- Favourites now forward `capabilities` so badges match live provider models
- No rollback risk beyond reverting this commit; no persisted state written

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa4cc-db39-73a7-9cda-2df82daccb44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa4cc-db39-73a7-9cda-2df82daccb44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

