### PR TITLE
fix(sidebar): make worktree delete action discoverable

### DIFF
--- a/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionGroupSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Session } from '@opencode-ai/sdk/v2';
+import { ContextMenu } from '@base-ui/react/context-menu';
 
 // Archived buckets routinely grow into the hundreds/thousands; virtualize
 // when we cross this row count so the DOM stays bounded.
@@ -12,6 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Icon } from "@/components/icon/Icon";
 import { cn } from '@/lib/utils';
 import { sessionEvents } from '@/lib/sessionEvents';
+import { dropdownMenuItemClass, dropdownMenuPopupClass } from '@/components/ui/dropdown-menu.styles';
 import type { MainTab } from '@/stores/useUIStore';
 import { SessionFolderItem } from '../SessionFolderItem';
 import type { SortableDragHandleProps } from './sortableItems';
@@ -1032,30 +1034,42 @@ function SessionGroupSectionBase(props: Props): React.ReactNode {
     return <div className="oc-group"><div className={cn('oc-group-body', groupBodyPaddingClass)}>{body}</div></div>;
   }
 
-  return (
-    <div className="oc-group">
+  // Worktree rows get an explicit "Delete worktree" context-menu item (with
+  // danger styling, like session rows) so the destructive action stays
+  // discoverable even when the hover-revealed trash button is missed.
+  const canDeleteWorktree = Boolean(group.directory && !group.isMain && group.worktree);
+  const requestDeleteWorktree = () => {
+    if (!canDeleteWorktree) return;
+    sessionEvents.requestDelete({
+      sessions: allGroupSessions,
+      mode: 'worktree',
+      worktree: group.worktree,
+    });
+  };
+
+  const groupHeader = (
+    <div
+      className={cn('group/gh relative flex items-start justify-between gap-1 py-1 min-w-0 rounded-md', 'cursor-pointer')}
+      onClick={() => onToggleCollapsedGroup(groupKey)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onToggleCollapsedGroup(groupKey);
+        }
+      }}
+      aria-label={isCollapsed
+        ? t('sessions.sidebar.group.expandAria', { label: group.label })
+        : t('sessions.sidebar.group.collapseAria', { label: group.label })}
+      aria-expanded={!isCollapsed}
+    >
       <div
