### PR TITLE
fix(chat): preserve Markdown spacing in copied replies (#2867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Chat: copying assistant replies as Markdown now preserves paragraph, list, and code-block spacing.
+- Chat: copying assistant replies as Markdown now preserves paragraph, list, and code-block spacing (thanks to @bashrusakh).
 - Chat: if OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
 
 ## [1.19.0] - 2026-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Chat: copying assistant replies as Markdown now preserves paragraph, list, and code-block spacing.
 - Chat: if OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
 
 ## [1.19.0] - 2026-08-19

--- a/packages/ui/src/lib/messages/messageText.clipboard.test.ts
+++ b/packages/ui/src/lib/messages/messageText.clipboard.test.ts
@@ -33,6 +33,7 @@ afterEach(() => {
   restoreGlobal('ClipboardItem', originalClipboardItem);
 });
 
+// SAFETY: each mapped fixture supplies every required SDK TextPart field, and its `type: 'text'` discriminant selects that Part variant.
 const textParts = (texts: string[]): Part[] => texts.map((text, index) => ({
   id: `part-${index}`,
   sessionID: 'session-1',

--- a/packages/ui/src/lib/messages/messageText.clipboard.test.ts
+++ b/packages/ui/src/lib/messages/messageText.clipboard.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import type { Part } from '@opencode-ai/sdk/v2';
+
+mock.module('dompurify', () => ({
+  default: {
+    isSupported: true,
+    addHook: () => undefined,
+    sanitize: (html: string) => html,
+  },
+}));
+mock.module('../../components/chat/markdown/markdown-worker', () => ({
+  highlightCodeInWorker: async () => null,
+}));
+
+import { copyMarkdownToClipboard } from '../clipboard';
+import { flattenAssistantTextParts } from './messageText';
+
+const { renderMarkdownSync } = await import('../../components/chat/markdown/markdownCore');
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+const originalClipboardItem = Object.getOwnPropertyDescriptor(globalThis, 'ClipboardItem');
+
+const restoreGlobal = (name: 'navigator' | 'ClipboardItem', descriptor?: PropertyDescriptor): void => {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, name);
+  }
+};
+
+afterEach(() => {
+  restoreGlobal('navigator', originalNavigator);
+  restoreGlobal('ClipboardItem', originalClipboardItem);
+});
+
+const textParts = (texts: string[]): Part[] => texts.map((text, index) => ({
+  id: `part-${index}`,
+  sessionID: 'session-1',
+  messageID: 'message-1',
+  type: 'text',
+  text,
+} as Part));
+
+describe('assistant Markdown clipboard payload', () => {
+  test('carries preserved block separation into each clipboard format', async () => {
+    let writtenItem: { data: Record<string, Blob> } | undefined;
+    class FakeClipboardItem {
+      static supports(type: string): boolean {
+        return type === 'text/markdown';
+      }
+
+      readonly data: Record<string, Blob>;
+
+      constructor(data: Record<string, Blob>) {
+        this.data = data;
+      }
+    }
+
+    Object.defineProperty(globalThis, 'ClipboardItem', { configurable: true, value: FakeClipboardItem });
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        clipboard: {
+          write: async (items: Array<{ data: Record<string, Blob> }>) => {
+            writtenItem = items[0];
+          },
+        },
+      },
+    });
+
+    const markdown = flattenAssistantTextParts(textParts([
+      'First paragraph',
+      'Second paragraph',
+      '```ts\nconst value = 1;\n```',
+      '- item 1\n- item 2',
+    ]));
+    const html = renderMarkdownSync(markdown);
+
+    expect(html).toContain('<p>First paragraph</p>');
+    expect(html).toContain('<p>Second paragraph</p>');
+    expect(html).toContain('<pre><code class="language-ts">const value = 1;\n</code></pre>');
+    expect(html).toContain('<ul>\n<li>item 1</li>\n<li>item 2</li>\n</ul>');
+
+    const result = await copyMarkdownToClipboard(markdown, html);
+    const plain = await writtenItem?.data['text/plain']?.text();
+    const markdownText = await writtenItem?.data['text/markdown']?.text();
+    const htmlText = await writtenItem?.data['text/html']?.text();
+
+    expect(result).toEqual({ ok: true, method: 'clipboard' });
+    expect(Object.keys(writtenItem?.data ?? {}).sort()).toEqual(['text/html', 'text/markdown', 'text/plain']);
+    expect(plain).toBe(markdown);
+    expect(markdownText).toBe(markdown);
+    expect(htmlText).toBe(html);
+  });
+});

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -1,122 +1,125 @@
 import { describe, expect, test } from 'bun:test';
-
 import type { Part } from '@opencode-ai/sdk/v2';
-import { flattenAssistantTextParts, flattenUserTextParts } from './messageText';
 
-// Regression tests for https://github.com/openchamber/openchamber/issues/2867
-//
-// `flattenAssistantTextParts` used to collapse every blank line into a single
-// `\n`. Markdown block structure (paragraphs, lists, fenced code blocks)
-// requires a blank line (`\n\n`); a single `\n` is a CommonMark soft break.
-// `ChatMessage.tsx`'s `handleCopyMessage` feeds the flattened string into
-// `copyMarkdownToClipboard`, which writes it to `text/plain`, `text/markdown`
-// and its markdown-rendered HTML into `text/html`.
+import { flattenAssistantTextParts, suggestPlanTitleFromText } from './messageText';
 
-const basePart = (overrides: Record<string, unknown>): Part =>
-  ({
-    id: 'p1',
-    sessionID: 's',
-    messageID: 'm',
-    type: 'text',
-    text: '',
-    ...overrides,
-  }) as Part;
+const textPart = (id: string, text: string): Part => ({
+  id,
+  sessionID: 'session-1',
+  messageID: 'message-1',
+  type: 'text',
+  text,
+} as Part);
 
-const makeParts = (texts: string[]): Part[] =>
-  texts.map((text, index) => basePart({ id: `p${index}`, text }));
-
-const makeUserParts = (
-  entries: Array<{ text?: string; shellAction?: { output?: unknown; command?: unknown } }>,
-): Part[] =>
-  entries.map((entry, index) =>
-    basePart({ id: `u${index}`, text: entry.text ?? '', shellAction: entry.shellAction }),
-  );
+const textParts = (...texts: string[]): Part[] => texts.map((text, index) => textPart(`part-${index}`, text));
 
 describe('flattenAssistantTextParts', () => {
-  const parts = makeParts([
-    '第一段',
-    '第二段',
-    '```js\nconsole.log(1)\n```',
-    '第三段',
-    '- item 1\n- item 2',
-  ]);
+  test('preserves fenced-code blank lines while normalizing Markdown boundaries', () => {
+    expect(flattenAssistantTextParts(textParts(
+      'First paragraph',
+      '- item 1\n- item 2',
+      '```ts\nconst first = 1;\n\n  \n\nconst second = 2;\n```\n\n\n\nFollowing paragraph',
+    ))).toBe([
+      'First paragraph',
+      '- item 1\n- item 2',
+      '```ts\nconst first = 1;\n\n  \n\nconst second = 2;\n```',
+      'Following paragraph',
+    ].join('\n\n'));
+  });
 
-  test('blank lines between paragraphs/code blocks/lists are preserved', () => {
-    expect(flattenAssistantTextParts(parts)).toBe(
-      '第一段\n\n第二段\n\n```js\nconsole.log(1)\n```\n\n第三段\n\n- item 1\n- item 2',
+  test('recognizes tilde fences as code boundaries', () => {
+    expect(flattenAssistantTextParts(textParts(
+      'Before\n\n\n~~~text\nfirst\n\n\nsecond\n~~~\n\n\nAfter',
+    ))).toBe('Before\n\n~~~text\nfirst\n\n\nsecond\n~~~\n\nAfter');
+  });
+
+  test('normalizes CRLF line endings in paragraphs and fenced code', () => {
+    expect(flattenAssistantTextParts(textParts(
+      'First paragraph\r\n\r\nSecond paragraph\r\n\r\n```ts\r\nconst first = 1;\r\n\r\nconst second = 2;\r\n```\r\n\r\nFollowing paragraph',
+    ))).toBe([
+      'First paragraph',
+      '',
+      'Second paragraph',
+      '',
+      '```ts',
+      'const first = 1;',
+      '',
+      'const second = 2;',
+      '```',
+      '',
+      'Following paragraph',
+    ].join('\n'));
+  });
+
+  test('keeps one blank line at each text-part boundary', () => {
+    expect(flattenAssistantTextParts(textParts('First paragraph', 'Second paragraph')))
+      .toBe('First paragraph\n\nSecond paragraph');
+  });
+
+  test('collapses excessive blank-line runs to one blank line', () => {
+    expect(flattenAssistantTextParts(textParts('First\n\n\n\nSecond\n \n\n\nThird')))
+      .toBe('First\n\nSecond\n\nThird');
+  });
+
+  test('normalizes blank lines in list continuations', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '- item\n    continuation\n\n\n\n    next continuation',
+    ))).toBe('- item\n    continuation\n\n    next continuation');
+  });
+
+  test('preserves blank lines in indented code blocks', () => {
+    expect(flattenAssistantTextParts(textParts(
+      'Before\n\n\n\n    const first = 1;\n\n\n\n    const second = 2;\n\n\n\nAfter',
+    ))).toBe(
+      'Before\n\n    const first = 1;\n\n\n\n    const second = 2;\n\nAfter',
     );
   });
 
-  test('a code fence is not glued to the following paragraph', () => {
-    const flattened = flattenAssistantTextParts(parts);
-    expect(flattened).not.toContain('```\n第三段');
-    expect(flattened).toContain('```\n\n第三段');
+  test('preserves blank lines in mixed-space/tab indented code blocks', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '   \tconst first = 1;\n\n\n\n   \tconst second = 2',
+    ))).toBe('   \tconst first = 1;\n\n\n\n   \tconst second = 2');
   });
 
-  test('list items keep single newlines inside their part', () => {
-    expect(flattenAssistantTextParts(parts)).toContain('\n\n- item 1\n- item 2');
+  test('treats a tab-indented fence-like block as indented code', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '\t```\n\n\n\tconst value = 1;\n\n\n\nAfter',
+    ))).toBe('\t```\n\n\n\tconst value = 1;\n\nAfter');
   });
 
-  test('internal blank-line runs are preserved', () => {
-    const text = 'a\n\n\n\nb\n \n \nd';
-    expect(flattenAssistantTextParts(makeParts([text]))).toBe(text);
+  test('preserves indentation on leading indented code', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '\n\n    const first = 1;\n\n    const second = 2\n\n',
+    ))).toBe('    const first = 1;\n\n    const second = 2');
   });
 
