### PR TITLE
fix(sessions): snapshot send target so a project switch cannot reroute a pending send

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -962,6 +962,9 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
         const queuedMessageId = options?.queuedMessageId;
         const delivery = options?.delivery === 'steer' && sessionPhase !== 'idle' ? 'steer' : undefined;
         const capturedTarget = messageQueueTarget;
+        // Snapshot the draft and current-session identity before the first
+        // async gap so a later sidebar selection cannot reroute the send.
+        const capturedDraftSnapshot = newSessionDraftOpen ? { ...newSessionDraft } : null;
         const inputSnapshot = options?.presetText != null
             ? {
                 message: options.presetText,
@@ -1034,9 +1037,17 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             }
         }
 
-        const sendMessageOptions = capturedTarget
-            ? { target: capturedTarget, ...(delivery ? { delivery } : {}) }
-            : delivery ? { delivery } : undefined;
+        const sendMessageOptions: {
+            target?: NonNullable<typeof capturedTarget>;
+            draftSnapshot?: NonNullable<typeof capturedDraftSnapshot>;
+            delivery?: 'steer';
+        } | undefined = (capturedTarget || capturedDraftSnapshot || delivery)
+            ? {
+                ...(capturedTarget ? { target: capturedTarget } : {}),
+                ...(capturedDraftSnapshot ? { draftSnapshot: capturedDraftSnapshot } : {}),
+                ...(delivery ? { delivery } : {}),
+            }
+            : undefined;
 
         // Inline review comments and synthetic context are consumed before
         // assembly so a failed send can restore exactly what it took.

