### PR TITLE
fix(web): prevent server crash when Reveal in Finder opener is missing

### DIFF
--- a/packages/web/server/lib/fs/DOCUMENTATION.md
+++ b/packages/web/server/lib/fs/DOCUMENTATION.md
@@ -35,3 +35,4 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 ## Notes for contributors
 - Keep filesystem policy (workspace root checks, error mapping, exec timeout behavior) inside this module, not in the composition root.
 - If adding new `/api/fs/*` endpoints, add them in `routes.js` and extend this document.
+- `POST /api/fs/reveal` must await opener launch (or attach spawn error handlers) before responding. Missing openers such as `xdg-open` on headless hosts return HTTP 500 JSON errors; spawn failures must never become uncaught exceptions that tear down the server.

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -1124,6 +1124,37 @@ export const registerFsRoutes = (app, dependencies) => {
     }
   });
 
+  const awaitDetachedRevealSpawn = (command, args) => new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (callback) => (value) => {
+      if (settled) return;
+      settled = true;
+      callback(value);
+    };
+
+    let child;
+    try {
+      child = spawn(command, args, {
+        windowsHide: true,
+        stdio: 'ignore',
+        detached: true,
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    child.once('error', settle(reject));
+    child.once('spawn', settle(() => {
+      try {
+        child.unref();
+      } catch {
+        // Best-effort: reveal already launched.
+      }
+      resolve();
+    }));
+  });
+
   app.post('/api/fs/reveal', async (req, res) => {
     const { path: targetPath } = req.body || {};
     if (!targetPath || typeof targetPath !== 'string') {
@@ -1138,9 +1169,9 @@ export const registerFsRoutes = (app, dependencies) => {
       if (platform === 'darwin') {
         const stat = await fsPromises.stat(resolved);
         if (stat.isDirectory()) {
-          spawn('open', [resolved], { windowsHide: true, stdio: 'ignore', detached: true }).unref();
+          await awaitDetachedRevealSpawn('open', [resolved]);
         } else {
-          spawn('open', ['-R', resolved], { windowsHide: true, stdio: 'ignore', detached: true }).unref();
+          await awaitDetachedRevealSpawn('open', ['-R', resolved]);
         }
       } else if (platform === 'win32') {
         const stat = await fsPromises.stat(resolved);
@@ -1164,13 +1195,19 @@ export const registerFsRoutes = (app, dependencies) => {
       } else {
         const stat = await fsPromises.stat(resolved);
         const dir = stat.isDirectory() ? resolved : path.dirname(resolved);
-        spawn('xdg-open', [dir], { windowsHide: true, stdio: 'ignore', detached: true }).unref();
+        await awaitDetachedRevealSpawn('xdg-open', [dir]);
       }
 
       return res.json({ success: true, path: resolved });
     } catch (error) {
       const err = error;
-      if (err && typeof err === 'object' && err.code === 'ENOENT') {
+      const isSpawnFailure = Boolean(
+        err
+        && typeof err === 'object'
+        && typeof err.syscall === 'string'
+        && err.syscall.startsWith('spawn')
+      );
+      if (err && typeof err === 'object' && err.code === 'ENOENT' && !isSpawnFailure) {
         return res.status(404).json({ error: 'Path not found' });
       }
       console.error('Failed to reveal path:', error);

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -200,6 +200,52 @@ const registerMkdir = (fsPromises) => {
   return getRoute('POST', '/api/fs/mkdir');
 };
 
+const registerReveal = ({ spawn, fsPromises }) => {
+  const { app, getRoute } = createRouteRegistry();
+  registerFsRoutes(app, {
+    os: { homedir: () => '/home/user' },
+    path: path.posix,
+    fsPromises: {
+      realpath: async (targetPath) => targetPath,
+      access: async () => undefined,
+      stat: async () => ({ isDirectory: () => false }),
+      ...fsPromises,
+    },
+    spawn,
+    crypto: { randomUUID: () => 'job-0' },
+    normalizeDirectoryPath: (p) => p,
+    resolveProjectDirectory: async () => ({ directory: '/repo' }),
+    buildAugmentedPath: () => '/usr/bin',
+    resolveGitBinaryForSpawn: () => 'git',
+    openchamberUserConfigRoot: '/home/user/.config',
+  });
+  return getRoute('POST', '/api/fs/reveal');
+};
+
+const createDetachedRevealSpawn = ({ mode = 'spawn' } = {}) => {
+  const calls = [];
+  const spawn = vi.fn((command, args) => {
+    calls.push({ command, args });
+    const child = new EventEmitter();
+    child.unref = vi.fn();
+    queueMicrotask(() => {
+      if (mode === 'error') {
+        const error = Object.assign(new Error('Executable not found in $PATH: "xdg-open"'), {
+          code: 'ENOENT',
+          errno: -2,
+          path: command,
+          syscall: `spawn ${command}`,
+        });
+        child.emit('error', error);
+        return;
+      }
+      child.emit('spawn');
+    });
+    return child;
+  });
+  return { spawn, calls };
+};
+
 const callExec = async (handler, body) => {
   const res = createMockResponse();
   await handler({ body }, res);
@@ -225,6 +271,12 @@ const callRaw = async (handler, query) => {
 };
 
 const callMkdir = async (handler, body) => {
+  const res = createMockResponse();
+  await handler({ body }, res);
+  return res;
+};
+
+const callReveal = async (handler, body) => {
   const res = createMockResponse();
   await handler({ body }, res);
   return res;
@@ -594,6 +646,67 @@ describe('fs exec git-read cache', () => {
     await callExec(handler, { commands: [command], cwd: '/repo/worktree-499' }); // cached  -> no spawn
 
     expect(calls.length).toBe(afterFill + 2);
+  });
+});
+
+describe('fs reveal', () => {
+  let platformSpy;
+
+  afterEach(() => {
+    platformSpy?.mockRestore();
+    platformSpy = undefined;
+  });
+
+  it('returns 500 when linux opener is missing instead of crashing', async () => {
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    const { spawn, calls } = createDetachedRevealSpawn({ mode: 'error' });
+    const handler = registerReveal({ spawn });
+
+    const res = await callReveal(handler, { path: '/repo/design' });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      error: 'Executable not found in $PATH: "xdg-open"',
+    });
+    expect(calls).toEqual([{ command: 'xdg-open', args: ['/repo'] }]);
+  });
+
+  it('reveals a linux directory with xdg-open after spawn succeeds', async () => {
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    const { spawn, calls } = createDetachedRevealSpawn({ mode: 'spawn' });
+    const handler = registerReveal({
+      spawn,
+      fsPromises: {
+        access: vi.fn(async () => undefined),
+        stat: vi.fn(async () => ({ isDirectory: () => true })),
+      },
+    });
+
+    const res = await callReveal(handler, { path: '/repo/design' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ success: true, path: '/repo/design' });
+    expect(calls).toEqual([{ command: 'xdg-open', args: ['/repo/design'] }]);
+  });
+
+  it('returns 404 when the target path does not exist', async () => {
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    const { spawn } = createDetachedRevealSpawn({ mode: 'spawn' });
+    const missing = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    const handler = registerReveal({
+      spawn,
+      fsPromises: {
+        access: vi.fn(async () => {
+          throw missing;
+        }),
+      },
+    });
+
+    const res = await callReveal(handler, { path: '/repo/missing' });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: 'Path not found' });
+    expect(spawn).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes openchamber/openchamber#735

## Intent

Clicking **Reveal in Finder / File Manager** against a headless or Docker host without `xdg-open` (or a similar opener) spawned the opener with no error handler. The resulting `ENOENT` became an uncaught exception and shut down the OpenChamber server.

This change awaits detached reveal spawn success/failure on Darwin/Linux so missing openers return HTTP 500 JSON, matching the Windows path's existing error handling. The existing UI toast path continues to surface the failure.

## Non-goals

- Hiding or disabling the Reveal action for remote/headless sessions
- Installing or bundling a desktop opener in Docker images
- Changing Electron IPC `desktop_reveal_path` behavior

## Affected surfaces

- `packages/web` server: `POST /api/fs/reveal`
- Desktop Web / hosted web (including Docker/headless Linux) that use the shared web files API
- Electron is unaffected for its IPC reveal path; if Electron uses the same HTTP route, it now also fails closed instead of crashing
- VS Code uses `api:fs:reveal` via the extension host and is unaffected

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` / OpenChamber change discipline | Source change in web server FS module | Smallest complete fix in owning module; focused tests; owning docs updated for the failure invariant |
| `ui-api-decoupling` | OpenChamber server API route `/api/fs/reveal` | Kept route behavior explicit; authoritative failure remains a non-OK response (no empty success) |
| `packages/web/server/lib/fs/DOCUMENTATION.md` | Nearest owning docs for FS routes | Documented that reveal must await spawn / handle errors and must not crash the process |

## Validation

| Check | Result |
|---|---|
| `bun run test -- server/lib/fs/routes.test.js` (in `packages/web`) | Passed (26 tests), including new reveal missing-opener / success / 404 cases |
| `node --check server/lib/fs/routes.js` + module import | Passed |
| Package `lint:web` / `type-check:web` | Not run — change is server JS outside the web `src/**/*.{ts,tsx}` lint/type-check surface |
| Manual Docker/headless click of Reveal | Not verified in this cloud environment; still recommended on a host without `xdg-open` |

## Visual evidence

No rendered UI change. Failure still surfaces through the existing reveal-failed toast once the API returns an error instead of killing the process.

## Risks and failure behavior

- Missing opener (`xdg-open` / `open`) now returns HTTP 500 with the spawn error message; path-missing `ENOENT` remains 404 and is distinguished from spawn `ENOENT` via `syscall`.
- Successful spawn still returns `{ success: true }` without waiting for the GUI process to exit (correct for detached openers that stay open).
- If an opener spawns but cannot show a UI (for example no `DISPLAY`), the server stays up; the client may still show success because launch itself succeeded. That case was already possible and is outside this crash fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e6d8d42-48ed-4f63-8a61-c261fc39fde2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e6d8d42-48ed-4f63-8a61-c261fc39fde2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

