### PR TITLE
fix(git): include remote-only branches from ls-remote in branch lists

### DIFF
--- a/packages/web/server/lib/git/DOCUMENTATION.md
+++ b/packages/web/server/lib/git/DOCUMENTATION.md
@@ -112,7 +112,7 @@ The following functions are internal helpers used by exported functions:
 - `rebaseInProgress`: Object with `{ headName, onto }` if rebase in progress.
 
 ### Branches Response
-- `all`: Local branches plus remote-tracking branches that still exist on their remote. A remote that fails to answer keeps its branches in the list: "we could not ask" must not be reported as "these branches are gone", because callers use this list to decide whether a base branch exists at all.
+- `all`: Local branches plus every branch each reachable remote reports via `ls-remote --heads`, formatted as `remotes/<remote>/<branch>`. This is a union: local remote-tracking refs deleted on the remote are pruned, and branches that exist on the remote without a local tracking ref (never fetched) are still included, so a freshly pushed branch appears without requiring a fetch. A remote that fails to answer keeps its locally known branches in the list: "we could not ask" must not be reported as "these branches are gone", because callers use this list to decide whether a base branch exists at all.
 - `current`: Current branch name.
 - `branches`: Per-branch detail keyed by branch name, as reported by `git branch`.
 - `defaultBranches`: Each remote's default branch, keyed by remote name. Read from the local `remotes/<name>/HEAD` symbolic ref; for a remote that has none — clone writes it, a hand-added remote may not — the remote itself is asked once with `ls-remote --symref`. A remote that answers neither is absent rather than guessed, and consumers fall back to conventional branch names. Omitted entirely by runtimes that do not provide this Git metadata.

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -3490,7 +3490,7 @@ async function filterActiveRemoteBranches(git, remoteBranches) {
       }
     }));
 
