### PR TITLE
fix(files): keep the editor toolbar recoverable after file search (#1683)

### DIFF
--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -2237,6 +2237,7 @@ export const ContextPanel: React.FC = () => {
   const setContextPanelWidth = useUIStore((state) => state.setContextPanelWidth);
   const setActiveContextPanelTab = useUIStore((state) => state.setActiveContextPanelTab);
   const reorderContextPanelTabs = useUIStore((state) => state.reorderContextPanelTabs);
+  const isSettingsDialogOpen = useUIStore((state) => state.isSettingsDialogOpen);
   const setSelectedFilePath = useFilesViewTabsStore((state) => state.setSelectedPath);
   const openContextPreview = useUIStore((state) => state.openContextPreview);
   const contextEditorTreeVisible = useUIStore((state) => state.contextEditorTreeVisible);
@@ -2896,7 +2897,7 @@ export const ContextPanel: React.FC = () => {
           <div className={cn('absolute inset-0 flex', isFileTabActive ? 'flex' : 'hidden')}>
             <div className="h-full min-w-0 flex-1">
               {hasOpenEditorFile ? (
-                <FilesView mode="editor-only" />
+                <FilesView mode="editor-only" active={isOpen && isFileTabActive && !isSettingsDialogOpen} />
               ) : (
                 <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
                   <Icon name="file-code" className="h-12 w-12 text-muted-foreground/50" />

--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -263,7 +263,11 @@ export const MainLayout: React.FC = () => {
             case 'terminal':
                 return <TerminalView />;
             case 'files':
-                return <React.Suspense fallback={null}><FilesView /></React.Suspense>;
+                return (
+                    <React.Suspense fallback={null}>
+                        <FilesView active={!isSettingsDialogOpen && !isSurfacePageOpen && !mobileLeftDrawerVisible && !mobileRightDrawerVisible} />
+                    </React.Suspense>
+                );
             case 'context':
                 return <React.Suspense fallback={null}><ProjectContextPanel /></React.Suspense>;
             case 'diagram':
@@ -271,7 +275,7 @@ export const MainLayout: React.FC = () => {
             default:
                 return null;
         }
-    }, [activeMainTab, isMobile, mobileRightSidebarOpen]);
+    }, [activeMainTab, isMobile, isSettingsDialogOpen, isSurfacePageOpen, mobileLeftDrawerVisible, mobileRightDrawerVisible, mobileRightSidebarOpen]);
 
     const isChatActive = activeMainTab === 'chat';
 

--- a/packages/ui/src/components/views/FilesView.find.test.ts
+++ b/packages/ui/src/components/views/FilesView.find.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  handleFilesViewFind,
+  reduceFilesViewFindState,
+  renderFilesViewSurface,
+} from './filesViewFind';
+
+describe('FilesView find behavior (issue #1683)', () => {
+  test('does not intercept find from a mounted hidden FilesView', () => {
+    let prevented = false;
+    let opened = false;
+    const event = { preventDefault: () => { prevented = true; } };
+
+    expect(handleFilesViewFind(false, true, event, () => { opened = true; })).toBe(false);
+    expect(prevented).toBe(false);
+    expect(opened).toBe(false);
+
+    expect(handleFilesViewFind(true, true, event, () => { opened = true; })).toBe(true);
+    expect(prevented).toBe(true);
+    expect(opened).toBe(true);
+  });
+
+  test('keeps search open while moving between inline and fullscreen editors', () => {
+    const openInline = { fullscreen: false, searchOpen: true };
+    const fullscreen = reduceFilesViewFindState(openInline, { type: 'toggle-fullscreen' });
+    const inlineAgain = reduceFilesViewFindState(fullscreen, { type: 'exit-fullscreen' });
+
+    expect(fullscreen).toEqual({ fullscreen: true, searchOpen: true });
+    expect(inlineAgain).toEqual(openInline);
+  });
+
+  test('mounts only the selected editor surface', () => {
+    const mounted: string[] = [];
+    const renderInline = () => { mounted.push('inline'); return 'inline'; };
+    const renderFullscreen = () => { mounted.push('fullscreen'); return 'fullscreen'; };
+
+    expect(renderFilesViewSurface(
+      { fullscreen: false, searchOpen: true },
+      renderInline,
+      renderFullscreen,
+    )).toBe('inline');
+    expect(mounted).toEqual(['inline']);
+
+    mounted.length = 0;
+    expect(renderFilesViewSurface(
+      { fullscreen: true, searchOpen: true },
+      renderInline,
+      renderFullscreen,
+    )).toBe('fullscreen');
+    expect(mounted).toEqual(['fullscreen']);
+  });
+
+  test('applies search panel close notifications', () => {
+    const state = reduceFilesViewFindState(
+      { fullscreen: true, searchOpen: true },
+      { type: 'set-search-open', open: false },
+    );
+
+    expect(state).toEqual({ fullscreen: true, searchOpen: false });
+  });
+});

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -74,6 +74,7 @@ import { openDesktopFileInApp, openDesktopPath } from '@/lib/desktop';
 import { useOpenInAppsStore } from '@/stores/useOpenInAppsStore';
 import { eventMatchesShortcut, getEffectiveShortcutCombo } from '@/lib/shortcuts';
 import { useI18n } from '@/lib/i18n';
+import { handleFilesViewFind, reduceFilesViewFindState, renderFilesViewSurface } from './filesViewFind';
 
 type FileNode = {
   name: string;
@@ -656,6 +657,7 @@ const Dialogs: React.FC<DialogsProps> = ({
 
 interface FilesViewProps {
   mode?: 'full' | 'editor-only';
+  active?: boolean;
 }
 
 /**
@@ -714,7 +716,7 @@ const useAssetAuthRefresh = (
   return { readyKey, nonce };
 };
 
-export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
+export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', active = true }) => {
   const { t } = useI18n();
   const { files, runtime } = useRuntimeAPIs();
   const { currentTheme, availableThemes, lightThemeId, darkThemeId } = useThemeSystem();
@@ -736,8 +738,11 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
 
   const [showMobilePageContent, setShowMobilePageContent] = React.useState(false);
   const [wrapLines, setWrapLines] = React.useState(true);
-  const [isFullscreen, setIsFullscreen] = React.useState(false);
-  const [isSearchOpen, setIsSearchOpen] = React.useState(false);
+  const [findState, dispatchFind] = React.useReducer(
+    reduceFilesViewFindState,
+    { fullscreen: false, searchOpen: false },
+  );
+  const { fullscreen: isFullscreen, searchOpen: isSearchOpen } = findState;
   const [isFloatingToolbarOpen, setIsFloatingToolbarOpen] = React.useState(false);
   const floatingToolbarRef = React.useRef<HTMLDivElement | null>(null);
   const toolbarDropdownOpenCountRef = React.useRef(0);
@@ -1759,6 +1764,9 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       }
 
       if (e.key.toLowerCase() === 's') {
+        if (!active) {
+          return;
+        }
         e.preventDefault();
         // Cancel pending auto-save; user wants immediate save
         if (autoSaveTimerRef.current) {
@@ -1773,14 +1781,15 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           });
         }
       } else if (e.key.toLowerCase() === 'f') {
-        e.preventDefault();
-        setIsSearchOpen(true);
+        handleFilesViewFind(active, editorViewRef.current !== null, e, () => {
+          dispatchFind({ type: 'set-search-open', open: true });
+        });
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isSaving, saveDraft]);
+  }, [active, isSaving, saveDraft]);
 
   const loadSelectedFile = React.useCallback(async (node: FileNode) => {
     const loadId = activeFileLoadIdRef.current + 1;
@@ -3170,6 +3179,14 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     );
   }, [currentTheme.metadata.variant, pierreTheme, wrapLines]);
 
+  const isSearchEditorMounted = active && editorViewRef.current !== null;
+
+  React.useEffect(() => {
+    if (!isSearchEditorMounted && isSearchOpen) {
+      dispatchFind({ type: 'set-search-open', open: false });
+    }
+  }, [isSearchEditorMounted, isSearchOpen]);
+
   const renderFloatingFileControls = ({
     exitFullscreenOnly = false,
     layout = 'floating',
@@ -3296,14 +3313,14 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
                 <Icon name="text-wrap" className="size-4" />
               </Button>
             )}
-            {textViewMode === 'edit' && (
+            {isSearchEditorMounted && (
               <>
                 {withTooltip(t('filesView.editor.findInFile'),
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={(event) => {
-                      setIsSearchOpen(!isSearchOpen);
+                      dispatchFind({ type: 'set-search-open', open: !isSearchOpen });
                       event.currentTarget.blur();
                     }}
                     className="size-6 p-0 text-foreground opacity-100 transition-opacity hover:bg-transparent focus-visible:bg-transparent active:bg-transparent"
@@ -3549,7 +3566,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setIsFullscreen(false)}
+              onClick={() => dispatchFind({ type: 'exit-fullscreen' })}
               className="size-6 p-0 hover:bg-transparent focus-visible:bg-transparent active:bg-transparent"
               title={t('filesView.editor.exitFullscreen')}
               aria-label={t('filesView.editor.exitFullscreen')}
@@ -3562,7 +3579,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setIsFullscreen(!isFullscreen)}
+              onClick={() => dispatchFind({ type: 'toggle-fullscreen' })}
               className="size-6 p-0 hover:bg-transparent focus-visible:bg-transparent active:bg-transparent"
               title={isFullscreen ? t('filesView.editor.exitFullscreen') : t('filesView.editor.fullscreen')}
               aria-label={isFullscreen ? t('filesView.editor.exitFullscreen') : t('filesView.editor.fullscreen')}
@@ -3773,10 +3790,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       </div>
 
       <div className="flex-1 min-h-0 min-w-0 relative">
-        {selectedFile && !isSearchOpen && !(settingsExpandedEditorToolbar && !isMobile) && (
+        {selectedFile && !(settingsExpandedEditorToolbar && !isMobile) && (
           <div
             ref={floatingToolbarRef}
-            className="absolute right-3 top-3 z-30"
+            className={cn('absolute right-3 z-30', isSearchOpen ? 'top-20' : 'top-3')}
             onMouseLeave={() => {
               if (toolbarDropdownOpenCountRef.current > 0) return;
               setIsFloatingToolbarOpen(false);
@@ -3985,14 +4002,12 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
                     });
                   }}
                   onViewDestroy={() => {
-                    if (editorViewRef.current) {
-                      editorViewRef.current = null;
-                    }
+                    editorViewRef.current = null;
                     setEditorViewReadyNonce((value) => value + 1);
                   }}
                   enableSearch
                   searchOpen={isSearchOpen}
-                  onSearchOpenChange={setIsSearchOpen}
+                  onSearchOpenChange={(open) => dispatchFind({ type: 'set-search-open', open })}
                   highlightLines={lineSelection
                     ? {
                       start: Math.min(lineSelection.start, lineSelection.end),
@@ -4229,7 +4244,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     <div className="absolute inset-0 z-50 flex flex-col bg-background">
       {/* Fullscreen content */}
       <div className="flex-1 min-h-0 min-w-0 relative">
-        <div className="absolute right-4 top-4 z-30">
+        <div className={cn('absolute right-4 z-30', isSearchOpen ? 'top-20' : 'top-4')}>
           {renderFloatingFileControls({ exitFullscreenOnly: true })}
         </div>
         <ScrollableOverlay outerClassName="h-full min-w-0" className="h-full min-w-0">
@@ -4317,15 +4332,18 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
                 className="h-full"
                 onViewReady={(view) => {
                   editorViewRef.current = view;
+                  setEditorViewReadyNonce((value) => value + 1);
                   window.requestAnimationFrame(() => {
                     nudgeEditorSelectionAboveKeyboard(view);
                   });
                 }}
                 onViewDestroy={() => {
-                  if (editorViewRef.current) {
-                    editorViewRef.current = null;
-                  }
+                  editorViewRef.current = null;
+                  setEditorViewReadyNonce((value) => value + 1);
                 }}
+                enableSearch
+                searchOpen={isSearchOpen}
+                onSearchOpenChange={(open) => dispatchFind({ type: 'set-search-open', open })}
               />
               </div>
               {shouldMaskEditorForPendingNavigation && (
@@ -4355,8 +4373,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
         onClose={handleCloseDialog}
         inputRef={dialogInputRef}
       />
-      {fullscreenViewer}
-      {isMobile ? (
+      {renderFilesViewSurface(findState, () => isMobile ? (
         showMobilePageContent ? (
           fileViewer
         ) : (
@@ -4379,7 +4396,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
              {fileViewer}
            </div>
          </div>
-       )}
+       ), () => fullscreenViewer)}
     </div>
   );
 };

--- a/packages/ui/src/components/views/filesViewFind.ts
+++ b/packages/ui/src/components/views/filesViewFind.ts
@@ -1,0 +1,43 @@
+interface FilesViewFindState {
+  fullscreen: boolean;
+  searchOpen: boolean;
+}
+
+type FilesViewFindAction =
+  | { type: 'set-search-open'; open: boolean }
+  | { type: 'toggle-fullscreen' }
+  | { type: 'exit-fullscreen' };
+
+export const reduceFilesViewFindState = (
+  state: FilesViewFindState,
+  action: FilesViewFindAction,
+): FilesViewFindState => {
+  switch (action.type) {
+    case 'set-search-open':
+      return { ...state, searchOpen: action.open };
+    case 'toggle-fullscreen':
+      return { ...state, fullscreen: !state.fullscreen };
+    case 'exit-fullscreen':
+      return { ...state, fullscreen: false };
+  }
+};
+
+export const handleFilesViewFind = (
+  active: boolean,
+  editorMounted: boolean,
+  event: Pick<Event, 'preventDefault'>,
+  openSearch: () => void,
+): boolean => {
+  if (!active || !editorMounted) {
+    return false;
+  }
+  event.preventDefault();
+  openSearch();
+  return true;
+};
+
+export const renderFilesViewSurface = <T>(
+  state: FilesViewFindState,
+  renderInline: () => T,
+  renderFullscreen: () => T,
+): T => state.fullscreen ? renderFullscreen() : renderInline();


### PR DESCRIPTION
> Validated commit: `627ea6b9214367d77929dc2ed18523cd75440195`.

## Intent

Fixes #1683. The floating editor toolbar could become permanently unreachable after opening file search. Its visibility was gated on `!isSearchOpen`, and the only thing that cleared that flag was CodeMirror's `onSearchOpenChange`, which could get stuck open. This removes `isSearchOpen` from the visibility condition entirely and moves the toolbar to `top-20` while the search panel is open, so search state can no longer hide the toolbar at all.

Two supporting changes are load-bearing rather than scope creep:

- The new `active` prop: `MainLayout` and `ContextPanel` can both mount a `FilesView` at the same time, and the window-level `Cmd/Ctrl+F` and `Cmd/Ctrl+S` handlers previously fired in the hidden instance too. Both are now gated on `active`.
- `renderFilesViewSurface`: on `main`, opening fullscreen leaves the fullscreen **and** the inline editor mounted as siblings, so two CodeMirror views both wrote `editorViewRef`. This PR gives the fullscreen editor `enableSearch`, which makes that ambiguity a correctness problem, so the two surfaces are now mutually exclusive.

The find-state reducer also keeps `searchOpen` stable across fullscreen enter/exit, which is the invariant covered by the unit tests.

## Non-goals

Does not add CodeMirror find to Markdown, HTML, image, PDF, draw.io, or other non-editor previews; their `Cmd/Ctrl+F` stays with the host or browser.

## Affected surfaces

Shared `FilesView` editor instances in the main Files page and the context panel, across web, desktop, VS Code, hosted mobile, and Capacitor mobile. No persisted or API contract change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Shared UI component contract gains an `active` prop and find state moves to a reducer | Find state and surface selection live in one focused helper (`filesViewFind.ts`) with state-transition tests; the added prop is required by the fix, not an unrelated refactor. |
| `theme-system` | Toolbar visibility and position change | No new color, token, or typography value; only existing Tailwind offset utilities are used. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/views/FilesView.find.test.ts` | 4 passed, 0 failed. Covers hidden-instance find suppression, `searchOpen` surviving fullscreen enter/exit, single-surface mounting, and search-close notification. |
| `bun run type-check:ui` | Exit 0. |
| `bun run lint:ui` | Exit 0. |

Not validated: no browser, desktop, VS Code, or mobile run. Toolbar reachability with the search panel open was not observed at runtime, only reasoned from the removed gate and covered indirectly by the reducer tests.

## Visual evidence

Not captured — this is a visible UI fix and the evidence is genuinely missing. The states a reviewer needs are before/after screenshots of the Files editor with (1) the search panel closed and (2) the search panel open, each at a narrow/mobile width and a wide desktop width, showing the floating toolbar present and not overlapping the search panel.

## Risks and failure behavior

`top-20`, `top-3`, and `top-4` are hardcoded offsets chosen to clear CodeMirror's search panel. A taller translated search-and-replace panel or a very narrow viewport could still overlap the toolbar; that was not measured.

Find is intercepted only when the `FilesView` is `active` and its editor is mounted; otherwise the keydown is left untouched for the containing runtime, so a runtime whose own find should win is not regressed.
