### PR TITLE
fix(ui): virtualize heavy chat history

### DIFF
--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -1112,7 +1112,11 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
             let messageCount = 0;
             let sampleCount = 0;
             for (const [key, size] of sizes) {
-                const count = entryMessageCounts.get(String(key));
+                // The configured keys are entry IDs. Keep an index fallback
+                // for restored/default-key caches from another engine state.
+                const indexedEntry = typeof key === 'number' ? entriesRef.current[key] : undefined;
+                const count = entryMessageCounts.get(String(key))
+                    ?? (indexedEntry ? getRenderEntryMessageCount(indexedEntry) : undefined);
                 if (count === undefined) continue;
                 total += size;
                 messageCount += count;

--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -7,7 +7,10 @@ import { areOptionalRenderRelevantMessagesEqual, areRelevantTurnGroupingContexts
 import TurnItem from './components/TurnItem';
 import type { AnimationHandlers, ContentChangeReason } from '@/hooks/useChatAutoFollow';
 import type { ChatMessageEntry, TurnRecord, TurnGroupingContext } from './lib/turns/types';
-import { useTurnRecords } from './hooks/useTurnRecords';
+import {
+    collectTrailingUngroupedMessages,
+    useTurnRecords,
+} from './hooks/useTurnRecords';
 import { applyRetryOverlay } from './lib/turns/applyRetryOverlay';
 import { buildLiveStreamingEntry } from './lib/turns/streamingTailEntry';
 import { getNormalizedMessageForDisplay, hasCompactionPart } from './lib/messageDisplayNormalization';
@@ -1409,31 +1412,30 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
     }), [baseDisplayMessages, retryOverlay]);
 
     const planModeEnabled = useFeatureFlagsStore((state) => state.planModeEnabled);
