### PR TITLE
fix(instances): add back-to-local bar and drag region for remote instance pages

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -12,6 +12,7 @@ import { promisify } from 'node:util';
 import updaterPkg from 'electron-updater';
 import { ElectronSshManager } from './ssh-manager.mjs';
 import { createTrayController } from './tray.mjs';
+import { buildRemoteShellInjectionScript } from './remote-shell.mjs';
 import { resolveManagedOpenCodeCwd } from './opencode-cwd.mjs';
 import { resolveStartupUrlProbePlan, shouldIgnoreLoopbackConnectionLimit } from './startup-url-selection.mjs';
 import { sanitizeRuntimeRequestHeaders } from './runtime-request-headers.mjs';
@@ -2579,6 +2580,19 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
     if (initScript) {
       void browserWindow.webContents.executeJavaScript(initScript).catch(() => {});
     }
+    // Remote pages loaded in an OpenChamber window (e.g. an instance whose
+    // server serves a foreign UI such as opencode web) get a slim draggable
+    // bar with a "Back to OpenChamber" button. OpenChamber UI documents and
+    // local/packaged pages are detected in-page and skipped. Mini Chat is
+    // exempt: its own navigation guard never loads remote pages.
+    if (!browserWindow.__ocMiniChat) {
+      const localUiTarget = buildLocalUiBackTarget();
+      if (localUiTarget) {
+        void browserWindow.webContents.executeJavaScript(
+          buildRemoteShellInjectionScript({ localUiUrl: localUiTarget }),
+        ).catch(() => {});
+      }
+    }
   });
 
   browserWindow.webContents.on('did-finish-load', () => {
@@ -2656,6 +2670,16 @@ const activateMainWindow = async (url, localOrigin, bootOutcome, runtimeConfig =
     runtimeConfig,
   });
   return state.mainWindow;
+};
+
+// Where the main window boots when no saved host applies: the packaged UI in
+// bundled builds, otherwise the local server origin. Mirrors openMainWindow's
+// local UI resolution so the remote-page overlay and window startup agree.
+const buildLocalUiBackTarget = () => {
+  if (shouldUsePackagedUi()) {
+    return buildPackagedUiUrl('/index.html');
+  }
+  return state.sidecarUrl || state.localOrigin || '';
 };
 
 const openMainWindow = async () => {

--- a/packages/electron/remote-shell.mjs
+++ b/packages/electron/remote-shell.mjs
@@ -1,0 +1,117 @@
+// Remote-page shell overlay (Electron main process).
+//
+// The OpenChamber UI renders its own window chrome — title-bar drag regions
+// and the instance switcher — everywhere it runs, including when it is served
+// from a remote instance origin (managed SSH servers serve the same UI). But
+// a configured instance can also serve a FOREIGN page (e.g. an `opencode web`
+// server on a VPS that the user added as a remote instance). Such a page has
+// neither a `-webkit-app-region` drag region (the frameless window becomes
+// impossible to move on Windows/Linux) nor any way to get back to the local
+// OpenChamber instance.
+//
+// This module builds the tiny overlay the main process injects into foreign
+// pages loaded inside OpenChamber windows: a slim draggable bar with a
+// "Back to OpenChamber" button that navigates back to the local UI. The
+// injection is additive and self-contained (inline styles, one button), and
+// never runs on OpenChamber UI documents or on local/packaged pages.
+
+export const OPENCHAMBER_UI_MARKER_ATTR = 'data-oc-ui';
+export const REMOTE_SHELL_BAR_ID = 'oc-remote-shell';
+export const REMOTE_SHELL_BACK_BUTTON_ID = 'oc-remote-shell-back';
+
+const REMOTE_SHELL_BAR_HEIGHT_PX = 28;
+
+/**
+ * Decide whether the remote-page shell should be injected for a page.
+ *
+ * Pure decision helper; the injected script embeds a serialized copy of this
+ * function so main-process logic and in-page behavior cannot drift apart.
+ *
+ * @param {object} page
+ * @param {string} page.protocol  `window.location.protocol` of the page.
+ * @param {string} page.origin    `window.location.origin` of the page.
+ * @param {string} page.openChamberUiMarker  value of the OpenChamber UI marker attribute.
+ * @param {string} page.localOrigin  `window.__OPENCHAMBER_LOCAL_ORIGIN__` ('' when absent).
+ * @returns {boolean} true when the shell bar should be injected.
+ */
+export const remoteShellPageShouldInject = ({ protocol, origin, openChamberUiMarker, localOrigin }) => {
+  if (protocol !== 'http:' && protocol !== 'https:') return false;
+  if (!origin || origin === 'null') return false;
+  // OpenChamber UI documents (local, packaged, or remote-origin) render their
+  // own chrome: drag regions plus the instance switcher. The literal is
+  // intentional: this function is serialized into the injected page script,
+  // so it must not reference module-scope constants.
+  if (openChamberUiMarker === 'openchamber') return false;
+  if (localOrigin) {
+    try {
+      if (new URL(localOrigin).origin === origin) return false;
+    } catch {
+      // Unparseable local origin is not a reason to overlay a foreign page.
+    }
+  }
+  return true;
+};
+
+/**
+ * Build the IIFE injected into foreign pages rendered inside OpenChamber
+ * windows. The script is defensive (try/catch, idempotent, no globals) and
+ * contains no secrets: the only dynamic value is the local UI URL, which the
+ * preload already exposes to remote pages as `__OPENCHAMBER_LOCAL_ORIGIN__`.
+ *
+ * @param {object} options
+ * @param {string} options.localUiUrl  URL to navigate to when "Back to
+ *   OpenChamber" is pressed (packaged UI URL, or the local server origin).
+ * @returns {string} executable JavaScript.
+ */
+export const buildRemoteShellInjectionScript = ({ localUiUrl }) => {
+  const backTarget = JSON.stringify(localUiUrl || '');
+  const guardSource = remoteShellPageShouldInject.toString();
+  const barHeight = REMOTE_SHELL_BAR_HEIGHT_PX;
+  return [
+    '(function () {',
+    '  try {',
+    `    if (document.getElementById(${JSON.stringify(REMOTE_SHELL_BAR_ID)})) return;`,
+    '    var docRoot = document.documentElement;',
+    '    if (!docRoot) return;',
+    '    var shouldInject = (',
+    `      ${guardSource}`,
+    '    )({',
+    '      protocol: window.location && window.location.protocol || \'\',',
+    '      origin: window.location && window.location.origin || \'\',',
+    '      openChamberUiMarker: docRoot.getAttribute(\'data-oc-ui\') || \'\',',
+    '      localOrigin: window.__OPENCHAMBER_LOCAL_ORIGIN__ || \'\',',
+    '    });',
+    '    if (!shouldInject) return;',
+    `    var backTarget = ${backTarget};`,
+    '    if (!backTarget) return;',
+    '    var bar = document.createElement(\'div\');',
+    `    bar.id = ${JSON.stringify(REMOTE_SHELL_BAR_ID)};`,
+    `    bar.setAttribute('data-oc-remote-shell', '1');`,
+    '    bar.setAttribute(\'role\', \'region\');',
+    '    bar.setAttribute(\'aria-label\', \'OpenChamber remote instance\');',
+    `    bar.style.cssText = 'position:fixed;top:0;left:0;right:0;height:${barHeight}px;z-index:2147483647;display:flex;align-items:center;gap:8px;padding:0 10px 0 8px;box-sizing:border-box;-webkit-app-region:drag;user-select:none;cursor:default;background:rgba(21,19,19,0.94);border-bottom:1px solid rgba(255,255,255,0.14);font:12px/1.2 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,ui-sans-serif,system-ui,sans-serif;color:#e8e6df;';`,
+    '    var mark = document.createElement(\'span\');',
+    '    mark.setAttribute(\'aria-hidden\', \'true\');',
+    '    mark.style.cssText = \'display:inline-block;width:14px;height:14px;border-radius:4px;background:#edb449;flex-shrink:0;\';',
+    '    bar.appendChild(mark);',
+    '    var label = document.createElement(\'span\');',
+    '    label.textContent = \'OpenChamber\';',
+    '    label.style.cssText = \'font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;\';',
+    '    bar.appendChild(label);',
+    '    var back = document.createElement(\'button\');',
+    `    back.id = ${JSON.stringify(REMOTE_SHELL_BACK_BUTTON_ID)};`,
+    '    back.type = \'button\';',
+    '    back.textContent = \'← Back to OpenChamber\';',
+    `    back.setAttribute('title', 'Return to the local OpenChamber instance');`,
+    '    back.style.cssText = \'margin-left:auto;-webkit-app-region:no-drag;pointer-events:auto;appearance:none;border:1px solid rgba(255,255,255,0.22);border-radius:6px;background:rgba(255,255,255,0.10);color:#ffffff;padding:3px 10px;font:inherit;cursor:pointer;white-space:nowrap;flex-shrink:0;\';',
+    '    back.addEventListener(\'click\', function () {',
+    '      try { window.location.assign(backTarget); } catch (_) { window.location.href = backTarget; }',
+    '    });',
+    '    back.addEventListener(\'mouseenter\', function () { back.style.background = \'rgba(255,255,255,0.18)\'; });',
+    '    back.addEventListener(\'mouseleave\', function () { back.style.background = \'rgba(255,255,255,0.10)\'; });',
+    '    bar.appendChild(back);',
+    '    (document.body || docRoot).appendChild(bar);',
+    '  } catch (_e) { /* The overlay is best-effort; never break the remote page. */ }',
+    '}())',
+  ].join('\n');
+};

--- a/packages/electron/remote-shell.test.mjs
+++ b/packages/electron/remote-shell.test.mjs
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  OPENCHAMBER_UI_MARKER_ATTR,
+  REMOTE_SHELL_BACK_BUTTON_ID,
+  REMOTE_SHELL_BAR_ID,
+  buildRemoteShellInjectionScript,
+  remoteShellPageShouldInject,
+} from './remote-shell.mjs';
+describe('remoteShellPageShouldInject', () => {
+  const foreignPage = () => ({
+    protocol: 'http:',
+    origin: 'http://100.64.0.10:3000',
+    openChamberUiMarker: '',
+    localOrigin: 'http://127.0.0.1:3901',
+  });
+
+  test('injects on a foreign http page (e.g. an opencode web server)', () => {
+    expect(remoteShellPageShouldInject(foreignPage())).toBe(true);
+  });
+
+  test('skips OpenChamber UI documents via the marker, even at a remote origin', () => {
+    expect(remoteShellPageShouldInject({
+      ...foreignPage(),
+      openChamberUiMarker: 'openchamber',
+    })).toBe(false);
+  });
+
+  test('skips the page when its origin is the local OpenChamber origin', () => {
+    expect(remoteShellPageShouldInject({
+      ...foreignPage(),
+      origin: 'http://127.0.0.1:3901',
+    })).toBe(false);
+    expect(remoteShellPageShouldInject({
+      ...foreignPage(),
+      localOrigin: 'http://100.64.0.10:3000',
+    })).toBe(false);
+  });
+
+  test('skips non-http(s) pages (splash, devtools, packaged UI protocol)', () => {
+    for (const protocol of ['data:', 'devtools:', 'openchamber-ui:', 'about:']) {
+      expect(remoteShellPageShouldInject({ ...foreignPage(), protocol })).toBe(false);
+    }
+  });
+
+  test('skips pages without a usable origin', () => {
+    expect(remoteShellPageShouldInject({ ...foreignPage(), origin: '' })).toBe(false);
+    expect(remoteShellPageShouldInject({ ...foreignPage(), origin: 'null' })).toBe(false);
+  });
+
+  test('skips when the local origin is unparseable only if it does not match', () => {
+    // Unparseable local origin must not suppress injection on a foreign page.
+    expect(remoteShellPageShouldInject({ ...foreignPage(), localOrigin: 'not a url' })).toBe(true);
+  });
+});
+
+describe('buildRemoteShellInjectionScript', () => {
+  test('produces parseable JavaScript', () => {
+    const script = buildRemoteShellInjectionScript({ localUiUrl: 'http://127.0.0.1:3901' });
+    expect(() => new Function(script)).not.toThrow();
+  });
+
+  test('embeds the local UI back target JSON-encoded', () => {
+    const script = buildRemoteShellInjectionScript({ localUiUrl: 'http://127.0.0.1:3901' });
+    expect(script).toContain('"http://127.0.0.1:3901"');
+  });
+
+  test('carries the marker attribute, bar id, and back button id', () => {
+    const script = buildRemoteShellInjectionScript({ localUiUrl: 'openchamber-ui://app/index.html' });
+    expect(script).toContain(OPENCHAMBER_UI_MARKER_ATTR);
+    expect(script).toContain(REMOTE_SHELL_BAR_ID);
+    expect(script).toContain(REMOTE_SHELL_BACK_BUTTON_ID);
+    expect(script).toContain('openchamber-ui://app/index.html');
+  });
+
+  test('embeds the serialized guard so in-page and main-process rules match', () => {
+    const script = buildRemoteShellInjectionScript({ localUiUrl: 'http://127.0.0.1:3901' });
+    expect(script).toContain('openChamberUiMarker');
+    // The marker comparison literal must be inlined (module constants are out
+    // of scope in the page). Function.prototype.toString output differs by
+    // runtime quoting, so accept both quote styles.
+    expect(script.includes('"openchamber"') || script.includes("'openchamber'")).toBe(true);
+  });
+
+  test('skips injection when no back target is available', () => {
+    const script = buildRemoteShellInjectionScript({ localUiUrl: '' });
+    expect(script).toContain('if (!backTarget) return;');
+  });
+
+  test('contains no secrets or local filesystem data', () => {
+    const script = buildRemoteShellInjectionScript({ localUiUrl: 'http://127.0.0.1:3901' });
+    for (const forbidden of ['process.env', 'child_process', 'fs.', 'ipcRenderer', '__OPENCHAMBER_DESKTOP__']) {
+      expect(script).not.toContain(forbidden);
+    }
+  });
+});

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
 
