### PR TITLE
feat(server): validate OPENCHAMBER_OPENCODE_HOSTNAME bind hostname

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -110,7 +110,7 @@ OPENCODE_HOST=https://myhost:4096 OPENCODE_SKIP_START=true openchamber
 | `OPENCODE_HOST` | Full base URL of external server (overrides `OPENCODE_PORT`) |
 | `OPENCODE_PORT` | Port of external server |
 | `OPENCODE_SKIP_START` | Skip starting embedded OpenCode server |
-| `OPENCHAMBER_OPENCODE_HOSTNAME` | Bind hostname for managed OpenCode server (default: `127.0.0.1`, use `0.0.0.0` for LAN/remote access — trusted networks only) |
+| `OPENCHAMBER_OPENCODE_HOSTNAME` | Bind hostname for managed OpenCode server (default: `127.0.0.1`, use `0.0.0.0` for LAN/remote access — trusted networks only). Invalid values are rejected with an error and fall back to loopback |
 | `OPENCHAMBER_HOST` | Bind hostname for the OpenChamber web server (default: `127.0.0.1`; use `0.0.0.0` for LAN/remote access — trusted networks only) |
 | `OPENCHAMBER_VERBOSE_REQUEST_LOGS` | Set to `true` to log every HTTP request; disabled by default to keep user logs small |
 | `OPENCHAMBER_SKIP_API_COMPRESSION` | Set to `true` to disable gzip compression for `/api/*` responses |

