### PR TITLE
fix(update): refuse web auto-update when no package manager owns the install

### DIFF
--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -342,7 +342,12 @@ an authoritative loopback callback URL even when OpenChamber binds port `0`.
 ## Public exports (openchamber-routes.js)
 - `registerOpenChamberRoutes(app, dependencies)`: registers OpenChamber endpoints:
   - `GET /api/openchamber/update-check`
-  - `POST /api/openchamber/update-install`
+  - `POST /api/openchamber/update-install` — returns `400` when no update is
+    available; returns `409` with a manual-update message when the installation
+    is not owned by a global package manager (`default-fallback` detection
+    reason, e.g. tarball/docker extraction) so a blind `npm install -g` is
+    never attempted; otherwise responds `200` and runs the detected package
+    manager's update command.
   - `GET /api/openchamber/models-metadata`
   - `GET /api/zen/models`
 

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -67,6 +67,16 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
       }
 
       const pmDetails = detectPackageManagerDetails();
+      if (pmDetails.reason === 'default-fallback') {
+        // No package manager owns this installation (e.g. tarball/docker
+        // extraction). Blindly running `npm install -g @openchamber/web@latest`
+        // would install into an unrelated global root and hang or fail.
+        return res.status(409).json({
+          error:
+            'Automatic update is not available for this installation. OpenChamber was not installed through a global package manager (npm, pnpm, yarn, or bun), so it cannot update itself in place. Please update manually: reinstall the new version using your original installation method, or download it from the GitHub releases page.',
+        });
+      }
+
       const pm = pmDetails.packageManager;
       const updateCmd = getUpdateCommand(pm);
       const isContainer =

