### PR TITLE
fix(sync): route question/permission replies by the request's own session directory

### DIFF
--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -255,6 +255,10 @@ Examples of global-store updates performed in `session-actions.ts`:
 - `deleteSession()` / `deleteSessions()` -> wait for server confirmation or `404`, then remove the session and its persisted state
 - `moveSessionToDirectory()` -> move the session between directory stores and update the global directory index
 
+### Blocking-request (question/permission) reply routing
+
+`respondToQuestion`, `rejectQuestion`, `respondToPermission`, and `dismissPermission` route the reply through `resolveDirectoryForBlockingRequest`. The directory chosen decides which OpenCode instance resolves the pending request, so it must be the **session record's own server-confirmed directory** (ownership), never the containing child-store key (containment): a project store legitimately holds its worktree sessions, and a reply addressed to the parent instance makes the server answer `QuestionNotFoundError` while the question stays pending in the worktree instance — the session is then stuck on the running question tool with no recovery. When a reply/reject comes back not-found, the stale request is removed locally and a `settled-running-tool` tail materialization is enqueued so the trailing tool part converges to the server's actual state instead of leaving the UI on "asking question" forever.
+
 ### Restore (unarchive) contract
 
 The OpenCode server cannot clear `time.archived` over HTTP: `session.update`

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -1461,6 +1461,165 @@ describe("rejectQuestion passes directory", () => {
   })
 })
 
