### PR TITLE
fix(mobile): shrink model/agent label font on phones

### DIFF
--- a/packages/ui/src/components/chat/MobileAgentButton.tsx
+++ b/packages/ui/src/components/chat/MobileAgentButton.tsx
@@ -79,7 +79,7 @@ export const MobileAgentButton: React.FC<MobileAgentButtonProps> = ({ onCycleAge
             onContextMenu={(e) => e.preventDefault()}
             onMouseDown={(e) => e.preventDefault()}
             className={cn(
-                'inline-flex min-w-0 items-stretch select-none',
+                'oc-composer-chip inline-flex min-w-0 items-stretch select-none',
                 'rounded-lg',
                 'typography-micro font-medium',
                 'focus:outline-none hover:bg-[var(--interactive-hover)]',

--- a/packages/ui/src/components/chat/MobileModelButton.tsx
+++ b/packages/ui/src/components/chat/MobileModelButton.tsx
@@ -33,7 +33,7 @@ export const MobileModelButton: React.FC<MobileModelButtonProps> = ({ onOpenMode
                 }
             }}
             className={cn(
-                'inline-flex min-w-0 items-stretch',
+                'oc-composer-chip inline-flex min-w-0 items-stretch',
                 'rounded-lg',
                 'typography-micro font-medium text-foreground/80',
                 'focus:outline-none hover:bg-[var(--interactive-hover)]',

--- a/packages/ui/src/styles/mobile.css
+++ b/packages/ui/src/styles/mobile.css
@@ -34,6 +34,17 @@
     font-size: unset !important;
   }
 
+  /* Composer model/agent chips (MobileModelButton / MobileAgentButton): the
+     generic override above (font-size: unset !important) makes their
+     typography-micro labels inherit the base text size on phones — LARGER
+     than the desktop scale they were sized with (16px inherited vs 14px
+     desktop), which is why the labels look oversized and truncate. Pin the
+     chips to a compact size, scoped to the chips only: the app-wide --text-*
+     shrink (revert of #1791) was reverted because it resized every surface. */
+  :root.mobile-pointer:not(.desktop-runtime) .oc-composer-chip {
+    font-size: 0.75rem !important; /* 12px on phones vs 14px on desktop */
+  }
+
   /* Fix font size for tool displays */
   :root.mobile-pointer:not(.desktop-runtime) [class*="tool"],
   :root.mobile-pointer:not(.desktop-runtime) [class*="code"] {


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-200

On phones, the composer's model selector label ("GPT-5.3 Codex") and agent label ("Sisyphus (Ultraworker)") render LARGER than the desktop scale and truncate badly. Root cause: `mobile.css` applies `font-size: unset !important` to every `.typography-*` class inside the `@media (max-width: 1024px)` block, so the chips' `typography-micro` labels stop resolving `--text-micro` and instead inherit the base text size (~16px) — bigger than the 14px desktop size and 13px the mobile `--text-micro` token was meant to produce. This change pins the two chips to 12px on touch/mobile viewports.

A previous attempt to fix this by shrinking the app-wide `--text-*` tokens (PR #1791, "actually shrink typography classes on mobile viewports") was reverted the same day because it resized every surface. This PR deliberately takes the scoped route: only the two composer chips get a smaller size.

## Non-goals

- No user-configurable font-size option (the issue lists it as an alternative; a settings surface + persistence is a larger, separate change).
- No change to the global `--text-*` typography tokens (that approach was reverted in #1791).
- No change to the model picker list rows, working-status line, or any other typography consumer.

## Affected surfaces

- `packages/ui` only. Web, Electron, VS Code, and Capacitor all consume the same `packages/ui` CSS and components; Electron/VS Code add `desktop-runtime`, which is excluded by the `:not(.desktop-runtime)` gate, so desktop surfaces are untouched. On iOS standalone PWA the existing `@media (display-mode: standalone)` block already forces `typography-micro` to 13px; the new rule wins by specificity (0,4,0 vs 0,1,0, both `!important`) so iOS PWA chips become 12px too.
- Visible user change: on phones (touch pointer, width ≤ 1024px) the model/agent chips in the chat composer show 12px labels instead of the inherited ~16px. Desktop, Electron, VS Code, and tablets ≥ 1024px are unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` runtime boundaries + always-on constraints | Shared UI change owned by `packages/ui`; no new dependencies; minimal diff | Only 2 components + 1 CSS file touched; no deps, no secrets, no unrelated files staged |
| Project skill `theme-system` | Styling/typography change; tokens + light/dark rules apply | Reuses the existing typography-class pattern (`typography-micro` stays on the chips) and the existing `mobile.css` `:root.mobile-pointer:not(.desktop-runtime)` gating; the only hardcoded size (0.75rem) mirrors the value the reverted #1791 PR used for `ui-label`/`meta` and matches Tailwind `text-xs`; scoped via a dedicated `.oc-composer-chip` class instead of altering shared tokens |
| `packages/ui/README.md` + `packages/ui/src/styles/` (nearest docs) | CSS/token conventions live there | Change follows the file's existing block structure and comment style |
| `packages/ui/src/lib/typography.ts` | Typography tokens reference (issue instruction) | Consulted; no token edits — the fix is a scoped override because global token changes were reverted before |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (worktree `fix/ope-200-mobile-label-font`) | PASS — `tsc --noEmit` clean, exit 0 |
| `bun run lint:ui` | PASS — `eslint "./src/**/*.{ts,tsx}" --config ../../eslint.config.js` clean, exit 0 |
| `bun run build:ui` | PASS — script is `tsc --noEmit`; clean |
| `git status` before commit | Only the 3 intended files modified |

Not verified: no browser/device available in this environment (no screenshots possible — see Visual evidence). The computed cascade was verified by reading `mobile.css` (the `font-size: unset !important` rule at lines 28–35 that neutralizes `typography-micro` on mobile) and `typography.css` (`--text-micro` resolution), but the final rendered size on a real device was not measured.

## Visual evidence

No screenshots could be captured: this environment has no display/browser and the agent cannot produce images. Expected rendering after the fix, on a phone (touch pointer, ≤ 1024px viewport):

- Composer chips row above the input: model chip "GPT-5.3 Codex" and agent chip "Sisyphus (Ultraworker)" render at 12px (0.75rem), down from the inherited ~16px base — noticeably smaller, truncating far less often, and balanced against the 26px chip height.
- Desktop / Electron / VS Code / iPad landscape (≥ 1024px): unchanged at 14px (`typography-micro` desktop token).

## Risks and failure behavior

- The new rule only matches `:root.mobile-pointer:not(.desktop-runtime) .oc-composer-chip`; the class exists only on the two chip buttons, so no other surface can be affected. If the class is ever removed from a chip, the chip falls back to today's behavior (no regression).
- Both `!important` rules compete only for these two elements; the higher-specificity scoped rule wins deterministically, and there is no later CSS that re-sets font-size on the chips.
- 12px is smaller than the 13px mobile `--text-micro` token; if accessibility concerns arise, the scoped class is the single point to bump the value.
- No persisted contracts, storage, or sync behavior involved.
