### PR TITLE
fix(ui): normalize Windows paths in skill visibility filtering

### DIFF
--- a/packages/ui/src/stores/skillVisibility.test.ts
+++ b/packages/ui/src/stores/skillVisibility.test.ts
@@ -6,6 +6,9 @@ const skill = (name: string, path: string) => ({ name, path });
 const AGENTS = (name: string) => skill(name, `/repo/.agents/skills/${name}/SKILL.md`);
 const CLAUDE = (name: string) => skill(name, `/repo/.claude/skills/${name}/SKILL.md`);
 const OPENCODE = (name: string) => skill(name, `/home/u/.config/opencode/skill/${name}/SKILL.md`);
+const WIN_AGENTS = (name: string) => skill(name, String.raw`C:\Users\u\.agents\skills\${name}\SKILL.md`);
+const WIN_CLAUDE = (name: string) => skill(name, String.raw`C:\Users\u\.claude\skills\${name}\SKILL.md`);
+const WIN_OPENCODE = (name: string) => skill(name, String.raw`C:\Users\u\.config\opencode\skill\${name}\SKILL.md`);
 
 const ENABLED = { claudeDisabled: false, allDisabled: false };
 
@@ -19,6 +22,13 @@ describe('resolveSkillRoot', () => {
 
   test('does not match a directory that merely contains the name', () => {
     expect(resolveSkillRoot('/repo/my.claude.backup/skills/a/SKILL.md')).toBe('opencode');
+  });
+
+  test('classifies Windows backslash paths', () => {
+    expect(resolveSkillRoot(WIN_CLAUDE('a').path)).toBe('claude');
+    expect(resolveSkillRoot(WIN_AGENTS('a').path)).toBe('agents');
+    expect(resolveSkillRoot(WIN_OPENCODE('a').path)).toBe('opencode');
+    expect(resolveSkillRoot(String.raw`C:\repo\my.claude.backup\skills\a\SKILL.md`)).toBe('opencode');
   });
 });
 
@@ -71,5 +81,23 @@ describe('filterSkillsByRuntimeFlags', () => {
   test('does not let dedup drop a name that only exists under .claude', () => {
     const result = filterSkillsByRuntimeFlags([CLAUDE('only-claude'), AGENTS('other')], ENABLED);
     expect(result.map((s) => s.name).sort()).toEqual(['only-claude', 'other']);
+  });
+
+  test('drops Windows .agents and .claude skills when external skills are disabled', () => {
+    const skills = [WIN_AGENTS('a'), WIN_CLAUDE('b'), WIN_OPENCODE('c')];
+    const result = filterSkillsByRuntimeFlags(skills, { claudeDisabled: false, allDisabled: true });
+    expect(result.map((s) => s.name)).toEqual(['c']);
+  });
+
+  test('drops only Windows .claude skills when claude skills are disabled', () => {
+    const skills = [WIN_AGENTS('a'), WIN_CLAUDE('b'), WIN_OPENCODE('c')];
+    const result = filterSkillsByRuntimeFlags(skills, { claudeDisabled: true, allDisabled: false });
+    expect(result.map((s) => s.name).sort()).toEqual(['a', 'c']);
+  });
+
+  test('prefers the .agents copy for a duplicated name on Windows', () => {
+    const result = filterSkillsByRuntimeFlags([WIN_CLAUDE('dup'), WIN_AGENTS('dup')], ENABLED);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toContain('.agents');
   });
 });

--- a/packages/ui/src/stores/skillVisibility.ts
+++ b/packages/ui/src/stores/skillVisibility.ts
@@ -35,8 +35,12 @@ const AGENTS_ROOT = /(^|\/)\.agents\//;
 type SkillRoot = 'claude' | 'agents' | 'opencode';
 
 export const resolveSkillRoot = (skillPath: string): SkillRoot => {
-  if (CLAUDE_ROOT.test(skillPath)) return 'claude';
-  if (AGENTS_ROOT.test(skillPath)) return 'agents';
+  // Server discovery joins paths with the platform separator, so Windows
+  // skill paths arrive with backslashes. Normalize before matching the
+  // root regexes, which are expressed with forward slashes.
+  const normalized = skillPath.replace(/\\/g, '/');
+  if (CLAUDE_ROOT.test(normalized)) return 'claude';
+  if (AGENTS_ROOT.test(normalized)) return 'agents';
   return 'opencode';
 };
 


