### PR TITLE
Explain unavailable Home Network Only option

### DIFF
--- a/packages/ui/src/components/sections/remote-instances/RemoteInstancesPage.tsx
+++ b/packages/ui/src/components/sections/remote-instances/RemoteInstancesPage.tsx
@@ -1865,7 +1865,7 @@ export const RemoteInstancesPage: React.FC = () => {
                   <div role="radiogroup" aria-label={t('settings.remoteInstances.clientAuth.addDevice.transportLabel')} className="space-y-1.5">
                     {([
                       { key: 'relay' as const, label: t('settings.remoteInstances.clientAuth.addDevice.transport.relay'), hint: t('settings.remoteInstances.clientAuth.addDevice.transport.relayHint'), available: Boolean(transportOptions?.relayAvailable) },
-                      { key: 'lan' as const, label: t('settings.remoteInstances.clientAuth.addDevice.transport.lan'), hint: !transportOptions?.lanUrl && isDesktopShell() ? t('settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint') : t('settings.remoteInstances.clientAuth.addDevice.transport.lanHint'), available: Boolean(transportOptions?.lanUrl) },
+                      { key: 'lan' as const, label: t('settings.remoteInstances.clientAuth.addDevice.transport.lan'), hint: transportOptions && !transportOptions.lanUrl && isDesktopShell() ? t('settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint') : t('settings.remoteInstances.clientAuth.addDevice.transport.lanHint'), available: Boolean(transportOptions?.lanUrl) },
                       { key: 'local' as const, label: t('settings.remoteInstances.clientAuth.addDevice.transport.local'), hint: t('settings.remoteInstances.clientAuth.addDevice.transport.localHint'), available: Boolean(transportOptions?.localUrl) },
                     ]).map((option) => {
                       const selected = addDeviceTransport === option.key;

--- a/packages/ui/src/components/sections/remote-instances/RemoteInstancesPage.tsx
+++ b/packages/ui/src/components/sections/remote-instances/RemoteInstancesPage.tsx
@@ -1865,7 +1865,7 @@ export const RemoteInstancesPage: React.FC = () => {
                   <div role="radiogroup" aria-label={t('settings.remoteInstances.clientAuth.addDevice.transportLabel')} className="space-y-1.5">
                     {([
                       { key: 'relay' as const, label: t('settings.remoteInstances.clientAuth.addDevice.transport.relay'), hint: t('settings.remoteInstances.clientAuth.addDevice.transport.relayHint'), available: Boolean(transportOptions?.relayAvailable) },
-                      { key: 'lan' as const, label: t('settings.remoteInstances.clientAuth.addDevice.transport.lan'), hint: t('settings.remoteInstances.clientAuth.addDevice.transport.lanHint'), available: Boolean(transportOptions?.lanUrl) },
+                      { key: 'lan' as const, label: t('settings.remoteInstances.clientAuth.addDevice.transport.lan'), hint: !transportOptions?.lanUrl && isDesktopShell() ? t('settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint') : t('settings.remoteInstances.clientAuth.addDevice.transport.lanHint'), available: Boolean(transportOptions?.lanUrl) },
                       { key: 'local' as const, label: t('settings.remoteInstances.clientAuth.addDevice.transport.local'), hint: t('settings.remoteInstances.clientAuth.addDevice.transport.localHint'), available: Boolean(transportOptions?.localUrl) },
                     ]).map((option) => {
                       const selected = addDeviceTransport === option.key;

--- a/packages/ui/src/lib/i18n/messages/de.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/de.settings.ts
@@ -323,6 +323,7 @@ export const settingsDict = {
   'settings.remoteInstances.clientAuth.addDevice.transport.localHint': 'Für Apps, die auf derselben Maschine laufen.',
   'settings.remoteInstances.clientAuth.addDevice.transport.lan': 'Nur Heimnetzwerk',
   'settings.remoteInstances.clientAuth.addDevice.transport.lanHint': 'Verbindet direkt über dein Wi-Fi. Funktioniert nicht außerhalb dieses Netzwerks.',
+  'settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint': 'Gehe zu Einstellungen > Desktop-Netzwerkzugriff, lege ein Desktop-UI-Passwort fest und erlaube anderen Geräten in deinem lokalen Netzwerk, diese App zu öffnen.',
   'settings.remoteInstances.clientAuth.addDevice.transport.relay': 'Überall',
   'settings.remoteInstances.clientAuth.addDevice.transport.relayHint': 'Funktioniert zu Hause und unterwegs. Verkehr außerhalb des Heimnetzwerks geht über OpenChamber Private Relay — einen Ende-zu-Ende-verschlüsselten Tunnel. Keine Einrichtung nötig.',
   'settings.remoteInstances.clientAuth.addDevice.fallback.relay': 'Verschlüsselte Relay-Verbindung auch außerhalb des Heimnetzwerks erlauben',

--- a/packages/ui/src/lib/i18n/messages/en.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/en.settings.ts
@@ -339,6 +339,7 @@ export const settingsDict = {
   'settings.remoteInstances.clientAuth.addDevice.transport.localHint': 'For apps running on this same machine.',
   'settings.remoteInstances.clientAuth.addDevice.transport.lan': 'Home network only',
   'settings.remoteInstances.clientAuth.addDevice.transport.lanHint': 'Connects directly over your Wi-Fi. Does not work away from this network.',
+  'settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint': 'To use this option, go to Settings > Desktop Network Access, set a Desktop UI password, and allow other devices on your local network to open this app.',
   'settings.remoteInstances.clientAuth.addDevice.transport.relay': 'Anywhere',
   'settings.remoteInstances.clientAuth.addDevice.transport.relayHint': 'Works at home and away. Away traffic goes through OpenChamber Private Relay — an end-to-end encrypted tunnel. No setup needed.',
   'settings.remoteInstances.clientAuth.addDevice.fallback.relay': 'Also allow the encrypted relay when away from home',

--- a/packages/ui/src/lib/i18n/messages/es.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/es.settings.ts
@@ -307,6 +307,7 @@ export const settingsDict = {
   "settings.remoteInstances.clientAuth.addDevice.transport.localHint": "Para aplicaciones en esta misma máquina.",
   "settings.remoteInstances.clientAuth.addDevice.transport.lan": "Solo red doméstica",
   "settings.remoteInstances.clientAuth.addDevice.transport.lanHint": "Se conecta directamente por tu Wi-Fi. No funciona fuera de esta red.",
+  "settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint": "Para usar esta opción, ve a Ajustes > Acceso de red de escritorio, establece una contraseña para la interfaz de escritorio y permite que otros dispositivos de tu red local abran esta aplicación.",
   "settings.remoteInstances.clientAuth.addDevice.transport.relay": "En cualquier lugar",
   "settings.remoteInstances.clientAuth.addDevice.transport.relayHint": "Funciona en casa y fuera. Fuera de casa el tráfico pasa por OpenChamber Private Relay, un túnel cifrado de extremo a extremo. Sin configuración.",
   "settings.remoteInstances.clientAuth.addDevice.fallback.relay": "Permitir también el relay cifrado fuera de casa",

--- a/packages/ui/src/lib/i18n/messages/fr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.settings.ts
@@ -2116,6 +2116,7 @@ export const settingsDict = {
   'settings.remoteInstances.clientAuth.addDevice.transport.localHint': 'Pour les applications sur cette même machine.',
   'settings.remoteInstances.clientAuth.addDevice.transport.lan': 'Réseau domestique uniquement',
   'settings.remoteInstances.clientAuth.addDevice.transport.lanHint': 'Connexion directe via votre Wi-Fi. Ne fonctionne pas hors de ce réseau.',
+  'settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint': 'Pour utiliser cette option, accédez à Paramètres > Accès réseau du bureau, définissez un mot de passe pour l’interface du bureau et autorisez les autres appareils de votre réseau local à ouvrir cette application.',
   'settings.remoteInstances.clientAuth.addDevice.transport.relay': 'Partout',
   'settings.remoteInstances.clientAuth.addDevice.transport.relayHint': 'Fonctionne à la maison et en déplacement. En déplacement, le trafic passe par OpenChamber Private Relay — un tunnel chiffré de bout en bout. Aucune configuration.',
   'settings.remoteInstances.clientAuth.addDevice.fallback.relay': 'Autoriser aussi le relais chiffré en déplacement',

--- a/packages/ui/src/lib/i18n/messages/ja.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.settings.ts
@@ -340,6 +340,7 @@ export const settingsDict = {
   'settings.remoteInstances.clientAuth.addDevice.transport.localHint': '同じマシン上のアプリ用です。',
   'settings.remoteInstances.clientAuth.addDevice.transport.lan': '自宅ネットワークのみ',
   'settings.remoteInstances.clientAuth.addDevice.transport.lanHint': 'Wi-Fi経由で直接接続します。このネットワークの外では使えません。',
+  'settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint': 'このオプションを使うには、設定 > デスクトップネットワークアクセスでデスクトップ UI パスワードを設定し、ローカルネットワーク上の他のデバイスからこのアプリを開けるようにしてください。',
   'settings.remoteInstances.clientAuth.addDevice.transport.relay': 'どこでも',
   'settings.remoteInstances.clientAuth.addDevice.transport.relayHint': '自宅でも外出先でも使えます。外出先の通信は、エンドツーエンド暗号化トンネルのOpenChamber Private Relayを経由します。設定は不要です。',
   'settings.remoteInstances.clientAuth.addDevice.fallback.relay': '外出先では暗号化リレー経由の接続も許可',

--- a/packages/ui/src/lib/i18n/messages/ko.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.settings.ts
@@ -307,6 +307,7 @@ export const settingsDict = {
   'settings.remoteInstances.clientAuth.addDevice.transport.localHint': '같은 컴퓨터의 앱을 위한 옵션입니다.',
   'settings.remoteInstances.clientAuth.addDevice.transport.lan': '집 네트워크 전용',
   'settings.remoteInstances.clientAuth.addDevice.transport.lanHint': 'Wi-Fi로 직접 연결합니다. 이 네트워크 밖에서는 작동하지 않습니다.',
+  'settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint': '이 옵션을 사용하려면 설정 > 데스크톱 네트워크 액세스에서 데스크톱 UI 비밀번호를 설정하고 로컬 네트워크의 다른 기기가 이 앱을 열 수 있도록 허용하세요.',
   'settings.remoteInstances.clientAuth.addDevice.transport.relay': '어디서나',
   'settings.remoteInstances.clientAuth.addDevice.transport.relayHint': '집과 밖 어디서나 작동합니다. 밖에서는 종단간 암호화 터널인 OpenChamber Private Relay를 통해 연결됩니다. 설정이 필요 없습니다.',
   'settings.remoteInstances.clientAuth.addDevice.fallback.relay': '밖에서는 암호화 릴레이 연결도 허용',

--- a/packages/ui/src/lib/i18n/messages/pl.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.settings.ts
@@ -1777,6 +1777,7 @@ export const settingsDict = {
   'settings.remoteInstances.clientAuth.addDevice.transport.localHint': 'Dla aplikacji na tej samej maszynie.',
   'settings.remoteInstances.clientAuth.addDevice.transport.lan': 'Tylko sieć domowa',
   'settings.remoteInstances.clientAuth.addDevice.transport.lanHint': 'Łączy się bezpośrednio przez Wi-Fi. Nie działa poza tą siecią.',
+  'settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint': 'Aby użyć tej opcji, przejdź do Ustawienia > Dostęp do sieci w aplikacji komputerowej, ustaw hasło interfejsu aplikacji komputerowej i zezwól innym urządzeniom w sieci lokalnej na otwieranie tej aplikacji.',
   'settings.remoteInstances.clientAuth.addDevice.transport.relay': 'Wszędzie',
   'settings.remoteInstances.clientAuth.addDevice.transport.relayHint': 'Działa w domu i poza nim. Poza domem ruch przechodzi przez OpenChamber Private Relay — szyfrowany end-to-end tunel. Bez konfiguracji.',
   'settings.remoteInstances.clientAuth.addDevice.fallback.relay': 'Zezwól też na szyfrowany relay poza domem',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
@@ -307,6 +307,7 @@ export const settingsDict = {
   "settings.remoteInstances.clientAuth.addDevice.transport.localHint": "Para aplicativos nesta mesma máquina.",
   "settings.remoteInstances.clientAuth.addDevice.transport.lan": "Somente rede doméstica",
   "settings.remoteInstances.clientAuth.addDevice.transport.lanHint": "Conecta diretamente pela sua rede Wi-Fi. Não funciona fora desta rede.",
+  "settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint": "Para usar esta opção, vá para Configurações > Acesso à rede do desktop, defina uma senha da interface do desktop e permita que outros dispositivos da rede local abram este aplicativo.",
   "settings.remoteInstances.clientAuth.addDevice.transport.relay": "Em qualquer lugar",
   "settings.remoteInstances.clientAuth.addDevice.transport.relayHint": "Funciona em casa e fora. Fora de casa o tráfego passa pelo OpenChamber Private Relay, um túnel criptografado de ponta a ponta. Sem configuração.",
   "settings.remoteInstances.clientAuth.addDevice.fallback.relay": "Também permitir o relay criptografado fora de casa",

--- a/packages/ui/src/lib/i18n/messages/uk.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.settings.ts
@@ -307,6 +307,7 @@ export const settingsDict = {
   "settings.remoteInstances.clientAuth.addDevice.transport.localHint": "Для застосунків на цій самій машині.",
   "settings.remoteInstances.clientAuth.addDevice.transport.lan": "Лише домашня мережа",
   "settings.remoteInstances.clientAuth.addDevice.transport.lanHint": "Підключається напряму через ваш Wi-Fi. Поза цією мережею не працює.",
+  "settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint": "Щоб скористатися цією опцією, перейдіть до Налаштування > Мережевий доступ десктопного застосунку, встановіть пароль інтерфейсу застосунку та дозвольте іншим пристроям у локальній мережі відкривати цей застосунок.",
   "settings.remoteInstances.clientAuth.addDevice.transport.relay": "Будь-де",
   "settings.remoteInstances.clientAuth.addDevice.transport.relayHint": "Працює вдома і поза домом. Поза домом трафік іде через OpenChamber Private Relay — наскрізно зашифрований тунель. Нічого налаштовувати не треба.",
   "settings.remoteInstances.clientAuth.addDevice.fallback.relay": "Також дозволити зашифрований relay поза домом",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
@@ -307,6 +307,7 @@ export const settingsDict = {
   'settings.remoteInstances.clientAuth.addDevice.transport.localHint': '供同一台电脑上的应用使用。',
   'settings.remoteInstances.clientAuth.addDevice.transport.lan': '仅家庭网络',
   'settings.remoteInstances.clientAuth.addDevice.transport.lanHint': '通过 Wi-Fi 直接连接。离开此网络后无法使用。',
+  'settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint': '要使用此选项，请前往“设置 > 桌面端网络访问”，设置桌面 UI 密码，并勾选“允许本地网络中的其他设备打开此应用”。',
   'settings.remoteInstances.clientAuth.addDevice.transport.relay': '任何地方',
   'settings.remoteInstances.clientAuth.addDevice.transport.relayHint': '在家和外出都可用。外出时流量经由 OpenChamber Private Relay(端到端加密隧道)传输，无需配置。',
   'settings.remoteInstances.clientAuth.addDevice.fallback.relay': '外出时也允许通过加密中继连接',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
@@ -313,6 +313,7 @@ export const settingsDict = {
   'settings.remoteInstances.clientAuth.addDevice.transport.localHint': '供同一台電腦上的應用程式使用。',
   'settings.remoteInstances.clientAuth.addDevice.transport.lan': '僅家用網路',
   'settings.remoteInstances.clientAuth.addDevice.transport.lanHint': '透過 Wi-Fi 直接連線。離開此網路後無法使用。',
+  'settings.remoteInstances.clientAuth.addDevice.transport.lanUnavailableDesktopHint': '若要使用此選項，請前往「設定 > 桌面端網路存取」，設定桌面 UI 密碼，並勾選「允許本機網路中的其他裝置開啟此應用程式」。',
   'settings.remoteInstances.clientAuth.addDevice.transport.relay': '任何地方',
   'settings.remoteInstances.clientAuth.addDevice.transport.relayHint': '在家與外出都可用。外出時流量經由 OpenChamber Private Relay(端對端加密隧道)傳輸，無需設定。',
   'settings.remoteInstances.clientAuth.addDevice.fallback.relay': '外出時也允許透過加密中繼連線',


### PR DESCRIPTION
## Intent

Closes #3068. When the desktop app cannot offer a LAN pairing address, explain how to enable Home Network Only: Settings > Desktop Network Access, a Desktop UI password, and allowing devices on the local network.  
No explanation is provided for why this option is grayed out, leaving many people completely confused.

## Non-goals

Does not change server binding, pairing candidates, relay behavior, or the browser Web hint.

## Affected surfaces

- packages/ui: Add a desktop-only unavailable hint for the disabled Home Network Only option.
- Electron desktop: Shows the setup path when the local server is loopback-only.
- Browser Web, VS Code, and mobile: Retain the existing LAN description. No runtime, persistence, route, or API contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md and openchamber-change-discipline | Shared UI source changed. | Kept the change local to the pairing option description and used focused validation. |
| locale-ui-patterns | The change adds user-visible text. | Used i18n keys and added translated copy to every shipped locale. |
| 	heme-system | The change affects an existing UI state. | Reused existing typography and disabled-state styling without new tokens or controls. |

## Validation

| Check | Result |
|---|---|
| bun run type-check:ui | Passed. |
| bun run lint:ui | Passed. |
| bun run --cwd packages/ui test | 323 of 326 files passed. Existing failures: SessionAuthGate.behavior.test.tsx lacks React.useSyncExternalStore; 
awMessagePreview.test.ts AM/PM assertion; shortcuts.test.ts expects mod, receives mod+alt. These do not cover the changed pairing dialog. |
| bunx oxlint packages/ui/src/components/sections/remote-instances/RemoteInstancesPage.tsx | Reports 33 pre-existing findings in this component. The changed line has no finding. |

## Visual evidence

Not captured. The change affects the disabled desktop-only state of an existing dialog; this environment did not provide a desktop UI renderer for a current-HEAD screenshot. The rendered copy is directly selected by isDesktopShell() and the absent LAN URL condition.

## Risks and failure behavior

Low risk. The option remains disabled and existing pairing behavior is unchanged. If LAN access remains unavailable, the app now tells desktop users the required settings instead of showing the normal Wi-Fi description.