-        className={cn('group/gh relative flex items-start justify-between gap-1 py-1 min-w-0 rounded-md', 'cursor-pointer')}
-        onClick={() => onToggleCollapsedGroup(groupKey)}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            onToggleCollapsedGroup(groupKey);
-          }
-        }}
-        aria-label={isCollapsed
-          ? t('sessions.sidebar.group.expandAria', { label: group.label })
-          : t('sessions.sidebar.group.collapseAria', { label: group.label })}
-        aria-expanded={!isCollapsed}
-      >
-        <div
-          ref={dragHandleProps?.setActivatorNodeRef}
-          className={cn(
-            // pl-1.5 lines the branch icon up with the project-zone header
-            // icon (container pl-2.5 + 6px = band pl-4 past its -ml-2.5).
-            'min-w-0 flex flex-1 items-start gap-1 overflow-hidden pl-1.5 transition-[padding]',
+        ref={dragHandleProps?.setActivatorNodeRef}
+        className={cn(
+          // pl-1.5 lines the branch icon up with the project-zone header
+          // icon (container pl-2.5 + 6px = band pl-4 past its -ml-2.5).
+          'min-w-0 flex flex-1 items-start gap-1 overflow-hidden pl-1.5 transition-[padding]',
             groupHeaderRightPadding,
           )}
           {...(dragHandleProps?.listeners ?? {})}
@@ -1149,7 +1163,7 @@ function SessionGroupSectionBase(props: Props): React.ReactNode {
             </Tooltip>
           </div>
         ) : null}
-        {group.directory && !group.isMain && group.worktree ? (
+        {canDeleteWorktree ? (
           <div className={cn('absolute right-7 top-1/2 -translate-y-1/2 z-10 transition-opacity', alwaysShowActions ? 'opacity-100' : 'opacity-0 group-hover/gh:opacity-100 group-focus-within/gh:opacity-100')}>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -1157,13 +1171,13 @@ function SessionGroupSectionBase(props: Props): React.ReactNode {
                   type="button"
                   onClick={(event) => {
                     event.stopPropagation();
-                    sessionEvents.requestDelete({
-                      sessions: allGroupSessions,
-                      mode: 'worktree',
-                      worktree: group.worktree,
-                    });
+                    requestDeleteWorktree();
                   }}
-                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-interactive-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                  // Clear destructive affordance (elevated fill + destructive
+                  // border/text + destructive hover fill) so the worktree
+                  // delete action reads as a destructive button, not a faint
+                  // ghost icon. Mirrors the BulkActionBar destructive style.
+                  className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-destructive/50 bg-[var(--surface-elevated)] text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50"
                   aria-label={t('sessions.sidebar.group.actions.deleteGroupAria', { label: group.label })}
                 >
                   <Icon name="delete-bin" className="h-4 w-4" />
@@ -1196,7 +1210,40 @@ function SessionGroupSectionBase(props: Props): React.ReactNode {
              </Tooltip>
            </div>
          ) : null}
-      </div>
+    </div>
+  );
+
+  const worktreeContextMenu = canDeleteWorktree ? (
+    <ContextMenu.Portal>
+      <ContextMenu.Positioner className="app-region-no-drag z-50">
+        <ContextMenu.Popup
+          data-slot="dropdown-menu-content"
+          style={{
+            backgroundColor: 'var(--surface-elevated)',
+            color: 'var(--surface-elevated-foreground)',
+          }}
+          className={cn(dropdownMenuPopupClass, 'min-w-[180px]')}
+        >
+          <ContextMenu.Item
+            onClick={requestDeleteWorktree}
+            className={cn(dropdownMenuItemClass, 'text-destructive focus:text-destructive [&>svg]:mr-1')}
+          >
+            <Icon name="delete-bin" className="mr-1 h-4 w-4" />
+            {t('sessions.sidebar.group.actions.deleteWorktree')}
+          </ContextMenu.Item>
+        </ContextMenu.Popup>
+      </ContextMenu.Positioner>
+    </ContextMenu.Portal>
+  ) : null;
+
+  return (
+    <div className="oc-group">
+      {canDeleteWorktree ? (
+        <ContextMenu.Root>
+          <ContextMenu.Trigger render={groupHeader} />
+          {worktreeContextMenu}
+        </ContextMenu.Root>
+      ) : groupHeader}
       {!isCollapsed ? <div className={cn('oc-group-body', groupBodyPaddingClass)}>{body}</div> : null}
     </div>
   );


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-258

The delete action for a worktree in the sidebar was only reachable through a faint hover-revealed ghost icon, so it looked like decoration and was effectively undiscoverable. This PR makes it prominent and clear in two ways, both following existing codebase patterns for row actions:

1. The hover/focus-revealed trash button on the worktree header now carries explicit destructive chrome — elevated fill (`--surface-elevated`), destructive border and icon, destructive hover fill — mirroring the `BulkActionBar` destructive icon-button style and the destructive affordance introduced for the session quick-archive button.
2. Worktree rows now expose an explicit **Delete worktree** item in a right-click context menu with danger styling (`text-destructive focus:text-destructive`), mirroring the session-row context menu that already has a danger-styled delete item.

Both paths invoke the same `sessionEvents.requestDelete({ sessions, mode: 'worktree', worktree })`, so the existing confirmation dialog flow (archive linked sessions + remove worktree + remote cleanup, per `SessionDialogs.tsx`) is fully preserved.

## Non-goals

- No change to the confirmation dialog, delete semantics, or session archiving behavior.
- No change to the archived-bucket "delete all sessions" button (a different action; issue names worktree delete).
- No change to project-level rows, session rows, or the worktree management page (WorktreesPage already has explicit delete affordances).

## Affected surfaces

- `packages/ui` — `SessionGroupSection.tsx` worktree group header. Affects web, desktop (Electron), VS Code, hosted mobile, and Capacitor mobile renders of the sessions sidebar (the header renders in all runtimes; on touch/always-show runs the button is always visible and now reads clearly destructive). No persisted state or external contracts touched.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md: theme tokens, no hardcoded colors; shared UI primitives; hover only on interactive elements | New button/menu styling | Uses `--surface-elevated`, `--destructive`, `--interactive-hover` tokens via existing utilities; destructive tokens only on the destructive action; menu popup reuses `dropdownMenuPopupClass`/`dropdownMenuItemClass` shared styles |
| theme-system skill: tokens-and-examples, icons references | Choosing colors/icons for the affordance | No new icons (existing `delete-bin` sprite); no palette colors; danger styling follows the destructive button pattern used by `BulkActionBar` and session-row menu delete items |
| locale-ui-patterns skill | User-facing labels | No new strings — reuses existing `sessions.sidebar.group.actions.deleteWorktree` (tooltip/menu label) and `deleteGroupAria` keys, already present in all locale dictionaries |
| AGENTS.md: minimal diffs; preserve behavior unless the issue replaces it | Affordance change must not alter delete flow | The context-menu item and restyled button call the same `requestDelete` payload as before; only presentation and discoverability changed |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` in `packages/ui` (`tsc --noEmit`) | Passed, no errors |
| `bun run lint` in `packages/ui` (`eslint "./src/**/*.{ts,tsx}" --config ../../eslint.config.js`) | Passed, no errors |
| `bun test src/components/session/sidebar/` in `packages/ui` | 43 pass, 0 fail (8 files) |
| `bun run dead-code` | Not run — no files added/deleted/renamed, no exports/entrypoints changed |

Not verified: no live browser/Electron run in this environment, so the rendered button chrome, context-menu interaction, and the confirmation dialog were not exercised at runtime (see Visual evidence).

## Visual evidence

Screenshots could not be taken in this environment (no display/browser available). Expected rendering: on hovering or focusing a worktree header row, the trash icon now appears inside a small rounded button with an elevated fill, a `--destructive`/50 hairline border, and a destructive-red icon (previously a muted gray ghost glyph); hovering the button fills it with a `--destructive`/10 tint. Right-clicking a worktree header (or pressing the context-menu key) opens a popup with a single "Delete worktree" item showing a delete-bin icon in destructive red, matching the danger styling of the session-row context menu's delete item. On touch runs (always-show actions) the button is permanently visible in the destructive style.

## Risks and failure behavior

- Context menu vs. drag: group headers participate in manual project sorting via dnd-kit with `PointerSensor` (8px activation distance); the context menu opens on right-click, which cannot exceed the drag distance without an explicit drag, so no drag/menu conflict is expected. Session rows already combine the same two interactions in production.
- Header click behavior: the header still collapses/expands on left click; the context menu only intercepts right-click, so keyboard and click behavior is unchanged.
- Confirmation flow: unchanged — both affordances emit the identical `requestDelete` event consumed by `SessionDialogs`; no failure/rollback paths altered.
- Failure mode: if the popup fails to position (old engine), the button affordance still works; no data loss risk — delete always requires the existing confirmation dialog.
- Performance: one conditional context-menu mount per worktree header; no new subscriptions or per-frame work.
