### PR TITLE
fix(chat): normalize composer rewrite selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Chat: if OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
+- Chat: recalling or restoring composer text with Windows line endings no longer crashes the conversation (thanks to @mattv8).
 
 ## [1.19.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Work status: the session cost now counts what its subagents spent, with a line under the context meter splitting the session's own cost from the subagents' share, and each subagent's cost shown next to it in the Subagents list. Previously a session that delegated most of its work looked far cheaper than it was.
+- Chat: recalling or restoring composer text with Windows line endings no longer crashes the conversation (thanks to @mattv8).
 - Files: opening a file over 5,000 lines is no longer blocked — the line-count guard now allows up to 20,000 lines, letting large files reach the virtualized full-file preview instead of being rejected at the open step (thanks @gaojunran).
 - Usage: GitHub Copilot now shows a single AI Credits window, matching Copilot's token-based quota, in place of the old Chat Requests and Completions windows (thanks to @jakoss).
 - Settings: fixed the Cloudflare Tunnel download link shown when cloudflared is not installed (thanks to @AyoubAchour).

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -143,12 +143,13 @@ hardware.
 
 ## Testing
 
-The package has no DOM test environment, so coverage stops at the state and
-logic layers: the language, the submit assembly, path and drop handling, text
-splicing, message history, and the CodeMirror language extension at the
-`EditorState` level.
+The package has no browser DOM test environment. Focused tests can still mount
+React component effects with minimal stubs and real state logic, alongside the
+state and logic layers: the language, the submit assembly, path and drop
+handling, text splicing, message history, and the CodeMirror language
+extension at the `EditorState` level.
 
-Rendering, focus, keyboard behavior, IME and WKWebView are **not covered by
+Rendering, focus, keyboard behavior, IME, and WKWebView are **not covered by
 tests** and are verified by hand. Do not report a change to them as validated
 on the strength of type-check and unit tests.
 

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -168,12 +168,13 @@ hardware.
 
 ## Testing
 
-The package has no DOM test environment, so coverage stops at the state and
-logic layers: the language, the submit assembly, path and drop handling, text
-splicing, message history, and the CodeMirror language extension at the
-`EditorState` level.
+The package has no browser DOM test environment. Focused tests can still mount
+React component effects with minimal stubs and real state logic, alongside the
+state and logic layers: the language, the submit assembly, path and drop
+handling, text splicing, message history, and the CodeMirror language
+extension at the `EditorState` level.
 
-Rendering, focus, keyboard behavior, IME and WKWebView are **not covered by
+Rendering, focus, keyboard behavior, IME, and WKWebView are **not covered by
 tests** and are verified by hand. Do not report a change to them as validated
 on the strength of type-check and unit tests.
 

--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -351,8 +351,9 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
             // A stale value echo can differ from CodeMirror's newer document,
             // and replacing it would interrupt the IME session and move the caret.
             if (view.compositionStarted) return;
+            const changes = view.state.changes({ from: 0, to: current.length, insert: value });
             view.dispatch({
-                changes: { from: 0, to: current.length, insert: value },
+                changes,
                 // An external rewrite (draft restore, history navigation,
                 // "add to chat", dictation insert) lands the caret at the END,
                 // matching what a plain textarea did when its value was
@@ -360,7 +361,7 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                 // replaces wholesale; keeping the old caret instead left it
                 // stranded before the inserted text, and the next insertion
                 // or keystroke landed inside the previous one.
-                selection: { anchor: value.length },
+                selection: { anchor: changes.newLength },
             });
             // A large insert can push the caret below the fold, and a
             // transaction-time `scrollIntoView` cannot reach it: wrapped-line

--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -347,8 +347,9 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
             // A stale value echo can differ from CodeMirror's newer document,
             // and replacing it would interrupt the IME session and move the caret.
             if (view.compositionStarted) return;
+            const changes = view.state.changes({ from: 0, to: current.length, insert: value });
             view.dispatch({
-                changes: { from: 0, to: current.length, insert: value },
+                changes,
                 // An external rewrite (draft restore, history navigation,
                 // "add to chat", dictation insert) lands the caret at the END,
                 // matching what a plain textarea did when its value was
@@ -356,7 +357,7 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                 // replaces wholesale; keeping the old caret instead left it
                 // stranded before the inserted text, and the next insertion
                 // or keystroke landed inside the previous one.
-                selection: { anchor: value.length },
+                selection: { anchor: changes.newLength },
             });
             // A large insert can push the caret below the fold, and a
             // transaction-time `scrollIntoView` cannot reach it: wrapped-line

