### PR TITLE
feat: add DeepSeek quota provider

### DIFF
--- a/packages/ui/src/lib/quota/providers/index.ts
+++ b/packages/ui/src/lib/quota/providers/index.ts
@@ -22,5 +22,6 @@ export const QUOTA_PROVIDERS: QuotaProviderMeta[] = [
   { id: 'wafer', name: 'Wafer.ai' },
   { id: 'opencode-go', name: 'OpenCode Go' },
   { id: 'crof', name: 'CrofAI' },
+  { id: 'deepseek', name: 'DeepSeek' },
   { id: 'neuralwatt', name: 'NeuralWatt' },
 ];

--- a/packages/ui/src/types/quota.ts
+++ b/packages/ui/src/types/quota.ts
@@ -17,6 +17,7 @@ export type QuotaProviderId =
   | 'wafer'
   | 'opencode-go'
   | 'crof'
+  | 'deepseek'
   | 'neuralwatt';
 
 export interface UsageWindow {

--- a/packages/vscode/src/quotaProviders.test.ts
+++ b/packages/vscode/src/quotaProviders.test.ts
@@ -11,6 +11,7 @@ const AUTH = JSON.stringify({
   crof: { key: 'test-token' },
   neuralwatt: { key: 'test-token' },
   'zai-coding-plan': { key: 'test-token' },
+  deepseek: { key: 'test-token' },
 });
 ((fs as unknown) as { existsSync: () => boolean }).existsSync = () => true;
 ((fs as unknown) as { readFileSync: () => string }).readFileSync = () => AUTH;
@@ -417,5 +418,74 @@ describe('NeuralWatt quota provider (VS Code parity)', () => {
     const fsMock = fs as unknown as { existsSync: unknown; readFileSync: unknown };
     fsMock.existsSync = ORIGINAL_FS.existsSync;
     fsMock.readFileSync = ORIGINAL_FS.readFileSync;
+  });
+});
+
+describe('DeepSeek quota provider (VS Code parity)', () => {
+  test('builds credits_balance window from documented USD payload (string balance)', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      is_available: true,
+      balance_infos: [
+        { currency: 'USD', total_balance: '7.54', granted_balance: '0.00', topped_up_balance: '7.54' },
+      ],
+    })));
+
+    const result = await fetchQuotaForProvider('deepseek');
+
+    assert.equal(result.ok, true);
+    assert.equal(result.providerId, 'deepseek');
+    assert.equal(result.usage!.windows.credits_balance!.valueLabel, '$7.54');
+    assert.equal(result.usage!.windows.credits_balance!.usedPercent, null);
+    assert.equal(result.usage!.windows.credits_balance!.windowSeconds, null);
+    assert.equal(result.usage!.windows.credits_balance!.resetAt, null);
+  });
+
+  test('falls back to CNY entry with ¥ symbol when no USD entry is present', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      is_available: true,
+      balance_infos: [
+        { currency: 'CNY', total_balance: '100.00', granted_balance: '0.00', topped_up_balance: '100.00' },
+      ],
+    })));
+
+    const result = await fetchQuotaForProvider('deepseek');
+
+    assert.equal(result.ok, true);
+    assert.equal(result.usage!.windows.credits_balance!.valueLabel, '¥100.00');
+  });
+
+  test('maps 401 to session-expired', async () => {
+    stubFetchFailing(async () => ({}), { ok: false, status: 401 });
+
+    const result = await fetchQuotaForProvider('deepseek');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'Session expired — please re-authenticate with DeepSeek');
+  });
+
+  test('returns no-quota-data on a 200 payload with no usable balance', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      is_available: true,
+      balance_infos: [{ currency: 'USD', total_balance: '', granted_balance: '0.00', topped_up_balance: '0.00' }],
+    })));
+
+    const result = await fetchQuotaForProvider('deepseek');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.configured, true);
+    assert.equal(result.error, 'No quota data in response');
+    assert.equal(result.usage, null);
+  });
+
+  test('keeps a literal zero balance as a valid valueLabel', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      is_available: true,
+      balance_infos: [{ currency: 'USD', total_balance: '0.00', granted_balance: '0.00', topped_up_balance: '0.00' }],
+    })));
+
+    const result = await fetchQuotaForProvider('deepseek');
+
+    assert.equal(result.ok, true);
+    assert.equal(result.usage!.windows.credits_balance!.valueLabel, '$0.00');
   });
 });

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -124,6 +124,16 @@ type CrofPayload = {
   credits?: number | string;
 };
 
