### PR TITLE
feat(ui): maintain sessions across Home Assistant reloads

### DIFF
--- a/packages/ui/src/components/session/sidebar/projects/useProjectSessionSelection.ts
+++ b/packages/ui/src/components/session/sidebar/projects/useProjectSessionSelection.ts
@@ -20,7 +20,7 @@ type Args = {
   handleSessionSelect: (sessionId: string, sessionDirectory: string | null) => void;
   newSessionDraftOpen: boolean;
   mobileVariant: boolean;
-  openNewSessionDraft: (options?: { selectedProjectId?: string | null; directoryOverride?: string | null }) => void;
+  openNewSessionDraft: (options?: { automatic?: boolean; selectedProjectId?: string | null; directoryOverride?: string | null }) => void;
   setSessionSwitcherOpen: (open: boolean) => void;
 };
 
@@ -67,7 +67,7 @@ export function resolveMissingProjectSessionSelection<T>({
         ([projectId, sessions]) => projectId !== activeProjectId && sessions.has(currentSessionId),
       ),
     );
-    if (currentSessionId && projectMap && !currentSessionBelongsToAnotherProject) {
+    if (currentSessionId && !currentSessionBelongsToAnotherProject) {
       return { kind: 'preserve-current' };
     }
   }
@@ -206,6 +206,7 @@ export const useProjectSessionSelection = (args: Args): void => {
         setSessionSwitcherOpen(false);
       }
       openNewSessionDraft({
+        automatic: true,
         selectedProjectId: section.project.id,
         directoryOverride: section.project.normalizedPath,
       });

--- a/packages/ui/src/hooks/useRouter.ts
+++ b/packages/ui/src/hooks/useRouter.ts
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useUIStore, type ContextPanelMode } from '@/stores/useUIStore';
-import { parseRoute, updateBrowserURL, hasRouteParams } from '@/lib/router';
+import { parseRoute, updateBrowserURL, hasRouteParams, RECENT_SESSION_TOKEN } from '@/lib/router';
 import type { RouteState, AppRouteState } from '@/lib/router';
 import { resolveSettingsSlug } from '@/lib/settings/metadata';
+import { resolveRecentSession } from '@/lib/recentSession';
 import { isEmbeddedSessionChat } from '@/components/layout/contextPanelEmbeddedChat';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 
