### PR TITLE
fix(ui): scope theme settings per runtime instance

### DIFF
--- a/packages/ui/src/apps/mobileNativeChrome.ts
+++ b/packages/ui/src/apps/mobileNativeChrome.ts
@@ -70,6 +70,27 @@ export const useNativeMobileChrome = (): void => {
       const retry = window.setTimeout(() => void applyStatusBar(), 400);
       cleanup.push(() => window.clearTimeout(retry));
 
+      // Theme toggles must reach the status bar without an app restart: re-run
+      // whenever the root dark/light class flips — the one signal every theme
+      // path converges on (settings toggle, synced settings, storage events,
+      // system-preference changes while in system mode). splashBg* colors are
+      // per-variant values, so they are stable across mode toggles.
+      if (platform === 'android') {
+        let wasDark = root.classList.contains('dark');
+        const themeClassObserver = new MutationObserver(() => {
+          const isDark = root.classList.contains('dark');
+          if (isDark === wasDark) return;
+          wasDark = isDark;
+          void applyStatusBar();
+        });
+        themeClassObserver.observe(root, { attributes: true, attributeFilter: ['class'] });
+        if (disposed) {
+          themeClassObserver.disconnect();
+          return;
+        }
+        cleanup.push(() => themeClassObserver.disconnect());
+      }
+
       const { App } = await import('@capacitor/app');
       const stateHandle = await App.addListener('appStateChange', ({ isActive }) => {
         if (isActive) void applyStatusBar();

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -32,6 +32,11 @@ import {
 import { isValidTheme } from './theme-validation';
 import { getSyncedThemeFromPayload, getSyncedThemeVariant } from './theme-sync-payload';
 import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
+import {
+  getThemePreferencesStorageKey,
+  readThemePreferencesForRuntime,
+  writeThemePreferencesForRuntime,
+} from './theme-storage';
 
 type ThemePreferences = {
   themeMode: ThemeMode;
@@ -88,9 +93,10 @@ const buildInitialPreferences = (defaultThemeId?: string): ThemePreferences => {
     const embeddedMode = embeddedParams?.get('themeMode');
     const embeddedLightId = embeddedParams?.get('lightThemeId');
     const embeddedDarkId = embeddedParams?.get('darkThemeId');
-    const storedMode = localStorage.getItem('themeMode');
-    const storedLightId = localStorage.getItem('lightThemeId');
-    const storedDarkId = localStorage.getItem('darkThemeId');
+    const storedPreferences = readThemePreferencesForRuntime(getRuntimeKey());
+    const storedMode = storedPreferences?.themeMode ?? null;
+    const storedLightId = storedPreferences?.lightThemeId ?? null;
+    const storedDarkId = storedPreferences?.darkThemeId ?? null;
     const legacyUseSystem = localStorage.getItem('useSystemTheme');
     const legacyThemeId = localStorage.getItem('selectedThemeId');
     const legacyVariant = localStorage.getItem('selectedThemeVariant');
@@ -315,6 +321,9 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
     customThemesRequestRef.current += 1;
     setCustomThemes([]);
     setCustomThemesLoading(false);
+    // Adopt the new instance's last-known theme immediately; the incoming
+    // settings sync refines it with the server's authoritative value.
+    setPreferences((prev) => readThemePreferencesForRuntime(detail.runtimeKey) ?? prev);
     void reloadCustomThemes();
   }), [isVSCode, reloadCustomThemes]);
 
@@ -425,6 +434,12 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
       return;
     }
 
+    writeThemePreferencesForRuntime(getRuntimeKey(), {
+      themeMode: preferences.themeMode,
+      lightThemeId: preferences.lightThemeId,
+      darkThemeId: preferences.darkThemeId,
+    });
+
     localStorage.setItem('themeMode', preferences.themeMode);
     localStorage.setItem('lightThemeId', preferences.lightThemeId);
     localStorage.setItem('darkThemeId', preferences.darkThemeId);
@@ -460,35 +475,26 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
         return;
       }
 
-      if (event.key !== 'themeMode' && event.key !== 'lightThemeId' && event.key !== 'darkThemeId') {
+      // Only same-runtime windows share the scoped key; windows pointing at a
+      // different instance write their own runtime's key and are ignored.
+      if (event.key !== getThemePreferencesStorageKey(getRuntimeKey())) {
+        return;
+      }
+
+      const stored = readThemePreferencesForRuntime(getRuntimeKey());
+      if (!stored) {
         return;
       }
 
       setPreferences((prev) => {
-        const nextModeRaw = localStorage.getItem('themeMode');
-        const nextMode: ThemeMode =
-          nextModeRaw === 'light' || nextModeRaw === 'dark' || nextModeRaw === 'system'
-            ? nextModeRaw
-            : prev.themeMode;
-
-        const nextLightRaw = localStorage.getItem('lightThemeId');
-        const nextLight = typeof nextLightRaw === 'string' && nextLightRaw.trim().length > 0
-          ? nextLightRaw.trim()
-          : prev.lightThemeId;
-
-        const nextDarkRaw = localStorage.getItem('darkThemeId');
-        const nextDark = typeof nextDarkRaw === 'string' && nextDarkRaw.trim().length > 0
-          ? nextDarkRaw.trim()
-          : prev.darkThemeId;
-
-        if (nextMode === prev.themeMode && nextLight === prev.lightThemeId && nextDark === prev.darkThemeId) {
+        if (prev.themeMode === stored.themeMode && prev.lightThemeId === stored.lightThemeId && prev.darkThemeId === stored.darkThemeId) {
           return prev;
         }
 
         return {
-          themeMode: nextMode,
-          lightThemeId: nextLight,
-          darkThemeId: nextDark,
+          themeMode: stored.themeMode,
+          lightThemeId: stored.lightThemeId,
+          darkThemeId: stored.darkThemeId,
         };
       });
     };

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -97,23 +97,58 @@ const buildInitialPreferences = (defaultThemeId?: string): ThemePreferences => {
     const storedMode = storedPreferences?.themeMode ?? null;
     const storedLightId = storedPreferences?.lightThemeId ?? null;
     const storedDarkId = storedPreferences?.darkThemeId ?? null;
+    // One-time migration seed: pre-scoped builds persisted theme state in
+    // these global keys. They are read only while no scoped entry exists —
+    // the persist effect then seeds the scoped key from these preferences and
+    // writeThemePreferencesForRuntime removes the global keys — so no
+    // client-only theme state is discarded before the authoritative server
+    // sync lands.
+    const legacyMode = localStorage.getItem('themeMode');
+    const legacyLightId = localStorage.getItem('lightThemeId');
+    const legacyDarkId = localStorage.getItem('darkThemeId');
+    const legacyUseSystem = localStorage.getItem('useSystemTheme');
+    const legacyThemeId = localStorage.getItem('selectedThemeId');
+    const legacyVariant = localStorage.getItem('selectedThemeVariant');
 
     if (embeddedMode === 'light' || embeddedMode === 'dark' || embeddedMode === 'system') {
       themeMode = embeddedMode;
     } else if (storedMode === 'light' || storedMode === 'dark' || storedMode === 'system') {
       themeMode = storedMode;
+    } else if (legacyMode === 'light' || legacyMode === 'dark' || legacyMode === 'system') {
+      themeMode = legacyMode;
+    } else if (legacyUseSystem !== null) {
+      const useSystem = legacyUseSystem === 'true';
+      if (useSystem) {
+        themeMode = 'system';
+      } else if (legacyThemeId) {
+        const legacyTheme = getThemeById(legacyThemeId);
+        if (legacyTheme) {
+          themeMode = legacyTheme.metadata.variant === 'dark' ? 'dark' : 'light';
+          if (legacyTheme.metadata.variant === 'dark') {
+            darkThemeId = legacyTheme.metadata.id;
+          } else {
+            lightThemeId = legacyTheme.metadata.id;
+          }
+        }
+      }
+    } else if (legacyVariant === 'light' || legacyVariant === 'dark') {
+      themeMode = legacyVariant;
     }
 
     if (typeof embeddedLightId === 'string' && embeddedLightId.trim().length > 0) {
       lightThemeId = embeddedLightId.trim();
     } else if (typeof storedLightId === 'string' && storedLightId.trim().length > 0) {
       lightThemeId = storedLightId.trim();
+    } else if (typeof legacyLightId === 'string' && legacyLightId.trim().length > 0) {
+      lightThemeId = legacyLightId.trim();
     }
 
     if (typeof embeddedDarkId === 'string' && embeddedDarkId.trim().length > 0) {
       darkThemeId = embeddedDarkId.trim();
     } else if (typeof storedDarkId === 'string' && storedDarkId.trim().length > 0) {
       darkThemeId = storedDarkId.trim();
+    } else if (typeof legacyDarkId === 'string' && legacyDarkId.trim().length > 0) {
+      darkThemeId = legacyDarkId.trim();
     }
   }
 

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -33,8 +33,8 @@ import { isValidTheme } from './theme-validation';
 import { getSyncedThemeFromPayload, getSyncedThemeVariant } from './theme-sync-payload';
 import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import {
-  getThemePreferencesStorageKey,
   readThemePreferencesForRuntime,
+  resolveThemePreferencesFromStorageEvent,
   writeThemePreferencesForRuntime,
 } from './theme-storage';
 
@@ -475,28 +475,7 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
         return;
       }
 
-      // Only same-runtime windows share the scoped key; windows pointing at a
-      // different instance write their own runtime's key and are ignored.
-      if (event.key !== getThemePreferencesStorageKey(getRuntimeKey())) {
-        return;
-      }
-
-      const stored = readThemePreferencesForRuntime(getRuntimeKey());
-      if (!stored) {
-        return;
-      }
-
-      setPreferences((prev) => {
-        if (prev.themeMode === stored.themeMode && prev.lightThemeId === stored.lightThemeId && prev.darkThemeId === stored.darkThemeId) {
-          return prev;
-        }
-
-        return {
-          themeMode: stored.themeMode,
-          lightThemeId: stored.lightThemeId,
-          darkThemeId: stored.darkThemeId,
-        };
-      });
+      setPreferences((prev) => resolveThemePreferencesFromStorageEvent(event.key, getRuntimeKey(), prev) ?? prev);
     };
 
     window.addEventListener('storage', handleStorage);

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -97,31 +97,11 @@ const buildInitialPreferences = (defaultThemeId?: string): ThemePreferences => {
     const storedMode = storedPreferences?.themeMode ?? null;
     const storedLightId = storedPreferences?.lightThemeId ?? null;
     const storedDarkId = storedPreferences?.darkThemeId ?? null;
-    const legacyUseSystem = localStorage.getItem('useSystemTheme');
-    const legacyThemeId = localStorage.getItem('selectedThemeId');
-    const legacyVariant = localStorage.getItem('selectedThemeVariant');
 
     if (embeddedMode === 'light' || embeddedMode === 'dark' || embeddedMode === 'system') {
       themeMode = embeddedMode;
     } else if (storedMode === 'light' || storedMode === 'dark' || storedMode === 'system') {
       themeMode = storedMode;
-    } else if (legacyUseSystem !== null) {
-      const useSystem = legacyUseSystem === 'true';
-      if (useSystem) {
-        themeMode = 'system';
-      } else if (legacyThemeId) {
-        const legacyTheme = getThemeById(legacyThemeId);
-        if (legacyTheme) {
-          themeMode = legacyTheme.metadata.variant === 'dark' ? 'dark' : 'light';
-          if (legacyTheme.metadata.variant === 'dark') {
-            darkThemeId = legacyTheme.metadata.id;
-          } else {
-            lightThemeId = legacyTheme.metadata.id;
-          }
-        }
-      }
-    } else if (legacyVariant === 'light' || legacyVariant === 'dark') {
-      themeMode = legacyVariant;
     }
 
     if (typeof embeddedLightId === 'string' && embeddedLightId.trim().length > 0) {
@@ -439,27 +419,7 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
       lightThemeId: preferences.lightThemeId,
       darkThemeId: preferences.darkThemeId,
     });