+type DeepseekPayload = {
+  is_available?: boolean;
+  balance_infos?: Array<{
+    currency?: string;
+    total_balance?: number | string;
+    granted_balance?: number | string;
+    topped_up_balance?: number | string;
+  }>;
+};
+
 type NeuralwattPayload = {
   balance?: {
     credits_remaining_usd?: number | string;
@@ -490,6 +500,11 @@ export const listConfiguredQuotaProviders = () => {
   const neuralwattAuth = normalizeAuthEntry(getAuthEntry(auth, ['neuralwatt']));
   if (neuralwattAuth && ((neuralwattAuth as Record<string, unknown>).key || (neuralwattAuth as Record<string, unknown>).token)) {
     configured.add('neuralwatt');
+  }
+
+  const deepseekAuth = normalizeAuthEntry(getAuthEntry(auth, ['deepseek']));
+  if (deepseekAuth && ((deepseekAuth as Record<string, unknown>).key || (deepseekAuth as Record<string, unknown>).token)) {
+    configured.add('deepseek');
   }
 
   return Array.from(configured);
@@ -2175,6 +2190,101 @@ const fetchCrofQuota = async (): Promise<ProviderResult> => {
   }
 };
 
+const DEEPSEEK_QUOTA_URL = 'https://api.deepseek.com/user/balance';
+
+const fetchDeepseekQuota = async (): Promise<ProviderResult> => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, ['deepseek'])) as Record<string, unknown> | null;
+  const apiKey = (entry?.key as string | undefined) ?? (entry?.token as string | undefined);
+
+  if (!apiKey) {
+    return buildResult({
+      providerId: 'deepseek',
+      providerName: 'DeepSeek',
+      ok: false,
+      configured: false,
+      error: 'Not configured',
+    });
+  }
+
+  const timeoutSignal = AbortSignal.timeout(15_000);
+
+  try {
+    const response = await fetch(DEEPSEEK_QUOTA_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Accept-Encoding': 'identity',
+      },
+      signal: timeoutSignal,
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId: 'deepseek',
+        providerName: 'DeepSeek',
+        ok: false,
+        configured: true,
+        error: response.status === 401 || response.status === 403
+          ? 'Session expired — please re-authenticate with DeepSeek'
+          : `API error: ${response.status}`,
+      });
+    }
+
+    const payload = await response.json() as DeepseekPayload;
+    const balanceInfos = Array.isArray(payload?.balance_infos) ? payload.balance_infos : [];
+    const balanceInfo = balanceInfos.find((info) => info?.currency === 'USD')
+      ?? balanceInfos.find((info) => info?.currency === 'CNY')
+      ?? null;
+    const rawBalance = balanceInfo?.total_balance;
+    const totalBalance = (typeof rawBalance === 'number' || (typeof rawBalance === 'string' && rawBalance.trim() !== ''))
+      ? toNumber(rawBalance)
+      : null;
+
+    if (totalBalance === null) {
+      return buildResult({
+        providerId: 'deepseek',
+        providerName: 'DeepSeek',
+        ok: false,
+        configured: true,
+        error: 'No quota data in response',
+      });
+    }
+
+    const symbol = balanceInfo?.currency === 'CNY' ? '¥' : '$';
+    const windows: Record<string, UsageWindow> = {
+      credits_balance: toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: `${symbol}${formatMoney(totalBalance)}`,
+      }),
+    };
+
+    return buildResult({
+      providerId: 'deepseek',
+      providerName: 'DeepSeek',
+      ok: true,
+      configured: true,
+      usage: { windows },
+    });
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && error.name === 'AbortError' && timeoutSignal.aborted;
+    const isParseError = error instanceof SyntaxError;
+    return buildResult({
+      providerId: 'deepseek',
+      providerName: 'DeepSeek',
+      ok: false,
+      configured: true,
+      error: isTimeout
+        ? 'Request timed out'
+        : isParseError
+          ? 'Invalid response from provider'
+          : (error instanceof Error ? error.message : 'Request failed'),
+    });
+  }
+};
+
 export const fetchQuotaForProvider = async (providerId: string): Promise<ProviderResult> => {
   switch (providerId) {
     case 'claude':
@@ -2218,6 +2328,8 @@ export const fetchQuotaForProvider = async (providerId: string): Promise<Provide
       return fetchCursorQuota();
     case 'crof':
       return fetchCrofQuota();
+    case 'deepseek':
+      return fetchDeepseekQuota();
     case 'neuralwatt':
       return fetchNeuralwattQuota();
     default:

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -20,6 +20,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 | `codex` | Codex | `providers/codex.js` | `openai`, `codex`, `chatgpt` |
 | `cursor` | Cursor | `providers/cursor.js` | Environment/token files, OpenChamber-managed credentials, or explicit one-time Cursor import |
 | `crof` | CrofAI | `providers/crof.js` | `crof` (API key under `key` or `token`) |
+| `deepseek` | DeepSeek | `providers/deepseek.js` | `deepseek` (API key under `key` or `token`) |
 | `google` | Google | `providers/google/index.js` | `google`, `google.oauth`, Antigravity accounts file |
 | `github-copilot` | GitHub Copilot | `providers/copilot.js` | `github-copilot`, `copilot` |
 | `github-copilot-addon` | GitHub Copilot Add-on | `providers/copilot.js` | `github-copilot`, `copilot` |

--- a/packages/web/server/lib/quota/index.js
+++ b/packages/web/server/lib/quota/index.js
@@ -13,6 +13,7 @@ export {
   fetchGoogleQuota,
   fetchCodexQuota,
   fetchCursorQuota,
+  fetchDeepseekQuota,
   fetchCopilotQuota,
   fetchCopilotAddonQuota,
   fetchKimiQuota,

--- a/packages/web/server/lib/quota/providers/deepseek.js
+++ b/packages/web/server/lib/quota/providers/deepseek.js
@@ -1,0 +1,116 @@
+import { readAuthFile } from '../../opencode/auth.js';
+import {
+  getAuthEntry,
+  normalizeAuthEntry,
+  buildResult,
+  toUsageWindow,
+  toNumber,
+  formatMoney
+} from '../utils/index.js';
+
+export const providerId = 'deepseek';
+export const providerName = 'DeepSeek';
+const aliases = ['deepseek'];
+const DEEPSEEK_QUOTA_URL = 'https://api.deepseek.com/user/balance';
+
+export const isConfigured = () => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  return Boolean(entry?.key || entry?.token);
+};
+
+export const fetchQuota = async () => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  const apiKey = entry?.key ?? entry?.token;
+
+  if (!apiKey) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: false,
+      error: 'Not configured'
+    });
+  }
+
+  const timeoutSignal = AbortSignal.timeout(15_000);
+
+  try {
+    const response = await fetch(DEEPSEEK_QUOTA_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Accept-Encoding': 'identity'
+      },
+      signal: timeoutSignal
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: response.status === 401 || response.status === 403
+          ? 'Session expired — please re-authenticate with DeepSeek'
+          : `API error: ${response.status}`
+      });
+    }
+
+    const payload = await response.json();
+    const balanceInfos = Array.isArray(payload?.balance_infos) ? payload.balance_infos : [];
+    const balanceInfo = balanceInfos.find((info) => info?.currency === 'USD')
+      ?? balanceInfos.find((info) => info?.currency === 'CNY')
+      ?? null;
+    const rawBalance = balanceInfo?.total_balance;
+    const totalBalance = (typeof rawBalance === 'number' || (typeof rawBalance === 'string' && rawBalance.trim() !== ''))
+      ? toNumber(rawBalance)
+      : null;
+
+    if (totalBalance === null) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'No quota data in response'
+      });
+    }
+
+    const isCny = balanceInfo?.currency === 'CNY';
+    const symbol = isCny ? '¥' : '$';
+    const valueLabel = `${symbol}${formatMoney(totalBalance)}`;
+
+    const windows = {
+      credits_balance: toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel
+      })
+    };
+
+    return buildResult({
+      providerId,
+      providerName,
+      ok: true,
+      configured: true,
+      usage: { windows }
+    });
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && error.name === 'AbortError' && timeoutSignal.aborted;
+    const isParseError = error instanceof SyntaxError;
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: isTimeout
+        ? 'Request timed out'
+        : isParseError
+          ? 'Invalid response from provider'
+          : (error instanceof Error ? error.message : 'Request failed')
+    });
+  }
+};

