### PR TITLE
Fix dialog close button hit area

### DIFF
--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -111,7 +111,7 @@ function DialogContent({
         {showCloseButton && (
           <BaseDialog.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[open]:bg-interactive-active data-[open]:text-foreground absolute top-2 right-2 rounded-lg opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none text-muted-foreground hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[open]:bg-interactive-active data-[open]:text-foreground absolute top-2 right-2 z-10 inline-flex size-7 items-center justify-center rounded-lg opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none text-muted-foreground hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <Icon name="close"/>
             <span className="sr-only">{t('dialog.common.actions.close')}</span>


### PR DESCRIPTION
## Intent

Fix the close “x” control in the keyboard shortcuts popup so it can be clicked or tapped reliably.

The shared dialog close control now:

- sits above the dialog’s scrollable content through an explicit stacking level; and
- has a 28×28-pixel interactive area centred around the existing close icon.

This preserves the existing Base UI close behaviour, focus treatment, hover treatment, icon, and localised screen-reader label.

## Non-goals

- This PR does not change how the shortcuts popup is opened or how its open state is stored.
- It does not change Escape-key or backdrop dismissal.
- It does not change shortcut definitions, keyboard handling, or shortcut customisation.
- It does not change dialog content, copy, colours, or animations.
- It does not introduce a new dialog or button abstraction.

## Affected surfaces

- **Package:** `packages/ui`.
- **Primary user-visible state:** the close control shown in the keyboard shortcuts popup.
- **Shared UI impact:** the adjustment is made in the shared `DialogContent` close control, so dialogs using the default close button receive the same stacking and hit-area correction.
- **Runtimes:** web, desktop, VS Code, hosted mobile, and Capacitor mobile consume the shared UI dialog primitive and may therefore receive the corrected close control.
- **Persisted or external contracts:** none. The change does not alter stored settings, routes, APIs, runtime bridges, serialised data, or package exports.