### PR TITLE
feat: ?session=recent per Home Assistant embedded panel

### DIFF
--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
@@ -69,7 +69,7 @@ export function resolveMissingProjectSessionSelection<T>({
         ([projectId, sessions]) => projectId !== activeProjectId && sessions.has(currentSessionId),
       ),
     );
-    if (currentSessionId && projectMap && !currentSessionBelongsToAnotherProject) {
+    if (currentSessionId && !currentSessionBelongsToAnotherProject) {
       return { kind: 'preserve-current' };
     }
   }

--- a/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
+++ b/packages/ui/src/components/session/sidebar/hooks/useProjectSessionSelection.ts
@@ -21,7 +21,7 @@ type Args = {
   handleSessionSelect: (sessionId: string, sessionDirectory: string | null) => void;
   newSessionDraftOpen: boolean;
   mobileVariant: boolean;
-  openNewSessionDraft: (options?: { selectedProjectId?: string | null; directoryOverride?: string | null }) => void;
+  openNewSessionDraft: (options?: { automatic?: boolean; selectedProjectId?: string | null; directoryOverride?: string | null }) => void;
   setActiveMainTab: (tab: MainTab) => void;
   setSessionSwitcherOpen: (open: boolean) => void;
 };
@@ -210,6 +210,7 @@ export const useProjectSessionSelection = (args: Args): void => {
         setSessionSwitcherOpen(false);
       }
       openNewSessionDraft({
+        automatic: true,
         selectedProjectId: section.project.id,
         directoryOverride: section.project.normalizedPath,
       });

--- a/packages/ui/src/hooks/useRouter.ts
+++ b/packages/ui/src/hooks/useRouter.ts
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useUIStore } from '@/stores/useUIStore';
-import { parseRoute, updateBrowserURL, hasRouteParams } from '@/lib/router';
+import { parseRoute, updateBrowserURL, hasRouteParams, RECENT_SESSION_TOKEN } from '@/lib/router';
 import type { RouteState, AppRouteState } from '@/lib/router';
 import type { MainTab } from '@/stores/useUIStore';
 import { resolveSettingsSlug } from '@/lib/settings/metadata';
