### PR TITLE
fix(sync): narrow the archived session query at the data boundary

### DIFF
--- a/packages/ui/src/stores/DOCUMENTATION.md
+++ b/packages/ui/src/stores/DOCUMENTATION.md
@@ -56,6 +56,7 @@ User-visible session ordering is also not owned by the global cache array order.
 
 Global refresh rules:
 
+- The OpenCode `archived` list flag means "also include archived sessions": the server only drops its `time_archived IS NULL` condition. `listGlobalSessionPages` therefore narrows archived requests to records carrying `time.archived`, at the data boundary, so the archived cache never holds active sessions and no consumer has to re-derive that. Pagination progress stays measured on the raw response, so a page that is full upstream but filtered out here is not mistaken for the last page.
 - Per-directory refresh is bounded to two requests across callers and prioritizes the current directory.
 - Each directory is an independent completeness scope. A failed directory preserves its previous sessions while successful directories reconcile normally.
 - Fetch failure must remain distinguishable from a successful empty list; failed scopes cannot destructively clear cached sessions.

--- a/packages/ui/src/stores/globalSessions.test.ts
+++ b/packages/ui/src/stores/globalSessions.test.ts
@@ -96,6 +96,164 @@ describe('listGlobalSessionPages', () => {
     expect(sessions.map((session) => session.id)).toEqual(['ses_root', 'ses_child_1', 'ses_child_2'])
   })
 
