### PR TITLE
test(ui): remove stale chat surface assertions

### DIFF
--- a/packages/ui/src/lib/addSelectionToChat.test.ts
+++ b/packages/ui/src/lib/addSelectionToChat.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const focusChatInputCalls: number[] = [];
 const pendingInputCalls: Array<{ text: string | null; mode?: string }> = [];
-const activeSurfaceCalls: string[] = [];
 const sessionSwitcherCalls: boolean[] = [];
 const codeMirrorDispatches: Array<{ selection: { anchor: number } }> = [];
 
@@ -41,9 +40,6 @@ mock.module('@/sync/input-store', () => ({
 mock.module('@/stores/useUIStore', () => ({
   useUIStore: {
     getState: () => ({
-      setActiveSurface: (tab: string) => {
-        activeSurfaceCalls.push(tab);
-      },
       setSessionSwitcherOpen: (open: boolean) => {
         sessionSwitcherCalls.push(open);
       },
@@ -86,7 +82,6 @@ const installSelectionEnvironment = (options: {
 const clearCalls = () => {
   focusChatInputCalls.length = 0;
   pendingInputCalls.length = 0;
-  activeSurfaceCalls.length = 0;
   sessionSwitcherCalls.length = 0;
   codeMirrorDispatches.length = 0;
   codeMirrorView = null;
@@ -262,7 +257,6 @@ describe('addSelectionToChat', () => {
     installSelectionEnvironment({ activeElement: textarea });
 
     expect(addSelectionToChat()).toBe(true);
-    expect(activeSurfaceCalls).toEqual([]);
     expect(sessionSwitcherCalls).toEqual([false]);
     expect(pendingInputCalls).toEqual([{ text: '```md\nselected\n```', mode: 'append' }]);
 
@@ -290,7 +284,6 @@ describe('addSelectionToChat', () => {
 
     expect(addSelectionToChat()).toBe(false);
     expect(pendingInputCalls).toEqual([]);
-    expect(activeSurfaceCalls).toEqual([]);
 
     await Promise.resolve();
     expect(focusChatInputCalls.length).toBe(1);


### PR DESCRIPTION
## Intent

Restore mainline CI by removing stale test expectations for `setActiveSurface('chat')`, which production code intentionally stopped calling in the surface refactor.

## Non-goals

- No production behavior changes.
- No navigation, focus, session-switcher, or selection-capture changes.
- No dependency, API, persistence, or runtime-contract changes.

## Affected surfaces

- `packages/ui/src/lib/addSelectionToChat.test.ts` only.
- The test continues to verify selection capture, session-switcher closing, pending-input append, and chat-input focus without asserting a removed surface transition.

## Repository guidance

- `AGENTS.md`: keep test-only fixes narrow and do not change product behavior when correcting stale tests.
- `CONTRIBUTING.md`: focused validation is included below; no user-visible behavior changed.

## Validation

- `bun test packages/ui/src/lib/addSelectionToChat.test.ts` — 10 passed, 24 assertions.
- `node scripts/run-isolated-tests.mjs packages/ui/src/lib` — 90/90 test files passed.
- `bun run type-check:ui` and `bun run lint:ui` — passed.
- `git diff --check` — passed.
- GitHub `checks`, label, and Greptile Review — passed; Greptile confidence 5/5.
- OCR review selected no files for this deletion-only test diff; manual diff review confirmed only obsolete mock plumbing and assertions were removed.

## Visual evidence

No user-visible behavior changed; this PR removes obsolete test-only assertions.

## Risk and failure behavior

The change removes stale test coverage only for a surface transition the current implementation no longer performs. Existing tests still cover the supported selection-to-chat behavior.

---

## Closed — no longer needed (2026-09-13)

Verified against current `main` (`961f1611c`): `bun test packages/ui/src/lib/addSelectionToChat.test.ts` passes 10/10, and production no longer defines `setActiveSurface` (removed earlier in `1eb6123e8` / `81558aa46`). The assertions this PR removes are already dead mock plumbing with no failing CI to restore, so the test-only cleanup is obsolete.

Closing as not reproducible.
