### PR TITLE
fix(ui): bound OpenCode read requests so half-open sockets cannot freeze bootstrap (#2470)

### DIFF
--- a/packages/ui/src/lib/opencode/client-timeout.test.ts
+++ b/packages/ui/src/lib/opencode/client-timeout.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for issue #2470: sessions stuck on "loading sessions"
+ * forever after the managed OpenCode connection goes half-open.
+ *
+ * The SDK client fetch wrapper must bound read requests so a socket that
+ * neither resolves nor rejects fails after `requestTimeoutMs`, releasing the
+ * directory bootstrap concurrency slot. Long-lived streams must be excluded:
+ * POST (prompt/shell/summarize/command) and the `/event` SSE stream.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+
+(mock as unknown as { restore?: () => void }).restore?.();
+
+type CapturedFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+const capturedConfigs: Array<{ fetch?: CapturedFetch }> = [];
+const sdkCreateMock = mock((config: { fetch?: CapturedFetch }) => {
+  capturedConfigs.push(config);
+  return {};
+});
+
+mock.module('@opencode-ai/sdk/v2', () => ({
+  createOpencodeClient: sdkCreateMock,
+}));
+
+mock.module('@/contexts/runtimeAPIRegistry', () => ({
+  getRegisteredRuntimeAPIs: mock(() => null),
+}));
+
+mock.module('@/lib/runtime-url', () => ({
+  getRuntimeUrlResolver: mock(() => ({
+    api: (path: string) => path,
+  })),
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeApiBaseUrl: mock(() => ''),
+  getRuntimeKey: mock(() => 'test-runtime'),
+}));
+
+mock.module('@/lib/runtime-fetch', () => ({
+  runtimeFetch: mock(async () => new Response('{}', {
+    headers: { 'Content-Type': 'application/json' },
+  })),
+}));
+
+mock.module('@/lib/startupTrace', () => ({
+  markStartupTrace: mock(() => undefined),
+}));
+
+const { createRuntimeOpencodeClient } = await import(`./client?timeout-test=${Date.now()}`);
+
+const neverSettles = (_input: string | URL | Request, init?: RequestInit) =>
+  new Promise<Response>((_resolve, reject) => {
+    // Mimic real fetch: an aborted signal rejects the pending request.
+    init?.signal?.addEventListener('abort', () => {
+      reject(new DOMException('Aborted', 'AbortError'));
+    }, { once: true });
+  });
+
+describe('createRuntimeOpencodeClient read timeout (#2470)', () => {
+  test('a GET whose socket never settles rejects with a normalized "request timed out" error', async () => {
+    capturedConfigs.length = 0;
+    const client = createRuntimeOpencodeClient({ baseUrl: '/api', requestTimeoutMs: 50 });
+    const fetchImpl = capturedConfigs[0]?.fetch;
+    expect(typeof fetchImpl).toBe('function');
+    expect(client).toBeDefined();
+
+    const { runtimeFetch } = await import('@/lib/runtime-fetch');
+    (runtimeFetch as unknown as { mockImplementation: (impl: unknown) => void }).mockImplementation(neverSettles);
+
+    const error = await fetchImpl!(new Request('http://127.0.0.1/api/session', { method: 'GET' })).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('request timed out');
+  });
+
+  test('POST requests (long-running prompt/shell/summarize) are NOT timed out', async () => {
+    capturedConfigs.length = 0;
+    createRuntimeOpencodeClient({ baseUrl: '/api', requestTimeoutMs: 30 });
+
+    const { runtimeFetch } = await import('@/lib/runtime-fetch');
+    (runtimeFetch as unknown as { mockImplementation: (impl: unknown) => void }).mockImplementation(neverSettles);
+
+    const fetchImpl = capturedConfigs[0]?.fetch as CapturedFetch;
+    const result = await Promise.race([
+      fetchImpl(new Request('http://127.0.0.1/api/session/ses_1/message', { method: 'POST' }))
+        .then(() => 'resolved'),
+      new Promise<string>((resolve) => setTimeout(() => resolve('timed-out'), 200)),
+    ]);
+    // The promise must still be pending after the timeout window: POST is excluded.
+    expect(result).toBe('timed-out');
+  });
+
+  test('the /event SSE stream is NOT timed out', async () => {
+    capturedConfigs.length = 0;
+    createRuntimeOpencodeClient({ baseUrl: '/api', requestTimeoutMs: 30 });
+
+    const { runtimeFetch } = await import('@/lib/runtime-fetch');
+    (runtimeFetch as unknown as { mockImplementation: (impl: unknown) => void }).mockImplementation(neverSettles);
+
+    const fetchImpl = capturedConfigs[0]?.fetch as CapturedFetch;
+    const result = await Promise.race([
+      fetchImpl(new Request('http://127.0.0.1/api/global/event', { method: 'GET' }))
+        .then(() => 'resolved'),
+      new Promise<string>((resolve) => setTimeout(() => resolve('timed-out'), 200)),
+    ]);
+    expect(result).toBe('timed-out');
+  });
+
+  test('a caller-provided abort signal still wins (no normalized timeout error)', async () => {
+    capturedConfigs.length = 0;
+    createRuntimeOpencodeClient({ baseUrl: '/api', requestTimeoutMs: 50 });
+
+    const { runtimeFetch } = await import('@/lib/runtime-fetch');
+    (runtimeFetch as unknown as { mockImplementation: (impl: unknown) => void }).mockImplementation(neverSettles);
+
+    const fetchImpl = capturedConfigs[0]?.fetch as CapturedFetch;
+    const controller = new AbortController();
+    const pending = fetchImpl(new Request('http://127.0.0.1/api/session', { method: 'GET' }), { signal: controller.signal })
+      .then(() => null, (e: unknown) => e);
+    controller.abort();
+    const error = await pending;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain('request timed out');
+  });
+});

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -183,10 +183,69 @@ const createTimeoutSignal = (timeoutMs: number): { signal: AbortSignal; cleanup:
   };
 };
 
