### PR TITLE
fix: Kimi for Coding usage showing 0% despite full consumption

### DIFF
--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -1137,6 +1137,24 @@ const fetchCopilotAddonQuota = async (): Promise<ProviderResult> => {
   }
 };
 
+// Kimi's weekly `usage` block reports `used`; its rate-limit `limits[].detail`
+// blocks report `remaining` instead. Neither field is guaranteed present, so
+// derive usedPercent from whichever one the API actually returned.
+const computeKimiUsedPercent = (
+  total: number | null,
+  used: number | null,
+  remaining: number | null,
+): number | null => {
+  if (!total) return null;
+  if (used !== null) {
+    return Math.max(0, Math.min(100, (used / total) * 100));
+  }
+  if (remaining !== null) {
+    return Math.max(0, Math.min(100, 100 - (remaining / total) * 100));
+  }
+  return null;
+};
+
 const fetchKimiQuota = async (): Promise<ProviderResult> => {
   const auth = readAuthFile();
   const entry = normalizeAuthEntry(getAuthEntry(auth, ['kimi-for-coding', 'kimi'])) as Record<string, unknown> | null;
@@ -1176,10 +1194,9 @@ const fetchKimiQuota = async (): Promise<ProviderResult> => {
     const usage = payload.usage as Record<string, unknown> | undefined;
     if (usage) {
       const limit = toNumber(usage.limit);
+      const used = toNumber(usage.used);
       const remaining = toNumber(usage.remaining);
-      const usedPercent = limit && remaining !== null
-        ? Math.max(0, Math.min(100, 100 - (remaining / limit) * 100))
-        : null;
+      const usedPercent = computeKimiUsedPercent(limit, used, remaining);
       windows.weekly = toUsageWindow({
         usedPercent,
         windowSeconds: null,
@@ -1195,10 +1212,9 @@ const fetchKimiQuota = async (): Promise<ProviderResult> => {
       const windowSeconds = durationToSeconds(window?.duration as number | undefined, window?.timeUnit as string | undefined);
       const label = windowSeconds === 5 * 60 * 60 ? `Rate Limit (${rawLabel})` : rawLabel;
       const total = toNumber(detail?.limit);
+      const used = toNumber(detail?.used);
       const remaining = toNumber(detail?.remaining);
-      const usedPercent = total && remaining !== null
-        ? Math.max(0, Math.min(100, 100 - (remaining / total) * 100))
-        : null;
+      const usedPercent = computeKimiUsedPercent(total, used, remaining);
       windows[label] = toUsageWindow({
         usedPercent,
         windowSeconds,

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -70,6 +70,14 @@ In 2025/2026 MiniMax rebranded "Coding Plan" to "Token Plan" alongside the M3 mo
 - **model_remains array**: Now contains entries for multiple model categories (chat, speech, video, image). The provider selects the chat-model entry by matching `MiniMax-M*`, then `general`/`chat`/`text` by name, then any entry with a remaining percent.
 - **Window status**: The `current_interval_status` and `current_weekly_status` fields indicate whether a window is active. Status `3` means the window is not applicable for the current plan tier (e.g. legacy plans without weekly limits). The provider omits inactive windows.
 
+## Kimi for Coding field semantics
+
+`GET https://api.kimi.com/coding/v1/usages` is inconsistent about which field carries consumption:
+- The weekly `usage` block returns `used` (consumed) with no `remaining` field.
+- Each `limits[].detail` rate-limit block returns `remaining` (available) with no `used` field.
+
+The provider computes `usedPercent` from whichever of `used`/`remaining` is present (`used` takes precedence when both exist) rather than assuming one field name. Both `packages/web/server/lib/quota/providers/kimi.js` and `packages/vscode/src/quotaProviders.ts` (`fetchKimiQuota`) must stay in sync — the VS Code extension duplicates this parsing logic rather than importing it.
+
 ## Notes for contributors
 - Keep provider IDs stable; clients use them directly.
 - Avoid adding alias-based dispatch in `fetchQuotaForProvider`; dispatch currently expects exact provider IDs.

--- a/packages/web/server/lib/quota/providers/kimi.js
+++ b/packages/web/server/lib/quota/providers/kimi.js
@@ -14,6 +14,20 @@ export const providerId = 'kimi-for-coding';
 export const providerName = 'Kimi for Coding';
 const aliases = ['kimi-for-coding', 'kimi'];
 
+// Kimi's weekly `usage` block reports `used`; its rate-limit `limits[].detail`
+// blocks report `remaining` instead. Neither field is guaranteed present, so
+// derive usedPercent from whichever one the API actually returned.
+const computeUsedPercent = (total, used, remaining) => {
+  if (!total) return null;
+  if (used !== null) {
+    return Math.max(0, Math.min(100, (used / total) * 100));
+  }
+  if (remaining !== null) {
+    return Math.max(0, Math.min(100, 100 - (remaining / total) * 100));
+  }
+  return null;
+};
+
 export const isConfigured = () => {
   const auth = readAuthFile();
   const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
@@ -59,10 +73,9 @@ export const fetchQuota = async () => {
     const usage = payload?.usage ?? null;
     if (usage) {
       const limit = toNumber(usage.limit);
+      const used = toNumber(usage.used);
       const remaining = toNumber(usage.remaining);
-      const usedPercent = limit && remaining !== null
-        ? Math.max(0, Math.min(100, 100 - (remaining / limit) * 100))
-        : null;
+      const usedPercent = computeUsedPercent(limit, used, remaining);
       windows.weekly = toUsageWindow({
         usedPercent,
         windowSeconds: null,
@@ -78,10 +91,9 @@ export const fetchQuota = async () => {
       const windowSeconds = durationToSeconds(window?.duration, window?.timeUnit);
       const label = windowSeconds === 5 * 60 * 60 ? `Rate Limit (${rawLabel})` : rawLabel;
       const total = toNumber(detail?.limit);
+      const used = toNumber(detail?.used);
       const remaining = toNumber(detail?.remaining);
-      const usedPercent = total && remaining !== null
-        ? Math.max(0, Math.min(100, 100 - (remaining / total) * 100))
-        : null;
+      const usedPercent = computeUsedPercent(total, used, remaining);
       windows[label] = toUsageWindow({
         usedPercent,
         windowSeconds,

--- a/packages/web/server/lib/quota/providers/kimi.test.js
+++ b/packages/web/server/lib/quota/providers/kimi.test.js
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../opencode/auth.js', () => ({
+  readAuthFile: () => ({ 'kimi-for-coding': { key: 'test-token' } }),
+}));
+
+import { fetchQuota } from './kimi.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const mockResponse = (body, init = {}) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+  ...init,
+});
+
+describe('Kimi for Coding quota provider', () => {
+  it('computes weekly usedPercent from the used field (live API shape, no remaining field)', async () => {
+    // Captured from GET https://api.kimi.com/coding/v1/usages — the weekly
+    // `usage` block only ever includes `used`, never `remaining`.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      mockResponse({
+        usage: { limit: '100', used: '100', resetTime: '2026-08-04T06:21:48.514003Z' },
+        limits: [{
+          window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' },
+          detail: { limit: '100', remaining: '100', resetTime: '2026-08-03T07:21:48.514003Z' },
+        }],
+      }),
+    ));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows.weekly.usedPercent).toBe(100);
+    expect(result.usage.windows['Rate Limit (300m)'].usedPercent).toBe(0);
+  });
+
+  it('falls back to computing usedPercent from remaining when used is absent', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      mockResponse({
+        usage: { limit: '2048', remaining: '512', resetTime: '2026-08-04T06:21:48.514003Z' },
+        limits: [],
+      }),
+    ));
+
+    const result = await fetchQuota();
+
+    expect(result.usage.windows.weekly.usedPercent).toBe(75);
+  });
+
+  it('prefers used over remaining when both fields are present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      mockResponse({
+        usage: { limit: '100', used: '30', remaining: '999', resetTime: null },
+        limits: [],
+      }),
+    ));
+
+    const result = await fetchQuota();
+
+    expect(result.usage.windows.weekly.usedPercent).toBe(30);
+  });
+
+  it('reports null usedPercent when neither used nor remaining is present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      mockResponse({
+        usage: { limit: '100', resetTime: null },
+        limits: [],
+      }),
+    ));
+
+    const result = await fetchQuota();
+
+    expect(result.usage.windows.weekly.usedPercent).toBeNull();
+  });
+
+  it('reports not configured when no credentials are stored', async () => {
+    vi.doMock('../../opencode/auth.js', () => ({ readAuthFile: () => ({}) }));
+    vi.resetModules();
+    const { fetchQuota: fetchQuotaFresh } = await import('./kimi.js');
+
+    const result = await fetchQuotaFresh();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(false);
+    expect(result.error).toBe('Not configured');
+
+    vi.doUnmock('../../opencode/auth.js');
+    vi.resetModules();
+  });
+
+  it('surfaces API errors with status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('API error: 401');
+  });
+});


