### PR TITLE
feat(linux): add RPM package support for Fedora/RHEL/CentOS (#2779)

### DIFF
--- a/.github/workflows/release-desktop-smoke.yml
+++ b/.github/workflows/release-desktop-smoke.yml
@@ -376,6 +376,7 @@ jobs:
           name: desktop-release-smoke-linux-${{ matrix.arch }}
           path: |
             packages/electron/dist/OpenChamber-${{ steps.versions.outputs.app }}-linux-${{ matrix.artifact_arch }}.AppImage
+            packages/electron/dist/OpenChamber-${{ steps.versions.outputs.app }}-linux-${{ matrix.artifact_arch }}.rpm
             packages/electron/dist/${{ matrix.manifest }}
           if-no-files-found: error
           retention-days: ${{ fromJSON(inputs.retention_days) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,6 +459,7 @@ jobs:
           name: linux-release-${{ matrix.arch }}
           path: |
             packages/electron/dist/OpenChamber-${{ needs.create-release.outputs.version }}-linux-${{ matrix.artifact_arch }}.AppImage
+            packages/electron/dist/OpenChamber-${{ needs.create-release.outputs.version }}-linux-${{ matrix.artifact_arch }}.rpm
             packages/electron/dist/${{ matrix.manifest }}
           if-no-files-found: error
           retention-days: 1
@@ -495,15 +496,17 @@ jobs:
             "artifacts/arm64/OpenChamber-${VERSION}-linux-arm64.AppImage" \
             "$VERSION"
 
-      - name: Upload Linux AppImages and manifests to release
+      - name: Upload Linux AppImages, RPMs, and manifests to release
         if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: v${{ needs.create-release.outputs.version }}
           files: |
             artifacts/x64/OpenChamber-${{ needs.create-release.outputs.version }}-linux-x86_64.AppImage
+            artifacts/x64/OpenChamber-${{ needs.create-release.outputs.version }}-linux-x86_64.rpm
             artifacts/x64/latest-linux.yml
             artifacts/arm64/OpenChamber-${{ needs.create-release.outputs.version }}-linux-arm64.AppImage
+            artifacts/arm64/OpenChamber-${{ needs.create-release.outputs.version }}-linux-arm64.rpm
             artifacts/arm64/latest-linux-arm64.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -573,8 +576,10 @@ jobs:
           const { REPOSITORY: repo, VERSION: version, GITHUB_TOKEN: token } = process.env;
           const expected = [
             `OpenChamber-${version}-linux-x86_64.AppImage`,
+            `OpenChamber-${version}-linux-x86_64.rpm`,
             'latest-linux.yml',
             `OpenChamber-${version}-linux-arm64.AppImage`,
+            `OpenChamber-${version}-linux-arm64.rpm`,
             'latest-linux-arm64.yml',
           ];
           const response = await fetch(`https://api.github.com/repos/${repo}/releases/tags/v${version}`, {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - **Settings/Integrations:** a new Integrations settings page lists Claude Code, Command Code, and Cursor plugins with install, update, setup, and remove actions, plus Discord and Telegram Coming soon placeholders.
+- **Desktop/Linux:** added official RPM packages for Fedora, RHEL, and CentOS. Install with `sudo dnf install ./OpenChamber-<version>-linux-<arch>.rpm`; the in-app updater is silently skipped for RPM installs (updates are manual via downloading the next release artifact) (thanks to @rlevidev).
 - Usage/Claude: Claude plan limits now work when you are signed in through Claude Code, without also signing into Anthropic in OpenCode; the account is read from Claude Code's own login on macOS, Linux, and WSL. The page shows your session and weekly limits again, adds per-model weekly limits and extra usage spending, and names your plan. Limits are kept on screen instead of disappearing when Anthropic temporarily blocks refreshes.
 - Git: the pull request panel now follows the branch's current open PR, and an open PR always wins over an older merged or closed one. After a PR is merged or closed the panel keeps showing it as the branch's last PR and offers creating the next one right below it (thanks to @makeittech).
 - Chat: new chats no longer start against a deleted last worktree directory; they fall back to the active project instead of saving the first message and never starting.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ chmod +x OpenChamber-*.AppImage
 
 Linux AppImages require FUSE (`libfuse.so.2`). Without FUSE, run with `APPIMAGE_EXTRACT_AND_RUN=1`.
 
+On Fedora, RHEL, or CentOS, install the `.rpm` instead: `sudo dnf install ./OpenChamber-*.rpm` (updates are manual — download the new `.rpm` from the releases page).
+
 ### VS Code
 
 Install [OpenChamber from the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=fedaykindev.openchamber), or search for “OpenChamber” in Extensions.

--- a/packages/docs/content/docs/install.mdx
+++ b/packages/docs/content/docs/install.mdx
@@ -28,6 +28,22 @@ Open the URL the CLI prints (usually `http://localhost:3000`). You should see th
 
 Download the latest desktop build from the GitHub releases page or the OpenChamber download page. Open it and sign into your usual OpenCode workflow.
 
+### Fedora, RHEL, and CentOS (RPM)
+
+On RPM-based distributions, install OpenChamber with your native package manager instead of the AppImage:
+
+```bash
+sudo dnf install ./OpenChamber-<version>-linux-<arch>.rpm
+```
+
+Releases include x86_64 and aarch64 (ARM64) RPMs. To uninstall:
+
+```bash
+sudo dnf remove OpenChamber
+```
+
+RPM installs update manually: download the new `.rpm` from the GitHub releases page and run `sudo dnf install ./OpenChamber-<version>-linux-<arch>.rpm` again. The in-app updater is skipped for RPM installs.
+
 ## VS Code
 
 Install from the VS Code Marketplace and sign into your usual OpenCode workflow. The OpenChamber view then opens in the sidebar.

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -114,7 +114,8 @@
     },
     "linux": {
       "target": [
-        "AppImage"
+        "AppImage",
+        "rpm"
       ],
       "category": "Development",
       "icon": "resources/icons/icon.png",

--- a/packages/electron/updater-capability.mjs
+++ b/packages/electron/updater-capability.mjs
@@ -10,11 +10,9 @@ export const assertUpdaterCapability = ({
 } = {}) => {
   if (platform !== 'linux' || !packaged) return;
 
-  if (!appImagePath) {
-    throw new Error(
-      'Updates require the packaged Linux AppImage. Start OpenChamber from its .AppImage file, not an extracted or repackaged copy.',
-    );
-  }
+  // RPM installs (and extracted AppImages) have no APPIMAGE env var; skip the
+  // updater silently instead of throwing so RPM users see no error on launch.
+  if (!appImagePath) return;
   if (!path.isAbsolute(appImagePath)) {
     throw new Error(`Updates require APPIMAGE to be an absolute path, got: ${appImagePath}`);
   }

--- a/packages/electron/updater-capability.test.mjs
+++ b/packages/electron/updater-capability.test.mjs
@@ -9,10 +9,9 @@ test('preserves updater behavior outside packaged Linux', () => {
   assert.doesNotThrow(() => assertUpdaterCapability({ platform: 'linux', packaged: false }));
 });
 
-test('rejects packaged Linux execution outside an AppImage', () => {
-  assert.throws(
-    () => assertUpdaterCapability({ platform: 'linux', packaged: true, appImagePath: '' }),
-    /Start OpenChamber from its \.AppImage file/,
+test('accepts packaged Linux execution outside an AppImage (RPM installs)', () => {
+  assert.doesNotThrow(
+    () => assertUpdaterCapability({ platform: 'linux', packaged: true, appImagePath: '' })
   );
 });
 


### PR DESCRIPTION
# Add RPM package support for Fedora/RHEL/CentOS

- Closes #2779

## Summary

Adds official RPM package support for Fedora, RHEL, and CentOS distributions. Users can now install OpenChamber with `sudo dnf install ./OpenChamber-*.rpm` instead of relying on AppImage or global npm installs. The in-app updater silently skips for RPM installs instead of throwing an error on every launch.

---

## What changed

### Core changes

- **`packages/electron/package.json`**
  - Added `"rpm"` to `build.linux.target` alongside `"AppImage"`.
  - electron-builder now produces both formats in the same run via fpm.

- **`packages/electron/updater-capability.mjs`**
  - Changed Linux+packaged+no-APPIMAGE branch from `throw` to `return`.
  - RPM users no longer see an error on every launch.

- **`packages/electron/updater-capability.test.mjs`**
  - Updated test from "rejects" to "accepts" packaged Linux outside AppImage.
  - Verifies the new silent-skip behavior.

### Documentation

- **`README.md`**
  - Added RPM install instruction in the Linux section.

- **`packages/docs/content/docs/install.mdx`**
  - Added Fedora/RHEL/CentOS section with install, uninstall, and update instructions.

- **`CHANGELOG.md`**
  - Added entry under `[Unreleased]`.

### CI/Release workflows

- **`.github/workflows/release.yml`**
  - Upload step: added `*.rpm` alongside `*.AppImage` per-arch.
  - Release upload: added RPM files to the release assets.
  - Asset inventory assertion: added `OpenChamber-*-linux-{x86_64,arm64}.rpm` to expected set.

- **`.github/workflows/release-desktop-smoke.yml`**
  - Upload step: added `*.rpm` to smoke build artifacts.

---

## How to test

1. Run `bun run type-check` — must pass.
2. Run `bun run lint` — must pass.
3. Run `node --test packages/electron/updater-capability.test.mjs` — 4/4 tests pass.
4. Run `bun run docs:validate` — must pass.
5. (Manual) Install the `.rpm` on Fedora, verify it appears in dnf, verify it launches, verify in-app updater does not error.

---

## Risk and failure behavior

| Scenario | Before | After |
|---|---|---|
| AppImage launch | Updater enabled (no change) | Updater enabled (no change) |
| RPM launch | Crash on startup (throw) | App starts normally (return) |
| Extracted AppImage | Crash on startup (throw) | App starts normally (return, already unsupported) |

**Rollback:** Revert the `if (!appImagePath) return;` line to restore the original throw behavior.

---

## Deferred to follow-up

- `verify-linux-rpm.mjs`: automated RPM verification script (electron-builder output + manual Fedora testing sufficient for v1).
- COPR repository: deferred if demand justifies.
