### PR TITLE
Fix/settings scrollbar

### DIFF
--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -1013,13 +1013,13 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
         // No sidebar available; fall back to direct content.
         const fallback = renderPageContent(settingsSlug);
         return (
-          <div className="flex-1 min-h-0 overflow-y-scroll bg-background">
+          <div className="flex-1 min-h-0 overflow-y-scroll overflow-x-hidden bg-background">
             <ErrorBoundary>{fallback}</ErrorBoundary>
           </div>
         );
       }
       return (
-        <div className="flex-1 min-h-0 overflow-y-scroll bg-background">
+        <div className="flex-1 min-h-0 overflow-y-scroll overflow-x-hidden bg-background">
           <ErrorBoundary>
             {renderPageSidebar(settingsSlug, { onItemSelect: handleMobilePageSidebarItemSelect })}
           </ErrorBoundary>
@@ -1031,7 +1031,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
     const content = renderPageContent(settingsSlug);
 
     return (
-      <div className="flex-1 min-h-0 overflow-y-scroll bg-background">
+      <div className="flex-1 min-h-0 overflow-y-scroll overflow-x-hidden bg-background">
         <ErrorBoundary>{content}</ErrorBoundary>
       </div>
     );
@@ -1048,7 +1048,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
           <div className={cn('border-r', runtimeCtx.isVSCode ? 'bg-background' : 'bg-sidebar')} style={{ width: SETTINGS_SPLIT_SIDEBAR_WIDTH, minWidth: SETTINGS_SPLIT_SIDEBAR_WIDTH, borderColor: 'var(--interactive-border)' }}>
             <ErrorBoundary>{renderPageSidebar(settingsSlug, {})}</ErrorBoundary>
           </div>
-          <div className="flex-1 min-h-0 overflow-y-scroll bg-background">
+          <div className="flex-1 min-h-0 overflow-y-scroll overflow-x-hidden bg-background">
             <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
           </div>
         </div>
@@ -1056,7 +1056,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
     }
 
     return (
-      <div className="h-full min-h-0 overflow-y-scroll bg-background">
+      <div className="h-full min-h-0 overflow-y-scroll overflow-x-hidden bg-background">
         <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
       </div>
     );

