### PR TITLE
fix(ui): allow entering already-added directories in the add-project picker

### DIFF
--- a/packages/ui/src/components/session/DirectoryExplorerDialog.tsx
+++ b/packages/ui/src/components/session/DirectoryExplorerDialog.tsx
@@ -359,7 +359,7 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
   const canSubmitClone = canAddProject && cloneRemoteUrl.trim().length > 0;
   const highlightedRow = rows[highlightedIndex] ?? null;
   const hasHighlightedBrowseItem = Boolean(
-    highlightedRow && (highlightedRow.type === 'up' || (highlightedRow.type === 'directory' && !highlightedRow.disabled))
+    highlightedRow && (highlightedRow.type === 'up' || highlightedRow.type === 'directory')
   );
   const submitModifierLabel = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
     ? '⌘'
@@ -486,7 +486,6 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
       if (row.path) browseToDisplayPath(row.path);
       return;
     }
-    if (row.disabled) return;
     browseToEntry(row);
   }, [browseToDisplayPath, browseToEntry]);
 
@@ -665,7 +664,6 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
                     }
                   }}
                   type="button"
-                  disabled={row.type === 'directory' && row.disabled}
                   onMouseEnter={() => setHighlightedIndex(index)}
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => executeRow(row)}
@@ -673,7 +671,7 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
                     'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
                     isActive && 'bg-interactive-selection text-interactive-selection-foreground',
                     !isActive && 'hover:bg-interactive-hover/50',
-                    row.type === 'directory' && row.disabled && 'cursor-not-allowed opacity-45 hover:bg-transparent'
+                    row.type === 'directory' && row.disabled && 'opacity-45'
                   )}
                 >
                   {row.type === 'up' ? (


### PR DESCRIPTION
## Intent
In the "Add project" picker (`DirectoryExplorerDialog`), a directory already added as a project rendered as a fully disabled row (`disabled` attribute, `cursor-not-allowed`), so users could not click or keyboard-navigate into it to browse subdirectories — making it impossible to add a subdirectory as its own project. This PR keeps the row faded but makes it navigable, while all duplicate-add prevention stays intact.

## Non-goals
- No change to re-add prevention semantics: the quick-add `+` is still replaced by the "Added" badge, `handleQuickAdd`/`finalizeSelection`/`canAddProject` guards and store-level dedupe in `useProjectsStore.addProject` are untouched.
- No new visual affordance beyond the existing "Added" badge; per product decision the fade + pointer/hover feedback is the only distinction.

## Affected surfaces
- `packages/ui` shared component `DirectoryExplorerDialog.tsx` (2 additions / 4 deletions). Web/desktop (`SessionDialogs.tsx`) and mobile (`MobileSessionsSheet.tsx`) consume the same component, so both runtimes get identical behavior. No persisted data, APIs, or store contracts change.

## Repository guidance
| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Shared React component change | Smallest correct change; decouples "row navigation" from "quick-add"; duplicate-add dedupe preserved unchanged |
| `theme-system` | Row/button visual states touched | Reuses existing token classes only (`opacity-45`, `hover:bg-interactive-hover/50`, `cursor-pointer`); no new colors/tokens |
| `locale-ui-patterns` | No new strings introduced | No i18n changes; existing `directoryExplorerDialog.browse.addedBadge` reused as-is |

## Validation
| Check | Result |
|---|---|
| `bun run type-check` (packages/ui) | Pass |
| `bun run lint` (packages/ui) | Pass |
| `bun test packages/ui/src/components/session` | 48 pass / 0 fail |
| Manual (vite dev server + HMR) | Clicking and Enter on an already-added row browse into its subdirectories; exact already-added path still shows disabled submit button with "Already added"; `+` quick-add hidden |
Not verified: the session tests do not cover this dialog (no test file exists); keyboard/pointer behavior was verified by code reading and manual dev-server testing only, not an automated harness.

## Visual evidence
Before: an already-added directory row in the picker rendered fully disabled — `cursor-not-allowed`, unclickable, skipped by keyboard highlight, with no hover feedback.
After: the same row keeps the `opacity-45` fade and the "Added" badge, but shows a pointer cursor and hover background, and clicking or pressing Enter navigates into the directory so a subdirectory can be added as its own project.


https://github.com/user-attachments/assets/e438d8f2-6d19-434e-b436-e8648c8d3942

## Risks and failure behavior
None identified. The diff only removes interaction gates (row `disabled` attribute, `executeRow` guard, `hasHighlightedBrowseItem` exclusion); all three duplicate-prevention layers remain (`isAlreadyAdded` submit guard, `handleQuickAdd` set check, store dedupe), and no data is persisted or rewritten.