-
-    localStorage.setItem('themeMode', preferences.themeMode);
-    localStorage.setItem('lightThemeId', preferences.lightThemeId);
-    localStorage.setItem('darkThemeId', preferences.darkThemeId);
-    localStorage.setItem('useSystemTheme', String(preferences.themeMode === 'system'));
-    localStorage.setItem('selectedThemeId', currentTheme.metadata.id);
-    localStorage.setItem(
-      'selectedThemeVariant',
-      currentTheme.metadata.variant === 'light' ? 'light' : 'dark',
-    );
-
-    // Splash screen (packages/web/index.html) runs before the theme CSS vars load.
-    // Persist just enough to theme it on next boot.
-    const lightTheme = ensureThemeById(preferences.lightThemeId, 'light');
-    const darkTheme = ensureThemeById(preferences.darkThemeId, 'dark');
-
-    localStorage.setItem('splashBgLight', lightTheme.colors.surface.background);
-    localStorage.setItem('splashFgLight', lightTheme.colors.surface.foreground);
-    localStorage.setItem('splashBgDark', darkTheme.colors.surface.background);
-    localStorage.setItem('splashFgDark', darkTheme.colors.surface.foreground);
-  }, [preferences, currentTheme, ensureThemeById, receivesParentThemeSync]);
+  }, [preferences, receivesParentThemeSync]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -34,6 +34,7 @@ import { getSyncedThemeFromPayload, getSyncedThemeVariant } from './theme-sync-p
 import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import {
   readThemePreferencesForRuntime,
+  resolveThemePreferencesForRuntime,
   resolveThemePreferencesFromStorageEvent,
   writeThemePreferencesForRuntime,
 } from './theme-storage';
@@ -93,62 +94,27 @@ const buildInitialPreferences = (defaultThemeId?: string): ThemePreferences => {
     const embeddedMode = embeddedParams?.get('themeMode');
     const embeddedLightId = embeddedParams?.get('lightThemeId');
     const embeddedDarkId = embeddedParams?.get('darkThemeId');
-    const storedPreferences = readThemePreferencesForRuntime(getRuntimeKey());
-    const storedMode = storedPreferences?.themeMode ?? null;
-    const storedLightId = storedPreferences?.lightThemeId ?? null;
-    const storedDarkId = storedPreferences?.darkThemeId ?? null;
-    // One-time migration seed: pre-scoped builds persisted theme state in
-    // these global keys. They are read only while no scoped entry exists —
-    // the persist effect then seeds the scoped key from these preferences and
-    // writeThemePreferencesForRuntime removes the global keys — so no
-    // client-only theme state is discarded before the authoritative server
-    // sync lands.
-    const legacyMode = localStorage.getItem('themeMode');
-    const legacyLightId = localStorage.getItem('lightThemeId');
-    const legacyDarkId = localStorage.getItem('darkThemeId');
-    const legacyUseSystem = localStorage.getItem('useSystemTheme');
-    const legacyThemeId = localStorage.getItem('selectedThemeId');
-    const legacyVariant = localStorage.getItem('selectedThemeVariant');
+    // Scoped entry when present; otherwise a one-time seed from the superseded
+    // global keys (see resolveThemePreferencesForRuntime), so the first scoped
+    // write carries the last-known theme instead of defaults.
+    const resolvedPreferences = resolveThemePreferencesForRuntime(getRuntimeKey());
 
     if (embeddedMode === 'light' || embeddedMode === 'dark' || embeddedMode === 'system') {
       themeMode = embeddedMode;
-    } else if (storedMode === 'light' || storedMode === 'dark' || storedMode === 'system') {
-      themeMode = storedMode;
-    } else if (legacyMode === 'light' || legacyMode === 'dark' || legacyMode === 'system') {
-      themeMode = legacyMode;
-    } else if (legacyUseSystem !== null) {
-      const useSystem = legacyUseSystem === 'true';
-      if (useSystem) {
-        themeMode = 'system';
-      } else if (legacyThemeId) {
-        const legacyTheme = getThemeById(legacyThemeId);
-        if (legacyTheme) {
-          themeMode = legacyTheme.metadata.variant === 'dark' ? 'dark' : 'light';
-          if (legacyTheme.metadata.variant === 'dark') {
-            darkThemeId = legacyTheme.metadata.id;
-          } else {
-            lightThemeId = legacyTheme.metadata.id;
-          }
-        }
-      }
-    } else if (legacyVariant === 'light' || legacyVariant === 'dark') {
-      themeMode = legacyVariant;
+    } else {
+      themeMode = resolvedPreferences.themeMode;
     }
 
     if (typeof embeddedLightId === 'string' && embeddedLightId.trim().length > 0) {
       lightThemeId = embeddedLightId.trim();
-    } else if (typeof storedLightId === 'string' && storedLightId.trim().length > 0) {
-      lightThemeId = storedLightId.trim();
-    } else if (typeof legacyLightId === 'string' && legacyLightId.trim().length > 0) {
-      lightThemeId = legacyLightId.trim();
+    } else {
+      lightThemeId = resolvedPreferences.lightThemeId;
     }
 
     if (typeof embeddedDarkId === 'string' && embeddedDarkId.trim().length > 0) {
       darkThemeId = embeddedDarkId.trim();
-    } else if (typeof storedDarkId === 'string' && storedDarkId.trim().length > 0) {
-      darkThemeId = storedDarkId.trim();
-    } else if (typeof legacyDarkId === 'string' && legacyDarkId.trim().length > 0) {
-      darkThemeId = legacyDarkId.trim();
+    } else {
+      darkThemeId = resolvedPreferences.darkThemeId;
     }
   }
 

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -96,31 +96,11 @@ const buildInitialPreferences = (defaultThemeId?: string): ThemePreferences => {
     const storedMode = storedPreferences?.themeMode ?? null;
     const storedLightId = storedPreferences?.lightThemeId ?? null;
     const storedDarkId = storedPreferences?.darkThemeId ?? null;
-    const legacyUseSystem = localStorage.getItem('useSystemTheme');
-    const legacyThemeId = localStorage.getItem('selectedThemeId');
-    const legacyVariant = localStorage.getItem('selectedThemeVariant');
 
     if (embeddedMode === 'light' || embeddedMode === 'dark' || embeddedMode === 'system') {
       themeMode = embeddedMode;
     } else if (storedMode === 'light' || storedMode === 'dark' || storedMode === 'system') {
       themeMode = storedMode;
-    } else if (legacyUseSystem !== null) {
-      const useSystem = legacyUseSystem === 'true';
-      if (useSystem) {
-        themeMode = 'system';
-      } else if (legacyThemeId) {
-        const legacyTheme = getThemeById(legacyThemeId);
-        if (legacyTheme) {
-          themeMode = legacyTheme.metadata.variant === 'dark' ? 'dark' : 'light';
-          if (legacyTheme.metadata.variant === 'dark') {
-            darkThemeId = legacyTheme.metadata.id;
-          } else {
-            lightThemeId = legacyTheme.metadata.id;
-          }
-        }
-      }
-    } else if (legacyVariant === 'light' || legacyVariant === 'dark') {
-      themeMode = legacyVariant;
     }
 
     if (typeof embeddedLightId === 'string' && embeddedLightId.trim().length > 0) {
@@ -438,27 +418,7 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
       lightThemeId: preferences.lightThemeId,
       darkThemeId: preferences.darkThemeId,
     });
