### PR TITLE
fix(ui): remove desktop sidebar project header artifacts

### DIFF
--- a/packages/ui/src/components/session/sidebar/sortableItems.tsx
+++ b/packages/ui/src/components/session/sidebar/sortableItems.tsx
@@ -196,7 +196,8 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
                 <div
                   className={cn(
                     '-ml-2.5 -mr-2 text-left group/project select-none',
-                    stickyZoneHeaders && 'oc-zone-header-backing sticky top-0 z-20 bg-sidebar',
+                    stickyZoneHeaders && 'sticky top-0 z-20 bg-sidebar',
+                    stickyZoneHeaders && isStuck && 'oc-zone-header-backing',
                   )}
                   onContextMenu={(event) => {
                     // VS Code hides project actions entirely (hideDirectoryControls).
@@ -422,4 +423,3 @@ const SortableGroupItemBase: React.FC<{
 };
 
 export const SortableGroupItem = React.memo(SortableGroupItemBase);
-

--- a/packages/ui/src/styles/design-system.css
+++ b/packages/ui/src/styles/design-system.css
@@ -150,18 +150,12 @@
     background-color: transparent !important;
   }
 
-  /* Sticky sidebar zone headers must fully mask the rows scrolling under
-     them. A frosted (translucent + backdrop-blur) backing is NOT possible
-     here: Electron's transparent/vibrancy windows break backdrop-filter
-     entirely (electron#20357 — the backdrop snapshot fails against a
-     transparent root), so any translucency lets row text bleed through
-     un-blurred. Use the opaque sidebar tone instead; the blur declaration
-     stays only as a progressive enhancement if Electron ever fixes it. */
+  /* Stuck sidebar zone headers must fully mask the rows scrolling under
+     them. Electron's transparent/vibrancy windows break backdrop-filter
+     (electron#20357), so use the opaque sidebar tone instead. */
   :root.desktop-runtime[data-oc-vibrancy] .oc-zone-header-backing {
     background: var(--sidebar-stuck-bg) !important;
     background-color: var(--sidebar-stuck-bg) !important;
-    -webkit-backdrop-filter: blur(16px) saturate(1.2);
-    backdrop-filter: blur(16px) saturate(1.2);
   }
 
   .font-sans {


### PR DESCRIPTION
## Intent

<!-- What user or maintainer problem does this solve? What behavior changes? -->

Remove opaque rectangular artifacts behind non-stuck project headers in the macOS Desktop sidebar when native vibrancy is enabled.

Reproduction:
1. Run OpenChamber Desktop on macOS with vibrancy enabled.
2. Open the sidebar with multiple projects and sticky headers enabled (the default).
3. Observe opaque header-sized rectangles behind project rows that are not currently stuck.
4. Closing and reopening the sidebar recreates the artifacts because the project header elements are remounted with the original backing styles.

Cause: every sticky-capable project header received `oc-zone-header-backing`, even when it was not actually stuck. Under Electron vibrancy that class paints an opaque sidebar background and also requested an unsupported `backdrop-filter`.

Solution: keep sticky positioning enabled, but apply `oc-zone-header-backing` only while the existing intersection observer reports that a project header is stuck. Remove the unsupported backdrop-filter declarations from the Electron vibrancy backing rule.

## Non-goals

<!-- What nearby behavior is intentionally outside this PR? Write "None" only when the scope is unambiguous. -->

- No changes to the sticky-header preference or its default value.
- No changes to sidebar scrolling, project ordering, session rendering, or macOS vibrancy configuration.
- No changes to the Recent section header.

## Affected surfaces

<!-- Name affected packages, runtimes, user-visible states, and persisted/external contracts. Explain why an apparently applicable runtime is unaffected. -->

- `packages/ui`: project-header class selection and the desktop vibrancy backing style.
- macOS Desktop with native vibrancy enabled: non-stuck project headers remain transparent; actually stuck headers retain an opaque backing so rows cannot show through.
- Web, VS Code, mobile, Windows, and Linux are unaffected because the backing override is scoped to `.desktop-runtime[data-oc-vibrancy]`.
- No persisted data, external API, runtime bridge, or package contract changes.

## Repository guidance

<!-- List the AGENTS.md rules, matching project skills, required skill references, and nearest README/DOCUMENTATION.md files used for this change. Explain why each applies and the important constraints you followed. Do not merely list filenames. -->

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes executable shared UI source and styling. | The diff is limited to the project-header state class and its owning desktop vibrancy rule; no dependencies, exports, or contracts changed. |
| `theme-system` and `tokens-and-examples.md` | This changes a sidebar visual state. | The existing semantic `--sidebar-stuck-bg` token is preserved; no hardcoded colors or new visual primitives were introduced. |
| `desktop-shell` and `packages/electron/README.md` | The bug is visible only through Electron macOS vibrancy composition. | The native shell and privileged boundary are unchanged; the fix stays in the shared UI-owned renderer styling. |
| `packages/ui/src/components/session/sidebar/DOCUMENTATION.md` | This module owns project sticky headers and their observer state. | The implementation reuses the existing authoritative `isStuck` state instead of adding a heuristic or parallel lifecycle. |

## Validation

<!-- Report exact commands/manual checks and results. State what was not verified. Do not claim runtime behavior from type-check/lint alone. -->

| Check | Result |
|---|---|
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bun run build:web` | Passed. Vite reported existing unresolved KaTeX font and chunk-size warnings. |
| `bun run type-check:electron` | Passed (`node --check` for main and preload). |
| `bun run lint:electron` | Passed. |
| Manual diagnosis in macOS Desktop | Reproduced the artifacts, verified computed opaque background and blur on `.oc-zone-header-backing`, and verified that an equivalent inline transparent/no-blur override removed the artifacts. Reopening the sidebar restored the issue before this source fix because the elements remounted. |
| Current PR HEAD macOS visual run | Not run after the source edit; the manual override exercised the equivalent rendered styles, but a fresh before/after capture for this commit is not attached. |

## Visual evidence

<!-- User-visible change: attach current before/after screenshots or recordings for the affected desktop/mobile, narrow/wide, theme, and interaction states. No visible change: explain concretely why the diff cannot affect rendered behavior. -->

The reporter supplied before-state screenshots during diagnosis. No repository-hosted before/after artifact is attached to this PR; a maintainer should verify the current HEAD on macOS with vibrancy enabled, including sidebar close/reopen and a header entering the stuck state.

## Risks and failure behavior

<!-- Cover relevant failure, rollback, cleanup, compatibility, security, performance, data-loss, and cross-runtime concerns. State "None identified" only with a concrete reason. -->

The opaque backing now follows the same existing `isStuck` observer state already used for stuck-header elevation. If that observer updates late, a header could briefly remain transparent while entering the stuck state; no data or external state is involved. The change is reversible by restoring the previous class assignment and CSS declarations. Security, persistence, API compatibility, and cleanup behavior are unchanged.