### PR TITLE
fix(ui): cycle through all thinking variants

### DIFF
--- a/packages/ui/src/stores/useConfigStore.test.ts
+++ b/packages/ui/src/stores/useConfigStore.test.ts
@@ -471,6 +471,22 @@ describe('useConfigStore provider persistence', () => {
     expect(state.directoryScoped[DIRECTORY]?.currentVariant).toBe('high');
   });
 
+  test('cycleCurrentVariant wraps through every model variant', () => {
+    useConfigStore.setState({
+      providers: [provider('openai', 'gpt-5.6-sol', { none: {}, low: {}, medium: {}, high: {}, xhigh: {}, max: {} })],
+      currentProviderId: 'openai',
+      currentModelId: 'gpt-5.6-sol',
+      currentVariant: 'high',
+      directoryScoped: {},
+    });
+
+    const expectedVariants = ['xhigh', 'max', 'none', 'low', 'medium', 'high'];
+    for (const expectedVariant of expectedVariants) {
+      useConfigStore.getState().cycleCurrentVariant();
+      expect(useConfigStore.getState().currentVariant).toBe(expectedVariant);
+    }
+  });
+
   test('setAgent prefers saved and agent variants before settings default', () => {
     const sessionId = 'ses_agent_saved_variant';
     useSessionUIStore.setState({ currentSessionId: sessionId });

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -1878,12 +1878,12 @@ export const useConfigStore = create<ConfigStore>()(
                     }
 
                     const index = variantKeys.indexOf(current);
-                    if (index === -1 || index === variantKeys.length - 1) {
-                        get().setCurrentVariant(undefined);
+                    if (index === -1) {
+                        get().setCurrentVariant(variantKeys[0]);
                         return;
                     }
 
-                    get().setCurrentVariant(variantKeys[index + 1]);
+                    get().setCurrentVariant(variantKeys[(index + 1) % variantKeys.length]);
                 },
  
                 setSelectedProvider: (providerId: string) => {


### PR DESCRIPTION
## Intent

Fix `Cmd/Ctrl+Shift+T` thinking-variant cycling when the selected variant is near the end of the model-provided list. The shortcut now wraps directly from the last explicit variant to the first, so every thinking level remains reachable. For a model exposing `none`, `low`, `medium`, `high`, `xhigh`, and `max`, cycling from `high` proceeds through `xhigh`, `max`, `none`, `low`, and `medium` before returning to `high`.

## Reproduction

1. In OpenChamber settings, choose a model exposing ordered thinking variants such as `none`, `low`, `medium`, `high`, `xhigh`, and `max` (for example, GPT-5.6 Sol).
2. Set the default thinking variant to `high`, then open a draft or session using that model.
3. Press `Cmd+Shift+T` on macOS or `Ctrl+Shift+T` elsewhere repeatedly.
4. Before this fix, observe `high → xhigh → max → high`; `none`, `low`, and `medium` are unreachable.
5. Expected after this fix: `high → xhigh → max → none → low → medium → high`.

The bug appears when the current explicit variant is after the first entries in the model-provided order. Reaching the final variant previously selected the implicit `default`, which could resolve back to a configured mid-list level such as `high`.

## Non-goals

- Change model-provided variant ordering.
- Include the implicit configuration fallback (`default`) in the shortcut cycle.
- Change model-picker selection or default-variant settings behavior.

## Affected surfaces

- `packages/ui`: changes the shared `useConfigStore.cycleCurrentVariant` action and adds regression coverage.
- Web, Desktop, VS Code, and mini-chat surfaces inherit the behavior because their keyboard shortcut handlers call the shared store action.
- Mobile has no affected keyboard interaction.
- No persisted data, network API, runtime bridge, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` | This is shared UI executable source and store behavior. | Kept the change in the owning config store, preserved model-provided ordering, added focused regression coverage, and ran package plus repository-wide validation. |
| `openchamber-change-discipline` skill | The PR modifies executable OpenChamber source. | Uses the smallest behavior change, adds an observable state-transition test, introduces no dependency/export/contract changes, and validates the affected package and workspaces. |
| `packages/ui/src/stores/DOCUMENTATION.md` | The changed action is owned by a shared Zustand store. | Keeps the imperative behavior in the existing owning action and does not broaden subscriptions or store shape. |
| `CONTRIBUTING.md` and PR template | This PR is a reviewer handoff. | Documents intent, non-goals, affected runtimes, validation limits, evidence status, and risk. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/stores/useConfigStore.test.ts` | Passed: 21 tests, 81 assertions. (newly added test was red before fix, green after) |
| `bun run type-check` in `packages/ui` | Passed. |
| `bun run lint` in `packages/ui` | Passed with no warnings or errors. |
| `bun run type-check` at repository root | Passed for all workspaces. |
| `bun run lint` at repository root | Passed for all workspaces. |
| `bun run build` at repository root | Passed; Vite reported only its existing large-chunk advisory. |
| Manual keyboard/runtime verification | See visual evidence below. |

## Visual evidence

**Before**

https://github.com/user-attachments/assets/517eb972-2253-4077-a880-8216e533b25b

**After**

https://github.com/user-attachments/assets/73ee671e-1655-4f0c-8efd-1cf9bc7dbd2f

## Risks and failure behavior

- The behavioral change is limited to the transition after the final explicit variant: it now wraps to the first model-provided variant instead of selecting the implicit default.
- Variant order remains authoritative from the model metadata; the code does not invent or reorder levels.
- No migration, cleanup, rollback, security, or data-loss path is involved. Reverting the commit restores the prior cycle behavior.
- Shared runtimes use the same store action, but the actual keyboard interaction has not yet been manually verified across those runtimes.