-  test('multiple blank lines inside a fenced code block are preserved', () => {
-    const fenced = '```js\na\n\n\nb\n```';
-    expect(flattenAssistantTextParts(makeParts([fenced]))).toBe(fenced);
+  test('preserves indentation when a fenced block spans text parts', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '```ts\n',
+      '\n    const value = 1;\n```',
+    ))).toBe('```ts\n\n    const value = 1;\n```');
   });
 
-  test('part boundaries produce block separators', () => {
-    expect(flattenAssistantTextParts(makeParts(['first', 'second']))).toBe('first\n\nsecond');
-  });
-
-  test('empty and whitespace-only parts are dropped', () => {
-    expect(flattenAssistantTextParts([])).toBe('');
-    expect(flattenAssistantTextParts(makeParts(['', '   ', '\n']))).toBe('');
-  });
-
-  test('single part without blank lines is returned unchanged', () => {
-    const single = 'only line\nsecond line';
-    expect(flattenAssistantTextParts(makeParts([single]))).toBe(single);
-  });
-
-  test('non-text parts are ignored', () => {
-    const partsWithTool: Part[] = [
-      ...makeParts(['before']),
-      { id: 't1', sessionID: 's', messageID: 'm', type: 'tool', tool: 'bash' } as Part,
-      ...makeParts(['after']),
-    ];
-    expect(flattenAssistantTextParts(partsWithTool)).toBe('before\n\nafter');
+  test('preserves multiple fenced-code blank lines split across text parts', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '```ts\nconst first = 1;\n',
+      '\n\n',
+      '\nconst second = 2;\n```',
+    ))).toBe([
+      '```ts',
+      'const first = 1;',
+      '',
+      '',
+      '',
+      'const second = 2;',
+      '```',
+    ].join('\n'));
   });
 });
 
-describe('flattenUserTextParts', () => {
-  test('plain text parts keep blank-line block separators', () => {
-    const parts = makeUserParts([{ text: '第一段\n\n\n第二段' }, { text: '下一段' }]);
-    expect(flattenUserTextParts(parts)).toBe('第一段\n\n\n第二段\n\n下一段');
-  });
-
-  test('shell outputs win over other content and are joined with blank lines', () => {
-    const parts = makeUserParts([
-      { text: 'note', shellAction: { command: 'ls -la' } },
-      { text: '', shellAction: { output: '  file-a\nfile-b  ' } },
-      { text: '', shellAction: { output: 'done' } },
-    ]);
-    expect(flattenUserTextParts(parts)).toBe('file-a\nfile-b\n\ndone');
-  });
-
-  test('shell commands fall back to a single-newline command list', () => {
-    const parts = makeUserParts([
-      { shellAction: { command: ' bun install ' } },
-      { shellAction: { command: 'bun test' } },
-      { text: 'ignored when commands exist' },
-    ]);
-    expect(flattenUserTextParts(parts)).toBe('bun install\nbun test');
-  });
-
-  test('returns empty string for parts without text', () => {
-    expect(flattenUserTextParts([])).toBe('');
-    expect(flattenUserTextParts(makeUserParts([{ text: '  ' }]))).toBe('');
+describe('suggestPlanTitleFromText', () => {
+  test('keeps deriving a title from the first non-empty line', () => {
+    expect(suggestPlanTitleFromText('\n\n## Preserve Markdown spacing\n\nMore detail'))
+      .toBe('Preserve Markdown spacing');
   });
 });

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -3,6 +3,7 @@ import type { Part } from '@opencode-ai/sdk/v2';
 
 import { flattenAssistantTextParts, suggestPlanTitleFromText } from './messageText';
 
+// SAFETY: the fixture supplies every required SDK TextPart field, and its `type: 'text'` discriminant selects that Part variant.
 const textPart = (id: string, text: string): Part => ({
   id,
   sessionID: 'session-1',

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -56,6 +56,20 @@ describe('flattenAssistantTextParts', () => {
       .toBe('First paragraph\n\nSecond paragraph');
   });
 
+  test('does not add a blank line when a fenced block splits without a newline', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '```ts',
+      'const value = 1;\n```',
+    ))).toBe('```ts\nconst value = 1;\n```');
+  });
+
+  test('does not add a blank line when an indented code block splits without a newline', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '    const first = 1;',
+      '    const second = 2;',
+    ))).toBe('    const first = 1;\n    const second = 2;');
+  });
+
   test('collapses excessive blank-line runs to one blank line', () => {
     expect(flattenAssistantTextParts(textParts('First\n\n\n\nSecond\n \n\n\nThird')))
       .toBe('First\n\nSecond\n\nThird');

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { Part } from '@opencode-ai/sdk/v2';
 
-import { flattenAssistantTextParts, suggestPlanTitleFromText } from './messageText';
+import { flattenAssistantTextParts, flattenUserTextParts, suggestPlanTitleFromText } from './messageText';
 
 // SAFETY: the fixture supplies every required SDK TextPart field, and its `type: 'text'` discriminant selects that Part variant.
 const textPart = (id: string, text: string): Part => ({
@@ -13,6 +13,12 @@ const textPart = (id: string, text: string): Part => ({
 } as Part);
 
 const textParts = (...texts: string[]): Part[] => texts.map((text, index) => textPart(`part-${index}`, text));
+
+// SAFETY: shellAction is the existing display-only bridge property attached to text parts by MessageList.
+const shellPart = (id: string, shellAction: { output?: string; command?: string }): Part => ({
+  ...textPart(id, ''),
+  shellAction,
+} as Part);
 
 describe('flattenAssistantTextParts', () => {
   test('preserves fenced-code blank lines while normalizing Markdown boundaries', () => {
@@ -129,6 +135,39 @@ describe('flattenAssistantTextParts', () => {
       'const second = 2;',
       '```',
     ].join('\n'));
+  });
+});
+
+describe('flattenUserTextParts', () => {
+  test('keeps plain text block separators', () => {
+    expect(flattenUserTextParts(textParts('First paragraph\n\n\nSecond paragraph', 'Next paragraph')))
+      .toBe('First paragraph\n\n\nSecond paragraph\n\nNext paragraph');
+  });
+
+  test('prefers shell output and joins separate outputs with blank lines', () => {
+    const parts = [
+      textPart('plain', 'ignored when shell output exists'),
+      shellPart('shell-command', { command: 'ls -la' }),
+      shellPart('shell-output-1', { output: '  file-a\nfile-b  ' }),
+      shellPart('shell-output-2', { output: 'done' }),
+    ];
+
+    expect(flattenUserTextParts(parts)).toBe('file-a\nfile-b\n\ndone');
+  });
+
+  test('falls back to shell commands when no output is available', () => {
+    const parts = [
+      shellPart('command-1', { command: ' bun install ' }),
+      shellPart('command-2', { command: 'bun test' }),
+      textPart('plain', 'ignored when commands exist'),
+    ];
+
+    expect(flattenUserTextParts(parts)).toBe('bun install\nbun test');
+  });
+
+  test('returns empty text when no visible text parts exist', () => {
+    expect(flattenUserTextParts([])).toBe('');
+    expect(flattenUserTextParts(textParts('  '))).toBe('');
   });
 });
 

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -4,21 +4,22 @@ import type { Part } from '@opencode-ai/sdk/v2';
 import { flattenAssistantTextParts, flattenUserTextParts, suggestPlanTitleFromText } from './messageText';
 
 // SAFETY: the fixture supplies every required SDK TextPart field, and its `type: 'text'` discriminant selects that Part variant.
-const textPart = (id: string, text: string): Part => ({
-  id,
-  sessionID: 'session-1',
-  messageID: 'message-1',
+const basePart = (overrides: Record<string, unknown>): Part => ({
+  id: 'p1',
+  sessionID: 's',
+  messageID: 'm',
   type: 'text',
-  text,
+  text: '',
+  ...overrides,
 } as Part);
+
+const textPart = (id: string, text: string): Part => basePart({ id, text });
 
 const textParts = (...texts: string[]): Part[] => texts.map((text, index) => textPart(`part-${index}`, text));
 
 // SAFETY: shellAction is the existing display-only bridge property attached to text parts by MessageList.
-const shellPart = (id: string, shellAction: { output?: string; command?: string }): Part => ({
-  ...textPart(id, ''),
-  shellAction,
-} as Part);
+const shellPart = (id: string, shellAction: { output?: string; command?: string }): Part =>
+  basePart({ id, shellAction });
 
 describe('flattenAssistantTextParts', () => {
   test('preserves fenced-code blank lines while normalizing Markdown boundaries', () => {

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+import type { Part } from '@opencode-ai/sdk/v2';
+
+import { flattenAssistantTextParts, suggestPlanTitleFromText } from './messageText';
+
+const textPart = (id: string, text: string): Part => ({
+  id,
+  sessionID: 'session-1',
+  messageID: 'message-1',
+  type: 'text',
+  text,
+} as Part);
+
+const textParts = (...texts: string[]): Part[] => texts.map((text, index) => textPart(`part-${index}`, text));
+
+describe('flattenAssistantTextParts', () => {
+  test('preserves fenced-code blank lines while normalizing Markdown boundaries', () => {
+    expect(flattenAssistantTextParts(textParts(
+      'First paragraph',
+      '- item 1\n- item 2',
+      '```ts\nconst first = 1;\n\n  \n\nconst second = 2;\n```\n\n\n\nFollowing paragraph',
+    ))).toBe([
+      'First paragraph',
+      '- item 1\n- item 2',
+      '```ts\nconst first = 1;\n\n  \n\nconst second = 2;\n```',
+      'Following paragraph',
+    ].join('\n\n'));
+  });
+
+  test('recognizes tilde fences as code boundaries', () => {
+    expect(flattenAssistantTextParts(textParts(
+      'Before\n\n\n~~~text\nfirst\n\n\nsecond\n~~~\n\n\nAfter',
+    ))).toBe('Before\n\n~~~text\nfirst\n\n\nsecond\n~~~\n\nAfter');
+  });
+
+  test('normalizes CRLF line endings in paragraphs and fenced code', () => {
+    expect(flattenAssistantTextParts(textParts(
+      'First paragraph\r\n\r\nSecond paragraph\r\n\r\n```ts\r\nconst first = 1;\r\n\r\nconst second = 2;\r\n```\r\n\r\nFollowing paragraph',
+    ))).toBe([
+      'First paragraph',
+      '',
+      'Second paragraph',
+      '',
+      '```ts',
+      'const first = 1;',
+      '',
+      'const second = 2;',
+      '```',
+      '',
+      'Following paragraph',
+    ].join('\n'));
+  });
+
+  test('keeps one blank line at each text-part boundary', () => {
+    expect(flattenAssistantTextParts(textParts('First paragraph', 'Second paragraph')))
+      .toBe('First paragraph\n\nSecond paragraph');
+  });
+
+  test('collapses excessive blank-line runs to one blank line', () => {
+    expect(flattenAssistantTextParts(textParts('First\n\n\n\nSecond\n \n\n\nThird')))
+      .toBe('First\n\nSecond\n\nThird');
+  });
+
+  test('normalizes blank lines in list continuations', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '- item\n    continuation\n\n\n\n    next continuation',
+    ))).toBe('- item\n    continuation\n\n    next continuation');
+  });
+
+  test('preserves blank lines in indented code blocks', () => {
+    expect(flattenAssistantTextParts(textParts(
+      'Before\n\n\n\n    const first = 1;\n\n\n\n    const second = 2;\n\n\n\nAfter',
+    ))).toBe(
+      'Before\n\n    const first = 1;\n\n\n\n    const second = 2;\n\nAfter',
+    );
+  });
+
+  test('preserves blank lines in mixed-space/tab indented code blocks', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '   \tconst first = 1;\n\n\n\n   \tconst second = 2',
+    ))).toBe('   \tconst first = 1;\n\n\n\n   \tconst second = 2');
+  });
+
+  test('treats a tab-indented fence-like block as indented code', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '\t```\n\n\n\tconst value = 1;\n\n\n\nAfter',
+    ))).toBe('\t```\n\n\n\tconst value = 1;\n\nAfter');
+  });
+
+  test('preserves indentation on leading indented code', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '\n\n    const first = 1;\n\n    const second = 2\n\n',
+    ))).toBe('    const first = 1;\n\n    const second = 2');
+  });
+
+  test('preserves indentation when a fenced block spans text parts', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '```ts\n',
+      '\n    const value = 1;\n```',
+    ))).toBe('```ts\n\n    const value = 1;\n```');
+  });
+
+  test('preserves multiple fenced-code blank lines split across text parts', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '```ts\nconst first = 1;\n',
+      '\n\n',
+      '\nconst second = 2;\n```',
+    ))).toBe([
+      '```ts',
+      'const first = 1;',
+      '',
+      '',
+      '',
+      'const second = 2;',
+      '```',
+    ].join('\n'));
+  });
+});
+
+describe('suggestPlanTitleFromText', () => {
+  test('keeps deriving a title from the first non-empty line', () => {
+    expect(suggestPlanTitleFromText('\n\n## Preserve Markdown spacing\n\nMore detail'))
+      .toBe('Preserve Markdown spacing');
+  });
+});

