### PR TITLE
fix(telegram): collapse Owners & groups; last sync in Advanced

### DIFF
--- a/packages/ui/src/components/sections/openchamber-agent-settings/TelegramCard.tsx
+++ b/packages/ui/src/components/sections/openchamber-agent-settings/TelegramCard.tsx
@@ -303,7 +303,7 @@ function TelegramListenerPanel({ conn }: { conn: MessengerConnection }) {
   );
 }
 
-type TelegramDangerZoneKey = 'fallback' | 'owner' | 'allowed' | 'replyMode';
+type TelegramDangerZoneKey = 'fallback' | 'allowed' | 'replyMode';
 
 const TELEGRAM_CHAT_REPLY_MODES: Array<'always' | 'mention'> = ['always', 'mention'];
 
@@ -547,17 +547,60 @@ function TelegramChatRow({
   );
 }
 
-function TelegramGroupsBlock({ conn }: { conn: MessengerConnection }) {
+function TelegramOwnerUserIdsEditor({ conn }: { conn: MessengerConnection }) {
+  const { t } = useI18n();
+  const updateConnection = useMessengerStore((s) => s.updateConnection);
+  const saveTelegramConfig = useMessengerStore((s) => s.saveTelegramConfig);
+  const persist = () => setTimeout(() => saveTelegramConfig(), 0);
+  const inputClass =
+    'w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+
+  return (
+    <div data-settings-item="integrations.telegram.owner-user" className="space-y-2">
+      <div className="text-sm font-semibold text-foreground">
+        {t('settings.integrations.telegram.advanced.ownerUserIds.title')}
+      </div>
+      <div className="text-xs text-muted-foreground leading-snug">
+        <TelegramUserInfoBotHint
+          beforeKey="settings.integrations.telegram.advanced.ownerUserIds.description.before"
+          afterKey="settings.integrations.telegram.advanced.ownerUserIds.description.after"
+        />
+      </div>
+      <p className="text-xs text-[var(--status-warning)] leading-snug">
+        {t('settings.integrations.telegram.advanced.ownerUserIds.required')}
+      </p>
+      <textarea
+        value={(conn.telegramOwnerUserIds ?? []).join('\n')}
+        onChange={(e) => {
+          const telegramOwnerUserIds = parseMessengerIdList(e.target.value);
+          updateConnection('telegram', {
+            telegramOwnerUserIds,
+            defaultUserId: telegramOwnerUserIds[0],
+          });
+        }}
+        onBlur={() => {
+          const latest = useMessengerStore
+            .getState()
+            .connections.find((c) => c.type === 'telegram');
+          if (!(latest?.telegramOwnerUserIds ?? []).length) return;
+          persist();
+        }}
+        placeholder={t('settings.integrations.telegram.advanced.ownerUserIds.placeholder')}
+        className={cn(inputClass, 'min-h-16 resize-y')}
+      />
+    </div>
+  );
+}
+
+function TelegramGroupsList({ conn }: { conn: MessengerConnection }) {
   const { t } = useI18n();
   const inbound = useMessengerStore((s) => s.telegramInbound);
   const chats = listTelegramManagedChats(conn, inbound);
-  const restrictions = conn.lastSyncTelegramRestrictions ?? [];
-  const results = conn.lastSyncTelegramProjects ?? [];
 
   return (
     <div data-settings-item="integrations.telegram.groups" className="space-y-3">
       <div>
-        <div className="text-base font-semibold text-foreground">
+        <div className="text-sm font-semibold text-foreground">
           {t('settings.integrations.telegram.groups.title')}
         </div>
         <p className="mt-1 text-xs text-muted-foreground leading-snug">
@@ -576,34 +619,74 @@ function TelegramGroupsBlock({ conn }: { conn: MessengerConnection }) {
           ))}
         </div>
       )}
