### PR TITLE
fix: wait for worktree bootstrap before prompt dispatch; resolve session directory for send/fork

### DIFF
--- a/packages/web/server/lib/openchamber-control/service.js
+++ b/packages/web/server/lib/openchamber-control/service.js
@@ -240,10 +240,32 @@ export const createOpenChamberControlService = (dependencies) => {
     }
   };
 
+  // session.send/fork default the directory to the caller's context directory,
+  // which is wrong for sessions living in other worktrees: prompt_async then
+  // targets an instance that does not hold the session and the run dies with
+  // UnknownError. Resolve the target session's directory from the global
+  // session list when the caller did not scope explicitly.
+  const resolveSessionDirectory = async (sessionID) => {
+    try {
+      const client = await getClient();
+      const response = await client.experimental?.session?.list?.({});
+      const sessions = Array.isArray(response?.data) ? response.data : [];
+      const session = sessions.find((item) => item?.id === sessionID);
+      return asNonEmptyString(session?.directory) || null;
+    } catch {
+      return null;
+    }
+  };
+
   const executeSessionAction = async (action, input, contextDirectory, signal) => {
     if (input.timeout !== undefined && input.wait !== true) throw new OpenChamberControlError('timeout requires wait', 400);
     if (input.lastAssistant === true && input.wait !== true) throw new OpenChamberControlError('lastAssistant requires wait', 400);
-    const directory = asNonEmptyString(input.directory) || (!input.projectId ? asNonEmptyString(contextDirectory) : null);
+    const sessionID = asNonEmptyString(input.sessionId);
+    let directory = asNonEmptyString(input.directory) || (!input.projectId ? asNonEmptyString(contextDirectory) : null);
+    if (sessionID && action !== 'session.create' && !asNonEmptyString(input.directory) && !input.projectId) {
+      const resolvedSessionDirectory = await resolveSessionDirectory(sessionID);
+      if (resolvedSessionDirectory) directory = resolvedSessionDirectory;
+    }
     const payload = {
       ...(directory ? { directory } : {}),
       ...(asNonEmptyString(input.projectId) ? { projectId: input.projectId.trim() } : {}),
@@ -262,7 +284,6 @@ export const createOpenChamberControlService = (dependencies) => {
       ...(typeof input.setUpstream === 'boolean' ? { setUpstream: input.setUpstream } : {}),
       ...(asNonEmptyString(input.messageId) ? { messageId: input.messageId.trim() } : {}),
     };
-    const sessionID = asNonEmptyString(input.sessionId);
     const startedAt = now();
     let result;
     if (action === 'session.create') {

--- a/packages/web/server/lib/openchamber-control/service.test.js
+++ b/packages/web/server/lib/openchamber-control/service.test.js
@@ -132,6 +132,43 @@ describe('OpenChamber control service', () => {
     expect(sessionService[method]).toHaveBeenCalledWith('ses_1', { directory: '/repo', prompt: 'Continue' });
   });
 
+  it('resolves the target session directory from the global session list when send omits it', async () => {
+    const { service, sessionService, client } = createService({
+      createClient: () => ({
+        ...client,
+        experimental: {
+          session: {
+            list: vi.fn(async () => ({
+              data: [
+                { id: 'ses_other', directory: '/repo/worktrees/other' },
+                { id: 'ses_target', directory: '/repo/worktrees/target' },
+              ],
+            })),
+          },
+        },
+      }),
+    });
+    sessionService.send.mockResolvedValue({ sessionId: 'ses_target', directory: '/repo/worktrees/target', promptDispatched: true });
+
+    await service.execute('session.send', { sessionId: 'ses_target', prompt: 'Continue' }, '/repo');
+
+    expect(sessionService.send).toHaveBeenCalledWith('ses_target', { directory: '/repo/worktrees/target', prompt: 'Continue' });
+  });
+
+  it('falls back to the context directory when the session is not in the global list', async () => {
+    const { service, sessionService, client } = createService({
+      createClient: () => ({
+        ...client,
+        experimental: { session: { list: vi.fn(async () => ({ data: [] })) } },
+      }),
+    });
+    sessionService.send.mockResolvedValue({ sessionId: 'ses_unknown', directory: '/repo', promptDispatched: true });
+
+    await service.execute('session.send', { sessionId: 'ses_unknown', prompt: 'Continue' }, '/repo');
+
+    expect(sessionService.send).toHaveBeenCalledWith('ses_unknown', { directory: '/repo', prompt: 'Continue' });
+  });
+
   it('waits past initial idle until a completed assistant result appears', async () => {
     let timestamp = 1000;
     const { service, client, sessionService } = createService({

--- a/packages/web/server/lib/openchamber-sessions/routes.js
+++ b/packages/web/server/lib/openchamber-sessions/routes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { createOpencodeClient } from '@opencode-ai/sdk/v2';
-import { createWorktree } from '../git/index.js';
+import { createWorktree, getWorktreeBootstrapStatus } from '../git/index.js';
 import { expandSnippets } from '../opencode/snippets.js';
 import { expandCommandGoalObjective, parseScheduledCommandPrompt } from '../scheduled-tasks/runtime.js';
 import { buildGoalIntroText, createSessionGoal } from '../session-goal/create.js';
@@ -274,6 +274,31 @@ const resolveRequestedDirectory = async ({ payload, readSettingsFromDiskMigrated
 
 const PROMPT_LANDED_TIMEOUT_MS = 5_000;
 const PROMPT_LANDED_POLL_MS = 150;
+
+// createWorktree returns while the worktree is still being populated in the
+// background (git reset --hard after a --no-checkout add). Dispatching a
+// prompt into a half-populated directory makes opencode's run die with
+// UnknownError (agent and config files are not there yet), so wait until the
+// bootstrap reaches git-ready (population done) or fails before creating the
+// session and dispatching.
+const WORKTREE_BOOTSTRAP_TIMEOUT_MS = 60_000;
+const WORKTREE_BOOTSTRAP_POLL_MS = 150;
+
+const waitForWorktreeBootstrapReady = async ({ directory }) => {
+  const deadline = Date.now() + WORKTREE_BOOTSTRAP_TIMEOUT_MS;
+  for (;;) {
+    const status = await getWorktreeBootstrapStatus(directory);
+    if (status?.status === 'failed') {
+      throw new OpenChamberControlError(`Worktree bootstrap failed: ${status.error || 'unknown error'}`, 500);
+    }
+    const phase = status?.phase;
+    if (status?.status === 'ready' || phase === 'git-ready' || phase === 'setup-ready') return;
+    if (Date.now() >= deadline) {
+      throw new OpenChamberControlError('Timed out waiting for the worktree bootstrap', 500);
+    }
+    await new Promise((resolve) => setTimeout(resolve, WORKTREE_BOOTSTRAP_POLL_MS));
+  }
+};
 
 const latestUserMessageID = async ({ client, sessionID, directory }) => {
   let response;
@@ -579,6 +604,7 @@ export const createOpenChamberSessionService = (dependencies) => {
     if (worktreeInput) {
       worktree = await createWorktree(resolvedDirectory.directory, worktreeInput);
       sessionDirectory = worktree.path;
+      await waitForWorktreeBootstrapReady({ directory: sessionDirectory });
     }
 
     const baseUrl = buildOpenCodeUrl('/', '').replace(/\/$/, '');

--- a/packages/web/server/lib/openchamber-sessions/routes.test.js
+++ b/packages/web/server/lib/openchamber-sessions/routes.test.js
@@ -8,6 +8,12 @@ const createWorktreeMock = vi.fn(async () => ({
   branch: 'openchamber/side-task',
   path: '/repo/worktrees/side-task',
 }));
+const getWorktreeBootstrapStatusMock = vi.fn(async () => ({
+  status: 'ready',
+  phase: 'setup-ready',
+  error: null,
+  updatedAt: Date.now(),
+}));
 const sessionCreateMock = vi.fn(async () => ({ data: { id: 'ses_123' } }));
 const sessionForkMock = vi.fn(async () => ({ data: { id: 'ses_fork', title: 'Forked session' } }));
 const sessionMessagesMock = vi.fn(async () => ({ data: [] }));
@@ -61,6 +67,7 @@ const selectionInputResponse = (url) => {
 const sessionCommandMock = vi.fn(async () => ({ data: {} }));
 const commandListMock = vi.fn(async () => ({ data: [] }));
 globalThis.__openchamberCreateWorktreeMock = createWorktreeMock;
+globalThis.__openchamberGetWorktreeBootstrapStatusMock = getWorktreeBootstrapStatusMock;
 
 let registerOpenChamberSessionRoutes;
 
@@ -80,6 +87,7 @@ vi.mock('@opencode-ai/sdk/v2', () => ({
 
 vi.mock('../git/index.js', () => ({
   createWorktree: (...args) => globalThis.__openchamberCreateWorktreeMock(...args),
+  getWorktreeBootstrapStatus: (...args) => globalThis.__openchamberGetWorktreeBootstrapStatusMock(...args),
 }));
 
 const createApp = (overrides = {}, options = {}) => {
@@ -107,6 +115,13 @@ describe('openchamber session routes', () => {
 
   beforeEach(() => {
     createWorktreeMock.mockClear();
+    getWorktreeBootstrapStatusMock.mockClear();
+    getWorktreeBootstrapStatusMock.mockImplementation(async () => ({
+      status: 'ready',
+      phase: 'setup-ready',
+      error: null,
+      updatedAt: Date.now(),
+    }));
     sessionCreateMock.mockClear();
     sessionForkMock.mockClear();
     existingSessionMessages = [];
@@ -361,6 +376,74 @@ describe('openchamber session routes', () => {
         'http://opencode.test/session/ses_123/prompt_async?directory=%2Frepo%2Fworktrees%2Fside-task',
         expect.objectContaining({ method: 'POST' }),
       );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('waits for the worktree bootstrap to complete before creating the session', async () => {
+    const statuses = [
+      { status: 'pending', phase: 'directory-created', error: null, updatedAt: 1 },
+      { status: 'pending', phase: 'git-ready', error: null, updatedAt: 2 },
+      { status: 'ready', phase: 'setup-ready', error: null, updatedAt: 3 },
+    ];
+    getWorktreeBootstrapStatusMock.mockImplementation(async () => statuses.shift() || statuses[statuses.length - 1]);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).includes('/prompt_async')) {
+        return { ok: true, text: async () => '' };
+      }
+      return { ok: true, json: async () => ({ id: 'ses_123' }) };
+    });
+    try {
+      const { app } = createApp();
+      const response = await request(app)
+        .post('/api/openchamber/sessions')
+        .send({
+          directory: '/repo/app',
+          worktree: { name: 'side-task' },
+          prompt: 'Run this',
+          model: 'openai/gpt-5.5',
+        })
+        .expect(200);
+
+      expect(response.body.promptDispatched).toBe(true);
+      const sessionCreateCalls = globalThis.fetch.mock.calls.filter(([url]) => String(url).includes('/session?directory'));
+      const promptCalls = globalThis.fetch.mock.calls.filter(([url]) => String(url).includes('/prompt_async'));
+      expect(sessionCreateCalls.length).toBeGreaterThanOrEqual(1);
+      expect(promptCalls.length).toBeGreaterThanOrEqual(1);
+      const createIndex = globalThis.fetch.mock.calls.indexOf(sessionCreateCalls[0]);
+      const promptIndex = globalThis.fetch.mock.calls.indexOf(promptCalls[0]);
+      expect(getWorktreeBootstrapStatusMock).toHaveBeenCalled();
+      expect(createIndex).toBeGreaterThan(-1);
+      expect(promptIndex).toBeGreaterThan(createIndex);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('fails the create when the worktree bootstrap failed', async () => {
+    getWorktreeBootstrapStatusMock.mockImplementation(async () => ({
+      status: 'failed',
+      phase: 'directory-created',
+      error: 'branch already exists',
+      updatedAt: Date.now(),
+    }));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url) => ({ ok: true, json: async () => ({ id: 'ses_123' }) }));
+    try {
+      const { app } = createApp();
+      await request(app)
+        .post('/api/openchamber/sessions')
+        .send({
+          directory: '/repo/app',
+          worktree: { name: 'side-task' },
+          prompt: 'Run this',
+          model: 'openai/gpt-5.5',
+        })
+        .expect(500, { error: 'Worktree bootstrap failed: branch already exists' });
+      const promptCalls = globalThis.fetch.mock.calls.filter(([url]) => String(url).includes('/prompt_async'));
+      expect(promptCalls.length).toBe(0);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Intent

Two related prompt-dispatch races for sessions created or targeted through the agent tool's worktree flow:

1. `createWorktree` returns while the worktree directory is still being populated in the background (git reset after a `--no-checkout` add). A prompt dispatched into a half-populated directory makes opencode's run die with `UnknownError` because agent/config files are not there yet. The session routes now wait for the worktree bootstrap to reach `git-ready`/`setup-ready` (or `ready`) before creating the session and dispatching the prompt, failing the request cleanly when bootstrap failed or exceeded a 60s deadline.
2. `session.send`/`session.fork` default the target directory to the caller's context directory, which is wrong for sessions living in other worktrees: `prompt_async` then targets an instance that does not hold the session and the run dies with `UnknownError`. The control service now resolves the target session's directory from the global session list when the caller did not scope explicitly, with a fallback to the previous context-directory behavior when the session is not found.

## Non-goals

- No change to how worktrees are created or bootstrapped (`createWorktree`/`getWorktreeBootstrapStatus` untouched).
- No change to session behavior when the caller supplies an explicit `directory` or `projectId`.
- No UI, CLI, or SDK surface changes; server API shape unchanged.

## Affected surfaces

- `packages/web` server only: `openchamber-control/service.js` (session send/fork dispatch) and `openchamber-sessions/routes.js` (worktree session create + prompt dispatch), plus their vitest suites.
- Runtime: the OpenChamber server API, which desktop, VS Code, mobile, and web surfaces all reach through `RuntimeAPIs`. Behavior is intentionally identical across those surfaces since it is server-side.
- Persisted/external contracts: none. No schema, config, or SDK changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Any source change to packages/web | Change is focused on the two server modules; tests added alongside; no dependencies or exports touched. |
| `sync-state-invariants` | Worktree bootstrap readiness and session-directory resolution are authoritative-state waits | Polls `getWorktreeBootstrapStatus` until ready/failed instead of guessing a fixed delay; failure/timeout are explicit 500 errors, not silent dispatches. Directory resolution falls back to the previous context-directory behavior when the authoritative session list lacks the session, and only replaces the directory when authoritative state exists. |
| `ui-api-decoupling` | Server API routes used by shared UI control surfaces | Behavior is implemented server-side in the owning server modules; no new client fetch/auth/URL handling introduced. |

## Validation

| Check | Result |
|---|---|
| `bun run test -- openchamber-control/service openchamber-sessions/routes` (packages/web, vitest) | 2 files passed, 38 tests passed, including the 4 new tests (directory resolution x2, bootstrap wait ordering, bootstrap-failure 500 with no prompt dispatch) |
| Full workspace suite / lint / type-check | Not run; change is server JS without type-check coverage in this package |
| Manual live-server reproduction | Not verified; tests cover the dispatch ordering and failure paths via mocked SDK/git calls |

## Visual evidence

No user-visible change. The diff only affects server-side dispatch ordering and error responses; rendered UI, themes, and interactions are untouched.

## Risks and failure behavior

- `resolveSessionDirectory` adds one `session.list` call per send/fork without an explicit directory/projectId. On failure it returns `null` and the previous behavior applies; it can never erase an explicit caller scope.
- Bootstrap wait has a 60s deadline and polls every 150ms; a failed bootstrap returns a 500 with the bootstrap error instead of dispatching into a broken directory. The worktree directory itself is not cleaned up on failure — same as before this change, since `createWorktree` already owned that lifecycle.
- Sessions created without a worktree are unaffected: the wait only runs on the worktree-creation path.
- The fallback in the second scenario preserves legacy behavior exactly, so no existing callers regress when the session list is unavailable or the session is unknown.