-const createRuntimeOpencodeClient = (config: { baseUrl: string; directory?: string }): OpencodeClient => {
+// Half-open sockets (managed OpenCode process died, TCP connection lost
+// without a FIN/RST) make fetch promises hang forever: they neither resolve
+// nor reject. Directory bootstrap holds one of two concurrency slots for the
+// whole promise, so two hung directories freeze every other project on
+// "loading sessions" indefinitely (#2470). The SDK client therefore gets a
+// defensive request timeout for reads so a dead upstream fails, releases the
+// slot, and surfaces the retry button instead of an infinite spinner.
+//
+// The timeout only applies to reads:
+// - POST is excluded: `session.prompt`, `shell`, `summarize`, and `command`
+//   are long-running by design (minutes of model/tool work), so they must
+//   never be cut short.
+// - The `/event` SSE stream is excluded: it is long-lived by design. (It is
+//   also fetched through `createSseClient`, which bypasses this wrapper.)
+// - `fetch()` resolves at response headers, so large file reads are not
+//   affected; only the header wait is bounded.
+const OPENCODE_REQUEST_TIMEOUT_MS = 30_000;
+
+const isEventStreamUrl = (input: string | URL | Request): boolean => {
+  const url = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+  return url.includes("/event");
+};
+
+type RuntimeOpencodeClientConfig = {
+  baseUrl: string
+  directory?: string
+  /** Read-request timeout in ms. Overridable so tests can use a short value. */
+  requestTimeoutMs?: number
+}
+
+export const createRuntimeOpencodeClient = (config: RuntimeOpencodeClientConfig): OpencodeClient => {
+  const requestTimeoutMs = config.requestTimeoutMs ?? OPENCODE_REQUEST_TIMEOUT_MS;
   return createOpencodeClient({
     ...config,
-    fetch: runtimeFetch,
+    fetch: async (input: string | URL | Request, init?: RequestInit) => {
+      const method = String(init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+      if (isEventStreamUrl(input) || method === "POST") {
+        return runtimeFetch(input, init);
+      }
+
+      const timeout = createTimeoutSignal(requestTimeoutMs);
+      const callerSignal = init?.signal;
+      const supportsAny = typeof AbortSignal !== "undefined" && typeof (AbortSignal as { any?: unknown }).any === "function";
+      const signal = callerSignal && supportsAny
+        ? (AbortSignal as typeof AbortSignal & { any: (signals: AbortSignal[]) => AbortSignal }).any([callerSignal, timeout.signal])
+        : (callerSignal ?? timeout.signal);
+      try {
+        return await runtimeFetch(input, { ...init, signal });
+      } catch (error) {
+        // Normalize the timeout rejection so `retry` can recognize it as
+        // transient; a caller-initiated abort keeps its own error shape.
+        if (timeout.signal.aborted && !callerSignal?.aborted) {
+          throw new Error(`OpenCode request timed out after ${requestTimeoutMs}ms`);
+        }
+        throw error;
+      } finally {
+        timeout.cleanup();
+      }
+    },
   });
 };
 

--- a/packages/ui/src/sync/retry.test.ts
+++ b/packages/ui/src/sync/retry.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { retry } from './retry';
+
+describe('retry TRANSIENT_MESSAGES (#2470)', () => {
+  test('"terminated" (undici half-open socket teardown) is retried', async () => {
+    let attempts = 0;
+    const fn = async (): Promise<string> => {
+      attempts += 1;
+      throw new Error('TypeError: terminated');
+    };
+    await expect(retry(fn, { attempts: 3, delay: 1 })).rejects.toThrow();
+    expect(attempts).toBe(3);
+  });
+
+  test('normalized "request timed out" (SDK read timeout) is retried', async () => {
+    let attempts = 0;
+    const fn = async (): Promise<string> => {
+      attempts += 1;
+      throw new Error('OpenCode request timed out after 30000ms');
+    };
+    await expect(retry(fn, { attempts: 3, delay: 1 })).rejects.toThrow();
+    expect(attempts).toBe(3);
+  });
+
+  test('a caller-initiated abort (AbortError) is NOT retried', async () => {
+    let attempts = 0;
+    const fn = async (): Promise<string> => {
+      attempts += 1;
+      const error = new DOMException('Aborted', 'AbortError');
+      throw error;
+    };
+    await expect(retry(fn, { attempts: 3, delay: 1 })).rejects.toThrow();
+    expect(attempts).toBe(1);
+  });
+});

--- a/packages/ui/src/sync/retry.ts
+++ b/packages/ui/src/sync/retry.ts
@@ -15,6 +15,13 @@ const TRANSIENT_MESSAGES = [
   "econnrefused",
   "etimedout",
   "socket hang up",
+  // undici tears down a half-open upstream connection with `TypeError:
+  // terminated` (the exact failure from the #2470 logs); the SDK client now
+  // also rejects reads with a normalized "request timed out" error after
+  // OPENCODE_REQUEST_TIMEOUT_MS. Both are transient — the managed process may
+  // simply be restarting.
+  "terminated",
+  "request timed out",
   "opencode api unavailable",
   "503",
   "502",


### PR DESCRIPTION
## Intent

Fixes #2470 — Sessions stuck on "loading sessions" forever; existing sessions won't open after OpenCode socket drops.

No Linear issue exists for this GitHub issue.

When the managed OpenCode connection goes half-open (process died without a FIN/RST — the exact `socket hang up` / `TypeError: terminated` / `ECONNREFUSED` sequence in the report), SDK `fetch` promises hang forever: they neither resolve nor reject. `ChildStoreManager` holds one of its two bootstrap concurrency slots for the whole `onBootstrap` promise, so two hung directories occupy both slots and every other project stays on the "loading sessions" spinner; opening a known session waits on the same never-completing bootstrap. `retry()` cannot help because it only reacts to rejections.

This PR bounds SDK **read** requests with the existing `createTimeoutSignal` helper, so a hung fetch fails after 30s, the bootstrap slot is released, and the UI surfaces the retry button instead of an infinite spinner. It also adds `terminated` and `request timed out` to `retry`'s transient allowlist so those failures are retried (bounded) instead of failing on the first attempt.

## Non-goals

- No timeout for POST requests: `session.prompt`, `shell`, `summarize`, and `command` are long-running by design (minutes of model/tool work) and must never be cut short.
- No timeout for the `/event` SSE stream (long-lived; it also bypasses this wrapper via `createSseClient`).
- No change to the message stream WS/SSE pipeline or bootstrap scheduling; the fix only ensures a dead upstream produces a real failure instead of an eternal hang.

## Affected surfaces

| Surface | Effect |
|---|---|
| `packages/ui/src/lib/opencode/client.ts` — `createRuntimeOpencodeClient` fetch wrapper | Bounds the header wait of non-POST, non-`/event` SDK requests to `OPENCODE_REQUEST_TIMEOUT_MS` (30s). Large file reads are unaffected: `fetch()` resolves at response headers, the body streams afterwards. Caller-provided abort signals are combined via `AbortSignal.any` (fallback: caller signal wins), and a caller-initiated abort is never rewritten into a "timed out" error. |
| `packages/ui/src/sync/retry.ts` — `TRANSIENT_MESSAGES` | Adds `terminated` (undici half-open teardown, exact message from the issue logs) and `request timed out` (normalized timeout rejection). |
| Runtimes | All runtimes (web, desktop, VS Code, mobile) share this client; behavior is identical and additive — previously-hanging reads now reject with a retryable error. No persisted data or external contracts change. |

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `ui-api-decoupling` | Change touches the SDK client fetch path and `runtimeFetch` | The wrapper preserves the SDK `Request` (method/body/headers/signal) and only adds an abort bound; `runtimeFetch` still owns routing/auth; SSE is untouched. |
| `sync-state-invariants` | Bootstrap slot release and retry semantics | Failure is a real rejection, never an empty success; the retry loop now has a real failure signal for the reported error shapes; one hung directory fails independently and no longer blocks unrelated directories. |
| `openchamber-change-discipline` | Executable source + exported factory + new test files | Smallest complete change; POST and `/event` exclusions documented in code; focused tests added at both layers. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/lib/opencode/client-timeout.test.ts` (4 tests) | 4 pass — GET timeout rejects with normalized error; POST excluded (still pending past the timeout window); `/event` excluded; caller abort wins (no normalized timeout). |
| `bun test packages/ui/src/sync/retry.test.ts` (3 tests) | 3 pass — `terminated` retried 3×, `request timed out` retried 3×, caller `AbortError` not retried. |
| `bun test packages/ui/src/lib/opencode/client.test.ts` (5 tests) | 5 pass — existing SDK client suite unaffected. |
| `bun test packages/ui/src/sync packages/ui/src/lib/opencode` (full sync+client suites) | No new failures vs clean main: same pre-existing failing test names only (`adoptAuthoritativeSessionDirectory`, `input-store attachments`, `createEventPipeline` WS-frame tests, `issue 2039 draft auto-accept`, `routeMessage skill`), all present on unmodified `upstream/main` HEAD 1fd80b91a. |
| `bun run type-check:ui` | Pass (`tsc --noEmit`, no output) |
| `bun run lint:ui` | Pass (eslint, no output) |
| `bun run dead-code` | Flags the new `createRuntimeOpencodeClient` export — knip cannot resolve its usage because the test imports it through a cache-busted dynamic import (`./client?timeout-test=…`), the same tolerated pattern the existing `client.test.ts` uses and identical to the pre-existing `FetchPermissionResult` flag; report is non-blocking. |

Not verified: no live half-open-socket reproduction against a real managed OpenCode process (requires a platform runtime); the 30s bound is intentionally generous so slow-but-alive servers surface the retry button after one bounded wait instead of hanging forever.

## Visual evidence

The fixed transition cannot be demonstrated in this environment: it is the 30s bounded failure on a half-open socket (process died without FIN/RST) against a real managed OpenCode process, surfacing the existing retry affordance instead of an eternal "loading sessions" spinner. Fault injection needs a platform runtime with a killable managed process — the dev boot starts its own healthy backend, and the app cannot be pointed at a blackholed port, so the hang the fix bounds is not reproducible here. No screenshot of the failure path was produced, and none is faked.

What was verified instead (from Validation): `bun test packages/ui/src/lib/opencode/client-timeout.test.ts` (4 pass — GET timeout rejects with the normalized error; POST and `/event` excluded; caller abort wins), `bun test packages/ui/src/sync/retry.test.ts` (3 pass — `terminated` and `request timed out` retried, caller `AbortError` not), `bun test packages/ui/src/lib/opencode/client.test.ts` (5 pass), and the full sync+client suites (no new failures vs clean main).

Context screenshot (app booted from `fix/gh-2470-loading-sessions`): the exact surface that froze in #2470 — the sessions list and sidebar — renders, and normal bootstrap completes:

![context: app booted normally; sessions list renders and bootstrap completes — the half-open-socket timeout path itself is covered by the client-timeout and retry unit tests](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2692/screens/pr-2692-boot.png)

## Risks and failure behavior

- **Legitimate slow reads**: 30s to response headers is generous for every GET in the SDK surface; a slow-but-alive server gets 3 attempts with backoff before the retry button appears — strictly better than the infinite spinner.
- **Caller aborts**: a user-initiated abort is never converted into a retryable timeout (guarded by `!callerSignal?.aborted`), so cancel actions keep their exact previous semantics.
- **POST safety**: prompt/shell/summarize/command keep their previous unbounded behavior; the commit-message generation path (`session.prompt` in `gitApi.ts`) is untouched.
- **Rollback**: no persisted state is written by this change; a timeout failure is identical to any other transient fetch failure the bootstrap already handles.