-    return remoteBranches.filter(remoteBranch => {
+    const activeBranches = remoteBranches.filter(remoteBranch => {
       const match = remoteBranch.match(/^remotes\/[^\/]+\/(.+)$/);
       if (!match) return false;
       const remoteName = remoteBranch.split('/')[1];
@@ -3498,6 +3498,25 @@ async function filterActiveRemoteBranches(git, remoteBranches) {
       if (unreachableRemotes.has(remoteName)) return true;
       return branchesByRemote.get(remoteName)?.has(branchName) ?? false;
     });
+
+    // A branch pushed to the remote that was never fetched locally has no
+    // remote-tracking ref, so `git branch` never reports it — but ls-remote
+    // just told us it exists. Add those so a freshly pushed branch shows up
+    // without requiring a fetch first (#2098). Unreachable remotes have no
+    // ls-remote data and therefore add nothing here; their local view above
+    // is preserved unchanged.
+    const seenBranches = new Set(activeBranches);
+    for (const [remoteName, actualRemoteBranches] of branchesByRemote) {
+      for (const branchName of actualRemoteBranches) {
+        const qualifiedBranch = `remotes/${remoteName}/${branchName}`;
+        if (!seenBranches.has(qualifiedBranch)) {
+          seenBranches.add(qualifiedBranch);
+          activeBranches.push(qualifiedBranch);
+        }
+      }
+    }
+
+    return activeBranches;
   } catch (error) {
     console.warn('Failed to filter active remote branches, returning all:', error.message);
     return remoteBranches;

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -1043,6 +1043,47 @@ describe.runIf(canRunGit())('getBranches', () => {
     // decide whether a base branch exists at all.
     expect(branches.all).toContain('remotes/origin/react');
   });
+
+  it('includes remote branches with no local tracking ref and prunes refs deleted on the remote (#2098)', async () => {
+    const remote = createTempDir();
+    runGit(remote, ['init', '--bare', '--initial-branch=main']);
+
+    const repository = createTempDir();
+    runGit(repository, ['init', '-b', 'main']);
+    runGit(repository, ['config', 'user.email', 'test@example.com']);
+    runGit(repository, ['config', 'user.name', 'Test']);
+    fs.writeFileSync(path.join(repository, 'README.md'), '# Test\n');
+    runGit(repository, ['add', 'README.md']);
+    runGit(repository, ['commit', '-m', 'init']);
+    runGit(repository, ['remote', 'add', 'origin', remote]);
+    runGit(repository, ['push', '-u', 'origin', 'main']);
+    runGit(repository, ['checkout', '-b', 'feature-known']);
+    runGit(repository, ['push', '-u', 'origin', 'feature-known']);
+    // This tracking ref will go stale: the collaborator deletes the branch on
+    // the remote below, and the list must prune it.
+    runGit(repository, ['checkout', '-b', 'feature-stale']);
+    runGit(repository, ['push', '-u', 'origin', 'feature-stale']);
+    runGit(repository, ['checkout', 'main']);
+    runGit(repository, ['branch', '-D', 'feature-stale']);
+
+    // A collaborator pushes a branch straight to the remote and deletes
+    // another; this repository never fetches, so it has no local
+    // remote-tracking ref for feature-remote-only.
+    const collaborator = createTempDir();
+    runGit(collaborator, ['clone', remote, '.']);
+    runGit(collaborator, ['config', 'user.email', 'test@example.com']);
+    runGit(collaborator, ['config', 'user.name', 'Test']);
+    runGit(collaborator, ['checkout', '-b', 'feature-remote-only']);
+    runGit(collaborator, ['push', 'origin', 'feature-remote-only']);
+    runGit(collaborator, ['push', 'origin', ':feature-stale']);
+
+    const branches = await getBranches(repository);
+
+    expect(branches.all).toContain('remotes/origin/feature-remote-only');
+    expect(branches.all).toContain('remotes/origin/feature-known');
+    expect(branches.all).toContain('feature-known');
+    expect(branches.all).not.toContain('remotes/origin/feature-stale');
+  });
 });
 
 describe.runIf(canRunGit())('getRangeDiff', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fixes #2098. The New Worktree dialog's "fetch branches" refresh never showed branches that exist on a remote but have no local remote-tracking ref. `getBranches` in `packages/web/server/lib/git/service.js` lists refs via `git branch` (local refs only), then `filterActiveRemoteBranches` runs `git ls-remote --heads <remote>` per remote but returned only the intersection with local remote-tracking refs — a branch pushed to the remote that was never fetched locally was silently dropped. The filter is now a union: stale local remote-tracking refs deleted on the remote are still pruned, and branches present in `ls-remote` output without a local tracking ref are added as `remotes/<remote>/<branch>`, so a freshly pushed branch appears in branch pickers without requiring a fetch first.

## Non-goals

- No change to which git commands run or how often (`ls-remote` per remote was already executed on every `getBranches` call).
- No change to the VS Code runtime's branch listing (`packages/vscode/src/gitService.ts` uses the editor's Git extension bridge, not this server route).
- No change to `defaultBranches` resolution, branch creation/checkout, or worktree creation flows; they only consume the corrected list.
- No auto-fetch of remote-only branches; selecting one still goes through the existing worktree/checkout paths.

## Affected surfaces

- `packages/web/server/lib/git/service.js`: `filterActiveRemoteBranches` (internal helper of exported `getBranches`).
- External contract: the `all` array of the `/api/git/branches` response now also contains `remotes/<remote>/<branch>` entries for remote branches without a local tracking ref. Consumers (`NewWorktreeDialog`, `GitView`, `BranchSelector`, `PullRequestView` via `useGitStore`) already split this list on the `remotes/` prefix and parse `remote/branch` from it, so no consumer change is needed; none index the per-branch detail map (`branches.branches`) for remote entries.
- Runtimes: web, desktop (Electron runs this server in-process), and hosted/Capacitor mobile all serve branches through this route and benefit. VS Code is unaffected because its extension host serves Git through its own bridge rather than these routes.
- `packages/web/server/lib/git/DOCUMENTATION.md`: branches response contract updated to describe the union semantics.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` correctness invariants ("never let fetch failure masquerade as authoritative empty success", "prefer authoritative state over heuristics") | The change alters how remote answers and remote failures shape the branch list | `ls-remote` (authoritative) now both prunes and adds; an unreachable remote contributes no `ls-remote` data, so nothing is added or pruned for it and its locally known branches remain listed — the pre-existing unreachable-remote test still passes |
| `.agents/skills/openchamber-change-discipline/SKILL.md` (module contract risk) | `getBranches` is a documented public API with an external HTTP response contract | Smallest change (one helper), all real consumers traced (`branches.all` prefix filtering only), focused regression test added, owning `DOCUMENTATION.md` updated |
| `packages/web/server/lib/git/DOCUMENTATION.md` | Owning module doc; documents the branches response contract | Read before editing; the `all` contract line was updated because the fix changes its truth |
| `AGENTS.md` validation rules for server JS | TypeScript type-check does not cover `server/**/*.js` | Validated with focused vitest runs and `node --check` instead of relying on type-check/lint |

## Validation

| Check | Result |
|---|---|
| `cd packages/web && bunx vitest run server/lib/git/service.test.js -t "2098"` before the fix | Failed as expected: `expected [ 'feature-known', 'main', …(2) ] to include 'remotes/origin/feature-remote-only'` — bug reproduced with real temporary git repositories (bare remote + two clones) |
| Same command after the fix | 1 passed (159ms); the test also asserts `remotes/origin/feature-known` and local `feature-known` are kept and `remotes/origin/feature-stale` (deleted on the remote after being tracked locally) is pruned |
| `cd packages/web && bunx vitest run server/lib/git/service.test.js server/lib/git/routes.test.js --testTimeout=60000` | 2 files, 66/66 passed, including the pre-existing `getBranches` tests for default-branch resolution and unreachable-remote behavior |
| `node --check packages/web/server/lib/git/service.js` | Passed |

Notes: the raised `--testTimeout` was required only because the validation VM was CPU-saturated by unrelated concurrent jobs; the identical per-test 5s timeouts reproduced on the unmodified base, so they are environmental. `bun run dead-code` was not run because no files were added/deleted/renamed and no export or import shape changed. Package `type-check`/`lint` were not run because they cover only `src/**/*.{ts,tsx}` and cannot validate server JS; not verified: live end-to-end UI interaction with the New Worktree dialog against a real hosted remote.

## Visual evidence

No screenshots are applicable: this is a server-side change to the `/api/git/branches` response with no rendering, styling, or component change. The dialog UI already renders whatever `branches.all` contains; the behavior is demonstrated by the fail-before/pass-after regression test above, which asserts the exact `remotes/origin/<branch>` entries the dialog's pickers consume.

## Risks and failure behavior

- Unreachable remote (offline): unchanged and explicitly tested — no `ls-remote` data means no additions and no pruning for that remote, so the local remote-tracking view is preserved; fetch failure is never reported as "branches gone".
- Remote-listing failure: unchanged — the helper still falls back to returning all local remote-tracking refs unfiltered.
- Contract compatibility: additive only; entries use the same `remotes/<remote>/<branch>` format the list already contains, deduplicated against local tracking refs, so existing consumers cannot double-render a branch.
- Remote-only entries have no local tracking ref until checked out; selecting one flows through the existing `existingBranch: remotes/<remote>/<branch>` worktree path, which already handles remote refs.
- Performance: no additional git invocations; the union iterates data `ls-remote` already returned.
- Rollback: revert the single commit; no persisted data or migrations involved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01aa063c-5183-4ae0-b21d-67bf4767cb02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01aa063c-5183-4ae0-b21d-67bf4767cb02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

