### PR TITLE
fix(settings): show scrollbars on Windows

### DIFF
--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -1063,7 +1063,12 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
   };
 
   return (
-    <div ref={containerRef} data-settings-view="true" className={cn('relative flex h-full min-h-0 flex-col overflow-hidden bg-background')}>
+    <div
+      ref={containerRef}
+      data-settings-view="true"
+      data-settings-platform={isWindows ? 'windows' : undefined}
+      className={cn('relative flex h-full min-h-0 flex-col overflow-hidden bg-background')}
+    >
       {isMobile ? (
         <div
           className={cn(

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1881,7 +1881,6 @@ input[aria-label="Terminal input"] {
 
 [data-settings-view="true"][data-settings-platform="windows"] :is(.overflow-y-auto, .overlay-scrollbar-target)::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
-  border-width: 1px;
 }
 
 /* Desktop app shell (Electron/native window): native apps use the arrow cursor

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1867,6 +1867,23 @@ input[aria-label="Terminal input"] {
   display: none;
 }
 
+/* Windows keeps Settings scrollbars persistently visible for discoverability. */
+[data-settings-view="true"][data-settings-platform="windows"] :is(.overflow-y-auto, .overlay-scrollbar-target) {
+  scrollbar-width: auto !important;
+  scrollbar-color: color-mix(in srgb, var(--foreground) 80%, transparent) transparent !important;
+  -ms-overflow-style: auto !important;
+}
+
+[data-settings-view="true"][data-settings-platform="windows"] :is(.overflow-y-auto, .overlay-scrollbar-target)::-webkit-scrollbar {
+  display: block !important;
+  width: 10px !important;
+}
+
+[data-settings-view="true"][data-settings-platform="windows"] :is(.overflow-y-auto, .overlay-scrollbar-target)::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
+  border-width: 1px;
+}
+
 /* Desktop app shell (Electron/native window): native apps use the arrow cursor
    for clickable controls, not the web's hand/pointer. Neutralize pointer
    cursors under the desktop runtime only — web in a browser keeps them.

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1770,7 +1770,6 @@ input[aria-label="Terminal input"] {
 
 [data-settings-view="true"][data-settings-platform="windows"] :is(.overflow-y-auto, .overlay-scrollbar-target)::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
-  border-width: 1px;
 }
 
 /* Desktop app shell (Electron/native window): native apps use the arrow cursor

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1756,6 +1756,23 @@ input[aria-label="Terminal input"] {
   display: none;
 }
 
+/* Windows keeps Settings scrollbars persistently visible for discoverability. */
+[data-settings-view="true"][data-settings-platform="windows"] :is(.overflow-y-auto, .overlay-scrollbar-target) {
+  scrollbar-width: auto !important;
+  scrollbar-color: color-mix(in srgb, var(--foreground) 80%, transparent) transparent !important;
+  -ms-overflow-style: auto !important;
+}
+
+[data-settings-view="true"][data-settings-platform="windows"] :is(.overflow-y-auto, .overlay-scrollbar-target)::-webkit-scrollbar {
+  display: block !important;
+  width: 10px !important;
+}
+
+[data-settings-view="true"][data-settings-platform="windows"] :is(.overflow-y-auto, .overlay-scrollbar-target)::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--foreground) 80%, transparent) !important;
+  border-width: 1px;
+}
+
 /* Desktop app shell (Electron/native window): native apps use the arrow cursor
    for clickable controls, not the web's hand/pointer. Neutralize pointer
    cursors under the desktop runtime only — web in a browser keeps them.


### PR DESCRIPTION
## Intent

Keep Settings scrollbars persistently visible on Windows so long panes and sidebars remain discoverable after the overlay scrollbar fades. Fixes #2402.

## Non-goals

This PR does not change scrollbar behavior on non-Windows platforms, global application scrollbars, Settings layout, or scrolling mechanics.

## Affected surfaces

Windows Desktop (Electron) Settings surfaces are affected. Browser runtimes on Windows, non-Windows Desktop, hosted mobile, Capacitor mobile, and VS Code retain existing behavior.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes shared UI source and CSS. | The platform marker is scoped to Settings and no global scrollbar rule changes. |
| `theme-system` | Scrollbar colors and visual states are theme-sensitive. | Colors derive from `--foreground` and remain compatible with light/dark themes. |
| `settings-ui-patterns` | The change targets Settings panes and responsive surfaces. | The selector covers existing Settings scroll targets without changing pane structure. |

## Validation

| Check | Result |
|---|---|
| `bun run lint:ui` | Passed. |
| `bun run type-check:ui` | Passed. |
| `bun run build:web` | Passed. |
| `bun run --cwd packages/electron build:web-assets` | Passed. |
| `git diff --check` | Passed. |
| Windows Desktop Settings in light and dark themes | Passed manually for the main navigation, split-page sidebar, and content pane. Scrollbars remained visible and did not obscure content. |

## Visual evidence

<img width="1523" height="512" alt="Windows Settings scrollbars in dark theme" src="https://github.com/user-attachments/assets/94f9d938-f7ad-4742-81e7-6ee4a777d72f" />
<img width="1428" height="478" alt="Windows Settings scrollbars in light theme" src="https://github.com/user-attachments/assets/60431782-6062-4853-a9a9-e2ee1296b0f4" />

## Risks and failure behavior

The CSS is gated by a Settings-only Windows Desktop data attribute, limiting regressions to that surface. Browsers that ignore one scrollbar API still receive the WebKit or standards rule; scrolling itself does not depend on the styling.
