### PR TITLE
fix(cli): atomic settings writes and gate relay key regeneration in connect-url

### DIFF
--- a/packages/web/bin/lib/DOCUMENTATION.md
+++ b/packages/web/bin/lib/DOCUMENTATION.md
@@ -78,6 +78,18 @@ These modules hold reusable, non-presentational logic for commands.
 - `cli-paths.js`
   - Data, run, log, settings, tunnel profile, and managed-local config paths.
 
+- `cli-settings-accessors.js`
+  - Minimal settings.json read/write for CLI contexts that must not load the
+    full web settings runtime (`connect-url` relay identity resolution).
+  - Mirrors the settings runtime's guarantees so a CLI read-modify-write can
+    never corrupt shared state: atomic tmp+rename writes (no concurrent reader
+    in the running app can observe a torn file), a strict read that throws on
+    corrupt/unreadable payloads, and the same `0600` file mode.
+  - The strict read gates relay identity regeneration exactly like the server
+    runtime: a swallowed read failure can never mint a replacement signing or
+    encryption keypair, which would change `serverId` and orphan every paired
+    device and push binding.
+
 - `cli-process.js`
   - PID files, instance registry files, process identity checks, runtime metadata checks, and process termination helpers.
 

--- a/packages/web/bin/lib/cli-settings-accessors.js
+++ b/packages/web/bin/lib/cli-settings-accessors.js
@@ -1,0 +1,101 @@
+// Minimal settings.json access for CLI contexts (connect-url, pairing
+// candidate building) that must not load the full web settings runtime.
+//
+// The running app already treats settings.json as a shared store — the relay
+// identity, tunnels, notifications, the Electron main, and ssh-manager all
+// read-modify-write it. This accessor must therefore mirror the settings
+// runtime's guarantees or it will corrupt or regenerate shared state:
+//
+//   - ATOMIC writes (write tmp, rename into place). A plain writeFile can
+//     interleave with a concurrent reader in the running app; the reader sees
+//     a half-written file, its lenient read maps it to `{}`, and relay
+//     identity logic then mints a NEW serverId — orphaning every paired
+//     device. The tmp+rename below means no reader can ever observe a partial
+//     file.
+//
+//   - A STRICT read that THROWS on corrupt/unreadable payloads, gating relay
+//     identity regeneration. Only a genuinely missing file means "no
+//     settings"; any other failure (corrupt JSON, EACCES, transient I/O,
+//     non-object payload) must propagate so callers never confuse a broken
+//     read with first run and mint a replacement signing/encryption keypair.
+
+export const createSettingsAccessors = ({ fsPromises, path, dataDir, settingsFileName }) => {
+  const settingsPath = path.join(dataDir, settingsFileName);
+
+  const readSettingsFromDiskMigrated = async () => {
+    try {
+      return JSON.parse(await fsPromises.readFile(settingsPath, 'utf8'));
+    } catch {
+      return {};
+    }
+  };
+
+  const readSettingsStrict = async () => {
+    let raw;
+    try {
+      raw = await fsPromises.readFile(settingsPath, 'utf8');
+    } catch (error) {
+      if (error && typeof error === 'object' && error.code === 'ENOENT') {
+        return {};
+      }
+      throw error;
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('Settings file is malformed (non-object payload)');
+    }
+    return parsed;
+  };
+
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const isTransientWindowsReplaceError = (error) => {
+    if (process.platform !== 'win32' || !error || typeof error !== 'object') {
+      return false;
+    }
+    return error.code === 'EPERM' || error.code === 'EACCES' || error.code === 'EBUSY';
+  };
+
+  const replaceFile = async (tmp, target) => {
+    const maxAttempts = process.platform === 'win32' ? 6 : 1;
+    let lastError = null;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        await fsPromises.rename(tmp, target);
+        return;
+      } catch (error) {
+        lastError = error;
+        if (!isTransientWindowsReplaceError(error) || attempt === maxAttempts) {
+          break;
+        }
+        await sleep(25 * attempt);
+      }
+    }
+
+    if (!isTransientWindowsReplaceError(lastError)) {
+      throw lastError;
+    }
+
+    // Windows can transiently reject the atomic replace while another process
+    // briefly holds the target open. Copy the COMPLETE tmp file into place so
+    // persistence never wedges; a reader can still never see partial content.
+    await fsPromises.copyFile(tmp, target);
+    await fsPromises.rm(tmp, { force: true });
+  };
+
+  const writeSettingsToDisk = async (settings) => {
+    await fsPromises.mkdir(path.dirname(settingsPath), { recursive: true });
+    const tmp = `${settingsPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await fsPromises.writeFile(tmp, JSON.stringify(settings, null, 2), { encoding: 'utf8', mode: 0o600 });
+    if (process.platform !== 'win32') {
+      await fsPromises.chmod(tmp, 0o600);
+    }
+    await replaceFile(tmp, settingsPath);
+    if (process.platform !== 'win32') {
+      await fsPromises.chmod(settingsPath, 0o600);
+    }
+  };
+
+  return { readSettingsFromDiskMigrated, readSettingsStrict, writeSettingsToDisk };
+};

--- a/packages/web/bin/lib/cli-settings-accessors.js
+++ b/packages/web/bin/lib/cli-settings-accessors.js
@@ -78,8 +78,10 @@ export const createSettingsAccessors = ({ fsPromises, path, dataDir, settingsFil
     }
 
     // Windows can transiently reject the atomic replace while another process
-    // briefly holds the target open. Copy the COMPLETE tmp file into place so
-    // persistence never wedges; a reader can still never see partial content.
+    // briefly holds the target open. Fall back to copying the COMPLETE tmp file
+    // so persistence never wedges. Note: copyFile is NOT atomic — this is a
+    // last-resort path confined to Windows, matching the settings runtime's
+    // fallback, not a substitute for the atomic rename used everywhere else.
     await fsPromises.copyFile(tmp, target);
     await fsPromises.rm(tmp, { force: true });
   };

--- a/packages/web/bin/lib/cli-settings-accessors.test.js
+++ b/packages/web/bin/lib/cli-settings-accessors.test.js
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+
+import { createSettingsAccessors } from './cli-settings-accessors.js';
+import { createRelayIdentityRuntime } from '../../server/lib/relay/identity.js';
+
+const withTempDir = async (fn) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-settings-accessors-'));
+  try {
+    return await fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+const makeAccessors = (dir) =>
+  createSettingsAccessors({ fsPromises: fs.promises, path, dataDir: dir, settingsFileName: 'settings.json' });
+
+describe('cli settings accessors', () => {
+  it('persists the full object atomically and cleans up its tmp file', async () => {
+    await withTempDir(async (dir) => {
+      const accessors = makeAccessors(dir);
+      await accessors.writeSettingsToDisk({ theme: 'dark', count: 3 });
+
+      const raw = JSON.parse(fs.readFileSync(path.join(dir, 'settings.json'), 'utf8'));
+      expect(raw).toEqual({ theme: 'dark', count: 3 });
+
+      const leftovers = fs.readdirSync(dir).filter((name) => name.startsWith('settings.json.tmp-'));
+      expect(leftovers).toEqual([]);
+    });
+  });
+
+  it('never leaves a partial file observable by a concurrent reader during writes', async () => {
+    await withTempDir(async (dir) => {
+      const accessors = makeAccessors(dir);
+      const filePath = path.join(dir, 'settings.json');
+
+      // Hammer reads concurrently with writes; every observed payload must be a
+      // complete, parseable object (the old plain writeFile could surface a
+      // torn file mid-rename, which is what tripped the relay identity logic).
+      const stop = { value: false };
+      const reader = (async () => {
+        while (!stop.value) {
+          try {
+            const parsed = JSON.parse(await fs.promises.readFile(filePath, 'utf8'));
+            if (parsed && typeof parsed === 'object') {
+              // A complete object is always fine; anything else would be a tear.
+              expect(parsed.theme).toBe('dark');
+            }
+          } catch {
+            // ENOENT during the very first write is acceptable.
+          }
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+      })();
+
+      const big = { theme: 'dark', filler: 'x'.repeat(4096) };
+      await Promise.all(
+        Array.from({ length: 50 }, (_, i) =>
+          accessors.writeSettingsToDisk({ ...big, n: i }).catch(() => {}),
+        ),
+      );
+      stop.value = true;
+      await reader;
+
+      const final = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      expect(final.theme).toBe('dark');
+    });
+  });
+
+  it('lenient read maps a corrupt file to {} for config lookup', async () => {
+    await withTempDir(async (dir) => {
+      const accessors = makeAccessors(dir);
+      fs.writeFileSync(path.join(dir, 'settings.json'), '{"unfinished": "trunc');
+      expect(await accessors.readSettingsFromDiskMigrated()).toEqual({});
+    });
+  });
+
+  it('strict read throws on a corrupt file instead of reporting "no settings"', async () => {
+    await withTempDir(async (dir) => {
+      const accessors = makeAccessors(dir);
+      fs.writeFileSync(path.join(dir, 'settings.json'), '{"unfinished": "trunc');
+      await expect(accessors.readSettingsStrict()).rejects.toThrow();
+    });
+  });
+
+  it('strict read throws on a non-object payload', async () => {
+    await withTempDir(async (dir) => {
+      const accessors = makeAccessors(dir);
+      fs.writeFileSync(path.join(dir, 'settings.json'), '"just a string"');
+      await expect(accessors.readSettingsStrict()).rejects.toThrow(/non-object payload/);
+    });
+  });
+
+  it('strict read treats only a genuinely missing file as no settings', async () => {
+    await withTempDir(async (dir) => {
+      const accessors = makeAccessors(dir);
+      expect(await accessors.readSettingsStrict()).toEqual({});
+    });
+  });
+
+  it('does not regenerate the relay identity off a corrupt settings file', async () => {
+    await withTempDir(async (dir) => {
+      const accessors = makeAccessors(dir);
+      fs.writeFileSync(
+        path.join(dir, 'settings.json'),
+        JSON.stringify({
+          relaySigningKey: {
+            privateJwk: crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' }).privateKey.export({ format: 'jwk' }),
+            publicJwk: crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' }).publicKey.export({ format: 'jwk' }),
+          },
+        }),
+      );
+      const identity = await createRelayIdentityRuntime({ crypto, ...accessors }).getRelayIdentity();
+      const serverIdBefore = identity.serverId;
+
+      // Corrupt the file, then ask for the identity again: the strict gate must
+      // make this FAIL rather than mint a replacement keypair.
+      fs.writeFileSync(path.join(dir, 'settings.json'), '{"relaySigningKey": {"unfinished');
+      await expect(createRelayIdentityRuntime({ crypto, ...accessors }).getRelayIdentity()).rejects.toThrow();
+      expect(serverIdBefore).toBeTruthy();
+    });
+  });
+});

--- a/packages/web/bin/lib/cli-settings-accessors.test.js
+++ b/packages/web/bin/lib/cli-settings-accessors.test.js
@@ -16,8 +16,66 @@ const withTempDir = async (fn) => {
   }
 };
 
-const makeAccessors = (dir) =>
-  createSettingsAccessors({ fsPromises: fs.promises, path, dataDir: dir, settingsFileName: 'settings.json' });
+const makeAccessors = (dir, overrides = {}) =>
+  createSettingsAccessors({
+    fsPromises: fs.promises,
+    path,
+    dataDir: dir,
+    settingsFileName: 'settings.json',
+    ...overrides,
+  });
+
+// Wraps writeFile so each write lands in two chunks with a pause in between —
+// a stand-in for a large, slow write on a real disk (one open handle, so the
+// file grows from the prefix to the full payload). With a non-atomic writer a
+// concurrent reader deterministically catches the half-written file in that
+// window; with the atomic tmp+rename writer the target only ever changes via a
+// complete rename, so the window is never observable.
+const makeSlowWriteFs = () => {
+  const realFs = fs.promises;
+  const slowWriteFile = async (filePath, data) => {
+    const handle = await realFs.open(filePath, 'w');
+    try {
+      const half = Math.floor(data.length / 2);
+      await handle.writeFile(data.slice(0, half), 'utf8');
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await handle.writeFile(data.slice(half), 'utf8');
+    } finally {
+      await handle.close();
+    }
+  };
+  return { slowWriteFile, fsPromises: { ...realFs, writeFile: slowWriteFile } };
+};
+
+// Runs `writer` against filePath while a concurrent reader hammers it; returns
+// how many times the reader observed an unparseable (torn) payload. ENOENT
+// during the very first write is not a tear and is excluded.
+const countTornReads = async (filePath, writer, iterations) => {
+  const big = { theme: 'dark', filler: 'x'.repeat(4096) };
+  let torn = 0;
+  let stop = false;
+  const reader = (async () => {
+    while (!stop) {
+      try {
+        const parsed = JSON.parse(await fs.promises.readFile(filePath, 'utf8'));
+        if (parsed && typeof parsed === 'object') {
+          expect(parsed.theme).toBe('dark');
+        }
+      } catch (error) {
+        if (error?.code !== 'ENOENT') {
+          torn += 1;
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  })();
+  for (let i = 0; i < iterations; i += 1) {
+    await writer({ ...big, n: i });
+  }
+  stop = true;
+  await reader;
+  return torn;
+};
 
 describe('cli settings accessors', () => {
   it('persists the full object atomically and cleans up its tmp file', async () => {
@@ -33,41 +91,36 @@ describe('cli settings accessors', () => {
     });
   });
 
-  it('never leaves a partial file observable by a concurrent reader during writes', async () => {
+  it('atomic writes: concurrent readers never observe a torn file, even under slow writes', async () => {
     await withTempDir(async (dir) => {
-      const accessors = makeAccessors(dir);
+      const { fsPromises } = makeSlowWriteFs();
+      const accessors = makeAccessors(dir, { fsPromises });
       const filePath = path.join(dir, 'settings.json');
 
-      // Hammer reads concurrently with writes; every observed payload must be a
-      // complete, parseable object (the old plain writeFile could surface a
-      // torn file mid-rename, which is what tripped the relay identity logic).
-      const stop = { value: false };
-      const reader = (async () => {
-        while (!stop.value) {
-          try {
-            const parsed = JSON.parse(await fs.promises.readFile(filePath, 'utf8'));
-            if (parsed && typeof parsed === 'object') {
-              // A complete object is always fine; anything else would be a tear.
-              expect(parsed.theme).toBe('dark');
-            }
-          } catch {
-            // ENOENT during the very first write is acceptable.
-          }
-          await new Promise((resolve) => setTimeout(resolve, 0));
-        }
-      })();
+      // Each write is chunked with a pause, yet the reader must never see a
+      // partial payload: the target only changes via a complete atomic rename.
+      const torn = await countTornReads(filePath, (settings) => accessors.writeSettingsToDisk(settings), 20);
+      expect(torn).toBe(0);
 
-      const big = { theme: 'dark', filler: 'x'.repeat(4096) };
-      await Promise.all(
-        Array.from({ length: 50 }, (_, i) =>
-          accessors.writeSettingsToDisk({ ...big, n: i }).catch(() => {}),
-        ),
+      const leftovers = fs.readdirSync(dir).filter((name) => name.startsWith('settings.json.tmp-'));
+      expect(leftovers).toEqual([]);
+    });
+  });
+
+  it('demonstrates the protected failure mode: a naive direct writer tears under the same slow write', async () => {
+    await withTempDir(async (dir) => {
+      const { slowWriteFile } = makeSlowWriteFs();
+      const filePath = path.join(dir, 'settings.json');
+
+      // The old CLI accessor wrote straight to settings.json with writeFile.
+      // The same slow-write load therefore MUST produce torn reads — proving
+      // the concurrency test above can actually fail on the pre-fix writer.
+      const torn = await countTornReads(
+        filePath,
+        (settings) => slowWriteFile(filePath, JSON.stringify(settings)),
+        20,
       );
-      stop.value = true;
-      await reader;
-
-      const final = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-      expect(final.theme).toBe('dark');
+      expect(torn).toBeGreaterThan(0);
     });
   });
 

--- a/packages/web/bin/lib/commands-connect-url.js
+++ b/packages/web/bin/lib/commands-connect-url.js
@@ -17,6 +17,7 @@ import { createClientPairingRuntime } from '../../server/lib/client-auth/pairing
 import { createRelayIdentityRuntime } from '../../server/lib/relay/identity.js';
 import { DEFAULT_RELAY_URL } from '../../server/lib/relay/service.js';
 import { bytesToBase64Url } from '../../server/lib/relay/e2ee.js';
+import { createSettingsAccessors as createSettingsAccessorsModule } from './cli-settings-accessors.js';
 import {
   intro as clackIntro,
   outro as clackOutro,
@@ -28,7 +29,6 @@ import {
 } from '../cli-output.js';
 
 const REMOTE_CLIENTS_FILE_NAME = 'remote-clients.json';
-const SETTINGS_FILE_NAME = 'settings.json';
 const PAIRING_SESSIONS_FILE_NAME = 'client-pairing-sessions.json';
 
 function isValidRelayUrl(value) {
@@ -55,20 +55,18 @@ function resolveRelayUrl(settings) {
 // Minimal settings.json read/write for the relay identity runtime. It reads the
 // whole object and writes it back with the relay keys added, so other settings
 // are preserved. Enough for the CLI without wiring the full settings runtime.
+//
+// Mirrors the settings runtime's guarantees: atomic writes (tmp + rename) so
+// concurrent readers in the running app never observe a half-written file, and
+// a STRICT reader gating relay identity regeneration so a swallowed read
+// failure can never mint a new serverId and orphan paired devices.
 function createSettingsAccessors() {
-  const settingsPath = path.join(getOpenChamberDataDir(), SETTINGS_FILE_NAME);
-  const readSettingsFromDiskMigrated = async () => {
-    try {
-      return JSON.parse(await fs.promises.readFile(settingsPath, 'utf8'));
-    } catch {
-      return {};
-    }
-  };
-  const writeSettingsToDisk = async (settings) => {
-    await fs.promises.mkdir(path.dirname(settingsPath), { recursive: true });
-    await fs.promises.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
-  };
-  return { readSettingsFromDiskMigrated, writeSettingsToDisk };
+  return createSettingsAccessorsModule({
+    fsPromises: fs.promises,
+    path,
+    dataDir: getOpenChamberDataDir(),
+    settingsFileName: 'settings.json',
+  });
 }
 
 // Resolves the instance's relay identity (serverId + encryption public key,


### PR DESCRIPTION
## Intent

`openchamber connect-url` (and any CLI path that builds a relay pairing candidate) wrote `settings.json` directly with `writeFile` and read it leniently, with no strict-reader gate on relay identity regeneration. Running the CLI while the desktop app is up could:

1. tear the settings file for a concurrent reader in the app, tripping the relay service's read into `{}` ("first run");
2. then the CLI's own lenient read + identity logic minted a **new relay signing/encryption keypair**, changing `serverId` and orphaning every paired device and push binding.

This moves the CLI accessors into a dedicated module that mirrors the settings runtime's guarantees so a CLI read-modify-write can never corrupt shared state or regenerate the relay identity.

## Non-goals

- Not touching the server/desktop settings runtime (already atomic + strict-gated).
- Not changing the pairing/transport behavior itself.

## Affected surfaces

- `packages/web` CLI (`connect-url` relay candidate building). Behavior is otherwise identical: same settings file, same relay keys, same pairing output. No user-visible UI, no persisted contract changes; the file on disk is now written atomically and with the same `0600` mode the settings runtime uses.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — Correctness invariants: "Prefer authoritative state over heuristics" / "Never let fetch failure masquerade as authoritative empty success" | A swallowed read failure previously looked like "first run" and triggered key regeneration | Added a strict reader (mirrors `readSettingsFromDiskStrict`) that throws on corrupt/unreadable payloads; only a genuinely missing file means "no settings" |
| Skill `openchamber-change-discipline` | Any source/module-ownership change; this adds a helper module and updates the owning docs | Smallest complete change; preserved observable CLI behavior; atomic write + strict read mirror the existing settings runtime; updated `packages/web/bin/lib/DOCUMENTATION.md` module map |
| Skill `clack-cli-patterns` | CLI command behavior (`connect-url` output/exit modes) | The change keeps command behavior unchanged; the new throw path is surfaced by the existing CLI `main().catch` per-mode handling (GENERAL_ERROR), no new output contract introduced |
| Skill `relay-transport` | The change hardens relay identity persistence (serverId / trust anchor) | Strict-read gating is exactly the pattern the relay identity runtime already uses server-side; no wire/tunnel behavior touched |
| `packages/web` runtime boundary (server + CLI) | The change is in the CLI settings accessors used by `connect-url` | Kept logic in the CLI lib; wired the strict reader into `createRelayIdentityRuntime` exactly like `packages/web/server/index.js` does |
| Local code precedent | `packages/web/server/lib/opencode/settings-runtime.js` already does atomic tmp+rename and strict reads | The new `cli-settings-accessors.js` mirrors that implementation (tmp + rename, `0600`, Windows replace fallback) |

## Validation

| Check | Result |
|---|---|
| `node --check` on all three source files | Passed |
| New unit tests `cli-settings-accessors.test.js` (8 tests) via vitest | 8/8 passed — includes deterministic torn-write coverage: a slow chunked write makes the naive direct writer produce torn reads (proving the atomicity test can fail on the pre-fix writer), while the atomic writer yields zero torn reads under the same load; plus strict-read throws on corrupt/non-object, ENOENT → `{}`, and corrupt file makes `getRelayIdentity` throw instead of regenerating keys |
| Review follow-up | Windows fallback comment corrected (copyFile is non-atomic, last-resort); `cli-settings-accessors.js` added to the CLI module map in `packages/web/bin/lib/DOCUMENTATION.md` |

Not verified: full repo build/test suite (dependencies not installed in this checkout); `bun run dead-code` and package `type-check`/`lint` require a Bun install that this checkout lacks.

## Visual evidence

No user-visible change: this is a backend file-write path with no rendered surface, so screenshots cannot show anything different.

## Risks and failure behavior

- Failure mode: a corrupt/racy settings file previously caused silent key regeneration and data loss (settings wiped to `{}`). Now it surfaces as a thrown error from `getRelayIdentity` (CLI aborts) — no regeneration, no wipe.
- Rollback/cleanup: leftover tmp files are removed on the Windows fallback; on failure nothing is left in place of the original file.
- Compatibility: same settings schema and file path; write is mode `0600` as before, matching the settings runtime.
- Security: no secrets touched; identity keys are only read/generated, never logged.