+    <!-- Desktop shell marker. The Electron main process recognizes OpenChamber
+         UI documents (local, packaged, or remote-origin) by this attribute and
+         skips its foreign-page overlay (drag strip + Back to OpenChamber) —
+         this UI renders its own window chrome everywhere, including when it is
+         served by a remote instance. Must run before any document listener. -->
+    <script>
+      document.documentElement.setAttribute('data-oc-ui', 'openchamber');
+    </script>
+
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />


### PR DESCRIPTION
## Intent

Fixes https://linear.app/openchamber/issue/OPE-204

When an OpenChamber desktop window navigates to a configured remote instance
that serves a **foreign** page — e.g. the user pointed an instance at their
VPS's `opencode web` server (Tailscale URL) — that page has:

- no drag region, so the frameless Electron window cannot be moved
  (sub-issue b), and
- no navigation affordance back to the local instance (sub-issue a).

The root cause is that the whole window navigates to the remote origin (the
"Open instance" action in Settings → Remote instances, the instance switcher,
and startup with a remote default host), and a foreign page has neither
OpenChamber's `.app-region-drag` CSS nor the instance switcher.

This PR keeps the existing navigation behavior but guarantees the window is
never left without an escape hatch: the Electron main process injects a slim,
always-draggable overlay bar with a "Back to OpenChamber" button into **any
non-OpenChamber page** rendered inside an OpenChamber window. Clicking the
button navigates back to the local UI (packaged `openchamber-ui://` URL, or
the local server origin in dev). OpenChamber UI documents — local, packaged,
or served by a managed SSH instance at a remote origin — are recognized via a
new `data-oc-ui` marker in `packages/web/index.html` and keep their own
chrome (header drag region + instance switcher), so no double chrome appears.

