### PR TITLE
fix: kill orphaned process on Windows before OpenCode restart

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -1080,8 +1080,8 @@ const openCodeLifecycleRuntime = createOpenCodeLifecycleRuntime({
     return [...new Set(directories)];
   },
   // A managed restart can move OpenCode to a NEW port (the old one may stay
-  // occupied by an orphaned process, e.g. killProcessOnPort is a no-op on
-  // Windows). Rebind the message-stream upstream readers to the current port
+  // occupied if killProcessOnPort/waitForPortRelease didn't free it in time,
+  // on any platform). Rebind the message-stream upstream readers to the current port
   // so the UI keeps receiving events instead of staying pinned to the old
   // process (#2638). The runtime is created later by the startup pipeline;
   // by the time any restart runs, it is assigned.

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -53,8 +53,35 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     now = Date.now,
   } = deps;
 
+  const killProcessOnPortWin32 = (port) => {
+    try {
+      const result = spawnSync('netstat', ['-ano'], { encoding: 'utf8', timeout: 5000, windowsHide: true });
+      const output = result.stdout || '';
+      const myPid = process.pid;
+      const listeningPidPattern = /^\s*TCP\s+\S*:(\d+)\s+\S+\s+LISTENING\s+(\d+)\s*$/gim;
+      const pids = new Set();
+      let match;
+      while ((match = listeningPidPattern.exec(output)) !== null) {
+        if (Number.parseInt(match[1], 10) !== port) continue;
+        const pid = Number.parseInt(match[2], 10);
+        if (pid && pid !== myPid) pids.add(pid);
+      }
+      for (const pid of pids) {
+        try {
+          spawnSync('taskkill', ['/PID', String(pid), '/F'], { stdio: 'ignore', timeout: 3000, windowsHide: true });
+        } catch {
+        }
+      }
+    } catch {
+    }
+  };
+
   const killProcessOnPort = (port) => {
-    if (!port || process.platform === 'win32') return;
+    if (!port) return;
+    if (process.platform === 'win32') {
+      killProcessOnPortWin32(port);
+      return;
+    }
     try {
       const result = spawnSync('lsof', ['-ti', `:${port}`], { encoding: 'utf8', timeout: 5000, windowsHide: true });
       const output = result.stdout || '';
@@ -698,10 +725,11 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
       }
 
       // The restart may have landed on a NEW port (the old one can remain
-      // occupied by an orphaned process, e.g. Windows killProcessOnPort is a
-      // no-op). Upstream event readers pinned to the old process would keep
-      // the UI silent forever, so rebind them to the current port. Best
-      // effort: a failure here must not fail the restart itself.
+      // occupied if killProcessOnPort/waitForPortRelease didn't free it in
+      // time, on any platform). Upstream event readers pinned to the old
+      // process would keep the UI silent forever, so rebind them to the
+      // current port. Best effort: a failure here must not fail the restart
+      // itself.
       try {
         onOpenCodeRestarted?.();
       } catch (error) {

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -55,15 +55,25 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
 
   const killProcessOnPortWin32 = (port) => {
     try {
-      const result = spawnSync('netstat', ['-ano'], { encoding: 'utf8', timeout: 5000, windowsHide: true });
+      // Get-NetTCPConnection reads the same locale-independent WinNT API
+      // netstat's display layer translates (e.g. "LISTENING" renders as
+      // "ABHÖREN"/"ÉCOUTE"/"ESCUTANDO" on non-English Windows), so this
+      // works regardless of the OS display language.
+      const result = spawnSync(
+        'powershell',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `Get-NetTCPConnection -State Listen -LocalPort ${Number.parseInt(port, 10)} -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess`,
+        ],
+        { encoding: 'utf8', timeout: 5000, windowsHide: true }
+      );
       const output = result.stdout || '';
       const myPid = process.pid;
-      const listeningPidPattern = /^\s*TCP\s+\S*:(\d+)\s+\S+\s+LISTENING\s+(\d+)\s*$/gim;
       const pids = new Set();
-      let match;
-      while ((match = listeningPidPattern.exec(output)) !== null) {
-        if (Number.parseInt(match[1], 10) !== port) continue;
-        const pid = Number.parseInt(match[2], 10);
+      for (const line of output.split(/\r?\n/)) {
+        const pid = Number.parseInt(line.trim(), 10);
         if (pid && pid !== myPid) pids.add(pid);
       }
       for (const pid of pids) {

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -627,21 +627,12 @@ describe('killProcessOnPort on Windows', () => {
     Object.defineProperty(process, 'platform', { value: platform, configurable: true });
   };
 
-  const netstatOutput = (port, pid) => [
-    '',
-    'Active Connections',
-    '',
-    '  Proto  Local Address          Foreign Address        State           PID',
-    `  TCP    0.0.0.0:${port}            0.0.0.0:0              LISTENING       ${pid}`,
-    '',
-  ].join('\r\n');
-
   it('force-kills the process listening on the target port via taskkill', () => {
     setPlatform('win32');
     const orphanPid = 54321;
     spawnSyncMock.mockImplementation((cmd) => {
-      if (cmd === 'netstat') {
-        return { stdout: netstatOutput(45678, orphanPid) };
+      if (cmd === 'powershell') {
+        return { stdout: `${orphanPid}\r\n` };
       }
       return { stdout: '' };
     });
@@ -649,7 +640,11 @@ describe('killProcessOnPort on Windows', () => {
     const runtime = createRuntime();
     runtime.killProcessOnPort(45678);
 
-    expect(spawnSyncMock).toHaveBeenCalledWith('netstat', ['-ano'], expect.objectContaining({ windowsHide: true }));
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'powershell',
+      expect.arrayContaining([expect.stringContaining('-LocalPort 45678')]),
+      expect.objectContaining({ windowsHide: true })
+    );
     expect(spawnSyncMock).toHaveBeenCalledWith(
       'taskkill',
       ['/PID', String(orphanPid), '/F'],
@@ -660,8 +655,8 @@ describe('killProcessOnPort on Windows', () => {
   it('never force-kills its own process id', () => {
     setPlatform('win32');
     spawnSyncMock.mockImplementation((cmd) => {
-      if (cmd === 'netstat') {
-        return { stdout: netstatOutput(45678, process.pid) };
+      if (cmd === 'powershell') {
+        return { stdout: `${process.pid}\r\n` };
       }
       return { stdout: '' };
     });
@@ -675,8 +670,8 @@ describe('killProcessOnPort on Windows', () => {
   it('does nothing when no process is listening on the target port', () => {
     setPlatform('win32');
     spawnSyncMock.mockImplementation((cmd) => {
-      if (cmd === 'netstat') {
-        return { stdout: netstatOutput(9999, 54321) };
+      if (cmd === 'powershell') {
+        return { stdout: '' };
       }
       return { stdout: '' };
     });

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -2,11 +2,12 @@ import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const spawnMock = vi.fn();
+const spawnSyncMock = vi.fn();
 const recordStartupPerformanceMock = vi.fn();
 
 vi.mock('node:child_process', () => ({
   spawn: spawnMock,
-  spawnSync: vi.fn(),
+  spawnSync: spawnSyncMock,
 }));
 vi.mock('./startup-performance.js', () => ({
   recordStartupPerformance: recordStartupPerformanceMock,
@@ -20,6 +21,7 @@ const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   spawnMock.mockReset();
+  spawnSyncMock.mockReset();
   recordStartupPerformanceMock.mockReset();
   globalThis.fetch = originalFetch;
   if (typeof originalOpencodeBinary === 'string') {
@@ -611,5 +613,77 @@ describe('OpenCode lifecycle', () => {
 
     expect(spawnMock).toHaveBeenCalledTimes(2);
     await server.close();
+  });
+});
+
+describe('killProcessOnPort on Windows', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  const setPlatform = (platform) => {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  };
+
+  const netstatOutput = (port, pid) => [
+    '',
+    'Active Connections',
+    '',
+    '  Proto  Local Address          Foreign Address        State           PID',
+    `  TCP    0.0.0.0:${port}            0.0.0.0:0              LISTENING       ${pid}`,
+    '',
+  ].join('\r\n');
+
+  it('force-kills the process listening on the target port via taskkill', () => {
+    setPlatform('win32');
+    const orphanPid = 54321;
+    spawnSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'netstat') {
+        return { stdout: netstatOutput(45678, orphanPid) };
+      }
+      return { stdout: '' };
+    });
+
+    const runtime = createRuntime();
+    runtime.killProcessOnPort(45678);
+
+    expect(spawnSyncMock).toHaveBeenCalledWith('netstat', ['-ano'], expect.objectContaining({ windowsHide: true }));
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/PID', String(orphanPid), '/F'],
+      expect.objectContaining({ windowsHide: true })
+    );
+  });
+
+  it('never force-kills its own process id', () => {
+    setPlatform('win32');
+    spawnSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'netstat') {
+        return { stdout: netstatOutput(45678, process.pid) };
+      }
+      return { stdout: '' };
+    });
+
+    const runtime = createRuntime();
+    runtime.killProcessOnPort(45678);
+
+    expect(spawnSyncMock).not.toHaveBeenCalledWith('taskkill', expect.anything(), expect.anything());
+  });
+
+  it('does nothing when no process is listening on the target port', () => {
+    setPlatform('win32');
+    spawnSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'netstat') {
+        return { stdout: netstatOutput(9999, 54321) };
+      }
+      return { stdout: '' };
+    });
+
+    const runtime = createRuntime();
+    runtime.killProcessOnPort(45678);
+
+    expect(spawnSyncMock).not.toHaveBeenCalledWith('taskkill', expect.anything(), expect.anything());
   });
 });


### PR DESCRIPTION
## Intent

`killProcessOnPort()` in `packages/web/server/lib/opencode/lifecycle.js` is a no-op on `win32` (POSIX-only, implemented via `lsof`/`kill`). When the managed OpenCode process needs restarting, this means the old process can keep holding the port on Windows, forcing the new instance onto a different allocated port. This is a plausible, concrete contributor to a chronic instability pattern found in real Windows production logs (log excerpts, not aggregate speculation): 9 "OpenCode process exited, restarting" events and over a thousand `ECONNRESET`/proxy errors across 6 separate days over roughly a week, unrelated to any test/dev activity in that window.

## Approach

- Give `killProcessOnPort` a real Windows branch: query `Get-NetTCPConnection -State Listen -LocalPort <port>` for PIDs listening on the target port, filter out our own `process.pid`, then force-kill each match via `taskkill /PID <pid> /F` — no `/T` (kill tree), since we don't own that process and only want the listener itself, not any children it may have.
- `Get-NetTCPConnection` reads the same underlying WinNT API `netstat`'s display layer translates into localized strings — an earlier version of this PR parsed `netstat -ano` output for the literal `LISTENING` state, which only exists on English-language Windows (it renders as `ABHÖREN`/`ÉCOUTE`/`ESCUTANDO` etc. elsewhere), silently making the fix inert for non-English users. Filtering by structured `-State Listen`/`-LocalPort` avoids parsing any locale-dependent text at all.
- Each kill attempt is wrapped in its own try/catch (matching the POSIX loop), so one failure doesn't abort the rest; the whole function is wrapped in an outer try/catch so a missing/failing PowerShell invocation never throws.
- Updated two stale comments (in `lifecycle.js` and a duplicate in `server/index.js`) that specifically called out "Windows killProcessOnPort is a no-op" — now inaccurate, generalized to describe the slow-port-release case on any platform.

## Non-goals

- `waitForPortRelease()`'s existing soft-fail-and-warn behavior is untouched. That's a deliberate, already-tested safety net for *any* platform where a port doesn't free up in time (not Windows-specific), and the restart path already rebinds event-stream readers to the actual resulting port via `onOpenCodeRestarted`. Converting the timeout into a hard error would make restarts fail in more cases (e.g. transient slow socket release) for no clear benefit once the primary kill path works.
- No restart backoff/circuit-breaker added to the health-check loop — the failure pattern is slow chronic recurrence (multiple restarts spread over days), not rapid storms, so there's no evidence motivating that additional complexity.
- No changes to `terminateChildProcess()`'s existing Windows `taskkill` escalation (used for killing the *known* child PID) — that's a separate, already-correct mechanism for a different problem (an unknown orphaned PID squatting on the port after the known child was already terminated).

## Affected surfaces

- **Package**: `packages/web/server` (shared Express/Node server that all runtimes — web, Electron desktop, VS Code webview — load through).
- **Runtime**: Windows only (`process.platform === 'win32'` branch); POSIX behavior is byte-for-byte unchanged.
- **User-visible state**: none directly — this is a background process-lifecycle fix. The observable effect (fewer stuck-on-stale-port restarts) isn't something to screenshot.
- **Persisted/external contracts**: none. No new dependencies, no config schema changes, no API changes.

## Repository guidance

| Source | Why applicable | How this change complies |
|---|---|---|
| `AGENTS.md` | Server-side lifecycle code managing a child process | Platform-specific branch is intentional and isolated to a single function; no secrets, no persisted-data changes; mirrors the existing POSIX branch's error-handling shape rather than inventing a new pattern. |
| `CONTRIBUTING.md` | PR contract and evidence policy | Intent/Non-goals/Affected surfaces/Validation/Risks present; no user-visible UI surface, so no Visual evidence section — this is a server process-management fix with no interactive/visual state to screenshot. |
| `openchamber-change-discipline` (SKILL) | Any source change | Smallest scoped change (one function, two comment fixes); existing behavior preserved (POSIX branch and `waitForPortRelease` untouched); explicit fail-open on missing/failing PowerShell, matching the pre-existing `lsof`-unavailable fallback; focused tests added at the level of real risk. |

## Validation

| Check | Result |
|---|---|
| `bun x vitest run server/lib/opencode/lifecycle.test.js` (from `packages/web`) | Pass — 21/21 tests (18 pre-existing + 3 new: force-kills the listening PID via taskkill, never targets its own PID, no-ops when no process matches the port) |
| `node --check` on both changed `.js` files | Syntax OK |
| `bun run build` (full workspace) | Pass |
| Real port lookup on this Windows machine | Ran `Get-NetTCPConnection -State Listen -LocalPort <port>` against an actual listening port outside the test suite (a live managed OpenCode process) and confirmed the returned PID matched the real owning process exactly |
| Live Windows repro (port genuinely orphaned by an external process, restart triggered, confirm no cross-port limp-along) | Not run — no isolated repro harness readily available; covered instead by the unit tests above, the real-port lookup verification, and code-level reasoning |

## Risks and failure behavior

- If PowerShell is unavailable or `Get-NetTCPConnection` fails for any reason, the function silently no-ops (same fail-open behavior as the POSIX branch when `lsof` is unavailable) — restart falls back to the existing slow-port-release limp-along path, not a regression from today's behavior.
- `taskkill /F` without `/T` could theoretically miss a case where the orphaned listener spawned child processes of its own that also hold resources — considered and rejected in favor of not risking killing unrelated processes we don't own.
- No persisted data, API, or contract changes — this is a server-process-management fix scoped to a single platform branch.
