### PR TITLE
feat: per-project MCP scoping — reload config on directory change + scope badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - VS Code: the extension starts in the current workspace folder instead of one restored from storage (thanks to @makeittech).
 - Themes: custom themes loaded through symlinks now work (thanks to @divyam234).
 - Debug: the debug panel (Ctrl/Cmd+Shift+D) has a Requests tab showing in-flight requests and their age over the last five minutes (thanks to @tomzx).
+- Settings: MCP servers are now per-project — the MCP configuration reloads when the active directory changes and the server list shows whether each server comes from your user config or the current project's config (thanks to @herjarsa).
 - Reliability: switching sessions quickly no longer saves the wrong scroll position, and the log no longer fills with worktree warnings for non-Git folders (thanks to @herjarsa); startup cleanup of leftover processes no longer blocks the server on Windows (thanks to @bashrusakh).
 
 ## [1.21.0] - 2026-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable changes to this project will be documented in this file.
 - VS Code: the extension starts in the current workspace folder instead of one restored from storage (thanks to @makeittech).
 - Themes: custom themes loaded through symlinks now work (thanks to @divyam234).
 - Debug: the debug panel (Ctrl/Cmd+Shift+D) has a Requests tab showing in-flight requests and their age over the last five minutes (thanks to @tomzx).
-- Settings: MCP servers are now per-project — the MCP configuration reloads when the active directory changes and the server list shows whether each server comes from your user config or the current project's config (thanks to @herjarsa).
+- Settings: MCP server detail card now shows a per-server scope badge (project vs user) so the origin is visible at a glance (thanks to @herjarsa).
 - Reliability: switching sessions quickly no longer saves the wrong scroll position, and the log no longer fills with worktree warnings for non-Git folders (thanks to @herjarsa); startup cleanup of leftover processes no longer blocks the server on Windows (thanks to @bashrusakh).
 
 ## [1.21.0] - 2026-08-26