-
-    localStorage.setItem('themeMode', preferences.themeMode);
-    localStorage.setItem('lightThemeId', preferences.lightThemeId);
-    localStorage.setItem('darkThemeId', preferences.darkThemeId);
-    localStorage.setItem('useSystemTheme', String(preferences.themeMode === 'system'));
-    localStorage.setItem('selectedThemeId', currentTheme.metadata.id);
-    localStorage.setItem(
-      'selectedThemeVariant',
-      currentTheme.metadata.variant === 'light' ? 'light' : 'dark',
-    );
-
-    // Splash screen (packages/web/index.html) runs before the theme CSS vars load.
-    // Persist just enough to theme it on next boot.
-    const lightTheme = ensureThemeById(preferences.lightThemeId, 'light');
-    const darkTheme = ensureThemeById(preferences.darkThemeId, 'dark');
-
-    localStorage.setItem('splashBgLight', lightTheme.colors.surface.background);
-    localStorage.setItem('splashFgLight', lightTheme.colors.surface.foreground);
-    localStorage.setItem('splashBgDark', darkTheme.colors.surface.background);
-    localStorage.setItem('splashFgDark', darkTheme.colors.surface.foreground);
-  }, [preferences, currentTheme, ensureThemeById, receivesParentThemeSync]);
+  }, [preferences, receivesParentThemeSync]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -33,6 +33,7 @@ import { getSyncedThemeFromPayload, getSyncedThemeVariant } from './theme-sync-p
 import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import {
   readThemePreferencesForRuntime,
+  resolveThemePreferencesForRuntime,
   resolveThemePreferencesFromStorageEvent,
   writeThemePreferencesForRuntime,
 } from './theme-storage';
@@ -92,62 +93,27 @@ const buildInitialPreferences = (defaultThemeId?: string): ThemePreferences => {
     const embeddedMode = embeddedParams?.get('themeMode');
     const embeddedLightId = embeddedParams?.get('lightThemeId');
     const embeddedDarkId = embeddedParams?.get('darkThemeId');
-    const storedPreferences = readThemePreferencesForRuntime(getRuntimeKey());
-    const storedMode = storedPreferences?.themeMode ?? null;
-    const storedLightId = storedPreferences?.lightThemeId ?? null;
-    const storedDarkId = storedPreferences?.darkThemeId ?? null;
-    // One-time migration seed: pre-scoped builds persisted theme state in
-    // these global keys. They are read only while no scoped entry exists —
-    // the persist effect then seeds the scoped key from these preferences and
-    // writeThemePreferencesForRuntime removes the global keys — so no
-    // client-only theme state is discarded before the authoritative server
-    // sync lands.
-    const legacyMode = localStorage.getItem('themeMode');
-    const legacyLightId = localStorage.getItem('lightThemeId');
-    const legacyDarkId = localStorage.getItem('darkThemeId');
-    const legacyUseSystem = localStorage.getItem('useSystemTheme');
-    const legacyThemeId = localStorage.getItem('selectedThemeId');
-    const legacyVariant = localStorage.getItem('selectedThemeVariant');
+    // Scoped entry when present; otherwise a one-time seed from the superseded
+    // global keys (see resolveThemePreferencesForRuntime), so the first scoped
+    // write carries the last-known theme instead of defaults.
+    const resolvedPreferences = resolveThemePreferencesForRuntime(getRuntimeKey());
 
     if (embeddedMode === 'light' || embeddedMode === 'dark' || embeddedMode === 'system') {
       themeMode = embeddedMode;
-    } else if (storedMode === 'light' || storedMode === 'dark' || storedMode === 'system') {
-      themeMode = storedMode;
-    } else if (legacyMode === 'light' || legacyMode === 'dark' || legacyMode === 'system') {
-      themeMode = legacyMode;
-    } else if (legacyUseSystem !== null) {
-      const useSystem = legacyUseSystem === 'true';
-      if (useSystem) {
-        themeMode = 'system';
-      } else if (legacyThemeId) {
-        const legacyTheme = getThemeById(legacyThemeId);
-        if (legacyTheme) {
-          themeMode = legacyTheme.metadata.variant === 'dark' ? 'dark' : 'light';
-          if (legacyTheme.metadata.variant === 'dark') {
-            darkThemeId = legacyTheme.metadata.id;
-          } else {
-            lightThemeId = legacyTheme.metadata.id;
-          }
-        }
-      }
-    } else if (legacyVariant === 'light' || legacyVariant === 'dark') {
-      themeMode = legacyVariant;
+    } else {
+      themeMode = resolvedPreferences.themeMode;
     }
 
     if (typeof embeddedLightId === 'string' && embeddedLightId.trim().length > 0) {
       lightThemeId = embeddedLightId.trim();
-    } else if (typeof storedLightId === 'string' && storedLightId.trim().length > 0) {
-      lightThemeId = storedLightId.trim();
-    } else if (typeof legacyLightId === 'string' && legacyLightId.trim().length > 0) {
-      lightThemeId = legacyLightId.trim();
+    } else {
+      lightThemeId = resolvedPreferences.lightThemeId;
     }
 
     if (typeof embeddedDarkId === 'string' && embeddedDarkId.trim().length > 0) {
       darkThemeId = embeddedDarkId.trim();
-    } else if (typeof storedDarkId === 'string' && storedDarkId.trim().length > 0) {
-      darkThemeId = storedDarkId.trim();
-    } else if (typeof legacyDarkId === 'string' && legacyDarkId.trim().length > 0) {
-      darkThemeId = legacyDarkId.trim();
+    } else {
+      darkThemeId = resolvedPreferences.darkThemeId;
     }
   }
 

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -32,8 +32,8 @@ import { isValidTheme } from './theme-validation';
 import { getSyncedThemeFromPayload, getSyncedThemeVariant } from './theme-sync-payload';
 import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import {
-  getThemePreferencesStorageKey,
   readThemePreferencesForRuntime,
+  resolveThemePreferencesFromStorageEvent,
   writeThemePreferencesForRuntime,
 } from './theme-storage';
 
@@ -474,28 +474,7 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
         return;
       }
 
-      // Only same-runtime windows share the scoped key; windows pointing at a
-      // different instance write their own runtime's key and are ignored.
-      if (event.key !== getThemePreferencesStorageKey(getRuntimeKey())) {
-        return;
-      }
-
-      const stored = readThemePreferencesForRuntime(getRuntimeKey());
-      if (!stored) {
-        return;
-      }
-
-      setPreferences((prev) => {
-        if (prev.themeMode === stored.themeMode && prev.lightThemeId === stored.lightThemeId && prev.darkThemeId === stored.darkThemeId) {
-          return prev;
-        }
-
-        return {
-          themeMode: stored.themeMode,
-          lightThemeId: stored.lightThemeId,
-          darkThemeId: stored.darkThemeId,
-        };
-      });
+      setPreferences((prev) => resolveThemePreferencesFromStorageEvent(event.key, getRuntimeKey(), prev) ?? prev);
     };
 
     window.addEventListener('storage', handleStorage);

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -31,6 +31,11 @@ import {
 import { isValidTheme } from './theme-validation';
 import { getSyncedThemeFromPayload, getSyncedThemeVariant } from './theme-sync-payload';
 import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
+import {
+  getThemePreferencesStorageKey,
+  readThemePreferencesForRuntime,
+  writeThemePreferencesForRuntime,
+} from './theme-storage';
 
 type ThemePreferences = {
   themeMode: ThemeMode;
@@ -87,9 +92,10 @@ const buildInitialPreferences = (defaultThemeId?: string): ThemePreferences => {
     const embeddedMode = embeddedParams?.get('themeMode');
     const embeddedLightId = embeddedParams?.get('lightThemeId');
     const embeddedDarkId = embeddedParams?.get('darkThemeId');
-    const storedMode = localStorage.getItem('themeMode');
-    const storedLightId = localStorage.getItem('lightThemeId');
-    const storedDarkId = localStorage.getItem('darkThemeId');
+    const storedPreferences = readThemePreferencesForRuntime(getRuntimeKey());
+    const storedMode = storedPreferences?.themeMode ?? null;
+    const storedLightId = storedPreferences?.lightThemeId ?? null;
+    const storedDarkId = storedPreferences?.darkThemeId ?? null;
     const legacyUseSystem = localStorage.getItem('useSystemTheme');
     const legacyThemeId = localStorage.getItem('selectedThemeId');
     const legacyVariant = localStorage.getItem('selectedThemeVariant');
@@ -314,6 +320,9 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
     customThemesRequestRef.current += 1;
     setCustomThemes([]);
     setCustomThemesLoading(false);
+    // Adopt the new instance's last-known theme immediately; the incoming
+    // settings sync refines it with the server's authoritative value.
+    setPreferences((prev) => readThemePreferencesForRuntime(detail.runtimeKey) ?? prev);
     void reloadCustomThemes();
   }), [isVSCode, reloadCustomThemes]);
 
@@ -424,6 +433,12 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
       return;
     }
 
+    writeThemePreferencesForRuntime(getRuntimeKey(), {
+      themeMode: preferences.themeMode,
+      lightThemeId: preferences.lightThemeId,
+      darkThemeId: preferences.darkThemeId,
+    });
+
     localStorage.setItem('themeMode', preferences.themeMode);
     localStorage.setItem('lightThemeId', preferences.lightThemeId);
     localStorage.setItem('darkThemeId', preferences.darkThemeId);
@@ -459,35 +474,26 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
         return;
       }
 
