### PR TITLE
fix(composer): restore Shift+Enter newline on iOS

### DIFF
--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -131,6 +131,16 @@ function insertedTextOf(transaction: { changes: { iterChanges: (fn: (fromA: numb
 }
 
 /**
+ * True for keydown events CodeMirror re-dispatches after deferring the real
+ * one (iOS Enter/Backspace/Delete, Chrome Android Enter): `dispatchKey`
+ * stamps the replacement event with a `synthetic` expando. These events are
+ * built from the key name alone, so they carry no modifier keys.
+ */
+function isDeferredSyntheticEvent(event: KeyboardEvent): boolean {
+    return Boolean((event as unknown as { synthetic?: boolean }).synthetic);
+}
+
+/**
  * Compartments are configuration keys, not per-view state, so one set can serve
  * every editor. They live at module scope because a kept-alive view outlives
  * the component that created it: per-instance compartments would be unknown to
@@ -159,6 +169,14 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
 
         const hostRef = React.useRef<HTMLDivElement | null>(null);
         const viewRef = React.useRef<EditorView | null>(null);
+
+        // The real keydown's shift state for the LAST Enter that reached the
+        // editor. CodeMirror defers Enter on iOS (and Chrome Android) and
+        // re-dispatches it as a synthetic keydown built from the key name
+        // alone, dropping every modifier (see `trackRealEnterShift` and the
+        // `interceptKeys` handler below); this ref is what lets the deferred
+        // event still tell Shift+Enter from Enter.
+        const lastRealEnterShiftRef = React.useRef(false);
 
         // Callbacks reach the CodeMirror extensions through a ref: the view is
         // built once and must not be torn down when a handler identity changes,
@@ -200,7 +218,15 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
             }
 
             const interceptKeys: KeyBinding[] = [{
-                any: (_view, event) => handlersRef.current.onKeyDown?.(event) ?? false,
+                any: (_view, event) => {
+                    // A deferred Enter lost its modifiers in the re-dispatch;
+                    // give the caller's policy (Enter vs Shift+Enter) back the
+                    // shift state it saw on the real keydown.
+                    if (event.key === 'Enter' && isDeferredSyntheticEvent(event) && lastRealEnterShiftRef.current) {
+                        Object.defineProperty(event, 'shiftKey', { value: true });
+                    }
+                    return handlersRef.current.onKeyDown?.(event) ?? false;
+                },
             }];
 
             const view = new EditorView({
@@ -275,6 +301,25 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
 
             viewRef.current = view;
             if (store) store.view = view;
+
+            // CodeMirror defers Enter on iOS (and Chrome Android): the real
+            // keydown is captured without running the keymaps, the browser's
+            // native newline goes through, and the keymaps then run against a
+            // synthetic keydown `dispatchKey` builds from the key name alone —
+            // which has NO modifiers. Recording the real shift state here (a
+            // plain listener, registered after CodeMirror's own, so it runs
+            // after the deferral decision but before the deferred dispatch)
+            // lets the deferred Enter be re-presented with Shift+Enter intact
+            // instead of arriving as a plain Enter that "sends" where Enter
+            // sends. Without it, Shift+Enter on iOS/Android submits the
+            // message instead of inserting a newline. The listener lives on
+            // the kept-alive view's contentDOM, so it stays across mounts and
+            // keeps feeding the same ref the `interceptKeys` closure reads.
+            const trackRealEnterShift = (event: KeyboardEvent) => {
+                if (event.key !== 'Enter' || isDeferredSyntheticEvent(event)) return;
+                lastRealEnterShiftRef.current = event.shiftKey;
+            };
+            view.contentDOM.addEventListener('keydown', trackRealEnterShift);
 
             return () => {
                 viewRef.current = null;


### PR DESCRIPTION
## Intent

Fixes #2558 (GitHub-only issue; no Linear counterpart exists for it).

On iOS Safari (web/PWA), Shift+Enter in the chat composer submits the message instead of inserting a newline. This worked on 1.16.3 and regressed in 1.17.0/1.17.1 — the release range that shipped the CodeMirror composer migration (#2419).

Root cause: CodeMirror defers Enter on iOS (and Chrome Android): the real keydown never runs the composer's keymaps; the browser's native newline goes through, and the keymaps then run against a synthetic keydown that `dispatchKey` builds from the key name alone — carrying **no modifier keys**. The composer's `handleKeyDown` therefore saw the deferred Shift+Enter as a plain Enter (`key === 'Enter'`, `shiftKey === false`), and on devices where the desktop layout applies (`isMobile === false` — e.g. iPad Safari/PWA above 768px), the Enter branch `(!isMobile || e.ctrlKey || e.metaKey)` fired and submitted the message. On a textarea (1.16.3) the not-prevented Shift+Enter produced a native newline, so the loss never mattered.

Fix: record the real Enter keydown's shift state on the CodeMirror view's contentDOM (registered after CodeMirror's own listener, so it runs after the deferral decision but before the deferred dispatch) and restore `shiftKey` onto the synthetic event before the caller's `onKeyDown` policy runs. Shift+Enter now reaches the same `insertNewlineAndIndent` path plain Enter already used on iOS — a single newline. Plain Enter behavior is unchanged on every runtime: it still takes the identical deferred path it took before.

## Non-goals

- No change to what plain Enter does on any runtime (iPhone: newline; desktop-layout iPad: send; desktop: send). The reporter's regression is specifically Shift+Enter.
- No change to Backspace/Delete deferral, IME composition handling, or the `QuestionCard` textarea (a plain `<textarea>` — not CodeMirror — so its Shift+Enter already yields a native newline on iOS).

## Affected surfaces

- `packages/ui` — `components/chat/composer/editor/ComposerEditor.tsx` (the CodeMirror wrapper). The only consumer is `ChatInput.tsx`, which keeps its send policy untouched: it just sees `event.shiftKey === true` again for the deferred Shift+Enter.
- Runtimes: mobile web/PWA (Safari iOS — the reported surface; also Chrome Android, which uses the same `dispatchKey` deferral for Enter), Capacitor iOS/Android shells, desktop web, VS Code, Electron. The change is additive for every runtime: the ref is only consulted for CodeMirror `synthetic` keydown events (`keydown` events the library itself stamps), and `shiftKey` is only patched when the recorded real Enter carried Shift. Desktop never produces synthetic Enters, so its path is byte-for-byte the previous one.
- No persisted data, no exports, no new dependencies.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md — keep bridges thin, policy in owning modules | `ChatInput.tsx` owns the Enter/send policy; `ComposerEditor` owns CodeMirror internals | The CodeMirror synthetic-event quirk is contained in `ComposerEditor`; the caller's `onKeyDown` contract is unchanged |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | Defines module ownership ("`ChatInput.tsx` is the orchestrator… should not grow logic that belongs to [the modules]") and test limits ("keyboard behavior… not covered by tests, verified by hand") | Fix lives in `editor/` (the CodeMirror wrapper layer); no unit test was added because the package has no DOM test environment and this path is explicitly hand-verified per the docs |
| `openchamber-change-discipline` skill | Any OpenChamber source change | Smallest complete change: one internal helper + a listener + a shift restore in the existing `interceptKeys` binding; no refactors, no new deps, no export changes |
| `theme-system` skill (loaded per task) | Task required loading it | No UI/styling change; no theme tokens involved |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (packages/ui) | Passed — `tsc --noEmit` clean |
| `bun run lint:ui` (packages/ui) | Passed — eslint clean |
| `bun test packages/ui/src/components/chat/composer/` | 277 pass, 0 fail (15 files) |
| `bun run dead-code` | Not run — no files/exports/entrypoints added, deleted, or renamed (one internal function added) |

Not verified (impossible in this environment): actual iOS Safari/iPad hardware-keyboard behavior. The composer documentation states keyboard behavior is verified by hand, not by tests. The mechanism was traced statically through the installed `@codemirror/view` 6.10.2 source: `InputState.keydown` defers iOS Enter (`PendingKeys`/`flushIOSKey`) and Chrome Android Enter (`delayAndroidKey`), both re-dispatching through `dispatchKey`, which builds `new KeyboardEvent("keydown", { key, code, keyCode, which })` with no modifier keys and stamps `synthetic = true`; `buildKeymap` folds the `any` binding into the `Enter` binding's run chain, so the deferred event reaches `onKeyDown` with `shiftKey === false`.

Expected behavior after the fix, to be confirmed on device: iOS Safari (iPhone and iPad/PWA) — Shift+Enter inserts a newline in the composer without sending; plain Enter behaves exactly as before (newline on iPhone, send on desktop-layout iPad); hardware-keyboard Enter follows the same paths.

## Visual evidence

No screenshots/recordings: this environment has no iOS simulator or browser, and the composer documentation notes keyboard behavior must be hand-verified on hardware. The change has no rendering effect — it only alters which key-handling branch a keydown takes.

## Risks and failure behavior

- **Deferred-Enter pairing**: each synthetic Enter is preceded by its own real Enter keydown (the pending state is set only by a real event and cleared by the flush), so the recorded shift state always belongs to the matching press. A stale ref cannot be consulted by a synthetic event that has no corresponding real one.
- **Kept-alive views** (`viewStore`): the recording listener lives on the view's `contentDOM` and the `interceptKeys` closure was created with the same ref, so both survive remounts and stay in sync.
- **CodeMirror version drift**: the fix depends on two documented internals — the `synthetic` expando on deferred events and the modifier loss in `dispatchKey`. If a future CodeMirror version preserves modifiers, the recorded state and the event agree and behavior is unchanged (the patch only applies when the synthetic event is missing the shift it really had).
- **Failure behavior**: the deferred Enter follows the identical pre-existing path (native newline + keymap run); the fix only changes which branch `onKeyDown` takes for Shift+Enter. No cleanup, rollback, or data concerns — the composer state machine, submit assembly, and message queue are untouched.
