### PR TITLE
fix(files): refresh sidebar tree after external changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Chat: if OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
+- Files: the project file sidebar now updates automatically when agents or other programs create, rename, or delete files, while expanded folders stay open (thanks to @zzhonglei).
 
 ## [1.19.0] - 2026-08-19
 

--- a/bun.lock
+++ b/bun.lock
@@ -290,6 +290,7 @@
         "web-push": "^3.6.7",
         "ws": "^8.18.3",
         "yaml": "^2.8.1",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@base-ui/react": "^1.4.0",

--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -257,7 +257,10 @@ const EDITOR_TREE_MAX_WIDTH = 480;
 
 // The editor surface's file-tree column: docked on the right, resizable from
 // its left edge, and animated open/closed like the app sidebars.
-const EditorTreeColumn: React.FC<{ visible: boolean }> = ({ visible }) => {
+const EditorTreeColumn: React.FC<{
+  visible: boolean;
+  autoRefreshEnabled: boolean;
+}> = ({ visible, autoRefreshEnabled }) => {
   const { t } = useI18n();
   const width = useUIStore((state) => state.contextEditorTreeWidth);
   const setWidth = useUIStore((state) => state.setContextEditorTreeWidth);
@@ -370,7 +373,7 @@ const EditorTreeColumn: React.FC<{ visible: boolean }> = ({ visible }) => {
         style={{ width: 'var(--oc-editor-tree-width)' }}
         aria-hidden={!visible}
       >
-        <SidebarFilesTree />
+        <SidebarFilesTree autoRefreshEnabled={autoRefreshEnabled} />
       </div>
     </div>
   );
@@ -1164,7 +1167,10 @@ export const ContextPanel: React.FC = () => {
                 </div>
               )}
             </div>
-            <EditorTreeColumn visible={contextEditorTreeVisible} />
+            <EditorTreeColumn
+              visible={contextEditorTreeVisible}
+              autoRefreshEnabled={isOpen && isFileTabActive && contextEditorTreeVisible}
+            />
           </div>
         ) : null}
         {activeChatTab && activeChatSessionID && activeChatSrc ? (

--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -266,7 +266,10 @@ const EDITOR_TREE_MAX_WIDTH = 480;
 
 // The editor surface's file-tree column: docked on the right, resizable from
 // its left edge, and animated open/closed like the app sidebars.
-const EditorTreeColumn: React.FC<{ visible: boolean }> = ({ visible }) => {
+const EditorTreeColumn: React.FC<{
+  visible: boolean;
+  autoRefreshEnabled: boolean;
+}> = ({ visible, autoRefreshEnabled }) => {
   const { t } = useI18n();
   const width = useUIStore((state) => state.contextEditorTreeWidth);
   const setWidth = useUIStore((state) => state.setContextEditorTreeWidth);
@@ -379,7 +382,7 @@ const EditorTreeColumn: React.FC<{ visible: boolean }> = ({ visible }) => {
         style={{ width: 'var(--oc-editor-tree-width)' }}
         aria-hidden={!visible}
       >
-        <SidebarFilesTree />
+        <SidebarFilesTree autoRefreshEnabled={autoRefreshEnabled} />
       </div>
     </div>
   );
@@ -1227,7 +1230,10 @@ export const ContextPanel: React.FC = () => {
                 </div>
               )}
             </div>
-            <EditorTreeColumn visible={contextEditorTreeVisible} />
+            <EditorTreeColumn
+              visible={contextEditorTreeVisible}
+              autoRefreshEnabled={isOpen && isFileTabActive && contextEditorTreeVisible}
+            />
           </div>
         ) : null}
         {activeChatTab && activeChatSessionID && activeChatSrc ? (

--- a/packages/ui/src/components/layout/SidebarFilesTree.tsx
+++ b/packages/ui/src/components/layout/SidebarFilesTree.tsx
@@ -31,6 +31,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
 import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
+import { useFileTreeAutoRefresh } from '@/hooks/useFileTreeAutoRefresh';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useFilesViewTabsStore } from '@/stores/useFilesViewTabsStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -45,6 +46,11 @@ import { Icon } from "@/components/icon/Icon";
 import { getContextFileOpenFailureMessage, validateContextFileOpen } from '@/lib/contextFileOpenGuard';
 import { isFilesystemError } from '@/lib/api/files-errors';
 import { notifyFileContentInvalidated } from '@/lib/fileContentInvalidation';
+import {
+  getFileTreeRelativePath,
+  isFileTreePathWithinRoot,
+  normalizeFileTreePath as normalizePath,
+} from '@/lib/fileTreePath';
 import { isBrowserClientRuntime } from '@/lib/desktop';
 import { useI18n } from '@/lib/i18n';
 
@@ -98,35 +104,11 @@ const sortNodes = (items: FileNode[]) =>
     return a.name.localeCompare(b.name);
   });
 
