### PR TITLE
fix(ui): stop the context meter from counting every internal round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Chat: new chats no longer start against a deleted last worktree directory; they fall back to the active project instead of saving the first message and never starting.
 - Chat: opening a busy subagent in the context panel now shows its history instead of only the working-status line (thanks to @makeittech).
 - Chat: saved chats in the context panel open again instead of staying blank.
+- Chat: the context meter no longer climbs over 100% (330% readouts) after turns with many tool calls and no longer jumps when reopening an older session; it now shows what the window actually holds, everywhere the value appears — header, context sidebar, work status panel, mini chat, and mobile.
 - Projects: project names now match the folder name exactly, so `.ssh` and `opencode-claude` are no longer shown as `.Ssh` and `Opencode Claude` in the sidebar, window title, settings and notifications; names you renamed yourself are kept.
 - Settings: the session retention action you pick is now saved instead of being dropped (thanks to @Gautam0507).
 - Browser: typing a comment on a page no longer triggers app shortcuts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Chat: new chats no longer start against a deleted last worktree directory; they fall back to the active project instead of saving the first message and never starting.
 - Chat: opening a busy subagent in the context panel now shows its history instead of only the working-status line (thanks to @makeittech).
 - Chat: saved chats in the context panel open again instead of staying blank.
-- Chat: the context meter no longer climbs over 100% (330% readouts) after turns with many tool calls and no longer jumps when reopening an older session; it now shows what the window actually holds, everywhere the value appears — header, context sidebar, work status panel, mini chat, and mobile.
+- Chat: the context meter no longer climbs over 100% (330% readouts) after turns with many tool calls and no longer jumps when reopening an older session; it now shows what the window actually holds, everywhere the value appears — header, context sidebar, work status panel, mini chat, and mobile (thanks to @pocharlies).
 - Projects: project names now match the folder name exactly, so `.ssh` and `opencode-claude` are no longer shown as `.Ssh` and `Opencode Claude` in the sidebar, window title, settings and notifications; names you renamed yourself are kept.
 - Settings: the session retention action you pick is now saved instead of being dropped (thanks to @Gautam0507).
 - Browser: typing a comment on a page no longer triggers app shortcuts.

