### PR TITLE
fix(ui): drop unused runtimeFetch import in gitApi

### DIFF
--- a/packages/ui/src/lib/gitApi.ts
+++ b/packages/ui/src/lib/gitApi.ts
@@ -2,7 +2,6 @@
 import * as gitHttp from './gitApiHttp';
 import { opencodeClient } from './opencode/client';
 import { renderMagicPrompt } from './magicPrompts';
-import { runtimeFetch } from './runtime-fetch';
 import { requestSmallModel } from './smallModelRequest';
 import { materializeOpenDraftSession, useSessionUIStore } from '@/sync/session-ui-store';
 import { useSelectionStore } from '@/sync/selection-store';


### PR DESCRIPTION
## Intent

`main` is currently red: `bun run --filter '*' lint` fails in `@openchamber/ui`.

```
packages/ui/src/lib/gitApi.ts
  5:10  error  'runtimeFetch' is defined but never used  @typescript-eslint/no-unused-vars
✖ 1 problem (1 error, 0 warnings)
error: script "lint" exited with code 1
```

109e957fe ("fix: integrate Claude CLI provider state") replaced both `runtimeFetch('/api/small-model/generate', ...)` call sites in `gitApi.ts` with `requestSmallModel` and added that import, but left the now-unused `runtimeFetch` import behind. This removes it.

Because `pull_request` runs lint against the merge with `main`, this fails CI on **every open PR**, not only on `main` itself — which is how I hit it (#2916).

<img width="250*3" height="450" alt="pr2920-unused-import" src="https://github.com/user-attachments/assets/732ddc5f-6c56-45d4-a9eb-6dea2d36231d" />


## Non-goals

- No change to `requestSmallModel`, the small-model request path, or any behavior from 109e957fe. This is import hygiene only.
- No other lint findings addressed; the rest of the suite is clean.

## Affected surfaces

`packages/ui/src/lib/gitApi.ts` only — one deleted import line. No runtime behavior: the symbol had zero references in the file (verified with `grep -c runtimeFetch` → `0` after removal). No other package imports it from here.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Repo-wide correctness and validation rules | Minimal single-concern fix; lint and type-check run locally before push |
| `openchamber-change-discipline` | Executable source changed | Smallest complete change — one line, no drive-by refactors, no behavior change |
| `ui-api-decoupling` | Applicable — `gitApi.ts` is a shared UI data-access module and the removed symbol is the shared `runtime-fetch` helper | Trivially satisfied: the import had zero references, so removal does not alter route access, auth, runtime URL switching, or any data-access path |
| `locale-ui-patterns` | Not applicable | No user-facing strings |
| `theme-system` | Not applicable | No styling |

## Validation

| Check | Result |
|---|---|
| `npx eslint ./src/lib/gitApi.ts --config ../../eslint.config.js` | clean, exit 0 |
| `bun run lint` (packages/ui, exactly as CI invokes it) | clean, exit 0 |
| `npx tsc --noEmit` (packages/ui) | clean |

Not verified: runtime behavior, since no runtime code changed — the removed symbol had no remaining references.

## Visual evidence

No user-visible change. The diff deletes an unused import; it cannot affect rendered output, and no component, style, or string is touched.

## Risks and failure behavior

None identified. Removing an import with zero references in the file has no runtime effect, and the type-checker confirms nothing else in the package depended on it. Rollback is a one-line revert.