-    const keepLastTurnLive = sessionIsWorking || activeStreamingMessageId !== null;
-    const { projection, staticTurns, streamingTurn } = useTurnRecords(displayMessages, {
+    const { projection, staticTurns, streamingTurn, keepLastTurnLive } = useTurnRecords(displayMessages, {
         sessionKey,
         showTextJustificationActivity: chatRenderMode === 'sorted',
         showTurnChangedFiles,
         planModeEnabled,
-        keepLastTurnLive,
+        sessionIsWorking,
+        activeStreamingMessageId,
     });
-    const trailingUngroupedMessage = React.useMemo(() => {
-        if (!keepLastTurnLive || projection.ungroupedMessageIds.size === 0) return undefined;
-        const lastMessage = displayMessages[displayMessages.length - 1];
-        return lastMessage && projection.ungroupedMessageIds.has(lastMessage.info.id)
-            ? lastMessage
-            : undefined;
+    const trailingUngroupedMessages = React.useMemo(() => {
+        return collectTrailingUngroupedMessages(
+            displayMessages,
+            projection.ungroupedMessageIds,
+            keepLastTurnLive,
+        );
     }, [displayMessages, keepLastTurnLive, projection.ungroupedMessageIds]);
-    const renderedTrailingUngroupedMessage = streamingTurn ? undefined : trailingUngroupedMessage;
     const hasUngroupedStaticEntries = projection.ungroupedMessageIds.size > 0;
     const staticEntryMessages = hasUngroupedStaticEntries ? displayMessages : EMPTY_STATIC_ENTRY_MESSAGES;
     const staticEntryUngroupedIds = React.useMemo(() => {
         if (!hasUngroupedStaticEntries) return EMPTY_UNGROUPED_MESSAGE_IDS;
-        if (!renderedTrailingUngroupedMessage) return projection.ungroupedMessageIds;
+        if (trailingUngroupedMessages.length === 0) return projection.ungroupedMessageIds;
         const ids = new Set(projection.ungroupedMessageIds);
-        ids.delete(renderedTrailingUngroupedMessage.info.id);
+        trailingUngroupedMessages.forEach((message) => ids.delete(message.info.id));
         return ids;
-    }, [hasUngroupedStaticEntries, projection.ungroupedMessageIds, renderedTrailingUngroupedMessage]);
+    }, [hasUngroupedStaticEntries, projection.ungroupedMessageIds, trailingUngroupedMessages]);
     const staticRenderEntries = React.useMemo<RenderEntry[]>(() => streamPerfMeasure('ui.message_list.render_entries_ms', () => {
         const turnEntries = staticTurns.map((turn) => ({
             kind: 'turn' as const,
@@ -1475,38 +1477,42 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
         return orderedEntries;
     }), [projection.lastTurnId, staticEntryMessages, staticEntryUngroupedIds, staticTurns]);
 
-    const trailingStreamingEntry = React.useMemo<RenderEntry | undefined>(() => {
+    const liveTailEntries = React.useMemo<RenderEntry[]>(() => {
+        const entries: RenderEntry[] = [];
         if (streamingTurn) {
-            return {
+            entries.push({
                 kind: 'turn',
                 key: `turn:${streamingTurn.turnId}`,
                 turn: streamingTurn,
                 isLastTurn: streamingTurn.turnId === projection.lastTurnId,
-            } satisfies RenderEntry;
+                nextEntryFirstMessage: trailingUngroupedMessages[0],
+            });
         }
 
-        if (!renderedTrailingUngroupedMessage) {
-            return undefined;
-        }
+        const trailingStart = displayMessages.length - trailingUngroupedMessages.length;
+        trailingUngroupedMessages.forEach((message, index) => {
+            const messageIndex = trailingStart + index;
+            entries.push({
+                kind: 'ungrouped',
+                key: `msg:${message.info.id}`,
+                message,
+                previousMessage: messageIndex > 0 ? displayMessages[messageIndex - 1] : undefined,
+                nextMessage: messageIndex < displayMessages.length - 1 ? displayMessages[messageIndex + 1] : undefined,
+            });
+        });
+        return entries;
+    }, [displayMessages, projection.lastTurnId, streamingTurn, trailingUngroupedMessages]);
 
-        return {
-            kind: 'ungrouped',
-            key: `msg:${renderedTrailingUngroupedMessage.info.id}`,
-            message: renderedTrailingUngroupedMessage,
-            previousMessage: displayMessages.length > 1 ? displayMessages[displayMessages.length - 2] : undefined,
-            nextMessage: undefined,
-        } satisfies RenderEntry;
-    }, [displayMessages, projection.lastTurnId, renderedTrailingUngroupedMessage, streamingTurn]);
-
-    if (trailingStreamingEntry) {
+    if (liveTailEntries.length > 0) {
         streamPerfCount('ui.message_list.render.streaming');
     }
 
     // Depend on the trailing entry's first message (stable while its assistant
     // streams), not the trailing entry itself, so streaming updates do not
     // recreate every static entry and re-render every turn block.
-    const trailingEntryFirstMessage = trailingStreamingEntry
-        ? (trailingStreamingEntry.kind === 'turn' ? trailingStreamingEntry.turn.userMessage : trailingStreamingEntry.message)
+    const firstLiveTailEntry = liveTailEntries[0];
+    const trailingEntryFirstMessage = firstLiveTailEntry
+        ? (firstLiveTailEntry.kind === 'turn' ? firstLiveTailEntry.turn.userMessage : firstLiveTailEntry.message)
         : undefined;
     const historyEntries = React.useMemo<RenderEntry[]>(() => {
         return staticRenderEntries.map((entry, index) => {
@@ -1526,8 +1532,8 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
         });
     }, [staticRenderEntries, trailingEntryFirstMessage]);
     const allEntries = React.useMemo(() => {
-        return trailingStreamingEntry ? [...historyEntries, trailingStreamingEntry] : historyEntries;
-    }, [historyEntries, trailingStreamingEntry]);
+        return liveTailEntries.length > 0 ? [...historyEntries, ...liveTailEntries] : historyEntries;
+    }, [historyEntries, liveTailEntries]);
 
     // Mobile always starts with the same virtualized engine it will use after
     // pagination. Switching a short list from normal DOM to TanStack during a
@@ -1703,7 +1709,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
                     return true;
                 }
 
-                const targetIsTail = trailingStreamingEntry !== undefined && index >= historyEntries.length;
+                const targetIsTail = liveTailEntries.length > 0 && index >= historyEntries.length;
                 if (targetIsTail) {
                     return false;
                 }
@@ -1720,7 +1726,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
 
                 return scrollMessageElementIntoView(messageId, behavior)
                     || (
-                        trailingStreamingEntry !== undefined && index >= historyEntries.length
+                        liveTailEntries.length > 0 && index >= historyEntries.length
                             ? false
                             : scrollHistoryIndexIntoView(index)
                     );
@@ -1863,7 +1869,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
         return () => {
             objectRef.current = null;
         };
-    }, [findMessageElement, historyEntries.length, messageIndexMap, resolveScrollContainer, scrollHistoryIndexIntoView, scrollMessageElementIntoView, shouldVirtualizeHistory, trailingStreamingEntry, turnIndexMap, ref]);
+    }, [findMessageElement, historyEntries.length, liveTailEntries.length, messageIndexMap, resolveScrollContainer, scrollHistoryIndexIntoView, scrollMessageElementIntoView, shouldVirtualizeHistory, turnIndexMap, ref]);
 
     const disableFadeIn = false;
 
@@ -1898,9 +1904,10 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
                                 reviewTransferDirection={reviewTransferDirection}
                             />
                         </FadeInDisabledProvider>
-                        {trailingStreamingEntry ? (
+                        {liveTailEntries.map((entry) => (
                             <StreamingTailContent
-                                entry={trailingStreamingEntry}
+                                key={entry.key}
+                                entry={entry}
                                 directory={directory}
                                 onMessageContentChange={stableTailContentChange}
                                 getAnimationHandlers={stableGetAnimationHandlers}
@@ -1918,7 +1925,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
                                 activeStreamingPhase={activeStreamingPhase}
                                 reviewTransferDirection={reviewTransferDirection}
                             />
-                        ) : null}
+                        ))}
                     </div>
                 </FadeInDisabledProvider>
 

