### PR TITLE
fix(ui): preserve project names

### DIFF
--- a/packages/ui/src/apps/mobilePaths.test.ts
+++ b/packages/ui/src/apps/mobilePaths.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getProjectDisplayLabel, getProjectLabel } from './mobilePaths';
+
+describe('mobile project labels', () => {
+  test('uses the directory basename without changing its text', () => {
+    expect(getProjectLabel('/workspace/my-project_Name')).toBe('my-project_Name');
+  });
+
+  test('prefers a trimmed custom label over the directory basename', () => {
+    expect(getProjectDisplayLabel({
+      id: 'project-1',
+      path: '/workspace/my-project',
+      label: '  My Custom_Project  ',
+    }, '/workspace/fallback')).toBe('My Custom_Project');
+  });
+});

--- a/packages/ui/src/apps/mobilePaths.ts
+++ b/packages/ui/src/apps/mobilePaths.ts
@@ -7,7 +7,7 @@ export const getProjectLabel = (path: string): string => {
   const normalized = normalizePath(path);
   if (!normalized) return '';
   const segments = normalized.split('/').filter(Boolean);
-  return segments[segments.length - 1]?.replace(/[-_]/g, ' ') || normalized;
+  return segments[segments.length - 1] || normalized;
 };
 
 export const getProjectDisplayLabel = (project: ProjectEntry | null, fallbackDirectory: string): string => {

--- a/packages/ui/src/components/sections/projects/useProjectIdentityAutoSave.ts
+++ b/packages/ui/src/components/sections/projects/useProjectIdentityAutoSave.ts
@@ -30,7 +30,7 @@ export const useProjectIdentityAutoSave = (
   const isSavingRef = React.useRef(false);
 
   React.useEffect(() => {
-    if (!hasChanges || !name.trim() || isUploadingIcon || isRemovingCustomIcon || isSavingRef.current) {
+    if (!hasChanges || isUploadingIcon || isRemovingCustomIcon || isSavingRef.current) {
       return;
     }
 

--- a/packages/ui/src/components/sections/projects/useProjectIdentityForm.ts
+++ b/packages/ui/src/components/sections/projects/useProjectIdentityForm.ts
@@ -19,12 +19,16 @@ export const normalizeProjectIconBackground = (value: string | null | undefined)
 };
 
 export type ProjectIdentitySaveData = {
-  label: string;
+  label: string | null;
   icon: string | null;
   color: string | null;
   iconBackground: string | null;
   defaultModel: string | null;
 };
+
+const getDefaultProjectName = (project: Pick<ProjectEntry, 'path'>): string => (
+  project.path.split(/[\\/]/).filter(Boolean).pop() || project.path
+);
 
 type EditableProject = Pick<
   ProjectEntry,
@@ -75,7 +79,7 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
       setDefaultModel(undefined);
       return;
     }
-    setName(project.label ?? '');
+    setName(project.label?.trim() || getDefaultProjectName(project));
     setIcon(project.icon ?? null);
     setColor(project.color ?? null);
     setIconBackground(project.iconBackground ?? null);
@@ -105,7 +109,7 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
   const showImagePreview = !previewImageFailed && (hasPendingUploadImageIcon || showStoredImagePreview);
 
   const hasChanges = Boolean(project) && (
-    name.trim() !== (project?.label ?? '').trim()
+    name.trim() !== (project?.label?.trim() || (project ? getDefaultProjectName(project) : ''))
     || icon !== (project?.icon ?? null)
     || color !== (project?.color ?? null)
     || iconBackground !== (project?.iconBackground ?? null)
@@ -190,10 +194,6 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
     }
 
     const trimmed = name.trim();
-    if (!trimmed) {
-      return null;
-    }
-
     if (pendingUploadIconFile) {
       setIsUploadingIcon(true);
       const uploadResult = await uploadProjectIcon(project.id, pendingUploadIconFile);
@@ -227,7 +227,9 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
     }
 
     return {
-      label: trimmed,
+      label: trimmed && trimmed !== getDefaultProjectName(project)
+        ? trimmed
+        : null,
       icon,
       color,
       iconBackground: normalizeProjectIconBackground(willRemoveImageIcon ? null : iconBackground),

--- a/packages/ui/src/components/sections/shared/SettingsProjectSelector.tsx
+++ b/packages/ui/src/components/sections/shared/SettingsProjectSelector.tsx
@@ -12,10 +12,6 @@ import { isVSCodeRuntime } from '@/lib/desktop';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 
-const formatProjectLabel = (label: string): string => {
-  return label.replace(/[-_]/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
-};
-
 export const SettingsProjectSelector: React.FC<{ className?: string }> = ({ className }) => {
   const { t } = useI18n();
   const projects = useProjectsStore((state) => state.projects);
@@ -42,7 +38,7 @@ export const SettingsProjectSelector: React.FC<{ className?: string }> = ({ clas
   const rawLabel = activeProject?.label && activeProject.label.trim().length > 0
     ? activeProject.label
     : (activeProject?.path.split('/').filter(Boolean).pop() || activeProject?.path || t('settings.shared.projectSelector.fallbackProject'));
-  const label = formatProjectLabel(rawLabel);
+  const label = rawLabel;
 
   return (
     <div className={cn(className)}>
@@ -76,7 +72,7 @@ export const SettingsProjectSelector: React.FC<{ className?: string }> = ({ clas
               const raw = project.label?.trim()
                 ? project.label.trim()
                 : (project.path.split('/').filter(Boolean).pop() || project.path);
-              const itemLabel = formatProjectLabel(raw);
+              const itemLabel = raw;
               return (
                 <DropdownMenuRadioItem key={project.id} value={project.id}>
                   <span className="min-w-0 truncate typography-ui">{itemLabel}</span>

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -71,7 +71,6 @@ import {
 } from './sidebar/activitySections';
 import { useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
 import {
-  formatProjectLabel,
   normalizePath,
   selectExpandedParentKeysForContext,
   toggleExpandedParentKey,
@@ -770,7 +769,7 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
   );
 
   const handleSaveProjectEdit = React.useCallback((data: {
-    label: string;
+    label: string | null;
     icon: string | null;
     color: string | null;
     iconBackground: string | null;
@@ -1322,11 +1321,9 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
     const projectPathLengthBySessionId = new Map<string, number>();
 
     projectSections.forEach((section) => {
-      const projectLabel = formatProjectLabel(
-        section.project.label?.trim()
+      const projectLabel = section.project.label?.trim()
         || formatDirectoryName(section.project.normalizedPath, homeDirectory)
-        || section.project.normalizedPath,
-      );
+        || section.project.normalizedPath;
       section.groups.forEach((group) => {
         const branchCandidate = group.branch && group.branch !== 'HEAD' && group.branch !== projectLabel
           ? group.branch

--- a/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
+++ b/packages/ui/src/components/session/sidebar/DOCUMENTATION.md
@@ -36,6 +36,7 @@
 - `collapsedActivityIndicator.tsx`: Aggregate busy/unseen dot for collapsed groups and folders.
 - `ConfirmDialogs.tsx`: Shared confirm dialog wrappers for session delete and folder delete flows.
 - `sortableItems.tsx`: DnD sortable wrapper for project ordering plus the sticky zone-band project header and its action affordances.
+- Project labels preserve their source text: the directory basename is shown unchanged by default, while a non-empty user-defined label takes precedence unchanged. Clearing the project-name field, or setting it back to the exact basename, removes the override and restores the directory-derived default.
 - `sessionFolderDnd.tsx`: Folder/session DnD scope and wrappers for dropping/moving sessions into folders.
 - `sessionOwnership.ts`: Resolves session directories once into shared project/worktree ownership and folder-scope indexes.
 

--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -29,7 +29,7 @@ import { DraggableSessionRow } from './sessionFolderDnd';
 import { nodeContainsSessionId, nodeHasPinnedMembershipChange, selectQuestionBadgeSessionScopes } from './sessionNodeItemUtils';
 import type { SessionNodeChildRenderExtras, SessionNodeRenderExtras } from './sessionNodeItemUtils';
 import type { SessionNode } from './types';
-import { formatProjectLabel, formatSessionCompactDateLabel, formatSessionDateLabel, normalizePath, renderHighlightedText } from './utils';
+import { formatSessionCompactDateLabel, formatSessionDateLabel, normalizePath, renderHighlightedText } from './utils';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useSessionDisplayStore } from '@/stores/useSessionDisplayStore';
 import { getGitHubPrStatusKey, usePrVisualSummary } from '@/stores/useGitHubPrStatusStore';
@@ -355,7 +355,7 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
     }, [projectId, secondaryMeta?.projectLabel]),
   );
   const tooltipProjectLabel = secondaryMeta?.projectLabel
-    ?? (projectLabelFromStore ? formatProjectLabel(projectLabelFromStore) : null);
+    ?? projectLabelFromStore;
   const tooltipBranchLabel = secondaryMeta?.branchLabel ?? node.worktree?.branch ?? null;
   const prLookupKey = React.useMemo(() => {
     if (isVSCode) return null;

--- a/packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx
+++ b/packages/ui/src/components/session/sidebar/SidebarProjectsList.tsx
@@ -14,7 +14,6 @@ import { formatDirectoryName, formatPathForDisplay, cn } from '@/lib/utils';
 import type { SessionGroup } from './types';
 import type { SortableDragHandleProps } from './sortableItems';
 import { ProjectHeaderIdentity, SortableGroupItem, SortableProjectItem } from './sortableItems';
-import { formatProjectLabel } from './utils';
 import { useI18n } from '@/lib/i18n';
 import type { MainTab } from '@/stores/useUIStore';
 import type { ProjectSortOrder } from '@/stores/useSessionDisplayStore';
@@ -39,11 +38,9 @@ const TOP_FADE_MIN_SIZE = 32;
 const TOP_FADE_CLEAR_MAX_SIZE = 24;
 
 const getProjectLabel = (project: ProjectSection['project'], homeDirectory: string | null): string => (
-  formatProjectLabel(
-    project.label?.trim()
-    || formatDirectoryName(project.normalizedPath, homeDirectory)
-    || project.normalizedPath,
-  )
+  project.label?.trim()
+  || formatDirectoryName(project.normalizedPath, homeDirectory)
+  || project.normalizedPath
 );
 
 type Props = {

--- a/packages/ui/src/components/session/sidebar/projectHeaderIdentity.test.tsx
+++ b/packages/ui/src/components/session/sidebar/projectHeaderIdentity.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { ThemeSystemContext, type ThemeContextValue } from '@/contexts/theme-system-context';
+import { getDefaultTheme } from '@/lib/theme/themes';
+
+import { ProjectHeaderIdentity } from './sortableItems';
+
+const defaultTheme = getDefaultTheme(false);
+
+const themeContext = {
+  currentTheme: defaultTheme,
+  availableThemes: [defaultTheme],
+  setTheme: () => {},
+  customThemesLoading: false,
+  reloadCustomThemes: async () => {},
+  isSystemPreference: false,
+  setSystemPreference: () => {},
+  themeMode: 'system',
+  setThemeMode: () => {},
+  lightThemeId: 'mock',
+  darkThemeId: 'mock',
+  setLightThemePreference: () => {},
+  setDarkThemePreference: () => {},
+} satisfies ThemeContextValue;
+
+const renderProjectHeader = (label: string) => renderToStaticMarkup(
+  <ThemeSystemContext.Provider value={themeContext}>
+    <ProjectHeaderIdentity id="project-1" projectLabel={label} projectIcon="folder" />
+  </ThemeSystemContext.Provider>,
+);
+
+describe('ProjectHeaderIdentity project label casing', () => {
+  test('preserves a user-defined mixed-case project label', () => {
+    const markup = renderProjectHeader('MyProject');
+
+    expect(markup).toContain('>MyProject</span>');
+    expect(markup).not.toContain('lowercase');
+  });
+
+  test('preserves a directory-derived project label exactly', () => {
+    const markup = renderProjectHeader('my-project');
+
+    expect(markup).toContain('>my-project</span>');
+  });
+});

--- a/packages/ui/src/components/session/sidebar/sortableItems.tsx
+++ b/packages/ui/src/components/session/sidebar/sortableItems.tsx
@@ -93,7 +93,7 @@ export const ProjectHeaderIdentity: React.FC<ProjectHeaderIdentityProps> = ({
           <Icon name="folder" className={cn('h-3.5 w-3.5 text-muted-foreground/80', iconVisibilityClassName)} style={iconColor ? { color: iconColor } : undefined} />
         )}
       </span>
-      <span className="truncate text-[14px] font-semibold lowercase text-foreground">{projectLabel}</span>
+      <span className="truncate text-[14px] font-semibold text-foreground">{projectLabel}</span>
     </>
   );
 };

--- a/packages/ui/src/components/session/sidebar/utils.tsx
+++ b/packages/ui/src/components/session/sidebar/utils.tsx
@@ -156,12 +156,6 @@ export const resolveArchivedFolderName = (session: Session, projectRoot: string 
   return segments[segments.length - 1] ?? 'unassigned';
 };
 
-export const formatProjectLabel = (label: string): string => {
-  return label
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-};
-
 export const renderHighlightedText = (text: string, query: string): React.ReactNode => {
   if (!query) {
     return text;

--- a/packages/ui/src/hooks/useWindowTitle.ts
+++ b/packages/ui/src/hooks/useWindowTitle.ts
@@ -7,10 +7,6 @@ import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
 
 const APP_TITLE = 'OpenChamber';
 
-const formatProjectLabel = (label: string): string => {
-  return label.replace(/[-_]/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
-};
-
 const getProjectNameFromPath = (path: string): string => {
   const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
   const segments = normalized.split('/').filter(Boolean);
@@ -37,12 +33,12 @@ export const useWindowTitle = () => {
 
     const label = activeProject.label?.trim();
     if (label) {
-      return formatProjectLabel(label);
+      return label;
     }
 
     const pathName = getProjectNameFromPath(activeProject.path);
     if (pathName) {
-      return formatProjectLabel(pathName);
+      return pathName;
     }
 
     return null;

--- a/packages/ui/src/stores/useProjectsStore.test.ts
+++ b/packages/ui/src/stores/useProjectsStore.test.ts
@@ -18,4 +18,30 @@ describe("useProjectsStore settings synchronization", () => {
     expect(useProjectsStore.getState().activeProjectId).toBe(null)
     expect(useProjectsStore.getState().manualProjectOrder).toEqual([])
   })
+
+  test("treats legacy generated labels as directory defaults", () => {
+    useProjectsStore.getState().synchronizeFromSettings({
+      projects: [{ id: "ignored", path: "/workspace/my-project_Name", label: "My Project Name" }],
+    } as DesktopSettings)
+
+    expect(useProjectsStore.getState().projects[0]?.path).toBe("/workspace/my-project_Name")
+    expect(useProjectsStore.getState().projects[0]?.label).toBe(undefined)
+  })
+
+  test("preserves a custom label that differs from the legacy generated label", () => {
+    useProjectsStore.getState().synchronizeFromSettings({
+      projects: [{ id: "ignored", path: "/workspace/my-project", label: "my Custom_Project" }],
+    } as DesktopSettings)
+
+    expect(useProjectsStore.getState().projects[0]?.label).toBe("my Custom_Project")
+  })
+
+  test("removes a custom label when project metadata restores the directory default", () => {
+    const project = { id: "project-a", path: "/workspace/my-project", label: "Custom Name" } as ProjectEntry
+    useProjectsStore.setState({ projects: [project], activeProjectId: project.id })
+
+    useProjectsStore.getState().updateProjectMeta(project.id, { label: null })
+
+    expect(useProjectsStore.getState().projects[0]?.label).toBe(undefined)
+  })
 })

--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -55,7 +55,7 @@ interface ProjectsStore {
   setActiveProjectIdOnly: (id: string) => void;
   renameProject: (id: string, label: string) => void;
   updateProjectMeta: (id: string, meta: {
-    label?: string;
+    label?: string | null;
     icon?: string | null;
     color?: string | null;
     iconBackground?: string | null;
@@ -169,11 +169,16 @@ const normalizeProjectPath = (value: string): string => {
 const deriveProjectLabel = (path: string): string => {
   const normalized = normalizeProjectPath(path);
   if (!normalized || normalized === '/') {
-    return 'Root';
+    return normalized || '/';
   }
   const segments = normalized.split('/').filter(Boolean);
-  const raw = segments[segments.length - 1] || normalized;
-  return raw.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  return segments[segments.length - 1] || normalized;
+};
+
+const deriveLegacyProjectLabel = (path: string): string => {
+  const label = deriveProjectLabel(path);
+  if (label === '/') return 'Root';
+  return label.replace(/[-_]/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 };
 
 const sanitizeProjectIconImage = (value: unknown): ProjectEntry['iconImage'] | undefined => {
@@ -261,7 +266,10 @@ const sanitizeProjects = (value: unknown): ProjectEntry[] => {
     };
 
     if (typeof candidate.label === 'string' && candidate.label.trim().length > 0) {
-      project.label = candidate.label.trim();
+      const label = candidate.label.trim();
+      if (label !== deriveLegacyProjectLabel(normalizedPath)) {
+        project.label = label;
+      }
     }
     if (typeof candidate.icon === 'string' && candidate.icon.trim().length > 0) {
       project.icon = candidate.icon.trim();
@@ -582,12 +590,12 @@ export const useProjectsStore = create<ProjectsStore>()(
       }
 
       const now = Date.now();
-      const label = options?.label?.trim() || deriveProjectLabel(normalizedPath);
+      const label = options?.label?.trim();
       const id = createProjectIdFromPath(normalizedPath);
       const entry: ProjectEntry = {
         id,
         path: normalizedPath,
-        label,
+        ...(label ? { label } : {}),
         color: pickAutoColor(get().projects),
         addedAt: now,
         lastOpenedAt: now,
@@ -708,7 +716,7 @@ export const useProjectsStore = create<ProjectsStore>()(
     },
 
     updateProjectMeta: (id: string, meta: {
-      label?: string;
+      label?: string | null;
       icon?: string | null;
       color?: string | null;
       iconBackground?: string | null;
@@ -722,8 +730,9 @@ export const useProjectsStore = create<ProjectsStore>()(
         if (project.id !== id) return project;
         const updated = { ...project };
         if (meta.label !== undefined) {
-          const trimmed = meta.label.trim();
+          const trimmed = meta.label?.trim() ?? '';
           if (trimmed) updated.label = trimmed;
+          else delete updated.label;
         }
         if (meta.icon !== undefined) updated.icon = meta.icon;
         if (meta.color !== undefined) updated.color = meta.color;


### PR DESCRIPTION
## Latest rebase and validation

Rebased `b0d85232927365e9f6f2e604e9324ee8edaa9595` onto main `1636fd2bf8e4e29ee82fae3f4b2326195d9de825`. Current HEAD is `c9cf0b9fe96faddd4a6d9eea9d9fc12a33e3602e`. This section supersedes the older rebase details and validation below, which are retained as historical evidence.

The only textual conflict was in `SessionProjectScroller.tsx`, in the sticky-fade heading. Main now switches its icon and localized text between Chats and Recent using `isRecentHeaderStuck`; the PR removed `lowercase` from the same block. The resolution keeps main's conditional icon and localized text, its typography token, and the PR's removal of forced lowercasing. The remaining two commits replayed unchanged, verified by range-diff. Project labels, basename fallback, and clear-override logic retain their prior implementation.

### Current checks

| Check | Result at `c9cf0b9fe` |
|---|---|
| `bun test packages/ui/src/apps/mobilePaths.test.ts packages/ui/src/components/session/sidebar/projects/projectHeaderIdentity.test.tsx packages/ui/src/lib/projectDisplayLabel.test.ts packages/ui/src/stores/useProjectsStore.test.ts packages/ui/src/components/session/sidebar/projects/SessionProjectScroller.test.ts` | 24 passed, 43 assertions |
| `bun test packages/ui/src/components/session/sidebar/utils.test.ts` | 10 passed, 13 assertions |
| `bun run lint:ui` | Passed |
| `bunx oxlint packages/ui/src/components/session/sidebar/projects/SessionProjectScroller.tsx` | Passed |
| `bun run build:web` | Passed, including PWA service-worker build; large-chunk warnings remain |
| `bun run type-check:ui` | Same five duplicate-CodeMirror type errors in unchanged `languageByExtension.ts`, lines 34, 48, 51, 62, 73 |
| `git diff --check`, final diff and range-diff inspection | Passed; scroller delta against main only removes `lowercase` |

Applied change discipline, theme tokens, localization, performance/state ownership guidance, and the owning sidebar documentation. The resolution reuses existing localized keys and preserves upstream scroll logic; it adds no polling, cache, imports, exports, or files. No fresh screenshots, mounted scrolling interaction, native tests, performance profiles, persistence suite, or dead-code run were performed for this rebase. Historical screenshots below still illustrate custom-name casing, but do not verify the new Chats/Recent sticky-header behavior.

The previous review's non-blockers remain open: basename sorting fallback, two full-path display fallbacks, the missing form-level restore-default test, and mobile clear-name behavior. Resolving this textual conflict does not fix those findings. Backup ref `backup/pr2770-before-latest-rebase` preserves the old head. A new automated review is requested for the current HEAD.

---
## Intent

Fixes #2758. Preserve project-name casing across shared UI. The default is the exact directory basename; a non-empty custom name takes precedence. Clearing the name field or setting it to the exact basename removes the override.

Persisted labels matching the exact historical generated title-case value remain legacy defaults. Distinct custom labels remain intact.

Rebased previous HEAD `989bb5ed20ed0cce55f6a2e7dec5ebebc5d39858` onto upstream main `d073858dc231c91eaa0236a69547b6a50a8bd15c`. Final HEAD is `b0d85232927365e9f6f2e604e9324ee8edaa9595`.

### Actual rebase conflicts

Git stopped in `SessionProjectScroller.tsx` and `sortableItems.tsx`, both under `packages/ui/src/components/session/sidebar/projects`. Upstream replaced fixed `text-[14px]` sizing with `typography-ui-label`; this PR removed `lowercase` from those same class strings. The scroller conflict is the localized Recent heading; the sortable identity conflict is the project label itself.

Both resolutions keep upstream's typography token and remove forced lowercasing. The static-render regression now also guards the typography token. `useProjectsStore.ts` merged without a textual conflict. Current upstream settings parsing still accepts an optional label, and its registry, split-file persistence, and synchronization mechanisms remain unchanged.

## Non-goals

- No project directory, ID, order, icon, color, session ownership, or worktree behavior changes.
- No session-title casing or branch-formatting changes.
- Notification project-name formatting remains outside this PR.
- No server, SDK, IPC, transport, or native-shell changes.

## Affected surfaces

- `packages/ui`: project metadata, project identity editing and auto-save, sidebar labels, Projects Settings, Linear mapping, desktop window title, and shared mobile labels.
- Web and Electron consume the shared UI. Earlier Electron smoke evidence is historical, not a fresh validation of this HEAD.
- Hosted/Capacitor mobile consume the shared mobile path helper. Native device/simulator behavior was not exercised in this update.
- VS Code workspace projects retain shared basename derivation and do not expose project rename controls.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md`, `openchamber-change-discipline`, `CONTRIBUTING.md`, PR template | Source and persistence compatibility | Sequential rebase with backup ref; minimal resolution; no dependencies or changelog edits; final diff/range-diff review |
| `theme-system`, `references/tokens-and-examples.md`, `locale-ui-patterns` | Label classes and user-visible names | Keeps upstream typography token, removes only casing transform, leaves user-generated names literal and localized Recent label reactive |
| `settings-ui-patterns`, `references/controls.md` | Existing project identity input and auto-save | Preserves existing controls/layout/search; clearing the input removes the override. No controls or search entries added or moved |
| `sync-state-invariants`, `ui-api-decoupling`, `references/implementation-map.md` | Project metadata synchronization | Keeps upstream authority and runtime boundaries; no changes to settings registry or transport |
| Stores, sync, settings, and sidebar `DOCUMENTATION.md` | Owning state and storage contracts | Optional label and clear-override behavior remain compatible with current settings parsing and persistence |
| `performance-engineering` | Shared rendered labels and store updates | No polling, cache, or new performance mechanism; no performance improvement claimed |
| `communication-style`, `writing-for-agents`, `pr-review`, web `README.md` | Documentation and handoff | Preserves the owning label contract, reports current checks and historical visual limits. `packages/ui/README.md` does not exist |

## Validation

Checks ran on the final source tree committed as `b0d85232927365e9f6f2e604e9324ee8edaa9595`.

| Check | Result |
|---|---|
| `bun test packages/ui/src/lib/projectDisplayLabel.test.ts packages/ui/src/stores/useProjectsStore.test.ts packages/ui/src/components/session/sidebar/projects/projectHeaderIdentity.test.tsx packages/ui/src/apps/mobilePaths.test.ts packages/ui/src/components/session/sidebar/utils.test.ts` | Passed: 28 tests, 50 assertions. Covers casing, basename defaults, legacy labels, clear override, mobile labels, fallback helpers, and upstream typography |
| `bun test packages/ui/src/lib/persistence.test.ts` | Passed: 51 tests, 135 assertions. Runner logs include offline/connection warnings and caught `document is not defined` errors from DOM-less typography application; no test failed |
| `bun test packages/ui/src/lib/settings/registry.test.ts` | Passed: 9 tests, 604 assertions |
| `bun run type-check:ui` | Failed with five errors in unchanged `src/lib/codemirror/languageByExtension.ts`: TS2322 at 34:7, 48:7, 51:7; TS2345 at 62:52, 73:44. Installed `@codemirror/language` 6.12.2/6.12.4 and `@codemirror/state` 6.5.4/6.7.1 have incompatible private type identities. No dependency changes attempted |
| `bun run lint:ui` | Passed without warnings |
| `bun run build:web` | Passed, including production Vite and PWA service-worker builds. Large-chunk warnings remain |
| `bunx oxlint packages/ui/src/stores/useProjectsStore.ts packages/ui/src/stores/useProjectsStore.test.ts packages/ui/src/lib/projectDisplayLabel.ts packages/ui/src/lib/projectDisplayLabel.test.ts packages/ui/src/components/session/sidebar/projects/projectHeaderIdentity.test.tsx packages/ui/src/apps/mobilePaths.test.ts` | Store/older-test findings remain in pre-existing code. Removed the PR's unnecessary fixture casts and conditional empty-object spread. The four helper/regression files report no findings |
| `bun run dead-code` | Completed and inspected: 1 unused file, 266 unused exports, 160 unused exported types, 1 duplicate export. No finding names the added display-label helper or project-header regression file |
| `git diff --check`, final base-to-HEAD review, rebase range-diff | Passed; only typography conflicts plus scoped regression/simplification follow-up |

No independent simplifier tool was available; a scoped self-review removed unnecessary casts and the conditional spread. Full UI/workspace suites, live browser/Electron interaction, restart persistence, native mobile, VS Code runtime interaction, and production performance measurements were not rerun. Static rendering and builds do not establish those runtime results.

## Visual evidence

The following before/after images are retained from the earlier PR handoff. They demonstrate the intended mixed-case label behavior, not fresh captures of this final HEAD. Current upstream uses a typography token instead of the fixed size in that earlier code. This rebase preserves the token, so these images do not verify current sizing, surrounding chrome, responsive layouts, or theme variants.

### Historical before

![Before: mixed-case custom project label forced lowercase in sidebar](https://github.com/jephsdge/openchamber/releases/download/pr-2758-evidence/before_0.jpg)

![Before: custom project label context](https://github.com/jephsdge/openchamber/releases/download/pr-2758-evidence/before_1.jpg)

### Historical after

![After: mixed-case custom project label preserved in sidebar](https://github.com/jephsdge/openchamber/releases/download/pr-2758-evidence/after_0.jpg)

![After: custom project label context](https://github.com/jephsdge/openchamber/releases/download/pr-2758-evidence/after_1.jpg)

Earlier Electron smoke testing covered default/custom labels, restart persistence, restore-default, and another restart. That flow was not repeated in this update. Fresh post-rebase visual evidence remains unverified.

## Risks and failure behavior

- Persisted labels matching the exact historical generated form are interpreted as defaults. Distinct custom labels remain intact.
- Restoring the default removes only `label`. Project identity, metadata, sessions, worktrees, and ordering remain unchanged.
- The current upstream parser keeps `label` optional. Existing settings persistence reports failed writes; this PR does not replace its failure behavior or mutate the filesystem.
- No schema-version migration is added. Older versions accept projects without a label, but a downgrade/restart flow was not rerun.
- Local backup ref `backup/pr2770-before-rebase-20260910` preserves the previous head. A fresh `/oc-review` is requested for the final HEAD; previous verdicts do not validate this update.
