### PR TITLE
fix(chat): do not replay entry animations for already-seen fresh messages

### DIFF
--- a/packages/ui/src/lib/messageFreshness.test.ts
+++ b/packages/ui/src/lib/messageFreshness.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { MessageFreshnessDetector } from './messageFreshness';
+
+import type { Message } from '@opencode-ai/sdk/v2';
+
+const makeAssistantMessage = (id: string, created: number): Message =>
+    ({
+        id,
+        role: 'assistant',
+        sessionID: 'session-a',
+        time: { created },
+    }) as unknown as Message;
+
+describe('MessageFreshnessDetector.shouldAnimateMessage', () => {
+    let detector: MessageFreshnessDetector;
+
+    beforeEach(() => {
+        detector = MessageFreshnessDetector.getInstance();
+        detector.clearAll();
+    });
+
+    test('fresh message animates once and is recorded as seen', () => {
+        detector.recordSessionStart('session-a');
+        const message = makeAssistantMessage('msg-fresh', Date.now());
+
+        expect(detector.shouldAnimateMessage(message, 'session-a')).toBe(true);
+        expect(detector.hasBeenAnimated('msg-fresh')).toBe(true);
+    });
+
+    test('regression #2124: fresh message does not re-animate when returning to the session', () => {
+        detector.recordSessionStart('session-a');
+        const message = makeAssistantMessage('msg-fresh', Date.now());
+
+        // First visit: the message is fresh and animates.
+        expect(detector.shouldAnimateMessage(message, 'session-a')).toBe(true);
+
+        // User switches away and back; ChatViewport remounts and re-evaluates
+        // before recordSessionStart runs again, so the old session start time
+        // is still in effect. The message must not animate a second time.
+        expect(detector.shouldAnimateMessage(message, 'session-a')).toBe(false);
+    });
+
+    test('stale history message never animates and is recorded as seen', () => {
+        detector.recordSessionStart('session-a');
+        const message = makeAssistantMessage('msg-old', Date.now() - 60_000);
+
+        expect(detector.shouldAnimateMessage(message, 'session-a')).toBe(false);
+        expect(detector.hasBeenAnimated('msg-old')).toBe(true);
+        expect(detector.shouldAnimateMessage(message, 'session-a')).toBe(false);
+    });
+
+    test('message evaluated without a recorded session start does not animate and is recorded', () => {
+        const message = makeAssistantMessage('msg-no-session', Date.now());
+
+        expect(detector.shouldAnimateMessage(message, 'session-a')).toBe(false);
+        expect(detector.hasBeenAnimated('msg-no-session')).toBe(true);
+
+        // Recording the session start afterwards must not resurrect the animation.
+        detector.recordSessionStart('session-a');
+        expect(detector.shouldAnimateMessage(message, 'session-a')).toBe(false);
+    });
+
+    test('non-assistant messages never animate', () => {
+        detector.recordSessionStart('session-a');
+        const message = {
+            id: 'msg-user',
+            role: 'user',
+            sessionID: 'session-a',
+            time: { created: Date.now() },
+        } as unknown as Message;
+
+        expect(detector.shouldAnimateMessage(message, 'session-a')).toBe(false);
+    });
+
+    test('a new fresh message still animates after older fresh messages were seen', () => {
+        detector.recordSessionStart('session-a');
+        const first = makeAssistantMessage('msg-first', Date.now());
+        const second = makeAssistantMessage('msg-second', Date.now());
+
+        expect(detector.shouldAnimateMessage(first, 'session-a')).toBe(true);
+        expect(detector.shouldAnimateMessage(second, 'session-a')).toBe(true);
+        expect(detector.shouldAnimateMessage(second, 'session-a')).toBe(false);
+    });
+});

