### PR TITLE
fix(chat): keep mobile composer above keyboard

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -2505,8 +2505,8 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
         setMobileDraftPickerQuery('');
     }, [mobileDraftPicker]);
 
-    // Mobile browsers pan the visual viewport instead of resizing the layout,
-    // so the composer form is pinned to it explicitly.
+    // Mobile browsers do not reliably reveal the focused composer above the
+    // keyboard, so pin normal-height composers to the visual viewport.
     useMobileViewportPin({
         isMobile,
         isFullscreen: isMobileExpanded,

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -149,7 +149,12 @@ mostly not state machines but corrections for specific platform behaviors:
 mobile browsers dismissing the keyboard before a tap's click lands, iOS
 refusing programmatic focus outside a gesture, WebKit leaving the layout
 viewport panned after the keyboard hides, overlay chains handing off through a
-frame where nothing is open.
+frame where nothing is open. Non-Capacitor mobile browsers pin focused
+normal-height composers on both draft and active-session screens because native
+focus reveal is unreliable. In active sessions, fixing the form removes it from
+flow, so the parent composer slot preserves space (`minHeight` matching the form
+plus any keyboard-covered layout) to keep transcript text fully scrollable into
+view above the pinned composer.
 
 **Every timeout and `flushSync` in them has a reason recorded next to it, and
 none of them is verifiable outside a real device.** Change them only against

--- a/packages/ui/src/components/chat/composer/state/useMobileViewportPin.ts
+++ b/packages/ui/src/components/chat/composer/state/useMobileViewportPin.ts
@@ -96,15 +96,20 @@ export function useMobileViewportPin(options: MobileViewportPinOptions): void {
         };
     }, [editorRef, formRef, isFullscreen, isMobile]);
 
