### PR TITLE
fix(electron): prefer process.cwd() when it looks like a project root (closes #1392)

### DIFF
--- a/packages/electron/opencode-cwd.mjs
+++ b/packages/electron/opencode-cwd.mjs
@@ -1,3 +1,30 @@
+import { existsSync } from 'node:fs';
+
+// Markers that identify a directory as a project root. If process.cwd() matches
+// any of these we use it directly instead of falling back to HOME. Without
+// this, opencode re-indexes the user's home directory recursively on every
+// restart, leaking memory and blocking the proxy health-check.
+const PROJECT_MARKERS = [
+  '.git',
+  'package.json',
+  'Cargo.toml',
+  'go.mod',
+  'pyproject.toml',
+];
+
+const looksLikeProjectRoot = (dir) => {
+  if (typeof dir !== 'string' || !dir) return false;
+  return PROJECT_MARKERS.some((marker) => {
+    try {
+      return existsSync(`${dir}/${marker}`) || existsSync(`${dir}\\${marker}`);
+    } catch {
+      return false;
+    }
+  });
+};
+
+let warnedAboutHomeFallback = false;
+
 export const resolveManagedOpenCodeCwd = ({ env, homedir }) => {
   const configured = typeof env?.OPENCHAMBER_OPENCODE_CWD === 'string'
     ? env.OPENCHAMBER_OPENCODE_CWD.trim()
@@ -6,6 +33,29 @@ export const resolveManagedOpenCodeCwd = ({ env, homedir }) => {
     return configured;
   }
 
+  const cwd = process.cwd();
+  if (looksLikeProjectRoot(cwd)) {
+    return cwd;
+  }
+
   const home = typeof homedir === 'function' ? homedir() : '';
-  return typeof home === 'string' && home.trim() ? home : process.cwd();
+  if (typeof home === 'string' && home.trim()) {
+    if (!warnedAboutHomeFallback) {
+      warnedAboutHomeFallback = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[openchamber] cwd ${cwd} does not look like a project root; ` +
+          `falling back to home (${home}). ` +
+          `Set OPENCHAMBER_OPENCODE_CWD to silence this warning.`,
+      );
+    }
+    return home;
+  }
+  return cwd;
+};
+
+// Test-only export: reset the once-per-process warning flag so each test sees
+// the warning behaviour from a clean slate.
+export const __resetCwdFallbackWarning = () => {
+  warnedAboutHomeFallback = false;
 };

--- a/packages/electron/opencode-cwd.test.mjs
+++ b/packages/electron/opencode-cwd.test.mjs
@@ -1,7 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';mock.module('node:fs', () => ({
+  existsSync: mock(() => false),
 }));
 
 import { existsSync } from 'node:fs';
@@ -17,14 +15,13 @@ describe('resolveManagedOpenCodeCwd', () => {
 
   beforeEach(() => {
     __resetCwdFallbackWarning();
-    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/Users/example');
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    cwdSpy = spyOn(process, 'cwd').mockReturnValue('/Users/example');
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     cwdSpy.mockRestore();
     warnSpy.mockRestore();
-    vi.resetAllMocks();
   });
 
   it('defaults managed OpenCode cwd to the user home directory', () => {
@@ -75,7 +72,6 @@ describe('resolveManagedOpenCodeCwd', () => {
   it('suppresses the home-fallback warning on subsequent calls', () => {
     cwdSpy.mockReturnValue('/Users/example');
     existsSync.mockReturnValue(false);
-    resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
     resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
     resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
     expect(warnSpy).toHaveBeenCalledTimes(1);

--- a/packages/electron/opencode-cwd.test.mjs
+++ b/packages/electron/opencode-cwd.test.mjs
@@ -1,23 +1,83 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveManagedOpenCodeCwd } from './opencode-cwd.mjs';
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+import { existsSync } from 'node:fs';
+
+import {
+  __resetCwdFallbackWarning,
+  resolveManagedOpenCodeCwd,
+} from './opencode-cwd.mjs';
 
 describe('resolveManagedOpenCodeCwd', () => {
+  let cwdSpy;
+  let warnSpy;
+
+  beforeEach(() => {
+    __resetCwdFallbackWarning();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/Users/example');
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    warnSpy.mockRestore();
+    vi.resetAllMocks();
+  });
+
   it('defaults managed OpenCode cwd to the user home directory', () => {
-    expect(resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' })).toBe('/Users/example');
+    existsSync.mockReturnValue(false);
+    expect(
+      resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' }),
+    ).toBe('/Users/example');
   });
 
   it('preserves an explicit cwd override', () => {
-    expect(resolveManagedOpenCodeCwd({
-      env: { OPENCHAMBER_OPENCODE_CWD: '/tmp/opencode-cwd' },
-      homedir: () => '/Users/example',
-    })).toBe('/tmp/opencode-cwd');
+    expect(
+      resolveManagedOpenCodeCwd({
+        env: { OPENCHAMBER_OPENCODE_CWD: '/tmp/opencode-cwd' },
+        homedir: () => '/Users/example',
+      }),
+    ).toBe('/tmp/opencode-cwd');
   });
 
   it('ignores a blank cwd override', () => {
-    expect(resolveManagedOpenCodeCwd({
-      env: { OPENCHAMBER_OPENCODE_CWD: '   ' },
-      homedir: () => '/Users/example',
-    })).toBe('/Users/example');
+    existsSync.mockReturnValue(false);
+    expect(
+      resolveManagedOpenCodeCwd({
+        env: { OPENCHAMBER_OPENCODE_CWD: '   ' },
+        homedir: () => '/Users/example',
+      }),
+    ).toBe('/Users/example');
+  });
+
+  it('prefers process.cwd() when it looks like a project root', () => {
+    cwdSpy.mockReturnValue('/repos/openchamber');
+    existsSync.mockImplementation((p) => typeof p === 'string' && p.includes('package.json'));
+    expect(
+      resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' }),
+    ).toBe('/repos/openchamber');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to home with a single warning when cwd is not a project root', () => {
+    cwdSpy.mockReturnValue('/Users/example');
+    existsSync.mockReturnValue(false);
+    expect(
+      resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' }),
+    ).toBe('/Users/example');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('does not look like a project root');
+  });
+
+  it('suppresses the home-fallback warning on subsequent calls', () => {
+    cwdSpy.mockReturnValue('/Users/example');
+    existsSync.mockReturnValue(false);
+    resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
+    resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
+    resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Intent

Closes #1392. Related to #2784.

`opencode serve` is launched by the desktop app with `cwd` resolved from `resolveManagedOpenCodeCwd`. When `OPENCHAMBER_OPENCODE_CWD` is unset and the calling process's cwd is not the user's home directory, this function falls back to `homedir()` instead of preferring the project root. The result: `opencode` re-indexes the user's home directory recursively on every restart, leaks memory, and leaves zombie processes that break the proxy health-check (`periodic health check failed (N/20)` every 15s, `socket hang up` / `ECONNREFUSED` on the internal proxy port).

This PR makes `resolveManagedOpenCodeCwd` prefer `process.cwd()` first when it contains any standard project marker (`.git`, `package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`). Only falls back to `homedir()` when cwd is not a project root, and emits a single `console.warn` the first time so users notice the misconfiguration without log spam.

## Why not silence instead of fix

#2784 explicitly documents that the "\not a git repository" warning from `getWorktrees` is intentional per the `opencode-cwd.mjs` design (managed OpenCode runs with `cwd: <homedir>`). That PR silences the symptom; this one addresses the root cause by changing what cwd the managed process receives. Silencing alone would still leave the memory leak and the zombie-process lifecycle intact.

## Non-goals

- No removal of `OPENCHAMBER_OPENCODE_CWD` env var; it stays as the first-priority override and is what users/admins set when they want a non-project explicit path (containers, custom configs).
- No behavior change for users who already set `OPENCHAMBER_OPENCODE_CWD` — the env var path is unchanged.
- No change to the public function signature.
- No upstream-caller fix in this PR; this is the function itself.

## Affected surfaces

| Surface | Effect |
|---|---|
| `packages/electron/opencode-cwd.mjs` | Add `existsSync` import and a `looksLikeProjectRoot` helper; reorder the resolution so project-root `process.cwd()` wins over `homedir()`; add a one-shot `console.warn` flag with a test-only `__resetCwdFallbackWarning` export. |
| `packages/electron/opencode-cwd.test.mjs` | Mock `node:fs`, stub `process.cwd()` and `console.warn`, expand from 3 to 6 tests covering: defaults → home, env override wins, blank env falls through, project cwd preferred, single warning across repeated calls, warning content. |

## Validation

- `./packages/web/node_modules/.bin/vitest run packages/electron/opencode-cwd.test.mjs --root packages/electron` → **6 passed / 0 failed**.
- Existing tests unchanged in semantics; the test for "defaults to home" now also stubs `process.cwd()` to a non-project path so the new behavior doesn't regress it.

## Risk and failure behavior

- **Behavior change**: only the resolution order between `process.cwd()` and `homedir()`; the env var path is untouched.
- **False positive**: a non-project directory that happens to have any of the listed markers will be used. The markers (`.git`, `package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`) are conventional enough that this is the right trade-off; users with a true mismatch can still set `OPENCHAMBER_OPENCODE_CWD`.
- **Warning spam**: prevented by the once-per-process flag; tests reset the flag explicitly so test ordering doesn't matter.
- **Rollback**: revert the commit; behavior reverts to always preferring `homedir()` without any persisted state change.

## Reproduction evidence (before)

````
# From a non-project cwd with OPENCHAMBER_OPENCODE_CWD unset:
$ openchamber  # launches opencode serve with cwd = ~/.home
```

After this PR the same launch resolves to the project cwd when one is detected; only falls back to home when the cwd is genuinely not a project root, with one warning telling the user how to silence it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)