### PR TITLE
feat(web): detect and stop agent edit loops

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -76,6 +76,7 @@ import { createOpenCodeWatcherRuntime } from './lib/opencode/watcher.js';
 import { createSessionAssistRuntime } from './lib/session-assist/runtime.js';
 import { createSessionGoalRuntime } from './lib/session-goal/runtime.js';
 import { createContextObligatoryRuntime } from './lib/context-obligatory/runtime.js';
+import { createAgentLoopDetectionRuntime } from './lib/agent-loop-detection/runtime.js';
 import { createScheduledTasksRuntime } from './lib/scheduled-tasks/runtime.js';
 import { createServerStartupRuntime } from './lib/opencode/server-startup-runtime.js';
 import { createTunnelWiringRuntime } from './lib/opencode/tunnel-wiring-runtime.js';
@@ -777,6 +778,11 @@ const contextObligatoryRuntime = createContextObligatoryRuntime({
   getOpenCodeAuthHeaders,
 });
 
+const agentLoopDetectionRuntime = createAgentLoopDetectionRuntime({
+  buildOpenCodeUrl,
+  getOpenCodeAuthHeaders,
+});
+
 const globalMessageStreamHub = createGlobalMessageStreamHub({
   buildOpenCodeUrl,
   getOpenCodeAuthHeaders,
@@ -822,6 +828,7 @@ globalMessageStreamHub.subscribeEvent((event) => {
   sessionAssistRuntime.processPayload(payload, directory);
   sessionGoalRuntime.processPayload(payload, directory);
   contextObligatoryRuntime.processPayload(payload, directory);
+  agentLoopDetectionRuntime.processPayload(payload, directory);
 });
 
 const processForwardedEventPayload = (payload, emitSyntheticEvent) => {

--- a/packages/web/server/lib/agent-loop-detection/fingerprint.js
+++ b/packages/web/server/lib/agent-loop-detection/fingerprint.js
@@ -1,0 +1,196 @@
+import { createHash } from 'node:crypto';
+
+/** File-mutating tools most often involved in edit loops. */
+export const EDIT_LOOP_TOOLS = new Set([
+  'edit',
+  'write',
+  'multiedit',
+  'apply_patch',
+  'create',
+  'file_write',
+]);
+
+const isRecord = (value) => Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const stableStringify = (value) => {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+};
+
+const hashText = (value) => createHash('sha256').update(String(value ?? ''), 'utf8').digest('hex');
+
+/** Collapse whitespace so trivial reformats count as near-identical. */
+export const normalizeContent = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
+
+export const extractFilePath = (tool, input, metadata) => {
+  const source = isRecord(input) ? input : {};
+  const meta = isRecord(metadata) ? metadata : {};
+  const fromInput = typeof source.filePath === 'string' ? source.filePath
+    : typeof source.file_path === 'string' ? source.file_path
+      : typeof source.path === 'string' ? source.path
+        : '';
+  if (fromInput.trim()) return fromInput.trim();
+
+  const metaFiles = Array.isArray(meta.files) ? meta.files : [];
+  for (const file of metaFiles) {
+    if (!isRecord(file)) continue;
+    const path = typeof file.relativePath === 'string' ? file.relativePath
+      : typeof file.filePath === 'string' ? file.filePath
+        : '';
+    if (path.trim()) return path.trim();
+  }
+
+  if (isRecord(meta.filediff) && typeof meta.filediff.file === 'string' && meta.filediff.file.trim()) {
+    return meta.filediff.file.trim();
+  }
+
+  if (tool === 'apply_patch') {
+    const patch = typeof source.patchText === 'string' ? source.patchText
+      : typeof source.patch_text === 'string' ? source.patch_text
+        : typeof source.patch === 'string' ? source.patch
+          : '';
+    const match = patch.match(/^\+\+\+\s+(?:b\/)?(.+)$/m);
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+
+  return '';
+};
+
+export const extractContentSignature = (tool, input) => {
+  const source = isRecord(input) ? input : {};
+  switch (tool) {
+    case 'edit':
+      return stableStringify({
+        old: source.oldString ?? source.old_string ?? '',
+        new: source.newString ?? source.new_string ?? '',
+        replaceAll: source.replaceAll ?? source.replace_all ?? false,
+      });
+    case 'write':
+    case 'create':
+    case 'file_write':
+      return String(source.content ?? '');
+    case 'multiedit':
+      return stableStringify(source.edits ?? []);
+    case 'apply_patch':
+      return String(source.patchText ?? source.patch_text ?? source.patch ?? '');
+    default:
+      return stableStringify(source);
+  }
+};
+
+/**
+ * Dice coefficient over character bigrams. Cheap and good enough for near-duplicate
+ * edit payloads without pulling in a dependency.
+ */
+export const contentSimilarity = (left, right) => {
+  const a = normalizeContent(left);
+  const b = normalizeContent(right);
+  if (!a && !b) return 1;
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+  if (a.length < 2 || b.length < 2) return a === b ? 1 : 0;
+
+  const bigrams = (text) => {
+    const map = new Map();
+    for (let i = 0; i < text.length - 1; i += 1) {
+      const gram = text.slice(i, i + 2);
+      map.set(gram, (map.get(gram) ?? 0) + 1);
+    }
+    return map;
+  };
+
+  const leftMap = bigrams(a);
+  const rightMap = bigrams(b);
+  let overlap = 0;
+  for (const [gram, count] of leftMap) {
+    const other = rightMap.get(gram);
+    if (other) overlap += Math.min(count, other);
+  }
+  return (2 * overlap) / ((a.length - 1) + (b.length - 1));
+};
+
+/**
+ * Build a fingerprint for a completed tool call. Returns null when the part cannot
+ * be evaluated (missing tool/input).
+ */
+export const buildToolFingerprint = (part) => {
+  if (!part || part.type !== 'tool' || typeof part.tool !== 'string' || !part.tool) return null;
+  const state = isRecord(part.state) ? part.state : null;
+  if (!state || !isRecord(state.input)) return null;
+
+  const tool = part.tool.trim();
+  const path = extractFilePath(tool, state.input, state.metadata);
+  const content = extractContentSignature(tool, state.input);
+  const exactHash = hashText(`${tool}\0${path}\0${content}`);
+  const normalizedHash = hashText(`${tool}\0${path}\0${normalizeContent(content)}`);
+  const callId = typeof part.callID === 'string' && part.callID
+    ? part.callID
+    : (typeof part.id === 'string' ? part.id : '');
+
+  return {
+    callId,
+    tool,
+    path,
+    content,
+    exactHash,
+    normalizedHash,
+    isEditTool: EDIT_LOOP_TOOLS.has(tool),
+  };
+};
+
+/**
+ * Evaluate a rolling window of fingerprints for identical / near-identical streaks.
+ * Streaks are trailing (most recent consecutive matches).
+ */
+export const detectLoopFromWindow = (window, {
+  identicalThreshold = 3,
+  nearThreshold = 3,
+  nearSimilarity = 0.92,
+} = {}) => {
+  if (!Array.isArray(window) || window.length === 0) return null;
+
+  let identicalStreak = 1;
+  for (let i = window.length - 1; i > 0; i -= 1) {
+    if (window[i].exactHash !== window[i - 1].exactHash) break;
+    identicalStreak += 1;
+  }
+  if (identicalStreak >= identicalThreshold) {
+    const latest = window[window.length - 1];
+    return {
+      kind: 'identical',
+      count: identicalStreak,
+      tool: latest.tool,
+      path: latest.path,
+      exactHash: latest.exactHash,
+    };
+  }
+
+  const latest = window[window.length - 1];
+  if (!latest.isEditTool || !latest.path) return null;
+
+  let nearStreak = 1;
+  for (let i = window.length - 1; i > 0; i -= 1) {
+    const current = window[i];
+    const previous = window[i - 1];
+    if (!previous.isEditTool) break;
+    if (previous.tool !== current.tool || previous.path !== current.path) break;
+    const similar = previous.normalizedHash === current.normalizedHash
+      || contentSimilarity(previous.content, current.content) >= nearSimilarity;
+    if (!similar) break;
+    nearStreak += 1;
+  }
+
+  if (nearStreak >= nearThreshold) {
+    return {
+      kind: 'near-identical',
+      count: nearStreak,
+      tool: latest.tool,
+      path: latest.path,
+      exactHash: latest.exactHash,
+    };
+  }
+
+  return null;
+};

--- a/packages/web/server/lib/agent-loop-detection/fingerprint.js
+++ b/packages/web/server/lib/agent-loop-detection/fingerprint.js
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 
 /** File-mutating tools most often involved in edit loops. */
-export const EDIT_LOOP_TOOLS = new Set([
+const EDIT_LOOP_TOOLS = new Set([
   'edit',
   'write',
   'multiedit',
@@ -24,7 +24,7 @@ const hashText = (value) => createHash('sha256').update(String(value ?? ''), 'ut
 /** Collapse whitespace so trivial reformats count as near-identical. */
 export const normalizeContent = (value) => String(value ?? '').replace(/\s+/g, ' ').trim();
 
-export const extractFilePath = (tool, input, metadata) => {
+const extractFilePath = (tool, input, metadata) => {
   const source = isRecord(input) ? input : {};
   const meta = isRecord(metadata) ? metadata : {};
   const fromInput = typeof source.filePath === 'string' ? source.filePath
@@ -58,7 +58,7 @@ export const extractFilePath = (tool, input, metadata) => {
   return '';
 };
 
-export const extractContentSignature = (tool, input) => {
+const extractContentSignature = (tool, input) => {
   const source = isRecord(input) ? input : {};
   switch (tool) {
     case 'edit':

--- a/packages/web/server/lib/agent-loop-detection/runtime.js
+++ b/packages/web/server/lib/agent-loop-detection/runtime.js
@@ -1,0 +1,346 @@
+import {
+  buildToolFingerprint,
+  detectLoopFromWindow,
+} from './fingerprint.js';
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MESSAGE_FETCH_LIMIT = 8;
+const DEFAULT_IDENTICAL_THRESHOLD = 3;
+const DEFAULT_NEAR_THRESHOLD = 3;
+const DEFAULT_WINDOW_SIZE = 12;
+const DEFAULT_NEAR_SIMILARITY = 0.92;
+const DEFAULT_COOLDOWN_MS = 30_000;
+const SEEN_CALL_LIMIT = 500;
+const SESSION_STATE_LIMIT = 200;
+
+const parsePositiveInt = (raw, fallback) => {
+  const value = Number.parseInt(String(raw ?? ''), 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+};
+
+const parseFloatClamped = (raw, fallback, min, max) => {
+  const value = Number.parseFloat(String(raw ?? ''));
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+};
+
+const parseBool = (raw, fallback) => {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const normalized = String(raw).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+};
+
+/**
+ * Resolve loop-detection config from env (and optional overrides for tests).
+ *
+ * OPENCHAMBER_AGENT_LOOP_DETECTION   — enable/disable (default true)
+ * OPENCHAMBER_AGENT_LOOP_THRESHOLD   — identical repeat count before stop (default 3)
+ * OPENCHAMBER_AGENT_LOOP_NEAR_THRESHOLD — near-identical count before warn (default 3)
+ * OPENCHAMBER_AGENT_LOOP_WINDOW      — rolling window size (default 12)
+ * OPENCHAMBER_AGENT_LOOP_NEAR_SIMILARITY — 0..1 Dice threshold (default 0.92)
+ * OPENCHAMBER_AGENT_LOOP_BEHAVIOR    — auto | stop | warn (default auto)
+ *   auto: identical → stop (abort, no continue); near-identical → warn (abort + recover prompt)
+ *   stop: always abort without recovery
+ *   warn: always abort + inject recovery prompt
+ */
+export const resolveLoopDetectionConfig = (env = process.env) => {
+  const behaviorRaw = String(env.OPENCHAMBER_AGENT_LOOP_BEHAVIOR ?? 'auto').trim().toLowerCase();
+  const behavior = behaviorRaw === 'stop' || behaviorRaw === 'warn' ? behaviorRaw : 'auto';
+  return {
+    enabled: parseBool(env.OPENCHAMBER_AGENT_LOOP_DETECTION, true),
+    identicalThreshold: parsePositiveInt(env.OPENCHAMBER_AGENT_LOOP_THRESHOLD, DEFAULT_IDENTICAL_THRESHOLD),
+    nearThreshold: parsePositiveInt(
+      env.OPENCHAMBER_AGENT_LOOP_NEAR_THRESHOLD,
+      parsePositiveInt(env.OPENCHAMBER_AGENT_LOOP_THRESHOLD, DEFAULT_NEAR_THRESHOLD),
+    ),
+    windowSize: parsePositiveInt(env.OPENCHAMBER_AGENT_LOOP_WINDOW, DEFAULT_WINDOW_SIZE),
+    nearSimilarity: parseFloatClamped(env.OPENCHAMBER_AGENT_LOOP_NEAR_SIMILARITY, DEFAULT_NEAR_SIMILARITY, 0.5, 1),
+    behavior,
+    cooldownMs: parsePositiveInt(env.OPENCHAMBER_AGENT_LOOP_COOLDOWN_MS, DEFAULT_COOLDOWN_MS),
+  };
+};
+
+const buildRecoveryPrompt = ({ kind, tool, path, count }) => {
+  const target = path ? `"${path}"` : `tool "${tool}"`;
+  const mode = kind === 'identical' ? 'identical' : 'near-identical';
+  return [
+    '<system-reminder>',
+    `OpenChamber stopped this run because the agent repeated the same ${mode} ${tool} action on ${target} ${count} times without meaningful progress.`,
+    'Do not repeat the same edit or tool call. Change approach: re-read the file, verify the intended change, try a different strategy, or ask the user for guidance.',
+    'Acknowledge briefly what loop was detected and the next distinct step you will take. Do not continue the previous repeated action.',
+    '</system-reminder>',
+  ].join('\n');
+};
+
+const extractToolPart = (payload) => {
+  if (!payload || payload.type !== 'message.part.updated') return null;
+  const part = payload.properties?.part;
+  if (!part || part.type !== 'tool') return null;
+  const status = part.state?.status;
+  // Count completed and error terminal states — both burn tokens on a loop.
+  if (status !== 'completed' && status !== 'error') return null;
+  return part;
+};
+
+export const createAgentLoopDetectionRuntime = ({
+  buildOpenCodeUrl,
+  getOpenCodeAuthHeaders,
+  config: configOverride,
+  fetchImpl,
+  now = () => Date.now(),
+  log = console,
+  onDetection,
+} = {}) => {
+  const getConfig = () => configOverride ?? resolveLoopDetectionConfig();
+  const sessions = new Map();
+  const pendingRecovery = new Map();
+  const inflight = new Set();
+  let stopped = false;
+
+  const openCodeFetch = async (fetchPath, { directory, method = 'GET', body, query } = {}) => {
+    const params = new URLSearchParams(query || {});
+    if (directory) params.set('directory', directory);
+    const search = params.toString();
+    const runner = fetchImpl ?? fetch;
+    const response = await runner(`${buildOpenCodeUrl(fetchPath, '')}${search ? `?${search}` : ''}`, {
+      method,
+      headers: {
+        Accept: 'application/json',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+        ...getOpenCodeAuthHeaders(),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      const error = new Error(`OpenCode ${method} ${fetchPath} failed with ${response.status}`);
+      error.status = response.status;
+      throw error;
+    }
+    return response.json().catch(() => null);
+  };
+
+  const getSessionState = (sessionId) => {
+    let state = sessions.get(sessionId);
+    if (!state) {
+      state = {
+        window: [],
+        seenCallIds: new Set(),
+        cooldownUntil: 0,
+        directory: '',
+      };
+      sessions.set(sessionId, state);
+      if (sessions.size > SESSION_STATE_LIMIT) {
+        sessions.delete(sessions.keys().next().value);
+      }
+    }
+    return state;
+  };
+
+  const clearSessionHistory = (sessionId) => {
+    const state = sessions.get(sessionId);
+    if (!state) return;
+    state.window = [];
+    state.seenCallIds.clear();
+  };
+
+  const rememberCall = (state, fingerprint, windowSize) => {
+    if (fingerprint.callId) {
+      if (state.seenCallIds.has(fingerprint.callId)) return false;
+      state.seenCallIds.add(fingerprint.callId);
+      if (state.seenCallIds.size > SEEN_CALL_LIMIT) {
+        const first = state.seenCallIds.values().next().value;
+        state.seenCallIds.delete(first);
+      }
+    }
+    state.window.push(fingerprint);
+    while (state.window.length > windowSize) state.window.shift();
+    return true;
+  };
+
+  const resolveAction = (kind, behavior) => {
+    if (behavior === 'stop') return 'stop';
+    if (behavior === 'warn') return 'warn';
+    return kind === 'identical' ? 'stop' : 'warn';
+  };
+
+  const injectRecovery = async (sessionId, directory, detection) => {
+    const recent = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}/message`, {
+      directory,
+      query: { limit: String(MESSAGE_FETCH_LIMIT) },
+    });
+    if (!Array.isArray(recent) || recent.length === 0) {
+      throw new Error('no recent messages for recovery prompt');
+    }
+    const executionInfo = recent.toReversed().find((message) =>
+      message?.info?.role === 'assistant' && message.info.summary !== true)?.info;
+    const providerID = typeof executionInfo?.providerID === 'string' ? executionInfo.providerID : '';
+    const modelID = typeof executionInfo?.modelID === 'string' ? executionInfo.modelID : '';
+    if (!providerID || !modelID) throw new Error('no assistant provider/model for recovery prompt');
+    const agent = typeof executionInfo?.agent === 'string'
+      ? executionInfo.agent
+      : (typeof executionInfo?.mode === 'string' ? executionInfo.mode : undefined);
+
+    await openCodeFetch(`/session/${encodeURIComponent(sessionId)}/prompt_async`, {
+      directory,
+      method: 'POST',
+      body: {
+        model: { providerID, modelID },
+        ...(typeof agent === 'string' && agent ? { agent } : {}),
+        parts: [{ type: 'text', text: buildRecoveryPrompt(detection), synthetic: true }],
+      },
+    });
+  };
+
+  const flushRecovery = async (sessionId, directoryHint = '') => {
+    const pending = pendingRecovery.get(sessionId);
+    if (!pending) return;
+    const directory = directoryHint || pending.directory || '';
+    clearSessionHistory(sessionId);
+    await injectRecovery(sessionId, directory, pending.detection);
+    pendingRecovery.delete(sessionId);
+    log.warn?.(
+      `[agent-loop-detection] injected recovery prompt after ${pending.detection.kind} loop `
+      + `(session=${sessionId}, tool=${pending.detection.tool}, path=${pending.detection.path || '(none)'})`,
+    );
+  };
+
+  const intervene = async (sessionId, directory, detection, action) => {
+    const state = getSessionState(sessionId);
+    const config = getConfig();
+    state.cooldownUntil = now() + config.cooldownMs;
+    clearSessionHistory(sessionId);
+
+    const target = detection.path || detection.tool;
+    log.warn?.(
+      `[agent-loop-detection] ${detection.kind} loop detected `
+      + `(action=${action}, tool=${detection.tool}, path=${target || '(none)'}, `
+      + `count=${detection.count}, session=${sessionId})`,
+    );
+    onDetection?.({ sessionId, directory, detection, action });
+
+    await openCodeFetch(`/session/${encodeURIComponent(sessionId)}/abort`, {
+      directory,
+      method: 'POST',
+    });
+
+    if (action !== 'warn') {
+      pendingRecovery.delete(sessionId);
+      return;
+    }
+
+    pendingRecovery.set(sessionId, { directory, detection });
+    // Prefer an immediate recovery prompt after abort is accepted. If OpenCode
+    // still considers the session busy, leave pendingRecovery for the idle handler.
+    try {
+      await flushRecovery(sessionId, directory);
+    } catch (error) {
+      log.warn?.(
+        `[agent-loop-detection] recovery prompt deferred until idle: ${error?.message || error}`,
+      );
+    }
+  };
+
+  const observeToolPart = (part, directoryHint = '') => {
+    if (stopped) return null;
+    const config = getConfig();
+    if (!config.enabled) return null;
+
+    const sessionId = typeof part.sessionID === 'string' ? part.sessionID.trim() : '';
+    if (!sessionId) return null;
+
+    const fingerprint = buildToolFingerprint(part);
+    if (!fingerprint) return null;
+
+    const state = getSessionState(sessionId);
+    if (directoryHint) state.directory = directoryHint;
+    if (now() < state.cooldownUntil) return null;
+    if (!rememberCall(state, fingerprint, config.windowSize)) return null;
+
+    const detection = detectLoopFromWindow(state.window, {
+      identicalThreshold: config.identicalThreshold,
+      nearThreshold: config.nearThreshold,
+      nearSimilarity: config.nearSimilarity,
+    });
+    if (!detection) return null;
+
+    const action = resolveAction(detection.kind, config.behavior);
+    if (inflight.has(sessionId)) return detection;
+    inflight.add(sessionId);
+    const directory = directoryHint || state.directory || '';
+    void intervene(sessionId, directory, detection, action)
+      .catch((error) => {
+        log.warn?.(`[agent-loop-detection] intervene failed: ${error?.message || error}`);
+      })
+      .finally(() => {
+        inflight.delete(sessionId);
+      });
+    return detection;
+  };
+
+  const processPayload = (payload, directoryHint = '') => {
+    if (stopped || !payload || typeof payload !== 'object') return null;
+
+    if (payload.type === 'message.updated') {
+      const info = payload.properties?.info;
+      if (info?.role === 'user' && typeof info.sessionID === 'string') {
+        clearSessionHistory(info.sessionID);
+        pendingRecovery.delete(info.sessionID);
+      }
+      return null;
+    }
+
+    if (payload.type === 'session.status') {
+      const properties = payload.properties && typeof payload.properties === 'object' ? payload.properties : {};
+      const status = properties.status && typeof properties.status === 'object' ? properties.status : {};
+      const info = properties.info && typeof properties.info === 'object' ? properties.info : {};
+      const sessionId = typeof properties.sessionID === 'string' ? properties.sessionID.trim() : '';
+      const type = typeof status.type === 'string'
+        ? status.type.trim()
+        : (typeof info.type === 'string' ? info.type.trim() : '');
+      if (sessionId && type === 'idle' && pendingRecovery.has(sessionId)) {
+        const directory = typeof properties.directory === 'string' && properties.directory
+          ? properties.directory
+          : (directoryHint || '');
+        const run = async () => {
+          // Wait out an in-flight abort/intervene so idle is not dropped.
+          while (inflight.has(sessionId) && !stopped) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          if (stopped || !pendingRecovery.has(sessionId)) return;
+          inflight.add(sessionId);
+          try {
+            await flushRecovery(sessionId, directory);
+          } finally {
+            inflight.delete(sessionId);
+          }
+        };
+        void run().catch((error) => {
+          log.warn?.(`[agent-loop-detection] recovery prompt failed: ${error?.message || error}`);
+        });
+      }
+      return null;
+    }
+
+    const part = extractToolPart(payload);
+    if (!part) return null;
+    return observeToolPart(part, directoryHint);
+  };
+
+  const stop = () => {
+    stopped = true;
+    pendingRecovery.clear();
+    sessions.clear();
+  };
+
+  return {
+    processPayload,
+    observeToolPart,
+    stop,
+    // test helpers
+    _getSessionState: getSessionState,
+    _pendingRecovery: pendingRecovery,
+  };
+};

--- a/packages/web/server/lib/agent-loop-detection/runtime.test.js
+++ b/packages/web/server/lib/agent-loop-detection/runtime.test.js
@@ -1,0 +1,345 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildToolFingerprint,
+  contentSimilarity,
+  detectLoopFromWindow,
+  normalizeContent,
+} from './fingerprint.js';
+import {
+  createAgentLoopDetectionRuntime,
+  resolveLoopDetectionConfig,
+} from './runtime.js';
+
+const json = (body, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+const editPart = ({
+  sessionID = 'ses_1',
+  callID,
+  tool = 'edit',
+  status = 'completed',
+  filePath = 'src/app.ts',
+  oldString = 'foo',
+  newString = 'bar',
+  id,
+} = {}) => ({
+  id: id ?? `part_${callID}`,
+  sessionID,
+  messageID: 'msg_1',
+  type: 'tool',
+  callID,
+  tool,
+  state: {
+    status,
+    input: { filePath, oldString, newString },
+    ...(status === 'completed' ? { output: 'ok', title: filePath, metadata: {}, time: { start: 1, end: 2 } } : {}),
+  },
+});
+
+const partUpdated = (part) => ({
+  type: 'message.part.updated',
+  properties: { part },
+});
+
+describe('agent loop fingerprint helpers', () => {
+  it('hashes identical edit payloads the same way', () => {
+    const left = buildToolFingerprint(editPart({ callID: 'c1', oldString: 'a', newString: 'b' }));
+    const right = buildToolFingerprint(editPart({ callID: 'c2', oldString: 'a', newString: 'b' }));
+    expect(left.exactHash).toBe(right.exactHash);
+    expect(left.path).toBe('src/app.ts');
+  });
+
+  it('treats whitespace-only content changes as near-identical via normalized hash', () => {
+    const left = buildToolFingerprint(editPart({
+      callID: 'c1',
+      oldString: 'foo',
+      newString: 'hello world',
+    }));
+    const right = buildToolFingerprint(editPart({
+      callID: 'c2',
+      oldString: 'foo',
+      newString: 'hello   world',
+    }));
+    expect(left.exactHash).not.toBe(right.exactHash);
+    expect(left.normalizedHash).toBe(right.normalizedHash);
+    expect(normalizeContent('hello   world')).toBe('hello world');
+    expect(contentSimilarity('hello world', 'hello   world')).toBe(1);
+  });
+
+  it('detects identical trailing streaks and ignores normal multi-step progress', () => {
+    const a = buildToolFingerprint(editPart({ callID: '1', filePath: 'a.ts', newString: 'one' }));
+    const b = buildToolFingerprint(editPart({ callID: '2', filePath: 'b.ts', newString: 'two' }));
+    const c = buildToolFingerprint(editPart({ callID: '3', filePath: 'a.ts', newString: 'three' }));
+    expect(detectLoopFromWindow([a, b, c], { identicalThreshold: 3 })).toBeNull();
+
+    const same = buildToolFingerprint(editPart({ callID: '4', filePath: 'a.ts', newString: 'one' }));
+    const same2 = buildToolFingerprint(editPart({ callID: '5', filePath: 'a.ts', newString: 'one' }));
+    const same3 = buildToolFingerprint(editPart({ callID: '6', filePath: 'a.ts', newString: 'one' }));
+    expect(detectLoopFromWindow([same, same2, same3], { identicalThreshold: 3 })).toMatchObject({
+      kind: 'identical',
+      count: 3,
+      path: 'a.ts',
+      tool: 'edit',
+    });
+  });
+
+  it('detects near-identical trailing edit streaks on the same file', () => {
+    const first = buildToolFingerprint(editPart({
+      callID: '1',
+      filePath: 'loop.ts',
+      newString: 'const value = 1;',
+    }));
+    const second = buildToolFingerprint(editPart({
+      callID: '2',
+      filePath: 'loop.ts',
+      newString: 'const value = 1; ',
+    }));
+    const third = buildToolFingerprint(editPart({
+      callID: '3',
+      filePath: 'loop.ts',
+      newString: 'const  value = 1;',
+    }));
+    expect(detectLoopFromWindow([first, second, third], {
+      identicalThreshold: 5,
+      nearThreshold: 3,
+      nearSimilarity: 0.9,
+    })).toMatchObject({
+      kind: 'near-identical',
+      count: 3,
+      path: 'loop.ts',
+    });
+  });
+});
+
+describe('resolveLoopDetectionConfig', () => {
+  it('uses safe defaults and parses env overrides', () => {
+    expect(resolveLoopDetectionConfig({})).toMatchObject({
+      enabled: true,
+      identicalThreshold: 3,
+      nearThreshold: 3,
+      behavior: 'auto',
+    });
+    expect(resolveLoopDetectionConfig({
+      OPENCHAMBER_AGENT_LOOP_DETECTION: '0',
+      OPENCHAMBER_AGENT_LOOP_THRESHOLD: '4',
+      OPENCHAMBER_AGENT_LOOP_BEHAVIOR: 'warn',
+    })).toMatchObject({
+      enabled: false,
+      identicalThreshold: 4,
+      nearThreshold: 4,
+      behavior: 'warn',
+    });
+  });
+});
+
+describe('agent loop detection runtime', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not intervene during a normal multi-step edit sequence', async () => {
+    const fetchImpl = vi.fn();
+    const detections = [];
+    const runtime = createAgentLoopDetectionRuntime({
+      buildOpenCodeUrl: (path) => `http://opencode.test${path}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      fetchImpl,
+      onDetection: (event) => detections.push(event),
+      config: {
+        enabled: true,
+        identicalThreshold: 3,
+        nearThreshold: 3,
+        windowSize: 12,
+        nearSimilarity: 0.92,
+        behavior: 'auto',
+        cooldownMs: 30_000,
+      },
+    });
+
+    runtime.processPayload(partUpdated(editPart({ callID: 'c1', filePath: 'a.ts', newString: 'one' })), '/repo');
+    runtime.processPayload(partUpdated(editPart({ callID: 'c2', filePath: 'b.ts', newString: 'two' })), '/repo');
+    runtime.processPayload(partUpdated(editPart({ callID: 'c3', filePath: 'a.ts', newString: 'three' })), '/repo');
+    runtime.processPayload(partUpdated({
+      id: 'part_c4',
+      sessionID: 'ses_1',
+      messageID: 'msg_1',
+      type: 'tool',
+      callID: 'c4',
+      tool: 'write',
+      state: {
+        status: 'completed',
+        input: { filePath: 'c.ts', content: 'export {}' },
+        output: 'ok',
+        title: 'c.ts',
+        metadata: {},
+        time: { start: 1, end: 2 },
+      },
+    }), '/repo');
+
+    expect(detections).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it('aborts without recovery when identical edits repeat past the threshold', async () => {
+    const requests = [];
+    const detections = [];
+    const logs = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET' });
+      if (url.pathname.endsWith('/abort')) return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = createAgentLoopDetectionRuntime({
+      buildOpenCodeUrl: (path) => `http://opencode.test${path}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      onDetection: (event) => detections.push(event),
+      log: { warn: (message) => logs.push(message) },
+      config: {
+        enabled: true,
+        identicalThreshold: 3,
+        nearThreshold: 3,
+        windowSize: 12,
+        nearSimilarity: 0.92,
+        behavior: 'auto',
+        cooldownMs: 30_000,
+      },
+    });
+
+    const same = { filePath: 'loop.ts', oldString: 'x', newString: 'y' };
+    runtime.processPayload(partUpdated(editPart({ callID: 'c1', ...same })), '/repo');
+    runtime.processPayload(partUpdated(editPart({ callID: 'c2', ...same })), '/repo');
+    // duplicate callID must not count twice
+    runtime.processPayload(partUpdated(editPart({ callID: 'c2', ...same })), '/repo');
+    runtime.processPayload(partUpdated(editPart({ callID: 'c3', ...same })), '/repo');
+
+    await vi.waitFor(() => {
+      expect(requests.some((request) => request.path.endsWith('/abort'))).toBe(true);
+    });
+
+    expect(detections).toHaveLength(1);
+    expect(detections[0]).toMatchObject({
+      action: 'stop',
+      detection: { kind: 'identical', count: 3, path: 'loop.ts', tool: 'edit' },
+    });
+    expect(requests.some((request) => request.path.includes('/prompt_async'))).toBe(false);
+    expect(logs.some((line) => line.includes('identical loop detected') && line.includes('action=stop'))).toBe(true);
+
+    // idle with no pending recovery should not prompt
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    }, '/repo');
+    await Promise.resolve();
+    expect(requests.filter((request) => request.path.includes('/prompt_async'))).toHaveLength(0);
+    runtime.stop();
+  });
+
+  it('aborts and injects a recovery prompt for near-identical edit loops', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname.endsWith('/abort')) return json({});
+      if (url.pathname.endsWith('/message')) {
+        return json([
+          {
+            info: {
+              id: 'msg_agent',
+              role: 'assistant',
+              providerID: 'provider',
+              modelID: 'model',
+              agent: 'build',
+            },
+          },
+        ]);
+      }
+      if (url.pathname.endsWith('/prompt_async')) return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = createAgentLoopDetectionRuntime({
+      buildOpenCodeUrl: (path) => `http://opencode.test${path}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      config: {
+        enabled: true,
+        identicalThreshold: 5,
+        nearThreshold: 3,
+        windowSize: 12,
+        nearSimilarity: 0.9,
+        behavior: 'auto',
+        cooldownMs: 30_000,
+      },
+    });
+
+    runtime.processPayload(partUpdated(editPart({
+      callID: 'n1',
+      filePath: 'near.ts',
+      newString: 'const value = 1;',
+    })), '/repo');
+    runtime.processPayload(partUpdated(editPart({
+      callID: 'n2',
+      filePath: 'near.ts',
+      newString: 'const value = 1; ',
+    })), '/repo');
+    runtime.processPayload(partUpdated(editPart({
+      callID: 'n3',
+      filePath: 'near.ts',
+      newString: 'const  value = 1;',
+    })), '/repo');
+
+    await vi.waitFor(() => {
+      expect(requests.some((request) => request.path.endsWith('/abort'))).toBe(true);
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    }, '/repo');
+
+    await vi.waitFor(() => {
+      expect(requests.some((request) => request.path.endsWith('/prompt_async'))).toBe(true);
+    });
+
+    const prompt = requests.find((request) => request.path.endsWith('/prompt_async'));
+    const body = JSON.parse(prompt.body);
+    expect(body).toMatchObject({
+      model: { providerID: 'provider', modelID: 'model' },
+      agent: 'build',
+      parts: [{ type: 'text', synthetic: true }],
+    });
+    expect(body.parts[0].text).toContain('near-identical');
+    expect(body.parts[0].text).toContain('near.ts');
+    expect(body.parts[0].text).toContain('Change approach');
+    runtime.stop();
+  });
+
+  it('can be disabled via config / env', () => {
+    const fetchImpl = vi.fn();
+    const runtime = createAgentLoopDetectionRuntime({
+      buildOpenCodeUrl: (path) => `http://opencode.test${path}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      fetchImpl,
+      config: {
+        enabled: false,
+        identicalThreshold: 2,
+        nearThreshold: 2,
+        windowSize: 12,
+        nearSimilarity: 0.92,
+        behavior: 'auto',
+        cooldownMs: 30_000,
+      },
+    });
+
+    const same = { filePath: 'x.ts', oldString: 'a', newString: 'b' };
+    runtime.processPayload(partUpdated(editPart({ callID: 'd1', ...same })), '/repo');
+    runtime.processPayload(partUpdated(editPart({ callID: 'd2', ...same })), '/repo');
+    expect(fetchImpl).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Agent runs can get stuck repeatedly editing the same file with identical or near-identical content, wasting tokens until a human aborts. OpenChamber does not own the OpenCode LLM/tool loop, so this adds a server-side SSE observer that fingerprints recent tool calls, detects loops, aborts the session, and (for near-identical loops) injects a recovery `<system-reminder>` asking the model to change approach.

Closes openchamber/openchamber#382

## Non-goals

- Changing OpenCode’s built-in agent executor or `doom_loop` permission semantics (still available in agent permissions; complementary to this safety net).
- VS Code extension-host-only runtimes without the web backend (same limitation as session-goal / context-obligatory).
- Settings UI for the feature (env/config only for a minimal first cut).

## Affected surfaces

- `packages/web` server: new `agent-loop-detection` runtime subscribed on the global message stream hub alongside session-assist / session-goal / context-obligatory.
- User-visible: looping sessions are aborted; near-identical loops get a synthetic recovery prompt. Server logs include `[agent-loop-detection] …`.
- Runtimes: web, desktop (in-process web server), hosted mobile via OpenChamber server. VS Code without the web backend is unaffected by design.
- No persisted settings schema changes; configuration is env-only:
  - `OPENCHAMBER_AGENT_LOOP_DETECTION` (default `true`)
  - `OPENCHAMBER_AGENT_LOOP_THRESHOLD` (default `3`)
  - `OPENCHAMBER_AGENT_LOOP_NEAR_THRESHOLD` (default same as threshold)
  - `OPENCHAMBER_AGENT_LOOP_WINDOW` (default `12`)
  - `OPENCHAMBER_AGENT_LOOP_NEAR_SIMILARITY` (default `0.92`)
  - `OPENCHAMBER_AGENT_LOOP_BEHAVIOR` (`auto` | `stop` | `warn`, default `auto`)
  - `OPENCHAMBER_AGENT_LOOP_COOLDOWN_MS` (default `30000`)

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md runtime boundaries | Feature sits in OpenChamber-owned server observation, not `../opencode` | Detects via SSE tool parts; intervenes with OpenCode `abort` + `prompt_async` only |
| `openchamber-change-discipline` | New server module + wiring | Minimal focused module; no new deps; package-scoped validation |
| `ui-api-decoupling` | Touches server event/OpenCode HTTP side effects | No new shared UI RuntimeAPIs; uses existing OpenCode HTTP paths like sibling runtimes |
| session-goal / context-obligatory / permission-auto-accept docs | Architectural templates for SSE observers | Same hub subscription + abort/prompt patterns; no ownership doc rewrite for those modules |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run server/lib/agent-loop-detection/runtime.test.js` (in `packages/web`) | Passed on final HEAD (9 tests): normal multi-step, identical abort, near-identical recover, disable via config |
| `bun run type-check` (`packages/web`) | Passed |
| `bun run lint` (`packages/web`) | Passed |
| `bun run dead-code` (workspace) | Passed (exit 0); no `agent-loop-detection` hits on final HEAD |
| Live agent loop against a real OpenCode session | **Not verified** in this cloud environment (headless/web only). Still needs manual check: induce repeated identical edits and confirm abort + log; induce near-identical edits and confirm recovery prompt |

## Visual evidence

No UI chrome changes. Behavior is abort + optional synthetic recovery text in the session transcript and server log lines. Manual verification still needed on a live looping agent run.

## Risks and failure behavior

- False positives: mitigated by requiring trailing identical/near-identical streaks (default N=3) and clearing history on new user messages; disable with `OPENCHAMBER_AGENT_LOOP_DETECTION=0`.
- Abort interacts with session-goal (user-abort path pauses goals); intentional so a stuck goal does not keep auto-continuing.
- Recovery `prompt_async` may fail while OpenCode is still busy after abort; pending recovery retries on `session.status: idle`.
- Logs intentionally include tool name/path/count only — not edit body contents.
- Does not replace OpenCode `doom_loop` permission; both can coexist.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1710dbce-282e-4b09-b4ac-229cefc1e569?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1710dbce-282e-4b09-b4ac-229cefc1e569&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