--- a/packages/ui/src/components/chat/MessageList.tsx
+++ b/packages/ui/src/components/chat/MessageList.tsx
@@ -28,8 +28,12 @@ import {
     getShellBridgeAssistantDetails,
     type ShellBridgeDetails,
 } from './lib/shellBridge';
+import {
+    DEFAULT_HISTORY_MESSAGE_SIZE,
+    estimateHistoryEntrySize,
+    resolveHistoryWindowing,
+} from './lib/historyWindowing';
 
-const MESSAGE_LIST_VIRTUALIZE_THRESHOLD = 5;
 const EMPTY_STATIC_ENTRY_MESSAGES: ChatMessageEntry[] = [];
 const EMPTY_UNGROUPED_MESSAGE_IDS = new Set<string>();
 const TIMELINE_CACHE_LIMIT = 16;
@@ -50,14 +54,6 @@ const sameKeys = (a: readonly string[] | undefined, b: readonly string[] | undef
 type TanstackVirtualizerInstance = ReactVirtualizer<HTMLDivElement, HTMLDivElement>;
 type HistoryEngine = 'none' | 'tanstack';
 
-const TANSTACK_ESTIMATED_ENTRY_SIZE = 320;
-const TANSTACK_OVERSCAN = 8;
-// Touch flings cover more distance between paints than desktop wheels; a
-// larger window keeps fast mobile scrolling over mounted rows.
-const TANSTACK_MOBILE_OVERSCAN = 16;
-const resolveTanstackOverscan = (): number => (
-    isMobileSurfaceRuntime() ? TANSTACK_MOBILE_OVERSCAN : TANSTACK_OVERSCAN
-);
 // Post-prepend anchor hold: measurements of freshly
 // prepended rows settle over multiple frames, so a single restore can be
 // invalidated by the next measurement pass. Re-assert the anchor until it
@@ -67,6 +63,7 @@ const ANCHOR_HOLD_MAX_FRAMES = 180;
 // Adaptive estimate bounds: only trust the session average once a few rows
 // are measured, and keep it inside sane turn-height bounds.
 const TANSTACK_ESTIMATE_MIN_SAMPLES = 5;
+const TANSTACK_ESTIMATE_MAX_SAMPLES = 32;
 const TANSTACK_ESTIMATE_MIN = 120;
 const TANSTACK_ESTIMATE_MAX = 1200;
 // "At bottom" tolerance for resize-adjustment decisions.
@@ -388,6 +385,11 @@ type RenderEntry =
         nextMessage?: ChatMessageEntry;
     }
     | { kind: 'turn'; key: string; turn: TurnRecord; isLastTurn: boolean; nextEntryFirstMessage?: ChatMessageEntry };
+
+const getRenderEntryMessageCount = (entry: RenderEntry | undefined): number => {
+    if (!entry) return 1;
+    return entry.kind === 'turn' ? entry.turn.assistantMessages.length + 1 : 1;
+};
 
 type TurnUiState = { isExpanded: boolean };
 
@@ -937,6 +939,7 @@ type StaticHistoryListProps = {
     scrollRef?: React.RefObject<HTMLDivElement | null>;
     registerTanstackVirtualizer?: (virtualizer: TanstackVirtualizerInstance | null) => void;
     virtualizerKey: string;
+    overscan: number;
     onMessageContentChange: (reason?: ContentChangeReason) => void;
     getAnimationHandlers: (messageId: string) => AnimationHandlers;
     scrollToBottom?: () => void;
@@ -950,8 +953,20 @@ type StaticHistoryListProps = {
     reviewTransferDirection?: ReviewTransferDirection | null;
 };
 
-const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, registerTanstackVirtualizer, virtualizerKey, onMessageContentChange, getAnimationHandlers, scrollToBottom, stickyUserHeader, defaultActivityExpanded, turnUiStates, onToggleTurnGroup, chatRenderMode, shouldAnimateUserMessage, onUserAnimationConsumed, reviewTransferDirection }: StaticHistoryListProps) => {
+const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, registerTanstackVirtualizer, virtualizerKey, overscan, onMessageContentChange, getAnimationHandlers, scrollToBottom, stickyUserHeader, defaultActivityExpanded, turnUiStates, onToggleTurnGroup, chatRenderMode, shouldAnimateUserMessage, onUserAnimationConsumed, reviewTransferDirection }: StaticHistoryListProps) => {
     const isTanstack = engine === 'tanstack';
+    const wasTanstackRef = React.useRef(isTanstack);
+    const transitionOffsetRef = React.useRef<number | null>(null);
+    if (isTanstack && !wasTanstackRef.current) {
+        const element = scrollRef?.current;
+        if (element) {
+            const distanceFromEnd = element.scrollHeight - element.clientHeight - element.scrollTop;
+            transitionOffsetRef.current = distanceFromEnd <= TANSTACK_AT_END_THRESHOLD_PX
+                ? Number.MAX_SAFE_INTEGER
+                : element.scrollTop;
+        }
+    }
+    wasTanstackRef.current = isTanstack;
 
     // --- Quiet-window prepend (mobile) --------------------------------------
     // Gesture tracking for the deferred-prepend decision. Refs only: reading
@@ -1040,18 +1055,24 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
     ));
 
     const sizeContainerRef = React.useRef<HTMLDivElement | null>(null);
