### PR TITLE
fix(sync): keep bootstrap context live for deferred recovery pulls

### DIFF
--- a/packages/ui/src/sync/child-store.test.ts
+++ b/packages/ui/src/sync/child-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   ChildStoreManager,
+  type DirectoryBootstrapContext,
   markDirectorySessionPartChanged,
   subscribeDirectoryPermission,
   subscribeDirectoryQuestion,
@@ -555,6 +556,32 @@ describe('ChildStoreManager directory bootstrap scheduler', () => {
     expect(started).toEqual(['stale', 'current']);
     expect(manager.getBootstrapState('/workspace')).toBe('complete');
     cleanupCurrent();
+    manager.disposeAll();
+  });
+});
+
+describe('ChildStoreManager bootstrap context liveness', () => {
+  test('isCurrent stays true after the run settles so deferred recovery work can commit', async () => {
+    const manager = new ChildStoreManager();
+    let captured: DirectoryBootstrapContext | undefined;
+    const cleanup = manager.configure({
+      onBootstrap: (context) => {
+        captured = context;
+      },
+    });
+    manager.requestBootstrap({ directory: '/workspace', priority: 'selected', reason: 'current-directory' });
+    await settle();
+    expect(manager.getBootstrapState('/workspace')).toBe('complete');
+
+    // bootstrapDirectory schedules deferred recovery pulls (permission.list
+    // and friends) from a setTimeout(0), which always runs after the pump's
+    // .finally() has cleaned up the run entry. isCurrent must remain true
+    // there, or those pulls and every commit they make get skipped.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(captured?.isCurrent()).toBe(true);
+
+    cleanup();
+    expect(captured?.isCurrent()).toBe(false);
     manager.disposeAll();
   });
 });

--- a/packages/ui/src/sync/child-store.test.ts
+++ b/packages/ui/src/sync/child-store.test.ts
@@ -584,4 +584,29 @@ describe('ChildStoreManager bootstrap context liveness', () => {
     expect(captured?.isCurrent()).toBe(false);
     manager.disposeAll();
   });
+
+  test('a newer same-directory run invalidates the previous context', async () => {
+    const manager = new ChildStoreManager();
+    const contexts: DirectoryBootstrapContext[] = [];
+    const cleanup = manager.configure({
+      onBootstrap: (context) => {
+        contexts.push(context);
+      },
+    });
+    manager.requestBootstrap({ directory: '/workspace', priority: 'selected', reason: 'current-directory' });
+    await settle();
+    expect(contexts[0]?.isCurrent()).toBe(true);
+
+    // A forced rerun for the same directory must retire the previous
+    // context: its in-flight deferred responses may no longer commit over
+    // whatever the newer run synchronizes.
+    manager.requestBootstrap({ directory: '/workspace', priority: 'selected', reason: 'server-connected', force: true });
+    await settle();
+    expect(contexts).toHaveLength(2);
+    expect(contexts[0]?.isCurrent()).toBe(false);
+    expect(contexts[1]?.isCurrent()).toBe(true);
+
+    cleanup();
+    manager.disposeAll();
+  });
 });

--- a/packages/ui/src/sync/child-store.ts
+++ b/packages/ui/src/sync/child-store.ts
@@ -596,11 +596,19 @@ export class ChildStoreManager {
         queuedMs: Math.max(0, Date.now() - next.enqueuedAt),
       })
 
