### PR TITLE
fix(sync): render sessions in worktrees created while the client is running

### DIFF
--- a/packages/ui/src/lib/debug.ts
+++ b/packages/ui/src/lib/debug.ts
@@ -441,7 +441,11 @@ export const debugUtils = {
     const sources = {
       attachment,
       worktreeMetadata,
-      authoritative: owningStoreDirectory ?? recordDirectory,
+      // Record first, matching the resolver: holding a session proves
+      // containment, not ownership, so the parent repository holds its
+      // worktrees' sessions too. Reporting membership first made this
+      // diagnostic contradict the routing it exists to explain.
+      authoritative: recordDirectory ?? owningStoreDirectory,
       selected,
       remembered: remembered.runtime,
     };

--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -207,7 +207,7 @@ The discriminator is whether the server confirmed the path, not whether the valu
 
 | Source | Meaning |
 |---|---|
-| `authoritative` | The child store that actually holds the session, then its own record |
+| `authoritative` | The session record's own directory, then a child store that holds it |
 | `selected` | Server-confirmed directory captured at selection; a guessed one is never passed |
 | `attachment` | Worktree attachment recorded by this client; the *requested* path |
 | `worktree-metadata` | Worktree captured when the session was created in one; the *requested* path |
@@ -215,7 +215,7 @@ The discriminator is whether the server confirmed the path, not whether the valu
 
 Rules:
 
-1. `getSyncSessionDirectory()` is the authoritative session→directory mapping: a session lives in exactly the child store for its directory, whether or not the server populated `session.directory`. `null` means "not indexed yet", never "no directory".
+1. Ownership comes from the session record's own `directory`. `getSyncSessionDirectory()` reports *containment*, not ownership, and is only the fallback for a record without a directory: a project's session list includes the sessions of its worktrees so the sidebar can group them, so the parent repository holds worktree sessions too, and reading ownership from membership routes a worktree session to its parent. `null` means "not indexed yet", never "no directory".
 2. `attachment` and `worktreeMetadata` hold the worktree path this client asked for, before the server canonicalized it. They are a hint for a session sync has not indexed yet, never a correction of a confirmed directory — otherwise a stale local path re-creates the very mismatch this precedence exists to prevent.
 3. Never persist or rank a guessed directory. `selectSession` may fall back to the active directory to keep routing usable, but that value is not written to runtime memory, not written to the last-active snapshot, and not passed as `selected` — a persisted guess outlives the race that produced it and survives reloads and restarts.
 4. Components must not read `currentSessionDirectory` to build request or queue keys; use `getDirectoryForSession()` so every consumer resolves identically.

--- a/packages/ui/src/sync/session-directory-adoption.test.ts
+++ b/packages/ui/src/sync/session-directory-adoption.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+
+import { ChildStoreManager } from "./child-store"
+import { setSyncRefs } from "./sync-refs"
+import { useSessionUIStore } from "./session-ui-store"
+
+/**
+ * Selecting a session whose directory this client has not indexed yet routes it
+ * through the active directory as a deliberate guess. Nothing used to settle
+ * that guess once the owning directory finished bootstrapping, so every fetch
+ * stayed addressed to a directory that does not own the session and the session
+ * never rendered.
+ *
+ * These tests pin both directions: a guess is promoted once the authoritative
+ * directory becomes readable, and a confirmed selection is never rewritten.
+ */
+
+const PARENT = "/repo"
+const WORKTREE = "/repo/.worktrees/feature"
+const SESSION_ID = "ses_directory_adoption"
+
+const indexSessionIn = (manager: ChildStoreManager, directory: string): void => {
+  const store = manager.ensureChild(directory, { bootstrap: false })
+  store.setState({
+    session: [{ id: SESSION_ID, directory, title: "test" } as never],
+  })
+}
+
+let manager: ChildStoreManager
+
+beforeEach(() => {
+  manager = new ChildStoreManager()
+  setSyncRefs({} as never, manager, PARENT)
+  useSessionUIStore.getState().setCurrentSession(null)
+})
+
+describe("adoptAuthoritativeSessionDirectory", () => {
+  test("promotes a guessed selection once the owning directory is indexed", () => {
+    useSessionUIStore.getState().setCurrentSession(SESSION_ID)
+    expect(useSessionUIStore.getState().currentSessionDirectory).not.toBe(WORKTREE)
+
+    indexSessionIn(manager, WORKTREE)
+    useSessionUIStore.getState().adoptAuthoritativeSessionDirectory()
+
+    expect(useSessionUIStore.getState().currentSessionDirectory).toBe(WORKTREE)
+  })
+
+  test("does nothing while the owning directory is still unknown", () => {
+    useSessionUIStore.getState().setCurrentSession(SESSION_ID)
+    const before = useSessionUIStore.getState().currentSessionDirectory
+
+    useSessionUIStore.getState().adoptAuthoritativeSessionDirectory()
+
+    expect(useSessionUIStore.getState().currentSessionDirectory).toBe(before)
+  })
+
+  test("never rewrites a selection that was confirmed at selection time", () => {
+    useSessionUIStore.getState().setCurrentSession(SESSION_ID, WORKTREE)
+    expect(useSessionUIStore.getState().currentSessionDirectory).toBe(WORKTREE)
+
+    // A different directory claiming the session must not move a confirmed
+    // selection: the confirmed value outranks anything sync learns later.
+    indexSessionIn(manager, PARENT)
+    useSessionUIStore.getState().adoptAuthoritativeSessionDirectory()
+
+    expect(useSessionUIStore.getState().currentSessionDirectory).toBe(WORKTREE)
+  })
+
+  test("is a no-op for a session that is no longer selected", () => {
+    useSessionUIStore.getState().setCurrentSession(SESSION_ID)
+    indexSessionIn(manager, WORKTREE)
+    useSessionUIStore.getState().setCurrentSession("ses_other")
+
+    // Whatever the new selection resolved to, a late adoption for the previous
+    // session must not touch it.
+    const before = useSessionUIStore.getState().currentSessionDirectory
+    useSessionUIStore.getState().adoptAuthoritativeSessionDirectory(SESSION_ID)
+
+    expect(useSessionUIStore.getState().currentSessionId).toBe("ses_other")
+    expect(useSessionUIStore.getState().currentSessionDirectory).toBe(before)
+  })
+})

--- a/packages/ui/src/sync/session-directory-adoption.test.ts
+++ b/packages/ui/src/sync/session-directory-adoption.test.ts
@@ -19,10 +19,14 @@ const PARENT = "/repo"
 const WORKTREE = "/repo/.worktrees/feature"
 const SESSION_ID = "ses_directory_adoption"
 
-const indexSessionIn = (manager: ChildStoreManager, directory: string): void => {
+const indexSessionIn = (
+  manager: ChildStoreManager,
+  directory: string,
+  recordDirectory: string = directory,
+): void => {
   const store = manager.ensureChild(directory, { bootstrap: false })
   store.setState({
-    session: [{ id: SESSION_ID, directory, title: "test" } as never],
+    session: [{ id: SESSION_ID, directory: recordDirectory, title: "test" } as never],
   })
 }
 
@@ -40,6 +44,18 @@ describe("adoptAuthoritativeSessionDirectory", () => {
     expect(useSessionUIStore.getState().currentSessionDirectory).not.toBe(WORKTREE)
 
     indexSessionIn(manager, WORKTREE)
+    useSessionUIStore.getState().adoptAuthoritativeSessionDirectory()
+
+    expect(useSessionUIStore.getState().currentSessionDirectory).toBe(WORKTREE)
+  })
+
+  test("believes the session record over the store that merely holds it", () => {
+    // A project's session list includes the sessions of its worktrees so the
+    // sidebar can group them, so the parent store holds this session while the
+    // session itself reports the worktree. Ownership comes from the record.
+    useSessionUIStore.getState().setCurrentSession(SESSION_ID)
+    indexSessionIn(manager, PARENT, WORKTREE)
+
     useSessionUIStore.getState().adoptAuthoritativeSessionDirectory()
 
     expect(useSessionUIStore.getState().currentSessionDirectory).toBe(WORKTREE)

--- a/packages/ui/src/sync/session-directory-resolution.ts
+++ b/packages/ui/src/sync/session-directory-resolution.ts
@@ -13,8 +13,10 @@
  * The ordering discriminator is **whether the server confirmed the path**, not
  * whether the value is local or synced:
  *
- * 1. `authoritative` — the child store that actually holds the session, then
- *    the session's own record. Server-backed truth for an indexed session.
+ * 1. `authoritative` — the session's own record, then a child store that holds
+ *    it. Server-backed truth for an indexed session. Record first because
+ *    holding a session proves containment, not ownership: a project's session
+ *    list includes its worktrees' sessions so the sidebar can group them.
  * 2. `selected` — the directory captured when the session was selected, but
  *    only when it came from a server response (the directory `createSession`
  *    returned, which may be a canonicalized form of what was requested). A
@@ -42,7 +44,7 @@ export type SessionDirectorySource =
   | 'none'
 
 export type SessionDirectorySources = {
-  /** Directory of the child store that holds the session, or its own record. */
+  /** The session record's own directory, or a store that holds it. */
   authoritative?: string | null
   /** Server-confirmed directory captured at selection. Never a guessed one. */
   selected?: string | null

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -407,12 +407,10 @@ const getAttachmentForSession = (sessionId: string | null | undefined): SessionW
 }
 
 /**
- * Authoritative directory for a session: the child store that holds it, and
- * only then the session record's own fields. `null` means "not indexed yet",
- * never "no directory" — callers must fall back rather than treat it as empty.
- */
-/**
  * The directory that owns a session, from the two server-backed signals.
+ *
+ * `null` means "not indexed yet", never "no directory" — callers must fall back
+ * rather than treat it as empty.
  *
  * The session's own record wins. Holding a session in a child store proves
  * containment, not ownership: a project's session list legitimately includes

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -411,11 +411,24 @@ const getAttachmentForSession = (sessionId: string | null | undefined): SessionW
  * only then the session record's own fields. `null` means "not indexed yet",
  * never "no directory" — callers must fall back rather than treat it as empty.
  */
+/**
+ * The directory that owns a session, from the two server-backed signals.
+ *
+ * The session's own record wins. Holding a session in a child store proves
+ * containment, not ownership: a project's session list legitimately includes
+ * the sessions of its worktrees so the sidebar can group them, so the parent
+ * repository holds worktree sessions too. Reading ownership from store
+ * membership therefore reports the parent for a session that lives in a
+ * worktree, and every fetch is then addressed to a directory that does not own
+ * it. Store membership remains the fallback for a session whose record carries
+ * no directory.
+ */
 const getAuthoritativeSessionDirectory = (sessionId: string): string | null => {
-  const owningDirectory = getSyncSessionDirectory(sessionId)
-  if (owningDirectory) return normalizePath(owningDirectory)
   const target = getAllSyncSessions().find((s) => s.id === sessionId)
-  return target ? resolveDirectoryKey(target) : null
+  const recordDirectory = target ? resolveDirectoryKey(target) : null
+  if (recordDirectory) return normalizePath(recordDirectory)
+  const owningDirectory = getSyncSessionDirectory(sessionId)
+  return owningDirectory ? normalizePath(owningDirectory) : null
 }
 
 /**

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -352,6 +352,12 @@ export type SessionUIState = {
   debugSessionMessages: (sessionId: string) => Promise<void>
   pollForTokenUpdates: () => void
   setSessionDirectory: (sessionId: string, directory: string | null) => void
+  /**
+   * Replace a guessed selection directory with the authoritative one once sync
+   * has indexed the session. Safe to call at any time: it only ever promotes a
+   * guess, never overrides a confirmed selection.
+   */
+  adoptAuthoritativeSessionDirectory: (sessionId?: string) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -1737,6 +1743,26 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
 
   pollForTokenUpdates: () => {
     // Handled by sync system's SSE stream
+  },
+
+  adoptAuthoritativeSessionDirectory: (sessionId) => {
+    const target = sessionId ?? get().currentSessionId
+    // Only a guess is promoted. A confirmed selection outranks anything sync
+    // learns later, and a selection that has since moved on must not be
+    // rewritten by a directory that finished bootstrapping in the background.
+    if (!target || target !== guessedSelectionSessionId) return
+    if (target !== get().currentSessionId) return
+
+    const authoritative = getAuthoritativeSessionDirectory(target)
+    if (!authoritative) return
+
+    // The selection stops being a guess even when the directory is unchanged:
+    // the value has now been confirmed by the store that owns the session.
+    guessedSelectionSessionId = null
+    if (authoritative !== get().currentSessionDirectory) {
+      set({ currentSessionDirectory: authoritative })
+    }
+    writeRuntimeSessionMemory(runtimeMemoryKey(), { sessionId: target, directory: authoritative })
   },
 
   setSessionDirectory: (sessionId, directory) => {

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -34,6 +34,7 @@ import { countSyncPerformance } from "./performance-diagnostics"
 import { runBackgroundNetworkTask } from "@/lib/background-network"
 import { setActionRefs } from "./session-actions"
 import { setSyncRefs, getAllSyncSessions } from "./sync-refs"
+import { useSessionUIStore } from "./session-ui-store"
 import { stripSessionDiffSnapshots } from "./sanitize"
 import { applySessionEventToGlobalSessions } from "./session-event-router"
 import { syncDebug } from "./debug"
@@ -1949,6 +1950,16 @@ export function SyncProvider(props: {
 
         const result = await runBootstrap(0)
         if (result === "failed") throw new Error(`Directory bootstrap failed for ${directory}`)
+
+        // Selecting a session whose directory this client had not indexed yet
+        // routes it through the active directory as a documented guess. This is
+        // the moment that guess can be settled: the owning store now holds the
+        // session, so the authoritative directory is finally readable. Without
+        // this the guess survives, every fetch is addressed to a directory that
+        // does not own the session, and the session never renders.
+        if (result === "complete") {
+          useSessionUIStore.getState().adoptAuthoritativeSessionDirectory()
+        }
       },
       onDispose: (directory) => {
         messageLoader.invalidateDirectory(directory)

--- a/packages/ui/src/sync/sync-refs.ts
+++ b/packages/ui/src/sync/sync-refs.ts
@@ -123,13 +123,15 @@ export function getAllSyncSessionMap(): ReadonlyMap<string, State["session"][num
 }
 
 /**
- * Directory of the child store that actually holds this session.
+ * Directory of a child store that holds this session.
  *
- * This is the authoritative session→directory mapping: a session is present in
- * exactly the store for the directory it belongs to, regardless of whether the
- * server populated `session.directory` on the record itself. Returns `null`
- * when no initialized child store contains the session, which means "unknown",
- * never "no directory".
+ * This reports containment, not ownership, and a session can be held by more
+ * than one store: a project's session list includes the sessions of its
+ * worktrees so the sidebar can group them, so the parent repository holds
+ * worktree sessions too. Ownership comes from the session record's own
+ * directory; this is the fallback for a record that carries none. Returns
+ * `null` when no initialized child store contains the session, which means
+ * "unknown", never "no directory".
  */
 export function getSyncSessionDirectory(sessionId: string): string | null {
   if (!sessionId) return null

--- a/packages/web/bin/lib/cli-control.js
+++ b/packages/web/bin/lib/cli-control.js
@@ -10,14 +10,27 @@ const asNonEmptyString = (value) => {
 const DEFAULT_WAIT_TIMEOUT_SECONDS = 600;
 const WAIT_HTTP_TIMEOUT_BUFFER_MS = 30_000;
 
+// Provisioning a worktree is not one of the instant control calls the short
+// default is sized for: it runs git against the repository and prepares a new
+// directory, which on a cold path takes longer than the default allows. The
+// server finishes the work regardless of the client giving up, so a client-side
+// timeout here reported a failure for a worktree that was in fact created.
+const WORKTREE_PROVISION_TIMEOUT_MS = 120_000;
+
 // The control service blocks server-side while wait is set, so the client
 // HTTP timeout must outlive the requested wait window instead of the short
 // default used for instant control calls.
 export const resolveControlTimeoutMs = (input, options) => {
   if (Number.isFinite(options?.timeoutMs) && options.timeoutMs > 0) return options.timeoutMs;
-  if (input?.wait !== true) return undefined;
+  const provisionsWorktree = asNonEmptyString(input?.worktree) !== null;
+  if (input?.wait !== true) {
+    return provisionsWorktree ? WORKTREE_PROVISION_TIMEOUT_MS : undefined;
+  }
   const waitSeconds = Number(input?.timeout) > 0 ? Number(input.timeout) : DEFAULT_WAIT_TIMEOUT_SECONDS;
-  return (waitSeconds * 1000) + WAIT_HTTP_TIMEOUT_BUFFER_MS;
+  const waitTimeoutMs = (waitSeconds * 1000) + WAIT_HTTP_TIMEOUT_BUFFER_MS;
+  // Waiting for the session and provisioning its worktree are additive, so the
+  // window must cover whichever is longer rather than only the wait.
+  return provisionsWorktree ? Math.max(waitTimeoutMs, WORKTREE_PROVISION_TIMEOUT_MS) : waitTimeoutMs;
 };
 
 export const requestControlAction = async (port, action, input, options = {}) => {

--- a/packages/web/bin/lib/cli-control.js
+++ b/packages/web/bin/lib/cli-control.js
@@ -28,9 +28,10 @@ export const resolveControlTimeoutMs = (input, options) => {
   }
   const waitSeconds = Number(input?.timeout) > 0 ? Number(input.timeout) : DEFAULT_WAIT_TIMEOUT_SECONDS;
   const waitTimeoutMs = (waitSeconds * 1000) + WAIT_HTTP_TIMEOUT_BUFFER_MS;
-  // Waiting for the session and provisioning its worktree are additive, so the
-  // window must cover whichever is longer rather than only the wait.
-  return provisionsWorktree ? Math.max(waitTimeoutMs, WORKTREE_PROVISION_TIMEOUT_MS) : waitTimeoutMs;
+  // The server provisions the worktree inside session creation, before it
+  // starts waiting for the session to go idle, so the two windows run in
+  // sequence rather than overlapping. The client window has to cover both.
+  return provisionsWorktree ? waitTimeoutMs + WORKTREE_PROVISION_TIMEOUT_MS : waitTimeoutMs;
 };
 
 export const requestControlAction = async (port, action, input, options = {}) => {

--- a/packages/web/bin/lib/cli-control.test.js
+++ b/packages/web/bin/lib/cli-control.test.js
@@ -28,11 +28,10 @@ describe('resolveControlTimeoutMs', () => {
     expect(resolveControlTimeoutMs({ worktree: '   ' }, {})).toBeUndefined();
   });
 
-  it('covers worktree provisioning even when the wait window is shorter', () => {
-    expect(resolveControlTimeoutMs({ wait: true, timeout: 30, worktree: 'feature' }, {})).toBe(120_000);
-  });
-
-  it('keeps a longer wait window when it outlasts worktree provisioning', () => {
-    expect(resolveControlTimeoutMs({ wait: true, worktree: 'feature' }, {})).toBe(630_000);
+  it('covers provisioning and waiting in sequence when both are requested', () => {
+    // The server creates the worktree before it begins waiting for the session,
+    // so the client window must span both rather than the longer of the two.
+    expect(resolveControlTimeoutMs({ wait: true, timeout: 30, worktree: 'feature' }, {})).toBe(180_000);
+    expect(resolveControlTimeoutMs({ wait: true, worktree: 'feature' }, {})).toBe(750_000);
   });
 });

--- a/packages/web/bin/lib/cli-control.test.js
+++ b/packages/web/bin/lib/cli-control.test.js
@@ -19,4 +19,20 @@ describe('resolveControlTimeoutMs', () => {
   it('never shrinks an explicitly requested HTTP timeout', () => {
     expect(resolveControlTimeoutMs({ wait: true, timeout: 30 }, { timeoutMs: 5000 })).toBe(5000);
   });
+
+  it('allows a worktree to be provisioned without waiting for the session', () => {
+    expect(resolveControlTimeoutMs({ worktree: 'feature' }, {})).toBe(120_000);
+  });
+
+  it('ignores a blank worktree name', () => {
+    expect(resolveControlTimeoutMs({ worktree: '   ' }, {})).toBeUndefined();
+  });
+
+  it('covers worktree provisioning even when the wait window is shorter', () => {
+    expect(resolveControlTimeoutMs({ wait: true, timeout: 30, worktree: 'feature' }, {})).toBe(120_000);
+  });
+
+  it('keeps a longer wait window when it outlasts worktree provisioning', () => {
+    expect(resolveControlTimeoutMs({ wait: true, worktree: 'feature' }, {})).toBe(630_000);
+  });
 });


### PR DESCRIPTION
## Intent

Fixes the reported bug where prompting in a git worktree sometimes does nothing: a brief bubble appears, disappears, and the session stays empty, while `openchamber restart` makes the same worktree work.

The report is accurate and the cause is not what it looks like. The prompt is delivered and the assistant replies — both messages are in the session and visible on any fresh load. What fails is the live client, which addresses every request for that session to a directory that does not own it.

**Ownership was read from containment.** `getAuthoritativeSessionDirectory` decided which directory owns a session by asking which child store holds it. A project's session list includes the sessions of its worktrees so the sidebar can group them, so the parent repository holds worktree sessions too, and whichever store bootstrapped first won. Captured mid-failure, the two signals disagreed outright:

```
owningDirectory  /Users/…/projects/openchamber          <- parent, merely holds it
recordDirectory  /Users/…/worktree/…/au-1               <- the session's own directory
```

Every fetch then went to the parent, the session id resolved to `undefined` there, and requests failed as `GET /api/session/undefined?directory=<parent>` with a 500 in a retry loop. The session's own record is now believed; store membership remains the fallback for a record that carries no directory.

**A guessed directory was never settled.** Selecting a session whose directory the client has not indexed yet routes it through the active directory as a deliberate, documented guess, excluded from both the resolver and persistence. Nothing settled that guess afterwards: `setSessionDirectory` performs exactly that promotion, but only confirmed destinations call it — a completed move, or a worktree this client created. A session in a worktree created outside this client kept the guess forever. The promotion now runs when directory bootstrap completes, which is the moment the authoritative directory first becomes readable.

Both are required. Settling the guess against the containment-derived value adopted the parent directory and then cleared the guess, which prevented any later correction — that is why the first change alone did not fix the symptom.

**Worktree provisioning outlived its client timeout.** Creating a session with a worktree reported `Request to /api/openchamber/control timed out after 4000ms` while the worktree was in fact created, leaving a failure message, a real worktree and no session id. The client extended its timeout only when the caller asked to wait for the session, but provisioning runs git and prepares a directory on its own. On a cold path immediately after a restart it measures ~4.0 s, landing exactly on the 4 s default, which is why it failed intermittently rather than always.

## Non-goals

- **Not a change to delivery.** Sends already worked; only the live client's routing did not. Nothing in the send path is touched.
- **Not the worktree registration change.** `c290ce6a7` (stop writing worktree registration into OpenCode's storage) is on `main` already and targeted the same report from a different angle. It is correct on its own terms — writing into another live process's database is wrong regardless — but it does not affect this failure: the symptom reproduced identically with and without it.
- No change to the resolver precedence in `session-directory-resolution.ts`. Only the value fed into its `authoritative` slot is corrected.
- The `lib/debug.ts` session-directory report builds its `selected` value without the private guess filter, so it can show a conflict the real resolver would discard. Left alone here; noted so the next reader is not misled by it.

## Affected surfaces

| Surface | Effect |
|---|---|
| `packages/ui` session directory ownership | `getAuthoritativeSessionDirectory` prefers the session record. This feeds routing for every send, message fetch, queue key and confirmation lookup, in every runtime: web, desktop, VS Code, hosted mobile, Capacitor mobile. |
| `packages/ui` session selection | New `adoptAuthoritativeSessionDirectory`, called once per completed directory bootstrap. Only ever promotes a guess. |
| `packages/web` CLI | Worktree-provisioning control calls get a timeout sized for the work. Server behaviour is unchanged; the client simply stops abandoning an operation it will complete. |

No persisted-format, API or protocol changes. The runtime session memory now records the corrected directory instead of a guessed one, which is the existing contract for a confirmed value.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` / `CLAUDE.md` | Source change across two packages | No dependencies added; `../opencode` untouched; no secrets logged; domain logic kept in the owning sync modules rather than in components. |
| `sync-state-invariants` skill | Session/directory ownership, bootstrap, reconciliation | Authoritative state preferred over heuristics — that is precisely the defect: containment was used as a proxy for ownership. Partial state is explicit: a record without a directory still falls back to membership rather than resolving to nothing. The guess remains excluded from the resolver and from persistence until it is confirmed. |
| `ui-api-decoupling` skill | Routing decides which directory every SDK call is addressed to | Directory identity semantics unchanged; only the source of truth for ownership is corrected. |
| `clack-cli-patterns` skill | CLI timeout and failure reporting | The CLI no longer reports a failure for an operation that succeeded; `--json` output shape is unchanged. |
| `performance-engineering` skill | An intermittent bug cannot be judged from single runs | Verified by repeated runs on before/after builds rather than by reasoning, and the instrumentation used to find the race was removed before measuring. |
| `packages/ui/src/sync/DOCUMENTATION.md` | Nearest owning documentation | Read before editing. The documented precedence is preserved; this corrects the value supplied to it. |

## Validation

| Check | Result |
|---|---|
| Reproduction, before the fix | 1 of 4 runs rendered the reply live |
| Reproduction, after, clean build, instrumentation removed | **3 of 3 rendered live**, each routed to its own worktree |
| Cold-path worktree creation immediately after restart | Previously timed out; now ok in 4004 ms and 1376 ms |
| `packages/ui/src/sync/session-directory-adoption.test.ts` (new) | 5 pass — ownership disagreeing with containment; guess promoted once the owner is known; no-op while the owner is unknown; a confirmed selection is never rewritten; a superseded selection is untouched |
| `packages/web/bin/lib/cli-control.test.js` | 8 pass — 4 new, covering worktree provisioning without waiting, a blank worktree name, and both directions of the wait-versus-provision window |
| `bun test` per file across `packages/ui/src/sync` | No failures |
| `npx vitest run bin/` (`packages/web`) | 88 pass |
| `bun run type-check` (workspace) | Pass — ui, web, electron, mobile, root |
| `bun run lint` (workspace) | Pass — all packages |
| `bun run dead-code` | Run and inspected; findings in the touched files are pre-existing, no new unused exports |

**Not verified:** the fix was exercised in the web runtime only. The corrected ownership rule is runtime-agnostic and unit-tested, but VS Code, Electron and mobile were not run. The full `packages/web` suite was not run either — `bun test` there hangs on tests that start servers; the touched area was covered with vitest instead.

**Reproduction** (unattended, no human in the loop): open the app, wait for it to settle, create a worktree with a session while the page stays open, navigate to that session, type a prompt, and watch for 90 s. Before the fix the message list stays empty while the same session shows both messages on reload.

## Visual evidence

The user-visible change is that a session which previously rendered nothing now renders normally; there is no new or altered UI. The failing state produced an empty message list and a retry loop of failed requests, and the fixed state produces the ordinary chat view, which is why the evidence here is the reproduction result and the request log rather than a screenshot of new chrome.

## Risks and failure behavior

- **Ownership source.** The riskiest part is preferring the record over store membership. A session move updates the owning store, so a stale cached record could in principle lag behind; moves do not rely on this path, since a confirmed move calls `setSessionDirectory` explicitly and that continues to win. A record without a directory still falls back to membership, so no session loses routing.
- **Guess promotion.** It cannot overwrite a confirmed selection or a selection that has since moved on; both are covered by tests. Worst case it does nothing and the previous behaviour stands.
- **CLI timeout.** A longer ceiling means a genuinely hung server is now waited on for up to two minutes instead of four seconds for this one action. That is the correct trade for an operation the server completes regardless, and it does not affect any other control call.
- **Rollback.** Each commit is independently revertible. Reverting only the ownership commit would restore the original symptom; reverting only the promotion commit leaves ownership correct and the guess unsettled.
