### PR TITLE
fix(usage): refresh stale mobile quota data when the metadata panel opens

### DIFF
--- a/packages/ui/src/apps/MobileSessionMetadata.tsx
+++ b/packages/ui/src/apps/MobileSessionMetadata.tsx
@@ -6,7 +6,7 @@ import { ProviderLogo } from '@/components/ui/ProviderLogo';
 import { preloadProviderLogos } from '@/hooks/useProviderLogo';
 import { useTabletLayout } from '@/lib/device';
 import { useI18n } from '@/lib/i18n';
-import { clampPercent, formatQuotaResetLabel, formatQuotaValueLabel, formatWindowLabel, QUOTA_PROVIDERS, resolveUsageTone } from '@/lib/quota';
+import { clampPercent, formatQuotaResetLabel, formatQuotaValueLabel, formatWindowLabel, QUOTA_PROVIDERS, QUOTA_RESULTS_STALE_AFTER_MS, resolveUsageTone, shouldRefreshQuotaResults } from '@/lib/quota';
 import { getDisplayModelName } from '@/lib/quota/model-families';
 import { cn } from '@/lib/utils';
 import { useConfigStore } from '@/stores/useConfigStore';
@@ -417,11 +417,14 @@ export const MobileSessionMetadataButton = React.memo(function MobileSessionMeta
   }, [dropdownProviderIds]);
 
   React.useEffect(() => {
+    // Opening the panel refreshes stale quota data: results that already exist
+    // in the store (e.g. with auto-refresh disabled) must not stay frozen.
+    // Current values stay visible while the fetch runs — isLoading only adds
+    // the inline spinner, and per-provider results are replaced as they
+    // arrive. The stale window mirrors the default auto-refresh cadence, so
+    // an enabled auto-refresh never triggers a redundant fetch here.
     if (!open || isQuotaLoading) return;
-    const missingEnabledProvider = dropdownProviderIds.some((providerId) => (
-      !quotaResults.some((result) => result.providerId === providerId)
-    ));
-    if (!missingEnabledProvider) return;
+    if (!shouldRefreshQuotaResults(dropdownProviderIds, quotaResults, Date.now(), QUOTA_RESULTS_STALE_AFTER_MS)) return;
     void fetchAllQuotas();
   }, [dropdownProviderIds, fetchAllQuotas, isQuotaLoading, open, quotaResults]);
 

--- a/packages/ui/src/lib/quota/index.ts
+++ b/packages/ui/src/lib/quota/index.ts
@@ -9,5 +9,7 @@ export {
   getPaceStatusColor,
   formatRemainingTime,
   calculateExpectedUsagePercent,
+  QUOTA_RESULTS_STALE_AFTER_MS,
+  shouldRefreshQuotaResults,
 } from './utils';
 export type { PaceInfo } from './utils';

