### PR TITLE
Fix Changes Walkthrough for plugin-backed OpenCode models

### DIFF
--- a/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/DefaultsSettings.tsx
@@ -275,8 +275,8 @@ export const DefaultsSettings: React.FC = () => {
     [walkthroughModelOverride]
   );
   React.useEffect(() => {
-    // Both pickers filter by the same authenticated-provider list, and the
-    // walkthrough picker is always visible, so this is always worth fetching.
+    // Only the direct Small Model picker needs OpenChamber's credential list.
+    // Walkthrough inference delegates provider availability to OpenCode.
     let cancelled = false;
     (async () => {
       try {
@@ -452,7 +452,6 @@ export const DefaultsSettings: React.FC = () => {
                   providerId={parsedWalkthroughModel.providerId}
                   modelId={parsedWalkthroughModel.modelId}
                   onChange={handleWalkthroughModelOverrideChange}
-                  allowedProviderIds={smallModelProviders}
                   isModelAllowed={isStructuredOutputCapable}
                   placeholder={t('settings.openchamber.defaults.walkthroughModel.usesSmallModel')}
                   className={SETTINGS_CUSTOM_TRIGGER_CLASS}

--- a/packages/ui/src/components/sections/openchamber/defaultsWalkthroughModelProviders.test.ts
+++ b/packages/ui/src/components/sections/openchamber/defaultsWalkthroughModelProviders.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const source = readFileSync(join(fileURLToPath(new URL('.', import.meta.url)), 'DefaultsSettings.tsx'), 'utf8')
+
+const selectorFor = (providerExpression: string): string => {
+  const start = source.indexOf(`<ModelSelector\n                  providerId={${providerExpression}}`)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf('/>', start)
+  return source.slice(start, end)
+}
+
+describe('DefaultsSettings model provider filters', () => {
+  test('keeps direct-login filtering only on Small Model', () => {
+    expect(selectorFor('parsedSmallModel.providerId')).toContain('allowedProviderIds={smallModelProviders}')
+    expect(selectorFor('parsedWalkthroughModel.providerId')).not.toContain('allowedProviderIds=')
+    expect(selectorFor('parsedWalkthroughModel.providerId')).toContain('isModelAllowed={isStructuredOutputCapable}')
+  })
+})

--- a/packages/ui/src/components/views/walkthrough/WalkthroughBlocker.tsx
+++ b/packages/ui/src/components/views/walkthrough/WalkthroughBlocker.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Icon } from '@/components/icon/Icon';
 import { ModelSelector } from '@/components/sections/agents/ModelSelector';
 import { Button } from '@/components/ui/button';
 import { useI18n } from '@/lib/i18n';
 import { useConfigStore } from '@/stores/useConfigStore';
-import { runtimeFetch } from '@/lib/runtime-fetch';
 import { updateDesktopSettings } from '@/lib/persistence';
 import type { WalkthroughBlockedState, WalkthroughModel } from '@/lib/walkthrough/types';
 
@@ -33,7 +32,6 @@ export const WalkthroughBlocker = ({
 }: WalkthroughBlockerProps) => {
   const { t } = useI18n();
   const modelsMetadata = useConfigStore((state) => state.modelsMetadata);
-  const [providers, setProviders] = useState<string[] | undefined>(undefined);
   const [saving, setSaving] = useState(false);
 
   // Every one of these means "this small model cannot do this job", so the
@@ -42,32 +40,6 @@ export const WalkthroughBlocker = ({
   const canChooseModel = reason === 'context-too-small'
     || reason === 'structured-output-unsupported'
     || reason === 'output-exhausted';
-
-  useEffect(() => {
-    if (!canChooseModel || providers !== undefined) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const response = await runtimeFetch('/api/small-model', {
-          method: 'GET',
-          headers: { Accept: 'application/json' },
-        });
-        if (!response.ok) return;
-        const payload = (await response.json().catch(() => null)) as
-          | { authenticatedProviders?: unknown }
-          | null;
-        if (!cancelled && Array.isArray(payload?.authenticatedProviders)) {
-          setProviders(payload.authenticatedProviders.filter((id): id is string => typeof id === 'string'));
-        }
-      } catch {
-        // Leave undefined: the picker then offers every provider, which is a
-        // worse experience but not a broken one.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [canChooseModel, providers]);
 
   const handleModelChange = useCallback(
     async (providerId: string, modelId: string) => {
@@ -152,7 +124,6 @@ export const WalkthroughBlocker = ({
             onChange={(providerId, modelId) => {
               void handleModelChange(providerId, modelId);
             }}
-            allowedProviderIds={providers ?? []}
             isModelAllowed={isStructuredOutputCapable}
           />
         </div>

--- a/packages/ui/src/components/views/walkthrough/WalkthroughView.tsx
+++ b/packages/ui/src/components/views/walkthrough/WalkthroughView.tsx
@@ -17,7 +17,6 @@ import { buildWalkthroughView } from '@/lib/walkthrough/model';
 import type { WalkthroughSource, WalkthroughWorkingTreeScope } from '@/lib/walkthrough/types';
 import { ModelSelector } from '@/components/sections/agents/ModelSelector';
 import { deriveBaseBranch, hasResolvableBaseBranch } from '@/components/views/git/baseBranch';
-import { runtimeFetch } from '@/lib/runtime-fetch';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { useGitBranches, useGitStatus, useGitStore } from '@/stores/useGitStore';
 import { useGitHubAuthStore } from '@/stores/useGitHubAuthStore';

--- a/packages/ui/src/components/views/walkthrough/WalkthroughView.tsx
+++ b/packages/ui/src/components/views/walkthrough/WalkthroughView.tsx
@@ -348,59 +348,16 @@ export const WalkthroughView = ({ directory }: WalkthroughViewProps) => {
   // Explicit pick first, then the model that actually produced what is on
   // screen, then whatever settings resolve to. The middle step is what makes
   // reopening a review show the model behind it rather than the default.
-  // Never present a provider without a usable login as the current selection —
-  // the picker already hides them from the menu; showing one as selected was
-  // the whole "why say so?" failure mode.
   const modelsMetadata = useConfigStore((state) => state.modelsMetadata);
-  const [modelProviders, setModelProviders] = useState<string[] | undefined>(undefined);
-
-  const providerIsAuthenticated = (providerId: string | undefined) => {
-    if (!providerId) return false;
-    // Until the auth list loads, do not present a candidate as selected —
-    // otherwise an unauthenticated config model flashes in the picker.
-    if (modelProviders === undefined) return false;
-    return modelProviders.includes(providerId);
-  };
   const readinessModelRef = entry.readiness?.model
-    && entry.readiness.model.hasLogin !== false
-    && providerIsAuthenticated(entry.readiness.model.providerID)
     ? `${entry.readiness.model.providerID}/${entry.readiness.model.modelID}`
     : undefined;
   const resultModelRef = entry.result?.model
-    && providerIsAuthenticated(entry.result.model.providerID)
     ? `${entry.result.model.providerID}/${entry.result.model.modelID}`
     : undefined;
-  const selectedModelUsable = selectedModel
-    && providerIsAuthenticated(selectedModel.split('/')[0])
-    ? selectedModel
-    : undefined;
-  const activeModel = selectedModelUsable ?? resultModelRef ?? readinessModelRef;
+  const activeModel = selectedModel ?? resultModelRef ?? readinessModelRef;
   const [activeProviderId, ...activeModelParts] = (activeModel ?? '').split('/');
   const activeModelId = activeModelParts.join('/');
-
-  useEffect(() => {
-    if (modelProviders !== undefined) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const response = await runtimeFetch('/api/small-model', {
-          method: 'GET',
-          headers: { Accept: 'application/json' },
-        });
-        if (!response.ok) return;
-        const payload = (await response.json().catch(() => null)) as { authenticatedProviders?: unknown } | null;
-        if (!cancelled && Array.isArray(payload?.authenticatedProviders)) {
-          setModelProviders(payload.authenticatedProviders.filter((id): id is string => typeof id === 'string'));
-        }
-      } catch {
-        // Leave undefined: the picker then offers every provider, which is
-        // worse but not broken.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [modelProviders]);
 
   const isStructuredOutputCapable = useCallback(
     (providerId: string, modelId: string) =>
@@ -620,8 +577,6 @@ export const WalkthroughView = ({ directory }: WalkthroughViewProps) => {
             onChange={(providerId, modelId) => {
               selectModel(directory, source, providerId && modelId ? `${providerId}/${modelId}` : null);
             }}
-            // While the auth list is loading, allow none — not every provider.
-            allowedProviderIds={modelProviders ?? []}
             isModelAllowed={isStructuredOutputCapable}
             tooltipsEnabled={false}
             dropdownPortalToBody

--- a/packages/ui/src/lib/opencode/client.permission.test.ts
+++ b/packages/ui/src/lib/opencode/client.permission.test.ts
@@ -87,6 +87,7 @@ mock.module('@/lib/runtime-url', () => ({
 mock.module('@/lib/runtime-switch', () => ({
   getRuntimeApiBaseUrl: mock(() => ''),
   getRuntimeKey: mock(() => 'test-runtime'),
+  subscribeRuntimeEndpointWillChange: mock(() => () => undefined),
 }));
 
 mock.module('@/lib/runtime-fetch', () => ({

--- a/packages/ui/src/lib/opencode/client.test.ts
+++ b/packages/ui/src/lib/opencode/client.test.ts
@@ -56,6 +56,7 @@ mock.module('@/lib/runtime-url', () => ({
 mock.module('@/lib/runtime-switch', () => ({
   getRuntimeApiBaseUrl: mock(() => ''),
   getRuntimeKey: mock(() => runtimeKey),
+  subscribeRuntimeEndpointWillChange: mock(() => () => undefined),
 }));
 
 mock.module('@/lib/runtime-fetch', () => ({

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -16,7 +16,7 @@ import { isAmbiguousTransportFailure, markAmbiguousTransportFailure } from "@/li
 import { FilesystemError, parseFilesystemErrorReason } from "@/lib/api/files-errors";
 import type { PermissionRequest } from "@/types/permission";
 import type { QuestionRequest } from "@/types/question";
-import { visibleOpenCodeSessions } from "@/lib/sessionInternalMetadata";
+import { getOpenChamberInternalSessionGeneration, visibleOpenCodeSessions } from "@/lib/sessionInternalMetadata";
 
 /**
  * Tagged result of `OpencodeService.fetchPermission()`. The caller can
@@ -549,10 +549,11 @@ class OpencodeService {
 
   // Session Management
   async listSessions(): Promise<Session[]> {
+    const internalSessionGeneration = getOpenChamberInternalSessionGeneration();
     const response = await this.client.session.list(
       this.currentDirectory ? { directory: this.currentDirectory } : undefined
     );
-    return visibleOpenCodeSessions(Array.isArray(response.data) ? response.data : []);
+    return visibleOpenCodeSessions(Array.isArray(response.data) ? response.data : [], internalSessionGeneration);
   }
 
   async createSession(params?: { parentID?: string; title?: string; metadata?: Record<string, unknown> }, directory?: string | null): Promise<Session> {

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -16,6 +16,7 @@ import { isAmbiguousTransportFailure, markAmbiguousTransportFailure } from "@/li
 import { FilesystemError, parseFilesystemErrorReason } from "@/lib/api/files-errors";
 import type { PermissionRequest } from "@/types/permission";
 import type { QuestionRequest } from "@/types/question";
+import { visibleOpenCodeSessions } from "@/lib/sessionInternalMetadata";
 
 /**
  * Tagged result of `OpencodeService.fetchPermission()`. The caller can
@@ -551,7 +552,7 @@ class OpencodeService {
     const response = await this.client.session.list(
       this.currentDirectory ? { directory: this.currentDirectory } : undefined
     );
-    return Array.isArray(response.data) ? response.data : [];
+    return visibleOpenCodeSessions(Array.isArray(response.data) ? response.data : []);
   }
 
   async createSession(params?: { parentID?: string; title?: string; metadata?: Record<string, unknown> }, directory?: string | null): Promise<Session> {

--- a/packages/ui/src/lib/sessionInternalMetadata.test.ts
+++ b/packages/ui/src/lib/sessionInternalMetadata.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'bun:test'
 import type { Event, Session } from '@opencode-ai/sdk/v2/client'
 import {
   isOpenChamberInternalSessionEvent,
+  getOpenChamberInternalSessionGeneration,
   resetOpenChamberInternalSessions,
+  visibleOpenCodeSessions,
 } from './sessionInternalMetadata'
 
 const session = (id: string, metadata?: Session['metadata']): Session => ({
@@ -31,5 +33,21 @@ describe('internal session metadata', () => {
     expect(isOpenChamberInternalSessionEvent(deleted)).toBe(true)
     // SAFETY: The test constructs the exact session.idle fields consumed by the predicate.
     expect(isOpenChamberInternalSessionEvent({ id: 'evt_idle', type: 'session.idle', properties: { sessionID: 'ses_delete' } } as Event)).toBe(false)
+  })
+
+  test('stale list filtering hides marked records without repopulating ids after a runtime switch', () => {
+    const runtimeAGeneration = getOpenChamberInternalSessionGeneration()
+    resetOpenChamberInternalSessions()
+    const marked = session('ses_race', { openchamber: { internalSession: { kind: 'walkthrough-inference' } } })
+    expect(visibleOpenCodeSessions([marked], runtimeAGeneration)).toEqual([])
+    expect(isOpenChamberInternalSessionEvent(created(session('ses_race')))).toBe(false)
+  })
+
+  test('current list filtering registers marked ids for later id-only events', () => {
+    const generation = getOpenChamberInternalSessionGeneration()
+    const marked = session('ses_current', { openchamber: { internalSession: { kind: 'walkthrough-inference' } } })
+    expect(visibleOpenCodeSessions([marked], generation)).toEqual([])
+    // SAFETY: The test constructs the exact session.idle fields consumed by the predicate.
+    expect(isOpenChamberInternalSessionEvent({ id: 'evt_current', type: 'session.idle', properties: { sessionID: 'ses_current' } } as Event)).toBe(true)
   })
 })

--- a/packages/ui/src/lib/sessionInternalMetadata.test.ts
+++ b/packages/ui/src/lib/sessionInternalMetadata.test.ts
@@ -50,4 +50,19 @@ describe('internal session metadata', () => {
     // SAFETY: The test constructs the exact session.idle fields consumed by the predicate.
     expect(isOpenChamberInternalSessionEvent({ id: 'evt_current', type: 'session.idle', properties: { sessionID: 'ses_current' } } as Event)).toBe(true)
   })
+
+  test('stale deletion cannot clear a current-runtime classification', () => {
+    const staleGeneration = getOpenChamberInternalSessionGeneration()
+    resetOpenChamberInternalSessions()
+    const marked = session('ses_delete_collision', { openchamber: { internalSession: { kind: 'walkthrough-inference' } } })
+    expect(isOpenChamberInternalSessionEvent(created(marked))).toBe(true)
+    // SAFETY: The test constructs the SDK session.deleted fields consumed by the predicate.
+    expect(isOpenChamberInternalSessionEvent({
+      id: 'evt_stale_delete', type: 'session.deleted', properties: { sessionID: marked.id },
+    } as Event, staleGeneration)).toBe(false)
+    // SAFETY: The test constructs the SDK session.idle fields consumed by the predicate.
+    expect(isOpenChamberInternalSessionEvent({
+      id: 'evt_current_idle', type: 'session.idle', properties: { sessionID: marked.id },
+    } as Event)).toBe(true)
+  })
 })

--- a/packages/ui/src/lib/sessionInternalMetadata.test.ts
+++ b/packages/ui/src/lib/sessionInternalMetadata.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import type { Event, Session } from '@opencode-ai/sdk/v2/client'
+import {
+  isOpenChamberInternalSessionEvent,
+  resetOpenChamberInternalSessions,
+} from './sessionInternalMetadata'
+
+const session = (id: string, metadata?: Session['metadata']): Session => ({
+  id, slug: id, projectID: 'project', directory: '/repo', title: id, version: '1',
+  time: { created: 1, updated: 1 }, metadata,
+})
+
+// SAFETY: The test constructs the exact session.created event fields consumed by the predicate.
+const created = (info: Session): Event => ({ id: 'evt_created', type: 'session.created', properties: { info } } as Event)
+
+describe('internal session metadata', () => {
+  test('runtime reset prevents an internal id from hiding a colliding user session', () => {
+    const internal = session('ses_collision', { openchamber: { internalSession: { kind: 'walkthrough-inference', version: 1 } } })
+    expect(isOpenChamberInternalSessionEvent(created(internal))).toBe(true)
+    resetOpenChamberInternalSessions()
+    expect(isOpenChamberInternalSessionEvent(created(session('ses_collision')))).toBe(false)
+  })
+
+  test('metadata-bearing delete is hidden and always clears the id', () => {
+    // SAFETY: OpenCode's current deletion payload can include the deleted session as properties.info.
+    const deleted = {
+      id: 'evt_deleted',
+      type: 'session.deleted',
+      properties: { info: session('ses_delete', { openchamber: { internalSession: { kind: 'walkthrough-inference' } } }) },
+    } as Event
+    expect(isOpenChamberInternalSessionEvent(deleted)).toBe(true)
+    // SAFETY: The test constructs the exact session.idle fields consumed by the predicate.
+    expect(isOpenChamberInternalSessionEvent({ id: 'evt_idle', type: 'session.idle', properties: { sessionID: 'ses_delete' } } as Event)).toBe(false)
+  })
+})

--- a/packages/ui/src/lib/sessionInternalMetadata.ts
+++ b/packages/ui/src/lib/sessionInternalMetadata.ts
@@ -36,19 +36,23 @@ export const visibleOpenCodeSessions = <T extends Session>(sessions: T[], genera
   sessions.filter((session) => !rememberOpenChamberInternalSession(session, generation))
 )
 
-export const isOpenChamberInternalSessionEvent = (event: Event): boolean => {
+export const isOpenChamberInternalSessionEvent = (
+  event: Event,
+  generation = internalSessionGeneration,
+): boolean => {
   // SAFETY: every OpenCode event carries a properties object; the optional
   // fields below are the union members shared by session-addressed events.
   const properties = (event as { properties?: { info?: Session; sessionID?: string } }).properties
   const info = properties?.info
   const sessionID = properties?.sessionID ?? info?.id
+  const currentGeneration = generation === internalSessionGeneration
   if (event.type === 'session.deleted') {
-    const hidden = Boolean((info && isOpenChamberInternalSession(info)) || (sessionID && internalSessionIds.has(sessionID)))
-    if (sessionID) internalSessionIds.delete(sessionID)
+    const hidden = Boolean((info && isOpenChamberInternalSession(info)) || (currentGeneration && sessionID && internalSessionIds.has(sessionID)))
+    if (currentGeneration && sessionID) internalSessionIds.delete(sessionID)
     return hidden
   }
-  if (info && rememberOpenChamberInternalSession(info)) return true
-  return Boolean(sessionID && internalSessionIds.has(sessionID))
+  if (info && rememberOpenChamberInternalSession(info, generation)) return true
+  return Boolean(currentGeneration && sessionID && internalSessionIds.has(sessionID))
 }
 
 subscribeRuntimeEndpointWillChange(resetOpenChamberInternalSessions)

--- a/packages/ui/src/lib/sessionInternalMetadata.ts
+++ b/packages/ui/src/lib/sessionInternalMetadata.ts
@@ -1,0 +1,47 @@
+import type { Event, Session } from '@opencode-ai/sdk/v2/client'
+import { subscribeRuntimeEndpointWillChange } from '@/lib/runtime-switch'
+
+const INTERNAL_SESSION_KIND = 'walkthrough-inference'
+const MAX_TRACKED_INTERNAL_SESSIONS = 10_000
+const internalSessionIds = new Map<string, true>()
+
+export const resetOpenChamberInternalSessions = (): void => internalSessionIds.clear()
+
+const isOpenChamberInternalSession = (session: Pick<Session, 'metadata'> | null | undefined): boolean => {
+  // SAFETY: Session.metadata is SDK-owned but intentionally open-ended; this
+  // local view reads only our namespaced optional marker without widening it.
+  const metadata = session?.metadata as { openchamber?: { internalSession?: { kind?: unknown } } } | undefined
+  return metadata?.openchamber?.internalSession?.kind === INTERNAL_SESSION_KIND
+}
+
+export const rememberOpenChamberInternalSession = (session: Session): boolean => {
+  if (!isOpenChamberInternalSession(session)) return false
+  internalSessionIds.delete(session.id)
+  internalSessionIds.set(session.id, true)
+  while (internalSessionIds.size > MAX_TRACKED_INTERNAL_SESSIONS) {
+    const oldest = internalSessionIds.keys().next().value
+    if (oldest) internalSessionIds.delete(oldest)
+  }
+  return true
+}
+
+export const visibleOpenCodeSessions = <T extends Session>(sessions: T[]): T[] => (
+  sessions.filter((session) => !rememberOpenChamberInternalSession(session))
+)
+
+export const isOpenChamberInternalSessionEvent = (event: Event): boolean => {
+  // SAFETY: every OpenCode event carries a properties object; the optional
+  // fields below are the union members shared by session-addressed events.
+  const properties = (event as { properties?: { info?: Session; sessionID?: string } }).properties
+  const info = properties?.info
+  const sessionID = properties?.sessionID ?? info?.id
+  if (event.type === 'session.deleted') {
+    const hidden = Boolean((info && isOpenChamberInternalSession(info)) || (sessionID && internalSessionIds.has(sessionID)))
+    if (sessionID) internalSessionIds.delete(sessionID)
+    return hidden
+  }
+  if (info && rememberOpenChamberInternalSession(info)) return true
+  return Boolean(sessionID && internalSessionIds.has(sessionID))
+}
+
+subscribeRuntimeEndpointWillChange(resetOpenChamberInternalSessions)

--- a/packages/ui/src/lib/sessionInternalMetadata.ts
+++ b/packages/ui/src/lib/sessionInternalMetadata.ts
@@ -4,8 +4,14 @@ import { subscribeRuntimeEndpointWillChange } from '@/lib/runtime-switch'
 const INTERNAL_SESSION_KIND = 'walkthrough-inference'
 const MAX_TRACKED_INTERNAL_SESSIONS = 10_000
 const internalSessionIds = new Map<string, true>()
+let internalSessionGeneration = 0
 
-export const resetOpenChamberInternalSessions = (): void => internalSessionIds.clear()
+export const getOpenChamberInternalSessionGeneration = (): number => internalSessionGeneration
+
+export const resetOpenChamberInternalSessions = (): void => {
+  internalSessionGeneration += 1
+  internalSessionIds.clear()
+}
 
 const isOpenChamberInternalSession = (session: Pick<Session, 'metadata'> | null | undefined): boolean => {
   // SAFETY: Session.metadata is SDK-owned but intentionally open-ended; this
@@ -14,8 +20,9 @@ const isOpenChamberInternalSession = (session: Pick<Session, 'metadata'> | null 
   return metadata?.openchamber?.internalSession?.kind === INTERNAL_SESSION_KIND
 }
 
-export const rememberOpenChamberInternalSession = (session: Session): boolean => {
+export const rememberOpenChamberInternalSession = (session: Session, generation = internalSessionGeneration): boolean => {
   if (!isOpenChamberInternalSession(session)) return false
+  if (generation !== internalSessionGeneration) return true
   internalSessionIds.delete(session.id)
   internalSessionIds.set(session.id, true)
   while (internalSessionIds.size > MAX_TRACKED_INTERNAL_SESSIONS) {
@@ -25,8 +32,8 @@ export const rememberOpenChamberInternalSession = (session: Session): boolean =>
   return true
 }
 
-export const visibleOpenCodeSessions = <T extends Session>(sessions: T[]): T[] => (
-  sessions.filter((session) => !rememberOpenChamberInternalSession(session))
+export const visibleOpenCodeSessions = <T extends Session>(sessions: T[], generation = internalSessionGeneration): T[] => (
+  sessions.filter((session) => !rememberOpenChamberInternalSession(session, generation))
 )
 
 export const isOpenChamberInternalSessionEvent = (event: Event): boolean => {

--- a/packages/ui/src/stores/globalSessions.test.ts
+++ b/packages/ui/src/stores/globalSessions.test.ts
@@ -2,8 +2,70 @@ import { describe, expect, test } from 'bun:test'
 import type { OpencodeClient } from '@opencode-ai/sdk/v2'
 
 import { listGlobalSessionPages, splitGlobalSessionsByArchived } from './globalSessions'
+import { isOpenChamberInternalSessionEvent, resetOpenChamberInternalSessions } from '@/lib/sessionInternalMetadata'
+import type { Event, Session } from '@opencode-ai/sdk/v2/client'
 
 describe('listGlobalSessionPages', () => {
+  test('a stale runtime response filters marked sessions without repopulating the current registry', async () => {
+    let resolveList: ((value: { data: Session[]; response: { headers: Headers } }) => void) | undefined
+    const apiClient = {
+      experimental: { session: { list: () => new Promise((resolve) => { resolveList = resolve }) } },
+    } as unknown as OpencodeClient
+    const loading = listGlobalSessionPages(apiClient, { archived: false, pageSize: 500 })
+    await Promise.resolve()
+    resetOpenChamberInternalSessions()
+    resolveList?.({
+      data: [{
+        id: 'ses_runtime_collision',
+        slug: 'runtime-collision',
+        projectID: 'project',
+        directory: '/runtime-a',
+        title: 'Internal',
+        version: '1',
+        metadata: { openchamber: { internalSession: { kind: 'walkthrough-inference' } } },
+        time: { created: 1, updated: 2 },
+      }],
+      response: { headers: new Headers() },
+    })
+
+    expect(await loading).toEqual([])
+    // SAFETY: This fixture contains the SDK session.created fields consumed by the public event predicate.
+    const currentRuntimeEvent = {
+      id: 'evt_current_runtime',
+      type: 'session.created',
+      properties: { info: {
+        id: 'ses_runtime_collision', slug: 'runtime-collision', projectID: 'project', directory: '/runtime-b',
+        title: 'User session', version: '1', time: { created: 3, updated: 3 },
+      } },
+    } as Event
+    expect(isOpenChamberInternalSessionEvent(currentRuntimeEvent)).toBe(false)
+  })
+
+  test('registers a marked session from the successful runtime-B retry attempt', async () => {
+    let attempts = 0
+    const marked = {
+      id: 'ses_retry_runtime', slug: 'retry-runtime', projectID: 'project', directory: '/runtime-b',
+      title: 'Internal', version: '1', time: { created: 1, updated: 2 },
+      metadata: { openchamber: { internalSession: { kind: 'walkthrough-inference' } } },
+    }
+    const apiClient = {
+      experimental: { session: { list: async () => {
+        attempts += 1
+        if (attempts === 1) {
+          resetOpenChamberInternalSessions()
+          throw new Error('runtime A disconnected')
+        }
+        return { data: [marked], response: { headers: new Headers() } }
+      } } },
+    } as unknown as OpencodeClient
+
+    expect(await listGlobalSessionPages(apiClient, { archived: false, pageSize: 500 })).toEqual([])
+    // SAFETY: The fixture contains the SDK session.idle fields consumed by the event predicate.
+    expect(isOpenChamberInternalSessionEvent({
+      id: 'evt_retry_runtime', type: 'session.idle', properties: { sessionID: marked.id },
+    } as Event)).toBe(true)
+  })
+
   test('sanitizes session list records before returning them', async () => {
     const apiClient = {
       experimental: {

--- a/packages/ui/src/stores/globalSessions.test.ts
+++ b/packages/ui/src/stores/globalSessions.test.ts
@@ -138,6 +138,28 @@ describe('listGlobalSessionPages', () => {
     expect(sessions.map((session) => session.id)).toEqual(['ses_active_1', 'ses_active_2'])
   })
 
+  test('filters internal sessions from list pages without stopping pagination', async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const apiClient = {
+      experimental: { session: { list: async (options: Record<string, unknown>) => {
+        calls.push(options)
+        if (options.cursor === undefined) return {
+          data: [
+            { id: 'ses_internal', time: { updated: 20 }, metadata: { openchamber: { internalSession: { kind: 'walkthrough-inference', version: 1 } } } },
+            { id: 'ses_visible', time: { updated: 10 } },
+          ],
+          response: { headers: new Headers({ 'x-next-cursor': '10' }) },
+        }
+        return { data: [{ id: 'ses_visible_2', time: { updated: 5 } }], response: { headers: new Headers() } }
+      } } },
+    } as unknown as OpencodeClient
+
+    const sessions = await listGlobalSessionPages(apiClient, { directory: '/repo', archived: false, pageSize: 2 })
+
+    expect(calls).toHaveLength(2)
+    expect(sessions.map((session) => session.id)).toEqual(['ses_visible', 'ses_visible_2'])
+  })
+
   test('returns the inclusive response unfiltered when narrowing is disabled', async () => {
     const apiClient = {
       experimental: {

--- a/packages/ui/src/stores/globalSessions.ts
+++ b/packages/ui/src/stores/globalSessions.ts
@@ -3,6 +3,7 @@ import { runBackgroundNetworkTask } from '@/lib/background-network';
 import { retry } from "@/sync/retry";
 import { stripSessionListDetails } from "@/sync/sanitize";
 import { startSessionLoadPerformanceEvent } from "@/sync/session-load-performance";
+import { rememberOpenChamberInternalSession } from '@/lib/sessionInternalMetadata';
 
 export type GlobalSessionRecord = Session & {
     project?: {
@@ -20,47 +21,20 @@ const toNumber = (value: string | null): number | null => {
     return Number.isFinite(parsed) ? parsed : null;
 };
 
-const readResponseHeader = (response: unknown, header: string): string | null => {
-    if (!response || typeof response !== "object") {
-        return null;
-    }
-    const container = response as { headers?: unknown };
-    const headers = container.headers;
-    if (!headers || typeof headers !== "object") {
-        return null;
-    }
-
-    const maybeGet = headers as { get?: (name: string) => string | null };
-    if (typeof maybeGet.get === "function") {
-        return maybeGet.get(header);
-    }
-
-    const maybeRecord = headers as Record<string, unknown>;
-    const direct = maybeRecord[header] ?? maybeRecord[header.toLowerCase()];
-    return typeof direct === "string" ? direct : null;
-};
-
-const formatSdkError = (error: unknown): string => {
-    if (error instanceof Error) return error.message;
-    if (typeof error === "string") return error;
-    if (error && typeof error === "object" && "message" in error && typeof (error as { message?: unknown }).message === "string") {
-        return (error as { message: string }).message;
-    }
-    try {
-        return JSON.stringify(error);
-    } catch {
-        return String(error);
-    }
-};
+const readResponseHeader = (response: { headers?: Headers } | undefined, header: string): string | null => (
+    response?.headers?.get(header) ?? null
+);
 
 const unwrapSessionList = (
-    result: { data?: Session[]; error?: unknown; response?: { status?: number } },
+    result: Awaited<ReturnType<OpencodeClient["experimental"]["session"]["list"]>>,
     operation: string,
 ): GlobalSessionRecord[] => {
-    if (result.error) {
+    if ("error" in result && result.error) {
         const status = result.response?.status;
-        const error = new Error(`${operation} failed${status ? ` (${status})` : ""}: ${formatSdkError(result.error)}`);
+        const detail = result.error instanceof Error ? result.error.message : JSON.stringify(result.error);
+        const error = new Error(`${operation} failed${status ? ` (${status})` : ""}: ${detail}`);
         if (status !== undefined) {
+            // SAFETY: status is an intentional local extension used by retry callers.
             (error as Error & { status?: number }).status = status;
         }
         throw error;
@@ -68,11 +42,12 @@ const unwrapSessionList = (
 
     if (!Array.isArray(result.data)) {
         const error = new Error(`${operation} returned no data`);
+        // SAFETY: status is an intentional local extension used by retry callers.
         (error as Error & { status?: number }).status = 503;
         throw error;
     }
 
-    return result.data as GlobalSessionRecord[];
+    return result.data;
 };
 
 /**
@@ -95,7 +70,7 @@ const isArchivedSession = (session: GlobalSessionRecord): boolean => Boolean(ses
  */
 export const splitGlobalSessionsByArchived = <T extends GlobalSessionRecord>(
     sessions: T[],
-): { active: T[]; archived: T[] } => {
+) => {
     const active: T[] = [];
     const archived: T[] = [];
     for (const session of sessions) {
@@ -144,15 +119,16 @@ export async function listGlobalSessionPages(
         const { response, payload } = await runBackgroundNetworkTask(() => retry(
             async () => {
                 attempts += 1;
-                const response = await apiClient.experimental.session.list({
-                    ...(options.directory ? { directory: options.directory } : {}),
+                const request: Parameters<typeof apiClient.experimental.session.list>[0] = {
                     archived: options.archived,
-                    ...(options.roots !== undefined ? { roots: options.roots } : {}),
                     limit: options.pageSize,
-                    ...(cursor !== undefined ? { cursor } : {}),
-                });
+                };
+                if (options.directory) request.directory = options.directory;
+                if (options.roots !== undefined) request.roots = options.roots;
+                if (cursor !== undefined) request.cursor = cursor;
+                const response = await apiClient.experimental.session.list(request);
                 const payload = unwrapSessionList(response, "experimental.session.list")
-                    .map((session) => stripSessionListDetails(session) as GlobalSessionRecord);
+                    .map((session) => stripSessionListDetails(session));
                 return { response, payload };
             },
             { attempts: 3, delay: 500, retryIf: () => true },
@@ -177,6 +153,7 @@ export async function listGlobalSessionPages(
             if (!session?.id || seenIds.has(session.id)) continue;
             seenIds.add(session.id);
             appended += 1;
+            if (rememberOpenChamberInternalSession(session)) continue;
             if (options.archived && narrowToArchived && !isArchivedSession(session)) continue;
             all.push(session);
             accepted.push(session);
@@ -190,10 +167,10 @@ export async function listGlobalSessionPages(
 
         // Prefer server header; fall back to last session's `time.updated`
         // (cursor semantics on server = "updated strictly before this timestamp").
-        const headerCursor = toNumber(readResponseHeader(response, "x-next-cursor"));
+        const headerCursor = toNumber(readResponseHeader(response.response, "x-next-cursor"));
         const lastUpdated = payload[payload.length - 1]?.time?.updated;
         const nextCursor = headerCursor
-            ?? (typeof lastUpdated === "number" && Number.isFinite(lastUpdated) ? lastUpdated : undefined);
+            ?? (Number.isFinite(lastUpdated) ? lastUpdated : undefined);
 
         if (nextCursor === undefined) break;
         // Loop guard: cursor must move backwards in time.

--- a/packages/ui/src/stores/globalSessions.ts
+++ b/packages/ui/src/stores/globalSessions.ts
@@ -3,7 +3,7 @@ import { runBackgroundNetworkTask } from '@/lib/background-network';
 import { retry } from "@/sync/retry";
 import { stripSessionListDetails } from "@/sync/sanitize";
 import { startSessionLoadPerformanceEvent } from "@/sync/session-load-performance";
-import { rememberOpenChamberInternalSession } from '@/lib/sessionInternalMetadata';
+import { getOpenChamberInternalSessionGeneration, rememberOpenChamberInternalSession } from '@/lib/sessionInternalMetadata';
 
 export type GlobalSessionRecord = Session & {
     project?: {
@@ -116,9 +116,10 @@ export async function listGlobalSessionPages(
             operation,
             caller: cursor === undefined ? "initial-page" : "pagination",
         });
-        const { response, payload } = await runBackgroundNetworkTask(() => retry(
+        const { response, payload, internalSessionGeneration } = await runBackgroundNetworkTask(() => retry(
             async () => {
                 attempts += 1;
+                const internalSessionGeneration = getOpenChamberInternalSessionGeneration();
                 const request: Parameters<typeof apiClient.experimental.session.list>[0] = {
                     archived: options.archived,
                     limit: options.pageSize,
@@ -129,7 +130,7 @@ export async function listGlobalSessionPages(
                 const response = await apiClient.experimental.session.list(request);
                 const payload = unwrapSessionList(response, "experimental.session.list")
                     .map((session) => stripSessionListDetails(session));
-                return { response, payload };
+                return { response, payload, internalSessionGeneration };
             },
             { attempts: 3, delay: 500, retryIf: () => true },
         )).catch((error) => {
@@ -153,7 +154,7 @@ export async function listGlobalSessionPages(
             if (!session?.id || seenIds.has(session.id)) continue;
             seenIds.add(session.id);
             appended += 1;
-            if (rememberOpenChamberInternalSession(session)) continue;
+            if (rememberOpenChamberInternalSession(session, internalSessionGeneration)) continue;
             if (options.archived && narrowToArchived && !isArchivedSession(session)) continue;
             all.push(session);
             accepted.push(session);

--- a/packages/ui/src/stores/useAgentGroupsStore.internalSessions.test.ts
+++ b/packages/ui/src/stores/useAgentGroupsStore.internalSessions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, mock, test } from 'bun:test'
+import type { Event, Session } from '@opencode-ai/sdk/v2/client'
+import { isOpenChamberInternalSessionEvent, resetOpenChamberInternalSessions } from '@/lib/sessionInternalMetadata'
+
+mock.module('@/lib/worktrees/worktreeManager', () => ({
+  listProjectWorktrees: async () => [],
+  removeProjectWorktree: async () => undefined,
+}))
+
+const { listVisibleAgentGroupSessions } = await import('./useAgentGroupsStore')
+
+describe('agent group internal session filtering', () => {
+  test('registers a marked session from the successful runtime-B retry attempt', async () => {
+    let attempts = 0
+    const marked: Session = {
+      id: 'ses_agent_retry', slug: 'agent-retry', projectID: 'project', directory: '/runtime-b',
+      title: 'group/provider/model', version: '1', time: { created: 1, updated: 2 },
+      metadata: { openchamber: { internalSession: { kind: 'walkthrough-inference' } } },
+    }
+    const api = {
+      session: { list: async () => {
+        attempts += 1
+        if (attempts === 1) {
+          resetOpenChamberInternalSessions()
+          throw new Error('failed to fetch from runtime A')
+        }
+        return { data: [marked], error: undefined }
+      } },
+    }
+
+    // SAFETY: The mock implements the session.list portion consumed by this focused boundary helper.
+    expect(await listVisibleAgentGroupSessions(api as Parameters<typeof listVisibleAgentGroupSessions>[0], '/runtime-b')).toEqual([])
+    // SAFETY: The fixture contains the SDK session.idle fields consumed by the event predicate.
+    expect(isOpenChamberInternalSessionEvent({
+      id: 'evt_agent_retry', type: 'session.idle', properties: { sessionID: marked.id },
+    } as Event)).toBe(true)
+  })
+})

--- a/packages/ui/src/stores/useAgentGroupsStore.ts
+++ b/packages/ui/src/stores/useAgentGroupsStore.ts
@@ -7,7 +7,7 @@ import { deleteSessionInDirectory } from '@/sync/session-actions';
 import { retry } from '@/sync/retry';
 import type { WorktreeMetadata } from '@/types/worktree';
 import type { Session } from '@opencode-ai/sdk/v2';
-import { visibleOpenCodeSessions } from '@/lib/sessionInternalMetadata';
+import { getOpenChamberInternalSessionGeneration, visibleOpenCodeSessions } from '@/lib/sessionInternalMetadata';
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -190,6 +190,21 @@ interface AgentGroupsActions {
 
 type Store = AgentGroupsState & AgentGroupsActions;
 
+export async function listVisibleAgentGroupSessions(
+  api: ReturnType<typeof opencodeClient.getApiClient>,
+  directory: string,
+): Promise<Session[]> {
+  const result = await retry(async () => {
+    const internalSessionGeneration = getOpenChamberInternalSessionGeneration();
+    const response = await api.session.list({ directory });
+    if (response.error) {
+      throw new Error(`session.list failed for ${directory}: ${String(response.error)}`);
+    }
+    return { response, internalSessionGeneration };
+  });
+  return visibleOpenCodeSessions(result.response.data ?? [], result.internalSessionGeneration);
+}
+
 export const useAgentGroupsStore = create<Store>()(
   (set, get) => ({
     groups: [],
@@ -232,14 +247,7 @@ export const useAgentGroupsStore = create<Store>()(
 
         const fetchDir = async (dir: string) => {
           try {
-            const res = await retry(async () => {
-              const result = await api.session.list({ directory: dir });
-              if ((result as { error?: unknown }).error) {
-                throw new Error(`session.list failed for ${dir}: ${String((result as { error?: unknown }).error)}`);
-              }
-              return result;
-            });
-            const list = visibleOpenCodeSessions(Array.isArray(res.data) ? res.data : []);
+            const list = await listVisibleAgentGroupSessions(api, dir);
             for (const s of list) if (s?.id) allSessions.push(s);
           } catch {
             failedDirectories.add(dir);

--- a/packages/ui/src/stores/useAgentGroupsStore.ts
+++ b/packages/ui/src/stores/useAgentGroupsStore.ts
@@ -7,6 +7,7 @@ import { deleteSessionInDirectory } from '@/sync/session-actions';
 import { retry } from '@/sync/retry';
 import type { WorktreeMetadata } from '@/types/worktree';
 import type { Session } from '@opencode-ai/sdk/v2';
+import { visibleOpenCodeSessions } from '@/lib/sessionInternalMetadata';
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -238,7 +239,7 @@ export const useAgentGroupsStore = create<Store>()(
               }
               return result;
             });
-            const list = Array.isArray(res.data) ? res.data : [];
+            const list = visibleOpenCodeSessions(Array.isArray(res.data) ? res.data : []);
             for (const s of list) if (s?.id) allSessions.push(s);
           } catch {
             failedDirectories.add(dir);

--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -20,6 +20,13 @@ There are **two distinct session data scopes** in the UI:
      - global archived sessions
      - active sessions indexed by directory
 
+Both scopes reject sessions carrying the canonical OpenChamber internal-session
+metadata marker. Paginated bootstrap/list ingestion filters the marker at the
+data boundary, while the event boundary remembers a bounded set of marked ids
+so later id-only status/message events cannot create user-facing state.
+The bounded id memory is cleared before a runtime endpoint switch because
+session ids can collide across OpenCode runtimes.
+
 These two scopes are intentionally different, but they are no longer equal peers for live UI truth.
 
 ### Why both exist

--- a/packages/ui/src/sync/__tests__/sync-context-session-events.test.ts
+++ b/packages/ui/src/sync/__tests__/sync-context-session-events.test.ts
@@ -5,7 +5,7 @@ let currentSessions: Session[] = []
 const upsertedSessions: Session[] = []
 const removedSessionIds: string[] = []
 let runtimeKey = "runtime-a"
-let runtimeWillChange: (() => void) | null = null
+const runtimeWillChangeCallbacks: Array<() => void> = []
 
 mock.module("@/stores/useGlobalSessionsStore", () => ({
   isGlobalSessionRecencyOnlyUpdate: (existing: Session, incoming: Session) => (
@@ -30,8 +30,11 @@ mock.module("@/stores/useGlobalSessionsStore", () => ({
 mock.module("@/lib/runtime-switch", () => ({
   getRuntimeKey: () => runtimeKey,
   subscribeRuntimeEndpointWillChange: (callback: () => void) => {
-    runtimeWillChange = callback
-    return () => undefined
+    runtimeWillChangeCallbacks.push(callback)
+    return () => {
+      const index = runtimeWillChangeCallbacks.indexOf(callback)
+      if (index >= 0) runtimeWillChangeCallbacks.splice(index, 1)
+    }
   },
 }))
 import { applySessionEventToGlobalSessions } from "../session-event-router"
@@ -49,6 +52,11 @@ const buildEvent = (session: Session): Event => ({
   },
 } as Event)
 
+const buildCreatedEvent = (session: Session): Event => ({
+  type: "session.created",
+  properties: { info: session },
+} as Event)
+
 const buildDeleteEvent = (sessionId: string): Event => ({
   type: "session.deleted",
   properties: { sessionID: sessionId },
@@ -61,7 +69,7 @@ const buildLifecycleEvent = (type: "session.idle" | "session.error", sessionId: 
 
 describe("applySessionEventToGlobalSessions", () => {
   beforeEach(() => {
-    runtimeWillChange?.()
+    runtimeWillChangeCallbacks.forEach((callback) => callback())
     runtimeKey = "runtime-a"
     currentSessions = []
     upsertedSessions.length = 0
@@ -111,9 +119,23 @@ describe("applySessionEventToGlobalSessions", () => {
     applySessionEventToGlobalSessions(buildEvent(buildSession("Initial", { created: 1, updated: 20 })))
 
     runtimeKey = "runtime-b"
-    runtimeWillChange?.()
+    runtimeWillChangeCallbacks.forEach((callback) => callback())
     applySessionEventToGlobalSessions(buildLifecycleEvent("session.idle", "ses_1"))
 
     expect(upsertedSessions).toEqual([])
   })
+
+  test("ignores internal session create and update events", () => {
+    const internal = {
+      ...buildSession("Walkthrough", { created: 1, updated: 10 }),
+      metadata: { openchamber: { internalSession: { kind: "walkthrough-inference", version: 1 } } },
+    } as Session
+
+    applySessionEventToGlobalSessions(buildCreatedEvent(internal))
+    applySessionEventToGlobalSessions(buildEvent({ ...internal, time: { created: 1, updated: 20 } }))
+    applySessionEventToGlobalSessions(buildLifecycleEvent("session.idle", internal.id))
+
+    expect(upsertedSessions).toEqual([])
+  })
+
 })

--- a/packages/ui/src/sync/event-pipeline.test.ts
+++ b/packages/ui/src/sync/event-pipeline.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test"
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client"
 import { createEventPipeline } from "./event-pipeline"
+import {
+  isOpenChamberInternalSessionEvent,
+  resetOpenChamberInternalSessions,
+} from "@/lib/sessionInternalMetadata"
 
 const failAfter = (ms: number) => new Promise<never>((_, reject) => {
   setTimeout(() => reject(new Error("Timed out waiting for event pipeline flush")), ms)
@@ -68,6 +72,56 @@ function createSdk(events: Event[], streamFinished: () => void): OpencodeClient 
 }
 
 describe("createEventPipeline", () => {
+  test("an old pipeline flush suppresses marked events without contaminating the new runtime", async () => {
+    let resolveStreamFinished!: () => void
+    const streamFinished = new Promise<void>((resolve) => { resolveStreamFinished = resolve })
+    const markedInfo = {
+      id: "ses_collision", slug: "collision", projectID: "project", directory: "/runtime-a",
+      title: "Internal", version: "1", time: { created: 1, updated: 1 },
+      metadata: { openchamber: { internalSession: { kind: "walkthrough-inference" } } },
+    }
+    // SAFETY: The fixture includes the complete SDK session.created contract used by the pipeline.
+    const marked = {
+      id: "evt_internal_a",
+      type: "session.created",
+      properties: {
+        sessionID: markedInfo.id,
+        info: markedInfo,
+      },
+    } as Event
+    const delivered: boolean[] = []
+    const pipeline = createEventPipeline({
+      sdk: createSdk([marked], resolveStreamFinished),
+      transport: "sse",
+      onEvents: (_directory, events, generation) => {
+        delivered.push(...events.map((event) => isOpenChamberInternalSessionEvent(event, generation)))
+      },
+    })
+    await Promise.race([streamFinished, failAfter(500)])
+    resetOpenChamberInternalSessions()
+    pipeline.cleanup()
+
+    expect(delivered).toEqual([true])
+    const ordinaryB = {
+      id: "evt_user_b", type: "session.created",
+      properties: { info: {
+        id: "ses_collision", slug: "collision", projectID: "project", directory: "/runtime-b",
+        title: "User", version: "1", time: { created: 2, updated: 2 },
+      } },
+    } as Event
+    expect(isOpenChamberInternalSessionEvent(ordinaryB)).toBe(false)
+
+    const markedB = {
+      ...marked,
+      id: "evt_internal_b",
+      properties: { sessionID: markedInfo.id, info: { ...markedInfo, directory: "/runtime-b" } },
+    } as Event
+    expect(isOpenChamberInternalSessionEvent(markedB)).toBe(true)
+    expect(isOpenChamberInternalSessionEvent({
+      id: "evt_idle_b", type: "session.idle", properties: { sessionID: "ses_collision" },
+    } as Event)).toBe(true)
+  })
+
   test("delivers one ordered batch per directory flush", async () => {
     let resolveStreamFinished!: () => void
     const streamFinished = new Promise<void>((resolve) => {

--- a/packages/ui/src/sync/event-pipeline.ts
+++ b/packages/ui/src/sync/event-pipeline.ts
@@ -20,6 +20,7 @@ import { type RelayTunnelWebSocket } from "@/lib/relay/tunnel-client"
 import { openRuntimeWebSocket } from "@/lib/relay/runtime-socket"
 import { syncDebug } from "./debug"
 import { countSyncPerformance } from "./performance-diagnostics"
+import { getOpenChamberInternalSessionGeneration } from "@/lib/sessionInternalMetadata"
 
 const FLUSH_FRAME_MS = 33
 const BACKPRESSURE_FLUSH_FRAME_MS = 200
@@ -40,11 +41,11 @@ const RETRY_BACKOFF_CAP_VISIBLE_MS = 5_000
 const RETRY_BACKOFF_CAP_HIDDEN_OR_OFFLINE_MS = 60_000
 const RETRY_BACKOFF_MAX_EXPONENT = 8
 type EventPipelineDelivery = {
-  onEvent: (directory: string, payload: Event) => void
+  onEvent: (directory: string, payload: Event, internalSessionGeneration: number) => void
   onEvents?: never
 } | {
   onEvent?: never
-  onEvents: (directory: string, payloads: readonly Event[]) => void
+  onEvents: (directory: string, payloads: readonly Event[], internalSessionGeneration: number) => void
 }
 
 export type EventPipelineInput = {
@@ -261,6 +262,7 @@ export function createEventPipeline(input: EventPipelineInput): EventPipeline {
     wsReadyTimeoutMs = DEFAULT_WS_READY_TIMEOUT_MS,
   } = input
   const abort = new AbortController()
+  const internalSessionGeneration = getOpenChamberInternalSessionGeneration()
   let disconnected = false
   let lastEventId: string | undefined
   let wsFallbackUntil = 0
@@ -321,9 +323,9 @@ export function createEventPipeline(input: EventPipelineInput): EventPipeline {
       countSyncPerformance("pipelineDeliveredEvents")
     }
     if (onEvents) {
-      onEvents(directory, events)
+      onEvents(directory, events, internalSessionGeneration)
     } else if (onEvent) {
-      for (const payload of events) onEvent(directory, payload)
+      for (const payload of events) onEvent(directory, payload, internalSessionGeneration)
     }
 
     d.buffer.length = 0

--- a/packages/ui/src/sync/session-event-router.ts
+++ b/packages/ui/src/sync/session-event-router.ts
@@ -67,8 +67,8 @@ const getGlobalSessionSnapshot = (sessionId: string): Session | null => {
   return [...global.activeSessions, ...global.archivedSessions].find((session) => session.id === sessionId) ?? null
 }
 
-export const applySessionEventToGlobalSessions = (payload: Event): void => {
-  if (isOpenChamberInternalSessionEvent(payload)) return
+export const applySessionEventToGlobalSessions = (payload: Event, internalSessionGeneration?: number): void => {
+  if (isOpenChamberInternalSessionEvent(payload, internalSessionGeneration)) return
   if (payload.type === "session.idle" || payload.type === "session.error") {
     // SAFETY: session.idle/error share this SDK-owned properties contract.
     const sessionID = (payload as { properties?: { sessionID?: string } }).properties?.sessionID

--- a/packages/ui/src/sync/session-event-router.ts
+++ b/packages/ui/src/sync/session-event-router.ts
@@ -4,6 +4,7 @@ import { getRuntimeKey, subscribeRuntimeEndpointWillChange } from "@/lib/runtime
 import { streamPerfCount, streamPerfMark } from "@/stores/utils/streamDebug"
 import { stripSessionDiffSnapshots } from "./sanitize"
 import { shouldSkipStaleSessionEvent } from "./session-event-freshness"
+import { isOpenChamberInternalSessionEvent } from "@/lib/sessionInternalMetadata"
 
 const pendingGlobalSessionUpdates = new Map<string, { runtimeKey: string; session: Session }>()
 
@@ -40,22 +41,25 @@ const getSessionInfoFromPayload = (event: Event): Session | null => {
     return null
   }
 
-  const properties = (event as { properties?: unknown }).properties
-  if (!properties || typeof properties !== "object") {
+  // SAFETY: OpenCode session lifecycle events own a properties object; this
+  // narrow view reads only their shared info field before validating it.
+  const properties = (event as { properties?: { info?: Partial<Session> } }).properties
+  if (!properties) {
     return null
   }
 
-  const info = (properties as { info?: unknown }).info
-  if (!info || typeof info !== "object") {
+  const info = properties.info
+  if (!info) {
     return null
   }
 
-  const session = info as Partial<Session>
-  if (typeof session.id !== "string" || !session.time) {
+  if (info.id?.constructor !== String || !info.time) {
     return null
   }
 
-  return stripSessionDiffSnapshots(session as Session)
+  // SAFETY: id and time are the required Session fields consumed by this
+  // boundary; the SDK event contract supplies the remaining session fields.
+  return stripSessionDiffSnapshots(info as Session)
 }
 
 const getGlobalSessionSnapshot = (sessionId: string): Session | null => {
@@ -64,9 +68,11 @@ const getGlobalSessionSnapshot = (sessionId: string): Session | null => {
 }
 
 export const applySessionEventToGlobalSessions = (payload: Event): void => {
+  if (isOpenChamberInternalSessionEvent(payload)) return
   if (payload.type === "session.idle" || payload.type === "session.error") {
-    const sessionID = (payload as { properties?: { sessionID?: unknown } }).properties?.sessionID
-    if (typeof sessionID === "string") flushPendingGlobalSessionUpdate(sessionID)
+    // SAFETY: session.idle/error share this SDK-owned properties contract.
+    const sessionID = (payload as { properties?: { sessionID?: string } }).properties?.sessionID
+    if (sessionID?.constructor === String) flushPendingGlobalSessionUpdate(sessionID)
     return
   }
 
@@ -99,6 +105,7 @@ export const applySessionEventToGlobalSessions = (payload: Event): void => {
   }
 
   if (payload.type === "session.deleted") {
+    // SAFETY: session.deleted may identify the session directly or carry info.
     const sessionID = (payload as { properties?: { sessionID?: string } }).properties?.sessionID ?? getSessionInfoFromPayload(payload)?.id
     if (sessionID) {
       pendingGlobalSessionUpdates.delete(sessionID)

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1456,8 +1456,9 @@ export function handleEvent(
   skipVSCodeAutoAccept = false,
   streamingDirectory?: string,
   batch?: DirectoryEventBatch,
+  internalSessionGeneration?: number,
 ) {
-  if (isOpenChamberInternalSessionEvent(payload)) return
+  if (isOpenChamberInternalSessionEvent(payload, internalSessionGeneration)) return
   if ((payload as { type?: unknown }).type === "openchamber:permission-auto-accept.updated") {
     const properties = (payload as unknown as { properties?: unknown }).properties
     if (properties && typeof properties === "object") {
@@ -1485,7 +1486,7 @@ export function handleEvent(
     return
   }
 
-  applySessionEventToGlobalSessions(payload)
+  applySessionEventToGlobalSessions(payload, internalSessionGeneration)
   // Keep the cross-project status map current for ALL directories (mirrors the
   // global-session handling above). Child stores remain the primary source for
   // synced directories; this map covers sessions a child store doesn't list
@@ -2253,7 +2254,7 @@ export function SyncProvider(props: {
       routeDirectory: (directory, payload) => {
         return resolveDirectoryFromRoutingIndex(routingIndex, directory, payload, childStores)
       },
-      onEvents: (directory, payloads) => {
+      onEvents: (directory, payloads, internalSessionGeneration) => {
         // Track ALL stream activity (including heartbeats) as proof of
         // connection health. The watchdog stale check uses this to distinguish
         // a genuinely dead stream (no heartbeats for 20s) from a quiet-but-
@@ -2273,7 +2274,7 @@ export function SyncProvider(props: {
                 dispatchOpenCodeUpdateAvailable({ version })
               }
             }
-            handleEvent(directory, payload, childStores, routingIndex, runtimeKey, false, currentDirectoryRef.current, batch)
+            handleEvent(directory, payload, childStores, routingIndex, runtimeKey, false, currentDirectoryRef.current, batch, internalSessionGeneration)
           }
         } finally {
           publishDirectoryEventBatch(batch)

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -43,7 +43,7 @@ import { getReconnectCandidateSessionIds, mergeBootstrapSessions } from "./recon
 import { messagesBefore } from "./message-ordering"
 import { opencodeClient } from "@/lib/opencode/client"
 import { usePermissionStore } from "@/stores/permissionStore"
-import { isOpenChamberInternalSessionEvent, visibleOpenCodeSessions } from "@/lib/sessionInternalMetadata"
+import { getOpenChamberInternalSessionGeneration, isOpenChamberInternalSessionEvent, visibleOpenCodeSessions } from "@/lib/sessionInternalMetadata"
 import {
   processVSCodePermissionAutoAccept,
   processVSCodeReconciledPermissionAutoAccept,
@@ -2342,8 +2342,9 @@ export function SyncProvider(props: {
       if (parentSessionIds.length === 0) return
       try {
         const scopedClient = opencodeClient.getScopedSdkClient(directory)
-        const result: unknown = await runBackgroundNetworkTask(() => scopedClient.session.list({ directory, limit: 200 }))
-        const allSessions = visibleOpenCodeSessions(((result as { data?: unknown }).data ?? []) as Session[])
+        const internalSessionGeneration = getOpenChamberInternalSessionGeneration()
+        const result = await runBackgroundNetworkTask(() => scopedClient.session.list({ directory, limit: 200 }))
+        const allSessions = visibleOpenCodeSessions(result.data ?? [], internalSessionGeneration)
         const state = store.getState()
         const existingIds = new Set(state.session.map((s) => s.id))
         const parentIdSet = new Set(parentSessionIds)

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -43,6 +43,7 @@ import { getReconnectCandidateSessionIds, mergeBootstrapSessions } from "./recon
 import { messagesBefore } from "./message-ordering"
 import { opencodeClient } from "@/lib/opencode/client"
 import { usePermissionStore } from "@/stores/permissionStore"
+import { isOpenChamberInternalSessionEvent, visibleOpenCodeSessions } from "@/lib/sessionInternalMetadata"
 import {
   processVSCodePermissionAutoAccept,
   processVSCodeReconciledPermissionAutoAccept,
@@ -1456,6 +1457,7 @@ export function handleEvent(
   streamingDirectory?: string,
   batch?: DirectoryEventBatch,
 ) {
+  if (isOpenChamberInternalSessionEvent(payload)) return
   if ((payload as { type?: unknown }).type === "openchamber:permission-auto-accept.updated") {
     const properties = (payload as unknown as { properties?: unknown }).properties
     if (properties && typeof properties === "object") {
@@ -2341,7 +2343,7 @@ export function SyncProvider(props: {
       try {
         const scopedClient = opencodeClient.getScopedSdkClient(directory)
         const result: unknown = await runBackgroundNetworkTask(() => scopedClient.session.list({ directory, limit: 200 }))
-        const allSessions = ((result as { data?: unknown }).data ?? []) as Session[]
+        const allSessions = visibleOpenCodeSessions(((result as { data?: unknown }).data ?? []) as Session[])
         const state = store.getState()
         const existingIds = new Set(state.session.map((s) => s.id))
         const parentIdSet = new Set(parentSessionIds)

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -72,6 +72,7 @@ import { createOpenCodeResolutionRuntime } from './lib/opencode/opencode-resolut
 import { resolveOpenCodeUpgradeCapability } from './lib/opencode/upgrade-capability.js';
 import { createBootstrapRuntime } from './lib/opencode/bootstrap-runtime.js';
 import { createSessionRuntime } from './lib/opencode/session-runtime.js';
+import { classifyOpenChamberInternalSessionEvent, isOpenChamberInternalSession, isOpenChamberInternalSessionEvent, resetOpenChamberInternalSessions } from './lib/opencode/internal-sessions.js';
 import { createOpenCodeWatcherRuntime } from './lib/opencode/watcher.js';
 import { createSessionAssistRuntime } from './lib/session-assist/runtime.js';
 import { createSessionGoalRuntime } from './lib/session-goal/runtime.js';
@@ -854,6 +855,21 @@ const globalMessageStreamHub = createGlobalMessageStreamHub({
   buildOpenCodeUrl,
   getOpenCodeAuthHeaders,
   upstreamStallTimeoutMs: getUpstreamStallTimeoutMs,
+  eventFilter: async (event) => {
+    const raw = event?.payload;
+    const payload = raw?.payload && typeof raw.payload === 'object' ? raw.payload : raw;
+    if (!payload || typeof payload !== 'object') return false;
+    const directory = typeof event?.directory === 'string' && event.directory !== 'global' ? event.directory : '';
+    return classifyOpenChamberInternalSessionEvent(payload, async (sessionId) => {
+      const query = directory ? `?directory=${encodeURIComponent(directory)}` : '';
+      const response = await fetch(`${buildOpenCodeUrl(`/session/${encodeURIComponent(sessionId)}`, '')}${query}`, {
+        headers: { Accept: 'application/json', ...getOpenCodeAuthHeaders() },
+        signal: AbortSignal.timeout(300),
+      });
+      if (!response.ok) throw new Error(`session lookup failed with ${response.status}`);
+      return response.json();
+    });
+  },
 });
 
 const permissionAutoAcceptRuntime = createPermissionAutoAcceptRuntime({
@@ -863,6 +879,16 @@ const permissionAutoAcceptRuntime = createPermissionAutoAcceptRuntime({
   readSettingsFromDiskMigrated,
   persistSettings,
   broadcastGlobalUiEvent,
+  isInternalSessionEvent: isOpenChamberInternalSessionEvent,
+  isInternalSession: async (sessionId, directory) => {
+    const query = directory ? `?directory=${encodeURIComponent(directory)}` : '';
+    const response = await fetch(`${buildOpenCodeUrl(`/session/${encodeURIComponent(sessionId)}`, '')}${query}`, {
+      headers: { Accept: 'application/json', ...getOpenCodeAuthHeaders() },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) throw new Error(`session lookup failed with ${response.status}`);
+    return isOpenChamberInternalSession(await response.json());
+  },
 });
 permissionAutoAcceptRuntime.start();
 notificationTriggerRuntime.setGetIsSessionAutoAccepting(
@@ -875,7 +901,15 @@ const openCodeWatcherRuntime = createOpenCodeWatcherRuntime({
   getOpenCodeAuthHeaders,
   parseSseDataPayload: (...args) => parseSseDataPayload(...args),
   globalEventHub: globalMessageStreamHub,
-  onPayload: (payload) => {
+  onPayload: async (payload) => {
+    if (await classifyOpenChamberInternalSessionEvent(payload, async (sessionId) => {
+      const response = await fetch(buildOpenCodeUrl(`/session/${encodeURIComponent(sessionId)}`, ''), {
+        headers: { Accept: 'application/json', ...getOpenCodeAuthHeaders() },
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!response.ok) throw new Error(`session lookup failed with ${response.status}`);
+      return response.json();
+    })) return;
     maybeCacheSessionInfoFromEvent(payload);
     void maybeSendPushForTrigger(payload);
     sessionRuntime.processOpenCodeSsePayload(payload);
@@ -885,13 +919,22 @@ const openCodeWatcherRuntime = createOpenCodeWatcherRuntime({
 // Session-assist subscribes to the hub directly: it needs the envelope's
 // directory to route its own OpenCode calls to the right instance.
 console.log('[session-assist] listening for session events');
-globalMessageStreamHub.subscribeEvent((event) => {
+globalMessageStreamHub.subscribeEvent(async (event) => {
   const raw = event?.payload;
   const payload = raw?.payload && typeof raw.payload === 'object' ? raw.payload : raw;
   if (!payload || typeof payload !== 'object') return;
   const directory = typeof event?.directory === 'string' && event.directory && event.directory !== 'global'
     ? event.directory
     : '';
+  if (await classifyOpenChamberInternalSessionEvent(payload, async (sessionId) => {
+    const query = directory ? `?directory=${encodeURIComponent(directory)}` : '';
+    const response = await fetch(`${buildOpenCodeUrl(`/session/${encodeURIComponent(sessionId)}`, '')}${query}`, {
+      headers: { Accept: 'application/json', ...getOpenCodeAuthHeaders() },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) throw new Error(`session lookup failed with ${response.status}`);
+    return response.json();
+  })) return;
   sessionAssistRuntime.processPayload(payload, directory);
   sessionGoalRuntime.processPayload(payload, directory);
   contextObligatoryRuntime.processPayload(payload, directory);
@@ -1162,6 +1205,10 @@ const openCodeLifecycleRuntime = createOpenCodeLifecycleRuntime({
   // process (#2638). The runtime is created later by the startup pipeline;
   // by the time any restart runs, it is assigned.
   onOpenCodeRestarted: () => {
+    resetOpenChamberInternalSessions();
+    void import('./lib/walkthrough/inference.js').then(({ resetWalkthroughInferenceRuntime }) => {
+      resetWalkthroughInferenceRuntime();
+    }).catch(() => {});
     try {
       messageStreamRuntime?.rebindUpstream();
     } catch (error) {
@@ -1909,6 +1956,15 @@ async function main(options = {}) {
     buildOpenCodeUrl,
     getOpenCodeAuthHeaders,
     globalEventHub: globalMessageStreamHub,
+    classifyDirectoryEvent: (payload, directory) => classifyOpenChamberInternalSessionEvent(payload, async (sessionId) => {
+      const query = directory && directory !== 'global' ? `?directory=${encodeURIComponent(directory)}` : '';
+      const response = await fetch(`${buildOpenCodeUrl(`/session/${encodeURIComponent(sessionId)}`, '')}${query}`, {
+        headers: { Accept: 'application/json', ...getOpenCodeAuthHeaders() },
+        signal: AbortSignal.timeout(300),
+      });
+      if (!response.ok) throw new Error(`session lookup failed with ${response.status}`);
+      return response.json();
+    }),
     processForwardedEventPayload,
     messageStreamWsClients: uiNotificationWsClients,
     upstreamStallTimeoutMs: getUpstreamStallTimeoutMs,

--- a/packages/web/server/lib/event-stream/directory-ws-bridge.js
+++ b/packages/web/server/lib/event-stream/directory-ws-bridge.js
@@ -26,6 +26,7 @@ export function acceptDirectoryMessageStreamWsConnection({
   upstreamStallTimeoutMs,
   upstreamReconnectDelayMs,
   fetchImpl,
+  classifyEvent = async () => false,
 }) {
   const controller = new AbortController();
   let upstreamConnected = false;
@@ -71,16 +72,22 @@ export function acceptDirectoryMessageStreamWsConnection({
   });
 
   const run = async () => {
+    let forwardQueue = Promise.resolve();
     const forwardEvent = ({ envelope, payload }) => {
       const directory = requestedDirectory || envelope?.directory || 'global';
-
-      sendMessageStreamWsEvent(socket, payload, {
+      const forwardingOptions = {
         directory,
-        eventId: typeof envelope?.eventId === 'string' && envelope.eventId.length > 0 ? envelope.eventId : undefined,
-      });
-
-      processForwardedEventPayload(payload, (syntheticPayload) => {
-        sendMessageStreamWsEvent(socket, syntheticPayload, { directory: 'global' });
+        eventId: envelope?.eventId?.constructor === String && envelope.eventId.length > 0 ? envelope.eventId : undefined,
+      };
+      forwardQueue = forwardQueue.then(async () => {
+        if (await classifyEvent(payload, directory)) return;
+        sendMessageStreamWsEvent(socket, payload, forwardingOptions);
+        processForwardedEventPayload(payload, (syntheticPayload) => {
+          sendMessageStreamWsEvent(socket, syntheticPayload, { directory: 'global' });
+        });
+      }).catch(() => {
+        // Classification failure is fail-open for transport availability.
+        sendMessageStreamWsEvent(socket, payload, forwardingOptions);
       });
     };
 

--- a/packages/web/server/lib/event-stream/global-hub.js
+++ b/packages/web/server/lib/event-stream/global-hub.js
@@ -11,6 +11,7 @@ export function createGlobalMessageStreamHub({
   upstreamStallTimeoutMs,
   upstreamReconnectDelayMs,
   replayLimit = MESSAGE_STREAM_GLOBAL_REPLAY_LIMIT,
+  eventFilter,
 }) {
   const eventSubscribers = new Set();
   const statusSubscribers = new Set();
@@ -21,11 +22,12 @@ export function createGlobalMessageStreamHub({
   let connected = false;
   let everConnected = false;
   let buildUrlFailed = false;
+  let eventQueue = Promise.resolve();
 
   const notifySubscriber = (kind, subscriber, payload) => {
     try {
       const result = subscriber(payload);
-      if (result && typeof result.catch === 'function') {
+      if (result?.catch instanceof Function) {
         result.catch((error) => {
           console.warn(`Global message stream ${kind} subscriber failed:`, error);
         });
@@ -42,9 +44,12 @@ export function createGlobalMessageStreamHub({
   };
 
   const normalizeEvent = ({ envelope, payload }) => {
-    const directory =
-      typeof envelope?.directory === 'string' && envelope.directory.length > 0 ? envelope.directory : 'global';
-    const eventId = typeof envelope?.eventId === 'string' && envelope.eventId.length > 0 ? envelope.eventId : undefined;
+    const directory = envelope?.directory?.constructor === String && envelope.directory.length > 0
+      ? envelope.directory
+      : 'global';
+    const eventId = envelope?.eventId?.constructor === String && envelope.eventId.length > 0
+      ? envelope.eventId
+      : undefined;
     return {
       envelope,
       payload,
@@ -86,16 +91,21 @@ export function createGlobalMessageStreamHub({
       },
       onEvent(event) {
         const normalized = normalizeEvent(event);
-        if (normalized.eventId) {
-          replay.push(normalized);
-          if (replay.length > replayLimit) {
-            replay.splice(0, replay.length - replayLimit);
+        eventQueue = eventQueue.then(async () => {
+          if (eventFilter instanceof Function && await eventFilter(normalized)) return;
+          if (normalized.eventId) {
+            replay.push(normalized);
+            if (replay.length > replayLimit) {
+              replay.splice(0, replay.length - replayLimit);
+            }
           }
-        }
 
-        for (const subscriber of Array.from(eventSubscribers)) {
-          notifySubscriber('event', subscriber, normalized);
-        }
+          for (const subscriber of Array.from(eventSubscribers)) {
+            notifySubscriber('event', subscriber, normalized);
+          }
+        }).catch((error) => {
+          console.warn('Global message stream event filter failed:', error);
+        });
       },
       onError(error) {
         if (controller?.signal.aborted) {
@@ -153,6 +163,9 @@ export function createGlobalMessageStreamHub({
 
       const index = replay.findIndex((entry) => entry.eventId === eventId);
       return index === -1 ? [] : replay.slice(index + 1);
+    },
+    drainEvents() {
+      return eventQueue;
     },
   };
 }

--- a/packages/web/server/lib/event-stream/global-hub.test.js
+++ b/packages/web/server/lib/event-stream/global-hub.test.js
@@ -137,4 +137,26 @@ describe('createGlobalMessageStreamHub', () => {
       warnSpy.mockRestore();
     }
   });
+
+  it('filters events before ordered fanout and replay without blocking later events', async () => {
+    const received = [];
+    const hub = createGlobalMessageStreamHub({
+      buildOpenCodeUrl: (pathname) => `http://127.0.0.1:4096${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      upstreamReconnectDelayMs: 100,
+      eventFilter: async (event) => event.eventId === 'evt-internal',
+      fetchImpl: async () => createSseResponse({ blocks: [
+        'id: evt-internal\ndata: {"type":"session.created","properties":{}}\n\nid: evt-visible\ndata: {"type":"session.updated","properties":{}}\n\n',
+      ] }),
+    });
+    hub.subscribeEvent((event) => received.push(event.eventId));
+    try {
+      hub.start();
+      await hub.drainEvents();
+      await waitForAssertion(() => expect(received).toEqual(['evt-visible']));
+      expect(hub.replayAfter('evt-internal')).toEqual([]);
+    } finally {
+      hub.stop();
+    }
+  });
 });

--- a/packages/web/server/lib/event-stream/runtime.js
+++ b/packages/web/server/lib/event-stream/runtime.js
@@ -39,8 +39,8 @@ export function createGlobalUiEventBroadcaster({
     if (hasWsClients) {
       for (const socket of Array.from(wsClients)) {
         const sent = sendMessageStreamWsEvent(socket, payload, {
-          directory: typeof options.directory === 'string' && options.directory.length > 0 ? options.directory : 'global',
-          eventId: typeof options.eventId === 'string' && options.eventId.length > 0 ? options.eventId : undefined,
+          directory: options.directory?.constructor === String && options.directory.length > 0 ? options.directory : 'global',
+          eventId: options.eventId?.constructor === String && options.eventId.length > 0 ? options.eventId : undefined,
         });
         if (!sent) {
           wsClients.delete(socket);
@@ -65,6 +65,7 @@ export function createMessageStreamWsRuntime({
   upstreamReconnectDelayMs = DEFAULT_UPSTREAM_RECONNECT_DELAY_MS,
   fetchImpl = fetch,
   globalEventHub = null,
+  classifyDirectoryEvent,
 }) {
   const wsServer = new WebSocketServer({
     noServer: true,
@@ -95,7 +96,7 @@ export function createMessageStreamWsRuntime({
   });
 
   wsServer.on('connection', (socket, req) => {
-    const rawUrl = typeof req?.url === 'string' ? req.url : MESSAGE_STREAM_GLOBAL_WS_PATH;
+    const rawUrl = req?.url?.constructor === String ? req.url : MESSAGE_STREAM_GLOBAL_WS_PATH;
     const pathname = parseRequestPathname(rawUrl);
     const requestUrl = new URL(rawUrl, 'http://127.0.0.1');
     const isGlobalStream = pathname === MESSAGE_STREAM_GLOBAL_WS_PATH;
@@ -127,6 +128,7 @@ export function createMessageStreamWsRuntime({
       upstreamStallTimeoutMs,
       upstreamReconnectDelayMs,
       fetchImpl,
+      classifyEvent: classifyDirectoryEvent,
     });
   });
 

--- a/packages/web/server/lib/event-stream/runtime.test.js
+++ b/packages/web/server/lib/event-stream/runtime.test.js
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createGlobalUiEventBroadcaster, createMessageStreamWsRuntime } from './runtime.js';
 
@@ -506,6 +506,43 @@ describe('message stream websocket runtime', () => {
       directory: 'global',
     });
 
+    socket.close();
+    await runtime.close();
+  });
+
+  it('classifies directory events before raw and synthetic forwarding while preserving ordinary traffic', async () => {
+    const server = new EventEmitter();
+    const synthetic = vi.fn();
+    const runtime = createMessageStreamWsRuntime({
+      server,
+      uiAuthController: null,
+      isRequestOriginAllowed: async () => true,
+      rejectWebSocketUpgrade() {},
+      buildOpenCodeUrl: (path) => `http://127.0.0.1:4096${path}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      processForwardedEventPayload(payload, emitSynthetic) {
+        synthetic(payload);
+        emitSynthetic({ type: 'openchamber:session-status', properties: { sessionID: payload.properties?.sessionID } });
+      },
+      classifyDirectoryEvent: async (payload) => payload.properties?.sessionID === 'ses_internal'
+        || payload.properties?.info?.metadata?.openchamber?.internalSession?.kind === 'walkthrough-inference',
+      wsClients: new Set(),
+      upstreamReconnectDelayMs: 0,
+      fetchImpl: async (_url, options) => createSseResponse({
+        signal: options.signal,
+        holdOpen: true,
+        blocks: [
+          'id: evt-1\ndata: {"type":"session.created","properties":{"info":{"id":"ses_internal","metadata":{"openchamber":{"internalSession":{"kind":"walkthrough-inference"}}}}}}\n\nid: evt-2\ndata: {"type":"session.status","properties":{"sessionID":"ses_internal"}}\n\nid: evt-3\ndata: {"type":"session.status","properties":{"sessionID":"ses_user"}}\n\n',
+        ],
+      }),
+    });
+    const socket = new FakeSocket();
+    runtime.wsServer.emit('connection', socket, { url: '/api/event/ws?directory=%2Frepo' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const events = socket.sent.filter((frame) => frame.type === 'event');
+    expect(events.some((frame) => frame.payload?.properties?.sessionID === 'ses_internal')).toBe(false);
+    expect(events.some((frame) => frame.payload?.properties?.sessionID === 'ses_user')).toBe(true);
+    expect(synthetic).toHaveBeenCalledTimes(1);
     socket.close();
     await runtime.close();
   });

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -45,6 +45,11 @@ This module provides OpenCode server integration utilities for the web server ru
 - `packages/web/server/lib/opencode/theme-runtime.js`: custom theme JSON validation and theme directory loading runtime for settings utility routes.
 - `packages/web/server/lib/opencode/proxy.js`: OpenCode API/SSE forwarding and readiness-gate route registration.
 - `packages/web/server/lib/opencode/session-runtime.js`: session status/attention/activity runtime for OpenCode SSE events.
+- `packages/web/server/lib/opencode/internal-sessions.js`: canonical metadata predicate and bounded id registry for OpenChamber-owned inference sessions. The server has one active OpenCode runtime; its registry resets when that runtime restarts/rebinds. The ordered global event boundary suppresses classified events before replay, clients, notifications, activity, assist, goal, context, and permission side effects.
+  Directory WebSocket streams apply the same classification before raw or
+  synthetic forwarding. Unknown id-only events share one short-deadline lookup
+  per session; lookup failure forwards traffic and is cached briefly before a
+  retry, while later metadata-bearing events remain authoritative.
 - `packages/web/server/lib/opencode/watcher.js`: global SSE watcher runtime for push/session event fanout.
 - `packages/web/server/lib/opencode/shared.js`: shared utilities for config, markdown, skills, and git helpers.
 - `packages/web/server/lib/ui-auth/ui-auth.js`: UI session authentication runtime (outside OpenCode module).

--- a/packages/web/server/lib/opencode/feature-routes-runtime.js
+++ b/packages/web/server/lib/opencode/feature-routes-runtime.js
@@ -301,7 +301,7 @@ export const createFeatureRoutesRuntime = (dependencies) => {
 
     registerQuotaRoutes(app, { getQuotaProviders });
     registerSmallModelRoutes(app, { getSmallModelService });
-    registerWalkthroughRoutes(app, { getWalkthroughService });
+    registerWalkthroughRoutes(app, { getWalkthroughService, buildOpenCodeUrl, getOpenCodeAuthHeaders });
     registerSessionGoalRoutes(app);
     registerGitHubRoutes(app);
     registerGitRoutes(app);

--- a/packages/web/server/lib/opencode/internal-sessions.js
+++ b/packages/web/server/lib/opencode/internal-sessions.js
@@ -1,0 +1,106 @@
+export const OPENCHAMBER_INTERNAL_SESSION_KIND = 'walkthrough-inference';
+
+const MAX_TRACKED_INTERNAL_SESSIONS = 10_000;
+const EVENT_LOOKUP_TIMEOUT_MS = 300;
+const LOOKUP_FAILURE_TTL_MS = 2_000;
+const classifiedSessionIds = new Map();
+const inFlightLookups = new Map();
+const lookupFailedUntil = new Map();
+let registryGeneration = 0;
+
+const rememberClassification = (sessionId, internal) => {
+  classifiedSessionIds.delete(sessionId);
+  classifiedSessionIds.set(sessionId, internal);
+  while (classifiedSessionIds.size > MAX_TRACKED_INTERNAL_SESSIONS) {
+    classifiedSessionIds.delete(classifiedSessionIds.keys().next().value);
+  }
+};
+
+export const internalSessionMetadata = () => ({
+  openchamber: {
+    internalSession: {
+      kind: OPENCHAMBER_INTERNAL_SESSION_KIND,
+      version: 1,
+    },
+  },
+});
+
+export const isOpenChamberInternalSession = (session) => (
+  session?.metadata?.openchamber?.internalSession?.kind === OPENCHAMBER_INTERNAL_SESSION_KIND
+);
+
+export const trackOpenChamberInternalSession = (sessionId) => {
+  if (sessionId?.constructor !== String || !sessionId) return;
+  rememberClassification(sessionId, true);
+};
+
+const sessionIdFromEvent = (payload) => payload?.properties?.sessionID
+  ?? payload?.properties?.info?.sessionID
+  ?? payload?.properties?.info?.id;
+
+export const isOpenChamberInternalSessionEvent = (payload) => {
+  const info = payload?.properties?.info;
+  const sessionId = sessionIdFromEvent(payload);
+  if (payload?.type === 'session.deleted') {
+    const internal = isOpenChamberInternalSession(info) || classifiedSessionIds.get(sessionId) === true;
+    if (sessionId) classifiedSessionIds.delete(sessionId);
+    return internal;
+  }
+  if (isOpenChamberInternalSession(info)) {
+    trackOpenChamberInternalSession(info.id ?? sessionId);
+    return true;
+  }
+  if (info?.id) {
+    rememberClassification(info.id, false);
+  }
+  return classifiedSessionIds.get(sessionId) === true;
+};
+
+export const classifyOpenChamberInternalSessionEvent = async (payload, lookupSession) => {
+  if (isOpenChamberInternalSessionEvent(payload)) return true;
+  const sessionId = sessionIdFromEvent(payload);
+  if (!sessionId || classifiedSessionIds.has(sessionId) || !(lookupSession instanceof Function)) return false;
+  if ((lookupFailedUntil.get(sessionId) ?? 0) > Date.now()) return false;
+  let lookup = inFlightLookups.get(sessionId);
+  if (!lookup) {
+    const generation = registryGeneration;
+    const underlying = Promise.resolve().then(() => lookupSession(sessionId));
+    lookup = { generation, underlying };
+    inFlightLookups.set(sessionId, lookup);
+    underlying.finally(() => {
+      if (inFlightLookups.get(sessionId)?.underlying === underlying) inFlightLookups.delete(sessionId);
+    }).catch(() => {});
+  }
+  try {
+    const session = await Promise.race([
+      lookup.underlying,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('session classification timed out')), EVENT_LOOKUP_TIMEOUT_MS)),
+    ]);
+    if (lookup.generation !== registryGeneration) return false;
+    if (isOpenChamberInternalSession(session)) {
+      trackOpenChamberInternalSession(sessionId);
+      lookupFailedUntil.delete(sessionId);
+      return true;
+    }
+    rememberClassification(sessionId, false);
+    lookupFailedUntil.delete(sessionId);
+  } catch {
+    if (lookup.generation === registryGeneration) lookupFailedUntil.set(sessionId, Date.now() + LOOKUP_FAILURE_TTL_MS);
+  }
+  return false;
+};
+
+export const forgetOpenChamberInternalSession = (sessionId) => {
+  classifiedSessionIds.delete(sessionId);
+};
+
+export const resetOpenChamberInternalSessions = () => {
+  registryGeneration += 1;
+  classifiedSessionIds.clear();
+  inFlightLookups.clear();
+  lookupFailedUntil.clear();
+};
+
+export const __testing = {
+  clear: resetOpenChamberInternalSessions,
+};

--- a/packages/web/server/lib/opencode/internal-sessions.test.js
+++ b/packages/web/server/lib/opencode/internal-sessions.test.js
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __testing, classifyOpenChamberInternalSessionEvent, internalSessionMetadata, isOpenChamberInternalSessionEvent } from './internal-sessions.js';
+
+describe('internal session event registry', () => {
+  beforeEach(() => __testing.clear());
+
+  it('recognizes metadata-bearing and later id-only events', () => {
+    expect(isOpenChamberInternalSessionEvent({
+      type: 'session.created', properties: { info: { id: 'ses_1', metadata: internalSessionMetadata() } },
+    })).toBe(true);
+    expect(isOpenChamberInternalSessionEvent({ type: 'session.status', properties: { sessionID: 'ses_1' } })).toBe(true);
+    expect(isOpenChamberInternalSessionEvent({ type: 'session.deleted', properties: { sessionID: 'ses_1' } })).toBe(true);
+    expect(isOpenChamberInternalSessionEvent({ type: 'session.status', properties: { sessionID: 'ses_1' } })).toBe(false);
+  });
+
+  it('classifies the metadata-bearing delete shape before always forgetting its id', () => {
+    const deleted = {
+      type: 'session.deleted',
+      properties: { info: { id: 'ses_deleted', metadata: internalSessionMetadata() } },
+    };
+    expect(isOpenChamberInternalSessionEvent(deleted)).toBe(true);
+    expect(isOpenChamberInternalSessionEvent({ type: 'session.status', properties: { sessionID: 'ses_deleted' } })).toBe(false);
+  });
+
+  it('does not hide ordinary or review sessions', () => {
+    expect(isOpenChamberInternalSessionEvent({
+      type: 'session.created', properties: { info: { id: 'ses_review', metadata: { openchamber: { kind: 'review' } } } },
+    })).toBe(false);
+  });
+
+  it('recovers durable metadata for an id-only event after restart', async () => {
+    await expect(classifyOpenChamberInternalSessionEvent(
+      { type: 'session.status', properties: { sessionID: 'ses_restart' } },
+      async () => ({ id: 'ses_restart', metadata: internalSessionMetadata() }),
+    )).resolves.toBe(true);
+    expect(isOpenChamberInternalSessionEvent({ type: 'message.updated', properties: { info: { sessionID: 'ses_restart' } } })).toBe(true);
+  });
+
+  it('deduplicates failed lookups, forwards during the short failure TTL, and retries after reset', async () => {
+    let rejectLookup;
+    const lookup = vi.fn(() => new Promise((_, reject) => { rejectLookup = reject; }));
+    const event = { type: 'session.status', properties: { sessionID: 'ses_outage' } };
+    const first = classifyOpenChamberInternalSessionEvent(event, lookup);
+    const second = classifyOpenChamberInternalSessionEvent(event, lookup);
+    await Promise.resolve();
+    expect(lookup).toHaveBeenCalledOnce();
+    rejectLookup(new Error('offline'));
+    await expect(Promise.all([first, second])).resolves.toEqual([false, false]);
+    await expect(classifyOpenChamberInternalSessionEvent(event, lookup)).resolves.toBe(false);
+    expect(lookup).toHaveBeenCalledOnce();
+    __testing.clear();
+    const retry = vi.fn(async () => ({ id: 'ses_outage', metadata: internalSessionMetadata() }));
+    await expect(classifyOpenChamberInternalSessionEvent(event, retry)).resolves.toBe(true);
+    expect(retry).toHaveBeenCalledOnce();
+  });
+
+  it('keeps one underlying lookup after caller timeout and failure TTL expiry', async () => {
+    vi.useFakeTimers();
+    let resolveLookup;
+    const lookup = vi.fn(() => new Promise((resolve) => { resolveLookup = resolve; }));
+    const event = { type: 'session.status', properties: { sessionID: 'ses_slow' } };
+    const first = classifyOpenChamberInternalSessionEvent(event, lookup);
+    await vi.advanceTimersByTimeAsync(300);
+    await expect(first).resolves.toBe(false);
+    await vi.advanceTimersByTimeAsync(2_001);
+    const second = classifyOpenChamberInternalSessionEvent(event, lookup);
+    await vi.advanceTimersByTimeAsync(300);
+    await expect(second).resolves.toBe(false);
+    expect(lookup).toHaveBeenCalledOnce();
+    resolveLookup({ id: 'ses_slow' });
+    await Promise.resolve();
+    vi.useRealTimers();
+  });
+
+  it('ignores a lookup completion from before registry reset', async () => {
+    let resolveLookup;
+    const lookup = vi.fn(() => new Promise((resolve) => { resolveLookup = resolve; }));
+    const event = { type: 'session.status', properties: { sessionID: 'ses_collision' } };
+    const pending = classifyOpenChamberInternalSessionEvent(event, lookup);
+    await Promise.resolve();
+    __testing.clear();
+    resolveLookup({ id: 'ses_collision', metadata: internalSessionMetadata() });
+    await expect(pending).resolves.toBe(false);
+    expect(isOpenChamberInternalSessionEvent({ type: 'session.status', properties: { sessionID: 'ses_collision' } })).toBe(false);
+  });
+
+  it('starts a new-runtime lookup for the same id while the old lookup is still pending', async () => {
+    let resolveRuntimeA;
+    const runtimeA = vi.fn(() => new Promise((resolve) => { resolveRuntimeA = resolve; }));
+    const event = { type: 'session.status', properties: { sessionID: 'ses_same' } };
+    const pendingA = classifyOpenChamberInternalSessionEvent(event, runtimeA);
+    await Promise.resolve();
+    expect(runtimeA).toHaveBeenCalledOnce();
+
+    __testing.clear();
+    const runtimeB = vi.fn(async () => ({ id: 'ses_same', metadata: internalSessionMetadata() }));
+    await expect(classifyOpenChamberInternalSessionEvent(event, runtimeB)).resolves.toBe(true);
+    expect(runtimeB).toHaveBeenCalledOnce();
+
+    resolveRuntimeA({ id: 'ses_same' });
+    await expect(pendingA).resolves.toBe(false);
+    expect(isOpenChamberInternalSessionEvent({ type: 'session.status', properties: { sessionID: 'ses_same' } })).toBe(true);
+  });
+});

--- a/packages/web/server/lib/opencode/startup-pipeline-runtime.js
+++ b/packages/web/server/lib/opencode/startup-pipeline-runtime.js
@@ -30,6 +30,7 @@ export const createStartupPipelineRuntime = (dependencies) => {
       messageStreamWsClients,
       triggerHealthCheck,
       upstreamStallTimeoutMs,
+      classifyDirectoryEvent,
       terminalHeartbeatIntervalMs,
       terminalRebindWindowMs,
       terminalMaxRebindsPerWindow,
@@ -99,6 +100,7 @@ export const createStartupPipelineRuntime = (dependencies) => {
       wsClients: messageStreamWsClients,
       triggerHealthCheck,
       upstreamStallTimeoutMs,
+      classifyDirectoryEvent,
     });
 
     setupProxy(app);

--- a/packages/web/server/lib/permission-auto-accept/runtime.js
+++ b/packages/web/server/lib/permission-auto-accept/runtime.js
@@ -4,13 +4,13 @@ const REQUEST_TIMEOUT_MS = 5000;
 const SESSION_CACHE_LIMIT = 10000;
 
 const normalizePolicy = (value) => {
-  const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  const source = value && Object.prototype.toString.call(value) === '[object Object]' ? value : {};
   const sessions = {};
-  const entries = source.sessions && typeof source.sessions === 'object' && !Array.isArray(source.sessions)
+  const entries = source.sessions && Object.prototype.toString.call(source.sessions) === '[object Object]'
     ? Object.entries(source.sessions)
     : [];
   for (const [sessionId, enabled] of entries) {
-    if (sessionId && typeof enabled === 'boolean') sessions[sessionId] = enabled;
+    if (sessionId && enabled?.constructor === Boolean) sessions[sessionId] = enabled;
   }
   const revision = Number.isSafeInteger(source.revision) && source.revision >= 0 ? source.revision : 0;
   return { sessions, revision };
@@ -28,6 +28,8 @@ export function createPermissionAutoAcceptRuntime({
   fetchImpl = fetch,
   retryDelaysMs = RETRY_DELAYS_MS,
   requestTimeoutMs = REQUEST_TIMEOUT_MS,
+  isInternalSessionEvent = () => false,
+  isInternalSession = async () => false,
 }) {
   let policy = normalizePolicy();
   let loaded = false;
@@ -72,8 +74,8 @@ export function createPermissionAutoAcceptRuntime({
   };
 
   const setSessionPolicy = async (sessionId, enabled, directory) => {
-    if (typeof sessionId !== 'string' || !sessionId.trim()) throw new TypeError('sessionId is required');
-    if (typeof enabled !== 'boolean') throw new TypeError('enabled must be a boolean');
+    if (sessionId?.constructor !== String || !sessionId.trim()) throw new TypeError('sessionId is required');
+    if (enabled?.constructor !== Boolean) throw new TypeError('enabled must be a boolean');
     await load();
     const result = await persistUpdate((current) => ({
       ...current,
@@ -85,10 +87,10 @@ export function createPermissionAutoAcceptRuntime({
   };
 
   const rememberSession = (info, directoryHint) => {
-    if (!info || typeof info.id !== 'string' || !info.id) return;
+    if (!info || info.id?.constructor !== String || !info.id) return;
     sessions.set(info.id, {
-      parentID: typeof info.parentID === 'string' && info.parentID ? info.parentID : null,
-      directory: typeof info.directory === 'string' && info.directory ? info.directory : directoryHint,
+      parentID: info.parentID?.constructor === String && info.parentID ? info.parentID : null,
+      directory: info.directory?.constructor === String && info.directory ? info.directory : directoryHint,
     });
     if (sessions.size > SESSION_CACHE_LIMIT) {
       sessions.delete(sessions.keys().next().value);
@@ -98,16 +100,17 @@ export function createPermissionAutoAcceptRuntime({
   const request = async (path, { directory, method = 'GET', body } = {}) => {
     const url = new URL(buildOpenCodeUrl(path, ''));
     if (directory) url.searchParams.set('directory', directory);
-    const response = await fetchImpl(url, {
+    const headers = { Accept: 'application/json', ...getOpenCodeAuthHeaders() };
+    const init = {
       method,
-      headers: {
-        Accept: 'application/json',
-        ...(body ? { 'Content-Type': 'application/json' } : {}),
-        ...getOpenCodeAuthHeaders(),
-      },
-      ...(body ? { body: JSON.stringify(body) } : {}),
+      headers,
       signal: AbortSignal.timeout(requestTimeoutMs),
-    });
+    };
+    if (body) {
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(body);
+    }
+    const response = await fetchImpl(url, init);
     if (!response.ok) {
       const error = new Error(`OpenCode request failed (${response.status})`);
       error.status = response.status;
@@ -146,6 +149,13 @@ export function createPermissionAutoAcceptRuntime({
 
   const replyOnce = async (permission, directory) => {
     if (!permission?.id || !permission?.sessionID) return false;
+    try {
+      if (await isInternalSession(permission.sessionID, directory)) return false;
+    } catch {
+      // Classification is an authorization boundary. If durable metadata
+      // cannot be read, leave the permission for manual handling.
+      return false;
+    }
     await load();
     if (!(await isSessionAutoAccepting(permission.sessionID, directory))) return false;
     await request(`/permission/${encodeURIComponent(permission.id)}/reply`, {
@@ -178,7 +188,7 @@ export function createPermissionAutoAcceptRuntime({
 
   async function reconcilePending({ directories = [] } = {}) {
     const normalizedDirectories = Array.from(new Set(
-      directories.filter((directory) => typeof directory === 'string' && directory.trim()).map((directory) => directory.trim()),
+      directories.filter((directory) => directory?.constructor === String && directory.trim()).map((directory) => directory.trim()),
     ));
     const key = normalizedDirectories.length > 0 ? normalizedDirectories.join('\n') : 'all';
     const existing = reconcilePromises.get(key);
@@ -210,8 +220,9 @@ export function createPermissionAutoAcceptRuntime({
 
   const processEvent = (event) => {
     const raw = event?.payload;
-    const payload = raw?.payload && typeof raw.payload === 'object' ? raw.payload : raw;
-    const directory = typeof event?.directory === 'string' && event.directory !== 'global' ? event.directory : undefined;
+    const payload = raw?.payload && Object.prototype.toString.call(raw.payload) === '[object Object]' ? raw.payload : raw;
+    const directory = event?.directory?.constructor === String && event.directory !== 'global' ? event.directory : undefined;
+    if (isInternalSessionEvent(payload)) return;
     if (payload?.type === 'session.created' || payload?.type === 'session.updated') {
       rememberSession(payload.properties?.info, directory);
       return;
@@ -257,7 +268,7 @@ export function registerPermissionAutoAcceptRoutes(app, runtime) {
 
   app.put('/api/permission-auto-accept/sessions/:sessionId', async (req, res) => {
     try {
-      const directory = typeof req.body?.directory === 'string' ? req.body.directory : undefined;
+      const directory = req.body?.directory?.constructor === String ? req.body.directory : undefined;
       res.json(await runtime.setSessionPolicy(req.params.sessionId, req.body?.enabled, directory));
     } catch (error) {
       res.status(error instanceof TypeError ? 400 : 500).json({ error: error?.message });

--- a/packages/web/server/lib/permission-auto-accept/runtime.test.js
+++ b/packages/web/server/lib/permission-auto-accept/runtime.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createPermissionAutoAcceptRuntime } from './runtime.js';
 
-const createRuntime = ({ stored, fetchImpl, retryDelaysMs = [0] } = {}) => {
+const createRuntime = ({ stored, fetchImpl, retryDelaysMs = [0], isInternalSessionEvent, isInternalSession } = {}) => {
   let settings = stored ?? { permissionAutoAccept: { sessions: {} } };
   let eventHandler;
   let statusHandler;
@@ -16,6 +16,8 @@ const createRuntime = ({ stored, fetchImpl, retryDelaysMs = [0] } = {}) => {
     persistSettings: async (changes) => { settings = { ...settings, ...changes }; },
     fetchImpl: fetchImpl ?? vi.fn(async () => new Response('[]')),
     retryDelaysMs,
+    isInternalSessionEvent,
+    isInternalSession,
   });
   runtime.start();
   return {
@@ -59,6 +61,42 @@ describe('permission auto-accept runtime', () => {
     await expect(runtime.isSessionAutoAccepting('grandchild', '/project')).resolves.toBe(false);
     await runtime.setSessionPolicy('child', true);
     await expect(runtime.isSessionAutoAccepting('grandchild', '/project')).resolves.toBe(true);
+  });
+
+  it('does not retain internal sessions for permission side effects', async () => {
+    const predicate = vi.fn((payload) => payload.properties?.info?.id === 'internal');
+    const { runtime, emit } = createRuntime({
+      isInternalSessionEvent: predicate,
+    });
+    emit({ type: 'session.created', properties: { info: { id: 'internal', parentID: 'root' } } });
+    expect(predicate).toHaveBeenCalledWith(expect.objectContaining({ type: 'session.created' }));
+    await expect(runtime.isSessionAutoAccepting('child', '/project')).resolves.toBe(false);
+  });
+
+  it('durably classifies a live permission before replying after restart', async () => {
+    const fetchImpl = vi.fn(async () => Response.json({}));
+    const { emit } = createRuntime({
+      stored: { permissionAutoAccept: { sessions: { internal: true } } },
+      fetchImpl,
+      isInternalSession: async (sessionId) => sessionId === 'internal',
+    });
+    emit({ type: 'permission.asked', properties: { id: 'perm_live', sessionID: 'internal' } });
+    await flush();
+    expect(fetchImpl).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('durably classifies pending permissions before reconciliation replies', async () => {
+    const fetchImpl = vi.fn(async (url, init = {}) => {
+      if (new URL(url).pathname === '/permission') return Response.json([{ id: 'perm_pending', sessionID: 'internal' }]);
+      return Response.json({});
+    });
+    const { runtime } = createRuntime({
+      stored: { permissionAutoAccept: { sessions: { internal: true } } },
+      fetchImpl,
+      isInternalSession: async (sessionId) => sessionId === 'internal',
+    });
+    await runtime.reconcilePending();
+    expect(fetchImpl.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(false);
   });
 
   it('fetches missing subagent lineage before replying', async () => {

--- a/packages/web/server/lib/small-model/index.js
+++ b/packages/web/server/lib/small-model/index.js
@@ -46,7 +46,7 @@ export const getModelInputCharBudget = ({ catalog, providerID, modelID, outputRe
   const known = Number(limit?.context) > 0;
   const contextTokens = known ? Number(limit.context) : DEFAULT_CONTEXT_TOKENS;
   const reserve = Number(outputReserveTokens) > 0 ? Number(outputReserveTokens) : OUTPUT_RESERVE_TOKENS;
-  const inputBudgetTokens = Math.max(1_000, contextTokens - reserve);
+  const inputBudgetTokens = Math.max(0, contextTokens - reserve);
   return { maxChars: inputBudgetTokens * 4, contextTokens, contextKnown: known };
 };
 

--- a/packages/web/server/lib/walkthrough/DOCUMENTATION.md
+++ b/packages/web/server/lib/walkthrough/DOCUMENTATION.md
@@ -100,6 +100,22 @@ When a change consists only of generated files, generation is refused with
 
 ## Model selection
 
+Generation is dispatched through the normal OpenCode SDK v2 session pipeline.
+The resolved walkthrough model is passed to `session.promptAsync`, so OpenCode
+owns provider authentication and model dispatch rather than this feature calling
+provider APIs directly. Each attempt uses a root temporary session atomically
+marked as `metadata.openchamber.internalSession.kind = walkthrough-inference`.
+That marker is durable authority for hiding the session; a bounded server
+registry covers status and message events that carry only a session id. Tools
+and permissions are denied, cancellation or timeout aborts the turn, and
+deletion is always attempted in `finally`.
+On the next walkthrough use after startup or a cleanup failure, a bounded scan
+of at most 100 sessions deletes up to 20 marked orphans with concurrency two.
+Active walkthrough sessions are excluded. True orphans are aborted before
+deletion, and successful/404 cleanup forgets their classification immediately.
+Failures schedule another bounded scan; a cursor advances across full pages on
+later uses, and no directory or content is logged.
+
 The walkthrough has its own model setting (Settings → Sessions → Changes
 Walkthrough Model), read by `model-settings.js`:
 
@@ -125,18 +141,20 @@ in its cache entry, so reopening a panel resolves the picker as *explicit choice
 of the cache key, switching models and back returns the earlier review for free.
 
 The picker hides models the catalog reports as `structured_output: false` —
-offering them would move the same refusal one click later — and, like the small
-model picker, only shows providers with a usable login. The in-panel picker on a
+offering them would move the same refusal one click later. It otherwise follows
+OpenCode's model catalog rather than the direct Small Model login allowlist,
+because plugin-backed providers may not have an `auth.json` or API-key entry.
+OpenCode owns provider availability and authentication; inference maps a real
+`ProviderAuthError` to the user-facing login failure. The in-panel picker on a
 blocked walkthrough writes this setting too, so recovering from a refusal never
 silently changes the model behind commit messages.
 
-A settings or `opencode.json` `small_model` override can still name a provider
-with no usable login (neither `auth.json` nor `provider.<id>.options.apiKey`).
-`describeSmallModel` reports that as `hasLogin: false`, readiness refuses with
-`reason: 'no-provider-login'` and omits the unusable model so the panel cannot
-present it as selected, and generation maps the same code to HTTP 401. The UI
-disables Generate and keeps the picker on authenticated providers only — it does
-not surface a raw auth error or a special login blocker for this case.
+A settings or `opencode.json` model can be supplied by an OpenCode plugin even
+when direct-provider discovery finds neither `auth.json` nor an API key.
+Walkthrough readiness therefore does not use `hasLogin` as authority and its
+picker follows the OpenCode model catalog instead of the direct-provider login
+list. `session.promptAsync` is authoritative: a real OpenCode
+`ProviderAuthError` still maps to HTTP 401 with `code: 'no-provider-login'`.
 
 ## Output language
 
@@ -198,10 +216,11 @@ half of all models, and treating unknown as unsupported would hide models that
 work.
 
 Providers that do not declare the capability sometimes reject the schema at
-request time (a plain `400`, or Alibaba/Qwen's "'messages' must contain the word
-'json'"). A rejected request shape is not a dead end, so a `4xx` on a schema
-request triggers exactly one retry with the schema moved into the prompt and the
-tolerant parser handling the result. Only if *that* fails to yield usable JSON is
+request time. An explicit `StructuredOutputError`, or an SDK `APIError` whose
+message identifies JSON schema/response-format rejection, triggers exactly one
+retry with the schema moved into the prompt and the tolerant parser handling the
+result. Generic `4xx` errors such as an invalid model or missing session do not
+poison schema-refusal memory. Only if the fallback fails to yield usable JSON is
 `structured-output-unsupported` reported — at which point it is a real capability
 problem the user can fix by switching model.
 
@@ -216,28 +235,14 @@ also satisfies the providers that scan the request for the word `json` before
 honouring `response_format`. That keeps them on the fast path instead of paying
 for a wasted first call.
 
-## Output budget
+## Output allowance
 
-A walkthrough itself is only a few thousand tokens of JSON. The budget exists
-for what comes before it: reasoning models spend the same allowance thinking and
-return nothing when it runs out, which is a bill for no answer.
-
-The ask is therefore derived from the resolved model rather than fixed:
-`min(96k, max(24k, a quarter of the context))`, then capped by the catalog's
-`limit.output`. A flat 24k was the same number for a 64k-context model and for
-one that admits to 384k output tokens and a million of context — and on the
-latter it was the only reason generation failed.
-
-The bounds are not arbitrary. The **same number is reserved from the input
-allowance**, so the ceiling and the context share are what stop a generous
-answer budget from eating the diff it is supposed to describe; the 24k floor is
-what this feature always asked for, so no model gets less room than before. A
-model whose own `limit.output` is below the floor gets its limit, because asking
-for more than a provider allows is rejected by some and ignored by others.
-
-`describeSmallModel` decides this once — the walkthrough hands it the rule as a
-function and reads back `outputTokens` — so the reserve and the request cannot
-drift apart.
+`session.promptAsync` has no per-turn maximum-output field. Readiness therefore
+reserves the resolved model catalog's full `limit.output` from the context: that
+is the allowance OpenCode can actually consume for reasoning and JSON. If the
+catalog omits the limit, readiness uses a conservative 24k-token fallback. This
+may refuse a large diff earlier than a provider would in practice, but it never
+claims that an unsupported cap was sent to OpenCode.
 
 When a model exhausts even that, `code: 'output-exhausted'` reports it as what
 it is: this model cannot finish this job, so pick another or review a narrower

--- a/packages/web/server/lib/walkthrough/index.js
+++ b/packages/web/server/lib/walkthrough/index.js
@@ -1,9 +1,10 @@
 import { getRepositoryRoot } from '../git/service.js';
-import { describeSmallModel, generateSmallModelText } from '../small-model/index.js';
+import { describeSmallModel } from '../small-model/index.js';
+import { generateWalkthroughText } from './inference.js';
 import { buildDigest } from './digest.js';
 import { indexHunks } from './hunks.js';
 import { normalizeLanguage } from './languages.js';
-import { buildPrompt, JSON_SHAPE_INSTRUCTION } from './prompt.js';
+import { buildPrompt, WALKTHROUGH_JSON_INSTRUCTION } from './prompt.js';
 import { normalizeWalkthrough, parseModelJson, responseSchema } from './schema.js';
 import {
   buildCacheKey,
@@ -42,41 +43,18 @@ const generationTimeoutMs = (hunkCount) => Math.min(
   GENERATION_TIMEOUT_MAX_MS,
   GENERATION_TIMEOUT_BASE_MS + Math.max(0, hunkCount) * GENERATION_TIMEOUT_PER_HUNK_MS,
 );
-// A full walkthrough is a few thousand tokens of JSON. The budget exists for
-// what comes before it: reasoning models spend the same allowance thinking and
-// return nothing when it runs out, which is a bill for no answer.
-//
-// So the ask is derived from the model rather than fixed. A flat 24k was the
-// same number for a 64k-context model and for one that admits to 384k output
-// tokens, and on the latter it was the only reason generation failed.
-//
-// The reserve subtracted from the input budget is the same number, always: ask
-// for more than was reserved and a large diff overruns the context mid-answer,
-// which surfaces as a truncation bug rather than a budgeting one.
+// promptAsync has no per-turn output cap. Reserve the model catalog's effective
+// output allowance because OpenCode may use all of it for reasoning + JSON. For
+// models whose catalog omits the limit, retain the historical conservative 24k
+// fallback rather than claiming an unsupported cap was sent.
 const MIN_OUTPUT_TOKENS = 24_000;
-// A ceiling, because the reserve is taken out of the input allowance: a model
-// that would let us ask for 384k tokens of answer would also let us spend a
-// third of a million tokens of context reserving them, and no walkthrough needs
-// that much thinking.
-const MAX_OUTPUT_TOKENS = 96_000;
-// Above this share of the context, the reserve starts costing more diff than
-// the extra room is worth.
-const OUTPUT_CONTEXT_SHARE = 0.25;
 
 /**
- * Answer allowance for a specific model: as much as it admits it can emit,
- * bounded by a share of its context and never below what this feature always
- * asked for.
+ * Effective allowance OpenCode can consume for a specific model.
  */
-const walkthroughOutputTokens = ({ contextTokens, outputTokenLimit }) => {
-  const wanted = Math.min(
-    MAX_OUTPUT_TOKENS,
-    Math.max(MIN_OUTPUT_TOKENS, Math.floor((Number(contextTokens) || 0) * OUTPUT_CONTEXT_SHARE)),
-  );
-  // A model whose own limit is below the floor gets its limit: asking for more
-  // than a provider allows is rejected outright by some and ignored by others.
-  return Number(outputTokenLimit) > 0 ? Math.min(wanted, Number(outputTokenLimit)) : wanted;
-};
+const walkthroughOutputTokens = ({ outputTokenLimit }) => (
+  Number(outputTokenLimit) > 0 ? Number(outputTokenLimit) : MIN_OUTPUT_TOKENS
+);
 
 const fail = (message, statusCode, extra = {}) =>
   Object.assign(new Error(message), { statusCode, ...extra });
@@ -90,7 +68,7 @@ const fail = (message, statusCode, extra = {}) =>
 // and cancelling is an explicit request rather than a side effect of leaving.
 const jobs = new Map();
 
-// Providers that answered a schema request with a 4xx. Retrying the schema on
+// Providers that explicitly refused a schema request. Retrying the schema on
 // every generation means paying for a call we already know will fail, so the
 // refusal is remembered and the fallback goes first next time.
 //
@@ -331,13 +309,6 @@ function computeReadiness({ model, digest, files, fileCount, hunkCount, generate
     return { ready: false, reason, model, generatedFileCount };
   }
 
-  // A resolved override/config model can still have no usable login. Refuse up
-  // front and omit the model — offering an unauthenticated selection in the
-  // picker is what made the old raw auth error feel like a product bug.
-  if (model.hasLogin === false) {
-    return { ready: false, reason: 'no-provider-login' };
-  }
-
   // Built with the same language the generation would use: the instruction is
   // part of the prompt, so a readiness answer computed without it would be
   // measuring a request nobody is going to send.
@@ -397,14 +368,6 @@ async function runGeneration({ directory, source, repoRoot, key, force, explicit
   if (!model) {
     throw fail('No model is available — sign in to a provider first', 404, { code: 'no-model' });
   }
-  if (model.hasLogin === false) {
-    throw fail(
-      `No OpenCode login found for provider "${model.providerID}" — sign in or choose a different model`,
-      401,
-      { code: 'no-provider-login', model },
-    );
-  }
-
   const { digest, files, idByAlias, fileCount, hunkCount, generatedFileCount } = await loadCurrentDiff(directory, source, deps);
   setStage(repoRoot, key, 'asking');
   if (hunkCount === 0) {
@@ -461,6 +424,15 @@ async function runGeneration({ directory, source, repoRoot, key, force, explicit
   }
 
   const { prompt, system } = buildPrompt({ digest, fileCount, hunkCount, source, previousWalkthrough, language });
+  const requiredChars = prompt.length + system.length;
+  if (requiredChars > model.inputCharBudget) {
+    throw fail(`${modelLabel(model)} does not have enough context for this walkthrough`, 409, {
+      code: 'context-too-small',
+      model,
+      requiredChars,
+      availableChars: model.inputCharBudget,
+    });
+  }
 
   if (model.structuredOutput === false) {
     throw fail(
@@ -470,17 +442,16 @@ async function runGeneration({ directory, source, repoRoot, key, force, explicit
     );
   }
 
-  const run = (options) => generateSmallModelText({
+  const run = (options) => (deps.generateWalkthroughText ?? generateWalkthroughText)({
     prompt: options.prompt,
     system: options.system,
     directory,
-    model: `${model.providerID}/${model.modelID}`,
+    model,
     responseSchema: options.responseSchema,
-    onOverflow: 'error',
     timeoutMs: generationTimeoutMs(hunkCount),
-    // The number the input budget was already reduced by, not a fresh guess.
-    maxOutputTokens: model.outputTokens ?? MIN_OUTPUT_TOKENS,
     signal,
+    baseUrl: deps.openCodeBaseUrl,
+    headers: deps.openCodeAuthHeaders,
   });
 
   // Roughly half the catalog does not declare `structured_output`, and some of
@@ -490,7 +461,7 @@ async function runGeneration({ directory, source, repoRoot, key, force, explicit
   const withSchema = () => run({ prompt, system, responseSchema });
   const withoutSchema = () => run({
     prompt,
-    system: `${system}\n${JSON_SHAPE_INSTRUCTION}`,
+    system: `${system}\n${WALKTHROUGH_JSON_INSTRUCTION}`,
     responseSchema: undefined,
   });
 
@@ -512,8 +483,8 @@ async function runGeneration({ directory, source, repoRoot, key, force, explicit
     return null;
   };
 
-  const refusesSchema = (error) => error?.code === 'structured-output-unsupported'
-    || (Number(error?.status) >= 400 && Number(error?.status) < 500);
+  const refusesSchema = (error) => error?.code === 'structured-output-unsupported';
+  const remembersSchemaRefusal = (error) => error?.schemaRefusal === true;
 
   let raw;
   let usedSchema = false;
@@ -536,7 +507,7 @@ async function runGeneration({ directory, source, repoRoot, key, force, explicit
       if (failure) throw failure;
       if (!refusesSchema(error)) throw error;
 
-      schemaRefusedBy.add(modelKey(model));
+      if (remembersSchemaRefusal(error)) schemaRefusedBy.add(modelKey(model));
       setStage(repoRoot, key, 'retrying');
       try {
         raw = await withoutSchema();

--- a/packages/web/server/lib/walkthrough/inference.js
+++ b/packages/web/server/lib/walkthrough/inference.js
@@ -1,0 +1,220 @@
+import { createOpencodeClient } from '@opencode-ai/sdk/v2';
+import { forgetOpenChamberInternalSession, internalSessionMetadata, trackOpenChamberInternalSession } from '../opencode/internal-sessions.js';
+
+const POLL_INTERVAL_MS = 250;
+const MAX_POLL_INTERVAL_MS = 2_000;
+const CLEANUP_TIMEOUT_MS = 5_000;
+const DISABLED_TOOLS = Object.fromEntries([
+  'bash', 'edit', 'glob', 'grep', 'patch', 'question', 'read', 'skill',
+  'task', 'todoread', 'todowrite', 'webfetch', 'write',
+].map((tool) => [tool, false]));
+let orphanCleanupNeeded = true;
+let orphanCleanupCursor;
+const activeSessionIds = new Set();
+
+const isRecord = (value) => value !== null && Object.prototype.toString.call(value) === '[object Object]';
+
+export const resetWalkthroughInferenceRuntime = () => {
+  orphanCleanupNeeded = true;
+  orphanCleanupCursor = undefined;
+};
+
+const normalizedOpenCodeError = (raw, operation, responseStatus) => {
+  const name = raw?.name?.constructor === String ? raw.name : 'APIError';
+  const data = isRecord(raw?.data) ? raw.data : {};
+  const status = Number(data.statusCode ?? responseStatus) || undefined;
+  const detail = data.message?.constructor === String
+    ? data.message
+    : (raw?.message?.constructor === String ? raw.message : `${operation} failed`);
+  let code;
+  if (name === 'MessageOutputLengthError') code = 'output-exhausted';
+  else if (name === 'ContextOverflowError') code = 'context-too-small';
+  else if (name === 'ProviderAuthError' || status === 401 || status === 403) code = 'no-provider-login';
+  else if (name === 'StructuredOutputError') code = 'structured-output-unsupported';
+  else if (
+    name === 'APIError'
+    && status != null && status >= 400 && status < 500
+    && /json.?schema|structured.?output|response.?format|schema is not supported/i.test(`${detail}\n${data.responseBody ?? ''}`)
+  ) code = 'structured-output-unsupported';
+  const normalized = Object.assign(new Error(`${operation} failed${status ? ` (${status})` : ''}: ${detail}`), {
+    name,
+    status,
+    statusCode: code === 'no-provider-login' ? 401 : (code ? undefined : 502),
+  });
+  if (code) normalized.code = code;
+  if (code === 'structured-output-unsupported' && name === 'APIError') normalized.schemaRefusal = true;
+  return normalized;
+};
+
+const sdkError = (result, operation) => result?.error
+  ? normalizedOpenCodeError(result.error, operation, result.response?.status)
+  : null;
+
+const requireData = (result, operation) => {
+  const error = sdkError(result, operation);
+  if (error) throw error;
+  if (result?.data == null) throw new Error(`${operation} returned no data`);
+  return result.data;
+};
+
+const sleep = (ms, signal) => new Promise((resolve, reject) => {
+  const onAbort = () => {
+    clearTimeout(timer);
+    reject(signal.reason ?? Object.assign(new Error('Aborted'), { name: 'AbortError' }));
+  };
+  const timer = setTimeout(() => {
+    signal.removeEventListener('abort', onAbort);
+    resolve();
+  }, ms);
+  if (signal.aborted) return onAbort();
+  signal.addEventListener('abort', onAbort, { once: true });
+});
+
+const assistantOutcomeFor = (messages, promptMessageId) => {
+  if (!Array.isArray(messages)) return null;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    const info = message?.info;
+    if (info?.role !== 'assistant' || info.parentID !== promptMessageId) continue;
+    if (!info.time?.completed) return null;
+    if (info.error) return { error: normalizedOpenCodeError(info.error, 'assistant message') };
+    if (!info.finish) return null;
+    if (info.finish === 'length' || info.finish === 'max_tokens') {
+      return { error: Object.assign(new Error('The model exhausted its output allowance'), { code: 'output-exhausted' }) };
+    }
+    if (info.structured != null) return { result: { text: JSON.stringify(info.structured) } };
+    const text = Array.isArray(message.parts)
+      ? message.parts.filter((part) => part?.type === 'text' && part.text?.constructor === String).map((part) => part.text).join('\n').trim()
+      : '';
+    return text ? { result: { text } } : null;
+  }
+  return null;
+};
+
+const cleanupOrphanedWalkthroughSessions = async (client) => {
+  if (!orphanCleanupNeeded || !(client.experimental?.session?.list instanceof Function)) return;
+  orphanCleanupNeeded = false;
+  try {
+    const listRequest = { archived: true, limit: 100 };
+    if (orphanCleanupCursor !== undefined) listRequest.cursor = orphanCleanupCursor;
+    const listed = await client.experimental.session.list(
+      listRequest,
+      { signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS) },
+    );
+    const error = sdkError(listed, 'experimental.session.list');
+    if (error) throw error;
+    const listedSessions = Array.isArray(listed.data) ? listed.data : [];
+    const eligibleOrphans = listedSessions
+      .filter((session) => session?.metadata?.openchamber?.internalSession?.kind === 'walkthrough-inference')
+      .filter((session) => !activeSessionIds.has(session.id));
+    const orphans = eligibleOrphans.slice(0, 20);
+    const lastUpdated = listedSessions.at(-1)?.time?.updated;
+    const pageHasUnprocessedOrphans = eligibleOrphans.length > orphans.length;
+    if (!pageHasUnprocessedOrphans) {
+      orphanCleanupCursor = listedSessions.length === 100 && Number.isFinite(lastUpdated) ? lastUpdated : undefined;
+    }
+    if (pageHasUnprocessedOrphans || orphanCleanupCursor !== undefined) orphanCleanupNeeded = true;
+    for (let index = 0; index < orphans.length; index += 2) {
+      await Promise.all(orphans.slice(index, index + 2).map(async (session) => {
+        trackOpenChamberInternalSession(session.id);
+        await client.session.abort(
+          { sessionID: session.id, directory: session.directory },
+          { signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS) },
+        ).catch(() => {});
+        const removed = await client.session.delete(
+          { sessionID: session.id, directory: session.directory },
+          { signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS) },
+        );
+        if (removed?.error && removed.response?.status !== 404) orphanCleanupNeeded = true;
+        else forgetOpenChamberInternalSession(session.id);
+      }));
+    }
+  } catch {
+    orphanCleanupNeeded = true;
+  }
+};
+
+export async function generateWalkthroughText({
+  prompt, system, directory, model, responseSchema, timeoutMs, signal, baseUrl, headers,
+  createClient = createOpencodeClient, pollIntervalMs = POLL_INTERVAL_MS,
+}) {
+  if (!baseUrl) throw new Error('OpenCode API is unavailable');
+  const client = createClient({ baseUrl: baseUrl.replace(/\/$/, ''), headers: headers ?? {} });
+  await cleanupOrphanedWalkthroughSessions(client);
+  const deadline = AbortSignal.timeout(timeoutMs);
+  const combinedSignal = signal ? AbortSignal.any([signal, deadline]) : deadline;
+  const requestOptions = () => ({ signal: combinedSignal });
+  const promptMessageId = `msg_${crypto.randomUUID().replaceAll('-', '')}`;
+  let sessionId = '';
+  let pollDelayMs = pollIntervalMs;
+
+  try {
+    const session = requireData(await client.session.create({
+      directory,
+      title: 'Changes Walkthrough',
+      metadata: internalSessionMetadata(),
+      permission: [{ permission: '*', pattern: '*', action: 'deny' }],
+    }, requestOptions()), 'session.create');
+    sessionId = session.id;
+    if (!sessionId) throw new Error('session.create returned an invalid session');
+    trackOpenChamberInternalSession(sessionId);
+    activeSessionIds.add(sessionId);
+
+    const promptResult = await client.session.promptAsync({
+      sessionID: sessionId,
+      directory,
+      messageID: promptMessageId,
+      model: { providerID: model.providerID, modelID: model.modelID },
+      system,
+      tools: DISABLED_TOOLS,
+      ...(responseSchema ? { format: { type: 'json_schema', schema: responseSchema } } : { format: { type: 'text' } }),
+      parts: [{ type: 'text', text: prompt }],
+    }, requestOptions());
+    const promptError = sdkError(promptResult, 'session.promptAsync');
+    if (promptError) throw promptError;
+
+    while (!combinedSignal.aborted) {
+      const [statusResult, messagesResult] = await Promise.all([
+        client.session.status({ directory }, requestOptions()),
+        client.session.messages({ sessionID: sessionId, directory, limit: 20 }, requestOptions()),
+      ]);
+      const statusError = sdkError(statusResult, 'session.status');
+      if (statusError) throw statusError;
+      const messagesError = sdkError(messagesResult, 'session.messages');
+      if (messagesError) throw messagesError;
+      const status = statusResult.data?.[sessionId];
+      const outcome = assistantOutcomeFor(messagesResult.data, promptMessageId);
+      if (outcome?.error) throw outcome.error;
+      if (status?.type !== 'busy' && status?.type !== 'retry' && outcome?.result) return outcome.result;
+      await sleep(pollDelayMs, combinedSignal);
+      pollDelayMs = Math.min(MAX_POLL_INTERVAL_MS, Math.ceil(pollDelayMs * 1.5));
+    }
+    throw combinedSignal.reason;
+  } catch (error) {
+    if (sessionId && combinedSignal.aborted) {
+      await client.session.abort({ sessionID: sessionId, directory }, { signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS) }).catch(() => {});
+    }
+    throw error;
+  } finally {
+    if (sessionId) {
+      activeSessionIds.delete(sessionId);
+      try {
+        const removed = await client.session.delete(
+          { sessionID: sessionId, directory },
+          { signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS) },
+        );
+        if (removed?.error && removed.response?.status !== 404) orphanCleanupNeeded = true;
+        else forgetOpenChamberInternalSession(sessionId);
+      } catch {
+        orphanCleanupNeeded = true;
+      }
+    }
+  }
+}
+
+export const __testing = {
+  normalizedOpenCodeError,
+  sleep,
+  requireOrphanCleanup: resetWalkthroughInferenceRuntime,
+  activeSessionIds,
+};

--- a/packages/web/server/lib/walkthrough/inference.test.js
+++ b/packages/web/server/lib/walkthrough/inference.test.js
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest';
+import { __testing, generateWalkthroughText } from './inference.js';
+import { OPENCHAMBER_INTERNAL_SESSION_KIND } from '../opencode/internal-sessions.js';
+
+const result = (data) => ({ data });
+
+const createHarness = ({ deleteError = null, wait = false } = {}) => {
+  const create = vi.fn(async () => result({ id: 'ses_internal' }));
+  const promptAsync = vi.fn(async () => ({}));
+  const status = vi.fn(async () => result({ ses_internal: { type: wait ? 'busy' : 'idle' } }));
+  const messages = vi.fn(async () => result(wait ? [] : [{
+    info: {
+      id: 'msg_assistant',
+      role: 'assistant',
+      parentID: expect.anything(),
+      finish: 'stop',
+      structured: { title: 'Change' },
+      time: { created: 1, completed: 2 },
+    },
+    parts: [],
+  }]));
+  const abort = vi.fn(async () => result(true));
+  const remove = vi.fn(async () => deleteError ? ({ error: deleteError, response: { status: 500 } }) : result(true));
+  const list = vi.fn(async () => result([]));
+  const client = { session: { create, promptAsync, status, messages, abort, delete: remove }, experimental: { session: { list } } };
+  return { client, createClient: () => client, create, promptAsync, status, messages, abort, remove, list };
+};
+
+describe('walkthrough OpenCode inference', () => {
+  it('normalizes real SDK endpoint and assistant error shapes', () => {
+    const cases = [
+      [{ name: 'MessageOutputLengthError', data: {} }, 'output-exhausted'],
+      [{ name: 'ContextOverflowError', data: { message: 'context too long' } }, 'context-too-small'],
+      [{ name: 'ProviderAuthError', data: { providerID: 'p', message: 'login required' } }, 'no-provider-login'],
+      [{ name: 'StructuredOutputError', data: { message: 'could not match schema', retries: 2 } }, 'structured-output-unsupported'],
+      [{ name: 'APIError', data: { message: 'response_format json_schema is not supported', statusCode: 400, isRetryable: false } }, 'structured-output-unsupported'],
+    ];
+    for (const [payload, code] of cases) {
+      expect(__testing.normalizedOpenCodeError(payload, 'test').code).toBe(code);
+    }
+    const generic = __testing.normalizedOpenCodeError({
+      name: 'APIError', data: { message: 'invalid model', statusCode: 400, isRetryable: false },
+    }, 'test');
+    expect(generic.code).toBeUndefined();
+    expect(generic.status).toBe(400);
+    expect(generic.statusCode).toBe(502);
+  });
+
+  it('removes the sleep abort listener after the timer resolves', async () => {
+    vi.useFakeTimers();
+    const signal = new AbortController().signal;
+    const add = vi.spyOn(signal, 'addEventListener');
+    const remove = vi.spyOn(signal, 'removeEventListener');
+    const sleeping = __testing.sleep(10, signal);
+    await vi.advanceTimersByTimeAsync(10);
+    await sleeping;
+    expect(add).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith('abort', expect.any(Function));
+    vi.useRealTimers();
+  });
+
+  it('creates a marked restricted session and returns only the correlated terminal assistant output', async () => {
+    const harness = createHarness();
+    harness.messages.mockImplementation(async () => {
+      const promptId = harness.promptAsync.mock.calls[0][0].messageID;
+      return result([
+        { info: { role: 'assistant', parentID: 'old', finish: 'stop', time: { completed: 1 } }, parts: [{ type: 'text', text: 'old' }] },
+        { info: { role: 'assistant', parentID: promptId, finish: 'stop', structured: { title: 'Change' }, time: { completed: 2 } }, parts: [] },
+      ]);
+    });
+
+    const output = await generateWalkthroughText({
+      prompt: 'prompt', system: 'system', directory: '/repo',
+      model: { providerID: 'anthropic', modelID: 'haiku' }, responseSchema: { type: 'object' },
+      timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: harness.createClient, pollIntervalMs: 1,
+    });
+
+    expect(output).toEqual({ text: '{"title":"Change"}' });
+    expect(harness.create).toHaveBeenCalledWith(expect.objectContaining({
+      directory: '/repo',
+      metadata: { openchamber: { internalSession: { kind: OPENCHAMBER_INTERNAL_SESSION_KIND, version: 1 } } },
+      permission: [{ permission: '*', pattern: '*', action: 'deny' }],
+    }), expect.anything());
+    expect(harness.promptAsync).toHaveBeenCalledWith(expect.objectContaining({
+      model: { providerID: 'anthropic', modelID: 'haiku' },
+      tools: expect.objectContaining({ bash: false, question: false, read: false, write: false }),
+      format: { type: 'json_schema', schema: { type: 'object' } },
+    }), expect.anything());
+    expect(harness.remove).toHaveBeenCalledOnce();
+  });
+
+  it('aborts on explicit cancellation and still attempts deletion', async () => {
+    const harness = createHarness({ wait: true });
+    const controller = new AbortController();
+    const running = generateWalkthroughText({
+      prompt: 'prompt', system: 'system', directory: '/repo', model: { providerID: 'p', modelID: 'm' },
+      timeoutMs: 5_000, signal: controller.signal, baseUrl: 'http://opencode',
+      createClient: harness.createClient, pollIntervalMs: 1,
+    });
+    await vi.waitFor(() => expect(harness.promptAsync).toHaveBeenCalled());
+    controller.abort();
+    await expect(running).rejects.toThrow();
+    expect(harness.abort).toHaveBeenCalledOnce();
+    expect(harness.remove).toHaveBeenCalledOnce();
+  });
+
+  it('aborts the OpenCode turn when the generation deadline expires', async () => {
+    const harness = createHarness({ wait: true });
+    await expect(generateWalkthroughText({
+      prompt: 'prompt', system: 'system', directory: '/repo', model: { providerID: 'p', modelID: 'm' },
+      timeoutMs: 5, baseUrl: 'http://opencode', createClient: harness.createClient, pollIntervalMs: 1,
+    })).rejects.toThrow();
+    expect(harness.abort).toHaveBeenCalledOnce();
+    expect(harness.remove).toHaveBeenCalledOnce();
+  });
+
+  it('does not replace a successful result when cleanup fails', async () => {
+    const harness = createHarness({ deleteError: new Error('cleanup failed') });
+    harness.messages.mockImplementation(async () => {
+      const promptId = harness.promptAsync.mock.calls[0][0].messageID;
+      return result([{ info: { role: 'assistant', parentID: promptId, finish: 'stop', time: { completed: 2 } }, parts: [{ type: 'text', text: '{"title":"Change"}' }] }]);
+    });
+    await expect(generateWalkthroughText({
+      prompt: 'prompt', system: 'system', directory: '/repo', model: { providerID: 'p', modelID: 'm' },
+      timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: harness.createClient, pollIntervalMs: 1,
+    })).resolves.toEqual({ text: '{"title":"Change"}' });
+  });
+
+  it('deletes a pre-existing marked orphan during bounded first-use cleanup', async () => {
+    __testing.requireOrphanCleanup();
+    const harness = createHarness();
+    harness.list.mockResolvedValue(result([{ id: 'ses_orphan', directory: '/repo', metadata: {
+      openchamber: { internalSession: { kind: OPENCHAMBER_INTERNAL_SESSION_KIND, version: 1 } },
+    } }]));
+    harness.messages.mockImplementation(async () => {
+      const promptId = harness.promptAsync.mock.calls[0][0].messageID;
+      return result([{ info: { role: 'assistant', parentID: promptId, finish: 'stop', time: { completed: 2 } }, parts: [{ type: 'text', text: '{}' }] }]);
+    });
+    await generateWalkthroughText({ prompt: 'p', system: 's', directory: '/repo', model: { providerID: 'p', modelID: 'm' }, timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: harness.createClient, pollIntervalMs: 1 });
+    expect(harness.remove.mock.calls.some(([request]) => request.sessionID === 'ses_orphan')).toBe(true);
+    const abortIndex = harness.abort.mock.invocationCallOrder[0];
+    const orphanDeleteCall = harness.remove.mock.calls.findIndex(([request]) => request.sessionID === 'ses_orphan');
+    expect(abortIndex).toBeLessThan(harness.remove.mock.invocationCallOrder[orphanDeleteCall]);
+  });
+
+  it('does not orphan-clean a session owned by a live walkthrough', async () => {
+    const harness = createHarness();
+    let release;
+    harness.messages.mockImplementation(() => new Promise((resolve) => { release = resolve; }));
+    const running = generateWalkthroughText({ prompt: 'p', system: 's', directory: '/repo', model: { providerID: 'p', modelID: 'm' }, timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: harness.createClient, pollIntervalMs: 1 });
+    await vi.waitFor(() => expect(harness.create).toHaveBeenCalledOnce());
+    const activeId = 'ses_internal';
+    __testing.requireOrphanCleanup();
+    harness.list.mockResolvedValue(result([{ id: activeId, directory: '/repo', metadata: { openchamber: { internalSession: { kind: OPENCHAMBER_INTERNAL_SESSION_KIND } } } }]));
+    const second = createHarness();
+    second.create.mockResolvedValue(result({ id: 'ses_second' }));
+    second.list = harness.list;
+    second.client.experimental.session.list = harness.list;
+    second.messages.mockImplementation(async () => {
+      const promptId = second.promptAsync.mock.calls[0][0].messageID;
+      return result([{ info: { role: 'assistant', parentID: promptId, finish: 'stop', time: { completed: 2 } }, parts: [{ type: 'text', text: '{}' }] }]);
+    });
+    await generateWalkthroughText({ prompt: 'p2', system: 's', directory: '/repo2', model: { providerID: 'p', modelID: 'm' }, timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: second.createClient, pollIntervalMs: 1 });
+    expect(second.remove.mock.calls.some(([request]) => request.sessionID === activeId)).toBe(false);
+    const promptId = harness.promptAsync.mock.calls[0][0].messageID;
+    release(result([{ info: { role: 'assistant', parentID: promptId, finish: 'stop', time: { completed: 2 } }, parts: [{ type: 'text', text: '{}' }] }]));
+    await running;
+  });
+
+  it('retries orphan reconciliation after a cleanup failure', async () => {
+    __testing.requireOrphanCleanup();
+    const failed = createHarness({ deleteError: { name: 'APIError', data: { message: 'delete failed', statusCode: 500, isRetryable: true } } });
+    failed.messages.mockImplementation(async () => {
+      const promptId = failed.promptAsync.mock.calls[0][0].messageID;
+      return result([{ info: { role: 'assistant', parentID: promptId, finish: 'stop', time: { completed: 2 } }, parts: [{ type: 'text', text: '{}' }] }]);
+    });
+    await generateWalkthroughText({ prompt: 'p', system: 's', directory: '/repo', model: { providerID: 'p', modelID: 'm' }, timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: failed.createClient, pollIntervalMs: 1 });
+
+    const retry = createHarness();
+    retry.messages.mockImplementation(async () => {
+      const promptId = retry.promptAsync.mock.calls[0][0].messageID;
+      return result([{ info: { role: 'assistant', parentID: promptId, finish: 'stop', time: { completed: 2 } }, parts: [{ type: 'text', text: '{}' }] }]);
+    });
+    await generateWalkthroughText({ prompt: 'p', system: 's', directory: '/repo', model: { providerID: 'p', modelID: 'm' }, timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: retry.createClient, pollIntervalMs: 1 });
+    expect(retry.list).toHaveBeenCalledOnce();
+  });
+
+  it('rescans a full page until more than twenty eligible orphans are handled before advancing', async () => {
+    __testing.requireOrphanCleanup();
+    const sessions = Array.from({ length: 100 }, (_, index) => ({
+      id: `ses_page_${index}`,
+      directory: '/repo',
+      time: { updated: 100 - index },
+      ...(index < 25 ? { metadata: { openchamber: { internalSession: { kind: OPENCHAMBER_INTERNAL_SESSION_KIND } } } } : {}),
+    }));
+    const first = createHarness();
+    first.list.mockResolvedValue(result(sessions));
+    first.messages.mockImplementation(async () => {
+      const promptId = first.promptAsync.mock.calls[0][0].messageID;
+      return result([{ info: { role: 'assistant', parentID: promptId, finish: 'stop', time: { completed: 2 } }, parts: [{ type: 'text', text: '{}' }] }]);
+    });
+    await generateWalkthroughText({ prompt: 'p', system: 's', directory: '/repo', model: { providerID: 'p', modelID: 'm' }, timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: first.createClient, pollIntervalMs: 1 });
+    expect(first.list.mock.calls[0][0].cursor).toBeUndefined();
+    expect(first.remove.mock.calls.filter(([request]) => request.sessionID.startsWith('ses_page_'))).toHaveLength(20);
+
+    const remaining = createHarness();
+    remaining.create.mockResolvedValue(result({ id: 'ses_second_pass' }));
+    remaining.list.mockResolvedValue(result(sessions.map((session, index) => (
+      index < 20 ? { ...session, metadata: undefined } : session
+    ))));
+    remaining.messages.mockImplementation(async () => {
+      const promptId = remaining.promptAsync.mock.calls[0][0].messageID;
+      return result([{ info: { role: 'assistant', parentID: promptId, finish: 'stop', time: { completed: 2 } }, parts: [{ type: 'text', text: '{}' }] }]);
+    });
+    await generateWalkthroughText({ prompt: 'p2', system: 's', directory: '/repo', model: { providerID: 'p', modelID: 'm' }, timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: remaining.createClient, pollIntervalMs: 1 });
+    expect(remaining.list.mock.calls[0][0].cursor).toBeUndefined();
+    expect(remaining.remove.mock.calls.filter(([request]) => request.sessionID.startsWith('ses_page_'))).toHaveLength(5);
+  });
+
+  it('maps an SDK-shaped prompt endpoint error before cleanup', async () => {
+    const harness = createHarness();
+    harness.promptAsync.mockResolvedValue({
+      error: { name: 'ProviderAuthError', data: { providerID: 'p', message: 'login required' } },
+      response: { status: 401 },
+    });
+    await expect(generateWalkthroughText({
+      prompt: 'p', system: 's', directory: '/repo', model: { providerID: 'p', modelID: 'm' },
+      timeoutMs: 1_000, baseUrl: 'http://opencode', createClient: harness.createClient, pollIntervalMs: 1,
+    })).rejects.toMatchObject({ code: 'no-provider-login', statusCode: 401 });
+    expect(harness.remove).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/server/lib/walkthrough/jobs.test.js
+++ b/packages/web/server/lib/walkthrough/jobs.test.js
@@ -17,8 +17,8 @@ vi.mock('../git/service.js', () => ({
 }));
 vi.mock('../small-model/index.js', () => ({
   describeSmallModel: vi.fn(),
-  generateSmallModelText: vi.fn(),
 }));
+vi.mock('./inference.js', () => ({ generateWalkthroughText: vi.fn() }));
 const {
   generateWalkthrough,
   cancelWalkthroughGeneration,
@@ -26,7 +26,8 @@ const {
   getGenerationStage,
   __testing: walkthroughTesting,
 } = await import('./index.js');
-const { describeSmallModel, generateSmallModelText } = await import('../small-model/index.js');
+const { describeSmallModel } = await import('../small-model/index.js');
+const { generateWalkthroughText: generateSmallModelText } = await import('./inference.js');
 const { getDiff } = await import('../git/service.js');
 
 // bun's vitest shim has no `vi.waitFor`.
@@ -137,9 +138,7 @@ describe('generation jobs', () => {
       .toEqual({ cancelled: false });
   });
 
-  // The reserve and the request must be the same number: asking for more than
-  // was subtracted from the input allowance overruns the context mid-answer.
-  it('requests exactly the budget the model resolution reserved', async () => {
+  it('passes the resolved model through OpenCode', async () => {
     describeSmallModel.mockResolvedValue({
       providerID: 'opencode-go',
       modelID: 'deepseek-v4-flash',
@@ -153,7 +152,30 @@ describe('generation jobs', () => {
 
     await generateWalkthrough({ directory: '/repo', source: SOURCE });
 
-    expect(generateSmallModelText.mock.calls.at(-1)[0].maxOutputTokens).toBe(96_000);
+    expect(generateSmallModelText.mock.calls.at(-1)[0].model).toMatchObject({
+      providerID: 'opencode-go',
+      modelID: 'deepseek-v4-flash',
+      outputTokens: 96_000,
+    });
+  });
+
+  it('lets OpenCode handle auth when direct-provider discovery reports no login', async () => {
+    describeSmallModel.mockResolvedValue({
+      providerID: 'plugin-provider',
+      modelID: 'plugin-model',
+      source: 'request',
+      hasLogin: false,
+      inputCharBudget: 1_000_000,
+      structuredOutput: true,
+    });
+    generateSmallModelText.mockResolvedValue({ text: RESPONSE });
+
+    const result = await generateWalkthrough({ directory: '/repo', source: SOURCE });
+
+    expect(result.walkthrough.title).toBe('Change');
+    expect(generateSmallModelText).toHaveBeenCalledWith(expect.objectContaining({
+      model: expect.objectContaining({ providerID: 'plugin-provider', modelID: 'plugin-model', hasLogin: false }),
+    }));
   });
 
   it('serves the cache once the job has finished, without calling the model again', async () => {
@@ -190,31 +212,39 @@ describe('generation timeout', () => {
   });
 });
 
-// The failure this replaced: a flat 24k ask, spent entirely on reasoning by a
-// model that advertises 384k output tokens and a million of context. The ceiling
-// exists because the same number is reserved out of the input allowance.
 describe('output budget', () => {
   const { walkthroughOutputTokens } = walkthroughTesting;
 
-  it('asks a roomy model for far more than the old fixed budget', () => {
-    expect(walkthroughOutputTokens({ contextTokens: 1_000_000, outputTokenLimit: 384_000 })).toBe(96_000);
+  it('reserves the catalog output allowance because promptAsync cannot cap it', () => {
+    expect(walkthroughOutputTokens({ contextTokens: 1_000_000, outputTokenLimit: 384_000 })).toBe(384_000);
   });
 
   it('never asks for more than the model says it can emit', () => {
     expect(walkthroughOutputTokens({ contextTokens: 202_752, outputTokenLimit: 32_768 })).toBe(32_768);
   });
 
-  it('keeps the reserve to a share of the context', () => {
-    expect(walkthroughOutputTokens({ contextTokens: 200_000, outputTokenLimit: 64_000 })).toBe(50_000);
-  });
-
-  it('holds the old floor for a small or uncatalogued model', () => {
+  it('uses the conservative historical fallback for an uncatalogued model', () => {
     expect(walkthroughOutputTokens({ contextTokens: 64_000, outputTokenLimit: null })).toBe(24_000);
     expect(walkthroughOutputTokens({ contextTokens: 0, outputTokenLimit: null })).toBe(24_000);
   });
 
-  it('yields to a model whose own limit is below the floor', () => {
+  it('uses a catalog limit even when it is below the fallback', () => {
     expect(walkthroughOutputTokens({ contextTokens: 128_000, outputTokenLimit: 8_192 })).toBe(8_192);
+  });
+
+  it('leaves no fake input floor when output allowance consumes the context', () => {
+    expect(walkthroughOutputTokens({ contextTokens: 8_000, outputTokenLimit: 8_000 })).toBe(8_000);
+  });
+
+  it('refuses generation when the effective output allowance leaves no input room', async () => {
+    describeSmallModel.mockResolvedValue({
+      providerID: 'test', modelID: 'no-input-room', source: 'request', hasLogin: true,
+      inputCharBudget: 0, structuredOutput: true, outputTokenLimit: 8_000,
+    });
+    await expect(generateWalkthrough({ directory: '/repo', source: SOURCE })).rejects.toMatchObject({
+      code: 'context-too-small', availableChars: 0,
+    });
+    expect(generateSmallModelText).not.toHaveBeenCalled();
   });
 });
 
@@ -255,7 +285,7 @@ describe('generation stages', () => {
     generateSmallModelText.mockImplementation(async () => {
       attempt += 1;
       seen.push(getGenerationStage('/repo', 'working-tree:all'));
-      if (attempt === 1) throw Object.assign(new Error('bad request'), { status: 400 });
+      if (attempt === 1) throw Object.assign(new Error('schema unsupported'), { code: 'structured-output-unsupported', status: 400, schemaRefusal: true });
       return { text: RESPONSE };
     });
 
@@ -285,7 +315,7 @@ describe('schema refusal memory', () => {
     const sentSchema = [];
     generateSmallModelText.mockImplementation(async ({ responseSchema }) => {
       sentSchema.push(Boolean(responseSchema));
-      if (responseSchema) throw Object.assign(new Error('bad request'), { status: 400 });
+      if (responseSchema) throw Object.assign(new Error('schema unsupported'), { code: 'structured-output-unsupported', status: 400, schemaRefusal: true });
       return { text: RESPONSE };
     });
 
@@ -299,5 +329,28 @@ describe('schema refusal memory', () => {
     await generateWalkthrough({ directory: '/repo', source: SOURCE });
 
     expect(sentSchema).toEqual([true, false, false]);
+  });
+
+  it('does not retry or remember an unrelated generic 400', async () => {
+    generateSmallModelText.mockRejectedValue(Object.assign(new Error('invalid model'), { status: 400 }));
+    await expect(generateWalkthrough({ directory: '/repo', source: SOURCE })).rejects.toThrow('invalid model');
+    expect(generateSmallModelText).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back for StructuredOutputError without remembering provider refusal', async () => {
+    describeSmallModel.mockResolvedValue({
+      providerID: 'anthropic', modelID: 'structured-only-test', source: 'config',
+      inputCharBudget: 1_000_000, structuredOutput: null,
+    });
+    const sentSchema = [];
+    generateSmallModelText.mockImplementation(async ({ responseSchema }) => {
+      sentSchema.push(Boolean(responseSchema));
+      if (responseSchema) throw Object.assign(new Error('generation did not match schema'), { code: 'structured-output-unsupported' });
+      return { text: RESPONSE };
+    });
+    await generateWalkthrough({ directory: '/repo', source: SOURCE });
+    getDiff.mockImplementation(async (_dir, options) => options?.staged ? '' : PATCH.replace('true', 'false'));
+    await generateWalkthrough({ directory: '/repo', source: SOURCE });
+    expect(sentSchema).toEqual([true, false, true, false]);
   });
 });

--- a/packages/web/server/lib/walkthrough/language.test.js
+++ b/packages/web/server/lib/walkthrough/language.test.js
@@ -15,14 +15,15 @@ vi.mock('../git/service.js', () => ({
 }));
 vi.mock('../small-model/index.js', () => ({
   describeSmallModel: vi.fn(),
-  generateSmallModelText: vi.fn(),
 }));
+vi.mock('./inference.js', () => ({ generateWalkthroughText: vi.fn() }));
 
 const { normalizeLanguage, languageName } = await import('./languages.js');
 const { buildPrompt } = await import('./prompt.js');
 const { buildCacheKey } = await import('./store.js');
 const { generateWalkthrough, getWalkthrough } = await import('./index.js');
-const { describeSmallModel, generateSmallModelText } = await import('../small-model/index.js');
+const { describeSmallModel } = await import('../small-model/index.js');
+const { generateWalkthroughText: generateSmallModelText } = await import('./inference.js');
 const { getDiff } = await import('../git/service.js');
 
 const SOURCE = { kind: 'working-tree', scope: 'all' };

--- a/packages/web/server/lib/walkthrough/prompt.js
+++ b/packages/web/server/lib/walkthrough/prompt.js
@@ -77,7 +77,7 @@ ${outline}
 
 // Used only when a provider rejects a schema request: the shape has to travel
 // in the prompt instead of the request body.
-export const JSON_SHAPE_INSTRUCTION = `
+export const WALKTHROUGH_JSON_INSTRUCTION = `
 Return ONLY a JSON object, with no prose around it and no markdown fences, in exactly this shape:
 {"title": string, "focus": string, "chapters": [{"title": string, "icon": "bug"|"wrench"|"path"|"flask"|"doc"|"gear", "blurb": string, "stops": [{"title": string, "hunks": [string], "importance": "critical"|"normal"|"context", "prose": string}]}]}`;
 

--- a/packages/web/server/lib/walkthrough/reproduce-2607.test.js
+++ b/packages/web/server/lib/walkthrough/reproduce-2607.test.js
@@ -2,7 +2,6 @@ import { execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import express from 'express';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
@@ -14,8 +13,8 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 // message `No OpenCode login found for provider "deepseek"` — shown in the
 // error banner above the "No walkthrough yet" empty state.
 //
-// After the fix: readiness refuses with `no-provider-login`, and generation
-// answers 401 with the same structured code so the UI can show a blocker.
+// Direct-provider calls still refuse missing credentials. Walkthrough itself
+// now delegates auth to OpenCode so plugin-backed providers can run.
 // ---------------------------------------------------------------------------
 
 const TEMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-home-2607-'));
@@ -85,13 +84,11 @@ describe('issue 2607 — walkthrough blocks unauthenticated providers', () => {
     fs.rmSync(REPO_DIR, { recursive: true, force: true });
   });
 
-  it('resolves the deepseek model but reports not ready without a login', async () => {
+  it('does not treat direct-provider login discovery as walkthrough authority', async () => {
     const result = await walkthrough.getWalkthrough({ directory: REPO_DIR, source: SOURCE });
 
-    expect(result.readiness.ready).toBe(false);
-    expect(result.readiness.reason).toBe('no-provider-login');
-    // Unusable models must not be offered as the current selection.
-    expect(result.readiness.model).toBeUndefined();
+    expect(result.readiness.ready).toBe(true);
+    expect(result.readiness.model).toMatchObject({ providerID: 'deepseek', modelID: 'deepseek-v4-flash', hasLogin: false });
   });
 
   it('callSmallModel throws a structured no-provider-login error', async () => {
@@ -110,39 +107,4 @@ describe('issue 2607 — walkthrough blocks unauthenticated providers', () => {
     expect(error.statusCode).toBe(401);
   });
 
-  it('generateWalkthrough rejects with structured no-provider-login', async () => {
-    const error = await walkthrough.generateWalkthrough({ directory: REPO_DIR, source: SOURCE })
-      .then(() => null, (e) => e);
-
-    expect(error).toBeInstanceOf(Error);
-    expect(error.code).toBe('no-provider-login');
-    expect(error.statusCode).toBe(401);
-    expect(error.model).toMatchObject({ providerID: 'deepseek', modelID: 'deepseek-v4-flash' });
-  });
-
-  it('answers the generate route with HTTP 401 and code no-provider-login', async () => {
-    const service = { ...walkthrough, getPullRequestDiff: async () => { throw new Error('not used'); } };
-    const app = express();
-    app.use(express.json());
-    const { registerWalkthroughRoutes } = await import('./routes.js');
-    registerWalkthroughRoutes(app, { getWalkthroughService: async () => service });
-
-    const server = app.listen(0);
-    await new Promise((resolve) => server.once('listening', resolve));
-    const base = `http://127.0.0.1:${server.address().port}`;
-    try {
-      const response = await fetch(`${base}/api/walkthrough/generate`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ directory: REPO_DIR, source: SOURCE }),
-      });
-      const body = await response.json();
-
-      expect(response.status).toBe(401);
-      expect(body.code).toBe('no-provider-login');
-      expect(body.model).toMatchObject({ providerID: 'deepseek', modelID: 'deepseek-v4-flash' });
-    } finally {
-      await new Promise((resolve) => server.close(resolve));
-    }
-  });
 });

--- a/packages/web/server/lib/walkthrough/routes.js
+++ b/packages/web/server/lib/walkthrough/routes.js
@@ -4,23 +4,28 @@
 // client is still there.
 const clientIsGone = (res) => res.writableEnded || res.destroyed;
 
-export function registerWalkthroughRoutes(app, { getWalkthroughService }) {
+export function registerWalkthroughRoutes(app, { getWalkthroughService, buildOpenCodeUrl, getOpenCodeAuthHeaders }) {
+  const serviceDeps = (getPullRequestDiff) => {
+    const deps = { getPullRequestDiff };
+    if (buildOpenCodeUrl instanceof Function) deps.openCodeBaseUrl = buildOpenCodeUrl('/', '').replace(/\/$/, '');
+    if (getOpenCodeAuthHeaders instanceof Function) deps.openCodeAuthHeaders = getOpenCodeAuthHeaders();
+    return deps;
+  };
   const respondWithError = (res, error, fallback) => {
     const statusCode = Number(error?.statusCode) || 500;
     if (statusCode >= 500) {
       console.error(`${fallback}:`, error);
     }
-    res.status(statusCode).json({
-      error: error?.message || fallback,
-      ...(error?.code ? { code: error.code } : {}),
-      ...(error?.model ? { model: error.model } : {}),
-      ...(Number.isFinite(error?.requiredChars) ? { requiredChars: error.requiredChars } : {}),
-      ...(Number.isFinite(error?.availableChars) ? { availableChars: error.availableChars } : {}),
-    });
+    const payload = { error: error?.message || fallback };
+    if (error?.code) payload.code = error.code;
+    if (error?.model) payload.model = error.model;
+    if (Number.isFinite(error?.requiredChars)) payload.requiredChars = error.requiredChars;
+    if (Number.isFinite(error?.availableChars)) payload.availableChars = error.availableChars;
+    res.status(statusCode).json(payload);
   };
 
   const readSource = (value) => {
-    if (typeof value !== 'string' || !value) return null;
+    if (value?.constructor !== String || !value) return null;
     try {
       return JSON.parse(value);
     } catch {
@@ -31,7 +36,7 @@ export function registerWalkthroughRoutes(app, { getWalkthroughService }) {
   app.get('/api/walkthrough', async (req, res) => {
     try {
       const { getWalkthrough, getPullRequestDiff } = await getWalkthroughService();
-      const directory = typeof req.query.directory === 'string' ? req.query.directory : '';
+      const directory = req.query.directory?.constructor === String ? req.query.directory : '';
       if (!directory) {
         return res.status(400).json({ error: 'directory parameter is required' });
       }
@@ -40,10 +45,10 @@ export function registerWalkthroughRoutes(app, { getWalkthroughService }) {
         {
           directory,
           source: readSource(req.query.source),
-          model: typeof req.query.model === 'string' ? req.query.model : undefined,
-          language: typeof req.query.language === 'string' ? req.query.language : undefined,
+          model: req.query.model?.constructor === String ? req.query.model : undefined,
+          language: req.query.language?.constructor === String ? req.query.language : undefined,
         },
-        { getPullRequestDiff },
+        serviceDeps(getPullRequestDiff),
       );
       res.json(result);
     } catch (error) {
@@ -59,7 +64,7 @@ export function registerWalkthroughRoutes(app, { getWalkthroughService }) {
     try {
       const { generateWalkthrough, getPullRequestDiff } = await getWalkthroughService();
       const { directory, source, force, model, language } = req.body || {};
-      if (!directory || typeof directory !== 'string') {
+      if (!directory || directory.constructor !== String) {
         return res.status(400).json({ error: 'directory is required' });
       }
 
@@ -68,10 +73,10 @@ export function registerWalkthroughRoutes(app, { getWalkthroughService }) {
           directory,
           source,
           force: force === true,
-          model: typeof model === 'string' ? model : undefined,
-          language: typeof language === 'string' ? language : undefined,
+          model: model?.constructor === String ? model : undefined,
+          language: language?.constructor === String ? language : undefined,
         },
-        { getPullRequestDiff },
+        serviceDeps(getPullRequestDiff),
       );
       if (clientIsGone(res)) return;
       res.json(result);
@@ -86,7 +91,7 @@ export function registerWalkthroughRoutes(app, { getWalkthroughService }) {
   app.get('/api/walkthrough/progress', async (req, res) => {
     try {
       const { getGenerationStage, getRepositoryRootFor } = await getWalkthroughService();
-      const directory = typeof req.query.directory === 'string' ? req.query.directory : '';
+      const directory = req.query.directory?.constructor === String ? req.query.directory : '';
       if (!directory) {
         return res.status(400).json({ error: 'directory parameter is required' });
       }
@@ -102,7 +107,7 @@ export function registerWalkthroughRoutes(app, { getWalkthroughService }) {
     try {
       const { cancelWalkthroughGeneration } = await getWalkthroughService();
       const { directory, source } = req.body || {};
-      if (!directory || typeof directory !== 'string') {
+      if (!directory || directory.constructor !== String) {
         return res.status(400).json({ error: 'directory is required' });
       }
 


### PR DESCRIPTION
## Intent

Fixes Changes Walkthrough generation for models registered by OpenCode plugins. Walkthrough inference now runs through temporary OpenCode SDK v2 sessions instead of calling provider APIs directly, so plugin-owned authentication, transport, proxying, and model registration behave like normal chat.

Closes #2666

## Non-goals

- This does not migrate other direct Small Model features to OpenCode sessions.
- Temporary Walkthrough turns remain non-agentic: tools and permissions are denied.
- This does not change the visible Walkthrough layout or generated review format.

## Affected surfaces

- `packages/web`: Walkthrough inference, OpenCode event transport, internal-session lifecycle, permission/notification side-effect filtering, and readiness/error handling.
- `packages/ui`: Walkthrough model pickers plus global/directory session ingestion filters.
- Web, Desktop, and hosted mobile use the server routes and receive the new behavior. VS Code remains unaffected because the Walkthrough surface is not offered there.
- The only persisted contract added is temporary OpenCode session metadata: `metadata.openchamber.internalSession.kind = walkthrough-inference`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | Cross-package source, contracts, and lifecycle behavior changed | Kept provider dispatch in the owning OpenCode boundary, documented cleanup/failure behavior, and added focused contract tests. |
| `ui-api-decoupling` + implementation map | Walkthrough now calls official OpenCode session APIs | Uses `@opencode-ai/sdk/v2` through the server runtime URL/auth boundary; OpenChamber routes remain explicit and runtime credentials are resolved per request. |
| `sync-state-invariants` + UI sync documentation | Hidden sessions affect bootstrap, events, runtime switching, and deletion | Uses one metadata contract, generation-scopes async list results and buffered events, and handles delete/cancel/restart cleanup explicitly. |
| `performance-engineering` | Global and directory event streams are hot paths | Metadata fast-paths avoid lookups, unknown ID lookups are deduplicated with a short deadline/failure TTL, and inference polling backs off to two seconds. |
| `packages/web/README.md`, Walkthrough/OpenCode/UI sync `DOCUMENTATION.md` | These modules own the changed behavior | Updated model dispatch, output allowance, internal-session, transport, and cleanup invariants. |

## Validation

| Check | Result |
|---|---|
| Official `pr checks` on HEAD `56c2fba10` | Passed in 5m57s: build, type-check, lint, full test suite, and Electron Linux packaging unit tests. |
| Focused web Walkthrough/internal-session/transport/permission tests | Passed: 16 files, 144 tests. |
| Focused UI runtime-generation, buffered-event, filtering, settings, and sync tests | Passed; latest correction suite: 32 tests across 5 files. |
| `bun run type-check` and package lint in affected workspaces | Passed. |
| Focused `bun x oxlint` over new/substantially changed feature paths | Passed with no findings. |
| `bun x knip@5.80.0 --no-exit-code --include files,exports,nsExports,types,nsTypes,enumMembers,duplicates` | No new feature file or internal-session export reported; repository backlog remains. |
| SDK-boundary integration with a real SDK client and HTTP fake OpenCode server | Passed: session create/prompt/poll/delete, selected model/schema/tools/permissions, normalization/cache, hidden lists/events, zero side effects, and cancel abort/delete. |
| Greptile review on final HEAD | 5/5, no blocking failure. Both runtime-switch findings were fixed and their threads resolved. |

Not verified with a paid/live provider: provider-specific response quality, real process-crash recovery timing, and browser disconnect/reattach over a live socket.

## Visual evidence

No rendered UI changes. Existing model selectors keep the same appearance; this PR only removes the direct-provider credential allowlist from Walkthrough selectors so OpenCode/plugin models can be chosen.

## Risks and failure behavior

- Temporary sessions are atomically metadata-marked, denied tools/permissions, hidden before global/directory replay and UI ingestion, aborted on cancel/timeout, and deleted in `finally`.
- Cleanup failures retain hidden classification and schedule bounded orphan reconciliation. Active Walkthrough sessions are excluded; true orphans are aborted before deletion.
- Runtime generations are captured per network attempt and per event pipeline. Old list responses and buffered events remain filtered but cannot write, consult, or clear classifications in the newly selected runtime.
- Unknown ID-only server event classification fails open after a short deadline to avoid blocking ordinary session traffic; UI filtering remains defense in depth.
- `promptAsync` does not expose a per-turn output cap, so readiness conservatively reserves the catalog output allowance, or 24k tokens when unknown.
- OpenCode is authoritative for plugin/provider authentication. `ProviderAuthError` remains mapped to the existing `no-provider-login` response.