--- a/packages/web/server/lib/opencode/env-config.js
+++ b/packages/web/server/lib/opencode/env-config.js
@@ -1,3 +1,26 @@
+import { isIP } from 'node:net';
+
+const MAX_HOSTNAME_LENGTH = 253;
+const HOSTNAME_LABEL_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+// All-numeric dotted values must be a real IPv4 address; otherwise typo'd IPs
+// like "0.0.0.0.0" would slip through as (technically valid) hostnames.
+const ALL_NUMERIC_DOTTED_RE = /^\d+(?:\.\d+)*$/;
+
+// Valid bind hostnames for the managed OpenCode server: IPv4, IPv6 (with or
+// without brackets), or a DNS-style hostname. Everything else (URLs, ports,
+// paths, whitespace, underscores) is rejected.
+export const isValidOpenCodeHostname = (value) => {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_HOSTNAME_LENGTH) return false;
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    return isIP(trimmed.slice(1, -1)) === 6;
+  }
+  if (isIP(trimmed) !== 0) return true;
+  if (ALL_NUMERIC_DOTTED_RE.test(trimmed)) return false;
+  return trimmed.split('.').every((label) => HOSTNAME_LABEL_RE.test(label));
+};
+
 export const resolveOpenCodeEnvConfig = (options = {}) => {
   const env = options.env && typeof options.env === 'object' ? options.env : {};
   const logger = options.logger ?? console;
@@ -57,6 +80,14 @@ export const resolveOpenCodeEnvConfig = (options = {}) => {
     if (!trimmed) {
       logger.warn(
         `[config] Ignoring OPENCHAMBER_OPENCODE_HOSTNAME=${JSON.stringify(raw)}: empty after trimming`,
+      );
+      return '127.0.0.1';
+    }
+    if (!isValidOpenCodeHostname(trimmed)) {
+      logger.error(
+        `[config] Rejecting OPENCHAMBER_OPENCODE_HOSTNAME=${JSON.stringify(raw)}: `
+        + 'must be a valid hostname or IP address (for example 127.0.0.1, 0.0.0.0, localhost, [::1]); '
+        + 'falling back to 127.0.0.1 (loopback only)',
       );
       return '127.0.0.1';
     }

--- a/packages/web/server/lib/opencode/env-config.test.js
+++ b/packages/web/server/lib/opencode/env-config.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isValidOpenCodeHostname, resolveOpenCodeEnvConfig } from './env-config.js';
+
+describe('isValidOpenCodeHostname', () => {
+  it('accepts IPv4 addresses', () => {
+    expect(isValidOpenCodeHostname('127.0.0.1')).toBe(true);
+    expect(isValidOpenCodeHostname('0.0.0.0')).toBe(true);
+    expect(isValidOpenCodeHostname('192.168.1.10')).toBe(true);
+  });
+
+  it('accepts IPv6 addresses with and without brackets', () => {
+    expect(isValidOpenCodeHostname('::1')).toBe(true);
+    expect(isValidOpenCodeHostname('[::1]')).toBe(true);
+    expect(isValidOpenCodeHostname('::')).toBe(true);
+    expect(isValidOpenCodeHostname('[::]')).toBe(true);
+  });
+
+  it('accepts DNS-style hostnames', () => {
+    expect(isValidOpenCodeHostname('localhost')).toBe(true);
+    expect(isValidOpenCodeHostname('tailscale-host')).toBe(true);
+    expect(isValidOpenCodeHostname('my.host.example')).toBe(true);
+  });
+
+  it('rejects malformed values', () => {
+    const invalid = [
+      '',
+      '   ',
+      'http://localhost',
+      'https://host:4096',
+      'host:4096',
+      'host/path',
+      'bad host',
+      'bad_host',
+      '0.0.0.0.0',
+      '999.999.999.999',
+      '[::1',
+      '::1]',
+      'a'.repeat(254),
+      '1.2.3.4.5.6.7.8.9',
+    ];
+    for (const value of invalid) {
+      expect(isValidOpenCodeHostname(value), JSON.stringify(value)).toBe(false);
+    }
+  });
+
+  it('rejects non-string values', () => {
+    expect(isValidOpenCodeHostname(undefined)).toBe(false);
+    expect(isValidOpenCodeHostname(null)).toBe(false);
+    expect(isValidOpenCodeHostname(42)).toBe(false);
+  });
+});
+
+describe('resolveOpenCodeEnvConfig hostname', () => {
+  it('defaults to loopback when the env var is absent', () => {
+    expect(resolveOpenCodeEnvConfig({ env: {} }).configuredOpenCodeHostname).toBe('127.0.0.1');
+  });
+
+  it('reads OPENCHAMBER_OPENCODE_HOSTNAME', () => {
+    const result = resolveOpenCodeEnvConfig({ env: { OPENCHAMBER_OPENCODE_HOSTNAME: '0.0.0.0' } });
+    expect(result.configuredOpenCodeHostname).toBe('0.0.0.0');
+  });
+
+  it('trims surrounding whitespace', () => {
+    const result = resolveOpenCodeEnvConfig({ env: { OPENCHAMBER_OPENCODE_HOSTNAME: '  tailscale-host  ' } });
+    expect(result.configuredOpenCodeHostname).toBe('tailscale-host');
+  });
+
+  it('warns and falls back for an empty value', () => {
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    const result = resolveOpenCodeEnvConfig({ env: { OPENCHAMBER_OPENCODE_HOSTNAME: '   ' }, logger });
+    expect(result.configuredOpenCodeHostname).toBe('127.0.0.1');
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('empty after trimming'));
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid values with a clear error and falls back to loopback', () => {
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    const result = resolveOpenCodeEnvConfig({
+      env: { OPENCHAMBER_OPENCODE_HOSTNAME: 'http://nope:4096' },
+      logger,
+    });
+    expect(result.configuredOpenCodeHostname).toBe('127.0.0.1');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Rejecting OPENCHAMBER_OPENCODE_HOSTNAME'),
+    );
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('127.0.0.1'));
+  });
+
+  it('keeps other env config intact when the hostname is validated', () => {
+    const result = resolveOpenCodeEnvConfig({
+      env: { OPENCHAMBER_OPENCODE_HOSTNAME: '0.0.0.0', OPENCODE_PORT: '4096' },
+    });
+    expect(result.configuredOpenCodeHostname).toBe('0.0.0.0');
+    expect(result.configuredOpenCodePort).toBe(4096);
+    expect(result.effectivePort).toBe(4096);
+  });
+});

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -50,7 +50,7 @@ const createMockChild = () => {
   return child;
 };
 