+  test('returns only archived sessions when archived pages are requested', async () => {
+    const apiClient = {
+      experimental: {
+        session: {
+          list: async () => ({
+            // The server treats `archived: true` as "include archived", so the
+            // response mixes active and archived records.
+            data: [
+              { id: 'ses_active', time: { created: 1, updated: 20 } },
+              { id: 'ses_archived', time: { created: 1, updated: 10, archived: 15 } },
+            ],
+            response: { headers: new Headers() },
+          }),
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const sessions = await listGlobalSessionPages(apiClient, { archived: true, pageSize: 500 })
+
+    expect(sessions.map((session) => session.id)).toEqual(['ses_archived'])
+  })
+
+  test('keeps every record when active pages are requested', async () => {
+    const apiClient = {
+      experimental: {
+        session: {
+          list: async () => ({
+            data: [
+              { id: 'ses_active_1', time: { updated: 20 } },
+              { id: 'ses_active_2', time: { updated: 10 } },
+            ],
+            response: { headers: new Headers() },
+          }),
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const sessions = await listGlobalSessionPages(apiClient, { archived: false, pageSize: 500 })
+
+    expect(sessions.map((session) => session.id)).toEqual(['ses_active_1', 'ses_active_2'])
+  })
+
+  test('keeps paginating archived pages that are full of non-archived records', async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const apiClient = {
+      experimental: {
+        session: {
+          list: async (options: Record<string, unknown>) => {
+            calls.push(options)
+            if (options.cursor === undefined) {
+              return {
+                data: [
+                  { id: 'ses_active_1', time: { updated: 30 } },
+                  { id: 'ses_active_2', time: { updated: 20 } },
+                ],
+                response: { headers: new Headers({ 'x-next-cursor': '20' }) },
+              }
+            }
+            return {
+              data: [
+                { id: 'ses_archived', time: { updated: 10, archived: 12 } },
+              ],
+              response: { headers: new Headers() },
+            }
+          },
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const sessions = await listGlobalSessionPages(apiClient, { archived: true, pageSize: 2 })
+
+    // A page that is full upstream but fully filtered out here must not be
+    // mistaken for the last page: pagination progress is measured on the raw
+    // response, not on the accepted records.
+    expect(calls).toHaveLength(2)
+    expect(sessions.map((session) => session.id)).toEqual(['ses_archived'])
+  })
+
+  test('reports only accepted records to onPage for archived pages', async () => {
+    const pages: string[][] = []
+    const apiClient = {
+      experimental: {
+        session: {
+          list: async () => ({
+            data: [
+              { id: 'ses_active', time: { updated: 20 } },
+              { id: 'ses_archived', time: { updated: 10, archived: 12 } },
+            ],
+            response: { headers: new Headers() },
+          }),
+        },
+      },
+    } as unknown as OpencodeClient
+
+    await listGlobalSessionPages(apiClient, {
+      archived: true,
+      pageSize: 500,
+      onPage: (sessions) => pages.push(sessions.map((session) => session.id)),
+    })
+
+    expect(pages).toEqual([['ses_archived']])
+  })
+
+  test('does not notify onPage for an archived page with no archived records', async () => {
+    const pages: string[][] = []
+    const apiClient = {
+      experimental: {
+        session: {
+          list: async () => ({
+            data: [{ id: 'ses_active', time: { updated: 20 } }],
+            response: { headers: new Headers() },
+          }),
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const sessions = await listGlobalSessionPages(apiClient, {
+      archived: true,
+      pageSize: 500,
+      onPage: (page) => pages.push(page.map((session) => session.id)),
+    })
+
+    expect(sessions).toEqual([])
+    expect(pages).toEqual([])
+  })
+
+  test('dedupes archived records by id and stops when a page repeats known ids', async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const page = [
+      { id: 'ses_archived_1', time: { updated: 30, archived: 31 } },
+      { id: 'ses_archived_2', time: { updated: 20, archived: 21 } },
+    ]
+    const apiClient = {
+      experimental: {
+        session: {
+          list: async (options: Record<string, unknown>) => {
+            calls.push(options)
+            return {
+              data: page,
+              response: {
+                headers: new Headers({
+                  'x-next-cursor': options.cursor === undefined ? '20' : '10',
+                }),
+              },
+            }
+          },
+        },
+      },
+    } as unknown as OpencodeClient
+
+    const sessions = await listGlobalSessionPages(apiClient, { archived: true, pageSize: 2 })
+
+    // The second page repeats ids already seen, so the dedupe guard stops the
+    // loop and no record is returned twice.
+    expect(calls).toHaveLength(2)
+    expect(sessions.map((session) => session.id)).toEqual(['ses_archived_1', 'ses_archived_2'])
+  })
+
   test('retries SDK error responses before treating the load as failed', async () => {
     let calls = 0
     const apiClient = {

--- a/packages/ui/src/stores/globalSessions.ts
+++ b/packages/ui/src/stores/globalSessions.ts
@@ -75,6 +75,15 @@ const unwrapSessionList = (
     return result.data as GlobalSessionRecord[];
 };
 
+/**
+ * OpenCode's `archived` query flag means "also include archived sessions", not
+ * "return only archived sessions": the server simply drops its
+ * `time_archived IS NULL` condition. Callers that ask for the archived list
+ * expect archived-only records, so narrow the response here, at the data
+ * boundary, instead of leaving every consumer to re-derive it.
+ */
+const isArchivedSession = (session: GlobalSessionRecord): boolean => Boolean(session.time?.archived);
+
 export async function listGlobalSessionPages(
     apiClient: OpencodeClient,
     options: {
@@ -131,15 +140,22 @@ export async function listGlobalSessionPages(
         });
         if (payload.length === 0) break;
 
+        // `appended` tracks pagination progress over the raw response, while
+        // `accepted` holds the records this call actually returns. Filtering
+        // must not feed the pagination guards below, otherwise a page that is
+        // full upstream but mostly non-archived would look like a last page.
         let appended = 0;
+        const accepted: GlobalSessionRecord[] = [];
         for (const session of payload) {
             if (!session?.id || seenIds.has(session.id)) continue;
             seenIds.add(session.id);
-            all.push(session);
             appended += 1;
+            if (options.archived && !isArchivedSession(session)) continue;
+            all.push(session);
+            accepted.push(session);
         }
-        if (appended > 0) {
-            options.onPage?.(payload);
+        if (accepted.length > 0) {
+            options.onPage?.(accepted);
         }
 
         // Stop on partial page — nothing more to fetch.


### PR DESCRIPTION
## Intent

The global archived session cache is polluted with active sessions, because the client treats OpenCode's `archived` list flag as "return only archived sessions" when the server actually means "also include archived sessions".

Server behaviour, in `opencode/packages/opencode/src/session/session.ts` (`Session.listGlobal`):

```ts
if (!input?.archived) conditions.push(isNull(SessionTable.time_archived))
```

`archived: true` only *drops* the `time_archived IS NULL` condition. It never selects archived rows.

On the client, `listGlobalSessionPages()` returns that response verbatim, and `useGlobalSessionsStore.loadSessions()` stores it directly as `archivedSessions` — `applySnapshot()` does not re-partition by `time.archived`. So `archivedSessions` ends up holding the whole session universe.

Two consequences follow:

1. **User-visible.** `packages/ui/src/components/views/ArchiveView.tsx:32-42` renders `state.archivedSessions` with no `time.archived` filter of its own, so the Archive page lists active sessions alongside archived ones, and the "total" count at `ArchiveView.tsx:76` counts every session. The archived buckets built from the same list in `packages/ui/src/components/session/sidebar/sessionOwnership.ts:170` inherit the same defect.
2. **Correctness of the cache contract.** `packages/ui/src/stores/DOCUMENTATION.md` states that `useGlobalSessionsStore.ts` owns "global archived session coverage". That is only true if the archived list is actually archived-only. Any consumer that wants to treat archived membership as authoritative cannot do so today.

There is also a paging side effect: because the `archived: true` request walks the entire session universe in `PAGE_SIZE` (500) pages, on a large instance genuinely archived sessions can fall outside the fetched window entirely.

This PR narrows the response at the data boundary, in the module that owns the fetch, rather than asking every consumer to re-derive it.

Pagination progress is deliberately kept measured on the raw response. `appended` counts newly-seen records from the server page and continues to feed the loop guards; `accepted` holds what this call actually returns. Without that split, a page that is full upstream but mostly non-archived would look like a partial page and pagination would stop early.

`onPage` now receives `accepted` instead of the raw payload. No caller passes `onPage` today (the only references are the option declaration and this PR's tests), so this is a contract tightening with no current consumer impact: the callback now reports exactly the records the call accepted for that page, deduped, instead of the raw response including already-seen ids.

Origin: this is the "data boundary" half of #2407, extracted and re-based. #2407 was written against an older base and additionally carried mobile archive-cascade work whose target files were rewritten upstream (`MobileSessionsSheet.tsx` was rewritten and `MobileSessionStatusBar.tsx` was deleted by #2561). Applying that branch directly would have reverted the `runBackgroundNetworkTask` wrapper and disturbed `startSessionLoadPerformanceEvent` in this same function, so the change here was re-applied by hand on current `main` instead of cherry-picked. **#2407 will be closed in favour of this PR.**

## Non-goals

- The mobile archive cascade from #2407 (archiving a parent session on mobile still does not archive its subagents). That remains open work and needs to be rewritten against the post-#2561 `MobileSessionsSheet.tsx`.
- Any client-side reconciliation helper (`combineActiveSessionsWithLive` in #2407). Not included here.
- Changing the server, the SDK, the `archived` query parameter itself, or adding an "archived-only" server flag.
- Changing `ArchiveView`, the sidebar archived buckets, or any other consumer. They are fixed transitively by receiving a correct list; their own code is untouched.
- Changing active-list behaviour. `archived: false` requests are not filtered at all.

## Affected surfaces

- `packages/ui/src/stores/globalSessions.ts` — `listGlobalSessionPages()` only. One new module-private helper (`isArchivedSession`), not exported, not part of any package entrypoint.
- Transitively, every consumer of `useGlobalSessionsStore.archivedSessions`: the Archive page, the sidebar archived buckets and auto-folders, retention/bulk archive scopes, and session lookups that scan `[...activeSessions, ...archivedSessions]`. None of them are edited; they simply stop receiving active sessions in the archived list.
- Runtimes: web, desktop (Electron), VS Code, hosted mobile, and Capacitor mobile all share `packages/ui` and the same global sessions store, so all five get the corrected list identically. There is no runtime-specific branch in this code path, so no intentional runtime difference is introduced.
- Not affected: no server/backend change, no Electron privilege boundary, no transport or authentication change, no persisted data or migration, no route, no public package contract, no dependency, no generated asset.
- `packages/web`, `packages/electron`, `packages/vscode`, `packages/mobile`, and `packages/docs` have no source change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` — always-on constraints and correctness invariants | Executable shared-UI source change on a data-fetch path. | "Prefer authoritative state over heuristics": archived membership is now decided by the record's own `time.archived`, at the boundary, instead of being inferred from which request produced it. "Never let fetch failure masquerade as authoritative empty success" is preserved — `unwrapSessionList` still throws on SDK error and on a non-array body, and this change only filters an already-successful payload. No dependency added, no secret logged, unrelated worktree changes untouched. |
| `openchamber-change-discipline` | Source change to an exported function's returned data. | Risk classified as **module contract** (the returned archived list changes shape), not cross-workspace: `listGlobalSessionPages` is intra-package and its three call sites (`useGlobalSessionsStore.ts:271,530,531` and `sync-context.tsx:1881,1894`) were traced. Smallest correct change: one private predicate plus the `appended`/`accepted` split, no drive-by refactor, no new export, no reuse-speculative abstraction. Owning documentation updated because a documented invariant changed. Existing behaviour covered by the three pre-existing tests (sanitization, pagination, retry) is preserved and those tests still pass unmodified. |
| `sync-state-invariants` and `packages/ui/src/sync/DOCUMENTATION.md` | This is a global-sessions loader whose result replaces cached state. | "Sources of truth": the global sessions store is documented as owning the *complete global active/archived cache*; that contract required the archived scope to be genuinely archived. "Failure is not empty" is unchanged: errors still propagate as throws and `loadSessions()` keeps its previous snapshot via `Promise.allSettled`. Verification followed the skill's lifecycle list for the cases this diff can actually reach — successful empty result, multi-page continuation, filtered-page continuation, repeated/duplicate records, and the archive dimension itself. Mutation-revision overlay, runtime-switch generation, and per-directory completeness scoping are untouched by this diff. |
| `packages/ui/src/stores/DOCUMENTATION.md` (nearest owning documentation) | It contains the "Global refresh rules" list that describes this exact loader. | Updated with the `archived`-flag semantics, the archived-only guarantee of the cache, and the reason pagination progress is measured on the raw response. `packages/ui/src/sync/DOCUMENTATION.md` was re-read and deliberately **not** changed: its statements about scope ownership and about using the global store for archived coverage remain true, and this invariant belongs to the store module that owns the fetch. |
| Root `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` | PR handoff requirements. | Every check below was run at the current PR HEAD and reports a concrete result, including the counter-check that the new tests fail without the fix. Runtime correctness is not claimed from type-check or lint. The visual-evidence section is answered concretely rather than removed. |

Skills deliberately **not** loaded, with reason: `ui-api-decoupling` (no new fetch, runtime URL, credential, bridge, proxy, or server route — the existing SDK call is unchanged), `theme-system` / `locale-ui-patterns` / `settings-ui-patterns` (no component, style, or user-facing string), `relay-transport` (no socket, SSE, or streaming path), `performance-engineering` (this is a bounded per-page loop on a cold load path, not a render/event hot path; see the risk section for the cost analysis), `desktop-shell`, `drag-to-reorder`, `clack-cli-patterns`, `serve-sim` (no matching surface).

## Validation

Run in a dedicated worktree at PR HEAD `babe06a2c`, with `bun 1.3.8` after `bun install --frozen-lockfile` (3179 packages installed).

| Check | Result |
|---|---|
| `bun test packages/ui/src/stores/globalSessions.test.ts` | **9 pass, 0 fail**, 19 expect() calls, 1 file, 646 ms. The 3 pre-existing tests (record sanitization, multi-page pagination, SDK-error retry) are unmodified and still pass. |
| Counter-check: same test file against the **pre-fix** `globalSessions.ts` (restored from `1b1a3797b`) | **5 pass, 4 fail** — exactly the 4 new archived-boundary tests fail: `returns only archived sessions when archived pages are requested`, `keeps paginating archived pages that are full of non-archived records`, `reports only accepted records to onPage for archived pages`, `does not notify onPage for an archived page with no archived records`. This proves the tests exercise the fix rather than passing vacuously. The source file was restored afterwards and the suite re-run at 9 pass / 0 fail. |
| `bun run type-check:ui` (`tsc --noEmit` in `packages/ui`) | Passed, exit 0, no output. |
| `bun run lint:ui` (`eslint "./src/**/*.{ts,tsx}"`) | Passed, exit 0, no warnings. |
| `bun run dead-code` (knip 5.80.0, non-blocking) | Completed: 34 unused files, 277 unused exports, 186 unused exported types, 2 duplicate exports, 4 configuration hints. **Identical to the baseline run on `1b1a3797b`** (34 / 277 / 186 / 2 / 4), measured by temporarily restoring the three changed files and re-running. Neither `globalSessions.ts` nor `globalSessions.test.ts` appears anywhere in the report; `isArchivedSession` is module-private, so no export surface changed. |

Notes on the commands themselves: `bun run dead-code` is defined as `bunx knip@5.80.0 ...` and `bunx` was not on this machine's PATH, so it was executed as `bun x knip@5.80.0 --no-exit-code --include files,exports,nsExports,types,nsTypes,enumMembers,duplicates` — same tool, same version, same flags.

**Not verified.** No manual runtime check was performed: the Archive page was not opened against a live OpenCode instance with a mixed active/archived dataset, and no desktop, VS Code, mobile, or packaged build was exercised. The claim that `ArchiveView` currently lists active sessions is derived from reading the code path end to end (`globalSessions.ts` → `loadSessions`/`applySnapshot` in `useGlobalSessionsStore.ts:529-560` → `ArchiveView.tsx:32-42`) and from the server predicate quoted above, not from an observed screen. No workspace-wide type-check, lint, or build was run, on the grounds that the change is intra-package with no export, dependency, or entrypoint change; if a reviewer considers the archived-list shape a cross-workspace contract, a full `bun run build` should be requested. No performance measurement was taken.

## Visual evidence

No direct visual change: this diff touches only a data-fetch helper and a test file. It renders nothing, adds no component, style, string, icon, or layout, and contains no runtime-conditional branch, so it cannot alter rendered markup by itself.

The user-visible effect is indirect and lands on the **Archive page** (`packages/ui/src/components/views/ArchiveView.tsx`), which renders `useGlobalSessionsStore.archivedSessions` without filtering by `time.archived`. Today that page lists active sessions mixed in with archived ones and its total count reflects every session in the instance; after this change it lists archived sessions only and the count matches. The archived buckets and auto-folders in the session sidebar, built from the same list via `sessionOwnership.ts:170`, change the same way.

Before/after screenshots are deliberately not attached rather than fabricated: reproducing the difference requires a live OpenCode instance with both active and archived sessions, which was not available for this change, and I am not going to present a mocked screen as evidence. A reviewer with such an instance can confirm it by opening the Archive page on `main` and on this branch with the same dataset. Theme, narrow/wide, and interaction states are unaffected, since no rendering code changed.

## Risks and failure behavior

- **Failure handling is unchanged.** Filtering happens only after `unwrapSessionList` has already accepted a successful array response. SDK errors and non-array bodies still throw, `retry` still applies its 3 attempts, and `loadSessions()` still preserves the previous archived snapshot when the archived request rejects (`useGlobalSessionsStore.ts:553-555`). A failed fetch still cannot masquerade as an empty archived list.
- **Empty is still distinguishable from failed.** An instance with zero archived sessions now legitimately yields `[]` from a *successful* call, which was already the contract for the active list; the store's `status` still comes from the settled results, not from list length.
- **Pagination is the main risk and is guarded explicitly.** The `appended`/`accepted` split exists so the "partial page means last page" guard (`payload.length < options.pageSize`) and the "every id already seen" guard (`appended === 0`) keep reading the raw server page. The `keeps paginating archived pages that are full of non-archived records` test locks this in: a first page that is full upstream and 100% filtered out must still trigger a second request. Getting this wrong would truncate the archived list — hence the dedicated test rather than only the happy path.
- **Cursor derivation is untouched**, still taken from the `x-next-cursor` header or the raw page's last `time.updated`, so filtering cannot desynchronise the cursor.
- **Performance.** One extra boolean check per record and one extra array allocation per page, on a cold paginated load, not on a render or streaming path. The returned archived array is now smaller, which slightly reduces downstream work in every consumer that scans it. No new scan is introduced.
- **Behavioural change to be aware of when reviewing:** the archived list gets shorter, so anything that relied — knowingly or not — on active sessions being present in `archivedSessions` would change. I traced the consumers and found none that depend on it: `ChatMessage.tsx:405`, `session-actions.ts:412`, `session-event-router.ts:63`, and `session-ui-store.ts:1587` all search the union of active and archived, so a session removed from the archived list is still found in the active one. `MultiRunFusionDialog.tsx:102` and `WorktreeSectionContent.tsx:294` likewise merge both lists.
- **No data loss, no rollback surface, no migration:** nothing is persisted, written, or deleted by this path; it is a read that populates an in-memory cache, and the next successful load fully reconciles it.
- **Security:** no credential, token, or user content is read, logged, or newly exposed. The filter reads only `session.time.archived`.
- **Cross-runtime:** identical in all five runtimes, since the code path has no runtime branch.