--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -1013,13 +1013,13 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
         // No sidebar available; fall back to direct content.
         const fallback = renderPageContent(settingsSlug);
         return (
-          <div className="flex-1 min-h-0 overflow-hidden bg-background">
+          <div className="flex-1 min-h-0 overflow-y-scroll bg-background">
             <ErrorBoundary>{fallback}</ErrorBoundary>
           </div>
         );
       }
       return (
-        <div className="flex-1 min-h-0 overflow-hidden bg-background">
+        <div className="flex-1 min-h-0 overflow-y-scroll bg-background">
           <ErrorBoundary>
             {renderPageSidebar(settingsSlug, { onItemSelect: handleMobilePageSidebarItemSelect })}
           </ErrorBoundary>
@@ -1031,7 +1031,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
     const content = renderPageContent(settingsSlug);
 
     return (
-      <div className="flex-1 min-h-0 overflow-hidden bg-background">
+      <div className="flex-1 min-h-0 overflow-y-scroll bg-background">
         <ErrorBoundary>{content}</ErrorBoundary>
       </div>
     );
@@ -1048,7 +1048,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
           <div className={cn('border-r', runtimeCtx.isVSCode ? 'bg-background' : 'bg-sidebar')} style={{ width: SETTINGS_SPLIT_SIDEBAR_WIDTH, minWidth: SETTINGS_SPLIT_SIDEBAR_WIDTH, borderColor: 'var(--interactive-border)' }}>
             <ErrorBoundary>{renderPageSidebar(settingsSlug, {})}</ErrorBoundary>
           </div>
-          <div className="flex-1 min-h-0 overflow-hidden bg-background">
+          <div className="flex-1 min-h-0 overflow-y-scroll bg-background">
             <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
           </div>
         </div>
@@ -1056,7 +1056,7 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
     }
 
     return (
-      <div className="h-full min-h-0 overflow-hidden bg-background">
+      <div className="h-full min-h-0 overflow-y-scroll bg-background">
         <ErrorBoundary>{renderPageContent(settingsSlug)}</ErrorBoundary>
       </div>
     );


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Intent</h2>
<h2><strong>What user or maintainer problem does this solve? What behavior changes?</strong>
Fixes #2475 — Settings sub-panels (Shortcuts, Plugins, Extensions, etc.) have no scrollbar, causing content to be cut off when it exceeds the dialog height. Users cannot reach content below the fold in any settings sub-panel.
After this fix, all settings sub-panels show an always-visible vertical scrollbar on both desktop and mobile, in all three layout modes: mobile single-panel, desktop split-panel (page + sidebar), and desktop full-page. The scrollbar is always visible (<code>overflow-y-scroll</code>, not <code>overflow-y-auto</code>) so users can always see and interact with it.</h2>
<h2>Non-goals</h2>
<p><strong>What nearby behavior is intentionally outside this PR? Write "None" only when the scope is unambiguous.</strong></p>
<ul>
<li>The Dialog.Popup in <code>SettingsWindow.tsx</code> keeps <code>overflow-hidden</code> (needed for border-radius clipping)</li>
<li>Structural containers (root flex-col at line 1066, outer flex wrappers at lines 1047/1146, nav sidebar shell at line 1153) keep <code>overflow-hidden</code></li>
<li>Nav sidebar text truncation spans (lines 937, 946, 966, 974) keep <code>overflow-hidden</code></li>
<li>The nav sidebar at line 851 keeps its existing <code>overflow-y-auto overflow-x-hidden</code> pattern (unchanged)</li>
<li>No refactoring, no new dependencies, no other files touched</li>
<li>No behavior changes beyond enabling vertical scroll on content areas</li>
</ul>
<hr>
<h2>Affected surfaces</h2>
<p><strong>Name affected packages, runtimes, user-visible states, and persisted/external contracts. Explain why an apparently applicable runtime is unaffected.</strong></p>

Surface | Affected? | Reason
-- | -- | --
packages/ui (shared React components) | ✅ Yes | SettingsView.tsx is the only file changed
Web (packages/web) | ✅ Yes | Uses shared UI — settings dialog renders SettingsView
Desktop / Electron (packages/electron) | ✅ Yes | Uses shared UI — same component tree
VS Code extension (packages/vscode) | ✅ Yes | Uses shared UI — same component tree
Mobile / Capacitor (packages/mobile) | ✅ Yes | Uses shared UI — same component tree
Server / API | ❌ No | CSS-only change, no server logic affected
Persisted data / contracts | ❌ No | No schema, storage, or API changes
i18n / locale strings | ❌ No | No text changes
All four UI runtimes (web, desktop, VS Code, mobile) share the same packages/ui components, so a change to SettingsView.tsx affects all of them identically. |   |  

