### PR TITLE
fix(ui): correct keyboard shortcuts help

### DIFF
--- a/packages/ui/src/components/ui/HelpDialog.test.tsx
+++ b/packages/ui/src/components/ui/HelpDialog.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { describe, expect, mock, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { dict as enDict } from '@/lib/i18n/messages/en';
+
+type MockDialogProps = React.PropsWithChildren<{ open?: boolean }>;
+
+let shortcutOverrides: Record<string, string> = {};
+
+mock.module('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open = true }: MockDialogProps) => (open ? <>{children}</> : null),
+  DialogContent: ({ children }: MockDialogProps) => <div>{children}</div>,
+  DialogDescription: ({ children }: MockDialogProps) => <p>{children}</p>,
+  DialogHeader: ({ children }: MockDialogProps) => <div>{children}</div>,
+  DialogTitle: ({ children }: MockDialogProps) => <h2>{children}</h2>,
+}));
+
+mock.module('@/components/icon/Icon', () => ({
+  Icon: ({ name }: { name: string }) => <i data-icon={name} />,
+}));
+
+mock.module('@/components/icons/DiffIcon', () => ({
+  DiffIcon: () => <i data-icon="diff" />,
+}));
+
+mock.module('@/stores/useUIStore', () => ({
+  useUIStore: (selector: (state: Record<string, unknown>) => unknown) => selector({
+    isHelpDialogOpen: true,
+    setHelpDialogOpen: () => {},
+    shortcutOverrides,
+  }),
+}));
+
+mock.module('@/lib/i18n', () => ({
+  useI18n: () => ({
+    t: (key: keyof typeof enDict) => enDict[key] ?? key,
+  }),
+}));
+
+mock.module('@/lib/desktop', () => ({
+  isDesktopShell: () => true,
+  isVSCodeRuntime: () => false,
+}));
+
+mock.module('@/lib/utils', () => ({
+  isMacOS: () => true,
+}));
+
+const { HelpDialog } = await import('./HelpDialog');
+const { getShortcutAction } = await import('@/lib/shortcuts');
+
+const renderHelpDialog = (overrides: Record<string, string> = {}) => {
+  shortcutOverrides = overrides;
+  return renderToStaticMarkup(<HelpDialog />);
+};
+
+describe('HelpDialog', () => {
+  test('Open Changes references a registered shortcut action', () => {
+    expect(getShortcutAction('open_diff_panel')).toBeDefined();
+  });
+
+  test('shows Open Changes with its semantic icon', () => {
+    const markup = renderHelpDialog();
+
+    expect(markup).toContain('Open Changes Surface');
+    expect(markup).toContain('data-icon="diff"');
+  });
+
+  test('omits project switching and the rejected extra rows', () => {
+    const markup = renderHelpDialog();
+
+    expect(markup).not.toContain('Switch Project');
+    expect(markup).not.toContain('Open conversation timeline');
+    expect(markup).not.toContain('New Mini Chat window');
+  });
+
+  test('reflects the Open Changes shortcut override', () => {
+    const markup = renderHelpDialog({
+      open_diff_panel: 'mod+8',
+    });
+
+    expect(markup).toContain('⌘ + 8');
+  });
+});

