### PR TITLE
fix(settings): persist sessionRetentionAction through the settings sanitizer

### DIFF
--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -375,6 +375,9 @@ export const createSettingsHelpers = (dependencies) => {
       const normalizedDays = Math.max(1, Math.min(365, Math.round(candidate.autoDeleteAfterDays)));
       result.autoDeleteAfterDays = normalizedDays;
     }
+    if (candidate.sessionRetentionAction === 'archive' || candidate.sessionRetentionAction === 'delete') {
+      result.sessionRetentionAction = candidate.sessionRetentionAction;
+    }
     if (candidate.tunnelBootstrapTtlMs === null) {
       result.tunnelBootstrapTtlMs = null;
     } else if (typeof candidate.tunnelBootstrapTtlMs === 'number' && Number.isFinite(candidate.tunnelBootstrapTtlMs)) {

--- a/packages/web/server/lib/opencode/settings-helpers.test.js
+++ b/packages/web/server/lib/opencode/settings-helpers.test.js
@@ -466,4 +466,39 @@ describe('settings helpers', () => {
       expect(sanitized.recentModels).toEqual(payload.recentModels);
     });
   });
+
+  describe('session retention settings persistence', () => {
+    it('round-trips sessionRetentionAction archive and delete through the sanitizer', () => {
+      const helpers = createTestHelpersWithRealSanitizers();
+
+      expect(helpers.sanitizeSettingsUpdate({ sessionRetentionAction: 'archive' })).toEqual({
+        sessionRetentionAction: 'archive',
+      });
+      expect(helpers.sanitizeSettingsUpdate({ sessionRetentionAction: 'delete' })).toEqual({
+        sessionRetentionAction: 'delete',
+      });
+    });
+
+    it('rejects invalid sessionRetentionAction values', () => {
+      const helpers = createTestHelpersWithRealSanitizers();
+
+      expect(helpers.sanitizeSettingsUpdate({ sessionRetentionAction: 'remove' })).toEqual({});
+      expect(helpers.sanitizeSettingsUpdate({ sessionRetentionAction: true })).toEqual({});
+    });
+
+    it('survives a full settings payload containing sessionRetentionAction (regression)', () => {
+      const helpers = createTestHelpersWithRealSanitizers();
+      const payload = {
+        autoDeleteEnabled: true,
+        autoDeleteAfterDays: 60,
+        sessionRetentionAction: 'delete',
+      };
+
+      const sanitized = helpers.sanitizeSettingsUpdate(payload);
+
+      expect(sanitized.autoDeleteEnabled).toBe(true);
+      expect(sanitized.autoDeleteAfterDays).toBe(60);
+      expect(sanitized.sessionRetentionAction).toBe('delete');
+    });
+  });
 });


### PR DESCRIPTION
## Issue

Closes #2803

Fix follows the exact approach proposed in the issue itself (add `sessionRetentionAction` to `sanitizeSettingsUpdate`); its proposed frontend change was verified unnecessary.

## Intent

`sessionRetentionAction` (Settings → Sessions → "When sessions expire": `archive`/`delete`) is never saved to `settings.json`. The server sanitizer whitelist is missing this field, so both write and read paths drop it. This adds the missing entry.

## Non-goals

- No frontend changes — persistence already handled globally by `startAppearanceAutoSave()`.
- No server-side cleanup behavior — server only stores the preference; cleanup is UI-side.

## Affected surfaces

- `packages/web/server/lib/opencode/settings-helpers.js` — `sanitizeSettingsUpdate` (+1 whitelist entry).
- Persisted: `sessionRetentionAction` now round-trips through `settings.json`.
- Web + Electron fixed (both persist via this sanitizer); VS Code/mobile UI-only on this path, unaffected.

### Git history (why this happened)

Oversight, not a deep bug:

1. 4075e1560 (Dec '25) added `autoDeleteEnabled`/`autoDeleteAfterDays`. Server untouched.
2. b32ed938 (#803, Mar '26) created server `settings-helpers.js` and added `sessionRetentionAction` to UI in the same commit, but its server mirror only copied the `autoDelete*` fields — missed the new one.
3. Never added since. This PR restores the missing mirror.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Source change in web server; persisted contract | Smallest complete change: one entry + focused tests. No migration (new persisted field). |

## Validation

| Check | Result |
|---|---|
| `packages/web/server/lib/opencode/settings-helpers.test.js` (TDD, pre-fix) | 35 pass / 2 fail — exactly the 2 assertions asserting the field survives |
| `packages/web/server/lib/opencode/settings-helpers.test.js` (TDD, post-fix) | 37 pass / 0 fail |
| `bun run type-check` | Pass |
| `bun run lint` | Pass |
| `bun run test` | Pass |
| `bun run build` | Pass |

## Visual evidence

None — server-side persistence only, no UI rendering change.

## Risks and failure behavior

- Failure: failed write reverts as before; this only widens the whitelist.
- Compatibility: older versions drop the field again (today's behavior); no migration needed.
- Security: whitelist stays strict — only `archive`/`delete` accepted, garbage rejected.
