### PR TITLE
fix(settings): persist collapsible user messages setting

### DIFF
--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -577,6 +577,9 @@ export const createSettingsHelpers = (dependencies) => {
     if (typeof candidate.wideChatLayoutEnabled === 'boolean') {
       result.wideChatLayoutEnabled = candidate.wideChatLayoutEnabled;
     }
+    if (typeof candidate.collapsibleUserMessages === 'boolean') {
+      result.collapsibleUserMessages = candidate.collapsibleUserMessages;
+    }
     if (typeof candidate.showSplitAssistantMessageActions === 'boolean') {
       result.showSplitAssistantMessageActions = candidate.showSplitAssistantMessageActions;
     }

--- a/packages/web/server/lib/opencode/settings-helpers.test.js
+++ b/packages/web/server/lib/opencode/settings-helpers.test.js
@@ -74,6 +74,14 @@ describe('settings helpers', () => {
     expect(helpers.sanitizeSettingsUpdate({ wideChatLayoutEnabled: 'true' })).toEqual({});
   });
 
+  it('accepts only booleans for collapsible user messages', () => {
+    const helpers = createTestHelpers();
+
+    expect(helpers.sanitizeSettingsUpdate({ collapsibleUserMessages: true })).toEqual({ collapsibleUserMessages: true });
+    expect(helpers.sanitizeSettingsUpdate({ collapsibleUserMessages: false })).toEqual({ collapsibleUserMessages: false });
+    expect(helpers.sanitizeSettingsUpdate({ collapsibleUserMessages: 'false' })).toEqual({});
+  });
+
   it('accepts messageStreamTransport as a persisted shared setting', () => {
     const helpers = createTestHelpers();
 


### PR DESCRIPTION
## Intent

Fixes #2405

GitHub-only issue (no Linear counterpart exists for it).

"Collapse long user messages" (`collapsibleUserMessages`) never persisted across restarts: the server-side settings update sanitizer (`sanitizeSettingsUpdate` in `packages/web/server/lib/opencode/settings-helpers.js`) whitelists every key that may be written to the settings file, and this key was missing. Every `PUT /api/config/settings` containing it silently dropped it before the merge+write, so the toggle only changed the in-memory store for the session and reverted to its default after restart. The fix adds the key to the whitelist next to its neighbor `wideChatLayoutEnabled`, making the round-trip (UI → PUT → sanitize → merge → disk → GET → `sanitizeWebSettings` → store) complete.

Note on the second half of the issue: "Wide message layout" (`wideChatLayoutEnabled`) is already fixed on current main — the sanitizer has accepted it since commit `47e5ac843` ("feat: accept wide chat layout setting in updates"), and the UI read-back path (`sanitizeWebSettings` + `applyDesktopUiPreferences` + the store's persisted `partialize`) handles it. Only `collapsibleUserMessages` remains broken on main.

## Non-goals

- No changes to the UI store, `persistence.ts`, or `sanitizeWebSettings`: those already carry both keys (store partialize line ~2476, sanitizer lines 1428–1429, `materializeAuthoritativeUiSettings` line 566).
- No behavior change for any other setting; the sanitizer's whitelist semantics are preserved.

## Affected surfaces

- `packages/web` server (plain JS, not covered by `tsc`/`eslint` which only walk `src/`): `settings-helpers.js` `sanitizeSettingsUpdate` — shared by every settings write path: Desktop (Electron renderer → `/api/config/settings` PUT), web, hosted mobile, and VS Code. `formatSettingsResponse` (GET) also runs the sanitizer, so once the key is on disk it is returned and applied by the UI on restart.
- Persisted contract: settings file on disk gains a durable `collapsibleUserMessages` boolean. No migration needed — the key is additive and optional; older app versions simply ignore the unknown key on read (plain JSON merge, no strict validation).
- No other runtime-specific behavior changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md: persist mechanism must be intentional; use package.json scripts as validation source of truth | This is a persisted-settings contract change spanning UI write path and server store | Traced the full round-trip (updateDesktopSettings → `_flushSettingsUpdate` → `persistSettings` → `sanitizeSettingsUpdate` → `writeSettingsToDisk` → GET → `formatSettingsResponse` → `sanitizeWebSettings` → `applyDesktopUiPreferences`) before touching code; validated with the package test script plus `node --check` because server JS is outside `tsc`/`eslint` coverage |
| openchamber-change-discipline: smallest complete change; focused tests; do not force changes already fixed on main | Issue claims two settings broken; one is already fixed on main | Only added the missing whitelist entry + a sanitizer test; verified `wideChatLayoutEnabled` round-trips on main (commit `47e5ac843` in ancestry) instead of re-changing it |
| settings-ui-patterns (loaded) | Settings surface behavior | No settings UI was changed; the toggles already write through `updateDesktopSettings` exactly like their neighbors (`OpenChamberVisualSettings.tsx` lines 529–537) |
| theme-system (loaded) | Styling rules | Not applicable — no visual changes |
| `packages/web/server/lib/opencode/DOCUMENTATION.md` | Nearest module doc | No ownership/contract/invariant changes to document; the sanitizer whitelist is a bug fix within the existing contract |

## Validation

| Check | Result |
|---|---|
| `bun test server/lib/opencode/settings-helpers.test.js` (packages/web) | 34 pass, 0 fail (89 expect) — includes the new "accepts only booleans for collapsible user messages" test |
| `bun test server/lib/opencode/settings-runtime.test.js` (packages/web) | 2 pass, 1 skip, 0 fail — `persistSettings` flow intact |
| `bun run type-check:web` | Passed (tsc --noEmit, clean) |
| `bun run lint:web` | Passed (eslint on src, clean) |
| `node --check server/lib/opencode/settings-helpers.js` + test file | Syntax OK (server JS is not covered by tsc/eslint) |

Not verified: an actual app restart in the Desktop runtime (no display/Electron environment here) — the round-trip is verified at the sanitizer/merge level by tests and by code tracing of every hop; the persisted JSON merge is a plain spread so no key can be dropped after the sanitizer accepts it.

## Visual evidence

No user-visible rendering change. The fix restores persisted state on startup; expected behavior after this change: toggling "Collapse long user messages" off, restarting, and reopening Settings → Chat → Message Appearance shows the toggle off. Screenshots cannot be captured in this environment (no running Desktop app); none are needed since the diff cannot alter rendered output — it only changes which keys the server writes and returns.

## Risks and failure behavior

- None identified for existing users: the key is additive; a missing value on disk reads as `undefined` and falls back to the store default (`true`) exactly as before, and once written the boolean round-trips verbatim.
- The sanitizer accepts only booleans (strings/other types are dropped), matching the type `DesktopSettings.collapsibleUserMessages?: boolean` and the UI's own sanitizer, so malformed payloads cannot corrupt the file.
- Atomic file write path (`writeSettingsToDisk`) is unchanged.
