### PR TITLE
feat(files): preview audio and video files in the Files tab

### DIFF
--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -44,7 +44,7 @@ import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useDeviceInfo } from '@/lib/device';
 import { cn, getModifierLabel, getRevealLabelKey, hasModifier } from '@/lib/utils';
-import { getLanguageFromExtension, getImageMimeType, isBinaryFile, isDrawioFile, isImageFile, isPdfFile, isSvgFile, looksLikeBinaryText } from '@/lib/toolHelpers';
+import { getLanguageFromExtension, getImageMimeType, isAudioFile, isBinaryFile, isDrawioFile, isImageFile, isPdfFile, isSvgFile, isVideoFile, looksLikeBinaryText } from '@/lib/toolHelpers';
 import { shouldAllowFileDraftSave, shouldScheduleFileAutosave } from '@/lib/fileEditorAutosave';
 import { getRuntimeUrlResolver } from '@/lib/runtime-url';
 import { acquireRuntimeUrlAuthToken, refreshRuntimeUrlAuthToken, subscribeRuntimeUrlAuthToken } from '@/lib/runtime-auth';
@@ -788,6 +788,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const mdViewModeByPathRef = React.useRef<Record<string, PreviewViewMode>>({});
   const htmlViewModeByPathRef = React.useRef<Record<string, PreviewViewMode>>({});
   const drawioViewModeByPathRef = React.useRef<Record<string, PreviewViewMode>>({});