--- a/packages/ui/src/sync/session-ui-store.test.js
+++ b/packages/ui/src/sync/session-ui-store.test.js
@@ -435,6 +435,124 @@ describe('createSession draft lifecycle', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Issues #2222 and #2315 — send target must be snapshotted at submit time so a
+// later sidebar/project selection cannot reroute a pending draft or session
+// send to whichever session happens to be current when the async work resumes.
+// ---------------------------------------------------------------------------
+describe('sendMessage draft snapshot (issues #2222 / #2315)', () => {
+  const sendMessageCalls = [];
+  const createSessionCalls = [];
+  let originalSendMessage;
+  let originalCreateSession;
+
+  beforeEach(() => {
+    sendMessageCalls.length = 0;
+    createSessionCalls.length = 0;
+
+    const childStore = {
+      getState: () => ({ session: [], message: {}, part: {}, session_status: {} }),
+      setState: () => {},
+    };
+    const childStores = {
+      children: new Map(),
+      ensureChild: () => childStore,
+      getChild: () => childStore,
+    };
+    setActionRefs(opencodeClient, childStores, () => '/projects/alpha');
+    setOptimisticRefs(() => {}, () => {});
+    useConfigStore.setState({ isConnected: true });
+
+    originalSendMessage = opencodeClient.sendMessage;
+    originalCreateSession = opencodeClient.createSession;
+    opencodeClient.sendMessage = async (params) => {
+      sendMessageCalls.push(params);
+      return 'msg';
+    };
+    opencodeClient.createSession = async (_params, directory) => {
+      createSessionCalls.push(directory);
+      return { id: 'session-materialized', directory: directory ?? '/projects/alpha' };
+    };
+  });
+
+  afterEach(() => {
+    opencodeClient.sendMessage = originalSendMessage;
+    opencodeClient.createSession = originalCreateSession;
+    useSessionUIStore.setState({
+      currentSessionId: null,
+      currentSessionDirectory: null,
+      newSessionDraft: { open: false, directoryOverride: null, parentID: null },
+    });
+  });
+
+  test('draft send snapshots the draft; switching to another project mid-flight still targets the materialized session', async () => {
+    const draftSnapshot = {
+      open: true,
+      directoryOverride: '/projects/alpha',
+      parentID: null,
+      title: 'Project A draft',
+    };
+    useSessionUIStore.setState({
+      currentSessionId: null,
+      currentSessionDirectory: null,
+      newSessionDraft: draftSnapshot,
+    });
+
+    const sendPromise = useSessionUIStore.getState().sendMessage(
+      'message for project A',
+      'provider-a',
+      'model-a',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'normal',
+      { draftSnapshot },
+    );
+
+    // A sidebar switch while the send is still in flight must not reroute it.
+    useSessionUIStore.getState().setCurrentSession('session-project-b', '/projects/beta');
+
+    await sendPromise;
+
+    expect(createSessionCalls).toHaveLength(1);
+    expect(createSessionCalls[0]).toBe('/projects/alpha');
+    expect(sendMessageCalls).toHaveLength(1);
+    expect(sendMessageCalls[0].id).toBe('session-materialized');
+    expect(sendMessageCalls[0].directory).toBe('/projects/alpha');
+  });
+
+  test('existing-session send keeps the submit-time target even when selection changes', async () => {
+    useSessionUIStore.setState({
+      currentSessionId: 'session-project-a',
+      currentSessionDirectory: '/projects/alpha',
+      newSessionDraft: { open: false, directoryOverride: null, parentID: null },
+    });
+
+    const sendPromise = useSessionUIStore.getState().sendMessage(
+      'message for project A',
+      'provider-a',
+      'model-a',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'normal',
+      { target: { runtimeKey: getRuntimeKey(), sessionId: 'session-project-a', directory: '/projects/alpha' } },
+    );
+
+    useSessionUIStore.getState().setCurrentSession('session-project-b', '/projects/beta');
+
+    await sendPromise;
+
+    expect(sendMessageCalls).toHaveLength(1);
+    expect(sendMessageCalls[0].id).toBe('session-project-a');
+    expect(sendMessageCalls[0].directory).toBe('/projects/alpha');
+  });
+});
+
 describe('routeMessage skill invocation', () => {
   // OpenCode registers every skill as a command (source: "skill"), so a skill
   // selected from the slash menu must be dispatched via session.command so its

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -231,6 +231,8 @@ type SendMessageOptions = {
   target?: CapturedSendTarget
   sessionId?: string
   directory?: string
+  /** Immutable copy of the new-session draft at submit time; used instead of the live draft. */
+  draftSnapshot?: NewSessionDraftState
   delivery?: 'steer'
 }
 
@@ -609,9 +611,9 @@ export async function materializeOpenDraftSession(selection: {
   modelID: string
   agent?: string
   variant?: string
-}): Promise<MaterializedDraftSession | null> {
+}, draftOverride?: NewSessionDraftState): Promise<MaterializedDraftSession | null> {
   const store = useSessionUIStore.getState()
-  const draft = store.newSessionDraft
+  const draft = draftOverride ?? store.newSessionDraft
   if (!draft?.open) return null
   const draftPermissionAutoAcceptEnabled = draft.permissionAutoAcceptEnabled === true
 
@@ -1224,7 +1226,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       set({ pendingChangesBarDismissed: map });
     }
 
-    const draft = get().newSessionDraft
+    const draft = options?.draftSnapshot ?? get().newSessionDraft
     const trimmedAgent = typeof agent === "string" && agent.trim().length > 0 ? agent.trim() : undefined
 
     const goalArm = inputMode !== "shell" && content.trim().length > 0
@@ -1282,7 +1284,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
         modelID,
         agent: trimmedAgent,
         variant,
-      })
+      }, options?.draftSnapshot)
       if (!createdDraftSession) throw new Error("Failed to create session")
 
       const mergedAdditionalParts = createdDraftSession.syntheticParts?.length


### PR DESCRIPTION
## Intent

Fixes the send pipeline reading live session state after async preparation, which lets a sidebar/project switch during the in-flight window reroute a message to whichever session became current mid-send:

- **#2222** — the first prompt from a new-session draft can be delivered to the previously active session instead of the newly created session.
- **#2315** — a pending draft send in a long-lived project silently lands in another project's session if the user navigates away while it is in flight.

