### PR TITLE
fix(mobile): Add fallback parsing for pairing connection in old Android WebViews

### DIFF
--- a/packages/ui/src/apps/mobileQrScan.test.ts
+++ b/packages/ui/src/apps/mobileQrScan.test.ts
@@ -83,6 +83,42 @@ describe('scanConnectionQr on Android', () => {
     expect(removeCalls).toBe(2);
   });
 
+  test('falls back to string parsing when the WebView URL parser rejects the link (old Android WebView)', async () => {
+    // Old Android WebViews resolve openchamber://connect?... with hostname "" and
+    // pathname "//connect", so the URL-based parse fails on an intact string. The test
+    // runtime's URL parser handles the canonical form fine, so simulate the rejection
+    // with a case variant the URL parser refuses while the string parser accepts.
+    const url = encodePairingConnectionPayload(buildPairingConnectionPayload({
+      pairingId: 'pair_abc',
+      secret: 'one-time',
+      candidates: [{ type: 'lan', url: 'http://192.168.1.20:4096', priority: 10 }],
+    }));
+    const mixedCase = url.replace('openchamber://connect', 'OpenChamber://CONNECT');
+    const listeners = new Map<string, (event: { barcodes?: Array<{ rawValue?: string }> }) => void>();
+    const plugin = {
+      requestPermissions: mock(async () => ({ camera: 'granted' })),
+      startScan: mock(async () => {
+        listeners.get('barcodesScanned')?.({ barcodes: [{ rawValue: mixedCase }] });
+      }),
+      stopScan: mock(async () => undefined),
+      addListener: mock((event: string, callback: (info: { barcodes?: Array<{ rawValue?: string }> }) => void) => {
+        listeners.set(event, callback);
+        return { remove: () => undefined };
+      }),
+    };
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { Capacitor: { getPlatform: () => 'android', Plugins: { BarcodeScanner: plugin } } },
+    });
+
+    const result = await scanConnectionQr();
+    expect(result.status).toBe('pairing');
+    if (result.status === 'pairing') {
+      expect(result.pairing.pairingId).toBe('pair_abc');
+      expect(result.pairing.candidates).toEqual([{ type: 'lan', url: 'http://192.168.1.20:4096', priority: 10 }]);
+    }
+  });
+
   test('stops scanning when the caller aborts', async () => {
     let stopCalls = 0;
     const stopScan = async () => { stopCalls += 1; };

--- a/packages/ui/src/apps/mobileQrScan.ts
+++ b/packages/ui/src/apps/mobileQrScan.ts
@@ -4,7 +4,7 @@
 // scan() activity, this path bundles the barcode model in the app and does not need
 // Google Play Services. iOS keeps the native ready-made scanner.
 
-import { parsePairingConnectionPayload, type PairingConnectionPayload } from '@/lib/connectionPayload';
+import { parsePairingConnectionPayload, parsePairingConnectionPayloadString, type PairingConnectionPayload } from '@/lib/connectionPayload';
 
 export type MobileConnectionPayload = {
   url: string;
@@ -65,8 +65,15 @@ export const parseConnectionPayload = (raw: string): MobileConnectionPayload | M
   return null;
 };
 
-const resultFromRawValue = (raw: string): QrScanResult => {
+const resultFromRawValue = (raw: string, options?: { pairingStringFallback?: boolean }): QrScanResult => {
   const payload = parseConnectionPayload(raw);
+  if (!payload && options?.pairingStringFallback) {
+    // Old Android WebViews resolve openchamber://… with hostname "" / pathname "//connect",
+    // so the URL-based parse above fails even though the scanned string is intact. Retry
+    // with the URL-API-free string parser before declaring the scan invalid.
+    const pairing = parsePairingConnectionPayloadString(raw);
+    if (pairing) return { status: 'pairing', pairing };
+  }
   if (!payload) return { status: 'invalid' };
   if ('pairing' in payload) return { status: 'pairing', ...payload };
   return { status: 'ok', ...payload };
@@ -100,7 +107,7 @@ const scanWithBundledAndroidScanner = async (
       Promise.resolve(plugin.addListener('barcodesScanned', ({ barcodes }) => {
         const barcode = barcodes?.[0];
         const raw = (barcode?.rawValue ?? barcode?.displayValue ?? '').trim();
-        if (raw) finish(resultFromRawValue(raw));
+        if (raw) finish(resultFromRawValue(raw, { pairingStringFallback: true }));
       })).then((handle) => { barcodeListener = handle; }),
       Promise.resolve(plugin.addListener('scanError', () => finish({ status: 'failed' })))
         .then((handle) => { errorListener = handle; }),

--- a/packages/ui/src/lib/connectionPayload.test.ts
+++ b/packages/ui/src/lib/connectionPayload.test.ts
@@ -4,6 +4,7 @@ import {
   buildPairingConnectionPayload,
   encodePairingConnectionPayload,
   parsePairingConnectionPayload,
+  parsePairingConnectionPayloadString,
 } from './connectionPayload';
 
 const hostEncPubJwk = { kty: 'EC', crv: 'P-256', x: 'eHhY', y: 'eVlZ' } as const;
@@ -101,5 +102,47 @@ describe('connection payload helpers', () => {
       candidates: [{ type: 'lan', url: 'http://runtime.example' }],
     })).toString('base64url');
     expect(parsePairingConnectionPayload(`openchamber://connect?v=2&p=${expired}`)).toBeNull();
+  });
+});
+
+describe('parsePairingConnectionPayloadString (Android WebView fallback)', () => {
+  const payload = buildPairingConnectionPayload({
+    pairingId: 'pair_123',
+    secret: 'one-time-secret',
+    label: 'Desktop',
+    candidates: [
+      { type: 'lan', url: 'http://192.168.1.20:4096', priority: 20 },
+      { type: 'relay', relayUrl: 'wss://relay.example/ws', serverId: 'srv_abc', hostEncPubJwk, priority: 30 },
+    ],
+  });
+  const encoded = encodePairingConnectionPayload(payload);
+
+  test('parses the canonical link identically to the URL-based parser', () => {
+    // Old Android WebViews resolve the same string with hostname "" / pathname "//connect";
+    // the string parser must not depend on the URL API to succeed.
+    expect(parsePairingConnectionPayloadString(encoded)).toEqual(parsePairingConnectionPayload(encoded));
+  });
+
+  test('recovers a link whose scheme/host case the URL parser would reject', () => {
+    const mixedCase = encoded.replace('openchamber://connect', 'OpenChamber://CONNECT');
+    expect(parsePairingConnectionPayload(mixedCase)).toBeNull();
+    expect(parsePairingConnectionPayloadString(mixedCase)).toEqual(parsePairingConnectionPayload(encoded));
+  });
+
+  test('tolerates a trailing slash and reordered query params', () => {
+    const trailingSlash = encoded.replace('openchamber://connect?', 'openchamber://connect/?');
+    expect(parsePairingConnectionPayloadString(trailingSlash)).toEqual(parsePairingConnectionPayload(encoded));
+
+    const p = encoded.slice(encoded.indexOf('p=') + 2);
+    expect(parsePairingConnectionPayloadString(`openchamber://connect?p=${p}&v=2`)).toEqual(parsePairingConnectionPayload(encoded));
+  });
+
+  test('still rejects non-pairing and malformed payloads', () => {
+    expect(parsePairingConnectionPayloadString('')).toBeNull();
+    expect(parsePairingConnectionPayloadString('hello world')).toBeNull();
+    expect(parsePairingConnectionPayloadString('openchamber://connect')).toBeNull();
+    expect(parsePairingConnectionPayloadString('openchamber:///connect?v=2&p=x')).toBeNull();
+    expect(parsePairingConnectionPayloadString('openchamber://connect?v=1&server=http%3A%2F%2F192.168.1.10%3A2606&token=t')).toBeNull();
+    expect(parsePairingConnectionPayloadString('openchamber://connect?v=2&p=not-json')).toBeNull();
   });
 });