-const normalizePath = (value: string): string => {
-  if (!value) return '';
-
-  const raw = value.replace(/\\/g, '/');
-  const hadUncPrefix = raw.startsWith('//');
-
-  let normalized = raw.replace(/\/+$/g, '');
-  normalized = normalized.replace(/\/+/g, '/');
-  if (hadUncPrefix && !normalized.startsWith('//')) {
-    normalized = `/${normalized}`;
-  }
-
-  if (normalized === '') {
-    return raw.startsWith('/') ? '/' : '';
-  }
-
-  return normalized;
-};
-
 const getRelativePath = (root: string, path: string): string => {
   const normalizedPath = normalizePath(path);
-  const normalizedRoot = normalizePath(root).replace(/\/+$/, '');
-  if (normalizedPath === normalizedRoot) {
-    return '.';
-  }
-  if (!normalizedRoot || !normalizedPath.startsWith(`${normalizedRoot}/`)) {
-    return normalizedPath;
-  }
-  return normalizedPath.slice(normalizedRoot.length + 1);
+  const relativePath = getFileTreeRelativePath(normalizedPath, root);
+  if (relativePath === null) return normalizedPath;
+  return relativePath || '.';
 };
 
 const getDropTargetLabel = (root: string, target: string): string => {
@@ -525,7 +507,11 @@ const MemoizedFileRow = React.memo(FileRow, areFileRowPropsEqual);
 
 // --- Main component ---
 
-export const SidebarFilesTree: React.FC = () => {
+interface SidebarFilesTreeProps {
+  autoRefreshEnabled: boolean;
+}
+
+export const SidebarFilesTree: React.FC<SidebarFilesTreeProps> = ({ autoRefreshEnabled }) => {
   const { t } = useI18n();
   const { files, runtime } = useRuntimeAPIs();
   const isBrowserClient = isBrowserClientRuntime(runtime.platform);
@@ -553,6 +539,8 @@ export const SidebarFilesTree: React.FC = () => {
   const [loadErrorsByDir, setLoadErrorsByDir] = React.useState<Record<string, string>>({});
   const loadedDirsRef = React.useRef<Set<string>>(new Set());
   const inFlightDirsRef = React.useRef<Set<string>>(new Set());
+  const activeDirectoryLoadIdsRef = React.useRef<Map<string, number>>(new Map());
+  const nextDirectoryLoadIdRef = React.useRef(0);
   const refreshAbortRef = React.useRef<AbortController | null>(null);
 
   // Hydrate the per-root cache on mount or root change. The cache is
@@ -561,6 +549,7 @@ export const SidebarFilesTree: React.FC = () => {
   // combining the two means the tree re-paints with cached data instead
   // of blanking out and re-listing every directory.
   React.useEffect(() => {
+    activeDirectoryLoadIdsRef.current = new Map();
     setDropTarget(null);
     setUploadConflicts(null);
     if (!root) {
@@ -629,6 +618,7 @@ export const SidebarFilesTree: React.FC = () => {
   const setSelectedPath = useFilesViewTabsStore((state) => state.setSelectedPath);
   const addOpenPath = useFilesViewTabsStore((state) => state.addOpenPath);
   const removeOpenPathsByPrefix = useFilesViewTabsStore((state) => state.removeOpenPathsByPrefix);
+  const removeExpandedPathsByPrefix = useFilesViewTabsStore((state) => state.removeExpandedPathsByPrefix);
   const toggleExpandedPath = useFilesViewTabsStore((state) => state.toggleExpandedPath);
   const collapseAllExpandedPaths = useFilesViewTabsStore((state) => state.collapseAllExpandedPaths);
   const contextTabs = useUIStore((state) => (root ? (state.contextPanelByDirectory[root]?.tabs ?? EMPTY_CONTEXT_TABS) : EMPTY_CONTEXT_TABS));
@@ -694,12 +684,17 @@ export const SidebarFilesTree: React.FC = () => {
 
   const loadDirectory = React.useCallback(async (dirPath: string, isCancelled?: () => boolean) => {
     const normalizedDir = normalizePath(dirPath.trim());
-    if (!normalizedDir) return;
+    if (!normalizedDir) return false;
 
-    if (loadedDirsRef.current.has(normalizedDir) || inFlightDirsRef.current.has(normalizedDir)) return;
+    if (loadedDirsRef.current.has(normalizedDir) || inFlightDirsRef.current.has(normalizedDir)) return true;
 
     inFlightDirsRef.current = new Set(inFlightDirsRef.current);
     inFlightDirsRef.current.add(normalizedDir);
+    const requestId = nextDirectoryLoadIdRef.current + 1;
+    nextDirectoryLoadIdRef.current = requestId;
+    activeDirectoryLoadIdsRef.current = new Map(activeDirectoryLoadIdsRef.current);
+    activeDirectoryLoadIdsRef.current.set(normalizedDir, requestId);
+    const isCurrentRequest = () => activeDirectoryLoadIdsRef.current.get(normalizedDir) === requestId;
 
     const listPromise = files.listDirectory
       ? files.listDirectory(normalizedDir).then((result) => result.entries.map((entry) => ({
@@ -715,7 +710,7 @@ export const SidebarFilesTree: React.FC = () => {
 
     try {
       const entries = await listPromise;
-      if (isCancelled?.()) return;
+      if (isCancelled?.() || !isCurrentRequest()) return false;
       const mapped = mapDirectoryEntries(normalizedDir, entries);
 
       loadedDirsRef.current = new Set(loadedDirsRef.current);
@@ -727,19 +722,35 @@ export const SidebarFilesTree: React.FC = () => {
         return next;
       });
       setChildrenByDir((prev) => ({ ...prev, [normalizedDir]: mapped }));
+      return true;
     } catch (error) {
-      if (isCancelled?.()) return;
+      if (isCancelled?.() || !isCurrentRequest()) return false;
       const message = error instanceof Error ? error.message : String(error ?? '');
+      if (root && normalizedDir !== root && isFilesystemError(error) && error.status === 404) {
+        removeExpandedPathsByPrefix(root, normalizedDir);
+        setLoadErrorsByDir((prev) => {
+          if (!prev[normalizedDir]) return prev;
+          const next = { ...prev };
+          delete next[normalizedDir];
+          return next;
+        });
+        return false;
+      }
       console.error('Failed to load sidebar directory:', error);
       setLoadErrorsByDir((prev) => ({
         ...prev,
         [normalizedDir]: message,
       }));
+      return false;
     } finally {
-      inFlightDirsRef.current = new Set(inFlightDirsRef.current);
-      inFlightDirsRef.current.delete(normalizedDir);
+      if (isCurrentRequest()) {
+        activeDirectoryLoadIdsRef.current = new Map(activeDirectoryLoadIdsRef.current);
+        activeDirectoryLoadIdsRef.current.delete(normalizedDir);
+        inFlightDirsRef.current = new Set(inFlightDirsRef.current);
+        inFlightDirsRef.current.delete(normalizedDir);
+      }
     }
-  }, [files, mapDirectoryEntries]);
+  }, [files, mapDirectoryEntries, removeExpandedPathsByPrefix, root]);
 
   const refreshRoot = React.useCallback(async () => {
     if (!root) return;
@@ -759,13 +770,17 @@ export const SidebarFilesTree: React.FC = () => {
       const normalizedExpanded = currentExpanded
         .map((p) => normalizePath(p))
         .filter((normalized): normalized is string =>
-          Boolean(normalized) && normalized !== root && normalized.startsWith(`${root}/`),
+          Boolean(normalized) && normalized !== root && isFileTreePathWithinRoot(normalized, root),
         );
       const pathsToRefresh = [root, ...normalizedExpanded];
 
       loadedDirsRef.current = new Set(loadedDirsRef.current);
+      inFlightDirsRef.current = new Set(inFlightDirsRef.current);
+      activeDirectoryLoadIdsRef.current = new Map(activeDirectoryLoadIdsRef.current);
       for (const dirPath of pathsToRefresh) {
         loadedDirsRef.current.delete(dirPath);
+        inFlightDirsRef.current.delete(dirPath);
+        activeDirectoryLoadIdsRef.current.delete(dirPath);
       }
 
       setLoadErrorsByDir((prev) => {
@@ -818,6 +833,25 @@ export const SidebarFilesTree: React.FC = () => {
     await loadDirectory(normalized);
   }, [loadDirectory, refreshRoot]);
 
+  const refreshDirectoryForAutoRefresh = React.useCallback(async (dirPath: string) => {
+    const normalized = normalizePath(dirPath);
+    if (!normalized) throw new Error('File tree refresh requires a directory');
+    loadedDirsRef.current = new Set(loadedDirsRef.current);
+    loadedDirsRef.current.delete(normalized);
+    inFlightDirsRef.current = new Set(inFlightDirsRef.current);
+    inFlightDirsRef.current.delete(normalized);
+    const refreshed = await loadDirectory(normalized);
+    if (!refreshed) throw new Error('File tree directory refresh failed');
+  }, [loadDirectory]);
+
+  useFileTreeAutoRefresh({
+    enabled: autoRefreshEnabled,
+    root,
+    expandedPaths,
+    watchDirectories: files.watchDirectories,
+    refreshDirectory: refreshDirectoryForAutoRefresh,
+  });
+
   React.useEffect(() => {
     if (!root) return;
 
@@ -826,6 +860,7 @@ export const SidebarFilesTree: React.FC = () => {
     refreshAbortRef.current?.abort();
     loadedDirsRef.current = new Set();
     inFlightDirsRef.current = new Set();
+    activeDirectoryLoadIdsRef.current = new Map();
     setLoadErrorsByDir({});
     setChildrenByDir((prev) => (Object.keys(prev).length === 0 ? prev : {}));
     void loadDirectory(root);
@@ -840,7 +875,7 @@ export const SidebarFilesTree: React.FC = () => {
       .filter((normalized): normalized is string =>
         !!normalized &&
         normalized !== root &&
-        normalized.startsWith(`${root}/`) &&
+        isFileTreePathWithinRoot(normalized, root) &&
         !loadedDirsRef.current.has(normalized) &&
         !inFlightDirsRef.current.has(normalized),
       )
@@ -951,7 +986,7 @@ export const SidebarFilesTree: React.FC = () => {
       if (segments.length <= 1) continue;
       let currentDir = root;
       for (let i = 0; i < segments.length - 1; i++) {
-        currentDir = `${currentDir}/${segments[i]}`;
+        currentDir = normalizePath(`${currentDir}/${segments[i]}`);
         let entry = map.get(currentDir);
         if (!entry) {
           entry = { modified: 0, added: 0 };
@@ -967,7 +1002,7 @@ export const SidebarFilesTree: React.FC = () => {
   const getFileStatus = React.useCallback((path: string): FileStatus | null => {
     if (openContextFilePaths.has(path)) return 'open';
     if (statusByPath.size === 0) return null;
-    const relative = path.startsWith(root + '/') ? path.slice(root.length + 1) : path;
+    const relative = getFileTreeRelativePath(path, root) ?? path;
     return statusByPath.get(relative) ?? null;
   }, [openContextFilePaths, statusByPath, root]);
 

--- a/packages/ui/src/components/layout/SidebarFilesTree.tsx
+++ b/packages/ui/src/components/layout/SidebarFilesTree.tsx
@@ -31,6 +31,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
 import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
+import { useFileTreeAutoRefresh } from '@/hooks/useFileTreeAutoRefresh';
 import { useFileSearchStore } from '@/stores/useFileSearchStore';
 import { useFilesViewTabsStore } from '@/stores/useFilesViewTabsStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -45,6 +46,11 @@ import { Icon } from "@/components/icon/Icon";
 import { getContextFileOpenFailureMessage, validateContextFileOpen } from '@/lib/contextFileOpenGuard';
 import { isFilesystemError } from '@/lib/api/files-errors';
 import { notifyFileContentInvalidated } from '@/lib/fileContentInvalidation';
+import {
+  getFileTreeRelativePath,
+  isFileTreePathWithinRoot,
+  normalizeFileTreePath as normalizePath,
+} from '@/lib/fileTreePath';
 import { isBrowserClientRuntime } from '@/lib/desktop';
 import { useI18n } from '@/lib/i18n';
 import { recordFileTreeDragStart, shouldTreatFileTreeDragEndAsClick } from './fileTreeDragClick';
@@ -99,35 +105,11 @@ const sortNodes = (items: FileNode[]) =>
     return a.name.localeCompare(b.name);
   });
 
-const normalizePath = (value: string): string => {
-  if (!value) return '';
-
-  const raw = value.replace(/\\/g, '/');
-  const hadUncPrefix = raw.startsWith('//');
-
-  let normalized = raw.replace(/\/+$/g, '');
-  normalized = normalized.replace(/\/+/g, '/');
-  if (hadUncPrefix && !normalized.startsWith('//')) {
-    normalized = `/${normalized}`;
-  }
-
-  if (normalized === '') {
-    return raw.startsWith('/') ? '/' : '';
-  }
-
-  return normalized;
-};
-
 const getRelativePath = (root: string, path: string): string => {
   const normalizedPath = normalizePath(path);
-  const normalizedRoot = normalizePath(root).replace(/\/+$/, '');
-  if (normalizedPath === normalizedRoot) {
-    return '.';
-  }
-  if (!normalizedRoot || !normalizedPath.startsWith(`${normalizedRoot}/`)) {
-    return normalizedPath;
-  }
-  return normalizedPath.slice(normalizedRoot.length + 1);
+  const relativePath = getFileTreeRelativePath(normalizedPath, root);
+  if (relativePath === null) return normalizedPath;
+  return relativePath || '.';
 };
 
 const getDropTargetLabel = (root: string, target: string): string => {
@@ -534,7 +516,11 @@ const MemoizedFileRow = React.memo(FileRow, areFileRowPropsEqual);
 
 // --- Main component ---
 
-export const SidebarFilesTree: React.FC = () => {
+interface SidebarFilesTreeProps {
+  autoRefreshEnabled: boolean;
+}
+
+export const SidebarFilesTree: React.FC<SidebarFilesTreeProps> = ({ autoRefreshEnabled }) => {
   const { t } = useI18n();
   const { files, runtime } = useRuntimeAPIs();
   const isBrowserClient = isBrowserClientRuntime(runtime.platform);
@@ -562,6 +548,8 @@ export const SidebarFilesTree: React.FC = () => {
   const [loadErrorsByDir, setLoadErrorsByDir] = React.useState<Record<string, string>>({});
   const loadedDirsRef = React.useRef<Set<string>>(new Set());
   const inFlightDirsRef = React.useRef<Set<string>>(new Set());
+  const activeDirectoryLoadIdsRef = React.useRef<Map<string, number>>(new Map());
+  const nextDirectoryLoadIdRef = React.useRef(0);
   const refreshAbortRef = React.useRef<AbortController | null>(null);
 
   // Hydrate the per-root cache on mount or root change. The cache is
@@ -570,6 +558,7 @@ export const SidebarFilesTree: React.FC = () => {
   // combining the two means the tree re-paints with cached data instead
   // of blanking out and re-listing every directory.
   React.useEffect(() => {
+    activeDirectoryLoadIdsRef.current = new Map();
     setDropTarget(null);
     setUploadConflicts(null);
     if (!root) {
@@ -638,6 +627,7 @@ export const SidebarFilesTree: React.FC = () => {
   const setSelectedPath = useFilesViewTabsStore((state) => state.setSelectedPath);
   const addOpenPath = useFilesViewTabsStore((state) => state.addOpenPath);
   const removeOpenPathsByPrefix = useFilesViewTabsStore((state) => state.removeOpenPathsByPrefix);
+  const removeExpandedPathsByPrefix = useFilesViewTabsStore((state) => state.removeExpandedPathsByPrefix);
   const toggleExpandedPath = useFilesViewTabsStore((state) => state.toggleExpandedPath);
   const collapseAllExpandedPaths = useFilesViewTabsStore((state) => state.collapseAllExpandedPaths);
   const contextTabs = useUIStore((state) => (root ? (state.contextPanelByDirectory[root]?.tabs ?? EMPTY_CONTEXT_TABS) : EMPTY_CONTEXT_TABS));
@@ -703,12 +693,17 @@ export const SidebarFilesTree: React.FC = () => {
 
   const loadDirectory = React.useCallback(async (dirPath: string, isCancelled?: () => boolean) => {
     const normalizedDir = normalizePath(dirPath.trim());
-    if (!normalizedDir) return;
+    if (!normalizedDir) return false;
 
-    if (loadedDirsRef.current.has(normalizedDir) || inFlightDirsRef.current.has(normalizedDir)) return;
+    if (loadedDirsRef.current.has(normalizedDir) || inFlightDirsRef.current.has(normalizedDir)) return true;
 
     inFlightDirsRef.current = new Set(inFlightDirsRef.current);
     inFlightDirsRef.current.add(normalizedDir);
+    const requestId = nextDirectoryLoadIdRef.current + 1;
+    nextDirectoryLoadIdRef.current = requestId;
+    activeDirectoryLoadIdsRef.current = new Map(activeDirectoryLoadIdsRef.current);
+    activeDirectoryLoadIdsRef.current.set(normalizedDir, requestId);
+    const isCurrentRequest = () => activeDirectoryLoadIdsRef.current.get(normalizedDir) === requestId;
 
     const listPromise = files.listDirectory
       ? files.listDirectory(normalizedDir).then((result) => result.entries.map((entry) => ({
@@ -724,7 +719,7 @@ export const SidebarFilesTree: React.FC = () => {
 
     try {
       const entries = await listPromise;
-      if (isCancelled?.()) return;
+      if (isCancelled?.() || !isCurrentRequest()) return false;
       const mapped = mapDirectoryEntries(normalizedDir, entries);
 
       loadedDirsRef.current = new Set(loadedDirsRef.current);
@@ -736,19 +731,35 @@ export const SidebarFilesTree: React.FC = () => {
         return next;
       });
       setChildrenByDir((prev) => ({ ...prev, [normalizedDir]: mapped }));
+      return true;
     } catch (error) {
-      if (isCancelled?.()) return;
+      if (isCancelled?.() || !isCurrentRequest()) return false;
       const message = error instanceof Error ? error.message : String(error ?? '');
+      if (root && normalizedDir !== root && isFilesystemError(error) && error.status === 404) {
+        removeExpandedPathsByPrefix(root, normalizedDir);
+        setLoadErrorsByDir((prev) => {
+          if (!prev[normalizedDir]) return prev;
+          const next = { ...prev };
+          delete next[normalizedDir];
+          return next;
+        });
+        return false;
+      }
       console.error('Failed to load sidebar directory:', error);
       setLoadErrorsByDir((prev) => ({
         ...prev,
         [normalizedDir]: message,
       }));
+      return false;
     } finally {
-      inFlightDirsRef.current = new Set(inFlightDirsRef.current);
-      inFlightDirsRef.current.delete(normalizedDir);
+      if (isCurrentRequest()) {
+        activeDirectoryLoadIdsRef.current = new Map(activeDirectoryLoadIdsRef.current);
+        activeDirectoryLoadIdsRef.current.delete(normalizedDir);
+        inFlightDirsRef.current = new Set(inFlightDirsRef.current);
+        inFlightDirsRef.current.delete(normalizedDir);
+      }
     }
-  }, [files, mapDirectoryEntries]);
+  }, [files, mapDirectoryEntries, removeExpandedPathsByPrefix, root]);
 
   const refreshRoot = React.useCallback(async () => {
     if (!root) return;
@@ -768,13 +779,17 @@ export const SidebarFilesTree: React.FC = () => {
       const normalizedExpanded = currentExpanded
         .map((p) => normalizePath(p))
         .filter((normalized): normalized is string =>
-          Boolean(normalized) && normalized !== root && normalized.startsWith(`${root}/`),
+          Boolean(normalized) && normalized !== root && isFileTreePathWithinRoot(normalized, root),
         );
       const pathsToRefresh = [root, ...normalizedExpanded];
 
       loadedDirsRef.current = new Set(loadedDirsRef.current);
+      inFlightDirsRef.current = new Set(inFlightDirsRef.current);
+      activeDirectoryLoadIdsRef.current = new Map(activeDirectoryLoadIdsRef.current);
       for (const dirPath of pathsToRefresh) {
         loadedDirsRef.current.delete(dirPath);
+        inFlightDirsRef.current.delete(dirPath);
+        activeDirectoryLoadIdsRef.current.delete(dirPath);
       }
 
       setLoadErrorsByDir((prev) => {
@@ -827,6 +842,25 @@ export const SidebarFilesTree: React.FC = () => {
     await loadDirectory(normalized);
   }, [loadDirectory, refreshRoot]);
 
+  const refreshDirectoryForAutoRefresh = React.useCallback(async (dirPath: string) => {
+    const normalized = normalizePath(dirPath);
+    if (!normalized) throw new Error('File tree refresh requires a directory');
+    loadedDirsRef.current = new Set(loadedDirsRef.current);
+    loadedDirsRef.current.delete(normalized);
+    inFlightDirsRef.current = new Set(inFlightDirsRef.current);
+    inFlightDirsRef.current.delete(normalized);
+    const refreshed = await loadDirectory(normalized);
+    if (!refreshed) throw new Error('File tree directory refresh failed');
+  }, [loadDirectory]);
+
+  useFileTreeAutoRefresh({
+    enabled: autoRefreshEnabled,
+    root,
+    expandedPaths,
+    watchDirectories: files.watchDirectories,
+    refreshDirectory: refreshDirectoryForAutoRefresh,
+  });
+
   React.useEffect(() => {
     if (!root) return;
 
@@ -835,6 +869,7 @@ export const SidebarFilesTree: React.FC = () => {
     refreshAbortRef.current?.abort();
     loadedDirsRef.current = new Set();
     inFlightDirsRef.current = new Set();
+    activeDirectoryLoadIdsRef.current = new Map();
     setLoadErrorsByDir({});
     setChildrenByDir((prev) => (Object.keys(prev).length === 0 ? prev : {}));
     void loadDirectory(root);
@@ -849,7 +884,7 @@ export const SidebarFilesTree: React.FC = () => {
       .filter((normalized): normalized is string =>
         !!normalized &&
         normalized !== root &&
-        normalized.startsWith(`${root}/`) &&
+        isFileTreePathWithinRoot(normalized, root) &&
         !loadedDirsRef.current.has(normalized) &&
         !inFlightDirsRef.current.has(normalized),
       )
@@ -960,7 +995,7 @@ export const SidebarFilesTree: React.FC = () => {
       if (segments.length <= 1) continue;
       let currentDir = root;
       for (let i = 0; i < segments.length - 1; i++) {
-        currentDir = `${currentDir}/${segments[i]}`;
+        currentDir = normalizePath(`${currentDir}/${segments[i]}`);
         let entry = map.get(currentDir);
         if (!entry) {
           entry = { modified: 0, added: 0 };
@@ -976,7 +1011,7 @@ export const SidebarFilesTree: React.FC = () => {
   const getFileStatus = React.useCallback((path: string): FileStatus | null => {
     if (openContextFilePaths.has(path)) return 'open';
     if (statusByPath.size === 0) return null;
-    const relative = path.startsWith(root + '/') ? path.slice(root.length + 1) : path;
+    const relative = getFileTreeRelativePath(path, root) ?? path;
     return statusByPath.get(relative) ?? null;
   }, [openContextFilePaths, statusByPath, root]);
 

--- a/packages/ui/src/hooks/useFileTreeAutoRefresh.test.ts
+++ b/packages/ui/src/hooks/useFileTreeAutoRefresh.test.ts
@@ -1,0 +1,334 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { collectFileTreeWatchDirectories } from './useFileTreeAutoRefresh';
+import { useFileTreeAutoRefresh } from './useFileTreeAutoRefresh';
+import { getFileTreePathIdentity, normalizeFileTreePath } from '@/lib/fileTreePath';
+
+const installedGlobals = new Map<string, PropertyDescriptor | undefined>();
+
+type TestDocument = {
+  nodeType: number;
+  defaultView: typeof globalThis;
+  hidden: boolean;
+  visibilityState: string;
+  addEventListener: (event: string, listener: () => void) => void;
+  removeEventListener: (event: string, listener: () => void) => void;
+  documentElement?: Element;
+  body?: Element;
+};
+
+const installGlobal = <TValue,>(name: string, value: TValue) => {
+  if (!installedGlobals.has(name)) {
+    installedGlobals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+  }
+  Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+};
+
+const installMinimalDom = () => {
+  const listeners = new Map<string, Set<() => void>>();
+  class ElementStub {}
+  const documentStub: TestDocument = {
+    nodeType: 9,
+    defaultView: globalThis,
+    hidden: false,
+    visibilityState: 'visible',
+    addEventListener: (event: string, listener: () => void) => {
+      const eventListeners = listeners.get(event) ?? new Set();
+      eventListeners.add(listener);
+      listeners.set(event, eventListeners);
+    },
+    removeEventListener: (event: string, listener: () => void) => {
+      listeners.get(event)?.delete(listener);
+    },
+  };
+  const container: Element = Object.assign(Object.create(ElementStub.prototype), {
+    nodeType: 1,
+    tagName: 'DIV',
+    nodeName: 'DIV',
+    namespaceURI: 'http://www.w3.org/1999/xhtml',
+    ownerDocument: documentStub,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  });
+  documentStub.documentElement = container;
+  documentStub.body = container;
+  installGlobal('document', documentStub);
+  installGlobal('window', globalThis);
+  installGlobal('Element', ElementStub);
+  installGlobal('HTMLElement', ElementStub);
+  installGlobal('HTMLIFrameElement', ElementStub);
+  installGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  return container;
+};
+
+afterEach(() => {
+  for (const [name, descriptor] of installedGlobals) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+  installedGlobals.clear();
+});
+
+describe('collectFileTreeWatchDirectories', () => {
+  test('always includes the root and keeps only unique workspace descendants', () => {
+    expect(collectFileTreeWatchDirectories('C:\\Repo', [
+      'C:/Repo/src',
+      'c:/repo/SRC',
+      'C:/Repo/src/components',
+      'D:/Other',
+      '',
+    ])).toEqual([
+      'C:/Repo',
+      'C:/Repo/src',
+      'C:/Repo/src/components',
+    ]);
+  });
+
+  test('returns no directories without a workspace root', () => {
+    expect(collectFileTreeWatchDirectories('', ['/repo/src'])).toEqual([]);
+  });
+
+  test('preserves Unix, Windows drive, and UNC roots', () => {
+    expect(collectFileTreeWatchDirectories('/', ['/tmp'])).toEqual(['/', '/tmp']);
+    expect(collectFileTreeWatchDirectories('C:/', ['C:/Users'])).toEqual(['C:/', 'C:/Users']);
+    expect(collectFileTreeWatchDirectories('\\\\Server\\Share', [
+      '//server/share/project',
+    ])).toEqual([
+      '//Server/Share',
+      '//server/share/project',
+    ]);
+  });
+
+  test('preserves Windows drive-letter casing while comparing identities case-insensitively', () => {
+    expect(normalizeFileTreePath('c:\\repo')).toBe('c:/repo');
+    expect(getFileTreePathIdentity('c:/repo')).toBe(getFileTreePathIdentity('C:/REPO'));
+  });
+});
+
+describe('useFileTreeAutoRefresh', () => {
+  test('reconciles watched directories before treating the watcher as ready', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    const refreshed: string[] = [];
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: '/repo',
+        expandedPaths: ['/repo/src'],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => undefined };
+        },
+        refreshDirectory: async (directory) => {
+          refreshed.push(directory);
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    expect(handlers).not.toBeNull();
+
+    await act(async () => {
+      handlers?.onReady?.();
+      await Promise.resolve();
+    });
+
+    expect(refreshed).toEqual(['/repo', '/repo/src']);
+    act(() => root.unmount());
+  });
+
+  test('coalesces repeated events for one directory without overlapping refreshes', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+    let releaseFirstRefresh: (() => void) | null = null;
+    let refreshCount = 0;
+    let activeRefreshes = 0;
+    let maxActiveRefreshes = 0;
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: '/repo',
+        expandedPaths: [],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => undefined };
+        },
+        refreshDirectory: async () => {
+          refreshCount += 1;
+          activeRefreshes += 1;
+          maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
+          if (refreshCount === 1) {
+            await new Promise<void>((resolve) => {
+              releaseFirstRefresh = resolve;
+            });
+          }
+          activeRefreshes -= 1;
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    await act(async () => {
+      handlers?.onChange({ directory: '/repo' });
+      handlers?.onChange({ directory: '/repo' });
+      await Promise.resolve();
+    });
+
+    expect(refreshCount).toBe(1);
+    expect(maxActiveRefreshes).toBe(1);
+
+    await act(async () => {
+      releaseFirstRefresh?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(refreshCount).toBe(2);
+    expect(maxActiveRefreshes).toBe(1);
+    act(() => root.unmount());
+  });
+
+  test('keeps fallback polling until all watched directories reconcile', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    let closeCount = 0;
+    let clearIntervalCount = 0;
+    let fallbackTick: (() => void) | null = null;
+    const failingDirectories = new Set(['/repo']);
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+    const setIntervalStub = (callback: () => void) => {
+      fallbackTick = callback;
+      return 1;
+    };
+    const clearIntervalStub = () => {
+      clearIntervalCount += 1;
+    };
+    installGlobal('setInterval', setIntervalStub);
+    installGlobal('clearInterval', clearIntervalStub);
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: '/repo',
+        expandedPaths: ['/repo/src'],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => { closeCount += 1; } };
+        },
+        refreshDirectory: async (directory) => {
+          if (failingDirectories.has(directory)) throw new Error('list failed');
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    await act(async () => {
+      handlers?.onReady?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(closeCount).toBe(0);
+    expect(clearIntervalCount).toBe(0);
+    failingDirectories.clear();
+    await act(async () => {
+      handlers?.onChange({ directory: '/repo/src' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(clearIntervalCount).toBe(0);
+    await act(async () => {
+      fallbackTick?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(clearIntervalCount).toBe(1);
+    act(() => handlers?.onError?.());
+    await act(async () => {
+      fallbackTick?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(clearIntervalCount).toBe(1);
+    act(() => root.unmount());
+    expect(closeCount).toBe(1);
+    expect(clearIntervalCount).toBe(2);
+  });
+
+  test('does no background work while disabled and reconciles after enabling', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    const refreshed: string[] = [];
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+    let watchCount = 0;
+    let closeCount = 0;
+    let setIntervalCount = 0;
+    let clearIntervalCount = 0;
+    installGlobal('setInterval', () => {
+      setIntervalCount += 1;
+      return 1;
+    });
+    installGlobal('clearInterval', () => {
+      clearIntervalCount += 1;
+    });
+
+    const Probe: React.FC<{ enabled: boolean }> = ({ enabled }) => {
+      useFileTreeAutoRefresh({
+        enabled,
+        root: '/repo',
+        expandedPaths: [],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          watchCount += 1;
+          handlers = nextHandlers;
+          return { close: () => { closeCount += 1; } };
+        },
+        refreshDirectory: async (directory) => {
+          refreshed.push(directory);
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { enabled: false }));
+    });
+    expect(watchCount).toBe(0);
+    expect(setIntervalCount).toBe(0);
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { enabled: true }));
+    });
+    expect(watchCount).toBe(1);
+    expect(setIntervalCount).toBe(1);
+
+    await act(async () => {
+      handlers?.onReady?.();
+      await Promise.resolve();
+    });
+    expect(refreshed).toEqual(['/repo']);
+    expect(clearIntervalCount).toBe(1);
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { enabled: false }));
+    });
+    expect(closeCount).toBe(1);
+    expect(clearIntervalCount).toBe(1);
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/ui/src/hooks/useFileTreeAutoRefresh.test.ts
+++ b/packages/ui/src/hooks/useFileTreeAutoRefresh.test.ts
@@ -1,0 +1,487 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { collectFileTreeWatchDirectories } from './useFileTreeAutoRefresh';
+import { useFileTreeAutoRefresh } from './useFileTreeAutoRefresh';
+import { getBackgroundNetworkState, runBackgroundNetworkTask } from '@/lib/background-network';
+import { getFileTreePathIdentity, normalizeFileTreePath } from '@/lib/fileTreePath';
+
+const installedGlobals = new Map<string, PropertyDescriptor | undefined>();
+
+type TestDocument = {
+  nodeType: number;
+  defaultView: typeof globalThis;
+  hidden: boolean;
+  visibilityState: string;
+  addEventListener: (event: string, listener: () => void) => void;
+  removeEventListener: (event: string, listener: () => void) => void;
+  documentElement?: Element;
+  body?: Element;
+};
+
+const installGlobal = <TValue,>(name: string, value: TValue) => {
+  if (!installedGlobals.has(name)) {
+    installedGlobals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+  }
+  Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+};
+
+const flushMicrotasks = async (rounds = 8) => {
+  for (let index = 0; index < rounds; index += 1) await Promise.resolve();
+};
+
+const installMinimalDom = () => {
+  const listeners = new Map<string, Set<() => void>>();
+  class ElementStub {}
+  const documentStub: TestDocument = {
+    nodeType: 9,
+    defaultView: globalThis,
+    hidden: false,
+    visibilityState: 'visible',
+    addEventListener: (event: string, listener: () => void) => {
+      const eventListeners = listeners.get(event) ?? new Set();
+      eventListeners.add(listener);
+      listeners.set(event, eventListeners);
+    },
+    removeEventListener: (event: string, listener: () => void) => {
+      listeners.get(event)?.delete(listener);
+    },
+  };
+  const container: Element = Object.assign(Object.create(ElementStub.prototype), {
+    nodeType: 1,
+    tagName: 'DIV',
+    nodeName: 'DIV',
+    namespaceURI: 'http://www.w3.org/1999/xhtml',
+    ownerDocument: documentStub,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  });
+  documentStub.documentElement = container;
+  documentStub.body = container;
+  installGlobal('document', documentStub);
+  installGlobal('window', globalThis);
+  installGlobal('Element', ElementStub);
+  installGlobal('HTMLElement', ElementStub);
+  installGlobal('HTMLIFrameElement', ElementStub);
+  installGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  return container;
+};
+
+afterEach(() => {
+  for (const [name, descriptor] of installedGlobals) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+  installedGlobals.clear();
+});
+
+describe('collectFileTreeWatchDirectories', () => {
+  test('always includes the root and keeps only unique workspace descendants', () => {
+    expect(collectFileTreeWatchDirectories('C:\\Repo', [
+      'C:/Repo/src',
+      'c:/repo/SRC',
+      'C:/Repo/src/components',
+      'D:/Other',
+      '',
+    ])).toEqual([
+      'C:/Repo',
+      'C:/Repo/src',
+      'C:/Repo/src/components',
+    ]);
+  });
+
+  test('returns no directories without a workspace root', () => {
+    expect(collectFileTreeWatchDirectories('', ['/repo/src'])).toEqual([]);
+  });
+
+  test('preserves Unix, Windows drive, and UNC roots', () => {
+    expect(collectFileTreeWatchDirectories('/', ['/tmp'])).toEqual(['/', '/tmp']);
+    expect(collectFileTreeWatchDirectories('C:/', ['C:/Users'])).toEqual(['C:/', 'C:/Users']);
+    expect(collectFileTreeWatchDirectories('\\\\Server\\Share', [
+      '//server/share/project',
+    ])).toEqual([
+      '//Server/Share',
+      '//server/share/project',
+    ]);
+  });
+
+  test('preserves Windows drive-letter casing while comparing identities case-insensitively', () => {
+    expect(normalizeFileTreePath('c:\\repo')).toBe('c:/repo');
+    expect(getFileTreePathIdentity('c:/repo')).toBe(getFileTreePathIdentity('C:/REPO'));
+  });
+});
+
+describe('useFileTreeAutoRefresh', () => {
+  test('reconciles watched directories before treating the watcher as ready', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    const refreshed: string[] = [];
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: '/repo',
+        expandedPaths: ['/repo/src'],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => undefined };
+        },
+        refreshDirectory: async (directory) => {
+          refreshed.push(directory);
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    expect(handlers).not.toBeNull();
+
+    await act(async () => {
+      handlers?.onReady?.();
+      await Promise.resolve();
+    });
+
+    expect(refreshed).toEqual(['/repo', '/repo/src']);
+    act(() => root.unmount());
+  });
+
+  test('coalesces repeated events for one directory without overlapping refreshes', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+    let releaseFirstRefresh: (() => void) | null = null;
+    let refreshCount = 0;
+    let activeRefreshes = 0;
+    let maxActiveRefreshes = 0;
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: '/repo',
+        expandedPaths: [],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => undefined };
+        },
+        refreshDirectory: async () => {
+          refreshCount += 1;
+          activeRefreshes += 1;
+          maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
+          if (refreshCount === 1) {
+            await new Promise<void>((resolve) => {
+              releaseFirstRefresh = resolve;
+            });
+          }
+          activeRefreshes -= 1;
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    await act(async () => {
+      handlers?.onChange({ directory: '/repo' });
+      handlers?.onChange({ directory: '/repo' });
+      await Promise.resolve();
+    });
+
+    expect(refreshCount).toBe(1);
+    expect(maxActiveRefreshes).toBe(1);
+
+    await act(async () => {
+      releaseFirstRefresh?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(refreshCount).toBe(2);
+    expect(maxActiveRefreshes).toBe(1);
+    act(() => root.unmount());
+  });
+
+  test('caps concurrent refreshes across different watched directories', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    const directories = ['/repo', '/repo/a', '/repo/b', '/repo/c', '/repo/d', '/repo/e'];
+    const pendingReleases = new Map<string, () => void>();
+    const started: string[] = [];
+    let activeRefreshes = 0;
+    let maxActiveRefreshes = 0;
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: directories[0],
+        expandedPaths: directories.slice(1),
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => undefined };
+        },
+        refreshDirectory: async (directory) => {
+          started.push(directory);
+          activeRefreshes += 1;
+          maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
+          await new Promise<void>((resolve) => {
+            pendingReleases.set(directory, () => {
+              if (!pendingReleases.delete(directory)) return;
+              activeRefreshes -= 1;
+              resolve();
+            });
+          });
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    await act(async () => {
+      for (const directory of directories) handlers?.onChange({ directory });
+      await flushMicrotasks();
+    });
+
+    const startedBeforeRelease = started.length;
+    while (pendingReleases.size > 0) {
+      await act(async () => {
+        for (const release of [...pendingReleases.values()]) release();
+        await flushMicrotasks();
+      });
+    }
+    act(() => root.unmount());
+
+    expect(startedBeforeRelease).toBe(3);
+    expect(maxActiveRefreshes).toBe(3);
+    expect(started).toEqual(directories);
+  });
+
+  test('attempts later watched directories when an earlier reconciliation fails', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    const directories = ['/repo', '/repo/a', '/repo/b', '/repo/c', '/repo/d'];
+    const attempted: string[] = [];
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: directories[0],
+        expandedPaths: directories.slice(1),
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => undefined };
+        },
+        refreshDirectory: async (directory) => {
+          attempted.push(directory);
+          if (directory === directories[0]) throw new Error('root listing failed');
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    await act(async () => {
+      handlers?.onReady?.();
+      await flushMicrotasks();
+    });
+    act(() => root.unmount());
+
+    expect(attempted).toEqual(directories);
+  });
+
+  test('gates fallback traffic without delaying a live event for another directory', async () => {
+    const { limit } = getBackgroundNetworkState();
+    const blockerReleases: Array<() => void> = [];
+    const blockers = Array.from({ length: limit }, () => runBackgroundNetworkTask(() => new Promise<void>((resolve) => {
+      blockerReleases.push(resolve);
+    })));
+    await flushMicrotasks();
+
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    const refreshed: string[] = [];
+    let fallbackTick: (() => void) | null = null;
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+    installGlobal('setInterval', (callback: () => void) => {
+      fallbackTick = callback;
+      return 1;
+    });
+    installGlobal('clearInterval', () => undefined);
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: '/repo',
+        expandedPaths: ['/repo/a', '/repo/b', '/repo/c'],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => undefined };
+        },
+        refreshDirectory: async (directory) => {
+          refreshed.push(directory);
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    await act(async () => {
+      fallbackTick?.();
+      handlers?.onChange({ directory: '/repo/c' });
+      await flushMicrotasks();
+    });
+    const refreshedWhileGateWasFull = [...refreshed];
+    for (const release of blockerReleases) release();
+    await Promise.all(blockers);
+    await act(async () => {
+      await flushMicrotasks(16);
+    });
+    act(() => root.unmount());
+
+    expect(refreshedWhileGateWasFull).toEqual(['/repo/c']);
+    expect(getBackgroundNetworkState()).toEqual({ active: 0, waiting: 0, limit });
+  });
+
+  test('keeps fallback polling until all watched directories reconcile', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    let closeCount = 0;
+    let clearIntervalCount = 0;
+    let fallbackTick: (() => void) | null = null;
+    const failingDirectories = new Set(['/repo']);
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+    const setIntervalStub = (callback: () => void) => {
+      fallbackTick = callback;
+      return 1;
+    };
+    const clearIntervalStub = () => {
+      clearIntervalCount += 1;
+    };
+    installGlobal('setInterval', setIntervalStub);
+    installGlobal('clearInterval', clearIntervalStub);
+
+    const Probe: React.FC = () => {
+      useFileTreeAutoRefresh({
+        enabled: true,
+        root: '/repo',
+        expandedPaths: ['/repo/src'],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          handlers = nextHandlers;
+          return { close: () => { closeCount += 1; } };
+        },
+        refreshDirectory: async (directory) => {
+          if (failingDirectories.has(directory)) throw new Error('list failed');
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+    });
+    await act(async () => {
+      handlers?.onReady?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(closeCount).toBe(0);
+    expect(clearIntervalCount).toBe(0);
+    failingDirectories.clear();
+    await act(async () => {
+      handlers?.onChange({ directory: '/repo/src' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(clearIntervalCount).toBe(0);
+    await act(async () => {
+      fallbackTick?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(clearIntervalCount).toBe(1);
+    act(() => handlers?.onError?.());
+    await act(async () => {
+      fallbackTick?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(clearIntervalCount).toBe(1);
+    act(() => root.unmount());
+    expect(closeCount).toBe(1);
+    expect(clearIntervalCount).toBe(2);
+  });
+
+  test('does no background work while disabled and reconciles after enabling', async () => {
+    const container = installMinimalDom();
+    const root: Root = createRoot(container);
+    const refreshed: string[] = [];
+    let handlers: Parameters<NonNullable<Parameters<typeof useFileTreeAutoRefresh>[0]['watchDirectories']>>[2] | null = null;
+    let watchCount = 0;
+    let closeCount = 0;
+    let setIntervalCount = 0;
+    let clearIntervalCount = 0;
+    installGlobal('setInterval', () => {
+      setIntervalCount += 1;
+      return 1;
+    });
+    installGlobal('clearInterval', () => {
+      clearIntervalCount += 1;
+    });
+
+    const Probe: React.FC<{ enabled: boolean }> = ({ enabled }) => {
+      useFileTreeAutoRefresh({
+        enabled,
+        root: '/repo',
+        expandedPaths: [],
+        watchDirectories: (_workspace, _directories, nextHandlers) => {
+          watchCount += 1;
+          handlers = nextHandlers;
+          return { close: () => { closeCount += 1; } };
+        },
+        refreshDirectory: async (directory) => {
+          refreshed.push(directory);
+        },
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { enabled: false }));
+    });
+    expect(watchCount).toBe(0);
+    expect(setIntervalCount).toBe(0);
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { enabled: true }));
+    });
+    expect(watchCount).toBe(1);
+    expect(setIntervalCount).toBe(1);
+
+    await act(async () => {
+      handlers?.onReady?.();
+      await Promise.resolve();
+    });
+    expect(refreshed).toEqual(['/repo']);
+    expect(clearIntervalCount).toBe(1);
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { enabled: false }));
+    });
+    expect(closeCount).toBe(1);
+    expect(clearIntervalCount).toBe(1);
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/ui/src/hooks/useFileTreeAutoRefresh.ts
+++ b/packages/ui/src/hooks/useFileTreeAutoRefresh.ts
@@ -1,0 +1,221 @@
+import * as React from 'react';
+
+import type { FilesAPI, FileWatchSubscription } from '@/lib/api/types';
+import { runBackgroundNetworkTask } from '@/lib/background-network';
+import {
+  getFileTreePathIdentity,
+  isFileTreePathWithinRoot,
+  normalizeFileTreePath,
+} from '@/lib/fileTreePath';
+
+const FALLBACK_REFRESH_INTERVAL_MS = 8_000;
+const FILE_TREE_REFRESH_CONCURRENCY = 3;
+
+export const collectFileTreeWatchDirectories = (root: string, expandedPaths: string[]): string[] => {
+  const normalizedRoot = normalizeFileTreePath(root);
+  if (!normalizedRoot) return [];
+
+  const rootKey = getFileTreePathIdentity(normalizedRoot);
+  const seen = new Set([rootKey]);
+  const directories = [normalizedRoot];
+  for (const value of expandedPaths) {
+    const directory = normalizeFileTreePath(value);
+    const key = getFileTreePathIdentity(directory);
+    if (!directory || seen.has(key)) continue;
+    if (!isFileTreePathWithinRoot(directory, normalizedRoot)) continue;
+    seen.add(key);
+    directories.push(directory);
+  }
+  return directories;
+};
+
+interface UseFileTreeAutoRefreshOptions {
+  enabled: boolean;
+  root: string;
+  expandedPaths: string[];
+  watchDirectories: FilesAPI['watchDirectories'];
+  refreshDirectory: (directory: string) => Promise<void>;
+}
+
+export const useFileTreeAutoRefresh = ({
+  enabled,
+  root,
+  expandedPaths,
+  watchDirectories,
+  refreshDirectory,
+}: UseFileTreeAutoRefreshOptions): void => {
+  const directories = React.useMemo(
+    () => collectFileTreeWatchDirectories(root, expandedPaths),
+    [expandedPaths, root],
+  );
+  const watchedDirectoryKeys = React.useMemo(
+    () => new Set(directories.map(getFileTreePathIdentity)),
+    [directories],
+  );
+
+  React.useEffect(() => {
+    if (!enabled || directories.length === 0) return;
+
+    let active = true;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let watcherReady = false;
+    let activeRefreshes = 0;
+    const refreshWaiters: Array<() => void> = [];
+    const refreshStates = new Map<string, {
+      pending: boolean;
+      pendingLiveRefresh: boolean;
+      running: Promise<void> | null;
+    }>();
+    const acquireRefreshSlot = (): Promise<void> => {
+      if (activeRefreshes < FILE_TREE_REFRESH_CONCURRENCY) {
+        activeRefreshes += 1;
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        refreshWaiters.push(resolve);
+      });
+    };
+    const releaseRefreshSlot = () => {
+      const next = refreshWaiters.shift();
+      if (next) {
+        next();
+        return;
+      }
+      activeRefreshes = Math.max(0, activeRefreshes - 1);
+    };
+    const runRefresh = async (directory: string, live: boolean) => {
+      const refresh = async () => {
+        await acquireRefreshSlot();
+        try {
+          if (active) await refreshDirectory(directory);
+        } finally {
+          releaseRefreshSlot();
+        }
+      };
+      if (live) await refresh();
+      else await runBackgroundNetworkTask(refresh);
+    };
+    const queueRefresh = (directory: string, live = false): Promise<void> => {
+      const key = getFileTreePathIdentity(directory);
+      const state = refreshStates.get(key) ?? {
+        pending: false,
+        pendingLiveRefresh: false,
+        running: null,
+      };
+      refreshStates.set(key, state);
+      state.pending = true;
+      if (live) state.pendingLiveRefresh = true;
+      if (!state.running) {
+        state.running = (async () => {
+          let latestRefreshFailed = false;
+          while (active && state.pending) {
+            state.pending = false;
+            const nextRefreshIsLive = state.pendingLiveRefresh;
+            state.pendingLiveRefresh = false;
+            try {
+              await runRefresh(directory, nextRefreshIsLive);
+              latestRefreshFailed = false;
+            } catch {
+              latestRefreshFailed = true;
+            }
+          }
+          if (latestRefreshFailed) throw new Error('Failed to refresh the file-tree directory');
+        })().finally(() => {
+          state.running = null;
+          if (!state.pending) refreshStates.delete(key);
+        });
+      }
+      return state.running;
+    };
+    const refreshAll = async () => {
+      let refreshFailed = false;
+      for (let index = 0; index < directories.length && active; index += FILE_TREE_REFRESH_CONCURRENCY) {
+        const results = await Promise.allSettled(
+          directories
+            .slice(index, index + FILE_TREE_REFRESH_CONCURRENCY)
+            .map((directory) => queueRefresh(directory)),
+        );
+        if (results.some((result) => result.status === 'rejected')) refreshFailed = true;
+      }
+      if (refreshFailed) throw new Error('Failed to reconcile all file-tree directories');
+    };
+    const stopFallback = () => {
+      if (!interval) return;
+      clearInterval(interval);
+      interval = null;
+    };
+    const startFallback = () => {
+      if (interval) return;
+      interval = setInterval(() => {
+        if (document.hidden) return;
+        void refreshAll().then(
+          () => {
+            if (active && watcherReady) stopFallback();
+          },
+          () => undefined,
+        );
+      }, FALLBACK_REFRESH_INTERVAL_MS);
+    };
+    startFallback();
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) return;
+      void refreshAll().then(
+        () => {
+          if (active && watcherReady) stopFallback();
+        },
+        () => {
+          if (active) startFallback();
+        },
+      );
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    if (watchDirectories) {
+      let subscription: FileWatchSubscription | null = null;
+      try {
+        subscription = watchDirectories(root, directories, {
+          onReady: () => {
+            watcherReady = true;
+            void refreshAll().then(
+              () => {
+                if (active) stopFallback();
+              },
+              () => {
+                if (active) startFallback();
+              },
+            );
+          },
+          onError: () => {
+            watcherReady = false;
+            startFallback();
+          },
+          onChange: (event) => {
+            if (document.hidden) return;
+            const directory = normalizeFileTreePath(event.directory);
+            if (!watchedDirectoryKeys.has(getFileTreePathIdentity(directory))) return;
+            void queueRefresh(directory, true).catch(() => {
+              if (active) startFallback();
+            });
+          },
+        });
+      } catch {
+        subscription = null;
+      }
+      if (subscription) {
+        return () => {
+          active = false;
+          stopFallback();
+          document.removeEventListener('visibilitychange', handleVisibilityChange);
+          subscription.close();
+        };
+      }
+    }
+
+    return () => {
+      active = false;
+      stopFallback();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [directories, enabled, refreshDirectory, root, watchDirectories, watchedDirectoryKeys]);
+};

--- a/packages/ui/src/hooks/useFileTreeAutoRefresh.ts
+++ b/packages/ui/src/hooks/useFileTreeAutoRefresh.ts
@@ -1,0 +1,164 @@
+import * as React from 'react';
+
+import type { FilesAPI, FileWatchSubscription } from '@/lib/api/types';
+import {
+  getFileTreePathIdentity,
+  isFileTreePathWithinRoot,
+  normalizeFileTreePath,
+} from '@/lib/fileTreePath';
+
+const FALLBACK_REFRESH_INTERVAL_MS = 8_000;
+
+export const collectFileTreeWatchDirectories = (root: string, expandedPaths: string[]): string[] => {
+  const normalizedRoot = normalizeFileTreePath(root);
+  if (!normalizedRoot) return [];
+
+  const rootKey = getFileTreePathIdentity(normalizedRoot);
+  const seen = new Set([rootKey]);
+  const directories = [normalizedRoot];
+  for (const value of expandedPaths) {
+    const directory = normalizeFileTreePath(value);
+    const key = getFileTreePathIdentity(directory);
+    if (!directory || seen.has(key)) continue;
+    if (!isFileTreePathWithinRoot(directory, normalizedRoot)) continue;
+    seen.add(key);
+    directories.push(directory);
+  }
+  return directories;
+};
+
+interface UseFileTreeAutoRefreshOptions {
+  enabled: boolean;
+  root: string;
+  expandedPaths: string[];
+  watchDirectories: FilesAPI['watchDirectories'];
+  refreshDirectory: (directory: string) => Promise<void>;
+}
+
+export const useFileTreeAutoRefresh = ({
+  enabled,
+  root,
+  expandedPaths,
+  watchDirectories,
+  refreshDirectory,
+}: UseFileTreeAutoRefreshOptions): void => {
+  const directories = React.useMemo(
+    () => collectFileTreeWatchDirectories(root, expandedPaths),
+    [expandedPaths, root],
+  );
+  const watchedDirectoryKeys = React.useMemo(
+    () => new Set(directories.map(getFileTreePathIdentity)),
+    [directories],
+  );
+
+  React.useEffect(() => {
+    if (!enabled || directories.length === 0) return;
+
+    let active = true;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let watcherReady = false;
+    const refreshStates = new Map<string, {
+      pending: boolean;
+      running: Promise<void> | null;
+    }>();
+    const queueRefresh = (directory: string): Promise<void> => {
+      const key = getFileTreePathIdentity(directory);
+      const state = refreshStates.get(key) ?? { pending: false, running: null };
+      refreshStates.set(key, state);
+      state.pending = true;
+      if (!state.running) {
+        state.running = (async () => {
+          while (active && state.pending) {
+            state.pending = false;
+            await refreshDirectory(directory);
+          }
+        })().finally(() => {
+          state.running = null;
+          if (!state.pending) refreshStates.delete(key);
+        });
+      }
+      return state.running;
+    };
+    const refreshAll = async () => {
+      for (let index = 0; index < directories.length && active; index += 3) {
+        await Promise.all(directories.slice(index, index + 3).map(queueRefresh));
+      }
+    };
+    const stopFallback = () => {
+      if (!interval) return;
+      clearInterval(interval);
+      interval = null;
+    };
+    const startFallback = () => {
+      if (interval) return;
+      interval = setInterval(() => {
+        if (document.hidden) return;
+        void refreshAll().then(
+          () => {
+            if (active && watcherReady) stopFallback();
+          },
+          () => undefined,
+        );
+      }, FALLBACK_REFRESH_INTERVAL_MS);
+    };
+    startFallback();
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) return;
+      void refreshAll().then(
+        () => {
+          if (active && watcherReady) stopFallback();
+        },
+        () => undefined,
+      );
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    if (watchDirectories) {
+      let subscription: FileWatchSubscription | null = null;
+      try {
+        subscription = watchDirectories(root, directories, {
+          onReady: () => {
+            watcherReady = true;
+            void refreshAll().then(
+              () => {
+                if (active) stopFallback();
+              },
+              () => {
+                if (active) startFallback();
+              },
+            );
+          },
+          onError: () => {
+            watcherReady = false;
+            startFallback();
+          },
+          onChange: (event) => {
+            if (document.hidden) return;
+            const directory = normalizeFileTreePath(event.directory);
+            if (!watchedDirectoryKeys.has(getFileTreePathIdentity(directory))) return;
+            void queueRefresh(directory).catch(() => {
+              if (active) startFallback();
+            });
+          },
+        });
+      } catch {
+        subscription = null;
+      }
+      if (subscription) {
+        return () => {
+          active = false;
+          stopFallback();
+          document.removeEventListener('visibilitychange', handleVisibilityChange);
+          subscription.close();
+        };
+      }
+    }
+
+    return () => {
+      active = false;
+      stopFallback();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [directories, enabled, refreshDirectory, root, watchDirectories, watchedDirectoryKeys]);
+};

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -564,6 +564,20 @@ export interface DirectoryListResult {
   entries: FileListEntry[];
 }
 
+export interface FileChangeEvent {
+  directory: string;
+}
+
+export interface FileWatchHandlers {
+  onChange: (event: FileChangeEvent) => void;
+  onReady?: () => void;
+  onError?: () => void;
+}
+
+export interface FileWatchSubscription {
+  close: () => void;
+}
+
 export interface FileSearchQuery {
   directory: string;
   query: string;
@@ -600,6 +614,11 @@ interface FileReadOptions {
 
 export interface FilesAPI {
   listDirectory(path: string, options?: ListDirectoryOptions): Promise<DirectoryListResult>;
+  watchDirectories?(
+    workspaceDirectory: string,
+    directories: string[],
+    handlers: FileWatchHandlers,
+  ): FileWatchSubscription | null;
   search(payload: FileSearchQuery): Promise<FileSearchResult[]>;
   createDirectory(path: string): Promise<{ success: boolean; path: string }>;
   statFile?(path: string, options?: FileReadOptions): Promise<{ path: string; isFile: boolean; size: number; mtimeMs?: number }>;

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -593,6 +593,20 @@ export interface DirectoryListResult {
   entries: FileListEntry[];
 }
 
+export interface FileChangeEvent {
+  directory: string;
+}
+
+export interface FileWatchHandlers {
+  onChange: (event: FileChangeEvent) => void;
+  onReady?: () => void;
+  onError?: () => void;
+}
+
+export interface FileWatchSubscription {
+  close: () => void;
+}
+
 export interface FileSearchQuery {
   directory: string;
   query: string;
@@ -629,6 +643,11 @@ interface FileReadOptions {
 
 export interface FilesAPI {
   listDirectory(path: string, options?: ListDirectoryOptions): Promise<DirectoryListResult>;
+  watchDirectories?(
+    workspaceDirectory: string,
+    directories: string[],
+    handlers: FileWatchHandlers,
+  ): FileWatchSubscription | null;
   search(payload: FileSearchQuery): Promise<FileSearchResult[]>;
   createDirectory(path: string): Promise<{ success: boolean; path: string }>;
   statFile?(path: string, options?: FileReadOptions): Promise<{ path: string; isFile: boolean; size: number; mtimeMs?: number }>;

--- a/packages/ui/src/lib/fileTreePath.ts
+++ b/packages/ui/src/lib/fileTreePath.ts
@@ -1,0 +1,44 @@
+export const normalizeFileTreePath = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+
+  const withForwardSlashes = trimmed.replace(/\\/g, '/');
+  const hadUncPrefix = withForwardSlashes.startsWith('//');
+  let normalized = withForwardSlashes.replace(/\/+/g, '/');
+  if (hadUncPrefix && !normalized.startsWith('//')) {
+    normalized = `/${normalized}`;
+  }
+  if (normalized === '/' || /^[A-Za-z]:\/$/.test(normalized)) {
+    return normalized;
+  }
+  return normalized.replace(/\/+$/, '');
+};
+
+export const getFileTreePathIdentity = (value: string): string => {
+  const normalized = normalizeFileTreePath(value);
+  if (/^[A-Za-z]:\//.test(normalized) || normalized.startsWith('//')) {
+    return normalized.toLowerCase();
+  }
+  return normalized;
+};
+
+export const isFileTreePathWithinRoot = (value: string, root: string): boolean => {
+  const pathKey = getFileTreePathIdentity(value);
+  const rootKey = getFileTreePathIdentity(root);
+  if (!pathKey || !rootKey) return false;
+  if (pathKey === rootKey) return true;
+  if (rootKey === '/' || /^[a-z]:\/$/.test(rootKey)) {
+    return pathKey.startsWith(rootKey);
+  }
+  return pathKey.startsWith(`${rootKey}/`);
+};
+
+export const getFileTreeRelativePath = (value: string, root: string): string | null => {
+  const normalizedPath = normalizeFileTreePath(value);
+  const normalizedRoot = normalizeFileTreePath(root);
+  if (!isFileTreePathWithinRoot(normalizedPath, normalizedRoot)) return null;
+  if (getFileTreePathIdentity(normalizedPath) === getFileTreePathIdentity(normalizedRoot)) {
+    return '';
+  }
+  return normalizedPath.slice(normalizedRoot.length).replace(/^\/+/, '');
+};

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,8 @@
     "simple-git": "^3.36.0",
     "web-push": "^3.6.7",
     "ws": "^8.18.3",
-    "yaml": "^2.8.1"
+    "yaml": "^2.8.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@base-ui/react": "^1.4.0",

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -164,6 +164,7 @@ const SSE_PATH_PREFIXES = [
   '/api/notifications/stream',
   '/api/openchamber/events',
   '/api/openchamber/realtime-proxy/sse',
+  '/api/fs/watch',
 ];
 
 function shouldSkipCompression(req, res) {

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -165,6 +165,7 @@ const SSE_PATH_PREFIXES = [
   '/api/notifications/stream',
   '/api/openchamber/events',
   '/api/openchamber/realtime-proxy/sse',
+  '/api/fs/watch',
 ];
 
 function shouldSkipCompression(req, res) {

--- a/packages/web/server/lib/fs/DOCUMENTATION.md
+++ b/packages/web/server/lib/fs/DOCUMENTATION.md
@@ -6,6 +6,7 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 ## Entrypoints and structure
 - `packages/web/server/lib/fs/routes.js`: route registration and runtime-owned state for `/api/fs/*` endpoints.
 - `packages/web/server/lib/fs/search.js`: fuzzy filesystem search runtime used by non-FS routes (for example project icon discovery).
+- `packages/web/server/lib/fs/watcher.js`: shared, reference-counted `fs.watch` runtime with per-directory event batching.
 
 ## Public exports
 - `registerFsRoutes(app, dependencies)` from `routes.js`
@@ -23,8 +24,14 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
     - `POST /api/fs/exec`
     - `GET /api/fs/exec/:jobId`
     - `GET /api/fs/list`
+    - `GET /api/fs/watch`
   - Owns exec job queue state (`execJobs`) and lifecycle/TTL pruning.
   - Enforces workspace boundary checks with active project + worktree fallback support.
+- `createFsWatcherRuntime({ watch, path, platform, debounceMs, maxWaitMs, logger })` from `watcher.js`
+  - Shares one OS watcher for subscribers whose requested paths resolve to the same canonical directory.
+  - Batches directory invalidations after 250 ms of quiet time, with a 1-second maximum wait during continuous changes.
+  - Treats OS events as hints and lets clients authoritatively re-list the affected directory instead of depending on platform-specific filename details.
+  - Closes the OS watcher when its final subscriber disconnects.
 - `createFsSearchRuntime({ fsPromises, path, spawn, resolveGitBinaryForSpawn })` from `search.js`
   - Returns `{ searchFilesystemFiles(rootPath, options) }`.
   - Supports fuzzy matching, hidden-file handling, and optional `git check-ignore` filtering.
@@ -38,5 +45,8 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 - Filesystem `EPERM`/`EACCES` failures use the stable `reason: "os-permission"` response marker. Policy denials such as workspace-boundary or missing-grant failures must not use that marker because a native folder picker cannot remediate them.
 - Read-only routes authorize the requested path against the workspace before resolving symlinks. A symlink reached through the workspace may therefore target a file outside it, while a directly requested outside path still requires an exact-path grant. Write routes keep canonical-target boundary checks.
 - If adding new `/api/fs/*` endpoints, add them in `routes.js` and extend this document.
+- `GET /api/fs/watch` accepts the active workspace in `directory` and a JSON array in `directories`. Every watched directory is validated against the active workspace/worktree boundary before SSE headers are sent. The route emits `openchamber:files-watch-ready`, `openchamber:files-changed`, and heartbeat envelopes, and closes every subscription with the client request. No more than 64 directories may be watched by one connection. Disconnect and response-error handlers are installed before asynchronous path resolution so abandoned requests cannot leave watchers or heartbeat timers behind.
+- Standard Web and Electron Desktop surfaces mount `SidebarFilesTree`. While the tree is visible, direct connections consume `/api/fs/watch` through the runtime URL resolver; when the same surface uses the private relay, native `EventSource` cannot traverse the tunnel and the tree uses its 8-second polling fallback. Hiding the tree closes its subscription and fallback timer. Showing it again starts a new subscription and authoritatively reconciles the watched directories before treating the watcher as ready. The fallback remains active until that reconciliation finishes, and returns while the stream is unavailable. Failed streams reconnect with bounded exponential backoff, use a longer delay while the client is hidden or offline, and rebind immediately when the active runtime changes. Dedicated VS Code, hosted-mobile, and Capacitor surfaces do not mount this sidebar tree and are unaffected.
+- `GET /api/fs/watch` is an explicit read-only URL-auth and Desktop realtime-proxy SSE path. This keeps direct remote, SSH, and local standard surfaces on the same scoped authentication boundary without allowing URL tokens on filesystem mutation routes.
 - `GET /api/fs/list` may resolve symlinks with `realpath` to read directory contents, but the response `path` and each entry `path` must stay in the caller's requested path space (`path.join(requestedPath, name)`). Returning real paths breaks file-tree expansion for directories reached through workspace symlinks.
 - `POST /api/fs/upload` accepts one `application/octet-stream` body with `path` and optional `overwrite=true` query parameters. The body streams into a same-directory temp file with a 100 MiB default cap configurable through `OPENCHAMBER_FS_UPLOAD_MAX_BYTES`; failed and oversized uploads clean up that temp file. New files commit through an atomic no-replace link, existing files return `409` unless overwrite is explicit, directory targets are rejected, and the destination parent resolves before writing so uploads cannot escape through workspace symlinks.

--- a/packages/web/server/lib/fs/DOCUMENTATION.md
+++ b/packages/web/server/lib/fs/DOCUMENTATION.md
@@ -6,6 +6,7 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 ## Entrypoints and structure
 - `packages/web/server/lib/fs/routes.js`: route registration and runtime-owned state for `/api/fs/*` endpoints.
 - `packages/web/server/lib/fs/search.js`: fuzzy filesystem search runtime used by non-FS routes (for example project icon discovery).
+- `packages/web/server/lib/fs/watcher.js`: shared, reference-counted `fs.watch` runtime with per-directory event batching.
 
 ## Public exports
 - `registerFsRoutes(app, dependencies)` from `routes.js`
@@ -27,9 +28,15 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
       Git tab (depth- and visit-capped readdir walk; `.git` directory, file, or
       symlink marks a repository boundary; junk directories and symlinks are
       never descended into)
+    - `GET /api/fs/watch`
   - Owns exec job queue state (`execJobs`) and lifecycle/TTL pruning.
   - Enforces workspace boundary checks with active project + worktree fallback support.
   - The active project directory is validated with `fs.realpath`, so when the project root is itself a symlink the workspace base no longer matches the paths the client sends. Workspace resolution therefore retries against the raw directory the client requested (`requestedDirectory` from `resolveProjectDirectory`) before falling back to worktree roots. Symlinks are still resolved afterwards, and write/exec routes keep their canonical containment check against the resolved base.
+- `createFsWatcherRuntime({ watch, path, platform, debounceMs, maxWaitMs, logger })` from `watcher.js`
+  - Shares one OS watcher for subscribers whose requested paths resolve to the same canonical directory.
+  - Batches directory invalidations after 250 ms of quiet time, with a 1-second maximum wait during continuous changes.
+  - Treats OS events as hints and lets clients authoritatively re-list the affected directory instead of depending on platform-specific filename details.
+  - Closes the OS watcher when its final subscriber disconnects.
 - `createFsSearchRuntime({ fsPromises, path, spawn, resolveGitBinaryForSpawn })` from `search.js`
   - Returns `{ searchFilesystemFiles(rootPath, options) }`.
   - Supports fuzzy matching, hidden-file handling, and optional `git check-ignore` filtering.
@@ -43,5 +50,8 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 - Filesystem `EPERM`/`EACCES` failures use the stable `reason: "os-permission"` response marker. Policy denials such as workspace-boundary or missing-grant failures must not use that marker because a native folder picker cannot remediate them.
 - Read-only routes authorize the requested path against the workspace before resolving symlinks. A symlink reached through the workspace may therefore target a file outside it, while a directly requested outside path still requires an exact-path grant. Write routes keep canonical-target boundary checks.
 - If adding new `/api/fs/*` endpoints, add them in `routes.js` and extend this document.
+- `GET /api/fs/watch` accepts the active workspace in `directory` and a JSON array in `directories`. Every watched directory is validated against the active workspace/worktree boundary before SSE headers are sent. The route emits `openchamber:files-watch-ready`, `openchamber:files-changed`, and heartbeat envelopes, and closes every subscription with the client request. No more than 64 directories may be watched by one connection. Disconnect and response-error handlers are installed before asynchronous path resolution so abandoned requests cannot leave watchers or heartbeat timers behind.
+- Standard Web and Electron Desktop surfaces mount `SidebarFilesTree`. While the tree is visible, direct connections consume `/api/fs/watch` through the runtime URL resolver; when the same surface uses the private relay, native `EventSource` cannot traverse the tunnel and the tree uses its 8-second polling fallback. Hiding the tree closes its subscription and fallback timer. Showing it again starts a new subscription and authoritatively reconciles the watched directories before treating the watcher as ready. The fallback remains active until that reconciliation finishes, and returns while the stream is unavailable. Failed streams reconnect with bounded exponential backoff, use a longer delay while the client is hidden or offline, and rebind immediately when the active runtime changes. Dedicated VS Code, hosted-mobile, and Capacitor surfaces do not mount this sidebar tree and are unaffected.
+- `GET /api/fs/watch` is an explicit read-only URL-auth and Desktop realtime-proxy SSE path. This keeps direct remote, SSH, and local standard surfaces on the same scoped authentication boundary without allowing URL tokens on filesystem mutation routes.
 - `GET /api/fs/list` may resolve symlinks with `realpath` to read directory contents, but the response `path` and each entry `path` must stay in the caller's requested path space (`path.join(requestedPath, name)`). Returning real paths breaks file-tree expansion for directories reached through workspace symlinks.
 - `POST /api/fs/upload` accepts one `application/octet-stream` body with `path` and optional `overwrite=true` query parameters. The body streams into a same-directory temp file with a 100 MiB default cap configurable through `OPENCHAMBER_FS_UPLOAD_MAX_BYTES`; failed and oversized uploads clean up that temp file. New files commit through an atomic no-replace link, existing files return `409` unless overwrite is explicit, directory targets are rejected, and the destination parent resolves before writing so uploads cannot escape through workspace symlinks.

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -1,9 +1,19 @@
 import { createRealpathCache } from '../path-realpath-cache.js';
+import nodeFs from 'node:fs';
 import nodeFsPromises from 'node:fs/promises';
 import nodePath from 'node:path';
+import { z } from 'zod';
+import { createFsWatcherRuntime } from './watcher.js';
 
 const EXEC_JOB_TTL_MS = 30 * 60 * 1000;
 const OUTSIDE_FILE_GRANT_TTL_MS = 10 * 60 * 1000;
+const FS_WATCH_MAX_DIRECTORIES = 64;
+const FS_WATCH_HEARTBEAT_MS = 25_000;
+const fsWatchDirectoriesSchema = z.array(z.string().trim().min(1))
+  .min(1)
+  .max(FS_WATCH_MAX_DIRECTORIES);
+const fsWatchNotFoundErrorSchema = z.object({ code: z.literal('ENOENT') });
+const fsWatchErrorMessageSchema = z.object({ message: z.string().min(1) });
 
 const outsideFileGrants = new Map();
 
@@ -511,6 +521,7 @@ export const registerFsRoutes = (app, dependencies) => {
   const {
     os,
     path,
+    fs = nodeFs,
     fsPromises,
     spawn,
     platform = process.platform,
@@ -520,9 +531,15 @@ export const registerFsRoutes = (app, dependencies) => {
     buildAugmentedPath,
     resolveGitBinaryForSpawn,
     openchamberUserConfigRoot,
+    writeSseEvent,
   } = dependencies;
   const realpathCache = createRealpathCache({
     realpath: fsPromises.realpath.bind(fsPromises),
+  });
+  const fsWatcherRuntime = createFsWatcherRuntime({
+    watch: fs.watch.bind(fs),
+    path,
+    platform,
   });
 
   const spawnDetached = (command, args) => new Promise((resolve, reject) => {
@@ -1537,6 +1554,170 @@ export const registerFsRoutes = (app, dependencies) => {
       success: job.success === true,
       results: Array.isArray(job.results) ? job.results : [],
     });
+  });
+
+  app.get('/api/fs/watch', async (req, res) => {
+    const serializedDirectories = z.string().safeParse(req.query?.directories);
+    if (!serializedDirectories.success) {
+      return res.status(400).json({ error: 'directories must be a JSON array' });
+    }
+    let decodedDirectories;
+    try {
+      decodedDirectories = JSON.parse(serializedDirectories.data);
+    } catch {
+      return res.status(400).json({ error: 'directories must be a JSON array' });
+    }
+    const parsedDirectories = fsWatchDirectoriesSchema.safeParse(decodedDirectories);
+    if (!parsedDirectories.success) {
+      return res.status(400).json({ error: `directories must contain between 1 and ${FS_WATCH_MAX_DIRECTORIES} paths` });
+    }
+    const requestedDirectories = parsedDirectories.data;
+
+    let closed = false;
+    let clientClosed = false;
+    let streamReady = false;
+    let heartbeat = null;
+    let watchError = null;
+    const subscriptions = [];
+    const queuedPayloads = [];
+    const close = () => {
+      if (closed) return;
+      closed = true;
+      if (heartbeat) {
+        clearInterval(heartbeat);
+        heartbeat = null;
+      }
+      for (const subscription of subscriptions.splice(0)) {
+        subscription.close();
+      }
+      queuedPayloads.length = 0;
+    };
+    const handleClientClose = () => {
+      clientClosed = true;
+      close();
+    };
+    const emit = (payload) => {
+      if (closed || res.writableEnded || res.destroyed) {
+        close();
+        return false;
+      }
+      if (!streamReady) {
+        queuedPayloads.push(payload);
+        return true;
+      }
+      try {
+        writeSseEvent(res, payload);
+        return true;
+      } catch {
+        close();
+        res.end?.();
+        return false;
+      }
+    };
+    req.on('close', handleClientClose);
+    res.on?.('error', handleClientClose);
+
+    try {
+      const resolvedDirectories = [];
+      const seenRequestedDirectories = new Set();
+      for (const value of requestedDirectories) {
+        const resolved = await resolveWorkspacePathFromContext({
+          req,
+          targetPath: value,
+          resolveProjectDirectory,
+          path,
+          os,
+          normalizeDirectoryPath,
+          openchamberUserConfigRoot,
+        });
+        if (clientClosed) return undefined;
+        if (!resolved.ok) {
+          return res.status(400).json({ error: resolved.error });
+        }
+
+        const requestedDirectory = path.resolve(resolved.resolved);
+        const requestedKey = platform === 'win32' ? requestedDirectory.toLowerCase() : requestedDirectory;
+        if (seenRequestedDirectories.has(requestedKey)) continue;
+
+        // Watch setup is infrequent and must observe a replaced symlink or a
+        // directory recreated with a new inode. Do not reuse the listing
+        // realpath cache here.
+        const canonicalDirectory = await fsPromises.realpath(requestedDirectory);
+        if (clientClosed) return undefined;
+        const stats = await fsPromises.stat(canonicalDirectory);
+        if (clientClosed) return undefined;
+        if (!stats.isDirectory()) {
+          return res.status(400).json({ error: 'Watched path is not a directory' });
+        }
+
+        seenRequestedDirectories.add(requestedKey);
+        resolvedDirectories.push({ requestedDirectory, canonicalDirectory });
+      }
+
+      for (const directory of resolvedDirectories) {
+        if (clientClosed) return undefined;
+        subscriptions.push(fsWatcherRuntime.subscribe({
+          ...directory,
+          onChange: (event) => emit({
+            type: 'openchamber:files-changed',
+            properties: event,
+          }),
+          onError: (error) => {
+            watchError = error;
+            close();
+            if (streamReady) res.end?.();
+          },
+        }));
+      }
+
+      if (closed) {
+        throw watchError || new Error('Filesystem watcher closed during startup');
+      }
+
+      res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-cache, no-transform');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no');
+      res.flushHeaders?.();
+      streamReady = true;
+
+      if (!emit({
+        type: 'openchamber:files-watch-ready',
+        properties: {
+          directories: resolvedDirectories.map((entry) => entry.requestedDirectory),
+        },
+      })) return undefined;
+      for (const payload of queuedPayloads.splice(0)) {
+        if (!emit(payload)) return undefined;
+      }
+      heartbeat = setInterval(() => {
+        emit({
+          type: 'openchamber:heartbeat',
+          properties: { timestamp: Date.now() },
+        });
+      }, FS_WATCH_HEARTBEAT_MS);
+      heartbeat.unref?.();
+      return undefined;
+    } catch (error) {
+      close();
+      if (clientClosed || res.writableEnded || res.destroyed) {
+        return undefined;
+      }
+      if (res.headersSent) {
+        res.end?.();
+        return undefined;
+      }
+      if (isOsPermissionError(error)) {
+        return sendOsPermissionDenied(res, 'Access to directory denied');
+      }
+      if (fsWatchNotFoundErrorSchema.safeParse(error).success) {
+        return res.status(404).json({ error: 'Directory not found' });
+      }
+      const parsedError = fsWatchErrorMessageSchema.safeParse(error);
+      const message = parsedError.success ? parsedError.data.message : 'Failed to watch directories';
+      console.error('Failed to watch filesystem directories:', message);
+      return res.status(500).json({ error: message });
+    }
   });
 
   app.get('/api/fs/list', async (req, res) => {

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -1,9 +1,19 @@
 import { createRealpathCache } from '../path-realpath-cache.js';
+import nodeFs from 'node:fs';
 import nodeFsPromises from 'node:fs/promises';
 import nodePath from 'node:path';
+import { z } from 'zod';
+import { createFsWatcherRuntime } from './watcher.js';
 
 const EXEC_JOB_TTL_MS = 30 * 60 * 1000;
 const OUTSIDE_FILE_GRANT_TTL_MS = 10 * 60 * 1000;
+const FS_WATCH_MAX_DIRECTORIES = 64;
+const FS_WATCH_HEARTBEAT_MS = 25_000;
+const fsWatchDirectoriesSchema = z.array(z.string().trim().min(1))
+  .min(1)
+  .max(FS_WATCH_MAX_DIRECTORIES);
+const fsWatchNotFoundErrorSchema = z.object({ code: z.literal('ENOENT') });
+const fsWatchErrorMessageSchema = z.object({ message: z.string().min(1) });
 
 const outsideFileGrants = new Map();
 
@@ -417,6 +427,7 @@ export const registerFsRoutes = (app, dependencies) => {
   const {
     os,
     path,
+    fs = nodeFs,
     fsPromises,
     spawn,
     platform = process.platform,
@@ -426,9 +437,15 @@ export const registerFsRoutes = (app, dependencies) => {
     buildAugmentedPath,
     resolveGitBinaryForSpawn,
     openchamberUserConfigRoot,
+    writeSseEvent,
   } = dependencies;
   const realpathCache = createRealpathCache({
     realpath: fsPromises.realpath.bind(fsPromises),
+  });
+  const fsWatcherRuntime = createFsWatcherRuntime({
+    watch: fs.watch.bind(fs),
+    path,
+    platform,
   });
 
   const spawnDetached = (command, args) => new Promise((resolve, reject) => {
@@ -1443,6 +1460,170 @@ export const registerFsRoutes = (app, dependencies) => {
       success: job.success === true,
       results: Array.isArray(job.results) ? job.results : [],
     });
+  });
+
+  app.get('/api/fs/watch', async (req, res) => {
+    const serializedDirectories = z.string().safeParse(req.query?.directories);
+    if (!serializedDirectories.success) {
+      return res.status(400).json({ error: 'directories must be a JSON array' });
+    }
+    let decodedDirectories;
+    try {
+      decodedDirectories = JSON.parse(serializedDirectories.data);
+    } catch {
+      return res.status(400).json({ error: 'directories must be a JSON array' });
+    }
+    const parsedDirectories = fsWatchDirectoriesSchema.safeParse(decodedDirectories);
+    if (!parsedDirectories.success) {
+      return res.status(400).json({ error: `directories must contain between 1 and ${FS_WATCH_MAX_DIRECTORIES} paths` });
+    }
+    const requestedDirectories = parsedDirectories.data;
+
+    let closed = false;
+    let clientClosed = false;
+    let streamReady = false;
+    let heartbeat = null;
+    let watchError = null;
+    const subscriptions = [];
+    const queuedPayloads = [];
+    const close = () => {
+      if (closed) return;
+      closed = true;
+      if (heartbeat) {
+        clearInterval(heartbeat);
+        heartbeat = null;
+      }
+      for (const subscription of subscriptions.splice(0)) {
+        subscription.close();
+      }
+      queuedPayloads.length = 0;
+    };
+    const handleClientClose = () => {
+      clientClosed = true;
+      close();
+    };
+    const emit = (payload) => {
+      if (closed || res.writableEnded || res.destroyed) {
+        close();
+        return false;
+      }
+      if (!streamReady) {
+        queuedPayloads.push(payload);
+        return true;
+      }
+      try {
+        writeSseEvent(res, payload);
+        return true;
+      } catch {
+        close();
+        res.end?.();
+        return false;
+      }
+    };
+    req.on('close', handleClientClose);
+    res.on?.('error', handleClientClose);
+
+    try {
+      const resolvedDirectories = [];
+      const seenRequestedDirectories = new Set();
+      for (const value of requestedDirectories) {
+        const resolved = await resolveWorkspacePathFromContext({
+          req,
+          targetPath: value,
+          resolveProjectDirectory,
+          path,
+          os,
+          normalizeDirectoryPath,
+          openchamberUserConfigRoot,
+        });
+        if (clientClosed) return undefined;
+        if (!resolved.ok) {
+          return res.status(400).json({ error: resolved.error });
+        }
+
+        const requestedDirectory = path.resolve(resolved.resolved);
+        const requestedKey = platform === 'win32' ? requestedDirectory.toLowerCase() : requestedDirectory;
+        if (seenRequestedDirectories.has(requestedKey)) continue;
+
+        // Watch setup is infrequent and must observe a replaced symlink or a
+        // directory recreated with a new inode. Do not reuse the listing
+        // realpath cache here.
+        const canonicalDirectory = await fsPromises.realpath(requestedDirectory);
+        if (clientClosed) return undefined;
+        const stats = await fsPromises.stat(canonicalDirectory);
+        if (clientClosed) return undefined;
+        if (!stats.isDirectory()) {
+          return res.status(400).json({ error: 'Watched path is not a directory' });
+        }
+
+        seenRequestedDirectories.add(requestedKey);
+        resolvedDirectories.push({ requestedDirectory, canonicalDirectory });
+      }
+
+      for (const directory of resolvedDirectories) {
+        if (clientClosed) return undefined;
+        subscriptions.push(fsWatcherRuntime.subscribe({
+          ...directory,
+          onChange: (event) => emit({
+            type: 'openchamber:files-changed',
+            properties: event,
+          }),
+          onError: (error) => {
+            watchError = error;
+            close();
+            if (streamReady) res.end?.();
+          },
+        }));
+      }
+
+      if (closed) {
+        throw watchError || new Error('Filesystem watcher closed during startup');
+      }
+
+      res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-cache, no-transform');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no');
+      res.flushHeaders?.();
+      streamReady = true;
+
+      if (!emit({
+        type: 'openchamber:files-watch-ready',
+        properties: {
+          directories: resolvedDirectories.map((entry) => entry.requestedDirectory),
+        },
+      })) return undefined;
+      for (const payload of queuedPayloads.splice(0)) {
+        if (!emit(payload)) return undefined;
+      }
+      heartbeat = setInterval(() => {
+        emit({
+          type: 'openchamber:heartbeat',
+          properties: { timestamp: Date.now() },
+        });
+      }, FS_WATCH_HEARTBEAT_MS);
+      heartbeat.unref?.();
+      return undefined;
+    } catch (error) {
+      close();
+      if (clientClosed || res.writableEnded || res.destroyed) {
+        return undefined;
+      }
+      if (res.headersSent) {
+        res.end?.();
+        return undefined;
+      }
+      if (isOsPermissionError(error)) {
+        return sendOsPermissionDenied(res, 'Access to directory denied');
+      }
+      if (fsWatchNotFoundErrorSchema.safeParse(error).success) {
+        return res.status(404).json({ error: 'Directory not found' });
+      }
+      const parsedError = fsWatchErrorMessageSchema.safeParse(error);
+      const message = parsedError.success ? parsedError.data.message : 'Failed to watch directories';
+      console.error('Failed to watch filesystem directories:', message);
+      return res.status(500).json({ error: message });
+    }
   });
 
   app.get('/api/fs/list', async (req, res) => {

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -45,6 +45,12 @@ const createMockResponse = () => {
       headers.set(name.toLowerCase(), value);
       return this;
     },
+    flushHeaders() {
+      return this;
+    },
+    end() {
+      return this;
+    },
     getHeader(name) {
       return headers.get(name.toLowerCase());
     },
@@ -245,6 +251,49 @@ const registerReveal = ({ fsPromises, spawn, platform = 'linux' }) => {
   return getRoute('POST', '/api/fs/reveal');
 };
 
+const registerWatch = ({
+  failDirectory = '',
+  realpath = async (targetPath) => targetPath,
+  writeSseEvent = vi.fn(),
+} = {}) => {
+  const { app, getRoute } = createRouteRegistry();
+  const registrations = [];
+  const watch = vi.fn((directory, options, listener) => {
+    if (directory === failDirectory) {
+      throw new Error('watch failed');
+    }
+    const watcher = {
+      close: vi.fn(),
+      on: vi.fn(() => watcher),
+    };
+    registrations.push({ directory, options, listener, watcher });
+    return watcher;
+  });
+  registerFsRoutes(app, {
+    os: { homedir: () => '/home/user' },
+    path: path.posix,
+    fs: { watch },
+    fsPromises: {
+      realpath,
+      stat: async () => ({ isDirectory: () => true }),
+    },
+    spawn: vi.fn(),
+    crypto: { randomUUID: () => 'job-0' },
+    normalizeDirectoryPath: (p) => p,
+    resolveProjectDirectory: async () => ({ directory: '/repo' }),
+    buildAugmentedPath: () => '/usr/bin',
+    resolveGitBinaryForSpawn: () => 'git',
+    openchamberUserConfigRoot: '/home/user/.config',
+    writeSseEvent,
+  });
+  return {
+    handler: getRoute('GET', '/api/fs/watch'),
+    registrations,
+    watch,
+    writeSseEvent,
+  };
+};
+
 const callExec = async (handler, body) => {
   const res = createMockResponse();
   await handler({ body }, res);
@@ -302,6 +351,121 @@ const callReveal = async (handler, body) => {
   await handler({ body }, res);
   return res;
 };
+
+describe('fs watch', () => {
+  it('streams debounced changes and closes watchers with the client connection', async () => {
+    vi.useFakeTimers();
+    try {
+      const { handler, registrations, watch, writeSseEvent } = registerWatch();
+      expect(handler).toBeTypeOf('function');
+      const req = new EventEmitter();
+      req.query = {
+        directory: '/repo',
+        directories: JSON.stringify(['/repo', '/repo/src']),
+      };
+      const res = createMockResponse();
+
+      await handler(req, res);
+
+      expect(watch).toHaveBeenCalledTimes(2);
+      expect(writeSseEvent).toHaveBeenCalledWith(res, {
+        type: 'openchamber:files-watch-ready',
+        properties: { directories: ['/repo', '/repo/src'] },
+      });
+
+      registrations[1].listener('rename', 'new-file.ts');
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(writeSseEvent).toHaveBeenCalledWith(res, {
+        type: 'openchamber:files-changed',
+        properties: { directory: '/repo/src' },
+      });
+
+      req.emit('close');
+      expect(registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+      expect(registrations[1].watcher.close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects directories outside the active workspace before opening a watcher', async () => {
+    const { handler, watch } = registerWatch();
+    const req = new EventEmitter();
+    req.query = {
+      directory: '/repo',
+      directories: JSON.stringify(['/outside']),
+    };
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Path is outside of active workspace' });
+    expect(watch).not.toHaveBeenCalled();
+  });
+
+  it('closes earlier watchers when a later directory cannot be watched', async () => {
+    const { handler, registrations } = registerWatch({ failDirectory: '/repo/src' });
+    const req = new EventEmitter();
+    req.query = {
+      directory: '/repo',
+      directories: JSON.stringify(['/repo', '/repo/src']),
+    };
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'watch failed' });
+    expect(registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open watchers after the client disconnects during path resolution', async () => {
+    let releaseRealpath;
+    const realpath = vi.fn(() => new Promise((resolve) => {
+      releaseRealpath = resolve;
+    }));
+    const { handler, watch } = registerWatch({ realpath });
+    const req = new EventEmitter();
+    req.query = {
+      directory: '/repo',
+      directories: JSON.stringify(['/repo']),
+    };
+    const res = createMockResponse();
+
+    const pending = handler(req, res);
+    await vi.waitFor(() => expect(realpath).toHaveBeenCalledTimes(1));
+    req.emit('close');
+    releaseRealpath('/repo');
+    await pending;
+
+    expect(watch).not.toHaveBeenCalled();
+  });
+
+  it('does not leave a heartbeat behind when the ready event cannot be written', async () => {
+    vi.useFakeTimers();
+    try {
+      const writeSseEvent = vi.fn(() => {
+        throw new Error('socket closed');
+      });
+      const { handler, registrations } = registerWatch({ writeSseEvent });
+      const req = new EventEmitter();
+      req.query = {
+        directory: '/repo',
+        directories: JSON.stringify(['/repo']),
+      };
+
+      await handler(req, createMockResponse());
+
+      expect(writeSseEvent).toHaveBeenCalledTimes(1);
+      expect(registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe('fs write', () => {
   it('does not rewrite a file when content is unchanged', async () => {

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -46,6 +46,12 @@ const createMockResponse = () => {
       headers.set(name.toLowerCase(), value);
       return this;
     },
+    flushHeaders() {
+      return this;
+    },
+    end() {
+      return this;
+    },
     getHeader(name) {
       return headers.get(name.toLowerCase());
     },
@@ -246,6 +252,49 @@ const registerReveal = ({ fsPromises, spawn, platform = 'linux' }) => {
   return getRoute('POST', '/api/fs/reveal');
 };
 
+const registerWatch = ({
+  failDirectory = '',
+  realpath = async (targetPath) => targetPath,
+  writeSseEvent = vi.fn(),
+} = {}) => {
+  const { app, getRoute } = createRouteRegistry();
+  const registrations = [];
+  const watch = vi.fn((directory, options, listener) => {
+    if (directory === failDirectory) {
+      throw new Error('watch failed');
+    }
+    const watcher = {
+      close: vi.fn(),
+      on: vi.fn(() => watcher),
+    };
+    registrations.push({ directory, options, listener, watcher });
+    return watcher;
+  });
+  registerFsRoutes(app, {
+    os: { homedir: () => '/home/user' },
+    path: path.posix,
+    fs: { watch },
+    fsPromises: {
+      realpath,
+      stat: async () => ({ isDirectory: () => true }),
+    },
+    spawn: vi.fn(),
+    crypto: { randomUUID: () => 'job-0' },
+    normalizeDirectoryPath: (p) => p,
+    resolveProjectDirectory: async () => ({ directory: '/repo' }),
+    buildAugmentedPath: () => '/usr/bin',
+    resolveGitBinaryForSpawn: () => 'git',
+    openchamberUserConfigRoot: '/home/user/.config',
+    writeSseEvent,
+  });
+  return {
+    handler: getRoute('GET', '/api/fs/watch'),
+    registrations,
+    watch,
+    writeSseEvent,
+  };
+};
+
 const callExec = async (handler, body) => {
   const res = createMockResponse();
   await handler({ body }, res);
@@ -303,6 +352,121 @@ const callReveal = async (handler, body) => {
   await handler({ body }, res);
   return res;
 };
+
+describe('fs watch', () => {
+  it('streams debounced changes and closes watchers with the client connection', async () => {
+    vi.useFakeTimers();
+    try {
+      const { handler, registrations, watch, writeSseEvent } = registerWatch();
+      expect(handler).toBeTypeOf('function');
+      const req = new EventEmitter();
+      req.query = {
+        directory: '/repo',
+        directories: JSON.stringify(['/repo', '/repo/src']),
+      };
+      const res = createMockResponse();
+
+      await handler(req, res);
+
+      expect(watch).toHaveBeenCalledTimes(2);
+      expect(writeSseEvent).toHaveBeenCalledWith(res, {
+        type: 'openchamber:files-watch-ready',
+        properties: { directories: ['/repo', '/repo/src'] },
+      });
+
+      registrations[1].listener('rename', 'new-file.ts');
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(writeSseEvent).toHaveBeenCalledWith(res, {
+        type: 'openchamber:files-changed',
+        properties: { directory: '/repo/src' },
+      });
+
+      req.emit('close');
+      expect(registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+      expect(registrations[1].watcher.close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects directories outside the active workspace before opening a watcher', async () => {
+    const { handler, watch } = registerWatch();
+    const req = new EventEmitter();
+    req.query = {
+      directory: '/repo',
+      directories: JSON.stringify(['/outside']),
+    };
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Path is outside of active workspace' });
+    expect(watch).not.toHaveBeenCalled();
+  });
+
+  it('closes earlier watchers when a later directory cannot be watched', async () => {
+    const { handler, registrations } = registerWatch({ failDirectory: '/repo/src' });
+    const req = new EventEmitter();
+    req.query = {
+      directory: '/repo',
+      directories: JSON.stringify(['/repo', '/repo/src']),
+    };
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'watch failed' });
+    expect(registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open watchers after the client disconnects during path resolution', async () => {
+    let releaseRealpath;
+    const realpath = vi.fn(() => new Promise((resolve) => {
+      releaseRealpath = resolve;
+    }));
+    const { handler, watch } = registerWatch({ realpath });
+    const req = new EventEmitter();
+    req.query = {
+      directory: '/repo',
+      directories: JSON.stringify(['/repo']),
+    };
+    const res = createMockResponse();
+
+    const pending = handler(req, res);
+    await vi.waitFor(() => expect(realpath).toHaveBeenCalledTimes(1));
+    req.emit('close');
+    releaseRealpath('/repo');
+    await pending;
+
+    expect(watch).not.toHaveBeenCalled();
+  });
+
+  it('does not leave a heartbeat behind when the ready event cannot be written', async () => {
+    vi.useFakeTimers();
+    try {
+      const writeSseEvent = vi.fn(() => {
+        throw new Error('socket closed');
+      });
+      const { handler, registrations } = registerWatch({ writeSseEvent });
+      const req = new EventEmitter();
+      req.query = {
+        directory: '/repo',
+        directories: JSON.stringify(['/repo']),
+      };
+
+      await handler(req, createMockResponse());
+
+      expect(writeSseEvent).toHaveBeenCalledTimes(1);
+      expect(registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe('fs write', () => {
   it('does not rewrite a file when content is unchanged', async () => {

--- a/packages/web/server/lib/fs/watcher.js
+++ b/packages/web/server/lib/fs/watcher.js
@@ -1,0 +1,155 @@
+import nodeFs from 'node:fs';
+import nodePath from 'node:path';
+import { z } from 'zod';
+
+const nonEmptyStringSchema = z.string().trim().min(1);
+const callbackSchema = z.function();
+const errorCodeSchema = z.object({ code: z.string() });
+
+const asDirectory = (value, path) => {
+  const parsed = nonEmptyStringSchema.safeParse(value);
+  return parsed.success ? path.resolve(parsed.data) : '';
+};
+
+const watcherKey = (directory, platform) => (
+  platform === 'win32' ? directory.toLowerCase() : directory
+);
+
+export const createFsWatcherRuntime = ({
+  watch = nodeFs.watch,
+  path = nodePath,
+  platform = process.platform,
+  debounceMs = 250,
+  maxWaitMs = 1000,
+  logger = console,
+} = {}) => {
+  const entries = new Map();
+  let nextSubscriberId = 1;
+
+  const closeEntry = (entry) => {
+    if (entry.closed) return;
+    entry.closed = true;
+    if (entry.debounceTimer) {
+      clearTimeout(entry.debounceTimer);
+      entry.debounceTimer = null;
+    }
+    if (entry.maxWaitTimer) {
+      clearTimeout(entry.maxWaitTimer);
+      entry.maxWaitTimer = null;
+    }
+    entries.delete(entry.key);
+    try {
+      entry.watcher.close();
+    } catch {
+    }
+  };
+
+  const flush = (entry) => {
+    if (entry.closed) return;
+    if (entry.debounceTimer) {
+      clearTimeout(entry.debounceTimer);
+      entry.debounceTimer = null;
+    }
+    if (entry.maxWaitTimer) {
+      clearTimeout(entry.maxWaitTimer);
+      entry.maxWaitTimer = null;
+    }
+    if (!entry.dirty) return;
+    entry.dirty = false;
+
+    for (const subscriber of entry.subscribers.values()) {
+      try {
+        subscriber.onChange({ directory: subscriber.requestedDirectory });
+      } catch {
+      }
+    }
+  };
+
+  const scheduleFlush = (entry) => {
+    if (entry.closed) return;
+    if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+    entry.debounceTimer = setTimeout(() => flush(entry), debounceMs);
+    entry.debounceTimer.unref?.();
+    if (!entry.maxWaitTimer) {
+      entry.maxWaitTimer = setTimeout(() => flush(entry), maxWaitMs);
+      entry.maxWaitTimer.unref?.();
+    }
+  };
+
+  const createEntry = (canonicalDirectory, key) => {
+    const entry = {
+      key,
+      canonicalDirectory,
+      watcher: null,
+      subscribers: new Map(),
+      dirty: false,
+      debounceTimer: null,
+      maxWaitTimer: null,
+      closed: false,
+    };
+
+    entry.watcher = watch(canonicalDirectory, { persistent: false }, () => {
+      entry.dirty = true;
+      scheduleFlush(entry);
+    });
+    entry.watcher.on?.('error', (error) => {
+      entry.dirty = true;
+      flush(entry);
+      for (const subscriber of entry.subscribers.values()) {
+        try {
+          subscriber.onError?.(error);
+        } catch {
+        }
+      }
+      const parsedError = errorCodeSchema.safeParse(error);
+      const errorCode = parsedError.success ? parsedError.data.code : '';
+      logger.warn?.(`[fs-watch] watcher stopped${errorCode ? ` (${errorCode})` : ''}`);
+      closeEntry(entry);
+    });
+
+    entries.set(key, entry);
+    return entry;
+  };
+
+  const subscribe = ({ canonicalDirectory, requestedDirectory, onChange, onError }) => {
+    const canonical = asDirectory(canonicalDirectory, path);
+    const requested = asDirectory(requestedDirectory, path);
+    if (!canonical || !requested) {
+      throw new Error('Filesystem watcher directories are required');
+    }
+    if (!callbackSchema.safeParse(onChange).success) {
+      throw new Error('Filesystem watcher onChange callback is required');
+    }
+
+    const key = watcherKey(canonical, platform);
+    const entry = entries.get(key) ?? createEntry(canonical, key);
+    const subscriberId = nextSubscriberId;
+    nextSubscriberId += 1;
+    entry.subscribers.set(subscriberId, {
+      requestedDirectory: requested,
+      onChange,
+      onError,
+    });
+
+    let closed = false;
+    return {
+      close() {
+        if (closed) return;
+        closed = true;
+        entry.subscribers.delete(subscriberId);
+        if (entry.subscribers.size === 0 && entries.get(key) === entry) {
+          closeEntry(entry);
+        }
+      },
+    };
+  };
+
+  return {
+    subscribe,
+    close() {
+      for (const entry of Array.from(entries.values())) {
+        closeEntry(entry);
+      }
+    },
+  };
+};

--- a/packages/web/server/lib/fs/watcher.test.js
+++ b/packages/web/server/lib/fs/watcher.test.js
@@ -1,0 +1,190 @@
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createFsWatcherRuntime } from './watcher.js';
+
+const createWatchHarness = () => {
+  const registrations = [];
+  const watch = vi.fn((directory, options, listener) => {
+    const handlers = new Map();
+    const watcher = {
+      close: vi.fn(),
+      on: vi.fn((event, handler) => {
+        handlers.set(event, handler);
+        return watcher;
+      }),
+    };
+    registrations.push({ directory, options, listener, handlers, watcher });
+    return watcher;
+  });
+  return { registrations, watch };
+};
+
+describe('fs watcher runtime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shares one watcher and batches directory invalidations in each requested path space', async () => {
+    vi.useFakeTimers();
+    const harness = createWatchHarness();
+    const runtime = createFsWatcherRuntime({
+      watch: harness.watch,
+      path: path.posix,
+      debounceMs: 250,
+    });
+    const firstEvents = [];
+    const secondEvents = [];
+
+    const first = runtime.subscribe({
+      canonicalDirectory: '/real/project/src',
+      requestedDirectory: '/project/src',
+      onChange: (event) => firstEvents.push(event),
+    });
+    const second = runtime.subscribe({
+      canonicalDirectory: '/real/project/src',
+      requestedDirectory: '/linked/src',
+      onChange: (event) => secondEvents.push(event),
+    });
+
+    expect(harness.watch).toHaveBeenCalledTimes(1);
+    expect(harness.watch).toHaveBeenCalledWith(
+      '/real/project/src',
+      { persistent: false },
+      expect.any(Function),
+    );
+
+    harness.registrations[0].listener('rename', 'new-file.ts');
+    harness.registrations[0].listener('change', 'changed-file.ts');
+    harness.registrations[0].listener('change', 'changed-file.ts');
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(firstEvents).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(firstEvents).toEqual([{ directory: '/project/src' }]);
+    expect(secondEvents).toEqual([{ directory: '/linked/src' }]);
+
+    first.close();
+    expect(harness.registrations[0].watcher.close).not.toHaveBeenCalled();
+    second.close();
+    expect(harness.registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares Windows watcher identities case-insensitively, including UNC paths', () => {
+    const harness = createWatchHarness();
+    const runtime = createFsWatcherRuntime({
+      watch: harness.watch,
+      path: path.win32,
+      platform: 'win32',
+    });
+
+    const first = runtime.subscribe({
+      canonicalDirectory: '\\\\Server\\Share\\Repo',
+      requestedDirectory: '\\\\Server\\Share\\Repo',
+      onChange: () => undefined,
+    });
+    const second = runtime.subscribe({
+      canonicalDirectory: '\\\\server\\share\\repo',
+      requestedDirectory: '\\\\server\\share\\repo',
+      onChange: () => undefined,
+    });
+
+    expect(harness.watch).toHaveBeenCalledTimes(1);
+    first.close();
+    expect(harness.registrations[0].watcher.close).not.toHaveBeenCalled();
+    second.close();
+    expect(harness.registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps case-distinct POSIX directories as separate watcher identities', () => {
+    const harness = createWatchHarness();
+    const runtime = createFsWatcherRuntime({
+      watch: harness.watch,
+      path: path.posix,
+      platform: 'darwin',
+    });
+
+    runtime.subscribe({
+      canonicalDirectory: '/Users/me/Repo',
+      requestedDirectory: '/Users/me/Repo',
+      onChange: () => undefined,
+    });
+    runtime.subscribe({
+      canonicalDirectory: '/Users/me/repo',
+      requestedDirectory: '/Users/me/repo',
+      onChange: () => undefined,
+    });
+
+    expect(harness.watch).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates the watched directory when the platform omits a filename', async () => {
+    vi.useFakeTimers();
+    const harness = createWatchHarness();
+    const runtime = createFsWatcherRuntime({
+      watch: harness.watch,
+      path: path.posix,
+      debounceMs: 250,
+    });
+    const events = [];
+
+    const subscription = runtime.subscribe({
+      canonicalDirectory: '/repo',
+      requestedDirectory: '/repo',
+      onChange: (event) => events.push(event),
+    });
+    harness.registrations[0].listener('rename', null);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(events).toEqual([{ directory: '/repo' }]);
+
+    subscription.close();
+  });
+
+  it('flushes a continuous event stream within the maximum batch delay', async () => {
+    vi.useFakeTimers();
+    const harness = createWatchHarness();
+    const runtime = createFsWatcherRuntime({
+      watch: harness.watch,
+      path: path.posix,
+      debounceMs: 250,
+      maxWaitMs: 1000,
+    });
+    const events = [];
+
+    runtime.subscribe({
+      canonicalDirectory: '/repo',
+      requestedDirectory: '/repo',
+      onChange: (event) => events.push(event),
+    });
+
+    harness.registrations[0].listener('change', 'file-0.ts');
+    for (let index = 1; index <= 4; index += 1) {
+      await vi.advanceTimersByTimeAsync(200);
+      harness.registrations[0].listener('change', `file-${index}.ts`);
+    }
+    await vi.advanceTimersByTimeAsync(199);
+    expect(events).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(events).toEqual([{ directory: '/repo' }]);
+  });
+
+  it('closes an entry once when an error callback closes its subscription', () => {
+    const harness = createWatchHarness();
+    const runtime = createFsWatcherRuntime({ watch: harness.watch, path: path.posix });
+    let subscription;
+    subscription = runtime.subscribe({
+      canonicalDirectory: '/repo',
+      requestedDirectory: '/repo',
+      onChange: () => undefined,
+      onError: () => subscription.close(),
+    });
+
+    harness.registrations[0].handlers.get('error')(Object.assign(new Error('deleted'), { code: 'EPERM' }));
+
+    expect(harness.registrations[0].watcher.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/server/lib/opencode/feature-routes-runtime.js
+++ b/packages/web/server/lib/opencode/feature-routes-runtime.js
@@ -319,6 +319,7 @@ export const createFeatureRoutesRuntime = (dependencies) => {
     registerFsRoutes(app, {
       os,
       path,
+      fs,
       fsPromises,
       spawn,
       crypto,
@@ -327,6 +328,7 @@ export const createFeatureRoutesRuntime = (dependencies) => {
       buildAugmentedPath,
       resolveGitBinaryForSpawn,
       openchamberUserConfigRoot,
+      writeSseEvent,
     });
   };
 

--- a/packages/web/server/lib/opencode/feature-routes-runtime.js
+++ b/packages/web/server/lib/opencode/feature-routes-runtime.js
@@ -321,6 +321,7 @@ export const createFeatureRoutesRuntime = (dependencies) => {
     registerFsRoutes(app, {
       os,
       path,
+      fs,
       fsPromises,
       spawn,
       crypto,
@@ -329,6 +330,7 @@ export const createFeatureRoutesRuntime = (dependencies) => {
       buildAugmentedPath,
       resolveGitBinaryForSpawn,
       openchamberUserConfigRoot,
+      writeSseEvent,
     });
   };
 

--- a/packages/web/server/lib/realtime-proxy.js
+++ b/packages/web/server/lib/realtime-proxy.js
@@ -7,7 +7,8 @@ const isAllowedSsePath = (pathname) => {
   return pathname === '/api/event'
     || pathname === '/api/global/event'
     || pathname === '/api/openchamber/events'
-    || pathname === '/api/notifications/stream';
+    || pathname === '/api/notifications/stream'
+    || pathname === '/api/fs/watch';
 };
 
 const isAllowedWebSocketPath = (pathname) => {

--- a/packages/web/server/lib/realtime-proxy.test.js
+++ b/packages/web/server/lib/realtime-proxy.test.js
@@ -126,6 +126,25 @@ describe('realtime proxy', () => {
     }
   });
 
+  it('allows filesystem watcher SSE for remote runtimes', async () => {
+    const upstream = await startSseUpstream({ path: '/api/fs/watch' });
+    const { origin, runtime } = await startProxyServer({ apiBaseUrl: upstream.origin });
+
+    try {
+      const target = `${upstream.origin}/api/fs/watch?directory=%2Frepo&directories=%5B%22%2Frepo%22%5D`;
+      const response = await fetch(buildRealtimeProxySseUrl(origin, target), {
+        headers: { Origin: 'openchamber-ui://app' },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe('data: first\n\ndata: second\n\n');
+      expect(upstream.requests).toHaveLength(1);
+      expect(upstream.requests[0].headers['x-proxy-auth']).toBe('secret');
+    } finally {
+      runtime.stop();
+    }
+  });
+
   it('rejects unauthenticated SSE proxy requests', async () => {
     const upstream = await startSseUpstream();
     const { origin, runtime } = await startProxyServer({ apiBaseUrl: upstream.origin, authToken: null });

--- a/packages/web/server/lib/ui-auth/DOCUMENTATION.md
+++ b/packages/web/server/lib/ui-auth/DOCUMENTATION.md
@@ -42,3 +42,7 @@ Pairing v2 is implemented by `packages/web/server/lib/client-auth/pairing.js`. I
   - `beginAuthentication(req)`
   - `finishAuthentication(payload)`
   - `dispose()`
+
+## URL authentication boundary
+
+Browser APIs that cannot attach an authorization header use a short-lived `oc_url_token`. The controller accepts that token only for the explicit read-only asset and realtime allowlists in `ui-auth.js`; arbitrary API reads and every HTTP mutation still require normal session or bearer authentication. Filesystem watcher SSE uses this boundary through `GET /api/fs/watch`, matching the existing raw-file, notification, and global-event streams.

--- a/packages/web/server/lib/ui-auth/ui-auth.js
+++ b/packages/web/server/lib/ui-auth/ui-auth.js
@@ -298,6 +298,7 @@ const isUrlAuthReadableHttpPath = (pathname) => {
     || pathname === '/api/openchamber/realtime-proxy/sse'
     || pathname === '/api/notifications/stream'
     || pathname === '/api/fs/raw'
+    || pathname === '/api/fs/watch'
     || pathname === '/api/fs/serve'
     || pathname.startsWith('/api/fs/serve/')
     || pathname.startsWith('/api/preview/proxy/')

--- a/packages/web/server/lib/ui-auth/ui-auth.test.js
+++ b/packages/web/server/lib/ui-auth/ui-auth.test.js
@@ -182,6 +182,19 @@ describe('ui auth client credential seam', () => {
     expect(await auth.ensureSessionToken(urlReq, urlRes)).toBe('client:device-1');
     expect(await auth.resolveAuthContext(urlReq, urlRes, { allowUrlToken: false })).toBe(null);
 
+    const watchReq = {
+      method: 'GET',
+      path: '/api/fs/watch',
+      url: `/api/fs/watch?directory=%2Frepo&directories=%5B%22%2Frepo%22%5D&oc_url_token=${encodeURIComponent(urlToken)}`,
+      headers: { accept: 'text/event-stream' },
+    };
+    const watchRes = createResponse();
+    let watchCalled = false;
+    await auth.requireAuth(watchReq, watchRes, () => {
+      watchCalled = true;
+    });
+    expect(watchCalled).toBe(true);
+
     const serveReq = { method: 'GET', path: '/api/fs/serve/tmp/index.html', url: `/api/fs/serve/tmp/index.html?oc_url_token=${encodeURIComponent(urlToken)}`, headers: {} };
     const serveRes = createResponse();
     let serveCalled = false;

--- a/packages/web/src/api/files.test.ts
+++ b/packages/web/src/api/files.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { FileChangeEvent } from '@openchamber/ui/lib/api/types';
 import type { RuntimeUrlQuery, RuntimeUrlResolver } from '@openchamber/ui/lib/runtime-url';
 
 const runtimeFetchMock = vi.fn();
@@ -28,7 +29,252 @@ const urls: RuntimeUrlResolver = {
   websocket: toUrl,
 };
 
+const watchUrlAuth = {
+  acquire: () => () => undefined,
+  subscribe: () => () => undefined,
+};
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
 describe('createWebFilesAPI', () => {
+  it('subscribes to scoped filesystem changes and closes the stream', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+    const events: FileChangeEvent[] = [];
+    const onReady = vi.fn();
+    const onError = vi.fn();
+
+    const subscription = api.watchDirectories?.(
+      '/workspace',
+      ['/workspace', '/workspace/src', '/workspace/src'],
+      {
+        onChange: (event) => events.push(event),
+        onReady,
+        onError,
+      },
+    );
+
+    expect(subscription).toBeDefined();
+    expect(MockEventSource.instances).toHaveLength(1);
+    const source = MockEventSource.instances[0];
+    const url = new URL(source.url, 'http://runtime.test');
+    expect(url.pathname).toBe('/api/fs/watch');
+    expect(url.searchParams.get('directory')).toBe('/workspace');
+    expect(JSON.parse(url.searchParams.get('directories') || '[]')).toEqual([
+      '/workspace',
+      '/workspace/src',
+    ]);
+
+    source.onmessage?.({
+      data: JSON.stringify({ type: 'openchamber:files-watch-ready', properties: {} }),
+    });
+    expect(onReady).toHaveBeenCalledTimes(1);
+
+    source.onmessage?.({
+      data: JSON.stringify({
+        type: 'openchamber:files-changed',
+        properties: { directory: '/workspace/src' },
+      }),
+    });
+
+    expect(events).toEqual([{ directory: '/workspace/src' }]);
+
+    source.onerror?.();
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    subscription?.close();
+    expect(source.closed).toBe(true);
+  });
+
+  it('reconnects failed watcher streams with bounded exponential backoff', async () => {
+    vi.useFakeTimers();
+    try {
+      const { createWebFilesAPI } = await import('./files');
+      MockEventSource.instances = [];
+      vi.stubGlobal('EventSource', MockEventSource);
+      const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+      const onError = vi.fn();
+      const subscription = api.watchDirectories?.('/workspace', ['/workspace'], {
+        onChange: () => undefined,
+        onError,
+      });
+
+      const first = MockEventSource.instances[0];
+      first.onerror?.();
+      expect(first.closed).toBe(true);
+      expect(onError).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(MockEventSource.instances).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(MockEventSource.instances).toHaveLength(2);
+
+      const second = MockEventSource.instances[1];
+      second.onerror?.();
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(MockEventSource.instances).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(MockEventSource.instances).toHaveLength(3);
+
+      MockEventSource.instances[2].onmessage?.({
+        data: JSON.stringify({ type: 'openchamber:files-watch-ready', properties: {} }),
+      });
+      MockEventSource.instances[2].onerror?.();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(MockEventSource.instances).toHaveLength(4);
+
+      subscription?.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses the long retry delay while hidden and reconnects when visible again', async () => {
+    vi.useFakeTimers();
+    try {
+      const { createWebFilesAPI } = await import('./files');
+      MockEventSource.instances = [];
+      vi.stubGlobal('EventSource', MockEventSource);
+      let emitVisibility: () => void = () => undefined;
+      const documentStub = {
+        hidden: true,
+        addEventListener: vi.fn((event: string, listener: () => void) => {
+          if (event === 'visibilitychange') emitVisibility = listener;
+        }),
+        removeEventListener: vi.fn(),
+      };
+      vi.stubGlobal('document', documentStub);
+      vi.stubGlobal('window', {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      });
+      vi.stubGlobal('navigator', { onLine: true });
+      const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+      const subscription = api.watchDirectories?.('/workspace', ['/workspace'], {
+        onChange: () => undefined,
+      });
+
+      MockEventSource.instances[0].onerror?.();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(MockEventSource.instances).toHaveLength(1);
+
+      documentStub.hidden = false;
+      emitVisibility();
+      expect(MockEventSource.instances).toHaveLength(2);
+
+      subscription?.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the watcher lifecycle limited to closing the subscription', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+    const subscription = api.watchDirectories?.('/workspace', ['/workspace'], {
+      onChange: () => undefined,
+    });
+
+    expect(subscription).toBeDefined();
+    expect(subscription).not.toHaveProperty('restart');
+    subscription?.close();
+  });
+
+  it('rebinds on URL-token replacement and releases the auth lease on close', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const release = vi.fn();
+    const unsubscribe = vi.fn();
+    let notifyTokenChanged: () => void = () => undefined;
+    const api = createWebFilesAPI({
+      urls,
+      getDirectory: () => '/workspace',
+      watchUrlAuth: {
+        acquire: () => release,
+        subscribe: (listener) => {
+          notifyTokenChanged = listener;
+          return unsubscribe;
+        },
+      },
+    });
+    const subscription = api.watchDirectories?.('/workspace', ['/workspace'], {
+      onChange: () => undefined,
+    });
+
+    notifyTokenChanged();
+    expect(MockEventSource.instances[0].closed).toBe(true);
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    subscription?.close();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back instead of opening an oversized watcher subscription', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+    const directories = Array.from({ length: 65 }, (_, index) => `/workspace/dir-${index}`);
+
+    const subscription = api.watchDirectories?.('/workspace', directories, { onChange: () => undefined });
+
+    expect(subscription).toBeNull();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('falls back when the watcher URL would exceed the bounded request size', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+    const directories = Array.from(
+      { length: 64 },
+      (_, index) => `/workspace/${String(index).padStart(2, '0')}-${'nested'.repeat(40)}`,
+    );
+
+    const subscription = api.watchDirectories?.('/workspace', directories, { onChange: () => undefined });
+
+    expect(subscription).toBeNull();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('preserves a Windows drive root in watcher URLs', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => 'C:/', watchUrlAuth });
+
+    const subscription = api.watchDirectories?.('C:/', ['C:/', 'C:/Users'], {
+      onChange: () => undefined,
+    });
+
+    expect(subscription).toBeDefined();
+    const url = new URL(MockEventSource.instances[0].url, 'http://runtime.test');
+    expect(url.searchParams.get('directory')).toBe('C:/');
+    expect(JSON.parse(url.searchParams.get('directories') || '[]')).toEqual(['C:/', 'C:/Users']);
+    subscription?.close();
+  });
+
   it('preserves the directory permission failure contract', async () => {
     const { createWebFilesAPI } = await import('./files');
     const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace' });

--- a/packages/web/src/api/files.test.ts
+++ b/packages/web/src/api/files.test.ts
@@ -28,7 +28,252 @@ const urls: RuntimeUrlResolver = {
   websocket: toUrl,
 };
 
+const watchUrlAuth = {
+  acquire: () => () => undefined,
+  subscribe: () => () => undefined,
+};
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
 describe('createWebFilesAPI', () => {
+  it('subscribes to scoped filesystem changes and closes the stream', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+    const events: unknown[] = [];
+    const onReady = vi.fn();
+    const onError = vi.fn();
+
+    const subscription = api.watchDirectories?.(
+      '/workspace',
+      ['/workspace', '/workspace/src', '/workspace/src'],
+      {
+        onChange: (event) => events.push(event),
+        onReady,
+        onError,
+      },
+    );
+
+    expect(subscription).toBeDefined();
+    expect(MockEventSource.instances).toHaveLength(1);
+    const source = MockEventSource.instances[0];
+    const url = new URL(source.url, 'http://runtime.test');
+    expect(url.pathname).toBe('/api/fs/watch');
+    expect(url.searchParams.get('directory')).toBe('/workspace');
+    expect(JSON.parse(url.searchParams.get('directories') || '[]')).toEqual([
+      '/workspace',
+      '/workspace/src',
+    ]);
+
+    source.onmessage?.({
+      data: JSON.stringify({ type: 'openchamber:files-watch-ready', properties: {} }),
+    });
+    expect(onReady).toHaveBeenCalledTimes(1);
+
+    source.onmessage?.({
+      data: JSON.stringify({
+        type: 'openchamber:files-changed',
+        properties: { directory: '/workspace/src' },
+      }),
+    });
+
+    expect(events).toEqual([{ directory: '/workspace/src' }]);
+
+    source.onerror?.();
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    subscription?.close();
+    expect(source.closed).toBe(true);
+  });
+
+  it('reconnects failed watcher streams with bounded exponential backoff', async () => {
+    vi.useFakeTimers();
+    try {
+      const { createWebFilesAPI } = await import('./files');
+      MockEventSource.instances = [];
+      vi.stubGlobal('EventSource', MockEventSource);
+      const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+      const onError = vi.fn();
+      const subscription = api.watchDirectories?.('/workspace', ['/workspace'], {
+        onChange: () => undefined,
+        onError,
+      });
+
+      const first = MockEventSource.instances[0];
+      first.onerror?.();
+      expect(first.closed).toBe(true);
+      expect(onError).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(MockEventSource.instances).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(MockEventSource.instances).toHaveLength(2);
+
+      const second = MockEventSource.instances[1];
+      second.onerror?.();
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(MockEventSource.instances).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(MockEventSource.instances).toHaveLength(3);
+
+      MockEventSource.instances[2].onmessage?.({
+        data: JSON.stringify({ type: 'openchamber:files-watch-ready', properties: {} }),
+      });
+      MockEventSource.instances[2].onerror?.();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(MockEventSource.instances).toHaveLength(4);
+
+      subscription?.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses the long retry delay while hidden and reconnects when visible again', async () => {
+    vi.useFakeTimers();
+    try {
+      const { createWebFilesAPI } = await import('./files');
+      MockEventSource.instances = [];
+      vi.stubGlobal('EventSource', MockEventSource);
+      let emitVisibility: () => void = () => undefined;
+      const documentStub = {
+        hidden: true,
+        addEventListener: vi.fn((event: string, listener: () => void) => {
+          if (event === 'visibilitychange') emitVisibility = listener;
+        }),
+        removeEventListener: vi.fn(),
+      };
+      vi.stubGlobal('document', documentStub);
+      vi.stubGlobal('window', {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      });
+      vi.stubGlobal('navigator', { onLine: true });
+      const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+      const subscription = api.watchDirectories?.('/workspace', ['/workspace'], {
+        onChange: () => undefined,
+      });
+
+      MockEventSource.instances[0].onerror?.();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(MockEventSource.instances).toHaveLength(1);
+
+      documentStub.hidden = false;
+      emitVisibility();
+      expect(MockEventSource.instances).toHaveLength(2);
+
+      subscription?.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the watcher lifecycle limited to closing the subscription', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+    const subscription = api.watchDirectories?.('/workspace', ['/workspace'], {
+      onChange: () => undefined,
+    });
+
+    expect(subscription).toBeDefined();
+    expect(subscription).not.toHaveProperty('restart');
+    subscription?.close();
+  });
+
+  it('rebinds on URL-token replacement and releases the auth lease on close', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const release = vi.fn();
+    const unsubscribe = vi.fn();
+    let notifyTokenChanged: () => void = () => undefined;
+    const api = createWebFilesAPI({
+      urls,
+      getDirectory: () => '/workspace',
+      watchUrlAuth: {
+        acquire: () => release,
+        subscribe: (listener) => {
+          notifyTokenChanged = listener;
+          return unsubscribe;
+        },
+      },
+    });
+    const subscription = api.watchDirectories?.('/workspace', ['/workspace'], {
+      onChange: () => undefined,
+    });
+
+    notifyTokenChanged();
+    expect(MockEventSource.instances[0].closed).toBe(true);
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    subscription?.close();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back instead of opening an oversized watcher subscription', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+    const directories = Array.from({ length: 65 }, (_, index) => `/workspace/dir-${index}`);
+
+    const subscription = api.watchDirectories?.('/workspace', directories, { onChange: () => undefined });
+
+    expect(subscription).toBeNull();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('falls back when the watcher URL would exceed the bounded request size', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace', watchUrlAuth });
+    const directories = Array.from(
+      { length: 64 },
+      (_, index) => `/workspace/${String(index).padStart(2, '0')}-${'nested'.repeat(40)}`,
+    );
+
+    const subscription = api.watchDirectories?.('/workspace', directories, { onChange: () => undefined });
+
+    expect(subscription).toBeNull();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('preserves a Windows drive root in watcher URLs', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    const api = createWebFilesAPI({ urls, getDirectory: () => 'C:/', watchUrlAuth });
+
+    const subscription = api.watchDirectories?.('C:/', ['C:/', 'C:/Users'], {
+      onChange: () => undefined,
+    });
+
+    expect(subscription).toBeDefined();
+    const url = new URL(MockEventSource.instances[0].url, 'http://runtime.test');
+    expect(url.searchParams.get('directory')).toBe('C:/');
+    expect(JSON.parse(url.searchParams.get('directories') || '[]')).toEqual(['C:/', 'C:/Users']);
+    subscription?.close();
+  });
+
   it('preserves the directory permission failure contract', async () => {
     const { createWebFilesAPI } = await import('./files');
     const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace' });

--- a/packages/web/src/api/files.ts
+++ b/packages/web/src/api/files.ts
@@ -1,22 +1,100 @@
 import type {
   DirectoryListResult,
+  FileChangeEvent,
+  FileWatchHandlers,
   FileSearchQuery,
   FileSearchResult,
   FilesAPI,
 } from '@openchamber/ui/lib/api/types';
+import type { RuntimeUrlResolver } from '@openchamber/ui/lib/runtime-url';
 import {
   FilesystemError,
   parseFilesystemErrorReason,
   type FilesystemErrorReason,
 } from '@openchamber/ui/lib/api/files-errors';
 import { runtimeFetch } from '@openchamber/ui/lib/runtime-fetch';
+import { getRuntimeUrlResolver } from '@openchamber/ui/lib/runtime-url';
+import { subscribeRuntimeEndpointChanged } from '@openchamber/ui/lib/runtime-switch';
+import {
+  acquireRuntimeUrlAuthToken,
+  subscribeRuntimeUrlAuthToken,
+} from '@openchamber/ui/lib/runtime-auth';
+import {
+  getFileTreePathIdentity,
+  isFileTreePathWithinRoot,
+  normalizeFileTreePath,
+} from '@openchamber/ui/lib/fileTreePath';
+import { z } from 'zod';
 
 const normalizePath = (path: string): string => path.replace(/\\/g, '/');
+const MAX_WATCHED_DIRECTORIES = 64;
+const MAX_WATCH_URL_LENGTH = 12_000;
+const WATCH_RECONNECT_BASE_MS = 1_000;
+const WATCH_RECONNECT_MAX_MS = 30_000;
+const WATCH_RECONNECT_INACTIVE_MS = 60_000;
+
+const collectWatchedDirectories = (workspaceDirectory: string, directories: string[]): string[] => {
+  const workspace = normalizeFileTreePath(workspaceDirectory);
+  const seen = new Set<string>();
+  const watched: string[] = [];
+
+  for (const value of directories) {
+    const directory = normalizeFileTreePath(value);
+    const key = getFileTreePathIdentity(directory);
+    if (!directory || seen.has(key)) continue;
+    if (!isFileTreePathWithinRoot(directory, workspace)) continue;
+    seen.add(key);
+    watched.push(directory);
+  }
+
+  return watched;
+};
+
+const fileChangeEnvelopeSchema = z.object({
+  type: z.literal('openchamber:files-changed'),
+  properties: z.object({
+    directory: z.string().min(1),
+  }),
+});
+const fileWatchReadyEnvelopeSchema = z.object({
+  type: z.literal('openchamber:files-watch-ready'),
+});
+
+const isFileWatchReadyEvent = (raw: string): boolean => {
+  try {
+    return fileWatchReadyEnvelopeSchema.safeParse(JSON.parse(raw)).success;
+  } catch {
+    return false;
+  }
+};
+
+const parseFileChangeEvent = (raw: string, watchedDirectoryKeys: Set<string>): FileChangeEvent | null => {
+  try {
+    const parsed = fileChangeEnvelopeSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) return null;
+    const directory = normalizeFileTreePath(parsed.data.properties.directory);
+    if (!directory || !watchedDirectoryKeys.has(getFileTreePathIdentity(directory))) return null;
+    return { directory };
+  } catch {
+    return null;
+  }
+};
+
+interface FileWatchUrlAuth {
+  acquire: () => () => void;
+  subscribe: (listener: () => void) => () => void;
+}
 
 interface WebFilesAPIOptions {
-  urls?: unknown;
+  urls?: RuntimeUrlResolver;
   getDirectory?: () => string | undefined;
+  watchUrlAuth?: FileWatchUrlAuth;
 }
+
+const defaultWatchUrlAuth: FileWatchUrlAuth = {
+  acquire: () => acquireRuntimeUrlAuthToken(),
+  subscribe: (listener: () => void) => subscribeRuntimeUrlAuthToken(listener),
+};
 
 type WebDirectoryEntry = {
   name?: string;
@@ -66,7 +144,11 @@ const directoryHeaders = (getDirectory?: () => string | undefined, override?: st
   return directory ? { 'x-opencode-directory': directory } : undefined;
 };
 
-export const createWebFilesAPI = ({ getDirectory }: WebFilesAPIOptions): FilesAPI => ({
+export const createWebFilesAPI = ({
+  urls,
+  getDirectory,
+  watchUrlAuth = defaultWatchUrlAuth,
+}: WebFilesAPIOptions): FilesAPI => ({
   async listDirectory(path: string, options): Promise<DirectoryListResult> {
     const target = normalizePath(path);
     const params = new URLSearchParams();
@@ -98,6 +180,138 @@ export const createWebFilesAPI = ({ getDirectory }: WebFilesAPIOptions): FilesAP
 
     const result = (await response.json()) as WebDirectoryListResponse;
     return toDirectoryListResult(target, result);
+  },
+
+  watchDirectories(workspaceDirectory, directories, handlers: FileWatchHandlers) {
+    const EventSourceConstructor = globalThis.EventSource;
+    if (!EventSourceConstructor) return null;
+    const workspace = normalizeFileTreePath(workspaceDirectory);
+    const watched = collectWatchedDirectories(workspace, directories);
+    if (!workspace || watched.length === 0 || watched.length > MAX_WATCHED_DIRECTORIES) return null;
+
+    const query = new URLSearchParams({
+      directory: workspace,
+      directories: JSON.stringify(watched),
+    });
+    const watchedDirectoryKeys = new Set(watched.map(getFileTreePathIdentity));
+    const resolveWatchUrl = () => (urls ?? getRuntimeUrlResolver()).sse('/api/fs/watch', query);
+    if (resolveWatchUrl().length > MAX_WATCH_URL_LENGTH) return null;
+    const releaseUrlAuth = watchUrlAuth.acquire();
+
+    let closed = false;
+    let failures = 0;
+    let source: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearReconnectTimer = () => {
+      if (!reconnectTimer) return;
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    };
+    const closeSource = () => {
+      source?.close();
+      source = null;
+    };
+    const isInactive = () => (
+      globalThis.document?.hidden === true
+      || globalThis.navigator?.onLine === false
+    );
+    const scheduleReconnect = () => {
+      if (closed || reconnectTimer) return;
+      const exponentialDelay = Math.min(
+        WATCH_RECONNECT_BASE_MS * (2 ** Math.min(failures, 5)),
+        WATCH_RECONNECT_MAX_MS,
+      );
+      const delay = isInactive()
+        ? Math.max(exponentialDelay, WATCH_RECONNECT_INACTIVE_MS)
+        : exponentialDelay;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, delay);
+    };
+    const connect = () => {
+      if (closed || source) return;
+      let watchUrl = '';
+      try {
+        watchUrl = resolveWatchUrl();
+      } catch {
+        failures += 1;
+        handlers.onError?.();
+        scheduleReconnect();
+        return;
+      }
+      if (watchUrl.length > MAX_WATCH_URL_LENGTH) {
+        failures += 1;
+        handlers.onError?.();
+        scheduleReconnect();
+        return;
+      }
+      let nextSource: EventSource;
+      try {
+        nextSource = new EventSourceConstructor(watchUrl);
+      } catch {
+        failures += 1;
+        handlers.onError?.();
+        scheduleReconnect();
+        return;
+      }
+      source = nextSource;
+      nextSource.onmessage = (message) => {
+        if (source !== nextSource || closed) return;
+        if (isFileWatchReadyEvent(message.data)) {
+          failures = 0;
+          handlers.onReady?.();
+          return;
+        }
+        const event = parseFileChangeEvent(message.data, watchedDirectoryKeys);
+        if (event) handlers.onChange(event);
+      };
+      nextSource.onerror = () => {
+        if (source !== nextSource || closed) return;
+        closeSource();
+        handlers.onError?.();
+        scheduleReconnect();
+        failures += 1;
+      };
+    };
+    const retryWhenActive = () => {
+      if (!reconnectTimer || isInactive()) return;
+      clearReconnectTimer();
+      connect();
+    };
+
+    globalThis.window?.addEventListener('online', retryWhenActive);
+    globalThis.document?.addEventListener('visibilitychange', retryWhenActive);
+    const unsubscribeRuntimeChange = subscribeRuntimeEndpointChanged(() => {
+      if (closed) return;
+      clearReconnectTimer();
+      closeSource();
+      failures = 0;
+      connect();
+    });
+    const unsubscribeUrlAuth = watchUrlAuth.subscribe(() => {
+      if (closed) return;
+      clearReconnectTimer();
+      closeSource();
+      failures = 0;
+      connect();
+    });
+    connect();
+
+    return {
+      close() {
+        if (closed) return;
+        closed = true;
+        clearReconnectTimer();
+        closeSource();
+        globalThis.window?.removeEventListener('online', retryWhenActive);
+        globalThis.document?.removeEventListener('visibilitychange', retryWhenActive);
+        unsubscribeRuntimeChange();
+        unsubscribeUrlAuth();
+        releaseUrlAuth();
+      },
+    };
   },
 
   async search(payload: FileSearchQuery): Promise<FileSearchResult[]> {


### PR DESCRIPTION
## Intent

Fixes #2093.

The sidebar file tree can stay stale after an agent or another program creates, renames, or deletes files. This change watches the workspace root and expanded directories, then re-lists affected directories while preserving expansion state.

## Non-goals

- Recursively watching the workspace.
- Reloading already-open file contents.
- Coupling file-tree refresh to Git status.
- Adding this behavior to VS Code, hosted mobile, or Capacitor surfaces that do not mount `SidebarFilesTree`.

## Affected surfaces

- `packages/ui`: file-tree watcher lifecycle, directory reconciliation, stale-request rejection, and cross-platform path handling.
- `packages/web`: read-only `GET /api/fs/watch`, SSE authentication, runtime URL resolution, and Electron realtime proxy support.
- Standard Web and Electron Desktop use the watcher. Private-relay connections use visible-directory polling because native `EventSource` cannot cross that transport.
- Adds the direct `zod` runtime dependency required by the published Web server. No persisted schema changes.
- `CHANGELOG.md` is intentionally omitted; release notes are maintained in the upstream changelog pass.

## Repository guidance

| Guidance | Application |
|---|---|
| `AGENTS.md` and `openchamber-change-discipline` | Keeps watcher policy in the FS module, limits the change to file-tree consumers, adds no unrelated refactor, and updates owning docs/tests. |
| `ui-api-decoupling` and runtime/auth references | Uses an optional runtime capability, resolves watcher URLs at connection time, and follows the existing short-lived URL-token boundary. |
| `sync-state-invariants`, `performance-engineering`, and `relay-transport` | Re-lists authoritative state, rejects stale completions, bounds watcher/refresh work, stops hidden work, and uses polling where SSE cannot cross the relay. |

## Validation

HEAD: `680ea1c43`

| Check | Result |
|---|---|
| `git range-diff` against the pre-sync commit | Functional patch unchanged; only current upstream context and the documentation endpoint list were integrated. |
| `bun test ./packages/ui/src/hooks/useFileTreeAutoRefresh.test.ts` | 11 tests, 34 expectations passed. |
| Web focused suites (`watcher`, FS routes, realtime proxy, UI auth, Files API) | 101 tests passed across 5 files. |
| `bun run lint` | Passed across all workspaces. |
| `bun run --cwd packages/electron test` | 18/18 test files passed. |
| `bun run --cwd packages/vscode test` | 26/26 test files passed. VS Code does not mount the affected surface. |
| `git diff --check upstream/main...HEAD` | Passed. |
| `bun run type-check` and `bun run --cwd packages/web build` | Not completed locally because dependency downloads fail with `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`; missing SDK and Markdown packages prevent these commands. |
| Windows Electron manual validation | Previously passed for external and in-app create, rename, delete, multi-directory changes, hidden-tree reconciliation, expansion preservation, and manual refresh. The range-diff shows no functional change after that run; the later code change only adds the direct `zod` package declaration and lock entry. |

Not manually verified on macOS, Linux, direct browser Web, or private relay. No recording is attached because the current HEAD has no runtime behavior change after the recorded manual validation; the remaining difference is package metadata.

## Visual evidence

This is a behavioral bug fix with no new static UI state. The current HEAD preserves the previously validated runtime code; only upstream context and the published-server dependency declaration changed after that validation.

## Risks and failure behavior

- `fs.watch` differences across platforms are treated as directory invalidations; the client re-lists authoritative contents.
- Events debounce after 250 ms, with a 1-second maximum wait. Automatic refreshes run at most three at a time, and repeated events for one directory are coalesced.
- Subscriptions are limited to 64 directories. Hidden trees close their stream and polling timer, then reconcile when shown again. Relay connections use bounded polling fallback.
- The endpoint is read-only, validates every directory against the active workspace/worktree, and uses the existing URL-auth and Desktop proxy boundaries.
- The change does not mutate Git state or persisted data and requires no migration.