### PR TITLE
fix(chat): expand shell output by default

### DIFF
--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -284,16 +284,15 @@ const UserSubtaskPart: React.FC<{ part: SubtaskPartLike }> = ({ part }) => {
 const SHELL_CODE_TAG_STYLE: React.CSSProperties = { background: 'transparent', backgroundColor: 'transparent' };
 
 const UserShellActionPart: React.FC<{ part: ShellActionPartLike }> = ({ part }) => {
-    const [expanded, setExpanded] = React.useState(false);
+    const output = typeof part.shellAction?.output === 'string' ? part.shellAction.output : '';
+    const [expanded, setExpanded] = React.useState(true);
     const [copiedOutput, setCopiedOutput] = React.useState(false);
     const copiedResetTimeoutRef = React.useRef<number | null>(null);
     const { t } = useI18n();
 
     const command = typeof part.shellAction?.command === 'string' ? part.shellAction.command.trim() : '';
-    const output = typeof part.shellAction?.output === 'string' ? part.shellAction.output : '';
     const status = typeof part.shellAction?.status === 'string' ? part.shellAction.status.trim().toLowerCase() : '';
     const hasOutput = output.trim().length > 0;
-
     const clearCopiedResetTimeout = React.useCallback(() => {
         if (copiedResetTimeoutRef.current !== null && typeof window !== 'undefined') {
             window.clearTimeout(copiedResetTimeoutRef.current);


### PR DESCRIPTION
## Intent

Show shell command output expanded by default so users can see command results without an extra click. The existing collapse control remains available. Fixes #1433.

## Non-goals

This PR does not change output capture, maximum height, scrolling, copy behavior, syntax rendering, or user-controlled collapsing after mount.

## Affected surfaces

Shared `packages/ui` user shell-action rendering is affected across Web, Desktop, hosted mobile, Capacitor mobile, and VS Code. No runtime or persisted-data contracts change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes shared UI source and default state. | The implementation changes only the initial boolean and preserves the existing interaction. |
| `theme-system` | Expanded shell output is user-visible shared UI. | Existing layout, colors, typography, and controls are unchanged. |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | `MessageBody` owns message-part rendering. | No parallel renderer or abstraction is introduced. |

## Validation

| Check | Result |
|---|---|
| `bun run lint:ui` | Passed. |
| `git diff --check main...HEAD` | Passed. |
| Short/long live shell commands and user collapse during output updates | Not performed; manual interaction evidence remains required. |
| Full UI type-check/build | Not completed; the checkout-wide type-check is blocked by the unrelated unresolved `fflate` dependency in document attachments. |

## Visual evidence

<img width="411" height="371" alt="image" src="https://github.com/user-attachments/assets/8f0b7766-0573-46b0-af77-83b7c19329f0" />

## Risks and failure behavior

Large output can mount immediately rather than after one click, but the existing height bound and scroll container remain in place. Users can collapse output with the unchanged control; rollback is the initial-state boolean.
