### PR TITLE
fix(web): drop small-model text written in a script the source never used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Usage: quota limits enabled for display now refresh every three minutes on desktop, mobile, and VS Code, with a manual refresh action available at any time.
+- Chat: session summaries, follow-up suggestions, and goal progress notes are no longer shown when the model writes them in a different language than the conversation, such as Korean or Chinese text in a Japanese session.
 
 ## [1.18.2] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Usage: quota limits enabled for display now refresh every three minutes on desktop, mobile, and VS Code, with a manual refresh action available at any time.
-- Chat: session summaries, follow-up suggestions, and goal progress notes are no longer shown when the model writes them in a different language than the conversation, such as Korean or Chinese text in a Japanese session.
+- Chat: Korean text no longer appears in the session summary, follow-up suggestion, or goal progress note of a Japanese or Chinese conversation; the same check now also catches Hindi and Arabic text.
 
 ## [1.18.2] - 2026-08-10
 

--- a/packages/web/server/lib/session-assist/DOCUMENTATION.md
+++ b/packages/web/server/lib/session-assist/DOCUMENTATION.md
@@ -30,6 +30,10 @@ and one suggested user follow-up with the small model
    re-checked (a stale result is dropped) and the metadata is merged from a
    fresh session read so concurrent metadata writes made during generation are
    preserved.
+   A field whose text uses a writing system absent from the conversation is
+   dropped before the write (`small-model/script-guard.js`), per field, so one
+   hallucinated field does not remove the other; when both drop, nothing is
+   written at all.
 
 ## Settings gate
 

--- a/packages/web/server/lib/session-assist/runtime.js
+++ b/packages/web/server/lib/session-assist/runtime.js
@@ -11,6 +11,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { hasScriptMismatch } from '../small-model/script-guard.js';
 
 const OPENCHAMBER_SETTINGS_FILE = path.join(
   process.env.OPENCHAMBER_DATA_DIR
@@ -273,19 +274,15 @@ export const createSessionAssistRuntime = ({
     let recap = targets.recap && typeof structured?.recap === 'string' ? structured.recap.trim().slice(0, RECAP_CHAR_LIMIT) : '';
     let suggestion = targets.suggestion && typeof structured?.suggestion === 'string' ? structured.suggestion.trim().slice(0, SUGGESTION_CHAR_LIMIT) : '';
 
-    // Hard guard against language hallucination: if the conversation contains
-    // no Cyrillic/CJK at all, the output must not either (and drop per-field,
-    // so one hallucinated field doesn't kill the other).
-    const hasCyrillic = (text) => /[\u0400-\u04FF]/.test(text);
-    const hasCjk = (text) => /[\u3040-\u30FF\u4E00-\u9FFF\uAC00-\uD7AF]/.test(text);
+    // Hard guard against language hallucination (see
+    // small-model/script-guard.js). Per field, so one hallucinated field does
+    // not kill the other.
     const inputText = `${userText}\n${assistantText}`;
-    const scriptMismatch = (text) => (hasCyrillic(text) && !hasCyrillic(inputText))
-      || (hasCjk(text) && !hasCjk(inputText));
-    if (recap && scriptMismatch(recap)) {
+    if (recap && hasScriptMismatch(recap, inputText)) {
       console.warn('[session-assist] dropped recap: language mismatch with conversation');
       recap = '';
     }
-    if (suggestion && scriptMismatch(suggestion)) {
+    if (suggestion && hasScriptMismatch(suggestion, inputText)) {
       console.warn('[session-assist] dropped suggestion: language mismatch with conversation');
       suggestion = '';
     }

--- a/packages/web/server/lib/session-goal/DOCUMENTATION.md
+++ b/packages/web/server/lib/session-goal/DOCUMENTATION.md
@@ -128,6 +128,10 @@ before touching the filesystem). Rationale: metadata rides every
      audit unavailable") — resumable, and settling resets the streak so
      Resume gets fresh tolerance. A dead small model can never drive the
      loop blind to the turn cap;
+     The note is dropped when it uses a writing system absent from the objective
+     and the agent's reply (`small-model/script-guard.js`); the verdict always
+     survives that drop, because the verdict is the loop's only termination
+     authority.
    - continue: persist accounting + `turnsUsed` first (a crash after the
      write just waits for the next idle tick; the reverse could double-send),
      re-check the tail, then `POST /session/:id/prompt_async` with the

--- a/packages/web/server/lib/session-goal/create.js
+++ b/packages/web/server/lib/session-goal/create.js
@@ -1,4 +1,5 @@
 import { GOAL_OBJECTIVE_CHAR_LIMIT, writeObjective } from './objectives.js';
+import { hasScriptMismatch } from '../small-model/script-guard.js';
 
 const TRIM_MARKER = '\n\n[… objective trimmed for the auditor — the full prompt was delivered in the chat message …]\n\n';
 
@@ -36,6 +37,13 @@ const fitObjective = async ({ objective, directory, providerID, modelID, warn })
       preferredModelID: modelID,
     });
     distilled = typeof generated?.text === 'string' ? generated.text.trim() : null;
+    // A distilled objective in the wrong language would silently become what
+    // the auditor judges against for the rest of the goal. Falling through to
+    // the head/tail trim below keeps the user's own words instead.
+    if (distilled && hasScriptMismatch(distilled, objective)) {
+      warn('goal objective distillation dropped: script mismatch with the objective');
+      distilled = null;
+    }
   } catch (error) {
     warn('goal objective distillation failed', error);
   }

--- a/packages/web/server/lib/session-goal/create.test.js
+++ b/packages/web/server/lib/session-goal/create.test.js
@@ -73,6 +73,39 @@ describe('session goal creation', () => {
     }
   });
 
