### PR TITLE
fix(opencode): prevent OpenCode upgrades from failing with "Bad Request"

### DIFF
--- a/packages/vscode/src/opencode-upgrade-runtime.test.ts
+++ b/packages/vscode/src/opencode-upgrade-runtime.test.ts
@@ -75,13 +75,33 @@ describe('VS Code OpenCode upgrades', () => {
     assert.equal((request?.headers as Record<string, string>).Authorization, 'Basic test');
   });
 
+  test('resolves the latest version when no target is supplied', async () => {
+    const { manager, getRestartCount } = createManager();
+    let upgradeRequest: RequestInit | undefined;
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url.includes('registry.npmjs.org')) return new Response(JSON.stringify({ version: '1.18.9' }));
+      if (url.includes('api.github.com')) return new Response(JSON.stringify({ tag_name: 'v1.18.10' }));
+      assert.equal(url, 'http://127.0.0.1:4096/global/upgrade');
+      upgradeRequest = init;
+      return new Response(JSON.stringify({ success: true, version: '1.18.10' }));
+    };
+
+    assert.deepEqual(await upgradeManagedOpenCode(manager), {
+      status: 200,
+      body: { success: true, version: '1.18.10', restarted: true },
+    });
+    assert.equal(getRestartCount(), 1);
+    assert.deepEqual(JSON.parse(String(upgradeRequest?.body)), { target: '1.18.10' });
+  });
+
   test('serializes concurrent managed upgrades', async () => {
     const { manager } = createManager();
     let release: (response: Response) => void = () => {};
     globalThis.fetch = (() => new Promise<Response>((resolve) => { release = resolve; })) as typeof fetch;
 
-    const first = upgradeManagedOpenCode(manager);
-    const second = await upgradeManagedOpenCode(manager);
+    const first = upgradeManagedOpenCode(manager, '1.18.9');
+    const second = await upgradeManagedOpenCode(manager, '1.18.9');
     assert.equal(second.status, 409);
     assert.equal(second.body.code, 'OPENCODE_UPGRADE_IN_PROGRESS');
 

--- a/packages/vscode/src/opencode-upgrade-runtime.ts
+++ b/packages/vscode/src/opencode-upgrade-runtime.ts
@@ -107,13 +107,14 @@ export const upgradeManagedOpenCode = async (manager: OpenCodeUpgradeManager | u
   if (openCodeUpgradePromise) {
     return { status: 409, body: { success: false, code: 'OPENCODE_UPGRADE_IN_PROGRESS', error: 'An OpenCode upgrade is already in progress.' } };
   }
-  const targetVersion = typeof target === 'string' ? target.trim() : '';
+  const requestedTarget = typeof target === 'string' ? target.trim() : '';
   const operation = (async (): Promise<UpgradeResult> => {
     try {
+      const targetVersion = requestedTarget || await fetchLatestVersion();
       const response = await fetch(new URL('global/upgrade', apiUrl).toString(), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Accept: 'application/json', ...manager.getOpenCodeAuthHeaders() },
-        body: JSON.stringify(targetVersion ? { target: targetVersion } : {}),
+        body: JSON.stringify({ target: targetVersion }),
       });
       const payload = await response.json().catch(() => null) as { error?: unknown } | null;
       if (!response.ok) return { status: response.status, body: { success: false, error: typeof payload?.error === 'string' ? payload.error : response.statusText || 'Failed to upgrade OpenCode' } };

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -88,7 +88,7 @@ This module provides OpenCode server integration utilities for the web server ru
   - `GET /api/config/settings`
   - `PUT /api/config/settings`
   - `GET /api/config/opencode-resolution`
-  - `POST /api/opencode/upgrade` (enforces the active runtime's upgrade capability, serializes supported OpenCode upgrades, then restarts managed OpenCode so the new binary is active)
+  - `POST /api/opencode/upgrade` (enforces the active runtime's upgrade capability and serializes upgrades; an omitted `target` resolves the latest published OpenCode version before the required upstream payload is sent, then managed OpenCode restarts so the new binary is active)
   - `GET /api/opencode/upgrade-status` (returns version availability plus the authoritative `upgrade.supported`, `upgrade.manager`, and `upgrade.reason` capability)
   - `POST /api/opencode/directory` (validates and activates an existing project directory; `{ create: true }` explicitly creates the requested project directory before activation, including outside the previously active workspace)
   - `GET /api/provider/:providerId/source`

--- a/packages/web/server/lib/opencode/routes-upgrade.test.js
+++ b/packages/web/server/lib/opencode/routes-upgrade.test.js
@@ -86,7 +86,7 @@ describe('OpenCode upgrade routes', () => {
 
     const first = request(app)
       .post('/api/opencode/upgrade')
-      .send({})
+      .send({ target: '1.18.9' })
       .expect(200, {
         success: true,
         version: '1.18.9',
@@ -96,10 +96,12 @@ describe('OpenCode upgrade routes', () => {
     await vi.waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     });
+    const [, upgradeRequest] = globalThis.fetch.mock.calls[0];
+    expect(JSON.parse(upgradeRequest.body)).toEqual({ target: '1.18.9' });
 
     await request(app)
       .post('/api/opencode/upgrade')
-      .send({})
+      .send({ target: '1.18.9' })
       .expect(409, {
         success: false,
         code: 'OPENCODE_UPGRADE_IN_PROGRESS',
@@ -109,5 +111,39 @@ describe('OpenCode upgrade routes', () => {
     releaseUpgrade();
     await first;
     expect(dependencies.refreshOpenCodeAfterConfigChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the latest version when the client omits a target', async () => {
+    let upgradeRequest;
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.includes('registry.npmjs.org')) {
+        return new Response(JSON.stringify({ version: '1.18.9' }));
+      }
+      if (url.includes('api.github.com')) {
+        return new Response(JSON.stringify({ tag_name: 'v1.18.10' }));
+      }
+      expect(url).toBe('http://127.0.0.1:4096/global/upgrade');
+      upgradeRequest = init;
+      return new Response(JSON.stringify({ success: true, version: '1.18.10' }));
+    });
+    const { app } = createApp({
+      getOpenCodeUpgradeCapability: () => ({
+        supported: true,
+        manager: 'opencode',
+        reason: null,
+      }),
+    });
+
+    await request(app)
+      .post('/api/opencode/upgrade')
+      .send({})
+      .expect(200, {
+        success: true,
+        version: '1.18.10',
+        restarted: true,
+      });
+
+    expect(JSON.parse(upgradeRequest.body)).toEqual({ target: '1.18.10' });
   });
 });

--- a/packages/web/server/lib/opencode/routes.js
+++ b/packages/web/server/lib/opencode/routes.js
@@ -218,10 +218,11 @@ ${desktopReturn ? `<a class="return" href="openchamber://focus/mcp-auth">Return 
         });
       }
 
-      const target = typeof req.body?.target === 'string' && req.body.target.trim().length > 0
+      const requestedTarget = typeof req.body?.target === 'string' && req.body.target.trim().length > 0
         ? req.body.target.trim()
         : undefined;
       const upgradeOperation = (async () => {
+        const target = requestedTarget ?? await fetchLatestOpenCodeVersion();
         const response = await fetch(buildOpenCodeUrl('/global/upgrade', ''), {
           method: 'POST',
           headers: {
@@ -229,7 +230,7 @@ ${desktopReturn ? `<a class="return" href="openchamber://focus/mcp-auth">Return 
             Accept: 'application/json',
             ...getOpenCodeAuthHeaders(),
           },
-          body: JSON.stringify(target ? { target } : {}),
+          body: JSON.stringify({ target }),
         });
         const payload = await response.json().catch(() => null);
         if (!response.ok) {


### PR DESCRIPTION
## Intent

Fixes #3121.

OpenCode now requires `POST /global/upgrade` to include a semantic-version `target`. OpenChamber's existing update action omits that field, causing managed OpenCode updates to fail with HTTP 400 Bad Request.

To preserve the existing omitted-target behavior, the web and VS Code runtime implementations now resolve the latest published OpenCode version using their existing npm/GitHub lookup and include that version in the upstream request. Explicit caller-supplied targets continue through the existing path.

## Non-goals

1. No shared UI or update-toast changes.
2. No change to generic upstream error extraction. Improving diagnostics for other upstream failures can be handled separately.
3. No change to update availability or version comparison.
4. No change to OpenCode installation-method handling.

## Affected surfaces

1. Web resolves an omitted target before calling OpenCode's `/global/upgrade`.
2. Packaged Desktop continues to reject this operation for its bundled OpenCode through the existing capability guard. Desktop configurations that use the supported web-managed path share the web implementation.
3. Hosted mobile and Capacitor clients receive the corrected behavior from the OpenChamber server to which they connect.
4. VS Code applies the same fallback before calling its extension-managed OpenCode process.
5. Externally managed OpenCode remains unsupported through the existing capability guard.
6. No persisted data or rendered UI changes are involved.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | The change affects an external API request, multiple runtimes, and managed-process restart behavior. | The patch only resolves and forwards the newly required target. Focused tests cover target selection, request serialization, the upstream endpoint, and successful restart behavior. |
| `ui-api-decoupling` with `references/runtime-parity.md` and `references/implementation-map.md` | The shared update action crosses web, Desktop, hosted-mobile, Capacitor, and VS Code runtime boundaries. | The shared UI contract remains unchanged. Web and VS Code own their OpenCode transport behavior, Desktop reuses the web implementation where applicable, and mobile clients use their connected OpenChamber server. |
| `packages/web/README.md` and `packages/web/server/lib/opencode/DOCUMENTATION.md` | The web server owns `/api/opencode/upgrade` and managed OpenCode lifecycle behavior. | The route documentation records how an omitted target is resolved before forwarding and restarting managed OpenCode. |
| `packages/vscode/README.md` and `packages/vscode/src/DOCUMENTATION.md` | VS Code owns a separate extension-host OpenCode process and restart path. | `opencode-upgrade-runtime.ts` applies the same omitted-target behavior while preserving extension-owned restart handling. |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` | Passed across all workspaces |
| `bun run lint` | Passed across all workspaces |
| `bun run build` | Passed across all workspaces |
| `bun run test` | Passed across all workspaces |
| `bun test packages/vscode/src/opencode-upgrade-runtime.test.ts` | Passed |
| `bun run --cwd packages/web test -- server/lib/opencode/routes-upgrade.test.js` | Passed |
| `bun run build:web` | Passed; existing bundle-size warnings only |
| `bun run vscode:build` | Passed; existing bundle-size warnings only |
| `node --check packages/web/server/lib/opencode/routes.js` | Passed |
| `tool-use docs-list --check` | Passed with 0 warnings and 0 errors |
| `bun run docs:validate` | Passed with 460 pages and 46 sidebar links |
| Raw OpenCode 1.18.23: `curl -X POST http://127.0.0.1:<port>/global/upgrade -H 'Content-Type: application/json' -d '{}'` | Reproduced the original HTTP 400 response with `Missing key at ["target"]` |
| Isolated managed-runtime check: temporary `HOME`, data directory, `PATH`, and OpenCode binary; then `curl -X POST http://127.0.0.1:43824/api/opencode/upgrade -H 'Content-Type: application/json' -d '{}'` | Passed on branch HEAD `957620d4d`. OpenCode upgraded from 1.18.22 to 1.18.23, returned `{"success":true,"version":"1.18.23","restarted":true}`, restarted from port 33951 to 43729, and reported 1.18.23 after restart. |

## Visual evidence

There is a user-visible behavioral correction, but no rendered UI change. The existing Update action, toast, and surrounding UI are unchanged. This patch only corrects the runtime request sent after the existing action is invoked, so screenshots would be visually identical.

## Risks and failure behavior

1. An omitted-target upgrade depends on resolving a version from npm or GitHub.
2. If both lookups fail, OpenChamber returns an error without contacting `/global/upgrade` or restarting OpenCode.
3. If one lookup fails, the existing `Promise.allSettled` behavior uses the successful source.
4. If both succeed, the newer reported version is selected.
5. Explicit caller-supplied targets do not require the metadata lookup.
6. OpenCode remains authoritative for target validation and installation-specific upgrade behavior.
7. OpenCode restarts only after the upstream upgrade request succeeds.
8. Existing capability and in-flight upgrade guards remain in place.
9. No migration, persisted-state change, or rollback path is involved.
