### PR TITLE
fix(server): tolerate slow managed opencode bootstrap; support scoped config for managed server

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -9,10 +9,11 @@
 ## Fases
 1. [DONE] Wave0: auditoría (procesos, DB, logs, fork, proxy).
 2. [DONE] Wave2: poda backups (11.5+1.6+1.7GB) + magic-context 131MB + session_diff >20MB (238MB) + prune events (67K→49K, 3.93→3.69GB). Script prune reparado (bloque duplicado, línea truncada).
-3. [TODO] Wave4: rebuild dist-bundle/main.mjs desde fork HEAD + repack app.asar + sync packages/web → app.asar.unpacked/@openchamber/web.
-4. [TODO] Wave3: relanzar OpenChamber; verificar /session + PushWatcher + ausencia de 4x MCP.
-5. [TODO] Wave5: opencode.jsonc — quitar SessionStart hook roto.
-6. [TODO] QA: medir boot y /session; evidencias.
+3. [DONE] Wave4: rebuild main.mjs + repack app.asar (--unpack node_modules, 2.5MB) + sync packages/web -> @openchamber/web (warmup paralelo, session-merge, health tolerance, scoped-config). Backups: app.asar.bak-20260816-pre-sync + unpacked.bak.
+4. [DONE] Wave3: OpenChamber relanzado 12:20. PushWatcher connected en 1s (antes 2.5min). Gate /session 200 OK 3-90ms (28KB). 0 proxy errors. Health flapping (contention DB con 2 TUIs + managed) -> restart ciclico rapido OK.
+5. [DONE] Wave5: hook SessionStart roto eliminado de opencode.jsonc.
+6. [DONE] QA: gate estable 3x, 0 proxy errors, boot 1s. Pendiente: ver UI en vivo.
 
 ## Nota previa (sesión 15/08 23:45)
 - 11 AppHangB1 de OpenChamber.exe (20:31-23:39): el main de Electron se cuelga → proxy deja de procesar → socket hang up → UI congelada → se recupera → repite.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,18 @@
+# PLAN — Fix lentitud opencode/OpenChamber (16/08/2026)
+
+## Contexto
+- 6+ procesos opencode compartiendo opencode.db 3.93GB (event 67K/1.47GB, message 122K, part 408K) → stalls DB, /session cuelga.
+- Boot managed ~2.5-3min: warmup serial multi-directorio; app instalada (asar 14/08 22:35) SIN los fixes del fork (77d51d207: WARMUP_CONCURRENCY=2, filtro worktrees, timeout 5s; dd02d2e16: session merge paralelo).
+- Duplicación MCP 4x via self-connections /event; tormenta proxy 'socket hang up' en main.log.
+- Config CLI: 20 MCP + SessionStart hook a script inexistente.
+
+## Fases
+1. [DONE] Wave0: auditoría (procesos, DB, logs, fork, proxy).
+2. [DONE] Wave2: poda backups (11.5+1.6+1.7GB) + magic-context 131MB + session_diff >20MB (238MB) + prune events (67K→49K, 3.93→3.69GB). Script prune reparado (bloque duplicado, línea truncada).
+3. [TODO] Wave4: rebuild dist-bundle/main.mjs desde fork HEAD + repack app.asar + sync packages/web → app.asar.unpacked/@openchamber/web.
+4. [TODO] Wave3: relanzar OpenChamber; verificar /session + PushWatcher + ausencia de 4x MCP.
+5. [TODO] Wave5: opencode.jsonc — quitar SessionStart hook roto.
+6. [TODO] QA: medir boot y /session; evidencias.
+
+## Nota previa (sesión 15/08 23:45)
+- 11 AppHangB1 de OpenChamber.exe (20:31-23:39): el main de Electron se cuelga → proxy deja de procesar → socket hang up → UI congelada → se recupera → repite.

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,3 +17,25 @@
 ## Nota previa (sesión 15/08 23:45)
 - 11 AppHangB1 de OpenChamber.exe (20:31-23:39): el main de Electron se cuelga → proxy deja de procesar → socket hang up → UI congelada → se recupera → repite.
 
+
+## Prevencion de recurrencia (16/08/2026)
+
+### Reglas de oro
+1. **Max 2 instancias opencode simultaneas** (1 TUI + managed). Cada instancia comparte opencode.db (SQLite sync) — 3+ instancias = stalls de /session. Cierra TUIs que no uses.
+2. **Tras cada auto-update de OpenChamber**, verificar drift:
+   `node scripts/sync-installed.mjs --check` (exit 0 = OK; exit 2 = drift)
+3. **Antes de cualquier sync**: cerrar OpenChamber completo (bandeja -> Quit).
+
+### Mantenimiento
+- **Sync fork -> app instalada** (trae fixes de warmup/session-merge/health):
+  `node scripts/sync-installed.mjs` (con OpenChamber cerrado; backups automaticos en resources/)
+- **Prune event store**: tarea programada `PruneOpenCodeEventStore` SEMANAL (domingos 04:30,
+  cambio hecho 16/08; antes mensual y nunca habia corrido). Manual:
+  `bun C:\Users\herna\.config\opencode\scripts\prune-opencode-db.js --hours=24`
+- **Reinicio limpio** (si managed muere): bandeja -> Quit, verificar
+  `Get-Process opencode,OpenChamber` vacio, relanzar OpenChamber.
+
+### Health check rapido
+- Gate: `Invoke-WebRequest http://127.0.0.1:57123/session -Headers @{Authorization="Bearer <token config>"}`
+  → 200 y <500ms = sano. Proxy errors crecientes en main.log = managed colgado.
+- Si vuelve la lentitud: `Get-Process opencode` → si >2, cerrar extras y reiniciar limpio.

--- a/packages/docs/content/docs/environment.mdx
+++ b/packages/docs/content/docs/environment.mdx
@@ -91,6 +91,18 @@ OpenChamber-specific alias for selecting the WSL distro. `OPENCODE_WSL_DISTRO` t
 
 Secret used to sign UI authentication tokens. Use a long random value for persistent service deployments.
 
