### PR TITLE
fix(mobile): keep session screen on transient resume/online probe failures

### DIFF
--- a/packages/ui/src/apps/MobileApp.tsx
+++ b/packages/ui/src/apps/MobileApp.tsx
@@ -54,7 +54,7 @@ import { MobileSessionsSheet } from './MobileSessionsSheet';
 import { MobileFullscreenSurface } from './MobileFullscreenSurface';
 import { MobileWorkspaceDrawer, type MobileWorkspaceTab } from './MobileWorkspaceDrawer';
 import { DedicatedMobileAppProvider, type MobileAppActions } from './mobileAppContext';
-import { autoConnectLastInstance, getAutoConnectTargetLabel, reprobeActiveConnection, type AutoConnectOutcome } from './mobileConnections';
+import { autoConnectLastInstance, getAutoConnectTargetLabel, isFatalResumeProbeOutcome, reprobeActiveConnection, type AutoConnectOutcome } from './mobileConnections';
 import { isCapacitorMobileApp, useNativeAndroidBackButton, useNativeMobileChrome, useNativeMobileLifecycle } from './mobileNativeChrome';
 import { reconnectAppForTransportSwitch, resetAppForRuntimeEndpointChange } from './runtimeEndpointReset';
 import { useAppFontEffects } from './useAppFontEffects';
