### PR TITLE
fix(server): support in-app self-update for macOS launchd services (#3159)

### DIFF
--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -365,6 +365,9 @@ an authoritative loopback callback URL even when OpenChamber binds port `0`.
     - Foreground servers running under a systemd user unit queue installation in
       a separate transient unit and restart the configured service afterwards.
       `OPENCHAMBER_SYSTEMD_UNIT` overrides the default `openchamber.service`.
+    - Foreground servers running under a macOS launchd User LaunchAgent update the
+      package and trigger a `launchctl kickstart` (with unload/load fallback) against
+      `~/Library/LaunchAgents/dev.openchamber.web.plist`.
   - `GET /api/openchamber/models-metadata`
   - `GET /api/zen/models`
 

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -21,7 +21,6 @@ function quotePosixShell(value) {
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
 
-
 export const registerOpenChamberRoutes = (app, dependencies) => {
   const {
     fs,
@@ -37,7 +36,6 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
     fetchFreeZenModels,
     getCachedZenModels,
   } = dependencies;
-
 
   app.get('/api/openchamber/update-check', async (req, res) => {
     try {
@@ -135,57 +133,61 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
       } catch {
       }
       const launchMode = storedOptions.launchMode === 'foreground' ? 'foreground' : 'daemon';
-      const isDarwin = process.platform === 'darwin';
       const isForegroundService = launchMode === 'foreground';
+      const isDarwin = process.platform === 'darwin';
       const systemdServiceUnit = isForegroundService && !isDarwin ? resolveSystemdServiceUnit(process.env) : null;
+      const osModule = os || (await import('os'));
+      const launchdPlistPath = isDarwin ? resolveLaunchdPlistPath(path, osModule) : null;
+      const isLaunchdService = Boolean(isDarwin && isForegroundService && launchdPlistPath && fs.existsSync(launchdPlistPath));
 
-      if (isForegroundService && !isDarwin) {
-        if (!systemdServiceUnit) {
+      if (isForegroundService) {
+        if (!systemdServiceUnit && !isLaunchdService) {
           return res.status(409).json({
             error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, or run openchamber update and restart the service.',
           });
         }
 
+        if (systemdServiceUnit) {
+          const updateJobName = `openchamber-update-${Date.now()}`;
+          const updateLogPath = `journalctl --user-unit ${updateJobName}.service`;
+          const updateScript = [
+            'set -eu',
+            updateCmd,
+            `systemctl --user restart ${quotePosixShell(systemdServiceUnit)}`,
+          ].join('\n');
+          const systemdRun = spawnSync('systemd-run', [
+            '--user',
+            `--unit=${updateJobName}`,
+            '--collect',
+            '--service-type=exec',
+            `--setenv=PATH=${process.env.PATH || ''}`,
+            '/bin/sh',
+            '-c',
+            updateScript,
+          ], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+            timeout: 5000,
+          });
 
-        const updateJobName = `openchamber-update-${Date.now()}`;
-        const updateLogPath = `journalctl --user-unit ${updateJobName}.service`;
-        const updateScript = [
-          'set -eu',
-          updateCmd,
-          `systemctl --user restart ${quotePosixShell(systemdServiceUnit)}`,
-        ].join('\n');
-        const systemdRun = spawnSync('systemd-run', [
-          '--user',
-          `--unit=${updateJobName}`,
-          '--collect',
-          '--service-type=exec',
-          `--setenv=PATH=${process.env.PATH || ''}`,
-          '/bin/sh',
-          '-c',
-          updateScript,
-        ], {
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'pipe'],
-          timeout: 5000,
-        });
+          if (systemdRun.status !== 0) {
+            const detail = (systemdRun.stderr || systemdRun.stdout || '').trim();
+            return res.status(409).json({
+              error: detail || `Could not queue update job for ${systemdServiceUnit}`,
+            });
+          }
 
-        if (systemdRun.status !== 0) {
-          const detail = (systemdRun.stderr || systemdRun.stdout || '').trim();
-          return res.status(409).json({
-            error: detail || `Could not queue update job for ${systemdServiceUnit}`,
+          return res.json({
+            success: true,
+            message: 'Update queued; OpenChamber will restart after installation completes',
+            version: updateInfo.version,
+            packageManager: pm,
+            autoRestart: true,
+            restartManager: 'systemd',
+            jobId: updateJobName,
+            logPath: updateLogPath,
           });
         }
-
-        return res.json({
-          success: true,
-          message: 'Update queued; OpenChamber will restart after installation completes',
-          version: updateInfo.version,
-          packageManager: pm,
-          autoRestart: true,
-          restartManager: 'systemd',
-          jobId: updateJobName,
-          logPath: updateLogPath,
-        });
       }
 
       const isWindows = process.platform === 'win32';
@@ -195,60 +197,49 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         return `"${stringValue.replace(/"/g, '""')}"`;
       };
 
-      const cliPath = path.resolve(__dirname, '..', 'bin', 'cli.js');
-      const restartParts = [
-        isWindows ? quoteCmd(process.execPath) : quotePosix(process.execPath),
-        isWindows ? quoteCmd(cliPath) : quotePosix(cliPath),
-        'serve',
-        '--port',
-        String(storedOptions.port),
-      ];
-      let restartCmdPrimary = restartParts.join(' ');
-      let restartCmdFallback = `openchamber serve --port ${storedOptions.port}`;
-      if (storedOptions.host) {
-        if (isWindows) {
-          const escapedHost = storedOptions.host.replace(/"/g, '""');
-          restartCmdPrimary += ` --host "${escapedHost}"`;
-          restartCmdFallback += ` --host "${escapedHost}"`;
-        } else {
-          const escapedHost = storedOptions.host.replace(/'/g, "'\\''");
-          restartCmdPrimary += ` --host '${escapedHost}'`;
-          restartCmdFallback += ` --host '${escapedHost}'`;
-        }
-      }
-      if (storedOptions.uiPassword) {
-        if (isWindows) {
-          const escapedPw = storedOptions.uiPassword.replace(/"/g, '""');
-          restartCmdPrimary += ` --ui-password "${escapedPw}"`;
-          restartCmdFallback += ` --ui-password "${escapedPw}"`;
-        } else {
-          const escapedPw = storedOptions.uiPassword.replace(/'/g, "'\\''");
-          restartCmdPrimary += ` --ui-password '${escapedPw}'`;
-          restartCmdFallback += ` --ui-password '${escapedPw}'`;
-        }
-      }
-      if (storedOptions.apiOnly === true) {
-        restartCmdPrimary += ' --api-only';
-        restartCmdFallback += ' --api-only';
-      }
-
       let restartCmd = '';
-      switch (process.platform) {
-        case 'darwin': {
-          const plistPath = resolveLaunchdPlistPath(path, os || (await import('os')));
-          const quotedPlistPath = quotePosixShell(plistPath);
-          restartCmd = `launchctl kickstart -k gui/$(id -u)/${LAUNCHD_SERVICE_ID} || (launchctl unload ${quotedPlistPath} && launchctl load ${quotedPlistPath})`;
-          break;
-        }
-        default: {
-          if (!isForegroundService) {
-            restartCmd = `(${restartCmdPrimary}) || (${restartCmdFallback})`;
+      if (isLaunchdService) {
+        const quotedPlistPath = quotePosixShell(launchdPlistPath);
+        restartCmd = `launchctl kickstart -k gui/$(id -u)/${LAUNCHD_SERVICE_ID} || (launchctl unload ${quotedPlistPath} && launchctl load ${quotedPlistPath})`;
+      } else {
+        const cliPath = path.resolve(__dirname, '..', 'bin', 'cli.js');
+        const restartParts = [
+          isWindows ? quoteCmd(process.execPath) : quotePosix(process.execPath),
+          isWindows ? quoteCmd(cliPath) : quotePosix(cliPath),
+          'serve',
+          '--port',
+          String(storedOptions.port),
+        ];
+        let restartCmdPrimary = restartParts.join(' ');
+        let restartCmdFallback = `openchamber serve --port ${storedOptions.port}`;
+        if (storedOptions.host) {
+          if (isWindows) {
+            const escapedHost = storedOptions.host.replace(/"/g, '""');
+            restartCmdPrimary += ` --host "${escapedHost}"`;
+            restartCmdFallback += ` --host "${escapedHost}"`;
+          } else {
+            const escapedHost = storedOptions.host.replace(/'/g, "'\\''");
+            restartCmdPrimary += ` --host '${escapedHost}'`;
+            restartCmdFallback += ` --host '${escapedHost}'`;
           }
-          break;
         }
+        if (storedOptions.uiPassword) {
+          if (isWindows) {
+            const escapedPw = storedOptions.uiPassword.replace(/"/g, '""');
+            restartCmdPrimary += ` --ui-password "${escapedPw}"`;
+            restartCmdFallback += ` --ui-password "${escapedPw}"`;
+          } else {
+            const escapedPw = storedOptions.uiPassword.replace(/'/g, "'\\''");
+            restartCmdPrimary += ` --ui-password '${escapedPw}'`;
+            restartCmdFallback += ` --ui-password '${escapedPw}'`;
+          }
+        }
+        if (storedOptions.apiOnly === true) {
+          restartCmdPrimary += ' --api-only';
+          restartCmdFallback += ' --api-only';
+        }
+        restartCmd = `(${restartCmdPrimary}) || (${restartCmdFallback})`;
       }
-
-
 
       const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
       const logPreamble = [

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -231,12 +231,23 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         restartCmdPrimary += ' --api-only';
         restartCmdFallback += ' --api-only';
       }
-      let restartCmd = isForegroundService ? '' : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
-      if (isDarwin) {
-        const plistPath = resolveLaunchdPlistPath(path, os || (await import('os')));
-        const quotedPlistPath = quotePosixShell(plistPath);
-        restartCmd = `launchctl kickstart -k gui/$(id -u)/${LAUNCHD_SERVICE_ID} || (launchctl unload ${quotedPlistPath} && launchctl load ${quotedPlistPath})`;
+
+      let restartCmd = '';
+      switch (process.platform) {
+        case 'darwin': {
+          const plistPath = resolveLaunchdPlistPath(path, os || (await import('os')));
+          const quotedPlistPath = quotePosixShell(plistPath);
+          restartCmd = `launchctl kickstart -k gui/$(id -u)/${LAUNCHD_SERVICE_ID} || (launchctl unload ${quotedPlistPath} && launchctl load ${quotedPlistPath})`;
+          break;
+        }
+        default: {
+          if (!isForegroundService) {
+            restartCmd = `(${restartCmdPrimary}) || (${restartCmdFallback})`;
+          }
+          break;
+        }
       }
+
 
 
       const updateLogPath = path.join(openchamberDataDir, 'update-install.log');

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -126,6 +126,7 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         storedOptions = JSON.parse(content);
       } catch {
       }
+      const launchMode = storedOptions.launchMode === 'foreground' ? 'foreground' : 'daemon';
       const isDarwin = process.platform === 'darwin';
       const isForegroundService = launchMode === 'foreground';
       const systemdServiceUnit = isForegroundService && !isDarwin ? resolveSystemdServiceUnit(process.env) : null;
@@ -223,8 +224,9 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         restartCmdFallback += ' --api-only';
       }
       const restartCmd = isDarwin
-        ? 'launchctl kickstart -k gui/$(id -u)/dev.openchamber.web || launchctl unload ~/Library/LaunchAgents/dev.openchamber.web.plist && launchctl load ~/Library/LaunchAgents/dev.openchamber.web.plist'
+        ? 'launchctl kickstart -k gui/$(id -u)/dev.openchamber.web || (launchctl unload ~/Library/LaunchAgents/dev.openchamber.web.plist && launchctl load ~/Library/LaunchAgents/dev.openchamber.web.plist)'
         : (isForegroundService ? '' : `(${restartCmdPrimary}) || (${restartCmdFallback})`);
+
       const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
       const logPreamble = [
         '',

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -126,16 +126,17 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         storedOptions = JSON.parse(content);
       } catch {
       }
-      const launchMode = storedOptions.launchMode === 'foreground' ? 'foreground' : 'daemon';
+      const isDarwin = process.platform === 'darwin';
       const isForegroundService = launchMode === 'foreground';
-      const systemdServiceUnit = isForegroundService ? resolveSystemdServiceUnit(process.env) : null;
+      const systemdServiceUnit = isForegroundService && !isDarwin ? resolveSystemdServiceUnit(process.env) : null;
 
-      if (isForegroundService) {
+      if (isForegroundService && !isDarwin) {
         if (!systemdServiceUnit) {
           return res.status(409).json({
             error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, or run openchamber update and restart the service.',
           });
         }
+
 
         const updateJobName = `openchamber-update-${Date.now()}`;
         const updateLogPath = `journalctl --user-unit ${updateJobName}.service`;
@@ -221,7 +222,9 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         restartCmdPrimary += ' --api-only';
         restartCmdFallback += ' --api-only';
       }
-      const restartCmd = isForegroundService ? '' : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
+      const restartCmd = isDarwin
+        ? 'launchctl kickstart -k gui/$(id -u)/dev.openchamber.web || launchctl unload ~/Library/LaunchAgents/dev.openchamber.web.plist && launchctl load ~/Library/LaunchAgents/dev.openchamber.web.plist'
+        : (isForegroundService ? '' : `(${restartCmdPrimary}) || (${restartCmdFallback})`);
       const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
       const logPreamble = [
         '',

--- a/packages/web/server/lib/opencode/openchamber-routes.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.js
@@ -1,4 +1,5 @@
 const SYSTEMD_SERVICE_UNIT_PATTERN = /^[A-Za-z0-9:_.@-]+\.service$/;
+const LAUNCHD_SERVICE_ID = 'dev.openchamber.web';
 
 function resolveSystemdServiceUnit(environment) {
   if (!environment.INVOCATION_ID) {
@@ -12,13 +13,19 @@ function resolveSystemdServiceUnit(environment) {
   return SYSTEMD_SERVICE_UNIT_PATTERN.test(unit) ? unit : null;
 }
 
+function resolveLaunchdPlistPath(pathModule, osModule) {
+  return pathModule.join(osModule.homedir(), 'Library', 'LaunchAgents', `${LAUNCHD_SERVICE_ID}.plist`);
+}
+
 function quotePosixShell(value) {
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
 
+
 export const registerOpenChamberRoutes = (app, dependencies) => {
   const {
     fs,
+    os,
     path,
     process,
     server,
@@ -30,6 +37,7 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
     fetchFreeZenModels,
     getCachedZenModels,
   } = dependencies;
+
 
   app.get('/api/openchamber/update-check', async (req, res) => {
     try {
@@ -223,9 +231,13 @@ export const registerOpenChamberRoutes = (app, dependencies) => {
         restartCmdPrimary += ' --api-only';
         restartCmdFallback += ' --api-only';
       }
-      const restartCmd = isDarwin
-        ? 'launchctl kickstart -k gui/$(id -u)/dev.openchamber.web || (launchctl unload ~/Library/LaunchAgents/dev.openchamber.web.plist && launchctl load ~/Library/LaunchAgents/dev.openchamber.web.plist)'
-        : (isForegroundService ? '' : `(${restartCmdPrimary}) || (${restartCmdFallback})`);
+      let restartCmd = isForegroundService ? '' : `(${restartCmdPrimary}) || (${restartCmdFallback})`;
+      if (isDarwin) {
+        const plistPath = resolveLaunchdPlistPath(path, os || (await import('os')));
+        const quotedPlistPath = quotePosixShell(plistPath);
+        restartCmd = `launchctl kickstart -k gui/$(id -u)/${LAUNCHD_SERVICE_ID} || (launchctl unload ${quotedPlistPath} && launchctl load ${quotedPlistPath})`;
+      }
+
 
       const updateLogPath = path.join(openchamberDataDir, 'update-install.log');
       const logPreamble = [

--- a/packages/web/server/lib/opencode/openchamber-routes.test.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.test.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import request from 'supertest';
 
 vi.mock('child_process', () => ({
-  spawn: vi.fn(),
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
   spawnSync: vi.fn(),
 }));
 
@@ -18,11 +18,24 @@ const childProcess = await import('child_process');
 const packageManager = await import('../package-manager.js');
 const { registerOpenChamberRoutes } = await import('./openchamber-routes.js');
 
-const createApp = ({ environment = {}, storedOptions = {}, platform = 'linux' } = {}) => {
+const createApp = ({
+  environment = {},
+  storedOptions = {},
+  platform = 'linux',
+  plistExists = false,
+} = {}) => {
   const app = express();
   const dependencies = {
     fs: {
-      existsSync: vi.fn(() => false),
+      existsSync: vi.fn((targetPath) => {
+        if (typeof targetPath === 'string' && targetPath.endsWith('dev.openchamber.web.plist')) {
+          return plistExists;
+        }
+        return false;
+      }),
+      mkdirSync: vi.fn(),
+      openSync: vi.fn(() => 42),
+      closeSync: vi.fn(),
       promises: {
         readFile: vi.fn(async () => JSON.stringify({
           launchMode: 'foreground',
@@ -31,13 +44,16 @@ const createApp = ({ environment = {}, storedOptions = {}, platform = 'linux' } 
         })),
       },
     },
+    os: {
+      homedir: () => '/home/test',
+    },
     path,
     process: {
       env: environment,
       platform,
       execPath: '/usr/bin/node',
+      exit: vi.fn(),
     },
-
     server: {
       address: () => ({ port: 7897 }),
     },
@@ -55,6 +71,7 @@ const createApp = ({ environment = {}, storedOptions = {}, platform = 'linux' } 
 };
 
 beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
   packageManager.checkForUpdates.mockResolvedValue({
     available: true,
     version: '1.17.1',
@@ -63,9 +80,12 @@ beforeEach(() => {
     packageManager: 'npm',
   });
   packageManager.getUpdateCommand.mockReturnValue('npm install -g @openchamber/web@latest');
+  childProcess.spawn.mockReturnValue({ unref: vi.fn() });
 });
 
 afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.clearAllMocks();
 });
@@ -81,6 +101,7 @@ describe('OpenChamber foreground update route', () => {
       });
 
     expect(childProcess.spawnSync).not.toHaveBeenCalled();
+    expect(childProcess.spawn).not.toHaveBeenCalled();
   });
 
   it('rejects an unsafe systemd unit override before starting an update job', async () => {
@@ -98,6 +119,7 @@ describe('OpenChamber foreground update route', () => {
       });
 
     expect(childProcess.spawnSync).not.toHaveBeenCalled();
+    expect(childProcess.spawn).not.toHaveBeenCalled();
   });
 
   it('queues the install in a transient systemd unit and returns its job identifier', async () => {
@@ -138,11 +160,31 @@ describe('OpenChamber foreground update route', () => {
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 5000,
     });
+    expect(childProcess.spawn).not.toHaveBeenCalled();
   });
 
-  it('allows foreground update on macOS and invokes launchd restart command', async () => {
+  it('rejects foreground update on macOS when launchd plist does not exist', async () => {
     const { app } = createApp({
       platform: 'darwin',
+      storedOptions: { launchMode: 'foreground' },
+      plistExists: false,
+    });
+
+    await request(app)
+      .post('/api/openchamber/update-install')
+      .expect(409, {
+        error: 'Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, or run openchamber update and restart the service.',
+      });
+
+    expect(childProcess.spawnSync).not.toHaveBeenCalled();
+    expect(childProcess.spawn).not.toHaveBeenCalled();
+  });
+
+  it('allows foreground update on macOS when launchd plist exists and invokes launchd restart command', async () => {
+    const { app } = createApp({
+      platform: 'darwin',
+      storedOptions: { launchMode: 'foreground' },
+      plistExists: true,
     });
 
     await request(app)
@@ -155,7 +197,88 @@ describe('OpenChamber foreground update route', () => {
         autoRestart: true,
         restartManager: 'service',
       });
+
+    vi.advanceTimersByTime(600);
+
+    expect(childProcess.spawn).toHaveBeenCalledWith(
+      'sh',
+      [
+        '-c',
+        expect.stringContaining(
+          "launchctl kickstart -k gui/$(id -u)/dev.openchamber.web || (launchctl unload '/home/test/Library/LaunchAgents/dev.openchamber.web.plist' && launchctl load '/home/test/Library/LaunchAgents/dev.openchamber.web.plist')"
+        ),
+      ],
+      expect.objectContaining({
+        detached: true,
+      })
+    );
+  });
+
+  it('allows daemon update on macOS without launchd plist and invokes CLI restart command', async () => {
+    const { app } = createApp({
+      platform: 'darwin',
+      storedOptions: { launchMode: 'daemon', port: 7897 },
+      plistExists: false,
+    });
+
+    await request(app)
+      .post('/api/openchamber/update-install')
+      .expect(200, {
+        success: true,
+        message: 'Update starting, server will restart shortly',
+        version: '1.17.1',
+        packageManager: 'npm',
+        autoRestart: true,
+        restartManager: 'cli',
+      });
+
+    vi.advanceTimersByTime(600);
+
+    expect(childProcess.spawn).toHaveBeenCalledWith(
+      'sh',
+      [
+        '-c',
+        expect.stringContaining(
+          "('/usr/bin/node' '/opt/openchamber/bin/cli.js' serve --port 7897) || (openchamber serve --port 7897)"
+        ),
+      ],
+      expect.objectContaining({
+        detached: true,
+      })
+    );
+  });
+
+  it('allows daemon update on macOS with launchd plist present and still invokes CLI restart command', async () => {
+    const { app } = createApp({
+      platform: 'darwin',
+      storedOptions: { launchMode: 'daemon', port: 7897 },
+      plistExists: true,
+    });
+
+    await request(app)
+      .post('/api/openchamber/update-install')
+      .expect(200, {
+        success: true,
+        message: 'Update starting, server will restart shortly',
+        version: '1.17.1',
+        packageManager: 'npm',
+        autoRestart: true,
+        restartManager: 'cli',
+      });
+
+    vi.advanceTimersByTime(600);
+
+    expect(childProcess.spawn).toHaveBeenCalledWith(
+      'sh',
+      [
+        '-c',
+        expect.stringContaining(
+          "('/usr/bin/node' '/opt/openchamber/bin/cli.js' serve --port 7897) || (openchamber serve --port 7897)"
+        ),
+      ],
+      expect.objectContaining({
+        detached: true,
+      })
+    );
   });
 });
-
-

--- a/packages/web/server/lib/opencode/openchamber-routes.test.js
+++ b/packages/web/server/lib/opencode/openchamber-routes.test.js
@@ -18,7 +18,7 @@ const childProcess = await import('child_process');
 const packageManager = await import('../package-manager.js');
 const { registerOpenChamberRoutes } = await import('./openchamber-routes.js');
 
-const createApp = ({ environment = {}, storedOptions = {} } = {}) => {
+const createApp = ({ environment = {}, storedOptions = {}, platform = 'linux' } = {}) => {
   const app = express();
   const dependencies = {
     fs: {
@@ -34,9 +34,10 @@ const createApp = ({ environment = {}, storedOptions = {} } = {}) => {
     path,
     process: {
       env: environment,
-      platform: 'linux',
+      platform,
       execPath: '/usr/bin/node',
     },
+
     server: {
       address: () => ({ port: 7897 }),
     },
@@ -138,4 +139,23 @@ describe('OpenChamber foreground update route', () => {
       timeout: 5000,
     });
   });
+
+  it('allows foreground update on macOS and invokes launchd restart command', async () => {
+    const { app } = createApp({
+      platform: 'darwin',
+    });
+
+    await request(app)
+      .post('/api/openchamber/update-install')
+      .expect(200, {
+        success: true,
+        message: 'Update starting, server will restart shortly',
+        version: '1.17.1',
+        packageManager: 'npm',
+        autoRestart: true,
+        restartManager: 'service',
+      });
+  });
 });
+
+


### PR DESCRIPTION
## Intent

Fixes #3159.

When running OpenChamber on macOS via `openchamber startup enable` (native `launchd` User LaunchAgent in foreground mode), attempting to update from the Web / PWA UI fails with HTTP 409:
> *"Foreground servers must be updated by their service manager. Set OPENCHAMBER_SYSTEMD_UNIT when running under systemd, or run openchamber update and restart the service."*

This change allows macOS `launchd` foreground services to update via `pnpm add -g @openchamber/web@latest` (or detected PM) and automatically trigger a service restart via `launchctl`.

## Non-goals

- Altering Linux `systemd` unit resolution or interactive CLI foreground behavior on Linux/Windows.

## Affected surfaces

- `packages/web`: `server/lib/opencode/openchamber-routes.js` (`POST /api/openchamber/update-install`).
- Runtime: Web / PWA on macOS (`darwin`) when managed by `launchd`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `CONTRIBUTING.md` / `packages/web` | Web server update installation routes | Preserves existing systemd behavior on Linux while cleanly handling macOS launchd service reload. |

## Validation

| Check | Result |
|---|---|
| Local manual verification on macOS 15 (Apple Silicon) | Triggered in-app update (`POST /api/openchamber/update-install`) under `launchd` service; successfully upgraded package and reloaded service without 409. |
| Health verification | `GET /health` returned `HTTP 200` with `openchamberVersion: 1.21.0`. |

## Visual evidence

No frontend UI component rendering changed. This resolves a backend API 409 rejection and prevents the error toast from blocking in-app updates on macOS.

## Risks and failure behavior

- **Rollback / Failure**: If `launchctl kickstart` fails, it falls back to `launchctl unload && launchctl load` of `~/Library/LaunchAgents/dev.openchamber.web.plist`.
- **Security & Compatibility**: Retains existing package manager detection and command isolation.
