### PR TITLE
fix(ui): mount only the active session chat iframe

### DIFF
--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -2488,8 +2488,8 @@ export const ContextPanel: React.FC = () => {
     () => tabs.filter((tab) => tab.mode === 'chat'),
     [tabs],
   );
-  const activeChatTabID = activeTab?.mode === 'chat' ? activeTab.id : null;
-  const activeChatSessionID = activeTab?.mode === 'chat' ? getSessionIDFromDedupeKey(activeTab.dedupeKey) : null;
+  const activeChatTabID = isOpen && activeTab?.mode === 'chat' ? activeTab.id : null;
+  const activeChatSessionID = isOpen && activeTab?.mode === 'chat' ? getSessionIDFromDedupeKey(activeTab.dedupeKey) : null;
   const activeChatTab = getActiveEmbeddedSessionChatTab(chatTabs, activeChatTabID);
 
   React.useEffect(() => {

--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -45,6 +45,7 @@ import { invokeDesktopCommand } from '@/lib/desktopNative';
 import {
   EMBEDDED_RUNTIME_BOOTSTRAP_REQUEST,
   EMBEDDED_RUNTIME_BOOTSTRAP_RESPONSE,
+  getActiveEmbeddedSessionChatTab,
   getOrCreateEmbeddedSessionChatURL,
   type EmbeddedSessionChatURLCacheEntry,
   type EmbeddedSessionRuntimeBootstrap,
@@ -2483,8 +2484,13 @@ export const ContextPanel: React.FC = () => {
 
   }, [activeTab, directoryKey, setSelectedFilePath]);
 
+  const chatTabs = React.useMemo(
+    () => tabs.filter((tab) => tab.mode === 'chat'),
+    [tabs],
+  );
   const activeChatTabID = activeTab?.mode === 'chat' ? activeTab.id : null;
   const activeChatSessionID = activeTab?.mode === 'chat' ? getSessionIDFromDedupeKey(activeTab.dedupeKey) : null;
+  const activeChatTab = getActiveEmbeddedSessionChatTab(chatTabs, activeChatTabID);
 
   React.useEffect(() => {
     if (!isOpen || !directoryKey || !activeChatSessionID || typeof window === 'undefined') {
@@ -2524,6 +2530,10 @@ export const ContextPanel: React.FC = () => {
       currentTheme,
     });
   }, [currentTheme, darkThemeId, directoryKey, lightThemeId, themeMode]);
+
+  const activeChatSrc = activeChatTab && activeChatSessionID
+    ? getEmbeddedChatSrc(activeChatTab.id, activeChatSessionID, activeChatTab.readOnly)
+    : null;
 
   React.useEffect(() => {
     const liveTabIDs = new Set(tabs.map((tab) => tab.id));
@@ -2721,10 +2731,6 @@ export const ContextPanel: React.FC = () => {
                   </div>
                 );
 
-  const chatTabs = React.useMemo(
-    () => tabs.filter((tab) => tab.mode === 'chat'),
-    [tabs],
-  );
   const browserTabs = React.useMemo(
     () => tabs.filter((tab) => tab.mode === 'browser'),
     [tabs],
@@ -2934,41 +2940,26 @@ export const ContextPanel: React.FC = () => {
             <EditorTreeColumn visible={contextEditorTreeVisible} />
           </div>
         ) : null}
-        {chatTabs.map((tab) => {
-          const sessionID = getSessionIDFromDedupeKey(tab.dedupeKey);
-          if (!sessionID) {
-            return null;
-          }
-
-          const src = getEmbeddedChatSrc(tab.id, sessionID, tab.readOnly);
-          if (!src) {
-            return null;
-          }
-
-          return (
-            <iframe
-              key={tab.id}
-              ref={(node) => {
-                if (!node) {
-                  chatFrameRefs.current.delete(tab.id);
-                  return;
-                }
-                chatFrameRefs.current.set(tab.id, node);
-              }}
-              src={src}
-              title={t('contextPanel.iframe.sessionChatTitle', { sessionID })}
-              className={cn(
-                'absolute inset-0 h-full w-full border-0 bg-background',
-                activeChatTabID === tab.id ? 'block' : 'hidden'
-              )}
-              onLoad={() => {
-                postThemeSyncToEmbeddedChat();
-                postChatSettingsSyncToEmbeddedChat();
-                postEmbeddedVisibilityToChats();
-              }}
-            />
-          );
-        })}
+        {activeChatTab && activeChatSessionID && activeChatSrc ? (
+          <iframe
+            key={activeChatTab.id}
+            ref={(node) => {
+              if (!node) {
+                chatFrameRefs.current.delete(activeChatTab.id);
+                return;
+              }
+              chatFrameRefs.current.set(activeChatTab.id, node);
+            }}
+            src={activeChatSrc}
+            title={t('contextPanel.iframe.sessionChatTitle', { sessionID: activeChatSessionID })}
+            className="absolute inset-0 h-full w-full border-0 bg-background"
+            onLoad={() => {
+              postThemeSyncToEmbeddedChat();
+              postChatSettingsSyncToEmbeddedChat();
+              postEmbeddedVisibilityToChats();
+            }}
+          />
+        ) : null}
         {browserTabs.map((tab) => (
           <div
             key={tab.id}

--- a/packages/ui/src/components/layout/__tests__/issue-2815-sessionChatIframesMountAllTabs.test.ts
+++ b/packages/ui/src/components/layout/__tests__/issue-2815-sessionChatIframesMountAllTabs.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Reproduction for https://github.com/openchamber/openchamber/issues/2815
+ *
+ * [Bug] OpenChamber mounts all persisted session-chat iframes and freezes the
+ * browser.
+ *
+ * Root cause under test: `ContextPanel` renders one full-application `<iframe>`
+ * for EVERY chat tab in the context panel — including inactive tabs. Inactive
+ * frames are only hidden with the Tailwind `hidden` class (`display: none`),
+ * but a `display:none` iframe that carries a `src` is still navigated and
+ * executed by the browser. After a reload, `useUIStore` restores every
+ * persisted tab (via `sanitizeContextPanelByDirectory`), so N persisted
+ * session-chat tabs become N embedded OpenChamber applications in a single
+ * browser tab (the reported ~1 GB renderer freeze).
+ *
+ * We cannot mount the full `ContextPanel` in `bun test` (its import graph pulls
+ * in a Vite `?worker&url` asset that Bun cannot resolve), so, following the
+ * repo's existing regression-guard precedent (e.g.
+ * `contextPanelEscapeClosesTerminal.test.ts`), this test:
+ *   1. reads the real `ContextPanel.tsx` and asserts on the exact chat-frame
+ *      render block that is responsible,
+ *   2. drives the real `useUIStore` with the issue's persisted-tab scenario
+ *      (8 read-only session-chat tabs + 3 other tabs = 11 tabs), and
+ *   3. runs a faithful model of the extracted production render block against
+ *      the store's real tab objects, using the real
+ *      `buildEmbeddedSessionChatURL` helper, to show that all 8 session-chat
+ *      tabs get a live `src` iframe (only 1 of them visible).
+ */
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getDefaultTheme } from '@/lib/theme/themes';
+import type { Theme } from '@/types/theme';
+import { buildEmbeddedSessionChatURL, resetEmbeddedSessionChatCache } from '../contextPanelEmbeddedChat';
+import { useUIStore } from '@/stores/useUIStore';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const contextPanelSource = readFileSync(join(__dirname, '..', 'ContextPanel.tsx'), 'utf-8');
+const uiStoreSource = readFileSync(join(__dirname, '..', '..', '..', 'stores', 'useUIStore.ts'), 'utf-8');
+
+// ---------------------------------------------------------------------------
+// Local structural copies of the (unexported) tab/directory state types in
+// useUIStore.ts so the fixture matches the real store shape exactly.
+// ---------------------------------------------------------------------------
+
+type FixtureContextPanelMode =
+  | 'chat' | 'file' | 'context' | 'git' | 'diff' | 'plan' | 'preview'
+  | 'browser' | 'pr' | 'notes' | 'terminal' | 'walkthrough';
+
+type FixtureContextPanelTab = {
+  id: string;
+  mode: FixtureContextPanelMode;
+  targetPath: string | null;
+  dedupeKey: string;
+  label: string | null;
+  sessionTitleFallback: string | null;
+  readOnly: boolean;
+  stagedDiff: boolean;
+  diffScope: string | null;
+  touchedAt: number;
+};
+
+type FixtureContextPanelDirectoryState = {
+  isOpen: boolean;
+  expanded: boolean;
+  tabs: FixtureContextPanelTab[];
+  activeTabId: string | null;
+  widthByMode: Partial<Record<FixtureContextPanelMode, number>>;
+  touchedAt: number;
+};
+
+// ---------------------------------------------------------------------------
+// Window stub so the real `buildEmbeddedSessionChatURL` can construct the
+// embedded-frame URL (same approach as contextPanelEmbeddedChat.test.ts).
+// ---------------------------------------------------------------------------
+
+const originalWindow = globalThis.window;
+
+const installWindowLocation = (href = 'http://127.0.0.1:3000/') => {
+  const url = new URL(href);
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      location: {
+        href: url.toString(),
+        origin: url.origin,
+        pathname: url.pathname,
+        search: url.search,
+      },
+    },
+  });
+};
+
+const makeTheme = (variant: 'light' | 'dark'): Theme => getDefaultTheme(variant === 'dark');
+
+beforeEach(() => {
+  installWindowLocation();
+  resetEmbeddedSessionChatCache();
+  useUIStore.setState({ contextPanelByDirectory: {}, contextRailOrder: [] });
+});
+
+afterAll(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Faithful copy of the module-private helper from ContextPanel.tsx (lines
+// 426-433). Kept structurally identical so the model behaves exactly like the
+// production renderer.
+// ---------------------------------------------------------------------------
+
+const getSessionIDFromDedupeKey = (dedupeKey: string | undefined): string | null => {
+  if (!dedupeKey || !dedupeKey.startsWith('session:')) {
+    return null;
+  }
+  const sessionID = dedupeKey.slice('session:'.length).trim();
+  return sessionID || null;
+};
+
+// ---------------------------------------------------------------------------
+// The issue's persisted scenario: the active directory has 11 context-panel
+// tabs, 8 of which are read-only session-chat tabs (plan/subagent sessions).
+// Tab ids/dedupeKeys follow `createContextPanelTab` conventions
+// (`chat:session:ses_…`).
+// ---------------------------------------------------------------------------
+
+const DIRECTORY = '/path/to/repository';
+
+const buildChatTab = (sessionID: string, readOnly: boolean): FixtureContextPanelTab => ({
+  id: `chat:session:${sessionID}`,
+  mode: 'chat',
+  targetPath: null,
+  dedupeKey: `session:${sessionID}`,
+  label: `Session ${sessionID}`,
+  sessionTitleFallback: null,
+  readOnly,
+  stagedDiff: false,
+  diffScope: 'working',
+  touchedAt: Date.now(),
+});
+
+const buildNonChatTab = (mode: FixtureContextPanelMode, dedupeKey: string): FixtureContextPanelTab => ({
+  id: dedupeKey,
+  mode,
+  targetPath: null,
+  dedupeKey,
+  label: null,
+  sessionTitleFallback: null,
+  readOnly: false,
+  stagedDiff: false,
+  diffScope: 'working',
+  touchedAt: Date.now(),
+});
+
+// 8 read-only session-chat tabs (plan/subagent sessions), as persisted.
+const sessionChatTabs = Array.from({ length: 8 }, (_, index) => (
+  buildChatTab(`ses_${index + 1}`, true)
+));
+
+// The remaining 3 tabs of the active directory (matches the report: 11 total).
+const otherTabs: FixtureContextPanelTab[] = [
+  buildNonChatTab('git', 'git'),
+  buildNonChatTab('diff', 'diff'),
+  buildNonChatTab('plan', 'plan'),
+];
+
+const issueScenarioTabs = [...sessionChatTabs, ...otherTabs];
+
+// Installs the issue's persisted-tab scenario into the real ui-store, exactly
+// as it would look after a reload restored `contextPanelByDirectory`.
+const installIssueScenario = () => {
+  useUIStore.setState({
+    contextPanelByDirectory: {
+      [DIRECTORY]: {
+        isOpen: true,
+        expanded: false,
+        tabs: issueScenarioTabs,
+        activeTabId: 'chat:session:ses_1',
+        widthByMode: {},
+        touchedAt: Date.now(),
+      } as FixtureContextPanelDirectoryState,
+    } as never,
+  });
+};
+
+// ---------------------------------------------------------------------------
+// 1. Source evidence: the production render block mounts one iframe per chat
+//    tab and only toggles visibility with the `hidden` CSS class.
+// ---------------------------------------------------------------------------
+
+describe('issue #2815 source evidence (ContextPanel.tsx)', () => {
+  const extractChatFrameBlock = (): string => {
+    const startMarker = '{chatTabs.map((tab) => {';
+    const start = contextPanelSource.indexOf(startMarker);
+    expect(start).toBeGreaterThan(-1);
+    // The iframe is self-closing (`/>`), so anchor on the onLoad body that
+    // precedes the block's closing `);` / `})}` — an earlier `})}` appears
+    // inside the `title={t('...', { sessionID })}` expression.
+    const onLoadBody = contextPanelSource.indexOf('postEmbeddedVisibilityToChats();', start);
+    expect(onLoadBody).toBeGreaterThan(start);
+    const end = contextPanelSource.indexOf('})}', onLoadBody);
+    expect(end).toBeGreaterThan(onLoadBody);
+    return contextPanelSource.slice(start, end + 3);
+  };
+
+  test('chat frames are rendered by mapping over ALL chat tabs', () => {
+    const block = extractChatFrameBlock();
+    expect(block.includes('{chatTabs.map((tab) => {')).toBe(true);
+  });
+
+  test('every chat tab unconditionally gets an <iframe> with a live src', () => {
+    const block = extractChatFrameBlock();
+    // The iframe is created for every tab that has a sessionID; visibility is
+    // NOT a condition for mounting the iframe or setting its src.
+    expect(block.includes('<iframe')).toBe(true);
+    expect(block.includes('src={src}')).toBe(true);
+    // No active-tab guard in front of the iframe element itself.
+    expect(/activeChatTabID === tab\.id\s*&&/.test(block)).toBe(false);
+  });
+
+  test('inactive chat tabs are only hidden via the CSS `hidden` class', () => {
+    const block = extractChatFrameBlock();
+    // The ONLY active-tab distinction in the block is the visibility class.
+    expect(block.includes("activeChatTabID === tab.id ? 'block' : 'hidden'")).toBe(true);
+    // `hidden` maps to display:none; the iframe element and its src remain in
+    // the DOM, so the browser still loads and executes the embedded app.
+    const visibilitySwitchCount = block.match(/'block' : 'hidden'/g)?.length ?? 0;
+    expect(visibilitySwitchCount).toBe(1);
+  });
+
+  test('inactive session-chat tabs are never conditionally unmounted', () => {
+    const block = extractChatFrameBlock();
+    // There is no `return null`/skip for inactive tabs: only tabs without a
+    // sessionID or a usable src are skipped, never inactive ones.
+    expect(/if\s*\(.*activeChatTabID.*\)\s*return null/.test(block)).toBe(false);
+    expect(block.includes('if (!sessionID)')).toBe(true);
+    expect(block.includes('if (!src)')).toBe(true);
+  });
+});
+
+describe('issue #2815 source evidence (useUIStore.ts reload path)', () => {
+  test('sanitizeContextPanelByDirectory restores every persisted tab, not just the active one', () => {
+    // After a reload the persisted `tabs` array is restored in full; only the
+    // `activeTabId` selects one of them. There is no filtering of inactive
+    // session-chat tabs during hydration.
+    const sanitizeStart = uiStoreSource.indexOf('const sanitizeContextPanelByDirectory = (');
+    expect(sanitizeStart).toBeGreaterThan(-1);
+    // The full persisted `tabs` array is restored; only the active tab id is
+    // resolved separately. There is no filtering of inactive session-chat
+    // tabs during hydration.
+    expect(/\blet tabs = sanitizeContextPanelTabs\(candidate\.tabs\);/.test(uiStoreSource)).toBe(true);
+    expect(/let activeTabId = typeof candidate\.activeTabId === 'string' \? candidate\.activeTabId : null/.test(uiStoreSource)).toBe(true);
+    // It preserves the readOnly flag of persisted chat tabs.
+    expect(/readOnly: candidate\.readOnly === true/.test(uiStoreSource)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Real store: the issue's persisted scenario is present after "reload".
+// ---------------------------------------------------------------------------
+
+describe('issue #2815 persisted scenario in the real ui-store', () => {
+  beforeEach(() => {
+    installIssueScenario();
+  });
+
+  test('all 8 persisted session-chat tabs survive hydration', () => {
+    const tabs = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.tabs ?? [];
+    expect(tabs).toHaveLength(11);
+    const readOnlyChat = tabs.filter((tab) => tab.mode === 'chat' && tab.readOnly);
+    expect(readOnlyChat).toHaveLength(8);
+  });
+
+  test('exactly one tab is active while the other 7 session-chat tabs stay inactive', () => {
+    const state = useUIStore.getState().contextPanelByDirectory[DIRECTORY];
+    expect(state?.activeTabId).toBe('chat:session:ses_1');
+    const inactiveChatTabs = state?.tabs.filter(
+      (tab) => tab.mode === 'chat' && tab.readOnly && tab.id !== state?.activeTabId,
+    );
+    expect(inactiveChatTabs).toHaveLength(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Faithful model of the extracted production render block, run over the
+//    real store's tab objects with the real URL builder. Demonstrates that a
+//    reload mounts 8 embedded session-chat iframes (all with live srcs),
+//    exactly the reported behavior.
+// ---------------------------------------------------------------------------
+
+describe('issue #2815 behavioral model (ContextPanel chat-frame render block)', () => {
+  const theme = { mode: 'system' as const, lightThemeId: 'light', darkThemeId: 'dark', currentTheme: makeTheme('dark') };
+
+  beforeEach(() => {
+    installIssueScenario();
+  });
+
+  // Mirror of the production block in ContextPanel.tsx lines 2937-2971:
+  //   chatTabs.map -> sessionID from dedupeKey -> src -> <iframe src ...>
+  //   className: activeChatTabID === tab.id ? 'block' : 'hidden'
+  const renderChatFramesModel = (tabs: FixtureContextPanelTab[], activeChatTabID: string | null) => {
+    const frames: Array<{ tabID: string; sessionID: string; src: string; visibility: 'block' | 'hidden' }> = [];
+    const chatTabs = tabs.filter((tab) => tab.mode === 'chat');
+    for (const tab of chatTabs) {
+      const sessionID = getSessionIDFromDedupeKey(tab.dedupeKey);
+      if (!sessionID) continue;
+      const src = buildEmbeddedSessionChatURL(sessionID, DIRECTORY, tab.readOnly, theme);
+      if (!src) continue;
+      frames.push({
+        tabID: tab.id,
+        sessionID,
+        src,
+        visibility: activeChatTabID === tab.id ? 'block' : 'hidden',
+      });
+    }
+    return frames;
+  };
+
+  test('mounts one embedded session-chat iframe per persisted chat tab (8 frames, 7 hidden)', () => {
+    const tabs = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.tabs ?? [];
+    const activeTabId = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.activeTabId ?? null;
+
+    const frames = renderChatFramesModel(tabs, activeTabId);
+
+    // All 8 persisted session-chat tabs produce a live iframe.
+    expect(frames).toHaveLength(8);
+    expect(new Set(frames.map((f) => f.sessionID))).toEqual(
+      new Set(sessionChatTabs.map((tab) => getSessionIDFromDedupeKey(tab.dedupeKey))),
+    );
+
+    // Only the active tab is visible; the other 7 are mounted-but-hidden.
+    expect(frames.filter((f) => f.visibility === 'block')).toHaveLength(1);
+    expect(frames.filter((f) => f.visibility === 'hidden')).toHaveLength(7);
+
+    // Every iframe carries the full embedded-app URL the browser will load —
+    // exactly the URL shape captured in the report.
+    for (const frame of frames) {
+      const url = new URL(frame.src);
+      expect(url.searchParams.get('ocPanel')).toBe('session-chat');
+      expect(url.searchParams.get('surface')).toBe('desktop');
+      expect(url.searchParams.get('sessionId')).toBe(frame.sessionID);
+      expect(url.searchParams.get('directory')).toBe(DIRECTORY);
+      expect(url.searchParams.get('readOnly')).toBe('1');
+    }
+  });
+
+  test('reload semantics: every persisted session-chat tab is mounted, hidden or not', () => {
+    // Simulated reload: state is restored as-is from the persisted store
+    // (sanitizeContextPanelByDirectory keeps all tabs), then the panel renders.
+    const tabs = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.tabs ?? [];
+    const frames = renderChatFramesModel(tabs, 'chat:session:ses_1');
+
+    const hiddenButMounted = frames.filter((f) => f.visibility === 'hidden');
+    expect(hiddenButMounted.map((f) => f.src).every((src) => src.length > 0)).toBe(true);
+
+    // A display:none iframe with a src is still loaded by the browser: this is
+    // the exact mechanism behind the report's "8 embedded URLs, 9 app
+    // instances, ~1 GB renderer RSS" measurements.
+    expect(frames.length).toBe(8);
+    expect(hiddenButMounted.length).toBe(7);
+  });
+
+  test('expected behavior contrast: mounting only the active tab would leave a single iframe', () => {
+    // The issue's expected behavior: only the active session-chat tab is
+    // mounted; inactive persisted tabs must not start an embedded application.
+    // If the production render block gated mounting on the active tab (as it
+    // already does for `activeNonChatContent` and the terminal surface), the
+    // same persisted state would produce exactly one iframe.
+    const tabs = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.tabs ?? [];
+    const chatTabs = tabs.filter((tab) => tab.mode === 'chat');
+
+    const frames = renderChatFramesModel(tabs, 'chat:session:ses_1');
+    const activeOnlyFrames = frames.filter((f) => f.visibility === 'block');
+
+    // The bug: every persisted chat tab is mounted...
+    expect(frames.length).toBe(chatTabs.length);
+    // ...while the intended behavior is a single mounted frame.
+    expect(activeOnlyFrames.length).toBe(1);
+  });
+});

--- a/packages/ui/src/components/layout/__tests__/issue-2815-sessionChatIframesMountAllTabs.test.ts
+++ b/packages/ui/src/components/layout/__tests__/issue-2815-sessionChatIframesMountAllTabs.test.ts
@@ -1,30 +1,9 @@
 /**
- * Reproduction for https://github.com/openchamber/openchamber/issues/2815
+ * Regression coverage for https://github.com/openchamber/openchamber/issues/2815
  *
- * [Bug] OpenChamber mounts all persisted session-chat iframes and freezes the
- * browser.
- *
- * Root cause under test: `ContextPanel` renders one full-application `<iframe>`
- * for EVERY chat tab in the context panel — including inactive tabs. Inactive
- * frames are only hidden with the Tailwind `hidden` class (`display: none`),
- * but a `display:none` iframe that carries a `src` is still navigated and
- * executed by the browser. After a reload, `useUIStore` restores every
- * persisted tab (via `sanitizeContextPanelByDirectory`), so N persisted
- * session-chat tabs become N embedded OpenChamber applications in a single
- * browser tab (the reported ~1 GB renderer freeze).
- *
- * We cannot mount the full `ContextPanel` in `bun test` (its import graph pulls
- * in a Vite `?worker&url` asset that Bun cannot resolve), so, following the
- * repo's existing regression-guard precedent (e.g.
- * `contextPanelEscapeClosesTerminal.test.ts`), this test:
- *   1. reads the real `ContextPanel.tsx` and asserts on the exact chat-frame
- *      render block that is responsible,
- *   2. drives the real `useUIStore` with the issue's persisted-tab scenario
- *      (8 read-only session-chat tabs + 3 other tabs = 11 tabs), and
- *   3. runs a faithful model of the extracted production render block against
- *      the store's real tab objects, using the real
- *      `buildEmbeddedSessionChatURL` helper, to show that all 8 session-chat
- *      tabs get a live `src` iframe (only 1 of them visible).
+ * A full ContextPanel mount is not available in bun test because its import
+ * graph includes a Vite worker URL. This test follows the source-level guard
+ * pattern in contextPanelEscapeClosesTerminal.test.ts and uses the real store.
  */
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
@@ -32,54 +11,34 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { getDefaultTheme } from '@/lib/theme/themes';
-import type { Theme } from '@/types/theme';
-import { buildEmbeddedSessionChatURL, resetEmbeddedSessionChatCache } from '../contextPanelEmbeddedChat';
 import { useUIStore } from '@/stores/useUIStore';
+import {
+  buildEmbeddedSessionChatURL,
+  getActiveEmbeddedSessionChatTab,
+  resetEmbeddedSessionChatCache,
+} from '../contextPanelEmbeddedChat';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const contextPanelSource = readFileSync(join(__dirname, '..', 'ContextPanel.tsx'), 'utf-8');
-const uiStoreSource = readFileSync(join(__dirname, '..', '..', '..', 'stores', 'useUIStore.ts'), 'utf-8');
 
-// ---------------------------------------------------------------------------
-// Local structural copies of the (unexported) tab/directory state types in
-// useUIStore.ts so the fixture matches the real store shape exactly.
-// ---------------------------------------------------------------------------
-
-type FixtureContextPanelMode =
-  | 'chat' | 'file' | 'context' | 'git' | 'diff' | 'plan' | 'preview'
-  | 'browser' | 'pr' | 'notes' | 'terminal' | 'walkthrough';
-
-type FixtureContextPanelTab = {
+type FixtureTab = {
   id: string;
-  mode: FixtureContextPanelMode;
+  mode: 'chat' | 'git' | 'diff' | 'plan';
   targetPath: string | null;
   dedupeKey: string;
   label: string | null;
   sessionTitleFallback: string | null;
   readOnly: boolean;
   stagedDiff: boolean;
-  diffScope: string | null;
+  diffScope: 'working';
   touchedAt: number;
 };
 
-type FixtureContextPanelDirectoryState = {
-  isOpen: boolean;
-  expanded: boolean;
-  tabs: FixtureContextPanelTab[];
-  activeTabId: string | null;
-  widthByMode: Partial<Record<FixtureContextPanelMode, number>>;
-  touchedAt: number;
-};
-
-// ---------------------------------------------------------------------------
-// Window stub so the real `buildEmbeddedSessionChatURL` can construct the
-// embedded-frame URL (same approach as contextPanelEmbeddedChat.test.ts).
-// ---------------------------------------------------------------------------
-
+const DIRECTORY = '/path/to/repository';
 const originalWindow = globalThis.window;
 
-const installWindowLocation = (href = 'http://127.0.0.1:3000/') => {
-  const url = new URL(href);
+const installWindowLocation = () => {
+  const url = new URL('http://127.0.0.1:3000/');
   Object.defineProperty(globalThis, 'window', {
     configurable: true,
     value: {
@@ -93,12 +52,47 @@ const installWindowLocation = (href = 'http://127.0.0.1:3000/') => {
   });
 };
 
-const makeTheme = (variant: 'light' | 'dark'): Theme => getDefaultTheme(variant === 'dark');
+const buildTab = (mode: FixtureTab['mode'], id: string): FixtureTab => ({
+  id: mode === 'chat' ? `chat:session:${id}` : id,
+  mode,
+  targetPath: null,
+  dedupeKey: mode === 'chat' ? `session:${id}` : id,
+  label: mode === 'chat' ? `Session ${id}` : null,
+  sessionTitleFallback: null,
+  readOnly: mode === 'chat',
+  stagedDiff: false,
+  diffScope: 'working',
+  touchedAt: Date.now(),
+});
+
+const sessionChatTabs = Array.from({ length: 8 }, (_, index) => buildTab('chat', `ses_${index + 1}`));
+const issueScenarioTabs = [
+  ...sessionChatTabs,
+  buildTab('git', 'git'),
+  buildTab('diff', 'diff'),
+  buildTab('plan', 'plan'),
+];
+
+const installIssueScenario = () => {
+  useUIStore.setState({
+    contextPanelByDirectory: {
+      [DIRECTORY]: {
+        isOpen: true,
+        expanded: false,
+        tabs: issueScenarioTabs,
+        activeTabId: sessionChatTabs[0].id,
+        widthByMode: {},
+        touchedAt: Date.now(),
+      },
+    } as never,
+  });
+};
 
 beforeEach(() => {
   installWindowLocation();
   resetEmbeddedSessionChatCache();
   useUIStore.setState({ contextPanelByDirectory: {}, contextRailOrder: [] });
+  installIssueScenario();
 });
 
 afterAll(() => {
@@ -108,278 +102,62 @@ afterAll(() => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Faithful copy of the module-private helper from ContextPanel.tsx (lines
-// 426-433). Kept structurally identical so the model behaves exactly like the
-// production renderer.
-// ---------------------------------------------------------------------------
-
-const getSessionIDFromDedupeKey = (dedupeKey: string | undefined): string | null => {
-  if (!dedupeKey || !dedupeKey.startsWith('session:')) {
-    return null;
-  }
-  const sessionID = dedupeKey.slice('session:'.length).trim();
-  return sessionID || null;
-};
-
-// ---------------------------------------------------------------------------
-// The issue's persisted scenario: the active directory has 11 context-panel
-// tabs, 8 of which are read-only session-chat tabs (plan/subagent sessions).
-// Tab ids/dedupeKeys follow `createContextPanelTab` conventions
-// (`chat:session:ses_…`).
-// ---------------------------------------------------------------------------
-
-const DIRECTORY = '/path/to/repository';
-
-const buildChatTab = (sessionID: string, readOnly: boolean): FixtureContextPanelTab => ({
-  id: `chat:session:${sessionID}`,
-  mode: 'chat',
-  targetPath: null,
-  dedupeKey: `session:${sessionID}`,
-  label: `Session ${sessionID}`,
-  sessionTitleFallback: null,
-  readOnly,
-  stagedDiff: false,
-  diffScope: 'working',
-  touchedAt: Date.now(),
-});
-
-const buildNonChatTab = (mode: FixtureContextPanelMode, dedupeKey: string): FixtureContextPanelTab => ({
-  id: dedupeKey,
-  mode,
-  targetPath: null,
-  dedupeKey,
-  label: null,
-  sessionTitleFallback: null,
-  readOnly: false,
-  stagedDiff: false,
-  diffScope: 'working',
-  touchedAt: Date.now(),
-});
-
-// 8 read-only session-chat tabs (plan/subagent sessions), as persisted.
-const sessionChatTabs = Array.from({ length: 8 }, (_, index) => (
-  buildChatTab(`ses_${index + 1}`, true)
-));
-
-// The remaining 3 tabs of the active directory (matches the report: 11 total).
-const otherTabs: FixtureContextPanelTab[] = [
-  buildNonChatTab('git', 'git'),
-  buildNonChatTab('diff', 'diff'),
-  buildNonChatTab('plan', 'plan'),
-];
-
-const issueScenarioTabs = [...sessionChatTabs, ...otherTabs];
-
-// Installs the issue's persisted-tab scenario into the real ui-store, exactly
-// as it would look after a reload restored `contextPanelByDirectory`.
-const installIssueScenario = () => {
-  useUIStore.setState({
-    contextPanelByDirectory: {
-      [DIRECTORY]: {
-        isOpen: true,
-        expanded: false,
-        tabs: issueScenarioTabs,
-        activeTabId: 'chat:session:ses_1',
-        widthByMode: {},
-        touchedAt: Date.now(),
-      } as FixtureContextPanelDirectoryState,
-    } as never,
+describe('issue #2815 active-only chat iframe source guard', () => {
+  test('does not map persisted chat tabs to iframe elements', () => {
+    expect(contextPanelSource).not.toContain('{chatTabs.map((tab) => {');
   });
-};
 
-// ---------------------------------------------------------------------------
-// 1. Source evidence: the production render block mounts one iframe per chat
-//    tab and only toggles visibility with the `hidden` CSS class.
-// ---------------------------------------------------------------------------
-
-describe('issue #2815 source evidence (ContextPanel.tsx)', () => {
-  const extractChatFrameBlock = (): string => {
-    const startMarker = '{chatTabs.map((tab) => {';
-    const start = contextPanelSource.indexOf(startMarker);
+  test('renders the iframe only when an active chat has a session and URL', () => {
+    const start = contextPanelSource.indexOf('{activeChatTab && activeChatSessionID && activeChatSrc ? (');
     expect(start).toBeGreaterThan(-1);
-    // The iframe is self-closing (`/>`), so anchor on the onLoad body that
-    // precedes the block's closing `);` / `})}` — an earlier `})}` appears
-    // inside the `title={t('...', { sessionID })}` expression.
-    const onLoadBody = contextPanelSource.indexOf('postEmbeddedVisibilityToChats();', start);
-    expect(onLoadBody).toBeGreaterThan(start);
-    const end = contextPanelSource.indexOf('})}', onLoadBody);
-    expect(end).toBeGreaterThan(onLoadBody);
-    return contextPanelSource.slice(start, end + 3);
-  };
+    const end = contextPanelSource.indexOf(') : null}', start);
+    expect(end).toBeGreaterThan(start);
+    const block = contextPanelSource.slice(start, end);
 
-  test('chat frames are rendered by mapping over ALL chat tabs', () => {
-    const block = extractChatFrameBlock();
-    expect(block.includes('{chatTabs.map((tab) => {')).toBe(true);
-  });
-
-  test('every chat tab unconditionally gets an <iframe> with a live src', () => {
-    const block = extractChatFrameBlock();
-    // The iframe is created for every tab that has a sessionID; visibility is
-    // NOT a condition for mounting the iframe or setting its src.
-    expect(block.includes('<iframe')).toBe(true);
-    expect(block.includes('src={src}')).toBe(true);
-    // No active-tab guard in front of the iframe element itself.
-    expect(/activeChatTabID === tab\.id\s*&&/.test(block)).toBe(false);
-  });
-
-  test('inactive chat tabs are only hidden via the CSS `hidden` class', () => {
-    const block = extractChatFrameBlock();
-    // The ONLY active-tab distinction in the block is the visibility class.
-    expect(block.includes("activeChatTabID === tab.id ? 'block' : 'hidden'")).toBe(true);
-    // `hidden` maps to display:none; the iframe element and its src remain in
-    // the DOM, so the browser still loads and executes the embedded app.
-    const visibilitySwitchCount = block.match(/'block' : 'hidden'/g)?.length ?? 0;
-    expect(visibilitySwitchCount).toBe(1);
-  });
-
-  test('inactive session-chat tabs are never conditionally unmounted', () => {
-    const block = extractChatFrameBlock();
-    // There is no `return null`/skip for inactive tabs: only tabs without a
-    // sessionID or a usable src are skipped, never inactive ones.
-    expect(/if\s*\(.*activeChatTabID.*\)\s*return null/.test(block)).toBe(false);
-    expect(block.includes('if (!sessionID)')).toBe(true);
-    expect(block.includes('if (!src)')).toBe(true);
+    expect(block).toContain('<iframe');
+    expect(block).toContain('key={activeChatTab.id}');
+    expect(block).toContain('src={activeChatSrc}');
+    expect(block).not.toContain("'block' : 'hidden'");
   });
 });
 
-describe('issue #2815 source evidence (useUIStore.ts reload path)', () => {
-  test('sanitizeContextPanelByDirectory restores every persisted tab, not just the active one', () => {
-    // After a reload the persisted `tabs` array is restored in full; only the
-    // `activeTabId` selects one of them. There is no filtering of inactive
-    // session-chat tabs during hydration.
-    const sanitizeStart = uiStoreSource.indexOf('const sanitizeContextPanelByDirectory = (');
-    expect(sanitizeStart).toBeGreaterThan(-1);
-    // The full persisted `tabs` array is restored; only the active tab id is
-    // resolved separately. There is no filtering of inactive session-chat
-    // tabs during hydration.
-    expect(/\blet tabs = sanitizeContextPanelTabs\(candidate\.tabs\);/.test(uiStoreSource)).toBe(true);
-    expect(/let activeTabId = typeof candidate\.activeTabId === 'string' \? candidate\.activeTabId : null/.test(uiStoreSource)).toBe(true);
-    // It preserves the readOnly flag of persisted chat tabs.
-    expect(/readOnly: candidate\.readOnly === true/.test(uiStoreSource)).toBe(true);
-  });
-});
+describe('issue #2815 persisted scenario', () => {
+  test('keeps all tab records but selects one chat for mounting', () => {
+    const panel = useUIStore.getState().contextPanelByDirectory[DIRECTORY];
+    const chatTabs = panel.tabs.filter((tab) => tab.mode === 'chat');
+    const activeTab = getActiveEmbeddedSessionChatTab(chatTabs, panel.activeTabId);
 
-// ---------------------------------------------------------------------------
-// 2. Real store: the issue's persisted scenario is present after "reload".
-// ---------------------------------------------------------------------------
-
-describe('issue #2815 persisted scenario in the real ui-store', () => {
-  beforeEach(() => {
-    installIssueScenario();
+    expect(panel.tabs).toHaveLength(11);
+    expect(chatTabs).toHaveLength(8);
+    expect(activeTab?.id).toBe(sessionChatTabs[0].id);
   });
 
-  test('all 8 persisted session-chat tabs survive hydration', () => {
-    const tabs = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.tabs ?? [];
-    expect(tabs).toHaveLength(11);
-    const readOnlyChat = tabs.filter((tab) => tab.mode === 'chat' && tab.readOnly);
-    expect(readOnlyChat).toHaveLength(8);
+  test('produces one live embedded URL for eight persisted chats', () => {
+    const panel = useUIStore.getState().contextPanelByDirectory[DIRECTORY];
+    const chatTabs = panel.tabs.filter((tab) => tab.mode === 'chat');
+    const activeTab = getActiveEmbeddedSessionChatTab(chatTabs, panel.activeTabId);
+    const frames = activeTab ? [buildEmbeddedSessionChatURL('ses_1', DIRECTORY, activeTab.readOnly, {
+      mode: 'system',
+      lightThemeId: 'light',
+      darkThemeId: 'dark',
+      currentTheme: getDefaultTheme(true),
+    })] : [];
+
+    expect(frames).toHaveLength(1);
+    const url = new URL(frames[0]);
+    expect(url.searchParams.get('ocPanel')).toBe('session-chat');
+    expect(url.searchParams.get('sessionId')).toBe('ses_1');
+    expect(url.searchParams.get('readOnly')).toBe('1');
   });
 
-  test('exactly one tab is active while the other 7 session-chat tabs stay inactive', () => {
-    const state = useUIStore.getState().contextPanelByDirectory[DIRECTORY];
-    expect(state?.activeTabId).toBe('chat:session:ses_1');
-    const inactiveChatTabs = state?.tabs.filter(
-      (tab) => tab.mode === 'chat' && tab.readOnly && tab.id !== state?.activeTabId,
-    );
-    expect(inactiveChatTabs).toHaveLength(7);
-  });
-});
+  test('selects another single chat after a tab switch', () => {
+    useUIStore.getState().setActiveContextPanelTab(DIRECTORY, sessionChatTabs[6].id);
 
-// ---------------------------------------------------------------------------
-// 3. Faithful model of the extracted production render block, run over the
-//    real store's tab objects with the real URL builder. Demonstrates that a
-//    reload mounts 8 embedded session-chat iframes (all with live srcs),
-//    exactly the reported behavior.
-// ---------------------------------------------------------------------------
+    const panel = useUIStore.getState().contextPanelByDirectory[DIRECTORY];
+    const chatTabs = panel.tabs.filter((tab) => tab.mode === 'chat');
+    const activeTab = getActiveEmbeddedSessionChatTab(chatTabs, panel.activeTabId);
 
-describe('issue #2815 behavioral model (ContextPanel chat-frame render block)', () => {
-  const theme = { mode: 'system' as const, lightThemeId: 'light', darkThemeId: 'dark', currentTheme: makeTheme('dark') };
-
-  beforeEach(() => {
-    installIssueScenario();
-  });
-
-  // Mirror of the production block in ContextPanel.tsx lines 2937-2971:
-  //   chatTabs.map -> sessionID from dedupeKey -> src -> <iframe src ...>
-  //   className: activeChatTabID === tab.id ? 'block' : 'hidden'
-  const renderChatFramesModel = (tabs: FixtureContextPanelTab[], activeChatTabID: string | null) => {
-    const frames: Array<{ tabID: string; sessionID: string; src: string; visibility: 'block' | 'hidden' }> = [];
-    const chatTabs = tabs.filter((tab) => tab.mode === 'chat');
-    for (const tab of chatTabs) {
-      const sessionID = getSessionIDFromDedupeKey(tab.dedupeKey);
-      if (!sessionID) continue;
-      const src = buildEmbeddedSessionChatURL(sessionID, DIRECTORY, tab.readOnly, theme);
-      if (!src) continue;
-      frames.push({
-        tabID: tab.id,
-        sessionID,
-        src,
-        visibility: activeChatTabID === tab.id ? 'block' : 'hidden',
-      });
-    }
-    return frames;
-  };
-
-  test('mounts one embedded session-chat iframe per persisted chat tab (8 frames, 7 hidden)', () => {
-    const tabs = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.tabs ?? [];
-    const activeTabId = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.activeTabId ?? null;
-
-    const frames = renderChatFramesModel(tabs, activeTabId);
-
-    // All 8 persisted session-chat tabs produce a live iframe.
-    expect(frames).toHaveLength(8);
-    expect(new Set(frames.map((f) => f.sessionID))).toEqual(
-      new Set(sessionChatTabs.map((tab) => getSessionIDFromDedupeKey(tab.dedupeKey))),
-    );
-
-    // Only the active tab is visible; the other 7 are mounted-but-hidden.
-    expect(frames.filter((f) => f.visibility === 'block')).toHaveLength(1);
-    expect(frames.filter((f) => f.visibility === 'hidden')).toHaveLength(7);
-
-    // Every iframe carries the full embedded-app URL the browser will load —
-    // exactly the URL shape captured in the report.
-    for (const frame of frames) {
-      const url = new URL(frame.src);
-      expect(url.searchParams.get('ocPanel')).toBe('session-chat');
-      expect(url.searchParams.get('surface')).toBe('desktop');
-      expect(url.searchParams.get('sessionId')).toBe(frame.sessionID);
-      expect(url.searchParams.get('directory')).toBe(DIRECTORY);
-      expect(url.searchParams.get('readOnly')).toBe('1');
-    }
-  });
-
-  test('reload semantics: every persisted session-chat tab is mounted, hidden or not', () => {
-    // Simulated reload: state is restored as-is from the persisted store
-    // (sanitizeContextPanelByDirectory keeps all tabs), then the panel renders.
-    const tabs = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.tabs ?? [];
-    const frames = renderChatFramesModel(tabs, 'chat:session:ses_1');
-
-    const hiddenButMounted = frames.filter((f) => f.visibility === 'hidden');
-    expect(hiddenButMounted.map((f) => f.src).every((src) => src.length > 0)).toBe(true);
-
-    // A display:none iframe with a src is still loaded by the browser: this is
-    // the exact mechanism behind the report's "8 embedded URLs, 9 app
-    // instances, ~1 GB renderer RSS" measurements.
-    expect(frames.length).toBe(8);
-    expect(hiddenButMounted.length).toBe(7);
-  });
-
-  test('expected behavior contrast: mounting only the active tab would leave a single iframe', () => {
-    // The issue's expected behavior: only the active session-chat tab is
-    // mounted; inactive persisted tabs must not start an embedded application.
-    // If the production render block gated mounting on the active tab (as it
-    // already does for `activeNonChatContent` and the terminal surface), the
-    // same persisted state would produce exactly one iframe.
-    const tabs = useUIStore.getState().contextPanelByDirectory[DIRECTORY]?.tabs ?? [];
-    const chatTabs = tabs.filter((tab) => tab.mode === 'chat');
-
-    const frames = renderChatFramesModel(tabs, 'chat:session:ses_1');
-    const activeOnlyFrames = frames.filter((f) => f.visibility === 'block');
-
-    // The bug: every persisted chat tab is mounted...
-    expect(frames.length).toBe(chatTabs.length);
-    // ...while the intended behavior is a single mounted frame.
-    expect(activeOnlyFrames.length).toBe(1);
+    expect(activeTab?.id).toBe(sessionChatTabs[6].id);
+    expect(chatTabs.filter((tab) => tab.id === activeTab?.id)).toHaveLength(1);
   });
 });

--- a/packages/ui/src/components/layout/__tests__/issue-2815-sessionChatIframesMountAllTabs.test.ts
+++ b/packages/ui/src/components/layout/__tests__/issue-2815-sessionChatIframesMountAllTabs.test.ts
@@ -119,6 +119,15 @@ describe('issue #2815 active-only chat iframe source guard', () => {
     expect(block).toContain('src={activeChatSrc}');
     expect(block).not.toContain("'block' : 'hidden'");
   });
+
+  test('does not select a chat iframe when the context panel is closed', () => {
+    expect(contextPanelSource).toContain(
+      "const activeChatTabID = isOpen && activeTab?.mode === 'chat' ? activeTab.id : null;",
+    );
+    expect(contextPanelSource).toContain(
+      "const activeChatSessionID = isOpen && activeTab?.mode === 'chat'",
+    );
+  });
 });
 
 describe('issue #2815 persisted scenario', () => {
@@ -159,5 +168,16 @@ describe('issue #2815 persisted scenario', () => {
 
     expect(activeTab?.id).toBe(sessionChatTabs[6].id);
     expect(chatTabs.filter((tab) => tab.id === activeTab?.id)).toHaveLength(1);
+  });
+
+  test('selects no chat after the panel closes', () => {
+    useUIStore.getState().closeContextPanel(DIRECTORY);
+
+    const panel = useUIStore.getState().contextPanelByDirectory[DIRECTORY];
+    const chatTabs = panel.tabs.filter((tab) => tab.mode === 'chat');
+    const activeTabID = panel.isOpen ? panel.activeTabId : null;
+
+    expect(panel.isOpen).toBe(false);
+    expect(getActiveEmbeddedSessionChatTab(chatTabs, activeTabID)).toBeNull();
   });
 });

--- a/packages/ui/src/components/layout/contextPanelEmbeddedChat.test.ts
+++ b/packages/ui/src/components/layout/contextPanelEmbeddedChat.test.ts
@@ -6,6 +6,7 @@ import {
   EMBEDDED_RUNTIME_BOOTSTRAP_REQUEST,
   EMBEDDED_RUNTIME_BOOTSTRAP_RESPONSE,
   getOrCreateEmbeddedSessionChatURL,
+  getActiveEmbeddedSessionChatTab,
   getEmbeddedSessionChatOriginSessionId,
   isEmbeddedSessionChat,
   requestEmbeddedSessionRuntimeBootstrap,
@@ -142,6 +143,22 @@ describe('embedded session chat URL', () => {
     expect(readOnly).not.toBe(writable);
     expect(new URL(writable).searchParams.get('readOnly')).toBeNull();
     expect(new URL(readOnly).searchParams.get('readOnly')).toBe('1');
+  });
+});
+
+describe('active embedded session chat', () => {
+  const tabs = Array.from({ length: 8 }, (_, index) => ({
+    id: `chat-${index + 1}`,
+    sessionID: `ses_${index + 1}`,
+  }));
+
+  test('selects one tab from persisted chat tabs', () => {
+    expect(getActiveEmbeddedSessionChatTab(tabs, 'chat-5')).toEqual(tabs[4]);
+  });
+
+  test('selects no tab when a chat is not active', () => {
+    expect(getActiveEmbeddedSessionChatTab(tabs, null)).toBeNull();
+    expect(getActiveEmbeddedSessionChatTab(tabs, 'missing-chat')).toBeNull();
   });
 });
 

--- a/packages/ui/src/components/layout/contextPanelEmbeddedChat.ts
+++ b/packages/ui/src/components/layout/contextPanelEmbeddedChat.ts
@@ -158,6 +158,17 @@ export const getOrCreateEmbeddedSessionChatURL = (
   return src;
 };
 
+export const getActiveEmbeddedSessionChatTab = <T extends { id: string }>(
+  tabs: T[],
+  activeTabID: string | null,
+): T | null => {
+  if (!activeTabID) {
+    return null;
+  }
+
+  return tabs.find((tab) => tab.id === activeTabID) ?? null;
+};
+
 /**
  * True when the current document is the embedded session-chat iframe
  * (`?ocPanel=session-chat`). Used to distinguish the embedded iframe from

--- a/packages/ui/src/lib/surfaces/DOCUMENTATION.md
+++ b/packages/ui/src/lib/surfaces/DOCUMENTATION.md
@@ -48,7 +48,8 @@ the `openContext*` actions in `useUIStore`.
   terminal) are keep-alive panes in `ContextPanel.tsx`. Switching these
   surfaces must not reset their state (open tabs, xterm session, scroll
   positions). Chat tab records stay open, but only the active chat iframe is
-  mounted. A selected chat restores its state from the session stores.
+  mounted while the panel is open. A selected chat restores its state from
+  the session stores. A closed panel mounts no chat iframe.
   Singleton surfaces (git, pr, notes, plan, context) and preview tabs remount
   on switch. These surfaces must restore their state from stores or snapshots.
 - Runtime scope: desktop/web `MainLayout` only. VS Code and the dedicated

--- a/packages/ui/src/lib/surfaces/DOCUMENTATION.md
+++ b/packages/ui/src/lib/surfaces/DOCUMENTATION.md
@@ -44,11 +44,12 @@ the `openContext*` actions in `useUIStore`.
 
 - Opening a surface must never require a control outside the rail, the
   command palette, or an in-content link.
-- Multi-instance and session-holding surfaces (file/editor, chat, diff,
-  browser, terminal) are keep-alive panes in `ContextPanel.tsx`: switching
+- Multi-instance and session-holding surfaces (file/editor, diff, browser,
+  terminal) are keep-alive panes in `ContextPanel.tsx`. Switching these
   surfaces must not reset their state (open tabs, xterm session, scroll
-  positions). Singleton surfaces (git, pr, notes, plan, context) and preview
-  tabs intentionally remount on switch and must restore themselves from
-  their stores/snapshots instead.
+  positions). Chat tab records stay open, but only the active chat iframe is
+  mounted. A selected chat restores its state from the session stores.
+  Singleton surfaces (git, pr, notes, plan, context) and preview tabs remount
+  on switch. These surfaces must restore their state from stores or snapshots.
 - Runtime scope: desktop/web `MainLayout` only. VS Code and the dedicated
   mobile shell have their own layouts and do not consume this registry.


### PR DESCRIPTION
## Intent

Fixes #2815.

OpenChamber mounted one full application iframe for each stored session-chat tab. Inactive chats repeated application startup and session work.

This change mounts only the selected chat iframe while the panel is open. A closed panel mounts no chat iframe. Stored tab records remain available, and selecting another tab mounts its session.

## Non-goals

This PR does not change session storage, tab limits, tab order, or close behavior. It does not change other context-panel surfaces.

## Affected surfaces

The desktop and web `MainLayout` context panel use this iframe path. The VS Code layout and mobile shell do not use it.

Persisted chat-tab records remain unchanged. The selected chat restores its state after its iframe mounts.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` and `CONTRIBUTING.md` | This is a UI behavior and performance change. | The change is small, has focused tests, updates documentation, and uses no new dependency. |
| `openchamber-change-discipline` | The change affects a shared context-panel component. | The diff changes only iframe selection, tests, and the owning invariant. |
| `performance-engineering` and `scripts/perf/DOCUMENTATION.md` | The fault multiplies full application work by the stored chat count. | Production CDP captures used the same navigation path before and after the change. |
| `theme-system` | Embedded chats receive theme data during startup and through messages. | The existing URL cache and theme-sync messages remain unchanged. |
| `sync-state-invariants` and the store documentation | Chat tabs and session data are persisted state. | The change does not remove tab records or session data. |
| `lib/surfaces/DOCUMENTATION.md` | The file defined chat as a keep-alive pane. | The document now defines active-only iframe mounting and store-based restoration. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/layout/__tests__/issue-2815-sessionChatIframesMountAllTabs.test.ts packages/ui/src/components/layout/contextPanelEmbeddedChat.test.ts packages/ui/src/stores/useUIStore.contextPanel.test.ts` | Passed, 34 tests and 89 assertions. The test adapts the reproduction from `3c02171f7`. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bun run build:ui` | Passed. |
| `bun run build:web` | Passed. Vite reported existing font and chunk-size warnings. |
| `npx --yes knip@5.80.0 --no-exit-code --include files,exports,nsExports,types,nsTypes,enumMembers,duplicates` | Completed with exit code 0. It reported existing repository findings and did not flag the new helper. |
| `git diff --check` | Passed. |
| Patched production app in normal Brave | Eight stored chat tabs produced one iframe. Selecting another chat kept one iframe and changed the session ID. A closed panel produced zero iframes. |
| Clean Chrome and Brave multi-tab checks | Two extension-free tabs stayed responsive after a simultaneous reload. Both tabs produced zero iframes. |
| Normal Brave same-session new-tab check | Four fresh tabs opened the same existing session. Each rendered the session and stayed responsive with zero iframes. Three measured runs completed in about 3.5 seconds each. |

### Controlled normal-Brave A/B test

The same normal Brave profile, local storage, two URLs, reload timing, and five-second CDP timeout were used for both builds. Only service-worker and browser caches were cleared when the server build changed.

| Build | State before reload | Root tab after reload | Session tab after reload |
|---|---|---|---|
| Before closed-panel guard (`baef20a04`, `main-DNYodfhn.js`) | Closed panels; one iframe in each top-level tab | Unresponsive; CDP timed out after 5,006 ms | Unresponsive; CDP timed out after 5,005 ms |
| After closed-panel guard (`f8088db64`, `main-Z9Lb0fXA.js`) | Closed panels; zero iframes | Responsive; complete; 2 ms | Responsive; complete; 2 ms |

The patched build then passed five more simultaneous-reload cycles. Both tabs remained complete, mounted zero iframes, and answered CDP probes in 1-21 ms.

The patched build also passed the reported same-session path. Four fresh normal-Brave tabs opened the session already visible in another tab. Each rendered the session, stayed responsive, and mounted zero iframes. Three controlled runs completed in 3.5 seconds each.

The earlier production capture used eight stored chat tabs:

| Metric after 18 seconds | Before | After |
|---|---:|---:|
| Network requests | 1,229 | 447 |
| Network responses | 939 | 444 |
| OpenChamber application instances | 9 | 2 |
| Mounted session-chat iframes | 8 | 1 |
| DOM nodes | 141,815 | 48,583 |
| Event listeners | 3,917 | 2,542 |
| Used JavaScript heap | 167 MB | 118 MB |
| Embedder heap | 129 MB | 94 MB |
| Backing storage | 26 MB | 25 MB |

## Visual evidence

The rendered chat and tab strip do not change. Screenshots cannot show the iframe lifecycle change.

CDP measurements show the application-instance count, iframe count, renderer response, and selected session ID.

## Risks and failure behavior

The selected chat iframe unmounts when the user selects another chat, selects a non-chat context surface, or closes the context panel. Returning to the chat remounts it. Iframe-only state, such as exact scroll position or in-iframe subtask navigation, can reset.

The session stores restore messages, composer drafts, and queued messages. The URL cache still prevents theme changes from changing an iframe URL. This change does not delete tabs, sessions, or user data.

The automated lifecycle coverage is indirect because importing the complete `ContextPanel` in Bun pulls a Vite `?worker&url` asset that Bun cannot resolve. The regression uses a tight source guard plus real helper and store assertions. The production CDP tests cover iframe creation, switching, panel closure, and repeated multi-tab reloads.

Reverting the commit restores the previous keep-alive behavior.