### PR DESCRIPTION
## Intent

On Windows, skills under `~/.agents/skills` and `~/.claude/skills` are never filtered by `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` (or `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS`): they still appear in the skills list even though the agent cannot invoke them.

Root cause: server-side discovery (`server/lib/opencode/shared.js`) joins paths with the platform separator, so Windows skill paths arrive as `C:\Users\u\.agents\skills\...`. `resolveSkillRoot` matches root regexes expressed with forward slashes (`/(^|\/)\.agents\//`), so backslash paths are misclassified as `opencode`, which the filter always keeps (`if (root === 'opencode') return true`).

Fix: normalize backslashes to forward slashes at the `resolveSkillRoot` entry before regex matching. This also makes the `.claude`-vs-`.agents` dedup (`filterSkillsByRuntimeFlags`) work on Windows, where it previously never triggered.

## Non-goals

- Server-side scanning of `.claude`/`.agents` roots is unchanged (the server deliberately scans and reports flags for the client to filter).
- Dedup semantics (`.agents` wins a name collision) are unchanged — only the Windows misclassification of roots is fixed.
- No change to POSIX behavior: paths that already match the regexes are unaffected by normalization.

## Affected surfaces

- `packages/ui/src/stores/skillVisibility.ts` — `resolveSkillRoot` (exported) and, transitively, `filterSkillsByRuntimeFlags`.
- `packages/ui` is the shared UI library consumed by web, desktop (Electron), and VS Code; all surfaces benefit from the fix, none are adversely affected because the change only adds path normalization before existing regex matching.
- No persisted data, routes, SDK calls, or external contracts change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — always-on constraints | Change to shared UI source | Followed instruction order (root guide → skills → nearest docs); kept the diff to two files; did not modify `../opencode`; no new dependencies; no secrets; minimal scope. |
| `openchamber-change-discipline` | Fixing existing behavior in `packages/ui` | Smallest complete change: one normalization line in `resolveSkillRoot`; classified risk as local implementation with an exported function; validated with focused tests + package-scoped type-check and lint per the validation matrix. |
| `ui-api-decoupling` | Shared UI store consuming server-reported flags | No API/SDK changes; the filter continues to use the `externalSkills` flags reported by the server; no runtime-specific transport assumptions introduced. |
| `packages/ui/src/stores/DOCUMENTATION.md` | Stores are shared across runtimes | The change does not alter store shape, selectors, or ownership rules; `resolveSkillRoot` is a pure function, so no doc update is required. |
| `CONTRIBUTING.md` — PR contract | PR must state intent, scope, validation, risk | Filled in below with concrete evidence. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/stores/skillVisibility.test.ts` | 13 pass, 0 fail (4 new Windows-path tests added) |
| `bun run type-check:ui` | Passed (`tsc --noEmit`, no errors) |
| `bun run lint:ui` | Passed (eslint, no errors) |
| Node reproduction of the installed 1.18.3 bundle logic | Before fix: `resolveSkillRoot('C:\Users\u\.agents\skills\a\SKILL.md')` returned `'opencode'`; after normalization it returns `'agents'`, and `allDisabled: true` filters the skill out |

Not verified: no full workspace `bun run test`/`bun run build` was run — the change is isolated to `packages/ui` and its focused test suite plus package-scoped checks pass. The fix targets UI-side filtering only; no runtime/platform behavior is exercised beyond pure path-string logic.

## Visual evidence

No user-visible change to rendered UI. The diff only alters classification of skill paths (pure string function) used to filter the skills list; no component, styling, or layout is touched. The affected observable behavior — `.agents`/`.claude` skills disappearing from the list when `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` — is verified by the unit tests above (test-only, non-visual evidence).

## Risks and failure behavior

- POSIX paths: normalization is a no-op for paths without backslashes; existing classification and dedup behavior is preserved (covered by the existing POSIX tests).
- Misclassification regression: the `my.claude.backup` style guard still passes — a directory that merely contains the name is still classified as `opencode` (covered by existing and new tests).
- Failure behavior: `resolveSkillRoot` is a pure function; no state, caches, or persisted data are involved. A malformed path still falls through to `'opencode'` (keep), matching the pre-existing pass-through safety for unknown roots.
- Compatibility: the exported signature is unchanged; the fix applies to all runtimes consuming `packages/ui`.
