### PR TITLE
fix(ui): order chat messages by time.created, not raw ID

### DIFF
--- a/packages/ui/src/components/chat/revertedMessageDockState.ts
+++ b/packages/ui/src/components/chat/revertedMessageDockState.ts
@@ -1,4 +1,5 @@
 import type { Message, Part } from '@opencode-ai/sdk/v2/client';
+import { findMessageByID, isBeforeMessage } from '@/sync/messageOrder';
 import type { State } from '@/sync/types';
 
 type RevertedMessageRecord = {
@@ -50,9 +51,10 @@ export const buildRevertedMessageDockState = (
     }
 
     const messages = state.message[sessionId] ?? [];
+    const revertAnchor = findMessageByID(messages, revertMessageID);
     const records: RevertedMessageRecord[] = [];
     for (const message of messages) {
-        if (!isUserMessage(message) || message.id < revertMessageID) {
+        if (!isUserMessage(message) || isBeforeMessage(message, revertAnchor, revertMessageID)) {
             continue;
         }
         records.push({

--- a/packages/ui/src/sync/binary.ts
+++ b/packages/ui/src/sync/binary.ts
@@ -23,4 +23,32 @@ export namespace Binary {
 
     return { found: false, index: left }
   }
+
+  /**
+   * Binary search against a full ordering comparator (e.g. messages ordered
+   * by `time.created`, then id). Returns the insertion index when absent.
+   */
+  export function searchBy<T>(
+    array: readonly T[],
+    value: T,
+    compare: (left: T, right: T) => number,
+  ): { found: boolean; index: number } {
+    let left = 0
+    let right = array.length - 1
+
+    while (left <= right) {
+      const mid = Math.floor((left + right) / 2)
+      const comparison = compare(array[mid], value)
+
+      if (comparison === 0) {
+        return { found: true, index: mid }
+      } else if (comparison < 0) {
+        left = mid + 1
+      } else {
+        right = mid - 1
+      }
+    }
+
+    return { found: false, index: left }
+  }
 }

--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -10,6 +10,7 @@ import type {
   Todo,
 } from "@opencode-ai/sdk/v2/client"
 import { Binary } from "./binary"
+import { compareMessages } from "./messageOrder"
 import type { FileDiff, GlobalState, State } from "./types"
 import { dropSessionCaches } from "./session-cache"
 import { stripSessionDiffSnapshots } from "./sanitize"
@@ -180,7 +181,10 @@ function hasMessage(draft: State, sessionID: string | undefined, messageID: stri
   if (!sessionID) return false
   const messages = draft.message[sessionID]
   if (!messages) return false
-  return Binary.search(messages, messageID, (message) => message.id).found
+  // Messages are ordered chronologically (time.created, then id), so an
+  // id-only lookup cannot binary search. This runs on part.updated events
+  // (not per text delta), and the list is bounded, so a linear scan is fine.
+  return messages.some((message) => message.id === messageID)
 }
 
 export function reduceGlobalEvent(event: Event): GlobalEventResult {
@@ -353,7 +357,11 @@ export function applyDirectoryEvent(
         draft.message[info.sessionID] = [info]
         return true
       }
-      const result = Binary.search(messages, info.id, (m) => m.id)
+      // Search by chronological order (time.created, then id). A raw id
+      // search would break after the OpenCode ID wrap boundary and a
+      // time-only search could duplicate the optimistic echo when client and
+      // server clocks differ, so fall back to an id dedupe before inserting.
+      const result = Binary.searchBy(messages, info, compareMessages)
       if (result.found) {
         // Skip message replacement if unchanged — preserves reference, avoids re-render
         const existing = messages[result.index]
@@ -367,7 +375,12 @@ export function applyDirectoryEvent(
         draft.message[info.sessionID] = next
       } else {
         const next = [...messages]
-        next.splice(result.index, 0, info)
+        const duplicateIndex = next.findIndex((message) => message.id === info.id)
+        if (duplicateIndex >= 0) {
+          next[duplicateIndex] = info
+        } else {
+          next.splice(result.index, 0, info)
+        }
         draft.message[info.sessionID] = next
       }
       return true
@@ -378,9 +391,9 @@ export function applyDirectoryEvent(
       const messages = draft.message[props.sessionID]
       if (messages) {
         const next = [...messages]
-        const result = Binary.search(next, props.messageID, (m) => m.id)
-        if (result.found) {
-          next.splice(result.index, 1)
+        const index = next.findIndex((message) => message.id === props.messageID)
+        if (index >= 0) {
+          next.splice(index, 1)
           draft.message[props.sessionID] = next
         }
       }

--- a/packages/ui/src/sync/materialization.ts
+++ b/packages/ui/src/sync/materialization.ts
@@ -1,5 +1,6 @@
 import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { mergeMessages } from "./optimistic"
+import { compareMessages } from "./messageOrder"
 import type { SessionMaterializationReason } from "./event-reducer"
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
@@ -264,7 +265,7 @@ export function materializeSessionSnapshots(
   const skipPartTypes = options.skipPartTypes ?? new Set<string>()
   const snapshots = records
     .filter((record) => !!record?.info?.id)
-    .sort((left, right) => cmp(left.info.id, right.info.id))
+    .sort((left, right) => compareMessages(left.info, right.info))
   const nextMessages = snapshots.map((record) => record.info)
   const existingMessages = state.message[sessionID]
   const currentMessages = existingMessages ?? []

--- a/packages/ui/src/sync/messageOrder.test.ts
+++ b/packages/ui/src/sync/messageOrder.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from 'bun:test'
+import type { Message, Part } from '@opencode-ai/sdk/v2/client'
+
+import { Binary } from './binary'
+import {
+  compareMessages,
+  findMessageByID,
+  isAfterMessage,
+  isAtOrAfterMessage,
+  isBeforeMessage,
+  sortMessages,
+  getMessageCreatedAt,
+} from './messageOrder'
+import { mergeMessages, mergeOptimisticPage, type OptimisticItem } from './optimistic'
+import { materializeSessionSnapshots } from './materialization'
+
+const wrapOldMessage = (): Message => ({
+  // Created before the 2026-08-14 OpenCode ID wrap boundary: 48-bit hex
+  // timestamp prefix near the top of the space (ffff…).
+  id: 'msg_fffc192a8001AAAAAAAAAAAA',
+  sessionID: 'ses_1',
+  role: 'user',
+  time: { created: 1_784_000_000_000 },
+} as Message)
+
+const wrapNewMessage = (): Message => ({
+  // Created after the wrap boundary: the prefix wraps to near-zero (0000…),
+  // so lexicographic id order would place this message BEFORE all older ones.
+  id: 'msg_000851681002BBBBBBBBBBBB',
+  sessionID: 'ses_1',
+  role: 'assistant',
+  time: { created: 1_784_000_100_000 },
+} as Message)
+
+const message = (id: string, created: number): Message => ({
+  id,
+  sessionID: 'ses_1',
+  role: 'user',
+  time: { created },
+} as Message)
+
+describe('getMessageCreatedAt', () => {
+  test('returns time.created when present', () => {
+    expect(getMessageCreatedAt(message('m_1', 42))).toBe(42)
+  })
+
+  test('returns 0 when time is missing or malformed', () => {
+    expect(getMessageCreatedAt({ id: 'm_1' })).toBe(0)
+    const malformed = { id: 'm_1', time: { created: 'nope' } } as unknown as Message
+    expect(getMessageCreatedAt(malformed)).toBe(0)
+  })
+})
+
+describe('compareMessages / sortMessages', () => {
+  test('orders by time.created first, ignoring the id lexicographic order', () => {
+    // This is the regression case: after the OpenCode ID wrap boundary the
+    // newer message's id (0000…) sorts BEFORE the older id (ffff…) when
+    // compared as strings, but it is still newer in time.
+    const oldMsg = wrapOldMessage()
+    const newMsg = wrapNewMessage()
+    expect(compareMessages(newMsg, oldMsg)).toBeGreaterThan(0)
+    expect(compareMessages(oldMsg, newMsg)).toBeLessThan(0)
+    expect(sortMessages([newMsg, oldMsg]).map((m) => m.id)).toEqual([oldMsg.id, newMsg.id])
+  })
+
+  test('breaks ties by id', () => {
+    const a = message('msg_b', 5)
+    const b = message('msg_a', 5)
+    expect(sortMessages([a, b]).map((m) => m.id)).toEqual(['msg_a', 'msg_b'])
+  })
+
+  test('messages without a created time sort first (treated as created=0)', () => {
+    const noTime = { id: 'msg_z' } as Message
+    const withTime = message('msg_a', 10)
+    expect(compareMessages(noTime, withTime)).toBeLessThan(0)
+  })
+})
+
+describe('Binary.searchBy', () => {
+  test('finds existing messages by chronological position', () => {
+    const messages = [wrapOldMessage(), wrapNewMessage()]
+    const result = Binary.searchBy(messages, wrapNewMessage(), compareMessages)
+    expect(result.found).toBe(true)
+    expect(result.index).toBe(1)
+  })
+
+  test('returns the insertion index for a new message', () => {
+    const messages = [wrapOldMessage(), wrapNewMessage()]
+    const middle = message('msg_middle', 1_784_000_050_000)
+    const result = Binary.searchBy(messages, middle, compareMessages)
+    expect(result.found).toBe(false)
+    expect(result.index).toBe(1)
+  })
+})
+
+describe('mergeMessages', () => {
+  test('keeps chronological order across the ID wrap boundary', () => {
+    const oldMsg = wrapOldMessage()
+    const newMsg = wrapNewMessage()
+    const merged = mergeMessages([], [oldMsg, newMsg])
+    expect(merged.map((m) => m.id)).toEqual([oldMsg.id, newMsg.id])
+  })
+
+  test('deduplicates by id and preserves order', () => {
+    const oldMsg = wrapOldMessage()
+    const merged = mergeMessages([oldMsg], [oldMsg, wrapNewMessage()])
+    expect(merged.map((m) => m.id)).toEqual([oldMsg.id, wrapNewMessage().id])
+  })
+})
+
+describe('mergeOptimisticPage', () => {
+  test('inserts an optimistic message created after the wrap at the end, not the top', () => {
+    const oldMsg = wrapOldMessage()
+    const optimistic: OptimisticItem = {
+      message: wrapNewMessage(),
+      parts: [] as Part[],
+    }
+    const page = {
+      session: [oldMsg],
+      part: [{ id: oldMsg.id, part: [] as Part[] }],
+      cursor: undefined,
+      complete: true,
+    }
+    const merged = mergeOptimisticPage(page, [optimistic])
+    expect(merged.session.map((m) => m.id)).toEqual([oldMsg.id, optimistic.message.id])
+  })
+})
+
+describe('materializeSessionSnapshots', () => {
+  test('orders materialized messages chronologically across the wrap boundary', () => {
+    const oldMsg = wrapOldMessage()
+    const newMsg = wrapNewMessage()
+    const state = { message: {}, part: {} }
+    const result = materializeSessionSnapshots(state, 'ses_1', [
+      { info: newMsg, parts: [] },
+      { info: oldMsg, parts: [] },
+    ])
+    expect(result.messages.map((m) => m.id)).toEqual([oldMsg.id, newMsg.id])
+    expect(result.message['ses_1'].map((m) => m.id)).toEqual([oldMsg.id, newMsg.id])
+  })
+})
+
+describe('revert helpers', () => {
+  const anchor = wrapOldMessage()
+  const after = message('msg_z_big_id', 1_784_000_100_000)
+  const before = message('msg_a_small_id', 1_783_000_000_000)
+
+  test('isBeforeMessage compares against the anchor chronologically', () => {
+    expect(isBeforeMessage(before, anchor, anchor.id)).toBe(true)
+    expect(isBeforeMessage(after, anchor, anchor.id)).toBe(false)
+    expect(isBeforeMessage(anchor, anchor, anchor.id)).toBe(false)
+  })
+
+  test('isAtOrAfterMessage includes the anchor itself', () => {
+    expect(isAtOrAfterMessage(after, anchor, anchor.id)).toBe(true)
+    expect(isAtOrAfterMessage(anchor, anchor, anchor.id)).toBe(true)
+    expect(isAtOrAfterMessage(before, anchor, anchor.id)).toBe(false)
+  })
+
+  test('isAfterMessage excludes the anchor itself', () => {
+    expect(isAfterMessage(after, anchor, anchor.id)).toBe(true)
+    expect(isAfterMessage(anchor, anchor, anchor.id)).toBe(false)
+  })
+
+  test('falls back to raw id comparison when the anchor is absent', () => {
+    // Without the anchor the id tiebreaker of compareMessages cannot be
+    // applied; behavior matches the historical id-based filter.
+    expect(isBeforeMessage(before, undefined, anchor.id)).toBe(true)
+    expect(isBeforeMessage(after, undefined, anchor.id)).toBe(false)
+  })
+
+  test('findMessageByID locates the anchor linearly', () => {
+    expect(findMessageByID([after, before, anchor], anchor.id)).toBe(anchor)
+    expect(findMessageByID([after, before], anchor.id)).toBeNull()
+  })
+})

--- a/packages/ui/src/sync/messageOrder.ts
+++ b/packages/ui/src/sync/messageOrder.ts
@@ -1,0 +1,75 @@
+export type MessageLike = {
+  id: string
+  time?: { created?: unknown }
+}
+
+export const getMessageCreatedAt = (message: MessageLike): number => {
+  const created = message.time?.created
+  return typeof created === "number" && Number.isFinite(created) ? created : 0
+}
+
+/**
+ * Chronological message comparator: `time.created` first, `id` as tiebreaker.
+ *
+ * OpenCode message IDs encode `Date.now() * 0x1000 + counter` into a
+ * truncated 6-byte (48-bit) hex prefix, which wraps around every
+ * 2^36 ms (~795 days; the wrap occurred on 2026-08-14). Sorting by raw ID
+ * therefore stops being chronological across the wrap boundary and the
+ * newest messages sort before all older ones — they render at the top of the
+ * chat. Every message — server-side and optimistic client inserts — carries
+ * `time.created`, so ordering by time is immune to ID wraps and any future
+ * ID format changes.
+ */
+export const compareMessages = (left: MessageLike, right: MessageLike): number => {
+  const leftTime = getMessageCreatedAt(left)
+  const rightTime = getMessageCreatedAt(right)
+  if (leftTime !== rightTime) return leftTime - rightTime
+  if (left.id === right.id) return 0
+  return left.id < right.id ? -1 : 1
+}
+
+export const sortMessages = <T extends MessageLike>(messages: readonly T[]): T[] => {
+  return [...messages].sort(compareMessages)
+}
+
+/**
+ * Linear id lookup. Message arrays are ordered chronologically
+ * (time.created, then id), so an id-only lookup cannot binary search them.
+ * Used on rare paths (revert anchors, removals) where the cost is negligible.
+ */
+export const findMessageByID = <T extends MessageLike>(messages: readonly T[], id: string): T | undefined => {
+  return messages.find((message) => message.id === id)
+}
+
+/**
+ * Whether `message` is strictly before the revert point. `anchor` is the
+ * revert message itself when still present in the store; when it is missing
+ * (revert optimistically removes it from the store) the raw id comparison is
+ * used as a fallback — in that state the store only contains pre-anchor
+ * messages, so the fallback matches the historical behavior.
+ */
+export const isBeforeMessage = (
+  message: MessageLike,
+  anchor: MessageLike | undefined,
+  anchorID: string,
+): boolean => {
+  return anchor ? compareMessages(message, anchor) < 0 : message.id < anchorID
+}
+
+/** Whether `message` is at or after the revert point (see {@link isBeforeMessage}). */
+export const isAtOrAfterMessage = (
+  message: MessageLike,
+  anchor: MessageLike | undefined,
+  anchorID: string,
+): boolean => {
+  return anchor ? compareMessages(message, anchor) >= 0 : message.id >= anchorID
+}
+
+/** Whether `message` is strictly after the revert point (see {@link isBeforeMessage}). */
+export const isAfterMessage = (
+  message: MessageLike,
+  anchor: MessageLike | undefined,
+  anchorID: string,
+): boolean => {
+  return anchor ? compareMessages(message, anchor) > 0 : message.id > anchorID
+}

--- a/packages/ui/src/sync/optimistic.ts
+++ b/packages/ui/src/sync/optimistic.ts
@@ -1,5 +1,6 @@
 import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { Binary } from "./binary"
+import { compareMessages } from "./messageOrder"
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 
@@ -46,7 +47,10 @@ export function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) 
   const confirmed: string[] = []
 
   for (const item of items) {
-    const result = Binary.search(session, item.message.id, (message) => message.id)
+    // Messages are ordered chronologically (time.created, then id) — see
+    // compareMessages. A raw id search would place messages created after the
+    // OpenCode ID wrap boundary (2026-08-14) before all older ones.
+    const result = Binary.searchBy(session, item.message, compareMessages)
     const found = result.found
     if (!found) session.splice(result.index, 0, item.message)
 
@@ -83,5 +87,5 @@ export function mergeMessages<T extends { id: string }>(a: readonly T[], b: read
     }
   }
   if (!changed) return a as T[]
-  return [...existing.values()].sort((x, y) => cmp(x.id, y.id))
+  return [...existing.values()].sort(compareMessages)
 }

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -5,6 +5,7 @@
 
 import type { OpencodeClient, Session, Message, Part } from "@opencode-ai/sdk/v2/client"
 import { Binary } from "./binary"
+import { findMessageByID, isAtOrAfterMessage, isBeforeMessage, compareMessages } from "./messageOrder"
 import { useSessionUIStore } from "./session-ui-store"
 import { useInputStore } from "./input-store"
 import type { ChildStoreManager } from "./child-store"
@@ -1308,8 +1309,13 @@ export async function optimisticSend(input: {
   const stateBeforeSend = store.getState()
   const sessionBeforeSend = stateBeforeSend.session.find((session) => session.id === input.sessionId)
   const revertMessageID = sessionBeforeSend?.revert?.messageID
+  const storeMessages = stateBeforeSend.message[input.sessionId] ?? []
+  // Messages are ordered chronologically (time.created, then id), so the
+  // revert point must be compared by time — raw id comparison breaks across
+  // the OpenCode ID wrap boundary. The anchor is present at apply time.
+  const revertAnchor = revertMessageID ? findMessageByID(storeMessages, revertMessageID) : undefined
   const revertedMessages = revertMessageID
-    ? (stateBeforeSend.message[input.sessionId] ?? []).filter((message) => message.id >= revertMessageID)
+    ? storeMessages.filter((message) => isAtOrAfterMessage(message, revertAnchor, revertMessageID))
     : []
   const revertedParts = new Map(
     revertedMessages.map((message) => [message.id, stateBeforeSend.part[message.id] ?? []] as const),
@@ -1321,7 +1327,7 @@ export async function optimisticSend(input: {
     ))
     const message = {
       ...stateBeforeSend.message,
-      [input.sessionId]: (stateBeforeSend.message[input.sessionId] ?? []).filter((candidate) => candidate.id < revertMessageID),
+      [input.sessionId]: storeMessages.filter((candidate) => isBeforeMessage(candidate, revertAnchor, revertMessageID)),
     }
     const part = { ...stateBeforeSend.part }
     for (const revertedMessage of revertedMessages) delete part[revertedMessage.id]
@@ -1440,7 +1446,7 @@ export async function optimisticSend(input: {
       message = {
         ...rollbackState.message,
         [input.sessionId]: [...(rollbackState.message[input.sessionId] ?? []), ...revertedMessages]
-          .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)),
+          .sort(compareMessages),
       }
       part = { ...rollbackState.part }
       for (const [revertedMessageID, parts] of revertedParts) {

--- a/packages/ui/src/sync/session-message-loader.ts
+++ b/packages/ui/src/sync/session-message-loader.ts
@@ -3,6 +3,7 @@ import type { ChildStoreManager, DirectoryStore } from "./child-store"
 import { Binary } from "./binary"
 import { retry } from "./retry"
 import { mergeOptimisticPage, type OptimisticItem } from "./optimistic"
+import { compareMessages } from "./messageOrder"
 import { stripMessageDiffSnapshots } from "./sanitize"
 import { getSessionMaterializationStatus, materializeSessionSnapshots } from "./materialization"
 import {
@@ -345,7 +346,9 @@ export class SessionMessageLoader {
     const store = this.childStores.ensureChild(target.directory, { bootstrap: false })
     const current = store.getState()
     const messages = current.message[target.sessionID] ? [...current.message[target.sessionID]] : []
-    const result = Binary.search(messages, input.message.id, (message) => message.id)
+    // Messages are ordered chronologically (time.created, then id); searching
+    // by raw id would misplace messages across the OpenCode ID wrap boundary.
+    const result = Binary.searchBy(messages, input.message, compareMessages)
     if (!result.found) messages.splice(result.index, 0, input.message)
     store.setState({
       message: { ...current.message, [target.sessionID]: messages },
@@ -603,7 +606,7 @@ export class SessionMessageLoader {
       if (performance) performance.recordCount += recordCount
       const session = records
         .map((record: { info: Message }) => stripMessageDiffSnapshots(record.info))
-        .sort((left: Message, right: Message) => cmp(left.id, right.id))
+        .sort(compareMessages)
       const partsByMessageID = new Map<string, Part[]>()
       for (const record of records as Array<{ info: { id: string }; parts?: Part[] }>) {
         partsByMessageID.set(record.info.id, sortParts(record.parts ?? []))

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -50,6 +50,7 @@ import {
 } from "./session-directory-resolution"
 import { markSessionViewed } from "./notification-store"
 import { setActiveSession } from "./sync-context"
+import { isBeforeMessage, isAfterMessage } from "./messageOrder"
 import {
   createSession as createSessionAction,
   deleteSession as deleteSessionAction,
@@ -1488,9 +1489,10 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     if (userMessages.length === 0) return
 
     const revertToId = currentSession?.revert?.messageID
+    const revertAnchor = revertToId ? messages.find((m) => m.id === revertToId) : undefined
     let targetMessage: typeof messages[number] | undefined
     if (revertToId) {
-      targetMessage = [...userMessages].reverse().find((m) => m.id < revertToId)
+      targetMessage = [...userMessages].reverse().find((m) => isBeforeMessage(m, revertAnchor, revertToId))
     } else {
       targetMessage = userMessages[userMessages.length - 1]
     }
@@ -1537,7 +1539,8 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     await refetchSessionMessages(sessionId)
     const messages = getSyncMessages(sessionId)
     const userMessages = messages.filter((m) => m.role === "user")
-    const targetMessage = userMessages.find((m) => m.id > revertToId)
+    const revertAnchor = messages.find((m) => m.id === revertToId)
+    const targetMessage = userMessages.find((m) => isAfterMessage(m, revertAnchor, revertToId))
 
     if (targetMessage) {
       await get().revertToMessage(sessionId, targetMessage.id, { skipRedoPush: true })

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -31,6 +31,7 @@ import {
 import { bootstrapGlobal, bootstrapDirectory } from "./bootstrap"
 import { retry } from "./retry"
 import { touchStreamingSession, updateChangedStreamingSessions, updateStreamingState } from "./streaming"
+import { findMessageByID, isBeforeMessage } from "./messageOrder"
 import { countSyncPerformance } from "./performance-diagnostics"
 import { runBackgroundNetworkTask } from "@/lib/background-network"
 import { setActionRefs } from "./session-actions"
@@ -2995,7 +2996,13 @@ function getVisibleMessagesForSession(state: State, sessionID: string, previous?
 
   return {
     sourceMessages,
-    visibleMessages: revertMessageID ? sourceMessages.filter((message) => message.id < revertMessageID) : sourceMessages,
+    visibleMessages: revertMessageID
+      ? sourceMessages.filter((message) => isBeforeMessage(
+          message,
+          findMessageByID(sourceMessages, revertMessageID),
+          revertMessageID,
+        ))
+      : sourceMessages,
     revertMessageID,
   }
 }

--- a/packages/ui/src/sync/use-sync.test.ts
+++ b/packages/ui/src/sync/use-sync.test.ts
@@ -83,8 +83,9 @@ describe('incremental materialization of superset pages (#2084)', () => {
     // Simulate expansion: commit 50 (assistant-only), then 100 (with user), then 150.
     // Pages are supersets: the 100-page includes all 50 from the first page,
     // the 150-page includes all 100 from the second.
-    // Messages are sorted by id in the store (mergeMessages uses cmp by id),
-    // so look them up by id rather than positional index.
+    // Messages are sorted chronologically in the store (time.created, then
+    // id — see sync/messageOrder.ts), so look them up by id rather than
+    // positional index.
     const a1 = assistantMessage('a_1')
     const a2 = assistantMessage('a_2')
     const u1 = userMessage('u_1')

--- a/packages/ui/src/sync/user-message-history.ts
+++ b/packages/ui/src/sync/user-message-history.ts
@@ -1,4 +1,5 @@
 import type { Message, Part } from '@opencode-ai/sdk/v2/client';
+import { findMessageByID, isBeforeMessage } from './messageOrder';
 import type { State } from './types';
 
 type UserMessageHistoryRecord = {
@@ -61,13 +62,14 @@ export const buildUserMessageHistorySnapshot = (
   const messages = state.message[sessionID] ?? [];
   const session = state.session.find((candidate) => candidate.id === sessionID);
   const revertMessageID = (session as { revert?: { messageID?: string } } | undefined)?.revert?.messageID;
+  const revertAnchor = revertMessageID ? findMessageByID(messages, revertMessageID) : undefined;
   const records: UserMessageHistoryRecord[] = [];
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (message.role !== 'user') {
       continue;
     }
-    if (revertMessageID && message.id >= revertMessageID) {
+    if (revertMessageID && !isBeforeMessage(message, revertAnchor, revertMessageID)) {
       continue;
     }
     records.push({


### PR DESCRIPTION
## Problem

OpenCode message IDs embed `Date.now() * 0x1000 + counter` into a **truncated 6-byte (48-bit) hex prefix** (`msg_<12 hex><14 base62>`). That ID space wraps around every 2^36 ms (~**795 days**), and the latest wrap occurred **2026-08-14 11:19:55 UTC**.

OpenChamber's sync layer ordered messages by **string-comparing raw IDs** (`cmp(a.id, b.id)`) in several places. After the wrap, any message created *after* the boundary gets an ID prefix near `0000…`, which lexicographically sorts **before** all older IDs (`e3…`–`ffff…`). Result: in any session spanning the boundary, the **newest messages render at the top of the chat**.

I verified this against a real database: the same session contained `msg_fffc192a8001…` (2026-08-14 10:11 UTC, before the wrap) and `msg_0005afbc2002…` (12:59 UTC, after the wrap) — the raw-ID sort places the 12:59 messages before the 10:11 ones.

## Fix

Order messages chronologically using `time.created` (present on every message, including optimistic client inserts), with `id` only as a same-millisecond tiebreaker:

- **New `sync/messageOrder.ts`** — `compareMessages`, `sortMessages`, `findMessageByID`, and revert-anchor helpers (`isBeforeMessage`, `isAtOrAfterMessage`, `isAfterMessage`) that fall back to raw ID comparison when the anchor message has been optimistically removed from the store.
- **`Binary.searchBy()`** — binary search against a full ordering comparator (returns insertion index).
- **Sorts/searchs converted to chronological order** in `optimistic.ts` (`mergeMessages`, `mergeOptimisticPage`), `session-message-loader.ts` (fetched pages, optimistic insert), `materialization.ts` (snapshot merge), and `event-reducer.ts` (`message.updated`).
- **Id-only lookups** (`message.removed`, `hasMessage`, revert anchors) use bounded linear scans since a chronological array can't be binary searched by id alone.
- **Revert-point comparisons** (`session-actions.ts`, `session-ui-store.ts`, `sync-context.tsx`, `user-message-history.ts`, `revertedMessageDockState.ts`) now use the chronological comparator.
- **Parts remain id-ordered** — they're scoped to a single message, so the wrap cannot reorder them.

## Tests

New `sync/messageOrder.test.ts` covers the wrap-boundary regression at the comparator, merge, optimistic-merge, and materialization levels, plus the revert helpers. Full `src/sync` suite (52 files) and `src/components/chat` suite (53 files) pass; `tsc --noEmit` and eslint are clean.