+describe("blocking request reply routing and stale recovery (issue OPE-236)", () => {
+  const materializationCalls: Array<{ directory: string; sessionID: string; messageID: string }> = []
+  const enqueueMaterialization = (directory: string, sessionID: string, messageID: string) => {
+    materializationCalls.push({ directory, sessionID, messageID })
+  }
+
+  beforeEach(() => {
+    replyCalls.length = 0
+    scopedClientDirectories.length = 0
+    questionReplyError = null
+    questionRejectError = null
+    materializationCalls.length = 0
+  })
+
+  test("routes the question reply by the request's own session directory, not the containing store key", async () => {
+    // The question was asked by a worktree session whose record lives in the
+    // parent store (containment). The reply must be addressed to the session's
+    // own server-confirmed directory — otherwise the server resolves the
+    // parent instance, does not find the pending question, and answers
+    // QuestionNotFoundError, leaving the session stuck on "asking question".
+    const question = buildQuestion("q-wt", "session-wt")
+    const store = createStore({}, {
+      session: [{ id: "session-wt", directory: "/test/project/wt" } as Session],
+      question: { "session-wt": [question] },
+    })
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project", enqueueMaterialization)
+
+    await respondToQuestion("session-wt", "q-wt", [["Yes"]])
+
+    expect(scopedClientDirectories).toEqual(["/test/project/wt"])
+    expect(replyCalls[0]?.params.directory).toBe("/test/project/wt")
+    expect(replyCalls[0]?.params.requestID).toBe("q-wt")
+  })
+
+  test("routes permission replies by the request's own session directory", async () => {
+    const permission = buildPermission("perm-wt", "session-wt")
+    const store = createStore(
+      { "session-wt": [permission] },
+      {
+        session: [{ id: "session-wt", directory: "/test/project/wt" } as Session],
+      },
+    )
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { setActionRefs, respondToPermission } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project", enqueueMaterialization)
+
+    await respondToPermission("session-wt", "perm-wt", "once")
+
+    expect(scopedClientDirectories).toEqual(["/test/project/wt"])
+    expect(replyCalls[0]?.params.directory).toBe("/test/project/wt")
+    expect(replyCalls[0]?.params.requestID).toBe("perm-wt")
+  })
+
+  test("falls back to the containing store key when the session record carries no directory", async () => {
+    const question = buildQuestion("q-1", "session-a")
+    const store = createStore({}, {
+      session: [{ id: "session-a" } as Session],
+      question: { "session-a": [question] },
+    })
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project", enqueueMaterialization)
+
+    await respondToQuestion("session-a", "q-1", [["Yes"]])
+
+    expect(scopedClientDirectories).toEqual(["/test/project"])
+    expect(replyCalls[0]?.params.directory).toBe("/test/project")
+  })
+
+  test("enqueues settled-running-tool tail recovery when the question reply is not found", async () => {
+    const question = buildQuestion("q-stale", "session-a")
+    const store = createStore({}, {
+      session: [{ id: "session-a" } as Session],
+      question: { "session-a": [question] },
+      message: {
+        "session-a": [{ id: "msg-1", sessionID: "session-a", role: "assistant", time: { created: 1 } } as Message],
+      },
+      part: {
+        "msg-1": [{
+          id: "prt-1",
+          messageID: "msg-1",
+          sessionID: "session-a",
+          type: "tool",
+          tool: "question",
+          state: { status: "running" },
+        } as Part],
+      },
+    })
+    const childStores = createChildStores([["/test/project", store]])
+    questionReplyError = Object.assign(new Error("question.reply failed (404): QuestionNotFoundError"), { status: 404 })
+
+    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project", enqueueMaterialization)
+
+    let thrown: unknown
+    try {
+      await respondToQuestion("session-a", "q-stale", [["Yes"]])
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    // The stale request is gone from the store and the trailing running tool
+    // part is reconciled instead of leaving the UI stuck on "asking question".
+    expect(store.getState().question["session-a"]).toBe(undefined)
+    expect(materializationCalls).toEqual([{ directory: "/test/project", sessionID: "session-a", messageID: "msg-1" }])
+  })
+
+  test("enqueues tail recovery on reject not-found but not on success", async () => {
+    const question = buildQuestion("q-1", "session-a")
+    const store = createStore({}, {
+      session: [{ id: "session-a" } as Session],
+      question: { "session-a": [question] },
+      message: {
+        "session-a": [{ id: "msg-1", sessionID: "session-a", role: "assistant", time: { created: 1 } } as Message],
+      },
+      part: {
+        "msg-1": [{
+          id: "prt-1",
+          messageID: "msg-1",
+          sessionID: "session-a",
+          type: "tool",
+          tool: "question",
+          state: { status: "running" },
+        } as Part],
+      },
+    })
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { setActionRefs, rejectQuestion } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, childStores, () => "/test/project", enqueueMaterialization)
+
+    // Success: no recovery enqueued — the normal question.rejected event flow clears state.
+    await rejectQuestion("session-a", "q-1")
+    expect(materializationCalls).toEqual([])
+
+    // Not-found: the request is stale server-side; the tail must be reconciled.
+    questionRejectError = Object.assign(new Error("question.reject failed (404): QuestionNotFoundError"), { status: 404 })
+    const stale = buildQuestion("q-stale", "session-a")
+    store.setState({ question: { "session-a": [stale] } })
+
+    let thrown: unknown
+    try {
+      await rejectQuestion("session-a", "q-stale")
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(store.getState().question["session-a"]).toBe(undefined)
+    expect(materializationCalls).toEqual([{ directory: "/test/project", sessionID: "session-a", messageID: "msg-1" }])
+  })
+})
+
 function buildQuestion(id: string, sessionId: string): QuestionRequest {
   return {
     id,

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -30,6 +30,8 @@ import { getImperativeSessionMessageLoader } from "./session-message-loader"
 import { cleanupPersistedSessionState } from "./session-deletion-cleanup"
 import { getRuntimeKey } from "@/lib/runtime-switch"
 import { isAmbiguousTransportFailure } from "@/lib/relay/transport-error"
+import { getStaleRunningToolMessageID } from "./materialization"
+import { normalizePath } from "@/lib/pathNormalization"
 
 const MESSAGE_REFETCH_LIMIT = 100
 const SEND_CONFIRMATION_REFETCH_LIMIT = 30
@@ -52,6 +54,10 @@ const UNREVERT_REFETCH_RETRY_MS = 150
 let _sdk: OpencodeClient | null = null
 let _childStores: ChildStoreManager | null = null
 let _getDirectory: () => string = () => ""
+// Optional ref into the sync layer's session-tail materialization queue. Used
+// to reconcile a trailing running tool part after a blocking request is
+// confirmed stale server-side (see recoverStaleBlockingRequest).
+let _enqueueSessionMaterialization: ((directory: string, sessionID: string, messageID: string) => void) | null = null
 type OptimisticAddInput = { sessionID: string; directory?: string | null; message: Message; parts: Part[] }
 type OptimisticRemoveInput = { sessionID: string; directory?: string | null; messageID: string }
 type OptimisticConfirmInput = OptimisticRemoveInput
@@ -139,10 +145,12 @@ export function setActionRefs(
   sdk: OpencodeClient,
   childStores: ChildStoreManager,
   getDirectory: () => string,
+  enqueueSessionMaterialization?: (directory: string, sessionID: string, messageID: string) => void,
 ) {
   _sdk = sdk
   _childStores = childStores
   _getDirectory = getDirectory
+  _enqueueSessionMaterialization = enqueueSessionMaterialization ?? null
 }
 
 export function setOptimisticRefs(
@@ -480,6 +488,29 @@ function restoreFilePartsToInput(fileParts: Array<Record<string, unknown>>): voi
   }
 }
 
+/**
+ * Server-confirmed directory that owns a session, from the session record
+ * (`directory`, then `project.worktree`). Mirrors the authoritative source in
+ * session-directory-resolution: holding a session in a child store proves
+ * containment, not ownership — a project's session list legitimately includes
+ * the sessions of its worktrees so the sidebar can group them — so reading
+ * ownership from the containing store reports the parent for a session that
+ * lives in a worktree, and every fetch is then addressed to a directory that
+ * does not own it.
+ */
+function resolveSessionOwnedDirectory(session: Session): string | null {
+  const record = session as Session & {
+    directory?: string | null
+    project?: { worktree?: string | null } | null
+  }
+  const raw = typeof record.directory === "string" && record.directory.trim().length > 0
+    ? record.directory
+    : typeof record.project?.worktree === "string" && record.project.worktree.trim().length > 0
+      ? record.project.worktree
+      : null
+  return raw ? normalizePath(raw) : null
+}
+
 function resolveDirectoryForBlockingRequest(
   type: "permission" | "question",
   sessionId: string,
@@ -493,10 +524,28 @@ function resolveDirectoryForBlockingRequest(
   for (const [directory, store] of stores.children) {
     const state = store.getState()
     const requestMap = type === "permission" ? state.permission : state.question
-    for (const requests of Object.values(requestMap) as Array<Array<{ id: string }> | undefined>) {
-      if (requests?.some((request) => request.id === requestId)) {
-        return directory
-      }
+    for (const requests of Object.values(requestMap) as Array<Array<{ id: string; sessionID?: string }> | undefined>) {
+      const request = requests?.find((candidate) => candidate.id === requestId)
+      if (!request) continue
+
+      // Ownership beats containment. The request belongs to one specific
+      // session, and the reply must reach the instance that actually tracks
+      // it — the directory the session record's server-confirmed `directory`
+      // names. The containing store's key only proves containment: a project
+      // store holds its worktree sessions too, and a reply addressed to the
+      // parent instance makes the server answer QuestionNotFoundError while
+      // the question stays pending in the worktree instance, leaving the
+      // session stuck on the running question tool. Fall back to the store
+      // key only when the session record carries no directory.
+      const requestSessionID = typeof request.sessionID === "string" && request.sessionID.length > 0
+        ? request.sessionID
+        : sessionId
+      const sessionRecord = requestSessionID
+        ? state.session.find((s) => s.id === requestSessionID)
+        : undefined
+      const ownedDirectory = sessionRecord ? resolveSessionOwnedDirectory(sessionRecord) : null
+      if (ownedDirectory) return ownedDirectory
+      return directory
     }
   }
 
@@ -535,6 +584,38 @@ export function isQuestionRequestNotFoundError(error: unknown): boolean {
   }
 
   return /Question(?:\.)?NotFoundError|Question request not found/i.test(message)
+}
+
+/**
+ * Reconcile the trailing assistant tool part after a blocking request turned
+ * out to be stale server-side (reply/reject answered with not-found). The
+ * local request is removed (the server no longer tracks it), but the
+ * question/permission tool part can remain `running` with the session busy —
+ * the UI would stay on "asking question" with no recovery until the user
+ * stops the run. Enqueue the sync layer's settled-running-tool tail
+ * materialization so the part converges to the server's actual state.
+ */
+function recoverStaleBlockingRequest(sessionId: string): void {
+  const stores = _childStores
+  const enqueue = _enqueueSessionMaterialization
+  if (!stores || !enqueue || !sessionId) return
+
+  for (const [directory, store] of stores.children) {
+    const state = store.getState()
+    if (
+      !state.session.some((session) => session.id === sessionId)
+      && !Object.prototype.hasOwnProperty.call(state.message, sessionId)
+      && !Object.prototype.hasOwnProperty.call(state.session_status ?? {}, sessionId)
+      && !Object.prototype.hasOwnProperty.call(state.question ?? {}, sessionId)
+    ) {
+      continue
+    }
+    const messageID = getStaleRunningToolMessageID(state, sessionId)
+    if (messageID) {
+      enqueue(directory, sessionId, messageID)
+    }
+    return
+  }
 }
 
 function removeQuestionRequestFromChildStores(sessionId: string, requestId: string): boolean {
@@ -1581,6 +1662,7 @@ export async function respondToQuestion(
   } catch (error) {
     if (isQuestionRequestNotFoundError(error)) {
       removeQuestionRequestFromChildStores(sessionId, requestId)
+      recoverStaleBlockingRequest(sessionId)
     }
     throw error
   }
@@ -1605,6 +1687,7 @@ export async function rejectQuestion(
   } catch (error) {
     if (isQuestionRequestNotFoundError(error)) {
       removeQuestionRequestFromChildStores(sessionId, requestId)
+      recoverStaleBlockingRequest(sessionId)
     }
     throw error
   }

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -2260,6 +2260,12 @@ export function SyncProvider(props: {
       props.sdk,
       childStores,
       () => opencodeClient.getDirectory() || props.directory,
+      (directory, sessionID, messageID) => {
+        enqueueSessionMaterialization(directory, sessionID, childStores, {
+          reason: "settled-running-tool",
+          messageID,
+        })
+      },
     )
     return () => {
       if (getImperativeSessionMessageLoader() === messageLoader) {


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-236

Answering a question-tool prompt (or a permission prompt) in OpenChamber could leave the session permanently stuck at the "asking question" status: the answer was sent to the wrong OpenCode instance, the server answered `QuestionNotFoundError`, the local request was removed (card hidden), and the trailing question-tool part stayed `running` with the session `busy` — the only escape was pressing Stop. OpenCode TUI/official web app did not exhibit this because they route the reply to the session's own instance.

Root cause: `resolveDirectoryForBlockingRequest` returned the **containing child-store key** for the reply. A child store's key proves *containment*, not *ownership* — a project store legitimately holds its worktree sessions (and task-tool children) so the sidebar can group them. For a worktree session, the reply was therefore addressed to the **parent** directory's instance, which does not track the pending request → `404 QuestionNotFoundError`. The 404 path then removed the request locally while it stayed pending server-side (reappearing on session switch), leaving the UI stuck with no recovery.

This PR:
1. Routes question/permission replies by the **request's own session record directory** (server-confirmed `session.directory`, then `project.worktree`) before falling back to the containing store key.
2. On a not-found reply/reject, enqueues the existing `settled-running-tool` tail materialization so a stale running tool part converges to the server's actual state instead of leaving the session stuck.

## Non-goals

- No change to the server-side question protocol or the v1 `question.reply` endpoint shape (verified correct for the bundled OpenCode).
- No restructuring of the polling/stuck-timeout design; the `settled-running-tool` mechanism is reused as-is.
- `getSessionDirectory`/`findSessionDirectoryInChildStores` (used by many send/message-fetch paths) are intentionally untouched — the ownership fix is scoped to blocking-request reply delivery where the failure was demonstrated.

## Affected surfaces

- `packages/ui` sync layer only: `sync/session-actions.ts`, `sync/sync-context.tsx` (one new optional ref in `setActionRefs`), `sync/DOCUMENTATION.md`, `sync/session-actions.test.ts`.
- Behavior: question/permission reply + reject + dismiss now target the session's own directory; not-found replies additionally reconcile the trailing tool part. Web, desktop, VS Code, hosted-mobile, and Capacitor runtimes share this path (VS Code reproduces the same bug — the reply goes through the same directory resolution).
- No persisted or external contract changes; the SDK call shape (`question.reply({requestID, answers, directory})`) is unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md always-on constraints; `sync-state-invariants` skill | Change mutates session sync state (blocking-request routing + recovery) | Followed the ownership-vs-containment invariant from `session-directory-resolution.ts`; reused the existing `settled-running-tool` materialization instead of adding a new mechanism; stale-request removal stays limited to the 404 path |
| `ui-api-decoupling` skill | Reply delivery is an SDK call (`question.reply`) | No SDK bypass; the request still goes through `getRequestReplyClient` → scoped SDK client; only the resolved `directory` value changed |
| `packages/ui/src/sync/DOCUMENTATION.md` | Owning module documentation; AGENTS.md requires doc updates when contracts change | Added a "Blocking-request (question/permission) reply routing" section documenting the ownership rule and the not-found recovery |
| Repo precedent: `session-directory-resolution.ts` header, `useSessionActivity` question override | Documents exactly this failure class ("Routing a prompt by an unconfirmed path posts it against a directory that does not own the session, and the send is rejected") | The reply now uses the same authoritative precedence (record directory → store key fallback) |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (from worktree root) | Pass (tsc --noEmit, 0 errors) |
| `bun run lint:ui` | Pass (eslint, 0 errors) |
| `bun test src/sync/session-actions.test.ts` (packages/ui) | 56 pass, 0 fail (5 new tests: worktree-session reply routing, permission reply routing, store-key fallback, not-found tail recovery for reply and reject) |
| `bun test src/sync/` (full sync suite) | 413 pass, 16 fail — the 16 failures are pre-existing on clean `upstream/main` (verified via `git stash`): WS-transport tests in `event-pipeline.test.js`, `issue-2039` draft auto-accept, `session-directory-adoption`, `session-deletion-cleanup`, skill-invocation tests; same set with and without this change (clean: 408 pass/16 fail) |
| `bun run dead-code` (worktree root) | No new findings; only pre-existing entries (e.g. `mirrorSessionIntoLiveStores`, flagged on clean code too) |

Not verified: live server interaction. This environment has no running OpenChamber/OpenCode server, so the end-to-end answer flow (reply → `question.replied` → tool part completion) could not be exercised against a real server. The fix is validated at the unit level (directory resolution + recovery enqueue) and by code inspection against the OpenCode v1.17.4/v1.18.12 server sources (`/question/{requestID}/reply` resolves the instance from the `directory` query).

## Visual evidence

This fix's observable behavior cannot be demonstrated statically: it is a state transition in the sync pipeline (question/permission reply routed to the session's own directory, then `question.replied` clearing the card and settling the tool part, plus the not-found tail reconciliation) that requires a live agent turn against a real OpenCode instance raising and answering a question-tool/permission prompt. This environment has no LLM API keys and no running agent, so no screenshot can show the transition itself, and none is faked.

What was verified instead (from Validation): `bun test src/sync/session-actions.test.ts` (56 pass, 0 fail — 5 new tests covering worktree-session reply routing, permission reply routing, store-key fallback, and not-found tail recovery for reply and reject) and the full `src/sync/` suite (413 pass; the 16 failures are pre-existing on clean `upstream/main`).

Context screenshot (app booted from `fix/ope-236-question-tool-stuck`; the home surface — sidebar, sessions list, command palette — renders normally):

![context: app booted normally; the fixed reply-routing transition is covered by the session-actions unit tests, not by this screenshot](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2663/screens/pr-2663-boot.png)

## Risks and failure behavior

- If the session record carries no directory (not indexed yet), behavior falls back to the previous containment-key resolution — identical to today, so no regression for unindexed sessions.
- The recovery enqueue only fires on a definitive not-found (404/QuestionNotFoundError) after the local request is removed; it reuses the cooldown-guarded materialization queue, so it cannot create a request storm.
- The new `setActionRefs` parameter is optional; all existing callers (tests included) keep working with three arguments.
- No data-loss risk: the change never deletes server state; it only addresses the reply to the correct instance and reconciles client UI state with the server.