+      // Store liveness, not run-token ownership. The pump deletes the run
+      // token in `.finally()` as soon as onBootstrap settles, while
+      // bootstrapDirectory schedules deferred recovery pulls (permission.list
+      // and friends) from a `setTimeout(0)` that always runs after that
+      // cleanup — gating those on the token made them dead code. The pump
+      // never replaces a running entry for the same directory (queueBootstrap
+      // defers via rerunRequested), so during the run itself this is
+      // equivalent. Mirrors the isCurrent contract in session-message-loader.
+      const store = this.children.get(next.directory)
       const isCurrent = () => (
         !this.disposed
         && this.bootstrapGeneration === running.generation
-        && this.runningBootstraps.get(next.directory)?.token === token
-        && this.children.has(next.directory)
+        && this.children.get(next.directory) === store
       )
       let bootstrapPromise: Promise<void>
       try {

--- a/packages/ui/src/sync/child-store.ts
+++ b/packages/ui/src/sync/child-store.ts
@@ -307,6 +307,8 @@ export class ChildStoreManager {
   private bootstrapConcurrency = 2
   private bootstrapGeneration = 0
   private bootstrapSequence = 0
+  private bootstrapRunSequence = 0
+  private readonly directoryBootstrapRuns = new Map<string, number>()
   private manualBootstrapDemandRevision = 0
   private disposed = false
 
@@ -600,14 +602,18 @@ export class ChildStoreManager {
       // token in `.finally()` as soon as onBootstrap settles, while
       // bootstrapDirectory schedules deferred recovery pulls (permission.list
       // and friends) from a `setTimeout(0)` that always runs after that
-      // cleanup — gating those on the token made them dead code. The pump
-      // never replaces a running entry for the same directory (queueBootstrap
-      // defers via rerunRequested), so during the run itself this is
-      // equivalent. Mirrors the isCurrent contract in session-message-loader.
+      // cleanup — gating those on the token made them dead code. A per-
+      // directory run sequence keeps the context current across settle (so
+      // deferred pulls commit) while invalidating it as soon as a newer run
+      // starts, so a late deferred response cannot overwrite a newer run's
+      // state. Mirrors the isCurrent contract in session-message-loader.
+      const runSequence = ++this.bootstrapRunSequence
+      this.directoryBootstrapRuns.set(next.directory, runSequence)
       const store = this.children.get(next.directory)
       const isCurrent = () => (
         !this.disposed
         && this.bootstrapGeneration === running.generation
+        && this.directoryBootstrapRuns.get(next.directory) === runSequence
         && this.children.get(next.directory) === store
       )
       let bootstrapPromise: Promise<void>
@@ -681,6 +687,7 @@ export class ChildStoreManager {
     this.manualBootstrapDemands.delete(directory)
     this.bootstrapStates.delete(directory)
     this.bootstrapFailures.delete(directory)
+    this.directoryBootstrapRuns.delete(directory)
     for (const demands of this.bootstrapDemandsByOwner.values()) demands.delete(directory)
     this.children.delete(directory)
     this.notifyRegistrySubscribers()


### PR DESCRIPTION
## Intent

Pending permission requests (and pending `question` answers) disappear forever after a page reload, or after opening the session from a second client that connected late. The opencode server still holds the pending request — `GET /permission?directory=...` returns it — but the UI never re-pulls it, so the card cannot be rendered again and the session hangs on the running tool. Full investigation and reproduction steps: #3150.

The UI already contains the recovery path for exactly this scenario: `bootstrapDirectory` schedules a deferred phase that calls `sdk.permission.list` (plus `question.list`, `command.list`, `mcp.status`, `lsp.status`, `vcs.get`) after the critical phase and session load complete. That phase never executed — it was dead code since 226cd62b (#2360).

This PR un-deads it with a one-condition change.

## Non-goals

- No new pull paths (event-pipeline `ready` resync, materialization hooks, server-side synthesized events) — the designed recovery path is sufficient once it actually runs; those remain available as defense-in-depth follow-ups if maintainers want them.
- No changes to event replay semantics (global hub replay, `lastEventId` persistence).
- No changes to opencode — it is a separate repository, and its pull endpoint already provides the authoritative state.

## Affected surfaces

| Surface | Effect |
|---|---|
| `packages/ui` sync bootstrap | `isCurrent()` on the bootstrap context now reflects store liveness instead of run-token ownership. Deferred phase runs after every completed directory bootstrap: pending permissions/questions recover after reload, second-client opens, and directory re-materialization. |
| Web / desktop / VS Code / mobile | All surfaces share `packages/ui/src/sync/`; all benefit equally. No runtime-specific code touched. |
| `packages/web` server | Unaffected — no server files changed. |
| Persisted data / contracts | None. No exported types change shape; `DirectoryBootstrapContext.isCurrent` keeps the same `() => boolean` signature, only its lifetime semantics extend past run completion. |

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Source change in one package | Smallest complete change: one condition replaced, one comment, one regression test. Classified as local implementation risk; validated at the owning package level. |
| `sync-state-invariants` | Bootstrap/reconnect state ownership | Every deferred write still passes through the existing per-commit staleness guard and the merge-with-signature-comparison in `commit()`; failure is still distinguishable from empty (existing `retry`/`unwrap` contract untouched). Liveness now derives from authoritative store identity, not heuristics. |
| `packages/ui/src/sync/DOCUMENTATION.md` | Nearest owning module documentation | Read before editing; no documented invariant contradicts store-liveness semantics (the loader in the same module already uses this exact contract). |

## Validation

| Check | Result |
|---|---|
| `bun test src/sync/child-store.test.ts` (packages/ui) | 20 pass, 0 fail — includes two new regression tests |
| Regression test against pristine `main` | Fails on `main` (`isCurrent` false after settle), passes with the fix — verified by stashing only `child-store.ts` |
| `bun test src/sync/` (packages/ui) | 540 pass / 15 fail; the identical 15 fail on pristine `main` (pre-existing backlog), so the only delta is +2 passing tests |
| `bun run type-check` (packages/ui) | Pass |
| `bunx oxlint src/sync/child-store.ts src/sync/child-store.test.ts` | No findings on authored lines (pre-existing findings elsewhere in the test file are untouched backlog) |
| Not verified | Full browser E2E reload against a live pending ask (root cause and fix are unit-proven at the exact scheduling boundary; manual verification steps are in #3150) |

## Visual evidence

No rendered-output change is provable from this diff alone; the behavioral change is that an existing card re-appears after reload. Reproduce visually with the steps from #3150: trigger a permission ask (e.g. read a file outside the workspace → `external_directory: ask`), press F5 — before this PR the card and toast never return; after it, the card re-renders from the deferred `permission.list` pull.

## Risks and failure behavior

- **Superseded same-directory rerun:** handled by a per-directory run sequence captured in `isCurrent` — a completed run's context stays live long enough for its deferred pulls to commit, but is retired the instant a newer run for the same directory starts, so late deferred responses cannot overwrite the newer run's state. Covered by a dedicated regression test.
- **Evicted store:** `isCurrent` flips false once the directory is evicted (store identity check), so deferred writes stop for dead directories; eviction already cannot happen while a bootstrap is queued/running.
- **Rollback:** revert the single commit; behavior returns to today's (recovery broken, no crash risk either way).
- **Performance:** the deferred phase issues six already-designed requests per bootstrapped directory after load; it was always intended to run and is bounded by the existing per-directory bootstrap lifecycle.