--- a/packages/ui/src/components/chat/composer/editor/__tests__/controlledWriteback.test.tsx
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/controlledWriteback.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import React, { act } from 'react';
 import { EditorState, type TransactionSpec } from '@codemirror/state';
-import type { EditorView } from '@codemirror/view';
 import { createRoot } from 'react-dom/client';
 
 import { ComposerEditor, type ComposerEditorHandle, type ComposerEditorProps } from '../ComposerEditor';

--- a/packages/ui/src/components/chat/composer/editor/__tests__/controlledWriteback.test.tsx
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/controlledWriteback.test.tsx
@@ -1,0 +1,356 @@
+import { describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { EditorState, type TransactionSpec } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import { createRoot } from 'react-dom/client';
+
+import { ComposerEditor, type ComposerEditorHandle, type ComposerEditorProps } from '../ComposerEditor';
+import type { ComposerEditorViewStore } from '../viewStore';
+
+class ClassListStub {
+    add(): void {}
+    remove(): void {}
+    contains(): boolean { return false; }
+}
+
+class StyleStub {
+    maxHeight = '';
+    setProperty(): void {}
+    getPropertyValue(): string { return ''; }
+}
+
+type DocumentStub = {
+    nodeType: 9;
+    defaultView: WindowStub;
+    activeElement: ElementStub | null;
+    body: ElementStub;
+    documentElement: ElementStub;
+    createElement(tag: string): ElementStub;
+    createElementNS(namespace: string, tag: string): ElementStub;
+    createTextNode(text: string): TextStub;
+    addEventListener(): void;
+    removeEventListener(): void;
+};
+
+class TextStub {
+    readonly nodeType = 3 as const;
+    readonly nodeName = '#text';
+    parentNode: ElementStub | null = null;
+
+    constructor(
+        readonly ownerDocument: DocumentStub,
+        public textContent: string,
+    ) {}
+}
+
+class ElementStub {
+    readonly nodeType = 1 as const;
+    readonly namespaceURI = 'http://www.w3.org/1999/xhtml';
+    readonly style = new StyleStub();
+    readonly classList = new ClassListStub();
+    readonly childNodes: Array<ElementStub | TextStub> = [];
+    parentNode: ElementStub | null = null;
+    textContent = '';
+    innerHTML = '';
+
+    constructor(
+        readonly ownerDocument: DocumentStub,
+        readonly tagName: string,
+    ) {}
+
+    get nodeName(): string {
+        return this.tagName;
+    }
+
+    addEventListener(): void {}
+    removeEventListener(): void {}
+    setAttribute(): void {}
+    removeAttribute(): void {}
+    focus(): void {}
+    blur(): void {}
+
+    appendChild(child: ElementStub | TextStub): ElementStub | TextStub {
+        child.parentNode = this;
+        this.childNodes.push(child);
+        return child;
+    }
+
+    insertBefore(child: ElementStub | TextStub, reference: ElementStub | TextStub | null): ElementStub | TextStub {
+        child.parentNode = this;
+        if (reference === null) {
+            this.childNodes.push(child);
+            return child;
+        }
+        const index = this.childNodes.indexOf(reference);
+        if (index === -1) {
+            this.childNodes.push(child);
+            return child;
+        }
+        this.childNodes.splice(index, 0, child);
+        return child;
+    }
+
+    removeChild(child: ElementStub | TextStub): ElementStub | TextStub {
+        const index = this.childNodes.indexOf(child);
+        if (index !== -1) this.childNodes.splice(index, 1);
+        child.parentNode = null;
+        return child;
+    }
+
+    remove(): void {
+        this.parentNode?.removeChild(this);
+    }
+}
+
+type WindowStub = {
+    document: DocumentStub;
+    navigator: { userAgent: string; platform: string; maxTouchPoints: number };
+    addEventListener(): void;
+    removeEventListener(): void;
+    getComputedStyle(): { lineHeight: string };
+    HTMLIFrameElement: typeof HostConstructor;
+    HTMLFrameSetElement: typeof HostConstructor;
+    HTMLInputElement: typeof HostConstructor;
+    HTMLTextAreaElement: typeof HostConstructor;
+    HTMLSelectElement: typeof HostConstructor;
+    HTMLOptionElement: typeof HostConstructor;
+    HTMLAnchorElement: typeof HostConstructor;
+};
+
+class HostConstructor {}
+
+type GlobalMap = {
+    document: DocumentStub;
+    window: WindowStub;
+    navigator: WindowStub['navigator'];
+    requestAnimationFrame: (callback: FrameRequestCallback) => number;
+    cancelAnimationFrame: () => void;
+    getComputedStyle: () => { lineHeight: string };
+    IS_REACT_ACT_ENVIRONMENT: boolean;
+    Element: typeof HostConstructor;
+    HTMLElement: typeof HostConstructor;
+    HTMLIFrameElement: typeof HostConstructor;
+    HTMLFrameSetElement: typeof HostConstructor;
+    HTMLInputElement: typeof HostConstructor;
+    HTMLTextAreaElement: typeof HostConstructor;
+    HTMLSelectElement: typeof HostConstructor;
+    HTMLOptionElement: typeof HostConstructor;
+    HTMLAnchorElement: typeof HostConstructor;
+};
+
+type GlobalKey =
+    | 'document'
+    | 'window'
+    | 'navigator'
+    | 'requestAnimationFrame'
+    | 'cancelAnimationFrame'
+    | 'getComputedStyle'
+    | 'IS_REACT_ACT_ENVIRONMENT'
+    | 'Element'
+    | 'HTMLElement'
+    | 'HTMLIFrameElement'
+    | 'HTMLFrameSetElement'
+    | 'HTMLInputElement'
+    | 'HTMLTextAreaElement'
+    | 'HTMLSelectElement'
+    | 'HTMLOptionElement'
+    | 'HTMLAnchorElement';
+
+class MutableDocumentStub implements DocumentStub {
+    readonly nodeType = 9 as const;
+    defaultView!: WindowStub;
+    activeElement: ElementStub | null = null;
+    body!: ElementStub;
+    documentElement!: ElementStub;
+
+    createElement(tag: string): ElementStub {
+        return new ElementStub(this, tag.toUpperCase());
+    }
+
+    createElementNS(_namespace: string, tag: string): ElementStub {
+        return this.createElement(tag);
+    }
+
+    createTextNode(text: string): TextStub {
+        return new TextStub(this, text);
+    }
+
+    addEventListener(): void {}
+    removeEventListener(): void {}
+}
+
+function installMinimalDom() {
+    const descriptors = new Map<GlobalKey, PropertyDescriptor | undefined>();
+    const setGlobal = <K extends GlobalKey>(name: K, value: GlobalMap[K]) => {
+        descriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+        Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+    };
+
+    const document = new MutableDocumentStub();
+    const window: WindowStub = {
+        document,
+        navigator: { userAgent: 'test', platform: 'test', maxTouchPoints: 0 },
+        addEventListener() {},
+        removeEventListener() {},
+        getComputedStyle() {
+            return { lineHeight: '16px' };
+        },
+        HTMLIFrameElement: HostConstructor,
+        HTMLFrameSetElement: HostConstructor,
+        HTMLInputElement: HostConstructor,
+        HTMLTextAreaElement: HostConstructor,
+        HTMLSelectElement: HostConstructor,
+        HTMLOptionElement: HostConstructor,
+        HTMLAnchorElement: HostConstructor,
+    };
+
+    document.defaultView = window;
+    document.body = document.createElement('body');
+    document.documentElement = document.createElement('html');
+
+    setGlobal('document', document);
+    setGlobal('window', window);
+    setGlobal('navigator', window.navigator);
+    setGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+    });
+    setGlobal('cancelAnimationFrame', () => {});
+    setGlobal('getComputedStyle', () => ({ lineHeight: '16px' }));
+    setGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    setGlobal('Element', HostConstructor);
+    setGlobal('HTMLElement', HostConstructor);
+    setGlobal('HTMLIFrameElement', HostConstructor);
+    setGlobal('HTMLFrameSetElement', HostConstructor);
+    setGlobal('HTMLInputElement', HostConstructor);
+    setGlobal('HTMLTextAreaElement', HostConstructor);
+    setGlobal('HTMLSelectElement', HostConstructor);
+    setGlobal('HTMLOptionElement', HostConstructor);
+    setGlobal('HTMLAnchorElement', HostConstructor);
+
+    const container = document.createElement('div');
+
+    return {
+        container,
+        document,
+        restore() {
+            for (const [name, descriptor] of descriptors) {
+                if (descriptor) {
+                    Object.defineProperty(globalThis, name, descriptor);
+                } else {
+                    Reflect.deleteProperty(globalThis, name);
+                }
+            }
+        },
+    };
+}
+
+const LANGUAGE_CONTEXT: ComposerEditorProps['languageContext'] = {
+    inputMode: 'normal',
+    knownAgentNames: new Set(),
+    confirmedMentions: new Set(),
+    knownSlashNames: new Set(),
+    knownSnippetTriggers: new Set(),
+    attachmentFilenames: [],
+};
+
+class KeptViewHarness {
+    state: EditorState;
+    compositionStarted = false;
+    hasFocus = false;
+    readonly dom: ElementStub;
+    readonly contentDOM = {
+        isContentEditable: true,
+        setAttribute() {},
+        focus: () => {
+            this.hasFocus = true;
+        },
+        blur: () => {
+            this.hasFocus = false;
+        },
+    };
+    readonly scrollDOM = {
+        style: { maxHeight: '' },
+        scrollTop: 0,
+        scrollHeight: 48,
+    };
+
+    constructor(document: DocumentStub, value: string) {
+        this.state = EditorState.create({ doc: value });
+        this.dom = document.createElement('div');
+    }
+
+    requestMeasure(): void {}
+
+    dispatch(spec: TransactionSpec): void {
+        if (spec.changes === undefined && spec.selection === undefined && spec.userEvent === undefined) {
+            return;
+        }
+        this.state = this.state.update(spec).state;
+    }
+}
+
+function renderEditor(initialValue: string) {
+    const dom = installMinimalDom();
+    // @ts-expect-error TS2345 -- SAFETY: React only uses the DOM container subset implemented by the ElementStub test double.
+    const root = createRoot(dom.container);
+    const ref = React.createRef<ComposerEditorHandle>();
+    const keptView = new KeptViewHarness(dom.document, initialValue);
+    const store: ComposerEditorViewStore = {
+        // @ts-expect-error TS2352 -- SAFETY: ComposerEditor uses only the kept-view EditorView subset implemented by KeptViewHarness.
+        view: keptView,
+        handlers: null,
+    };
+
+    const render = (value: string) => {
+        act(() => {
+            root.render(
+                <ComposerEditor
+                    ref={ref}
+                    value={value}
+                    onChange={() => {}}
+                    languageContext={LANGUAGE_CONTEXT}
+                    fillContainer={true}
+                    viewStore={store}
+                />,
+            );
+        });
+    };
+
+    render(initialValue);
+
+    return {
+        ref,
+        render,
+        teardown() {
+            act(() => {
+                root.unmount();
+            });
+            dom.restore();
+        },
+    };
+}
+
+describe('ComposerEditor controlled writeback', () => {
+    test('normalizes CRLF rewrites and leaves the caret at the normalized document end', () => {
+        const editor = renderEditor('a');
+        try {
+            editor.render('x\r\ny');
+            expect(editor.ref.current?.getValue()).toBe('x\ny');
+            expect(editor.ref.current?.getSelection()).toEqual({ start: 3, end: 3 });
+        } finally {
+            editor.teardown();
+        }
+    });
+
+    test('places the caret at the end of a plain external rewrite', () => {
+        const editor = renderEditor('a');
+        try {
+            editor.render('xyz');
+            expect(editor.ref.current?.getValue()).toBe('xyz');
+            expect(editor.ref.current?.getSelection()).toEqual({ start: 3, end: 3 });
+        } finally {
+            editor.teardown();
+        }
+    });
+});

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - If OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
+- Recalling or restoring composer text with Windows line endings no longer crashes the conversation (thanks to @mattv8).
 
 ## [1.19.0] - 2026-08-19
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - GitHub Copilot usage now shows a single AI Credits window, matching Copilot's token-based quota, in place of the old Chat Requests and Completions windows (thanks to @jakoss).
 - The context usage readout now reports the session cost including everything its subagents spent, matching the work status panel instead of showing a lower figure.