--- a/packages/ui/src/lib/quota/utils.test.ts
+++ b/packages/ui/src/lib/quota/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { clampPercent, formatPercent } from './utils';
+import { clampPercent, formatPercent, QUOTA_RESULTS_STALE_AFTER_MS, shouldRefreshQuotaResults } from './utils';
 
 describe('quota utils', () => {
   test('treats non-finite percentages as missing', () => {
@@ -9,5 +9,29 @@ describe('quota utils', () => {
 
     expect(formatPercent(Infinity)).toBe('-');
     expect(formatPercent(-Infinity)).toBe('-');
+  });
+});
+
+describe('shouldRefreshQuotaResults', () => {
+  const now = 1_000_000;
+  const fresh = (providerId: string, ageMs = 0) => ({ providerId, fetchedAt: now - ageMs });
+
+  test('refreshes when any enabled provider has no result at all', () => {
+    expect(shouldRefreshQuotaResults(['a', 'b'], [fresh('a')], now, 60_000)).toBe(true);
+    expect(shouldRefreshQuotaResults(['a', 'b'], [], now, 60_000)).toBe(true);
+  });
+
+  test('refreshes when an existing result is older than the stale window', () => {
+    expect(shouldRefreshQuotaResults(['a'], [fresh('a', 61_000)], now, 60_000)).toBe(true);
+    expect(shouldRefreshQuotaResults(['a'], [fresh('a', 60_000)], now, 60_000)).toBe(true);
+  });
+
+  test('skips the refresh when every enabled provider is fresh enough', () => {
+    expect(shouldRefreshQuotaResults(['a', 'b'], [fresh('a', 1_000), fresh('b', 59_000)], now, 60_000)).toBe(false);
+    expect(shouldRefreshQuotaResults([], [], now, 60_000)).toBe(false);
+  });
+
+  test('the default stale window matches the default auto-refresh cadence', () => {
+    expect(QUOTA_RESULTS_STALE_AFTER_MS).toBe(60_000);
   });
 });

--- a/packages/ui/src/lib/quota/utils.ts
+++ b/packages/ui/src/lib/quota/utils.ts
@@ -295,3 +295,27 @@ export const formatRemainingTime = (seconds: number): string => {
 export const calculateExpectedUsagePercent = (elapsedRatio: number): number => {
   return Math.min(100, Math.max(0, elapsedRatio * 100));
 };
+
+/** How old stored quota data may be before an opening usage surface refreshes
+    it. Matches the default auto-refresh cadence, so opening a panel never
+    re-fetches data an enabled auto-refresh already keeps fresh. */
+export const QUOTA_RESULTS_STALE_AFTER_MS = 60_000;
+
+/**
+ * True when the stored quota results need a refresh for the given providers:
+ * a provider is missing entirely or its last fetch is older than `staleMs`.
+ *
+ * Used when a usage surface opens, so results that already exist locally
+ * (e.g. with auto-refresh disabled) cannot stay frozen indefinitely while the
+ * panel keeps showing them until the refresh completes.
+ */
+export const shouldRefreshQuotaResults = (
+  providerIds: readonly string[],
+  results: readonly { providerId: string; fetchedAt: number }[],
+  nowMs: number,
+  staleMs: number,
+): boolean =>
+  providerIds.some((providerId) => {
+    const result = results.find((entry) => entry.providerId === providerId);
+    return !result || nowMs - result.fetchedAt >= staleMs;
+  });


### PR DESCRIPTION
## Intent

Fixes #2416

(No Linear issue exists for this GitHub-only issue.)

The mobile session metadata panel (usage ring → metadata overlay, `MobileSessionMetadata.tsx`) only fetched provider quotas when an enabled provider had **no** stored result at all. Once results existed locally — e.g. fetched once earlier, with auto-refresh disabled — every later panel open showed frozen reset windows and remaining percentages indefinitely.

This PR makes the open-triggered fetch staleness-aware: opening the panel now refreshes when any enabled provider's result is missing **or older than 60s** (`QUOTA_RESULTS_STALE_AFTER_MS`, the default auto-refresh cadence), while preserving the current values until the request completes (per-provider results are replaced as they arrive; `isLoading` only adds the inline spinner).

## Non-goals

- No new manual refresh button on the mobile panel (not requested; the open trigger covers the reported flow).
- No change to the desktop header's explicit refresh button or `useQuotaAutoRefresh` interval behavior.
- No change to the quota server routes or the fetch payload — the refresh reuses `fetchAllQuotas` / `runtimeFetch('/api/quota/...')`.
- No focus/visibility-triggered refresh: the panel is a modal overlay whose open transition is the user-intent signal the issue describes.

## Affected surfaces

- `packages/ui/src/apps/MobileSessionMetadata.tsx` — the quota fetch-on-open effect. Condition changed from "any enabled provider missing" to `shouldRefreshQuotaResults(...)` (missing **or stale**).
- `packages/ui/src/lib/quota/utils.ts` — new pure helpers `shouldRefreshQuotaResults(providerIds, results, nowMs, staleMs)` and `QUOTA_RESULTS_STALE_AFTER_MS` (60s), re-exported from `lib/quota/index.ts`.
- `packages/ui/src/lib/quota/utils.test.ts` — unit tests for the helper (missing provider, stale, fresh, empty inputs, default window value).
- Web/desktop/VS Code/Electron: unaffected — the mobile panel is the only consumer of the new open-trigger path; desktop keeps its explicit refresh + auto-refresh.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md runtime boundaries / minimal diffs | Mobile UI lives in `packages/ui` | 4 files in `packages/ui`; the component diff is one condition swap plus comment |
| `sync-state-invariants` skill | Refresh-on-open must not fight in-flight fetches or clear current state | `isQuotaLoading` guard prevents double-fetch with auto-refresh; `fetchAllQuotas` never clears `results`, and per-provider results are replaced only after each provider request succeeds (failure keeps the fallback error result with its own `fetchedAt`, so a failed provider never loops on open); missing ≠ empty — a missing provider still forces a fetch |
| `ui-api-decoupling` skill | Quota data is an OpenChamber route | The store keeps using `runtimeFetch('/api/quota/{providerId}')`; the change only decides *when* the existing `fetchAllQuotas` action runs — no new fetch path, no URL/auth handling added |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/lib/quota/` | 5 pass, 0 fail (11 expect calls; includes 4 new `shouldRefreshQuotaResults` tests) |
| `bun test packages/ui/src/apps/` | 22 pass, 0 fail (no regression in mobile app suites) |
| `bun run type-check:ui` | Pass (tsc --noEmit, exit 0) |
| `bun run lint:ui` | Pass (eslint, exit 0) |
| `bun run dead-code` | No findings for the changed files/exports (report shows only pre-existing unrelated items) |

Not verified: no mobile runtime/simulator available in this environment, so the panel-open refresh flow was not exercised interactively and no screenshots were captured. Validation is type-check, lint, and unit tests; the effect's runtime behavior (stale data → fetch on open) is covered by the helper tests plus code review of the effect wiring.

## Visual evidence

No screenshots possible: no mobile runtime is available in this environment, and the change is a fetch-timing change with no new UI. Expected behavior: with auto-refresh disabled, the first open fetches quotas (existing behavior, loading row while `results` is empty); after >60s, reopening the panel triggers a refresh while the previously shown values remain on screen with the small spinning refresh icon next to the mode label (existing `isLoading` affordance), then values update per provider as responses arrive. Within 60s of the last fetch, reopening shows the current values without a network request.

## Risks and failure behavior

- No stale-success masking: the guard is per-provider (`fetchedAt`), and a failed provider keeps its error result (`ok: false` + `status`) whose `fetchedAt` is stamped at failure time — so the panel shows the visible failure state and will refresh it on a later open once the window passes, without an immediate retry loop.
- No fetch storm: `isQuotaLoading` still gates concurrent refreshes (auto-refresh + open can overlap without doubling), and fresh data (<60s) skips the fetch; after a refresh completes, all enabled providers have fresh stamps so the effect settles without re-firing.
- Partial failure semantics unchanged: `fetchAllQuotas` updates `lastUpdated` after the batch and per-provider results land independently; the panel keeps rendering whatever each provider returned.
- Runtime switch: results from a previous runtime are keyed by provider only and are at least 60s old by the time a user switches and opens the panel, so the staleness guard refreshes them — no stale cross-runtime quotas survive an open.
