### PR TITLE
fix(usage): renew Claude OAuth tokens before usage refreshes

### DIFF
--- a/packages/vscode/src/quotaProviders.test.ts
+++ b/packages/vscode/src/quotaProviders.test.ts
@@ -12,9 +12,16 @@ const AUTH = JSON.stringify({
   neuralwatt: { key: 'test-token' },
   'zai-coding-plan': { key: 'test-token' },
   deepseek: { key: 'test-token' },
+  anthropic: { type: 'oauth', access: 'expired-access', refresh: 'refresh-token', expires: 1 },
 });
+let writtenAuth: string | null = null;
 ((fs as unknown) as { existsSync: () => boolean }).existsSync = () => true;
 ((fs as unknown) as { readFileSync: () => string }).readFileSync = () => AUTH;
+((fs as unknown) as { writeFileSync: (path: string, data: string) => void }).writeFileSync = (_path, data) => {
+  writtenAuth = data;
+};
+((fs as unknown) as { copyFileSync: () => void }).copyFileSync = () => undefined;
+((fs as unknown) as { mkdirSync: () => void }).mkdirSync = () => undefined;
 
 import { fetchQuotaForProvider } from './quotaProviders';
 
@@ -508,5 +515,79 @@ describe('DeepSeek quota provider (VS Code parity)', () => {
     const fsMock = fs as unknown as { existsSync: unknown; readFileSync: unknown };
     fsMock.existsSync = ORIGINAL_FS.existsSync;
     fsMock.readFileSync = ORIGINAL_FS.readFileSync;
+  });
+});
+
+describe('Claude quota provider (VS Code parity)', () => {
+  const tokenUrl = 'https://console.anthropic.com/v1/oauth/token';
+  const usageUrl = 'https://api.anthropic.com/api/oauth/usage';
+  const usagePayload = {
+    five_hour: { utilization: 0.42, resets_at: '2026-08-05T12:00:00Z' },
+    seven_day: { utilization: 0.15, resets_at: '2026-08-08T12:00:00Z' },
+  };
+
+  beforeEach(() => {
+    writtenAuth = null;
+    // Later describe blocks restore real fs in their teardown; re-install the
+    // auth stubs so this block reads the fixture entry.
+    ((fs as unknown) as { existsSync: () => boolean }).existsSync = () => true;
+    ((fs as unknown) as { readFileSync: () => string }).readFileSync = () => AUTH;
+    ((fs as unknown) as { writeFileSync: (path: string, data: string) => void }).writeFileSync = (_path, data) => {
+      writtenAuth = data;
+    };
+    ((fs as unknown) as { copyFileSync: () => void }).copyFileSync = () => undefined;
+    ((fs as unknown) as { mkdirSync: () => void }).mkdirSync = () => undefined;
+  });
+
+  test('renews an expired oauth token before the usage call and persists it', async () => {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === tokenUrl) {
+        return mockResponse({
+          access_token: 'fresh-access',
+          refresh_token: 'rotated-refresh',
+          expires_in: 3600,
+        });
+      }
+      assert.equal(url, usageUrl);
+      return mockResponse(usagePayload);
+    }) as typeof fetch;
+
+    const result = await fetchQuotaForProvider('claude');
+
+    assert.equal(result.ok, true);
+    assert.equal(result.usage!.windows['5h']!.usedPercent, 0.42);
+    const persisted = JSON.parse(writtenAuth ?? '{}');
+    assert.equal(persisted.anthropic.access, 'fresh-access');
+    assert.equal(persisted.anthropic.refresh, 'rotated-refresh');
+    assert.equal(typeof persisted.anthropic.expires, 'number');
+  });
+
+  test('reports session expiry instead of a raw 401 when refresh fails to help', async () => {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === tokenUrl) {
+        return mockResponse({ access_token: 'fresh-access', refresh_token: 'rotated-refresh', expires_in: 3600 });
+      }
+      return mockResponse({}, { ok: false, status: 401 });
+    }) as typeof fetch;
+
+    const result = await fetchQuotaForProvider('claude');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.configured, true);
+    assert.equal(result.error, 'Session expired — please re-authenticate with Claude');
+  });
+
+  test('maps a 401 without a refresh token to session expiry', async () => {
+    ((fs as unknown) as { readFileSync: () => string }).readFileSync = () => JSON.stringify({
+      anthropic: { type: 'oauth', access: 'expired-access' },
+    });
+    globalThis.fetch = (async () => mockResponse({}, { ok: false, status: 401 })) as typeof fetch;
+
+    const result = await fetchQuotaForProvider('claude');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'Session expired — please re-authenticate with Claude');
   });
 });

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -254,6 +254,26 @@ const readAuthFile = (): AuthFile => {
   }
 };
 
