### PR TITLE
fix(electron): recover crashed renderer windows

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -33,6 +33,7 @@ import {
 } from './linux-autostart.mjs';
 import { unsupportedAppSpecificOpenError, validateLocalPath } from './path-open-utils.mjs';
 import { shouldAllowBrowserPanelCertificateError } from './browser-panel-security.mjs';
+import { createRendererRecoveryPolicy } from './renderer-recovery.mjs';
 import { mintOutsideFileGrant } from '@openchamber/web/server/lib/fs/routes.js';
 
 const execFileAsync = promisify(execFile);
@@ -2496,6 +2497,7 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
   };
 
   const browserWindow = new BrowserWindow(options);
+  const rendererRecoveryPolicy = createRendererRecoveryPolicy();
   browserWindow.__ocLabel = label || nextWindowLabel();
   browserWindow.__ocRuntimeConfig = { apiBaseUrl: desktopApiBaseUrl, clientToken: desktopClientToken, requestHeaders: desktopRequestHeaders };
   browserWindow.__ocInitScript = buildInitScript(desktopLocalOrigin, state.bootOutcome, desktopApiBaseUrl, desktopClientToken, desktopRequestHeaders);
@@ -2655,6 +2657,19 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
   browserWindow.webContents.setZoomFactor(1);
   browserWindow.webContents.on('zoom-changed', () => {
     browserWindow.webContents.setZoomFactor(1);
+  });
+  browserWindow.webContents.on('render-process-gone', (_event, details) => {
+    if (!rendererRecoveryPolicy.shouldReload(details.reason)) return;
+    log.warn('[electron] renderer exited unexpectedly; reloading window', {
+      label: browserWindow.__ocLabel,
+      reason: details.reason,
+      exitCode: details.exitCode,
+    });
+    setTimeout(() => {
+      if (!browserWindow.isDestroyed()) {
+        browserWindow.webContents.reload();
+      }
+    }, 100);
   });
 
   browserWindow.webContents.on('dom-ready', () => {

--- a/packages/electron/renderer-recovery.mjs
+++ b/packages/electron/renderer-recovery.mjs
@@ -1,0 +1,30 @@
+const RECOVERY_WINDOW_MS = 60_000;
+const MAX_RECOVERY_ATTEMPTS = 3;
+
+const RECOVERABLE_REASONS = new Set([
+  'abnormal-exit',
+  'crashed',
+  'oom',
+  'memory-eviction',
+]);
+
+export const createRendererRecoveryPolicy = (now = Date.now) => {
+  let windowStartedAt = 0;
+  let attempts = 0;
+
+  return {
+    shouldReload: (reason) => {
+      if (!RECOVERABLE_REASONS.has(reason)) return false;
+
+      const currentTime = now();
+      if (currentTime - windowStartedAt >= RECOVERY_WINDOW_MS) {
+        windowStartedAt = currentTime;
+        attempts = 0;
+      }
+      if (attempts >= MAX_RECOVERY_ATTEMPTS) return false;
+
+      attempts += 1;
+      return true;
+    },
+  };
+};

--- a/packages/electron/renderer-recovery.test.mjs
+++ b/packages/electron/renderer-recovery.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createRendererRecoveryPolicy } from './renderer-recovery.mjs';
+
+test('allows a bounded number of reloads for recoverable renderer failures', () => {
+  const policy = createRendererRecoveryPolicy(() => 1_000);
+
+  assert.equal(policy.shouldReload('crashed'), true);
+  assert.equal(policy.shouldReload('oom'), true);
+  assert.equal(policy.shouldReload('abnormal-exit'), true);
+  assert.equal(policy.shouldReload('memory-eviction'), false);
+});
+
+test('ignores clean and externally killed renderer exits', () => {
+  const policy = createRendererRecoveryPolicy(() => 1_000);
+
+  assert.equal(policy.shouldReload('clean-exit'), false);
+  assert.equal(policy.shouldReload('killed'), false);
+  assert.equal(policy.shouldReload('launch-failed'), false);
+});
+
+test('resets the recovery budget after the recovery window', () => {
+  let currentTime = 1_000;
+  const policy = createRendererRecoveryPolicy(() => currentTime);
+
+  assert.equal(policy.shouldReload('crashed'), true);
+  assert.equal(policy.shouldReload('crashed'), true);
+  assert.equal(policy.shouldReload('crashed'), true);
+  assert.equal(policy.shouldReload('crashed'), false);
+
+  currentTime += 60_000;
+  assert.equal(policy.shouldReload('crashed'), true);
+});


### PR DESCRIPTION
## Intent

Fixes #2818.

On macOS, an unexpected Electron renderer exit can leave the OpenChamber window black while the main process and OpenCode server continue running. The desktop runtime now listens for `render-process-gone` and reloads the affected window after recoverable renderer failures.

Recovery is bounded to three attempts per 60-second window so a persistent renderer failure does not create an infinite reload loop.

## Non-goals

- Fixing the underlying Chromium/V8/Electron crash cause without a deterministic reproduction.
- Restarting the OpenCode server.
- Recovering clean renderer exits or externally killed renderers.

## Affected surfaces

- `packages/electron`: desktop BrowserWindow renderer lifecycle on all platforms.
- OpenCode server lifecycle is unchanged.
- No web, mobile, or VS Code runtime behavior changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `packages/electron/package.json` | The fix changes the Electron desktop runtime. | Node syntax checks and Electron architecture tests pass. |
| Electron `render-process-gone` API | The event is the supported renderer crash/termination signal. | Only recoverable reasons trigger a bounded reload. |
| Existing isolated Electron tests | The recovery policy is pure and can be tested without launching Electron. | Three focused Node/Bun tests cover limits, ignored exits, and window reset. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/electron/renderer-recovery.test.mjs` | Passed, 3 tests |
| `node --check packages/electron/main.mjs` | Passed |
| `node --check packages/electron/renderer-recovery.mjs` | Passed |
| `bun run --cwd packages/electron test:architecture` | Passed, 38 tests |
| macOS crash reproduction | Not verified; issue has no deterministic action-level reproduction |
| Packaged Electron visual recovery | Not verified; this checkout was not packaged into a DMG |

## Visual evidence

No screenshot is attached because the change only runs after a renderer process termination; visual verification requires a packaged Electron crash/reload scenario that is not deterministically reproducible from #2818.

## Risks and failure behavior

- Reloading creates a fresh renderer while preserving the existing main process and OpenCode server.
- Recovery is limited to `abnormal-exit`, `crashed`, `oom`, and `memory-eviction`.
- After three failures in 60 seconds, the runtime stops automatic reloads and preserves the existing diagnostic state instead of looping indefinitely.
- The `render-process-gone` listener checks that the window still exists before reloading.