The user's stated ideal ("use the OpenChamber UI attached to my opencode web
instance") is out of scope: `opencode web` is a different server product and
not an OpenChamber server (confirmed by the maintainer in the original GitHub
issue thread), so this PR does not attempt to render foreign servers inside
the OpenChamber UI.

## Non-goals

- Supporting `opencode web` (or any non-OpenChamber server) as an instance
  the OpenChamber UI can attach to.
- Changing how SSH/managed instances are opened (window still navigates to
  the remote server's own UI, as before).
- Renderer-side UI changes: no React component, no i18n dictionaries, no
  theme tokens were touched (see Repository guidance).

## Affected surfaces

| Surface | Effect |
|---|---|
| `packages/electron/remote-shell.mjs` (new) | Builds the injected overlay script and the pure inject/don't-inject guard. |
| `packages/electron/main.mjs` | `createBrowserWindow` dom-ready: executes the overlay script in every non-Mini-Chat window; new `buildLocalUiBackTarget()` resolves the back URL (packaged UI URL vs local server origin, mirroring `openMainWindow`). |
| `packages/web/index.html` | New inline script sets `data-oc-ui="openchamber"` on `<html>` so the main process recognizes OpenChamber UI documents (any origin). Survives the vite build (verified in `dist/index.html`). |
| `packages/electron/remote-shell.test.mjs` (new) | Guard-logic unit tests + script parse/content/secret-absence tests. |

Unaffected and why:

- **OpenChamber UI at remote origins (managed SSH instances)**: already
  renders desktop chrome everywhere because `isDesktopShell()` is true on any
  page in the window (preload exposes `__OPENCHAMBER_ELECTRON__`
  unconditionally); the `data-oc-ui` marker makes the injection skip it.
- **Mini Chat windows**: their own `will-navigate` guard never loads remote
  pages, so the injection is skipped there.
- **Web/VS Code/mobile runtimes**: no shared UI or server code changed.
- **Navigation guard**: the back target is allowed by the existing
  `isAllowedNavigationUrl` (UI protocol / `state.localOrigin`).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — Runtime Boundaries | Electron owns windows and the privileged boundary; shared UI owns React | The fix lives in `packages/electron` (window/navigation ownership); the only UI change is a marker in `index.html`, no shared contracts touched. |
| Skill `desktop-shell` | Electron main process, window chrome, drag regions, remote pages, security boundaries | Overlay is injected via existing `webContents.executeJavaScript` (same pattern as the init script); contains no secrets (only the local UI URL, already exposed to remote pages as `__OPENCHAMBER_LOCAL_ORIGIN__`); remote pages gain no IPC privileges; `packages/electron/README.md` read. |
| Skill `openchamber-change-discipline` | Source change across packages | Smallest complete change; new module is the owning unit with focused tests; existing behaviors (navigation, host switching, packaged/init-script flows) preserved; `bun run dead-code` run. |
| Skill `locale-ui-patterns` | User-facing button label | The label lives in the Electron main process, not a React component: i18n (`useI18n`) cannot run inside a foreign page (no React/OpenChamber bundle). Hardcoded English matches existing main-process precedent ("Quit OpenChamber?", "Connect to OpenChamber server?", menu labels). Product name "OpenChamber" is exempt from translation per the skill. |
| Skill `theme-system` | Colors/buttons on the overlay | The overlay is injected into pages that have no OpenChamber theme CSS, so Tailwind/token classes are unusable; inline styles use the brand values that the theme tokens resolve to (`surface-background: #151313`, `primary-base: #edb449`). No React component or theme asset changed. |
| `packages/electron/README.md` | Electron package owning docs | Read; behavior addition is consistent with "main.mjs owns windows… SSH/tunnels" and the preload security model. |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:electron` (`node --check main.mjs && node --check preload.mjs`) | PASS |
| `node --check ./remote-shell.mjs` + `node --check ./remote-shell.test.mjs` (electron package) | PASS |
| `bun test packages/electron/remote-shell.test.mjs` | 12 pass / 0 fail (guard matrix, script parse, embedded target, ids/marker, secret absence) |
| `bun test packages/electron/remote-shell.test.mjs packages/electron/ssh-manager.test.mjs` | 19 pass / 0 fail (adjacent SSH manager tests unaffected) |
| `bun run type-check:web` / `bun run lint:web` | PASS (index.html is not covered by either — noted) |
| `bun run build:web` | PASS (54.6s); `data-oc-ui` marker present in `packages/web/dist/index.html` |
| `bun run bundle:main` (electron) | PASS; `remote-shell.mjs` bundled into `dist-bundle/main.mjs` with `minify:false` (so the serialized guard keeps its source form) |
| `bun run dead-code` | No findings for the new files (removed one unused export flagged by the report) |
| Runtime simulation (uncommitted shim, `/tmp`) | Injected script executed against a fake DOM: foreign page → bar injected and click navigates to the local UI; OpenChamber UI at remote origin / local page / `openchamber-ui://` / `data:` splash → not injected (5/5 PASS) |

**Not verified**: real Electron runtime behavior — this environment cannot
launch the packaged desktop app against a live remote instance. `-webkit-app-region`
dragging, overlay rendering on the actual opencode web page, and the
back-navigation round-trip need a manual check on a real VPS instance.

## Visual evidence

**No screenshots possible in this environment — by design.** This change is an Electron **main-process** injection (`packages/electron/remote-shell.mjs`): the injected bar is produced by the privileged desktop shell while rendering a foreign page (the remote opencode web UI) inside the Electron `BrowserWindow`, behind a live SSH remote instance. That runtime cannot be reproduced here: this environment has no display server, no packaged Electron app, and no reachable remote instance to SSH into, so there is no browser surface to drive or capture. Unlike the web-only PRs in this series, nothing about this change exists in the shared web UI, so no headless web capture can illustrate it.

What the behavior was verified with instead (see Validation):

- **12/12 unit tests pass** (`bun test packages/electron/remote-shell.test.mjs`, rerun locally during capture: `12 pass / 0 fail`, 25 expect calls) — covering the guard matrix (which URLs/origins get the bar), script parsing, the embedded target id, markers, and secret absence.
- **Fake-DOM runtime simulation (5/5 PASS)** — the injected script executed against a stub DOM: foreign page → bar injected and its back button navigates to the local UI; OpenChamber UI at remote origin, local page, `openchamber-ui://`, and `data:` splash → **not** injected.
- `bun run bundle:main` embeds the guard source verbatim (`minify:false`) into `dist-bundle/main.mjs` — confirmed during capture.

Expected rendering for a manual/real-VPS check (unchanged from implementation): on a foreign page, a 28px dark bar across the top of the window with an amber mark, "OpenChamber", and a "← Back to OpenChamber" button; the bar is a drag region (`-webkit-app-region: drag`) while the button is not; on OpenChamber UI pages nothing is injected. This PR therefore carries no screenshot evidence branch; runtime confirmation requires the manual desktop check noted in Validation.

## Risks and failure behavior

- **Overlay on foreign pages**: the injection is additive and defensive
  (try/catch, idempotent via element id, inline styles, no globals, no page
  content read). If it throws on some page, only the bar is missing — the
  page is unaffected and behavior is identical to today.
- **Top 28px click interception**: the bar covers the top strip of the remote
  page, so page controls under it are not clickable there (dragging requires
  the strip). This is the intended trade-off for a movable window and an
  escape hatch; the bar is slim and visually reads as app chrome.
- **Back navigation**: target is the packaged UI URL or the local server
  origin, both already allow-listed by `isAllowedNavigationUrl`. If the local
  server is unavailable, the navigation shows the app's normal unreachable
  state rather than stranding the user on a foreign page with no affordance.
- **Dev-mode HMR edge**: the back target uses `sidecarUrl || localOrigin`
  (same resolution as `openMainWindow`); if no built UI exists at that origin
  in a dev setup, the back page shows the server's "static files not found"
  state — identical to existing startup behavior, not a regression.
- **No secrets**: the injected script embeds only the local UI URL, which the
  preload already exposes to remote pages. No filesystem, shell, token, or
  host secrets are included; the desktop IPC surface for remote pages is
  unchanged.
- **Compatibility**: no persisted data, routes, exports, or dependencies
  change; older OpenChamber UI builds without the marker simply fall back to
  today's behavior (overlay would appear over the old UI's own header — a
  cosmetic degradation that self-heals on the next UI refresh).

