### PR TITLE
feat(mobile): add two-step archive to the header session switcher rows

### DIFF
--- a/packages/ui/src/apps/MobileSessionSwitcher.test.ts
+++ b/packages/ui/src/apps/MobileSessionSwitcher.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+import type { Session } from '@opencode-ai/sdk/v2';
+import type { SessionNode } from '@/components/session/sidebar/types';
+
+import { collectSessionNodeDescendantIds } from './mobileSessionArchive';
+
+const source = readFileSync(new URL('./MobileSessionSwitcher.tsx', import.meta.url), 'utf8');
+
+const makeSession = (id: string): Session => ({
+  id,
+  title: `session-${id}`,
+  time: { created: 0, updated: 0 },
+} as Session);
+
+const makeNode = (id: string, children: SessionNode[] = []): SessionNode => ({
+  session: makeSession(id),
+  children,
+  worktree: null,
+});
+
+describe('collectSessionNodeDescendantIds', () => {
+  test('returns every descendant depth-first, root excluded', () => {
+    const node = makeNode('root', [
+      makeNode('a', [makeNode('a1'), makeNode('a2', [makeNode('a2x')])]),
+      makeNode('b'),
+    ]);
+    expect(collectSessionNodeDescendantIds(node)).toEqual(['a', 'a1', 'a2', 'a2x', 'b']);
+  });
+
+  test('returns an empty list for a leaf node', () => {
+    expect(collectSessionNodeDescendantIds(makeNode('leaf'))).toEqual([]);
+  });
+});
+
+describe('MobileSessionSwitcher archive affordance', () => {
+  test('archive controls are siblings of the select button, so tapping them cannot select', () => {
+    const rowStart = source.indexOf('const SwitcherRow');
+    const selectButtonStart = source.indexOf('onClick={onSelect}', rowStart);
+    const archiveButtonStart = source.indexOf("onClick={onRequestArchive}", rowStart);
+    // The select button element is closed before the archive button opens:
+    // the archive button lives outside it (sibling), not nested.
+    expect(selectButtonStart).toBeGreaterThan(rowStart);
+    expect(archiveButtonStart).toBeGreaterThan(selectButtonStart);
+    // The archive button must not close over onSelect — tapping it never
+    // selects the session.
+    expect(source.indexOf('onSelect()', archiveButtonStart)).toBe(-1);
+  });
+
+  test('the confirm chip is gated behind the armed state and executes the archive', () => {
+    const rowStart = source.indexOf('const SwitcherRow');
+    // Confirm chip only renders while the row is armed.
+    const chipGuard = source.indexOf('{confirmingArchive ? (', rowStart);
+    expect(chipGuard).toBeGreaterThan(-1);
+    // The armed icon button flips to the cancel affordance; tapping it
+    // (onRequestArchive) disarms instead of archiving.
+    const cancelLabel = source.indexOf("t('mobile.sessions.cancelArchiveAria', { title })", rowStart);
+    expect(cancelLabel).toBeGreaterThan(chipGuard);
+    // The chip itself performs the archive through the confirm handler.
+    const chipConfirm = source.indexOf('onClick={onConfirmArchive}', rowStart);
+    expect(chipConfirm).toBeGreaterThan(chipGuard);
+  });
+
+  test('the panel resets the armed confirmation when it closes or a session is selected', () => {
+    const closeReset = source.indexOf('setConfirmingArchiveId(null);', source.indexOf('// Closing the panel cancels'));
+    expect(closeReset).toBeGreaterThan(-1);
+    const selectReset = source.indexOf('setConfirmingArchiveId(null);', source.indexOf('// Selecting a row cancels'));
+    expect(selectReset).toBeGreaterThan(-1);
+    const rowUsesArmedState = source.indexOf('confirmingArchive={confirmingArchiveId === session.id}');
+    expect(rowUsesArmedState).toBeGreaterThan(-1);
+  });
+
+  test('the confirmed archive reuses the canonical batch action with descendant ids', () => {
+    const handlerStart = source.indexOf('const handleConfirmArchive');
+    expect(handlerStart).toBeGreaterThan(-1);
+    expect(source.indexOf('archiveSessions([item.node.session.id, ...descendantIds])', handlerStart)).toBeGreaterThan(-1);
+    expect(source.indexOf('collectSessionNodeDescendantIds(item.node)', handlerStart)).toBeGreaterThan(-1);
+    // Partial failures keep their existing visible feedback.
+    expect(source.indexOf("t('sessions.sidebar.bulkActions.failedArchivePlural', { count: failedIds.length })", handlerStart)).toBeGreaterThan(-1);
+  });
+});