@@ -46,6 +47,7 @@ export function useRouter(): void {
   // Track initialization to avoid duplicate applies
   const initializedRef = React.useRef(false);
   const isApplyingRouteRef = React.useRef(false);
+  const routeGenerationRef = React.useRef(0);
 
   // Get store actions (stable references)
   const setCurrentSession = useSessionUIStore((state) => state.setCurrentSession);
@@ -58,19 +60,35 @@ export function useRouter(): void {
    */
   const applyRoute = React.useCallback(
     async (route: RouteState) => {
-      if (isApplyingRouteRef.current) {
-        return;
-      }
-
+      const generation = ++routeGenerationRef.current;
       isApplyingRouteRef.current = true;
 
       try {
         // 1. Apply session first (may trigger async operations)
         if (route.sessionId) {
-          const currentSessionId = useSessionUIStore.getState().currentSessionId;
-          if (route.sessionId !== currentSessionId) {
-            const directoryHint = useSessionUIStore.getState().getDirectoryForSession(route.sessionId);
-            setCurrentSession(route.sessionId, directoryHint);
+          let targetSessionId: string | null = route.sessionId;
+          let directoryHint: string | null | undefined;
+
+          if (route.sessionId === RECENT_SESSION_TOKEN) {
+            const resolved = await resolveRecentSession();
+            if (generation !== routeGenerationRef.current) {
+              return;
+            }
+            if (resolved) {
+              targetSessionId = resolved.sessionId;
+              directoryHint = resolved.directory;
+            } else {
+              targetSessionId = null;
+            }
+          } else {
+            directoryHint = useSessionUIStore.getState().getDirectoryForSession(route.sessionId);
+          }
+
+          if (targetSessionId) {
+            const currentSessionId = useSessionUIStore.getState().currentSessionId;
+            if (targetSessionId !== currentSessionId) {
+              setCurrentSession(targetSessionId, directoryHint ?? undefined);
+            }
           }
         }
 
@@ -104,7 +122,9 @@ export function useRouter(): void {
           navigateToDiff(route.diffFile);
         }
       } finally {
-        isApplyingRouteRef.current = false;
+        if (generation === routeGenerationRef.current) {
+          isApplyingRouteRef.current = false;
+        }
       }
     },
     [setCurrentSession, setSettingsDialogOpen, setSettingsPage, navigateToDiff]

--- a/packages/ui/src/hooks/useRouter.ts
+++ b/packages/ui/src/hooks/useRouter.ts
@@ -178,6 +178,11 @@ export function useRouter(): void {
     const initializeRoute = async () => {
       await applyRoute(route);
 
+      // Do not normalize the initial URL after a newer popstate route wins.
+      if (routeGenerationRef.current !== 1) {
+        return;
+      }
+
       // After applying, update URL to normalized form (use replaceState).
       // Use the parsed route values instead of an immediate store snapshot so
       // deep links do not briefly normalize `?session=...` back to `/` while

--- a/packages/ui/src/lib/recentSession.test.ts
+++ b/packages/ui/src/lib/recentSession.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const clearCalls: string[] = [];
+const snapshotCalls: Array<{
+  reject?: boolean;
+  pending?: boolean;
+  commit?: boolean;
+  delayMs?: number;
+  sessions: Array<{ id: string; directory?: string | null }>;
+}> = [];
+let storeStatus: 'idle' | 'loading' | 'ready' | 'error' = 'ready';
+let committedSessions: Array<{ id: string; directory?: string | null }> = [];
+
+type SnapshotResult = { activeSessions: Array<{ id: string; directory?: string | null }> };
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeKey: () => 'test-runtime',
+}));
+
+mock.module('@/sync/last-session-cache', () => ({
+  readLastActiveSession: (key: string) => {
+    if (key !== 'test-runtime') return null;
+    return (globalThis as { __persisted?: { sessionId: string; directory: string | null } | null }).__persisted ?? null;
+  },
+  clearLastActiveSession: (key: string) => {
+    clearCalls.push(key);
+  },
+  readMostRecentLastActiveSession: () => null,
+}));
+
+let sdkConnected = true;
+
+mock.module('@/stores/useConfigStore', () => ({
+  useConfigStore: {
+    getState: () => ({ isConnected: sdkConnected }),
+  },
+}));
+
+mock.module('@/stores/useGlobalSessionsStore', () => ({
+  refreshGlobalSessions: async (): Promise<SnapshotResult> => {
+    const next = snapshotCalls.shift();
+    if (next?.pending) return new Promise<SnapshotResult>(() => undefined);
+    if (next?.reject) {
+      storeStatus = 'error';
+      throw new Error('network down');
+    }
+    // A successful load commits its snapshot into the store and flips the
+    // status to 'ready' (mirrors `loadSessions`). Pass `commit: false` to
+    // simulate a generation-stale result that returns without touching the
+    // store (the runtime-switch mismatch case); `delayMs` defers the commit so
+    // the caller can observe the store being still non-ready.
+    if (next?.commit === false) {
+      return { activeSessions: next?.sessions ?? [] };
+    }
+    const apply = () => {
+      committedSessions = next?.sessions ?? [];
+      storeStatus = 'ready';
+    };
+    if (next?.delayMs) {
+      setTimeout(apply, next.delayMs);
+    } else {
+      apply();
+    }
+    return { activeSessions: next?.sessions ?? [] };
+  },
+  resolveGlobalSessionDirectory: (session: { directory?: string | null; project?: { worktree?: string | null } | null }) =>
+    session.directory ?? session.project?.worktree ?? null,
+  useGlobalSessionsStore: {
+    getState: () => ({ status: storeStatus, activeSessions: committedSessions }),
+  },
+}));
+
+const setPersisted = (sessionId: string | null, directory: string | null = null) => {
+  (globalThis as { __persisted?: unknown }).__persisted =
+    sessionId === null ? null : { sessionId, directory };
+};
+
+const queueSnapshot = (
+  sessions: Array<{ id: string; directory?: string | null }>,
+  options: { commit?: boolean; delayMs?: number } = {},
+) => {
+  snapshotCalls.push({ sessions, commit: options.commit, delayMs: options.delayMs });
+};
+
+beforeEach(() => {
+  setPersisted(null);
+  clearCalls.length = 0;
+  snapshotCalls.length = 0;
+  committedSessions = [];
+  storeStatus = 'ready';
+  sdkConnected = true;
+});
+
+afterEach(() => {
+  delete (globalThis as { __persisted?: unknown }).__persisted;
+});
+
+describe('resolveRecentSession', () => {
+  test('returns null when nothing was persisted', async () => {
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(snapshotCalls).toEqual([]);
+  });
+
+  test('returns the persisted session confirmed by the snapshot', async () => {
+    setPersisted('ses_active', '/repo/a');
+    committedSessions = [
+      { id: 'ses_other', directory: '/repo/b' },
+      { id: 'ses_active', directory: '/repo/c' },
+    ];
+    queueSnapshot([...committedSessions]);
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
+    expect(clearCalls).toEqual([]);
+  });
+
+  test('falls back to the persisted directory when the committed entry lacks one', async () => {
+    setPersisted('ses_active', '/repo/a');
+    committedSessions = [{ id: 'ses_active', directory: null }];
+    queueSnapshot([...committedSessions]);
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/a' });
+  });
+
+  test('drops the stale pointer and returns null when the session is gone', async () => {
+    setPersisted('ses_gone', '/repo/a');
+    committedSessions = [{ id: 'ses_other', directory: '/repo/b' }];
+    queueSnapshot([...committedSessions]);
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(clearCalls).toEqual(['test-runtime']);
+  });
+
+  test('returns null when the snapshot fetch fails', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'error';
+    snapshotCalls.push({ reject: true, sessions: [] });
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(clearCalls).toEqual([]);
+  });
+
+  test('keeps the pointer when the store reports a failed snapshot', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'error';
+    queueSnapshot([], { commit: false });
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(clearCalls).toEqual([]);
+  });
+
+  test('keeps the pointer when the snapshot is not authoritative (non-ready store status)', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'idle';
+    queueSnapshot([], { commit: false });
+    const { resolveRecentSession } = await import('./recentSession');
+    expect(await resolveRecentSession()).toBeNull();
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
+
+  test('restores from the committed store even when the refresh returns a stale empty snapshot', async () => {
+    setPersisted('ses_active', '/repo/a');
+    committedSessions = [{ id: 'ses_active', directory: '/repo/c' }];
+    storeStatus = 'ready';
+    queueSnapshot([], { commit: false });
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
+    expect(clearCalls).toEqual([]);
+  });
+
+  test('returns when snapshot resolution exceeds the startup timeout', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'loading';
+    snapshotCalls.push({ reject: false, pending: true, sessions: [] });
+    const { resolveRecentSession } = await import('./recentSession');
+    const startedAt = Date.now();
+    expect(await resolveRecentSession()).toBeNull();
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(5_900);
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
+
+  test('keeps waiting past the deadline while the SDK is not connected yet', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'loading';
+    sdkConnected = false;
+    setTimeout(() => {
+      sdkConnected = true;
+      committedSessions = [{ id: 'ses_active', directory: '/repo/c' }];
+      storeStatus = 'ready';
+    }, 50);
+    queueSnapshot([], { commit: false });
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
+
+  test('recovers from a transient boot error once the SDK connects', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'error';
+    sdkConnected = false;
+    queueSnapshot([{ id: 'ses_active', directory: '/repo/c' }], { commit: false });
+    setTimeout(() => {
+      sdkConnected = true;
+      storeStatus = 'ready';
+      committedSessions = [{ id: 'ses_active', directory: '/repo/c' }];
+    }, 50);
+    const { resolveRecentSession } = await import('./recentSession');
+    const resolved = await resolveRecentSession();
+    expect(resolved).toEqual({ sessionId: 'ses_active', directory: '/repo/c' });
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
+
+  test('still gives up once connected when the snapshot never becomes ready', async () => {
+    setPersisted('ses_active', '/repo/a');
+    storeStatus = 'loading';
+    snapshotCalls.push({ reject: false, pending: true, sessions: [] });
+    const { resolveRecentSession } = await import('./recentSession');
+    const startedAt = Date.now();
+    expect(await resolveRecentSession()).toBeNull();
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(5_900);
+    expect(clearCalls).toEqual([]);
+  }, 10_000);
+});
+
+describe('resolveRouteSessionToken', () => {
+  test('passes a plain session ID through with its directory hint', async () => {
+    const { resolveRouteSessionToken } = await import('./recentSession');
+    const resolved = await resolveRouteSessionToken(
+      'ses_plain',
+      async () => ({ sessionId: 'ses_recent', directory: '/repo/x' }),
+      (sessionId) => (sessionId === 'ses_plain' ? '/repo/plain' : null),
+    );
+    expect(resolved).toEqual({ sessionId: 'ses_plain', directoryHint: '/repo/plain' });
+  });
+
+  test('resolves the recent token to the last active session', async () => {
+    const { resolveRouteSessionToken } = await import('./recentSession');
+    const resolved = await resolveRouteSessionToken(
+      'recent',
+      async () => ({ sessionId: 'ses_active', directory: '/repo/a' }),
+      () => null,
+    );
+    expect(resolved).toEqual({ sessionId: 'ses_active', directoryHint: '/repo/a' });
+  });
+
+  test('falls through to the draft when the recent token resolves to nothing', async () => {
+    const { resolveRouteSessionToken } = await import('./recentSession');
+    const resolved = await resolveRouteSessionToken('recent', async () => null, () => null);
+    expect(resolved).toBeNull();
+  });
+
+  test('does not resolve the recent token when the route uses a plain session ID', async () => {
+    const { resolveRouteSessionToken } = await import('./recentSession');
+    let recentResolutionAttempted = false;
+    await resolveRouteSessionToken(
+      'ses_plain',
+      async () => {
+        recentResolutionAttempted = true;
+        return null;
+      },
+      () => null,
+    );
+    expect(recentResolutionAttempted).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/recentSession.ts
+++ b/packages/ui/src/lib/recentSession.ts
@@ -1,0 +1,83 @@
+import { getRuntimeKey } from '@/lib/runtime-switch';
+import { RECENT_SESSION_TOKEN } from '@/lib/router';
+import { useConfigStore } from '@/stores/useConfigStore';
+import { refreshGlobalSessions, resolveGlobalSessionDirectory, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
+import { clearLastActiveSession, readLastActiveSession, readMostRecentLastActiveSession } from '@/sync/last-session-cache';
+
+export type ResolvedRecentSession = {
+  sessionId: string;
+  directory: string | null;
+};
+
+export type RouteSessionResolution = {
+  sessionId: string;
+  directoryHint: string | null | undefined;
+} | null;
+
+export async function resolveRouteSessionToken(
+  rawSessionId: string,
+  resolveRecent: () => Promise<ResolvedRecentSession | null>,
+  getDirectoryForSession: (sessionId: string) => string | null | undefined,
+): Promise<RouteSessionResolution> {
+  if (rawSessionId !== RECENT_SESSION_TOKEN) {
+    return { sessionId: rawSessionId, directoryHint: getDirectoryForSession(rawSessionId) };
+  }
+  const resolved = await resolveRecent();
+  return resolved ? { sessionId: resolved.sessionId, directoryHint: resolved.directory } : null;
+}
+
+/**
+ * Resolve the `?session=recent` URL token to the last session that was active
+ * for the current runtime. The pointer is only cleared after a ready snapshot
+ * confirms that the session no longer exists.
+ *
+ * Returns `null` when there is no usable persisted session, so callers can
+ * fall back to the default new-session behavior.
+ */
+export async function resolveRecentSession(): Promise<ResolvedRecentSession | null> {
+  const runtimeKey = getRuntimeKey();
+  const persisted = readLastActiveSession(runtimeKey) ?? readMostRecentLastActiveSession();
+  if (!persisted) {
+    return null;
+  }
+
+  void refreshGlobalSessions().catch(() => null);
+  const deadline = Date.now() + 6_000;
+  const cap = Date.now() + 30_000;
+  let retriedAfterConnect = false;
+  for (;;) {
+    const state = useGlobalSessionsStore.getState();
+    const connected = useConfigStore.getState().isConnected;
+    if (Date.now() >= cap) {
+      return null;
+    }
+    if (state.status === 'error') {
+      if (!connected) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        continue;
+      }
+      if (!retriedAfterConnect) {
+        retriedAfterConnect = true;
+        void refreshGlobalSessions().catch(() => null);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        continue;
+      }
+      return null;
+    }
+    if (state.status === 'ready') {
+      const session = state.activeSessions.find((entry) => entry.id === persisted.sessionId);
+      if (!session) {
+        clearLastActiveSession(runtimeKey);
+        return null;
+      }
+      return {
+        sessionId: session.id,
+        directory: resolveGlobalSessionDirectory(session) ?? persisted.directory,
+      };
+    }
+    if (Date.now() >= deadline && connected) {
+      return null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}

--- a/packages/ui/src/lib/router/index.ts
+++ b/packages/ui/src/lib/router/index.ts
@@ -6,19 +6,21 @@
  *
  * URL Schema:
  * - `?session=<id>` - Navigate to specific session
+ * - `?session=recent` - Navigate to the last active session for this runtime
  * - `?tab=<chat|git|diff|terminal|files>` - Legacy URL name for the active workspace surface
  * - `?settings=<section>` - Open settings to specific section
  * - `?file=<path>` - Diff view with file selected
  *
  * Examples:
  * - `/?session=abc123` - Open session abc123
+ * - `/?session=recent` - Open the last session used on this instance
  * - `/?tab=git` - Open the Git surface
  * - `/?settings=providers` - Open settings to providers section
  * - `/?tab=diff&file=src/main.ts` - Open the Diff surface with a file
  */
 
 export type { RouteState } from './types';
-
+export { RECENT_SESSION_TOKEN } from './types';
 
 export { parseRoute, hasRouteParams } from './parseRoute';
 

--- a/packages/ui/src/lib/router/types.ts
+++ b/packages/ui/src/lib/router/types.ts
@@ -36,6 +36,14 @@ export const VALID_SETTINGS_SECTIONS: readonly SidebarSection[] = [
 ] as const;
 
 /**
+ * Special value for the `?session=` parameter that resolves to the last
+ * active session persisted for the current runtime (see
+ * `@/sync/last-session-cache`). Falls back to the default new-session
+ * behavior when no usable persisted session exists.
+ */
+export const RECENT_SESSION_TOKEN = 'recent';
+
+/**
  * URL parameter names used for routing.
  */
 export const ROUTE_PARAMS = {

--- a/packages/ui/src/sync/last-session-cache.ts
+++ b/packages/ui/src/sync/last-session-cache.ts
@@ -79,6 +79,19 @@ export function readLastActiveSession(
   return entry ? { sessionId: entry.sessionId, directory: entry.directory } : null
 }
 
+// A server can be opened through several equivalent origins (LAN address,
+// reverse proxy, or the public hostname). If the current origin has no exact
+// entry, the newest pointer is the safest continuity fallback; the caller
+// still validates the session against an authoritative snapshot.
+export function readMostRecentLastActiveSession(
+  storage: Storage = getDeferredSafeStorage(),
+): PersistedLastSession | null {
+  const entries = Object.values(readEnvelope(storage).runtimes)
+    .sort((left, right) => right.updatedAt - left.updatedAt)
+  const entry = entries[0]
+  return entry ? { sessionId: entry.sessionId, directory: entry.directory } : null
+}
+
 export function clearLastActiveSession(
   runtimeKey: string,
   storage: Storage = getDeferredSafeStorage(),


### PR DESCRIPTION
Superseded by #3221, rebuilt atomically on the current `main` with updated validation.