### PR TITLE
fix(event-stream): use exponential backoff for upstream SSE reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - VS Code: the extension starts in the current workspace folder instead of one restored from storage (thanks to @makeittech).
 - Themes: custom themes loaded through symlinks now work (thanks to @divyam234).
 - Debug: the debug panel (Ctrl/Cmd+Shift+D) has a Requests tab showing in-flight requests and their age over the last five minutes (thanks to @tomzx).
+- Server: upstream SSE reconnects use exponential backoff (5 s cap) instead of a tight 250 ms retry loop, which previously flooded `main.log` with thousands of `ECONNRESET`/`ECONNREFUSED` errors when the managed OpenCode process died (thanks to @herjarsa).
 - Reliability: switching sessions quickly no longer saves the wrong scroll position, and the log no longer fills with worktree warnings for non-Git folders (thanks to @herjarsa); startup cleanup of leftover processes no longer blocks the server on Windows (thanks to @bashrusakh).
 
 ## [1.21.0] - 2026-08-26

--- a/packages/web/server/lib/event-stream/upstream-reader.js
+++ b/packages/web/server/lib/event-stream/upstream-reader.js
@@ -3,6 +3,21 @@ import { parseSseEventEnvelope } from './protocol.js';
 export const DEFAULT_UPSTREAM_STALL_TIMEOUT_MS = 20_000;
 export const UPSTREAM_STALL_TIMEOUT_CONCURRENT_MS = DEFAULT_UPSTREAM_STALL_TIMEOUT_MS * 3;
 export const DEFAULT_UPSTREAM_RECONNECT_DELAY_MS = 250;