-      if (event.key !== 'themeMode' && event.key !== 'lightThemeId' && event.key !== 'darkThemeId') {
+      // Only same-runtime windows share the scoped key; windows pointing at a
+      // different instance write their own runtime's key and are ignored.
+      if (event.key !== getThemePreferencesStorageKey(getRuntimeKey())) {
+        return;
+      }
+
+      const stored = readThemePreferencesForRuntime(getRuntimeKey());
+      if (!stored) {
         return;
       }
 
       setPreferences((prev) => {
-        const nextModeRaw = localStorage.getItem('themeMode');
-        const nextMode: ThemeMode =
-          nextModeRaw === 'light' || nextModeRaw === 'dark' || nextModeRaw === 'system'
-            ? nextModeRaw
-            : prev.themeMode;
-
-        const nextLightRaw = localStorage.getItem('lightThemeId');
-        const nextLight = typeof nextLightRaw === 'string' && nextLightRaw.trim().length > 0
-          ? nextLightRaw.trim()
-          : prev.lightThemeId;
-
-        const nextDarkRaw = localStorage.getItem('darkThemeId');
-        const nextDark = typeof nextDarkRaw === 'string' && nextDarkRaw.trim().length > 0
-          ? nextDarkRaw.trim()
-          : prev.darkThemeId;
-
-        if (nextMode === prev.themeMode && nextLight === prev.lightThemeId && nextDark === prev.darkThemeId) {
+        if (prev.themeMode === stored.themeMode && prev.lightThemeId === stored.lightThemeId && prev.darkThemeId === stored.darkThemeId) {
           return prev;
         }
 
         return {
-          themeMode: nextMode,
-          lightThemeId: nextLight,
-          darkThemeId: nextDark,
+          themeMode: stored.themeMode,
+          lightThemeId: stored.lightThemeId,
+          darkThemeId: stored.darkThemeId,
         };
       });
     };

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -96,23 +96,58 @@ const buildInitialPreferences = (defaultThemeId?: string): ThemePreferences => {
     const storedMode = storedPreferences?.themeMode ?? null;
     const storedLightId = storedPreferences?.lightThemeId ?? null;
     const storedDarkId = storedPreferences?.darkThemeId ?? null;
+    // One-time migration seed: pre-scoped builds persisted theme state in
+    // these global keys. They are read only while no scoped entry exists —
+    // the persist effect then seeds the scoped key from these preferences and
+    // writeThemePreferencesForRuntime removes the global keys — so no
+    // client-only theme state is discarded before the authoritative server
+    // sync lands.
+    const legacyMode = localStorage.getItem('themeMode');
+    const legacyLightId = localStorage.getItem('lightThemeId');
+    const legacyDarkId = localStorage.getItem('darkThemeId');
+    const legacyUseSystem = localStorage.getItem('useSystemTheme');
+    const legacyThemeId = localStorage.getItem('selectedThemeId');
+    const legacyVariant = localStorage.getItem('selectedThemeVariant');
 
     if (embeddedMode === 'light' || embeddedMode === 'dark' || embeddedMode === 'system') {
       themeMode = embeddedMode;
     } else if (storedMode === 'light' || storedMode === 'dark' || storedMode === 'system') {
       themeMode = storedMode;
+    } else if (legacyMode === 'light' || legacyMode === 'dark' || legacyMode === 'system') {
+      themeMode = legacyMode;
+    } else if (legacyUseSystem !== null) {
+      const useSystem = legacyUseSystem === 'true';
+      if (useSystem) {
+        themeMode = 'system';
+      } else if (legacyThemeId) {
+        const legacyTheme = getThemeById(legacyThemeId);
+        if (legacyTheme) {
+          themeMode = legacyTheme.metadata.variant === 'dark' ? 'dark' : 'light';
+          if (legacyTheme.metadata.variant === 'dark') {
+            darkThemeId = legacyTheme.metadata.id;
+          } else {
+            lightThemeId = legacyTheme.metadata.id;
+          }
+        }
+      }
+    } else if (legacyVariant === 'light' || legacyVariant === 'dark') {
+      themeMode = legacyVariant;
     }
 
     if (typeof embeddedLightId === 'string' && embeddedLightId.trim().length > 0) {
       lightThemeId = embeddedLightId.trim();
     } else if (typeof storedLightId === 'string' && storedLightId.trim().length > 0) {
       lightThemeId = storedLightId.trim();
+    } else if (typeof legacyLightId === 'string' && legacyLightId.trim().length > 0) {
+      lightThemeId = legacyLightId.trim();
     }
 
     if (typeof embeddedDarkId === 'string' && embeddedDarkId.trim().length > 0) {
       darkThemeId = embeddedDarkId.trim();
     } else if (typeof storedDarkId === 'string' && storedDarkId.trim().length > 0) {
       darkThemeId = storedDarkId.trim();
+    } else if (typeof legacyDarkId === 'string' && legacyDarkId.trim().length > 0) {
+      darkThemeId = legacyDarkId.trim();
     }
   }
 

--- a/packages/ui/src/contexts/ThemeSystemContext.tsx
+++ b/packages/ui/src/contexts/ThemeSystemContext.tsx
@@ -32,7 +32,7 @@ import { isValidTheme } from './theme-validation';
 import { getSyncedThemeFromPayload, getSyncedThemeVariant } from './theme-sync-payload';
 import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import {
-  readThemePreferencesForRuntime,
+  adoptThemePreferencesForRuntime,
   resolveThemePreferencesForRuntime,
   resolveThemePreferencesFromStorageEvent,
   writeThemePreferencesForRuntime,
@@ -303,7 +303,7 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
     setCustomThemesLoading(false);
     // Adopt the new instance's last-known theme immediately; the incoming
     // settings sync refines it with the server's authoritative value.
-    setPreferences((prev) => readThemePreferencesForRuntime(detail.runtimeKey) ?? prev);
+    setPreferences((prev) => adoptThemePreferencesForRuntime(detail.runtimeKey, prev));
     void reloadCustomThemes();
   }), [isVSCode, reloadCustomThemes]);
 
@@ -419,7 +419,30 @@ export function ThemeSystemProvider({ children, defaultThemeId }: ThemeSystemPro
       lightThemeId: preferences.lightThemeId,
       darkThemeId: preferences.darkThemeId,
     });
-  }, [preferences, receivesParentThemeSync]);
+
+    // Cosmetic last-writer-wins hints for the pre-React splash shells
+    // (packages/web/index.html, mobile.html, mini-chat.html) and the Android
+    // status bar, which run before the scoped key can be read. Not part of the
+    // app's theme authority — the scoped entry and the per-instance server
+    // settings own that.
+    localStorage.setItem('themeMode', preferences.themeMode);
+    localStorage.setItem('lightThemeId', preferences.lightThemeId);
+    localStorage.setItem('darkThemeId', preferences.darkThemeId);
+    localStorage.setItem('useSystemTheme', String(preferences.themeMode === 'system'));
+    localStorage.setItem('selectedThemeId', currentTheme.metadata.id);
+    localStorage.setItem(
+      'selectedThemeVariant',
+      currentTheme.metadata.variant === 'light' ? 'light' : 'dark',
+    );
+
+    const lightTheme = ensureThemeById(preferences.lightThemeId, 'light');
+    const darkTheme = ensureThemeById(preferences.darkThemeId, 'dark');
+
+    localStorage.setItem('splashBgLight', lightTheme.colors.surface.background);
+    localStorage.setItem('splashFgLight', lightTheme.colors.surface.foreground);
+    localStorage.setItem('splashBgDark', darkTheme.colors.surface.background);
+    localStorage.setItem('splashFgDark', darkTheme.colors.surface.foreground);
+  }, [preferences, currentTheme, ensureThemeById, receivesParentThemeSync]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {

--- a/packages/ui/src/contexts/theme-storage.test.ts
+++ b/packages/ui/src/contexts/theme-storage.test.ts
@@ -1,8 +1,11 @@
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 
+import { DEFAULT_DARK_THEME_ID, DEFAULT_LIGHT_THEME_ID } from '@/lib/theme/themes';
+
 import {
   getThemePreferencesStorageKey,
   readThemePreferencesForRuntime,
+  resolveThemePreferencesForRuntime,
   resolveThemePreferencesFromStorageEvent,
   writeThemePreferencesForRuntime,
 } from './theme-storage';
@@ -126,6 +129,62 @@ describe('theme preference runtime scoping', () => {
     expect(localStorage.getItem('splashBgDark')).toBeNull();
     expect(localStorage.getItem('splashFgDark')).toBeNull();
     expect(readThemePreferencesForRuntime('runtime-a')).toEqual(preferences);
+  });
+});
+
+describe('theme preference resolution chain', () => {
+  test('uses the scoped entry when present', () => {
+    writeThemePreferencesForRuntime('runtime-a', preferences);
+
+    expect(resolveThemePreferencesForRuntime('runtime-a')).toEqual(preferences);
+  });
+
+  test('seeds from the legacy mode and theme ids when no scoped entry exists', () => {
+    localStorage.setItem('themeMode', 'dark');
+    localStorage.setItem('lightThemeId', 'legacy-light');
+    localStorage.setItem('darkThemeId', 'legacy-dark');
+
+    expect(resolveThemePreferencesForRuntime('runtime-a')).toEqual({
+      themeMode: 'dark',
+      lightThemeId: 'legacy-light',
+      darkThemeId: 'legacy-dark',
+    });
+  });
+
+  test('seeds from the useSystemTheme/selectedThemeId legacy chain', () => {
+    localStorage.setItem('useSystemTheme', 'false');
+    localStorage.setItem('selectedThemeId', DEFAULT_DARK_THEME_ID);
+
+    expect(resolveThemePreferencesForRuntime('runtime-a')).toEqual({
+      themeMode: 'dark',
+      lightThemeId: DEFAULT_LIGHT_THEME_ID,
+      darkThemeId: DEFAULT_DARK_THEME_ID,
+    });
+  });
+
+  test('falls back to defaults when nothing is stored', () => {
+    expect(resolveThemePreferencesForRuntime('runtime-a')).toEqual({
+      themeMode: 'system',
+      lightThemeId: DEFAULT_LIGHT_THEME_ID,
+      darkThemeId: DEFAULT_DARK_THEME_ID,
+    });
+  });
+
+  test('the migrated seed survives into the scoped key with legacy keys removed', () => {
+    localStorage.setItem('themeMode', 'dark');
+    localStorage.setItem('lightThemeId', 'legacy-light');
+    localStorage.setItem('darkThemeId', 'legacy-dark');
+
+    writeThemePreferencesForRuntime('runtime-a', resolveThemePreferencesForRuntime('runtime-a'));
+
+    expect(readThemePreferencesForRuntime('runtime-a')).toEqual({
+      themeMode: 'dark',
+      lightThemeId: 'legacy-light',
+      darkThemeId: 'legacy-dark',
+    });
+    expect(localStorage.getItem('themeMode')).toBeNull();
+    expect(localStorage.getItem('lightThemeId')).toBeNull();
+    expect(localStorage.getItem('darkThemeId')).toBeNull();
   });
 });
 

