### PR TITLE
fix(desktop): preserve native taskbar minimize

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -2376,12 +2376,6 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
   browserWindow.on('move', () => {
     debounceWindowStatePersist(browserWindow, false);
   });
-  browserWindow.on('minimize', (event) => {
-    if (!shouldHideMainWindowToTray(browserWindow)) return;
-    debounceWindowStatePersist(browserWindow, true);
-    event.preventDefault();
-    browserWindow.hide();
-  });
   browserWindow.on('close', (event) => {
     if (!state.quitRequested && shouldHideMainWindowToTray(browserWindow)) {
       debounceWindowStatePersist(browserWindow, true);
@@ -4331,7 +4325,12 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
 
     case 'desktop_minimize_current_window':
       if (browserWindow && !browserWindow.isDestroyed()) {
-        browserWindow.minimize();
+        if (shouldHideMainWindowToTray(browserWindow)) {
+          debounceWindowStatePersist(browserWindow, true);
+          browserWindow.hide();
+        } else {
+          browserWindow.minimize();
+        }
       }
       return null;
 


### PR DESCRIPTION
## Intent

Keep Windows taskbar minimization native while preserving hide-to-tray behavior for OpenChamber's custom minimize command when the tray preference is enabled. Fixes #2176.

## Non-goals

This PR does not change close-to-tray behavior, tray enablement, window restoration, non-main windows, or renderer bridge contracts.

## Affected surfaces

`packages/electron` main-process window lifecycle is affected on Windows. The custom title-bar minimize command still follows the tray preference; OS/taskbar minimization now remains minimized. Web, hosted mobile, Capacitor mobile, and VS Code are unaffected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes Electron source and native window behavior. | The diff is limited to the existing event and IPC command paths. |
| `desktop-shell` | Window lifecycle and tray behavior are Electron-owned. | Enforcement remains in `main.mjs`; no privileged behavior moves into shared UI. |
| `packages/electron/README.md` | It defines native-shell ownership and platform validation boundaries. | Existing in-process architecture and preload contract remain unchanged. |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:electron` | Passed: `main.mjs` and `preload.mjs` syntax checks. |
| `bun run lint:electron` | Passed. |
| `bun run --cwd packages/electron bundle:main` | Passed; `dist-bundle/main.mjs` generated successfully. |
| `git diff --check main...HEAD` | Passed. |
| Windows: custom minimize, taskbar minimize, tray enabled/disabled | Passed manually: the custom title-bar button hides to the tray when enabled, Windows taskbar minimization remains native and restorable, and disabling the tray preference makes the custom button minimize to the taskbar. |

## Visual evidence

No screenshot is attached because a static image cannot demonstrate the window/taskbar/tray lifecycle. The full Windows behavior matrix above was verified manually.

## Risks and failure behavior

The global `minimize` interception is removed, so OS-driven minimization cannot unexpectedly hide a window. The custom command explicitly hides only when the existing tray predicate allows it; close-to-tray remains unchanged.