This is a focused fix that snapshots the send target at `handleSubmit` and uses that snapshot for draft materialization and routing, instead of re-reading live `newSessionDraft` / `currentSessionId` after `await`s.

This PR covers the project-session-routing piece of #2242's scope without that PR's broader composer/goal-arm/message-queue changes, which is why it is kept small here.

## Non-goals

- Does not adopt #2242's `chatSubmitIsolation` / goal-arm / queued-message / input-store-by-session changes — only the snapshot of the send target and draft at submit time is fixed here.
- Sidebar project-switch selection behavior itself is unchanged (that is the separately-merged #2865).
- The optimistic "creating session…" placeholder mentioned in #2315's suggested fix is not added here; only the misrouting is fixed.

## Affected surfaces

- `packages/ui/src/components/chat/ChatInput.tsx` — captures the draft snapshot at submit entry.
- `packages/ui/src/sync/session-ui-store.ts` — `sendMessage` accepts and uses the snapshot, `materializeOpenDraftSession` takes an explicit draft override.
- Shared UI consumed by web, desktop, VS Code, and mobile; no runtime-specific branching added.
- No persisted or external contracts change: `SendMessageOptions` gains one optional field, `materializeOpenDraftSession` gains an optional parameter, both backward-compatible with existing callers.

## Repository guidance applied

- `AGENTS.md` Correctness Invariants — "Prefer authoritative state over heuristics": the send now uses the submit-time snapshot instead of whichever live session/draft state happens to be current after async work.
- `AGENTS.md` Correctness Invariants — "Scope temporary fallbacks narrowly": the snapshot only changes the send-path target resolution; it does not widen the guard or touch unrelated composer behavior.
- `.agents/skills/sync-state-invariants/SKILL.md` — Session And Queue Consistency: "Capture provider, model, agent, variant, and other send configuration when queueing. Do not re-resolve queued configuration from mutable current state at send time": extended the existing captured-target pattern to the draft snapshot so neither queued nor fresh sends re-resolve from live state.
- `.agents/skills/openchamber-change-discipline/SKILL.md`: smallest complete change, focused tests reproducing both reported races.
- `packages/ui/src/sync/DOCUMENTATION.md` names `session-ui-store.ts` as owning session selection/draft lifecycle; ownership unchanged, doc not edited.

## Validation

| Check | Result |
| --- | --- |
| `bun test packages/ui/src/sync/session-ui-store.test.js` | Passed: 29 tests (including 2 new regression tests below) |
| `bun run type-check:ui` | Passed |
| `bun run lint:ui` (ChatInput.tsx, session-ui-store.ts, session-ui-store.test.js) | Passed |

Not run / explicitly not verified:
- Full workspace build, Electron packaging, `bun run dead-code` — not run because no exports/entrypoints changed.
- Manual interactive walkthrough of the two reproductions — not performed because this environment has no interactive OpenChamber instance with two configured projects to drive the UI through; each is pinned by an automated test instead:
  - #2222 — `draft send snapshots the draft; switching to another project mid-flight still targets the materialized session`
  - #2315 — `existing-session send keeps the submit-time target even when selection changes`

## Visual evidence

No screenshot or recording attached.

The user-visible change is which session receives a message after a project/session switch during a pending send — no new UI, layout, copy, or styling. Capturing this requires an interactive two-project OpenChamber instance that is not available in this environment; the hook/store-level regression tests assert the routing outcome directly instead.

## Risks and failure behavior

- A draft snapshot is a shallow copy at submit time; later mutations to the live draft (project reassignment, target-folder change) do not affect the in-flight send, which is exactly the intended behavior.
- If draft materialization fails (server error), the draft-open contract is unchanged — the existing `createSession draft lifecycle` test still passes and the failure path returns `null` as before.
- Rollback: revert this commit; no data migration, persisted schema, or external contract was touched.

Fixes #2222
Fixes #2315