### PR TITLE
fix(mobile): keep stop action in collapsed composer

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -2470,6 +2470,8 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                         isVSCode={isVSCode}
                         footerIconButtonClass={footerIconButtonClass}
                         iconSizeClass={iconSizeClass}
+                        stopIconSizeClass={stopIconSizeClass}
+                        canAbort={canAbort}
                         theme={currentTheme}
                         onExpand={mobileShell.expand}
                         onApplySuggestion={applyAssistSuggestion}
@@ -2479,6 +2481,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                         onOpenPrPicker={openPrPicker}
                         onOpenAttachSheet={openMobileAttachSheet}
                         onStartDictation={toggleDictation}
+                        onAbort={handleAbort}
                     />
                 ) : (
                 <>

--- a/packages/ui/src/components/chat/ComposerStopButton.test.tsx
+++ b/packages/ui/src/components/chat/ComposerStopButton.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { I18nProvider } from '@/lib/i18n';
+import { ComposerStopButton } from './ComposerStopButton';
+
+describe('ComposerStopButton', () => {
+    test('renders an accessible semantic stop action with a mobile touch target', () => {
+        const markup = renderToStaticMarkup(
+            <I18nProvider>
+                <ComposerStopButton
+                    buttonClassName="min-h-[44px] min-w-[44px]"
+                    iconClassName="h-6 w-6"
+                    onStop={() => {}}
+                />
+            </I18nProvider>,
+        );
+
+        expect(markup).toContain('type="button"');
+        expect(markup).toContain('aria-label="Stop generating"');
+        expect(markup).toContain('min-h-[44px] min-w-[44px]');
+        expect(markup).toContain('text-[var(--status-error)]');
+        expect(markup).toContain('focus-visible:ring-[3px]');
+        expect(markup).toContain('aria-hidden="true"');
+    });
+});

--- a/packages/ui/src/components/chat/ComposerStopButton.tsx
+++ b/packages/ui/src/components/chat/ComposerStopButton.tsx
@@ -1,0 +1,27 @@
+import { StopIcon } from '@/components/icons/StopIcon';
+import { useI18n } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
+
+type ComposerStopButtonProps = {
+    buttonClassName?: string;
+    iconClassName?: string;
+    onStop: () => void;
+};
+
+export function ComposerStopButton({ buttonClassName, iconClassName, onStop }: ComposerStopButtonProps) {
+    const { t } = useI18n();
+
+    return (
+        <button
+            type="button"
+            onClick={onStop}
+            className={cn(
+                buttonClassName,
+                'text-[var(--status-error)] hover:text-[var(--status-error)] focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+            )}
+            aria-label={t('chat.chatInput.actions.stopGeneratingAria')}
+        >
+            <StopIcon className={iconClassName} aria-hidden="true" />
+        </button>
+    );
+}

--- a/packages/ui/src/components/chat/composer/ui/ComposerActionButtons.tsx
+++ b/packages/ui/src/components/chat/composer/ui/ComposerActionButtons.tsx
@@ -9,9 +9,9 @@
 import React from 'react';
 
 import { Icon } from '@/components/icon/Icon';
-import { StopIcon } from '@/components/icons/StopIcon';
 import { useI18n } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
+import { ComposerStopButton } from '../../ComposerStopButton';
 
 type ComposerActionButtonsProps = {
     isMobile: boolean;
@@ -95,17 +95,11 @@ export const ComposerActionButtons = React.memo(function ComposerActionButtons(p
                     <Icon name="send-plane-2" className={cn(sendIconSizeClass, '-rotate-90')} />
                 </button>
             ) : null}
-            <button
-                type="button"
-                onClick={onAbort}
-                className={cn(
-                    footerIconButtonClass,
-                    'text-[var(--status-error)] hover:text-[var(--status-error)]'
-                )}
-                aria-label={t('chat.chatInput.actions.stopGeneratingAria')}
-            >
-                <StopIcon className={cn(stopIconSizeClass)} />
-            </button>
+            <ComposerStopButton
+                buttonClassName={footerIconButtonClass}
+                iconClassName={stopIconSizeClass}
+                onStop={onAbort}
+            />
         </div>
     );
 }, (prev, next) => (

--- a/packages/ui/src/components/chat/composer/ui/MobilePillComposer.tsx
+++ b/packages/ui/src/components/chat/composer/ui/MobilePillComposer.tsx
@@ -19,6 +19,7 @@ import { SessionSuggestionChip } from '@/components/chat/SessionSuggestionChip';
 import { useI18n } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import type { Theme } from '@/types/theme';
+import { ComposerStopButton } from '../../ComposerStopButton';
 import { MobileSessionPanelTrigger } from '../../MobileSessionStatusBar';
 import { ComposerAttachmentControls } from './ComposerAttachmentControls';
 
@@ -31,6 +32,8 @@ export interface MobilePillComposerProps {
     isVSCode: boolean;
     footerIconButtonClass: string;
     iconSizeClass: string;
+    stopIconSizeClass: string;
+    canAbort: boolean;
     theme: Theme;
     onExpand: () => void;
     onApplySuggestion: (text: string) => void;
@@ -40,6 +43,7 @@ export interface MobilePillComposerProps {
     onOpenPrPicker: () => void;
     onOpenAttachSheet: () => void;
     onStartDictation: () => void;
+    onAbort: () => void;
 }
 
 export function MobilePillComposer(props: MobilePillComposerProps) {
@@ -53,6 +57,8 @@ export function MobilePillComposer(props: MobilePillComposerProps) {
         isVSCode,
         footerIconButtonClass,
         iconSizeClass,
+        stopIconSizeClass,
+        canAbort,
         theme: currentTheme,
         onExpand,
         onApplySuggestion,
@@ -62,6 +68,7 @@ export function MobilePillComposer(props: MobilePillComposerProps) {
         onOpenPrPicker,
         onOpenAttachSheet,
         onStartDictation,
+        onAbort,
     } = props;
 
     return (
@@ -114,17 +121,25 @@ export function MobilePillComposer(props: MobilePillComposerProps) {
                                 : t('chat.chatInput.placeholder.selectSession')}
                     </span>
                 </button>
-                <button
-                    type="button"
-                    className={footerIconButtonClass}
-                    // Starts recording in place; the composer morphs into the
-                    // voice variant once dictation actually goes live.
-                    onClick={onStartDictation}
-                    title={t('chat.dictation.start')}
-                    aria-label={t('chat.dictation.start')}
-                >
-                    <Icon name="mic" className={cn(iconSizeClass, 'text-current')} />
-                </button>
+                {canAbort ? (
+                    <ComposerStopButton
+                        buttonClassName={cn(footerIconButtonClass, 'min-h-[44px] min-w-[44px]')}
+                        iconClassName={stopIconSizeClass}
+                        onStop={onAbort}
+                    />
+                ) : (
+                    <button
+                        type="button"
+                        className={footerIconButtonClass}
+                        // Starts recording in place; the composer morphs into the
+                        // voice variant once dictation actually goes live.
+                        onClick={onStartDictation}
+                        title={t('chat.dictation.start')}
+                        aria-label={t('chat.dictation.start')}
+                    >
+                        <Icon name="mic" className={cn(iconSizeClass, 'text-current')} />
+                    </button>
+                )}
             </div>
             {/* New-session button: fades/shrinks away when the draft is
                 already open, letting the pill expand into its place. */}

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1146,7 +1146,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.chatInput.actions.modelAgentSettings': 'Model and agent settings',
   'chat.chatInput.actions.queueMessageAria': 'Queue message',
   'chat.chatInput.actions.sendMessageAria': 'Send message',
-  'chat.chatInput.actions.stopGeneratingAria': 'Stop generating',
+  'chat.chatInput.actions.stopGeneratingAria': 'Zatrzymaj generowanie',
   'chat.chatInput.branch': 'Gałąź',
   'chat.chatInput.draftPicker.projectTitle': 'Projekt',
   'chat.chatInput.draftPicker.searchProjects': 'Szukaj projektów...',


### PR DESCRIPTION
## Intent

Replace the microphone with an accessible stop action in the collapsed mobile composer while a session is active, allowing generation to be stopped without reopening the keyboard. Fixes #2129.

## Non-goals

This PR does not change abort semantics, session activity derivation, mobile keyboard choreography, dictation startup while idle, or the expanded composer action layout.

## Affected surfaces

Shared `packages/ui` collapsed mobile composer behavior is affected in hosted mobile/PWA and Capacitor mobile. Desktop and VS Code continue using their existing expanded controls. One Polish aria-label translation is corrected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes shared source, adds a component/test, and was rebased across a composer refactor. | The behavior was moved to the new `MobilePillComposer` owner instead of restoring obsolete `ChatInput` structure. |
| `theme-system` | The stop control is a visible button and status state. | It reuses the existing error token, icon sizing, focus ring, and 44px mobile target. |
| `locale-ui-patterns` | The control adds an aria label and updates Polish copy. | It uses the existing i18n key and supplies a localized Polish value. |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | It defines mobile composer ownership and hardware-only interaction boundaries. | Presentation stays in `composer/ui`; keyboard/viewport state machines are untouched and native device validation remains explicit. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/ComposerStopButton.test.tsx` | Passed: 1 test, 0 failures. |
| `bun run lint:ui` | Passed. |
| `bun run type-check:ui` | Passed. |
| `bun run build:web` | Passed. |
| `bun run dead-code` | Completed; no new finding from the added component/export. Existing repository findings remain. |
| `git diff --check main...HEAD` | Passed. |
| Hosted mobile interface | Passed manually. The Stop button remains accessible in the collapsed composer pill while a turn is running. |
| Stop action | Passed manually. A 30-second `Start-Sleep` command was interrupted after 7.6 seconds, then the idle microphone returned. |
| Native Android / TalkBack | Not tested on this Windows host. |

## Visual evidence

### Stop button in the collapsed composer

<img width="809" height="740" alt="image" src="https://github.com/user-attachments/assets/66040cd2-5085-4a2f-b700-41a42c1537f7" />

The Stop button replaces the microphone while the turn is active.

### Current dark mobile verification

![Collapsed mobile composer showing the Stop button during an active shell command](https://raw.githubusercontent.com/pascalandr/openchamber/pr-evidence-2118/pr-evidence/2493-mobile-dark-stop.png)

Captured from current PR HEAD `5e9db6fdc5b9d4091b1c8b1b35ae2fd9616d92b4` in the built hosted Web surface at a 500x749 mobile viewport. The dark theme is active, the shell command is visibly running, and the collapsed pill exposes the accessible Stop action.

### Turn interrupted successfully

<img width="791" height="432" alt="image" src="https://github.com/user-attachments/assets/f15cb7c8-12c7-4345-bc24-e24c1e5b10b1" />

The 30-second command was stopped after 7.6 seconds and the idle microphone was restored.

## Risks and failure behavior

The button calls the existing `handleAbort` path and is shown from the existing authoritative session phase. When idle, the microphone path is unchanged. The composer mobile shell and its timing-sensitive focus/keyboard code are untouched.
