### PR TITLE
fix(chat): keep sticky header gradient inside its padding

### DIFF
--- a/packages/ui/src/components/chat/components/TurnItem.tsx
+++ b/packages/ui/src/components/chat/components/TurnItem.tsx
@@ -18,13 +18,13 @@ const TurnItem: React.FC<TurnItemProps> = ({ turn, stickyUserHeader = true, rend
             data-scroll-spy-id={turn.turnId}
         >
             {stickyUserHeader ? (
-                <div className="sticky top-0 z-20 relative bg-[var(--surface-background)] [overflow-anchor:none]">
+                <div className="sticky top-0 z-20 relative bg-[var(--surface-background)] pb-4 sm:pb-8 [overflow-anchor:none]">
                     <div className="relative z-10">
                         {renderMessage(turn.userMessage)}
                     </div>
                     <div
                         aria-hidden="true"
-                        className="pointer-events-none absolute inset-x-0 top-full z-0 h-4 bg-gradient-to-b from-[var(--surface-background)] to-transparent sm:h-8"
+                        className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-4 bg-gradient-to-b from-[var(--surface-background)] to-transparent sm:h-8"
                     />
                 </div>
             ) : (


### PR DESCRIPTION
## Intent

Fixes #2524 (GitHub issue; no Linear issue exists for it).

The gradient fade div under the sticky user header (`pointer-events-none absolute inset-x-0 top-full z-0 h-4 bg-gradient-to-b from-[var(--surface-background)] to-transparent sm:h-8` in `TurnItem.tsx`) was positioned at `top: 100%` of the sticky header container, i.e. below the header box, overlapping the first 16–32px of the assistant content that follows in normal document flow. Because the sticky container forms a `z-20` stacking context, the gradient painted above the assistant block (`z-0`) — opaque at its top edge — obscuring readable message text. This happened in the natural (non-stuck) position too, and was worst for assistant messages rendered without a header (`pt-0`) and during streaming.

Behavior change: the fade now occupies the sticky header's own bottom padding (16px, 32px on `sm+`) and never overlaps in-flow message content. Visually, the fade under the user message looks the same (a soft fade of the surface background below the message), including when the header is stuck and content scrolls beneath it.

## Non-goals

- No change to the `ScrollShadow` top/bottom edge indicators of the chat scroll container — those are a separate mechanism (and are already hidden on mobile when sticky headers are on).
- No z-index/layering changes to message rows or the composer.
- No JS-based "stuck" detection — the fix is purely geometric, so there is no runtime cost.

## Affected surfaces

- `packages/ui` — `src/components/chat/components/TurnItem.tsx` (rendering of every turn's sticky user header).
- Runtimes: web, desktop (Electron), VS Code, hosted mobile, Capacitor mobile all render the shared chat UI, so the fix applies uniformly; it is a pure class change with no runtime-specific branches.
- Persisted/external contracts: none.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` correctness invariants + minimal diffs | Root rules for any source change | Single-file, 2-line class change; no drive-by edits; worktree only |
| `theme-system` skill | Change touches theme tokens/styling (`--surface-background`, gradient) | Token usage unchanged; no new colors, no palette values; light/dark unaffected (token resolves per theme) |
| `performance-engineering` skill | Task requires no re-layout cost; hot path is the chat message list | Fix is static CSS (padding + `bottom-0`); no observers, listeners, or per-render work added; no memo/selector changes; no layout measurement |
| `packages/ui/package.json` scripts | Validation command source of truth | Ran `type-check:ui` / `lint:ui` from root (and package-local `type-check` / `lint`) |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (root, `bun run --cwd packages/ui type-check` → `tsc --noEmit`) | PASS — exit 0, no diagnostics |
| `bun run lint:ui` (root, `bun run --cwd packages/ui lint` → `eslint "./src/**/*.{ts,tsx}"`) | PASS — exit 0, no findings |
| Focused tests | None exist for `TurnItem` (no test file references it; grep across `packages/ui` for `TurnItem` in `*.test.*` returned nothing). This is a CSS-class-only change. |
| `bun run dead-code` | Not run — no files added/deleted/renamed, no export/type/entrypoint changes |

Geometry reasoning (static): `top: 100%` on an absolutely positioned child resolves against the containing block's padding box; previously the container had no bottom padding, so the gradient landed below the header over the assistant block. With `pb-4 sm:pb-8` on the container and `bottom-0 h-4 sm:h-8` on the gradient, the gradient fills exactly the padding box, which is part of the sticky header — it can no longer intersect the assistant block's box in flow. `pointer-events-none` and `aria-hidden` are retained.

## Visual evidence

Captured live, before vs after, on the same session at the same scroll position (sticky user headers enabled via the app's own Settings → Chat → "Sticky User Header" toggle; both builds `dev:web:hmr`, headless Chromium 1440×900):

- `after-sticky-header-gradient.png` — this PR's build (`fix/gh-2524-gradient-mask`): a sticky user header stuck at the top of the chat viewport while assistant content scrolls beneath it. Geometry verified in-DOM: the header (`.sticky.top-0 ... pb-4 sm:pb-8`) is 142px tall ending at viewport y=191; its gradient child (`bottom-0 h-4 sm:h-8`) spans y=159–191 — exactly the header's bottom padding box, fully inside the header, so no part of the fade can cover the assistant block's text in flow. The band above the fade (y=49–159) is the user message.
- `before-sticky-header-gradient-main.png` — the base build (main HEAD, `1fd80b91a`) at the identical scroll position: the header is 110px tall ending at y=159, and the gradient (`top-full h-4 sm:h-8`) spans y=159–191 — i.e. 32px BELOW the header, directly over the first rows of the following assistant block. This is the washed-out-text overlap the issue reports (the same 32px band, but on top of content).

Raw URLs:

- https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2676/screens/after-sticky-header-gradient.png
- https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2676/screens/before-sticky-header-gradient-main.png

Notes on method and honesty:

- "Sticky user headers" is an opt-in setting in this app; it was enabled through the real Settings UI (a genuine user interaction), then the same 287-message session was opened in both builds and both chats scrolled to `scrollTop = 1200`, so the comparison is pixel-equivalent except for the PR's class change.
- Natural (non-stuck) position: when the header is not stuck, the fade now sits inside the header's 16/32px bottom padding — a decorative band between the user message and the assistant content with no text underneath (the header is simply 16/32px taller in flow). In this session, user turns are sparse and always followed by very tall assistant blocks, so a mid-viewport non-stuck header could not be parked on screen; the stuck-state geometry above is the exact same padding box, verified by the bounding rects.
- The PR is a CSS-only class change (`top-full` → `bottom-0` + `pb-4 sm:pb-8` on the container), so no seeded data, mocks, or store manipulation were involved in either screenshot.

## Risks and failure behavior

- The sticky header is 16px (32px on `sm+`) taller in flow, which shifts subsequent content down by that amount — a one-time layout delta at the new geometry. The header already carries `[overflow-anchor:none]`, so scroll anchoring is not perturbed by the added padding.
- Sticky behavior when stuck is unchanged (the fade travels with the header; content is meant to be obscured under a sticky header, and the fade makes that edge soft rather than hard).
- No failure/rollback paths: pure presentational class change; no state, no async, no data.

