### PR TITLE
fix(settings): persist editor font size

### DIFF
--- a/packages/web/server/lib/opencode/settings-helpers.js
+++ b/packages/web/server/lib/opencode/settings-helpers.js
@@ -601,6 +601,9 @@ export const createSettingsHelpers = (dependencies) => {
     if (typeof candidate.terminalFontSize === 'number' && Number.isFinite(candidate.terminalFontSize)) {
       result.terminalFontSize = Math.max(9, Math.min(52, Math.round(candidate.terminalFontSize)));
     }
+    if (typeof candidate.editorFontSize === 'number' && Number.isFinite(candidate.editorFontSize)) {
+      result.editorFontSize = Math.max(9, Math.min(32, Math.round(candidate.editorFontSize)));
+    }
     if (typeof candidate.terminalShell === 'string') {
       const shell = candidate.terminalShell.trim().toLowerCase();
       if (TERMINAL_SHELL_VALUES.has(shell)) result.terminalShell = shell;

--- a/packages/web/server/lib/opencode/settings-helpers.test.js
+++ b/packages/web/server/lib/opencode/settings-helpers.test.js
@@ -82,6 +82,16 @@ describe('settings helpers', () => {
     expect(helpers.sanitizeSettingsUpdate({ collapsibleUserMessages: 'true' })).toEqual({});
   });
 
+  it('sanitizes and returns the persisted editor font size', () => {
+    const helpers = createTestHelpers();
+
+    expect(helpers.sanitizeSettingsUpdate({ editorFontSize: 20.6 })).toEqual({ editorFontSize: 21 });
+    expect(helpers.sanitizeSettingsUpdate({ editorFontSize: 8 })).toEqual({ editorFontSize: 9 });
+    expect(helpers.sanitizeSettingsUpdate({ editorFontSize: 33 })).toEqual({ editorFontSize: 32 });
+    expect(helpers.sanitizeSettingsUpdate({ editorFontSize: Number.NaN })).toEqual({});
+    expect(helpers.formatSettingsResponse({ editorFontSize: 20 })).toMatchObject({ editorFontSize: 20 });
+  });
+
   it('accepts messageStreamTransport as a persisted shared setting', () => {
     const helpers = createTestHelpers();
 


### PR DESCRIPTION
## Intent

Close #3046 by preserving `editorFontSize` in the server-backed OpenChamber settings round trip. The settings sanitizer now accepts finite numeric values, rounds them, and clamps them to the same 9-32 range used by the UI.

## Non-goals

- No Settings UI or CodeMirror rendering changes.
- No changes to `terminalFontSize` or other persisted settings.

## Affected surfaces

- `packages/web` settings request/response shaping for Web and Electron runtimes.
- The persisted `settings.json` contract now retains `editorFontSize`; existing files need no migration.
- VS Code is unaffected because this patch only changes the OpenChamber server settings helper.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes executable server code and a persisted settings contract. | The patch is limited to the owning sanitizer and adds round-trip, bounds, rounding, and invalid-value coverage. |
| `ui-api-decoupling` | The setting crosses the shared UI/server runtime boundary through `/api/config/settings`. | Validation remains in the server-owned settings helper; no UI-only guard or runtime-specific shortcut was added. |
| `packages/web/README.md` and `packages/web/server/lib/opencode/DOCUMENTATION.md` | These define the web runtime and assign settings payload shaping to `settings-helpers.js`. | The change stays in that owner and does not alter route registration or bridge contracts. |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run packages/web/server/lib/opencode/settings-helpers.test.js` | Passed: 38 tests. |
| `node --check packages/web/server/lib/opencode/settings-helpers.js` | Passed. |
| `git diff --check` | Passed. |
| Manual restart/persistence check | Not run. The regression is covered at the sanitizer and formatted-response round trip used by both PUT and GET settings paths. |

## Visual evidence

No rendered component or styling changes. A screenshot cannot show the server-side serialization difference; the observable change occurs after restarting and reading the same setting back.

## Risks and failure behavior

The accepted range matches the existing UI contract. Non-numeric and non-finite values remain ignored, and out-of-range values are clamped rather than persisted unchecked. No migration, cleanup, credential, security, or performance behavior changes.
