### PR TITLE
fix(sessions): recover sessions stranded on interrupted or empty turns

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -731,6 +731,9 @@ const sessionAssistRuntime = createSessionAssistRuntime({
   buildOpenCodeUrl,
   getOpenCodeAuthHeaders,
   getSmallModelService: async () => import('./lib/small-model/index.js'),
+  // Startup recovery scan: recovers sessions stranded on an interrupted turn
+  // after an OpenCode serve restart (which re-emits no status for them).
+  getStartupDirectories: getWarmupDirectories,
 });
 
 const sessionGoalRuntime = createSessionGoalRuntime({
@@ -1031,6 +1034,28 @@ Object.defineProperties(openCodeLifecycleState, {
   resolvedWslDistro: { get: () => resolvedWslDistro, set: (value) => { resolvedWslDistro = value; } },
 });
 
+// Most-recently-used directories first: OpenCode initializes each directory
+// lazily on first request (seconds on large session stores), so the lifecycle
+// warms these right after readiness — before the UI's first interactive
+// request would otherwise pay that cost. The session-assist startup recovery
+// scans the same list for sessions stranded by a serve restart.
+const getWarmupDirectories = async () => {
+  const settings = await readSettingsFromDiskMigrated().catch(() => null);
+  if (!settings) return [];
+  const directories = [];
+  if (typeof settings.lastDirectory === 'string' && settings.lastDirectory) {
+    directories.push(settings.lastDirectory);
+  }
+  const projects = Array.isArray(settings.projects) ? [...settings.projects] : [];
+  projects.sort((a, b) => (b?.lastOpenedAt ?? 0) - (a?.lastOpenedAt ?? 0));
+  for (const project of projects) {
+    if (typeof project?.path === 'string' && project.path) {
+      directories.push(project.path);
+    }
+  }
+  return [...new Set(directories)];
+};
+
 const openCodeLifecycleRuntime = createOpenCodeLifecycleRuntime({
   state: openCodeLifecycleState,
   env: {
@@ -1063,22 +1088,11 @@ const openCodeLifecycleRuntime = createOpenCodeLifecycleRuntime({
   // lazily on first request (seconds on large session stores), so the
   // lifecycle warms these right after readiness — before the UI's first
   // interactive request would otherwise pay that cost.
-  getWarmupDirectories: async () => {
-    const settings = await readSettingsFromDiskMigrated().catch(() => null);
-    if (!settings) return [];
-    const directories = [];
-    if (typeof settings.lastDirectory === 'string' && settings.lastDirectory) {
-      directories.push(settings.lastDirectory);
-    }
-    const projects = Array.isArray(settings.projects) ? [...settings.projects] : [];
-    projects.sort((a, b) => (b?.lastOpenedAt ?? 0) - (a?.lastOpenedAt ?? 0));
-    for (const project of projects) {
-      if (typeof project?.path === 'string' && project.path) {
-        directories.push(project.path);
-      }
-    }
-    return [...new Set(directories)];
-  },
+  getWarmupDirectories,
+  // After EVERY serve (re)start — including health-check recovery restarts —
+  // re-run the session-assist startup recovery, which finds sessions stranded
+  // on interrupted turns and retries or recaps them.
+  onOpenCodeReady: () => sessionAssistRuntime.runStartupRecovery(),
   getManagedOpenCodeEnv: async () => {
     const settings = await readSettingsFromDiskMigrated().catch(() => null);
     const managedEnv = settings?.agentControlToolEnabled === false

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -48,11 +48,24 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     getActiveSessionCount = () => 0,
     reapManagedOrphanedProcesses = reapOrphanedProcesses,
     getWarmupDirectories = async () => [],
+    // Fired (best-effort, never awaited by the lifecycle) after the OpenCode
+    // server comes up — both the initial bootstrap and every restart. Used by
+    // session-assist to recover sessions stranded by a serve restart.
+    onOpenCodeReady = null,
     now = Date.now,
   } = deps;
 
-  const killProcessOnPort = (port) => {
-    if (!port || process.platform === 'win32') return;
+  // Best-effort notification that the OpenCode server is (re)started. Never
+  // awaited: a slow or failing consumer (e.g. the session-assist startup
+  // recovery scan) must not delay or break the lifecycle.
+  const notifyOpenCodeReady = () => {
+    if (typeof onOpenCodeReady !== 'function') return;
+    Promise.resolve(onOpenCodeReady()).catch((error) => {
+      console.warn(`[lifecycle] onOpenCodeReady hook failed: ${error?.message || error}`);
+    });
+  };
+
+  const killProcessOnPort = (port) => {    if (!port || process.platform === 'win32') return;
     try {
       const result = spawnSync('lsof', ['-ti', `:${port}`], { encoding: 'utf8', timeout: 5000, windowsHide: true });
       const output = result.stdout || '';
@@ -698,6 +711,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
 
     try {
       await state.currentRestartPromise;
+      notifyOpenCodeReady();
     } catch (error) {
       console.error(`Failed to restart OpenCode: ${error.message}`);
       state.lastOpenCodeError = error.message;
@@ -925,6 +939,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
       },
     );
     if (!bootstrapError) {
+      notifyOpenCodeReady();
       void warmOpenCodeDirectories();
     }
   };

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -257,6 +257,76 @@ describe('OpenCode lifecycle', () => {
     warn.mockRestore();
   });
 
+  it('notifies onOpenCodeReady after a successful bootstrap', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ healthy: true }),
+    }));
+    const onOpenCodeReady = vi.fn(async () => {});
+    const runtime = createRuntime({
+      env: {
+        ENV_CONFIGURED_OPENCODE_PORT: 45678,
+        ENV_CONFIGURED_OPENCODE_HOST: null,
+        ENV_EFFECTIVE_PORT: 45678,
+        ENV_CONFIGURED_OPENCODE_HOSTNAME: '127.0.0.1',
+        ENV_SKIP_OPENCODE_START: true,
+      },
+      reapManagedOrphanedProcesses: vi.fn(async () => ({ reaped: 0 })),
+      onOpenCodeReady,
+    });
+
+    await runtime.bootstrapOpenCodeAtStartup();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onOpenCodeReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify onOpenCodeReady when bootstrap fails', async () => {
+    const onOpenCodeReady = vi.fn(async () => {});
+    const runtime = createRuntime({
+      syncFromHmrState: vi.fn(() => {
+        throw new Error('bootstrap failed');
+      }),
+      reapManagedOrphanedProcesses: vi.fn(async () => ({ reaped: 0 })),
+      onOpenCodeReady,
+    });
+
+    await runtime.bootstrapOpenCodeAtStartup();
+
+    expect(onOpenCodeReady).not.toHaveBeenCalled();
+  });
+
+  it('notifies onOpenCodeReady after restarting an exited managed process', async () => {
+    const close = vi.fn(async () => {});
+    const replacement = createMockChild();
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      json: async () => null,
+    }));
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        replacement.stdout.emit('data', 'opencode server listening on http://127.0.0.1:45678\n');
+      });
+      return replacement;
+    });
+    const onOpenCodeReady = vi.fn(async () => {});
+    const runtime = createRuntime({ onOpenCodeReady }, {
+      openCodePort: 45678,
+      openCodeProcess: {
+        pid: null,
+        exitCode: 1,
+        signalCode: null,
+        close,
+      },
+    });
+
+    await runtime.triggerHealthCheck();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(onOpenCodeReady).toHaveBeenCalledTimes(1);
+  });
+
   it('restarts an exited managed process without waiting for the failure interval', async () => {
     const close = vi.fn(async () => {});
     const replacement = createMockChild();

--- a/packages/web/server/lib/session-assist/DOCUMENTATION.md
+++ b/packages/web/server/lib/session-assist/DOCUMENTATION.md
@@ -14,9 +14,11 @@ and one suggested user follow-up with the small model
 2. `session.status: idle` arms a 60-second per-session timer; any `busy`/
    `retry` status or a user `message.updated` clears it (the "1 minute of
    quiet" rule).
-3. On fire: fetch the session (skip sub-agent sessions with `parentID`),
-   take the LAST exchange only — the final assistant reply plus the user
-   message it answered (assistant `parentID` → user id) — and call
+3. On fire: fetch the session (skip sub-agent sessions with `parentID`).
+   A broken last assistant turn (empty or unfinished, see below) takes the
+   recovery path instead of a recap. Otherwise take the LAST exchange only —
+   the final assistant reply plus the user message it answered (assistant
+   `parentID` → user id) — and call
    `generateSmallModelText` with the
    session's own provider/model taken from the last assistant message — so
    the utility call spends the same subscription as the conversation.
@@ -39,6 +41,64 @@ time. When both are off, no small-model calls run and nothing is written. When
 one is on, the runtime still makes at most one small-model call and asks only
 for that field. The UI also hides disabled payload types immediately.
 
+`sessionAutoRetryEnabled` (default on) is a behavior switch for the
+failed-turn recovery below: when off, a broken turn skips retries and
+immediately gets the honest recap.
+
+## Empty-completion recovery
+
+When the last assistant turn is BROKEN — it completed with zero output (no
+text, no tool calls, no reasoning parts; step-start/step-finish markers do
+not count) OR it never completed at all (`time.completed` missing, meaning the
+OpenCode serve process died mid-stream and left an unfinished turn; an idle
+session cannot legitimately have one) — a normal recap would be meaningless.
+A `MessageAbortedError` turn and compaction summaries are excluded. The
+runtime instead:
+
+1. Up to `FAILED_TURN_RETRY_MAX` (2) times, re-prompts the session via
+   `POST /session/:id/prompt_async` with a short continuation prompt, waiting
+   `RETRY_QUIET_MS` (60s) first so provider usage windows ("resets in 2min")
+   can recover. Attempts are tracked in
+   `metadata.openchamber.assistRetry = { count, lastMessageID, lastAttemptAt }`,
+   scoped to the failed message id — any new last assistant turn resets the
+   counter, so retries never accumulate across unrelated turns. The retry is
+   dropped if the session tail moves during the wait (the user sent a
+   message) or if the session is busy again (a race with a live turn must
+   never get a duplicate prompt). The provider/model/agent for the retry come
+   from the failed turn itself; when they are absent, the recovery goes
+   straight to the honest recap.
+2. Once retries are exhausted (or disabled), writes an honest assist payload
+   whose recap states plainly that the agent's reply came back empty (likely a
+   provider limit) and that the user can send "Continue" or switch models.
+   The recap/suggestion are generated with the small model in the
+   conversation's language, falling back to a fixed English text when the
+   small model is unavailable — the failure is never silent.
+
+The retry counter is written BEFORE the prompt (write-first), so a failed
+prompt cannot loop forever: the next idle tick sees the recorded count and
+escalates.
+
+## Startup recovery scan
+
+OpenCode re-emits no status for sessions whose turn was interrupted by the
+previous serve process dying — without extra help they would stay silently
+stranded on an unfinished turn forever. `runStartupRecovery` compensates:
+it scans the warm directories (the same most-recently-used list the lifecycle
+warms, injected as `getStartupDirectories`) and for each idle session updated
+within `STARTUP_SESSION_AGE_LIMIT_MS` checks the tail; sessions whose last
+assistant turn is broken get the same failed-turn recovery.
+
+Triggers (all debounced to at most one scan per
+`STARTUP_RECOVERY_MIN_INTERVAL_MS`):
+- the startup timer (`STARTUP_RECOVERY_DELAY_MS` after the runtime is
+  created, as a fallback);
+- the lifecycle `onOpenCodeReady` hook, which fires after EVERY OpenCode
+  serve (re)start — including health-check recovery restarts. So a serve
+  crash that does not restart OpenChamber itself is recovered too.
+
+Best-effort: fetch failures are logged, never block startup, and the pass
+retries a bounded number of times while upstream is not ready.
+
 ## Freshness contract (no clearing writes)
 
 Clients do not need the payload to be deleted: they render it only while
@@ -60,7 +120,12 @@ everywhere instantly and offline; the next idle cycle overwrites it.
 ## Limitations
 
 - The watcher lives in the web server, so VS Code (extension-only, no web
-  server) does not generate assists; it still renders payloads produced by a
-  web/desktop instance of the same OpenCode server via `session.updated`.
+  server) does not generate assists and does not run the startup recovery
+  scan; it still renders payloads produced by a web/desktop instance of the
+  same OpenCode server via `session.updated`.
+- The startup recovery scan only covers the warm (most-recently-used)
+  directories and sessions updated within the last 30 minutes. A serve crash
+  in a cold directory, or one followed by no restart of the OpenChamber
+  server, is not recovered until the next server start.
 - Metadata payloads ride every `session.updated` event — keep the clamps
   (`RECAP_CHAR_LIMIT`, `SUGGESTION_CHAR_LIMIT`) small.

--- a/packages/web/server/lib/session-assist/runtime.js
+++ b/packages/web/server/lib/session-assist/runtime.js
@@ -5,14 +5,28 @@
 // assist.forMessageID — a new message makes the payload stale everywhere
 // without any extra writes.
 //
+// Failed-turn recovery: when the last assistant turn is broken — it COMPLETED
+// with no content (empty stream: provider usage limit, transient failure) or
+// never completed at all (the OpenCode serve process died mid-stream and left
+// an unfinished turn) — a recap of that turn would be meaningless. Instead
+// the runtime retries the session up to FAILED_TURN_RETRY_MAX times via
+// prompt_async with a continuation prompt, tracking attempts in
+// metadata.openchamber.assistRetry (scoped to the last message id), then
+// writes an honest recap telling the user the reply failed.
+//
 // Purely event-driven: only sessions that transition busy→idle while the
-// server is running ever generate anything. No backfill, no session scans.
+// server is running ever generate anything. No backfill, no session scans —
+// EXCEPT one startup recovery pass (runStartupRecovery) that compensates for
+// a serve restart, which loses all in-flight events: sessions whose last turn
+// is broken get the same recovery, so a restart never silently strands a
+// session on an unfinished turn.
 
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-const OPENCHAMBER_SETTINGS_FILE = path.join(
+// Resolved lazily so tests can point OPENCHAMBER_DATA_DIR before first use.
+const getOpenChamberSettingsFile = () => path.join(
   process.env.OPENCHAMBER_DATA_DIR
     ? path.resolve(process.env.OPENCHAMBER_DATA_DIR)
     : path.join(os.homedir(), '.config', 'openchamber'),
@@ -24,23 +38,48 @@ const OPENCHAMBER_SETTINGS_FILE = path.join(
 // payloads stay untouched — clients keep showing them and dismissal still works.
 const getSessionAssistTargets = () => {
   try {
-    const raw = fs.readFileSync(OPENCHAMBER_SETTINGS_FILE, 'utf8');
+    const raw = fs.readFileSync(getOpenChamberSettingsFile(), 'utf8');
     const settings = JSON.parse(raw);
     return {
       recap: settings?.sessionRecapEnabled !== false,
       suggestion: settings?.sessionSuggestionEnabled !== false,
+      // Auto-retry of empty completions is a behavior switch too: when off,
+      // an empty turn immediately gets the honest recap instead.
+      autoRetry: settings?.sessionAutoRetryEnabled !== false,
     };
   } catch {
-    return { recap: true, suggestion: true };
+    return { recap: true, suggestion: true, autoRetry: true };
   }
 };
 
 const IDLE_QUIET_MS = 60_000;
+// Pause between auto-retries of a failed turn: providers usually reset usage
+// windows within ~2 minutes, so a single quiet period is not enough.
+const RETRY_QUIET_MS = 60_000;
+// Hard cap on auto-retries per failed assistant turn (scoped via
+// assistRetry.lastMessageID, so a new turn resets the counter).
+const FAILED_TURN_RETRY_MAX = 2;
+// Startup recovery: after the server (re)starts, OpenCode re-emits no status
+// for sessions whose turn was interrupted by the previous process dying.
+// One bounded scan over the warm directories finds those sessions.
+const STARTUP_RECOVERY_DELAY_MS = 30_000;
+const STARTUP_RECOVERY_MAX_ATTEMPTS = 3;
+// Serve restarts can fire rapidly (health-check storms) — never scan more
+// often than this, whatever the trigger.
+const STARTUP_RECOVERY_MIN_INTERVAL_MS = 60_000;
+const STARTUP_DIRECTORY_LIMIT = 5;
+const STARTUP_SESSION_LIMIT = 8;
+const STARTUP_SESSION_AGE_LIMIT_MS = 30 * 60 * 1000;
 const TRANSCRIPT_MESSAGE_LIMIT = 12;
 const TRANSCRIPT_PART_CHAR_LIMIT = 6_000;
 const RECAP_CHAR_LIMIT = 320;
 const SUGGESTION_CHAR_LIMIT = 500;
 const FETCH_TIMEOUT_MS = 5_000;
+// Last-resort honest recap when the small model cannot generate one (e.g. the
+// same provider limit that killed the turn). English by necessity — the
+// runtime cannot invent the conversation's language without a model call.
+const FAILED_TURN_FALLBACK_RECAP = 'The agent\'s last reply came back empty — likely a provider usage limit or a transient failure. Auto-retries are exhausted; send "Continue" or switch the model.';
+const FAILED_TURN_FALLBACK_SUGGESTION = 'Continue the work.';
 
 const buildAssistSystemPrompt = ({ recap, suggestion }) => [
   'You assist a user who chats with a coding agent. Based on the conversation transcript, return exactly one JSON object and nothing else — no prose, no markdown, no code fences.',
@@ -88,6 +127,27 @@ const buildAssistSystemPrompt = ({ recap, suggestion }) => [
   'All requested values MUST be written in the same language as the conversation text itself. Ignore any other language preferences or personalization you may have — only the conversation text decides the language.',
   'Use double quotes for JSON strings, no trailing commas.',
 ].filter(Boolean).join('\n');
+
+// Continuation prompt injected into the session on a failed turn: the agent's
+// last turn produced nothing (or never finished), so it must not repeat
+// finished work.
+const buildFailedTurnContinuationPrompt = () => [
+  'Your previous response came back empty — the model stream ended without any output (likely a transient provider failure or usage limit).',
+  'The host received no reply from you for the last turn.',
+  'Do NOT repeat tool calls that already completed successfully.',
+  'Continue the task where you left off: take the next concrete action or give your final answer now.',
+].join('\n');
+// Prompt for the honest recap written when the agent's last turn failed (empty
+// stream or interrupted by a restart): state the failure plainly, never invent
+// content the agent produced.
+const buildFailedTurnSystemPrompt = () => [
+  'You assist a user who chats with a coding agent. The agent\'s LAST reply came back EMPTY — the model stream produced no text and no tool calls (typically a provider usage limit or a transient failure).',
+  'Return exactly one JSON object and nothing else — no prose, no markdown, no code fences.',
+  'Shape: {"recap": string, "suggestion": string}',
+  'recap: at most 20 words, in the SAME language as the conversation sample in the user message. State plainly that the agent\'s reply failed with an empty response (likely a provider limit) and that the user can send "Continue" or switch models. Do not summarize any work — there is none to summarize.',
+  'suggestion: ONE immediately sendable next user message addressed to the coding agent, in the SAME language as the sample, telling it to continue the work.',
+  'Use double quotes for JSON strings, no trailing commas.',
+].join('\n');
 
 const extractJsonObject = (value) => {
   const text = String(value ?? '').trim();
@@ -145,15 +205,76 @@ const messagePartsToText = (message) => {
     .slice(0, TRANSCRIPT_PART_CHAR_LIMIT);
 };
 
+// A broken assistant turn that needs recovery: either it never completed
+// (time.completed missing — the serve process died mid-stream and left an
+// unfinished turn; an idle session cannot legitimately have one, so it is
+// always a failure regardless of any running tool parts) or it COMPLETED with
+// no content at all (no text, no tool calls, no reasoning parts — the model
+// stream ended empty). Aborted turns (user cancel) and compaction summaries
+// are explicitly excluded.
+const isFailedAssistantTurn = (message) => {
+  const info = message?.info;
+  if (!info || info.role !== 'assistant') return false;
+  if (info.summary === true) return false;
+  if (info.error) return false;
+  if (!(info.time?.completed > 0)) return true;
+  const parts = Array.isArray(message?.parts) ? message.parts : [];
+  return !parts.some(
+    (part) => part?.type === 'text' || part?.type === 'tool' || part?.type === 'reasoning',
+  );
+};
+
+// Retry bookkeeping for failed turns, stored under
+// metadata.openchamber.assistRetry. Scoped to lastMessageID: any new last
+// assistant turn resets the counter, so retries never accumulate across
+// unrelated turns.
+const parseAssistRetry = (session) => {
+  const metadata = session?.metadata && typeof session.metadata === 'object' ? session.metadata : {};
+  const namespace = metadata.openchamber && typeof metadata.openchamber === 'object'
+    ? metadata.openchamber
+    : {};
+  const retry = namespace.assistRetry && typeof namespace.assistRetry === 'object'
+    ? namespace.assistRetry
+    : {};
+  return {
+    count: Number.isFinite(retry.count) && retry.count > 0 ? Math.min(Math.floor(retry.count), FAILED_TURN_RETRY_MAX) : 0,
+    lastMessageID: typeof retry.lastMessageID === 'string' ? retry.lastMessageID : '',
+    lastAttemptAt: Number.isFinite(retry.lastAttemptAt) ? retry.lastAttemptAt : 0,
+  };
+};
+
+// Id of the newest assistant message in a tail, or null when the tail ends on
+// a user message or is unavailable. Shared by the stale-result checks.
+const findLatestAssistantId = (messages) => {
+  if (!messages) return null;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const info = messages[i]?.info;
+    if (info?.role === 'assistant') return info.id;
+    if (info?.role === 'user') return null;
+  }
+  return null;
+};
+
 export const createSessionAssistRuntime = ({
   buildOpenCodeUrl,
   getOpenCodeAuthHeaders,
   getSmallModelService,
   quietMs = IDLE_QUIET_MS,
+  retryQuietMs = RETRY_QUIET_MS,
+  maxEmptyRetries = FAILED_TURN_RETRY_MAX,
+  // Startup recovery deps: when provided, one bounded scan runs after the
+  // server starts to recover sessions stranded by a serve restart. External
+  // triggers (lifecycle onOpenCodeReady) may also call runStartupRecovery.
+  getStartupDirectories = null,
+  startupRecoveryDelayMs = STARTUP_RECOVERY_DELAY_MS,
+  startupRecoveryMinIntervalMs = STARTUP_RECOVERY_MIN_INTERVAL_MS,
 }) => {
   const timers = new Map();
   const inflight = new Set();
   let stopped = false;
+  let startupRecoveryTimer = null;
+  let startupRecoveryAttempts = 0;
+  let lastStartupScanAt = 0;
 
   const clearTimer = (sessionId) => {
     const existing = timers.get(sessionId);
@@ -163,9 +284,12 @@ export const createSessionAssistRuntime = ({
     }
   };
 
-  const openCodeFetch = async (path, { directory, method = 'GET', body } = {}) => {
+  const openCodeFetch = async (path, { directory, method = 'GET', body, query } = {}) => {
     const base = buildOpenCodeUrl(path, '');
-    const url = directory ? `${base}?directory=${encodeURIComponent(directory)}` : base;
+    const params = new URLSearchParams(query || {});
+    if (directory) params.set('directory', directory);
+    const search = params.toString();
+    const url = search ? `${base}?${search}` : base;
     const response = await fetch(url, {
       method,
       headers: {
@@ -196,6 +320,21 @@ export const createSessionAssistRuntime = ({
     return Array.isArray(messages) ? messages : null;
   };
 
+  const fetchSessionStatuses = async (directory) => {
+    const base = buildOpenCodeUrl('/session/status', '');
+    const url = directory ? `${base}?directory=${encodeURIComponent(directory)}` : base;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json', ...getOpenCodeAuthHeaders() },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const statuses = await response.json().catch(() => null);
+    return statuses && typeof statuses === 'object' && !Array.isArray(statuses) ? statuses : null;
+  };
+
+  const isWorkingStatus = (status) => status?.type === 'busy' || status?.type === 'retry';
+
   const generateAssist = async (sessionId, directory) => {
     const targets = getSessionAssistTargets();
     if (!targets.recap && !targets.suggestion) return;
@@ -224,6 +363,15 @@ export const createSessionAssistRuntime = ({
     }
     const lastAssistantInfo = lastAssistant?.info;
     if (!lastAssistantInfo?.id) return;
+
+    // Failed-turn recovery: the last turn finished with no output at all or
+    // never finished (serve died mid-stream). A recap of that would be
+    // nonsense — retry first, then write an honest recap explaining the
+    // failure.
+    if (isFailedAssistantTurn(lastAssistant)) {
+      await handleFailedTurn({ sessionId, directory, session, messages, lastAssistant, targets });
+      return;
+    }
 
     // Only the last exchange: the assistant reply plus the user message it
     // answered (assistant info.parentID → user info.id). Everything else is
@@ -291,26 +439,21 @@ export const createSessionAssistRuntime = ({
     }
     if (!recap && !suggestion) return;
 
-    // The session may have moved on while we generated — a stale patch would
-    // flash outdated content, so re-check the tail before writing.
+    console.log(`[session-assist] generated for ${sessionId} via ${generated.providerID}/${generated.modelID}`);
+    await writeAssistPayload({ sessionId, directory, session, forMessageID: lastAssistantInfo.id, recap, suggestion });
+  };
+
+  // Shared write tail of both recap paths: re-check the session tail (the
+  // user may have moved on while we generated), then merge the payload into
+  // the metadata from a FRESH read so concurrent metadata writes (suggestion
+  // dismissals, review links, retry bookkeeping, …) survive.
+  const writeAssistPayload = async ({ sessionId, directory, session, forMessageID, recap, suggestion }) => {
     const latest = await fetchRecentMessages(sessionId, directory);
-    const latestAssistantId = (() => {
-      if (!latest) return null;
-      for (let i = latest.length - 1; i >= 0; i -= 1) {
-        const info = latest[i]?.info;
-        if (info?.role === 'assistant') return info.id;
-        if (info?.role === 'user') return null;
-      }
-      return null;
-    })();
-    if (latestAssistantId !== lastAssistantInfo.id) {
+    if (findLatestAssistantId(latest) !== forMessageID) {
       console.log('[session-assist] tail moved on, dropping result');
       return;
     }
 
-    // Merge from a FRESH read: generation takes tens of seconds, and merging
-    // from the session snapshot fetched before it would clobber any metadata
-    // written meanwhile (suggestion dismissals, review links, …).
     const freshSession = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, { directory })
       .catch(() => null);
     const currentMetadata = freshSession?.metadata && typeof freshSession.metadata === 'object'
@@ -320,7 +463,6 @@ export const createSessionAssistRuntime = ({
       ? currentMetadata.openchamber
       : {};
 
-    console.log(`[session-assist] generated for ${sessionId} via ${generated.providerID}/${generated.modelID}`);
     await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, {
       directory,
       method: 'PATCH',
@@ -332,13 +474,268 @@ export const createSessionAssistRuntime = ({
             assist: {
               recap,
               suggestion,
-              forMessageID: lastAssistantInfo.id,
+              forMessageID,
               generatedAt: Date.now(),
             },
           },
         },
       },
     });
+  };
+
+  // Persist the empty-completion retry counter, merging from a fresh read so
+  // concurrent metadata writes survive.
+  const writeAssistRetry = async ({ sessionId, directory, count, lastMessageID }) => {
+    const freshSession = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, { directory })
+      .catch(() => null);
+    const currentMetadata = freshSession?.metadata && typeof freshSession.metadata === 'object'
+      ? freshSession.metadata
+      : {};
+    const currentNamespace = currentMetadata.openchamber && typeof currentMetadata.openchamber === 'object'
+      ? currentMetadata.openchamber
+      : {};
+    await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, {
+      directory,
+      method: 'PATCH',
+      body: {
+        metadata: {
+          ...currentMetadata,
+          openchamber: {
+            ...currentNamespace,
+            assistRetry: { count, lastMessageID, lastAttemptAt: Date.now() },
+          },
+        },
+      },
+    });
+  };
+
+  // Honest recap for a failed turn: say the reply failed, never invent
+  // content. Small-model generation first (keeps the conversation language),
+  // then a fixed English fallback so the failure is never silent.
+  const writeHonestFailedTurnRecap = async ({ sessionId, directory, session, messages, lastAssistant }) => {
+    const lastAssistantInfo = lastAssistant?.info;
+    const messageId = lastAssistantInfo.id;
+    const parentUserMessage = typeof lastAssistantInfo.parentID === 'string' && lastAssistantInfo.parentID
+      ? messages.find((message) => message?.info?.id === lastAssistantInfo.parentID && message?.info?.role === 'user')
+      : null;
+    const userText = parentUserMessage ? messagePartsToText(parentUserMessage) : '';
+    const languageSample = userText.slice(0, 200).replace(/\s+/g, ' ').trim();
+
+    let recap = FAILED_TURN_FALLBACK_RECAP;
+    let suggestion = FAILED_TURN_FALLBACK_SUGGESTION;
+    try {
+      const { generateSmallModelText } = await getSmallModelService();
+      const generated = await generateSmallModelText({
+        // Background feature: conversation content must never leave the
+        // session's own provider unless the user explicitly picked a small
+        // model (settings override / opencode config).
+        restrictToPreferredProvider: true,
+        prompt: `The agent's last reply in this conversation came back EMPTY (no text, no tool calls).\n\nWrite the recap and suggestion in the SAME language as this sample from the conversation: "${languageSample || 'no text available'}"`,
+        system: buildFailedTurnSystemPrompt(),
+        directory,
+        preferredProviderID: typeof lastAssistantInfo.providerID === 'string' ? lastAssistantInfo.providerID : undefined,
+        preferredModelID: typeof lastAssistantInfo.modelID === 'string' ? lastAssistantInfo.modelID : undefined,
+      });
+      const structured = extractJsonObject(generated?.text);
+      if (structured && typeof structured?.recap === 'string' && structured.recap.trim()) {
+        recap = structured.recap.trim().slice(0, RECAP_CHAR_LIMIT);
+      }
+      if (structured && typeof structured?.suggestion === 'string' && structured.suggestion.trim()) {
+        suggestion = structured.suggestion.trim().slice(0, SUGGESTION_CHAR_LIMIT);
+      }
+      // Same language guard as the normal path: a hallucinated script must not
+      // leak into a conversation that never used it.
+      const hasCyrillic = (text) => /[\u0400-\u04FF]/.test(text);
+      const hasCjk = (text) => /[\u3040-\u30FF\u4E00-\u9FFF\uAC00-\uD7AF]/.test(text);
+      const scriptMismatch = (text) => (hasCyrillic(text) && !hasCyrillic(userText))
+        || (hasCjk(text) && !hasCjk(userText));
+      if (recap !== FAILED_TURN_FALLBACK_RECAP && scriptMismatch(recap)) {
+        console.warn('[session-assist] dropped failed-turn recap: language mismatch');
+        recap = FAILED_TURN_FALLBACK_RECAP;
+      }
+      if (suggestion !== FAILED_TURN_FALLBACK_SUGGESTION && scriptMismatch(suggestion)) {
+        console.warn('[session-assist] dropped failed-turn suggestion: language mismatch');
+        suggestion = FAILED_TURN_FALLBACK_SUGGESTION;
+      }
+    } catch (error) {
+      // No authenticated small model (404) or a transient failure — the
+      // fixed-language fallback still surfaces the failure.
+      if (Number(error?.statusCode) !== 404) {
+        console.warn('[session-assist] failed-turn recap generation failed:', error?.message || error);
+      }
+    }
+
+    console.log(`[session-assist] failed turn on ${sessionId}, writing honest recap`);
+    await writeAssistPayload({ sessionId, directory, session, forMessageID: messageId, recap, suggestion });
+  };
+
+  // A broken turn (empty stream, or interrupted by a serve restart): retry the
+  // session with a continuation prompt up to maxEmptyRetries (tracked per
+  // last message id), then write an honest recap that tells the user the
+  // reply failed.
+  const handleFailedTurn = async ({ sessionId, directory, session, messages, lastAssistant, targets, isWorking = null }) => {
+    const lastAssistantInfo = lastAssistant?.info;
+    const messageId = lastAssistantInfo.id;
+    const retry = parseAssistRetry(session);
+    const scopedRetry = retry.lastMessageID === messageId
+      ? retry
+      : { count: 0, lastMessageID: messageId, lastAttemptAt: 0 };
+
+    const providerID = typeof lastAssistantInfo.providerID === 'string' ? lastAssistantInfo.providerID : '';
+    const modelID = typeof lastAssistantInfo.modelID === 'string' ? lastAssistantInfo.modelID : '';
+    const canRetry = targets.autoRetry && scopedRetry.count < maxEmptyRetries && providerID && modelID;
+    if (!canRetry) {
+      await writeHonestFailedTurnRecap({ sessionId, directory, session, messages, lastAssistant });
+      return;
+    }
+
+    // Write-first bookkeeping: if the prompt below fails, the recorded count
+    // keeps the next idle tick from retrying forever.
+    await writeAssistRetry({ sessionId, directory, count: scopedRetry.count + 1, lastMessageID: messageId });
+    console.log(`[session-assist] failed turn on ${sessionId}, retrying (${scopedRetry.count + 1}/${maxEmptyRetries})`);
+
+    // Providers usually reset usage windows within a couple of minutes —
+    // wait before re-prompting instead of hammering the same limit.
+    await new Promise((resolve) => setTimeout(resolve, retryQuietMs));
+    if (stopped) return;
+
+    // The tail must not have moved during the wait (the user sent a message).
+    const latest = await fetchRecentMessages(sessionId, directory);
+    if (findLatestAssistantId(latest) !== messageId) {
+      console.log('[session-assist] tail moved on, dropping failed-turn retry');
+      return;
+    }
+
+    // The session must still be idle: a turn that merely LOOKS unfinished
+    // because it is genuinely running right now (race with a user message)
+    // must never get a duplicate prompt. isWorking is three-valued: true =
+    // busy (drop), false = idle already confirmed by the caller (startup
+    // scan), null = unknown — fetch the live status, and if it cannot be
+    // confirmed (fetch failed), drop the retry: never re-prompt without
+    // proof that the session is idle.
+    let statusConfirmed = false;
+    let isBusy = false;
+    if (isWorking === true) {
+      statusConfirmed = true;
+      isBusy = true;
+    } else if (isWorking === false) {
+      statusConfirmed = true;
+    } else {
+      const statuses = await fetchSessionStatuses(directory);
+      statusConfirmed = Boolean(statuses);
+      isBusy = statusConfirmed && isWorkingStatus(statuses[sessionId]);
+    }
+    if (!statusConfirmed || isBusy) {
+      console.log(`[session-assist] ${isBusy ? 'session is busy' : 'status unavailable'}, dropping failed-turn retry`);
+      return;
+    }
+
+    const agent = typeof lastAssistantInfo.agent === 'string' && lastAssistantInfo.agent
+      ? lastAssistantInfo.agent
+      : (typeof lastAssistantInfo.mode === 'string' ? lastAssistantInfo.mode : '');
+    const variant = typeof lastAssistantInfo.variant === 'string' ? lastAssistantInfo.variant : '';
+    await openCodeFetch(`/session/${encodeURIComponent(sessionId)}/prompt_async`, {
+      directory,
+      method: 'POST',
+      body: {
+        model: { providerID, modelID },
+        ...(agent ? { agent } : {}),
+        ...(variant ? { variant } : {}),
+        parts: [{ type: 'text', text: buildFailedTurnContinuationPrompt() }],
+      },
+    });
+  };
+
+  // One bounded startup pass over the warm directories: after a serve (or
+  // server) restart, OpenCode re-emits no status for sessions whose turn was
+  // interrupted by the previous process dying — they would stay silently
+  // stranded on an unfinished turn forever. Recover them with the same
+  // failed-turn path. Best-effort: fetch failures are logged and retried a
+  // few times, then abandoned.
+  //
+  // Called from three places: the startup timer, the lifecycle
+  // onOpenCodeReady hook (every serve restart), and the internal retry loop
+  // (fromRetry bypasses the debounce so a single scan cycle can retry while
+  // upstream is not ready).
+  const runStartupRecovery = async ({ fromRetry = false } = {}) => {
+    if (stopped || typeof getStartupDirectories !== 'function') return;
+    const nowMs = Date.now();
+    if (!fromRetry) {
+      // Serve restarts can fire rapidly — a bounded rate keeps repeated
+      // triggers from stacking scans on top of each other.
+      if (lastStartupScanAt && nowMs - lastStartupScanAt < startupRecoveryMinIntervalMs) return;
+      startupRecoveryAttempts = 0;
+      lastStartupScanAt = nowMs;
+    }
+    let directories = [];
+    try {
+      directories = await getStartupDirectories();
+    } catch (error) {
+      console.warn('[session-assist] startup recovery: directory list failed:', error?.message || error);
+      return;
+    }
+    if (!Array.isArray(directories)) return;
+    const targets = getSessionAssistTargets();
+    let anyDirectoryFailed = false;
+
+    for (const directory of directories.slice(0, STARTUP_DIRECTORY_LIMIT)) {
+      if (!directory || stopped) return;
+      if (inflight.has(`startup:${directory}`)) continue;
+      inflight.add(`startup:${directory}`);
+      try {
+        const statuses = await fetchSessionStatuses(directory);
+        const sessionList = await openCodeFetch('/session', { directory, query: { limit: String(STARTUP_SESSION_LIMIT) } })
+          .catch(() => null);
+        if (!statuses || !Array.isArray(sessionList)) {
+          anyDirectoryFailed = true;
+          continue;
+        }
+        for (const session of sessionList) {
+          if (stopped) return;
+          if (typeof session?.id !== 'string' || !session.id) continue;
+          if (typeof session.parentID === 'string' && session.parentID) continue;
+          if (isWorkingStatus(statuses[session.id])) continue;
+          const updated = Number.isFinite(session?.time?.updated) ? session.time.updated : 0;
+          if (nowMs - updated > STARTUP_SESSION_AGE_LIMIT_MS) continue;
+
+          const messages = await fetchRecentMessages(session.id, directory);
+          let lastAssistant = null;
+          if (messages) {
+            for (let i = messages.length - 1; i >= 0; i -= 1) {
+              if (messages[i]?.info?.role === 'assistant') {
+                lastAssistant = messages[i];
+                break;
+              }
+            }
+          }
+          if (!lastAssistant || !isFailedAssistantTurn(lastAssistant)) continue;
+
+          console.log(`[session-assist] startup recovery: failed turn on ${session.id}`);
+          await handleFailedTurn({
+            sessionId: session.id,
+            directory,
+            session,
+            messages,
+            lastAssistant,
+            targets,
+            isWorking: isWorkingStatus(statuses[session.id]),
+          });
+        }
+      } catch (error) {
+        anyDirectoryFailed = true;
+        console.warn(`[session-assist] startup recovery failed for ${directory}:`, error?.message || error);
+      } finally {
+        inflight.delete(`startup:${directory}`);
+      }
+    }
+
+    // Upstream may not be ready yet on first attempts — retry the whole pass
+    // a bounded number of times.
+    if (anyDirectoryFailed && !stopped && startupRecoveryAttempts < STARTUP_RECOVERY_MAX_ATTEMPTS) {
+      startupRecoveryAttempts += 1;
+      startupRecoveryTimer = setTimeout(() => runStartupRecovery({ fromRetry: true }), startupRecoveryDelayMs);
+      if (typeof startupRecoveryTimer?.unref === 'function') startupRecoveryTimer.unref();
+    }
   };
 
   const armTimer = (sessionId, directory) => {
@@ -384,11 +781,22 @@ export const createSessionAssistRuntime = ({
 
   const stop = () => {
     stopped = true;
+    if (startupRecoveryTimer) {
+      clearTimeout(startupRecoveryTimer);
+      startupRecoveryTimer = null;
+    }
     for (const { timer } of timers.values()) {
       clearTimeout(timer);
     }
     timers.clear();
   };
 
-  return { processPayload, stop };
+  // One startup recovery pass (see runStartupRecovery) when the server has
+  // warm directories to scan — compensates for serve restarts losing events.
+  if (typeof getStartupDirectories === 'function') {
+    startupRecoveryTimer = setTimeout(runStartupRecovery, startupRecoveryDelayMs);
+    if (typeof startupRecoveryTimer?.unref === 'function') startupRecoveryTimer.unref();
+  }
+
+  return { processPayload, stop, runStartupRecovery };
 };

--- a/packages/web/server/lib/session-assist/runtime.test.js
+++ b/packages/web/server/lib/session-assist/runtime.test.js
@@ -1,0 +1,596 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSessionAssistRuntime } from './runtime.js';
+
+const json = (body) => new Response(JSON.stringify(body), {
+  status: 200,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Condition-based waiting instead of fixed sleeps: the runtime arms timers
+// (quietMs, retryQuietMs, startup delay), so assertions must wait for the
+// observable request to appear rather than racing a clock.
+const waitFor = async (predicate, timeoutMs = 1_000) => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return true;
+    await sleep(10);
+  }
+  return false;
+};
+
+const userMessage = (id, text) => ({
+  info: { id, role: 'user', time: { created: 1 } },
+  parts: [{ type: 'text', text }],
+});
+
+const emptyAssistantMessage = (id, overrides = {}) => ({
+  info: {
+    id,
+    role: 'assistant',
+    agent: 'build',
+    providerID: 'provider',
+    modelID: 'model',
+    parentID: 'msg_u1',
+    time: { created: 10, completed: 20 },
+    finish: 'unknown',
+    ...overrides,
+  },
+  parts: [
+    { type: 'step-start' },
+    { type: 'step-finish', reason: 'unknown' },
+  ],
+});
+
+const unfinishedAssistantMessage = (id, overrides = {}) => ({
+  info: {
+    id,
+    role: 'assistant',
+    agent: 'build',
+    providerID: 'provider',
+    modelID: 'model',
+    parentID: 'msg_u1',
+    time: { created: 10 },
+    ...overrides,
+  },
+  parts: [
+    { type: 'step-start' },
+    { type: 'tool', tool: 'bash', callID: 'call_00_1', state: { status: 'running', input: { command: 'sleep 999' } } },
+  ],
+});
+
+const contentAssistantMessage = (id, overrides = {}) => ({
+  info: {
+    id,
+    role: 'assistant',
+    agent: 'build',
+    providerID: 'provider',
+    modelID: 'model',
+    parentID: 'msg_u1',
+    time: { created: 10, completed: 20 },
+    finish: 'stop',
+    ...overrides,
+  },
+  parts: [{ type: 'text', text: 'Real reply.' }],
+});
+
+describe('session assist runtime — failed-turn recovery', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.OPENCHAMBER_DATA_DIR;
+  });
+
+  const buildRuntime = ({ fetchImpl, smallModelText, opts = {} } = {}) => {
+    const runtime = createSessionAssistRuntime({
+      buildOpenCodeUrl: (path) => `http://opencode.test${path}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({
+        generateSmallModelText: vi.fn(async () => ({
+          text: smallModelText ?? '{"recap":"Recap","suggestion":"Suggestion"}',
+          providerID: 'smallp',
+          modelID: 'smallm',
+        })),
+      }),
+      quietMs: 5,
+      retryQuietMs: 5,
+      startupRecoveryDelayMs: 10_000_000,
+      ...opts,
+    });
+    return runtime;
+  };
+
+  const hasPrompt = (requests) => requests.some((request) => request.path.endsWith('/prompt_async'));
+
+  const idleStatuses = (sessionId) => ({ [sessionId]: { type: 'idle' } });
+
+  it('retries an empty completed assistant turn via prompt_async and records the retry state', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') return json({ id: 'ses_1' });
+      if (url.pathname === '/session/status') return json(idleStatuses('ses_1'));
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), emptyAssistantMessage('msg_e1')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime();
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => hasPrompt(requests));
+
+    const prompt = requests.find((request) => request.path.endsWith('/prompt_async'));
+    expect(prompt).toBeTruthy();
+    const payload = JSON.parse(prompt.body);
+    expect(payload).toMatchObject({
+      model: { providerID: 'provider', modelID: 'model' },
+      agent: 'build',
+    });
+    expect(payload.parts[0].text).toContain('empty');
+    const retryPatch = requests.find((request) => request.method === 'PATCH');
+    expect(JSON.parse(retryPatch.body).metadata.openchamber.assistRetry).toMatchObject({
+      count: 1,
+      lastMessageID: 'msg_e1',
+    });
+    runtime.stop();
+  });
+
+  it('retries an unfinished assistant turn (serve died mid-stream) via the idle path', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') return json({ id: 'ses_1' });
+      if (url.pathname === '/session/status') return json(idleStatuses('ses_1'));
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), unfinishedAssistantMessage('msg_u1f')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime();
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => hasPrompt(requests));
+
+    expect(hasPrompt(requests)).toBe(true);
+    runtime.stop();
+  });
+
+  it('drops the retry when the session turns busy before the prompt', async () => {    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') return json({ id: 'ses_1' });
+      if (url.pathname === '/session/status') return json({ ses_1: { type: 'busy' } });
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), emptyAssistantMessage('msg_e1')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime();
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => requests.some((request) => request.method === 'PATCH'));
+    await sleep(150);
+
+    expect(hasPrompt(requests)).toBe(false);
+    runtime.stop();
+  });
+
+  it('drops the retry when the session status cannot be confirmed', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') return json({ id: 'ses_1' });
+      if (url.pathname === '/session/status') return new Response('boom', { status: 500 });
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), emptyAssistantMessage('msg_e1')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime();
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => requests.some((request) => request.method === 'PATCH'));
+    await sleep(150);
+
+    expect(hasPrompt(requests)).toBe(false);
+    runtime.stop();
+  });
+
+  it('escalates to an honest recap once retries are exhausted and sends no prompt', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') {
+        return json({
+          id: 'ses_1',
+          metadata: { openchamber: { assistRetry: { count: 2, lastMessageID: 'msg_e1' } } },
+        });
+      }
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), emptyAssistantMessage('msg_e1')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime({
+      smallModelText: '{"recap":"Agent reply came back empty — provider limit","suggestion":"Continue the work."}',
+    });
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => requests.some((request) => request.method === 'PATCH'));
+    await sleep(150);
+
+    expect(hasPrompt(requests)).toBe(false);
+    const patches = requests.filter((request) => request.method === 'PATCH');
+    const assistPatch = patches[patches.length - 1];
+    expect(JSON.parse(assistPatch.body).metadata.openchamber.assist).toMatchObject({
+      recap: 'Agent reply came back empty — provider limit',
+      suggestion: 'Continue the work.',
+      forMessageID: 'msg_e1',
+    });
+    runtime.stop();
+  });
+
+  it('resets the retry counter when the failed turn is a new message', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') {
+        return json({
+          id: 'ses_1',
+          metadata: { openchamber: { assistRetry: { count: 2, lastMessageID: 'msg_old' } } },
+        });
+      }
+      if (url.pathname === '/session/status') return json(idleStatuses('ses_1'));
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), emptyAssistantMessage('msg_new')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime();
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => hasPrompt(requests));
+
+    expect(hasPrompt(requests)).toBe(true);
+    const retryPatch = requests.find((request) => request.method === 'PATCH');
+    expect(JSON.parse(retryPatch.body).metadata.openchamber.assistRetry).toMatchObject({
+      count: 1,
+      lastMessageID: 'msg_new',
+    });
+    runtime.stop();
+  });
+
+  it('never retries a user-aborted turn', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') return json({ id: 'ses_1' });
+      if (url.pathname === '/session/ses_1/message') {
+        return json([
+          userMessage('msg_u1', 'Continue the work'),
+          emptyAssistantMessage('msg_ab', {
+            error: { name: 'MessageAbortedError', data: { message: 'Aborted' } },
+          }),
+        ]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime();
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => requests.some((request) => request.method === 'PATCH'));
+    await sleep(150);
+
+    expect(hasPrompt(requests)).toBe(false);
+    runtime.stop();
+  });
+
+  it('drops the retry when the session tail moves during the quiet window', async () => {
+    const requests = [];
+    let messageCalls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') return json({ id: 'ses_1' });
+      if (url.pathname === '/session/ses_1/message') {
+        messageCalls += 1;
+        if (messageCalls === 1) {
+          return json([userMessage('msg_u1', 'Continue the work'), emptyAssistantMessage('msg_e1')]);
+        }
+        return json([userMessage('msg_u2', 'Wait, actually…')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime();
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => requests.some((request) => request.method === 'PATCH'));
+    await sleep(150);
+
+    expect(hasPrompt(requests)).toBe(false);
+    runtime.stop();
+  });
+
+  it('keeps the plain recap path for a normal assistant turn (no prompt)', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') return json({ id: 'ses_1' });
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), contentAssistantMessage('msg_ok')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime();
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => requests.some((request) => request.method === 'PATCH'));
+    await sleep(100);
+
+    expect(hasPrompt(requests)).toBe(false);
+    const patches = requests.filter((request) => request.method === 'PATCH');
+    expect(patches.length).toBe(1);
+    expect(JSON.parse(patches[0].body).metadata.openchamber.assist).toMatchObject({
+      recap: 'Recap',
+      forMessageID: 'msg_ok',
+    });
+    runtime.stop();
+  });
+
+  it('falls back to a fixed-language honest recap when the small model fails', async () => {
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') {
+        return json({
+          id: 'ses_1',
+          metadata: { openchamber: { assistRetry: { count: 2, lastMessageID: 'msg_e1' } } },
+        });
+      }
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), emptyAssistantMessage('msg_e1')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime({
+      opts: {
+        getSmallModelService: async () => ({
+          generateSmallModelText: vi.fn(async () => {
+            throw new Error('small model down');
+          }),
+        }),
+      },
+    });
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => requests.some((request) => request.method === 'PATCH'));
+    await sleep(150);
+
+    expect(hasPrompt(requests)).toBe(false);
+    const patches = requests.filter((request) => request.method === 'PATCH');
+    const assistPatch = patches[patches.length - 1];
+    const assist = JSON.parse(assistPatch.body).metadata.openchamber.assist;
+    expect(assist.recap).toContain('empty');
+    expect(assist.suggestion).toContain('Continue');
+    runtime.stop();
+  });
+
+  it('skips auto-retry when disabled in settings and writes the honest recap immediately', async () => {
+    const fs = await import('fs');
+    const os = await import('os');
+    const path = await import('path');
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchamber-assist-test-'));
+    fs.writeFileSync(path.join(dataDir, 'settings.json'), JSON.stringify({ sessionAutoRetryEnabled: false }));
+    process.env.OPENCHAMBER_DATA_DIR = dataDir;
+
+    const requests = [];
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+      if (url.pathname === '/session/ses_1') return json({ id: 'ses_1' });
+      if (url.pathname === '/session/ses_1/message') {
+        return json([userMessage('msg_u1', 'Continue the work'), emptyAssistantMessage('msg_e1')]);
+      }
+      if (url.pathname === '/session/ses_1/prompt_async') return json({});
+      throw new Error(`Unexpected ${url.pathname}`);
+    }));
+
+    const runtime = buildRuntime({
+      smallModelText: '{"recap":"Agent reply came back empty","suggestion":"Continue the work."}',
+    });
+    await runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_1', status: { type: 'idle' }, directory: '/repo' },
+    });
+    await waitFor(() => requests.some((request) => request.method === 'PATCH'));
+    await sleep(150);
+
+    expect(hasPrompt(requests)).toBe(false);
+    const patches = requests.filter((request) => request.method === 'PATCH');
+    expect(JSON.parse(patches[0].body).metadata.openchamber.assist.recap).toContain('empty');
+    runtime.stop();
+  });
+
+  describe('startup recovery scan', () => {
+    it('retries a session stranded on an unfinished turn after a serve restart', async () => {
+      const requests = [];
+      const dirs = ['/repo'];
+      vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+        const url = new URL(typeof input === 'string' ? input : input.url);
+        requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+        if (url.pathname === '/session/status') return json(idleStatuses('ses_stranded'));
+        if (url.pathname === '/session' && init.method === 'GET') {
+          return json([{ id: 'ses_stranded', time: { updated: Date.now() } }]);
+        }
+        if (url.pathname === '/session/ses_stranded') return json({ id: 'ses_stranded' });
+        if (url.pathname === '/session/ses_stranded/message') {
+          return json([userMessage('msg_u1', 'Continue the work'), unfinishedAssistantMessage('msg_str')]);
+        }
+        if (url.pathname === '/session/ses_stranded/prompt_async') return json({});
+        throw new Error(`Unexpected ${url.pathname}`);
+      }));
+
+      const runtime = buildRuntime({
+        opts: { getStartupDirectories: async () => dirs },
+      });
+      await runtime.runStartupRecovery();
+      await waitFor(() => hasPrompt(requests));
+
+      expect(hasPrompt(requests)).toBe(true);
+      const prompt = requests.find((request) => request.path.endsWith('/prompt_async'));
+      expect(JSON.parse(prompt.body)).toMatchObject({ model: { providerID: 'provider', modelID: 'model' } });
+      runtime.stop();
+    });
+
+    it('skips sessions that are busy', async () => {
+      const requests = [];
+      const dirs = ['/repo'];
+      vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+        const url = new URL(typeof input === 'string' ? input : input.url);
+        requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+        if (url.pathname === '/session/status') return json({ ses_busy: { type: 'busy' } });
+        if (url.pathname === '/session' && init.method === 'GET') {
+          return json([{ id: 'ses_busy', time: { updated: Date.now() } }]);
+        }
+        if (url.pathname === '/session/ses_busy/prompt_async') return json({});
+        throw new Error(`Unexpected ${url.pathname}`);
+      }));
+
+      const runtime = buildRuntime({
+        opts: { getStartupDirectories: async () => dirs },
+      });
+      await runtime.runStartupRecovery();
+      await sleep(150);
+
+      expect(hasPrompt(requests)).toBe(false);
+      expect(requests.some((request) => request.path === '/session/ses_busy/message')).toBe(false);
+      runtime.stop();
+    });
+
+    it('skips sessions whose last turn is normal', async () => {
+      const requests = [];
+      const dirs = ['/repo'];
+      vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+        const url = new URL(typeof input === 'string' ? input : input.url);
+        requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+        if (url.pathname === '/session/status') return json(idleStatuses('ses_ok'));
+        if (url.pathname === '/session' && init.method === 'GET') {
+          return json([{ id: 'ses_ok', time: { updated: Date.now() } }]);
+        }
+        if (url.pathname === '/session/ses_ok/message') {
+          return json([userMessage('msg_u1', 'Continue the work'), contentAssistantMessage('msg_ok')]);
+        }
+        if (url.pathname === '/session/ses_ok/prompt_async') return json({});
+        throw new Error(`Unexpected ${url.pathname}`);
+      }));
+
+      const runtime = buildRuntime({
+        opts: { getStartupDirectories: async () => dirs },
+      });
+      await runtime.runStartupRecovery();
+      await sleep(150);
+
+      expect(hasPrompt(requests)).toBe(false);
+      runtime.stop();
+    });
+
+    it('does nothing without startup directories', async () => {
+      const fetchImpl = vi.fn();
+      vi.stubGlobal('fetch', fetchImpl);
+      const runtime = buildRuntime();
+      await runtime.runStartupRecovery();
+      await sleep(50);
+      expect(fetchImpl).not.toHaveBeenCalled();
+      runtime.stop();
+    });
+
+    it('debounces rapid triggers (serve restart storms) and re-scans after the interval', async () => {
+      const requests = [];
+      const dirs = ['/repo'];
+      vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+        const url = new URL(typeof input === 'string' ? input : input.url);
+        requests.push({ path: url.pathname, method: init.method ?? 'GET', body: init.body });
+        if (url.pathname === '/session/status') return json(idleStatuses('ses_x'));
+        if (url.pathname === '/session' && init.method === 'GET') {
+          return json([{ id: 'ses_x', time: { updated: Date.now() } }]);
+        }
+        if (url.pathname === '/session/ses_x/message') {
+          return json([userMessage('msg_u1', 'Continue the work'), contentAssistantMessage('msg_ok')]);
+        }
+        throw new Error(`Unexpected ${url.pathname}`);
+      }));
+
+      const runtime = buildRuntime({
+        opts: {
+          getStartupDirectories: async () => dirs,
+          startupRecoveryMinIntervalMs: 80,
+        },
+      });
+      await runtime.runStartupRecovery();
+      await runtime.runStartupRecovery();
+      await runtime.runStartupRecovery();
+      await sleep(120);
+      await runtime.runStartupRecovery();
+      await sleep(50);
+
+      // First trigger scans; two immediate repeats are debounced; after the
+      // interval a fresh scan runs again.
+      const sessionListCalls = requests.filter(
+        (request) => request.path === '/session' && (request.method ?? 'GET') === 'GET',
+      );
+      expect(sessionListCalls.length).toBe(2);
+      runtime.stop();
+    });
+  });
+});


### PR DESCRIPTION
## Intent

OpenCode sessions can silently stop in two ways, both leaving the user with a session that just stopped with no explanation:

1. **Empty turn** — the model stream ends with no output (provider usage limit such as `AI_APICallError: Monthly usage limit reached`, or a transient failure). OpenCode closes the turn with `finish: "unknown"`, 0 tokens, no error, and the loop exits quietly.
2. **Interrupted turn** — the OpenCode serve process dies mid-stream (crash, kill, restart). The turn stays unfinished (`time.completed` missing, possibly with a `running` tool part) forever; after a serve restart OpenCode re-emits no status for that session, so nothing ever resumes it.

This change makes the OpenChamber web server (session-assist runtime) detect both failure classes and act:

- **Failed-turn recovery**: up to 2 auto-retries via `POST /session/:id/prompt_async` with a short continuation prompt, waiting 60s between attempts (provider usage windows typically reset within ~2 minutes). Attempts are tracked in `metadata.openchamber.assistRetry` scoped to the failed message id, written *before* the prompt (a failed prompt cannot loop). Before every prompt the session tail and the *live* session status are re-checked, so a genuinely running turn never receives a duplicate prompt; a retry is dropped unless the session is confirmed idle.
- **Honest recap**: once retries are exhausted, an assist payload whose recap states plainly that the agent's reply came back empty (likely a provider limit) and that the user can send "Continue" or switch models — instead of the previous meaningless recap of an empty turn.
- **Startup recovery scan**: a bounded scan (`runStartupRecovery`) finds sessions stranded by a serve restart. It runs once after server startup and — via the new lifecycle `onOpenCodeReady` hook — after **every** OpenCode serve (re)start, including health-check recovery restarts (debounced to one scan per minute, limited to the warm directories, recent idle sessions, best-effort with bounded retries while upstream is not ready).

## Non-goals

- No changes to OpenCode itself (separate repository) — in particular, orphaned tool subprocesses left by a `kill -9`'d serve cannot be cancelled from OpenChamber; the continuation prompt instructs the agent not to repeat already-completed tool calls, but a still-running orphaned process may duplicate work (documented limitation).
- No UI changes: the existing `SessionRecapSpacer`/`SessionSuggestionChip` rendering path is reused unchanged.
- No changes to VS Code (extension-only, no web server — it cannot run the scan; it still renders payloads produced by a web/desktop instance).
- No periodic background polling beyond the bounded startup/restart-triggered scan.

## Affected surfaces

- `packages/web/server/lib/session-assist/runtime.js` — the watcher that generates recaps/suggestions for idle sessions; now also detects broken turns and runs the recovery.
- `packages/web/server/lib/opencode/lifecycle.js` — new optional `onOpenCodeReady` dependency (default `null`, no behavior change when absent) fired after every successful serve (re)start; never awaited, best-effort.
- `packages/web/server/index.js` — wires `getStartupDirectories` (the shared MRU directory list, extracted from the lifecycle warmup block — same behavior) and the `onOpenCodeReady` hook.
- Persisted/external contract: new `metadata.openchamber.assistRetry` (server-internal bookkeeping; ignored by all existing clients — UI only reads `metadata.openchamber.assist`); `metadata.openchamber.assist.recap` may now describe a failure instead of invented content; new settings key `sessionAutoRetryEnabled` (default on, read from OpenChamber `settings.json`, absent → on).
- Desktop/mobile/VSCode runtimes unaffected: the change is entirely in the web server process; clients consume the same assist payload shape as before.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Executable server source + persisted metadata contract + added source file | Smallest scoped change; `runtime.test.js` added with focused tests; DOCUMENTATION.md updated; dead-code run; validation at the narrowest level that covers real risk (session-assist + lifecycle suites, then the full server suite). |
| `sync-state-invariants` | Change touches live session status, reconnect/reconciliation after serve restarts, and directory-scoped scans | Live status (`/session/status`, `session.status` events) is the sole discriminator for "broken turn" — never text heuristics; failure ≠ empty (`fetchSessionStatuses`/`fetchRecentMessages` return `null` on failure and the scan retries on that real failure signal); per-directory try/catch so one failed directory never blocks others; retry only with confirmed-idle status (no duplicate prompts); bounded retries with `unref`'d timers. |
| `session-assist/DOCUMENTATION.md`, `lib/opencode` docs | Owning module documentation for both touched modules | Updated `session-assist/DOCUMENTATION.md` (failed-turn recovery, startup scan, triggers, limitations); lifecycle change documented in code comments. |
| AGENTS.md always-on constraints | Server-side behavior change; correctness invariants; no secrets | Authoritative state over heuristics (status-gated); temporary fallbacks scoped and cleared (retry counters scoped per message id); no secrets logged; owning docs updated. |

## Validation

| Check | Result |
|---|---|
| `node --check` on `runtime.js`, `lifecycle.js`, `index.js`, test files | OK |
| `bun x vitest run server/lib/session-assist` | 15/15 passed |
| `bun x vitest run server/lib/opencode/lifecycle.test.js` | 18/18 passed (3 new `onOpenCodeReady` tests) |
| `bun x vitest run server` (full web server suite, warm cache) | 994 passed / 2 skipped; known pre-existing timing-flaky tests (`walkthrough/routes.test.js`, occasionally `relay/tunnel-codec.test.js`, `ui-auth.test.js`, `event-stream/runtime.test.js`) fail under full-load runs but pass in isolation (verified: walkthrough 6/6, tunnel-codec 5/5, ui-auth 6/6); none touch this change |
| `bun run dead-code` | No findings related to this change (baseline report unchanged) |
| Live end-to-end | Not run: the fix is deployed only after merge/restart; the failure scenarios were verified against real session data from the production database (`opencode.db`) and server logs during development |

Not verified: no live restart of OpenChamber instances with the fix (requires deployment); no Windows/macOS-specific behavior (server-only JS, no platform APIs).

## Visual evidence

No user-visible rendering change: the diff is entirely server-side. The existing recap/suggestion components already render `metadata.openchamber.assist`; this change only affects *when* and *what content* the server writes (honest failure recap instead of a recap of an empty turn, or a retry first). There is no before/after UI state to capture; the observable difference is that a previously silent session stop now either resumes automatically or surfaces an honest explanation.

## Risks and failure behavior

- **Runaway retry loop**: prevented by the hard cap (2), the write-first counter, and counter reset on message-id change; after exhaustion the runtime writes the honest recap and stops.
- **Duplicate prompt into a running turn**: prevented by three gates — 60s quiet window + tail-move check + live status check immediately before `prompt_async`; if the status cannot be confirmed (fetch failure) the retry is dropped (never re-prompt without proof of idle).
- **Scan overhead**: bounded (5 directories × 8 sessions, 30-minute session age window, one scan per minute max, `unref`'d timers, best-effort); cannot block startup or the lifecycle (hook is fire-and-forget).
- **Rollback/compatibility**: reverting the commit removes the behavior; stale `assistRetry` metadata is harmless (overwritten on next use, not rendered, ignored by older clients); absent settings key defaults to enabled; older OpenChamber versions ignore the new metadata key.
- **Orphaned tool subprocesses** after a hard serve kill cannot be cancelled (OpenCode limitation) — documented in the module docs.
- **Security**: no secrets or sensitive content are logged or persisted beyond existing metadata patterns; the continuation prompt contains no conversation content.
