### PR TITLE
fix(preview): stop probing dead upstreams forever, surface unreachable state

### DIFF
--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -1174,6 +1174,26 @@ const PreviewPane: React.FC<PreviewPaneProps> = ({ rawUrl, onNavigate }) => {
         response.headers,
         proxyRecoveryAttemptedKeyRef.current === proxyCacheKey,
       );
+      if (recoveryAction === 'retry-grace') {
+        // The proxy signals the upstream origin is not accepting connections
+        // (ECONNREFUSED & friends). The target itself is valid — the origin
+        // may be a dev server that is still binding — so keep retrying with
+        // backoff during the startup grace window, then settle on a stable
+        // "unreachable" state (rendered with a manual retry button) instead
+        // of probing a dead origin forever.
+        const startedAt = upstreamProbeStartedAtRef.current || Date.now();
+        const elapsed = Date.now() - startedAt;
+        if (elapsed < PREVIEW_STARTUP_GRACE_MS) {
+          setUpstreamState('starting');
+          upstreamProbeAttemptRef.current += 1;
+          const attempt = upstreamProbeAttemptRef.current;
+          const delay = Math.min(2000, 250 * Math.pow(2, Math.min(4, attempt)));
+          scheduleRetry(delay);
+          return;
+        }
+        setUpstreamState('unreachable');
+        return;
+      }
       if (recoveryAction !== 'none') {
         previewProxyTargetCache.delete(proxyCacheKey);
         if (recoveryAction === 'retry-registration') {

--- a/packages/ui/src/lib/preview/proxy-response.test.ts
+++ b/packages/ui/src/lib/preview/proxy-response.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe('preview proxy response classification', () => {
   test('recognizes proxy-owned target failures', () => {
-    for (const code of ['missing', 'expired', 'invalid-token'] as const) {
+    for (const code of ['missing', 'expired', 'invalid-token', 'unreachable'] as const) {
       const headers = new Headers({ [PREVIEW_TARGET_ERROR_HEADER]: code });
       expect(getPreviewTargetErrorCode(headers)).toBe(code);
     }
@@ -24,5 +24,11 @@ describe('preview proxy response classification', () => {
     const headers = new Headers({ [PREVIEW_TARGET_ERROR_HEADER]: 'expired' });
     expect(getPreviewTargetRecoveryAction(headers, false)).toBe('retry-registration');
     expect(getPreviewTargetRecoveryAction(headers, true)).toBe('stop-retrying');
+  });
+
+  test('never auto-registers for an unreachable upstream, regardless of attempt count', () => {
+    const headers = new Headers({ [PREVIEW_TARGET_ERROR_HEADER]: 'unreachable' });
+    expect(getPreviewTargetRecoveryAction(headers, false)).toBe('retry-grace');
+    expect(getPreviewTargetRecoveryAction(headers, true)).toBe('retry-grace');
   });
 });

--- a/packages/ui/src/lib/preview/proxy-response.ts
+++ b/packages/ui/src/lib/preview/proxy-response.ts
@@ -1,10 +1,10 @@
 export const PREVIEW_TARGET_ERROR_HEADER = 'x-openchamber-preview-target-error';
 
-type PreviewTargetErrorCode = 'missing' | 'expired' | 'invalid-token';
+type PreviewTargetErrorCode = 'missing' | 'expired' | 'invalid-token' | 'unreachable';
 
 export const getPreviewTargetErrorCode = (headers: Pick<Headers, 'get'>): PreviewTargetErrorCode | null => {
   const value = headers.get(PREVIEW_TARGET_ERROR_HEADER);
-  return value === 'missing' || value === 'expired' || value === 'invalid-token'
+  return value === 'missing' || value === 'expired' || value === 'invalid-token' || value === 'unreachable'
     ? value
     : null;
 };
@@ -12,7 +12,12 @@ export const getPreviewTargetErrorCode = (headers: Pick<Headers, 'get'>): Previe
 export const getPreviewTargetRecoveryAction = (
   headers: Pick<Headers, 'get'>,
   recoveryAttempted: boolean,
-): 'none' | 'retry-registration' | 'stop-retrying' => {
-  if (!getPreviewTargetErrorCode(headers)) return 'none';
+): 'none' | 'retry-registration' | 'stop-retrying' | 'retry-grace' => {
+  const code = getPreviewTargetErrorCode(headers);
+  if (!code) return 'none';
+  // The target itself is valid, but the upstream origin is not accepting
+  // connections (ECONNREFUSED & friends). Re-registering would not help;
+  // give the dev server a startup grace window, then stop retrying.
+  if (code === 'unreachable') return 'retry-grace';
   return recoveryAttempted ? 'stop-retrying' : 'retry-registration';
 };

--- a/packages/web/server/lib/preview/proxy-runtime.js
+++ b/packages/web/server/lib/preview/proxy-runtime.js
@@ -1,4 +1,21 @@
 const DEFAULT_TARGET_TTL_MS = 30 * 60 * 1000;
+
+// Connection-level failures mean the upstream origin is not accepting
+// connections at all (process not listening / dead socket). These are
+// surfaced to the renderer via the preview target error header so the UI can
+// stop retrying and show an actionable "unreachable" state instead of
+// hammering the dead origin indefinitely.
+const UPSTREAM_CONNECTION_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ESOCKETTIMEDOUT',
+  'ENOTFOUND',
+  'EPIPE',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EAI_AGAIN',
+]);
 const TOKEN_COOKIE_NAME = 'oc_preview_token';
 const TOKEN_QUERY_PARAM = 'oc_preview_token';
 const CLIENT_TOKEN_QUERY_PARAM = 'oc_client_token';
@@ -1544,6 +1561,13 @@ export const createPreviewProxyRuntime = ({
               } catch {
                 payload.details = { message };
               }
+            }
+
+            const errorCode = err && typeof err === 'object' && typeof err.code === 'string'
+              ? err.code
+              : '';
+            if (UPSTREAM_CONNECTION_ERROR_CODES.has(errorCode)) {
+              res.setHeader(PREVIEW_TARGET_ERROR_HEADER, 'unreachable');
             }
 
             res.status(502).json(payload);

--- a/packages/web/server/lib/preview/proxy-runtime.test.js
+++ b/packages/web/server/lib/preview/proxy-runtime.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
 
 import {
   applyPreviewPassthroughRequestHeaders,
@@ -524,5 +524,32 @@ describe('preview CSP rewrite', () => {
   it('returns empty/unset CSP values unchanged', () => {
     expect(rewritePreviewCspHeader('', 'abc123')).toBe('');
     expect(rewritePreviewCspHeader(undefined, 'abc123')).toBe(undefined);
+  });
+});
+
+describe('preview proxy upstream connection errors', () => {
+  const { proxyOptions } = createAttachedPreviewRuntime();
+  const silencedConsole = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  afterAll(() => {
+    silencedConsole.mockRestore();
+  });
+
+  it('flags unreachable upstreams via the target error header', () => {
+    const res = createResponse();
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:5180');
+    error.code = 'ECONNREFUSED';
+    proxyOptions().on.error(error, { originalUrl: '/api/preview/proxy/abc123' }, res);
+    expect(res.statusCode).toBe(502);
+    expect(res.headers.get(PREVIEW_TARGET_ERROR_HEADER)).toBe('unreachable');
+  });
+
+  it('does not flag non-connection proxy errors', () => {
+    const res = createResponse();
+    const error = new Error('socket hang up');
+    error.code = 'ERR_STREAM_WRITE_AFTER_END';
+    proxyOptions().on.error(error, { originalUrl: '/api/preview/proxy/abc123' }, res);
+    expect(res.statusCode).toBe(502);
+    expect(res.headers.has(PREVIEW_TARGET_ERROR_HEADER)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

A preview tab whose upstream origin is dead (e.g. a dev server that was stopped, or a stale `http://127.0.0.1:<port>` URL persisted across restarts) makes the preview proxy retry **forever**:

- The proxy answers every request with a plain `502` and **no** `x-openchamber-preview-target-error` header, so the renderer cannot tell "upstream unreachable" apart from "upstream still starting".
- The renderer therefore keeps retrying with backoff (250ms → 2s) indefinitely, and the iframe is remounted on every retry — producing a steady stream of
  `[preview-proxy] proxy error: connect ECONNREFUSED 127.0.0.1:5180` log lines (~2/s) that resumes after every app restart.

## Fix

- **server** (`packages/web/server/lib/preview/proxy-runtime.js`): when the proxy fails with a connection-level error (`ECONNREFUSED`, `ECONNRESET`, timeouts, host-not-found, …), emit `x-openchamber-preview-target-error: unreachable` alongside the existing `502`.
- **ui** (`packages/ui/src/lib/preview/proxy-response.ts`): recognize the new `unreachable` code and map it to a new `retry-grace` recovery action — never re-register the target, since the target itself is valid.
- **ui** (`packages/ui/src/components/layout/ContextPanel.tsx`): during the existing 15s startup grace window, keep the current backoff so dev servers that are still binding aren't affected; afterwards settle on the already-rendered "Dev server is not responding" state (with the manual **Retry** button) and **stop probing automatically**.

## Testing

- `packages/ui`: `bun test src/lib/preview/proxy-response.test.ts` — 4 pass (new case: `unreachable` → `retry-grace` regardless of attempt count)
- `packages/web`: `vitest run server/lib/preview/proxy-runtime.test.js` — 37 pass (new cases: connection errors → `unreachable` header; non-connection proxy errors → no header)
- `tsc --noEmit` (5.9.3) and eslint clean on all touched files