+    const entryMessageCounts = React.useMemo(() => new Map(
+        renderEntries.map((entry) => [entry.key, getRenderEntryMessageCount(entry)]),
+    ), [renderEntries]);
     // Adaptive estimate: rows this session has actually measured are a far
     // better predictor for the still-unmeasured ones than a fixed constant.
     // Smaller estimate error → smaller anchor corrections when prepended rows
     // measure in → less visible drift. The ref keeps estimateSize's identity
     // stable so updating the average never triggers a global remeasure.
-    const estimatedEntrySizeRef = React.useRef(TANSTACK_ESTIMATED_ENTRY_SIZE);
+    const estimatedMessageSizeRef = React.useRef(DEFAULT_HISTORY_MESSAGE_SIZE);
     const tanstackVirtualizer = useTanstackVirtualizer<HTMLDivElement, HTMLDivElement>({
         count: renderEntries.length,
         enabled: isTanstack,
         getScrollElement: () => scrollRef?.current ?? null,
-        estimateSize: () => estimatedEntrySizeRef.current,
-        overscan: resolveTanstackOverscan(),
+        estimateSize: (index) => estimateHistoryEntrySize(
+            getRenderEntryMessageCount(entriesRef.current[index]),
+            estimatedMessageSizeRef.current,
+        ),
+        overscan,
         scrollToFn: (offset, options, instance) => {
             // Expose the new total height before core writes an anchor
             // correction so the browser does not clamp the offset to the old
@@ -1065,7 +1086,7 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
         // viewport must not move what the user is reading, and iOS-specific
         // touch/momentum deferral for those adjustments lives in the core.
         anchorTo: 'end',
-        initialOffset: () => Number.MAX_SAFE_INTEGER,
+        initialOffset: () => transitionOffsetRef.current ?? Number.MAX_SAFE_INTEGER,
         initialMeasurementsCache: initialMeasurements,
     });
     // Only compensate scroll for rows growing ABOVE the viewport (history
@@ -1085,10 +1106,20 @@ const StaticHistoryList = React.memo(({ entries, engine, contentRef, scrollRef, 
         const sizes = tanstackVirtualizer.itemSizeCache;
         if (sizes.size >= TANSTACK_ESTIMATE_MIN_SAMPLES) {
             let total = 0;
-            for (const size of sizes.values()) total += size;
-            estimatedEntrySizeRef.current = Math.min(
+            let messageCount = 0;
+            let sampleCount = 0;
+            for (const [key, size] of sizes) {
+                const count = entryMessageCounts.get(String(key));
+                if (count === undefined) continue;
+                total += size;
+                messageCount += count;
+                sampleCount += 1;
+                if (sampleCount >= TANSTACK_ESTIMATE_MAX_SAMPLES) break;
+            }
+            if (messageCount === 0) return;
+            estimatedMessageSizeRef.current = Math.min(
                 TANSTACK_ESTIMATE_MAX,
-                Math.max(TANSTACK_ESTIMATE_MIN, Math.round(total / sizes.size)),
+                Math.max(TANSTACK_ESTIMATE_MIN, Math.round(total / messageCount)),
             );
         }
     });
@@ -1378,15 +1409,31 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
     }), [baseDisplayMessages, retryOverlay]);
 
     const planModeEnabled = useFeatureFlagsStore((state) => state.planModeEnabled);
+    const keepLastTurnLive = sessionIsWorking || activeStreamingMessageId !== null;
     const { projection, staticTurns, streamingTurn } = useTurnRecords(displayMessages, {
         sessionKey,
         showTextJustificationActivity: chatRenderMode === 'sorted',
         showTurnChangedFiles,
         planModeEnabled,
+        keepLastTurnLive,
     });
+    const trailingUngroupedMessage = React.useMemo(() => {
+        if (!keepLastTurnLive || projection.ungroupedMessageIds.size === 0) return undefined;
+        const lastMessage = displayMessages[displayMessages.length - 1];
+        return lastMessage && projection.ungroupedMessageIds.has(lastMessage.info.id)
+            ? lastMessage
+            : undefined;
+    }, [displayMessages, keepLastTurnLive, projection.ungroupedMessageIds]);
+    const renderedTrailingUngroupedMessage = streamingTurn ? undefined : trailingUngroupedMessage;
     const hasUngroupedStaticEntries = projection.ungroupedMessageIds.size > 0;
     const staticEntryMessages = hasUngroupedStaticEntries ? displayMessages : EMPTY_STATIC_ENTRY_MESSAGES;
