### PR TITLE
Reduce anti-slop findings in Persistence

### DIFF
--- a/packages/ui/src/lib/persistence.test.ts
+++ b/packages/ui/src/lib/persistence.test.ts
@@ -241,6 +241,47 @@ describe('updateDesktopSettings', () => {
     }
   });
 
+  test('sanitizes a successful fallback settings response before applying it', async () => {
+    const previousFetch = globalThis.fetch;
+    const fallbackFetch: typeof fetch = async () => new Response(JSON.stringify({ terminalShell: 'zsh' }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    try {
+      globalThis.fetch = fallbackFetch;
+      useUIStore.getState().setTerminalShell('fish');
+
+      await updateDesktopSettings({ terminalShell: 'zsh' });
+
+      expect(useUIStore.getState().terminalShell).toBe('zsh');
+      expect(getSettingsSaveState()).toBe('idle');
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test('reports an error without applying a malformed fallback settings response', async () => {
+    const previousFetch = globalThis.fetch;
+    const fallbackFetch: typeof fetch = async () => new Response(JSON.stringify('ok'), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const states: string[] = [];
+    const unsubscribe = subscribeToSettingsSaveState(() => {
+      states.push(getSettingsSaveState());
+    });
+    try {
+      globalThis.fetch = fallbackFetch;
+      useUIStore.getState().setTerminalShell('fish');
+
+      await updateDesktopSettings({ terminalShell: 'zsh' });
+
+      expect(useUIStore.getState().terminalShell).toBe('fish');
+      expect(states).toEqual(['saving', 'error']);
+    } finally {
+      unsubscribe();
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   test('drains a pending save to the previous runtime and ignores its stale response', async () => {
     switchRuntimeEndpoint({ apiBaseUrl: 'https://settings-a.example', runtimeKey: 'settings-a' });
     const saveResult = deferred<SettingsPayload>();

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -1326,11 +1326,7 @@ const sanitizeWebSettings = (payload: unknown): DesktopSettings | null => {
     for (const [providerId, config] of Object.entries(candidate.usageModelGroups)) {
       if (config && typeof config === 'object') {
         const typedConfig = config as Record<string, unknown>;
-        const providerConfig: {
-          customGroups?: Array<{id: string; label: string; models: string[]; order: number}>;
-          modelAssignments?: Record<string, string>;
-          renamedGroups?: Record<string, string>;
-        } = {};
+        const providerConfig: NonNullable<DesktopSettings['usageModelGroups']>[string] = {};
 
         // Parse customGroups
         if (Array.isArray(typedConfig.customGroups)) {

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -130,7 +130,7 @@ const persistToLocalStorage = (settings: DesktopSettings) => {
 
   if (Array.isArray(settings.projects) && settings.projects.length > 0) {
     const collapsed = settings.projects
-      .filter((project) => (project as unknown as { sidebarCollapsed?: boolean }).sidebarCollapsed === true)
+      .filter((project) => project.sidebarCollapsed === true)
       .map((project) => project.id)
       .filter((id): id is string => typeof id === 'string' && id.length > 0);
     if (collapsed.length > 0) {
@@ -273,13 +273,14 @@ const sanitizeSkillCatalogs = (value: unknown): DesktopSettings['skillCatalogs']
     if (seen.has(id)) continue;
     seen.add(id);
 
-    result.push({
+    const catalog: NonNullable<DesktopSettings['skillCatalogs']>[number] = {
       id,
       label,
       source,
-      ...(subpath ? { subpath } : {}),
-      ...(gitIdentityId ? { gitIdentityId } : {}),
-    });
+    };
+    if (subpath) catalog.subpath = subpath;
+    if (gitIdentityId) catalog.gitIdentityId = gitIdentityId;
+    result.push(catalog);
   }
 
   return result;
@@ -393,7 +394,7 @@ const sanitizeProjects = (value: unknown): DesktopSettings['projects'] | undefin
       project.icon = candidate.icon.trim();
     }
     if (candidate.iconImage === null) {
-      (project as unknown as Record<string, unknown>).iconImage = null;
+      project.iconImage = null;
     } else if (candidate.iconImage && typeof candidate.iconImage === 'object') {
       const iconImage = candidate.iconImage as Record<string, unknown>;
       const mime = typeof iconImage.mime === 'string' ? iconImage.mime.trim() : '';
@@ -404,18 +405,18 @@ const sanitizeProjects = (value: unknown): DesktopSettings['projects'] | undefin
         ? iconImage.source
         : null;
       if (mime && updatedAt > 0 && source) {
-        (project as unknown as Record<string, unknown>).iconImage = { mime, updatedAt, source };
+        project.iconImage = { mime, updatedAt, source };
       }
     }
     if (typeof candidate.color === 'string' && candidate.color.trim().length > 0) {
       project.color = candidate.color.trim();
     }
     if (candidate.iconBackground === null) {
-      (project as unknown as Record<string, unknown>).iconBackground = null;
+      project.iconBackground = null;
     } else {
       const iconBackground = normalizeIconBackground(candidate.iconBackground);
       if (iconBackground) {
-        (project as unknown as Record<string, unknown>).iconBackground = iconBackground;
+        project.iconBackground = iconBackground;
       }
     }
     if (typeof candidate.addedAt === 'number' && Number.isFinite(candidate.addedAt) && candidate.addedAt >= 0) {
@@ -429,7 +430,7 @@ const sanitizeProjects = (value: unknown): DesktopSettings['projects'] | undefin
       project.lastOpenedAt = candidate.lastOpenedAt;
     }
     if (typeof candidate.sidebarCollapsed === 'boolean') {
-      (project as unknown as Record<string, unknown>).sidebarCollapsed = candidate.sidebarCollapsed;
+      project.sidebarCollapsed = candidate.sidebarCollapsed;
     }
     result.push(project);
   }
@@ -507,7 +508,7 @@ const sanitizeModelRefs = (value: unknown, limit: number): Array<{ providerID: s
 };
 
 const getPersistApi = (): PersistApi | undefined => {
-  const candidate = (useUIStore as unknown as { persist?: PersistApi }).persist;
+  const candidate = useUIStore.persist;
   if (candidate && typeof candidate === 'object') {
     return candidate;
   }
@@ -1875,7 +1876,7 @@ async function _flushSettingsUpdate(): Promise<void> {
         return;
       }
 
-      const updated = (await response.json().catch(() => null)) as DesktopSettings | null;
+      const updated = sanitizeWebSettings(await response.json().catch(() => null));
       if (!isSettingsRuntimeContextCurrent(context)) return;
       if (updated) {
         applyDesktopUiPreferences(updated);


### PR DESCRIPTION
## Intent

This unattended maintenance batch (`Run ID: 2026-08-16T15-01-26Z`, branch `anti-slop/as-20260816-150126-persistence`) reduces anti-slop findings in `packages/ui/src/lib/persistence.ts` without weakening type contracts. It removes unsupported assertions where the owning contracts already provide the fields, preserves optional-key omission while constructing skill catalogs, uses the Zustand persist contract directly, and sanitizes the fallback `PUT /api/config/settings` response before applying it. Malformed or non-object fallback responses now leave current settings unchanged and report a failed save.

The batch originally reported 19 selected findings fixed and 24 remaining. This review fixed the remaining local `no-known-value-widening` finding by deriving the usage-model-group value type from `DesktopSettings`; `bun run deslop -- file packages/ui/src/lib/persistence.ts` now reports 23 remaining parser-boundary findings.

## Non-goals

The 23 remaining findings in `persistence.ts` are 10 `no-unknown-parameters` and 13 `no-unsafe-dictionary-type` findings within the existing persisted/network settings parser. Correctly removing them requires defining and applying a complete explicit external-data contract across the parser. Local assertions, primitive unions, or narrow type predicates would only launder the same untrusted values, while rebuilding the full parser would make this maintenance PR unreviewably broad. No settings schema, server route, runtime API, release metadata, or user-facing settings layout is changed.

## Affected surfaces

`packages/ui/src/lib/persistence.ts` is shared by web, Electron, VS Code, hosted mobile, and Capacitor mobile. The observable behavior change is limited to the fallback web `PUT /api/config/settings` response path when no runtime settings API is available. The runtime-settings-API save path is unchanged. Persisted settings remain compatible because valid partial responses continue through the existing sanitizer and invalid responses are neither written nor applied.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Shared UI source and external settings data are changed. | Kept the change minimal, preserved runtime boundaries, and distinguished malformed response failure from valid empty success. |
| `openchamber-change-discipline` | The change covers persisted and external behavior. | Traced owner contracts, removed a duplicated widened type, and ran focused plus package-wide validation. |
| `sync-state-invariants` and `packages/ui/src/sync/DOCUMENTATION.md` | Settings saves are debounced state transitions with persistence behavior. | A malformed response retains current in-memory settings and transitions the save indicator to `error`; it is never treated as authoritative empty success. |
| `packages/ui/src/stores/DOCUMENTATION.md` | The persistence module applies data to the shared UI store. | Save responses remain partial patches and cannot clear unrelated preferences or local mirrors. |
| `ui-api-decoupling` and `references/implementation-map.md` | `runtimeFetch` consumes the OpenChamber settings route. | The existing runtime transport remains authoritative, and the raw fallback response is parsed once before shared UI code uses it. |
| `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` | This is a PR review handoff. | This description records final scope, exact validation, visual impact, and failure behavior. |

## Validation

| Check | Result |
|---|---|
| `bun run deslop -- check-batch --run 2026-08-16T15-01-26Z` | Not available: the run directory no longer exists (`Unknown run`). |
| `bun run deslop -- file packages/ui/src/lib/persistence.ts` | Completed: 23 remaining findings, reduced from the 24 documented before review; only 10 `no-unknown-parameters` and 13 `no-unsafe-dictionary-type` parser-boundary findings remain. |
| `bun test packages/ui/src/lib/persistence.test.ts` | PASS: 21 tests, 61 assertions. |
| `bun run --cwd packages/ui type-check` | PASS. |
| `bun run --cwd packages/ui lint` | PASS. |
| `bun run --cwd packages/ui test` | PASS: 265/265 isolated test files. |
| `bunx oxlint packages/ui/src/lib/persistence.ts packages/ui/src/lib/persistence.test.ts` | Completed with existing anti-slop findings in these selected files; the review removed the only remaining `no-known-value-widening` finding and introduced none. |
| `git diff --check origin/main...HEAD` | PASS. |
| `gh pr checks 2953` before the review push | PASS: automation, checks, and label jobs. New-head checks were triggered by the push and were not awaited. |

## Visual evidence

No screenshots or recording: the diff changes type evidence, object construction with equivalent omitted-key behavior, and validation of a network response. It does not change normal rendered settings layout, theme, copy, or interaction. The only observable error-path difference occurs when a misbehaving fallback settings endpoint returns a malformed payload, where the existing save indicator reports an error instead of accepting the payload.

## Risks and failure behavior

For a valid fallback response, settings continue to be sanitized and applied as a partial patch. For malformed or non-object JSON, current settings remain intact, `openchamber:settings-synced` is not dispatched for the bad payload, and the save indicator enters `error`; no exception is introduced. Optional skill catalog keys remain absent when empty, preserving serialization behavior. The runtime-settings-API path, server response shape, and persisted settings format are unchanged. Rollback is the PR commits; no data migration or cleanup is required.

## Manual testing recommendations

Exercise a web runtime without a registered settings API against both a valid partial `PUT /api/config/settings` response and malformed JSON. Confirm the valid patch applies, the malformed payload preserves existing preferences, and the save indicator reports the failure.