### PR TITLE
fix(chat): prevent auto-load cascade on history scroll; remove translateZ(0) GPU ghosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - VS Code: the extension starts in the current workspace folder instead of one restored from storage (thanks to @makeittech).
 - Themes: custom themes loaded through symlinks now work (thanks to @divyam234).
 - Debug: the debug panel (Ctrl/Cmd+Shift+D) has a Requests tab showing in-flight requests and their age over the last five minutes (thanks to @tomzx).
+- Chat: scrolling up through history no longer auto-loads more messages in a runaway cascade; rendering also stops promoting messages to their own GPU layer (no more ghosting from `translateZ(0)`) (thanks to @herjarsa).
 - Reliability: switching sessions quickly no longer saves the wrong scroll position, and the log no longer fills with worktree warnings for non-Git folders (thanks to @herjarsa); startup cleanup of leftover processes no longer blocks the server on Windows (thanks to @bashrusakh).
 
 ## [1.21.0] - 2026-08-26

--- a/packages/ui/src/components/chat/hooks/useChatTimelineController.ts
+++ b/packages/ui/src/components/chat/hooks/useChatTimelineController.ts
@@ -758,6 +758,12 @@ export const useChatTimelineController = ({
         if (!container) return;
         if (isPinnedRef.current) return;
         if (container.scrollTop >= resolveHistoryScrollThreshold(container.clientHeight)) return;
+
+        // Prevent cascade re-triggering: if a loadEarlier interaction is active
+        // (settleHistoryInteraction 2s guard), skip until it settles. Without this,
+        // loading history while near the top can trigger another load immediately
+        // because the scroll compensation keeps scrollTop within threshold.
+        if (historyInteractionRef.current) return;
         if (!historySignalsRef.current.canLoadEarlier) return;
         if (isLoadingOlderRef.current || pendingRevealWorkRef.current) return;
 

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -58,7 +58,7 @@ import { getAgentColor } from '@/lib/agentColors';
 import { isCapacitorMobileApp } from '@/apps/mobileNativeChrome';
 
 
-const CONTAIN_LAYOUT_STYLE = { contain: 'layout' as const, transform: 'translateZ(0)' };
+const CONTAIN_LAYOUT_STYLE = { contain: 'layout' as const };
 const MESSAGE_FOOTER_CONTAINER_STYLE = { containerType: 'inline-size' as const, containerName: 'message-footer' };
 const INLINE_MESSAGE_ACTIONS_CLASS_NAME = 'mt-2 mb-1 flex items-center justify-start gap-1.5';
 

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -59,7 +59,7 @@ import { getAgentColor } from '@/lib/agentColors';
 import { isCapacitorMobileApp } from '@/apps/mobileNativeChrome';
 
 
-const CONTAIN_LAYOUT_STYLE = { contain: 'layout' as const, transform: 'translateZ(0)' };
+const CONTAIN_LAYOUT_STYLE = { contain: 'layout' as const };
 const MESSAGE_FOOTER_CONTAINER_STYLE = { containerType: 'inline-size' as const, containerName: 'message-footer' };
 const INLINE_MESSAGE_ACTIONS_CLASS_NAME = 'mt-2 mb-1 flex items-center justify-start gap-1.5';
 


### PR DESCRIPTION
## Intent

Chat history scroll could re-trigger `loadEarlier` in a runaway cascade: when scrolling upward through a long history, the scroll position keeps `scrollTop` within the load-earlier threshold while the in-flight request settles, so each settle immediately triggers another. The cascade guard in `useChatTimelineController.handleHistoryScroll` now skips while a `historyInteractionRef` is active (the same 2 s settle window used by `loadEarlierIfPinnedViewportUnderfilled`), matching the pattern main already uses.

Separately, `MessageBody` was creating its own GPU compositing layer via `transform: translateZ(0)` on the `contain: layout` style, which on some Windows GPUs produced a visible ghosting artifact when the message content updated. Removing the transform keeps `contain: layout` (which still gives the containing-block semantics) without the spurious layer promotion.

Both are cherry-picks of changes that landed on a now-closed branch (#1887). The current diff has only these two files plus the CHANGELOG entry; the old wholesale `ChatContainer.tsx` revert is no longer present.

## Non-goals

- Not changing `loadEarlierIfPinnedViewportUnderfilled` (it already had the same `historyInteractionRef` guard).
- Not reintroducing layer promotion for any message element.
- Not changing the public chat API.

## Affected surfaces

- `packages/ui/src/components/chat/hooks/useChatTimelineController.ts` — `handleHistoryScroll` now bails when `historyInteractionRef.current` is truthy.
- `packages/ui/src/components/chat/message/MessageBody.tsx` — `CONTAIN_LAYOUT_STYLE` keeps `contain: layout` and drops `transform: translateZ(0)`.
- `CHANGELOG.md` — `[Unreleased]` entry.

All runtimes use the same chat code (web, desktop, VS Code, mobile).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Shared UI behavior in shared chat code | The cascade guard is the parallel of `loadEarlierIfPinnedViewportUnderfilled`'s existing guard — same ref, same settle window, same effect; one source of truth, no duplicated lifecycle |
| `.github/PULL_REQUEST_TEMPLATE.md` | Required handoff structure | All seven sections present |
| `CONTRIBUTING.md` | PR contract | Validation below; visual evidence note where no recording exists |
| `openchamber-change-discipline` | Source change in shared chat hook | Smallest complete change: only the guard is added; no other lifecycle touched |
| `sync-state-invariants` | History pagination driven by scroll | The guard makes scroll-position-based pagination idempotent against the in-flight settle window — no duplicate fetches |
| `performance-engineering` | Interaction hot path | The new branch is a single ref check (truthy → return); no new allocations, no extra render work. Layer promotion removal is the explicit perf/compositing cleanup the PR claims |

## Validation

- `bun test packages/ui/src/components/chat/hooks/useChatTimelineController.test.ts` — 6/6 pass.
- Manual reasoning: the guard short-circuits a single ref check inside `handleHistoryScroll`; the only behavior change is that scroll events arriving during the 2 s settle window now skip `loadEarlier` instead of re-entering it. The settle window itself is unchanged.
- `bun run --filter @openchamber/ui type-check` — exit 0 (verified locally on the rebased branch).

## Visual evidence

Removing `translateZ(0)` is a compositing-layer change. A before/after recording of the GPU-ghosting artifact would require reproducing the artifact on a Windows desktop with a compatible GPU; I was unable to capture this in the dev environment, so the fix is justified by code reasoning (`contain: layout` preserves the layout/stacking semantics per the CSS containment spec) rather than empirical before/after. If a reviewer can attach a recording of the original artifact, I can confirm the visual fix on the same setup.

## Risks and failure behavior

- **Cascade guard**: only effective if `historyInteractionRef` is correctly set/cleared by the existing `beginHistoryInteraction`/`settleHistoryInteraction` callsites (lines `loadEarlier` and `fetchOlderHistory` `finally` blocks). Those are unchanged.
- **Layer promotion removal**: any layout/paint that depended on the GPU layer for off-thread rasterization will now run on the main thread. The contained elements are short-lived message bodies, so this is bounded.
- **Rollback**: revert the single commit; the guard and the style change are isolated.
