### PR TITLE
feat(ui): add ClinePass to QUOTA_PROVIDERS frontend whitelist

### DIFF
--- a/packages/ui/src/lib/quota/providers/index.ts
+++ b/packages/ui/src/lib/quota/providers/index.ts
@@ -7,6 +7,7 @@ export interface QuotaProviderMeta {
 
 export const QUOTA_PROVIDERS: QuotaProviderMeta[] = [
   { id: 'claude', name: 'Claude' },
+  { id: 'cline-pass', name: 'ClinePass' },
   { id: 'codex', name: 'Codex' },
   { id: 'cursor', name: 'Cursor' },
   { id: 'github-copilot', name: 'GitHub Copilot' },

--- a/packages/ui/src/types/quota.ts
+++ b/packages/ui/src/types/quota.ts
@@ -3,6 +3,7 @@ export type QuotaProviderId =
   | 'codex'
   | 'cursor'
   | 'claude'
+  | 'cline-pass'
   | 'github-copilot'
   | 'github-copilot-addon'
   | 'google'


### PR DESCRIPTION
## Problem

The ClinePass server-side quota provider module exists in the backend registry but is invisible in the Usage panel because the frontend `QUOTA_PROVIDERS` array and `QuotaProviderId` type don't include it. The UI never queries `/api/quota/providers` for discovery — it uses a hardcoded compile-time list.

## Changes

Two files, two insertions:

1. `packages/ui/src/types/quota.ts` — add `'cline-pass'` to the `QuotaProviderId` union type
2. `packages/ui/src/lib/quota/providers/index.ts` — add `{ id: 'cline-pass', name: 'ClinePass' }` to `QUOTA_PROVIDERS` array

## Notes

This is the same pattern as [issue #1051](https://github.com/openchamber/openchamber/issues/1051) where MiniMax and Ollama Cloud providers were missing from the VS Code extension frontend. The server-side module at `packages/web/server/lib/quota/providers/cline-pass.js` is already registered in the registry — this PR completes the frontend wiring.

A longer-term improvement would be to have the UI fetch the provider list dynamically from `GET /api/quota/providers` instead of maintaining a separate compile-time whitelist.