### PR TITLE
fix: preserve Markdown blocks when copying messages

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -21,7 +21,7 @@ import { deriveMessageRole } from './message/messageRole';
 import { filterVisibleParts, normalizeParts } from './message/partUtils';
 import { normalizeUserDisplayParts } from './message/normalizeUserDisplayParts';
 import { isHiddenUserMessage } from './message/hiddenUserMessage';
-import { flattenAssistantTextParts } from '@/lib/messages/messageText';
+import { flattenAssistantTextParts, flattenUserTextParts } from '@/lib/messages/messageText';
 import { isLikelyProviderAuthFailure, PROVIDER_AUTH_FAILURE_MESSAGE } from '@/lib/messages/providerAuthError';
 import { getProviderModelDisplayName } from '@/lib/modelDisplay';
 import { lazyWithChunkRecovery } from '@/lib/chunkLoadRecovery';
@@ -730,40 +730,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
 
     const messageTextContent = React.useMemo(() => {
         if (isUser) {
-            const shellOutputs = displayParts
-                .filter((part): part is Part & { type: 'text'; shellAction?: { output?: unknown } } => part.type === 'text')
-                .map((part) => {
-                    const output = part.shellAction?.output;
-                    return typeof output === 'string' ? output.trim() : '';
-                })
-                .filter((output) => output.length > 0);
-
-            if (shellOutputs.length > 0) {
-                return shellOutputs.join('\n\n');
-            }
-
-            const shellCommands = displayParts
-                .filter((part): part is Part & { type: 'text'; shellAction?: { command?: unknown } } => part.type === 'text')
-                .map((part) => {
-                    const command = part.shellAction?.command;
-                    return typeof command === 'string' ? command.trim() : '';
-                })
-                .filter((command) => command.length > 0);
-
-            if (shellCommands.length > 0) {
-                return shellCommands.join('\n');
-            }
-
-            const textParts = displayParts
-                .filter((part): part is Part & { type: 'text'; text?: string; content?: string } => part.type === 'text')
-                .map((part) => {
-                    const text = part.text || part.content || '';
-                    return text.trim();
-                })
-                .filter((text) => text.length > 0);
-
-            const combined = textParts.join('\n');
-            return combined.replace(/\n\s*\n+/g, '\n');
+            return flattenUserTextParts(displayParts);
         }
 
         if (assistantErrorText && assistantErrorText.trim().length > 0) {

--- a/packages/ui/src/components/chat/markdown/decorate.ts
+++ b/packages/ui/src/components/chat/markdown/decorate.ts
@@ -151,9 +151,8 @@ const layoutCodeLines = (pre: HTMLPreElement): void => {
     row.setAttribute('data-md-code-line', '');
 
     const number = document.createElement('span');
-    number.setAttribute('data-md-code-line-number', '');
+    number.setAttribute('data-md-code-line-number', String(index + 1));
     number.setAttribute('aria-hidden', 'true');
-    number.textContent = String(index + 1);
 
     const content = document.createElement('span');
     content.setAttribute('data-md-code-line-content', '');
@@ -163,7 +162,6 @@ const layoutCodeLines = (pre: HTMLPreElement): void => {
     } else {
       content.textContent = sourceLine;
     }
-
     row.append(number, content);
     fragment.appendChild(row);
     if (index < sourceLines.length - 1 || hasTrailingNewline) {
@@ -530,6 +528,67 @@ const closeAllMenus = (container: HTMLElement): void => {
   }
 };
 
+const getContainingMarkdownCode = (node: Node): HTMLElement | null => {
+  const element = node.nodeType === 1 ? node as Element : node.parentElement;
+  return element?.closest<HTMLElement>('pre code[data-md-code-lines]') ?? null;
+};
+
+const getMarkdownCodeSelectionText = (range: Range): string | null => {
+  const code = getContainingMarkdownCode(range.startContainer);
+  if (!code || code !== getContainingMarkdownCode(range.endContainer)) return null;
+  // Line numbers are CSS-generated, so the DOM range is already the exact
+  // source selection, including boundaries between rows and empty lines.
+  return range.toString();
+};
+
+type MarkdownCopyState = {
+  registrations: number;
+  handler: (event: ClipboardEvent) => void;
+  menuHandler: (event: Event) => void;
+};
+
+const markdownCopyStates = new WeakMap<Document, MarkdownCopyState>();
+
+const registerMarkdownCodeCopy = (doc: Document): (() => void) => {
+  let state = markdownCopyStates.get(doc);
+  if (!state) {
+    const getSelectedText = (): string | null => {
+      const selection = doc.getSelection();
+      if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) return null;
+      return getMarkdownCodeSelectionText(selection.getRangeAt(0));
+    };
+    const handler = (event: ClipboardEvent) => {
+      if (!event.clipboardData) return;
+      const text = getSelectedText();
+      if (text === null) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.clipboardData.setData('text/plain', text);
+    };
+    const menuHandler = (event: Event) => {
+      const text = getSelectedText();
+      if (text === null) return;
+      event.preventDefault();
+      void copyTextToClipboard(text);
+    };
+    state = { registrations: 0, handler, menuHandler };
+    markdownCopyStates.set(doc, state);
+    doc.addEventListener('copy', handler, true);
+    doc.defaultView?.addEventListener('openchamber:copy', menuHandler);
+  }
+  state.registrations += 1;
+
+  return () => {
+    const current = markdownCopyStates.get(doc);
+    if (!current) return;
+    current.registrations -= 1;
+    if (current.registrations > 0) return;
+    doc.removeEventListener('copy', current.handler, true);
+    doc.defaultView?.removeEventListener('openchamber:copy', current.menuHandler);
+    markdownCopyStates.delete(doc);
+  };
+};
+
 /**
  * Attach a single delegated click listener for all in-markdown actions: code
  * copy, table copy/download menus, mermaid copy/download, loopback preview.
@@ -539,6 +598,7 @@ export const attachMarkdownInteractions = (
   container: HTMLElement,
   ctx: DecorateContext,
 ): (() => void) => {
+  const unregisterCodeCopy = registerMarkdownCodeCopy(container.ownerDocument);
   const handleClick = (event: MouseEvent) => {
     const target = event.target;
     if (!(target instanceof Element)) return;
@@ -640,5 +700,8 @@ export const attachMarkdownInteractions = (
   };
 
   container.addEventListener('click', handleClick);
-  return () => container.removeEventListener('click', handleClick);
+  return () => {
+    unregisterCodeCopy();
+    container.removeEventListener('click', handleClick);
+  };
 };

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1345,6 +1345,10 @@ html:not(.dark) .chat-scroll {
   white-space: nowrap;
 }
 
+.markdown-content [data-md-code-line-number]::before {
+  content: attr(data-md-code-line-number);
+}
+
 .markdown-content [data-md-code-line-content] {
   min-width: 0;
 }

--- a/packages/ui/src/lib/clipboard.test.ts
+++ b/packages/ui/src/lib/clipboard.test.ts
@@ -117,7 +117,7 @@ describe('copyMarkdownToClipboard', () => {
     const parts = [
       { id: 'p0', sessionID: 's', messageID: 'm', type: 'text', text: '第一段' },
       { id: 'p1', sessionID: 's', messageID: 'm', type: 'text', text: '第二段' },
-      { id: 'p2', sessionID: 's', messageID: 'm', type: 'text', text: '```js\nconsole.log(1)\n```' },
+      { id: 'p2', sessionID: 's', messageID: 'm', type: 'text', text: '```js\nconsole.log(1)\n\n\nconsole.log(2)\n```' },
       { id: 'p3', sessionID: 's', messageID: 'm', type: 'text', text: '第三段' },
     ];
 
@@ -126,7 +126,7 @@ describe('copyMarkdownToClipboard', () => {
     const html = marked.parse(text, { gfm: true, breaks: false }) as string;
     const result = await copyMarkdownToClipboard(text, html);
 
-    const expected = '第一段\n\n第二段\n\n```js\nconsole.log(1)\n```\n\n第三段';
+    const expected = '第一段\n\n第二段\n\n```js\nconsole.log(1)\n\n\nconsole.log(2)\n```\n\n第三段';
     expect(result).toEqual({ ok: true, method: 'clipboard' });
     expect(await writtenItem?.data['text/plain']?.text()).toBe(expected);
     expect(await writtenItem?.data['text/markdown']?.text()).toBe(expected);

--- a/packages/ui/src/lib/clipboard.test.ts
+++ b/packages/ui/src/lib/clipboard.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
+import { marked } from 'marked';
+
 import { copyMarkdownToClipboard } from './clipboard';
+import { flattenAssistantTextParts } from './messages/messageText';
 
 const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
 const originalClipboardItem = Object.getOwnPropertyDescriptor(globalThis, 'ClipboardItem');
@@ -83,5 +86,53 @@ describe('copyMarkdownToClipboard', () => {
 
     expect(result).toEqual({ ok: true, method: 'clipboard' });
     expect(fallbackText).toBe('# title');
+  });
+
+  test('assistant copy payload keeps Markdown block separation in every clipboard format', async () => {
+    let writtenItem: { data: Record<string, Blob> } | undefined;
+    class FakeClipboardItem {
+      static supports(type: string): boolean {
+        return type === 'text/markdown';
+      }
+
+      readonly data: Record<string, Blob>;
+
+      constructor(data: Record<string, Blob>) {
+        this.data = data;
+      }
+    }
+
+    Object.defineProperty(globalThis, 'ClipboardItem', { configurable: true, value: FakeClipboardItem });
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        clipboard: {
+          write: async (items: Array<{ data: Record<string, Blob> }>) => {
+            writtenItem = items[0];
+          },
+        },
+      },
+    });
+
+    const parts = [
+      { id: 'p0', sessionID: 's', messageID: 'm', type: 'text', text: '第一段' },
+      { id: 'p1', sessionID: 's', messageID: 'm', type: 'text', text: '第二段' },
+      { id: 'p2', sessionID: 's', messageID: 'm', type: 'text', text: '```js\nconsole.log(1)\n```' },
+      { id: 'p3', sessionID: 's', messageID: 'm', type: 'text', text: '第三段' },
+    ];
+
+    // Same path as ChatMessage.tsx handleCopyMessage:
+    const text = flattenAssistantTextParts(parts as Parameters<typeof flattenAssistantTextParts>[0]);
+    const html = marked.parse(text, { gfm: true, breaks: false }) as string;
+    const result = await copyMarkdownToClipboard(text, html);
+
+    const expected = '第一段\n\n第二段\n\n```js\nconsole.log(1)\n```\n\n第三段';
+    expect(result).toEqual({ ok: true, method: 'clipboard' });
+    expect(await writtenItem?.data['text/plain']?.text()).toBe(expected);
+    expect(await writtenItem?.data['text/markdown']?.text()).toBe(expected);
+    const htmlText = await writtenItem?.data['text/html']?.text();
+    expect(htmlText).toContain('<p>第一段</p>');
+    expect(htmlText).toContain('<p>第二段</p>');
+    expect(htmlText).not.toContain('<p>第一段\n第二段</p>');
   });
 });

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -57,12 +57,13 @@ describe('flattenAssistantTextParts', () => {
     expect(flattenAssistantTextParts(parts)).toContain('\n\n- item 1\n- item 2');
   });
 
-  test('runs of blank lines collapse to exactly one blank line', () => {
-    expect(flattenAssistantTextParts(makeParts(['a\n\n\n\nb', 'c\n \n \nd']))).toBe('a\n\nb\n\nc\n\nd');
+  test('internal blank-line runs are preserved', () => {
+    const text = 'a\n\n\n\nb\n \n \nd';
+    expect(flattenAssistantTextParts(makeParts([text]))).toBe(text);
   });
 
-  test('a single blank line inside a fenced code block is preserved', () => {
-    const fenced = '```js\na\n\nb\n```';
+  test('multiple blank lines inside a fenced code block are preserved', () => {
+    const fenced = '```js\na\n\n\nb\n```';
     expect(flattenAssistantTextParts(makeParts([fenced]))).toBe(fenced);
   });
 
@@ -92,8 +93,8 @@ describe('flattenAssistantTextParts', () => {
 
 describe('flattenUserTextParts', () => {
   test('plain text parts keep blank-line block separators', () => {
-    const parts = makeUserParts([{ text: '第一段\n\n第二段' }, { text: '下一段' }]);
-    expect(flattenUserTextParts(parts)).toBe('第一段\n\n第二段\n\n下一段');
+    const parts = makeUserParts([{ text: '第一段\n\n\n第二段' }, { text: '下一段' }]);
+    expect(flattenUserTextParts(parts)).toBe('第一段\n\n\n第二段\n\n下一段');
   });
 
   test('shell outputs win over other content and are joined with blank lines', () => {

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Part } from '@opencode-ai/sdk/v2';
+import { flattenAssistantTextParts, flattenUserTextParts } from './messageText';
+
+// Regression tests for https://github.com/openchamber/openchamber/issues/2867
+//
+// `flattenAssistantTextParts` used to collapse every blank line into a single
+// `\n`. Markdown block structure (paragraphs, lists, fenced code blocks)
+// requires a blank line (`\n\n`); a single `\n` is a CommonMark soft break.
+// `ChatMessage.tsx`'s `handleCopyMessage` feeds the flattened string into
+// `copyMarkdownToClipboard`, which writes it to `text/plain`, `text/markdown`
+// and its markdown-rendered HTML into `text/html`.
+
+const basePart = (overrides: Record<string, unknown>): Part =>
+  ({
+    id: 'p1',
+    sessionID: 's',
+    messageID: 'm',
+    type: 'text',
+    text: '',
+    ...overrides,
+  }) as Part;
+
+const makeParts = (texts: string[]): Part[] =>
+  texts.map((text, index) => basePart({ id: `p${index}`, text }));
+
+const makeUserParts = (
+  entries: Array<{ text?: string; shellAction?: { output?: unknown; command?: unknown } }>,
+): Part[] =>
+  entries.map((entry, index) =>
+    basePart({ id: `u${index}`, text: entry.text ?? '', shellAction: entry.shellAction }),
+  );
+
+describe('flattenAssistantTextParts', () => {
+  const parts = makeParts([
+    '第一段',
+    '第二段',
+    '```js\nconsole.log(1)\n```',
+    '第三段',
+    '- item 1\n- item 2',
+  ]);
+
+  test('blank lines between paragraphs/code blocks/lists are preserved', () => {
+    expect(flattenAssistantTextParts(parts)).toBe(
+      '第一段\n\n第二段\n\n```js\nconsole.log(1)\n```\n\n第三段\n\n- item 1\n- item 2',
+    );
+  });
+
+  test('a code fence is not glued to the following paragraph', () => {
+    const flattened = flattenAssistantTextParts(parts);
+    expect(flattened).not.toContain('```\n第三段');
+    expect(flattened).toContain('```\n\n第三段');
+  });
+
+  test('list items keep single newlines inside their part', () => {
+    expect(flattenAssistantTextParts(parts)).toContain('\n\n- item 1\n- item 2');
+  });
+
+  test('runs of blank lines collapse to exactly one blank line', () => {
+    expect(flattenAssistantTextParts(makeParts(['a\n\n\n\nb', 'c\n \n \nd']))).toBe('a\n\nb\n\nc\n\nd');
+  });
+
+  test('a single blank line inside a fenced code block is preserved', () => {
+    const fenced = '```js\na\n\nb\n```';
+    expect(flattenAssistantTextParts(makeParts([fenced]))).toBe(fenced);
+  });
+
+  test('part boundaries produce block separators', () => {
+    expect(flattenAssistantTextParts(makeParts(['first', 'second']))).toBe('first\n\nsecond');
+  });
+
+  test('empty and whitespace-only parts are dropped', () => {
+    expect(flattenAssistantTextParts([])).toBe('');
+    expect(flattenAssistantTextParts(makeParts(['', '   ', '\n']))).toBe('');
+  });
+
+  test('single part without blank lines is returned unchanged', () => {
+    const single = 'only line\nsecond line';
+    expect(flattenAssistantTextParts(makeParts([single]))).toBe(single);
+  });
+
+  test('non-text parts are ignored', () => {
+    const partsWithTool: Part[] = [
+      ...makeParts(['before']),
+      { id: 't1', sessionID: 's', messageID: 'm', type: 'tool', tool: 'bash' } as Part,
+      ...makeParts(['after']),
+    ];
+    expect(flattenAssistantTextParts(partsWithTool)).toBe('before\n\nafter');
+  });
+});
+
+describe('flattenUserTextParts', () => {
+  test('plain text parts keep blank-line block separators', () => {
+    const parts = makeUserParts([{ text: '第一段\n\n第二段' }, { text: '下一段' }]);
+    expect(flattenUserTextParts(parts)).toBe('第一段\n\n第二段\n\n下一段');
+  });
+
+  test('shell outputs win over other content and are joined with blank lines', () => {
+    const parts = makeUserParts([
+      { text: 'note', shellAction: { command: 'ls -la' } },
+      { text: '', shellAction: { output: '  file-a\nfile-b  ' } },
+      { text: '', shellAction: { output: 'done' } },
+    ]);
+    expect(flattenUserTextParts(parts)).toBe('file-a\nfile-b\n\ndone');
+  });
+
+  test('shell commands fall back to a single-newline command list', () => {
+    const parts = makeUserParts([
+      { shellAction: { command: ' bun install ' } },
+      { shellAction: { command: 'bun test' } },
+      { text: 'ignored when commands exist' },
+    ]);
+    expect(flattenUserTextParts(parts)).toBe('bun install\nbun test');
+  });
+
+  test('returns empty string for parts without text', () => {
+    expect(flattenUserTextParts([])).toBe('');
+    expect(flattenUserTextParts(makeUserParts([{ text: '  ' }]))).toBe('');
+  });
+});

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -3,15 +3,13 @@ import type { Part } from '@opencode-ai/sdk/v2';
 type TextLikePart = Part & { text?: string; content?: string };
 type UserTextPart = Part & { text?: string; content?: string; shellAction?: { output?: unknown; command?: unknown } };
 
-const collapseBlankLines = (value: string): string => value.replace(/\n\s*\n+/g, '\n\n');
-
 export const flattenAssistantTextParts = (parts: Part[]): string => {
     const textParts = parts
         .filter((part): part is TextLikePart => part?.type === 'text')
         .map((part) => (part.text || part.content || '').trim())
         .filter((text) => text.length > 0);
 
-    return collapseBlankLines(textParts.join('\n\n'));
+    return textParts.join('\n\n');
 };
 
 export const flattenUserTextParts = (parts: Part[]): string => {
@@ -40,7 +38,7 @@ export const flattenUserTextParts = (parts: Part[]): string => {
     const plainTexts = textParts
         .map((part) => (part.text || part.content || '').trim())
         .filter((text) => text.length > 0);
-    return collapseBlankLines(plainTexts.join('\n\n'));
+    return plainTexts.join('\n\n');
 };
 
 export const suggestPlanTitleFromText = (text: string): string => {

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -1,6 +1,9 @@
 import type { Part } from '@opencode-ai/sdk/v2';
 
 type TextLikePart = Part & { text?: string; content?: string };
+type UserTextPart = Part & { text?: string; content?: string; shellAction?: { output?: unknown; command?: unknown } };
+
+const collapseBlankLines = (value: string): string => value.replace(/\n\s*\n+/g, '\n\n');
 
 export const flattenAssistantTextParts = (parts: Part[]): string => {
     const textParts = parts
@@ -8,8 +11,36 @@ export const flattenAssistantTextParts = (parts: Part[]): string => {
         .map((part) => (part.text || part.content || '').trim())
         .filter((text) => text.length > 0);
 
-    const combined = textParts.join('\n');
-    return combined.replace(/\n\s*\n+/g, '\n');
+    return collapseBlankLines(textParts.join('\n\n'));
+};
+
+export const flattenUserTextParts = (parts: Part[]): string => {
+    const textParts = parts.filter((part): part is UserTextPart => part?.type === 'text');
+
+    const shellOutputs = textParts
+        .map((part) => {
+            const output = part.shellAction?.output;
+            return typeof output === 'string' ? output.trim() : '';
+        })
+        .filter((output) => output.length > 0);
+    if (shellOutputs.length > 0) {
+        return shellOutputs.join('\n\n');
+    }
+
+    const shellCommands = textParts
+        .map((part) => {
+            const command = part.shellAction?.command;
+            return typeof command === 'string' ? command.trim() : '';
+        })
+        .filter((command) => command.length > 0);
+    if (shellCommands.length > 0) {
+        return shellCommands.join('\n');
+    }
+
+    const plainTexts = textParts
+        .map((part) => (part.text || part.content || '').trim())
+        .filter((text) => text.length > 0);
+    return collapseBlankLines(plainTexts.join('\n\n'));
 };
 
 export const suggestPlanTitleFromText = (text: string): string => {


### PR DESCRIPTION
## Intent

Preserve Markdown block boundaries when users copy assistant or user messages. Assistant text parts now retain paragraph, fenced-code, and list separation in the clipboard payloads.

## Non-goals

This PR does not change selected-text Add to Chat behavior, table filtering, shell command formatting, runtime-specific clipboard configuration, or Electron and VS Code runtime code.

## Affected surfaces

Shared UI message copying in `packages/ui` is consumed by web, Electron, VS Code, and mobile. The changed clipboard payloads are `text/plain`, `text/markdown`, and rendered `text/html`. Web was manually exercised; Electron, VS Code, and mobile runtime behavior was not exercised.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | The change updates shared UI message-copy behavior. | The existing UI helper owns the behavior; no runtime bridge, API, persisted state, or configuration is added. |
| `openchamber-change-discipline` | Source and exported-helper behavior changes in `packages/ui`. | The change stays in the existing message-text helper and adds focused observable regression tests. |
| `CONTRIBUTING.md` | This PR changes user-visible copy behavior. | The body documents intent, non-goals, affected runtimes, validation, visual-check limits, and residual risk. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/lib/messages/messageText.test.ts packages/ui/src/lib/clipboard.test.ts packages/ui/src/components/chat/message/selectionMarkdown.test.ts` | 25 passing; assistant and user block separation, shell output and command separators, selection serialization, and all clipboard MIME payloads asserted |
| `bun run type-check` | Passing |
| `bun run lint` | Passing |
| `bun run build:ui` | Passing |
| `bun run dead-code` | Completed; reported existing unused items only |
| Not run | Electron manual clipboard validation and the full test suite |

## Visual evidence

No screenshot is attached. The regression is the serialized system clipboard payload, so a static UI capture cannot assert the behavior that changed. The focused regression test directly reads the `text/plain`, `text/markdown`, and `text/html` blobs written by the production clipboard helper and asserts Markdown block separation in each payload.

## Risks and failure behavior

Clipboard writes and their fallback behavior are unchanged. The intentional behavior distinction is preserved: shell outputs use blank-line separators, while shell command lists retain single-line separators. Runtime parity remains unverified for Electron, VS Code, and mobile.