### PR TITLE
fix(vscode): re-send connection status when webview is ready

### DIFF
--- a/packages/vscode/src/AgentManagerPanelProvider.ts
+++ b/packages/vscode/src/AgentManagerPanelProvider.ts
@@ -78,6 +78,13 @@ export class AgentManagerPanelProvider {
 
     // Handle messages
     this._panel.webview.onDidReceiveMessage(async (message: BridgeRequest) => {
+      if (message.type === 'webviewReady') {
+        // Re-send cached state once the webview can receive messages; an early
+        // push is dropped while the bundle is still loading.
+        this._sendCachedState();
+        return;
+      }
+
       if (message.type === 'restartApi') {
         await this._openCodeManager?.restart();
         return;

--- a/packages/vscode/src/ChatViewProvider.ts
+++ b/packages/vscode/src/ChatViewProvider.ts
@@ -133,6 +133,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         return;
       }
 
+      if (message.type === 'webviewReady') {
+        // The webview announces it can receive messages (an initial cached-state
+        // push can be dropped while its bundle is still loading), so re-send the
+        // latest connection status instead of leaving it stuck on the bootstrap
+        // value in the HTML.
+        this._sendCachedState();
+        return;
+      }
+
       if (!('id' in message) || typeof message.id !== 'string') {
         return;
       }

--- a/packages/vscode/src/SessionEditorPanelProvider.ts
+++ b/packages/vscode/src/SessionEditorPanelProvider.ts
@@ -129,6 +129,13 @@ export class SessionEditorPanelProvider {
     }, null, this._context.subscriptions);
 
     panel.webview.onDidReceiveMessage(async (message: BridgeRequest) => {
+      if (message.type === 'webviewReady') {
+        // Re-send cached state once the webview can receive messages; an early
+        // push is dropped while the bundle is still loading.
+        this._sendCachedStateToPanel(state);
+        return;
+      }
+
       if (message.type === 'restartApi') {
         await this._openCodeManager?.restart();
         return;

--- a/packages/vscode/webview/api/bridge.ts
+++ b/packages/vscode/webview/api/bridge.ts
@@ -80,6 +80,10 @@ window.addEventListener('message', (event: MessageEvent<BridgeResponse>) => {
   }
 });
 
+export function postVSCodeMessage(message: unknown): void {
+  getVSCodeAPI().postMessage(message);
+}
+
 export function sendBridgeMessage<T = unknown>(type: string, payload?: unknown): Promise<T> {
   return sendBridgeMessageWithOptions<T>(type, payload);
 }

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -1,5 +1,5 @@
 import { createVSCodeAPIs } from './api';
-import { onCommand, onThemeChange, proxyApiRequest, proxySessionMessageRequest, sendBridgeMessage, startSseProxy, stopSseProxy } from './api/bridge';
+import { onCommand, onThemeChange, postVSCodeMessage, proxyApiRequest, proxySessionMessageRequest, sendBridgeMessage, startSseProxy, stopSseProxy } from './api/bridge';
 import { vscodeStreamPerfCount, vscodeStreamPerfMeasure, vscodeStreamPerfObserve } from './api/streamPerf';
 import { extractBodyBase64, extractBodyText, extractJsonBody, hasInitBody } from './requestBodyTransport';
 import type { RuntimeAPIs } from '@openchamber/ui/lib/api/types';
@@ -87,6 +87,10 @@ const handleConnectionMessage = (event: MessageEvent) => {
 };
 
 window.addEventListener('message', handleConnectionMessage);
+// The extension's connectionStatus pushes race with webview loading and can be
+// lost before the bundle executes; announce readiness so providers re-send
+// their cached state once we can actually receive messages.
+postVSCodeMessage({ type: 'webviewReady' });
 window.addEventListener('openchamber:connection-status', () => {
   maybeHideLoadingOverlay();
 });


### PR DESCRIPTION
## Intent

Prevent the VS Code loading splash from remaining on its bootstrap `connecting` state after OpenCode has already connected. The webview now announces readiness after installing its connection-status listener, and each VS Code provider responds by re-sending its cached state.

## Non-goals

- Change OpenCode process startup, retry, or reconnection policy.
- Change the splash presentation or timing.
- Introduce a shared runtime API contract for this VS Code lifecycle handshake.

## Affected surfaces

- `packages/vscode` extension host and webview bridge.
- Chat sidebar, session editor panels, and Agent Manager panels.
- VS Code startup and webview restoration when an early `connectionStatus` push races bundle loading.
- Web, Electron, hosted mobile, and Capacitor do not use this extension-host/webview message boundary.
- No persisted data or external API changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes VS Code source and a platform lifecycle invariant. | Keeps entrypoints thin, uses cached authoritative connection state, and covers every VS Code webview provider that consumes the shared bundle. |
| `ui-api-decoupling` runtime parity guidance | The fix crosses the VS Code webview and extension-host boundary. | Keeps the handshake inside the VS Code runtime and does not add assumptions to shared web, Electron, or mobile APIs. |
| `packages/vscode/README.md` and `packages/vscode/src/DOCUMENTATION.md` | These define the extension surfaces and bridge ownership. | Uses the existing bridge messaging path and provider-owned cached-state methods. |

## Validation

| Check | Result |
|---|---|
| Handshake ordering inspection | The webview installs `handleConnectionMessage` before posting `webviewReady`, so the re-sent status has an active listener. |
| Provider coverage inspection | Chat View, Session Editor, and Agent Manager all handle `webviewReady` and re-send their own cached state. |
| PR diff against `origin/main` | One focused commit touching only the five VS Code handshake files. |

## Visual evidence
I as a human are using my fork and confirm it is ok now. I don't have a handy tool to make a gif and many of my PR is not even checked by human so I decide to omit it as the fix is very simple.
Static image is not enough to show the fix.

## Risks and failure behavior

A ready message can cause one duplicate cached-state delivery when the initial push already arrived. The state is authoritative and the existing receivers already accept repeated status updates, so the duplicate does not create a second process or mutation. If readiness is never announced, behavior remains the previous initial-push path. The message contains no credentials or user data.
