### PR TITLE
fix(chat): keep the composer's platform period-on-double-space intact (Fixes #2504)

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -97,6 +97,7 @@ import {
     type ComposerEditorHandle,
 } from './composer/editor/ComposerEditor';
 import { createComposerEditorViewStore } from './composer/editor/viewStore';
+import { composerAutoCorrect } from './composer/editor/autocorrect';
 import {
     appendInlineText,
     appendWithLineBreaks,
@@ -2646,7 +2647,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                                         : t(useCompactChatPlaceholder ? 'chat.chatInput.placeholder.chatCompact' : 'chat.chatInput.placeholder.chat')
                                     : t('chat.chatInput.placeholder.selectSession')}
                                 editable={Boolean(currentSessionId || newSessionDraftOpen)}
-                                autoCorrect={isMobile}
+                                autoCorrect={composerAutoCorrect({ isMobile })}
                                 autoCapitalize={isMobile ? 'sentences' : 'none'}
                                 spellCheck={isMobile || inputSpellcheckEnabled}
                                 fillContainer={isComposerExpanded}

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -81,6 +81,19 @@ composer holds a prompt, not a source file: it is short enough that a full pass
 is cheaper and far simpler than incremental mapping, and it keeps the editor
 and the send path reading the same grammar.
 
+The content element's `autocorrect` keyword is a policy decided by the caller
+through `editor/autocorrect.ts`. The HTML `autocorrect` attribute matches its
+keywords ASCII case-insensitively, so the composer keeps desktop word
+correction off everywhere — but @codemirror/view reads the attribute with an
+exact `== "off"` and rewrites macOS and Android's insert-period-on-double-space
+into a plain double space when it sees exactly `off`. `editor/autocorrect.ts`
+therefore emits the case-insensitively-equivalent `Off` on exactly the
+platforms CodeMirror reverts (`browser.mac || browser.android`, mirrored
+deliberately), and the literal `off` everywhere else. Do not "normalize" the
+`Off` spelling back to `off`, and if a @codemirror/view upgrade changes the
+guard, the pinned-guard test in `editor/__tests__/autocorrect.test.ts` fails
+first.
+
 ## Ordering rules worth knowing
 
 - `editor/ComposerEditor.tsx` forwards a click on the composer's padding by

