### PR TITLE
fix(sync): honor expectedRuntimeKey in archive actions

### DIFF
--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -213,9 +213,19 @@ Examples of global-store updates performed in `session-actions.ts`:
 - `createSession()` -> `upsertSession(session)`
 - `updateSessionTitle()` -> `upsertSession(result.data)`
 - `shareSession()` / `unshareSession()` -> `upsertSession(result.data)`
-- `archiveSession()` -> waits for server confirmation, then upserts the archived session
+- `archiveSession()` / `archiveSessions()` -> wait for server confirmation, then upsert each archived session
 - `deleteSession()` -> waits for server confirmation or `404`, then removes the session and its persisted state
 - `moveSessionToDirectory()` -> move the session between directory stores and update the global directory index
+
+Archive callers whose confirmation spans asynchronous SDK calls may capture the
+runtime key at operation start and pass it as `expectedRuntimeKey`. The guarded
+action rechecks that key before every store reconciliation, so a response
+produced by the previous runtime is rejected instead of mutating the current
+runtime's live or global session state. A guarded batch stops at the first
+observed runtime change: sessions the server already confirmed remain archived
+and stay in `archivedIds`, while every ID not confirmed on the captured runtime
+is returned in `failedIds` so existing partial-failure feedback stays truthful.
+Callers that pass no runtime key keep the previous unguarded behavior.
 
 ## The golden rule
 

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -14,6 +14,7 @@ let sessionShareResult: { data?: unknown; error?: unknown; response?: { status?:
 let sessionUpdateResult: { data?: unknown; error?: unknown; response?: { status?: number } } = {}
 let sessionMessagesResult: { data?: unknown; error?: unknown; response?: { status?: number } } = { data: [] }
 let sessionDeleteError: unknown | null = null
+let beforeSessionUpdateResolve: ((sessionId: string) => void) | null = null
 const globalUpsertedSessions: unknown[] = []
 const globalRemovedSessionIds: string[] = []
 const deletedCleanupIdentities: Array<{ runtimeKey: string; directory: string; sessionId: string }> = []
@@ -145,6 +146,9 @@ mock.module("@/lib/opencode/client", () => ({
     }),
     updateSession: mock((sessionId: string, changes: Record<string, unknown>, directory?: string | null) => {
       replyCalls.push({ method: "session.update", params: { sessionID: sessionId, ...changes, directory } })
+      // Lets a test mutate global runtime state while the SDK call is in flight,
+      // so the action observes the switch only after awaiting the response.
+      beforeSessionUpdateResolve?.(sessionId)
       return Promise.resolve(sessionUpdateResult.data)
     }),
     deleteSession: mock((sessionId: string, directory?: string | null) => {
@@ -368,6 +372,7 @@ describe("confirmed session removal", () => {
     deletedCleanupIdentities.length = 0
     sessionDeleteError = null
     sessionUpdateResult = {}
+    beforeSessionUpdateResolve = null
   })
 
   test("does not remove live or persisted state when delete fails", async () => {
@@ -426,6 +431,86 @@ describe("confirmed session removal", () => {
     expect(await archiveSession("session-a")).toBe(true)
     expect(source.getState().session).toEqual([])
     expect((globalUpsertedSessions[0] as Session)?.time?.archived).toBe(2)
+  })
+
+  test("rejects an archive response that arrives after a runtime switch", async () => {
+    sessionUpdateResult = {
+      data: { id: "session-a", directory: "/test/project", time: { created: 1, archived: 2 } } as Session,
+    }
+    const source = createStore({}, {
+      session: [{ id: "session-a", directory: "/test/project", time: { created: 1 } } as Session],
+    })
+    const { getRuntimeKey, switchRuntimeEndpoint } = await import("../lib/runtime-switch")
+    switchRuntimeEndpoint({ apiBaseUrl: "http://archive-runtime-a.test", runtimeKey: "archive-runtime-a" })
+    beforeSessionUpdateResolve = () => {
+      switchRuntimeEndpoint({ apiBaseUrl: "http://archive-runtime-b.test", runtimeKey: "archive-runtime-b" })
+    }
+    const { archiveSession, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/test/project", source]]), () => "/test/project")
+
+    expect(await archiveSession("session-a", "archive-runtime-a")).toBe(false)
+    expect(getRuntimeKey()).toBe("archive-runtime-b")
+    // The stale response must not reconcile the runtime the user switched to.
+    expect(source.getState().session.map((item) => item.id)).toEqual(["session-a"])
+    expect(globalUpsertedSessions).toEqual([])
+  })
+
+  test("keeps confirmed sessions and fails the rest when the runtime changes mid-batch", async () => {
+    sessionUpdateResult = {
+      data: { id: "session-a", directory: "/test/project", time: { created: 1, archived: 2 } } as Session,
+    }
+    const source = createStore({}, {
+      session: [
+        { id: "session-a", directory: "/test/project", time: { created: 1 } } as Session,
+        { id: "session-b", directory: "/test/project", time: { created: 1 } } as Session,
+        { id: "session-c", directory: "/test/project", time: { created: 1 } } as Session,
+      ],
+    })
+    const { switchRuntimeEndpoint } = await import("../lib/runtime-switch")
+    switchRuntimeEndpoint({ apiBaseUrl: "http://archive-batch-a.test", runtimeKey: "archive-batch-a" })
+    beforeSessionUpdateResolve = (sessionId) => {
+      if (sessionId === "session-b") {
+        switchRuntimeEndpoint({ apiBaseUrl: "http://archive-batch-b.test", runtimeKey: "archive-batch-b" })
+      }
+    }
+    const { archiveSessions, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/test/project", source]]), () => "/test/project")
+
+    const result = await archiveSessions(["session-a", "session-b", "session-c"], {
+      expectedRuntimeKey: "archive-batch-a",
+    })
+
+    // session-a was confirmed before the switch and stays archived; session-b's
+    // response is stale and session-c is never attempted, so both are reported
+    // as failures instead of being silently dropped.
+    expect(result).toEqual({ archivedIds: ["session-a"], failedIds: ["session-b", "session-c"] })
+    expect(source.getState().session.map((item) => item.id)).toEqual(["session-b", "session-c"])
+    expect(globalUpsertedSessions).toHaveLength(1)
+    // session-c must not reach the SDK after the runtime changed.
+    expect(replyCalls.filter((call) => call.method === "session.update").map((call) => call.params.sessionID))
+      .toEqual(["session-a", "session-b"])
+  })
+
+  test("archives every session when the runtime stays stable", async () => {
+    sessionUpdateResult = {
+      data: { id: "session-a", directory: "/test/project", time: { created: 1, archived: 2 } } as Session,
+    }
+    const source = createStore({}, {
+      session: [
+        { id: "session-a", directory: "/test/project", time: { created: 1 } } as Session,
+        { id: "session-b", directory: "/test/project", time: { created: 1 } } as Session,
+      ],
+    })
+    const { getRuntimeKey } = await import("../lib/runtime-switch")
+    const { archiveSessions, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/test/project", source]]), () => "/test/project")
+
+    const result = await archiveSessions(["session-a", "session-b"], {
+      expectedRuntimeKey: getRuntimeKey(),
+    })
+
+    expect(result).toEqual({ archivedIds: ["session-a", "session-b"], failedIds: [] })
+    expect(source.getState().session).toEqual([])
   })
 })
 

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -654,15 +654,29 @@ export async function createSession(
   }
 }
 
+/**
+ * True when a caller captured a runtime key before an asynchronous mutation and
+ * that runtime is no longer the active one. Callers pass `undefined` when they
+ * do not participate in runtime-scoped guarding, which keeps the previous
+ * unguarded behavior.
+ */
+function isStaleRuntime(expectedRuntimeKey: string | undefined): boolean {
+  return expectedRuntimeKey !== undefined && getRuntimeKey() !== expectedRuntimeKey
+}
+
 export async function patchSessionMetadata(
   sessionId: string,
   directory: string | null | undefined,
   updater: (metadata: SessionMetadataRecord) => SessionMetadataRecord,
+  expectedRuntimeKey?: string,
 ): Promise<Session> {
+  if (isStaleRuntime(expectedRuntimeKey)) throw new Error("runtime changed")
   const targetDirectory = directory ?? getSessionDirectory(sessionId)
   const current = await opencodeClient.getSession(sessionId, targetDirectory)
+  if (isStaleRuntime(expectedRuntimeKey)) throw new Error("runtime changed")
   const nextMetadata = updater(getSessionMetadata(current))
   const updated = await opencodeClient.updateSession(sessionId, { metadata: nextMetadata }, targetDirectory)
+  if (isStaleRuntime(expectedRuntimeKey)) throw new Error("runtime changed")
   useGlobalSessionsStore.getState().upsertSession(updated)
   const sessionDirectory = (updated as { directory?: string | null }).directory ?? targetDirectory
   if (sessionDirectory) registerSessionDirectory(updated.id, sessionDirectory)
@@ -682,19 +696,26 @@ export async function setContextObligatoryMessage(
   return updated
 }
 
-async function cleanupReviewMetadataBeforeDelete(sessionId: string, directory?: string | null): Promise<void> {
+async function cleanupReviewMetadataBeforeDelete(
+  sessionId: string,
+  directory?: string | null,
+  expectedRuntimeKey?: string,
+): Promise<void> {
+  if (isStaleRuntime(expectedRuntimeKey)) return
   let session: Session
   try {
     session = await opencodeClient.getSession(sessionId, directory ?? getSessionDirectory(sessionId))
   } catch {
     return
   }
+  if (isStaleRuntime(expectedRuntimeKey)) return
   if (!isReviewSession(session)) return
   const originalSessionID = getOriginalSessionID(session)
   if (!originalSessionID) return
   try {
     await patchSessionMetadata(originalSessionID, directory ?? getSessionDirectory(originalSessionID), (metadata) =>
       withoutReviewSessionLink(metadata, sessionId),
+      expectedRuntimeKey,
     )
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -803,12 +824,26 @@ export async function deleteSessionInDirectory(sessionId: string, directory: str
   }
 }
 
-export async function archiveSession(sessionId: string): Promise<boolean> {
+/**
+ * Archive one session.
+ *
+ * `expectedRuntimeKey` is the runtime key the caller captured when the user
+ * confirmed the operation. When it is supplied and the runtime changes, the
+ * action stops and returns `false` without reconciling any store, so a response
+ * produced by the previous runtime cannot mutate the current runtime's live or
+ * global session state. A session the server already archived before the switch
+ * stays archived on that runtime and is re-read from the server the next time
+ * the runtime is loaded.
+ */
+export async function archiveSession(sessionId: string, expectedRuntimeKey?: string): Promise<boolean> {
+  if (isStaleRuntime(expectedRuntimeKey)) return false
   const sessionDirectory = getSessionDirectory(sessionId)
   const archivedAt = Date.now()
   try {
-    await cleanupReviewMetadataBeforeDelete(sessionId, sessionDirectory)
+    await cleanupReviewMetadataBeforeDelete(sessionId, sessionDirectory, expectedRuntimeKey)
+    if (isStaleRuntime(expectedRuntimeKey)) return false
     const archived = await opencodeClient.updateSession(sessionId, { time: { archived: archivedAt } }, sessionDirectory)
+    if (isStaleRuntime(expectedRuntimeKey)) return false
     if (!archived) {
       throw new Error("session.update failed: server did not return the archived session")
     }
@@ -822,6 +857,45 @@ export async function archiveSession(sessionId: string): Promise<boolean> {
     console.error("[session-actions] archiveSession failed", error)
     return false
   }
+}
+
+export type ArchiveSessionsOptions = {
+  /**
+   * Runtime key captured when the batch was confirmed. When supplied, the batch
+   * stops as soon as the active runtime differs.
+   */
+  expectedRuntimeKey?: string
+}
+
+/**
+ * Archive several sessions sequentially, preserving partial results.
+ *
+ * One failed session never blocks or erases the others: it is reported in
+ * `failedIds` while the remaining IDs are still attempted. When
+ * `expectedRuntimeKey` is supplied and the runtime changes mid-batch, the
+ * already-confirmed sessions stay in `archivedIds` and every ID that was not
+ * confirmed on the captured runtime is reported in `failedIds`, so callers keep
+ * showing the existing partial-failure feedback instead of silently dropping
+ * work.
+ */
+export async function archiveSessions(
+  ids: string[],
+  options?: ArchiveSessionsOptions,
+): Promise<{ archivedIds: string[]; failedIds: string[] }> {
+  const archivedIds: string[] = []
+  const failedIds: string[] = []
+  const expectedRuntimeKey = options?.expectedRuntimeKey
+
+  for (const [index, id] of ids.entries()) {
+    if (isStaleRuntime(expectedRuntimeKey)) {
+      failedIds.push(...ids.slice(index))
+      break
+    }
+    if (await archiveSession(id, expectedRuntimeKey)) archivedIds.push(id)
+    else failedIds.push(id)
+  }
+
+  return { archivedIds, failedIds }
 }
 
 export async function updateSessionTitle(sessionId: string, title: string): Promise<void> {

--- a/packages/ui/src/sync/session-ui-store.test.js
+++ b/packages/ui/src/sync/session-ui-store.test.js
@@ -454,3 +454,33 @@ describe('routeMessage skill invocation', () => {
     expect(sendCommandCalls).toHaveLength(0);
   });
 });
+
+describe('archiveSessions option forwarding', () => {
+  let originalUpdateSession;
+  let updateSessionCalls;
+
+  beforeEach(() => {
+    updateSessionCalls = [];
+    originalUpdateSession = opencodeClient.updateSession;
+    opencodeClient.updateSession = (sessionId) => {
+      updateSessionCalls.push(sessionId);
+      return Promise.resolve(null);
+    };
+  });
+
+  afterEach(() => {
+    opencodeClient.updateSession = originalUpdateSession;
+  });
+
+  // The store used to accept an options object and silently drop it, so a
+  // caller-supplied runtime key had no effect. Passing a key that cannot match
+  // the active runtime must abort the batch before any SDK call.
+  test('honors expectedRuntimeKey instead of discarding the options object', async () => {
+    const result = await useSessionUIStore.getState().archiveSessions(['session-x', 'session-y'], {
+      expectedRuntimeKey: 'runtime-that-is-not-active',
+    });
+
+    expect(result).toEqual({ archivedIds: [], failedIds: ['session-x', 'session-y'] });
+    expect(updateSessionCalls).toEqual([]);
+  });
+});

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -47,6 +47,7 @@ import {
   createSession as createSessionAction,
   deleteSession as deleteSessionAction,
   archiveSession as archiveSessionAction,
+  archiveSessions as archiveSessionsAction,
   updateSessionTitle as updateSessionTitleAction,
   shareSession as shareSessionAction,
   unshareSession as unshareSessionAction,
@@ -56,6 +57,7 @@ import {
   unrevertSession as unrevertSessionAction,
   forkFromMessage as forkFromMessageAction,
   fetchMessagesForSession,
+  type ArchiveSessionsOptions,
 } from "./session-actions"
 import { useInputStore, type SyntheticContextPart } from "./input-store"
 import { useSessionGoalArmStore } from "@/stores/useSessionGoalArmStore"
@@ -323,7 +325,7 @@ export type SessionUIState = {
   deleteSession: (id: string, options?: Record<string, unknown>) => Promise<boolean>
   deleteSessions: (ids: string[], options?: Record<string, unknown>) => Promise<{ deletedIds: string[]; failedIds: string[] }>
   archiveSession: (id: string) => Promise<boolean>
-  archiveSessions: (ids: string[], options?: Record<string, unknown>) => Promise<{ archivedIds: string[]; failedIds: string[] }>
+  archiveSessions: (ids: string[], options?: ArchiveSessionsOptions) => Promise<{ archivedIds: string[]; failedIds: string[] }>
   updateSessionTitle: (sessionId: string, title: string) => Promise<void>
   shareSession: (sessionId: string) => Promise<Session | null>
   unshareSession: (sessionId: string) => Promise<Session | null>
@@ -1304,16 +1306,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
 
   archiveSession: (id) => archiveSessionAction(id),
 
-  archiveSessions: async (ids) => {
-    const archivedIds: string[] = []
-    const failedIds: string[] = []
-    for (const id of ids) {
-      const ok = await archiveSessionAction(id)
-      if (ok) archivedIds.push(id)
-      else failedIds.push(id)
-    }
-    return { archivedIds, failedIds }
-  },
+  archiveSessions: (ids, options) => archiveSessionsAction(ids, options),
 
   // ---------------------------------------------------------------------------
   // updateSessionTitle — calls SDK, SSE event updates child store


### PR DESCRIPTION
## Intent

`useSessionUIStore.archiveSessions` declared `options?: Record<string, unknown>` and its implementation was `async (ids) => {...}` — the options object was accepted by the type and silently discarded. Any caller passing a captured runtime key got a mute no-op rather than a guarded batch.

The archive path also never rechecked the runtime after its asynchronous SDK calls. `archiveSession()` awaits `cleanupReviewMetadataBeforeDelete()` and `session.update`, then unconditionally calls `removeSessionFromLiveStores()`, `invalidateSessionLoads()`, `upsertSession()` and may clear `currentSessionId`. If the user switched runtime while those calls were in flight, a response produced by the previous runtime reconciled the live and global session stores of the runtime the user had switched to.

This PR makes the batch a canonical action and gives the archive path an opt-in runtime guard:

- new `archiveSessions(ids, options)` in `session-actions.ts`, so `session-ui-store.ts` delegates instead of duplicating the loop;
- optional `expectedRuntimeKey` on `archiveSession()`, `patchSessionMetadata()` and `cleanupReviewMetadataBeforeDelete()`, rechecked before every store reconciliation;
- the store option typed as `ArchiveSessionsOptions` instead of `Record<string, unknown>`, because the loose type is what allowed the drop to pass review and type-check.

Callers that pass no runtime key keep exactly their previous behavior.

This defect is **not mobile-specific**. It is reachable from every bulk archive caller: `components/layout/Header.tsx:1471`, `components/session/SessionDialogs.tsx:449`, `components/layout/VSCodeLayout.tsx:324`, `components/session/sidebar/hooks/useSidebarBulkActions.ts:184`, `components/session/sidebar/hooks/useSessionActions.ts:246`, and `apps/MobileDeleteWorktreeDialog.tsx:127`.

Origin: this is the sync-layer part of #2557, extracted and rewritten on current `main`. #2557 targeted `MobileSessionStatusBar.tsx`, which #2561 deleted, and was based on a pre-#2561 tree. #2557 will be closed in favor of this PR. The mobile UI behavior it proposed (two-step confirmation, subtree cascade) is deliberately **not** included here.

## Non-goals

- No mobile UI change. No archive affordance, confirmation pattern, or layout change on any surface.
- No archive cascade over a session subtree, and no descendant collection.
- No cross-surface in-flight/duplicate-confirmation guard.
- No change to the desktop/VS Code archive controls, dialogs, toasts, ordering, or filtering.
- No new user-facing copy or locale keys.
- No change to `deleteSession`/`deleteSessions`, which have the same ignored-`options` shape. Fixing them is a separate, independently reviewable change.
- No backend, route, transport, or SDK contract change.
- No runtime key is passed by any caller in this PR. It adds the mechanism and its contract; adopting it in a specific surface is follow-up work.

## Affected surfaces

- `packages/ui/src/sync/session-actions.ts`: new exported `archiveSessions()` and `ArchiveSessionsOptions`, optional `expectedRuntimeKey` parameter on three functions, and a module-private `isStaleRuntime()` helper.
- `packages/ui/src/sync/session-ui-store.ts`: `archiveSessions` delegates to the action; its option type narrows from `Record<string, unknown>` to `ArchiveSessionsOptions`.
- Shared UI, so web, Electron desktop, VS Code, hosted mobile and Capacitor mobile all consume it. Behavior is identical on all of them: no caller passes `expectedRuntimeKey` yet, so the guard is inert and every existing call site keeps its current archive behavior, byte for byte in outcome.
- No user-visible state, persisted schema, server route, transport, authentication, dependency, generated asset, or public package entrypoint changes.
- Type-contract note: `archiveSessions` narrows an option type. All six store callers pass only `ids`, and the two hook prop types that redeclare it (`useSessionActions.ts:42`, `useSidebarBulkActions.ts:20`) declare `(ids: string[]) => Promise<...>`, which a function with an extra optional parameter still satisfies. `useGlobalSessionsStore.archiveSessions(ids, archivedAt?)` is a different, untouched function.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` — correctness invariants | The change is in core sync logic and touches partial-failure and stale-data behavior | Prefers authoritative state: no store is reconciled until the server confirms and the captured runtime is still active. Partial results, rollback and stale-data behavior are made explicit in code, docs and tests. One failed session neither erases nor blocks unrelated confirmed sessions. |
| Root `AGENTS.md` — thin entrypoints, owning modules | The batch loop lived in the store | The loop moves into `session-actions.ts`, the documented canonical owner of SDK-calling session mutations that affect global session lists; the store becomes a one-line delegation. |
| `packages/ui/src/sync/DOCUMENTATION.md` — "Session action rules" | Rule 3 says `session-ui-store.ts` should delegate to `session-actions.ts` instead of duplicating SDK calls; rule 1 requires the action to update `useGlobalSessionsStore` | The duplicated loop is removed and the archive batch now lives with the other canonical actions. The document's action list and the new runtime-guard contract were updated in the same commit, since the implementation changed that section's truth. |
| `sync-state-invariants` — "Reject stale async/event completions" | The archive path spans multiple awaits and then mutates live + global stores | The captured runtime key is rechecked immediately before each reconciliation point, so an obsolete completion is rejected rather than committed. |
| `sync-state-invariants` — "Failure is not empty" / partial results | The batch reports results to callers that drive destructive UI feedback | A runtime switch never returns a falsely successful or falsely empty result: confirmed IDs stay in `archivedIds`, unconfirmed IDs are returned in `failedIds`, and no ID silently disappears from both lists. |
| `sync-state-invariants` — verification checklist ("archive … runtime or worktree switch") | The skill explicitly requires covering archive under a runtime switch | Added tests for a stale single-session archive response, a mid-batch runtime switch, and the stable-runtime batch, plus a store-level test for option forwarding. |
| `openchamber-change-discipline` — smallest complete change, module contract risk | An exported module contract changes and consumers exist | Scope kept to the archive path; every consumer was traced and listed above; the new export is consumed, `bun run dead-code` was run because export shape changed, and the owning documentation was updated. |
| `openchamber-change-discipline` — test design | Destructive and failure-sensitive path | Tests assert observable contracts (returned ID partition, live-store contents, global upserts, and which session IDs reached the SDK) rather than internal structure. Each new test was confirmed to fail against the unguarded implementation. |
| `ui-api-decoupling` | The mutation calls the official OpenCode session API | Continues to go through `opencodeClient` inside the canonical action. No raw feature fetch, hardcoded runtime URL, bridge, proxy, or new runtime capability. |
| `locale-ui-patterns`, `theme-system` | Considered and found not to apply | No user-facing string, label, icon, token, or component is touched. |

## Validation

All commands run from the repository root on Linux, at commit `9e5751f0f`, with `bun 1.3.8`.

| Check | Result |
|---|---|
| `bun test packages/ui/src/sync/session-actions.test.ts` | **40 pass, 0 fail, 182 expect() calls.** Up from 38 pass on `main`. The stderr output is the expected error-path logging from the pre-existing negative delete/archive tests. |
| `bun test packages/ui/src/sync/session-ui-store.test.js` | **19 pass, 3 fail.** The 3 failures (`routeMessage skill invocation > …`) reproduce identically on unmodified `main` (18 pass, 3 fail) and are unrelated to this change. The new `archiveSessions option forwarding` test passes. |
| `bun test packages/ui/src/sync/` (whole module, regression sweep) | **349 pass, 15 fail, 364 tests.** Baseline on unmodified `main`: **345 pass, 15 fail, 360 tests**. The two failure lists were diffed and are identical test-for-test, so this change adds 4 passing tests and introduces no regression. The 15 failures are pre-existing (`createEventPipeline`, `issue 2039 draft auto-accept`, `cleanupPersistedSessionState`, `routeMessage skill invocation`). |
| Mutation check — guard neutralized (`isStaleRuntime` forced to `return false`) | Both new `session-actions` tests **fail**, confirming they exercise the guard and are not vacuous. Source restored and byte-identical afterwards. |
| Mutation check — store delegation reverted to the old `async (ids) => …` loop | The new store test **fails** on `expect(updateSessionCalls).toEqual([])`, confirming it detects the dropped `options`. Source restored and byte-identical afterwards. |
| `bun run type-check:ui` | **Passed, exit 0, no errors.** Covers every call site of the three changed signatures and the narrowed store option type. |
| `bun run lint:ui` | **Passed, exit 0, no errors.** |
| `bun run dead-code` | **Exit 0.** Report diffed against a baseline run on unmodified `main`: both are 509 lines and the finding set is identical — the only differences are shifted line numbers for pre-existing findings (`deleteSessionInDirectory`, `session-ui-store` types). No new file, export, or type finding. `ArchiveSessionsOptions` and `archiveSessions` are not reported, since both are consumed by `session-ui-store.ts`. |
| `git diff --check` | Passed, no whitespace errors. |

**Not validated.** No runtime, browser, or device execution was performed, so nothing here demonstrates real runtime behavior — the runtime-switch scenario is proven only at unit level with a simulated `switchRuntimeEndpoint` during an in-flight SDK call, not against a live server with two real runtimes. No Electron, VS Code extension host, hosted mobile, or Capacitor/native run was made; native iOS/Android validation was not possible because this host is Linux and `serve-sim` requires macOS/Xcode. No workspace-wide type-check, lint, or build was run: the change is confined to `packages/ui/src/sync` and no cross-workspace contract, dependency, lockfile, or generated asset is touched. No performance measurement was taken; the batch remains sequential with one added string comparison per session. The 15 pre-existing `packages/ui/src/sync` failures were confirmed to pre-exist but were not investigated or fixed.

## Visual evidence

None, and none is possible: this change cannot alter rendered output.

Concretely, the diff touches only `packages/ui/src/sync/session-actions.ts` and `packages/ui/src/sync/session-ui-store.ts`. It contains no JSX, no component, no CSS, no theme token, no icon, and no locale key. It adds no new user-facing string and removes none.

More importantly, the new behavior is unreachable in this PR: the guard activates only when a caller passes `expectedRuntimeKey`, and **no caller passes it**. All six existing `archiveSessions` call sites invoke `archiveSessions(ids)`, so `options` is `undefined`, `isStaleRuntime()` returns `false` at every checkpoint, and the executed path is identical to `main`. The returned `{ archivedIds, failedIds }` shape is unchanged, so the existing archive/failure toasts, dialogs, list removal, and sidebar behavior render exactly as before. The visible surface only changes once a follow-up wires a captured runtime key into a specific caller, and that PR is where before/after captures belong.

## Risks and failure behavior

- **Partial failure.** The batch stays sequential and per-ID. A single failed session is reported in `failedIds` and the remaining IDs are still attempted, so one failure never blocks or erases unrelated confirmed work. This is unchanged from the previous loop.
- **Runtime switch mid-batch — what the user observes.** Sessions the server already confirmed before the switch stay archived and remain in `archivedIds`. Every ID not confirmed on the captured runtime — the one in flight during the switch plus the ones never attempted — is returned in `failedIds`. Callers therefore keep showing their existing partial-result feedback, for example "Archived 2 sessions" together with "Failed to archive 3 sessions", instead of silently dropping the remainder. This is deliberately conservative: reporting unconfirmed work as failed is safer than implying success.
- **Known imprecision, accepted.** If the switch happens after the server archived a session but before the response is reconciled, that ID is reported as failed even though the server did archive it. The alternative — reconciling it — would mutate the wrong runtime's stores, which is the bug being fixed. The session stays archived on its own runtime and is re-read authoritatively the next time that runtime is loaded, so no state is lost or corrupted; only the transient toast count can understate success.
- **No optimistic state to roll back.** Nothing is removed from any store before the server returns the archived session, so an aborted or rejected archive leaves the row active and needs no cleanup. A guarded early return performs no store mutation at all.
- **Stale reconciliation.** `patchSessionMetadata` throws `"runtime changed"` instead of returning a value, because it must return a `Session`. Only `cleanupReviewMetadataBeforeDelete` passes a runtime key to it today, and that call is already inside a `try/catch` that logs and continues, so a review-metadata cleanup aborted by a runtime switch degrades to a skipped cleanup rather than a failed archive.
- **Backward compatibility.** Every parameter added is optional and every existing caller omits it, so behavior on `main`'s call sites is unchanged. The store's option type narrows rather than widens; `bun run type-check:ui` passes, which is the compile-time proof that no consumer relied on the previous `Record<string, unknown>`.
- **Security and data.** No secret, token, directory path, session content, or runtime key is logged. The existing `console.error` in `archiveSession` is untouched, and guarded early returns log nothing.
- **Performance.** One string comparison per session plus one per reconciliation checkpoint. No new allocation per item, no added request, no change to concurrency.
- **Rollback.** Plain code revert; there is no migration, persisted-state change, or API change. Sessions archived by an explicit user confirmation stay archived, as before.
- **Residual risk.** The guard's correctness under a real concurrent runtime switch is demonstrated by unit tests with a simulated in-flight switch, not by live multi-runtime execution. See the "Not validated" note above.