-const createRuntime = (overrides = {}, stateOverrides = {}) => {
+const createRuntime = (overrides = {}, stateOverrides = {}, envOverrides = {}) => {
   const state = {
     openCodeWorkingDirectory: '/tmp/project',
     openCodeProcess: null,
@@ -83,6 +83,7 @@ const createRuntime = (overrides = {}, stateOverrides = {}) => {
       ENV_EFFECTIVE_PORT: 3001,
       ENV_CONFIGURED_OPENCODE_HOSTNAME: '127.0.0.1',
       ENV_SKIP_OPENCODE_START: false,
+      ...envOverrides,
     },
     syncToHmrState: vi.fn(),
     syncFromHmrState: vi.fn(),
@@ -307,6 +308,27 @@ describe('OpenCode lifecycle', () => {
     expect(options.env.OPENCODE_SERVER_PASSWORD).toBe('password');
     expect(server.exitCode).toBeNull();
     expect(server.signalCode).toBeNull();
+
+    await server.close();
+    expect(server.signalCode).toBe('SIGTERM');
+  });
+
+  it('launches managed OpenCode on the configured bind hostname', async () => {
+    delete process.env.OPENCODE_BINARY;
+    const child = createMockChild();
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        child.stdout.emit('data', 'opencode server listening on http://0.0.0.0:45678\n');
+      });
+      return child;
+    });
+
+    const runtime = createRuntime({}, {}, { ENV_CONFIGURED_OPENCODE_HOSTNAME: '0.0.0.0' });
+    const server = await runtime.startOpenCode();
+    const [binary, args] = spawnMock.mock.calls[0];
+
+    expect(binary).toBe('opencode');
+    expect(args).toEqual(['serve', '--hostname', '0.0.0.0', '--port', '45678']);
 
     await server.close();
     expect(server.signalCode).toBe('SIGTERM');


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-231

Allow configuring the bind hostname of the managed OpenCode server spawn via
`OPENCHAMBER_OPENCODE_HOSTNAME` so the OpenCode server can be reached from LAN
or overlay networks (Tailscale) without a reverse proxy. The env var was
already read with a `127.0.0.1` default and passed through to the spawn
(`--hostname`), but **any non-empty string was accepted**. This PR adds the
missing validation: values that are not a valid IPv4/IPv6 address (brackets
allowed) or DNS-style hostname are rejected with a clear `[config]` error and
fall back to the secure loopback default, so a typo can never silently bind a
non-loopback address. Default stays loopback-only; binding to `0.0.0.0` /
`::` remains opt-in and is documented as trusted-networks-only.

## Non-goals

- Not changing the `OPENCHAMBER_HOST` (OpenChamber web server bind) behavior.
- Not changing the managed OpenCode **port** resolution (`OPENCODE_PORT` /
  `OPENCHAMBER_OPENCODE_PORT`).
- Not adding a CLI flag; the issue asks for the env var, which already exists
  end-to-end. Only validation was missing.
- Not hard-failing server startup on an invalid value (see Risks): the invalid
  value is rejected and the server continues on loopback with a visible error.

## Affected surfaces

- `packages/web/server/lib/opencode/env-config.js` — new exported
  `isValidOpenCodeHostname()` validator; `configuredOpenCodeHostname` now
  rejects invalid values with `logger.error` and falls back to `127.0.0.1`.
- `packages/web/server/lib/opencode/env-config.test.js` — new focused test file.
- `packages/web/server/lib/opencode/lifecycle.test.js` — env parameterization
  plus a test that a non-default hostname flows into the spawn args
  (`serve --hostname 0.0.0.0 --port ...`).
- `packages/web/README.md` — env-var table row documents rejection + fallback.
- Runtimes: the env config is resolved once at server module load
  (`server/index.js`) and consumed by the web/Electron-managed spawn path
  (`lifecycle.js`), the network runtime (`buildOpenCodeUrl`), and port probing.
  VS Code/mobile do not spawn the managed OpenCode server from this config and
  are unaffected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `clack-cli-patterns` skill | Error-path output contract for the CLI (`openchamber serve`/`openchamber -d` surface this config) | The rejection is emitted via `logger.error` with a stable `[config] Rejecting OPENCHAMBER_OPENCODE_HOSTNAME=...` prefix so it is deterministic and greppable in foreground stdout and in daemon logs (`openchamber logs -p <port>`); mode-agnostic (no prompts, no TTY dependence). |
| `ui-api-decoupling` skill | Runtime config plumbing for the managed OpenCode spawn | Validation stays at the single config-resolution entry point (`env-config.js`) that `index.js` feeds into the spawn/network runtimes; no URL building or auth behavior changes. |
| `packages/web/README.md` | Docs precedent from the original feature PR (#599) | Env-var table updated; the existing "Bind managed OpenCode to LAN / Tailscale" section already documents the `0.0.0.0` security risk, which this PR preserves. |
| `AGENTS.md` security invariant | "Do not change security defaults" | Default remains `127.0.0.1`; invalid values fall back to loopback; `0.0.0.0`/`::` are valid but remain explicit opt-in with documented risk. |

## Validation

| Check | Result |
|---|---|
| `node --check packages/web/server/lib/opencode/{env-config.js,env-config.test.js}` | Syntax OK |
| `bun test packages/web/server/lib/opencode/env-config.test.js packages/web/server/lib/opencode/lifecycle.test.js` | 26 pass, 0 fail (includes new validator tests + new spawn-args test) |
| `bun test packages/web/server/lib/opencode/network-runtime.test.js` | 4 pass, 0 fail |
| `bun test packages/web/server/lib/opencode/` (full dir) | 5 fail / 1 error — **pre-existing environmental flakiness**, verified identical on the unmodified baseline via `git stash` (rate-limit timing tests, upgrade-route tests doing real `fetch` to `http://127.0.0.1:4096/global/upgrade` → ConnectionRefused, shutdown-timer test). None touch env-config or the hostname path. |
| `bun run type-check:web` | Clean (tsc --noEmit) |
| `bun run lint:web` | Clean (eslint) |
| `bun run dead-code` | No new findings for touched files (new export `isValidOpenCodeHostname` and new test file are both used; report is pre-existing items only, non-blocking) |

Not verified end-to-end: actually spawning a real `opencode serve --hostname 0.0.0.0`
on this machine (the spawn-arg contract is covered by the lifecycle unit test;
a live spawn on a non-loopback interface would require a network-interface
change on the test host). The validation behavior itself is fully unit-tested
with a mock logger.

## Visual evidence

No screenshots: CLI/server config change. Expected terminal/log output for an
invalid value (`OPENCHAMBER_OPENCODE_HOSTNAME=http://nope:4096 openchamber`):

```
[config] Rejecting OPENCHAMBER_OPENCODE_HOSTNAME="http://nope:4096": must be a valid hostname or IP address (for example 127.0.0.1, 0.0.0.0, localhost, [::1]); falling back to 127.0.0.1 (loopback only)
```

## Risks and failure behavior

- **Security default preserved:** an invalid or absent value always yields
  loopback-only binding; nothing in this PR can widen exposure. Binding to
  `0.0.0.0`/`::` exposes the managed OpenCode server on all interfaces — the
  README already warns to use it only on trusted networks (with firewall rules
  or `--ui-password`), and that guidance is unchanged.
- **Hard-fail vs fallback:** invalid values are rejected with an error but the
  server still starts on loopback rather than exiting. Rationale: the same
  env-config module already treats invalid `OPENCODE_HOST`/`OPENCODE_PORT`
  values as ignore-with-warning, and `index.js` is embedded in-process by the
  Electron host, where a module-load throw would take down the whole app.
  The error is deterministic and visible in foreground output and daemon logs.
- **Fallback semantics:** `'  '` (whitespace-only) keeps the existing warn +
  fallback path; non-string values (e.g. empty) default silently as before.
- **Compatibility:** valid existing configurations (`127.0.0.1`, `0.0.0.0`,
  `localhost`, `::1`, `[::1]`, DNS names) are unaffected; only previously
  garbage values change behavior (from "silently passed to `listen` and likely
  crash at runtime" to "rejected with a clear error and safe fallback").