--- a/packages/ui/src/components/ui/HelpDialog.tsx
+++ b/packages/ui/src/components/ui/HelpDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Icon } from "@/components/icon/Icon";
+import { DiffIcon } from '@/components/icons/DiffIcon';
 import { useUIStore } from "@/stores/useUIStore";
 import {
   getEffectiveShortcutCombo,
@@ -22,7 +23,7 @@ type ShortcutItem = {
   id?: string;
   keys: string | string[];
   descriptionKey: I18nKey;
-  icon: IconName | null;
+  icon: IconName | 'diff' | null;
 };
 
 type ShortcutSection = {
@@ -152,6 +153,12 @@ export const HelpDialog: React.FC = () => {
           keys: '',
         },
         {
+          id: 'open_diff_panel',
+          descriptionKey: 'helpDialog.item.openChangesSurface',
+          icon: 'diff',
+          keys: '',
+        },
+        {
           id: 'toggle_terminal',
           descriptionKey: 'helpDialog.item.toggleTerminalDock',
           icon: "window",
@@ -179,11 +186,6 @@ export const HelpDialog: React.FC = () => {
           descriptionKey: "helpDialog.item.cycleTheme",
           icon: "palette",
           keys: '',
-        },
-        {
-          keys: [`${mod} + 1...9`],
-          descriptionKey: "helpDialog.item.switchProject",
-          icon: "layout-left",
         },
         {
           id: 'toggle_services_menu',
@@ -241,9 +243,11 @@ export const HelpDialog: React.FC = () => {
                         className="flex items-center justify-between py-1 px-2"
                       >
                         <div className="flex items-center gap-2">
-                          {shortcut.icon && (
+                          {shortcut.icon === 'diff' ? (
+                            <DiffIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                          ) : shortcut.icon ? (
                             <Icon name={shortcut.icon} className="h-3.5 w-3.5 text-muted-foreground" />
-                          )}
+                          ) : null}
                           <span className="typography-meta">
                             {t(shortcut.descriptionKey)}
                           </span>

--- a/packages/ui/src/lib/i18n/messages/de.ts
+++ b/packages/ui/src/lib/i18n/messages/de.ts
@@ -1546,6 +1546,7 @@ export const dict = {
   'helpDialog.item.toggleRightSidebar': 'Rechte Seitenleiste umschalten',
   'helpDialog.item.openRightSidebarGitTab': 'Git-Registerkarte der rechten Seitenleiste öffnen',
   'helpDialog.item.openRightSidebarFilesTab': 'Datei-Registerkarte der rechten Seitenleiste öffnen',
+  'helpDialog.item.openChangesSurface': 'Änderungsansicht öffnen',
   'helpDialog.item.toggleTerminalDock': 'Terminal-Dock umschalten',
   'helpDialog.item.toggleTerminalExpanded': 'Terminal erweitert umschalten',
   'helpDialog.item.togglePlanContextPanel': 'Plan-Kontext-Panel umschalten',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -1693,6 +1693,7 @@ export const dict = {
   'helpDialog.item.toggleRightSidebar': 'Toggle context panel',
   'helpDialog.item.openRightSidebarGitTab': 'Open Git surface',
   'helpDialog.item.openRightSidebarFilesTab': 'Open Files surface',
+  'helpDialog.item.openChangesSurface': 'Open Changes Surface',
   'helpDialog.item.toggleTerminalDock': 'Toggle Terminal Dock',
   'helpDialog.item.toggleTerminalExpanded': 'Toggle Terminal Expanded',
   'helpDialog.item.togglePlanContextPanel': 'Toggle Plan Context Panel',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -1671,6 +1671,7 @@ export const dict: Record<I18nKey, string> = {
   "helpDialog.item.toggleRightSidebar": 'Alternar panel de contexto',
   "helpDialog.item.openRightSidebarGitTab": 'Abrir superficie de Git',
   "helpDialog.item.openRightSidebarFilesTab": 'Abrir superficie de archivos',
+  "helpDialog.item.openChangesSurface": "Abrir superficie de cambios",
   "helpDialog.item.toggleTerminalDock": "Mostrar u ocultar dock de terminal",
   "helpDialog.item.toggleTerminalExpanded": "Expandir o contraer terminal",
   "helpDialog.item.togglePlanContextPanel": "Alternar panel de contexto del plan",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1506,6 +1506,7 @@ export const dict = {
   'helpDialog.item.toggleRightSidebar': 'Afficher/masquer le panneau de contexte',
   'helpDialog.item.openRightSidebarGitTab': 'Ouvrir la surface Git',
   'helpDialog.item.openRightSidebarFilesTab': 'Ouvrir la surface Fichiers',
+  'helpDialog.item.openChangesSurface': 'Ouvrir la vue Modifications',
   'helpDialog.item.toggleTerminalDock': 'Basculer la station d\'accueil du terminal',
   'helpDialog.item.toggleTerminalExpanded': 'Terminal à bascule étendu',
   'helpDialog.item.togglePlanContextPanel': 'Toggle Panneau contextuel du plan',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -1689,6 +1689,7 @@ export const dict: Record<I18nKey, string> = {
   'helpDialog.item.toggleRightSidebar': 'コンテキストパネルの表示切替',
   'helpDialog.item.openRightSidebarGitTab': 'Git サーフェスを開く',
   'helpDialog.item.openRightSidebarFilesTab': 'ファイルサーフェスを開く',
+  'helpDialog.item.openChangesSurface': '変更画面を開く',
   'helpDialog.item.toggleTerminalDock': 'ターミナルドックの切り替え',
   'helpDialog.item.toggleTerminalExpanded': 'ターミナル展開の切り替え',
   'helpDialog.item.togglePlanContextPanel': '計画コンテキストパネルの切り替え',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -1695,6 +1695,7 @@ export const dict: Record<I18nKey, string> = {
   'helpDialog.item.toggleRightSidebar': '컨텍스트 패널 표시 전환',
   'helpDialog.item.openRightSidebarGitTab': 'Git 서피스 열기',
   'helpDialog.item.openRightSidebarFilesTab': '파일 서피스 열기',
+  'helpDialog.item.openChangesSurface': '변경사항 화면 열기',
   'helpDialog.item.toggleTerminalDock': '터미널 독 전환',
   'helpDialog.item.toggleTerminalExpanded': '터미널 펼치기/접기',
   'helpDialog.item.togglePlanContextPanel': '플랜 컨텍스트 패널 전환',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -2317,6 +2317,7 @@ export const dict: Record<I18nKey, string> = {
   'helpDialog.item.openCommandPalette': 'Otwórz paletę poleceń',
   'helpDialog.item.openModelSelector': 'Otwórz selektor modeli',
   'helpDialog.item.openRightSidebarFilesTab': 'Otwórz powierzchnię plików',
+  'helpDialog.item.openChangesSurface': 'Otwórz widok zmian',
   'helpDialog.item.openRightSidebarGitTab': 'Otwórz powierzchnię Git',
   'helpDialog.item.openSettings': 'Otwórz ustawienia',
   'helpDialog.item.showKeyboardShortcuts': 'Pokaż skróty klawiaturowe (to okno)',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -1671,6 +1671,7 @@ export const dict: Record<I18nKey, string> = {
   "helpDialog.item.toggleRightSidebar": 'Alternar painel de contexto',
   "helpDialog.item.openRightSidebarGitTab": 'Abrir superfície do Git',
   "helpDialog.item.openRightSidebarFilesTab": 'Abrir superfície de arquivos',
+  "helpDialog.item.openChangesSurface": "Abrir área de alterações",
   "helpDialog.item.toggleTerminalDock": "Mostrar ou ocultar dock de terminal",
   "helpDialog.item.toggleTerminalExpanded": "Expandir ou recolher o terminal",
   "helpDialog.item.togglePlanContextPanel": "Alternar painel de contexto do plano",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -1671,6 +1671,7 @@ export const dict: Record<I18nKey, string> = {
   "helpDialog.item.toggleRightSidebar": 'Перемкнути контекстну панель',
   "helpDialog.item.openRightSidebarGitTab": 'Відкрити поверхню Git',
   "helpDialog.item.openRightSidebarFilesTab": 'Відкрити поверхню файлів',
+  "helpDialog.item.openChangesSurface": "Відкрити подання змін",
   "helpDialog.item.toggleTerminalDock": "Перемкнути панель терміналу",
   "helpDialog.item.toggleTerminalExpanded": "Розгорнути або згорнути термінал",
   "helpDialog.item.togglePlanContextPanel": "Перемкнути панель контексту плану",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -1659,6 +1659,7 @@ export const dict: Record<I18nKey, string> = {
   'helpDialog.item.toggleRightSidebar': '切换上下文面板',
   'helpDialog.item.openRightSidebarGitTab': '打开 Git 界面',
   'helpDialog.item.openRightSidebarFilesTab': '打开文件界面',
+  'helpDialog.item.openChangesSurface': '打开更改界面',
   'helpDialog.item.toggleTerminalDock': '切换终端停靠栏',
   'helpDialog.item.toggleTerminalExpanded': '切换终端展开状态',
   'helpDialog.item.togglePlanContextPanel': '切换计划上下文面板',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -1663,6 +1663,7 @@ export const dict: Record<I18nKey, string> = {
   'helpDialog.item.toggleRightSidebar': '切換上下文面板',
   'helpDialog.item.openRightSidebarGitTab': '開啟 Git 介面',
   'helpDialog.item.openRightSidebarFilesTab': '開啟檔案介面',
+  'helpDialog.item.openChangesSurface': '開啟變更介面',
   'helpDialog.item.toggleTerminalDock': '切換終端機停靠欄',
   'helpDialog.item.toggleTerminalExpanded': '切換終端機展開狀態',
   'helpDialog.item.togglePlanContextPanel': '切換計畫上下文面板',


### PR DESCRIPTION
## PR infographic

<img width="1600" height="900" alt="OpenChamber keyboard shortcuts PR infographic" src="https://github.com/user-attachments/assets/98807926-623d-4108-a346-7f6df89a3cbf" />

## Intent

Keep Keyboard Shortcuts Help accurate and curated. The popup no longer advertises `⌘1…9` project switching, which has no desktop implementation, and now includes the verified **Open Changes Surface** command backed by `open_diff_panel` (`⌘2`). Customized bindings continue to render through the existing shortcut registry.

## Non-goals

- No shortcut behavior or binding changes.
- No shortcut-registry cleanup.
- No Help dialog layout redesign or additional command rows.
- No changes to Electron menus, desktop handlers, or navigation surfaces.

## Affected surfaces

- `packages/ui`: Keyboard Shortcuts Help content, one semantic diff icon, focused rendering tests, and locale dictionaries.
- Web, Electron, and VS Code consume the shared Help dialog. This changes only displayed Help content; runtime command handling is unchanged.
- No persisted data, API, bridge, route, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `CONTRIBUTING.md` | Shared UI source and a user-visible PR handoff are affected. | The diff is limited to Help content, translations, and focused tests; no dependency or runtime contract changes. |
| `openchamber-change-discipline` | Executable UI source and a test file changed. | Reuses the existing registry and rendering path, preserves overrides, and runs focused/package validation. |
| `theme-system` + icon reference | The new row needs a semantic icon. | Reuses the existing `DiffIcon`; no new icon asset, palette color, or generated sprite. |
| `locale-ui-patterns` | A new user-facing label is introduced. | Adds a real translation to every shipped locale and verifies dictionary parity. |
| Package/module docs | `packages/ui/README.md` and a nearby `components/ui/DOCUMENTATION.md` do not exist. | Followed local component and test precedent instead; no ownership or documented invariant changed. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/ui/HelpDialog.test.tsx` | Passed: 4 tests, 7 assertions. |
| `bun test packages/ui/src/lib/i18n/messages.test.ts` | Passed: 2 tests; all locale dictionaries remain in parity. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bun run dead-code` | Completed using the repository's non-blocking configuration; it reported existing workspace findings unrelated to this diff. |
| Headless Chromium on macOS against `bun run dev:web:hmr`, with macOS Electron runtime globals emulated | Passed: Help opened via `⌘.` and rendered Open Changes with `⌘2`; the after screenshot below was captured. This was not a packaged Electron run. |

Not verified: each shortcut was not manually exercised in a packaged macOS Electron build. This PR does not alter shortcut handlers or bindings.

## Visual evidence

### Before

Unsupported **Switch Project** row:

<img width="648" height="507" alt="Keyboard Shortcuts Help before: unsupported Switch Project row" src="https://github.com/user-attachments/assets/31ef5502-5509-4977-baf4-a8094874f26c" />

### After

Verified **Open Changes Surface** row:

<img width="621" height="497" alt="Keyboard Shortcuts Help after: verified Open Changes Surface row" src="https://github.com/user-attachments/assets/10941858-b575-4e21-9a36-1aa16f6640db" />

Compared with `main`, the list replaces the unsupported **Switch Project** row with **Open Changes Surface** and retains the original single-column layout.

## Risks and failure behavior

Low risk. The added row references the existing `open_diff_panel` registry action and uses the existing shortcut override path. If the active desktop context cannot open Changes, behavior remains the handler's existing contextual no-op; Help rendering does not mutate application state. Removing the stale row affects only documentation in the popup. No rollback, cleanup, migration, security, performance, or data-loss behavior is involved.
