### PR TITLE
feat: run OpenChamber UI against a Pi kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ Around that foundation, OpenChamber brings together the work that happens before
 
 OpenChamber is an independent project and is not affiliated with the OpenCode team.
 
+## Pichamber (Pi kernel)
+
+This fork runs the OpenChamber UI against [Pi](https://github.com/earendil-works/pi) instead of an OpenCode process. See [docs/PICHAMBER.md](docs/PICHAMBER.md) for macOS setup, mock mode, and what is still OpenCode-only.
+
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and contribution guidelines. Documentation authoring guidance lives in [`packages/docs`](packages/docs/README.md).

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     },
     "packages/electron": {
       "name": "@openchamber/electron",
-      "version": "1.18.2",
+      "version": "1.18.4",
       "dependencies": {
         "@openchamber/web": "workspace:*",
         "electron-context-menu": "^4.1.2",
@@ -132,7 +132,7 @@
     },
     "packages/ui": {
       "name": "@openchamber/ui",
-      "version": "1.18.2",
+      "version": "1.18.4",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@base-ui/react": "^1.4.0",
@@ -236,7 +236,7 @@
     },
     "packages/vscode": {
       "name": "openchamber",
-      "version": "1.18.2",
+      "version": "1.18.4",
       "dependencies": {
         "@openchamber/ui": "workspace:*",
         "@opencode-ai/sdk": "1.18.18",
@@ -259,12 +259,13 @@
     },
     "packages/web": {
       "name": "@openchamber/web",
-      "version": "1.18.2",
+      "version": "1.18.4",
       "bin": {
         "openchamber": "./bin/cli.js",
       },
       "dependencies": {
         "@clack/prompts": "^1.1.0",
+        "@earendil-works/pi-coding-agent": "0.84.2",
         "@octokit/rest": "^22.0.1",
         "@opencode-ai/sdk": "1.18.18",
         "@simplewebauthn/server": "13.3.1",
@@ -361,9 +362,59 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
     "@aparajita/capacitor-secure-storage": ["@aparajita/capacitor-secure-storage@8.0.0", "", { "dependencies": { "@capacitor/android": "^8.0.2", "@capacitor/app": "^8.0.0", "@capacitor/core": "^8.0.2", "@capacitor/ios": "^8.0.2", "@capacitor/keyboard": "^8.0.0" } }, "sha512-oYnwSjdIh23aRNgz8982+TmFvQH/2yZkEdw1iIg+H2ziFJoOVELPTc7u6Ez2HwOuDIW5AGqBX75GvrzQ+D70Qg=="],
 
     "@apideck/better-ajv-errors": ["@apideck/better-ajv-errors@0.3.6", "", { "dependencies": { "json-schema": "^0.4.0", "jsonpointer": "^5.0.0", "leven": "^3.1.0" }, "peerDependencies": { "ajv": ">=8" } }, "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.8", "", { "dependencies": { "@aws-sdk/types": "^3.974.4", "@aws-sdk/xml-builder": "^3.972.39", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.69", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.71", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.14", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/credential-provider-env": "^3.972.69", "@aws-sdk/credential-provider-http": "^3.972.71", "@aws-sdk/credential-provider-login": "^3.972.76", "@aws-sdk/credential-provider-process": "^3.972.69", "@aws-sdk/credential-provider-sso": "^3.973.13", "@aws-sdk/credential-provider-web-identity": "^3.972.75", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.76", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.80", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.69", "@aws-sdk/credential-provider-http": "^3.972.71", "@aws-sdk/credential-provider-ini": "^3.973.14", "@aws-sdk/credential-provider-process": "^3.972.69", "@aws-sdk/credential-provider-sso": "^3.973.13", "@aws-sdk/credential-provider-web-identity": "^3.972.75", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.69", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.13", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/token-providers": "3.1111.0", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.75", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.33", "", { "dependencies": { "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.28", "", { "dependencies": { "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.51", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.43", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/signature-v4-multi-region": "^3.996.45", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.45", "", { "dependencies": { "@aws-sdk/types": "^3.974.4", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.4", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.10", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.39", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@azu/format-text": ["@azu/format-text@1.0.2", "", {}, "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="],
 
@@ -673,6 +724,20 @@
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.2", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.2", "@earendil-works/pi-telemetry": "^0.84.2", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.2", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.2", "@google/genai": "1.52.0", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig=="],
+
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.2", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.2" } }, "sha512-/RFSPhD/bZbpOp1oJj+UneSUFSgZhWxzcSENUY+8+8xhoBrWXMYI2t77XNx4Yf+c8YK2qTHquForhNcelYpXvg=="],
+
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.2", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.2", "@earendil-works/pi-ai": "^0.84.2", "@earendil-works/pi-client": "^0.84.2", "@earendil-works/pi-protocol": "^0.84.2", "@earendil-works/pi-tui": "^0.84.2", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA=="],
+
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.2", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-jbBh03fkeckWEroHpcZBr4w5/Ibat8WwdXFlXHivYQImrQNFtLpDeL0t1cku4hmK0q3pceIRQHkw4fwbM4YILQ=="],
+
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.2", "", {}, "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.2", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg=="],
+
     "@electron-internal/extract-zip": ["@electron-internal/extract-zip@1.0.5", "", {}, "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
@@ -780,6 +845,8 @@
     "@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@1.8.16", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "tslib": "^2.8.0" } }, "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ=="],
 
     "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@heroui/react-rsc-utils": ["@heroui/react-rsc-utils@2.1.9", "", { "peerDependencies": { "react": ">=18 || >=19.0.0-rc.0" } }, "sha512-e77OEjNCmQxE9/pnLDDb93qWkX58/CcgIqdNAczT/zUP+a48NxGq2A2WRimvc1uviwaNL2StriE2DmyZPyYW7Q=="],
 
@@ -949,6 +1016,28 @@
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
@@ -994,6 +1083,8 @@
     "@openchamber/web": ["@openchamber/web@workspace:packages/web"],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.18", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-zJlwXskIR47V1dkPJqeKBgq7nejG1uU8lJaGIGqbX3MWRCT8vKn0fEotbxuPCKnTdmWsDyNGNg9q1qIliDSMDA=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 
@@ -1253,6 +1344,8 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
+
     "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
 
     "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
@@ -1264,6 +1357,24 @@
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
+
+    "@smithy/core": ["@smithy/core@3.33.0", "", { "dependencies": { "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.5.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.7.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.7.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q=="],
+
+    "@smithy/types": ["@smithy/types@4.17.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -1382,6 +1493,8 @@
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/sarif": ["@types/sarif@2.1.7", "", {}, "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ=="],
 
@@ -1573,6 +1686,8 @@
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "binaryextensions": ["binaryextensions@6.11.0", "", { "dependencies": { "editions": "^6.21.0" } }, "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw=="],
@@ -1588,6 +1703,8 @@
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "boundary": ["boundary@2.0.0", "", {}, "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "bplist-parser": ["bplist-parser@0.3.2", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ=="],
 
@@ -1748,6 +1865,8 @@
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -1981,6 +2100,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
@@ -2013,6 +2134,8 @@
 
     "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
 
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
     "formidable": ["formidable@3.5.4", "", { "dependencies": { "@paralleldrive/cuid2": "^2.2.2", "dezalgo": "^1.0.4", "once": "^1.4.0" } }, "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
@@ -2041,13 +2164,17 @@
 
     "fuse.js": ["fuse.js@7.1.0", "", {}, "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ=="],
 
+    "gaxios": ["gaxios@7.3.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -2067,7 +2194,7 @@
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
-    "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -2079,11 +2206,17 @@
 
     "globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
 
+    "google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "got": ["got@11.8.6", "", { "dependencies": { "@sindresorhus/is": "^4.0.0", "@szmarczak/http-timer": "^4.0.5", "@types/cacheable-request": "^6.0.1", "@types/responselike": "^1.0.0", "cacheable-lookup": "^5.0.3", "cacheable-request": "^7.0.2", "decompress-response": "^6.0.0", "http2-wrapper": "^1.0.0-beta.5.2", "lowercase-keys": "^2.0.0", "p-cancelable": "^2.0.0", "responselike": "^2.0.0" } }, "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "grok-mermaid": ["grok-mermaid@0.2.2", "", {}, "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA=="],
 
     "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
 
@@ -2125,7 +2258,9 @@
 
     "heic2any": ["heic2any@0.0.4", "", {}, "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA=="],
 
-    "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
     "html-to-image": ["html-to-image@1.11.13", "", {}, "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg=="],
 
@@ -2299,9 +2434,13 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -2411,7 +2550,7 @@
 
     "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
 
-    "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+    "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
 
@@ -2671,6 +2810,8 @@
 
     "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
 
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
@@ -2690,6 +2831,8 @@
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "patch-package": ["patch-package@8.0.1", "", { "dependencies": { "@yarnpkg/lockfile": "^1.1.0", "chalk": "^4.1.2", "ci-info": "^3.7.0", "cross-spawn": "^7.0.3", "find-yarn-workspace-root": "^2.0.0", "fs-extra": "^10.0.0", "json-stable-stringify": "^1.0.2", "klaw-sync": "^6.0.0", "minimist": "^1.2.6", "open": "^7.4.2", "semver": "^7.5.3", "slash": "^2.0.0", "tmp": "^0.2.4", "yaml": "^2.2.2" }, "bin": { "patch-package": "index.js" } }, "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw=="],
 
@@ -3153,6 +3296,8 @@
 
     "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -3172,6 +3317,8 @@
     "type-fest": ["type-fest@0.16.0", "", {}, "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -3195,7 +3342,7 @@
 
     "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
 
-    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
+    "undici": ["undici@8.9.0", "", {}, "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -3387,6 +3534,12 @@
 
     "@apideck/better-ajv-errors/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.11.0", "", { "dependencies": { "@smithy/core": "^3.33.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1111.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.11.0", "", { "dependencies": { "@smithy/core": "^3.33.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ=="],
+
     "@azure/identity/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -3406,6 +3559,30 @@
     "@capacitor/cli/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "@capacitor/cli/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "@earendil-works/pi-agent-core/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "@earendil-works/pi-agent-core/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@earendil-works/pi-agent-core/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@earendil-works/pi-ai/openai": ["openai@6.40.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA=="],
+
+    "@earendil-works/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@earendil-works/pi-coding-agent/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "@earendil-works/pi-coding-agent/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@earendil-works/pi-coding-agent/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "@earendil-works/pi-coding-agent/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "@earendil-works/pi-coding-agent/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@earendil-works/pi-tui/marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
@@ -3434,6 +3611,8 @@
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "@google/genai/protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "@heroui/theme/tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
@@ -3507,6 +3686,10 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "@vscode/vsce/glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
+
+    "@vscode/vsce/hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
+
     "@vscode/vsce/xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
 
     "@xenova/transformers/sharp": ["sharp@0.32.6", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.2", "node-addon-api": "^6.1.0", "prebuild-install": "^7.1.1", "semver": "^7.5.4", "simple-get": "^4.0.1", "tar-fs": "^3.0.4", "tunnel-agent": "^0.6.0" } }, "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w=="],
@@ -3520,6 +3703,8 @@
     "app-builder-lib/@electron/rebuild": ["@electron/rebuild@4.0.3", "", { "dependencies": { "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.1.1", "detect-libc": "^2.0.1", "got": "^11.7.0", "graceful-fs": "^4.2.11", "node-abi": "^4.2.0", "node-api-version": "^0.2.1", "node-gyp": "^11.2.0", "ora": "^5.1.0", "read-binary-file-arch": "^1.0.6", "semver": "^7.3.5", "tar": "^7.5.6", "yargs": "^17.0.1" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA=="],
 
     "app-builder-lib/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
+
+    "app-builder-lib/hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
     "app-builder-lib/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
@@ -3563,11 +3748,15 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fetch-blob/web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
@@ -3584,8 +3773,6 @@
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "keytar/node-addon-api": ["node-addon-api@4.3.0", "", {}, "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="],
-
-    "lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "make-fetch-happen/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -3609,6 +3796,8 @@
 
     "node-gyp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "node-gyp/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
+
     "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "node-sarif-builder/fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
@@ -3621,6 +3810,8 @@
 
     "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
@@ -3628,8 +3819,6 @@
     "parse-semver/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
@@ -3652,8 +3841,6 @@
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "rehype-katex/katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
-
-    "rimraf/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
@@ -3701,6 +3888,8 @@
 
     "workbox-build/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
+    "workbox-build/glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
+
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
     "workbox-build/rollup": ["rollup@2.80.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ=="],
@@ -3715,7 +3904,15 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@earendil-works/pi-coding-agent/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
     "@electron/universal/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "@google/genai/protobufjs/@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@google/genai/protobufjs/@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@google/genai/protobufjs/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "@rollup/plugin-node-resolve/@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -3724,6 +3921,10 @@
     "@secretlint/formatter/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "@vscode/vsce/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "@vscode/vsce/hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "@vscode/vsce/xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
@@ -3734,6 +3935,8 @@
     "app-builder-lib/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "app-builder-lib/@electron/rebuild/node-gyp": ["node-gyp@11.5.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "make-fetch-happen": "^14.0.3", "nopt": "^8.0.0", "proc-log": "^5.0.0", "semver": "^7.3.5", "tar": "^7.4.3", "tinyglobby": "^0.2.12", "which": "^5.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ=="],
+
+    "app-builder-lib/hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "app-builder-lib/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
@@ -3746,6 +3949,8 @@
     "cacache/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "cli-truncate/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "cli-truncate/string-width/get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -3796,8 +4001,6 @@
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "rehype-katex/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
-
-    "rimraf/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "source-map/whatwg-url/tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
@@ -3913,7 +4116,15 @@
 
     "workbox-build/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "workbox-build/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "@earendil-works/pi-coding-agent/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@vscode/vsce/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "@vscode/vsce/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "app-builder-lib/@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -3922,6 +4133,8 @@
     "app-builder-lib/@electron/rebuild/node-gyp/nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
 
     "app-builder-lib/@electron/rebuild/node-gyp/proc-log": ["proc-log@5.0.0", "", {}, "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ=="],
+
+    "app-builder-lib/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "app-builder-lib/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -3939,7 +4152,9 @@
 
     "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
-    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+    "workbox-build/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "@vscode/vsce/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "app-builder-lib/@electron/rebuild/node-gyp/nopt/abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
@@ -3951,7 +4166,7 @@
 
     "qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
-    "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+    "workbox-build/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "cacache/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 

--- a/docs/PICHAMBER.md
+++ b/docs/PICHAMBER.md
@@ -1,0 +1,54 @@
+# Pichamber on Pi
+
+Pichamber keeps the OpenChamber UI (`@opencode-ai/sdk/v2`) and serves an OpenCode-shaped HTTP/SSE facade backed by [Pi](https://github.com/earendil-works/pi) (`@earendil-works/pi-coding-agent`).
+
+The happy path does **not** require OpenCode to be installed.
+
+## macOS (the supported product target)
+
+1. Install [bun](https://bun.sh) and Node 22+.
+2. Clone this repo and install dependencies:
+
+```bash
+bun install
+```
+
+3. Configure Pi auth/models the usual way (`~/.pi/agent`, or `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` in the environment). The `pi` CLI on your PATH is optional; the in-process SDK is preferred.
+4. Start the web server:
+
+```bash
+OPENCHAMBER_KERNEL=pi bun run start:web
+# or, during development:
+OPENCHAMBER_KERNEL=pi bun run dev
+```
+
+`OPENCHAMBER_KERNEL` defaults to `pi`. Set `OPENCHAMBER_KERNEL=opencode` to restore the upstream OpenCode process + proxy.
+
+5. Open the UI. Chat/session/event traffic stays on `/api/session`, `/api/global/event`, and `/api/global/event/ws`. Git, files, and terminal RuntimeAPIs are unchanged.
+
+### Mock kernel (no LLM keys)
+
+```bash
+OPENCHAMBER_KERNEL=pi OPENCHAMBER_PI_MOCK=1 bun run start:web
+```
+
+Useful for UI/bootstrap work. Prompts stream a canned reply and still exercise session create, SSE, and abort.
+
+## What the Pi facade implements
+
+- Session CRUD, `prompt_async` / `prompt`, abort, messages, status
+- Providers from `ModelRuntime.getAvailable()` (or a mock provider)
+- Event mapping: `text_delta` → `message.part.delta` field `text`; `thinking_delta` → reasoning; `tool_execution_*` → tool parts; `agent_start` → busy; `agent_settled` → idle
+- Empty-success stubs so bootstrap does not crash: MCP, LSP, permission, question, share, revert
+
+## Still OpenCode-only / not ported
+
+- Native OpenCode plugins, MCP OAuth, LSP diagnostics, permission/question dialogs, share, revert, and the managed OpenCode upgrade/binary resolver
+- VS Code, mobile, Windows, and Linux desktop packaging were not the product target for this kernel swap
+
+## Tests
+
+```bash
+cd packages/web
+bunx vitest run server/lib/pi
+```

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@octokit/rest": "^22.0.1",
+    "@earendil-works/pi-coding-agent": "0.84.2",
     "@opencode-ai/sdk": "1.18.18",
     "@simplewebauthn/server": "13.3.1",
     "adm-zip": "^0.6.0",

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -48,6 +48,7 @@ import {
 } from './lib/event-stream/index.js';
 import { createFsSearchRuntime as createFsSearchRuntimeFactory } from './lib/fs/search.js';
 import { createOpenCodeLifecycleRuntime } from './lib/opencode/lifecycle.js';
+import { createPiKernel, isPiKernelEnabled, isPiMockEnabled } from './lib/pi/index.js';
 import { createOpenCodeEnvRuntime } from './lib/opencode/env-runtime.js';
 import { resolveOpenCodeEnvConfig } from './lib/opencode/env-config.js';
 import { createHmrStateRuntime } from './lib/opencode/hmr-state-runtime.js';
@@ -779,11 +780,24 @@ const contextObligatoryRuntime = createContextObligatoryRuntime({
   getOpenCodeAuthHeaders,
 });
 
-const globalMessageStreamHub = createGlobalMessageStreamHub({
-  buildOpenCodeUrl,
-  getOpenCodeAuthHeaders,
-  upstreamStallTimeoutMs: getUpstreamStallTimeoutMs,
-});
+const piKernelEnabled = isPiKernelEnabled();
+const piKernel = piKernelEnabled
+  ? createPiKernel({
+      defaultDirectory: process.cwd(),
+      mock: isPiMockEnabled(),
+    })
+  : null;
+if (piKernel) {
+  console.log(`[pichamber] kernel=pi mock=${piKernel.mock ? 'yes' : 'no'} (OpenCode process not required)`);
+}
+
+const globalMessageStreamHub = piKernel
+  ? piKernel.bus
+  : createGlobalMessageStreamHub({
+      buildOpenCodeUrl,
+      getOpenCodeAuthHeaders,
+      upstreamStallTimeoutMs: getUpstreamStallTimeoutMs,
+    });
 
 const permissionAutoAcceptRuntime = createPermissionAutoAcceptRuntime({
   globalEventHub: globalMessageStreamHub,
@@ -920,6 +934,7 @@ const serverUtilsRuntime = createServerUtilsRuntime({
     }
     return snapshot.PATH;
   },
+  piKernel,
 });
 
 const setOpenCodePort = (...args) => serverUtilsRuntime.setOpenCodePort(...args);
@@ -1061,6 +1076,7 @@ const openCodeLifecycleRuntime = createOpenCodeLifecycleRuntime({
   buildManagedOpenCodePath,
   getManagedOpenCodeShellEnvSnapshot: getLoginShellEnvSnapshot,
   getActiveSessionCount,
+  isPiKernelEnabled: () => piKernelEnabled,
   // Most-recently-used directories first: OpenCode initializes each directory
   // lazily on first request (seconds on large session stores), so the
   // lifecycle warms these right after readiness — before the UI's first
@@ -1249,6 +1265,12 @@ const ensureGlobalWatcherStarted = async () => {
   return globalWatcherStartPromise;
 };
 const bootstrapOpenCodeAtStartup = async (...args) => {
+  if (piKernel) {
+    await piKernel.ready();
+    await openCodeLifecycleRuntime.bootstrapOpenCodeAtStartup(...args);
+    console.log('[pichamber] Pi kernel ready — chat/session/event routes are served by the facade');
+    return;
+  }
   await openCodeLifecycleRuntime.bootstrapOpenCodeAtStartup(...args);
   scheduleOpenCodeApiDetection();
   if (openCodeLifecycleState.openCodeProcess && !openCodeLifecycleState.isExternalOpenCode) {
@@ -1540,8 +1562,10 @@ async function main(options = {}) {
         ? resolveManagedOpenCodeLaunchSpec(resolvedOpencodeBinary)
         : null;
       return {
+        kernel: piKernelEnabled ? 'pi' : 'opencode',
+        piMock: Boolean(piKernel?.mock),
         openCodePort,
-        openCodeRunning: Boolean(openCodePort && isOpenCodeReady && !isRestartingOpenCode),
+        openCodeRunning: piKernelEnabled ? true : Boolean(openCodePort && isOpenCodeReady && !isRestartingOpenCode),
         openCodeSecureConnection: isOpenCodeConnectionSecure(),
         openCodeAuthSource: openCodeAuthSource || null,
         openCodeApiPrefix: '',

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -47,6 +47,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     getManagedOpenCodeShellEnvSnapshot,
     getManagedOpenCodeEnv = async () => ({}),
     getActiveSessionCount = () => 0,
+    isPiKernelEnabled = () => false,
     reapManagedOrphanedProcesses = reapOrphanedProcesses,
     getWarmupDirectories = async () => [],
     onOpenCodeRestarted = null,
@@ -857,6 +858,19 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     const bootstrapStartedAt = performance.now();
     let bootstrapError = null;
     recordStartupPerformance('opencode.bootstrap.start');
+    if (isPiKernelEnabled()) {
+      state.isOpenCodeReady = true;
+      state.lastOpenCodeError = null;
+      state.openCodeNotReadySince = 0;
+      state.isExternalOpenCode = true;
+      syncToHmrState();
+      recordStartupPerformance('opencode.bootstrap.ready', {
+        durationMs: performance.now() - bootstrapStartedAt,
+        kernel: 'pi',
+      });
+      console.log('[lifecycle] Pi kernel active — skipping OpenCode process bootstrap');
+      return;
+    }
     try {
       // Before doing anything, reap any OpenCode process WE spawned in a prior
       // run that was orphaned by a crash/hard-exit. Verified + scoped to our own

--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -193,6 +193,7 @@ export const registerOpenCodeProxy = (app, deps) => {
     SSE_HEARTBEAT_INTERVAL_MS = DEFAULT_SSE_HEARTBEAT_INTERVAL_MS,
     SSE_UPSTREAM_STALL_TIMEOUT_MS = DEFAULT_UPSTREAM_STALL_TIMEOUT_MS,
     getSseUpstreamStallTimeoutMs = () => SSE_UPSTREAM_STALL_TIMEOUT_MS,
+    piKernel = null,
   } = deps;
 
   if (app.get('opencodeProxyConfigured')) {
@@ -206,6 +207,11 @@ export const registerOpenCodeProxy = (app, deps) => {
     console.log('Setting up OpenCode API gate (OpenCode not started yet)');
   }
   app.set('opencodeProxyConfigured', true);
+
+  if (piKernel) {
+    piKernel.register(app);
+    console.log('Pi kernel facade registered (OpenCode proxy is fallback-only)');
+  }
 
   const isAbortError = (error) => error?.name === 'AbortError';
   const FALLBACK_PROXY_TARGET = 'http://127.0.0.1:3902';
@@ -621,6 +627,9 @@ export const registerOpenCodeProxy = (app, deps) => {
   };
 
   app.use('/api', async (req, res, next) => {
+    if (piKernel) {
+      return next();
+    }
     if (
       req.path.startsWith('/themes/custom') ||
       req.path.startsWith('/push') ||

--- a/packages/web/server/lib/opencode/server-utils-runtime.js
+++ b/packages/web/server/lib/opencode/server-utils-runtime.js
@@ -22,6 +22,7 @@ export const createServerUtilsRuntime = (dependencies) => {
     setOpenCodeNotReadySince,
     clearLastOpenCodeError,
     getLoginShellPath,
+    piKernel = null,
   } = dependencies;
 
   const setOpenCodePort = (port) => {
@@ -215,6 +216,7 @@ export const createServerUtilsRuntime = (dependencies) => {
       ensureOpenCodeApiPrefix,
       getSseUpstreamStallTimeoutMs: getUpstreamStallTimeoutMs,
       getUiNotificationClients,
+      piKernel,
     });
   };
 

--- a/packages/web/server/lib/pi/event-translator.js
+++ b/packages/web/server/lib/pi/event-translator.js
@@ -1,0 +1,407 @@
+import { createEventId, createMessageId, createPartId } from './ids.js';
+
+const toolText = (value) => {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (typeof item === 'string') return item;
+        if (item && typeof item === 'object' && typeof item.text === 'string') return item.text;
+        return '';
+      })
+      .filter(Boolean)
+      .join('');
+  }
+  if (typeof value === 'object') {
+    if (typeof value.text === 'string') return value.text;
+    if (Array.isArray(value.content)) return toolText(value.content);
+  }
+  return '';
+};
+
+export const createOpenCodeEvent = (type, properties, { id, now } = {}) => ({
+  id: id || createEventId(),
+  type,
+  properties,
+  ...(now ? { timestamp: now } : {}),
+});
+
+export const createEventTranslator = ({
+  sessionID,
+  directory,
+  createMessageId: nextMessageId = createMessageId,
+  createPartId: nextPartId = createPartId,
+  createEventId: nextEventId = createEventId,
+  now = () => Date.now(),
+} = {}) => {
+  const textParts = new Map();
+  const reasoningParts = new Map();
+  const toolParts = new Map();
+  let assistantMessageID = null;
+  let userMessageID = null;
+
+  const event = (type, properties) => createOpenCodeEvent(type, properties, {
+    id: nextEventId(),
+    now: now(),
+  });
+
+  const setAssistantMessage = (messageID) => {
+    assistantMessageID = messageID;
+  };
+
+  const setUserMessage = (messageID) => {
+    userMessageID = messageID;
+  };
+
+  const assistantInfo = ({ completed = false, model } = {}) => {
+    const created = now();
+    return {
+      id: assistantMessageID,
+      sessionID,
+      role: 'assistant',
+      time: completed ? { created, completed } : { created },
+      ...(model ? { model } : {}),
+    };
+  };
+
+  const textPart = (partID, text = '') => ({
+    id: partID,
+    sessionID,
+    messageID: assistantMessageID,
+    type: 'text',
+    text,
+  });
+
+  const reasoningPart = (partID, text = '') => ({
+    id: partID,
+    sessionID,
+    messageID: assistantMessageID,
+    type: 'reasoning',
+    text,
+  });
+
+  const toolPart = (partID, { callID, tool, status, input, output, error }) => ({
+    id: partID,
+    sessionID,
+    messageID: assistantMessageID,
+    type: 'tool',
+    callID,
+    tool,
+    state: {
+      status,
+      input: input ?? {},
+      ...(output !== undefined ? { output } : {}),
+      ...(error ? { error } : {}),
+      time: { start: now(), ...(status === 'completed' || status === 'error' ? { end: now() } : {}) },
+    },
+  });
+
+  const translateAssistantDelta = (delta) => {
+    if (!delta || typeof delta !== 'object') return [];
+    const contentIndex = typeof delta.contentIndex === 'number' ? delta.contentIndex : 0;
+
+    switch (delta.type) {
+      case 'text_start': {
+        if (!assistantMessageID) {
+          assistantMessageID = nextMessageId();
+        }
+        const partID = nextPartId();
+        textParts.set(contentIndex, partID);
+        return [
+          event('message.updated', { info: assistantInfo() }),
+          event('message.part.updated', { sessionID, part: textPart(partID, '') }),
+        ];
+      }
+      case 'text_delta': {
+        if (!assistantMessageID) {
+          assistantMessageID = nextMessageId();
+        }
+        let partID = textParts.get(contentIndex);
+        const created = [];
+        if (!partID) {
+          partID = nextPartId();
+          textParts.set(contentIndex, partID);
+          created.push(event('message.updated', { info: assistantInfo() }));
+          created.push(event('message.part.updated', { sessionID, part: textPart(partID, '') }));
+        }
+        created.push(event('message.part.delta', {
+          sessionID,
+          messageID: assistantMessageID,
+          partID,
+          field: 'text',
+          delta: typeof delta.delta === 'string' ? delta.delta : '',
+        }));
+        return created;
+      }
+      case 'text_end': {
+        const partID = textParts.get(contentIndex);
+        if (!partID || !assistantMessageID) return [];
+        const text = typeof delta.content === 'string' ? delta.content : undefined;
+        if (text === undefined) return [];
+        return [event('message.part.updated', { sessionID, part: textPart(partID, text) })];
+      }
+      case 'thinking_start': {
+        if (!assistantMessageID) {
+          assistantMessageID = nextMessageId();
+        }
+        const partID = nextPartId();
+        reasoningParts.set(contentIndex, partID);
+        return [
+          event('message.updated', { info: assistantInfo() }),
+          event('message.part.updated', { sessionID, part: reasoningPart(partID, '') }),
+        ];
+      }
+      case 'thinking_delta': {
+        if (!assistantMessageID) {
+          assistantMessageID = nextMessageId();
+        }
+        let partID = reasoningParts.get(contentIndex);
+        const created = [];
+        if (!partID) {
+          partID = nextPartId();
+          reasoningParts.set(contentIndex, partID);
+          created.push(event('message.updated', { info: assistantInfo() }));
+          created.push(event('message.part.updated', { sessionID, part: reasoningPart(partID, '') }));
+        }
+        created.push(event('message.part.delta', {
+          sessionID,
+          messageID: assistantMessageID,
+          partID,
+          field: 'text',
+          delta: typeof delta.delta === 'string' ? delta.delta : '',
+        }));
+        return created;
+      }
+      case 'thinking_end': {
+        const partID = reasoningParts.get(contentIndex);
+        if (!partID || !assistantMessageID) return [];
+        const text = typeof delta.content === 'string'
+          ? delta.content
+          : typeof delta.thinking === 'string'
+            ? delta.thinking
+            : undefined;
+        if (text === undefined) return [];
+        return [event('message.part.updated', { sessionID, part: reasoningPart(partID, text) })];
+      }
+      case 'toolcall_start': {
+        if (!assistantMessageID) {
+          assistantMessageID = nextMessageId();
+        }
+        const callID = delta.toolCall?.id || delta.id || nextPartId();
+        const tool = delta.toolCall?.name || delta.name || 'tool';
+        const partID = nextPartId();
+        toolParts.set(callID, partID);
+        return [
+          event('message.updated', { info: assistantInfo() }),
+          event('message.part.updated', {
+            sessionID,
+            part: toolPart(partID, { callID, tool, status: 'pending', input: delta.toolCall?.arguments || {} }),
+          }),
+        ];
+      }
+      case 'toolcall_end': {
+        const call = delta.toolCall || {};
+        const callID = call.id || delta.id;
+        const partID = callID ? toolParts.get(callID) : null;
+        if (!partID || !assistantMessageID) return [];
+        return [event('message.part.updated', {
+          sessionID,
+          part: toolPart(partID, {
+            callID,
+            tool: call.name || 'tool',
+            status: 'pending',
+            input: call.arguments || {},
+          }),
+        })];
+      }
+      default:
+        return [];
+    }
+  };
+
+  const translate = (piEvent) => {
+    if (!piEvent || typeof piEvent !== 'object') return [];
+    const type = piEvent.type;
+
+    switch (type) {
+      case 'agent_start':
+        return [event('session.status', { sessionID, status: { type: 'busy' } })];
+
+      case 'agent_settled':
+        return [
+          event('session.status', { sessionID, status: { type: 'idle' } }),
+          event('session.idle', { sessionID }),
+        ];
+
+      case 'agent_end':
+        // Idle is agent_settled, not agent_end — retries/compaction may still follow.
+        return [];
+
+      case 'auto_retry_start':
+        return [event('session.status', {
+          sessionID,
+          status: {
+            type: 'retry',
+            attempt: Number(piEvent.attempt) || 1,
+            message: typeof piEvent.errorMessage === 'string' ? piEvent.errorMessage : 'retrying',
+            next: now() + (Number(piEvent.delayMs) || 0),
+          },
+        })];
+
+      case 'message_start': {
+        const message = piEvent.message;
+        const role = message?.role;
+        if (role === 'user') {
+          userMessageID = message.id || userMessageID || nextMessageId();
+          const text = typeof message.content === 'string'
+            ? message.content
+            : Array.isArray(message.content)
+              ? message.content.filter((block) => block?.type === 'text').map((block) => block.text).join('')
+              : '';
+          const partID = nextPartId();
+          return [
+            event('message.updated', {
+              info: {
+                id: userMessageID,
+                sessionID,
+                role: 'user',
+                time: { created: now() },
+              },
+            }),
+            event('message.part.updated', {
+              sessionID,
+              part: {
+                id: partID,
+                sessionID,
+                messageID: userMessageID,
+                type: 'text',
+                text,
+              },
+            }),
+          ];
+        }
+        assistantMessageID = nextMessageId();
+        textParts.clear();
+        reasoningParts.clear();
+        toolParts.clear();
+        return [event('message.updated', { info: assistantInfo() })];
+      }
+
+      case 'message_update':
+        return translateAssistantDelta(piEvent.assistantMessageEvent);
+
+      case 'message_end': {
+        if (!assistantMessageID) return [];
+        const events = [event('message.updated', { info: assistantInfo({ completed: true }) })];
+        return events;
+      }
+
+      case 'tool_execution_start': {
+        if (!assistantMessageID) {
+          assistantMessageID = nextMessageId();
+        }
+        const callID = piEvent.toolCallId;
+        let partID = toolParts.get(callID);
+        const created = [];
+        if (!partID) {
+          partID = nextPartId();
+          toolParts.set(callID, partID);
+          created.push(event('message.updated', { info: assistantInfo() }));
+        }
+        created.push(event('message.part.updated', {
+          sessionID,
+          part: toolPart(partID, {
+            callID,
+            tool: piEvent.toolName || 'tool',
+            status: 'running',
+            input: piEvent.args || {},
+          }),
+        }));
+        return created;
+      }
+
+      case 'tool_execution_update': {
+        const callID = piEvent.toolCallId;
+        const partID = toolParts.get(callID);
+        if (!partID || !assistantMessageID) return [];
+        const output = toolText(piEvent.partialResult?.content ?? piEvent.partialResult);
+        return [event('message.part.updated', {
+          sessionID,
+          part: toolPart(partID, {
+            callID,
+            tool: piEvent.toolName || 'tool',
+            status: 'running',
+            input: piEvent.args || {},
+            output,
+          }),
+        })];
+      }
+
+      case 'tool_execution_end': {
+        const callID = piEvent.toolCallId;
+        const partID = toolParts.get(callID);
+        if (!partID || !assistantMessageID) return [];
+        const output = toolText(piEvent.result?.content ?? piEvent.result);
+        return [event('message.part.updated', {
+          sessionID,
+          part: toolPart(partID, {
+            callID,
+            tool: piEvent.toolName || 'tool',
+            status: piEvent.isError ? 'error' : 'completed',
+            input: piEvent.args || {},
+            output,
+            error: piEvent.isError ? output || 'tool error' : undefined,
+          }),
+        })];
+      }
+
+      default:
+        return [];
+    }
+  };
+
+  return {
+    translate,
+    setAssistantMessage,
+    setUserMessage,
+    get assistantMessageID() {
+      return assistantMessageID;
+    },
+    get userMessageID() {
+      return userMessageID;
+    },
+    directory,
+  };
+};
+
+export const extractPromptText = (parts) => {
+  if (!Array.isArray(parts)) return '';
+  return parts
+    .filter((part) => part && part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text)
+    .join('\n')
+    .trim();
+};
+
+export const extractPromptImages = (parts) => {
+  if (!Array.isArray(parts)) return [];
+  const images = [];
+  for (const part of parts) {
+    if (!part || part.type !== 'file' || typeof part.url !== 'string') continue;
+    if (!part.mime || !String(part.mime).startsWith('image/')) continue;
+    const url = part.url;
+    if (!url.startsWith('data:')) continue;
+    const comma = url.indexOf(',');
+    if (comma === -1) continue;
+    images.push({
+      type: 'image',
+      source: {
+        type: 'base64',
+        mediaType: part.mime,
+        data: url.slice(comma + 1),
+      },
+    });
+  }
+  return images;
+};

--- a/packages/web/server/lib/pi/event-translator.test.js
+++ b/packages/web/server/lib/pi/event-translator.test.js
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import { createEventTranslator, extractPromptImages, extractPromptText } from './event-translator.js';
+
+const translator = (overrides = {}) => createEventTranslator({
+  sessionID: 'ses_1',
+  directory: '/tmp/project',
+  createMessageId: (() => {
+    let n = 0;
+    return () => `msg_${++n}`;
+  })(),
+  createPartId: (() => {
+    let n = 0;
+    return () => `prt_${++n}`;
+  })(),
+  createEventId: (() => {
+    let n = 0;
+    return () => `evt_${++n}`;
+  })(),
+  now: () => 1_700_000_000_000,
+  ...overrides,
+});
+
+describe('createEventTranslator', () => {
+  it('maps agent_start to session.status busy', () => {
+    const events = translator().translate({ type: 'agent_start' });
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'session.status',
+        properties: { sessionID: 'ses_1', status: { type: 'busy' } },
+      }),
+    ]);
+  });
+
+  it('maps agent_settled to idle, not agent_end', () => {
+    const t = translator();
+    expect(t.translate({ type: 'agent_end', messages: [], willRetry: false })).toEqual([]);
+    const settled = t.translate({ type: 'agent_settled' });
+    expect(settled.map((event) => event.type)).toEqual(['session.status', 'session.idle']);
+    expect(settled[0].properties.status).toEqual({ type: 'idle' });
+    expect(settled[1].properties.sessionID).toBe('ses_1');
+  });
+
+  it('maps text_delta to message.part.delta field text', () => {
+    const t = translator();
+    t.translate({ type: 'message_start', message: { role: 'assistant', content: [] } });
+    const events = t.translate({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Hello' },
+    });
+    const delta = events.find((event) => event.type === 'message.part.delta');
+    expect(delta.properties).toMatchObject({
+      sessionID: 'ses_1',
+      messageID: 'msg_1',
+      partID: 'prt_1',
+      field: 'text',
+      delta: 'Hello',
+    });
+  });
+
+  it('maps thinking_delta to a reasoning part text delta', () => {
+    const t = translator();
+    const events = t.translate({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'thinking_delta', contentIndex: 0, delta: 'hmm' },
+    });
+    const updated = events.find((event) => event.type === 'message.part.updated');
+    const delta = events.find((event) => event.type === 'message.part.delta');
+    expect(updated.properties.part.type).toBe('reasoning');
+    expect(delta.properties.field).toBe('text');
+    expect(delta.properties.delta).toBe('hmm');
+  });
+
+  it('maps tool_execution_* to tool parts', () => {
+    const t = translator();
+    t.translate({ type: 'message_start', message: { role: 'assistant', content: [] } });
+    const start = t.translate({
+      type: 'tool_execution_start',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      args: { command: 'ls' },
+    });
+    const toolStart = start.find((event) => event.type === 'message.part.updated');
+    expect(toolStart.properties.part).toMatchObject({
+      type: 'tool',
+      tool: 'bash',
+      callID: 'call_1',
+      state: expect.objectContaining({ status: 'running', input: { command: 'ls' } }),
+    });
+
+    const end = t.translate({
+      type: 'tool_execution_end',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: 'ok' }] },
+      isError: false,
+    });
+    expect(end[0].properties.part.state.status).toBe('completed');
+    expect(end[0].properties.part.state.output).toBe('ok');
+  });
+
+  it('maps auto_retry_start to session.status retry', () => {
+    const events = translator().translate({
+      type: 'auto_retry_start',
+      attempt: 2,
+      delayMs: 1000,
+      errorMessage: 'overloaded',
+    });
+    expect(events[0].type).toBe('session.status');
+    expect(events[0].properties.status.type).toBe('retry');
+    expect(events[0].properties.status.attempt).toBe(2);
+    expect(events[0].properties.status.message).toBe('overloaded');
+  });
+});
+
+describe('prompt extractors', () => {
+  it('joins text parts and extracts data-url images', () => {
+    expect(extractPromptText([
+      { type: 'text', text: 'hello' },
+      { type: 'text', text: 'world' },
+      { type: 'file', mime: 'image/png', url: 'data:image/png;base64,abc' },
+    ])).toBe('hello\nworld');
+    expect(extractPromptImages([
+      { type: 'file', mime: 'image/png', url: 'data:image/png;base64,abc' },
+    ])).toEqual([{
+      type: 'image',
+      source: { type: 'base64', mediaType: 'image/png', data: 'abc' },
+    }]);
+  });
+});

--- a/packages/web/server/lib/pi/ids.js
+++ b/packages/web/server/lib/pi/ids.js
@@ -1,0 +1,29 @@
+const ID_CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+const randomBase62 = (length) => {
+  let result = '';
+  for (let index = 0; index < length; index += 1) {
+    result += ID_CHARS[Math.floor(Math.random() * ID_CHARS.length)];
+  }
+  return result;
+};
+
+let lastTimestamp = 0;
+let counter = 0;
+
+export const createId = (prefix) => {
+  const timestamp = Date.now();
+  if (timestamp !== lastTimestamp) {
+    lastTimestamp = timestamp;
+    counter = 0;
+  }
+  counter += 1;
+  const sortable = BigInt(timestamp) * BigInt(0x1000) + BigInt(counter);
+  const hex = sortable.toString(16).padStart(12, '0').slice(-12);
+  return `${prefix}_${hex}${randomBase62(10)}`;
+};
+
+export const createSessionId = () => createId('ses');
+export const createMessageId = () => createId('msg');
+export const createPartId = () => createId('prt');
+export const createEventId = () => createId('evt');

--- a/packages/web/server/lib/pi/index.js
+++ b/packages/web/server/lib/pi/index.js
@@ -1,0 +1,59 @@
+import { createPiHost, createInMemoryPiSession, mapPiModelsToProviders } from './pi-host.js';
+import { registerPiFacade } from './opencode-facade.js';
+import { createSseBus } from './sse-bus.js';
+import { createEventTranslator } from './event-translator.js';
+import { isPiKernelEnabled, isPiMockEnabled, resolveKernelName, PI_KERNEL, OPENCODE_KERNEL } from './kernel.js';
+
+export const createPiKernel = (options = {}) => {
+  const env = options.env || process.env;
+  const mock = options.mock ?? isPiMockEnabled(env);
+  const bus = options.bus || createSseBus();
+  const host = options.host || createPiHost({
+    ...options,
+    mock,
+    onEvent: (directory, event) => {
+      bus.publish(directory, event, { eventId: event?.id });
+      if (typeof options.onEvent === 'function') {
+        options.onEvent(directory, event);
+      }
+    },
+  });
+
+  bus.start();
+
+  return {
+    kernel: PI_KERNEL,
+    mock,
+    host,
+    bus,
+    register(app) {
+      registerPiFacade(app, {
+        host,
+        bus,
+        defaultDirectory: options.defaultDirectory || process.cwd(),
+      });
+    },
+    async ready() {
+      await host.ready();
+      return true;
+    },
+    dispose() {
+      host.dispose();
+      bus.stop();
+    },
+  };
+};
+
+export {
+  createPiHost,
+  createInMemoryPiSession,
+  mapPiModelsToProviders,
+  registerPiFacade,
+  createSseBus,
+  createEventTranslator,
+  isPiKernelEnabled,
+  isPiMockEnabled,
+  resolveKernelName,
+  PI_KERNEL,
+  OPENCODE_KERNEL,
+};

--- a/packages/web/server/lib/pi/kernel.js
+++ b/packages/web/server/lib/pi/kernel.js
@@ -1,0 +1,16 @@
+export const PI_KERNEL = 'pi';
+export const OPENCODE_KERNEL = 'opencode';
+
+export const resolveKernelName = (env = process.env) => {
+  const raw = typeof env.OPENCHAMBER_KERNEL === 'string' ? env.OPENCHAMBER_KERNEL.trim().toLowerCase() : '';
+  if (raw === OPENCODE_KERNEL) return OPENCODE_KERNEL;
+  if (raw === PI_KERNEL || raw === '' || raw === 'pichamber') return PI_KERNEL;
+  return PI_KERNEL;
+};
+
+export const isPiKernelEnabled = (env = process.env) => resolveKernelName(env) === PI_KERNEL;
+
+export const isPiMockEnabled = (env = process.env) => {
+  if (env.OPENCHAMBER_PI_MOCK === '1' || env.OPENCHAMBER_PI_MOCK === 'true') return true;
+  return false;
+};

--- a/packages/web/server/lib/pi/kernel.test.js
+++ b/packages/web/server/lib/pi/kernel.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPiKernelEnabled, isPiMockEnabled, resolveKernelName } from './kernel.js';
+
+describe('kernel flags', () => {
+  it('defaults to pi', () => {
+    expect(resolveKernelName({})).toBe('pi');
+    expect(isPiKernelEnabled({})).toBe(true);
+  });
+
+  it('can restore the OpenCode kernel', () => {
+    expect(isPiKernelEnabled({ OPENCHAMBER_KERNEL: 'opencode' })).toBe(false);
+  });
+
+  it('enables mock mode from env', () => {
+    expect(isPiMockEnabled({})).toBe(false);
+    expect(isPiMockEnabled({ OPENCHAMBER_PI_MOCK: '1' })).toBe(true);
+  });
+});

--- a/packages/web/server/lib/pi/opencode-facade.js
+++ b/packages/web/server/lib/pi/opencode-facade.js
@@ -1,0 +1,259 @@
+import express from 'express';
+
+const json = (res, status, body) => {
+  res.status(status).json(body);
+};
+
+const requestDirectory = (req) => {
+  const query = typeof req.query?.directory === 'string' ? req.query.directory.trim() : '';
+  if (query) return query;
+  const header = req.headers?.['x-opencode-directory'];
+  if (typeof header === 'string' && header.trim()) {
+    if (req.headers['x-opencode-directory-encoding'] === 'uri') {
+      try {
+        return decodeURIComponent(header.trim());
+      } catch {
+        return header.trim();
+      }
+    }
+    return header.trim();
+  }
+  return '';
+};
+
+const unsupported = (name) => ({
+  error: 'unsupported',
+  message: `${name} is not implemented on the Pi kernel`,
+  kernel: 'pi',
+});
+
+export const registerPiFacade = (app, { host, bus, defaultDirectory = process.cwd() } = {}) => {
+  if (!app || !host) {
+    throw new Error('registerPiFacade requires app and host');
+  }
+  if (app.get('piFacadeConfigured')) {
+    return;
+  }
+  app.set('piFacadeConfigured', true);
+
+  const resolveDirectory = (req) => requestDirectory(req) || defaultDirectory;
+  const parseJson = express.json({ limit: '50mb' });
+
+  const handle = (fn) => async (req, res, next) => {
+    try {
+      await fn(req, res);
+    } catch (error) {
+      if (res.headersSent) {
+        return next(error);
+      }
+      const status = Number(error?.status) || 500;
+      json(res, status, { error: error?.message || 'Pi facade error' });
+    }
+  };
+
+  app.get('/api/path', handle(async (req, res) => {
+    json(res, 200, host.getPath(resolveDirectory(req)));
+  }));
+
+  app.get('/api/global/config', handle(async (_req, res) => {
+    json(res, 200, { kernel: 'pi' });
+  }));
+
+  app.get('/api/config', handle(async (_req, res) => {
+    json(res, 200, { kernel: 'pi' });
+  }));
+
+  app.patch('/api/config', parseJson, handle(async (req, res) => {
+    json(res, 200, { kernel: 'pi', ...(req.body?.config || req.body || {}) });
+  }));
+
+  app.get('/api/config/providers', handle(async (_req, res) => {
+    json(res, 200, await host.getProviders());
+  }));
+
+  app.get('/api/provider', handle(async (_req, res) => {
+    const { providers } = await host.getProviders();
+    json(res, 200, providers);
+  }));
+
+  app.get('/api/project', handle(async (req, res) => {
+    const directory = resolveDirectory(req);
+    json(res, 200, [{
+      id: directory,
+      worktree: directory,
+      sandboxes: [],
+      time: { created: Date.now(), updated: Date.now() },
+    }]);
+  }));
+
+  app.get('/api/project/current', handle(async (req, res) => {
+    const directory = resolveDirectory(req);
+    json(res, 200, {
+      id: directory,
+      worktree: directory,
+      sandboxes: [],
+      time: { created: Date.now(), updated: Date.now() },
+    });
+  }));
+
+  app.get('/api/command', handle(async (_req, res) => {
+    json(res, 200, []);
+  }));
+
+  app.get('/api/agent', handle(async (_req, res) => {
+    json(res, 200, [{
+      name: 'pi',
+      mode: 'primary',
+      native: true,
+      hidden: false,
+      description: 'Pi coding agent',
+    }]);
+  }));
+
+  app.get('/api/mcp', handle(async (_req, res) => {
+    json(res, 200, {});
+  }));
+
+  app.get('/api/lsp', handle(async (_req, res) => {
+    json(res, 200, []);
+  }));
+
+  app.get('/api/vcs', handle(async (_req, res) => {
+    json(res, 200, {});
+  }));
+
+  app.get('/api/question', handle(async (_req, res) => {
+    json(res, 200, []);
+  }));
+
+  app.post('/api/question/:requestID/reply', parseJson, handle(async (_req, res) => {
+    json(res, 200, true);
+  }));
+
+  app.post('/api/question/:requestID/reject', parseJson, handle(async (_req, res) => {
+    json(res, 200, true);
+  }));
+
+  app.get('/api/permission', handle(async (_req, res) => {
+    json(res, 200, []);
+  }));
+
+  app.post('/api/permission/:requestID/reply', parseJson, handle(async (_req, res) => {
+    json(res, 200, true);
+  }));
+
+  app.get('/api/tool', handle(async (_req, res) => {
+    json(res, 200, ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls']);
+  }));
+
+  app.get('/api/session/status', handle(async (req, res) => {
+    json(res, 200, host.getStatus(requestDirectory(req) || undefined));
+  }));
+
+  app.get('/api/session', handle(async (req, res) => {
+    const directory = requestDirectory(req);
+    const records = host.listSessions(directory || undefined);
+    json(res, 200, records.map((record) => record.info));
+  }));
+
+  app.get('/api/experimental/session', handle(async (req, res) => {
+    const directory = requestDirectory(req);
+    const records = host.listSessions(directory || undefined);
+    json(res, 200, records.map((record) => record.info));
+  }));
+
+  app.post('/api/session', parseJson, handle(async (req, res) => {
+    const record = await host.createSession({
+      directory: resolveDirectory(req),
+      title: req.body?.title,
+      parentID: req.body?.parentID,
+      metadata: req.body?.metadata,
+    });
+    json(res, 200, record.info);
+  }));
+
+  app.get('/api/session/:sessionID', handle(async (req, res) => {
+    json(res, 200, host.getSession(req.params.sessionID).info);
+  }));
+
+  app.delete('/api/session/:sessionID', parseJson, handle(async (req, res) => {
+    json(res, 200, host.deleteSession(req.params.sessionID));
+  }));
+
+  app.patch('/api/session/:sessionID', parseJson, handle(async (req, res) => {
+    const record = host.updateSession(req.params.sessionID, req.body || {});
+    json(res, 200, record.info);
+  }));
+
+  app.get('/api/session/:sessionID/message', handle(async (req, res) => {
+    json(res, 200, host.getMessages(req.params.sessionID));
+  }));
+
+  app.get('/api/session/:sessionID/todo', handle(async (_req, res) => {
+    json(res, 200, []);
+  }));
+
+  app.post('/api/session/:sessionID/prompt_async', parseJson, handle(async (req, res) => {
+    const result = await host.promptAsync(req.params.sessionID, req.body || {});
+    json(res, 200, result);
+  }));
+
+  app.post('/api/session/:sessionID/prompt', parseJson, handle(async (req, res) => {
+    const result = await host.promptAsync(req.params.sessionID, req.body || {});
+    json(res, 200, result);
+  }));
+
+  app.post('/api/session/:sessionID/abort', parseJson, handle(async (req, res) => {
+    json(res, 200, await host.abort(req.params.sessionID));
+  }));
+
+  app.post('/api/session/:sessionID/command', parseJson, handle(async (req, res) => {
+    const command = typeof req.body?.command === 'string' ? req.body.command : '';
+    const args = typeof req.body?.arguments === 'string' ? req.body.arguments : '';
+    const text = [command, args].filter(Boolean).join(' ').trim();
+    const result = await host.promptAsync(req.params.sessionID, {
+      ...req.body,
+      parts: text ? [{ type: 'text', text: `/${text}` }] : req.body?.parts,
+    });
+    json(res, 200, result);
+  }));
+
+  app.post('/api/session/:sessionID/revert', parseJson, handle(async (_req, res) => {
+    json(res, 200, unsupported('session.revert'));
+  }));
+
+  app.post('/api/session/:sessionID/unrevert', parseJson, handle(async (_req, res) => {
+    json(res, 200, unsupported('session.unrevert'));
+  }));
+
+  app.post('/api/session/:sessionID/fork', parseJson, handle(async (req, res) => {
+    const source = host.getSession(req.params.sessionID);
+    const record = await host.createSession({
+      directory: source.directory,
+      title: source.info.title,
+      parentID: source.id,
+    });
+    json(res, 200, record.info);
+  }));
+
+  app.post('/api/session/:sessionID/share', parseJson, handle(async (_req, res) => {
+    json(res, 200, unsupported('session.share'));
+  }));
+
+  app.post('/api/session/:sessionID/summarize', parseJson, handle(async (_req, res) => {
+    json(res, 200, true);
+  }));
+
+  app.post('/api/session/:sessionID/shell', parseJson, handle(async (_req, res) => {
+    json(res, 200, unsupported('session.shell'));
+  }));
+
+  if (bus) {
+    app.get('/api/global/event', (req, res) => {
+      bus.attachSse(req, res);
+    });
+    app.get('/api/event', (req, res) => {
+      bus.attachSse(req, res);
+    });
+  }
+};

--- a/packages/web/server/lib/pi/opencode-facade.test.js
+++ b/packages/web/server/lib/pi/opencode-facade.test.js
@@ -1,0 +1,132 @@
+import express from 'express';
+import { createServer } from 'node:http';
+import { describe, expect, it } from 'vitest';
+
+import { createPiKernel } from './index.js';
+import { registerPiFacade } from './opencode-facade.js';
+
+const listen = (app) => new Promise((resolve) => {
+  const server = createServer(app);
+  server.listen(0, '127.0.0.1', () => {
+    const { port } = server.address();
+    resolve({
+      server,
+      url: `http://127.0.0.1:${port}`,
+      close: () => new Promise((done) => server.close(done)),
+    });
+  });
+});
+
+const startFacade = async () => {
+  const kernel = createPiKernel({
+    mock: true,
+    defaultDirectory: '/tmp/project',
+  });
+  const app = express();
+  app.use(express.json());
+  registerPiFacade(app, { host: kernel.host, bus: kernel.bus, defaultDirectory: '/tmp/project' });
+  const http = await listen(app);
+  return { kernel, ...http };
+};
+
+describe('OpenCode facade HTTP/SSE', () => {
+  it('bootstraps path/providers/session and streams a mock prompt', async () => {
+    const { url, close, kernel } = await startFacade();
+    try {
+      const pathRes = await fetch(`${url}/api/path`);
+      const pathBody = await pathRes.json();
+      expect(pathRes.status).toBe(200);
+      expect(pathBody.directory).toBe('/tmp/project');
+      expect(pathBody.config).toContain('.pi/agent');
+
+      const providers = await (await fetch(`${url}/api/config/providers`)).json();
+      expect(providers.providers[0].id).toBe('pi-mock');
+
+      expect(await (await fetch(`${url}/api/mcp`)).json()).toEqual({});
+      expect(await (await fetch(`${url}/api/lsp`)).json()).toEqual([]);
+      expect(await (await fetch(`${url}/api/permission`)).json()).toEqual([]);
+      expect(await (await fetch(`${url}/api/question`)).json()).toEqual([]);
+      expect(await (await fetch(`${url}/api/command`)).json()).toEqual([]);
+
+      const created = await (await fetch(`${url}/api/session`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title: 'Facade session' }),
+      })).json();
+      expect(created.id).toMatch(/^ses_/);
+      expect(created.title).toBe('Facade session');
+
+      const listed = await (await fetch(`${url}/api/session`)).json();
+      expect(listed).toHaveLength(1);
+
+      const sseChunks = [];
+      const sseAbort = new AbortController();
+      const ssePromise = (async () => {
+        const response = await fetch(`${url}/api/global/event`, { signal: sseAbort.signal });
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          sseChunks.push(decoder.decode(value));
+          if (sseChunks.join('').includes('session.idle')) break;
+        }
+      })();
+
+      const prompt = await fetch(`${url}/api/session/${created.id}/prompt_async`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          messageID: 'msg_user_1',
+          parts: [{ type: 'text', text: 'hello facade' }],
+        }),
+      });
+      expect(prompt.status).toBe(200);
+
+      await Promise.race([
+        ssePromise,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('SSE timeout')), 2000)),
+      ]);
+      sseAbort.abort();
+
+      const stream = sseChunks.join('');
+      expect(stream).toContain('message.part.delta');
+      expect(stream).toContain('"field":"text"');
+      expect(stream).toContain('session.idle');
+
+      const messages = await (await fetch(`${url}/api/session/${created.id}/message`)).json();
+      expect(messages[0].info.role).toBe('user');
+      expect(messages.some((entry) => entry.info.role === 'assistant')).toBe(true);
+
+      const status = await (await fetch(`${url}/api/session/status`)).json();
+      expect(status).toEqual({});
+    } finally {
+      kernel.dispose();
+      await close();
+    }
+  });
+
+  it('aborts a streaming mock session', async () => {
+    const { url, close, kernel } = await startFacade();
+    try {
+      const created = await (await fetch(`${url}/api/session`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title: 'Abort me' }),
+      })).json();
+
+      const prompt = fetch(`${url}/api/session/${created.id}/prompt_async`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ parts: [{ type: 'text', text: 'long' }] }),
+      });
+      const aborted = await fetch(`${url}/api/session/${created.id}/abort`, { method: 'POST' });
+      expect(aborted.status).toBe(200);
+      expect(await aborted.json()).toBe(true);
+      await prompt;
+    } finally {
+      kernel.dispose();
+      await close();
+    }
+  });
+});

--- a/packages/web/server/lib/pi/pi-host.js
+++ b/packages/web/server/lib/pi/pi-host.js
@@ -1,0 +1,591 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { createMessageId, createPartId, createSessionId } from './ids.js';
+import { createEventTranslator, extractPromptImages, extractPromptText } from './event-translator.js';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const createInMemoryPiSession = ({
+  sessionId = createSessionId(),
+  chunks = ['Hello from ', 'the Pi mock kernel.'],
+  chunkDelayMs = 5,
+} = {}) => {
+  const listeners = new Set();
+  let streaming = false;
+  let aborted = false;
+  const messages = [];
+
+  const emit = (event) => {
+    for (const listener of Array.from(listeners)) {
+      try {
+        listener(event);
+      } catch {
+      }
+    }
+  };
+
+  const runPrompt = async (text) => {
+    streaming = true;
+    aborted = false;
+    messages.push({ role: 'user', content: text, timestamp: Date.now() });
+    emit({ type: 'agent_start' });
+    emit({ type: 'message_start', message: { role: 'assistant', content: [] } });
+    emit({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_start', contentIndex: 0 },
+    });
+
+    let assembled = '';
+    for (const chunk of chunks) {
+      if (aborted) break;
+      assembled += chunk;
+      emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: chunk },
+      });
+      if (chunkDelayMs > 0) {
+        await sleep(chunkDelayMs);
+      }
+    }
+
+    if (!aborted) {
+      emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_end', contentIndex: 0, content: assembled },
+      });
+      emit({
+        type: 'message_end',
+        message: { role: 'assistant', content: [{ type: 'text', text: assembled }] },
+      });
+      messages.push({ role: 'assistant', content: assembled, timestamp: Date.now() });
+    }
+
+    emit({ type: 'agent_end', messages: [], willRetry: false });
+    emit({ type: 'agent_settled' });
+    streaming = false;
+  };
+
+  return {
+    sessionId,
+    get isStreaming() {
+      return streaming;
+    },
+    get messages() {
+      return messages;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    async prompt(text) {
+      if (streaming) {
+        throw new Error('Already streaming; use steer or followUp');
+      }
+      await runPrompt(text);
+    },
+    async steer(text) {
+      if (!streaming) {
+        await runPrompt(text);
+        return;
+      }
+      emit({ type: 'queue_update', steering: [text], followUp: [] });
+    },
+    async followUp(text) {
+      if (!streaming) {
+        await runPrompt(text);
+        return;
+      }
+      emit({ type: 'queue_update', steering: [], followUp: [text] });
+    },
+    async abort() {
+      aborted = true;
+      streaming = false;
+      emit({ type: 'agent_settled' });
+    },
+    dispose() {
+      listeners.clear();
+      streaming = false;
+    },
+  };
+};
+
+const defaultHome = () => os.homedir();
+
+const createSessionInfo = ({
+  id,
+  directory,
+  title,
+  parentID,
+  metadata,
+  projectID,
+}) => {
+  const created = Date.now();
+  return {
+    id,
+    projectID: projectID || directory || 'pi',
+    directory,
+    parentID,
+    title: title || 'New session',
+    version: 'pi',
+    time: { created, updated: created },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    ...(metadata ? { metadata } : {}),
+  };
+};
+
+const applyEventToStore = (store, ocEvent) => {
+  const type = ocEvent?.type;
+  const props = ocEvent?.properties || {};
+  if (type === 'message.updated' && props.info) {
+    const existing = store.messages.find((entry) => entry.info.id === props.info.id);
+    if (existing) {
+      existing.info = { ...existing.info, ...props.info };
+    } else {
+      store.messages.push({ info: props.info, parts: [] });
+    }
+  }
+  if (type === 'message.part.updated' && props.part) {
+    const messageID = props.part.messageID;
+    let entry = store.messages.find((item) => item.info.id === messageID);
+    if (!entry) {
+      entry = {
+        info: {
+          id: messageID,
+          sessionID: props.part.sessionID,
+          role: 'assistant',
+          time: { created: Date.now() },
+        },
+        parts: [],
+      };
+      store.messages.push(entry);
+    }
+    const index = entry.parts.findIndex((part) => part.id === props.part.id);
+    if (index >= 0) {
+      entry.parts[index] = props.part;
+    } else {
+      entry.parts.push(props.part);
+    }
+  }
+  if (type === 'message.part.delta') {
+    const entry = store.messages.find((item) => item.info.id === props.messageID);
+    if (!entry) return;
+    const part = entry.parts.find((item) => item.id === props.partID);
+    if (!part) return;
+    const field = props.field || 'text';
+    part[field] = `${part[field] || ''}${props.delta || ''}`;
+  }
+  if (type === 'session.status' && props.status) {
+    store.status = props.status;
+  }
+  if (type === 'session.idle') {
+    store.status = { type: 'idle' };
+  }
+};
+
+export const mapPiModelsToProviders = (models) => {
+  const byProvider = new Map();
+  for (const model of models || []) {
+    const providerID = model.provider || 'pi';
+    if (!byProvider.has(providerID)) {
+      byProvider.set(providerID, {
+        id: providerID,
+        name: providerID,
+        source: 'pi',
+        env: [],
+        models: {},
+      });
+    }
+    const provider = byProvider.get(providerID);
+    provider.models[model.id] = {
+      id: model.id,
+      name: model.name || model.id,
+      reasoning: Boolean(model.reasoning),
+      contextWindow: model.contextWindow,
+      maxTokens: model.maxTokens,
+      cost: model.cost,
+    };
+  }
+  return Array.from(byProvider.values());
+};
+
+const loadPiSdk = async () => import('@earendil-works/pi-coding-agent');
+
+export const createPiHost = ({
+  createSession,
+  createModelRuntime,
+  createDirectoryRuntime,
+  defaultDirectory = process.cwd(),
+  home = defaultHome(),
+  onEvent,
+  mock = false,
+} = {}) => {
+  const sessions = new Map();
+  const directoryRuntimes = new Map();
+  let modelRuntime = null;
+  let modelRuntimeError = null;
+  let readyPromise = null;
+
+  const emit = (directory, ocEvent) => {
+    if (typeof onEvent === 'function') {
+      onEvent(directory, ocEvent);
+    }
+  };
+
+  const resolveCreateSession = async () => {
+    if (typeof createSession === 'function') return createSession;
+    if (mock) {
+      return async () => createInMemoryPiSession();
+    }
+    try {
+      const pi = await loadPiSdk();
+      return async ({ cwd, modelRuntime: runtime, model }) => {
+        const { session } = await pi.createAgentSession({
+          cwd,
+          modelRuntime: runtime,
+          ...(model ? { model } : {}),
+          sessionManager: pi.SessionManager.inMemory(cwd),
+        });
+        return session;
+      };
+    } catch (error) {
+      console.warn('[pi-host] @earendil-works/pi-coding-agent unavailable, using in-memory mock session:', error?.message || error);
+      return async () => createInMemoryPiSession();
+    }
+  };
+
+  const ensureModelRuntime = async () => {
+    if (modelRuntime || mock) return modelRuntime;
+    if (modelRuntimeError) throw modelRuntimeError;
+    try {
+      if (typeof createModelRuntime === 'function') {
+        modelRuntime = await createModelRuntime();
+      } else {
+        const pi = await loadPiSdk();
+        modelRuntime = await pi.ModelRuntime.create({ allowModelNetwork: false });
+      }
+    } catch (error) {
+      modelRuntimeError = error;
+      throw error;
+    }
+    return modelRuntime;
+  };
+
+  const ensureDirectoryRuntime = async (directory) => {
+    if (directoryRuntimes.has(directory)) return directoryRuntimes.get(directory);
+    if (typeof createDirectoryRuntime !== 'function' && mock) {
+      const placeholder = { session: null, directory };
+      directoryRuntimes.set(directory, placeholder);
+      return placeholder;
+    }
+    try {
+      if (typeof createDirectoryRuntime === 'function') {
+        const runtime = await createDirectoryRuntime({ cwd: directory, modelRuntime });
+        directoryRuntimes.set(directory, runtime);
+        return runtime;
+      }
+      const pi = await loadPiSdk();
+      if (typeof pi.createAgentSessionRuntime !== 'function') {
+        const placeholder = { session: null, directory };
+        directoryRuntimes.set(directory, placeholder);
+        return placeholder;
+      }
+      const factory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+        const services = await pi.createAgentSessionServices({ cwd });
+        return {
+          ...(await pi.createAgentSessionFromServices({
+            services,
+            sessionManager,
+            sessionStartEvent,
+          })),
+          services,
+          diagnostics: services.diagnostics,
+        };
+      };
+      const runtime = await pi.createAgentSessionRuntime(factory, {
+        cwd: directory,
+        agentDir: typeof pi.getAgentDir === 'function' ? pi.getAgentDir() : undefined,
+        sessionManager: pi.SessionManager.inMemory(directory),
+      });
+      directoryRuntimes.set(directory, runtime);
+      return runtime;
+    } catch (error) {
+      console.warn(`[pi-host] directory runtime unavailable for ${directory}:`, error?.message || error);
+      const placeholder = { session: null, directory, error };
+      directoryRuntimes.set(directory, placeholder);
+      return placeholder;
+    }
+  };
+
+  const ready = () => {
+    if (!readyPromise) {
+      readyPromise = (async () => {
+        if (!mock) {
+          try {
+            await ensureModelRuntime();
+          } catch (error) {
+            console.warn('[pi-host] ModelRuntime unavailable:', error?.message || error);
+          }
+        }
+        await ensureDirectoryRuntime(defaultDirectory);
+        return true;
+      })();
+    }
+    return readyPromise;
+  };
+
+  const attachSession = (record) => {
+    const unsubscribe = record.piSession.subscribe((piEvent) => {
+      const ocEvents = record.translator.translate(piEvent);
+      for (const ocEvent of ocEvents) {
+        applyEventToStore(record, ocEvent);
+        record.info.time.updated = Date.now();
+        emit(record.directory, ocEvent);
+      }
+    });
+    record.unsubscribe = unsubscribe;
+  };
+
+  const createFacadeSession = async ({ directory, title, parentID, metadata, id } = {}) => {
+    const cwd = directory || defaultDirectory;
+    await ensureDirectoryRuntime(cwd);
+    const factory = await resolveCreateSession();
+    let model;
+    try {
+      const runtime = await ensureModelRuntime();
+      if (runtime && typeof runtime.getAvailable === 'function') {
+        const available = await runtime.getAvailable();
+        model = Array.isArray(available) && available.length > 0 ? available[0] : undefined;
+      }
+    } catch {
+    }
+
+    const piSession = await factory({
+      cwd,
+      modelRuntime,
+      model,
+    });
+    const sessionID = id || createSessionId();
+    const record = {
+      id: sessionID,
+      directory: cwd,
+      info: createSessionInfo({
+        id: sessionID,
+        directory: cwd,
+        title,
+        parentID,
+        metadata,
+        projectID: cwd,
+      }),
+      messages: [],
+      status: { type: 'idle' },
+      piSession,
+      translator: createEventTranslator({ sessionID, directory: cwd }),
+      unsubscribe: null,
+    };
+    attachSession(record);
+    sessions.set(sessionID, record);
+    emit(cwd, {
+      id: createSessionId().replace('ses_', 'evt_'),
+      type: 'session.created',
+      properties: { info: record.info },
+    });
+    return record;
+  };
+
+  const getRecord = (sessionID) => {
+    const record = sessions.get(sessionID);
+    if (!record) {
+      const error = new Error(`Session not found: ${sessionID}`);
+      error.status = 404;
+      throw error;
+    }
+    return record;
+  };
+
+  return {
+    ready,
+    isMock() {
+      return mock;
+    },
+    async createSession(input) {
+      await ready();
+      return createFacadeSession(input);
+    },
+    getSession(sessionID) {
+      return getRecord(sessionID);
+    },
+    listSessions(directory) {
+      const items = Array.from(sessions.values());
+      if (!directory) return items;
+      return items.filter((record) => record.directory === directory);
+    },
+    deleteSession(sessionID) {
+      const record = getRecord(sessionID);
+      try {
+        record.unsubscribe?.();
+        record.piSession?.dispose?.();
+      } catch {
+      }
+      sessions.delete(sessionID);
+      emit(record.directory, {
+        type: 'session.deleted',
+        properties: { info: record.info, sessionID },
+      });
+      return true;
+    },
+    updateSession(sessionID, patch = {}) {
+      const record = getRecord(sessionID);
+      if (typeof patch.title === 'string') {
+        record.info.title = patch.title;
+      }
+      if (patch.metadata && typeof patch.metadata === 'object') {
+        record.info.metadata = { ...(record.info.metadata || {}), ...patch.metadata };
+      }
+      if (patch.time?.archived) {
+        record.info.time = { ...record.info.time, archived: patch.time.archived };
+      }
+      record.info.time.updated = Date.now();
+      emit(record.directory, {
+        type: 'session.updated',
+        properties: { info: record.info },
+      });
+      return record;
+    },
+    getMessages(sessionID) {
+      return getRecord(sessionID).messages;
+    },
+    getStatus(directory) {
+      const map = {};
+      for (const record of sessions.values()) {
+        if (directory && record.directory !== directory) continue;
+        if (record.status?.type && record.status.type !== 'idle') {
+          map[record.id] = record.status;
+        }
+      }
+      return map;
+    },
+    getPath(directory) {
+      const cwd = directory || defaultDirectory;
+      return {
+        home,
+        directory: cwd,
+        worktree: cwd,
+        state: path.join(home, '.pi', 'agent'),
+        config: path.join(home, '.pi', 'agent'),
+      };
+    },
+    async getProviders() {
+      if (mock) {
+        return {
+          providers: [{
+            id: 'pi-mock',
+            name: 'Pi Mock',
+            source: 'pi',
+            env: [],
+            models: {
+              mock: { id: 'mock', name: 'Mock model' },
+            },
+          }],
+          default: { 'pi-mock': 'mock' },
+        };
+      }
+      try {
+        const runtime = await ensureModelRuntime();
+        const available = runtime && typeof runtime.getAvailable === 'function'
+          ? await runtime.getAvailable()
+          : [];
+        const providers = mapPiModelsToProviders(available);
+        const first = providers[0];
+        const firstModel = first ? Object.keys(first.models)[0] : undefined;
+        return {
+          providers,
+          default: first && firstModel ? { [first.id]: firstModel } : {},
+        };
+      } catch {
+        return { providers: [], default: {} };
+      }
+    },
+    async promptAsync(sessionID, body = {}) {
+      const record = getRecord(sessionID);
+      const text = extractPromptText(body.parts) || (typeof body.text === 'string' ? body.text : '');
+      if (!text) {
+        const error = new Error('Message must have at least one text part');
+        error.status = 400;
+        throw error;
+      }
+
+      const userMessageID = body.messageID || createMessageId();
+      record.translator.setUserMessage(userMessageID);
+      const userPart = {
+        id: createPartId(),
+        sessionID,
+        messageID: userMessageID,
+        type: 'text',
+        text,
+      };
+      const userInfo = {
+        id: userMessageID,
+        sessionID,
+        role: 'user',
+        time: { created: Date.now() },
+        ...(body.agent ? { agent: body.agent } : {}),
+        ...(body.model ? { model: body.model } : {}),
+      };
+      record.messages.push({ info: userInfo, parts: [userPart] });
+      emit(record.directory, { type: 'message.updated', properties: { info: userInfo } });
+      emit(record.directory, { type: 'message.part.updated', properties: { sessionID, part: userPart } });
+
+      const images = extractPromptImages(body.parts);
+      const promptOptions = {
+        ...(images.length > 0 ? { images } : {}),
+      };
+
+      const isStreaming = Boolean(record.piSession.isStreaming);
+      const delivery = body.delivery;
+      const run = async () => {
+        try {
+          if (isStreaming && delivery === 'steer' && typeof record.piSession.steer === 'function') {
+            await record.piSession.steer(text);
+            return;
+          }
+          if (isStreaming && (delivery === 'followUp' || delivery === 'follow_up') && typeof record.piSession.followUp === 'function') {
+            await record.piSession.followUp(text);
+            return;
+          }
+          if (isStreaming && typeof record.piSession.steer === 'function') {
+            await record.piSession.steer(text);
+            return;
+          }
+          await record.piSession.prompt(text, promptOptions);
+        } catch (error) {
+          record.status = { type: 'idle' };
+          emit(record.directory, {
+            type: 'session.error',
+            properties: { sessionID, error: { message: error?.message || String(error) } },
+          });
+          emit(record.directory, { type: 'session.idle', properties: { sessionID } });
+        }
+      };
+
+      void run();
+      return { info: userInfo, parts: [userPart] };
+    },
+    async abort(sessionID) {
+      const record = getRecord(sessionID);
+      await record.piSession.abort();
+      return true;
+    },
+    dispose() {
+      for (const record of sessions.values()) {
+        try {
+          record.unsubscribe?.();
+          record.piSession?.dispose?.();
+        } catch {
+        }
+      }
+      sessions.clear();
+    },
+  };
+};

