### PR TITLE
fix(quota): export OpenCode Go quota helper

### DIFF
--- a/packages/web/server/lib/quota/index.js
+++ b/packages/web/server/lib/quota/index.js
@@ -24,5 +24,6 @@ export {
   fetchMinimaxCnCodingPlanQuota,
   fetchOllamaCloudQuota,
   fetchZhipuaiQuota,
-  fetchWaferQuota
+  fetchWaferQuota,
+  fetchOpenCodeGoQuota
 } from './providers/index.js';

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -224,4 +224,5 @@ export const fetchMinimaxCodingPlanQuota = minimaxCodingPlan.fetchQuota;
 export const fetchMinimaxCnCodingPlanQuota = minimaxCnCodingPlan.fetchQuota;
 export const fetchOllamaCloudQuota = ollamaCloud.fetchQuota;
 export const fetchWaferQuota = wafer.fetchQuota;
+export const fetchOpenCodeGoQuota = opencodeGo.fetchQuota;
 export const fetchZhipuaiQuota = zhipuaiCodingPlan.fetchQuota;

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -210,4 +210,5 @@ export const fetchMinimaxCodingPlanQuota = minimaxCodingPlan.fetchQuota;
 export const fetchMinimaxCnCodingPlanQuota = minimaxCnCodingPlan.fetchQuota;
 export const fetchOllamaCloudQuota = ollamaCloud.fetchQuota;
 export const fetchWaferQuota = wafer.fetchQuota;
+export const fetchOpenCodeGoQuota = opencodeGo.fetchQuota;
 export const fetchZhipuaiQuota = zhipuaiCodingPlan.fetchQuota;

--- a/packages/web/server/lib/quota/providers/index.test.js
+++ b/packages/web/server/lib/quota/providers/index.test.js
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import * as google from './google/index.js';
-import { fetchQuotaForProvider, listConfiguredQuotaProviders } from './index.js';
+import {
+  fetchOpenCodeGoQuota,
+  fetchQuotaForProvider,
+  listConfiguredQuotaProviders
+} from './index.js';
 
 describe('quota provider registry', () => {
   it('exposes google provider configuration helpers through the provider module', () => {
@@ -22,5 +26,9 @@ describe('quota provider registry', () => {
     expect(first).toBe(second);
     await first;
     expect(fetchQuotaForProvider('unsupported-test-provider')).not.toBe(first);
+  });
+
+  it('exports the OpenCode Go quota helper', () => {
+    expect(typeof fetchOpenCodeGoQuota).toBe('function');
   });
 });

--- a/packages/web/server/lib/quota/providers/index.test.js
+++ b/packages/web/server/lib/quota/providers/index.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import * as google from './google/index.js';
-import { listConfiguredQuotaProviders } from './index.js';
+import { fetchOpenCodeGoQuota, listConfiguredQuotaProviders } from './index.js';
 
 describe('quota provider registry', () => {
   it('exposes google provider configuration helpers through the provider module', () => {
@@ -13,5 +13,9 @@ describe('quota provider registry', () => {
 
   it('can list configured providers without missing provider exports', () => {
     expect(() => listConfiguredQuotaProviders()).not.toThrow();
+  });
+
+  it('exports the OpenCode Go quota helper', () => {
+    expect(typeof fetchOpenCodeGoQuota).toBe('function');
   });
 });


### PR DESCRIPTION
## Intent

Export the existing OpenCode Go quota fetcher through both quota module indexes. The provider is already registered and dispatchable as `opencode-go`, but the fetch helper was missing from the named exports used by direct consumers.

## Non-goals

This does not change provider behavior, routing, credentials, UI, persistence, or any other quota provider.

## Affected surfaces

- `packages/web/server/lib/quota/providers/index.js`
- `packages/web/server/lib/quota/index.js`
- `packages/web/server/lib/quota/providers/index.test.js`

The runtime dispatcher and provider registry are unchanged. This only restores the export contract for an existing provider.

## Rebase note

This branch has been rebased onto `main` and now merges cleanly. The only conflict was in `packages/web/server/lib/quota/providers/index.test.js`, where both sides were additive: `main` added the `coalesces concurrent refreshes by provider ID` test importing `fetchQuotaForProvider`, and this branch added the `exports the OpenCode Go quota helper` test importing `fetchOpenCodeGoQuota`. The shared import statement was the collision point. Both imports and both tests are retained. The other two files auto-merged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | This is an OpenChamber source and export change. | The diff is minimal, adds no dependency, preserves the existing dispatcher, and changes only the owning quota modules plus a focused test. |
| `.agents/skills/openchamber-change-discipline/SKILL.md` | The change modifies a documented module contract and named exports. | The provider implementation and callers were inspected, the existing behavior is preserved, the named export contract has a regression assertion, and dead-code validation was run. |
| `packages/web/README.md` | The changed module belongs to the web package. | Web package type-check, lint, and the repository build all pass. |
| `packages/web/server/lib/quota/DOCUMENTATION.md` | It documents the quota entrypoints and explicitly permits named fetcher exports for direct use. | The existing `opencode-go` provider entry and response contract remain unchanged; this restores the documented export path. |
| `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` | They define the pull request contract and required evidence. | This PR documents intent, non-goals, affected surfaces, applicable guidance, exact validation results, visual scope, risks, and rollback. |
| Additional runtime skills | No UI, SDK bridge, runtime switching, persistence, relay, desktop, mobile, or platform behavior changes are included. | No additional runtime-specific skill applies to this server-only export. |

## Validation

Validation below was re-run against the rebased PR HEAD `162bfa98b`, on top of `main` at `85a95bb8`.

| Check | Result |
|---|---|
| `bun test packages/web/server/lib/quota/providers/index.test.js` | Pass, 4 tests and 8 expectations |
| `bun run type-check:web` | Pass |
| `bun run lint:web` | Pass |
| `bun run dead-code` | Exit 0; reports the repository's existing unused-export inventory, including the other direct quota helpers |
| `bun run type-check` | Pass, all five packages exit 0 |
| `bun run lint` | Pass, all five packages exit 0 |
| `bun run build` | Pass; emits existing unresolved KaTeX font and large-chunk warnings |
| `git diff --check` | Pass |

The broader `packages/web/server/lib/quota` suite was also run, with a baseline comparison:

| Revision | Result |
|---|---|
| `main` at `85a95bb8`, unmodified | 29 pass, 59 fail, 88 tests |
| This branch at `162bfa98b` | 30 pass, 59 fail, 89 tests |

The 59 failures are pre-existing and identical on both revisions. They occur because those tests use `vi.stubGlobal`, `vi.unstubAllGlobals`, and `vi.doMock`, which are unavailable in this checkout's Bun test runtime. This branch adds exactly one passing test and introduces no new failures.

## Visual evidence

Not applicable. This is a server-only module export and test change with no rendered UI changes.

## Risks and rollback

No existing runtime path changes. The only new behavior is that callers can import `fetchOpenCodeGoQuota` from the quota modules. Rollback is a one-commit revert. No secrets, persistence, or API wire shape changes are involved.