--- a/packages/ui/src/contexts/theme-storage.test.ts
+++ b/packages/ui/src/contexts/theme-storage.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  getThemePreferencesStorageKey,
+  readThemePreferencesForRuntime,
+  writeThemePreferencesForRuntime,
+} from './theme-storage';
+
+let createdWindow = false;
+let createdLocalStorage = false;
+
+const ensureLocalStorage = (): void => {
+  if (typeof localStorage !== 'undefined') {
+    return;
+  }
+  const values = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+      },
+      removeItem: (key: string) => {
+        values.delete(key);
+      },
+      clear: () => {
+        values.clear();
+      },
+    },
+    configurable: true,
+    writable: true,
+  });
+  createdLocalStorage = true;
+};
+
+beforeEach(() => {
+  if (typeof window === 'undefined') {
+    Object.defineProperty(globalThis, 'window', {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+    createdWindow = true;
+  }
+  ensureLocalStorage();
+  localStorage.clear();
+});
+
+afterAll(() => {
+  if (createdWindow) {
+    delete (globalThis as { window?: unknown }).window;
+  }
+  if (createdLocalStorage) {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
+});
+
+const preferences = {
+  themeMode: 'dark' as const,
+  lightThemeId: 'light-theme',
+  darkThemeId: 'dark-theme',
+};
+
+describe('theme preference runtime scoping', () => {
+  test('keys differ per runtime', () => {
+    expect(getThemePreferencesStorageKey('runtime-a')).not.toBe(getThemePreferencesStorageKey('runtime-b'));
+  });
+
+  test('round-trips preferences for the same runtime', () => {
+    writeThemePreferencesForRuntime('runtime-a', preferences);
+
+    expect(readThemePreferencesForRuntime('runtime-a')).toEqual(preferences);
+  });
+
+  test('a window on one instance never reads another instance theme', () => {
+    writeThemePreferencesForRuntime('runtime-a', preferences);
+
+    expect(readThemePreferencesForRuntime('runtime-b')).toBeNull();
+  });
+
+  test('latest write wins per runtime without cross-instance effects', () => {
+    writeThemePreferencesForRuntime('runtime-a', preferences);
+    writeThemePreferencesForRuntime('runtime-b', { themeMode: 'light', lightThemeId: 'other-light', darkThemeId: 'other-dark' });
+
+    expect(readThemePreferencesForRuntime('runtime-a')).toEqual(preferences);
+    expect(readThemePreferencesForRuntime('runtime-b')).toEqual({
+      themeMode: 'light',
+      lightThemeId: 'other-light',
+      darkThemeId: 'other-dark',
+    });
+  });
+
+  test('malformed or invalid payloads are failure, not empty authority', () => {
+    localStorage.setItem(getThemePreferencesStorageKey('runtime-a'), 'not-json');
+    expect(readThemePreferencesForRuntime('runtime-a')).toBeNull();
+
+    localStorage.setItem(getThemePreferencesStorageKey('runtime-a'), JSON.stringify({ themeMode: 'neon' }));
+    expect(readThemePreferencesForRuntime('runtime-a')).toBeNull();
+
+    localStorage.setItem(
+      getThemePreferencesStorageKey('runtime-a'),
+      JSON.stringify({ themeMode: 'dark', lightThemeId: '', darkThemeId: 'dark-theme' }),
+    );
+    expect(readThemePreferencesForRuntime('runtime-a')).toBeNull();
+  });
+});

--- a/packages/ui/src/contexts/theme-storage.test.ts
+++ b/packages/ui/src/contexts/theme-storage.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import {
   getThemePreferencesStorageKey,
   readThemePreferencesForRuntime,
+  resolveThemePreferencesFromStorageEvent,
   writeThemePreferencesForRuntime,
 } from './theme-storage';
 
@@ -102,5 +103,44 @@ describe('theme preference runtime scoping', () => {
       JSON.stringify({ themeMode: 'dark', lightThemeId: '', darkThemeId: 'dark-theme' }),
     );
     expect(readThemePreferencesForRuntime('runtime-a')).toBeNull();
+  });
+});
+
+describe('theme storage event resolution', () => {
+  const current = { themeMode: 'system' as const, lightThemeId: 'light-theme', darkThemeId: 'dark-theme' };
+
+  test('adopts a storage event for the current runtime', () => {
+    writeThemePreferencesForRuntime('runtime-a', preferences);
+
+    expect(resolveThemePreferencesFromStorageEvent(getThemePreferencesStorageKey('runtime-a'), 'runtime-a', current)).toEqual(preferences);
+  });
+
+  test('ignores a storage event from another runtime', () => {
+    writeThemePreferencesForRuntime('runtime-b', preferences);
+
+    expect(resolveThemePreferencesFromStorageEvent(getThemePreferencesStorageKey('runtime-b'), 'runtime-a', current)).toBeNull();
+  });
+
+  test('ignores legacy global theme keys (revert-to-globals regression guard)', () => {
+    localStorage.setItem('themeMode', 'dark');
+    localStorage.setItem('lightThemeId', 'light-theme');
+    localStorage.setItem('darkThemeId', 'dark-theme');
+
+    expect(resolveThemePreferencesFromStorageEvent('themeMode', 'runtime-a', current)).toBeNull();
+    expect(resolveThemePreferencesFromStorageEvent('lightThemeId', 'runtime-a', current)).toBeNull();
+    expect(resolveThemePreferencesFromStorageEvent('darkThemeId', 'runtime-a', current)).toBeNull();
+  });
+
+  test('resolves to no change when stored preferences already match', () => {
+    writeThemePreferencesForRuntime('runtime-a', preferences);
+
+    expect(resolveThemePreferencesFromStorageEvent(getThemePreferencesStorageKey('runtime-a'), 'runtime-a', preferences)).toBeNull();
+  });
+
+  test('resolves to no change when nothing valid is stored', () => {
+    expect(resolveThemePreferencesFromStorageEvent(getThemePreferencesStorageKey('runtime-a'), 'runtime-a', current)).toBeNull();
+
+    localStorage.setItem(getThemePreferencesStorageKey('runtime-a'), 'not-json');
+    expect(resolveThemePreferencesFromStorageEvent(getThemePreferencesStorageKey('runtime-a'), 'runtime-a', current)).toBeNull();
   });
 });

--- a/packages/ui/src/contexts/theme-storage.test.ts
+++ b/packages/ui/src/contexts/theme-storage.test.ts
@@ -104,6 +104,29 @@ describe('theme preference runtime scoping', () => {
     );
     expect(readThemePreferencesForRuntime('runtime-a')).toBeNull();
   });
