### PR TITLE
fix(sync): guard delete actions by default

### DIFF
--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -214,18 +214,41 @@ Examples of global-store updates performed in `session-actions.ts`:
 - `updateSessionTitle()` -> `upsertSession(result.data)`
 - `shareSession()` / `unshareSession()` -> `upsertSession(result.data)`
 - `archiveSession()` / `archiveSessions()` -> wait for server confirmation, then upsert each archived session
-- `deleteSession()` -> waits for server confirmation or `404`, then removes the session and its persisted state
+- `deleteSession()` / `deleteSessions()` -> wait for server confirmation or `404`, then remove the session and its persisted state
 - `moveSessionToDirectory()` -> move the session between directory stores and update the global directory index
 
-Archive actions capture the active runtime key when they start and recheck it
-before every store reconciliation, so a response
+Archive and delete actions capture the active runtime key when they start and
+recheck it before every store reconciliation, so a response
 produced by the previous runtime is rejected instead of mutating the current
 runtime's live or global session state. A guarded batch stops at the first
 observed runtime change: sessions the server already confirmed remain archived
-and stay in `archivedIds`, while every ID not confirmed on the captured runtime
-is returned in `failedIds` so existing partial-failure feedback stays truthful.
+or deleted and stay in `archivedIds`/`deletedIds`, while every ID not confirmed
+on the captured runtime is returned in `failedIds` so existing partial-failure
+feedback stays truthful.
 Callers whose confirmation can span a runtime switch may pass an
 `expectedRuntimeKey` captured earlier; ordinary callers are guarded by default.
