### PR TITLE
fix(chat): stop sticky turn headers painting over adjacent turns

### DIFF
--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -1057,7 +1057,7 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
             // correction so the browser does not clamp the offset to the old
             // height.
             const sizeElement = sizeContainerRef.current;
-            if (sizeElement) sizeElement.style.height = `${instance.getTotalSize()}px`;
+            if (sizeElement) sizeElement.style.minHeight = `${instance.getTotalSize()}px`;
             elementScroll(offset, options, instance);
         },
         getItemKey: (index) => entriesRef.current[index]?.key ?? `index:${index}`,
@@ -1155,8 +1155,17 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
         // top edge mid-list and float over the previous turn. Padding only
         // changes when the virtual window shifts — not per scroll frame — so the
         // layout cost is negligible.
+        //
+        // The container height MUST be min-height, not a fixed height: rows are
+        // in normal flow, so when their real height briefly exceeds
+        // getTotalSize() (row content resized or a completed turn entered
+        // history before measureElement caught up) a fixed height makes the
+        // streaming-tail sibling overlap the last rows and crop them
+        // (#2094, #2095, #2119). min-height lets the container grow with its
+        // in-flow rows, pushing the tail below them, and is equivalent when
+        // measurements are exact.
         return (
-            <div ref={sizeContainerRef} className="relative w-full" style={{ height: tanstackVirtualizer.getTotalSize() }}>
+            <div ref={sizeContainerRef} className="relative w-full" style={{ minHeight: tanstackVirtualizer.getTotalSize() }}>
                 <div style={{ paddingTop: `${startOffset}px` }}>
                     {virtualItems.map((item) => {
                         const entry = renderEntries[item.index];

--- a/packages/ui/src/components/chat/__tests__/turnStackingContract.test.ts
+++ b/packages/ui/src/components/chat/__tests__/turnStackingContract.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { createElement, type ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import TurnItem from '../components/TurnItem';
+import type { ChatMessageEntry, Turn } from '../lib/turns/types';
+
+/**
+ * Regression contract for #2094 / #2095 / #2119 (one root cause).
+ *
+ * Every turn's sticky user header is z-20 and its assistant block is z-0.
+ * Turn <section>s must therefore be isolated stacking contexts: without
+ * `isolation: isolate` all headers and assistant blocks share the scroll
+ * container's single stacking context, and any geometric overlap between
+ * adjacent turns (virtualizer measurement lag at the history/streaming-tail
+ * seam) lets one turn's stuck header paint over another turn's content —
+ * the reversed visual order, hidden action buttons, and cropped messages
+ * reported in the three issues.
+ *
+ * These are structural (server-rendered markup + source) assertions, not
+ * paint tests: they prove the DOM contract the fix established — per-turn
+ * isolation, a single unambiguous position on the sticky header, and a
+ * min-height (never fixed-height / transform) virtualizer size container —
+ * and they trip if any of those regress. Actual paint order was verified in
+ * a real browser during the fix (headless Chrome hit-testing).
+ */
+
+const messageEntry = (id: string): ChatMessageEntry => ({
+    info: { id } as ChatMessageEntry['info'],
+    parts: [],
+});
+
+const turn: Turn = {
+    turnId: 'turn-a',
+    userMessage: messageEntry('user-a'),
+    assistantMessages: [messageEntry('assistant-a')],
+};
+
+const renderMessage = (message: ChatMessageEntry): ReactNode =>
+    createElement('div', { 'data-msg': message.info.id });
+
+const renderTurn = (stickyUserHeader: boolean) =>
+    renderToStaticMarkup(createElement(TurnItem, { turn, stickyUserHeader, renderMessage }));
+
+const classTokens = (markup: string, matcher: RegExp): string[] => {
+    const match = markup.match(matcher);
+    if (!match) return [];
+    return match[1].split(/\s+/).filter(Boolean);
+};
+
+describe('turn stacking contract (#2094, #2095, #2119)', () => {
+    test('turn section is an isolated stacking context', () => {
+        const markup = renderTurn(true);
+        const sectionClasses = classTokens(markup, /<section class="([^"]*)"/);
+        expect(sectionClasses).toContain('isolate');
+        expect(sectionClasses).toContain('relative');
+    });
+
+    test('sticky user header declares exactly one position', () => {
+        const markup = renderTurn(true);
+        const headerClasses = classTokens(markup, /<div class="([^"]*sticky[^"]*)"/);
+        expect(headerClasses).toContain('sticky');
+        expect(headerClasses).toContain('top-0');
+        expect(headerClasses).toContain('z-20');
+        // `relative` alongside `sticky` made the header's position depend on
+        // utility cascade order; the header must carry a single position.
+        expect(headerClasses).not.toContain('relative');
+    });
+
+    test('assistant block stays a z-0 layer inside the turn', () => {
+        const markup = renderTurn(true);
+        expect(markup).toContain('<div class="relative z-0">');
+    });
+
+    test('non-sticky render path keeps the same isolated section', () => {
+        const markup = renderTurn(false);
+        expect(markup).not.toContain('sticky');
+        const sectionClasses = classTokens(markup, /<section class="([^"]*)"/);
+        expect(sectionClasses).toContain('isolate');
+    });
+});
+
+describe('virtualized history seam contract (#2119)', () => {
+    // Source-level tripwire: StaticHistoryList is not exported and renders
+    // only under a live virtualizer, so the invariants are asserted against
+    // the source. This proves the structural fix is in place, not paint
+    // behavior.
+    const messageListSource = readFileSync(
+        new URL('../MessageList.tsx', import.meta.url),
+        'utf8'
+    );
+
+    test('size container uses min-height so overflowing rows push the tail down instead of overlapping it', () => {
+        expect(messageListSource).toContain('style={{ minHeight: tanstackVirtualizer.getTotalSize() }}');
+        expect(messageListSource).not.toContain('style={{ height: tanstackVirtualizer.getTotalSize() }}');
+        // The eager pre-scroll write must target the same property the render
+        // path owns, or React and the manual write fight over two properties.
+        expect(messageListSource).toContain('sizeElement.style.minHeight');
+        expect(messageListSource).not.toContain('sizeElement.style.height =');
+    });
+
+    test('virtual window offset stays padding-based; a transform ancestor would break sticky headers again', () => {
+        expect(messageListSource).toContain('paddingTop: `${startOffset}px`');
+        expect(messageListSource).not.toContain('translateY(${startOffset}px)');
+    });
+});

--- a/packages/ui/src/components/chat/components/TurnItem.tsx
+++ b/packages/ui/src/components/chat/components/TurnItem.tsx
@@ -12,13 +12,20 @@ interface TurnItemProps {
 const TurnItem: React.FC<TurnItemProps> = ({ turn, stickyUserHeader = true, renderMessage }) => {
     return (
         <section
-            className="relative w-full"
+            // `isolate` makes every turn its own stacking context so paint
+            // between turns always follows DOM order. Without it the sticky
+            // header (z-20) and assistant block (z-0) of every turn share the
+            // scroll container's stacking context, and any geometric overlap
+            // between adjacent turns (e.g. virtualizer measurement lag at the
+            // history/streaming-tail seam) lets an earlier turn's stuck header
+            // paint over a later turn's content (#2094, #2095, #2119).
+            className="relative isolate w-full"
             id={`turn-${turn.turnId}`}
             data-turn-id={turn.turnId}
             data-scroll-spy-id={turn.turnId}
         >
             {stickyUserHeader ? (
-                <div className="sticky top-0 z-20 relative bg-[var(--surface-background)] [overflow-anchor:none]">
+                <div className="sticky top-0 z-20 bg-[var(--surface-background)] [overflow-anchor:none]">
                     <div className="relative z-10">
                         {renderMessage(turn.userMessage)}
                     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fixes #2094, Fixes #2095, Fixes #2119 — three reports of one chat paint-order defect: assistant text appearing above the user message that precedes it, action buttons hidden under an overlapping message, and cropped/misaligned messages mid-session.

The originally triaged mechanism (`transform: translateY()` on the virtualizer wrapper breaking `position: sticky`) was already fixed on main by c7481336, but the underlying stacking hazard survived at the history/streaming-tail seam. The virtualizer size container used a fixed `height: getTotalSize()`; rows are in normal flow, so whenever their real height briefly exceeds the measured total (a completed turn enters history at its estimated size before `measureElement` catches up, or row content resizes), the streaming-tail sibling overlaps the last history turn. Because turn `<section>`s did not isolate their stacking contexts, every turn's `sticky z-20` user header and `z-0` assistant block shared the scroll container's single stacking context, so under that overlap an earlier turn's stuck header painted over a later turn's assistant text (reversed order) and the tail cropped the previous turn's action buttons and last lines.

Three changes, verified in a real browser:

1. `TurnItem.tsx`: turn sections get `isolate` — each turn is an atomic paint unit, cross-turn paint always follows DOM order, per-turn z-index stays internal. Applies identically to the virtualized history, the streaming tail, and the non-virtualized path, so the two render paths compose consistently.
2. `MessageList.tsx`: size container `height` → `minHeight` (render style and the eager pre-scroll write in `scrollToFn`) — rows that outgrow `getTotalSize()` push the tail below them instead of being overlapped; identical layout when measurements are exact.
3. `TurnItem.tsx`: removed the redundant `relative` alongside `sticky` on the user header (flagged in all three triages). A focused Tailwind v4 build over the source confirms `.relative` is emitted before `.sticky`, so `sticky` already won; behavior is unchanged and the position is now unambiguous.

## Non-goals

- No change to the @tanstack/react-virtual integration (measurement, overscan, anchoring, padding-based offset from c7481336 all untouched).
- No change to sticky-header UX (headers still pin to the scroll container top and overlay their own turn's content).
- `TimelineDialog` and other non-message-list sticky surfaces are out of scope.

## Affected surfaces

`packages/ui` only (`MessageList.tsx`, `components/TurnItem.tsx`, one new test file). The message list is shared by web, desktop, VS Code, hosted mobile, and Capacitor mobile; the fix applies uniformly to all of them and to all three render paths (virtualized history, streaming tail, `engine === 'none'`). No persisted data, routes, exports, or package contracts change. Inline message overlays are unaffected by the new isolation because they portal to `document.body` (`TextSelectionMenu`, `ToolOutputDialog`, `TurnChangedFilesDropdown`).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` correctness invariants + `openchamber-change-discipline` skill | Source change in shared UI | Smallest complete change (3 CSS-level edits), reproduction before fix, focused regression tests, package-scoped type-check/lint, dead-code run for the added file |
| `theme-system` skill | Styling/classes change | Only Tailwind utility classes (`isolate`) and a CSS property swap; no colors, buttons, or icons touched; no animation added |
| `performance-engineering` skill | Virtualized list hot path | No per-frame work added: `isolation` is paint-tree only; `minHeight` updates at the same frequency the `height` write had (only when the measured total changes). Virtualization contracts (measurement, anchoring, total-size exposure before scroll) preserved; verified sticky/scroll behavior in a real browser |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | Nearest module doc | Read; tool-part rendering untouched |

## Validation

| Check | Result |
|---|---|
| Headless-Chrome verification (repo `scripts/perf/cdp.mjs` + a standalone replica of the exact current DOM/classes): scroll sweeps, `elementFromPoint` hit-tests, screenshots for old-transform, current-main, and fixed variants | Defect reproduced on the current structure (tail overlap hides action buttons; earlier stuck header paints over later assistant text); after the fix, paint follows DOM order and the seam no longer overlaps; sticky headers still pin at the container top and still overlay their own turn |
| `bun test src/components/chat` (packages/ui) | 566 pass; 3 failures are in uncommitted `ReasoningPart.test.tsx` work from a parallel branch and fail identically without this change |
| New `turnStackingContract.test.ts` | 6 pass — server-rendered markup asserts the isolated section, single-position sticky header, and z-0 assistant block; source-level tripwires assert the min-height size container and padding-based (never transform) offset. These prove the structural contract, not paint; paint order was verified in the browser runs above |
| `bun run type-check:ui` | Clean for changed files (2 pre-existing errors in `src/sync/__tests__/session-switch-resync.test.ts` exist on the base commit) |
| `bun run lint:ui` | Clean for changed files |
| `bun run dead-code` | No findings for changed/added files |
| Focused Tailwind v4 build over `TurnItem.tsx` | `.isolate { isolation: isolate }` emitted; `.relative` precedes `.sticky`, confirming the `relative` removal is behavior-preserving |

Not validated: a live model-backed streaming session in the running app, and no production-build scroll profile (justified: the diff adds zero per-frame work to the scroll path).

## Visual evidence

Screenshots captured from headless-Chrome verification of a replica using the exact production DOM structure and classes.

Reproduction of the current-main defect — the streaming tail overlaps the last history turn and hides/garbles its action buttons:

![Current main under measurement lag: tail overlaps last turn, action buttons garbled/hidden](https://cursor.com/artifacts/c/art-d9e59a12-970a-4055-a7ee-abf7d797bd06)

Reproduction of the reversed visual order — an earlier stuck user header paints over the later assistant's text:

![Current main: earlier user header paints over later assistant text (reversed order)](https://cursor.com/artifacts/c/art-9888ee41-153e-4727-b510-3f772cda1328)

After the fix — action buttons fully visible, tail below the last turn, clean paint order at the seam:

![After fix: action buttons fully visible, tail below the last turn](https://cursor.com/artifacts/c/art-38cd4b90-7151-4829-92d7-0419829203e5)
![After fix: clean paint order at the seam](https://cursor.com/artifacts/c/art-7c09fbdb-eb97-450a-b246-90ba723de0ed)

Visible change: before, when the streaming tail overlapped the last history turn (virtualizer measurement lag), the previous turn's Copy/Retry/Share buttons and last text lines were cropped mid-line and a taller earlier user bubble painted on top of the newer assistant's text; after, the tail always starts below the previous turn's action buttons, and in any residual overlap the newer turn paints coherently above the older one as a unit — no interleaved cropping, no user-over-assistant inversion. In steady state (exact measurements) rendering is pixel-identical to before, including sticky header pinning and the header's fade gradient.

## Risks and failure behavior

- `isolation: isolate` risk: an inline (non-portaled) element inside a turn can no longer paint above later turns. Audited all chat message overlays — every one portals to `document.body`, so none is affected.
- `minHeight` risk: if measurements ever overstate, the container is briefly too tall — identical behavior to the previous fixed `height`. The eager `scrollToFn` write now targets `minHeight` so React and the manual write manage the same property.
- Rollback: revert the single commit; no data, contract, or dependency changes.
- Performance: no new per-frame style/layout work; virtualizer logic untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01aa063c-5183-4ae0-b21d-67bf4767cb02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01aa063c-5183-4ae0-b21d-67bf4767cb02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

