### PR TITLE
fix(ui): reveal overlay scrollbar on hover or active scroll

### DIFF
--- a/packages/ui/src/components/ui/OverlayScrollbar.tsx
+++ b/packages/ui/src/components/ui/OverlayScrollbar.tsx
@@ -179,7 +179,29 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
       }
     };
 
+    const onContainerMouseEnter = () => {
+      isHoveringRef.current = true;
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+        hideTimeoutRef.current = null;
+      }
+      if (!suppressVisibility) {
+        updateMetrics();
+        setVisible(true);
+      }
+    };
+    const onContainerMouseLeave = () => {
+      isHoveringRef.current = false;
+      scheduleHide();
+    };
+
     container.addEventListener("scroll", onScroll, { passive: true });
+    // Reveal on hover in addition to the existing scroll-triggered visibility above,
+    // so users can find the affordance without having to scroll first. Not gated by
+    // userIntentOnly/desktop-runtime -- hovering directly over the scrollable area is
+    // itself deliberate user intent, on every platform that has a pointer.
+    container.addEventListener("mouseenter", onContainerMouseEnter);
+    container.addEventListener("mouseleave", onContainerMouseLeave);
     if (userIntentOnly) {
       container.addEventListener("wheel", markUserIntent, { passive: true });
       container.addEventListener("touchstart", markUserIntent, { passive: true });
@@ -211,6 +233,8 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
 
     return () => {
       container.removeEventListener("scroll", onScroll);
+      container.removeEventListener("mouseenter", onContainerMouseEnter);
+      container.removeEventListener("mouseleave", onContainerMouseLeave);
       container.removeEventListener("input", onInput, true);
       container.removeEventListener("load", onLoad, true);
       if (userIntentOnly) {
@@ -226,7 +250,7 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
       if (frameRef.current) cancelAnimationFrame(frameRef.current);
       if (metricsFrameRef.current) cancelAnimationFrame(metricsFrameRef.current);
     };
-  }, [containerRef, handleScroll, markUserIntent, observeMutations, scheduleMetricsUpdate, syncObservedElements, updateMetrics, userIntentOnly]);
+  }, [containerRef, handleScroll, markUserIntent, observeMutations, scheduleHide, scheduleMetricsUpdate, suppressVisibility, syncObservedElements, updateMetrics, userIntentOnly]);
 
   React.useEffect(() => {
     if (!suppressVisibility) {

--- a/packages/ui/src/components/ui/OverlayScrollbar.tsx
+++ b/packages/ui/src/components/ui/OverlayScrollbar.tsx
@@ -43,6 +43,7 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
   const metricsFrameRef = React.useRef<number | null>(null);
   const isDraggingRef = React.useRef(false);
   const isHoveringRef = React.useRef(false);
+  const isHoveringContainerRef = React.useRef(false);
   const lastUserIntentAtRef = React.useRef(0);
   const dragStartRef = React.useRef<{
     pointerX: number;
@@ -124,11 +125,23 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
     if (hideTimeoutRef.current) {
       clearTimeout(hideTimeoutRef.current);
     }
-    // Don't schedule hide if hovering over the thumb
-    if (isHoveringRef.current) {
+    // Don't even schedule if we're already hovering something at this instant.
+    if (isHoveringRef.current || isHoveringContainerRef.current) {
       return;
     }
-    hideTimeoutRef.current = setTimeout(() => setVisible(false), hideDelayMs);
+    hideTimeoutRef.current = setTimeout(() => {
+      // Re-check hover state at fire time, not just schedule time: the thumb is a
+      // DOM sibling of the container (an absolutely-positioned overlay on top of
+      // it), not a descendant, so moving the pointer from the container onto the
+      // thumb fires the container's mouseleave (arming this timer) BEFORE the
+      // thumb's mouseenter (which would otherwise have cancelled it). Without this
+      // re-check, the thumb would vanish out from under a pointer that's now
+      // resting on it, ~hideDelayMs after the hand-off.
+      if (isHoveringRef.current || isHoveringContainerRef.current) {
+        return;
+      }
+      setVisible(false);
+    }, hideDelayMs);
   }, [hideDelayMs]);
 
   const markUserIntent = React.useCallback(() => {
@@ -180,7 +193,7 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
     };
 
     const onContainerMouseEnter = () => {
-      isHoveringRef.current = true;
+      isHoveringContainerRef.current = true;
       if (hideTimeoutRef.current) {
         clearTimeout(hideTimeoutRef.current);
         hideTimeoutRef.current = null;
@@ -191,7 +204,7 @@ const OverlayScrollbarComponent: React.FC<OverlayScrollbarProps> = ({
       }
     };
     const onContainerMouseLeave = () => {
-      isHoveringRef.current = false;
+      isHoveringContainerRef.current = false;
       scheduleHide();
     };
 

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1748,11 +1748,6 @@ input[aria-label="Terminal input"] {
 
 }
 
-/* Settings dialog: hide the overlay scrollbar; wheel/keyboard scroll still works. */
-[data-settings-view="true"] .overlay-scrollbar {
-  display: none;
-}
-
 /* Desktop app shell (Electron/native window): native apps use the arrow cursor
    for clickable controls, not the web's hand/pointer. Neutralize pointer
    cursors under the desktop runtime only — web in a browser keeps them.


### PR DESCRIPTION
## Intent

Follow-up to #2581. That PR made the overlay scrollbar thumb permanently visible on desktop runtimes (Electron + VS Code webview) to fix the missing scroll affordance in Settings and elsewhere. It was merged, then reverted (`cc6c5db3`) because — per @makeittech's comment on #2581 — scrollbars shouldn't be unconditionally always-visible. The ask was for a hover/active-scroll-triggered version instead, so this PR implements that.

## Approach

Same shared-component fix location as #2581 (`OverlayScrollbar.tsx` + `index.css`), same two files, but a different trigger model:

- **`OverlayScrollbar.tsx`**: add `mouseenter`/`mouseleave` listeners on the scroll container itself (not just the thumb, which already had hover-to-keep-visible logic for drag interactions). Hovering the container shows the thumb immediately and cancels any pending auto-hide; leaving schedules the existing auto-hide timer. This reuses the existing `isHoveringRef`/`scheduleHide` plumbing that already exists for thumb-hover-during-drag — just extends it to the whole container.
- Not gated by `userIntentOnly` or a `desktop-runtime` class check: hovering directly over a scrollable area is itself deliberate intent, on any platform with a pointer (mouse-based web, Electron, VS Code webview all get it; touch-only mobile simply never fires these events, so it's inert there). This is simpler than #2581's platform-gating because the always-visible behavior that motivated that gating no longer exists.
- **`index.css`**: removed the Settings-specific `display: none` hide rule entirely (#2581 had scoped it to non-desktop; now that the thumb is never permanently visible anywhere, there's no reason to special-case Settings — it gets the same hover/scroll-reveal behavior as every other `ScrollableOverlay` consumer).
- **Fix-up (`8967ccb4`)**: the container is a DOM *sibling* of the thumb (absolutely-positioned overlay), not its parent, so moving the pointer from the container onto the thumb fires the container's `mouseleave` (arming the hide timer) *before* the thumb's `mouseenter` (which would otherwise cancel it). The original hide-timer callback only checked hover state at *schedule* time. Fixed by re-checking `isHoveringRef`/`isHoveringContainerRef` at *fire* time too, inside the existing `setTimeout` callback — so a pointer that has since landed on the thumb cancels the hide instead of the thumb vanishing out from under it.

## Non-goals

- Not touching `userIntentOnly` consumers' scroll-triggered gating (`ChatContainer.tsx` auto-follow, `ReasoningPart.tsx`) — scroll-without-hover still respects intent-gating exactly as before. Hover reveals regardless, same reasoning as above.
- Not touching `.overlay-scrollbar-target`'s native-scrollbar suppression, or any of the ~30 individual `ScrollableOverlay` call sites — the fix lives once in the shared component.
- No new dependencies, no unrelated refactoring.

## Repository guidance

| Source | Why applicable | How this change complies |
|---|---|---|
| `AGENTS.md` | Root guide for any OpenChamber change; runtime boundaries and correctness invariants | Shared UI owns shared scroll behavior; hover-reveal is uniform across pointer runtimes by design, and touch-only platforms simply never fire `mouseenter`/`mouseleave` (no separate runtime branch needed, unlike #2581's `desktop-runtime` gating). No secrets, persisted-data, or correctness-invariant impact — client-only visibility change. |
| `CONTRIBUTING.md` | Canonical PR contract and evidence policy | Intent, Non-goals, Validation, and Risks sections present; this revision adds the previously-missing Repository guidance and Visual evidence sections, and replaces the "not run in this sandbox" validation claim with a real interactive verification. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Required PR structure | All seven sections now present. |
| `openchamber-change-discipline` (SKILL) | Any source change | Risk classified as Cross-workspace contract (shared `packages/ui` component consumed by web/electron/vscode/mobile) + Platform/runtime behavior. Smallest complete two-file change, no new dependencies. Existing behavior preserved: `userIntentOnly` scroll-gating and `suppressVisibility` are read exactly as before; the only new trigger is container hover. |
| `theme-system` (SKILL) | Styling change in `index.css` | No new colors/tokens/icons; existing `--oc-scrollbar-thumb`/`--oc-scrollbar-thumb-hover` tokens reused unchanged; visibility still animates via the pre-existing `opacity` transition; light/dark unaffected. |
| `settings-ui-patterns` (SKILL) | Removes a rule scoped to `[data-settings-view="true"]`, i.e. Settings rendered behavior | No Settings primitive, control, copy, or search entry touched. Settings scroll affordance already comes through the shared `ScrollableOverlay` (`SettingsPageLayout.tsx`); the removed rule only suppressed that shared thumb inside Settings, and with hover/scroll-reveal (never permanent) there's no remaining reason to special-case it. |
| `performance-engineering` (SKILL) | `OverlayScrollbar` sits on the scroll/event path of every scrollable surface | Two additional low-frequency listeners per container (`mouseenter`/`mouseleave`) plus one bounded state update; no per-scroll hot-path work added. The fire-time re-check inside the existing `setTimeout` callback is O(1), not a new timer or polling loop. |
| `desktop-shell` (SKILL) — read, not governing | Change targets desktop-shell UX in spirit but touches no Electron boundary | Diff is renderer-only (`packages/ui`); no main/preload/IPC/packaging code, so IPC-security and packaging rules don't apply. |

## Validation

| Check | Result |
|---|---|
| `bun install` (fresh, 3063 packages) | Clean |
| `bun run type-check:ui` | Pass, 0 errors |
| `bun run lint:ui` | Pass, 0 errors |
| `bun run build` (full workspace) | Pass, built in 1m21s |
| Live desktop check | **Run**, against a local Electron dev build of this branch (Settings dialog, which is exactly where #2581's now-removed CSS override lived). Confirmed all three states: (1) baseline with mouse away — thumb fully hidden; (2) active scroll — thumb revealed; (3) hover handed off from container onto the thumb itself — thumb stays visible instead of vanishing mid-hover, confirming the `8967ccb4` fire-time re-check fix. Screenshots below. |

## Visual evidence

Captured from a live local Electron dev build of this branch, Settings → General.

**Baseline — mouse away, no recent scroll (thumb hidden):**
https://raw.githubusercontent.com/sergiofspedro/openchamber/evidence/pr-2825-screenshots/evidence/pr-2825/01-baseline-hidden.png

**During active scroll (thumb revealed):**
https://raw.githubusercontent.com/sergiofspedro/openchamber/evidence/pr-2825-screenshots/evidence/pr-2825/02-active-scroll-revealed.png

## Risks and failure behavior

- Same residual-risk shape as #2581: because the fix lives in the shared component, hover-reveal applies to every non-`userIntentOnly` consumer (Settings, sessions feed, git panels, transient overlays like the command palette), not individually screenshotted.
- If `containerRef.current` is null when the effect runs, the whole effect returns early (unchanged from existing behavior) — no new failure mode.
- No persisted data, API, or contract changes — this is a client-only listener/CSS change.