--- a/packages/ui/src/lib/messages/messageText.test.ts
+++ b/packages/ui/src/lib/messages/messageText.test.ts
@@ -89,6 +89,54 @@ describe('flattenAssistantTextParts', () => {
     ))).toBe('- item\n    continuation\n\n    next continuation');
   });
 
+  test('recognizes a fence indented relative to its enclosing list item', () => {
+    expect(flattenAssistantTextParts(textParts(
+      '- item\n\n    ```ts\n    a\n\n\n\n    b\n    ```\n\n    after',
+    ))).toBe('- item\n\n    ```ts\n    a\n\n\n\n    b\n    ```\n\n    after');
+  });
+
+  test('recognizes a nested-list fence relative to the innermost list item', () => {
+    const nested = [
+      '- outer',
+      '',
+      '    - inner',
+      '',
+      '        ```ts',
+      '        a',
+      '',
+      '',
+      '',
+      '',
+      '        b',
+      '        ```',
+      '',
+      '    after inner',
+      '',
+      '',
+      '',
+      '    last line',
+    ].join('\n');
+
+    expect(flattenAssistantTextParts(textParts(nested))).toBe([
+      '- outer',
+      '',
+      '    - inner',
+      '',
+      '        ```ts',
+      '        a',
+      '',
+      '',
+      '',
+      '',
+      '        b',
+      '        ```',
+      '',
+      '    after inner',
+      '',
+      '    last line',
+    ].join('\n'));
+  });
+
   test('preserves blank lines in indented code blocks', () => {
     expect(flattenAssistantTextParts(textParts(
       'Before\n\n\n\n    const first = 1;\n\n\n\n    const second = 2;\n\n\n\nAfter',
@@ -136,6 +184,27 @@ describe('flattenAssistantTextParts', () => {
       'const second = 2;',
       '```',
     ].join('\n'));
+  });
+
+  test('joins a large streamed part list without rescanning the accumulated text', () => {
+    const texts = Array.from({ length: 1000 }, (_, index) => {
+      let text = `Segment ${index}: `;
+      while (text.length < 119) text += 'markdown text ';
+      return text;
+    });
+    const parts = textParts(...texts);
+    const expected = texts.join('\n\n');
+
+    flattenAssistantTextParts(parts.slice(0, 50));
+
+    const startedAt = performance.now();
+    const joined = flattenAssistantTextParts(parts);
+    const elapsed = performance.now() - startedAt;
+
+    expect(joined).toBe(expected);
+    // Rescanning the accumulated text at every part boundary is quadratic (~2s here);
+    // the incremental scanner keeps this input in the tens of milliseconds.
+    expect(elapsed).toBeLessThan(1000);
   });
 });
 

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -3,42 +3,243 @@ import type { Part } from '@opencode-ai/sdk/v2';
 type TextLikePart = Part & { text?: string; content?: string };
 type UserTextPart = Part & { text?: string; content?: string; shellAction?: { output?: unknown; command?: unknown } };
 
+type MarkdownFence = {
+    character: '`' | '~';
+    length: number;
+};
+
+type MarkdownListItem = {
+    markerIndent: number;
+    contentIndent: number;
+    codeIndent: number;
+};
+
+const getIndentWidth = (indentation: string): number => {
+    let width = 0;
+    for (const character of indentation) {
+        width += character === '\t' ? 4 - (width % 4) : 1;
+    }
+    return width;
+};
+
+const FENCE_OPEN_RE = /^([ \t]*)(`{3,}|~{3,})(.*)$/;
+const FENCE_CLOSE_RE = /^([ \t]*)(`{3,}|~{3,})[ \t]*\r?$/;
+const LIST_ITEM_RE = /^([ \t]*)([-+*]|\d{1,9}[.)])([ \t]+|$)/;
+const THEMATIC_BREAK_RE = /^([ \t]*)(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/;
+const BLOCK_BOUNDARY_RE = /^([ \t]*)(?:#{1,6}(?:[ \t]|$)|>[ \t]?)/;
+
+const hasAtMostThreeColumnIndent = (indentation: string | undefined): boolean => (
+    indentation !== undefined && getIndentWidth(indentation) <= 3
+);
+
+const getFence = (line: string): MarkdownFence | null => {
+    const match = line.match(FENCE_OPEN_RE);
+    const indentation = match?.[1];
+    const marker = match?.[2];
+    if (!hasAtMostThreeColumnIndent(indentation) || !marker || (marker[0] === '`' && match[3]?.includes('`'))) {
+        return null;
+    }
+    const character = marker[0];
+    if (character !== '`' && character !== '~') return null;
+    return { character, length: marker.length };
+};
+
+const closesFence = (line: string, fence: MarkdownFence): boolean => {
+    const match = line.match(FENCE_CLOSE_RE);
+    const indentation = match?.[1];
+    const marker = match?.[2];
+    return Boolean(
+        hasAtMostThreeColumnIndent(indentation)
+        && marker
+        && marker[0] === fence.character
+        && marker.length >= fence.length,
+    );
+};
+
+const isBlankLine = (line: string): boolean => /^\s*$/.test(line);
+
+const getLineIndent = (line: string): number => getIndentWidth(line.match(/^[ \t]*/)?.[0] || '');
+
+const isThematicBreak = (line: string): boolean => {
+    const indentation = line.match(THEMATIC_BREAK_RE)?.[1];
+    return hasAtMostThreeColumnIndent(indentation);
+};
+
+const isBlockBoundary = (line: string): boolean => {
+    const indentation = line.match(BLOCK_BOUNDARY_RE)?.[1];
+    return hasAtMostThreeColumnIndent(indentation);
+};
+
+const getListItem = (line: string): MarkdownListItem | null => {
+    if (isThematicBreak(line)) return null;
+
+    const match = line.match(LIST_ITEM_RE);
+    const indentation = match?.[1];
+    const marker = match?.[2];
+    const spacing = match?.[3];
+    if (indentation === undefined || !marker) return null;
+
+    const markerIndent = getIndentWidth(indentation);
+    const contentIndent = markerIndent + marker.length + getIndentWidth(spacing || ' ');
+    return { markerIndent, contentIndent, codeIndent: contentIndent + 4 };
+};
+
+const isMarkdownBlockBoundary = (line: string): boolean => (
+    Boolean(getFence(line)) || isThematicBreak(line) || isBlockBoundary(line)
+);
+
+const getListContinuation = (
+    line: string,
+    listItems: MarkdownListItem[],
+    hasPendingBlankLines: boolean,
+): MarkdownListItem | null => {
+    const indent = getLineIndent(line);
+    for (let index = listItems.length - 1; index >= 0; index -= 1) {
+        const listItem = listItems[index];
+        if (!listItem || indent < listItem.contentIndent) continue;
+        if (!hasPendingBlankLines || indent < listItem.codeIndent) return listItem;
+    }
+    return null;
+};
+
+const isValidListItem = (item: MarkdownListItem, listItems: MarkdownListItem[]): boolean => {
+    let parentIndex = listItems.length - 1;
+    while (parentIndex >= 0 && (listItems[parentIndex]?.markerIndent || 0) >= item.markerIndent) {
+        parentIndex -= 1;
+    }
+
+    const parent = parentIndex >= 0 ? listItems[parentIndex] : undefined;
+    return parent
+        ? item.markerIndent >= parent.contentIndent && item.markerIndent < parent.codeIndent
+        : item.markerIndent <= 3;
+};
+
+const updateListItems = (item: MarkdownListItem, listItems: MarkdownListItem[]): void => {
+    let parentIndex = listItems.length - 1;
+    while (parentIndex >= 0 && (listItems[parentIndex]?.markerIndent || 0) >= item.markerIndent) {
+        parentIndex -= 1;
+    }
+    listItems.length = parentIndex + 1;
+    listItems.push(item);
+};
+
+const isLazyListContinuation = (
+    line: string,
+    listItems: MarkdownListItem[],
+    hasPendingBlankLines: boolean,
+): boolean => {
+    if (hasPendingBlankLines || listItems.length === 0 || isMarkdownBlockBoundary(line)) return false;
+    const current = listItems[listItems.length - 1];
+    return Boolean(current && getLineIndent(line) < current.contentIndent);
+};
+
+const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
+    const match = fromStart
+        ? text.match(/^[ \t]*(?:\r?\n[ \t]*)+/)
+        : text.match(/(?:[ \t]*\r?\n)+[ \t]*$/);
+
+    return match?.[0].match(/\r?\n/g)?.length || 0;
+};
+
+const joinTextParts = (textParts: string[]): string => textParts
+    .map((text, index) => {
+        if (index === 0) return text;
+
+        const previousText = textParts[index - 1];
+        const boundaryLineBreaks = countBoundaryLineBreaks(previousText, false)
+            + countBoundaryLineBreaks(text, true);
+        const separator = '\n'.repeat(Math.max(0, 2 - boundaryLineBreaks));
+        return `${separator}${text}`;
+    })
+    .join('');
+
+const normalizeMarkdownBlankLines = (text: string): string => {
+    const lines = text.replace(/\r\n?/g, '\n').split('\n');
+    const normalized: string[] = [];
+    let fence: MarkdownFence | null = null;
+    let inIndentedCode = false;
+    let indentedCodeIndent = 0;
+    const listItems: MarkdownListItem[] = [];
+    let pendingIndentedBlankLines: string[] = [];
+    let pendingBlankLines = 0;
+
+    const flushPendingBlankLines = (): void => {
+        if (pendingBlankLines > 0 && normalized.length > 0) normalized.push('');
+        pendingBlankLines = 0;
+    };
+
+    for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+
+        if (fence) {
+            normalized.push(line);
+            if (closesFence(line, fence)) fence = null;
+            continue;
+        }
+
+        if (inIndentedCode) {
+            if (getLineIndent(line) >= indentedCodeIndent) {
+                normalized.push(...pendingIndentedBlankLines);
+                pendingIndentedBlankLines = [];
+                normalized.push(line);
+                continue;
+            }
+
+            if (isBlankLine(line)) {
+                pendingIndentedBlankLines.push(line);
+                continue;
+            }
+
+            inIndentedCode = false;
+            indentedCodeIndent = 0;
+            pendingBlankLines += pendingIndentedBlankLines.length;
+            pendingIndentedBlankLines = [];
+        }
+
+        if (isBlankLine(line)) {
+            pendingBlankLines += 1;
+            continue;
+        }
+
+        const hasPendingBlankLines = pendingBlankLines > 0;
+        const listItem = getListItem(line);
+        const validListItem = listItem ? isValidListItem(listItem, listItems) : false;
+        const listContinuation = getListContinuation(line, listItems, hasPendingBlankLines);
+        const isIndentedCode = getLineIndent(line) >= 4;
+
+        flushPendingBlankLines();
+        normalized.push(line);
+
+        const nextFence = getFence(line);
+        if (nextFence) {
+            fence = nextFence;
+        } else if (isIndentedCode && !validListItem && !listContinuation) {
+            inIndentedCode = true;
+            indentedCodeIndent = listItems[listItems.length - 1]?.codeIndent || 4;
+        }
+
+        if (validListItem && listItem) {
+            updateListItems(listItem, listItems);
+        } else if (
+            !listContinuation
+            && !isIndentedCode
+            && !isLazyListContinuation(line, listItems, hasPendingBlankLines)
+        ) {
+            listItems.length = 0;
+        }
+    }
+
+    return normalized.join('\n');
+};
+
 export const flattenAssistantTextParts = (parts: Part[]): string => {
     const textParts = parts
         .filter((part): part is TextLikePart => part?.type === 'text')
-        .map((part) => (part.text || part.content || '').trim())
+        .map((part) => part.text || part.content || '')
         .filter((text) => text.length > 0);
 
-    return textParts.join('\n\n');
-};
-
-export const flattenUserTextParts = (parts: Part[]): string => {
-    const textParts = parts.filter((part): part is UserTextPart => part?.type === 'text');
-
-    const shellOutputs = textParts
-        .map((part) => {
-            const output = part.shellAction?.output;
-            return typeof output === 'string' ? output.trim() : '';
-        })
-        .filter((output) => output.length > 0);
-    if (shellOutputs.length > 0) {
-        return shellOutputs.join('\n\n');
-    }
-
-    const shellCommands = textParts
-        .map((part) => {
-            const command = part.shellAction?.command;
-            return typeof command === 'string' ? command.trim() : '';
-        })
-        .filter((command) => command.length > 0);
-    if (shellCommands.length > 0) {
-        return shellCommands.join('\n');
-    }
-
-    const plainTexts = textParts
-        .map((part) => (part.text || part.content || '').trim())
-        .filter((text) => text.length > 0);
-    return plainTexts.join('\n\n');
+    const combined = joinTextParts(textParts);
+    return normalizeMarkdownBlankLines(combined);
 };
 
 export const suggestPlanTitleFromText = (text: string): string => {

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -133,6 +133,73 @@ const isLazyListContinuation = (
     return Boolean(current && getLineIndent(line) < current.contentIndent);
 };
 
+const isInsideMarkdownCodeBlock = (text: string): boolean => {
+    const lines = text.replace(/\r\n?/g, '\n').split('\n');
+    let fence: MarkdownFence | null = null;
+    let inIndentedCode = false;
+    let indentedCodeIndent = 0;
+    const listItems: MarkdownListItem[] = [];
+    let pendingIndentedBlankLines = 0;
+    let pendingBlankLines = 0;
+
+    for (const line of lines) {
+        if (fence) {
+            if (closesFence(line, fence)) fence = null;
+            continue;
+        }
+
+        if (inIndentedCode) {
+            if (getLineIndent(line) >= indentedCodeIndent) {
+                pendingIndentedBlankLines = 0;
+                continue;
+            }
+
+            if (isBlankLine(line)) {
+                pendingIndentedBlankLines += 1;
+                continue;
+            }
+
+            inIndentedCode = false;
+            indentedCodeIndent = 0;
+            pendingBlankLines += pendingIndentedBlankLines;
+            pendingIndentedBlankLines = 0;
+        }
+
+        if (isBlankLine(line)) {
+            pendingBlankLines += 1;
+            continue;
+        }
+
+        const hasPendingBlankLines = pendingBlankLines > 0;
+        const listItem = getListItem(line);
+        const validListItem = listItem ? isValidListItem(listItem, listItems) : false;
+        const listContinuation = getListContinuation(line, listItems, hasPendingBlankLines);
+        const isIndentedCode = getLineIndent(line) >= 4;
+
+        pendingBlankLines = 0;
+
+        const nextFence = getFence(line);
+        if (nextFence) {
+            fence = nextFence;
+        } else if (isIndentedCode && !validListItem && !listContinuation) {
+            inIndentedCode = true;
+            indentedCodeIndent = listItems[listItems.length - 1]?.codeIndent || 4;
+        }
+
+        if (validListItem && listItem) {
+            updateListItems(listItem, listItems);
+        } else if (
+            !listContinuation
+            && !isIndentedCode
+            && !isLazyListContinuation(line, listItems, hasPendingBlankLines)
+        ) {
+            listItems.length = 0;
+        }
+    }
+
+    return Boolean(fence || inIndentedCode);
+};
+
 const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
     const match = fromStart
         ? text.match(/^[ \t]*(?:\r?\n[ \t]*)+/)
@@ -141,17 +208,25 @@ const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
     return match?.[0].match(/\r?\n/g)?.length || 0;
 };
 