-
-      {(restrictions.length > 0 || results.length > 0) && (
-        <div className="space-y-1.5 rounded-lg border border-[var(--interactive-border)] bg-[var(--surface-muted)]/40 px-3 py-2">
-          <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            {t('settings.integrations.telegram.groups.syncResults')}
-          </div>
-          {restrictions.map((r) => (
-            <p key={r} className="text-[11px] leading-snug text-muted-foreground">
-              {r}
-            </p>
-          ))}
-          {results.map((row) => (
-            <div
-              key={`${row.chatId ?? ''}:${row.projectId}`}
-              className="text-[11px] leading-snug text-foreground"
-            >
-              {row.projectLabel}
-              {row.error
-                ? ` — ${row.error}`
-                : row.messageId
-                  ? ` — ✓${row.topicCreated ? ' topic' : ''}`
-                  : ''}
-              {row.topicSkippedReason ? ` (${row.topicSkippedReason})` : ''}
-            </div>
-          ))}
-        </div>
-      )}
     </div>
+  );
+}
+
+function TelegramLastSyncResults({ conn }: { conn: MessengerConnection }) {
+  const { t } = useI18n();
+  const restrictions = conn.lastSyncTelegramRestrictions ?? [];
+  const results = conn.lastSyncTelegramProjects ?? [];
+  if (restrictions.length === 0 && results.length === 0) return null;
+
+  return (
+    <div
+      data-settings-item="integrations.telegram.sync-results"
+      className="space-y-1.5 rounded-lg border border-[var(--interactive-border)] bg-[var(--surface-muted)]/40 px-3 py-2"
+    >
+      <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {t('settings.integrations.telegram.groups.syncResults')}
+      </div>
+      {restrictions.map((r) => (
+        <p key={r} className="text-[11px] leading-snug text-muted-foreground">
+          {r}
+        </p>
+      ))}
+      {results.map((row) => (
+        <div
+          key={`${row.chatId ?? ''}:${row.projectId}`}
+          className="text-[11px] leading-snug text-foreground"
+        >
+          {row.projectLabel}
+          {row.error
+            ? ` — ${row.error}`
+            : row.messageId
+              ? ` — ✓${row.topicCreated ? ' topic' : ''}`
+              : ''}
+          {row.topicSkippedReason ? ` (${row.topicSkippedReason})` : ''}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Collapsed by default: click to show owner IDs + groups; click again to hide. */
+function TelegramOwnersAndGroupsPanel({ conn }: { conn: MessengerConnection }) {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const ownerCount = (conn.telegramOwnerUserIds ?? []).length;
+  const inbound = useMessengerStore((s) => s.telegramInbound);
+  const chatCount = listTelegramManagedChats(conn, inbound).length;
+
+  return (
+    <AdvancedSectionCard
+      icon="shield-user"
+      title={t('settings.integrations.telegram.controls.title')}
+      meta={t('settings.integrations.telegram.controls.meta', {
+        owners: ownerCount,
+        chats: chatCount,
+      })}
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <div className="space-y-4">
+        <p className="text-xs text-muted-foreground leading-snug">
+          {t('settings.integrations.telegram.controls.description')}
+        </p>
+        <TelegramOwnerUserIdsEditor conn={conn} />
+        <TelegramGroupsList conn={conn} />
+      </div>
+    </AdvancedSectionCard>
   );
 }
 
@@ -683,6 +766,8 @@ function TelegramAdvancedSettings({ conn }: { conn: MessengerConnection }) {
           {t('settings.integrations.telegram.advanced.description')}
         </p>
       </div>
+
+      <TelegramLastSyncResults conn={conn} />
 
       <div className="space-y-3">
         <AdvancedSectionCard
@@ -795,42 +880,6 @@ function TelegramAdvancedSettings({ conn }: { conn: MessengerConnection }) {
                   </Button>
                 </div>
               )}
-            </div>
-          </DangerZoneRow>
-          <DangerZoneRow
-            label={t('settings.integrations.telegram.advanced.ownerUserIds.title')}
-            open={dangerOpen === 'owner'}
-            onToggle={() => toggleDanger('owner')}
-          >
-            <div data-settings-item="integrations.telegram.owner-user" className="space-y-2">
-              <div className="text-xs text-muted-foreground leading-snug">
-                <TelegramUserInfoBotHint
-                  beforeKey="settings.integrations.telegram.advanced.ownerUserIds.description.before"
-                  afterKey="settings.integrations.telegram.advanced.ownerUserIds.description.after"
-                />
-              </div>
-              <p className="text-xs text-[var(--status-warning)] leading-snug">
-                {t('settings.integrations.telegram.advanced.ownerUserIds.required')}
-              </p>
-              <textarea
-                value={(conn.telegramOwnerUserIds ?? []).join('\n')}
-                onChange={(e) => {
-                  const telegramOwnerUserIds = parseMessengerIdList(e.target.value);
-                  updateConnection('telegram', {
-                    telegramOwnerUserIds,
-                    defaultUserId: telegramOwnerUserIds[0],
-                  });
-                }}
-                onBlur={() => {
-                  const latest = useMessengerStore
-                    .getState()
-                    .connections.find((c) => c.type === 'telegram');
-                  if (!(latest?.telegramOwnerUserIds ?? []).length) return;
-                  persist();
-                }}
-                placeholder={t('settings.integrations.telegram.advanced.ownerUserIds.placeholder')}
-                className={cn(inputClass, 'min-h-16 resize-y')}
-              />
             </div>
           </DangerZoneRow>
           <DangerZoneRow
@@ -981,7 +1030,7 @@ export function TelegramSectionCard({ conn }: { conn: MessengerConnection }) {
         <TelegramOnboardingWizard conn={conn} />
       ) : (
         <>
-          <TelegramGroupsBlock conn={conn} />
+          <TelegramOwnersAndGroupsPanel conn={conn} />
           {advancedOpen && (
           <div className="space-y-4 border-t border-[var(--interactive-border)] pt-4">
             <div className="flex flex-wrap items-center gap-2">

--- a/packages/ui/src/lib/i18n/messages/telegram-integration.i18n.ts
+++ b/packages/ui/src/lib/i18n/messages/telegram-integration.i18n.ts
@@ -147,6 +147,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.interruptTimeout.unit': 'ms',
     'settings.integrations.telegram.bridge.activeOne': '1 prompt streaming…',
     'settings.integrations.telegram.bridge.activeMany': '{count} prompts streaming…',
+    'settings.integrations.telegram.controls.title': 'Owners & groups',
+    'settings.integrations.telegram.controls.description':
+      'Add at least one owner user id for safety, then choose which groups and chats the bot answers in.',
+    'settings.integrations.telegram.controls.meta': '{owners} owners · {chats} chats',
     'settings.integrations.telegram.groups.title': 'Groups & chats',
     'settings.integrations.telegram.groups.description':
       'Enable the groups and chats where OpenChamber should respond. Sync projects posts a status message into each selected chat and creates forum topics when the bot can manage topics.',
@@ -339,6 +343,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 Prompt wird gestreamt…',
     'settings.integrations.telegram.bridge.activeMany': '{count} Prompts werden gestreamt…',
 
+    'settings.integrations.telegram.controls.title': 'Eigentümer & Gruppen',
+    'settings.integrations.telegram.controls.description':
+      'Fügen Sie aus Sicherheitsgründen mindestens eine Eigentümer-Benutzer-ID hinzu und wählen Sie dann, in welchen Gruppen und Chats der Bot antwortet.',
+    'settings.integrations.telegram.controls.meta': '{owners} Eigentümer · {chats} Chats',
     'settings.integrations.telegram.groups.title': 'Gruppen & Chats',
     'settings.integrations.telegram.groups.description': 'Aktivieren Sie die Gruppen und Chats, in denen OpenChamber antworten soll. „Projekte synchronisieren“ sendet eine Statusnachricht in jeden ausgewählten Chat und erstellt Forumsthemen, wenn der Bot Themen verwalten darf.',
     'settings.integrations.telegram.groups.empty': 'Noch keine Chats. Schreiben Sie dem Bot oder fügen Sie Chat-IDs unter „Erlaubte Chat-IDs“ hinzu — dann erscheinen sie hier.',
@@ -550,6 +558,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 prompt en curso…',
     'settings.integrations.telegram.bridge.activeMany': '{count} prompts en curso…',
 
+    'settings.integrations.telegram.controls.title': 'Propietarios y grupos',
+    'settings.integrations.telegram.controls.description':
+      'Añade al menos un id de propietario por seguridad y luego elige en qué grupos y chats responde el bot.',
+    'settings.integrations.telegram.controls.meta': '{owners} propietarios · {chats} chats',
     'settings.integrations.telegram.groups.title': 'Grupos y chats',
     'settings.integrations.telegram.groups.description': 'Activa los grupos y chats donde OpenChamber debe responder. Sincronizar proyectos publica un mensaje de estado en cada chat seleccionado y crea temas de foro cuando el bot puede gestionar temas.',
     'settings.integrations.telegram.groups.empty': 'Aún no hay chats. Envía un mensaje al bot o añade IDs en «IDs de chat permitidos» y aparecerán aquí.',
@@ -761,6 +773,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 prompt en cours…',
     'settings.integrations.telegram.bridge.activeMany': '{count} prompts en cours…',
 
+    'settings.integrations.telegram.controls.title': 'Propriétaires et groupes',
+    'settings.integrations.telegram.controls.description':
+      'Ajoutez au moins un identifiant de propriétaire pour la sécurité, puis choisissez les groupes et discussions où le bot répond.',
+    'settings.integrations.telegram.controls.meta': '{owners} propriétaires · {chats} discussions',
     'settings.integrations.telegram.groups.title': 'Groupes et discussions',
     'settings.integrations.telegram.groups.description': 'Activez les groupes et discussions où OpenChamber doit répondre. Synchroniser les projets publie un message d’état dans chaque discussion sélectionnée et crée des sujets de forum lorsque le bot peut gérer les sujets.',
     'settings.integrations.telegram.groups.empty': 'Aucune discussion pour l’instant. Écrivez au bot ou ajoutez des identifiants sous « IDs de discussion autorisés », puis ils apparaîtront ici.',
@@ -972,6 +988,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 件のプロンプトを送信中…',
     'settings.integrations.telegram.bridge.activeMany': '{count} 件のプロンプトを送信中…',
 
+    'settings.integrations.telegram.controls.title': 'オーナーとグループ',
+    'settings.integrations.telegram.controls.description':
+      '安全のためオーナーのユーザー ID を少なくとも 1 つ追加し、ボットが応答するグループとチャットを選びます。',
+    'settings.integrations.telegram.controls.meta': 'オーナー {owners} · チャット {chats}',
     'settings.integrations.telegram.groups.title': 'グループとチャット',
     'settings.integrations.telegram.groups.description': 'OpenChamber が応答するグループとチャットを有効にします。「プロジェクトを同期」は選択した各チャットにステータスメッセージを投稿し、ボットがトピックを管理できる場合はフォーラムトピックを作成します。',
     'settings.integrations.telegram.groups.empty': 'まだチャットがありません。ボットにメッセージを送るか、「許可するチャット ID」に追加するとここに表示されます。',
@@ -1183,6 +1203,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '프롬프트 1개 스트리밍 중…',
     'settings.integrations.telegram.bridge.activeMany': '프롬프트 {count}개 스트리밍 중…',
 
+    'settings.integrations.telegram.controls.title': '소유자 및 그룹',
+    'settings.integrations.telegram.controls.description':
+      '보안을 위해 소유자 사용자 ID를 하나 이상 추가한 다음, 봇이 응답할 그룹과 채팅을 선택하세요.',
+    'settings.integrations.telegram.controls.meta': '소유자 {owners} · 채팅 {chats}',
     'settings.integrations.telegram.groups.title': '그룹 및 채팅',
     'settings.integrations.telegram.groups.description': 'OpenChamber가 응답할 그룹과 채팅을 활성화하세요. 프로젝트 동기화는 선택한 각 채팅에 상태 메시지를 게시하고, 봇이 주제를 관리할 수 있으면 포럼 주제를 만듭니다.',
     'settings.integrations.telegram.groups.empty': '아직 채팅이 없습니다. 봇에게 메시지를 보내거나 허용된 채팅 ID에 추가하면 여기에 표시됩니다.',
@@ -1394,6 +1418,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 prompt w toku…',
     'settings.integrations.telegram.bridge.activeMany': '{count} promptów w toku…',
 
+    'settings.integrations.telegram.controls.title': 'Właściciele i grupy',
+    'settings.integrations.telegram.controls.description':
+      'Dodaj co najmniej jeden identyfikator właściciela dla bezpieczeństwa, a następnie wybierz grupy i czaty, w których bot ma odpowiadać.',
+    'settings.integrations.telegram.controls.meta': '{owners} właścicieli · {chats} czatów',
     'settings.integrations.telegram.groups.title': 'Grupy i czaty',
     'settings.integrations.telegram.groups.description': 'Włącz grupy i czaty, w których OpenChamber ma odpowiadać. Synchronizacja projektów publikuje komunikat statusu w każdym wybranym czacie i tworzy tematy forum, gdy bot może zarządzać tematami.',
     'settings.integrations.telegram.groups.empty': 'Brak czatów. Napisz do bota lub dodaj ID w „Dozwolone ID czatów”, a pojawią się tutaj.',
@@ -1605,6 +1633,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 prompt em andamento…',
     'settings.integrations.telegram.bridge.activeMany': '{count} prompts em andamento…',
 
+    'settings.integrations.telegram.controls.title': 'Proprietários e grupos',
+    'settings.integrations.telegram.controls.description':
+      'Adicione pelo menos um id de proprietário por segurança e depois escolha em quais grupos e chats o bot responde.',
+    'settings.integrations.telegram.controls.meta': '{owners} proprietários · {chats} chats',
     'settings.integrations.telegram.groups.title': 'Grupos e chats',
     'settings.integrations.telegram.groups.description': 'Ative os grupos e chats em que o OpenChamber deve responder. Sincronizar projetos publica uma mensagem de status em cada chat selecionado e cria tópicos de fórum quando o bot pode gerenciar tópicos.',
     'settings.integrations.telegram.groups.empty': 'Nenhum chat ainda. Envie uma mensagem ao bot ou adicione IDs em «IDs de chat permitidos» e eles aparecerão aqui.',
@@ -1816,6 +1848,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 промпт надсилається…',
     'settings.integrations.telegram.bridge.activeMany': '{count} промптів надсилається…',
 
+    'settings.integrations.telegram.controls.title': 'Власники та групи',
+    'settings.integrations.telegram.controls.description':
+      'Додайте щонайменше один ідентифікатор власника для безпеки, а потім виберіть групи та чати, в яких бот відповідає.',
+    'settings.integrations.telegram.controls.meta': '{owners} власників · {chats} чатів',
     'settings.integrations.telegram.groups.title': 'Групи та чати',
     'settings.integrations.telegram.groups.description': 'Увімкніть групи та чати, де OpenChamber має відповідати. Синхронізація проєктів надсилає статус у кожний вибраний чат і створює теми форуму, коли бот може керувати темами.',
     'settings.integrations.telegram.groups.empty': 'Ще немає чатів. Напишіть боту або додайте ID в «Дозволені ID чатів» — тоді вони з’являться тут.',
@@ -2027,6 +2063,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 个提示正在流式传输…',
     'settings.integrations.telegram.bridge.activeMany': '{count} 个提示正在流式传输…',
 
+    'settings.integrations.telegram.controls.title': '所有者与群组',
+    'settings.integrations.telegram.controls.description':
+      '为安全起见请至少添加一个所有者用户 ID，然后选择机器人要回复的群组和聊天。',
+    'settings.integrations.telegram.controls.meta': '{owners} 位所有者 · {chats} 个聊天',
     'settings.integrations.telegram.groups.title': '群组与聊天',
     'settings.integrations.telegram.groups.description': '启用 OpenChamber 应回复的群组和聊天。“同步项目”会向每个选定聊天发布状态消息，并在机器人可管理话题时创建论坛话题。',
     'settings.integrations.telegram.groups.empty': '尚无聊天。先给机器人发消息，或在“允许的聊天 ID”中添加 ID，随后会显示在这里。',
@@ -2238,6 +2278,10 @@ export const telegramIntegrationI18n = {
     'settings.integrations.telegram.bridge.activeOne': '1 個提示正在串流…',
     'settings.integrations.telegram.bridge.activeMany': '{count} 個提示正在串流…',
 
+    'settings.integrations.telegram.controls.title': '擁有者與群組',
+    'settings.integrations.telegram.controls.description':
+      '為安全起見請至少新增一個擁有者使用者 ID，然後選擇機器人要回覆的群組與聊天。',
+    'settings.integrations.telegram.controls.meta': '{owners} 位擁有者 · {chats} 個聊天',
     'settings.integrations.telegram.groups.title': '群組與聊天',
     'settings.integrations.telegram.groups.description': '啟用 OpenChamber 應回覆的群組與聊天。「同步專案」會向每個選定聊天發布狀態訊息，並在機器人可管理主題時建立論壇主題。',
     'settings.integrations.telegram.groups.empty': '尚無聊天。先傳訊息給機器人，或在「允許的聊天 ID」中新增 ID，之後會顯示在這裡。',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Telegram Owners & groups was always expanded and showed last-sync details on the main card. Collapse that panel by default: click to show owner user ids (at least one required for safety) and Telegram groups; click again to hide. Move last sync results into Advanced settings only.

## Non-goals

- Changing sync/binding/rate-limit behavior (already merged in #2793)
- Discord servers panel layout parity beyond the existing click-to-open chat pattern

## Affected surfaces

- `packages/ui` Settings → Integrations → Telegram card (`TelegramCard.tsx`) and telegram integration i18n
- Runtimes: shared UI; no server or runtime-specific fork

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | UI source + i18n change | Minimal layout change; no new deps |
| `settings-ui-patterns` | Settings Integrations surface | Reused `AdvancedSectionCard` collapsible for click show/hide |
| `locale-ui-patterns` | New controls title/description/meta strings | Added real translations in every locale in `telegram-integration.i18n.ts` |
| `theme-system` | Icons/colors in the panel | Existing `Icon` / semantic tokens only |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` | Pass |
| `bun run lint:ui` | Pass |
| Manual Settings click toggle / Advanced last-sync visibility | **Not verified** visually in this headless cloud run |

## Visual evidence

User-visible Settings change: Owners & groups starts collapsed; expands to owner ids + groups; last sync only under Advanced. Screenshots not captured in this headless cloud run — please spot-check Integrations → Telegram after merge.

## Risks and failure behavior

- Owner user ids moved from Advanced danger zone into the Owners & groups panel; empty list still refuses to persist (same safety rule).
- Last sync block renders only when restriction/result data exists; otherwise Advanced stays unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb6d30bf-a8b3-443c-9945-8a9e0ede32a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb6d30bf-a8b3-443c-9945-8a9e0ede32a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

