### PR TITLE
fix: recover new chats from stale worktree directory

### DIFF
--- a/packages/ui/src/lib/opencode/client.test.ts
+++ b/packages/ui/src/lib/opencode/client.test.ts
@@ -9,12 +9,19 @@ let configCalls = 0;
 let runtimeKey = 'test-runtime';
 const promptAsyncCalls: unknown[][] = [];
 const promptAsyncResults: Array<unknown> = [];
+const pathGetResults: Array<unknown> = [];
 
 const promptAsyncMock = mock(async (...args: unknown[]) => {
   promptAsyncCalls.push(args);
   const next = promptAsyncResults.shift();
   if (next instanceof Error) throw next;
   return next ?? { response: new Response(null, { status: 200 }) };
+});
+
+const pathGetMock = mock(async () => {
+  const next = pathGetResults.shift();
+  if (next instanceof Error) throw next;
+  return next ?? { data: { directory: '/workspace/project' } };
 });
 
 mock.module('@opencode-ai/sdk/v2', () => ({
@@ -29,6 +36,9 @@ mock.module('@opencode-ai/sdk/v2', () => ({
     },
     session: {
       promptAsync: promptAsyncMock,
+    },
+    path: {
+      get: pathGetMock,
     },
   })),
 }));
@@ -64,6 +74,17 @@ beforeEach(() => {
   runtimeKey = 'test-runtime';
   promptAsyncCalls.length = 0;
   promptAsyncResults.length = 0;
+  pathGetResults.length = 0;
+});
+
+describe('opencodeClient directory availability', () => {
+  test('distinguishes a missing directory from an unavailable path probe', async () => {
+    pathGetResults.push({ error: { code: 'ENOENT', message: 'no such file or directory' } });
+    expect(await opencodeClient.getDirectoryAvailability('/private/deleted-worktree')).toBe('missing');
+
+    pathGetResults.push(new Error('offline'));
+    expect(await opencodeClient.getDirectoryAvailability('/private/deleted-worktree')).toBe('unknown');
+  });
 });
 
 describe('opencodeClient getConfig cache', () => {

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -68,6 +68,21 @@ type SdkResult<T> = {
   response?: { status?: number };
 };
 
+type DirectoryAvailability = 'available' | 'missing' | 'unknown';
+
+const isMissingDirectoryError = (error: unknown): boolean => {
+  if (error instanceof FilesystemError) {
+    return error.reason === 'not-found' || error.reason === 'not-directory';
+  }
+  if (error && typeof error === 'object') {
+    const code = (error as { code?: unknown }).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return true;
+    }
+  }
+  return /\bENOENT\b|\bENOTDIR\b|no such file or directory/i.test(formatSdkError(error));
+};
+
 function unwrapSdkData<T>(result: SdkResult<T>, operation: string): T {
   if (result.error) {
     const status = result.response?.status;
@@ -517,6 +532,27 @@ class OpencodeService {
       return Boolean(returned && returned.trim().length > 0);
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * Determines whether OpenCode can resolve a directory without treating an
+   * unavailable runtime as proof that the directory is missing.
+   */
+  async getDirectoryAvailability(directory: string): Promise<DirectoryAvailability> {
+    const normalized = this.normalizeCandidatePath(directory);
+    if (!normalized) {
+      return 'unknown';
+    }
+    try {
+      const response = await this.client.path.get({ directory: normalized }) as SdkResult<{ directory?: unknown }>;
+      if (response.error) {
+        return isMissingDirectoryError(response.error) ? 'missing' : 'unknown';
+      }
+      const returned = typeof response.data?.directory === 'string' ? response.data.directory.trim() : '';
+      return returned ? 'available' : 'unknown';
+    } catch (error) {
+      return isMissingDirectoryError(error) ? 'missing' : 'unknown';
     }
   }
 

--- a/packages/ui/src/sync/session-ui-store.test.js
+++ b/packages/ui/src/sync/session-ui-store.test.js
@@ -8,6 +8,7 @@ import { setActionRefs, setOptimisticRefs } from './session-actions';
 import { useSkillsStore } from '@/stores/useSkillsStore';
 import { useCommandsStore } from '@/stores/useCommandsStore';
 import { useConfigStore } from '@/stores/useConfigStore';
+import { getDeferredSafeStorage } from '@/stores/utils/safeStorage';
 import { getRuntimeKey } from '@/lib/runtime-switch';
 
 /**
@@ -408,9 +409,21 @@ describe('openNewSessionDraft project binding', () => {
 
 describe('createSession draft lifecycle', () => {
   let originalCreateSession;
+  let originalGetDirectoryAvailability;
+  let originalProjects;
+  let originalActiveProjectId;
+  let originalDirectoryState;
+  let originalClientDirectory;
+  let originalLastDirectory;
 
   beforeEach(() => {
     originalCreateSession = opencodeClient.createSession;
+    originalGetDirectoryAvailability = opencodeClient.getDirectoryAvailability;
+    originalProjects = useProjectsStore.getState().projects;
+    originalActiveProjectId = useProjectsStore.getState().activeProjectId;
+    originalDirectoryState = useDirectoryStore.getState();
+    originalClientDirectory = opencodeClient.getDirectory();
+    originalLastDirectory = getDeferredSafeStorage().getItem('lastDirectory');
     useSessionUIStore.setState({
       currentSessionId: null,
       currentSessionDirectory: null,
@@ -420,6 +433,15 @@ describe('createSession draft lifecycle', () => {
 
   afterEach(() => {
     opencodeClient.createSession = originalCreateSession;
+    opencodeClient.getDirectoryAvailability = originalGetDirectoryAvailability;
+    useProjectsStore.setState({ projects: originalProjects, activeProjectId: originalActiveProjectId });
+    useDirectoryStore.setState(originalDirectoryState, true);
+    opencodeClient.setDirectory(originalClientDirectory ?? undefined);
+    if (originalLastDirectory === null) {
+      getDeferredSafeStorage().removeItem('lastDirectory');
+    } else {
+      getDeferredSafeStorage().setItem('lastDirectory', originalLastDirectory);
+    }
   });
 
   test('keeps the draft open when session creation fails', async () => {
@@ -432,6 +454,88 @@ describe('createSession draft lifecycle', () => {
     expect(session).toBeNull();
     expect(useSessionUIStore.getState().newSessionDraft.open).toBe(true);
     expect(useSessionUIStore.getState().newSessionDraft.title).toBe('Draft title');
+  });
+
+  test('falls back to the current active project when a regular new-chat directory is missing', async () => {
+    const createSessionCalls = [];
+    useProjectsStore.setState({
+      projects: [
+        { id: 'project-draft', path: '/projects/draft', label: 'Draft' },
+        { id: 'project-active', path: '/projects/active', label: 'Active' },
+      ],
+      activeProjectId: 'project-active',
+    });
+    useDirectoryStore.getState().setDirectory('/private/deleted-worktree', { showOverlay: false });
+    useSessionUIStore.getState().openNewSessionDraft();
+    opencodeClient.getDirectoryAvailability = async () => 'missing';
+    opencodeClient.createSession = async (_params, directory) => {
+      createSessionCalls.push(directory);
+      return { id: 'session-fallback', directory };
+    };
+
+    await useSessionUIStore.getState().createSession('Draft title', '/private/deleted-worktree');
+
+    expect(createSessionCalls).toEqual(['/projects/active']);
+    expect(useDirectoryStore.getState().currentDirectory).toBe('/projects/active');
+    expect(getDeferredSafeStorage().getItem('lastDirectory')).toBe('/projects/active');
+  });
+
+  test('keeps an explicitly pinned worktree directory unchanged', async () => {
+    const createSessionCalls = [];
+    useProjectsStore.setState({
+      projects: [{ id: 'project-main', path: '/projects/main', label: 'Main' }],
+      activeProjectId: 'project-main',
+    });
+    useSessionUIStore.getState().openNewSessionDraft({ directoryOverride: '/private/deleted-worktree' });
+    expect(useSessionUIStore.getState().newSessionDraft.preserveDirectoryOverride).toBe(true);
+    opencodeClient.getDirectoryAvailability = async () => 'missing';
+    opencodeClient.createSession = async (_params, directory) => {
+      createSessionCalls.push(directory);
+      return { id: 'session-pinned', directory };
+    };
+
+    await useSessionUIStore.getState().createSession('Draft title', '/private/deleted-worktree');
+
+    expect(createSessionCalls).toEqual(['/private/deleted-worktree']);
+  });
+
+  test('keeps the stale directory when its availability cannot be confirmed', async () => {
+    const createSessionCalls = [];
+    useProjectsStore.setState({
+      projects: [{ id: 'project-main', path: '/projects/main', label: 'Main' }],
+      activeProjectId: 'project-main',
+    });
+    useDirectoryStore.getState().setDirectory('/private/unavailable-worktree', { showOverlay: false });
+    useSessionUIStore.getState().openNewSessionDraft();
+    opencodeClient.getDirectoryAvailability = async () => 'unknown';
+    opencodeClient.createSession = async (_params, directory) => {
+      createSessionCalls.push(directory);
+      return { id: 'session-unavailable', directory };
+    };
+
+    await useSessionUIStore.getState().createSession('Draft title', '/private/unavailable-worktree');
+
+    expect(createSessionCalls).toEqual(['/private/unavailable-worktree']);
+    expect(useDirectoryStore.getState().currentDirectory).toBe('/private/unavailable-worktree');
+  });
+
+  test('does not persist a fallback when session creation fails', async () => {
+    useProjectsStore.setState({
+      projects: [{ id: 'project-main', path: '/projects/main', label: 'Main' }],
+      activeProjectId: 'project-main',
+    });
+    useDirectoryStore.getState().setDirectory('/private/deleted-worktree', { showOverlay: false });
+    useSessionUIStore.getState().openNewSessionDraft();
+    opencodeClient.getDirectoryAvailability = async () => 'missing';
+    opencodeClient.createSession = async () => {
+      throw new Error('offline');
+    };
+
+    const session = await useSessionUIStore.getState().createSession('Draft title', '/private/deleted-worktree');
+
+    expect(session).toBeNull();
+    expect(useDirectoryStore.getState().currentDirectory).toBe('/private/deleted-worktree');
+    expect(getDeferredSafeStorage().getItem('lastDirectory')).toBe('/private/deleted-worktree');
   });
 });
 

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -921,7 +921,10 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       permissionAutoAcceptEnabled: options?.permissionAutoAcceptEnabled === true,
       pendingWorktreeRequestId: options?.pendingWorktreeRequestId ?? null,
       bootstrapPendingDirectory: normalizePath(options?.bootstrapPendingDirectory ?? null),
-      preserveDirectoryOverride: options?.preserveDirectoryOverride === true,
+      // A caller that supplies a directory is making a deliberate routing
+      // choice (for example, opening a specific worktree). Do not later
+      // reinterpret that target as the persisted default directory.
+      preserveDirectoryOverride: options?.preserveDirectoryOverride === true || explicitDirectory !== null,
       parentID: options?.parentID ?? null,
       title: options?.title,
       initialPrompt: options?.initialPrompt,
@@ -1416,14 +1419,42 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     const targetFolderId = draft.targetFolderId
 
     try {
-      const dir = directoryOverride ?? opencodeClient.getDirectory()
+      let dir = directoryOverride ?? opencodeClient.getDirectory()
+      const isDefaultDraftDirectory =
+        draft.open
+        && !draft.preserveDirectoryOverride
+        && normalizePath(draft.directoryOverride) === normalizePath(dir ?? null)
+      const projectsState = useProjectsStore.getState()
+      const activeProjectDirectory = projectsState.getActiveProject()?.path
+        ?? (draft.selectedProjectId
+          ? projectsState.projects.find((project) => project.id === draft.selectedProjectId)?.path
+          : null)
+      const runtimeKey = getRuntimeKey()
+      const draftDirectory = draft.directoryOverride
+
+      if (isDefaultDraftDirectory && dir && activeProjectDirectory && normalizePath(dir) !== normalizePath(activeProjectDirectory)) {
+        const availability = await opencodeClient.getDirectoryAvailability(dir)
+        const currentDraft = get().newSessionDraft
+        const draftChanged = !currentDraft.open
+          || currentDraft.preserveDirectoryOverride !== draft.preserveDirectoryOverride
+          || normalizePath(currentDraft.directoryOverride) !== normalizePath(draftDirectory)
+
+        if (getRuntimeKey() !== runtimeKey || draftChanged) {
+          return null
+        }
+
+        if (availability === 'missing') {
+          dir = activeProjectDirectory
+        }
+      }
+
       const session = await createSessionAction(title, dir, parentID ?? null, metadata)
       if (!session) return null
 
       get().closeNewSessionDraft()
 
       if (targetFolderId) {
-        const scopeKey = directoryOverride || get().lastLoadedDirectory || session.directory
+        const scopeKey = dir || get().lastLoadedDirectory || session.directory
         if (scopeKey) {
           useSessionFoldersStore.getState().addSessionToFolder(scopeKey, targetFolderId, session.id)
         }


### PR DESCRIPTION
Closes #2854

Fixes new chats that inherit a deleted persisted lastDirectory. Validates confirmed-missing paths, falls back only for regular new-chat drafts to the current active project, preserves explicit worktree targets, and keeps unknown/offline probes unchanged.

Validation: 40 targeted tests passed; ESLint, TypeScript, and git diff --check passed. Full UI suite: 256/257 test files passed; the remaining Windows locale assertion is unrelated.