### PR TITLE
fix(chat): preserve Markdown in partial selection copy (#2840)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Chat: copying a partial text selection on mobile now preserves its Markdown formatting in rich clipboard targets instead of copying only rendered plain text. (thanks to @bashrusakh).
 - Chat: if OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
 
 ## [1.19.0] - 2026-08-19
@@ -24,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Chat: opening a busy subagent in the context panel now shows its history instead of only the working-status line (thanks to @makeittech).
 - Chat: saved chats in the context panel open again instead of staying blank.
 - Chat: the context meter no longer climbs over 100% (330% readouts) after turns with many tool calls and no longer jumps when reopening an older session; it now shows what the window actually holds, everywhere the value appears — header, context sidebar, work status panel, mini chat, and mobile (thanks to @pocharlies).
+- Chat: copying a partial text selection on mobile now preserves its Markdown formatting in rich clipboard targets instead of copying only rendered plain text (thanks to @bashrusakh).
 - Chat/Attachments: extracted Office and OpenDocument content is now capped and presented more compactly, preventing large documents and their images from overwhelming the message context.
 - Projects: project names now match the folder name exactly, so `.ssh` and `opencode-claude` are no longer shown as `.Ssh` and `Opencode Claude` in the sidebar, window title, settings and notifications; names you renamed yourself are kept.
 - Files: files reached through a symlink inside the workspace now open correctly instead of being rejected as outside the workspace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Chat: copying a partial text selection on mobile now preserves its Markdown formatting in rich clipboard targets instead of copying only rendered plain text.
+- Chat: copying a partial text selection on mobile now preserves its Markdown formatting in rich clipboard targets instead of copying only rendered plain text. (thanks to @bashrusakh).
 - Chat: if OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
 
 ## [1.19.0] - 2026-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Chat: copying a partial text selection on mobile now preserves its Markdown formatting in rich clipboard targets instead of copying only rendered plain text.
 - Chat: if OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
 
 ## [1.19.0] - 2026-08-19

--- a/packages/ui/src/components/chat/message/TextSelectionMenu.test.tsx
+++ b/packages/ui/src/components/chat/message/TextSelectionMenu.test.tsx
@@ -1,0 +1,581 @@
+/**
+ * Regression coverage for issue #2840.
+ *
+ * This mounts the real mobile TextSelectionMenu against the small DOM stub used
+ * by UI component tests, selects formatted DOM content through the component's
+ * selectionchange listener, and invokes the real Copy button handler. The
+ * selected DOM text is intentionally plain while its Markdown selection is
+ * bold, so a plain-text-only copy cannot satisfy the assertions.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+type FakeClickEvent = { preventDefault?: () => void; stopPropagation?: () => void };
+type CopyHandler = (event: FakeClickEvent) => void | Promise<void>;
+type ReactProps = { title?: string; onClick?: CopyHandler };
+type ReactPropsKey = `__reactProps${string}`;
+type FakeEvent = { type: string; target: FakeDocument };
+type FakeListener = (event: FakeEvent) => void;
+type FakeStyleValue = string | ((...args: string[]) => string | void);
+
+interface FakeStyle {
+  cssText: string;
+  setProperty: (...args: string[]) => void;
+  getPropertyValue: (...args: string[]) => string;
+  [key: string]: FakeStyleValue;
+}
+
+interface FakeDocument {
+  nodeType: number;
+  nodeName: string;
+  compatMode: string;
+  defaultView: FakeWindow;
+  body: FakeNode;
+  documentElement: FakeNode;
+  activeElement: FakeNode | null;
+  addEventListener: (type: string, listener: FakeListener) => void;
+  removeEventListener: (type: string, listener: FakeListener) => void;
+  createElement: (tag: string) => FakeNode;
+  createElementNS: (_namespace: string, tag: string) => FakeNode;
+  createTextNode: (text: string) => FakeNode;
+  execCommand: (_command: string) => boolean;
+  emit: (type: string) => void;
+}
+
+interface FakeWindow {
+  document: FakeDocument;
+  navigator: {
+    clipboard: {
+      write: (items: FakeClipboardItem[]) => Promise<void>;
+      writeText: (text: string) => Promise<void>;
+    };
+  };
+  innerWidth: number;
+  innerHeight: number;
+  getSelection: () => SelectionStub | null;
+  requestAnimationFrame: (callback: FrameRequestCallback) => number;
+  cancelAnimationFrame: (id: number) => void;
+  addEventListener: () => void;
+  removeEventListener: () => void;
+  HTMLIFrameElement: unknown;
+  HTMLFrameSetElement: unknown;
+  HTMLInputElement: unknown;
+  HTMLTextAreaElement: unknown;
+  HTMLSelectElement: unknown;
+  HTMLOptionElement: unknown;
+  HTMLAnchorElement: unknown;
+}
+
+interface FakeNode {
+  nodeType: number;
+  nodeName: string;
+  tagName: string;
+  namespaceURI: string;
+  ownerDocument: FakeDocument;
+  parentNode: FakeNode | null;
+  parentElement: FakeNode | null;
+  childNodes: FakeNode[];
+  style: FakeStyle;
+  classList: FakeClassList;
+  value: string;
+  textContent: string;
+  innerHTML: string;
+  offsetWidth: number;
+  appendChild: (child: FakeNode) => FakeNode;
+  insertBefore: (child: FakeNode, reference: FakeNode | null) => FakeNode;
+  removeChild: (child: FakeNode) => FakeNode;
+  select: () => void;
+  setSelectionRange: (_start: number, _end: number) => void;
+  contains: (node: FakeNode) => boolean;
+  setAttribute: (name: string, value: string) => void;
+  getAttribute: (name: string) => string | null;
+  hasAttribute: (name: string) => boolean;
+  removeAttribute: (name: string) => void;
+  addEventListener: () => void;
+  removeEventListener: () => void;
+  getBoundingClientRect: () => DOMRect;
+  closest: (selector: string) => FakeNode | null;
+  [key: ReactPropsKey]: ReactProps;
+}
+
+interface RangeFragment {
+  childNodes: FakeNode[];
+}
+
+interface TestRange {
+  startContainer: FakeNode;
+  endContainer: FakeNode;
+  commonAncestorContainer: FakeNode;
+  cloneContents: () => RangeFragment;
+  getBoundingClientRect: () => DOMRect;
+}
+
+interface SelectionStub {
+  toString: () => string;
+  getRangeAt: (_index: number) => TestRange;
+  removeAllRanges: () => void;
+}
+
+class FakeClassList {
+  private readonly classes = new Set<string>();
+
+  add(...classes: string[]): void {
+    classes.forEach((value) => this.classes.add(value));
+  }
+
+  remove(...classes: string[]): void {
+    classes.forEach((value) => this.classes.delete(value));
+  }
+
+  contains(value: string): boolean {
+    return this.classes.has(value);
+  }
+}
+
+const makeRect = (): DOMRect => ({
+  left: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  width: 0,
+  height: 0,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+});
+
+const makeStyle = (): FakeStyle => ({
+  cssText: '',
+  setProperty: () => undefined,
+  getPropertyValue: () => '',
+});
+
+const makeNode = (tag: string, ownerDocument: FakeDocument, nodeType = 1, textContent = ''): FakeNode => {
+  const attributes = new Map<string, string>();
+  const node: FakeNode = {
+    nodeType,
+    nodeName: nodeType === 3 ? '#text' : tag.toUpperCase(),
+    tagName: nodeType === 3 ? '' : tag.toUpperCase(),
+    namespaceURI: 'http://www.w3.org/1999/xhtml',
+    ownerDocument,
+    parentNode: null,
+    parentElement: null,
+    childNodes: [],
+    style: makeStyle(),
+    classList: new FakeClassList(),
+    value: '',
+    textContent,
+    innerHTML: '',
+    offsetWidth: 0,
+    appendChild(child) {
+      if (child.parentNode) child.parentNode.removeChild(child);
+      this.childNodes.push(child);
+      child.parentNode = this;
+      child.parentElement = this.nodeType === 1 ? this : null;
+      return child;
+    },
+    insertBefore(child, reference) {
+      if (child.parentNode) child.parentNode.removeChild(child);
+      const index = reference ? this.childNodes.indexOf(reference) : -1;
+      if (index === -1) this.childNodes.push(child);
+      else this.childNodes.splice(index, 0, child);
+      child.parentNode = this;
+      child.parentElement = this.nodeType === 1 ? this : null;
+      return child;
+    },
+    removeChild(child) {
+      const index = this.childNodes.indexOf(child);
+      if (index !== -1) this.childNodes.splice(index, 1);
+      child.parentNode = null;
+      child.parentElement = null;
+      return child;
+    },
+    select: () => undefined,
+    setSelectionRange: () => undefined,
+    contains(target) {
+      let current: FakeNode | null = target;
+      while (current) {
+        if (current === this) return true;
+        current = current.parentNode;
+      }
+      return false;
+    },
+    setAttribute(name, value) {
+      attributes.set(name, value);
+    },
+    getAttribute(name) {
+      return attributes.get(name) ?? null;
+    },
+    hasAttribute(name) {
+      return attributes.has(name);
+    },
+    removeAttribute(name) {
+      attributes.delete(name);
+    },
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    getBoundingClientRect: makeRect,
+    closest: () => null,
+  };
+  return node;
+};
+
+class FakeClipboardItem {
+  static supports(type: string): boolean {
+    return type === 'text/markdown';
+  }
+
+  readonly data: Record<string, Blob>;
+
+  constructor(data: Record<string, Blob>) {
+    this.data = data;
+  }
+}
+
+const isReactPropsKey = (key: string): key is ReactPropsKey => key.startsWith('__reactProps');
+
+const getReactProps = (node: FakeNode): ReactProps | null => {
+  const propsKey = Object.keys(node).find(isReactPropsKey);
+  return propsKey ? node[propsKey] : null;
+};
+
+const findNode = (root: FakeNode, predicate: (node: FakeNode) => boolean): FakeNode | null => {
+  if (predicate(root)) return root;
+  for (const child of root.childNodes) {
+    const match = findNode(child, predicate);
+    if (match) return match;
+  }
+  return null;
+};
+
+const asElement = (node: FakeNode): Element => {
+  // SAFETY: the test DOM node implements the host methods React uses for a root.
+  return node as never;
+};
+
+const asHTMLElement = (node: FakeNode): HTMLElement => {
+  // SAFETY: the test DOM node implements the host methods used by the selection menu.
+  return node as never;
+};
+
+const createSelectorHook = <State,>(state: State) => <Result,>(selector: (value: State) => Result): Result => selector(state);
+
+const installDomStub = () => {
+  const previousGlobals = new Map<string, PropertyDescriptor | undefined>();
+  const listeners = new Map<string, Set<FakeListener>>();
+  const writtenItems: Array<FakeClipboardItem | undefined> = [];
+  let currentSelection: SelectionStub | null = null;
+  let nextAnimationFrameId = 0;
+  const animationFrames = new Set<number>();
+
+  const setGlobal = <Value,>(name: string, value: Value): void => {
+    if (!previousGlobals.has(name)) {
+      previousGlobals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    }
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  };
+
+  // SAFETY: document and window are mutually recursive; both are populated before exposure.
+  const documentStub = {} as FakeDocument;
+  const addDocumentListener = (type: string, listener: FakeListener): void => {
+    const callbacks = listeners.get(type) ?? new Set<FakeListener>();
+    callbacks.add(listener);
+    listeners.set(type, callbacks);
+  };
+  const removeDocumentListener = (type: string, listener: FakeListener): void => {
+    const callbacks = listeners.get(type);
+    if (!callbacks) return;
+    callbacks.delete(listener);
+    if (callbacks.size === 0) listeners.delete(type);
+  };
+
+  const clipboard = {
+    write: async (items: FakeClipboardItem[]): Promise<void> => {
+      writtenItems.push(items[0]);
+    },
+    writeText: async (text: string): Promise<void> => {
+      void text;
+    },
+  };
+  const windowStub: FakeWindow = {
+    document: documentStub,
+    navigator: { clipboard },
+    innerWidth: 390,
+    innerHeight: 844,
+    getSelection: () => currentSelection,
+    requestAnimationFrame: (callback) => {
+      const id = ++nextAnimationFrameId;
+      animationFrames.add(id);
+      setTimeout(() => {
+        if (!animationFrames.delete(id)) return;
+        callback(Date.now());
+      }, 0);
+      return id;
+    },
+    cancelAnimationFrame: (id) => {
+      animationFrames.delete(id);
+    },
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    HTMLIFrameElement: class {},
+    HTMLFrameSetElement: class {},
+    HTMLInputElement: class {},
+    HTMLTextAreaElement: class {},
+    HTMLSelectElement: class {},
+    HTMLOptionElement: class {},
+    HTMLAnchorElement: class {},
+  };
+
+  Object.assign(documentStub, {
+    nodeType: 9,
+    nodeName: '#document',
+    compatMode: 'CSS1Compat',
+    defaultView: windowStub,
+    activeElement: null,
+    addEventListener: addDocumentListener,
+    removeEventListener: removeDocumentListener,
+    createElement: (tag: string) => makeNode(tag, documentStub),
+    createElementNS: (_namespace: string, tag: string) => makeNode(tag, documentStub),
+    createTextNode: (text: string) => makeNode('', documentStub, 3, text),
+    execCommand: () => false,
+    emit: (type: string) => {
+      const event = { type, target: documentStub };
+      listeners.get(type)?.forEach((listener) => listener(event));
+    },
+  });
+  documentStub.body = makeNode('body', documentStub);
+  documentStub.documentElement = makeNode('html', documentStub);
+
+  setGlobal('document', documentStub);
+  setGlobal('window', windowStub);
+  setGlobal('navigator', windowStub.navigator);
+  setGlobal('Element', class {});
+  setGlobal('HTMLElement', class {});
+  setGlobal('HTMLIFrameElement', windowStub.HTMLIFrameElement);
+  setGlobal('HTMLFrameSetElement', windowStub.HTMLFrameSetElement);
+  setGlobal('HTMLInputElement', windowStub.HTMLInputElement);
+  setGlobal('HTMLTextAreaElement', windowStub.HTMLTextAreaElement);
+  setGlobal('HTMLSelectElement', windowStub.HTMLSelectElement);
+  setGlobal('HTMLOptionElement', windowStub.HTMLOptionElement);
+  setGlobal('HTMLAnchorElement', windowStub.HTMLAnchorElement);
+  setGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  setGlobal('requestAnimationFrame', windowStub.requestAnimationFrame);
+  setGlobal('cancelAnimationFrame', windowStub.cancelAnimationFrame);
+  setGlobal('ClipboardItem', FakeClipboardItem);
+
+  return {
+    document: documentStub,
+    setSelection: (selection: SelectionStub): void => {
+      currentSelection = selection;
+    },
+    writtenItems,
+    restore: (): void => {
+      previousGlobals.forEach((descriptor, name) => {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      });
+    },
+  };
+};
+
+const sessionUIState = {
+  createSession: async (): Promise<null> => null,
+  currentSessionId: null,
+  availableWorktreesByProject: new Map<string, string[]>(),
+};
+const inputState = {
+  setPendingInputText: (): void => undefined,
+};
+const toastErrors: Array<{ message: string; description?: string }> = [];
+
+mock.module('@/components/icon/Icon', () => ({ Icon: () => null }));
+mock.module('@/components/ui', () => ({
+  toast: {
+    error: (message: string, options?: { description?: string }) => {
+      toastErrors.push({ message, description: options?.description });
+    },
+    success: () => undefined,
+  },
+}));
+mock.module('@/components/chat/composer/editor/dom', () => ({ focusChatInput: () => undefined }));
+mock.module('@/hooks/useEffectiveDirectory', () => ({ useEffectiveDirectory: () => undefined }));
+mock.module('@/lib/desktop', () => ({ isVSCodeRuntime: () => false }));
+mock.module('@/lib/i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+mock.module('@/lib/projectContextApi', () => ({ PROJECT_NOTE_BODY_MAX_LENGTH: 3000 }));
+mock.module('@/lib/projectResolution', () => ({ resolveProjectForSessionDirectory: () => null }));
+mock.module('@/lib/smallModel', () => ({ summarizeSelectionForNotes: async () => '' }));
+mock.module('@/lib/utils', () => ({ cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ') }));
+mock.module('@/stores/useProjectContextStore', () => ({ useProjectContextStore: { getState: () => ({ createNote: async () => null }) } }));
+mock.module('@/stores/useProjectsStore', () => ({ useProjectsStore: createSelectorHook({ projects: [] }) }));
+mock.module('@/stores/useUIStore', () => ({ useUIStore: createSelectorHook({ isMobile: true }) }));
+mock.module('@/sync/input-store', () => ({ useInputStore: createSelectorHook(inputState) }));
+mock.module('@/sync/session-ui-store', () => ({ useSessionUIStore: createSelectorHook(sessionUIState) }));
+mock.module('@/sync/sync-context', () => ({ useSessions: () => [] }));
+mock.module('dompurify', () => ({ default: { isSupported: true, addHook: () => undefined, sanitize: (html: string) => html } }));
+mock.module('../markdown/markdown-worker', () => ({ highlightCodeInWorker: async () => null }));
+
+const { TextSelectionMenu } = await import('./TextSelectionMenu');
+
+describe('TextSelectionMenu mobile Copy', () => {
+  test('copies a formatted selection as plain Markdown, Markdown source, and HTML', async () => {
+    const dom = installDomStub();
+    let root: Root | null = null;
+    toastErrors.length = 0;
+
+    try {
+      const mountNode = dom.document.createElement('div');
+      dom.document.body.appendChild(mountNode);
+      const content = dom.document.createElement('div');
+      const strong = dom.document.createElement('strong');
+      const selectedTextNode = dom.document.createTextNode('Bold selection');
+      strong.appendChild(selectedTextNode);
+      content.appendChild(strong);
+
+      const range: TestRange = {
+        startContainer: selectedTextNode,
+        endContainer: selectedTextNode,
+        commonAncestorContainer: strong,
+        cloneContents: () => ({ childNodes: [strong] }),
+        getBoundingClientRect: () => ({
+          left: 100,
+          top: 200,
+          right: 220,
+          bottom: 220,
+          width: 120,
+          height: 20,
+          x: 100,
+          y: 200,
+          toJSON: () => ({}),
+        }),
+      };
+      let rangeCount = 1;
+      const selection: SelectionStub = {
+        toString: () => (rangeCount > 0 ? 'Bold selection' : ''),
+        getRangeAt: () => range,
+        removeAllRanges: () => { rangeCount = 0; },
+      };
+      dom.setSelection(selection);
+
+      root = createRoot(asElement(mountNode));
+      const containerRef = { current: asHTMLElement(content) };
+      await act(async () => {
+        root?.render(React.createElement(TextSelectionMenu, { containerRef }));
+      });
+      await act(async () => {
+        dom.document.emit('selectionchange');
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const copyButton = findNode(
+        dom.document.body,
+        (node) => getReactProps(node)?.title === 'chat.textSelection.actions.copy',
+      );
+      if (!copyButton) throw new Error('Mobile Copy button was not mounted');
+      const copyHandler = getReactProps(copyButton)?.onClick;
+      if (!copyHandler) throw new Error('Mobile Copy button has no click handler');
+
+      await act(async () => {
+        await copyHandler({});
+      });
+
+      const writtenItem = dom.writtenItems[0];
+      if (!writtenItem) throw new Error('Copy did not write a ClipboardItem');
+      const plainText = await writtenItem.data['text/plain']?.text();
+      const markdown = await writtenItem.data['text/markdown']?.text();
+      const html = await writtenItem.data['text/html']?.text();
+
+      expect(plainText).toBe('**Bold selection**');
+      expect(markdown).toBe('**Bold selection**');
+      expect(html).toContain('<strong>Bold selection</strong>');
+      expect(plainText).not.toBe('Bold selection');
+      expect(markdown).not.toBe('Bold selection');
+      expect(html).not.toBe('Bold selection');
+    } finally {
+      const mountedRoot = root;
+      if (mountedRoot) {
+        await act(async () => {
+          mountedRoot.unmount();
+        });
+      }
+      dom.restore();
+    }
+  });
+
+  test('hides the menu and clears the selection when clipboard writes are rejected', async () => {
+    const dom = installDomStub();
+    let root: Root | null = null;
+    toastErrors.length = 0;
+
+    try {
+      dom.document.defaultView.navigator.clipboard.write = async () => {
+        throw new Error('Clipboard rejected');
+      };
+      dom.document.defaultView.navigator.clipboard.writeText = async () => {
+        throw new Error('Plain clipboard rejected');
+      };
+
+      const mountNode = dom.document.createElement('div');
+      dom.document.body.appendChild(mountNode);
+      const content = dom.document.createElement('div');
+      const selectedTextNode = dom.document.createTextNode('Rejected selection');
+      content.appendChild(selectedTextNode);
+
+      const range: TestRange = {
+        startContainer: selectedTextNode,
+        endContainer: selectedTextNode,
+        commonAncestorContainer: content,
+        cloneContents: () => ({ childNodes: [selectedTextNode] }),
+        getBoundingClientRect: makeRect,
+      };
+      let rangeCount = 1;
+      const selection: SelectionStub = {
+        toString: () => (rangeCount > 0 ? 'Rejected selection' : ''),
+        getRangeAt: () => range,
+        removeAllRanges: () => { rangeCount = 0; },
+      };
+      dom.setSelection(selection);
+
+      root = createRoot(asElement(mountNode));
+      const containerRef = { current: asHTMLElement(content) };
+      await act(async () => {
+        root?.render(React.createElement(TextSelectionMenu, { containerRef }));
+      });
+      await act(async () => {
+        dom.document.emit('selectionchange');
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const copyButton = findNode(
+        dom.document.body,
+        (node) => getReactProps(node)?.title === 'chat.textSelection.actions.copy',
+      );
+      if (!copyButton) throw new Error('Mobile Copy button was not mounted');
+      const copyHandler = getReactProps(copyButton)?.onClick;
+      if (!copyHandler) throw new Error('Mobile Copy button has no click handler');
+
+      await act(async () => {
+        await copyHandler({});
+      });
+
+      expect(toastErrors).toEqual([{
+        message: 'chat.textSelection.toast.copyFailed',
+        description: undefined,
+      }]);
+      expect(selection.toString()).toBe('');
+      expect(findNode(
+        dom.document.body,
+        (node) => getReactProps(node)?.title === 'chat.textSelection.actions.copy',
+      )).toBeNull();
+    } finally {
+      const mountedRoot = root;
+      if (mountedRoot) {
+        await act(async () => {
+          mountedRoot.unmount();
+        });
+      }
+      dom.restore();
+    }
+  });
+});

--- a/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
+++ b/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
@@ -7,6 +7,7 @@ import { useInputStore } from '@/sync/input-store';
 import { useUIStore } from '@/stores/useUIStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { cn } from '@/lib/utils';
+import { copyMarkdownToClipboard } from '@/lib/clipboard';
 import { toast } from '@/components/ui';
 import { Icon } from "@/components/icon/Icon";
 import { PROJECT_NOTE_BODY_MAX_LENGTH } from '@/lib/projectContextApi';
@@ -498,7 +499,39 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
     queueMicrotask(() => {
       focusChatInput();
     });
-  }, [addContextDraft, commentText, currentSessionId, effectiveDirectory, hideMenu, newSessionDraftOpen, selectedMessageId, selectedTextMarkdown]);
+  }, [selectedTextMarkdown, setPendingInputText, hideMenu]);
+
+  const handleCreateNewSession = React.useCallback(async () => {
+    if (!selectedText) return;
+
+    const session = await createSession(undefined, null, null);
+    if (session) {
+      setPendingInputText(selectedText, 'replace');
+    }
+
+    hideMenu();
+    window.getSelection()?.removeAllRanges();
+  }, [selectedText, createSession, setPendingInputText, hideMenu]);
+
+  const handleCopy = React.useCallback(async () => {
+    if (!selectedText) return;
+
+    try {
+      const markdownText = selectedTextMarkdown || selectedText;
+      const { renderMarkdownSync } = await import('../markdown/markdownCore');
+      const result = await copyMarkdownToClipboard(markdownText, renderMarkdownSync(markdownText));
+      if (!result.ok) {
+        console.error('Failed to copy:', result.error);
+        toast.error(t('chat.textSelection.toast.copyFailed'));
+      }
+    } catch (error) {
+      console.error('Failed to copy:', error);
+      toast.error(t('chat.textSelection.toast.copyFailed'));
+    } finally {
+      hideMenu();
+      window.getSelection()?.removeAllRanges();
+    }
+  }, [hideMenu, selectedText, selectedTextMarkdown, t]);
 
   const currentSession = React.useMemo(() => {
     if (!currentSessionId) {

--- a/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
+++ b/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
@@ -6,7 +6,7 @@ import { useInputStore } from '@/sync/input-store';
 import { useUIStore } from '@/stores/useUIStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { cn } from '@/lib/utils';
-import { copyTextToClipboard } from '@/lib/clipboard';
+import { copyMarkdownToClipboard } from '@/lib/clipboard';
 import { toast } from '@/components/ui';
 import { Icon } from "@/components/icon/Icon";
 import { PROJECT_NOTE_BODY_MAX_LENGTH } from '@/lib/projectContextApi';
@@ -325,14 +325,22 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
   const handleCopy = React.useCallback(async () => {
     if (!selectedText) return;
 
-    const result = await copyTextToClipboard(selectedText);
-    if (!result.ok) {
-      console.error('Failed to copy:', result.error);
+    try {
+      const markdownText = selectedTextMarkdown || selectedText;
+      const { renderMarkdownSync } = await import('../markdown/markdownCore');
+      const result = await copyMarkdownToClipboard(markdownText, renderMarkdownSync(markdownText));
+      if (!result.ok) {
+        console.error('Failed to copy:', result.error);
+        toast.error(t('chat.textSelection.toast.copyFailed'));
+      }
+    } catch (error) {
+      console.error('Failed to copy:', error);
+      toast.error(t('chat.textSelection.toast.copyFailed'));
+    } finally {
+      hideMenu();
+      window.getSelection()?.removeAllRanges();
     }
-
-    hideMenu();
-    window.getSelection()?.removeAllRanges();
-  }, [selectedText, hideMenu]);
+  }, [hideMenu, selectedText, selectedTextMarkdown, t]);
 
   const currentSession = React.useMemo(() => {
     if (!currentSessionId) {

--- a/packages/ui/src/lib/i18n/messages/de.ts
+++ b/packages/ui/src/lib/i18n/messages/de.ts
@@ -2019,6 +2019,7 @@ export const dict = {
   'chat.questionCard.noLongerPending': 'Diese Frage wartet nicht mehr auf eine Antwort.',
   'chat.questionCard.tryAgain': 'Bitte versuchen Sie es in einem Moment erneut.',
   'chat.textSelection.toast.noProject': 'Kein Projekt für diese Sitzung gefunden',
+  'chat.textSelection.toast.copyFailed': 'Fehler beim Kopieren des ausgewählten Textes',
   'chat.textSelection.toast.addToNotesFailed': 'Fehler beim Hinzufügen zu Notizen',
   'chat.textSelection.toast.addToNotesSuccess': 'Ausgewählter Text zu Notizen hinzugefügt',
   'chat.textSelection.toast.addToNotesSummaryFailed': 'Zusammenfassung der Auswahl nicht möglich, ausgewählter Text wurde zu Notizen hinzugefügt',

--- a/packages/ui/src/lib/i18n/messages/de.ts
+++ b/packages/ui/src/lib/i18n/messages/de.ts
@@ -1977,6 +1977,7 @@ export const dict = {
   'chat.questionCard.noLongerPending': 'Diese Frage wartet nicht mehr auf eine Antwort.',
   'chat.questionCard.tryAgain': 'Bitte versuchen Sie es in einem Moment erneut.',
   'chat.textSelection.toast.noProject': 'Kein Projekt für diese Sitzung gefunden',
+  'chat.textSelection.toast.copyFailed': 'Fehler beim Kopieren des ausgewählten Textes',
   'chat.textSelection.toast.addToNotesFailed': 'Fehler beim Hinzufügen zu Notizen',
   'chat.textSelection.toast.addToNotesSuccess': 'Ausgewählter Text zu Notizen hinzugefügt',
   'chat.textSelection.toast.addToNotesSummaryFailed': 'Zusammenfassung der Auswahl nicht möglich, ausgewählter Text wurde zu Notizen hinzugefügt',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2233,6 +2233,7 @@ export const dict = {
   'chat.questionCard.noLongerPending': 'This question is no longer waiting for a response.',
   'chat.questionCard.tryAgain': 'Please try again in a moment.',
   'chat.textSelection.toast.noProject': 'No project found for this session',
+  'chat.textSelection.toast.copyFailed': 'Failed to copy selected text',
   'chat.textSelection.toast.addToNotesFailed': 'Failed to add to notes',
   'chat.textSelection.toast.addToNotesSuccess': 'Added selected text to notes',
   'chat.textSelection.toast.addToNotesSummaryFailed': 'Could not summarize selection, added selected text to notes',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2146,6 +2146,7 @@ export const dict = {
   'chat.questionCard.noLongerPending': 'This question is no longer waiting for a response.',
   'chat.questionCard.tryAgain': 'Please try again in a moment.',
   'chat.textSelection.toast.noProject': 'No project found for this session',
+  'chat.textSelection.toast.copyFailed': 'Failed to copy selected text',
   'chat.textSelection.toast.addToNotesFailed': 'Failed to add to notes',
   'chat.textSelection.toast.addToNotesSuccess': 'Added selected text to notes',
   'chat.textSelection.toast.addToNotesSummaryFailed': 'Could not summarize selection, added selected text to notes',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2211,6 +2211,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.questionCard.noLongerPending": "Esta pregunta ya no espera una respuesta.",
   "chat.questionCard.tryAgain": "Inténtalo de nuevo en un momento.",
   "chat.textSelection.toast.noProject": "No se encontró proyecto para esta sesión",
+  "chat.textSelection.toast.copyFailed": "No se pudo copiar el texto seleccionado",
   "chat.textSelection.toast.addToNotesFailed": "No se pudo añadir a las notas",
   "chat.textSelection.toast.addToNotesSuccess": "Texto seleccionado añadido a notas",
   "chat.textSelection.toast.addToNotesSummaryFailed": "No se pudo resumir la selección; se añadió el texto seleccionado a las notas",

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2124,6 +2124,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.questionCard.noLongerPending": "Esta pregunta ya no espera una respuesta.",
   "chat.questionCard.tryAgain": "Inténtalo de nuevo en un momento.",
   "chat.textSelection.toast.noProject": "No se encontró proyecto para esta sesión",
+  "chat.textSelection.toast.copyFailed": "No se pudo copiar el texto seleccionado",
   "chat.textSelection.toast.addToNotesFailed": "No se pudo añadir a las notas",
   "chat.textSelection.toast.addToNotesSuccess": "Texto seleccionado añadido a notas",
   "chat.textSelection.toast.addToNotesSummaryFailed": "No se pudo resumir la selección; se añadió el texto seleccionado a las notas",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1959,6 +1959,7 @@ export const dict = {
   'chat.questionCard.copiedJson': 'Question copiée sous le nom JSON',
   'chat.questionCard.copyFailed': 'Échec de la copie de la question',
   'chat.textSelection.toast.noProject': 'Aucun projet trouvé pour cette session',
+  'chat.textSelection.toast.copyFailed': 'Échec de la copie du texte sélectionné',
   'chat.textSelection.toast.addToNotesFailed': 'Échec de l\'ajout aux notes',
   'chat.textSelection.toast.addToNotesSuccess': 'Ajout du texte sélectionné aux notes',
   'chat.textSelection.toast.addToNotesSummaryFailed': 'Impossible de résumer la sélection, ajout du texte sélectionné aux notes',

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -1874,6 +1874,7 @@ export const dict = {
   'chat.questionCard.copiedJson': 'Question copiée sous le nom JSON',
   'chat.questionCard.copyFailed': 'Échec de la copie de la question',
   'chat.textSelection.toast.noProject': 'Aucun projet trouvé pour cette session',
+  'chat.textSelection.toast.copyFailed': 'Échec de la copie du texte sélectionné',
   'chat.textSelection.toast.addToNotesFailed': 'Échec de l\'ajout aux notes',
   'chat.textSelection.toast.addToNotesSuccess': 'Ajout du texte sélectionné aux notes',
   'chat.textSelection.toast.addToNotesSummaryFailed': 'Impossible de résumer la sélection, ajout du texte sélectionné aux notes',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2229,6 +2229,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': 'この質問は応答待ちではなくなりました。',
   'chat.questionCard.tryAgain': 'しばらくしてからもう一度お試しください。',
   'chat.textSelection.toast.noProject': 'このセッションのプロジェクトが見つかりません',
+  'chat.textSelection.toast.copyFailed': '選択したテキストのコピーに失敗しました',
   'chat.textSelection.toast.addToNotesFailed': 'メモへの追加に失敗しました',
   'chat.textSelection.toast.addToNotesSuccess': '選択テキストをメモに追加しました',
   'chat.textSelection.toast.addToNotesSummaryFailed': '選択範囲を要約できませんでした。選択テキストをメモに追加しました。',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2142,6 +2142,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': 'この質問は応答待ちではなくなりました。',
   'chat.questionCard.tryAgain': 'しばらくしてからもう一度お試しください。',
   'chat.textSelection.toast.noProject': 'このセッションのプロジェクトが見つかりません',
+  'chat.textSelection.toast.copyFailed': '選択したテキストのコピーに失敗しました',
   'chat.textSelection.toast.addToNotesFailed': 'メモへの追加に失敗しました',
   'chat.textSelection.toast.addToNotesSuccess': '選択テキストをメモに追加しました',
   'chat.textSelection.toast.addToNotesSummaryFailed': '選択範囲を要約できませんでした。選択テキストをメモに追加しました。',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2235,6 +2235,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': '이 질문은 더 이상 응답을 기다리지 않습니다.',
   'chat.questionCard.tryAgain': '잠시 후 다시 시도하세요.',
   'chat.textSelection.toast.noProject': '이 세션의 프로젝트를 찾을 수 없음',
+  'chat.textSelection.toast.copyFailed': '선택한 텍스트를 복사하지 못했습니다',
   'chat.textSelection.toast.addToNotesFailed': '메모 추가 실패',
   'chat.textSelection.toast.addToNotesSuccess': '선택한 텍스트를 메모에 추가함',
   'chat.textSelection.toast.addToNotesSummaryFailed': '선택 영역을 요약할 수 없어 선택한 텍스트를 메모에 추가함',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2148,6 +2148,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': '이 질문은 더 이상 응답을 기다리지 않습니다.',
   'chat.questionCard.tryAgain': '잠시 후 다시 시도하세요.',
   'chat.textSelection.toast.noProject': '이 세션의 프로젝트를 찾을 수 없음',
+  'chat.textSelection.toast.copyFailed': '선택한 텍스트를 복사하지 못했습니다',
   'chat.textSelection.toast.addToNotesFailed': '메모 추가 실패',
   'chat.textSelection.toast.addToNotesSuccess': '선택한 텍스트를 메모에 추가함',
   'chat.textSelection.toast.addToNotesSummaryFailed': '선택 영역을 요약할 수 없어 선택한 텍스트를 메모에 추가함',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -912,6 +912,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': 'To pytanie nie czeka już na odpowiedź.',
   'chat.questionCard.tryAgain': 'Spróbuj ponownie za chwilę.',
   'chat.textSelection.toast.noProject': 'Nie znaleziono projektu dla tej sesji',
+  'chat.textSelection.toast.copyFailed': 'Nie udało się skopiować zaznaczonego tekstu',
   'chat.textSelection.toast.addToNotesFailed': 'Nie udało się dodać do notatek',
   'chat.textSelection.toast.addToNotesSuccess': 'Dodano zaznaczony tekst do notatek',
   'chat.textSelection.toast.addToNotesSummaryFailed': 'Nie można podsumować zaznaczenia, dodano wybrany tekst do notatek',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -851,6 +851,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': 'To pytanie nie czeka już na odpowiedź.',
   'chat.questionCard.tryAgain': 'Spróbuj ponownie za chwilę.',
   'chat.textSelection.toast.noProject': 'Nie znaleziono projektu dla tej sesji',
+  'chat.textSelection.toast.copyFailed': 'Nie udało się skopiować zaznaczonego tekstu',
   'chat.textSelection.toast.addToNotesFailed': 'Nie udało się dodać do notatek',
   'chat.textSelection.toast.addToNotesSuccess': 'Dodano zaznaczony tekst do notatek',
   'chat.textSelection.toast.addToNotesSummaryFailed': 'Nie można podsumować zaznaczenia, dodano wybrany tekst do notatek',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2211,6 +2211,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.questionCard.noLongerPending": "Esta pergunta não está mais aguardando uma resposta.",
   "chat.questionCard.tryAgain": "Tente novamente em instantes.",
   "chat.textSelection.toast.noProject": "Não foi encontrado projeto para esta sessão",
+  "chat.textSelection.toast.copyFailed": "Não foi possível copiar o texto selecionado",
   "chat.textSelection.toast.addToNotesFailed": "Não foi possível adicionar às notas",
   "chat.textSelection.toast.addToNotesSuccess": "Texto selecionado adicionado às notas",
   "chat.textSelection.toast.addToNotesSummaryFailed": "Não foi possível resumir a seleção; o texto selecionado foi adicionado às notas",

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2124,6 +2124,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.questionCard.noLongerPending": "Esta pergunta não está mais aguardando uma resposta.",
   "chat.questionCard.tryAgain": "Tente novamente em instantes.",
   "chat.textSelection.toast.noProject": "Não foi encontrado projeto para esta sessão",
+  "chat.textSelection.toast.copyFailed": "Não foi possível copiar o texto selecionado",
   "chat.textSelection.toast.addToNotesFailed": "Não foi possível adicionar às notas",
   "chat.textSelection.toast.addToNotesSuccess": "Texto selecionado adicionado às notas",
   "chat.textSelection.toast.addToNotesSummaryFailed": "Não foi possível resumir a seleção; o texto selecionado foi adicionado às notas",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2211,6 +2211,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.questionCard.noLongerPending": "Це питання більше не очікує відповіді.",
   "chat.questionCard.tryAgain": "Спробуйте ще раз за мить.",
   "chat.textSelection.toast.noProject": "Для цієї сесії не знайдено жодного проєкту",
+  "chat.textSelection.toast.copyFailed": "Не вдалося скопіювати вибраний текст",
   "chat.textSelection.toast.addToNotesFailed": "Не вдалося додати до нотаток",
   "chat.textSelection.toast.addToNotesSuccess": "Вибраний текст додано до нотаток",
   "chat.textSelection.toast.addToNotesSummaryFailed": "Не вдалося підсумувати виділення, виділений текст додано до нотаток",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2124,6 +2124,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.questionCard.noLongerPending": "Це питання більше не очікує відповіді.",
   "chat.questionCard.tryAgain": "Спробуйте ще раз за мить.",
   "chat.textSelection.toast.noProject": "Для цієї сесії не знайдено жодного проєкту",
+  "chat.textSelection.toast.copyFailed": "Не вдалося скопіювати вибраний текст",
   "chat.textSelection.toast.addToNotesFailed": "Не вдалося додати до нотаток",
   "chat.textSelection.toast.addToNotesSuccess": "Вибраний текст додано до нотаток",
   "chat.textSelection.toast.addToNotesSummaryFailed": "Не вдалося підсумувати виділення, виділений текст додано до нотаток",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2199,6 +2199,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': '此问题不再等待回答。',
   'chat.questionCard.tryAgain': '请稍后重试。',
   'chat.textSelection.toast.noProject': '未找到此会话对应的项目',
+  'chat.textSelection.toast.copyFailed': '复制选中文本失败',
   'chat.textSelection.toast.addToNotesFailed': '添加到笔记失败',
   'chat.textSelection.toast.addToNotesSuccess': '已将选中文本添加到笔记',
   'chat.textSelection.toast.addToNotesSummaryFailed': '无法总结所选内容，已将所选文本添加到笔记',

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2112,6 +2112,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': '此问题不再等待回答。',
   'chat.questionCard.tryAgain': '请稍后重试。',
   'chat.textSelection.toast.noProject': '未找到此会话对应的项目',
+  'chat.textSelection.toast.copyFailed': '复制选中文本失败',
   'chat.textSelection.toast.addToNotesFailed': '添加到笔记失败',
   'chat.textSelection.toast.addToNotesSuccess': '已将选中文本添加到笔记',
   'chat.textSelection.toast.addToNotesSummaryFailed': '无法总结所选内容，已将所选文本添加到笔记',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2203,6 +2203,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': '此問題不再等待回答。',
   'chat.questionCard.tryAgain': '請稍後再試。',
   'chat.textSelection.toast.noProject': '找不到此會話對應的專案',
+  'chat.textSelection.toast.copyFailed': '複製選取文字失敗',
   'chat.textSelection.toast.addToNotesFailed': '加入筆記失敗',
   'chat.textSelection.toast.addToNotesSuccess': '已將選取文字加入筆記',
   'chat.textSelection.toast.addToNotesSummaryFailed': '無法總結所選內容，已將所選文字加入筆記',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2116,6 +2116,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.questionCard.noLongerPending': '此問題不再等待回答。',
   'chat.questionCard.tryAgain': '請稍後再試。',
   'chat.textSelection.toast.noProject': '找不到此會話對應的專案',
+  'chat.textSelection.toast.copyFailed': '複製選取文字失敗',
   'chat.textSelection.toast.addToNotesFailed': '加入筆記失敗',
   'chat.textSelection.toast.addToNotesSuccess': '已將選取文字加入筆記',
   'chat.textSelection.toast.addToNotesSummaryFailed': '無法總結所選內容，已將所選文字加入筆記',


### PR DESCRIPTION
## Intent

Fixes #2840.

The in-app text-selection Copy action now uses the selected Markdown source and writes rich clipboard formats consistently with full-message copy.

## Non-goals

- Native Ctrl/Cmd+C and right-click browser copy remain native browser behavior; this change fixes the shared in-app Copy action.
- No new clipboard API, runtime-specific bridge, dependency, or public contract.
- No visual redesign of the selection menu.

## Affected surfaces

- `packages/ui/src/components/chat/message/TextSelectionMenu.tsx`: shared selection Copy action, failure cleanup, and localized feedback.
- `packages/ui/src/components/chat/message/TextSelectionMenu.test.tsx`: real component regression coverage.
- `packages/ui/src/lib/i18n/messages/*.ts`: the 11 runtime locale dictionaries.
- Shared web, desktop, mobile, and VS Code surfaces that use `TextSelectionMenu` and the existing clipboard helper.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Shared React UI and clipboard behavior | Reuses existing components/helpers, keeps failure explicit, avoids raw internal error text, and preserves runtime parity. |
| `CONTRIBUTING.md` | Pull-request handoff, validation, and visual-evidence contract | All required handoff sections and exact validation results are included below. |
| `locale-ui-patterns` | Adds a user-facing copy-failure toast | Adds `chat.textSelection.toast.copyFailed` with real translations in all 11 runtime dictionaries and parity coverage. |
| `ui-api-decoupling` | Clipboard is a shared runtime capability | Uses `copyMarkdownToClipboard` and its existing fallback contract; no direct runtime API or raw endpoint was added. |
| `packages/ui/src/lib/clipboard.ts` and `markdownCore.ts` | Existing clipboard/Markdown sources of truth | The selection path now matches the full-message `text/plain`/`text/markdown`/`text/html` flow. |
| `changelog-authoring` | Adds an Unreleased user-visible entry | Entry placement and contributor credit follow current changelog style. |

## Validation

```text
bun test packages/ui/src/components/chat/message/TextSelectionMenu.test.tsx — 2 passed
bun test packages/ui/src/lib/clipboard.test.ts — 2 passed
bun test packages/ui/src/components/chat/message/selectionMarkdown.test.ts — 9 passed
bun test packages/ui/src/components/chat/message/parts/UserTextPart.test.ts — 4 passed
Isolated chat + i18n suites — passed (61/61 files)
bun run type-check:ui — passed
bun run lint:ui — passed
bunx oxlint on changed UI paths — existing baseline findings only in unchanged TextSelectionMenu lines
bun run dead-code — completed with the existing repository-wide backlog
git diff --check — passed
```

## Visual evidence

No browser screenshot was captured. The real `TextSelectionMenu` component is mounted in the isolated DOM harness, the mobile Copy button is invoked, and clipboard payload, toast, menu cleanup, and selection clearing are asserted.

## Risks and failure behavior

- The shared clipboard helper remains the source of truth and falls back consistently on runtimes without `ClipboardItem`.
- Rendering or clipboard failure shows a localized toast, logs the diagnostic, and always clears the menu/selection in `finally`.

