### PR TITLE
fix(chat): key streamed text/reasoning blocks by part id

### DIFF
--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -1854,8 +1854,13 @@ const AssistantMessageBody = React.memo(({
                     i += 1;
                     continue;
                 }
+                // Key by the part's stable id (falling back to the index) so a
+                // new part inserted or filtered earlier in the array cannot
+                // remount every following text block. A remount re-parses the
+                // markdown from scratch and reads as a blink while streaming.
+                const textPartKey = part.id ? `assistant-text-${messageId}-${part.id}` : `assistant-text-${messageId}-${i}`;
                 rendered.push(
-                    <div key={`assistant-text-${messageId}-${i}`} ref={messageTextContentRef} data-message-text-export-source="true">
+                    <div key={textPartKey} ref={messageTextContentRef} data-message-text-export-source="true">
                         <AssistantTextPart
                             part={part}
                             sessionId={sessionId}
@@ -1886,12 +1891,16 @@ const AssistantMessageBody = React.memo(({
                     i += 1;
                     continue;
                 }
+                // Same stable-id keying as text parts above: keeps reasoning
+                // blocks mounted when earlier parts are inserted/filtered, so
+                // their markdown is not re-parsed mid-stream.
+                const reasoningPartKey = part.id ? `reasoning-${messageId}-${part.id}` : `reasoning-${messageId}-${i}`;
                 if (showReasoningTraces) {
                     if (!collapsibleThinkingBlocks) {
                         // Non-collapsible mode: render thinking blocks as plain text inline.
                         rendered.push(
                             <AssistantTextPart
-                                key={`reasoning-${messageId}-${i}`}
+                                key={reasoningPartKey}
                                 part={part}
                                 sessionId={sessionId}
                                 messageId={messageId}
@@ -1905,7 +1914,7 @@ const AssistantMessageBody = React.memo(({
                         // Per-part mode: each reasoning block at its natural position.
                         rendered.push(
                             <ReasoningPart
-                                key={`reasoning-${messageId}-${i}`}
+                                key={reasoningPartKey}
                                 part={part}
                                 messageId={messageId}
                                 streamPhase={effectiveStreamPhase}


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-259

Chat blinks during streaming updates. The chat render pipeline is already extensively optimized (per-block markdown morphdom reconciliation, `htmlCache` keyed by content hash, reference-stable turn projections, deep `React.memo` comparators on rows), but one remount hazard remained: in `MessageBody`'s flat part-render loop, assistant **text** and **reasoning** blocks were keyed by their array **index** (`assistant-text-${messageId}-${i}` / `reasoning-${messageId}-${i}`), while the parts array is kept ID-sorted and filtered by emptiness (`isEmptyTextPart`, compaction removal). Any part inserted or filtered in/out earlier in the array shifts every following index, so all subsequent text/reasoning blocks unmount and remount. A remount re-parses the block's markdown from scratch (sync plain-first paint → async morph) and can re-trigger reveal styling — a visible blink mid-stream.

Fix: key assistant text and reasoning blocks by the part's stable id (index as fallback), matching the existing user-message rendering path which already keys by `part.id ?? ...`. Existing blocks now survive part-insertion/filtering changes without remounting.

## Non-goals

- No sync/store restructuring (per issue instruction): the parts-array ordering, event reducer, and materialization are untouched.
- No change to the markdown renderer, throttle, or scroll/autofollow logic — these were already optimized; investigation confirmed their memoization/morphdom behavior is correct.
- No change to tool rows (already keyed by `toolPart.id`) or the streaming-tail/static-history split.

## Affected surfaces

- `packages/ui` only: `packages/ui/src/components/chat/message/MessageBody.tsx`. Affects every runtime (web, Electron, VS Code, Capacitor) that renders assistant messages in chat, in both sorted and live render modes.
- User-visible behavior: no layout or content change; streaming blocks keep their DOM identity across part-array mutations instead of flashing. At-rest rendering is identical.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` always-on constraints + correctness invariants | Shared UI render path; minimal diff; no deps; preserve unrelated work | 1 file, 12 insertions; no dependencies, no store/sync changes |
| Project skill `performance-engineering` | Render hot path; stable keys / avoiding re-parse / memoization are the mandated fix categories | Verified the existing memo chain (MarkdownRenderer comparator, per-block morphdom, `htmlCache`, reference-stable static turns via `useTurnRecords`), then removed the remaining index-key remount hazard; no new caches added |
| `packages/ui/src/sync/DOCUMENTATION.md` + `packages/ui/src/stores/DOCUMENTATION.md` (required reading) | Understand part-store invariants (ID-sorted, filtered) that make index keys unstable | Parts are maintained ID-sorted via `Binary.search` inserts (`event-reducer.ts`) and filtered in `MessageBody` (`isEmptyTextPart`, compaction) — documented in the PR; read before editing, no sync files touched |
| Nearest package `README.md` / chat module docs | Chat rendering conventions | Followed the existing user-message key pattern (`part.id ?? index`) |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (worktree `fix/ope-259-chat-flicker`) | PASS — `tsc --noEmit` clean, exit 0 |
| `bun run lint:ui` | PASS — eslint clean, exit 0 |
| `bun test packages/ui/src/components/chat/` | PASS — 548 pass, 0 fail, 934 expect() across 49 files |
| `git status` before commit | Only `MessageBody.tsx` modified |

Not verified: no browser/profiler available in this environment, so no `openchamber_stream_perf` trace or visual before/after could be captured; the fix is verified by code inspection of the key derivation and by the unchanged test suites. `bun run dead-code` not required — no files added/removed, no exports changed.

## Visual evidence

No screenshots could be captured: this environment has no display/browser and the agent cannot produce images. Expected rendering after the fix:

- During streaming, when a new part is inserted earlier in a message's part array (e.g., a reasoning block emitted between existing text blocks, or an empty text part becoming visible), the text/reasoning blocks after it stay mounted — no flash of plain text, no markdown re-parse, no layout jump.
- When no part is inserted (the common single-text-part stream), rendering is byte-for-byte identical to before.
- Completed messages render exactly as before (key only affects reconciliation identity, not structure).

## Risks and failure behavior

- Key collision: two parts sharing an id within one message would collide, but part ids are server-unique (`prt_<timestamp+counter><random>`); the user-message path already keys by part id, so this follows established precedent. The index fallback covers hypothetical id-less parts.
- No fallback behavior change: if a part ever lacks an id, the previous index-based key is used, so there is no crash path.
- No persisted state, no sync contracts, no scroll/animation behavior touched.
