### PR TITLE
fix(ui): make overlay scrollbar persistent on desktop shells

### DIFF
--- a/packages/ui/src/components/ui/OverlayScrollbar.tsx
+++ b/packages/ui/src/components/ui/OverlayScrollbar.tsx
@@ -25,6 +25,12 @@ const isSameThumbMetrics = (a: ThumbMetrics, b: ThumbMetrics): boolean => {
   return Math.abs(a.length - b.length) < METRIC_EPSILON && Math.abs(a.offset - b.offset) < METRIC_EPSILON;
 };
 
+// Desktop shells (Electron, VS Code webview) use persistent, not
+// auto-hiding, scrollbars. Reads the same `desktop-runtime` root class that
+// index.css keys off, so JS and CSS never disagree on what counts as desktop.
+const isDesktopScrollbarRuntime = (): boolean =>
+  typeof document !== "undefined" && document.documentElement.classList.contains("desktop-runtime");
+
 const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
   containerRef,
   minThumbSize = 32,
@@ -128,8 +134,15 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
     if (isHoveringRef.current) {
       return;
     }
+    // Desktop shells keep the thumb visible once shown instead of
+    // auto-hiding it after a delay. userIntentOnly callers (e.g. chat
+    // auto-follow scroll) opt out of persistence on purpose, so they keep
+    // the existing auto-hide behavior even on desktop.
+    if (isDesktopScrollbarRuntime() && !userIntentOnly) {
+      return;
+    }
     hideTimeoutRef.current = setTimeout(() => setVisible(false), hideDelayMs);
