### PR TITLE
fix(chat): show a visible caret in the focused empty composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Chat: saved chats in the context panel open again instead of staying blank.
 - Chat: the context meter no longer climbs over 100% (330% readouts) after turns with many tool calls and no longer jumps when reopening an older session; it now shows what the window actually holds, everywhere the value appears — header, context sidebar, work status panel, mini chat, and mobile (thanks to @pocharlies).
 - Chat/Attachments: extracted Office and OpenDocument content is now capped and presented more compactly, preventing large documents and their images from overwhelming the message context.
+- Chat: the input now shows a blinking cursor as soon as it is focused, even when empty, so it is clear the field is ready for typing.
 - Projects: project names now match the folder name exactly, so `.ssh` and `opencode-claude` are no longer shown as `.Ssh` and `Opencode Claude` in the sidebar, window title, settings and notifications; names you renamed yourself are kept.
 - Files: files reached through a symlink inside the workspace now open correctly instead of being rejected as outside the workspace.
 - Settings: the session retention action you pick is now saved instead of being dropped (thanks to @Gautam0507).

--- a/packages/ui/src/components/chat/composer/editor/__tests__/theme.test.ts
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/theme.test.ts
@@ -41,10 +41,23 @@ describe('composerEditorTheme', () => {
      * `caret-color: transparent !important` and draws a `.cm-cursor` element
      * instead. Styling `caret-color` looks correct and does nothing, leaving
      * CodeMirror's hard-coded black cursor on dark themes.
+     *
+     * The one exception is the empty-document fallback (issue #2518): while
+     * the placeholder is showing, the theme re-enables the native caret
+     * because some engines cannot measure a drawn-cursor position in an empty
+     * document. Every `caretColor` declaration must live in that
+     * placeholder-scoped rule and nowhere else.
      */
     test('the caret is coloured where it is drawn, not on the native caret', () => {
         expect(selectors.some((selector) => selector.includes('.cm-cursor'))).toBe(true);
-        expect(declarations.includes('caretColor')).toBe(false);
+        // SAFETY: the theme spec is a plain object literal; indexing it with a
+        // selector key found in `selectors` (its own keys) is always defined.
+        const spec = COMPOSER_EDITOR_THEME_SPEC as Record<string, Record<string, string>>;
+        const caretColorRules = selectors.filter((selector) => spec[selector].caretColor);
+        expect(caretColorRules.length).toBeGreaterThan(0);
+        for (const selector of caretColorRules) {
+            expect(selector.includes('.cm-placeholder')).toBe(true);
+        }
     });
 
     test('the drawn caret follows the theme rather than a fixed colour', () => {
@@ -111,6 +124,57 @@ describe('composerEditorTheme', () => {
 
     test('the common theme does not re-show the native selection', () => {
         expect(selectors.some((selector) => selector.includes('::selection'))).toBe(false);
+    });
+
+    /**
+     * Issue #2518: on engines where CodeMirror cannot measure a caret position
+     * in an empty document, no `.cm-cursor` element is drawn and the focused
+     * empty input shows no caret at all. While the placeholder is showing
+     * (document empty) and the editor is focused, the theme re-enables the
+     * native caret and hides the drawn cursor layer instead.
+     */
+    test('the empty-document fallback re-enables the native caret while focused', () => {
+        // SAFETY: the theme spec is a plain object literal; indexing it with a
+        // selector key found in `selectors` (its own keys) is always defined.
+        const spec = COMPOSER_EDITOR_THEME_SPEC as Record<string, Record<string, string>>;
+        const rule = selectors.find((selector) =>
+            selector.includes('.cm-placeholder') && spec[selector].caretColor);
+        expect(rule).toBeDefined();
+        // SAFETY: `rule` was just asserted defined; the same keyed lookup is
+        // defined for the same reason as above.
+        const value = spec[rule!];
+        expect(value.caretColor.startsWith('var(--')).toBe(true);
+        expect(value.caretColor.includes('!important')).toBe(true);
+        // Must beat `drawSelection()`'s `Prec.highest` transparent caret.
+        expect(rule!.includes('&.cm-editor')).toBe(true);
+        expect(rule!.includes('.cm-focused')).toBe(true);
+    });
+
+    test('the empty-document fallback hides the drawn cursor layer', () => {
+        // SAFETY: the theme spec is a plain object literal; indexing it with a
+        // selector key found in `selectors` (its own keys) is always defined.
+        const spec = COMPOSER_EDITOR_THEME_SPEC as Record<string, Record<string, string>>;
+        const rule = selectors.find((selector) =>
+            selector.includes('.cm-placeholder') && selector.includes('.cm-cursorLayer'));
+        expect(rule).toBeDefined();
+        // SAFETY: `rule` was just asserted defined; the same keyed lookup is
+        // defined for the same reason as above.
+        const value = spec[rule!];
+        expect(value.display).toBe('none');
+    });
+
+    test('the empty-document fallback is scoped to the placeholder, so typing releases it', () => {
+        // SAFETY: the theme spec is a plain object literal; indexing it with a
+        // selector key found in `selectors` (its own keys) is always defined.
+        const spec = COMPOSER_EDITOR_THEME_SPEC as Record<string, Record<string, string>>;
+        const caretRule = selectors.find((selector) =>
+            selector.includes('.cm-placeholder') && spec[selector].caretColor);
+        const layerRule = selectors.find((selector) =>
+            selector.includes('.cm-placeholder') && selector.includes('.cm-cursorLayer'));
+        // The placeholder only exists while the document is empty, so both
+        // rules release automatically on the first keystroke.
+        expect(caretRule!.includes('.cm-placeholder')).toBe(true);
+        expect(layerRule!.includes('.cm-placeholder')).toBe(true);
     });
 });
 

--- a/packages/ui/src/components/chat/composer/editor/theme.ts
+++ b/packages/ui/src/components/chat/composer/editor/theme.ts
@@ -51,6 +51,24 @@ export const COMPOSER_EDITOR_THEME_SPEC = {
         transform: 'scaleY(1.15)',
         transformOrigin: 'center',
     },
+    // Empty-document caret fallback. The drawn cursor is only painted when
+    // CodeMirror can measure a caret position, and for an empty document that
+    // position resolves to the line's zero-width break/buffer geometry — some
+    // engines report no rects there, so no cursor element is drawn and the
+    // focused empty input shows no caret at all (`drawSelection()` also hides
+    // the native one). While the placeholder is showing (the document is
+    // empty) and the editor is focused, re-enable the native caret and hide
+    // the drawn cursor layer instead. The rules release the moment the first
+    // character is typed — the placeholder disappears, the native caret goes
+    // back to transparent, and the drawn cursor takes over before any
+    // keystroke-driven decoration redraw could make the native caret
+    // expensive.
+    '&.cm-editor.cm-focused:has(.cm-placeholder) .cm-content, &.cm-editor.cm-focused:has(.cm-placeholder) .cm-content .cm-line': {
+        caretColor: 'var(--surface-foreground) !important',
+    },
+    '&.cm-editor.cm-focused:has(.cm-placeholder) .cm-cursorLayer': {
+        display: 'none',
+    },
     '.cm-line': { padding: '0' },
     '.cm-scroller': {
         fontFamily: 'inherit',


### PR DESCRIPTION
## Intent

Fixes #2518. In the web UI, the chat input showed no blinking cursor when focused and empty, making focus state ambiguous. Root cause: the composer is a CodeMirror editor running `drawSelection()`, which hides the native caret (`caret-color: transparent`) and paints its own `.cm-cursor` element — but for an empty document the caret position resolves to zero-width geometry that reports no client rects, so no drawn cursor appears. The fix re-enables the native caret while the placeholder is showing (empty doc) and hides the drawn cursor layer, scoped to `&.cm-editor.cm-focused:has(.cm-placeholder)` so it releases automatically on the first keystroke.

## Non-goals

- No change to the drawn-cursor path when the document has text.
- No change to the iOS selection-handle workaround (the fallback releases before any keystroke-driven decoration redraw).

## Affected surfaces

- `packages/ui/src/components/chat/composer/editor/theme.ts` — shared composer theme, reaches web, desktop, VS Code, and mobile. All composer surfaces (shell mode, mini/compact chat, expanded focus) share this theme.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md root guide | Mandatory before editing | Read; minimal diff, no unrelated changes |
| `theme-system` skill | Styling/token rules | Uses semantic `--surface-foreground` token; no hardcoded colors |
| `openchamber-change-discipline` | Change risk classification | Local theme change at the shared primitive; validated at package level |
| `changelog-authoring` | Changelog entry | One bullet in `[Unreleased]` |

## Validation

| Check | Result |
|---|---|
| `bun test src/components/chat/composer/editor/` | ✅ 45 pass / 0 fail (17 in theme file incl. 3 new regression tests) |
| `bun test src/components/chat/composer/` | ✅ 291 pass / 0 fail |
| `bun run type-check` (packages/ui) | ✅ pass |
| `bun run lint` (packages/ui) | ✅ pass |
| `bunx oxlint` on changed files | ✅ no findings in authored code |
| Live browser checks (Chromium + Firefox, dark theme, narrow composer, shell mode, expanded focus, mini-chat) | ✅ empty+focused: native caret paints and blinks; typing releases fallback; deleting re-engages |
| Full packages/ui suite | ⚠️ 2076 pass / 254 fail / 13 errors — all failures pre-existing in unrelated files (e.g. markdownCore htmlCache #2769); every touched-area suite is green |

## Visual evidence

No screenshot captured in this environment; the live-browser verification above covers the rendered behavior (caret visible when focused+empty, released on typing).

## Risks and failure behavior

- `:has()` support: Chrome 105+, Firefox 121+, Safari 15.4+. On legacy engines the rule is ignored and behavior falls back to the pre-fix state (no regression).
- iOS: the fallback only engages while the placeholder is showing; the moment the first character is typed it releases, so the documented iOS input-latency concern does not apply.
- Behavior with text: unchanged — the drawn cursor path is untouched.