--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -34,6 +34,7 @@ import {
 
 import { cn } from '@/lib/utils';
 import type { ComposerLanguageContext } from '../language/tokenize';
+import type { ComposerAutoCorrect } from './autocorrect';
 import { composerLanguage, setLanguageContext } from './composerLanguage';
 import type { ComposerEditorViewStore } from './viewStore';
 import { composerEditorTheme, composerNativeSelectionExtension } from './theme';
@@ -89,8 +90,13 @@ export interface ComposerEditorProps {
     placeholder?: string;
     editable?: boolean;
     spellCheck?: boolean;
-    /** Mobile keyboards; ignored on desktop. */
-    autoCorrect?: boolean;
+    /**
+     * The content element's `autocorrect` keyword, chosen by the caller via
+     * `autocorrect.ts`. `'Off'` (the HTML case-insensitive spelling of off)
+     * is a workaround for CodeMirror's exact-match revert of the platform's
+     * insert-period-on-double-space; see the module for the invariant.
+     */
+    autoCorrect?: ComposerAutoCorrect;
     autoCapitalize?: 'none' | 'sentences';
     /** Fill the available height instead of growing with the content. */
     fillContainer?: boolean;
@@ -147,7 +153,7 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
             placeholder,
             editable = true,
             spellCheck = false,
-            autoCorrect = false,
+            autoCorrect = 'off',
             autoCapitalize = 'none',
             fillContainer = false,
             maxLines = 8,
@@ -262,7 +268,7 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                         }),
                         EditorView.contentAttributes.of({
                             spellcheck: String(handlersRef.current.spellCheck ?? false),
-                            autocorrect: handlersRef.current.autoCorrect ? 'on' : 'off',
+                            autocorrect: handlersRef.current.autoCorrect ?? 'off',
                             autocapitalize: handlersRef.current.autoCapitalize ?? 'none',
                             ...(handlersRef.current['aria-label']
                                 ? { 'aria-label': handlersRef.current['aria-label'] }
@@ -406,7 +412,7 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
             if (!view) return;
             const content = view.contentDOM;
             content.setAttribute('spellcheck', String(spellCheck));
-            content.setAttribute('autocorrect', autoCorrect ? 'on' : 'off');
+            content.setAttribute('autocorrect', autoCorrect);
             content.setAttribute('autocapitalize', autoCapitalize);
         }, [autoCapitalize, autoCorrect, spellCheck]);
 

--- a/packages/ui/src/components/chat/composer/editor/__tests__/autocorrect.test.ts
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/autocorrect.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { composerAutoCorrect } from '../autocorrect';
+
+// The installed bundle of @codemirror/view, resolved through the package's
+// own node_modules (the same copy the editor imports) rather than through
+// the Bun cache, which may hold other versions.
+const codeMirrorViewDist = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..', '..', '..', '..', '..', '..',
+    'node_modules', '@codemirror', 'view', 'dist', 'index.js',
+);
+
+type Signals = Pick<Navigator, 'userAgent' | 'vendor' | 'platform' | 'maxTouchPoints'>;
+
+const signals = (overrides: Partial<Signals>): Signals => ({
+    userAgent: '',
+    vendor: '',
+    platform: '',
+    maxTouchPoints: 0,
+    ...overrides,
+});
+
+// The platforms where @codemirror/view's insert-period-on-double-space
+// revert path is live (`browser.mac || browser.android`).
+const revertedPlatforms: Array<[string, Signals]> = [
+    ['macOS', signals({ platform: 'MacIntel' })],
+    ['iPhone', signals({
+        platform: 'iPhone',
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148',
+        vendor: 'Apple Computer, Inc.',
+    })],
+    ['iPadOS (touch detection)', signals({
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.4 Safari/605.1.15',
+        vendor: 'Apple Computer, Inc.',
+        maxTouchPoints: 5,
+    })],
+    ['Android', signals({
+        platform: 'Linux armv8l',
+        userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile Safari/537.36',
+    })],
+];
+
+// The platforms where CodeMirror never reverts, so the literal keyword stays.
+const untouchedPlatforms: Array<[string, Signals]> = [
+    ['Windows', signals({ platform: 'Win32' })],
+    ['Linux', signals({ platform: 'Linux x86_64' })],
+];
+
+describe('composerAutoCorrect', () => {
+    for (const [name, nav] of revertedPlatforms) {
+        test(`keeps desktop correction off on ${name} without tripping CodeMirror's revert`, () => {
+            const keyword = composerAutoCorrect({ isMobile: false, navigator: nav });
+
+            // Off to the browser (ASCII case-insensitive), so desktop word
+            // correction stays disabled...
+            expect(keyword.toLowerCase()).toBe('off');
+            // ...but not the exact string CodeMirror matches against, so the
+            // platform's insert-period-on-double-space is not rewritten.
+            expect(keyword).not.toBe('off');
+            expect(keyword).toBe('Off');
+        });
+    }
+
+    for (const [name, nav] of untouchedPlatforms) {
+        test(`emits the literal off keyword on ${name}`, () => {
+            expect(composerAutoCorrect({ isMobile: false, navigator: nav })).toBe('off');
+        });
+    }
+
+    test('detects the platform like CodeMirror does, not by user agent alone', () => {
+        // A spoofed macOS UA on Linux must not enable the workaround: the
+        // browser still matches `autocorrect` case-insensitively, so `Off`
+        // would be harmless — but CodeMirror's revert path is what the
+        // spelling must track, and it keys off `nav.platform`.
+        expect(composerAutoCorrect({
+            isMobile: false,
+            navigator: signals({
+                platform: 'Linux x86_64',
+                userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+            }),
+        })).toBe('off');
+    });
+
+    test('preserves the mobile policy', () => {
+        expect(composerAutoCorrect({
+            isMobile: true,
+            navigator: signals({ platform: 'Win32' }),
+        })).toBe('on');
+    });
+
+    test('matches the pinned @codemirror/view revert guard', () => {
+        // The `Off` workaround only works while CodeMirror compares the
+        // attribute with an exact `== "off"` on the mac/android flags. Read
+        // the installed bundle (resolved through the package's own
+        // node_modules, not the Bun cache) and match whitespace-tolerantly so
+        // non-semantic minifier reformatting does not false-fail; a semantic
+        // change (case-insensitive match, different platform flags) is what
+        // this test is here to catch.
+        const dist = readFileSync(codeMirrorViewDist, 'utf8');
+
+        // The exact-match attribute read that gates the revert path.
+        expect(
+            /getAttribute\(\s*["']autocorrect["']\s*\)\s*==\s*["']off["']\s*\)/.test(dist),
+        ).toBe(true);
+        // The period-on-double-space detection both revert paths share.
+        expect(/\/\^\\\.\s*\?\$\/?/.test(dist)).toBe(true);
+        // The platform flags the guard is gated on.
+        expect(/\/Mac\/\.test\(\s*nav\.platform\s*\)/.test(dist)).toBe(true);
+        expect(/\/Android\\b\/\.test\(\s*nav\.userAgent\s*\)/.test(dist)).toBe(true);
+    });
+});

--- a/packages/ui/src/components/chat/composer/editor/autocorrect.ts
+++ b/packages/ui/src/components/chat/composer/editor/autocorrect.ts
@@ -1,0 +1,74 @@
+/**
+ * The `autocorrect` keyword for the composer's content element.
+ *
+ * The composer's correction policy is "on for mobile keyboards, off
+ * elsewhere". That policy is applied through the HTML `autocorrect`
+ * attribute, which uses ASCII case-insensitive keywords — `on`, `off`,
+ * `Off` all mean "off" to the browser.
+ *
+ * The `Off` spelling is load-bearing. @codemirror/view reads the attribute
+ * with an exact string comparison and actively rewrites the platform's
+ * insert-period-on-double-space (macOS and Android) into a plain double
+ * space when it sees exactly `"off"`:
+ *
+ *     (browser.mac || browser.android) && change.from == change.to &&
+ *     /^\. ?$/.test(...) && view.contentDOM.getAttribute("autocorrect") == "off"
+ *
+ * So on those platforms emitting the exact keyword `off` silently destroys
+ * the period the user asked for. Emitting the case-insensitively-equivalent
+ * `Off` keeps correction disabled for the browser while the exact match
+ * fails, and the period survives.
+ *
+ * Windows and Linux keep the literal `off`: CodeMirror has no revert path
+ * there, and staying on the standard spelling limits exposure if a browser
+ * ever started matching the keyword case-sensitively.
+ */
+
+export type ComposerAutoCorrect = 'on' | 'off' | 'Off';
+
+/**
+ * The platform signals @codemirror/view's own `browser` flags read. The
+ * detection below deliberately mirrors them, so the `Off` workaround turns
+ * on exactly where CodeMirror's revert path turns on.
+ */
+interface CodeMirrorPlatformSignals {
+    userAgent: string;
+    vendor: string;
+    platform: string;
+    maxTouchPoints: number;
+}
+
+/**
+ * Whether CodeMirror's insert-period-on-double-space revert path is active
+ * on this platform. Mirrors `browser.mac || browser.android` from
+ * @codemirror/view (see the pinned-guard test).
+ */
+function codeMirrorRevertsPeriod(nav: CodeMirrorPlatformSignals): boolean {
+    // `safari` in CodeMirror: `!ie && /Apple Computer/.test(nav.vendor)`.
+    const safari = /Apple Computer/.test(nav.vendor);
+    // `ios` in CodeMirror: `safari && (/Mobile\/\w+/.test(nav.userAgent) || nav.maxTouchPoints > 2)`.
+    const ios = safari && (/Mobile\/\w+/.test(nav.userAgent) || nav.maxTouchPoints > 2);
+    // `mac` in CodeMirror: `ios || /Mac/.test(nav.platform)`.
+    const mac = ios || /Mac/.test(nav.platform);
+    // `android` in CodeMirror: `/Android\b/.test(nav.userAgent)`.
+    const android = /Android\b/.test(nav.userAgent);
+    return mac || android;
+}
+
+/**
+ * The autocorrect keyword for the composer content element.
+ *
+ * `isMobile` keeps the existing mobile policy (`on`). Desktop stays `off`
+ * for the browser everywhere, spelled `Off` on macOS/iOS/iPadOS and Android
+ * so CodeMirror does not undo the platform's period-on-double-space.
+ */
+export function composerAutoCorrect(options: {
+    isMobile: boolean;
+    navigator?: Pick<Navigator, 'userAgent' | 'vendor' | 'platform' | 'maxTouchPoints'>;
+}): ComposerAutoCorrect {
+    if (options.isMobile) {
+        return 'on';
+    }
+    const nav = options.navigator ?? globalThis.navigator;
+    return codeMirrorRevertsPeriod(nav) ? 'Off' : 'off';
+}


### PR DESCRIPTION
## Intent

Fixes #2504 (GitHub issue; no Linear counterpart exists for it).

Double-tapping space in the composer used to produce ". " on macOS/Android
via the platform's insert-period-on-double-space. The 1.17.0 CodeMirror
migration (2cfd69d1c, PR #2419) regressed it: `@codemirror/view` 6.39.13
actively rewrites the platform's ". " insertion into a plain double space
when the content element's `autocorrect` attribute is exactly `"off"` —
and the composer sets exactly `"off"` on desktop.

This change keeps desktop word correction off everywhere (the existing
policy, unchanged for the browser) while spelling the attribute `Off` on
the platforms where CodeMirror's revert path is live. The HTML `autocorrect`
attribute matches its keywords ASCII case-insensitively, so browsers still
treat `Off` as off — but CodeMirror's exact `== "off"` comparison fails,
and the period survives.

Behavior change: on macOS desktop web (and iOS/iPadOS/Android via the same
revert path), double-tapping space in the composer again inserts ". " as the
platform intends. Windows/Linux are deliberately unchanged (CodeMirror has no
revert path there).

Note for maintainers: PR #2510 by another contributor targets the same
issue with the same mechanism (verified independently here against the
installed `@codemirror/view@6.39.13` bundle, which contains the exact-match
guard). This PR is an independent implementation with a less brittle
pinned-guard test (whitespace-tolerant regexes against the installed bundle
resolved through the package's own node_modules, instead of pinning
minified platform-flag expressions) and keeps the `autoCorrect` prop
contract change confined to the composer's own modules.

## Non-goals

- No custom double-space-to-period engine: the feature is and stays the
  platform's, this only stops CodeMirror from undoing it.
- No spellcheck policy change: `spellcheck` remains tied to the existing
  "Enable spellcheck in text inputs" setting.
- No change to non-composer inputs (CommitInput, textareas, etc.).
- No change on Windows/Linux desktop (nothing to fix there — CodeMirror
  never reverts on those platforms).

## Affected surfaces

Shared `ComposerEditor` used by web, Electron, VS Code, hosted mobile and
Capacitor mobile surfaces (packages/ui only). The `autoCorrect` prop changes
from `boolean` to the `ComposerAutoCorrect` keyword union; only `ChatInput`
passes it. No persisted data, API route, or external contract changes.

Mobile keeps the existing `on` policy; iOS/iPadOS desktop-web users get
`Off` (revert path is `browser.mac`, which includes iOS in CodeMirror's
flags), which also restores their period-on-double-space.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Composer editor input behavior + component prop type change | Platform policy isolated in one pure helper (`editor/autocorrect.ts`) with focused tests; prop type change confined to the composer's own modules; no drive-by refactors |
| Composer `DOCUMENTATION.md` (nearest module doc, read before editing) | Owns editor input behavior and invariants | Records the HTML-case-insensitive-vs-CodeMirror-exact-match invariant and why `Off` must not be "normalized" back to `off` |
| Root `AGENTS.md` | Always-on repo rules | No new dependencies, no secrets, minimal diff, owning docs updated |
| Skill `performance-engineering`, `theme-system` | Checked | Not applicable: no render/event hot path or styling change (attribute string only) |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/composer/editor/__tests__/autocorrect.test.ts` | 9/9 pass (exit 0). Covers macOS, iPhone, iPadOS touch detection, Android, Windows, Linux, spoofed macOS UA on Linux, mobile `on` policy, and the pinned CodeMirror guard |
| `bun test packages/ui/src/components/chat/composer` (full suite) | 286 tests across 16 files, exit 0 |
| `bun run type-check:ui` | Exit 0 |
| `bun run lint:ui` | Exit 0 |
| `bun run dead-code` (new file added) | No findings for the new file/exports (report non-blocking; pre-existing 258 unused-export baseline unchanged) |

Not verified: real typing on macOS, iOS, or Android hardware/simulator —
this environment is Linux; headless Chromium cannot produce the OS-level
period substitution, so the fix is validated at the code level (the exact
guard in the installed `@codemirror/view@6.39.13` dist is asserted by the
pinned-guard test) and by the HTML spec's case-insensitive keyword
semantics.

## Visual evidence

No screenshots possible: the change affects native text substitution while
typing, not layout, color, or styling. The right evidence is a short screen
recording of double-tapping space in the composer on macOS (or iOS/Android)
showing the period surviving; that recording could not be made in this
environment. Expected rendering: identical UI; typing "hello" + double
space yields "hello. " instead of "hello  " on affected platforms.

## Risks and failure behavior

- The pinned-guard test reads the installed `@codemirror/view` dist bundle.
  A future dependency upgrade that keeps the exact-match guard passes; one
  that changes the guard (case-insensitive match, different platform flags,
  removed revert path) fails the test first — that failure is a signal to
  re-read the upstream guard, not a regression. The regexes are
  whitespace-tolerant so minifier reformatting does not false-fail.
- The workaround depends on browsers treating `autocorrect` keywords as
  ASCII case-insensitive (HTML spec). If a browser became case-sensitive,
  `Off` would fall back to the attribute default (`on`) on macOS/Android
  only — a contained, worst-case behavior change that the pinned test and
  this doc surface.
- Rollback: pure attribute string change; reverting the commit restores the
  previous behavior exactly. No state, cache, or persistence involved.
