### PR TITLE
fix(git): refresh git status changed files after worktree setup completes

### DIFF
--- a/packages/ui/src/lib/worktrees/worktreeBootstrap.test.ts
+++ b/packages/ui/src/lib/worktrees/worktreeBootstrap.test.ts
@@ -45,6 +45,16 @@ mock.module('@/lib/gitApiHttp', () => ({
   },
 }));
 
+const gitRefreshHints: Array<{ directory: string; paths?: string[] }> = [];
+
+mock.module('@/lib/sessionEvents', () => ({
+  sessionEvents: {
+    requestGitRefresh: (hint: { directory: string; paths?: string[] }) => {
+      gitRefreshHints.push(hint);
+    },
+  },
+}));
+
 const {
   clearWorktreeBootstrapState,
   getWorktreeBootstrapState,
@@ -67,6 +77,7 @@ describe('worktreeBootstrap.waitForWorktreeBootstrap', () => {
   beforeEach(() => {
     bootstrapStatusCalls.length = 0;
     toastErrors.length = 0;
+    gitRefreshHints.length = 0;
     bootstrapStatusResult = { status: 'ready', error: null, updatedAt: 1 };
     getBootstrapStatus = () => Promise.resolve(bootstrapStatusResult);
     clearWorktreeBootstrapState('/repo');
@@ -244,5 +255,100 @@ describe('worktreeBootstrap.waitForWorktreeBootstrap', () => {
     await waitFor(() => bootstrapStatusCalls.length === 1);
     expect(bootstrapStatusCalls).toEqual(['/repo-wt']);
     clearWorktreeBootstrapState('/repo-wt');
+  });
+
+  test('emits a git status refresh hint when setup completes via wait', async () => {
+    markWorktreeBootstrapPending('/repo-wt');
+    bootstrapStatusResult = {
+      status: 'ready',
+      phase: 'setup-ready',
+      error: null,
+      updatedAt: 2,
+    };
+
+    await waitForWorktreeBootstrap('/repo-wt');
+
+    expect(gitRefreshHints).toEqual([{ directory: '/repo-wt' }]);
+  });
+
+  test('emits a git status refresh hint when setup completes via background watcher', async () => {
+    markWorktreeBootstrapPending('/repo-wt');
+    bootstrapStatusResult = {
+      status: 'ready',
+      phase: 'setup-ready',
+      error: null,
+      updatedAt: 2,
+    };
+
+    startWorktreeBootstrapWatcher('/repo-wt', { pollIntervalMs: 0 });
+
+    await waitFor(() => gitRefreshHints.length === 1);
+    expect(gitRefreshHints).toEqual([{ directory: '/repo-wt' }]);
+  });
+
+  test('does not emit a git status refresh hint for git-ready alone', async () => {
+    markWorktreeBootstrapPending('/repo-wt');
+    bootstrapStatusResult = {
+      status: 'pending',
+      phase: 'git-ready',
+      error: null,
+      updatedAt: 2,
+    };
+
+    await waitForWorktreeGitReady('/repo-wt');
+
+    expect(gitRefreshHints).toEqual([]);
+  });
+
+  test('emits a single git status refresh hint when waiter and watcher observe the same completion', async () => {
+    markWorktreeBootstrapPending('/repo-wt');
+    bootstrapStatusResult = {
+      status: 'ready',
+      phase: 'setup-ready',
+      error: null,
+      updatedAt: 2,
+    };
+
+    const waiter = waitForWorktreeBootstrap('/repo-wt');
+    startWorktreeBootstrapWatcher('/repo-wt', { pollIntervalMs: 0 });
+    await waiter;
+    await waitFor(() => bootstrapStatusCalls.length >= 2);
+
+    expect(gitRefreshHints).toEqual([{ directory: '/repo-wt' }]);
+  });
+
+  test('does not emit for an already-ready directory without polling', async () => {
+    setWorktreeBootstrapState('/repo-wt', {
+      status: 'ready',
+      phase: 'setup-ready',
+      error: null,
+      updatedAt: 1,
+    });
+
+    await waitForWorktreeBootstrap('/repo-wt');
+
+    expect(bootstrapStatusCalls).toEqual([]);
+    expect(gitRefreshHints).toEqual([]);
+  });
+
+  test('emits again for a fresh lifecycle after re-marking the same directory pending', async () => {
+    markWorktreeBootstrapPending('/repo-wt');
+    bootstrapStatusResult = {
+      status: 'ready',
+      phase: 'setup-ready',
+      error: null,
+      updatedAt: 2,
+    };
+
+    await waitForWorktreeBootstrap('/repo-wt');
+    expect(gitRefreshHints).toEqual([{ directory: '/repo-wt' }]);
+
+    markWorktreeBootstrapPending('/repo-wt');
+    await waitForWorktreeBootstrap('/repo-wt');
+
+    expect(gitRefreshHints).toEqual([
+      { directory: '/repo-wt' },
+      { directory: '/repo-wt' },
+    ]);
   });
 });

--- a/packages/ui/src/lib/worktrees/worktreeBootstrap.ts
+++ b/packages/ui/src/lib/worktrees/worktreeBootstrap.ts
@@ -1,6 +1,7 @@
 import * as gitHttp from '@/lib/gitApiHttp';
 import type { GitWorktreeBootstrapStatus } from '@/lib/api/types';
 import { getRegisteredRuntimeAPIs } from '@/contexts/runtimeAPIRegistry';
+import { sessionEvents } from '@/lib/sessionEvents';
 import { toast } from '@/components/ui';
 import { formatMessage, useI18nStore, type I18nKey, type I18nParams } from '@/lib/i18n';
 
@@ -20,6 +21,12 @@ const waiters = new Map<string, Promise<void>>();
 const lifecycleVersions = new Map<string, number>();
 let nextLifecycleVersion = 0;
 const watchers = new Map<string, { cancelled: boolean; lifecycleVersion: number }>();
+// Lifecycle-scoped dedupe for the git-status refresh hint: when a poll observes
+// the server-side setup completion (status 'ready'), the worktree directory may
+// have been fetched before setup finished (not yet a repo / empty status), so
+// subscribers must re-fetch changed files. Emit once per lifecycle — a fresh
+// lifecycle (new setup for the same path) may emit again.
+const readyNotifiedLifecycles = new Map<string, number>();
 
 const getKey = (directory: string): string => normalizePath(directory);
 const getWaiterKey = (key: string, target: WorktreeBootstrapTarget): string => `${key}\n${target}`;
@@ -33,12 +40,21 @@ const startLifecycle = (key: string): void => {
 
   waiters.delete(getWaiterKey(key, 'git-ready'));
   waiters.delete(getWaiterKey(key, 'setup-ready'));
+  readyNotifiedLifecycles.delete(key);
 
   const version = ++nextLifecycleVersion;
   lifecycleVersions.set(key, version);
 };
 
 const isCurrentLifecycle = (key: string, version: number): boolean => lifecycleVersions.get(key) === version;
+
+const notifyGitStatusRefreshOnce = (key: string, lifecycleVersion: number, directory: string): void => {
+  if (readyNotifiedLifecycles.get(key) === lifecycleVersion) {
+    return;
+  }
+  readyNotifiedLifecycles.set(key, lifecycleVersion);
+  sessionEvents.requestGitRefresh({ directory });
+};
 
 const phaseRank = (phase: GitWorktreeBootstrapStatus['phase']): number => {
   switch (phase) {
@@ -172,6 +188,9 @@ const pollWorktreeBootstrapUntilSettled = async (
     }
 
     if (hasReachedTarget(current, target)) {
+      if (current.status === 'ready') {
+        notifyGitStatusRefreshOnce(key, lifecycleVersion, directory);
+      }
       return;
     }
 
@@ -208,6 +227,7 @@ const pollWorktreeBootstrapInBackground = async (
     }
 
     if (current.status === 'ready') {
+      notifyGitStatusRefreshOnce(key, watcher.lifecycleVersion, directory);
       onReady?.(current);
       return;
     }


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-266

After a worktree's setup completes (server-side background bootstrap: checkout, upstream config, setup commands), the UI's git status changed-files state for the new worktree directory was never refreshed. The changed-files view (GitView) could stay on the "Worktree setup in progress" empty state indefinitely, because a status fetch that ran while setup was pending cached `isGitRepo=false` and the re-probe is gated behind the 60-second repo-check threshold in `useGitStore`.

Fix: when a worktree bootstrap poll observes the server-side `ready` status, emit the established git-refresh signal (`sessionEvents.requestGitRefresh({ directory })`) for that worktree directory. GitView, DiffView, and ChatInput already subscribe to this hint and re-fetch git status (including re-probing repo-ness) for the hinted directory, so the changed-files list appears as soon as setup completes.

## Non-goals

- Server-side change of the bootstrap flow itself: the server already marks setup-ready correctly; only the client-side completion signal was missing. No server routes touched.
- Refreshing the primary project's status on worktree creation: worktree setup only writes into the new worktree directory (setup commands run there), so the primary repo's changed files are unaffected. The hint targets the worktree directory.
- Touching the `waitForWorktreeBootstrap` early-return path (already-ready state, no polling): emitting there would fire on every session send in a ready worktree when "wait for setup commands" is enabled — noisy and out of scope. Emissions only happen on an observed pending→ready transition.

## Affected surfaces

- `packages/ui` shared library: `packages/ui/src/lib/worktrees/worktreeBootstrap.ts` — the single choke point where all setup-completion observations funnel (the background watcher started by `worktreeManager.createWorktree`, and the waiters used by `NewWorktreeDialog`, `worktreeSessionCreator`, `useMultiRunStore`, and `session-ui-store`).
- The refresh channel is the existing `sessionEvents.requestGitRefresh` (used by `session-actions`, `ToolPart`, `FilesView` after git-mutating operations), consumed by `GitView`, `DiffView`, and `ChatInput`. No new channels, no new stores.
- Runtimes: web, desktop, hosted-mobile and Capacitor all run this shared UI and the same server bootstrap API, so the fix applies to every runtime where worktree creation exists. VS Code webview shares the same shared-UI module.
- Persisted contracts: none.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `ui-api-decoupling` skill | Change emits a shared-UI refresh signal consumed by components that fetch git data via `RuntimeAPIs`/`gitApi` | Reuses the existing `sessionEvents.requestGitRefresh` channel and `GitWorktreeBootstrapStatus` API; no new routes, no SDK bypass, no runtime-specific assumptions |
| `sync-state-invariants` skill + `packages/ui/src/sync/DOCUMENTATION.md` | Refresh signals must be authoritative and not noisy; store updates must not fire from stale lifecycles | Emission is tied to the authoritative server-observed `ready` status, scoped to the bootstrap lifecycle (stale-lifecycle polls return null before any emission), and deduped once per lifecycle; no store mutation added here |
| `AGENTS.md` root rules | Keep changes minimal, preserve unrelated behavior | 2 files touched; the hint is a no-op when no consumer subscribes for that directory; failure of the hint cannot break setup completion (emission is fire-and-forget, after the state is stored) |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/lib/worktrees/worktreeBootstrap.test.ts` | 18 pass, 0 fail (76ms) — 12 existing + 6 new: hint emitted once on ready via waiter; emitted once on ready via background watcher; NOT emitted for git-ready alone (setup not finished); single emission when waiter + watcher observe the same completion; no emission for already-ready directories without polling; re-emission for a fresh lifecycle after re-marking pending |
| `bun test packages/ui/src/lib/worktrees/worktreeManager.test.ts` | 18 pass, 0 fail (58ms) — createWorktree flow unaffected |
| `bun test packages/ui/src/stores/useMultiRunStore.test.ts` | 3 pass, 0 fail (86ms) — multi-run worktree wait flow unaffected |
| `bun test packages/ui/src/lib/worktrees/worktreeStatus.test.ts` | 9 pass, 0 fail |
| `bun run type-check` (packages/ui) | Passed (tsc --noEmit, exit 0) |
| `bun run lint` (packages/ui) | Passed (eslint exit 0) |
| `bun run dead-code` | Not run: no files added/deleted, no export/entrypoint/type changes (only a new internal import) |

Not verified: no live server + browser session was available in this environment, so the end-to-end "create worktree → setup completes → changed files appear" interaction was not exercised in a running app; it is covered by the unit tests at the emission point plus the pre-existing subscription behavior in GitView/DiffView/ChatInput (unchanged by this PR).

Note: running several test files in one `bun test` invocation shows pre-existing `mock.module` registry interference (verified identical failures on the unmodified baseline); each file passes individually, which is how focused validation runs here.

## Visual evidence

No screenshots: this environment cannot run the OpenChamber UI against a live server. The change is a signal-emission fix with no rendering change. Expected visible behavior: when a worktree's setup completes, the Changes view for that worktree stops showing the "Worktree setup in progress" placeholder and shows the actual changed-files list (including untracked/modified files produced by setup commands) without requiring a manual refresh; sidebar/file-tree status badges for the worktree directory update on the same hint.

## Risks and failure behavior

- Emission is fire-and-forget and happens after the polled state is stored, so a failure inside `requestGitRefresh` cannot break bootstrap completion, session creation, or the existing toasts.
- The hint is deduped per bootstrap lifecycle; a new lifecycle (re-creating a worktree at the same path, or a failed setup retried) re-arms it, so repeated setups still trigger one refresh each.
- No data loss or cleanup concerns: the hint only triggers a silent `fetchStatus` in consumers subscribed to that directory; in-flight status fetches are deduped in `useGitStore`, and a hint for a directory no consumer is viewing is a no-op.
