### PR TITLE
fix(terminal): keep default terminal tab names unique after closing tabs

### DIFF
--- a/packages/ui/src/stores/useTerminalStore.test.ts
+++ b/packages/ui/src/stores/useTerminalStore.test.ts
@@ -123,3 +123,38 @@ describe('terminal state reconciliation', () => {
     expect(useTerminalStore.getState().buffers.size).toBe(0);
   });
 });
+
+describe('default terminal tab labels', () => {
+  afterEach(() => useTerminalStore.getState().clearAll());
+
+  const labels = () =>
+    useTerminalStore.getState().getDirectoryState('/repo')!.tabs.map((tab) => tab.label);
+
+  // Regression for https://github.com/openchamber/openchamber/issues/2718
+  test('does not reuse the number of a closed tab', () => {
+    const first = setup();
+    useTerminalStore.getState().createTab('/repo');
+    expect(labels()).toEqual(['Terminal', 'Terminal 2']);
+
+    useTerminalStore.getState().closeTab('/repo', first);
+    useTerminalStore.getState().createTab('/repo');
+
+    expect(labels()).toEqual(['Terminal 2', 'Terminal 3']);
+  });
+
+  test('numbers past a user-renamed "Terminal N" label instead of duplicating it', () => {
+    const first = setup();
+    useTerminalStore.getState().setTabLabel('/repo', first, 'Terminal 5');
+    useTerminalStore.getState().createTab('/repo');
+
+    expect(labels()).toEqual(['Terminal 5', 'Terminal 6']);
+  });
+
+  test('ignores custom labels and starts over at "Terminal" when no default-labeled tabs remain', () => {
+    const first = setup();
+    useTerminalStore.getState().setTabLabel('/repo', first, 'build');
+    useTerminalStore.getState().createTab('/repo');
+
+    expect(labels()).toEqual(['build', 'Terminal']);
+  });
+});

--- a/packages/ui/src/stores/useTerminalStore.ts
+++ b/packages/ui/src/stores/useTerminalStore.ts
@@ -157,6 +157,27 @@ function normalizeDirectory(dir: string): string {
   return normalized;
 }
 