### PR DESCRIPTION
## Intent

Kimi for Coding usage in Settings → Usage showed 0% used even when the account had consumed 100% of its weekly quota. Kimi's `GET /coding/v1/usages` API is inconsistent about which field carries consumption: the weekly `usage` block returns a `used` field (never `remaining`), while each `limits[].detail` rate-limit block returns `remaining` (never `used`). Both provider implementations only ever read `.remaining`, so the weekly window's `usedPercent` always computed to `null` (rendered as unused). The fix derives `usedPercent` from whichever of `used`/`remaining` the response actually contains.

## Non-goals

- Not changing the Kimi rate-limit ("Rate Limit (Nm)") window logic beyond the same field-detection fix — its behavior was already correct since `limits[].detail` does return `remaining`.
- Not deduplicating the `packages/web` and `packages/vscode` copies of this provider logic — they were already independent duplicates before this change; consolidating them is a larger refactor outside this fix's scope.

## Affected surfaces

- `packages/web/server/lib/quota/providers/kimi.js` — web server quota provider (source of truth for the OpenChamber web/desktop Usage page).
- `packages/vscode/src/quotaProviders.ts` (`fetchKimiQuota`) — VS Code extension's independent duplicate of the same parsing logic; kept in sync so both runtimes report the same numbers.
- `packages/web/server/lib/quota/DOCUMENTATION.md` — documented the field-semantics quirk so future contributors don't reintroduce the bug.
- Electron and mobile web surfaces consume the same `packages/web` quota route and are fixed by the same server-side change; no separate edits needed there.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `.agents/skills/openchamber-change-discipline/SKILL.md` | Source change to provider parsing logic consumed by web/desktop/VS Code Usage UI | Made the smallest change (added `used`-vs-`remaining` field detection) without refactoring nearby code; kept the `packages/web`/`packages/vscode` duplication pattern that already existed rather than introducing new shared abstraction |
| `packages/web/server/lib/quota/DOCUMENTATION.md` | Nearest module doc for the quota provider being changed; already documents a precedent (MiniMax) for provider-specific API field-semantics quirks | Added a matching "Kimi for Coding field semantics" section documenting the `used`/`remaining` inconsistency and the two-file sync requirement |

