### PR TITLE
fix(ui): never auto-send the message queue into a streaming turn

### DIFF
--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { Agent } from '@opencode-ai/sdk/v2';
+import type { Agent, Message } from '@opencode-ai/sdk/v2';
 import type { QueuedMessage } from '../stores/messageQueueStore';
+import { ChildStoreManager } from '@/sync/child-store';
+import { setSyncRefs } from '@/sync/sync-refs';
 
 let visibleAgents: Agent[] = [];
 const sendMessageCalls: unknown[][] = [];
@@ -32,6 +34,7 @@ import {
   createQueuedAutoSendRetryScheduler,
   getQueuedAutoSendRetryDelayMs,
   isQueuedAutoSendBackedOff,
+  resolveQueuedSessionStatusType,
   sendQueuedAutoSendPayload,
   shouldDispatchQueuedAutoSend,
 } from './useQueuedMessageAutoSend';
@@ -116,6 +119,59 @@ describe('queued auto-send retry backoff', () => {
     expect(isQueuedAutoSendBackedOff(failure, 'queued-1', 10_000)).toBe(false);
     expect(isQueuedAutoSendBackedOff(failure, 'queued-2', 9_999)).toBe(false);
     expect(isQueuedAutoSendBackedOff(undefined, 'queued-1', 0)).toBe(false);
+  });
+});
+
+describe('resolveQueuedSessionStatusType', () => {
+  const DIRECTORY = '/repo';
+
+  const assistantMessage = (id: string, completed?: number): Message => ({
+    id,
+    role: 'assistant',
+    sessionID: 'ses_1',
+    time: { created: 1, ...(completed !== undefined ? { completed } : {}) },
+  } as Message);
+
+  let childStores: ChildStoreManager;
+
+  beforeEach(() => {
+    childStores = new ChildStoreManager();
+    const store = childStores.ensureChild(DIRECTORY, { bootstrap: false });
+    store.setState({ status: 'complete', session_status: {}, message: {} });
+    setSyncRefs({} as never, childStores, DIRECTORY);
+  });
+
+  test('treats a session with an in-flight assistant turn as busy even when the status entry is missing', () => {
+    // The server status map only lists busy/retry sessions, so a missed busy
+    // event leaves NO status entry while the turn is still streaming. The
+    // queue gate must not read that absence as idle: queued prompts would be
+    // dispatched into the running turn and merged into one model response.
+    childStores.ensureChild(DIRECTORY, { bootstrap: false }).setState({
+      message: { ses_1: [assistantMessage('msg_streaming')] },
+    });
+
+    expect(resolveQueuedSessionStatusType('ses_1', DIRECTORY)).toBe('busy');
+  });
+
+  test('resolves an explicit busy or retry status entry', () => {
+    const store = childStores.ensureChild(DIRECTORY, { bootstrap: false });
+    store.setState({ session_status: { ses_1: { type: 'busy' } } });
+    expect(resolveQueuedSessionStatusType('ses_1', DIRECTORY)).toBe('busy');
+    store.setState({ session_status: { ses_1: { type: 'retry', attempt: 2, message: 'boom', next: 30 } } });
+    expect(resolveQueuedSessionStatusType('ses_1', DIRECTORY)).toBe('retry');
+  });
+
+  test('resolves idle when the trailing assistant message has completed', () => {
+    const store = childStores.ensureChild(DIRECTORY, { bootstrap: false });
+    store.setState({ message: { ses_1: [assistantMessage('msg_done', 5)] } });
+    expect(resolveQueuedSessionStatusType('ses_1', DIRECTORY)).toBe('idle');
+  });
+
+  test('resolves an explicit idle entry and unknown sessions as idle', () => {
+    const store = childStores.ensureChild(DIRECTORY, { bootstrap: false });
+    store.setState({ session_status: { ses_1: { type: 'idle' } } });
+    expect(resolveQueuedSessionStatusType('ses_1', DIRECTORY)).toBe('idle');
+    expect(resolveQueuedSessionStatusType('ses_unknown', DIRECTORY)).toBe('idle');
   });
 });
 

--- a/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
+++ b/packages/ui/src/hooks/useQueuedMessageAutoSend.ts
@@ -173,11 +173,50 @@ export const shouldDispatchQueuedAutoSend = (
     && currentStatusType === 'idle';
 };
 