-  }, [hideDelayMs]);
+  }, [hideDelayMs, userIntentOnly]);
 
   const markUserIntent = React.useCallback(() => {
     lastUserIntentAtRef.current = Date.now();
@@ -162,7 +175,10 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
     if (!container) return;
 
     updateMetrics();
-    setVisible(false);
+    // On desktop shells, show the thumb immediately if content overflows
+    // instead of waiting for the first scroll event (persistent affordance,
+    // matching native desktop scrollbar conventions).
+    setVisible(isDesktopScrollbarRuntime() && !userIntentOnly);
 
     const onScroll = () => handleScroll();
     const onKeyDown = (event: KeyboardEvent) => {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1735,8 +1735,10 @@ input[aria-label="Terminal input"] {
 
 }
 
-/* Settings dialog: hide the overlay scrollbar; wheel/keyboard scroll still works. */
-[data-settings-view="true"] .overlay-scrollbar {
+/* Settings dialog: hide the overlay scrollbar on mobile/web; wheel/keyboard
+   scroll still works. Desktop shells keep the persistent scrollbar so the
+   Settings sub-panels aren't left with no scroll affordance at all. */
+html:not(.desktop-runtime) [data-settings-view="true"] .overlay-scrollbar {
   display: none;
 }
 


### PR DESCRIPTION
## Intent

PR #2520 (merged, shipped in v1.17.2) attempted to fix #2475 by changing `overflow-hidden` to `overflow-y-scroll` on 5 wrapper `div`s in `SettingsView.tsx`. It didn't work — issue #2402 (filed earlier, still open) already root-caused why: Settings sub-panels and other scrollable content don't use the browser's native scrollbar at all. They render through a shared `ScrollableOverlay` → `OverlayScrollbar` component pair that (a) hides the native scrollbar unconditionally via the `.overlay-scrollbar-target` CSS class, and draws its own JS thumb instead, and (b) for Settings specifically, a second CSS rule (`[data-settings-view="true"] .overlay-scrollbar { display: none; }`) hides that custom thumb too — so Settings sub-panels had **zero** scrollbar affordance of any kind. `SettingsView.tsx` never touches any of this, so PR #2520's change had no visible effect.

Outside Settings, the same `OverlayScrollbar` component auto-hides its thumb ~1s after scroll activity stops (`hideDelayMs = 1000`, `visible` starts `false`), which is why the sessions feed (`SidebarProjectsList.tsx`) has the same "no persistent scrollbar" symptom the user originally reported in #2402.

This PR fixes both, at the shared-component layer so every consumer (Settings, sessions feed, git panels, chat, etc.) gets a persistent scrollbar on desktop shells (Electron + VS Code webview) in one change, while leaving mobile/web behavior untouched:

- `packages/ui/src/components/ui/OverlayScrollbar.tsx`: on desktop runtimes, skip the auto-hide timer and show the thumb immediately on mount when content overflows, instead of waiting for the first scroll event. `userIntentOnly` consumers (`ChatContainer.tsx`'s auto-follow scroll, `ReasoningPart.tsx`) explicitly opt out and keep today's intent-gated behavior unchanged — persistent scrollbars would be visual noise there.
- `packages/ui/src/index.css`: scope the Settings-specific `display: none` override to `html:not(.desktop-runtime)`, so mobile/web keep the existing "no affordance, wheel/keyboard still works" behavior, and desktop gets the thumb back.

## Non-goals

- Not touching `.overlay-scrollbar-target`'s native-scrollbar suppression — the custom JS thumb stays the visible affordance everywhere; this isn't a switch back to native OS scrollbars.
- Not adding Windows-only (win32 vs darwin/linux) detection. The fix reads the existing `desktop-runtime` root class (set by `packages/ui/src/lib/device.ts` for `isDesktopShell() || isVSCodeRuntime() || hasDesktopSurfaceOverride()`), which already governs other native-feel behavior (e.g. cursor handling in the same `index.css`) uniformly across Electron and VS Code — no new platform plumbing.
- Not touching the ~30 individual `ScrollableOverlay` call sites (`SidebarProjectsList.tsx`, `SettingsPageLayout.tsx`, `ChatContainer.tsx`, git panels, etc.) — the fix lives once in the shared `OverlayScrollbar` component so all of them inherit it.
- Not reverting or touching PR #2520's `SettingsView.tsx` changes — harmless, left as-is.
- No new dependencies, no refactoring beyond the two files above.

## Affected surfaces

| Surface | Affected? | Reason |
|---|---|---|
| `packages/ui` (shared React components) | ✅ Yes | `OverlayScrollbar.tsx` and `index.css` are the only files changed |
| Desktop / Electron (`packages/electron`) | ✅ Yes | This is the primary target — `desktop-runtime` is true here; scrollbar persistence is the whole point of the fix |
| VS Code extension (`packages/vscode`) | ✅ Yes (secondary) | `desktop-runtime` is also true for the VS Code webview (`isVSCodeRuntime()`), so it gets persistent scrollbars too — consistent with how that class already governs other native-feel behavior for both runtimes |
| Web (`packages/web`) | ❌ No, by code inspection — not independently verified live | `desktop-runtime` is false in a plain browser tab, so both changed rules reduce to their original, unscoped form; attempted to verify live via `?surface=desktop` against the Vite HMR dev server but hit an unrelated dev-harness auth error before the app rendered (see Validation) |
| Mobile / Capacitor (`packages/mobile`) | ❌ No | Not a desktop-runtime path; unaffected by both changes |
| Server / API | ❌ No | CSS + client-only visibility/timing change, no server logic |
| Persisted data / contracts | ❌ No | No schema, storage, or API changes |
| i18n / locale strings | ❌ No | No text changes |

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — Always-On Constraints | Any source change | Kept to 2 files, no new dependencies, no unrelated cleanup; `../opencode` untouched |
| `.agents/skills/openchamber-change-discipline` | Any source change | Risk classified as Cross-workspace contract (shared `packages/ui` component consumed by web/desktop/VS Code/mobile) + Platform/runtime behavior (Electron-desktop-specific effect); validated at both levels below rather than relying on type-check/lint alone |
| `.agents/skills/theme-system` | Styling/visual-state change to the scrollbar | No new colors/hex values — reuses the existing `--oc-scrollbar-thumb`/`--oc-scrollbar-thumb-hover` tokens unchanged; no new buttons/icons |
| `.agents/skills/settings-ui-patterns` | Fix changes a CSS rule scoped to `[data-settings-view="true"]`, i.e. Settings-specific rendered behavior, even though no Settings component file is touched | No Settings primitive, control, or copy was touched — the change only restores the shared scrollbar affordance Settings already relies on via `ScrollableOverlay`; companion skills (`locale-ui-patterns`, `ui-api-decoupling`) don't apply (no text, no runtime-data changes) |
| Considered, not applicable: `desktop-shell` | Trigger is Electron main/preload/IPC/native windows/updater/etc. | This change only reads an existing renderer-side `desktop-runtime` DOM class; no main-process, preload, or IPC code touched |
| Considered, not applicable: `performance-engineering` | Trigger is hot-path/high-volume render work | One-time mount-level branch and a single `classList.contains` read, not a loop over large collections; no memoization/caching introduced as a fix |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (workspace-wide: mobile, ui, web, electron, root) | ✅ All exit 0 |
| `bun run lint` (workspace-wide: mobile, web, electron, ui, root) | ✅ All exit 0 |
| `bun run build` (full workspace build) | ✅ Succeeded (`built in 1m 29s`, `Done in 92.44s`) |
| Manual runtime check — desktop path, dark theme | ✅ Verified with real screenshots (attached) against both the installed v1.17.2 build and a local patched `bun run electron:dev:bundled` build: Settings → General and Settings → Shortcuts (content that overflows the pane) now show a persistent scrollbar thumb immediately, without scrolling first. Before: zero scrollbar affordance on the right edge in either panel. |
| Manual runtime check — Settings → Agents sidebar | ⚠️ Partially verified. Confirmed the bug reproduces on the installed v1.17.2 build (screenshot attached: "Total 31" agents, only ~10 visible, no scrollbar). Could not get a live "after" screenshot in this sandbox — the dev checkout has no OpenCode CLI installed and no configured agents (`Total 0`), so the list never overflows here. Verified instead by code inspection: `packages/ui/src/components/sections/agents/AgentsSidebar.tsx:369` calls `<ScrollableOverlay outerClassName="flex-1 min-h-0" className="space-y-1 px-3 py-2 overflow-x-hidden">` with no `hideDelayMs`/`userIntentOnly` override — identical call shape to the panels that were verified live, so it goes through the exact same fixed code path. |
| Manual runtime check — sessions feed (`SidebarProjectsList.tsx`) | ❌ Not independently verified live — this checkout/dev environment has no populated sessions to overflow the list. Same reasoning as the Agents sidebar: identical `ScrollableOverlay` usage, no per-consumer override, so it's covered by the fix but unverified by screenshot. |
| Manual runtime check — light theme | ❌ Not verified — the dev build's local backend crashed ("Startup failed / could not finish initialization") partway through this check and only dark theme was captured before that. The changed code (CSS `display`/opacity and a JS boolean read) has no theme-conditional branches, so light-theme parity is expected but not independently screenshotted. |
| Manual runtime check — non-desktop path (regression) | ❌ Not verified live — attempted via a browser tab against the Vite HMR dev server (`?surface=desktop` toggle), but that harness hit an unrelated "Unable to reach server / could not verify the UI session" error before the app rendered, independent of this fix. Verified instead by static code reasoning: both changed rules gate on the same `desktop-runtime` DOM class/selector, so when that class is absent the code paths are byte-for-byte the original `hideDelayMs`/`setVisible(false)` logic and the original unscoped CSS selector — provably unchanged, not just assumed. |
| `bun run dead-code` | Not run — no file added/deleted/renamed, no export/type/entrypoint/import shape changed (per `openchamber-change-discipline`'s trigger for that check) |
| Focused component tests for `OverlayScrollbar.tsx` | Not added. This component has no existing test file, and its visibility/timing logic is effect- and timer-driven (mount effects, `scheduleHide`, scroll listeners), which in this repo's existing patterns (see `number-input.test.tsx`) requires a fairly heavy hand-rolled DOM/timer stub to exercise correctly under `bun:test`. Flagged here explicitly rather than skipped silently — happy to add a focused test (assert thumb visible at mount with overflow + `desktop-runtime`, no auto-hide after scroll on desktop, `userIntentOnly` still auto-hides, non-desktop unchanged) as a follow-up if useful before merge. |

## Visual evidence

**Settings → Shortcuts, dark theme:**

Before (installed v1.17.2, unpatched) — content overflows past "Open Files surface" with zero scrollbar on the right edge:

![before](https://raw.githubusercontent.com/sergiofspedro/openchamber/evidence/pr-2581-screenshots/evidence/before_settings_shortcuts_dark.png)

After (this branch) — persistent thumb visible on the right edge without scrolling first:

![after](https://raw.githubusercontent.com/sergiofspedro/openchamber/evidence/pr-2581-screenshots/evidence/after_settings_shortcuts_dark.png)

**Settings → Agents sidebar, dark theme:**

Before (installed v1.17.2) — "Total 31" agents, only ~10 visible, zero scrollbar:

![before-agents](https://raw.githubusercontent.com/sergiofspedro/openchamber/evidence/pr-2581-screenshots/evidence/before_settings_agents_dark.png)

No "after" screenshot for this one — see the Validation table above for why (this sandbox has no configured agents to overflow the list) and the code-level justification for why it's still covered by the fix.

**Not captured, and why**: light theme (dev backend crashed mid-check), the sessions feed (no populated sessions in this sandbox to overflow), and the non-desktop/web regression path (dev HMR harness auth issue, unrelated to this fix). All three are covered by the same code path as what *was* verified, reasoned through the actual diff rather than assumed — see the Validation table.

## Risks and failure behavior

- If `document.documentElement` doesn't yet have the `desktop-runtime` class at the moment `OverlayScrollbar` mounts (e.g. a future ordering change upstream), the component simply falls back to today's existing behavior (auto-hide, hidden-in-Settings) for that render — no new failure mode, no crash, no persisted state involved.
- `userIntentOnly` consumers (chat auto-follow scroll, reasoning blocks) are unaffected by design — verified by inspecting both call sites before writing the fix.
- **Breadth not individually screenshotted**: because the fix lives in the shared `OverlayScrollbar` component, it also makes the thumb persistent on desktop for every other non-`userIntentOnly` consumer — transient overlays like the command palette (`CommandList`), model picker, branch selectors, and the Providers combobox, not just the panels shown above. This is intentional (same reasoning as the rest of this PR: one shared fix for one shared component), but it wasn't independently screenshotted for each of those surfaces.
- No persisted data, IDs, exported contracts, or API routes change; this is a client-only visibility/timing change scoped by a CSS class and a single boolean read.