--- a/packages/ui/src/apps/MobileSessionSwitcher.tsx
+++ b/packages/ui/src/apps/MobileSessionSwitcher.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
 
+import { Icon } from '@/components/icon/Icon';
 import { SessionActivityDuration } from '@/components/session/SessionActivityDuration';
 import { formatSessionCompactDateLabel } from '@/components/session/sidebar/utils';
-import { useSwitcherItems } from '@/components/session/sidebar/hooks/useSwitcherItems';
+import { useSwitcherItems, type SwitcherItem } from '@/components/session/sidebar/hooks/useSwitcherItems';
+import { toast } from '@/components/ui';
 import { useTabletLayout } from '@/lib/device';
 import { useI18n } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
+import { collectSessionNodeDescendantIds } from '@/apps/mobileSessionArchive';
 import { refreshGlobalSessions, resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useSessionUnseenCount } from '@/sync/notification-store';
@@ -23,13 +26,20 @@ const getSessionTitle = (session: Session, fallback: string): string =>
 
 /** One switcher row: live status (busy spinner / attention dot), title,
     "project · branch", compact time. Mirrors the desktop SessionSwitcherDropdown
-    indicator conventions; no subsession chevrons on mobile by design. */
+    indicator conventions; no subsession chevrons on mobile by design. The
+    archive affordance is a SIBLING of the select button — tapping it never
+    selects the session — and uses the two-step pattern from the sessions
+    drawer: the first tap arms a destructive confirm chip, the second tap on
+    the chip archives; the armed icon button (X) or any row selection cancels. */
 const SwitcherRow: React.FC<{
   session: Session;
   meta: string;
   active: boolean;
   onSelect: () => void;
-}> = ({ session, meta, active, onSelect }) => {
+  confirmingArchive?: boolean;
+  onRequestArchive?: () => void;
+  onConfirmArchive?: () => void;
+}> = ({ session, meta, active, onSelect, confirmingArchive = false, onRequestArchive, onConfirmArchive }) => {
   const { t } = useI18n();
   const status = useGlobalSessionStatus(session.id);
   const unseenCount = useSessionUnseenCount(session.id);
@@ -39,47 +49,78 @@ const SwitcherRow: React.FC<{
   const hasActivityDuration = useHasSessionActivityDuration(session.id, isStreaming);
   const showActivityDuration = (isStreaming || showUnreadDot) && hasActivityDuration;
   const timeLabel = formatSessionCompactDateLabel(session.time?.updated ?? session.time?.created ?? 0);
+  const title = getSessionTitle(session, t('sessions.sidebar.session.untitled'));
+  const archiveEnabled = Boolean(onRequestArchive && onConfirmArchive);
 
   return (
-    <button
-      type="button"
-      className={cn(
-        'flex w-full items-center gap-3 rounded-xl px-2.5 py-2 text-left transition-colors active:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary',
-        active && 'bg-[color-mix(in_srgb,var(--primary)_10%,transparent)]',
-      )}
-      onClick={onSelect}
-      style={{ touchAction: 'manipulation' }}
-    >
-      <span className="flex min-w-0 flex-1 flex-col">
-        <span className={cn('block truncate typography-ui-label', active ? 'text-primary' : 'text-foreground')}>
-          {getSessionTitle(session, t('sessions.sidebar.session.untitled'))}
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        className={cn(
+          'flex min-w-0 flex-1 items-center gap-3 rounded-xl px-2.5 py-2 text-left transition-colors active:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary',
+          active && 'bg-[color-mix(in_srgb,var(--primary)_10%,transparent)]',
+        )}
+        onClick={onSelect}
+        style={{ touchAction: 'manipulation' }}
+      >
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className={cn('block truncate typography-ui-label', active ? 'text-primary' : 'text-foreground')}>
+            {title}
+          </span>
+          {meta ? (
+            <span className="block truncate typography-micro text-muted-foreground">{meta}</span>
+          ) : null}
         </span>
-        {meta ? (
-          <span className="block truncate typography-micro text-muted-foreground">{meta}</span>
+        {/* Activity sits on the right, before the time — no reserved left gutter. */}
+        {isStreaming || showUnreadDot ? (
+          <span
+            className={cn(
+              'size-1.5 shrink-0 rounded-full',
+              isStreaming ? 'bg-primary' : 'bg-[var(--status-info)]',
+            )}
+            aria-hidden
+          />
         ) : null}
-      </span>
-      {/* Activity sits on the right, before the time — no reserved left gutter. */}
-      {isStreaming || showUnreadDot ? (
-        <span
-          className={cn(
-            'size-1.5 shrink-0 rounded-full',
-            isStreaming ? 'bg-primary' : 'bg-[var(--status-info)]',
-          )}
-          aria-hidden
-        />
+        {/* The elapsed turn takes the time slot while it matters, then hands it
+            back to the relative timestamp. */}
+        {showActivityDuration ? (
+          <SessionActivityDuration
+            sessionId={session.id}
+            running={isStreaming}
+            className="typography-micro"
+          />
+        ) : timeLabel ? (
+          <span className="shrink-0 typography-micro text-muted-foreground tabular-nums">{timeLabel}</span>
+        ) : null}
+      </button>
+      {archiveEnabled ? (
+        <>
+          {confirmingArchive ? (
+            <button
+              type="button"
+              className="mr-1.5 flex h-9 shrink-0 items-center gap-1.5 rounded-xl bg-destructive px-3 text-destructive-foreground transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
+              aria-label={t('mobile.sessions.archiveSessionAria', { title })}
+              onClick={onConfirmArchive}
+              style={{ touchAction: 'manipulation' }}
+            >
+              <Icon name="archive" className="size-4" />
+              <span className="typography-ui-label">{t('sessions.sidebar.bulkActions.archive')}</span>
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="mr-1.5 flex size-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground/70 transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label={confirmingArchive
+              ? t('mobile.sessions.cancelArchiveAria', { title })
+              : t('mobile.sessions.archiveSessionAria', { title })}
+            onClick={onRequestArchive}
+            style={{ touchAction: 'manipulation' }}
+          >
+            <Icon name={confirmingArchive ? 'close' : 'archive'} className="size-4" />
+          </button>
+        </>
       ) : null}
-      {/* The elapsed turn takes the time slot while it matters, then hands it
-          back to the relative timestamp. */}
-      {showActivityDuration ? (
-        <SessionActivityDuration
-          sessionId={session.id}
-          running={isStreaming}
-          className="typography-micro"
-        />
-      ) : timeLabel ? (
-        <span className="shrink-0 typography-micro text-muted-foreground tabular-nums">{timeLabel}</span>
-      ) : null}
-    </button>
+    </div>
   );
 };
 
@@ -133,6 +174,11 @@ export const MobileSessionSwitcher: React.FC<{
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
   const setCurrentSession = useSessionUIStore((state) => state.setCurrentSession);
   const setActiveProjectIdOnly = useProjectsStore((state) => state.setActiveProjectIdOnly);
+  const archiveSession = useSessionUIStore((state) => state.archiveSession);
+  const archiveSessions = useSessionUIStore((state) => state.archiveSessions);
+  // Two-step archive: which row's confirm chip is armed. Any selection or
+  // panel close disarms it, so cancel leaves the session unchanged.
+  const [confirmingArchiveId, setConfirmingArchiveId] = React.useState<string | null>(null);
 
   const items = useSwitcherItems(open || shouldRender, { maxParents: RECENT_SESSIONS_LIMIT });
 
@@ -145,6 +191,8 @@ export const MobileSessionSwitcher: React.FC<{
       setIsExiting(false);
       return;
     }
+    // Closing the panel cancels any armed archive confirmation.
+    setConfirmingArchiveId(null);
     if (!shouldRender) return;
     setIsExiting(true);
     const timeoutId = window.setTimeout(() => {
@@ -179,9 +227,43 @@ export const MobileSessionSwitcher: React.FC<{
   }, [anchorRef, onClose, open]);
 
   const handleSelect = React.useCallback((session: Session) => {
+    // Selecting a row cancels any armed archive confirmation.
+    setConfirmingArchiveId(null);
     void setCurrentSession(session.id, resolveGlobalSessionDirectory(session));
     onClose();
   }, [onClose, setCurrentSession]);
+
+  // First tap arms the row's confirm chip; tapping the armed icon (X) or
+  // selecting the row disarms it. Archive never selects the session.
+  const handleRequestArchive = React.useCallback((sessionId: string) => {
+    setConfirmingArchiveId((current) => (current === sessionId ? null : sessionId));
+  }, []);
+
+  // Second tap: archive the session and its known active descendants through
+  // the canonical batch action, keeping the existing per-result toasts so
+  // partial failures stay visible. The global store reconciliation removes
+  // the archived rows from this panel automatically.
+  const handleConfirmArchive = React.useCallback(async (item: SwitcherItem) => {
+    setConfirmingArchiveId(null);
+    const descendantIds = collectSessionNodeDescendantIds(item.node);
+    if (descendantIds.length === 0) {
+      const ok = await archiveSession(item.node.session.id);
+      if (ok) toast.success(t('sessions.sidebar.session.archive.success'));
+      else toast.error(t('sessions.sidebar.session.archive.error'));
+      return;
+    }
+    const { archivedIds, failedIds } = await archiveSessions([item.node.session.id, ...descendantIds]);
+    if (archivedIds.length > 0) {
+      toast.success(archivedIds.length === 1
+        ? t('sessions.sidebar.bulkActions.archivedSingle', { count: archivedIds.length })
+        : t('sessions.sidebar.bulkActions.archivedPlural', { count: archivedIds.length }));
+    }
+    if (failedIds.length > 0) {
+      toast.error(failedIds.length === 1
+        ? t('sessions.sidebar.bulkActions.failedArchiveSingle', { count: failedIds.length })
+        : t('sessions.sidebar.bulkActions.failedArchivePlural', { count: failedIds.length }));
+    }
+  }, [archiveSession, archiveSessions, t]);
 
   if (!shouldRender) return null;
 
@@ -229,6 +311,9 @@ export const MobileSessionSwitcher: React.FC<{
                     if (item.projectId) setActiveProjectIdOnly(item.projectId);
                     handleSelect(session);
                   }}
+                  confirmingArchive={confirmingArchiveId === session.id}
+                  onRequestArchive={() => handleRequestArchive(session.id)}
+                  onConfirmArchive={() => void handleConfirmArchive(item)}
                 />
               );
             })

--- a/packages/ui/src/apps/mobileSessionArchive.ts
+++ b/packages/ui/src/apps/mobileSessionArchive.ts
@@ -1,0 +1,19 @@
+import type { SessionNode } from '@/components/session/sidebar/types';
+
+/**
+ * Depth-first list of every known descendant session of a session node.
+ * Switcher nodes are built from the global active-session cache, which already
+ * excludes archived sessions, so the collected subtree is exactly the "known
+ * active descendants" an archive confirmation covers.
+ */
+export const collectSessionNodeDescendantIds = (node: SessionNode): string[] => {
+  const ids: string[] = [];
+  const visit = (current: SessionNode): void => {
+    for (const child of current.children) {
+      ids.push(child.session.id);
+      visit(child);
+    }
+  };
+  visit(node);
+  return ids;
+};


### PR DESCRIPTION
## Intent

Fixes #2556

(No Linear issue exists for this GitHub-only issue.)

The mobile session panel opened from the composer footer (`MobileSessionStatusBar.tsx`) used to expose the archive action, but that component was removed by the navigation rework (#2561, already in main). The cross-project session panel on mobile today is the header session switcher (`MobileSessionSwitcher`), whose rows were select-only. This PR adds the archive affordance to those rows: a visible icon button per row that never selects the session, a two-step confirmation (first tap arms a destructive confirm chip, second tap archives; X or row selection cancels), reuse of the canonical `archiveSession`/`archiveSessions` store actions with existing localized labels/toasts, and subtree archive of the selected session's known active descendants.

## Non-goals

- No change to the sessions drawer (`MobileSessionsSheet`), which already has swipe archive on rows.
- No backend/API change: the subtree archive reuses the existing `archiveSessions` batch action with descendant IDs collected from the global active-session cache.
- No archived-sessions view on mobile (unchanged).
- The composer footer itself is untouched (it no longer hosts a session panel after #2561).

## Affected surfaces

- `packages/ui/src/apps/MobileSessionSwitcher.tsx` — header recents popover (phone sheet + iPad popover variant). New props on `SwitcherRow`; row restructured so the archive button is a sibling of the select button.
- `packages/ui/src/apps/mobileSessionArchive.ts` — new tiny pure helper `collectSessionNodeDescendantIds` (extracted to its own module because the repo's react-refresh rule forbids non-component exports from component files).
- `packages/ui/src/apps/MobileSessionSwitcher.test.ts` — focused tests: pure logic for descendant collection plus source-structure assertions for the two-step gating (mirrors the deleted `MobileSessionStatusBar.test.ts` precedent).
- i18n: no new keys — reuses `mobile.sessions.archiveSessionAria`, `mobile.sessions.cancelArchiveAria` (previously dead key restored to use), `sessions.sidebar.bulkActions.archive` / `archivedSingle` / `archivedPlural` / `failedArchiveSingle` / `failedArchivePlural`, `sessions.sidebar.session.archive.success` / `.error` (all present in all 10 locales).
- Web/desktop/VS Code/Electron: unaffected — this component is mobile-app only.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md runtime boundaries / minimal diffs | Mobile UI belongs to `packages/ui`; one issue = one branch = one PR | Only three files in `packages/ui/src/apps` changed; no drive-by refactors |
| `theme-system` skill | New buttons/icons with color states | Sprite-based `Icon` (`archive`, `close`) instead of direct `@remixicon/react` imports; `bg-destructive`/`text-destructive-foreground` for the confirm chip, `interactive-hover` for the icon hover, `interactive-selection`-style primary mix for the active row; no hardcoded hex |
| `locale-ui-patterns` skill | User-facing labels/aria | All visible strings go through `useI18n()` with existing keys; zero new keys, so no untranslated-locale risk; aria labels distinguish armed vs. unarmed state |
| `sync-state-invariants` skill | Archive must not leave stale rows; failures must not masquerade as success | Row removal comes from the authoritative global store (the batch action upserts archived records; `useSwitcherItems` reads `activeSessions`); per-id `archivedIds`/`failedIds` keep partial failures visible through existing toasts; armed state is cleared on close/select |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/apps/MobileSessionSwitcher.test.ts` | 6 pass, 0 fail (15 expect calls) |
| `bun test packages/ui/src/apps/` | 23 pass, 0 fail (includes the new suite) |
| `bun run type-check:ui` | Pass (tsc --noEmit, exit 0) |
| `bun run lint:ui` | Pass (eslint, exit 0) — fixed one react-refresh violation by extracting the helper module |
| `bun run dead-code` | No findings for the new files/exports (report shows only pre-existing unrelated items) |

Not verified: no mobile runtime/simulator available in this environment, so the two-step tap flow and the iPad popover variant were not exercised interactively; no screenshots possible. Validation is type-check, lint, and focused unit/structure tests only.

## Visual evidence

No screenshots possible: there is no mobile runtime or browser viewport harness available in this environment, and the component only renders inside the Capacitor mobile shell / mobile web layout. Expected rendering: each switcher row gains a 36px icon button on the right showing the archive (box) icon at `text-muted-foreground/70`, turning `text-foreground` with `interactive-hover` background on hover. First tap swaps it to a close (X) icon and inserts a destructive (red) "Archive" chip with the archive icon between the time and the X button; the row content is unchanged. Tapping the chip archives (row disappears), tapping the X or any row restores the plain row. In the iPad popover the same row layout applies at 380px width; long titles truncate as before since the archive controls are shrink-0.

## Risks and failure behavior

- Cancel semantics: the armed state is local component state and is reset on panel close (including the 140ms exit animation) and on any row selection; a tap on the X button toggles it off. A session is only mutated on the second tap of the confirm chip.
- Partial failure: `archiveSessions` returns `{ archivedIds, failedIds }`; both are toasted with the existing single/plural keys, and the rows for archived ids disappear while failed ones remain — no stale rows and no swallowed failures.
- Subtree correctness: descendants are collected from the same global active cache the switcher renders, which already excludes archived sessions, so the executed ID list always matches what the user was told (the sheet's existing "known active descendants" contract).
- Current-session archive: the canonical `archiveSession` action already clears `currentSessionId` when the archived session was active; the panel then drops the row via store reconciliation.
- Accessibility: all controls are real `<button>`s with localized aria-labels; the select button and archive controls are siblings, so keyboard focus order is select → archive; no nested interactive elements.
- Performance: the descendant walk is bounded by the already-in-memory node tree; no new fetch, no new polling.
