### PR TITLE
fix(electron): retry blocked settings replacements

### DIFF
--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -19,7 +19,7 @@ The preload bridge exposes desktop-only APIs to the web UI through `window.__OPE
 | File | Purpose |
 |------|---------|
 | `main.mjs` | Electron main process, app lifecycle, windows, menus, deep links, native IPC handlers, updates, local server startup |
-| `file-replace.mjs` | Windows settings replacement retries, fallback rollback, and backup-aware JSON recovery shared by main and SSH settings writers |
+| `file-replace.mjs` | Windows settings replacement retries, per-write fallback rollback, and backup-aware JSON recovery shared by main and SSH settings writers |
 | `startup-url-selection.mjs` | Pure bundled/HMR startup probe and loopback connection-limit policy |
 | `preload.mjs` | Safe bridge from the rendered UI to Electron IPC |
 | `ssh-manager.mjs` | SSH host import, connection lifecycle, tunnel/port forwarding helpers |

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -19,6 +19,7 @@ The preload bridge exposes desktop-only APIs to the web UI through `window.__OPE
 | File | Purpose |
 |------|---------|
 | `main.mjs` | Electron main process, app lifecycle, windows, menus, deep links, native IPC handlers, updates, local server startup |
+| `file-replace.mjs` | Windows settings replacement retries, fallback rollback, and backup-aware JSON recovery shared by main and SSH settings writers |
 | `startup-url-selection.mjs` | Pure bundled/HMR startup probe and loopback connection-limit policy |
 | `preload.mjs` | Safe bridge from the rendered UI to Electron IPC |
 | `ssh-manager.mjs` | SSH host import, connection lifecycle, tunnel/port forwarding helpers |

--- a/packages/electron/file-replace.mjs
+++ b/packages/electron/file-replace.mjs
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 
 const WINDOWS_REPLACE_ERRORS = new Set(['EPERM', 'EACCES', 'EBUSY']);
@@ -6,7 +7,34 @@ const isTransientWindowsReplaceError = (error, platform) => (
   platform === 'win32' && WINDOWS_REPLACE_ERRORS.has(error?.code)
 );
 
+export const readJsonFileWithBackup = (targetPath) => {
+  try {
+    return JSON.parse(fs.readFileSync(targetPath, 'utf8'));
+  } catch (targetError) {
+    try {
+      return JSON.parse(fs.readFileSync(`${targetPath}.backup`, 'utf8'));
+    } catch {
+      throw targetError;
+    }
+  }
+};
+
 export const replaceFile = async (temporaryPath, targetPath, platform = process.platform) => {
+  const backupPath = `${targetPath}.backup`;
+
+  if (platform === 'win32') {
+    try {
+      await fsp.access(targetPath);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+      try {
+        await fsp.rename(backupPath, targetPath);
+      } catch (backupError) {
+        if (backupError?.code !== 'ENOENT') throw backupError;
+      }
+    }
+  }
+
   const maxAttempts = platform === 'win32' ? 6 : 1;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -21,7 +49,6 @@ export const replaceFile = async (temporaryPath, targetPath, platform = process.
     }
   }
 
-  const backupPath = `${targetPath}.backup-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   await fsp.rename(targetPath, backupPath);
   try {
     await fsp.rename(temporaryPath, targetPath);

--- a/packages/electron/file-replace.mjs
+++ b/packages/electron/file-replace.mjs
@@ -1,0 +1,26 @@
+import fsp from 'node:fs/promises';
+
+const WINDOWS_REPLACE_ERRORS = new Set(['EPERM', 'EACCES', 'EBUSY']);
+
+const isTransientWindowsReplaceError = (error, platform) => (
+  platform === 'win32' && WINDOWS_REPLACE_ERRORS.has(error?.code)
+);
+
+export const replaceFile = async (temporaryPath, targetPath, platform = process.platform) => {
+  const maxAttempts = platform === 'win32' ? 6 : 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await fsp.rename(temporaryPath, targetPath);
+      return;
+    } catch (error) {
+      if (!isTransientWindowsReplaceError(error, platform)) throw error;
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 25 * attempt));
+      }
+    }
+  }
+
+  await fsp.copyFile(temporaryPath, targetPath);
+  await fsp.rm(temporaryPath, { force: true });
+};

--- a/packages/electron/file-replace.mjs
+++ b/packages/electron/file-replace.mjs
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
+import path from 'node:path';
 
 const WINDOWS_REPLACE_ERRORS = new Set(['EPERM', 'EACCES', 'EBUSY']);
+let windowsFallbackChain = Promise.resolve();
 
 const isTransientWindowsReplaceError = (error, platform) => (
   platform === 'win32' && WINDOWS_REPLACE_ERRORS.has(error?.code)
@@ -12,31 +14,31 @@ export const readJsonFileWithBackup = (targetPath) => {
     return JSON.parse(fs.readFileSync(targetPath, 'utf8'));
   } catch (targetError) {
     if (targetError?.code !== 'ENOENT') throw targetError;
+
+    const directory = path.dirname(targetPath);
+    const backupName = `${path.basename(targetPath)}.backup`;
+    let names;
     try {
-      return JSON.parse(fs.readFileSync(`${targetPath}.backup`, 'utf8'));
+      names = fs.readdirSync(directory);
+    } catch {
+      throw targetError;
+    }
+    const name = names.filter((name) => name === backupName || name.startsWith(`${backupName}-`)).sort().at(-1);
+    if (!name) throw targetError;
+    try {
+      return JSON.parse(fs.readFileSync(path.join(directory, name), 'utf8'));
     } catch (backupError) {
-      if (backupError?.code === 'ENOENT') throw targetError;
-      throw backupError;
+      try {
+        return JSON.parse(fs.readFileSync(targetPath, 'utf8'));
+      } catch (retryError) {
+        if (retryError?.code !== 'ENOENT') throw retryError;
+        throw backupError;
+      }
     }
   }
 };
 
 export const replaceFile = async (temporaryPath, targetPath, platform = process.platform) => {
-  const backupPath = `${targetPath}.backup`;
-
-  if (platform === 'win32') {
-    try {
-      await fsp.access(targetPath);
-    } catch (error) {
-      if (error?.code !== 'ENOENT') throw error;
-      try {
-        await fsp.rename(backupPath, targetPath);
-      } catch (backupError) {
-        if (backupError?.code !== 'ENOENT') throw backupError;
-      }
-    }
-  }
-
   const maxAttempts = platform === 'win32' ? 6 : 1;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -49,16 +51,33 @@ export const replaceFile = async (temporaryPath, targetPath, platform = process.
       }
       continue;
     }
-    await fsp.rm(backupPath, { force: true }).catch(() => undefined);
     return;
   }
 
-  await fsp.rename(targetPath, backupPath);
-  try {
-    await fsp.rename(temporaryPath, targetPath);
-  } catch (error) {
-    await fsp.rename(backupPath, targetPath);
-    throw error;
-  }
-  await fsp.rm(backupPath, { force: true }).catch(() => undefined);
+  const fallback = windowsFallbackChain.then(async () => {
+    try {
+      await fsp.rename(temporaryPath, targetPath);
+      return;
+    } catch (error) {
+      if (!isTransientWindowsReplaceError(error, platform)) throw error;
+    }
+
+    const suffix = `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+    const backupPath = `${targetPath}.backup-${suffix}`;
+    const linkProbePath = `${temporaryPath}.link-${suffix}`;
+    await fsp.link(temporaryPath, linkProbePath);
+    await fsp.rm(linkProbePath);
+    await fsp.rename(targetPath, backupPath);
+    try {
+      await fsp.link(temporaryPath, targetPath);
+    } catch (error) {
+      await fsp.link(backupPath, targetPath);
+      await fsp.rm(backupPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+    await fsp.rm(temporaryPath, { force: true }).catch(() => undefined);
+    await fsp.rm(backupPath, { force: true }).catch(() => undefined);
+  });
+  windowsFallbackChain = fallback.catch(() => undefined);
+  return fallback;
 };