+const DEFAULT_TAB_LABEL_PATTERN = /^Terminal(?: (\d+))?$/;
+
+/**
+ * Default labels must stay unique among the directory's open tabs even after
+ * closes (#2718), so number from the highest existing "Terminal N" suffix
+ * instead of the live tab count. Labels are persisted with the tabs, so the
+ * derivation also survives reloads without a dedicated counter. User-renamed
+ * labels only participate when they match the default pattern; they are never
+ * rewritten.
+ */
+const nextDefaultTabLabel = (tabs: readonly TerminalTab[]): string => {
+  let highest = 0;
+  for (const tab of tabs) {
+    const match = DEFAULT_TAB_LABEL_PATTERN.exec(tab.label);
+    if (!match) continue;
+    const value = match[1] ? Number.parseInt(match[1], 10) : 1;
+    if (Number.isSafeInteger(value)) highest = Math.max(highest, value);
+  }
+  return highest === 0 ? 'Terminal' : `Terminal ${highest + 1}`;
+};
+
 const createEmptyTab = (id: string, label: string): TerminalTab => ({
   id,
   terminalSessionId: null,
@@ -295,8 +316,7 @@ export const useTerminalStore = create<TerminalStore>()(
             const existing = newSessions.get(key);
 
             const nextTabId = state.nextTabId + 1;
-            const labelIndex = (existing?.tabs.length ?? 0) + 1;
-            const label = `Terminal ${labelIndex}`;
+            const label = nextDefaultTabLabel(existing?.tabs ?? []);
             const tab = createEmptyTab(tabId, label);
 
             if (!existing) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fixes #2718 ("[Bug] Terminal names are not unique"). Default terminal tab names reused numbers after a tab was closed: with "Terminal" and "Terminal 2" open, closing "Terminal" and creating a new tab produced a second "Terminal 2". `createTab` derived the default label from the live open-tab count (`(existing?.tabs.length ?? 0) + 1`), which shrinks on close.

The fix derives the next default label from the highest existing `Terminal`/`Terminal N` suffix among the directory's currently open tabs (bare `Terminal` counts as 1), so the scenario above now yields "Terminal 3". When no default-pattern labels remain (all tabs user-renamed), numbering starts over at "Terminal", matching the first-tab name used by `ensureDirectory`. Because labels are persisted with the tabs, the derivation survives reloads without persisting a counter — this is the explicit persistence behavior chosen instead of a stored monotonic counter (the maintainer accepted "whatever is easier" as long as names are unique).

## Non-goals

- No change to user-initiated renaming (`setTabLabel`); custom labels are never rewritten, and labels the user renamed to `Terminal N` are numbered past, not duplicated.
- No change to `ensureDirectory` or the `closeTab` last-tab re-creation: both operate on an empty tab set where the literal `Terminal` is already unique.
- No cross-directory uniqueness; naming stays scoped per directory as before.
- No change to tab identity (`tab-<uuid>`), persistence shape, or scrollback/buffer reconciliation.

## Affected surfaces

- `packages/ui` only: `src/stores/useTerminalStore.ts` (one module-private helper + one line in `createTab`) and its test file.
- All runtimes that render the shared terminal tab strip (web, desktop, VS Code, hosted mobile, Capacitor mobile) get the corrected default naming identically, since the label is produced solely in the shared store; no runtime-specific code paths exist for tab naming.
- Persisted contract unchanged: the persisted snapshot still stores `sessions` (including labels) and `nextTabId`; previously persisted labels hydrate as-is and the next default label is derived from them, so no migration is needed.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` (root guide) | Governs skill loading, doc discovery, minimal changes, validation | Loaded matching skill and nearest docs before editing; diff limited to the owning store and its test file; no new dependencies |
| `.agents/skills/openchamber-change-discipline/SKILL.md` | Source change in `packages/ui` | Classified as local implementation + persisted-behavior touchpoint; reproduced with a failing test first; smallest complete fix; focused tests plus package-scoped type-check/lint; `dead-code` not required because no file or export/import shape changed (helper is module-private) |
| `packages/ui/src/stores/DOCUMENTATION.md` | Nearest module docs; documents `useTerminalStore` invariants | Preserved every listed invariant: output actions untouched, buffer ownership untouched, only `sessions`/`nextTabId` persisted, `partialize` projection reuse unaffected (label computation happens inside the same `set` that already replaced `sessions`); no doc update needed because no documented contract changed |

## Validation

| Check | Result |
|---|---|
| `cd packages/ui && bun test src/stores/useTerminalStore` before the fix | 11 pass, 3 fail — new regression tests reproduce the duplicate `"Terminal 2"` |
| `cd packages/ui && bun test src/stores/useTerminalStore` after the fix | 14 pass, 0 fail (all pre-existing rename/persistence/scrollback tests still pass) |
| `bun run type-check:ui` | Fails with two pre-existing `TS2554` errors in `src/sync/__tests__/session-switch-resync.test.ts`; verified byte-identical output on the unmodified base commit, so unrelated to this change; no new errors introduced |
| `bun run lint:ui` on touched files (`bunx eslint src/stores/useTerminalStore.ts src/stores/useTerminalStore.test.ts`) | Pass (exit 0) |
| `bun run dead-code` | Not run: no added/deleted/renamed files and no export/type/entrypoint/import-shape change |
| Not verified | No manual runtime (browser/Electron/VS Code/mobile) session was exercised; behavior is proven at the store level, which is the sole producer of default tab labels |

## Visual evidence

Automated headless validation only; no screenshots or recordings were captured. The visible behavior change: with tabs "Terminal" and "Terminal 2" open, closing "Terminal" and clicking new-terminal now creates a tab named "Terminal 3" instead of a second "Terminal 2". If every tab is user-renamed (no `Terminal N` labels remain), the next new tab is named "Terminal".

## Risks and failure behavior

- Naming-only change: tab identity, activation, lifecycle, buffers, and persistence shape are untouched, so no data-loss or rollback concern.
- Hydration compatibility: previously persisted labels (including old duplicates) load unchanged; the next created tab numbers past the highest existing suffix, so duplicates are not created going forward and existing ones are not silently renamed.
- Edge inputs: labels renamed to `Terminal <huge number>` are guarded by `Number.isSafeInteger` (non-safe parses are ignored); non-matching custom labels never influence numbering.
- Performance: the helper is an O(open tabs in one directory) scan executed once per tab creation — a rare user action, not a hot path.
- Minor intentional behavior change: `createTab` on a directory with no tabs now names the first tab "Terminal" (previously "Terminal 1"), aligning with `ensureDirectory`; in practice `ensureDirectory` always runs first, so this path is cosmetic.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01aa063c-5183-4ae0-b21d-67bf4767cb02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01aa063c-5183-4ae0-b21d-67bf4767cb02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

