### PR TITLE
fix(ui): improve inline code contrast and chip styling

### DIFF
--- a/packages/ui/src/components/chat/composerHighlight.ts
+++ b/packages/ui/src/components/chat/composerHighlight.ts
@@ -103,7 +103,7 @@ const STYLE_CLASS: Record<AnyStyle, string> = {
     mentionAgent: 'text-[var(--status-success)]',
     mentionCommand: 'text-[var(--primary)]',
     mentionSnippet: 'text-[var(--status-warning)]',
-    code: 'rounded-[3px] bg-[var(--surface-subtle)] text-[var(--markdown-inline-code)]',
+    code: 'rounded-[6px] bg-[var(--markdown-inline-code-bg)] text-[var(--markdown-inline-code)] px-[0.3125rem] py-0.5',
     codeFence: 'bg-[var(--surface-subtle)] text-[var(--markdown-inline-code)]',
     // A `~path` is written for the reader's benefit, not to attach anything —
     // it takes the same colour as a file mention, since it names the same kind

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1117,8 +1117,10 @@ html:not(.dark) .chat-scroll {
 
 /* Override Streamdown's hardcoded bg-muted for inline code - use theme colors instead */
 .markdown-content code[data-markdown="inline-code"] {
-  background-color: var(--markdown-inline-code-bg, var(--surface-muted)) !important;
+  background-color: var(--markdown-inline-code-bg, var(--surface-subtle)) !important;
   color: var(--markdown-inline-code, var(--foreground)) !important;
+  padding: 0.125rem 0.3125rem;
+  border-radius: 0.375rem;
   word-break: break-all;
   overflow-wrap: break-word;
 }

--- a/packages/ui/src/lib/theme/themes/aura-dark.json
+++ b/packages/ui/src/lib/theme/themes/aura-dark.json
@@ -134,7 +134,7 @@
       "link": "#A277FF",
       "linkHover": "#F694FF",
       "inlineCode": "#61FFCA",
-      "inlineCodeBackground": "#1A1921",
+      "inlineCodeBackground": "#222128",
       "blockquote": "#6D6D6D",
       "blockquoteBorder": "#2D2B38",
       "listMarker": "#A277FF99"

--- a/packages/ui/src/lib/theme/themes/aura-light.json
+++ b/packages/ui/src/lib/theme/themes/aura-light.json
@@ -133,8 +133,8 @@
       "heading4": "#2D2640",
       "link": "#A277FF",
       "linkHover": "#C17AC8",
-      "inlineCode": "#40BF7A",
-      "inlineCodeBackground": "#EFE8FC",
+      "inlineCode": "#00732E",
+      "inlineCodeBackground": "#E8E3F2",
       "blockquote": "#6D6D6D",
       "blockquoteBorder": "#E0D6F2",
       "listMarker": "#A277FF99"

--- a/packages/ui/src/lib/theme/themes/ayu-dark.json
+++ b/packages/ui/src/lib/theme/themes/ayu-dark.json
@@ -134,7 +134,7 @@
       "link": "#66C6F1",
       "linkHover": "#3FB7E3",
       "inlineCode": "#B1C74A",
-      "inlineCodeBackground": "#161d23",
+      "inlineCodeBackground": "#1C2126",
       "blockquote": "#E4A75C",
       "blockquoteBorder": "#2B3440",
       "listMarker": "#3FB7E399"

--- a/packages/ui/src/lib/theme/themes/ayu-light.json
+++ b/packages/ui/src/lib/theme/themes/ayu-light.json
@@ -133,8 +133,8 @@
       "heading4": "#394049",
       "link": "#2F9BCE",
       "linkHover": "#4AA8C8",
-      "inlineCode": "#7FAD00",
-      "inlineCodeBackground": "#FCF9F3",
+      "inlineCode": "#497700",
+      "inlineCodeBackground": "#F0EDE7",
       "blockquote": "#ED982E",
       "blockquoteBorder": "#E6DDCF",
       "listMarker": "#4AA8C899"

--- a/packages/ui/src/lib/theme/themes/carbonfox-dark.json
+++ b/packages/ui/src/lib/theme/themes/carbonfox-dark.json
@@ -134,7 +134,7 @@
       "link": "#33B1FF",
       "linkHover": "#78A9FF",
       "inlineCode": "#42BE65",
-      "inlineCodeBackground": "#1e1e1e",
+      "inlineCodeBackground": "#232323",
       "blockquote": "#8D8D8D",
       "blockquoteBorder": "#393939",
       "listMarker": "#33B1FF99"

--- a/packages/ui/src/lib/theme/themes/carbonfox-light.json
+++ b/packages/ui/src/lib/theme/themes/carbonfox-light.json
@@ -133,8 +133,8 @@
       "heading4": "#161616",
       "link": "#0072C3",
       "linkHover": "#0043CE",
-      "inlineCode": "#198038",
-      "inlineCodeBackground": "#F4F4F4",
+      "inlineCode": "#00661E",
+      "inlineCodeBackground": "#F2F2F2",
       "blockquote": "#525252",
       "blockquoteBorder": "#DCDCDC",
       "listMarker": "#0072C399"

--- a/packages/ui/src/lib/theme/themes/catppuccin-dark.json
+++ b/packages/ui/src/lib/theme/themes/catppuccin-dark.json
@@ -134,7 +134,7 @@
       "link": "#89DCEB",
       "linkHover": "#B4BEFE",
       "inlineCode": "#A6E3A1",
-      "inlineCodeBackground": "#2d2a42",
+      "inlineCodeBackground": "#2B2B3B",
       "blockquote": "#F9E2AF",
       "blockquoteBorder": "#35324A",
       "listMarker": "#B4BEFE99"

--- a/packages/ui/src/lib/theme/themes/catppuccin-light.json
+++ b/packages/ui/src/lib/theme/themes/catppuccin-light.json
@@ -133,8 +133,8 @@
       "heading4": "#2e314a",
       "link": "#04A5E5",
       "linkHover": "#7287FD",
-      "inlineCode": "#40A02B",
-      "inlineCodeBackground": "#f6eeec",
+      "inlineCode": "#1A7A05",
+      "inlineCodeBackground": "#F2E9E7",
       "blockquote": "#DF8E1D",
       "blockquoteBorder": "#E0CFD3",
       "listMarker": "#7287FD99"

--- a/packages/ui/src/lib/theme/themes/dracula-dark.json
+++ b/packages/ui/src/lib/theme/themes/dracula-dark.json
@@ -134,7 +134,7 @@
       "link": "#8BE9FD",
       "linkHover": "#BD93F9",
       "inlineCode": "#4aeb72",
-      "inlineCodeBackground": "#202132",
+      "inlineCodeBackground": "#21222C",
       "blockquote": "#FFB86C",
       "blockquoteBorder": "#2D2F3C",
       "listMarker": "#BD93F999"

--- a/packages/ui/src/lib/theme/themes/dracula-light.json
+++ b/packages/ui/src/lib/theme/themes/dracula-light.json
@@ -133,8 +133,8 @@
       "heading4": "#1F1F2F",
       "link": "#1D7FC5",
       "linkHover": "#7C6BF5",
-      "inlineCode": "#2FBF71",
-      "inlineCodeBackground": "#F1F2ED",
+      "inlineCode": "#007325",
+      "inlineCodeBackground": "#EBEBE5",
       "blockquote": "#F7A14D",
       "blockquoteBorder": "#E2E3DA",
       "listMarker": "#7C6BF599"

--- a/packages/ui/src/lib/theme/themes/fields-of-the-shire-dark.json
+++ b/packages/ui/src/lib/theme/themes/fields-of-the-shire-dark.json
@@ -137,7 +137,7 @@
       "link": "#5a6d7a",
       "linkHover": "#93a56b",
       "inlineCode": "#93a56b",
-      "inlineCodeBackground": "#23201c",
+      "inlineCodeBackground": "#282522",
       "blockquote": "#a89888",
       "blockquoteBorder": "#f0e6d830",
       "listMarker": "#c47a3a99"

--- a/packages/ui/src/lib/theme/themes/fields-of-the-shire-light.json
+++ b/packages/ui/src/lib/theme/themes/fields-of-the-shire-light.json
@@ -136,8 +136,8 @@
       "heading4": "#1a1612",
       "link": "#3d4f5a",
       "linkHover": "#4a6030",
-      "inlineCode": "#4a6030",
-      "inlineCodeBackground": "#ece5d6",
+      "inlineCode": "#4A6030",
+      "inlineCodeBackground": "#ECE8DE",
       "blockquote": "#5a5048",
       "blockquoteBorder": "#1a161230",
       "listMarker": "#8c552099"

--- a/packages/ui/src/lib/theme/themes/flexoki-dark.json
+++ b/packages/ui/src/lib/theme/themes/flexoki-dark.json
@@ -136,7 +136,7 @@
       "link": "#4385BE",
       "linkHover": "#205EA6",
       "inlineCode": "#A0AF53",
-      "inlineCodeBackground": "#1C1B1A",
+      "inlineCodeBackground": "#242222",
       "blockquote": "#878580",
       "blockquoteBorder": "#343331",
       "listMarker": "#D0A21599"

--- a/packages/ui/src/lib/theme/themes/flexoki-light.json
+++ b/packages/ui/src/lib/theme/themes/flexoki-light.json
@@ -135,8 +135,8 @@
       "heading4": "#100F0F",
       "link": "#205EA6",
       "linkHover": "#4385BE",
-      "inlineCode": "#24837B",
-      "inlineCodeBackground": "#f6f5ee",
+      "inlineCode": "#0A6961",
+      "inlineCodeBackground": "#F2F0E7",
       "blockquote": "#6F6E69",
       "blockquoteBorder": "#DAD8CE",
       "listMarker": "#AD830199"

--- a/packages/ui/src/lib/theme/themes/gruvbox-dark.json
+++ b/packages/ui/src/lib/theme/themes/gruvbox-dark.json
@@ -134,7 +134,7 @@
       "link": "#8EC07C",
       "linkHover": "#83A598",
       "inlineCode": "#B8BB26",
-      "inlineCodeBackground": "#32302F",
+      "inlineCodeBackground": "#353535",
       "blockquote": "#928374",
       "blockquoteBorder": "#504945",
       "listMarker": "#83A59899"

--- a/packages/ui/src/lib/theme/themes/gruvbox-light.json
+++ b/packages/ui/src/lib/theme/themes/gruvbox-light.json
@@ -133,8 +133,8 @@
       "heading4": "#3C3836",
       "link": "#427B58",
       "linkHover": "#076678",
-      "inlineCode": "#79740E",
-      "inlineCodeBackground": "#F2E5BC",
+      "inlineCode": "#5F5A00",
+      "inlineCodeBackground": "#EBE4C8",
       "blockquote": "#928374",
       "blockquoteBorder": "#D5C4A1",
       "listMarker": "#07667899"

--- a/packages/ui/src/lib/theme/themes/jetbrains-dark.json
+++ b/packages/ui/src/lib/theme/themes/jetbrains-dark.json
@@ -138,7 +138,7 @@
       "link": "#56A8F5",
       "linkHover": "#6796f5",
       "inlineCode": "#6AAB73",
-      "inlineCodeBackground": "#26282B",
+      "inlineCodeBackground": "#2B2C2F",
       "blockquote": "#7A7E85",
       "blockquoteBorder": "#393B41",
       "listMarker": "#B3AE6099"

--- a/packages/ui/src/lib/theme/themes/jetbrains-light.json
+++ b/packages/ui/src/lib/theme/themes/jetbrains-light.json
@@ -138,7 +138,7 @@
       "link": "#006DCC",
       "linkHover": "#3573F0",
       "inlineCode": "#067D17",
-      "inlineCodeBackground": "#F5F7F9",
+      "inlineCodeBackground": "#F2F2F2",
       "blockquote": "#8C8C8C",
       "blockquoteBorder": "#C9CCD6",
       "listMarker": "#9E880D99"

--- a/packages/ui/src/lib/theme/themes/kanagawa-dark.json
+++ b/packages/ui/src/lib/theme/themes/kanagawa-dark.json
@@ -136,7 +136,7 @@
       "link": "#7FB4CA",
       "linkHover": "#7E9CD8",
       "inlineCode": "#98BB6C",
-      "inlineCodeBackground": "#16161D",
+      "inlineCodeBackground": "#2C2C35",
       "blockquote": "#54546D",
       "blockquoteBorder": "#363646",
       "listMarker": "#FF9E3B99"

--- a/packages/ui/src/lib/theme/themes/kanagawa-light.json
+++ b/packages/ui/src/lib/theme/themes/kanagawa-light.json
@@ -135,8 +135,8 @@
       "heading4": "#545464",
       "link": "#5D57A3",
       "linkHover": "#4D699B",
-      "inlineCode": "#6F894E",
-      "inlineCodeBackground": "#e7e2c7",
+      "inlineCode": "#496328",
+      "inlineCodeBackground": "#E9E6C9",
       "blockquote": "#716E61",
       "blockquoteBorder": "#716E61",
       "listMarker": "#836F4A99"

--- a/packages/ui/src/lib/theme/themes/mono-dark.json
+++ b/packages/ui/src/lib/theme/themes/mono-dark.json
@@ -136,7 +136,7 @@
       "link": "#CCCCCC",
       "linkHover": "#FFFFFF",
       "inlineCode": "#B3B3B3",
-      "inlineCodeBackground": "#1A1A1A",
+      "inlineCodeBackground": "#0D0D0D",
       "blockquote": "#808080",
       "blockquoteBorder": "#333333",
       "listMarker": "#99999999"

--- a/packages/ui/src/lib/theme/themes/mono-light.json
+++ b/packages/ui/src/lib/theme/themes/mono-light.json
@@ -136,7 +136,7 @@
       "link": "#333333",
       "linkHover": "#000000",
       "inlineCode": "#4D4D4D",
-      "inlineCodeBackground": "#f1f1f1",
+      "inlineCodeBackground": "#F2F2F2",
       "blockquote": "#808080",
       "blockquoteBorder": "#D9D9D9",
       "listMarker": "#66666699"

--- a/packages/ui/src/lib/theme/themes/mono-plus-dark.json
+++ b/packages/ui/src/lib/theme/themes/mono-plus-dark.json
@@ -114,7 +114,7 @@
       "link": "#CCCCCC",
       "linkHover": "#a2bee8",
       "inlineCode": "#a2bee8",
-      "inlineCodeBackground": "#1A1A1A",
+      "inlineCodeBackground": "#0D0D0D",
       "blockquote": "#808080",
       "blockquoteBorder": "#333333",
       "listMarker": "#99999999"

--- a/packages/ui/src/lib/theme/themes/mono-plus-light.json
+++ b/packages/ui/src/lib/theme/themes/mono-plus-light.json
@@ -113,8 +113,8 @@
       "heading4": "#262626",
       "link": "#333333",
       "linkHover": "#4a6a9e",
-      "inlineCode": "#4a6a9e",
-      "inlineCodeBackground": "#f1f1f1",
+      "inlineCode": "#4A6A9E",
+      "inlineCodeBackground": "#F2F2F2",
       "blockquote": "#808080",
       "blockquoteBorder": "#D9D9D9",
       "listMarker": "#66666699"

--- a/packages/ui/src/lib/theme/themes/monokai-dark.json
+++ b/packages/ui/src/lib/theme/themes/monokai-dark.json
@@ -134,7 +134,7 @@
       "link": "#66D9EF",
       "linkHover": "#AE81FF",
       "inlineCode": "#A6E22E",
-      "inlineCodeBackground": "#27281F",
+      "inlineCodeBackground": "#30312B",
       "blockquote": "#FD971F",
       "blockquoteBorder": "#343528",
       "listMarker": "#AE81FF99"

--- a/packages/ui/src/lib/theme/themes/monokai-light.json
+++ b/packages/ui/src/lib/theme/themes/monokai-light.json
@@ -133,8 +133,8 @@
       "heading4": "#292318",
       "link": "#2D9AD7",
       "linkHover": "#BF7BFF",
-      "inlineCode": "#4FB54B",
-      "inlineCodeBackground": "#F8F2E6",
+      "inlineCode": "#0F750B",
+      "inlineCodeBackground": "#F0EBDF",
       "blockquote": "#F1A948",
       "blockquoteBorder": "#E9E0CF",
       "listMarker": "#BF7BFF99"

--- a/packages/ui/src/lib/theme/themes/nightowl-dark.json
+++ b/packages/ui/src/lib/theme/themes/nightowl-dark.json
@@ -134,7 +134,7 @@
       "link": "#7FDBCA",
       "linkHover": "#82AAFF",
       "inlineCode": "#C5E478",
-      "inlineCodeBackground": "#0B253A",
+      "inlineCodeBackground": "#0E2334",
       "blockquote": "#5F7E97",
       "blockquoteBorder": "#1D3B53",
       "listMarker": "#82AAFF99"

--- a/packages/ui/src/lib/theme/themes/nightowl-light.json
+++ b/packages/ui/src/lib/theme/themes/nightowl-light.json
@@ -133,8 +133,8 @@
       "heading4": "#403F53",
       "link": "#2AA298",
       "linkHover": "#4876D6",
-      "inlineCode": "#2AA298",
-      "inlineCodeBackground": "#F0F0F0",
+      "inlineCode": "#00746A",
+      "inlineCodeBackground": "#EEEEEE",
       "blockquote": "#7A8181",
       "blockquoteBorder": "#D9D9D9",
       "listMarker": "#4876D699"

--- a/packages/ui/src/lib/theme/themes/nord-dark.json
+++ b/packages/ui/src/lib/theme/themes/nord-dark.json
@@ -134,7 +134,7 @@
       "link": "#81A1C1",
       "linkHover": "#88C0D0",
       "inlineCode": "#A3BE8C",
-      "inlineCodeBackground": "#252c3c",
+      "inlineCodeBackground": "#2C313D",
       "blockquote": "#D08770",
       "blockquoteBorder": "#343A47",
       "listMarker": "#88C0D099"

--- a/packages/ui/src/lib/theme/themes/nord-light.json
+++ b/packages/ui/src/lib/theme/themes/nord-light.json
@@ -133,8 +133,8 @@
       "heading4": "#2E3440",
       "link": "#81A1C1",
       "linkHover": "#5E81AC",
-      "inlineCode": "#4f7034",
-      "inlineCodeBackground": "#E4E8F0",
+      "inlineCode": "#35561A",
+      "inlineCodeBackground": "#DFE2E7",
       "blockquote": "#D08770",
       "blockquoteBorder": "#D5DBE7",
       "listMarker": "#5E81AC99"

--- a/packages/ui/src/lib/theme/themes/onedarkpro-dark.json
+++ b/packages/ui/src/lib/theme/themes/onedarkpro-dark.json
@@ -134,7 +134,7 @@
       "link": "#56B6C2",
       "linkHover": "#61AFEF",
       "inlineCode": "#a0c288",
-      "inlineCodeBackground": "#232937",
+      "inlineCodeBackground": "#2B2F37",
       "blockquote": "#E5C07B",
       "blockquoteBorder": "#323848",
       "listMarker": "#61AFEF99"

--- a/packages/ui/src/lib/theme/themes/onedarkpro-light.json
+++ b/packages/ui/src/lib/theme/themes/onedarkpro-light.json
@@ -133,8 +133,8 @@
       "heading4": "#2B303B",
       "link": "#61AFEF",
       "linkHover": "#528BFF",
-      "inlineCode": "#327d4c",
-      "inlineCodeBackground": "#EEF0F4",
+      "inlineCode": "#186332",
+      "inlineCodeBackground": "#E8E9EB",
       "blockquote": "#D19A66",
       "blockquoteBorder": "#DEE2EB",
       "listMarker": "#528BFF99"

--- a/packages/ui/src/lib/theme/themes/openchamber-dark.json
+++ b/packages/ui/src/lib/theme/themes/openchamber-dark.json
@@ -138,7 +138,7 @@
       "link": "#5d99a9",
       "linkHover": "#6ba7b8",
       "inlineCode": "#76ad4f",
-      "inlineCodeBackground": "#211f1d",
+      "inlineCodeBackground": "#1F1C1B",
       "blockquote": "#8f8b81",
       "blockquoteBorder": "#302e2b",
       "listMarker": "#4d934e99"

--- a/packages/ui/src/lib/theme/themes/openchamber-light.json
+++ b/packages/ui/src/lib/theme/themes/openchamber-light.json
@@ -137,8 +137,8 @@
       "heading4": "#393a34",
       "link": "#2e808f",
       "linkHover": "#296aa3",
-      "inlineCode": "#1a8446",
-      "inlineCodeBackground": "#f4f3f1",
+      "inlineCode": "#006A2C",
+      "inlineCodeBackground": "#F0EFED",
       "blockquote": "#6b6b63",
       "blockquoteBorder": "#d8d5d0",
       "listMarker": "#1e754f99"

--- a/packages/ui/src/lib/theme/themes/solarized-dark.json
+++ b/packages/ui/src/lib/theme/themes/solarized-dark.json
@@ -134,7 +134,7 @@
       "link": "#2AA198",
       "linkHover": "#6C71C4",
       "inlineCode": "#859900",
-      "inlineCodeBackground": "#022733",
+      "inlineCodeBackground": "#0D2B32",
       "blockquote": "#B58900",
       "blockquoteBorder": "#20373F",
       "listMarker": "#6C71C499"

--- a/packages/ui/src/lib/theme/themes/solarized-light.json
+++ b/packages/ui/src/lib/theme/themes/solarized-light.json
@@ -133,8 +133,8 @@
       "heading4": "#586E75",
       "link": "#2AA198",
       "linkHover": "#268BD2",
-      "inlineCode": "#859900",
-      "inlineCodeBackground": "#F6EFDA",
+      "inlineCode": "#576B00",
+      "inlineCodeBackground": "#F0E9D6",
       "blockquote": "#B58900",
       "blockquoteBorder": "#E3E0CD",
       "listMarker": "#268BD299"

--- a/packages/ui/src/lib/theme/themes/tokyonight-dark.json
+++ b/packages/ui/src/lib/theme/themes/tokyonight-dark.json
@@ -134,7 +134,7 @@
       "link": "#7DCFFF",
       "linkHover": "#7AA2F7",
       "inlineCode": "#9ECE6A",
-      "inlineCodeBackground": "#111428",
+      "inlineCodeBackground": "#1C1E27",
       "blockquote": "#E0AF68",
       "blockquoteBorder": "#25283B",
       "listMarker": "#7AA2F799"

--- a/packages/ui/src/lib/theme/themes/tokyonight-light.json
+++ b/packages/ui/src/lib/theme/themes/tokyonight-light.json
@@ -133,8 +133,8 @@
       "heading4": "#273153",
       "link": "#007197",
       "linkHover": "#2E7DE9",
-      "inlineCode": "#587539",
-      "inlineCodeBackground": "#DEE0EA",
+      "inlineCode": "#3E5B1F",
+      "inlineCodeBackground": "#D4D5DA",
       "blockquote": "#8C6C3E",
       "blockquoteBorder": "#CDD0DC",
       "listMarker": "#2E7DE999"

--- a/packages/ui/src/lib/theme/themes/vesper-dark.json
+++ b/packages/ui/src/lib/theme/themes/vesper-dark.json
@@ -134,7 +134,7 @@
       "link": "#A0A0A0",
       "linkHover": "#FFC799",
       "inlineCode": "#bba2a2",
-      "inlineCodeBackground": "#292727",
+      "inlineCodeBackground": "#222222",
       "blockquote": "#FFFFFF",
       "blockquoteBorder": "#1C1C1C",
       "listMarker": "#FFFFFF99"

--- a/packages/ui/src/lib/theme/themes/vesper-light.json
+++ b/packages/ui/src/lib/theme/themes/vesper-light.json
@@ -134,7 +134,7 @@
       "link": "#717070",
       "linkHover": "#c48959",
       "inlineCode": "#665050",
-      "inlineCodeBackground": "#f3f1f1",
+      "inlineCodeBackground": "#F2F2F2",
       "blockquote": "#101010",
       "blockquoteBorder": "#E8E8E8",
       "listMarker": "#10101099"

--- a/packages/ui/src/lib/theme/themes/vitesse-dark-dark.json
+++ b/packages/ui/src/lib/theme/themes/vitesse-dark-dark.json
@@ -114,7 +114,7 @@
       "link": "#4d9375",
       "linkHover": "#4d9375",
       "inlineCode": "#80a665",
-      "inlineCodeBackground": "#121212",
+      "inlineCodeBackground": "#1F1F1F",
       "blockquote": "#dedcd550",
       "blockquoteBorder": "#ffffff15",
       "listMarker": "#4d937599"

--- a/packages/ui/src/lib/theme/themes/vitesse-light-light.json
+++ b/packages/ui/src/lib/theme/themes/vitesse-light-light.json
@@ -113,8 +113,8 @@
       "heading4": "#2c2c28",
       "link": "#1e754f",
       "linkHover": "#1c6b48",
-      "inlineCode": "#3a631e",
-      "inlineCodeBackground": "#f7f3f395",
+      "inlineCode": "#3A631E",
+      "inlineCodeBackground": "#F2F2F2",
       "blockquote": "#2c2c2850",
       "blockquoteBorder": "#00000015",
       "listMarker": "#1c6b4899"


### PR DESCRIPTION
## Intent
Fix inline `code` contrast where `inlineCodeBackground` was indistinguishable from `surface.background` (e.g. Ayu light, Vitesse dark). Result: inline code renders as a visible pill with correct text contrast in light themes.

## Non-goals
No changes to fenced code blocks, syntax tokens, markdown parsing, or palette generation logic.

## Affected surfaces
- `packages/ui` (shared) — `themes/*.json` static values, `index.css` pill style, `composerHighlight.ts` chip
- Runtimes: web, desktop, VS Code, hosted mobile (shared UI)
- User-visible: inline code in chat markdown and composer. No persisted/external contract.

## Repository guidance
| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` / `openchamber-change-discipline` | Theme and style change, shared contracts | Minimal scope (44 files), no new exports, reverts runtime derivation to static data — correct ownership in theme JSONs |
| `theme-system` | UI colors, chip styling | Uses existing tokens, corrected `markdown.inlineCode`/`inlineCodeBackground` values, kept `index.css` `var(--markdown-inline-code-bg)` with padding/radius |

## Validation
Executed locally at HEAD `3792a77` (bun 1.4.0, node v22.19.0, Windows):

| Check | Result |
|---|---|
| JSON validity (`python3 -c json.load`) | Pass — 42 themes valid |
| Contrast calc (WCAG AA >=4.5 on light) | Pass — 21 light themes verified >=4.5 |
| Braces/balance script | Pass |
| `bun run type-check` | Pass — all 5 workspaces exit 0 |
| `bun run lint` | Pass — all 5 workspaces exit 0 |
| `bun run build` | Pass — full workspace build exits 0 (pre-existing chunk-size warning only) |
| `bun run test` — scripts | Pass — 1/1 files |
| `bun run test` — packages/ui | 270/271 files pass. The 1 failure is a pre-existing locale-dependent test: `rawMessagePreview.test.ts` asserts `/AM\|PM/i`, but on an `es-EC` system locale `toLocaleString(..., { hour12: true })` renders `p. m.`, which never matches. Module has zero overlap with this diff (`components/layout/` vs `components/chat/composerHighlight.ts` + theme JSONs + CSS). Reproduced identically under node and bun. |
| `bun run test` — packages/vscode | Pass — 25/25 files |
| `bun run test` — packages/electron | Pass — 16/16 files |
| `bun run test` — packages/web | 146/161 files pass. All 34 failures are server/CLI specs (git worktree bootstrap, pid-file lifecycle, long-path limits, spawning `node.exe` through `cmd /c` on a localized Windows shell) — platform/environment issues with no overlap with this diff (packages/ui only). |

Note: the failing tests above are pre-existing environmental failures on this machine (Spanish-locale Windows), not regressions introduced by this PR. No test that touches theme data, markdown rendering, or composer highlighting fails.

## Visual evidence

Inline code contrast before/after per theme, top to bottom:

**Ayu light — current (before):**
<img width="713" height="130" alt="image" src="https://github.com/user-attachments/assets/01e6622f-76a1-4c5c-b8d6-8a52a0d1acb6" />

**Ayu light — with this change (after):**
<img width="722" height="129" alt="image" src="https://github.com/user-attachments/assets/0af19895-cb91-4ec2-a2ad-09651b282b89" />

**Vitesse dark — current (before):**
<img width="726" height="134" alt="image" src="https://github.com/user-attachments/assets/6b4f4cd5-fc3c-4d98-a7a3-a9ff34416aca" />

**Vitesse dark — with this change (after):**
<img width="731" height="132" alt="image" src="https://github.com/user-attachments/assets/d6c99a30-a5f4-4aba-8868-c138a1df01d0" />

**OpenChamber light — current (before):**
<img width="714" height="126" alt="image" src="https://github.com/user-attachments/assets/73f5bdb3-45cc-461b-b360-329d42d22a0b" />

**OpenChamber light — with this change (after):**
<img width="721" height="129" alt="image" src="https://github.com/user-attachments/assets/1619a73c-2ff6-4cc3-86ca-86559f6bd09a" />

**Flexoki dark — current (before):**
<img width="717" height="128" alt="image" src="https://github.com/user-attachments/assets/b7d3196f-e6f9-4e8c-b5e9-db44a3566974" />

**Flexoki dark — with this change (after):**
<img width="722" height="133" alt="image" src="https://github.com/user-attachments/assets/7a9fc282-2fd6-42fa-bf0a-c40a293a6fbe" />

## Risks and failure behavior
Low complexity. Static data only, no runtime derivation — no perf impact. Failure is just wrong color value; rollback is revert JSONs. No migration, no cross-runtime divergence.