+
+  test('removes superseded global theme keys once the scoped key is written', () => {
+    localStorage.setItem('themeMode', 'dark');
+    localStorage.setItem('lightThemeId', 'light-theme');
+    localStorage.setItem('darkThemeId', 'dark-theme');
+    localStorage.setItem('useSystemTheme', 'false');
+    localStorage.setItem('selectedThemeId', 'dark-theme');
+    localStorage.setItem('selectedThemeVariant', 'dark');
+    localStorage.setItem('splashBgDark', '#0c0a09');
+    localStorage.setItem('splashFgDark', '#fafaf9');
+
+    writeThemePreferencesForRuntime('runtime-a', preferences);
+
+    expect(localStorage.getItem('themeMode')).toBeNull();
+    expect(localStorage.getItem('lightThemeId')).toBeNull();
+    expect(localStorage.getItem('darkThemeId')).toBeNull();
+    expect(localStorage.getItem('useSystemTheme')).toBeNull();
+    expect(localStorage.getItem('selectedThemeId')).toBeNull();
+    expect(localStorage.getItem('selectedThemeVariant')).toBeNull();
+    expect(localStorage.getItem('splashBgDark')).toBeNull();
+    expect(localStorage.getItem('splashFgDark')).toBeNull();
+    expect(readThemePreferencesForRuntime('runtime-a')).toEqual(preferences);
+  });
 });
 
 describe('theme storage event resolution', () => {

--- a/packages/ui/src/contexts/theme-storage.test.ts
+++ b/packages/ui/src/contexts/theme-storage.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import { DEFAULT_DARK_THEME_ID, DEFAULT_LIGHT_THEME_ID } from '@/lib/theme/themes';
 
 import {
+  adoptThemePreferencesForRuntime,
   getThemePreferencesStorageKey,
   readThemePreferencesForRuntime,
   resolveThemePreferencesForRuntime,
@@ -108,7 +109,7 @@ describe('theme preference runtime scoping', () => {
     expect(readThemePreferencesForRuntime('runtime-a')).toBeNull();
   });
 
-  test('removes superseded global theme keys once the scoped key is written', () => {
+  test('leaves the splash-hint and migration-seed globals untouched', () => {
     localStorage.setItem('themeMode', 'dark');
     localStorage.setItem('lightThemeId', 'light-theme');
     localStorage.setItem('darkThemeId', 'dark-theme');
@@ -120,14 +121,17 @@ describe('theme preference runtime scoping', () => {
 
     writeThemePreferencesForRuntime('runtime-a', preferences);
 
-    expect(localStorage.getItem('themeMode')).toBeNull();
-    expect(localStorage.getItem('lightThemeId')).toBeNull();
-    expect(localStorage.getItem('darkThemeId')).toBeNull();
-    expect(localStorage.getItem('useSystemTheme')).toBeNull();
-    expect(localStorage.getItem('selectedThemeId')).toBeNull();
-    expect(localStorage.getItem('selectedThemeVariant')).toBeNull();
-    expect(localStorage.getItem('splashBgDark')).toBeNull();
-    expect(localStorage.getItem('splashFgDark')).toBeNull();
+    // The scoped key owns the app theme; the global keys stay as cosmetic
+    // last-writer-wins hints for the pre-React splash shells and the Android
+    // status bar, and as the one-time migration seed for new runtimes.
+    expect(localStorage.getItem('themeMode')).toBe('dark');
+    expect(localStorage.getItem('lightThemeId')).toBe('light-theme');
+    expect(localStorage.getItem('darkThemeId')).toBe('dark-theme');
+    expect(localStorage.getItem('useSystemTheme')).toBe('false');
+    expect(localStorage.getItem('selectedThemeId')).toBe('dark-theme');
+    expect(localStorage.getItem('selectedThemeVariant')).toBe('dark');
+    expect(localStorage.getItem('splashBgDark')).toBe('#0c0a09');
+    expect(localStorage.getItem('splashFgDark')).toBe('#fafaf9');
     expect(readThemePreferencesForRuntime('runtime-a')).toEqual(preferences);
   });
 });
@@ -170,7 +174,7 @@ describe('theme preference resolution chain', () => {
     });
   });
 
-  test('the migrated seed survives into the scoped key with legacy keys removed', () => {
+  test('the migrated seed survives into the scoped key while the seed globals stay', () => {
     localStorage.setItem('themeMode', 'dark');
     localStorage.setItem('lightThemeId', 'legacy-light');
     localStorage.setItem('darkThemeId', 'legacy-dark');
@@ -182,9 +186,23 @@ describe('theme preference resolution chain', () => {
       lightThemeId: 'legacy-light',
       darkThemeId: 'legacy-dark',
     });
-    expect(localStorage.getItem('themeMode')).toBeNull();
-    expect(localStorage.getItem('lightThemeId')).toBeNull();
-    expect(localStorage.getItem('darkThemeId')).toBeNull();
+    expect(localStorage.getItem('themeMode')).toBe('dark');
+    expect(localStorage.getItem('lightThemeId')).toBe('legacy-light');
+    expect(localStorage.getItem('darkThemeId')).toBe('legacy-dark');
+  });
+});
+
+describe('runtime-switch adoption', () => {
+  const current = { themeMode: 'dark' as const, lightThemeId: 'current-light', darkThemeId: 'current-dark' };
+
+  test('adopts the target runtime stored theme when one exists', () => {
+    writeThemePreferencesForRuntime('runtime-b', preferences);
+
+    expect(adoptThemePreferencesForRuntime('runtime-b', current)).toEqual(preferences);
+  });
+
+  test('keeps the current preferences — same reference — when the target runtime has no entry', () => {
+    expect(adoptThemePreferencesForRuntime('runtime-empty', current)).toBe(current);
   });
 });
 

--- a/packages/ui/src/contexts/theme-storage.test.ts
+++ b/packages/ui/src/contexts/theme-storage.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_DARK_THEME_ID, DEFAULT_LIGHT_THEME_ID } from '@/lib/theme/theme
 import {
   adoptThemePreferencesForRuntime,
   getThemePreferencesStorageKey,
+  isTransientRuntimeKey,
   readThemePreferencesForRuntime,
   resolveThemePreferencesForRuntime,
   resolveThemePreferencesFromStorageEvent,
@@ -203,6 +204,49 @@ describe('runtime-switch adoption', () => {
 
   test('keeps the current preferences — same reference — when the target runtime has no entry', () => {
     expect(adoptThemePreferencesForRuntime('runtime-empty', current)).toBe(current);
+  });
+});
+
+describe('transient runtime keys', () => {
+  test('uninitialized and disconnected runtime keys are transient', () => {
+    expect(isTransientRuntimeKey('url:default')).toBe(true);
+    expect(isTransientRuntimeKey('mobile-disconnected')).toBe(true);
+    expect(isTransientRuntimeKey('')).toBe(true);
+    expect(isTransientRuntimeKey('local')).toBe(false);
+    expect(isTransientRuntimeKey('url:https://host.example')).toBe(false);
+  });
+
+  test('writes are skipped for transient runtimes — no stale cold-boot theme gets pinned', () => {
+    writeThemePreferencesForRuntime('url:default', preferences);
+    writeThemePreferencesForRuntime('mobile-disconnected', preferences);
+
+    expect(readThemePreferencesForRuntime('url:default')).toBeNull();
+    expect(readThemePreferencesForRuntime('mobile-disconnected')).toBeNull();
+    expect(localStorage.getItem(getThemePreferencesStorageKey('url:default'))).toBeNull();
+  });
+
+  test('reads never surface an entry under a transient key', () => {
+    localStorage.setItem(getThemePreferencesStorageKey('url:default'), JSON.stringify(preferences));
+
+    expect(readThemePreferencesForRuntime('url:default')).toBeNull();
+  });
+
+  test('boot resolution falls back to the global splash hints for transient runtimes', () => {
+    localStorage.setItem('themeMode', 'light');
+    localStorage.setItem('lightThemeId', 'legacy-light');
+    localStorage.setItem('darkThemeId', 'legacy-dark');
+
+    expect(resolveThemePreferencesForRuntime('url:default')).toEqual({
+      themeMode: 'light',
+      lightThemeId: 'legacy-light',
+      darkThemeId: 'legacy-dark',
+    });
+  });
+
+  test('endpoint-switch adoption keeps current preferences for transient runtimes', () => {
+    const current = { themeMode: 'light' as const, lightThemeId: 'light-theme', darkThemeId: 'dark-theme' };
+
+    expect(adoptThemePreferencesForRuntime('mobile-disconnected', current)).toBe(current);
   });
 });
 

--- a/packages/ui/src/contexts/theme-storage.ts
+++ b/packages/ui/src/contexts/theme-storage.ts
@@ -1,0 +1,63 @@
+import type { ThemeMode } from '@/types/theme';
+
+type StoredThemePreferences = {
+  themeMode: ThemeMode;
+  lightThemeId: string;
+  darkThemeId: string;
+};
+
+// Theme preferences are scoped per runtime endpoint, like the settings mirror
+// (lib/persistence.ts), so windows pointing at different instances never
+// overwrite or adopt each other's theme through shared localStorage.
+const THEME_PREFERENCES_KEY_PREFIX = 'openchamber.theme.v2:';
+
+export const getThemePreferencesStorageKey = (runtimeKey: string): string =>
+  `${THEME_PREFERENCES_KEY_PREFIX}${encodeURIComponent(runtimeKey)}`;
+
+export const readThemePreferencesForRuntime = (runtimeKey: string): StoredThemePreferences | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(getThemePreferencesStorageKey(runtimeKey));
+  } catch {
+    return null;
+  }
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    const candidate = parsed as Record<string, unknown>;
+    if (candidate.themeMode !== 'light' && candidate.themeMode !== 'dark' && candidate.themeMode !== 'system') {
+      return null;
+    }
+    if (typeof candidate.lightThemeId !== 'string' || typeof candidate.darkThemeId !== 'string') {
+      return null;
+    }
+    const lightThemeId = candidate.lightThemeId.trim();
+    const darkThemeId = candidate.darkThemeId.trim();
+    if (!lightThemeId || !darkThemeId) {
+      return null;
+    }
+    return { themeMode: candidate.themeMode, lightThemeId, darkThemeId };
+  } catch {
+    return null;
+  }
+};
+
+export const writeThemePreferencesForRuntime = (runtimeKey: string, preferences: StoredThemePreferences): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(getThemePreferencesStorageKey(runtimeKey), JSON.stringify(preferences));
+  } catch {
+    // localStorage unavailable (e.g. read-only contextBridge) — the server
+    // settings sync remains authoritative and the app still works.
+  }
+};

--- a/packages/ui/src/contexts/theme-storage.ts
+++ b/packages/ui/src/contexts/theme-storage.ts
@@ -9,6 +9,12 @@ type StoredThemePreferences = {
 // Theme preferences are scoped per runtime endpoint, like the settings mirror
 // (lib/persistence.ts), so windows pointing at different instances never
 // overwrite or adopt each other's theme through shared localStorage.
+//
+// Retention is intentionally unbounded, unlike the mirror's capped 5-runtime
+// index: each entry is ~150 bytes, the count is bounded by the distinct
+// instances ever visited from this origin, and evicting old entries would only
+// discard the last-known theme for rarely visited instances while saving
+// trivial space.
 const THEME_PREFERENCES_KEY_PREFIX = 'openchamber.theme.v2:';
 
 export const getThemePreferencesStorageKey = (runtimeKey: string): string =>
@@ -60,4 +66,29 @@ export const writeThemePreferencesForRuntime = (runtimeKey: string, preferences:
     // localStorage unavailable (e.g. read-only contextBridge) — the server
     // settings sync remains authoritative and the app still works.
   }
+};
+
+/**
+ * Resolve the preferences a cross-window storage event should apply for the
+ * current runtime. Returns null — meaning "keep current preferences" — when
+ * the event targets another runtime's key, when no valid stored preferences
+ * exist, or when the stored preferences already match the current ones (the
+ * identity check breaks cross-window adoption loops).
+ */
+export const resolveThemePreferencesFromStorageEvent = (
+  eventKey: string | null,
+  runtimeKey: string,
+  current: StoredThemePreferences,
+): StoredThemePreferences | null => {
+  if (eventKey !== getThemePreferencesStorageKey(runtimeKey)) {
+    return null;
+  }
+  const stored = readThemePreferencesForRuntime(runtimeKey);
+  if (!stored) {
+    return null;
+  }
+  if (stored.themeMode === current.themeMode && stored.lightThemeId === current.lightThemeId && stored.darkThemeId === current.darkThemeId) {
+    return null;
+  }
+  return stored;
 };

