### PR TITLE
fix(ui): keep owning project when opening plans from a worktree session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Chat: if OpenCode restarts while a response is still running, the chat now stops with an interrupted state and a notification to continue instead of hanging silently (thanks to @sum117).
+- Project knowledge: plans opened from the panel now load while a session runs from a temporary worktree, instead of showing a blank editor.
 
 ## [1.19.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ All notable changes to this project will be documented in this file.
 - Git: pull-request checks in Work status stay current as their status changes.
 - UI: the default dialog close button is easier to click or tap (thanks to @rockinrimmer).
 - Desktop/Windows: the close button now aligns correctly with the rest of the window chrome.
+- Project knowledge: plans opened from the panel now load while a session runs from a temporary worktree, instead of showing a blank editor.
 
 ## [1.19.0] - 2026-08-19
 

--- a/packages/ui/src/apps/MobileApp.tsx
+++ b/packages/ui/src/apps/MobileApp.tsx
@@ -24,6 +24,7 @@ import { readTabletLayout, useOrientation, useTabletLayout } from '@/lib/device'
 import { useHardwareKeyboard } from '@/lib/hardwareKeyboard';
 import { useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
+import type { ProjectRef } from '@/lib/projectContextApi';
 import { getRuntimeApiBaseUrl, getRuntimeKey, subscribeRuntimeEndpointChanged, switchRuntimeEndpoint } from '@/lib/runtime-switch';
 import { refreshGlobalSessions, resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
 import { clearLastActiveSession, readLastActiveSession } from '@/sync/last-session-cache';
@@ -109,7 +110,7 @@ const MobileShell: React.FC<{ onActiveConnectionDeleted: () => void }> = ({ onAc
   const [workspaceTab, setWorkspaceTab] = React.useState<MobileWorkspaceTab>('changes');
   // A plan opened from the workspace drawer's Notes tab, shown as a fullscreen
   // layer on top of it (back returns to the notes).
-  const [openPlan, setOpenPlan] = React.useState<{ id: string; title: string } | null>(null);
+  const [openPlan, setOpenPlan] = React.useState<{ id: string; title: string; project: ProjectRef } | null>(null);
   const [settingsInitialMobileStage, setSettingsInitialMobileStage] = React.useState<'nav' | 'page-content'>('nav');
   // When set, the Changes surface opens directly into the per-file diff for this path.
   const [pendingChangesDiff, setPendingChangesDiff] = React.useState<{ path: string; staged: boolean } | null>(null);
@@ -541,6 +542,7 @@ const MobileShell: React.FC<{ onActiveConnectionDeleted: () => void }> = ({ onAc
             <ErrorBoundary>
               <PlanView
                 projectPlanId={openPlan.id}
+                projectRef={openPlan.project}
                 onNavigatedToChat={() => {
                   closeSurface();
                   closeWorkspace();

--- a/packages/ui/src/apps/MobileApp.tsx
+++ b/packages/ui/src/apps/MobileApp.tsx
@@ -26,6 +26,7 @@ import { readTabletLayout, useOrientation, useTabletLayout } from '@/lib/device'
 import { useHardwareKeyboard } from '@/lib/hardwareKeyboard';
 import { useI18n } from '@/lib/i18n';
 import { runtimeFetch } from '@/lib/runtime-fetch';
+import type { ProjectRef } from '@/lib/projectContextApi';
 import { getRuntimeApiBaseUrl, getRuntimeKey, subscribeRuntimeEndpointChanged, switchRuntimeEndpoint } from '@/lib/runtime-switch';
 import { refreshGlobalSessions, resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
 import { clearLastActiveSession, readLastActiveSession } from '@/sync/last-session-cache';
@@ -111,7 +112,7 @@ const MobileShell: React.FC<{ onActiveConnectionDeleted: () => void }> = ({ onAc
   const [workspaceTab, setWorkspaceTab] = React.useState<MobileWorkspaceTab>('changes');
   // A plan opened from the workspace drawer's Notes tab, shown as a fullscreen
   // layer on top of it (back returns to the notes).
-  const [openPlan, setOpenPlan] = React.useState<{ id: string; title: string } | null>(null);
+  const [openPlan, setOpenPlan] = React.useState<{ id: string; title: string; project: ProjectRef } | null>(null);
   const [settingsInitialMobileStage, setSettingsInitialMobileStage] = React.useState<'nav' | 'page-content'>('nav');
   // When set, the Changes surface opens directly into the per-file diff for this path.
   const [pendingChangesDiff, setPendingChangesDiff] = React.useState<{ path: string; staged: boolean } | null>(null);
@@ -543,6 +544,7 @@ const MobileShell: React.FC<{ onActiveConnectionDeleted: () => void }> = ({ onAc
             <ErrorBoundary>
               <PlanView
                 projectPlanId={openPlan.id}
+                projectRef={openPlan.project}
                 onNavigatedToChat={() => {
                   closeSurface();
                   closeWorkspace();

--- a/packages/ui/src/apps/MobileWorkspaceDrawer.tsx
+++ b/packages/ui/src/apps/MobileWorkspaceDrawer.tsx
@@ -6,6 +6,7 @@ import { McpIcon } from '@/components/icons/McpIcon';
 import { McpDropdownContent } from '@/components/mcp/McpDropdown';
 import { ProjectContextPanel } from '@/components/layout/RightSidebarTabs';
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
+import type { ProjectRef } from '@/lib/projectContextApi';
 import { SortableTabsStrip, type SortableTabsStripItem } from '@/components/ui/sortable-tabs-strip';
 import { TerminalView } from '@/components/views/TerminalView';
 import { useI18n } from '@/lib/i18n';
@@ -104,8 +105,9 @@ export const MobileWorkspaceDrawer: React.FC<{
   onTabChange: (tab: MobileWorkspaceTab) => void;
   /** When set, the Changes tab opens directly into the per-file diff. */
   pendingChangesDiff: { path: string; staged: boolean } | null;
-  /** Notes tab: opens a plan fullscreen (layered above the drawer). */
-  onOpenPlan: (plan: { id: string; title: string }) => void;
+  /** Notes tab: opens a plan fullscreen (layered above the drawer). The
+      owning project rides along for the viewer's project-plan lookup. */
+  onOpenPlan: (plan: { id: string; title: string; project: ProjectRef }) => void;
   /** MCP tab: jump to the MCP settings page pre-seeded with a new server draft. */
   onOpenMcpSettings: () => void;
   variant?: 'drawer' | 'panel';

--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -940,7 +940,7 @@ export const ContextPanel: React.FC = () => {
             : activeTab?.mode === 'notes'
                 ? <ProjectContextPanel />
         : activeTab?.mode === 'plan'
-            ? <React.Suspense fallback={null}><PlanView targetPath={activeTab.targetPath} projectPlanId={activeTab.projectPlanId} /></React.Suspense>
+            ? <React.Suspense fallback={null}><PlanView targetPath={activeTab.targetPath} projectPlanId={activeTab.projectPlanId} projectRef={activeTab.projectRef} /></React.Suspense>
             : null;
 
   const browserTabs = React.useMemo(

--- a/packages/ui/src/components/layout/ContextPanel.tsx
+++ b/packages/ui/src/components/layout/ContextPanel.tsx
@@ -943,7 +943,7 @@ export const ContextPanel: React.FC = () => {
             : activeTab?.mode === 'notes'
                 ? <ProjectContextPanel />
         : activeTab?.mode === 'plan'
-            ? <React.Suspense fallback={null}><PlanView targetPath={activeTab.targetPath} projectPlanId={activeTab.projectPlanId} /></React.Suspense>
+            ? <React.Suspense fallback={null}><PlanView targetPath={activeTab.targetPath} projectPlanId={activeTab.projectPlanId} projectRef={activeTab.projectRef} /></React.Suspense>
             : null;
 
   const browserTabs = React.useMemo(

--- a/packages/ui/src/components/layout/RightSidebarTabs.tsx
+++ b/packages/ui/src/components/layout/RightSidebarTabs.tsx
@@ -5,13 +5,14 @@ import { useGitStore } from '@/stores/useGitStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { formatDirectoryName } from '@/lib/utils';
+import type { ProjectRef } from '@/lib/projectContextApi';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { CHAT_DRAFT_PROJECT_ID, getChatsRootForHome, getChatsRootFromDirectory, isChatDirectoryPath } from '@/lib/chatDirectories';
 import { useI18n } from '@/lib/i18n';
 
 export const ProjectContextPanel: React.FC<{
   onActionComplete?: () => void;
-  onOpenPlan?: (plan: { id: string; title: string }) => void;
+  onOpenPlan?: (plan: { id: string; title: string; project: ProjectRef }) => void;
 }> = ({ onActionComplete, onOpenPlan }) => {
   const activeProjectId = useProjectsStore((state) => state.activeProjectId);
   const projects = useProjectsStore((state) => state.projects);

--- a/packages/ui/src/components/session/project-context/DOCUMENTATION.md
+++ b/packages/ui/src/components/session/project-context/DOCUMENTATION.md
@@ -60,6 +60,12 @@ Leaving the section or the project closes it, so its editor never sits over a
 list it no longer matches. Hosts that own a fullscreen plan surface (mobile)
 still pass `onOpenPlan` and keep theirs.
 
+A plan's owning project travels with it. The panel passes its `projectRef` to
+`PlanView`, and the mobile and desktop context-tab flows carry the project in
+the open-plan payload, so the editor loads the plan even while the session
+directory is a worktree outside the project path. The directory-based project
+lookup survives only as the fallback for viewers that were not handed one.
+
 ## Pins belong to one session
 
 Notes and plans are project data, but attaching one writes its id to the current

--- a/packages/ui/src/components/session/project-context/PlansSection.tsx
+++ b/packages/ui/src/components/session/project-context/PlansSection.tsx
@@ -22,8 +22,10 @@ export const PlansSection: React.FC<{
   plans: ProjectPlanLink[];
   /** Panel-wide filter, matched against plan titles. */
   query: string;
-  /** Hosts without a ContextPanel (mobile) render their own plan viewer. */
-  onOpenPlan?: (plan: { id: string; title: string }) => void;
+  /** Hosts without a ContextPanel (mobile) render their own plan viewer.
+      Includes the owning project so the host's viewer does not have to resolve
+      it from the session directory. */
+  onOpenPlan?: (plan: { id: string; title: string; project: ProjectRef }) => void;
   pinnedPlanIds: ReadonlySet<string>;
   onTogglePinned: (planId: string, pinned: boolean) => Promise<boolean>;
 }> = ({ projectRef, plans, query, onOpenPlan, pinnedPlanIds, onTogglePinned }) => {
@@ -155,7 +157,7 @@ export const PlansSection: React.FC<{
   const handleOpenPlan = React.useCallback(
     (plan: ProjectPlanLink) => {
       if (onOpenPlan) {
-        onOpenPlan({ id: plan.id, title: plan.title });
+        onOpenPlan({ id: plan.id, title: plan.title, project: projectRef });
         return;
       }
       const panelDirectory = currentDirectory?.trim() || projectRef.path.trim();
@@ -165,11 +167,12 @@ export const PlansSection: React.FC<{
       openContextPanelTab(panelDirectory, {
         mode: 'plan',
         projectPlanId: plan.id,
+        projectRef,
         dedupeKey: `plan:${plan.id}`,
         label: plan.title,
       });
     },
-    [currentDirectory, onOpenPlan, openContextPanelTab, projectRef.path]
+    [currentDirectory, onOpenPlan, openContextPanelTab, projectRef]
   );
 
   return (

--- a/packages/ui/src/components/session/project-context/PlansSection.tsx
+++ b/packages/ui/src/components/session/project-context/PlansSection.tsx
@@ -23,8 +23,10 @@ export const PlansSection: React.FC<{
   plans: ProjectPlanLink[];
   /** Panel-wide filter, matched against plan titles. */
   query: string;
-  /** Hosts without a ContextPanel (mobile) render their own plan viewer. */
-  onOpenPlan?: (plan: { id: string; title: string }) => void;
+  /** Hosts without a ContextPanel (mobile) render their own plan viewer.
+      Includes the owning project so the host's viewer does not have to resolve
+      it from the session directory. */
+  onOpenPlan?: (plan: { id: string; title: string; project: ProjectRef }) => void;
   pinnedPlanIds: ReadonlySet<string>;
   onTogglePinned: (planId: string, pinned: boolean) => Promise<boolean>;
 }> = ({ projectRef, plans, query, onOpenPlan, pinnedPlanIds, onTogglePinned }) => {
@@ -155,7 +157,7 @@ export const PlansSection: React.FC<{
   const handleOpenPlan = React.useCallback(
     (plan: ProjectPlanLink) => {
       if (onOpenPlan) {
-        onOpenPlan({ id: plan.id, title: plan.title });
+        onOpenPlan({ id: plan.id, title: plan.title, project: projectRef });
         return;
       }
       const panelDirectory = currentDirectory?.trim() || projectRef.path.trim();
@@ -165,11 +167,12 @@ export const PlansSection: React.FC<{
       openContextPanelTab(panelDirectory, {
         mode: 'plan',
         projectPlanId: plan.id,
+        projectRef,
         dedupeKey: `plan:${plan.id}`,
         label: plan.title,
       });
     },
-    [currentDirectory, onOpenPlan, openContextPanelTab, projectRef.path]
+    [currentDirectory, onOpenPlan, openContextPanelTab, projectRef]
   );
 
   return (

--- a/packages/ui/src/components/session/project-context/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/project-context/ProjectNotesTodoPanel.tsx
@@ -29,8 +29,10 @@ interface ProjectNotesTodoPanelProps {
   canCreateWorktree?: boolean;
   onActionComplete?: () => void;
   /** When provided, opening a plan calls this instead of the desktop context
-      panel tab — hosts without ContextPanel (mobile) render their own viewer. */
-  onOpenPlan?: (plan: { id: string; title: string }) => void;
+      panel tab — hosts without ContextPanel (mobile) render their own viewer.
+      The owning project rides along so the host's viewer never has to guess it
+      from the session directory. */
+  onOpenPlan?: (plan: { id: string; title: string; project: ProjectRef }) => void;
   className?: string;
 }
 
@@ -153,7 +155,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
    * separate context-panel tab, which pushed the user out of the panel they
    * were browsing to read something that belongs to it.
    */
-  const [openPlan, setOpenPlan] = React.useState<{ id: string; title: string } | null>(null);
+  const [openPlan, setOpenPlan] = React.useState<{ id: string; title: string; project: ProjectRef } | null>(null);
   const trimmedQuery = query.trim().toLowerCase();
 
   // Completed items sink to the bottom in the list; storage order is untouched.
@@ -503,6 +505,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
           <React.Suspense fallback={null}>
             <PlanView
               projectPlanId={openPlan.id}
+              projectRef={projectRef}
               onNavigatedToChat={() => setOpenPlan(null)}
             />
           </React.Suspense>

--- a/packages/ui/src/components/session/project-context/ProjectNotesTodoPanel.tsx
+++ b/packages/ui/src/components/session/project-context/ProjectNotesTodoPanel.tsx
@@ -29,8 +29,10 @@ interface ProjectNotesTodoPanelProps {
   canCreateWorktree?: boolean;
   onActionComplete?: () => void;
   /** When provided, opening a plan calls this instead of the desktop context
-      panel tab — hosts without ContextPanel (mobile) render their own viewer. */
-  onOpenPlan?: (plan: { id: string; title: string }) => void;
+      panel tab — hosts without ContextPanel (mobile) render their own viewer.
+      The owning project rides along so the host's viewer never has to guess it
+      from the session directory. */
+  onOpenPlan?: (plan: { id: string; title: string; project: ProjectRef }) => void;
   className?: string;
 }
 
@@ -152,7 +154,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
    * separate context-panel tab, which pushed the user out of the panel they
    * were browsing to read something that belongs to it.
    */
-  const [openPlan, setOpenPlan] = React.useState<{ id: string; title: string } | null>(null);
+  const [openPlan, setOpenPlan] = React.useState<{ id: string; title: string; project: ProjectRef } | null>(null);
   const trimmedQuery = query.trim().toLowerCase();
 
   // Completed items sink to the bottom in the list; storage order is untouched.
@@ -466,6 +468,7 @@ export const ProjectNotesTodoPanel: React.FC<ProjectNotesTodoPanelProps> = ({
           <React.Suspense fallback={null}>
             <PlanView
               projectPlanId={openPlan.id}
+              projectRef={projectRef}
               onNavigatedToChat={() => setOpenPlan(null)}
             />
           </React.Suspense>

--- a/packages/ui/src/components/views/PlanView.tsx
+++ b/packages/ui/src/components/views/PlanView.tsx
@@ -38,7 +38,7 @@ import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
 import { EditorView } from '@codemirror/view';
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { generateBranchName } from '@/lib/git/branchNameGenerator';
-import { fetchProjectPlan, parsePlanMarkdown } from '@/lib/projectContextApi';
+import { fetchProjectPlan, parsePlanMarkdown, type ProjectRef } from '@/lib/projectContextApi';
 import { useProjectContextStore } from '@/stores/useProjectContextStore';
 import { createWorktreeSessionForNewBranch } from '@/lib/worktreeSessionCreator';
 import { TodoSendDialog, type TodoSendExecution } from '@/components/session/TodoSendDialog';
@@ -52,6 +52,11 @@ type PlanViewProps = {
   /** Saved project plan to open. Project plans are server-owned and addressed
       by id; they never carry a client-visible filesystem path. */
   projectPlanId?: string | null;
+  /** The project that owns `projectPlanId`. Callers opening a plan from a
+      project-scoped list pass this so the view does not have to re-derive the
+      project from the session directory, which resolves to nothing for
+      sessions running in a worktree outside the project path. */
+  projectRef?: ProjectRef | null;
   /** Called after a send action routes the user to the chat — hosts that show
       PlanView in an overlay (mobile fullscreen surface) close it here. */
   onNavigatedToChat?: () => void;
@@ -154,7 +159,7 @@ type SelectedLineRange = {
   end: number;
 };
 
-export const PlanView: React.FC<PlanViewProps> = ({ targetPath = null, projectPlanId = null, onNavigatedToChat }) => {
+export const PlanView: React.FC<PlanViewProps> = ({ targetPath = null, projectPlanId = null, projectRef = null, onNavigatedToChat }) => {
   const { t } = useI18n();
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
   const createSession = useSessionUIStore((state) => state.createSession);
@@ -186,10 +191,12 @@ export const PlanView: React.FC<PlanViewProps> = ({ targetPath = null, projectPl
     () => normalize(effectiveDirectory || sessionDirectory),
     [effectiveDirectory, sessionDirectory],
   );
-  const currentProjectRef = React.useMemo(
-    () => resolveProjectRefForDirectory(projectDirectory, projects, activeProjectId),
-    [activeProjectId, projectDirectory, projects],
-  );
+  const currentProjectRef = React.useMemo(() => {
+    if (projectRef) {
+      return projectRef;
+    }
+    return resolveProjectRefForDirectory(projectDirectory, projects, activeProjectId);
+  }, [activeProjectId, projectDirectory, projectRef, projects]);
   const canCreateWorktree = React.useMemo(
     () => (currentProjectRef ? gitDirectories.get(currentProjectRef.path)?.isGitRepo === true : false),
     [currentProjectRef, gitDirectories],

--- a/packages/ui/src/components/views/PlanView.tsx
+++ b/packages/ui/src/components/views/PlanView.tsx
@@ -38,7 +38,7 @@ import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
 import { EditorView } from '@codemirror/view';
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { generateBranchName } from '@/lib/git/branchNameGenerator';
-import { fetchProjectPlan, parsePlanMarkdown } from '@/lib/projectContextApi';
+import { fetchProjectPlan, parsePlanMarkdown, type ProjectRef } from '@/lib/projectContextApi';
 import { useProjectContextStore } from '@/stores/useProjectContextStore';
 import { createWorktreeSessionForNewBranch } from '@/lib/worktreeSessionCreator';
 import { TodoSendDialog, type TodoSendExecution } from '@/components/session/TodoSendDialog';
@@ -52,6 +52,11 @@ type PlanViewProps = {
   /** Saved project plan to open. Project plans are server-owned and addressed
       by id; they never carry a client-visible filesystem path. */
   projectPlanId?: string | null;
+  /** The project that owns `projectPlanId`. Callers opening a plan from a
+      project-scoped list pass this so the view does not have to re-derive the
+      project from the session directory, which resolves to nothing for
+      sessions running in a worktree outside the project path. */
+  projectRef?: ProjectRef | null;
   /** Called after a send action routes the user to the chat — hosts that show
       PlanView in an overlay (mobile fullscreen surface) close it here. */
   onNavigatedToChat?: () => void;
@@ -154,7 +159,7 @@ type SelectedLineRange = {
   end: number;
 };
 
-export const PlanView: React.FC<PlanViewProps> = ({ targetPath = null, projectPlanId = null, onNavigatedToChat }) => {
+export const PlanView: React.FC<PlanViewProps> = ({ targetPath = null, projectPlanId = null, projectRef = null, onNavigatedToChat }) => {
   const { t } = useI18n();
   const currentSessionId = useSessionUIStore((state) => state.currentSessionId);
   const createSession = useSessionUIStore((state) => state.createSession);
@@ -187,10 +192,12 @@ export const PlanView: React.FC<PlanViewProps> = ({ targetPath = null, projectPl
     () => normalize(effectiveDirectory || sessionDirectory),
     [effectiveDirectory, sessionDirectory],
   );
-  const currentProjectRef = React.useMemo(
-    () => resolveProjectRefForDirectory(projectDirectory, projects, activeProjectId),
-    [activeProjectId, projectDirectory, projects],
-  );
+  const currentProjectRef = React.useMemo(() => {
+    if (projectRef) {
+      return projectRef;
+    }
+    return resolveProjectRefForDirectory(projectDirectory, projects, activeProjectId);
+  }, [activeProjectId, projectDirectory, projectRef, projects]);
   const canCreateWorktree = React.useMemo(
     () => (currentProjectRef ? gitDirectories.get(currentProjectRef.path)?.isGitRepo === true : false),
     [currentProjectRef, gitDirectories],

--- a/packages/ui/src/stores/useUIStore.contextPanel.test.ts
+++ b/packages/ui/src/stores/useUIStore.contextPanel.test.ts
@@ -142,6 +142,55 @@ describe('useUIStore closeContextPanelTab surface stability', () => {
   });
 });
 
+describe('useUIStore plan tab project ref', () => {
+  const directory = '/repo';
+
+  test('stores the owning project passed with a project plan tab', () => {
+    useUIStore.getState().openContextPanelTab(directory, {
+      mode: 'plan',
+      projectPlanId: 'plan_1',
+      projectRef: { id: 'project_1', path: '/repo' },
+      dedupeKey: 'plan:plan_1',
+    });
+
+    const tabs = useUIStore.getState().contextPanelByDirectory[directory]?.tabs ?? [];
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.projectPlanId).toBe('plan_1');
+    expect(tabs[0]?.projectRef).toEqual({ id: 'project_1', path: '/repo' });
+  });
+
+  test('keeps plan tabs without an owning project nullable', () => {
+    useUIStore.getState().openContextPanelTab(directory, {
+      mode: 'plan',
+      projectPlanId: 'plan_1',
+      dedupeKey: 'plan:plan_1',
+    });
+
+    const tabs = useUIStore.getState().contextPanelByDirectory[directory]?.tabs ?? [];
+    expect(tabs[0]?.projectPlanId).toBe('plan_1');
+    expect(tabs[0]?.projectRef).toBe(null);
+  });
+
+  test('reopening a plan tab refreshes the owning project', () => {
+    useUIStore.getState().openContextPanelTab(directory, {
+      mode: 'plan',
+      projectPlanId: 'plan_1',
+      projectRef: { id: 'project_1', path: '/repo' },
+      dedupeKey: 'plan:plan_1',
+    });
+    useUIStore.getState().openContextPanelTab(directory, {
+      mode: 'plan',
+      projectPlanId: 'plan_1',
+      projectRef: { id: 'project_1', path: '/repo' },
+      dedupeKey: 'plan:plan_1',
+    });
+
+    const tabs = useUIStore.getState().contextPanelByDirectory[directory]?.tabs ?? [];
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.projectRef).toEqual({ id: 'project_1', path: '/repo' });
+  });
+});
+
 describe('useUIStore per-surface panel widths', () => {
   const directory = '/repo';
 

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -11,6 +11,7 @@ import type { TerminalShell } from '@/lib/api/types';
 import { useFilesViewTabsStore } from './useFilesViewTabsStore';
 import { isWindowsArm64 } from '@/lib/platform';
 import { isVSCodeRuntime } from '@/lib/desktop';
+import type { ProjectRef } from '@/lib/projectContextApi';
 
 export type PendingDiffScope = 'working' | 'staged' | 'turn' | 'branch';
 export type ContextPanelMode = 'diff' | 'walkthrough' | 'file' | 'context' | 'plan' | 'chat' | 'browser' | 'git' | 'pr' | 'notes' | 'terminal';
@@ -37,6 +38,11 @@ type ContextPanelTab = {
       panel. Project plans are addressed by id because their markdown is
       server-owned and has no client-visible path. */
   projectPlanId: string | null;
+  /** Owning project for the saved plan, carried because plan tabs open from a
+      project-scoped list. Without it the editor infers the project from the
+      session directory, which fails for worktree sessions outside the
+      project path. */
+  projectRef: ProjectRef | null;
   dedupeKey: string;
   label: string | null;
   sessionTitleFallback: string | null;
@@ -50,6 +56,7 @@ type ContextPanelTabDescriptor = {
   mode: ContextPanelMode;
   targetPath?: string | null;
   projectPlanId?: string | null;
+  projectRef?: ProjectRef | null;
   dedupeKey?: string | null;
   label?: string | null;
   sessionTitleFallback?: string | null;
@@ -222,6 +229,19 @@ const normalizeContextPanelTabDedupeKey = (
   return buildDefaultContextPanelTabDedupeKey(mode, targetPath);
 };
 
+const normalizeProjectRef = (value: unknown): ProjectRef | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const candidate = value as { id?: unknown; path?: unknown };
+  const id = typeof candidate.id === 'string' ? candidate.id.trim() : '';
+  const path = typeof candidate.path === 'string' ? candidate.path.trim() : '';
+  if (!id || !path) {
+    return null;
+  }
+  return { id, path };
+};
+
 const buildContextPanelTabID = (mode: ContextPanelMode, dedupeKey: string): string => {
   return dedupeKey === mode ? mode : `${mode}:${dedupeKey}`;
 };
@@ -240,6 +260,7 @@ const createContextPanelTab = (descriptor: ContextPanelTabDescriptor): ContextPa
     projectPlanId: typeof descriptor.projectPlanId === 'string' && descriptor.projectPlanId.trim()
       ? descriptor.projectPlanId.trim()
       : null,
+    projectRef: normalizeProjectRef(descriptor.projectRef),
     dedupeKey,
     label: normalizeContextTabLabel(descriptor.label),
     sessionTitleFallback: normalizeContextTabLabel(descriptor.sessionTitleFallback),
@@ -300,6 +321,7 @@ const sanitizeContextPanelTabs = (tabs: unknown): ContextPanelTab[] => {
       mode?: unknown;
       targetPath?: unknown;
       projectPlanId?: unknown;
+      projectRef?: unknown;
       dedupeKey?: unknown;
       label?: unknown;
       sessionTitleFallback?: unknown;
@@ -341,6 +363,7 @@ const sanitizeContextPanelTabs = (tabs: unknown): ContextPanelTab[] => {
       projectPlanId: typeof candidate.projectPlanId === 'string' && candidate.projectPlanId.trim()
         ? candidate.projectPlanId.trim()
         : null,
+      projectRef: normalizeProjectRef(candidate.projectRef),
       dedupeKey,
       label: normalizeContextTabLabel(typeof candidate.label === 'string' ? candidate.label : null),
       sessionTitleFallback: normalizeContextTabLabel(typeof candidate.sessionTitleFallback === 'string' ? candidate.sessionTitleFallback : null),
@@ -413,6 +436,7 @@ const upsertContextPanelTab = (
           dedupeKey: nextTab.dedupeKey,
           label: nextTab.label,
           sessionTitleFallback: nextTab.sessionTitleFallback || tab.sessionTitleFallback,
+          projectRef: nextTab.projectRef,
           stagedDiff: nextTab.stagedDiff,
           diffScope: nextTab.diffScope,
           readOnly: nextTab.readOnly,

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -12,6 +12,7 @@ import type { TerminalShell } from '@/lib/api/types';
 import { useFilesViewTabsStore } from './useFilesViewTabsStore';
 import { isWindowsArm64 } from '@/lib/platform';
 import { isVSCodeRuntime } from '@/lib/desktop';
+import type { ProjectRef } from '@/lib/projectContextApi';
 
 export type MainTab = 'chat' | 'plan' | 'git' | 'diff' | 'terminal' | 'files' | 'context' | 'diagram';
 export type PendingDiffScope = 'working' | 'staged' | 'turn';
@@ -39,6 +40,11 @@ type ContextPanelTab = {
       panel. Project plans are addressed by id because their markdown is
       server-owned and has no client-visible path. */
   projectPlanId: string | null;
+  /** Owning project for the saved plan, carried because plan tabs open from a
+      project-scoped list. Without it the editor infers the project from the
+      session directory, which fails for worktree sessions outside the
+      project path. */
+  projectRef: ProjectRef | null;
   dedupeKey: string;
   label: string | null;
   sessionTitleFallback: string | null;
@@ -52,6 +58,7 @@ type ContextPanelTabDescriptor = {
   mode: ContextPanelMode;
   targetPath?: string | null;
   projectPlanId?: string | null;
+  projectRef?: ProjectRef | null;
   dedupeKey?: string | null;
   label?: string | null;
   sessionTitleFallback?: string | null;
@@ -231,6 +238,19 @@ const normalizeContextPanelTabDedupeKey = (
   return buildDefaultContextPanelTabDedupeKey(mode, targetPath);
 };
 
+const normalizeProjectRef = (value: unknown): ProjectRef | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const candidate = value as { id?: unknown; path?: unknown };
+  const id = typeof candidate.id === 'string' ? candidate.id.trim() : '';
+  const path = typeof candidate.path === 'string' ? candidate.path.trim() : '';
+  if (!id || !path) {
+    return null;
+  }
+  return { id, path };
+};
+
 const buildContextPanelTabID = (mode: ContextPanelMode, dedupeKey: string): string => {
   return dedupeKey === mode ? mode : `${mode}:${dedupeKey}`;
 };
@@ -249,6 +269,7 @@ const createContextPanelTab = (descriptor: ContextPanelTabDescriptor): ContextPa
     projectPlanId: typeof descriptor.projectPlanId === 'string' && descriptor.projectPlanId.trim()
       ? descriptor.projectPlanId.trim()
       : null,
+    projectRef: normalizeProjectRef(descriptor.projectRef),
     dedupeKey,
     label: normalizeContextTabLabel(descriptor.label),
     sessionTitleFallback: normalizeContextTabLabel(descriptor.sessionTitleFallback),
@@ -309,6 +330,7 @@ const sanitizeContextPanelTabs = (tabs: unknown): ContextPanelTab[] => {
       mode?: unknown;
       targetPath?: unknown;
       projectPlanId?: unknown;
+      projectRef?: unknown;
       dedupeKey?: unknown;
       label?: unknown;
       sessionTitleFallback?: unknown;
@@ -350,6 +372,7 @@ const sanitizeContextPanelTabs = (tabs: unknown): ContextPanelTab[] => {
       projectPlanId: typeof candidate.projectPlanId === 'string' && candidate.projectPlanId.trim()
         ? candidate.projectPlanId.trim()
         : null,
+      projectRef: normalizeProjectRef(candidate.projectRef),
       dedupeKey,
       label: normalizeContextTabLabel(typeof candidate.label === 'string' ? candidate.label : null),
       sessionTitleFallback: normalizeContextTabLabel(typeof candidate.sessionTitleFallback === 'string' ? candidate.sessionTitleFallback : null),
@@ -420,6 +443,7 @@ const upsertContextPanelTab = (
           dedupeKey: nextTab.dedupeKey,
           label: nextTab.label,
           sessionTitleFallback: nextTab.sessionTitleFallback || tab.sessionTitleFallback,
+          projectRef: nextTab.projectRef,
           stagedDiff: nextTab.stagedDiff,
           diffScope: nextTab.diffScope,
           readOnly: nextTab.readOnly,


### PR DESCRIPTION
## Intent

Opening a saved plan from the Project knowledge panel while a session runs from a temporary worktree showed a blank editor with a "Save failed" error. The panel lists plans correctly (it resolves the project from `activeProjectId`), but `PlanView` re-derives the project from the session directory by path containment. A worktree lives under `~/.local/share/opencode/worktree/...`, outside every registered project path, so that lookup returns null and the viewer clears its content.

The fix threads the owning project through to `PlanView` everywhere a plan is opened from a project-scoped list, instead of guessing it from the directory. The directory-based lookup stays as the fallback for callers that never had a project in hand.

## Non-goals

- Not changing how the directory-based project lookup works for file-based plan tabs (`openContextPlan`) or any other surface.
- Not changing project resolution for notes, todos, or memory.
- Not migrating existing persisted plan tabs; tabs without a stored project keep the old fallback behavior.

## Affected surfaces

- `packages/ui` only. Shared UI consumed by web, desktop, VS Code, and mobile, so all of them take the same path.
- `PlanView` gains an optional `projectRef` prop.
- `useUIStore` context-panel plan tabs gain a persisted `projectRef` field (nullable; old tabs hydrate to `null`).
- The `onOpenPlan` payload across `PlansSection` to `ProjectNotesTodoPanel` to `ProjectContextPanel` / `MobileWorkspaceDrawer` now carries the owning project.
- Desktop note panel, mobile fullscreen plan surface, and the context-panel `plan` tab all pass the project through.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Adds a persisted field and a shared prop, so I classified the change as local UI behavior plus a persisted-contract addition | Kept the diff to one mechanism (carry the project), added a nullable default so existing stored tabs are valid without a migration, and validated at the package level; no new exports or generated assets |
| `ui-api-decoupling` | `PlanView` resolves project-scoped data reachable through `useProjectContextStore` and a server route | Only flowed an already-trusted `ProjectRef` from existing store state; no new routes, runtime branches, or SDK calls |
| `communication-style` | Loaded at task start per AGENTS.md | Applied to prose and this description |
| `project-context/DOCUMENTATION.md` | Nearest module doc for the panel | Updated the "Plans open in place" section |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (all 5 workspaces) | pass, exit 0 |
| `bun run lint:ui` (eslint) | clean, no warnings |
| `bunx oxlint <changed files>` | no findings in changed lines; remaining findings are in pre-existing migration/portal code, not touched here |
| `bun test packages/ui/src/stores/useUIStore.contextPanel.test.ts` | 19 pass, 0 fail (includes 3 new tests for `projectRef` on plan tabs) |
| `bun run --cwd packages/ui test` | 273/274 files pass; the 1 failing file (`sync/__tests__/event-pipeline.test.js`, 10 failures) fails identically on a clean checkout with this branch's changes stashed, so it is pre-existing and unrelated |

## Visual evidence

Reproduced against a local dev build with an isolated data dir: a `foo-foo` git project with a saved plan, and a worktree session created from it (worktree lives under `~/.local/share/opencode/worktree/...`, outside the project path). Same steps, before and after.

Before (main): clicking the plan opens an empty editor with "Save failed":

![before](https://gist.githubusercontent.com/joeyfromspace/6b7b84900280e90ceab3bc35f9e07569/raw/173d1d7b93ffffdb69bf1c7211668524bc40c01a/before-plan-blank.png)

After (this branch): the same plan loads its markdown:

![after](https://gist.githubusercontent.com/joeyfromspace/6b7b84900280e90ceab3bc35f9e07569/raw/0279feca8d95a539378c5f652d5afa284d9229a5/after-plan-loaded.png)

## Risks and failure behavior

- Old persisted plan tabs hydrate `projectRef` to `null` and keep the existing directory-fallback behavior, so no migration or rollback path is needed.
- If an owning project has been deleted, a plan tab opened with a stale `projectRef` now surfaces the store's "plan not found" error instead of silently blanking, which is the intended failure mode.
- The project-explicit path changes where "improve"/"implement" sends route (to the project path rather than a worktree path), matching the project-scoped ownership of the plan.