-const joinTextParts = (textParts: string[]): string => textParts
-    .map((text, index) => {
-        if (index === 0) return text;
+const joinTextParts = (textParts: string[]): string => {
+    let joined = '';
+
+    textParts.forEach((text, index) => {
+        if (index === 0) {
+            joined = text;
+            return;
+        }
 
         const previousText = textParts[index - 1];
         const boundaryLineBreaks = countBoundaryLineBreaks(previousText, false)
             + countBoundaryLineBreaks(text, true);
-        const separator = '\n'.repeat(Math.max(0, 2 - boundaryLineBreaks));
-        return `${separator}${text}`;
-    })
-    .join('');
+        const desiredLineBreaks = isInsideMarkdownCodeBlock(joined) ? 1 : 2;
+        const separator = '\n'.repeat(Math.max(0, desiredLineBreaks - boundaryLineBreaks));
+        joined += `${separator}${text}`;
+    });
+
+    return joined;
+};
 
 const normalizeMarkdownBlankLines = (text: string): string => {
     const lines = text.replace(/\r\n?/g, '\n').split('\n');

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -324,6 +324,35 @@ export const flattenAssistantTextParts = (parts: Part[]): string => {
     return normalizeMarkdownBlankLines(combined);
 };
 
+export const flattenUserTextParts = (parts: Part[]): string => {
+    const textParts = parts.filter((part): part is UserTextPart => part?.type === 'text');
+
+    const shellOutputs = textParts
+        .map((part) => {
+            const output = part.shellAction?.output;
+            return typeof output === 'string' ? output.trim() : '';
+        })
+        .filter((output) => output.length > 0);
+    if (shellOutputs.length > 0) {
+        return shellOutputs.join('\n\n');
+    }
+
+    const shellCommands = textParts
+        .map((part) => {
+            const command = part.shellAction?.command;
+            return typeof command === 'string' ? command.trim() : '';
+        })
+        .filter((command) => command.length > 0);
+    if (shellCommands.length > 0) {
+        return shellCommands.join('\n');
+    }
+
+    const plainTexts = textParts
+        .map((part) => (part.text || part.content || '').trim())
+        .filter((text) => text.length > 0);
+    return plainTexts.join('\n\n');
+};
+
 export const suggestPlanTitleFromText = (text: string): string => {
     const normalized = text
         .replace(/\r\n?/g, '\n')

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -133,71 +133,128 @@ const isLazyListContinuation = (
     return Boolean(current && getLineIndent(line) < current.contentIndent);
 };
 
-const isInsideMarkdownCodeBlock = (text: string): boolean => {
-    const lines = text.replace(/\r\n?/g, '\n').split('\n');
-    let fence: MarkdownFence | null = null;
-    let inIndentedCode = false;
-    let indentedCodeIndent = 0;
-    const listItems: MarkdownListItem[] = [];
-    let pendingIndentedBlankLines = 0;
-    let pendingBlankLines = 0;
+type MarkdownScannerState = {
+    fence: MarkdownFence | null;
+    indentedCodeIndent: number;
+    listItems: MarkdownListItem[];
+    pendingIndentedBlankLines: string[] | null;
+    pendingIndentedBlankLineCount: number;
+    pendingBlankLines: number;
+};
 
-    for (const line of lines) {
-        if (fence) {
-            if (closesFence(line, fence)) fence = null;
-            continue;
+type MarkdownLineScan = {
+    kind: 'fence' | 'indented-code' | 'blank' | 'content';
+    pendingIndentedBlankLines: string[];
+    pendingBlankLines: number;
+};
+
+type MarkdownScannerMode = 'count' | 'normalize';
+
+const createMarkdownScanner = (mode: MarkdownScannerMode) => {
+    const retainLineDetails = mode === 'normalize';
+    const state: MarkdownScannerState = {
+        fence: null,
+        indentedCodeIndent: 0,
+        listItems: [],
+        pendingIndentedBlankLines: retainLineDetails ? [] : null,
+        pendingIndentedBlankLineCount: 0,
+        pendingBlankLines: 0,
+    };
+
+    const scanLine = (line: string): MarkdownLineScan | undefined => {
+        if (state.fence) {
+            if (closesFence(line, state.fence)) state.fence = null;
+            return retainLineDetails
+                ? { kind: 'fence', pendingIndentedBlankLines: [], pendingBlankLines: 0 }
+                : undefined;
         }
 
-        if (inIndentedCode) {
-            if (getLineIndent(line) >= indentedCodeIndent) {
-                pendingIndentedBlankLines = 0;
-                continue;
+        if (state.indentedCodeIndent > 0) {
+            if (getLineIndent(line) >= state.indentedCodeIndent) {
+                const pendingIndentedBlankLines = state.pendingIndentedBlankLines;
+                state.pendingIndentedBlankLines = retainLineDetails ? [] : null;
+                state.pendingIndentedBlankLineCount = 0;
+                return retainLineDetails
+                    ? {
+                        kind: 'indented-code',
+                        pendingIndentedBlankLines: pendingIndentedBlankLines ?? [],
+                        pendingBlankLines: 0,
+                    }
+                    : undefined;
             }
 
             if (isBlankLine(line)) {
-                pendingIndentedBlankLines += 1;
-                continue;
+                if (state.pendingIndentedBlankLines) {
+                    state.pendingIndentedBlankLines.push(line);
+                } else {
+                    state.pendingIndentedBlankLineCount += 1;
+                }
+                return retainLineDetails
+                    ? { kind: 'blank', pendingIndentedBlankLines: [], pendingBlankLines: 0 }
+                    : undefined;
             }
 
-            inIndentedCode = false;
-            indentedCodeIndent = 0;
-            pendingBlankLines += pendingIndentedBlankLines;
-            pendingIndentedBlankLines = 0;
+            state.indentedCodeIndent = 0;
+            state.pendingBlankLines += (
+                state.pendingIndentedBlankLines?.length ?? state.pendingIndentedBlankLineCount
+            );
+            state.pendingIndentedBlankLines = retainLineDetails ? [] : null;
+            state.pendingIndentedBlankLineCount = 0;
         }
 
         if (isBlankLine(line)) {
-            pendingBlankLines += 1;
-            continue;
+            state.pendingBlankLines += 1;
+            return retainLineDetails
+                ? { kind: 'blank', pendingIndentedBlankLines: [], pendingBlankLines: 0 }
+                : undefined;
         }
 
-        const hasPendingBlankLines = pendingBlankLines > 0;
+        const hasPendingBlankLines = state.pendingBlankLines > 0;
         const listItem = getListItem(line);
-        const validListItem = listItem ? isValidListItem(listItem, listItems) : false;
-        const listContinuation = getListContinuation(line, listItems, hasPendingBlankLines);
+        const validListItem = listItem ? isValidListItem(listItem, state.listItems) : false;
+        const listContinuation = getListContinuation(line, state.listItems, hasPendingBlankLines);
         const isIndentedCode = getLineIndent(line) >= 4;
+        const pendingBlankLines = state.pendingBlankLines;
 
-        pendingBlankLines = 0;
+        state.pendingBlankLines = 0;
 
         const nextFence = getFence(line);
         if (nextFence) {
-            fence = nextFence;
+            state.fence = nextFence;
         } else if (isIndentedCode && !validListItem && !listContinuation) {
-            inIndentedCode = true;
-            indentedCodeIndent = listItems[listItems.length - 1]?.codeIndent || 4;
+            state.indentedCodeIndent = state.listItems[state.listItems.length - 1]?.codeIndent || 4;
         }
 
         if (validListItem && listItem) {
-            updateListItems(listItem, listItems);
+            updateListItems(listItem, state.listItems);
         } else if (
             !listContinuation
             && !isIndentedCode
-            && !isLazyListContinuation(line, listItems, hasPendingBlankLines)
+            && !isLazyListContinuation(line, state.listItems, hasPendingBlankLines)
         ) {
-            listItems.length = 0;
+            state.listItems.length = 0;
         }
+
+        return retainLineDetails
+            ? { kind: 'content', pendingIndentedBlankLines: [], pendingBlankLines }
+            : undefined;
+    };
+
+    return {
+        scanLine,
+        isInsideCodeBlock: (): boolean => Boolean(state.fence || state.indentedCodeIndent),
+    };
+};
+
+const isInsideMarkdownCodeBlock = (text: string): boolean => {
+    const lines = text.replace(/\r\n?/g, '\n').split('\n');
+    const scanner = createMarkdownScanner('count');
+
+    for (const line of lines) {
+        scanner.scanLine(line);
     }
 
-    return Boolean(fence || inIndentedCode);
+    return scanner.isInsideCodeBlock();
 };
 
 const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
@@ -231,77 +288,27 @@ const joinTextParts = (textParts: string[]): string => {
 const normalizeMarkdownBlankLines = (text: string): string => {
     const lines = text.replace(/\r\n?/g, '\n').split('\n');
     const normalized: string[] = [];
-    let fence: MarkdownFence | null = null;
-    let inIndentedCode = false;
-    let indentedCodeIndent = 0;
-    const listItems: MarkdownListItem[] = [];
-    let pendingIndentedBlankLines: string[] = [];
-    let pendingBlankLines = 0;
+    const scanner = createMarkdownScanner('normalize');
 
-    const flushPendingBlankLines = (): void => {
-        if (pendingBlankLines > 0 && normalized.length > 0) normalized.push('');
-        pendingBlankLines = 0;
-    };
+    for (const line of lines) {
+        const scan = scanner.scanLine(line);
 
-    for (let index = 0; index < lines.length; index += 1) {
-        const line = lines[index];
+        if (!scan) continue;
 
-        if (fence) {
+        if (scan.kind === 'fence') {
             normalized.push(line);
-            if (closesFence(line, fence)) fence = null;
             continue;
         }
 
-        if (inIndentedCode) {
-            if (getLineIndent(line) >= indentedCodeIndent) {
-                normalized.push(...pendingIndentedBlankLines);
-                pendingIndentedBlankLines = [];
-                normalized.push(line);
-                continue;
-            }
-
-            if (isBlankLine(line)) {
-                pendingIndentedBlankLines.push(line);
-                continue;
-            }
-
-            inIndentedCode = false;
-            indentedCodeIndent = 0;
-            pendingBlankLines += pendingIndentedBlankLines.length;
-            pendingIndentedBlankLines = [];
-        }
-
-        if (isBlankLine(line)) {
-            pendingBlankLines += 1;
+        if (scan.kind === 'indented-code') {
+            normalized.push(...scan.pendingIndentedBlankLines, line);
             continue;
         }
 
-        const hasPendingBlankLines = pendingBlankLines > 0;
-        const listItem = getListItem(line);
-        const validListItem = listItem ? isValidListItem(listItem, listItems) : false;
-        const listContinuation = getListContinuation(line, listItems, hasPendingBlankLines);
-        const isIndentedCode = getLineIndent(line) >= 4;
+        if (scan.kind === 'blank') continue;
 
-        flushPendingBlankLines();
+        if (scan.pendingBlankLines > 0 && normalized.length > 0) normalized.push('');
         normalized.push(line);
-
-        const nextFence = getFence(line);
-        if (nextFence) {
-            fence = nextFence;
-        } else if (isIndentedCode && !validListItem && !listContinuation) {
-            inIndentedCode = true;
-            indentedCodeIndent = listItems[listItems.length - 1]?.codeIndent || 4;
-        }
-
-        if (validListItem && listItem) {
-            updateListItems(listItem, listItems);
-        } else if (
-            !listContinuation
-            && !isIndentedCode
-            && !isLazyListContinuation(line, listItems, hasPendingBlankLines)
-        ) {
-            listItems.length = 0;
-        }
     }
 
     return normalized.join('\n');

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -2,14 +2,243 @@ import type { Part } from '@opencode-ai/sdk/v2';
 
 type TextLikePart = Part & { text?: string; content?: string };
 
+type MarkdownFence = {
+    character: '`' | '~';
+    length: number;
+};
+
+type MarkdownListItem = {
+    markerIndent: number;
+    contentIndent: number;
+    codeIndent: number;
+};
+
+const getIndentWidth = (indentation: string): number => {
+    let width = 0;
+    for (const character of indentation) {
+        width += character === '\t' ? 4 - (width % 4) : 1;
+    }
+    return width;
+};
+
+const FENCE_OPEN_RE = /^([ \t]*)(`{3,}|~{3,})(.*)$/;
+const FENCE_CLOSE_RE = /^([ \t]*)(`{3,}|~{3,})[ \t]*\r?$/;
+const LIST_ITEM_RE = /^([ \t]*)([-+*]|\d{1,9}[.)])([ \t]+|$)/;
+const THEMATIC_BREAK_RE = /^([ \t]*)(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/;
+const BLOCK_BOUNDARY_RE = /^([ \t]*)(?:#{1,6}(?:[ \t]|$)|>[ \t]?)/;
+
+const hasAtMostThreeColumnIndent = (indentation: string | undefined): boolean => (
+    indentation !== undefined && getIndentWidth(indentation) <= 3
+);
+
+const getFence = (line: string): MarkdownFence | null => {
+    const match = line.match(FENCE_OPEN_RE);
+    const indentation = match?.[1];
+    const marker = match?.[2];
+    if (!hasAtMostThreeColumnIndent(indentation) || !marker || (marker[0] === '`' && match[3]?.includes('`'))) {
+        return null;
+    }
+    const character = marker[0];
+    if (character !== '`' && character !== '~') return null;
+    return { character, length: marker.length };
+};
+
+const closesFence = (line: string, fence: MarkdownFence): boolean => {
+    const match = line.match(FENCE_CLOSE_RE);
+    const indentation = match?.[1];
+    const marker = match?.[2];
+    return Boolean(
+        hasAtMostThreeColumnIndent(indentation)
+        && marker
+        && marker[0] === fence.character
+        && marker.length >= fence.length,
+    );
+};
+
+const isBlankLine = (line: string): boolean => /^\s*$/.test(line);
+
+const getLineIndent = (line: string): number => getIndentWidth(line.match(/^[ \t]*/)?.[0] || '');
+
+const isThematicBreak = (line: string): boolean => {
+    const indentation = line.match(THEMATIC_BREAK_RE)?.[1];
+    return hasAtMostThreeColumnIndent(indentation);
+};
+
+const isBlockBoundary = (line: string): boolean => {
+    const indentation = line.match(BLOCK_BOUNDARY_RE)?.[1];
+    return hasAtMostThreeColumnIndent(indentation);
+};
+
+const getListItem = (line: string): MarkdownListItem | null => {
+    if (isThematicBreak(line)) return null;
+
+    const match = line.match(LIST_ITEM_RE);
+    const indentation = match?.[1];
+    const marker = match?.[2];
+    const spacing = match?.[3];
+    if (indentation === undefined || !marker) return null;
+
+    const markerIndent = getIndentWidth(indentation);
+    const contentIndent = markerIndent + marker.length + getIndentWidth(spacing || ' ');
+    return { markerIndent, contentIndent, codeIndent: contentIndent + 4 };
+};
+
+const isMarkdownBlockBoundary = (line: string): boolean => (
+    Boolean(getFence(line)) || isThematicBreak(line) || isBlockBoundary(line)
+);
+
+const getListContinuation = (
+    line: string,
+    listItems: MarkdownListItem[],
+    hasPendingBlankLines: boolean,
+): MarkdownListItem | null => {
+    const indent = getLineIndent(line);
+    for (let index = listItems.length - 1; index >= 0; index -= 1) {
+        const listItem = listItems[index];
+        if (!listItem || indent < listItem.contentIndent) continue;
+        if (!hasPendingBlankLines || indent < listItem.codeIndent) return listItem;
+    }
+    return null;
+};
+
+const isValidListItem = (item: MarkdownListItem, listItems: MarkdownListItem[]): boolean => {
+    let parentIndex = listItems.length - 1;
+    while (parentIndex >= 0 && (listItems[parentIndex]?.markerIndent || 0) >= item.markerIndent) {
+        parentIndex -= 1;
+    }
+
+    const parent = parentIndex >= 0 ? listItems[parentIndex] : undefined;
+    return parent
+        ? item.markerIndent >= parent.contentIndent && item.markerIndent < parent.codeIndent
+        : item.markerIndent <= 3;
+};
+
+const updateListItems = (item: MarkdownListItem, listItems: MarkdownListItem[]): void => {
+    let parentIndex = listItems.length - 1;
+    while (parentIndex >= 0 && (listItems[parentIndex]?.markerIndent || 0) >= item.markerIndent) {
+        parentIndex -= 1;
+    }
+    listItems.length = parentIndex + 1;
+    listItems.push(item);
+};
+
+const isLazyListContinuation = (
+    line: string,
+    listItems: MarkdownListItem[],
+    hasPendingBlankLines: boolean,
+): boolean => {
+    if (hasPendingBlankLines || listItems.length === 0 || isMarkdownBlockBoundary(line)) return false;
+    const current = listItems[listItems.length - 1];
+    return Boolean(current && getLineIndent(line) < current.contentIndent);
+};
+
+const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
+    const match = fromStart
+        ? text.match(/^[ \t]*(?:\r?\n[ \t]*)+/)
+        : text.match(/(?:[ \t]*\r?\n)+[ \t]*$/);
+
+    return match?.[0].match(/\r?\n/g)?.length || 0;
+};
+
+const joinTextParts = (textParts: string[]): string => textParts
+    .map((text, index) => {
+        if (index === 0) return text;
+
+        const previousText = textParts[index - 1];
+        const boundaryLineBreaks = countBoundaryLineBreaks(previousText, false)
+            + countBoundaryLineBreaks(text, true);
+        const separator = '\n'.repeat(Math.max(0, 2 - boundaryLineBreaks));
+        return `${separator}${text}`;
+    })
+    .join('');
+
+const normalizeMarkdownBlankLines = (text: string): string => {
+    const lines = text.replace(/\r\n?/g, '\n').split('\n');
+    const normalized: string[] = [];
+    let fence: MarkdownFence | null = null;
+    let inIndentedCode = false;
+    let indentedCodeIndent = 0;
+    const listItems: MarkdownListItem[] = [];
+    let pendingIndentedBlankLines: string[] = [];
+    let pendingBlankLines = 0;
+
+    const flushPendingBlankLines = (): void => {
+        if (pendingBlankLines > 0 && normalized.length > 0) normalized.push('');
+        pendingBlankLines = 0;
+    };
+
+    for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+
+        if (fence) {
+            normalized.push(line);
+            if (closesFence(line, fence)) fence = null;
+            continue;
+        }
+
+        if (inIndentedCode) {
+            if (getLineIndent(line) >= indentedCodeIndent) {
+                normalized.push(...pendingIndentedBlankLines);
+                pendingIndentedBlankLines = [];
+                normalized.push(line);
+                continue;
+            }
+
+            if (isBlankLine(line)) {
+                pendingIndentedBlankLines.push(line);
+                continue;
+            }
+
+            inIndentedCode = false;
+            indentedCodeIndent = 0;
+            pendingBlankLines += pendingIndentedBlankLines.length;
+            pendingIndentedBlankLines = [];
+        }
+
+        if (isBlankLine(line)) {
+            pendingBlankLines += 1;
+            continue;
+        }
+
+        const hasPendingBlankLines = pendingBlankLines > 0;
+        const listItem = getListItem(line);
+        const validListItem = listItem ? isValidListItem(listItem, listItems) : false;
+        const listContinuation = getListContinuation(line, listItems, hasPendingBlankLines);
+        const isIndentedCode = getLineIndent(line) >= 4;
+
+        flushPendingBlankLines();
+        normalized.push(line);
+
+        const nextFence = getFence(line);
+        if (nextFence) {
+            fence = nextFence;
+        } else if (isIndentedCode && !validListItem && !listContinuation) {
+            inIndentedCode = true;
+            indentedCodeIndent = listItems[listItems.length - 1]?.codeIndent || 4;
+        }
+
+        if (validListItem && listItem) {
+            updateListItems(listItem, listItems);
+        } else if (
+            !listContinuation
+            && !isIndentedCode
+            && !isLazyListContinuation(line, listItems, hasPendingBlankLines)
+        ) {
+            listItems.length = 0;
+        }
+    }
+
+    return normalized.join('\n');
+};
+
 export const flattenAssistantTextParts = (parts: Part[]): string => {
     const textParts = parts
         .filter((part): part is TextLikePart => part?.type === 'text')
-        .map((part) => (part.text || part.content || '').trim())
+        .map((part) => part.text || part.content || '')
         .filter((text) => text.length > 0);
 
-    const combined = textParts.join('\n');
-    return combined.replace(/\n\s*\n+/g, '\n');
+    const combined = joinTextParts(textParts);
+    return normalizeMarkdownBlankLines(combined);
 };
 
 export const suggestPlanTitleFromText = (text: string): string => {

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -132,71 +132,128 @@ const isLazyListContinuation = (
     return Boolean(current && getLineIndent(line) < current.contentIndent);
 };
 
-const isInsideMarkdownCodeBlock = (text: string): boolean => {
-    const lines = text.replace(/\r\n?/g, '\n').split('\n');
-    let fence: MarkdownFence | null = null;
-    let inIndentedCode = false;
-    let indentedCodeIndent = 0;
-    const listItems: MarkdownListItem[] = [];
-    let pendingIndentedBlankLines = 0;
-    let pendingBlankLines = 0;
+type MarkdownScannerState = {
+    fence: MarkdownFence | null;
+    indentedCodeIndent: number;
+    listItems: MarkdownListItem[];
+    pendingIndentedBlankLines: string[] | null;
+    pendingIndentedBlankLineCount: number;
+    pendingBlankLines: number;
+};
 
-    for (const line of lines) {
-        if (fence) {
-            if (closesFence(line, fence)) fence = null;
-            continue;
+type MarkdownLineScan = {
+    kind: 'fence' | 'indented-code' | 'blank' | 'content';
+    pendingIndentedBlankLines: string[];
+    pendingBlankLines: number;
+};
+
+type MarkdownScannerMode = 'count' | 'normalize';
+
+const createMarkdownScanner = (mode: MarkdownScannerMode) => {
+    const retainLineDetails = mode === 'normalize';
+    const state: MarkdownScannerState = {
+        fence: null,
+        indentedCodeIndent: 0,
+        listItems: [],
+        pendingIndentedBlankLines: retainLineDetails ? [] : null,
+        pendingIndentedBlankLineCount: 0,
+        pendingBlankLines: 0,
+    };
+
+    const scanLine = (line: string): MarkdownLineScan | undefined => {
+        if (state.fence) {
+            if (closesFence(line, state.fence)) state.fence = null;
+            return retainLineDetails
+                ? { kind: 'fence', pendingIndentedBlankLines: [], pendingBlankLines: 0 }
+                : undefined;
         }
 
-        if (inIndentedCode) {
-            if (getLineIndent(line) >= indentedCodeIndent) {
-                pendingIndentedBlankLines = 0;
-                continue;
+        if (state.indentedCodeIndent > 0) {
+            if (getLineIndent(line) >= state.indentedCodeIndent) {
+                const pendingIndentedBlankLines = state.pendingIndentedBlankLines;
+                state.pendingIndentedBlankLines = retainLineDetails ? [] : null;
+                state.pendingIndentedBlankLineCount = 0;
+                return retainLineDetails
+                    ? {
+                        kind: 'indented-code',
+                        pendingIndentedBlankLines: pendingIndentedBlankLines ?? [],
+                        pendingBlankLines: 0,
+                    }
+                    : undefined;
             }
 
             if (isBlankLine(line)) {
-                pendingIndentedBlankLines += 1;
-                continue;
+                if (state.pendingIndentedBlankLines) {
+                    state.pendingIndentedBlankLines.push(line);
+                } else {
+                    state.pendingIndentedBlankLineCount += 1;
+                }
+                return retainLineDetails
+                    ? { kind: 'blank', pendingIndentedBlankLines: [], pendingBlankLines: 0 }
+                    : undefined;
             }
 
-            inIndentedCode = false;
-            indentedCodeIndent = 0;
-            pendingBlankLines += pendingIndentedBlankLines;
-            pendingIndentedBlankLines = 0;
+            state.indentedCodeIndent = 0;
+            state.pendingBlankLines += (
+                state.pendingIndentedBlankLines?.length ?? state.pendingIndentedBlankLineCount
+            );
+            state.pendingIndentedBlankLines = retainLineDetails ? [] : null;
+            state.pendingIndentedBlankLineCount = 0;
         }
 
         if (isBlankLine(line)) {
-            pendingBlankLines += 1;
-            continue;
+            state.pendingBlankLines += 1;
+            return retainLineDetails
+                ? { kind: 'blank', pendingIndentedBlankLines: [], pendingBlankLines: 0 }
+                : undefined;
         }
 
-        const hasPendingBlankLines = pendingBlankLines > 0;
+        const hasPendingBlankLines = state.pendingBlankLines > 0;
         const listItem = getListItem(line);
-        const validListItem = listItem ? isValidListItem(listItem, listItems) : false;
-        const listContinuation = getListContinuation(line, listItems, hasPendingBlankLines);
+        const validListItem = listItem ? isValidListItem(listItem, state.listItems) : false;
+        const listContinuation = getListContinuation(line, state.listItems, hasPendingBlankLines);
         const isIndentedCode = getLineIndent(line) >= 4;
+        const pendingBlankLines = state.pendingBlankLines;
 
-        pendingBlankLines = 0;
+        state.pendingBlankLines = 0;
 
         const nextFence = getFence(line);
         if (nextFence) {
-            fence = nextFence;
+            state.fence = nextFence;
         } else if (isIndentedCode && !validListItem && !listContinuation) {
-            inIndentedCode = true;
-            indentedCodeIndent = listItems[listItems.length - 1]?.codeIndent || 4;
+            state.indentedCodeIndent = state.listItems[state.listItems.length - 1]?.codeIndent || 4;
         }
 
         if (validListItem && listItem) {
-            updateListItems(listItem, listItems);
+            updateListItems(listItem, state.listItems);
         } else if (
             !listContinuation
             && !isIndentedCode
-            && !isLazyListContinuation(line, listItems, hasPendingBlankLines)
+            && !isLazyListContinuation(line, state.listItems, hasPendingBlankLines)
         ) {
-            listItems.length = 0;
+            state.listItems.length = 0;
         }
+
+        return retainLineDetails
+            ? { kind: 'content', pendingIndentedBlankLines: [], pendingBlankLines }
+            : undefined;
+    };
+
+    return {
+        scanLine,
+        isInsideCodeBlock: (): boolean => Boolean(state.fence || state.indentedCodeIndent),
+    };
+};
+
+const isInsideMarkdownCodeBlock = (text: string): boolean => {
+    const lines = text.replace(/\r\n?/g, '\n').split('\n');
+    const scanner = createMarkdownScanner('count');
+
+    for (const line of lines) {
+        scanner.scanLine(line);
     }
 
-    return Boolean(fence || inIndentedCode);
+    return scanner.isInsideCodeBlock();
 };
 
 const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
@@ -230,77 +287,27 @@ const joinTextParts = (textParts: string[]): string => {
 const normalizeMarkdownBlankLines = (text: string): string => {
     const lines = text.replace(/\r\n?/g, '\n').split('\n');
     const normalized: string[] = [];
-    let fence: MarkdownFence | null = null;
-    let inIndentedCode = false;
-    let indentedCodeIndent = 0;
-    const listItems: MarkdownListItem[] = [];
-    let pendingIndentedBlankLines: string[] = [];
-    let pendingBlankLines = 0;
+    const scanner = createMarkdownScanner('normalize');
 
-    const flushPendingBlankLines = (): void => {
-        if (pendingBlankLines > 0 && normalized.length > 0) normalized.push('');
-        pendingBlankLines = 0;
-    };
+    for (const line of lines) {
+        const scan = scanner.scanLine(line);
 
-    for (let index = 0; index < lines.length; index += 1) {
-        const line = lines[index];
+        if (!scan) continue;
 
-        if (fence) {
+        if (scan.kind === 'fence') {
             normalized.push(line);
-            if (closesFence(line, fence)) fence = null;
             continue;
         }
 
-        if (inIndentedCode) {
-            if (getLineIndent(line) >= indentedCodeIndent) {
-                normalized.push(...pendingIndentedBlankLines);
-                pendingIndentedBlankLines = [];
-                normalized.push(line);
-                continue;
-            }
-
-            if (isBlankLine(line)) {
-                pendingIndentedBlankLines.push(line);
-                continue;
-            }
-
-            inIndentedCode = false;
-            indentedCodeIndent = 0;
-            pendingBlankLines += pendingIndentedBlankLines.length;
-            pendingIndentedBlankLines = [];
-        }
-
-        if (isBlankLine(line)) {
-            pendingBlankLines += 1;
+        if (scan.kind === 'indented-code') {
+            normalized.push(...scan.pendingIndentedBlankLines, line);
             continue;
         }
 
-        const hasPendingBlankLines = pendingBlankLines > 0;
-        const listItem = getListItem(line);
-        const validListItem = listItem ? isValidListItem(listItem, listItems) : false;
-        const listContinuation = getListContinuation(line, listItems, hasPendingBlankLines);
-        const isIndentedCode = getLineIndent(line) >= 4;
+        if (scan.kind === 'blank') continue;
 
-        flushPendingBlankLines();
+        if (scan.pendingBlankLines > 0 && normalized.length > 0) normalized.push('');
         normalized.push(line);
-
-        const nextFence = getFence(line);
-        if (nextFence) {
-            fence = nextFence;
-        } else if (isIndentedCode && !validListItem && !listContinuation) {
-            inIndentedCode = true;
-            indentedCodeIndent = listItems[listItems.length - 1]?.codeIndent || 4;
-        }
-
-        if (validListItem && listItem) {
-            updateListItems(listItem, listItems);
-        } else if (
-            !listContinuation
-            && !isIndentedCode
-            && !isLazyListContinuation(line, listItems, hasPendingBlankLines)
-        ) {
-            listItems.length = 0;
-        }
     }
 
     return normalized.join('\n');

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -132,6 +132,73 @@ const isLazyListContinuation = (
     return Boolean(current && getLineIndent(line) < current.contentIndent);
 };
 
+const isInsideMarkdownCodeBlock = (text: string): boolean => {
+    const lines = text.replace(/\r\n?/g, '\n').split('\n');
+    let fence: MarkdownFence | null = null;
+    let inIndentedCode = false;
+    let indentedCodeIndent = 0;
+    const listItems: MarkdownListItem[] = [];
+    let pendingIndentedBlankLines = 0;
+    let pendingBlankLines = 0;
+
+    for (const line of lines) {
+        if (fence) {
+            if (closesFence(line, fence)) fence = null;
+            continue;
+        }
+
+        if (inIndentedCode) {
+            if (getLineIndent(line) >= indentedCodeIndent) {
+                pendingIndentedBlankLines = 0;
+                continue;
+            }
+
+            if (isBlankLine(line)) {
+                pendingIndentedBlankLines += 1;
+                continue;
+            }
+
+            inIndentedCode = false;
+            indentedCodeIndent = 0;
+            pendingBlankLines += pendingIndentedBlankLines;
+            pendingIndentedBlankLines = 0;
+        }
+
+        if (isBlankLine(line)) {
+            pendingBlankLines += 1;
+            continue;
+        }
+
+        const hasPendingBlankLines = pendingBlankLines > 0;
+        const listItem = getListItem(line);
+        const validListItem = listItem ? isValidListItem(listItem, listItems) : false;
+        const listContinuation = getListContinuation(line, listItems, hasPendingBlankLines);
+        const isIndentedCode = getLineIndent(line) >= 4;
+
+        pendingBlankLines = 0;
+
+        const nextFence = getFence(line);
+        if (nextFence) {
+            fence = nextFence;
+        } else if (isIndentedCode && !validListItem && !listContinuation) {
+            inIndentedCode = true;
+            indentedCodeIndent = listItems[listItems.length - 1]?.codeIndent || 4;
+        }
+
+        if (validListItem && listItem) {
+            updateListItems(listItem, listItems);
+        } else if (
+            !listContinuation
+            && !isIndentedCode
+            && !isLazyListContinuation(line, listItems, hasPendingBlankLines)
+        ) {
+            listItems.length = 0;
+        }
+    }
+
+    return Boolean(fence || inIndentedCode);
+};
+
 const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
     const match = fromStart
         ? text.match(/^[ \t]*(?:\r?\n[ \t]*)+/)
@@ -140,17 +207,25 @@ const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
     return match?.[0].match(/\r?\n/g)?.length || 0;
 };
 
-const joinTextParts = (textParts: string[]): string => textParts
-    .map((text, index) => {
-        if (index === 0) return text;
+const joinTextParts = (textParts: string[]): string => {
+    let joined = '';
+
+    textParts.forEach((text, index) => {
+        if (index === 0) {
+            joined = text;
+            return;
+        }
 
         const previousText = textParts[index - 1];
         const boundaryLineBreaks = countBoundaryLineBreaks(previousText, false)
             + countBoundaryLineBreaks(text, true);
-        const separator = '\n'.repeat(Math.max(0, 2 - boundaryLineBreaks));
-        return `${separator}${text}`;
-    })
-    .join('');
+        const desiredLineBreaks = isInsideMarkdownCodeBlock(joined) ? 1 : 2;
+        const separator = '\n'.repeat(Math.max(0, desiredLineBreaks - boundaryLineBreaks));
+        joined += `${separator}${text}`;
+    });
+
+    return joined;
+};
 
 const normalizeMarkdownBlankLines = (text: string): string => {
     const lines = text.replace(/\r\n?/g, '\n').split('\n');

--- a/packages/ui/src/lib/messages/messageText.ts
+++ b/packages/ui/src/lib/messages/messageText.ts
@@ -6,6 +6,7 @@ type UserTextPart = Part & { text?: string; content?: string; shellAction?: { ou
 type MarkdownFence = {
     character: '`' | '~';
     length: number;
+    contentIndent: number;
 };
 
 type MarkdownListItem = {
@@ -32,16 +33,27 @@ const hasAtMostThreeColumnIndent = (indentation: string | undefined): boolean =>
     indentation !== undefined && getIndentWidth(indentation) <= 3
 );
 
-const getFence = (line: string): MarkdownFence | null => {
+const getEnclosingContentIndent = (indent: number, listItems: MarkdownListItem[]): number => {
+    for (let index = listItems.length - 1; index >= 0; index -= 1) {
+        const listItem = listItems[index];
+        if (listItem && indent >= listItem.contentIndent) return listItem.contentIndent;
+    }
+    return 0;
+};
+
+const getFence = (line: string, listItems: MarkdownListItem[]): MarkdownFence | null => {
     const match = line.match(FENCE_OPEN_RE);
     const indentation = match?.[1];
     const marker = match?.[2];
-    if (!hasAtMostThreeColumnIndent(indentation) || !marker || (marker[0] === '`' && match[3]?.includes('`'))) {
+    if (indentation === undefined || !marker || (marker[0] === '`' && match[3]?.includes('`'))) {
         return null;
     }
     const character = marker[0];
     if (character !== '`' && character !== '~') return null;
-    return { character, length: marker.length };
+    const indent = getIndentWidth(indentation);
+    const contentIndent = getEnclosingContentIndent(indent, listItems);
+    if (indent - contentIndent > 3) return null;
+    return { character, length: marker.length, contentIndent };
 };
 
 const closesFence = (line: string, fence: MarkdownFence): boolean => {
@@ -49,7 +61,8 @@ const closesFence = (line: string, fence: MarkdownFence): boolean => {
     const indentation = match?.[1];
     const marker = match?.[2];
     return Boolean(
-        hasAtMostThreeColumnIndent(indentation)
+        indentation !== undefined
+        && getIndentWidth(indentation) - fence.contentIndent <= 3
         && marker
         && marker[0] === fence.character
         && marker.length >= fence.length,
@@ -84,8 +97,8 @@ const getListItem = (line: string): MarkdownListItem | null => {
     return { markerIndent, contentIndent, codeIndent: contentIndent + 4 };
 };
 
-const isMarkdownBlockBoundary = (line: string): boolean => (
-    Boolean(getFence(line)) || isThematicBreak(line) || isBlockBoundary(line)
+const isMarkdownBlockBoundary = (line: string, listItems: MarkdownListItem[]): boolean => (
+    Boolean(getFence(line, listItems)) || isThematicBreak(line) || isBlockBoundary(line)
 );
 
 const getListContinuation = (
@@ -128,7 +141,7 @@ const isLazyListContinuation = (
     listItems: MarkdownListItem[],
     hasPendingBlankLines: boolean,
 ): boolean => {
-    if (hasPendingBlankLines || listItems.length === 0 || isMarkdownBlockBoundary(line)) return false;
+    if (hasPendingBlankLines || listItems.length === 0 || isMarkdownBlockBoundary(line, listItems)) return false;
     const current = listItems[listItems.length - 1];
     return Boolean(current && getLineIndent(line) < current.contentIndent);
 };
@@ -218,7 +231,7 @@ const createMarkdownScanner = (mode: MarkdownScannerMode) => {
 
         state.pendingBlankLines = 0;
 
-        const nextFence = getFence(line);
+        const nextFence = getFence(line, state.listItems);
         if (nextFence) {
             state.fence = nextFence;
         } else if (isIndentedCode && !validListItem && !listContinuation) {
@@ -240,21 +253,72 @@ const createMarkdownScanner = (mode: MarkdownScannerMode) => {
             : undefined;
     };
 
+    const isInsideCodeBlock = (): boolean => Boolean(state.fence || state.indentedCodeIndent);
+
+    const isInsideCodeBlockAfterLine = (line: string): boolean => {
+        const snapshot = {
+            ...state,
+            listItems: [...state.listItems],
+            pendingIndentedBlankLines: state.pendingIndentedBlankLines ? [...state.pendingIndentedBlankLines] : null,
+        };
+        scanLine(line);
+        const isInside = isInsideCodeBlock();
+        state.fence = snapshot.fence;
+        state.indentedCodeIndent = snapshot.indentedCodeIndent;
+        state.listItems = snapshot.listItems;
+        state.pendingIndentedBlankLines = snapshot.pendingIndentedBlankLines;
+        state.pendingIndentedBlankLineCount = snapshot.pendingIndentedBlankLineCount;
+        state.pendingBlankLines = snapshot.pendingBlankLines;
+        return isInside;
+    };
+
     return {
         scanLine,
-        isInsideCodeBlock: (): boolean => Boolean(state.fence || state.indentedCodeIndent),
+        isInsideCodeBlock,
+        isInsideCodeBlockAfterLine,
     };
 };
 
-const isInsideMarkdownCodeBlock = (text: string): boolean => {
-    const lines = text.replace(/\r\n?/g, '\n').split('\n');
+const createIncrementalCodeBlockScanner = () => {
     const scanner = createMarkdownScanner('count');
+    let currentLine = '';
+    let pendingCarriageReturn = false;
 
-    for (const line of lines) {
-        scanner.scanLine(line);
-    }
+    const endLine = (): void => {
+        scanner.scanLine(currentLine);
+        currentLine = '';
+    };
 
-    return scanner.isInsideCodeBlock();
+    const append = (text: string): void => {
+        let chunk = text;
+        if (pendingCarriageReturn) {
+            pendingCarriageReturn = false;
+            endLine();
+            if (chunk.startsWith('\n')) chunk = chunk.slice(1);
+        }
+        if (chunk.length === 0) return;
+        if (chunk.endsWith('\r')) {
+            pendingCarriageReturn = true;
+            chunk = chunk.slice(0, -1);
+        }
+
+        const lines = chunk.replace(/\r\n?/g, '\n').split('\n');
+        for (let index = 0; index < lines.length - 1; index += 1) {
+            currentLine += lines[index];
+            endLine();
+        }
+        currentLine += lines[lines.length - 1];
+    };
+
+    return {
+        append,
+        // Mirrors scanning the accumulated text, including a final line without a terminator.
+        isInsideCodeBlock: (): boolean => (
+            pendingCarriageReturn || currentLine.length > 0
+                ? scanner.isInsideCodeBlockAfterLine(currentLine)
+                : scanner.isInsideCodeBlock()
+        ),
+    };
 };
 
 const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
@@ -267,19 +331,23 @@ const countBoundaryLineBreaks = (text: string, fromStart: boolean): number => {
 
 const joinTextParts = (textParts: string[]): string => {
     let joined = '';
+    const codeBlockScanner = createIncrementalCodeBlockScanner();
 
     textParts.forEach((text, index) => {
         if (index === 0) {
             joined = text;
+            codeBlockScanner.append(text);
             return;
         }
 
         const previousText = textParts[index - 1];
         const boundaryLineBreaks = countBoundaryLineBreaks(previousText, false)
             + countBoundaryLineBreaks(text, true);
-        const desiredLineBreaks = isInsideMarkdownCodeBlock(joined) ? 1 : 2;
+        const desiredLineBreaks = codeBlockScanner.isInsideCodeBlock() ? 1 : 2;
         const separator = '\n'.repeat(Math.max(0, desiredLineBreaks - boundaryLineBreaks));
-        joined += `${separator}${text}`;
+        const appendedText = `${separator}${text}`;
+        joined += appendedText;
+        codeBlockScanner.append(appendedText);
     });
 
     return joined;


### PR DESCRIPTION
## Intent

Fixes #2867 residual copy formatting. `flattenAssistantTextParts` now preserves Markdown block structure when copying a reply, with two defects from the earlier #2944 fix corrected:

- split fenced code no longer gets an injected blank line;
- indented code is no longer destroyed by per-part `.trim()`;
- fenced code inside list items is recognized by indent relative to the enclosing item, so interior blank runs survive;
- joining is O(total chars): one incremental scanner per join instead of re-scanning the accumulated text per part (1000 parts / 120 KB: ~2.2 s → ~28 ms).

The branch was rebased onto current main (content unchanged; the old `checks` failure came from `tr.ts` keys that main has since added).

## Non-goals

- No renderer changes; display rendering is untouched. This is the flattened text used for clipboard and prompt seeding.
- No new dependencies or clipboard API changes.
- No changelog edit (maintainer-owned).

## Affected surfaces

- `packages/ui/src/lib/messages/messageText.ts` + tests.
- Consumers: message copy (`ChatMessage`), plan title (`MessageBody`), multirun fusion prompt, review-flow handoff.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` | Shared helper used across runtimes | Centralized fix, caller contracts preserved |
| `openchamber-change-discipline` | Shared helper with multiple consumers | Consumers traced; focused tests |
| `performance-engineering` | Runs from memoized streaming render | Single-pass scanner + timing regression test |
| `clipboard.ts` / `markdownCore.ts` | Production copy pipeline | Clipboard tests exercise the real payloads |

## Validation

| Check | Result |
|---|---|
| `bun test messageText.test.ts messageText.clipboard.test.ts clipboard.test.ts` | 26 pass / 0 fail |
| `node scripts/run-isolated-tests.mjs packages/ui/src/lib` | 131/131 files pass |
| Differential fuzz pre/post scanner (200k list-free + 150k list-bearing inputs) | 0 output mismatches |
| Timing 1000 parts / 120 KB | ~28 ms (pre-fix ~2.2 s); regression test bound 1000 ms |
| `bun run type-check:ui`, `bun run lint:ui` | Passed |
| Whole-PR review | PASS-WITH-FINDINGS, no blocking findings at `fc7ac4a5d`; previous blockers fixed |

## Visual evidence

No rendered change; clipboard payload only.

## Risks and failure behavior

- Deliberate behavior change: excessive blank runs outside code collapse to one block separator (the previous main test asserted preservation). Reviewed as safe for all consumers.
- The scanner remains a heuristic for exotic CommonMark; tested structures match `marked`.


---

CI note (2026-09-13): the `checks` job is red only on `packages/vscode/webview/api/settings.test.ts` ("propagates a failed bridge read and retries successfully"), which times out deterministically on clean current `main` (`961f1611c`, reproduced locally 3/3; the test was added by main commit `6cf247894`). It is unrelated to this diff — every fresh PR head on this base fails it. Do not treat this red check as a finding against this PR.
