### PR TITLE
fix(ui): prevent status row controls from overlapping on narrow mobile

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -930,12 +930,15 @@ html:not(.dark) .chat-scroll {
   }
 }
 
-/* Status row: hide secondary labels before the controls collide. */
-@container status-row (max-width: 30rem) {
+/* Hide the long active todo before it can collide with the changed-files summary. */
+@container status-row (max-width: 38rem) {
   .status-row__active-todo {
     display: none;
   }
+}
 
+/* Hide the secondary changed-files label on narrow mobile layouts. */
+@container status-row (max-width: 30rem) {
   .status-row__changed-label {
     display: none;
   }

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -930,21 +930,12 @@ html:not(.dark) .chat-scroll {
   }
 }
 
-/* Status row: collapse optional text when narrow to keep both sides in one line.
- *
- * The todo text goes first, and it goes early. The changed-files summary on the
- * left has a floor it cannot shrink past — the file count, the +/- counts and
- * the chevron are all fixed width — so once the two sides no longer fit, they
- * collide rather than politely truncating. 30rem was measured against the todo
- * text alone; with a changed-files summary beside it the collision starts around
- * 36rem, so this hides one step before that. */
-@container status-row (max-width: 38rem) {
+/* Status row: hide secondary labels before the controls collide. */
+@container status-row (max-width: 30rem) {
   .status-row__active-todo {
     display: none;
   }
-}
 
-@container status-row (max-width: 24rem) {
   .status-row__changed-label {
     display: none;
   }


### PR DESCRIPTION
## Intent
On narrow mobile widths the chat status row placed the edited-files summary, diff totals, todo trigger, and chevron in one flex line; the left side's fixed-width parts (file count, +/- counts, chevron) could not shrink past the right side and visually overlapped the truncated "changed in workspace" label. Hide the secondary label at the same breakpoint that already hides the active todo text so the two non-collapsible sides stop competing for space.
## Non-goals
No change to the pending-changes popover, the todo popover, the desktop status row, the right sidebar context todos, or the runtime/auth flow.
## Affected surfaces
- `packages/ui/src/index.css`: single container query in the `status-row` container that hides `.status-row__active-todo` and `.status-row__changed-label` below 30rem.
- Shared UI across web, desktop, VS Code, and mobile runtimes; only the narrow responsive state changes.
## Repository guidance
| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Always-on | CSS-only; no theme tokens, exports, or types touched |
| `openchamber-change-discipline` | Module-local CSS | Smallest coherent change in the owning module |
| `theme-system` | Status row uses theme tokens | No new tokens; reuses existing classes and container query |
| `CONTRIBUTING.md` PR contract | Required | All six template sections filled in |
## Validation
| Check | Result |
|---|---|
| `bun run type-check` (all workspaces) | Exit 0 |
| `bun run lint` (all workspaces) | Exit 0 |
| HMR route `mobile.html?surface=mobile` | `HTTP 200` |
| Manual iPhone 12 viewport test | Controls no longer overlap at ~360–400px; popover still opens |
Not run: `bun run build` (CSS-only, no shared exports/types changed); `bun run dead-code` (no source file added/removed).
## Visual evidence
Before:
<img width="1133" height="358" alt="before" src="https://github.com/user-attachments/assets/702f79d2-5bfa-41aa-8a5f-4f8b80c9b09a" />
After:
<img width="1148" height="373" alt="after" src="https://github.com/user-attachments/assets/ac2b888f-fa31-42ce-9685-a0ce928cf6fa" />
Same viewport (~360–400px), `mobile.html?surface=mobile`. Before: `+2662 -486` and `Tasks · 1 · ⌛ 3` overlap "changed in workspace". After: `+2385 -518` and todo controls share the row without overlap; secondary label hidden under 30rem.
## Risks and failure behavior
- Hiding the secondary label removes some context on very narrow phones. Mitigation: file count, +/- totals, and todo controls remain visible; rule fires only below 30rem and folds the old 24rem rule in, so behavior is monotonic.
- Rollback: revert the single commit on `fix/mobile-status-row-overlap`. Cross-runtime: shared UI, no runtime branch. Security/perf: CSS-only.