### PR TITLE
Remove the 5-model limit on multi-run groups

### DIFF
--- a/packages/ui/src/components/multirun/MultiRunLauncher.tsx
+++ b/packages/ui/src/components/multirun/MultiRunLauncher.tsx
@@ -32,7 +32,6 @@ import { startDesktopWindowDrag } from '@/lib/desktopNative';
 import { useI18n } from '@/lib/i18n';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
-const MAX_MODELS_PER_GROUP = 5;
 
 interface MultiRunAttachedFile {
   id: string;
@@ -727,7 +726,6 @@ const RunGroupCard: React.FC<RunGroupCardProps> = ({
   const snippetRef = React.useRef<SnippetAutocompleteHandle>(null);
 
   const handleAddModel = React.useCallback((model: ModelSelectionWithId) => {
-    if (group.models.length >= MAX_MODELS_PER_GROUP) return;
     onUpdate(group.id, { models: [...group.models, model] });
   }, [group.id, group.models, onUpdate]);
 
@@ -987,7 +985,7 @@ const RunGroupCard: React.FC<RunGroupCardProps> = ({
       <div className="flex flex-col gap-1.5">
         <FieldLabel
           required
-          info={<InfoTip>{t('multirun.launcher.models.info', { max: MAX_MODELS_PER_GROUP })}</InfoTip>}
+          info={<InfoTip>{t('multirun.launcher.models.info')}</InfoTip>}
         >
           {t('multirun.launcher.models.label')}
         </FieldLabel>
@@ -997,7 +995,6 @@ const RunGroupCard: React.FC<RunGroupCardProps> = ({
           onRemove={handleRemoveModel}
           onUpdate={handleUpdateModel}
           minModels={1}
-          maxModels={MAX_MODELS_PER_GROUP}
         />
       </div>
     </div>

--- a/packages/ui/src/components/views/agent-manager/AgentManagerEmptyState.tsx
+++ b/packages/ui/src/components/views/agent-manager/AgentManagerEmptyState.tsx
@@ -22,8 +22,6 @@ import { useI18n } from '@/lib/i18n';
 
 /** Max file size in bytes (10MB) */
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
-/** Max number of concurrent runs */
-const MAX_MODELS = 5;
 
 /** Attached file for agent manager */
 interface AttachedFile {
@@ -132,11 +130,8 @@ export const AgentManagerEmptyState: React.FC<AgentManagerEmptyStateProps> = ({
   }, [projectRef]);
 
   const handleAddModel = React.useCallback((model: ModelSelectionWithId) => {
-    if (selectedModels.length >= MAX_MODELS) {
-      return;
-    }
     setSelectedModels((prev) => [...prev, model]);
-  }, [selectedModels.length]);
+  }, []);
 
   const handleRemoveModel = React.useCallback((index: number) => {
     setSelectedModels((prev) => prev.filter((_, i) => i !== index));
@@ -529,7 +524,6 @@ export const AgentManagerEmptyState: React.FC<AgentManagerEmptyStateProps> = ({
             onUpdate={handleUpdateModel}
             minModels={1}
             addButtonLabel={t('agentManager.empty.models.addModel')}
-            maxModels={5}
           />
         </div>
 

--- a/packages/ui/src/lib/i18n/messages/de.ts
+++ b/packages/ui/src/lib/i18n/messages/de.ts
@@ -347,7 +347,7 @@ export const dict = {
   'multirun.launcher.attachments.attach': 'Anhängen',
   'multirun.launcher.attachments.tooltip': 'Denselben Dateien an alle Durchläufe senden',
   'multirun.launcher.models.label': 'Modelle',
-  'multirun.launcher.models.info': 'Wählen Sie 2-{max} Modelle. Das gleiche Modell kann mehrfach hinzugefügt werden.',
+  'multirun.launcher.models.info': 'Wählen Sie 2 oder mehr Modelle. Das gleiche Modell kann mehrfach hinzugefügt werden.',
   'multirun.launcher.toast.fileTooLarge': 'Datei "{fileName}" ist zu groß (max. 10MB)',
   'multirun.launcher.toast.attachFailed': 'Fehler beim Anhängen von "{fileName}"',
   'multirun.launcher.toast.attachedSingle': '{count} Datei angehängt',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -369,7 +369,7 @@ export const dict = {
   'multirun.launcher.attachments.attach': 'Attach',
   'multirun.launcher.attachments.tooltip': 'Same files sent to all runs',
   'multirun.launcher.models.label': 'Models',
-  'multirun.launcher.models.info': 'Select 2-{max} models. Same model can be added multiple times.',
+  'multirun.launcher.models.info': 'Select 2 or more models. Same model can be added multiple times.',
   'multirun.launcher.toast.fileTooLarge': 'File "{fileName}" is too large (max 10MB)',
   'multirun.launcher.toast.attachFailed': 'Failed to attach "{fileName}"',
   'multirun.launcher.toast.attachedSingle': 'Attached {count} file',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -370,7 +370,7 @@ export const dict: Record<I18nKey, string> = {
   "multirun.launcher.attachments.attach": "Adjuntar",
   "multirun.launcher.attachments.tooltip": "Archivos idénticos enviados a todas las ejecuciones",
   "multirun.launcher.models.label": "Modelos",
-  "multirun.launcher.models.info": "Selecciona 2-{max} modelos. El mismo modelo puede añadirse varias veces.",
+  "multirun.launcher.models.info": "Selecciona 2 o más modelos. El mismo modelo puede añadirse varias veces.",
   "multirun.launcher.toast.fileTooLarge": "El archivo \"{fileName}\" es demasiado grande (máximo 10MB)",
   "multirun.launcher.toast.attachFailed": "No se pudo adjuntar \"{fileName}\"",
   "multirun.launcher.toast.attachedSingle": "Archivo adjuntado ({count})",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -201,7 +201,7 @@ export const dict = {
   'multirun.launcher.attachments.attach': 'Attacher',
   'multirun.launcher.attachments.tooltip': 'Mêmes fichiers envoyés à toutes les exécutions',
   'multirun.launcher.models.label': 'Modèles',
-  'multirun.launcher.models.info': 'Sélectionnez les modèles 2-{max}. Le même modèle peut être ajouté plusieurs fois.',
+  'multirun.launcher.models.info': 'Sélectionnez 2 modèles ou plus. Le même modèle peut être ajouté plusieurs fois.',
   'multirun.launcher.toast.fileTooLarge': 'Le fichier "{fileName}" est trop volumineux (max 10 Mo)',
   'multirun.launcher.toast.attachFailed': 'Échec de la connexion de "{fileName}"',
   'multirun.launcher.toast.attachedSingle': 'Fichier {count} joint',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -370,7 +370,7 @@ export const dict: Record<I18nKey, string> = {
   'multirun.launcher.attachments.attach': '添付',
   'multirun.launcher.attachments.tooltip': '同じファイルをすべての実行に送信',
   'multirun.launcher.models.label': 'モデル',
-  'multirun.launcher.models.info': '2～{max}モデルを選択。同じモデルを複数回追加できます。',
+  'multirun.launcher.models.info': '2つ以上のモデルを選択。同じモデルを複数回追加できます。',
   'multirun.launcher.toast.fileTooLarge': 'ファイル「{fileName}」が大きすぎます（最大10MB）',
   'multirun.launcher.toast.attachFailed': '「{fileName}」の添付に失敗しました',
   'multirun.launcher.toast.attachedSingle': '{count}ファイルを添付しました',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -370,7 +370,7 @@ export const dict: Record<I18nKey, string> = {
   'multirun.launcher.attachments.attach': '첨부',
   'multirun.launcher.attachments.tooltip': '같은 파일을 모든 실행에 보냅니다',
   'multirun.launcher.models.label': '모델',
-  'multirun.launcher.models.info': '모델을 2~{max}개 선택하세요. 같은 모델을 여러 번 추가할 수 있습니다.',
+  'multirun.launcher.models.info': '모델을 2개 이상 선택하세요. 같은 모델을 여러 번 추가할 수 있습니다.',
   'multirun.launcher.toast.fileTooLarge': '파일 "{fileName}"이 너무 큽니다(최대 10MB)',
   'multirun.launcher.toast.attachFailed': '"{fileName}" 첨부 실패',
   'multirun.launcher.toast.attachedSingle': '파일 {count}개 첨부됨',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -497,7 +497,7 @@ export const dict: Record<I18nKey, string> = {
   'multirun.launcher.attachments.attach': 'Dołącz',
   'multirun.launcher.attachments.tooltip': 'Te same pliki wysłane do wszystkich uruchomień',
   'multirun.launcher.models.label': 'Modele',
-  'multirun.launcher.models.info': 'Wybierz od 2 do {max} modeli. Ten sam model może być dodany wielokrotnie.',
+  'multirun.launcher.models.info': 'Wybierz 2 lub więcej modeli. Ten sam model może być dodany wielokrotnie.',
   'multirun.launcher.toast.fileTooLarge': 'Plik "{fileName}" jest zbyt duży (max 10MB)',
   'multirun.launcher.toast.attachFailed': 'Nie udało się dołączyć "{fileName}"',
   'multirun.launcher.toast.attachedSingle': 'Dołączono {count} plik',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -370,7 +370,7 @@ export const dict: Record<I18nKey, string> = {
   "multirun.launcher.attachments.attach": "Anexar",
   "multirun.launcher.attachments.tooltip": "Arquivos idênticos enviados a todas as execuções",
   "multirun.launcher.models.label": "Modelos",
-  "multirun.launcher.models.info": "Selecione 2-{max} modelos. O mesmo modelo pode ser adicionado várias vezes.",
+  "multirun.launcher.models.info": "Selecione 2 ou mais modelos. O mesmo modelo pode ser adicionado várias vezes.",
   "multirun.launcher.toast.fileTooLarge": "O arquivo \"{fileName}\" é grande demais (máximo 10MB)",
   "multirun.launcher.toast.attachFailed": "Não foi possível anexar \"{fileName}\"",
   "multirun.launcher.toast.attachedSingle": "Arquivo anexado ({count})",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -370,7 +370,7 @@ export const dict: Record<I18nKey, string> = {
   "multirun.launcher.attachments.attach": "Прикріпити",
   "multirun.launcher.attachments.tooltip": "Ті самі файли буде надіслано в усі запуски",
   "multirun.launcher.models.label": "Моделі",
-  "multirun.launcher.models.info": "Вибрати моделі 2-{max}. Ту саму модель можна додавати кілька разів.",
+  "multirun.launcher.models.info": "Вибрати 2 або більше моделей. Ту саму модель можна додавати кілька разів.",
   "multirun.launcher.toast.fileTooLarge": "Файл \"{fileName}\" завеликий (макс. 10 МБ)",
   "multirun.launcher.toast.attachFailed": "Не вдалося вкласти \"{fileName}\"",
   "multirun.launcher.toast.attachedSingle": "Прикріплено файл: {count}",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -370,7 +370,7 @@ export const dict: Record<I18nKey, string> = {
   'multirun.launcher.attachments.attach': '附加',
   'multirun.launcher.attachments.tooltip': '相同文件会发送到所有运行',
   'multirun.launcher.models.label': '模型',
-  'multirun.launcher.models.info': '选择 2-{max} 个模型。同一模型可重复添加。',
+  'multirun.launcher.models.info': '选择 2 个或更多模型。同一模型可重复添加。',
   'multirun.launcher.toast.fileTooLarge': '文件“{fileName}”过大（最大 10MB）',
   'multirun.launcher.toast.attachFailed': '附加“{fileName}”失败',
   'multirun.launcher.toast.attachedSingle': '已附加 {count} 个文件',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -383,7 +383,7 @@ export const dict: Record<I18nKey, string> = {
   'multirun.launcher.attachments.attach': '附加',
   'multirun.launcher.attachments.tooltip': '相同檔案會傳送到所有執行',
   'multirun.launcher.models.label': '模型',
-  'multirun.launcher.models.info': '選擇 2-{max} 個模型。同一模型可重複加入。',
+  'multirun.launcher.models.info': '選擇 2 個或更多模型。同一模型可重複加入。',
   'multirun.launcher.toast.fileTooLarge': '檔案「{fileName}」過大（最大 10MB）',
   'multirun.launcher.toast.attachFailed': '附加「{fileName}」失敗',
   'multirun.launcher.toast.attachedSingle': '已附加 {count} 個檔案',

--- a/packages/ui/src/stores/useMultiRunStore.test.ts
+++ b/packages/ui/src/stores/useMultiRunStore.test.ts
@@ -226,4 +226,20 @@ describe('useMultiRunStore', () => {
       'createSession:/repo-worktrees/fix-thing',
     ]);
   });
+
+  test('accepts more than 5 models per group without a "maximum 5 models" error', async () => {
+    const models = Array.from({ length: 6 }, (_, i) => ({
+      providerID: 'anthropic',
+      modelID: `claude-sonnet-4-5-${i}`,
+    }));
+
+    const result = await useMultiRunStore.getState().createMultiRun({
+      name: 'Many models',
+      isolateRuns: false,
+      groups: [{ prompt: 'Fix it', models }],
+    });
+
+    expect(useMultiRunStore.getState().error).toBeNull();
+    expect(result?.sessionIds).toHaveLength(6);
+  });
 });

--- a/packages/ui/src/stores/useMultiRunStore.test.ts
+++ b/packages/ui/src/stores/useMultiRunStore.test.ts
@@ -242,4 +242,23 @@ describe('useMultiRunStore', () => {
     expect(useMultiRunStore.getState().error).toBeNull();
     expect(result?.sessionIds).toHaveLength(6);
   });
+
+  test('accepts more than 5 models on the isolated (per-worktree) dispatch path', async () => {
+    isGitRepository = true;
+
+    const models = Array.from({ length: 6 }, (_, i) => ({
+      providerID: 'anthropic',
+      modelID: `claude-sonnet-4-5-${i}`,
+    }));
+
+    const result = await useMultiRunStore.getState().createMultiRun({
+      name: 'Many models',
+      isolateRuns: true,
+      groups: [{ prompt: 'Fix it', models }],
+    });
+
+    expect(useMultiRunStore.getState().error).toBeNull();
+    expect(result?.sessionIds).toHaveLength(6);
+    expect(worktreeCreateCalls.length).toBe(6);
+  });
 });

--- a/packages/ui/src/stores/useMultiRunStore.ts
+++ b/packages/ui/src/stores/useMultiRunStore.ts
@@ -138,10 +138,6 @@ export const useMultiRunStore = create<MultiRunStore>()(
             set({ error: `Group ${gi + 1}: select at least 1 model` });
             return null;
           }
-          if (groups[gi].models.length > 5) {
-            set({ error: `Group ${gi + 1}: maximum 5 models allowed` });
-            return null;
-          }
         }
 
         set({ isLoading: true, error: null });


### PR DESCRIPTION
## Intent

Removes the arbitrary 5-model-per-group cap from multi-run. The cap was enforced in three client-side locations with no server-side constraint and no technical justification (the store iterates models in a plain loop and dispatches each run independently via `Promise.allSettled`), so users can now choose how many models to run.

Changes:
- `MultiRunLauncher.tsx` — dropped the `MAX_MODELS_PER_GROUP` constant, the `handleAddModel` early-return guard, and the `maxModels` prop; the info tooltip no longer interpolates `{max}`.
- `useMultiRunStore.ts` — removed the `models.length > 5` validation block (the `"maximum 5 models allowed"` error).
- `AgentManagerEmptyState.tsx` — dropped the `MAX_MODELS` constant, the `handleAddModel` guard, and `maxModels={5}`.
- `multirun.launcher.models.info` copy rewritten across all 11 shipped locale dictionaries (en, es, fr, ko, pl, pt-BR, uk, zh-CN, zh-TW, de, ja) to drop the `{max}` ceiling; `ModelMultiSelect` now falls back to its `minOnly` validation hint for these surfaces.
- Added store tests for a 6-model group on both the non-isolated and the isolated (per-worktree) dispatch paths.

## Non-goals

- Not changing `MultiRunFusionDialog`'s `maxModels={1}` single-select behavior (legitimate, unrelated).
- Not adding a server-side or configurable limit; the cap is removed entirely per the issue, not raised.
- No performance gating for very large groups (called out under Risks).

## Affected surfaces

- `packages/ui` (shared): `MultiRunLauncher`, `AgentManagerEmptyState`, `useMultiRunStore`, i18n dictionaries. Consumed unchanged by all runtimes.
- Runtimes: web, desktop (Electron), VS Code, hosted mobile, and Capacitor mobile all render this shared UI, so all benefit uniformly. No runtime-specific behavior added.
- No persisted/external contracts change; no API/server changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` (runtime boundaries; PR handoff) | Change touches shared UI in `packages/ui` | Shared UI only; entrypoints/bridges unchanged; domain logic stays in owning modules |
| `.agents/skills/openchamber-change-discipline` | Removed invariant enforced at three sites | All three enforcement sites covered in one diff; smallest complete change; regression tests added |
| `.agents/skills/locale-ui-patterns` | Edited user-facing tooltip copy | `{max}` removal applied to every shipped dictionary (11/11); no hardcoded English added |
| `packages/ui/src/stores/DOCUMENTATION.md` | Nearest owning docs for the changed store | No documented invariant on the cap; store shape unchanged |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/stores/useMultiRunStore.test.ts` | 5 pass / 0 fail (22 expect calls) — incl. >5-model cases on both dispatch paths |
| `bun run build:web` | Succeeded (green) after `bun install`; locale chunks emit new copy, no residual `{max}` in `dist` |
| Runtime verification across runtimes | Not executed; manual steps below |

Manual verification (author): open the multi-run launcher, add 6+ models to a group, submit — all accepted, all runs created, no `"maximum 5 models allowed"` error; tooltip reads "Select 2 or more models…"; same from the Agent Manager empty state.

## Visual evidence

<img width="1204" height="859" alt="chrome_HwwQZwsQjf" src="https://github.com/user-attachments/assets/db23f089-c6ed-4582-bb72-cdc924c614e4" />
<img width="1161" height="1033" alt="chrome_KZ5CIh5BF8" src="https://github.com/user-attachments/assets/bb26dc7f-43f6-472a-8cba-c3ef8b3268bb" />
<img width="531" height="283" alt="chrome_QTpSHbHdif" src="https://github.com/user-attachments/assets/56475dca-1e90-4db8-a6b4-c9bfc6a5e803" />
<img width="526" height="340" alt="chrome_YzxaP6SMrY" src="https://github.com/user-attachments/assets/e3fcca88-cb74-4d38-a1f1-747f63f01787" />

## Risks and failure behavior

- **Scale/load:** removing the cap removes the only UI guard on group size. Session creation is sequential but message dispatch is parallel (`Promise.allSettled`), and isolated runs create one worktree per model, so very large groups create heavy load. No performance measurement was performed (none claimed).
- **Rollback:** revert the commits on this branch; the change is isolated to the three sites + locale copy.
- **Compatibility/data-loss/security:** none identified — no dependencies, credentials, network, or runtime boundaries change; removing a client-side cap only affects how many sessions/worktrees a user can create from the UI.
- **Cross-runtime:** uniform effect across web/desktop/VS Code/mobile via shared `packages/ui`.

## Acceptance criteria coverage

- [x] A multi-run group accepts more than 5 models (launcher + store validation, no `"maximum 5 models allowed"` error).
- [x] Cap removed from all three enforcement sites (`MultiRunLauncher.tsx`, `useMultiRunStore.ts`, `AgentManagerEmptyState.tsx`).
- [x] No real reason to retain a limit was found — removed entirely rather than raised.
- [x] Launcher info and validation copy no longer reference a fixed `{max}` ceiling (all 11 locales).

## References

- Closes #2847

---

SDLC phase: pr (FEAT-2847 #2847)
Created with [create-pr](https://github.com/tomzx/agents/blob/897460b7dfbc982186a8c0c7ddd5edc2415e454b/skills/create-pr/SKILL.md) via glm-5.2 (`897460b`)