+### `OPENCHAMBER_OPENCODE_HEALTH_TIMEOUT_MS`
+
+Per-probe timeout (ms) for the managed OpenCode server health check. Default `30000`.
+
+### `OPENCHAMBER_OPENCODE_HEALTH_CONSECUTIVE_FAILURES`
+
+Consecutive health-check failures before the managed OpenCode server is restarted. Default `40`. A genuinely exited process still restarts immediately; this threshold only guards a hung-but-alive server during heavy bootstrap.
+
+### `OPENCHAMBER_OPENCODE_CONFIG_DIR`
+
+Optional config directory for the managed OpenCode server, so it can run with a lean config (e.g. without heavy plugins that starve the Bun event loop during bootstrap). When unset, an inherited `OPENCODE_CONFIG_DIR` wins, then on Windows only `%APPDATA%\openchamber\managed-config` is used when its `opencode.jsonc` exists. When a scoped dir is active, UI config edits that write to the user global layer are not visible to the managed server until mirrored into the scoped config.
+
 ## Terminal and Git
 
 ### `OPENCHAMBER_TERMINAL_SHELL`

--- a/packages/electron/opencode-cwd.mjs
+++ b/packages/electron/opencode-cwd.mjs
@@ -1,3 +1,30 @@
+import { existsSync } from 'node:fs';
+
+// Markers that identify a directory as a project root. If process.cwd() matches
+// any of these we use it directly instead of falling back to HOME. Without
+// this, opencode re-indexes the user's home directory recursively on every
+// restart, leaking memory and blocking the proxy health-check.
+const PROJECT_MARKERS = [
+  '.git',
+  'package.json',
+  'Cargo.toml',
+  'go.mod',
+  'pyproject.toml',
+];
+
+const looksLikeProjectRoot = (dir) => {
+  if (typeof dir !== 'string' || !dir) return false;
+  return PROJECT_MARKERS.some((marker) => {
+    try {
+      return existsSync(`${dir}/${marker}`) || existsSync(`${dir}\\${marker}`);
+    } catch {
+      return false;
+    }
+  });
+};
+
+let warnedAboutHomeFallback = false;
+
 export const resolveManagedOpenCodeCwd = ({ env, homedir }) => {
   const configured = typeof env?.OPENCHAMBER_OPENCODE_CWD === 'string'
     ? env.OPENCHAMBER_OPENCODE_CWD.trim()
@@ -6,6 +33,29 @@ export const resolveManagedOpenCodeCwd = ({ env, homedir }) => {
     return configured;
   }
 
+  const cwd = process.cwd();
+  if (looksLikeProjectRoot(cwd)) {
+    return cwd;
+  }
+
   const home = typeof homedir === 'function' ? homedir() : '';
-  return typeof home === 'string' && home.trim() ? home : process.cwd();
+  if (typeof home === 'string' && home.trim()) {
+    if (!warnedAboutHomeFallback) {
+      warnedAboutHomeFallback = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[openchamber] cwd ${cwd} does not look like a project root; ` +
+          `falling back to home (${home}). ` +
+          `Set OPENCHAMBER_OPENCODE_CWD to silence this warning.`,
+      );
+    }
+    return home;
+  }
+  return cwd;
+};
+
+// Test-only export: reset the once-per-process warning flag so each test sees
+// the warning behaviour from a clean slate.
+export const __resetCwdFallbackWarning = () => {
+  warnedAboutHomeFallback = false;
 };

--- a/packages/electron/opencode-cwd.mjs
+++ b/packages/electron/opencode-cwd.mjs
@@ -44,9 +44,9 @@ export const resolveManagedOpenCodeCwd = ({ env, homedir }) => {
       warnedAboutHomeFallback = true;
       // eslint-disable-next-line no-console
       console.warn(
-        `[openchamber] cwd ${cwd} does not look like a project root; ` +
-          `falling back to home (${home}). ` +
-          `Set OPENCHAMBER_OPENCODE_CWD to silence this warning.`,
+        `[openchamber] managed OpenCode cwd is the launch directory (${cwd}), which is not a project root; ` +
+          `using home (${home}) as the managed working directory instead. ` +
+          `Set OPENCHAMBER_OPENCODE_CWD to pick a specific directory.`,
       );
     }
     return home;

--- a/packages/electron/opencode-cwd.test.mjs
+++ b/packages/electron/opencode-cwd.test.mjs
@@ -1,23 +1,83 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveManagedOpenCodeCwd } from './opencode-cwd.mjs';
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+import { existsSync } from 'node:fs';
+
+import {
+  __resetCwdFallbackWarning,
+  resolveManagedOpenCodeCwd,
+} from './opencode-cwd.mjs';
 
 describe('resolveManagedOpenCodeCwd', () => {
+  let cwdSpy;
+  let warnSpy;
+
+  beforeEach(() => {
+    __resetCwdFallbackWarning();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/Users/example');
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    warnSpy.mockRestore();
+    vi.resetAllMocks();
+  });
+
   it('defaults managed OpenCode cwd to the user home directory', () => {
-    expect(resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' })).toBe('/Users/example');
+    existsSync.mockReturnValue(false);
+    expect(
+      resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' }),
+    ).toBe('/Users/example');
   });
 
   it('preserves an explicit cwd override', () => {
-    expect(resolveManagedOpenCodeCwd({
-      env: { OPENCHAMBER_OPENCODE_CWD: '/tmp/opencode-cwd' },
-      homedir: () => '/Users/example',
-    })).toBe('/tmp/opencode-cwd');
+    expect(
+      resolveManagedOpenCodeCwd({
+        env: { OPENCHAMBER_OPENCODE_CWD: '/tmp/opencode-cwd' },
+        homedir: () => '/Users/example',
+      }),
+    ).toBe('/tmp/opencode-cwd');
   });
 
   it('ignores a blank cwd override', () => {
-    expect(resolveManagedOpenCodeCwd({
-      env: { OPENCHAMBER_OPENCODE_CWD: '   ' },
-      homedir: () => '/Users/example',
-    })).toBe('/Users/example');
+    existsSync.mockReturnValue(false);
+    expect(
+      resolveManagedOpenCodeCwd({
+        env: { OPENCHAMBER_OPENCODE_CWD: '   ' },
+        homedir: () => '/Users/example',
+      }),
+    ).toBe('/Users/example');
+  });
+
+  it('prefers process.cwd() when it looks like a project root', () => {
+    cwdSpy.mockReturnValue('/repos/openchamber');
+    existsSync.mockImplementation((p) => typeof p === 'string' && p.includes('package.json'));
+    expect(
+      resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' }),
+    ).toBe('/repos/openchamber');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to home with a single warning when cwd is not a project root', () => {
+    cwdSpy.mockReturnValue('/Users/example');
+    existsSync.mockReturnValue(false);
+    expect(
+      resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' }),
+    ).toBe('/Users/example');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('does not look like a project root');
+  });
+
+  it('suppresses the home-fallback warning on subsequent calls', () => {
+    cwdSpy.mockReturnValue('/Users/example');
+    existsSync.mockReturnValue(false);
+    resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
+    resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
+    resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/electron/opencode-cwd.test.mjs
+++ b/packages/electron/opencode-cwd.test.mjs
@@ -1,15 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
+mock.module('node:fs', () => ({
+  existsSync: mock(() => false),
 }));
 
-import { existsSync } from 'node:fs';
-
-import {
-  __resetCwdFallbackWarning,
-  resolveManagedOpenCodeCwd,
-} from './opencode-cwd.mjs';
+const { existsSync } = await import('node:fs');
+const { __resetCwdFallbackWarning, resolveManagedOpenCodeCwd } = await import('./opencode-cwd.mjs');
 
 describe('resolveManagedOpenCodeCwd', () => {
   let cwdSpy;
@@ -17,14 +13,14 @@ describe('resolveManagedOpenCodeCwd', () => {
 
   beforeEach(() => {
     __resetCwdFallbackWarning();
-    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/Users/example');
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    cwdSpy = spyOn(process, 'cwd').mockReturnValue('/Users/example');
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     cwdSpy.mockRestore();
     warnSpy.mockRestore();
-    vi.resetAllMocks();
+    mock.restore();
   });
 
   it('defaults managed OpenCode cwd to the user home directory', () => {
@@ -69,7 +65,7 @@ describe('resolveManagedOpenCodeCwd', () => {
       resolveManagedOpenCodeCwd({ env: {}, homedir: () => '/Users/example' }),
     ).toBe('/Users/example');
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain('does not look like a project root');
+    expect(warnSpy.mock.calls[0][0]).toContain('which is not a project root');
   });
 
   it('suppresses the home-fallback warning on subsequent calls', () => {

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -1159,7 +1159,19 @@ const openCodeLifecycleRuntime = createOpenCodeLifecycleRuntime({
         directories.push(project.path);
       }
     }
-    return [...new Set(directories)];
+    // Skip transient worktrees that the managed server would otherwise
+    // bootstrap at startup: each warmed directory spawns an internal server
+    // that self-fetches /global/event, and dozens of them saturate Bun's
+    // single-threaded event loop for minutes (observed: 24 servers, 42
+    // self-connections, health checks timing out). Mission Control and
+    // Claude worktrees are recreated on demand and have no lasting sessions.
+    // Normalize to forward slashes first: settings can store mixed Windows
+    // separators, and the filter must match both \ and /.
+    const isTransientWorktree = (dir) => {
+      const normalized = String(dir).replace(/\\/g, '/');
+      return /(?:^|\/)\.omo\/wt-/.test(normalized) || /(?:^|\/)\.claude\/worktrees\//.test(normalized);
+    };
+    return [...new Set(directories)].filter((dir) => !isTransientWorktree(dir));
   },
   // A managed restart can move OpenCode to a NEW port (the old one may stay
   // occupied by an orphaned process, e.g. killProcessOnPort is a no-op on

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -166,11 +166,6 @@ the user's global config. UI config edits that write to the user global layer
 (providers/agents/MCP) are therefore not visible to the managed server until
 mirrored into the scoped config — an intentional tradeoff for a lean managed
 runtime.
-runtime. PATH and `OPENCODE_SERVER_PASSWORD` remain lifecycle-owned and cannot
-be replaced by injected values. External OpenCode processes receive no
-OpenChamber tool injection. Managed launch env strips AppImage `ARGV0` before
-spawn so zsh-backed OpenCode tools do not rewrite child argv[0] to the AppImage
-path (#2588).
 
 Before spawn, `applyProviderEnvAliases` fills unset Google credential aliases
 from any present sibling (`GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_API_KEY`,

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -136,6 +136,42 @@ OpenChamber tool injection. Managed launch env strips AppImage `ARGV0` before
 spawn so zsh-backed OpenCode tools do not rewrite child argv[0] to the AppImage
 path (#2588).
 
+### Managed OpenCode health-check tolerance
+
+The managed process health check uses these defaults, both overrideable:
+
+- `OPENCHAMBER_OPENCODE_HEALTH_TIMEOUT_MS` (default `30000`): per-probe
+  timeout for `GET /global/health` on the managed server.
+- `OPENCHAMBER_OPENCODE_HEALTH_CONSECUTIVE_FAILURES` (default `40`):
+  consecutive failures before the managed process is restarted. Genuinely
+  exited processes still restart immediately via the process-liveness check;
+  the threshold only guards a hung-but-alive server during heavy bootstrap.
+  Counting is rate-limited by the health-check interval (default 15 s).
+
+### Scoped config for the managed server
+
+The managed OpenCode process can be launched with a dedicated config directory
+so heavy plugins/daemons that starve the Bun event loop during bootstrap are
+not loaded. Resolution order:
+
+1. `OPENCHAMBER_OPENCODE_CONFIG_DIR` env var (explicit override).
+2. An inherited `OPENCODE_CONFIG_DIR` — if the user already set it, it wins
+   and no scoped dir is injected.
+3. Windows only: `%APPDATA%\openchamber\managed-config\opencode.jsonc` when
+   that file exists (default convention; nothing creates it automatically).
+
+When a scoped dir is active, `OPENCODE_CONFIG_DIR` is injected into the managed
+spawn environment and the child reads its config from that directory instead of
+the user's global config. UI config edits that write to the user global layer
+(providers/agents/MCP) are therefore not visible to the managed server until
+mirrored into the scoped config — an intentional tradeoff for a lean managed
+runtime.
+runtime. PATH and `OPENCODE_SERVER_PASSWORD` remain lifecycle-owned and cannot
+be replaced by injected values. External OpenCode processes receive no
+OpenChamber tool injection. Managed launch env strips AppImage `ARGV0` before
+spawn so zsh-backed OpenCode tools do not rewrite child argv[0] to the AppImage
+path (#2588).
+
 Before spawn, `applyProviderEnvAliases` fills unset Google credential aliases
 from any present sibling (`GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_API_KEY`,
 `GEMINI_API_KEY`) so a shell that only exports `GEMINI_API_KEY` still satisfies

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -85,6 +85,17 @@ const classifyHealthProbeError = (error) => {
   return { class: 'error', detail: getHealthFailureDetail(error) };
 };
 
+// Pure resolution of the default scoped config dir for the managed server.
+// Exported for tests; production callers pass the real env/fs.
+const resolveDefaultManagedConfigDir = ({ platform = process.platform, appData = process.env.APPDATA, homedir = os.homedir, existsSyncFn = existsSync } = {}) => {
+  if (platform !== 'win32') return null;
+  const base = appData || path.join(homedir(), '.config');
+  const candidate = path.join(base, 'openchamber', 'managed-config');
+  return existsSyncFn(path.join(candidate, 'opencode.jsonc')) ? candidate : null;
+};
+
+export { resolveDefaultManagedConfigDir };
+
 export const createOpenCodeLifecycleRuntime = (deps) => {
   const {
     state,
@@ -684,13 +695,9 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     const managedConfigDir = (() => {
       const override = process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR;
       if (override) return override;
-      // Default: a scoped config dir shipped next to the app's own data dir.
-      // Only injected when it actually exists, so a stock install keeps using
-      // the user's global config without any behavior change.
-      if (process.platform !== 'win32') return null;
-      const base = process.env.APPDATA || path.join(os.homedir(), '.config');
-      const candidate = path.join(base, 'openchamber', 'managed-config');
-      return existsSync(path.join(candidate, 'opencode.jsonc')) ? candidate : null;
+      // Never clobber a user-provided OPENCODE_CONFIG_DIR with the default.
+      if (process.env.OPENCODE_CONFIG_DIR) return null;
+      return resolveDefaultManagedConfigDir();
     })();
     recordStartupPerformance('opencode.environment.ready', {
       attempt,

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -675,6 +675,11 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
       ? getManagedOpenCodeShellEnvSnapshot() || {}
       : {};
     const managedOpenCodeEnv = await getManagedOpenCodeEnv();
+    // Optional scoped config dir for the managed server (e.g. a lean config that
+    // avoids heavy plugins/daemons which can starve the managed event loop).
+    // Explicit env override wins; otherwise no var is injected and the managed
+    // server keeps using the user's global config as before.
+    const managedConfigDir = process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR || null;
     recordStartupPerformance('opencode.environment.ready', {
       attempt,
       durationMs: performance.now() - phaseStartedAt,
@@ -693,6 +698,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
           ...shellEnv,
           ...process.env,
           ...managedOpenCodeEnv,
+          ...(managedConfigDir ? { OPENCODE_CONFIG_DIR: managedConfigDir } : {}),
           PATH: envPath,
           OPENCODE_SERVER_PASSWORD: openCodePassword,
         })),

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -1,5 +1,8 @@
 import { spawn, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
 import { stripAppImageArgv0Leak } from '../inherited-env.js';
 import { registerManagedProcess, unregisterManagedProcess, reapOrphanedProcesses } from './managed-process-registry.js';
 import { applyProviderEnvAliases } from './provider-env-aliases.js';
@@ -678,8 +681,17 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     // Optional scoped config dir for the managed server (e.g. a lean config that
     // avoids heavy plugins/daemons which can starve the managed event loop).
     // Explicit env override wins; otherwise no var is injected and the managed
-    // server keeps using the user's global config as before.
-    const managedConfigDir = process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR || null;
+    const managedConfigDir = (() => {
+      const override = process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR;
+      if (override) return override;
+      // Default: a scoped config dir shipped next to the app's own data dir.
+      // Only injected when it actually exists, so a stock install keeps using
+      // the user's global config without any behavior change.
+      if (process.platform !== 'win32') return null;
+      const base = process.env.APPDATA || path.join(os.homedir(), '.config');
+      const candidate = path.join(base, 'openchamber', 'managed-config');
+      return existsSync(path.join(candidate, 'opencode.jsonc')) ? candidate : null;
+    })();
     recordStartupPerformance('opencode.environment.ready', {
       attempt,
       durationMs: performance.now() - phaseStartedAt,

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -94,8 +94,25 @@ const classifyHealthProbeError = (error) => {
 const resolveDefaultManagedConfigDir = ({ platform = process.platform, appData = process.env.APPDATA, homedir = os.homedir, existsSyncFn = existsSync } = {}) => {
   if (platform !== 'win32') return null;
   const base = appData || path.join(homedir(), '.config');
-  const candidate = path.join(base, 'openchamber', 'managed-config');
-  return existsSyncFn(path.join(candidate, 'opencode.jsonc')) ? candidate : null;
+  // Canonicalize candidate to all-backslashes so the returned value and the
+  // probe keys match what callers (and Windows path APIs) emit. On real
+  // Windows hosts, path.join already produces backslashes, so the replace is
+  // a no-op there; it only matters on POSIX CI hosts where path.join leaves
+  // backslashes as literals in mixed-separator strings.
+  const candidate = path.join(base, 'openchamber', 'managed-config').replace(/\//g, '\\');
+  const configPath = path.join(candidate, 'opencode.jsonc');
+  // Probe all separator styles so callers can mock either form and real
+  // Windows path APIs (which normalize to backslashes) still resolve:
+  // path.join may produce mixed separators on POSIX hosts when input
+  // contains backslashes, so we canonicalize both directions.
+  if (
+    existsSyncFn(configPath)
+    || existsSyncFn(configPath.replace(/\\/g, '/'))
+    || existsSyncFn(configPath.replace(/\//g, '\\'))
+  ) {
+    return candidate;
+  }
+  return null;
 };
 
 export { resolveDefaultManagedConfigDir };

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -24,7 +24,11 @@ const OPENCODE_HEALTH_PATH = '/global/health';
 // Last-used directory plus the three most recently opened projects — deeper
 // tails are unlikely to be the user's first click and just add background work.
 const WARMUP_DIRECTORY_LIMIT = 4;
-const WARMUP_REQUEST_TIMEOUT_MS = 30000;
+// WARMUP_REQUEST_TIMEOUT_MS was 30000 in the original PR (#2917); upstream
+// commit 77d51d207 reduced it to 5000 once warmup runs with bounded
+// concurrency (2). Taking the upstream value because it is the contract
+// already shipped on main and covered by existing tests.
+const WARMUP_REQUEST_TIMEOUT_MS = 5000;
 const MANAGED_STDERR_TAIL_MAX_BYTES = 32 * 1024;
 const HEALTH_FAILURE_DETAIL_MAX_LENGTH = 256;
 
@@ -1133,9 +1137,13 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
   // session stores. Without warming, the user's first session open pays it
   // interactively (the chat waits on the message fetch until the directory
   // finishes initializing). Warm the most recently used directories right
-  // after readiness so the work overlaps UI startup instead. Sequential and
-  // best-effort: a failed or slow directory never blocks the others for long,
-  // and a restart invalidates the pass via the port/readiness guard.
+  // after readiness so the work overlaps UI startup instead. Runs the
+  // warmup requests with bounded concurrency so a slow directory cannot
+  // serialize the whole pass (observed: 30s x 4 dirs = 120s of managed
+  // startup where health checks already started timing out). Best-effort:
+  // a failed or slow directory never blocks the others for long, and a
+  // restart invalidates the pass via the port/readiness guard.
+  const WARMUP_CONCURRENCY = 2;
   const warmOpenCodeDirectories = async () => {
     let directories = [];
     try {
@@ -1146,8 +1154,10 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     if (!Array.isArray(directories) || directories.length === 0) return;
 
     const warmedPort = state.openCodePort;
-    for (const directory of directories.slice(0, WARMUP_DIRECTORY_LIMIT)) {
-      if (typeof directory !== 'string' || !directory) continue;
+    const targets = directories
+      .slice(0, WARMUP_DIRECTORY_LIMIT)
+      .filter((directory) => typeof directory === 'string' && directory);
+    const warmOne = async (directory) => {
       if (!state.isOpenCodeReady || state.openCodePort !== warmedPort) return;
       let timeout = null;
       try {
@@ -1164,7 +1174,18 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
       } finally {
         if (timeout) clearTimeout(timeout);
       }
-    }
+    };
+    // Consume the targets with bounded parallelism (up to WARMUP_CONCURRENCY
+    // in flight).
+    let cursor = 0;
+    const workers = Array.from({ length: Math.min(WARMUP_CONCURRENCY, targets.length) }, async () => {
+      while (cursor < targets.length) {
+        const directory = targets[cursor];
+        cursor += 1;
+        await warmOne(directory);
+      }
+    });
+    await Promise.allSettled(workers);
   };
 
   /**

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -10,10 +10,10 @@ const parsePositiveInt = (value, fallback) => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 };
 
-const HEALTH_CHECK_TIMEOUT_MS = parsePositiveInt(process.env.OPENCHAMBER_OPENCODE_HEALTH_TIMEOUT_MS, 5000);
+const HEALTH_CHECK_TIMEOUT_MS = parsePositiveInt(process.env.OPENCHAMBER_OPENCODE_HEALTH_TIMEOUT_MS, 30000);
 const HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES = parsePositiveInt(
   process.env.OPENCHAMBER_OPENCODE_HEALTH_CONSECUTIVE_FAILURES,
-  20
+  40
 );
 const HEALTH_CHECK_INTERVAL_OVERRIDE_MS = parsePositiveInt(process.env.OPENCHAMBER_OPENCODE_HEALTH_INTERVAL_MS, 0);
 const HEALTH_CHECK_RESULT_CACHE_MS = parsePositiveInt(process.env.OPENCHAMBER_OPENCODE_HEALTH_CACHE_MS, 750);

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -783,21 +783,86 @@ describe('OpenCode lifecycle', () => {
   it('does not inject OPENCODE_CONFIG_DIR when no managed config dir exists', async () => {
     delete process.env.OPENCODE_BINARY;
     delete process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR;
-    const child = createMockChild();
-    spawnMock.mockImplementationOnce(() => {
-      queueMicrotask(() => {
-        child.stdout.emit('data', 'opencode server listening on http://127.0.0.1:45678\n');
+    const previousAppData = process.env.APPDATA;
+    process.env.APPDATA = 'C:\\NoSuchDir';
+    try {
+      const child = createMockChild();
+      spawnMock.mockImplementationOnce(() => {
+        queueMicrotask(() => {
+          child.stdout.emit('data', 'opencode server listening on http://127.0.0.1:45678\n');
+        });
+        return child;
       });
-      return child;
-    });
 
-    const runtime = createRuntime();
-    const server = await runtime.startOpenCode();
-    const [, , options] = spawnMock.mock.calls[0];
+      const runtime = createRuntime();
+      const server = await runtime.startOpenCode();
+      const [, , options] = spawnMock.mock.calls[0];
 
-    expect(options.env.OPENCODE_CONFIG_DIR).toBeUndefined();
+      expect(options.env.OPENCODE_CONFIG_DIR).toBeUndefined();
 
-    await server.close();
+      await server.close();
+    } finally {
+      if (typeof previousAppData === 'string') {
+        process.env.APPDATA = previousAppData;
+      } else {
+        delete process.env.APPDATA;
+      }
+    }
+  });
+  it('does not override a user-provided OPENCODE_CONFIG_DIR with the default', async () => {
+    delete process.env.OPENCODE_BINARY;
+    delete process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR;
+    const previous = process.env.OPENCODE_CONFIG_DIR;
+    process.env.OPENCODE_CONFIG_DIR = '/user/config-dir';
+    try {
+      const child = createMockChild();
+      spawnMock.mockImplementationOnce(() => {
+        queueMicrotask(() => {
+          child.stdout.emit('data', 'opencode server listening on http://127.0.0.1:45678\n');
+        });
+        return child;
+      });
+
+      const runtime = createRuntime();
+      const server = await runtime.startOpenCode();
+      const [, , options] = spawnMock.mock.calls[0];
+
+      expect(options.env.OPENCODE_CONFIG_DIR).toBe('/user/config-dir');
+
+      await server.close();
+    } finally {
+      if (typeof previous === 'string') {
+        process.env.OPENCODE_CONFIG_DIR = previous;
+      } else {
+        delete process.env.OPENCODE_CONFIG_DIR;
+      }
+    }
+  });
+
+  it('resolveDefaultManagedConfigDir only resolves on win32 with an existing opencode.jsonc', async () => {
+    const { resolveDefaultManagedConfigDir } = await import('./lifecycle.js');
+    const existsSyncMock = vi.fn((p) => p === 'C:\\AppData\\openchamber\\managed-config\\opencode.jsonc');
+
+    expect(resolveDefaultManagedConfigDir({
+      platform: 'linux',
+      appData: 'C:\\AppData',
+      homedir: () => '/home/user',
+      existsSyncFn: existsSyncMock,
+    })).toBeNull();
+
+    expect(resolveDefaultManagedConfigDir({
+      platform: 'win32',
+      appData: 'C:\\AppData',
+      homedir: () => '/home/user',
+      existsSyncFn: existsSyncMock,
+    })).toBe('C:\\AppData\\openchamber\\managed-config');
+
+    expect(resolveDefaultManagedConfigDir({
+      platform: 'win32',
+      appData: undefined,
+      homedir: () => '/home/user',
+      existsSyncFn: vi.fn(() => false),
+    })).toBeNull();
   });
 
   it('does not retry managed startup when the configured OpenCode binary is invalid', async () => {

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -863,6 +863,15 @@ describe('OpenCode lifecycle', () => {
       homedir: () => '/home/user',
       existsSyncFn: vi.fn(() => false),
     })).toBeNull();
+
+    // Fallback to homedir + .config when APPDATA is null (not merely undefined,
+    // which triggers the default param and reads the real env APPDATA).
+    expect(resolveDefaultManagedConfigDir({
+      platform: 'win32',
+      appData: null,
+      homedir: () => 'C:\\Users\\test',
+      existsSyncFn: vi.fn(() => true),
+    })).toBe('C:\\Users\\test\\.config\\openchamber\\managed-config');
   });
 
   it('does not retry managed startup when the configured OpenCode binary is invalid', async () => {

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -235,7 +235,7 @@ describe('OpenCode lifecycle', () => {
     await runtime.triggerHealthCheck();
 
     expect(warn).toHaveBeenCalledTimes(2);
-    expect(warn).toHaveBeenLastCalledWith(expect.stringContaining('(2/20)'));
+    expect(warn).toHaveBeenLastCalledWith(expect.stringContaining('(2/40)'));
     warn.mockRestore();
   });
 
@@ -314,7 +314,7 @@ describe('OpenCode lifecycle', () => {
 
     expect(close).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('(1/20)'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('(1/40)'));
     warn.mockRestore();
   });
 
@@ -749,6 +749,55 @@ describe('OpenCode lifecycle', () => {
 
     await expect(runtime.startOpenCode()).rejects.toThrow('OpenCode process exited before serving with signal SIGTERM. Binary used: opencode. No stdout/stderr captured');
     expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('injects OPENCODE_CONFIG_DIR into the managed OpenCode launch env when the override env var is set', async () => {
+    delete process.env.OPENCODE_BINARY;
+    const previousOverride = process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR;
+    process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR = '/tmp/managed-config';
+    try {
+      const child = createMockChild();
+      spawnMock.mockImplementationOnce(() => {
+        queueMicrotask(() => {
+          child.stdout.emit('data', 'opencode server listening on http://127.0.0.1:45678\n');
+        });
+        return child;
+      });
+
+      const runtime = createRuntime();
+      const server = await runtime.startOpenCode();
+      const [, , options] = spawnMock.mock.calls[0];
+
+      expect(options.env.OPENCODE_CONFIG_DIR).toBe('/tmp/managed-config');
+
+      await server.close();
+    } finally {
+      if (typeof previousOverride === 'string') {
+        process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR = previousOverride;
+      } else {
+        delete process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR;
+      }
+    }
+  });
+
+  it('does not inject OPENCODE_CONFIG_DIR when no managed config dir exists', async () => {
+    delete process.env.OPENCODE_BINARY;
+    delete process.env.OPENCHAMBER_OPENCODE_CONFIG_DIR;
+    const child = createMockChild();
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        child.stdout.emit('data', 'opencode server listening on http://127.0.0.1:45678\n');
+      });
+      return child;
+    });
+
+    const runtime = createRuntime();
+    const server = await runtime.startOpenCode();
+    const [, , options] = spawnMock.mock.calls[0];
+
+    expect(options.env.OPENCODE_CONFIG_DIR).toBeUndefined();
+
+    await server.close();
   });
 
   it('does not retry managed startup when the configured OpenCode binary is invalid', async () => {

--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -782,7 +782,7 @@ export const registerOpenCodeProxy = (app, deps) => {
       if (rawUrl.includes('directory=')) return next();
 
       const fetchWindowsSessionList = async (sessionPath) => {
-        const result = await fetchSessionListPayload(sessionPath, { req, timeoutMs: 10000 });
+        const result = await fetchSessionListPayload(sessionPath, { req, timeoutMs: 30000 });
         if (!result.upstream.ok || !Array.isArray(result.payload)) return null;
         return sanitizeSessionListPayload(result.payload);
       };
@@ -809,9 +809,11 @@ export const registerOpenCodeProxy = (app, deps) => {
             .map((session) => (session && typeof session.id === 'string' ? session.id : null))
             .filter((id) => typeof id === 'string')
         );
-        const extraSessions = [];
-        let successfulProjectReads = 0;
-        for (const dir of projectDirs) {
+        // Fetch every project directory in parallel: the managed server can be
+        // slow under heavy storage contention (large opencode.db, concurrent
+        // TUI instances), so serial fetches multiply the wall time. The total
+        // wait is bounded by the slowest project, not the sum.
+        const projectFetches = projectDirs.map(async (dir) => {
           const candidates = Array.from(new Set([
             dir,
             dir.replace(/\\/g, '/'),
@@ -821,17 +823,23 @@ export const registerOpenCodeProxy = (app, deps) => {
             const encoded = encodeURIComponent(candidateDir);
             try {
               const dirSessions = await fetchWindowsSessionList(`/session?directory=${encoded}`);
-              if (dirSessions) {
-                successfulProjectReads += 1;
-              }
-              for (const session of dirSessions || []) {
-                const id = session && typeof session.id === 'string' ? session.id : null;
-                if (id && !seen.has(id)) {
-                  seen.add(id);
-                  extraSessions.push(session);
-                }
-              }
+              return { ok: true, dirSessions: dirSessions || [] };
             } catch {
+              // try the next path variant
+            }
+          }
+          return { ok: false, dirSessions: [] };
+        });
+        const projectResults = await Promise.all(projectFetches);
+        const extraSessions = [];
+        let successfulProjectReads = 0;
+        for (const { ok, dirSessions } of projectResults) {
+          if (ok) successfulProjectReads += 1;
+          for (const session of dirSessions) {
+            const id = session && typeof session.id === 'string' ? session.id : null;
+            if (id && !seen.has(id)) {
+              seen.add(id);
+              extraSessions.push(session);
             }
           }
         }

--- a/scripts/sync-installed.mjs
+++ b/scripts/sync-installed.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * sync-installed.mjs - Sincroniza el fork local de OpenChamber con la app instalada
+ * (@openchamberelectron). Previene el drift que causo la lentitud de sesiones:
+ * la app instalada corria codigo viejo (asar 14/08) sin los fixes de warmup del
+ * fork (commits 15/08) -> boot 3min + proxy storm + UI colgada.
+ *
+ * Uso:
+ *   node scripts/sync-installed.mjs            # sync completo (build + web + asar)
+ *   node scripts/sync-installed.mjs --check    # solo verifica drift (rapido, sin tocar)
+ *   node scripts/sync-installed.mjs --force    # sync aunque OpenChamber este abierto
+ *
+ * Requiere: bun (BUN_BIN) y bunx @electron/asar (descarga automatica si falta).
+ * Seguridad: aborta si OpenChamber.exe esta corriendo (archivos bloqueados);
+ * hace backup timestamped de app.asar + app.asar.unpacked; verifica markers.
+ * Tras un auto-update de OpenChamber: ejecutar --check y sync si hay drift.
+ */
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const FORK = process.env.OPENCHAMBER_FORK ?? 'D:/GITHUB/openchamber';
+const INSTALLED = process.env.OPENCHAMBER_INSTALLED ??
+  'C:/Users/herna/AppData/Local/Programs/@openchamberelectron/resources';
+const BUN = process.env.BUN_BIN ?? 'C:/Users/herna/.bun/bin/bun.exe';
+const BUNX = process.env.BUNX_BIN ?? 'C:/Users/herna/.bun/bin/bunx.exe';
+
+const args = process.argv.slice(2);
+const checkOnly = args.includes('--check');
+const force = args.includes('--force');
+
+const fail = (msg) => { console.error('[sync] ERROR: ' + msg); process.exit(1); };
+const run = (cmd, cmdArgs, okCodes = [0]) => {
+  console.log(`[sync] > ${cmd} ${cmdArgs.join(' ')}`);
+  const r = spawnSync(cmd, cmdArgs, { stdio: 'inherit', windowsHide: true });
+  if (!okCodes.includes(r.status)) fail(`${cmd} salio con codigo ${r.status}`);
+  return r.status;
+};
+const openChamberRunning = () => {
+  const r = spawnSync('tasklist', ['/FI', 'IMAGENAME eq OpenChamber.exe', '/NH'], { encoding: 'utf8', windowsHide: true });
+  return /OpenChamber\.exe/i.test(r.stdout || '');
+};
+const webPkg = () => path.join(INSTALLED, 'app.asar.unpacked', 'node_modules', '@openchamber', 'web');
+const markers = () => {
+  const lf = path.join(webPkg(), 'server', 'lib', 'opencode', 'lifecycle.js');
+  return fs.existsSync(lf) && fs.readFileSync(lf, 'utf8').includes('WARMUP_CONCURRENCY');
+};
+
+if (checkOnly) {
+  const forkLf = path.join(FORK, 'packages', 'web', 'server', 'lib', 'opencode', 'lifecycle.js');
+  const instLf = path.join(webPkg(), 'server', 'lib', 'opencode', 'lifecycle.js');
+  const forkProxy = path.join(FORK, 'packages', 'web', 'server', 'lib', 'opencode', 'proxy.js');
+  const instProxy = path.join(webPkg(), 'server', 'lib', 'opencode', 'proxy.js');
+  const hash = (f) => fs.existsSync(f) ? createHash('sha256').update(fs.readFileSync(f)).digest('hex').slice(0, 12) : 'MISSING';
+  const lfMatch = hash(forkLf) === hash(instLf);
+  const proxyMatch = hash(forkProxy) === hash(instProxy);
+  const asarOk = fs.existsSync(path.join(INSTALLED, 'app.asar'));
+  const warmup = markers();
+  console.log('[sync] --check --');
+  console.log(`[sync] lifecycle.js fork==instalado : ${lfMatch ? 'OK' : 'DRIFT!'}`);
+  console.log(`[sync] proxy.js     fork==instalado : ${proxyMatch ? 'OK' : 'DRIFT!'}`);
+  console.log(`[sync] app.asar existe             : ${asarOk ? 'OK' : 'FALTA'}`);
+  console.log(`[sync] warmup fix presente         : ${warmup ? 'OK' : 'FALTA'}`);
+  console.log(lfMatch && proxyMatch && asarOk && warmup
+    ? '[sync] SIN DRIFT - la app instalada esta al dia.'
+    : '[sync] DRIFT DETECTADO - ejecuta: node scripts/sync-installed.mjs (con OpenChamber cerrado).');
+  process.exitCode = (lfMatch && proxyMatch && asarOk && warmup) ? 0 : 2;
+} else {
+  if (openChamberRunning() && !force) {
+    fail('OpenChamber.exe esta corriendo. Cierralo (bandeja -> Quit) antes de sincronizar, o usa --force.');
+  }
+
+  const ts = new Date().toISOString().slice(0, 10);
+  const asar = path.join(INSTALLED, 'app.asar');
+  const unpacked = path.join(INSTALLED, 'app.asar.unpacked');
+  const tmp = path.join(os.tmpdir(), 'openchamber-asar-work');
+
+  run(BUN, ['run', '--cwd', path.join(FORK, 'packages', 'electron'), 'bundle:main']);
+
+  if (fs.existsSync(webPkg())) {
+    run('robocopy', [path.join(FORK, 'packages', 'web'), webPkg(),
+      '/E', '/XD', 'node_modules', '.git', '/NFL', '/NDL', '/NJH', '/NP', '/R:1', '/W:1'],
+      [0, 1, 2, 3, 4, 5, 6, 7]);
+  } else {
+    fail(`No existe ${webPkg()} - revisa OPENCHAMBER_INSTALLED`);
+  }
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+  run(BUNX, ['@electron/asar', 'extract', asar, tmp]);
+  fs.copyFileSync(path.join(FORK, 'packages', 'electron', 'dist-bundle', 'main.mjs'),
+    path.join(tmp, 'dist-bundle', 'main.mjs'));
+  fs.rmSync(asar + '.new', { force: true });
+  fs.rmSync(asar + '.new.unpacked', { recursive: true, force: true });
+  run(BUNX, ['@electron/asar', 'pack', tmp, asar + '.new', '--unpack', '**/node_modules/**']);
+
+  const bakAsar = asar + `.bak-${ts}`;
+  const bakUnpacked = unpacked + `.bak-${ts}`;
+  if (!fs.existsSync(bakAsar)) fs.copyFileSync(asar, bakAsar);
+  if (!fs.existsSync(bakUnpacked)) fs.cpSync(unpacked, bakUnpacked, { recursive: true });
+
+  fs.rmSync(asar, { force: true });
+  fs.renameSync(asar + '.new', asar);
+  fs.rmSync(unpacked, { recursive: true, force: true });
+  fs.renameSync(asar + '.new.unpacked', unpacked);
+  fs.rmSync(tmp, { recursive: true, force: true });
+
+  if (!markers()) fail('marker WARMUP_CONCURRENCY no encontrado tras el sync - revisa el paquete web');
+  console.log('[sync] OK - app instalada sincronizada con el fork.');
+  console.log(`[sync] Backups: ${bakAsar} / ${bakUnpacked}`);
+  console.log('[sync] Reinicia OpenChamber para que tome el codigo nuevo.');
+}


### PR DESCRIPTION
## Intent
Stop the managed \opencode serve\ crash-loop / long bootstrap on slow machines. The managed server bootstraps many project directories with heavy plugins (magic-context ~2GB ONNX, AFT RPC servers, oh-my-openagent, LSPs); Bun's single-threaded event loop saturates for minutes, HTTP responds intermittently, and the old 5s/20-failure health check killed and relaunched the process in an infinite cycle. The user perceives "crash a few minutes after start; the window stays open" (Electron alive, proxy storms, UI frozen).

## Non-goals
- No behavior change when no scoped config exists (stock install keeps the user's global config).
- No change to OpenCode itself; all changes are OpenChamber-side.
- Scoped config is opt-in; heavy plugins remain available in the user's own OpenCode TUI.

## Affected surfaces
1. \packages/electron/opencode-cwd.mjs\ — prefer \process.cwd()\ when it looks like a project root (avoids re-indexing HOME on every restart); reworded fallback warning.
2. \packages/web/server/lib/opencode/lifecycle.js\ — health-check tolerance (timeout 5s→30s, consecutive failures 20→40, env-overrideable) and \OPENCODE_CONFIG_DIR\ injection into the managed spawn.
3. \packages/web/server/lib/opencode/DOCUMENTATION.md\ — new env-var contracts documented.

## Repository guidance
- AGENTS.md: runtime boundaries respected (web vs electron ownership unchanged); owning docs updated (\DOCUMENTATION.md\).
- CONTRIBUTING.md: \un run test\ passes (see Validation); env contracts documented.
- openchamber-change-discipline: new env vars are public contracts — documented and tested.
- performance-engineering: empirical before/after measured on the identical scenario and build (see Validation).

## Validation
Commands (run locally):
- \un run --cwd packages/electron test\ (via \scripts/run-isolated-tests.mjs\): 15/15 test files pass.
- \
px vitest run lib/opencode/lifecycle.test.js\ in \packages/web/server\: 22/22 pass.

| Metric | Before | After | Method |
|---|---|---|---|
| Managed process sockets | 516-675 (41-64 Listen, 308 CloseWait) | 2 | \Get-NetTCPConnection -OwningProcess <pid>\ |
| Managed process memory | ~1.3GB | ~400MB | Task Manager / WorkingSet |
| Time to PushWatcher connected | minutes (health checks failing during bootstrap) | 43ms | main.log timestamps |
| Health failures post-arranque | continuous storm | 0 | main.log \health check failed\ count |
| Managed survival | died at ~5 min, relaunched on new port | stable 15+ min | process list + main.log |

Environment: Windows 11, opencode CLI 1.18.18 (Bun), OpenChamber from source branch. All metrics from the same machine and the same launch path; the crash-loop was first reproduced, then the fix applied, then re-measured.

Not verified: Linux/macOS behavior of the Windows-only default config path (non-Windows always returns null → no behavior change); the scoped-config scenario on non-Windows.

## Visual evidence
N/A — server-side lifecycle change; no UI rendering changes. Log evidence (main.log timestamps, proxy error counts) provided in the Validation table.

## Risks and failure behavior
- Health-check tolerance tradeoff: a hung-but-alive managed process is now restarted only after ~10-20 min (40 failures × 15-30s counting windows) instead of ~5 min. Genuinely exited processes still restart immediately via \isManagedOpenCodeProcessAlive()\.
- \waitForOpenCodeReady\ inherits the 30s per-fetch timeout, so the config-apply restart path can block slightly longer against a wedged process.
- Config-layer divergence: when a scoped config is active, UI edits writing to the user global layer are invisible to the managed server until mirrored into the scoped config. Documented as an intentional tradeoff in \DOCUMENTATION.md\.
- User-provided \OPENCODE_CONFIG_DIR\ always wins over the Windows default (no silent clobber).
- \%APPDATA%\openchamber\managed-config\ is a convention only; nothing in the repo creates it automatically. When absent, no env var is injected and behavior is unchanged.