### PR TITLE
feat(chat): add quick-open file icon in tool card header

### DIFF
--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -1996,6 +1996,7 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
         return null;
     }, [descriptionPath, normalizedPartTool, stateWithData, input]);
     const runtime = React.useContext(RuntimeAPIContext);
+    const mobileActions = useMobileAppActions();
 
     const openApplyPatchFile = (file: Record<string, unknown>, event: React.MouseEvent<HTMLButtonElement>) => {
         if (!runtime?.editor) {
@@ -2066,6 +2067,61 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
         }
         event.preventDefault();
         handleMainClick(event);
+    };
+
+    // Quick-open target for the file-link icon in the tool header. Resolves the
+    // primary file path (and, for diff tools, the first changed line + diff) so
+    // the user can open the file in the side panel (web/desktop) or editor
+    // (VS Code) without expanding the tool card. Reuses the same path helpers as
+    // handleMainClick above; the difference is the web fallback — handleMainClick
+    // only opens when runtime.editor is available, this icon also falls back to
+    // useUIStore.openContextFile{AtLine} so the file opens in the right pane.
+    const quickOpenTarget = React.useMemo<{ absolutePath: string; line?: number; toolDiff?: string; toolName: string } | null>(() => {
+        if (isTaskTool) return null;
+        const toolName = normalizedPartTool || part.tool;
+        const filePath = getPrimaryToolPath(toolName, input, metadata);
+        if (typeof filePath !== 'string') return null;
+        const absolutePath = toAbsoluteFilePath(currentDirectory, filePath);
+        let line: number | undefined;
+        let toolDiff: string | undefined;
+        if (toolName === 'edit' || toolName === 'multiedit' || toolName === 'apply_patch') {
+            line = getFirstChangedLineFromMetadata(toolName, metadata, filePath);
+            toolDiff = getPrimaryDiffFromMetadata(toolName, metadata, filePath);
+        }
+        return { absolutePath, line, toolDiff, toolName };
+    }, [isTaskTool, normalizedPartTool, part.tool, input, metadata, currentDirectory]);
+
+    const openQuickTarget = () => {
+        if (!quickOpenTarget) return;
+        const { absolutePath, line, toolDiff, toolName } = quickOpenTarget;
+        if (runtime?.editor) {
+            if (runtime.runtime.isVSCode && toolDiff && (toolName === 'edit' || toolName === 'multiedit' || toolName === 'apply_patch')) {
+                const label = `${getRelativePath(absolutePath, currentDirectory)} (changes)`;
+                void runtime.editor.openDiff('', absolutePath, label, { line, patch: toolDiff });
+                return;
+            }
+            runtime.editor.openFile(absolutePath, line);
+            return;
+        }
+        const uiStore = useUIStore.getState();
+        if (typeof line === 'number' && Number.isFinite(line)) {
+            uiStore.openContextFileAtLine(currentDirectory, absolutePath, Math.max(1, Math.trunc(line)), 1);
+        } else {
+            uiStore.openContextFile(currentDirectory, absolutePath);
+        }
+        mobileActions?.openFiles();
+    };
+
+    const handleQuickOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        openQuickTarget();
+    };
+
+    const handleQuickOpenKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        event.stopPropagation();
+        openQuickTarget();
     };
 
     const iconStyle = !isTaskTool && isError ? TOOL_ERROR_ICON_STYLE : TOOL_NORMAL_ICON_STYLE;
@@ -2161,7 +2217,7 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
                                     {isExpanded ? <Icon name="arrow-down-s" className="h-3.5 w-3.5" /> : <Icon name="arrow-right-s" className="h-3.5 w-3.5" />}
                                 </div>
                             </div>
-                            <div className="flex items-center gap-2 min-w-0 flex-1">
+                            <div className="flex items-center gap-1 min-w-0 flex-1">
                                 <MinDurationShineText
                                     active={Boolean(isActive && !isError)}
                                     minDurationMs={300}
@@ -2171,6 +2227,22 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
                                 >
                                     {displayName}
                                 </MinDurationShineText>