--- a/packages/electron/file-replace.mjs
+++ b/packages/electron/file-replace.mjs
@@ -11,10 +11,12 @@ export const readJsonFileWithBackup = (targetPath) => {
   try {
     return JSON.parse(fs.readFileSync(targetPath, 'utf8'));
   } catch (targetError) {
+    if (targetError?.code !== 'ENOENT') throw targetError;
     try {
       return JSON.parse(fs.readFileSync(`${targetPath}.backup`, 'utf8'));
-    } catch {
-      throw targetError;
+    } catch (backupError) {
+      if (backupError?.code === 'ENOENT') throw targetError;
+      throw backupError;
     }
   }
 };
@@ -40,13 +42,15 @@ export const replaceFile = async (temporaryPath, targetPath, platform = process.
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
       await fsp.rename(temporaryPath, targetPath);
-      return;
     } catch (error) {
       if (!isTransientWindowsReplaceError(error, platform)) throw error;
       if (attempt < maxAttempts) {
         await new Promise((resolve) => setTimeout(resolve, 25 * attempt));
       }
+      continue;
     }
+    await fsp.rm(backupPath, { force: true }).catch(() => undefined);
+    return;
   }
 
   await fsp.rename(targetPath, backupPath);
@@ -56,5 +60,5 @@ export const replaceFile = async (temporaryPath, targetPath, platform = process.
     await fsp.rename(backupPath, targetPath);
     throw error;
   }
-  await fsp.rm(backupPath, { force: true });
+  await fsp.rm(backupPath, { force: true }).catch(() => undefined);
 };

--- a/packages/electron/file-replace.mjs
+++ b/packages/electron/file-replace.mjs
@@ -21,6 +21,13 @@ export const replaceFile = async (temporaryPath, targetPath, platform = process.
     }
   }
 