+- Recalling or restoring composer text with Windows line endings no longer crashes the conversation (thanks to @mattv8).
 
 ## [1.21.0] - 2026-08-26
 


### PR DESCRIPTION
## Intent

Fixes #3013.

External composer rewrites such as history recall and draft restore can contain CRLF text. CodeMirror normalizes that text to LF while constructing the change, but the controlled writeback selected the raw string's longer `value.length`. The resulting anchor could fall outside the normalized document and replace the conversation with `RangeError: Selection points outside of document`.

The writeback now builds one CodeMirror `ChangeSet` and uses that same change's `newLength` for the end selection. The rewrite remains atomic, and the caret lands at the normalized document end.

If anyone on MacOS wants to try this feature, and others I've been working on, I have pre-releases you can download and easily install here: https://github.com/mattv8/openchamber-testing/releases

## Non-goals

- No changes to persisted drafts, sent messages, user history, or PTY output.
- No manual or regex line-ending normalization outside CodeMirror.
- No change to `insertText` or `replaceRange`. They have the same raw-length assumption, but their current callers also track raw offsets. The #3013 history and draft paths use the controlled writeback fixed here; changing the imperative coordinate contract belongs in separate, coordinated work.

## Affected surfaces

- `packages/ui`: shared composer controlled-value synchronization.
- Web, Electron, VS Code webview, hosted mobile, and Capacitor mobile consume
  the same composer and receive the fix.
