### PR TITLE
fix(chat): handle truncated diff headers

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.test.ts
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { getStreamingOutputAppend, getToolOutput, renderTerminalOutput } from './toolOutput';
 import { readTaskTagSessionIdFromOutput } from './taskSessionIdParser';
-import { tryParseJsonOutput } from '../toolRenderers';
+import { parseDiffToUnified, tryParseJsonOutput } from '../toolRenderers';
 import { getStreamingThrottleText } from '../../hooks/useStreamingTextThrottle';
 import { getToolDescriptionFallback } from './toolRenderUtils';
 
@@ -39,6 +39,29 @@ describe('getToolOutput', () => {
 
     test('ignores empty metadata.output for bash', () => {
         expect(getToolOutput('bash', undefined, '', 'completed')).toBe(undefined);
+    });
+});
+
+describe('parseDiffToUnified', () => {
+    test('handles a streamed diff with a bare Index header', () => {
+        expect(parseDiffToUnified('Index:')).toEqual([]);
+        expect(parseDiffToUnified('Index:\n@@ -1,1 +1,1 @@\n-old\n+new')).toEqual([
+            {
+                file: 'file',
+                oldStart: 1,
+                newStart: 1,
+                lines: [
+                    { type: 'removed', lineNumber: 1, content: 'old' },
+                    { type: 'added', lineNumber: 1, content: 'new' },
+                ],
+            },
+        ]);
+    });
+
+    test('preserves spaces when extracting the indexed filename', () => {
+        const [hunk] = parseDiffToUnified('Index: src/my file.ts\n@@ -1,1 +1,1 @@\n-old\n+new');
+
+        expect(hunk?.file).toBe('my file.ts');
     });
 });
 

--- a/packages/ui/src/components/chat/message/toolRenderers.tsx
+++ b/packages/ui/src/components/chat/message/toolRenderers.tsx
@@ -575,7 +575,7 @@ export const parseDiffToUnified = (diffText: string): UnifiedDiffHunk[] => {
 
         if (line.startsWith('Index:') || line.startsWith('===') || line.startsWith('---') || line.startsWith('+++')) {
             if (line.startsWith('Index:')) {
-                currentFile = line.split(' ')[1].split('/').pop() || 'file';
+                currentFile = line.slice('Index:'.length).trim().split('/').pop() || 'file';
             }
             i++;
             continue;


### PR DESCRIPTION
## Intent

Close #2788 by making unified-diff parsing tolerate a streamed or truncated bare `Index:` header. The parser now extracts everything after the header, preserves spaces in filenames, and falls back to the existing generic filename when the header has no path instead of calling `.split()` on `undefined`.

## Non-goals

- No changes to diff rendering, syntax highlighting, or tool-card layout.
- No attempt to reconstruct a filename that has not arrived in the stream yet.

## Affected surfaces

- Shared chat tool-output parsing in `packages/ui`, used by Web, Electron, VS Code, and mobile runtimes.
- Only `Index:` header parsing changes; persisted messages and external API contracts are unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This is executable shared UI code on a malformed-input failure path. | The root cause is fixed in the shared parser with focused regression cases rather than guards in individual renderers. |
| `performance-engineering` | Diff parsing runs in the chat render path and may receive streaming updates. | The replacement remains a single linear string operation and adds no cache, subscription, or repeated scan. |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | This documents ownership of tool output and diff presentation. | The patch changes only parsing and leaves the lazy rich-diff rendering boundary intact. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/message/parts/ToolPart.test.ts` | Passed: 31 tests, 42 assertions, including bare and spaced `Index:` headers. |
| `bun run lint:ui` | Passed. |
| `git diff --check` | Passed. |
| `bun run type-check:ui` and `bun run build:ui` | Blocked outside this diff by simultaneously installed CodeMirror `6.12.2` and `6.12.4` types in `languageByExtension.ts`. |
| Manual VS Code reproduction | Not run; the supplied malformed streaming inputs exercise the crashing parser directly. |

## Visual evidence

No visual styling or layout changes. The issue contains the before-state error screenshot; this PR keeps the existing diff UI and prevents the parser exception for a partial header. No after screenshot was captured.

## Risks and failure behavior

A bare `Index:` header now uses the parser's existing `file` fallback until more input arrives. Complete paths retain their basename, including spaces. Invalid or partial diff input returns partial/empty parsed output instead of crashing the chat. No persistence, transport, security, cleanup, or cross-runtime divergence is introduced.