+/**
+ * Resolve the live status the queue gate should honor for a session.
+ *
+ * The server's `/session/status` map only lists busy/retry sessions — idle
+ * sessions are absent — so a missing entry means "idle per the snapshot", not
+ * "no information". A missed busy event therefore leaves no entry while a turn
+ * is still streaming. The trailing in-flight assistant message is the live
+ * evidence of that running turn: treat it as busy so the queue never dispatches
+ * into it (mirrors `useSessionActivity`'s fallback). The entry becomes idle the
+ * moment the message completes or an idle status event lands. This reads the
+ * directory child store directly so both the effect-loop gate and the
+ * dispatch-time re-check agree.
+ */
+export const resolveQueuedSessionStatusType = (
+  sessionId: string,
+  directory: string,
+): SessionStatusType => {
+  const state = getDirectoryState(directory);
+  const statusType = state?.session_status?.[sessionId]?.type;
+  if (statusType === 'busy' || statusType === 'retry') {
+    return statusType;
+  }
+  const sessionMessages = state?.message?.[sessionId];
+  const lastMessage = sessionMessages && sessionMessages.length > 0
+    ? sessionMessages[sessionMessages.length - 1]
+    : undefined;
+  if (
+    lastMessage?.role === 'assistant'
+    && typeof (lastMessage as { time?: { completed?: number } }).time?.completed !== 'number'
+  ) {
+    return 'busy';
+  }
+  return 'idle';
+};
+
 export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?: boolean }) {
   const enabled = typeof enabledOrOptions === 'boolean' ? enabledOrOptions : (enabledOrOptions?.enabled ?? true);
   const queuedMessages = useMessageQueueStore((state) => state.queuedMessages);
   const autoReviewRuns = useAutoReviewStore((state) => state.runsByOriginalSessionID);
   const sessionStatusRecord = useDirectorySync((state) => state.session_status);
+  // Message completion clears the in-flight fallback in
+  // resolveQueuedSessionStatusType; subscribe so the queue drains the moment
+  // the trailing assistant message completes even if status events were missed.
+  const sessionMessages = useDirectorySync((state) => state.message);
   const currentDirectory = useDirectoryStore((state) => state.currentDirectory);
 
   const inFlightSessionsRef = React.useRef<Set<string>>(new Set());
@@ -216,7 +255,7 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
         return;
       }
 
-      const currentStatus = getDirectoryState(target.directory)?.session_status?.[sessionId]?.type ?? 'idle';
+      const currentStatus = resolveQueuedSessionStatusType(sessionId, target.directory);
       if (currentStatus !== 'idle') {
         return;
       }
@@ -294,7 +333,7 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
       const target = parseMessageQueueKey(key);
       if (!target || target.runtimeKey !== getRuntimeKey() || target.directory !== currentDirectory) return;
       const { sessionId } = target;
-      const currentStatusType = (statusRecord[sessionId]?.type ?? 'idle') as SessionStatusType;
+      const currentStatusType = resolveQueuedSessionStatusType(sessionId, target.directory);
       const previousStatusType = previousStatusRef.current.get(sessionId);
       const wasAutoReviewBlocked = autoReviewBlockedSessionsRef.current.has(sessionId);
       const isAutoReviewRunning = useAutoReviewStore.getState().isRunningForSession(sessionId);
@@ -315,5 +354,5 @@ export function useQueuedMessageAutoSend(enabledOrOptions?: boolean | { enabled?
     });
 
     previousStatusRef.current = nextStatusMap;
-  }, [enabled, queuedMessages, sessionStatusRecord, autoReviewRuns, currentDirectory, retryTick, retryScheduler]);
+  }, [enabled, queuedMessages, sessionStatusRecord, sessionMessages, autoReviewRuns, currentDirectory, retryTick, retryScheduler]);
 }


### PR DESCRIPTION
## Intent

When the session has a trailing **in-flight assistant message** (a turn is streaming) but the client's `session_status` map has **no entry** for it, the queued-message auto-send hook treated the session as `idle` and dispatched queued follow-up prompts into the running turn.

Why this state occurs: OpenCode's `/session/status` map only lists busy/retry sessions (idle sessions are absent), and a busy event can be missed on a reconnect/background window. The composer correctly recognized the session as busy (via the in-flight-message fallback in `useSessionActivity`) and queued the prompts — but the auto-send hook used a weaker gate (`session_status?.[id]?.type ?? 'idle'`) and drained the queue immediately. OpenCode then merged both prompt_async calls into a **single model turn** (confirmed in the incident: two user messages with empty `parentID`, one assistant response with `parent = P2`, model reasoning referencing both prompts), instead of waiting for the first response and sending the second sequentially.

The fix makes the queue gate honor the same live evidence as the composer: a trailing in-flight assistant message means busy, so the queue dispatches only after the turn completes (message completed or idle status event).

## Non-goals

