### PR TITLE
fix(ui): prevent code line numbers from wrapping

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1399,6 +1399,7 @@ html:not(.dark) .chat-scroll {
   font-variant-numeric: tabular-nums;
   text-align: right;
   user-select: none;
+  white-space: nowrap;
 }
 
 .markdown-content [data-md-code-line-content] {


### PR DESCRIPTION
## Intent

<!-- What user or maintainer problem does this solve? What behavior changes? -->

Prevent Markdown code block line numbers with three or more digits from wrapping inside the fixed-width line-number column. Line numbers now remain on one line so code rows keep a consistent height and stay aligned with their content.

## Non-goals

<!-- What nearby behavior is intentionally outside this PR? Write "None" only when the scope is unambiguous. -->

- This PR does not widen the existing `2rem` line-number column.
- This PR does not change code block DOM generation, syntax highlighting, or code wrapping behavior.

## Affected surfaces

<!-- Name affected packages, runtimes, user-visible states, and persisted/external contracts. Explain why an apparently applicable runtime is unaffected. -->

- `packages/ui`: shared Markdown code block styling.
- Web, Electron, VS Code, hosted mobile, and Capacitor mobile consume the shared UI stylesheet and receive the same layout fix.
- The visible state affected is code blocks with line numbers of three or more digits, at both desktop and narrow viewport widths.
- No persisted data, external API, runtime bridge, or transport contract changes.

## Repository guidance

<!-- List the AGENTS.md rules, matching project skills, required skill references, and nearest README/DOCUMENTATION.md files used for this change. Explain why each applies and the important constraints you followed. Do not merely list filenames. -->

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes shared UI source styling. | Keeps the fix to one CSS declaration, preserves existing layout behavior, and uses focused package validation plus browser verification. |
| `theme-system` | The change affects a shared UI visual state. | Reuses the existing semantic border and text styling and introduces no colors, tokens, components, icons, or animations. |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | The affected code block is rendered in chat Markdown. | Preserves the documented Markdown rendering and code block structure; only line-number wrapping changes. |
| `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` | This is a user-visible pull request. | Documents intent, non-goals, affected runtimes, exact validation, visual evidence requirements, and rollback behavior. |

## Validation

<!-- Report exact commands/manual checks and results. State what was not verified. Do not claim runtime behavior from type-check/lint alone. -->

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/markdown/markdownCore.test.ts` | Passed: 2 tests, 0 failures. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bun test ./packages/ui/src/components/chat/markdown/decorate.test.ts` | Not run: this file does not exist in the current repository, so Bun reported no matching test files. |
| Ego-browser desktop check with an agent-generated 200-line code block | Before the fix, line `99` was `24px` high while lines `100`, `199`, and `200` were `48px` high with computed `white-space: pre-wrap`. After the fix, all sampled rows were `24px` high with computed `white-space: nowrap` and a `12px` gap before code content. |
| Ego-browser narrow viewport check | Temporarily measured `999` and `1000` as line-number labels. Each produced one text layout rectangle and neither overlapped the code content. |
| Dark theme visual check | Not run. The change affects whitespace layout only and does not modify colors, but visual evidence was captured in the light theme. |

## Visual evidence

<!-- User-visible change: attach current before/after screenshots or recordings for the affected desktop/mobile, narrow/wide, theme, and interaction states. No visible change: explain concretely why the diff cannot affect rendered behavior. -->

### Before

<!-- Upload openchamber-code-line-number-before.png here. -->
<img width="3568" height="1894" alt="openchamber-code-line-number-before" src="https://github.com/user-attachments/assets/3f852035-5b82-4cfd-8c8a-360592fb62da" />

### After

<!-- Upload openchamber-code-line-number-after.png here. -->

<img width="3568" height="1894" alt="openchamber-code-line-number-after" src="https://github.com/user-attachments/assets/2abd0dab-cb41-41fe-98b0-2aa4133dad07" />


## Risks and failure behavior

<!-- Cover relevant failure, rollback, cleanup, compatibility, security, performance, data-loss, and cross-runtime concerns. State "None identified" only with a concrete reason. -->

- Long line numbers can extend left within the fixed grid column, but browser checks confirmed they remain single-line and do not overlap code content at narrow widths.
- The change does not affect persisted state, authentication, network behavior, or data integrity.
- Runtime behavior is consistent because all surfaces consume the same shared stylesheet.
- Rollback is a single-declaration removal from `[data-md-code-line-number]`.
