### PR TITLE
feat(chat): refocus composer after adding message to context

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -37,6 +37,7 @@ import { useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
 import { getContextObligatoryMessages } from '@/lib/contextObligatoryMessages';
 import { setContextObligatoryMessage } from '@/sync/session-actions';
 import { isVSCodeRuntime } from '@/lib/desktop';
+import { focusChatInput } from './composer/editor/dom';
 
 const ToolOutputDialog = lazyWithChunkRecovery(() => import('./message/ToolOutputDialog'));
 
@@ -416,6 +417,10 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                 createdAt: messageCreatedAt,
                 role: isUser ? 'user' : 'assistant',
             }, !isPinnedIntoContext);
+            // Return focus to the composer so the user can keep typing right
+            // after adding the message to context (matches the refocus pattern
+            // used by the model/agent selectors).
+            requestAnimationFrame(focusChatInput);
         } catch (error) {
             console.error('[chat-message] failed to update context pin', error);
             toast.error(t('chat.messageBody.actions.contextPinFailed'));


### PR DESCRIPTION
## Intent

Fixes #2447 (GitHub issue; no Linear issue exists for it).

After the "add to context" action (context pin toggle on a chat message) completes successfully, the chat input should regain focus so the user can immediately continue typing. Previously the pin button kept focus after the async update, forcing an extra click/tab to get back to the composer.

Behavior change: clicking pin/unpin on a message now returns focus to the composer editor on success. Focus is only moved after the context update succeeds; on failure the error toast path is unchanged and focus is left where it is.

## Non-goals

- No change to the pin/unpin action itself, its optimistic state, or the sync path (`setContextObligatoryMessage`).
- No change to keyboard shortcut behavior, model/agent selector refocusing, or any other `focusChatInput` call site.
- No new public API; the existing `focusChatInput()` helper is reused.

## Affected surfaces

- `packages/ui` — `src/components/chat/ChatMessage.tsx` (`handleToggleContextPin`), using the existing `src/components/chat/composer/editor/dom.ts` `focusChatInput` helper (unchanged).
- Runtimes: web, desktop (Electron), VS Code, hosted mobile, Capacitor mobile all render this handler; the focus call is runtime-agnostic (DOM query for `[data-chat-input="true"] .cm-content`). On mobile WebKit, programmatic focus outside a user gesture may be refused by the platform — the same limitation already applies to every existing `focusChatInput` call site (keyboard shortcuts, model selectors, text-selection menu).
- Persisted/external contracts: none.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` root rules (minimal diffs, thin bridges) | Any source change | 5-line single-file diff; reuses the established cross-component focus helper instead of threading new props/refs |
| `theme-system` skill | Task instruction for this issue | No styling, token, icon, or button changes; the pin button itself is untouched |
| `ui-api-decoupling` skill trigger ("Shared UI data access… bridges") | The action calls `setContextObligatoryMessage` (sync/API boundary) | No API surface changed; focus is a purely local UI side effect after the awaited call succeeds |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | Documents the composer focus/editor layer and its testing boundaries | Confirms `focusChatInput` targets the CodeMirror `.cm-content`; documents that focus behavior is not covered by tests and must be verified by hand |
| `packages/ui/package.json` scripts | Validation command source of truth | Ran `type-check:ui` / `lint:ui` and the focused `dom` / `addSelectionToChat` tests |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (root; `tsc --noEmit` in `packages/ui`) | PASS — exit 0, no diagnostics |
| `bun run lint:ui` (root; `eslint "./src/**/*.{ts,tsx}"`) | PASS — exit 0, no findings |
| `bun test src/components/chat/composer/editor/__tests__/dom.test.ts` | 1 pass / 0 fail (verifies `focusChatInput` targets `[data-chat-input="true"] .cm-content` and calls `.focus()`) |
| `bun test src/lib/addSelectionToChat.test.ts` | 10 pass / 0 fail (regression suite for another consumer of the same focus helper) |
| Focused tests for the pin handler | None exist — the composer DOCUMENTATION.md states rendering/focus behavior is not covered by the test environment and is verified by hand |
| `bun run dead-code` | Not run — no files added/deleted/renamed, no exports changed |

Not verified in this environment: an actual browser run (no display/server available), so the real focus move after clicking the pin button was not observed; iOS keyboard-rasing/refusal behavior remains platform-verified-by-hand as documented.

## Visual evidence

No screenshots could be captured (no browser/display in this environment). Expected behavior, described concretely:

- Before: clicking the pushpin ("Add to context" / "Remove from context") action on a message leaves focus on the pin button; the composer is not focused.
- After: on a successful pin/unpin, focus moves to the chat input (caret visible in the composer) within the next animation frame, ready for typing. The pin button's pressed state (`aria-pressed`) and spinner (`contextPinPending`) behave exactly as before; on failure an error toast shows and focus is not moved.

## Risks and failure behavior

- If the composer is unmounted (no `[data-chat-input="true"]` element, e.g. some read-only surfaces), `focusChatInput` is a safe no-op (`?.` on the query result) — verified in `dom.test.ts` semantics.
- On mobile, the platform may ignore the programmatic focus (existing, documented limitation of all `focusChatInput` call sites); behavior there is unchanged from the established pattern.
- Failure path: `setContextObligatoryMessage` throwing keeps the existing `toast.error` + `setPinPending(false)` behavior; focus is intentionally not moved on failure.
- No data, storage, or sync behavior changes; no cleanup or rollback needed (pure UI side effect).