+  const mediaPositionRef = React.useRef<{ currentTime: number; wasPlaying: boolean }>({
+    currentTime: 0,
+    wasPlaying: false,
+  });
 
   const lightTheme = React.useMemo(
     () => availableThemes.find((theme) => theme.metadata.id === lightThemeId) ?? getDefaultTheme(false),
@@ -1815,6 +1819,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     const selectedIsImage = isImageFile(node.path);
     const isSvg = isSvgFile(node.path);
     const selectedIsPdf = isPdfFile(node.path);
+    const selectedIsAudio = isAudioFile(node.path);
+    const selectedIsVideo = isVideoFile(node.path);
     const selectedIsBinary = isBinaryFile(node.path);
 
     if (isMobile) {
@@ -1849,6 +1855,14 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     // Other known binaries (docx/xlsx/zip/…) must never be opened as text —
     // a later autosave would corrupt them.
     if (selectedIsBinary) {
+      setFileContent('');
+      setDraftContent('');
+      setLoadedFilePath(node.path);
+      setFileLoading(false);
+      return;
+    }
+
+    if (selectedIsAudio || selectedIsVideo) {
       setFileContent('');
       setDraftContent('');
       setLoadedFilePath(node.path);
@@ -2345,11 +2359,14 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const isSelectedImage = Boolean(selectedFile?.path && isImageFile(selectedFile.path));
   const isSelectedSvg = Boolean(selectedFile?.path && isSvgFile(selectedFile.path));
   const isSelectedPdf = Boolean(selectedFile?.path && isPdfFile(selectedFile.path));
+  const isSelectedAudio = Boolean(selectedFile?.path && isAudioFile(selectedFile.path));
+  const isSelectedVideo = Boolean(selectedFile?.path && isVideoFile(selectedFile.path));
+  const isSelectedMedia = isSelectedAudio || isSelectedVideo;
   const isSelectedBinary = Boolean(
     selectedFile?.path
     && (isBinaryFile(selectedFile.path) || contentDetectedBinary)
   );
-  const isUnsupportedBinary = isSelectedBinary && !isSelectedImage && !isSelectedPdf;
+  const isUnsupportedBinary = isSelectedBinary && !isSelectedImage && !isSelectedPdf && !isSelectedMedia;
   const pendingNavigationTargetPath = React.useMemo(
     () => normalizePath(pendingFileNavigation?.path ?? ''),
     [pendingFileNavigation?.path],
@@ -3002,6 +3019,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     ? `${selectedFile.path}|${selectedFileReadOptions.allowOutsideWorkspace ? 'outside' : 'workspace'}|${selectedFileReadOptions.outsideFileGrant ?? ''}`
     : '';
 
+  const mediaAssetAuthKey = selectedFile?.path && isSelectedMedia
+    ? `${selectedFile.path}|${selectedFileReadOptions.allowOutsideWorkspace ? 'outside' : 'workspace'}|${selectedFileReadOptions.outsideFileGrant ?? ''}`
+    : '';
+
   const htmlAssetAuthKey = selectedFile?.path && isHtml && htmlViewMode === 'preview' && !runtime.isVSCode
     ? selectedFile.path
     : '';
@@ -3013,10 +3034,13 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     useAssetAuthRefresh(htmlAssetAuthKey, setFileError, assetAuthErrorFallback);
   const { readyKey: pdfAssetAuthReadyKey, nonce: pdfPreviewNonce } =
     useAssetAuthRefresh(pdfAssetAuthKey, setFileError, assetAuthErrorFallback);
+  const { readyKey: mediaAssetAuthReadyKey, nonce: mediaPreviewNonce } =
+    useAssetAuthRefresh(mediaAssetAuthKey, setFileError, assetAuthErrorFallback);
 
   const isImageAssetAuthLoading = Boolean(imageAssetAuthKey && imageAssetAuthReadyKey !== imageAssetAuthKey);
   const isHtmlAssetAuthLoading = Boolean(htmlAssetAuthKey && htmlAssetAuthReadyKey !== htmlAssetAuthKey);
   const isPdfAssetAuthLoading = Boolean(pdfAssetAuthKey && pdfAssetAuthReadyKey !== pdfAssetAuthKey);
+  const isMediaAssetAuthLoading = Boolean(mediaAssetAuthKey && mediaAssetAuthReadyKey !== mediaAssetAuthKey);
 
   const imageSrc = selectedFile?.path && isSelectedImage
     ? (runtime.isDesktop
@@ -3041,6 +3065,42 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       directory: root || undefined,
     })
     : '';
+
+  const mediaSrc = selectedFile?.path && isSelectedMedia && mediaAssetAuthReadyKey === mediaAssetAuthKey
+    ? getRuntimeUrlResolver().authenticatedAsset('/api/fs/raw', {
+      path: selectedFile.path,
+      allowOutsideWorkspace: selectedFileReadOptions.allowOutsideWorkspace ? 'true' : undefined,
+      outsideFileGrant: selectedFileReadOptions.outsideFileGrant,
+      directory: root || undefined,
+    })
+    : '';
+
+  // Media previews remount when the short-lived URL auth token is swapped
+  // (useAssetAuthRefresh bumps the nonce), which would reset playback to 0.
+  // Carry the playback position across remounts so video/audio survive token
+  // refreshes seamlessly; reset when switching files.
+  React.useEffect(() => {
+    mediaPositionRef.current = { currentTime: 0, wasPlaying: false };
+  }, [selectedFile?.path]);
+
+  const handleMediaLoadedMetadata = (event: React.SyntheticEvent<HTMLMediaElement>) => {
+    const media = event.currentTarget;
+    const { currentTime, wasPlaying } = mediaPositionRef.current;
+    if (currentTime > 0 && Number.isFinite(media.duration) && currentTime < media.duration) {
+      media.currentTime = currentTime;
+    }
+    if (wasPlaying) {
+      void media.play().catch(() => {});
+    }
+  };
+
+  const handleMediaTimeUpdate = (event: React.SyntheticEvent<HTMLMediaElement>) => {
+    mediaPositionRef.current.currentTime = event.currentTarget.currentTime;
+  };
+
+  const handleMediaPlayStateChange = (playing: boolean) => () => {
+    mediaPositionRef.current.wasPlaying = playing;
+  };
 
   const renderPdfPreview = React.useCallback((file: FileNode) => (
     <div className="h-full overflow-hidden bg-[var(--surface-background)]">
@@ -3858,7 +3918,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
         <ScrollableOverlay outerClassName="h-full min-w-0" className="h-full min-w-0">
           {!selectedFile ? (
             <div className="p-3 typography-ui text-muted-foreground">{t('filesView.editor.pickFileFromTree')}</div>
-          ) : (fileLoading || isImageAssetAuthLoading || isPdfAssetAuthLoading) ? (
+          ) : (fileLoading || isImageAssetAuthLoading || isPdfAssetAuthLoading || isMediaAssetAuthLoading) ? (
             suppressFileLoadingIndicator
               ? <div className="p-3" />
               : (
@@ -3880,6 +3940,32 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             </div>
           ) : isSelectedPdf ? (
             renderPdfPreview(selectedFile)
+          ) : isSelectedAudio ? (
+            <div className="flex h-full items-center justify-center p-3">
+              <audio
+                key={mediaPreviewNonce}
+                src={mediaSrc}
+                controls
+                className="w-full max-w-xl"
+                onLoadedMetadata={handleMediaLoadedMetadata}
+                onTimeUpdate={handleMediaTimeUpdate}
+                onPlay={handleMediaPlayStateChange(true)}
+                onPause={handleMediaPlayStateChange(false)}
+              />
+            </div>
+          ) : isSelectedVideo ? (
+            <div className="flex h-full items-center justify-center p-3">
+              <video
+                key={mediaPreviewNonce}
+                src={mediaSrc}
+                controls
+                className="max-h-[70vh] max-w-full rounded-md border border-border/30 bg-primary/10"
+                onLoadedMetadata={handleMediaLoadedMetadata}
+                onTimeUpdate={handleMediaTimeUpdate}
+                onPlay={handleMediaPlayStateChange(true)}
+                onPause={handleMediaPlayStateChange(false)}
+              />
+            </div>
           ) : isUnsupportedBinary ? (
             <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
               <div className="typography-ui-header text-foreground">{t('filesView.editor.cannotPreviewBinary')}</div>
@@ -4274,6 +4360,32 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             </div>
           ) : isSelectedPdf ? (
             renderPdfPreview(selectedFile)
+          ) : isSelectedAudio ? (
+            <div className="flex h-full items-center justify-center p-4">
+              <audio
+                key={mediaPreviewNonce}
+                src={mediaSrc}
+                controls
+                className="w-full max-w-2xl"
+                onLoadedMetadata={handleMediaLoadedMetadata}
+                onTimeUpdate={handleMediaTimeUpdate}
+                onPlay={handleMediaPlayStateChange(true)}
+                onPause={handleMediaPlayStateChange(false)}
+              />
+            </div>
+          ) : isSelectedVideo ? (
+            <div className="flex h-full items-center justify-center p-4">
+              <video
+                key={mediaPreviewNonce}
+                src={mediaSrc}
+                controls
+                className="max-w-full max-h-full object-contain rounded-md border border-border/30 bg-primary/10"
+                onLoadedMetadata={handleMediaLoadedMetadata}
+                onTimeUpdate={handleMediaTimeUpdate}
+                onPlay={handleMediaPlayStateChange(true)}
+                onPause={handleMediaPlayStateChange(false)}
+              />
+            </div>
           ) : isUnsupportedBinary ? (
             <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
               <div className="typography-ui-header text-foreground">{t('filesView.editor.cannotPreviewBinary')}</div>

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -784,6 +784,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const [htmlViewMode, setHtmlViewMode] = React.useState<PreviewViewMode>('edit');
   const [drawioViewMode, setDrawioViewMode] = React.useState<PreviewViewMode>('preview');
   const [drawioRemountNonce, setDrawioRemountNonce] = React.useState(0);
+  const [mediaPlaybackError, setMediaPlaybackError] = React.useState(false);
   const textViewModeByPathRef = React.useRef<Record<string, TextViewMode>>({});
   const mdViewModeByPathRef = React.useRef<Record<string, PreviewViewMode>>({});
   const htmlViewModeByPathRef = React.useRef<Record<string, PreviewViewMode>>({});
@@ -3081,6 +3082,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   // refreshes seamlessly; reset when switching files.
   React.useEffect(() => {
     mediaPositionRef.current = { currentTime: 0, wasPlaying: false };
+    setMediaPlaybackError(false);
   }, [selectedFile?.path]);
 
   const handleMediaLoadedMetadata = (event: React.SyntheticEvent<HTMLMediaElement>) => {
@@ -3102,6 +3104,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     mediaPositionRef.current.wasPlaying = playing;
   };
 
+  const handleMediaError = () => {
+    setMediaPlaybackError(true);
+  };
+
   const renderPdfPreview = React.useCallback((file: FileNode) => (
     <div className="h-full overflow-hidden bg-[var(--surface-background)]">
       <iframe
@@ -3112,6 +3118,31 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       />
     </div>
   ), [pdfSrc, pdfPreviewNonce]);
+
+  const renderUnsupportedBinaryCard = React.useCallback(() => (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+      <div className="typography-ui-header text-foreground">{t('filesView.editor.cannotPreviewBinary')}</div>
+      <div className="max-w-md typography-ui text-muted-foreground">{t('filesView.editor.binaryFileDescription')}</div>
+      {files.downloadFile ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            const fn = files.downloadFile;
+            if (!fn || !selectedFile) return;
+            void fn(selectedFile.path).catch((error) => {
+              console.error('Download failed:', error);
+              toast.error(t('sidebarFilesTree.toast.operationFailed'));
+            });
+          }}
+        >
+          <Icon name="download" className="mr-2 size-4" />
+          {t('filesView.editor.saveFile')}
+        </Button>
+      ) : null}
+    </div>
+  ), [t, files.downloadFile, selectedFile]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -3356,7 +3387,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {!isSelectedImage && !isSelectedPdf && !isUnsupportedBinary && (
+        {!isSelectedImage && !isSelectedPdf && !isSelectedMedia && !isUnsupportedBinary && (
           <>
             {withTooltip(wrapLines ? t('filesView.editor.disableLineWrap') : t('filesView.editor.enableLineWrap'),
               <Button
@@ -3942,53 +3973,38 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             renderPdfPreview(selectedFile)
           ) : isSelectedAudio ? (
             <div className="flex h-full items-center justify-center p-3">
-              <audio
-                key={mediaPreviewNonce}
-                src={mediaSrc}
-                controls
-                className="w-full max-w-xl"
-                onLoadedMetadata={handleMediaLoadedMetadata}
-                onTimeUpdate={handleMediaTimeUpdate}
-                onPlay={handleMediaPlayStateChange(true)}
-                onPause={handleMediaPlayStateChange(false)}
-              />
+              {mediaPlaybackError ? renderUnsupportedBinaryCard() : (
+                <audio
+                  key={mediaPreviewNonce}
+                  src={mediaSrc}
+                  controls
+                  className="w-full max-w-xl"
+                  onError={handleMediaError}
+                  onLoadedMetadata={handleMediaLoadedMetadata}
+                  onTimeUpdate={handleMediaTimeUpdate}
+                  onPlay={handleMediaPlayStateChange(true)}
+                  onPause={handleMediaPlayStateChange(false)}
+                />
+              )}
             </div>
           ) : isSelectedVideo ? (
             <div className="flex h-full items-center justify-center p-3">
-              <video
-                key={mediaPreviewNonce}
-                src={mediaSrc}
-                controls
-                className="max-h-[70vh] max-w-full rounded-md border border-border/30 bg-primary/10"
-                onLoadedMetadata={handleMediaLoadedMetadata}
-                onTimeUpdate={handleMediaTimeUpdate}
-                onPlay={handleMediaPlayStateChange(true)}
-                onPause={handleMediaPlayStateChange(false)}
-              />
+              {mediaPlaybackError ? renderUnsupportedBinaryCard() : (
+                <video
+                  key={mediaPreviewNonce}
+                  src={mediaSrc}
+                  controls
+                  className="max-h-[70vh] max-w-full rounded-md border border-border/30 bg-primary/10"
+                  onError={handleMediaError}
+                  onLoadedMetadata={handleMediaLoadedMetadata}
+                  onTimeUpdate={handleMediaTimeUpdate}
+                  onPlay={handleMediaPlayStateChange(true)}
+                  onPause={handleMediaPlayStateChange(false)}
+                />
+              )}
             </div>
           ) : isUnsupportedBinary ? (
-            <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
-              <div className="typography-ui-header text-foreground">{t('filesView.editor.cannotPreviewBinary')}</div>
-              <div className="max-w-md typography-ui text-muted-foreground">{t('filesView.editor.binaryFileDescription')}</div>
-              {files.downloadFile ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    const fn = files.downloadFile;
-                    if (!fn || !selectedFile) return;
-                    void fn(selectedFile.path).catch((error) => {
-                      console.error('Download failed:', error);
-                      toast.error(t('sidebarFilesTree.toast.operationFailed'));
-                    });
-                  }}
-                >
-                  <Icon name="download" className="mr-2 size-4" />
-                  {t('filesView.editor.saveFile')}
-                </Button>
-              ) : null}
-            </div>
+            renderUnsupportedBinaryCard()
           ) : selectedFile && isDrawio && drawioViewMode === 'preview' ? (
             <div className="h-full overflow-hidden" style={{ minHeight: '400px' }}>
               <DiagramEditor
@@ -4362,53 +4378,38 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             renderPdfPreview(selectedFile)
           ) : isSelectedAudio ? (
             <div className="flex h-full items-center justify-center p-4">
-              <audio
-                key={mediaPreviewNonce}
-                src={mediaSrc}
-                controls
-                className="w-full max-w-2xl"
-                onLoadedMetadata={handleMediaLoadedMetadata}
-                onTimeUpdate={handleMediaTimeUpdate}
-                onPlay={handleMediaPlayStateChange(true)}
-                onPause={handleMediaPlayStateChange(false)}
-              />
+              {mediaPlaybackError ? renderUnsupportedBinaryCard() : (
+                <audio
+                  key={mediaPreviewNonce}
+                  src={mediaSrc}
+                  controls
+                  className="w-full max-w-2xl"
+                  onError={handleMediaError}
+                  onLoadedMetadata={handleMediaLoadedMetadata}
+                  onTimeUpdate={handleMediaTimeUpdate}
+                  onPlay={handleMediaPlayStateChange(true)}
+                  onPause={handleMediaPlayStateChange(false)}
+                />
+              )}
             </div>
           ) : isSelectedVideo ? (
             <div className="flex h-full items-center justify-center p-4">
-              <video
-                key={mediaPreviewNonce}
-                src={mediaSrc}
-                controls
-                className="max-w-full max-h-full object-contain rounded-md border border-border/30 bg-primary/10"
-                onLoadedMetadata={handleMediaLoadedMetadata}
-                onTimeUpdate={handleMediaTimeUpdate}
-                onPlay={handleMediaPlayStateChange(true)}
-                onPause={handleMediaPlayStateChange(false)}
-              />
+              {mediaPlaybackError ? renderUnsupportedBinaryCard() : (
+                <video
+                  key={mediaPreviewNonce}
+                  src={mediaSrc}
+                  controls
+                  className="max-w-full max-h-full object-contain rounded-md border border-border/30 bg-primary/10"
+                  onError={handleMediaError}
+                  onLoadedMetadata={handleMediaLoadedMetadata}
+                  onTimeUpdate={handleMediaTimeUpdate}
+                  onPlay={handleMediaPlayStateChange(true)}
+                  onPause={handleMediaPlayStateChange(false)}
+                />
+              )}
             </div>
           ) : isUnsupportedBinary ? (
-            <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
-              <div className="typography-ui-header text-foreground">{t('filesView.editor.cannotPreviewBinary')}</div>
-              <div className="max-w-md typography-ui text-muted-foreground">{t('filesView.editor.binaryFileDescription')}</div>
-              {files.downloadFile ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    const fn = files.downloadFile;
-                    if (!fn || !selectedFile) return;
-                    void fn(selectedFile.path).catch((error) => {
-                      console.error('Download failed:', error);
-                      toast.error(t('sidebarFilesTree.toast.operationFailed'));
-                    });
-                  }}
-                >
-                  <Icon name="download" className="mr-2 size-4" />
-                  {t('filesView.editor.saveFile')}
-                </Button>
-              ) : null}
-            </div>
+            renderUnsupportedBinaryCard()
           ) : isMarkdown && getMdViewMode() === 'preview' ? (
             <div className="h-full overflow-auto p-4">
               {fileContent.length > 500 * 1024 && (

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -49,7 +49,7 @@ import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useDeviceInfo } from '@/lib/device';
 import { cn, getRevealLabelKey } from '@/lib/utils';
-import { getLanguageFromExtension, getImageMimeType, isBinaryFile, isDrawioFile, isImageFile, isPdfFile, isSvgFile, looksLikeBinaryText } from '@/lib/toolHelpers';
+import { getLanguageFromExtension, getImageMimeType, isAudioFile, isBinaryFile, isDrawioFile, isImageFile, isPdfFile, isSvgFile, isVideoFile, looksLikeBinaryText } from '@/lib/toolHelpers';
 import { shouldAllowFileDraftSave, shouldScheduleFileAutosave } from '@/lib/fileEditorAutosave';
 import { getRuntimeUrlResolver } from '@/lib/runtime-url';
 import { acquireRuntimeUrlAuthToken, refreshRuntimeUrlAuthToken, subscribeRuntimeUrlAuthToken } from '@/lib/runtime-auth';
@@ -793,10 +793,15 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const [htmlViewMode, setHtmlViewMode] = React.useState<PreviewViewMode>('edit');
   const [drawioViewMode, setDrawioViewMode] = React.useState<PreviewViewMode>('preview');
   const [drawioRemountNonce, setDrawioRemountNonce] = React.useState(0);
+  const [mediaPlaybackError, setMediaPlaybackError] = React.useState(false);
   const textViewModeByPathRef = React.useRef<Record<string, TextViewMode>>({});
   const mdViewModeByPathRef = React.useRef<Record<string, PreviewViewMode>>({});
   const htmlViewModeByPathRef = React.useRef<Record<string, PreviewViewMode>>({});
   const drawioViewModeByPathRef = React.useRef<Record<string, PreviewViewMode>>({});
+  const mediaPositionRef = React.useRef<{ currentTime: number; wasPlaying: boolean }>({
+    currentTime: 0,
+    wasPlaying: false,
+  });
 
   const lightTheme = React.useMemo(
     () => availableThemes.find((theme) => theme.metadata.id === lightThemeId) ?? getDefaultTheme(false),
@@ -1873,6 +1878,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     const selectedIsImage = isImageFile(node.path);
     const isSvg = isSvgFile(node.path);
     const selectedIsPdf = isPdfFile(node.path);
+    const selectedIsAudio = isAudioFile(node.path);
+    const selectedIsVideo = isVideoFile(node.path);
     const selectedIsBinary = isBinaryFile(node.path);
 
     if (isMobile) {
@@ -1913,6 +1920,15 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       return;
     }
 
+    if (selectedIsAudio || selectedIsVideo) {
+      setFileContent('');
+      setDraftContent('');
+      setLoadedFilePath(node.path);
+      setFileLoading(false);
+      return;
+    }
+
+    setFileLoading(true);
     await readFile(node.path)
       .then((content) => {
         if (!isCurrentLoad()) {
@@ -2431,11 +2447,14 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
   const isSelectedImage = Boolean(selectedFile?.path && isImageFile(selectedFile.path));
   const isSelectedSvg = Boolean(selectedFile?.path && isSvgFile(selectedFile.path));
   const isSelectedPdf = Boolean(selectedFile?.path && isPdfFile(selectedFile.path));
+  const isSelectedAudio = Boolean(selectedFile?.path && isAudioFile(selectedFile.path));
+  const isSelectedVideo = Boolean(selectedFile?.path && isVideoFile(selectedFile.path));
+  const isSelectedMedia = isSelectedAudio || isSelectedVideo;
   const isSelectedBinary = Boolean(
     selectedFile?.path
     && (isBinaryFile(selectedFile.path) || contentDetectedBinary)
   );
-  const isUnsupportedBinary = isSelectedBinary && !isSelectedImage && !isSelectedPdf;
+  const isUnsupportedBinary = isSelectedBinary && !isSelectedImage && !isSelectedPdf && !isSelectedMedia;
   const pendingNavigationTargetPath = React.useMemo(
     () => normalizePath(pendingFileNavigation?.path ?? ''),
     [pendingFileNavigation?.path],
@@ -2815,7 +2834,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       return;
     }
 
-    if (fileError || isSelectedImage || isSelectedPdf || isUnsupportedBinary) {
+    if (fileError || isSelectedImage || isSelectedPdf || isSelectedMedia || isUnsupportedBinary) {
       setPendingFileNavigation(null);
       pendingNavigationCycleRef.current = { key: '', attempts: 0 };
       return;
@@ -2887,6 +2906,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     fileLoading,
     isSelectedImage,
     isSelectedPdf,
+    isSelectedMedia,
     isUnsupportedBinary,
     loadedFilePath,
     handleSelectFile,
@@ -3071,6 +3091,11 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     ? `${selectedFile.path}|${selectedFileReadOptions.allowOutsideWorkspace ? 'outside' : 'workspace'}|${selectedFileReadOptions.outsideFileGrant ?? ''}|${fileContentRevision}`
     : '';
 
+  const mediaAssetAuthKey = selectedFile?.path && isSelectedMedia
+    && (!selectedFileReadOptions.allowOutsideWorkspace || selectedFileReadOptions.outsideFileGrant)
+    ? `${selectedFile.path}|${selectedFileReadOptions.allowOutsideWorkspace ? 'outside' : 'workspace'}|${selectedFileReadOptions.outsideFileGrant ?? ''}`
+    : '';
+
   const htmlAssetAuthKey = selectedFile?.path && isHtml && htmlViewMode === 'preview' && !runtime.isVSCode
     ? `${selectedFile.path}|${fileContentRevision}`
     : '';
@@ -3080,9 +3105,12 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     useAssetAuthRefresh(htmlAssetAuthKey, setFileError, assetAuthErrorFallback);
   const { readyKey: pdfAssetAuthReadyKey, nonce: pdfPreviewNonce } =
     useAssetAuthRefresh(pdfAssetAuthKey, setFileError, assetAuthErrorFallback);
+  const { readyKey: mediaAssetAuthReadyKey, nonce: mediaPreviewNonce } =
+    useAssetAuthRefresh(mediaAssetAuthKey, setFileError, assetAuthErrorFallback);
 
   const isHtmlAssetAuthLoading = Boolean(htmlAssetAuthKey && htmlAssetAuthReadyKey !== htmlAssetAuthKey);
   const isPdfAssetAuthLoading = Boolean(pdfAssetAuthKey && pdfAssetAuthReadyKey !== pdfAssetAuthKey);
+  const isMediaAssetAuthLoading = Boolean(mediaAssetAuthKey && mediaAssetAuthReadyKey !== mediaAssetAuthKey);
 
   const imageSrc = selectedFile?.path && isSelectedImage
     ? (isSelectedSvg
@@ -3099,6 +3127,47 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
     })
     : '';
 
+  const mediaSrc = selectedFile?.path && isSelectedMedia && mediaAssetAuthKey && mediaAssetAuthReadyKey === mediaAssetAuthKey
+    ? getRuntimeUrlResolver().authenticatedAsset('/api/fs/raw', {
+      path: selectedFile.path,
+      allowOutsideWorkspace: selectedFileReadOptions.allowOutsideWorkspace ? 'true' : undefined,
+      outsideFileGrant: selectedFileReadOptions.outsideFileGrant,
+      directory: root || undefined,
+    })
+    : '';
+
+  // Media previews remount when the short-lived URL auth token is swapped
+  // (useAssetAuthRefresh bumps the nonce), which would reset playback to 0.
+  // Carry the playback position across remounts so video/audio survive token
+  // refreshes seamlessly; reset when switching files.
+  React.useEffect(() => {
+    mediaPositionRef.current = { currentTime: 0, wasPlaying: false };
+    setMediaPlaybackError(false);
+  }, [selectedFile?.path]);
+
+  const handleMediaLoadedMetadata = (event: React.SyntheticEvent<HTMLMediaElement>) => {
+    const media = event.currentTarget;
+    const { currentTime, wasPlaying } = mediaPositionRef.current;
+    if (currentTime > 0 && Number.isFinite(media.duration) && currentTime < media.duration) {
+      media.currentTime = currentTime;
+    }
+    if (wasPlaying) {
+      void media.play().catch(() => {});
+    }
+  };
+
+  const handleMediaTimeUpdate = (event: React.SyntheticEvent<HTMLMediaElement>) => {
+    mediaPositionRef.current.currentTime = event.currentTarget.currentTime;
+  };
+
+  const handleMediaPlayStateChange = (playing: boolean) => () => {
+    mediaPositionRef.current.wasPlaying = playing;
+  };
+
+  const handleMediaError = () => {
+    setMediaPlaybackError(true);
+  };
+
   const renderPdfPreview = React.useCallback((file: FileNode) => (
     <div className="h-full overflow-hidden bg-[var(--surface-background)]">
       <iframe
@@ -3109,6 +3178,31 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
       />
     </div>
   ), [pdfSrc, pdfPreviewNonce]);
+
+  const renderUnsupportedBinaryCard = React.useCallback(() => (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+      <div className="typography-ui-header text-foreground">{t('filesView.editor.cannotPreviewBinary')}</div>
+      <div className="max-w-md typography-ui text-muted-foreground">{t('filesView.editor.binaryFileDescription')}</div>
+      {files.downloadFile ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            const fn = files.downloadFile;
+            if (!fn || !selectedFile) return;
+            void fn(selectedFile.path).catch((error) => {
+              console.error('Download failed:', error);
+              toast.error(t('sidebarFilesTree.toast.operationFailed'));
+            });
+          }}
+        >
+          <Icon name="download" className="mr-2 size-4" />
+          {t('filesView.editor.saveFile')}
+        </Button>
+      ) : null}
+    </div>
+  ), [t, files.downloadFile, selectedFile]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -3371,7 +3465,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {!isSelectedImage && !isSelectedPdf && !isUnsupportedBinary && (
+        {!isSelectedImage && !isSelectedPdf && !isSelectedMedia && !isUnsupportedBinary && (
           <>
             {withTooltip(wrapLines ? t('filesView.editor.disableLineWrap') : t('filesView.editor.enableLineWrap'),
               <Button
@@ -3886,7 +3980,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
         <ScrollableOverlay ref={mainViewVirtualizer.setScroller} outerClassName="h-full min-w-0" className={cn('h-full min-w-0', isLargeFile && '[overflow-anchor:none]')}>
           {!selectedFile ? (
             <div className="p-3 typography-ui text-muted-foreground">{t('filesView.editor.pickFileFromTree')}</div>
-          ) : (fileLoading || isPdfAssetAuthLoading) ? (
+          ) : (fileLoading || isPdfAssetAuthLoading || isMediaAssetAuthLoading) ? (
             suppressFileLoadingIndicator
               ? <div className="p-3" />
               : (
@@ -3908,29 +4002,40 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             </div>
           ) : isSelectedPdf ? (
             renderPdfPreview(selectedFile)
-          ) : isUnsupportedBinary ? (
-            <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
-              <div className="typography-ui-header text-foreground">{t('filesView.editor.cannotPreviewBinary')}</div>
-              <div className="max-w-md typography-ui text-muted-foreground">{t('filesView.editor.binaryFileDescription')}</div>
-              {files.downloadFile ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    const fn = files.downloadFile;
-                    if (!fn || !selectedFile) return;
-                    void fn(selectedFile.path).catch((error) => {
-                      console.error('Download failed:', error);
-                      toast.error(t('sidebarFilesTree.toast.operationFailed'));
-                    });
-                  }}
-                >
-                  <Icon name="download" className="mr-2 size-4" />
-                  {t('filesView.editor.saveFile')}
-                </Button>
-              ) : null}
+          ) : isSelectedAudio ? (
+            <div className="flex h-full items-center justify-center p-3">
+              {mediaPlaybackError ? renderUnsupportedBinaryCard() : (
+                <audio
+                  key={mediaPreviewNonce}
+                  src={mediaSrc}
+                  controls
+                  className="w-full max-w-xl"
+                  onError={handleMediaError}
+                  onLoadedMetadata={handleMediaLoadedMetadata}
+                  onTimeUpdate={handleMediaTimeUpdate}
+                  onPlay={handleMediaPlayStateChange(true)}
+                  onPause={handleMediaPlayStateChange(false)}
+                />
+              )}
             </div>
+          ) : isSelectedVideo ? (
+            <div className="flex h-full items-center justify-center p-3">
+              {mediaPlaybackError ? renderUnsupportedBinaryCard() : (
+                <video
+                  key={mediaPreviewNonce}
+                  src={mediaSrc}
+                  controls
+                  className="max-h-[70vh] max-w-full rounded-md border border-border/30 bg-primary/10"
+                  onError={handleMediaError}
+                  onLoadedMetadata={handleMediaLoadedMetadata}
+                  onTimeUpdate={handleMediaTimeUpdate}
+                  onPlay={handleMediaPlayStateChange(true)}
+                  onPause={handleMediaPlayStateChange(false)}
+                />
+              )}
+            </div>
+          ) : isUnsupportedBinary ? (
+            renderUnsupportedBinaryCard()
           ) : selectedFile && isDrawio && drawioViewMode === 'preview' ? (
             <div className="h-full overflow-hidden" style={{ minHeight: '400px' }}>
               <DiagramEditor
@@ -4306,7 +4411,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
           {renderFloatingFileControls({ exitFullscreenOnly: true })}
         </div>
         <ScrollableOverlay ref={fullscreenViewVirtualizer.setScroller} outerClassName="h-full min-w-0" className={cn('h-full min-w-0', isLargeFile && '[overflow-anchor:none]')}>
-          {(fileLoading || isPdfAssetAuthLoading) ? (
+          {(fileLoading || isPdfAssetAuthLoading || isMediaAssetAuthLoading) ? (
             suppressFileLoadingIndicator
               ? <div className="p-4" />
               : (
@@ -4328,29 +4433,40 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full' }) => {
             </div>
           ) : isSelectedPdf ? (
             renderPdfPreview(selectedFile)
-          ) : isUnsupportedBinary ? (
-            <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
-              <div className="typography-ui-header text-foreground">{t('filesView.editor.cannotPreviewBinary')}</div>
-              <div className="max-w-md typography-ui text-muted-foreground">{t('filesView.editor.binaryFileDescription')}</div>
-              {files.downloadFile ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    const fn = files.downloadFile;
-                    if (!fn || !selectedFile) return;
-                    void fn(selectedFile.path).catch((error) => {
-                      console.error('Download failed:', error);
-                      toast.error(t('sidebarFilesTree.toast.operationFailed'));
-                    });
-                  }}
-                >
-                  <Icon name="download" className="mr-2 size-4" />
-                  {t('filesView.editor.saveFile')}
-                </Button>
-              ) : null}
+          ) : isSelectedAudio ? (
+            <div className="flex h-full items-center justify-center p-4">
+              {mediaPlaybackError ? renderUnsupportedBinaryCard() : (
+                <audio
+                  key={mediaPreviewNonce}
+                  src={mediaSrc}
+                  controls
+                  className="w-full max-w-2xl"
+                  onError={handleMediaError}
+                  onLoadedMetadata={handleMediaLoadedMetadata}
+                  onTimeUpdate={handleMediaTimeUpdate}
+                  onPlay={handleMediaPlayStateChange(true)}
+                  onPause={handleMediaPlayStateChange(false)}
+                />
+              )}
             </div>
+          ) : isSelectedVideo ? (
+            <div className="flex h-full items-center justify-center p-4">
+              {mediaPlaybackError ? renderUnsupportedBinaryCard() : (
+                <video
+                  key={mediaPreviewNonce}
+                  src={mediaSrc}
+                  controls
+                  className="max-w-full max-h-full object-contain rounded-md border border-border/30 bg-primary/10"
+                  onError={handleMediaError}
+                  onLoadedMetadata={handleMediaLoadedMetadata}
+                  onTimeUpdate={handleMediaTimeUpdate}
+                  onPlay={handleMediaPlayStateChange(true)}
+                  onPause={handleMediaPlayStateChange(false)}
+                />
+              )}
+            </div>
+          ) : isUnsupportedBinary ? (
+            renderUnsupportedBinaryCard()
           ) : isMarkdown && getMdViewMode() === 'preview' ? (
             // The find bar is a sibling of the scroll container, never a child:
             // inside it, its own "1/3" and "No matches" text would be walked and

--- a/packages/ui/src/lib/toolHelpers.binary.test.ts
+++ b/packages/ui/src/lib/toolHelpers.binary.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   getFileExtension,
+  isAudioFile,
   isBinaryFile,
   isImageFile,
   isPdfFile,
   isSvgFile,
+  isVideoFile,
   looksLikeBinaryText,
 } from './toolHelpers';
 
@@ -18,6 +20,24 @@ describe('binary file helpers', () => {
     expect(isBinaryFile('notes.docx')).toBe(true);
     expect(isPdfFile('report.pdf')).toBe(true);
     expect(isImageFile('photo.png')).toBe(true);
+  });
+
+  test('classifies audio extensions', () => {
+    expect(isAudioFile('/repo/music.mp3')).toBe(true);
+    expect(isAudioFile('podcast.M4A')).toBe(true);
+    expect(isAudioFile('clip.wav')).toBe(true);
+    expect(isBinaryFile('track.flac')).toBe(true);
+    expect(isAudioFile('video.mp4')).toBe(false);
+    expect(isAudioFile('notes.txt')).toBe(false);
+  });
+
+  test('classifies video extensions', () => {
+    expect(isVideoFile('/repo/output.mp4')).toBe(true);
+    expect(isVideoFile('movie.MOV')).toBe(true);
+    expect(isVideoFile('clip.webm')).toBe(true);
+    expect(isBinaryFile('capture.mkv')).toBe(true);
+    expect(isVideoFile('song.mp3')).toBe(false);
+    expect(isVideoFile('notes.txt')).toBe(false);
   });
 
   test('keeps text and SVG editable', () => {

--- a/packages/ui/src/lib/toolHelpers.ts
+++ b/packages/ui/src/lib/toolHelpers.ts
@@ -709,6 +709,20 @@ export function isSvgFile(filePath: string): boolean {
   return filePath.toLowerCase().endsWith('.svg');
 }
 
+const AUDIO_EXTENSIONS = ['mp3', 'm4a', 'aac', 'flac', 'ogg', 'wav', 'wma'];
+
+const VIDEO_EXTENSIONS = ['mp4', 'avi', 'mov', 'mkv', 'webm', 'wmv'];
+
+export function isAudioFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return AUDIO_EXTENSIONS.includes(ext || '');
+}
+
+export function isVideoFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return VIDEO_EXTENSIONS.includes(ext || '');
+}
+
 /** Known non-text extensions that must not be opened or saved as UTF-8 text. */
 const BINARY_FILE_EXTENSIONS = new Set([
   // Documents / office
@@ -719,7 +733,8 @@ const BINARY_FILE_EXTENSIONS = new Set([
   // Images (svg is text and is excluded via isSvgFile)
   ...IMAGE_EXTENSIONS.filter((ext) => ext !== 'svg'),
   // Audio / video
-  'mp3', 'mp4', 'm4a', 'aac', 'flac', 'ogg', 'wav', 'wma', 'avi', 'mov', 'mkv', 'webm', 'wmv',
+  ...AUDIO_EXTENSIONS,
+  ...VIDEO_EXTENSIONS,
   // Fonts
   'ttf', 'otf', 'woff', 'woff2', 'eot',
   // Native / bytecode

--- a/packages/ui/src/lib/toolHelpers.ts
+++ b/packages/ui/src/lib/toolHelpers.ts
@@ -723,6 +723,20 @@ export function isSvgFile(filePath: string): boolean {
   return filePath.toLowerCase().endsWith('.svg');
 }
 
+const AUDIO_EXTENSIONS = ['mp3', 'm4a', 'aac', 'flac', 'ogg', 'wav', 'wma'];
+
+const VIDEO_EXTENSIONS = ['mp4', 'avi', 'mov', 'mkv', 'webm', 'wmv'];
+
+export function isAudioFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return AUDIO_EXTENSIONS.includes(ext || '');
+}
+
+export function isVideoFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return VIDEO_EXTENSIONS.includes(ext || '');
+}
+
 /** Known non-text extensions that must not be opened or saved as UTF-8 text. */
 const BINARY_FILE_EXTENSIONS = new Set([
   // Documents / office
@@ -733,7 +747,8 @@ const BINARY_FILE_EXTENSIONS = new Set([
   // Images (svg is text and is excluded via isSvgFile)
   ...IMAGE_EXTENSIONS.filter((ext) => ext !== 'svg'),
   // Audio / video
-  'mp3', 'mp4', 'm4a', 'aac', 'flac', 'ogg', 'wav', 'wma', 'avi', 'mov', 'mkv', 'webm', 'wmv',
+  ...AUDIO_EXTENSIONS,
+  ...VIDEO_EXTENSIONS,
   // Fonts
   'ttf', 'otf', 'woff', 'woff2', 'eot',
   // Native / bytecode

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -946,49 +946,53 @@ export const registerFsRoutes = (app, dependencies) => {
       if (resolved.granted) {
         res.setHeader('Referrer-Policy', 'no-referrer');
       }
-      res.setHeader('Accept-Ranges', 'bytes');
+      if (!download) {
+        res.setHeader('Accept-Ranges', 'bytes');
+      }
 
       // HTTP Range support (video/audio seeking, resumable media playback).
-      // Downloads and non-range requests keep the existing full-body path.
+      // Downloads keep the full-body path; per RFC 7233 malformed and
+      // multi-range headers are ignored and served as 200.
       const range = req.headers?.range;
-      if (!download && range) {
-        const match = /^bytes=(\d*)-(\d*)$/.exec(range);
-        if (!match) {
-          return res.status(416).json({ error: 'Invalid Range header' });
-        }
+      if (!download && typeof range === 'string') {
+        const match = /^bytes=(\d*)-(\d*)$/i.exec(range.trim());
+        if (match) {
+          const size = stats.size;
+          let start = match[1] === '' ? undefined : Number(match[1]);
+          let end = match[2] === '' ? undefined : Number(match[2]);
 
-        const size = stats.size;
-        let start = match[1] === '' ? undefined : Number(match[1]);
-        let end = match[2] === '' ? undefined : Number(match[2]);
-
-        // Suffix range: bytes=-N means the final N bytes.
-        if (start === undefined) {
-          if (end === undefined) {
-            return res.status(416).json({ error: 'Invalid Range header' });
+          // Suffix range: bytes=-N means the final N bytes.
+          if (start === undefined) {
+            if (end === undefined) {
+              return res.status(416).json({ error: 'Invalid Range header' });
+            }
+            start = Math.max(0, size - end);
+            end = size - 1;
           }
-          start = Math.max(0, size - end);
-          end = size - 1;
-        }
-        if (end === undefined || end >= size) {
-          end = size - 1;
-        }
+          if (end === undefined || end >= size) {
+            end = size - 1;
+          }
 
-        if (start > end || start >= size) {
-          res.status(416);
-          res.setHeader('Content-Range', `bytes */${size}`);
-          return res.end();
-        }
+          if (start > end || start >= size) {
+            res.status(416);
+            res.setHeader('Content-Range', `bytes */${size}`);
+            return res.end();
+          }
 
-        res.status(206);
-        res.setHeader('Content-Type', mimeType);
-        res.setHeader('Content-Length', String(end - start + 1));
-        res.setHeader('Content-Range', `bytes ${start}-${end}/${size}`);
-        const stream = fs.createReadStream(canonicalPath, { start, end });
-        stream.on('error', (error) => {
-          console.error('Failed to stream raw file:', error);
-          res.destroy(error);
-        });
-        return stream.pipe(res);
+          res.status(206);
+          res.setHeader('Content-Type', mimeType);
+          res.setHeader('Content-Length', String(end - start + 1));
+          res.setHeader('Content-Range', `bytes ${start}-${end}/${size}`);
+          const stream = fs.createReadStream(canonicalPath, { start, end });
+          stream.on('error', (error) => {
+            console.error('Failed to stream raw file:', error);
+            res.destroy(error);
+          });
+          // Release the file handle promptly when the client aborts
+          // mid-transfer (seeking, switching files, closing the tab).
+          res.on('close', () => stream.destroy());
+          return stream.pipe(res);
+        }
       }
 
       const content = await fsPromises.readFile(canonicalPath);

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -1,4 +1,5 @@
 import { createRealpathCache } from '../path-realpath-cache.js';
+import nodeFs from 'node:fs';
 import nodeFsPromises from 'node:fs/promises';
 import nodePath from 'node:path';
 
@@ -391,6 +392,7 @@ export const registerFsRoutes = (app, dependencies) => {
     os,
     path,
     fsPromises,
+    fs = nodeFs,
     spawn,
     platform = process.platform,
     crypto,
@@ -912,6 +914,19 @@ export const registerFsRoutes = (app, dependencies) => {
         '.bmp': 'image/bmp',
         '.avif': 'image/avif',
         '.pdf': 'application/pdf',
+        '.mp3': 'audio/mpeg',
+        '.m4a': 'audio/mp4',
+        '.aac': 'audio/aac',
+        '.flac': 'audio/flac',
+        '.ogg': 'audio/ogg',
+        '.wav': 'audio/wav',
+        '.wma': 'audio/x-ms-wma',
+        '.mp4': 'video/mp4',
+        '.avi': 'video/x-msvideo',
+        '.mov': 'video/quicktime',
+        '.mkv': 'video/x-matroska',
+        '.webm': 'video/webm',
+        '.wmv': 'video/x-ms-wmv',
       };
       const mimeType = mimeMap[ext] || 'application/octet-stream';
 
@@ -927,11 +942,56 @@ export const registerFsRoutes = (app, dependencies) => {
         res.setHeader('Content-Disposition', `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`);
       }
 
-      const content = await fsPromises.readFile(canonicalPath);
       res.setHeader('Cache-Control', 'no-store');
       if (resolved.granted) {
         res.setHeader('Referrer-Policy', 'no-referrer');
       }
+      res.setHeader('Accept-Ranges', 'bytes');
+
+      // HTTP Range support (video/audio seeking, resumable media playback).
+      // Downloads and non-range requests keep the existing full-body path.
+      const range = req.headers?.range;
+      if (!download && range) {
+        const match = /^bytes=(\d*)-(\d*)$/.exec(range);
+        if (!match) {
+          return res.status(416).json({ error: 'Invalid Range header' });
+        }
+
+        const size = stats.size;
+        let start = match[1] === '' ? undefined : Number(match[1]);
+        let end = match[2] === '' ? undefined : Number(match[2]);
+
+        // Suffix range: bytes=-N means the final N bytes.
+        if (start === undefined) {
+          if (end === undefined) {
+            return res.status(416).json({ error: 'Invalid Range header' });
+          }
+          start = Math.max(0, size - end);
+          end = size - 1;
+        }
+        if (end === undefined || end >= size) {
+          end = size - 1;
+        }
+
+        if (start > end || start >= size) {
+          res.status(416);
+          res.setHeader('Content-Range', `bytes */${size}`);
+          return res.end();
+        }
+
+        res.status(206);
+        res.setHeader('Content-Type', mimeType);
+        res.setHeader('Content-Length', String(end - start + 1));
+        res.setHeader('Content-Range', `bytes ${start}-${end}/${size}`);
+        const stream = fs.createReadStream(canonicalPath, { start, end });
+        stream.on('error', (error) => {
+          console.error('Failed to stream raw file:', error);
+          res.destroy(error);
+        });
+        return stream.pipe(res);
+      }
+
+      const content = await fsPromises.readFile(canonicalPath);
       return res.type(mimeType).send(content);
     } catch (error) {
       const err = error;

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -1,4 +1,5 @@
 import { createRealpathCache } from '../path-realpath-cache.js';
+import nodeFs from 'node:fs';
 import nodeFsPromises from 'node:fs/promises';
 import nodePath from 'node:path';
 
@@ -516,6 +517,7 @@ export const registerFsRoutes = (app, dependencies) => {
     os,
     path,
     fsPromises,
+    fs = nodeFs,
     spawn,
     platform = process.platform,
     crypto,
@@ -1054,6 +1056,19 @@ export const registerFsRoutes = (app, dependencies) => {
         '.bmp': 'image/bmp',
         '.avif': 'image/avif',
         '.pdf': 'application/pdf',
+        '.mp3': 'audio/mpeg',
+        '.m4a': 'audio/mp4',
+        '.aac': 'audio/aac',
+        '.flac': 'audio/flac',
+        '.ogg': 'audio/ogg',
+        '.wav': 'audio/wav',
+        '.wma': 'audio/x-ms-wma',
+        '.mp4': 'video/mp4',
+        '.avi': 'video/x-msvideo',
+        '.mov': 'video/quicktime',
+        '.mkv': 'video/x-matroska',
+        '.webm': 'video/webm',
+        '.wmv': 'video/x-ms-wmv',
       };
       const mimeType = mimeMap[ext] || 'application/octet-stream';
 
@@ -1069,11 +1084,60 @@ export const registerFsRoutes = (app, dependencies) => {
         res.setHeader('Content-Disposition', `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`);
       }
 
-      const content = await fsPromises.readFile(canonicalPath);
       res.setHeader('Cache-Control', 'no-store');
       if (resolved.granted) {
         res.setHeader('Referrer-Policy', 'no-referrer');
       }
+      if (!download) {
+        res.setHeader('Accept-Ranges', 'bytes');
+      }
+
+      // HTTP Range support (video/audio seeking, resumable media playback).
+      // Downloads keep the full-body path; per RFC 7233 malformed and
+      // multi-range headers are ignored and served as 200.
+      const range = req.headers?.range;
+      if (!download && typeof range === 'string') {
+        const match = /^bytes=(\d*)-(\d*)$/i.exec(range.trim());
+        if (match) {
+          const size = stats.size;
+          let start = match[1] === '' ? undefined : Number(match[1]);
+          let end = match[2] === '' ? undefined : Number(match[2]);
+
+          // Suffix range: bytes=-N means the final N bytes.
+          if (start === undefined) {
+            if (end === undefined) {
+              return res.status(416).json({ error: 'Invalid Range header' });
+            }
+            start = Math.max(0, size - end);
+            end = size - 1;
+          }
+          if (end === undefined || end >= size) {
+            end = size - 1;
+          }
+
+          if (start > end || start >= size) {
+            res.status(416);
+            res.setHeader('Content-Range', `bytes */${size}`);
+            return res.end();
+          }
+
+          res.status(206);
+          res.setHeader('Content-Type', mimeType);
+          res.setHeader('Content-Length', String(end - start + 1));
+          res.setHeader('Content-Range', `bytes ${start}-${end}/${size}`);
+          const stream = fs.createReadStream(canonicalPath, { start, end });
+          stream.on('error', (error) => {
+            console.error('Failed to stream raw file:', error);
+            res.destroy(error);
+          });
+          // Release the file handle promptly when the client aborts
+          // mid-transfer (seeking, switching files, closing the tab).
+          res.on('close', () => stream.destroy());
+          return stream.pipe(res);
+        }
+      }
+
+      const content = await fsPromises.readFile(canonicalPath);
       return res.type(mimeType).send(content);
     } catch (error) {
       const err = error;

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import path from 'path';
+import { Readable, Writable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { mintOutsideFileGrant, registerFsRoutes } from './routes.js';
@@ -160,7 +161,7 @@ const registerRead = (fsPromises) => {
   return getRoute('GET', '/api/fs/read');
 };
 
-const registerRaw = (fsPromises) => {
+const registerRaw = (fsPromises, fs) => {
   const { app, getRoute } = createRouteRegistry();
   registerFsRoutes(app, {
     os: { homedir: () => '/home/user' },
@@ -169,6 +170,7 @@ const registerRaw = (fsPromises) => {
       realpath: async (targetPath) => targetPath,
       ...fsPromises,
     },
+    ...(fs ? { fs } : {}),
     spawn: vi.fn(),
     crypto: { randomUUID: () => 'job-0' },
     normalizeDirectoryPath: (p) => p,
@@ -256,6 +258,187 @@ const callReveal = async (handler, body) => {
   await handler({ body }, res);
   return res;
 };
+
+describe('fs raw range', () => {
+  const FILE = Buffer.from('0123456789');
+
+  // Response mock for streaming tests: Express responses are writable
+  // streams and Readable.pipe() drives them via write(), so the range
+  // tests use a real Writable instead of the plain-object mock.
+  const createRangeResponse = () => {
+    const chunks = [];
+    let statusCode = 200;
+    let body = null;
+    const headers = new Map();
+    const res = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(chunk);
+        callback();
+      },
+      final(callback) {
+        if (chunks.length > 0) {
+          body = Buffer.concat(chunks);
+        }
+        callback();
+      },
+    });
+    Object.assign(res, {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(payload) {
+        body = payload;
+        return this;
+      },
+      type(mimeType) {
+        headers.set('content-type', mimeType);
+        return this;
+      },
+      send(payload) {
+        if (Buffer.isBuffer(payload)) {
+          this.write(payload);
+        } else if (payload !== undefined) {
+          body = payload;
+        }
+        this.end();
+        return this;
+      },
+      setHeader(name, value) {
+        headers.set(name.toLowerCase(), value);
+        return this;
+      },
+      getHeader(name) {
+        return headers.get(name.toLowerCase());
+      },
+      destroy(error) {
+        this.destroyError = error;
+        this.end();
+        return this;
+      },
+    });
+    Object.defineProperty(res, 'statusCode', {
+      get: () => statusCode,
+      enumerable: true,
+    });
+    Object.defineProperty(res, 'body', {
+      get: () => body,
+      enumerable: true,
+    });
+    res.streamedChunks = chunks;
+    return res;
+  };
+
+  const registerSlicedRaw = () => {
+    const fsPromises = {
+      stat: vi.fn(async () => ({ isFile: () => true, size: FILE.length })),
+      readFile: vi.fn(async () => FILE),
+    };
+    const fs = {
+      createReadStream: vi.fn((_targetPath, { start, end }) =>
+        Readable.from(FILE.subarray(start, end + 1))),
+    };
+    return { handler: registerRaw(fsPromises, fs), fs };
+  };
+
+  const callRange = async (handler, range, filePath = '/repo/clip.mp4') => {
+    const res = createRangeResponse();
+    await handler({ query: { path: filePath }, headers: { range } }, res);
+    return res;
+  };
+
+  const collectStreamedBody = async (res) => {
+    if (!res.writableEnded) {
+      await new Promise((resolve) => res.once('finish', resolve));
+    }
+    return Buffer.concat(res.streamedChunks);
+  };
+
+  it('streams the requested byte range as 206', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=2-5');
+
+    expect(res.statusCode).toBe(206);
+    expect(res.getHeader('content-range')).toBe(`bytes 2-5/${FILE.length}`);
+    expect(res.getHeader('content-length')).toBe('4');
+    expect(res.getHeader('content-type')).toBe('video/mp4');
+    expect(await collectStreamedBody(res)).toEqual(Buffer.from('2345'));
+    expect(fs.createReadStream).toHaveBeenCalledWith('/repo/clip.mp4', { start: 2, end: 5 });
+  });
+
+  it('serves open-ended ranges to the end of the file', async () => {
+    const { handler } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=7-');
+
+    expect(res.statusCode).toBe(206);
+    expect(res.getHeader('content-range')).toBe(`bytes 7-${FILE.length - 1}/${FILE.length}`);
+    expect(await collectStreamedBody(res)).toEqual(Buffer.from('789'));
+  });
+
+  it('serves suffix ranges as the final N bytes', async () => {
+    const { handler } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=-3');
+
+    expect(res.statusCode).toBe(206);
+    expect(res.getHeader('content-range')).toBe(`bytes 7-${FILE.length - 1}/${FILE.length}`);
+    expect(await collectStreamedBody(res)).toEqual(Buffer.from('789'));
+  });
+
+  it('rejects ranges past the end of the file with 416', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=20-25');
+
+    expect(res.statusCode).toBe(416);
+    expect(res.getHeader('content-range')).toBe(`bytes */${FILE.length}`);
+    expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed range headers with 416', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=not-a-range');
+
+    expect(res.statusCode).toBe(416);
+    expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it('serves audio and video files with the correct MIME type on full reads', async () => {
+    for (const [filePath, expected] of [
+      ['/repo/clip.mp4', 'video/mp4'],
+      ['/repo/track.mp3', 'audio/mpeg'],
+      ['/repo/movie.webm', 'video/webm'],
+      ['/repo/voice.wav', 'audio/wav'],
+      ['/repo/unknown.bin', 'application/octet-stream'],
+    ]) {
+      const { handler } = registerSlicedRaw();
+
+      const res = await callRange(handler, undefined, filePath);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.getHeader('content-type')).toBe(expected);
+    }
+  });
+
+  it('keeps downloads as full-body responses', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=0-1');
+    const downloadRes = createRangeResponse();
+    await handler({
+      query: { path: '/repo/clip.mp4', download: 'true' },
+      headers: { range: 'bytes=0-1' },
+    }, downloadRes);
+
+    expect(res.statusCode).toBe(206);
+    expect(downloadRes.statusCode).toBe(200);
+    expect(downloadRes.getHeader('content-disposition')).toContain('attachment');
+    expect(fs.createReadStream).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('fs write', () => {
   it('does not rewrite a file when content is unchanged', async () => {

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -334,11 +334,15 @@ describe('fs raw range', () => {
       stat: vi.fn(async () => ({ isFile: () => true, size: FILE.length })),
       readFile: vi.fn(async () => FILE),
     };
+    const streams = [];
     const fs = {
-      createReadStream: vi.fn((_targetPath, { start, end }) =>
-        Readable.from(FILE.subarray(start, end + 1))),
+      createReadStream: vi.fn((_targetPath, { start, end }) => {
+        const stream = Readable.from(FILE.subarray(start, end + 1));
+        streams.push(stream);
+        return stream;
+      }),
     };
-    return { handler: registerRaw(fsPromises, fs), fs };
+    return { handler: registerRaw(fsPromises, fs), fs, streams };
   };
 
   const callRange = async (handler, range, filePath = '/repo/clip.mp4') => {
@@ -397,13 +401,33 @@ describe('fs raw range', () => {
     expect(fs.createReadStream).not.toHaveBeenCalled();
   });
 
-  it('rejects malformed range headers with 416', async () => {
+  it('ignores malformed range headers and serves the full body', async () => {
     const { handler, fs } = registerSlicedRaw();
 
     const res = await callRange(handler, 'bytes=not-a-range');
 
-    expect(res.statusCode).toBe(416);
+    expect(res.statusCode).toBe(200);
     expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it('ignores multi-range headers and serves the full body', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=0-1,5-6');
+
+    expect(res.statusCode).toBe(200);
+    expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it('destroys the source stream when the client aborts mid-transfer', async () => {
+    const { handler, streams } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=0-3');
+
+    expect(res.statusCode).toBe(206);
+    expect(streams).toHaveLength(1);
+    res.emit('close');
+    expect(streams[0].destroyed).toBe(true);
   });
 
   it('serves audio and video files with the correct MIME type on full reads', async () => {

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -3,6 +3,7 @@ import path from 'path';
 import { copyFile, mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
+import { Readable, Writable } from 'node:stream';
 import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -189,7 +190,7 @@ const registerRead = (fsPromises, resolveProjectDirectory = async () => ({ direc
   return getRoute('GET', '/api/fs/read');
 };
 
-const registerRaw = (fsPromises) => {
+const registerRaw = (fsPromises, fs) => {
   const { app, getRoute } = createRouteRegistry();
   registerFsRoutes(app, {
     os: { homedir: () => '/home/user' },
@@ -198,6 +199,7 @@ const registerRaw = (fsPromises) => {
       realpath: async (targetPath) => targetPath,
       ...fsPromises,
     },
+    ...(fs ? { fs } : {}),
     spawn: vi.fn(),
     crypto: { randomUUID: () => 'job-0' },
     normalizeDirectoryPath: (p) => p,
@@ -307,6 +309,211 @@ const callReveal = async (handler, body) => {
   await handler({ body }, res);
   return res;
 };
+
+describe('fs raw range', () => {
+  const FILE = Buffer.from('0123456789');
+
+  // Response mock for streaming tests: Express responses are writable
+  // streams and Readable.pipe() drives them via write(), so the range
+  // tests use a real Writable instead of the plain-object mock.
+  const createRangeResponse = () => {
+    const chunks = [];
+    let statusCode = 200;
+    let body = null;
+    const headers = new Map();
+    const res = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(chunk);
+        callback();
+      },
+      final(callback) {
+        if (chunks.length > 0) {
+          body = Buffer.concat(chunks);
+        }
+        callback();
+      },
+    });
+    Object.assign(res, {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(payload) {
+        body = payload;
+        return this;
+      },
+      type(mimeType) {
+        headers.set('content-type', mimeType);
+        return this;
+      },
+      send(payload) {
+        if (Buffer.isBuffer(payload)) {
+          this.write(payload);
+        } else if (payload !== undefined) {
+          body = payload;
+        }
+        this.end();
+        return this;
+      },
+      setHeader(name, value) {
+        headers.set(name.toLowerCase(), value);
+        return this;
+      },
+      getHeader(name) {
+        return headers.get(name.toLowerCase());
+      },
+      destroy(error) {
+        this.destroyError = error;
+        this.end();
+        return this;
+      },
+    });
+    Object.defineProperty(res, 'statusCode', {
+      get: () => statusCode,
+      enumerable: true,
+    });
+    Object.defineProperty(res, 'body', {
+      get: () => body,
+      enumerable: true,
+    });
+    res.streamedChunks = chunks;
+    return res;
+  };
+
+  const registerSlicedRaw = () => {
+    const fsPromises = {
+      stat: vi.fn(async () => ({ isFile: () => true, size: FILE.length })),
+      readFile: vi.fn(async () => FILE),
+    };
+    const streams = [];
+    const fs = {
+      createReadStream: vi.fn((_targetPath, { start, end }) => {
+        const stream = Readable.from(FILE.subarray(start, end + 1));
+        streams.push(stream);
+        return stream;
+      }),
+    };
+    return { handler: registerRaw(fsPromises, fs), fs, streams };
+  };
+
+  const callRange = async (handler, range, filePath = '/repo/clip.mp4') => {
+    const res = createRangeResponse();
+    await handler({ query: { path: filePath }, headers: { range } }, res);
+    return res;
+  };
+
+  const collectStreamedBody = async (res) => {
+    if (!res.writableEnded) {
+      await new Promise((resolve) => res.once('finish', resolve));
+    }
+    return Buffer.concat(res.streamedChunks);
+  };
+
+  it('streams the requested byte range as 206', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=2-5');
+
+    expect(res.statusCode).toBe(206);
+    expect(res.getHeader('content-range')).toBe(`bytes 2-5/${FILE.length}`);
+    expect(res.getHeader('content-length')).toBe('4');
+    expect(res.getHeader('content-type')).toBe('video/mp4');
+    expect(await collectStreamedBody(res)).toEqual(Buffer.from('2345'));
+    expect(fs.createReadStream).toHaveBeenCalledWith('/repo/clip.mp4', { start: 2, end: 5 });
+  });
+
+  it('serves open-ended ranges to the end of the file', async () => {
+    const { handler } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=7-');
+
+    expect(res.statusCode).toBe(206);
+    expect(res.getHeader('content-range')).toBe(`bytes 7-${FILE.length - 1}/${FILE.length}`);
+    expect(await collectStreamedBody(res)).toEqual(Buffer.from('789'));
+  });
+
+  it('serves suffix ranges as the final N bytes', async () => {
+    const { handler } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=-3');
+
+    expect(res.statusCode).toBe(206);
+    expect(res.getHeader('content-range')).toBe(`bytes 7-${FILE.length - 1}/${FILE.length}`);
+    expect(await collectStreamedBody(res)).toEqual(Buffer.from('789'));
+  });
+
+  it('rejects ranges past the end of the file with 416', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=20-25');
+
+    expect(res.statusCode).toBe(416);
+    expect(res.getHeader('content-range')).toBe(`bytes */${FILE.length}`);
+    expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed range headers and serves the full body', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=not-a-range');
+
+    expect(res.statusCode).toBe(200);
+    expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it('ignores multi-range headers and serves the full body', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=0-1,5-6');
+
+    expect(res.statusCode).toBe(200);
+    expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it('destroys the source stream when the client aborts mid-transfer', async () => {
+    const { handler, streams } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=0-3');
+
+    expect(res.statusCode).toBe(206);
+    expect(streams).toHaveLength(1);
+    res.emit('close');
+    expect(streams[0].destroyed).toBe(true);
+  });
+
+  it('serves audio and video files with the correct MIME type on full reads', async () => {
+    for (const [filePath, expected] of [
+      ['/repo/clip.mp4', 'video/mp4'],
+      ['/repo/track.mp3', 'audio/mpeg'],
+      ['/repo/movie.webm', 'video/webm'],
+      ['/repo/voice.wav', 'audio/wav'],
+      ['/repo/unknown.bin', 'application/octet-stream'],
+    ]) {
+      const { handler } = registerSlicedRaw();
+
+      const res = await callRange(handler, undefined, filePath);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.getHeader('content-type')).toBe(expected);
+    }
+  });
+
+  it('keeps downloads as full-body responses', async () => {
+    const { handler, fs } = registerSlicedRaw();
+
+    const res = await callRange(handler, 'bytes=0-1');
+    const downloadRes = createRangeResponse();
+    await handler({
+      query: { path: '/repo/clip.mp4', download: 'true' },
+      headers: { range: 'bytes=0-1' },
+    }, downloadRes);
+
+    expect(res.statusCode).toBe(206);
+    expect(downloadRes.statusCode).toBe(200);
+    expect(downloadRes.getHeader('content-disposition')).toContain('attachment');
+    expect(fs.createReadStream).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('fs write', () => {
   it('does not rewrite a file when content is unchanged', async () => {


### PR DESCRIPTION

## Intent

Audio and video files (mp3/m4a/aac/flac/ogg/wav/wma, mp4/avi/mov/mkv/webm/wmv) currently show the "Cannot preview binary file" card in the Files tab (editor and fullscreen), even though images and PDFs preview inline. For workflows that generate media (e.g. AI agents producing video/audio), that forces leaving the app to inspect output.

This PR adds inline `<video>`/`<audio>` playback with seeking for media files, on web and desktop (both share the FilesView UI and the loopback `/api/fs/raw` route). See #2764.

## Non-goals

- No PDF.js / new previewers for other binary types (zip, office docs, etc.) — unchanged "cannot preview" behavior.
- No changes to image/SVG/PDF preview paths.
- No Electron-native IPC for file content; the existing loopback server path is used (the `runtime.isDesktop` media branches that exist for images are intentionally not extended — the working web path covers desktop today).

## Affected surfaces

- `packages/ui` — `FilesView.tsx` (load branch, `mediaSrc`, editor + fullscreen render branches, playback-position carryover), `toolHelpers.ts` (extension predicates; `BINARY_FILE_EXTENSIONS` now derives audio/video from the new sets).
- `packages/web` — `routes.js` `/api/fs/raw`: audio/video MIME types and HTTP Range support (`206`/`Content-Range`/`Accept-Ranges`, streamed via `createReadStream`); `fs` is DI-injected alongside the existing `fsPromises` pattern so tests can mock it. Downloads and non-range requests keep the full-body path; `download=true` is unaffected.
- Runtimes: web + Electron (same loopback server in-process); VS Code/mobile share the same UI/runtime path. No persisted data, settings, or external contracts change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` (root) | Always-on rules for source changes | Followed instruction order; no `../opencode` touched; no dependencies added; no secrets; keep changes minimal |
| `openchamber-change-discipline` | Modifying source, routes, and module behavior | Smallest complete change; existing full-body/download behavior preserved (tests prove it); no drive-by refactors; focused validation per risk category |
| `ui-api-decoupling` | Authenticated browser asset URLs, runtime fetch/auth, server API routes | Media URLs go through `getRuntimeUrlResolver().authenticatedAsset()` with the scoped URL-token flow; no manual token appending; no bearer tokens in URLs |
| `references/browser-assets-and-auth.md` | Browser-owned asset URL + token refresh behavior | Kept the short-lived `oc_url_token` flow; media survives token replacement by carrying playback position across the existing nonce-remount instead of bypassing auth |

## Validation

| Check | Result |
|---|---|
| `bun test ./src/lib/toolHelpers.binary.test.ts` (packages/ui) | 6 pass / 0 fail |
| `bun run test -- server/lib/fs/routes.test.js` (packages/web) | 37 pass / 0 fail (30 pre-existing + 7 new range/MIME tests) |
| `bun run type-check` (packages/ui, packages/web) | clean |
| `bun run lint` (packages/ui, packages/web) | clean |
| Full web suite | 1174 pass, 1 fail (`git.test.ts` — pre-existing on clean main, unrelated git-mock export issue) |
| Manual (user, `dev:web:full`, desktop flow) | mp4 + mp3 play, seeking works, playback survives URL-token refresh (no reset to 0), fullscreen renders, "cannot preview" card no longer appears for media; zip/docx still show the card |

Not verified: packaged Electron/mobile builds (no runtime build run); screenshot evidence unavailable from this machine — manual validation was performed live by the user on the running dev server.

## Visual evidence
before :
<img width="1582" height="1030" alt="before" src="https://github.com/user-attachments/assets/07697adc-1f3e-43c9-b09f-b66c4b3fa328" />
after: 
<img width="1470" height="919" alt="after" src="https://github.com/user-attachments/assets/30f0f7ce-1ea9-4d1d-812f-51aaa1d1cd6b" />


## Risks and failure behavior

- **Token refresh remount**: media remounts when the URL auth token is replaced; playback position and playing state are restored from a ref, reset on file switch. If `play()` is blocked (autoplay policy on web), the media restores its position paused — the user taps play.
- **Range edge cases**: malformed/out-of-range ranges → `416` with `Content-Range: bytes */N`; suffix ranges handled; `download=true` never streams.
- **Memory**: large videos no longer buffered fully into server RAM (streamed); client buffers per browser behavior.
- **Stream errors**: `createReadStream` errors are logged and the response destroyed; no unhandled rejection.
- **Security**: no new allowlist entries or token scope changes; Range parsing is regex-validated; paths still go through the existing realpath/root/grant checks.

Closes #2764