--- a/packages/ui/src/contexts/theme-storage.ts
+++ b/packages/ui/src/contexts/theme-storage.ts
@@ -17,6 +17,22 @@ type StoredThemePreferences = {
 // trivial space.
 const THEME_PREFERENCES_KEY_PREFIX = 'openchamber.theme.v2:';
 
+// Superseded by the per-runtime key. Removed once the scoped key is written so
+// theme persistence has a single owner; the pre-React HTML shells that read
+// them (splash theme class and colors) have their own fallbacks.
+const LEGACY_THEME_KEYS = [
+  'themeMode',
+  'lightThemeId',
+  'darkThemeId',
+  'useSystemTheme',
+  'selectedThemeId',
+  'selectedThemeVariant',
+  'splashBgLight',
+  'splashFgLight',
+  'splashBgDark',
+  'splashFgDark',
+] as const;
+
 export const getThemePreferencesStorageKey = (runtimeKey: string): string =>
   `${THEME_PREFERENCES_KEY_PREFIX}${encodeURIComponent(runtimeKey)}`;
 
@@ -65,6 +81,17 @@ export const writeThemePreferencesForRuntime = (runtimeKey: string, preferences:
   } catch {
     // localStorage unavailable (e.g. read-only contextBridge) — the server
     // settings sync remains authoritative and the app still works.
+    return;
+  }
+  // One-time migration: keep the legacy keys only if the scoped write failed,
+  // otherwise remove them (removal is best-effort; a stale key only affects
+  // the pre-React splash, which falls back to system preference and defaults).
+  for (const key of LEGACY_THEME_KEYS) {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // ignore — best-effort cleanup
+    }
   }
 };
 

--- a/packages/ui/src/contexts/theme-storage.ts
+++ b/packages/ui/src/contexts/theme-storage.ts
@@ -1,4 +1,5 @@
 import type { ThemeMode } from '@/types/theme';
+import { DEFAULT_DARK_THEME_ID, DEFAULT_LIGHT_THEME_ID, getThemeById } from '@/lib/theme/themes';
 
 type StoredThemePreferences = {
   themeMode: ThemeMode;
@@ -118,4 +119,67 @@ export const resolveThemePreferencesFromStorageEvent = (
     return null;
   }
   return stored;
+};
+
+// One-time migration seed: pre-scoped builds persisted theme state in these
+// global keys. They are resolved only while no scoped entry exists — the
+// persist effect then seeds the scoped key from the returned preferences and
+// writeThemePreferencesForRuntime removes the global keys — so no client-only
+// theme state is discarded before the authoritative server sync lands.
+const readLegacyThemePreferences = (): StoredThemePreferences => {
+  let themeMode: ThemeMode = 'system';
+  let lightThemeId: string = DEFAULT_LIGHT_THEME_ID;
+  let darkThemeId: string = DEFAULT_DARK_THEME_ID;
+
+  if (typeof window === 'undefined') {
+    return { themeMode, lightThemeId, darkThemeId };
+  }
+
+  const legacyMode = localStorage.getItem('themeMode');
+  const legacyUseSystem = localStorage.getItem('useSystemTheme');
+  const legacyThemeId = localStorage.getItem('selectedThemeId');
+  const legacyVariant = localStorage.getItem('selectedThemeVariant');
+
+  if (legacyMode === 'light' || legacyMode === 'dark' || legacyMode === 'system') {
+    themeMode = legacyMode;
+  } else if (legacyUseSystem !== null) {
+    const useSystem = legacyUseSystem === 'true';
+    if (useSystem) {
+      themeMode = 'system';
+    } else if (legacyThemeId) {
+      const legacyTheme = getThemeById(legacyThemeId);
+      if (legacyTheme) {
+        themeMode = legacyTheme.metadata.variant === 'dark' ? 'dark' : 'light';
+        if (legacyTheme.metadata.variant === 'dark') {
+          darkThemeId = legacyTheme.metadata.id;
+        } else {
+          lightThemeId = legacyTheme.metadata.id;
+        }
+      }
+    }
+  } else if (legacyVariant === 'light' || legacyVariant === 'dark') {
+    themeMode = legacyVariant;
+  }
+
+  const legacyLightId = localStorage.getItem('lightThemeId');
+  const legacyDarkId = localStorage.getItem('darkThemeId');
+  if (typeof legacyLightId === 'string' && legacyLightId.trim().length > 0) {
+    lightThemeId = legacyLightId.trim();
+  }
+  if (typeof legacyDarkId === 'string' && legacyDarkId.trim().length > 0) {
+    darkThemeId = legacyDarkId.trim();
+  }
+
+  return { themeMode, lightThemeId, darkThemeId };
+};
+
+/**
+ * Resolve the preferences for a runtime at boot: the scoped entry when one
+ * exists, otherwise a one-time seed from the superseded global keys, otherwise
+ * defaults. The seed guarantees the first scoped write carries the last-known
+ * theme instead of defaults.
+ */
+export const resolveThemePreferencesForRuntime = (runtimeKey: string): StoredThemePreferences => {
+  const stored = readThemePreferencesForRuntime(runtimeKey);
+  return stored ?? readLegacyThemePreferences();
 };

--- a/packages/ui/src/contexts/theme-storage.ts
+++ b/packages/ui/src/contexts/theme-storage.ts
@@ -18,22 +18,6 @@ type StoredThemePreferences = {
 // trivial space.
 const THEME_PREFERENCES_KEY_PREFIX = 'openchamber.theme.v2:';
 
-// Superseded by the per-runtime key. Removed once the scoped key is written so
-// theme persistence has a single owner; the pre-React HTML shells that read
-// them (splash theme class and colors) have their own fallbacks.
-const LEGACY_THEME_KEYS = [
-  'themeMode',
-  'lightThemeId',
-  'darkThemeId',
-  'useSystemTheme',
-  'selectedThemeId',
-  'selectedThemeVariant',
-  'splashBgLight',
-  'splashFgLight',
-  'splashBgDark',
-  'splashFgDark',
-] as const;
-
 export const getThemePreferencesStorageKey = (runtimeKey: string): string =>
   `${THEME_PREFERENCES_KEY_PREFIX}${encodeURIComponent(runtimeKey)}`;
 
@@ -82,17 +66,6 @@ export const writeThemePreferencesForRuntime = (runtimeKey: string, preferences:
   } catch {
     // localStorage unavailable (e.g. read-only contextBridge) — the server
     // settings sync remains authoritative and the app still works.
-    return;
-  }
-  // One-time migration: keep the legacy keys only if the scoped write failed,
-  // otherwise remove them (removal is best-effort; a stale key only affects
-  // the pre-React splash, which falls back to system preference and defaults).
-  for (const key of LEGACY_THEME_KEYS) {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // ignore — best-effort cleanup
-    }
   }
 };
 
