### PR TITLE
feat(mobile): show recents in the sessions sheet

### DIFF
--- a/packages/ui/src/apps/MobileSessionsSheet.tsx
+++ b/packages/ui/src/apps/MobileSessionsSheet.tsx
@@ -31,6 +31,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useShallow } from 'zustand/react/shallow';
 
 import { DirectoryExplorerDialog } from '@/components/session/DirectoryExplorerDialog';
 import { Icon } from '@/components/icon/Icon';
@@ -56,7 +57,10 @@ import { useMobileSessionTreeStore } from '@/stores/useMobileSessionTreeStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
 import { orderWorktrees, useWorktreeOrderStore } from '@/stores/useWorktreeOrderStore';
+import { deriveRecentSessions } from '@/components/session/sidebar/activitySections';
+import { useGlobalSessionStatusStore } from '@/sync/global-session-status';
 import {
+  compareSessionsByLifecycleOrder,
   EMPTY_SESSION_ORDER_RANKS,
   orderSessionsByLifecycleScopes,
   useSessionOrderingStore,
@@ -90,8 +94,14 @@ type MobileSessionsSheetProps = {
 };
 
 const EMPTY_PINNED_SESSION_IDS = new Set<string>();
+const EMPTY_ACTIVE_SESSION_IDS: string[] = [];
+const EMPTY_RECENT_SESSIONS: Session[] = [];
 
-// Pseudo-project key for the collapsible "recent" group's persisted expansion.
+// Pseudo-project key for the collapsible "recent" group's persisted expansion
+// in useMobileSessionTreeStore — same store and default-expanded semantics as
+// real projects (a missing key means expanded). Real project ids can never
+// collide with it.
+const RECENT_GROUP_KEY = '__recent__';
 
 type ProjectMeta = {
   id: string;
@@ -852,6 +862,8 @@ const SortableProjectRow: React.FC<{
 
 export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, onOpenChange, variant = 'drawer', footer }) => {
   const { t } = useI18n();
+  // Shared with the desktop sidebar's recent zone (same key, all locales).
+  const recentLabel = t('sessions.sidebar.activity.recentTitle');
   const { git } = useRuntimeAPIs();
   const liveSessions = useAllLiveSessions();
   const globalActiveSessions = useGlobalSessionsStore((state) => state.activeSessions);
@@ -1025,6 +1037,29 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   }, [globalActiveSessions, liveSessions]);
 
   const normalizedQuery = query.trim().toLowerCase();
+
+  // The "active now" set (sessions with a non-idle status). The recents
+  // window keeps running sessions even when they are older than the retention
+  // period, mirroring the desktop sidebar's deriveRecentSessions semantics.
+  const activeSessionIds = useGlobalSessionStatusStore(useShallow(
+    (state) => (open || variant === 'sidebar')
+      ? [...state.statusById.keys()].sort()
+      : EMPTY_ACTIVE_SESSION_IDS,
+  ));
+  const activeSessionIdSet = React.useMemo(() => new Set(activeSessionIds), [activeSessionIds]);
+
+  // Desktop-parity "recents" zone: non-archived root sessions updated within
+  // the retention window or active right now, ordered by lifecycle order.
+  const recentSessions = React.useMemo(() => {
+    if (!open && variant !== 'sidebar') return EMPTY_RECENT_SESSIONS;
+    return deriveRecentSessions(sessions, activeSessionIdSet)
+      .sort((a, b) => compareSessionsByLifecycleOrder(a, b, pinnedSessionIds, sessionOrderRanks));
+  }, [activeSessionIdSet, open, pinnedSessionIds, sessionOrderRanks, sessions, variant]);
+
+  const recentVisibleCount = visibleCountByBucket.get(RECENT_GROUP_KEY) ?? SESSIONS_PER_BUCKET;
+  const visibleRecentSessions = recentSessions.slice(0, recentVisibleCount);
+  const remainingRecentSessions = recentSessions.length - visibleRecentSessions.length;
+  const canShowFewerRecent = recentSessions.length > SESSIONS_PER_BUCKET && remainingRecentSessions === 0;
 
   // On open, bring the current session (or at least its project) into view —
   // the list keeps its scroll position between opens, so a long project list