+const writeAuthFile = (auth: AuthFile): void => {
+  try {
+    if (!fs.existsSync(OPENCODE_DATA_DIR)) {
+      fs.mkdirSync(OPENCODE_DATA_DIR, { recursive: true });
+    }
+
+    if (fs.existsSync(AUTH_FILE)) {
+      const backupFile = `${AUTH_FILE}.openchamber.backup`;
+      fs.copyFileSync(AUTH_FILE, backupFile);
+      console.log(`Created auth backup: ${backupFile}`);
+    }
+
+    fs.writeFileSync(AUTH_FILE, JSON.stringify(auth, null, 2), 'utf8');
+    console.log('Successfully wrote auth file');
+  } catch (error) {
+    console.error('Failed to write auth file:', error);
+    throw new Error('Failed to write OpenCode auth configuration');
+  }
+};
+
 const readJsonFile = (filePath: string): Record<string, unknown> | null => {
   if (!fs.existsSync(filePath)) {
     return null;
@@ -921,6 +941,150 @@ const fetchGoogleQuota = async (): Promise<ProviderResult> => {
   });
 };
 
+// Public OAuth contract used by the OpenCode Anthropic plugin
+// (packages/opencode/src/auth/anthropic.ts): refresh-token exchange against the
+// console token endpoint with this client id, returning a rotated refresh token.
+const ANTHROPIC_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const ANTHROPIC_OAUTH_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+const ANTHROPIC_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const ANTHROPIC_REQUEST_TIMEOUT_MS = 30_000;
+// Renew while the token is still valid so a request in flight cannot fall into
+// the expired window between a model call and the usage refresh.
+const ANTHROPIC_EXPIRY_MARGIN_MS = 60_000;
+
+// Single-flight renewal: concurrent usage refreshes share one token exchange
+// instead of firing several renewals at the same time.
+let claudeRefreshPromise: Promise<Record<string, unknown>> | null = null;
+
+const decodeJwtExpiryMs = (token: string): number | null => {
+  try {
+    const payload = token.split('.')[1];
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as { exp?: number };
+    return typeof claims?.exp === 'number' ? claims.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+};
+
+const normalizeExpiryMs = (value: unknown): number | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  // OpenCode stores `expires` in milliseconds; tolerate seconds for older entries.
+  return value < 1_000_000_000_000 ? value * 1000 : value;
+};
+
+const refreshClaudeOauth = (entry: Record<string, unknown>, authKey: string): Promise<Record<string, unknown>> => {
+  if (!claudeRefreshPromise) {
+    claudeRefreshPromise = (async () => {
+      const response = await fetch(ANTHROPIC_OAUTH_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: entry.refresh,
+          client_id: ANTHROPIC_OAUTH_CLIENT_ID,
+        }),
+        signal: AbortSignal.timeout(ANTHROPIC_REQUEST_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(`Claude token refresh failed with ${response.status}`);
+      }
+      const payload = await response.json() as Record<string, unknown>;
+      const access = typeof payload?.access_token === 'string' ? payload.access_token : '';
+      if (!access) {
+        throw new Error('Claude token refresh returned no access token');
+      }
+      const refreshed = {
+        ...entry,
+        type: 'oauth',
+        access,
+        refresh: typeof payload?.refresh_token === 'string' && payload.refresh_token
+          ? payload.refresh_token
+          : entry.refresh,
+        expires: Date.now() + (Number(payload?.expires_in) > 0 ? Number(payload.expires_in) : 3600) * 1000,
+      };
+      const auth = readAuthFile();
+      auth[authKey] = refreshed;
+      writeAuthFile(auth);
+      return refreshed;
+    })().finally(() => {
+      claudeRefreshPromise = null;
+    });
+  }
+  return claudeRefreshPromise;
+};
+
+/**
+ * Return the entry with a usable access token, renewing it when the stored
+ * token is expired (or about to expire). Returns null when the entry has no
+ * refresh token, so callers fall back to the stored token as-is.
+ */
+const ensureFreshClaudeOauth = async (
+  entry: Record<string, unknown>,
+  authKey: string,
+): Promise<Record<string, unknown> | null> => {
+  const expires = normalizeExpiryMs(entry.expires) ?? decodeJwtExpiryMs(entry.access as string);
+  if (entry.access && expires !== null && expires > Date.now() + ANTHROPIC_EXPIRY_MARGIN_MS) {
+    return entry;
+  }
+  if (!entry.refresh) {
+    return null;
+  }
+  return refreshClaudeOauth(entry, authKey);
+};
+
+const fetchClaudeUsage = async (accessToken: string): Promise<{ status: number; windows: Record<string, UsageWindow> }> => {
+  const response = await fetch(ANTHROPIC_USAGE_URL, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'anthropic-beta': 'oauth-2025-04-20',
+    },
+    signal: AbortSignal.timeout(ANTHROPIC_REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    return { status: response.status, windows: {} };
+  }
+
+  const payload = await response.json() as Record<string, unknown>;
+  const windows: Record<string, UsageWindow> = {};
+  const fiveHour = payload.five_hour as Record<string, unknown> | undefined;
+  const sevenDay = payload.seven_day as Record<string, unknown> | undefined;
+  const sevenDaySonnet = payload.seven_day_sonnet as Record<string, unknown> | undefined;
+  const sevenDayOpus = payload.seven_day_opus as Record<string, unknown> | undefined;
+
+  if (fiveHour) {
+    windows['5h'] = toUsageWindow({
+      usedPercent: toNumber(fiveHour.utilization),
+      windowSeconds: null,
+      resetAt: toTimestamp(fiveHour.resets_at),
+    });
+  }
+  if (sevenDay) {
+    windows['7d'] = toUsageWindow({
+      usedPercent: toNumber(sevenDay.utilization),
+      windowSeconds: null,
+      resetAt: toTimestamp(sevenDay.resets_at),
+    });
+  }
+  if (sevenDaySonnet) {
+    windows['7d-sonnet'] = toUsageWindow({
+      usedPercent: toNumber(sevenDaySonnet.utilization),
+      windowSeconds: null,
+      resetAt: toTimestamp(sevenDaySonnet.resets_at),
+    });
+  }
+  if (sevenDayOpus) {
+    windows['7d-opus'] = toUsageWindow({
+      usedPercent: toNumber(sevenDayOpus.utilization),
+      windowSeconds: null,
+      resetAt: toTimestamp(sevenDayOpus.resets_at),
+    });
+  }
+
+  return { status: 200, windows };
+};
+
 const fetchClaudeQuota = async (): Promise<ProviderResult> => {
   const auth = readAuthFile();
   const entry = normalizeAuthEntry(getAuthEntry(auth, ['anthropic', 'claude'])) as Record<string, unknown> | null;
@@ -936,58 +1100,69 @@ const fetchClaudeQuota = async (): Promise<ProviderResult> => {
     });
   }
 
