### PR TITLE
fix(providers): load auth methods on detail; hide API key for OAuth-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Providers: load auth methods on connected provider detail pages and hide the API key field for OAuth-only providers (for example Cursor), so Login with Cursor and the browser URL are shown instead of a fake Connected + API key state.
 - **Walkthrough:** a new guided walkthrough reorders a diff into a sequence of stops — the model groups related changes, explains what each one does, and orders them so each builds on the last. Start one from the Changes and pull-request views for uncommitted work, a branch against its base, or a pull request; nothing runs on its own. Walkthroughs are written in your interface language by default, and the panel can generate one in any other supported language.
 - **Mobile/Tablet:** reworked the tablet and foldable layout around the phone's navigation — a persistent resizable sessions sidebar on the left, the workspace (Changes, Files, Terminal, Notes, MCP) as a resizable right sidebar, and app pages like settings and instances shown as centered dialogs. An open diff, edited file, or attached terminal now survives rotation.
 - **Providers:** custom OpenAI-compatible providers can now be added and edited from Settings, including their endpoint, models, credentials, headers, and configuration scope (thanks to @makeittech).

--- a/packages/ui/src/components/sections/providers/ProviderAuthPanel.tsx
+++ b/packages/ui/src/components/sections/providers/ProviderAuthPanel.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { SettingsInfoHint } from '@/components/sections/shared/SettingsInfoHint';
+import { useI18n } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
+import { openExternalUrl } from '@/lib/url';
+import type { ProviderOAuthEntry } from './providerAuth';
+
+export interface ProviderOAuthDetails {
+  url?: string;
+  instructions?: string;
+  userCode?: string;
+}
+
+interface ProviderAuthPanelProps {
+  providerId: string;
+  oauthEntries: ProviderOAuthEntry[];
+  showApiKeyField: boolean;
+  apiKeyValue: string;
+  onApiKeyChange: (value: string) => void;
+  onSaveApiKey: () => void;
+  busyKey: string | null;
+  oauthDetails: Record<string, ProviderOAuthDetails>;
+  oauthCodes: Record<string, string>;
+  onOAuthCodeChange: (codeKey: string, value: string) => void;
+  pendingOAuth: { providerId: string; methodIndex: number } | null;
+  onOAuthStart: (methodIndex: number) => void;
+  onOAuthComplete: (methodIndex: number) => void;
+  onCopyOAuthLink: (url: string) => void;
+  onCopyOAuthCode: (code: string) => void;
+  className?: string;
+}
+
+/**
+ * Authentication controls shared by the connected provider detail page and the
+ * add-provider flow, so both surfaces expose the same API key and OAuth paths.
+ */
+export const ProviderAuthPanel: React.FC<ProviderAuthPanelProps> = ({
+  providerId,
+  oauthEntries,
+  showApiKeyField,
+  apiKeyValue,
+  onApiKeyChange,
+  onSaveApiKey,
+  busyKey,
+  oauthDetails,
+  oauthCodes,
+  onOAuthCodeChange,
+  pendingOAuth,
+  onOAuthStart,
+  onOAuthComplete,
+  onCopyOAuthLink,
+  onCopyOAuthCode,
+  className,
+}) => {
+  const { t } = useI18n();
+  const apiKeyBusy = busyKey === `api:${providerId}`;
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {showApiKeyField ? (
+        <div className="py-1.5">
+          <label className="typography-ui-label text-foreground flex items-center gap-1.5">
+            {t('settings.providers.page.auth.apiKeyLabel')}
+            <SettingsInfoHint>{t('settings.providers.page.auth.apiKeyTooltip')}</SettingsInfoHint>
+          </label>
+          <div className="flex flex-col @xl:flex-row @xl:items-center gap-2 mt-1.5">
+            <Input
+              type="password"
+              value={apiKeyValue}
+              onChange={(event) => onApiKeyChange(event.target.value)}
+              placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
+              className="flex-1 font-mono text-xs"
+            />
+            <Button
+              size="xs"
+              className="!font-normal shrink-0"
+              onClick={onSaveApiKey}
+              disabled={apiKeyBusy}
+            >
+              {apiKeyBusy ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {oauthEntries.length > 0 ? (
+        <div className={cn('space-y-4', showApiKeyField && 'border-t border-[var(--surface-subtle)] pt-2')}>
+          {oauthEntries.map(({ index, method }) => {
+            const methodLabel = method.label
+              || method.name
+              || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
+            const codeKey = `${providerId}:${index}`;
+            const details = oauthDetails[codeKey];
+            const isPending = pendingOAuth?.providerId === providerId && pendingOAuth?.methodIndex === index;
+            const startBusy = busyKey === `oauth:${providerId}:${index}`;
+            const completeBusy = busyKey === `oauth-complete:${providerId}:${index}`;
+
+            return (
+              <div key={codeKey} className="space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <div className="typography-ui-label text-foreground">{methodLabel}</div>
+                    {(method.description || method.help) && (
+                      <div className="typography-meta text-muted-foreground">
+                        {String(method.description || method.help)}
+                      </div>
+                    )}
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    className="!font-normal"
+                    onClick={() => onOAuthStart(index)}
+                    disabled={startBusy}
+                  >
+                    {t('settings.providers.page.actions.connect')}
+                  </Button>
+                </div>
+
+                {details?.instructions && (
+                  <p className="typography-meta text-[var(--primary-base)] bg-[var(--primary-base)]/10 px-2 py-1.5 rounded whitespace-pre-line">
+                    {details.instructions}
+                  </p>
+                )}
+
+                {details?.userCode && (
+                  <div className="flex items-center gap-2 mt-2">
+                    <Input value={details.userCode} readOnly className="font-mono text-center tracking-widest" />
+                    <Button variant="outline" size="xs" className="!font-normal" onClick={() => onCopyOAuthCode(details.userCode ?? '')}>{t('settings.providers.page.actions.copyCode')}</Button>
+                  </div>
+                )}
+
+                {details?.url && (
+                  <div className="flex items-center gap-2 mt-2">
+                    <Input value={details.url} readOnly className="text-xs text-muted-foreground" />
+                    <div className="flex gap-1 shrink-0">
+                      <Button variant="outline" size="xs" className="!font-normal" onClick={() => openExternalUrl(details.url ?? '')}>{t('settings.providers.page.actions.open')}</Button>
+                      <Button variant="outline" size="xs" className="!font-normal" onClick={() => onCopyOAuthLink(details.url ?? '')}>{t('settings.providers.page.actions.copy')}</Button>
+                    </div>
+                  </div>
+                )}
+
+                {isPending && (
+                  <div className="flex items-center gap-2 mt-2">
+                    <Input
+                      value={oauthCodes[codeKey] ?? ''}
+                      onChange={(event) => onOAuthCodeChange(codeKey, event.target.value)}
+                      placeholder={t('settings.providers.page.auth.pasteAuthorizationCodePlaceholder')}
+                      className="font-mono text-xs"
+                    />
+                    <Button
+                      size="xs"
+                      className="!font-normal"
+                      onClick={() => onOAuthComplete(index)}
+                      disabled={completeBusy}
+                    >
+                      {completeBusy ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.complete')}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/ui/src/components/sections/providers/ProvidersPage.test.ts
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.test.ts
@@ -1,49 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import { shouldLoadAvailableProviders } from './providerAvailability';
-import {
-  hasOauthAuthMethod,
-  isOauthOnlyAuthMethods,
-  normalizeAuthType,
-  oauthMethodIndexes,
-  shouldShowApiKeyField,
-} from './providerAuth';
 
 describe('ProvidersPage available provider loading', () => {
   test('loads available providers only in add-provider mode', () => {
     expect(shouldLoadAvailableProviders(false)).toBe(false);
     expect(shouldLoadAvailableProviders(true)).toBe(true);
-  });
-});
-
-describe('provider auth method helpers', () => {
-  test('normalizeAuthType recognizes oauth and api from type or label', () => {
-    expect(normalizeAuthType({ type: 'oauth' })).toBe('oauth');
-    expect(normalizeAuthType({ type: 'api' })).toBe('api');
-    expect(normalizeAuthType({ label: 'Login with Cursor' })).toBe('');
-    expect(normalizeAuthType({ label: 'OAuth login' })).toBe('oauth');
-    expect(normalizeAuthType({ name: 'API Key' })).toBe('api');
-  });
-
-  test('shouldShowApiKeyField is true for unknown/empty and explicit api methods', () => {
-    expect(shouldShowApiKeyField([])).toBe(true);
-    expect(shouldShowApiKeyField([{ type: 'oauth', label: 'Login with Cursor' }])).toBe(false);
-    expect(shouldShowApiKeyField([{ type: 'api' }])).toBe(true);
-    expect(shouldShowApiKeyField([{ type: 'oauth' }, { type: 'api' }])).toBe(true);
-  });
-
-  test('oauth-only detection and original method indexes', () => {
-    const oauthOnly = [{ type: 'oauth', label: 'Login with Cursor' }];
-    expect(hasOauthAuthMethod(oauthOnly)).toBe(true);
-    expect(isOauthOnlyAuthMethods(oauthOnly)).toBe(true);
-    expect(oauthMethodIndexes(oauthOnly)).toEqual([0]);
-
-    const mixed = [{ type: 'api' }, { type: 'oauth', label: 'Login' }];
-    expect(hasOauthAuthMethod(mixed)).toBe(true);
-    expect(isOauthOnlyAuthMethods(mixed)).toBe(false);
-    expect(shouldShowApiKeyField(mixed)).toBe(true);
-    expect(oauthMethodIndexes(mixed)).toEqual([1]);
-
-    expect(isOauthOnlyAuthMethods([])).toBe(false);
-    expect(hasOauthAuthMethod([])).toBe(false);
   });
 });

--- a/packages/ui/src/components/sections/providers/ProvidersPage.test.ts
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.test.ts
@@ -1,9 +1,68 @@
 import { describe, expect, test } from 'bun:test';
-import { shouldLoadAvailableProviders } from './providerAvailability';
+import { listConnectableProviders, shouldLoadAvailableProviders } from './providerAvailability';
 
 describe('ProvidersPage available provider loading', () => {
   test('loads available providers only in add-provider mode', () => {
     expect(shouldLoadAvailableProviders(false)).toBe(false);
     expect(shouldLoadAvailableProviders(true)).toBe(true);
+  });
+});
+
+describe('listConnectableProviders', () => {
+  const connected = (...ids: string[]) => new Set(ids);
+
+  test('offers a plugin provider that only advertises auth methods', () => {
+    const result = listConnectableProviders({
+      catalog: [{ id: 'openai', name: 'OpenAI' }],
+      authProviderIds: ['openai', 'cursor'],
+      connectedIds: connected(),
+    });
+
+    expect(result.map((provider) => provider.id)).toEqual(['cursor', 'openai']);
+    expect(result.find((provider) => provider.id === 'cursor')).toEqual({ id: 'cursor' });
+  });
+
+  test('excludes already connected providers from both sources', () => {
+    const result = listConnectableProviders({
+      catalog: [{ id: 'openai', name: 'OpenAI' }, { id: 'google', name: 'Google' }],
+      authProviderIds: ['cursor', 'openai'],
+      connectedIds: connected('google', 'cursor'),
+    });
+
+    expect(result.map((provider) => provider.id)).toEqual(['openai']);
+  });
+
+  test('keeps the catalog name when a provider appears in both sources', () => {
+    const result = listConnectableProviders({
+      catalog: [{ id: 'github-copilot', name: 'GitHub Copilot' }],
+      authProviderIds: ['github-copilot'],
+      connectedIds: connected(),
+    });
+
+    expect(result).toEqual([{ id: 'github-copilot', name: 'GitHub Copilot' }]);
+  });
+
+  test('sorts by display label and de-duplicates ids', () => {
+    const result = listConnectableProviders({
+      catalog: [
+        { id: 'zzz', name: 'Alpha' },
+        { id: 'aaa', name: 'Zeta' },
+        { id: 'zzz', name: 'Duplicate' },
+      ],
+      authProviderIds: ['middle'],
+      connectedIds: connected(),
+    });
+
+    expect(result.map((provider) => provider.name || provider.id)).toEqual(['Alpha', 'middle', 'Zeta']);
+  });
+
+  test('returns nothing when every known provider is connected', () => {
+    const result = listConnectableProviders({
+      catalog: [{ id: 'openai' }],
+      authProviderIds: ['openai'],
+      connectedIds: connected('openai'),
+    });
+
+    expect(result).toEqual([]);
   });
 });

--- a/packages/ui/src/components/sections/providers/ProvidersPage.test.ts
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.test.ts
@@ -1,9 +1,49 @@
 import { describe, expect, test } from 'bun:test';
 import { shouldLoadAvailableProviders } from './providerAvailability';
+import {
+  hasOauthAuthMethod,
+  isOauthOnlyAuthMethods,
+  normalizeAuthType,
+  oauthMethodIndexes,
+  shouldShowApiKeyField,
+} from './providerAuth';
 
 describe('ProvidersPage available provider loading', () => {
   test('loads available providers only in add-provider mode', () => {
     expect(shouldLoadAvailableProviders(false)).toBe(false);
     expect(shouldLoadAvailableProviders(true)).toBe(true);
+  });
+});
+
+describe('provider auth method helpers', () => {
+  test('normalizeAuthType recognizes oauth and api from type or label', () => {
+    expect(normalizeAuthType({ type: 'oauth' })).toBe('oauth');
+    expect(normalizeAuthType({ type: 'api' })).toBe('api');
+    expect(normalizeAuthType({ label: 'Login with Cursor' })).toBe('');
+    expect(normalizeAuthType({ label: 'OAuth login' })).toBe('oauth');
+    expect(normalizeAuthType({ name: 'API Key' })).toBe('api');
+  });
+
+  test('shouldShowApiKeyField is true for unknown/empty and explicit api methods', () => {
+    expect(shouldShowApiKeyField([])).toBe(true);
+    expect(shouldShowApiKeyField([{ type: 'oauth', label: 'Login with Cursor' }])).toBe(false);
+    expect(shouldShowApiKeyField([{ type: 'api' }])).toBe(true);
+    expect(shouldShowApiKeyField([{ type: 'oauth' }, { type: 'api' }])).toBe(true);
+  });
+
+  test('oauth-only detection and original method indexes', () => {
+    const oauthOnly = [{ type: 'oauth', label: 'Login with Cursor' }];
+    expect(hasOauthAuthMethod(oauthOnly)).toBe(true);
+    expect(isOauthOnlyAuthMethods(oauthOnly)).toBe(true);
+    expect(oauthMethodIndexes(oauthOnly)).toEqual([0]);
+
+    const mixed = [{ type: 'api' }, { type: 'oauth', label: 'Login' }];
+    expect(hasOauthAuthMethod(mixed)).toBe(true);
+    expect(isOauthOnlyAuthMethods(mixed)).toBe(false);
+    expect(shouldShowApiKeyField(mixed)).toBe(true);
+    expect(oauthMethodIndexes(mixed)).toEqual([1]);
+
+    expect(isOauthOnlyAuthMethods([])).toBe(false);
+    expect(hasOauthAuthMethod([])).toBe(false);
   });
 });

--- a/packages/ui/src/components/sections/providers/ProvidersPage.tsx
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.tsx
@@ -26,13 +26,8 @@ import { getCurrentIntlLocale, useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { opencodeClient } from '@/lib/opencode/client';
 import { shouldLoadAvailableProviders } from './providerAvailability';
-import {
-  hasOauthAuthMethod,
-  isOauthOnlyAuthMethods,
-  oauthMethodIndexes,
-  shouldShowApiKeyField,
-  type AuthMethodLike,
-} from './providerAuth';
+import { deriveProviderAuthView, type ProviderAuthMethod } from './providerAuth';
+import { ProviderAuthPanel, type ProviderOAuthDetails } from './ProviderAuthPanel';
 import { CustomProviderForm } from './CustomProviderForm';
 import {
   buildAuthSetRequest,
@@ -66,11 +61,7 @@ const formatTokens = (value?: number | null) => {
 
 const ADD_PROVIDER_ID = '__add_provider__';
 
-interface AuthMethod extends AuthMethodLike {
-  description?: string;
-  help?: string;
-  method?: number;
-}
+const EMPTY_AUTH_METHODS: ProviderAuthMethod[] = [];
 
 interface ProviderOption {
   id: string;
@@ -92,14 +83,14 @@ interface ProviderSources {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
-const parseAuthPayload = (payload: unknown): Record<string, AuthMethod[]> => {
+const parseAuthPayload = (payload: unknown): Record<string, ProviderAuthMethod[]> => {
   if (!isRecord(payload)) {
     return {};
   }
-  const result: Record<string, AuthMethod[]> = {};
+  const result: Record<string, ProviderAuthMethod[]> = {};
   for (const [providerId, value] of Object.entries(payload)) {
     if (Array.isArray(value)) {
-      result[providerId] = value.filter((entry) => isRecord(entry)) as AuthMethod[];
+      result[providerId] = value.filter((entry) => isRecord(entry)) as ProviderAuthMethod[];
     }
   }
   return result;
@@ -162,14 +153,14 @@ export const ProvidersPage: React.FC = () => {
   const hideAllModels = useUIStore((state) => state.hideAllModels);
   const showAllModels = useUIStore((state) => state.showAllModels);
 
-  const [authMethodsByProvider, setAuthMethodsByProvider] = React.useState<Record<string, AuthMethod[]>>({});
+  const [authMethodsByProvider, setAuthMethodsByProvider] = React.useState<Record<string, ProviderAuthMethod[]>>({});
   const [authLoading, setAuthLoading] = React.useState(false);
   const [apiKeyInputs, setApiKeyInputs] = React.useState<Record<string, string>>({});
   const [authBusyKey, setAuthBusyKey] = React.useState<string | null>(null);
   const [modelQuery, setModelQuery] = React.useState('');
   const [pendingOAuth, setPendingOAuth] = React.useState<{ providerId: string; methodIndex: number } | null>(null);
   const [oauthCodes, setOauthCodes] = React.useState<Record<string, string>>({});
-  const [oauthDetails, setOauthDetails] = React.useState<Record<string, { url?: string; instructions?: string; userCode?: string }>>({});
+  const [oauthDetails, setOauthDetails] = React.useState<Record<string, ProviderOAuthDetails>>({});
   const [availableProviders, setAvailableProviders] = React.useState<ProviderOption[]>([]);
   const [availableLoading, setAvailableLoading] = React.useState(false);
   const [availableError, setAvailableError] = React.useState<string | null>(null);
@@ -295,6 +286,55 @@ export const ProvidersPage: React.FC = () => {
     }
   }, [selectedProviderId, candidateProviderId, unconnectedProviders]);
 
+  const loadProviderSources = React.useCallback(async (providerId: string) => {
+    try {
+      // OpenChamber-only metadata endpoint: the SDK exposes provider data but
+      // not local auth/source-file provenance used by this settings UI.
+      const response = await runtimeFetch(`/api/provider/${encodeURIComponent(providerId)}/source`, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(payload?.error || t('settings.providers.page.toast.providerSourcesLoadFailed'));
+      }
+
+      const sources = (payload?.sources ?? payload?.data?.sources) as ProviderSources | undefined;
+      if (sources) {
+        setProviderSources((prev) => ({ ...prev, [providerId]: sources }));
+      }
+    } catch (error) {
+      // Provenance stays unresolved on failure so the UI cannot claim stored credentials.
+      console.error('Failed to load provider sources:', error);
+    }
+  }, [t]);
+
+  React.useEffect(() => {
+    if (!selectedProviderId || selectedProviderId === ADD_PROVIDER_ID) {
+      return;
+    }
+
+    void loadProviderSources(selectedProviderId);
+  }, [selectedProviderId, loadProviderSources]);
+
+  const selectedProvider = providers.find((provider) => provider.id === selectedProviderId);
+  const selectedSources = selectedProviderId ? providerSources[selectedProviderId] : undefined;
+
+  const selectedAuthView = React.useMemo(() => {
+    const methods = selectedProviderId && selectedProviderId !== ADD_PROVIDER_ID
+      ? (authMethodsByProvider[selectedProviderId] ?? EMPTY_AUTH_METHODS)
+      : EMPTY_AUTH_METHODS;
+
+    return deriveProviderAuthView({
+      methods,
+      credentialsResolved: Boolean(selectedSources),
+      hasStoredCredentials: Boolean(selectedSources?.auth.exists),
+    });
+  }, [authMethodsByProvider, selectedProviderId, selectedSources]);
+
+  const autoOpenAuthPanel = selectedAuthView.autoOpenPanel;
+
   React.useEffect(() => {
     if (selectedProviderId === ADD_PROVIDER_ID) {
       setShowAuthPanel(true);
@@ -305,12 +345,7 @@ export const ProvidersPage: React.FC = () => {
       return;
     }
 
-    const methods = selectedProviderId ? (authMethodsByProvider[selectedProviderId] ?? []) : [];
-    if (hasOauthAuthMethod(methods)) {
-      setShowAuthPanel(true);
-    } else {
-      setShowAuthPanel(false);
-    }
+    setShowAuthPanel(autoOpenAuthPanel);
 
     if (editingCustomProviderId && editingCustomProviderId !== selectedProviderId) {
       setEditingCustomProviderId(null);
@@ -318,52 +353,7 @@ export const ProvidersPage: React.FC = () => {
       setEditingCustomScope(null);
       setCustomAuthFailureHint(null);
     }
-  }, [selectedProviderId, editingCustomProviderId, authMethodsByProvider]);
-
-  React.useEffect(() => {
-    if (!selectedProviderId || selectedProviderId === ADD_PROVIDER_ID) {
-      return;
-    }
-
-    let cancelled = false;
-
-    const loadSources = async () => {
-      try {
-        // OpenChamber-only metadata endpoint: the SDK exposes provider data but
-        // not local auth/source-file provenance used by this settings UI.
-        const response = await runtimeFetch(`/api/provider/${encodeURIComponent(selectedProviderId)}/source`, {
-          method: 'GET',
-          headers: { Accept: 'application/json' },
-        });
-
-        const payload = await response.json().catch(() => null);
-        if (!response.ok) {
-          throw new Error(payload?.error || t('settings.providers.page.toast.providerSourcesLoadFailed'));
-        }
-
-        const sources = (payload?.sources ?? payload?.data?.sources) as ProviderSources | undefined;
-        if (!cancelled && sources) {
-          setProviderSources((prev) => ({
-            ...prev,
-            [selectedProviderId]: sources,
-          }));
-        }
-      } catch (error) {
-        if (!cancelled) {
-          console.error('Failed to load provider sources:', error);
-        }
-      }
-    };
-
-    loadSources();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedProviderId, t]);
-
-  const selectedProvider = providers.find((provider) => provider.id === selectedProviderId);
-  const selectedSources = selectedProviderId ? providerSources[selectedProviderId] : undefined;
+  }, [selectedProviderId, editingCustomProviderId, autoOpenAuthPanel]);
 
   const handleSaveApiKey = async (providerId: string) => {
     const apiKey = apiKeyInputs[providerId]?.trim() ?? '';
@@ -387,6 +377,7 @@ export const ProvidersPage: React.FC = () => {
       toast.success(t('settings.providers.page.toast.apiKeySaved'));
       setApiKeyInputs((prev) => ({ ...prev, [providerId]: '' }));
       await reloadOpenCodeConfiguration({ scopes: ["providers"], mode: "active" });
+      await loadProviderSources(providerId);
       setSelectedProvider(providerId);
     } catch (error) {
       console.error('Failed to save API key:', error);
@@ -458,7 +449,16 @@ export const ProvidersPage: React.FC = () => {
     }
   };
 
-  const handleOAuthStart = async (providerId: string, methodIndex: number) => {
+  /**
+   * Requests the provider authorization details. `interactive` runs are user
+   * initiated and may open the browser and report failures; the prefetch used to
+   * reveal the sign-in URL never navigates or raises toasts on its own.
+   */
+  const startOAuth = React.useCallback(async (
+    providerId: string,
+    methodIndex: number,
+    { interactive }: { interactive: boolean },
+  ) => {
     const busyKey = `oauth:${providerId}:${methodIndex}`;
     setAuthBusyKey(busyKey);
 
@@ -503,48 +503,54 @@ export const ProvidersPage: React.FC = () => {
         },
       }));
 
+      setPendingOAuth({ providerId, methodIndex });
+
+      if (!interactive) {
+        return;
+      }
+
       if (urlCandidate) {
         void openExternalUrl(urlCandidate);
       }
-      setPendingOAuth({ providerId, methodIndex });
       toast.message(t('settings.providers.page.toast.completeOAuthInBrowser'));
     } catch (error) {
       console.error('Failed to start OAuth flow:', error);
-      toast.error(t('settings.providers.page.toast.oauthStartFailed'));
+      if (interactive) {
+        toast.error(t('settings.providers.page.toast.oauthStartFailed'));
+      }
     } finally {
       setAuthBusyKey(null);
     }
-  };
+  }, [t]);
 
-  // Auto-start OAuth authorize for oauth-only providers so the browser URL appears
-  // without an extra Connect click. Guarded once per provider id for this mount.
+  const handleOAuthStart = React.useCallback(
+    (providerId: string, methodIndex: number) => {
+      void startOAuth(providerId, methodIndex, { interactive: true });
+    },
+    [startOAuth],
+  );
+
+  // Prefetch the sign-in URL for providers that only support OAuth so it is visible
+  // with Open/Copy without pressing Connect first. Runs once per provider+method and
+  // never navigates on its own, since opening a browser needs explicit user intent.
   React.useEffect(() => {
-    if (authLoading || isAddMode) {
-      return;
-    }
-    if (!selectedProviderId || selectedProviderId === ADD_PROVIDER_ID) {
+    if (authLoading || isAddMode || !selectedProviderId) {
       return;
     }
 
-    const methods = authMethodsByProvider[selectedProviderId] ?? [];
-    if (!isOauthOnlyAuthMethods(methods)) {
-      return;
-    }
-    if (oauthAutoStartedRef.current.has(selectedProviderId)) {
+    const methodIndex = selectedAuthView.autoStartMethodIndex;
+    if (methodIndex === null) {
       return;
     }
 
-    const indexes = oauthMethodIndexes(methods);
-    const methodIndex = indexes[0];
-    if (methodIndex === undefined) {
+    const startKey = `${selectedProviderId}:${methodIndex}`;
+    if (oauthAutoStartedRef.current.has(startKey)) {
       return;
     }
 
-    oauthAutoStartedRef.current.add(selectedProviderId);
-    void handleOAuthStart(selectedProviderId, methodIndex);
-    // handleOAuthStart is stable enough for one-shot auto-start; intentionally omit from deps.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot per provider id
-  }, [authLoading, authMethodsByProvider, isAddMode, selectedProviderId]);
+    oauthAutoStartedRef.current.add(startKey);
+    void startOAuth(selectedProviderId, methodIndex, { interactive: false });
+  }, [authLoading, isAddMode, selectedAuthView.autoStartMethodIndex, selectedProviderId, startOAuth]);
 
   const handleOAuthComplete = async (providerId: string, methodIndex: number) => {
     const codeKey = `${providerId}:${methodIndex}`;
@@ -572,6 +578,8 @@ export const ProvidersPage: React.FC = () => {
       setOauthCodes((prev) => ({ ...prev, [codeKey]: '' }));
       setPendingOAuth(null);
       await reloadOpenCodeConfiguration({ scopes: ["providers"], mode: "active" });
+      // Refresh provenance so a completed sign-in stops showing as unauthenticated.
+      await loadProviderSources(providerId);
       setSelectedProvider(providerId);
     } catch (error) {
       console.error('Failed to complete OAuth flow:', error);
@@ -617,8 +625,23 @@ export const ProvidersPage: React.FC = () => {
       }
 
       toast.success(t('settings.providers.page.toast.providerDisconnected'));
-      oauthAutoStartedRef.current.delete(providerId);
+      // Allow a fresh sign-in URL prefetch for a provider that was just disconnected.
+      for (const key of [...oauthAutoStartedRef.current]) {
+        if (key.startsWith(`${providerId}:`)) {
+          oauthAutoStartedRef.current.delete(key);
+        }
+      }
+      setOauthDetails((prev) => {
+        const next = { ...prev };
+        for (const key of Object.keys(next)) {
+          if (key.startsWith(`${providerId}:`)) {
+            delete next[key];
+          }
+        }
+        return next;
+      });
       await reloadOpenCodeConfiguration({ scopes: ["providers"], mode: "active" });
+      await loadProviderSources(providerId);
     } catch (error) {
       console.error('Failed to disconnect provider:', error);
       toast.error(t('settings.providers.page.toast.providerDisconnectFailed'));
@@ -653,6 +676,12 @@ export const ProvidersPage: React.FC = () => {
   }
 
   if (isAddMode) {
+    const candidateAuthView = deriveProviderAuthView({
+      methods: authMethodsByProvider[candidateProviderId] ?? EMPTY_AUTH_METHODS,
+      credentialsResolved: false,
+      hasStoredCredentials: false,
+    });
+
     return (
       <SettingsPageLayout
         title={t('settings.providers.page.connect.title')}
@@ -805,131 +834,23 @@ export const ProvidersPage: React.FC = () => {
               {authLoading ? (
                 <p className="typography-meta text-muted-foreground">{t('settings.providers.page.auth.loadingMethods')}</p>
               ) : (
-                <>
-                  {(() => {
-                    const candidateAuthMethods = authMethodsByProvider[candidateProviderId] ?? [];
-                    const candidateOauthIndexes = oauthMethodIndexes(candidateAuthMethods);
-                    const showCandidateApiKey = shouldShowApiKeyField(candidateAuthMethods);
-
-                    return (
-                      <>
-                        {showCandidateApiKey ? (
-                          <div className="py-1.5">
-                            <label className="typography-ui-label text-foreground flex items-center gap-1.5">
-                              {t('settings.providers.page.auth.apiKeyLabel')}
-                              <SettingsInfoHint>{t('settings.providers.page.auth.apiKeyTooltip')}</SettingsInfoHint>
-                            </label>
-                            <div className="flex flex-col @xl:flex-row @xl:items-center gap-2 mt-1.5">
-                              <Input
-                                type="password"
-                                value={apiKeyInputs[candidateProviderId] ?? ''}
-                                onChange={(event) =>
-                                  setApiKeyInputs((prev) => ({
-                                    ...prev,
-                                    [candidateProviderId]: event.target.value,
-                                  }))
-                                }
-                                placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
-                                className="flex-1 font-mono text-xs"
-                              />
-                              <Button
-                                size="xs"
-                                className="!font-normal shrink-0"
-                                onClick={() => handleSaveApiKey(candidateProviderId)}
-                                disabled={authBusyKey === `api:${candidateProviderId}`}
-                              >
-                                {authBusyKey === `api:${candidateProviderId}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
-                              </Button>
-                            </div>
-                          </div>
-                        ) : null}
-
-                        {candidateOauthIndexes.length > 0 ? (
-                          <div className={cn('space-y-4', showCandidateApiKey && 'border-t border-[var(--surface-subtle)] pt-2')}>
-                            {candidateOauthIndexes.map((index) => {
-                              const method = candidateAuthMethods[index];
-                              const methodLabel = method?.label || method?.name || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
-                              const codeKey = `${candidateProviderId}:${index}`;
-                              const isPending =
-                                pendingOAuth?.providerId === candidateProviderId && pendingOAuth?.methodIndex === index;
-
-                              return (
-                                <div key={`${candidateProviderId}-${index}-${methodLabel}`} className="space-y-3">
-                                  <div className="flex items-center justify-between gap-2">
-                                    <div>
-                                      <div className="typography-ui-label text-foreground">{methodLabel}</div>
-                                      {(method?.description || method?.help) && (
-                                        <div className="typography-meta text-muted-foreground">
-                                          {String(method.description || method.help)}
-                                        </div>
-                                      )}
-                                    </div>
-                                    <Button
-                                      variant="outline"
-                                      size="xs"
-                                      className="!font-normal"
-                                      onClick={() => handleOAuthStart(candidateProviderId, index)}
-                                      disabled={authBusyKey === `oauth:${candidateProviderId}:${index}`}
-                                    >
-                                      {t('settings.providers.page.actions.connect')}
-                                    </Button>
-                                  </div>
-
-                                  {oauthDetails[codeKey]?.instructions && (
-                                    <p className="typography-meta text-[var(--primary-base)] bg-[var(--primary-base)]/10 px-2 py-1.5 rounded">
-                                      {oauthDetails[codeKey]?.instructions}
-                                    </p>
-                                  )}
-
-                                  {oauthDetails[codeKey]?.userCode && (
-                                    <div className="flex items-center gap-2 mt-2">
-                                      <Input value={oauthDetails[codeKey]?.userCode} readOnly className="font-mono text-center tracking-widest" />
-                                      <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthCode(oauthDetails[codeKey]?.userCode ?? '')}>{t('settings.providers.page.actions.copyCode')}</Button>
-                                    </div>
-                                  )}
-
-                                  {oauthDetails[codeKey]?.url && (
-                                    <div className="flex items-center gap-2 mt-2">
-                                      <Input value={oauthDetails[codeKey]?.url} readOnly className="text-xs text-muted-foreground" />
-                                      <div className="flex gap-1 shrink-0">
-                                        <Button variant="outline" size="xs" className="!font-normal" onClick={() => openExternalUrl(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.open')}</Button>
-                                        <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthLink(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.copy')}</Button>
-                                      </div>
-                                    </div>
-                                  )}
-
-                                  {isPending && (
-                                    <div className="flex items-center gap-2 mt-2">
-                                      <Input
-                                        value={oauthCodes[codeKey] ?? ''}
-                                        onChange={(event) =>
-                                          setOauthCodes((prev) => ({
-                                            ...prev,
-                                            [codeKey]: event.target.value,
-                                          }))
-                                        }
-                                        placeholder={t('settings.providers.page.auth.pasteAuthorizationCodePlaceholder')}
-                                        className="font-mono text-xs"
-                                      />
-                                      <Button
-                                        size="xs"
-                                        className="!font-normal"
-                                        onClick={() => handleOAuthComplete(candidateProviderId, index)}
-                                        disabled={authBusyKey === `oauth-complete:${candidateProviderId}:${index}`}
-                                      >
-                                        {authBusyKey === `oauth-complete:${candidateProviderId}:${index}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.complete')}
-                                      </Button>
-                                    </div>
-                                  )}
-                                </div>
-                              );
-                            })}
-                          </div>
-                        ) : null}
-                      </>
-                    );
-                  })()}
-                </>
+                <ProviderAuthPanel
+                  providerId={candidateProviderId}
+                  oauthEntries={candidateAuthView.oauthEntries}
+                  showApiKeyField={candidateAuthView.showApiKeyField}
+                  apiKeyValue={apiKeyInputs[candidateProviderId] ?? ''}
+                  onApiKeyChange={(value) => setApiKeyInputs((prev) => ({ ...prev, [candidateProviderId]: value }))}
+                  onSaveApiKey={() => handleSaveApiKey(candidateProviderId)}
+                  busyKey={authBusyKey}
+                  oauthDetails={oauthDetails}
+                  oauthCodes={oauthCodes}
+                  onOAuthCodeChange={(codeKey, value) => setOauthCodes((prev) => ({ ...prev, [codeKey]: value }))}
+                  pendingOAuth={pendingOAuth}
+                  onOAuthStart={(methodIndex) => handleOAuthStart(candidateProviderId, methodIndex)}
+                  onOAuthComplete={(methodIndex) => handleOAuthComplete(candidateProviderId, methodIndex)}
+                  onCopyOAuthLink={handleCopyOAuthLink}
+                  onCopyOAuthCode={handleCopyOAuthCode}
+                />
               )}
             </SettingsSection>
           ) : null}
@@ -950,11 +871,6 @@ export const ProvidersPage: React.FC = () => {
   }
 
   const providerModels = Array.isArray(selectedProvider.models) ? selectedProvider.models : [];
-  const providerAuthMethods = authMethodsByProvider[selectedProvider.id] ?? [];
-  const providerOauthIndexes = oauthMethodIndexes(providerAuthMethods);
-  const showProviderApiKey = shouldShowApiKeyField(providerAuthMethods);
-  const oauthOnlyWithoutCredentials = isOauthOnlyAuthMethods(providerAuthMethods)
-    && !selectedSources?.auth.exists;
   const sourcesLoaded = Boolean(selectedSources);
   const isEditableCustomProvider = sourcesLoaded
     && isConfigDefinedCustomProvider(selectedProvider, selectedSources);
@@ -965,11 +881,6 @@ export const ProvidersPage: React.FC = () => {
   const hasEnvCredentials = providerEnv.length > 0;
   const hasCredentials = hasStoredAuth || hasEnvCredentials;
   const authStatusIncomplete = isEditableCustomProvider && !hasCredentials;
-  // OAuth-only providers without stored credentials must not show a fake Connected state.
-  const showAuthConnectedSummary = !authLoading
-    && !showAuthPanel
-    && !authStatusIncomplete
-    && !oauthOnlyWithoutCredentials;
 
   const filteredModels = providerModels.filter((model) => {
     const name = typeof model?.name === 'string' ? model.name : '';
@@ -1047,136 +958,46 @@ export const ProvidersPage: React.FC = () => {
         )}
         settingsItem="providers.auth"
       >
-            {showAuthConnectedSummary ? (
-              <div className="flex items-center gap-1.5 py-1.5">
-                <Icon name="check" className="w-4 h-4 text-[var(--status-success)] shrink-0" />
-                <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.connected')}</span>
-                <SettingsInfoHint>{t('settings.providers.page.auth.useReconnectHint')}</SettingsInfoHint>
-              </div>
-            ) : !showAuthPanel && authStatusIncomplete ? (
-              <div className="flex items-center gap-1.5 py-1.5">
-                <Icon name="alert" className="w-4 h-4 text-[var(--status-warning)] shrink-0" />
-                <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.incomplete')}</span>
-                <SettingsInfoHint>{t('settings.providers.page.auth.incompleteHint')}</SettingsInfoHint>
-              </div>
+            {!showAuthPanel ? (
+              authStatusIncomplete ? (
+                <div className="flex items-center gap-1.5 py-1.5">
+                  <Icon name="alert" className="w-4 h-4 text-[var(--status-warning)] shrink-0" />
+                  <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.incomplete')}</span>
+                  <SettingsInfoHint>{t('settings.providers.page.auth.incompleteHint')}</SettingsInfoHint>
+                </div>
+              ) : selectedAuthView.signInRequired ? (
+                <div className="flex items-center gap-1.5 py-1.5">
+                  <Icon name="alert" className="w-4 h-4 text-[var(--status-warning)] shrink-0" />
+                  <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.signInRequired')}</span>
+                  <SettingsInfoHint>{t('settings.providers.page.auth.signInRequiredHint')}</SettingsInfoHint>
+                </div>
+              ) : (
+                <div className="flex items-center gap-1.5 py-1.5">
+                  <Icon name="check" className="w-4 h-4 text-[var(--status-success)] shrink-0" />
+                  <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.connected')}</span>
+                  <SettingsInfoHint>{t('settings.providers.page.auth.useReconnectHint')}</SettingsInfoHint>
+                </div>
+              )
             ) : authLoading ? (
               <div className="py-1.5 typography-meta text-muted-foreground">{t('settings.providers.page.auth.loadingMethods')}</div>
             ) : (
-              <div className="space-y-4">
-                {showProviderApiKey ? (
-                  <div className="py-1.5">
-                    <label className="typography-ui-label text-foreground flex items-center gap-1.5">
-                      {t('settings.providers.page.auth.apiKeyLabel')}
-                      <SettingsInfoHint>{t('settings.providers.page.auth.apiKeyTooltip')}</SettingsInfoHint>
-                    </label>
-                    <div className="flex flex-col @xl:flex-row @xl:items-center gap-2 mt-1.5">
-                      <Input
-                        type="password"
-                        value={apiKeyInputs[selectedProvider.id] ?? ''}
-                        onChange={(event) =>
-                          setApiKeyInputs((prev) => ({
-                            ...prev,
-                            [selectedProvider.id]: event.target.value,
-                          }))
-                        }
-                        placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
-                        className="flex-1 font-mono text-xs"
-                      />
-                      <Button
-                        size="xs"
-                        className="!font-normal shrink-0"
-                        onClick={() => handleSaveApiKey(selectedProvider.id)}
-                        disabled={authBusyKey === `api:${selectedProvider.id}`}
-                      >
-                        {authBusyKey === `api:${selectedProvider.id}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
-                      </Button>
-                    </div>
-                  </div>
-                ) : null}
-
-                {providerOauthIndexes.length > 0 && (
-                  <div className={cn('space-y-4', showProviderApiKey && 'border-t border-[var(--surface-subtle)] pt-2')}>
-                    {providerOauthIndexes.map((index) => {
-                      const method = providerAuthMethods[index];
-                      const methodLabel = method?.label || method?.name || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
-                      const codeKey = `${selectedProvider.id}:${index}`;
-                      const isPending =
-                        pendingOAuth?.providerId === selectedProvider.id && pendingOAuth?.methodIndex === index;
-
-                      return (
-                        <div key={`${selectedProvider.id}-${index}-${methodLabel}`} className="space-y-3">
-                          <div className="flex items-center justify-between gap-2">
-                            <div>
-                              <div className="typography-ui-label text-foreground">{methodLabel}</div>
-                              {(method?.description || method?.help) && (
-                                <div className="typography-meta text-muted-foreground">
-                                  {String(method.description || method.help)}
-                                </div>
-                              )}
-                            </div>
-                            <Button
-                              variant="outline"
-                              size="xs"
-                              className="!font-normal"
-                              onClick={() => handleOAuthStart(selectedProvider.id, index)}
-                              disabled={authBusyKey === `oauth:${selectedProvider.id}:${index}`}
-                            >
-                              {t('settings.providers.page.actions.connect')}
-                            </Button>
-                          </div>
-
-                          {oauthDetails[codeKey]?.instructions && (
-                            <p className="typography-meta text-[var(--primary-base)] bg-[var(--primary-base)]/10 px-2 py-1.5 rounded">
-                              {oauthDetails[codeKey]?.instructions}
-                            </p>
-                          )}
-
-                          {oauthDetails[codeKey]?.userCode && (
-                            <div className="flex items-center gap-2 mt-2">
-                              <Input value={oauthDetails[codeKey]?.userCode} readOnly className="font-mono text-center tracking-widest" />
-                              <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthCode(oauthDetails[codeKey]?.userCode ?? '')}>{t('settings.providers.page.actions.copyCode')}</Button>
-                            </div>
-                          )}
-
-                          {oauthDetails[codeKey]?.url && (
-                            <div className="flex items-center gap-2 mt-2">
-                              <Input value={oauthDetails[codeKey]?.url} readOnly className="text-xs text-muted-foreground" />
-                              <div className="flex gap-1 shrink-0">
-                                <Button variant="outline" size="xs" className="!font-normal" onClick={() => openExternalUrl(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.open')}</Button>
-                                <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthLink(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.copy')}</Button>
-                              </div>
-                            </div>
-                          )}
-
-                          {isPending && (
-                            <div className="flex items-center gap-2 mt-2">
-                              <Input
-                                value={oauthCodes[codeKey] ?? ''}
-                                onChange={(event) =>
-                                  setOauthCodes((prev) => ({
-                                    ...prev,
-                                    [codeKey]: event.target.value,
-                                  }))
-                                }
-                                placeholder={t('settings.providers.page.auth.pasteAuthorizationCodePlaceholder')}
-                                className="font-mono text-xs"
-                              />
-                              <Button
-                                size="xs"
-                                className="!font-normal"
-                                onClick={() => handleOAuthComplete(selectedProvider.id, index)}
-                                disabled={authBusyKey === `oauth-complete:${selectedProvider.id}:${index}`}
-                              >
-                                {authBusyKey === `oauth-complete:${selectedProvider.id}:${index}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.complete')}
-                              </Button>
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
+              <ProviderAuthPanel
+                providerId={selectedProvider.id}
+                oauthEntries={selectedAuthView.oauthEntries}
+                showApiKeyField={selectedAuthView.showApiKeyField}
+                apiKeyValue={apiKeyInputs[selectedProvider.id] ?? ''}
+                onApiKeyChange={(value) => setApiKeyInputs((prev) => ({ ...prev, [selectedProvider.id]: value }))}
+                onSaveApiKey={() => handleSaveApiKey(selectedProvider.id)}
+                busyKey={authBusyKey}
+                oauthDetails={oauthDetails}
+                oauthCodes={oauthCodes}
+                onOAuthCodeChange={(codeKey, value) => setOauthCodes((prev) => ({ ...prev, [codeKey]: value }))}
+                pendingOAuth={pendingOAuth}
+                onOAuthStart={(methodIndex) => handleOAuthStart(selectedProvider.id, methodIndex)}
+                onOAuthComplete={(methodIndex) => handleOAuthComplete(selectedProvider.id, methodIndex)}
+                onCopyOAuthLink={handleCopyOAuthLink}
+                onCopyOAuthCode={handleCopyOAuthCode}
+              />
             )}
       </SettingsSection>
 

--- a/packages/ui/src/components/sections/providers/ProvidersPage.tsx
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.tsx
@@ -25,7 +25,11 @@ import type { ModelMetadata } from '@/types';
 import { getCurrentIntlLocale, useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { opencodeClient } from '@/lib/opencode/client';
-import { shouldLoadAvailableProviders } from './providerAvailability';
+import {
+  listConnectableProviders,
+  shouldLoadAvailableProviders,
+  type ConnectableProvider,
+} from './providerAvailability';
 import { deriveProviderAuthView, type ProviderAuthMethod } from './providerAuth';
 import { ProviderAuthPanel, type ProviderOAuthDetails } from './ProviderAuthPanel';
 import { CustomProviderForm } from './CustomProviderForm';
@@ -63,11 +67,6 @@ const ADD_PROVIDER_ID = '__add_provider__';
 
 const EMPTY_AUTH_METHODS: ProviderAuthMethod[] = [];
 
-interface ProviderOption {
-  id: string;
-  name?: string;
-}
-
 interface ProviderSourceInfo {
   exists: boolean;
   path?: string | null;
@@ -96,7 +95,7 @@ const parseAuthPayload = (payload: unknown): Record<string, ProviderAuthMethod[]
   return result;
 };
 
-const normalizeProviderEntry = (entry: unknown): ProviderOption | null => {
+const normalizeProviderEntry = (entry: unknown): ConnectableProvider | null => {
   if (typeof entry === 'string') {
     return { id: entry };
   }
@@ -115,7 +114,7 @@ const normalizeProviderEntry = (entry: unknown): ProviderOption | null => {
   return { id: idCandidate, name: nameCandidate };
 };
 
-const parseProvidersPayload = (payload: unknown): ProviderOption[] => {
+const parseProvidersPayload = (payload: unknown): ConnectableProvider[] => {
   let entries: unknown[] = [];
 
   if (Array.isArray(payload)) {
@@ -130,7 +129,7 @@ const parseProvidersPayload = (payload: unknown): ProviderOption[] => {
 
   const mapped = entries
     .map((entry) => normalizeProviderEntry(entry))
-    .filter((entry): entry is ProviderOption => Boolean(entry));
+    .filter((entry): entry is ConnectableProvider => Boolean(entry));
 
   const seen = new Set<string>();
   return mapped.filter((entry) => {
@@ -161,7 +160,7 @@ export const ProvidersPage: React.FC = () => {
   const [pendingOAuth, setPendingOAuth] = React.useState<{ providerId: string; methodIndex: number } | null>(null);
   const [oauthCodes, setOauthCodes] = React.useState<Record<string, string>>({});
   const [oauthDetails, setOauthDetails] = React.useState<Record<string, ProviderOAuthDetails>>({});
-  const [availableProviders, setAvailableProviders] = React.useState<ProviderOption[]>([]);
+  const [availableProviders, setAvailableProviders] = React.useState<ConnectableProvider[]>([]);
   const [availableLoading, setAvailableLoading] = React.useState(false);
   const [availableError, setAvailableError] = React.useState<string | null>(null);
   const [candidateProviderId, setCandidateProviderId] = React.useState('');
@@ -261,15 +260,12 @@ export const ProvidersPage: React.FC = () => {
   );
 
   const unconnectedProviders = React.useMemo(
-    () =>
-      availableProviders
-        .filter((provider) => !connectedProviderIds.has(provider.id))
-        .sort((a, b) => {
-          const labelA = (a.name || a.id).toLowerCase();
-          const labelB = (b.name || b.id).toLowerCase();
-          return labelA.localeCompare(labelB);
-        }),
-    [availableProviders, connectedProviderIds]
+    () => listConnectableProviders({
+      catalog: availableProviders,
+      authProviderIds: Object.keys(authMethodsByProvider),
+      connectedIds: connectedProviderIds,
+    }),
+    [availableProviders, authMethodsByProvider, connectedProviderIds]
   );
 
   React.useEffect(() => {

--- a/packages/ui/src/components/sections/providers/ProvidersPage.tsx
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.tsx
@@ -26,6 +26,13 @@ import { getCurrentIntlLocale, useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
 import { opencodeClient } from '@/lib/opencode/client';
 import { shouldLoadAvailableProviders } from './providerAvailability';
+import {
+  hasOauthAuthMethod,
+  isOauthOnlyAuthMethods,
+  oauthMethodIndexes,
+  shouldShowApiKeyField,
+  type AuthMethodLike,
+} from './providerAuth';
 import { CustomProviderForm } from './CustomProviderForm';
 import {
   buildAuthSetRequest,
@@ -59,14 +66,10 @@ const formatTokens = (value?: number | null) => {
 
 const ADD_PROVIDER_ID = '__add_provider__';
 
-interface AuthMethod {
-  type?: string;
-  name?: string;
-  label?: string;
+interface AuthMethod extends AuthMethodLike {
   description?: string;
   help?: string;
   method?: number;
-  [key: string]: unknown;
 }
 
 interface ProviderOption {
@@ -88,15 +91,6 @@ interface ProviderSources {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
-
-const normalizeAuthType = (method: AuthMethod) => {
-  const raw = typeof method.type === 'string' ? method.type : '';
-  const label = `${method.name ?? ''} ${method.label ?? ''}`.toLowerCase();
-  const merged = `${raw} ${label}`.toLowerCase();
-  if (merged.includes('oauth')) return 'oauth';
-  if (merged.includes('api')) return 'api';
-  return raw.toLowerCase();
-};
 
 const parseAuthPayload = (payload: unknown): Record<string, AuthMethod[]> => {
   if (!isRecord(payload)) {
@@ -189,6 +183,7 @@ export const ProvidersPage: React.FC = () => {
   const [editingCustomScope, setEditingCustomScope] = React.useState<ProviderConfigScope | null>(null);
   const [customAuthFailureHint, setCustomAuthFailureHint] = React.useState<string | null>(null);
   const [lastCustomPersistId, setLastCustomPersistId] = React.useState<string | null>(null);
+  const oauthAutoStartedRef = React.useRef(new Set<string>());
   const isAddMode = selectedProviderId === ADD_PROVIDER_ID;
   const isCustomCreateMode = isAddMode && candidateProviderId === CUSTOM_PROVIDER_ID;
   const isCustomEditMode = Boolean(
@@ -205,10 +200,6 @@ export const ProvidersPage: React.FC = () => {
   }, [providers, selectedProviderId, setSelectedProvider]);
 
   React.useEffect(() => {
-    if (!isAddMode) {
-      return;
-    }
-
     let isMounted = true;
 
     const loadAuthMethods = async () => {
@@ -236,7 +227,7 @@ export const ProvidersPage: React.FC = () => {
     return () => {
       isMounted = false;
     };
-  }, [isAddMode, t]);
+  }, [t]);
 
   React.useEffect(() => {
     if (!shouldLoadAvailableProviders(isAddMode)) {
@@ -314,14 +305,20 @@ export const ProvidersPage: React.FC = () => {
       return;
     }
 
-    setShowAuthPanel(false);
+    const methods = selectedProviderId ? (authMethodsByProvider[selectedProviderId] ?? []) : [];
+    if (hasOauthAuthMethod(methods)) {
+      setShowAuthPanel(true);
+    } else {
+      setShowAuthPanel(false);
+    }
+
     if (editingCustomProviderId && editingCustomProviderId !== selectedProviderId) {
       setEditingCustomProviderId(null);
       setEditingCustomFormInitial(null);
       setEditingCustomScope(null);
       setCustomAuthFailureHint(null);
     }
-  }, [selectedProviderId, editingCustomProviderId]);
+  }, [selectedProviderId, editingCustomProviderId, authMethodsByProvider]);
 
   React.useEffect(() => {
     if (!selectedProviderId || selectedProviderId === ADD_PROVIDER_ID) {
@@ -519,6 +516,36 @@ export const ProvidersPage: React.FC = () => {
     }
   };
 
+  // Auto-start OAuth authorize for oauth-only providers so the browser URL appears
+  // without an extra Connect click. Guarded once per provider id for this mount.
+  React.useEffect(() => {
+    if (authLoading || isAddMode) {
+      return;
+    }
+    if (!selectedProviderId || selectedProviderId === ADD_PROVIDER_ID) {
+      return;
+    }
+
+    const methods = authMethodsByProvider[selectedProviderId] ?? [];
+    if (!isOauthOnlyAuthMethods(methods)) {
+      return;
+    }
+    if (oauthAutoStartedRef.current.has(selectedProviderId)) {
+      return;
+    }
+
+    const indexes = oauthMethodIndexes(methods);
+    const methodIndex = indexes[0];
+    if (methodIndex === undefined) {
+      return;
+    }
+
+    oauthAutoStartedRef.current.add(selectedProviderId);
+    void handleOAuthStart(selectedProviderId, methodIndex);
+    // handleOAuthStart is stable enough for one-shot auto-start; intentionally omit from deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot per provider id
+  }, [authLoading, authMethodsByProvider, isAddMode, selectedProviderId]);
+
   const handleOAuthComplete = async (providerId: string, methodIndex: number) => {
     const codeKey = `${providerId}:${methodIndex}`;
     const code = oauthCodes[codeKey]?.trim();
@@ -590,6 +617,7 @@ export const ProvidersPage: React.FC = () => {
       }
 
       toast.success(t('settings.providers.page.toast.providerDisconnected'));
+      oauthAutoStartedRef.current.delete(providerId);
       await reloadOpenCodeConfiguration({ scopes: ["providers"], mode: "active" });
     } catch (error) {
       console.error('Failed to disconnect provider:', error);
@@ -778,125 +806,127 @@ export const ProvidersPage: React.FC = () => {
                 <p className="typography-meta text-muted-foreground">{t('settings.providers.page.auth.loadingMethods')}</p>
               ) : (
                 <>
-                  <div className="py-1.5">
-                    <label className="typography-ui-label text-foreground flex items-center gap-1.5">
-                      {t('settings.providers.page.auth.apiKeyLabel')}
-                      <SettingsInfoHint>{t('settings.providers.page.auth.apiKeyTooltip')}</SettingsInfoHint>
-                    </label>
-                    <div className="flex flex-col @xl:flex-row @xl:items-center gap-2 mt-1.5">
-                      <Input
-                        type="password"
-                        value={apiKeyInputs[candidateProviderId] ?? ''}
-                        onChange={(event) =>
-                          setApiKeyInputs((prev) => ({
-                            ...prev,
-                            [candidateProviderId]: event.target.value,
-                          }))
-                        }
-                        placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
-                        className="flex-1 font-mono text-xs"
-                      />
-                      <Button
-                        size="xs"
-                        className="!font-normal shrink-0"
-                        onClick={() => handleSaveApiKey(candidateProviderId)}
-                        disabled={authBusyKey === `api:${candidateProviderId}`}
-                      >
-                        {authBusyKey === `api:${candidateProviderId}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
-                      </Button>
-                    </div>
-                  </div>
-
                   {(() => {
                     const candidateAuthMethods = authMethodsByProvider[candidateProviderId] ?? [];
-                    const candidateOAuthMethods = candidateAuthMethods.filter(
-                      (method) => normalizeAuthType(method) === 'oauth'
-                    );
-
-                    if (candidateOAuthMethods.length === 0) {
-                      return null;
-                    }
+                    const candidateOauthIndexes = oauthMethodIndexes(candidateAuthMethods);
+                    const showCandidateApiKey = shouldShowApiKeyField(candidateAuthMethods);
 
                     return (
-                      <div className="space-y-4 border-t border-[var(--surface-subtle)] pt-2">
-                        {candidateOAuthMethods.map((method, index) => {
-                          const methodLabel = method.label || method.name || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
-                          const codeKey = `${candidateProviderId}:${index}`;
-                          const isPending =
-                            pendingOAuth?.providerId === candidateProviderId && pendingOAuth?.methodIndex === index;
+                      <>
+                        {showCandidateApiKey ? (
+                          <div className="py-1.5">
+                            <label className="typography-ui-label text-foreground flex items-center gap-1.5">
+                              {t('settings.providers.page.auth.apiKeyLabel')}
+                              <SettingsInfoHint>{t('settings.providers.page.auth.apiKeyTooltip')}</SettingsInfoHint>
+                            </label>
+                            <div className="flex flex-col @xl:flex-row @xl:items-center gap-2 mt-1.5">
+                              <Input
+                                type="password"
+                                value={apiKeyInputs[candidateProviderId] ?? ''}
+                                onChange={(event) =>
+                                  setApiKeyInputs((prev) => ({
+                                    ...prev,
+                                    [candidateProviderId]: event.target.value,
+                                  }))
+                                }
+                                placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
+                                className="flex-1 font-mono text-xs"
+                              />
+                              <Button
+                                size="xs"
+                                className="!font-normal shrink-0"
+                                onClick={() => handleSaveApiKey(candidateProviderId)}
+                                disabled={authBusyKey === `api:${candidateProviderId}`}
+                              >
+                                {authBusyKey === `api:${candidateProviderId}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
+                              </Button>
+                            </div>
+                          </div>
+                        ) : null}
 
-                          return (
-                            <div key={`${candidateProviderId}-${methodLabel}`} className="space-y-3">
-                              <div className="flex items-center justify-between gap-2">
-                                <div>
-                                  <div className="typography-ui-label text-foreground">{methodLabel}</div>
-                                  {(method.description || method.help) && (
-                                    <div className="typography-meta text-muted-foreground">
-                                      {String(method.description || method.help)}
+                        {candidateOauthIndexes.length > 0 ? (
+                          <div className={cn('space-y-4', showCandidateApiKey && 'border-t border-[var(--surface-subtle)] pt-2')}>
+                            {candidateOauthIndexes.map((index) => {
+                              const method = candidateAuthMethods[index];
+                              const methodLabel = method?.label || method?.name || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
+                              const codeKey = `${candidateProviderId}:${index}`;
+                              const isPending =
+                                pendingOAuth?.providerId === candidateProviderId && pendingOAuth?.methodIndex === index;
+
+                              return (
+                                <div key={`${candidateProviderId}-${index}-${methodLabel}`} className="space-y-3">
+                                  <div className="flex items-center justify-between gap-2">
+                                    <div>
+                                      <div className="typography-ui-label text-foreground">{methodLabel}</div>
+                                      {(method?.description || method?.help) && (
+                                        <div className="typography-meta text-muted-foreground">
+                                          {String(method.description || method.help)}
+                                        </div>
+                                      )}
+                                    </div>
+                                    <Button
+                                      variant="outline"
+                                      size="xs"
+                                      className="!font-normal"
+                                      onClick={() => handleOAuthStart(candidateProviderId, index)}
+                                      disabled={authBusyKey === `oauth:${candidateProviderId}:${index}`}
+                                    >
+                                      {t('settings.providers.page.actions.connect')}
+                                    </Button>
+                                  </div>
+
+                                  {oauthDetails[codeKey]?.instructions && (
+                                    <p className="typography-meta text-[var(--primary-base)] bg-[var(--primary-base)]/10 px-2 py-1.5 rounded">
+                                      {oauthDetails[codeKey]?.instructions}
+                                    </p>
+                                  )}
+
+                                  {oauthDetails[codeKey]?.userCode && (
+                                    <div className="flex items-center gap-2 mt-2">
+                                      <Input value={oauthDetails[codeKey]?.userCode} readOnly className="font-mono text-center tracking-widest" />
+                                      <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthCode(oauthDetails[codeKey]?.userCode ?? '')}>{t('settings.providers.page.actions.copyCode')}</Button>
+                                    </div>
+                                  )}
+
+                                  {oauthDetails[codeKey]?.url && (
+                                    <div className="flex items-center gap-2 mt-2">
+                                      <Input value={oauthDetails[codeKey]?.url} readOnly className="text-xs text-muted-foreground" />
+                                      <div className="flex gap-1 shrink-0">
+                                        <Button variant="outline" size="xs" className="!font-normal" onClick={() => openExternalUrl(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.open')}</Button>
+                                        <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthLink(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.copy')}</Button>
+                                      </div>
+                                    </div>
+                                  )}
+
+                                  {isPending && (
+                                    <div className="flex items-center gap-2 mt-2">
+                                      <Input
+                                        value={oauthCodes[codeKey] ?? ''}
+                                        onChange={(event) =>
+                                          setOauthCodes((prev) => ({
+                                            ...prev,
+                                            [codeKey]: event.target.value,
+                                          }))
+                                        }
+                                        placeholder={t('settings.providers.page.auth.pasteAuthorizationCodePlaceholder')}
+                                        className="font-mono text-xs"
+                                      />
+                                      <Button
+                                        size="xs"
+                                        className="!font-normal"
+                                        onClick={() => handleOAuthComplete(candidateProviderId, index)}
+                                        disabled={authBusyKey === `oauth-complete:${candidateProviderId}:${index}`}
+                                      >
+                                        {authBusyKey === `oauth-complete:${candidateProviderId}:${index}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.complete')}
+                                      </Button>
                                     </div>
                                   )}
                                 </div>
-                                <Button
-                                  variant="outline"
-                                  size="xs"
-                                  className="!font-normal"
-                                  onClick={() => handleOAuthStart(candidateProviderId, index)}
-                                  disabled={authBusyKey === `oauth:${candidateProviderId}:${index}`}
-                                >
-                                  {t('settings.providers.page.actions.connect')}
-                                </Button>
-                              </div>
-
-                              {oauthDetails[codeKey]?.instructions && (
-                                <p className="typography-meta text-[var(--primary-base)] bg-[var(--primary-base)]/10 px-2 py-1.5 rounded">
-                                  {oauthDetails[codeKey]?.instructions}
-                                </p>
-                              )}
-
-                              {oauthDetails[codeKey]?.userCode && (
-                                <div className="flex items-center gap-2 mt-2">
-                                  <Input value={oauthDetails[codeKey]?.userCode} readOnly className="font-mono text-center tracking-widest" />
-                                  <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthCode(oauthDetails[codeKey]?.userCode ?? '')}>{t('settings.providers.page.actions.copyCode')}</Button>
-                                </div>
-                              )}
-
-                              {oauthDetails[codeKey]?.url && (
-                                <div className="flex items-center gap-2 mt-2">
-                                  <Input value={oauthDetails[codeKey]?.url} readOnly className="text-xs text-muted-foreground" />
-                                  <div className="flex gap-1 shrink-0">
-                                    <Button variant="outline" size="xs" className="!font-normal" onClick={() => openExternalUrl(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.open')}</Button>
-                                    <Button variant="outline" size="xs" className="!font-normal" onClick={() => handleCopyOAuthLink(oauthDetails[codeKey]?.url ?? '')}>{t('settings.providers.page.actions.copy')}</Button>
-                                  </div>
-                                </div>
-                              )}
-
-                              {isPending && (
-                                <div className="flex items-center gap-2 mt-2">
-                                  <Input
-                                    value={oauthCodes[codeKey] ?? ''}
-                                    onChange={(event) =>
-                                      setOauthCodes((prev) => ({
-                                        ...prev,
-                                        [codeKey]: event.target.value,
-                                      }))
-                                    }
-                                    placeholder={t('settings.providers.page.auth.pasteAuthorizationCodePlaceholder')}
-                                    className="font-mono text-xs"
-                                  />
-                                  <Button
-                                    size="xs"
-                                    className="!font-normal"
-                                    onClick={() => handleOAuthComplete(candidateProviderId, index)}
-                                    disabled={authBusyKey === `oauth-complete:${candidateProviderId}:${index}`}
-                                  >
-                                    {authBusyKey === `oauth-complete:${candidateProviderId}:${index}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.complete')}
-                                  </Button>
-                                </div>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
+                              );
+                            })}
+                          </div>
+                        ) : null}
+                      </>
                     );
                   })()}
                 </>
@@ -921,7 +951,10 @@ export const ProvidersPage: React.FC = () => {
 
   const providerModels = Array.isArray(selectedProvider.models) ? selectedProvider.models : [];
   const providerAuthMethods = authMethodsByProvider[selectedProvider.id] ?? [];
-  const oauthAuthMethods = providerAuthMethods.filter((method) => normalizeAuthType(method) === 'oauth');
+  const providerOauthIndexes = oauthMethodIndexes(providerAuthMethods);
+  const showProviderApiKey = shouldShowApiKeyField(providerAuthMethods);
+  const oauthOnlyWithoutCredentials = isOauthOnlyAuthMethods(providerAuthMethods)
+    && !selectedSources?.auth.exists;
   const sourcesLoaded = Boolean(selectedSources);
   const isEditableCustomProvider = sourcesLoaded
     && isConfigDefinedCustomProvider(selectedProvider, selectedSources);
@@ -932,6 +965,11 @@ export const ProvidersPage: React.FC = () => {
   const hasEnvCredentials = providerEnv.length > 0;
   const hasCredentials = hasStoredAuth || hasEnvCredentials;
   const authStatusIncomplete = isEditableCustomProvider && !hasCredentials;
+  // OAuth-only providers without stored credentials must not show a fake Connected state.
+  const showAuthConnectedSummary = !authLoading
+    && !showAuthPanel
+    && !authStatusIncomplete
+    && !oauthOnlyWithoutCredentials;
 
   const filteredModels = providerModels.filter((model) => {
     const name = typeof model?.name === 'string' ? model.name : '';
@@ -1009,67 +1047,68 @@ export const ProvidersPage: React.FC = () => {
         )}
         settingsItem="providers.auth"
       >
-            {!showAuthPanel ? (
-              authStatusIncomplete ? (
-                <div className="flex items-center gap-1.5 py-1.5">
-                  <Icon name="alert" className="w-4 h-4 text-[var(--status-warning)] shrink-0" />
-                  <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.incomplete')}</span>
-                  <SettingsInfoHint>{t('settings.providers.page.auth.incompleteHint')}</SettingsInfoHint>
-                </div>
-              ) : (
-                <div className="flex items-center gap-1.5 py-1.5">
-                  <Icon name="check" className="w-4 h-4 text-[var(--status-success)] shrink-0" />
-                  <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.connected')}</span>
-                  <SettingsInfoHint>{t('settings.providers.page.auth.useReconnectHint')}</SettingsInfoHint>
-                </div>
-              )
+            {showAuthConnectedSummary ? (
+              <div className="flex items-center gap-1.5 py-1.5">
+                <Icon name="check" className="w-4 h-4 text-[var(--status-success)] shrink-0" />
+                <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.connected')}</span>
+                <SettingsInfoHint>{t('settings.providers.page.auth.useReconnectHint')}</SettingsInfoHint>
+              </div>
+            ) : !showAuthPanel && authStatusIncomplete ? (
+              <div className="flex items-center gap-1.5 py-1.5">
+                <Icon name="alert" className="w-4 h-4 text-[var(--status-warning)] shrink-0" />
+                <span className="typography-ui-label text-foreground">{t('settings.providers.page.auth.incomplete')}</span>
+                <SettingsInfoHint>{t('settings.providers.page.auth.incompleteHint')}</SettingsInfoHint>
+              </div>
             ) : authLoading ? (
               <div className="py-1.5 typography-meta text-muted-foreground">{t('settings.providers.page.auth.loadingMethods')}</div>
             ) : (
               <div className="space-y-4">
-                <div className="py-1.5">
-                  <label className="typography-ui-label text-foreground flex items-center gap-1.5">
-                    {t('settings.providers.page.auth.apiKeyLabel')}
-                    <SettingsInfoHint>{t('settings.providers.page.auth.apiKeyTooltip')}</SettingsInfoHint>
-                  </label>
-                  <div className="flex flex-col @xl:flex-row @xl:items-center gap-2 mt-1.5">
-                    <Input
-                      type="password"
-                      value={apiKeyInputs[selectedProvider.id] ?? ''}
-                      onChange={(event) =>
-                        setApiKeyInputs((prev) => ({
-                          ...prev,
-                          [selectedProvider.id]: event.target.value,
-                        }))
-                      }
-                      placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
-                      className="flex-1 font-mono text-xs"
-                    />
-                    <Button
-                      size="xs"
-                      className="!font-normal shrink-0"
-                      onClick={() => handleSaveApiKey(selectedProvider.id)}
-                      disabled={authBusyKey === `api:${selectedProvider.id}`}
-                    >
-                      {authBusyKey === `api:${selectedProvider.id}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
-                    </Button>
+                {showProviderApiKey ? (
+                  <div className="py-1.5">
+                    <label className="typography-ui-label text-foreground flex items-center gap-1.5">
+                      {t('settings.providers.page.auth.apiKeyLabel')}
+                      <SettingsInfoHint>{t('settings.providers.page.auth.apiKeyTooltip')}</SettingsInfoHint>
+                    </label>
+                    <div className="flex flex-col @xl:flex-row @xl:items-center gap-2 mt-1.5">
+                      <Input
+                        type="password"
+                        value={apiKeyInputs[selectedProvider.id] ?? ''}
+                        onChange={(event) =>
+                          setApiKeyInputs((prev) => ({
+                            ...prev,
+                            [selectedProvider.id]: event.target.value,
+                          }))
+                        }
+                        placeholder={t('settings.providers.page.auth.apiKeyPlaceholder')}
+                        className="flex-1 font-mono text-xs"
+                      />
+                      <Button
+                        size="xs"
+                        className="!font-normal shrink-0"
+                        onClick={() => handleSaveApiKey(selectedProvider.id)}
+                        disabled={authBusyKey === `api:${selectedProvider.id}`}
+                      >
+                        {authBusyKey === `api:${selectedProvider.id}` ? t('settings.providers.page.actions.saving') : t('settings.providers.page.actions.saveKey')}
+                      </Button>
+                    </div>
                   </div>
-                </div>
+                ) : null}
 
-                {oauthAuthMethods.length > 0 && (
-                  <div className="space-y-4 border-t border-[var(--surface-subtle)] pt-2">
-                    {oauthAuthMethods.map((method, index) => {
-                      const methodLabel = method.label || method.name || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
+                {providerOauthIndexes.length > 0 && (
+                  <div className={cn('space-y-4', showProviderApiKey && 'border-t border-[var(--surface-subtle)] pt-2')}>
+                    {providerOauthIndexes.map((index) => {
+                      const method = providerAuthMethods[index];
+                      const methodLabel = method?.label || method?.name || t('settings.providers.page.auth.oauthMethodFallback', { index: String(index + 1) });
                       const codeKey = `${selectedProvider.id}:${index}`;
                       const isPending =
                         pendingOAuth?.providerId === selectedProvider.id && pendingOAuth?.methodIndex === index;
 
                       return (
-                        <div key={`${selectedProvider.id}-${methodLabel}`} className="space-y-3">
+                        <div key={`${selectedProvider.id}-${index}-${methodLabel}`} className="space-y-3">
                           <div className="flex items-center justify-between gap-2">
                             <div>
                               <div className="typography-ui-label text-foreground">{methodLabel}</div>
-                              {(method.description || method.help) && (
+                              {(method?.description || method?.help) && (
                                 <div className="typography-meta text-muted-foreground">
                                   {String(method.description || method.help)}
                                 </div>

--- a/packages/ui/src/components/sections/providers/providerAuth.test.ts
+++ b/packages/ui/src/components/sections/providers/providerAuth.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  deriveProviderAuthView,
+  normalizeAuthType,
+  oauthMethodEntries,
+  type ProviderAuthMethod,
+} from './providerAuth';
+
+const CURSOR_METHODS: ProviderAuthMethod[] = [{ type: 'oauth', label: 'Login with Cursor' }];
+const API_METHODS: ProviderAuthMethod[] = [{ type: 'api', label: 'API Key' }];
+const MIXED_METHODS: ProviderAuthMethod[] = [
+  { type: 'api', label: 'API Key' },
+  { type: 'oauth', label: 'Sign in' },
+];
+
+const view = (
+  methods: ProviderAuthMethod[],
+  overrides: { credentialsResolved?: boolean; hasStoredCredentials?: boolean } = {},
+) =>
+  deriveProviderAuthView({
+    methods,
+    credentialsResolved: overrides.credentialsResolved ?? true,
+    hasStoredCredentials: overrides.hasStoredCredentials ?? false,
+  });
+
+describe('normalizeAuthType', () => {
+  test('classifies by type first, then by name or label', () => {
+    expect(normalizeAuthType({ type: 'oauth' })).toBe('oauth');
+    expect(normalizeAuthType({ type: 'api' })).toBe('api');
+    expect(normalizeAuthType({ label: 'OAuth login' })).toBe('oauth');
+    expect(normalizeAuthType({ name: 'API Key' })).toBe('api');
+    expect(normalizeAuthType({ label: 'Login with Cursor' })).toBe('');
+  });
+});
+
+describe('oauthMethodEntries', () => {
+  test('keeps the index that oauth.authorize addresses', () => {
+    expect(oauthMethodEntries(MIXED_METHODS)).toEqual([{ index: 1, method: MIXED_METHODS[1] }]);
+    expect(oauthMethodEntries(API_METHODS)).toEqual([]);
+  });
+});
+
+describe('deriveProviderAuthView', () => {
+  test('OAuth-only provider without credentials shows sign-in instead of an API key', () => {
+    const result = view(CURSOR_METHODS);
+
+    expect(result.showApiKeyField).toBe(false);
+    expect(result.signInRequired).toBe(true);
+    expect(result.autoOpenPanel).toBe(true);
+    expect(result.autoStartMethodIndex).toBe(0);
+    expect(result.oauthEntries).toHaveLength(1);
+  });
+
+  test('OAuth-only provider with stored credentials keeps the connected summary', () => {
+    const result = view(CURSOR_METHODS, { hasStoredCredentials: true });
+
+    expect(result.showApiKeyField).toBe(false);
+    expect(result.signInRequired).toBe(false);
+    expect(result.autoOpenPanel).toBe(false);
+    expect(result.autoStartMethodIndex).toBeNull();
+  });
+
+  test('unresolved provenance never claims a missing credential', () => {
+    const result = view(CURSOR_METHODS, { credentialsResolved: false });
+
+    expect(result.signInRequired).toBe(false);
+    expect(result.autoOpenPanel).toBe(false);
+    expect(result.autoStartMethodIndex).toBeNull();
+  });
+
+  test('api-only provider keeps the key field and no OAuth behavior', () => {
+    const result = view(API_METHODS);
+
+    expect(result.showApiKeyField).toBe(true);
+    expect(result.oauthEntries).toEqual([]);
+    expect(result.signInRequired).toBe(false);
+    expect(result.autoOpenPanel).toBe(false);
+    expect(result.autoStartMethodIndex).toBeNull();
+  });
+
+  test('provider offering both paths keeps the key field and does not auto-open', () => {
+    const result = view(MIXED_METHODS);
+
+    expect(result.showApiKeyField).toBe(true);
+    expect(result.oauthEntries).toHaveLength(1);
+    expect(result.oauthEntries[0]?.index).toBe(1);
+    expect(result.signInRequired).toBe(false);
+    expect(result.autoOpenPanel).toBe(false);
+    expect(result.autoStartMethodIndex).toBeNull();
+  });
+
+  test('unknown methods keep the API key field available', () => {
+    const result = view([]);
+
+    expect(result.showApiKeyField).toBe(true);
+    expect(result.oauthEntries).toEqual([]);
+    expect(result.signInRequired).toBe(false);
+  });
+});

--- a/packages/ui/src/components/sections/providers/providerAuth.ts
+++ b/packages/ui/src/components/sections/providers/providerAuth.ts
@@ -1,11 +1,20 @@
-export interface AuthMethodLike {
+export interface ProviderAuthMethod {
   type?: string;
   name?: string;
   label?: string;
+  description?: string;
+  help?: string;
+  method?: number;
   [key: string]: unknown;
 }
 
-export const normalizeAuthType = (method: AuthMethodLike): string => {
+export interface ProviderOAuthEntry {
+  /** Index in the provider.auth() array; oauth.authorize addresses methods by this index. */
+  index: number;
+  method: ProviderAuthMethod;
+}
+
+export const normalizeAuthType = (method: ProviderAuthMethod): string => {
   const raw = typeof method.type === 'string' ? method.type : '';
   const label = `${method.name ?? ''} ${method.label ?? ''}`.toLowerCase();
   const merged = `${raw} ${label}`.toLowerCase();
@@ -14,20 +23,54 @@ export const normalizeAuthType = (method: AuthMethodLike): string => {
   return raw.toLowerCase();
 };
 
-/** Show API key when methods are unknown/empty, or when an explicit api method exists. */
-export const shouldShowApiKeyField = (methods: AuthMethodLike[]): boolean => {
-  if (methods.length === 0) return true;
-  return methods.some((method) => normalizeAuthType(method) === 'api');
-};
+export const oauthMethodEntries = (methods: ProviderAuthMethod[]): ProviderOAuthEntry[] =>
+  methods
+    .map((method, index) => ({ index, method }))
+    .filter((entry) => normalizeAuthType(entry.method) === 'oauth');
 
-export const hasOauthAuthMethod = (methods: AuthMethodLike[]): boolean =>
-  methods.some((method) => normalizeAuthType(method) === 'oauth');
-
-export const isOauthOnlyAuthMethods = (methods: AuthMethodLike[]): boolean =>
+const isOauthOnly = (methods: ProviderAuthMethod[]): boolean =>
   methods.length > 0 && methods.every((method) => normalizeAuthType(method) === 'oauth');
 
-/** Original index in the provider.auth() methods array (required by oauth.authorize). */
-export const oauthMethodIndexes = (methods: AuthMethodLike[]): number[] =>
-  methods
-    .map((method, index) => (normalizeAuthType(method) === 'oauth' ? index : -1))
-    .filter((index) => index >= 0);
+interface ProviderAuthViewInput {
+  methods: ProviderAuthMethod[];
+  /** True once provider credential provenance is known (source lookup resolved). */
+  credentialsResolved: boolean;
+  /** Stored credentials for the provider (auth.json entry). */
+  hasStoredCredentials: boolean;
+}
+
+interface ProviderAuthView {
+  oauthEntries: ProviderOAuthEntry[];
+  /** Unknown methods keep the key field; an explicit api method always shows it. */
+  showApiKeyField: boolean;
+  /** OAuth-only provider whose credentials are known to be missing. */
+  signInRequired: boolean;
+  /** Open the auth panel without user action instead of a Connected summary. */
+  autoOpenPanel: boolean;
+  /** Fetch the browser URL up front so it is visible without pressing Connect. */
+  autoStartMethodIndex: number | null;
+}
+
+/**
+ * Derives the Authentication section state from the provider's advertised auth
+ * methods. OAuth-only providers (plugin providers such as Cursor) have no API
+ * key path at all, so the key field is hidden and, when no credentials are
+ * stored, the OAuth flow replaces the Connected summary.
+ */
+export const deriveProviderAuthView = ({
+  methods,
+  credentialsResolved,
+  hasStoredCredentials,
+}: ProviderAuthViewInput): ProviderAuthView => {
+  const oauthEntries = oauthMethodEntries(methods);
+  const oauthOnly = isOauthOnly(methods);
+  const signInRequired = oauthOnly && credentialsResolved && !hasStoredCredentials;
+
+  return {
+    oauthEntries,
+    showApiKeyField: methods.length === 0 || methods.some((method) => normalizeAuthType(method) === 'api'),
+    signInRequired,
+    autoOpenPanel: signInRequired,
+    autoStartMethodIndex: signInRequired ? (oauthEntries[0]?.index ?? null) : null,
+  };
+};

--- a/packages/ui/src/components/sections/providers/providerAuth.ts
+++ b/packages/ui/src/components/sections/providers/providerAuth.ts
@@ -1,0 +1,33 @@
+export interface AuthMethodLike {
+  type?: string;
+  name?: string;
+  label?: string;
+  [key: string]: unknown;
+}
+
+export const normalizeAuthType = (method: AuthMethodLike): string => {
+  const raw = typeof method.type === 'string' ? method.type : '';
+  const label = `${method.name ?? ''} ${method.label ?? ''}`.toLowerCase();
+  const merged = `${raw} ${label}`.toLowerCase();
+  if (merged.includes('oauth')) return 'oauth';
+  if (merged.includes('api')) return 'api';
+  return raw.toLowerCase();
+};
+
+/** Show API key when methods are unknown/empty, or when an explicit api method exists. */
+export const shouldShowApiKeyField = (methods: AuthMethodLike[]): boolean => {
+  if (methods.length === 0) return true;
+  return methods.some((method) => normalizeAuthType(method) === 'api');
+};
+
+export const hasOauthAuthMethod = (methods: AuthMethodLike[]): boolean =>
+  methods.some((method) => normalizeAuthType(method) === 'oauth');
+
+export const isOauthOnlyAuthMethods = (methods: AuthMethodLike[]): boolean =>
+  methods.length > 0 && methods.every((method) => normalizeAuthType(method) === 'oauth');
+
+/** Original index in the provider.auth() methods array (required by oauth.authorize). */
+export const oauthMethodIndexes = (methods: AuthMethodLike[]): number[] =>
+  methods
+    .map((method, index) => (normalizeAuthType(method) === 'oauth' ? index : -1))
+    .filter((index) => index >= 0);

--- a/packages/ui/src/components/sections/providers/providerAvailability.ts
+++ b/packages/ui/src/components/sections/providers/providerAvailability.ts
@@ -1,1 +1,48 @@
 export const shouldLoadAvailableProviders = (isAddMode: boolean): boolean => isAddMode;
+
+export interface ConnectableProvider {
+  id: string;
+  name?: string;
+}
+
+interface ConnectableProvidersInput {
+  /** Providers OpenCode can describe: catalog entries plus config-defined ones. */
+  catalog: ConnectableProvider[];
+  /** Providers that advertise auth methods, including plugin-registered ones. */
+  authProviderIds: string[];
+  connectedIds: ReadonlySet<string>;
+}
+
+/**
+ * Providers the user can still connect. A plugin can register auth methods for a
+ * provider the catalog does not know (Cursor via its OAuth plugin), and such a
+ * provider is absent from the provider list until it holds credentials, so auth
+ * methods are a first-class source of connectable providers.
+ */
+export const listConnectableProviders = ({
+  catalog,
+  authProviderIds,
+  connectedIds,
+}: ConnectableProvidersInput): ConnectableProvider[] => {
+  const byId = new Map<string, ConnectableProvider>();
+
+  for (const provider of catalog) {
+    if (connectedIds.has(provider.id) || byId.has(provider.id)) {
+      continue;
+    }
+    byId.set(provider.id, provider);
+  }
+
+  for (const providerId of authProviderIds) {
+    if (connectedIds.has(providerId) || byId.has(providerId)) {
+      continue;
+    }
+    byId.set(providerId, { id: providerId });
+  }
+
+  return [...byId.values()].sort((a, b) => {
+    const labelA = (a.name || a.id).toLowerCase();
+    const labelB = (b.name || b.id).toLowerCase();
+    return labelA.localeCompare(labelB);
+  });
+};

--- a/packages/ui/src/lib/i18n/messages/de.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/de.settings.ts
@@ -1325,6 +1325,8 @@ export const settingsDict = {
   'settings.providers.page.auth.incomplete': 'Anmeldedaten fehlen',
   'settings.providers.page.auth.incompleteHint': '· Fügen Sie einen API-Schlüssel oder {env:VAR} hinzu, bevor Sie diesen Anbieter im Chat verwenden',
   'settings.providers.page.auth.useReconnectHint': '· Verwenden Sie „Erneut verbinden“, um Anmeldedaten zu aktualisieren',
+  'settings.providers.page.auth.signInRequired': 'Anmeldung erforderlich',
+  'settings.providers.page.auth.signInRequiredHint': '· Verwenden Sie „Verbinden“, um sich bei diesem Anbieter im Browser anzumelden',
   'settings.providers.page.connectionDetails.title': 'Verbindungsdetails',
   'settings.providers.page.connectionDetails.configuredIn': 'Konfiguriert in:',
   'settings.providers.page.connectionDetails.noActiveSource': 'Keine aktive Konfigurationsquelle',

--- a/packages/ui/src/lib/i18n/messages/en.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/en.settings.ts
@@ -1390,6 +1390,8 @@ export const settingsDict = {
   'settings.providers.page.auth.incomplete': 'Credentials missing',
   'settings.providers.page.auth.incompleteHint': '· Add an API key or {env:VAR} before using this provider in chat',
   'settings.providers.page.auth.useReconnectHint': '· Use Reconnect to update credentials',
+  'settings.providers.page.auth.signInRequired': 'Sign-in required',
+  'settings.providers.page.auth.signInRequiredHint': '· Use Connect to sign in with this provider in your browser',
   'settings.providers.page.connectionDetails.title': 'Connection Details',
   'settings.providers.page.connectionDetails.configuredIn': 'Configured in:',
   'settings.providers.page.connectionDetails.noActiveSource': 'No active configuration source',

--- a/packages/ui/src/lib/i18n/messages/es.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/es.settings.ts
@@ -1365,6 +1365,8 @@ export const settingsDict = {
 
 
   "settings.providers.page.auth.useReconnectHint": "· Usar Reconnect para actualizar credenciales",
+  "settings.providers.page.auth.signInRequired": "Inicio de sesión requerido",
+  "settings.providers.page.auth.signInRequiredHint": "· Usa Conectar para iniciar sesión con este proveedor en el navegador",
   "settings.providers.page.connectionDetails.title": "Detalles de conexión",
   "settings.providers.page.connectionDetails.configuredIn": "Configurado en:",
   "settings.providers.page.connectionDetails.noActiveSource": "No hay fuente de configuración activa",

--- a/packages/ui/src/lib/i18n/messages/fr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.settings.ts
@@ -1286,6 +1286,8 @@ export const settingsDict = {
 
 
   'settings.providers.page.auth.useReconnectHint': '· Utilisez Reconnect pour mettre à jour les informations d\'identification',
+  'settings.providers.page.auth.signInRequired': 'Connexion requise',
+  'settings.providers.page.auth.signInRequiredHint': '· Utilisez Connecter pour vous connecter à ce fournisseur dans le navigateur',
   'settings.providers.page.connectionDetails.title': 'Détails de connexion',
   'settings.providers.page.connectionDetails.configuredIn': 'Configuré dans :',
   'settings.providers.page.connectionDetails.noActiveSource': 'Aucune source de configuration active',

--- a/packages/ui/src/lib/i18n/messages/ja.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.settings.ts
@@ -1398,6 +1398,8 @@ export const settingsDict = {
 
 
   'settings.providers.page.auth.useReconnectHint': '· 認証情報を更新するには再接続を使用',
+  'settings.providers.page.auth.signInRequired': 'サインインが必要です',
+  'settings.providers.page.auth.signInRequiredHint': '· 「接続」からブラウザーでこのプロバイダーにサインインしてください',
   'settings.providers.page.connectionDetails.title': '接続詳細',
   'settings.providers.page.connectionDetails.configuredIn': '設定場所:',
   'settings.providers.page.connectionDetails.noActiveSource': 'アクティブな設定ソースがありません',

--- a/packages/ui/src/lib/i18n/messages/ko.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.settings.ts
@@ -1365,6 +1365,8 @@ export const settingsDict = {
 
 
   'settings.providers.page.auth.useReconnectHint': '· 인증 정보를 업데이트하려면 Reconnect를 사용하세요',
+  'settings.providers.page.auth.signInRequired': '로그인이 필요합니다',
+  'settings.providers.page.auth.signInRequiredHint': '· 연결을 눌러 브라우저에서 이 프로바이더에 로그인하세요',
   'settings.providers.page.connectionDetails.title': '연결 세부 정보',
   'settings.providers.page.connectionDetails.configuredIn': '설정 위치:',
   'settings.providers.page.connectionDetails.noActiveSource': '활성 설정 소스 없음',

--- a/packages/ui/src/lib/i18n/messages/pl.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.settings.ts
@@ -1386,6 +1386,8 @@ export const settingsDict = {
   'settings.providers.page.auth.pasteAuthorizationCodePlaceholder': 'Wklej kod autoryzacyjny',
   'settings.providers.page.auth.title': 'Uwierzytelnianie',
   'settings.providers.page.auth.useReconnectHint': '· Użyj Połącz ponownie, aby zaktualizować dane logowania',
+  'settings.providers.page.auth.signInRequired': 'Wymagane logowanie',
+  'settings.providers.page.auth.signInRequiredHint': '· Użyj przycisku Połącz, aby zalogować się u tego dostawcy w przeglądarce',
   'settings.providers.page.custom.optionLabel': 'Inny / Niestandardowy',
   'settings.providers.page.custom.title': 'Niestandardowy dostawca',
   'settings.providers.page.custom.editTitle': 'Edytuj niestandardowego dostawcę',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
@@ -1365,6 +1365,8 @@ export const settingsDict = {
 
 
   "settings.providers.page.auth.useReconnectHint": "· Usar Reconnect para atualizar credenciais",
+  "settings.providers.page.auth.signInRequired": "Login necessário",
+  "settings.providers.page.auth.signInRequiredHint": "· Use Conectar para entrar neste provedor pelo navegador",
   "settings.providers.page.connectionDetails.title": "Detalhes de conexão",
   "settings.providers.page.connectionDetails.configuredIn": "Configuredo en:",
   "settings.providers.page.connectionDetails.noActiveSource": "Não há origem de configurações ativa",

--- a/packages/ui/src/lib/i18n/messages/uk.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.settings.ts
@@ -1365,6 +1365,8 @@ export const settingsDict = {
 
 
   "settings.providers.page.auth.useReconnectHint": "· Скористайтеся повторним підключенням, щоб оновити облікові дані",
+  "settings.providers.page.auth.signInRequired": "Потрібен вхід",
+  "settings.providers.page.auth.signInRequiredHint": "· Скористайтеся «Підключитися», щоб увійти до цього провайдера у браузері",
   "settings.providers.page.connectionDetails.title": "Деталі підключення",
   "settings.providers.page.connectionDetails.configuredIn": "Налаштовано в:",
   "settings.providers.page.connectionDetails.noActiveSource": "Немає активного джерела конфігурації",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
@@ -1365,6 +1365,8 @@ export const settingsDict = {
 
 
   'settings.providers.page.auth.useReconnectHint': '· 使用“重新连接”以更新凭据',
+  'settings.providers.page.auth.signInRequired': '需要登录',
+  'settings.providers.page.auth.signInRequiredHint': '· 使用“连接”在浏览器中登录该提供商',
   'settings.providers.page.connectionDetails.title': '连接详情',
   'settings.providers.page.connectionDetails.configuredIn': '配置来源：',
   'settings.providers.page.connectionDetails.noActiveSource': '没有活动配置来源',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
@@ -1271,6 +1271,8 @@
 
 
   'settings.providers.page.auth.useReconnectHint': '· 使用「重新連線」以更新憑證',
+  'settings.providers.page.auth.signInRequired': '需要登入',
+  'settings.providers.page.auth.signInRequiredHint': '· 使用「連線」在瀏覽器中登入此供應商',
   'settings.providers.page.connectionDetails.title': '連線詳情',
   'settings.providers.page.connectionDetails.configuredIn': '設定來源：',
   'settings.providers.page.connectionDetails.noActiveSource': '沒有活動設定來源',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Settings → Providers only loaded `provider.auth()` in add-provider mode. On a connected OAuth-only provider (Cursor via `@otto-assistant/opencode-cursor-oauth`) the page therefore had no auth methods: it showed a green **Connected** label whose Reconnect panel offered only an API key, and never surfaced **Login with Cursor** or the `cursor.com/loginDeepControl` sign-in URL.

Now auth methods load for every Providers page visit, the Authentication panel is driven by the provider's advertised methods, the API key field is hidden for providers that only support OAuth, and such a provider without stored credentials shows a sign-in state plus a ready-to-use browser URL instead of a fake Connected label.

## Non-goals

- Changes to opencode-cursor / Cursor APIs, models.dev, or a Cursor API-key flow.
- Reworking the credential status model for API-key providers; the existing Connected / Credentials missing summary is preserved.
- Auto-starting OAuth in add-provider mode: selecting a candidate from the dropdown still requires pressing Connect, so browsing the list cannot trigger authorization calls.

## Affected surfaces

- `packages/ui` Settings → Providers (shared across web, desktop, VS Code, hosted mobile, Capacitor mobile — one shared component, no runtime-specific behavior added).
- Behavior keys off `provider.auth()` method types (`oauth` / `api`), never off a provider id, so any plugin OAuth-only provider benefits.
- New localized strings in all 11 dictionaries. No persisted schema, server route, or SDK contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` instruction order and correctness invariants | Shared UI change touching credential state | Sign-in state derives from authoritative provenance (`/api/provider/:id/source`), never from a config placeholder model; unresolved provenance is treated as unknown rather than "no credentials" |
| `openchamber-change-discipline` | Source change plus new modules | Pure derivation extracted and unit-tested; duplicated add/detail markup collapsed into one component so the two surfaces cannot drift again; focused tests + package type-check/lint + `dead-code` run |
| `settings-ui-patterns` | Settings Providers page | Existing `SettingsSection` / `SettingsInfoHint` / container-query classes reused; no new page chrome, no new search entries needed (section anchor `providers.auth` unchanged) |
| `locale-ui-patterns` | New sign-in status copy | `settings.providers.page.auth.signInRequired(.Hint)` added and fully translated in de, es, fr, ja, ko, pl, pt-BR, uk, zh-CN, zh-TW |
| `theme-system` | Auth panel visuals | Existing semantic tokens (`--status-success`, `--status-warning`, `--primary-base`, `--surface-subtle`), shared `Button` variants and `Icon` sprite only |
| `ui-api-decoupling` | `provider.auth()`, `oauth.authorize`, provider source lookup | Official calls stay on `opencodeClient`; the OpenChamber-only provenance endpoint stays on `runtimeFetch`; browser navigation stays behind explicit user intent |

## Behavior details

- `provider.auth()` now loads once per Providers page mount for connected and add-provider modes.
- `deriveProviderAuthView` returns the OAuth entries (carrying their original `provider.auth()` index, which `oauth.authorize` addresses), whether to show the API key field, and whether sign-in is required.
- API key field: hidden only when every advertised method is OAuth. Unknown/empty methods and any explicit `api` method keep it, so API-key and mixed providers are untouched.
- Sign-in required (OAuth-only, provenance resolved, no stored credential) opens the panel automatically and prefetches the authorization URL. The prefetch never opens a browser tab and raises no toasts — `Open` remains the user's action, which also avoids popup blocking in the web runtime.
- Provider provenance is re-fetched after key save, OAuth complete, and disconnect, so the panel reflects the new credential state immediately. Disconnect also clears the cached sign-in URL and the prefetch guard so a later sign-in fetches a fresh URL.

## Validation

Manual testing used a local OpenCode instance with a fixture plugin that mirrors the Cursor plugin contract: `cursor` advertising a single `{ type: 'oauth', label: 'Login with Cursor' }` method with a `loginDeepControl` URL and a placeholder model in config, plus `fixture-api` (api-only) and `fixture-mixed` (api + oauth) providers. OpenChamber ran via `OPENCODE_HOST=http://127.0.0.1:4599 bun run dev:web:hmr`.

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/sections/providers/` | Pass (25 tests, includes 8 new auth-derivation cases) |
| `bun run --filter @openchamber/ui type-check` | Pass |
| `bun run --filter @openchamber/ui lint` | Pass |
| `bun run dead-code` | Ran; no new unused exports from this change |
| Manual: pre-fix build, Cursor provider | Reproduced the bug — green "Connected", Reconnect reveals only an API key, no OAuth anywhere |
| Manual: fixed build, Cursor provider | "Login with Cursor" + instructions + `cursor.com/loginDeepControl` URL with Open/Copy + Complete; no API key field, no Connected label |
| Manual: Copy button | Toast "Copied OAuth link to clipboard" |
| Manual: Complete → stored credential | Switches to green "Connected"; Connection Details reads "auth credentials, user config" |
| Manual: Disconnect | Returns to the sign-in state with a freshly fetched URL; Connection Details reads "No active configuration source" |
| Manual: api-only provider | Reconnect still shows only the API key field with Save key |
| Manual: oauth+api provider | Reconnect shows both the API key field and the OAuth row |
| Real Cursor account sign-in and live model list | Not run — no Cursor credentials in this environment; the fixture exercises the same OpenCode auth/authorize/callback contract |

## Visual evidence

Before (pre-fix build): the OAuth-only provider claims to be connected and only offers an API key behind Reconnect.

![Cursor provider before the fix showing a green Connected label and no OAuth flow](https://cursor.com/artifacts/c/art-bf25bd5e-faf0-4511-9c88-d0ae4dc140a5)

After: the sign-in flow with the browser URL is shown directly, and no API key field appears.

![Cursor provider after the fix showing Login with Cursor, instructions and the loginDeepControl URL with open and copy buttons](https://cursor.com/artifacts/c/art-3e0ac649-08b9-4f03-82be-bb0b4d30e3a6)

No regression for a provider offering both methods — API key and OAuth remain side by side.

![Fixture Mixed Provider showing both an API Key field and a Sign in with Fixture OAuth row](https://cursor.com/artifacts/c/art-c9d95637-ca6f-40dd-b772-8268da49061b)

OAuth-only provider plus api-only and mixed providers in one pass:

<a href="https://cursor.com/agents/bc-6fe3cee0-e465-462b-8a68-92bc386f3425/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproviders_oauth_only_cursor_and_regressions.mp4"><img src="https://cursor.com/artifacts/c/art-a30df5d2-2ac5-41f9-a3e4-0e4a8b4049b6" alt="providers_oauth_only_cursor_and_regressions.mp4" /></a>

Completing the sign-in and then disconnecting:

<a href="https://cursor.com/agents/bc-6fe3cee0-e465-462b-8a68-92bc386f3425/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproviders_cursor_oauth_complete_then_disconnect.mp4"><img src="https://cursor.com/artifacts/c/art-ebef28ff-59ba-429f-b884-6c5f621f92af" alt="providers_cursor_oauth_complete_then_disconnect.mp4" /></a>

## Risks and failure behavior

- `provider.auth()` failure keeps the existing error toast and leaves methods unknown, which keeps the API key field available rather than locking the user out of every credential path.
- Provider source lookup failure leaves provenance unresolved; the page then keeps its previous summary instead of asserting a missing credential, so a failed fetch cannot manufacture a sign-in prompt.
- The URL prefetch runs at most once per provider and method per page mount, performs no navigation, and swallows only its own toast noise (failures are still logged, and pressing Connect surfaces a real error).
- OAuth authorize/callback failures leave prior state intact; no credential is written on a failed authorize.
- Mixed oauth+api providers previously passed the filtered position to `oauth.authorize`; the shared panel now passes the true method index, correcting the addressed method.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fe3cee0-e465-462b-8a68-92bc386f3425?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fe3cee0-e465-462b-8a68-92bc386f3425&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

