### PR TITLE
fix(vscode): reuse manager output channel across restarts

### DIFF
--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -14,6 +14,17 @@ import { registerManagedProcess, unregisterManagedProcess, reapOrphanedProcesses
 const t = vscode.l10n.t;
 
 const READY_CHECK_TIMEOUT_MS = 30000;
+
+// Reuse a single output channel across restarts instead of creating (and
+// leaking) a new one on every waitForReady call.
+let managerOutputChannel: vscode.OutputChannel | null = null;
+
+function getManagerOutputChannel(): vscode.OutputChannel {
+  if (!managerOutputChannel) {
+    managerOutputChannel = vscode.window.createOutputChannel('OpenChamberManager');
+  }
+  return managerOutputChannel;
+}
 const WINDOWS_EXECUTABLE_EXTENSIONS = (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM')
   .split(';')
   .map((ext) => ext.trim().toLowerCase())
@@ -612,7 +623,6 @@ async function waitForReady(
   timeoutMs = 15000,
   authHeaders: Record<string, string> = {}
 ): Promise<ReadyResult> {
-  const outputChannel = vscode.window.createOutputChannel('OpenChamberManager');
   const start = Date.now();
   const candidates = getCandidateBaseUrls(serverUrl);
   let attempts = 0;
@@ -640,7 +650,7 @@ async function waitForReady(
         }
 
         clearTimeout(timeout);
-        outputChannel?.appendLine(
+        getManagerOutputChannel().appendLine(
           `Health check to ${url.toString()} returned ${res.status} with body: ${JSON.stringify(body)}`
         );
 


### PR DESCRIPTION
## Intent

Prevent managed OpenCode restarts from creating and retaining another `OpenChamberManager` output channel on every readiness check. The extension now creates that channel lazily once and reuses it for subsequent health-check diagnostics.

## Non-goals

- Change readiness polling, timeout, restart, or health-check behavior.
- Change the channel name, diagnostic message content, or when diagnostics are written.
- Add output-channel lifecycle controls outside the extension-host lifetime.

## Affected surfaces

- `packages/vscode/src/opencode.ts` managed OpenCode lifecycle diagnostics.
- VS Code Output panel after repeated API connection restarts.
- External OpenCode server behavior and non-VS Code runtimes are unaffected.
- No persisted data, external API, webview bridge, or shared UI contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes executable VS Code extension-host lifecycle code. | Keeps readiness behavior unchanged and scopes ownership to the existing `opencode.ts` manager module. |
| `packages/vscode/README.md` and `packages/vscode/src/DOCUMENTATION.md` | These define the managed extension runtime and backend ownership. | Reuses the existing VS Code `OutputChannel` API without changing bridge or shared runtime contracts. |

## Validation

| Check | Result |
|---|---|
| Allocation-path inspection | `createOutputChannel('OpenChamberManager')` now exists only in the lazy getter rather than inside `waitForReady()`. |
| Restart-path inspection | Every readiness check resolves the same module-level channel before appending diagnostics. |
| PR diff against `origin/main` | One focused commit touching only `packages/vscode/src/opencode.ts`. |

## Visual evidence
Now "Restart API Connection" will not result in multiple output channels
<img width="2296" height="676" alt="image" src="https://github.com/user-attachments/assets/65e8b9c0-cb20-439a-944b-669f24f30f02" />



## Risks and failure behavior

The channel now lives for the extension-host module lifetime instead of one readiness call, which matches the intended single Output panel entry. Channel creation remains lazy, so successful health checks that never log diagnostics do not allocate it. Polling, error propagation, process cleanup, and diagnostic payloads remain unchanged. Rollback consists of restoring the call-local channel allocation.
