### PR TITLE
fix(ui): stable chat seam anchor during panel resize; single width writer + 120ms reduced-motion animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Chat: the conversation no longer jumps while the sidebar or context panel is being resized; the first visible message stays put during panel drags.
+- UI: sidebar and context panel open/close now animate smoothly instead of appearing in a single frame, with a shorter, softer animation when reduced motion is enabled.
 - Usage: quota limits enabled for display now refresh every three minutes on desktop, mobile, and VS Code, with a manual refresh action available at any time.
 
 ## [1.18.2] - 2026-08-10

--- a/bun-patches/@tanstack+virtual-core+3.17.3.patch
+++ b/bun-patches/@tanstack+virtual-core+3.17.3.patch
@@ -16,6 +16,37 @@ index 52ae6ca12f8d1c650ee7f1bd55573ee7d4f8b65f..bcee09df7377c37ffb220606b741c9ff
            lanes,
            // Pass the typed array so binary search + forward-walk can read
            // start/end directly from Float64Array, skipping the Proxy traps.
++@@ -850,5 +850,10 @@
++      if (delta !== 0) {
++        // OpenChamber patch: during a panel-resize transaction the anchor
++        // controller is the ONLY scroll writer. suppressScrollAdjustments
++        // stops both the end-anchor ("keep at bottom") and the above-viewport
++        // item-size-change compensation branches from writing scrollTop here.
++        const suppressAdjustments = this.options.suppressScrollAdjustments === true;
++        const wasAtEnd = !suppressAdjustments && this.options.anchorTo === "end" && ((_a = this.scrollState) == null ? void 0 : _a.behavior) !== "smooth" && this.getVirtualDistanceFromEnd() <= this.options.scrollEndThreshold;
++        const prevTotalSize = wasAtEnd ? this.getTotalSize() : 0;
++        const shouldAdjustScroll = !suppressAdjustments && ((_b = this.scrollState) == null ? void 0 : _b.behavior) !== "smooth" && (this.shouldAdjustScrollPositionOnItemSizeChange !== void 0 ? this.shouldAdjustScrollPositionOnItemSizeChange(
+           // The callback expects a VirtualItem; build one lazily only
+           // when the consumer actually supplied a custom predicate.
+           this.measurementsCache[index] ?? {
+             index,
+             key,
+             start: itemStart,
+             size: cachedSize,
+             end: itemStart + cachedSize,
+             lane: 0
+           },
+           delta,
+           this
+         ) : (
+           // Default: adjust when the resize is an above-viewport item.
+           // First measurement (!has(key)): always adjust — the item
+           // has never been sized, so the estimate→actual delta must
+           // be compensated regardless of scroll direction.
+           // Re-measurement (has(key)): skip during backward scroll
+           // to avoid the "items jump while scrolling up" cascade.
+           itemStart < this.getScrollOffset() + this.scrollAdjustments && (!this.itemSizeCache.has(key) || this.scrollDirection !== "backward")
+         ));
 diff --git a/dist/esm/index.js b/dist/esm/index.js
 index 3032c0ca457582be3f47923cba1f7d92c848745c..90b574881a073aabac99c075f7eab0a8f363fff6 100644
 --- a/dist/esm/index.js
@@ -34,3 +65,34 @@ index 3032c0ca457582be3f47923cba1f7d92c848745c..90b574881a073aabac99c075f7eab0a8
            lanes,
            // Pass the typed array so binary search + forward-walk can read
            // start/end directly from Float64Array, skipping the Proxy traps.
++@@ -848,5 +848,10 @@
++      if (delta !== 0) {
++        // OpenChamber patch: during a panel-resize transaction the anchor
++        // controller is the ONLY scroll writer. suppressScrollAdjustments
++        // stops both the end-anchor ("keep at bottom") and the above-viewport
++        // item-size-change compensation branches from writing scrollTop here.
++        const suppressAdjustments = this.options.suppressScrollAdjustments === true;
++        const wasAtEnd = !suppressAdjustments && this.options.anchorTo === "end" && ((_a = this.scrollState) == null ? void 0 : _a.behavior) !== "smooth" && this.getVirtualDistanceFromEnd() <= this.options.scrollEndThreshold;
++        const prevTotalSize = wasAtEnd ? this.getTotalSize() : 0;
++        const shouldAdjustScroll = !suppressAdjustments && ((_b = this.scrollState) == null ? void 0 : _b.behavior) !== "smooth" && (this.shouldAdjustScrollPositionOnItemSizeChange !== void 0 ? this.shouldAdjustScrollPositionOnItemSizeChange(
+           // The callback expects a VirtualItem; build one lazily only
+           // when the consumer actually supplied a custom predicate.
+           this.measurementsCache[index] ?? {
+             index,
+             key,
+             start: itemStart,
+             size: cachedSize,
+             end: itemStart + cachedSize,
+             lane: 0
+           },
+           delta,
+           this
+         ) : (
+           // Default: adjust when the resize is an above-viewport item.
+           // First measurement (!has(key)): always adjust — the item
+           // has never been sized, so the estimate→actual delta must
+           // be compensated regardless of scroll direction.
+           // Re-measurement (has(key)): skip during backward scroll
+           // to avoid the "items jump while scrolling up" cascade.
+           itemStart < this.getScrollOffset() + this.scrollAdjustments && (!this.itemSizeCache.has(key) || this.scrollDirection !== "backward")
+         ));

--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -171,6 +171,7 @@ type ChatViewportProps = {
     sessionQuestions: QuestionRequest[];
     sessionPermissions: PermissionRequest[];
     isProgrammaticFollowActive: boolean;
+    isPinned: boolean;
     showLoadOlderButton: boolean;
     onLoadOlder: () => void;
     turnIds: string[];
@@ -205,6 +206,7 @@ const ChatViewport = React.memo(({
     sessionQuestions,
     sessionPermissions,
     isProgrammaticFollowActive,
+    isPinned,
     showLoadOlderButton,
     onLoadOlder,
     turnIds,
@@ -367,6 +369,7 @@ const ChatViewport = React.memo(({
                             scrollToBottom={scrollToBottom}
                             scrollRef={scrollRef}
                             directory={directory}
+                            isPinned={isPinned}
                         />
                         {(sessionQuestions.length > 0 || sessionPermissions.length > 0) && (
                             <div>
@@ -1266,6 +1269,7 @@ export const ChatContainer: React.FC<ChatContainerProps> = ({ active = true, aut
                 sessionQuestions={sessionQuestions}
                 sessionPermissions={sessionPermissions}
                 isProgrammaticFollowActive={isFollowingProgrammatically}
+                isPinned={isPinned}
                 showLoadOlderButton={showLoadOlderButton}
                 onLoadOlder={handleLoadOlderClick}
                 turnIds={timelineController.turnIds}

--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -2453,6 +2453,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         <>
         <form
             ref={composerFormRef}
+            data-chat-composer-occlusion="true"
             onSubmit={(e) => { e.preventDefault(); handlePrimaryAction(); }}
             className={cn(
                 "relative w-full pt-0 pb-4",

--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -1034,7 +1034,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                 data-message-id={message.info.id}
                 ref={messageContainerRef}
             >
-                <div className="chat-message-column relative" data-chat-wrap-surface="true">
+                <div className="chat-message-column relative">
                     {isUser ? (
                         displayParts.length === 0 ? null : (
                             <FadeInOnReveal
@@ -1047,7 +1047,6 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                     <div className={cn('max-w-[85%]', showStickyInlineHoverRow ? 'pb-5' : undefined)}>
                                         <div
                                             data-chat-user-bubble="true"
-                                            data-chat-message-id={message.info.id}
                                             style={{
                                                 backgroundColor: 'var(--chat-user-message-bg)',
                                                 borderRadius: userMessageRadius,

--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -1034,7 +1034,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                 data-message-id={message.info.id}
                 ref={messageContainerRef}
             >
-                <div className="chat-message-column relative">
+                <div className="chat-message-column relative" data-chat-wrap-surface="true">
                     {isUser ? (
                         displayParts.length === 0 ? null : (
                             <FadeInOnReveal
@@ -1046,6 +1046,8 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                 <div className={cn('relative flex justify-end', !isMobile ? 'group/user-shell' : undefined)}>
                                     <div className={cn('max-w-[85%]', showStickyInlineHoverRow ? 'pb-5' : undefined)}>
                                         <div
+                                            data-chat-user-bubble="true"
+                                            data-chat-message-id={message.info.id}
                                             style={{
                                                 backgroundColor: 'var(--chat-user-message-bg)',
                                                 borderRadius: userMessageRadius,

--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -1063,15 +1063,6 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
     const deferPrepends = isTanstack && isMobileSurfaceRuntime();
 
     React.useEffect(() => {
-        const element = scrollRef?.current;
-        // Stable selector for the performance recorder's targeted view probe
-        // (it must not scan the whole DOM on every heartbeat).
-        if (element && !element.hasAttribute('data-message-scroll-container')) {
-            element.setAttribute('data-message-scroll-container', '');
-        }
-    }, [scrollRef]);
-
-    React.useEffect(() => {
         if (!deferPrepends) return;
         const element = scrollRef?.current;
         if (!element) return;
@@ -1463,7 +1454,6 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
         return (
             <div
                 ref={sizeContainerRef}
-                data-vlist-size-container="true"
                 className="relative w-full"
                 style={{
                     height: tanstackVirtualizer.getTotalSize(),

--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Part } from '@opencode-ai/sdk/v2';
-import { elementScroll, useVirtualizer as useTanstackVirtualizer, type ReactVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
+import { useVirtualizer as useTanstackVirtualizer, type ReactVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
 
 import ChatMessage from './ChatMessage';
 import { areOptionalRenderRelevantMessagesEqual, areRelevantTurnGroupingContextsEqual, areRenderRelevantMessagesEqual } from './message/renderCompare';
@@ -8,6 +8,23 @@ import TurnItem from './components/TurnItem';
 import type { AnimationHandlers, ContentChangeReason } from '@/hooks/useChatAutoFollow';
 import type { ChatMessageEntry, TurnRecord, TurnGroupingContext } from './lib/turns/types';
 import { useTurnRecords } from './hooks/useTurnRecords';
+import { useConversationResizeAnchor } from './hooks/useConversationResizeAnchor';
+import { extendHeldRange } from './lib/conversationResizeLayout';
+
+// The bun patch (bun-patches/@tanstack+virtual-core+3.17.3.patch) adds
+// suppressScrollAdjustments to the virtualizer options so the resize
+// transaction can stop BOTH TanStack scroll-adjustment branches (end-anchor
+// "keep at bottom" and above-viewport item-size compensation). Declare the
+// option here for the type-checker (react-virtual re-exports VirtualizerOptions
+// from virtual-core via `export *`).
+declare module '@tanstack/react-virtual' {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- generic names must match the merged interface exactly
+    interface VirtualizerOptions<TScrollElement extends Element | Window, TItemElement extends Element> {
+        /** OpenChamber patch: when true, resizeItem never writes scrollTop
+         *  (the anchor controller is the only scroll writer mid-transaction). */
+        suppressScrollAdjustments?: boolean;
+    }
+}
 import { applyRetryOverlay } from './lib/turns/applyRetryOverlay';
 import { buildLiveStreamingEntry } from './lib/turns/streamingTailEntry';
 import { getNormalizedMessageForDisplay, hasCompactionPart } from './lib/messageDisplayNormalization';
@@ -21,6 +38,13 @@ import type { StreamPhase } from './message/types';
 import { useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
 import { useSessionParts } from '@/sync/sync-context';
 import { isMobileSurfaceRuntime } from '@/lib/runtimeSurface';
+import {
+    getResizeInteractionPhase,
+    isResizeSettling,
+    registerResizeFinalizer,
+    subscribeResizeInteraction,
+} from '@/lib/resizeInteraction';
+import { recordPerformanceTraceEvent } from '@/stores/utils/performanceTrace';
 import type { ReviewTransferDirection } from '@/lib/reviewFlow';
 import {
     USER_SHELL_MARKER,
@@ -41,6 +65,70 @@ const sameKeys = (a: readonly string[] | undefined, b: readonly string[] | undef
     return a.every((key, index) => key === b[index]);
 };
 
+// --- Resize anchor (pure layout model) --------------------------------------
+// Semantic anchor kept stable across the WHOLE resize transaction. The pure
+// layout math lives in ./lib/resizeAnchorLayout (DOM-free, unit-tested); the
+// component owns the transaction height model (cache-seeded Map over ALL
+// render entries + a frozen estimate) and the DOM adapter that reads mounted
+// row heights. Two modes:
+//   - bottom:  the list is genuinely bottom-following (<= 24px from bottom);
+//              keep the distance from the bottom constant.
+//   - entry:   a stable render-entry key (turn OR ungrouped row) the user was
+//              reading; the entry's layout top must stay pinned. Anchored on
+//              the outer non-sticky virtual row, never on the sticky user
+//              header's [data-message-id] (its visual top is CSS-clipped and
+//              is not a document coordinate). The conversation-boundary anchor
+//              lives in ./hooks/useConversationResizeAnchor (DOM controller)
+//              and ./lib/conversationResizeAnchor (pure math).
+
+/** DOM adapter: read the mounted virtual rows as {key, index, height}. Only
+ *  direct children marked [data-chat-virtual-row] qualify (nested virtualized
+ *  code rows also use [data-index]); index must be in range, unique, and the
+ *  data-turn-entry must match the entry key at that index. */
+const readMountedRowMeasurements = (
+    liveContent: HTMLElement | null,
+    entries: readonly RenderEntry[],
+): Array<{ key: string; index: number; height: number }> => {
+    if (!liveContent) {
+        return [];
+    }
+    const seen = new Set<number>();
+    const out: Array<{ key: string; index: number; height: number }> = [];
+    for (const child of Array.from(liveContent.children)) {
+        if (!(child instanceof HTMLElement)) {
+            continue;
+        }
+        if (child.getAttribute('data-chat-virtual-row') !== 'true') {
+            continue;
+        }
+        const index = Number(child.getAttribute('data-index'));
+        if (!Number.isFinite(index) || index < 0 || index >= entries.length) {
+            continue;
+        }
+        const expectedKey = entries[index]?.key;
+        if (expectedKey === undefined || child.getAttribute('data-turn-entry') !== expectedKey) {
+            continue;
+        }
+        if (seen.has(index)) {
+            continue;
+        }
+        seen.add(index);
+        const height = Math.round(child.offsetHeight);
+        if (height > 0) {
+            out.push({ key: expectedKey, index, height });
+        }
+    }
+    return out;
+};
+
+const isListVisibleForResize = (scroller: HTMLElement): boolean => {
+    if (typeof document !== 'undefined' && document.hidden) {
+        return false;
+    }
+    const rect = scroller.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+};
+
 // --- History virtualization (@tanstack/react-virtual) ----------------------
 // The history list virtualizes with @tanstack/react-virtual on all surfaces:
 // its core has bottom anchoring (anchorTo: 'end'), key-stable prepend
@@ -51,12 +139,19 @@ type TanstackVirtualizerInstance = ReactVirtualizer<HTMLDivElement, HTMLDivEleme
 type HistoryEngine = 'none' | 'tanstack';
 
 const TANSTACK_ESTIMATED_ENTRY_SIZE = 320;
-const TANSTACK_OVERSCAN = 8;
+// Overscan is FIXED for idle/dragging/finalizing (no stage switching): a
+// drag->finalize overscan expansion mounts fresh rows with stale widths and
+// lets TanStack re-adjust scrollTop — the "release jump". 2 keeps the anchor
+// turn's row and its neighbors mounted during a drag; if fast scrolling ever
+// shows blank space, raise the fixed value (3/4), never switch per phase.
+const TANSTACK_OVERSCAN = 2;
 // Touch flings cover more distance between paints than desktop wheels; a
 // larger window keeps fast mobile scrolling over mounted rows.
 const TANSTACK_MOBILE_OVERSCAN = 16;
 const resolveTanstackOverscan = (): number => (
-    isMobileSurfaceRuntime() ? TANSTACK_MOBILE_OVERSCAN : TANSTACK_OVERSCAN
+    isMobileSurfaceRuntime()
+        ? TANSTACK_MOBILE_OVERSCAN
+        : TANSTACK_OVERSCAN
 );
 // Post-prepend anchor hold: measurements of freshly
 // prepended rows settle over multiple frames, so a single restore can be
@@ -367,6 +462,9 @@ interface MessageListProps {
     scrollToBottom?: () => void;
     scrollRef?: React.RefObject<HTMLDivElement | null>;
     directory?: string;
+    /** True while auto-follow is pinned (real bottom-following). Drives the
+     *  resize anchor: only then may the controller use bottom mode. */
+    isPinned?: boolean;
 }
 
 export interface MessageListHandle {
@@ -937,6 +1035,9 @@ type StaticHistoryListProps = {
     scrollRef?: React.RefObject<HTMLDivElement | null>;
     registerTanstackVirtualizer?: (virtualizer: TanstackVirtualizerInstance | null) => void;
     virtualizerKey: string;
+    /** Held contiguous virtual range during a resize transaction (read by the
+     *  rangeExtractor; null when idle). */
+    resizeHeldRangeRef?: React.RefObject<{ start: number; end: number } | null>;
     onMessageContentChange: (reason?: ContentChangeReason) => void;
     getAnimationHandlers: (messageId: string) => AnimationHandlers;
     scrollToBottom?: () => void;
@@ -950,7 +1051,7 @@ type StaticHistoryListProps = {
     reviewTransferDirection?: ReviewTransferDirection | null;
 };
 
-const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, registerTanstackVirtualizer, virtualizerKey, onMessageContentChange, getAnimationHandlers, scrollToBottom, stickyUserHeader, defaultActivityExpanded, turnUiStates, onToggleTurnGroup, chatRenderMode, shouldAnimateUserMessage, onUserAnimationConsumed, reviewTransferDirection }: StaticHistoryListProps) => {
+const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, registerTanstackVirtualizer, virtualizerKey, resizeHeldRangeRef, onMessageContentChange, getAnimationHandlers, scrollToBottom, stickyUserHeader, defaultActivityExpanded, turnUiStates, onToggleTurnGroup, chatRenderMode, shouldAnimateUserMessage, onUserAnimationConsumed, reviewTransferDirection }: StaticHistoryListProps) => {
     const isTanstack = engine === 'tanstack';
 
     // --- Quiet-window prepend (mobile) --------------------------------------
@@ -960,6 +1061,15 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
     const lastScrollAtRef = React.useRef(0);
     const holdSinceRef = React.useRef<number | null>(null);
     const deferPrepends = isTanstack && isMobileSurfaceRuntime();
+
+    React.useEffect(() => {
+        const element = scrollRef?.current;
+        // Stable selector for the performance recorder's targeted view probe
+        // (it must not scan the whole DOM on every heartbeat).
+        if (element && !element.hasAttribute('data-message-scroll-container')) {
+            element.setAttribute('data-message-scroll-container', '');
+        }
+    }, [scrollRef]);
 
     React.useEffect(() => {
         if (!deferPrepends) return;
@@ -1040,27 +1150,115 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
     ));
 
     const sizeContainerRef = React.useRef<HTMLDivElement | null>(null);
+    // Inner flow container (the paddingTop wrapper).
+    const liveContentRef = React.useRef<HTMLDivElement | null>(null);
     // Adaptive estimate: rows this session has actually measured are a far
     // better predictor for the still-unmeasured ones than a fixed constant.
     // Smaller estimate error → smaller anchor corrections when prepended rows
     // measure in → less visible drift. The ref keeps estimateSize's identity
     // stable so updating the average never triggers a global remeasure.
     const estimatedEntrySizeRef = React.useRef(TANSTACK_ESTIMATED_ENTRY_SIZE);
+    // Counts virtualizer.measure() calls per resize transaction. The
+    // finalization must NOT call measure() at all (it clears the whole cache).
+    const measureCountRef = React.useRef(0);
+    // Counts targeted resizeItem calls per transaction (acceptance: <= number
+    // of mounted rows, one React commit).
+    const resizeItemCountRef = React.useRef(0);
+    // Subscribe to the full transaction phase (not just a settling boolean):
+    // dragging freezes the size cache, finalizing owns the single cache commit.
+    const resizePhase = React.useSyncExternalStore(
+        subscribeResizeInteraction,
+        getResizeInteractionPhase,
+        getResizeInteractionPhase,
+    );
+    // Synchronous phase mirror for high-frequency callbacks (ResizeObserver,
+    // rAF): writing during render means the ref is never a commit behind the
+    // actual phase, so a queued callback cannot treat finalizing as dragging.
+    const phaseRef = React.useRef(resizePhase);
+    phaseRef.current = resizePhase;
     const tanstackVirtualizer = useTanstackVirtualizer<HTMLDivElement, HTMLDivElement>({
         count: renderEntries.length,
         enabled: isTanstack,
         getScrollElement: () => scrollRef?.current ?? null,
+        // While dragging/finalizing, disable TanStack's end-anchored scroll
+        // following. -1 makes wasAtEnd false even at the exact bottom (a 0
+        // threshold would still match 0 <= 0); the patched core also honors
+        // suppressScrollAdjustments to stop both adjustment branches.
+        scrollEndThreshold: resizePhase !== 'idle' ? -1 : TANSTACK_AT_END_THRESHOLD_PX,
+        suppressScrollAdjustments: resizePhase !== 'idle',
         estimateSize: () => estimatedEntrySizeRef.current,
         overscan: resolveTanstackOverscan(),
-        scrollToFn: (offset, options, instance) => {
-            // Expose the new total height before core writes an anchor
-            // correction so the browser does not clamp the offset to the old
-            // height.
-            const sizeElement = sizeContainerRef.current;
-            if (sizeElement) sizeElement.style.height = `${instance.getTotalSize()}px`;
-            elementScroll(offset, options, instance);
+        // During a resize transaction the anchor turn and its previous
+        // assistant must never unmount (a large reflow would otherwise drop
+        // them and flash unrelated rows). The held range is a CONTIGUOUS
+        // window that only ever extends — rows render in normal flow inside
+        // one paddingTop wrapper, so a non-contiguous index set would collapse
+        // the intermediate space.
+        rangeExtractor: (range) => {
+            const held = resizeHeldRangeRef?.current;
+            if (held) {
+                // Monotonic extension via the shared pure helper; the merged
+                // range is written BACK so later frames keep extending.
+                const merged = extendHeldRange(
+                    held,
+                    range.startIndex - range.overscan,
+                    range.endIndex + range.overscan,
+                    range.count,
+                );
+                held.start = merged.start;
+                held.end = merged.end;
+                const arr: number[] = [];
+                for (let index = merged.start; index <= merged.end; index += 1) {
+                    arr.push(index);
+                }
+                return arr;
+            }
+            const start = Math.max(range.startIndex - range.overscan, 0);
+            const end = Math.min(range.endIndex + range.overscan, range.count - 1);
+            const arr: number[] = [];
+            for (let index = start; index <= end; index += 1) {
+                arr.push(index);
+            }
+            return arr;
         },
         getItemKey: (index) => entriesRef.current[index]?.key ?? `index:${index}`,
+        // While a transaction is active, record the real blockSize into the
+        // final-commit map and return the FROZEN cached size so TanStack's own
+        // resizeItem for this measurement is a no-op (rows reflow to the live
+        // width every frame, but writing those into the cache would make
+        // totalSize swing and fight the anchor controller). The conversation-
+        // seam controller batches the real heights itself (one flushSync per
+        // frame) and the finalizer is only a safety net at release.
+        measureElement: (element, entry, instance) => {
+            const index = instance.indexFromElement(element);
+            const key = String(instance.options.getItemKey(index));
+
+            if (phaseRef.current !== 'idle') {
+                const cached = instance.itemSizeCache.get(key);
+                if (cached !== undefined) {
+                    return cached;
+                }
+                const liveHeight = element.offsetHeight;
+                if (liveHeight > 0) {
+                    return liveHeight;
+                }
+                return instance.options.estimateSize(index);
+            }
+
+            const borderBox = entry?.borderBoxSize?.[0];
+            if (borderBox) {
+                return Math.round(borderBox.blockSize);
+            }
+
+            if (!entry) {
+                const cachedSize = instance.itemSizeCache.get(key);
+                if (cachedSize !== undefined) {
+                    return cachedSize;
+                }
+            }
+
+            return element.offsetHeight;
+        },
         // Bottom-anchored chat semantics: prepending older entries above the
         // viewport must not move what the user is reading, and iOS-specific
         // touch/momentum deferral for those adjustments lives in the core.
@@ -1075,6 +1273,11 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
     // app-level auto-follow owns pinning, so skip there too instead of
     // double-writing. (This is an instance field, not a constructor option.)
     tanstackVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => {
+        // During drag/settling, the anchor-based compensation in the settle
+        // timeout below owns scroll stability (it tracks a specific visible
+        // row, like ChatGPT's thread-virtualizer). Disable tanstack's
+        // above-viewport heuristic here to avoid double compensation.
+        if (isResizeSettling()) return false;
         if (instance.isAtEnd(TANSTACK_AT_END_THRESHOLD_PX)) return false;
         const firstVisibleIndex = instance.range?.startIndex;
         return firstVisibleIndex !== undefined && item.index < firstVisibleIndex;
@@ -1082,6 +1285,11 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
 
     React.useEffect(() => {
         if (!isTanstack) return;
+        if (phaseRef.current !== 'idle') {
+            // The resize transaction froze the estimate; updating it mid-drag
+            // would re-value every unmeasured row and fake an anchor mutation.
+            return;
+        }
         const sizes = tanstackVirtualizer.itemSizeCache;
         if (sizes.size >= TANSTACK_ESTIMATE_MIN_SAMPLES) {
             let total = 0;
@@ -1105,6 +1313,102 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
             registerTanstackVirtualizer?.(null);
         };
     }, [isTanstack, registerTanstackVirtualizer, tanstackVirtualizer, virtualizerKey]);
+
+    // Verify after the final commit that the size container height matches the
+    // virtual total (<= 1px) — a cheap guard against cache/height divergence.
+    const verifyFinalizedHeights = React.useCallback((scroller: HTMLElement | null) => {
+        const sizeEl = sizeContainerRef.current;
+        if (!scroller || !sizeEl) {
+            return;
+        }
+        const total = tanstackVirtualizer.getTotalSize();
+        const containerHeight = Number.parseFloat(sizeEl.style.height || '0');
+        if (Number.isFinite(containerHeight) && Math.abs(containerHeight - total) > 1) {
+            recordPerformanceTraceEvent(
+                'ui.message_list.final_height_mismatch',
+                { containerHeight, total },
+                0,
+                undefined,
+            );
+        }
+    }, [tanstackVirtualizer]);
+
+    // Register the single finalization for this transaction. The anchor
+    // controller (useConversationResizeAnchor) committed the real heights
+    // per applied-width frame; this finalizer is a ZERO-CHANGE verifier:
+    // it only re-commits rows whose cached height still differs by > 0.5px
+    // (a safety net for rows that were never mounted during the drag), then
+    // verifies height/cache consistency and records diagnostics. Normally
+    // finalizeChangedRowCount is 0 — the release must not trigger a new
+    // layout-changing commit.
+    const finalizeResize = React.useCallback((signal: AbortSignal) => {
+        return new Promise<void>((resolve) => {
+            if (typeof window === 'undefined') {
+                resolve();
+                return;
+            }
+            const scroller = scrollRef?.current ?? null;
+            requestAnimationFrame(() => {
+                if (signal.aborted) {
+                    resolve();
+                    return;
+                }
+                // READ-ONLY verifier: the anchor controller already committed
+                // the real heights per applied-width frame (the final width
+                // was applied synchronously at pointerup). The finalizer must
+                // NOT re-commit mounted rows — any remaining cache/real
+                // mismatch is a hard error that fails acceptance.
+                const rows = readMountedRowMeasurements(liveContentRef.current, entriesRef.current);
+                const mismatched = rows.filter((row) => {
+                    const cached = tanstackVirtualizer.itemSizeCache.get(entriesRef.current[row.index]?.key ?? row.index);
+                    return typeof cached !== 'number' || Math.abs(cached - row.height) > 0.5;
+                });
+                verifyFinalizedHeights(scroller);
+                recordPerformanceTraceEvent(
+                    'ui.message_list.finalize',
+                    {
+                        changedRowCount: mismatched.length,
+                        mountedRowCount: rows.length,
+                        resizeItemCount: resizeItemCountRef.current,
+                    },
+                    0,
+                    undefined,
+                );
+                // Hard acceptance invariants: zero global measure() calls per
+                // transaction (it would clear the cache).
+                if (measureCountRef.current !== 0) {
+                    recordPerformanceTraceEvent(
+                        'ui.message_list.global_measure',
+                        { count: measureCountRef.current },
+                        0,
+                        undefined,
+                    );
+                }
+                resolve();
+            });
+        });
+    }, [entriesRef, liveContentRef, scrollRef, tanstackVirtualizer, verifyFinalizedHeights]);
+
+    React.useEffect(() => {
+        if (!isTanstack) return;
+        return subscribeResizeInteraction((active) => {
+            if (!active) {
+                // Release/cancel: the transaction state machine runs the
+                // registered finalizer (single final-height commit).
+                return;
+            }
+            const scroller = scrollRef?.current ?? null;
+            if (!scroller || !isListVisibleForResize(scroller)) {
+                // Hidden page or background list: no finalizer is registered,
+                // so the transaction ends on the next frame.
+                return;
+            }
+            measureCountRef.current = 0;
+            resizeItemCountRef.current = 0;
+            registerResizeFinalizer(finalizeResize);
+        });
+    }, [finalizeResize, isTanstack, scrollRef]);
+
 
     const renderEntry = React.useCallback((entry: RenderEntry) => {
         return (
@@ -1135,6 +1439,7 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
                 {renderEntries.map((entry) => (
                     <div
                         key={entry.key}
+                        data-chat-resize-row="true"
                         data-turn-entry={entry.key}
                     >
                         {renderEntry(entry)}
@@ -1156,14 +1461,32 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
         // changes when the virtual window shifts — not per scroll frame — so the
         // layout cost is negligible.
         return (
-            <div ref={sizeContainerRef} className="relative w-full" style={{ height: tanstackVirtualizer.getTotalSize() }}>
-                <div style={{ paddingTop: `${startOffset}px` }}>
+            <div
+                ref={sizeContainerRef}
+                data-vlist-size-container="true"
+                className="relative w-full"
+                style={{
+                    height: tanstackVirtualizer.getTotalSize(),
+                }}
+            >
+                <div ref={liveContentRef} style={{ paddingTop: `${startOffset}px` }}>
                     {virtualItems.map((item) => {
                         const entry = renderEntries[item.index];
                         if (!entry) return null;
+                        // NOTE: no content-visibility on virtual rows. The
+                        // virtualizer's range/size are estimate-derived during
+                        // a resize, so "overscan" here can misjudge physical
+                        // visibility and skip layout of rows that are actually
+                        // on screen (the mixed new-wrap/old-height state).
+                        // Tightening the drag overscan (0) is the controlled
+                        // knob instead; re-introduce content-visibility only
+                        // from a real IntersectionObserver if profiling shows
+                        // it is needed again.
                         return (
                             <div
                                 key={entry.key}
+                                data-chat-virtual-row="true"
+                                data-chat-resize-row="true"
                                 data-index={item.index}
                                 ref={tanstackVirtualizer.measureElement}
                                 data-turn-entry={entry.key}
@@ -1230,23 +1553,29 @@ const StreamingTailContent: React.FC<{
     }), [activeStreamingMessageId, chatRenderMode, entry, liveParts, showTurnChangedFiles, planModeEnabled]);
 
     return (
-        <MessageListEntry
-            entry={liveEntry}
-            onMessageContentChange={onMessageContentChange}
-            getAnimationHandlers={getAnimationHandlers}
-            scrollToBottom={scrollToBottom}
-            stickyUserHeader={stickyUserHeader}
-            sessionIsWorking={sessionIsWorking}
-            defaultActivityExpanded={defaultActivityExpanded}
-            turnUiStates={turnUiStates}
-            onToggleTurnGroup={onToggleTurnGroup}
-            chatRenderMode={chatRenderMode}
-            shouldAnimateUserMessage={shouldAnimateUserMessage}
-            onUserAnimationConsumed={onUserAnimationConsumed}
-            activeStreamingMessageId={activeStreamingMessageId}
-            activeStreamingPhase={activeStreamingPhase}
-            reviewTransferDirection={reviewTransferDirection}
-        />
+        // The streaming tail participates in the same seam anchor model with a
+        // stable key (explicit data-turn-entry, never falling back to the raw
+        // turn id). It has no virtual index; the held range keeps the last
+        // history row mounted and the tail itself is always rendered.
+        <div data-chat-resize-row="true" data-turn-entry={entry.key}>
+            <MessageListEntry
+                entry={liveEntry}
+                onMessageContentChange={onMessageContentChange}
+                getAnimationHandlers={getAnimationHandlers}
+                scrollToBottom={scrollToBottom}
+                stickyUserHeader={stickyUserHeader}
+                sessionIsWorking={sessionIsWorking}
+                defaultActivityExpanded={defaultActivityExpanded}
+                turnUiStates={turnUiStates}
+                onToggleTurnGroup={onToggleTurnGroup}
+                chatRenderMode={chatRenderMode}
+                shouldAnimateUserMessage={shouldAnimateUserMessage}
+                onUserAnimationConsumed={onUserAnimationConsumed}
+                activeStreamingMessageId={activeStreamingMessageId}
+                activeStreamingPhase={activeStreamingPhase}
+                reviewTransferDirection={reviewTransferDirection}
+            />
+        </div>
     );
 };
 
@@ -1264,6 +1593,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
     scrollToBottom,
     scrollRef,
     directory,
+    isPinned = false,
 }, ref) => {
     streamPerfMark('react.message_list_render');
     streamPerfCount('ui.message_list.render');
@@ -1358,6 +1688,29 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
     }), [messages]);
 
     const historyContentRef = React.useRef<HTMLDivElement | null>(null);
+    // Root of every render surface (virtualized history, short list, streaming
+    // tail) — the conversation-boundary anchor queries turn markers here.
+    const resizeRootRef = React.useRef<HTMLDivElement | null>(null);
+    const tanstackVirtualizerRef = React.useRef<TanstackVirtualizerInstance | null>(null);
+    // Held contiguous virtual range for the resize transaction (seeded by the
+    // anchor hook on capture, cleared at idle); the virtualizer's rangeExtractor
+    // merges it monotonically so the anchor turn and its previous assistant
+    // never unmount mid-drag.
+    const resizeHeldRangeRef = React.useRef<{ start: number; end: number } | null>(null);
+    // Authoritative entry key sequence for the layout transaction (refreshed
+    // every render, including the streaming tail).
+    const resizeEntryKeysRef = React.useRef<readonly string[]>([]);
+    const localScrollRef = React.useRef<HTMLDivElement | null>(null);
+    const listScrollRef = scrollRef ?? localScrollRef;
+    useConversationResizeAnchor({
+        scrollerRef: listScrollRef,
+        containerRef: resizeRootRef,
+        isPinned,
+        sessionKey,
+        virtualizerRef: tanstackVirtualizerRef,
+        heldRangeRef: resizeHeldRangeRef,
+        entryKeysRef: resizeEntryKeysRef,
+    });
     const resolveScrollContainer = React.useCallback((): HTMLDivElement | null => {
         if (scrollRef?.current) {
             return scrollRef.current;
@@ -1492,7 +1845,6 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
     const shouldVirtualizeHistory = isMobileSurfaceRuntime()
         || historyEntries.length >= MESSAGE_LIST_VIRTUALIZE_THRESHOLD;
     const historyEngine: HistoryEngine = shouldVirtualizeHistory ? 'tanstack' : 'none';
-    const tanstackVirtualizerRef = React.useRef<TanstackVirtualizerInstance | null>(null);
     const registerTanstackVirtualizer = React.useCallback((virtualizer: TanstackVirtualizerInstance | null) => {
         tanstackVirtualizerRef.current = virtualizer;
     }, []);
@@ -1500,6 +1852,8 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
     const allEntries = React.useMemo(() => {
         return trailingStreamingEntry ? [...historyEntries, trailingStreamingEntry] : historyEntries;
     }, [historyEntries, trailingStreamingEntry]);
+    // Authoritative key sequence for the resize layout transaction.
+    resizeEntryKeysRef.current = allEntries.map((entry) => entry.key);
 
     const stableHistoryContentChange = useStableEvent((reason?: ContentChangeReason) => {
         onMessageContentChange(reason);
@@ -1819,7 +2173,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
     const disableFadeIn = false;
 
     return (
-        <div>
+        <div ref={resizeRootRef}>
                 <FadeInDisabledProvider disabled={disableFadeIn}>
                     <div className="relative w-full">
                         {/* Virtualized history rows unmount/remount during scroll;
@@ -1835,6 +2189,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
                                 scrollRef={scrollRef}
                                 registerTanstackVirtualizer={registerTanstackVirtualizer}
                                 virtualizerKey={sessionKey}
+                                resizeHeldRangeRef={resizeHeldRangeRef}
                                 onMessageContentChange={stableHistoryContentChange}
                                 getAnimationHandlers={stableGetAnimationHandlers}
                                 scrollToBottom={stableScrollToBottom}

--- a/packages/ui/src/components/chat/components/TurnAssistantBlock.tsx
+++ b/packages/ui/src/components/chat/components/TurnAssistantBlock.tsx
@@ -9,7 +9,7 @@ interface TurnAssistantBlockProps {
 
 const TurnAssistantBlock: React.FC<TurnAssistantBlockProps> = ({ assistantMessages, renderMessage }) => {
     return (
-        <div className="relative z-0">
+        <div className="relative z-0" data-chat-assistant-block="true">
             {assistantMessages.map((message) => renderMessage(message))}
         </div>
     );

--- a/packages/ui/src/components/chat/components/TurnItem.tsx
+++ b/packages/ui/src/components/chat/components/TurnItem.tsx
@@ -17,6 +17,11 @@ const TurnItem: React.FC<TurnItemProps> = ({ turn, stickyUserHeader = true, rend
             data-turn-id={turn.turnId}
             data-scroll-spy-id={turn.turnId}
         >
+            {/* Document-flow start of the turn. position:sticky never changes
+                layout position, but this zero-size marker is a stable sibling
+                of both the sticky header and the assistant block — its top is
+                the turn's true flow start, unaffected by the sticky offset. */}
+            <div data-chat-turn-flow-start="true" aria-hidden="true" />
             {stickyUserHeader ? (
                 <div className="sticky top-0 z-20 relative bg-[var(--surface-background)] [overflow-anchor:none]">
                     <div className="relative z-10">

--- a/packages/ui/src/components/chat/hooks/useConversationResizeAnchor.ts
+++ b/packages/ui/src/components/chat/hooks/useConversationResizeAnchor.ts
@@ -1,0 +1,533 @@
+// DOM controller for the conversation-seam resize anchor (frame-delta model).
+//
+// The controller runs INSIDE the same rAF that applies the panel width
+// (usePanelResize -> notifyResizeFrame -> registerResizeFrameParticipant), so
+// the width write, the real-height read, the one flushSync commit and the one
+// scrollTop write all happen before the browser paints.
+//
+// The anchor model is a PER-FRAME delta against the last COMMITTED frame:
+//   anchorDelta = next.anchorDocumentTop - previous.anchorDocumentTop
+//   target      = currentScrollTop + anchorDelta
+// The first frame's baseline is built from the REAL DOM (flow-start document
+// top + mounted-row real heights) — never from the virtualizer cache or a
+// fixed estimate. Because the delta is relative to the previous committed
+// frame, a +10 growth writes +10 once and the next unchanged frame writes 0;
+// there is NO capture-time accumulated baseline to drift.
+//
+// Release is ONLY user intent (wheel/touch/key), a session switch, the anchor
+// key leaving the authoritative entry list, or the composer covering the
+// CAPTURED question top. Reaching the scroll bounds CLAMPS the target and
+// keeps the transaction active ('clamped') — a reverse drag resumes the same
+// anchor automatically.
+import React from 'react';
+import { flushSync } from 'react-dom';
+import {
+    getCurrentResizeTransactionId,
+    getResizeInteractionPhase,
+    registerResizeFrameParticipant,
+    registerResizeTransactionStartParticipant,
+    subscribeResizeInteraction,
+    type ResizeFrameParticipant,
+} from '@/lib/resizeInteraction';
+import { recordPerformanceTraceEvent } from '@/stores/utils/performanceTrace';
+import {
+    clampScrollTarget,
+    computeAnchorDelta,
+    computeTargetScrollTop,
+    diffMountedRows,
+    initHeldRange,
+    type MountedRowInfo,
+    type ResizeFrameLayout,
+    type ResizeLayoutTransaction,
+} from '../lib/conversationResizeLayout';
+import {
+    isAtBottom,
+    selectTurnSeam,
+    shouldReleaseByComposer,
+    type ConversationSeamAnchor,
+    type EffectiveViewport,
+    type SeamCandidate,
+} from '../lib/conversationResizeAnchor';
+
+type AnchorMode = 'none' | 'bottom' | 'seam';
+
+interface SeamElements {
+    flowStart: HTMLElement | null;
+    userBubble: HTMLElement | null;
+    previousAssistant: HTMLElement | null;
+}
+
+interface CandidateWithRefs extends SeamCandidate {
+    flowStartEl: HTMLElement;
+    userBubbleEl: HTMLElement | null;
+    previousAssistantEl: HTMLElement | null;
+}
+
+/** Structural slice of the virtualizer the seam controller needs. */
+interface SeamVirtualizer {
+    itemSizeCache: Map<unknown, number>;
+    resizeItem: (index: number, height: number) => void;
+}
+
+export interface UseConversationResizeAnchorOptions {
+    /** The chat scroll container ([data-message-scroll-container]). */
+    scrollerRef: React.RefObject<HTMLDivElement | null>;
+    /** The MessageList root element used to query turn markers + rows. */
+    containerRef: React.RefObject<HTMLDivElement | null>;
+    /** True while auto-follow is pinned (real bottom-following). */
+    isPinned: boolean;
+    /** Session key — a change releases any active anchor. */
+    sessionKey: string | null;
+    /** The TanStack virtualizer (may be null for short lists). */
+    virtualizerRef: React.RefObject<SeamVirtualizer | null>;
+    /** Held contiguous virtual range for the transaction (unconditionally
+     *  seeded on capture, cleared at idle) — the list's rangeExtractor merges
+     *  it monotonically. */
+    heldRangeRef: React.RefObject<{ start: number; end: number } | null>;
+    /** The AUTHORITATIVE full entry key sequence (render entries, including
+     *  any streaming tail) — refreshed every render. */
+    entryKeysRef: React.RefObject<readonly string[]>;
+}
+
+const RESIZE_BOTTOM_THRESHOLD_PX = 24;
+const HEIGHT_CHANGE_TOLERANCE_PX = 0.5;
+const SCROLL_WRITE_TOLERANCE_PX = 0.25;
+
+export const useConversationResizeAnchor = ({
+    scrollerRef,
+    containerRef,
+    isPinned,
+    sessionKey,
+    virtualizerRef,
+    heldRangeRef,
+    entryKeysRef,
+}: UseConversationResizeAnchorOptions): void => {
+    const modeRef = React.useRef<AnchorMode>('none');
+    const txRef = React.useRef<ResizeLayoutTransaction | null>(null);
+    const seamRef = React.useRef<ConversationSeamAnchor | null>(null);
+    const seamElementsRef = React.useRef<SeamElements>({ flowStart: null, userBubble: null, previousAssistant: null });
+    const bottomDistanceRef = React.useRef(0);
+    const scrollWriteCountRef = React.useRef(0);
+    const isPinnedRef = React.useRef(isPinned);
+    isPinnedRef.current = isPinned;
+    const sessionKeyRef = React.useRef(sessionKey);
+    sessionKeyRef.current = sessionKey;
+    const containerRefRef = React.useRef(containerRef);
+    containerRefRef.current = containerRef;
+    const virtualizerRefRef = React.useRef(virtualizerRef);
+    virtualizerRefRef.current = virtualizerRef;
+    const heldRangeRefRef = React.useRef(heldRangeRef);
+    heldRangeRefRef.current = heldRangeRef;
+    const entryKeysRefRef = React.useRef(entryKeysRef);
+    entryKeysRefRef.current = entryKeysRef;
+
+    const resizePhase = React.useSyncExternalStore(
+        subscribeResizeInteraction,
+        getResizeInteractionPhase,
+        getResizeInteractionPhase,
+    );
+
+    const readEffectiveViewport = React.useCallback((scroller: HTMLElement): EffectiveViewport => {
+        const scrollerRect = scroller.getBoundingClientRect();
+        const composer = document.querySelector<HTMLElement>('[data-chat-composer-occlusion]');
+        const composerTop = composer ? composer.getBoundingClientRect().top : null;
+        const bottom = composerTop !== null && composerTop < scrollerRect.bottom
+            ? composerTop
+            : scrollerRect.bottom;
+        return { top: scrollerRect.top, bottom };
+    }, []);
+
+    /** Document top of an element: flowStartRect.top - scrollerRect.top + scrollTop. */
+    const documentTopOf = React.useCallback((element: HTMLElement, scroller: HTMLElement): number => {
+        const rect = element.getBoundingClientRect();
+        const scrollerRect = scroller.getBoundingClientRect();
+        return rect.top - scrollerRect.top + scroller.scrollTop;
+    }, []);
+
+    const readCandidates = React.useCallback((): CandidateWithRefs[] => {
+        const container = containerRefRef.current?.current;
+        if (!container) {
+            return [];
+        }
+        const flowStarts = container.querySelectorAll<HTMLElement>('[data-chat-turn-flow-start]');
+        const candidates: CandidateWithRefs[] = [];
+        let previousAssistantEl: HTMLElement | null = null;
+        for (const flowStart of Array.from(flowStarts)) {
+            const turnRoot = flowStart.parentElement;
+            if (!turnRoot) {
+                continue;
+            }
+            const key = turnRoot.closest<HTMLElement>('[data-turn-entry]')?.getAttribute('data-turn-entry')
+                ?? turnRoot.getAttribute('data-turn-id')
+                ?? '';
+            if (!key) {
+                continue;
+            }
+            const rowEl = turnRoot.closest<HTMLElement>('[data-chat-resize-row]');
+            const rowIndex = rowEl ? Number(rowEl.getAttribute('data-index') ?? -1) : 0;
+            const flowTop = flowStart.getBoundingClientRect().top;
+            const bubble = turnRoot.querySelector<HTMLElement>('[data-chat-user-bubble]');
+            const bubbleRect = bubble ? {
+                top: bubble.getBoundingClientRect().top,
+                bottom: bubble.getBoundingClientRect().bottom,
+            } : undefined;
+            const previousRect = previousAssistantEl ? {
+                top: previousAssistantEl.getBoundingClientRect().top,
+                bottom: previousAssistantEl.getBoundingClientRect().bottom,
+            } : undefined;
+            candidates.push({
+                key,
+                rowIndex,
+                flowTop,
+                userBubble: bubbleRect,
+                previousAssistant: previousRect,
+                flowStartEl: flowStart,
+                userBubbleEl: bubble ?? null,
+                previousAssistantEl,
+            });
+            const assistant = turnRoot.querySelector<HTMLElement>('[data-chat-assistant-block]');
+            previousAssistantEl = assistant ?? previousAssistantEl;
+        }
+        return candidates;
+    }, []);
+
+    /** Build the first frame layout from the REAL DOM (never cache/estimate). */
+    const readFrameLayout = React.useCallback((
+        scroller: HTMLElement,
+        anchorKey: string,
+        flowStartEl: HTMLElement | null,
+    ): ResizeFrameLayout => {
+        const container = containerRefRef.current?.current;
+        const mountedRows = new Map<string, MountedRowInfo>();
+        let mountedStart: number | null = null;
+        let mountedEnd: number | null = null;
+        if (container) {
+            for (const rowEl of Array.from(container.querySelectorAll<HTMLElement>('[data-chat-resize-row]'))) {
+                const key = rowEl.getAttribute('data-turn-entry');
+                if (!key) {
+                    continue;
+                }
+                const rawIndex = rowEl.getAttribute('data-index');
+                const virtualIndex = rawIndex !== null && rawIndex !== '' && Number.isFinite(Number(rawIndex))
+                    ? Number(rawIndex)
+                    : null;
+                const height = Math.round(rowEl.offsetHeight);
+                if (height > 0) {
+                    mountedRows.set(key, { key, virtualIndex, height });
+                    if (virtualIndex !== null) {
+                        mountedStart = mountedStart === null ? virtualIndex : Math.min(mountedStart, virtualIndex);
+                        mountedEnd = mountedEnd === null ? virtualIndex : Math.max(mountedEnd, virtualIndex);
+                    }
+                }
+            }
+        }
+        const anchorDocumentTop = flowStartEl
+            ? documentTopOf(flowStartEl, scroller)
+            : 0;
+        return { anchorKey, anchorDocumentTop, mountedRows, mountedStart, mountedEnd };
+    }, [documentTopOf]);
+
+    const capture = React.useCallback(() => {
+        const scroller = scrollerRef.current;
+        if (!scroller) {
+            modeRef.current = 'none';
+            return;
+        }
+        const viewport = readEffectiveViewport(scroller);
+        const distanceFromBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+        if (isPinnedRef.current && isAtBottom(distanceFromBottom, RESIZE_BOTTOM_THRESHOLD_PX)) {
+            modeRef.current = 'bottom';
+            bottomDistanceRef.current = Math.max(0, distanceFromBottom);
+            txRef.current = null;
+            seamRef.current = null;
+            recordPerformanceTraceEvent('ui.message_list.anchor_capture', { mode: 'bottom', distanceFromBottom }, 0, undefined);
+            return;
+        }
+        const candidates = readCandidates();
+        const selected = selectTurnSeam(candidates, viewport);
+        if (!selected) {
+            modeRef.current = 'none';
+            txRef.current = null;
+            seamRef.current = null;
+            recordPerformanceTraceEvent('ui.message_list.anchor_capture', { mode: 'none', distanceFromBottom }, 0, undefined);
+            return;
+        }
+        const matched = candidates.find((c) => c.key === selected.key) ?? null;
+        seamElementsRef.current = {
+            flowStart: matched?.flowStartEl ?? null,
+            userBubble: matched?.userBubbleEl ?? null,
+            previousAssistant: matched?.previousAssistantEl ?? null,
+        };
+        seamRef.current = selected;
+        const anchorIndex = matched?.rowIndex ?? null;
+        // First frame layout from the REAL DOM (the baseline).
+        const firstLayout = readFrameLayout(scroller, selected.key, matched?.flowStartEl ?? null);
+        txRef.current = {
+            transactionId: getCurrentResizeTransactionId() ?? 0,
+            anchorKey: selected.key,
+            anchorVirtualIndex: anchorIndex,
+            capturedViewportTop: selected.capturedFlowViewportTop,
+            previousLayout: firstLayout,
+            state: 'active',
+        };
+        // Held range: UNCONDITIONALLY seed = mounted indexes ∪ anchor window.
+        const mountedIndexes = Array.from(firstLayout.mountedRows.values())
+            .map((r) => r.virtualIndex)
+            .filter((i): i is number => i !== null);
+        if (heldRangeRefRef.current) {
+            heldRangeRefRef.current.current = initHeldRange(mountedIndexes, anchorIndex);
+        }
+        modeRef.current = 'seam';
+        recordPerformanceTraceEvent(
+            'ui.message_list.anchor_capture',
+            {
+                mode: 'seam',
+                key: selected.key,
+                index: anchorIndex ?? undefined,
+                flowTop: selected.capturedFlowViewportTop,
+                bubbleOffsetFromFlow: selected.bubbleOffsetFromFlow,
+                previousAssistantGap: selected.previousAssistantGap ?? undefined,
+                heldStart: heldRangeRefRef.current?.current?.start,
+                heldEnd: heldRangeRefRef.current?.current?.end,
+            },
+            0,
+            undefined,
+        );
+    }, [readCandidates, readEffectiveViewport, readFrameLayout, scrollerRef]);
+
+    const releaseToNone = React.useCallback((reason: string) => {
+        modeRef.current = 'none';
+        txRef.current = null;
+        seamRef.current = null;
+        seamElementsRef.current = { flowStart: null, userBubble: null, previousAssistant: null };
+        if (heldRangeRefRef.current) {
+            heldRangeRefRef.current.current = null;
+        }
+        recordPerformanceTraceEvent('ui.message_list.anchor_release', { reason }, 0, undefined);
+    }, []);
+
+    const writeScrollTop = React.useCallback((target: number) => {
+        const scroller = scrollerRef.current;
+        if (!scroller) {
+            return;
+        }
+        if (Math.abs(scroller.scrollTop - target) <= SCROLL_WRITE_TOLERANCE_PX) {
+            return;
+        }
+        scroller.scrollTop = target;
+        scrollWriteCountRef.current += 1;
+    }, [scrollerRef]);
+
+    // The SAME-FRAME entry point: invoked from usePanelResize's rAF right
+    // after the width write, before paint. Delta is relative to the last
+    // COMMITTED frame; frames from stale transactions are ignored.
+    const onResizeWidthFrame: ResizeFrameParticipant = React.useCallback((frame) => {
+        const scroller = scrollerRef.current;
+        const container = containerRefRef.current?.current;
+        if (!scroller || !container) {
+            return;
+        }
+        if (modeRef.current === 'none') {
+            return; // Zero-write invariant.
+        }
+        if (modeRef.current === 'bottom') {
+            const target = scroller.scrollHeight - scroller.clientHeight - bottomDistanceRef.current;
+            writeScrollTop(target);
+            return;
+        }
+        const tx = txRef.current;
+        if (!tx || tx.transactionId !== frame.transactionId) {
+            return; // Stale transaction frame.
+        }
+        // Dedupe by frameSequence (never by width — two panels can share a
+        // width value and would otherwise lose frames).
+        if (tx.lastFrameSequence !== undefined && frame.frameSequence <= tx.lastFrameSequence) {
+            return; // Already processed this frame.
+        }
+        tx.lastFrameSequence = frame.frameSequence;
+
+        // Release checks INDEPENDENT of the uncorrected geometry.
+        const composer = document.querySelector<HTMLElement>('[data-chat-composer-occlusion]');
+        const composerTop = composer ? composer.getBoundingClientRect().top : null;
+        const seam = seamRef.current;
+        if (seam) {
+            const capturedBubbleTop = seam.capturedFlowViewportTop + seam.bubbleOffsetFromFlow;
+            if (shouldReleaseByComposer(capturedBubbleTop, composerTop)) {
+                releaseToNone('composer-occlusion');
+                return;
+            }
+        }
+        const authoritativeKeys = entryKeysRefRef.current?.current ?? [];
+        if (!authoritativeKeys.includes(tx.anchorKey)) {
+            releaseToNone('anchor-key-removed');
+            return;
+        }
+
+        // 1. Real mounted-row heights of THIS frame.
+        const nextLayout = readFrameLayout(scroller, tx.anchorKey, seamElementsRef.current.flowStart);
+        // 2. Compare with the previous committed frame; no real change -> zero
+        //    commit, zero flushSync, zero scrollTop write.
+        const changed = diffMountedRows(tx.previousLayout, nextLayout, HEIGHT_CHANGE_TOLERANCE_PX);
+        const changedRealRowCount = changed.length;
+        let cacheCommitRowCount = 0;
+        let flushSyncDelta = 0;
+        let anchorDelta = 0;
+        if (changedRealRowCount > 0) {
+            // 3. Commit only rows that changed AND belong to the virtual history.
+            const virtualizer = virtualizerRefRef.current?.current;
+            if (virtualizer) {
+                const changedSet = new Set(changed);
+                const changedRows: Array<{ index: number; height: number }> = [];
+                for (const info of nextLayout.mountedRows.values()) {
+                    if (info.virtualIndex !== null && changedSet.has(info.key)) {
+                        changedRows.push({ index: info.virtualIndex, height: info.height });
+                    }
+                }
+                if (changedRows.length > 0) {
+                    flushSyncDelta = 1;
+                    cacheCommitRowCount = changedRows.length;
+                    flushSync(() => {
+                        for (const row of changedRows) {
+                            virtualizer.resizeItem(row.index, row.height);
+                        }
+                    });
+                }
+            }
+            // 4. After the commit, re-resolve the same stable key's flow start
+            //    and read the FINAL anchor document top.
+            const flowStart = seamElementsRef.current.flowStart;
+            const nextDocumentTop = flowStart
+                ? documentTopOf(flowStart, scroller)
+                : nextLayout.anchorDocumentTop;
+            // 5. Delta vs the previous committed frame; clamp at the scroll
+            //    bounds (state 'clamped', NOT a release).
+            anchorDelta = computeAnchorDelta({ ...nextLayout, anchorDocumentTop: nextDocumentTop }, tx.previousLayout);
+            if (Math.abs(anchorDelta) > SCROLL_WRITE_TOLERANCE_PX) {
+                const { target, clamped } = clampScrollTarget(
+                    computeTargetScrollTop(scroller.scrollTop, anchorDelta),
+                    scroller.scrollHeight,
+                    scroller.clientHeight,
+                );
+                if (clamped) {
+                    tx.state = 'clamped';
+                } else if (tx.state === 'clamped') {
+                    tx.state = 'active'; // Reverse drag resumed into the feasible area.
+                }
+                writeScrollTop(target);
+            }
+            // 6. Commit this frame as the new baseline.
+            tx.previousLayout = { ...nextLayout, anchorDocumentTop: nextDocumentTop };
+        }
+        // Per-frame diagnostics (acceptance hard invariants).
+        recordPerformanceTraceEvent(
+            'ui.message_list.anchor_frame',
+            {
+                anchorMode: 'seam',
+                anchorKey: tx.anchorKey,
+                changedRealRowCount,
+                cacheCommitRowCount,
+                anchorDelta: Math.round(anchorDelta * 10) / 10,
+                flushSyncDelta,
+                clamped: tx.state === 'clamped',
+                heldStart: heldRangeRefRef.current?.current?.start,
+                heldEnd: heldRangeRefRef.current?.current?.end,
+                mountedRowCount: nextLayout.mountedRows.size,
+            },
+            0,
+            undefined,
+        );
+    }, [documentTopOf, entryKeysRefRef, readFrameLayout, releaseToNone, scrollerRef, writeScrollTop]);
+
+    // Same-frame participant registration (the ONLY scroll-adjustment entry).
+    React.useEffect(() => {
+        const unsubscribe = registerResizeFrameParticipant(onResizeWidthFrame);
+        return unsubscribe;
+    }, [onResizeWidthFrame]);
+
+    // Synchronous transaction-start participant: capture runs at BEGIN (before
+    // the first width frame of a pointer drag OR a programmatic animation),
+    // so a quick open/close toggle's first animated width lands on an
+    // already-anchored baseline. Joining sources do not re-fire.
+    React.useEffect(() => {
+        const unsubscribe = registerResizeTransactionStartParticipant(() => {
+            scrollWriteCountRef.current = 0;
+            capture();
+        });
+        return unsubscribe;
+    }, [capture]);
+
+    // Transaction lifecycle driven by the PHASE: only the IDLE edge resets
+    // state (capture itself is handled by the synchronous start participant).
+    const lastPhaseRef = React.useRef(resizePhase);
+    React.useLayoutEffect(() => {
+        lastPhaseRef.current = resizePhase;
+        if (resizePhase === 'idle') {
+            modeRef.current = 'none';
+            txRef.current = null;
+            seamRef.current = null;
+            seamElementsRef.current = { flowStart: null, userBubble: null, previousAssistant: null };
+            if (heldRangeRefRef.current) {
+                heldRangeRefRef.current.current = null;
+            }
+        }
+    }, [resizePhase]);
+
+    // Session switch releases any active anchor.
+    const lastSessionKeyRef = React.useRef(sessionKey);
+    React.useEffect(() => {
+        if (lastSessionKeyRef.current !== sessionKey) {
+            lastSessionKeyRef.current = sessionKey;
+            if (resizePhase !== 'idle' && modeRef.current !== 'none') {
+                releaseToNone('session-switch');
+            }
+        }
+    }, [releaseToNone, resizePhase, sessionKey]);
+
+    // User intent (wheel/touch/key) releases the anchor; plain scroll events
+    // never infer user intent (they only confirm programmatic writes).
+    React.useEffect(() => {
+        const scroller = scrollerRef.current;
+        if (!scroller) {
+            return;
+        }
+        const handleUserIntent = () => {
+            if (resizePhase !== 'idle' && modeRef.current !== 'none') {
+                releaseToNone('user-intent');
+            }
+        };
+        scroller.addEventListener('wheel', handleUserIntent, { passive: true });
+        scroller.addEventListener('touchstart', handleUserIntent, { passive: true });
+        scroller.addEventListener('keydown', handleUserIntent);
+        return () => {
+            scroller.removeEventListener('wheel', handleUserIntent);
+            scroller.removeEventListener('touchstart', handleUserIntent);
+            scroller.removeEventListener('keydown', handleUserIntent);
+        };
+    }, [releaseToNone, resizePhase, scrollerRef]);
+
+    // Post-commit diagnostics: anchor DOM presence (re-resolve by key; a
+    // missing DOM while the key still exists is a hard error that must NOT
+    // switch turns or degrade the anchor).
+    React.useEffect(() => {
+        if (resizePhase === 'idle' || modeRef.current !== 'seam') {
+            return;
+        }
+        const flowStart = seamElementsRef.current.flowStart;
+        if (flowStart && !flowStart.isConnected) {
+            const container = containerRefRef.current?.current;
+            const tx = txRef.current;
+            if (container && tx) {
+                const re = container.querySelector<HTMLElement>(`[data-chat-resize-row][data-turn-entry="${CSS.escape(tx.anchorKey)}"]`)
+                    ?? container.querySelector<HTMLElement>(`[data-turn-id="${CSS.escape(tx.anchorKey)}"]`);
+                if (re) {
+                    seamElementsRef.current.flowStart = re.querySelector('[data-chat-turn-flow-start]') ?? null;
+                    seamElementsRef.current.userBubble = re.querySelector('[data-chat-user-bubble]') ?? null;
+                    seamElementsRef.current.previousAssistant = re.querySelector('[data-chat-assistant-block]') ?? null;
+                    recordPerformanceTraceEvent('ui.message_list.anchor_dom_missing', { key: tx.anchorKey, recovered: true }, 0, undefined);
+                } else {
+                    recordPerformanceTraceEvent('ui.message_list.anchor_dom_missing', { key: tx.anchorKey, recovered: false }, 0, undefined);
+                }
+            }
+        }
+    }, [resizePhase]);
+};

--- a/packages/ui/src/components/chat/hooks/useConversationResizeAnchor.ts
+++ b/packages/ui/src/components/chat/hooks/useConversationResizeAnchor.ts
@@ -70,7 +70,7 @@ interface SeamVirtualizer {
 }
 
 export interface UseConversationResizeAnchorOptions {
-    /** The chat scroll container ([data-message-scroll-container]). */
+    /** The chat scroll container element. */
     scrollerRef: React.RefObject<HTMLDivElement | null>;
     /** The MessageList root element used to query turn markers + rows. */
     containerRef: React.RefObject<HTMLDivElement | null>;

--- a/packages/ui/src/components/chat/lib/conversationResizeAnchor.test.ts
+++ b/packages/ui/src/components/chat/lib/conversationResizeAnchor.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    computeSeamTarget,
+    isAtBottom,
+    isAtScrollBounds,
+    isFullyVisible,
+    seamDiagnostics,
+    selectTurnSeam,
+    shouldReleaseByComposer,
+    type ConversationSeamAnchor,
+    type EffectiveViewport,
+    type SeamCandidate,
+} from './conversationResizeAnchor';
+
+// The review scenario: viewport 48.7..780.7; Decision 73's giant turn hangs in
+// from above (flowTop far above the viewport) while Decision 74's flow start is
+// the session seam the user is reading.
+const viewport: EffectiveViewport = { top: 48.7, bottom: 780.7 };
+
+const candidate73: SeamCandidate = {
+    key: 'turn-73',
+    rowIndex: 72,
+    flowTop: -1780.1,
+    userBubble: { top: -100, bottom: 400 },
+};
+
+const candidate74: SeamCandidate = {
+    key: 'turn-74',
+    rowIndex: 73,
+    flowTop: 575.9,
+    userBubble: { top: 585, bottom: 700 },
+    previousAssistant: { top: 300, bottom: 555 },
+};
+
+describe('conversationResizeAnchor selectTurnSeam', () => {
+    test('chooses Decision 74, not the giant turn-73 hanging in from above', () => {
+        const result = selectTurnSeam([candidate73, candidate74], viewport);
+        expect(result).not.toBeNull();
+        expect(result!.key).toBe('turn-74');
+        expect(result!.capturedFlowViewportTop).toBe(575.9);
+    });
+
+    test('bubbleOffsetFromFlow and previousAssistantGap are captured', () => {
+        const result = selectTurnSeam([candidate74], viewport);
+        expect(result).not.toBeNull();
+        expect(Math.abs(result!.bubbleOffsetFromFlow - (585 - 575.9)) < 0.001).toBe(true);
+        expect(Math.abs(result!.previousAssistantGap! - (575.9 - 555)) < 0.001).toBe(true);
+    });
+
+    test('qualification requires bubble OR previous assistant fully visible', () => {
+        // Bubble bottom overflows the viewport AND previous assistant is
+        // undefined -> not qualified.
+        const unqualified = selectTurnSeam([
+            { key: 'turn-x', rowIndex: 0, flowTop: 100, userBubble: { top: 100, bottom: 900 } },
+        ], viewport);
+        expect(unqualified).toBeNull();
+    });
+
+    test('null when the turn top is above the viewport (long-question mid-scroll)', () => {
+        const result = selectTurnSeam([
+            { key: 'turn-x', rowIndex: 0, flowTop: -500, userBubble: { top: -500, bottom: 300 } },
+        ], viewport);
+        expect(result).toBeNull();
+    });
+
+    test('empty candidates -> null (never bottom fallback)', () => {
+        expect(selectTurnSeam([], viewport)).toBeNull();
+    });
+});
+
+describe('conversationResizeAnchor computeSeamTarget (continuous-frame)', () => {
+    const anchor: ConversationSeamAnchor = {
+        key: 'turn-74',
+        rowIndex: 73,
+        capturedFlowViewportTop: 575.9,
+        bubbleOffsetFromFlow: 9.1,
+        previousAssistantGap: 20.9,
+    };
+
+    test('first frame: current scrollTop + current flow drift', () => {
+        // Before any write: scrollTop 500, flowTop drifted +10 (content grew).
+        expect(computeSeamTarget(anchor, 500, 585.9)).toBe(510);
+    });
+
+    test('after the write the flow top reflects it; no new growth -> delta 0', () => {
+        // The write moved scrollTop 500 -> 510, so the flow start's viewport
+        // top came back to the captured value; the NEXT frame recomputes from
+        // the CURRENT scrollTop and sees zero drift -> zero write.
+        expect(computeSeamTarget(anchor, 510, 575.9)).toBe(510);
+    });
+
+    test('a second growth of +5 from the settled state gives +5, never +15', () => {
+        // Settled: scrollTop 510, flowTop back at 575.9. New growth +5 ->
+        // flowTop 580.9. Target = 510 + 5 = 515 (NOT 500 + 15).
+        expect(computeSeamTarget(anchor, 510, 580.9)).toBe(515);
+    });
+
+    test('no drift -> currentScrollTop (zero write)', () => {
+        expect(computeSeamTarget(anchor, 510, 575.9)).toBe(510);
+    });
+
+    test('negative drift clamps at 0', () => {
+        expect(computeSeamTarget(anchor, 10, 500)).toBe(0);
+    });
+});
+
+describe('conversationResizeAnchor seamDiagnostics', () => {
+    test('seam gap preserved and overlap always 0', () => {
+        const d1 = seamDiagnostics(585, 555);
+        expect(d1.seamGap).toBe(30);
+        expect(d1.overlapDepth).toBe(0);
+        // Overlap: previous assistant bottom below bubble top.
+        const d2 = seamDiagnostics(555, 585);
+        expect(d2.seamGap).toBe(-30);
+        expect(d2.overlapDepth).toBe(30);
+    });
+
+    test('null inputs -> null gap, zero overlap', () => {
+        expect(seamDiagnostics(null, 555)).toEqual({ seamGap: null, overlapDepth: 0 });
+        expect(seamDiagnostics(585, null)).toEqual({ seamGap: null, overlapDepth: 0 });
+    });
+});
+
+describe('conversationResizeAnchor isFullyVisible / isAtBottom', () => {
+    test('fully visible within tolerance', () => {
+        expect(isFullyVisible({ top: 49, bottom: 780 }, viewport)).toBe(true);
+        expect(isFullyVisible({ top: 48.3, bottom: 780.2 }, viewport)).toBe(true);
+        expect(isFullyVisible({ top: 48, bottom: 700 }, viewport)).toBe(false);
+        expect(isFullyVisible({ top: 100, bottom: 781.3 }, viewport)).toBe(false);
+    });
+
+    test('bottom mode boundary at 24px', () => {
+        expect(isAtBottom(23.9)).toBe(true);
+        expect(isAtBottom(24)).toBe(true);
+        expect(isAtBottom(24.1)).toBe(false);
+    });
+});
+
+describe('conversationResizeAnchor release conditions', () => {
+    const anchor: ConversationSeamAnchor = {
+        key: 'turn-74',
+        rowIndex: 73,
+        capturedFlowViewportTop: 575.9,
+        bubbleOffsetFromFlow: 9.1,
+        previousAssistantGap: 20.9,
+    };
+
+    test('composer covering the CAPTURED question top releases', () => {
+        const capturedBubbleTop = anchor.capturedFlowViewportTop + anchor.bubbleOffsetFromFlow;
+        // Composer top (y) at/above the question top covers it.
+        expect(shouldReleaseByComposer(capturedBubbleTop, capturedBubbleTop)).toBe(true);
+        expect(shouldReleaseByComposer(capturedBubbleTop, capturedBubbleTop - 10)).toBe(true);
+        // Composer top below the question top -> not covering.
+        expect(shouldReleaseByComposer(capturedBubbleTop, capturedBubbleTop + 10)).toBe(false);
+    });
+
+    test('composer above the flow start but below the question top does not release', () => {
+        // flow start 575.9, bubble top 585; composer top at 590 sits below the
+        // question box -> no release even though the flow start is covered.
+        expect(shouldReleaseByComposer(585, 590)).toBe(false);
+    });
+
+    test('document scroll bounds release only at the very top/bottom', () => {
+        expect(isAtScrollBounds(0, 1000, 500)).toBe(true);
+        expect(isAtScrollBounds(1, 1000, 500)).toBe(true);
+        expect(isAtScrollBounds(499, 1000, 500)).toBe(true); // 1px from bottom
+        expect(isAtScrollBounds(500, 1000, 500)).toBe(true); // exactly max
+        expect(isAtScrollBounds(300, 1000, 500)).toBe(false);
+    });
+});

--- a/packages/ui/src/components/chat/lib/conversationResizeAnchor.ts
+++ b/packages/ui/src/components/chat/lib/conversationResizeAnchor.ts
@@ -1,0 +1,142 @@
+// Pure "conversation seam" anchor model for the sidebar-resize controller.
+//
+// DOM-free. The controller anchors the NORMAL-FLOW start of the first user
+// turn whose flow top sits inside the effective viewport (scroller top ..
+// min(scroller bottom, composer top)) AND whose own user bubble OR the
+// previous turn's assistant block is fully visible. The user bubble and the
+// previous assistant block are QUALIFICATION + seam-diagnostic surfaces only —
+// the anchor coordinate is always the turn's document-flow start
+// ([data-chat-turn-flow-start], never the sticky bubble).
+//
+// The per-frame target uses the CURRENT scroll position (continuous-frame
+// correct): after a write, the next frame's flow-top already reflects it, so
+// recomputing from a captured initial scrollTop would double/under-compensate.
+//   target = currentScrollTop + (currentFlowTop - capturedFlowViewportTop)
+// Once the correction lands and nothing grows, currentFlowTop ===
+// capturedFlowViewportTop -> delta 0 -> zero writes.
+
+export interface SeamCandidate {
+    /** Stable render-entry key (turn key). */
+    key: string;
+    /** Virtualizer row index (0 for non-virtualized surfaces). */
+    rowIndex: number;
+    /** Document-flow top of the turn (data-chat-turn-flow-start), viewport px. */
+    flowTop: number;
+    /** User question bubble rect (may be undefined for empty user messages). */
+    userBubble?: { top: number; bottom: number };
+    /** PREVIOUS turn's assistant block rect (undefined for the first turn). */
+    previousAssistant?: { top: number; bottom: number };
+}
+
+export interface ConversationSeamAnchor {
+    key: string;
+    rowIndex: number;
+    /** Captured viewport top of the turn's document-flow start. */
+    capturedFlowViewportTop: number;
+    /** bubble.top - flowStart.top at capture (sticky-independent offset). */
+    bubbleOffsetFromFlow: number;
+    /** flowStart.top - previousAssistant.bottom at capture (the seam gap). */
+    previousAssistantGap: number | null;
+}
+
+export interface EffectiveViewport {
+    top: number;
+    bottom: number;
+}
+
+const EDGE_TOLERANCE_PX = 0.5;
+
+export const isFullyVisible = (
+    rect: { top: number; bottom: number },
+    viewport: EffectiveViewport,
+    tolerance = EDGE_TOLERANCE_PX,
+): boolean => (
+    rect.top >= viewport.top - tolerance && rect.bottom <= viewport.bottom + tolerance
+);
+
+/** Qualification + capture. Returns the seam anchor for the FIRST candidate
+ *  whose flow top is inside the effective viewport AND whose user bubble or
+ *  previous assistant block is fully visible. Never falls back to bottom. */
+export const selectTurnSeam = (
+    candidates: readonly SeamCandidate[],
+    viewport: EffectiveViewport,
+): ConversationSeamAnchor | null => {
+    for (const candidate of candidates) {
+        if (candidate.flowTop < viewport.top - EDGE_TOLERANCE_PX
+            || candidate.flowTop > viewport.bottom + EDGE_TOLERANCE_PX) {
+            continue;
+        }
+        const userVisible = candidate.userBubble
+            ? isFullyVisible(candidate.userBubble, viewport)
+            : false;
+        const previousVisible = candidate.previousAssistant
+            ? isFullyVisible(candidate.previousAssistant, viewport)
+            : false;
+        if (!userVisible && !previousVisible) {
+            continue;
+        }
+        const bubbleOffsetFromFlow = candidate.userBubble
+            ? candidate.userBubble.top - candidate.flowTop
+            : 0;
+        const previousAssistantGap = candidate.previousAssistant
+            ? candidate.flowTop - candidate.previousAssistant.bottom
+            : null;
+        return {
+            key: candidate.key,
+            rowIndex: candidate.rowIndex,
+            capturedFlowViewportTop: candidate.flowTop,
+            bubbleOffsetFromFlow,
+            previousAssistantGap,
+        };
+    }
+    return null;
+};
+
+/** Continuous-frame-correct target: based on the CURRENT scrollTop, so after a
+ *  write the next frame's flow-top already reflects it and the delta collapses
+ *  to zero when nothing grows. */
+export const computeSeamTarget = (
+    anchor: Pick<ConversationSeamAnchor, 'capturedFlowViewportTop'>,
+    currentScrollTop: number,
+    currentFlowTop: number,
+): number => Math.max(0, currentScrollTop + (currentFlowTop - anchor.capturedFlowViewportTop));
+
+/** Seam diagnostics: the gap between the previous assistant bottom and the
+ *  user bubble top, and any overlap (must always be 0). */
+export const seamDiagnostics = (
+    bubbleTop: number | null,
+    previousAssistantBottom: number | null,
+): { seamGap: number | null; overlapDepth: number } => {
+    if (bubbleTop === null || previousAssistantBottom === null) {
+        return { seamGap: null, overlapDepth: 0 };
+    }
+    const seamGap = bubbleTop - previousAssistantBottom;
+    return { seamGap, overlapDepth: Math.max(0, -seamGap) };
+};
+
+/** Release ONLY when the composer covers the CAPTURED user-question top
+ *  (capturedFlowViewportTop + bubbleOffsetFromFlow — the question box, not the
+ *  flow start). A transient out-of-viewport flow start during a large reflow
+ *  is correction input, never a release. */
+export const shouldReleaseByComposer = (
+    capturedBubbleTop: number,
+    composerTop: number | null,
+    tolerance = 1,
+): boolean => composerTop !== null && composerTop <= capturedBubbleTop + tolerance;
+
+/** Release when the document scroll bounds make the anchor mathematically
+ *  impossible (scrolled to the very top or bottom). */
+export const isAtScrollBounds = (
+    scrollTop: number,
+    scrollHeight: number,
+    clientHeight: number,
+    tolerance = 1,
+): boolean => {
+    const max = Math.max(0, scrollHeight - clientHeight);
+    return scrollTop <= tolerance || scrollTop >= max - tolerance;
+};
+
+/** Bottom mode is only allowed when genuinely bottom-following. */
+export const isAtBottom = (distanceFromBottom: number, threshold = 24): boolean => (
+    distanceFromBottom <= threshold
+);

--- a/packages/ui/src/components/chat/lib/conversationResizeLayout.test.ts
+++ b/packages/ui/src/components/chat/lib/conversationResizeLayout.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    clampScrollTarget,
+    computeAnchorDelta,
+    computeTargetScrollTop,
+    diffMountedRows,
+    extendHeldRange,
+    initHeldRange,
+    type ResizeFrameLayout,
+    type ResizeLayoutTransaction,
+} from './conversationResizeLayout';
+
+// Build a frame with real mounted-row heights and an anchor document top.
+const frame = (
+    anchorKey: string,
+    anchorDocumentTop: number,
+    rows: Array<[string, number | null, number]>,
+): ResizeFrameLayout => ({
+    anchorKey,
+    anchorDocumentTop,
+    mountedRows: new Map(rows.map(([key, virtualIndex, height]) => [key, { key, virtualIndex, height }])),
+    mountedStart: rows.length ? Math.min(...rows.map(([, i]) => i ?? 0)) : null,
+    mountedEnd: rows.length ? Math.max(...rows.map(([, i]) => i ?? 0)) : null,
+});
+
+const makeTx = (previousLayout: ResizeFrameLayout): ResizeLayoutTransaction => ({
+    transactionId: 1,
+    anchorKey: previousLayout.anchorKey,
+    anchorVirtualIndex: 2,
+    capturedViewportTop: 300,
+    previousLayout,
+    state: 'active',
+});
+
+describe('conversationResizeLayout sequential frames (ONE transaction)', () => {
+    test('previous row +10 -> 0 (no change) -> +5 gives targets 510 -> 510 -> 515', () => {
+        // Frame 1: rows above the anchor grew 10px -> anchor doc top 300 -> 310.
+        let tx = makeTx(frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150]]));
+        let next = frame('c', 310, [['a', 0, 110], ['b', 1, 200], ['c', 2, 150]]);
+        let delta = computeAnchorDelta(next, tx.previousLayout);
+        expect(delta).toBe(10);
+        let target = computeTargetScrollTop(500, delta);
+        expect(target).toBe(510);
+        // Commit: update the transaction's previous layout.
+        tx = { ...tx, previousLayout: next };
+
+        // Frame 2: no real change -> delta 0 -> target = current scrollTop (510).
+        next = frame('c', 310, [['a', 0, 110], ['b', 1, 200], ['c', 2, 150]]);
+        delta = computeAnchorDelta(next, tx.previousLayout);
+        expect(delta).toBe(0);
+        target = computeTargetScrollTop(510, delta);
+        expect(target).toBe(510);
+        tx = { ...tx, previousLayout: next };
+
+        // Frame 3: another +5 growth -> delta +5 -> target 515 (NOT 525).
+        next = frame('c', 315, [['a', 0, 115], ['b', 1, 200], ['c', 2, 150]]);
+        delta = computeAnchorDelta(next, tx.previousLayout);
+        expect(delta).toBe(5);
+        target = computeTargetScrollTop(510, delta);
+        expect(target).toBe(515);
+    });
+
+    test('cache/DOM initial mismatch but identical consecutive real heights -> zero change', () => {
+        // First frame's real heights differ from the cache, but frame 2 has the
+        // SAME real heights as frame 1 -> diffMountedRows is empty.
+        const tx = makeTx(frame('c', 300, [['a', 0, 120], ['b', 1, 210], ['c', 2, 150]]));
+        const next = frame('c', 300, [['a', 0, 120], ['b', 1, 210], ['c', 2, 150]]);
+        expect(diffMountedRows(tx.previousLayout, next)).toEqual([]);
+        expect(computeAnchorDelta(next, tx.previousLayout)).toBe(0);
+    });
+
+    test('anchor row itself grows -> anchor delta 0', () => {
+        const tx = makeTx(frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150]]));
+        const next = frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 400]]);
+        expect(computeAnchorDelta(next, tx.previousLayout)).toBe(0);
+    });
+
+    test('rows AFTER the anchor grow -> anchor delta 0', () => {
+        const tx = makeTx(frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150], ['d', 3, 150]]));
+        const next = frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150], ['d', 3, 400]]);
+        expect(computeAnchorDelta(next, tx.previousLayout)).toBe(0);
+    });
+
+    test('multiple rows above grow/shrink simultaneously -> single frame delta sum', () => {
+        const tx = makeTx(frame('d', 500, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150], ['d', 3, 150]]));
+        // a +20, b -10 -> anchor top 500 -> 510.
+        const next = frame('d', 510, [['a', 0, 120], ['b', 1, 190], ['c', 2, 150], ['d', 3, 150]]);
+        expect(computeAnchorDelta(next, tx.previousLayout)).toBe(10);
+        expect(computeTargetScrollTop(500, 10)).toBe(510);
+    });
+
+    test('same-width final frame -> zero commit, zero write', () => {
+        const tx = makeTx(frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150]]));
+        const next = frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150]]);
+        expect(diffMountedRows(tx.previousLayout, next)).toEqual([]);
+        expect(computeAnchorDelta(next, tx.previousLayout)).toBe(0);
+    });
+});
+
+describe('conversationResizeLayout clamp (no release)', () => {
+    test('target beyond max clamps and flags clamped state', () => {
+        const r = clampScrollTarget(1200, 1000, 500);
+        expect(r.target).toBe(500);
+        expect(r.clamped).toBe(true);
+    });
+
+    test('target below 0 clamps to 0', () => {
+        const r = clampScrollTarget(-40, 1000, 500);
+        expect(r.target).toBe(0);
+        expect(r.clamped).toBe(true);
+    });
+
+    test('in-range target not clamped', () => {
+        const r = clampScrollTarget(300, 1000, 500);
+        expect(r.target).toBe(300);
+        expect(r.clamped).toBe(false);
+    });
+
+    test('reverse drag after clamp resumes: same anchor key, delta recomputed from the last committed frame', () => {
+        // Clamped at max: scrollTop 500 (max), anchor doc top 310.
+        const tx = makeTx(frame('c', 310, [['a', 0, 110], ['b', 1, 200], ['c', 2, 150]]));
+        // Content shrinks (reverse drag): anchor top 310 -> 300, delta -10.
+        const next = frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150]]);
+        const delta = computeAnchorDelta(next, tx.previousLayout);
+        expect(delta).toBe(-10);
+        expect(computeTargetScrollTop(500, delta)).toBe(490);
+        expect(tx.anchorKey).toBe('c'); // same key kept; state flips back to active
+    });
+});
+
+describe('conversationResizeLayout diffMountedRows', () => {
+    test('reports only keys with real height change > 0.5px', () => {
+        const tx = makeTx(frame('c', 300, [['a', 0, 100], ['b', 1, 200], ['c', 2, 150]]));
+        const next = frame('c', 300, [['a', 0, 100], ['b', 1, 201], ['c', 2, 150]]);
+        expect(diffMountedRows(tx.previousLayout, next)).toEqual(['b']);
+    });
+
+    test('newly mounted rows count as changed', () => {
+        const tx = makeTx(frame('c', 300, [['a', 0, 100]]));
+        const next = frame('c', 300, [['a', 0, 100], ['b', 1, 250]]);
+        expect(diffMountedRows(tx.previousLayout, next)).toEqual(['b']);
+    });
+});
+
+describe('conversationResizeLayout held range', () => {
+    test('initial range = union of mounted indexes and the anchor window', () => {
+        // mounted [10..14], anchor window [11..13] -> union [10..14]
+        // (covers anchorIndex-1 = 11 = previous assistant).
+        const held = initHeldRange([10, 11, 12, 13, 14], 12);
+        expect(held.start).toBe(10);
+        expect(held.end).toBe(14);
+    });
+
+    test('anchor without mounted window keeps the anchor window', () => {
+        const held = initHeldRange([], 5);
+        expect(held.start).toBe(4);
+        expect(held.end).toBe(6);
+    });
+
+    test('monotonic extension: start never grows, end never shrinks', () => {
+        let held = { start: 9, end: 15 };
+        held = extendHeldRange(held, 12, 18, 40);
+        expect(held).toEqual({ start: 9, end: 18 });
+        held = extendHeldRange(held, 4, 10, 40);
+        expect(held).toEqual({ start: 4, end: 18 });
+        held = extendHeldRange(held, 20, 30, 40);
+        expect(held).toEqual({ start: 4, end: 30 });
+    });
+
+    test('clamps to [0, count-1]', () => {
+        expect(extendHeldRange({ start: -2, end: 12 }, 0, 2, 10)).toEqual({ start: 0, end: 9 });
+    });
+});

--- a/packages/ui/src/components/chat/lib/conversationResizeLayout.ts
+++ b/packages/ui/src/components/chat/lib/conversationResizeLayout.ts
@@ -1,0 +1,124 @@
+// Pure frame-layout model for the conversation-seam resize controller.
+//
+// DOM-free. The controller keeps a per-frame layout of the MOUNTED rows (real
+// DOM heights only — TanStack's cache is a commit target, never a change
+// source) plus the anchor's DOCUMENT top (flowStartRect.top -
+// scrollerRect.top + scrollTop). Every width frame compares the new layout to
+// the PREVIOUS committed frame:
+//
+//   anchorDelta = next.anchorDocumentTop - previous.anchorDocumentTop
+//   target      = currentScrollTop + anchorDelta
+//
+// Because the delta is relative to the last committed frame (never to a
+// capture-time baseline), a +10 growth writes +10 once; the next frame with
+// no growth has delta strictly 0 (zero writes); a further +5 writes +5. The
+// anchor row's own growth or any growth AFTER it leaves its document top
+// unchanged -> delta 0. Clamping at the scroll bounds keeps the transaction
+// ACTIVE (state 'clamped'), preserving the anchor key/baseline/held range so
+// a reverse drag resumes automatically — it is NOT a release.
+
+export interface MountedRowInfo {
+    key: string;
+    virtualIndex: number | null;
+    height: number;
+}
+
+export interface ResizeFrameLayout {
+    anchorKey: string;
+    /** Document top of the anchor's flow start (css px). */
+    anchorDocumentTop: number;
+    /** Real mounted rows of THIS frame (key -> info). */
+    mountedRows: Map<string, MountedRowInfo>;
+    mountedStart: number | null;
+    mountedEnd: number | null;
+}
+
+export interface ResizeLayoutTransaction {
+    transactionId: number;
+    anchorKey: string;
+    anchorVirtualIndex: number | null;
+    /** Anchor viewport top captured at drag start (diagnostics). */
+    capturedViewportTop: number;
+    /** Layout of the last COMMITTED frame (updated after every write). */
+    previousLayout: ResizeFrameLayout;
+    /** Last processed frame sequence (dedup — never dedupe by width). */
+    lastFrameSequence?: number;
+    state: 'active' | 'clamped';
+}
+
+export const EMPTY_FRAME_LAYOUT = (anchorKey: string): ResizeFrameLayout => ({
+    anchorKey,
+    anchorDocumentTop: 0,
+    mountedRows: new Map(),
+    mountedStart: null,
+    mountedEnd: null,
+});
+
+/** Delta of the anchor's document top between two consecutive committed
+ *  frames. Zero when the real heights above the anchor did not change. */
+export const computeAnchorDelta = (
+    next: ResizeFrameLayout,
+    previous: ResizeFrameLayout,
+): number => next.anchorDocumentTop - previous.anchorDocumentTop;
+
+/** Target based on the CURRENT scrollTop and the PREVIOUS-frame delta. */
+export const computeTargetScrollTop = (currentScrollTop: number, anchorDelta: number): number => (
+    currentScrollTop + anchorDelta
+);
+
+/** Clamp a target into the legal range; returns the clamped value and whether
+ *  the clamp actually engaged (-> transaction state 'clamped'). */
+export const clampScrollTarget = (
+    target: number,
+    scrollHeight: number,
+    clientHeight: number,
+): { target: number; clamped: boolean } => {
+    const max = Math.max(0, scrollHeight - clientHeight);
+    const clampedTarget = Math.min(max, Math.max(0, target));
+    return { target: clampedTarget, clamped: clampedTarget !== target };
+};
+
+/** Real-height comparison between two consecutive frames (> 0.5px). Keys
+ *  present in both frames with the same height are NOT changed. */
+export const diffMountedRows = (
+    previous: ResizeFrameLayout,
+    next: ResizeFrameLayout,
+    tolerance = 0.5,
+): string[] => {
+    const changed: string[] = [];
+    for (const [key, info] of next.mountedRows) {
+        const prev = previous.mountedRows.get(key);
+        if (prev === undefined || Math.abs(prev.height - info.height) > tolerance) {
+            changed.push(key);
+        }
+    }
+    return changed;
+};
+
+/** Initial held range = union of the current mounted indexes and the anchor
+ *  window (anchorIndex-1 .. anchorIndex+1). Always covers the previous
+ *  assistant row and the anchor row. */
+export const initHeldRange = (
+    mountedIndexes: readonly number[],
+    anchorIndex: number | null,
+): { start: number; end: number } => {
+    let start = anchorIndex === null ? 0 : Math.max(0, anchorIndex - 1);
+    let end = anchorIndex === null ? 0 : anchorIndex + 1;
+    for (const index of mountedIndexes) {
+        start = Math.min(start, index);
+        end = Math.max(end, index);
+    }
+    return { start, end };
+};
+
+/** Monotonic extension: next.start <= previous.start AND next.end >=
+ *  previous.end, clamped to [0, count-1]. */
+export const extendHeldRange = (
+    held: { start: number; end: number },
+    normalStart: number,
+    normalEnd: number,
+    count: number,
+): { start: number; end: number } => ({
+    start: Math.max(0, Math.min(held.start, normalStart)),
+    end: Math.min(count - 1, Math.max(held.end, normalEnd)),
+});

--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -53,6 +53,10 @@ import {
 import { getContextSurfaceWidthFraction } from '@/lib/surfaces/registry';
 import { isTerminalEventTarget } from '@/lib/terminalFocus';
 import {
+  recordPerformanceTraceEvent,
+} from '@/stores/utils/performanceTrace';
+import { usePanelResize } from './usePanelResize';
+import {
   type PreviewElementMetadata,
   isPreviewElementMetadata,
   formatPreviewAnnotationMarkdown,
@@ -66,7 +70,6 @@ import {
 const CONTEXT_PANEL_MIN_WIDTH = 380;
 const CONTEXT_PANEL_MAX_WIDTH = 1400;
 const CONTEXT_PANEL_DEFAULT_WIDTH = 600;
-const RESIZE_FOLLOW_INTERVAL_MS = 100;
 const CONTEXT_TAB_LABEL_MAX_CHARS = 24;
 type TranslateFn = ReturnType<typeof useI18n>['t'];
 const EMPTY_SESSION_TITLE_MAP = new Map<string, string>();
@@ -309,73 +312,36 @@ const EditorTreeColumn: React.FC<{ visible: boolean }> = ({ visible }) => {
   const { t } = useI18n();
   const width = useUIStore((state) => state.contextEditorTreeWidth);
   const setWidth = useUIStore((state) => state.setContextEditorTreeWidth);
-  const [isResizing, setIsResizing] = React.useState(false);
-  const startXRef = React.useRef(0);
-  const startWidthRef = React.useRef(width);
-  const liveWidthRef = React.useRef<number | null>(null);
-  const pointerIDRef = React.useRef<number | null>(null);
-  const columnRef = React.useRef<HTMLDivElement | null>(null);
+  // Same drag lifecycle as the main panels, but LOCAL: the tree column does
+  // not change the central chat width, so it publishes no global transaction.
+  const { isResizing, containerRef: columnRef, handlePointerDown, handlePointerUp, handlePointerAbort } = usePanelResize<HTMLDivElement>({
+    minWidth: EDITOR_TREE_MIN_WIDTH,
+    maxWidth: EDITOR_TREE_MAX_WIDTH,
+    onUserCommitWidth: setWidth,
+    widthCssVariable: '--oc-editor-tree-width',
+    directWidth: true,
+    reverse: true,
+    canResize: () => visible,
+    getCurrentWidth: () => width,
+  });
 
-  const clampTreeWidth = React.useCallback((value: number) => {
-    return Math.min(EDITOR_TREE_MAX_WIDTH, Math.max(EDITOR_TREE_MIN_WIDTH, Math.round(value)));
-  }, []);
+  const appliedWidth = visible ? width : 0;
 
-  const applyLiveTreeWidth = React.useCallback((nextWidth: number) => {
+  // During a live tree-column resize the width changes on every pointer move,
+  // reflowing the whole (non-virtualized) file tree each frame. Contain the
+  // column so those reflows/repaints stay inside the column subtree instead of
+  // leaking into the rest of the panel + chat. Paint containment also keeps
+  // repaints scoped to the column (mirrors the MessageList/Sidebar guards).
+  React.useEffect(() => {
     const column = columnRef.current;
     if (!column) {
       return;
     }
-    column.style.width = `${nextWidth}px`;
-    column.style.setProperty('--oc-editor-tree-width', `${nextWidth}px`);
-  }, []);
-
-  const handlePointerDown = (event: React.PointerEvent) => {
-    if (!visible) {
-      return;
-    }
-    try {
-      event.currentTarget.setPointerCapture(event.pointerId);
-    } catch {
-      // ignore
-    }
-    pointerIDRef.current = event.pointerId;
-    setIsResizing(true);
-    startXRef.current = event.clientX;
-    startWidthRef.current = width;
-    liveWidthRef.current = width;
-    event.preventDefault();
-  };
-
-  const handlePointerMove = (event: React.PointerEvent) => {
-    if (!isResizing || pointerIDRef.current !== event.pointerId) {
-      return;
-    }
-    const delta = startXRef.current - event.clientX;
-    const nextWidth = clampTreeWidth(startWidthRef.current + delta);
-    if (liveWidthRef.current === nextWidth) {
-      return;
-    }
-    liveWidthRef.current = nextWidth;
-    applyLiveTreeWidth(nextWidth);
-  };
-
-  const handlePointerEnd = (event: React.PointerEvent) => {
-    if (pointerIDRef.current !== event.pointerId) {
-      return;
-    }
-    try {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    } catch {
-      // ignore
-    }
-    const finalWidth = clampTreeWidth(liveWidthRef.current ?? width);
-    pointerIDRef.current = null;
-    liveWidthRef.current = null;
-    setIsResizing(false);
-    setWidth(finalWidth);
-  };
-
-  const appliedWidth = visible ? width : 0;
+    column.style.contain = isResizing ? 'layout style paint' : '';
+    return () => {
+      column.style.contain = '';
+    };
+  }, [columnRef, isResizing]);
 
   return (
     <div
@@ -385,8 +351,8 @@ const EditorTreeColumn: React.FC<{ visible: boolean }> = ({ visible }) => {
         !visible && 'border-l-0',
       )}
       style={{
-        width: `${isResizing ? (liveWidthRef.current ?? appliedWidth) : appliedWidth}px`,
-        ['--oc-editor-tree-width' as string]: `${isResizing ? (liveWidthRef.current ?? width) : width}px`,
+        width: `${appliedWidth}px`,
+        ['--oc-editor-tree-width' as string]: `${appliedWidth}px`,
         overflowX: 'clip',
         transitionProperty: isResizing ? 'none' : 'width',
         transitionDuration: '200ms',
@@ -401,9 +367,9 @@ const EditorTreeColumn: React.FC<{ visible: boolean }> = ({ visible }) => {
             isResizing && 'bg-[var(--interactive-border)]'
           )}
           onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerEnd}
-          onPointerCancel={handlePointerEnd}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerAbort}
+          onLostPointerCapture={handlePointerAbort}
           role="separator"
           aria-orientation="vertical"
           aria-label={t('contextPanel.actions.resizePanelAria')}
@@ -2262,11 +2228,15 @@ export const ContextPanel: React.FC = () => {
   const activeTab = tabs.find((tab) => tab.id === panelState?.activeTabId) ?? tabs[tabs.length - 1] ?? null;
   const isOpen = Boolean(panelState?.isOpen && activeTab);
   const isExpanded = Boolean(isOpen && panelState?.expanded);
-  const [availablePanelAreaWidth, setAvailablePanelAreaWidth] = React.useState<number | null>(null);
+  // Parent/available area width lives in a REF (never React state): the
+  // ResizeObserver fires per pixel during sidebar animations and must not
+  // re-render the whole panel content tree. The resize hook re-resolves
+  // follow targets per frame; only semantic state changes re-render.
+  const availablePanelAreaWidthRef = React.useRef<number | null>(null);
   const activeModeForWidth = activeTab?.mode ?? null;
   const manualWidth = activeModeForWidth ? panelState?.widthByMode?.[activeModeForWidth] : undefined;
   const widthFraction = activeModeForWidth ? getContextSurfaceWidthFraction(activeModeForWidth) : 0.5;
-  const widthFallbackBase = availablePanelAreaWidth
+  const widthFallbackBase = availablePanelAreaWidthRef.current
     ?? (typeof window !== 'undefined' ? window.innerWidth : CONTEXT_PANEL_DEFAULT_WIDTH * 2);
   const width = clampWidth(manualWidth ?? Math.round(widthFraction * widthFallbackBase));
   const chatSessionIDs = React.useMemo(() => {
@@ -2280,18 +2250,90 @@ export const ContextPanel: React.FC = () => {
   }, [tabs]);
   const sessionTitleById = useSessionTitleMap(directoryKey || undefined, chatSessionIDs);
 
-  const [isResizing, setIsResizing] = React.useState(false);
-  const startXRef = React.useRef(0);
-  const startWidthRef = React.useRef(width);
-  const resizingWidthRef = React.useRef<number | null>(null);
-  const activeResizePointerIDRef = React.useRef<number | null>(null);
-  const panelRef = React.useRef<HTMLElement | null>(null);
+  const { isResizing, containerRef: panelRef, handlePointerDown: handleResizeStart, handlePointerUp: handleResizeEnd, handlePointerAbort: handleResizeAbort, notifyAvailableWidthChange } = usePanelResize({
+    minWidth: CONTEXT_PANEL_MIN_WIDTH,
+    maxWidth: CONTEXT_PANEL_MAX_WIDTH,
+    // Persist the manual width on pointerup ONLY — programmatic open/close,
+    // mode switches and parent-layout follows never write widthByMode.
+    onUserCommitWidth: (finalWidth) => {
+      if (directoryKey && activeModeForWidth) {
+        setContextPanelWidth(directoryKey, activeModeForWidth, finalWidth);
+      }
+    },
+    transactionSource: 'context-panel',
+    widthCssVariable: '--oc-context-panel-width',
+    reverse: true,
+    canResize: () => isOpen && !isExpanded && Boolean(directoryKey),
+    getCurrentWidth: () => width,
+    getAvailableWidth: (container) => getAvailablePanelWidth(container),
+    traceSpanName: 'ui.context_panel.resize',
+    traceContext: () => ({ mode: activeModeForWidth ?? 'unknown' }),
+    // Quick open/close toggles, MODE SWITCHES and expand/collapse go through
+    // the same per-frame width writer as a pointer drag (200ms programmatic
+    // animation) so the chat anchor controller keeps the seam stable. The key
+    // includes the mode AND the expanded state so any semantic transition
+    // re-directs the animation from the current width. Proportional (default)
+    // and expanded widths use cause 'parent-layout': while a global transaction
+    // is active the panel FOLLOWS the available area per frame without
+    // restarting an animation clock; manual widths use 'mode' (fixed animate).
+    programmaticTarget: isOpen
+      ? {
+          key: `${isExpanded ? 'expand' : 'open'}:${activeModeForWidth ?? ''}`,
+          width: isExpanded ? (availablePanelAreaWidthRef.current ?? width) : width,
+          cause: isExpanded || manualWidth === undefined ? 'parent-layout' : 'mode',
+        }
+      : {
+          key: `close:${activeModeForWidth ?? ''}`,
+          width: 0,
+          cause: 'visibility',
+        },
+    // Per-frame follow resolver: proportional widths re-resolve to the CURRENT
+    // parent width; expanded re-resolves to the full available width; manual
+    // widths and the closed state return null (no follow).
+    resolveFollowWidth: () => {
+      if (!isOpen) {
+        return null;
+      }
+      if (isExpanded) {
+        return availablePanelAreaWidthRef.current;
+      }
+      if (manualWidth !== undefined) {
+        return null;
+      }
+      const base = availablePanelAreaWidthRef.current;
+      if (base === null || base <= 0) {
+        return null;
+      }
+      return clampWidth(Math.round(widthFraction * base));
+    },
+  });
+  const handleContextPanelProfiler = React.useCallback<React.ProfilerOnRenderCallback>(
+    (_id, phase, actualDuration, baseDuration) => {
+      recordPerformanceTraceEvent(
+        'ui.profiler.context_panel',
+        {
+          phase,
+          actualDuration,
+          baseDuration,
+          mode: activeModeForWidth ?? 'none',
+          isOpen,
+          isResizing,
+          tabCount: tabs.length,
+        },
+        actualDuration,
+      );
+    },
+    [activeModeForWidth, isOpen, isResizing, tabs.length],
+  );
+  const panelContentRef = React.useRef<HTMLDivElement | null>(null);
   const chatFrameRefs = React.useRef<Map<string, HTMLIFrameElement>>(new Map());
   const chatFrameSrcByTabIDRef = React.useRef<Map<string, EmbeddedSessionChatURLCacheEntry>>(new Map());
   const wasOpenRef = React.useRef(false);
 
   // Tracks the panel area width so fraction-based surface defaults stay
-  // proportional as the window resizes; manual widths remain fixed px.
+  // proportional as the parent changes (left sidebar open/close, window
+  // resize); manual widths remain fixed px. Writes a REF and wakes the resize
+  // hook's follow loop — no React re-render per pixel.
   React.useLayoutEffect(() => {
     const parent = panelRef.current?.parentElement;
     if (!parent || typeof ResizeObserver === 'undefined') {
@@ -2299,13 +2341,14 @@ export const ContextPanel: React.FC = () => {
     }
 
     const observer = new ResizeObserver(() => {
-      setAvailablePanelAreaWidth(parent.clientWidth || null);
+      availablePanelAreaWidthRef.current = parent.clientWidth || null;
+      notifyAvailableWidthChange();
     });
     observer.observe(parent);
-    setAvailablePanelAreaWidth(parent.clientWidth || null);
+    availablePanelAreaWidthRef.current = parent.clientWidth || null;
 
     return () => observer.disconnect();
-  }, []);
+  }, [notifyAvailableWidthChange, panelRef]);
 
   React.useEffect(() => {
     if (!isOpen || wasOpenRef.current) {
@@ -2319,127 +2362,7 @@ export const ContextPanel: React.FC = () => {
 
     wasOpenRef.current = true;
     return () => window.cancelAnimationFrame(frame);
-  }, [isOpen]);
-
-  // Deferred resize: reflowing the chat column and the active surface (xterm,
-  // editor, embedded chat iframes) on every drag frame is unavoidably janky,
-  // so during the drag only a ghost guide line follows the pointer and the
-  // real width is applied once on release (riding the width transition).
-  const resizeAvailableWidthRef = React.useRef<number | null>(null);
-  // The panel content follows the guide line lazily: the real width is
-  // re-applied at most every RESIZE_FOLLOW_INTERVAL_MS and the standing
-  // 200ms width transition smooths each step, VS Code-style.
-  const resizeFollowTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const applyFollowWidth = React.useCallback(() => {
-    resizeFollowTimerRef.current = null;
-    const panel = panelRef.current;
-    const next = resizingWidthRef.current;
-    if (!panel || next === null) {
-      return;
-    }
-    panel.style.setProperty('--oc-context-panel-width', `${next}px`);
-  }, []);
-
-  React.useEffect(() => () => {
-    if (resizeFollowTimerRef.current !== null) {
-      clearTimeout(resizeFollowTimerRef.current);
-    }
-  }, []);
-
-  const clampWidthForDrag = React.useCallback((nextWidth: number) => {
-    const clamped = clampWidth(nextWidth);
-    const available = resizeAvailableWidthRef.current;
-    return available === null ? clamped : Math.min(clamped, Math.max(1, available));
-  }, []);
-
-  const handleResizeStart = React.useCallback((event: React.PointerEvent) => {
-    if (!isOpen || isExpanded || !directoryKey) {
-      return;
-    }
-
-    activeResizePointerIDRef.current = event.pointerId;
-    setIsResizing(true);
-    startXRef.current = event.clientX;
-    startWidthRef.current = width;
-    resizingWidthRef.current = width;
-    // Measure once per drag; no layout reads happen during pointermove.
-    resizeAvailableWidthRef.current = getAvailablePanelWidth(panelRef.current);
-    document.documentElement.style.cursor = 'col-resize';
-    event.preventDefault();
-  }, [directoryKey, isExpanded, isOpen, width]);
-
-  const finishResize = React.useCallback(() => {
-    // Apply the final width once, letting the regular 200ms width transition
-    // carry the panel to the release position.
-    const finalWidth = clampWidthForDrag(resizingWidthRef.current ?? width);
-    resizingWidthRef.current = null;
-    resizeAvailableWidthRef.current = null;
-    if (resizeFollowTimerRef.current !== null) {
-      clearTimeout(resizeFollowTimerRef.current);
-      resizeFollowTimerRef.current = null;
-    }
-    document.documentElement.style.cursor = '';
-    if (directoryKey && activeModeForWidth) {
-      setContextPanelWidth(directoryKey, activeModeForWidth, finalWidth);
-    }
-    setIsResizing(false);
-    activeResizePointerIDRef.current = null;
-  }, [activeModeForWidth, clampWidthForDrag, directoryKey, setContextPanelWidth, width]);
-
-  // Window-level drag listeners: tracking the pointer via the 3px handle and
-  // pointer capture is unreliable (capture can fail over iframes and a missed
-  // pointerup leaves the drag stuck), so while resizing the whole window
-  // tracks the pointer and any release/cancel/blur ends the drag.
-  React.useEffect(() => {
-    if (!isResizing) {
-      return;
-    }
-
-    const handleMove = (event: PointerEvent) => {
-      if (activeResizePointerIDRef.current !== event.pointerId) {
-        return;
-      }
-      const delta = startXRef.current - event.clientX;
-      const nextWidth = clampWidthForDrag(startWidthRef.current + delta);
-      if (resizingWidthRef.current === nextWidth) {
-        return;
-      }
-      resizingWidthRef.current = nextWidth;
-      if (resizeFollowTimerRef.current === null) {
-        resizeFollowTimerRef.current = setTimeout(applyFollowWidth, RESIZE_FOLLOW_INTERVAL_MS);
-      }
-    };
-
-    const handleUp = (event: PointerEvent) => {
-      if (activeResizePointerIDRef.current !== event.pointerId) {
-        return;
-      }
-      finishResize();
-    };
-
-    const handleWindowBlur = () => {
-      finishResize();
-    };
-
-    window.addEventListener('pointermove', handleMove);
-    window.addEventListener('pointerup', handleUp);
-    window.addEventListener('pointercancel', handleUp);
-    window.addEventListener('blur', handleWindowBlur);
-    return () => {
-      window.removeEventListener('pointermove', handleMove);
-      window.removeEventListener('pointerup', handleUp);
-      window.removeEventListener('pointercancel', handleUp);
-      window.removeEventListener('blur', handleWindowBlur);
-    };
-  }, [applyFollowWidth, clampWidthForDrag, finishResize, isResizing]);
-
-  React.useEffect(() => {
-    if (!isResizing) {
-      resizingWidthRef.current = null;
-      document.documentElement.style.cursor = '';
-    }
-  }, [isResizing]);
+  }, [isOpen, panelRef]);
 
   const handleClose = React.useCallback(() => {
     if (!directoryKey) {
@@ -2837,32 +2760,33 @@ export const ContextPanel: React.FC = () => {
     </header>
   );
 
-  // width/min/max stay interpolable across open/close (no instant min/max
-  // jumps) so the 200ms width transition matches the sidebars.
+  // The width is owned ENTIRELY by the resize hook's CSS variable — React
+  // never writes the variable or a px width on any render (open, closed,
+  // expanded, mode switch). This is what makes a re-render unable to override
+  // the in-flight animation or fight the anchor transaction.
   const panelStyle: React.CSSProperties = !isOpen
     ? {
-        ['--oc-context-panel-width' as string]: `${width}px`,
-        width: 0,
+        // Closed: the width ANIMATES to 0 through the programmatic transaction
+        // (the CSS variable is interpolated by the hook); no CSS transition.
+        width: 'var(--oc-context-panel-width, 0px)',
         maxWidth: '100%',
         overflowX: 'clip',
       }
     : isExpanded
       ? {
-          // px, not '100%': px↔% width changes do not interpolate, which
-          // would make the expand/collapse width snap instead of animating.
-          ['--oc-context-panel-width' as string]: availablePanelAreaWidth !== null ? `${availablePanelAreaWidth}px` : '100%',
-          width: availablePanelAreaWidth !== null ? `${availablePanelAreaWidth}px` : '100%',
+          // Expanded: same variable, animated to the full available width.
+          width: 'var(--oc-context-panel-width, 0px)',
           maxWidth: '100%',
         }
       : {
-          width: 'min(var(--oc-context-panel-width), 100%)',
+          width: 'min(var(--oc-context-panel-width, 0px), 100%)',
           maxWidth: '100%',
           overflowX: 'clip',
-          ['--oc-context-panel-width' as string]: `${width}px`,
         };
 
   return (
-    <aside
+    <React.Profiler id={`context_panel.${activeModeForWidth ?? 'none'}`} onRender={handleContextPanelProfiler}>
+      <aside
       ref={panelRef}
       data-context-panel="true"
       tabIndex={-1}
@@ -2876,11 +2800,20 @@ export const ContextPanel: React.FC = () => {
           ? 'absolute inset-y-0 right-0 z-20 min-w-0'
           : 'relative h-full flex-shrink-0',
         !isOpen && 'pointer-events-none',
-        'will-change-[width] motion-reduce:transition-none',
-        'transition-[width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]'
+        'will-change-[width]'
       )}
       onKeyDownCapture={handlePanelKeyDownCapture}
-      style={panelStyle}
+      style={{
+        ...panelStyle,
+        // flex:none + the CSS variable keep React re-renders from ever
+        // overriding the hook's width writes. Live flex resize: the panel
+        // stays in the flex row while dragging so the chat surface reflows in
+        // real time. Layout containment keeps the panel subtree's layout from
+        // leaking outward during the drag; the real flex width is committed
+        // once when the pointer is released.
+        flex: 'none',
+        contain: 'layout style paint',
+      }}
     >
       {/* Painted divider instead of border-l: a real border eats 1px of the
           content box only while collapsed, shifting the header controls by
@@ -2899,31 +2832,44 @@ export const ContextPanel: React.FC = () => {
             isResizing && 'bg-[var(--interactive-border)]'
           )}
           onPointerDown={handleResizeStart}
+          onPointerUp={handleResizeEnd}
+          onPointerCancel={handleResizeAbort}
+          onLostPointerCapture={handleResizeAbort}
           role="separator"
           aria-orientation="vertical"
           aria-label={t('contextPanel.actions.resizePanelAria')}
         />
       )}
       <div
+        ref={panelContentRef}
         className={cn(
           'relative z-10 flex h-full min-h-0 shrink-0 flex-col duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none',
-          // Width animates in sync with the panel (surface switches, resize
-          // release); during the drag itself nothing resizes — only the ghost
-          // guide line moves.
-          'transition-[width,opacity]',
+          // Keep the content OPACITY animation; the width is interpolated by
+          // the resize hook's programmatic transaction (no CSS width
+          // transition — that would double-interpolate with the JS animator).
+          'transition-opacity',
           !isOpen && 'pointer-events-none select-none opacity-0'
         )}
-        // px in the expanded state too: px↔% width changes cannot interpolate,
-        // so the header controls would snap instead of riding the animation.
         style={{
-          width: isExpanded
-            ? (availablePanelAreaWidth !== null ? `${availablePanelAreaWidth}px` : '100%')
-            : 'var(--oc-context-panel-width)',
+          // The content column inherits the root width via 100% — it never
+          // writes a final width of its own (the hook owns the geometry).
+          width: '100%',
+          transitionProperty: 'opacity',
         }}
         aria-hidden={!isOpen}
       >
       {header}
-      <div className={cn('relative min-h-0 flex-1 overflow-hidden', isResizing && 'pointer-events-none')}>
+      <div
+        className={cn('relative min-h-0 flex-1 overflow-hidden', isResizing && 'pointer-events-none')}
+        style={{
+          // During a live resize every mode's content (context list, file tree,
+          // git/pr/notes/plan views) reflows as the panel width changes each
+          // frame. Contain the content area so those reflows/repaints stay
+          // inside the panel instead of leaking into the chat surface, and
+          // paint containment keeps repaints scoped to the panel.
+          contain: isResizing ? 'layout style paint' : undefined,
+        }}
+      >
         {hasFileTabs ? (
           <div className={cn('absolute inset-0 flex', isFileTabActive ? 'flex' : 'hidden')}>
             <div className="h-full min-w-0 flex-1">
@@ -3008,6 +2954,7 @@ export const ContextPanel: React.FC = () => {
         {activeTab?.mode !== 'chat' && !isFileTabActive && activeTab?.mode !== 'browser' && activeTab?.mode !== 'diff' && activeTab?.mode !== 'terminal' && activeTab?.mode !== 'walkthrough' ? activeNonChatContent : null}
       </div>
       </div>
-    </aside>
+      </aside>
+    </React.Profiler>
   );
 };

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import { ErrorBoundary } from '../ui/ErrorBoundary';
 import { useI18n } from '@/lib/i18n';
 import { useUIStore } from '@/stores/useUIStore';
+import { usePanelResize } from './usePanelResize';
 
 const SIDEBAR_CONTENT_WIDTH = 280;
 const SIDEBAR_MIN_WIDTH = 280;
@@ -21,133 +22,71 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, isMobile, children, cl
     const { t } = useI18n();
     const sidebarWidth = useUIStore((state) => state.sidebarWidth);
     const setSidebarWidth = useUIStore((state) => state.setSidebarWidth);
-    const [isResizing, setIsResizing] = React.useState(false);
-    const startXRef = React.useRef(0);
-    const startWidthRef = React.useRef(sidebarWidth || SIDEBAR_CONTENT_WIDTH);
-    const resizingWidthRef = React.useRef<number | null>(null);
-    const activeResizePointerIDRef = React.useRef<number | null>(null);
-    const sidebarRef = React.useRef<HTMLElement | null>(null);
-
-    const clampSidebarWidth = React.useCallback((value: number) => {
-        return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, value));
-    }, []);
-
-    const applyLiveWidth = React.useCallback((nextWidth: number) => {
-        const sidebar = sidebarRef.current;
-        if (!sidebar) {
-            return;
-        }
-
-        sidebar.style.width = `${nextWidth}px`;
-        sidebar.style.minWidth = `${nextWidth}px`;
-        sidebar.style.maxWidth = `${nextWidth}px`;
-        sidebar.style.setProperty('--oc-left-sidebar-width', `${nextWidth}px`);
-    }, []);
-
-    React.useEffect(() => {
-        if (isMobile && isResizing) {
-            setIsResizing(false);
-        }
-    }, [isMobile, isResizing]);
-
-    React.useEffect(() => {
-        if (!isResizing) {
-            resizingWidthRef.current = null;
-            activeResizePointerIDRef.current = null;
-        }
-    }, [isResizing]);
-
-    if (isMobile) {
-        return null;
-    }
 
     const openWidth = Math.min(
         SIDEBAR_MAX_WIDTH,
         Math.max(SIDEBAR_MIN_WIDTH, sidebarWidth || SIDEBAR_CONTENT_WIDTH)
     );
-    const appliedWidth = isOpen ? openWidth : 0;
 
-    const handlePointerDown = (event: React.PointerEvent) => {
-        if (!isOpen) {
-            return;
-        }
+    const { isResizing, containerRef, handlePointerDown, handlePointerUp, handlePointerAbort } = usePanelResize({
+        minWidth: SIDEBAR_MIN_WIDTH,
+        maxWidth: SIDEBAR_MAX_WIDTH,
+        // Persist the manual width on pointerup ONLY — programmatic open/close
+        // never touches the saved width or the manual-resize flag.
+        onUserCommitWidth: setSidebarWidth,
+        transactionSource: 'left-sidebar',
+        widthCssVariable: '--oc-left-sidebar-width',
+        // canResize also returns false on mobile: the hook cancels an in-flight
+        // drag when the guard flips (the component stays mounted, returning
+        // null below, so an unmount-only cleanup would never run).
+        canResize: () => isOpen && !isMobile,
+        getCurrentWidth: () => openWidth,
+        traceSpanName: 'ui.sidebar.resize',
+        // Quick open/close toggles go through the SAME per-frame width writer
+        // as a pointer drag (200ms programmatic animation) so the chat anchor
+        // controller keeps the seam stable. The hook is the ONLY writer of
+        // --oc-left-sidebar-width; React re-renders never touch it.
+        programmaticTarget: {
+            key: isOpen ? 'open' : 'close',
+            width: isOpen ? openWidth : 0,
+            cause: 'visibility',
+        },
+    });
 
-        try {
-            event.currentTarget.setPointerCapture(event.pointerId);
-        } catch {
-            // ignore
-        }
-
-        activeResizePointerIDRef.current = event.pointerId;
-        setIsResizing(true);
-        startXRef.current = event.clientX;
-        startWidthRef.current = appliedWidth;
-        resizingWidthRef.current = appliedWidth;
-        applyLiveWidth(appliedWidth);
-        event.preventDefault();
-    };
-
-    const handlePointerMove = (event: React.PointerEvent) => {
-        if (isMobile || !isResizing || activeResizePointerIDRef.current !== event.pointerId) {
-            return;
-        }
-
-        const delta = event.clientX - startXRef.current;
-        const nextWidth = clampSidebarWidth(startWidthRef.current + delta);
-        if (resizingWidthRef.current === nextWidth) {
-            return;
-        }
-
-        resizingWidthRef.current = nextWidth;
-        applyLiveWidth(nextWidth);
-    };
-
-    const handlePointerEnd = (event: React.PointerEvent) => {
-        if (activeResizePointerIDRef.current !== event.pointerId || isMobile) {
-            return;
-        }
-
-        try {
-            event.currentTarget.releasePointerCapture(event.pointerId);
-        } catch {
-            // ignore
-        }
-
-        const finalWidth = clampSidebarWidth(resizingWidthRef.current ?? appliedWidth);
-        activeResizePointerIDRef.current = null;
-        resizingWidthRef.current = null;
-        setIsResizing(false);
-        setSidebarWidth(finalWidth);
-    };
-
-    const currentWidth = isResizing ? (resizingWidthRef.current ?? appliedWidth) : appliedWidth;
+    if (isMobile) {
+        return null;
+    }
 
     return (
         <aside
-            ref={sidebarRef}
+            ref={containerRef}
             className={cn(
-                'relative flex h-full overflow-hidden border-r border-border will-change-[width] motion-reduce:transition-none',
+                'relative flex h-full overflow-hidden border-r border-border will-change-[width]',
                 'bg-sidebar',
                 !isOpen && 'border-r-0',
                 className,
             )}
             style={{
-                width: `${currentWidth}px`,
-                minWidth: `${currentWidth}px`,
-                maxWidth: `${currentWidth}px`,
-                ['--oc-left-sidebar-width' as string]: `${isResizing ? currentWidth : openWidth}px`,
+                // Live flex resize: the sidebar stays in the flex row while
+                // dragging, so the chat surface reflows in real time. Layout
+                // containment keeps the sidebar's subtree from widening the
+                // layout dirt during the drag; final width is committed once
+                // on pointerup. The width is driven by the resize hook's
+                // programmatic animation on open/close — no CSS width
+                // transition (the JS animation is the single interpolator).
+                // flex:none + the CSS variable keep React re-renders from ever
+                // overriding the hook's width writes.
+                contain: isResizing ? 'layout style paint' : undefined,
+                flex: 'none',
+                width: 'var(--oc-left-sidebar-width, 0px)',
+                minWidth: 'var(--oc-left-sidebar-width, 0px)',
+                maxWidth: 'var(--oc-left-sidebar-width, 0px)',
                 overflowX: 'clip',
-                transitionProperty: isResizing ? 'none' : 'width, min-width, max-width',
-                transitionDuration: '200ms',
-                transitionTimingFunction: 'cubic-bezier(0.22, 1, 0.36, 1)',
             }}
-            aria-hidden={!isOpen || appliedWidth === 0}
+            aria-hidden={!isOpen}
         >
             {isOpen && (
-                <div
-                    className="pointer-events-none absolute inset-0 z-30 shadow-[inset_-2px_0_10px_-2px_rgb(0_0_0_/_0.06)]"
-                    aria-hidden="true"
-                />
+                <div className="pointer-events-none absolute inset-0 z-30 shadow-[inset_-2px_0_10px_-2px_rgb(0_0_0_/_0.06)]" aria-hidden="true" />
             )}
             {isOpen && (
                 <div
@@ -156,9 +95,9 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, isMobile, children, cl
                         isResizing && 'bg-[var(--interactive-border)]'
                     )}
                     onPointerDown={handlePointerDown}
-                    onPointerMove={handlePointerMove}
-                    onPointerUp={handlePointerEnd}
-                    onPointerCancel={handlePointerEnd}
+                    onPointerUp={handlePointerUp}
+                    onPointerCancel={handlePointerAbort}
+                    onLostPointerCapture={handlePointerAbort}
                     role="separator"
                     aria-orientation="vertical"
                     aria-label={t('sidebar.resize.leftPanelAria')}

--- a/packages/ui/src/components/layout/usePanelResize.test.tsx
+++ b/packages/ui/src/components/layout/usePanelResize.test.tsx
@@ -1,0 +1,1182 @@
+/**
+ * Regression tests for the panel resize hook (issue: drag never started).
+ *
+ * The P0 bug was that handlePointerDown initialized the pointer, width and
+ * transaction but never set isResizing=true, so the window-level
+ * pointermove/pointerup effect bailed out early and NO panel could be
+ * dragged. The fix installs the window listeners synchronously in
+ * pointerdown and keeps isResizing purely visual.
+ *
+ * These tests mount a real component using usePanelResize via createRoot
+ * against a minimal DOM/window stub (Bun provides no DOM by default) and
+ * drive the returned handlers directly, firing synthetic window pointer
+ * events to exercise the real listener closures.
+ *
+ * Round 10 additions: the hook is the ONLY width writer (React re-renders
+ * never clobber the CSS variable), `width === 0` is a legal close target
+ * (never min-clamped), programmatic open/close/mode/parent-layout NEVER call
+ * onUserCommitWidth, a semantic target mid-drag hands over in the SAME
+ * global transaction, parent-layout follows re-resolve per frame without
+ * restarting the animation clock, and both panels share one transaction.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { usePanelResize, type ProgrammaticPanelTarget } from "./usePanelResize";
+import {
+  beginResizeInteraction,
+  getCurrentResizeTransactionId,
+  getResizeInteractionPhase,
+  registerResizeFrameParticipant,
+  resetResizeFrameParticipantsForTests,
+  resetResizeInteractionForTests,
+  setResizeSchedulerForTests,
+  type ResizeScheduler,
+} from "@/lib/resizeInteraction";
+
+// --- Minimal DOM stub (window listeners + rAF controllable) --------------
+
+class FakeStyle {
+  private readonly values = new Map<string, string>();
+  setProperty(key: string, value: string): void { this.values.set(key, String(value)); }
+  getPropertyValue(key: string): string { return this.values.get(key) ?? ""; }
+  get(key: string): string | undefined { return this.values.get(key); }
+}
+
+interface FakeElement {
+  nodeType: number;
+  nodeName: string;
+  tagName: string;
+  ownerDocument: FakeElement | null;
+  parentNode: FakeElement | null;
+  childNodes: FakeElement[];
+  style: FakeStyle;
+  setAttribute(): void;
+  removeAttribute(): void;
+  hasAttribute(): boolean;
+  getAttribute(): string | null;
+  setPointerCapture(): void;
+  releasePointerCapture(): void;
+  addEventListener(): void;
+  removeEventListener(): void;
+  appendChild(c: FakeElement): FakeElement;
+  insertBefore(c: FakeElement, ref: FakeElement): FakeElement;
+  removeChild(c: FakeElement): FakeElement;
+  contains(): boolean;
+  cloneNode(): FakeElement;
+  textContent: string;
+  innerHTML: string;
+}
+
+function makeElement(tag: string, ownerDocument: FakeElement | null = null): FakeElement {
+  const el: FakeElement = {
+    nodeType: 1,
+    nodeName: tag.toUpperCase(),
+    tagName: tag.toUpperCase(),
+    ownerDocument,
+    parentNode: null,
+    childNodes: [],
+    style: new FakeStyle(),
+    setAttribute() {},
+    removeAttribute() {},
+    hasAttribute() { return false; },
+    getAttribute() { return null; },
+    setPointerCapture() {},
+    releasePointerCapture() {},
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild(c) { this.childNodes.push(c); c.parentNode = this; return c; },
+    insertBefore(c, ref) {
+      const i = this.childNodes.indexOf(ref);
+      if (i < 0) this.childNodes.push(c); else this.childNodes.splice(i, 0, c);
+      c.parentNode = this;
+      return c;
+    },
+    removeChild(c) {
+      const i = this.childNodes.indexOf(c);
+      if (i >= 0) this.childNodes.splice(i, 1);
+      c.parentNode = null;
+      return c;
+    },
+    contains() { return false; },
+    cloneNode() { return el; },
+    textContent: "",
+    innerHTML: "",
+  };
+  (el as unknown as { __uid?: number }).__uid = ++makeElement.uidCounter;
+  return el;
+}
+makeElement.uidCounter = 0;
+
+type Handler = (event: Record<string, unknown>) => void;
+
+function installDomStub() {
+  const windowListeners = new Map<string, Handler[]>();
+  const documentListeners = new Map<string, Handler[]>();
+  // rAF queue entries carry their id so cancelAnimationFrame can remove a
+  // pending frame (the programmatic animation's stop path relies on it).
+  const rafQueue: Array<{ id: number; fn: () => void }> = [];
+  let rafId = 1;
+
+  const documentElement = makeElement("html", null);
+  const body = makeElement("body", null);
+  const documentObj = {
+    nodeType: 9,
+    nodeName: "#document",
+    tagName: "#document",
+    parentNode: null,
+    childNodes: [],
+    style: new FakeStyle(),
+    body,
+    documentElement,
+    visibilityState: "visible",
+    createElement(tag: string) { return makeElement(tag, documentObj as unknown as FakeElement); },
+    createElementNS(_ns: string, tag: string) { return makeElement(tag, documentObj as unknown as FakeElement); },
+    createTextNode(text: string) {
+      return { nodeType: 3, nodeName: "#text", textContent: text, parentNode: null, ownerDocument: documentObj } as unknown as FakeElement;
+    },
+    getElementById() { return null; },
+    addEventListener(type: string, fn: Handler) {
+      const list = documentListeners.get(type) ?? [];
+      list.push(fn);
+      documentListeners.set(type, list);
+    },
+    removeEventListener(type: string, fn: Handler) {
+      documentListeners.set(type, (documentListeners.get(type) ?? []).filter((h) => h !== fn));
+    },
+    activeElement: null,
+    HTMLIFrameElement: class {},
+    HTMLFrameSetElement: class {},
+    HTMLInputElement: class {},
+    HTMLTextAreaElement: class {},
+    HTMLSelectElement: class {},
+    HTMLOptionElement: class {},
+    HTMLAnchorElement: class {},
+  };
+  documentObj.body = makeElement("body", documentObj as unknown as FakeElement);
+  documentObj.documentElement = makeElement("html", documentObj as unknown as FakeElement);
+
+  const windowObj = {
+    document: documentObj,
+    navigator: { userAgent: "test", platform: "test", maxTouchPoints: 0 },
+    matchMedia() { return { matches: false, addEventListener() {}, removeEventListener() {} }; },
+    addEventListener(type: string, fn: Handler) {
+      const list = windowListeners.get(type) ?? [];
+      list.push(fn);
+      windowListeners.set(type, list);
+    },
+    removeEventListener(type: string, fn: Handler) {
+      windowListeners.set(type, (windowListeners.get(type) ?? []).filter((h) => h !== fn));
+    },
+    requestAnimationFrame(fn: () => void) { rafQueue.push({ id: rafId, fn }); return rafId++; },
+    cancelAnimationFrame(id: number) {
+      const idx = rafQueue.findIndex((entry) => entry.id === id);
+      if (idx >= 0) rafQueue.splice(idx, 1);
+    },
+    HTMLIFrameElement: class {},
+    HTMLFrameSetElement: class {},
+    HTMLInputElement: class {},
+    HTMLTextAreaElement: class {},
+    HTMLSelectElement: class {},
+    HTMLOptionElement: class {},
+    HTMLAnchorElement: class {},
+  };
+
+  const g = globalThis as unknown as {
+    document?: typeof documentObj;
+    window?: typeof windowObj;
+    navigator?: typeof windowObj.navigator;
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  const previous = {
+    document: g.document,
+    window: g.window,
+    navigator: g.navigator,
+    IS_REACT_ACT_ENVIRONMENT: g.IS_REACT_ACT_ENVIRONMENT,
+  };
+  g.IS_REACT_ACT_ENVIRONMENT = true;
+  g.document = documentObj as unknown as typeof g.document;
+  g.window = windowObj as unknown as typeof g.window;
+  g.navigator = windowObj.navigator as unknown as typeof g.navigator;
+
+  return {
+    windowObj,
+    documentObj,
+    fireWindow(type: string, event: Record<string, unknown>) {
+      for (const fn of windowListeners.get(type) ?? []) fn(event);
+    },
+    fireDocument(type: string, event: Record<string, unknown>) {
+      for (const fn of documentListeners.get(type) ?? []) fn(event);
+    },
+    flushRaf() {
+      const pending = rafQueue.splice(0, rafQueue.length);
+      for (const entry of pending) entry.fn();
+    },
+    restore() {
+      g.document = previous.document;
+      g.window = previous.window;
+      g.navigator = previous.navigator;
+      g.IS_REACT_ACT_ENVIRONMENT = previous.IS_REACT_ACT_ENVIRONMENT;
+    },
+  };
+}
+
+type HarnessApi = {
+  isResizing: () => boolean;
+  container: () => FakeElement | null;
+  handlePointerDown: (event: Record<string, unknown>) => void;
+  handlePointerUp: (event: Record<string, unknown>) => void;
+  handlePointerAbort: (event: Record<string, unknown>) => void;
+  notifyAvailableWidthChange: () => void;
+};
+
+// Deterministic scheduler for the resize state machine (no global timers).
+const fakeScheduler: ResizeScheduler = {
+  setTimeout: () => 1,
+  clearTimeout: () => undefined,
+  requestAnimationFrame: (fn: () => void) => { queueMicrotask(fn); return 1; },
+  cancelAnimationFrame: () => undefined,
+};
+
+const Harness: React.FC<{
+  id?: string;
+  reverse?: boolean;
+  initial?: number;
+  onUserCommit?: (width: number) => void;
+  transactionSource?: "left-sidebar" | "context-panel";
+  programmaticTarget?: ProgrammaticPanelTarget | null;
+  resolveFollowWidth?: () => number | null;
+  programmaticDurationMs?: number;
+  /** A React-managed style prop: proves re-renders never clobber --w. */
+  styleProp?: React.CSSProperties;
+}> = ({
+  id = "default",
+  reverse = false,
+  initial = 200,
+  onUserCommit = () => {},
+  transactionSource = "left-sidebar",
+  programmaticTarget = null,
+  resolveFollowWidth,
+  programmaticDurationMs,
+  styleProp,
+}) => {
+  const { isResizing, containerRef, handlePointerDown, handlePointerUp, handlePointerAbort, notifyAvailableWidthChange } = usePanelResize({
+    minWidth: 100,
+    maxWidth: 500,
+    onUserCommitWidth: onUserCommit,
+    transactionSource,
+    widthCssVariable: "--w",
+    reverse,
+    getCurrentWidth: () => initial,
+    programmaticTarget,
+    resolveFollowWidth,
+    programmaticDurationMs,
+  });
+  React.useEffect(() => {
+    const g = globalThis as unknown as { __resizeHarnessMap?: Record<string, HarnessApi> };
+    g.__resizeHarnessMap = g.__resizeHarnessMap ?? {};
+    g.__resizeHarnessMap[id] = {
+      isResizing: () => isResizing,
+      container: () => containerRef.current as unknown as FakeElement | null,
+      handlePointerDown: handlePointerDown as unknown as HarnessApi["handlePointerDown"],
+      handlePointerUp: handlePointerUp as unknown as HarnessApi["handlePointerUp"],
+      handlePointerAbort: handlePointerAbort as unknown as HarnessApi["handlePointerAbort"],
+      notifyAvailableWidthChange,
+    };
+  });
+  return React.createElement("div", { ref: containerRef as React.Ref<HTMLDivElement>, style: styleProp });
+};
+
+const makePointerEvent = (overrides: Record<string, unknown>) => ({
+  pointerId: 1,
+  button: 0,
+  isPrimary: true,
+  clientX: 100,
+  currentTarget: makeElement("div"),
+  preventDefault() {},
+  ...overrides,
+});
+
+let stub: ReturnType<typeof installDomStub> | null = null;
+let root: Root | null = null;
+let root2: Root | null = null;
+let onCommitCalls: number[] = [];
+
+const apiFor = (id: string): HarnessApi => {
+  const g = globalThis as unknown as { __resizeHarnessMap?: Record<string, HarnessApi> };
+  return g.__resizeHarnessMap![id];
+};
+
+beforeEach(() => {
+  stub = installDomStub();
+  setResizeSchedulerForTests(fakeScheduler);
+  resetResizeInteractionForTests();
+  resetResizeFrameParticipantsForTests();
+  onCommitCalls = [];
+});
+
+afterEach(async () => {
+  // Unmount inside act: the hook's unmount cleanups may flip isResizing and
+  // must not produce "update not wrapped in act" warnings.
+  await act(async () => {
+    root?.unmount();
+    root = null;
+    root2?.unmount();
+    root2 = null;
+  });
+  // Let React's scheduler flush any deferred (macrotask) work BEFORE the DOM
+  // stub is removed — otherwise that work runs with window=undefined.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  stub?.restore();
+  stub = null;
+  delete (globalThis as unknown as { __resizeHarnessMap?: Record<string, HarnessApi> }).__resizeHarnessMap;
+});
+
+const renderHarness = (host: { root: Root | null; container: FakeElement | null }, id: string, props: React.ComponentProps<typeof Harness>) => {
+  const container = host.container ?? stub!.documentObj.createElement("div");
+  if (!host.container) {
+    stub!.documentObj.body.appendChild(container);
+    host.container = container;
+  }
+  host.root = createRoot(container as unknown as HTMLElement);
+  return act(async () => {
+    host.root!.render(React.createElement(Harness, { id, ...props }));
+  });
+};
+
+// The harness re-exposes itself on every render (its useEffect replaces the
+// map entry), so hand back a proxy that always reads the LATEST one.
+const proxyApi = (id: string): HarnessApi => ({
+  isResizing: () => apiFor(id).isResizing(),
+  container: () => apiFor(id).container(),
+  handlePointerDown: (e: Record<string, unknown>) => apiFor(id).handlePointerDown(e),
+  handlePointerUp: (e: Record<string, unknown>) => apiFor(id).handlePointerUp(e),
+  handlePointerAbort: (e: Record<string, unknown>) => apiFor(id).handlePointerAbort(e),
+  notifyAvailableWidthChange: () => apiFor(id).notifyAvailableWidthChange(),
+});
+
+const mount = async (props: React.ComponentProps<typeof Harness>) => {
+  // A second mount in the same test must not leak the previous root: the
+  // leaked harness's effects (rAF/animation) would keep running against the
+  // NEXT test's fresh DOM stub and pollute its assertions.
+  await act(async () => {
+    root?.unmount();
+    root = null;
+  });
+  const host = { root: null as Root | null, container: null as FakeElement | null };
+  await renderHarness(host, "default", props);
+  root = host.root;
+  return proxyApi("default");
+};
+
+const mountSecond = async (props: React.ComponentProps<typeof Harness>) => {
+  await act(async () => {
+    root2?.unmount();
+    root2 = null;
+  });
+  const host = { root: null as Root | null, container: null as FakeElement | null };
+  await renderHarness(host, "second", props);
+  root2 = host.root;
+  return proxyApi("second");
+};
+const startDrag = async (api: HarnessApi, clientX: number) => {
+  const handle = makeElement("div");
+  await act(async () => {
+    api.handlePointerDown(makePointerEvent({ clientX, currentTarget: handle }));
+  });
+  return handle;
+};
+
+describe("usePanelResize drag lifecycle", () => {
+  test("pointerdown flips isResizing to true (P0 regression)", async () => {
+    const api = await mount({});
+    expect(api.isResizing()).toBe(false);
+    await startDrag(api, 100);
+    expect(api.isResizing()).toBe(true);
+  });
+
+  test("pointermove 100px changes the CSS width by 100±1 before pointerup", async () => {
+    const api = await mount({ initial: 200 });
+    await startDrag(api, 100);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 200 });
+    stub!.flushRaf();
+    const width = Number.parseFloat(api.container()!.style.get("--w") ?? "");
+    expect(Math.abs(width - 300) <= 1).toBe(true);
+  });
+
+  test("left handle (default direction) widens when dragging right", async () => {
+    const api = await mount({ initial: 200 });
+    await startDrag(api, 100);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 250 });
+    stub!.flushRaf();
+    const width = Number.parseFloat(api.container()!.style.get("--w") ?? "");
+    expect(width).toBeGreaterThan(200);
+  });
+
+  test("reverse handle widens when dragging left", async () => {
+    const api = await mount({ initial: 200, reverse: true });
+    await startDrag(api, 300);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 200 });
+    stub!.flushRaf();
+    const width = Number.parseFloat(api.container()!.style.get("--w") ?? "");
+    expect(width).toBeGreaterThan(200);
+  });
+
+  test("pointerup persists exactly once", async () => {
+    const api = await mount({ initial: 200, onUserCommit: (w) => onCommitCalls.push(w) });
+    const handle = await startDrag(api, 100);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 250 });
+    stub!.flushRaf();
+    await act(async () => {
+      api.handlePointerUp(makePointerEvent({ clientX: 250, currentTarget: handle }));
+    });
+    expect(onCommitCalls).toHaveLength(1);
+    expect(api.isResizing()).toBe(false);
+  });
+
+  test("pointercancel does not persist and ends the drag", async () => {
+    const api = await mount({ initial: 200, onUserCommit: (w) => onCommitCalls.push(w) });
+    await startDrag(api, 100);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 250 });
+    stub!.flushRaf();
+    await act(async () => {
+      api.handlePointerAbort(makePointerEvent({ pointerId: 1 }));
+    });
+    expect(onCommitCalls).toHaveLength(0);
+    expect(api.isResizing()).toBe(false);
+  });
+
+  test("window blur does not persist", async () => {
+    const api = await mount({ initial: 200, onUserCommit: (w) => onCommitCalls.push(w) });
+    await startDrag(api, 100);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 250 });
+    stub!.flushRaf();
+    await act(async () => {
+      stub!.fireWindow("blur", {});
+    });
+    expect(onCommitCalls).toHaveLength(0);
+    expect(api.isResizing()).toBe(false);
+  });
+
+  test("visibilitychange hidden does not persist; visible is a no-op", async () => {
+    const api = await mount({ initial: 200, onUserCommit: (w) => onCommitCalls.push(w) });
+    await startDrag(api, 100);
+    // visible -> nothing
+    stub!.documentObj.visibilityState = "visible";
+    await act(async () => {
+      stub!.fireDocument("visibilitychange", {});
+    });
+    expect(onCommitCalls).toHaveLength(0);
+    // hidden -> cancel
+    stub!.documentObj.visibilityState = "hidden";
+    await act(async () => {
+      stub!.fireDocument("visibilitychange", {});
+    });
+    expect(onCommitCalls).toHaveLength(0);
+    expect(api.isResizing()).toBe(false);
+  });
+
+  test("a second consecutive drag still works after pointerup", async () => {
+    const api = await mount({ initial: 200, onUserCommit: (w) => onCommitCalls.push(w) });
+    // First drag
+    let handle = await startDrag(api, 100);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 220 });
+    stub!.flushRaf();
+    await act(async () => {
+      api.handlePointerUp(makePointerEvent({ clientX: 220, currentTarget: handle }));
+    });
+    // Second drag with a fresh pointer id
+    handle = makeElement("div");
+    await act(async () => {
+      api.handlePointerDown(makePointerEvent({ pointerId: 2, clientX: 220, currentTarget: handle }));
+    });
+    expect(api.isResizing()).toBe(true);
+    stub!.fireWindow("pointermove", { pointerId: 2, clientX: 320 });
+    stub!.flushRaf();
+    await act(async () => {
+      api.handlePointerUp(makePointerEvent({ pointerId: 2, clientX: 320, currentTarget: handle }));
+    });
+    expect(onCommitCalls).toHaveLength(2);
+  });
+
+  test("root phase transitions dragging -> finalizing -> idle (transaction)", async () => {
+    const txId = beginResizeInteraction("left-sidebar");
+    void txId;
+    const api = await mount({});
+    await startDrag(api, 100);
+    expect(api.isResizing()).toBe(true);
+    const handle = makeElement("div");
+    await act(async () => {
+      api.handlePointerUp(makePointerEvent({ currentTarget: handle }));
+    });
+    expect(api.isResizing()).toBe(false);
+  });
+
+  test("live width frames notify resize frame participants with transactionId/width/kind", async () => {
+    const seen: Array<{ transactionId: number; width: number; kind: string }> = [];
+    const unsubscribe = registerResizeFrameParticipant((frame) => { seen.push({ ...frame }); });
+    const api = await mount({ initial: 200 });
+    await startDrag(api, 100);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 200 });
+    stub!.flushRaf();
+    expect(seen.length).toBe(1);
+    expect(seen[0].width).toBe(300);
+    expect(seen[0].kind).toBe("drag");
+    expect(typeof seen[0].transactionId).toBe("number");
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 250 });
+    stub!.flushRaf();
+    expect(seen.length).toBe(2);
+    expect(seen[1].width).toBe(350);
+    expect(seen[1].kind).toBe("drag");
+    unsubscribe();
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 300 });
+    stub!.flushRaf();
+    expect(seen.length).toBe(2);
+  });
+});
+
+// --- Programmatic width animation (quick open/close toggles, mode switches) --
+describe("programmatic resize targets", () => {
+  const realNow = performance.now.bind(performance);
+  let fakeTime = 0;
+  let realMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    fakeTime = 0;
+    realMatchMedia = window.matchMedia;
+    // Replace ONLY the now() method — spreading performance would drop the
+    // prototype methods (mark/measure) React's render timing relies on.
+    (globalThis as unknown as { performance: typeof performance }).performance.now = () => fakeTime;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { performance: typeof performance }).performance.now = realNow;
+    if (realMatchMedia) window.matchMedia = realMatchMedia;
+  });
+
+  const width = (api: HarnessApi) => Number.parseFloat(api.container()!.style.get("--w") ?? "");
+
+  test("animates monotonically to the target, commits once, and ends the transaction", async () => {
+    const onUserCommit: number[] = [];
+    // Initial mount: the first target writes the final width WITHOUT a
+    // transaction (component bootstrap).
+    const api = await mount({
+      initial: 200,
+      programmaticTarget: { key: "open", width: 200, cause: "visibility" },
+      onUserCommit: (w) => onUserCommit.push(w),
+    });
+    expect(width(api)).toBe(200);
+    expect(getResizeInteractionPhase()).toBe("idle");
+    // Target change: animate 200 -> 300 over 200ms.
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 300, cause: "visibility" },
+        onUserCommit: (w) => onUserCommit.push(w),
+      }));
+    });
+    expect(getResizeInteractionPhase()).toBe("dragging");
+    // Intermediate frames: monotonic increase toward 300.
+    let last = 200;
+    for (let i = 0; i < 12; i += 1) {
+      fakeTime += 20;
+      await act(async () => { stub!.flushRaf(); });
+      const w = width(api);
+      expect(w).toBeGreaterThanOrEqual(last);
+      expect(w <= 300).toBe(true);
+      last = w;
+    }
+    // After the duration has elapsed the final frame commits exactly once.
+    fakeTime += 100;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(300);
+    // Programmatic animation NEVER persists the width (user intent only).
+    expect(onUserCommit).toEqual([]);
+    expect(api.isResizing()).toBe(false);
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("same key and near-identical width start NO transaction", async () => {
+    const api = await mount({ initial: 200, programmaticTarget: { key: "open", width: 200, cause: "visibility" } });
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 200, cause: "visibility" },
+      }));
+    });
+    expect(getResizeInteractionPhase()).toBe("idle");
+    expect(api.isResizing()).toBe(false);
+  });
+
+  test("a target change mid-animation re-directs from the CURRENT width (no jump back)", async () => {
+    const api = await mount({ initial: 200, programmaticTarget: { key: "open", width: 200, cause: "visibility" } });
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 300, cause: "visibility" },
+      }));
+    });
+    fakeTime += 60; // ~1/3 of the way
+    await act(async () => { stub!.flushRaf(); });
+    const mid = width(api);
+    expect(mid).toBeGreaterThan(200);
+    expect(mid).toBeLessThan(300);
+    // Re-direct to 400 from the CURRENT width.
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open2", width: 400, cause: "visibility" },
+      }));
+    });
+    expect(width(api)).toBe(mid); // No jump back to 200.
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(400);
+  });
+
+  test("expand/collapse (mode cause, key change) animates from the current width", async () => {
+    const api = await mount({ initial: 300, programmaticTarget: { key: "open:file", width: 300, cause: "mode" } });
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 300,
+        programmaticTarget: { key: "expand:file", width: 450, cause: "mode" },
+      }));
+    });
+    // Re-direct from the current (300) width; the first frame must be between.
+    fakeTime += 60;
+    await act(async () => { stub!.flushRaf(); });
+    const mid = width(api);
+    expect(mid).toBeGreaterThan(300);
+    expect(mid).toBeLessThan(450);
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(450);
+  });
+
+  test("a pointerdown mid-animation hands over from the current width", async () => {
+    const api = await mount({ initial: 200, programmaticTarget: { key: "open", width: 200, cause: "visibility" } });
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 300, cause: "visibility" },
+      }));
+    });
+    fakeTime += 60;
+    await act(async () => { stub!.flushRaf(); });
+    const mid = width(api);
+    // Pointer takes over.
+    const handle = makeElement("div");
+    await act(async () => {
+      api.handlePointerDown(makePointerEvent({ clientX: 100, currentTarget: handle }));
+    });
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 160 });
+    await act(async () => { stub!.flushRaf(); });
+    // The width now follows the pointer from the mid-animation value.
+    expect(width(api)).toBe(mid + 60);
+  });
+
+  test("unmounting mid-animation cancels the transaction", async () => {
+    const api = await mount({ initial: 200, programmaticTarget: { key: "open", width: 200, cause: "visibility" } });
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 300, cause: "visibility" },
+      }));
+    });
+    fakeTime += 40;
+    await act(async () => { stub!.flushRaf(); });
+    expect(getResizeInteractionPhase()).toBe("dragging");
+    await act(async () => {
+      root!.unmount();
+      root = null;
+    });
+    // Unmount cancels the transaction; the finalizing -> idle edge is
+    // microtask-flushed by the fake scheduler.
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    expect(getResizeInteractionPhase()).toBe("idle");
+    void api;
+  });
+});
+
+// --- Round 10: single writer, legal 0 target, no programmatic persistence ---
+describe("round 10: single width writer and legal close target", () => {
+  const realNow = performance.now.bind(performance);
+  let fakeTime = 0;
+
+  beforeEach(() => {
+    fakeTime = 0;
+    (globalThis as unknown as { performance: typeof performance }).performance.now = () => fakeTime;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { performance: typeof performance }).performance.now = realNow;
+  });
+
+  const width = (api: HarnessApi) => Number.parseFloat(api.container()!.style.get("--w") ?? "");
+
+  test("close target 0 is legal and animates to 0 below minWidth", async () => {
+    // minWidth is 100 — a closed panel must reach exactly 0, not 100.
+    const api = await mount({ initial: 300, programmaticTarget: { key: "open", width: 300, cause: "visibility" } });
+    expect(width(api)).toBe(300);
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 300,
+        programmaticTarget: { key: "close", width: 0, cause: "visibility" },
+      }));
+    });
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(0);
+  });
+
+  test("programmatic open and close never call onUserCommitWidth", async () => {
+    const onUserCommit: number[] = [];
+    const api = await mount({
+      initial: 200,
+      programmaticTarget: { key: "close", width: 0, cause: "visibility" },
+      onUserCommit: (w) => onUserCommit.push(w),
+    });
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 300, cause: "visibility" },
+        onUserCommit: (w) => onUserCommit.push(w),
+      }));
+    });
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(300);
+    // Close again.
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "close", width: 0, cause: "visibility" },
+        onUserCommit: (w) => onUserCommit.push(w),
+      }));
+    });
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(0);
+    expect(onUserCommit).toEqual([]);
+  });
+
+  test("a React re-render cannot overwrite the hook-written CSS variable", async () => {
+    const styleProp = { backgroundColor: "red" as const };
+    const api = await mount({
+      initial: 200,
+      programmaticTarget: { key: "open", width: 200, cause: "visibility" },
+      styleProp,
+    });
+    // Hook animates the width to 340.
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 340, cause: "visibility" },
+        styleProp,
+      }));
+    });
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(340);
+    // React-managed style changes (re-render) must not clobber --w.
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 340, cause: "visibility" },
+        styleProp: { backgroundColor: "blue" },
+      }));
+    });
+    expect(width(api)).toBe(340);
+  });
+
+  test("a close target mid-drag hands over in the SAME transaction and never persists", async () => {
+    const onUserCommit: number[] = [];
+    const api = await mount({ initial: 300, onUserCommit: (w) => onUserCommit.push(w) });
+    // Pointer drag moves the panel to ~380.
+    await startDrag(api, 100);
+    stub!.fireWindow("pointermove", { pointerId: 1, clientX: 180 });
+    stub!.flushRaf();
+    expect(width(api)).toBe(380);
+    const txDuringDrag = getCurrentResizeTransactionId();
+    expect(txDuringDrag).not.toBeNull();
+    // Semantic close arrives mid-drag: the SAME transaction continues the
+    // animation 380 -> 0 (no release, no new transaction, no persistence).
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 300,
+        programmaticTarget: { key: "close", width: 0, cause: "visibility" },
+        onUserCommit: (w) => onUserCommit.push(w),
+      }));
+    });
+    expect(getCurrentResizeTransactionId()).toBe(txDuringDrag);
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(0);
+    expect(onUserCommit).toEqual([]);
+    expect(api.isResizing()).toBe(false);
+    expect(getResizeInteractionPhase()).toBe("idle");
+    // Re-open from 0 (drag already handed over; no user persistence).
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 300,
+        programmaticTarget: { key: "open", width: 300, cause: "visibility" },
+        onUserCommit: (w) => onUserCommit.push(w),
+      }));
+    });
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(300);
+    expect(onUserCommit).toEqual([]);
+  });
+});
+
+// --- Round 10: parent-layout follow + shared transaction -------------------
+describe("round 10: parent-layout follow and shared transaction", () => {
+  const realNow = performance.now.bind(performance);
+  let fakeTime = 0;
+
+  beforeEach(() => {
+    fakeTime = 0;
+    (globalThis as unknown as { performance: typeof performance }).performance.now = () => fakeTime;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { performance: typeof performance }).performance.now = realNow;
+  });
+
+  const width = (api: HarnessApi) => Number.parseFloat(api.container()!.style.get("--w") ?? "");
+
+  test("a parent-layout width change opens a short transaction and follows the new width", async () => {
+    let parentWidth = 600;
+    const api = await mount({
+      initial: 300,
+      programmaticTarget: { key: "open:mode", width: 300, cause: "parent-layout" },
+      resolveFollowWidth: () => Math.round(0.5 * parentWidth),
+    });
+    expect(width(api)).toBe(300);
+    expect(getResizeInteractionPhase()).toBe("idle");
+    // ResizeObserver-style wake-up: parent grows -> follow re-resolves to 350.
+    parentWidth = 700;
+    await act(async () => {
+      api.notifyAvailableWidthChange();
+      stub!.flushRaf();
+    });
+    expect(width(api)).toBe(350);
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("parent width changes during an open animation re-resolve the goal without restarting the clock", async () => {
+    let parentWidth = 600; // 0.5 * 600 = 300
+    const api = await mount({
+      initial: 0,
+      programmaticTarget: { key: "close", width: 0, cause: "visibility" },
+      resolveFollowWidth: () => Math.round(0.5 * parentWidth),
+    });
+    // Open toward 300 (parent-layout cause, key change -> animate).
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 0,
+        programmaticTarget: { key: "open:mode", width: 300, cause: "parent-layout" },
+        resolveFollowWidth: () => Math.round(0.5 * parentWidth),
+      }));
+    });
+    fakeTime += 60;
+    await act(async () => { stub!.flushRaf(); });
+    const mid = width(api);
+    expect(mid).toBeGreaterThan(0);
+    // Parent changes mid-animation: the goal must move 300 -> 350 WITHOUT
+    // restarting (the animation never jumps back to the start width).
+    parentWidth = 700;
+    fakeTime += 60;
+    await act(async () => { stub!.flushRaf(); });
+    const mid2 = width(api);
+    expect(mid2).toBeGreaterThanOrEqual(mid);
+    fakeTime += 200;
+    await act(async () => { stub!.flushRaf(); });
+    // Lands on the FINAL parent-derived goal.
+    expect(width(api)).toBe(350);
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("a closed panel ignores parent-layout changes (no follow, no transaction)", async () => {
+    let parentWidth = 600;
+    const api = await mount({
+      initial: 0,
+      programmaticTarget: { key: "close:mode", width: 0, cause: "visibility" },
+      resolveFollowWidth: () => (parentWidth === 600 ? null : Math.round(0.5 * parentWidth)),
+    });
+    expect(width(api)).toBe(0);
+    parentWidth = 800;
+    await act(async () => {
+      api.notifyAvailableWidthChange();
+      stub!.flushRaf();
+    });
+    // resolveFollowWidth returns null while closed -> nothing happens.
+    expect(width(api)).toBe(0);
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("left and right panels changing together share ONE global transaction", async () => {
+    const left = await mount({
+      initial: 200,
+      programmaticTarget: { key: "open", width: 200, cause: "visibility" },
+    });
+    // Left animates 200 -> 300, opening transaction T.
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 200,
+        programmaticTarget: { key: "open", width: 300, cause: "visibility" },
+      }));
+    });
+    const txId = getCurrentResizeTransactionId();
+    expect(txId).not.toBeNull();
+    // Right panel starts its own animation mid-left-transition: it must JOIN T
+    // (no second transaction, no re-capture).
+    const right = await mountSecond({
+      transactionSource: "context-panel",
+      initial: 200,
+      programmaticTarget: { key: "open:mode", width: 200, cause: "visibility" },
+    });
+    await act(async () => {
+      root2!.render(React.createElement(Harness, {
+        id: "second",
+        transactionSource: "context-panel",
+        initial: 200,
+        programmaticTarget: { key: "open:mode", width: 260, cause: "visibility" },
+      }));
+    });
+    expect(getCurrentResizeTransactionId()).toBe(txId);
+    // Let both finish; the transaction finalizes exactly once.
+    fakeTime += 300;
+    await act(async () => { stub!.flushRaf(); });
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    expect(getResizeInteractionPhase()).toBe("idle");
+    expect(width(left)).toBe(300);
+    expect(width(right)).toBe(260);
+  });
+});
+
+// --- Round 11: motion profiles (standard 200ms / reduced 120ms) -----------
+describe("round 11: motion profiles (standard 200ms / reduced 120ms)", () => {
+  const realNow = performance.now.bind(performance);
+  let realMatchMedia: typeof window.matchMedia;
+  let fakeTime = 0;
+  let reducedMotion = false;
+  let mediaListeners: Array<(matches: boolean) => void> = [];
+
+  const setReducedMotion = (reduced: boolean) => {
+    reducedMotion = reduced;
+    for (const listener of [...mediaListeners]) listener(reduced);
+  };
+
+  const installControllableMedia = () => {
+    reducedMotion = false;
+    mediaListeners = [];
+    const stubMedia = () => ({
+      get matches() { return reducedMotion; },
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      dispatchEvent: () => false,
+      addEventListener(_type: string, fn: (event: { matches: boolean }) => void) {
+        mediaListeners.push((matches) => fn({ matches }));
+      },
+      removeEventListener(_type: string, fn: (event: { matches: boolean }) => void) {
+        const index = mediaListeners.findIndex((candidate) => candidate.toString() === ((m: boolean) => fn({ matches: m })).toString());
+        if (index >= 0) mediaListeners.splice(index, 1);
+      },
+      addListener(fn: (event: { matches: boolean }) => void) {
+        mediaListeners.push((matches) => fn({ matches }));
+      },
+      removeListener(fn: (event: { matches: boolean }) => void) {
+        const index = mediaListeners.findIndex((candidate) => candidate.toString() === ((m: boolean) => fn({ matches: m })).toString());
+        if (index >= 0) mediaListeners.splice(index, 1);
+      },
+    }) as unknown as MediaQueryList;
+    window.matchMedia = stubMedia as unknown as typeof window.matchMedia;
+  };
+
+  beforeEach(() => {
+    fakeTime = 0;
+    realMatchMedia = window.matchMedia;
+    installControllableMedia();
+    (globalThis as unknown as { performance: typeof performance }).performance.now = () => fakeTime;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { performance: typeof performance }).performance.now = realNow;
+    if (realMatchMedia) window.matchMedia = realMatchMedia;
+  });
+
+  const width = (api: HarnessApi) => Number.parseFloat(api.container()!.style.get("--w") ?? "");
+
+  const driveToTarget = async (api: HarnessApi, target: number, steps: number, stepMs = 20): Promise<number[]> => {
+    const widths: number[] = [];
+    for (let i = 0; i < steps; i += 1) {
+      fakeTime += stepMs;
+      await act(async () => { stub!.flushRaf(); });
+      widths.push(width(api));
+      if (widths[widths.length - 1] === target) break;
+    }
+    return widths;
+  };
+
+  const renderTarget = (target: { key: string; width: number; cause: "visibility" | "mode" }, extra: React.ComponentProps<typeof Harness> = {}) => act(async () => {
+    root!.render(React.createElement(Harness, {
+      initial: 0,
+      programmaticTarget: target,
+      ...extra,
+    }));
+  });
+
+  test("standard mode animates 0→280 over ~200ms with strictly increasing widths (open)", async () => {
+    const api = await mount({ initial: 0, programmaticTarget: { key: "close", width: 0, cause: "visibility" } });
+    await renderTarget({ key: "open", width: 280, cause: "visibility" });
+    const widths = await driveToTarget(api, 280, 20);
+    expect(width(api)).toBe(280);
+    // First applied frame is NOT the target (no instant jump).
+    expect(widths[0]).not.toBe(280);
+    // Multiple strictly increasing intermediate widths (no jumps back).
+    const distinct = new Set(widths).size;
+    expect(distinct).toBeGreaterThanOrEqual(5);
+    for (let i = 1; i < widths.length; i += 1) {
+      expect(widths[i]).toBeGreaterThanOrEqual(widths[i - 1]);
+    }
+    // Completed at ~200ms (10 steps of 20ms), not later.
+    expect(widths.length <= 11).toBe(true);
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("standard mode animates 280→0 over ~200ms (close)", async () => {
+    const api = await mount({ initial: 0, programmaticTarget: { key: "open", width: 280, cause: "visibility" } });
+    await renderTarget({ key: "close", width: 0, cause: "visibility" });
+    const widths = await driveToTarget(api, 0, 20);
+    expect(width(api)).toBe(0);
+    expect(widths[0]).not.toBe(0);
+    expect(new Set(widths).size).toBeGreaterThanOrEqual(5);
+    for (let i = 1; i < widths.length; i += 1) {
+      expect(widths[i] <= widths[i - 1]).toBe(true);
+    }
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("reduced mode animates 0→280 over ~120ms with >= 4 distinct widths (open)", async () => {
+    setReducedMotion(true);
+    const api = await mount({ initial: 0, programmaticTarget: { key: "close", width: 0, cause: "visibility" } });
+    await renderTarget({ key: "open", width: 280, cause: "visibility" });
+    const widths = await driveToTarget(api, 280, 12);
+    expect(width(api)).toBe(280);
+    // No single-frame 0→280 jump.
+    expect(widths[0]).not.toBe(280);
+    expect(new Set(widths).size).toBeGreaterThanOrEqual(4);
+    // Completed at ~120ms (6 steps of 20ms), not at 200ms.
+    expect(widths.length <= 7).toBe(true);
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("reduced mode animates 280→0 over ~120ms (close)", async () => {
+    setReducedMotion(true);
+    const api = await mount({ initial: 0, programmaticTarget: { key: "open", width: 280, cause: "visibility" } });
+    await renderTarget({ key: "close", width: 0, cause: "visibility" });
+    const widths = await driveToTarget(api, 0, 12);
+    expect(width(api)).toBe(0);
+    expect(widths[0]).not.toBe(0);
+    expect(new Set(widths).size).toBeGreaterThanOrEqual(4);
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("neither mode ever calls onUserCommitWidth", async () => {
+    const onUserCommit: number[] = [];
+    // Standard open+close.
+    let api = await mount({
+      initial: 0,
+      programmaticTarget: { key: "close", width: 0, cause: "visibility" },
+      onUserCommit: (w) => onUserCommit.push(w),
+    });
+    await renderTarget({ key: "open", width: 280, cause: "visibility" }, { onUserCommit: (w) => onUserCommit.push(w) });
+    await driveToTarget(api, 280, 20);
+    await renderTarget({ key: "close", width: 0, cause: "visibility" }, { onUserCommit: (w) => onUserCommit.push(w) });
+    await driveToTarget(api, 0, 20);
+    // Reduced open+close.
+    setReducedMotion(true);
+    api = await mount({
+      initial: 0,
+      programmaticTarget: { key: "close", width: 0, cause: "visibility" },
+      onUserCommit: (w) => onUserCommit.push(w),
+    });
+    await renderTarget({ key: "open", width: 280, cause: "visibility" }, { onUserCommit: (w) => onUserCommit.push(w) });
+    await driveToTarget(api, 280, 12);
+    await renderTarget({ key: "close", width: 0, cause: "visibility" }, { onUserCommit: (w) => onUserCommit.push(w) });
+    await driveToTarget(api, 0, 12);
+    expect(onUserCommit).toEqual([]);
+    void api;
+  });
+
+  test("a motion-preference change mid-animation affects only the NEXT animation", async () => {
+    const api = await mount({ initial: 0, programmaticTarget: { key: "close", width: 0, cause: "visibility" } });
+    // Standard open (200ms profile snapshotted at start).
+    await renderTarget({ key: "open", width: 280, cause: "visibility" });
+    fakeTime += 60;
+    await act(async () => { stub!.flushRaf(); });
+    const mid = width(api);
+    expect(mid).toBeGreaterThan(0);
+    // System preference flips to reduce MID-animation.
+    setReducedMotion(true);
+    // The running animation must stay on the 200ms schedule: at 120ms total
+    // (t=0.6) it is still short of the target. A live profile switch to 120ms
+    // would have finished it here.
+    fakeTime += 60;
+    await act(async () => { stub!.flushRaf(); });
+    const mid2 = width(api);
+    expect(mid2).toBeLessThan(280);
+    // Complete the current animation.
+    fakeTime += 100;
+    await act(async () => { stub!.flushRaf(); });
+    expect(width(api)).toBe(280);
+    // The NEXT animation uses the reduced 120ms profile.
+    await renderTarget({ key: "close", width: 0, cause: "visibility" });
+    const closeWidths = await driveToTarget(api, 0, 12);
+    expect(width(api)).toBe(0);
+    expect(new Set(closeWidths).size).toBeGreaterThanOrEqual(4);
+  });
+
+  test("programmaticDurationMs 0 is the ONLY single-frame path (explicit test config)", async () => {
+    const api = await mount({
+      initial: 0,
+      programmaticTarget: { key: "close", width: 0, cause: "visibility" },
+      programmaticDurationMs: 0,
+    });
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 0,
+        programmaticTarget: { key: "open", width: 280, cause: "visibility" },
+        programmaticDurationMs: 0,
+      }));
+    });
+    // True single-frame jump only when explicitly configured.
+    expect(width(api)).toBe(280);
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("first mount still writes the initial width silently (no animation, no transaction)", async () => {
+    const api = await mount({ initial: 0, programmaticTarget: { key: "open", width: 280, cause: "visibility" } });
+    expect(width(api)).toBe(280);
+    expect(getResizeInteractionPhase()).toBe("idle");
+    expect(api.isResizing()).toBe(false);
+  });
+
+  test("unchanged target keeps zero transactions and zero width writes", async () => {
+    const api = await mount({ initial: 0, programmaticTarget: { key: "open", width: 280, cause: "visibility" } });
+    await act(async () => {
+      root!.render(React.createElement(Harness, {
+        initial: 0,
+        programmaticTarget: { key: "open", width: 280, cause: "visibility" },
+      }));
+    });
+    expect(getResizeInteractionPhase()).toBe("idle");
+    expect(width(api)).toBe(280);
+  });
+});
+

--- a/packages/ui/src/components/layout/usePanelResize.test.tsx
+++ b/packages/ui/src/components/layout/usePanelResize.test.tsx
@@ -31,6 +31,7 @@ import {
   getCurrentResizeTransactionId,
   getResizeInteractionPhase,
   registerResizeFrameParticipant,
+  registerResizeTransactionStartParticipant,
   resetResizeFrameParticipantsForTests,
   resetResizeInteractionForTests,
   setResizeSchedulerForTests,
@@ -185,22 +186,20 @@ function installDomStub() {
     HTMLAnchorElement: class {},
   };
 
-  const g = globalThis as unknown as {
-    document?: typeof documentObj;
-    window?: typeof windowObj;
-    navigator?: typeof windowObj.navigator;
-    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  // Another test file's stub may have left a global as a READ-ONLY
+  // (defineProperty'd) property, where plain assignment throws
+  // "Attempted to assign to readonly property" and kills every test in this
+  // file depending on file order. (Re)define instead, keeping each ORIGINAL
+  // descriptor so restore() puts back exactly what was there before.
+  const savedGlobals: Array<[string, PropertyDescriptor | undefined]> = [];
+  const setGlobal = (name: string, value: unknown) => {
+    savedGlobals.push([name, Object.getOwnPropertyDescriptor(globalThis, name)]);
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
   };
-  const previous = {
-    document: g.document,
-    window: g.window,
-    navigator: g.navigator,
-    IS_REACT_ACT_ENVIRONMENT: g.IS_REACT_ACT_ENVIRONMENT,
-  };
-  g.IS_REACT_ACT_ENVIRONMENT = true;
-  g.document = documentObj as unknown as typeof g.document;
-  g.window = windowObj as unknown as typeof g.window;
-  g.navigator = windowObj.navigator as unknown as typeof g.navigator;
+  setGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  setGlobal("document", documentObj);
+  setGlobal("window", windowObj);
+  setGlobal("navigator", windowObj.navigator);
 
   return {
     windowObj,
@@ -216,10 +215,13 @@ function installDomStub() {
       for (const entry of pending) entry.fn();
     },
     restore() {
-      g.document = previous.document;
-      g.window = previous.window;
-      g.navigator = previous.navigator;
-      g.IS_REACT_ACT_ENVIRONMENT = previous.IS_REACT_ACT_ENVIRONMENT;
+      for (const [name, descriptor] of savedGlobals.reverse()) {
+        if (descriptor) {
+          Object.defineProperty(globalThis, name, descriptor);
+        } else {
+          Reflect.deleteProperty(globalThis, name);
+        }
+      }
     },
   };
 }
@@ -1177,6 +1179,101 @@ describe("round 11: motion profiles (standard 200ms / reduced 120ms)", () => {
     });
     expect(getResizeInteractionPhase()).toBe("idle");
     expect(width(api)).toBe(280);
+  });
+});
+
+// --- Review follow-up: follow-during-drag joins the shared transaction ----
+describe("follow-during-drag joins the shared transaction", () => {
+  const widthOf = (api: HarnessApi) => Number.parseFloat(api.container()!.style.get("--w") ?? "");
+
+  test("a parent-layout follow riding a pointer drag JOINS the transaction: its frames carry the drag's transactionId and no re-capture fires", async () => {
+    const frames: Array<{ transactionId: number; kind: string; origin: string; source: string }> = [];
+    const starts: Array<{ transactionId: number; source: string; origin: string }> = [];
+    registerResizeFrameParticipant((frame) => frames.push({ ...frame }));
+    registerResizeTransactionStartParticipant((start) => starts.push({ ...start }));
+
+    // Left sidebar pointer drag opens transaction T.
+    const left = await mount({ initial: 200 });
+    let followWidth: number | null = 300;
+    const right = await mountSecond({
+      transactionSource: "context-panel",
+      initial: 300,
+      programmaticTarget: { key: "open:mode", width: 300, cause: "parent-layout" },
+      resolveFollowWidth: () => followWidth,
+    });
+    await startDrag(left, 100);
+    const txId = getCurrentResizeTransactionId();
+    expect(txId).not.toBeNull();
+
+    // Parent layout changes mid-drag: the right panel wakes up and follows.
+    followWidth = 340;
+    await act(async () => {
+      right.notifyAvailableWidthChange();
+      stub!.flushRaf();
+    });
+    // The follow frame was written WHILE RIDING, and it carries the drag's
+    // transactionId — not 0 (a dropped frame would delay the anchor by one).
+    const followFrames = frames.filter((f) => f.source === "context-panel");
+    expect(followFrames.length).toBe(1);
+    expect(followFrames[0]!.transactionId).toBe(txId);
+    expect(followFrames[0]!.origin).toBe("programmatic");
+    expect(widthOf(right)).toBe(340);
+
+    // Joining must NOT re-fire the transaction-start capture: the anchor
+    // baseline stays the left drag's ORIGINAL capture (no re-anchor).
+    expect(starts.length).toBe(1);
+    expect(starts[0]!.source).toBe("left-sidebar");
+
+    // The follow width stabilizes: the right panel finalizes ITS part while
+    // the transaction stays open for the still-dragging left panel.
+    await act(async () => { stub!.flushRaf(); });
+    const rightFrames = frames.filter((f) => f.source === "context-panel");
+    expect(rightFrames[rightFrames.length - 1]!.kind).toBe("final");
+    expect(rightFrames.every((f) => f.transactionId === txId)).toBe(true);
+    expect(getResizeInteractionPhase()).toBe("dragging");
+
+    // Pointerup: the left drag releases and the transaction finalizes once.
+    await act(async () => {
+      left.handlePointerUp(makePointerEvent({ clientX: 100 }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(getResizeInteractionPhase()).toBe("idle");
+  });
+
+  test("a follow that detaches mid-drag releases its part; the other drag still owns and finalizes the transaction", async () => {
+    const left = await mount({ initial: 200 });
+    let followWidth: number | null = 300;
+    const right = await mountSecond({
+      transactionSource: "context-panel",
+      initial: 300,
+      programmaticTarget: { key: "open:mode", width: 300, cause: "parent-layout" },
+      resolveFollowWidth: () => followWidth,
+    });
+    await startDrag(left, 100);
+    const txId = getCurrentResizeTransactionId();
+    expect(txId).not.toBeNull();
+    followWidth = 340;
+    await act(async () => {
+      right.notifyAvailableWidthChange();
+      stub!.flushRaf();
+    });
+    // The follow detaches mid-drag (resolveFollowWidth -> null): it must
+    // release its registration so the shared transaction is not held open
+    // by a ghost source.
+    followWidth = null;
+    await act(async () => {
+      right.notifyAvailableWidthChange();
+      stub!.flushRaf();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(getResizeInteractionPhase()).toBe("dragging");
+    expect(getCurrentResizeTransactionId()).toBe(txId);
+    // The left drag can still finalize the shared transaction.
+    await act(async () => {
+      left.handlePointerUp(makePointerEvent({ clientX: 100 }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(getResizeInteractionPhase()).toBe("idle");
   });
 });
 

--- a/packages/ui/src/components/layout/usePanelResize.ts
+++ b/packages/ui/src/components/layout/usePanelResize.ts
@@ -526,7 +526,13 @@ export const usePanelResize = <T extends HTMLElement = HTMLElement>(
                 animFrameRef.current = window.requestAnimationFrame(() => followFrameRef.current());
                 return;
             }
-            // Riding an existing global transaction: write this frame.
+            // Riding an existing global transaction: JOIN it before writing
+            // so these frames carry the shared transactionId (the anchor
+            // controller drops frames from unknown ids) and this source is
+            // registered for the shared finalize. Joining shares the current
+            // id WITHOUT re-firing transaction-start participants (no
+            // re-capture, no finalizer reset).
+            ensureTransaction();
             if (prev === null) {
                 setIsResizing(true);
             }

--- a/packages/ui/src/components/layout/usePanelResize.ts
+++ b/packages/ui/src/components/layout/usePanelResize.ts
@@ -1,0 +1,935 @@
+import React from 'react';
+import {
+    beginResizeInteraction,
+    cancelResizeInteraction,
+    getResizeInteractionPhase,
+    notifyResizeFrame,
+    releaseResizeInteraction,
+    subscribeResizeInteraction,
+    type ResizeInteractionSource,
+    type ResizeOrigin,
+} from '@/lib/resizeInteraction';
+import {
+    recordPerformanceTraceEvent,
+    startPerformanceTraceSpan,
+    type PerformanceTraceSpan,
+} from '@/stores/utils/performanceTrace';
+
+/**
+ * Shared panel/column drag-resize lifecycle for the Sidebar, the ContextPanel
+ * and its file-tree column.
+ *
+ * Responsibilities (see the resize plan):
+ * - ONE geometry writer: this hook is the ONLY module that writes the panel
+ *   width (the CSS variable and/or element width). React re-renders never
+ *   write the width; consumers keep the root at a fixed structure (`flex:
+ *   none`, width reads `var(--...)`) and let the hook interpolate. At most one
+ *   width write happens per animation frame.
+ * - Unified target resolution: `programmaticTarget { key, width, cause }`.
+ *   `width === 0` is a legal close target and is NOT min-clamped; only
+ *   positive widths are clamped to minWidth/maxWidth/available. `visibility`
+ *   and `mode` transitions animate once (200ms); `parent-layout` updates
+ *   FOLLOW the available area per frame WITHOUT restarting an animation clock
+ *   (and with no transaction open they open a short one to apply the change in
+ *   the same frame as the anchor capture); `prefers-reduced-motion` resolves
+ *   in a single frame through the SAME transaction.
+ * - Persistence: `onUserCommitWidth` runs EXACTLY once, on pointerup, and
+ *   persists the manual width into user settings. Programmatic open/close,
+ *   mode switches and parent-layout follows NEVER persist — they only update
+ *   the applied DOM width (manual-resize flags and per-mode widths stay
+ *   untouched).
+ * - Concurrent operations: a semantic target change mid-drag hands the pointer
+ *   ownership over to the programmatic path WITHOUT releasing the global
+ *   transaction (the same anchor capture continues) and animates from the
+ *   CURRENT applied width; the target is never marked handled before it is
+ *   actually executed. A pointerdown mid-animation stops the animation and
+ *   hands over seamlessly from the current width (same transaction).
+ * - Window-level pointer listeners are installed SYNCHRONOUSLY at pointerdown
+ *   (not from an effect keyed on isResizing), so the first pointermove is
+ *   never missed; `isResizing` only drives visual state.
+ */
+
+export type PanelTargetCause = 'visibility' | 'mode' | 'parent-layout';
+
+/** A requested programmatic width. `width === 0` is a legal close target. */
+export interface ProgrammaticPanelTarget {
+    /** Identity for re-direction decisions (open/close, mode change). */
+    key: string;
+    /** Target width; 0 means closed (never min-clamped). */
+    width: number;
+    /** Why the target changed: visibility/mode animate once; parent-layout
+     *  follows the available area per frame. */
+    cause: PanelTargetCause;
+}
+
+export interface PanelResizeOptions<T extends HTMLElement = HTMLElement> {
+    minWidth: number;
+    maxWidth: number;
+    /** Persist the final width exactly once on pointerup — USER intent only.
+     *  Programmatic open/close, mode switches and parent-layout follows never
+     *  call this. */
+    onUserCommitWidth: (finalWidth: number) => void;
+    /** Global resize transaction source; omit to keep the drag local. */
+    transactionSource?: ResizeInteractionSource;
+    /** CSS custom property that carries the live width (e.g. --oc-left-sidebar-width). */
+    widthCssVariable?: string;
+    /** Also write element.style.width directly (file-tree column). */
+    directWidth?: boolean;
+    /** Drag direction: false (default) means the handle is on the right edge
+     *  (dragging right widens); true means the handle is on the left edge
+     *  (dragging left widens) — used by the right-side ContextPanel and its
+     *  file-tree column. */
+    reverse?: boolean;
+    /** Reject starting a drag (e.g. panel closed or expanded). */
+    canResize?: () => boolean;
+    /** Current committed width at drag start. */
+    getCurrentWidth?: () => number;
+    /** Clamp against the available area, measured once at drag start. */
+    getAvailableWidth?: (container: T | null) => number | null;
+    /** Optional performance trace span name (e.g. "ui.sidebar.resize"). */
+    traceSpanName?: string;
+    /** Extra span metadata captured at drag start (e.g. context panel mode). */
+    traceContext?: () => Record<string, unknown>;
+    /**
+     * Programmatic width target for quick open/close toggles, mode switches
+     * and parent-layout follows.
+     * - `cause: 'visibility' | 'mode'` — fixed 200ms animation (single frame
+     *   under prefers-reduced-motion) through the SAME per-frame writer as a
+     *   pointer drag; a key change re-directs the animation from the current
+     *   applied width.
+     * - `cause: 'parent-layout'` — per-frame FOLLOW: no animation clock. While
+     *   a global transaction is active the panel rides its frames; otherwise a
+     *   short transaction opens on the first real width change and closes once
+     *   the width stabilizes.
+     * A pointerdown mid-animation stops the animation and hands over
+     * seamlessly (same transaction). Pass `null` when idle.
+     */
+    programmaticTarget?: ProgrammaticPanelTarget | null;
+    /** Re-resolve the parent-layout follow width every frame; return null when
+     *  no follow applies (panel closed / manually resized / no panel). */
+    resolveFollowWidth?: () => number | null;
+    /** Animation duration for programmatic targets (ms). */
+    programmaticDurationMs?: number;
+}
+
+export interface PanelResizeController<T extends HTMLElement = HTMLElement> {
+    isResizing: boolean;
+    containerRef: React.RefObject<T | null>;
+    /** Bind to the handle's onPointerDown. */
+    handlePointerDown: (event: React.PointerEvent) => void;
+    /** Bind to the handle's onPointerUp — the ONLY normal-end path. */
+    handlePointerUp: (event: React.PointerEvent) => void;
+    /** Bind to the handle's onPointerCancel / onLostPointerCapture — an
+     *  abnormal end that must NOT persist the width. */
+    handlePointerAbort: (event: React.PointerEvent) => void;
+    /** Consumer ResizeObserver callback: the parent/available area width
+     *  changed. Re-resolves any follow target in the next frame; an in-flight
+     *  animation re-resolves its goal per frame on its own. */
+    notifyAvailableWidthChange: () => void;
+}
+
+/** Panel-local state machine. `finalizing` mirrors the global transaction's
+ *  finalizing phase (the panel released but the shared finalize is pending). */
+type PanelResizePhase = 'idle' | 'programmatic' | 'pointer' | 'finalizing';
+
+/**
+ * Motion configuration for programmatic width animations. Reduced motion is a
+ * SHORT 120ms easeOutQuad animation — NOT a single-frame jump (the plan:
+ * "reduce=120ms" keeps a visible, softer animation). The single-frame path is
+ * reserved for explicit test configuration (`programmaticDurationMs === 0`).
+ */
+type PanelMotionMode = 'standard' | 'reduced';
+
+interface PanelMotionProfile {
+    mode: PanelMotionMode;
+    durationMs: number;
+    easing: (progress: number) => number;
+}
+
+const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+const easeOutQuad = (t: number): number => t * (2 - t);
+
+const getMotionProfile = (reduced: boolean): PanelMotionProfile => (reduced
+    ? { mode: 'reduced', durationMs: 120, easing: easeOutQuad }
+    : { mode: 'standard', durationMs: 200, easing: easeOutCubic });
+
+export const usePanelResize = <T extends HTMLElement = HTMLElement>(
+    options: PanelResizeOptions<T>,
+): PanelResizeController<T> => {
+    const {
+        minWidth,
+        maxWidth,
+        onUserCommitWidth,
+        transactionSource,
+        widthCssVariable,
+        directWidth,
+        reverse = false,
+        canResize,
+        getCurrentWidth,
+        getAvailableWidth,
+        traceSpanName,
+        traceContext,
+        programmaticTarget,
+        resolveFollowWidth,
+        programmaticDurationMs,
+    } = options;
+
+    // Keep latest callbacks/context in refs so window listeners and cleanup
+    // closures never go stale without re-registering effects.
+    const onUserCommitWidthRef = React.useRef(onUserCommitWidth);
+    const canResizeRef = React.useRef(canResize);
+    const getCurrentWidthRef = React.useRef(getCurrentWidth);
+    const getAvailableWidthRef = React.useRef(getAvailableWidth);
+    const traceContextRef = React.useRef(traceContext);
+    const resolveFollowWidthRef = React.useRef(resolveFollowWidth);
+    React.useEffect(() => {
+        onUserCommitWidthRef.current = onUserCommitWidth;
+        canResizeRef.current = canResize;
+        getCurrentWidthRef.current = getCurrentWidth;
+        getAvailableWidthRef.current = getAvailableWidth;
+        traceContextRef.current = traceContext;
+        resolveFollowWidthRef.current = resolveFollowWidth;
+    });
+
+    // Live system motion preference: read at mount, then subscribe. A change
+    // mid-animation does NOT alter the running animation (each animation
+    // snapshots its profile at start); the new preference applies from the
+    // NEXT open/close/mode switch.
+    React.useEffect(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return;
+        }
+        const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+        prefersReducedMotionRef.current = mql.matches;
+        const handleChange = (event: MediaQueryListEvent) => {
+            prefersReducedMotionRef.current = event.matches;
+        };
+        mql.addEventListener('change', handleChange);
+        return () => {
+            mql.removeEventListener('change', handleChange);
+        };
+    }, []);
+
+    const [isResizing, setIsResizing] = React.useState(false);
+    const containerRef = React.useRef<T | null>(null);
+    const startXRef = React.useRef(0);
+    const startWidthRef = React.useRef(0);
+    const resizingWidthRef = React.useRef<number | null>(null);
+    const activePointerIdRef = React.useRef<number | null>(null);
+    const transactionIdRef = React.useRef<number | null>(null);
+    const availableWidthRef = React.useRef<number | null>(null);
+    const resizeFrameRef = React.useRef<number | null>(null);
+    const traceRef = React.useRef<PerformanceTraceSpan | null>(null);
+    const pointerMovesRef = React.useRef(0);
+    const appliedFramesRef = React.useRef(0);
+    const lastAppliedAtRef = React.useRef<number | null>(null);
+    const maxFrameGapRef = React.useRef(0);
+    const stallFramesRef = React.useRef(0);
+    // Holds the single teardown for the window/document listeners installed
+    // synchronously at pointerdown; all exit paths call it exactly once.
+    const removeWindowListenersRef = React.useRef<(() => void) | null>(null);
+    // Programmatic width control (quick open/close, mode switches, follows).
+    // Intermediate frames mutate the CSS variable directly — no React render
+    // per frame; only the START and END flip React state.
+    const targetRef = React.useRef<ProgrammaticPanelTarget | null>(null);
+    const animFrameRef = React.useRef<number | null>(null);
+    const animStartedRef = React.useRef(false);
+    const followLastWidthRef = React.useRef<number | null>(null);
+    const animStartTimeRef = React.useRef(0);
+    const animDurationRef = React.useRef(programmaticDurationMs ?? 200);
+    // Live system motion preference: read at mount, then subscribed below.
+    // Changes are low-frequency and never drive per-frame React state; each
+    // semantic animation snapshots its profile at start.
+    const prefersReducedMotionRef = React.useRef(false);
+    const animProfileRef = React.useRef<PanelMotionProfile | null>(null);
+    const animAppliedFramesRef = React.useRef(0);
+    const animDistinctWidthsRef = React.useRef<Set<number>>(new Set());
+    const phaseRef = React.useRef<PanelResizePhase>('idle');
+    // True only for the component's first mounted commit. The layout effect's
+    // bootstrap write (initial width, no transaction) is allowed ONLY there; a
+    // target arriving later (e.g. mid-drag) must go through the normal
+    // animation path so it joins the open transaction instead of silently
+    // overwriting the applied width.
+    const firstMountRef = React.useRef(true);
+
+    // The global transaction phase: reset the panel state machine once the
+    // shared finalize completes (a released session stays 'finalizing').
+    const globalPhase = React.useSyncExternalStore(
+        subscribeResizeInteraction,
+        getResizeInteractionPhase,
+        getResizeInteractionPhase,
+    );
+    React.useEffect(() => {
+        if (phaseRef.current === 'finalizing' && globalPhase === 'idle') {
+            phaseRef.current = 'idle';
+        }
+    }, [globalPhase]);
+
+    const nowMs = (): number => (
+        typeof performance !== 'undefined' && typeof performance.now === 'function'
+            ? performance.now()
+            : Date.now()
+    );
+
+    const stopProgrammatic = React.useCallback(() => {
+        if (animFrameRef.current !== null) {
+            window.cancelAnimationFrame(animFrameRef.current);
+            animFrameRef.current = null;
+        }
+        animStartedRef.current = false;
+        followLastWidthRef.current = null;
+        if (activePointerIdRef.current === null) {
+            setIsResizing(false);
+        }
+    }, []);
+
+    const clampWidth = React.useCallback((value: number) => {
+        const clamped = Math.min(maxWidth, Math.max(minWidth, Math.round(value)));
+        const available = availableWidthRef.current;
+        return available === null ? clamped : Math.min(clamped, Math.max(1, available));
+    }, [maxWidth, minWidth]);
+
+    /** Programmatic target resolution: 0 is a legal close target and is NOT
+     *  min-clamped; only positive widths are clamped. */
+    const resolveTargetWidth = React.useCallback((target: ProgrammaticPanelTarget): number => {
+        if (target.cause === 'parent-layout') {
+            const follow = resolveFollowWidthRef.current?.() ?? null;
+            if (follow !== null) {
+                return follow;
+            }
+        }
+        if (target.width <= 0) {
+            return 0;
+        }
+        return clampWidth(target.width);
+    }, [clampWidth]);
+
+    const applyLiveWidth = React.useCallback((nextWidth: number) => {
+        const el = containerRef.current;
+        if (!el) {
+            return;
+        }
+        if (widthCssVariable) {
+            el.style.setProperty(widthCssVariable, `${nextWidth}px`);
+        }
+        if (directWidth) {
+            el.style.width = `${nextWidth}px`;
+        }
+    }, [directWidth, widthCssVariable]);
+
+    /** Shared frame accounting (applied frames, frame gaps, stalls) for every
+     *  writer — pointer, animate and follow alike. */
+    const recordAppliedFrame = React.useCallback((width: number) => {
+        appliedFramesRef.current += 1;
+        const appliedAt = nowMs();
+        const previousAppliedAt = lastAppliedAtRef.current;
+        if (previousAppliedAt !== null) {
+            const frameGap = appliedAt - previousAppliedAt;
+            maxFrameGapRef.current = Math.max(maxFrameGapRef.current, frameGap);
+            if (frameGap > 50 && traceSpanName) {
+                stallFramesRef.current += 1;
+                recordPerformanceTraceEvent(
+                    `${traceSpanName}_stall`,
+                    { width, frame: appliedFramesRef.current, gapMs: frameGap },
+                    frameGap,
+                    traceRef.current?.traceId,
+                );
+            }
+        }
+        lastAppliedAtRef.current = appliedAt;
+    }, [traceSpanName]);
+
+    /** The single per-frame width write + anchor notification. */
+    const writeWidthAndNotify = React.useCallback((
+        width: number,
+        kind: 'drag' | 'final' | 'cancel',
+        origin: ResizeOrigin,
+    ) => {
+        applyLiveWidth(width);
+        recordAppliedFrame(width);
+        notifyResizeFrame({
+            transactionId: transactionIdRef.current ?? 0,
+            width,
+            kind,
+            origin,
+            source: transactionSource ?? 'left-sidebar',
+        });
+    }, [applyLiveWidth, recordAppliedFrame, transactionSource]);
+
+    /** Join or open the one global layout transaction for this active period.
+     *  A joining source SHARES the current id (no re-capture, no finalizer
+     *  reset); only idle/finalizing creates a fresh id. */
+    const ensureTransaction = React.useCallback((): void => {
+        if (!transactionSource) {
+            return;
+        }
+        transactionIdRef.current = beginResizeInteraction(transactionSource, 'programmatic');
+    }, [transactionSource]);
+
+    const cleanupResize = React.useCallback((kind: 'released' | 'cancelled') => {
+        traceRef.current?.end({
+            ...(kind === 'cancelled' ? { cancelled: true } : {}),
+            pointerMoves: pointerMovesRef.current,
+            appliedFrames: appliedFramesRef.current,
+            maxFrameGapMs: maxFrameGapRef.current,
+            stallFramesOver50ms: stallFramesRef.current,
+        });
+        traceRef.current = null;
+        activePointerIdRef.current = null;
+        resizingWidthRef.current = null;
+        availableWidthRef.current = null;
+        document.documentElement.style.cursor = '';
+        removeWindowListenersRef.current?.();
+        removeWindowListenersRef.current = null;
+        const transactionId = transactionIdRef.current;
+        transactionIdRef.current = null;
+        if (transactionSource && transactionId !== null) {
+            if (kind === 'released') {
+                releaseResizeInteraction(transactionSource, transactionId);
+            } else {
+                cancelResizeInteraction(transactionSource, transactionId, 'cancelled');
+            }
+            phaseRef.current = getResizeInteractionPhase() === 'finalizing' ? 'finalizing' : 'idle';
+        } else {
+            phaseRef.current = 'idle';
+        }
+        setIsResizing(false);
+    }, [transactionSource]);
+
+    /** End the programmatic session in ONE frame: write the final width,
+     *  notify the anchor, stop the loop and release the transaction. NEVER
+     *  persists (programmatic operations never touch user settings). */
+    const finishProgrammatic = React.useCallback((width: number) => {
+        resizingWidthRef.current = width;
+        writeWidthAndNotify(width, 'final', 'programmatic');
+        stopProgrammatic();
+        cleanupResize('released');
+    }, [cleanupResize, stopProgrammatic, writeWidthAndNotify]);
+
+    /** Animation observability, emitted when a programmatic ANIMATION finishes
+     *  (the follow loop and pointer drags do not use it). Size/timing only —
+     *  never session text or user data. */
+    const recordProgrammaticEnd = React.useCallback((finalWidth: number) => {
+        const profile = animProfileRef.current;
+        if (!profile) {
+            return;
+        }
+        animProfileRef.current = null;
+        recordPerformanceTraceEvent(
+            'ui.panel.programmatic_end',
+            {
+                motionMode: profile.mode,
+                configuredDurationMs: animDurationRef.current,
+                actualDurationMs: Math.round(nowMs() - animStartTimeRef.current),
+                appliedFrameCount: animAppliedFramesRef.current,
+                distinctWidthCount: animDistinctWidthsRef.current.size,
+                startWidth: startWidthRef.current,
+                finalWidth,
+                reducedMotionAtStart: profile.mode === 'reduced',
+            },
+            0,
+            undefined,
+        );
+    }, []);
+
+    /** Terminate an active pointer drag WITHOUT releasing the global
+     *  transaction: a semantic target change mid-drag keeps the same anchor
+     *  capture and the programmatic animation continues from the CURRENT
+     *  applied width. */
+    const endPointerOwnership = React.useCallback(() => {
+        if (resizeFrameRef.current !== null) {
+            window.cancelAnimationFrame(resizeFrameRef.current);
+            resizeFrameRef.current = null;
+        }
+        removeWindowListenersRef.current?.();
+        removeWindowListenersRef.current = null;
+        traceRef.current?.end({
+            cancelled: true,
+            pointerMoves: pointerMovesRef.current,
+            appliedFrames: appliedFramesRef.current,
+            maxFrameGapMs: maxFrameGapRef.current,
+            stallFramesOver50ms: stallFramesRef.current,
+        });
+        traceRef.current = null;
+        activePointerIdRef.current = null;
+        document.documentElement.style.cursor = '';
+        phaseRef.current = 'programmatic';
+    }, []);
+
+    const readAppliedWidth = React.useCallback((): number | null => {
+        const el = containerRef.current;
+        if (!el) {
+            return null;
+        }
+        if (widthCssVariable) {
+            const raw = el.style.getPropertyValue(widthCssVariable);
+            const parsed = Number.parseFloat(raw);
+            if (Number.isFinite(parsed)) {
+                return parsed;
+            }
+        }
+        if (directWidth) {
+            const parsed = Number.parseFloat(el.style.width);
+            if (Number.isFinite(parsed)) {
+                return parsed;
+            }
+        }
+        return null;
+    }, [directWidth, widthCssVariable]);
+
+    // --- Parent-layout follow loop -----------------------------------------
+    // Re-resolves the follow width every frame. While another panel animates
+    // (global transaction dragging) it RIDES those frames as a joining source;
+    // with no transaction it opens a single-frame one (capture -> apply ->
+    // final -> release). It never writes into a finalizing transaction.
+    const followFrameRef = React.useRef<() => void>(() => {});
+    followFrameRef.current = () => {
+        animFrameRef.current = null;
+        if (!animStartedRef.current) {
+            return;
+        }
+        if (activePointerIdRef.current !== null) {
+            stopProgrammatic();
+            return;
+        }
+        const w = resolveFollowWidthRef.current?.() ?? null;
+        if (w === null) {
+            // Follow no longer applies: release our source registration so the
+            // shared transaction can finalize (others may still be active).
+            if (transactionSource && transactionIdRef.current !== null) {
+                releaseResizeInteraction(transactionSource, transactionIdRef.current);
+                transactionIdRef.current = null;
+            }
+            stopProgrammatic();
+            return;
+        }
+        const prev = followLastWidthRef.current;
+        // First frame of a loop run: compare against the APPLIED width so a
+        // no-op wake-up (width unchanged, no transaction) does not open a
+        // throwaway transaction. Later frames compare against the last write.
+        const appliedNow = prev === null ? readAppliedWidth() : null;
+        const changed = prev === null
+            ? appliedNow === null || Math.abs(w - appliedNow) > 0.5
+            : Math.abs(w - prev) > 0.5;
+        const phase = getResizeInteractionPhase();
+        if (changed) {
+            if (phase === 'idle') {
+                // Fresh single-frame transaction: capture now, apply, commit.
+                ensureTransaction();
+                setIsResizing(true);
+                followLastWidthRef.current = w;
+                finishProgrammatic(w);
+                return;
+            }
+            if (phase === 'finalizing') {
+                // Never interleave writes into a finalizing transaction.
+                animFrameRef.current = window.requestAnimationFrame(() => followFrameRef.current());
+                return;
+            }
+            // Riding an existing global transaction: write this frame.
+            if (prev === null) {
+                setIsResizing(true);
+            }
+            followLastWidthRef.current = w;
+            resizingWidthRef.current = w;
+            writeWidthAndNotify(w, 'drag', 'programmatic');
+            animFrameRef.current = window.requestAnimationFrame(() => followFrameRef.current());
+            return;
+        }
+        if (phase === 'dragging' && transactionIdRef.current !== null) {
+            // Stable and we are a registered source: finalize our part; the
+            // transaction stays open while other panels are still active.
+            finishProgrammatic(w);
+            return;
+        }
+        if (phase !== 'idle') {
+            // Stable while another panel settles: keep watching (no writes).
+            animFrameRef.current = window.requestAnimationFrame(() => followFrameRef.current());
+            return;
+        }
+        stopProgrammatic();
+    };
+
+    const startFollowLoop = React.useCallback(() => {
+        if (animFrameRef.current !== null || animStartedRef.current) {
+            return;
+        }
+        if (activePointerIdRef.current !== null) {
+            return;
+        }
+        if (resolveFollowWidthRef.current?.() === null) {
+            return;
+        }
+        animStartedRef.current = true;
+        animFrameRef.current = window.requestAnimationFrame(() => followFrameRef.current());
+    }, []);
+
+    const notifyAvailableWidthChange = React.useCallback(() => {
+        if (activePointerIdRef.current !== null) {
+            return; // a pointer drag owns the width
+        }
+        if (animFrameRef.current !== null) {
+            return; // a loop is already re-resolving per frame
+        }
+        const target = targetRef.current;
+        if (!target || target.cause !== 'parent-layout') {
+            return;
+        }
+        if (resolveFollowWidthRef.current?.() === null) {
+            return;
+        }
+        startFollowLoop();
+    }, [startFollowLoop]);
+
+    const scheduleLiveWidth = React.useCallback(() => {
+        if (resizeFrameRef.current !== null) {
+            return;
+        }
+        resizeFrameRef.current = window.requestAnimationFrame(() => {
+            resizeFrameRef.current = null;
+            const nextWidth = resizingWidthRef.current;
+            if (nextWidth === null) {
+                return;
+            }
+            writeWidthAndNotify(nextWidth, 'drag', 'pointer');
+        });
+    }, [writeWidthAndNotify]);
+
+    const finishResize = React.useCallback(() => {
+        if (activePointerIdRef.current === null) {
+            return;
+        }
+        if (resizeFrameRef.current !== null) {
+            window.cancelAnimationFrame(resizeFrameRef.current);
+            resizeFrameRef.current = null;
+        }
+        const finalWidth = clampWidth(resizingWidthRef.current ?? startWidthRef.current);
+        // Write the final width synchronously BEFORE React commits
+        // isResizing=false: the render reads resizingWidthRef ?? committed
+        // width, and the store update may commit a frame later, so without
+        // this write the CSS variable would briefly fall back to the stale
+        // pre-drag width ("jump at release").
+        resizingWidthRef.current = finalWidth;
+        writeWidthAndNotify(finalWidth, 'final', 'pointer');
+        // USER intent only: persist the manual width exactly once on pointerup.
+        onUserCommitWidthRef.current(finalWidth);
+        cleanupResize('released');
+    }, [clampWidth, cleanupResize, writeWidthAndNotify]);
+
+    const cancelResize = React.useCallback(() => {
+        if (activePointerIdRef.current === null) {
+            return;
+        }
+        if (resizeFrameRef.current !== null) {
+            window.cancelAnimationFrame(resizeFrameRef.current);
+            resizeFrameRef.current = null;
+        }
+        // Commit the last legal width synchronously so the visual state
+        // matches; do NOT persist (the user did not complete the drag).
+        const lastWidth = clampWidth(resizingWidthRef.current ?? startWidthRef.current);
+        resizingWidthRef.current = lastWidth;
+        writeWidthAndNotify(lastWidth, 'cancel', 'pointer');
+        cleanupResize('cancelled');
+    }, [clampWidth, cleanupResize, writeWidthAndNotify]);
+
+    // Install the window/document drag listeners synchronously at pointerdown.
+    const installWindowListeners = React.useCallback(() => {
+        if (removeWindowListenersRef.current) {
+            return;
+        }
+        const handleMove = (event: PointerEvent) => {
+            if (activePointerIdRef.current !== event.pointerId) {
+                return;
+            }
+            const delta = reverse
+                ? startXRef.current - event.clientX
+                : event.clientX - startXRef.current;
+            const nextWidth = clampWidth(startWidthRef.current + delta);
+            if (resizingWidthRef.current === nextWidth) {
+                return;
+            }
+            resizingWidthRef.current = nextWidth;
+            pointerMovesRef.current += 1;
+            if (traceSpanName) {
+                recordPerformanceTraceEvent(
+                    `${traceSpanName}_move`,
+                    { width: nextWidth, move: pointerMovesRef.current },
+                    0,
+                    traceRef.current?.traceId,
+                );
+            }
+            scheduleLiveWidth();
+        };
+        const handleUp = (event: PointerEvent) => {
+            if (activePointerIdRef.current !== event.pointerId) {
+                return;
+            }
+            finishResize();
+        };
+        const handleAbort = () => {
+            cancelResize();
+        };
+        const handleVisibility = () => {
+            if (document.visibilityState === 'hidden') {
+                cancelResize();
+            }
+        };
+
+        window.addEventListener('pointermove', handleMove);
+        window.addEventListener('pointerup', handleUp);
+        window.addEventListener('pointercancel', handleAbort);
+        window.addEventListener('blur', handleAbort);
+        document.addEventListener('visibilitychange', handleVisibility);
+        removeWindowListenersRef.current = () => {
+            window.removeEventListener('pointermove', handleMove);
+            window.removeEventListener('pointerup', handleUp);
+            window.removeEventListener('pointercancel', handleAbort);
+            window.removeEventListener('blur', handleAbort);
+            document.removeEventListener('visibilitychange', handleVisibility);
+            removeWindowListenersRef.current = null;
+        };
+    }, [cancelResize, clampWidth, finishResize, reverse, scheduleLiveWidth, traceSpanName]);
+
+    const handlePointerDown = React.useCallback((event: React.PointerEvent) => {
+        if (event.button !== 0 || !event.isPrimary || activePointerIdRef.current !== null) {
+            return;
+        }
+        if (canResizeRef.current && !canResizeRef.current()) {
+            return;
+        }
+        setIsResizing(true);
+        try {
+            event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+            // capture is only an enhancement; window listeners below take over
+        }
+        activePointerIdRef.current = event.pointerId;
+        phaseRef.current = 'pointer';
+        startXRef.current = event.clientX;
+        // Pointer takes over from the CURRENT applied width — a programmatic
+        // animation may be mid-flight (resizingWidthRef holds its live width).
+        startWidthRef.current = resizingWidthRef.current ?? getCurrentWidthRef.current?.() ?? 0;
+        resizingWidthRef.current = startWidthRef.current;
+        pointerMovesRef.current = 0;
+        appliedFramesRef.current = 0;
+        lastAppliedAtRef.current = null;
+        maxFrameGapRef.current = 0;
+        stallFramesRef.current = 0;
+        availableWidthRef.current = getAvailableWidthRef.current?.(containerRef.current) ?? null;
+        if (traceSpanName) {
+            traceRef.current = startPerformanceTraceSpan(traceSpanName, {
+                ...(traceContextRef.current ? traceContextRef.current() : {}),
+                startWidth: startWidthRef.current,
+                layoutStrategy: 'live-flex-during-drag',
+            });
+        }
+        // Pointer takes over any running programmatic animation: stop it and
+        // hand over from the CURRENT applied width, reusing the transaction id.
+        stopProgrammatic();
+        if (transactionSource) {
+            transactionIdRef.current = beginResizeInteraction(transactionSource, 'pointer');
+        }
+        document.documentElement.style.cursor = 'col-resize';
+        installWindowListeners();
+        event.preventDefault();
+    }, [installWindowListeners, stopProgrammatic, traceSpanName, transactionSource]);
+
+    const handlePointerUp = React.useCallback((event: React.PointerEvent) => {
+        if (activePointerIdRef.current !== event.pointerId) {
+            return;
+        }
+        try {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+        } catch {
+            // ignore
+        }
+        finishResize();
+    }, [finishResize]);
+
+    const handlePointerAbort = React.useCallback((event: React.PointerEvent) => {
+        if (activePointerIdRef.current !== event.pointerId) {
+            return;
+        }
+        cancelResize();
+    }, [cancelResize]);
+
+    // Unmount cleanup: never overwrite a user-saved width; only cancel pending
+    // work, restore the cursor and release the global transaction.
+    React.useEffect(() => () => {
+        removeWindowListenersRef.current?.();
+        removeWindowListenersRef.current = null;
+        if (resizeFrameRef.current !== null) {
+            window.cancelAnimationFrame(resizeFrameRef.current);
+            resizeFrameRef.current = null;
+        }
+        if (activePointerIdRef.current !== null) {
+            traceRef.current?.end({
+                cancelled: true,
+                pointerMoves: pointerMovesRef.current,
+                appliedFrames: appliedFramesRef.current,
+                maxFrameGapMs: maxFrameGapRef.current,
+                stallFramesOver50ms: stallFramesRef.current,
+            });
+            traceRef.current = null;
+            activePointerIdRef.current = null;
+            resizingWidthRef.current = null;
+            document.documentElement.style.cursor = '';
+            if (transactionSource && transactionIdRef.current !== null) {
+                cancelResizeInteraction(transactionSource, transactionIdRef.current, 'cancelled');
+                transactionIdRef.current = null;
+            }
+        }
+    }, [transactionSource]);
+
+    // Unmount cleanup for a running programmatic animation / follow loop. (The
+    // animation effect's own cleanup runs first and stops the loop, but the
+    // transaction must still be cancelled — key off the open transaction id,
+    // not the started flag.)
+    React.useEffect(() => () => {
+        stopProgrammatic();
+        if (transactionSource && transactionIdRef.current !== null && activePointerIdRef.current === null) {
+            cancelResizeInteraction(transactionSource, transactionIdRef.current, 'cancelled');
+            transactionIdRef.current = null;
+        }
+    }, [stopProgrammatic, transactionSource]);
+
+    // --- Programmatic targets ----------------------------------------------
+
+    // Layout effect writes the INITIAL width before the first paint and
+    // records the target — NO state, NO transaction (safe in commit). This is
+    // the ONLY silent bootstrap write and it happens ONLY on the first mounted
+    // commit; every later target goes through the animation path below. React
+    // never writes the width on re-renders; the hook is the single writer.
+    React.useLayoutEffect(() => {
+        const firstMount = firstMountRef.current;
+        firstMountRef.current = false;
+        const target = programmaticTarget ?? null;
+        if (!target) {
+            return;
+        }
+        if (!firstMount || targetRef.current !== null) {
+            return;
+        }
+        const w = resolveTargetWidth(target);
+        applyLiveWidth(w);
+        resizingWidthRef.current = w;
+        targetRef.current = { ...target };
+    }, [applyLiveWidth, programmaticTarget, resolveTargetWidth]);
+
+    // Programmatic transitions (animate / follow / immediate). Runs AFTER the
+    // layout effect and BEFORE the canResize-flip effect, so a target change
+    // mid-drag hands over before any cancel logic can fire. `prev` may be
+    // null when the FIRST target arrives after mount (mid-drag) — that case
+    // must animate through the open transaction, not silently jump.
+    React.useEffect(() => {
+        const target = programmaticTarget ?? null;
+        if (!target) {
+            return;
+        }
+        if (firstMountRef.current) {
+            return; // first mounted commit: bootstrap was written by the layout effect
+        }
+        const prev = targetRef.current;
+        const sameKey = prev !== null && prev.key === target.key;
+        const sameWidth = prev !== null && Math.abs(prev.width - target.width) <= 0.5;
+        if (sameKey && sameWidth && prev !== null && prev.cause === target.cause) {
+            targetRef.current = { ...target };
+            return; // Same target: no transaction.
+        }
+        // A semantic target change mid-drag hands the pointer ownership over
+        // to the programmatic path WITHOUT releasing the global transaction.
+        if (activePointerIdRef.current !== null) {
+            endPointerOwnership();
+        }
+        if (sameKey && target.cause === 'parent-layout') {
+            // Same-transition parent-layout update: goal-only, NEVER restart
+            // the animation clock. An in-flight animation re-resolves its goal
+            // per frame; otherwise ensure a follow loop is watching.
+            targetRef.current = { ...target };
+            startFollowLoop();
+            return;
+        }
+        // New transition: animate (200ms) or single-frame (reduced motion).
+        const fromWidth = resizingWidthRef.current ?? readAppliedWidth() ?? 0;
+        const toWidth = resolveTargetWidth(target);
+        if (Math.abs(fromWidth - toWidth) <= 0.5) {
+            targetRef.current = { ...target };
+            return; // Already at the target.
+        }
+        if (!animStartedRef.current) {
+            ensureTransaction();
+            setIsResizing(true);
+            animStartedRef.current = true;
+            phaseRef.current = 'programmatic';
+        }
+        targetRef.current = { ...target };
+        startWidthRef.current = fromWidth;
+        // Snapshot the motion profile at animation START: a system preference
+        // change mid-animation does not alter the running animation. Reduced
+        // motion keeps a SHORT 120ms animation — never a single-frame jump.
+        const profile = getMotionProfile(prefersReducedMotionRef.current);
+        animProfileRef.current = profile;
+        animStartTimeRef.current = nowMs();
+        animDurationRef.current = programmaticDurationMs ?? profile.durationMs;
+        animAppliedFramesRef.current = 0;
+        animDistinctWidthsRef.current = new Set<number>();
+        if (programmaticDurationMs === 0) {
+            // Explicit test configuration ONLY: a true single-frame jump.
+            animDistinctWidthsRef.current.add(toWidth);
+            recordProgrammaticEnd(toWidth);
+            finishProgrammatic(toWidth);
+            return;
+        }
+        if (animFrameRef.current === null) {
+            animFrameRef.current = window.requestAnimationFrame(function animateProgrammaticFrame() {
+                animFrameRef.current = null;
+                if (!animStartedRef.current) {
+                    return;
+                }
+                const now = nowMs();
+                const elapsed = now - animStartTimeRef.current;
+                const t = Math.min(1, elapsed / Math.max(1, animDurationRef.current));
+                const eased = animProfileRef.current?.easing(t) ?? easeOutCubic(t);
+                // Per-frame goal re-resolution: parent-layout-driven opens land
+                // on the FINAL parent width even when the parent keeps moving.
+                let goal = targetRef.current?.width ?? 0;
+                const follow = resolveFollowWidthRef.current?.();
+                if (follow !== null && follow !== undefined) {
+                    goal = follow;
+                }
+                const start = startWidthRef.current;
+                const current = Math.round(start + (goal - start) * eased);
+                animAppliedFramesRef.current += 1;
+                animDistinctWidthsRef.current.add(current);
+                if (t >= 1 || Math.abs(current - goal) <= 0.5) {
+                    recordProgrammaticEnd(goal);
+                    finishProgrammatic(goal);
+                    return;
+                }
+                resizingWidthRef.current = current;
+                writeWidthAndNotify(current, 'drag', 'programmatic');
+                animFrameRef.current = window.requestAnimationFrame(animateProgrammaticFrame);
+            });
+        }
+    }, [applyLiveWidth, endPointerOwnership, ensureTransaction, finishProgrammatic, programmaticDurationMs, programmaticTarget, readAppliedWidth, recordProgrammaticEnd, resolveTargetWidth, startFollowLoop, writeWidthAndNotify]);
+
+    // End a drag when the consumer's canResize guard flips false mid-drag. A
+    // semantic target change already handed the session to the programmatic
+    // path (activePointerIdRef cleared) before this effect runs, so this only
+    // fires for paths without a target change — cancelResize itself bails when
+    // no pointer owns the session.
+    React.useEffect(() => {
+        if (isResizing && canResizeRef.current && !canResizeRef.current()) {
+            cancelResize();
+        }
+    });
+
+    return {
+        isResizing,
+        containerRef,
+        handlePointerDown,
+        handlePointerUp,
+        handlePointerAbort,
+        notifyAvailableWidthChange,
+    };
+};

--- a/packages/ui/src/lib/resizeInteraction.test.ts
+++ b/packages/ui/src/lib/resizeInteraction.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  beginResizeInteraction,
+  cancelResizeInteraction,
+  getResizeInteractionPhase,
+  isResizeInteractionActive,
+  isResizeSettling,
+  notifyResizeFrame,
+  registerResizeFinalizer,
+  registerResizeFrameParticipant,
+  registerResizeTransactionStartParticipant,
+  releaseResizeInteraction,
+  resetResizeFrameParticipantsForTests,
+  resetResizeInteractionForTests,
+  resetResizeSchedulerForTests,
+  setResizeInteractionActive,
+  setResizeSchedulerForTests,
+  subscribeResizeInteraction,
+  type ResizeScheduler,
+} from './resizeInteraction'
+
+/** Deterministic scheduler: timeouts and rAF callbacks are queued and only run
+ *  when the test explicitly flushes them. */
+class FakeScheduler implements ResizeScheduler {
+  timeouts: Array<{ id: number; fn: () => void }> = []
+  frames: Array<{ id: number; fn: () => void }> = []
+  nextId = 1
+
+  setTimeout(fn: () => void): number {
+    const id = this.nextId++
+    this.timeouts.push({ id, fn })
+    return id
+  }
+
+  clearTimeout(id: unknown): void {
+    this.timeouts = this.timeouts.filter((t) => t.id !== id)
+  }
+
+  requestAnimationFrame(fn: () => void): number {
+    const id = this.nextId++
+    this.frames.push({ id, fn })
+    return id
+  }
+
+  cancelAnimationFrame(id: unknown): void {
+    this.frames = this.frames.filter((f) => f.id !== id)
+  }
+
+  runTimeouts(): void {
+    const pending = [...this.timeouts]
+    this.timeouts = []
+    for (const t of pending) t.fn()
+  }
+
+  runFrames(): void {
+    const pending = [...this.frames]
+    this.frames = []
+    for (const f of pending) f.fn()
+  }
+
+  get pendingTimeoutCount(): number {
+    return this.timeouts.length
+  }
+
+  get pendingFrameCount(): number {
+    return this.frames.length
+  }
+}
+
+const flushMicrotasks = (): Promise<void> =>
+  new Promise<void>((resolve) => queueMicrotask(resolve))
+
+let scheduler: FakeScheduler
+
+beforeEach(() => {
+  scheduler = new FakeScheduler()
+  setResizeSchedulerForTests(scheduler)
+  resetResizeInteractionForTests()
+})
+
+afterEach(() => {
+  resetResizeSchedulerForTests()
+})
+
+describe('resize interaction state machine', () => {
+  test('transitions idle -> dragging -> finalizing -> idle for a plain release', async () => {
+    expect(getResizeInteractionPhase()).toBe('idle')
+    expect(isResizeSettling()).toBe(false)
+
+    const id = beginResizeInteraction('left-sidebar')
+    expect(getResizeInteractionPhase()).toBe('dragging')
+    expect(isResizeInteractionActive()).toBe(true)
+    expect(isResizeSettling()).toBe(true)
+
+    releaseResizeInteraction('left-sidebar', id)
+    expect(getResizeInteractionPhase()).toBe('finalizing')
+    expect(isResizeInteractionActive()).toBe(false)
+    // Settling stays true through the finalizing window.
+    expect(isResizeSettling()).toBe(true)
+
+    // No visible list -> finalizes on the next frame, not on a settle timer.
+    // The only pending timer is the 1000ms fail-safe, cleared on completion.
+    expect(scheduler.pendingTimeoutCount).toBe(1)
+    scheduler.runFrames()
+    expect(getResizeInteractionPhase()).toBe('idle')
+    expect(isResizeSettling()).toBe(false)
+    expect(scheduler.pendingTimeoutCount).toBe(0)
+  })
+
+  test('runs a registered finalizer exactly once per release and then completes', async () => {
+    const id = beginResizeInteraction('context-panel')
+    const finalizer = () => {
+      finalizerCalls += 1
+    }
+    let finalizerCalls = 0
+    registerResizeFinalizer(finalizer)
+
+    releaseResizeInteraction('context-panel', id)
+    await flushMicrotasks()
+    await flushMicrotasks()
+    expect(finalizerCalls).toBe(1)
+    expect(getResizeInteractionPhase()).toBe('idle')
+  })
+
+  test('a stale release with a wrong transaction id is ignored', () => {
+    const id = beginResizeInteraction('left-sidebar')
+    releaseResizeInteraction('left-sidebar', id + 1)
+    expect(getResizeInteractionPhase()).toBe('dragging')
+    releaseResizeInteraction('left-sidebar', id)
+    expect(getResizeInteractionPhase()).toBe('finalizing')
+  })
+
+  test('left and right sources share ONE transaction id; only the last release finalizes', async () => {
+    const left = beginResizeInteraction('left-sidebar')
+    const right = beginResizeInteraction('context-panel')
+    // One global transaction per active period: the second source joins the
+    // same id (no re-capture, no competing transaction).
+    expect(right).toBe(left)
+
+    // Releasing one source while the other is still dragging keeps dragging.
+    releaseResizeInteraction('left-sidebar', left)
+    expect(getResizeInteractionPhase()).toBe('dragging')
+
+    releaseResizeInteraction('context-panel', right)
+    expect(getResizeInteractionPhase()).toBe('finalizing')
+    scheduler.runFrames()
+    expect(getResizeInteractionPhase()).toBe('idle')
+  })
+
+  test('a joining source does not re-fire transaction-start participants', async () => {
+    const starts: Array<{ transactionId: number; source: string; origin: string }> = []
+    const unsubscribe = registerResizeTransactionStartParticipant((s) => { starts.push({ ...s }) })
+    const first = beginResizeInteraction('left-sidebar')
+    expect(starts.length).toBe(1)
+    expect(starts[0].transactionId).toBe(first)
+    expect(starts[0].origin).toBe('pointer')
+
+    beginResizeInteraction('context-panel', 'programmatic')
+    expect(starts.length).toBe(1) // Joining source: no re-fire.
+
+    releaseResizeInteraction('left-sidebar', first)
+    releaseResizeInteraction('context-panel', first)
+    scheduler.runFrames()
+    unsubscribe()
+  })
+
+  test('transaction-start participant fires synchronously before the first width frame', async () => {
+    const order: string[] = []
+    registerResizeTransactionStartParticipant(() => { order.push('start') })
+    registerResizeFrameParticipant(() => { order.push('frame') })
+    const id = beginResizeInteraction('left-sidebar', 'programmatic')
+    notifyResizeFrame({ transactionId: id, width: 300, kind: 'drag', origin: 'programmatic', source: 'left-sidebar' })
+    expect(order).toEqual(['start', 'frame'])
+    releaseResizeInteraction('left-sidebar', id)
+    scheduler.runFrames()
+  })
+
+  test('a new transaction during finalizing aborts the old finalizer', async () => {
+    const first = beginResizeInteraction('left-sidebar')
+    // Container objects: TS does not track values assigned inside closures for
+    // reads outside them, so capture through properties instead of variables.
+    const capturedSignal: { signal: AbortSignal | null } = { signal: null }
+    const capturedResolve: { fn: (() => void) | null } = { fn: null }
+    registerResizeFinalizer((signal) => {
+      capturedSignal.signal = signal
+      return new Promise<void>((resolve) => {
+        capturedResolve.fn = resolve
+      })
+    })
+
+    releaseResizeInteraction('left-sidebar', first)
+    expect(getResizeInteractionPhase()).toBe('finalizing')
+    await flushMicrotasks()
+    expect(capturedSignal.signal?.aborted).toBe(false)
+
+    // New drag supersedes the in-flight finalization.
+    beginResizeInteraction('context-panel')
+    expect(capturedSignal.signal?.aborted).toBe(true)
+    expect(getResizeInteractionPhase()).toBe('dragging')
+
+    // Letting the old finalizer resolve afterwards must not corrupt the new
+    // transaction.
+    capturedResolve.fn?.()
+    await flushMicrotasks()
+    expect(getResizeInteractionPhase()).toBe('dragging')
+  })
+
+  test('a never-resolving finalizer is recovered by the 1000ms fail-safe', async () => {
+    const id = beginResizeInteraction('left-sidebar')
+    const capturedSignal: { signal: AbortSignal | null } = { signal: null }
+    registerResizeFinalizer((signal) => {
+      capturedSignal.signal = signal
+      return new Promise<void>(() => {
+        // never resolves
+      })
+    })
+
+    releaseResizeInteraction('left-sidebar', id)
+    expect(getResizeInteractionPhase()).toBe('finalizing')
+    await flushMicrotasks()
+    expect(capturedSignal.signal?.aborted).toBe(false)
+    scheduler.runTimeouts()
+    expect(getResizeInteractionPhase()).toBe('idle')
+    expect(capturedSignal.signal?.aborted).toBe(true)
+  })
+
+  test('cancel follows the same single-finalization path as release', async () => {
+    const id = beginResizeInteraction('context-panel')
+    let finalizerCalls = 0
+    registerResizeFinalizer(() => {
+      finalizerCalls += 1
+    })
+    cancelResizeInteraction('context-panel', id, 'cancelled')
+    await flushMicrotasks()
+    await flushMicrotasks()
+    expect(finalizerCalls).toBe(1)
+    expect(getResizeInteractionPhase()).toBe('idle')
+  })
+
+  test('listeners observe begin/release transitions with active boolean', async () => {
+    const seen: boolean[] = []
+    const unsubscribe = subscribeResizeInteraction((active) => {
+      seen.push(active)
+    })
+
+    const id = beginResizeInteraction('left-sidebar')
+    expect(seen).toEqual([true])
+    releaseResizeInteraction('left-sidebar', id)
+    // finalizing starts synchronously on release -> false notification.
+    expect(seen).toEqual([true, false])
+    // The no-finalizer next-frame end fires one more false for idle.
+    scheduler.runFrames()
+    expect(seen).toEqual([true, false, false])
+    unsubscribe()
+  })
+
+  test('legacy setResizeInteractionActive maps to begin/release', () => {
+    setResizeInteractionActive('left-sidebar', true)
+    expect(getResizeInteractionPhase()).toBe('dragging')
+
+    setResizeInteractionActive('left-sidebar', false)
+    expect(getResizeInteractionPhase()).toBe('finalizing')
+
+    // Idempotent: releasing an already-ended source is a no-op.
+    setResizeInteractionActive('left-sidebar', false)
+    expect(getResizeInteractionPhase()).toBe('finalizing')
+  })
+
+  test('frame participants are notified with transactionId/width/kind/origin/source/frameSequence and unsubscribe works', () => {
+    const seen: Array<{ transactionId: number; width: number; kind: string; origin: string; source: string; frameSequence: number }> = []
+    const unsubscribe = registerResizeFrameParticipant((frame) => { seen.push({ ...frame }) })
+    notifyResizeFrame({ transactionId: 7, width: 320, kind: 'drag', origin: 'pointer', source: 'left-sidebar' })
+    notifyResizeFrame({ transactionId: 7, width: 410, kind: 'drag', origin: 'programmatic', source: 'context-panel' })
+    expect(seen.length).toBe(2)
+    expect(seen[0].transactionId).toBe(7)
+    expect(seen[0].width).toBe(320)
+    expect(seen[0].origin).toBe('pointer')
+    expect(seen[0].source).toBe('left-sidebar')
+    expect(seen[0].frameSequence).toBeGreaterThan(0)
+    expect(seen[1].origin).toBe('programmatic')
+    expect(seen[1].frameSequence).toBeGreaterThan(seen[0].frameSequence)
+
+    unsubscribe()
+    notifyResizeFrame({ transactionId: 8, width: 500, kind: 'final', origin: 'pointer', source: 'left-sidebar' })
+    expect(seen.length).toBe(2)
+  })
+
+  test('notifyResizeFrame with no participants is a no-op', () => {
+    resetResizeFrameParticipantsForTests()
+    let threw = false
+    try {
+      notifyResizeFrame({ transactionId: 1, width: 123, kind: 'drag', origin: 'pointer', source: 'left-sidebar' })
+    } catch {
+      threw = true
+    }
+    expect(threw).toBe(false)
+  })
+
+  test('multiple participants all receive every frame in registration order', () => {
+    resetResizeFrameParticipantsForTests()
+    const order: string[] = []
+    const a = registerResizeFrameParticipant(() => { order.push('a') })
+    const b = registerResizeFrameParticipant(() => { order.push('b') })
+    notifyResizeFrame({ transactionId: 1, width: 300, kind: 'drag', origin: 'pointer', source: 'left-sidebar' })
+    expect(order).toEqual(['a', 'b'])
+    a()
+    b()
+    resetResizeFrameParticipantsForTests()
+  })
+})

--- a/packages/ui/src/lib/resizeInteraction.ts
+++ b/packages/ui/src/lib/resizeInteraction.ts
@@ -1,0 +1,451 @@
+// Deterministic resize transaction state machine.
+//
+// Replaces the previous fixed 340ms "settling" timer with an explicit
+// idle -> dragging -> finalizing -> idle transaction. A release or cancel
+// opens the finalizing phase: registered finalizers (typically the visible
+// message list) run their single remeasure + anchor restore, and the
+// transaction only returns to idle once every finalizer has completed — or a
+// 1000ms fail-safe forces it back (recorded as an abnormal completion). This
+// removes the double end notification and the ~300ms/640ms double remeasure
+// that the timer-based settling window caused.
+//
+// Consumers that only need the old boolean semantics keep using
+// `isResizeInteractionActive()` / `isResizeSettling()` / `setResizeInteractionActive`
+// (derived compatibility methods); panel handles migrate to the explicit
+// begin/release/cancel transaction API to obtain a transactionId.
+
+export type ResizeInteractionSource = 'left-sidebar' | 'context-panel';
+
+/** How the transaction started: a pointer drag or a programmatic width
+ *  animation (quick open/close toggle, mode switch). */
+export type ResizeOrigin = 'pointer' | 'programmatic';
+
+export type ResizeInteractionPhase = 'idle' | 'dragging' | 'finalizing';
+
+/** Why a transaction ended. `released` is the normal path; the rest are
+ *  exceptional and are recorded for diagnostics. */
+export type ResizeFinalizeReason =
+  | 'released'
+  | 'cancelled'
+  | 'new-drag'
+  | 'timeout';
+
+export type ResizeFinalizer = (signal: AbortSignal) => void | Promise<void>;
+
+type ResizeInteractionListener = (active: boolean) => void;
+
+import { recordPerformanceTraceEvent } from '@/stores/utils/performanceTrace';
+
+/** Injected clock/frame scheduler so the state machine is deterministically
+ *  testable without depending on global timers or requestAnimationFrame. */
+export interface ResizeScheduler {
+  setTimeout(handler: () => void, ms: number): unknown;
+  clearTimeout(id: unknown): void;
+  requestAnimationFrame(handler: () => void): unknown;
+  cancelAnimationFrame(id: unknown): void;
+}
+
+const defaultScheduler: ResizeScheduler = {
+  setTimeout: (handler, ms) => window.setTimeout(handler, ms),
+  clearTimeout: (id) => window.clearTimeout(id as number),
+  requestAnimationFrame: (handler) => window.requestAnimationFrame(handler),
+  cancelAnimationFrame: (id) => window.cancelAnimationFrame(id as number),
+};
+
+let scheduler: ResizeScheduler = defaultScheduler;
+
+export const setResizeSchedulerForTests = (next: ResizeScheduler): void => {
+  scheduler = next;
+};
+
+export const resetResizeSchedulerForTests = (): void => {
+  scheduler = defaultScheduler;
+};
+
+/** Reset the transaction state machine to idle. Test-only: production code
+ *  never calls this (a fresh transaction supersedes finalizing on its own). */
+export const resetResizeInteractionForTests = (): void => {
+  finalizeAbortController?.abort();
+  finalizeAbortController = null;
+  clearFailSafe();
+  pendingFinalizers.clear();
+  activeSources.clear();
+  sourceTransactionIds.clear();
+  currentTransaction = null;
+  phase = 'idle';
+};
+
+/** Abnormal-completion budget for a finalizing phase. Finalizers are expected
+ *  to finish well inside this; the timer only exists to guarantee the UI can
+ *  never get stuck in finalizing after a buggy/never-resolving finalizer. */
+const FAIL_SAFE_MS = 1000;
+
+let phase: ResizeInteractionPhase = 'idle';
+let nextTransactionId = 0;
+let currentTransaction: number | null = null;
+const activeSources = new Set<ResizeInteractionSource>();
+const sourceTransactionIds = new Map<ResizeInteractionSource, number>();
+let failSafeTimer: unknown = null;
+let finalizeAbortController: AbortController | null = null;
+const pendingFinalizers = new Set<ResizeFinalizer>();
+const listeners = new Set<ResizeInteractionListener>();
+let finalizingStartedAt = 0;
+let finalizingSource: ResizeInteractionSource | null = null;
+let finalizingReason: ResizeFinalizeReason = 'released';
+
+const nowMs = (): number => (
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+
+const notify = (): void => {
+  const active = phase === 'dragging';
+  for (const listener of listeners) {
+    listener(active);
+  }
+};
+
+const clearFailSafe = (): void => {
+  if (failSafeTimer !== null) {
+    scheduler.clearTimeout(failSafeTimer);
+    failSafeTimer = null;
+  }
+};
+
+const startFailSafe = (transactionId: number): void => {
+  clearFailSafe();
+  failSafeTimer = scheduler.setTimeout(() => {
+    failSafeTimer = null;
+    completeFinalization(transactionId, 'timeout');
+  }, FAIL_SAFE_MS);
+};
+
+const completeFinalization = (
+  transactionId: number,
+  reason: ResizeFinalizeReason,
+): void => {
+  if (currentTransaction !== transactionId || phase !== 'finalizing') {
+    return;
+  }
+  // Record the transaction outcome BEFORE clearing state so source/phase are
+  // still readable. This is how the perf tooling learns about cancel vs
+  // released vs timeout endings.
+  if (typeof window !== 'undefined') {
+    recordPerformanceTraceEvent(
+      'ui.resize.transaction_end',
+      {
+        transactionId,
+        source: finalizingSource ?? 'unknown',
+        phase: 'finalizing',
+        reason: reason === 'timeout' ? 'timeout' : finalizingReason,
+        durationMs: Math.round(nowMs() - finalizingStartedAt),
+      },
+      0,
+      undefined,
+    );
+  }
+  clearFailSafe();
+  finalizeAbortController?.abort();
+  finalizeAbortController = null;
+  pendingFinalizers.clear();
+  activeSources.clear();
+  sourceTransactionIds.clear();
+  finalizingSource = null;
+  finalizingReason = 'released';
+  currentTransaction = null;
+  phase = 'idle';
+  notify();
+};
+
+const enterFinalizing = (
+  transactionId: number,
+  source: ResizeInteractionSource,
+  reason: Exclude<ResizeFinalizeReason, 'timeout' | 'new-drag'> = 'released',
+): void => {
+  phase = 'finalizing';
+  finalizingStartedAt = nowMs();
+  finalizingSource = source;
+  finalizingReason = reason;
+  startFailSafe(transactionId);
+  notify();
+
+  const finalizers = [...pendingFinalizers];
+  pendingFinalizers.clear();
+  if (finalizers.length === 0) {
+    // No visible list to remeasure: end on the next frame so the final
+    // width commit frame is not cut short by an immediate reset.
+    scheduler.requestAnimationFrame(() => {
+      completeFinalization(transactionId, 'released');
+    });
+    return;
+  }
+
+  const controller = new AbortController();
+  finalizeAbortController = controller;
+  let settled = false;
+  const finish = (): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    completeFinalization(transactionId, 'released');
+  };
+  Promise.all(
+    finalizers.map((fn) => Promise.resolve().then(() => fn(controller.signal))),
+  ).then(finish, finish);
+};
+
+/**
+ * Start a resize transaction. Returns the transaction id that must be passed
+ * to `releaseResizeInteraction` / `cancelResizeInteraction`.
+ *
+ * ONE GLOBAL TRANSACTION per active period: a second source joining while a
+ * transaction is already dragging REUSES the current id (it only registers its
+ * own source accounting) — no re-capture, no finalizer reset. Only a transition
+ * out of idle/finalizing creates a fresh id and fires the synchronous
+ * transaction-start participants (the anchor controller captures the OLD
+ * layout there, before the first width write).
+ *
+ * Starting a new transaction while a previous one is still finalizing aborts
+ * the old finalization (finalizers observe the abort signal) and supersedes
+ * it; a stale completion from the old transaction is then a no-op because the
+ * transaction id no longer matches.
+ */
+export const beginResizeInteraction = (
+  source: ResizeInteractionSource,
+  origin: ResizeOrigin = 'pointer',
+): number => {
+  if (phase === 'finalizing') {
+    finalizeAbortController?.abort();
+    finalizeAbortController = null;
+    clearFailSafe();
+  }
+  if (phase === 'dragging' && currentTransaction !== null) {
+    // Second source joins the SAME active period: share the id.
+    activeSources.add(source);
+    sourceTransactionIds.set(source, currentTransaction);
+    return currentTransaction;
+  }
+  const transactionId = ++nextTransactionId;
+  pendingFinalizers.clear();
+  activeSources.add(source);
+  sourceTransactionIds.set(source, transactionId);
+  currentTransaction = transactionId;
+  phase = 'dragging';
+  // Synchronous transaction-start: participants capture the pre-resize layout
+  // BEFORE any width frame may be written.
+  notifyTransactionStart({ transactionId, source, origin });
+  notify();
+  return transactionId;
+};
+
+/**
+ * End a drag normally (pointerup). If other sources are still dragging, the
+ * transaction stays open; otherwise the finalizing phase starts and the
+ * transaction completes once every registered finalizer has run.
+ */
+export const releaseResizeInteraction = (
+  source: ResizeInteractionSource,
+  transactionId: number,
+): void => {
+  if (sourceTransactionIds.get(source) !== transactionId || !activeSources.has(source)) {
+    return;
+  }
+  activeSources.delete(source);
+  sourceTransactionIds.delete(source);
+  if (activeSources.size > 0) {
+    return;
+  }
+  enterFinalizing(transactionId, source);
+};
+
+/**
+ * End a drag abnormally (pointercancel, lost capture, window blur,
+ * visibilitychange). The last legal width has already been committed by the
+ * caller, so the same single finalization path runs; the reason is preserved
+ * for diagnostics.
+ */
+export const cancelResizeInteraction = (
+  source: ResizeInteractionSource,
+  transactionId: number,
+  reason: Exclude<ResizeFinalizeReason, 'timeout' | 'new-drag'> = 'cancelled',
+): void => {
+  if (sourceTransactionIds.get(source) !== transactionId || !activeSources.has(source)) {
+    return;
+  }
+  activeSources.delete(source);
+  sourceTransactionIds.delete(source);
+  if (activeSources.size > 0) {
+    return;
+  }
+  enterFinalizing(transactionId, source, reason);
+};
+
+/**
+ * Register a finalizer that runs once at the end of the current drag
+ * transaction (during the finalizing phase). It receives an AbortSignal that
+ * fires if a new transaction starts before it completes. The transaction stays
+ * in `finalizing` until every registered finalizer has resolved.
+ *
+ * Registration only takes effect for the transaction that is active at
+ * registration time (begin clears the set); the returned unsubscribe removes
+ * the finalizer if the registration happens to be superseded.
+ */
+export const registerResizeFinalizer = (
+  finalizer: ResizeFinalizer,
+): (() => void) => {
+  pendingFinalizers.add(finalizer);
+  return () => {
+    pendingFinalizers.delete(finalizer);
+  };
+};
+
+/** True while at least one panel drag is actively moving the pointer. */
+export const isResizeInteractionActive = (): boolean => phase === 'dragging';
+
+/** True while dragging OR while the post-release remeasure/anchor restore is
+ *  still running. Consumers (virtual list measurement freeze, scroll
+ *  compensation) must keep behaving as "mid-resize" throughout this window. */
+export const isResizeSettling = (): boolean => phase !== 'idle';
+
+/** Stable boolean snapshot for `useSyncExternalStore`. */
+export const getResizeSettlingSnapshot = (): boolean => isResizeSettling();
+
+/** Alias with the same semantics; use when the caller wants the transaction
+ *  framing rather than the settling-window framing. */
+export const getResizeInteractionSnapshot = (): boolean => isResizeSettling();
+
+export const getResizeInteractionPhase = (): ResizeInteractionPhase => phase;
+
+/** The active transaction id (null when idle). Frame participants use it to
+ *  ignore frames from superseded transactions. */
+export const getCurrentResizeTransactionId = (): number | null => currentTransaction;
+
+export const subscribeResizeInteraction = (
+  listener: ResizeInteractionListener,
+): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+/**
+ * Per-frame resize participants. A panel drag applies its width once per
+ * animation frame (usePanelResize's single-flight rAF); every registered
+ * participant is invoked IN THAT SAME FRAME, immediately after the width is
+ * written and before the browser paints. This is how the chat anchor
+ * controller adjusts scrollTop with the width — one deterministic writer per
+ * frame, no post-paint chase. Participants are invoked for every live width
+ * frame AND for the final width commit (release/cancel), so the last frame
+ * cannot be missed.
+ */
+/** Per-frame participant payload. `frameSequence` is a monotonic sequence
+ *  (across transactions) so consumers can detect "a new frame happened" for
+ *  the current transaction without deduping by width (two panels can share a
+ *  width value and would otherwise lose frames). */
+export type ResizeFrameParticipant = (frame: {
+    transactionId: number;
+    width: number;
+    kind: 'drag' | 'final' | 'cancel';
+    origin: ResizeOrigin;
+    source: ResizeInteractionSource;
+    frameSequence: number;
+}) => void;
+
+const frameParticipants = new Set<ResizeFrameParticipant>();
+
+/** Monotonic frame sequence — never dedupe by width. */
+let frameSequence = 0;
+
+/**
+ * Synchronous transaction-start participants. Fired from beginResizeInteraction
+ * for a FRESH transaction (idle/finalizing -> dragging), BEFORE the first width
+ * frame may be written. The anchor controller captures the pre-resize layout
+ * here, so a quick programmatic toggle's first animated width lands on an
+ * already-anchored baseline. Joining sources within the same active period do
+ * NOT re-fire (no re-capture, no finalizer reset).
+ */
+export type ResizeTransactionStartParticipant = (start: {
+    transactionId: number;
+    source: ResizeInteractionSource;
+    origin: ResizeOrigin;
+}) => void;
+
+const transactionStartParticipants = new Set<ResizeTransactionStartParticipant>();
+
+/** Register a synchronous transaction-start participant; returns the
+ *  unsubscribe. */
+export const registerResizeTransactionStartParticipant = (
+    participant: ResizeTransactionStartParticipant,
+): (() => void) => {
+    transactionStartParticipants.add(participant);
+    return () => {
+        transactionStartParticipants.delete(participant);
+    };
+};
+
+const notifyTransactionStart = (start: {
+    transactionId: number;
+    source: ResizeInteractionSource;
+    origin: ResizeOrigin;
+}): void => {
+    for (const participant of transactionStartParticipants) {
+        participant(start);
+    }
+};
+
+/** Register a per-frame participant; returns the unsubscribe. */
+export const registerResizeFrameParticipant = (
+    participant: ResizeFrameParticipant,
+): (() => void) => {
+    frameParticipants.add(participant);
+    return () => {
+        frameParticipants.delete(participant);
+    };
+};
+
+/** Notify participants that the panel width was applied this frame. Called by
+ *  usePanelResize from inside its rAF (and from the final width commit). */
+export const notifyResizeFrame = (frame: {
+    transactionId: number;
+    width: number;
+    kind: 'drag' | 'final' | 'cancel';
+    origin: ResizeOrigin;
+    source: ResizeInteractionSource;
+}): void => {
+    const seq = ++frameSequence;
+    if (frameParticipants.size === 0) {
+        return;
+    }
+    for (const participant of frameParticipants) {
+        participant({ ...frame, frameSequence: seq });
+    }
+};
+
+/** Test-only: clear registered participants. */
+export const resetResizeFrameParticipantsForTests = (): void => {
+    frameParticipants.clear();
+    transactionStartParticipants.clear();
+    frameSequence = 0;
+};
+
+/**
+ * Legacy two-arg wrapper kept for callers that have not yet migrated to the
+ * explicit transaction API: `active=true` maps to begin, `active=false` maps
+ * to release using the tracked transaction id for that source.
+ */
+export const setResizeInteractionActive = (
+  source: ResizeInteractionSource,
+  active: boolean,
+): void => {
+  if (active) {
+    beginResizeInteraction(source);
+    return;
+  }
+  const transactionId = sourceTransactionIds.get(source);
+  if (transactionId !== undefined) {
+    releaseResizeInteraction(source, transactionId);
+  }
+};

--- a/packages/ui/src/lib/surfaces/DOCUMENTATION.md
+++ b/packages/ui/src/lib/surfaces/DOCUMENTATION.md
@@ -54,3 +54,57 @@ the `openContext*` actions in `useUIStore`.
   on switch. These surfaces must restore their state from stores or snapshots.
 - Runtime scope: desktop/web `MainLayout` only. VS Code and the dedicated
   mobile shell have their own layouts and do not consume this registry.
+
+## Layout animation invariant (migrated from the 1.17.2 repair, 2026-08)
+
+A surface only provides a TARGET WIDTH; the panel's layout animation is
+controlled by the single global resize transaction in `lib/resizeInteraction.ts`
+and driven by `usePanelResize`'s `programmaticTarget` option:
+
+- `usePanelResize` is the ONLY geometry writer. Panel components never write
+  the root width, the width CSS variable or a width transition from React —
+  even the closed state (`0px` is a legal close target and is never
+  min-clamped; only positive widths are clamped to min/max/available). The
+  root keeps a fixed structure (`flex: none`, width reads
+  `var(--oc-left-sidebar-width, 0px)` / `var(--oc-context-panel-width, 0px)`);
+  the content column is `width: 100%`. At most one width write happens per
+  animation frame.
+- `programmaticTarget { key, width, cause }`:
+  - `cause: 'visibility' | 'mode'` — a fixed animation through the SAME
+    per-frame writer as a pointer drag: CSS variable write →
+    `notifyResizeFrame` → chat anchor commit, all before paint. A key change
+    re-directs the animation from the current applied width in the same
+    transaction.
+  - `cause: 'parent-layout'` — per-frame FOLLOW (no animation clock). While a
+    global transaction is active the panel rides its frames; otherwise a short
+    transaction opens on the first real width change and closes once the width
+    stabilizes. The ContextPanel's ResizeObserver writes the available width to
+    a REF (no per-pixel React re-render) and wakes the follow loop via
+    `notifyAvailableWidthChange`.
+- Motion profiles: **standard = 200ms easeOutCubic; reduced motion = 120ms
+  easeOutQuad** — reduced motion is a SHORT visible animation, NEVER a
+  single-frame jump. The preference is read from a live MediaQueryList
+  subscription (a system change mid-animation does not alter the running
+  animation; it applies from the next open/close). The single-frame path is
+  reserved for explicit test configuration (`programmaticDurationMs === 0`).
+  First mount still writes the initial width silently (no animation, no
+  transaction). No CSS width transition on the panel root — the JS animation
+  is the single interpolator; only the content opacity transition remains.
+- Persistence: `onUserCommitWidth` runs EXACTLY once, on pointerup, and is the
+  only path that writes user settings (`sidebarWidth` +
+  `hasManuallyResizedLeftSidebar`, `widthByMode`, default fractions).
+  Programmatic open/close, mode switches and parent-layout follows NEVER
+  persist — they only update the applied DOM width.
+- Concurrent operations: a semantic target change mid-drag hands the pointer
+  ownership over to the programmatic path WITHOUT releasing the global
+  transaction (same anchor capture) and animates from the current applied
+  width; the target is never marked handled before it is executed. A pointer
+  drag takes over any running programmatic animation from the current width and
+  reuses the transaction id.
+- The chat conversation seam is anchored during the transaction
+  (`useConversationResizeAnchor` + `conversationResizeLayout/Anchor`): the
+  question-bubble top stays stable (delta vs the last committed frame; zero
+  writes when nothing changed). Programmatic animation observability is
+  emitted as `ui.panel.programmatic_end` (motionMode / configuredDurationMs /
+  actualDurationMs / appliedFrameCount / distinctWidthCount / startWidth /
+  finalWidth / reducedMotionAtStart — size and timing only).

--- a/packages/ui/src/stores/utils/performanceTrace.ts
+++ b/packages/ui/src/stores/utils/performanceTrace.ts
@@ -1,0 +1,278 @@
+const STORAGE_KEY = "openchamber_performance_trace"
+const MAX_EVENTS = 512
+const MAX_FIELD_STRING_LENGTH = 96
+const MAX_CONTEXT_LINKS = 8
+
+type PerformanceTraceFieldValue = string | number | boolean
+export type PerformanceTraceFields = Record<string, PerformanceTraceFieldValue | undefined>
+
+type PerformanceTraceEvent = {
+  seq: number
+  atMs: number
+  name: string
+  kind: "event" | "span"
+  durationMs?: number
+  traceId?: string
+  spanId?: string
+  fields: Record<string, PerformanceTraceFieldValue>
+}
+
+export type PerformanceTraceLink = {
+  name: string
+  traceId?: string
+  atMs: number
+  durationMs: number
+}
+
+type PerformanceTraceSnapshot = {
+  enabled: boolean
+  startedAt: number | null
+  lastUpdatedAt: number | null
+  durationMs: number
+  events: PerformanceTraceEvent[]
+  droppedEvents: number
+  openSpans: number
+}
+
+export type PerformanceTraceSpan = {
+  traceId?: string
+  spanId?: string
+  child: (name: string, fields?: PerformanceTraceFields) => PerformanceTraceSpan
+  end: (fields?: PerformanceTraceFields) => void
+}
+
+type PerformanceTraceState = {
+  startedAt: number
+  startedAtPerf: number
+  lastUpdatedAt: number
+  nextSequence: number
+  nextTraceId: number
+  nextSpanId: number
+  droppedEvents: number
+  events: PerformanceTraceEvent[]
+  openSpans: Map<string, true>
+}
+
+declare global {
+  interface Window {
+    __openchamberPerformanceTrace?: {
+      setEnabled: (enabled: boolean) => void
+      reset: () => void
+      getSnapshot: () => PerformanceTraceSnapshot
+    }
+  }
+}
+
+const now = (): number => (
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now()
+)
+
+const round = (value: number): number => Number(value.toFixed(3))
+
+const readInitialEnabled = (): boolean => {
+  if (typeof window === "undefined") return false
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1"
+  } catch {
+    return false
+  }
+}
+
+const createState = (): PerformanceTraceState => {
+  const startedAtPerf = now()
+  return {
+    startedAt: Date.now(),
+    startedAtPerf,
+    lastUpdatedAt: Date.now(),
+    nextSequence: 1,
+    nextTraceId: 1,
+    nextSpanId: 1,
+    droppedEvents: 0,
+    events: [],
+    openSpans: new Map(),
+  }
+}
+
+let enabled = readInitialEnabled()
+let state: PerformanceTraceState | null = enabled ? createState() : null
+
+const sanitizeName = (name: string): string => name.trim().slice(0, MAX_FIELD_STRING_LENGTH)
+
+const sanitizeFields = (fields: PerformanceTraceFields | undefined): Record<string, PerformanceTraceFieldValue> => {
+  if (!fields) return {}
+  const result: Record<string, PerformanceTraceFieldValue> = {}
+  for (const [key, value] of Object.entries(fields)) {
+    if (!key || value === undefined) continue
+    const safeKey = key.trim().slice(0, MAX_FIELD_STRING_LENGTH)
+    if (!safeKey) continue
+    if (typeof value === "string") {
+      result[safeKey] = value.replace(/[\r\n\t]/g, " ").slice(0, MAX_FIELD_STRING_LENGTH)
+    } else if (typeof value === "number" && Number.isFinite(value)) {
+      result[safeKey] = round(value)
+    } else if (typeof value === "boolean") {
+      result[safeKey] = value
+    }
+  }
+  return result
+}
+
+type AppendEventInput = Omit<PerformanceTraceEvent, "seq" | "atMs" | "fields"> & {
+  atPerf?: number
+  fields?: PerformanceTraceFields
+}
+
+const appendEvent = (input: AppendEventInput): void => {
+  if (!state) return
+  const event: PerformanceTraceEvent = {
+    seq: state.nextSequence++,
+    atMs: round(Math.max(0, (input.atPerf ?? now()) - state.startedAtPerf)),
+    name: sanitizeName(input.name),
+    kind: input.kind,
+    ...(input.durationMs !== undefined ? { durationMs: round(Math.max(0, input.durationMs)) } : {}),
+    ...(input.traceId ? { traceId: input.traceId } : {}),
+    ...(input.spanId ? { spanId: input.spanId } : {}),
+    fields: sanitizeFields(input.fields),
+  }
+  if (state.events.length >= MAX_EVENTS) {
+    state.events.shift()
+    state.droppedEvents += 1
+  }
+  state.events.push(event)
+  state.lastUpdatedAt = Date.now()
+}
+
+const noopSpan: PerformanceTraceSpan = {
+  child: () => noopSpan,
+  end: () => undefined,
+}
+
+export const startPerformanceTraceSpan = (
+  name: string,
+  fields?: PerformanceTraceFields,
+  parentTraceId?: string,
+): PerformanceTraceSpan => {
+  if (!enabled || !state || !sanitizeName(name)) return noopSpan
+
+  const spanState = state
+  const traceId = parentTraceId || `t${state.nextTraceId++}`
+  const spanId = `s${state.nextSpanId++}`
+  const startedAt = now()
+  state.openSpans.set(spanId, true)
+  let ended = false
+
+  return {
+    traceId,
+    spanId,
+    child: (childName, childFields) => startPerformanceTraceSpan(childName, childFields, traceId),
+    end: (endFields) => {
+      if (ended) return
+      ended = true
+      spanState.openSpans.delete(spanId)
+      if (state !== spanState || !enabled) return
+      appendEvent({
+        name,
+        kind: "span",
+        durationMs: now() - startedAt,
+        traceId,
+        spanId,
+        fields: { ...fields, ...endFields },
+      })
+    },
+  }
+}
+
+export const recordPerformanceTraceEvent = (
+  name: string,
+  fields?: PerformanceTraceFields,
+  durationMs?: number,
+  traceId?: string,
+): void => {
+  if (!enabled || !state || !sanitizeName(name)) return
+  appendEvent({
+    name,
+    kind: "event",
+    ...(durationMs !== undefined && Number.isFinite(durationMs) ? { durationMs } : {}),
+    ...(traceId ? { traceId } : {}),
+    fields,
+  })
+}
+
+export const getRecentPerformanceTraceLinks = (
+  windowMs = 1_000,
+  limit = MAX_CONTEXT_LINKS,
+): PerformanceTraceLink[] => {
+  if (!enabled || !state || windowMs < 0 || limit <= 0) return []
+  const currentAtMs = Math.max(0, now() - state.startedAtPerf)
+  const cutoffMs = currentAtMs - windowMs
+  return state.events
+    .filter((event) => (
+      event.durationMs !== undefined
+      && event.atMs <= currentAtMs
+      && event.atMs + event.durationMs >= cutoffMs
+    ))
+    .slice(-limit)
+    .map((event) => ({
+      name: event.name,
+      ...(event.traceId ? { traceId: event.traceId } : {}),
+      atMs: event.atMs,
+      durationMs: event.durationMs ?? 0,
+    }))
+}
+
+const emptySnapshot = (): PerformanceTraceSnapshot => ({
+  enabled: false,
+  startedAt: null,
+  lastUpdatedAt: null,
+  durationMs: 0,
+  events: [],
+  droppedEvents: 0,
+  openSpans: 0,
+})
+
+export const getPerformanceTraceSnapshot = (): PerformanceTraceSnapshot => {
+  if (!enabled || !state) return emptySnapshot()
+  return {
+    enabled: true,
+    startedAt: state.startedAt,
+    lastUpdatedAt: state.lastUpdatedAt,
+    durationMs: Math.max(0, Date.now() - state.startedAt),
+    events: state.events.map((event) => ({
+      ...event,
+      fields: { ...event.fields },
+    })),
+    droppedEvents: state.droppedEvents,
+    openSpans: state.openSpans.size,
+  }
+}
+
+export const resetPerformanceTrace = (): void => {
+  if (enabled) state = createState()
+}
+
+export const setPerformanceTraceEnabled = (nextEnabled: boolean): void => {
+  if (nextEnabled === enabled) {
+    if (nextEnabled) resetPerformanceTrace()
+    return
+  }
+
+  enabled = nextEnabled
+  state = nextEnabled ? createState() : null
+  if (typeof window === "undefined") return
+
+  try {
+    if (nextEnabled) window.localStorage.setItem(STORAGE_KEY, "1")
+    else window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Ignore storage failures in the opt-in debug helper.
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.__openchamberPerformanceTrace = {
+    setEnabled: setPerformanceTraceEnabled,
+    reset: resetPerformanceTrace,
+    getSnapshot: getPerformanceTraceSnapshot,
+  }
+}


### PR DESCRIPTION
## Intent

Stabilize the chat seam while the left sidebar / right ContextPanel changes width, and restore a visible open/close animation under `prefers-reduced-motion`.

The previous behavior:

- Sidebar/ContextPanel wrote the width from React inline styles **and** ran CSS width transitions, while the message list had no anchor during the change — dragging or toggling a panel let the first visible user question drift (or the viewport jump), especially across wrap boundaries (768/1024) and with long messages.
- Under `prefers-reduced-motion: reduce` the programmatic open/close collapsed to a single-frame width write — the panel "popped" instead of animating.

What this PR does:

- Introduces a single global resize transaction (`lib/resizeInteraction.ts`) and a **single geometry writer** (`usePanelResize`): React no longer writes panel widths or CSS transitions; the hook owns the width CSS variables and animates open/close / mode switches / expand through one per-frame writer (CSS var write → `notifyResizeFrame` → anchor commit, all before paint).
- Anchors the conversation seam during the transaction (`useConversationResizeAnchor` + `conversationResizeLayout`/`conversationResizeAnchor`): the first visible user-question top stays stable (frame-delta model, zero writes when nothing changed), with a per-transaction held range.
- Motion profiles: **standard 200ms easeOutCubic; reduced motion 120ms easeOutQuad** — reduced motion is a short visible animation, never a single-frame jump. The preference is a live MediaQueryList subscription; a change mid-animation does not alter the running animation.
- Persistence is pointer-up only (`onUserCommitWidth`): programmatic open/close, mode switches and parent-layout follows never write user settings.
- Adds the `suppressScrollAdjustments` option to the existing `@tanstack/virtual-core` 3.17.3 bun patch so the anchor controller is the only scroll writer during a transaction.

## Non-goals

- No new dependencies (the virtual-core patch extends the existing pinned version).
- No change to persisted settings schema or IDs.
- No change to the VS Code / mobile shell layouts (they do not consume this shared desktop/web layout path).

## Affected surfaces

- `packages/ui` (desktop + web): `Sidebar`, `ContextPanel`, `MessageList`, `ChatContainer`, `ChatInput`, `ChatMessage`, `TurnItem`, `TurnAssistantBlock`; new modules `resizeInteraction`, `usePanelResize`, `useConversationResizeAnchor`, `conversationResizeLayout`, `conversationResizeAnchor`, `performanceTrace`; bun patch `bun-patches/@tanstack+virtual-core+3.17.3.patch`.
- Runtime scope: desktop/web `MainLayout` only. VS Code and the mobile shells have their own layouts and do not consume this registry — unchanged.
- No persisted/external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md `openchamber-change-discipline` | Any source/module-ownership change in `packages/ui` | Modules are placed in their owning paths; the width-writer contract is documented in `packages/ui/src/lib/surfaces/DOCUMENTATION.md`; no unrelated refactors |
| AGENTS.md `performance-engineering` | This is a jank/lag/anchor-drift fix on a per-frame render hot path | Removed the per-pixel ResizeObserver re-render (ref-based follow loop); at most one width write per animation frame; frame-count assertions in tests |
| `packages/ui/src/lib/surfaces/DOCUMENTATION.md` | Nearest module doc for the layout-animation contract | Added the "Layout animation invariant" section (single width writer, motion profiles, reduced=120ms, seam anchor) |
| CONTRIBUTING.md PR contract | Review handoff requirements | Intent/non-goals/affected surfaces/validation/risks documented here with current-HEAD evidence |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (packages/ui) | Pass |
| `bun run lint` (packages/ui) | Pass |
| `bun run build` (packages/web vite build) | Pass (web assets built during packaging) |
| Unit tests (4 suites) | **81/81 pass**: `usePanelResize.test.tsx` (34 — incl. drag lifecycle, programmatic targets, round-10 single-writer/follow/shared-transaction, round-11 motion-profile suites), `resizeInteraction.test.ts` (14), `conversationResizeAnchor.test.ts` (17), `conversationResizeLayout.test.ts` (16) |
| Reduced-motion animation (unit-level) | Tests assert ≥4 distinct intermediate widths, first applied frame ≠ final frame, ~120ms completion — a single-frame jump fails these |
| `bun run dead-code` | No new items |
| Manual acceptance | Verified on the packaged desktop build: 120ms open/close animation visible under system reduce; sidebar/panel drag anchors the question top; right-panel proportional follow; no regressions in upstream 1.18.2 features (lazy views, single-iframe chat, walkthrough, Escape→terminal) |

Not verified here: VS Code / mobile runtimes (untouched by this change); CI runs the workspace-wide checks.

## Visual evidence

This is a motion/anchor change. The before (upstream) and after (this branch) desktop builds cannot be run side by side on the verification machine: the app server binds a fixed port and the installed upstream instance was in use during validation. The motion behavior is instead asserted deterministically by the unit tests (reduced-motion suites prove intermediate widths exist and the first frame differs from the final frame — i.e. no single-frame jump; drag suites prove the seam anchor key and DOM reference stay constant through the transaction). Static screenshots of the packaged build's sidebar states can be added on request.

## Risks and failure behavior

- **Virtual-core patch**: `suppressScrollAdjustments` is additive on the already-pinned 3.17.3 patch. If a consumer's lockfile does not apply the patch, the option is silently ignored (TanStack's `options` type accepts unknown keys at runtime) and the anchor controller would compete with TanStack's own scroll writes; the anchor suites fail in that case, so CI catches it.
- **Width persistence**: programmatic operations never call `onUserCommitWidth` (pointer-up only), so toggles/mode switches cannot clobber saved widths or the manual-resize flag. Reverting the PR restores the previous behavior exactly (no data migration).
- **Parent-layout follow**: opens a short transaction per real width change when no transaction is active; stale/failed frames are bounded by the transaction fail-safe and release on user intent.
- Cross-runtime: no VS Code/mobile behavior is touched; the shared modules only run under the desktop/web layout path.
