### PR TITLE
feat(ui): make the composer stop button a solid red square for distance visibility

### DIFF
--- a/packages/ui/src/components/chat/composer/ui/ComposerActionButtons.tsx
+++ b/packages/ui/src/components/chat/composer/ui/ComposerActionButtons.tsx
@@ -100,7 +100,15 @@ export const ComposerActionButtons = React.memo(function ComposerActionButtons(p
                 onClick={onAbort}
                 className={cn(
                     footerIconButtonClass,
-                    'text-[var(--status-error)] hover:text-[var(--status-error)]'
+                    // Solid error fill so the stop control reads as a red
+                    // square even from across the room (OPE-195). The glyph
+                    // flips to the theme's error foreground, which every
+                    // theme defines for its own light/dark contrast. Hover
+                    // and active use opacity so no extra colour values are
+                    // introduced and both themes stay correct.
+                    'bg-[var(--status-error)] text-[var(--status-error-foreground)]',
+                    'hover:bg-[var(--status-error)] hover:text-[var(--status-error-foreground)]',
+                    'hover:opacity-90 active:opacity-75'
                 )}
                 aria-label={t('chat.chatInput.actions.stopGeneratingAria')}
             >

--- a/packages/ui/src/components/chat/composer/ui/MobilePillComposer.tsx
+++ b/packages/ui/src/components/chat/composer/ui/MobilePillComposer.tsx
@@ -132,7 +132,15 @@ export function MobilePillComposer(props: MobilePillComposerProps) {
                 {canAbort ? (
                     <button
                         type="button"
-                        className={cn(footerIconButtonClass, 'text-[var(--status-error)] hover:text-[var(--status-error)]')}
+                        className={cn(
+                            footerIconButtonClass,
+                            // Solid error fill — same treatment as the full
+                            // composer's stop control (OPE-195) so the pill's
+                            // stop stays identifiable from a distance too.
+                            'bg-[var(--status-error)] text-[var(--status-error-foreground)]',
+                            'hover:bg-[var(--status-error)] hover:text-[var(--status-error-foreground)]',
+                            'hover:opacity-90 active:opacity-75'
+                        )}
                         // The pill shows only while the keyboard is down — the
                         // tap must abort in place, never focus/expand the
                         // composer or raise the keyboard.


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-195

The composer's stop-generation control was a small red glyph on a transparent
icon button. Users running long queries want to see it at a glance from across
the room; the previous rendering was easy to miss. The stop button now fills
with the theme's error color and the glyph flips to the theme's error
foreground, so it reads as a solid red square in both light and dark themes.
Applied to both stop controls: the full composer footer and the compact mobile
pill.

## Non-goals

- No change to the theme tokens themselves (`--status-error` values stay as
  each theme defines them) — restyling every error surface app-wide is out of
  scope and would be risky.
- No change to stop button size, position, gating (`canAbort`), or abort
  behavior (same `onAbort` → `abortCurrentOperation` path as before).
- No change to the send/queue buttons or any other footer control.

## Affected surfaces

- `packages/ui` — `components/chat/composer/ui/ComposerActionButtons.tsx`
  (full composer footer: desktop web, Electron, VS Code webview, mini-chat,
  mobile expanded composer) and `components/chat/composer/ui/MobilePillComposer.tsx`
  (collapsed mobile pill).
- Runtime-agnostic: both components render on every runtime (web, desktop,
  VS Code, hosted/Capacitor mobile) and the change is pure class-name styling,
  so all surfaces change consistently.
- Theme behavior: `--status-error` and `--status-error-foreground` are emitted
  by `packages/ui/src/lib/theme/cssGenerator.ts` for every built-in theme;
  the button renders correctly in light and dark without touching token
  definitions. No persisted/external contracts change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` root rules | Minimal changes; theme tokens; light+dark support | Two component files touched; only theme tokens and opacity utilities used |
| `.agents/skills/theme-system` | Any styling/color change | Used semantic `status.*` tokens only (status is correct here: the button communicates an in-flight/abortable state); no hardcoded hex or palette colors; hover only on the interactive element; the existing shared `Button` destructive variant was reviewed but the footer's icon-button system predates it and the stop button must stay size-consistent with sibling footer controls (`footerIconButtonClass`) |
| `.agents/skills/theme-system/references/tokens-and-examples.md` | Token families and usage rules | Fill uses `--status-error`, glyph uses `--status-error-foreground`; hover/active use opacity (no extra color values) |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | Nearest module doc | Confirms rendering is not covered by unit tests (no DOM test env) and must be verified by hand — did browser-based computed-style verification instead |
| `locale-ui-patterns` | User-facing text | No new strings; existing `chat.chatInput.actions.stopGeneratingAria` label reused |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (`tsc --noEmit` in `packages/ui`) | Passed, exit 0 |
| `bun run lint:ui` (eslint over `packages/ui/src`) | Passed, exit 0 |
| Tailwind v4 compile of the exact new class list (`bg-[var(--status-error)] text-[var(--status-error-foreground)] hover:… active:opacity-75`) | Compiled; CSS output generated (verified via a standalone Vite+`@tailwindcss/postcss` build) |
| Computed-style check in headless Chromium 150 (real CSS, light + dark vars) | Light: `background-color: rgb(183, 73, 63)` (`#b7493f`), glyph `rgb(255,255,255)`; Dark: `background-color: rgb(218, 91, 74)` (`#da5b4a`), glyph `rgb(0,0,0)`; button 24×24 — matches theme token values exactly |
| Contrast of glyph on fill | Light `#b7493f`/white ≈ 5.5:1; dark `#da5b4a`/black ≈ 7.0:1 — both exceed WCAG AA for normal text |
| Unit tests for the changed components | None exist (`ComposerActionButtons`/`MobilePillComposer` are presentation-only; composer `DOCUMENTATION.md` states the package has no DOM test environment) |

Not verified: live hover/active interaction in the running app, iOS WKWebView
rendering, and screenshots (no display/screenshot capability in this
environment — see Visual evidence).

## Visual evidence

No screenshots could be captured in this environment (headless-only, and the
full app requires the OpenCode backend + a session). Instead, the exact
rendered output was verified programmatically in headless Chromium: a harness
page built with the project's real Tailwind pipeline (`@tailwindcss/postcss`,
same utility syntax) rendered a button with the exact new class list under
both theme variable sets and reported computed styles.

Expected rendering: the stop control becomes a solid square filled with the
theme's error red (`#b7493f` light / `#da5b4a` dark) with the stop glyph in
the theme's error foreground (`#ffffff` light / `#000000` dark), at the same
size and position as before (24×24 desktop footer, 32×32 mobile footer,
32×32 mobile pill), hovering at 90% opacity and active at 75% — clearly
identifiable from a distance in both themes.

## Risks and failure behavior

- Contrast: verified above for the two default OpenChamber themes; every
  built-in theme defines both `status.error` and `status.errorForeground`
  explicitly (cssGenerator), so the fill/foreground pair always exists —
  no fallback path needed.
- Visual regression scope: only the two stop buttons change; abort behavior,
  layout, and sizes are untouched. Rollback is a one-line class revert per
  file.
- Accessibility: the button keeps its existing `aria-label` and `title`;
  a solid fill with a contrasting glyph increases, rather than reduces,
  target visibility.
- None of the changed files affect persisted state, sync, or server code.
