### PR TITLE
fix(chat): render question prompts as markdown

### DIFF
--- a/packages/ui/src/components/chat/MarkdownRenderer.tsx
+++ b/packages/ui/src/components/chat/MarkdownRenderer.tsx
@@ -43,8 +43,12 @@ export const MarkdownRenderer: React.FC<React.ComponentPropsWithoutRef<typeof Ma
   </React.Suspense>
 );
 
-export const SimpleMarkdownRenderer: React.FC<React.ComponentPropsWithoutRef<typeof SimpleMarkdownRendererLazy>> = (props) => (
-  <React.Suspense fallback={<MobileMarkdownFallback {...props} />}>
+type SimpleMarkdownRendererProps = React.ComponentPropsWithoutRef<typeof SimpleMarkdownRendererLazy> & {
+  fallbackContent?: React.ReactNode;
+};
+
+export const SimpleMarkdownRenderer: React.FC<SimpleMarkdownRendererProps> = ({ fallbackContent, ...props }) => (
+  <React.Suspense fallback={fallbackContent ?? <MobileMarkdownFallback {...props} />}>
     <SimpleMarkdownRendererLazy {...props} />
   </React.Suspense>
 );

--- a/packages/ui/src/components/chat/QuestionCard.tsx
+++ b/packages/ui/src/components/chat/QuestionCard.tsx
@@ -15,6 +15,7 @@ import * as sessionActions from '@/sync/session-actions';
 import { useI18n } from '@/lib/i18n';
 import { serializeQuestionAsJson, serializeQuestionAsMarkdown } from './questionSerializers';
 import { QUESTION_CUSTOM_TEXTAREA_MIN_HEIGHT, getQuestionCustomTextareaHeight } from './questionTextareaSizing';
+import { QuestionMarkdown } from './QuestionMarkdown';
 
 interface QuestionCardProps {
   question: QuestionRequest;
@@ -423,7 +424,11 @@ export const QuestionCard: React.FC<QuestionCardProps> = ({ question }) => {
               </div>
             ) : activeQuestion ? (
               <>
-                <div className="typography-meta font-medium text-foreground mb-1.5">{activeQuestion.question}</div>
+                <QuestionMarkdown
+                  content={activeQuestion.question}
+                  size="meta"
+                  className="font-medium text-foreground mb-1.5"
+                />
 
                 {isMultiple ? (
                   <div className="typography-micro text-muted-foreground mb-1.5">{t('chat.questionCard.selectMultiple')}</div>

--- a/packages/ui/src/components/chat/QuestionMarkdown.test.tsx
+++ b/packages/ui/src/components/chat/QuestionMarkdown.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+import { SimpleMarkdownRenderer } from './MarkdownRenderer';
+import { QuestionMarkdown } from './QuestionMarkdown';
+
+describe('QuestionMarkdown', () => {
+  test('delegates exact content to the tool markdown renderer', () => {
+    const content = 'Choose **one** from `mode`: [details](https://example.com)';
+    const element = QuestionMarkdown({ content, size: 'meta' });
+
+    expect(element.type).toBe(SimpleMarkdownRenderer);
+    expect(element.props.content).toBe(content);
+    expect(element.props.variant).toBe('tool');
+    expect(element.props.fallbackContent.props.children).toBe(content);
+    expect(element.props.fallbackContent.props.className).toContain('whitespace-pre-wrap');
+  });
+
+  test('preserves question typography size and caller classes', () => {
+    const meta = QuestionMarkdown({ content: 'Meta', size: 'meta', className: 'font-medium text-foreground' });
+    const micro = QuestionMarkdown({ content: 'Micro', size: 'micro', className: 'text-muted-foreground' });
+
+    expect(meta.props.className).toBe('question-markdown typography-meta font-medium text-foreground');
+    expect(micro.props.className).toBe('question-markdown typography-micro text-muted-foreground');
+  });
+});

--- a/packages/ui/src/components/chat/QuestionMarkdown.tsx
+++ b/packages/ui/src/components/chat/QuestionMarkdown.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+import { SimpleMarkdownRenderer } from './MarkdownRenderer';
+
+interface QuestionMarkdownProps {
+  content: string;
+  size: 'meta' | 'micro';
+  className?: string;
+}
+
+export function QuestionMarkdown({ content, size, className }: QuestionMarkdownProps) {
+  const classes = cn('question-markdown', size === 'meta' ? 'typography-meta' : 'typography-micro', className);
+
+  return (
+    <SimpleMarkdownRenderer
+      content={content}
+      variant="tool"
+      className={classes}
+      fallbackContent={<div className={cn(classes, 'whitespace-pre-wrap')}>{content}</div>}
+    />
+  );
+}

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -4,6 +4,7 @@ import { RuntimeAPIContext } from '@/contexts/runtimeAPIContext';
 import { PatchDiff } from '@pierre/diffs/react';
 import { cn } from '@/lib/utils';
 import { SimpleMarkdownRenderer } from '../../MarkdownRenderer';
+import { QuestionMarkdown } from '../../QuestionMarkdown';
 import { MessageFilesDisplay } from '../../FileAttachment';
 import { getToolMetadata } from '@/lib/toolHelpers';
 import type { ToolPart as ToolPartType, ToolState as ToolStateUnion, FilePart } from '@opencode-ai/sdk/v2';
@@ -1672,7 +1673,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                         <div className="space-y-2">
                             {parsedQA.map((qa, index) => (
                                 <div key={index} className="space-y-0.5">
-                                    <div className="typography-micro text-muted-foreground">{qa.question}</div>
+                                    <QuestionMarkdown content={qa.question} size="micro" className="text-muted-foreground" />
                                     <div className="typography-meta text-foreground whitespace-pre-wrap">{qa.answer}</div>
                                 </div>
                             ))}
@@ -1709,7 +1710,7 @@ const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.memo(({
                                 {q.header ? (
                                     <div className="typography-micro text-muted-foreground">{coerceToText(q.header)}</div>
                                 ) : null}
-                                <div className="typography-meta text-foreground">{coerceToText(q.question)}</div>
+                                <QuestionMarkdown content={coerceToText(q.question)} size="meta" className="text-foreground" />
                                 {Array.isArray(q.options) && q.options.length > 0 ? (
                                     <div className="flex flex-wrap gap-1 mt-0.5">
                                         {q.options.map((opt) => (

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1022,6 +1022,18 @@ html:not(.dark) .chat-scroll {
   font-size: var(--text-code) !important;
 }
 
+.question-markdown > .markdown-content.markdown-tool {
+  font-size: inherit !important;
+}
+
+.question-markdown > .markdown-content > [data-md-block]:first-child > :first-child {
+  margin-top: 0;
+}
+
+.question-markdown > .markdown-content > [data-md-block]:last-child > :last-child {
+  margin-bottom: 0;
+}
+
 /* Reasoning markdown renders at meta size, dimmed. */
 .markdown-content.markdown-reasoning {
   font-size: var(--text-markdown);

--- a/packages/ui/src/styles/mobile.css
+++ b/packages/ui/src/styles/mobile.css
@@ -79,6 +79,10 @@
     font-size: var(--text-code) !important;
   }
 
+  :root.mobile-pointer:not(.desktop-runtime) .question-markdown > .markdown-content.markdown-tool {
+    font-size: inherit !important;
+  }
+
   /* Improve touch targets for mobile */
   :root.mobile-pointer:not(.desktop-runtime) button:not([role="radio"]):not([role="checkbox"]):not([role="switch"]),
   :root.mobile-pointer:not(.desktop-runtime) .btn,


### PR DESCRIPTION
## Intent

Render question-tool prompts with the existing simple Markdown renderer in both live question cards and historical tool output, including paragraphs, emphasis, lists, and inline code. Fixes #856.

## Non-goals

This PR does not enable arbitrary HTML, change answer controls, alter question submission, or replace the full chat Markdown renderer.

## Affected surfaces

Shared `packages/ui` question rendering and responsive styles are affected across Web, Desktop, hosted mobile, Capacitor mobile, and VS Code. No server or persisted-data contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes shared source, styles, and a rendered-content contract. | The implementation reuses the existing Markdown renderer and leaves data access untouched. |
| `theme-system` | Markdown introduces visible typography and spacing in shared UI. | Styles use existing theme tokens and cover compact/mobile layouts without new colors. |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | Historical question output is rendered through `ToolPart`. | The expandable tool path remains authoritative and shares the same question renderer. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/QuestionMarkdown.test.tsx packages/ui/src/components/chat/message/parts/ToolPart.test.ts packages/ui/src/components/chat/message/parts/ReasoningPart.test.tsx` | Passed: 10 tests across 3 files, 0 failures. |
| `bun run lint:ui` | Passed. |
| `git diff --check main...HEAD` | Passed. |
| Live/historical question rendering in light, dark, desktop, and mobile layouts | Not performed; visual evidence remains required. |
| Full UI type-check/build | Not completed; the checkout-wide type-check is blocked by the unrelated unresolved `fflate` dependency in document attachments. |

## Visual evidence

<img width="739" height="473" alt="image-1 (17)" src="https://github.com/user-attachments/assets/cbe3dbd0-4eff-4fc8-af7e-a441d6c8d475" />


<img width="582" height="324" alt="image-2 (5)" src="https://github.com/user-attachments/assets/1c99dc5d-869a-4023-b5cb-552e00238e10" />


## Risks and failure behavior

Question text now follows the established simple Markdown parsing path rather than raw text rendering. Unsupported syntax falls back to normal text, and no execution or submission path changes.