+                                {quickOpenTarget ? (
+                                    <button
+                                        type="button"
+                                        onClick={handleQuickOpen}
+                                        onKeyDown={handleQuickOpenKeyDown}
+                                        className={cn(
+                                            'flex-shrink-0 inline-flex h-4 w-4 items-center justify-center rounded transition-opacity hover:bg-[var(--surface-hover)]',
+                                            'opacity-0 group-hover/tool:opacity-60 hover:opacity-100 focus-visible:opacity-100',
+                                        )}
+                                        style={{ color: 'var(--tools-icon)' }}
+                                        title={t('chat.toolPart.openFile')}
+                                        aria-label={t('chat.toolPart.openFile')}
+                                    >
+                                        <Icon name="external-link" className="h-3 w-3" />
+                                    </button>
+                                ) : null}
                             </div>
                             {normalizedPartTool === 'bash' && typeof effectiveTimeStart === 'number' ? (
                                 <span className={cn('flex-shrink-0 tabular-nums text-muted-foreground/80', TOOL_ROW_DESCRIPTION_CLASS)}>

--- a/packages/ui/src/lib/i18n/messages/de.ts
+++ b/packages/ui/src/lib/i18n/messages/de.ts
@@ -2157,6 +2157,7 @@ export const dict = {
   'chat.toolPart.showRawJson': 'Rohe JSON anzeigen',
   'chat.toolPart.showFormattedJson': 'Formatierte JSON anzeigen',
   'chat.toolPart.showNavigableJson': 'Navigierbare JSON anzeigen',
+  'chat.toolPart.openFile': 'Datei öffnen',
   'chat.toolPart.openFileAtFirstChange': 'Datei bei erster Änderung öffnen',
   'chat.toolPart.openFileDiff': 'Datei-Unterschied öffnen',
   'chat.toolPart.copyOutput': 'Ausgabe kopieren',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2334,6 +2334,7 @@ export const dict = {
   'chat.toolPart.showRawJson': 'Show raw JSON',
    'chat.toolPart.showFormattedJson': 'Show formatted JSON',
    'chat.toolPart.showNavigableJson': 'Show navigable JSON',
+   'chat.toolPart.openFile': 'Open file',
    'chat.toolPart.openFileAtFirstChange': 'Open file at first change',
    'chat.toolPart.openFileDiff': 'Open file diff',
   'chat.toolPart.copyOutput': 'Copy output',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2300,6 +2300,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.toolPart.showRawJson": "Mostrar JSON sin formato",
   "chat.toolPart.showFormattedJson": "Mostrar JSON formateado",
   "chat.toolPart.showNavigableJson": "Mostrar JSON navegable",
+  "chat.toolPart.openFile": "Abrir archivo",
   "chat.toolPart.openFileAtFirstChange": "Abrir archivo en el primer cambio",
   "chat.toolPart.openFileDiff": "Abrir diferencias del archivo",
   "chat.toolPart.copyOutput": "Copiar salida",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -3063,6 +3063,7 @@ export const dict = {
   'chat.toolPart.showRawJson': 'Afficher le JSON brut',
   'chat.toolPart.showFormattedJson': 'Afficher le JSON formaté',
   'chat.toolPart.showNavigableJson': 'Afficher le JSON navigable',
+  'chat.toolPart.openFile': 'Ouvrir le fichier',
   'chat.toolPart.openFileAtFirstChange': 'Ouvrir le fichier à la première modification',
   'chat.toolPart.openFileDiff': 'Ouvrir les différences du fichier',
   'chat.toolPart.copyOutput': 'Copier la sortie',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2333,6 +2333,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.toolPart.showRawJson': '生JSONを表示',
   'chat.toolPart.showFormattedJson': '整形JSONを表示',
   'chat.toolPart.showNavigableJson': 'ナビゲーション可能なJSONを表示',
+  'chat.toolPart.openFile': 'ファイルを開く',
   'chat.toolPart.openFileAtFirstChange': '最初の変更箇所でファイルを開く',
   'chat.toolPart.openFileDiff': 'ファイル差分を開く',
   'chat.toolPart.copyOutput': '出力をコピー',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2334,6 +2334,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.toolPart.showRawJson': '원시 JSON 표시',
   'chat.toolPart.showFormattedJson': '형식화된 JSON 표시',
   'chat.toolPart.showNavigableJson': '탐색 가능한 JSON 표시',
+  'chat.toolPart.openFile': '파일 열기',
   'chat.toolPart.openFileAtFirstChange': '첫 번째 변경 위치에서 파일 열기',
   'chat.toolPart.openFileDiff': '파일 diff 열기',
   'chat.toolPart.copyOutput': '출력 복사',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1416,6 +1416,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.toolPart.showRawJson': 'Pokaż surowy JSON',
   'chat.toolPart.showFormattedJson': 'Pokaż sformatowany JSON',
   'chat.toolPart.showNavigableJson': 'Pokaż nawigowalny JSON',
+  'chat.toolPart.openFile': 'Otwórz plik',
   'chat.toolPart.openFileAtFirstChange': 'Otwórz plik przy pierwszej zmianie',
   'chat.toolPart.openFileDiff': 'Otwórz różnice pliku',
   'chat.toolPart.copyOutput': 'Kopiuj wyjście',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2300,6 +2300,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.toolPart.showRawJson": "Mostrar JSON bruto",
   "chat.toolPart.showFormattedJson": "Mostrar JSON formatado",
   "chat.toolPart.showNavigableJson": "Mostrar JSON navegável",
+  "chat.toolPart.openFile": "Abrir arquivo",
   "chat.toolPart.openFileAtFirstChange": "Abrir arquivo na primeira alteração",
   "chat.toolPart.openFileDiff": "Abrir diferenças do arquivo",
   "chat.toolPart.copyOutput": "Copiar saída",

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2300,6 +2300,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.toolPart.showRawJson": "Показати сирий JSON",
   "chat.toolPart.showFormattedJson": "Показати форматований JSON",
   "chat.toolPart.showNavigableJson": "Показати навігаційний JSON",
+  "chat.toolPart.openFile": "Відкрити файл",
   "chat.toolPart.openFileAtFirstChange": "Відкрити файл на першій зміні",
   "chat.toolPart.openFileDiff": "Відкрити diff файлу",
   "chat.toolPart.copyOutput": "Скопіювати вивід",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2300,6 +2300,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.toolPart.showRawJson': '显示原始 JSON',
   'chat.toolPart.showFormattedJson': '显示格式化 JSON',
   'chat.toolPart.showNavigableJson': '显示可导航 JSON',
+  'chat.toolPart.openFile': '打开文件',
   'chat.toolPart.openFileAtFirstChange': '在首次更改处打开文件',
   'chat.toolPart.openFileDiff': '打开文件差异',
   'chat.toolPart.copyOutput': '复制输出',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2304,6 +2304,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.toolPart.showRawJson': '顯示原始 JSON',
   'chat.toolPart.showFormattedJson': '顯示格式化 JSON',
   'chat.toolPart.showNavigableJson': '顯示可導覽 JSON',
+  'chat.toolPart.openFile': '開啟檔案',
   'chat.toolPart.openFileAtFirstChange': '在首次變更處開啟檔案',
   'chat.toolPart.openFileDiff': '開啟檔案差異',
   'chat.toolPart.copyOutput': '複製輸出',


### PR DESCRIPTION

<h2>Intent</h2>
<p>In the browser, a collapsed tool card for Write/Edit/MultiEdit/ApplyPatch shows the target path but has no way to open that file from the header — clicking the header only expands the card. The existing <code>openFileAtFirstChange</code>/<code>openFileDiff</code> buttons live inside the expanded diff content and only render when <code>diffEntries.length &gt; 0</code>, so a Write of a new file (no diff) has no open affordance at all. This adds an <code>external-link</code> icon in the collapsed header that opens the target file in the side panel (web) or editor (VS Code) without expanding.</p>
<h2>Non-goals</h2>
<ul>
<li>Not changing <code>handleMainClick</code> — the header row keeps toggling the card in the browser; the icon is a separate, opt-in open affordance.</li>
<li>Not covering <code>read</code>/<code>lsp</code> — <code>getPrimaryToolPath</code> does not resolve those; icon does not render for them.</li>
<li>Not adding copy/download actions to the header (exists elsewhere).</li>
</ul>
<h2>Affected surfaces</h2>
<ul>
<li><code>packages/ui</code> — <code>ToolPart.tsx</code> (<code>ToolPartContent</code>), <code>i18n/messages/*</code> (11 locales). </li>
<li>Web, desktop (Electron), VS Code, hosted mobile: the icon renders on all runtimes; the open target routes to <code>runtime.editor</code> when available (VS Code/Electron) or <code>useUIStore.openContextFile{AtLine}</code> + <code>mobileActions.openFiles()</code> on web/mobile.</li>
<li>No persisted or external contracts touched.</li>
</ul>
<h2>Repository guidance</h2>

Guidance | Why it applies | How the change complies
-- | -- | --
Smallest correct change | Header open-from-file was missing; fix is one icon + one memo | No refactor of handleMainClick; reuses its existing helpers
No any | TypeScript strictness | quickOpenTarget memo has an explicit type
Theme tokens | UI must use tokens, no hardcoded colors | var(--tools-icon), var(--surface-hover) only
Cross-runtime parity | Shared UI serves web/desktop/VS Code/mobile | Web fallback mirrors the existing openEntryFile pattern; VS Code path reuses handleMainClick logic
locale-ui-patterns | New user-facing label | chat.toolPart.openFile added to all 11 locales; parity test passes


<h2>Visual evidence</h2>
<p>Visible change: an <code>external-link</code> icon (16px) appears next to the tool name in the collapsed tool card header on hover, for Write/Edit/MultiEdit/ApplyPatch. Screenshots to be attached by maintainer dogfooding.</p>
<h2>Risks and failure behavior</h2>
<ul>
<li>If <code>getPrimaryToolPath</code> returns null (tool without a file path, e.g. bash/grep/task), <code>quickOpenTarget</code> is null and the icon does not render — no behavior change for those tools.</li>
<li><code>stopPropagation</code> on the icon button prevents the card-toggle-on-row-click; the rest of the row still toggles.</li>
<li>Web fallback uses <code>useUIStore.getState()</code> (snapshot) — no subscription, no render fanout; matches <code>openEntryFile</code>.</li>
<li>No new dependencies.</li>
</ul>
