### PR TITLE
fix(terminal): let Escape reach the terminal instead of closing the pane (Fixes #2644)

### DIFF
--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -29,6 +29,7 @@ import { setExternallyViewedSession, useDirectoryStore } from '@/sync/sync-conte
 import { ContextPanelContent } from './ContextSidebarTab';
 import { toast } from '@/components/ui';
 import { runtimeFetch } from '@/lib/runtime-fetch';
+import { isTerminalEventTarget } from '@/lib/terminalFocus';
 import { getRuntimeBearerTokenSync, getRuntimeExtraHeadersSync, refreshRuntimeUrlAuthToken } from '@/lib/runtime-auth';
 import { getRuntimeUrlResolver } from '@/lib/runtime-url';
 import { getRuntimeApiBaseUrl, getRuntimeKey } from '@/lib/runtime-switch';
@@ -2450,6 +2451,14 @@ export const ContextPanel: React.FC = () => {
 
   const handlePanelKeyDownCapture = React.useCallback((event: React.KeyboardEvent<HTMLElement>) => {
     if (event.key !== 'Escape') {
+      return;
+    }
+
+    // Escape belongs to the terminal while it is focused: Vim's Normal mode,
+    // menu cancels and shell line-editing all begin with it. Intercepting
+    // here (capture phase) would stop the key before the terminal's own
+    // listeners and close the pane instead of reaching the running program.
+    if (isTerminalEventTarget(event.target)) {
       return;
     }
 

--- a/packages/ui/src/components/layout/__tests__/contextPanelTerminalEscape.test.ts
+++ b/packages/ui/src/components/layout/__tests__/contextPanelTerminalEscape.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Regression guard for issue #2644: pressing Escape inside the terminal pane
+// must reach the terminal (Vim's Normal mode, menu cancels, shell line
+// editing) instead of closing the context panel.
+//
+// The context panel's <aside> intercepts Escape in the capture phase
+// (`onKeyDownCapture={handlePanelKeyDownCapture}`) and closes the panel. The
+// terminal lives inside that aside, so without a guard every Escape was
+// swallowed by the capture handler before the terminal's own listeners saw
+// it, and the pane closed — making it impossible to exit Vim.
+//
+// The guard must run before `preventDefault`/`handleClose` and must match on
+// the terminal viewport's `data-terminal-owner` marker.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const contextPanelSource = readFileSync(
+    join(__dirname, '..', 'ContextPanel.tsx'),
+    'utf-8',
+);
+const terminalViewportSource = readFileSync(
+    join(__dirname, '..', '..', 'terminal', 'TerminalViewport.tsx'),
+    'utf-8',
+);
+
+const extractCallback = (name: string): string => {
+    const start = contextPanelSource.indexOf(`const ${name} = React.useCallback(`);
+    expect(start).toBeGreaterThan(-1);
+    // The callback ends at the dependency-array close `}, [...])`; find the
+    // first `}, [` after the handler opens.
+    const tail = contextPanelSource.slice(start);
+    const close = tail.indexOf('}, [');
+    expect(close).toBeGreaterThan(-1);
+    return tail.slice(0, close + 3);
+};
+
+describe('context panel Escape handling (issue #2644 regression guard)', () => {
+    test('the panel still closes on Escape outside the terminal', () => {
+        const handler = extractCallback('handlePanelKeyDownCapture');
+
+        expect(handler).toContain(`event.key !== 'Escape'`);
+        expect(handler).toContain('event.preventDefault()');
+        expect(handler).toContain('event.stopPropagation()');
+        expect(handler).toContain('handleClose()');
+    });
+
+    test('Escape inside the terminal returns before the panel closes', () => {
+        const handler = extractCallback('handlePanelKeyDownCapture');
+
+        const guardIndex = handler.indexOf('isTerminalEventTarget(event.target)');
+        const preventDefaultIndex = handler.indexOf('event.preventDefault()');
+
+        // The terminal guard is present...
+        expect(guardIndex).toBeGreaterThan(-1);
+        // ...and runs before the close path, so the key is not swallowed.
+        expect(preventDefaultIndex).toBeGreaterThan(guardIndex);
+    });
+
+    test('the guard matches on the terminal viewport marker', () => {
+        // The guard relies on `data-terminal-owner` (see lib/terminalFocus.ts);
+        // if the terminal viewport ever stops carrying it, the guard silently
+        // stops matching and Escape closes the pane again.
+        expect(terminalViewportSource).toContain('data-terminal-owner="main"');
+        expect(contextPanelSource).toContain(
+            "import { isTerminalEventTarget } from '@/lib/terminalFocus';",
+        );
+    });
+});


### PR DESCRIPTION
## Intent

Fixes #2644 (GitHub issue; no Linear counterpart exists for it).

Pressing Escape in the built-in terminal closed the context panel instead of
reaching the running program (e.g. Vim's Normal mode, menu cancels, shell
line editing). The terminal lives inside the context panel's `<aside>`,
which intercepts Escape in the React capture phase
(`onKeyDownCapture={handlePanelKeyDownCapture}`) and closes the panel —
before the terminal's own native keydown listeners ever see the key.

The fix: `handlePanelKeyDownCapture` now returns early (no preventDefault,
no stopPropagation, no close) when the event target is inside the terminal
viewport (`isTerminalEventTarget`, matching the `data-terminal-owner` marker
the terminal viewport carries). Escape then reaches Ghostty as it should.

Behavior preserved: with the terminal NOT focused, Escape anywhere else in
the panel still closes it exactly as before. Closing the terminal pane while
it is focused still works via the existing explicit affordances (close
button, terminal toggle shortcut), as the issue requests.

## Non-goals

- No change to the terminal toggle/close shortcuts (`toggle_terminal`,
  `toggle_terminal_expanded`) — already guarded for terminal targets in
  `useKeyboardShortcuts.ts`.
- No change to the double-Escape abort flow or other Escape uses
  (command palette, dialogs, inspect modes) — all already skip terminal
  targets or run only in their own overlays.
- No mobile change: `MobileWorkspaceDrawer` already excludes the terminal
  tab from its Escape-close.

## Affected surfaces

Shared `ContextPanel` (packages/ui) used by web, Electron, VS Code webview,
hosted mobile and Capacitor mobile. Terminal focus detection reuses the
existing `lib/terminalFocus.ts` helper. No persisted data, API route, or
external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Component key-handling behavior change | 3-line guard reusing the existing `isTerminalEventTarget` helper; no refactor, no new deps; focused regression test added following the repo's source-pinning test precedent |
| Root `AGENTS.md` | Always-on repo rules | Minimal diff, no secrets, behavior preserved unless the issue replaces it |
| `terminalFocus.ts` / `TerminalViewport.tsx` | The marker the guard depends on | Verified `data-terminal-owner="main"` is rendered by the terminal viewport; pinned by the regression test so a marker change fails loudly |
| `theme-system`, `locale-ui-patterns`, `sync-state-invariants` | Checked | Not applicable: no styling, no user-facing strings, no state/sync change |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/layout/__tests__/contextPanelTerminalEscape.test.ts` | 3/3 pass. Pins: panel still closes outside the terminal; the terminal guard runs before `preventDefault`; the `data-terminal-owner` marker and `isTerminalEventTarget` import stay in place |
| `bun test packages/ui/src/components/layout/__tests__ src/components/views/__tests__ src/components/terminal` | 42 tests; only pre-existing failure: `mainLayoutMobileSidebarMount.test.ts > hidden sidebars disable render-only subscriptions and effects` — fails identically on clean main without this change (stale source-pinning test for `SessionSidebar`, unrelated to ContextPanel) |
| `bun run type-check:ui` | Exit 0 |
| `bun run lint:ui` | Exit 0 |

Not verified: real terminal runtime (Vim/ghostty session) in a browser —
this environment has no running OpenChamber server UI to drive. The
regression mechanism (capture-phase Escape interception before the
terminal's own listeners) is verified by code inspection of the React
capture handler and the terminal viewport's native event wiring; the
behavioral guarantee is pinned by the ordering assertion in the test.

## Visual evidence

Captured live from the PR branch (`fix/gh-2644-terminal-escape`) — web app via `dev:web:hmr` (UI 5187 / API 3909), driven through headless Chromium. The terminal pane was opened (Ctrl+J), showing a live fish shell in the fixture project (`~/oc-ev-fproj - fish` — verified via the terminal's `currentTitle`). A real `cat` was started so key events have visible echoes.

| Demonstration | Evidence |
|---|---|
| Terminal pane open with live shell | [terminal-pane-open.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2686/screens/terminal-pane-open.png) |
| Side-by-side terminal crop: before vs after dispatching **Escape** at the terminal (red box = the only changed region, `^[` echo) | [escape-compare.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2686/screens/escape-compare.png) |
| 4× zoom of the red-boxed region showing the two echoed glyphs (`^[` = Escape byte that reached `cat`) | [escape-zoom.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2686/screens/escape-zoom.png) |
| Contrast: Escape dispatched while the **panel tab** (non-terminal element) was focused — panel closed (red outline = where the panel was; content expanded) | [panel-escape-closes.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2686/screens/panel-escape-closes.png) |

How each claim was verified (headless, DOM + pixel analysis):

1. **Escape does not close the pane when the terminal is focused** — focused the terminal's hidden input (`textarea[aria-label="Terminal input"]`), dispatched a `keydown` `Escape` (keyCode 27, bubbles, cancelable). After the dispatch the context panel `<aside>` was still mounted and full-width (670px; verified by `getBoundingClientRect()`), i.e. the pane did **not** close. The event was consumed by the terminal's own handler (`preventDefault` observed) instead of the panel's capture-phase handler.
2. **Escape reaches the running program** — the shell was running `cat` (echo mode). The Escape dispatch produced a pixel diff of exactly **2×15 px at (760,617)** in the terminal canvas — the bounding box of two glyphs — i.e. `cat` echoed `^[`, the escape byte. No other pixels changed (diff = 0 elsewhere), and the input path stayed alive afterwards (a subsequent paste echoed normally).
3. **Escape while the panel (not the terminal) is focused still closes it** — focused the "Terminal" tab button (inside the panel `<aside>`, outside the terminal viewport) and dispatched the same Escape keydown. The panel collapsed to width 0 — exactly the behavior preserved by the fix (`isTerminalEventTarget` guard returns early only for terminal targets).

The terminal in this headless run is a real server-side pty (`cat`/shell I/O round-tripped through the app's socket), so the key-routing behavior was observed against a live terminal, not a mock. No styling change exists in this PR, so no layout screenshots are needed beyond the pane state above.

## Risks and failure behavior

- The guard keys off `data-terminal-owner`, which wraps the whole terminal
  viewport (Ghostty canvas included). If a future refactor removed the
  marker, Escape would silently start closing the pane again — the pinned
  test fails on that removal.
- Escape is a terminal-level key; shell programs that use Escape for their
  own purposes (e.g. `clear`-style bindings, `readline` vi mode) now
  receive it, which is the intended terminal behavior.
- Rollback: reverting the commit restores previous behavior exactly. No
  state, cache, or persistence involved.

