### PR TITLE
fix(server): percent-encode non-ASCII directory headers to OpenCode

### DIFF
--- a/packages/web/server/lib/markdown-image-grants/DOCUMENTATION.md
+++ b/packages/web/server/lib/markdown-image-grants/DOCUMENTATION.md
@@ -34,3 +34,7 @@ server implementation. VS Code does not call this route for workspace images;
 those use its local filesystem bridge. If called, the grant route returns an
 explicit unsupported response because OpenCode temporary images are not
 supported there.
+
+Requests to OpenCode carry the directory in a percent-encoded
+`x-opencode-directory` header, matching the SDK wire format; OpenCode rejects
+raw non-ASCII header values.

--- a/packages/web/server/lib/markdown-image-grants/routes.js
+++ b/packages/web/server/lib/markdown-image-grants/routes.js
@@ -200,7 +200,9 @@ const fetchMessage = async ({ sessionId, messageId, directory, buildOpenCodeUrl,
   const response = await fetch(url, {
     headers: {
       accept: 'application/json',
-      'x-opencode-directory': directory,
+      // Percent-encoded to match the SDK wire format; raw non-ASCII values
+      // are rejected by OpenCode.
+      'x-opencode-directory': encodeURIComponent(directory),
       ...getOpenCodeAuthHeaders(),
     },
     signal: AbortSignal.timeout(10_000),

--- a/packages/web/server/lib/markdown-image-grants/routes.test.js
+++ b/packages/web/server/lib/markdown-image-grants/routes.test.js
@@ -74,6 +74,20 @@ const prepare = (app, directory, sources) => request(app)
   .expect(200);
 
 describe('session image assets', () => {
+  it('percent-encodes the directory header on the message fetch', async () => {
+    const fixture = await createFixture();
+    await prepare(fixture.app, fixture.directory, ['image.png']);
+
+    expect(fixture.fetchMock).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-opencode-directory': encodeURIComponent(fixture.directory),
+        }),
+      }),
+    );
+  });
+
   it('prepares workspace and OpenCode temporary images with one message fetch', async () => {
     const fixture = await createFixture({ sources: ['workspace.png'] });
     await fs.writeFile(path.join(fixture.directory, 'workspace.png'), PNG);

--- a/packages/web/server/lib/openchamber-sessions/routes.js
+++ b/packages/web/server/lib/openchamber-sessions/routes.js
@@ -83,7 +83,10 @@ const resolveVariant = (providers, providerID, modelID, variant) => {
 const parseConfigModel = (value) => splitModel(value);
 
 const buildDirectoryHeaders = (directory) => ({
-  ...(directory ? { 'x-opencode-directory': directory } : {}),
+  // OpenCode rejects non-ASCII header values; the official SDK sends this
+  // header percent-encoded, so match that wire format (non-ASCII checkout
+  // paths such as "Masaüstü" otherwise fail every dispatched prompt).
+  ...(directory ? { 'x-opencode-directory': encodeURIComponent(directory) } : {}),
 });
 
 const fetchJson = async (url, authHeaders, fallback, directory) => {

--- a/packages/web/server/lib/openchamber-sessions/routes.test.js
+++ b/packages/web/server/lib/openchamber-sessions/routes.test.js
@@ -161,6 +161,29 @@ describe('openchamber session routes', () => {
     }
   });
 
+  it('percent-encodes the directory header for non-ASCII checkout paths', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ id: 'ses_123' }) }));
+    try {
+      const { app } = createApp();
+      await request(app)
+        .post('/api/openchamber/sessions')
+        .send({ directory: '/home/user/Masaüstü/projeler', title: 'Side task' })
+        .expect(200);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-opencode-directory': encodeURIComponent('/home/user/Masaüstü/projeler'),
+          }),
+        }),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('parses JSON body without global middleware', async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ id: 'ses_123' }) }));


### PR DESCRIPTION
## Intent

Session actions (send/fork/create) and markdown image grants fail for projects whose checkout path contains non-ASCII characters (for example `/home/user/Masaüstü/projeler`). The OpenChamber server hand-rolls `fetch` calls to OpenCode with a raw UTF-8 `x-opencode-directory` header value; OpenCode rejects the request with `Header 'x-opencode-directory' has invalid value: '/home/user/Masaüstü/projeler'`, so dispatching a prompt to a session in such a directory always fails. The official `@opencode-ai/sdk` sends this header percent-encoded, which is why every SDK-based path already works. This change percent-encodes the header in the two hand-rolled call sites, matching the SDK wire format.

Reproduced on v1.20.0 by calling the agent tool's `session.send` against a session in a `Masaüstü` directory; the error returns verbatim. After the change the same header value the SDK produces (`%2Fhome%2F...%C3%BC...`) is sent.

## Non-goals

- No change to how the UI sends the header (`runtime-fetch.ts` already sends `x-opencode-directory-encoding: uri`), or to the proxy that decodes it.
- No migration of the hand-rolled `fetch` calls to the SDK client; only the header value is corrected to the SDK wire format.
- No changes to other headers, URLs (already encoded via `URL`/`searchParams`), or bodies.

## Affected surfaces

- `packages/web/server/lib/openchamber-sessions/routes.js` — `buildDirectoryHeaders` now percent-encodes the directory; covers `fetchJson` (providers/agents/config reads), prompt dispatch, and session creation.
- `packages/web/server/lib/markdown-image-grants/routes.js` — the message fetch sends the same encoded header.
- `packages/web/server/lib/markdown-image-grants/DOCUMENTATION.md` — documents the encoded header as part of the module contract.
- Runtimes: server-side only; web, Electron, and VS Code all run this server code, so all runtimes get the fix. Desktop native menus, relay paths, and persisted formats are unaffected.
- Persisted contracts: none; the encoding is per-request.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `ui-api-decoupling` | OpenCode transport behavior and server routes | The SDK is the canonical transport for OpenCode calls and already percent-encodes this header; the fix aligns the hand-rolled call sites with that exact wire format instead of inventing a new one. No new routes, no bypass introduced |
| `openchamber-change-discipline` | Source changes in server modules | Minimal two-call-site change plus regression tests and an owning-doc contract note; no refactors, no unrelated edits |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run packages/web/server/lib/openchamber-sessions/routes.test.js packages/web/server/lib/markdown-image-grants/routes.test.js` | 33/33 pass (incl. two new regression tests asserting the encoded header for a `Masaüstü` path) |
| `bun run --cwd packages/web type-check` | pass |
| `bunx oxlint` on both changed source files | no new findings; three pre-existing findings elsewhere in `routes.js` (conditional spreads, `typeof` narrowing) untouched |
| Live reproduction before fix (v1.20.0, installed package) | `session.send` to a session under `Masaüstü` returns `Header 'x-opencode-directory' has invalid value` |
| Not verified | A live end-to-end run of the patched server against a real `Masaüstü` project (would require restarting the user's running daemon); the unit tests pin the exact outgoing header value instead |

## Visual evidence

None: the change affects an internal request header between the OpenChamber server and OpenCode; there is no user-visible rendering difference. The failure and fix are observable only in request/response behavior, which the regression tests assert.

## Risks and failure behavior

- ASCII-only paths encode to themselves, so existing projects are byte-for-byte unaffected.
- OpenCode already decodes this header form today for every SDK call (including all UI traffic from directories with non-ASCII names), so no server-side change is required.
- If encoding were ever wrong, the failure is the same visible error as today (rejected header), not a silent wrong-directory dispatch; the directory is also passed in the URL query/body unchanged.
- Rollback is a commit revert; no migrations, no persisted formats.
