### PR TITLE
fix(web): run dev server through cross-platform launcher on Windows

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "dev": "bun run build:watch",
-    "dev:server": "OPENCHAMBER_RELAY_HOST=${OPENCHAMBER_RELAY_HOST:-off} bun server/index.js --port ${OPENCHAMBER_PORT:-3001}",
-    "dev:server:watch": "OPENCHAMBER_RELAY_HOST=${OPENCHAMBER_RELAY_HOST:-off} nodemon --watch server --ext js --exec \"bun server/index.js --port ${OPENCHAMBER_PORT:-3001}\"",
+    "dev:server": "bun scripts/dev-server.mjs",
+    "dev:server:watch": "nodemon --watch server --ext js --exec \"bun scripts/dev-server.mjs\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "type-check": "tsc --noEmit",

--- a/packages/web/scripts/dev-server.mjs
+++ b/packages/web/scripts/dev-server.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, '..');
+
+const port = process.env.OPENCHAMBER_PORT || '3001';
+const relayHost = process.env.OPENCHAMBER_RELAY_HOST || 'off';
+
+const child = spawn('bun', ['server/index.js', '--port', port], {
+  cwd: packageRoot,
+  env: {
+    ...process.env,
+    OPENCHAMBER_RELAY_HOST: relayHost,
+  },
+  stdio: 'inherit',
+});
+
+let shuttingDown = false;
+
+function forwardSignal(signal) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  try {
+    child.kill(signal);
+  } catch {
+  }
+}
+
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => {
+    shuttingDown = true;
+    forwardSignal(signal);
+  });
+}
+
+child.on('exit', (code, signal) => {
+  if (shuttingDown) {
+    process.exit(0);
+  }
+  if (signal) {
+    process.exit(1);
+  }
+  process.exit(typeof code === 'number' ? code : 1);
+});


### PR DESCRIPTION
## Intent

Fixes #3162. `bun run dev` (the default HMR dev flow) was broken on Windows: every `/auth`, `/api`, and `/health` request proxied by Vite failed with `ECONNREFUSED`.

Root cause: `packages/web/package.json` `dev:server` / `dev:server:watch` used bash-style `${OPENCHAMBER_PORT:-3001}` and `${OPENCHAMBER_RELAY_HOST:-off}` expansion. npm/bun run launches scripts through `cmd.exe` on Windows, which does not expand this syntax. The literal token reached `--port`, `parseInt` produced `NaN`, and the server fell back to `DEFAULT_PORT` 3000 (`server/index.js:121`) while `dev-web-hmr.mjs` set `OPENCHAMBER_PORT=3902` for both the API and Vite processes. Vite's proxy (`vite.config.ts:111`) targeted 3902, so the backend on 3000 was unreachable.

Fix: add `packages/web/scripts/dev-server.mjs`, a small launcher that resolves `OPENCHAMBER_PORT` (default 3001) and `OPENCHAMBER_RELAY_HOST` (default off) in JS and spawns `server/index.js --port <port>`. The two dev scripts now call the launcher. The defaults are unchanged from the bash syntax, so macOS/Linux behavior is identical; Windows now binds the port Vite expects.

## Non-goals

- No change to server runtime logic, port parsing, Vite proxy config, or the CLI serve path (`bin/cli.js serve` passes an explicit `--port`, which is unaffected).
- No change to the remote-shell scripts in `scripts/oc-dev.mjs` / `packages/electron/ssh-manager.mjs`; those strings execute in POSIX shells on remote Linux hosts, where the syntax is valid.
- The pre-existing `server/index.js` oxlint findings are unrelated and left untouched.

## Affected surfaces

- `packages/web/package.json` dev scripts (`dev:server`, `dev:server:watch`) — used by `scripts/dev-web-hmr.mjs`, `scripts/dev-web-full.mjs`, and root `dev:web:server`.
- New `packages/web/scripts/dev-server.mjs` dev launcher.
- Windows dev flow only. macOS/Linux dev flow behavior is preserved. No persisted data, exports, routes, or packaged behavior change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Dev script + package contract change in `packages/web` | Narrowest fix (script change only, no runtime edits); defaults preserved so observable behavior is unchanged outside Windows; validation matches the actual risk |
| `clack-cli-patterns` | Command/terminal execution semantics | Not a CLI command; the launcher keeps stdout/stderr/stdin inherited and forwards SIGINT/SIGTERM/SIGHUP, so terminal lifecycle behavior matches the previous direct spawn |

Docs reviewed: `packages/web/README.md` (no dev-script port documentation), `CONTRIBUTING.md` (dev script table, ports unchanged).

## Validation

Environment: Windows 10.0.26200 x64, bun 1.4.0.

| Check | Result |
|---|---|
| `bun run dev` end to end | Pass. Backend logged `Starting OpenChamber on port 3902` and listened on 3902; `http://127.0.0.1:5180/health` returned 200 through the Vite proxy; no `proxy error`/`ECONNREFUSED` in the log (before the fix: server bound 3000, proxy to 3902 refused) |
| Launcher default port | Pass. `OPENCHAMBER_PORT` unset -> server listens on 3001 |
| Launcher env override | Pass. `OPENCHAMBER_PORT=3999` -> server listens on 3999 |
| `bun run dev:server` via package.json | Pass. Resolves to `bun scripts/dev-server.mjs`, server listens on the configured port |
| `bun run --cwd packages/web type-check` | Pass |
| `bunx oxlint packages/web/scripts/dev-server.mjs` | Pass (no findings in the new file; `server/index.js` findings are pre-existing, unchanged file) |
| `bun run dead-code` | Exit 0 (report contains pre-existing UI package items, none from this change) |

Not verified: macOS/Linux execution (no such host available here); the change is a pure default-preserving refactor for those platforms, and the launcher uses only cross-platform Node APIs.

## Visual evidence

No user-visible rendering change. The diff touches dev tooling only; rendered UI is identical. The observable fix is the dev server binding the Vite proxy port on Windows, reported in Validation.

## Risks and failure behavior

- If the launcher's spawned server crashes, the launcher exits non-zero (matches the previous script behavior where a failing server process would surface its exit code).
- Signal forwarding: SIGINT/SIGTERM/SIGHUP are forwarded to the server child; on Windows, `nodemon`'s `taskkill /T` still terminates the whole tree, so watch-mode restarts remain clean.
- `OPENCHAMBER_PORT` unset defaults to 3001, matching the previous bash default and `vite.config.ts` fallback.
- None identified for persistence, security, or data loss; the change adds no network surface beyond the existing dev server.