### PR TITLE
fix(ui): keep the selected model when switching agent modes

### DIFF
--- a/packages/ui/src/components/chat/ModelControls.tsx
+++ b/packages/ui/src/components/chat/ModelControls.tsx
@@ -641,7 +641,6 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
     ];
 
     const prevAgentNameRef = React.useRef<string | undefined>(undefined);
-    const explicitAgentSwitchRef = React.useRef<string | null>(null);
     const latestLoadedUserChoiceRestoreRef = React.useRef<string | null>(null);
 
     const currentSessionDirectory = currentSessionId ? getDirectoryForSession(currentSessionId) : undefined;
@@ -1032,9 +1031,6 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
                     prevAgentNameRef.current = currentAgentName;
 
                     if (currentAgentName && currentSessionId) {
-                        const shouldPreferAgentModel = explicitAgentSwitchRef.current === currentAgentName;
-                        explicitAgentSwitchRef.current = null;
-
                         await new Promise<void>((resolve) => {
                             const timer = setTimeout(resolve, 50);
                             abortController.signal.addEventListener('abort', () => {
@@ -1045,33 +1041,6 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
 
                         if (abortController.signal.aborted) {
                             return;
-                        }
-
-                        const selectedAgent = shouldPreferAgentModel
-                            ? agents.find((agent) => agent.name === currentAgentName)
-                            : undefined;
-                        if (selectedAgent?.model?.providerID && selectedAgent.model.modelID) {
-                            const result = tryApplyModelSelection(
-                                selectedAgent.model.providerID,
-                                selectedAgent.model.modelID,
-                                currentAgentName,
-                            );
-                            if (result === 'applied' || result === 'provider-missing') {
-                                if (result === 'applied') {
-                                    saveSessionModelSelection(
-                                        currentSessionId,
-                                        selectedAgent.model.providerID,
-                                        selectedAgent.model.modelID,
-                                    );
-                                    saveAgentModelForSession(
-                                        currentSessionId,
-                                        currentAgentName,
-                                        selectedAgent.model.providerID,
-                                        selectedAgent.model.modelID,
-                                    );
-                                }
-                                return;
-                            }
                         }
 
                         const persistedChoice = getAgentModelForSession(currentSessionId, currentAgentName);
@@ -1099,12 +1068,9 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
             abortController.abort();
         };
     }, [
-        agents,
         currentAgentName,
         currentSessionId,
         getAgentModelForSession,
-        saveAgentModelForSession,
-        saveSessionModelSelection,
         tryApplyModelSelection,
         contextHydrated,
     ]);
@@ -1185,7 +1151,6 @@ export const ModelControls: React.FC<ModelControlsProps> = ({
 
     const handleAgentChange = React.useCallback((agentName: string, options?: { closeModelSelector?: boolean }) => {
         try {
-            explicitAgentSwitchRef.current = agentName;
             setAgent(agentName);
             addRecentAgent(agentName);
             if (options?.closeModelSelector ?? true) {

--- a/packages/ui/src/stores/useConfigStore.test.ts
+++ b/packages/ui/src/stores/useConfigStore.test.ts
@@ -589,6 +589,30 @@ describe('useConfigStore provider persistence', () => {
     expect(state.currentModelId).toBe('model-a');
   });
 
+  test('[issue-2531] setAgent keeps the manual model when switching to an agent without an override', () => {
+    const sessionId = 'ses_2531_mode_switch';
+    useSessionUIStore.setState({ currentSessionId: sessionId });
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      providers: [provider('deepseek', 'deepseek-v4-pro'), provider('kimi', 'kimi-k3')],
+      agents: [testAgent('build'), testAgent('plan')],
+      settingsDefaultModel: 'deepseek/deepseek-v4-pro',
+      currentProviderId: 'kimi',
+      currentModelId: 'kimi-k3',
+      currentAgentName: 'build',
+      selectionSource: 'manual',
+      currentVariant: undefined,
+      directoryScoped: {},
+    });
+
+    useConfigStore.getState().setAgent('plan');
+
+    const state = useConfigStore.getState();
+    expect(state.currentAgentName).toBe('plan');
+    expect(state.currentProviderId).toBe('kimi');
+    expect(state.currentModelId).toBe('kimi-k3');
+  });
+
   test('loadAgents does not fetch OpenCode config directly', async () => {
     useConfigStore.setState({
       activeDirectoryKey: DIRECTORY,

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -2387,6 +2387,9 @@ export const useConfigStore = create<ConfigStore>()(
                         currentProviderId,
                         currentModelId,
                     } = get();
+                    // Captured before the first set below, which unconditionally
+                    // marks the selection as manual.
+                    const hadManualSelection = get().selectionSource === "manual";
 
                     set((state) => {
                         const directoryKey = state.activeDirectoryKey;
@@ -2508,8 +2511,7 @@ export const useConfigStore = create<ConfigStore>()(
                         // Prefer a session-level manual override for this agent over the
                         // agent's configured default. Re-applying setAgent after subtask
                         // completion / rematerialization must not clobber the override
-                        // (issue #2404). Explicit agent-picker switches still force the
-                        // agent default via ModelControls' shouldPreferAgentModel path.
+                        // (issue #2404).
                         if (currentSessionId) {
                             const existingAgentModel = useSelectionStore.getState().getAgentModelForSession(currentSessionId, agentName);
                             if (existingAgentModel && hasProviderModel(providers, existingAgentModel.providerId, existingAgentModel.modelId)) {
@@ -2536,6 +2538,14 @@ export const useConfigStore = create<ConfigStore>()(
                                 applyResolvedModelSelection(providerID, modelID, resolveVariantForModel(providerID, modelID, agent?.variant));
                                 return;
                             }
+                        }
+
+                        // The user has a live manual model selection and the target
+                        // agent configures no model of its own. Switching modes or
+                        // agents must not reset the selection to the settings default
+                        // (issue #2531) — mode switches are not model changes.
+                        if (hadManualSelection && currentProviderId && currentModelId) {
+                            return;
                         }
 
                         // If the agent has no preferred model, use settings default.


### PR DESCRIPTION
## Intent

Fixes #2531

Switching between Build and Plan modes (primary agent modes) reset the model selector back to the default model even though the user had manually chosen another model. The selected model is now retained across mode switches: `setAgent` keeps the live manual model selection when the target agent has no saved per-agent override and configures no model of its own, and the explicit agent-switch handler in ModelControls no longer force-applies the agent's default model over a saved per-agent override.

No Linear issue exists for this GitHub issue.

## Non-goals

- No change to per-agent model persistence semantics for agents that configure their own model: switching to a pinned agent still applies that agent's configured model (unchanged behavior, covered by the existing `[issue-2404] setAgent uses agent default when no session override exists` test).
- No change to startup / fresh-session defaulting (`applyDefaultModelAgentSelection`, `applyOpenCodeConfigDefaults` untouched).
- No change to the #2404 behavior: session-level manual overrides still win over the agent's configured default on `setAgent` re-application.
- No UI changes.

## Affected surfaces

- `packages/ui` (shared by web, desktop, VS Code, hosted mobile, Capacitor mobile):
  - `stores/useConfigStore.ts` (`setAgent`): captured `selectionSource` before the first `set` (which unconditionally marks the selection as manual), and added a guard between the agent-pin branch and the settings-default fallback: when the user has a live manual selection (`selectionSource === "manual"` before the call) with valid current provider/model, and the target agent has no saved override, the settings-default fallback is skipped so the current model is kept.
  - `components/chat/ModelControls.tsx` (`handleAgentSwitch` effect + `handleAgentChange`): removed `explicitAgentSwitchRef` and the `shouldPreferAgentModel` path that applied and persisted the agent's default model on every explicit agent-picker switch — this overwrote saved per-agent overrides (e.g. Build's manually chosen model was replaced by Build's default when switching back from Plan). The effect now only applies a persisted per-agent override for the new agent.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md change discipline | Minimal fix, preserve existing behavior unless the issue replaces it | The pin branch, override branch, startup cascade, and #2404 behaviors are untouched; only the settings-default fallback for manual selections and the explicit-switch clobber are changed. |
| `settings-ui-patterns` skill | Settings/selection behavior flows through `useConfigStore` | No settings UI or copy changed; the change is inside the selection cascade only. |
| `ui-api-decoupling` skill | Selection state is read/written through stores | No API/route/runtime changes; all reads/writes stay in `useConfigStore` + `useSelectionStore` as before. |
| Local code precedent | `useConfigStore.test.ts` covers `setAgent` cascade with `[issue-2404]` tests | New tests follow the exact setup pattern of the existing cascade tests. |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` | PASS (tsc --noEmit, no errors) |
| `bun run lint:ui` | PASS (eslint, no warnings) |
| `bun test src/stores/useConfigStore.test.ts` | 21 pass / 0 fail — includes the new `[issue-2531] setAgent keeps the manual model when switching to an agent without an override` test (verified it fails without the fix: reproduction run before the change showed 2 new failures) and all pre-existing `setAgent` tests (variant precedence, issue-2404 pin/override cases) |
| Full `bun test src/stores/` | 5 fail / 4 errors — identical pre-existing parallel-run flakiness on pristine `main` at the same commit; every failing file (e.g. `useGitStore.test.ts`, `useProjectsStore.test.ts`) passes in isolation on this worktree |
| `bun run dead-code` | Not required: no files added/deleted/renamed, no export changes |

Not verified: no live desktop run in this environment. The repro was verified at the store level (the exact cascade `setAgent` runs on mode switch); the ModelControls effect change is covered by type-check/lint and code inspection — the removed branch was the only consumer of `explicitAgentSwitchRef` and its behavior is now fully handled by the `setAgent` cascade.

## Visual evidence

No screenshots possible (no headed desktop runtime). Expected rendering: with default model DeepSeek V4 Pro, pick Kimi K3 in Build mode, switch to Plan mode — the model selector continues to show Kimi K3 instead of reverting to DeepSeek V4 Pro; switching back to Build still shows Kimi K3.

## Risks and failure behavior

- The guard requires `selectionSource === "manual"` captured before `setAgent`'s own first `set` (which unconditionally writes `"manual"`); reading it after would defeat the check. Captured before the first `set` in the same call.
- Fresh sessions (no manual selection, `selectionSource: "auto"`) still receive the settings-default / agent-pin cascade, preserving startup behavior; guarded by `currentProviderId && currentModelId` being falsy-empty at startup.
- Pinned agents keep applying their configured model on switch (pin branch precedes the guard), so deliberately configured agent defaults are not silently ignored.
- The removed ModelControls branch previously saved the agent default as the per-agent override; that write was redundant (the cascade re-derives it on every `setAgent`) and its removal is what stops per-agent memory from being overwritten.
- No persisted data format changes, no new dependencies, no runtime/platform differences.
