### PR TITLE
fix(ui): add vertical rhythm to Sessions settings blocks

### DIFF
--- a/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
@@ -12,6 +12,7 @@ import {
   SETTINGS_SELECT_ROW_TRIGGER_CLASS,
   SETTINGS_SELECT_SIZE,
   SETTINGS_OPTION_STACK_CLASS,
+  SETTINGS_FIELDS_STACK_CLASS,
 } from '@/components/sections/shared/SettingsSection';
 import { SettingsInfoHint } from '@/components/sections/shared/SettingsInfoHint';
 import { updateDesktopSettings } from '@/lib/persistence';
@@ -330,7 +331,7 @@ export const DefaultsSettings: React.FC = () => {
   return (
     <>
       <SettingsSection title={t('settings.openchamber.defaults.title')} divider={false}>
-        <div className="space-y-0">
+        <div className={SETTINGS_FIELDS_STACK_CLASS}>
           <div className="mt-0 mb-1 typography-meta text-muted-foreground">
             {t('settings.openchamber.defaults.summaryPrefix')}
             {' '}
@@ -350,7 +351,7 @@ export const DefaultsSettings: React.FC = () => {
             )}
           </div>
 
-          <div>
+          <div className={SETTINGS_FIELDS_STACK_CLASS}>
             <SettingsFieldRow
               settingsItem="sessions.default-model"
               label={t('settings.openchamber.defaults.field.defaultModel')}

--- a/packages/ui/src/components/sections/openchamber/SessionRetentionSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/SessionRetentionSettings.tsx
@@ -10,6 +10,7 @@ import {
   SettingsChipGroup,
   SettingsInset,
   SETTINGS_ICON_BUTTON_CLASS,
+  SETTINGS_FIELDS_STACK_CLASS,
 } from '@/components/sections/shared/SettingsSection';
 import { useUIStore } from '@/stores/useUIStore';
 import { useSessionAutoCleanup } from '@/hooks/useSessionAutoCleanup';
@@ -75,7 +76,7 @@ export const SessionRetentionSettings: React.FC = () => {
         ariaLabel={t('settings.openchamber.sessionRetention.field.enableAutoCleanupAria')}
       />
 
-      <SettingsInset className="space-y-0">
+      <SettingsInset className={SETTINGS_FIELDS_STACK_CLASS}>
         <SettingsFieldRow
           settingsItem="sessions.retention-period"
           label={t('settings.openchamber.sessionRetention.field.retentionPeriod')}
@@ -119,7 +120,7 @@ export const SessionRetentionSettings: React.FC = () => {
         </SettingsFieldRow>
       </SettingsInset>
 
-      <div className="mt-1 py-1.5 space-y-1">
+      <SettingsInset className="space-y-1">
         <SettingsFieldRow
           label={t('settings.openchamber.sessionRetention.manualCleanup.title')}
         >
@@ -139,7 +140,7 @@ export const SessionRetentionSettings: React.FC = () => {
             ? t('settings.openchamber.sessionRetention.manualCleanup.eligibleArchiveNow', { count: pendingCount })
             : t('settings.openchamber.sessionRetention.manualCleanup.eligibleDeleteNow', { count: pendingCount })}
         </p>
-      </div>
+      </SettingsInset>
     </SettingsSection>
   );
 };


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-255

The Settings → Sessions page packed its setting blocks together: field rows inside "Default model & agent" and "Session retention" were stacked at `space-y-0` (only the 4px from each `SettingsFieldRow`'s own `py-0.5`), and the manual cleanup block sat only ~4px below the retention inset. There was no visual hierarchy between blocks. This change gives the page the same vertical rhythm every other settings page uses: field stacks get `SETTINGS_FIELDS_STACK_CLASS` (`space-y-4`), sub-blocks get 16px separation, and the manual cleanup block becomes a proper `SettingsInset` (16px top separation). No controls moved, no labels changed, no behavior changed.

## Non-goals

- No control was added, moved, renamed, or re-ordered; settings search registry, anchors, and availability are untouched.
- Section-level rhythm between the two top-level `SettingsSection`s (Defaults + Retention) is already the shared standard (`pb-8` + `py-8` with divider) and was left alone.
- Other settings pages were not touched.

## Affected surfaces

- `packages/ui` — Settings → Sessions page (web, desktop, VS Code, hosted mobile, Capacitor: the page is shared UI; the Sessions page renders in every runtime that opens Settings).
- Visible states: spacing between settings rows/blocks changes; nothing else.
- Persisted/external contracts: none — no settings values, routes, or APIs touched.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — follow local precedent; smallest complete change | The issue is a spacing-only UI improvement | Only two files, only spacing classes changed; no refactor |
| Project skill `settings-ui-patterns` (+ `theme-system`, `locale-ui-patterns`) | Any Settings surface change must follow the shared primitives and canonical spacing | Used `SETTINGS_FIELDS_STACK_CLASS` (canonical field stack, `space-y-4` per `references/layout.md` and `SettingsSection.tsx`) and the shared `SettingsInset` primitive instead of ad-hoc `mt-1 py-1.5`; no new strings (no locale work needed); no theme tokens or icons introduced |
| `packages/ui/src/components/sections/shared/SettingsSection.tsx` (nearest component doc) | Owning module for the primitives used | Imports constants from the owning module; verified `SETTINGS_FIELDS_STACK_CLASS` is `space-y-4` and `SettingsInset` is `pt-4` |
| `packages/ui/src/components/sections/openchamber/OpenChamberPage.tsx` | Owns the Sessions page composition | Read to confirm the page structure (DefaultsSettings + SessionRetentionSettings) before editing |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (packages/ui) | Pass — `tsc --noEmit` exited 0 |
| `bun run lint` (packages/ui, `eslint "./src/**/*.{ts,tsx}" --config ../../eslint.config.js`) | Pass — no findings |
| Focused tests | None exist for `DefaultsSettings.tsx` / `SessionRetentionSettings.tsx` (verified: no `*.test.*` files in `components/sections/openchamber` for these modules) |
| `bun run dead-code` | Not run — no files added/deleted/renamed, no export or import-shape changes (class-name changes only) |
| Runtime rendering | Not verified in a running app in this environment — see Visual evidence |

## Visual evidence

I cannot take screenshots in this environment (no display/browser available to the agent). Expected rendering after the change, at the default 100% spacing density:

- **Default model & agent section**: the three field rows (Default model / Default thinking / Default agent) are now 16px apart instead of ~4px; the "Ask before deleting sessions" checkbox block and the "Small model" group are each separated by 16px instead of 0–4px (small-model group keeps its existing `pt-6` emphasis on top of the new stack margin).
- **Session retention section**: "Retention period" and "When sessions expire" rows are now 16px apart; the manual cleanup block ("Run cleanup now" + eligible-count caption) sits 16px below the retention inset (previously ~4px), matching `SettingsInset` rhythm used elsewhere on the page.
- Both light and dark themes are unaffected (spacing-only change, no colors touched).

## Risks and failure behavior

- No failure/rollback surface: pure CSS-class spacing change, no data, no async behavior.
- `SettingsInset` adds `pt-4` (16px) top padding to the manual cleanup block; combined with the section's `space-y-5` this is ~36px above the block, consistent with how `SettingsInset` separates blocks elsewhere (e.g., Defaults section checkbox).
- The inner fields wrapper in `DefaultsSettings` and the retention inset both use the shared stack class (`space-y-4`); the summary caption keeps its `mb-1` for a slightly tighter link to the first field, matching prior intent.
- Layout at narrow pane widths (container queries) is unchanged: `SETTINGS_FIELDS_STACK_CLASS` is a plain vertical stack and behaves the same as the section's default `space-y-5` rhythm.
