### PR TITLE
fix(terminal): preserve mobile input and snapshot replay

### DIFF
--- a/packages/ui/src/components/terminal/TerminalViewport.tsx
+++ b/packages/ui/src/components/terminal/TerminalViewport.tsx
@@ -536,9 +536,6 @@ const TerminalViewport = React.forwardRef<TerminalController, Props>(({
   return (
     <div
       ref={containerRef}
-      autoCapitalize="off"
-      autoCorrect="off"
-      spellCheck={false}
       data-terminal-owner="main"
       className={cn('terminal-viewport-container h-full w-full overflow-hidden touch-none', className)}
     />

--- a/packages/ui/src/components/terminal/TerminalViewport.tsx
+++ b/packages/ui/src/components/terminal/TerminalViewport.tsx
@@ -322,8 +322,9 @@ const TerminalViewport = React.forwardRef<TerminalController, Props>(({
         if (id < previous) break;
       }
       if (previousIndex < 0) {
+        // A replacement buffer, including an authoritative snapshot, drops old
+        // chunk ids. Reset the existing VT, then replay it immediately.
         recreateRenderer();
-        return;
       }
     }
     const isReplay = previousIndex < 0;
@@ -535,6 +536,9 @@ const TerminalViewport = React.forwardRef<TerminalController, Props>(({
   return (
     <div
       ref={containerRef}
+      autoCapitalize="off"
+      autoCorrect="off"
+      spellCheck={false}
       data-terminal-owner="main"
       className={cn('terminal-viewport-container h-full w-full overflow-hidden touch-none', className)}
     />

--- a/packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts
+++ b/packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts
@@ -1,30 +1,231 @@
-/**
- * Regression guard for Android terminal IME input.
- *
- * This remains source-scoped because packages/ui has no DOM environment for a
- * mount test (no jsdom / happy-dom), and ghostty-web only initializes in a
- * real mount. The beforeinput effect cannot be exercised behaviorally here.
- */
-import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { describe, expect, mock, test } from 'bun:test';
+import { Window } from 'happy-dom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const terminalViewportSource = readFileSync(join(__dirname, '..', 'TerminalViewport.tsx'), 'utf-8');
+import type { TerminalTheme } from '@/lib/terminalTheme';
+
+class TestResizeObserver implements ResizeObserver {
+  disconnect(): void {}
+  observe(): void {}
+  unobserve(): void {}
+}
+
+class MockFitAddon {
+  fit(): void {}
+}
+
+class MockTerminal {
+  cols = 80;
+  rows = 24;
+  options = { cursorBlink: false };
+  buffer = {
+    active: {
+      length: 0,
+      viewportY: 0,
+      getLine: () => undefined,
+    },
+  };
+
+  loadAddon(): void {}
+  open(): void {}
+  onData() {
+    return { dispose: () => undefined };
+  }
+  write(_data: string, callback?: () => void): void {
+    callback?.();
+  }
+  reset(): void {}
+  dispose(): void {}
+  focus(): void {}
+  scrollLines(): void {}
+  getSelectionPosition(): undefined {
+    return undefined;
+  }
+  getSelection(): string {
+    return '';
+  }
+}
+
+mock.module('ghostty-web', () => ({
+  Ghostty: { load: async () => ({}) },
+  Terminal: MockTerminal,
+  FitAddon: MockFitAddon,
+}));
+
+const terminalTheme: TerminalTheme = {
+  background: '#000000',
+  foreground: '#ffffff',
+  cursor: '#ffffff',
+  cursorAccent: '#000000',
+  selectionBackground: '#333333',
+  black: '#000000',
+  red: '#ff0000',
+  green: '#00ff00',
+  yellow: '#ffff00',
+  blue: '#0000ff',
+  magenta: '#ff00ff',
+  cyan: '#00ffff',
+  white: '#ffffff',
+  brightBlack: '#666666',
+  brightRed: '#ff6666',
+  brightGreen: '#66ff66',
+  brightYellow: '#ffff66',
+  brightBlue: '#6666ff',
+  brightMagenta: '#ff66ff',
+  brightCyan: '#66ffff',
+  brightWhite: '#ffffff',
+};
+
+type InstalledDom = {
+  restore: () => void;
+};
+
+const installDom = (): InstalledDom => {
+  const windowInstance = new Window({ url: 'http://localhost/' });
+  const previousGlobals = new Map<string, PropertyDescriptor | undefined>();
+  const pendingFrameIds = new Set<number>();
+  let nextFrameId = 1;
+
+  const installGlobal = (name: string, value: Window[keyof Window]): void => {
+    previousGlobals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  };
+
+  const requestAnimationFrame = (): number => {
+    const frameId = nextFrameId++;
+    pendingFrameIds.add(frameId);
+    return frameId;
+  };
+  const cancelAnimationFrame = (frameId: number): void => {
+    pendingFrameIds.delete(frameId);
+  };
+
+  installGlobal('window', windowInstance);
+  installGlobal('document', windowInstance.document);
+  installGlobal('navigator', windowInstance.navigator);
+  installGlobal('Document', windowInstance.Document);
+  installGlobal('Element', windowInstance.Element);
+  installGlobal('HTMLElement', windowInstance.HTMLElement);
+  installGlobal('SVGElement', windowInstance.SVGElement);
+  installGlobal('Node', windowInstance.Node);
+  installGlobal('Text', windowInstance.Text);
+  installGlobal('Event', windowInstance.Event);
+  installGlobal('InputEvent', windowInstance.InputEvent);
+  installGlobal('FocusEvent', windowInstance.FocusEvent);
+  installGlobal('MouseEvent', windowInstance.MouseEvent);
+  installGlobal('PointerEvent', windowInstance.PointerEvent);
+  installGlobal('ResizeObserver', TestResizeObserver);
+  installGlobal('requestAnimationFrame', requestAnimationFrame);
+  installGlobal('cancelAnimationFrame', cancelAnimationFrame);
+  installGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+  return {
+    restore: () => {
+      pendingFrameIds.clear();
+      for (const [name, descriptor] of previousGlobals) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+      windowInstance.close();
+    },
+  };
+};
+
+type BeforeInputInit = {
+  inputType: string;
+  data?: string;
+  isComposing?: boolean;
+};
+
+const dispatchBeforeInput = (container: HTMLDivElement, init: BeforeInputInit): void => {
+  const event = new Event('beforeinput', {
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperties(event, {
+    inputType: { configurable: true, value: init.inputType },
+    data: { configurable: true, value: init.data ?? '' },
+    isComposing: { configurable: true, value: init.isComposing ?? false },
+  });
+  container.dispatchEvent(event);
+};
+
+const withMountedViewport = async (
+  enableTouchScroll: boolean,
+  callback: (container: HTMLDivElement, received: string[]) => void | Promise<void>,
+): Promise<void> => {
+  const dom = installDom();
+  let root: Root | null = null;
+
+  try {
+    const { TerminalViewport } = await import('../TerminalViewport');
+    const received: string[] = [];
+    const host = document.createElement('div');
+    document.body.append(host);
+    const mountedRoot = createRoot(host);
+    root = mountedRoot;
+
+    await act(async () => {
+      mountedRoot.render(React.createElement(TerminalViewport, {
+        sessionKey: 'android-input-test',
+        chunks: [],
+        onInput: (data: string) => received.push(data),
+        onResize: () => undefined,
+        theme: terminalTheme,
+        fontFamily: 'monospace',
+        fontSize: 14,
+        enableTouchScroll,
+        autoFocus: false,
+      }));
+    });
+
+    const container = host.querySelector<HTMLDivElement>('[data-terminal-owner="main"]');
+    if (!container) throw new Error('TerminalViewport did not mount its container');
+    await callback(container, received);
+  } finally {
+    const mountedRoot = root;
+    if (mountedRoot) await act(async () => mountedRoot.unmount());
+    dom.restore();
+  }
+};
 
 describe('Android terminal IME input', () => {
-  test('forwards untouched Android beforeinput text only through the touch input path', () => {
-    const handlerStart = terminalViewportSource.indexOf('const handleBeforeInput =');
-    expect(handlerStart).toBeGreaterThan(-1);
-    const wiringEnd = terminalViewportSource.indexOf(
-      "container.addEventListener('beforeinput', handleBeforeInput);",
-      handlerStart,
-    );
-    expect(wiringEnd).toBeGreaterThan(handlerStart);
-    const inputHandler = terminalViewportSource.slice(handlerStart, wiringEnd);
+  test('forwards non-composing beforeinput payloads through the touch input path', async () => {
+    await withMountedViewport(true, async (container, received) => {
+      await act(async () => {
+        dispatchBeforeInput(container, { inputType: 'insertText', data: 'android text' });
+        dispatchBeforeInput(container, { inputType: 'insertLineBreak' });
+        dispatchBeforeInput(container, { inputType: 'insertParagraph' });
+        dispatchBeforeInput(container, { inputType: 'deleteContentBackward' });
+      });
 
-    expect(inputHandler).toContain('if (input.isComposing) return;');
-    expect(inputHandler).toContain('if (input.data) inputRef.current(input.data);');
+      expect(received).toEqual(['android text', '\r', '\r', '\x7f']);
+    });
+  });
+
+  test('ignores composing and unsupported beforeinput events', async () => {
+    await withMountedViewport(true, async (container, received) => {
+      await act(async () => {
+        dispatchBeforeInput(container, {
+          inputType: 'insertText',
+          data: 'composing text',
+          isComposing: true,
+        });
+        dispatchBeforeInput(container, { inputType: 'insertFromPaste', data: 'pasted text' });
+      });
+
+      expect(received).toEqual([]);
+    });
+  });
+
+  test('does not attach beforeinput handling when touch scrolling is disabled', async () => {
+    await withMountedViewport(false, async (container, received) => {
+      await act(async () => {
+        dispatchBeforeInput(container, { inputType: 'insertText', data: 'desktop text' });
+      });
+
+      expect(received).toEqual([]);
+    });
   });
 });

--- a/packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts
+++ b/packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts
@@ -1,35 +1,152 @@
 /**
- * Regression guard for #3096.
+ * Regression guard for #3096 (Android terminal IME input) and the PR #3111
+ * fixes (attribute flags on the container, replay without early return).
  *
- * Ghostty disables text transformations on its hidden textarea, but focuses the
- * contenteditable terminal host. Android IMEs use that host for normal typing.
+ * The container attributes (`autoCapitalize`, `autoCorrect`, `spellCheck`)
+ * are verified through a REAL render of the component with
+ * `renderToStaticMarkup`: the assertions run against the actual HTML output
+ * of `<TerminalViewport />`, not against the source file, so they catch a
+ * regression even if the attributes are moved, renamed, or applied through
+ * a different mechanism.
+ *
+ * The beforeinput handler and the chunk-replay logic are still pinned by
+ * source fragments (scoped to the relevant block, not the whole file):
+ * `packages/ui` has no DOM environment for a mount test (no jsdom /
+ * happy-dom), and ghostty-web is a WASM bundle that only initializes in a
+ * real mount — effects never run under `renderToStaticMarkup`, so event
+ * wiring cannot be exercised behaviorally here.
  */
-import { describe, expect, test } from 'bun:test';
+import React from 'react';
+import { describe, expect, mock, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import type { TerminalTheme } from '@/lib/terminalTheme';
+
+// ghostty-web is only imported lazily by the mount effect (which never runs
+// under renderToStaticMarkup), but keep a stub so importing TerminalViewport
+// can never pull in the WASM emulator bundle.
+mock.module('ghostty-web', () => {
+  class Terminal {
+    cols = 80;
+    rows = 24;
+    options: Record<string, unknown> = {};
+    loadAddon() {}
+    open() {}
+    write() {}
+    reset() {}
+    dispose() {}
+    focus() {}
+    scrollLines() {}
+    getSelection() {
+      return '';
+    }
+    getSelectionPosition() {
+      return null;
+    }
+    onData() {
+      return { dispose: () => {} };
+    }
+  }
+  class FitAddon {
+    fit() {}
+  }
+  return {
+    Terminal,
+    FitAddon,
+    Ghostty: { load: async () => ({}) },
+  };
+});
+
+const { TerminalViewport } = await import('../TerminalViewport');
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const terminalViewportSource = readFileSync(join(__dirname, '..', 'TerminalViewport.tsx'), 'utf-8');
 
-const terminalHostStart = terminalViewportSource.indexOf('return (\n    <div');
-const terminalHostEnd = terminalViewportSource.indexOf('/>', terminalHostStart);
-const terminalHost = terminalViewportSource.slice(terminalHostStart, terminalHostEnd);
+const theme: TerminalTheme = {
+  background: '#000000',
+  foreground: '#ffffff',
+  cursor: '#ffffff',
+  cursorAccent: '#000000',
+  selectionBackground: '#ffffff',
+  black: '#000000',
+  red: '#ff0000',
+  green: '#00ff00',
+  yellow: '#ffff00',
+  blue: '#0000ff',
+  magenta: '#ff00ff',
+  cyan: '#00ffff',
+  white: '#ffffff',
+  brightBlack: '#555555',
+  brightRed: '#ff5555',
+  brightGreen: '#55ff55',
+  brightYellow: '#ffff55',
+  brightBlue: '#5555ff',
+  brightMagenta: '#ff55ff',
+  brightCyan: '#55ffff',
+  brightWhite: '#ffffff',
+};
 
-const inputHandlerStart = terminalViewportSource.indexOf('const handleBeforeInput =');
-const inputEffectStart = terminalViewportSource.lastIndexOf('React.useEffect(() => {', inputHandlerStart);
-const inputEffectEnd = terminalViewportSource.indexOf('}, [enableTouchScroll, ready]);', inputHandlerStart);
-const inputEffect = terminalViewportSource.slice(inputEffectStart, inputEffectEnd);
+const renderTerminalViewport = () =>
+  renderToStaticMarkup(
+    React.createElement(TerminalViewport, {
+      sessionKey: 'test-session',
+      chunks: [],
+      onInput: () => {},
+      onResize: () => {},
+      theme,
+      fontFamily: 'monospace',
+      fontSize: 14,
+    }),
+  );
 
 describe('issue #3096: Android terminal IME input', () => {
-  test("disables text transformations on Ghostty's focused terminal host", () => {
-    expect(terminalHost).toContain('autoCapitalize="off"');
-    expect(terminalHost).toContain('autoCorrect="off"');
-    expect(terminalHost).toContain('spellCheck={false}');
+  test('renders the container div with text-transformation flags disabled', () => {
+    const markup = renderTerminalViewport();
+
+    // The flags must be on the terminal host div, identified by
+    // data-terminal-owner. Slice out that tag from the rendered HTML.
+    const ownerIndex = markup.indexOf('data-terminal-owner="main"');
+    expect(ownerIndex).toBeGreaterThan(-1);
+    const tagStart = markup.lastIndexOf('<', ownerIndex);
+    const tagEnd = markup.indexOf('>', ownerIndex);
+    const containerTag = markup.slice(tagStart, tagEnd);
+
+    expect(containerTag).toContain('autoCapitalize="off"');
+    expect(containerTag).toContain('autoCorrect="off"');
+    // renderToStaticMarkup keeps the camelCase attribute name and renders the
+    // false value as a quoted attribute.
+    expect(containerTag).toContain('spellCheck="false"');
   });
 
   test('forwards untouched Android beforeinput text only through the touch input path', () => {
-    expect(inputEffect).toContain('if (!enableTouchScroll || !container) return;');
-    expect(inputEffect).toContain('if (input.data) inputRef.current(input.data);');
+    const handlerStart = terminalViewportSource.indexOf('const handleBeforeInput =');
+    expect(handlerStart).toBeGreaterThan(-1);
+    const wiringEnd = terminalViewportSource.indexOf(
+      "container.addEventListener('beforeinput', handleBeforeInput);",
+      handlerStart,
+    );
+    expect(wiringEnd).toBeGreaterThan(handlerStart);
+    const inputHandler = terminalViewportSource.slice(handlerStart, wiringEnd);
+
+    expect(inputHandler).toContain('if (input.isComposing) return;');
+    expect(inputHandler).toContain('if (input.data) inputRef.current(input.data);');
+  });
+
+  test('replays a replacement chunk through the existing VT without returning early', () => {
+    const start = terminalViewportSource.indexOf('if (previousIndex < 0) {');
+    expect(start).toBeGreaterThan(-1);
+    const end = terminalViewportSource.indexOf('flush();', start);
+    expect(end).toBeGreaterThan(start);
+    const discontinuity = terminalViewportSource.slice(start, end);
+
+    expect(discontinuity).toContain('recreateRenderer();');
+    // The regression: the replay used to stop after the reset, dropping the
+    // pending chunks. The flush must still run.
+    expect(discontinuity.indexOf('return;', discontinuity.indexOf('recreateRenderer();'))).toBe(-1);
+    expect(discontinuity).toContain('const isReplay = previousIndex < 0;');
+    expect(discontinuity).toContain('chunk.replayData ?? chunk.data');
   });
 });

--- a/packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts
+++ b/packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression guard for #3096.
+ *
+ * Ghostty disables text transformations on its hidden textarea, but focuses the
+ * contenteditable terminal host. Android IMEs use that host for normal typing.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const terminalViewportSource = readFileSync(join(__dirname, '..', 'TerminalViewport.tsx'), 'utf-8');
+
+const terminalHostStart = terminalViewportSource.indexOf('return (\n    <div');
+const terminalHostEnd = terminalViewportSource.indexOf('/>', terminalHostStart);
+const terminalHost = terminalViewportSource.slice(terminalHostStart, terminalHostEnd);
+
+const inputHandlerStart = terminalViewportSource.indexOf('const handleBeforeInput =');
+const inputEffectStart = terminalViewportSource.lastIndexOf('React.useEffect(() => {', inputHandlerStart);
+const inputEffectEnd = terminalViewportSource.indexOf('}, [enableTouchScroll, ready]);', inputHandlerStart);
+const inputEffect = terminalViewportSource.slice(inputEffectStart, inputEffectEnd);
+
+describe('issue #3096: Android terminal IME input', () => {
+  test("disables text transformations on Ghostty's focused terminal host", () => {
+    expect(terminalHost).toContain('autoCapitalize="off"');
+    expect(terminalHost).toContain('autoCorrect="off"');
+    expect(terminalHost).toContain('spellCheck={false}');
+  });
+
+  test('forwards untouched Android beforeinput text only through the touch input path', () => {
+    expect(inputEffect).toContain('if (!enableTouchScroll || !container) return;');
+    expect(inputEffect).toContain('if (input.data) inputRef.current(input.data);');
+  });
+});

--- a/packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts
+++ b/packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts
@@ -1,126 +1,19 @@
 /**
- * Regression guard for #3096 (Android terminal IME input) and the PR #3111
- * fixes (attribute flags on the container, replay without early return).
+ * Regression guard for Android terminal IME input.
  *
- * The container attributes (`autoCapitalize`, `autoCorrect`, `spellCheck`)
- * are verified through a REAL render of the component with
- * `renderToStaticMarkup`: the assertions run against the actual HTML output
- * of `<TerminalViewport />`, not against the source file, so they catch a
- * regression even if the attributes are moved, renamed, or applied through
- * a different mechanism.
- *
- * The beforeinput handler and the chunk-replay logic are still pinned by
- * source fragments (scoped to the relevant block, not the whole file):
- * `packages/ui` has no DOM environment for a mount test (no jsdom /
- * happy-dom), and ghostty-web is a WASM bundle that only initializes in a
- * real mount — effects never run under `renderToStaticMarkup`, so event
- * wiring cannot be exercised behaviorally here.
+ * This remains source-scoped because packages/ui has no DOM environment for a
+ * mount test (no jsdom / happy-dom), and ghostty-web only initializes in a
+ * real mount. The beforeinput effect cannot be exercised behaviorally here.
  */
-import React from 'react';
-import { describe, expect, mock, test } from 'bun:test';
-import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { TerminalTheme } from '@/lib/terminalTheme';
-
-// ghostty-web is only imported lazily by the mount effect (which never runs
-// under renderToStaticMarkup), but keep a stub so importing TerminalViewport
-// can never pull in the WASM emulator bundle.
-mock.module('ghostty-web', () => {
-  class Terminal {
-    cols = 80;
-    rows = 24;
-    options: Record<string, unknown> = {};
-    loadAddon() {}
-    open() {}
-    write() {}
-    reset() {}
-    dispose() {}
-    focus() {}
-    scrollLines() {}
-    getSelection() {
-      return '';
-    }
-    getSelectionPosition() {
-      return null;
-    }
-    onData() {
-      return { dispose: () => {} };
-    }
-  }
-  class FitAddon {
-    fit() {}
-  }
-  return {
-    Terminal,
-    FitAddon,
-    Ghostty: { load: async () => ({}) },
-  };
-});
-
-const { TerminalViewport } = await import('../TerminalViewport');
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const terminalViewportSource = readFileSync(join(__dirname, '..', 'TerminalViewport.tsx'), 'utf-8');
 
-const theme: TerminalTheme = {
-  background: '#000000',
-  foreground: '#ffffff',
-  cursor: '#ffffff',
-  cursorAccent: '#000000',
-  selectionBackground: '#ffffff',
-  black: '#000000',
-  red: '#ff0000',
-  green: '#00ff00',
-  yellow: '#ffff00',
-  blue: '#0000ff',
-  magenta: '#ff00ff',
-  cyan: '#00ffff',
-  white: '#ffffff',
-  brightBlack: '#555555',
-  brightRed: '#ff5555',
-  brightGreen: '#55ff55',
-  brightYellow: '#ffff55',
-  brightBlue: '#5555ff',
-  brightMagenta: '#ff55ff',
-  brightCyan: '#55ffff',
-  brightWhite: '#ffffff',
-};
-
-const renderTerminalViewport = () =>
-  renderToStaticMarkup(
-    React.createElement(TerminalViewport, {
-      sessionKey: 'test-session',
-      chunks: [],
-      onInput: () => {},
-      onResize: () => {},
-      theme,
-      fontFamily: 'monospace',
-      fontSize: 14,
-    }),
-  );
-
-describe('issue #3096: Android terminal IME input', () => {
-  test('renders the container div with text-transformation flags disabled', () => {
-    const markup = renderTerminalViewport();
-
-    // The flags must be on the terminal host div, identified by
-    // data-terminal-owner. Slice out that tag from the rendered HTML.
-    const ownerIndex = markup.indexOf('data-terminal-owner="main"');
-    expect(ownerIndex).toBeGreaterThan(-1);
-    const tagStart = markup.lastIndexOf('<', ownerIndex);
-    const tagEnd = markup.indexOf('>', ownerIndex);
-    const containerTag = markup.slice(tagStart, tagEnd);
-
-    expect(containerTag).toContain('autoCapitalize="off"');
-    expect(containerTag).toContain('autoCorrect="off"');
-    // renderToStaticMarkup keeps the camelCase attribute name and renders the
-    // false value as a quoted attribute.
-    expect(containerTag).toContain('spellCheck="false"');
-  });
-
+describe('Android terminal IME input', () => {
   test('forwards untouched Android beforeinput text only through the touch input path', () => {
     const handlerStart = terminalViewportSource.indexOf('const handleBeforeInput =');
     expect(handlerStart).toBeGreaterThan(-1);
@@ -133,20 +26,5 @@ describe('issue #3096: Android terminal IME input', () => {
 
     expect(inputHandler).toContain('if (input.isComposing) return;');
     expect(inputHandler).toContain('if (input.data) inputRef.current(input.data);');
-  });
-
-  test('replays a replacement chunk through the existing VT without returning early', () => {
-    const start = terminalViewportSource.indexOf('if (previousIndex < 0) {');
-    expect(start).toBeGreaterThan(-1);
-    const end = terminalViewportSource.indexOf('flush();', start);
-    expect(end).toBeGreaterThan(start);
-    const discontinuity = terminalViewportSource.slice(start, end);
-
-    expect(discontinuity).toContain('recreateRenderer();');
-    // The regression: the replay used to stop after the reset, dropping the
-    // pending chunks. The flush must still run.
-    expect(discontinuity.indexOf('return;', discontinuity.indexOf('recreateRenderer();'))).toBe(-1);
-    expect(discontinuity).toContain('const isReplay = previousIndex < 0;');
-    expect(discontinuity).toContain('chunk.replayData ?? chunk.data');
   });
 });

--- a/packages/ui/src/components/views/__tests__/terminalViewportRemount.test.ts
+++ b/packages/ui/src/components/views/__tests__/terminalViewportRemount.test.ts
@@ -47,6 +47,19 @@ describe('terminal viewport remount guard', () => {
         expect(body.indexOf('if (!terminal)')).toBeLessThan(body.indexOf('terminal.reset()'));
     });
 
+    test('replays an authoritative snapshot immediately after its replacement drops the prior chunk id', () => {
+        const start = terminalViewportSource.indexOf('if (previousIndex < 0) {');
+        expect(start).toBeGreaterThan(-1);
+        const end = terminalViewportSource.indexOf('flush();', start);
+        expect(end).toBeGreaterThan(start);
+        const discontinuity = terminalViewportSource.slice(start, end);
+
+        expect(discontinuity).toContain('recreateRenderer();');
+        expect(discontinuity.indexOf('return;', discontinuity.indexOf('recreateRenderer();'))).toBe(-1);
+        expect(discontinuity).toContain('const isReplay = previousIndex < 0;');
+        expect(discontinuity).toContain('chunk.replayData ?? chunk.data');
+    });
+
     test('scrollback is read from the buffer slice, not from the tab', () => {
         expect(terminalViewSource).toContain('getBuffer(');
         expect(terminalViewSource).not.toContain('activeTab?.bufferChunks');


### PR DESCRIPTION
## Intent

Fixes #3103.

- Replay an authoritative replacement terminal snapshot immediately after resetting the existing renderer, instead of waiting for the next output chunk.
- Preserve the existing touch-only `beforeinput` forwarding for mobile terminal input.

## Non-goals

- Does not claim to fix #3096. The current base already contains the separate Ghostty mobile IME attribute change.
- Does not address the separately unconfirmed cross-terminal output-mixing report.
- Does not claim Android device/WebView IME or macOS Electron renderer validation.
- Does not change terminal transport, store ownership, session selection, or VS Code-specific support.

## Affected surfaces

- Shared `packages/ui` terminal viewport used by the web and desktop terminal surfaces, including touch input and replacement-snapshot replay.
- No persisted data, public API, transport, or session-selection contract changes.
- VS Code-specific terminal bridging remains unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | This is a shared terminal UI change. The repository requires minimal diffs, intentional runtime behavior, and no unrelated work. | Keeps the replay production path unchanged and replaces only the affected terminal test with behavioral mount coverage. |
| `openchamber-change-discipline` | Source and regression-test code are changed. | Keeps the fix local, preserves the existing replay owner, and validates the affected package with focused checks. |
| `theme-system` | The shared `TerminalViewport` component is touched. | No colors, icons, controls, or visual tokens are introduced or changed. |
| Package/module documentation | `packages/ui` has no package README or terminal `DOCUMENTATION.md` in the affected path. | No ownership or documented module contract changes. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts` | Passed: 3 tests, 0 failures. Uses the existing `happy-dom` ^18.0.1 dependency from current `main`; local stale-branch validation used a no-save install. |
| `bun test packages/ui/src/components/views/__tests__/terminalViewportRemount.test.ts` | Passed: 9 tests, 0 failures. |
| `bun run --cwd packages/ui test` | Passed: 290/290 test files. |
| `bun run type-check:ui` | Passed with the existing `happy-dom` dependency available; no package metadata changes. |
| `bun run lint:ui` | Passed. |
| `bunx oxlint packages/ui/src/components/terminal/TerminalViewport.tsx packages/ui/src/components/terminal/__tests__/terminalViewportAndroidInput.test.ts packages/ui/src/components/views/__tests__/terminalViewportRemount.test.ts` | Exit 1 because 8 pre-existing findings remain in unchanged `TerminalViewport.tsx` lines. The changed test file is clean and no current diff line is flagged. |
| `git diff --check` | Passed. |
| Final-diff review | Automated review at `2437969e` returned `PASS` with no new findings. Manual inspection found no blocking issue; a fresh local `@reviewer` pass was unavailable in this environment. |

## Visual evidence

No screenshot or recording is attached. This follow-up introduces no rendered visual change: it removes ineffective container attributes and test-only rendering scaffolding. Android/WebView and macOS runtime interaction were not manually verified.

## Risks and failure behavior

- The Android `beforeinput` guard now has behavioral coverage through a real `happy-dom` mount with a mocked `ghostty-web` runtime. Actual Android device/WebView IME behavior and macOS renderer behavior were not manually tested.
- The test uses the `happy-dom` devDependency already present on current `main`; local validation used a no-save install because this PR branch predates that base change.
- The temporary no-save install reported an existing `patch-package` failure while applying the `ghostty-web` patch; it did not alter tracked files, and the target tests/type-check passed afterward.
- Snapshot replay remains scoped to the existing per-viewport buffer, reset, queue, and flush lifecycle.
- The previous PR check at the earlier head failed on 7 unrelated unused-variable lint errors in other files. Local touched-surface checks above separate those baseline findings from this follow-up.




---

## Closed — superseded by the terminal adapter rewrite (2026-09-13)

Verified against current `main` (`961f1611c`):

- `e5c2c81bf` (2026-09-07) replaced `ghostty-web` with an in-repo libghostty-vt adapter, and `e7d8bb7e5` reworked replay. A replacement snapshot is now reset and written in one pass (`selectTerminalChunkReplay` → `surface.resetAndWrite`), so there is no wait for the next output chunk to fix.
- Mobile input moved into the adapter (auto-capitalize/spellcheck handling, composition and keyCode-229 guards); the container `beforeinput` forwarder this branch touched no longer exists on `main`.
- The branch conflicts with `main` in `TerminalViewport.tsx`, and its tests target removed symbols (`recreateRenderer`, `previousIndex`).

Closing as superseded. If #3103 still reproduces on the current release, it needs a fresh repro against the adapter.
