### PR TITLE
fix(server): allow reading files through workspace-internal symlinks

### DIFF
--- a/packages/web/server/lib/fs/DOCUMENTATION.md
+++ b/packages/web/server/lib/fs/DOCUMENTATION.md
@@ -24,6 +24,7 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
     - `GET /api/fs/list`
   - Owns exec job queue state (`execJobs`) and lifecycle/TTL pruning.
   - Enforces workspace boundary checks with active project + worktree fallback support.
+  - Read-family endpoints (`stat`, `read`, `raw`, `serve`) resolve symlinks before serving and allow paths that are lexically inside the active workspace even when their canonical (realpath) target lives outside it through a workspace-internal symlink (for example `~/test_folder -> /shared/test_folder`). Paths that are not inside the workspace lexically are still rejected before any symlink resolution, and write/exec operations keep the strict canonical containment check.
 - `createFsSearchRuntime({ fsPromises, path, spawn, resolveGitBinaryForSpawn })` from `search.js`
   - Returns `{ searchFilesystemFiles(rootPath, options) }`.
   - Supports fuzzy matching, hidden-file handling, and optional `git check-ignore` filtering.

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -169,11 +169,11 @@ const resolveWorkspacePath = ({ targetPath, baseDirectory, path, os, normalizeDi
   const resolvedBase = path.resolve(baseDirectory || os.homedir());
 
   if (isPathWithinRoot(resolved, resolvedBase, path, os)) {
-    return { ok: true, base: resolvedBase, resolved };
+    return { ok: true, base: resolvedBase, resolved, insideWorkspace: true };
   }
 
   if (isPathWithinRoot(resolved, openchamberUserConfigRoot, path, os)) {
-    return { ok: true, base: path.resolve(openchamberUserConfigRoot), resolved };
+    return { ok: true, base: path.resolve(openchamberUserConfigRoot), resolved, insideWorkspace: true };
   }
 
   return { ok: false, error: 'Path is outside of active workspace' };
@@ -202,7 +202,7 @@ const resolveWorkspacePathFromWorktrees = async ({ targetPath, baseDirectory, pa
       }
       const candidateResolved = path.resolve(candidate);
       if (isPathWithinRoot(resolved, candidateResolved, path, os)) {
-        return { ok: true, base: candidateResolved, resolved };
+        return { ok: true, base: candidateResolved, resolved, insideWorkspace: true };
       }
     }
   } catch (error) {
@@ -296,7 +296,7 @@ const resolveReadPathFromContext = async ({ req, targetPath, scope, resolveProje
     });
   }
 
-  return resolveWorkspacePathFromContext({
+  const resolved = await resolveWorkspacePathFromContext({
     req,
     targetPath,
     resolveProjectDirectory,
@@ -305,6 +305,49 @@ const resolveReadPathFromContext = async ({ req, targetPath, scope, resolveProje
     normalizeDirectoryPath,
     openchamberUserConfigRoot,
   });
+  if (resolved.ok || resolved.error !== 'Path is outside of active workspace') {
+    return resolved;
+  }
+
+  // The active project directory is validated with fs.realpath, so the base
+  // is canonical while the client (and the file tree) addresses files under
+  // the user-visible, possibly symlinked root (a workspace-internal symlinked
+  // folder, or a project root that is itself a symlink). Accept paths that
+  // are lexically inside the raw directory the client sent; symlink
+  // resolution happens afterwards, so direct paths outside the workspace
+  // remain rejected and the canonical containment check still applies to
+  // every path that is not inside the workspace.
+  const rawHeaderDirectory = typeof req.get === 'function' ? req.get('x-opencode-directory') : null;
+  const rawHeaderEncoding = typeof req.get === 'function' ? req.get('x-opencode-directory-encoding') : null;
+  const decodedHeaderDirectory = rawHeaderDirectory && rawHeaderEncoding === 'uri'
+    ? (() => {
+      try {
+        return decodeURIComponent(rawHeaderDirectory);
+      } catch {
+        return rawHeaderDirectory;
+      }
+    })()
+    : rawHeaderDirectory;
+  const queryDirectory = Array.isArray(req.query?.directory)
+    ? req.query.directory[0]
+    : req.query?.directory;
+  const lexicalBase = [decodedHeaderDirectory, queryDirectory]
+    .find((value) => typeof value === 'string' && value.trim().length > 0);
+  if (lexicalBase) {
+    const lexical = resolveWorkspacePath({
+      targetPath,
+      baseDirectory: lexicalBase,
+      path,
+      os,
+      normalizeDirectoryPath,
+      openchamberUserConfigRoot,
+    });
+    if (lexical.ok) {
+      return lexical;
+    }
+  }
+
+  return resolved;
 };
 
 const runCommandInDirectory = ({ shell, shellFlag, command, resolvedCwd, spawn, buildAugmentedPath, commandTimeoutMs }) => {
@@ -728,7 +771,7 @@ export const registerFsRoutes = (app, dependencies) => {
         fsPromises.realpath(resolved.base).catch(() => path.resolve(resolved.base)),
       ]);
 
-      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os)) {
+      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os) && !resolved.insideWorkspace) {
         return res.status(403).json({ error: 'Access to file denied' });
       }
 
@@ -785,7 +828,7 @@ export const registerFsRoutes = (app, dependencies) => {
         fsPromises.realpath(resolved.base).catch(() => path.resolve(resolved.base)),
       ]);
 
