### PR TITLE
fix(web): support supervised remote updates

### DIFF
--- a/packages/docs/content/docs/environment.mdx
+++ b/packages/docs/content/docs/environment.mdx
@@ -45,6 +45,14 @@ Overrides the update-check API endpoint. Most users should leave this unset.
 
 Forces the package manager used by update operations when auto-detection is wrong.
 
+### `OPENCHAMBER_PACKAGE_MANAGER_COMMAND`
+
+Sets the absolute package-manager executable used with `OPENCHAMBER_PACKAGE_MANAGER`. Use this for supervised services whose runtime `PATH` can resolve a different global installation than the one that owns the running OpenChamber package.
+
+### `OPENCHAMBER_UPDATE_RESTART_ON_EXIT`
+
+Set to `true` for a foreground server whose process manager restarts it after exit. UI updates keep the current server online during installation, then exit only after success so the manager starts the new version.
+
 ## OpenCode server
 
 ### `OPENCODE_HOST`

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -272,6 +272,7 @@ type DesktopServicesMenuProps = {
   isDesktopServicesOpen: boolean;
   setIsDesktopServicesOpen: React.Dispatch<React.SetStateAction<boolean>>;
   refreshCurrentInstanceLabel: () => Promise<void>;
+  refreshRemoteUpdate: () => Promise<void>;
   shortcutLabel: (actionId: string) => string;
   remoteUpdateInfo: UpdateInfo | null;
   remoteUpdateChecking: boolean;
@@ -287,6 +288,7 @@ const DesktopServicesMenu = React.memo(function DesktopServicesMenu({
   isDesktopServicesOpen,
   setIsDesktopServicesOpen,
   refreshCurrentInstanceLabel,
+  refreshRemoteUpdate,
   shortcutLabel,
   remoteUpdateInfo,
   remoteUpdateChecking,
@@ -301,6 +303,7 @@ const DesktopServicesMenu = React.memo(function DesktopServicesMenu({
         setIsDesktopServicesOpen(open);
         if (open) {
           void refreshCurrentInstanceLabel();
+          void refreshRemoteUpdate();
         }
       }}
     >
@@ -736,6 +739,7 @@ export const Header: React.FC<HeaderProps> = ({
     }
 
     setRemoteUpdateChecking(true);
+    setRemoteUpdateInfo(null);
     setRemoteUpdateError(null);
     try {
       // Status-only poll: must not count as usage on the remote server's install id.
@@ -1876,6 +1880,7 @@ export const Header: React.FC<HeaderProps> = ({
         isDesktopServicesOpen={isDesktopServicesOpen}
         setIsDesktopServicesOpen={setIsDesktopServicesOpen}
         refreshCurrentInstanceLabel={refreshCurrentInstanceLabel}
+        refreshRemoteUpdate={checkRemoteInstanceUpdate}
         shortcutLabel={shortcutLabel}
         remoteUpdateInfo={remoteUpdateInfo}
         remoteUpdateChecking={remoteUpdateChecking}

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -116,6 +116,8 @@ OPENCODE_HOST=https://myhost:4096 OPENCODE_SKIP_START=true openchamber
 | `OPENCHAMBER_SKIP_API_COMPRESSION` | Set to `true` to disable gzip compression for `/api/*` responses |
 | `OPENCHAMBER_COMPRESS_API` | Set to `true` to force `/api/*` compression, or `false` to disable it. Desktop runtime disables API compression by default to reduce local sidecar CPU use |
 | `OPENCHAMBER_TERMINAL_SHELL` | Preferred terminal shell executable used by the `Auto` setting before platform defaults |
+| `OPENCHAMBER_PACKAGE_MANAGER_COMMAND` | Absolute package-manager executable used with `OPENCHAMBER_PACKAGE_MANAGER`. Use this for services whose runtime PATH can resolve a different global installation. |
+| `OPENCHAMBER_UPDATE_RESTART_ON_EXIT` | Set to `true` for a foreground server whose process manager restarts it after exit. UI updates keep the current server online during installation, then exit after success so the manager starts the new version. |
 
 </details>
 

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -359,6 +359,11 @@ an authoritative loopback callback URL even when OpenChamber binds port `0`.
     - Foreground servers running under a systemd user unit queue installation in
       a separate transient unit and restart the configured service afterwards.
       `OPENCHAMBER_SYSTEMD_UNIT` overrides the default `openchamber.service`.
+    - Foreground servers managed by another restart-on-exit supervisor can set
+      `OPENCHAMBER_UPDATE_RESTART_ON_EXIT=true`. The current server remains
+      online while the detached installation runs and exits only after it
+      succeeds, allowing the supervisor to start the updated package. A failed
+      installation leaves the current process running.
   - `GET /api/openchamber/models-metadata`
   - `GET /api/zen/models`
 

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -12,6 +12,13 @@ function resolveSystemdServiceUnit(environment) {
   return SYSTEMD_SERVICE_UNIT_PATTERN.test(unit) ? unit : null;
 }
 
+function shouldRestartOnUpdateExit(environment) {
+  const value = typeof environment.OPENCHAMBER_UPDATE_RESTART_ON_EXIT === 'string'
+    ? environment.OPENCHAMBER_UPDATE_RESTART_ON_EXIT.trim().toLowerCase()
+    : '';
+  return value === '1' || value === 'true';
+}
+
 function quotePosixShell(value) {
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
@@ -131,50 +138,85 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
       const systemdServiceUnit = isForegroundService ? resolveSystemdServiceUnit(process.env) : null;
 
       if (isForegroundService) {
-        if (!systemdServiceUnit) {
-          return res.status(409).json({
-            error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, or run openchamber update and restart the service.',
+        if (systemdServiceUnit) {
+          const updateJobName = `openchamber-update-${Date.now()}`;
+          const updateLogPath = `journalctl --user-unit ${updateJobName}.service`;
+          const updateScript = [
+            'set -eu',
+            updateCmd,
+            `systemctl --user restart ${quotePosixShell(systemdServiceUnit)}`,
+          ].join('\n');
+          const systemdRun = spawnSync('systemd-run', [
+            '--user',
+            `--unit=${updateJobName}`,
+            '--collect',
+            '--service-type=exec',
+            `--setenv=PATH=${process.env.PATH || ''}`,
+            '/bin/sh',
+            '-c',
+            updateScript,
+          ], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+            timeout: 5000,
+          });
+
+          if (systemdRun.status !== 0) {
+            const detail = (systemdRun.stderr || systemdRun.stdout || '').trim();
+            return res.status(409).json({
+              error: detail || `Could not queue update job for ${systemdServiceUnit}`,
+            });
+          }
+
+          return res.json({
+            success: true,
+            message: 'Update queued; OpenChamber will restart after installation completes',
+            version: updateInfo.version,
+            packageManager: pm,
+            autoRestart: true,
+            restartManager: 'systemd',
+            jobId: updateJobName,
+            logPath: updateLogPath,
           });
         }
 
-        const updateJobName = `openchamber-update-${Date.now()}`;
-        const updateLogPath = `journalctl --user-unit ${updateJobName}.service`;
-        const updateScript = [
-          'set -eu',
-          updateCmd,
-          `systemctl --user restart ${quotePosixShell(systemdServiceUnit)}`,
-        ].join('\n');
-        const systemdRun = spawnSync('systemd-run', [
-          '--user',
-          `--unit=${updateJobName}`,
-          '--collect',
-          '--service-type=exec',
-          `--setenv=PATH=${process.env.PATH || ''}`,
-          '/bin/sh',
-          '-c',
-          updateScript,
-        ], {
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'pipe'],
-          timeout: 5000,
-        });
+        if (process.platform !== 'win32' && shouldRestartOnUpdateExit(process.env)) {
+          const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
+          const updateScript = [
+            'set -eu',
+            'sleep 1',
+            updateCmd,
+            `kill -TERM ${process.pid}`,
+          ].join('\n');
+          let logFd = null;
+          try {
+            fs.mkdirSync(path.dirname(updateLogPath), { recursive: true });
+            logFd = fs.openSync(updateLogPath, 'a');
+            const child = spawnChild('/bin/sh', ['-c', updateScript], {
+              detached: true,
+              stdio: ['ignore', logFd, logFd],
+              env: process.env,
+            });
+            child.unref();
+          } finally {
+            if (logFd !== null) {
+              fs.closeSync(logFd);
+            }
+          }
 
-        if (systemdRun.status !== 0) {
-          const detail = (systemdRun.stderr || systemdRun.stdout || '').trim();
-          return res.status(409).json({
-            error: detail || `Could not queue update job for ${systemdServiceUnit}`,
+          return res.json({
+            success: true,
+            message: 'Update queued; OpenChamber will exit after installation completes',
+            version: updateInfo.version,
+            packageManager: pm,
+            autoRestart: true,
+            restartManager: 'process-manager',
+            logPath: updateLogPath,
           });
         }
 
-        return res.json({
-          success: true,
-          message: 'Update queued; OpenChamber will restart after installation completes',
-          version: updateInfo.version,
-          packageManager: pm,
-          autoRestart: true,
-          restartManager: 'systemd',
-          jobId: updateJobName,
-          logPath: updateLogPath,
+        return res.status(409).json({
+          error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, set OPENCHAMBER_UPDATE_RESTART_ON_EXIT=true for a restart-on-exit supervisor, or run openchamber update and restart the service.',
         });
       }
 

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -215,8 +215,11 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
           });
         }
 
+        const serviceManagerGuidance = process.platform === 'win32'
+          ? 'Run openchamber update and restart the service.'
+          : 'Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, set OPENCHAMBER_UPDATE_RESTART_ON_EXIT=true for a restart-on-exit supervisor, or run openchamber update and restart the service.';
         return res.status(409).json({
-          error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, set OPENCHAMBER_UPDATE_RESTART_ON_EXIT=true for a restart-on-exit supervisor, or run openchamber update and restart the service.',
+          error: `Foreground servers must be updated by their service manager. ${serviceManagerGuidance}`,
         });
       }
 

--- a/packages/web/server/lib/opencode/openchamber-routes.test.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.test.js
@@ -178,6 +178,24 @@ describe('OpenChamber foreground update route', () => {
     expect(dependencies.fs.closeSync).toHaveBeenCalledWith(17);
   });
 
+  it('does not queue a supervised update when its log cannot be opened', async () => {
+    const { app, dependencies } = createApp({
+      platform: 'darwin',
+      environment: { OPENCHAMBER_UPDATE_RESTART_ON_EXIT: 'true' },
+    });
+    dependencies.fs.openSync.mockImplementation(() => {
+      throw new Error('update log unavailable');
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await request(app)
+      .post('/api/openchamber/update-install')
+      .expect(500, { error: 'update log unavailable' });
+
+    expect(childProcess.spawn).not.toHaveBeenCalled();
+    expect(dependencies.fs.closeSync).not.toHaveBeenCalled();
+  });
+
   it('does not enable restart-on-exit updates on Windows', async () => {
     const { app } = createApp({
       platform: 'win32',
@@ -186,7 +204,9 @@ describe('OpenChamber foreground update route', () => {
 
     await request(app)
       .post('/api/openchamber/update-install')
-      .expect(409);
+      .expect(409, {
+        error: 'Foreground servers must be updated by their service manager. Run openchamber update and restart the service.',
+      });
 
     expect(childProcess.spawn).not.toHaveBeenCalled();
   });

--- a/packages/web/server/lib/opencode/openchamber-routes.test.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.test.js
@@ -18,11 +18,14 @@ const childProcess = await import('child_process');
 const packageManager = await import('../package-manager.js');
 const { registerOpenChamberRoutes } = await import('./openchamber-routes.js');
 
-const createApp = ({ environment = {}, storedOptions = {} } = {}) => {
+const createApp = ({ environment = {}, platform = 'linux', storedOptions = {} } = {}) => {
   const app = express();
   const dependencies = {
     fs: {
       existsSync: vi.fn(() => false),
+      mkdirSync: vi.fn(),
+      openSync: vi.fn(() => 17),
+      closeSync: vi.fn(),
       promises: {
         readFile: vi.fn(async () => JSON.stringify({
           launchMode: 'foreground',
@@ -34,8 +37,9 @@ const createApp = ({ environment = {}, storedOptions = {} } = {}) => {
     path,
     process: {
       env: environment,
-      platform: 'linux',
+      platform,
       execPath: '/usr/bin/node',
+      pid: 4321,
     },
     server: {
       address: () => ({ port: 7897 }),
@@ -62,6 +66,7 @@ beforeEach(() => {
     packageManager: 'npm',
   });
   packageManager.getUpdateCommand.mockReturnValue('npm install -g @openchamber/web@latest');
+  childProcess.spawn.mockReturnValue({ unref: vi.fn() });
 });
 
 afterEach(() => {
@@ -76,7 +81,7 @@ describe('OpenChamber foreground update route', () => {
     await request(app)
       .post('/api/openchamber/update-install')
       .expect(409, {
-        error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, or run openchamber update and restart the service.',
+        error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, set OPENCHAMBER_UPDATE_RESTART_ON_EXIT=true for a restart-on-exit supervisor, or run openchamber update and restart the service.',
       });
 
     expect(childProcess.spawnSync).not.toHaveBeenCalled();
@@ -93,7 +98,7 @@ describe('OpenChamber foreground update route', () => {
     await request(app)
       .post('/api/openchamber/update-install')
       .expect(409, {
-        error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, or run openchamber update and restart the service.',
+        error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, set OPENCHAMBER_UPDATE_RESTART_ON_EXIT=true for a restart-on-exit supervisor, or run openchamber update and restart the service.',
       });
 
     expect(childProcess.spawnSync).not.toHaveBeenCalled();
@@ -137,5 +142,52 @@ describe('OpenChamber foreground update route', () => {
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 5000,
     });
+  });
+
+  it('keeps a supervised foreground server online until installation succeeds', async () => {
+    const { app, dependencies } = createApp({
+      platform: 'darwin',
+      environment: {
+        OPENCHAMBER_UPDATE_RESTART_ON_EXIT: 'true',
+        PATH: '/Users/test/.local/bin:/usr/bin:/bin',
+      },
+    });
+
+    await request(app)
+      .post('/api/openchamber/update-install')
+      .expect(200, {
+        success: true,
+        message: 'Update queued; OpenChamber will exit after installation completes',
+        version: '1.17.1',
+        packageManager: 'npm',
+        autoRestart: true,
+        restartManager: 'process-manager',
+        logPath: '/tmp/openchamber/update-install.log',
+      });
+
+    expect(childProcess.spawn).toHaveBeenCalledWith('/bin/sh', ['-c', [
+      'set -eu',
+      'sleep 1',
+      'npm install -g @openchamber/web@latest',
+      'kill -TERM 4321',
+    ].join('\n')], {
+      detached: true,
+      stdio: ['ignore', 17, 17],
+      env: dependencies.process.env,
+    });
+    expect(dependencies.fs.closeSync).toHaveBeenCalledWith(17);
+  });
+
+  it('does not enable restart-on-exit updates on Windows', async () => {
+    const { app } = createApp({
+      platform: 'win32',
+      environment: { OPENCHAMBER_UPDATE_RESTART_ON_EXIT: 'true' },
+    });
+
+    await request(app)
+      .post('/api/openchamber/update-install')
+      .expect(409);
+
+    expect(childProcess.spawn).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/server/lib/package-manager.js
+++ b/packages/web/server/lib/package-manager.js
@@ -570,6 +570,11 @@ function detectPackageManagerFromInvocationPath(invokedPath) {
 
 function getPackageManagerCommandCandidates(pm) {
   const candidates = [];
+  const configuredPackageManager = process.env.OPENCHAMBER_PACKAGE_MANAGER?.trim();
+  const configuredCommand = process.env.OPENCHAMBER_PACKAGE_MANAGER_COMMAND?.trim();
+  if (configuredPackageManager === pm && configuredCommand && path.isAbsolute(configuredCommand)) {
+    candidates.push(configuredCommand);
+  }
   if (pm === 'bun') {
     const bunExecutable = process.platform === 'win32' ? 'bun.exe' : 'bun';
     if (process.env.BUN_INSTALL) {
@@ -598,7 +603,7 @@ function resolvePackageManagerCommand(pm) {
 
 function quoteCommand(command) {
   if (!command) return command;
-  if (!/\s/.test(command)) return command;
+  if (/^[A-Za-z0-9_./:\\-]+$/.test(command)) return command;
   if (process.platform === 'win32') {
     return `"${command.replace(/"/g, '""')}"`;
   }

--- a/packages/web/server/lib/package-manager.test.js
+++ b/packages/web/server/lib/package-manager.test.js
@@ -9,8 +9,10 @@ vi.mock('node:child_process', () => ({
 const {
   checkForUpdates,
   detectPackageManager,
+  detectPackageManagerDetails,
   executeUpdate,
   getCurrentVersion,
+  getUpdateCommand,
 } = await import('./package-manager.js');
 
 /** Helper: create a fetch mock that routes by URL pattern */
@@ -329,5 +331,25 @@ describe('CLI update exports', () => {
   it('exports package-manager helpers used by the update command', () => {
     expect(typeof detectPackageManager).toBe('function');
     expect(typeof executeUpdate).toBe('function');
+  });
+
+  it('uses an absolute command override for the forced package manager', () => {
+    const originalPackageManager = process.env.OPENCHAMBER_PACKAGE_MANAGER;
+    const originalPackageManagerCommand = process.env.OPENCHAMBER_PACKAGE_MANAGER_COMMAND;
+    process.env.OPENCHAMBER_PACKAGE_MANAGER = 'npm';
+    process.env.OPENCHAMBER_PACKAGE_MANAGER_COMMAND = '/opt/OpenChamber Runtime/npm';
+
+    try {
+      expect(detectPackageManagerDetails()).toMatchObject({
+        packageManager: 'npm',
+        packageManagerCommand: '/opt/OpenChamber Runtime/npm',
+      });
+      expect(getUpdateCommand('npm')).toBe("'/opt/OpenChamber Runtime/npm' install -g @openchamber/web@latest");
+    } finally {
+      if (originalPackageManager === undefined) delete process.env.OPENCHAMBER_PACKAGE_MANAGER;
+      else process.env.OPENCHAMBER_PACKAGE_MANAGER = originalPackageManager;
+      if (originalPackageManagerCommand === undefined) delete process.env.OPENCHAMBER_PACKAGE_MANAGER_COMMAND;
+      else process.env.OPENCHAMBER_PACKAGE_MANAGER_COMMAND = originalPackageManagerCommand;
+    }
   });
 });


### PR DESCRIPTION
## Intent

Make remote web/CLI self-updates reliable when OpenChamber runs as a foreground process under a restart-on-exit supervisor such as launchd.

- Add an explicit `OPENCHAMBER_UPDATE_RESTART_ON_EXIT=true` path that keeps the current server online during installation and signals it only after the install succeeds.
- Add `OPENCHAMBER_PACKAGE_MANAGER_COMMAND` so supervised services can pin the absolute package-manager executable that owns the running installation even if startup later rewrites `PATH`.
- Refresh remote update status whenever the Desktop services menu opens, clearing stale update availability before the authoritative request completes.

## Non-goals

- Auto-detecting arbitrary process managers or assuming every foreground process will restart after exit.
- Changing the existing systemd transient-unit path, daemon-mode restart behavior, Desktop app updater, or OpenCode updater.
- Enabling restart-on-exit behavior on Windows.

## Affected surfaces

- `packages/web`: OpenChamber update route and package-manager command resolution for web/CLI servers.
- `packages/ui`: Desktop's remote-instance update status in the services menu. The rendered states and styling are unchanged; the menu now refreshes its remote authority on open.
- `packages/docs`: environment variable and module contract documentation.
- External contract: two opt-in environment variables. No persisted data, route shape, authentication, or existing systemd behavior changes.
- Web/mobile clients continue to use the existing update endpoint. The new supervisor path is inactive unless the server operator opts in.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` and `openchamber-change-discipline` | Executable source, an HTTP route, platform lifecycle behavior, and external environment contracts change. | The diff is limited to update ownership/restart behavior, adds focused success/rejection tests, documents failure behavior, and was exercised on the affected macOS runtime. |
| `ui-api-decoupling` and `references/implementation-map.md` | The shared UI reads an OpenChamber route through runtime switching/auth. | The UI continues to call `runtimeFetch` at invocation time; no origin, token, or runtime transport is cached or bypassed. |
| `sync-state-invariants` and `packages/ui/src/sync/DOCUMENTATION.md` | Remote update status is polled authority that was remaining stale across a server change. | Opening the visible menu clears stale availability and performs an authoritative refresh; failures remain errors rather than valid empty success. |
| `packages/web/README.md` and `packages/web/server/lib/opencode/DOCUMENTATION.md` | They own web service setup and the update route contract. | Both new operator controls and the install-failure/restart ordering are documented. |

## Validation

| Check | Result |
|---|---|
| `bun x vitest run packages/web/server/lib/opencode/openchamber-routes.test.js packages/web/server/lib/package-manager.test.js` | Passed: 2 files, 21 tests. |
| `bun run --cwd packages/web type-check` and `bun run --cwd packages/web lint` | Passed. |
| `bun run --cwd packages/ui type-check` and `bun run --cwd packages/ui lint` | Passed. |
| `bun run build:web` | Passed; only existing Vite chunk/dynamic-import warnings were emitted. |
| `bun run docs:validate` | Passed: 450 pages and 45 sidebar links. |
| `node --check` for both changed server modules and tests | Passed. |
| Live macOS launchd integration through an authenticated Desktop SSH tunnel | Passed: the remote endpoint reported `1.18.1 -> 1.18.2`, staged installation completed, the PID changed only after success, launchd restarted one listener, `/health` reported `1.18.2` with OpenCode ready, and the same laptop tunnel then returned `available: false`, `currentVersion: 1.18.2`. |
| `bun run --cwd packages/web test` | Not clean on current upstream `main`: 10 unrelated failures out of 1,188 tests. Failures were in existing CLI fallback-provider, SSE mock, Git API mock, Git service timeout/temp cleanup, and walkthrough timeout/reconnect tests. The CLI failure observed another user's live server on port 3000 (`api:3000` instead of fallback). Both changed test files pass independently. |

## Visual evidence

No new rendered state, styling, layout, or motion is introduced. Before the change, the Desktop services menu could continue showing “Version 1.18.2 is available” after the remote endpoint already returned `available: false` until the app was fully restarted. After the change, opening that same menu performs the authoritative check and removes the existing update action. The before state was transient production state and was no longer available after the successful update; the live authenticated before/after API and restart evidence is recorded in Validation.

## Risks and failure behavior

- Restart-on-exit is explicit opt-in. An operator must configure a supervisor that actually restarts the process; otherwise a successful update intentionally exits and remains stopped.
- The detached script uses `set -eu`, so installation failure never reaches `kill -TERM`; the current server remains online and the install log retains the package-manager error.
- Existing systemd behavior takes precedence and remains covered by its original test. Windows ignores the restart-on-exit opt-in and returns the existing service-manager guidance.
- The command override is accepted only when paired with the forced package-manager name and expressed as an absolute path. Shell metacharacters are quoted before command construction.
- Refresh failure clears stale availability and displays the existing error state instead of preserving an update button backed by old data.
- No persisted data or credentials are added or logged.
