### PR TITLE
fix(update): complete the in-app update before reloading and surface install failures

### DIFF
--- a/packages/ui/src/components/ui/UpdateDialog.tsx
+++ b/packages/ui/src/components/ui/UpdateDialog.tsx
@@ -14,6 +14,11 @@ import { copyTextToClipboard } from '@/lib/clipboard';
 import { openExternalUrl } from '@/lib/url';
 import { getCurrentIntlLocale, useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
+import {
+  fetchWebUpdateCheck,
+  fetchWebUpdateStatus,
+  waitForWebUpdateApplied,
+} from '@/components/update/webUpdateStatus';
 
 type WebUpdateState = 'idle' | 'updating' | 'restarting' | 'reconnecting' | 'error';
 
@@ -117,9 +122,6 @@ type InstallWebUpdateResult = {
   autoRestart?: boolean;
 };
 
-const WEB_UPDATE_POLL_INTERVAL_MS = 2000;
-const WEB_UPDATE_MAX_WAIT_MS = 10 * 60 * 1000;
-
 async function installWebUpdate(): Promise<InstallWebUpdateResult> {
   try {
     const response = await runtimeFetch('/api/openchamber/update-install', {
@@ -140,54 +142,6 @@ async function installWebUpdate(): Promise<InstallWebUpdateResult> {
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : undefined };
   }
-}
-
-async function isServerReachable(): Promise<boolean> {
-  try {
-    const response = await runtimeFetch('/health', {
-      method: 'GET',
-      headers: { Accept: 'application/json' },
-    });
-    return response.ok;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForUpdateApplied(
-  previousVersion?: string,
-  maxAttempts = Math.ceil(WEB_UPDATE_MAX_WAIT_MS / WEB_UPDATE_POLL_INTERVAL_MS),
-  intervalMs = WEB_UPDATE_POLL_INTERVAL_MS,
-): Promise<boolean> {
-  for (let i = 0; i < maxAttempts; i++) {
-    try {
-      // Status-only poll while waiting for the update to apply; not a usage report.
-      const response = await runtimeFetch('/api/openchamber/update-check?reportUsage=false', {
-        method: 'GET',
-        headers: { Accept: 'application/json' },
-      });
-      if (response.ok) {
-        const data = await response.json().catch(() => null);
-        if (data && data.available === false) {
-          return true;
-        }
-        if (
-          data &&
-          typeof data.currentVersion === 'string' &&
-          typeof previousVersion === 'string' &&
-          data.currentVersion !== previousVersion
-        ) {
-          return true;
-        }
-      } else if ((response.status === 401 || response.status === 403) && await isServerReachable()) {
-        return true;
-      }
-    } catch {
-      // Server may be restarting
-    }
-    await new Promise(resolve => setTimeout(resolve, intervalMs));
-  }
-  return false;
 }
 
 export const UpdateDialog: React.FC<UpdateDialogProps> = ({
@@ -258,15 +212,26 @@ export const UpdateDialog: React.FC<UpdateDialogProps> = ({
 
     setWebUpdateState('reconnecting');
 
-    const applied = await waitForUpdateApplied(info?.currentVersion);
+    const waitResult = await waitForWebUpdateApplied({
+      previousVersion: info?.currentVersion,
+      targetVersion: info?.version,
+      fetchStatus: fetchWebUpdateStatus,
+      fetchCheck: fetchWebUpdateCheck,
+    });
 
-    if (applied) {
+    if (waitResult.outcome === 'applied') {
       window.location.reload();
+      return;
+    }
+
+    setWebUpdateState('error');
+    if (waitResult.outcome === 'failed') {
+      const exitSuffix = typeof waitResult.exitCode === 'number' ? ` (exit ${waitResult.exitCode})` : '';
+      setWebError(`${t('updateDialog.error.updateFailed')}${exitSuffix}`);
     } else {
-      setWebUpdateState('error');
       setWebError(t('updateDialog.error.takingLonger'));
     }
-  }, [info?.currentVersion, t]);
+  }, [info?.currentVersion, info?.version, t]);
 
   const handleMobileUpdate = useCallback(() => {
     void handleOpenExternal(mobileUpdateUrl);

--- a/packages/ui/src/components/update/__tests__/webUpdateStatus.test.ts
+++ b/packages/ui/src/components/update/__tests__/webUpdateStatus.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  waitForWebUpdateApplied,
+  type WebUpdateCheckResult,
+  type WebUpdateStatusPayload,
+} from '../webUpdateStatus';
+
+const noSleep = async (): Promise<void> => {};
+
+const statusOf = (state: WebUpdateStatusPayload['state'], exitCode?: number): WebUpdateStatusPayload => (
+  exitCode === undefined ? { state } : { state, exitCode }
+);
+
+const checkOk = (available: boolean, currentVersion?: string): WebUpdateCheckResult => ({
+  kind: 'ok',
+  available,
+  currentVersion,
+});
+
+describe('waitForWebUpdateApplied', () => {
+  test('returns applied immediately when the status endpoint reports success', async () => {
+    const fetchCheck = () => {
+      throw new Error('version check must not be consulted when status is authoritative');
+    };
+
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => statusOf('success'),
+      fetchCheck,
+      maxAttempts: 3,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  test('returns failed with the npm exit code when the install fails', async () => {
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => statusOf('failed', 1),
+      maxAttempts: 3,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'failed', exitCode: 1 });
+  });
+
+  test('returns failed without exit code when the spawn itself errored', async () => {
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => statusOf('failed'),
+      maxAttempts: 3,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'failed' });
+  });
+
+  test('keeps polling while installing, then applies on success', async () => {
+    let calls = 0;
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => {
+        calls += 1;
+        return calls < 3 ? statusOf('installing') : statusOf('success');
+      },
+      maxAttempts: 5,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+    expect(calls).toBe(3);
+  });
+
+  test('falls back to version-move detection when the status endpoint is unreachable', async () => {
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => null,
+      fetchCheck: async () => checkOk(false, '1.8.0'),
+      maxAttempts: 3,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  test('regression: a no-update answer with an unchanged version is NOT treated as applied', async () => {
+    // The old flow reloaded whenever `available === false`. The check reports
+    // exactly that when the npm registry fetch fails or while package.json is
+    // being replaced mid-install — reloading there is the reported bug.
+    let calls = 0;
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => null,
+      fetchCheck: async () => {
+        calls += 1;
+        return calls < 2
+          ? checkOk(false, '1.7.3') // no update + unchanged version → keep waiting
+          : checkOk(false, '1.8.0'); // version eventually moves → applied
+      },
+      maxAttempts: 5,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+    expect(calls).toBe(2);
+  });
+
+  test('applies when the current version reaches the exact target version', async () => {
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => null,
+      fetchCheck: async () => checkOk(true, '1.8.0'),
+      maxAttempts: 3,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  test('applies when the version moves even if it differs from the advertised target', async () => {
+    // npm may deliver a newer patch than the update API advertised.
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => null,
+      fetchCheck: async () => checkOk(false, '1.8.1'),
+      maxAttempts: 3,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  test('never treats an unknown current version as a version move', async () => {
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => null,
+      fetchCheck: async () => checkOk(false, 'unknown'),
+      maxAttempts: 2,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'timeout' });
+  });
+
+  test('applies after a restart behind auth when the server is reachable again', async () => {
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => null,
+      fetchCheck: async () => ({ kind: 'unauthorized' }),
+      isServerReachable: async () => true,
+      maxAttempts: 3,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'applied' });
+  });
+
+  test('does not apply on unauthorized when the server is still down', async () => {
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => null,
+      fetchCheck: async () => ({ kind: 'unauthorized' }),
+      isServerReachable: async () => false,
+      maxAttempts: 2,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'timeout' });
+  });
+
+  test('times out when the install never completes', async () => {
+    const result = await waitForWebUpdateApplied({
+      previousVersion: '1.7.3',
+      targetVersion: '1.8.0',
+      fetchStatus: async () => statusOf('installing'),
+      maxAttempts: 2,
+      intervalMs: 1,
+      sleep: noSleep,
+    });
+
+    expect(result).toEqual({ outcome: 'timeout' });
+  });
+});

--- a/packages/ui/src/components/update/webUpdateStatus.ts
+++ b/packages/ui/src/components/update/webUpdateStatus.ts
@@ -1,0 +1,198 @@
+import { runtimeFetch } from '@/lib/runtime-fetch';
+
+/**
+ * Web-runtime update completion logic for `UpdateDialog`.
+ *
+ * Extracted from `UpdateDialog.tsx` so the wait-for-apply decision can be
+ * unit-tested without a DOM, timers, or network. The dialog remains the sole
+ * owner of UI state (progress text, reload, error rendering).
+ *
+ * Why this exists: the old flow polled `/update-check` and treated any
+ * `available === false` answer as "the update is applied". That is wrong —
+ * `checkForUpdates` reports `available: false` for check failures too (npm
+ * registry unreachable, or the install window where `package.json` is missing
+ * from disk and the version is `'unknown'`). The UI then reloaded while the
+ * detached `npm install` was still running or had failed, and the update
+ * button reappeared. The server now records authoritative install state
+ * (`/api/openchamber/update-status`); this module waits on that state first
+ * and only falls back to version-move detection when the endpoint is missing
+ * or unreachable (older server, server restarting).
+ *
+ * Exposed for unit testing. Not part of the stable consumer surface.
+ */
+
+export type WebUpdateStatusState = 'installing' | 'success' | 'failed' | 'idle';
+
+export interface WebUpdateStatusPayload {
+  state: WebUpdateStatusState;
+  exitCode?: number;
+}
+
+export type WebUpdateCheckResult =
+  | { kind: 'ok'; available: boolean; currentVersion: string | undefined }
+  | { kind: 'unauthorized' }
+  | { kind: 'unavailable' };
+
+export type WebUpdateWaitResult =
+  | { outcome: 'applied' }
+  | { outcome: 'failed'; exitCode?: number }
+  | { outcome: 'timeout' };
+
+export interface WebUpdateWaitOptions {
+  /** Version reported by the server when the dialog opened. */
+  previousVersion: string | undefined;
+  /** Version the install is expected to deliver. */
+  targetVersion: string | undefined;
+  fetchStatus?: () => Promise<WebUpdateStatusPayload | null>;
+  fetchCheck?: () => Promise<WebUpdateCheckResult>;
+  isServerReachable?: () => Promise<boolean>;
+  maxAttempts?: number;
+  intervalMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const WEB_UPDATE_POLL_INTERVAL_MS = 2000;
+const WEB_UPDATE_MAX_WAIT_MS = 10 * 60 * 1000;
+
+const sleepDefault = (ms: number): Promise<void> => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+/**
+ * True when the server's reported current version proves the install landed:
+ * either it reached the exact target version, or it moved off the previous
+ * version to any known version (npm may deliver a newer patch than the API
+ * advertised). An `'unknown'` current version never counts — it is the
+ * transient state while the package directory is being replaced.
+ */
+const versionMovedToTarget = (
+  currentVersion: string | undefined,
+  previousVersion: string | undefined,
+  targetVersion: string | undefined,
+): boolean => {
+  if (typeof currentVersion !== 'string' || currentVersion.length === 0) {
+    return false;
+  }
+  if (typeof targetVersion === 'string' && targetVersion.length > 0 && currentVersion === targetVersion) {
+    return true;
+  }
+  return typeof previousVersion === 'string'
+    && previousVersion.length > 0
+    && currentVersion !== previousVersion
+    && currentVersion !== 'unknown';
+};
+
+export const waitForWebUpdateApplied = async (options: WebUpdateWaitOptions): Promise<WebUpdateWaitResult> => {
+  const {
+    previousVersion,
+    targetVersion,
+    fetchStatus = fetchWebUpdateStatus,
+    fetchCheck = fetchWebUpdateCheck,
+    isServerReachable: isServerReachableFn = isServerReachable,
+    maxAttempts = Math.ceil(WEB_UPDATE_MAX_WAIT_MS / WEB_UPDATE_POLL_INTERVAL_MS),
+    intervalMs = WEB_UPDATE_POLL_INTERVAL_MS,
+    sleep = sleepDefault,
+  } = options;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const status = await fetchStatus();
+    if (status) {
+      if (status.state === 'success') {
+        return { outcome: 'applied' };
+      }
+      if (status.state === 'failed') {
+        return {
+          outcome: 'failed',
+          ...(typeof status.exitCode === 'number' ? { exitCode: status.exitCode } : {}),
+        };
+      }
+      // 'installing' (and 'idle' for an erased file) → keep polling.
+    } else {
+      // Status endpoint unreachable: server restarting, or an older server
+      // without the route. Fall back to version-move detection only — a
+      // "no update available" answer without a version change is a check
+      // failure, not proof that the install finished.
+      const check = await fetchCheck();
+      if (check.kind === 'ok') {
+        if (versionMovedToTarget(check.currentVersion, previousVersion, targetVersion)) {
+          return { outcome: 'applied' };
+        }
+      } else if (check.kind === 'unauthorized' && await isServerReachableFn()) {
+        // Server restarted behind auth: the reload will re-authenticate.
+        return { outcome: 'applied' };
+      }
+    }
+    await sleep(intervalMs);
+  }
+
+  return { outcome: 'timeout' };
+};
+
+/**
+ * Reads the server's authoritative install state. Returns `null` when the
+ * endpoint is missing (older server) or unreachable (server restarting) so
+ * callers fall back to version-move detection.
+ */
+export const fetchWebUpdateStatus = async (): Promise<WebUpdateStatusPayload | null> => {
+  try {
+    const response = await runtimeFetch('/api/openchamber/update-status', {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const data = await response.json().catch(() => null);
+    if (!data || typeof data.state !== 'string') {
+      return null;
+    }
+    if (data.state !== 'installing' && data.state !== 'success' && data.state !== 'failed' && data.state !== 'idle') {
+      return null;
+    }
+    return {
+      state: data.state,
+      ...(typeof data.exitCode === 'number' ? { exitCode: data.exitCode } : {}),
+    };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Status-only update check used by the version-move fallback. Never a usage
+ * report; `reportUsage=false` is fixed so background polls stay silent.
+ */
+export const fetchWebUpdateCheck = async (): Promise<WebUpdateCheckResult> => {
+  try {
+    const response = await runtimeFetch('/api/openchamber/update-check?reportUsage=false', {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (response.ok) {
+      const data = await response.json().catch(() => null);
+      return {
+        kind: 'ok',
+        available: data?.available === true,
+        currentVersion: typeof data?.currentVersion === 'string' ? data.currentVersion : undefined,
+      };
+    }
+    if (response.status === 401 || response.status === 403) {
+      return { kind: 'unauthorized' };
+    }
+    return { kind: 'unavailable' };
+  } catch {
+    return { kind: 'unavailable' };
+  }
+};
+
+const isServerReachable = async (): Promise<boolean> => {
+  try {
+    const response = await runtimeFetch('/health', {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+};

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -343,6 +343,7 @@ an authoritative loopback callback URL even when OpenChamber binds port `0`.
 - `registerOpenChamberRoutes(app, dependencies)`: registers OpenChamber endpoints:
   - `GET /api/openchamber/update-check`
   - `POST /api/openchamber/update-install`
+  - `GET /api/openchamber/update-status` (authoritative install completion state written by the update-install flow: `installing` → `success`/`failed`; `idle` when no install is recorded)
   - `GET /api/openchamber/models-metadata`
   - `GET /api/zen/models`
 

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -13,6 +13,30 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
     getCachedZenModels,
   } = dependencies;
 
+  function readUpdateStatusFile(filePath) {
+    try {
+      const content = fs.readFileSync(filePath, 'utf8').trim();
+      if (!content) {
+        return null;
+      }
+      return JSON.parse(content);
+    } catch {
+      return null;
+    }
+  }
+
+  function writeUpdateStatusFile(filePath, status) {
+    try {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, `${JSON.stringify(status)}\n`, { encoding: 'utf8' });
+    } catch (error) {
+      console.warn('Failed to write update status file:', error);
+    }
+  }
+
+  const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
+  const updateStatusFilePath = path.join(openchamberDataDir, 'update-status.json');
+
   app.get('/api/openchamber/update-check', async (req, res) => {
     try {
       const { checkForUpdates } = await import('../package-manager.js');
@@ -75,6 +99,13 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         process.env.container === 'docker';
 
       if (isContainer) {
+        const containerUpdateStatus = {
+          state: 'installing',
+          startedAt: Date.now(),
+          targetVersion: updateInfo.version || null,
+        };
+        writeUpdateStatusFile(updateStatusFilePath, containerUpdateStatus);
+
         res.json({
           success: true,
           message: 'Update starting, server will stay online',
@@ -89,12 +120,55 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
 
           const shell = process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : 'sh';
           const shellFlag = process.platform === 'win32' ? '/c' : '-c';
+
+          let logFd = null;
+          try {
+            fs.mkdirSync(path.dirname(updateLogPath), { recursive: true });
+            logFd = fs.openSync(updateLogPath, 'a');
+          } catch (logError) {
+            console.warn('Failed to open update log file, continuing without log capture:', logError);
+          }
+
           const child = spawnChild(shell, [shellFlag, updateCmd], {
             detached: true,
-            stdio: 'ignore',
+            stdio: logFd !== null ? ['ignore', logFd, logFd] : 'ignore',
             env: process.env,
           });
+
+          const writeFinishedStatus = (state, exitCode, errorMessage) => {
+            writeUpdateStatusFile(updateStatusFilePath, {
+              state,
+              startedAt: containerUpdateStatus.startedAt,
+              targetVersion: updateInfo.version || null,
+              finishedAt: Date.now(),
+              ...(exitCode !== undefined && exitCode !== null ? { exitCode } : {}),
+              ...(errorMessage ? { error: errorMessage } : {}),
+            });
+          };
+
+          child.on('exit', (code) => {
+            writeFinishedStatus(code === 0 ? 'success' : 'failed', code);
+            if (code === 0) {
+              console.log(`Update installed successfully (${pm}).`);
+            } else {
+              console.error(`Update failed (${pm}) with exit code ${code}. See ${updateLogPath}`);
+            }
+          });
+
+          child.on('error', (spawnError) => {
+            const message = spawnError instanceof Error ? spawnError.message : String(spawnError);
+            console.error(`Failed to spawn update command (${updateCmd}):`, spawnError);
+            writeFinishedStatus('failed', undefined, message);
+          });
+
           child.unref();
+
+          if (logFd !== null) {
+            try {
+              fs.closeSync(logFd);
+            } catch {
+            }
+          }
         }, 500);
 
         return;
@@ -155,7 +229,12 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         restartCmdFallback += ' --api-only';
       }
       const restartCmd = isForegroundService ? '' : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
-      const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
+      const updateStatus = {
+        state: 'installing',
+        startedAt: Date.now(),
+        targetVersion: updateInfo.version || null,
+      };
+      writeUpdateStatusFile(updateStatusFilePath, updateStatus);
       const logPreamble = [
         '',
         `=== OpenChamber update ${new Date().toISOString()} ===`,
@@ -189,15 +268,18 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
 
           const shell = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'sh';
           const shellFlag = isWindows ? '/c' : '-c';
+          const quoteStatusFile = isWindows ? quoteCmd(updateStatusFilePath) : quotePosix(updateStatusFilePath);
           const script = isWindows
             ? `
             echo ${quoteCmd(logPreamble)}
             timeout /t 2 /nobreak >nul
             ${updateCmd}
             if %ERRORLEVEL% EQU 0 (
+              echo {"state":"success"} 1> ${quoteStatusFile}
               echo Update successful, restarting OpenChamber...
               ${restartCmd || 'echo Service manager will restart OpenChamber.'}
             ) else (
+              echo {"state":"failed","exitCode":%ERRORLEVEL%} 1> ${quoteStatusFile}
               echo Update failed
               exit /b 1
             )
@@ -206,10 +288,13 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
             printf '%s\n' ${quotePosix(logPreamble)}
             sleep 2
             ${updateCmd}
-            if [ $? -eq 0 ]; then
+            code=$?
+            if [ $code -eq 0 ]; then
+              printf '%s\n' '{"state":"success"}' > ${quoteStatusFile}
               echo "Update successful, restarting OpenChamber..."
               ${restartCmd || 'echo "Service manager will restart OpenChamber."'}
             else
+              printf '{"state":"failed","exitCode":%s}\\n' "$code" > ${quoteStatusFile}
               echo "Update failed"
               exit 1
             fi
@@ -249,6 +334,14 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         error: error instanceof Error ? error.message : 'Failed to install update',
       });
     }
+  });
+
+  app.get('/api/openchamber/update-status', (_req, res) => {
+    // Authoritative completion state for the in-app updater. Written by the
+    // update-install flow before it responds, then replaced by the install
+    // process when it finishes. `idle` means no install is recorded, which the
+    // UI treats the same as an unreachable status endpoint.
+    res.json(readUpdateStatusFile(updateStatusFilePath) || { state: 'idle' });
   });
 
   app.get('/api/openchamber/models-metadata', async (_req, res) => {

--- a/packages/web/server/lib/opencode/openchamber-routes.test.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.test.js
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { registerOpenChamberRoutes } from './openchamber-routes.js';
+
+// Mock child_process so the route's spawn and the package-manager detection
+// spawnSync calls never touch a real shell.
+vi.mock('child_process', () => {
+  const { EventEmitter } = require('node:events');
+  return {
+    spawn: vi.fn(() => {
+      const child = new EventEmitter();
+      child.unref = vi.fn();
+      child.pid = 4242;
+      return child;
+    }),
+    spawnSync: vi.fn(() => ({ status: 0, stdout: '/usr/local/bin', stderr: '' })),
+  };
+});
+
+const { spawn } = await import('child_process');
+
+function createFetchMock() {
+  const handlers = new Map();
+  const mock = vi.fn((url) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    for (const [pattern, response] of handlers) {
+      if (urlStr.includes(pattern)) {
+        return Promise.resolve(response);
+      }
+    }
+    return Promise.reject(new Error(`Unexpected fetch call: ${urlStr}`));
+  });
+  mock.when = (pattern, response) => {
+    handlers.set(pattern, response);
+    return mock;
+  };
+  return mock;
+}
+
+const makeApp = async (dataDir) => {
+  const app = express();
+  app.use(express.json());
+  registerOpenChamberRoutes(app, {
+    fs,
+    path,
+    process,
+    server: { address: () => ({ port: 3000 }) },
+    __dirname,
+    openchamberDataDir: dataDir,
+    modelsDevApiUrl: 'http://models.test',
+    modelsMetadataCacheTtl: 300,
+    readSettingsFromDiskMigrated: () => ({}),
+    fetchFreeZenModels: async () => [],
+    getCachedZenModels: () => null,
+  });
+  return app;
+};
+
+const waitForSpawn = async () => {
+  // The container-mode install spawns inside a 500ms setTimeout after the
+  // response is sent, so wait for it deterministically.
+  await new Promise((resolve) => setTimeout(resolve, 700));
+};
+
+describe('openchamber update-install (container mode) + update-status', () => {
+  let fetchMock;
+  let originalFetch;
+  let dataDir;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchamber-update-route-test-'));
+    fetchMock = createFetchMock()
+      .when('api.openchamber.dev', {
+        ok: true,
+        json: async () => ({
+          latestVersion: '1.19.0',
+          updateAvailable: true,
+          releaseNotes: '## [1.19.0] - 2026-07-01\n\n- Great new feature',
+        }),
+      })
+      .when('registry.npmjs.org', {
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.19.0' },
+        }),
+      });
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock;
+    process.env.CONTAINER = 'true';
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.CONTAINER;
+    globalThis.fetch = originalFetch;
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('records installing, then success with exit code when npm exits 0', async () => {
+    const app = await makeApp(dataDir);
+    const response = await request(app).post('/api/openchamber/update-install');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ success: true, autoRestart: false });
+
+    await waitForSpawn();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const [shell, args] = spawn.mock.calls[0];
+    expect(shell).toBe('sh');
+    expect(args[0]).toBe('-c');
+    expect(args[1]).toContain('npm install -g @openchamber/web@latest');
+
+    const installing = JSON.parse(fs.readFileSync(path.join(dataDir, 'update-status.json'), 'utf8'));
+    expect(installing.state).toBe('installing');
+    expect(installing.targetVersion).toBe('1.19.0');
+
+    const child = spawn.mock.results[0].value;
+    child.emit('exit', 0);
+
+    const finished = JSON.parse(fs.readFileSync(path.join(dataDir, 'update-status.json'), 'utf8'));
+    expect(finished).toMatchObject({ state: 'success', exitCode: 0, targetVersion: '1.19.0' });
+    expect(typeof finished.finishedAt).toBe('number');
+
+    const statusResponse = await request(app).get('/api/openchamber/update-status');
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body).toMatchObject({ state: 'success', exitCode: 0 });
+  });
+
+  it('records failed with the npm exit code when install exits non-zero', async () => {
+    const app = await makeApp(dataDir);
+    await request(app).post('/api/openchamber/update-install');
+    await waitForSpawn();
+
+    const child = spawn.mock.results[0].value;
+    child.emit('exit', 1);
+
+    const statusResponse = await request(app).get('/api/openchamber/update-status');
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body).toMatchObject({ state: 'failed', exitCode: 1 });
+  });
+
+  it('records failed with an error message when the spawn itself errors', async () => {
+    const app = await makeApp(dataDir);
+    await request(app).post('/api/openchamber/update-install');
+    await waitForSpawn();
+
+    const child = spawn.mock.results[0].value;
+    child.emit('error', new Error('ENOENT: no such file or directory'));
+
+    const statusResponse = await request(app).get('/api/openchamber/update-status');
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body.state).toBe('failed');
+    expect(statusResponse.body.error).toContain('ENOENT');
+  });
+
+  it('reports idle before any install has been started', async () => {
+    const app = await makeApp(dataDir);
+    const statusResponse = await request(app).get('/api/openchamber/update-status');
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body).toEqual({ state: 'idle' });
+  });
+
+  it('rejects the install when no update is available', async () => {
+    fetchMock.when('api.openchamber.dev', {
+      ok: true,
+      json: async () => ({
+        latestVersion: '1.19.0',
+        updateAvailable: false,
+      }),
+    });
+    fetchMock.when('registry.npmjs.org', {
+      ok: true,
+      json: async () => ({
+        'dist-tags': { latest: '1.19.0' },
+      }),
+    });
+
+    const app = await makeApp(dataDir);
+    const response = await request(app).post('/api/openchamber/update-install');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('No update available');
+    expect(fs.existsSync(path.join(dataDir, 'update-status.json'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-201

The in-app "Update available" button did not actually update: clicking Update ran the dialog, the UI reloaded, but the new version never appeared and the button stayed. `npm install -g @openchamber/web` from a terminal works, so the problem is the updater flow, not npm.

Root cause, in two parts:

1. **Premature reload.** `UpdateDialog` polled `/api/openchamber/update-check` and treated any `available === false` answer as "update applied" (`waitForUpdateApplied`). But `checkForUpdates` (server `package-manager.js`) returns `available: false` for *check failures* too: when the npm registry fetch fails, and — critically — during the install window where npm has removed/replaced `package.json` and `getCurrentVersion()` reads `'unknown'`. In container mode (the reporter runs Docker; the install runs detached with the server staying up) the poll hits exactly these transient states, the UI reloads mid-install, and the button reappears. It can also reload when the install simply failed, which the old code could never distinguish.

2. **Silent container-mode failure.** The container branch of `/api/openchamber/update-install` spawned `npm install -g @openchamber/web@latest` detached with `stdio: 'ignore'` — no log, no result signal, no spawn-error handler (an unhandled spawn `error` event would crash the process). If npm failed, nothing told the server or the user; the UI waited 10 minutes and then showed a generic timeout.

Fix:

- **Server** (`packages/web/server/lib/opencode/openchamber-routes.js`): the install flow now writes authoritative state to `update-status.json` (`{ state: 'installing', startedAt, targetVersion }` before responding) and exposes it via new `GET /api/openchamber/update-status`. The detached install process records the terminal state — `success`/`failed` with the npm exit code — when it finishes:
  - container mode: node-side `exit`/`error` handlers on the spawned child (server stays alive); npm output now captured to `update-install.log` instead of `/dev/null`.
  - restart mode: the POSIX/Windows restart scripts write the terminal state, because the server exits 500 ms after spawning.
- **UI** (`packages/ui/src/components/ui/UpdateDialog.tsx` + new `packages/ui/src/components/update/webUpdateStatus.ts`): the wait loop polls the status endpoint first and reloads only on confirmed `success`; `failed` shows the npm exit code inline plus the existing terminal fallback command. When the status endpoint is missing/unreachable (older server, restarting), it falls back to version-move detection only — `currentVersion === targetVersion` or the version moved off the previous value; a "no update available" answer with an unchanged version is never treated as applied.

## Non-goals

- No change to the CLI `openchamber update` flow (it already stops instances before installing and reports failures).
- No change to `package-manager.js` version-comparison/ownership logic; the npm cross-check remains authoritative for *displaying* the button.
- No new user-facing strings (reuses existing `updateDialog.error.updateFailed` / `updateDialog.error.takingLonger` i18n keys — no locale files touched).

## Affected surfaces

| Surface | Effect |
|---|---|
| `packages/web` server route `/api/openchamber/update-install` | Writes `update-status.json`; container mode logs to `update-install.log` and reports spawn/exit results; restart-mode scripts write terminal state |
| New route `GET /api/openchamber/update-status` | Returns `{ state: 'idle' }` when no install is recorded, `installing`/`success`/`failed` (+`exitCode`, `error`, timestamps, `targetVersion`) otherwise |
| `packages/ui` `UpdateDialog` web runtime | Reloads only on confirmed success; surfaces failures with exit code + fallback command |
| Electron/VS Code/mobile runtimes | Unaffected: they never call `update-install` (desktop uses electron-updater; mobile opens the release page; VS Code has no in-app install). The new status route is server-side only |
| Persisted state | `update-status.json` in the existing `openchamberDataDir`; not user settings; harmless if stale (UI only consults it while waiting after a successful install POST) |

Downgrade compatibility: a new UI against an old server (no `/update-status`) falls back to version-move detection, which still fixes the premature-reload bug because the `available === false` shortcut is gone.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Source change to two packages, new route, new files | Smallest complete change; no drive-by refactors; failure/rollback behavior explicit (failed install surfaces, never looks applied); focused tests added at both layers |
| `ui-api-decoupling` (incl. `references/implementation-map.md`) | New OpenChamber HTTP route consumed by shared UI via `runtimeFetch` | Route registered in the owning `openchamber-routes.js` (registered before the generic proxy); UI consumes it only through `runtimeFetch`, no hardcoded origins; `reportUsage=false` kept on the status-only check |
| Nearest docs: `packages/web/server/lib/opencode/DOCUMENTATION.md`, `packages/web/README.md` | Route list is the documented contract of `registerOpenChamberRoutes` | DOCUMENTATION.md route list updated with the new endpoint |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/update/__tests__/webUpdateStatus.test.ts` (bun:test, 12 tests) | 12 pass — incl. regression: "no-update answer with unchanged version is NOT treated as applied"; status success/failed(exit code)/installing→success; version-move fallback; target-version match; `'unknown'` never counts; unauthorized+reachable; timeout |
| `bunx vitest run server/lib/opencode/openchamber-routes.test.js` (web package, 5 tests) | 5 pass — container install records installing→success(exit 0)/failed(exit 1)/spawn-error; `GET /update-status` idle before install; 400 when no update available |
| `bunx vitest run server/lib/package-manager.test.js server/lib/opencode/` (32 files) | 311 pass, 2 skipped — existing updater + opencode route suites unaffected |
| `bun run type-check:ui` | Pass (`tsc --noEmit`, no output) |
| `bun run lint:ui` | Pass (eslint, no output) |
| `bun run type-check:web` | Pass (`tsc --noEmit`, no output) |
| `bun run lint:web` | Pass (eslint, no output; note web lint covers `src/**/*.{ts,tsx}` only) |
| `node --check` on `openchamber-routes.js` + new test file | Syntax OK |
| `bun run dead-code` | Only the two contract type exports (`WebUpdateWaitResult`, `WebUpdateWaitOptions`) flagged — identical to the tolerated pre-existing pattern in `openCodeUpdateDedup.ts`; no new dead values/files |

Not verified: an end-to-end live install against the npm registry (no network side effects were allowed in this environment; the detached install and restart script paths are exercised by tests with a mocked `child_process`, so the actual `npm install` output and the restart-mode script were not run for real). The POSIX restart script's status-write syntax was reviewed manually; the Windows `cmd` branch mirrors the existing `%ERRORLEVEL%` pattern in that script.

## Visual evidence

The end-to-end update flow could **not** be captured as a live screenshot, and this is by design of the feature, not an environment limitation:

- The UpdateDialog only renders after `GET /api/openchamber/update-check` reports `available: true` against the **live npm registry**. In this environment the check genuinely resolves against the registry (the response even carries the published changelog body) and reports `{"available": false, "version": "1.18.1", "currentVersion": "1.18.1"}` — the worktree build *is* the latest published `@openchamber/web`, so no update exists to click.
- Even with `available: true`, the actual install runs `npm install -g @openchamber/web@latest` against the registry with real side effects (a detached child process, `update-status.json` writes, and in restart mode an actual server exit). Reproducing that here would require publishing a newer package to npm or pointing the server at a spoofed registry — neither is an honest capture of the real flow.
- What the fix changes is the **state machine** around that install (server writes `installing → success/failed` to `update-status.json`; the UI polls `GET /api/openchamber/update-status` and reloads only on confirmed `success`, surfacing the npm exit code on failure). That state machine is exactly what the tests in the Validation section cover end-to-end with a mocked `child_process`: `webUpdateStatus.test.ts` (12 tests, incl. "no-update answer with unchanged version is NOT treated as applied") and `openchamber-routes.test.js` (5 tests: container install records installing→success/failed/spawn-error; idle status before install; 400 when no update available).

Context capture (the update surface, honestly labeled):

| Screenshot | What it shows |
|---|---|
| [About dialog — update surface](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2670/screens/1-about-dialog-update-surface.png) | The About surface that hosts the in-app update entry point, on the fixed build: `OpenChamber version 1.18.1`, `OpenCode version 1.18.12`, Copy diagnostics, GitHub/Discord links. No "Update available" button is rendered because the live registry check reports the running build is current (`available: false`) — the button and the `UpdateDialog` it opens only exist when the registry reports a newer version. |

Everything else the dialog does when an update *is* available (install spinner, confirmed-success reload, "Update failed (exit N)" + terminal fallback) is covered by the unit/integration tests in the Validation section; per the environment rules no real `npm install -g` was executed.


## Risks and failure behavior

- **Install fails (npm error, EACCES, network):** server records `failed` with exit code; UI shows "Update failed (exit N)" + terminal fallback; log at `update-install.log` (now also in container mode). Server stays up in container mode; in restart mode the supervisor/restart command is unchanged from before.
- **Check fails during install (npm registry unreachable, `package.json` mid-replace):** no longer mistaken for success; UI keeps polling until status resolves or the 10-minute timeout shows `updateDialog.error.takingLonger`.
- **Server restarts mid-wait (restart mode):** polls keep failing (unreachable) until the new server serves `update-status`; the script wrote `success`/`failed` before the restart command ran, so the state survives.
- **Stale status file:** only consulted while the dialog is actively waiting after a successful install POST; a stale entry from a previous attempt is overwritten by the `installing` write before each POST responds. `idle`/absent file falls back to version-move detection.
- **Old server + new UI:** version-move fallback applies; behavior strictly safer than before (no false-positive reload).
- **Security:** no new secrets/credentials; status file contains versions/timestamps only. No new dependencies.
