### PR TITLE
fix(chat): show a newline key instead of send on the mobile composer keyboard

### DIFF
--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -287,6 +287,18 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                             paste: (event) => { handlersRef.current.onPaste?.(event); return false; },
                         }),
                         EditorView.contentAttributes.of({
+                            // Without an explicit hint the action key is the
+                            // IME's own guess at what a contenteditable wants,
+                            // and Android IMEs (like iOS WKWebView) tend to
+                            // answer "Send" for a chat-shaped box — while a
+                            // bare Enter here inserts a newline on mobile
+                            // (ChatInput's keydown policy leaves it to the
+                            // browser; sending is the send button's job). The
+                            // "enter" hint keeps the keycap honest: it reads
+                            // as a newline/return key, which is what the press
+                            // actually does. Virtual keyboards only, so
+                            // desktop behavior is untouched.
+                            enterkeyhint: 'enter',
                             spellcheck: String(handlersRef.current.spellCheck ?? false),
                             autocorrect: handlersRef.current.autoCorrect ? 'on' : 'off',
                             autocapitalize: handlersRef.current.autoCapitalize ?? 'none',


### PR DESCRIPTION
## Intent

On Android (and likely iOS WKWebView), focusing the chat composer can make the on-screen keyboard show a **"Send" action key** — but pressing it inserts a **newline**, because the composer's keydown policy deliberately leaves bare Enter to the browser on mobile (sending is the send button's job; see `ChatInput.tsx`). The keycap contradicts the actual behavior.

Root cause: the composer is a CodeMirror `contenteditable`, and it never declares an `enterkeyhint`. Without one, the action key is the IME's own guess at what a chat-shaped editable box wants — and several Android IMEs guess "Send".

The fix declares `enterkeyhint="enter"` on the editor's content DOM, so the keyboard presents a newline/return key that matches what the press actually does.

> [!IMPORTANT]
> **Not yet verified on a real device.** This was validated statically only (type-check / lint / unit tests). IME behavior varies across vendors, so this needs a **preview build on Android hardware** to confirm the keycap actually flips from "Send" to a newline key across common IMEs (Gboard, Sogou, Baidu, etc.). Please do not merge until that manual check lands — evidence will be attached here once done.

## Non-goals

- The Enter keydown policy itself is unchanged: bare Enter still inserts a newline on mobile, send stays button-only. This PR is about the keycap *label*, not the key's *behavior*.
- No optional "Enter sends on mobile" mode — that would be a separate, behavior-changing feature.
- Other multiline inputs (e.g. `QuestionCard`) use a native `<textarea>`, which already gets a newline keycap by default; untouched.

## Affected surfaces

- `packages/ui` shared composer → all runtimes that render it (web, desktop, VS Code, hosted mobile, Capacitor mobile).
- Effect is mobile-only in practice: `enterkeyhint` only influences virtual keyboards; desktops have none, so desktop/VS Code rendering is unaffected.
- No persisted data, routes, IDs, or external contracts changed.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` (root) | Source change in `packages/ui` | Minimal diff; no new dependencies; runtime differences (virtual keyboard vs desktop) made intentional and visible in a code comment |
| Skill `openchamber-change-discipline` | Any source change requires it | Risk classified as *platform/runtime behavior*: smallest complete change (one attribute), validation reported honestly, runtime correctness explicitly **not** claimed from static checks |
| `composer/DOCUMENTATION.md` | Nearest owning module doc | Change sits in `editor/`, which owns the CodeMirror view; no documented invariant altered (document stays a plain string, policy still lives with the caller) |
| `CONTRIBUTING.md` + PR template | PR handoff requirements | Unverified status stated explicitly instead of implied evidence |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` | Pass |
| `bun run lint:ui` | Pass |
| `bun test packages/ui/src/components/chat/composer` | 277 pass / 0 fail |
| Real-device keyboard check (Android IMEs) | **Not done — no device environment available here; requires a preview build** |
| iOS WKWebView keyboard check | **Not done — same reason** |

## Visual evidence

Cannot be produced without a device: the changed surface is the **system IME's action keycap**, which only renders on physical mobile keyboards. Before/after screenshots from an Android preview build will be attached once the manual verification above happens. The diff cannot affect any in-page rendering (it sets one HTML attribute consumed only by the OS keyboard).

## Risks and failure behavior

- **IME ignores the hint**: `enterkeyhint` is advisory; a non-conforming IME may still show "Send". Degradation is graceful — behavior is exactly today's, no regression path.
- **Support matrix**: supported by Chrome/Android WebView and iOS Safari 13.4+; unsupported engines ignore unknown attributes, so worst case is the status quo.
- **Future conflict**: if the product ever wants "Enter sends on mobile", this hint should be flipped to `"send"` together with the keydown policy — the comment at the change site points at that coupling.