@@ -123,9 +96,11 @@ export const resolveThemePreferencesFromStorageEvent = (
 
 // One-time migration seed: pre-scoped builds persisted theme state in these
 // global keys. They are resolved only while no scoped entry exists — the
-// persist effect then seeds the scoped key from the returned preferences and
-// writeThemePreferencesForRuntime removes the global keys — so no client-only
-// theme state is discarded before the authoritative server sync lands.
+// persist effect then seeds the scoped key from the returned preferences — so
+// no client-only theme state is discarded before the authoritative server sync
+// lands. The keys themselves stay (see ThemeSystemContext's persist effect):
+// the pre-React splash shells and the Android status bar read them as
+// cosmetic last-writer-wins hints.
 const readLegacyThemePreferences = (): StoredThemePreferences => {
   let themeMode: ThemeMode = 'system';
   let lightThemeId: string = DEFAULT_LIGHT_THEME_ID;
@@ -183,3 +158,15 @@ export const resolveThemePreferencesForRuntime = (runtimeKey: string): StoredThe
   const stored = readThemePreferencesForRuntime(runtimeKey);
   return stored ?? readLegacyThemePreferences();
 };
+
+/**
+ * Adopt another runtime's stored preferences when the endpoint switches: the
+ * new runtime's scoped entry when one exists, otherwise the current
+ * preferences unchanged (the same reference — no re-render, no write-through)
+ * until the incoming settings sync refines with the server's authoritative
+ * value.
+ */
+export const adoptThemePreferencesForRuntime = (
+  runtimeKey: string,
+  current: StoredThemePreferences,
+): StoredThemePreferences => readThemePreferencesForRuntime(runtimeKey) ?? current;

--- a/packages/ui/src/contexts/theme-storage.ts
+++ b/packages/ui/src/contexts/theme-storage.ts
@@ -21,8 +21,20 @@ const THEME_PREFERENCES_KEY_PREFIX = 'openchamber.theme.v2:';
 export const getThemePreferencesStorageKey = (runtimeKey: string): string =>
   `${THEME_PREFERENCES_KEY_PREFIX}${encodeURIComponent(runtimeKey)}`;
 
+// Runtime keys that mean "no instance connected" — the uninitialized default
+// and the mobile disconnect state. They carry no instance theme, so scoped
+// storage must not read or write them: a write would pin whatever theme was
+// current at that moment (e.g. cold-boot defaults) to a key every future
+// launch resolves before connecting, and a read would surface that stale
+// entry on the mobile connect splash. The global splash hints are the right
+// fallback for those phases.
+const TRANSIENT_RUNTIME_KEYS = new Set(['', 'url:default', 'mobile-disconnected']);
+
+export const isTransientRuntimeKey = (runtimeKey: string): boolean =>
+  TRANSIENT_RUNTIME_KEYS.has(runtimeKey);
+
 export const readThemePreferencesForRuntime = (runtimeKey: string): StoredThemePreferences | null => {
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || isTransientRuntimeKey(runtimeKey)) {
     return null;
   }
   let raw: string | null = null;
@@ -58,7 +70,7 @@ export const readThemePreferencesForRuntime = (runtimeKey: string): StoredThemeP
 };
 
 export const writeThemePreferencesForRuntime = (runtimeKey: string, preferences: StoredThemePreferences): void => {
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || isTransientRuntimeKey(runtimeKey)) {
     return;
   }
   try {

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -106,11 +106,6 @@ const persistToLocalStorage = (settings: DesktopSettings) => {
   }
 
   persistRuntimeSettingsMirror(settings, getRuntimeKey());
-  setOrRemoveLocalStorage('selectedThemeId', settings.themeId || null);
-  setOrRemoveLocalStorage('selectedThemeVariant', settings.themeVariant || null);
-  setOrRemoveLocalStorage('lightThemeId', settings.lightThemeId || null);
-  setOrRemoveLocalStorage('darkThemeId', settings.darkThemeId || null);
-  setOrRemoveLocalStorage('useSystemTheme', typeof settings.useSystemTheme === 'boolean' ? String(settings.useSystemTheme) : null);
   setOrRemoveLocalStorage('lastDirectory', settings.lastDirectory || null);
   if (settings.homeDirectory) {
     localStorage.setItem('homeDirectory', settings.homeDirectory);

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -100,11 +100,6 @@ const persistToLocalStorage = (settings: DesktopSettings) => {
   }
 
   persistRuntimeSettingsMirror(settings, getRuntimeKey());
-  setOrRemoveLocalStorage('selectedThemeId', settings.themeId || null);
-  setOrRemoveLocalStorage('selectedThemeVariant', settings.themeVariant || null);
-  setOrRemoveLocalStorage('lightThemeId', settings.lightThemeId || null);
-  setOrRemoveLocalStorage('darkThemeId', settings.darkThemeId || null);
-  setOrRemoveLocalStorage('useSystemTheme', typeof settings.useSystemTheme === 'boolean' ? String(settings.useSystemTheme) : null);
   setOrRemoveLocalStorage('lastDirectory', settings.lastDirectory || null);
   if (settings.homeDirectory) {
     localStorage.setItem('homeDirectory', settings.homeDirectory);


### PR DESCRIPTION
## Intent

Two same-origin windows pointed at different OpenChamber instances (Electron windows all load the UI from `openchamber-ui://`, and same-origin web paths share localStorage) shared a single theme: theme preferences were persisted to unscoped global localStorage keys (`themeMode`, `lightThemeId`, `darkThemeId` plus legacy `useSystemTheme`/`selectedThemeId`/`selectedThemeVariant`). Consequences: a window booted with the other instance's theme, the cross-window `storage` listener live-applied the other window's theme (both windows flip-flopped), and `persistToLocalStorage` clobbered the globals on every settings sync from any instance.

The change scopes theme preferences per runtime endpoint, mirroring the existing per-runtime settings-mirror pattern (`openchamber.settingsMirror.v2:<runtimeKey>`), so every window uses the settings of the instance it points at.

Implementation path:

- New `packages/ui/src/contexts/theme-storage.ts`: per-runtime scoped persistence (`openchamber.theme.v2:<runtimeKey>`), with validated reads (malformed payloads are failure, not authority) and transient-runtime-key guarding (uninitialized `url:default` / disconnected `mobile-disconnected` keys never participate in scoped storage).
- `packages/ui/src/contexts/ThemeSystemContext.tsx`: boots from `resolveThemePreferencesForRuntime` (scoped entry, else the superseded global keys as a one-time migration seed, else defaults); the persist effect writes the scoped key and maintains the splash-hint globals; the cross-window `storage` listener reacts only to the current runtime's key (same-instance windows keep live sync, different instances are isolated); runtime endpoint switches re-adopt the new instance's last-known theme.
- `packages/ui/src/lib/persistence.ts`: removed the redundant global theme-key writes — the per-runtime settings mirror already carries those fields, and theme persistence is now single-owner.
- `packages/ui/src/apps/mobileNativeChrome.ts`: the Android status bar re-applies its style/background whenever the root dark/light class flips (previously only on mount and app re-activation), so theme toggles update the status-bar text contrast immediately, without an app restart.

## Non-goals

- Other appearance settings (font size, fonts, padding, corner radius, terminal options) remain per-instance server settings; their shared client cache (`ui-store` zustand blob) is intentionally not re-scoped in this PR.
- Window-controls position/style stay instance-scoped server settings (no client-local chrome store introduced).
- The pre-React splash-hint globals (`themeMode`/`selectedThemeVariant`/`useSystemTheme`/`splashBg*`/`splashFg*`) stay as cosmetic last-writer-wins keys maintained by the persist effect — they feed the splash shells and the Android status bar and are explicitly not theme authority (per maintainer review). The Electron native splash reads per-instance server settings.

## Affected surfaces

- `packages/ui` — shared React UI consumed by web, Electron, VS Code, and mobile; theme persistence routes through this shared code in every runtime, so no runtime-specific branch was added.
- Persisted contract: theme authority moves to per-runtime `openchamber.theme.v2:<runtimeKey>`; transient runtime keys (uninitialized/disconnected) are excluded from scoped storage so cold-boot defaults can never pin a stale theme to the pre-connect phase. On first boot without a scoped entry, the legacy global keys (`themeMode`/`lightThemeId`/`darkThemeId`/`useSystemTheme`/`selectedThemeId`/`selectedThemeVariant`) are read once as a migration seed so no client-only theme state is discarded before the server sync lands. The globals are never deleted: the persist effect keeps them fresh as cosmetic last-writer-wins hints for the pre-React splash shells and the Android status bar. Older builds cannot read the scoped key and keep using the globals, so rollback works unchanged.
- `persistToLocalStorage` no longer writes theme globals; the settings mirror and server-side per-instance settings are unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Theme persistence is shared-UI state crossing runtime boundaries; the change alters persisted state | Runtime-scoped keys follow the existing settings-mirror pattern; authoritative per-instance server settings still win via `settings-synced`; minimal diff with no unrelated refactors |
| `sync-state-invariants` (skill) | Runtime-scoped persisted state and cross-window reconciliation | Caches keyed by runtime identity; persisted payload shape validated before granting authority (malformed → null, never empty success); same-runtime windows still sync, cross-runtime writes are ignored; retention is explicit: intentionally unbounded (module comment) because entries are ~150 bytes and bounded by distinct instances ever visited |
| `theme-system` (skill) | Theme state and persistence are the subject of the change | Theme mode/light/dark semantics preserved; no token or visual changes |
| `openchamber-change-discipline` (skill) | Source change with a persisted-contract dimension and two new files | Smallest complete change; legacy keys kept as migration fallback for existing persisted data; removed writes had no remaining in-app reader (verified by grep); dead-code and package-scoped checks run |
| `ui-api-decoupling` (skill) | Runtime key resolution and endpoint-switch safety | Runtime key resolved at call time in every handler (no cached keys); host switches re-read the new runtime's scoped preferences |
| Not applicable | `settings-ui-patterns` (no Settings UI changed), `locale-ui-patterns` (no user-facing strings), `desktop-shell`/`relay-transport` (no Electron/transport code changed) | — |

## Validation

| Check | Result |
|---|---|
| `bun test contexts/theme-storage.test.ts contexts/ThemeSystemContext.test.ts lib/persistence.test.ts` (packages/ui) | 60 pass, 0 fail — 23 theme-storage tests: per-runtime isolation, round-trip, malformed-payload rejection, splash-hint globals preserved on scoped write, the migration-seed resolution chain (scoped → legacy → defaults), runtime-switch adoption (adopt-or-keep), transient-runtime-key guarding (uninitialized/disconnected keys never read or write scoped entries — the mobile connect splash falls back to the global hints), and storage-event resolution (current-runtime adoption, foreign-runtime and legacy-key ignoring, no-change identity check) |
| `bun test` (full packages/ui suite) | 1981 pass / 202 fail — failure count identical with and without this change (pre-existing environment failures, e.g. codemirror bundling); no change-induced failures |
| `bun run type-check` (packages/ui) | clean |
| `bun run lint` (packages/ui) | clean |
| `bun run dead-code` (workspace) | no findings for the changed/new files |
| Manual: two windows against two loopback instances | Each window follows its own instance's theme; no cross-window flip-flop (see visual evidence) |
| Manual: packaged-Electron live host switch | Theme follows each instance through host switches in the packaged app |
| Manual: Android device | Light/dark toggle updates the status-bar text contrast immediately; cold-boot splash and connecting phases follow the persisted theme (transient-key fix verified on device) |

Not verified: iOS status-bar behavior (unchanged by this PR — the live adaptation is Android-only; iOS keeps `Style.Default` with overlay).

## Visual evidence

<img width="1577" height="955" alt="2026-08-14_12-03" src="https://github.com/user-attachments/assets/d2b275c5-8da2-47f8-a3cf-003deec3c6f8" />


Two same-origin windows pointed at different instances: each window stays on its own instance's theme simultaneously — no flip-flopping or shared theme.

## Risks and failure behavior

- Migration: on first boot after upgrade, an instance without a scoped entry is seeded from the global keys (last-known theme) into its scoped entry; the globals stay as splash hints. A flash exists only for instances never visited before this change, then authoritative server values apply. Malformed scoped payloads are rejected (null) — defaults + server sync apply, no crash, no stale authority.
- Cross-window behavior: same-instance windows keep live theme sync (storage listener keyed per runtime); different-instance windows are fully isolated.
- Rollback: older builds keep reading/writing the global keys, which remain maintained, so a downgrade works unchanged.
- No secrets, no new dependencies, localStorage only.
- Race audit (2+ windows): adoption writes are no-ops (identical-value `setItem` fires no event) and the reducer identity check returns the same state — every cross-window path converges. The only transient race is a boot-time rollback of a concurrent local theme change by another window's in-flight server fetch (pre-existing; the old code had more writers, so it was worse before).