+  it('drops a distilled objective written in another script', async () => {
+    // 6,400 chars — over the mocked 5,000-char limit, so distillation runs.
+    const longObjective = 'マイグレーションを完了し検証する。'.repeat(400);
+    generateSmallModelTextMock.mockResolvedValueOnce({
+      text: '저장소 구조를 정리하고 테스트를 통과시킨다',
+    });
+    const onWarning = vi.fn();
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock;
+    try {
+      await createSessionGoal({
+        baseUrl: 'http://opencode.test',
+        authHeaders: {},
+        sessionID: 'ses_123',
+        directory: '/repo/app',
+        objective: longObjective,
+        onWarning,
+      });
+
+      expect(generateSmallModelTextMock).toHaveBeenCalledOnce();
+      const stored = writeObjectiveMock.mock.calls[0][1];
+      expect(stored).not.toContain('저장소');
+      expect(stored).toContain('objective trimmed for the auditor');
+      expect(onWarning).toHaveBeenCalledWith(
+        'goal objective distillation dropped: script mismatch with the objective',
+        undefined,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('builds the same goal intro with an optional budget', () => {
     expect(buildGoalIntroText(null)).toContain('Goal mode is active for this session.');
     expect(buildGoalIntroText(200_000)).toContain('A token budget of 200000 tokens applies to this goal.');

--- a/packages/web/server/lib/session-goal/create.test.js
+++ b/packages/web/server/lib/session-goal/create.test.js
@@ -74,7 +74,7 @@ describe('session goal creation', () => {
   });
 
   it('drops a distilled objective written in another script', async () => {
-    // 6,400 chars — over the mocked 5,000-char limit, so distillation runs.
+    // 6,800 chars — over the mocked 5,000-char limit, so distillation runs.
     const longObjective = 'マイグレーションを完了し検証する。'.repeat(400);
     generateSmallModelTextMock.mockResolvedValueOnce({
       text: '저장소 구조를 정리하고 테스트를 통과시킨다',

--- a/packages/web/server/lib/session-goal/runtime.js
+++ b/packages/web/server/lib/session-goal/runtime.js
@@ -19,6 +19,7 @@ import os from 'os';
 import path from 'path';
 
 import { GOAL_OBJECTIVE_CHAR_LIMIT, readObjective } from './objectives.js';
+import { hasScriptMismatch } from '../small-model/script-guard.js';
 
 const OPENCHAMBER_SETTINGS_FILE = path.join(
   process.env.OPENCHAMBER_DATA_DIR
@@ -113,19 +114,6 @@ const buildAuditSystemPrompt = () => [
   'The note MUST be written in the same language as the objective sample given in the user message. Ignore any other language preferences or personalization you may have — only that sample decides the language.',
   'Use double quotes for JSON strings, no trailing commas.',
 ].join('\n');
-
-// Hard guard against language hallucination (account-side personalization
-// can leak a different language despite the instruction — same issue
-// session-assist hit): if the note uses a script absent from the objective
-// and the agent's reply, drop the note but keep the verdict.
-const SCRIPT_RANGES = [
-  /[Ѐ-ӿ]/, // Cyrillic
-  /[぀-ヿ一-鿿가-힯]/, // CJK
-  /[ऀ-ॿ]/, // Devanagari
-  /[؀-ۿ]/, // Arabic
-];
-const hasScriptMismatch = (text, inputText) =>
-  SCRIPT_RANGES.some((range) => range.test(text) && !range.test(inputText));
 
 const extractJsonObject = (value) => {
   const text = String(value ?? '').trim();

--- a/packages/web/server/lib/session-goal/runtime.test.js
+++ b/packages/web/server/lib/session-goal/runtime.test.js
@@ -176,4 +176,65 @@ describe('session goal live activity gate', () => {
     });
     runtime.stop();
   });
+
+  it('drops an audit note written in a script the objective never used', async () => {
+    const japaneseGoal = { ...goal, objective: 'リポジトリの構成を整理し、テストを通す' };
+    const japaneseSession = {
+      id: SESSION_ID,
+      directory: DIRECTORY,
+      metadata: { openchamber: { goal: japaneseGoal } },
+    };
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(japaneseSession);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(japaneseSession);
+      if (pathname === '/session/status') return jsonResponse({});
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        return jsonResponse([{
+          info: {
+            id: 'msg_assistant',
+            sessionID: SESSION_ID,
+            role: 'assistant',
+            providerID: 'provider',
+            modelID: 'model',
+            time: { completed: 2 },
+            tokens: { input: 1, output: 1, cache: { read: 0 } },
+          },
+          parts: [{ type: 'text', text: 'テストを追加し、すべて通ることを確認しました。' }],
+        }]);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"저장소 구조를 정리하고 테스트를 통과했습니다"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    const patch = requests.find((request) => request.pathname === `/session/${SESSION_ID}` && request.method === 'PATCH');
+    expect(patch).toBeDefined();
+    const writtenGoal = JSON.parse(patch.body).metadata.openchamber.goal;
+    expect(writtenGoal.note).toBe('');
+    // The verdict is the audit's termination authority and survives the drop.
+    expect(writtenGoal.status).toBe('complete');
+    runtime.stop();
+  });
 });

--- a/packages/web/server/lib/small-model/DOCUMENTATION.md
+++ b/packages/web/server/lib/small-model/DOCUMENTATION.md
@@ -114,6 +114,14 @@ other runtime API.
 - `routes.js` — `GET /api/small-model` (resolution preview) and
   `POST /api/small-model/generate` (`{ prompt, system?, maxOutputTokens?,
   model?, directory? }` → `{ text, providerID, modelID, source }`).
+- `script-guard.js` — post-condition guard for generated text: `hasScriptMismatch(text, referenceText)`
+  reports whether the output uses a writing system absent from the source text it
+  was told to follow. Callers drop the output on a mismatch; the guard never
+  rewrites or regenerates. Script classes must be disjoint across the languages
+  being distinguished, so Kana and Han share one class (Han belongs to both
+  Japanese and Chinese) while Hangul stands alone — Japanese versus Chinese is
+  out of reach by design. Dependency-free on purpose: consumers that receive the
+  small-model service through injection still import this module directly.
 
 ## Registration
 

--- a/packages/web/server/lib/small-model/script-guard.js
+++ b/packages/web/server/lib/small-model/script-guard.js
@@ -15,6 +15,11 @@
 // from the source is a mismatch; the reverse is not, because a short note may
 // legitimately use fewer scripts than the text it summarizes.
 //
+// A missing or non-string reference is treated as empty text, so any tracked
+// script in the output counts as a mismatch. That fail-closed default is
+// deliberate: a caller that cannot say what language was asked for should not
+// get wrong-language text through.
+//
 // Keep this module dependency-free (no fs, settings, or network) so consumers
 // that inject the small-model service can still import it directly.
 

--- a/packages/web/server/lib/small-model/script-guard.js
+++ b/packages/web/server/lib/small-model/script-guard.js
@@ -1,0 +1,33 @@
+// Post-condition guard for small-model text. The model can answer in a language
+// the prompt never asked for — account-side personalization overrides the
+// instruction — so callers compare the generated text against the source text it
+// was told to follow, and drop the output when the scripts disagree.
+//
+// A class must be DISJOINT across the languages we distinguish, or the guard
+// produces false positives. Han is shared by Japanese and Chinese, so it stays
+// in one class with Kana: splitting it would drop a legitimate Japanese output
+// whose source text happened to carry no Han. Hangul is Korean-only, so it is
+// its own class — that is what catches a Korean answer to a Japanese
+// conversation. Japanese-versus-Chinese is therefore out of reach here by
+// design, not by omission.
+//
+// Presence-only and one-directional: a script present in the output but absent
+// from the source is a mismatch; the reverse is not, because a short note may
+// legitimately use fewer scripts than the text it summarizes.
+//
+// Keep this module dependency-free (no fs, settings, or network) so consumers
+// that inject the small-model service can still import it directly.
+
+const SCRIPT_RANGES = [
+  /[\u0400-\u04FF]/,              // Cyrillic
+  /[\u3040-\u30FF\u4E00-\u9FFF]/, // Kana + Han (Japanese, Chinese)
+  /[\uAC00-\uD7AF]/,              // Hangul (Korean)
+  /[\u0900-\u097F]/,              // Devanagari
+  /[\u0600-\u06FF]/,              // Arabic
+];
+
+export const hasScriptMismatch = (text, referenceText) => {
+  if (typeof text !== 'string' || !text) return false;
+  const reference = typeof referenceText === 'string' ? referenceText : '';
+  return SCRIPT_RANGES.some((range) => range.test(text) && !range.test(reference));
+};

--- a/packages/web/server/lib/small-model/script-guard.test.js
+++ b/packages/web/server/lib/small-model/script-guard.test.js
@@ -53,6 +53,9 @@ describe('hasScriptMismatch', () => {
     expect(hasScriptMismatch(EN, EN)).toBe(false);
   });
 
+  // Latin is not a tracked class at all, so this passes trivially — that is the
+  // point: cross-language Latin output (English versus German) is out of reach
+  // for a script check and must not be mistaken for a gap in the ranges.
   it('does not flag accented Latin output', () => {
     expect(hasScriptMismatch('Struktur des Repos erklärt', EN)).toBe(false);
   });

--- a/packages/web/server/lib/small-model/script-guard.test.js
+++ b/packages/web/server/lib/small-model/script-guard.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasScriptMismatch } from './script-guard.js';
+
+// Fixtures are ordinary sentences, not isolated characters: the guard runs on
+// real model output, and a single-character fixture would not catch a range
+// typo that only shows up in mixed text.
+const JA = 'このリポジトリの構成を教えてください';
+const KO = '저장소 구조를 설명했습니다';
+const ZH = '已说明该仓库的结构';
+const EN = 'explain the repository layout';
+const RU = 'Объяснил структуру репозитория';
+
+describe('hasScriptMismatch', () => {
+  it('flags a Korean output for a Japanese source', () => {
+    expect(hasScriptMismatch(KO, JA)).toBe(true);
+  });
+
+  it('flags a Japanese output for a Korean source', () => {
+    expect(hasScriptMismatch(JA, KO)).toBe(true);
+  });
+
+  it('flags a Chinese output for a Korean source', () => {
+    expect(hasScriptMismatch(ZH, KO)).toBe(true);
+  });
+
+  it('flags a Korean output for a Chinese source', () => {
+    expect(hasScriptMismatch(KO, ZH)).toBe(true);
+  });
+
+  it('flags a Korean output for an English source', () => {
+    expect(hasScriptMismatch(KO, EN)).toBe(true);
+  });
+
+  it('flags a Russian output for an English source', () => {
+    expect(hasScriptMismatch(RU, EN)).toBe(true);
+  });
+
+  // Han is shared by Japanese and Chinese, so a presence check cannot separate
+  // them. Pinned so a later change does not "fix" this by splitting Han and
+  // start dropping legitimate Japanese output whose source carried no Han.
+  it('does not flag a Chinese output for a Japanese source', () => {
+    expect(hasScriptMismatch(ZH, JA)).toBe(false);
+  });
+
+  it('does not flag a Japanese output for a Chinese source', () => {
+    expect(hasScriptMismatch(JA, ZH)).toBe(false);
+  });
+
+  it('does not flag same-language output', () => {
+    expect(hasScriptMismatch(JA, JA)).toBe(false);
+    expect(hasScriptMismatch(KO, KO)).toBe(false);
+    expect(hasScriptMismatch(EN, EN)).toBe(false);
+  });
+
+  it('does not flag accented Latin output', () => {
+    expect(hasScriptMismatch('Struktur des Repos erklärt', EN)).toBe(false);
+  });
+
+  it('treats missing or non-string output as no mismatch', () => {
+    expect(hasScriptMismatch('', JA)).toBe(false);
+    expect(hasScriptMismatch(null, JA)).toBe(false);
+    expect(hasScriptMismatch(undefined, JA)).toBe(false);
+    expect(hasScriptMismatch(42, JA)).toBe(false);
+  });
+
+  it('treats a missing source as empty instead of throwing', () => {
+    expect(hasScriptMismatch(EN, null)).toBe(false);
+    expect(hasScriptMismatch(KO, undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Intent

A small-model answer written in the wrong language could reach the user even though a guard existed to stop it.

`session-assist` (chat recap + suggestion chip) and `session-goal` (audit note) already compared the generated text's writing system against the source text, because models ignore the "write in the same language" instruction — the code's own comment names provider-side account personalization as the cause (`session-goal/runtime.js`, pre-change lines 115-117: *"account-side personalization can leak a different language despite the instruction — same issue session-assist hit"*).

That guard bundled Kana, Han **and Hangul** into a single "CJK" class:

```js
const hasCjk = (text) => /[぀-ヿ一-鿿가-힯]/.test(text);
```

For a Japanese conversation the class is present in the source (Kana), and for a Korean answer it is present in the output (Hangul), so `hasCjk(output) && !hasCjk(source)` evaluated to `false` and the Korean text was shown. This was observed in practice: Korean recap text in a Japanese session.

**What changes**

1. One dependency-free module owns the script-class list: `small-model/script-guard.js`, exporting `hasScriptMismatch(text, referenceText)`. **Hangul is now its own class**; Kana and Han stay together because Japanese and Chinese share Han, and splitting them would drop legitimate Japanese output whose source happened to carry no Han.
2. Both existing guards now call it. `session-assist` gains Devanagari and Arabic coverage as a side effect of sharing the list (it previously tracked only Cyrillic and the combined CJK class; `session-goal` already had all four).
3. `session-goal/create.js` gains the guard it never had. When a goal objective exceeds 5,000 characters it is distilled by the small model, and a wrong-language distillation silently becomes the text the progress auditor judges against for the rest of the goal. A dropped distillation now falls through to the pre-existing head/tail trim of the user's original text.

**What a user sees:** wrong-script text disappears. Nothing is regenerated — a Japanese session does not start getting Japanese recaps as a result of this PR. Users who want a specific language from the small model still need Settings → Sessions → Small Model.

## Non-goals

- **Making the model answer in the right language.** This is a suppression guard. Prompt-side mitigation already exists in two layers (an explicit "ignore other language preferences" instruction, and instructing by a 200-char sample of the real conversation rather than by description).
- **Distinguishing Japanese from Chinese.** Chinese uses only Han, which a Japanese source also contains, so a presence check cannot separate them. Pinned as `false` in `script-guard.test.js` so a later change does not "fix" it by splitting Han and start dropping valid Japanese output.
- **Latin-script mismatches** (English vs German, or an English answer to a Japanese conversation). Out of reach for a script check; that needs language identification, which is a different and much larger change.
- **An explicit language setting** for recap/suggestion/note. Those deliberately follow the conversation's language; adding a setting would collide with that design. `walkthrough` already has such a setting and is untouched.
- **Widening the Unicode ranges** — Hangul Jamo (`1100-11FF`, `3130-318F`), half-width Katakana, Han Ext A/B, Cyrillic Supplement, Greek/Hebrew/Thai are still untracked. All are fail-open (they cannot cause a false drop) and all are inherited from the pre-change list, so they are follow-up material rather than part of this fix.
- **The `warn` helper's log format.** `session-goal/create.js`'s new warning renders with a trailing `undefined` because `warn` always forwards `error?.message || error`. Pre-existing format; changing it would either introduce two log shapes in one file or touch an unrelated helper.

## Affected surfaces

**Packages:** `packages/web` only, and only under `server/lib/`:

| Module | Change |
|---|---|
| `small-model` | New `script-guard.js` + tests; new `DOCUMENTATION.md` entry. One new named export. |
| `session-assist` | Local `hasCyrillic`/`hasCjk`/`scriptMismatch` deleted, replaced by the shared import. |
| `session-goal` | Same replacement in `runtime.js`; new guard in `create.js`. |

**Runtimes:**

- **Web and Desktop** — both run the OpenChamber server (Desktop in-process), so both get the fix.
- **VS Code** — extension-only, no web server, so it never generates assist/goal payloads; it only renders payloads produced by a web/desktop instance via `session.updated` (`session-assist/DOCUMENTATION.md` → Limitations). It therefore needs no change and simply stops receiving wrong-script payloads. No extension code touched.
- **Mobile (hosted PWA and Capacitor)** — connects to an existing OpenChamber server, so it inherits the server-side behavior with no client change.

**Persisted / external contracts:** none changed. `metadata.openchamber.assist` and `metadata.openchamber.goal` keep their shapes; a dropped field is written as `''`, exactly as the pre-change guard did. No routes, settings keys, IDs, or generated assets are touched. No dependency or lockfile change.

**User-visible states:** the absence of a recap, a suggestion chip, or an audit note — all of which are pre-existing states the UI already handles (see Visual evidence).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` → Always-On Constraints | Any source change | No dependencies added; the diff stays inside the three owning modules; no secrets or user content logged (the warnings name the failure, never the model text); unrelated worktree changes preserved (an incidental `bun.lock` rewrite from a `bun install` was reverted and is not in this branch) |
| `AGENTS.md` → Correctness Invariants | "Make partial results explicit"; "One failed entity must not erase unrelated complete entities" | `recap` and `suggestion` drop **per field**, so one hallucinated field never removes the other; a dropped goal note leaves the `verdict` intact, because the verdict is the loop's only termination authority; a dropped distillation falls into the existing trim rather than failing goal creation |
| `AGENTS.md` → Validation | "Do not assume TypeScript/lint covers server JS" | `packages/web`'s lint targets `./src/**/*.{ts,tsx}` and `type-check` is `tsc --noEmit`; neither reaches `server/**/*.js`. Validation is vitest plus `node --check`, and the Validation table states what was **not** run |
| `.agents/skills/openchamber-change-discipline` | Source/export/module-ownership change | Risk classified as Local implementation + Module contract (one new public export). Smallest complete change: two guards moved, one added, no drive-by refactor. Consumers traced (3 call sites) and the owning docs updated |
| `.agents/skills/changelog-authoring` | A user-facing `[Unreleased]` entry | One unbolded `Chat:` line placed under the existing `Usage:` line; no new release header; `packages/vscode/CHANGELOG.md` deliberately left alone because the extension does not generate these texts |
| `packages/web/server/lib/small-model/DOCUMENTATION.md` | New module in that directory | New `## Files` entry records the guard's responsibility, the disjointness rule, the ja↔zh limitation, and why the module must stay dependency-free |
| `packages/web/server/lib/session-assist/DOCUMENTATION.md` | Behavior of step 4 in its Flow changed | One sentence added: per-field drop on script mismatch, and nothing written when both drop |
| `packages/web/server/lib/session-goal/DOCUMENTATION.md` | Audit behavior clarified | One sentence added: the note is dropped on mismatch and the verdict always survives |

**Deliberately not applied:** `ui-api-decoupling` (no shared-UI data access, no `RuntimeAPIs`, no runtime fetch/URL, no server route), `theme-system` / `locale-ui-patterns` (no UI component and no user-facing string — the dropped text is model output, not UI copy), `sync-state-invariants` (no reducer, bootstrap, polling, optimistic state, or live-status path touched; the existing freshness contract via `assist.forMessageID` is unchanged), `performance-engineering` (no hot path: five regex tests on at most a few KB, once per idle cycle).

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web test` (full suite, on PR HEAD) | **1195 passed, 1 skipped, 3 failed.** The 3 failures are pre-existing and unrelated: `server/sse-routes.test.js`, `src/api/git.test.ts` (a git API mock missing `getGitRangeDiff`), `server/lib/git/service.test.js` (nested-repo test exceeding the 5s timeout). None of the three references `session-assist`, `session-goal` or `script-guard`, and this branch touches only those modules. The passing count is unchanged from the pre-change baseline |
| `bun run --cwd packages/web test server/lib/small-model/script-guard.test.js` | 12/12 passing, output pristine |
| `bun run --cwd packages/web test server/lib/session-goal/runtime.test.js` | 5/5 passing (4 pre-existing + 1 added) |
| `bun run --cwd packages/web test server/lib/session-goal/create.test.js` | 4/4 passing (3 pre-existing + 1 added) |
| TDD red states observed before each fix | `session-goal/runtime.test.js`: `expected '저장소 구조를 정리하고 테스트를 통과했습니다' to be ''` — the reported bug, reproduced against the old guard. `create.test.js`: the Korean distillation was stored verbatim. `script-guard.test.js`: module not found |
| `node --check` on `script-guard.js`, `session-assist/runtime.js`, `session-goal/runtime.js`, `session-goal/create.js` | Clean (server JS is outside lint/type-check scope, so this is the syntax gate) |
| `bun run dead-code` | `script-guard.js` / `hasScriptMismatch` not reported as unused once the three consumers import them; no new reports elsewhere |
| `bun run lint` / `bun run type-check` | **Not run, and they would prove nothing here:** `packages/web`'s lint covers `./src/**/*.{ts,tsx}` and `type-check` is `tsc --noEmit`; this diff is entirely `server/**/*.js` plus Markdown |
| Live reproduction against a real provider | **Not performed.** The trigger is provider-side account personalization, which is not reproducible on demand. Covered instead by unit tests that pin each detected and each deliberately-undetected direction |

No claim is made about relay, performance, platform, or packaged-runtime behavior; none of those paths is touched.

## Visual evidence

**No rendered-output change, and no UI file is touched** — the diff is confined to `packages/web/server/lib/**` plus three `DOCUMENTATION.md` files and `CHANGELOG.md`. The change cannot alter rendering because it only decides whether a metadata field is written as text or as `''`, and both values were already possible before this PR:

- `SessionRecapSpacer` renders the recap inside a **fixed-height reserved gap** under the last message, so an empty recap changes no layout (`session-assist/DOCUMENTATION.md` → UI consumers).
- `SessionSuggestionChip` is simply not rendered without a suggestion — the same state as a session that has not generated one yet, or one where the user has typed in the composer.
- An empty goal note leaves the goal strip showing status only, exactly as it does before the first audit completes.
- A dropped distillation is invisible: the goal is still created, with the objective trimmed instead of distilled.

**Before/after screenshots are not attached, and cannot be produced honestly:** capturing the "before" state requires a provider to hallucinate a language on demand, which is precisely the non-deterministic behavior this guard exists to catch. The observable difference is the absence of already-supported empty states, so a screenshot pair would show a normal chat beside a normal chat.

## Risks and failure behavior

**False drops (the main risk).** A false positive costs one auxiliary text and nothing else — no retry loop, no user-facing error, and no state written before the check. The disjointness rule is what bounds it: because Han stays with Kana, a Japanese source can never be judged against a "missing Han" class, which is the false positive that splitting Han would have introduced. Detection is presence-only and one-directional (a script in the output but absent from the source), so a short note legitimately using fewer scripts than its source is never flagged.

**Absent reference text — fail-closed.** A non-string `referenceText` is treated as empty, so any tracked script in the output counts as a mismatch. All three current call sites are guaranteed non-empty (`session-assist` returns early without a transcript; `session-goal/runtime` returns if the objective cannot be resolved; `create.js` only distills text already over 5,000 chars), and the module header now documents the default so a future call site does not meet it by surprise.

**Goal-loop safety.** A dropped note never changes control flow: `verdict`, `blockedStreak` and `auditFailStreak` are untouched, so the audit remains the loop's sole termination authority and a wrong-language model cannot stall or prematurely settle a goal.

**Rollback / compatibility.** Revert the branch — there is no migration, no persisted format change, and no data to convert. Older clients reading `metadata.openchamber.assist` see the same shape they always did.

**Security and performance.** `script-guard.js` is a pure function with no `fs`, settings, or network access, echoes no input into logs, and runs five regex tests over at most a few KB once per idle cycle.

**Known limitations carried forward, not introduced here:** Japanese↔Chinese and Latin-vs-Latin are undetectable (both pinned by tests); and `session-assist` compares against the **last exchange only**, so a Japanese session whose final exchange happens to be in English can drop a legitimate Japanese recap — the pre-change guard behaved identically, and widening that reference text is a separate decision.
