### PR TITLE
fix(dictation): stop dropping trailing captured audio when a recording ends

### DIFF
--- a/packages/ui/src/lib/dictation/use-dictation-audio-source.ts
+++ b/packages/ui/src/lib/dictation/use-dictation-audio-source.ts
@@ -22,6 +22,11 @@ export interface DictationAudioSource {
 
 const OUTPUT_RATE = 16000;
 const CHUNK_SAMPLES = OUTPUT_RATE; // ~1s per chunk
+// Safety ceiling only — not the drain signal itself. stop() normally
+// resolves as soon as one more onaudioprocess callback actually fires (see
+// below); this just guarantees stop() can't hang forever if the audio
+// context is suspended (e.g. a backgrounded tab) and no callback ever comes.
+const STOP_DRAIN_TIMEOUT_MS = 500;
 
 const getAudioContextCtor = (): typeof AudioContext | null => {
     if (typeof window === 'undefined') {
@@ -91,6 +96,9 @@ interface CaptureGraph {
     gain: GainNode | null;
     pending: Int16Array;
     started: boolean;
+    /** Set by stop() while draining; onaudioprocess calls it once, then
+        clears it, to signal that the next real buffer has landed. */
+    onDrain: (() => void) | null;
 }
 
 const emptyGraph = (): CaptureGraph => ({
@@ -101,6 +109,7 @@ const emptyGraph = (): CaptureGraph => ({
     gain: null,
     pending: new Int16Array(0),
     started: false,
+    onDrain: null,
 });
 
 const safeDisconnect = (node: AudioNode | null): void => {
@@ -174,7 +183,7 @@ export function useDictationAudioSource(config: DictationAudioSourceConfig): Dic
             const gain = context.createGain();
             gain.gain.value = 0;
 
-            graphRef.current = {
+            const graph: CaptureGraph = {
                 stream,
                 context,
                 source,
@@ -182,11 +191,18 @@ export function useDictationAudioSource(config: DictationAudioSourceConfig): Dic
                 gain,
                 pending: new Int16Array(0),
                 started: true,
+                onDrain: null,
             };
+            graphRef.current = graph;
 
             processor.onaudioprocess = (event) => {
-                const graph = graphRef.current;
-                if (!graph.started) {
+                // Close over this call's own graph rather than re-reading
+                // graphRef.current: stop() below keeps this processor
+                // connected for a short drain window after a newer
+                // dictation could in principle have already started and
+                // replaced graphRef.current, and a stale trailing callback
+                // must not inject leftover audio into that new session.
+                if (graphRef.current !== graph) {
                     return;
                 }
                 const input = event.inputBuffer.getChannelData(0);
@@ -205,6 +221,17 @@ export function useDictationAudioSource(config: DictationAudioSourceConfig): Dic
                     const chunk = graph.pending.slice(0, CHUNK_SAMPLES);
                     graph.pending = graph.pending.slice(CHUNK_SAMPLES);
                     onPcmSegmentRef.current(int16ToBase64(chunk));
+                }
+
+                // Tell a draining stop() that this delivery — guaranteed by
+                // the Web Audio API to be contiguous with the previous one —
+                // covers everything captured up through "now". One firing is
+                // enough; clear it so later callbacks in the same recording
+                // don't loop back into an already-resolved stop().
+                if (graph.onDrain) {
+                    const onDrain = graph.onDrain;
+                    graph.onDrain = null;
+                    onDrain();
                 }
             };
 
@@ -231,8 +258,31 @@ export function useDictationAudioSource(config: DictationAudioSourceConfig): Dic
 
     const stop = useCallback(async () => {
         const graph = graphRef.current;
-        graph.started = false;
         setVolume(0);
+
+        // Wait for one more real onaudioprocess delivery — not a guessed
+        // delay — before tearing the graph down. Web Audio buffers are
+        // contiguous, so the very next callback is guaranteed to cover
+        // everything captured up to this point; anything still in flight
+        // through the pipeline right now lands in that callback instead of
+        // being silently dropped. The timeout is a ceiling for a stalled
+        // audio context (e.g. a backgrounded tab), not the mechanism itself.
+        if (graph.started && graph.processor) {
+            await new Promise<void>((resolve) => {
+                let settled = false;
+                const settle = () => {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    graph.onDrain = null;
+                    resolve();
+                };
+                graph.onDrain = settle;
+                setTimeout(settle, STOP_DRAIN_TIMEOUT_MS);
+            });
+        }
+        graph.started = false;
 
         if (graph.processor) {
             try {


### PR DESCRIPTION
## Intent

Dictation silently drops roughly the last 100ms+ of captured microphone audio every time a recording stops (pressing Enter to confirm, or Cancel) — not intermittently, on every stop. `stop()` in `useDictationAudioSource` nulled the `ScriptProcessorNode`'s `onaudioprocess` handler and stopped the `MediaStreamTrack` essentially immediately. Any audio already captured by the microphone but still working its way through the browser's audio pipeline (one more delivery, ~85-93ms at typical native sample rates) was discarded instead of ever reaching the transcription pipeline. For a short utterance this reads as "the end of what I said got cut off"; a user reported it as text missing from the composer after dictating and pressing Enter.

Fix: `stop()` now waits for one more real `onaudioprocess` delivery — an actual completion signal — before tearing the capture graph down, instead of guessing a fixed delay. Web Audio delivers buffers contiguously, so that next callback is guaranteed to cover everything captured up to the moment `stop()` was called. A `setTimeout` remains only as a safety ceiling for a stalled/suspended audio context (e.g. a backgrounded tab), not as the drain mechanism itself — an earlier version of this fix used a fixed `150ms` delay for that purpose and it was strictly worse (too short under load, needlessly long otherwise).

## Non-goals

- Not migrating off the deprecated `ScriptProcessorNode` to `AudioWorkletNode`. The file's existing comment states it was deliberately chosen over `AudioWorkletNode` for broader compatibility, including iOS WKWebView; an `AudioWorkletNode` could offer an even cleaner explicit-flush signal, but that's a larger change outside this fix's scope.
- Not touching server-side transcription/finalization logic (`stream-manager.js`, provider sessions). I separately verified, by driving a long multi-segment dictation directly through the server-side stream manager and a local STT provider, that server-side finalization correctly waits for and concatenates every committed segment's final transcript with nothing missing — which is what pointed this investigation at client-side capture instead of the server in the first place.

## Affected surfaces

- `packages/ui/src/lib/dictation/use-dictation-audio-source.ts` only.
- Shared client-side microphone capture used by every dictation/STT provider (local and OpenAI-compatible) — not provider-specific.
- Affects Desktop and Web (and any Capacitor/PWA mobile surface that reuses this shared hook). VS Code does **not** have a dictation server process (`ComposerDictation.tsx` explicitly gates on `!isVSCodeRuntime()`), so this path is unreachable there — unaffected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` (skill) | Any source change in this repo; classifies as "local implementation" risk (private hook behavior in one package, no exported contract/type change, no cross-workspace surface) | Kept the diff to the single owning file; no new abstraction introduced beyond one `onDrain` field already scoped to `CaptureGraph`; validated at the package level (`packages/ui`) per the risk classification's validation matrix, not workspace-wide |
| Nearest module docs | Checked for a `DOCUMENTATION.md` covering this hook | None exists for `packages/ui/src/lib/dictation/` (only the server-side dictation module has one, which doesn't cover client audio capture) — noting this rather than fabricating a reference |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui type-check` | Pass |
| `bun run --cwd packages/ui lint` | Pass |
| `bunx oxlint packages/ui/src/lib/dictation/use-dictation-audio-source.ts` | Clean on every changed line; 7 pre-existing findings remain on unrelated, untouched lines (SSR/feature-detection `typeof` guards in `getAudioContextCtor`, `isDictationCaptureSupported`, and `start`'s environment check), left alone per this repo's "don't mass-fix backlog findings" convention |
| Existing automated tests | No automated test exists for this hook (or any Web Audio capture code) anywhere in this codebase — confirmed by search, not an omission specific to this change. Not something this PR adds coverage for; would need a Web Audio API mock harness that doesn't currently exist in the test setup |
| Manual / root-cause verification | Traced the exact execution order in `stop()` and `onaudioprocess` by reading the code: confirmed the prior code nulls the callback and stops the track before an in-flight buffer can be delivered, and confirmed the fix's correctness follows from the Web Audio API's documented contiguous, non-overlapping buffer delivery (the next callback necessarily covers up to the current moment) |
| **Not verified** | A recorded, reproducible microphone session demonstrating the exact truncation before this fix and its absence after. I have no way to script/simulate real microphone input into a live browser `AudioContext` from this environment. This is a timing-dependent capture bug; a maintainer or the reporting user re-testing a real dictation session (especially stopping immediately after finishing a sentence) is the strongest remaining check before merge |

## Visual evidence

No rendered UI changed — this is a data-capture timing fix inside a hook with no JSX/markup. Nothing in the diff can affect what's on screen; the observable effect is entirely in the *content* of the transcribed text, not its presentation, which the Validation section above covers instead.

## Risks and failure behavior

- **Worst case if the drain signal never arrives** (e.g. audio context suspended by a backgrounded tab): `stop()` waits up to the `STOP_DRAIN_TIMEOUT_MS` (500ms) ceiling, then proceeds through the exact same teardown as before. No worse than prior behavior, just now correctly bounded instead of unbounded/unclear.
- **Cross-contamination risk considered and closed:** `onaudioprocess` now closes over its own call's `graph` object and checks `graphRef.current !== graph` before touching `pending`, specifically because the processor stays connected slightly longer during the drain window, during which a new dictation could in principle already have started and replaced `graphRef.current`. Without this check, a stale trailing callback could inject leftover audio into a session it doesn't belong to.
- **Rollback:** single-file revert restores prior (buggy but previously-shipped) behavior exactly; no persisted state, migration, or schema involved.
- **Performance:** adds at most one audio buffer's worth of latency (commonly under 100ms, hard-capped at 500ms) to `stop()`, and only when a recording was actually active — not on every call, not on the happy path being slower than necessary.
