### PR TITLE
fix(git): silence getWorktrees warning when directory is not a repo

### DIFF
--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -3738,7 +3738,15 @@ export async function getWorktrees(directory) {
       path: entry.worktree,
     }));
   } catch (error) {
-    console.warn('Failed to list worktrees, returning empty list:', error?.message || error);
+    // Worktrees are an optional feature. When the caller passes a directory
+    // that is not inside any git repository (for example, the managed
+    // OpenCode's working directory or an unconfigured project path), git
+    // exits with "fatal: not a git repository ...". Treat that as an
+    // authoritative empty result so the route handler can still respond
+    // 200 [] and the desktop main.log stays free of noise.
+    if (!isNotGitRepositoryError(error)) {
+      console.warn('Failed to list worktrees, returning empty list:', error?.message || error);
+    }
     return [];
   }
 }

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import simpleGit from 'simple-git';
 
 import {
@@ -13,6 +13,7 @@ import {
   getBranches,
   getRangeDiff,
   getStatus,
+  getWorktrees,
   isGitRepository,
   populateWorktreeWithLockRecovery,
   removeWorktree,
@@ -457,6 +458,47 @@ describe('worktree root resolution', () => {
     runGit(repo, ['worktree', 'add', '-b', 'feature/test', worktree, 'HEAD']);
 
     await expect(resolvePrimaryWorktreeRoot(worktree)).resolves.toEqual({ root: fs.realpathSync(repo) });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getWorktrees
+// ---------------------------------------------------------------------------
+
+describe('getWorktrees', () => {
+  if (!canRunGit()) {
+    it.skip('git binary not available', () => {});
+    return;
+  }
+
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  it('returns an empty list for a non-git directory without warning', async () => {
+    const nonGit = createTempDir();
+
+    const result = await getWorktrees(nonGit);
+
+    expect(result).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the worktrees for a real git repository', async () => {
+    const repo = createTempDir();
+    runGit(repo, ['init', '-b', 'main']);
+    runGit(repo, ['config', 'user.email', 'test@example.com']);
+    runGit(repo, ['config', 'user.name', 'Test User']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '# Test\n');
+    runGit(repo, ['add', 'README.md']);
+    runGit(repo, ['commit', '-m', 'init']);
+
+    const result = await getWorktrees(repo);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Intent

`packages/web/server/lib/git/service.js::getWorktrees` logs a warn-level line every time any caller passes a directory that is not inside a git repository. The OpenChamber desktop `main.log` accumulates hundreds of these:

```
Failed to list worktrees, returning empty list: fatal: not a git repository (or any of the parent directories): .git
```

…across a normal session (observed 282 such warnings in one user's 8-day window). The empty-list return value is already the correct behavior — worktrees are an optional feature — but the warning is noise that hides real git failures (lock contention, permission errors, corrupt repositories).

This PR uses the existing `isNotGitRepositoryError` helper to suppress the warn specifically for the "not a git repository" case while keeping it for genuine failures.

## Non-goals

- No change to the empty-list fallback behavior.
- No change to the public API (`getWorktrees` signature unchanged).
- No change to other git commands or the routes.js handler (it already has its own try/catch and warning).
- No upstream-caller fix (the call site that passes the home directory is in `electron` / `web/server` runtime code and is intentional per the `opencode-cwd.mjs` design — the managed OpenCode runs with `cwd: <homedir>` and `getWorktrees` is invoked with that directory by some metadata refresh path).

## Affected surfaces

- `packages/web/server/lib/git/service.js` — suppress warning in `getWorktrees` catch when the error is a "not a git repository" error.
- `packages/web/server/lib/git/service.test.js` — two new tests: (a) silent return for a non-git directory, (b) normal return for a real git repository.

## Repository guidance

- `.agents/skills/openchamber-change-discipline/SKILL.md`: smallest complete change; preserves existing public API and empty-list fallback.
- The skill explicitly cautions against "swallowing an error for smoother UX". The fix is narrower: it preserves the failure signal (function still returns `[]` and the route still responds 200) but suppresses the warn line for the case where the directory is provably not a git repo. Genuine errors still log.

## Validation

- `bun run --cwd packages/web test -- service.test.js -t getWorktrees` → **2 passed / 0 failed** (the new test block).
- `bun run --cwd packages/web type-check` → passes.

The broader `service.test.js` suite has pre-existing timeout-related failures on tests like `applyHunk`, `cherryPick`, `revertCommit`, `resetToCommit` (long-running git operations in CI sandbox). They are unrelated to this PR (verified by running them on the unchanged branch baseline before applying the diff). They are not blocking this change.

## Risk and failure behavior

- **Behavior change**: only the warn line is suppressed; `getWorktrees` still returns `[]` for non-git directories (unchanged) and still throws/warns for other errors.
- **Risk of missed errors**: low. `isNotGitRepositoryError` matches `/not a git repository/i` against the combined stderr/stdout/message text of the underlying `GitError`. Any genuine failure (lock, permission, parse, etc.) does not match and continues to log.
- **Rollback**: revert this commit; behavior reverts to the previous "always warn on failure" state without any data or state change.

## Reproduction evidence (before)

```
$ grep -c "Failed to list worktrees" C:\Users\herna\AppData\Roaming\openchamber\logs\main.log
282
```

After this PR the same query should return 0 for non-git-directory cases while still surfacing genuine git failures.