--- a/packages/web/server/lib/pi/pi-host.test.js
+++ b/packages/web/server/lib/pi/pi-host.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { createInMemoryPiSession, createPiHost, mapPiModelsToProviders } from './pi-host.js';
+
+describe('mapPiModelsToProviders', () => {
+  it('groups Pi models by provider id', () => {
+    const providers = mapPiModelsToProviders([
+      { id: 'claude-sonnet-4-5', name: 'Sonnet', provider: 'anthropic', reasoning: true },
+      { id: 'gpt-5', name: 'GPT-5', provider: 'openai' },
+    ]);
+    expect(providers.map((provider) => provider.id)).toEqual(['anthropic', 'openai']);
+    expect(providers[0].models['claude-sonnet-4-5'].name).toBe('Sonnet');
+  });
+});
+
+describe('createPiHost', () => {
+  it('creates sessions, lists them, and returns OpenCode-shaped messages after a mock prompt', async () => {
+    const events = [];
+    const host = createPiHost({
+      mock: true,
+      defaultDirectory: '/tmp/project',
+      onEvent: (directory, event) => events.push({ directory, event }),
+    });
+
+    const record = await host.createSession({ directory: '/tmp/project', title: 'Demo' });
+    expect(record.info.id).toMatch(/^ses_/);
+    expect(record.info.title).toBe('Demo');
+    expect(host.listSessions('/tmp/project')).toHaveLength(1);
+
+    await host.promptAsync(record.id, {
+      messageID: 'msg_user',
+      parts: [{ type: 'text', text: 'hi' }],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    const messages = host.getMessages(record.id);
+    expect(messages[0].info.role).toBe('user');
+    expect(messages[0].parts[0].text).toBe('hi');
+    const assistant = messages.find((entry) => entry.info.role === 'assistant');
+    expect(assistant).toBeTruthy();
+    const text = assistant.parts.filter((part) => part.type === 'text').map((part) => part.text).join('');
+    expect(text).toContain('Pi mock kernel');
+
+    expect(events.some((item) => item.event.type === 'session.status' && item.event.properties.status.type === 'busy')).toBe(true);
+    expect(events.some((item) => item.event.type === 'session.idle')).toBe(true);
+    expect(events.some((item) => item.event.type === 'message.part.delta' && item.event.properties.field === 'text')).toBe(true);
+
+    expect(host.getPath('/tmp/project').config).toContain('.pi/agent');
+    host.dispose();
+  });
+
+  it('aborts an in-flight mock prompt', async () => {
+    const host = createPiHost({
+      mock: true,
+      createSession: async () => createInMemoryPiSession({
+        chunks: ['one ', 'two ', 'three'],
+        chunkDelayMs: 30,
+      }),
+    });
+    const record = await host.createSession({ directory: '/tmp/project' });
+    const prompt = host.promptAsync(record.id, { parts: [{ type: 'text', text: 'go' }] });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await host.abort(record.id);
+    await prompt;
+    expect(host.getStatus()[record.id]).toBeUndefined();
+    host.dispose();
+  });
+});

--- a/packages/web/server/lib/pi/sse-bus.js
+++ b/packages/web/server/lib/pi/sse-bus.js
@@ -1,0 +1,168 @@
+import { createEventId } from './ids.js';
+
+const DEFAULT_REPLAY_LIMIT = 2048;
+const DEFAULT_HEARTBEAT_MS = 20_000;
+
+const writeSse = (res, eventId, payload) => {
+  if (!res || res.writableEnded || res.destroyed) return false;
+  const lines = [];
+  if (eventId) lines.push(`id: ${eventId}`);
+  lines.push(`data: ${JSON.stringify(payload)}`);
+  lines.push('', '');
+  return res.write(lines.join('\n'));
+};
+
+export const createSseBus = ({
+  replayLimit = DEFAULT_REPLAY_LIMIT,
+  heartbeatMs = DEFAULT_HEARTBEAT_MS,
+} = {}) => {
+  const eventSubscribers = new Set();
+  const statusSubscribers = new Set();
+  const sseClients = new Set();
+  const replay = [];
+  let connected = false;
+  let everConnected = false;
+  let heartbeatTimer = null;
+
+  const notify = (subscribers, payload) => {
+    for (const subscriber of Array.from(subscribers)) {
+      try {
+        const result = subscriber(payload);
+        if (result && typeof result.catch === 'function') {
+          result.catch(() => {});
+        }
+      } catch {
+      }
+    }
+  };
+
+  const normalize = ({ directory, payload, eventId }) => {
+    const resolvedDirectory = typeof directory === 'string' && directory.length > 0 ? directory : 'global';
+    const resolvedEventId = typeof eventId === 'string' && eventId.length > 0 ? eventId : createEventId();
+    return {
+      envelope: { directory: resolvedDirectory, eventId: resolvedEventId },
+      payload,
+      directory: resolvedDirectory,
+      eventId: resolvedEventId,
+    };
+  };
+
+  const publish = (directory, payload, options = {}) => {
+    const eventId = options.eventId || payload?.id || createEventId();
+    const normalized = normalize({ directory, payload, eventId });
+    replay.push(normalized);
+    if (replay.length > replayLimit) {
+      replay.splice(0, replay.length - replayLimit);
+    }
+
+    notify(eventSubscribers, normalized);
+
+    const ssePayload = {
+      directory: normalized.directory,
+      payload: normalized.payload,
+    };
+    for (const res of Array.from(sseClients)) {
+      const ok = writeSse(res, normalized.eventId, ssePayload);
+      if (!ok) {
+        sseClients.delete(res);
+      }
+    }
+
+    return normalized;
+  };
+
+  const attachSse = (req, res) => {
+    res.status(200);
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    if (typeof res.flushHeaders === 'function') {
+      res.flushHeaders();
+    }
+    if (res.socket && typeof res.socket.setNoDelay === 'function') {
+      res.socket.setNoDelay(true);
+    }
+
+    sseClients.add(res);
+    start();
+
+    const lastEventId = req.headers?.['last-event-id'] || req.query?.lastEventId;
+    if (lastEventId) {
+      for (const entry of replayAfter(lastEventId)) {
+        writeSse(res, entry.eventId, { directory: entry.directory, payload: entry.payload });
+      }
+    }
+
+    const heartbeat = setInterval(() => {
+      if (res.writableEnded || res.destroyed) {
+        clearInterval(heartbeat);
+        return;
+      }
+      res.write(':heartbeat\n\n');
+    }, heartbeatMs);
+    heartbeat.unref?.();
+
+    const cleanup = () => {
+      clearInterval(heartbeat);
+      sseClients.delete(res);
+    };
+    req.on('close', cleanup);
+    res.on('close', cleanup);
+  };
+
+  const start = () => {
+    if (connected) return;
+    connected = true;
+    const wasReady = everConnected;
+    everConnected = true;
+    notify(statusSubscribers, { type: 'connect', wasReady });
+  };
+
+  const stop = () => {
+    connected = false;
+    everConnected = false;
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    for (const res of Array.from(sseClients)) {
+      try {
+        res.end();
+      } catch {
+      }
+    }
+    sseClients.clear();
+  };
+
+  const replayAfter = (eventId) => {
+    if (!eventId) return [];
+    const index = replay.findIndex((entry) => entry.eventId === eventId);
+    return index === -1 ? [] : replay.slice(index + 1);
+  };
+
+  return {
+    start,
+    stop,
+    publish,
+    attachSse,
+    isConnected() {
+      return connected;
+    },
+    hasConnected() {
+      return everConnected;
+    },
+    subscribeEvent(subscriber) {
+      eventSubscribers.add(subscriber);
+      return () => eventSubscribers.delete(subscriber);
+    },
+    subscribeStatus(subscriber) {
+      statusSubscribers.add(subscriber);
+      return () => statusSubscribers.delete(subscriber);
+    },
+    replayAfter,
+    getSseClientCount() {
+      return sseClients.size;
+    },
+  };
+};

--- a/packages/web/server/lib/pi/sse-bus.test.js
+++ b/packages/web/server/lib/pi/sse-bus.test.js
@@ -1,0 +1,58 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it } from 'vitest';
+
+import { createSseBus } from './sse-bus.js';
+
+const createFakeSseResponse = () => {
+  const req = new EventEmitter();
+  const chunks = [];
+  const res = new EventEmitter();
+  res.statusCode = 0;
+  res.headers = {};
+  res.writableEnded = false;
+  res.destroyed = false;
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.setHeader = (key, value) => {
+    res.headers[key] = value;
+  };
+  res.flushHeaders = () => {};
+  res.write = (value) => {
+    chunks.push(String(value));
+    return true;
+  };
+  res.end = () => {
+    res.writableEnded = true;
+  };
+  return { req, res, chunks };
+};
+
+describe('createSseBus', () => {
+  it('publishes to subscribers and SSE clients', () => {
+    const bus = createSseBus({ heartbeatMs: 60_000 });
+    const seen = [];
+    bus.subscribeEvent((event) => seen.push(event));
+    const { req, res, chunks } = createFakeSseResponse();
+    bus.attachSse(req, res);
+
+    bus.publish('/tmp/project', { id: 'evt_1', type: 'session.idle', properties: { sessionID: 'ses_1' } }, { eventId: 'evt_1' });
+
+    expect(seen[0].directory).toBe('/tmp/project');
+    expect(seen[0].payload.type).toBe('session.idle');
+    expect(chunks.join('')).toContain('id: evt_1');
+    expect(chunks.join('')).toContain('"type":"session.idle"');
+    bus.stop();
+  });
+
+  it('replays events after lastEventId', () => {
+    const bus = createSseBus({ heartbeatMs: 60_000 });
+    bus.publish('global', { type: 'a' }, { eventId: 'evt_a' });
+    bus.publish('global', { type: 'b' }, { eventId: 'evt_b' });
+    const replayed = bus.replayAfter('evt_a');
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0].payload.type).toBe('b');
+    bus.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- Add an in-process Pi host (`@earendil-works/pi-coding-agent`) plus an OpenCode-shaped HTTP/SSE facade so the existing UI (`@opencode-ai/sdk/v2`) keeps working without rewriting 200+ SDK imports.
- Default kernel is Pi (`OPENCHAMBER_KERNEL=pi`). The happy path does **not** require OpenCode installed. Set `OPENCHAMBER_KERNEL=opencode` to restore the upstream process + proxy.
- Product target is macOS: `~/.pi/agent` auth/models, `bun run start:web` / `bun run dev`. Mock mode (`OPENCHAMBER_PI_MOCK=1`) streams a canned reply when no LLM keys are present.

## What works
- Session CRUD, `prompt_async` / `prompt`, abort, messages, status
- Event mapping: `text_delta` → `message.part.delta` field `text`; `thinking_delta` → reasoning; `tool_execution_*` → tool parts; `agent_start` → busy; `agent_settled` → idle
- Providers from `ModelRuntime.getAvailable()` (or a mock provider)
- Bootstrap stubs so the UI does not crash: MCP, LSP, permission, question, command, share, revert
- RuntimeAPIs (git/files/terminal) unchanged

## Still OpenCode-only
- Native OpenCode plugins, MCP OAuth, LSP diagnostics, permission/question dialogs, share, revert, managed OpenCode upgrade/binary resolver
- VS Code / mobile / Windows / Linux desktop packaging were not the product target

## How to try (macOS)
```bash
bun install
# real Pi (uses ~/.pi/agent or ANTHROPIC_API_KEY / OPENAI_API_KEY)
OPENCHAMBER_KERNEL=pi bun run start:web
# or mock, no keys required
OPENCHAMBER_KERNEL=pi OPENCHAMBER_PI_MOCK=1 bun run start:web
```
See `docs/PICHAMBER.md`.

## Test plan
- [x] `cd packages/web && bunx vitest run server/lib/pi` — 5 files / 17 tests passed
- [x] Standalone facade HTTP smoke: path, providers, session create, prompt_async, messages, abort
- [x] Full web server on this VM with `OPENCHAMBER_KERNEL=pi OPENCHAMBER_PI_MOCK=1`: `/health` reports `kernel: pi`, session create + prompt_async + messages (user + assistant)
- [ ] Live Pi prompt against a real model — **skipped** (no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `~/.pi/agent` on the test VM)
- [ ] macOS desktop/Electron smoke with a real `pi` install and `~/.pi/agent` credentials