### PR TITLE
fix(opencode): preserve external host during recovery

### DIFF
--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -792,11 +792,12 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
 
       if (state.isExternalOpenCode) {
         console.log('Re-probing external OpenCode server...');
-        const probePort = state.openCodePort || env.ENV_CONFIGURED_OPENCODE_PORT || 4096;
+        const probePort = state.openCodePort ?? env.ENV_EFFECTIVE_PORT ?? 4096;
         const probeOrigin = state.openCodeBaseUrl ?? env.ENV_CONFIGURED_OPENCODE_HOST?.origin;
         const healthy = await probeExternalOpenCode(probePort, probeOrigin);
         if (healthy) {
           console.log(`External OpenCode server on port ${probePort} is healthy`);
+          state.openCodeBaseUrl = probeOrigin ?? null;
           setOpenCodePort(probePort);
           state.isOpenCodeReady = true;
           state.lastOpenCodeError = null;
@@ -875,7 +876,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     } catch (error) {
       console.error(`Failed to restart OpenCode: ${error.message}`);
       state.lastOpenCodeError = error.message;
-      if (!env.ENV_CONFIGURED_OPENCODE_PORT) {
+      if (!env.ENV_EFFECTIVE_PORT) {
         state.openCodePort = null;
         syncToHmrState();
       }

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -151,6 +151,56 @@ describe('OpenCode lifecycle', () => {
     expect(terminalEvents).toHaveLength(1);
   });
 
+  it('recovers an external OPENCODE_HOST connection using its configured endpoint', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ healthy: true }),
+    }));
+    globalThis.fetch = fetchMock;
+    const runtime = createRuntime({}, {
+      openCodePort: null,
+      openCodeBaseUrl: null,
+      isExternalOpenCode: true,
+    }, {
+      ENV_CONFIGURED_OPENCODE_PORT: null,
+      ENV_CONFIGURED_OPENCODE_HOST: { origin: 'http://seamus:4095', port: 4095 },
+      ENV_EFFECTIVE_PORT: 4095,
+    });
+
+    await runtime.restartOpenCode();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://seamus:4095/global/health',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(runtime.testState.openCodePort).toBe(4095);
+    expect(runtime.testState.openCodeBaseUrl).toBe('http://seamus:4095');
+    expect(runtime.testState.lastOpenCodeError).toBeNull();
+  });
+
+  it('retains the OPENCODE_HOST port after an external re-probe fails', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      json: async () => null,
+    }));
+    const runtime = createRuntime({}, {
+      openCodePort: 4095,
+      openCodeBaseUrl: 'http://seamus:4095',
+      isExternalOpenCode: true,
+    }, {
+      ENV_CONFIGURED_OPENCODE_PORT: null,
+      ENV_CONFIGURED_OPENCODE_HOST: { origin: 'http://seamus:4095', port: 4095 },
+      ENV_EFFECTIVE_PORT: 4095,
+    });
+
+    await expect(runtime.restartOpenCode()).rejects.toThrow(
+      'External OpenCode server on port 4095 is not responding',
+    );
+
+    expect(runtime.testState.openCodePort).toBe(4095);
+    expect(runtime.testState.openCodeBaseUrl).toBe('http://seamus:4095');
+  });
+
   it('warms recently used directories after a successful bootstrap', async () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,


### PR DESCRIPTION
## Intent

Fix external OpenCode recovery when `OPENCODE_HOST` supplies the endpoint. Recovery previously ignored the effective port derived from `OPENCODE_HOST` when lifecycle state lacked a port, fell back to `4096`, and could leave later requests without the configured base URL.

After this change, external recovery probes and restores the configured host and effective port. A failed re-probe retains that configured endpoint for the next recovery attempt instead of discarding it.

## Non-goals

- Change `OPENCODE_HOST` parsing or precedence.
- Change managed OpenCode startup, proxy routing, authentication, or health-check thresholds.
- Add retries beyond the existing lifecycle recovery behavior.

## Affected surfaces

- `packages/web/server/lib/opencode/lifecycle.js`: external OpenCode re-probe and failure cleanup.
- `OPENCODE_HOST` external endpoint behavior in the web/server runtime.
- No shared UI, Electron, VS Code, mobile, persisted data, or rendered UI behavior changes. Those runtimes and states do not own this web server lifecycle path.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes executable web runtime behavior and an external configuration contract. | The diff stays in the owning lifecycle module, preserves managed startup behavior, and adds focused success and failure regression tests. |
| `ui-api-decoupling` and `references/implementation-map.md` | The fix changes how the web runtime resolves its external OpenCode endpoint. | Endpoint resolution remains at the runtime boundary and uses the canonical parsed `ENV_EFFECTIVE_PORT` and configured origin rather than adding host logic to consumers. |
| `packages/web/README.md` and `packages/web/server/lib/opencode/DOCUMENTATION.md` | These define `OPENCODE_HOST` precedence and lifecycle ownership. | The implementation now matches the documented contract that `OPENCODE_HOST` overrides `OPENCODE_PORT`; no documentation text needed to change. |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run "server/lib/opencode/lifecycle.test.js"` from `packages/web` | Passed: 1 file, 25 tests. Includes new successful recovery and failed re-probe cases for `http://seamus:4095`. |
| `bun run type-check` from `packages/web` | Passed. |
| `bun run lint` from `packages/web` | Passed. |
| `node --check "server/lib/opencode/lifecycle.js"` and `node --check "server/lib/opencode/lifecycle.test.js"` | Passed. |
| `bunx oxlint packages/web/server/lib/opencode/lifecycle.js packages/web/server/lib/opencode/lifecycle.test.js` | Reported only existing anti-slop findings outside the changed lines, including the file's existing module mocks and runtime `typeof` checks. No finding points to this change. |
| Live systemd deployment against a separate OpenCode service | Passed with `OPENCODE_HOST` set to the explicit address OpenCode binds. The OpenCode health endpoint returned HTTP 200; after restarting OpenChamber, `/health` returned HTTP 200 with port `4095`, `isOpenCodeReady: true`, and no OpenCode error, and the journal reported `[PushWatcher] connected`. The original hostname did not resolve to the interface where OpenCode was listening, so that configuration failure is not attributed to this code change. |

## Visual evidence

No rendered behavior changes. This diff only changes the server-side endpoint used while recovering an external OpenCode connection.

## Risks and failure behavior

The change is limited to connections already marked external. If a re-probe succeeds, lifecycle state restores both the configured origin and effective port. If it fails, `/health` continues reporting the failure while retaining the configured endpoint for a later attempt. Connections without an explicit effective port keep the existing `4096` fallback. Managed OpenCode process ownership, credentials, request payloads, and persisted state are unchanged. Rollback is a direct revert of this commit.
