### PR TITLE
fix(ui): keep empty composer caret visible

### DIFF
--- a/packages/ui/src/components/chat/composer/editor/theme.ts
+++ b/packages/ui/src/components/chat/composer/editor/theme.ts
@@ -19,6 +19,8 @@ export const COMPOSER_EDITOR_THEME_SPEC = {
     '&.cm-focused': { outline: 'none' },
     '.cm-content': {
         padding: '0',
+        // Keep the drawn empty-document cursor inside the scroller's horizontal clip.
+        paddingInlineStart: '1px',
         fontFamily: 'inherit',
         fontSize: 'inherit',
         lineHeight: 'inherit',


### PR DESCRIPTION
## Intent

Keep the CodeMirror composer caret visible when the prompt is empty. The drawn cursor sits at the scroller's zero-width horizontal boundary; a 1px inline content inset keeps its border inside the scroller clip while moving the placeholder and typed text through the same coordinate system.

## Non-goals

- Change CodeMirror cursor color, blink timing, or native-selection behavior.
- Change composer sizing, scrolling, or input semantics.

## Affected surfaces

- `packages/ui`: shared chat composer CodeMirror theme.
- User-visible empty prompt state, observed in the VS Code webview.
- The 1px content inset applies to every runtime using the shared composer so cursor, placeholder, and text alignment remain consistent.
- No persisted data, external API, runtime bridge, or package contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes shared UI source and platform-visible editor behavior. | Keeps the change to one owning theme rule, preserves existing CodeMirror selection behavior, and records the manual runtime validation. |
| `theme-system` | The change modifies component styling. | Uses a logical layout property and introduces no color, token, icon, or dependency changes. |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | The composer editor owns its drawn caret and documents that DOM rendering requires manual verification. | Changes `editor/theme.ts` and leaves `drawSelection()`, native selection, and mobile caret behavior untouched. |

## Validation

| Check | Result |
|---|---|
| VS Code webview DevTools, empty composer | Confirmed the CodeMirror cursor layer existed and blinked after moving the cursor inside the horizontal clip. |
| Temporary `padding-inline-start: 1px` on `.cm-content` | Confirmed the empty caret became visible and blinking while caret, placeholder, and text remained aligned. |

## Visual evidence
cursor in empty text input is working now.
<img width="878" height="231" alt="image" src="https://github.com/user-attachments/assets/4851ad16-5400-441b-aa38-5df9c83c0dfe" />

## Risks and failure behavior

The shared composer content shifts by 1px at the inline start in every runtime. The cursor, placeholder, and text share that inset, avoiding the misalignment produced by translating only the cursor. The change does not touch editor state, input handling, persistence, or security-sensitive behavior. Rollback consists of removing the single `paddingInlineStart` declaration.
