### PR TITLE
fix(sidebar): make session quick archive button look interactive

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -229,10 +229,15 @@ const QuickSessionAction = React.memo(function QuickSessionAction({
         <button
           type="button"
           className={cn(
-            'inline-flex items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 transition-opacity',
+            // Visible button chrome (elevated fill + hairline border) so the
+            // quick archive action reads as a clickable button, not a passive
+            // status glyph. Mirror of the shared Button outline variant, kept
+            // inline because this memoized row button needs tiny sizes and
+            // Shift-aware handlers the shared Button cannot express.
+            'inline-flex items-center justify-center rounded-md border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 transition-[opacity,background-color,border-color]',
             shiftHeld
-              ? 'text-destructive hover:text-destructive'
-              : 'text-muted-foreground hover:text-foreground',
+              ? 'border-destructive/50 bg-[var(--surface-elevated)] text-destructive hover:bg-destructive/10 hover:text-destructive'
+              : 'border-border/60 bg-[var(--surface-elevated)] text-muted-foreground hover:bg-interactive-hover hover:text-foreground',
             buttonSizeClass,
           )}
           aria-label={label}


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-252

The hover-revealed quick archive action on session rows in the sidebar looked like a passive status indicator, not a button: a 16px ghost icon with muted foreground color, no background, no border, and no hover fill. This change gives it visible button chrome (elevated fill + hairline border + hover fill, mirroring the shared `Button` `outline` variant) so it reads as a clickable control. The Shift-held delete variant gets a destructive border and destructive hover tint. All existing action behavior is preserved: click archives, Shift+click hard-deletes, tooltip and aria-label unchanged, same hover-reveal and focus behavior.

## Non-goals

- No change to sizes or the row padding-reservation logic (`pr-7`/`pr-13` classes), which would be needed if the button grew.
- No change to the bulk-action bar, the row context menu, or the Archive page — those already have visible affordance.
- No change to the "open in editor" (VS Code) or "..." menu row actions; the issue names only the archive action.

## Affected surfaces

- `packages/ui` — `SessionNodeItem.tsx` `QuickSessionAction` component. Affects the sessions sidebar on web, desktop (Electron), and VS Code surfaces that render session rows (the button renders in the same row for all runtimes; `alwaysShowActions`/mobile renders it at h-6 w-6 with the same chrome). No persisted state or external contracts touched.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md: theme tokens, no hardcoded colors; shared UI primitives; hover only on interactive elements | Button styling change in shared UI | Uses `--surface-elevated`, `--border`, `--interactive-hover`, `--destructive` tokens via existing utilities; hover states only on the interactive element; mirrors the shared `Button` outline variant classes inline because the memoized row button needs tiny sizes and Shift-aware handlers the shared `Button` cannot express (documented in a comment) |
| theme-system skill: tokens-and-examples, icons references | Choosing colors for an interactive control | Kept the `Icon` sprite contract (`archive`, `delete-bin`); no new icons; no palette colors introduced |
| locale-ui-patterns skill | User-facing text/labels | No new strings; existing `sessions.sidebar.bulkActions.archive/delete` keys and aria-labels reused |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` in `packages/ui` (`tsc --noEmit`) | Passed, no errors |
| `bun run lint` in `packages/ui` (`eslint "./src/**/*.{ts,tsx}" --config ../../eslint.config.js`) | Passed, no errors |
| `bun run dead-code` | Not run — no files added/deleted/renamed and no exports/entrypoints changed (single-component class change) |
| Focused tests | None exist for `SessionNodeItem` (only `sessionNodeItemUtils.test.ts` and `sessionNodeItemUtils.ts` helpers, untouched) |

Not verified: no live browser/Electron run in this environment, so the hover-reveal rendering was not observed at runtime.

## Visual evidence

Screenshots could not be taken in this environment (no display/browser available). Expected rendering: on row hover (or focus-within), the archive icon now appears inside a small rounded button with an elevated fill (`--surface-elevated`), a hairline `--border` border, and muted foreground icon; hovering the button fills it with `--interactive-hover` and brightens the icon to foreground. With Shift held the same button shows a `--destructive` border/tint and a delete-bin icon, turning `--destructive` on hover. In always-show (touch) rows the same chrome renders at 24px. Previously the same icon rendered as a bare ghost glyph with no border or fill.

## Risks and failure behavior

- Failure mode: none new — the button is additive chrome; handlers, reveal logic, and layout reservations unchanged.
- Visual contrast: `--surface-elevated` fill is theme-aware and exists in all built-in themes (light/dark/high-contrast); `border-border/60` matches the shared `Button` outline variant used throughout the app. The fill sits above row selection/active tints (`bg-interactive-selection`, `bg-primary/10`) — both are distinct surfaces, and the elevated fill is intentionally opaque to keep the button legible on any row state.
- Performance: no new renders; the memoized `QuickSessionAction` structure is unchanged.
- Cross-runtime: identical classes on web, Electron, VS Code, and mobile renders; VS Code hover-reveal classes are untouched.
