### PR TITLE
fix(ui): raise file open line limit to 20k lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Files: opening a file over 5,000 lines is no longer blocked — the line-count guard now allows up to 20,000 lines, letting large files reach the virtualized full-file preview instead of being rejected at the open step (thanks @gaojunran).
+
 ## [1.21.0] - 2026-08-26
 
 - **Chat scrolling rebuilt around your message.** Sending parks your message near the top and the reply streams in below it, gliding smoothly a paragraph at a time. Scrolling up immediately hands you the wheel; the scroll-to-bottom pill carries the model's working status while you're away.

--- a/packages/ui/src/lib/fileOpenLimits.ts
+++ b/packages/ui/src/lib/fileOpenLimits.ts
@@ -1,4 +1,4 @@
-export const MAX_OPEN_FILE_LINES = 5_000;
+export const MAX_OPEN_FILE_LINES = 20_000;
 
 export const countLinesWithLimit = (content: string, limit: number): number => {
   if (!content) {


### PR DESCRIPTION
## Intent

Opening a file over 5,000 lines is currently rejected with "File is too large to open (>5,000 lines)". The guard lives in `validateContextFileOpen` (`packages/ui/src/lib/contextFileOpenGuard.ts`), which reads the whole file and counts lines before opening, with `MAX_OPEN_FILE_LINES = 5_000` (`packages/ui/src/lib/fileOpenLimits.ts`).

Since #3061, files above the editable size cap are rendered through a virtualized full-file preview (validated up to 20k lines / 1.89 MB), but that path is unreachable from the three open entries — sidebar file tree, command palette, diff view — for any ordinary >5k-line code file: the guard blocks them first. This PR raises the guard to 20,000 lines so large files reach the virtualized preview instead of being rejected.

## Non-goals

- Keeping the guard entirely (removing the line cap) is not attempted: the guard also protects the pre-open full-file read, and the virtualized preview has a validated rendering envelope. 20k matches what #3061 verified.
- `MAX_VIEW_CHARS` (200k chars, edit cap in `FilesView`) is untouched; the edit path and force-view behavior are unchanged.
- No change to the toast copy: it interpolates `{count}`, so it renders "20,000" automatically.

## Affected surfaces

- `packages/ui/src/lib/fileOpenLimits.ts` — `MAX_OPEN_FILE_LINES` 5_000 → 20_000. Shared UI package: web / desktop / VS Code / mobile all render the same component, all get the raised limit.
- Changelog: new [Unreleased] entry.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Source change in shared UI package | Smallest complete change: one constant; guard logic, callers, and i18n (interpolated `count`) untouched. |
| `changelog-authoring` | User-visible behavior change | Entry added under [Unreleased] in the repo's existing style. |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (packages/ui) | PASS (0 errors) |
| `bun test src/lib/contextFileOpenGuard.test.ts` | PASS (3 tests) |
| `bunx oxlint` on changed files | No findings in `fileOpenLimits.ts`; 2 pre-existing anti-slop findings in `contextFileOpenGuard.ts` (backlog, not introduced here) |

**Not verified**: interactive UI open of a >5k-line file in a running app.

## Visual evidence

No rendered change. The observable difference is behavioral: the open entry no longer shows the "too large" toast for files up to 20k lines and the file opens into the virtualized view.

## Risks and failure behavior

- Files beyond 20k lines remain blocked (same toast as before). The guard reads the full file into memory to count lines before opening; raising the cap increases worst-case pre-open read size, bounded at the new 20k-line/rendering envelope.
- `countLinesWithLimit` short-circuits as soon as the limit is exceeded, so over-limit files are not read further than needed.