- The resulting CodeMirror document continues to normalize CRLF to LF as it did
  before. No persisted or external data format changes.
- No server, CLI, transport, sync, or Electron-main behavior changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` | Shared UI source, tests, changelogs, and PR handoff changed | Kept the production change at the owning editor boundary, added focused coverage, ran package-scoped checks, updated owning documentation, and completed every PR template section. |
| `openchamber-change-discipline` | Executable source and a new test file changed | Uses the smallest atomic production change, preserves contracts, avoids downstream compatibility code, runs focused tests/type-check/lint, and inspects the non-blocking dead-code report. |
| Composer `DOCUMENTATION.md` | Owns editor and testing invariants | Preserves controlled end-selection behavior and updates the testing section to distinguish minimal React/state harnesses from browser/device validation. |
| `changelog-authoring` | Main and VS Code `[Unreleased]` entries changed | Adds concise user-visible bullets only to affected surfaces and credits issue author @mattv8. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/composer/editor/__tests__/controlledWriteback.test.tsx` before the production fix | Reproduced the report: `RangeError: Selection points outside of document`; 1 pass, 1 fail. |
| `bun test packages/ui/src/components/chat/composer/editor/__tests__` | Pass: 44 tests, 0 failures, 85 assertions. |
| `bun run type-check:ui` | Pass: `tsc --noEmit`, exit 0. |
| `bunx oxlint packages/ui/src/components/chat/composer/editor/__tests__/controlledWriteback.test.tsx` | Pass: exit 0, no findings. |
| `bunx oxlint packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx` | Ran; reports only the same pre-existing findings at lines 140, 292, and 445 on the unmodified upstream file. The two changed lines add no finding. |
| `bun run dead-code` | Completed with the repository's existing non-blocking backlog; the new regression test was not reported. |
| `git diff --check` | Pass: exit 0. |
| `bun run test` | The root script reached the UI suite, where the unrelated `packages/ui/src/sync/__tests__/event-pipeline.test.js` had 10 existing timing failures with no events delivered after about 80 ms; 272/273 isolated UI files passed before the script stopped. Rerunning that unchanged sync file alone reproduced the same 10 failures. |

