### PR TITLE
fix(deps): upgrade adm-zip to 0.6.0 to fix GHSA-xcpc-8h2w-3j85

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -240,7 +240,7 @@
       "dependencies": {
         "@openchamber/ui": "workspace:*",
         "@opencode-ai/sdk": "1.18.12",
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "jsonc-parser": "^3.3.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -268,7 +268,7 @@
         "@octokit/rest": "^22.0.1",
         "@opencode-ai/sdk": "1.18.12",
         "@simplewebauthn/server": "13.3.1",
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "bun-pty": "^0.4.5",
         "compression": "^1.8.1",
         "cron-parser": "^4.9.0",
@@ -1487,7 +1487,7 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "adm-zip": ["adm-zip@0.5.16", "", {}, "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="],
+    "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -245,7 +245,7 @@
   "dependencies": {
     "@openchamber/ui": "workspace:*",
     "@opencode-ai/sdk": "1.18.12",
-    "adm-zip": "^0.5.16",
+    "adm-zip": "^0.6.0",
     "jsonc-parser": "^3.3.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,7 +27,7 @@
     "@octokit/rest": "^22.0.1",
     "@opencode-ai/sdk": "1.18.12",
     "@simplewebauthn/server": "13.3.1",
-    "adm-zip": "^0.5.16",
+    "adm-zip": "^0.6.0",
     "bun-pty": "^0.4.5",
     "compression": "^1.8.1",
     "cron-parser": "^4.9.0",

--- a/packages/web/server/lib/skills-catalog/clawdhub/install.test.js
+++ b/packages/web/server/lib/skills-catalog/clawdhub/install.test.js
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import AdmZip from 'adm-zip';
+
+// Mock the ClawdHub network client so no real HTTP happens. The download
+// function is what feeds the ZIP buffer into adm-zip inside install.js.
+vi.mock('./api.js', () => ({
+  downloadClawdHubSkill: vi.fn(),
+  fetchClawdHubSkillInfo: vi.fn(),
+}));
+
+const { downloadClawdHubSkill } = await import('./api.js');
+const { installSkillsFromClawdHub } = await import('./install.js');
+
+/**
+ * Build a real ZIP archive with adm-zip (the dependency under test).
+ * Returns the raw Buffer, mirroring what downloadClawdHubSkill resolves to.
+ */
+function buildSkillZip(entries) {
+  const zip = new AdmZip();
+  for (const [entryName, content] of Object.entries(entries)) {
+    zip.addFile(entryName, Buffer.from(content, 'utf8'));
+  }
+  return zip.toBuffer();
+}
+
+describe('installSkillsFromClawdHub (adm-zip extraction path)', () => {
+  let userSkillDir;
+
+  beforeEach(async () => {
+    // Keep the target dir under os.tmpdir() so the temp->target rename in
+    // install.js stays on one filesystem (avoids EXDEV cross-device errors).
+    userSkillDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'clawdhub-test-skills-'));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(userSkillDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('extracts a real ZIP (incl. nested subdirectories) into the target skill dir', async () => {
+    const skillMd = 'name: demo-skill\ndescription: adm-zip extraction regression guard\n';
+    const nested = 'nested file content for subdirectory extraction check\n';
+    downloadClawdHubSkill.mockResolvedValue(
+      buildSkillZip({ 'SKILL.md': skillMd, 'nested/data.txt': nested }),
+    );
+
+    const result = await installSkillsFromClawdHub({
+      scope: 'user',
+      targetSource: 'opencode',
+      userSkillDir,
+      // Non-'latest' version avoids the fetchClawdHubSkillInfo resolve branch.
+      selections: [{ clawdhub: { slug: 'demo-skill', version: '1.0.0' } }],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.installed).toEqual([
+      { skillName: 'demo-skill', scope: 'user', source: 'opencode' },
+    ]);
+    expect(result.skipped).toEqual([]);
+
+    // downloadClawdHubSkill received the resolved (non-latest) version.
+    expect(downloadClawdHubSkill).toHaveBeenCalledWith('demo-skill', '1.0.0');
+
+    // adm-zip actually wrote the files, preserving the nested subdirectory.
+    const targetDir = path.join(userSkillDir, 'demo-skill');
+    const skillMdPath = path.join(targetDir, 'SKILL.md');
+    const nestedPath = path.join(targetDir, 'nested', 'data.txt');
+
+    expect(fs.existsSync(skillMdPath)).toBe(true);
+    expect(fs.existsSync(nestedPath)).toBe(true);
+    expect(fs.readFileSync(skillMdPath, 'utf8')).toBe(skillMd);
+    expect(fs.readFileSync(nestedPath, 'utf8')).toBe(nested);
+  });
+
+  it('skips a package whose extracted contents lack SKILL.md', async () => {
+    // Valid ZIP, but no SKILL.md at the root -> install.js must skip it and
+    // must NOT create the target dir. This exercises the extractAllTo path
+    // followed by the post-extraction validation.
+    downloadClawdHubSkill.mockResolvedValue(
+      buildSkillZip({ 'README.md': 'no skill manifest here\n' }),
+    );
+
+    const result = await installSkillsFromClawdHub({
+      scope: 'user',
+      targetSource: 'opencode',
+      userSkillDir,
+      selections: [{ clawdhub: { slug: 'broken-skill', version: '1.0.0' } }],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.installed).toEqual([]);
+    expect(result.skipped).toEqual([
+      { skillName: 'broken-skill', reason: 'SKILL.md not found in downloaded package' },
+    ]);
+    expect(fs.existsSync(path.join(userSkillDir, 'broken-skill'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Intent

`adm-zip <0.6.0` has a high-severity vulnerability (GHSA-xcpc-8h2w-3j85): a crafted ZIP can trigger a ~4GB memory allocation. This upgrades the pinned dependency from `^0.5.16` to `^0.6.0` in the packages that declare it, closing the advisory. No behavior change for callers.

## Non-goals

- No refactor of the ClawdHub install flow beyond the dependency bump.
- No change to the project version (`1.18.1`).
- No removal of `@types/adm-zip` (0.6.0 ships built-in types, but dropping the type package is out of scope here).

## Affected surfaces

- `packages/web` — declares and uses `adm-zip` at `server/lib/skills-catalog/clawdhub/install.js` (`new AdmZip(Buffer.from(zipBuffer)).extractAllTo(tempDir, true)`).
- `packages/vscode` — declares `adm-zip` as a dependency; no code reference, so runtime behavior is unaffected (declaration bump only).
- `bun.lock` — resolves `adm-zip@0.5.16 → adm-zip@0.6.0`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` skill | Dependency/lockfile change | Smallest complete change (only the adm-zip lines + one focused regression test); ran workspace-wide checks + affected build per the matrix |
| AGENTS.md "Do not add dependencies unless explicitly requested" | Touches package.json deps | Only upgrades an existing dependency's version; adds no new dependency |
| `packages/web/server/lib/skills-catalog/DOCUMENTATION.md` | Owns the install path using adm-zip | Confirmed `new AdmZip(buffer)` + `extractAllTo` APIs are unchanged in 0.6.0 (only bug fixes), so documented behavior holds |

## Validation

| Check | Result |
|---|---|
| `bun audit` (project scope) | No `adm-zip` advisory remaining |
| `bun run type-check` | Pass (5 workspaces, exit 0) |
| `bun run lint` | Pass (5 workspaces, exit 0) |
| `bun run build` | Pass (exit 0) |
| `bun run dead-code` | Ran; no adm-zip/new-test findings (pre-existing unused exports only) |
| `bun run --filter '@openchamber/web' test` | New `install.test.js`: 2 passed — builds a real ZIP with adm-zip and asserts `extractAllTo` restores files incl. nested subdirectories into the target skill dir |
| CI `pr checks` (oc-review.yml) on the source branch | Green (build + type-check + lint + electron architecture/updater tests) |

Note: 1 pre-existing failure in `packages/web/src/api/git.test.ts` (`getGitRangeDiff` mock) is unrelated to this change and untouched by it.

## Visual evidence

No user-visible change. Dependency version bump plus a backend regression test; it does not alter any rendered UI.

## Risks and failure behavior

Low risk. The 0.6.0 changes to `extractAllTo` are bug fixes only (utimes failures now ignored per upstream #379; directory permissions restored per #530); the constructor and method signatures are identical to 0.5.16, so no call-site adaptation was required. Rollback is a simple revert of the dependency bump. The added test guards the extraction path against future regressions.