+export const DEFAULT_UPSTREAM_RECONNECT_MAX_DELAY_MS = 30_000;
+export const DEFAULT_UPSTREAM_RECONNECT_BACKOFF_MULTIPLIER = 2;
+const INITIAL_RECONNECT_DELAY_MS = 0;
+
+function resolveReconnectDelay(consecutiveFailures, baseMs, maxMs, multiplier) {
+  const safeBase = Number.isFinite(baseMs) && baseMs > 0 ? baseMs : 0;
+  const safeMax = Number.isFinite(maxMs) && maxMs > 0 ? maxMs : DEFAULT_UPSTREAM_RECONNECT_MAX_DELAY_MS;
+  const safeMultiplier = Number.isFinite(multiplier) && multiplier > 1 ? multiplier : DEFAULT_UPSTREAM_RECONNECT_BACKOFF_MULTIPLIER;
+  if (safeBase <= 0) {
+    return INITIAL_RECONNECT_DELAY_MS;
+  }
+  const exponent = Math.min(consecutiveFailures, 30);
+  const candidate = safeBase * Math.pow(safeMultiplier, exponent);
+  return Math.min(candidate, safeMax);
+}
 
 function resolveTimeoutMs(value, fallback) {
   const resolved = typeof value === 'function' ? value() : value;
@@ -54,6 +69,8 @@ export function createUpstreamSseReader({
   signal,
   stallTimeoutMs = DEFAULT_UPSTREAM_STALL_TIMEOUT_MS,
   reconnectDelayMs = DEFAULT_UPSTREAM_RECONNECT_DELAY_MS,
+  reconnectMaxDelayMs = DEFAULT_UPSTREAM_RECONNECT_MAX_DELAY_MS,
+  reconnectBackoffMultiplier = DEFAULT_UPSTREAM_RECONNECT_BACKOFF_MULTIPLIER,
   onEvent,
   onConnect,
   onDisconnect,
@@ -64,6 +81,7 @@ export function createUpstreamSseReader({
   let activeController = null;
   let lastEventId = typeof initialLastEventId === 'string' ? initialLastEventId : '';
   let stopListenerAttached = false;
+  let consecutiveReconnectFailures = 0;
 
   function detachStopListener() {
     if (!stopListenerAttached) return;
@@ -138,16 +156,24 @@ export function createUpstreamSseReader({
           });
 
           if (!response?.ok || !response.body) {
+            consecutiveReconnectFailures += 1;
             onError?.({
               type: 'upstream_unavailable',
               status: response?.status ?? 0,
               response,
             });
             await cancelResponseBody(response);
-            await waitForReconnectDelay(reconnectDelayMs, signal);
+            const delay = resolveReconnectDelay(
+              consecutiveReconnectFailures,
+              reconnectDelayMs,
+              reconnectMaxDelayMs,
+              reconnectBackoffMultiplier,
+            );
+            await waitForReconnectDelay(delay, signal);
             continue;
           }
 
+          consecutiveReconnectFailures = 0;
           onConnect?.({ response, lastEventId });
 
           const decoder = new TextDecoder();
@@ -204,6 +230,7 @@ export function createUpstreamSseReader({
           }
         } catch (error) {
           if (!stopped && !signal?.aborted && abortReason !== 'upstream_stalled') {
+            consecutiveReconnectFailures += 1;
             onError?.({
               type: 'stream_error',
               error,
@@ -219,7 +246,13 @@ export function createUpstreamSseReader({
         }
 
         if (!stopped && !signal?.aborted) {
-          await waitForReconnectDelay(reconnectDelayMs, signal);
+          const delay = resolveReconnectDelay(
+            consecutiveReconnectFailures,
+            reconnectDelayMs,
+            reconnectMaxDelayMs,
+            reconnectBackoffMultiplier,
+          );
+          await waitForReconnectDelay(delay, signal);
         }
       }
     })().finally(() => {

--- a/packages/web/server/lib/event-stream/upstream-reader.js
+++ b/packages/web/server/lib/event-stream/upstream-reader.js
@@ -3,7 +3,7 @@ import { parseSseEventEnvelope } from './protocol.js';
 export const DEFAULT_UPSTREAM_STALL_TIMEOUT_MS = 20_000;
 export const UPSTREAM_STALL_TIMEOUT_CONCURRENT_MS = DEFAULT_UPSTREAM_STALL_TIMEOUT_MS * 3;
 export const DEFAULT_UPSTREAM_RECONNECT_DELAY_MS = 250;
-export const DEFAULT_UPSTREAM_RECONNECT_MAX_DELAY_MS = 30_000;
+export const DEFAULT_UPSTREAM_RECONNECT_MAX_DELAY_MS = 5_000;
 export const DEFAULT_UPSTREAM_RECONNECT_BACKOFF_MULTIPLIER = 2;
 const INITIAL_RECONNECT_DELAY_MS = 0;
 
@@ -14,7 +14,10 @@ function resolveReconnectDelay(consecutiveFailures, baseMs, maxMs, multiplier) {
   if (safeBase <= 0) {
     return INITIAL_RECONNECT_DELAY_MS;
   }
-  const exponent = Math.min(consecutiveFailures, 30);
+  // Conventional exponential backoff: first failure waits `base`, then `base * multiplier`,
+  // `base * multiplier^2`, etc., capped at `max`. The counter passed in is incremented BEFORE this
+  // call (so the first failure uses counter = 1 and waits `base * multiplier^0` = base).
+  const exponent = Math.min(Math.max(consecutiveFailures - 1, 0), 30);
   const candidate = safeBase * Math.pow(safeMultiplier, exponent);
   return Math.min(candidate, safeMax);
 }

--- a/packages/web/server/lib/event-stream/upstream-reader.js
+++ b/packages/web/server/lib/event-stream/upstream-reader.js
@@ -3,8 +3,8 @@ import { parseSseEventEnvelope } from './protocol.js';
 export const DEFAULT_UPSTREAM_STALL_TIMEOUT_MS = 20_000;
 export const UPSTREAM_STALL_TIMEOUT_CONCURRENT_MS = DEFAULT_UPSTREAM_STALL_TIMEOUT_MS * 3;
 export const DEFAULT_UPSTREAM_RECONNECT_DELAY_MS = 250;
-export const DEFAULT_UPSTREAM_RECONNECT_MAX_DELAY_MS = 5_000;
-export const DEFAULT_UPSTREAM_RECONNECT_BACKOFF_MULTIPLIER = 2;
+const DEFAULT_UPSTREAM_RECONNECT_MAX_DELAY_MS = 5_000;
+const DEFAULT_UPSTREAM_RECONNECT_BACKOFF_MULTIPLIER = 2;
 const INITIAL_RECONNECT_DELAY_MS = 0;
 
 function resolveReconnectDelay(consecutiveFailures, baseMs, maxMs, multiplier) {
@@ -27,7 +27,7 @@ function resolveTimeoutMs(value, fallback) {
   return Number.isFinite(resolved) ? resolved : fallback;
 }
 
-function waitForReconnectDelay(ms, signal) {
+function waitForReconnectDelay(ms, signal, setTimeoutImpl = globalThis.setTimeout) {
   if (signal?.aborted) {
     return Promise.resolve();
   }
@@ -40,7 +40,7 @@ function waitForReconnectDelay(ms, signal) {
       signal?.removeEventListener('abort', onAbort);
       resolve();
     };
-    const timeout = setTimeout(finish, Math.max(0, ms));
+    const timeout = setTimeoutImpl(finish, Math.max(0, ms));
     const onAbort = () => {
       clearTimeout(timeout);
       finish();
@@ -74,6 +74,7 @@ export function createUpstreamSseReader({
   reconnectDelayMs = DEFAULT_UPSTREAM_RECONNECT_DELAY_MS,
   reconnectMaxDelayMs = DEFAULT_UPSTREAM_RECONNECT_MAX_DELAY_MS,
   reconnectBackoffMultiplier = DEFAULT_UPSTREAM_RECONNECT_BACKOFF_MULTIPLIER,
+  setTimeoutImpl = globalThis.setTimeout,
   onEvent,
   onConnect,
   onDisconnect,
@@ -172,7 +173,7 @@ export function createUpstreamSseReader({
               reconnectMaxDelayMs,
               reconnectBackoffMultiplier,
             );
-            await waitForReconnectDelay(delay, signal);
+            await waitForReconnectDelay(delay, signal, setTimeoutImpl);
             continue;
           }
 
@@ -255,7 +256,7 @@ export function createUpstreamSseReader({
             reconnectMaxDelayMs,
             reconnectBackoffMultiplier,
           );
-          await waitForReconnectDelay(delay, signal);
+          await waitForReconnectDelay(delay, signal, setTimeoutImpl);
         }
       }
     })().finally(() => {

--- a/packages/web/server/lib/event-stream/upstream-reader.test.js
+++ b/packages/web/server/lib/event-stream/upstream-reader.test.js
@@ -317,8 +317,8 @@ describe("createUpstreamSseReader", () => {
 
     expect(errors).toHaveLength(4);
     expect(attempt).toBe(5);
-    // Expected wait: 20 + 40 + 40 + 40 = 140ms minimum (first failure = 10*2, then capped at 40)
-    expect(elapsed).toBeGreaterThanOrEqual(100);
+    // Conventional backoff: first failure waits base (10ms), then 20, 40, 40 (capped) = 110ms minimum
+    expect(elapsed).toBeGreaterThanOrEqual(80);
   });
 
   it("resets the consecutive failure counter after a successful connect", async () => {

--- a/packages/web/server/lib/event-stream/upstream-reader.test.js
+++ b/packages/web/server/lib/event-stream/upstream-reader.test.js
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { createUpstreamSseReader } from './upstream-reader.js';
+import { createUpstreamSseReader } from "./upstream-reader.js";
 
 function createSseResponse({ blocks = [], signal, holdOpen = false }) {
   const encoder = new TextEncoder();
@@ -23,12 +23,12 @@ function createSseResponse({ blocks = [], signal, holdOpen = false }) {
 
             return new Promise((_resolve, reject) => {
               const onAbort = () => {
-                signal.removeEventListener('abort', onAbort);
-                const error = new Error('Aborted');
-                error.name = 'AbortError';
+                signal.removeEventListener("abort", onAbort);
+                const error = new Error("Aborted");
+                error.name = "AbortError";
                 reject(error);
               };
-              signal.addEventListener('abort', onAbort, { once: true });
+              signal.addEventListener("abort", onAbort, { once: true });
             });
           },
         };
@@ -43,12 +43,12 @@ function createTrackedSignal() {
     signal: {
       aborted: false,
       addEventListener(type, listener) {
-        if (type === 'abort') {
+        if (type === "abort") {
           listeners.add(listener);
         }
       },
       removeEventListener(type, listener) {
-        if (type === 'abort') {
+        if (type === "abort") {
           listeners.delete(listener);
         }
       },
@@ -59,20 +59,21 @@ function createTrackedSignal() {
   };
 }
 
-describe('createUpstreamSseReader', () => {
-  it('emits parsed events and tracks the latest event id', async () => {
+describe("createUpstreamSseReader", () => {
+  it("emits parsed events and tracks the latest event id", async () => {
     const events = [];
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => 'http://127.0.0.1:4096/global/event',
+      buildUrl: () => "http://127.0.0.1:4096/global/event",
       reconnectDelayMs: 0,
-      fetchImpl: async (_url, options) => createSseResponse({
-        signal: options.signal,
-        blocks: [
-          'id: evt-1\r\ndata: {"type":"server.connected","properties":{"directory":"/tmp/project"}}\r\n\r\n',
-        ],
-      }),
+      fetchImpl: async (_url, options) =>
+        createSseResponse({
+          signal: options.signal,
+          blocks: [
+            'id: evt-1\r\ndata: {"type":"server.connected","properties":{"directory":"/tmp/project"}}\r\n\r\n',
+          ],
+        }),
       onEvent(event) {
         events.push(event);
         reader.stop();
@@ -82,29 +83,29 @@ describe('createUpstreamSseReader', () => {
     await reader.start();
 
     expect(events).toHaveLength(1);
-    expect(events[0].eventId).toBe('evt-1');
-    expect(events[0].directory).toBe('/tmp/project');
+    expect(events[0].eventId).toBe("evt-1");
+    expect(events[0].directory).toBe("/tmp/project");
     expect(events[0].payload).toEqual({
-      type: 'server.connected',
+      type: "server.connected",
       properties: {
-        directory: '/tmp/project',
+        directory: "/tmp/project",
       },
     });
-    expect(reader.getLastEventId()).toBe('evt-1');
+    expect(reader.getLastEventId()).toBe("evt-1");
   });
 
-  it('reconnects a stalled stream with Last-Event-ID', async () => {
+  it("reconnects a stalled stream with Last-Event-ID", async () => {
     const fetchLastEventIds = [];
     const events = [];
     let attempt = 0;
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => 'http://127.0.0.1:4096/global/event',
+      buildUrl: () => "http://127.0.0.1:4096/global/event",
       stallTimeoutMs: 10,
       reconnectDelayMs: 0,
       fetchImpl: async (_url, options) => {
-        fetchLastEventIds.push(options.headers['Last-Event-ID'] ?? null);
+        fetchLastEventIds.push(options.headers["Last-Event-ID"] ?? null);
         attempt += 1;
 
         if (attempt === 1) {
@@ -126,7 +127,7 @@ describe('createUpstreamSseReader', () => {
       },
       onEvent(event) {
         events.push(event.eventId);
-        if (event.eventId === 'evt-2') {
+        if (event.eventId === "evt-2") {
           reader.stop();
         }
       },
@@ -134,19 +135,19 @@ describe('createUpstreamSseReader', () => {
 
     await reader.start();
 
-    expect(events).toEqual(['evt-1', 'evt-2']);
-    expect(fetchLastEventIds.slice(0, 2)).toEqual([null, 'evt-1']);
-    expect(reader.getLastEventId()).toBe('evt-2');
+    expect(events).toEqual(["evt-1", "evt-2"]);
+    expect(fetchLastEventIds.slice(0, 2)).toEqual([null, "evt-1"]);
+    expect(reader.getLastEventId()).toBe("evt-2");
   });
 
-  it('resolves the stall timeout for each upstream read window', async () => {
+  it("resolves the stall timeout for each upstream read window", async () => {
     const events = [];
     let attempt = 0;
     let currentTimeout = 10;
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => 'http://127.0.0.1:4096/global/event',
+      buildUrl: () => "http://127.0.0.1:4096/global/event",
       stallTimeoutMs: () => currentTimeout,
       reconnectDelayMs: 0,
       fetchImpl: async (_url, options) => {
@@ -172,7 +173,7 @@ describe('createUpstreamSseReader', () => {
       },
       onEvent(event) {
         events.push(event.eventId);
-        if (event.eventId === 'evt-2') {
+        if (event.eventId === "evt-2") {
           reader.stop();
         }
       },
@@ -180,18 +181,18 @@ describe('createUpstreamSseReader', () => {
 
     await reader.start();
 
-    expect(events).toEqual(['evt-1', 'evt-2']);
+    expect(events).toEqual(["evt-1", "evt-2"]);
     expect(attempt).toBe(2);
   });
 
-  it('reports unavailable upstream responses and continues reconnecting until stopped', async () => {
+  it("reports unavailable upstream responses and continues reconnecting until stopped", async () => {
     const errors = [];
     let attempt = 0;
     let unavailableBodyCanceled = false;
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => 'http://127.0.0.1:4096/global/event',
+      buildUrl: () => "http://127.0.0.1:4096/global/event",
       reconnectDelayMs: 0,
       fetchImpl: async (_url, options) => {
         attempt += 1;
@@ -226,7 +227,7 @@ describe('createUpstreamSseReader', () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        type: 'upstream_unavailable',
+        type: "upstream_unavailable",
         status: 503,
       }),
     ]);
@@ -234,13 +235,13 @@ describe('createUpstreamSseReader', () => {
     expect(attempt).toBe(2);
   });
 
-  it('removes abort listeners after stop', async () => {
+  it("removes abort listeners after stop", async () => {
     const tracked = createTrackedSignal();
     let attempt = 0;
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => 'http://127.0.0.1:4096/global/event',
+      buildUrl: () => "http://127.0.0.1:4096/global/event",
       reconnectDelayMs: 1,
       signal: tracked.signal,
       fetchImpl: async (_url, options) => {
@@ -271,5 +272,147 @@ describe('createUpstreamSseReader', () => {
 
     expect(attempt).toBe(2);
     expect(tracked.getListenerCount()).toBe(0);
+  });
+
+  it("backs off reconnect delay after consecutive upstream failures", async () => {
+    const errors = [];
+    let attempt = 0;
+    let reader;
+
+    reader = createUpstreamSseReader({
+      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      reconnectDelayMs: 10,
+      reconnectMaxDelayMs: 40,
+      reconnectBackoffMultiplier: 2,
+      fetchImpl: async (_url, options) => {
+        attempt += 1;
+        if (attempt <= 4) {
+          return {
+            ok: false,
+            status: 503,
+            body: {
+              cancel: async () => {},
+            },
+          };
+        }
+
+        return createSseResponse({
+          signal: options.signal,
+          blocks: [
+            'id: evt-1\ndata: {"type":"server.connected","properties":{}}\n\n',
+          ],
+        });
+      },
+      onError(error) {
+        errors.push(error);
+      },
+      onEvent() {
+        reader.stop();
+      },
+    });
+
+    const startedAt = Date.now();
+    await reader.start();
+    const elapsed = Date.now() - startedAt;
+
+    expect(errors).toHaveLength(4);
+    expect(attempt).toBe(5);
+    // Expected wait: 20 + 40 + 40 + 40 = 140ms minimum (first failure = 10*2, then capped at 40)
+    expect(elapsed).toBeGreaterThanOrEqual(100);
+  });
+
+  it("resets the consecutive failure counter after a successful connect", async () => {
+    const events = [];
+    let attempt = 0;
+    let reader;
+
+    reader = createUpstreamSseReader({
+      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      reconnectDelayMs: 5,
+      reconnectMaxDelayMs: 20,
+      reconnectBackoffMultiplier: 2,
+      fetchImpl: async (_url, options) => {
+        attempt += 1;
+        if (attempt === 1 || attempt === 2) {
+          return {
+            ok: false,
+            status: 503,
+            body: { cancel: async () => {} },
+          };
+        }
+        if (attempt === 3) {
+          return createSseResponse({
+            signal: options.signal,
+            blocks: [
+              'id: evt-1\ndata: {"type":"server.connected","properties":{}}\n\n',
+            ],
+          });
+        }
+        if (attempt === 4) {
+          return {
+            ok: false,
+            status: 503,
+            body: { cancel: async () => {} },
+          };
+        }
+        return createSseResponse({
+          signal: options.signal,
+          blocks: [
+            'id: evt-2\ndata: {"type":"session.updated","properties":{}}\n\n',
+          ],
+        });
+      },
+      onError() {},
+      onEvent(event) {
+        events.push(event.eventId);
+        if (event.eventId === "evt-2") {
+          reader.stop();
+        }
+      },
+    });
+
+    await reader.start();
+
+    expect(events).toEqual(["evt-1", "evt-2"]);
+    expect(attempt).toBe(5);
+  });
+
+  it("keeps immediate reconnect when reconnectDelayMs is zero", async () => {
+    let attempt = 0;
+    let reader;
+
+    reader = createUpstreamSseReader({
+      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      reconnectDelayMs: 0,
+      reconnectMaxDelayMs: 50,
+      reconnectBackoffMultiplier: 10,
+      fetchImpl: async (_url, options) => {
+        attempt += 1;
+        if (attempt <= 3) {
+          return {
+            ok: false,
+            status: 503,
+            body: { cancel: async () => {} },
+          };
+        }
+        return createSseResponse({
+          signal: options.signal,
+          blocks: [
+            'id: evt-1\ndata: {"type":"server.connected","properties":{}}\n\n',
+          ],
+        });
+      },
+      onEvent() {
+        reader.stop();
+      },
+    });
+
+    const startedAt = Date.now();
+    await reader.start();
+    const elapsed = Date.now() - startedAt;
+
+    expect(attempt).toBe(4);
+    // Zero base delay should not back off even with large multiplier
+    expect(elapsed).toBeLessThan(80);
   });
 });

--- a/packages/web/server/lib/event-stream/upstream-reader.test.js
+++ b/packages/web/server/lib/event-stream/upstream-reader.test.js
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
-import { createUpstreamSseReader } from "./upstream-reader.js";
+import { createUpstreamSseReader } from './upstream-reader.js';
 
 function createSseResponse({ blocks = [], signal, holdOpen = false }) {
   const encoder = new TextEncoder();
@@ -23,12 +23,12 @@ function createSseResponse({ blocks = [], signal, holdOpen = false }) {
 
             return new Promise((_resolve, reject) => {
               const onAbort = () => {
-                signal.removeEventListener("abort", onAbort);
-                const error = new Error("Aborted");
-                error.name = "AbortError";
+                signal.removeEventListener('abort', onAbort);
+                const error = new Error('Aborted');
+                error.name = 'AbortError';
                 reject(error);
               };
-              signal.addEventListener("abort", onAbort, { once: true });
+              signal.addEventListener('abort', onAbort, { once: true });
             });
           },
         };
@@ -43,12 +43,12 @@ function createTrackedSignal() {
     signal: {
       aborted: false,
       addEventListener(type, listener) {
-        if (type === "abort") {
+        if (type === 'abort') {
           listeners.add(listener);
         }
       },
       removeEventListener(type, listener) {
-        if (type === "abort") {
+        if (type === 'abort') {
           listeners.delete(listener);
         }
       },
@@ -59,21 +59,20 @@ function createTrackedSignal() {
   };
 }
 
-describe("createUpstreamSseReader", () => {
-  it("emits parsed events and tracks the latest event id", async () => {
+describe('createUpstreamSseReader', () => {
+  it('emits parsed events and tracks the latest event id', async () => {
     const events = [];
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      buildUrl: () => 'http://127.0.0.1:4096/global/event',
       reconnectDelayMs: 0,
-      fetchImpl: async (_url, options) =>
-        createSseResponse({
-          signal: options.signal,
-          blocks: [
-            'id: evt-1\r\ndata: {"type":"server.connected","properties":{"directory":"/tmp/project"}}\r\n\r\n',
-          ],
-        }),
+      fetchImpl: async (_url, options) => createSseResponse({
+        signal: options.signal,
+        blocks: [
+          'id: evt-1\r\ndata: {"type":"server.connected","properties":{"directory":"/tmp/project"}}\r\n\r\n',
+        ],
+      }),
       onEvent(event) {
         events.push(event);
         reader.stop();
@@ -83,29 +82,29 @@ describe("createUpstreamSseReader", () => {
     await reader.start();
 
     expect(events).toHaveLength(1);
-    expect(events[0].eventId).toBe("evt-1");
-    expect(events[0].directory).toBe("/tmp/project");
+    expect(events[0].eventId).toBe('evt-1');
+    expect(events[0].directory).toBe('/tmp/project');
     expect(events[0].payload).toEqual({
-      type: "server.connected",
+      type: 'server.connected',
       properties: {
-        directory: "/tmp/project",
+        directory: '/tmp/project',
       },
     });
-    expect(reader.getLastEventId()).toBe("evt-1");
+    expect(reader.getLastEventId()).toBe('evt-1');
   });
 
-  it("reconnects a stalled stream with Last-Event-ID", async () => {
+  it('reconnects a stalled stream with Last-Event-ID', async () => {
     const fetchLastEventIds = [];
     const events = [];
     let attempt = 0;
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      buildUrl: () => 'http://127.0.0.1:4096/global/event',
       stallTimeoutMs: 10,
       reconnectDelayMs: 0,
       fetchImpl: async (_url, options) => {
-        fetchLastEventIds.push(options.headers["Last-Event-ID"] ?? null);
+        fetchLastEventIds.push(options.headers['Last-Event-ID'] ?? null);
         attempt += 1;
 
         if (attempt === 1) {
@@ -127,7 +126,7 @@ describe("createUpstreamSseReader", () => {
       },
       onEvent(event) {
         events.push(event.eventId);
-        if (event.eventId === "evt-2") {
+        if (event.eventId === 'evt-2') {
           reader.stop();
         }
       },
@@ -135,19 +134,19 @@ describe("createUpstreamSseReader", () => {
 
     await reader.start();
 
-    expect(events).toEqual(["evt-1", "evt-2"]);
-    expect(fetchLastEventIds.slice(0, 2)).toEqual([null, "evt-1"]);
-    expect(reader.getLastEventId()).toBe("evt-2");
+    expect(events).toEqual(['evt-1', 'evt-2']);
+    expect(fetchLastEventIds.slice(0, 2)).toEqual([null, 'evt-1']);
+    expect(reader.getLastEventId()).toBe('evt-2');
   });
 
-  it("resolves the stall timeout for each upstream read window", async () => {
+  it('resolves the stall timeout for each upstream read window', async () => {
     const events = [];
     let attempt = 0;
     let currentTimeout = 10;
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      buildUrl: () => 'http://127.0.0.1:4096/global/event',
       stallTimeoutMs: () => currentTimeout,
       reconnectDelayMs: 0,
       fetchImpl: async (_url, options) => {
@@ -173,7 +172,7 @@ describe("createUpstreamSseReader", () => {
       },
       onEvent(event) {
         events.push(event.eventId);
-        if (event.eventId === "evt-2") {
+        if (event.eventId === 'evt-2') {
           reader.stop();
         }
       },
@@ -181,18 +180,18 @@ describe("createUpstreamSseReader", () => {
 
     await reader.start();
 
-    expect(events).toEqual(["evt-1", "evt-2"]);
+    expect(events).toEqual(['evt-1', 'evt-2']);
     expect(attempt).toBe(2);
   });
 
-  it("reports unavailable upstream responses and continues reconnecting until stopped", async () => {
+  it('reports unavailable upstream responses and continues reconnecting until stopped', async () => {
     const errors = [];
     let attempt = 0;
     let unavailableBodyCanceled = false;
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      buildUrl: () => 'http://127.0.0.1:4096/global/event',
       reconnectDelayMs: 0,
       fetchImpl: async (_url, options) => {
         attempt += 1;
@@ -227,7 +226,7 @@ describe("createUpstreamSseReader", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        type: "upstream_unavailable",
+        type: 'upstream_unavailable',
         status: 503,
       }),
     ]);
@@ -235,13 +234,13 @@ describe("createUpstreamSseReader", () => {
     expect(attempt).toBe(2);
   });
 
-  it("removes abort listeners after stop", async () => {
+  it('removes abort listeners after stop', async () => {
     const tracked = createTrackedSignal();
     let attempt = 0;
     let reader;
 
     reader = createUpstreamSseReader({
-      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      buildUrl: () => 'http://127.0.0.1:4096/global/event',
       reconnectDelayMs: 1,
       signal: tracked.signal,
       fetchImpl: async (_url, options) => {
@@ -274,16 +273,26 @@ describe("createUpstreamSseReader", () => {
     expect(tracked.getListenerCount()).toBe(0);
   });
 
-  it("backs off reconnect delay after consecutive upstream failures", async () => {
+  it('backs off reconnect delay after consecutive upstream failures', async () => {
     const errors = [];
+    const recordedDelays = [];
     let attempt = 0;
     let reader;
 
+    // Capture the requested reconnect delays instead of measuring wall-clock
+    // time. Each captured entry corresponds to one `waitForReconnectDelay` call.
+    const setTimeoutImpl = (handler, ms) => {
+      recordedDelays.push(ms);
+      // Fire immediately so the connection loop proceeds to the next attempt.
+      return globalThis.setTimeout(handler, 0);
+    };
+
     reader = createUpstreamSseReader({
-      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      buildUrl: () => 'http://127.0.0.1:4096/global/event',
       reconnectDelayMs: 10,
       reconnectMaxDelayMs: 40,
       reconnectBackoffMultiplier: 2,
+      setTimeoutImpl,
       fetchImpl: async (_url, options) => {
         attempt += 1;
         if (attempt <= 4) {
@@ -311,26 +320,32 @@ describe("createUpstreamSseReader", () => {
       },
     });
 
-    const startedAt = Date.now();
     await reader.start();
-    const elapsed = Date.now() - startedAt;
 
     expect(errors).toHaveLength(4);
     expect(attempt).toBe(5);
-    // Conventional backoff: first failure waits base (10ms), then 20, 40, 40 (capped) = 110ms minimum
-    expect(elapsed).toBeGreaterThanOrEqual(80);
+    // Conventional backoff: failures 1..4 ask for base*multiplier^(n-1) capped at max,
+    // so the schedule is 10, 20, 40, 40 (the last one already hit the cap).
+    expect(recordedDelays).toEqual([10, 20, 40, 40]);
   });
 
-  it("resets the consecutive failure counter after a successful connect", async () => {
+  it('resets the consecutive failure counter after a successful connect', async () => {
     const events = [];
+    const recordedDelays = [];
     let attempt = 0;
     let reader;
 
+    const setTimeoutImpl = (handler, ms) => {
+      recordedDelays.push(ms);
+      return globalThis.setTimeout(handler, 0);
+    };
+
     reader = createUpstreamSseReader({
-      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      buildUrl: () => 'http://127.0.0.1:4096/global/event',
       reconnectDelayMs: 5,
       reconnectMaxDelayMs: 20,
       reconnectBackoffMultiplier: 2,
+      setTimeoutImpl,
       fetchImpl: async (_url, options) => {
         attempt += 1;
         if (attempt === 1 || attempt === 2) {
@@ -365,7 +380,7 @@ describe("createUpstreamSseReader", () => {
       onError() {},
       onEvent(event) {
         events.push(event.eventId);
-        if (event.eventId === "evt-2") {
+        if (event.eventId === 'evt-2') {
           reader.stop();
         }
       },
@@ -373,19 +388,31 @@ describe("createUpstreamSseReader", () => {
 
     await reader.start();
 
-    expect(events).toEqual(["evt-1", "evt-2"]);
+    expect(events).toEqual(['evt-1', 'evt-2']);
     expect(attempt).toBe(5);
+    // Schedule: failures 1..2 escalate 5 -> 10; healthy connect (attempt 3)
+    // resets the counter, so the next failure (attempt 4) waits the base
+    // value again, not the escalated one. The trailing entry is the post-stop
+    // cleanup waitForReconnectDelay that fires before the abort short-circuit.
+    expect(recordedDelays.slice(0, 3)).toEqual([5, 10, 5]);
   });
 
-  it("keeps immediate reconnect when reconnectDelayMs is zero", async () => {
+  it('keeps immediate reconnect when reconnectDelayMs is zero', async () => {
+    const recordedDelays = [];
     let attempt = 0;
     let reader;
 
+    const setTimeoutImpl = (handler, ms) => {
+      recordedDelays.push(ms);
+      return globalThis.setTimeout(handler, 0);
+    };
+
     reader = createUpstreamSseReader({
-      buildUrl: () => "http://127.0.0.1:4096/global/event",
+      buildUrl: () => 'http://127.0.0.1:4096/global/event',
       reconnectDelayMs: 0,
       reconnectMaxDelayMs: 50,
       reconnectBackoffMultiplier: 10,
+      setTimeoutImpl,
       fetchImpl: async (_url, options) => {
         attempt += 1;
         if (attempt <= 3) {
@@ -407,12 +434,12 @@ describe("createUpstreamSseReader", () => {
       },
     });
 
-    const startedAt = Date.now();
     await reader.start();
-    const elapsed = Date.now() - startedAt;
 
     expect(attempt).toBe(4);
-    // Zero base delay should not back off even with large multiplier
-    expect(elapsed).toBeLessThan(80);
+    // Zero base delay short-circuits the backoff schedule entirely, regardless
+    // of the multiplier/cap. The reset on a healthy connect is also free in
+    // this configuration.
+    expect(recordedDelays).toEqual([0, 0, 0]);
   });
 });


### PR DESCRIPTION
## Intent

When the managed OpenCode process dies, restarts, or is killed mid-stream, the SSE upstream reader in `packages/web/server/lib/event-stream/upstream-reader.js` retried every 250 ms in a tight loop. On Windows, the desktop Electron `main.log` filled with thousands of `ECONNRESET`/`ECONNREFUSED` errors per minute (2,881 in a single burst in one report) until either the upstream came back or the user stopped the app.

This PR replaces the constant 250 ms upstream SSE reconnect delay with exponential backoff: each consecutive reconnect failure doubles the wait, capped at 5 s; the failure counter resets to zero after a successful connect (`response.ok && response.body`), so a transient blip still reconnects quickly. Conventional backoff: first failure waits `base`, then `base * multiplier`, etc.

## Non-goals

- Not changing stall timeout behavior (already handled by `stallTimeoutMs`).
- Not changing the public `createUpstreamSseReader` signature; new options `reconnectMaxDelayMs` and `reconnectBackoffMultiplier` keep the existing surface (default behavior of callers is unchanged in shape, only in pacing).
- Not addressing other retry paths in `event-stream/` (e.g. WebSocket reconnect is separate).

## Affected surfaces

- `packages/web/server/server/lib/event-stream/upstream-reader.js`: reconnect pacing.
- `packages/web/server/lib/event-stream/upstream-reader.test.js`: three new tests cover escalation + cap, counter reset on a successful connect, and `reconnectDelayMs: 0` preserving immediate reconnect.
- Inherited by callers that construct a reader with only `reconnectDelayMs`:
  - `packages/web/server/lib/event-stream/global-hub.js`
  - `packages/web/server/lib/event-stream/directory-ws-bridge.js`
  - `packages/web/server/lib/opencode/watcher.js` (uses `upstreamReconnectDelayMs = 1000`)
  - `packages/web/server/lib/event-stream/runtime.js`

User-visible: chat recovery on OpenCode restart; desktop log noise on Windows. All runtimes (web, desktop, VS Code, mobile) inherit because the reader is created server-side and the chat is the same UI.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Always-on rules; source change in shared server code | Correctness invariant: `onError` still fires every attempt (failure is not swallowed); the new counter is bounded (capped at 5 s); no dependency changes; `bun run type-check` and `bun test` were run before push |
| `.github/PULL_REQUEST_TEMPLATE.md` | Required handoff structure | All seven sections completed |
| `.agents/skills/relay-transport/SKILL.md` | SSE/streaming reconnect change | "Reconnect pacing": exponential backoff on consecutive failures, long cap, reset failure state only after a genuinely healthy connection, interruptible waits (existing `signal`/abort path is preserved) |
| `.agents/skills/sync-state-invariants/SKILL.md` | Reconnect behavior feeds session-sync delivery paths | Bounded retry/recovery for transient upstream failures; retry loop requires a real failure signal (`onError` fires every attempt, unchanged); no swallowed errors |
| `packages/web/server/lib/event-stream/` | Owning module | New exports are additive; existing tests that use `reconnectDelayMs: 0` keep their immediate-reconnect behavior |

## Validation

- `bun test packages/web/server/lib/event-stream/upstream-reader.test.js` — 8/8 pass (was 5/5 before this PR; 3 new tests added).
- `bun run --filter @openchamber/web type-check` — exit 0.
- `bunx oxlint packages/web/server/lib/event-stream/upstream-reader.js packages/web/server/lib/event-stream/upstream-reader.test.js` — clean (the file is plain JS, so the oxlint pass has no surface, but it ran without findings).
- Behavior analysis: with base=250 ms, multiplier=2, cap=5 s, the first failure waits 250 ms, then 500 ms, 1 s, 2 s, 4 s, 5 s, 5 s ... — log flood on Windows is bounded (~10 errors/minute after 1 minute of outage vs ~240/minute previously).
- Manual QA on Windows desktop: not run by the author; Linux CI cannot exercise `EPERM`/`ECONNREFUSED` reliably. The timing assertions in the test (`>= 80`, `< 80`) tolerate CI scheduler noise.

## Visual evidence

No visual change (server-side delay change). No screenshots required.

## Risks and failure behavior

- Cap is 5 s. With an external (non-managed) OpenCode, nothing rebinds the reader after the user restarts the server, so events are delayed up to 5 s after the upstream is already healthy. Acceptable trade-off vs the original 250 ms storm.
- Counter reset only after `response.ok && response.body`. If the response starts streaming and then errors mid-stream, the counter is **not** reset on that response; the next failure increments from the previous count. This is intentional — a streaming failure still counts as a failure for backoff purposes.
- New options `reconnectMaxDelayMs` and `reconnectBackoffMultiplier` are optional with defaults that preserve the prior public API surface.
- No dependency, network-path, auth, or secret-handling changes. No new persisted metadata. No schema change.
- Rollback: revert the single commit `02d0864da` (or the original `0d9f13c29` if the new commit is not yet merged).