### PR TITLE
fix(ui): cap accumulated part text/output size to prevent renderer freeze

### DIFF
--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -18,6 +18,19 @@ import { shouldSkipStaleSessionEvent } from "./session-event-freshness"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 const DELTA_OVERLAP_FIELDS = ["text", "output"] as const
+
+/**
+ * 单个 part 可累积的 text/output 上限（约 2MB）。
+ * 防止单条命令输出量极大（如遍历大型 node_modules）时无限追加，
+ * 导致 reducer 内存暴涨 + React 渲染卡死（OpenChamber 窗口冻结 / 后台高 CPU 内存）。
+ */
+const MAX_PART_TEXT_SIZE = 2 * 1024 * 1024
+
+function capPartText(value: string): string {
+  return value.length > MAX_PART_TEXT_SIZE
+    ? value.slice(0, MAX_PART_TEXT_SIZE)
+    : value
+}
 const FINAL_TOOL_STATUSES = new Set(["completed", "error", "aborted", "failed", "timeout", "cancelled"])
 
 type DedupeMetadata = {
@@ -492,7 +505,11 @@ export function applyDirectoryEvent(
       const next = [...parts]
       next[result.index] = {
         ...existing,
-        [props.field]: shouldDedupe ? appendNonOverlappingDelta(existingValue, props.delta) : (existingValue ?? "") + props.delta,
+        [props.field]: capPartText(
+          shouldDedupe
+            ? appendNonOverlappingDelta(existingValue, props.delta)
+            : (existingValue ?? "") + props.delta
+        ),
         __dedupeNextDeltaFields: dedupeFields.filter((field) => field !== props.field),
       } as unknown as Part
       draft.part[props.messageID] = next


### PR DESCRIPTION
## 问题

单条命令输出量极大时（例如对巨型 node_modules 做依赖追踪），其输出以 message.part.delta 事件流式到达 UI，event-reducer 对每个 part 的 	ext/output 字段**无限追加**（existingValue + props.delta）。

后果：part 字符串膨胀到 MB 级 → reducer 内存暴涨 + React 全量重渲染 → **Electron 窗口冻结、后台高 CPU/内存**。

## 修复

在 packages/ui/src/sync/event-reducer.ts 的 message.part.delta 分支对累积字段做 **~2MB 上限**（capPartText）：超过上限后截断，后续增量不再增长，渲染器保持响应。

- 单 part 文本上限：2 * 1024 * 1024 字符
- 不影响正常长文本（代码/长回复），仅拦截失控输出

## 验证说明

本机无 bun，未运行单测；改动为单一纯函数封装，逻辑自包含。可运行的测试：packages/ui 下 event-reducer 相关单测。请维护者补充 CI 校验。