@@ -683,10 +683,14 @@ export function MobileApp({ apis }: MobileAppProps) {
     void reprobeActiveConnection().then((outcome) => {
       if (nativeResumeValidationSeqRef.current !== validationSeq) return;
       if (outcome === 'no-connection') {
-        disconnect();
+        // The runtime endpoint is up but it does not map to a saved connection
+        // (a bookkeeping mismatch, e.g. after a candidate rewrite). That is not
+        // a transport failure — keep the current connection; the sync pipeline
+        // reconnects on its own.
+        refreshInPlace();
         return;
       }
-      if (outcome === 'needs-login') {
+      if (isFatalResumeProbeOutcome(outcome)) {
         // Token explicitly rejected (revoked/expired) — tell the user why they
         // land back on the connect screen instead of silently bouncing them.
         setAutoConnectNotice({ kind: 'auth-expired', label: getAutoConnectTargetLabel() ?? '' });
@@ -697,7 +701,12 @@ export function MobileApp({ apis }: MobileAppProps) {
         // Right after a resume or Wi-Fi switch the network is often still
         // settling (on Android without a SIM there is NO connectivity at all for
         // a few seconds), so a single fast probe races the network coming up.
-        // Retry once after a grace period before tearing the connection down.
+        // Retry once after a grace period — the retry exists to hot-switch to a
+        // better transport when it comes back ('switched'/'unchanged'). A
+        // transport that stays unreachable is transient, not fatal: tearing the
+        // connection down here is what randomly kicked users back to the
+        // connect screen. Keep the runtime; the sync layer's own reconnect loop
+        // recovers, and the user leaves manually via the recovery UI/Instances.
         window.setTimeout(() => {
           if (nativeResumeValidationSeqRef.current !== validationSeq) return;
           void reprobeActiveConnection().then((retry) => {
@@ -707,10 +716,12 @@ export function MobileApp({ apis }: MobileAppProps) {
               refreshInPlace();
               return;
             }
-            if (retry === 'needs-login') {
+            if (isFatalResumeProbeOutcome(retry)) {
               setAutoConnectNotice({ kind: 'auth-expired', label: getAutoConnectTargetLabel() ?? '' });
+              disconnect();
+              return;
             }
-            disconnect();
+            refreshInPlace();
           });
         }, 4000);
         return;

--- a/packages/ui/src/apps/mobileConnections.test.ts
+++ b/packages/ui/src/apps/mobileConnections.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 
-import { createMobilePasswordOperationTracker, loadMobileConnections, migrateLegacyInlineTokenRecords, upsertMobileConnection, validateMobileConnectionSession, type MobileRelayConfig } from './mobileConnections';
+import { createMobilePasswordOperationTracker, isFatalResumeProbeOutcome, loadMobileConnections, migrateLegacyInlineTokenRecords, upsertMobileConnection, validateMobileConnectionSession, type MobileRelayConfig } from './mobileConnections';
 
 const originalFetch = globalThis.fetch;
 const originalWindow = globalThis.window;
@@ -212,5 +212,15 @@ describe('validateMobileConnectionSession', () => {
     } finally {
       restoreGlobals();
     }
+  });
+});
+
+describe('resume re-probe policy', () => {
+  test('only an explicit auth rejection is fatal — transient failures never tear the session down', () => {
+    expect(isFatalResumeProbeOutcome('needs-login')).toBe(true);
+    expect(isFatalResumeProbeOutcome('switched')).toBe(false);
+    expect(isFatalResumeProbeOutcome('unchanged')).toBe(false);
+    expect(isFatalResumeProbeOutcome('unreachable')).toBe(false);
+    expect(isFatalResumeProbeOutcome('no-connection')).toBe(false);
   });
 });

--- a/packages/ui/src/apps/mobileConnections.ts
+++ b/packages/ui/src/apps/mobileConnections.ts
@@ -1155,6 +1155,16 @@ export const isActiveRuntimeConnection = (connection: MobileSavedConnection): bo
 
 export type ReprobeOutcome = 'switched' | 'unchanged' | 'unreachable' | 'needs-login' | 'no-connection';
 
+// Resume/online re-probe policy: an outcome is FATAL (tears the runtime down
+// and lands the user on the connect screen) only when the server EXPLICITLY
+// rejected the token. Transport reachability failures ('unreachable',
+// 'no-connection') are transient on mobile — Wi-Fi/cellular handover, radio
+// congestion, a Keychain read hiccup — and the sync pipeline reconnects on its
+// own (visibility/system-resume + exponential backoff), so they must never
+// bounce the user off the session screen. The user leaves via the recovery UI
+// or Instances, never via an implicit probe result.
+export const isFatalResumeProbeOutcome = (outcome: ReprobeOutcome): boolean => outcome === 'needs-login';
+
 // App-resume re-probe: when the app wakes (Capacitor `isActive`), the network may
 // have changed while it slept, so re-select the active device's transport and
 // hot-switch if a better one is reachable — the seamless "LAN at home ⇄ relay


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-319

On the native mobile app (Capacitor iOS/Android), the session screen randomly returned to the server-choose (connect) screen. Root cause: every background→foreground resume and every WebView `online` connectivity event ran `handleNativeResume` → `reprobeActiveConnection()` with fast (2.5s) probe timeouts. A transient network blip (Wi-Fi/cellular handover, radio congestion, a Keychain read hiccup) made the probe fail, and the code tore the runtime endpoint down (`switchRuntimeEndpoint({ apiBaseUrl: '' })`), landing the user on `MobileConnectionWelcome` — even though the sync pipeline recovers from transient drops on its own (visibility/system-resume reconnect + exponential backoff + watchdog).

Behavior change: the resume/online re-probe now tears the connection down **only** on an explicit auth rejection (`needs-login` — revoked/expired token, shown with an `auth-expired` banner). `unreachable` and `no-connection` are treated as transient: the runtime endpoint and session screen are kept, and the sync layer's own reconnect loop recovers. The user leaves the session screen only by explicit action — the recovery UI Cancel button, the Instances sheet, or deleting the active connection.

## Non-goals

- Cold-launch classification (mount-only effect) still drops to the connect screen when the saved instance is unreachable/rejected at startup — there is no session screen to protect yet, and the user must pick a server. Unchanged.
- No change to the connect/pairing/password flows themselves.
- No change to `reprobeActiveConnection()`'s transport hot-switch (`switched` still rebinds LAN⇄relay in place).

## Affected surfaces

- `packages/ui/src/apps/MobileApp.tsx` — `handleNativeResume` decision logic (Capacitor-only runtime).
- `packages/ui/src/apps/mobileConnections.ts` — new exported policy helper `isFatalResumeProbeOutcome`; no behavior change to the module itself.
- `packages/ui/src/apps/mobileConnections.test.ts` — new focused test.
- Unaffected: web/desktop/VS Code runtimes (this code path is gated on `isNativeMobileApp`/`isCapacitorApp`); the connect screen itself; persisted connections.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `sync-state-invariants` | Change touches mobile bootstrap/reconnect resilience and transient-failure handling | Keeps authoritative runtime state during transient failure; only explicit auth rejection is treated as fatal; the pipeline (not the probe) remains the reconnect authority |
| `ui-api-decoupling` | Change sits in the Capacitor runtime boundary and uses `switchRuntimeEndpoint` | No new transports or API routes; runtime switching behavior preserved; policy helper lives in the owning mobile app module |
| `packages/mobile/README.md` | Mobile runtime model: connections saved locally, connect screen is Capacitor-only | Change only affects the Capacitor shell path (`isNativeMobileApp`), browser-hosted mobile keeps prior behavior |
| `packages/ui/src/sync/DOCUMENTATION.md` | Defines reconnect/polling/bootstrap rules ("Preserve previous authoritative state during transient bootstrap/reconnect failures") | The fix implements exactly that rule for the resume re-probe path |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (worktree) | PASS — `tsc --noEmit`, no errors |
| `bun run lint:ui` (worktree) | PASS — eslint clean |
| `bun test packages/ui/src/apps/mobileConnections.test.ts` | PASS — 11 pass / 0 fail, 28 expect() calls (10 existing + 1 new policy test) |
| `bun run dead-code` (worktree root) | Run; report is non-blocking, new export not flagged (listed `mobileConnections.ts` entries are pre-existing) |
| iOS Simulator / real server run | NOT RUN — this environment cannot run the iOS simulator or a live OpenChamber server. The reconnect-on-resume behavior (resume → flaky network → session screen stays) was verified by code path analysis only: the changed branches keep the endpoint set (`hasRuntimeEndpoint` stays truthy) and never bump the epochs, so the render condition `!hasRuntimeEndpoint || (!isConnected && !isReconnecting)` cannot switch to `MobileConnectionWelcome`; the pipeline's own `visibilitychange`/`system-resume` listeners reconnect. |

## Visual evidence

No screenshots possible — the iOS simulator cannot be launched in this session. Expected rendering: during a transient network blip the session screen remains visible (possibly with the reconnecting state); the connect screen appears only after an explicit user action (recovery Cancel / Instances) or an auth-expired notice after a real token rejection. The code change is a decision-flow change; no visual states were added.

## Risks and failure behavior

- **Permanently dead server while app is foregrounded**: the app now stays on the session screen in the reconnecting state instead of auto-bouncing to the connect screen. Manual escape routes remain: recovery UI Cancel (when shown), the Instances entry in the sessions footer, or app relaunch (cold-launch auto-connect still classifies unreachable/rejected and shows the connect screen with a reason). This is the intended trade-off of the issue ("stays until the user manually leaves").
- **`needs-login` is still fatal** exactly as before — revoked/expired tokens cannot silently masquerade as reachable.
- **No new dependencies, no persisted-contract changes, no logging of tokens or user data** (existing `[mobile-connect]`/`[mobile-storage]` logs are unchanged).
- Rollback: revert of the single commit restores prior behavior; no data migrations involved.