+
+Deletion needs this guard more than archiving does. Session IDs are not unique
+across runtimes, and a committed deletion does more than hide a row: it evicts
+the session from every live store, removes it from the global cache, clears the
+current-session pointer, and calls `cleanupPersistedSessionState`, which erases
+that session's queued messages, todos, folder membership, inline-comment drafts,
+chat draft, and pins. Committing a stale deletion can therefore destroy user
+state belonging to an unrelated session on the new runtime.
+
+`cleanupPersistedSessionState` already refuses an identity whose runtime is no
+longer active, so `finalizeConfirmedSessionDeletion` must forward the **captured**
+runtime key. Passing the live key would make that check compare a value with
+itself and always pass. The in-memory live, global, and UI stores it mutates are
+not runtime-scoped, so the calling action must reject a stale runtime before
+committing rather than relying on that helper alone.
+
+A `404` still means "already deleted" and commits cleanup, but only while the
+captured runtime is active. After a runtime change the `404` describes either
+the previous runtime or one this session never belonged to, so the action
+reports failure instead of committing. The deletion already accepted by the
+server stays deleted there; its persisted state is left as harmless stale
+metadata and the next authoritative load reconciles it.
 
 ## The golden rule
 

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -15,6 +15,7 @@ let sessionUpdateResult: { data?: unknown; error?: unknown; response?: { status?
 let sessionMessagesResult: { data?: unknown; error?: unknown; response?: { status?: number } } = { data: [] }
 let sessionDeleteError: unknown | null = null
 let beforeSessionUpdateResolve: ((sessionId: string) => void) | null = null
+let beforeSessionDeleteResolve: ((sessionId: string) => void) | null = null
 const globalUpsertedSessions: unknown[] = []
 const globalRemovedSessionIds: string[] = []
 const deletedCleanupIdentities: Array<{ runtimeKey: string; directory: string; sessionId: string }> = []
@@ -153,6 +154,9 @@ mock.module("@/lib/opencode/client", () => ({
     }),
     deleteSession: mock((sessionId: string, directory?: string | null) => {
       replyCalls.push({ method: "session.delete", params: { sessionID: sessionId, directory } })
+      // Lets a test switch runtime while the delete is in flight, so the action
+      // observes the change only after awaiting (or catching) the response.
+      beforeSessionDeleteResolve?.(sessionId)
       if (sessionDeleteError) throw sessionDeleteError
       return Promise.resolve(true)
     }),
@@ -373,6 +377,7 @@ describe("confirmed session removal", () => {
     sessionDeleteError = null
     sessionUpdateResult = {}
     beforeSessionUpdateResolve = null
+    beforeSessionDeleteResolve = null
   })
 
   test("does not remove live or persisted state when delete fails", async () => {
@@ -404,6 +409,107 @@ describe("confirmed session removal", () => {
       directory: deletedCleanupIdentities[0]?.directory,
       sessionId: deletedCleanupIdentities[0]?.sessionId,
     }).toEqual({ directory: "/test/project", sessionId: "session-a" })
+  })
+
+  test("scopes persisted cleanup to the runtime captured when the delete started", async () => {
+    const source = createStore({}, {
+      session: [{ id: "session-a", directory: "/test/project", time: { created: 1 } } as Session],
+    })
+    const { getRuntimeKey, switchRuntimeEndpoint } = await import("../lib/runtime-switch")
+    switchRuntimeEndpoint({ apiBaseUrl: "http://delete-scope.test", runtimeKey: "delete-scope" })
+    const { deleteSession, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/test/project", source]]), () => "/test/project")
+
+    expect(await deleteSession("session-a")).toBe(true)
+    // The cleanup identity must carry the captured runtime, which is what lets
+    // cleanupPersistedSessionState reject a stale identity instead of comparing
+    // the live runtime key with itself.
+    expect(deletedCleanupIdentities[0]?.runtimeKey).toBe("delete-scope")
+    expect(deletedCleanupIdentities[0]?.runtimeKey).toBe(getRuntimeKey())
+  })
+
+  test("rejects a delete response that arrives after a runtime switch", async () => {
+    const source = createStore({}, {
+      session: [{ id: "session-a", directory: "/test/project", time: { created: 1 } } as Session],
+    })
+    const { switchRuntimeEndpoint } = await import("../lib/runtime-switch")
+    switchRuntimeEndpoint({ apiBaseUrl: "http://delete-runtime-a.test", runtimeKey: "delete-runtime-a" })
+    beforeSessionDeleteResolve = () => {
+      switchRuntimeEndpoint({ apiBaseUrl: "http://delete-runtime-b.test", runtimeKey: "delete-runtime-b" })
+    }
+    const { deleteSession, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/test/project", source]]), () => "/test/project")
+
+    expect(await deleteSession("session-a")).toBe(false)
+    // Session IDs are not unique across runtimes: committing here could evict an
+    // unrelated session and erase its queue, todos, drafts, folders, and pins.
+    expect(source.getState().session.map((item) => item.id)).toEqual(["session-a"])
+    expect(globalRemovedSessionIds).toEqual([])
+    expect(deletedCleanupIdentities).toEqual([])
+  })
+
+  test("does not treat a 404 as an already-completed deletion after a runtime switch", async () => {
+    sessionDeleteError = Object.assign(new Error("not found"), { status: 404 })
+    const source = createStore({}, {
+      session: [{ id: "session-a", directory: "/test/project", time: { created: 1 } } as Session],
+    })
+    const { switchRuntimeEndpoint } = await import("../lib/runtime-switch")
+    switchRuntimeEndpoint({ apiBaseUrl: "http://delete-404-a.test", runtimeKey: "delete-404-a" })
+    beforeSessionDeleteResolve = () => {
+      switchRuntimeEndpoint({ apiBaseUrl: "http://delete-404-b.test", runtimeKey: "delete-404-b" })
+    }
+    const { deleteSession, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/test/project", source]]), () => "/test/project")
+
+    // A 404 only proves "already deleted" for the captured runtime. After a
+    // switch it describes the wrong runtime, so it must not commit cleanup.
+    expect(await deleteSession("session-a")).toBe(false)
+    expect(source.getState().session.map((item) => item.id)).toEqual(["session-a"])
+    expect(globalRemovedSessionIds).toEqual([])
+    expect(deletedCleanupIdentities).toEqual([])
+  })
+
+  test("still treats a 404 as an already-completed deletion while the runtime is stable", async () => {
+    sessionDeleteError = Object.assign(new Error("not found"), { status: 404 })
+    const source = createStore({}, {
+      session: [{ id: "session-a", directory: "/test/project", time: { created: 1 } } as Session],
+    })
+    const { deleteSession, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/test/project", source]]), () => "/test/project")
+
+    expect(await deleteSession("session-a")).toBe(true)
+    expect(source.getState().session).toEqual([])
+    expect(globalRemovedSessionIds).toEqual(["session-a"])
+    expect(deletedCleanupIdentities).toHaveLength(1)
+  })
+
+  test("keeps committed deletions and fails the rest when the runtime changes mid-batch", async () => {
+    const source = createStore({}, {
+      session: [
+        { id: "session-a", directory: "/test/project", time: { created: 1 } } as Session,
+        { id: "session-b", directory: "/test/project", time: { created: 1 } } as Session,
+        { id: "session-c", directory: "/test/project", time: { created: 1 } } as Session,
+      ],
+    })
+    const { switchRuntimeEndpoint } = await import("../lib/runtime-switch")
+    switchRuntimeEndpoint({ apiBaseUrl: "http://delete-batch-a.test", runtimeKey: "delete-batch-a" })
+    beforeSessionDeleteResolve = (sessionId) => {
+      if (sessionId === "session-b") {
+        switchRuntimeEndpoint({ apiBaseUrl: "http://delete-batch-b.test", runtimeKey: "delete-batch-b" })
+      }
+    }
+    const { deleteSessions, setActionRefs } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/test/project", source]]), () => "/test/project")
+
+    const result = await deleteSessions(["session-a", "session-b", "session-c"])
+
+    // session-a was committed before the switch; session-b's response is stale
+    // and session-c is never attempted, so both are reported as failures.
+    expect(result).toEqual({ deletedIds: ["session-a"], failedIds: ["session-b", "session-c"] })
+    expect(source.getState().session.map((item) => item.id)).toEqual(["session-b", "session-c"])
+    expect(globalRemovedSessionIds).toEqual(["session-a"])
+    expect(replyCalls.filter((call) => call.method === "session.delete").map((call) => call.params.sessionID))
+      .toEqual(["session-a", "session-b"])
   })
 
   test("does not archive locally until the server returns the archived session", async () => {

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -664,6 +664,16 @@ function isStaleRuntime(expectedRuntimeKey: string | undefined): boolean {
   return expectedRuntimeKey !== undefined && getRuntimeKey() !== expectedRuntimeKey
 }
 
+/**
+ * Read a session, apply `updater` to its metadata, and persist the result.
+ *
+ * `expectedRuntimeKey` is optional here and unguarded when omitted, unlike the
+ * archive and delete actions. When supplied, the runtime is rechecked before
+ * the read, before the write, and before the global store is updated; a change
+ * at any of those points **throws** `"runtime changed"` rather than returning a
+ * value, because this function must resolve to a `Session`. Callers that pass a
+ * key must therefore be prepared to catch that rejection.
+ */
 export async function patchSessionMetadata(
   sessionId: string,
   directory: string | null | undefined,
@@ -764,7 +774,21 @@ function cleanupSessionWorktreeMetadata(sessionId: string): void {
   useSessionUIStore.getState().setWorktreeMetadata(sessionId, null)
 }
 
-function finalizeConfirmedSessionDeletion(sessionId: string, sessionDirectory?: string): void {
+/**
+ * Commit a server-confirmed deletion.
+ *
+ * `expectedRuntimeKey` is the runtime the deletion was confirmed on. It is
+ * forwarded to `cleanupPersistedSessionState`, which rejects an identity whose
+ * runtime is no longer active. Passing the live `getRuntimeKey()` here would
+ * make that existing check a tautology, so the captured key is required to keep
+ * it meaningful. Callers must still reject a stale runtime themselves, because
+ * the in-memory live/global/UI stores mutated below are not runtime-scoped.
+ */
+function finalizeConfirmedSessionDeletion(
+  sessionId: string,
+  sessionDirectory?: string,
+  expectedRuntimeKey = getRuntimeKey(),
+): void {
   const snapshots = removeSessionFromLiveStores(sessionId, sessionDirectory)
   invalidateSessionLoads(sessionId, [...snapshots.map((snapshot) => snapshot.directory), sessionDirectory])
   useGlobalSessionsStore.getState().removeSessions([sessionId])
@@ -773,23 +797,59 @@ function finalizeConfirmedSessionDeletion(sessionId: string, sessionDirectory?: 
   cleanupSessionWorktreeMetadata(sessionId)
   if (sessionDirectory) {
     cleanupPersistedSessionState({
-      runtimeKey: getRuntimeKey(),
+      runtimeKey: expectedRuntimeKey,
       directory: sessionDirectory,
       sessionId,
     })
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function deleteSession(sessionId: string, _options?: Record<string, unknown>): Promise<boolean> {
+export type DeleteSessionOptions = {
+  /**
+   * Runtime key the deletion is scoped to. Defaults to the active runtime when
+   * the action starts; callers may supply a key captured earlier when
+   * confirmation spans a runtime switch.
+   */
+  expectedRuntimeKey?: string
+  /**
+   * Worktree flags accepted from `SessionDialogs`. This action does not consume
+   * them today — the dialog performs worktree removal itself. They are declared
+   * so the call site stays type-checked instead of hidden behind an untyped
+   * bag; wiring or removing them is separate follow-up work.
+   */
+  archiveWorktree?: boolean
+  deleteRemoteBranch?: boolean
+  deleteLocalBranch?: boolean
+}
+
+/**
+ * Delete one session.
+ *
+ * The runtime is rechecked before the request and again before any store is
+ * reconciled, so a response produced by the previous runtime cannot mutate the
+ * current runtime's state. Session IDs are not unique across runtimes, so
+ * committing a stale deletion could otherwise evict an unrelated session and
+ * erase its persisted queue, todos, drafts, folders, and pins.
+ *
+ * A `404` is treated as an already-completed deletion, but only when it is
+ * still authoritative for the captured runtime. After a runtime change the
+ * `404` describes either the previous runtime or a runtime this session never
+ * belonged to; neither justifies committing cleanup here, so the action reports
+ * failure and leaves reconciliation to the next authoritative load.
+ */
+export async function deleteSession(sessionId: string, options?: DeleteSessionOptions): Promise<boolean> {
+  const expectedRuntimeKey = options?.expectedRuntimeKey ?? getRuntimeKey()
+  if (isStaleRuntime(expectedRuntimeKey)) return false
   const sessionDirectory = getSessionDirectory(sessionId)
   try {
-    await cleanupReviewMetadataBeforeDelete(sessionId, sessionDirectory)
+    await cleanupReviewMetadataBeforeDelete(sessionId, sessionDirectory, expectedRuntimeKey)
+    if (isStaleRuntime(expectedRuntimeKey)) return false
     const deleted = await opencodeClient.deleteSession(sessionId, sessionDirectory)
+    if (isStaleRuntime(expectedRuntimeKey)) return false
     if (deleted !== true) {
       throw new Error("session.delete failed: server did not confirm deletion")
     }
-    finalizeConfirmedSessionDeletion(sessionId, sessionDirectory)
+    finalizeConfirmedSessionDeletion(sessionId, sessionDirectory, expectedRuntimeKey)
     return true
   } catch (error) {
     console.error("[session-actions] deleteSession failed", error)
@@ -797,7 +857,8 @@ export async function deleteSession(sessionId: string, _options?: Record<string,
     // Subsequent delete attempts for those children return 404; treat as
     // success since the session was already deleted by the cascade.
     if ((error as { status?: number })?.status === 404) {
-      finalizeConfirmedSessionDeletion(sessionId, sessionDirectory)
+      if (isStaleRuntime(expectedRuntimeKey)) return false
+      finalizeConfirmedSessionDeletion(sessionId, sessionDirectory, expectedRuntimeKey)
       return true
     }
     return false
@@ -805,23 +866,68 @@ export async function deleteSession(sessionId: string, _options?: Record<string,
 }
 
 /** Delete a session specifying which directory it lives in. Used by agent groups for cross-directory deletes. */
-export async function deleteSessionInDirectory(sessionId: string, directory: string): Promise<boolean> {
+export async function deleteSessionInDirectory(
+  sessionId: string,
+  directory: string,
+  expectedRuntimeKey = getRuntimeKey(),
+): Promise<boolean> {
+  if (isStaleRuntime(expectedRuntimeKey)) return false
   try {
-    await cleanupReviewMetadataBeforeDelete(sessionId, directory)
+    await cleanupReviewMetadataBeforeDelete(sessionId, directory, expectedRuntimeKey)
+    if (isStaleRuntime(expectedRuntimeKey)) return false
     const deleted = await opencodeClient.deleteSession(sessionId, directory)
+    if (isStaleRuntime(expectedRuntimeKey)) return false
     if (deleted !== true) {
       throw new Error("session.delete failed: server did not confirm deletion")
     }
-    finalizeConfirmedSessionDeletion(sessionId, directory)
+    finalizeConfirmedSessionDeletion(sessionId, directory, expectedRuntimeKey)
     return true
   } catch (error) {
     console.error("[session-actions] deleteSessionInDirectory failed", error)
     if ((error as { status?: number })?.status === 404) {
-      finalizeConfirmedSessionDeletion(sessionId, directory)
+      if (isStaleRuntime(expectedRuntimeKey)) return false
+      finalizeConfirmedSessionDeletion(sessionId, directory, expectedRuntimeKey)
       return true
     }
     return false
   }
+}
+
+export type DeleteSessionsOptions = {
+  /**
+   * Runtime key captured when the batch was confirmed. When supplied, the batch
+   * stops as soon as the active runtime differs.
+   */
+  expectedRuntimeKey?: string
+}
+
+/**
+ * Delete several sessions sequentially, preserving partial results.
+ *
+ * One failed session never blocks or erases the others: it is reported in
+ * `failedIds` while the remaining IDs are still attempted. When the runtime
+ * changes mid-batch, the sessions already committed on the captured runtime
+ * stay in `deletedIds` and every ID that was not committed there is reported in
+ * `failedIds`, so existing partial-failure feedback stays truthful.
+ */
+export async function deleteSessions(
+  ids: string[],
+  options?: DeleteSessionsOptions,
+): Promise<{ deletedIds: string[]; failedIds: string[] }> {
+  const deletedIds: string[] = []
+  const failedIds: string[] = []
+  const expectedRuntimeKey = options?.expectedRuntimeKey ?? getRuntimeKey()
+
+  for (const [index, id] of ids.entries()) {
+    if (isStaleRuntime(expectedRuntimeKey)) {
+      failedIds.push(...ids.slice(index))
+      break
+    }
+    if (await deleteSession(id, { expectedRuntimeKey })) deletedIds.push(id)
+    else failedIds.push(id)
+  }
+
+  return { deletedIds, failedIds }
 }
 
 /**

--- a/packages/ui/src/sync/session-ui-store.test.js
+++ b/packages/ui/src/sync/session-ui-store.test.js
@@ -484,3 +484,42 @@ describe('archiveSessions option forwarding', () => {
     expect(updateSessionCalls).toEqual([]);
   });
 });
+
+describe('deleteSessions option forwarding', () => {
+  let originalDeleteSession;
+  let deleteSessionCalls;
+
+  beforeEach(() => {
+    deleteSessionCalls = [];
+    originalDeleteSession = opencodeClient.deleteSession;
+    opencodeClient.deleteSession = (sessionId) => {
+      deleteSessionCalls.push(sessionId);
+      return Promise.resolve(true);
+    };
+  });
+
+  afterEach(() => {
+    opencodeClient.deleteSession = originalDeleteSession;
+  });
+
+  // The store accepted an options object and dropped it on both the single and
+  // batch delete paths. A key that cannot match the active runtime must abort
+  // before any SDK call rather than deleting and erasing persisted state.
+  test('honors expectedRuntimeKey on the batch delete instead of discarding options', async () => {
+    const result = await useSessionUIStore.getState().deleteSessions(['session-x', 'session-y'], {
+      expectedRuntimeKey: 'runtime-that-is-not-active',
+    });
+
+    expect(result).toEqual({ deletedIds: [], failedIds: ['session-x', 'session-y'] });
+    expect(deleteSessionCalls).toEqual([]);
+  });
+
+  test('honors expectedRuntimeKey on the single delete instead of discarding options', async () => {
+    const deleted = await useSessionUIStore.getState().deleteSession('session-x', {
+      expectedRuntimeKey: 'runtime-that-is-not-active',
+    });
+
+    expect(deleted).toBe(false);
+    expect(deleteSessionCalls).toEqual([]);
+  });
+});

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -46,6 +46,7 @@ import { setActiveSession } from "./sync-context"
 import {
   createSession as createSessionAction,
   deleteSession as deleteSessionAction,
+  deleteSessions as deleteSessionsAction,
   archiveSession as archiveSessionAction,
   archiveSessions as archiveSessionsAction,
   updateSessionTitle as updateSessionTitleAction,
@@ -58,6 +59,8 @@ import {
   forkFromMessage as forkFromMessageAction,
   fetchMessagesForSession,
   type ArchiveSessionsOptions,
+  type DeleteSessionOptions,
+  type DeleteSessionsOptions,
 } from "./session-actions"
 import { useInputStore, type SyntheticContextPart } from "./input-store"
 import { useSessionGoalArmStore } from "@/stores/useSessionGoalArmStore"
@@ -322,8 +325,8 @@ export type SessionUIState = {
   ) => Promise<void>
 
   createSession: (title?: string, directoryOverride?: string | null, parentID?: string | null, metadata?: Record<string, unknown>) => Promise<Session | null>
-  deleteSession: (id: string, options?: Record<string, unknown>) => Promise<boolean>
-  deleteSessions: (ids: string[], options?: Record<string, unknown>) => Promise<{ deletedIds: string[]; failedIds: string[] }>
+  deleteSession: (id: string, options?: DeleteSessionOptions) => Promise<boolean>
+  deleteSessions: (ids: string[], options?: DeleteSessionsOptions) => Promise<{ deletedIds: string[]; failedIds: string[] }>
   archiveSession: (id: string) => Promise<boolean>
   archiveSessions: (ids: string[], options?: ArchiveSessionsOptions) => Promise<{ archivedIds: string[]; failedIds: string[] }>
   updateSessionTitle: (sessionId: string, title: string) => Promise<void>
@@ -1291,18 +1294,9 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
   // ---------------------------------------------------------------------------
   // deleteSession — calls SDK, SSE event updates child store
   // ---------------------------------------------------------------------------
-  deleteSession: (id) => deleteSessionAction(id),
+  deleteSession: (id, options) => deleteSessionAction(id, options),
 
-  deleteSessions: async (ids) => {
-    const deletedIds: string[] = []
-    const failedIds: string[] = []
-    for (const id of ids) {
-      const ok = await deleteSessionAction(id)
-      if (ok) deletedIds.push(id)
-      else failedIds.push(id)
-    }
-    return { deletedIds, failedIds }
-  },
+  deleteSessions: (ids, options) => deleteSessionsAction(ids, options),
 
   archiveSession: (id) => archiveSessionAction(id),
 


### PR DESCRIPTION
## Intent

Follow-up to #2574 and to the maintainer's `e6b736793` ("guard archive actions by default"), which closed the runtime-switch race on the **archive** path. The **delete** path had the same two defects, and its consequences are worse.

**Defect 1 — dropped options.** `useSessionUIStore` declared `deleteSession: (id, options?: Record<string, unknown>)` and `deleteSessions: (ids, options?: Record<string, unknown>)`, but the implementations were `(id) => deleteSessionAction(id)` and `async (ids) => {...}`. The options object was accepted by the type and discarded on both paths. This is not hypothetical: `SessionDialogs.tsx:416` passes an options object today and it never reaches the action.

**Defect 2 — no runtime recheck, with data loss.** `deleteSession` awaits `cleanupReviewMetadataBeforeDelete()` and `session.delete`, then unconditionally calls `finalizeConfirmedSessionDeletion()`. Session IDs are **not unique across runtimes** (`packages/ui/src/sync/DOCUMENTATION.md`, "Request identity is runtime key + normalized directory + session ID"). If the user switched runtime while those calls were in flight, the response from the previous runtime committed against the new one:

- `removeSessionFromLiveStores()` — evicts a possibly unrelated session from every live store;
- `useGlobalSessionsStore.removeSessions([id])` — removes it from the global cache;
- `setCurrentSession(null)` — closes the chat the user has open;
- `cleanupSessionWorktreeMetadata()`;
- `cleanupPersistedSessionState()` — **erases queued messages, todos, folder membership, inline-comment drafts, the chat draft, and pins**.

That last one is why this PR is more serious than #2574. Archiving a wrong row is a visible, reversible nuisance. Committing a stale deletion destroys user-authored state with no undo.

**Defect 3 — a real guard disarmed.** `session-deletion-cleanup.ts:14` already refuses a stale identity:

```ts
if (identity.runtimeKey !== getRuntimeKey() || ...) return;
```

But `finalizeConfirmedSessionDeletion` called it with `runtimeKey: getRuntimeKey()`, comparing a value with itself. The check could never fail. This PR forwards the **captured** key, so the existing protection actually protects something. The fix arms a guard that was already written, rather than inventing a new mechanism.

This PR adopts the shape the maintainer chose in `e6b736793` — `expectedRuntimeKey = getRuntimeKey()` as a parameter default rather than a pure optional — so every existing caller is protected with no call-site change.

### Affected callers

Batch: `Header.tsx:1471`, `SessionDialogs.tsx:453`, `useSidebarBulkActions.ts:172`, `useSessionActions.ts:234`.
Single: `SessionDialogs.tsx:158`, `SessionDialogs.tsx:416` (the one already passing dropped options), `useSessionActions.ts:215`, `MobileSessionsSheet.tsx:1267`.
Cross-directory: `useAgentGroupsStore.ts:296` via `deleteSessionInDirectory`.

### The 404 decision

`deleteSession` treats `404` as "already deleted" (the server cascade-deletes children, so a later child delete 404s) and commits the same cleanup. Under a runtime switch that shortcut needs an explicit answer, so this PR defines one rather than letting it fall out by accident.

**A `404` is authoritative only for the captured runtime.** Two sub-cases, both handled by the same recheck:

1. The request was already in flight when the switch happened. It reached the captured runtime, so the `404` means "not on the captured runtime" — genuinely already deleted **there**. It says nothing about the runtime now active.
2. The switch happened before the request was dispatched (the SDK resolves the base URL at call time). The `404` then means "not on the new runtime", which is expected for a session that never belonged to it.

Neither justifies committing cleanup against the currently active runtime. So after a detected runtime change the action returns `false` in the `404` branch instead of `true`, and commits nothing. While the runtime is stable, `404` keeps its existing meaning and still commits — covered by a regression test so the cascade-delete optimization is not lost.

Returning `false` for sub-case 1 is deliberately conservative: the deletion did happen on the old runtime, so the result understates success. The alternative — returning `true` — would tell the caller a deletion was reconciled when nothing was, and callers act on that (`SessionDialogs.tsx:458` only removes the worktree when `failedIds` is empty). Reporting failure routes into the existing partial-failure channel; claiming success would corrupt dependent work.

## Non-goals

- No UI, copy, locale, icon, or component change.
- No adoption of `expectedRuntimeKey` at any call site: the default covers them, exactly as `e6b736793` did for archive.
- **Not** wiring the `archiveWorktree` / `deleteRemoteBranch` / `deleteLocalBranch` flags that `SessionDialogs.tsx:419-421` passes. They are dropped today and stay dropped; this PR only makes them visible in the type instead of hidden inside `Record<string, unknown>`. Deciding whether they should do something is a separate behavioral question that deserves its own review.
- **Not** guarding the remaining `patchSessionMetadata` callers (`reviewFlow.ts:445,466,584`, `sessionGoalActions.ts:23`, `SessionSuggestionChip.tsx:35`). See "Deliberately deferred" below.
- No backend, route, transport, SDK, persisted-schema, or dependency change.

### Deliberately deferred

I considered folding the unguarded `patchSessionMetadata` callers into this PR and decided against it. `patchSessionMetadata` **throws** on a runtime change rather than returning a value, so guarding those call sites changes error paths inside the review flow and needs its own capture points, failure semantics, and tests across three files outside `sync/`. That would roughly double the review surface of a data-loss fix that should be easy to verify. Tracking it as follow-up work.

I did include the review bot's non-blocking nit #2 from #2574 (JSDoc for the `patchSessionMetadata` throw contract) because it is comment-only, touches no behavior, and directly documents the hazard the deferred work will have to handle.

## Affected surfaces

- `packages/ui/src/sync/session-actions.ts`: `expectedRuntimeKey` default parameter on `deleteSession`, `deleteSessionInDirectory` and `finalizeConfirmedSessionDeletion`; new exported `deleteSessions()` action plus `DeleteSessionOptions` / `DeleteSessionsOptions`; captured key forwarded to `cleanupPersistedSessionState`; JSDoc on `patchSessionMetadata`. Removes an `eslint-disable @typescript-eslint/no-unused-vars` that existed only to tolerate the ignored `_options`.
- `packages/ui/src/sync/session-ui-store.ts`: both delete entries delegate and forward options; the batch loop moves into the canonical action; option types narrow from `Record<string, unknown>`.
- Shared UI, so web, Electron desktop, VS Code, hosted mobile and Capacitor mobile all consume it. Behavior is identical across them: the guard only changes outcomes when the runtime actually changes mid-operation.
- No persisted schema, server route, transport, auth, dependency, generated asset, or public package entrypoint change.
- Type-contract note: `deleteSession`/`deleteSessions` narrow an option type. Type-check passes, which is the compile-time proof no consumer relied on the loose type. `DeleteSessionOptions` intentionally declares the three worktree flags so `SessionDialogs.tsx:416` keeps compiling.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` — correctness invariants | Core sync logic; stale data, partial failure, and data loss | No store is reconciled until the server confirms **and** the captured runtime is still active. Partial results, rollback, and stale-data behavior are explicit in code, docs, and tests. One failed session neither erases nor blocks unrelated sessions. |
| Root `AGENTS.md` — thin entrypoints, owning modules | The batch loop lived in the store | Moved into `session-actions.ts`, the documented owner of SDK-calling session mutations affecting global session lists; the store becomes a one-line delegation, matching what `archiveSessions` already does. |
| `packages/ui/src/sync/DOCUMENTATION.md` — "Session action rules" | Rule 1 (actions update the global store after confirmed SDK calls) and rule 3 (the store delegates to the actions module) | Duplicated loop removed; the doc's action list and a new delete-guard contract section updated in the same commit, since the implementation changed that section's truth. |
| `sync-state-invariants` — "Reject stale async/event completions" | The delete path spans multiple awaits, then mutates live + global + persisted state | The captured key is rechecked immediately before every commit point, including the `404` branch. |
| `sync-state-invariants` — "Failure is not empty" / partial results | The batch drives destructive UI feedback | A runtime switch never yields a falsely successful or empty result: committed IDs stay in `deletedIds`, uncommitted IDs go to `failedIds`, none silently vanish. |
| `sync-state-invariants` — Cache and lifecycle, runtime-scoped keys | `cleanupPersistedSessionState` is keyed by runtime identity | The captured key is forwarded so the helper's own runtime check stops being a tautology. |
| `sync-state-invariants` — verification checklist ("archive/delete … runtime or worktree switch") | The skill names this exact scenario | Tests cover stale single delete, stale `404`, stable `404` regression, mid-batch switch, captured-key cleanup scoping, and store-level option forwarding. |
| `openchamber-change-discipline` — smallest complete change, module contract risk | Exported contract changes with real consumers | Scope limited to the delete path; all nine consumers traced and listed; `bun run dead-code` run and diffed because export shape changed; owning docs updated. |
| `openchamber-change-discipline` — test design | Destructive, data-loss-sensitive path | Tests assert observable contracts (ID partitions, live-store contents, global removals, cleanup identities, which IDs reached the SDK), not internal structure. Mutation-tested — see Validation. |
| `ui-api-decoupling` | Mutation calls the official OpenCode session API | Still routed through `opencodeClient.deleteSession`; no raw fetch, hardcoded URL, bridge, or new runtime capability. Runtime identity resolved at call time, not cached. |
| `theme-system`, `locale-ui-patterns` | Considered, not applicable | No user-facing string, component, token, or icon touched. |

## Validation

All commands from the repository root on Linux, at commit `83497e068`, `bun 1.3.8`. Branch base: `e6b736793`.

| Check | Result |
|---|---|
| `bun test packages/ui/src/sync/session-actions.test.ts` | **45 pass, 0 fail, 201 expect() calls.** Baseline on `e6b736793`: 40 pass. +5 tests. |
| `bun test packages/ui/src/sync/session-ui-store.test.js` | **21 pass, 3 fail.** The 3 failures (`routeMessage skill invocation > …`) reproduce identically on unmodified `e6b736793` (19 pass, 3 fail) and are unrelated. Both new delete-forwarding tests pass. |
| `bun test packages/ui/src/sync/` (regression sweep) | **356 pass, 15 fail, 371 tests.** Baseline on unmodified `e6b736793`: **349 pass, 15 fail, 364 tests**. The two failure lists were diffed and are **identical test-for-test**: +7 passing tests, zero regression. The 15 are pre-existing (`createEventPipeline`, `issue 2039 draft auto-accept`, `cleanupPersistedSessionState`, `routeMessage skill invocation`). |
| Mutation — `isStaleRuntime` forced to `return false` | **5 tests fail**, exactly the intended ones: `rejects a delete response that arrives after a runtime switch`, `does not treat a 404 as an already-completed deletion after a runtime switch`, `keeps committed deletions and fails the rest when the runtime changes mid-batch`, plus the two pre-existing archive guard tests. Store file: both new delete-forwarding tests fail. Source restored byte-identical. |
| Mutation — `finalizeConfirmedSessionDeletion` reverted to `runtimeKey: getRuntimeKey()` | **45 pass, 0 fail — not caught.** Reported honestly: while the outer guard holds, the captured key always equals the live key at the commit point, so this forwarding is defense-in-depth and is not observable through the public API. `scopes persisted cleanup to the runtime captured when the delete started` pins the contract but cannot distinguish the two implementations today. Its value is that the helper's own check stops being a tautology if the outer guard is ever reordered or removed. Source restored byte-identical. |
| `bun run type-check:ui` | **Passed, exit 0.** Covers every call site of the changed signatures and the narrowed option types. |
| `bun run lint:ui` | **Passed, exit 0.** Confirms the removed `eslint-disable` is no longer needed. |
| `bun run dead-code` | **Exit 0.** Diffed against a baseline run on unmodified `e6b736793`: finding set **identical**, only line numbers shifted for pre-existing findings. No new file, export, or type finding; `DeleteSessionOptions`, `DeleteSessionsOptions` and `deleteSessions` are consumed by `session-ui-store.ts`. |
| `git diff --check` | Passed, no whitespace errors. |
| `git merge-tree upstream/main HEAD` | No conflicts against current `main`. |

**Not validated.** No runtime, browser, or device execution: nothing here demonstrates real runtime behavior. The runtime-switch scenarios are proven only at unit level, with `switchRuntimeEndpoint` invoked synchronously during an in-flight SDK call, not against a live server with two real runtimes; in particular I did not observe an actual stale deletion destroying persisted state before the fix, nor the fix preventing it, outside the mocked stores. No Electron, VS Code host, hosted mobile, or Capacitor run; native iOS/Android was impossible because this host is Linux and `serve-sim` needs macOS/Xcode. No workspace-wide type-check, lint, or build: the change is confined to `packages/ui/src/sync` with no cross-workspace consumer. No performance measurement; the batch stays sequential with one added string comparison per session. The 15 pre-existing sync failures were confirmed pre-existing but not investigated. I did not verify the behavior of the three unconsumed worktree flags beyond confirming they are read nowhere in `packages/ui/src/sync`.

## Visual evidence

None, and none is possible: this change cannot alter rendered output.

The diff touches two files under `packages/ui/src/sync` and contains no JSX, component, CSS, theme token, icon, or locale key. It adds no user-facing string and removes none. Every changed function returns the same shapes as before — `Promise<boolean>` and `{ deletedIds, failedIds }` — so the existing delete toasts, confirmation dialogs, list removal, and sidebar behavior render exactly as they do on `main`.

The guard changes an outcome only when the active runtime differs from the one captured when the operation started. With a stable runtime — every normal interaction, including the `404` cascade-delete path, which has an explicit regression test — the executed path and the observable result are identical to `main`. There is no steady-state screen to capture a difference in. The one user-visible difference happens exclusively mid-runtime-switch: an affected session is reported through the existing failure toast instead of silently corrupting the newly selected runtime. Reproducing that on camera needs two live runtimes and a switch timed inside an in-flight delete, which, as stated above, I could not exercise in this environment.

## Risks and failure behavior

- **What stays valid after the first failure.** The batch is sequential and per-ID. A single failed delete is recorded in `failedIds` and the remaining IDs are still attempted; one failure never blocks or erases unrelated committed work. Unchanged from the previous loop.
- **Runtime switch mid-batch — what the user observes.** Sessions committed before the switch stay deleted and remain in `deletedIds`. The in-flight one and the not-yet-attempted ones land in `failedIds`. Callers keep showing their existing partial feedback, e.g. "Deleted 2 sessions" together with "Failed to delete 3 sessions". `Header.tsx:1472-1479` is the exception: it treats any `failedIds` as total failure and shows only an error, hiding the successful part. That pre-existing UI imprecision is out of scope here and is noted as follow-up.
- **What is cleaned up.** Nothing partial. A guarded early return commits no store mutation at all — no live eviction, no global removal, no current-session reset, no persisted cleanup. There is no optimistic state to roll back because nothing is removed before the server confirms.
- **What is retryable.** Everything in `failedIds`. Re-running the delete on the correct runtime is safe and idempotent: if the server already deleted the session, the retry gets `404`, which — with a stable runtime — is treated as success and commits the cleanup that was skipped.
- **Known imprecision, accepted.** A deletion confirmed by the server immediately before the switch is reported as failed. The alternative would be committing it against the wrong runtime, which is the data loss this PR exists to prevent. Nothing is corrupted: the session stays deleted on its own runtime and the next authoritative load reconciles it.
- **Orphaned persisted state.** When a delete is confirmed but its cleanup is skipped due to a switch, that session's queue/todos/drafts/pins remain under the old runtime's namespace as hidden stale metadata. This follows the preference already documented in `DOCUMENTATION.md`: favour harmless hidden stale metadata over irreversible user-state loss. Retrying the delete on that runtime clears it.
- **Backward compatibility.** Every added parameter has a default or is optional, and no existing caller passes one, so behavior on a stable runtime is unchanged. `DeleteSessionOptions` deliberately keeps the three worktree flags so the existing `SessionDialogs` call still type-checks; they remain unconsumed, exactly as before.
- **Security and data.** No secret, token, directory path, session content, or runtime key is logged. Existing `console.error` calls are untouched; guarded early returns log nothing.
- **Performance.** One string comparison per session and per checkpoint. No added allocation, request, or concurrency change.
- **Rollback.** Plain code revert; no migration, persisted-state change, or API change. Sessions already deleted by explicit user confirmation stay deleted.
- **Residual risk.** Correctness under a real concurrent runtime switch is demonstrated by unit tests with a simulated switch, not by live multi-runtime execution. See "Not validated".
