### PR TITLE
fix(ui): keep icons intrinsic under spacing density and let session/project menus scale

### DIFF
--- a/packages/ui/src/components/icons/DiffIcon.tsx
+++ b/packages/ui/src/components/icons/DiffIcon.tsx
@@ -1,6 +1,7 @@
 import type { SVGProps } from 'react';
 
 import { Icon } from '@/components/icon/Icon';
+import { cn } from '@/lib/utils';
 
 interface DiffIconProps extends Omit<SVGProps<SVGSVGElement>, 'children'> {
   size?: number | string;
@@ -25,7 +26,7 @@ export function DiffIcon({ size, className, style, ...props }: DiffIconProps) {
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 256 256"
       fill="currentColor"
-      className={className}
+      className={cn('remixicon', className)}
       style={{
         width: typeof size === 'number' ? `${size}px` : size,
         height: typeof size === 'number' ? `${size}px` : size,

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -2880,7 +2880,6 @@ export const Header: React.FC<HeaderProps> = ({
       <header
         ref={headerRef}
         className={headerClassName}
-        style={{ ['--padding-scale' as string]: '1' } as React.CSSProperties}
       >
         {isMobile ? renderMobile() : renderDesktop()}
       </header>

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -455,6 +455,14 @@ button svg,
   shape-rendering: geometricPrecision;
 }
 
+/* Icons keep their intrinsic size regardless of the spacing-density scale:
+   sizing utilities (size-4 / h-4 / w-4 …) resolve --spacing-* which is
+   multiplied by --padding-scale, so re-pin the scale to 1 on the icon
+   element itself. Surrounding layout (paddings, gaps) still scales. */
+svg.remixicon {
+  --padding-scale: 1;
+}
+
 /* GPU acceleration for non-spinning SVGs */
 button svg:not(.animate-spin),
 [role="button"] svg:not(.animate-spin) {


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-248

The "Spacing" density setting (Appearance → Spacing, 50–200%) multiplies every Tailwind spacing token by `--padding-scale` (`useUIStore.applyPadding()` sets it on `document.documentElement`; `design-system.css` redefines the whole `--spacing-*` scale as `calc(<base> * var(--padding-scale, 1))`). Two defects resulted:

1. **Icons changed size with density.** Icon sizing utilities (`size-4`, `h-3.5 w-3.5`, `w-4`, …) applied directly on icon elements resolve against the scaled `--spacing-*` scale, so icons grew/shrunk with the setting. Icons are glyphs and must keep their intrinsic size; only the spacing around them should scale.
2. **Session/project menus ignored density.** The app header pinned `--padding-scale: 1` on the `<header>` element, so the session switcher trigger, the session actions (three-dot) menu, the tabs, and the project actions surfaces did not respond to density while every other surface did.

Fix: re-pin `--padding-scale: 1` on the icon element itself (`svg.remixicon`) so icon sizing resolves to the intrinsic base size everywhere, and remove the header pin so header surfaces (session switcher, session actions menu, project actions) scale with density like the rest of the app. The header's dependent geometry is already adaptive: `--oc-header-height` and `--oc-titlebar-controls-width` are published from `ResizeObserver` measurements of the header/controls cluster.

## Non-goals

- The density scale itself (sqrt mapping, 50–200% clamp, `--line-height-*` dampening) is unchanged.
- Layout elements (buttons, rows, paddings, gaps) intentionally continue to scale with density.
- Typography size (separate Font size setting) untouched.
- Mobile native app header (`MobileHeader.tsx`) was already unpinned and is untouched.

## Affected surfaces

- `packages/ui` — shared UI: every surface rendering the sprite `Icon` (web, desktop, VS Code, hosted mobile, Capacitor) and the app header (web + desktop; VS Code uses its own `VSCodeHeader`, mobile native uses `MobileHeader`).
- User-visible states: icon pixel sizes are now constant across density values; header session/project menus and their triggers scale with density; header height grows/shrinks with density (e.g. 48px at 100%, ~59px at 150%, ~34px at 50%) and dependent surfaces (`SidebarTopBar` spacer, mobile services sheet offset) follow via the ResizeObserver-synced `--oc-header-height`.
- Persisted/external contracts: none — no settings values, storage, or APIs changed.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — smallest complete change; keep entrypoints thin; theme tokens from `packages/ui/src/lib/theme/` | Density is a store + CSS-variable mechanism; fix must be scoped to the variable that drives icon size | Changed only the CSS rule for icon elements, one component class, and removed one inline style; no new abstractions |
| Project skill `theme-system` (`references/icons.md`, `references/tokens-and-examples.md`) | Icon sizing and theme-token changes | Icons keep the shared `Icon`/`IconName` contract and are sized by classes; the fix is a CSS custom-property pin, not a new sizing API; no new icon names, so `icons:generate` not needed |
| Project skill `settings-ui-patterns` | The density control lives in Settings → Appearance | Read `OpenChamberVisualSettings.tsx` (Spacing field) and `useUIStore.applyPadding()` to confirm the mechanism before changing it; no Settings markup changed |
| `packages/ui/src/styles/design-system.css` + `packages/ui/src/index.css` (owning CSS modules) | Where the spacing scale and icon rules live | New rule placed next to the existing `svg.remixicon` icon rules in `index.css` |
| `packages/ui/src/components/layout/Header.tsx` (nearest README: `packages/ui` README; component docs in `packages/ui/src/components/layout/`) | Owns the header pin and the session/project menu surfaces | Verified `--oc-header-height`/`--oc-titlebar-controls-width` are ResizeObserver-published before removing the pin |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (packages/ui) | Pass — `tsc --noEmit` exited 0 |
| `bun run lint` (packages/ui, `eslint "./src/**/*.{ts,tsx}" --config ../../eslint.config.js`) | Pass — no findings |
| CSS emission check: compiled the real `packages/ui/src/index.css` with the Tailwind v4 CLI (`@tailwindcss/cli`) | Pass — utilities confirm the mechanism: `.size-4 { width: calc(1rem * var(--padding-scale, 1)) }`, `.h-3\.5 { height: calc(0.875rem * var(--padding-scale, 1)) }`, etc., and the new `svg.remixicon { --padding-scale: 1 }` rule is emitted. `var(--padding-scale)` resolves at the element carrying the utility class, so a value of 1 pinned on the icon element yields the intrinsic base size — the same mechanism the header pin already used in production |
| Focused tests | None exist for `Icon`/`DiffIcon`/`Header` density behavior (no `*.test.*` files reference `padding-scale`, `remixicon`, or `applyPadding`) |
| `bun run dead-code` | Not run — no files added/deleted/renamed and no export/entrypoint changes |
| Runtime rendering | Not verified in a running app in this environment — see Visual evidence |

## Visual evidence

I cannot take screenshots in this environment (no display or browser available to the agent). Expected rendering after the change:

- **Icons** (`size-4`, `h-4 w-4`, `h-3.5 w-3.5`, `h-5 w-5`…): identical pixel size at 50%, 100%, 150%, and 200% spacing density, in light and dark themes, everywhere the sprite `Icon` is used (buttons, menu items, markdown inline icons, header, sidebar). Same for the Diff tab icon (`DiffIcon` now carries the `remixicon` class).
- **Session menu** (session switcher trigger, session title area, three-dot actions menu) and **project actions** surfaces: at 150% density their buttons/paddings/gaps are ~22% larger, at 50% ~29% smaller, exactly like the rest of the app; the header bar height follows (`--oc-header-height` re-measured by the existing `ResizeObserver`), so the sidebar spacer and mobile sheets stay aligned.
- **Dropdown popups** (session switcher, project actions, session actions): already portaled to `body` and scaling with density; unchanged by this PR, now consistent with their triggers.

## Risks and failure behavior

- **Header height at extreme density**: at 200% the header is ~68px tall (from 48px). `--oc-header-height` is ResizeObserver-synced, so `SidebarTopBar` and the mobile services sheet offset follow; no stale-margin state. Window drag regions scale with the header — no code relies on a fixed drag area.
- **Window-controls-overlay surfaces** (web PWA / desktop with WCO): the header keeps an inline `height: max(3rem, var(--oc-wco-titlebar-height, 0px))` minimum, so the OS overlay buttons never get covered; inner spacing still scales. At extreme density inner content can get visually tight inside the fixed minimum — acceptable and user-chosen (density is a user setting), no clipping (no `overflow-hidden` on the header).
- **DiffIcon rendering**: adding `remixicon` to its class list exposes it to existing `index.css` rules (`fill: none !important` on root, `path { fill: currentColor !important }`); the path fill resolves to `currentColor`, identical to the previous attribute-inherited fill. Verified against the compiled CSS.
- **Rollback/cleanup**: the change is two CSS/attribute scopes and one removed inline style; reverting the commit restores prior behavior exactly. No persisted data, caches, or async state involved.
- **Unverified**: actual pixel rendering at runtime (no browser available); the WCO surface interaction at extreme densities; Electron titlebar behavior on macOS (traffic-light inset is width-based and unaffected, but not exercised).
