### PR TITLE
fix: restore baseline validation

### DIFF
--- a/packages/ui/src/apps/runtimeEndpointReset.ts
+++ b/packages/ui/src/apps/runtimeEndpointReset.ts
@@ -15,7 +15,7 @@ import { useFilesViewTabsStore } from '@/stores/useFilesViewTabsStore';
 import { useTerminalStore } from '@/stores/useTerminalStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { resetStreamingState } from '@/sync/streaming';
-import { useGlobalSessionStatusStore, replaceGlobalSessionStatusById } from '@/sync/global-session-status';
+import { replaceGlobalSessionStatusById } from '@/sync/global-session-status';
 import { resetSessionOrdering } from '@/sync/session-ordering';
 import { resetSessionActivityTiming } from '@/sync/session-activity-timing';
 import { syncDesktopSettings } from '@/lib/persistence';

--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -457,13 +457,6 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
     }, [chatRenderMode, isMessageCompleted, isUser, visibleParts]);
 
 
-    const assistantTextParts = React.useMemo(() => {
-        if (isUser) {
-            return [];
-        }
-        return visibleParts.filter((part) => part.type === 'text');
-    }, [isUser, visibleParts]);
-
     const toolParts = React.useMemo(() => {
         if (isUser) {
             return [];
@@ -544,19 +537,6 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
     }, [isUser, normalizedParts]);
 
     const shouldHideUserMessage = isUser && displayParts.length === 0;
-
-    // Message is considered to have an "open step" if info.finish is not yet present
-    const hasOpenStep = typeof messageFinish !== 'string';
-
-    const shouldCoordinateRendering = React.useMemo(() => {
-        if (isUser) {
-            return false;
-        }
-        if (assistantTextParts.length === 0 || toolParts.length === 0) {
-            return hasOpenStep;
-        }
-        return true;
-    }, [assistantTextParts.length, toolParts.length, hasOpenStep, isUser]);
 
     const themeVariant = currentTheme?.metadata.variant;
     const isDarkTheme = React.useMemo(() => {

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -1343,16 +1343,6 @@ const AssistantMessageBody = React.memo(({
         return resolved ? { id: resolved.id, path: resolved.path } : null;
     }, [availableWorktreesByProject, canUseProjectPlanActions, currentSessionId, effectiveDirectory, getDirectoryForSession, projects]);
 
-    const hasTools = toolParts.length > 0;
-
-    const hasPendingTools = React.useMemo(() => {
-        return toolParts.some((toolPart) => {
-            const state = (toolPart as Record<string, unknown>).state as Record<string, unknown> | undefined ?? {};
-            const status = state?.status;
-            return status === 'pending' || status === 'running' || status === 'started';
-        });
-    }, [toolParts]);
-
     const isActiveTool = React.useCallback((toolPart: ToolPartType): boolean => {
         const state = (toolPart as Record<string, unknown>).state as Record<string, unknown> | undefined ?? {};
         const status = state?.status;
@@ -1380,42 +1370,6 @@ const AssistantMessageBody = React.memo(({
     const shouldShowTool = React.useCallback((toolPart: ToolPartType): boolean => {
         return isActiveTool(toolPart) || isToolFinalized(toolPart);
     }, [isActiveTool, isToolFinalized]);
-
-    const allToolsFinalized = React.useMemo(() => {
-        if (toolParts.length === 0) {
-            return true;
-        }
-        if (hasPendingTools) {
-            return false;
-        }
-        return toolParts.every((toolPart) => isToolFinalized(toolPart));
-    }, [toolParts, hasPendingTools, isToolFinalized]);
-
-    const reasoningParts = React.useMemo(() => {
-        return visibleParts.filter((part) => part.type === 'reasoning');
-    }, [visibleParts]);
-
-    const reasoningComplete = React.useMemo(() => {
-        if (reasoningParts.length === 0) {
-            return true;
-        }
-        return reasoningParts.every((part) => {
-            const time = (part as Record<string, unknown>).time as { end?: number } | undefined;
-            return typeof time?.end === 'number';
-        });
-    }, [reasoningParts]);
-
-    // Message is considered to have an "open step" if info.finish is not yet present
-    const hasOpenStep = typeof messageFinish !== 'string';
-
-    const shouldHoldForReasoning =
-        reasoningParts.length > 0 &&
-        hasTools &&
-        (hasPendingTools || hasOpenStep || !allToolsFinalized);
-
-    const shouldHoldTools = awaitingMessageCompletion
-        || (hasTools && (hasPendingTools || hasOpenStep || !allToolsFinalized));
-    const shouldHoldReasoning = awaitingMessageCompletion || shouldHoldForReasoning;
 
     const hasCopyableText = Boolean(hasTextContent) && !awaitingMessageCompletion;
 

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -486,8 +486,6 @@ export const Header: React.FC = () => {
     const pathSegments = activeProject.path.split(/[\\/]/).filter(Boolean);
     return pathSegments[pathSegments.length - 1] ?? null;
   }, [activeProject]);
-  const quotaResults = useQuotaStore((state) => state.results);
-  const fetchAllQuotas = useQuotaStore((state) => state.fetchAllQuotas);
   const loadQuotaSettings = useQuotaStore((state) => state.loadSettings);
 
   const { isMobile } = useDeviceInfo();

--- a/packages/ui/src/components/session/sidebar/list/sessionCollection.test.ts
+++ b/packages/ui/src/components/session/sidebar/list/sessionCollection.test.ts
@@ -4,7 +4,7 @@ import type { Event } from '@opencode-ai/sdk/v2/client';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { deriveRecentSessions } from '../recent/activitySections';
-import { applyGlobalSessionStatusEvent, useGlobalSessionStatusStore , replaceGlobalSessionStatusById} from '@/sync/global-session-status';
+import { applyGlobalSessionStatusEvent, replaceGlobalSessionStatusById } from '@/sync/global-session-status';
 import {
   buildSidebarSessionProjection,
   getDescendantIds,

--- a/packages/ui/src/components/session/sidebar/sessions/collapsedActivityIndicator.behavior.test.tsx
+++ b/packages/ui/src/components/session/sidebar/sessions/collapsedActivityIndicator.behavior.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { Session } from '@opencode-ai/sdk/v2';
-import { useGlobalSessionStatusStore , replaceGlobalSessionStatusById} from '@/sync/global-session-status';
+import { replaceGlobalSessionStatusById } from '@/sync/global-session-status';
 import { useNotificationStore } from '@/sync/notification-store';
 import { useCollapsedSessionActivityState } from './collapsedActivityState';
 import type { SessionNode } from '../types';

--- a/packages/web/server/lib/session-goal/runtime.js
+++ b/packages/web/server/lib/session-goal/runtime.js
@@ -249,6 +249,7 @@ export const createSessionGoalRuntime = ({
   getOpenCodeAuthHeaders,
   getSmallModelService,
   emitGoalNotification,
+  isEnabled = isSessionGoalEnabled,
   idleQuietMs = IDLE_QUIET_MS,
   kickoffQuietMs = KICKOFF_QUIET_MS,
   maxAutoTurns = MAX_AUTO_TURNS,
@@ -444,7 +445,7 @@ export const createSessionGoalRuntime = ({
   };
 
   const tick = async (sessionId, directory) => {
-    if (!isSessionGoalEnabled()) return;
+    if (!isEnabled()) return;
 
     const session = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, { directory })
       .catch((error) => {

--- a/packages/web/server/lib/session-goal/runtime.test.js
+++ b/packages/web/server/lib/session-goal/runtime.test.js
@@ -35,13 +35,14 @@ const startIdleTick = async (fetchImpl) => {
     buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
     getOpenCodeAuthHeaders: () => ({}),
     getSmallModelService,
+    isEnabled: () => true,
     idleQuietMs: 10,
   });
   runtime.processPayload({
     type: 'session.status',
     properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
   });
-  await vi.advanceTimersByTimeAsync(10);
+  await vi.runOnlyPendingTimersAsync();
   return { runtime, getSmallModelService };
 };
 
@@ -156,6 +157,7 @@ describe('session goal live activity gate', () => {
       buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
       getOpenCodeAuthHeaders: () => ({}),
       getSmallModelService: async () => service,
+      isEnabled: () => true,
       idleQuietMs: 10,
     });
 
@@ -163,7 +165,7 @@ describe('session goal live activity gate', () => {
       type: 'session.status',
       properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
     });
-    await vi.advanceTimersByTimeAsync(10);
+    await vi.runOnlyPendingTimersAsync();
 
     expect(service.generateSmallModelText).toHaveBeenCalledOnce();
     const patch = requests.find((request) => request.pathname === `/session/${SESSION_ID}` && request.method === 'PATCH');


### PR DESCRIPTION
## Intent

Restore green repository validation after recent integrations left unused UI calculations and session-goal tests dependent on host settings.

## Non-goals

No user-visible behavior change. This does not include the subagent context indicator or alter session-goal production defaults.

## Affected surfaces

Shared UI lint cleanliness and the web session-goal test seam. No persisted or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md`, `openchamber-change-discipline` | Executable UI and server test code changed | The diff contains only dead-code removal and explicit dependency injection for the existing goal-enabled gate. |
| `sync-state-invariants` and sync documentation | Removed code sat near session rendering and status reset paths | No state transition or ownership changes; only values with no consumers are removed. |
| `performance-engineering` | The removed calculations ran in render paths | Removes calculations already proven unused, without adding caching or lifecycle work. |
| `CONTRIBUTING.md` and PR template | Review handoff and validation requirements apply | Scope, validation, and failure behavior are recorded here. |

## Validation

| Check | Result |
|---|---|
| `bun install --frozen-lockfile` with Bun 1.3.14 and `OPENCHAMBER_ALLOW_UNAUTHENTICATED_LAN` unset | Passed. |
| `bun run --cwd packages/web test -- server/lib/session-goal/runtime.test.js` | Passed: 4 tests. |
| `bun run test` | Passed: root 1/1 files, UI 325/325 files, VS Code 26/26 files, Electron 17/17 files, Web 162/162 files with 1,627 passed and 2 skipped tests. |
| `bun run type-check` | Passed for every workspace. |
| `bun run lint` | Passed for every workspace. |
| `bun run build` | Passed for every workspace. Existing Vite chunk-size and mixed dynamic/static import warnings remain. |
| `bun run docs:validate` | Passed: 460 pages and 46 sidebar links. |
| `bun run dead-code` | Completed with exit 0. It reports the existing repository backlog; this change adds no files or exports. |
| `git diff --check` | Passed. |

## Visual evidence

No visual change. The UI edits remove variables and memoized calculations that had no consumers, so rendered output is unchanged.

## Risks and failure behavior

The session-goal runtime keeps its production default by injecting `isSessionGoalEnabled` when no override is supplied. Tests inject `() => true`, isolating them from a developer or CI host setting. The remaining edits only remove unused imports and calculations, so there is no rollback, persistence, network, or cross-runtime state change.