--- a/packages/ui/src/lib/messageFreshness.ts
+++ b/packages/ui/src/lib/messageFreshness.ts
@@ -44,10 +44,13 @@ export class MessageFreshnessDetector {
 
         const isFresh = message.time.created > (sessionStartTime - 5000);
 
-        if (!isFresh) {
-            this.seenMessageIds.add(message.id);
-            this.messageCreationTimes.set(message.id, message.time.created);
-        }
+        // Record fresh messages too so they animate at most once per detector
+        // lifetime. The detector is a module singleton that outlives ChatViewport
+        // remounts; without this, switching away and back re-evaluates the same
+        // message against the stale session start time (recordSessionStart runs
+        // in an effect after the first render) and replays the entry animation.
+        this.seenMessageIds.add(message.id);
+        this.messageCreationTimes.set(message.id, message.time.created);
 
         return isFresh;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fixes #2124. Switching away from a session and back re-played the entry animation of assistant messages the user had already seen, which is disorienting when monitoring many sessions. After this change, a message's entry animation plays at most once: `MessageFreshnessDetector.shouldAnimateMessage()` now records every evaluated message (fresh and stale) in `seenMessageIds`/`messageCreationTimes`, so the singleton's seen-set — which outlives `ChatViewport` remounts (`key={currentSessionId}`) — suppresses replays even though the memo in `ChatMessage` evaluates before `recordSessionStart` re-runs in `useChatAutoFollow`'s session-change effect.

## Non-goals

- User-message send animation (`shouldAnimateUserMessage` / `animateUserOnMount` in `MessageList`), which uses a separate per-session mechanism and is not affected by this bug.
- Streaming text/tool reveal animation, which is gated by `streamPhase`, not the freshness detector.
- The per-mount `hasEverStreamedRef` reset in `ChatMessage.tsx`; it remains a per-mount guard because the singleton detector now provides cross-mount protection.
- The pre-existing type errors in `src/sync/__tests__/session-switch-resync.test.ts` and the 5-second freshness window heuristic itself.

## Affected surfaces

- Package: `packages/ui` only (`src/lib/messageFreshness.ts` + new test `src/lib/messageFreshness.test.ts`).
- All runtimes that render shared chat UI (web, desktop, VS Code, hosted mobile, Capacitor mobile) inherit the fix identically because the detector is runtime-agnostic shared UI state; no runtime-specific branches are involved.
- No persisted data, routes, exported API shapes, or external contracts change. `shouldAnimateMessage`'s signature and return semantics for first evaluation are unchanged; only repeat evaluations of an already-evaluated message now return false.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` correctness invariants ("prefer authoritative state over heuristics", "scope temporary fallbacks narrowly") | The replay came from a stale session-start heuristic re-evaluating on remount | The fix records authoritative "already animated" state at the layer that persists across remounts (module singleton), instead of adding another per-mount heuristic |
| `.agents/skills/openchamber-change-discipline/SKILL.md` (local implementation risk) | Executable source change in one package | Smallest complete change (one branch of one method), no drive-by refactors, no new dependencies; focused tests plus package-scoped type-check and lint; `bun run dead-code` run because a test file was added |
| `.agents/skills/performance-engineering/SKILL.md` (chat render hot path) | `shouldAnimateMessage` runs inside a `React.useMemo` in `ChatMessage` for every assistant message | The fix adds two O(1) set/map inserts on a path that already performed them for stale messages; no new subscriptions, scans, or allocations per render; the memo dependency shape is unchanged |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` (nearest module doc) | Documents the message-part rendering flow around `MessageBody` | Confirmed streaming/tool reveal visuals are owned by `streamPhase`/tool-reveal caches, not the freshness detector, so recording fresh messages cannot regress streaming rendering; no doc-owned contract changed |

## Validation

| Check | Result |
|---|---|
| `cd packages/ui && bun test src/lib/messageFreshness` on unfixed code | Regression test fails (3 fail / 3 pass): second evaluation of a fresh message returned `true` and the message was never recorded as seen — reproduces #2124 |
| `cd packages/ui && bun test src/lib/messageFreshness.test.ts` after fix | 6 pass / 0 fail, covering: fresh message animates once and is recorded; no re-animation on return without a new `recordSessionStart`; stale history never animates; missing session start never animates and cannot be resurrected; non-assistant messages never animate; new fresh messages still animate after earlier ones were seen |
| `bun run type-check:ui` | Passes for this change; the only reported errors (2× TS2554 in `src/sync/__tests__/session-switch-resync.test.ts`) were verified to exist on the base commit with this change stashed and are unrelated |
| `bun run lint:ui` / `bunx eslint src/lib/messageFreshness.ts src/lib/messageFreshness.test.ts` | Both changed files lint clean |
| `bun run dead-code` | Inspected; no findings for the touched module |
| Not verified | Manual GUI session-switching walkthrough in a running app; the behavior is covered by the deterministic detector-level regression test instead |

## Visual evidence

Automated headless validation only (no GUI run in this environment). Visible behavior change: when a user watches a fresh assistant message appear in a session, switches to another session, and switches back, the message no longer fades/slides in again — it renders statically like the rest of history. Brand-new messages that arrive after returning still animate exactly once. Live streaming rendering is unchanged, as it is driven by `streamPhase` rather than the freshness detector.

## Risks and failure behavior

- Behavioral risk: a message that is evaluated as fresh but whose entry animation is suppressed downstream that render (e.g. `allowAnimation` blocked by `isStreamingPhase`/`hasEverStreamedRef`) is now marked seen and will not receive a later entry animation. This matches the issue's intent — a message the user already watched (streaming counts as watching) must not replay — and `FadeInOnReveal` latches its mount decision, so no mid-animation snap can occur if `shouldAnimateMessage` flips false after `message.info` identity changes.
- Memory: `seenMessageIds`/`messageCreationTimes` now also grow for fresh messages. Growth is bounded by messages actually rendered in a browsing session (stale history messages were already recorded on first render), so the incremental footprint is negligible.
- Rollback: single self-contained commit; reverting restores the previous (buggy) behavior with no data or contract migration.
- Cross-runtime: identical shared-UI code path on all runtimes; no runtime-specific divergence introduced.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01aa063c-5183-4ae0-b21d-67bf4767cb02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01aa063c-5183-4ae0-b21d-67bf4767cb02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