--- a/packages/ui/src/lib/connectionPayload.ts
+++ b/packages/ui/src/lib/connectionPayload.ts
@@ -212,3 +212,35 @@ export const parsePairingConnectionPayload = (value: string): PairingConnectionP
     return null;
   }
 };
+
+// URL-string-only sibling of parsePairingConnectionPayload. Old Android WebViews
+// (e.g. WebView 114) mis-parse non-special schemes: `new URL('openchamber://connect?...')`
+// yields hostname "" and pathname "//connect", so the URL-based parser above rejects a
+// perfectly valid pairing link. This parser never touches the URL/URLSearchParams APIs —
+// it matches the head with a regex and reads `v`/`p` straight off the query string.
+// Used by the Android QR-scan path after the standard parse fails; keeps every existing
+// validation (version, payload length, base64url, candidate normalization).
+export const parsePairingConnectionPayloadString = (value: string): PairingConnectionPayload | null => {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  const question = trimmed.indexOf('?');
+  if (question === -1 || !/^openchamber:\/\/connect\/?$/i.test(trimmed.slice(0, question))) return null;
+  let version: string | null = null;
+  let encoded: string | null = null;
+  for (const part of trimmed.slice(question + 1).split('&')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const key = part.slice(0, eq);
+    const value_ = part.slice(eq + 1);
+    if (key === 'v') version = value_;
+    else if (key === 'p') encoded = value_;
+  }
+  if (version !== '2' || !encoded || encoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  const decoded = base64UrlDecode(encoded);
+  if (!decoded || decoded.length > MAX_PAIRING_PAYLOAD_LENGTH) return null;
+  try {
+    return normalizePairingPayload(JSON.parse(decoded) as unknown);
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Intent

Fixes #2609. On Android devices whose WebView mis-parses non-special URL schemes (verified on a Huawei ELS-AN00 / Android 12 / WebView Chrome/114), `new URL('openchamber://connect?v=2&p=…')` resolves `hostname` to `""` and `pathname` to `"//connect"`, so `parsePairingConnectionPayload` rejected a perfectly valid pairing QR and the Connect screen surfaced `mobile.connect.scan.invalid`.

This PR adds a URL-API-independent sibling parser (`parsePairingConnectionPayloadString`) that matches the `openchamber://connect` head with a regex and reads `v`/`p` directly off the query string, reusing every existing validation (version check, payload length limit, base64url decoding, candidate normalization). The Android bundled-scanner callback (`startScan` path) falls back to it only when the standard parse fails, so scanning a valid pairing code now redeems the pairing instead of erroring. Results are identical to the URL-based parser for canonical input.

## Non-goals

- Legacy `openchamber://connect?v=1&server=…&token=…` links: still rejected by both the URL parser and the fallback (`version !== '2'`); no legacy conversion added.
- The iOS `plugin.scan()` path and hosted `mobile.html`: deliberately do not opt into the fallback; their behavior is unchanged.
- `parsePairingConnectionPayload` and all other runtime surfaces (web/desktop/VS Code): untouched.
- QR generation and the pairing payload format (v2): unchanged.
- No user-facing strings, error copy, or rendered UI: unchanged.

## Affected surfaces

| Surface | Impact |
|---|---|
| `packages/ui/src/lib/connectionPayload.ts` | New additive export `parsePairingConnectionPayloadString`; existing exports and behavior unchanged. |
| `packages/ui/src/apps/mobileQrScan.ts` | Android `startScan` callback (`scanWithBundledAndroidScanner`) now retries with the string parser before returning `{ status: 'invalid' }`. |
| Mobile Capacitor Android runtime | The only runtime with observable behavior change: a valid pairing QR now redeems instead of showing the invalid-code error. |
| Mobile iOS runtime | Unaffected — the `scan()` path calls `resultFromRawValue(raw)` without the fallback option; iOS WebKit parses `openchamber://` correctly. |
| Web / desktop / VS Code / hosted mobile.html | Unaffected — `mobileQrScan.ts` is consumed only by the Capacitor-only surfaces `MobileConnectionWelcome.tsx` and `MobileInstancesSurface.tsx`; `parseConnectionPayload` is unchanged. |
| Persisted / external contracts | None — no settings, routes, server code, or generated assets change. |

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md — Correctness invariants ("Prefer authoritative state over heuristics"; "Scope temporary fallbacks narrowly and clear them when authoritative state arrives") | The fix is a fallback beside an authoritative parser | The URL-based parse always runs first; the string fallback fires only on its failure and is scoped to the Android `startScan` callback, never replacing the authoritative path. |
| AGENTS.md — Always-on constraints (minimal changes, no dependencies, no secrets) | Any source change | 4 files / +121 −3 lines, no new dependencies, parser never logs or persists payload content. |
| AGENTS.md — Runtime boundaries (shared UI in `packages/ui`) | Change lives in shared UI but targets one runtime | Runtime opt-in is explicit in code (`pairingStringFallback` option, Android-only call site); documented parity in the affected-surfaces table above. |
| Skill `openchamber-change-discipline` | Any source change: smallest complete change, preserve existing behavior, focused tests | Existing URL parser left untouched; validators (version, length, base64url, `normalizePairingPayload`) reused; tests added at the two changed modules; no drive-by refactors. |
| Skill `ui-api-decoupling` — runtime parity must be intentional, runtime state resolved at call time | `mobileQrScan.ts` is Capacitor-runtime code with platform-specific branches | Android opts in deliberately; iOS `scan()` explicitly does not; no hardcoded origins, credentials, or SDK bypass; fallback never constructs URLs, sidestepping the broken WebView parser entirely. |
| `packages/mobile/README.md` | Nearest owning doc for the runtime consuming this surface | Confirms the mobile package bundles the mobile UI only; no `packages/mobile` source change, so the fix requires no native-project change. |
| Module docs discovery (AGENTS.md) | Required before editing | Searched `packages/ui/**/DOCUMENTATION.md`: none exist under `src/lib` or `src/apps`; `packages/ui` has no README. No owning doc needed updating (additive export, no ownership/contract change). |
| Not triggered: `relay-transport`, `sync-state-invariants`, `locale-ui-patterns`, `theme-system`, `desktop-shell`, `clack-cli-patterns`, `settings-ui-patterns` | No transport/realtime, sync, user-facing string, styling, Electron, CLI, or settings code changed | Diff only adds a pure parser and one call-site fallback; no new copy (reuses `mobile.connect.scan.invalid`), no rendering, no state stores. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/apps/mobileQrScan.test.ts packages/ui/src/lib/connectionPayload.test.ts` | **17 pass / 0 fail** (52 expect calls) on PR HEAD `0a7673768` — includes parity with the URL parser on canonical links, recovery of case-variant/trailing-slash/reordered-query links, rejection of empty/malformed/legacy-v1 links, and the Android scan-path fallback producing a pairing result. |
| `bun run type-check:ui` (`tsc --noEmit`) | Pass, no errors. |
| `bun run lint:ui` (eslint, package config) | Pass, no errors. |
| `bun run dead-code` (knip, workspace-wide, non-blocking) | Report inspected: `parsePairingConnectionPayloadString` is not flagged (has a real consumer). The pre-existing unused-type entries (e.g. `PairingDirectCandidate`, `QrScanResult`) are unchanged by this PR. |
| Manual on-device verification (issue #2609) | Huawei ELS-AN00, Android 12, WebView Chrome/114: pairing QR previously failed with the invalid-code toast; after the fix the scan redeems the pairing. Device is in the author's possession; the repro and result are recorded in the issue. |
| Not verified | iOS device path (unchanged by design), web/desktop surfaces (unchanged code paths), packaged Android APK build (no `packages/mobile` change — the fix is in shared UI bundled into the app). |

## Visual evidence

No rendered UI change. The diff only alters scan-result classification for one previously-failing input on the Android bundled-scanner path (error toast → pairing flow); no component, styling, text, theme, or layout code is touched, so the before/after difference is behavioral (a scan succeeding) rather than visual. The failure toast shown for genuinely invalid codes (`mobile.connect.scan.invalid`) is unchanged.

## Risks and failure behavior

- **Scope**: The fallback runs only on the Android `startScan` path and only after the URL-based parse returns `null`; iOS, web, desktop, VS Code, and hosted mobile behavior are untouched. A regression would be limited to Android scans that previously errored.
- **Validation parity**: The string parser enforces the same gates as the URL parser — `v=2`, `MAX_PAIRING_PAYLOAD_LENGTH` (head and decoded payload), base64url decoding, and `normalizePairingPayload`. Canonical input produces identical results (asserted by tests).
- **Anchoring**: The head regex `^openchamber:\/\/connect\/?$/i` is anchored, so `openchamber://connect.evil/…` or path-injected strings cannot match; case-insensitivity matches URL spec semantics for scheme/host, not a security relaxation.
- **Percent-encoding**: The string parser does not percent-decode values; `v=2` and base64url payloads use only unreserved characters, so generated links decode identically. A hypothetical percent-encoded value would fail base64url decode and return `null` → same invalid-code UX as before (no regression).
- **Duplicate query keys**: Last occurrence wins, matching `URLSearchParams.get()` semantics.
- **Security/data**: The parser never constructs a URL, executes nothing, and logs nothing; `JSON.parse` is guarded. No secrets are added, persisted, or transmitted.
- **Failure/rollback**: Parsing is stateless — no rollback, cleanup, or migration needed. `parseConnectionPayload` still rejects non-pairing/legacy links exactly as before.
- **Performance**: One regex + linear string scan per barcode on the scan hot path; negligible.
- **Compatibility**: Additive export only; no package contract, entrypoint, or persisted-data change, so older app versions and other consumers are unaffected.