-  try {
-    const response = await fetch('https://api.anthropic.com/api/oauth/usage', {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'anthropic-beta': 'oauth-2025-04-20',
-      },
-    });
+  // Write renewed credentials back under the key the entry was read from, so
+  // the OpenCode Anthropic plugin keeps using them.
+  const authKey = auth.anthropic !== undefined ? 'anthropic' : 'claude';
 
-    if (!response.ok) {
+  try {
+    // Renew first when the stored token is expired (or about to expire) — the
+    // window between model calls and the usage refresh must not 401.
+    let current = entry;
+    let token = accessToken;
+    if (entry?.type === 'oauth' && entry.refresh) {
+      const fresh = await ensureFreshClaudeOauth(entry, authKey);
+      if (fresh) {
+        current = fresh;
+        if (fresh.access) {
+          token = fresh.access as string;
+        }
+      }
+    }
+
+    const result = await fetchClaudeUsage(token);
+
+    if (result.status === 401 && current?.type === 'oauth' && current.refresh) {
+      // The usage API rejected even a fresh token — renew once more (with the
+      // rotated refresh token from the last renewal) and retry before declaring
+      // the session dead.
+      const renewed = await refreshClaudeOauth(current, authKey);
+      const retryResult = await fetchClaudeUsage(renewed.access as string);
+      if (retryResult.status === 200) {
+        return buildResult({
+          providerId: 'claude',
+          providerName: 'Claude',
+          ok: true,
+          configured: true,
+          usage: { windows: retryResult.windows },
+        });
+      }
+      if (retryResult.status === 401) {
+        return buildResult({
+          providerId: 'claude',
+          providerName: 'Claude',
+          ok: false,
+          configured: true,
+          error: 'Session expired — please re-authenticate with Claude',
+        });
+      }
       return buildResult({
         providerId: 'claude',
         providerName: 'Claude',
         ok: false,
         configured: true,
-        error: `API error: ${response.status}`,
+        error: `API error: ${retryResult.status}`,
       });
     }
 
-    const payload = await response.json() as Record<string, unknown>;
-    const windows: Record<string, UsageWindow> = {};
-    const fiveHour = (payload as Record<string, unknown>).five_hour as Record<string, unknown> | undefined;
-    const sevenDay = (payload as Record<string, unknown>).seven_day as Record<string, unknown> | undefined;
-    const sevenDaySonnet = (payload as Record<string, unknown>).seven_day_sonnet as Record<string, unknown> | undefined;
-    const sevenDayOpus = (payload as Record<string, unknown>).seven_day_opus as Record<string, unknown> | undefined;
-
-    if (fiveHour) {
-      windows['5h'] = toUsageWindow({
-        usedPercent: toNumber(fiveHour.utilization),
-        windowSeconds: null,
-        resetAt: toTimestamp(fiveHour.resets_at),
-      });
-    }
-    if (sevenDay) {
-      windows['7d'] = toUsageWindow({
-        usedPercent: toNumber(sevenDay.utilization),
-        windowSeconds: null,
-        resetAt: toTimestamp(sevenDay.resets_at),
-      });
-    }
-    if (sevenDaySonnet) {
-      windows['7d-sonnet'] = toUsageWindow({
-        usedPercent: toNumber(sevenDaySonnet.utilization),
-        windowSeconds: null,
-        resetAt: toTimestamp(sevenDaySonnet.resets_at),
-      });
-    }
-    if (sevenDayOpus) {
-      windows['7d-opus'] = toUsageWindow({
-        usedPercent: toNumber(sevenDayOpus.utilization),
-        windowSeconds: null,
-        resetAt: toTimestamp(sevenDayOpus.resets_at),
+    if (result.status !== 200) {
+      return buildResult({
+        providerId: 'claude',
+        providerName: 'Claude',
+        ok: false,
+        configured: true,
+        error: result.status === 401
+          ? 'Session expired — please re-authenticate with Claude'
+          : `API error: ${result.status}`,
       });
     }
 
@@ -996,7 +1171,7 @@ const fetchClaudeQuota = async (): Promise<ProviderResult> => {
       providerName: 'Claude',
       ok: true,
       configured: true,
-      usage: { windows },
+      usage: { windows: result.windows },
     });
   } catch (error) {
     return buildResult({

--- a/packages/web/server/lib/quota/providers/claude.js
+++ b/packages/web/server/lib/quota/providers/claude.js
@@ -1,4 +1,4 @@
-import { readAuthFile } from '../../opencode/auth.js';
+import { readAuthFile, writeAuthFile } from '../../opencode/auth.js';
 import {
   getAuthEntry,
   normalizeAuthEntry,
@@ -11,6 +11,151 @@ import {
 export const providerId = 'claude';
 export const providerName = 'Claude';
 const aliases = ['anthropic', 'claude'];
+
+// Public OAuth contract used by the OpenCode Anthropic plugin
+// (packages/opencode/src/auth/anthropic.ts): refresh-token exchange against the
+// console token endpoint with this client id, returning a rotated refresh token.
+const ANTHROPIC_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const ANTHROPIC_OAUTH_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+const ANTHROPIC_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const REQUEST_TIMEOUT_MS = 30_000;
+// Renew while the token is still valid so a request in flight cannot fall into
+// the expired window between a model call and the usage refresh.
+const EXPIRY_MARGIN_MS = 60_000;
+
+// Single-flight renewal: concurrent usage refreshes share one token exchange
+// instead of firing several renewals at the same time.
+let claudeRefreshPromise = null;
+
+const decodeJwtExpiryMs = (token) => {
+  try {
+    const payload = token.split('.')[1];
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    return typeof claims?.exp === 'number' ? claims.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+};
+
+const normalizeExpiryMs = (value) => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  // OpenCode stores `expires` in milliseconds; tolerate seconds for older entries.
+  return value < 1_000_000_000_000 ? value * 1000 : value;
+};
+
+const refreshClaudeOauth = async (entry, authKey) => {
+  if (!claudeRefreshPromise) {
+    claudeRefreshPromise = (async () => {
+      const response = await fetch(ANTHROPIC_OAUTH_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: entry.refresh,
+          client_id: ANTHROPIC_OAUTH_CLIENT_ID,
+        }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(`Claude token refresh failed with ${response.status}`);
+      }
+      const payload = await response.json();
+      const access = typeof payload?.access_token === 'string' ? payload.access_token : '';
+      if (!access) {
+        throw new Error('Claude token refresh returned no access token');
+      }
+      const refreshed = {
+        ...entry,
+        type: 'oauth',
+        access,
+        refresh: typeof payload?.refresh_token === 'string' && payload.refresh_token
+          ? payload.refresh_token
+          : entry.refresh,
+        expires: Date.now() + (Number(payload?.expires_in) > 0 ? Number(payload.expires_in) : 3600) * 1000,
+      };
+      const auth = readAuthFile();
+      auth[authKey] = refreshed;
+      writeAuthFile(auth);
+      return refreshed;
+    })().finally(() => {
+      claudeRefreshPromise = null;
+    });
+  }
+  return claudeRefreshPromise;
+};
+
+/**
+ * Return the entry with a usable access token, renewing it when the stored
+ * token is expired (or about to expire). Returns null when the entry has no
+ * refresh token, so callers fall back to the stored token as-is.
+ */
+const ensureFreshClaudeOauth = async (entry, authKey) => {
+  const expires = normalizeExpiryMs(entry.expires) ?? decodeJwtExpiryMs(entry.access);
+  if (entry.access && expires !== null && expires > Date.now() + EXPIRY_MARGIN_MS) {
+    return entry;
+  }
+  if (!entry.refresh) {
+    return null;
+  }
+  return refreshClaudeOauth(entry, authKey);
+};
+
+const parseUsagePayload = (payload) => {
+  const windows = {};
+  const fiveHour = payload?.five_hour ?? null;
+  const sevenDay = payload?.seven_day ?? null;
+  const sevenDaySonnet = payload?.seven_day_sonnet ?? null;
+  const sevenDayOpus = payload?.seven_day_opus ?? null;
+
+  if (fiveHour) {
+    windows['5h'] = toUsageWindow({
+      usedPercent: toNumber(fiveHour.utilization),
+      windowSeconds: null,
+      resetAt: toTimestamp(fiveHour.resets_at)
+    });
+  }
+  if (sevenDay) {
+    windows['7d'] = toUsageWindow({
+      usedPercent: toNumber(sevenDay.utilization),
+      windowSeconds: null,
+      resetAt: toTimestamp(sevenDay.resets_at)
+    });
+  }
+  if (sevenDaySonnet) {
+    windows['7d-sonnet'] = toUsageWindow({
+      usedPercent: toNumber(sevenDaySonnet.utilization),
+      windowSeconds: null,
+      resetAt: toTimestamp(sevenDaySonnet.resets_at)
+    });
+  }
+  if (sevenDayOpus) {
+    windows['7d-opus'] = toUsageWindow({
+      usedPercent: toNumber(sevenDayOpus.utilization),
+      windowSeconds: null,
+      resetAt: toTimestamp(sevenDayOpus.resets_at)
+    });
+  }
+
+  return windows;
+};
+
+const fetchClaudeUsage = async (accessToken) => {
+  const response = await fetch(ANTHROPIC_USAGE_URL, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'anthropic-beta': 'oauth-2025-04-20'
+    },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+  });
+
+  if (!response.ok) {
+    return { status: response.status };
+  }
+
+  const payload = await response.json();
+  return { status: 200, windows: parseUsagePayload(payload) };
+};
 
 export const isConfigured = () => {
   const auth = readAuthFile();
@@ -33,58 +178,69 @@ export const fetchQuota = async () => {
     });
   }
 
-  try {
-    const response = await fetch('https://api.anthropic.com/api/oauth/usage', {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'anthropic-beta': 'oauth-2025-04-20'
-      }
-    });
+  // Write renewed credentials back under the key the entry was read from, so
+  // the OpenCode Anthropic plugin keeps using them.
+  const authKey = aliases.find((alias) => auth[alias]) ?? 'anthropic';
 
-    if (!response.ok) {
+  try {
+    // Renew first when the stored token is expired (or about to expire) — the
+    // window between model calls and the usage refresh must not 401.
+    let current = entry;
+    let token = accessToken;
+    if (entry?.type === 'oauth' && entry.refresh) {
+      const fresh = await ensureFreshClaudeOauth(entry, authKey);
+      if (fresh) {
+        current = fresh;
+        if (fresh.access) {
+          token = fresh.access;
+        }
+      }
+    }
+
+    const result = await fetchClaudeUsage(token);
+
+    if (result.status === 401 && current?.type === 'oauth' && current.refresh) {
+      // The usage API rejected even a fresh token — renew once more (with the
+      // rotated refresh token from the last renewal) and retry before declaring
+      // the session dead.
+      const renewed = await refreshClaudeOauth(current, authKey);
+      const retryResult = await fetchClaudeUsage(renewed.access);
+      if (retryResult.status === 200) {
+        return buildResult({
+          providerId,
+          providerName,
+          ok: true,
+          configured: true,
+          usage: { windows: retryResult.windows }
+        });
+      }
+      if (retryResult.status === 401) {
+        return buildResult({
+          providerId,
+          providerName,
+          ok: false,
+          configured: true,
+          error: 'Session expired — please re-authenticate with Claude'
+        });
+      }
       return buildResult({
         providerId,
         providerName,
         ok: false,
         configured: true,
-        error: `API error: ${response.status}`
+        error: `API error: ${retryResult.status}`
       });
     }
 
-    const payload = await response.json();
-    const windows = {};
-    const fiveHour = payload?.five_hour ?? null;
-    const sevenDay = payload?.seven_day ?? null;
-    const sevenDaySonnet = payload?.seven_day_sonnet ?? null;
-    const sevenDayOpus = payload?.seven_day_opus ?? null;
-
-    if (fiveHour) {
-      windows['5h'] = toUsageWindow({
-        usedPercent: toNumber(fiveHour.utilization),
-        windowSeconds: null,
-        resetAt: toTimestamp(fiveHour.resets_at)
-      });
-    }
-    if (sevenDay) {
-      windows['7d'] = toUsageWindow({
-        usedPercent: toNumber(sevenDay.utilization),
-        windowSeconds: null,
-        resetAt: toTimestamp(sevenDay.resets_at)
-      });
-    }
-    if (sevenDaySonnet) {
-      windows['7d-sonnet'] = toUsageWindow({
-        usedPercent: toNumber(sevenDaySonnet.utilization),
-        windowSeconds: null,
-        resetAt: toTimestamp(sevenDaySonnet.resets_at)
-      });
-    }
-    if (sevenDayOpus) {
-      windows['7d-opus'] = toUsageWindow({
-        usedPercent: toNumber(sevenDayOpus.utilization),
-        windowSeconds: null,
-        resetAt: toTimestamp(sevenDayOpus.resets_at)
+    if (result.status !== 200) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: result.status === 401
+          ? 'Session expired — please re-authenticate with Claude'
+          : `API error: ${result.status}`
       });
     }
 
@@ -93,7 +249,7 @@ export const fetchQuota = async () => {
       providerName,
       ok: true,
       configured: true,
-      usage: { windows }
+      usage: { windows: result.windows }
     });
   } catch (error) {
     return buildResult({

--- a/packages/web/server/lib/quota/providers/claude.test.js
+++ b/packages/web/server/lib/quota/providers/claude.test.js
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authState = { value: { anthropic: { type: 'oauth', access: 'expired-access', refresh: 'refresh-token', expires: 1 } } };
+
+vi.mock('../../opencode/auth.js', () => ({
+  readAuthFile: () => authState.value,
+  writeAuthFile: vi.fn((auth) => {
+    authState.value = auth;
+  }),
+}));
+
+import { fetchQuota, isConfigured } from './claude.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  authState.value = { anthropic: { type: 'oauth', access: 'expired-access', refresh: 'refresh-token', expires: 1 } };
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const usagePayload = {
+  five_hour: { utilization: 0.42, resets_at: '2026-08-05T12:00:00Z' },
+  seven_day: { utilization: 0.15, resets_at: '2026-08-08T12:00:00Z' },
+};
+
+const mockUsageResponse = (status = 200, body = usagePayload) => ({
+  ok: status === 200,
+  status,
+  json: async () => body,
+});
+
+const mockTokenResponse = (status = 200, body = {}) => ({
+  ok: status === 200,
+  status,
+  json: async () => body,
+});
+
+const isTokenRequest = (url) => url === 'https://console.anthropic.com/v1/oauth/token';
+
+describe('Claude quota provider OAuth renewal', () => {
+  it('is not configured without any stored credential', () => {
+    authState.value = {};
+    expect(isConfigured()).toBe(false);
+  });
+
+  it('uses a plain token entry directly without touching the token endpoint', async () => {
+    authState.value = { anthropic: { token: 'plain-token' } };
+    const fetchMock = vi.fn().mockResolvedValue(mockUsageResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows['5h'].usedPercent).toBe(0.42);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.anthropic.com/api/oauth/usage');
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer plain-token');
+  });
+
+  it('renews an expired oauth token before calling the usage API and persists it', async () => {
+    authState.value = {
+      anthropic: { type: 'oauth', access: 'stale-access', refresh: 'refresh-token', expires: Date.now() - 60_000 },
+    };
+    const fetchMock = vi.fn().mockImplementation((url) => (
+      isTokenRequest(url)
+        ? Promise.resolve(mockTokenResponse(200, {
+          access_token: 'fresh-access',
+          refresh_token: 'rotated-refresh',
+          expires_in: 3600,
+        }))
+        : Promise.resolve(mockUsageResponse())
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows['5h'].usedPercent).toBe(0.42);
+    const tokenCalls = fetchMock.mock.calls.filter(([url]) => isTokenRequest(url));
+    expect(tokenCalls).toHaveLength(1);
+    const tokenBody = JSON.parse(tokenCalls[0][1].body);
+    expect(tokenBody).toEqual({
+      grant_type: 'refresh_token',
+      refresh_token: 'refresh-token',
+      client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
+    });
+    const usageCall = fetchMock.mock.calls.find(([url]) => !isTokenRequest(url));
+    expect(usageCall[1].headers.Authorization).toBe('Bearer fresh-access');
+    expect(authState.value.anthropic.access).toBe('fresh-access');
+    expect(authState.value.anthropic.refresh).toBe('rotated-refresh');
+    expect(typeof authState.value.anthropic.expires).toBe('number');
+  });
+
+  it('skips renewal while the stored token is still valid', async () => {
+    authState.value = {
+      anthropic: { type: 'oauth', access: 'live-access', refresh: 'refresh-token', expires: Date.now() + 3600_000 },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(mockUsageResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer live-access');
+  });
+
+  it('falls back to the jwt exp claim when the entry has no expires field', async () => {
+    const futureExp = Math.floor((Date.now() + 3600_000) / 1000);
+    const payload = Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64url');
+    authState.value = {
+      anthropic: { type: 'oauth', access: `header.${payload}.sig`, refresh: 'refresh-token' },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(mockUsageResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe(`Bearer header.${payload}.sig`);
+  });
+
+  it('retries once with a freshly renewed token when the usage API still 401s, then reports session expiry', async () => {
+    authState.value = {
+      anthropic: { type: 'oauth', access: 'stale-access', refresh: 'refresh-token', expires: Date.now() - 60_000 },
+    };
+    const fetchMock = vi.fn().mockImplementation((url) => (
+      isTokenRequest(url)
+        ? Promise.resolve(mockTokenResponse(200, {
+          access_token: `fresh-${Math.random()}`,
+          refresh_token: `rotated-${Math.random()}`,
+          expires_in: 3600,
+        }))
+        : Promise.resolve(mockUsageResponse(401))
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('Session expired — please re-authenticate with Claude');
+    // renewal + retry renewal = two token exchanges, two usage attempts
+    expect(fetchMock.mock.calls.filter(([url]) => isTokenRequest(url))).toHaveLength(2);
+  });
+
+  it('succeeds when the retry with a renewed token passes', async () => {
+    let usageAttempts = 0;
+    authState.value = {
+      anthropic: { type: 'oauth', access: 'stale-access', refresh: 'refresh-token', expires: Date.now() - 60_000 },
+    };
+    const fetchMock = vi.fn().mockImplementation((url) => {
+      if (isTokenRequest(url)) {
+        return Promise.resolve(mockTokenResponse(200, {
+          access_token: 'fresh-access',
+          refresh_token: 'rotated-refresh',
+          expires_in: 3600,
+        }));
+      }
+      usageAttempts += 1;
+      return Promise.resolve(mockUsageResponse(usageAttempts === 1 ? 401 : 200));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows['5h'].usedPercent).toBe(0.42);
+    expect(usageAttempts).toBe(2);
+  });
+
+  it('surfaces non-401 API errors with the status', async () => {
+    authState.value = {
+      anthropic: { type: 'oauth', access: 'live-access', refresh: 'refresh-token', expires: Date.now() + 3600_000 },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(mockUsageResponse(503));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('API error: 503');
+  });
+
+  it('reports session expiry for a 401 without a refresh token instead of a raw API error', async () => {
+    authState.value = { anthropic: { type: 'oauth', access: 'expired-access' } };
+    const fetchMock = vi.fn().mockResolvedValue(mockUsageResponse(401));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Session expired — please re-authenticate with Claude');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent refreshes into a single renewal', async () => {
+    authState.value = {
+      anthropic: { type: 'oauth', access: 'stale-access', refresh: 'refresh-token', expires: Date.now() - 60_000 },
+    };
+    const fetchMock = vi.fn().mockImplementation((url) => (
+      isTokenRequest(url)
+        ? Promise.resolve(mockTokenResponse(200, {
+          access_token: 'fresh-access',
+          refresh_token: 'rotated-refresh',
+          expires_in: 3600,
+        }))
+        : Promise.resolve(mockUsageResponse())
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const [first, second] = await Promise.all([fetchQuota(), fetchQuota()]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    const tokenCalls = fetchMock.mock.calls.filter(([url]) => isTokenRequest(url));
+    expect(tokenCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Intent

Fixes #2443

Claude usage intermittently showed `API error: 401` in the usage panels because the quota provider read the OAuth access token straight from OpenCode's `auth.json` and called `https://api.anthropic.com/api/oauth/usage` with it; nothing renewed the token until the next model call. The provider now renews the access token before the usage call when it is expired (or about to expire), persists the renewed credentials (including the rotated refresh token) back to `auth.json`, retries once with a freshly renewed token when the usage API still answers 401, and only then reports a clear `Session expired — please re-authenticate with Claude` message instead of a raw API error. Renewals are single-flight, so concurrent usage refreshes share one token exchange.

No Linear issue exists for this GitHub issue.

## Non-goals

- No new UI, no new settings (matches the issue's out-of-scope list). The error string renders through the existing usage-panel error display, identically to the existing DeepSeek/CrofAI/NeuralWatt "Session expired — please re-authenticate with X" pattern.
- No change to how other providers authenticate.
- No change to the OpenCode plugin's own token handling; the renewal uses the same public OAuth contract the plugin uses and writes back the same `auth.json` shape (`type: "oauth"`, `access`, `refresh`, `expires`).

## Affected surfaces

- `packages/web/server/lib/quota/providers/claude.js` — web/desktop/mobile (the OpenChamber server serves all of them).
- `packages/vscode/src/quotaProviders.ts` (`fetchClaudeQuota` + new `writeAuthFile`) — VS Code rate-limits surface.
- New tests: `packages/web/server/lib/quota/providers/claude.test.js` (vitest, 10 tests) and a Claude parity block in `packages/vscode/src/quotaProviders.test.ts` (node:test, 3 tests).

The OAuth refresh contract was taken from OpenCode's own Anthropic plugin (`packages/opencode/src/auth/anthropic.ts` at opencode tag v0.1.0): POST `https://console.anthropic.com/v1/oauth/token` with JSON `{ grant_type: "refresh_token", refresh_token, client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e" }`, response carries `access_token`, rotated `refresh_token`, `expires_in`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md always-on constraints | Secrets handling, correctness invariants, minimal change | Tokens never leave the process except to Anthropic's own endpoints (same as the existing code); credentials are only written back to the existing `auth.json` via the existing `writeAuthFile` helper (with its backup behavior); no logging of token values. |
| `ui-api-decoupling` skill | Server API surface and runtime parity | The change is confined to the two quota providers (web server + VS Code) that already own this behavior; no shared-UI or SDK changes. |
| Existing local precedent | `small-model/call.js` already implements single-flight OAuth refresh + write-back for OpenAI; DeepSeek/CrofAI/NeuralWatt already map 401 to a "Session expired — please re-authenticate" message | The new Claude code mirrors `refreshOpenaiOauth`'s single-flight pattern and the existing 401 message style. |
| Docs | Nearest module docs | `packages/web/server/lib/quota` has no DOCUMENTATION.md; `small-model/DOCUMENTATION.md` untouched (no behavior change there). |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:web` | PASS |
| `bun run lint:web` | PASS |
| `bun run type-check:ui` | PASS (UI untouched, run as cross-check) |
| `packages/vscode`: `tsc --noEmit` | PASS |
| `packages/vscode`: `eslint src/quotaProviders.ts` | PASS |
| `node --check` on `claude.js` + `claude.test.js` | PASS (server JS is plain JS — static TS checks do not cover it) |
| `vitest run server/lib/quota/` | 14 files, 68 tests PASS (incl. 10 new Claude tests) |
| `vitest run server/lib/small-model/ server/lib/opencode/` | 33 files, 353 tests PASS |
| `bun test src/quotaProviders.test.ts` (vscode) | 31 tests PASS (incl. 3 new Claude parity tests) |

Not verified: no live network call to the Anthropic token endpoint in this environment (no real Claude OAuth credentials available). The refresh contract is verified against OpenCode's published source; the single-flight, expiry, retry, and message-mapping behavior is covered by the mocked tests above.

## Visual evidence

Captured live from the PR branch (`fix/gh-2443-oauth-401`) — web app via `dev:web:hmr` (UI 5187 / API 3909), headless Chromium.

**What could be captured:** the usage panel itself, which renders provider quota cards fed by the server's quota API. Opened via the header control (Services/Usage/MCP): the panel shows the quota cards for every provider that has credentials in this environment — GitHub Copilot (Chat Requests/Completions/Premium Interactions), Kimi for Coding (Weekly Limit / 300m Rate Limit), OpenRouter (Credits $2.58 left · $7.42 spent), NeuralWatt (Credits Balance $0.00) — all rendered from server-side quota data, exactly the surface that previously showed `API error: 401` for Claude.

| Evidence |
|---|
| [usage-panel.png](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2696/screens/usage-panel.png) — usage panel with the configured providers' quota cards |

**What cannot be captured and why:** the Claude 401 → renew → retry path itself. It requires a real expired Claude OAuth credential set (`auth.json` with an `anthropic` oauth entry whose access token has expired). This environment has **no Claude credentials at all** — confirmed via the same API the panel consumes: `GET /api/quota/providers` returns `["kimi-for-coding","openrouter","github-copilot","github-copilot-addon","neuralwatt"]` (no Claude provider is configured, so no Claude card renders, and no 401 is reachable). Since this PR is server-side (renewal before the usage call + one retry + clear expiry message), the panel rendering itself is unchanged; the fix only changes what data path produces those cards for Claude.

**Behavioral verification instead (rerun during capture):** `vitest run server/lib/quota/providers/claude.test.js` → **10 pass / 0 fail** (renewal before usage call, single-flight coalescing, retry-once-on-401, rotated refresh-token persistence, no-refresh-token → immediate session-expiry message, plain-token passthrough). Note: `bun test` (bun's built-in runner) reports these as failing only because it lacks vitest's `vi.unstubAllGlobals` — the repo's `packages/web` test script (`vitest run`) is the authoritative runner, and there they pass.

## Risks and failure behavior

- **Refresh token rotation**: the retry path reuses the entry returned by the last renewal (rotated refresh token), so a stale refresh token is never sent after a successful renewal.
- **Concurrent refreshes**: module-level single-flight promise; concurrent usage refreshes share one exchange (covered by test).
- **No refresh token**: a 401 with an oauth entry lacking `refresh` reports session expiry immediately (one usage call), never a raw 401.
- **Write failures**: `writeAuthFile` throws; the error is caught and surfaced as the result error — the usage refresh still fails visibly rather than silently succeeding.
- **Non-oauth entries** (plain token/api-key strings): used as-is, no token endpoint call (covered by test).
- **Timeouts**: both the token exchange and usage calls carry `AbortSignal.timeout(30s)`; a timeout surfaces the timeout message instead of hanging the refresh.
- **auth.json shape**: renewed entries preserve all existing fields (`accountId`, etc.) via spread and write under the key the entry was read from (`anthropic` or `claude`), so the OpenCode plugin keeps working.
- No persisted-format change, no new dependencies, no data loss: existing `writeAuthFile` backup behavior preserved.