@@ -1231,6 +1266,16 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   const toggleWorktree = (projectId: string, bucketKey: string, currentlyExpanded: boolean) => {
     setWorktreeExpanded(`${projectId}::${bucketKey}`, !currentlyExpanded);
     resetBucketVisibleCount(`${projectId}::${bucketKey}`);
+  };
+
+  // Recents group: same persisted expansion store as projects, keyed by the
+  // pseudo-project key; toggling resets its "show more" batch like any other
+  // group.
+  const isRecentGroupExpanded = projectExpandedMap[RECENT_GROUP_KEY] ?? true;
+
+  const toggleRecentGroup = (currentlyExpanded: boolean) => {
+    setProjectExpanded(RECENT_GROUP_KEY, !currentlyExpanded);
+    resetBucketVisibleCount(RECENT_GROUP_KEY);
   };
 
   const handleSelectSession = (session: Session) => {
@@ -1604,6 +1649,67 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
             </div>
           ) : (
             <div className="flex flex-col">
+              {/* Recents: desktop-parity zone above the projects. Sessions
+                  also appear under their project — this is a shortcut list,
+                  exactly like the desktop sidebar's recent section. Hidden in
+                  search and reorder modes, which render their own surfaces. */}
+              {recentSessions.length > 0 ? (
+                <section className="border-b border-border/70">
+                  <button
+                    type="button"
+                    className="flex min-h-12 w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
+                    onClick={() => toggleRecentGroup(isRecentGroupExpanded)}
+                    aria-expanded={isRecentGroupExpanded}
+                    aria-label={
+                      isRecentGroupExpanded
+                        ? t('sessions.sidebar.group.collapseAria', { label: recentLabel })
+                        : t('sessions.sidebar.group.expandAria', { label: recentLabel })
+                    }
+                    style={{ touchAction: 'manipulation' }}
+                  >
+                    <Icon name="history" className="size-4 shrink-0 text-muted-foreground" />
+                    <span className="block min-w-0 flex-1 truncate typography-ui-label font-semibold text-foreground">
+                      {recentLabel}
+                    </span>
+                    <span className="shrink-0 typography-micro text-muted-foreground tabular-nums">
+                      {recentSessions.length}
+                    </span>
+                  </button>
+                  {isRecentGroupExpanded ? (
+                    <div className="pb-2">
+                      {visibleRecentSessions.map((session) => (
+                        <SessionRow
+                          key={session.id}
+                          session={session}
+                          active={currentSessionId === session.id}
+                          indent={12}
+                          contextLabel={buildSessionContextLabel(session)}
+                          onSelect={() => handleSelectSession(session)}
+                          revealed={revealedSessionId === session.id}
+                          onRevealedChange={(nextRevealed) => handleRowRevealedChange(session.id, nextRevealed)}
+                          confirmingDelete={confirmingDeleteSessionId === session.id}
+                          onArchive={() => void handleArchive(session)}
+                          onRequestDelete={() => setConfirmingDeleteSessionId(session.id)}
+                          onConfirmDelete={() => void handleConfirmDelete(session)}
+                          renaming={renamingSessionId === session.id}
+                          onRequestRename={() => handleRequestRename(session.id)}
+                          onSubmitRename={(nextTitle) => void handleSubmitRename(session.id, nextTitle)}
+                          onCancelRename={() => setRenamingSessionId(null)}
+                        />
+                      ))}
+                      {remainingRecentSessions > 0 ? (
+                        <ShowMoreRow
+                          indent={12}
+                          onClick={() => showMoreBucketSessions(RECENT_GROUP_KEY, visibleRecentSessions.length)}
+                        />
+                      ) : null}
+                      {canShowFewerRecent ? (
+                        <ShowFewerRow indent={12} onClick={() => resetBucketVisibleCount(RECENT_GROUP_KEY)} />
+                      ) : null}
+                    </div>
+                  ) : null}
+                </section>
+              ) : null}
               {orderedNodes.map((node, nodeIndex) => {
                 const projectExpanded = isProjectExpanded(node);
                 const buckets = normalizedQuery


### PR DESCRIPTION
## Intent

Fixes #2565 (GitHub-only issue; no Linear counterpart exists for it).

Add the desktop sidebar's "recent" sessions zone to the mobile app's sessions sheet (the phone drawer and the iPad persistent sidebar), as requested: "Add the recents chat section in mobile app as well."

The mobile sessions sheet previously showed only the project → worktree → session tree. It now renders a collapsible "Recents" group above the projects, with the same membership semantics as the desktop sidebar's recent section (`deriveRecentSessions`: non-archived root sessions updated within the 48h retention window or running right now), sorted by the same lifecycle order. Sessions in recents are a shortcut list — they still appear under their project, exactly like on desktop.

## Non-goals

- No new recents *data* model: the mobile app already has a header session switcher fed by `useSwitcherItems`; this change adds the in-list recents surface the issue asks for, reusing the desktop's derivation helper so both surfaces agree on membership.
- No change to the project tree, search, or reorder modes; recents is hidden in those modes (desktop parity: the recent zone also hides during sidebar search).
- No new i18n keys: the section reuses the existing, fully translated `sessions.sidebar.activity.recentTitle`.

## Affected surfaces

- `packages/ui` — `apps/MobileSessionsSheet.tsx` (the mobile sessions drawer + iPad sidebar). No other files touched; no exports changed; no new dependencies.
- Runtimes: mobile web/PWA, Capacitor iOS/Android (phone drawer + tablet sidebar). Desktop/VS Code/Electron surfaces are untouched — the desktop sidebar's recents zone already exists and is not modified.
- Persisted state: the recents group's collapsed/expanded choice persists via the existing `useMobileSessionTreeStore` (localStorage key `mobile-session-tree`), using the pseudo-project key `__recent__` that the sheet already reserved for this purpose in an orphaned comment ("Pseudo-project key for the collapsible 'recent' group's persisted expansion"). Real project ids cannot collide with it.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md — use existing store data and components | The issue explicitly asks to reuse store data and components | Recents reuse `deriveRecentSessions` (the desktop sidebar's tested derivation), `compareSessionsByLifecycleOrder`, the existing `SessionRow`/`ShowMoreRow`/`ShowFewerRow` components, the existing bucket pagination mechanism, and the existing expansion store |
| `openchamber-change-discipline` skill | Any OpenChamber source change | Smallest complete change in one file; no refactors of adjacent code; behavior of the project tree, search, and reorder surfaces preserved |
| `theme-system` skill (loaded per task) | Task required loading it | Uses only existing theme tokens/utilities (`text-muted-foreground`, `border-border/70`, `typography-*`, `Icon` sprite — the existing `history` icon) and the sheet's own header-row conventions; no new colors |
| `locale-ui-patterns` skill (loaded per task) | New visible text | No new keys — reuses `sessions.sidebar.activity.recentTitle` (translated in all 11 locale dictionaries) and existing aria/copy keys (`sessions.sidebar.group.collapseAria`/`expandAria`, `sessions.sidebar.group.showMore`/`showFewer`) |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` (packages/ui) | Passed — `tsc --noEmit` clean |
| `bun run lint:ui` (packages/ui) | Passed — eslint clean |
| `bun test packages/ui/src` (full package suite) | 1667 pass; **204 fail + 13 errors — identical counts on clean `upstream/main` (verified by stashing the change and re-running), so all failures pre-exist and are unrelated**; the `apps/` directory containing the changed file: 17 pass, 0 fail |
| Focused tests (`activitySections.test.ts`, `globalSessions.test.ts`, `session-ordering.test.ts`, `mobileConnections.test.ts`) | 34 pass, 0 fail |
| `bun run dead-code` | Not run — no files/exports/entrypoints added, deleted, or renamed (one internal constant + memo added) |

Not verified: actual rendering on a phone/iPad — this environment has no iOS simulator or mobile browser. Expected behavior (to be confirmed on device): opening the sessions drawer (or the iPad sidebar) shows "Recents" with a history icon and session count above the project list; the group is expanded by default and persists its collapsed state; rows show title + "project · branch" context, live busy/attention indicators, relative time, and swipe actions (archive/delete/rename); more than 7 recents paginate via the existing show-more/fewer rows; selecting a recents session switches to it and expands its project in the tree.

## Visual evidence

No screenshots/recordings: no iOS simulator or mobile browser is available in this environment. The change renders within the existing sessions sheet layout; expected appearance is a section header row matching the sheet's project-header conventions (icon + semibold label + count) followed by the standard session rows, above the first project section.

## Risks and failure behavior

- **Membership divergence**: mobile `sessions` excludes archived sessions before `deriveRecentSessions` runs (unchanged, pre-existing filter); the desktop derivation also excludes archived, so both surfaces agree.
- **Stale active set**: the "active now" set comes from the existing `useGlobalSessionStatusStore` (same store the desktop sidebar uses); while the sheet is closed the subscription returns a stable empty array (gated on `open || variant === 'sidebar'`, matching the sheet's existing pinned/ranks gating), so no work happens off-screen.
- **Collapsed-state persistence**: keyed `__recent__` in the existing persisted expansion store; a missing key defaults to expanded. Toggling resets the recents "show more" batch, consistent with every other group in the sheet.
- **None of the existing flows are altered**: search, reorder, project/worktree expansion, swipe actions, and session switching keep their prior behavior; recents rows reuse the same handlers as tree rows.