--- a/packages/web/server/lib/quota/providers/deepseek.test.js
+++ b/packages/web/server/lib/quota/providers/deepseek.test.js
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../opencode/auth.js', () => ({
+  readAuthFile: () => ({ deepseek: { key: 'test-token' } }),
+}));
+
+import { fetchQuota } from './deepseek.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const mockResponse = (body, init = {}) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+  ...init,
+});
+
+// Documented payload shape from https://api.deepseek.com/user/balance
+const DOCUMENTED_PAYLOAD = {
+  is_available: true,
+  balance_infos: [
+    {
+      currency: 'USD',
+      total_balance: '7.54',
+      granted_balance: '0.00',
+      topped_up_balance: '7.54'
+    }
+  ]
+};
+
+describe('DeepSeek quota provider', () => {
+  it('builds credits_balance window from documented USD payload (string balance)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse(DOCUMENTED_PAYLOAD)));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.providerId).toBe('deepseek');
+
+    const window = result.usage.windows.credits_balance;
+    expect(window).toBeDefined();
+    expect(window.valueLabel).toBe('$7.54');
+    expect(window.usedPercent).toBeNull();
+    expect(window.windowSeconds).toBeNull();
+    expect(window.resetAt).toBeNull();
+  });
+
+  it('falls back to CNY entry when no USD entry is present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      is_available: true,
+      balance_infos: [
+        { currency: 'CNY', total_balance: '100.00', granted_balance: '0.00', topped_up_balance: '100.00' }
+      ]
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows.credits_balance.valueLabel).toBe('¥100.00');
+  });
+
+  it('prefers the USD entry when both USD and CNY are present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      is_available: true,
+      balance_infos: [
+        { currency: 'CNY', total_balance: '100.00', granted_balance: '0.00', topped_up_balance: '100.00' },
+        { currency: 'USD', total_balance: '3.55', granted_balance: '0.00', topped_up_balance: '3.55' }
+      ]
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows.credits_balance.valueLabel).toBe('$3.55');
+  });
+
+  it('tolerates a numeric total_balance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      is_available: true,
+      balance_infos: [{ currency: 'USD', total_balance: 12.5, granted_balance: 0, topped_up_balance: 12.5 }]
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows.credits_balance.valueLabel).toBe('$12.50');
+  });
+
+  it('maps 401 to session-expired error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Session expired — please re-authenticate with DeepSeek');
+  });
+
+  it('maps 403 to session-expired error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403, json: async () => ({}) }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Session expired — please re-authenticate with DeepSeek');
+  });
+
+  it('reports invalid-response on JSON parse failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => { throw new SyntaxError('Unexpected token'); },
+    }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Invalid response from provider');
+  });
+
+  it('returns no-quota-data on a 200 payload with no usable balance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      is_available: true,
+      balance_infos: [{ currency: 'USD', total_balance: '', granted_balance: '0.00', topped_up_balance: '0.00' }]
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('No quota data in response');
+    expect(result.usage).toBeNull();
+  });
+
+  it('keeps a literal zero balance as a valid valueLabel', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      is_available: true,
+      balance_infos: [{ currency: 'USD', total_balance: '0.00', granted_balance: '0.00', topped_up_balance: '0.00' }]
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows.credits_balance.valueLabel).toBe('$0.00');
+  });
+});

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -12,6 +12,7 @@ import * as codex from './codex.js';
 import * as copilot from './copilot.js';
 import * as crof from './crof.js';
 import * as cursor from './cursor.js';
