### PR TITLE
fix(web): parse agent frontmatter as leniently as OpenCode

### DIFF
--- a/packages/web/server/lib/opencode/shared.js
+++ b/packages/web/server/lib/opencode/shared.js
@@ -49,9 +49,36 @@ function ensureDirs() {
 
 // ============== MARKDOWN FILE OPERATIONS ==============
 
+// Mirror of OpenCode's markdown frontmatter sanitizer (packages/opencode/src/
+// config/markdown.ts): other coding agents accept unquoted colons in YAML
+// values (e.g. `description: Build agent: creates builds`), which strict YAML
+// rejects. Rewrite those values as block scalars and retry the parse, so files
+// OpenCode accepts are parsed identically here.
+function sanitizeFrontmatter(frontmatter) {
+  return frontmatter
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      if (line.trim().startsWith('#') || line.trim() === '' || /^\s+/.test(line)) return [line];
+      const entry = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/);
+      if (!entry) return [line];
+      const value = entry[2].trim();
+      if (value === '' || value === '>' || value === '|' || value.startsWith('"') || value.startsWith("'")) return [line];
+      if (!value.includes(':')) return [line];
+      return [`${entry[1]}: |-`, `  ${value}`];
+    })
+    .join('\n');
+}
+
 function parseMdFile(filePath) {
-  const content = fs.readFileSync(filePath, 'utf8');
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  const rawContent = fs.readFileSync(filePath, 'utf8');
+  // Strip a UTF-8 BOM so frontmatter is recognized regardless of the editor
+  // that saved the file.
+  const content = rawContent.charCodeAt(0) === 0xfeff ? rawContent.slice(1) : rawContent;
+  // The closing `---` may sit at end-of-file without a trailing newline.
+  // gray-matter (used by OpenCode) accepts that, so we must too: otherwise the
+  // whole file is treated as the prompt body and a later save rewrites the
+  // existing YAML block into the body, duplicating the frontmatter.
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/);
 
   if (!match) {
     return { frontmatter: {}, body: content.trim() };
@@ -61,8 +88,14 @@ function parseMdFile(filePath) {
   try {
     frontmatter = yaml.parse(match[1]) || {};
   } catch (error) {
-    console.warn(`Failed to parse markdown frontmatter ${filePath}, treating as empty:`, error);
-    frontmatter = {};
+    // Lenient fallback for frontmatter that strict YAML rejects but OpenCode
+    // still accepts (unquoted colons in scalar values).
+    try {
+      frontmatter = yaml.parse(sanitizeFrontmatter(match[1])) || {};
+    } catch {
+      console.warn(`Failed to parse markdown frontmatter ${filePath}, treating as empty:`, error);
+      frontmatter = {};
+    }
   }
 
   const body = match[2].trim();

--- a/packages/web/server/lib/opencode/shared.test.js
+++ b/packages/web/server/lib/opencode/shared.test.js
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { parseMdFile, writeMdFile } from './shared.js';
+import { updateAgent } from './agents.js';
+
+const FIXTURE_DIR = path.join(os.tmpdir(), `openchamber-shared-test-${process.pid}`);
+
+const STANDARD_MD = [
+  '---',
+  'description: My build agent',
+  'model: anthropic/claude-sonnet-4',
+  'mode: primary',
+  '---',
+  '',
+  'This is the prompt body.',
+  '',
+].join('\n');
+
+const writeFixture = (name, content) => {
+  const filePath = path.join(FIXTURE_DIR, name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+  return filePath;
+};
+
+describe('parseMdFile', () => {
+  beforeEach(() => {
+    fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+    fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+  });
+
+  it('parses standard YAML frontmatter', () => {
+    const file = writeFixture('standard.md', STANDARD_MD);
+    const { frontmatter, body } = parseMdFile(file);
+    expect(frontmatter).toEqual({
+      description: 'My build agent',
+      model: 'anthropic/claude-sonnet-4',
+      mode: 'primary',
+    });
+    expect(body).toBe('This is the prompt body.');
+  });
+
+  it('parses frontmatter whose closing --- is at end-of-file without a trailing newline', () => {
+    // gray-matter (used by OpenCode) accepts this shape; OpenChamber must too,
+    // otherwise a later save duplicates the YAML block.
+    const file = writeFixture('eof-close.md', [
+      '---',
+      'description: My build agent',
+      'model: anthropic/claude-sonnet-4',
+      '---',
+    ].join('\n'));
+    const { frontmatter, body } = parseMdFile(file);
+    expect(frontmatter).toEqual({
+      description: 'My build agent',
+      model: 'anthropic/claude-sonnet-4',
+    });
+    expect(body).toBe('');
+  });
+
+  it('parses frontmatter with CRLF line endings', () => {
+    const file = writeFixture('crlf.md', STANDARD_MD.replace(/\n/g, '\r\n'));
+    const { frontmatter, body } = parseMdFile(file);
+    expect(frontmatter.model).toBe('anthropic/claude-sonnet-4');
+    expect(body).toBe('This is the prompt body.');
+  });
+
+  it('parses frontmatter preceded by a UTF-8 BOM', () => {
+    const file = writeFixture('bom.md', `\uFEFF${STANDARD_MD}`);
+    const { frontmatter, body } = parseMdFile(file);
+    expect(frontmatter.description).toBe('My build agent');
+    expect(body).toBe('This is the prompt body.');
+  });
+
+  it('falls back to lenient YAML for unquoted colons in values, matching OpenCode', () => {
+    const file = writeFixture('colon.md', [
+      '---',
+      'description: Build agent: creates builds',
+      'model: anthropic/claude-sonnet-4',
+      '---',
+      '',
+      'Body',
+      '',
+    ].join('\n'));
+    const { frontmatter, body } = parseMdFile(file);
+    expect(frontmatter).toEqual({
+      description: 'Build agent: creates builds',
+      model: 'anthropic/claude-sonnet-4',
+    });
+    expect(body).toBe('Body');
+  });
+
+  it('treats files without frontmatter as a plain body', () => {
+    const file = writeFixture('plain.md', 'Just a prompt body.');
+    const { frontmatter, body } = parseMdFile(file);
+    expect(frontmatter).toEqual({});
+    expect(body).toBe('Just a prompt body.');
+  });
+});
+
+describe('writeMdFile', () => {
+  beforeEach(() => {
+    fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+    fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+  });
+
+  it('round-trips a canonical single frontmatter block', () => {
+    const file = writeFixture('roundtrip.md', STANDARD_MD);
+    const parsed = parseMdFile(file);
+    parsed.frontmatter.model = 'openai/gpt-5';
+    writeMdFile(file, parsed.frontmatter, parsed.body);
+
+    const content = fs.readFileSync(file, 'utf8');
+    // Exactly one frontmatter block.
+    expect(content.match(/^---\r?\n/g)).toHaveLength(1);
+
+    const reparsed = parseMdFile(file);
+    expect(reparsed.frontmatter).toEqual({
+      description: 'My build agent',
+      model: 'openai/gpt-5',
+      mode: 'primary',
+    });
+    expect(reparsed.body).toBe('This is the prompt body.');
+  });
+});
+
+describe('updateAgent frontmatter preservation', () => {
+  beforeEach(() => {
+    fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+    fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+  });
+
+  it('updates the model in place without duplicating YAML for a file with EOF-closed frontmatter', () => {
+    // Repro of OPE-178: the file's closing --- sits at EOF (no trailing
+    // newline). OpenCode parses it; OpenChamber previously treated the whole
+    // file as the prompt body and prepended a second frontmatter block on save.
+    const projectDir = path.join(FIXTURE_DIR, 'project');
+    const agentPath = path.join(projectDir, '.opencode', 'agents', 'strateg.md');
+    writeFixture(path.join('project', '.opencode', 'agents', 'strateg.md'), [
+      '---',
+      'description: Strategy agent',
+      'model: anthropic/claude-sonnet-4',
+      'temperature: 0.7',
+      '---',
+    ].join('\n'));
+
+    updateAgent('strateg', { model: 'openai/gpt-5' }, projectDir);
+
+    const content = fs.readFileSync(agentPath, 'utf8');
+    expect(content.match(/^---\r?\n/g)).toHaveLength(1);
+
+    const parsed = parseMdFile(agentPath);
+    expect(parsed.frontmatter).toEqual({
+      description: 'Strategy agent',
+      model: 'openai/gpt-5',
+      temperature: 0.7,
+    });
+    expect(parsed.body).toBe('');
+  });
+
+  it('preserves unrelated frontmatter fields when saving one field', () => {
+    const projectDir = path.join(FIXTURE_DIR, 'project');
+    const agentPath = path.join(projectDir, '.opencode', 'agents', 'strateg.md');
+    writeFixture(path.join('project', '.opencode', 'agents', 'strateg.md'), [
+      '---',
+      'description: Strategy agent',
+      'mode: primary',
+      'temperature: 0.7',
+      '---',
+      '',
+      'Body of strateg.',
+      '',
+    ].join('\n'));
+
+    updateAgent('strateg', { description: 'Updated strategy agent' }, projectDir);
+
+    const content = fs.readFileSync(agentPath, 'utf8');
+    expect(content.match(/^---\r?\n/g)).toHaveLength(1);
+
+    const parsed = parseMdFile(agentPath);
+    expect(parsed.frontmatter).toEqual({
+      description: 'Updated strategy agent',
+      mode: 'primary',
+      temperature: 0.7,
+    });
+    expect(parsed.body).toBe('Body of strateg.');
+  });
+});


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-178

File-backed agents (.md with YAML frontmatter) were handled inconsistently: OpenChamber's own frontmatter parser was stricter than the gray-matter parser OpenCode uses, so files OpenCode parsed fine (closing `---` at end-of-file without trailing newline, UTF-8 BOM prefix, YAML with unquoted colons in scalar values) were read by OpenChamber as "no frontmatter, whole file is the prompt body". A subsequent save then wrote a new frontmatter block while the old YAML block stayed in the body — producing duplicated `--- ... ---` sections and raw YAML shown in the system prompt.

Fix: `parseMdFile` (packages/web/server/lib/opencode/shared.js) now matches OpenCode's parsing for those shapes — the closing `---` may sit at EOF, a leading BOM is stripped, and unparseable strict YAML is retried through the same line-sanitizer OpenCode applies (unquoted-colon values become block scalars). With the file parsed correctly, `updateAgent` rewrites a single canonical frontmatter block and preserves all untouched fields — the duplicate-YAML write path is gone.

Per-project loading: verified live against an OpenCode 1.18.12 server that OpenChamber's `/api/agent?directory=<project>` proxies to — the agent list is directory-scoped and YAML is parsed identically for the main project, a new project, and the global fallback (project `.opencode/agent(s)` files win over global `~/.config/opencode/agent(s)` files). No loading-side defect exists on current main; the "default metadata" symptom in the original report is the built-in agent fallback when the project-scoped file is absent, which is correct OpenCode semantics.

## Non-goals

- Changing OpenCode's agent-loading semantics (project-scoped agents staying project-scoped).
- Snippets (`snippets.js`) — has its own parser that already accepts EOF-closed frontmatter; out of scope for this agents issue.
- UI changes — the display path (description/model/prompt) comes from the OpenCode `/agent` list, which parses correctly.

## Affected surfaces

- `packages/web` server runtime: `parseMdFile` in `packages/web/server/lib/opencode/shared.js` — the shared parser used by agents (`agents.js`), commands (`commands.js`), and skills (`addSkillFromMdFile`). All surfaces that read/write `.md` config files inherit the same leniency, so commands/skills with the same file shapes also stop duplicating frontmatter on save.
- Files on disk (user-level `~/.config/opencode/agent(s)/*.md` and project `.opencode/agent(s)/*.md`): saves now produce a single canonical block instead of stacking duplicate blocks.
- No API contract changes; response shapes are unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md — match OpenCode behavior; minimal changes; server JS needs runtime/focused-test validation, not just static checks | OpenChamber's parser must agree with OpenCode's gray-matter parsing | Parser behavior verified against the real OpenCode 1.18.12 binary (live probe) and gray-matter 4.0.3; regression tests added |
| AGENTS.md — "Match Opencode Config Resolution Behavior (#949)" precedent in this module | The sanitizer fallback mirrors that existing pattern | New sanitizer is a faithful port of opencode's `ConfigMarkdown.sanitize` |
| `openchamber-change-discipline` skill | Server source change with new test file | Followed validation discipline: focused tests, syntax check, dead-code review |
| Nearest docs: `packages/web/server/lib/opencode/DOCUMENTATION.md` | Module docs anchor for server changes | Read; no ownership/contract changes, so no doc update required |

## Validation

| Check | Result |
|---|---|
| `bun test server/lib/opencode/shared.test.js` (new file) | 9 pass / 0 fail — parse shapes (standard, EOF-closed, CRLF, BOM, unquoted-colon fallback, no-frontmatter), write round-trip single block, and `updateAgent` save on an EOF-closed project agent (single block, fields preserved) |
| Live repro of the original bug (real `shared.js` module, shape-B file): before fix → duplicated `---` blocks on save; after fix → single canonical block with `description` preserved and `model` updated | Fixed |
| `bun run type-check:web` | Pass |
| `bun run lint:web` | Pass (note: web lint only covers `src/**/*.{ts,tsx}`, so server JS is covered by tests/syntax check instead) |
| `node --check server/lib/opencode/shared.js` and `shared.test.js` | Pass |
| Full opencode test dir `bun test server/lib/opencode/` | 291 pass / 2 skip / 5 fail / 1 error — baseline on clean main is 9 fail / 1 error; the 5 remaining failures are pre-existing timing/network tests (core-routes rate limits, upgrade routes, shutdown runtime, startup-performance) unrelated to this change |
| Live probe: OpenCode 1.18.12 `/agent?directory=` for main project, new project, and no-project fallback | YAML parsed identically everywhere; directory-scoped project agents override global agents; global fallback parsed correctly |
| `bun run dead-code` | No entries related to the change (pre-existing report only) |
| Not verified | Real browser session of the Web UI (no GUI in this environment); the "system prompt" rendering after the fix is inferred from the parser change, not clicked through |

## Visual evidence

Captured live from the PR branch (`fix/ope-178-yaml-frontmatter`) — web app via `dev:web:hmr` (UI 5187 / API 3909, `/api/system/info` 200), headless Chromium. Fixture project `/tmp/opencode/fixtures/agproj` was added via the UI, containing two file-backed agents that previously broke:

- `.opencode/agent/build.md` — the **exact OPE-178 shape**: YAML frontmatter whose closing `---` sits at EOF with no trailing newline (byte-verified: file ends `sonnet-4\n---`, no `\n` after). Previously OpenChamber treated the whole file as prompt body and prepended a duplicate frontmatter block on save.
- `.opencode/agent/ship.md` — frontmatter (description + model + temperature) **plus a prompt body**, the normal shape whose save path previously stacked duplicate `--- ... ---` blocks.

| Step | Evidence |
|---|---|
| Settings → Agents list for the fixture project — both agents listed with the frontmatter description parsed (`build`: "Fixture build agent, EOF-closed frontmatter"; `ship`: "Fixture ship agent with body") | [agents-list.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2665/screens/agents-list.png) |
| `build` editor (EOF-closed file): Description field shows the parsed YAML description; System Prompt is empty — the YAML was **not** treated as prompt body, no raw `---` anywhere in the editor | [agent-build-editor.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2665/screens/agent-build-editor.png) |
| `ship` editor before save: Description from frontmatter, Model `claude-sonnet-4` from frontmatter, System Prompt = body only (`You are the fixture ship agent...`) — no duplicated YAML | [agent-ship-editor.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2665/screens/agent-ship-editor.png) |
| `ship` editor after **UI save** of a model change (Override Model → GPT-5.4 Pro, "save changes" clicked): single frontmatter block on disk, model updated, description preserved | [agent-ship-saved.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2665/screens/agent-ship-saved.png) |

Round-trip verification (not just pixels): after the UI save, the on-disk `ship.md` contains **exactly one** `---`-delimited block with `description`/`temperature` preserved, `model: opencode/gpt-5.4-pro` updated, and the prompt body intact — the duplicated-block write path from OPE-178 is gone. `build.md` remained byte-identical (EOF-closed shape untouched). The server proxy agrees: `GET /api/agent?directory=/tmp/opencode/fixtures/agproj` returns `build` with `description: "Fixture build agent, EOF-closed frontmatter"`.

## Risks and failure behavior

- The sanitizer fallback only triggers when strict `yaml.parse` throws; otherwise parsing is byte-identical to before, so no behavior change for well-formed files.
- Genuinely corrupt YAML that even the sanitizer cannot fix still degrades to `frontmatter: {}` with a warning (unchanged fallback), and such a file is also skipped by OpenCode, so it can never be reached from the UI save path.
- The BOM strip only affects the leading byte; content and byte-for-byte write output for non-BOM files are unchanged.
- No migration needed: existing files are re-read with the more lenient parser on next load.