Not verified: concrete `EditorView` DOM construction, rendering, focus, keyboard behavior, IME, and WKWebView behavior. The regression mounts the real React controlled component and applies its transaction through real `EditorState.update`, which owns the normalization and selection validation that threw. It does not claim browser rendering coverage. The repository-wide suite is not green because of the unrelated sync test failures reported above.

## Visual evidence

No rendered appearance changes. The affected interaction either completed with the existing composer appearance or crashed into the session error boundary; the regression evidence above captures the failing and fixed state transition without claiming a visual change.

## Risks and failure behavior

- The selection now derives from the exact normalized `ChangeSet` being dispatched, so future CodeMirror line-separator behavior stays consistent with the coordinate.
- Existing end-of-document behavior for ordinary external rewrites has focused regression coverage.
- If reverted, CRLF history or draft rewrites can crash again. Revert requires no data migration or cleanup because this PR changes no stored state.
- The imperative `insertText`/`replaceRange` audit is documented under non-goals rather than partially changing a broader caller coordinate contract.

## Related work

- #2419 introduced the CodeMirror composer and the external-rewrite end-caret behavior preserved here.
- #2691 fixed the adjacent controlled-writeback IME guard without changing external rewrite selection semantics.
- codemirror/dev#1509 identifies the same raw string length versus normalized document coordinate root cause and recommends deriving insertion coordinates from CodeMirror state.
- firasdib/Regex101#2403 is the downstream incident that led to the upstream CodeMirror diagnosis.