-  await fsp.copyFile(temporaryPath, targetPath);
-  await fsp.rm(temporaryPath, { force: true });
+  const backupPath = `${targetPath}.backup-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  await fsp.rename(targetPath, backupPath);
+  try {
+    await fsp.rename(temporaryPath, targetPath);
+  } catch (error) {
+    await fsp.rename(backupPath, targetPath);
+    throw error;
+  }
+  await fsp.rm(backupPath, { force: true });
 };

--- a/packages/electron/file-replace.test.mjs
+++ b/packages/electron/file-replace.test.mjs
@@ -6,26 +6,61 @@ import test from 'node:test';
 
 import { replaceFile } from './file-replace.mjs';
 
-test('falls back after Windows repeatedly blocks atomic file replacement', async (t) => {
+test('moves the old file aside after Windows repeatedly blocks atomic replacement', async (t) => {
   const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-file-replace-'));
   const temporaryPath = path.join(directory, 'settings.json.tmp');
   const targetPath = path.join(directory, 'settings.json');
+  const rename = fsp.rename.bind(fsp);
   let renameAttempts = 0;
   t.after(() => fsp.rm(directory, { recursive: true, force: true }));
-  t.mock.method(fsp, 'rename', async () => {
+  t.mock.method(fsp, 'rename', async (...args) => {
     renameAttempts += 1;
-    const error = new Error('operation not permitted');
-    error.code = 'EPERM';
-    throw error;
+    if (renameAttempts <= 6) {
+      const error = new Error('operation not permitted');
+      error.code = 'EPERM';
+      throw error;
+    }
+    return rename(...args);
   });
 
   await fsp.writeFile(temporaryPath, 'new settings');
   await fsp.writeFile(targetPath, 'old settings');
   await replaceFile(temporaryPath, targetPath, 'win32');
 
-  assert.equal(renameAttempts, 6);
+  assert.equal(renameAttempts, 8);
   assert.equal(await fsp.readFile(targetPath, 'utf8'), 'new settings');
   await assert.rejects(fsp.access(temporaryPath), { code: 'ENOENT' });
+  assert.deepEqual(await fsp.readdir(directory), ['settings.json']);
+});
+
+test('restores the old file when fallback promotion fails', async (t) => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-file-replace-'));
+  const temporaryPath = path.join(directory, 'settings.json.tmp');
+  const targetPath = path.join(directory, 'settings.json');
+  const rename = fsp.rename.bind(fsp);
+  let renameAttempts = 0;
+  t.after(() => fsp.rm(directory, { recursive: true, force: true }));
+  t.mock.method(fsp, 'rename', async (...args) => {
+    renameAttempts += 1;
+    if (renameAttempts <= 6) {
+      const error = new Error('operation not permitted');
+      error.code = 'EPERM';
+      throw error;
+    }
+    if (renameAttempts === 8) {
+      const error = new Error('input/output error');
+      error.code = 'EIO';
+      throw error;
+    }
+    return rename(...args);
+  });
+
+  await fsp.writeFile(temporaryPath, 'new settings');
+  await fsp.writeFile(targetPath, 'old settings');
+
+  await assert.rejects(replaceFile(temporaryPath, targetPath, 'win32'), { code: 'EIO' });
+  assert.equal(await fsp.readFile(targetPath, 'utf8'), 'old settings');
+  assert.equal(await fsp.readFile(temporaryPath, 'utf8'), 'new settings');
 });
 
 test('does not mask non-transient replacement errors', async (t) => {

--- a/packages/electron/file-replace.test.mjs
+++ b/packages/electron/file-replace.test.mjs
@@ -15,7 +15,7 @@ test('moves the old file aside after Windows repeatedly blocks atomic replacemen
   t.after(() => fsp.rm(directory, { recursive: true, force: true }));
   t.mock.method(fsp, 'rename', async (...args) => {
     renameAttempts += 1;
-    if (renameAttempts <= 6) {
+    if (renameAttempts <= 7) {
       const error = new Error('operation not permitted');
       error.code = 'EPERM';
       throw error;
@@ -38,21 +38,27 @@ test('restores the old file when fallback promotion fails', async (t) => {
   const temporaryPath = path.join(directory, 'settings.json.tmp');
   const targetPath = path.join(directory, 'settings.json');
   const rename = fsp.rename.bind(fsp);
+  const link = fsp.link.bind(fsp);
   let renameAttempts = 0;
+  let linkAttempts = 0;
   t.after(() => fsp.rm(directory, { recursive: true, force: true }));
   t.mock.method(fsp, 'rename', async (...args) => {
     renameAttempts += 1;
-    if (renameAttempts <= 6) {
+    if (renameAttempts <= 7) {
       const error = new Error('operation not permitted');
       error.code = 'EPERM';
       throw error;
     }
-    if (renameAttempts === 8) {
+    return rename(...args);
+  });
+  t.mock.method(fsp, 'link', async (...args) => {
+    linkAttempts += 1;
+    if (linkAttempts === 2) {
       const error = new Error('input/output error');
       error.code = 'EIO';
       throw error;
     }
-    return rename(...args);
+    return link(...args);
   });
 
   await fsp.writeFile(temporaryPath, 'new settings');
@@ -61,6 +67,7 @@ test('restores the old file when fallback promotion fails', async (t) => {
   await assert.rejects(replaceFile(temporaryPath, targetPath, 'win32'), { code: 'EIO' });
   assert.equal(await fsp.readFile(targetPath, 'utf8'), 'old settings');
   assert.equal(await fsp.readFile(temporaryPath, 'utf8'), 'new settings');
+  assert.equal(linkAttempts, 3);
 });
 
 test('reads the backup when fallback rollback also fails', async (t) => {
@@ -68,21 +75,25 @@ test('reads the backup when fallback rollback also fails', async (t) => {
   const temporaryPath = path.join(directory, 'settings.json.tmp');
   const targetPath = path.join(directory, 'settings.json');
   const rename = fsp.rename.bind(fsp);
+  const link = fsp.link.bind(fsp);
   let renameAttempts = 0;
+  let linkAttempts = 0;
   t.after(() => fsp.rm(directory, { recursive: true, force: true }));
   t.mock.method(fsp, 'rename', async (...args) => {
     renameAttempts += 1;
-    if (renameAttempts <= 6) {
+    if (renameAttempts <= 7) {
       const error = new Error('operation not permitted');
       error.code = 'EPERM';
       throw error;
     }
-    if (renameAttempts >= 8) {
-      const error = new Error('input/output error');
-      error.code = 'EIO';
-      throw error;
-    }
     return rename(...args);
+  });
+  t.mock.method(fsp, 'link', async (...args) => {
+    linkAttempts += 1;
+    if (linkAttempts === 1) return link(...args);
+    const error = new Error('input/output error');
+    error.code = 'EIO';
+    throw error;
   });
 
   await fsp.writeFile(temporaryPath, '{"theme":"new"}');
@@ -91,12 +102,129 @@ test('reads the backup when fallback rollback also fails', async (t) => {
   await assert.rejects(replaceFile(temporaryPath, targetPath, 'win32'), { code: 'EIO' });
   assert.deepEqual(readJsonFileWithBackup(targetPath), { theme: 'old' });
   await assert.rejects(fsp.access(targetPath), { code: 'ENOENT' });
-  assert.equal(await fsp.readFile(`${targetPath}.backup`, 'utf8'), '{"theme":"old"}');
+  const backupName = (await fsp.readdir(directory)).find((name) => name.startsWith('settings.json.backup-'));
+  assert.equal(await fsp.readFile(path.join(directory, backupName), 'utf8'), '{"theme":"old"}');
+});
+
+test('does not overwrite a concurrent writer while rolling back', async (t) => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-file-replace-'));
+  const temporaryPath = path.join(directory, 'settings.json.tmp');
+  const targetPath = path.join(directory, 'settings.json');
+  const rename = fsp.rename.bind(fsp);
+  const link = fsp.link.bind(fsp);
+  let renameAttempts = 0;
+  let linkAttempts = 0;
+  t.after(() => fsp.rm(directory, { recursive: true, force: true }));
+  t.mock.method(fsp, 'rename', async (...args) => {
+    renameAttempts += 1;
+    if (renameAttempts <= 7) {
+      const error = new Error('operation not permitted');
+      error.code = 'EPERM';
+      throw error;
+    }
+    return rename(...args);
+  });
+  t.mock.method(fsp, 'link', async (...args) => {
+    linkAttempts += 1;
+    if (linkAttempts === 2) {
+      await fsp.writeFile(targetPath, 'concurrent settings');
+    }
+    return link(...args);
+  });
+  await fsp.writeFile(temporaryPath, 'new settings');
+  await fsp.writeFile(targetPath, 'old settings');
+
+  await assert.rejects(replaceFile(temporaryPath, targetPath, 'win32'), { code: 'EEXIST' });
+
+  assert.equal(await fsp.readFile(targetPath, 'utf8'), 'concurrent settings');
+  assert.equal(linkAttempts, 3);
+  const backupName = (await fsp.readdir(directory)).find((name) => name.startsWith('settings.json.backup-'));
+  assert.equal(await fsp.readFile(path.join(directory, backupName), 'utf8'), 'old settings');
+});
+
+test('keeps the canonical file when hard links are unavailable', async (t) => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-file-replace-'));
+  const temporaryPath = path.join(directory, 'settings.json.tmp');
+  const targetPath = path.join(directory, 'settings.json');
+  let renameAttempts = 0;
+  t.after(() => fsp.rm(directory, { recursive: true, force: true }));
+  t.mock.method(fsp, 'rename', async () => {
+    renameAttempts += 1;
+    const error = new Error('operation not permitted');
+    error.code = 'EPERM';
+    throw error;
+  });
+  t.mock.method(fsp, 'link', async () => {
+    const error = new Error('operation not supported');
+    error.code = 'ENOTSUP';
+    throw error;
+  });
+  await fsp.writeFile(temporaryPath, 'new settings');
+  await fsp.writeFile(targetPath, 'old settings');
+
+  await assert.rejects(replaceFile(temporaryPath, targetPath, 'win32'), { code: 'ENOTSUP' });
+
+  assert.equal(renameAttempts, 7);
+  assert.equal(await fsp.readFile(targetPath, 'utf8'), 'old settings');
+  assert.equal(await fsp.readFile(temporaryPath, 'utf8'), 'new settings');
+});
+
+test('serializes concurrent Windows fallbacks', async (t) => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-file-replace-'));
+  const firstTemporaryPath = path.join(directory, 'settings.json.first.tmp');
+  const secondTemporaryPath = path.join(directory, 'settings.json.second.tmp');
+  const targetPath = path.join(directory, 'settings.json');
+  const rename = fsp.rename.bind(fsp);
+  const attempts = new Map();
+  let backupMoves = 0;
+  let releaseFirstFallback;
+  const holdFirstFallback = new Promise((resolve) => {
+    releaseFirstFallback = resolve;
+  });
+  let firstFallbackEntered;
+  const firstFallback = new Promise((resolve) => {
+    firstFallbackEntered = resolve;
+  });
+  t.after(() => fsp.rm(directory, { recursive: true, force: true }));
+  t.mock.method(fsp, 'rename', async (from, to) => {
+    if (to === targetPath && (from === firstTemporaryPath || from === secondTemporaryPath)) {
+      const attempt = (attempts.get(from) || 0) + 1;
+      attempts.set(from, attempt);
+      if (attempt <= 7) {
+        const error = new Error('operation not permitted');
+        error.code = 'EPERM';
+        throw error;
+      }
+    }
+    if (from === targetPath && to.startsWith(`${targetPath}.backup-`)) {
+      backupMoves += 1;
+      if (backupMoves === 1) {
+        firstFallbackEntered();
+        await holdFirstFallback;
+      }
+    }
+    return rename(from, to);
+  });
+  await fsp.writeFile(firstTemporaryPath, 'first settings');
+  await fsp.writeFile(secondTemporaryPath, 'second settings');
+  await fsp.writeFile(targetPath, 'old settings');
+
+  const firstReplacement = replaceFile(firstTemporaryPath, targetPath, 'win32');
+  const secondReplacement = replaceFile(secondTemporaryPath, targetPath, 'win32');
+  await firstFallback;
+
+  assert.equal(attempts.get(firstTemporaryPath), 7);
+  assert.equal(attempts.get(secondTemporaryPath), 6);
+  assert.equal(backupMoves, 1);
+
+  releaseFirstFallback();
+  await Promise.all([firstReplacement, secondReplacement]);
+  assert.equal(backupMoves, 2);
+  assert.equal(await fsp.readFile(targetPath, 'utf8'), 'second settings');
 });
 
 test('does not mask non-transient replacement errors', async (t) => {
   let renameAttempts = 0;
-  t.mock.method(fsp, 'access', async () => {});
   t.mock.method(fsp, 'rename', async () => {
     renameAttempts += 1;
     const error = new Error('input/output error');

--- a/packages/electron/file-replace.test.mjs
+++ b/packages/electron/file-replace.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { replaceFile } from './file-replace.mjs';
+
+test('falls back after Windows repeatedly blocks atomic file replacement', async (t) => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-file-replace-'));
+  const temporaryPath = path.join(directory, 'settings.json.tmp');
+  const targetPath = path.join(directory, 'settings.json');
+  let renameAttempts = 0;
+  t.after(() => fsp.rm(directory, { recursive: true, force: true }));
+  t.mock.method(fsp, 'rename', async () => {
+    renameAttempts += 1;
+    const error = new Error('operation not permitted');
+    error.code = 'EPERM';
+    throw error;
+  });
+
+  await fsp.writeFile(temporaryPath, 'new settings');
+  await fsp.writeFile(targetPath, 'old settings');
+  await replaceFile(temporaryPath, targetPath, 'win32');
+
+  assert.equal(renameAttempts, 6);
+  assert.equal(await fsp.readFile(targetPath, 'utf8'), 'new settings');
+  await assert.rejects(fsp.access(temporaryPath), { code: 'ENOENT' });
+});
+
+test('does not mask non-transient replacement errors', async (t) => {
+  let renameAttempts = 0;
+  t.mock.method(fsp, 'rename', async () => {
+    renameAttempts += 1;
+    const error = new Error('input/output error');
+    error.code = 'EIO';
+    throw error;
+  });
+
+  await assert.rejects(replaceFile('temporary', 'target', 'win32'), { code: 'EIO' });
+  assert.equal(renameAttempts, 1);
+});

--- a/packages/electron/file-replace.test.mjs
+++ b/packages/electron/file-replace.test.mjs
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { replaceFile } from './file-replace.mjs';
+import { readJsonFileWithBackup, replaceFile } from './file-replace.mjs';
 
 test('moves the old file aside after Windows repeatedly blocks atomic replacement', async (t) => {
   const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-file-replace-'));
@@ -63,8 +63,40 @@ test('restores the old file when fallback promotion fails', async (t) => {
   assert.equal(await fsp.readFile(temporaryPath, 'utf8'), 'new settings');
 });
 
+test('reads the backup when fallback rollback also fails', async (t) => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-file-replace-'));
+  const temporaryPath = path.join(directory, 'settings.json.tmp');
+  const targetPath = path.join(directory, 'settings.json');
+  const rename = fsp.rename.bind(fsp);
+  let renameAttempts = 0;
+  t.after(() => fsp.rm(directory, { recursive: true, force: true }));
+  t.mock.method(fsp, 'rename', async (...args) => {
+    renameAttempts += 1;
+    if (renameAttempts <= 6) {
+      const error = new Error('operation not permitted');
+      error.code = 'EPERM';
+      throw error;
+    }
+    if (renameAttempts >= 8) {
+      const error = new Error('input/output error');
+      error.code = 'EIO';
+      throw error;
+    }
+    return rename(...args);
+  });
+
+  await fsp.writeFile(temporaryPath, '{"theme":"new"}');
+  await fsp.writeFile(targetPath, '{"theme":"old"}');
+
+  await assert.rejects(replaceFile(temporaryPath, targetPath, 'win32'), { code: 'EIO' });
+  assert.deepEqual(readJsonFileWithBackup(targetPath), { theme: 'old' });
+  await assert.rejects(fsp.access(targetPath), { code: 'ENOENT' });
+  assert.equal(await fsp.readFile(`${targetPath}.backup`, 'utf8'), '{"theme":"old"}');
+});
+
 test('does not mask non-transient replacement errors', async (t) => {
   let renameAttempts = 0;
+  t.mock.method(fsp, 'access', async () => {});
   t.mock.method(fsp, 'rename', async () => {
     renameAttempts += 1;
     const error = new Error('input/output error');

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -543,7 +543,7 @@ const sshManager = new ElectronSshManager({
 
 const readJsonFile = (filePath) => {
   try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return readJsonFileWithBackup(filePath);
   } catch (error) {
     if (error && error.code === 'ENOENT') return {};
     // Parse errors can happen if a concurrent writer just truncated the file

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import updaterPkg from 'electron-updater';
 import { ElectronSshManager } from './ssh-manager.mjs';
-import { replaceFileWithRetry } from './windows-file-replace.mjs';
+import { readJsonFileWithBackup, replaceFile } from './file-replace.mjs';
 import { createTrayController } from './tray.mjs';
 import { resolveManagedOpenCodeCwd } from './opencode-cwd.mjs';
 import { resolveStartupUrlProbePlan, shouldIgnoreLoopbackConnectionLimit } from './startup-url-selection.mjs';
@@ -564,7 +564,7 @@ const writeJsonFile = async (filePath, data) => {
   try {
     await fsp.writeFile(tmp, JSON.stringify(data, null, 2), { encoding: 'utf8', mode: 0o600 });
     if (process.platform !== 'win32') await fsp.chmod(tmp, 0o600);
-    await replaceFileWithRetry(tmp, filePath);
+    await replaceFile(tmp, filePath);
     if (process.platform !== 'win32') await fsp.chmod(filePath, 0o600);
   } catch (error) {
     await fsp.rm(tmp, { force: true }).catch(() => {});

--- a/packages/electron/ssh-manager.mjs
+++ b/packages/electron/ssh-manager.mjs
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 
-import { replaceFileWithRetry } from './windows-file-replace.mjs';
+import { readJsonFileWithBackup, replaceFile } from './file-replace.mjs';
 
 const LOCAL_HOST_ID = 'local';
 const DEFAULT_CONNECTION_TIMEOUT_SEC = 60;
@@ -87,7 +87,7 @@ const expandSshIncludeToken = (token, baseDir) => {
 
 const readJsonRoot = (settingsFilePath) => {
   try {
-    const parsed = JSON.parse(fs.readFileSync(settingsFilePath, 'utf8'));
+    const parsed = readJsonFileWithBackup(settingsFilePath);
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
   } catch {
     return {};
@@ -102,7 +102,7 @@ const writeJsonRoot = async (settingsFilePath, root) => {
   const tmp = `${settingsFilePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   try {
     await fsp.writeFile(tmp, JSON.stringify(root, null, 2));
-    await replaceFileWithRetry(tmp, settingsFilePath);
+    await replaceFile(tmp, settingsFilePath);
   } catch (error) {
     await fsp.rm(tmp, { force: true }).catch(() => {});
     throw error;

--- a/packages/vscode/src/DOCUMENTATION.md
+++ b/packages/vscode/src/DOCUMENTATION.md
@@ -62,7 +62,7 @@ The webview CSP permits `blob:` only for `worker-src` so shared UI parsers can r
   - OpenCode JSONC reads in `opencodeConfig.ts` fail closed on a partial or non-object `jsonc-parser` tree (`INVALID_JSONC`) so mutations cannot rewrite a `$schema`-only stub over an existing config. Comment-only files read as empty, while other content that yields no JSON value (YAML, plain text) fails closed. A broken layer is omitted from the merge and recorded on `layerErrors`; valid sibling layers still load, including plugin list/read via `getPluginConfigSources`. Writes still refuse to overwrite the broken file.
 
 - `bridge-settings-runtime.ts`
-  - Settings read/write and OpenCode skills discovery via API for bridge consumers.
+  - Settings read/write and OpenCode skills discovery via API for bridge consumers. Shared reads recognize Electron's stable `settings.json.backup` before read-modify-write.
 
 - `bridge-system-runtime.ts`
   - System/editor/provider/quota/notification/update-check message handlers.

--- a/packages/vscode/src/DOCUMENTATION.md
+++ b/packages/vscode/src/DOCUMENTATION.md
@@ -62,7 +62,7 @@ The webview CSP permits `blob:` only for `worker-src` so shared UI parsers can r
   - OpenCode JSONC reads in `opencodeConfig.ts` fail closed on a partial or non-object `jsonc-parser` tree (`INVALID_JSONC`) so mutations cannot rewrite a `$schema`-only stub over an existing config. Comment-only files read as empty, while other content that yields no JSON value (YAML, plain text) fails closed. A broken layer is omitted from the merge and recorded on `layerErrors`; valid sibling layers still load, including plugin list/read via `getPluginConfigSources`. Writes still refuse to overwrite the broken file.
 
 - `bridge-settings-runtime.ts`
-  - Settings read/write and OpenCode skills discovery via API for bridge consumers. Shared reads recognize Electron's stable `settings.json.backup` before read-modify-write.
+  - Settings read/write and OpenCode skills discovery via API for bridge consumers. Shared reads recognize Electron's per-write settings backups before read-modify-write.
 
 - `bridge-system-runtime.ts`
   - System/editor/provider/quota/notification/update-check message handlers.

--- a/packages/vscode/src/bridge-settings-runtime.ts
+++ b/packages/vscode/src/bridge-settings-runtime.ts
@@ -183,7 +183,6 @@ const writeSharedSettingsToDisk = async (changes: Record<string, unknown>): Prom
     tmp = `${OPENCHAMBER_SHARED_SETTINGS_PATH}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await fs.promises.writeFile(tmp, JSON.stringify(next, null, 2), 'utf8');
     await fs.promises.rename(tmp, OPENCHAMBER_SHARED_SETTINGS_PATH);
-    await fs.promises.rm(`${OPENCHAMBER_SHARED_SETTINGS_PATH}.backup`, { force: true }).catch(() => undefined);
   } catch {
     if (tmp) {
       await fs.promises.rm(tmp, { force: true }).catch(() => {});

--- a/packages/vscode/src/bridge-settings-runtime.ts
+++ b/packages/vscode/src/bridge-settings-runtime.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { BUILT_IN_SKILL_LOCATION, type DiscoveredSkill, type SkillScope, type SkillSource } from './opencodeConfig';
 import type { BridgeContext } from './bridge';
+import { mergeSharedSettings, readSharedSettingsFile } from './shared-settings-file';
 
 const SETTINGS_KEY = 'openchamber.settings';
 const OPENCHAMBER_SHARED_SETTINGS_PATH = path.join(os.homedir(), '.config', 'openchamber', 'settings.json');
@@ -161,8 +162,7 @@ export const fetchOpenCodeSkillsFromApi = async (
 
 const readSharedSettingsFromDisk = (): Record<string, unknown> => {
   try {
-    const raw = fs.readFileSync(OPENCHAMBER_SHARED_SETTINGS_PATH, 'utf8');
-    const parsed = JSON.parse(raw) as unknown;
+    const parsed = readSharedSettingsFile(OPENCHAMBER_SHARED_SETTINGS_PATH);
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed as Record<string, unknown>;
     }
@@ -177,12 +177,13 @@ const writeSharedSettingsToDisk = async (changes: Record<string, unknown>): Prom
   try {
     await fs.promises.mkdir(path.dirname(OPENCHAMBER_SHARED_SETTINGS_PATH), { recursive: true });
     const current = readSharedSettingsFromDisk();
-    const next: Record<string, unknown> = { ...current, ...changes };
+    const next = mergeSharedSettings(current, changes);
     // Atomic write: tmp file + rename. Readers never see a partial/truncated
     // JSON that would fail to parse and silently get coerced to {}.
     tmp = `${OPENCHAMBER_SHARED_SETTINGS_PATH}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await fs.promises.writeFile(tmp, JSON.stringify(next, null, 2), 'utf8');
     await fs.promises.rename(tmp, OPENCHAMBER_SHARED_SETTINGS_PATH);
+    await fs.promises.rm(`${OPENCHAMBER_SHARED_SETTINGS_PATH}.backup`, { force: true }).catch(() => undefined);
   } catch {
     if (tmp) {
       await fs.promises.rm(tmp, { force: true }).catch(() => {});

--- a/packages/vscode/src/opencode.ts
+++ b/packages/vscode/src/opencode.ts
@@ -11,6 +11,7 @@ import { normalizeWindowsDriveLetter } from './pathUtils';
 import { resolveWorkingDirectoryChange } from './workingDirectoryChange';
 import { registerManagedProcess, unregisterManagedProcess, reapOrphanedProcesses } from './opencodeProcessRegistry';
 import { applyProviderEnvAliases } from './provider-env-aliases';
+import { readSharedSettingsFile } from './shared-settings-file';
 
 const t = vscode.l10n.t;
 
@@ -86,8 +87,7 @@ function isValidOpenCodePassword(password: string): boolean {
 function readOpenChamberSettings(): Record<string, unknown> {
   const settingsPath = path.join(os.homedir(), '.config', 'openchamber', 'settings.json');
   try {
-    const raw = fs.readFileSync(settingsPath, 'utf8');
-    const parsed = JSON.parse(raw) as unknown;
+    const parsed = readSharedSettingsFile(settingsPath);
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed as Record<string, unknown>;
     }

--- a/packages/vscode/src/shared-settings-file.test.ts
+++ b/packages/vscode/src/shared-settings-file.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { mergeSharedSettings, readSharedSettingsFile } from './shared-settings-file';
+
+test('preserves backup fields while preparing a partial settings write', (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'openchamber-vscode-settings-'));
+  const settingsPath = path.join(directory, 'settings.json');
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  fs.writeFileSync(`${settingsPath}.backup`, '{"theme":"old"}');
+
+  const current = readSharedSettingsFile(settingsPath);
+  assert.deepEqual(mergeSharedSettings(current, { chatMessageWidthMode: 'fluid' }), {
+    theme: 'old',
+    chatMessageWidthMode: 'fluid',
+  });
+});

--- a/packages/vscode/src/shared-settings-file.test.ts
+++ b/packages/vscode/src/shared-settings-file.test.ts
@@ -10,7 +10,7 @@ test('preserves backup fields while preparing a partial settings write', (t) => 
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'openchamber-vscode-settings-'));
   const settingsPath = path.join(directory, 'settings.json');
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
-  fs.writeFileSync(`${settingsPath}.backup`, '{"theme":"old"}');
+  fs.writeFileSync(`${settingsPath}.backup-1-electron`, '{"theme":"old"}');
 
   const current = readSharedSettingsFile(settingsPath);
   assert.deepEqual(mergeSharedSettings(current, { chatMessageWidthMode: 'fluid' }), {

--- a/packages/vscode/src/shared-settings-file.ts
+++ b/packages/vscode/src/shared-settings-file.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 export type SharedSettingsJson = string | number | boolean | null | SharedSettingsJson[] | {
   [key: string]: SharedSettingsJson;
 };
 
-export const mergeSharedSettings = <Changes extends object>(current: SharedSettingsJson, changes: Changes) => (
+export const mergeSharedSettings = <Current, Changes extends object>(current: Current, changes: Changes) => (
   Object.assign({}, current, changes)
 );
 
@@ -13,11 +14,25 @@ export const readSharedSettingsFile = (filePath: string): SharedSettingsJson => 
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
   } catch (targetError) {
     if (targetError instanceof Error && 'code' in targetError && targetError.code !== 'ENOENT') throw targetError;
+    const directory = path.dirname(filePath);
+    const backupName = `${path.basename(filePath)}.backup`;
+    let names: string[];
     try {
-      return JSON.parse(fs.readFileSync(`${filePath}.backup`, 'utf8'));
+      names = fs.readdirSync(directory);
+    } catch {
+      throw targetError;
+    }
+    const name = names.filter((name) => name === backupName || name.startsWith(`${backupName}-`)).sort().at(-1);
+    if (!name) throw targetError;
+    try {
+      return JSON.parse(fs.readFileSync(path.join(directory, name), 'utf8'));
     } catch (backupError) {
-      if (backupError instanceof Error && 'code' in backupError && backupError.code === 'ENOENT') throw targetError;
-      throw backupError;
+      try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      } catch (retryError) {
+        if (retryError instanceof Error && 'code' in retryError && retryError.code !== 'ENOENT') throw retryError;
+        throw backupError;
+      }
     }
   }
 };

--- a/packages/vscode/src/shared-settings-file.ts
+++ b/packages/vscode/src/shared-settings-file.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+
+export type SharedSettingsJson = string | number | boolean | null | SharedSettingsJson[] | {
+  [key: string]: SharedSettingsJson;
+};
+
+export const mergeSharedSettings = <Changes extends object>(current: SharedSettingsJson, changes: Changes) => (
+  Object.assign({}, current, changes)
+);
+
+export const readSharedSettingsFile = (filePath: string): SharedSettingsJson => {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (targetError) {
+    if (targetError instanceof Error && 'code' in targetError && targetError.code !== 'ENOENT') throw targetError;
+    try {
+      return JSON.parse(fs.readFileSync(`${filePath}.backup`, 'utf8'));
+    } catch (backupError) {
+      if (backupError instanceof Error && 'code' in backupError && backupError.code === 'ENOENT') throw targetError;
+      throw backupError;
+    }
+  }
+};

--- a/packages/web/bin/lib/commands-connect-url.js
+++ b/packages/web/bin/lib/commands-connect-url.js
@@ -70,7 +70,6 @@ function createSettingsAccessors() {
     const temporaryPath = `${settingsPath}.tmp-${process.pid}-${Date.now()}`;
     await fs.promises.writeFile(temporaryPath, JSON.stringify(settings, null, 2), 'utf8');
     await fs.promises.rename(temporaryPath, settingsPath);
-    await fs.promises.rm(`${settingsPath}.backup`, { force: true }).catch(() => undefined);
   };
   return { readSettingsFromDiskMigrated, writeSettingsToDisk };
 }

--- a/packages/web/bin/lib/commands-connect-url.js
+++ b/packages/web/bin/lib/commands-connect-url.js
@@ -17,6 +17,7 @@ import { createClientPairingRuntime } from '../../server/lib/client-auth/pairing
 import { createRelayIdentityRuntime } from '../../server/lib/relay/identity.js';
 import { DEFAULT_RELAY_URL } from '../../server/lib/relay/service.js';
 import { bytesToBase64Url } from '../../server/lib/relay/e2ee.js';
+import { readJsonFileWithBackup } from '../../server/lib/opencode/settings-file.js';
 import {
   intro as clackIntro,
   outro as clackOutro,
@@ -59,14 +60,17 @@ function createSettingsAccessors() {
   const settingsPath = path.join(getOpenChamberDataDir(), SETTINGS_FILE_NAME);
   const readSettingsFromDiskMigrated = async () => {
     try {
-      return JSON.parse(await fs.promises.readFile(settingsPath, 'utf8'));
+      return await readJsonFileWithBackup(fs.promises, settingsPath);
     } catch {
       return {};
     }
   };
   const writeSettingsToDisk = async (settings) => {
     await fs.promises.mkdir(path.dirname(settingsPath), { recursive: true });
-    await fs.promises.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
+    const temporaryPath = `${settingsPath}.tmp-${process.pid}-${Date.now()}`;
+    await fs.promises.writeFile(temporaryPath, JSON.stringify(settings, null, 2), 'utf8');
+    await fs.promises.rename(temporaryPath, settingsPath);
+    await fs.promises.rm(`${settingsPath}.backup`, { force: true }).catch(() => undefined);
   };
   return { readSettingsFromDiskMigrated, writeSettingsToDisk };
 }

--- a/packages/web/server/lib/github/auth.js
+++ b/packages/web/server/lib/github/auth.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { readJsonFileWithBackupSync } from '../opencode/settings-file.js';
 
 const OPENCHAMBER_DATA_DIR = process.env.OPENCHAMBER_DATA_DIR
   ? path.resolve(process.env.OPENCHAMBER_DATA_DIR)
@@ -162,9 +163,7 @@ function writeAuthList(list) {
 
 function readSettingsFile() {
   try {
-    if (fs.existsSync(SETTINGS_FILE)) {
-      return JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf8')) || {};
-    }
+    return readJsonFileWithBackupSync(fs, SETTINGS_FILE) || {};
   } catch {
     // ignore
   }
@@ -181,6 +180,11 @@ function writeSettingsFile(settings) {
     // best-effort
   }
   fs.renameSync(tmpFile, SETTINGS_FILE);
+  try {
+    fs.rmSync(`${SETTINGS_FILE}.backup`, { force: true });
+  } catch {
+    // The canonical file is already complete.
+  }
   try {
     fs.chmodSync(SETTINGS_FILE, 0o600);
   } catch {

--- a/packages/web/server/lib/github/auth.js
+++ b/packages/web/server/lib/github/auth.js
@@ -181,11 +181,6 @@ function writeSettingsFile(settings) {
   }
   fs.renameSync(tmpFile, SETTINGS_FILE);
   try {
-    fs.rmSync(`${SETTINGS_FILE}.backup`, { force: true });
-  } catch {
-    // The canonical file is already complete.
-  }
-  try {
     fs.chmodSync(SETTINGS_FILE, 0o600);
   } catch {
     // best-effort

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -40,6 +40,7 @@ This module provides OpenCode server integration utilities for the web server ru
 - `packages/web/server/lib/opencode/project-icon-routes.js`: project icon upload/read/discovery route registration and icon storage orchestration.
 - `packages/web/server/lib/opencode/skill-routes.js`: route registration for skill config CRUD, supporting files, and skills catalog scan/install flows.
 - `packages/web/server/lib/opencode/settings-runtime.js`: Settings persistence runtime (disk IO, migrations, normalization, project validation, and persisted update serialization).
+- `packages/web/server/lib/opencode/settings-file.js`: canonical settings JSON reads with recovery from Electron's stable replacement backup.
 - `packages/web/server/lib/opencode/settings-helpers.js`: Settings payload sanitization/format helpers runtime for response shaping and persisted merge prep.
 - `packages/web/server/lib/opencode/settings-normalization-runtime.js`: path/settings/tunnel normalization and sanitization helpers runtime used by settings/routes/config wiring.
 - `packages/web/server/lib/opencode/theme-runtime.js`: custom theme JSON validation and theme directory loading runtime for settings utility routes.

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -40,7 +40,7 @@ This module provides OpenCode server integration utilities for the web server ru
 - `packages/web/server/lib/opencode/project-icon-routes.js`: project icon upload/read/discovery route registration and icon storage orchestration.
 - `packages/web/server/lib/opencode/skill-routes.js`: route registration for skill config CRUD, supporting files, and skills catalog scan/install flows.
 - `packages/web/server/lib/opencode/settings-runtime.js`: Settings persistence runtime (disk IO, migrations, normalization, project validation, and persisted update serialization).
-- `packages/web/server/lib/opencode/settings-file.js`: canonical settings JSON reads with recovery from Electron's stable replacement backup.
+- `packages/web/server/lib/opencode/settings-file.js`: canonical settings JSON reads with recovery from Electron's per-write replacement backups.
 - `packages/web/server/lib/opencode/settings-helpers.js`: Settings payload sanitization/format helpers runtime for response shaping and persisted merge prep.
 - `packages/web/server/lib/opencode/settings-normalization-runtime.js`: path/settings/tunnel normalization and sanitization helpers runtime used by settings/routes/config wiring.
 - `packages/web/server/lib/opencode/theme-runtime.js`: custom theme JSON validation and theme directory loading runtime for settings utility routes.

--- a/packages/web/server/lib/opencode/settings-file.js
+++ b/packages/web/server/lib/opencode/settings-file.js
@@ -1,13 +1,33 @@
+import path from 'node:path';
+
+const latestBackupName = (names, filePath) => {
+  const backupName = `${path.basename(filePath)}.backup`;
+  return names.filter((name) => name === backupName || name.startsWith(`${backupName}-`)).sort().at(-1);
+};
+
 export const readJsonFileWithBackup = async (fsPromises, filePath) => {
   try {
     return JSON.parse(await fsPromises.readFile(filePath, 'utf8'));
   } catch (targetError) {
     if (targetError?.code !== 'ENOENT') throw targetError;
+    const directory = path.dirname(filePath);
+    let names;
     try {
-      return JSON.parse(await fsPromises.readFile(`${filePath}.backup`, 'utf8'));
+      names = await fsPromises.readdir(directory);
+    } catch {
+      throw targetError;
+    }
+    const name = latestBackupName(names, filePath);
+    if (!name) throw targetError;
+    try {
+      return JSON.parse(await fsPromises.readFile(path.join(directory, name), 'utf8'));
     } catch (backupError) {
-      if (backupError?.code === 'ENOENT') throw targetError;
-      throw backupError;
+      try {
+        return JSON.parse(await fsPromises.readFile(filePath, 'utf8'));
+      } catch (retryError) {
+        if (retryError?.code !== 'ENOENT') throw retryError;
+        throw backupError;
+      }
     }
   }
 };
@@ -17,11 +37,24 @@ export const readJsonFileWithBackupSync = (fs, filePath) => {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
   } catch (targetError) {
     if (targetError?.code !== 'ENOENT') throw targetError;
+    const directory = path.dirname(filePath);
+    let names;
     try {
-      return JSON.parse(fs.readFileSync(`${filePath}.backup`, 'utf8'));
+      names = fs.readdirSync(directory);
+    } catch {
+      throw targetError;
+    }
+    const name = latestBackupName(names, filePath);
+    if (!name) throw targetError;
+    try {
+      return JSON.parse(fs.readFileSync(path.join(directory, name), 'utf8'));
     } catch (backupError) {
-      if (backupError?.code === 'ENOENT') throw targetError;
-      throw backupError;
+      try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      } catch (retryError) {
+        if (retryError?.code !== 'ENOENT') throw retryError;
+        throw backupError;
+      }
     }
   }
 };

--- a/packages/web/server/lib/opencode/settings-file.js
+++ b/packages/web/server/lib/opencode/settings-file.js
@@ -1,0 +1,27 @@
+export const readJsonFileWithBackup = async (fsPromises, filePath) => {
+  try {
+    return JSON.parse(await fsPromises.readFile(filePath, 'utf8'));
+  } catch (targetError) {
+    if (targetError?.code !== 'ENOENT') throw targetError;
+    try {
+      return JSON.parse(await fsPromises.readFile(`${filePath}.backup`, 'utf8'));
+    } catch (backupError) {
+      if (backupError?.code === 'ENOENT') throw targetError;
+      throw backupError;
+    }
+  }
+};
+
+export const readJsonFileWithBackupSync = (fs, filePath) => {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (targetError) {
+    if (targetError?.code !== 'ENOENT') throw targetError;
+    try {
+      return JSON.parse(fs.readFileSync(`${filePath}.backup`, 'utf8'));
+    } catch (backupError) {
+      if (backupError?.code === 'ENOENT') throw targetError;
+      throw backupError;
+    }
+  }
+};

--- a/packages/web/server/lib/opencode/settings-file.test.js
+++ b/packages/web/server/lib/opencode/settings-file.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { readJsonFileWithBackup, readJsonFileWithBackupSync } from './settings-file.js';
+
+describe('settings backup reads', () => {
+  it('uses the backup when the canonical file is unavailable', async () => {
+    const readFile = vi.fn(async (filePath) => {
+      if (filePath.endsWith('.backup')) return '{"theme":"old"}';
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+    });
+
+    await expect(readJsonFileWithBackup({ readFile }, 'settings.json')).resolves.toEqual({ theme: 'old' });
+  });
+
+  it('uses the backup when the canonical file is missing', () => {
+    const readFileSync = vi.fn((filePath) => {
+      if (filePath.endsWith('.backup')) return '{"theme":"old"}';
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+    });
+
+    expect(readJsonFileWithBackupSync({ readFileSync }, 'settings.json')).toEqual({ theme: 'old' });
+  });
+
+  it('does not hide a malformed recovery backup as a missing canonical file', async () => {
+    const readFile = vi.fn(async (filePath) => {
+      if (filePath.endsWith('.backup')) return '{';
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+    });
+
+    await expect(readJsonFileWithBackup({ readFile }, 'settings.json')).rejects.toBeInstanceOf(SyntaxError);
+  });
+});

--- a/packages/web/server/lib/opencode/settings-file.test.js
+++ b/packages/web/server/lib/opencode/settings-file.test.js
@@ -1,32 +1,45 @@
-import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { readJsonFileWithBackup, readJsonFileWithBackupSync } from './settings-file.js';
 
 describe('settings backup reads', () => {
-  it('uses the backup when the canonical file is unavailable', async () => {
-    const readFile = vi.fn(async (filePath) => {
-      if (filePath.endsWith('.backup')) return '{"theme":"old"}';
-      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
-    });
+  let directory;
+  let settingsPath;
 
-    await expect(readJsonFileWithBackup({ readFile }, 'settings.json')).resolves.toEqual({ theme: 'old' });
+  beforeEach(async () => {
+    directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'openchamber-settings-file-'));
+    settingsPath = path.join(directory, 'settings.json');
+  });
+
+  afterEach(() => fsp.rm(directory, { recursive: true, force: true }));
+
+  it('uses the backup when the canonical file is unavailable', async () => {
+    await fsp.writeFile(`${settingsPath}.backup-1-electron`, '{"theme":"old"}');
+
+    await expect(readJsonFileWithBackup(fsp, settingsPath)).resolves.toEqual({ theme: 'old' });
   });
 
   it('uses the backup when the canonical file is missing', () => {
-    const readFileSync = vi.fn((filePath) => {
-      if (filePath.endsWith('.backup')) return '{"theme":"old"}';
-      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
-    });
+    fs.writeFileSync(`${settingsPath}.backup-1-electron`, '{"theme":"old"}');
 
-    expect(readJsonFileWithBackupSync({ readFileSync }, 'settings.json')).toEqual({ theme: 'old' });
+    expect(readJsonFileWithBackupSync(fs, settingsPath)).toEqual({ theme: 'old' });
   });
 
-  it('does not hide a malformed recovery backup as a missing canonical file', async () => {
-    const readFile = vi.fn(async (filePath) => {
-      if (filePath.endsWith('.backup')) return '{';
-      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
-    });
+  it('uses the newest valid recovery backup', async () => {
+    await fsp.writeFile(`${settingsPath}.backup-1-electron`, '{"theme":"old"}');
+    await fsp.writeFile(`${settingsPath}.backup-2-electron`, '{"theme":"newer"}');
 
-    await expect(readJsonFileWithBackup({ readFile }, 'settings.json')).rejects.toBeInstanceOf(SyntaxError);
+    await expect(readJsonFileWithBackup(fsp, settingsPath)).resolves.toEqual({ theme: 'newer' });
+  });
+
+  it('does not hide malformed recovery data as a missing canonical file', async () => {
+    await fsp.writeFile(`${settingsPath}.backup-1-electron`, '{"theme":"stale"}');
+    await fsp.writeFile(`${settingsPath}.backup-2-electron`, '{');
+
+    await expect(readJsonFileWithBackup(fsp, settingsPath)).rejects.toBeInstanceOf(SyntaxError);
   });
 });

--- a/packages/web/server/lib/opencode/settings-runtime.js
+++ b/packages/web/server/lib/opencode/settings-runtime.js
@@ -1,4 +1,5 @@
 import { createProjectIdFromPath } from '../projects/project-id.js';
+import { readJsonFileWithBackup } from './settings-file.js';
 
 const DEFAULT_NOTIFICATION_TEMPLATES = {
   completion: { title: '{agent_name} is ready', message: '{model_name} completed the task' },
@@ -474,8 +475,7 @@ export const createSettingsRuntime = (deps) => {
 
   const readSettingsFromDisk = async () => {
     try {
-      const raw = await fsPromises.readFile(SETTINGS_FILE_PATH, 'utf8');
-      const parsed = JSON.parse(raw);
+      const parsed = await readJsonFileWithBackup(fsPromises, SETTINGS_FILE_PATH);
       if (parsed && typeof parsed === 'object') {
         return parsed;
       }
@@ -497,20 +497,18 @@ export const createSettingsRuntime = (deps) => {
   // the empty spread. Here only a genuinely missing file means "no settings";
   // any other failure (including a non-object payload) throws.
   const readSettingsFromDiskStrict = async () => {
-    let raw;
     try {
-      raw = await fsPromises.readFile(SETTINGS_FILE_PATH, 'utf8');
+      const parsed = await readJsonFileWithBackup(fsPromises, SETTINGS_FILE_PATH);
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Settings file is malformed (non-object payload)');
+      }
+      return parsed;
     } catch (error) {
       if (error && typeof error === 'object' && error.code === 'ENOENT') {
         return {};
       }
       throw error;
     }
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object') {
-      throw new Error('Settings file is malformed (non-object payload)');
-    }
-    return parsed;
   };
 
   const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -579,6 +577,7 @@ export const createSettingsRuntime = (deps) => {
       await fsPromises.writeFile(tmp, JSON.stringify(settings, null, 2), { encoding: 'utf8', mode: 0o600 });
       if (process.platform !== 'win32') await fsPromises.chmod(tmp, 0o600);
       await replaceFile(tmp, SETTINGS_FILE_PATH);
+      await fsPromises.rm(`${SETTINGS_FILE_PATH}.backup`, { force: true }).catch(() => undefined);
       if (process.platform !== 'win32') await fsPromises.chmod(SETTINGS_FILE_PATH, 0o600);
     } catch (error) {
       await fsPromises.rm(tmp, { force: true }).catch(() => {});

--- a/packages/web/server/lib/opencode/settings-runtime.js
+++ b/packages/web/server/lib/opencode/settings-runtime.js
@@ -577,7 +577,6 @@ export const createSettingsRuntime = (deps) => {
       await fsPromises.writeFile(tmp, JSON.stringify(settings, null, 2), { encoding: 'utf8', mode: 0o600 });
       if (process.platform !== 'win32') await fsPromises.chmod(tmp, 0o600);
       await replaceFile(tmp, SETTINGS_FILE_PATH);
-      await fsPromises.rm(`${SETTINGS_FILE_PATH}.backup`, { force: true }).catch(() => undefined);
       if (process.platform !== 'win32') await fsPromises.chmod(SETTINGS_FILE_PATH, 0o600);
     } catch (error) {
       await fsPromises.rm(tmp, { force: true }).catch(() => {});


### PR DESCRIPTION
## Intent

Windows filesystem filters can repeatedly reject atomic replacement of an existing `settings.json` with `EPERM`, preventing OpenChamber Desktop from starting. This change keeps atomic rename as the normal path, retries transient Windows replacement failures, then moves the old file aside and promotes the completed temporary file into the vacated path.

Each Windows fallback owns a unique recovery backup. Every direct read-modify-write owner for the shared settings file reads the newest backup when the canonical file is absent. Non-owning writers never delete recovery data.

Closes #2544

## Non-goals

- Changing the settings JSON format or migration behavior.
- Applying replacement fallback behavior to unrelated persisted files.
- Changing rendered UI, IPC contracts, or runtime authentication.

## Affected surfaces

- `packages/electron`: desktop and SSH settings writes use retries, serialized per-write fallbacks, no-overwrite hard-link promotion and rollback, and backup-aware reads.
- `packages/web`: the settings runtime, GitHub settings mutations, and `connect-url` preserve fields from the recovery backup before writing.
- `packages/vscode`: shared settings reads preserve backup fields before VS Code writes partial changes.
- Shared UI and mobile behavior are unchanged. The persisted JSON schema is unchanged; `settings.json.backup` is temporary recovery state.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | Executable code and a cross-runtime persisted settings contract changed | Traced every direct read-modify-write owner, kept the recovery contract local to settings persistence, added focused failure tests, and ran package builds/checks |
| `desktop-shell` and `packages/electron/README.md` | The initiating failure and fallback run in Electron main | Kept filesystem mechanics outside renderer/preload, shared one helper between main and SSH settings, and validated the Electron bundle and test suite |
| `clack-cli-patterns` and `packages/web/bin/lib/DOCUMENTATION.md` | `connect-url` can write relay identity into the shared settings file | Changed only persistence mechanics; terminal output and interactive/non-interactive contracts are unchanged |
| `packages/web/server/lib/opencode/DOCUMENTATION.md` | The web settings runtime owns canonical server reads and writes | Added one backup-aware JSON helper used by direct web and CLI writers |
| `packages/vscode/src/DOCUMENTATION.md` | VS Code independently reads and writes the shared file | Added a focused backup reader and merge test without changing bridge messages |
| `writing-for-agents` | Owning module documentation changed | Added only the new recovery ownership and local runtime consequences |
| `ponytail` | The fix should stay narrow | Added no dependency or configuration and reused one helper per package boundary |

## Validation

| Check | Result |
|---|---|
| `node --test file-replace.test.mjs` | Pass, 7 tests covering retries, serialized fallbacks, promotion, rollback, rollback failure, concurrent writers, unsupported hard links, and non-transient errors |
| `bun run test` in `packages/electron` | Pass, 17/17 test files |
| `bun run bundle:main` and `bun run type-check` in `packages/electron` | Pass |
| `bun run test server/lib/opencode/settings-file.test.js server/lib/opencode/settings-runtime.test.js` | Pass, 6 tests; 1 unrelated platform test skipped |
| `bun test src/shared-settings-file.test.ts` in `packages/vscode` | Pass, 1 test proving a partial merge retains backup fields |
| `bun run lint` in `packages/web` and `packages/vscode` | Pass |
| `bun run build:web` and `bun run build:extension` | Pass |
| `bunx oxlint` on the six new/substantially changed helper and test files | Pass, 0 warnings / 0 errors |
| `git diff --check` and syntax checks for changed server/CLI JS | Pass |
| `bun run test -- bin/cli.test.js` | 81 passed, 1 skipped, 2 unrelated Windows lifecycle tests failed because their fixture invokes unavailable Unix `sleep`; the settings helper tests pass |
| Web and VS Code type-checks | Blocked outside the diff by duplicate CodeMirror `6.12.2` / `6.12.4` types in `packages/ui/src/lib/codemirror/languageByExtension.ts` |
| `bun run dead-code` | Blocked before analysis by the local `bunx` cache missing `knip/bin/knip.js` |

HMR and bundled Electron startup smokes on Windows passed on the initial implementation (`0dfddd7a8`), both reaching `electron.window.ready-to-show` with valid settings. They were not rerun after the backup-only review follow-ups. The enterprise filesystem-filter environment from the report was unavailable; deterministic tests force each retry and recovery failure path.

## Visual evidence

No rendered UI changes. The diff only changes shared settings file replacement and recovery behavior.

## Risks and failure behavior

- Atomic rename remains the normal path. The move-aside fallback runs only on Windows after six transient replacement failures over approximately 375 ms.
- Each fallback uses a unique `settings.json.backup-*` path. Readers consult only the newest backup and only when `settings.json` is absent, so older recovery data cannot override a present canonical file.
- If promotion fails, Electron restores the backup. If rollback also fails, direct writers merge from the backup rather than `{}`; a later Electron replacement first attempts to restore it.
- Only the fallback that created a backup removes it after successful promotion or rollback. Other writers leave it untouched.
- The fallback probes hard-link support before moving the canonical file. Unsupported storage fails without removing the previous settings. Non-transient errors still propagate, and non-Windows replacement remains one atomic rename attempt.
- Rollback is a code revert; there is no data migration or persisted-format change.