### PR TITLE
fix(tunnels): update cloudflared download link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Settings: fixed the Cloudflare Tunnel download link shown when cloudflared is not installed (thanks to @AyoubAchour).
+
 ## [1.21.0] - 2026-08-26
 
 - **Chat scrolling rebuilt around your message.** Sending parks your message near the top and the reply streams in below it, gliding smoothly a paragraph at a time. Scrolling up immediately hands you the wheel; the scroll-to-bottom pill carries the model's working status while you're away.

--- a/packages/ui/src/components/sections/openchamber/TunnelSettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/TunnelSettings.tsx
@@ -205,7 +205,7 @@ const getFallbackInstallCommand = (provider: string, platform = getClientInstall
   if (platform === 'darwin') {
     return 'brew install cloudflared';
   }
-  return 'https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflared/downloads/';
+  return 'https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/';
 };
 
 const createTunnelDependencyInstallInfo = (provider: string, checkData?: TunnelCheckResponse): TunnelDependencyInstallInfo => {

--- a/packages/web/server/lib/cloudflare-tunnel.js
+++ b/packages/web/server/lib/cloudflare-tunnel.js
@@ -64,7 +64,7 @@ Install instructions for your platform:
   Windows:  winget install --id Cloudflare.cloudflared
   Linux:    Download from https://github.com/cloudflare/cloudflared/releases
 
-Or visit: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflared/downloads/
+Or visit: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/
 `);
 }
 

--- a/packages/web/server/lib/tunnels/install-help.js
+++ b/packages/web/server/lib/tunnels/install-help.js
@@ -6,11 +6,11 @@ import {
 const PROVIDER_INSTALL_INFO = {
   [TUNNEL_PROVIDER_CLOUDFLARE]: {
     dependency: 'cloudflared',
-    installUrl: 'https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflared/downloads/',
+    installUrl: 'https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/',
     commands: {
       darwin: 'brew install cloudflared',
       win32: 'winget install --id Cloudflare.cloudflared',
-      linux: 'Download cloudflared from https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflared/downloads/',
+      linux: 'Download cloudflared from https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/',
     },
   },
   [TUNNEL_PROVIDER_NGROK]: {

--- a/packages/web/server/lib/tunnels/install-help.test.js
+++ b/packages/web/server/lib/tunnels/install-help.test.js
@@ -28,4 +28,13 @@ describe('getTunnelDependencyInstallInfo', () => {
 
     expect(info.installCommand).toBe('brew install cloudflared');
   });
+
+  it('returns the current Linux cloudflared download guidance', () => {
+    const info = getTunnelDependencyInstallInfo(TUNNEL_PROVIDER_CLOUDFLARE, 'linux');
+    const downloadUrl = 'https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/';
+
+    expect(info.installUrl).toBe(downloadUrl);
+    expect(info.installCommand).toBe(`Download cloudflared from ${downloadUrl}`);
+    expect(info.message).toContain(downloadUrl);
+  });
 });


### PR DESCRIPTION
## Intent

Fixes #3125. Linux users who do not have `cloudflared` installed currently receive a Cloudflare documentation URL that returns 404. This updates every server, Settings fallback, and terminal-help occurrence to Cloudflare's current Tunnel downloads page and adds Linux regression coverage.

## Non-goals

- No tunnel startup, installation, process, credential, or networking changes.
- No API response shape or Settings layout changes.
- Windows winget and macOS Homebrew guidance remain unchanged.

## Affected surfaces

- Web and Desktop Tunnel Settings missing-dependency guidance.
- Web server and CLI tunnel diagnostics that reuse the install metadata.
- Direct Cloudflare tunnel terminal help.
- Mobile and VS Code do not expose this Settings page; no VS Code changelog change is included.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Executable server/UI strings and a regression test changed | Replaces only the four stale literals, preserves all surrounding behavior, and tests the public install-info result |
| `settings-ui-patterns`, `theme-system`, `locale-ui-patterns` | One Settings fallback value changed | Keeps the existing component and layout untouched; the URL remains a literal technical value and adds no untranslated prose |
| `clack-cli-patterns` | The same metadata reaches human, quiet, and JSON tunnel commands | Keeps output structure and mode behavior unchanged; only the dead URL value changes |
| `changelog-authoring` | The fix is visible in the main app | Adds one concrete bullet under `[Unreleased]`; no VS Code entry because that Settings page is unavailable there |

Owning documentation reviewed: `packages/web/README.md` and `packages/web/server/lib/tunnels/DOCUMENTATION.md`. No module contract changed, so those files remain accurate.

## Validation

| Check | Result |
|---|---|
| `bun test packages/web/server/lib/tunnels/install-help.test.js` | Passed: 4 tests, 10 assertions |
| `node --check` on both changed server JS files | Passed |
| `bun run type-check` | Passed in every workspace |
| `bun run lint` | Passed in every workspace |
| `bun run build` | Passed in every workspace; existing Vite chunk-size warnings remain |
| `bun run docs:validate` | Passed: 460 pages and 46 sidebar links |
| Old/new URL checks | Old URL returns 404, new official Cloudflare URL returns 200, and the old exact URL has zero repository matches |
| `git diff --check origin/main...HEAD` | Passed |
| `bun run --cwd packages/web test` | Partial on Windows: 143 files passed and 18 unrelated files failed on existing POSIX path, chmod, symlink, `sleep`, timing, and local-port assumptions. The changed tunnel test passes independently. |
| `bunx oxlint <changed code files>` | Reports existing findings in unchanged lines of `TunnelSettings.tsx` and `cloudflare-tunnel.js`; no finding points to a changed line, and both `install-help` files are clean |

## Visual evidence

No layout, styling, or interaction changes. On Linux, the existing missing-dependency text now points to a working page instead of a 404. This Windows host cannot render the Linux server state; the issue contains the before screenshot, while the Linux regression test and live HTTP checks cover the changed behavior.

## Risks and failure behavior

This only changes help text. Tunnel startup, credentials, subprocesses, API contracts, and persisted state are untouched. If `cloudflared` is missing, users receive the same recovery flow with a working Cloudflare URL.
