### PR TITLE
fix(settings): persist collapsed message preference

### DIFF
--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -552,6 +552,9 @@ export const createSettingsHelpers = (dependencies) => {
         result.userMessageRenderingMode = mode;
       }
     }
+    if (typeof candidate.collapsibleUserMessages === 'boolean') {
+      result.collapsibleUserMessages = candidate.collapsibleUserMessages;
+    }
     if (typeof candidate.stickyUserHeader === 'boolean') {
       result.stickyUserHeader = candidate.stickyUserHeader;
     }

--- a/packages/web/server/lib/opencode/settings-helpers.test.js
+++ b/packages/web/server/lib/opencode/settings-helpers.test.js
@@ -74,6 +74,14 @@ describe('settings helpers', () => {
     expect(helpers.sanitizeSettingsUpdate({ wideChatLayoutEnabled: 'true' })).toEqual({});
   });
 
+  it('accepts only booleans for collapsible user messages', () => {
+    const helpers = createTestHelpers();
+
+    expect(helpers.sanitizeSettingsUpdate({ collapsibleUserMessages: true })).toEqual({ collapsibleUserMessages: true });
+    expect(helpers.sanitizeSettingsUpdate({ collapsibleUserMessages: false })).toEqual({ collapsibleUserMessages: false });
+    expect(helpers.sanitizeSettingsUpdate({ collapsibleUserMessages: 'true' })).toEqual({});
+  });
+
   it('accepts messageStreamTransport as a persisted shared setting', () => {
     const helpers = createTestHelpers();
 


### PR DESCRIPTION
## Intent

Persist the `collapsibleUserMessages` preference by allowing boolean values through the server settings sanitizer. Invalid non-boolean values remain rejected. Fixes #2405.

## Non-goals

This PR does not change the setting UI, its default value, migrations, or any other settings key.

## Affected surfaces

`packages/web` settings persistence is affected for every runtime that stores settings through the OpenChamber server. No OpenCode API contract or renderer layout changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes server source and a persisted settings contract. | The change stays in the owning settings helper and adds focused sanitizer coverage. |
| `ui-api-decoupling` | The setting crosses the shared UI/server boundary. | Validation remains server-side rather than relying on UI visibility. |
| `packages/web/README.md` and `packages/web/server/lib/opencode/DOCUMENTATION.md` | They define Web runtime and settings-helper ownership. | The sanitizer change remains in `settings-helpers.js`; entrypoints remain unchanged. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/web/server/lib/opencode/settings-helpers.test.js` | Passed: 32 tests, 0 failures. |
| `node --check packages/web/server/lib/opencode/settings-helpers.js` | Passed. |
| `bun run lint:web` | Passed. |
| `git diff --check main...HEAD` | Passed. |
| Desktop/Web restart with the preference disabled | Not performed; this draft still requires manual persistence verification. |

## Visual evidence

 the preference remains disabled after a Web or Desktop restart; the rendered UI itself is unchanged by this server-only diff.
<img width="618" height="121" alt="image" src="https://github.com/user-attachments/assets/21600dc0-4484-4bfa-ae26-36d166f2a70d" />

## Risks and failure behavior

The sanitizer still drops malformed values, so persisted data cannot acquire a string in place of the boolean. Rollback is a one-line sanitizer removal; existing settings files need no migration.