--- a/packages/ui/src/components/sections/mcp/McpPage.tsx
+++ b/packages/ui/src/components/sections/mcp/McpPage.tsx
@@ -1449,17 +1449,16 @@ export const McpPage: React.FC = () => {
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                     <span className={SETTINGS_FIELD_LABEL_CLASS}>{t('settings.mcp.page.status.runtimeStatus')}</span>
                     <StatusBadge status={effectiveRuntimeStatus?.status} enabled={enabled} getStatusLabel={getStatusLabel} />
-                  <div className="flex items-center gap-2">
-                {selectedServer?.scope && (
-                  <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${
-                    selectedServer.scope === 'user'
-                      ? 'bg-warning/15 text-warning-foreground border border-warning/30'
-                      : 'bg-info/15 text-info-foreground border border-info/30'
-                  }`}>
-                    {t(selectedServer.scope === 'user' ? 'settings.common.scope.global' : 'settings.common.scope.project')}
-                  </span>
-                )}
-              </div></div>
+                    {selectedServer?.scope && (
+                      <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${
+                        selectedServer.scope === 'user'
+                          ? 'bg-warning/15 text-warning-foreground border border-warning/30'
+                          : 'bg-info/15 text-info-foreground border border-info/30'
+                      }`}>
+                        {t(selectedServer.scope === 'user' ? 'settings.common.scope.global' : 'settings.common.scope.project')}
+                      </span>
+                    )}
+                  </div>
                   <p className="typography-meta text-muted-foreground">{runtimeDescription}</p>
                   <p className="typography-micro text-muted-foreground/80">
                     {draftScope === 'project'

--- a/packages/ui/src/components/sections/mcp/McpPage.tsx
+++ b/packages/ui/src/components/sections/mcp/McpPage.tsx
@@ -1450,11 +1450,23 @@ export const McpPage: React.FC = () => {
                     <span className={SETTINGS_FIELD_LABEL_CLASS}>{t('settings.mcp.page.status.runtimeStatus')}</span>
                     <StatusBadge status={effectiveRuntimeStatus?.status} enabled={enabled} getStatusLabel={getStatusLabel} />
                     {selectedServer?.scope && (
-                      <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${
-                        selectedServer.scope === 'user'
-                          ? 'bg-warning/15 text-warning-foreground border border-warning/30'
-                          : 'bg-info/15 text-info-foreground border border-info/30'
-                      }`}>
+                      <span
+                        className="inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium"
+                        style={{
+                          backgroundColor:
+                            selectedServer.scope === 'user'
+                              ? 'var(--status-warning-background)'
+                              : 'var(--status-info-background)',
+                          borderColor:
+                            selectedServer.scope === 'user'
+                              ? 'var(--status-warning-border)'
+                              : 'var(--status-info-border)',
+                          color:
+                            selectedServer.scope === 'user'
+                              ? 'var(--status-warning-foreground)'
+                              : 'var(--status-info-foreground)',
+                        }}
+                      >
                         {t(selectedServer.scope === 'user' ? 'settings.common.scope.global' : 'settings.common.scope.project')}
                       </span>
                     )}

--- a/packages/ui/src/components/sections/mcp/McpPage.tsx
+++ b/packages/ui/src/components/sections/mcp/McpPage.tsx
@@ -1449,7 +1449,17 @@ export const McpPage: React.FC = () => {
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                     <span className={SETTINGS_FIELD_LABEL_CLASS}>{t('settings.mcp.page.status.runtimeStatus')}</span>
                     <StatusBadge status={effectiveRuntimeStatus?.status} enabled={enabled} getStatusLabel={getStatusLabel} />
-                  </div>
+                  <div className="flex items-center gap-2">
+                {selectedServer?.scope && (
+                  <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${
+                    selectedServer.scope === 'user'
+                      ? 'bg-warning/15 text-warning-foreground border border-warning/30'
+                      : 'bg-info/15 text-info-foreground border border-info/30'
+                  }`}>
+                    {t(selectedServer.scope === 'user' ? 'settings.common.scope.global' : 'settings.common.scope.project')}
+                  </span>
+                )}
+              </div></div>
                   <p className="typography-meta text-muted-foreground">{runtimeDescription}</p>
                   <p className="typography-micro text-muted-foreground/80">
                     {draftScope === 'project'

--- a/packages/ui/src/components/sections/mcp/McpPage.tsx
+++ b/packages/ui/src/components/sections/mcp/McpPage.tsx
@@ -1384,7 +1384,17 @@ export const McpPage: React.FC = () => {
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                     <span className={SETTINGS_FIELD_LABEL_CLASS}>{t('settings.mcp.page.status.runtimeStatus')}</span>
                     <StatusBadge status={effectiveRuntimeStatus?.status} enabled={enabled} getStatusLabel={getStatusLabel} />
-                  </div>
+                  <div className="flex items-center gap-2">
+                {server.scope && (
+                  <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${
+                    server.scope === 'user' 
+                      ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300' 
+                      : 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
+                  }`}>
+                    {t(server.scope === 'user' ? 'settings.common.scope.global' : 'settings.common.scope.project')}
+                  </span>
+                )}
+              </div></div>
                   <p className="typography-meta text-muted-foreground">{runtimeDescription}</p>
                   <p className="typography-micro text-muted-foreground/80">
                     {draftScope === 'project'

--- a/packages/ui/src/stores/useMcpConfigStore.ts
+++ b/packages/ui/src/stores/useMcpConfigStore.ts
@@ -119,9 +119,11 @@ interface McpConfigStore {
   selectedMcpName: string | null;
   isLoading: boolean;
   mcpDraft: McpDraft | null;
+  currentDirectory: string | null;
 
   setSelectedMcp: (name: string | null) => void;
   setMcpDraft: (draft: McpDraft | null) => void;
+  setCurrentDirectory: (dir: string | null) => void;
   loadMcpConfigs: (options?: { force?: boolean }) => Promise<boolean>;
   createMcp: (config: McpDraft) => Promise<McpMutationResult>;
   updateMcp: (name: string, config: Partial<McpDraft>) => Promise<McpMutationResult>;
@@ -141,10 +143,18 @@ export const useMcpConfigStore = create<McpConfigStore>()(
         selectedMcpName: null,
         isLoading: false,
         mcpDraft: null,
+  currentDirectory: null,
 
         setSelectedMcp: (name) => set({ selectedMcpName: name }),
 
         setMcpDraft: (draft) => set({ mcpDraft: draft }),
+  setCurrentDirectory: (dir) => {
+    const prevDir = get().currentDirectory;
+    set({ currentDirectory: dir });
+    if (prevDir !== dir) {
+      get().loadMcpConfigs({ force: true });
+    }
+  },
 
         loadMcpConfigs: async (options) => {
           const configDirectory = getConfigDirectory();

--- a/packages/ui/src/stores/useMcpConfigStore.ts
+++ b/packages/ui/src/stores/useMcpConfigStore.ts
@@ -135,9 +135,11 @@ interface McpConfigStore {
   selectedMcpName: string | null;
   isLoading: boolean;
   mcpDraft: McpDraft | null;
+  currentDirectory: string | null;
 
   setSelectedMcp: (name: string | null) => void;
   setMcpDraft: (draft: McpDraft | null) => void;
+  setCurrentDirectory: (dir: string | null) => void;
   loadMcpConfigs: (options?: { force?: boolean; directory?: string | null }) => Promise<boolean>;
   createMcp: (config: McpDraft, directory?: string | null) => Promise<McpMutationResult>;
   updateMcp: (name: string, config: Partial<McpDraft>, directory?: string | null) => Promise<McpMutationResult>;
@@ -173,10 +175,18 @@ export const useMcpConfigStore = create<McpConfigStore>()(
         selectedMcpName: null,
         isLoading: false,
         mcpDraft: null,
+  currentDirectory: null,
 
         setSelectedMcp: (name) => set({ selectedMcpName: name }),
 
         setMcpDraft: (draft) => set({ mcpDraft: draft }),
+        setCurrentDirectory: (dir) => {
+          const prevDir = get().currentDirectory;
+          set({ currentDirectory: dir });
+          if (prevDir !== dir) {
+            void get().loadMcpConfigs({ force: true, directory: dir });
+          }
+        },
 
         loadMcpConfigs: async (options) => {
           const configDirectory = resolveDirectory(options?.directory);

--- a/packages/ui/src/stores/useMcpConfigStore.ts
+++ b/packages/ui/src/stores/useMcpConfigStore.ts
@@ -135,11 +135,9 @@ interface McpConfigStore {
   selectedMcpName: string | null;
   isLoading: boolean;
   mcpDraft: McpDraft | null;
-  currentDirectory: string | null;
 
   setSelectedMcp: (name: string | null) => void;
   setMcpDraft: (draft: McpDraft | null) => void;
-  setCurrentDirectory: (dir: string | null) => void;
   loadMcpConfigs: (options?: { force?: boolean; directory?: string | null }) => Promise<boolean>;
   createMcp: (config: McpDraft, directory?: string | null) => Promise<McpMutationResult>;
   updateMcp: (name: string, config: Partial<McpDraft>, directory?: string | null) => Promise<McpMutationResult>;
@@ -175,18 +173,10 @@ export const useMcpConfigStore = create<McpConfigStore>()(
         selectedMcpName: null,
         isLoading: false,
         mcpDraft: null,
-  currentDirectory: null,
 
         setSelectedMcp: (name) => set({ selectedMcpName: name }),
 
         setMcpDraft: (draft) => set({ mcpDraft: draft }),
-        setCurrentDirectory: (dir) => {
-          const prevDir = get().currentDirectory;
-          set({ currentDirectory: dir });
-          if (prevDir !== dir) {
-            void get().loadMcpConfigs({ force: true, directory: dir });
-          }
-        },
 
         loadMcpConfigs: async (options) => {
           const configDirectory = resolveDirectory(options?.directory);


### PR DESCRIPTION
## Intent

Land the per-server scope badge in the MCP settings page. Main already reloads MCP configs when the active directory changes and already groups servers by scope in the sidebar — the only net user-visible change this PR adds is the badge itself.

## Non-goals

- No change to MCP config reload semantics (already in main via `useSettingsDirectory` consumers).
- No change to MCP tool transport or to the opencode SDK contract.
- No new store state — `currentDirectory`/`setCurrentDirectory` were added in an earlier iteration of this branch but reverted after code review flagged them as a second source of truth that fights the settings directory selector.

## Affected surfaces

- `packages/ui/src/components/sections/mcp/McpPage.tsx` — renders a per-server scope badge (project vs user) inside the selected server's runtime status card. The badge uses the existing `--status-warning-*` / `--status-info-*` CSS variables, not hand-rolled colors.
- `CHANGELOG.md` — `[Unreleased]` bullet crediting @herjarsa for the badge.

## Repository guidance applied

| Source | Why applicable | Rules applied |
|---|---|---|
| `AGENTS.md` runtime boundaries | Shared UI page logic | "Prefer authoritative state over heuristics" — the badge reads `selectedServer.scope` (already populated by the existing server loader) and does not introduce a parallel source. |
| `.agents/skills/openchamber-change-discipline/SKILL.md` | Visual change to settings page | Smallest complete change; nothing else was modified. |
| `.agents/skills/theme-system/SKILL.md` | Badge tokens | Badge uses `var(--status-warning-background|background|border|foreground)` and `var(--status-info-*)` defined in `lib/theme/cssGenerator.ts`. No `bg-warning/15` or hand-rolled color. |
| `.agents/skills/locale-ui-patterns/SKILL.md` | User-facing badge text | Reuses `settings.common.scope.global` / `settings.common.scope.project` from the existing scope strings. |

## Validation

- `bun run --filter @openchamber/ui type-check` — exit 0; the only file touched in this iteration is `McpPage.tsx` and `CHANGELOG.md`, and both compile cleanly against current main. (Note: the prior iteration's validation section claimed a passing run of `useMcpConfigStore.test.ts` — no such file exists in the repo, and that section has been removed.)
- Manual review of the badge render: same inline layout (`inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium`) as the working status card examples at `McpPage.tsx:491` and `McpPage.tsx:1429`, but using the `--status-*-background` / `-border` / `-foreground` CSS variables defined by `lib/theme/cssGenerator.ts` for both light and dark themes.

## Visual evidence

The badge sits inside the selected server's runtime status card, inline with the existing `<StatusBadge>` chip. No new layout, no new card. Scope is already visible in the sidebar grouping and in the runtime card prose two lines below the badge, so this is an at-a-glance visual confirmation, not new information.

## Risks and failure behavior

- If `selectedServer.scope` is `undefined` (server not yet loaded), the badge is omitted. Matches pre-PR behavior.
- The badge does not affect server load, transport, or restart flow; it is purely presentational.
- Reverting this PR leaves the rest of the page in a clean state — no half-wired store action, no leftover store field.
