### PR TITLE
fix(ui): keep failed dictation recovery controls on screen

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1731,10 +1731,10 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
         }
     }, [agents, currentAgentName, currentSessionId, setAgent, saveSessionAgentSelection]);
 
-    // Height the dictation transcript needs (null when idle). Its overlay sits
+    // Height the failed-dictation salvage text needs. Its overlay sits
     // absolutely over the composer, so the composer must be able to grow for
     // it. Apply the editor's line and screen bounds before using that height as
-    // a floor, otherwise a long transcript can push the action row off-screen.
+    // a floor, otherwise long salvage text can push the action row off-screen.
     const dictationHeightHostRef = React.useRef<HTMLDivElement | null>(null);
     const [dictationContentHeight, setDictationContentHeight] = React.useState<number | null>(null);
     const handleDictationContentHeightChange = React.useCallback((height: number | null) => {

--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -104,6 +104,7 @@ import {
     type ComposerChange,
     type ComposerEditorHandle,
 } from './composer/editor/ComposerEditor';
+import { useComposerHeightLimit } from './composer/editor/useComposerHeightLimit';
 import { createComposerEditorViewStore } from './composer/editor/viewStore';
 import { composerAutoCorrect } from './composer/editor/autocorrect';
 import {
@@ -1732,12 +1733,21 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
 
     // Height the dictation transcript needs (null when idle). Its overlay sits
     // absolutely over the composer, so the composer must be able to grow for
-    // it. The editor sizes itself to its own content; this is the one external
-    // constraint, applied as a floor on the editor's container.
+    // it. Apply the editor's line and screen bounds before using that height as
+    // a floor, otherwise a long transcript can push the action row off-screen.
+    const dictationHeightHostRef = React.useRef<HTMLDivElement | null>(null);
     const [dictationContentHeight, setDictationContentHeight] = React.useState<number | null>(null);
     const handleDictationContentHeightChange = React.useCallback((height: number | null) => {
         setDictationContentHeight((prev) => (prev === height ? prev : height));
     }, []);
+    const dictationHeightLimit = useComposerHeightLimit({
+        active: dictationContentHeight !== null,
+        disabled: isComposerExpanded,
+        hostRef: dictationHeightHostRef,
+        maxLines: isMobile ? MAX_MOBILE_COMPOSER_LINES : MAX_VISIBLE_COMPOSER_LINES,
+        boundSelector: isMobile ? '[data-composer-bound]' : undefined,
+        boundGapPx: isMobile ? MOBILE_COMPOSER_BOUND_GAP_PX : 0,
+    });
 
     const updateAutocompleteState = React.useCallback((
         value: string,
@@ -2802,14 +2812,20 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
                             <ActiveEditorFileSuggestion />
                         </div>
                         <div
+                            ref={dictationHeightHostRef}
                             className={cn("relative overflow-hidden", isComposerExpanded && 'flex flex-1 min-h-0 flex-col')}
                             onDragEnter={handleDragEnter}
                             onDragOver={handleDragOver}
                             onDropCapture={handleDropCapture}
                             onDrop={handleDrop}
                             onDragEnd={handleDragEnd}
-                            style={dictationContentHeight !== null
-                                ? { minHeight: `${dictationContentHeight}px` }
+                            style={dictationContentHeight !== null && !isComposerExpanded
+                                ? {
+                                    minHeight: `${Math.min(
+                                        dictationContentHeight,
+                                        dictationHeightLimit ?? dictationContentHeight,
+                                    )}px`,
+                                }
                                 : undefined}
                         >
                             <ComposerEditor

--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -99,6 +99,7 @@ import {
     type ComposerChange,
     type ComposerEditorHandle,
 } from './composer/editor/ComposerEditor';
+import { useComposerHeightLimit } from './composer/editor/useComposerHeightLimit';
 import { createComposerEditorViewStore } from './composer/editor/viewStore';
 import {
     appendInlineText,
@@ -1687,12 +1688,21 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
 
     // Height the dictation transcript needs (null when idle). Its overlay sits
     // absolutely over the composer, so the composer must be able to grow for
-    // it. The editor sizes itself to its own content; this is the one external
-    // constraint, applied as a floor on the editor's container.
+    // it. Apply the editor's line and screen bounds before using that height as
+    // a floor, otherwise a long transcript can push the action row off-screen.
+    const dictationHeightHostRef = React.useRef<HTMLDivElement | null>(null);
     const [dictationContentHeight, setDictationContentHeight] = React.useState<number | null>(null);
     const handleDictationContentHeightChange = React.useCallback((height: number | null) => {
         setDictationContentHeight((prev) => (prev === height ? prev : height));
     }, []);
+    const dictationHeightLimit = useComposerHeightLimit({
+        active: dictationContentHeight !== null,
+        disabled: isComposerExpanded,
+        hostRef: dictationHeightHostRef,
+        maxLines: isMobile ? MAX_MOBILE_COMPOSER_LINES : MAX_VISIBLE_COMPOSER_LINES,
+        boundSelector: isMobile ? '[data-composer-bound]' : undefined,
+        boundGapPx: isMobile ? MOBILE_COMPOSER_BOUND_GAP_PX : 0,
+    });
 
     const updateAutocompleteState = React.useCallback((
         value: string,
@@ -2768,14 +2778,20 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                             <ActiveEditorFileSuggestion />
                         </div>
                         <div
+                            ref={dictationHeightHostRef}
                             className={cn("relative overflow-hidden", isComposerExpanded && 'flex flex-1 min-h-0 flex-col')}
                             onDragEnter={handleDragEnter}
                             onDragOver={handleDragOver}
                             onDropCapture={handleDropCapture}
                             onDrop={handleDrop}
                             onDragEnd={handleDragEnd}
-                            style={dictationContentHeight !== null
-                                ? { minHeight: `${dictationContentHeight}px` }
+                            style={dictationContentHeight !== null && !isComposerExpanded
+                                ? {
+                                    minHeight: `${Math.min(
+                                        dictationContentHeight,
+                                        dictationHeightLimit ?? dictationContentHeight,
+                                    )}px`,
+                                }
                                 : undefined}
                         >
                             <ComposerEditor

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -162,6 +162,10 @@ refusing programmatic focus outside a gesture, WebKit leaving the layout
 viewport panned after the keyboard hides, overlay chains handing off through a
 frame where nothing is open.
 
+Typed and dictated text use the same measured line and screen-height limits.
+After either limit, content scrolls inside the composer so its action row stays
+inside the chat screen.
+
 **Every timeout and `flushSync` in them has a reason recorded next to it, and
 none of them is verifiable outside a real device.** Change them only against
 hardware.

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -162,9 +162,9 @@ refusing programmatic focus outside a gesture, WebKit leaving the layout
 viewport panned after the keyboard hides, overlay chains handing off through a
 frame where nothing is open.
 
-Typed and dictated text use the same measured line and screen-height limits.
-After either limit, content scrolls inside the composer so its action row stays
-inside the chat screen.
+Typed text and salvage text shown after a failed dictation use the same measured
+line and screen-height limits. After either limit, content scrolls inside the
+composer so the failed-dictation action row stays inside the chat screen.
 
 **Every timeout and `flushSync` in them has a reason recorded next to it, and
 none of them is verifiable outside a real device.** Change them only against

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -163,8 +163,10 @@ viewport panned after the keyboard hides, overlay chains handing off through a
 frame where nothing is open.
 
 Typed text and salvage text shown after a failed dictation use the same measured
-line and screen-height limits. After either limit, content scrolls inside the
-composer so the failed-dictation action row stays inside the chat screen.
+line and screen-height limits. Once the viewport reports usable space, content
+scrolls inside the composer so the failed-dictation action row stays inside the
+chat screen. A transient non-positive viewport measurement keeps the existing
+line cap until the next resize instead of collapsing the editor to zero height.
 
 **Every timeout and `flushSync` in them has a reason recorded next to it, and
 none of them is verifiable outside a real device.** Change them only against

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -137,6 +137,10 @@ refusing programmatic focus outside a gesture, WebKit leaving the layout
 viewport panned after the keyboard hides, overlay chains handing off through a
 frame where nothing is open.
 
+Typed and dictated text use the same measured line and screen-height limits.
+After either limit, content scrolls inside the composer so its action row stays
+inside the chat screen.
+
 **Every timeout and `flushSync` in them has a reason recorded next to it, and
 none of them is verifiable outside a real device.** Change them only against
 hardware.

--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -39,6 +39,7 @@ import { composerLanguage, setLanguageContext } from './composerLanguage';
 import type { ComposerEditorViewStore } from './viewStore';
 import { composerEditorTheme, composerSelectionExtension } from './theme';
 import { handleComposerHostMouseDown } from './hostMouseDown';
+import { getComposerHeightLimit } from './heightLimit';
 
 export interface ComposerSelection {
     start: number;
@@ -119,7 +120,6 @@ export interface ComposerEditorProps {
     'aria-label'?: string;
     'data-testid'?: string;
 }
-
 
 /**
  * The text inserted by a transaction, used to tell a typed `@` from a pasted
@@ -430,12 +430,14 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                     getComputedStyle(view.contentDOM).lineHeight || '',
                 );
                 if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
-                let cap = lineHeight * maxLines;
-                if (boundEl && branch) {
-                    const chrome = branch.offsetHeight - view.scrollDOM.offsetHeight;
-                    const available = boundEl.clientHeight - chrome - boundGapPx;
-                    if (available > 0) cap = Math.min(cap, available);
-                }
+                const cap = getComposerHeightLimit({
+                    maxLinesHeight: lineHeight * maxLines,
+                    boundHeight: boundEl?.clientHeight,
+                    surroundingHeight: branch
+                        ? branch.offsetHeight - view.scrollDOM.offsetHeight
+                        : undefined,
+                    boundGapPx,
+                });
                 const next = `${cap}px`;
                 // The scroller growing re-fires the observer with an unchanged
                 // result; writing only on change keeps that loop silent.

--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -38,6 +38,7 @@ import { composerLanguage, setLanguageContext } from './composerLanguage';
 import type { ComposerEditorViewStore } from './viewStore';
 import { composerEditorTheme, composerSelectionExtension } from './theme';
 import { handleComposerHostMouseDown } from './hostMouseDown';
+import { getComposerHeightLimit } from './heightLimit';
 
 export interface ComposerSelection {
     start: number;
@@ -115,7 +116,6 @@ export interface ComposerEditorProps {
     'aria-label'?: string;
     'data-testid'?: string;
 }
-
 
 /**
  * The text inserted by a transaction, used to tell a typed `@` from a pasted
@@ -426,12 +426,14 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                     getComputedStyle(view.contentDOM).lineHeight || '',
                 );
                 if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
-                let cap = lineHeight * maxLines;
-                if (boundEl && branch) {
-                    const chrome = branch.offsetHeight - view.scrollDOM.offsetHeight;
-                    const available = boundEl.clientHeight - chrome - boundGapPx;
-                    if (available > 0) cap = Math.min(cap, available);
-                }
+                const cap = getComposerHeightLimit({
+                    maxLinesHeight: lineHeight * maxLines,
+                    boundHeight: boundEl?.clientHeight,
+                    surroundingHeight: branch
+                        ? branch.offsetHeight - view.scrollDOM.offsetHeight
+                        : undefined,
+                    boundGapPx,
+                });
                 const next = `${cap}px`;
                 // The scroller growing re-fires the observer with an unchanged
                 // result; writing only on change keeps that loop silent.

--- a/packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts
@@ -32,18 +32,40 @@ describe('getComposerHeightLimit', () => {
         expect(appliedHeight + surroundingHeight + boundGapPx).toBeLessThanOrEqual(boundHeight);
     });
 
-    test('[issue-2533] caps an already-expanded failed-dictation salvage floor', () => {
-        const salvageTextHeight = 1800;
-        const scrollHeightLimit = 15;
-        const editorHeight = 52;
-        const renderedScrollHeight = 15;
-        const limit = getComposerHostHeightLimit(
-            scrollHeightLimit,
-            editorHeight,
-            renderedScrollHeight,
-        );
+    test('[issue-2533] keeps failed-dictation salvage text bounded after a short viewport reflow', () => {
+        expect(getComposerHostHeightLimit({
+            maxLinesHeight: 360,
+            editorHeight: 52,
+            renderedScrollHeight: 15,
+            boundHeight: 361,
+            branchHeight: 357,
+            hostHeight: 52,
+            boundGapPx: 4,
+        })).toBe(52);
+    });
 
-        expect(Math.min(salvageTextHeight, limit)).toBe(52);
+    test('[issue-2533] does not feed the applied salvage height back into its limit', () => {
+        const dimensions = {
+            maxLinesHeight: 360,
+            editorHeight: 52,
+            renderedScrollHeight: 52,
+            boundHeight: 640,
+            boundGapPx: 4,
+        };
+
+        const initial = getComposerHostHeightLimit({
+            ...dimensions,
+            branchHeight: 316,
+            hostHeight: 52,
+        });
+        const afterGrowth = getComposerHostHeightLimit({
+            ...dimensions,
+            branchHeight: 624,
+            hostHeight: 360,
+        });
+
+        expect(initial).toBe(360);
+        expect(afterGrowth).toBe(initial);
     });
 
     test('uses the line cap when a tablet has more vertical room', () => {
@@ -55,13 +77,13 @@ describe('getComposerHeightLimit', () => {
         })).toBe(360);
     });
 
-    test('does not drop the screen cap when surrounding controls use all available room', () => {
+    test('keeps the line cap when no positive screen budget can be measured', () => {
         expect(getComposerHeightLimit({
             maxLinesHeight: 360,
             boundHeight: 320,
             surroundingHeight: 340,
             boundGapPx: 4,
-        })).toBe(0);
+        })).toBe(360);
     });
 
     test('falls back to the line cap when no screen bound is available', () => {

--- a/packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts
@@ -15,8 +15,8 @@ describe('getComposerHeightLimit', () => {
         expect(Math.min(contentHeight, limit)).toBe(contentHeight);
     });
 
-    test('[issue-2533] keeps a long dictation and its controls inside the mobile bound', () => {
-        const transcriptHeight = 1800;
+    test('[issue-2533] keeps long failed-dictation salvage text and its controls inside the mobile bound', () => {
+        const salvageTextHeight = 1800;
         const boundHeight = 640;
         const surroundingHeight = 316;
         const boundGapPx = 4;
@@ -26,22 +26,24 @@ describe('getComposerHeightLimit', () => {
             surroundingHeight,
             boundGapPx,
         });
-        const appliedHeight = Math.min(transcriptHeight, limit);
+        const appliedHeight = Math.min(salvageTextHeight, limit);
 
         expect(appliedHeight).toBe(320);
         expect(appliedHeight + surroundingHeight + boundGapPx).toBeLessThanOrEqual(boundHeight);
     });
 
-    test('[issue-2533] mirrors the editor limit after a short viewport reflow', () => {
+    test('[issue-2533] caps an already-expanded failed-dictation salvage floor', () => {
+        const salvageTextHeight = 1800;
         const scrollHeightLimit = 15;
         const editorHeight = 52;
         const renderedScrollHeight = 15;
-
-        expect(getComposerHostHeightLimit(
+        const limit = getComposerHostHeightLimit(
             scrollHeightLimit,
             editorHeight,
             renderedScrollHeight,
-        )).toBe(52);
+        );
+
+        expect(Math.min(salvageTextHeight, limit)).toBe(52);
     });
 
     test('uses the line cap when a tablet has more vertical room', () => {

--- a/packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getComposerHeightLimit, getComposerHostHeightLimit } from '../heightLimit';
+
+describe('getComposerHeightLimit', () => {
+    test('keeps short composer content below both limits', () => {
+        const contentHeight = 120;
+        const limit = getComposerHeightLimit({
+            maxLinesHeight: 360,
+            boundHeight: 640,
+            surroundingHeight: 180,
+            boundGapPx: 4,
+        });
+
+        expect(Math.min(contentHeight, limit)).toBe(contentHeight);
+    });
+
+    test('[issue-2533] keeps a long dictation and its controls inside the mobile bound', () => {
+        const transcriptHeight = 1800;
+        const boundHeight = 640;
+        const surroundingHeight = 316;
+        const boundGapPx = 4;
+        const limit = getComposerHeightLimit({
+            maxLinesHeight: 360,
+            boundHeight,
+            surroundingHeight,
+            boundGapPx,
+        });
+        const appliedHeight = Math.min(transcriptHeight, limit);
+
+        expect(appliedHeight).toBe(320);
+        expect(appliedHeight + surroundingHeight + boundGapPx).toBeLessThanOrEqual(boundHeight);
+    });
+
+    test('[issue-2533] mirrors the editor limit after a short viewport reflow', () => {
+        const scrollHeightLimit = 15;
+        const editorHeight = 52;
+        const renderedScrollHeight = 15;
+
+        expect(getComposerHostHeightLimit(
+            scrollHeightLimit,
+            editorHeight,
+            renderedScrollHeight,
+        )).toBe(52);
+    });
+
+    test('uses the line cap when a tablet has more vertical room', () => {
+        expect(getComposerHeightLimit({
+            maxLinesHeight: 360,
+            boundHeight: 1200,
+            surroundingHeight: 220,
+            boundGapPx: 4,
+        })).toBe(360);
+    });
+
+    test('does not drop the screen cap when surrounding controls use all available room', () => {
+        expect(getComposerHeightLimit({
+            maxLinesHeight: 360,
+            boundHeight: 320,
+            surroundingHeight: 340,
+            boundGapPx: 4,
+        })).toBe(0);
+    });
+
+    test('falls back to the line cap when no screen bound is available', () => {
+        expect(getComposerHeightLimit({ maxLinesHeight: 180 })).toBe(180);
+    });
+});

--- a/packages/ui/src/components/chat/composer/editor/heightLimit.ts
+++ b/packages/ui/src/components/chat/composer/editor/heightLimit.ts
@@ -1,0 +1,29 @@
+export interface ComposerHeightLimitOptions {
+    maxLinesHeight: number;
+    boundHeight?: number;
+    surroundingHeight?: number;
+    boundGapPx?: number;
+}
+
+export function getComposerHeightLimit(options: ComposerHeightLimitOptions): number {
+    const {
+        maxLinesHeight,
+        boundHeight,
+        surroundingHeight,
+        boundGapPx = 0,
+    } = options;
+    let limit = maxLinesHeight;
+    if (boundHeight !== undefined && surroundingHeight !== undefined) {
+        const available = boundHeight - surroundingHeight - boundGapPx;
+        limit = Math.min(limit, Math.max(0, available));
+    }
+    return limit;
+}
+
+export function getComposerHostHeightLimit(
+    scrollHeightLimit: number,
+    editorHeight: number,
+    renderedScrollHeight: number,
+): number {
+    return scrollHeightLimit + Math.max(0, editorHeight - renderedScrollHeight);
+}

--- a/packages/ui/src/components/chat/composer/editor/heightLimit.ts
+++ b/packages/ui/src/components/chat/composer/editor/heightLimit.ts
@@ -15,15 +15,39 @@ export function getComposerHeightLimit(options: ComposerHeightLimitOptions): num
     let limit = maxLinesHeight;
     if (boundHeight !== undefined && surroundingHeight !== undefined) {
         const available = boundHeight - surroundingHeight - boundGapPx;
-        limit = Math.min(limit, Math.max(0, available));
+        if (available > 0) limit = Math.min(limit, available);
     }
     return limit;
 }
 
-export function getComposerHostHeightLimit(
-    scrollHeightLimit: number,
-    editorHeight: number,
-    renderedScrollHeight: number,
-): number {
-    return scrollHeightLimit + Math.max(0, editorHeight - renderedScrollHeight);
+export interface ComposerHostHeightLimitOptions {
+    maxLinesHeight: number;
+    editorHeight: number;
+    renderedScrollHeight: number;
+    boundHeight?: number;
+    branchHeight?: number;
+    hostHeight?: number;
+    boundGapPx?: number;
+}
+
+export function getComposerHostHeightLimit(options: ComposerHostHeightLimitOptions): number {
+    const {
+        maxLinesHeight,
+        editorHeight,
+        renderedScrollHeight,
+        boundHeight,
+        branchHeight,
+        hostHeight,
+        boundGapPx,
+    } = options;
+    const editorChrome = Math.max(0, editorHeight - renderedScrollHeight);
+    const surroundingHeight = branchHeight !== undefined && hostHeight !== undefined
+        ? Math.max(0, branchHeight - hostHeight)
+        : undefined;
+    return getComposerHeightLimit({
+        maxLinesHeight: maxLinesHeight + editorChrome,
+        boundHeight,
+        surroundingHeight,
+        boundGapPx,
+    });
 }

--- a/packages/ui/src/components/chat/composer/editor/useComposerHeightLimit.ts
+++ b/packages/ui/src/components/chat/composer/editor/useComposerHeightLimit.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getComposerHeightLimit, getComposerHostHeightLimit } from './heightLimit';
+import { getComposerHostHeightLimit } from './heightLimit';
 
 interface UseComposerHeightLimitOptions {
     active: boolean;
@@ -44,56 +44,31 @@ export function useComposerHeightLimit(options: UseComposerHeightLimitOptions): 
         }
 
         const applyLimit = () => {
-            // React applies the raw salvage floor before this layout effect.
-            // Ignore it while measuring or the expanded editor feeds that raw
-            // height back into its own cap.
-            const appliedMinHeight = host.style.minHeight;
-            host.style.minHeight = '';
-            try {
-                const scrollHeightLimit = parseFloat(scroller.style.maxHeight || '');
-                if (Number.isFinite(scrollHeightLimit) && scrollHeightLimit >= 0) {
-                    const next = getComposerHostHeightLimit(
-                        scrollHeightLimit,
-                        editor.offsetHeight,
-                        scroller.offsetHeight,
-                    );
-                    setHeightLimit((previous) => (previous === next ? previous : next));
-                    return;
-                }
-
-                // The editor normally publishes its limit first. This fallback
-                // covers its initial mount before that passive effect has run.
-                const lineHeight = parseFloat(window.getComputedStyle(content).lineHeight || '');
-                if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
-                const next = getComposerHeightLimit({
-                    maxLinesHeight: lineHeight * maxLines,
-                    boundHeight: bound?.clientHeight,
-                    surroundingHeight: bound && branch
-                        ? branch.offsetHeight - host.offsetHeight
-                        : undefined,
-                    boundGapPx,
-                });
-                setHeightLimit((previous) => (previous === next ? previous : next));
-            } finally {
-                host.style.minHeight = appliedMinHeight;
-            }
+            const lineHeight = parseFloat(window.getComputedStyle(content).lineHeight || '');
+            if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
+            const next = getComposerHostHeightLimit({
+                maxLinesHeight: lineHeight * maxLines,
+                editorHeight: editor.offsetHeight,
+                renderedScrollHeight: scroller.offsetHeight,
+                boundHeight: bound?.clientHeight,
+                // Excluding the host keeps this budget stable when its
+                // failed-dictation min-height changes.
+                branchHeight: bound && branch ? branch.offsetHeight : undefined,
+                hostHeight: bound && branch ? host.offsetHeight : undefined,
+                boundGapPx,
+            });
+            setHeightLimit((previous) => (previous === next ? previous : next));
         };
 
         applyLimit();
         if (!window.ResizeObserver) return;
         const observer = new window.ResizeObserver(applyLimit);
         observer.observe(content);
+        observer.observe(editor);
         observer.observe(scroller);
         if (branch) observer.observe(branch);
         if (bound) observer.observe(bound);
-        const styleObserver = window.MutationObserver
-            ? new window.MutationObserver(applyLimit)
-            : null;
-        styleObserver?.observe(scroller, { attributes: true, attributeFilter: ['style'] });
-        return () => {
-            observer.disconnect();
-            styleObserver?.disconnect();
-        };
+        return () => observer.disconnect();
     }, [active, boundGapPx, boundSelector, disabled, hostRef, maxLines]);
 
     return heightLimit;

--- a/packages/ui/src/components/chat/composer/editor/useComposerHeightLimit.ts
+++ b/packages/ui/src/components/chat/composer/editor/useComposerHeightLimit.ts
@@ -1,0 +1,91 @@
+import React from 'react';
+
+import { getComposerHeightLimit, getComposerHostHeightLimit } from './heightLimit';
+
+interface UseComposerHeightLimitOptions {
+    active: boolean;
+    disabled?: boolean;
+    hostRef: React.RefObject<HTMLElement | null>;
+    maxLines: number;
+    boundSelector?: string;
+    boundGapPx?: number;
+}
+
+export function useComposerHeightLimit(options: UseComposerHeightLimitOptions): number | null {
+    const {
+        active,
+        disabled = false,
+        hostRef,
+        maxLines,
+        boundSelector,
+        boundGapPx = 0,
+    } = options;
+    const [heightLimit, setHeightLimit] = React.useState<number | null>(null);
+
+    React.useLayoutEffect(() => {
+        if (!active || disabled) {
+            setHeightLimit(null);
+            return;
+        }
+
+        const host = hostRef.current;
+        const content = host?.querySelector<HTMLElement>('.cm-content');
+        const editor = host?.querySelector<HTMLElement>('[data-chat-input="true"]');
+        const scroller = editor?.querySelector<HTMLElement>('.cm-scroller');
+        if (!host || !content || !editor || !scroller) return;
+
+        const bound = boundSelector ? host.closest<HTMLElement>(boundSelector) : null;
+        let branch: HTMLElement | null = null;
+        if (bound) {
+            branch = host;
+            while (branch.parentElement && branch.parentElement !== bound) {
+                branch = branch.parentElement;
+            }
+        }
+
+        const applyLimit = () => {
+            const scrollHeightLimit = parseFloat(scroller.style.maxHeight || '');
+            if (Number.isFinite(scrollHeightLimit) && scrollHeightLimit >= 0) {
+                const next = getComposerHostHeightLimit(
+                    scrollHeightLimit,
+                    editor.offsetHeight,
+                    scroller.offsetHeight,
+                );
+                setHeightLimit((previous) => (previous === next ? previous : next));
+                return;
+            }
+
+            // The editor normally publishes its limit first. This fallback
+            // covers its initial mount before that passive effect has run.
+            const lineHeight = parseFloat(window.getComputedStyle(content).lineHeight || '');
+            if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
+            const next = getComposerHeightLimit({
+                maxLinesHeight: lineHeight * maxLines,
+                boundHeight: bound?.clientHeight,
+                surroundingHeight: bound && branch
+                    ? branch.offsetHeight - host.offsetHeight
+                    : undefined,
+                boundGapPx,
+            });
+            setHeightLimit((previous) => (previous === next ? previous : next));
+        };
+
+        applyLimit();
+        if (typeof ResizeObserver === 'undefined') return;
+        const observer = new ResizeObserver(applyLimit);
+        observer.observe(content);
+        observer.observe(scroller);
+        if (branch) observer.observe(branch);
+        if (bound) observer.observe(bound);
+        const styleObserver = typeof MutationObserver === 'undefined'
+            ? null
+            : new MutationObserver(applyLimit);
+        styleObserver?.observe(scroller, { attributes: true, attributeFilter: ['style'] });
+        return () => {
+            observer.disconnect();
+            styleObserver?.disconnect();
+        };
+    }, [active, boundGapPx, boundSelector, disabled, hostRef, maxLines]);
+
+    return heightLimit;
+}

--- a/packages/ui/src/components/chat/composer/editor/useComposerHeightLimit.ts
+++ b/packages/ui/src/components/chat/composer/editor/useComposerHeightLimit.ts
@@ -44,42 +44,51 @@ export function useComposerHeightLimit(options: UseComposerHeightLimitOptions): 
         }
 
         const applyLimit = () => {
-            const scrollHeightLimit = parseFloat(scroller.style.maxHeight || '');
-            if (Number.isFinite(scrollHeightLimit) && scrollHeightLimit >= 0) {
-                const next = getComposerHostHeightLimit(
-                    scrollHeightLimit,
-                    editor.offsetHeight,
-                    scroller.offsetHeight,
-                );
-                setHeightLimit((previous) => (previous === next ? previous : next));
-                return;
-            }
+            // React applies the raw salvage floor before this layout effect.
+            // Ignore it while measuring or the expanded editor feeds that raw
+            // height back into its own cap.
+            const appliedMinHeight = host.style.minHeight;
+            host.style.minHeight = '';
+            try {
+                const scrollHeightLimit = parseFloat(scroller.style.maxHeight || '');
+                if (Number.isFinite(scrollHeightLimit) && scrollHeightLimit >= 0) {
+                    const next = getComposerHostHeightLimit(
+                        scrollHeightLimit,
+                        editor.offsetHeight,
+                        scroller.offsetHeight,
+                    );
+                    setHeightLimit((previous) => (previous === next ? previous : next));
+                    return;
+                }
 
-            // The editor normally publishes its limit first. This fallback
-            // covers its initial mount before that passive effect has run.
-            const lineHeight = parseFloat(window.getComputedStyle(content).lineHeight || '');
-            if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
-            const next = getComposerHeightLimit({
-                maxLinesHeight: lineHeight * maxLines,
-                boundHeight: bound?.clientHeight,
-                surroundingHeight: bound && branch
-                    ? branch.offsetHeight - host.offsetHeight
-                    : undefined,
-                boundGapPx,
-            });
-            setHeightLimit((previous) => (previous === next ? previous : next));
+                // The editor normally publishes its limit first. This fallback
+                // covers its initial mount before that passive effect has run.
+                const lineHeight = parseFloat(window.getComputedStyle(content).lineHeight || '');
+                if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
+                const next = getComposerHeightLimit({
+                    maxLinesHeight: lineHeight * maxLines,
+                    boundHeight: bound?.clientHeight,
+                    surroundingHeight: bound && branch
+                        ? branch.offsetHeight - host.offsetHeight
+                        : undefined,
+                    boundGapPx,
+                });
+                setHeightLimit((previous) => (previous === next ? previous : next));
+            } finally {
+                host.style.minHeight = appliedMinHeight;
+            }
         };
 
         applyLimit();
-        if (typeof ResizeObserver === 'undefined') return;
-        const observer = new ResizeObserver(applyLimit);
+        if (!window.ResizeObserver) return;
+        const observer = new window.ResizeObserver(applyLimit);
         observer.observe(content);
         observer.observe(scroller);
         if (branch) observer.observe(branch);
         if (bound) observer.observe(bound);
-        const styleObserver = typeof MutationObserver === 'undefined'
-            ? null
-            : new MutationObserver(applyLimit);
+        const styleObserver = window.MutationObserver
+            ? new window.MutationObserver(applyLimit)
+            : null;
         styleObserver?.observe(scroller, { attributes: true, attributeFilter: ['style'] });
         return () => {
             observer.disconnect();

--- a/packages/ui/src/components/dictation/ComposerDictation.tsx
+++ b/packages/ui/src/components/dictation/ComposerDictation.tsx
@@ -38,8 +38,8 @@ interface ComposerDictationProps {
     onInsertAndSend: (text: string) => void;
     /** Reports whether dictation is active (recording/transcribing/failed overlay shown). */
     onActiveChange?: (active: boolean) => void;
-    /** Reports the height (px) the transcript needs, so the host can grow the
-        composer like typed text would; null when dictation is idle. */
+    /** Reports the height (px) failed-dictation salvage text needs, so the host
+        can grow the composer like typed text would; null when none is shown. */
     onContentHeightChange?: (height: number | null) => void;
     /** Render the mic trigger button (default). Pass false when the host renders
         its own trigger and only needs the overlay + recording engine. */
@@ -227,23 +227,23 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
     const transcriptContentRef = React.useRef<HTMLDivElement | null>(null);
     const [footerHeight, setFooterHeight] = React.useState<number | null>(null);
     const isActiveStatus = status !== 'idle';
+    const hasSalvageText = status === 'failed' && Boolean(partialTranscript);
 
-    // Grow the composer with the transcript, the way typing grows the
-    // textarea. The overlay is absolutely positioned over the composer, so it
-    // can't push the composer's height itself — measure how much room the
-    // transcript wants (scrollHeight ignores the clamped box) and report it to
-    // the host, which feeds it into the textarea autosize (same line cap, then
-    // the transcript area scrolls).
+    // Grow the composer with failed-dictation salvage text, the way typing grows
+    // the textarea. The overlay is absolutely positioned over the composer, so
+    // it can't push the composer's height itself. Measure how much room the text
+    // wants and report it to the host, which applies the editor's line and
+    // viewport caps before the salvage area scrolls.
     const onContentHeightChangeRef = React.useRef(onContentHeightChange);
     React.useEffect(() => {
         onContentHeightChangeRef.current = onContentHeightChange;
     }, [onContentHeightChange]);
     // Two instances can coexist (mobile footer + wrapper engine); only the one
-    // that actually reported a height may clear it, or an idle sibling
-    // mounting mid-recording would zero the active transcript's height.
+    // that reported salvage height may clear it, or an idle sibling mounting
+    // beside a failed dictation would zero the active overlay's height.
     const hasReportedHeightRef = React.useRef(false);
     React.useLayoutEffect(() => {
-        if (!isActiveStatus) {
+        if (!hasSalvageText) {
             if (hasReportedHeightRef.current) {
                 hasReportedHeightRef.current = false;
                 onContentHeightChangeRef.current?.(null);
@@ -253,7 +253,7 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
         const area = transcriptAreaRef.current;
         const content = transcriptContentRef.current;
         if (!area || !content) return;
-        // Measure the text block, not the container: the container is flex-1
+        // Measure the salvage text block, not the container: the container is flex-1
         // inside the overlay, so its scrollHeight tracks the composer's own
         // height — feeding that back would creep a few px on every transcript
         // update instead of stepping per wrapped line.
@@ -262,17 +262,17 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
             const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
             hasReportedHeightRef.current = true;
             onContentHeightChangeRef.current?.(content.offsetHeight + padding);
-            // Once the composer hits its line cap the transcript area starts
+            // Once the composer hits its line cap the salvage area starts
             // scrolling — follow the newest words like a textarea caret would.
             area.scrollTop = area.scrollHeight;
         };
         reportHeight();
-        if (typeof ResizeObserver === 'undefined') return;
-        const observer = new ResizeObserver(reportHeight);
+        if (!window.ResizeObserver) return;
+        const observer = new window.ResizeObserver(reportHeight);
         // Re-report after rotation or any other width change rewraps the text.
         observer.observe(content);
         return () => observer.disconnect();
-    }, [isActiveStatus, partialTranscript, status, error]);
+    }, [hasSalvageText, partialTranscript]);
     React.useEffect(() => () => {
         if (hasReportedHeightRef.current) {
             hasReportedHeightRef.current = false;

--- a/packages/ui/src/components/dictation/ComposerDictation.tsx
+++ b/packages/ui/src/components/dictation/ComposerDictation.tsx
@@ -257,13 +257,21 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
         // inside the overlay, so its scrollHeight tracks the composer's own
         // height — feeding that back would creep a few px on every transcript
         // update instead of stepping per wrapped line.
-        const style = window.getComputedStyle(area);
-        const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
-        hasReportedHeightRef.current = true;
-        onContentHeightChangeRef.current?.(content.offsetHeight + padding);
-        // Once the composer hits its line cap the transcript area starts
-        // scrolling — follow the newest words like a textarea caret would.
-        area.scrollTop = area.scrollHeight;
+        const reportHeight = () => {
+            const style = window.getComputedStyle(area);
+            const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
+            hasReportedHeightRef.current = true;
+            onContentHeightChangeRef.current?.(content.offsetHeight + padding);
+            // Once the composer hits its line cap the transcript area starts
+            // scrolling — follow the newest words like a textarea caret would.
+            area.scrollTop = area.scrollHeight;
+        };
+        reportHeight();
+        if (typeof ResizeObserver === 'undefined') return;
+        const observer = new ResizeObserver(reportHeight);
+        // Re-report after rotation or any other width change rewraps the text.
+        observer.observe(content);
+        return () => observer.disconnect();
     }, [isActiveStatus, partialTranscript, status, error]);
     React.useEffect(() => () => {
         if (hasReportedHeightRef.current) {

--- a/packages/ui/src/components/dictation/ComposerDictation.tsx
+++ b/packages/ui/src/components/dictation/ComposerDictation.tsx
@@ -227,7 +227,7 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
     const transcriptContentRef = React.useRef<HTMLDivElement | null>(null);
     const [footerHeight, setFooterHeight] = React.useState<number | null>(null);
     const isActiveStatus = status !== 'idle';
-    const hasSalvageText = status === 'failed' && Boolean(partialTranscript);
+    const hasSalvageText = status === 'failed' && Boolean(partialTranscript.trim());
 
     // Grow the composer with failed-dictation salvage text, the way typing grows
     // the textarea. The overlay is absolutely positioned over the composer, so

--- a/packages/ui/src/components/dictation/ComposerDictation.tsx
+++ b/packages/ui/src/components/dictation/ComposerDictation.tsx
@@ -271,13 +271,21 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
         // inside the overlay, so its scrollHeight tracks the composer's own
         // height — feeding that back would creep a few px on every transcript
         // update instead of stepping per wrapped line.
-        const style = window.getComputedStyle(area);
-        const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
-        hasReportedHeightRef.current = true;
-        onContentHeightChangeRef.current?.(content.offsetHeight + padding);
-        // Once the composer hits its line cap the transcript area starts
-        // scrolling — follow the newest words like a textarea caret would.
-        area.scrollTop = area.scrollHeight;
+        const reportHeight = () => {
+            const style = window.getComputedStyle(area);
+            const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
+            hasReportedHeightRef.current = true;
+            onContentHeightChangeRef.current?.(content.offsetHeight + padding);
+            // Once the composer hits its line cap the transcript area starts
+            // scrolling — follow the newest words like a textarea caret would.
+            area.scrollTop = area.scrollHeight;
+        };
+        reportHeight();
+        if (typeof ResizeObserver === 'undefined') return;
+        const observer = new ResizeObserver(reportHeight);
+        // Re-report after rotation or any other width change rewraps the text.
+        observer.observe(content);
+        return () => observer.disconnect();
     }, [isActiveStatus, partialTranscript, status, error]);
     React.useEffect(() => () => {
         if (hasReportedHeightRef.current) {


### PR DESCRIPTION
## Intent

Fixes #2533.

Re-checking current `main` confirmed that the composer does not render a live transcript while recording or transcribing. The overflow path is a failed dictation with long salvage text. This change grows the composer only for that failed state, then applies the editor's existing line and viewport limits so the recovery actions stay reachable.

The viewport calculation excludes the dictation host from the surrounding layout height. Growing the host therefore cannot reduce its own limit through a resize-observer feedback cycle. Width changes remeasure wrapped salvage text.

## Non-goals

This PR does not change speech capture, transcription providers, normal recording or transcribing states, recovery button behavior, keyboard handling, or fullscreen composer behavior.

## Affected surfaces

`packages/ui` owns the shared composer used by web, desktop, hosted mobile, and Capacitor mobile. The reported failure is on native Android, but hosted mobile uses the same bounded layout path.

Desktop keeps its eight-line limit. Mobile keeps its sixteen-line and chat-viewport limits. VS Code does not expose server-backed dictation. No persisted data, API, route, setting, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md`, `CONTRIBUTING.md`, and `openchamber-change-discipline` | This changes shared UI and mobile runtime behavior. | The diff stays in composer sizing, focused tests, and the owning documentation. It adds no dependency or persisted contract. |
| `theme-system` | The change affects component layout. | It reuses the existing editor and dictation controls. No colors, tokens, buttons, icons, or animations changed. |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | This document owns composer sizing and mobile behavior. | It records the failed-salvage limit, internal scrolling, and transient non-positive viewport fallback. |
| `packages/mobile/README.md` | The report affects the Capacitor Android shell. | The fix stays in the shared UI bundled by the native package and does not change native shell contracts. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts` | Passed on final HEAD: 7 tests and 9 assertions. Covers failed salvage containment, host-growth invariance, short viewport reflow, tablet line cap, and unavailable viewport measurements. |
| `bun run type-check:ui` | Passed on final HEAD. |
| `bun run lint:ui` | Passed on final HEAD. |
| `bun run docs:validate` | Passed on final HEAD: 460 pages and 46 sidebar links. |
| `bunx oxlint <changed TypeScript files>` | Reports only existing anti-slop findings outside the added lines. No new-line finding remains. |
| `git diff --check upstream/main...HEAD` | Passed. |
| Native Android or final browser interaction | Not run. This Linux host has no Android toolchain, and an earlier browser validation caused memory pressure. The current final arithmetic and observer lifecycle are covered statically, not on hardware. |

## Visual evidence

No current screenshot is attached. The visible change requires a failed dictation with a long partial result, and the final branch was not run on Android hardware. The expected change is internal scrolling in the salvage area while Discard, Retry, and Insert remain in the composer.

## Risks and failure behavior

The sizing hooks run only while failed salvage text is present. Their observers disconnect when recovery ends or the component unmounts. Whitespace-only partial text does not activate the path.

The host budget subtracts `branch height - host height`, so applying the result does not feed the new host size back into the next calculation. If the viewport temporarily reports no positive room, the composer keeps its existing line cap until the next resize instead of collapsing typed text to zero height.

Reverting the commits restores the previous unbounded failed-salvage floor. No user data or transcription state is converted or deleted.