## Validation

| Check | Result |
|---|---|
| Captured live API response via `curl` with the user's real `kimi-for-coding` credential against `https://api.kimi.com/coding/v1/usages` | Confirmed real shape: weekly `usage` block has `limit`/`used`/`resetTime` only (no `remaining`); `limits[].detail` has `limit`/`remaining`/`resetTime` only (no `used`) |
| `bun run test` (`packages/web`, scoped to `server/lib/quota`) | 12 files / 48 tests passed, including new `packages/web/server/lib/quota/providers/kimi.test.js` (6 cases covering the live shape, `remaining`-only fallback, `used`-precedence, both-absent, not-configured, and API-error paths) |
| `bun run type-check` (workspace-wide) | All 5 packages passed |
| `bun run lint` (workspace-wide) | All 5 packages passed |
| `bun run build:web` | Succeeded |
| `bun run vscode:build` | Succeeded |
| Live runtime check: started the actual OpenChamber web server + Vite HMR UI on isolated ports against this branch, hit `GET /api/quota/kimi-for-coding` | Returned `weekly.usedPercent: 100` (previously would have been `null`) |
| Live browser check: drove the real UI with Playwright to Settings → Usage → Kimi for Coding | Screenshot shows "Weekly Limit — 100%" with a full progress bar, matching the account's actual 100% consumption |
| Electron/mobile runtime behavior | Not independently verified — they consume the same web server quota route, and no Electron/mobile-specific code was touched |

## Visual evidence

After (this PR's HEAD), Settings → Usage → Kimi for Coding:
- "Weekly Limit — 100%" with a full/red progress bar, "Resets Tue, Aug 4, 9:21 AM"
- "Rate Limit (300m) — 0%" (this window was already correct)

No "before" screenshot was captured — the code was fixed prior to opening the browser in this session — but the raw API JSON evidence above shows why the old code produced `usedPercent: null` (rendered as unused) for the exact same live response that now produces `100`. No styling, layout, or narrow/wide/theme changes were made; this is a numeric-value-only fix, so light/dark and responsive states are unaffected.

## Risks and failure behavior

- If Kimi's API ever omits both `used` and `remaining` for a window, `usedPercent` now correctly falls back to `null` (unchanged "no data" behavior) rather than crashing or showing a misleading value.
- If Kimi later adds `used` to the rate-limit `detail` blocks too, the new precedence (`used` over `remaining`) picks it up automatically without further changes.
- No persisted data, auth, or external contract changes — this only changes in-memory percentage computation from an already-fetched API response.
- Both runtime copies (`packages/web`, `packages/vscode`) were updated together; a future change to only one would silently reintroduce the discrepancy between web/desktop and VS Code reporting, which is now called out in `DOCUMENTATION.md`.