- No change to `delivery: 'steer'` semantics in the web runtime (the SDK drops `delivery` for `promptAsync`; that is a separate, pre-existing issue tracked separately).
- No change to the composer's queue/steer decision logic in `ChatInput.tsx`.
- No change to the server-owned message queue (`packages/web/server/lib/message-queue`), which is used by messenger surfaces and already drains one item at a time.

## Affected surfaces

- `packages/ui` — shared UI library consumed by web, desktop (Electron), VS Code, hosted mobile, and Capacitor mobile surfaces. The fix lives in `useQueuedMessageAutoSend`, which is mounted in `SyncRuntimeEffects` for every surface, so all runtimes benefit identically; the change is runtime-agnostic (pure store-state reads).
- User-visible behavior: while a session is busy, queued follow-ups stay queued and are sent one-by-one after the turn completes, instead of being merged into the running turn.
- Persisted state: none — `resolveQueuedSessionStatusType` reads live child-store state only; no persisted schema, settings, or storage changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `sync-state-invariants` skill | Change touches the queued auto-send gate, live status derivation, and fallback scoping ("derive live activity from live channels, not persisted history"; "scope delayed-live fallbacks to the active entity and clear them when authoritative state arrives") | The fallback uses the live in-flight trailing message; it clears automatically when the message completes or an idle status event lands (the effect now subscribes to `state.message` for exactly that edge). |
| `openchamber-change-discipline` skill | Shared UI behavior change; smallest complete change; regression test first | Extracted the inline gate into `resolveQueuedSessionStatusType` without behavior change (verified: full sync suite identical to baseline), then added a red/green regression test, then the minimal fallback. |
| `sync/DOCUMENTATION.md` | Owning sync documentation | Reviewed; it does not document the auto-send gate internals, so no doc update required. Module ownership and contracts are unchanged. |
| `AGENTS.md` (Runtime Boundaries, Correctness Invariants) | Shared UI must define intentional behavior for every runtime | The fix is runtime-agnostic; all surfaces mount the same hook. |

## Validation

| Check | Result |
|---|---|
| Regression test before fix (red) | `expect(resolveQueuedSessionStatusType(...)).toBe('busy')` failed — received `"idle"` (bug reproduced: in-flight assistant + missing status entry) |
| Regression test after fix (green) | `bun test packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts` → 15 pass, 0 fail (4 new tests: in-flight→busy, busy/retry entry, completed message→idle, explicit idle/unknown→idle) |
| Queue store tests | `bun test packages/ui/src/stores/messageQueueStore.test.ts` → 7 pass, 0 fail |
| All hooks tests | `bun test packages/ui/src/hooks/` → 21 pass, 0 fail |
| Sync suite | `bun test packages/ui/src/sync/` → 375 pass; **49 fail + 2 errors — identical to clean `origin/main` baseline** (verified by stashing the change and re-running: all failures are pre-existing environment issues in worktree-store/input-store/etc., none related to this change) |
| Workspace type-check | `bun run type-check` → all 5 packages (mobile, ui, web, electron, root) exit 0 |
| Workspace lint | `bun run lint` → all 5 packages exit 0 |
| Build | `bun run build:web` (vite bundle of the shared UI) → `✓ built in 2m 33s`, no errors |
| Dead code | `bun run dead-code` → new export `resolveQueuedSessionStatusType` not flagged |
| Not verified | Full `bun run build` (electron packaging/mobile assets) and live runtime behavior on each device surface; static checks only for those. |

## Visual evidence

No user-visible rendering change. The diff only adds a status-resolution helper and two call sites inside `useQueuedMessageAutoSend`; it cannot alter any rendered element, styling, or layout. The observable behavior change is temporal (queued prompts now wait for the turn to finish) and is covered by the regression test asserting the gate's output.

## Risks and failure behavior

- **Missed idle events**: if both the busy and idle status events are missed, the queue now waits until the trailing message completes (the new `state.message` subscription re-runs the effect and the fallback clears) or any status event lands. Worst case is a delayed send, never a premature one — strictly safer than the previous behavior.
- **Turn that never completes** (hung step): the fallback keeps the queue blocked, same as the composer's existing behavior for the stuck-turn case; the existing Stop/abort path and stall-watchdog handle that scenario unchanged.
- **Rollback**: no persisted data, settings, or IDs change; reverting the commit fully restores prior behavior.
- **Performance**: the effect adds one subscription to `state.message` (whole-store message record), which changes on message create/complete only — streaming part updates touch `state.part`, not `state.message`. The dispatch gate reads the child store synchronously as before.
- **Cross-runtime**: no runtime-specific branches; all surfaces mount the same hook.
- **Security/data**: no new logging, secrets, or persisted content.