--- a/packages/web/server/lib/opencode/openchamber-routes.test.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.test.js
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import path from 'node:path';
+import request from 'supertest';
+import { registerOpenChamberRoutes } from './openchamber-routes.js';
+
+// Mock child_process so the update-install handler never spawns a real shell.
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(() => ({ unref: vi.fn() })),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+  spawnSync: vi.fn(() => ({ status: 0, stdout: '', stderr: '' })),
+}));
+
+// Mock package-manager.js so each test controls update availability and the
+// package-manager detection outcome.
+const {
+  checkForUpdatesMock,
+  detectPackageManagerDetailsMock,
+  getUpdateCommandMock,
+} = vi.hoisted(() => ({
+  checkForUpdatesMock: vi.fn(),
+  detectPackageManagerDetailsMock: vi.fn(),
+  getUpdateCommandMock: vi.fn(),
+}));
+
+vi.mock('../package-manager.js', () => ({
+  checkForUpdates: checkForUpdatesMock,
+  detectPackageManagerDetails: detectPackageManagerDetailsMock,
+  getUpdateCommand: getUpdateCommandMock,
+}));
+
+const createDependencies = (overrides = {}) => ({
+  fs: {
+    existsSync: vi.fn(() => false),
+    promises: { readFile: vi.fn(async () => { throw new Error('no instance file'); }) },
+    mkdirSync: vi.fn(),
+    openSync: vi.fn(() => 1),
+    closeSync: vi.fn(),
+  },
+  path,
+  process: { platform: 'linux', execPath: '/usr/bin/node', env: {}, exit: vi.fn() },
+  server: { address: () => ({ port: 3000 }) },
+  __dirname: '/workspace/packages/web/server/lib/opencode',
+  openchamberDataDir: '/tmp/oc-test-data',
+  modelsDevApiUrl: 'https://models.dev/api',
+  modelsMetadataCacheTtl: 300,
+  readSettingsFromDiskMigrated: vi.fn(async () => ({})),
+  fetchFreeZenModels: vi.fn(async () => []),
+  getCachedZenModels: vi.fn(() => null),
+  ...overrides,
+});
+
+const createApp = (overrides = {}) => {
+  const app = express();
+  registerOpenChamberRoutes(app, createDependencies(overrides));
+  return app;
+};
+
+const updateAvailable = { available: true, version: '2.0.0', currentVersion: '1.0.0' };
+
+describe('POST /api/openchamber/update-install', () => {
+  beforeEach(() => {
+    checkForUpdatesMock.mockReset();
+    detectPackageManagerDetailsMock.mockReset();
+    getUpdateCommandMock.mockReset();
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(() => ({ unref: vi.fn() }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects with 400 when no update is available', async () => {
+    checkForUpdatesMock.mockResolvedValue({ available: false, currentVersion: '1.0.0' });
+
+    const response = await request(createApp())
+      .post('/api/openchamber/update-install')
+      .expect(400);
+
+    expect(response.body).toEqual({ error: 'No update available' });
+    expect(detectPackageManagerDetailsMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 with manual-update guidance when no package manager owns the install (default-fallback)', async () => {
+    checkForUpdatesMock.mockResolvedValue(updateAvailable);
+    detectPackageManagerDetailsMock.mockReturnValue({
+      packageManager: 'npm',
+      reason: 'default-fallback',
+      packagePath: '/opt/openchamber',
+      packageManagerCommand: 'npm',
+      globalNodeModulesRoot: null,
+    });
+
+    const response = await request(createApp())
+      .post('/api/openchamber/update-install')
+      .expect(409);
+
+    expect(response.body.error).toMatch(/manually/i);
+    expect(response.body.error).toMatch(/package manager/i);
+    expect(getUpdateCommandMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 for default-fallback even when running inside a container', async () => {
+    checkForUpdatesMock.mockResolvedValue(updateAvailable);
+    detectPackageManagerDetailsMock.mockReturnValue({
+      packageManager: 'npm',
+      reason: 'default-fallback',
+      packagePath: '/opt/openchamber',
+      packageManagerCommand: 'npm',
+      globalNodeModulesRoot: null,
+    });
+
+    const response = await request(createApp({
+      process: { platform: 'linux', execPath: '/usr/bin/node', env: { CONTAINER: '1' }, exit: vi.fn() },
+    }))
+      .post('/api/openchamber/update-install')
+      .expect(409);
+
+    expect(response.body.error).toMatch(/manually/i);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('starts the update when a real package manager is detected', async () => {
+    vi.useFakeTimers();
+    checkForUpdatesMock.mockResolvedValue(updateAvailable);
+    detectPackageManagerDetailsMock.mockReturnValue({
+      packageManager: 'pnpm',
+      reason: 'global-root-owner',
+      packagePath: '/usr/local/lib/node_modules/@openchamber/web',
+      packageManagerCommand: 'pnpm',
+      globalNodeModulesRoot: '/usr/local/lib/node_modules',
+    });
+    getUpdateCommandMock.mockReturnValue('pnpm add -g @openchamber/web@latest');
+
+    const response = await request(createApp())
+      .post('/api/openchamber/update-install')
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      success: true,
+      packageManager: 'pnpm',
+      autoRestart: true,
+    });
+    expect(getUpdateCommandMock).toHaveBeenCalledWith('pnpm');
+
+    // Advance the deferred update shell to prove the update command is spawned.
+    await vi.advanceTimersByTimeAsync(600);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/server/lib/package-manager.js
+++ b/packages/web/server/lib/package-manager.js
@@ -15,6 +15,15 @@ const CHANGELOG_URL = 'https://raw.githubusercontent.com/openchamber/openchamber
 const GITHUB_RELEASES_URL = 'https://github.com/openchamber/openchamber/releases';
 const GITHUB_RELEASES_API_URL = 'https://api.github.com/repos/openchamber/openchamber/releases';
 let cachedDetectedPm = null;
+let cachedDetectedPmReason = null;
+let cachedGlobalNodeModulesRoot = null;
+// Cap how many package-manager ownership checks (each spawns several
+// `spawnSync(pm, ['bin'|'root'|'prefix', '-g'])` processes) run before giving
+// up on ownership detection. A non-global install (tarball/docker extraction)
+// must not hang for seconds probing every candidate; the remaining candidates
+// are still covered by the hint / runtime-path / last-resort checks below, so
+// genuinely-global installs keep resolving to the same package manager.
+const MAX_PACKAGE_MANAGER_OWNERSHIP_CHECKS = 2;
 
 function getSpawnSyncBaseOptions() {
   return process.platform === 'win32' ? { windowsHide: true } : {};
@@ -379,6 +388,11 @@ function packageManagerOwnsCurrentInstall(pm) {
   return false;
 }
 
+function cacheCurrentDetection(reason) {
+  cachedDetectedPmReason = reason;
+  cachedGlobalNodeModulesRoot = getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null;
+}
+
 export function detectPackageManagerDetails() {
   // In desktop (Electron) runtime, package-manager detection is worthless —
   // the app ships as a .app bundle, not installed via npm/pnpm/yarn/bun, and
@@ -397,13 +411,13 @@ export function detectPackageManagerDetails() {
   }
 
   if (cachedDetectedPm) {
-      return {
-        packageManager: cachedDetectedPm,
-        reason: 'cached',
-        packagePath: getCurrentPackagePath(),
-        packageManagerCommand: resolvePackageManagerCommand(cachedDetectedPm),
-        globalNodeModulesRoot: getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null,
-      };
+    return {
+      packageManager: cachedDetectedPm,
+      reason: cachedDetectedPmReason || 'cached',
+      packagePath: getCurrentPackagePath(),
+      packageManagerCommand: resolvePackageManagerCommand(cachedDetectedPm),
+      globalNodeModulesRoot: cachedGlobalNodeModulesRoot,
+    };
   }
 
   const forcedPm = process.env.OPENCHAMBER_PACKAGE_MANAGER?.trim();
@@ -411,12 +425,13 @@ export function detectPackageManagerDetails() {
     const forcedPmCommand = resolvePackageManagerCommand(forcedPm);
     if (isCommandAvailable(forcedPmCommand)) {
       cachedDetectedPm = forcedPm;
+      cacheCurrentDetection('forced-env');
       return {
         packageManager: cachedDetectedPm,
         reason: 'forced-env',
         packagePath: getCurrentPackagePath(),
         packageManagerCommand: forcedPmCommand,
-        globalNodeModulesRoot: getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null,
+        globalNodeModulesRoot: cachedGlobalNodeModulesRoot,
       };
     }
   }
@@ -425,25 +440,27 @@ export function detectPackageManagerDetails() {
   const installPathPm = detectPackageManagerFromCurrentInstallPath();
   if (installPathPm && packageManagerOwnsCurrentInstall(installPathPm)) {
     cachedDetectedPm = installPathPm;
+    cacheCurrentDetection('install-path-owner');
     return {
       packageManager: cachedDetectedPm,
       reason: 'install-path-owner',
       packagePath: getCurrentPackagePath(),
       packageManagerCommand: resolvePackageManagerCommand(cachedDetectedPm),
-      globalNodeModulesRoot: getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null,
+      globalNodeModulesRoot: cachedGlobalNodeModulesRoot,
     };
   }
 
   const ownershipCandidates = ['pnpm', 'yarn', 'bun', 'npm'];
-  for (const candidate of ownershipCandidates) {
+  for (const candidate of ownershipCandidates.slice(0, MAX_PACKAGE_MANAGER_OWNERSHIP_CHECKS)) {
     if (packageManagerOwnsCurrentInstall(candidate)) {
       cachedDetectedPm = candidate;
+      cacheCurrentDetection('global-root-owner');
       return {
         packageManager: cachedDetectedPm,
         reason: 'global-root-owner',
         packagePath: getCurrentPackagePath(),
         packageManagerCommand: resolvePackageManagerCommand(cachedDetectedPm),
-        globalNodeModulesRoot: getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null,
+        globalNodeModulesRoot: cachedGlobalNodeModulesRoot,
       };
     }
   }
@@ -478,24 +495,26 @@ export function detectPackageManagerDetails() {
   // Validate the hint against package visibility, but only after ownership checks failed.
   if (hintedPm && isCommandAvailable(resolvePackageManagerCommand(hintedPm)) && isPackageInstalledWith(hintedPm)) {
     cachedDetectedPm = hintedPm;
+    cacheCurrentDetection('hinted-visible-install');
     return {
       packageManager: cachedDetectedPm,
       reason: 'hinted-visible-install',
       packagePath: getCurrentPackagePath(),
       packageManagerCommand: resolvePackageManagerCommand(cachedDetectedPm),
-      globalNodeModulesRoot: getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null,
+      globalNodeModulesRoot: cachedGlobalNodeModulesRoot,
     };
   }
 
   const runtimePm = detectPackageManagerFromRuntimePath(process.execPath);
   if (runtimePm && isCommandAvailable(resolvePackageManagerCommand(runtimePm)) && isPackageInstalledWith(runtimePm)) {
     cachedDetectedPm = runtimePm;
+    cacheCurrentDetection('runtime-visible-install');
     return {
       packageManager: cachedDetectedPm,
       reason: 'runtime-visible-install',
       packagePath: getCurrentPackagePath(),
       packageManagerCommand: resolvePackageManagerCommand(cachedDetectedPm),
-      globalNodeModulesRoot: getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null,
+      globalNodeModulesRoot: cachedGlobalNodeModulesRoot,
     };
   }
 
@@ -512,24 +531,26 @@ export function detectPackageManagerDetails() {
       // Verify this PM actually has the package installed globally
       if (isPackageInstalledWith(name)) {
         cachedDetectedPm = name;
+        cacheCurrentDetection('last-resort-visible-install');
         return {
           packageManager: cachedDetectedPm,
           reason: 'last-resort-visible-install',
           packagePath: getCurrentPackagePath(),
           packageManagerCommand: resolvePackageManagerCommand(cachedDetectedPm),
-          globalNodeModulesRoot: getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null,
+          globalNodeModulesRoot: cachedGlobalNodeModulesRoot,
         };
       }
     }
   }
 
   cachedDetectedPm = 'npm';
+  cacheCurrentDetection('default-fallback');
   return {
     packageManager: cachedDetectedPm,
     reason: 'default-fallback',
     packagePath: getCurrentPackagePath(),
     packageManagerCommand: resolvePackageManagerCommand(cachedDetectedPm),
-    globalNodeModulesRoot: getGlobalNodeModulesRoots(cachedDetectedPm)[0] || null,
+    globalNodeModulesRoot: cachedGlobalNodeModulesRoot,
   };
 }
 

--- a/packages/web/server/lib/package-manager.test.js
+++ b/packages/web/server/lib/package-manager.test.js
@@ -9,6 +9,7 @@ vi.mock('node:child_process', () => ({
 const {
   checkForUpdates,
   detectPackageManager,
+  detectPackageManagerDetails,
   executeUpdate,
   getCurrentVersion,
 } = await import('./package-manager.js');
@@ -329,5 +330,76 @@ describe('CLI update exports', () => {
   it('exports package-manager helpers used by the update command', () => {
     expect(typeof detectPackageManager).toBe('function');
     expect(typeof executeUpdate).toBe('function');
+  });
+});
+
+describe('detectPackageManagerDetails', () => {
+  // Each test re-imports a fresh module instance (resetting the in-module
+  // detection cache) together with a fresh child_process mock, so the
+  // spawnSync behavior can be controlled without disturbing other tests.
+
+  it('falls back to default-fallback without probing every package manager when nothing owns the install', async () => {
+    vi.resetModules();
+    const { spawnSync: freshSpawnSync } = await import('node:child_process');
+    const { detectPackageManagerDetails: freshDetect } = await import('./package-manager.js');
+
+    // Every PM binary exists, but none of the global queries reveals an
+    // openchamber install (no ownership match, no `list -g` match).
+    freshSpawnSync.mockImplementation((command, args) => {
+      if (Array.isArray(args) && args.includes('--version')) {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (Array.isArray(args) && args.includes('-g')) {
+        return { status: 0, stdout: '/tmp/global-bin', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const details = freshDetect();
+
+    expect(details.reason).toBe('default-fallback');
+    expect(details.packageManager).toBe('npm');
+
+    // The ownership-check cap stops the per-PM `bin -g`/`root -g` storm before
+    // bun is ever ownership-probed (only the first two candidates are checked).
+    const bunOwnershipProbes = freshSpawnSync.mock.calls.filter(
+      ([command, args]) => command === 'bun' && Array.isArray(args) && args[0] === 'pm' && args[1] === 'bin',
+    );
+    expect(bunOwnershipProbes).toHaveLength(0);
+
+    // A second call is served from the cache: no global `-g` queries are
+    // re-run (only the cheap `--version` command-resolution check), and the
+    // fallback reason is preserved instead of being reported as 'cached'.
+    const spawnCallsBeforeSecondCall = freshSpawnSync.mock.calls.length;
+    const cached = freshDetect();
+    const callsDuringCached = freshSpawnSync.mock.calls.slice(spawnCallsBeforeSecondCall);
+    expect(cached.reason).toBe('default-fallback');
+    expect(callsDuringCached.filter(([, args]) => Array.isArray(args) && args.includes('-g'))).toHaveLength(0);
+  });
+
+  it('still detects a genuinely global npm install after the ownership-check cap', async () => {
+    vi.resetModules();
+    const { spawnSync: freshSpawnSync } = await import('node:child_process');
+    const { detectPackageManagerDetails: freshDetect } = await import('./package-manager.js');
+
+    // `npm list -g` reports the package; everything else finds nothing, so the
+    // npm-global install is only discoverable through the fallback checks.
+    freshSpawnSync.mockImplementation((command, args) => {
+      if (command === 'npm' && Array.isArray(args) && args[0] === 'list') {
+        return { status: 0, stdout: '@openchamber/web@1.2.3', stderr: '' };
+      }
+      if (Array.isArray(args) && args.includes('--version')) {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (Array.isArray(args) && args.includes('-g')) {
+        return { status: 0, stdout: '/tmp/global-bin', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const details = freshDetect();
+
+    expect(details.packageManager).toBe('npm');
+    expect(details.reason).not.toBe('default-fallback');
   });
 });


### PR DESCRIPTION
## Intent

Fixes #2391

GitHub-only issue (no Linear counterpart exists for it).

Clicking **Update** in the Web UI always timed out when openchamber was not
installed globally via a package manager (e.g. npm tarball extracted into a
deployment directory). `detectPackageManagerDetails()` ran a storm of
`spawnSync(pm, ['bin'|'root'|'prefix', '-g'])` ownership probes (4 candidates,
several spawns each, 5–10 s timeouts) and fell back to
`packageManager: 'npm'` + `reason: 'default-fallback'`; the
`POST /api/openchamber/update-install` handler then blindly ran
`npm install -g @openchamber/web@latest` — installing into an unrelated global
root — and the request died behind the reverse proxy before the update could
even start.

Behavior change: when no package manager owns the installation, the endpoint
now returns `409` with a clear manual-update message (reinstall via the
original installation method / download from the GitHub releases page) instead
of spawning a doomed `npm install -g`. The Web UI already renders non-OK
responses: it shows `data.error` inline and the terminal fallback command
(`openchamber update`) with a copy button, so no UI change was needed. When a
real package manager IS detected, the existing update path is preserved
unchanged.

## Non-goals

- No change to the CLI `openchamber update` command (`executeUpdate` /
  `getUpdateCommand`) — it keeps its existing behavior for all installs.
- No change to `GET /api/openchamber/update-check` response shape.
- PR #2670 (Fixes OPE-201, unmerged) addresses a different aspect: premature
  UI reload and silent container-mode install failures
  (`update-status.json`, spawn error handling, `waitForUpdateApplied`
  semantics). This PR is complementary and does not overlap its files
  (it does not touch `UpdateDialog.tsx`); both can land independently.
- Detection still probes the first two ownership candidates and still runs the
  hint/runtime-path/last-resort visibility checks; only the unbounded
  all-four-candidates ownership storm is capped.

## Affected surfaces

- `packages/web/server/lib/package-manager.js` (server JS, not TS):
  - New `MAX_PACKAGE_MANAGER_OWNERSHIP_CHECKS = 2` cap on the
    `packageManagerOwnsCurrentInstall` loop. Genuinely-global installs are
    unaffected: npm/pnpm/bun-global installs are first matched by the
    install-path owner check (current package path contains
    `/node_modules/`, `/.pnpm/`, `/.bun/`, etc.), which is not capped, and
    otherwise resolve to the same package manager through the
    hint/runtime-path/last-resort checks (`npm list -g` etc.).
  - Detection result now cached as `{ packageManager, reason,
    globalNodeModulesRoot }`; the cached call no longer re-runs the
    `spawnSync` global-root probes and reports the original reason (e.g.
    `default-fallback`) instead of the opaque `cached`.
- `packages/web/server/lib/opencode/openchamber-routes.js`: `update-install`
  returns `409 { error }` for `reason === 'default-fallback'` before any
  update command is built or spawned, including before the container branch,
  so container/tarball installs get the same clear error instead of a doomed
  background spawn.
- `packages/web/server/lib/opencode/openchamber-routes.test.js` (new) and
  `packages/web/server/lib/package-manager.test.js`: focused tests.
- `packages/web/server/lib/opencode/DOCUMENTATION.md`: updated the
  `update-install` contract note (400 / 409 / 200 semantics).
- Unaffected runtimes: Electron short-circuits detection
  (`desktop-runtime`) and never calls this route from its UI; VS Code and
  mobile surfaces do not use the web update-install endpoint.
- Persisted/external contract: none — no files, IDs, or settings change; the
  `reason` field is only used for logging/decisions inside the server.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md (root) | Always-on rules for OpenChamber source changes | Kept changes minimal and in owning modules; server-side correctness enforced in core logic (route guard), not UI; docs updated for the changed route contract; no secrets/dependencies added. |
| `openchamber-change-discipline` | Any source change | Smallest complete change; existing behavior (genuine-PM update path, CLI path) preserved; validation at the narrowest level covering the real risk (node --check + focused tests + package type-check/lint). |
| `ui-api-decoupling` | Server API routes are in scope; route registration/consumers | No SDK bypass; the OpenChamber route keeps returning JSON errors that `UpdateDialog.installWebUpdate()` already parses (`data.error`); verified the UI consumer before deciding no UI change was needed. |
| `packages/web/server/lib/opencode/DOCUMENTATION.md` | Nearest owning docs for the changed module | Updated the `update-install` contract description. |
| `packages/web/README.md` + package.json scripts | Command source of truth for validation | Used `bun run type-check` / `bun run lint` / `bunx vitest run`; lint covers `src/**` TS only, so changed server JS was validated with `node --check` + vitest. |

## Validation

| Check | Result |
|---|---|
| `node --check` on all 4 changed/new JS files | PASS (all four) |
| `bunx vitest run server/lib/package-manager.test.js server/lib/opencode/openchamber-routes.test.js` | PASS — 20/20 tests (18 existing + 2 new detection tests + 4 new route tests; new tests cover: default-fallback → 409 + no spawn, container + default-fallback → 409, genuine PM → 200 + spawn, bounded ownership probes, cached call re-runs no `-g` queries, genuine npm install still detected) |
| `bunx vitest run` (full web suite) | 1076 passed, 2 skipped, 2 failed — both failures (`bin/cli.test.js` LAN auth, `src/api/git.test.ts` bulk stage) reproduced identically with the changes stashed; pre-existing environment failures, unrelated |
| `bun run type-check` (web) | PASS (tsc --noEmit, no output) |
| `bun run lint` (web) | PASS (eslint on src TS; no issues) |
| `bun run dead-code` | Not run — no exports, entrypoints, or import shapes changed (new files are tests; `detectPackageManagerDetails` was already exported) |
| Real npm-registry update run | NOT verified — requires a live non-global installation behind a reverse proxy; behavior covered by unit tests only |

## Visual evidence

![Update surface](https://raw.githubusercontent.com/makeittech/openchamber/evidence/PR-2700/screens/update-surface.png)

**Update surface** (live build from this branch): the home page shows the
"Update available" banner with **Update** and **Dismiss** buttons. The fix
affects what happens when **Update** is clicked on a non-global install
(tarball, Docker, or manual install without a recognized package manager).

**API evidence** (verified against the running build at port 3912):

| Call | Response | Meaning |
|---|---|---|
| `GET /api/openchamber/update-check` | `{"available":false,"version":"1.18.1","currentVersion":"1.18.1"}` | Current build is latest — no update shown (update-check must report `available: true` for the dialog to appear) |
| `POST /api/openchamber/update-install` (no update available) | `{"error":"No update available"}` (HTTP 400) | Pre-check blocks install before reaching the PM code — standard early exit |
| `POST /api/openchamber/update-install` (hypothetical 409 path) | N/A here — requires `available: true` + `pmDetails.reason === 'default-fallback'` | Route test: 5/5 pass, confirms 409 for default-fallback, 200 for real PM |

The 409 error renders in the **UpdateDialog status-error box** (the same
component that shows "Update failed (exit N)" — see `webUpdateStatus.ts`
which parses `data.error` from the install response). The 409 message
("Automatic update is not available for this installation…") replaces the
spinner and shows the terminal fallback command with the GitHub releases link.

**Why no 409 dialog screenshot**: the update dialog is gated by
`GET /api/openchamber/update-check` returning `available: true`. In this
build (v1.18.1 = latest published version), the registry reports no newer
version, so `available: false` → dialog never opens → 409 never reached.
Capturing the 409 state would require deploying this build as an older
version behind the published one, which cannot be done in this environment.
The error path is fully verified by the route tests (5/5).

## Risks and failure behavior

- **False default-fallback** (a genuine global install that detection fails
  to attribute, e.g. an install with a custom npm prefix): the user now gets
  a clear manual-update message instead of a silent
  `npm install -g` into the wrong prefix. Strictly safer than today; the
  GitHub releases link in the dialog footer gives a concrete path forward.
- **Detection timing**: the storm is bounded (ownership loop capped at 2
  candidates, cached calls re-run no `-g` probes), so the request no longer
  exceeds proxy timeouts for non-global installs; the hint/last-resort
  visibility checks are unchanged, so genuinely-global installs still
  resolve to the same package manager and update command.
- **No partial state**: the 409 path returns before any file, log, child
  process, or restart is created — nothing to roll back.
- **Cache**: the cached-detection change only affects the `reason`/root
  fields of subsequent calls in the same process; the PM selection value is
  unchanged, and the `cached` reason string is retained as a fallback.