-    // Draft screen with the keyboard up: anchor the normal-height composer to
-    // the visible bottom. The chat screen does not need this — its own
-    // focused-field reveal works there.
+    // Normal-height composer with the keyboard up: anchor to the visible bottom.
+    // Native focused-field reveal is unreliable across mobile browsers (e.g.
+    // Chrome and Firefox Android, WebKit pans), so pin on both draft and active
+    // sessions. In active sessions, reserving layout space on the parent slot
+    // keeps the transcript scrollable above the pinned form.
     React.useLayoutEffect(() => {
         if (!isMobile || isCapacitorApp()) return;
-        if (!isDraftScreen || isFullscreen || !isFocused) return;
+        if (isFullscreen || !isFocused) return;
         const vv = window.visualViewport;
         const form = formRef.current;
         if (!vv || !form) return;
+
+        const parent = form.parentElement;
+        const originalParentMinHeight = parent?.style.minHeight ?? '';
 
         // Keep the in-flow horizontal geometry (page paddings) while fixed.
         const rect = form.getBoundingClientRect();
@@ -118,6 +123,7 @@ export function useMobileViewportPin(options: MobileViewportPinOptions): void {
         // can simply not fire), so track the pan with a rAF loop instead —
         // cheap math per frame, a style write only when the value changes.
         let lastTop = Number.NaN;
+        let lastSlotMinHeight = Number.NaN;
         let frame = 0;
         const track = () => {
             // iOS standalone (PWA) can serve stale visualViewport metrics after
@@ -128,12 +134,28 @@ export function useMobileViewportPin(options: MobileViewportPinOptions): void {
             // pan-mode browsers clientHeight stays full height, so the min
             // keeps the visual-viewport anchor there.
             const layoutBottom = document.documentElement.clientHeight;
-            const vvBottom = vv.offsetTop + vv.height;
-            const top = Math.max(0, Math.floor(Math.min(vvBottom, layoutBottom) - form.offsetHeight));
+            const visibleBottom = Math.min(vv.offsetTop + vv.height, layoutBottom);
+            const formHeight = form.offsetHeight;
+            const top = Math.max(0, Math.floor(visibleBottom - formHeight));
             if (top !== lastTop) {
                 lastTop = top;
                 form.style.top = `${top}px`;
             }
+
+            // In active sessions, taking the form out of flow would allow the
+            // transcript to hide behind the pinned composer. Reserve enough
+            // minHeight on the parent slot so the transcript remains fully
+            // scrollable above the composer. The reservation is derived from the
+            // exact applied top (layoutBottom - top), so fractional viewport
+            // values cannot leave a seam between the transcript and the pin.
+            if (!isDraftScreen && parent) {
+                const requiredMinHeight = Math.ceil(layoutBottom - top);
+                if (requiredMinHeight !== lastSlotMinHeight) {
+                    lastSlotMinHeight = requiredMinHeight;
+                    parent.style.minHeight = `${requiredMinHeight}px`;
+                }
+            }
+
             frame = requestAnimationFrame(track);
         };
         track();
@@ -141,6 +163,9 @@ export function useMobileViewportPin(options: MobileViewportPinOptions): void {
         return () => {
             cancelAnimationFrame(frame);
             releaseForm(form);
+            if (parent) {
+                parent.style.minHeight = originalParentMinHeight;
+            }
         };
     }, [formRef, isDraftScreen, isFocused, isFullscreen, isMobile]);
 }


### PR DESCRIPTION
## Intent

Fixes #3114.

On Android mobile web, focusing the normal-height composer in an ongoing session can open the keyboard without revealing the composer. It remains behind the keyboard until the first input.

Apply the existing visual-viewport pin to focused composers in ongoing sessions as well as new-session drafts. While the active-session form is fixed, reserve its layout space so the transcript remains fully scrollable above it.

## Non-goals

- Mobile layout during orientation changes.
- Browser background and foreground restoration.
- Fullscreen composer behavior.
- Native Capacitor keyboard handling.
- Keyboard submission or IME behavior.

## Affected surfaces

This changes focused, normal-height composers in non-Capacitor mobile browsers and PWAs.

Desktop web, Electron, and VS Code do not enter this mobile path. Capacitor remains excluded because its native keyboard choreography owns composer positioning.

No API, persistence, dependency, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | The shared composer runs across browser, desktop, VS Code, and native mobile runtimes. | The change stays in the composer-owned hook and preserves explicit desktop and Capacitor boundaries. |
| `openchamber-change-discipline` | This is an executable shared-UI platform fix. | The diff is limited to the viewport hook, its call-site comment, and owning documentation. |
| `performance-engineering` | The hook measures viewport geometry during keyboard animation. | It reuses the existing focused-state frame loop and writes styles only when integer geometry changes. |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | This document owns composer focus and mobile keyboard invariants. | It records active-session pinning, temporary layout reservation, cleanup, and hardware-only verification. |
| `packages/web/README.md` | The affected runtime is mobile browser/PWA. | The change was built through the web package and verified on physical Android browsers. |

## Validation

| Check | Result |
|---|---|
| Firefox 154.0, Pixel 9 Pro XL, Android 17, portrait browser tab | Passed. Composer appears above the keyboard before typing. Repeated keyboard open/close and transcript scrolling kept final content reachable. |
| Chrome 151.0.7922.169, same device and scenario | Passed. |
| `bun run type-check` | Passed for every workspace. |
| `bun run build` | Passed. |
| Root, UI, VS Code, and Electron tests | Passed: 1, 289, 25, and 17 test files respectively. |
| `bun run --cwd packages/web test` | Passed: 162 files, 1,626 tests passed, 2 skipped. |
| Repository-local ESLint for UI, web, and mobile | Passed. |
| `git diff --check` | Passed. |

The first web test run timed out in the relay integration test while the LAN development server was running. After stopping that server, the isolated relay test and complete web suite passed.

The workspace lint script resolved the host's ESLint 6 instead of the repository's ESLint 9 for UI, web, and mobile. Running those scopes through `bun x eslint` used the repository-local version and passed.

Oxlint could not load the TypeScript config and plugin because this host Node binary lacks TypeScript-loader support. Its configuration was not changed or bypassed.

Not manually verified on iOS or tablet browser layouts. Orientation changes are outside this PR's scope.

## Visual evidence

### Before

https://github.com/user-attachments/assets/b439aa62-8737-4f9d-918f-5a66a7e26eed

The keyboard opens while the composer remains hidden. The first input makes it jump into view.

### After

https://github.com/user-attachments/assets/80b4087f-0c3c-49b6-98fe-2475e55d990b


The verified behavior is that the composer appears above the keyboard immediately, and repeated keyboard open/close and scrolling leave final transcript content reachable.

## Risks and failure behavior

Fixing the form removes it from normal flow. In ongoing sessions, the hook temporarily reserves space on the parent composer slot so the transcript cannot extend behind the pinned form.

The reservation is derived from the exact top applied to the form, avoiding overlap from fractional viewport coordinates. Cleanup restores the parent's original inline `minHeight`, clears the form styles owned by the hook, and cancels its animation frame.

If `visualViewport` is unavailable, the hook preserves the previous browser behavior. Capacitor and desktop runtimes remain outside this path.

The focused frame loop now also runs in ongoing sessions. Geometry writes occur only when the integer composer top or reserved slot height changes. No visible keyboard-animation regression was observed on the tested device, but no profiler capture was recorded.

Rollback is a source-only revert. No persisted state or migration is involved.
