### PR TITLE
fix(composer): keep caret inside completed fence

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -102,6 +102,7 @@ import {
     appendInlineText,
     appendWithLineBreaks,
     buildImagePasteInsertion,
+    getMarkdownAutoPairEdit,
     shouldWrapSelectionAsLink,
     withInlineInsertionBoundaries,
 } from './composer/text';
@@ -1513,38 +1514,17 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
             const selEnd = ta?.getSelection().end ?? -1;
 
             if (ta && selStart >= 0) {
-                const applyEdit = (next: string, caretStart: number, caretEnd: number) => {
+                const edit = getMarkdownAutoPairEdit(message, e.key, selStart, selEnd);
+                if (edit) {
                     e.preventDefault();
-                    setMessage(next);
-                    composerRef.current?.setSelection(caretStart, caretEnd);
-                    updateAutocompleteState(next, caretEnd);
-                };
-
-                // Wrap the current selection: select text, press ` * _ ~ ( [ { " '
-                const WRAP_PAIRS: Record<string, [string, string]> = {
-                    '`': ['`', '`'], '*': ['*', '*'], '_': ['_', '_'], '~': ['~', '~'],
-                    '(': ['(', ')'], '[': ['[', ']'], '{': ['{', '}'],
-                    '"': ['"', '"'], "'": ["'", "'"],
-                };
-                if (selEnd > selStart && WRAP_PAIRS[e.key]) {
-                    const [open, close] = WRAP_PAIRS[e.key];
-                    const selected = message.slice(selStart, selEnd);
-                    const next = `${message.slice(0, selStart)}${open}${selected}${close}${message.slice(selEnd)}`;
-                    applyEdit(next, selStart + open.length, selEnd + open.length);
+                    ta.replaceRange(
+                        edit.from,
+                        edit.to,
+                        edit.insert,
+                        edit.selectionStart,
+                        edit.selectionEnd,
+                    );
                     return;
-                }
-
-                // Typing the third backtick at line start expands into a fenced
-                // code block with the caret on the empty middle line (Slack-like).
-                if (e.key === '`' && selStart === selEnd) {
-                    const before = message.slice(0, selStart);
-                    if (/(^|\n)``$/.test(before)) {
-                        const after = message.slice(selEnd);
-                        const next = `${before}\`\n\n\`\`\`${after}`;
-                        const caret = before.length + 2; // after the completed ``` and first newline
-                        applyEdit(next, caret, caret);
-                        return;
-                    }
                 }
             }
         }

--- a/packages/ui/src/components/chat/composer/__tests__/text.test.ts
+++ b/packages/ui/src/components/chat/composer/__tests__/text.test.ts
@@ -4,6 +4,7 @@ import {
     appendInlineText,
     appendWithLineBreaks,
     buildImagePasteInsertion,
+    getMarkdownAutoPairEdit,
     shouldWrapSelectionAsLink,
     withInlineInsertionBoundaries,
 } from '../text';
@@ -117,5 +118,41 @@ describe('shouldWrapSelectionAsLink', () => {
 
     test('a selection that is already a link is not nested', () => {
         expect(shouldWrapSelectionAsLink('https://x.dev', '[docs](https://y.dev)')).toBe(false);
+    });
+});
+
+describe('getMarkdownAutoPairEdit', () => {
+    test('completes a fenced block with the caret on the middle line', () => {
+        expect(getMarkdownAutoPairEdit('``', '`', 2, 2)).toEqual({
+            from: 2,
+            to: 2,
+            insert: '`\n\n```',
+            selectionStart: 4,
+            selectionEnd: 4,
+        });
+    });
+
+    test('completes a fence at the start of any line', () => {
+        expect(getMarkdownAutoPairEdit('intro\n``tail', '`', 8, 8)).toEqual({
+            from: 8,
+            to: 8,
+            insert: '`\n\n```',
+            selectionStart: 10,
+            selectionEnd: 10,
+        });
+    });
+
+    test('does not complete two backticks in the middle of a line', () => {
+        expect(getMarkdownAutoPairEdit('text ``', '`', 7, 7)).toBeNull();
+    });
+
+    test('wraps selected text and keeps the text selected', () => {
+        expect(getMarkdownAutoPairEdit('hello', '*', 1, 4)).toEqual({
+            from: 1,
+            to: 4,
+            insert: '*ell*',
+            selectionStart: 2,
+            selectionEnd: 5,
+        });
     });
 });

--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -63,8 +63,8 @@ export interface ComposerEditorHandle {
     selectAll(): void;
     /** Replace the current selection, leaving the caret after the insertion. */
     insertText(text: string): void;
-    /** Replace an explicit range; the caret lands at `caret` or after the text. */
-    replaceRange(from: number, to: number, text: string, caret?: number): void;
+    /** Replace a range; selection defaults to a caret after the inserted text. */
+    replaceRange(from: number, to: number, text: string, selectionStart?: number, selectionEnd?: number): void;
     /** Viewport coordinates of the caret, for positioning popups. */
     caretCoords(position?: number): { top: number; bottom: number; left: number } | null;
     /** The scrollable element, for measuring and scroll compensation. */
@@ -513,12 +513,13 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                     userEvent: 'input.type',
                 });
             },
