### PR TITLE
fix(git): don't treat bare HEAD as a branch diff base

### DIFF
--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -2660,7 +2660,8 @@ const BRANCH_CREATION_SOURCE_RE = /^branch: Created from (.+)$/;
  * Parse a branch reflog (`git reflog show --format=%gs <branch>`) and return the
  * ref the branch was created from, when that source is itself a named ref.
  *
- * Returns null when the branch was created from `HEAD@{...}` or a raw commit
+ * Returns null when the branch was created from `HEAD` (bare, as `git switch -c`
+ * / `git checkout -b` without an explicit start point record) or a raw commit
  * (detached start): the original branch name is not recorded anywhere in that
  * case, and guessing a base from commit topology would be a heuristic, not an
  * answer. Callers should ask the user to pick a base instead.
@@ -2675,7 +2676,9 @@ export function parseBranchCreationSource(reflogText) {
     const match = lines[index].match(BRANCH_CREATION_SOURCE_RE);
     if (!match) continue;
     const source = match[1].trim();
-    if (!source || /^HEAD@/.test(source) || /^[0-9a-f]{7,40}$/i.test(source)) {
+    // Bare `HEAD` (`git switch -c` from the current branch) and `HEAD@{...}`
+    // (detached start) both lack a named source; a raw commit hash does too.
+    if (!source || /^HEAD(@|$)/.test(source) || /^[0-9a-f]{7,40}$/i.test(source)) {
       return null;
     }
     return source;

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -1354,6 +1354,14 @@ describe('parseBranchCreationSource', () => {
     expect(parseBranchCreationSource(reflog)).toBeNull();
   });
 
+  it('returns null when the branch was created from the current HEAD without a named source', () => {
+    // `git switch -c <branch>` / `git checkout -b <branch>` from the current
+    // branch record `branch: Created from HEAD` in the reflog (git 2.x). The
+    // source branch name is not recorded, so no base can be derived from it.
+    const reflog = 'branch: Created from HEAD';
+    expect(parseBranchCreationSource(reflog)).toBeNull();
+  });
+
   it('returns null when the branch was created from a raw commit', () => {
     const reflog = 'branch: Created from 9a3b2c1d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b';
     expect(parseBranchCreationSource(reflog)).toBeNull();


### PR DESCRIPTION
## Intent

The Branch diff scope mis-derived its base for the most common way of creating a branch. `git switch -c <branch>` and `git checkout -b <branch>` (from the current branch, without an explicit start point) record `branch: Created from HEAD` in the reflog, but `parseBranchCreationSource` only rejected `HEAD@{...}` and raw commit hashes. The bare `HEAD` passed through, so `getBranchBase` returned `{ base: "HEAD" }`, and `getRangeFiles` ran `git diff HEAD...<branch>`:

- When the service is checked out on that branch, `HEAD...<branch>` is an empty range, so the branch scope shows no changes at all.
- When checked out on another branch, the diff is computed against the wrong base.
- A clone that happens to have `refs/remotes/origin/HEAD` gets silently coerced to `origin/HEAD` by `getRangeFiles`, which only matches when the default branch is the actual creation source.

The reflog records no named source for bare `HEAD`, exactly like `HEAD@{...}` (detached start). This change treats them the same: return `null`, so the UI shows the base picker and asks the user to choose once, which is the behavior the scope's comments already promise ("Callers should ask the user to pick a base instead").

## Non-goals

- No change to `getRangeFiles` or its `origin/<base>` preference; that logic stays as-is for genuine named bases.
- No heuristic fallback to main/master. The no-base path (user picks) is intentionally preserved.

## Affected surfaces

- `packages/web/server/lib/git/service.js`: `parseBranchCreationSource` return value for bare `HEAD` reflog entries.
- `packages/ui/src/components/views/DiffView.tsx`: unchanged; it already renders the base picker when `getBranchBase` returns `null`.
- No persisted data, routes, or cross-runtime contracts change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| openchamber-change-discipline | Source change in `packages/web` | Smallest complete change: one regex narrows `HEAD`/`HEAD@{...}`/raw-hash into the null path. Focused tests added. |
| AGENTS.md "Prefer authoritative state over heuristics" | This is exactly the fix's point | The change removes a guess (`HEAD` as base) and routes to the user-picks flow when git records no named source. |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web test -- server/lib/git/service.test.js` | 72 passed (includes new `Created from HEAD` case) |
| `bun run --cwd packages/web test -- server/lib/git/` (3 files) | 84 passed; one intermittent `ENOTEMPTY` cleanup race on a temporary repo on the first run, passed on rerun |
| Manual end-to-end: temp repo, `git switch -c feature`, `getBranchBase` | Before fix: `{ base: "HEAD" }`; after fix: `{ base: null }` |
| Manual end-to-end: `git switch -c feat2 main` (explicit start) | Unchanged: `{ base: "main" }` |
| `bunx oxlint` on both changed files | 0 new findings in changed lines; 48 pre-existing findings elsewhere in the file untouched |

Not validated: live UI interaction (base picker rendering) was not run in a browser; the picker path is existing code reached only when `getBranchBase` returns null.

## Visual evidence

No user-visible rendering changes. The diff only changes a server-side return value; the UI already renders the base picker for a `null` base (DiffView.tsx `if (!branchBase)` branch), which is unchanged code.

## Risks and failure behavior

- Branches created with an explicit start point (`git switch -c x main`) are unaffected; their reflog records the named ref and still resolves.
- Branches created from a named ref recorded via other means (e.g. `git branch` from a non-HEAD ref) still resolve as before.
- The only behavior change: branches whose reflog says `Created from HEAD` now ask the user for a base instead of showing an empty/wrong diff. That is a strictly better failure mode.
- No rollback or compatibility concerns: no persisted data, no API shape change (`{ base: null }` was already the documented no-answer response).