+import { resolveRecentSession } from '@/lib/recentSession';
 import { isEmbeddedSessionChat } from '@/components/layout/contextPanelEmbeddedChat';
 
 /**
@@ -68,10 +69,30 @@ export function useRouter(): void {
       try {
         // 1. Apply session first (may trigger async operations)
         if (route.sessionId) {
-          const currentSessionId = useSessionUIStore.getState().currentSessionId;
-          if (route.sessionId !== currentSessionId) {
-            const directoryHint = useSessionUIStore.getState().getDirectoryForSession(route.sessionId);
-            setCurrentSession(route.sessionId, directoryHint);
+          let targetSessionId: string | null = route.sessionId;
+          let directoryHint: string | null | undefined;
+
+          if (route.sessionId === RECENT_SESSION_TOKEN) {
+            // `?session=recent` resolves to the last active session for this
+            // runtime. When there is no usable persisted session (never opened
+            // one, or the persisted one is gone), fall through to the default
+            // new-session behavior without opening anything.
+            const resolved = await resolveRecentSession();
+            if (!resolved) {
+              targetSessionId = null;
+            } else {
+              targetSessionId = resolved.sessionId;
+              directoryHint = resolved.directory;
+            }
+          } else {
+            directoryHint = useSessionUIStore.getState().getDirectoryForSession(targetSessionId);
+          }
+
+          if (targetSessionId) {
+            const currentSessionId = useSessionUIStore.getState().currentSessionId;
+            if (targetSessionId !== currentSessionId) {
+              setCurrentSession(targetSessionId, directoryHint ?? undefined);
+            }
           }
         }
 

--- a/packages/ui/src/hooks/useRouter.ts
+++ b/packages/ui/src/hooks/useRouter.ts
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useUIStore } from '@/stores/useUIStore';
-import { parseRoute, updateBrowserURL, hasRouteParams, RECENT_SESSION_TOKEN } from '@/lib/router';
+import { parseRoute, updateBrowserURL, hasRouteParams } from '@/lib/router';
 import type { RouteState, AppRouteState } from '@/lib/router';
 import type { MainTab } from '@/stores/useUIStore';
 import { resolveSettingsSlug } from '@/lib/settings/metadata';
-import { resolveRecentSession } from '@/lib/recentSession';
+import { resolveRecentSession, resolveRouteSessionToken } from '@/lib/recentSession';
 import { isEmbeddedSessionChat } from '@/components/layout/contextPanelEmbeddedChat';
 
 /**
@@ -69,29 +69,15 @@ export function useRouter(): void {
       try {
         // 1. Apply session first (may trigger async operations)
         if (route.sessionId) {
-          let targetSessionId: string | null = route.sessionId;
-          let directoryHint: string | null | undefined;
-
-          if (route.sessionId === RECENT_SESSION_TOKEN) {
-            // `?session=recent` resolves to the last active session for this
-            // runtime. When there is no usable persisted session (never opened
-            // one, or the persisted one is gone), fall through to the default
-            // new-session behavior without opening anything.
-            const resolved = await resolveRecentSession();
-            if (!resolved) {
-              targetSessionId = null;
-            } else {
-              targetSessionId = resolved.sessionId;
-              directoryHint = resolved.directory;
-            }
-          } else {
-            directoryHint = useSessionUIStore.getState().getDirectoryForSession(targetSessionId);
-          }
-
-          if (targetSessionId) {
+          const resolution = await resolveRouteSessionToken(
+            route.sessionId,
+            resolveRecentSession,
+            (sessionId) => useSessionUIStore.getState().getDirectoryForSession(sessionId),
+          );
+          if (resolution) {
             const currentSessionId = useSessionUIStore.getState().currentSessionId;
-            if (targetSessionId !== currentSessionId) {
-              setCurrentSession(targetSessionId, directoryHint ?? undefined);
+            if (resolution.sessionId !== currentSessionId) {
+              setCurrentSession(resolution.sessionId, resolution.directoryHint ?? undefined);
             }
           }
         }

--- a/packages/ui/src/lib/recentSession.test.ts
+++ b/packages/ui/src/lib/recentSession.test.ts
@@ -6,7 +6,8 @@ const snapshotCalls: Array<{
   pending?: boolean;
   sessions: Array<{ id: string; directory?: string | null }>;
 }> = [];
-let storeStatus: 'ready' | 'error' = 'ready';
+let storeStatus: 'idle' | 'loading' | 'ready' | 'error' = 'ready';
+let committedSessions: Array<{ id: string; directory?: string | null }> = [];
 
 type SnapshotResult = { activeSessions: Array<{ id: string; directory?: string | null }> };
 
@@ -34,7 +35,7 @@ mock.module('@/stores/useGlobalSessionsStore', () => ({
   resolveGlobalSessionDirectory: (session: { directory?: string | null; project?: { worktree?: string | null } | null }) =>
     session.directory ?? session.project?.worktree ?? null,
   useGlobalSessionsStore: {
-    getState: () => ({ status: storeStatus }),
+    getState: () => ({ status: storeStatus, activeSessions: committedSessions }),
   },
 }));
 
@@ -51,6 +52,7 @@ beforeEach(() => {
   setPersisted(null);
   clearCalls.length = 0;
   snapshotCalls.length = 0;
+  committedSessions = [];
   storeStatus = 'ready';
 });
 
@@ -67,19 +69,21 @@ describe('resolveRecentSession', () => {
 
   test('returns the persisted session confirmed by the snapshot', async () => {
     setPersisted('ses_active', '/repo/a');
-    queueSnapshot([
+    committedSessions = [
       { id: 'ses_other', directory: '/repo/b' },
       { id: 'ses_active', directory: '/repo/c' },
-    ]);
+    ];
+    queueSnapshot([...committedSessions]);
     const { resolveRecentSession } = await import('./recentSession');
     const resolved = await resolveRecentSession();
     expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
     expect(clearCalls).toEqual([]);
   });
 
-  test('falls back to the persisted directory when the snapshot entry lacks one', async () => {
+  test('falls back to the persisted directory when the committed entry lacks one', async () => {
     setPersisted('ses_active', '/repo/a');
-    queueSnapshot([{ id: 'ses_active', directory: null }]);
+    committedSessions = [{ id: 'ses_active', directory: null }];
+    queueSnapshot([...committedSessions]);
     const { resolveRecentSession } = await import('./recentSession');
     const resolved = await resolveRecentSession();
     expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/a' });
@@ -87,7 +91,8 @@ describe('resolveRecentSession', () => {
 
   test('drops the stale pointer and returns null when the session is gone', async () => {
     setPersisted('ses_gone', '/repo/a');
-    queueSnapshot([{ id: 'ses_other', directory: '/repo/b' }]);
+    committedSessions = [{ id: 'ses_other', directory: '/repo/b' }];
+    queueSnapshot([...committedSessions]);
     const { resolveRecentSession } = await import('./recentSession');
     expect(await resolveRecentSession()).toBeNull();
     expect(clearCalls).toEqual(['test-runtime']);
@@ -95,6 +100,7 @@ describe('resolveRecentSession', () => {
 
   test('returns null when the snapshot fetch fails', async () => {
     setPersisted('ses_active', '/repo/a');
+    storeStatus = 'error';
     snapshotCalls.push({ reject: true, sessions: [] });
     const { resolveRecentSession } = await import('./recentSession');
     expect(await resolveRecentSession()).toBeNull();
@@ -110,9 +116,28 @@ describe('resolveRecentSession', () => {
     expect(clearCalls).toEqual([]);
   });
 
+  test('keeps the pointer when the snapshot is not authoritative (non-ready store status)', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'idle';
+    queueSnapshot([]);
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(clearCalls).toEqual([]);
+  });
+
+  test('restores from the committed store even when the refresh returns a stale empty snapshot', async () => {
+    setPersisted('ses_active', '/repo/a');
+    committedSessions = [{ id: 'ses_active', directory: '/repo/c' }];
+    queueSnapshot([]);
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
+    expect(clearCalls).toEqual([]);
+  });
+
   test('returns when snapshot resolution exceeds the startup timeout', async () => {
     setPersisted('ses_active', '/repo/a');
-    storeStatus = 'ready';
+    storeStatus = 'loading';
     snapshotCalls.push({ reject: false, pending: true, sessions: [] });
     const { resolveRecentSession } = await import('./recentSession');
     const startedAt = Date.now();
@@ -120,4 +145,46 @@ describe('resolveRecentSession', () => {
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(5_900);
     expect(clearCalls).toEqual([]);
   }, 10_000);
+});
+
+describe('resolveRouteSessionToken', () => {
+  test('passes a plain session ID through with its directory hint', async () => {
+    const { resolveRouteSessionToken } = await import('./recentSession');
+    const resolved = await resolveRouteSessionToken(
+      'ses_plain',
+      async () => ({ sessionId: 'ses_recent', directory: '/repo/x' }),
+      (sessionId) => (sessionId === 'ses_plain' ? '/repo/plain' : null),
+    );
+    expect(resolved).toEqual({ sessionId: 'ses_plain', directoryHint: '/repo/plain' });
+  });
+
+  test('resolves the recent token to the last active session', async () => {
+    const { resolveRouteSessionToken } = await import('./recentSession');
+    const resolved = await resolveRouteSessionToken(
+      'recent',
+      async () => ({ sessionId: 'ses_active', directory: '/repo/a' }),
+      () => null,
+    );
+    expect(resolved).toEqual({ sessionId: 'ses_active', directoryHint: '/repo/a' });
+  });
+
+  test('falls through to the draft when the recent token resolves to nothing', async () => {
+    const { resolveRouteSessionToken } = await import('./recentSession');
+    const resolved = await resolveRouteSessionToken('recent', async () => null, () => null);
+    expect(resolved).toBeNull();
+  });
+
+  test('does not resolve the recent token when the route uses a plain session ID', async () => {
+    const { resolveRouteSessionToken } = await import('./recentSession');
+    let recentResolutionAttempted = false;
+    await resolveRouteSessionToken(
+      'ses_plain',
+      async () => {
+        recentResolutionAttempted = true;
+        return null;
+      },
+      () => null,
+    );
+    expect(recentResolutionAttempted).toBe(false);
+  });
 });

--- a/packages/ui/src/lib/recentSession.test.ts
+++ b/packages/ui/src/lib/recentSession.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const clearCalls: string[] = [];
+const snapshotCalls: Array<{ reject: boolean; sessions: Array<{ id: string; directory?: string | null }> }> = [];
+
+type SnapshotResult = { activeSessions: Array<{ id: string; directory?: string | null }> };
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeKey: () => 'test-runtime',
+}));
+
+mock.module('@/sync/last-session-cache', () => ({
+  readLastActiveSession: (key: string) => {
+    if (key !== 'test-runtime') return null;
+    return (globalThis as { __persisted?: { sessionId: string; directory: string | null } | null }).__persisted ?? null;
+  },
+  clearLastActiveSession: (key: string) => {
+    clearCalls.push(key);
+  },
+}));
+
+mock.module('@/stores/useGlobalSessionsStore', () => ({
+  refreshGlobalSessions: async (): Promise<SnapshotResult> => {
+    const next = snapshotCalls.shift();
+    if (next?.reject) throw new Error('network down');
+    return { activeSessions: next?.sessions ?? [] };
+  },
+  resolveGlobalSessionDirectory: (session: { directory?: string | null; project?: { worktree?: string | null } | null }) =>
+    session.directory ?? session.project?.worktree ?? null,
+}));
+
+const setPersisted = (sessionId: string | null, directory: string | null = null) => {
+  (globalThis as { __persisted?: unknown }).__persisted =
+    sessionId === null ? null : { sessionId, directory };
+};
+
+const queueSnapshot = (sessions: Array<{ id: string; directory?: string | null }>) => {
+  snapshotCalls.push({ reject: false, sessions });
+};
+
+beforeEach(() => {
+  setPersisted(null);
+  clearCalls.length = 0;
+  snapshotCalls.length = 0;
+});
+
+afterEach(() => {
+  delete (globalThis as { __persisted?: unknown }).__persisted;
+});
+
+describe('resolveRecentSession', () => {
+  test('returns null when nothing was persisted', async () => {
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(snapshotCalls).toEqual([]);
+  });
+
+  test('returns the persisted session confirmed by the snapshot', async () => {
+    setPersisted('ses_active', '/repo/a');
+    queueSnapshot([
+      { id: 'ses_other', directory: '/repo/b' },
+      { id: 'ses_active', directory: '/repo/c' },
+    ]);
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
+    expect(clearCalls).toEqual([]);
+  });
+
+  test('falls back to the persisted directory when the snapshot entry lacks one', async () => {
+    setPersisted('ses_active', '/repo/a');
+    queueSnapshot([{ id: 'ses_active', directory: null }]);
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/a' });
+  });
+
+  test('drops the stale pointer and returns null when the session is gone', async () => {
+    setPersisted('ses_gone', '/repo/a');
+    queueSnapshot([{ id: 'ses_other', directory: '/repo/b' }]);
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(clearCalls).toEqual(['test-runtime']);
+  });
+
+  test('returns null when the snapshot fetch fails', async () => {
+    setPersisted('ses_active', '/repo/a');
+    snapshotCalls.push({ reject: true, sessions: [] });
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(clearCalls).toEqual([]);
+  });
+});

--- a/packages/ui/src/lib/recentSession.test.ts
+++ b/packages/ui/src/lib/recentSession.test.ts
@@ -27,6 +27,14 @@ mock.module('@/sync/last-session-cache', () => ({
   },
 }));
 
+let sdkConnected = true;
+
+mock.module('@/stores/useConfigStore', () => ({
+  useConfigStore: {
+    getState: () => ({ isConnected: sdkConnected }),
+  },
+}));
+
 mock.module('@/stores/useGlobalSessionsStore', () => ({
   refreshGlobalSessions: async (): Promise<SnapshotResult> => {
     const next = snapshotCalls.shift();
@@ -79,6 +87,7 @@ beforeEach(() => {
   snapshotCalls.length = 0;
   committedSessions = [];
   storeStatus = 'ready';
+  sdkConnected = true;
 });
 
 afterEach(() => {
@@ -162,6 +171,36 @@ describe('resolveRecentSession', () => {
   });
 
   test('returns when snapshot resolution exceeds the startup timeout', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'loading';
+    snapshotCalls.push({ reject: false, pending: true, sessions: [] });
+    const { resolveRecentSession } = await import('./recentSession');
+    const startedAt = Date.now();
+    expect(await resolveRecentSession()).toBeNull();
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(5_900);
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
+
+  test('keeps waiting past the deadline while the SDK is not connected yet', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'loading';
+    sdkConnected = false;
+    // The snapshot can only become ready once the SDK connects (slow mobile
+    // boot). Simulate the connection and the resulting committed snapshot
+    // arriving well after the 6s deadline would have expired.
+    setTimeout(() => {
+      sdkConnected = true;
+      committedSessions = [{ id: 'ses_active', directory: '/repo/c' }];
+      storeStatus = 'ready';
+    }, 50);
+    queueSnapshot([], { commit: false });
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
+
+  test('still gives up once connected when the snapshot never becomes ready', async () => {
     setPersisted('ses_active', '/repo/a');
     storeStatus = 'loading';
     snapshotCalls.push({ reject: false, pending: true, sessions: [] });

--- a/packages/ui/src/lib/recentSession.test.ts
+++ b/packages/ui/src/lib/recentSession.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const clearCalls: string[] = [];
-const snapshotCalls: Array<{ reject: boolean; sessions: Array<{ id: string; directory?: string | null }> }> = [];
+const snapshotCalls: Array<{
+  reject: boolean;
+  pending?: boolean;
+  sessions: Array<{ id: string; directory?: string | null }>;
+}> = [];
+let storeStatus: 'ready' | 'error' = 'ready';
 
 type SnapshotResult = { activeSessions: Array<{ id: string; directory?: string | null }> };
 
@@ -22,11 +27,15 @@ mock.module('@/sync/last-session-cache', () => ({
 mock.module('@/stores/useGlobalSessionsStore', () => ({
   refreshGlobalSessions: async (): Promise<SnapshotResult> => {
     const next = snapshotCalls.shift();
+    if (next?.pending) return new Promise<SnapshotResult>(() => undefined);
     if (next?.reject) throw new Error('network down');
     return { activeSessions: next?.sessions ?? [] };
   },
   resolveGlobalSessionDirectory: (session: { directory?: string | null; project?: { worktree?: string | null } | null }) =>
     session.directory ?? session.project?.worktree ?? null,
+  useGlobalSessionsStore: {
+    getState: () => ({ status: storeStatus }),
+  },
 }));
 
 const setPersisted = (sessionId: string | null, directory: string | null = null) => {
@@ -42,6 +51,7 @@ beforeEach(() => {
   setPersisted(null);
   clearCalls.length = 0;
   snapshotCalls.length = 0;
+  storeStatus = 'ready';
 });
 
 afterEach(() => {
@@ -90,4 +100,24 @@ describe('resolveRecentSession', () => {
     expect(await resolveRecentSession()).toBeNull();
     expect(clearCalls).toEqual([]);
   });
+
+  test('keeps the pointer when the store reports a failed snapshot', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'error';
+    queueSnapshot([]);
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(clearCalls).toEqual([]);
+  });
+
+  test('returns when snapshot resolution exceeds the startup timeout', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'ready';
+    snapshotCalls.push({ reject: false, pending: true, sessions: [] });
+    const { resolveRecentSession } = await import('./recentSession');
+    const startedAt = Date.now();
+    expect(await resolveRecentSession()).toBeNull();
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(5_900);
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
 });

--- a/packages/ui/src/lib/recentSession.test.ts
+++ b/packages/ui/src/lib/recentSession.test.ts
@@ -200,6 +200,25 @@ describe('resolveRecentSession', () => {
     expect(clearCalls).toEqual([]);
   }, 10_000);
 
+  test('recovers from a transient boot error once the SDK connects', async () => {
+    setPersisted('ses_active', '/repo/a');
+    // First refresh attempt fails while the SDK is still connecting (slow
+    // mobile boot) and flips the store to `error`; the resolve must not treat
+    // that as authoritative while disconnected.
+    storeStatus = 'error';
+    sdkConnected = false;
+    queueSnapshot([{ id: 'ses_active', directory: '/repo/c' }], { commit: false });
+    setTimeout(() => {
+      sdkConnected = true;
+      storeStatus = 'ready';
+      committedSessions = [{ id: 'ses_active', directory: '/repo/c' }];
+    }, 50);
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
+
   test('still gives up once connected when the snapshot never becomes ready', async () => {
     setPersisted('ses_active', '/repo/a');
     storeStatus = 'loading';

--- a/packages/ui/src/lib/recentSession.test.ts
+++ b/packages/ui/src/lib/recentSession.test.ts
@@ -25,6 +25,7 @@ mock.module('@/sync/last-session-cache', () => ({
   clearLastActiveSession: (key: string) => {
     clearCalls.push(key);
   },
+  readMostRecentLastActiveSession: () => null,
 }));
 
 let sdkConnected = true;

--- a/packages/ui/src/lib/recentSession.test.ts
+++ b/packages/ui/src/lib/recentSession.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const clearCalls: string[] = [];
 const snapshotCalls: Array<{
-  reject: boolean;
+  reject?: boolean;
   pending?: boolean;
+  commit?: boolean;
+  delayMs?: number;
   sessions: Array<{ id: string; directory?: string | null }>;
 }> = [];
 let storeStatus: 'idle' | 'loading' | 'ready' | 'error' = 'ready';
@@ -29,7 +31,27 @@ mock.module('@/stores/useGlobalSessionsStore', () => ({
   refreshGlobalSessions: async (): Promise<SnapshotResult> => {
     const next = snapshotCalls.shift();
     if (next?.pending) return new Promise<SnapshotResult>(() => undefined);
-    if (next?.reject) throw new Error('network down');
+    if (next?.reject) {
+      storeStatus = 'error';
+      throw new Error('network down');
+    }
+    // A successful load commits its snapshot into the store and flips the
+    // status to 'ready' (mirrors `loadSessions`). Pass `commit: false` to
+    // simulate a generation-stale result that returns without touching the
+    // store (the runtime-switch mismatch case); `delayMs` defers the commit so
+    // the caller can observe the store being still non-ready.
+    if (next?.commit === false) {
+      return { activeSessions: next?.sessions ?? [] };
+    }
+    const apply = () => {
+      committedSessions = next?.sessions ?? [];
+      storeStatus = 'ready';
+    };
+    if (next?.delayMs) {
+      setTimeout(apply, next.delayMs);
+    } else {
+      apply();
+    }
     return { activeSessions: next?.sessions ?? [] };
   },
   resolveGlobalSessionDirectory: (session: { directory?: string | null; project?: { worktree?: string | null } | null }) =>
@@ -44,8 +66,11 @@ const setPersisted = (sessionId: string | null, directory: string | null = null)
     sessionId === null ? null : { sessionId, directory };
 };
 
-const queueSnapshot = (sessions: Array<{ id: string; directory?: string | null }>) => {
-  snapshotCalls.push({ reject: false, sessions });
+const queueSnapshot = (
+  sessions: Array<{ id: string; directory?: string | null }>,
+  options: { commit?: boolean; delayMs?: number } = {},
+) => {
+  snapshotCalls.push({ sessions, commit: options.commit, delayMs: options.delayMs });
 };
 
 beforeEach(() => {
@@ -110,7 +135,7 @@ describe('resolveRecentSession', () => {
   test('keeps the pointer when the store reports a failed snapshot', async () => {
     setPersisted('ses_active', '/repo/a');
     storeStatus = 'error';
-    queueSnapshot([]);
+    queueSnapshot([], { commit: false });
     const { resolveRecentSession } = await import('./recentSession');
     expect(await resolveRecentSession()).toBeNull();
     expect(clearCalls).toEqual([]);
@@ -119,16 +144,17 @@ describe('resolveRecentSession', () => {
   test('keeps the pointer when the snapshot is not authoritative (non-ready store status)', async () => {
     setPersisted('ses_active', '/repo/a');
     storeStatus = 'idle';
-    queueSnapshot([]);
+    queueSnapshot([], { commit: false });
     const { resolveRecentSession } = await import('./recentSession');
     expect(await resolveRecentSession()).toBeNull();
     expect(clearCalls).toEqual([]);
-  });
+  }, 10_000);
 
   test('restores from the committed store even when the refresh returns a stale empty snapshot', async () => {
     setPersisted('ses_active', '/repo/a');
     committedSessions = [{ id: 'ses_active', directory: '/repo/c' }];
-    queueSnapshot([]);
+    storeStatus = 'ready';
+    queueSnapshot([], { commit: false });
     const { resolveRecentSession } = await import('./recentSession');
     const resolved = await resolveRecentSession();
     expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -2,7 +2,7 @@ import { getRuntimeKey } from '@/lib/runtime-switch';
 import { RECENT_SESSION_TOKEN } from '@/lib/router';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { refreshGlobalSessions, resolveGlobalSessionDirectory, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
-import { clearLastActiveSession, readLastActiveSession } from '@/sync/last-session-cache';
+import { clearLastActiveSession, readLastActiveSession, readMostRecentLastActiveSession } from '@/sync/last-session-cache';
 
 export type ResolvedRecentSession = {
   sessionId: string;
@@ -51,7 +51,7 @@ const RECENT_SESSION_RESOLUTION_ABSOLUTE_CAP_MS = 30_000;
  */
 export async function resolveRecentSession(): Promise<ResolvedRecentSession | null> {
   const runtimeKey = getRuntimeKey();
-  const persisted = readLastActiveSession(runtimeKey);
+  const persisted = readLastActiveSession(runtimeKey) ?? readMostRecentLastActiveSession();
   if (!persisted) {
     return null;
   }

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -1,11 +1,13 @@
 import { getRuntimeKey } from '@/lib/runtime-switch';
-import { refreshGlobalSessions, resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
+import { refreshGlobalSessions, resolveGlobalSessionDirectory, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
 import { clearLastActiveSession, readLastActiveSession } from '@/sync/last-session-cache';
 
 export type ResolvedRecentSession = {
   sessionId: string;
   directory: string | null;
 };
+
+const RECENT_SESSION_RESOLUTION_TIMEOUT_MS = 6_000;
 
 /**
  * Resolve the `?session=recent` URL token to the last session that was active
@@ -23,8 +25,21 @@ export async function resolveRecentSession(): Promise<ResolvedRecentSession | nu
     return null;
   }
 
-  const snapshot = await refreshGlobalSessions().catch(() => null);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const snapshot = await Promise.race([
+    refreshGlobalSessions().catch(() => null),
+    new Promise<null>((resolve) => {
+      timeout = setTimeout(() => resolve(null), RECENT_SESSION_RESOLUTION_TIMEOUT_MS);
+    }),
+  ]);
+  if (timeout !== undefined) {
+    clearTimeout(timeout);
+  }
   if (!snapshot) {
+    return null;
+  }
+
+  if (useGlobalSessionsStore.getState().status === 'error') {
     return null;
   }
 

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -36,6 +36,7 @@ export async function resolveRouteSessionToken(
 }
 
 const RECENT_SESSION_RESOLUTION_TIMEOUT_MS = 6_000;
+const RECENT_SESSION_RESOLUTION_ABSOLUTE_CAP_MS = 30_000;
 
 /**
  * Resolve the `?session=recent` URL token to the last session that was active
@@ -64,9 +65,18 @@ export async function resolveRecentSession(): Promise<ResolvedRecentSession | nu
   void refreshGlobalSessions().catch(() => null);
 
   const deadline = Date.now() + RECENT_SESSION_RESOLUTION_TIMEOUT_MS;
+  const absoluteCap = Date.now() + RECENT_SESSION_RESOLUTION_ABSOLUTE_CAP_MS;
   for (;;) {
     const state = useGlobalSessionsStore.getState();
-    if (state.status === 'error') {
+    if (Date.now() >= absoluteCap) {
+      return null;
+    }
+    // A transient `error` right after boot (the first refresh attempt fails
+    // while the SDK is still connecting on a slow first load, e.g. mobile web)
+    // is not authoritative — only give up once the SDK is connected, when an
+    // `error` really means the backend is unreachable. Non-connected errors are
+    // preserved for the connected retry below.
+    if (state.status === 'error' && useConfigStore.getState().isConnected) {
       return null;
     }
     if (state.status === 'ready') {

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -1,0 +1,41 @@
+import { getRuntimeKey } from '@/lib/runtime-switch';
+import { refreshGlobalSessions, resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
+import { clearLastActiveSession, readLastActiveSession } from '@/sync/last-session-cache';
+
+export type ResolvedRecentSession = {
+  sessionId: string;
+  directory: string | null;
+};
+
+/**
+ * Resolve the `?session=recent` URL token to the last session that was active
+ * for the current runtime. Mirrors the MobileApp cold-launch restore: the
+ * persisted pointer is only trusted after an authoritative sessions snapshot
+ * confirms the session still exists; otherwise the stale pointer is dropped.
+ *
+ * Returns `null` when there is no usable persisted session, so callers can
+ * fall back to the default new-session behavior.
+ */
+export async function resolveRecentSession(): Promise<ResolvedRecentSession | null> {
+  const runtimeKey = getRuntimeKey();
+  const persisted = readLastActiveSession(runtimeKey);
+  if (!persisted) {
+    return null;
+  }
+
+  const snapshot = await refreshGlobalSessions().catch(() => null);
+  if (!snapshot) {
+    return null;
+  }
+
+  const session = snapshot.activeSessions.find((entry) => entry.id === persisted.sessionId);
+  if (!session) {
+    clearLastActiveSession(runtimeKey);
+    return null;
+  }
+
+  return {
+    sessionId: session.id,
+    directory: resolveGlobalSessionDirectory(session) ?? persisted.directory,
+  };
+}

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -1,4 +1,5 @@
 import { getRuntimeKey } from '@/lib/runtime-switch';
+import { RECENT_SESSION_TOKEN } from '@/lib/router';
 import { refreshGlobalSessions, resolveGlobalSessionDirectory, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
 import { clearLastActiveSession, readLastActiveSession } from '@/sync/last-session-cache';
 
@@ -6,6 +7,32 @@ export type ResolvedRecentSession = {
   sessionId: string;
   directory: string | null;
 };
+
+export type RouteSessionResolution = {
+  sessionId: string;
+  directoryHint: string | null | undefined;
+} | null;
+
+/**
+ * Resolve the `session` part of a route. A plain session ID is passed through
+ * unchanged with its directory hint; the `?session=recent` token is resolved
+ * against the last active session for the current runtime, falling through to
+ * the default new-session behavior (null) when nothing usable is persisted.
+ */
+export async function resolveRouteSessionToken(
+  rawSessionId: string,
+  resolveRecent: () => Promise<ResolvedRecentSession | null>,
+  getDirectoryForSession: (sessionId: string) => string | null | undefined,
+): Promise<RouteSessionResolution> {
+  if (rawSessionId !== RECENT_SESSION_TOKEN) {
+    return { sessionId: rawSessionId, directoryHint: getDirectoryForSession(rawSessionId) };
+  }
+  const resolved = await resolveRecent();
+  if (!resolved) {
+    return null;
+  }
+  return { sessionId: resolved.sessionId, directoryHint: resolved.directory };
+}
 
 const RECENT_SESSION_RESOLUTION_TIMEOUT_MS = 6_000;
 
@@ -26,7 +53,7 @@ export async function resolveRecentSession(): Promise<ResolvedRecentSession | nu
   }
 
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  const snapshot = await Promise.race([
+  await Promise.race([
     refreshGlobalSessions().catch(() => null),
     new Promise<null>((resolve) => {
       timeout = setTimeout(() => resolve(null), RECENT_SESSION_RESOLUTION_TIMEOUT_MS);
@@ -35,15 +62,17 @@ export async function resolveRecentSession(): Promise<ResolvedRecentSession | nu
   if (timeout !== undefined) {
     clearTimeout(timeout);
   }
-  if (!snapshot) {
+
+  // Only the committed store snapshot is authoritative: the promise returned
+  // by `refreshGlobalSessions` may be a generation-stale (empty) result that
+  // was discarded without touching the store status, while a newer load
+  // already applied the real snapshot.
+  const state = useGlobalSessionsStore.getState();
+  if (state.status !== 'ready') {
     return null;
   }
 
-  if (useGlobalSessionsStore.getState().status === 'error') {
-    return null;
-  }
-
-  const session = snapshot.activeSessions.find((entry) => entry.id === persisted.sessionId);
+  const session = state.activeSessions.find((entry) => entry.id === persisted.sessionId);
   if (!session) {
     clearLastActiveSession(runtimeKey);
     return null;

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -1,5 +1,6 @@
 import { getRuntimeKey } from '@/lib/runtime-switch';
 import { RECENT_SESSION_TOKEN } from '@/lib/router';
+import { useConfigStore } from '@/stores/useConfigStore';
 import { refreshGlobalSessions, resolveGlobalSessionDirectory, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
 import { clearLastActiveSession, readLastActiveSession } from '@/sync/last-session-cache';
 
@@ -79,7 +80,13 @@ export async function resolveRecentSession(): Promise<ResolvedRecentSession | nu
         directory: resolveGlobalSessionDirectory(session) ?? persisted.directory,
       };
     }
-    if (Date.now() >= deadline) {
+    // On a slow first boot (mobile web in particular) the SDK connects only
+    // after several seconds, so the sessions load cannot reach `ready` within
+    // the resolve deadline. Don't let the deadline race the connection: pause
+    // the countdown until the SDK reports connected, mirroring the native
+    // mobile cold-launch restore which waits for `isConnected` too. The
+    // absolute cap still guards against an unreachable backend.
+    if (Date.now() >= deadline && useConfigStore.getState().isConnected) {
       return null;
     }
     await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -52,34 +52,34 @@ export async function resolveRecentSession(): Promise<ResolvedRecentSession | nu
     return null;
   }
 
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  await Promise.race([
-    refreshGlobalSessions().catch(() => null),
-    new Promise<null>((resolve) => {
-      timeout = setTimeout(() => resolve(null), RECENT_SESSION_RESOLUTION_TIMEOUT_MS);
-    }),
-  ]);
-  if (timeout !== undefined) {
-    clearTimeout(timeout);
-  }
+  // Kick off a load if none is in flight. The returned promise is not
+  // authoritative: on a runtime-switch generation mismatch it resolves to an
+  // empty snapshot without touching the store status, while a newer load may
+  // have already applied the real snapshot. Only the committed store status is
+  // authoritative, so wait (bounded) for it to reach `ready` and read the
+  // committed snapshot there.
+  void refreshGlobalSessions().catch(() => null);
 
-  // Only the committed store snapshot is authoritative: the promise returned
-  // by `refreshGlobalSessions` may be a generation-stale (empty) result that
-  // was discarded without touching the store status, while a newer load
-  // already applied the real snapshot.
-  const state = useGlobalSessionsStore.getState();
-  if (state.status !== 'ready') {
-    return null;
+  const deadline = Date.now() + RECENT_SESSION_RESOLUTION_TIMEOUT_MS;
+  for (;;) {
+    const state = useGlobalSessionsStore.getState();
+    if (state.status === 'error') {
+      return null;
+    }
+    if (state.status === 'ready') {
+      const session = state.activeSessions.find((entry) => entry.id === persisted.sessionId);
+      if (!session) {
+        clearLastActiveSession(runtimeKey);
+        return null;
+      }
+      return {
+        sessionId: session.id,
+        directory: resolveGlobalSessionDirectory(session) ?? persisted.directory,
+      };
+    }
+    if (Date.now() >= deadline) {
+      return null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
   }
-
-  const session = state.activeSessions.find((entry) => entry.id === persisted.sessionId);
-  if (!session) {
-    clearLastActiveSession(runtimeKey);
-    return null;
-  }
-
-  return {
-    sessionId: session.id,
-    directory: resolveGlobalSessionDirectory(session) ?? persisted.directory,
-  };
 }

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -40,7 +40,9 @@ const RECENT_SESSION_RESOLUTION_TIMEOUT_MS = 6_000;
  * Resolve the `?session=recent` URL token to the last session that was active
  * for the current runtime. Mirrors the MobileApp cold-launch restore: the
  * persisted pointer is only trusted after an authoritative sessions snapshot
- * confirms the session still exists; otherwise the stale pointer is dropped.
+ * confirms the session still exists. The pointer is dropped only when an
+ * authoritative `ready` snapshot confirms the session is gone; failures and
+ * non-authoritative statuses preserve it for a later retry.
  *
  * Returns `null` when there is no usable persisted session, so callers can
  * fall back to the default new-session behavior.

--- a/packages/ui/src/lib/router/index.ts
+++ b/packages/ui/src/lib/router/index.ts
@@ -6,18 +6,22 @@
  *
  * URL Schema:
  * - `?session=<id>` - Navigate to specific session
+ * - `?session=recent` - Navigate to the last active session for this runtime
+ *   (falls back to the default new-session screen when there is none)
  * - `?tab=<chat|git|diff|terminal|files>` - Active main tab
  * - `?settings=<section>` - Open settings to specific section
  * - `?file=<path>` - Diff view with file selected
  *
  * Examples:
  * - `/?session=abc123` - Open session abc123
+ * - `/?session=recent` - Open the last session used on this instance
  * - `/?tab=git` - Open git tab
  * - `/?settings=providers` - Open settings to providers section
  * - `/?tab=diff&file=src/main.ts` - Open diff view with file
  */
 
 export type { RouteState } from './types';
+export { RECENT_SESSION_TOKEN } from './types';
 
 
 export { parseRoute, hasRouteParams } from './parseRoute';

--- a/packages/ui/src/lib/router/types.ts
+++ b/packages/ui/src/lib/router/types.ts
@@ -35,6 +35,14 @@ export const VALID_SETTINGS_SECTIONS: readonly SidebarSection[] = [
 ] as const;
 
 /**
+ * Special value for the `?session=` parameter that resolves to the last
+ * active session persisted for the current runtime (see
+ * `@/sync/last-session-cache`). Falls back to the default new-session
+ * behavior when no usable persisted session exists.
+ */
+export const RECENT_SESSION_TOKEN = 'recent';
+
+/**
  * URL parameter names used for routing.
  */
 export const ROUTE_PARAMS = {

--- a/packages/ui/src/sync/last-session-cache.ts
+++ b/packages/ui/src/sync/last-session-cache.ts
@@ -79,6 +79,19 @@ export function readLastActiveSession(
   return entry ? { sessionId: entry.sessionId, directory: entry.directory } : null
 }
 
+// A server can be opened through several equivalent origins (LAN address,
+// reverse proxy, or the public hostname). If the current origin has no exact
+// entry, the newest pointer is the safest continuity fallback; the caller
+// still validates the session against an authoritative snapshot.
+export function readMostRecentLastActiveSession(
+  storage: Storage = getDeferredSafeStorage(),
+): PersistedLastSession | null {
+  const entries = Object.values(readEnvelope(storage).runtimes)
+    .sort((left, right) => right.updatedAt - left.updatedAt)
+  const entry = entries[0]
+  return entry ? { sessionId: entry.sessionId, directory: entry.directory } : null
+}
+
 export function clearLastActiveSession(
   runtimeKey: string,
   storage: Storage = getDeferredSafeStorage(),

--- a/packages/ui/src/types/bun-test.d.ts
+++ b/packages/ui/src/types/bun-test.d.ts
@@ -3,7 +3,7 @@
 
 declare module "bun:test" {
   export function describe(name: string, fn: () => void): void;
-  export function test(name: string, fn: () => void | Promise<void>): void;
+  export function test(name: string, fn: () => void | Promise<void>, timeout?: number): void;
   export function expect(value: unknown): {
     toEqual(expected: unknown): void;
     toBe(expected: unknown): void;


### PR DESCRIPTION
PR remplacée par une nouvelle branche propre rebasée sur le main actuel : feat/session-recent-v120-rebased. Les corrections desktop/mobile et les réponses aux remarques de revue sont reprises dans la nouvelle PR.