-            replaceRange(from, to, text, caret) {
+            replaceRange(from, to, text, selectionStart, selectionEnd = selectionStart) {
                 const view = viewRef.current;
                 if (!view) return;
+                const anchor = selectionStart ?? from + text.length;
                 view.dispatch({
                     changes: { from, to, insert: text },
-                    selection: { anchor: caret ?? from + text.length },
+                    selection: { anchor, head: selectionEnd ?? anchor },
                     userEvent: 'input.type',
                 });
             },

--- a/packages/ui/src/components/chat/composer/text.ts
+++ b/packages/ui/src/components/chat/composer/text.ts
@@ -104,3 +104,61 @@ export function shouldWrapSelectionAsLink(url: string, selected: string): boolea
         && selected.trim().length > 0
         && !selected.includes('](');
 }
+
+const MARKDOWN_WRAP_PAIRS: Record<string, [string, string]> = {
+    '`': ['`', '`'],
+    '*': ['*', '*'],
+    '_': ['_', '_'],
+    '~': ['~', '~'],
+    '(': ['(', ')'],
+    '[': ['[', ']'],
+    '{': ['{', '}'],
+    '"': ['"', '"'],
+    "'": ["'", "'"],
+};
+
+/**
+ * Markdown source-mode conveniences handled before CodeMirror inserts a key.
+ * The returned text change and selection belong to one editor transaction so
+ * the caret cannot be applied against the previous document.
+ */
+export function getMarkdownAutoPairEdit(
+    value: string,
+    key: string,
+    selectionStart: number,
+    selectionEnd: number,
+): {
+    from: number;
+    to: number;
+    insert: string;
+    selectionStart: number;
+    selectionEnd: number;
+} | null {
+    const pair = MARKDOWN_WRAP_PAIRS[key];
+    if (selectionEnd > selectionStart && pair) {
+        const selected = value.slice(selectionStart, selectionEnd);
+        const [open, close] = pair;
+        return {
+            from: selectionStart,
+            to: selectionEnd,
+            insert: `${open}${selected}${close}`,
+            selectionStart: selectionStart + open.length,
+            selectionEnd: selectionEnd + open.length,
+        };
+    }
+
+    if (key === '`' && selectionStart === selectionEnd) {
+        const before = value.slice(0, selectionStart);
+        if (/(^|\n)``$/.test(before)) {
+            return {
+                from: selectionStart,
+                to: selectionEnd,
+                insert: '`\n\n```',
+                selectionStart: selectionStart + 2,
+                selectionEnd: selectionStart + 2,
+            };
+        }
+    }
+
+    return null;
+}


### PR DESCRIPTION
## Intent

Fixes #2879.

Typing the third backtick at the beginning of a line already expands the prompt into a fenced Markdown block. This change keeps the caret on the empty line inside that block by applying the text insertion and selection in one CodeMirror transaction.

## Non-goals

- No changes to Markdown parsing, highlighting, or submitted prompt text.
- No VS Code-specific workaround; the bug is in the shared composer.
- No changes to autocomplete behavior outside the existing fence completion and selected-text wrapping paths.

## Affected surfaces

`packages/ui` shared chat composer:

- `ChatInput` delegates the Markdown edit calculation to a focused text helper.
- `ComposerEditor.replaceRange` can apply a range replacement and resulting selection atomically.
- Web, desktop, VS Code, and mobile consume this shared composer behavior.

There are no persisted data, route, protocol, dependency, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | This changes shared executable UI source and caret behavior. | The change stays in the shared UI owner, keeps the orchestration component thin, and uses package-scoped validation plus the affected VS Code build. |
| `openchamber-change-discipline` | The fix changes a local text-edit contract and the editor ref interface. | The edit is isolated in a pure helper, existing default `replaceRange` behavior is preserved, consumers were inspected, and focused contract tests cover the regression. |
| Composer `DOCUMENTATION.md` | The document defines `text.ts` as insertion ownership and CodeMirror as caret ownership. | Text calculation lives in `text.ts`; document and selection are committed together by `ComposerEditor`. Manual verification is reported separately because the package has no DOM test environment. |
| `CONTRIBUTING.md` and PR template | This is a user-visible interaction fix. | The PR records exact automated checks, manual scope, affected runtimes, and missing recording evidence. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/composer/__tests__/text.test.ts` | Passed: 27 tests, 0 failures. |
| `bun run type-check` in `packages/ui` | Passed. |
| `bun run lint` in `packages/ui` | Passed. |
| `bun run dead-code` | Exited 0. Existing upstream baseline remains: 205 unused exports and 1 duplicate export; the new helper is not reported. |
| `bun run vscode:build` | Passed on PR HEAD. Existing KaTeX runtime-font, mixed dynamic/static import, and large-chunk warnings remain. |
| Manual VS Code interaction | A VSIX containing the same four-file source patch was installed and the reporter confirmed that triple-backtick completion leaves the caret inside the fence. The installed artifact also contains downstream identity changes; the exact PR HEAD was build-validated but not separately installed. |

## Visual evidence

No recording is attached yet. This is a caret-position interaction with no static visual or styling change. The reporter manually verified the corrected interaction after installing the patched VSIX.

## Risks and failure behavior

Risk is limited to keyboard edits handled before CodeMirror inserts the pressed key. The same replacement and selection now occur atomically against one document version, preventing the controlled update from moving the caret to the end.

Selected-text wrapping retains its previous selection semantics and has focused coverage. Existing `replaceRange` callers keep the default caret-after-insertion behavior when selection arguments are omitted. There is no persistence, cleanup, rollback, security, or data-loss path; reverting the single commit restores the previous behavior.