-    const staticEntryUngroupedIds = hasUngroupedStaticEntries ? projection.ungroupedMessageIds : EMPTY_UNGROUPED_MESSAGE_IDS;
+    const staticEntryUngroupedIds = React.useMemo(() => {
+        if (!hasUngroupedStaticEntries) return EMPTY_UNGROUPED_MESSAGE_IDS;
+        if (!renderedTrailingUngroupedMessage) return projection.ungroupedMessageIds;
+        const ids = new Set(projection.ungroupedMessageIds);
+        ids.delete(renderedTrailingUngroupedMessage.info.id);
+        return ids;
+    }, [hasUngroupedStaticEntries, projection.ungroupedMessageIds, renderedTrailingUngroupedMessage]);
     const staticRenderEntries = React.useMemo<RenderEntry[]>(() => streamPerfMeasure('ui.message_list.render_entries_ms', () => {
         const turnEntries = staticTurns.map((turn) => ({
             kind: 'turn' as const,
@@ -1438,23 +1485,18 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
             } satisfies RenderEntry;
         }
 
-        if (projection.ungroupedMessageIds.size === 0) {
-            return undefined;
-        }
-
-        const lastMessage = displayMessages[displayMessages.length - 1];
-        if (!lastMessage || !projection.ungroupedMessageIds.has(lastMessage.info.id)) {
+        if (!renderedTrailingUngroupedMessage) {
             return undefined;
         }
 
         return {
             kind: 'ungrouped',
-            key: `msg:${lastMessage.info.id}`,
-            message: lastMessage,
+            key: `msg:${renderedTrailingUngroupedMessage.info.id}`,
+            message: renderedTrailingUngroupedMessage,
             previousMessage: displayMessages.length > 1 ? displayMessages[displayMessages.length - 2] : undefined,
             nextMessage: undefined,
         } satisfies RenderEntry;
-    }, [displayMessages, projection.lastTurnId, projection.ungroupedMessageIds, streamingTurn]);
+    }, [displayMessages, projection.lastTurnId, renderedTrailingUngroupedMessage, streamingTurn]);
 
     if (trailingStreamingEntry) {
         streamPerfCount('ui.message_list.render.streaming');
@@ -1483,23 +1525,30 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
             return { ...entry, nextEntryFirstMessage };
         });
     }, [staticRenderEntries, trailingEntryFirstMessage]);
+    const allEntries = React.useMemo(() => {
+        return trailingStreamingEntry ? [...historyEntries, trailingStreamingEntry] : historyEntries;
+    }, [historyEntries, trailingStreamingEntry]);
+
     // Mobile always starts with the same virtualized engine it will use after
     // pagination. Switching a short list from normal DOM to TanStack during a
     // prepend remounts the history subtree, and the newly enabled end-anchored
     // virtualizer initializes at the bottom before it has prior keyed state.
     // Desktop keeps the small-list threshold where that transition is not tied
     // to the explicit mobile load-older interaction.
-    const shouldVirtualizeHistory = isMobileSurfaceRuntime()
-        || historyEntries.length >= MESSAGE_LIST_VIRTUALIZE_THRESHOLD;
+    const historyWindowing = React.useMemo(() => resolveHistoryWindowing({
+        entryCount: historyEntries.length,
+        maxEntryMessageCount: historyEntries.reduce(
+            (maximum, entry) => Math.max(maximum, getRenderEntryMessageCount(entry)),
+            0,
+        ),
+        isMobile: isMobileSurfaceRuntime(),
+    }), [historyEntries]);
+    const shouldVirtualizeHistory = historyEntries.length > 0 && historyWindowing.shouldVirtualize;
     const historyEngine: HistoryEngine = shouldVirtualizeHistory ? 'tanstack' : 'none';
     const tanstackVirtualizerRef = React.useRef<TanstackVirtualizerInstance | null>(null);
     const registerTanstackVirtualizer = React.useCallback((virtualizer: TanstackVirtualizerInstance | null) => {
         tanstackVirtualizerRef.current = virtualizer;
     }, []);
