### PR TITLE
fix(electron): require TerminalEmulator category for terminal appId on Linux

### DIFF
--- a/packages/electron/linux-app-discovery.mjs
+++ b/packages/electron/linux-app-discovery.mjs
@@ -234,6 +234,11 @@ const commandExists = (program, env = process.env) => {
 
 const findEntry = (entries, appId, appName) => entries.find((entry) => desktopEntryMatchesApp(entry, appName, appId)) || null;
 
+const isTerminalEmulatorEntry = (entry) => {
+  const categories = Array.isArray(entry?.categories) ? entry.categories : [];
+  return categories.some((category) => normalizeComparable(category) === 'terminalemulator');
+};
+
 export const buildLinuxOpenSpecs = ({ targetPath, appId, appName, targetKind = 'path', entries = [], env = process.env }) => {
   if (appId === 'finder') {
     return [{ kind: 'default', targetKind, targetPath }];
@@ -241,7 +246,9 @@ export const buildLinuxOpenSpecs = ({ targetPath, appId, appName, targetKind = '
   const specs = [];
   if (TERMINAL_APP_IDS.has(appId)) {
     const directory = targetKind === 'file' ? path.dirname(targetPath) : targetPath;
-    const terminalEntry = findEntry(entries, appId, appName);
+    const terminalEntry = appId === 'terminal'
+      ? entries.find(isTerminalEmulatorEntry) || null
+      : findEntry(entries, appId, appName);
     if (terminalEntry) {
       const spec = buildCommandFromDesktopExec(terminalEntry, directory);
       if (spec) specs.push(spec);
@@ -515,7 +522,7 @@ export const buildLinuxInstalledApps = async (apps, options = {}) => {
           ...FILE_MANAGER_ICON_FALLBACKS,
         ], { ...options, env });
       } else if (normalizeComparable(name) === 'terminal') {
-        const terminalEntry = findEntry(entries, 'terminal', name)
+        const terminalEntry = entries.find(isTerminalEmulatorEntry)
           || findEntry(entries, 'ghostty', 'Ghostty');
         iconDataUrl = resolveIconDataUrlForName([
           terminalEntry?.icon,

--- a/packages/electron/scripts/smoke-linux-app-discovery.mjs
+++ b/packages/electron/scripts/smoke-linux-app-discovery.mjs
@@ -28,14 +28,22 @@ try {
   const iconsRoot = path.join(dataDir, 'icons');
   const thunarIcon = path.join(iconsRoot, 'hicolor', '48x48', 'apps', 'org.xfce.thunar.png');
   const codeIcon = path.join(iconsRoot, 'hicolor', '32x32', 'apps', 'code.png');
+  const terminalIcon = path.join(iconsRoot, 'hicolor', '48x48', 'apps', 'utilities-terminal.png');
+  const helperIcon = path.join(iconsRoot, 'hicolor', '48x48', 'apps', 'helper-app.png');
   await fs.mkdir(userApps, { recursive: true });
   await fs.mkdir(systemApps, { recursive: true });
   await fs.mkdir(path.dirname(thunarIcon), { recursive: true });
   await fs.mkdir(path.dirname(codeIcon), { recursive: true });
+  await fs.mkdir(path.dirname(terminalIcon), { recursive: true });
+  await fs.mkdir(path.dirname(helperIcon), { recursive: true });
   // Minimal valid 1x1 PNG.
   const png = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==', 'base64');
+  // Distinct PNG so the helper-app icon is distinguishable from the terminal theme icon.
+  const helperPng = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBASZNV9oAAAAASUVORK5CYII=', 'base64');
   await fs.writeFile(thunarIcon, png);
   await fs.writeFile(codeIcon, png);
+  await fs.writeFile(terminalIcon, png);
+  await fs.writeFile(helperIcon, helperPng);
 
   const codeDesktopPath = path.join(userApps, 'code.desktop');
   await fs.writeFile(codeDesktopPath, [
@@ -52,6 +60,23 @@ try {
   await fs.writeFile(path.join(userApps, 'missing-name.desktop'), '[Desktop Entry]\nType=Application\nExec=missing %f\n', 'utf8');
   await fs.writeFile(path.join(userApps, 'missing-exec.desktop'), '[Desktop Entry]\nType=Application\nName=Missing Exec\nIcon=missing\n', 'utf8');
   await fs.writeFile(path.join(systemApps, 'ghostty.desktop'), '[Desktop Entry]\nType=Application\nName=Ghostty\nExec=ghostty --working-directory=%f --open-uri=%u\nIcon=ghostty\n', 'utf8');
+  // A non-terminal app that launches itself via xdg-terminal-exec (e.g. a TUI
+  // helper). Its Exec line contains "xdg-terminal-exec", which the loose
+  // substring match in desktopEntryMatchesApp would mis-attribute to the
+  // generic "terminal" appId. Categories=Utility; (not TerminalEmulator) is
+  // the signal that this is NOT a terminal emulator.
+  await fs.writeFile(path.join(systemApps, 'helper-app.desktop'), [
+    '[Desktop Entry]',
+    'Type=Application',
+    'NoDisplay=false',
+    'Terminal=false',
+    'StartupNotify=true',
+    'Exec=/usr/bin/xdg-terminal-exec --app-id=helper-app --title="Helper App" -- /usr/bin/helper-script',
+    `Icon=${helperIcon}`,
+    'Name=Helper App',
+    'Categories=Utility;',
+    '',
+  ].join('\n'), 'utf8');
   await fs.writeFile(path.join(systemApps, 'plain.desktop'), '[Desktop Entry]\nType=Application\nName=Plain Editor\nExec=plain-editor --flag\nIcon=plain\n', 'utf8');
   await fs.writeFile(path.join(systemApps, 'thunar.desktop'), [
     '[Desktop Entry]',
@@ -69,7 +94,7 @@ try {
   assert(dirs.includes(systemApps), 'XDG_DATA_DIRS applications dir should be included');
 
   const entries = await readLinuxDesktopEntries({ applicationDirs: [userApps, systemApps], env, homeDir: tempRoot });
-  assert(entries.length === 4, `expected 4 visible valid entries, got ${entries.length}`);
+  assert(entries.length === 5, `expected 5 visible valid entries, got ${entries.length}`);
   assert(entries.some((entry) => entry.name === 'Visual Studio Code'), 'valid desktop entry should be parsed');
   assert(entries.some((entry) => entry.name === 'Ghostty'), 'system desktop entry should be parsed');
   assert(entries.some((entry) => entry.name === 'Plain Editor'), 'no-placeholder entry should be parsed');
@@ -127,6 +152,28 @@ try {
   const codeInfo = appInfos.find((entry) => entry.name === 'Visual Studio Code');
   assert(typeof codeInfo?.iconDataUrl === 'string' && codeInfo.iconDataUrl.startsWith('data:image/png;base64,'), 'desktop app should resolve Icon= theme PNG to data URL');
 
+  const terminalEmulatorEntry = parseDesktopEntry([
+    '[Desktop Entry]',
+    'Type=Application',
+    'Name=MyConsole',
+    'Exec=myconsole --working-directory=%f',
+    'Icon=utilities-terminal',
+    'Categories=TerminalEmulator;',
+    '',
+  ].join('\n'), path.join(systemApps, 'myconsole.desktop'));
+  const helperEntry = entries.find((entry) => entry.name === 'Helper App');
+  const terminalIconInfos = await buildLinuxInstalledApps(['Terminal'], {
+    entries: [helperEntry, terminalEmulatorEntry],
+    env,
+    homeDir: tempRoot,
+    execFileSyncImpl: () => 'thunar.desktop',
+  });
+  const terminalInfo = terminalIconInfos.find((entry) => entry.name === 'Terminal');
+  const expectedTerminalIconDataUrl = `data:image/png;base64,${png.toString('base64')}`;
+  const expectedHelperIconDataUrl = `data:image/png;base64,${helperPng.toString('base64')}`;
+  assert(terminalInfo?.iconDataUrl === expectedTerminalIconDataUrl, `Terminal should resolve the TerminalEmulator entry icon, got ${terminalInfo?.iconDataUrl}`);
+  assert(terminalInfo?.iconDataUrl !== expectedHelperIconDataUrl, 'Terminal icon must not resolve to a non-terminal entry whose Exec uses a terminal launcher (loose name/exec match regression)');
+
   const fetchedIcons = await fetchLinuxAppIcons(['Finder', 'Visual Studio Code'], {
     entries,
     env,
@@ -151,6 +198,27 @@ try {
   assert(fallbackTerminalSpecs.length >= 1, 'missing terminal desktop entry should include xdg-terminal-exec fallback');
   assert(fallbackTerminalSpecs[0]?.program === 'xdg-terminal-exec', 'missing terminal entry should use xdg-terminal-exec first');
   assert(fallbackTerminalSpecs[0]?.args.join('|') === '--working-directory|/tmp/My Project', `xdg-terminal-exec fallback should keep working directory args, got ${fallbackTerminalSpecs[0]?.args.join('|')}`);
+  assert(!fallbackTerminalSpecs.some((spec) => (spec.args || []).some((arg) => arg.includes('helper-script'))), 'non-terminal entry using a terminal launcher must not be launched for the generic terminal appId');
+
+  const ptyxisEntry = parseDesktopEntry([
+    '[Desktop Entry]',
+    'Type=Application',
+    'Name=Ptyxis',
+    'Exec=ptyxis --working-directory=%f',
+    'Categories=TerminalEmulator;',
+    '',
+  ].join('\n'), '/tmp/org.gnome.Ptyxis.desktop');
+  const terminalEmulatorSpecs = buildLinuxOpenSpecs({
+    targetPath: '/tmp/My Project',
+    appId: 'terminal',
+    appName: 'Terminal',
+    targetKind: 'project',
+    entries: [ptyxisEntry, ...entries],
+    env,
+  });
+  assert(terminalEmulatorSpecs[0]?.program === 'ptyxis', `terminal emulator entry should be preferred, got ${terminalEmulatorSpecs[0]?.program}`);
+  assert(terminalEmulatorSpecs[0]?.args.join('|') === '--working-directory=/tmp/My Project', `ptyxis should receive working directory, got ${terminalEmulatorSpecs[0]?.args.join('|')}`);
+  assert(!terminalEmulatorSpecs.some((spec) => (spec.args || []).some((arg) => arg.includes('helper-script'))), 'non-terminal entry using a terminal launcher must not be launched when a real terminal emulator entry exists');
 
   const defaultSpecs = buildLinuxOpenSpecs({ targetPath: '/tmp/My Project', appId: 'finder', appName: 'Finder', targetKind: 'project', entries, env });
   assert(defaultSpecs[0].kind === 'default', 'finder maps to safe default Linux opener spec');
@@ -169,6 +237,7 @@ try {
     specs,
     terminalFileSpecs,
     fallbackTerminalSpecs,
+    terminalEmulatorSpecs,
     defaultSpecs,
   }, null, 2));
 } finally {


### PR DESCRIPTION
## Intent

On Bazzite (and any distro shipping a non-terminal app that uses `xdg-terminal-exec` as its launcher — e.g. a TUI helper), the "Open in Terminal" action launched the helper script instead of a real terminal, and the Terminal picker entry showed the helper's icon. Root cause: `desktopEntryMatchesApp` uses a loose substring match that accepted any `.desktop` entry whose `Exec` line mentioned a terminal launcher, so a `Utility`-categorized app launched via `xdg-terminal-exec` was mis-attributed to the generic `terminal` appId.

For `appId === 'terminal'` only, require the XDG `Categories=...;TerminalEmulator;` signal via a shared `isTerminalEmulatorEntry` predicate. `ghostty`/`iterm2` keep name-based matching. The launch path (`buildLinuxOpenSpecs`) and the icon path (`buildLinuxInstalledApps`) both reuse the predicate, eliminating the duplicate source of the loose-match bug.

## Non-goals

- Changing how `ghostty`/`iterm2` resolve (name-based match preserved).
- Tightening `desktopEntryMatchesApp` itself for non-`terminal` appIds.
- Cache invalidation for `discovered-apps.json` — the 24h TTL self-resolves the stale cached icon; adding a version field was considered and dropped as speculative tech debt.
- Preferring the user's `xdg-mime query default x-scheme-handler/terminal` over the alphabetically-first `TerminalEmulator` entry (out of scope; the existing `xdg-terminal-exec` fallback already respects the user's configured default terminal).

## Affected surfaces

- `packages/electron/linux-app-discovery.mjs` — adds private `isTerminalEmulatorEntry`; `buildLinuxOpenSpecs` and `buildLinuxInstalledApps` use it for `appId === 'terminal'` only.
- `packages/electron/scripts/smoke-linux-app-discovery.mjs` — regression test.
- Runtimes: Electron main process on Linux only. macOS, Windows, VS Code, web, and mobile are unaffected (the changed code path is Linux-only).
- No IPC, preload, persisted-settings, or package-contract changes. No exports changed.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — Runtime Boundaries | Desktop-entry parsing and FreeDesktop icon lookup are inherently native Linux behavior. | Change stays in `packages/electron/`; no shared-UI or runtime-bridge surface touched. |
| `AGENTS.md` — Correctness Invariants | "Prefer authoritative state over heuristics." | Replaces a heuristic (loose Exec/name substring match) with the authoritative XDG category signal for `terminal` resolution. |
| `AGENTS.md` — Always-On Constraints | Minimal change, no new deps, no secrets, preserve unrelated worktree changes. | 11 source lines + one shared predicate; no new deps; no IPC/persistence changes. |
| `.agents/skills/openchamber-change-discipline/SKILL.md` | Mandatory for source changes. | Risk = Local implementation (private helper, no export/contract change); observable behavior preserved for `ghostty`/`iterm2`/`finder`; helper is reused twice (real reuse, not speculative); focused tests added. |
| `.agents/skills/desktop-shell/SKILL.md` | Trigger: Electron native behavior. | Desktop-entry parsing and icon resolution are inherently native; no preload/IPC shape change; `validateLocalPath` still gates `desktop_open_in_app` upstream of the changed code. |
| `packages/electron/README.md` | Owning package README; lists installed-app discovery and FreeDesktop icon lookup as native features. | Change is in-scope; no packaging, updater, or IPC contract surface changed. |

## Validation

| Check | Result |
|---|---|
| `node --check packages/electron/linux-app-discovery.mjs` | pass |
| `node --check packages/electron/scripts/smoke-linux-app-discovery.mjs` | pass |
| `bun run --cwd packages/electron test:linux-desktop` (autostart + smoke-linux-app-discovery + smoke-path-open-utils) | pass (3/3 node:test; both smoke scripts `ok: true`) |
| Discrimination check: temporarily revert the icon fix → smoke test | FAILS as expected (`Terminal should resolve the TerminalEmulator entry icon, got data:image/png;base64,<helperPng bytes>`), confirming the assertion catches a regression. Restored after. |
| `bun run --cwd packages/electron package` (full: `build:web-assets` + `prepare:opencode-cli` + `bundle:main` + `rebuild:native` + electron-builder) | succeeded; `dist/OpenChamber-1.17.2-linux-x86_64.AppImage` (216 MB) |
| `node ./scripts/verify-linux-appimage.mjs` | `[electron] verified Linux x64 AppImage`; `verified OpenCode CLI 1.18.11 and 5 native modules` |

Verified on a real Bazzite device by the author: "Open in Terminal" now launches the real terminal emulator (not the `xdg-terminal-exec`-launched helper), and the Terminal picker entry shows the terminal emulator's icon instead of the helper's. The fix is a spec-standard XDG category check; the `TerminalEmulator` category is documented at freedesktop.org and used by gnome-terminal, konsole, kgx, ptyxis, ghostty, etc. Static and smoke checks were run in this environment; the device verification confirms the runtime behavior.

## Visual evidence

No user-visible rendered change in this diff. The change affects which native terminal Electron launches and which icon data URL resolves for the Terminal picker entry on Linux — both exercised by `smoke-linux-app-discovery.mjs` assertions on exact `program`/`args` and exact `data:image/png;base64,...` bytes. A screenshot cannot represent "which terminal launched" or "which bytes the icon resolved to" more faithfully than the assertions already do.

## Risks and failure behavior

- **Non-conformant custom terminal `.desktop` without `Categories=TerminalEmulator;`** (and not Ghostty, which still has a name-based fallback in the icon path) will no longer be launched via its desktop entry. It still launches via the unchanged fallback chain: `xdg-terminal-exec` (unconditional, first fallback) → `gnome-terminal` → `konsole` → `xfce4-terminal` → `x-terminal-emulator`, tried in order by `runLinuxSpecChain` until one spawns. This is the correct tradeoff: such an entry is non-conformant by the freedesktop.org registered-category spec, and `xdg-terminal-exec` respects the user's configured default terminal.
- **Failure mode**: if no `TerminalEmulator`-categorized entry exists and all fallback commands are absent, the existing behavior (no spec succeeds; `runLinuxSpecChain` reports failure) is unchanged.
- **Rollback**: revert the commit; no persisted state to migrate.
- **Security**: the change narrows which desktop entries can be selected for the `terminal` appId from a loose substring match to a strict XDG category check — a positive security delta. No new IPC, no renderer-supplied data flows into the spawn target, no new dependencies, no secrets touched.
