### PR TITLE
fix(files): hide desktop-only reveal action in browser clients

### DIFF
--- a/packages/ui/src/components/layout/SidebarFilesTree.tsx
+++ b/packages/ui/src/components/layout/SidebarFilesTree.tsx
@@ -43,6 +43,7 @@ import { opencodeClient } from '@/lib/opencode/client';
 import { FileTypeIcon } from '@/components/icons/FileTypeIcon';
 import { Icon } from "@/components/icon/Icon";
 import { getContextFileOpenFailureMessage, validateContextFileOpen } from '@/lib/contextFileOpenGuard';
+import { isBrowserClientRuntime } from '@/lib/desktop';
 import { useI18n } from '@/lib/i18n';
 
 type FileNode = {
@@ -190,6 +191,7 @@ interface FileRowProps {
   root: string;
   isExpanded: boolean;
   isActive: boolean;
+  isBrowserClient: boolean;
   status?: FileStatus | null;
   badge?: { modified: number; added: number } | null;
   permissions: {
@@ -211,6 +213,7 @@ const FileRow: React.FC<FileRowProps> = ({
   root,
   isExpanded,
   isActive,
+  isBrowserClient,
   status,
   badge,
   permissions,
@@ -223,6 +226,9 @@ const FileRow: React.FC<FileRowProps> = ({
   const { t } = useI18n();
   const isDir = node.type === 'directory';
   const { canRename, canCreateFile, canCreateFolder, canDelete, canReveal } = permissions;
+  const canDownload = !isDir && Boolean(downloadFile);
+  const canRevealPath = canReveal && !isBrowserClient;
+  const hasMenuActions = canRename || canCreateFile || canCreateFolder || canDelete || canDownload || canRevealPath;
 
   // Menu open state is local to each row so opening a menu in one row
   // never re-renders its siblings. Previously this state lived on the
@@ -231,10 +237,10 @@ const FileRow: React.FC<FileRowProps> = ({
   const [rightClickOpen, setRightClickOpen] = React.useState(false);
 
   const handleContextMenu = React.useCallback((event?: React.MouseEvent) => {
-    if (!canRename && !canCreateFile && !canCreateFolder && !canDelete && !canReveal) return;
+    if (!hasMenuActions) return;
     event?.preventDefault();
     setRightClickOpen(true);
-  }, [canRename, canCreateFile, canCreateFolder, canDelete, canReveal]);
+  }, [hasMenuActions]);
 
   const handleInteraction = React.useCallback(() => {
     if (isDir) {
@@ -283,10 +289,10 @@ const FileRow: React.FC<FileRowProps> = ({
             toast.error(t('sidebarFilesTree.toast.operationFailed'));
           });
         }}>
-          <Icon name="download" className="mr-2 h-4 w-4" /> {t('sidebarFilesTree.menu.save')}
+          <Icon name="download" className="mr-2 h-4 w-4" /> {t(isBrowserClient ? 'sidebarFilesTree.menu.download' : 'sidebarFilesTree.menu.save')}
         </Item>
       )}
-      {canReveal && (
+      {canRevealPath && (
         <Item onClick={(e: React.MouseEvent) => { e.stopPropagation(); onRevealPath(node.path); }}>
           <Icon name="folder-received" className="mr-2 h-4 w-4" /> {t(getRevealLabelKey())}
         </Item>
@@ -362,7 +368,7 @@ const FileRow: React.FC<FileRowProps> = ({
           </span>
         )}
       </button>
-      {(canRename || canCreateFile || canCreateFolder || canDelete || canReveal) && (
+      {hasMenuActions && (
         <div className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 focus-within:opacity-100 group-hover:opacity-100">
           <DropdownMenu
             open={contextMenuOpen}
@@ -406,6 +412,7 @@ const areFileRowPropsEqual = (prev: FileRowProps, next: FileRowProps): boolean =
   && prev.root === next.root
   && prev.isExpanded === next.isExpanded
   && prev.isActive === next.isActive
+  && prev.isBrowserClient === next.isBrowserClient
   && prev.status === next.status
   && prev.badge === next.badge
   && prev.permissions === next.permissions
@@ -422,7 +429,8 @@ const MemoizedFileRow = React.memo(FileRow, areFileRowPropsEqual);
 
 export const SidebarFilesTree: React.FC = () => {
   const { t } = useI18n();
-  const { files } = useRuntimeAPIs();
+  const { files, runtime } = useRuntimeAPIs();
+  const isBrowserClient = isBrowserClientRuntime(runtime.platform);
   const currentDirectory = useEffectiveDirectory() ?? '';
   const root = normalizePath(currentDirectory.trim());
   const showHidden = useDirectoryShowHidden();
@@ -1045,6 +1053,7 @@ export const SidebarFilesTree: React.FC = () => {
             root={root}
             isExpanded={isExpanded}
             isActive={isActive}
+            isBrowserClient={isBrowserClient}
             status={!isDir ? getFileStatus(node.path) : undefined}
             badge={isDir ? getFolderBadge(node.path) : undefined}
             permissions={fileRowPermissions}

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -70,7 +70,7 @@ import { Icon } from "@/components/icon/Icon";
 import { useMessageTTS } from '@/hooks/useMessageTTS';
 import { ensurePierreThemeRegistered } from '@/lib/shiki/appThemeRegistry';
 import { getDefaultTheme } from '@/lib/theme/themes';
-import { openDesktopFileInApp, openDesktopPath } from '@/lib/desktop';
+import { isBrowserClientRuntime, openDesktopFileInApp, openDesktopPath } from '@/lib/desktop';
 import { useOpenInAppsStore } from '@/stores/useOpenInAppsStore';
 import { eventMatchesShortcut, getEffectiveShortcutCombo } from '@/lib/shortcuts';
 import { useI18n } from '@/lib/i18n';
@@ -361,6 +361,7 @@ interface FileRowProps {
   isExpanded: boolean;
   isActive: boolean;
   isMobile: boolean;
+  isBrowserClient: boolean;
   alwaysShowActions: boolean;
   status?: FileStatus | null;
   badge?: { modified: number; added: number } | null;
@@ -388,6 +389,7 @@ const FileRow: React.FC<FileRowProps> = ({
   isExpanded,
   isActive,
   isMobile,
+  isBrowserClient,
   alwaysShowActions,
   status,
   badge,
@@ -405,14 +407,17 @@ const FileRow: React.FC<FileRowProps> = ({
   const { t } = useI18n();
   const isDir = node.type === 'directory';
   const { canRename, canCreateFile, canCreateFolder, canDelete, canReveal } = permissions;
+  const canDownload = !isDir && Boolean(downloadFile);
+  const canRevealPath = canReveal && !isBrowserClient;
+  const hasMenuActions = canRename || canCreateFile || canCreateFolder || canDelete || canDownload || canRevealPath;
 
   const handleContextMenu = React.useCallback((event?: React.MouseEvent) => {
-    if (!canRename && !canCreateFile && !canCreateFolder && !canDelete && !canReveal) {
+    if (!hasMenuActions) {
       return;
     }
     event?.preventDefault();
     setRightClickMenuPath(node.path);
-  }, [canRename, canCreateFile, canCreateFolder, canDelete, canReveal, node.path, setRightClickMenuPath]);
+  }, [hasMenuActions, node.path, setRightClickMenuPath]);
 
   const handleInteraction = React.useCallback(() => {
     if (isDir) {
@@ -474,10 +479,10 @@ const FileRow: React.FC<FileRowProps> = ({
             toast.error(t('sidebarFilesTree.toast.operationFailed'));
           });
         }}>
-          <Icon name="download" className="mr-2 size-4" /> {t('sidebarFilesTree.menu.save')}
+          <Icon name="download" className="mr-2 size-4" /> {t(isBrowserClient ? 'sidebarFilesTree.menu.download' : 'sidebarFilesTree.menu.save')}
         </Item>
       )}
-      {canReveal && (
+      {canRevealPath && (
         <Item onClick={(e: React.MouseEvent) => { e.stopPropagation(); onRevealPath(node.path); }}>
           <Icon name="folder-received" className="mr-2 size-4" /> {t(getRevealLabelKey())}
         </Item>
@@ -546,7 +551,7 @@ const FileRow: React.FC<FileRowProps> = ({
           </span>
         )}
       </button>
-      {(canRename || canCreateFile || canCreateFolder || canDelete || canReveal) && (
+      {hasMenuActions && (
         <div className={cn(
           "absolute right-1 top-1/2 -translate-y-1/2",
           alwaysShowActions ? "opacity-100" : "opacity-0 focus-within:opacity-100 group-hover:opacity-100"
@@ -720,6 +725,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const { files, runtime } = useRuntimeAPIs();
   const { currentTheme, availableThemes, lightThemeId, darkThemeId } = useThemeSystem();
   const { isMobile, isTablet, screenWidth } = useDeviceInfo();
+  const isBrowserClient = isBrowserClientRuntime(runtime.platform);
   const alwaysShowActions = isMobile || isTablet;
   const showHidden = useDirectoryShowHidden();
   const showGitignored = useFilesViewShowGitignored();
@@ -2302,6 +2308,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             isExpanded={isExpanded}
             isActive={isActive}
             isMobile={isMobile}
+            isBrowserClient={isBrowserClient}
             alwaysShowActions={alwaysShowActions}
             status={!isDir ? getFileStatus(node.path) : undefined}
             badge={isDir ? getFolderBadge(node.path) : undefined}

--- a/packages/ui/src/lib/desktop.test.ts
+++ b/packages/ui/src/lib/desktop.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isBrowserClientRuntime } from './desktop';
+
+describe('browser client runtime', () => {
+  test('uses browser file behavior only outside the Electron shell', () => {
+    expect(isBrowserClientRuntime('web', false)).toBe(true);
+    expect(isBrowserClientRuntime('web', true)).toBe(false);
+  });
+
+  test('keeps desktop and VS Code runtime behavior out of browser-only flows', () => {
+    expect(isBrowserClientRuntime('desktop', false)).toBe(false);
+    expect(isBrowserClientRuntime('vscode', false)).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/desktop.ts
+++ b/packages/ui/src/lib/desktop.ts
@@ -1,4 +1,4 @@
-import type { ProjectEntry, TerminalShell } from '@/lib/api/types';
+import type { ProjectEntry, RuntimeAPIs, TerminalShell } from '@/lib/api/types';
 import { getInjectedBootOutcome } from '@/lib/desktopBoot';
 import type { DraftStarterRef } from '@/lib/draftStarters';
 import type { MobileKeyboardMode } from '@/lib/mobileKeyboardMode';
@@ -561,6 +561,15 @@ export const isWebRuntime = (): boolean => {
   // Default: anything that's not VSCode behaves like web (HTTP UI).
   return !isVSCodeRuntime();
 };
+
+/**
+ * Electron reuses the web RuntimeAPIs implementation, so distinguish a browser
+ * client from an Electron renderer with both the runtime descriptor and shell.
+ */
+export const isBrowserClientRuntime = (
+  platform: RuntimeAPIs['runtime']['platform'],
+  desktopShell = isDesktopShell(),
+): boolean => platform === 'web' && !desktopShell;
 
 export const getDesktopHomeDirectory = async (): Promise<string | null> => {
   if (typeof window !== 'undefined') {

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1225,6 +1225,7 @@ export const dict = {
   'sidebarFilesTree.menu.rename': 'Rename',
   'sidebarFilesTree.menu.copyPath': 'Copy Path',
   'sidebarFilesTree.menu.save': 'Save',
+  'sidebarFilesTree.menu.download': 'Download',
   'sidebarFilesTree.menu.newFile': 'New File',
   'sidebarFilesTree.menu.newFolder': 'New Folder',
   'sidebarFilesTree.menu.delete': 'Delete',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1191,6 +1191,7 @@ export const dict: Record<I18nKey, string> = {
   "sidebarFilesTree.menu.rename": "Cambiar nombre",
   "sidebarFilesTree.menu.copyPath": "Copiar ruta",
   "sidebarFilesTree.menu.save": "Guardar",
+  "sidebarFilesTree.menu.download": "Descargar",
   "sidebarFilesTree.menu.newFile": "Nuevo archivo",
   "sidebarFilesTree.menu.newFolder": "Nueva carpeta",
   "sidebarFilesTree.menu.delete": "Eliminar",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1047,6 +1047,7 @@ export const dict = {
   'sidebarFilesTree.menu.rename': 'Rebaptiser',
   'sidebarFilesTree.menu.copyPath': 'Copier le chemin',
   'sidebarFilesTree.menu.save': 'Sauvegarder',
+  'sidebarFilesTree.menu.download': 'Télécharger',
   'sidebarFilesTree.menu.newFile': 'Nouveau fichier',
   'sidebarFilesTree.menu.newFolder': 'Nouveau dossier',
   'sidebarFilesTree.menu.delete': 'Supprimer',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -1221,6 +1221,7 @@ export const dict: Record<I18nKey, string> = {
   'sidebarFilesTree.menu.rename': '名前の変更',
   'sidebarFilesTree.menu.copyPath': 'パスをコピー',
   'sidebarFilesTree.menu.save': '保存',
+  'sidebarFilesTree.menu.download': 'ダウンロード',
   'sidebarFilesTree.menu.newFile': '新しいファイル',
   'sidebarFilesTree.menu.newFolder': '新しいフォルダ',
   'sidebarFilesTree.menu.delete': '削除',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1228,6 +1228,7 @@ export const dict: Record<I18nKey, string> = {
   'sidebarFilesTree.menu.rename': '이름 변경',
   'sidebarFilesTree.menu.copyPath': '경로 복사',
   'sidebarFilesTree.menu.save': '저장',
+  'sidebarFilesTree.menu.download': '다운로드',
   'sidebarFilesTree.menu.newFile': '새 파일',
   'sidebarFilesTree.menu.newFolder': '새 폴더',
   'sidebarFilesTree.menu.delete': '삭제',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2708,6 +2708,7 @@ export const dict: Record<I18nKey, string> = {
   'sidebarFilesTree.menu.newFolder': 'Nowy folder',
   'sidebarFilesTree.menu.rename': 'Zmień nazwę',
   'sidebarFilesTree.menu.save': 'Zapisz',
+  'sidebarFilesTree.menu.download': 'Pobierz',
   'sidebarFilesTree.search.clearAria': 'Wyczyść wyszukiwanie',
   'sidebarFilesTree.search.placeholder': 'Szukaj plików...',
   'sidebarFilesTree.state.loading': 'Ładowanie...',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1191,6 +1191,7 @@ export const dict: Record<I18nKey, string> = {
   "sidebarFilesTree.menu.rename": "Renomear",
   "sidebarFilesTree.menu.copyPath": "Copiar caminho",
   "sidebarFilesTree.menu.save": "Salvar",
+  "sidebarFilesTree.menu.download": "Baixar",
   "sidebarFilesTree.menu.newFile": "Novo arquivo",
   "sidebarFilesTree.menu.newFolder": "Nova pasta",
   "sidebarFilesTree.menu.delete": "Excluir",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1191,6 +1191,7 @@ export const dict: Record<I18nKey, string> = {
   "sidebarFilesTree.menu.rename": "Перейменувати",
   "sidebarFilesTree.menu.copyPath": "Копіювати шлях",
   "sidebarFilesTree.menu.save": "Зберегти",
+  "sidebarFilesTree.menu.download": "Завантажити",
   "sidebarFilesTree.menu.newFile": "Новий файл",
   "sidebarFilesTree.menu.newFolder": "Нова папка",
   "sidebarFilesTree.menu.delete": "Видалити",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1191,6 +1191,7 @@ export const dict: Record<I18nKey, string> = {
   'sidebarFilesTree.menu.rename': '重命名',
   'sidebarFilesTree.menu.copyPath': '复制路径',
   'sidebarFilesTree.menu.save': '保存',
+  'sidebarFilesTree.menu.download': '下载',
   'sidebarFilesTree.menu.newFile': '新建文件',
   'sidebarFilesTree.menu.newFolder': '新建文件夹',
   'sidebarFilesTree.menu.delete': '删除',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1203,6 +1203,7 @@ export const dict: Record<I18nKey, string> = {
   'sidebarFilesTree.menu.rename': '重新命名',
   'sidebarFilesTree.menu.copyPath': '複製路徑',
   'sidebarFilesTree.menu.save': '儲存',
+  'sidebarFilesTree.menu.download': '下載',
   'sidebarFilesTree.menu.newFile': '新增檔案',
   'sidebarFilesTree.menu.newFolder': '新增資料夾',
   'sidebarFilesTree.menu.delete': '刪除',


### PR DESCRIPTION
## Intent

In a plain browser tab, the Files sidebar/view always offered "Reveal in Finder/Explorer" whenever the server exposed `revealPath` — but there is no local file manager for a remote server's filesystem to reveal into from a browser tab. This adds a shared `isBrowserClientRuntime` helper (web platform, no Electron shell) to hide that action in browser clients, and relabels the file-save menu item to "Download" there since it performs a browser-style blob download rather than an in-place save.

## Non-goals

Electron and VS Code menu behavior are unchanged (Electron reuses the web `RuntimeAPIs` implementation but is still excluded via the Electron-shell check). No changes to the underlying `revealPath`/`downloadFile` implementations themselves.

## Affected surfaces

- `packages/ui` shared UI: `SidebarFilesTree.tsx`, `FilesView.tsx`, `lib/desktop.ts` (new `isBrowserClientRuntime` export), all locale dictionaries (new `sidebarFilesTree.menu.download` key).
- Web browser: reveal action hidden, save action now labeled "Download".
- Electron desktop: unaffected — `isDesktopShell()` keeps `isBrowserClientRuntime` false even though Electron reports `platform: 'web'`.
- VS Code webview: unaffected — `platform: 'vscode'` already excluded.
- Capacitor mobile: mobile bundles the same web build/API (`platform: 'web'`, no Electron shell), so it is classified as a browser client too. Verified this is the correct outcome: mobile has no separate `revealPath`/`downloadFile` implementation — both come from the same `createWebAPIs` code as plain web, so hiding reveal and labeling "Download" matches actual mobile behavior.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `ui-api-decoupling` skill | Change touches `RuntimeAPIs`/runtime-platform-based behavior in shared UI | New helper takes `runtime.platform` from `useRuntimeAPIs()` (component-level hook), not a runtime global; no new HTTP/transport paths added |
| `locale-ui-patterns` skill | Adds a new user-facing menu label | Added `sidebarFilesTree.menu.download` key with a real, distinct translation in all 10 locale dictionaries (en, es, fr, ja, ko, pl, pt-BR, uk, zh-CN, zh-TW) — no English placeholders |
| CLAUDE.md "Correctness Invariants" — runtime-specific differences must be intentional and visible in code | Reveal/download behavior differs by runtime | Behavior gated through an explicit, named, tested helper rather than an implicit assumption |
| CLAUDE.md Validation section | Executable source changed in `packages/ui` | Ran package-scoped type-check, lint, dead-code, and focused tests (below) |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (packages/ui) | Pass, no errors |
| `bun run lint` (workspace-wide) | Pass, all packages exit 0 |
| `bun run dead-code` | No new unused exports introduced by this change |
| `bun test src/lib/desktop.test.ts` (new) | 2 pass, 0 fail |

Not verified: interactive browser/Electron/VS Code/mobile manual testing of the menu (no running dev server in this session).

## Visual evidence

No screenshots captured — could not run the dev server in this session to exercise the UI interactively. The change is a conditional label swap ("Save" → "Download") and conditional hide of one existing menu item in a dropdown; no layout change.

## Risks and failure behavior

Low risk: the new helper is a pure function with a default parameter (`isDesktopShell()`), used only to gate an existing menu item and swap an existing label. If `runtime.platform` is ever missing/unexpected, `isBrowserClientRuntime` returns `false` (safe default: keeps prior "Reveal"/"Save" behavior visible rather than hiding a legitimate action). No persisted state, migrations, or external contracts are touched.