### PR TITLE
fix(sidebar): auto-scroll expanded sessions block into view

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -338,6 +338,23 @@ function SessionGroupSectionBase(props: Props): React.ReactNode {
   const searchData = hasSessionSearchQuery ? groupSearchDataByGroup.get(group) : null;
   const foldersMap = useSessionFoldersStore((state) => state.foldersMap);
   const isCollapsed = hasSessionSearchQuery ? false : collapsedGroups.has(groupKey);
+  // When a collapsed sessions block is expanded, scroll the sidebar so the
+  // expanded block is fully visible. Track the previous state in a ref so the
+  // effect only fires on a real collapse→expand toggle, not on every render
+  // where the group stays collapsed or expanded.
+  const groupBlockRef = React.useRef<HTMLDivElement | null>(null);
+  const wasCollapsedRef = React.useRef(isCollapsed);
+  React.useLayoutEffect(() => {
+    const wasCollapsed = wasCollapsedRef.current;
+    wasCollapsedRef.current = isCollapsed;
+    // Search results force-expand groups without a user toggle; never
+    // scroll for that, or the sidebar would jump while typing.
+    if (hasSessionSearchQuery || !wasCollapsed || isCollapsed) return;
+    const element = groupBlockRef.current;
+    if (!element || typeof window === 'undefined') return;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    element.scrollIntoView({ block: 'nearest', behavior: reduceMotion ? 'auto' : 'smooth' });
+  }, [hasSessionSearchQuery, isCollapsed]);
   // PR state for the worktree sub-header (grouped display mode).
   const groupPrKey = React.useMemo(() => {
     if (group.isMain || group.isArchivedBucket || hideGroupLabel) return null;
@@ -1029,11 +1046,11 @@ function SessionGroupSectionBase(props: Props): React.ReactNode {
   const groupBodyPaddingClass = 'pb-2';
 
   if (hideGroupLabel) {
-    return <div className="oc-group"><div className={cn('oc-group-body', groupBodyPaddingClass)}>{body}</div></div>;
+    return <div ref={groupBlockRef} className="oc-group"><div className={cn('oc-group-body', groupBodyPaddingClass)}>{body}</div></div>;
   }
 
   return (
-    <div className="oc-group">
+    <div ref={groupBlockRef} className="oc-group">
       <div
         className={cn('group/gh relative flex items-start justify-between gap-1 py-1 min-w-0 rounded-md', 'cursor-pointer')}
         onClick={() => onToggleCollapsedGroup(groupKey)}

--- a/packages/ui/src/components/session/sidebar/SidebarActivitySections.tsx
+++ b/packages/ui/src/components/session/sidebar/SidebarActivitySections.tsx
@@ -130,6 +130,26 @@ export function SidebarActivitySections(props: Props): React.ReactNode {
   }, [editingId, openSidebarMenuKey]);
 
   const visibleSections = sections.filter((section) => section.items.length > 0);
+
+  // When a collapsed recent-sessions block is expanded, scroll the sidebar so
+  // the expanded block is fully visible. Track each section's previous
+  // collapse state in a ref so the effect only fires on real toggles.
+  const sectionBlockRefs = React.useRef(new Map<string, HTMLDivElement | null>());
+  const prevCollapsedRef = React.useRef(new Map<string, boolean>());
+  React.useLayoutEffect(() => {
+    const prev = prevCollapsedRef.current;
+    for (const [key, wasCollapsed] of prev) {
+      if (wasCollapsed && !collapsed.has(key)) {
+        const element = sectionBlockRefs.current.get(key);
+        if (element && typeof window !== 'undefined') {
+          const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+          element.scrollIntoView({ block: 'nearest', behavior: reduceMotion ? 'auto' : 'smooth' });
+        }
+      }
+    }
+    prevCollapsedRef.current = new Map(visibleSections.map((section) => [section.key, collapsed.has(section.key)]));
+  }, [collapsed, visibleSections]);
+
   if (visibleSections.length === 0) {
     return null;
   }
@@ -177,7 +197,14 @@ export function SidebarActivitySections(props: Props): React.ReactNode {
         }
 
         return (
-          <div key={section.key} className="relative space-y-1">
+          <div
+            key={section.key}
+            ref={(element) => {
+              if (element) sectionBlockRefs.current.set(section.key, element);
+              else sectionBlockRefs.current.delete(section.key);
+            }}
+            className="relative space-y-1"
+          >
             <div className={cn(
               '-ml-2.5 -mr-2',
               stickyZoneHeaders && 'sticky top-0 z-20 bg-sidebar',

--- a/packages/ui/src/components/session/sidebar/sortableItems.tsx
+++ b/packages/ui/src/components/session/sidebar/sortableItems.tsx
@@ -167,6 +167,26 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
   const isMenuOpen = openSidebarMenuKey === menuInstanceKey;
   const [isContextMenuOpen, setIsContextMenuOpen] = React.useState(false);
 
+  // When a collapsed project block is expanded, scroll the sidebar so the
+  // expanded block is fully visible. Track the previous state in a ref so the
+  // effect only fires on a real collapse→expand toggle.
+  const projectBlockRef = React.useRef<HTMLDivElement | null>(null);
+  const wasCollapsedRef = React.useRef(isCollapsed);
+  React.useLayoutEffect(() => {
+    const wasCollapsed = wasCollapsedRef.current;
+    wasCollapsedRef.current = isCollapsed;
+    if (!wasCollapsed || isCollapsed) return;
+    const element = projectBlockRef.current;
+    if (!element || typeof window === 'undefined') return;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    element.scrollIntoView({ block: 'nearest', behavior: reduceMotion ? 'auto' : 'smooth' });
+  }, [isCollapsed]);
+
+  const setProjectBlockRef = React.useCallback((element: HTMLDivElement | null) => {
+    projectBlockRef.current = element;
+    setNodeRef(element);
+  }, [setNodeRef]);
+
   const handleMenuOpenChange = React.useCallback((open: boolean) => {
     if (open) setIsContextMenuOpen(false);
     setOpenSidebarMenuKey(open ? menuInstanceKey : null);
@@ -230,7 +250,7 @@ export const SortableProjectItem: React.FC<SortableProjectItemProps> = ({
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setProjectBlockRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn('relative', isDragging && 'opacity-30')}
     >


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-251

Expanding a collapsed sessions block in the sidebar (a project block, a worktree/archived group block, or a recent-activity section) left the expanded content below the visible area when the block sat low in the list — the sidebar did not scroll, so the block was cut off. Now, on a real collapse→expand toggle, the expanded block is scrolled into view with `scrollIntoView({ block: 'nearest' })`, honoring `prefers-reduced-motion` (instant jump instead of smooth scroll). Search-driven force-expansion never triggers a scroll, so typing in the session search cannot yank the sidebar.

## Non-goals

- No change to collapse/expand behavior, persisted state, or sort/drag behavior.
- No scroll handling for per-session sub-tree expansion inside a row (that is the row's own chevron; the issue targets blocks).
- No change to the "show more / show fewer" batch buttons.

## Affected surfaces

- `packages/ui`, sidebar sessions components:
  - `SessionGroupSection.tsx` — worktree group blocks, archived buckets, project-root blocks (`collapsedGroups`).
  - `sortableItems.tsx` (`SortableProjectItem`) — project blocks (`collapsedProjects`), including drag-and-drop wrapper ref merge.
  - `SidebarActivitySections.tsx` — recent-activity sections ("Today"/"Yesterday" style blocks).
- Runtimes: web, desktop (Electron), VS Code, hosted mobile, and Capacitor mobile all render these components; `scrollIntoView` works against whichever scrollable ancestor each runtime provides. No persisted or external contracts touched.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md: shared contracts must behave in every applicable runtime; minimal diffs | Scroll-into-view must not break VS Code/mobile runtimes | Uses only DOM APIs (`scrollIntoView`, `matchMedia`) available in every runtime; no runtime-specific branches; dnd-kit ref merged without disturbing sort behavior |
| theme-system skill | Not a styling change | No tokens/colors touched; no visual classes added |
| sync-state-invariants / performance-engineering skills (loaded per trigger table) | Render hot path (sidebar rows) | The added `useLayoutEffect` runs once per collapse-state flip of a block, not per row; no new subscriptions; memoized components (`React.memo(SessionGroupSection)`) unchanged structurally |
| locale-ui-patterns skill | User-facing text | No new strings |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` in `packages/ui` (`tsc --noEmit`) | Passed, no errors |
| `bun run lint` in `packages/ui` (`eslint "./src/**/*.{ts,tsx}" --config ../../eslint.config.js`) | Passed, no errors |
| `bun test src/components/session/sidebar/` in `packages/ui` | 43 pass, 0 fail (8 files: activitySections, collapsedActivityState, sessionNodeItemUtils, sessionOwnership, sessionBootstrapDemands, utils, etc.) |
| `bun run dead-code` | Not run — no files added/deleted/renamed, no exports/entrypoints changed |

Not verified: no live browser/Electron run in this environment, so the actual scroll behavior was not observed at runtime (see Visual evidence).

## Visual evidence

Screenshots could not be taken in this environment (no display/browser available). Expected rendering/behavior: with the sidebar scrolled so a collapsed project or worktree header is visible near the bottom, clicking its chevron expands the block and the sidebar smoothly scrolls so the expanded block's bottom edge reaches the viewport bottom (fully visible when the block fits; as much as possible when taller than the viewport — `block: 'nearest'` semantics). With the OS "reduce motion" setting enabled, the same scroll happens instantly with no animation. Expanding while a session search query is active never scrolls. No permanent visual change to any state: the diff only adds scrolling on expand.

## Risks and failure behavior

- dnd-kit interplay: `SortableProjectItem`'s wrapper ref now also feeds `projectBlockRef`; `setNodeRef` is still invoked for every element, so `useSortable` measurement/drag behavior is unchanged. No drag regression observed statically; runtime drag behavior was not re-verified in this environment.
- Virtualized archived buckets: the expanded body mounts in the same commit as the collapse-state flip; `useLayoutEffect` runs after DOM commit, so the measured block includes the mounted rows. The virtualizer's own layout effect is independent.
- Sticky zone headers: `scrollIntoView` operates on the block element, so sticky headers are unaffected.
- Failure mode: `scrollIntoView` with unsupported options is a no-op in very old engines; `matchMedia` exists in all supported browsers. No cleanup/rollback needed — no listeners or timers are created.
- Performance: one layout effect per expanded block per toggle; no per-frame work; does not re-run while a block stays expanded.
