### PR TITLE
fix(server): keep env-provided OPENCODE_BINARY when settings clear the override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Desktop: browser pages served from a self-signed loopback HTTPS address now load instead of being blocked by the certificate warning.
 - Browser: typing a comment on a page no longer triggers app shortcuts.
 - Skills Catalog: the source is now named ClawHub instead of "ClawdHub" (thanks to @makeittech).
+- Settings: an explicitly set `OPENCODE_BINARY` environment variable is no longer discarded when settings contain an empty opencodeBinary value; the environment variable keeps pointing the managed OpenCode server at the binary you chose.
 
 ## [1.18.4] - 2026-08-14
 

--- a/packages/web/server/lib/opencode/env-runtime.js
+++ b/packages/web/server/lib/opencode/env-runtime.js
@@ -1011,7 +1011,13 @@ export const createOpenCodeEnvRuntime = (deps) => {
       const normalized = normalizeOpencodeBinarySetting(settings.opencodeBinary);
 
       if (normalized === '') {
-        delete process.env.OPENCODE_BINARY;
+        // The empty-string sentinel drops a previously APPLIED settings
+        // override (source === 'settings'). An OPENCODE_BINARY provided by
+        // the user's own environment is explicit configuration and must not
+        // be destroyed by an empty setting.
+        if (state.resolvedOpencodeBinarySource === 'settings') {
+          delete process.env.OPENCODE_BINARY;
+        }
         state.resolvedOpencodeBinary = null;
         state.resolvedOpencodeBinarySource = null;
         clearWslOpencodeResolution();

--- a/packages/web/server/lib/opencode/env-runtime.test.js
+++ b/packages/web/server/lib/opencode/env-runtime.test.js
@@ -200,6 +200,39 @@ describe('OpenCode env runtime', () => {
     expect(state.resolvedOpencodeBinarySource).toBe('settings');
   });
 
+  it('keeps an env-provided OPENCODE_BINARY when the setting is an empty-string sentinel', async () => {
+    const dir = createTempDir('openchamber-env-opencode-');
+    const binary = path.join(dir, 'opencode');
+    fs.writeFileSync(binary, '#!/bin/sh\nexit 0\n');
+    if (process.platform !== 'win32') fs.chmodSync(binary, 0o755);
+    process.env.OPENCODE_BINARY = binary;
+    const { runtime, state } = createRuntime({ opencodeBinary: '' });
+
+    await expect(runtime.applyOpencodeBinaryFromSettings()).resolves.toBeNull();
+    expect(process.env.OPENCODE_BINARY).toBe(binary);
+    expect(state.resolvedOpencodeBinary).toBeNull();
+    expect(state.resolvedOpencodeBinarySource).toBeNull();
+  });
+
+  it('drops a previously applied settings override when the setting is cleared to an empty string', async () => {
+    const dir = createTempDir('openchamber-settings-opencode-');
+    const binary = path.join(dir, 'opencode');
+    fs.writeFileSync(binary, '#!/bin/sh\nexit 0\n');
+    if (process.platform !== 'win32') fs.chmodSync(binary, 0o755);
+    const settings = { opencodeBinary: binary };
+    const { runtime, state } = createRuntime(settings);
+
+    await expect(runtime.applyOpencodeBinaryFromSettings()).resolves.toBe(binary);
+    expect(process.env.OPENCODE_BINARY).toBe(binary);
+    expect(state.resolvedOpencodeBinarySource).toBe('settings');
+
+    settings.opencodeBinary = '';
+    await expect(runtime.applyOpencodeBinaryFromSettings()).resolves.toBeNull();
+    expect(process.env.OPENCODE_BINARY).toBeUndefined();
+    expect(state.resolvedOpencodeBinary).toBeNull();
+    expect(state.resolvedOpencodeBinarySource).toBeNull();
+  });
+
   it('prefers the bundled CLI over a user-installed OpenCode from PATH', () => {
     const bundledDir = createTempDir('openchamber-bundled-opencode-');
     const bundledBinary = path.join(bundledDir, process.platform === 'win32' ? 'opencode.exe' : 'opencode');


### PR DESCRIPTION
## Intent

Fixes #2763. `OPENCODE_BINARY` set in the environment was silently destroyed when `settings.json` contained `opencodeBinary: ""`, causing the managed OpenCode server to fail with `spawn opencode ENOENT`. Root cause: `applyOpencodeBinaryFromSettings` unconditionally deleted `process.env.OPENCODE_BINARY` when the setting normalized to `''`. The empty-string sentinel exists to drop a **previously applied** override (one the app itself set from a non-empty setting, tracked by `state.resolvedOpencodeBinarySource === 'settings'`). The fix gates the delete on that source, so an env-provided `OPENCODE_BINARY` survives while the sentinel still drops settings-applied overrides.

## Non-goals

- No change to the sentinel contract (settings-applied overrides are still dropped on clear).
- The mixed case (env var + previously applied settings value + clear) still deletes the env var — pre-existing behavior inherent to "who last applied" tracking; a cleaner design (snapshot original env at module load) is future work.

## Affected surfaces

- `packages/web/server/lib/opencode/env-runtime.js` — `applyOpencodeBinaryFromSettings` (delete gated on source).
- `packages/web/server/lib/opencode/env-runtime.test.js` — 2 new tests.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md root guide | Mandatory before editing | Read; minimal diff, no unrelated changes |
| `openchamber-change-discipline` | Change risk classification | Local server-module change; validated at package level |
| `changelog-authoring` | Changelog entry | One bullet in `[Unreleased]` |

## Validation

| Check | Result |
|---|---|
| `bun run test -- server/lib/opencode/env-runtime.test.js` (packages/web) | ✅ 19 pass / 1 skipped |
| `bun run test -- server/lib/opencode` | ✅ 40 files, 370 pass / 2 skipped |
| `bun run test` (packages/web) | ✅ 158 files, 1566 pass / 2 skipped (2 unrelated flaky suites pass on rerun) |
| `bun run type-check` (packages/web) | ✅ pass |
| `bun run lint` (packages/web) | ✅ pass |
| `bunx oxlint` on changed files | ✅ zero findings in added code (pre-existing `typeof` findings untouched) |
| Live `openchamber serve` on NixOS/systemd | ⚠️ Not run — correctness covered by unit tests of the exact code path plus the spawn path reading the env var |

## Visual evidence

No rendered UI change (server-side fix). The reporter's logs in #2763 show the ENOENT failure; the fix preserves the env var so the spawn path honors it.

## Risks and failure behavior

- Startup path: state initializes source `null` → sentinel with env var present → gate blocks delete → `ensureOpencodeCliEnv` re-adopts the env value as `'env'`. Fixed.
- Refresh path: `clearResolvedOpenCodeBinary` clears only the binary, not the source, so `'settings'` survives to the sentinel check. Correct.
- Snapshot path: `resolveOpencodeCliPath()` restores the previous source before `applyOpencodeBinaryFromSettings` runs, so the gate never sees a clobbered source.