### PR TITLE
fix(ui): always show /init command in autocomplete

### DIFF
--- a/packages/ui/src/components/chat/CommandAutocomplete.tsx
+++ b/packages/ui/src/components/chat/CommandAutocomplete.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { cn, fuzzyMatch } from '@/lib/utils';
 import { useSessionUIStore } from '@/sync/session-ui-store';
-import { useSessionMessages } from '@/sync/sync-context';
 import { useCommandsStore } from '@/stores/useCommandsStore';
 import { useSkillsStore } from '@/stores/useSkillsStore';
 import { ScrollableOverlay } from '@/components/ui/ScrollableOverlay';
@@ -65,8 +64,6 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
 }, ref) => {
   const { t } = useI18n();
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
-  const sessionMessages = useSessionMessages(currentSessionId ?? '');
-  const hasMessagesInCurrentSession = sessionMessages.length > 0;
   const hasSession = Boolean(currentSessionId);
   const hasNewSessionDraft = useSessionUIStore((state) => Boolean(state.newSessionDraft?.open));
   const canStartSessionCommand = hasSession || hasNewSessionDraft;
@@ -139,7 +136,7 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
         }));
 
         const builtInCommands: CommandInfo[] = [
-          ...(hasSession && !hasMessagesInCurrentSession
+          ...(hasSession
             ? [{ id: 'openchamber:init', name: 'init', source: 'openchamber' as const, description: t('chat.commandAutocomplete.command.initDescription'), isBuiltIn: true }]
             : []
           ),
@@ -195,10 +192,9 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
         ];
         const allCommands = mergeCommandAutocompleteItems(builtInCommands, customCommands, skillCommands);
 
-        const allowInitCommand = !hasMessagesInCurrentSession;
-        const filtered = (searchQuery
+        const filtered = searchQuery
           ? allCommands.filter(cmd => commandMatchesSearch(cmd, searchQuery))
-          : allCommands).filter(cmd => allowInitCommand || cmd.name !== 'init');
+          : allCommands;
 
         filtered.sort((a, b) => {
           const aStartsWith = a.name.toLowerCase().startsWith(searchQuery.toLowerCase());
@@ -211,9 +207,8 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
         setCommands(filtered);
       } catch {
 
-        const allowInitCommand = !hasMessagesInCurrentSession;
         const builtInCommands: CommandInfo[] = [
-          ...(hasSession && !hasMessagesInCurrentSession
+          ...(hasSession
             ? [{ id: 'openchamber:init', name: 'init', source: 'openchamber' as const, description: t('chat.commandAutocomplete.command.initDescription'), isBuiltIn: true }]
             : []
           ),
@@ -268,12 +263,12 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
           ),
         ];
 
-        const filtered = (searchQuery
+        const filtered = searchQuery
           ? builtInCommands.filter(cmd =>
               fuzzyMatch(cmd.name, searchQuery) ||
               (cmd.description && fuzzyMatch(cmd.description, searchQuery))
             )
-          : builtInCommands).filter(cmd => allowInitCommand || cmd.name !== 'init');
+          : builtInCommands;
 
         setCommands(filtered);
       } finally {
@@ -282,7 +277,7 @@ export const CommandAutocomplete = React.forwardRef<CommandAutocompleteHandle, C
     };
 
     loadCommands();
-  }, [searchQuery, hasMessagesInCurrentSession, hasSession, canStartSessionCommand, canUseReviewHandoffFlow, commandsWithMetadata, skills, t]);
+  }, [searchQuery, hasSession, canStartSessionCommand, canUseReviewHandoffFlow, commandsWithMetadata, skills, t]);
 
   React.useEffect(() => {
     setSelectedIndex(0);


### PR DESCRIPTION
## Intent

`/init` (OpenCode's guided AGENTS.md setup) was the one built-in command the slash-command autocomplete hid as soon as the current session contained any messages. It only appeared in an empty session, and a `.filter(cmd => allowInitCommand || cmd.name !== 'init')` dropped it from the list once a message existed. Users who started a conversation and then wanted to (re)run the AGENTS.md setup saw `/init` "disappear", even though typing `/init` manually still executed server-side via `session.command`.

Behavior change: the `/init` entry is now offered in the command autocomplete whenever a session exists, regardless of how many messages it contains.

## Non-goals

- Not changing *when* a session is required to run `/init` (still gated on `hasSession`, because the dispatch path `session.command` requires a session ID).
- Not changing the server-side `session.command` execution path or the `init` command template.
- Not changing the visibility of any other command (`undo`, `redo`, `timeline`, `compact`, `review`, magic prompts, skills, custom commands).
- Not adding whole-session fork or any other unrelated feature.

## Affected surfaces

- Package: `packages/ui` only. `CommandAutocomplete.tsx` is the shared composer autocomplete used by web, desktop, VS Code, and mobile, so the behavior is uniform across all four runtimes (no runtime-conditional code was touched).
- User-visible state: the rendered slash-command autocomplete list mid-session.
- Persisted/external contracts: none — no config, no API, no session/message data, no storage. `useSessionMessages` is still exported and used by other consumers; only this component's subscription was removed.
- Unaffected: runtime/server (`session.command` endpoint), CLI, Electron shell, relay transport.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` → Pull Request Handoff; `CONTRIBUTING.md` → Pull Request Contract | Every source change to `packages/ui` must complete the PR contract and template. | Body completed per `.github/PULL_REQUEST_TEMPLATE.md` with this guidance table, concrete validation results, and risk analysis. |
| `openchamber-change-discipline` | Any source change in `packages/ui`, shared across runtimes. | Minimal diff (1 file, +7/−12): removed only the gate/filter and its now-dead subscription; both the merged and fallback paths updated consistently; observable behavior preserved everywhere except the intentional `/init`-visibility change. |
| `ui-api-decoupling` | Shared UI data access via stores/hooks in a shared runtime boundary. | The change only *removes* a `useSessionMessages` read and keeps the existing store selectors; no SDK bypass, no per-runtime divergence. |
| `sync-state-invariants` | Removing a live session-message subscription from a sync-backed component. | The subscription was read-only gating for the autocomplete list; dropping it cannot strand or corrupt sync state, and removing the stale effect dependency matches the narrow-subscription rules in `packages/ui/src/sync/DOCUMENTATION.md`. |
| `performance-engineering` | Render/effect path touched (subscription + effect dependency removed). | The change strictly removes work (no more per-message effect re-runs); no performance claim is made, so no measurement is required. |
| `locale-ui-patterns` | User-facing strings. | Reuses the existing `chat.commandAutocomplete.command.initDescription` key; no strings added or changed. |

Skills considered and not applied (no matching trigger in the diff): `theme-system` (no styling/icon change), `clack-cli-patterns`, `relay-transport`, `desktop-shell`, `settings-ui-patterns`, `drag-to-reorder`, `serve-sim`.

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (`packages/ui`, `tsc --noEmit`) | Pass — no type errors after removing the unused subscription/import. |
| `eslint ./src/components/chat/CommandAutocomplete.tsx` | Pass — no warnings or errors. |
| `bun test src/components/chat/__tests__/commandAutocompleteItems.test.ts` | Pass — 9/9 tests, 16 expect() calls. These cover the pure merge/dedup helpers this PR relies on (the built-in `init` entry wins name collisions at precedence 3). |
| Live UI verification | **Not performed.** Bootstrapping a full OpenChamber runtime plus a mid-conversation session to screenshot the composer autocomplete was not feasible in the author's environment. The rendered change is a deterministic predicate removal (no branching), verified by code reasoning and the checks above rather than a live run. |

## Visual evidence

The change is a single deterministic predicate removal in the autocomplete list builder, so the rendered difference is exactly:

- **Before:** in a session with ≥1 message, typing `/` produces a list from which `init` has been filtered out (`CommandAutocomplete.tsx` → `.filter(cmd => allowInitCommand || cmd.name !== 'init')`).
- **After:** the same list includes `init` (green file icon, built-in badge) alongside `undo`/`redo`/`timeline`/`compact`, etc.

No other rendered state (icons, badges, ordering of other commands, search highlighting) is affected. A live before/after screenshot could not be captured here — it requires booting the full web runtime and a conversation that already contains messages (see Validation). Per `CONTRIBUTING.md`'s Visual Evidence policy, the meaningful before state can't be captured in this environment; the concrete reason is above, and the diff cannot affect rendering beyond the described inclusion of the `/init` entry.

## Risks and failure behavior

- **Running `/init` mid-session:** now reachable from autocomplete, but it dispatches through the same `session.command` path a manually typed `/init` already used before this change, so no new execution path or failure mode is introduced. The `init` template asks the model to set up `AGENTS.md` for the project directory; failure is identical to the pre-existing manual case (toast error, message stays in the timeline).
- **Rollback:** none needed — UI-only filter removal; reverting the diff restores prior behavior with no cleanup.
- **Data/security:** no data touched, no new surfaces, no dependencies.
- **Cross-runtime:** web/desktop/VS Code/mobile share this component; the change is runtime-agnostic.