-      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os)) {
+      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os) && !resolved.insideWorkspace) {
         return res.status(403).json({ error: 'Access to file denied' });
       }
 
@@ -856,7 +899,7 @@ export const registerFsRoutes = (app, dependencies) => {
         fsPromises.realpath(resolved.base).catch(() => path.resolve(resolved.base)),
       ]);
 
-      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os)) {
+      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os) && !resolved.insideWorkspace) {
         return res.status(403).json({ error: 'Access to file denied' });
       }
 
@@ -941,7 +984,7 @@ export const registerFsRoutes = (app, dependencies) => {
         fsPromises.realpath(resolved.base).catch(() => path.resolve(resolved.base)),
       ]);
 
-      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os)) {
+      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os) && !resolved.insideWorkspace) {
         return res.status(403).json({ error: 'Access to file denied' });
       }
 
@@ -1305,7 +1348,14 @@ export const registerFsRoutes = (app, dependencies) => {
     };
 
     try {
-      resolvedPath = await realpathCache.resolve(path.resolve(normalizeDirectoryPath(rawPath)));
+      // Keep the listing directory canonical (realpath-resolved) so readdir
+      // and git check-ignore operate on the real directory, but expose entry
+      // paths under the requested (user-visible) directory. This keeps paths
+      // inside the workspace addressable when the requested directory is a
+      // symlink to a folder outside the project root — otherwise the file
+      // tree hands back canonical paths that the read/stat/raw routes reject.
+      const requestedPath = path.resolve(normalizeDirectoryPath(rawPath));
+      resolvedPath = await realpathCache.resolve(requestedPath);
 
       const stats = await fsPromises.stat(resolvedPath);
       if (!stats.isDirectory()) {
@@ -1364,7 +1414,7 @@ export const registerFsRoutes = (app, dependencies) => {
 
       const entries = await Promise.all(
         dirents.map(async (dirent) => {
-          const entryPath = path.join(resolvedPath, dirent.name);
+          const entryPath = path.join(requestedPath, dirent.name);
           if (respectGitignore && ignoredPaths.has(entryPath)) {
             return null;
           }

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -180,6 +180,26 @@ const registerRaw = (fsPromises) => {
   return getRoute('GET', '/api/fs/raw');
 };
 
+const registerList = (fsPromises) => {
+  const { app, getRoute } = createRouteRegistry();
+  registerFsRoutes(app, {
+    os: { homedir: () => '/home/user' },
+    path: path.posix,
+    fsPromises: {
+      realpath: async (targetPath) => targetPath,
+      ...fsPromises,
+    },
+    spawn: vi.fn(),
+    crypto: { randomUUID: () => 'job-0' },
+    normalizeDirectoryPath: (p) => p,
+    resolveProjectDirectory: async () => ({ directory: '/repo' }),
+    buildAugmentedPath: () => '/usr/bin',
+    resolveGitBinaryForSpawn: () => 'git',
+    openchamberUserConfigRoot: '/home/user/.config',
+  });
+  return getRoute('GET', '/api/fs/list');
+};
+
 const registerMkdir = (fsPromises) => {
   const { app, getRoute } = createRouteRegistry();
   registerFsRoutes(app, {
@@ -428,6 +448,135 @@ describe('fs read', () => {
     expect(fsPromises.readFile).toHaveBeenCalledTimes(4);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Read retry exhausted for /repo/file.txt'));
     warn.mockRestore();
+  });
+
+  it('reads files inside the workspace whose canonical path escapes through a symlinked directory', async () => {
+    // ~/test_folder -> /outside/shared: the requested path is lexically inside
+    // the workspace, the realpath is not. The read must follow the symlink
+    // instead of rejecting it as an outside path.
+    const fsPromises = {
+      realpath: vi.fn(async (targetPath) => {
+        if (targetPath === '/repo/link/file.txt') return '/outside/shared/file.txt';
+        return targetPath;
+      }),
+      stat: vi.fn(async () => ({ isFile: () => true, size: 5 })),
+      readFile: vi.fn(async () => 'hello'),
+    };
+    const handler = registerRead(fsPromises);
+
+    const res = await callRead(handler, { path: '/repo/link/file.txt' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('hello');
+    expect(fsPromises.readFile).toHaveBeenCalledWith('/outside/shared/file.txt', 'utf8');
+  });
+
+  it('rejects reads of canonical paths outside the workspace that no workspace symlink reaches', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fsPromises = {
+      stat: vi.fn(async () => ({ isFile: () => true, size: 6 })),
+      readFile: vi.fn(async () => 'secret'),
+    };
+    const handler = registerRead(fsPromises);
+
+    const res = await callRead(handler, { path: '/outside/shared/file.txt' });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Path is outside of active workspace' });
+    expect(fsPromises.readFile).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('reads files under a symlinked project root addressed via the client-sent lexical directory', async () => {
+    // /home/user/proj -> /real/proj: the validated base is canonical but the
+    // client (and the file tree) address files under the lexical root.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fsPromises = {
+      realpath: vi.fn(async (targetPath) => {
+        if (targetPath === '/home/user/proj') return '/real/proj';
+        if (targetPath === '/home/user/proj/file.txt') return '/real/proj/file.txt';
+        return targetPath;
+      }),
+      stat: vi.fn(async () => ({ isFile: () => true, size: 4 })),
+      readFile: vi.fn(async () => 'data'),
+    };
+    const handler = registerRead(fsPromises);
+    const res = createMockResponse();
+
+    await handler({
+      query: { path: '/home/user/proj/file.txt' },
+      get: (name) => (name === 'x-opencode-directory' ? '/home/user/proj' : undefined),
+    }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('data');
+    expect(fsPromises.readFile).toHaveBeenCalledWith('/real/proj/file.txt', 'utf8');
+    warn.mockRestore();
+  });
+
+  it('rejects path traversal that escapes the workspace even when it passes through a symlinked directory', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fsPromises = {
+      realpath: vi.fn(async (targetPath) => {
+        if (targetPath === '/repo/link') return '/outside/shared';
+        return targetPath;
+      }),
+      stat: vi.fn(async () => ({ isFile: () => true, size: 6 })),
+      readFile: vi.fn(async () => 'secret'),
+    };
+    const handler = registerRead(fsPromises);
+
+    const res = await callRead(handler, { path: '/repo/sub/../../etc/passwd' });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Path is outside of active workspace' });
+    expect(fsPromises.readFile).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('fs list', () => {
+  it('returns entry paths under the requested directory so workspace symlinks stay addressable', async () => {
+    const fsPromises = {
+      realpath: vi.fn(async (targetPath) => {
+        if (targetPath === '/repo/link') return '/outside/shared';
+        return targetPath;
+      }),
+      stat: vi.fn(async () => ({ isDirectory: () => true })),
+      readdir: vi.fn(async () => [
+        { name: 'file.md', isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false },
+      ]),
+    };
+    const handler = registerList(fsPromises);
+    const res = createMockResponse();
+
+    await handler({ query: { path: '/repo/link' } }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.path).toBe('/outside/shared');
+    expect(res.body.entries).toEqual([
+      expect.objectContaining({ name: 'file.md', path: '/repo/link/file.md' }),
+    ]);
+  });
+
+  it('still lists real (non-symlinked) directories with canonical entry paths', async () => {
+    const fsPromises = {
+      realpath: vi.fn(async (targetPath) => targetPath),
+      stat: vi.fn(async () => ({ isDirectory: () => true })),
+      readdir: vi.fn(async () => [
+        { name: 'file.md', isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false },
+      ]),
+    };
+    const handler = registerList(fsPromises);
+    const res = createMockResponse();
+
+    await handler({ query: { path: '/repo' } }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.path).toBe('/repo');
+    expect(res.body.entries).toEqual([
+      expect.objectContaining({ name: 'file.md', path: '/repo/file.md' }),
+    ]);
   });
 });
 


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-235

Opening a file through a symlinked folder inside the project (e.g. `~/test_folder -> /shared/test_folder` with the project rooted at `~`) failed with "Failed to open file" in the file explorer, even though listing the folder worked. The model and the terminal could read the same files, so this was purely an OpenChamber server-side containment bug.

Root cause: the read-family fs routes (`/api/fs/stat`, `/api/fs/read`, `/api/fs/raw`, `/api/fs/serve/*`) run the workspace containment check against the **canonical (realpath-resolved)** file path and base. A symlinked folder inside the workspace whose target lives outside the project root canonicalizes outside the base, so every file under it was rejected with 403 "Access to file denied" (surfaced in the UI as "Failed to open file" because the error text does not match the "not found" classifier). In addition, `/api/fs/list` returned entry paths under the canonical directory, so the file tree handed the read routes canonical paths that even failed the lexical workspace check.

Behavior change: files whose **user-visible (lexical) path is inside the active workspace** are now readable even when the symlink target resolves outside it. Symlink resolution still happens before any file is opened, direct paths outside the workspace (traversal, absolute paths, crafted canonical paths not reachable from the workspace) are still rejected before resolution, and write/exec operations keep the strict canonical containment boundary unchanged.

## Non-goals

- Writes through workspace-internal symlinks: `/api/fs/write` keeps its strict canonical containment check (existing behavior + test). The issue is about viewing files.
- `@`-mention file search (opencode's own `/api/find/file` search scope): the issue mentions it, but it is driven by the upstream OpenCode server's directory indexing, not this route module; out of scope for this fix.
- The dead/broken worktree fallback was not touched (unrelated; see Risks).

## Affected surfaces

- `packages/web` server: `/api/fs/read`, `/api/fs/stat`, `/api/fs/raw`, `/api/fs/serve/:path`, `/api/fs/list` in `packages/web/server/lib/fs/routes.js` (plain JS — not covered by the web TS type-check/lint scripts; validated with the vitest suite + a real-fs E2E script).
- Shared UI consumers are **not** changed: `SidebarFilesTree`, `FilesView`, `MobileFilesSurface` navigate with server-provided entry paths, which now stay under the requested (lexical) directory — the same contract shape (absolute path per entry), so no UI change needed. `DirectoryExplorerDialog` uses the SDK `listLocalDirectory` path, not `/api/fs/list`, so the project-add "already added" matching (#1316) is unaffected.
- Web/desktop/mobile all share the same server routes; behavior is identical across runtimes. VS Code webview has its own file bridge and is unaffected.
- Persisted contracts: none (no schema/settings changes).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` root rules | Workspace boundary enforcement is security-relevant; "enforce security and correctness in core/runtime logic" | Containment still enforced: outside paths rejected *before* symlink resolution; canonical check retained for every path that is not lexically inside the workspace; write/exec untouched |
| `ui-api-decoupling` skill | Change touches OpenChamber HTTP routes consumed by shared UI via `runtimeFetch`/`FilesAPI` | Route contract preserved (`FilesAPI.readFile/statFile/listDirectory` unchanged); no SDK bypass, no new routes, no hardcoded URLs |
| `packages/web/server/lib/fs/DOCUMENTATION.md` | Owning module documentation must reflect invariant changes | Updated with the read-family symlink rule |
| `packages/web/README.md` | Package-level doc read per AGENTS.md | No API surface documented there is affected |
| Focused test precedent (`routes.test.js`) | Server JS needs runtime validation, not just static checks | 6 new focused tests + real-fs E2E script (see Validation) |

## Validation

| Check | Result |
|---|---|
| `bun test server/lib/fs/routes.test.js` (packages/web) | 29 pass, 0 fail (438ms), incl. 6 new tests: read through symlinked dir → 200 + content read from realpath; direct canonical outside path → 400; traversal escape → 400; symlinked project root via lexical client directory → 200; list returns entry paths under requested dir for symlinked and non-symlinked dirs |
| `bun run type-check` (packages/web) | Passed (tsc --noEmit, exit 0) |
| `bun run lint` (packages/web) | Passed (eslint exit 0). Note: script only covers `src/**/*.{ts,tsx}` — server JS is validated via tests below |
| Real-fs E2E script (`/tmp/opencode/e2e-235.mjs`, real `fs.promises` + real symlinks) | list of `~/test_folder` returns `/home/test_folder/file.md`; read via symlinked dir → 200 "hello from shared"; direct canonical `/shared/...` path → 400; `../` traversal → 400; workspace-internal symlink to outside file → 200 (intended) |
| `bun run dead-code` | Not run: no files added/deleted, no export/entrypoint changes |

Not verified: no live browser/UI session against a real server was possible in this environment (no running OpenChamber instance), so the toast-level UI flow was not exercised end-to-end in a browser; the route-level behavior it depends on is covered by the vitest and real-fs checks.

## Visual evidence

No screenshots: this environment cannot run the OpenChamber web UI against a live server. The change is server-side only — the rendered file explorer itself is unchanged. Expected visible behavior after the fix: clicking a file inside a symlinked folder in the file explorer opens its contents (and stat/raw/preview/downloads for such files work) instead of showing the "Failed to open file" toast; listing behavior is visually identical (entries still show the same names under the same folders).

## Risks and failure behavior

- Security boundary: the relaxation only applies to paths that are lexically inside the workspace the client already selected (the client can already choose the workspace via `x-opencode-directory`). Direct outside paths, traversal, and crafted canonical paths are still rejected; the canonical containment check still runs for all non-workspace paths. Write (`/api/fs/write`) retains its strict canonical check and its existing regression test, so a symlinked outside target cannot be written through.
- Listing change: entry paths are now joined under the requested directory instead of the realpath'd one. Consumers of `/api/fs/list` (SidebarFilesTree, FilesView, MobileFilesSurface) only navigate/open with these paths, so behavior is preserved; the response `path` field stays canonical to keep the #1316 session/project matching intact. Search (git check-ignore) still runs against the canonical directory.
- Failure behavior: no new failure modes introduced — rejected requests return the same 400/403 error shapes as before; empty-read retry logic and `optional` handling untouched.
- Pre-existing, unrelated: `resolveWorkspacePathFromWorktrees` runs `git worktree list` and fails gracefully when the worktree fallback triggers (observed in E2E); unchanged by this PR.