--- a/packages/ui/src/apps/MobileSessionMetadata.tsx
+++ b/packages/ui/src/apps/MobileSessionMetadata.tsx
@@ -388,6 +388,7 @@ export const MobileSessionMetadataButton = React.memo(function MobileSessionMeta
     for (let i = activeSessionMessages.length - 1; i >= 0; i -= 1) {
       const message = activeSessionMessages[i] as typeof activeSessionMessages[number] & {
         tokens?: {
+          total?: unknown;
           input?: unknown;
           output?: unknown;
           reasoning?: unknown;
@@ -395,6 +396,11 @@ export const MobileSessionMetadataButton = React.memo(function MobileSessionMeta
         };
       };
       if (message.role !== 'assistant' || !message.tokens) continue;
+      // Multi-step turns accumulate the fields across API round-trips, so
+      // summing them overstates the window. The server-reported total is the
+      // final round-trip's window; sum only when the server did not send it.
+      const reportedTotal = getTokenCount(message.tokens.total);
+      if (reportedTotal > 0) return reportedTotal;
       const total = getTokenCount(message.tokens.input)
         + getTokenCount(message.tokens.output)
         + getTokenCount(message.tokens.reasoning)

--- a/packages/ui/src/components/chat/work-status/contextUsage.test.ts
+++ b/packages/ui/src/components/chat/work-status/contextUsage.test.ts
@@ -14,8 +14,8 @@ describe('computeContextUsage', () => {
   });
 
   test('reports the latest turn rather than a sum across turns', () => {
-    // Each assistant turn reports the whole window it saw, so adding them up
-    // would report several times the real fill.
+    // A turn's tokens describe that turn's window, so adding turns up would
+    // report several times the real fill.
     const usage = computeContextUsage(
       [
         assistant({ input: 400, output: 0, reasoning: 0 }, 'old'),
@@ -60,5 +60,25 @@ describe('computeContextUsage', () => {
   test('tolerates partial token payloads', () => {
     const usage = computeContextUsage([assistant({ input: 10 })], 100);
     expect(usage?.totalTokens).toBe(10);
+  });
+
+  test('prefers the server-reported total over summing round-trip fields', () => {
+    // Real payload from opencode 1.18.18: ~14 tool-call round-trips accumulated
+    // cache.read to 3.29M while the 1M window really held 232,872. Summing
+    // rendered 330.6%; the reported total renders the real 23.3%.
+    const usage = computeContextUsage(
+      [assistant({ total: 232_872, input: 0, output: 14_523, reasoning: 0, cache: { read: 3_291_956, write: 0 } })],
+      1_000_000,
+    );
+    expect(usage?.totalTokens).toBe(232_872);
+    expect(usage?.percent.toFixed(4)).toBe('23.2872');
+  });
+
+  test('selects a message whose only signal is the reported total', () => {
+    const usage = computeContextUsage(
+      [assistant({ total: 5_000, input: 0, output: 0, reasoning: 0 })],
+      100_000,
+    );
+    expect(usage?.totalTokens).toBe(5_000);
   });
 });

--- a/packages/ui/src/components/chat/work-status/contextUsage.ts
+++ b/packages/ui/src/components/chat/work-status/contextUsage.ts
@@ -13,7 +13,11 @@
  * global read to race with.
  */
 
+import { contextTokensFromBreakdown } from '@/stores/utils/tokenUtils';
+
 type MessageTokens = {
+  /** Server-reported window of the turn's final round-trip; absent on older servers. */
+  total?: number;
   input?: number;
   output?: number;
   reasoning?: number;
@@ -37,18 +41,12 @@ type WorkStatusContextUsage = {
 /** The store's own fallback when a model exposes no context limit. */
 export const DEFAULT_CONTEXT_LIMIT = 200_000;
 
-const sumTokens = (tokens: MessageTokens): number => (
-  (tokens.input ?? 0)
-  + (tokens.output ?? 0)
-  + (tokens.reasoning ?? 0)
-  + (tokens.cache?.read ?? 0)
-  + (tokens.cache?.write ?? 0)
-);
-
 /**
  * Usage from the newest assistant message that reported a non-zero token count.
- * Each assistant turn reports the whole window it saw, so the latest one is the
- * current fill — not a sum across turns.
+ * The latest turn describes the current fill — not a sum across turns. Within
+ * a turn, the server-reported `total` is the final round-trip's window;
+ * summing the breakdown fields instead overstates multi-step turns, whose
+ * input/cache fields accumulate across round-trips.
  */
 export const computeContextUsage = (
   messages: readonly MessageLike[],
@@ -60,7 +58,7 @@ export const computeContextUsage = (
     const message = messages[index];
     if (message?.role !== 'assistant' || !message.tokens) continue;
 
-    const totalTokens = sumTokens(message.tokens);
+    const totalTokens = contextTokensFromBreakdown(message.tokens);
     if (totalTokens <= 0) continue;
 
     const limit = contextLimit > 0 ? contextLimit : DEFAULT_CONTEXT_LIMIT;

--- a/packages/ui/src/components/layout/ContextSidebarTab.tsx
+++ b/packages/ui/src/components/layout/ContextSidebarTab.tsx
@@ -92,6 +92,7 @@ const extractTokenBreakdown = (message: SessionMessage): TokenBreakdown => {
   }
 
   const breakdown = source as {
+    total?: unknown;
     input?: unknown;
     output?: unknown;
     reasoning?: unknown;
@@ -103,6 +104,10 @@ const extractTokenBreakdown = (message: SessionMessage): TokenBreakdown => {
   const reasoning = toNonNegativeNumber(breakdown.reasoning);
   const cacheRead = toNonNegativeNumber(breakdown.cache?.read);
   const cacheWrite = toNonNegativeNumber(breakdown.cache?.write);
+  // Multi-step turns accumulate the fields across API round-trips (every tool
+  // call re-reads the whole cached prompt), so summing them overstates the
+  // window. The server-reported total is the final round-trip's window.
+  const reportedTotal = toNonNegativeNumber(breakdown.total);
 
   return {
     input,
@@ -110,7 +115,7 @@ const extractTokenBreakdown = (message: SessionMessage): TokenBreakdown => {
     reasoning,
     cacheRead,
     cacheWrite,
-    total: input + output + reasoning + cacheRead + cacheWrite,
+    total: reportedTotal > 0 ? reportedTotal : input + output + reasoning + cacheRead + cacheWrite,
   };
 };
 

--- a/packages/ui/src/components/layout/VSCodeLayout.tsx
+++ b/packages/ui/src/components/layout/VSCodeLayout.tsx
@@ -8,6 +8,7 @@ import { useViewportStore } from '@/sync/viewport-store';
 import { useSessions, useDirectorySync, useSessionMessages, useSessionMessagesResolved } from '@/sync/sync-context';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { resolveGlobalSessionDirectory, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
+import { contextTokensFromBreakdown } from '@/stores/utils/tokenUtils';
 import { ContextUsageDisplay } from '@/components/ui/ContextUsageDisplay';
 import { McpDropdown } from '@/components/mcp/McpDropdown';
 import { ArchiveAllDropdown } from '@/components/session/ArchiveAllDropdown';
@@ -702,7 +703,7 @@ const VSCodeHeader: React.FC<VSCodeHeaderProps> = ({ title, showBack, onBack, on
       }
 
       if (!lastTokens && message.tokens) {
-        const total = message.tokens.input + message.tokens.output + message.tokens.reasoning + (message.tokens.cache?.read ?? 0) + (message.tokens.cache?.write ?? 0);
+        const total = contextTokensFromBreakdown(message.tokens);
         if (total > 0) {
           lastTokens = message.tokens;
           lastMessageId = (currentSessionMessages[i] as { id?: string }).id;
@@ -730,7 +731,7 @@ const VSCodeHeader: React.FC<VSCodeHeaderProps> = ({ title, showBack, onBack, on
     }
 
     const lastTokens = headerMessageSummary.lastTokens;
-    const totalTokens = lastTokens.input + lastTokens.output + lastTokens.reasoning + (lastTokens.cache?.read ?? 0) + (lastTokens.cache?.write ?? 0);
+    const totalTokens = contextTokensFromBreakdown(lastTokens);
     const thresholdLimit = contextLimit > 0 ? contextLimit : 200000;
     const percentage = contextLimit > 0 ? Math.round((totalTokens / contextLimit) * 100) : 0;
     const normalizedOutput = outputLimit > 0 ? Math.round((lastTokens.output / outputLimit) * 100) : undefined;

--- a/packages/ui/src/components/mini-chat/MiniChatLayout.tsx
+++ b/packages/ui/src/components/mini-chat/MiniChatLayout.tsx
@@ -18,6 +18,7 @@ import { useGitBranchLabel, useGitStore } from '@/stores/useGitStore';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { Icon } from "@/components/icon/Icon";
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
+import { contextTokensFromBreakdown } from '@/stores/utils/tokenUtils';
 import type { SessionContextUsage } from '@/stores/types/sessionTypes';
 
 type MiniChatMode = 'session' | 'draft';
@@ -157,7 +158,7 @@ const MiniChatHeader: React.FC<{ mode: MiniChatMode }> = ({ mode }) => {
       return null;
     }
 
-    type AssistantTokens = { input: number; output: number; reasoning: number; cache: { read: number; write: number } };
+    type AssistantTokens = { total?: number; input: number; output: number; reasoning: number; cache: { read: number; write: number } };
     let lastTokens: AssistantTokens | undefined;
     let lastMessageId: string | undefined;
 
@@ -166,7 +167,7 @@ const MiniChatHeader: React.FC<{ mode: MiniChatMode }> = ({ mode }) => {
       if (message.role !== 'assistant') continue;
       const tokens = (message as { tokens?: AssistantTokens }).tokens;
       if (!tokens) continue;
-      const total = tokens.input + tokens.output + tokens.reasoning + (tokens.cache?.read ?? 0) + (tokens.cache?.write ?? 0);
+      const total = contextTokensFromBreakdown(tokens);
       if (total > 0) {
         lastTokens = tokens;
         lastMessageId = message.id;
@@ -178,7 +179,7 @@ const MiniChatHeader: React.FC<{ mode: MiniChatMode }> = ({ mode }) => {
       return null;
     }
 
-    const totalTokens = lastTokens.input + lastTokens.output + lastTokens.reasoning + (lastTokens.cache?.read ?? 0) + (lastTokens.cache?.write ?? 0);
+    const totalTokens = contextTokensFromBreakdown(lastTokens);
     const thresholdLimit = contextLimit > 0 ? contextLimit : 200000;
     const percentage = contextLimit > 0 ? Math.round((totalTokens / contextLimit) * 100) : 0;
     const normalizedOutput = outputLimit > 0 ? Math.round((lastTokens.output / outputLimit) * 100) : undefined;

--- a/packages/ui/src/stores/utils/tokenUtils.test.ts
+++ b/packages/ui/src/stores/utils/tokenUtils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { computeCacheHitRate, sumTokenBreakdown } from "./tokenUtils"
+import type { Message, Part } from "@opencode-ai/sdk/v2"
+import { computeCacheHitRate, contextTokensFromBreakdown, extractTokensFromMessage, sumTokenBreakdown } from "./tokenUtils"
+
+const assistantMessage = (tokens: unknown): { info: Message; parts: Part[] } => ({
+  info: { tokens } as unknown as Message,
+  parts: [],
+})
 
 describe("computeCacheHitRate", () => {
   test("returns zero and hasInput=false for null input", () => {
@@ -93,5 +99,69 @@ describe("sumTokenBreakdown (regression)", () => {
   test("handles null safely", () => {
     expect(sumTokenBreakdown(null)).toBe(0)
     expect(sumTokenBreakdown(undefined)).toBe(0)
+  })
+})
+
+describe("contextTokensFromBreakdown", () => {
+  test("prefers the server-reported total over the summed fields", () => {
+    const breakdown = { total: 500, input: 100, output: 50, reasoning: 20, cache: { read: 800, write: 20 } }
+    expect(contextTokensFromBreakdown(breakdown)).toBe(500)
+  })
+
+  test("real multi-step turn: summing overstates a 1M window 14x, the total matches it", () => {
+    // Captured from opencode 1.18.18 (/session/:id/message) after a turn with
+    // ~14 tool-call round-trips. Every round-trip re-reads the whole cached
+    // prompt, so cache.read accumulates to 3.29M while the window really held
+    // 232,872. Summing rendered the context meter at 330.6% of a 1M window.
+    const breakdown = { total: 232_872, input: 0, output: 14_523, reasoning: 0, cache: { read: 3_291_956, write: 0 } }
+    expect(contextTokensFromBreakdown(breakdown)).toBe(232_872)
+    expect(sumTokenBreakdown(breakdown)).toBe(3_306_479)
+  })
+
+  test("single-step turn: the total and the summed fields agree", () => {
+    // Captured from the same server: one round-trip, nothing accumulates.
+    const breakdown = { total: 117_714, input: 1_116, output: 87, reasoning: 543, cache: { read: 115_968, write: 0 } }
+    expect(contextTokensFromBreakdown(breakdown)).toBe(sumTokenBreakdown(breakdown))
+  })
+
+  test("falls back to summing when the server sends no total (older servers)", () => {
+    expect(contextTokensFromBreakdown({ input: 100, output: 50, reasoning: 20, cache: { read: 80, write: 20 } })).toBe(270)
+  })
+
+  test("falls back to summing when the total is zero or not a finite number", () => {
+    expect(contextTokensFromBreakdown({ total: 0, input: 40 })).toBe(40)
+    expect(contextTokensFromBreakdown({ total: Number.NaN, input: 40 })).toBe(40)
+  })
+
+  test("handles null and undefined", () => {
+    expect(contextTokensFromBreakdown(null)).toBe(0)
+    expect(contextTokensFromBreakdown(undefined)).toBe(0)
+  })
+})
+
+describe("extractTokensFromMessage", () => {
+  test("uses the reported total from the message info breakdown", () => {
+    const message = assistantMessage({ total: 232_872, input: 0, output: 14_523, reasoning: 0, cache: { read: 3_291_956, write: 0 } })
+    expect(extractTokensFromMessage(message)).toBe(232_872)
+  })
+
+  test("sums the info breakdown when no total is reported", () => {
+    expect(extractTokensFromMessage(assistantMessage({ input: 100, output: 50, reasoning: 20, cache: { read: 80, write: 20 } }))).toBe(270)
+  })
+
+  test("returns plain numeric tokens as-is", () => {
+    expect(extractTokensFromMessage(assistantMessage(1234))).toBe(1234)
+  })
+
+  test("prefers the reported total when tokens live on a part", () => {
+    const message: { info: Message; parts: Part[] } = {
+      info: {} as Message,
+      parts: [{ tokens: { total: 500, input: 2_000 } } as unknown as Part],
+    }
+    expect(extractTokensFromMessage(message)).toBe(500)
+  })
+
+  test("returns 0 when neither info nor parts carry tokens", () => {
+    expect(extractTokensFromMessage({ info: {} as Message, parts: [] })).toBe(0)
   })
 })

--- a/packages/ui/src/stores/utils/tokenUtils.ts
+++ b/packages/ui/src/stores/utils/tokenUtils.ts
@@ -1,6 +1,8 @@
 import type { Message, Part } from "@opencode-ai/sdk/v2";
 
 type TokenBreakdown = {
+    /** Server-reported window of the turn's final round-trip. Optional in the schema; absent on older servers. */
+    total?: number;
     input?: number;
     output?: number;
     reasoning?: number;
@@ -24,6 +26,31 @@ export const sumTokenBreakdown = (breakdown: TokenBreakdown | null | undefined):
     return inputTokens + outputTokens + reasoningTokens + cacheReadTokens + cacheWriteTokens;
 };
 
+/**
+ * Tokens the context window actually holds, from one message's token payload.
+ *
+ * The breakdown fields accumulate across every API round-trip inside a single
+ * assistant turn: each tool call re-reads the whole (cached) prompt, so on a
+ * multi-step turn `cache.read` alone can add up to several times the context
+ * window (observed on opencode 1.18.18: cache.read 3,291,956 on a turn whose
+ * 1M window really held 232,872 — rendered as a 330% context readout). The
+ * server reports the final round-trip's window as `tokens.total` (optional in
+ * the message schema, absent on older servers). Prefer it; fall back to
+ * summing the fields only when the server did not send it.
+ */
+export const contextTokensFromBreakdown = (breakdown: TokenBreakdown | null | undefined): number => {
+    if (!breakdown || typeof breakdown !== 'object') {
+        return 0;
+    }
+
+    const reportedTotal = breakdown.total;
+    if (typeof reportedTotal === 'number' && Number.isFinite(reportedTotal) && reportedTotal > 0) {
+        return reportedTotal;
+    }
+
+    return sumTokenBreakdown(breakdown);
+};
+
 export const extractTokensFromMessage = (message: { info: Message; parts: Part[] }): number => {
     const tokens = (message.info as { tokens?: number | TokenBreakdown }).tokens;
 
@@ -32,7 +59,7 @@ export const extractTokensFromMessage = (message: { info: Message; parts: Part[]
     }
 
     if (tokens && typeof tokens === 'object') {
-        return sumTokenBreakdown(tokens);
+        return contextTokensFromBreakdown(tokens);
     }
 
     const tokenPart = message.parts.find(
@@ -47,7 +74,7 @@ export const extractTokensFromMessage = (message: { info: Message; parts: Part[]
         return tokenPart.tokens;
     }
 
-    return sumTokenBreakdown(tokenPart.tokens);
+    return contextTokensFromBreakdown(tokenPart.tokens);
 };
 
 type CacheHitRateResult = {

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -86,6 +86,7 @@ import { getRuntimeKey } from "@/lib/runtime-switch"
 import { clearLastActiveSession, persistLastActiveSession, readLastActiveSession } from "./last-session-cache"
 import { persistWorktreeTopology, readPersistedWorktreeTopology } from "./worktree-topology-cache"
 import { rememberRuntimeLiveStatus } from "./runtime-live-memory"
+import { contextTokensFromBreakdown } from "@/stores/utils/tokenUtils"
 
 export type { AttachedFile }
 
@@ -1173,7 +1174,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     const messages = getSyncMessages(sessionId)
     if (messages.length === 0) return null
 
-    type AssistantTokens = { input: number; output: number; reasoning: number; cache: { read: number; write: number } }
+    type AssistantTokens = { total?: number; input: number; output: number; reasoning: number; cache: { read: number; write: number } }
     let lastTokens: AssistantTokens | undefined
     let lastMessageId: string | undefined
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -1181,7 +1182,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       if (msg.role !== "assistant") continue
       const tokens = (msg as { tokens?: AssistantTokens }).tokens
       if (!tokens) continue
-      const total = tokens.input + tokens.output + tokens.reasoning + (tokens.cache?.read ?? 0) + (tokens.cache?.write ?? 0)
+      const total = contextTokensFromBreakdown(tokens)
       if (total > 0) {
         lastTokens = tokens
         lastMessageId = msg.id
@@ -1191,7 +1192,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
 
     if (!lastTokens) return null
 
-    const totalTokens = lastTokens.input + lastTokens.output + lastTokens.reasoning + (lastTokens.cache?.read ?? 0) + (lastTokens.cache?.write ?? 0)
+    const totalTokens = contextTokensFromBreakdown(lastTokens)
     const thresholdLimit = contextLimit > 0 ? contextLimit : 200000
     const percentage = contextLimit > 0 ? Math.round((totalTokens / contextLimit) * 100) : 0
     const normalizedOutput = outputLimit > 0 ? Math.round((lastTokens.output / outputLimit) * 100) : undefined

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Chat: new chats no longer start against a deleted last worktree directory; they fall back to the active project instead of saving the first message and never starting.
 - Chat: opening a busy subagent in the context panel now shows its history instead of only the working-status line (thanks to @makeittech).
-- The context usage readout no longer climbs over 100% after turns with many tool calls and no longer jumps when reopening an older session; it now shows what the window actually holds.
+- The context usage readout no longer climbs over 100% after turns with many tool calls and no longer jumps when reopening an older session; it now shows what the window actually holds (thanks to @pocharlies).
 - Projects: project names now match the folder name exactly, so `.ssh` and `opencode-claude` are no longer shown as `.Ssh` and `Opencode Claude`; names you renamed yourself are kept.
 - Skills Catalog: the source is now named ClawHub instead of "ClawdHub" (thanks to @makeittech).
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Chat: new chats no longer start against a deleted last worktree directory; they fall back to the active project instead of saving the first message and never starting.
 - Chat: opening a busy subagent in the context panel now shows its history instead of only the working-status line (thanks to @makeittech).
+- The context usage readout no longer climbs over 100% after turns with many tool calls and no longer jumps when reopening an older session; it now shows what the window actually holds.
 - Projects: project names now match the folder name exactly, so `.ssh` and `opencode-claude` are no longer shown as `.Ssh` and `Opencode Claude`; names you renamed yourself are kept.
 - Skills Catalog: the source is now named ClawHub instead of "ClawdHub" (thanks to @makeittech).
 


### PR DESCRIPTION
## Intent

The context meter can show impossible values — 330.6% of a 1M window on mobile web, 115% in #2562 on VS Code — after an assistant turn with many tool calls, and jumps when reopening an older session. Every context-usage surface computed "window fill" by summing the message token breakdown (`input + output + reasoning + cache.read + cache.write`). Those fields **accumulate across every API round-trip inside a single turn** (each tool call re-reads the whole cached prompt), so a turn with ~14 tool calls sums to ~14× the real window.

Real payload captured from a stock opencode 1.18.18 server (`GET /session/:id/message`), the exact turn that rendered `330.6% · 3.3M/1.0M`:

| field | value |
|---|---|
| `tokens.total` (server-reported, final round-trip) | 232,872 → **23.3%** of the 1M window |
| `tokens.cache.read` (accumulated across round-trips) | 3,291,956 |
| `tokens.output` | 14,523 |
| sum the UI displayed | 3,306,479 → **330.6%** |

A single-step turn from the same server has `total` equal to the summed fields exactly (117,714 = 1,116 + 87 + 543 + 115,968), confirming the fields only diverge when round-trips accumulate.

The fix: prefer the server-reported `tokens.total` — the final round-trip's window — everywhere the fill is displayed, and fall back to the previous summing when a server does not send it. A new `contextTokensFromBreakdown` in `tokenUtils` owns that rule. Five call sites delegate to the helper (the context store extractor `extractTokensFromMessage`, `session-ui-store.getContextUsage`, the work status panel `contextUsage.ts`, the VS Code layout header, and mini chat), and two surfaces whose inputs are `unknown`-sanitized apply the identical `total > 0 ? total : sum` rule inline (the context sidebar tab and mobile session metadata).

`tokens.total` is optional in the opencode message schema, and the SDK pinned by this branch (`@opencode-ai/sdk@1.18.18`) declares `total?: number` on `AssistantMessage.tokens` and `StepFinishPart.tokens` in the `/v2` generated types this code imports. (An earlier revision of this description claimed the generated types lacked the field; that was read from a stale 1.18.16 install and was wrong.) The local defensive shapes remain for the `unknown`-typed call sites and older servers that do not send the field.

Fixes #2562 — same mechanism: reopening a session renders the last assistant message's accumulated breakdown, and readings over 100% are impossible as a real window fill.

## Non-goals

- Cost/usage accounting and the cache-hit-rate display keep using the raw breakdown fields — accumulated numbers are correct for those. `sumTokenBreakdown` and `computeCacheHitRate` are unchanged.
- How the context *limit* is resolved is unchanged.
- The context sidebar's "Last turn tokens" grid intentionally keeps showing the raw per-round-trip fields; only the headline usage (and the message chips' `total`) use the reported total. Declared consequence: on multi-step turns the grid's cache-read figure can exceed the headline total — they are different quantities (cumulative round-trip I/O vs. window fill).

## Affected surfaces

`packages/ui` only; every runtime consumes it through the shared UI: desktop/web header (contextStore + session-ui-store), work status panel, context sidebar tab, VS Code layout header, mini chat window, and mobile session metadata. No runtime-specific code changed, no persisted format or external contract changes — the message token payload is read-only input. `packages/vscode/CHANGELOG.md` gains an `[Unreleased]` entry because the VS Code header readout is affected (that is #2562's surface).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | executable source change across shared UI | smallest complete change: one helper owns the invariant, five call sites delegate to it, two `unknown`-sanitized surfaces inline the identical rule; fallback preserves old behavior byte-for-byte; `bun run dead-code` run for the new export |
| `sync-state-invariants` | touches `session-ui-store.getContextUsage` | follows "prefer deterministic authoritative records over heuristics": the server-reported total replaces a client-side summing heuristic; no ownership, lifecycle, or reconciliation semantics change |
| `changelog-authoring` | user-visible fix | `[Unreleased]` bullets added to the main and VS Code changelogs, symptom-focused, with contributor credit |
| `packages/ui/src/components/chat/work-status/DOCUMENTATION.md` | documents why `contextUsage.ts` computes usage itself | that rationale (directory-scoped computation) is untouched; the code comments that asserted "each assistant turn reports the whole window it saw" were corrected, since it does not hold for the summed fields on multi-step turns |

## Validation

| Check | Result |
|---|---|
| `bun test src/stores/utils/tokenUtils.test.ts src/components/chat/work-status/contextUsage.test.ts` | 35 pass, 0 fail — includes regression fixtures with the real captured payloads (the 330.6%→23.3% turn and the single-step turn where total equals the sum) |
| `bun run --cwd packages/ui test` (full isolated suite) | 263/263 test files passed |
| `bun run type-check` (workspace-wide) | all packages exit 0 |
| `bun run lint:ui` | clean |
| `bun run dead-code` | no findings for the changed/added symbols |
| Runtime render (see visual evidence) | web dev build of this branch and of `origin/main`, same session from the same live storage, rendered side by side |
| Not verified | full `bun run build`; per-surface screenshots beyond the desktop web header (identical store value / identical rule) |

## Visual evidence

Same session, same live storage, same moment, rendered by both builds (web dev build, desktop layout header — screenshots clipped to the header strip). The session's last reporting assistant turn sums to **18,611,976** tokens across its tool-call round-trips while reporting `total: 78,327` on a 1M-window model.

**Before — `origin/main` (`0d44041ef`):** the meter shows the capped 999%:

![before: context meter reads 999.0%](https://raw.githubusercontent.com/pocharlies/openchamber/evidence-pr-2914/before-header-999pct.png)

**After — this branch:** the same message renders the real fill:

![after: context meter reads 7.8%](https://raw.githubusercontent.com/pocharlies/openchamber/evidence-pr-2914/after-header-7-8pct.png)

The `330.6% · 3.3M/1.0M` capture referenced in Intent is the same class of readout on the mobile web header, taken earlier in the same session (it has since grown; its current unfixed readout is the capped 999.0% above). Issue #2562's screenshots show the same before-state on VS Code. The remaining surfaces render the same store value or apply the identical rule and were not individually screenshotted.

## Risks and failure behavior

- Servers that do not send `tokens.total` (older opencode) keep the previous behavior byte-for-byte: the fallback is the exact old sum.
- A malformed `total` (zero, negative, `NaN`, non-number) falls back to the sum — unit-tested.
- If a server reported a `total` inconsistent with its own breakdown, the meter now trusts the server; that is the intended authority order (authoritative record over client heuristic).
- No writes anywhere: a wrong value can only render a wrong percentage.
