### PR TITLE
fix: keep the composer's autocorrect on where the platform provides one

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -96,6 +96,7 @@ import {
     type ComposerEditorHandle,
 } from './composer/editor/ComposerEditor';
 import { createComposerEditorViewStore } from './composer/editor/viewStore';
+import { composerAutoCorrect } from './composer/editor/autocorrect';
 import {
     appendInlineText,
     appendWithLineBreaks,
@@ -2624,7 +2625,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                                         : t(useCompactChatPlaceholder ? 'chat.chatInput.placeholder.chatCompact' : 'chat.chatInput.placeholder.chat')
                                     : t('chat.chatInput.placeholder.selectSession')}
                                 editable={Boolean(currentSessionId || newSessionDraftOpen)}
-                                autoCorrect={isMobile}
+                                autoCorrect={composerAutoCorrect({ isMobile })}
                                 autoCapitalize={isMobile ? 'sentences' : 'none'}
                                 spellCheck={isMobile || inputSpellcheckEnabled}
                                 fillContainer={isComposerExpanded}

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -76,6 +76,14 @@ token:
 themes define `--interactive-selection` with its own alpha, so a translucent
 mix of it is nearly invisible.
 
+The content element keeps the existing correction policy: on in the mobile UI,
+off elsewhere. CodeMirror also reads the attribute and reverts Apple and
+Android's insert-period-on-double-space only when its value is exactly `off`.
+`editor/autocorrect.ts` uses the HTML standard's
+[ASCII case-insensitive `autocorrect` keywords](https://html.spec.whatwg.org/multipage/interaction.html#attr-autocorrect)
+to keep desktop word correction off while avoiding that CodeMirror-only
+revert. Its platform checks deliberately match CodeMirror's own browser flags.
+
 `composerLanguage.ts` retokenizes the whole document on every change. The
 composer holds a prompt, not a source file: it is short enough that a full pass
 is cheaper and far simpler than incremental mapping, and it keeps the editor

--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -34,6 +34,7 @@ import {
 
 import { cn } from '@/lib/utils';
 import type { ComposerLanguageContext } from '../language/tokenize';
+import type { ComposerAutoCorrect } from './autocorrect';
 import { composerLanguage, setLanguageContext } from './composerLanguage';
 import type { ComposerEditorViewStore } from './viewStore';
 import { composerEditorTheme, composerNativeSelectionExtension } from './theme';
@@ -89,8 +90,11 @@ export interface ComposerEditorProps {
     placeholder?: string;
     editable?: boolean;
     spellCheck?: boolean;
-    /** Mobile keyboards; ignored on desktop. */
-    autoCorrect?: boolean;
+    /**
+     * The content element's autocorrect keyword. See `autocorrect.ts` for the
+     * case-sensitive CodeMirror workaround.
+     */
+    autoCorrect?: ComposerAutoCorrect;
     autoCapitalize?: 'none' | 'sentences';
     /** Fill the available height instead of growing with the content. */
     fillContainer?: boolean;
@@ -147,7 +151,7 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
             placeholder,
             editable = true,
             spellCheck = false,
-            autoCorrect = false,
+            autoCorrect = 'off',
             autoCapitalize = 'none',
             fillContainer = false,
             maxLines = 8,
@@ -262,7 +266,7 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                         }),
                         EditorView.contentAttributes.of({
                             spellcheck: String(handlersRef.current.spellCheck ?? false),
-                            autocorrect: handlersRef.current.autoCorrect ? 'on' : 'off',
+                            autocorrect: handlersRef.current.autoCorrect ?? 'off',
                             autocapitalize: handlersRef.current.autoCapitalize ?? 'none',
                             ...(handlersRef.current['aria-label']
                                 ? { 'aria-label': handlersRef.current['aria-label'] }
@@ -406,7 +410,7 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
             if (!view) return;
             const content = view.contentDOM;
             content.setAttribute('spellcheck', String(spellCheck));
-            content.setAttribute('autocorrect', autoCorrect ? 'on' : 'off');
+            content.setAttribute('autocorrect', autoCorrect);
             content.setAttribute('autocapitalize', autoCapitalize);
         }, [autoCapitalize, autoCorrect, spellCheck]);
 

--- a/packages/ui/src/components/chat/composer/editor/__tests__/autocorrect.test.ts
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/autocorrect.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { composerAutoCorrect, type ComposerAutoCorrect } from '../autocorrect';
+
+const platform = (overrides: Partial<Navigator>): Navigator => ({
+    maxTouchPoints: 0,
+    platform: '',
+    userAgent: '',
+    vendor: '',
+    ...overrides,
+} as Navigator);
+
+const codeMirrorKeepsDoubleSpacePeriod = (
+    autoCorrect: ComposerAutoCorrect,
+): boolean => autoCorrect !== 'off';
+
+const affectedPlatforms: Array<[string, Navigator]> = [
+    ['macOS', platform({ platform: 'MacIntel' })],
+    ['iPhone', platform({
+        platform: 'iPhone',
+        userAgent: 'Mozilla/5.0 Mobile/15E148 Safari/604.1',
+        vendor: 'Apple Computer, Inc.',
+    })],
+    ['iPadOS touch detection', platform({
+        maxTouchPoints: 5,
+        userAgent: 'Mozilla/5.0 Version/17.4 Safari/605.1.15',
+        vendor: 'Apple Computer, Inc.',
+    })],
+    ['Android', platform({
+        platform: 'Linux armv8l',
+        userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8)',
+    })],
+];
+
+const unaffectedPlatforms: Array<[string, Navigator]> = [
+    ['Windows', platform({ platform: 'Win32' })],
+    ['Linux', platform({ platform: 'Linux x86_64' })],
+];
+
+describe('composerAutoCorrect', () => {
+    test('matches the pinned CodeMirror period-revert guard', () => {
+        const source = readFileSync(
+            fileURLToPath(import.meta.resolve('@codemirror/view')),
+            'utf8',
+        );
+        const semantics = source
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/\s+/g, '');
+
+        expect(/getAttribute\(["']autocorrect["']\)==["']off["']/.test(semantics)).toBe(true);
+        expect(semantics).toContain(
+            'constios=safari&&(/Mobile\\/\\w+/.test(nav.userAgent)||nav.maxTouchPoints>2)',
+        );
+        expect(semantics).toContain('mac:ios||/Mac/.test(nav.platform)');
+        expect(semantics).toContain('android:/Android\\b/.test(nav.userAgent)');
+    });
+
+    for (const [name, navigator] of affectedPlatforms) {
+        test(`preserves the ${name} platform period without enabling autocorrect`, () => {
+            const autoCorrect = composerAutoCorrect({ isMobile: false, navigator });
+
+            expect(autoCorrect.toLowerCase()).toBe('off');
+            // @codemirror/view 6.39.13 reverts the native period only for exact "off".
+            expect(codeMirrorKeepsDoubleSpacePeriod(autoCorrect)).toBe(true);
+        });
+    }
+
+    for (const [name, navigator] of unaffectedPlatforms) {
+        test(`leaves desktop correction off on ${name}`, () => {
+            expect(composerAutoCorrect({ isMobile: false, navigator })).toBe('off');
+        });
+    }
+
+    test('uses CodeMirror platform detection rather than a macOS user agent', () => {
+        expect(composerAutoCorrect({
+            isMobile: false,
+            navigator: platform({
+                platform: 'Linux x86_64',
+                userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+            }),
+        })).toBe('off');
+    });
+
+    test('preserves the existing mobile autocorrect policy', () => {
+        expect(composerAutoCorrect({
+            isMobile: true,
+            navigator: platform({ platform: 'Win32' }),
+        })).toBe('on');
+    });
+});

--- a/packages/ui/src/components/chat/composer/editor/autocorrect.ts
+++ b/packages/ui/src/components/chat/composer/editor/autocorrect.ts
@@ -1,0 +1,24 @@
+export type ComposerAutoCorrect = 'on' | 'off' | 'Off';
+
+type PlatformNavigator = Pick<Navigator,
+    'maxTouchPoints' | 'platform' | 'userAgent' | 'vendor'
+>;
+
+/** Keep desktop autocorrect off without triggering CodeMirror's period revert. */
+export function composerAutoCorrect(options: {
+    isMobile: boolean;
+    navigator?: PlatformNavigator;
+}): ComposerAutoCorrect {
+    if (options.isMobile) return 'on';
+
+    const nav = options.navigator
+        ?? (typeof navigator === 'undefined'
+            ? { maxTouchPoints: 0, platform: '', userAgent: '', vendor: '' }
+            : navigator);
+    // These must match CodeMirror's flags because its revert checks exact "off".
+    const ios = /Apple Computer/.test(nav.vendor)
+        && (/Mobile\/\w+/.test(nav.userAgent) || nav.maxTouchPoints > 2);
+    return ios || /Mac/.test(nav.platform) || /Android\b/.test(nav.userAgent)
+        ? 'Off'
+        : 'off';
+}


### PR DESCRIPTION
> Validated commit: `b1ebff7850c61592fdf2ebc16a02c270d4d411df`.

## Intent

Fixes #2504. The composer no longer discards the platform's double-space-to-period substitution while still keeping desktop word autocorrection off.

`@codemirror/view@6.39.13` reverts that native substitution only when `browser.mac || browser.android` **and** the content element's `autocorrect` attribute is exactly the string `'off'` (`view.contentDOM.getAttribute("autocorrect") == "off"`). The composer therefore emits the ASCII case-insensitive HTML keyword `Off` on those platforms: browsers still treat correction as disabled, but CodeMirror's exact-match check no longer fires. Mobile keeps the existing `'on'` policy.

`autocorrect.ts` reproduces CodeMirror's own platform flags (`mac: ios || /Mac/.test(nav.platform)`, `android: /Android\b/.test(nav.userAgent)`), so coverage is macOS, iOS/iPadOS, and Android.

## Non-goals

No custom autocorrect engine, no spellcheck policy change, and no change to non-composer inputs.

Windows and Linux desktop behavior is deliberately unchanged and still emits `'off'`, because CodeMirror has no revert path on those platforms — there is nothing for this fix to undo. #2504 reports "Desktop Web" without naming an OS; if the reporter is on Windows or Linux, this change does not address their report.

## Affected surfaces

The shared composer editor used by web, Electron, VS Code, hosted mobile, and Capacitor mobile. `ComposerEditor`'s `autoCorrect` prop changes from `boolean` to the `ComposerAutoCorrect` keyword union. No persisted or API contract change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Shared composer input behavior and a component prop type changed | The platform policy is isolated in one pure helper with focused tests; the prop type change is confined to the composer's own call site. |
| Composer `DOCUMENTATION.md` | Owns editor input behavior | It now records the HTML case-insensitivity versus CodeMirror exact-match invariant and links the spec keywords, so the `Off` casing is not "cleaned up" later. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/composer/editor/__tests__/autocorrect.test.ts` | 9 passed, 0 failed. Covers macOS, iPhone, iPadOS touch detection, Android, Windows, Linux, a spoofed macOS user agent on Linux, the mobile policy, and the pinned CodeMirror guard. |
| `bun run type-check:ui` | Exit 0. |
| `bun run lint:ui` | Exit 0. |

Not validated: no real typing on macOS, iOS, or Android hardware or simulator.

## Visual evidence

Not captured, and a screenshot cannot show this: the change affects native text substitution while typing, not layout, color, or styling. The right evidence is a short screen recording of double-tapping the space bar in the composer on an affected platform (macOS desktop web, or iOS/Android) showing the period survive; that recording was not made.

## Risks and failure behavior

The test asserts against whitespace-stripped literal source text of the installed `@codemirror/view` dist bundle (for example `mac:ios||/Mac/.test(nav.platform)`). A future non-semantic reformatting or minification change in that dependency will false-fail the test even though the fix itself is still correct — treat such a failure as a signal to re-read the upstream guard, not as a regression.

The workaround also depends on browsers continuing to treat the `autocorrect` attribute keywords as ASCII case-insensitive. If a browser ever became case-sensitive, `Off` would fall back to the attribute's default rather than silently enabling desktop correction on the wrong platform.