<html>
<body>
<!--StartFragment--><p style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px 0px 12px; padding: 0px; --tw-outline-style: none; outline-style: none; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent; line-height: inherit; color: oklab(0.846299 -0.0028193 0.0134025 / 0.9); font-family: &quot;SF Pro Text&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, sans-serif; font-size: 15px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(23, 21, 21); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">All four UI runtimes (web, desktop, VS Code, mobile) share the same<span> </span><code data-markdown="inline-code" style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; font-family: ui-monospace, SFMono-Regular, Menlo, &quot;Cascadia Mono&quot;, &quot;Segoe UI Mono&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 13px; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent; word-break: break-all; overflow-wrap: break-word; background-color: rgb(28, 27, 26) !important; color: rgb(160, 175, 83) !important;">packages/ui</code><span> </span>components, so a change to<span> </span><code data-markdown="inline-code" style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; font-family: ui-monospace, SFMono-Regular, Menlo, &quot;Cascadia Mono&quot;, &quot;Segoe UI Mono&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 13px; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent; word-break: break-all; overflow-wrap: break-word; background-color: rgb(28, 27, 26) !important; color: rgb(160, 175, 83) !important;">SettingsView.tsx</code><span> </span>affects all of them identically.</p><hr style="box-sizing: border-box; border-width: 1px 0px 0px; border-style: solid; border-color: rgb(52, 51, 49); border-image: none; margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; height: 0px; color: inherit; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent; font-family: &quot;SF Pro Text&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, sans-serif; font-size: 15px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(23, 21, 21); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0.875em 0px 0.375em; padding: 0px; --tw-outline-style: none; outline-style: none; font-size: 1.0625em; font-weight: 600; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent; color: rgb(230, 228, 210); font-family: &quot;SF Pro Text&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(23, 21, 21); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Repository guidance</h2><p style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px 0px 12px; padding: 0px; --tw-outline-style: none; outline-style: none; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent; line-height: inherit; color: oklab(0.846299 -0.0028193 0.0134025 / 0.9); font-family: &quot;SF Pro Text&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, sans-serif; font-size: 15px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(23, 21, 21); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; font-weight: bolder; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent; color: rgb(206, 205, 195);">List the AGENTS.md rules, matching project skills, required skill references, and nearest README/DOCUMENTATION.md files used for this change. Explain why each applies and the important constraints you followed. Do not merely list filenames.</strong></p><div class="group my-4 flex flex-col space-y-2" data-markdown="table-wrapper" style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; margin-block: 16px; display: flex; flex-direction: column; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent; color: oklab(0.846299 -0.0028193 0.0134025 / 0.9); font-family: &quot;SF Pro Text&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, system-ui, sans-serif; font-size: 15px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(23, 21, 21); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="flex items-center justify-end gap-1" style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; --tw-space-y-reverse: 0; margin-block: 0px 8px; display: flex; align-items: center; justify-content: flex-end; gap: 4px; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent;"><div class="relative" style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; position: relative; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent;"></div><div class="relative" style="box-sizing: border-box; border: 0px solid rgba(57, 56, 54, 0.5); margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; position: relative; scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent;"></div></div><div class="overflow-x-auto rounded-lg border border-border/80 bg-[var(--surface-elevated)]" style="box-sizing: border-box; border: 1px solid oklab(0.321384 0.000370696 0.00375712 / 0.8); margin: 0px; padding: 0px; --tw-outline-style: none; outline-style: none; overflow-x: auto; border-radius: 0.5625rem; background-color: rgb(28, 26, 25); scrollbar-width: thin; scrollbar-color: oklch(0.6 0.02 80 / 0.3) transparent;">
Guidance | Why it applies | How the change complies
-- | -- | --
AGENTS.md — Always-On Constraints | "Keep changes minimal" and "Do not add dependencies" | 1 file changed, +5/-5, no new dependencies
AGENTS.md — Project Skills: settings-ui-patterns | Change touches Settings UI components | Followed existing pattern: nav sidebar already uses overflow-y-auto overflow-x-hidden at line 851
AGENTS.md — Project Skills: theme-system | Change modifies className strings with theme colors | Used existing bg-background token, no new colors added
CONTRIBUTING.md — Before Submitting | bun run type-check and bun run lint must pass | Both passed with zero errors
CONTRIBUTING.md — Pull Request Contract | PR must explain intent, non-goals, affected surfaces, validation, risk | All sections completed in this description
CONTRIBUTING.md — Visual Evidence | User-visible changes require before/after screenshots | See Visual evidence section below
packages/ui/README.md | Package-level documentation for shared UI | Confirmed SettingsView.tsx is the correct file for settings layout

</div></div><!--EndFragment-->
</body>
</html>

</body></html><!--EndFragment-->
</body>
</html>