-
-    const allEntries = React.useMemo(() => {
-        return trailingStreamingEntry ? [...historyEntries, trailingStreamingEntry] : historyEntries;
-    }, [historyEntries, trailingStreamingEntry]);
 
     const stableHistoryContentChange = useStableEvent((reason?: ContentChangeReason) => {
         onMessageContentChange(reason);
@@ -1835,6 +1884,7 @@ const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(({
                                 scrollRef={scrollRef}
                                 registerTanstackVirtualizer={registerTanstackVirtualizer}
                                 virtualizerKey={sessionKey}
+                                overscan={historyWindowing.overscan}
                                 onMessageContentChange={stableHistoryContentChange}
                                 getAnimationHandlers={stableGetAnimationHandlers}
                                 scrollToBottom={stableScrollToBottom}

--- a/packages/ui/src/components/chat/hooks/useTurnRecords.test.ts
+++ b/packages/ui/src/components/chat/hooks/useTurnRecords.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+
+import { partitionLiveTurn } from './useTurnRecords';
+
+describe('partitionLiveTurn', () => {
+    test('keeps every completed turn in virtualized history', () => {
+        expect(partitionLiveTurn(['one', 'two', 'three'], false)).toEqual({
+            staticTurns: ['one', 'two', 'three'],
+            streamingTurn: undefined,
+        });
+    });
+
+    test('keeps only the active tail outside history', () => {
+        expect(partitionLiveTurn(['one', 'two', 'three'], true)).toEqual({
+            staticTurns: ['one', 'two'],
+            streamingTurn: 'three',
+        });
+    });
+});

--- a/packages/ui/src/components/chat/hooks/useTurnRecords.test.ts
+++ b/packages/ui/src/components/chat/hooks/useTurnRecords.test.ts
@@ -1,6 +1,48 @@
 import { describe, expect, test } from 'bun:test';
 
-import { partitionLiveTurn } from './useTurnRecords';
+import { projectTurnRecords } from '../lib/turns/projectTurnRecords';
+import type { ChatMessageEntry } from '../lib/turns/types';
+import {
+    collectTrailingUngroupedMessages,
+    partitionLiveTurn,
+    shouldKeepLastTurnLive,
+} from './useTurnRecords';
+
+const message = (id: string, role: 'user' | 'assistant', parentID?: string): ChatMessageEntry => ({
+    info: { id, role, parentID } as ChatMessageEntry['info'],
+    parts: [],
+});
+
+describe('shouldKeepLastTurnLive', () => {
+    test('keeps an actively streaming turn live', () => {
+        expect(shouldKeepLastTurnLive(true, 'assistant_1', { assistantMessages: [message('assistant_1', 'assistant')] })).toBe(true);
+    });
+
+    test('keeps the busy user-only turn live while waiting for an assistant', () => {
+        expect(shouldKeepLastTurnLive(true, null, { assistantMessages: [] })).toBe(true);
+    });
+
+    test('virtualizes a completed tail while retrying without an active stream', () => {
+        expect(shouldKeepLastTurnLive(true, null, { assistantMessages: [message('assistant_1', 'assistant')] })).toBe(false);
+    });
+
+    test('ignores a late assistant attached to an earlier turn', () => {
+        const projection = projectTurnRecords([
+            message('user_1', 'user'),
+            message('user_2', 'user'),
+            message('assistant_1', 'assistant', 'user_1'),
+        ]);
+        expect(shouldKeepLastTurnLive(true, null, projection.turns[1])).toBe(true);
+    });
+
+    test('ignores an orphan assistant after the final user message', () => {
+        const projection = projectTurnRecords([
+            message('user_1', 'user'),
+            message('assistant_orphan', 'assistant'),
+        ]);
+        expect(shouldKeepLastTurnLive(true, null, projection.turns[0])).toBe(true);
+    });
+});
 
 describe('partitionLiveTurn', () => {
     test('keeps every completed turn in virtualized history', () => {
@@ -15,5 +57,25 @@ describe('partitionLiveTurn', () => {
             staticTurns: ['one', 'two'],
             streamingTurn: 'three',
         });
+    });
+});
+
+describe('collectTrailingUngroupedMessages', () => {
+    const messages = ['user', 'assistant', 'system_1', 'system_2'].map((id) => ({ info: { id } }));
+
+    test('preserves the order of the ungrouped suffix after a live turn', () => {
+        expect(collectTrailingUngroupedMessages(
+            messages,
+            new Set(['system_1', 'system_2']),
+            true,
+        ).map((message) => message.info.id)).toEqual(['system_1', 'system_2']);
+    });
+
+    test('leaves the suffix in static history when there is no live turn', () => {
+        expect(collectTrailingUngroupedMessages(
+            messages,
+            new Set(['system_1', 'system_2']),
+            false,
+        )).toEqual([]);
     });
 });

--- a/packages/ui/src/components/chat/hooks/useTurnRecords.ts
+++ b/packages/ui/src/components/chat/hooks/useTurnRecords.ts
@@ -9,6 +9,7 @@ interface UseTurnRecordsOptions {
     showTextJustificationActivity: boolean;
     showTurnChangedFiles: boolean;
     planModeEnabled: boolean;
+    keepLastTurnLive: boolean;
 }
 
 export interface TurnRecordsResult {
@@ -16,6 +17,24 @@ export interface TurnRecordsResult {
     staticTurns: TurnProjectionResult['turns'];
     streamingTurn: TurnProjectionResult['turns'][number] | undefined;
 }
+
+export interface LiveTurnPartition<TTurn> {
+    staticTurns: TTurn[];
+    streamingTurn: TTurn | undefined;
+}
+
+export const partitionLiveTurn = <TTurn,>(
+    turns: readonly TTurn[],
+    keepLastTurnLive: boolean,
+): LiveTurnPartition<TTurn> => {
+    if (!keepLastTurnLive || turns.length === 0) {
+        return { staticTurns: [...turns], streamingTurn: undefined };
+    }
+    return {
+        staticTurns: turns.slice(0, -1),
+        streamingTurn: turns[turns.length - 1],
+    };
+};
 
 export const useTurnRecords = (
     messages: ChatMessageEntry[],
@@ -81,10 +100,13 @@ export const useTurnRecords = (
         });
     }, [messages, options.showTextJustificationActivity, options.showTurnChangedFiles, options.sessionKey, options.planModeEnabled]);
 
+    const livePartition = React.useMemo(
+        () => partitionLiveTurn(projection.turns, options.keepLastTurnLive),
+        [options.keepLastTurnLive, projection.turns],
+    );
+
     const staticTurns = React.useMemo(() => {
-        const nextStatic = projection.turns.length <= 1
-            ? []
-            : projection.turns.slice(0, -1);
+        const nextStatic = livePartition.staticTurns;
         const previousStatic = staticTurnsRef.current;
 
         if (previousStatic.length === nextStatic.length) {
@@ -102,18 +124,16 @@ export const useTurnRecords = (
 
         staticTurnsRef.current = nextStatic;
         return nextStatic;
-    }, [projection.turns]);
+    }, [livePartition.staticTurns]);
 
     const streamingTurn = React.useMemo(() => {
-        const nextStreamingTurn = projection.turns.length === 0
-            ? undefined
-            : projection.turns[projection.turns.length - 1];
+        const nextStreamingTurn = livePartition.streamingTurn;
         if (streamingTurnRef.current === nextStreamingTurn) {
             return streamingTurnRef.current;
         }
         streamingTurnRef.current = nextStreamingTurn;
         return nextStreamingTurn;
-    }, [projection.turns]);
+    }, [livePartition.streamingTurn]);
 
     return {
         projection,

--- a/packages/ui/src/components/chat/hooks/useTurnRecords.ts
+++ b/packages/ui/src/components/chat/hooks/useTurnRecords.ts
@@ -9,19 +9,42 @@ interface UseTurnRecordsOptions {
     showTextJustificationActivity: boolean;
     showTurnChangedFiles: boolean;
     planModeEnabled: boolean;
-    keepLastTurnLive: boolean;
+    sessionIsWorking: boolean;
+    activeStreamingMessageId: string | null | undefined;
 }
 
 export interface TurnRecordsResult {
     projection: TurnProjectionResult;
     staticTurns: TurnProjectionResult['turns'];
     streamingTurn: TurnProjectionResult['turns'][number] | undefined;
+    keepLastTurnLive: boolean;
 }
 
 export interface LiveTurnPartition<TTurn> {
     staticTurns: TTurn[];
     streamingTurn: TTurn | undefined;
 }
+
+export const shouldKeepLastTurnLive = (
+    sessionIsWorking: boolean,
+    activeStreamingMessageId: string | null | undefined,
+    lastTurn: Pick<TurnRecord, 'assistantMessages'> | undefined,
+): boolean => activeStreamingMessageId != null
+    || (sessionIsWorking && (lastTurn?.assistantMessages.length ?? 0) === 0);
+
+export const collectTrailingUngroupedMessages = <TMessage extends { info: { id: string } }>(
+    messages: readonly TMessage[],
+    ungroupedMessageIds: ReadonlySet<string>,
+    enabled: boolean,
+): TMessage[] => {
+    if (!enabled || ungroupedMessageIds.size === 0) return [];
+
+    let start = messages.length;
+    while (start > 0 && ungroupedMessageIds.has(messages[start - 1].info.id)) {
+        start -= 1;
+    }
+    return messages.slice(start);
+};
 
 export const partitionLiveTurn = <TTurn,>(
     turns: readonly TTurn[],
@@ -100,9 +123,14 @@ export const useTurnRecords = (
         });
     }, [messages, options.showTextJustificationActivity, options.showTurnChangedFiles, options.sessionKey, options.planModeEnabled]);
 
+    const keepLastTurnLive = shouldKeepLastTurnLive(
+        options.sessionIsWorking,
+        options.activeStreamingMessageId,
+        projection.turns[projection.turns.length - 1],
+    );
     const livePartition = React.useMemo(
-        () => partitionLiveTurn(projection.turns, options.keepLastTurnLive),
-        [options.keepLastTurnLive, projection.turns],
+        () => partitionLiveTurn(projection.turns, keepLastTurnLive),
+        [keepLastTurnLive, projection.turns],
     );
 
     const staticTurns = React.useMemo(() => {
@@ -139,5 +167,6 @@ export const useTurnRecords = (
         projection,
         staticTurns,
         streamingTurn,
+        keepLastTurnLive,
     };
 };

--- a/packages/ui/src/components/chat/lib/historyWindowing.test.ts
+++ b/packages/ui/src/components/chat/lib/historyWindowing.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+    estimateHistoryEntrySize,
+    resolveHistoryWindowing,
+} from './historyWindowing';
+
+describe('resolveHistoryWindowing', () => {
+    test('virtualizes a few turns when one contains many messages', () => {
+        expect(resolveHistoryWindowing({
+            entryCount: 4,
+            maxEntryMessageCount: 52,
+            isMobile: false,
+        })).toEqual({
+            shouldVirtualize: true,
+            overscan: 0,
+        });
+    });
+
+    test('preserves the existing small desktop and mobile behavior', () => {
+        expect(resolveHistoryWindowing({
+            entryCount: 4,
+            maxEntryMessageCount: 2,
+            isMobile: false,
+        })).toEqual({
+            shouldVirtualize: false,
+            overscan: 8,
+        });
+        expect(resolveHistoryWindowing({
+            entryCount: 4,
+            maxEntryMessageCount: 2,
+            isMobile: true,
+        })).toEqual({
+            shouldVirtualize: true,
+            overscan: 16,
+        });
+    });
+});
+
+describe('estimateHistoryEntrySize', () => {
+    test('accounts for all messages nested inside a turn', () => {
+        expect(estimateHistoryEntrySize(52)).toBe(16_640);
+        expect(estimateHistoryEntrySize(0)).toBe(320);
+    });
+});

--- a/packages/ui/src/components/chat/lib/historyWindowing.ts
+++ b/packages/ui/src/components/chat/lib/historyWindowing.ts
@@ -1,0 +1,37 @@
+const ENTRY_VIRTUALIZE_THRESHOLD = 5;
+const HEAVY_ENTRY_MESSAGE_THRESHOLD = 12;
+const DESKTOP_OVERSCAN = 8;
+const MOBILE_OVERSCAN = 16;
+
+export const DEFAULT_HISTORY_MESSAGE_SIZE = 320;
+
+interface HistoryWindowingInput {
+    entryCount: number;
+    maxEntryMessageCount: number;
+    isMobile: boolean;
+}
+
+export interface HistoryWindowing {
+    shouldVirtualize: boolean;
+    overscan: number;
+}
+
+export const resolveHistoryWindowing = ({
+    entryCount,
+    maxEntryMessageCount,
+    isMobile,
+}: HistoryWindowingInput): HistoryWindowing => {
+    const hasHeavyEntry = maxEntryMessageCount >= HEAVY_ENTRY_MESSAGE_THRESHOLD;
+    return {
+        shouldVirtualize: isMobile || entryCount >= ENTRY_VIRTUALIZE_THRESHOLD || hasHeavyEntry,
+        overscan: hasHeavyEntry ? 0 : (isMobile ? MOBILE_OVERSCAN : DESKTOP_OVERSCAN),
+    };
+};
+
+export const estimateHistoryEntrySize = (
+    messageCount: number,
+    estimatedMessageSize = DEFAULT_HISTORY_MESSAGE_SIZE,
+): number => Math.max(
+    DEFAULT_HISTORY_MESSAGE_SIZE,
+    Math.max(1, messageCount) * estimatedMessageSize,
+);


### PR DESCRIPTION
## Summary

- virtualize tool-heavy chat history based on nested message count instead of turn count alone
- keep only the actively changing final turn outside the history virtualizer
- move completed retry/busy tails into virtualized history while preserving user-only waiting states
- preserve trailing system/ungrouped message order after the live turn
- reduce overscan for heavy turns and estimate row heights from nested message counts plus bounded measured samples
- preserve the current scroll offset when a desktop history transitions into virtualization
- cover live-turn ownership, parent-linked edge cases, tail ordering, heavy-entry activation, overscan, and entry-size estimates with focused tests

## Why

Long, tool-heavy sessions can contain dozens of assistant messages inside only a few turns. The existing five-turn threshold and eight-row overscan therefore leave most or all message/tool DOM mounted. The final turn also remains outside the virtualizer after streaming finishes.

This change makes windowing account for the actual cost of each turn while retaining the existing behavior for small desktop conversations and mobile history.

## Performance

Representative production profile of the reported long session:

| Metric | Before | After initial load | Change |
| --- | ---: | ---: | ---: |
| Mounted messages | 145 | 23 | -84% |
| DOM nodes | 18,810 | 9,527 | -49% |
| JS heap | ~288 MB | ~178 MB | -38% |
| Longest main-thread task | 1.17 s | 866 ms | -26% |

The DOM and memory reductions are substantial, but the measured timing improvement is modest and an 866 ms task remains too long. First useful message rendering was approximately 664 ms. Keystroke-to-paint and session-switch latency were not measured, so this PR does not claim that those interactions are fully fixed.

Older history remains paginated and loaded when the user reaches the top. Browser verification also confirmed normal upward scrolling and an exact 0 px bottom gap after returning to the latest message.

## Limitation and next step

Virtualization remains turn-level. A single exceptionally large visible turn can still mount more than 100 messages and dominate main-thread work. Nested assistant-message virtualization was evaluated but omitted because it regressed prepend anchoring and message-target navigation.

A follow-up should add message/tool-level progressive rendering or nested virtualization while preserving:

- prepend anchor stability while older history loads
- `scrollToMessageId` navigation to currently unmounted messages
- streaming-tail behavior and bottom pinning
- keyboard and selection behavior across virtualized boundaries

That follow-up should benchmark keystroke-to-paint latency, session-switch latency, total blocking time, and longest tasks rather than relying only on DOM and heap reductions.

## Validation

- `bun run type-check`
- `bun run lint`
- 25 focused tests across live-turn ownership, parent-linked edge cases, tail ordering, history windowing, timeline anchoring, turn windows, and streaming-tail behavior
- `bun run build:web`
- production browser checks for initial load, older-history pagination, upward scrolling, and bottom pinning

Addresses #2267
Related to #2549