+import * as deepseek from './deepseek.js';
 import * as google from './google/index.js';
 import * as kimi from './kimi.js';
 import * as nanogpt from './nanogpt.js';
@@ -50,6 +51,12 @@ const registry = {
     providerName: cursor.providerName,
     isConfigured: cursor.isConfigured,
     fetchQuota: cursor.fetchQuota
+  },
+  deepseek: {
+    providerId: deepseek.providerId,
+    providerName: deepseek.providerName,
+    isConfigured: deepseek.isConfigured,
+    fetchQuota: deepseek.fetchQuota
   },
   google: {
     providerId: google.providerId,
@@ -184,6 +191,7 @@ export const fetchOpenaiQuota = openai.fetchQuota;
 export const fetchGoogleQuota = google.fetchGoogleQuota;
 export const fetchCodexQuota = codex.fetchQuota;
 export const fetchCursorQuota = cursor.fetchQuota;
+export const fetchDeepseekQuota = deepseek.fetchQuota;
 export const fetchCopilotQuota = copilot.fetchQuota;
 export const fetchCopilotAddonQuota = copilot.fetchQuotaAddon;
 export const fetchKimiQuota = kimi.fetchQuota;


### PR DESCRIPTION
## Intent

Add a DeepSeek quota provider so users can see their remaining DeepSeek balance in the Usage page and the header provider dropdown, alongside the existing quota providers (Claude, Codex, OpenRouter, NeuralWatt, etc.).

The provider fetches `GET https://api.deepseek.com/user/balance` with a Bearer API key read from the OpenCode `auth.json` (`deepseek` entry, `key` or `token` field) and surfaces the remaining balance as a `credits_balance` window with a `valueLabel` (e.g. `$7.54`). DeepSeek reports a lifetime balance rather than a periodic quota window, so the window carries no percentage and no reset time, matching the CrofAI/NeuralWatt "balance only" provider pattern.

Reference spec: https://github.com/barramee27/crossusage/blob/feat/linux-windows-native-support/docs/providers/deepseek.md

## Non-goals

- No "used = initial balance - remaining balance" tracking. OpenChamber's quota schema has no starting-balance concept, so the provider reports remaining balance only, consistent with OpenRouter and Crof.
- No managed-credential form in Settings (OpenCode Go / Ollama Cloud / Cursor style). DeepSeek uses the standard `auth.json` API key like Crof, NeuralWatt, and OpenRouter.
- No model-level quota windows (`usage.models`): the DeepSeek balance API has no per-model data.
- No local logo asset; the UI falls back to the remote `models.dev` logo as it does for NeuralWatt.

## Affected surfaces

| Surface | Impact |
|---|---|
| `packages/web` server quota module | New provider module, registry entry, and named export; new vitest suite |
| `packages/vscode` extension host | Parity implementation in `quotaProviders.ts` (fetch function, switch case, `listConfiguredQuotaProviders`); new parity tests |
| `packages/ui` shared types and registry | `QuotaProviderId` union and `QUOTA_PROVIDERS` list; consumed by web, Electron, and VS Code runtimes. Hosted mobile and Capacitor consume the web server runtime, so no separate implementation is needed |
| `packages/web/server/lib/quota/DOCUMENTATION.md` | Provider table row added |
| External contract | New `deepseek` auth alias read from `~/.local/share/opencode/auth.json`; no routes, persisted settings, or other provider behavior changed |

The VS Code webview needs no change: `/api/quota/:providerId` already proxies to the bridge, and the new switch case handles dispatch in the extension host.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` runtime boundaries / cross-runtime parity | Quota fetching lives in both the web server runtime and the VS Code extension host | Both runtimes implement the provider with identical logic, error messages, and window shape |
| `AGENTS.md` correctness invariants (authoritative state, explicit failure) | A fetch failure must not be masked as success | `ok` / `configured` / `error` contract preserved via `buildResult`; 401/403 maps to session-expired; timeout and parse failures classified explicitly |
| `openchamber-change-discipline` skill | Applies to any OpenChamber source change | Smallest complete change; nearest owning doc (`quota/DOCUMENTATION.md`) read and updated; package-scoped validation run |
| `ui-api-decoupling` skill | Shared UI data access goes through runtime routes | UI consumes the existing `/api/quota/:providerId` route via `runtimeFetch`; no new route and no SDK bypass |
| `quota/DOCUMENTATION.md` "Add a new provider" checklist | Owning module contract | Module shape (`providerId`, `providerName`, `aliases`, `isConfigured`, `fetchQuota`), shared `utils` helpers, registry registration, doc row, and tests all follow the checklist |
| Code style (CONTRIBUTING.md and provider precedent) | Style must match Crof/NeuralWatt/OpenRouter | Line-by-line comparison against `crof.js`, `neuralwatt.js`, and the VS Code `fetchNeuralwattQuota` was verified in review |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web test server/lib/quota/providers` | PASS: 8 files, 39 tests (includes `deepseek.test.js`, 9/9) |
| `bun test packages/vscode/src/quotaProviders.test.ts` | PASS: 26/26 (includes 5 DeepSeek parity tests) |
| `bun run --cwd packages/vscode type-check` | PASS |
| `bun run --cwd packages/ui type-check` | PASS |
| `bun run --cwd packages/web lint` | PASS |
| `bun x eslint --ext .ts,.tsx src` (vscode) | PASS |
| Live smoke test against `api.deepseek.com` with a real key | PASS: returned `{"valueLabel": "$7.54"}`; response shape matches the documented payload |
| `bun run dead-code` | Ran; report is non-blocking. `fetchDeepseekQuota` is listed under unused exports at `providers/index.js:194` and `quota/index.js:16`, the same pre-existing pattern as every other named quota fetcher (Claude, OpenAI, Google, Codex, etc.). No file-level or type-level findings for the new module |
| Full web vitest suite | 12 pre-existing failures (Windows-only: file permission mode, homedir paths, git service), unrelated to this change; all quota provider files pass |

Not verified: packaged Electron/mobile runtime behavior (static analysis only; both runtimes consume the web server runtime, so risk is low).

## Visual evidence

Screenshots were taken from the packaged desktop build (`deepseek-usage` branch) with a configured DeepSeek API key.

### DeepSeek balance in Settings > Usage

<img width="3096" height="1920" alt="clipboard_2026-08-03_21-03-49" src="https://github.com/user-attachments/assets/7018da12-8503-4a9b-89f5-5c2faa6eb1d0" />

The Settings Usage section shows a `credits_balance` card for DeepSeek. It renders the remaining balance as `valueLabel` only (for example `$7.54`) with no percentage and no reset time, matching the existing balance-only provider pattern already shipped for NeuralWatt.

### Title bar mini widget Usage section

<img width="3096" height="1920" alt="clipboard_2026-08-03_21-03-03" src="https://github.com/user-attachments/assets/73a729e8-0289-494e-8f0a-7498a89d6151" />

The title bar mini widget's Usage section lists DeepSeek alongside the configured quota providers and shows the same DeepSeek balance.

## Risks and failure behavior

- **Invalid or expired key**: 401/403 maps to `Session expired - please re-authenticate with DeepSeek`; the provider stays `configured: true` so the UI surfaces the error instead of silently clearing state.
- **Network, timeout, or parse failure**: classified as `Request timed out`, `Invalid response from provider`, or the request message with `ok: false`; the store keeps the failure signal, so a failure never looks like authoritative empty data.
- **Empty and zero balance edge cases**: literal `"0.00"` renders as `$0.00` (valid); an empty-string `total_balance` yields `No quota data in response` (`ok: false`, `configured: true`). Both cases guard against the `Number('') === 0` trap and are tested in both runtimes.
- **USD/CNY fallback**: the USD entry is preferred; the CNY entry renders with the `¥` symbol.
- **Security**: the API key is read from the existing `auth.json` credential store and is never logged or persisted by this change; no secrets appear in tests or docs.
- **Compatibility**: additive only (new provider ID `deepseek`); no existing routes, settings, or provider behavior changed.
- **Cross-runtime**: web and VS Code logic is kept identical; any future divergence surfaces in the parity tests.

